### PR TITLE
Make /dev-loops install skills explicitly

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -20,7 +20,8 @@ This repo should eventually provide four layers:
    - re-review loops
 
 3. **Extension UX and package glue**
-   - setup/doctor commands
+   - status/doctor commands
+   - explicit skill install/update commands for repo-local or system-wide skill copies
    - readiness/status widget or dashboard
    - future installer-style overlays
    - lightweight orchestration helpers that call into deterministic scripts rather than replacing them
@@ -41,7 +42,7 @@ For the initial versions, it is acceptable to require:
 - GitHub-hosted pull request workflows for remote loops
 - repositories that can tolerate an opinionated PR/review/fix loop
 
-The package may assume Pi-package installation and extension loading from the start.
+The package may assume Pi-package installation and extension loading from the start, but packaged skills should be installed explicitly rather than auto-exposed on package install.
 
 Non-goals for the first phase:
 
@@ -143,7 +144,8 @@ If `gh` does not natively watch the exact needed condition, use deterministic cu
 
 The extension should provide:
 
-- doctor/setup commands
+- status/doctor commands
+- explicit skill install/update commands
 - lightweight widgets or overlays
 - package-level status UX
 - small orchestration glue
@@ -343,13 +345,13 @@ Acceptance criteria:
 - the local dev-loop planning contract uses the refiner without collapsing coordinator responsibilities
 - durable planning surfaces can carry stable definition-of-done output
 
-### Phase 3 — package extension and setup UX
+### Phase 3 — package extension and install UX
 
 This phase should also define the runtime/build/test contract for the package.
 
 Add an initial extension that can:
 
-- register doctor/setup commands
+- register status/doctor plus explicit install/update commands
 - show readiness/status in a widget or overlay
 - report whether `gh` and `pi-subagents` are available
 - point users to the relevant skills and installation requirements
@@ -357,7 +359,7 @@ Add an initial extension that can:
 Acceptance criteria:
 
 - package exposes a working extension entrypoint
-- users can run a doctor/setup command from Pi
+- users can run status/doctor plus explicit install/update commands from Pi
 - the extension remains thin and mostly delegates to deterministic checks/helpers
 - the runtime/build/test contract is explicit:
   - supported Pi/Node/`gh` versions
@@ -517,7 +519,7 @@ Examples:
 4. design and integrate a dedicated refiner agent for phase-refinement work so planning/refinement can be delegated without overloading the coordinator
 5. choose the public license and add `LICENSE` plus matching package metadata
 6. add baseline GitHub Actions CI for the existing test suite
-7. finish documenting the runtime/build/test and install/override contract
+7. finish documenting the runtime/build/test, explicit skill-install, and install/override contract
 8. identify the first shared library modules to extract
 9. move the first deterministic helper into a shared npm support package with a thin skill-local wrapper
 10. add the first deterministic GitHub helper scripts

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For the first implementation phase, this repo may be opinionated and require:
 `pi-dev-loops` should eventually install as a Pi package that exposes:
 
 - `skills/` for local and remote loop orchestration
-- `extension/` for setup, doctor, status, and future dashboard/installer UI
+- `extension/` for status, doctor, explicit skill install/update commands, and future dashboard/installer UI
 - deterministic `lib/` and `scripts/` shared by multiple skills
 
 ## Layout
@@ -62,5 +62,5 @@ Turn these imported assets into a coherent, reusable toolkit where:
 - agents are workflow-agnostic role definitions
 - skills orchestrate loops
 - deterministic scripts and shared library code handle as much mechanical work as possible
-- the extension provides setup/doctor UX and can grow into dashboard/installer widgets
+- the extension provides status/doctor plus explicit skill install/update UX and can grow into dashboard/installer widgets
 - repo-local overlays can specialize behavior without forking the core workflow stack

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo is intended to become a reusable **Pi package** that bundles:
 
 - generic role agents
 - reusable loop skills
-- a small extension for setup/doctor/dashboard UX
+- a small extension for status/doctor plus explicit skill install/update UX
 - deterministic helper scripts
 - shared library code for GitHub/review/watch state
 

--- a/agents/coordinator.agent.md
+++ b/agents/coordinator.agent.md
@@ -64,6 +64,7 @@ Default operating mode:
 - Use pull requests as the default delivery mechanism for completed work, with reviewable commits and a clear description of code and documentation changes.
 - Default to draft pull requests first, then mark ready for review only after verification passes and the milestone is genuinely reviewable.
 - After moving a PR out of draft, explicitly attempt to request Copilot review instead of assuming repository automation will do it.
+- After any follow-up fix commit is pushed to an open PR, explicitly decide whether another Copilot pass is desired; if it is, re-request Copilot review for the new head instead of assuming GitHub will do it automatically.
 - Prefer the deterministic helper `scripts/github/request-copilot-review.mjs` when it exists, rather than ad hoc CLI/API combinations or web research.
 - If that explicit review request fails because Copilot review is unavailable, not requestable, or rejected by GitHub (for example not a collaborator/requestable reviewer), record the exact blocker in the PR status summary rather than pretending the request succeeded.
 - If work started on `main` and has become non-trivial, move to a task branch before declaring the milestone complete unless the user explicitly requests a direct-to-`main` workflow.
@@ -77,7 +78,7 @@ Default operating mode:
 - Require the final PR description to be detailed and structured, with explicit headings for summary, scope/context, acceptance criteria, definition of done items, and non-goals.
 - Require verification results, evidence, and merge-readiness status to be carried by the review subagent verdict rather than the PR description.
 - Require the review subagent verdict to include explicit acceptance-criteria and definition-of-done verification tables with status and evidence, while the PR description remains limited to a concise change description, acceptance criteria, definition of done, and non-goals.
-- Record whether automatic Copilot review is expected to trigger when the PR leaves draft, whether an explicit Copilot review request was attempted after ready-for-review, whether the review has actually posted, and whether all Copilot comments/threads were addressed, deferred with rationale, or blocked by repository settings/tooling.
+- Record whether automatic Copilot review is expected to trigger when the PR leaves draft, whether an explicit Copilot review request was attempted after ready-for-review, whether any post-fix re-request was attempted after new commits, whether the review has actually posted, and whether all Copilot comments/threads were addressed, deferred with rationale, or blocked by repository settings/tooling.
 - If no documentation change is needed, record that explicitly in the PR summary.
 
 ## Delegation Rules
@@ -95,7 +96,7 @@ A task is complete only when:
 - branch and worktree state are understood,
 - the required documentation is updated or an explicit no-docs rationale is recorded,
 - the result is pushed to a review branch and a draft pull request is opened by default, or an exact blocker to opening it is recorded with PR-ready handoff details.
-- after the PR leaves draft, an explicit Copilot review request has been attempted when appropriate, and either the Copilot review has posted and its comments/threads have been addressed or explicitly deferred, or its absence/inaccessibility has been explicitly explained as a repository-setting, tooling, permission, collaborator/requestability, or rate-limit limitation.
+- after the PR leaves draft, an explicit Copilot review request has been attempted when appropriate, and after later fix commits any needed Copilot re-request for the new head has also been attempted, and either the Copilot review has posted and its comments/threads have been addressed or explicitly deferred, or its absence/inaccessibility has been explicitly explained as a repository-setting, tooling, permission, collaborator/requestability, or rate-limit limitation.
 - the PR description includes a concise change description, explicit acceptance criteria, a complete definition of done, and non-goals, without verdict status, evidence, or changelog content.
 
 ## Output Format

--- a/agents/coordinator.agent.md
+++ b/agents/coordinator.agent.md
@@ -63,6 +63,8 @@ Default operating mode:
 - Push branches after verification, with branch names that reflect the task or story.
 - Use pull requests as the default delivery mechanism for completed work, with reviewable commits and a clear description of code and documentation changes.
 - Default to draft pull requests first, then mark ready for review only after verification passes and the milestone is genuinely reviewable.
+- After moving a PR out of draft, explicitly attempt to request Copilot review instead of assuming repository automation will do it.
+- If that explicit review request fails because Copilot review is unavailable, not requestable, or rejected by GitHub (for example not a collaborator/requestable reviewer), record the exact blocker in the PR status summary rather than pretending the request succeeded.
 - If work started on `main` and has become non-trivial, move to a task branch before declaring the milestone complete unless the user explicitly requests a direct-to-`main` workflow.
 - When creating or editing issue/PR descriptions or comments, prefer `--body-file` / `-F` or stdin over inline shell strings; use heredocs or temp files for multi-line content and do not interpolate untrusted text directly into shell commands.
 - To assign Copilot to a GitHub issue in this repository, use `gh issue edit <number> --add-assignee copilot-swe-agent`. Do not use `copilot`, and do not attempt `@github-copilot` mention comments — those do not trigger Copilot task assignment.
@@ -74,7 +76,7 @@ Default operating mode:
 - Require the final PR description to be detailed and structured, with explicit headings for summary, scope/context, acceptance criteria, definition of done items, and non-goals.
 - Require verification results, evidence, and merge-readiness status to be carried by the review subagent verdict rather than the PR description.
 - Require the review subagent verdict to include explicit acceptance-criteria and definition-of-done verification tables with status and evidence, while the PR description remains limited to a concise change description, acceptance criteria, definition of done, and non-goals.
-- Record whether automatic Copilot review is expected to trigger when the PR leaves draft, whether the review has actually posted, and whether all Copilot comments/threads were addressed, deferred with rationale, or blocked by repository settings/tooling.
+- Record whether automatic Copilot review is expected to trigger when the PR leaves draft, whether an explicit Copilot review request was attempted after ready-for-review, whether the review has actually posted, and whether all Copilot comments/threads were addressed, deferred with rationale, or blocked by repository settings/tooling.
 - If no documentation change is needed, record that explicitly in the PR summary.
 
 ## Delegation Rules
@@ -92,7 +94,7 @@ A task is complete only when:
 - branch and worktree state are understood,
 - the required documentation is updated or an explicit no-docs rationale is recorded,
 - the result is pushed to a review branch and a draft pull request is opened by default, or an exact blocker to opening it is recorded with PR-ready handoff details.
-- automatic Copilot review is expected to trigger when the PR leaves draft, and either the Copilot review has posted and its comments/threads have been addressed or explicitly deferred, or its absence/inaccessibility has been explicitly explained as a repository-setting, tooling, permission, or rate-limit limitation.
+- after the PR leaves draft, an explicit Copilot review request has been attempted when appropriate, and either the Copilot review has posted and its comments/threads have been addressed or explicitly deferred, or its absence/inaccessibility has been explicitly explained as a repository-setting, tooling, permission, collaborator/requestability, or rate-limit limitation.
 - the PR description includes a concise change description, explicit acceptance criteria, a complete definition of done, and non-goals, without verdict status, evidence, or changelog content.
 
 ## Output Format

--- a/agents/coordinator.agent.md
+++ b/agents/coordinator.agent.md
@@ -64,6 +64,7 @@ Default operating mode:
 - Use pull requests as the default delivery mechanism for completed work, with reviewable commits and a clear description of code and documentation changes.
 - Default to draft pull requests first, then mark ready for review only after verification passes and the milestone is genuinely reviewable.
 - After moving a PR out of draft, explicitly attempt to request Copilot review instead of assuming repository automation will do it.
+- Prefer the deterministic helper `scripts/github/request-copilot-review.mjs` when it exists, rather than ad hoc CLI/API combinations or web research.
 - If that explicit review request fails because Copilot review is unavailable, not requestable, or rejected by GitHub (for example not a collaborator/requestable reviewer), record the exact blocker in the PR status summary rather than pretending the request succeeded.
 - If work started on `main` and has become non-trivial, move to a task branch before declaring the milestone complete unless the user explicitly requests a direct-to-`main` workflow.
 - When creating or editing issue/PR descriptions or comments, prefer `--body-file` / `-F` or stdin over inline shell strings; use heredocs or temp files for multi-line content and do not interpolate untrusted text directly into shell commands.

--- a/agents/coordinator.agent.md
+++ b/agents/coordinator.agent.md
@@ -78,7 +78,7 @@ Default operating mode:
 - Require the final PR description to be detailed and structured, with explicit headings for summary, scope/context, acceptance criteria, definition of done items, and non-goals.
 - Require verification results, evidence, and merge-readiness status to be carried by the review subagent verdict rather than the PR description.
 - Require the review subagent verdict to include explicit acceptance-criteria and definition-of-done verification tables with status and evidence, while the PR description remains limited to a concise change description, acceptance criteria, definition of done, and non-goals.
-- Record whether automatic Copilot review is expected to trigger when the PR leaves draft, whether an explicit Copilot review request was attempted after ready-for-review, whether any post-fix re-request was attempted after new commits, whether the review has actually posted, and whether all Copilot comments/threads were addressed, deferred with rationale, or blocked by repository settings/tooling.
+- Record whether automatic Copilot review is expected to trigger when the PR leaves draft, whether an explicit Copilot review request was attempted after ready-for-review, whether any post-fix re-request was attempted after new commits, whether the review has actually posted, and whether all Copilot comments/threads from the latest requested pass were addressed, deferred with rationale, or blocked by repository settings/tooling.
 - If no documentation change is needed, record that explicitly in the PR summary.
 
 ## Delegation Rules
@@ -96,7 +96,7 @@ A task is complete only when:
 - branch and worktree state are understood,
 - the required documentation is updated or an explicit no-docs rationale is recorded,
 - the result is pushed to a review branch and a draft pull request is opened by default, or an exact blocker to opening it is recorded with PR-ready handoff details.
-- after the PR leaves draft, an explicit Copilot review request has been attempted when appropriate, and after later fix commits any needed Copilot re-request for the new head has also been attempted, and either the Copilot review has posted and its comments/threads have been addressed or explicitly deferred, or its absence/inaccessibility has been explicitly explained as a repository-setting, tooling, permission, collaborator/requestability, or rate-limit limitation.
+- after the PR leaves draft, an explicit Copilot review request has been attempted when appropriate, and after later fix commits any needed Copilot re-request for the new head has also been attempted, and either the latest requested Copilot pass has posted and its comments/threads have been addressed or explicitly deferred, or its absence/inaccessibility has been explicitly explained as a repository-setting, tooling, permission, collaborator/requestability, or rate-limit limitation.
 - the PR description includes a concise change description, explicit acceptance criteria, a complete definition of done, and non-goals, without verdict status, evidence, or changelog content.
 
 ## Output Format

--- a/agents/fixer.agent.md
+++ b/agents/fixer.agent.md
@@ -34,13 +34,14 @@ You are a focused review-fix agent. You take an existing pull request with revie
 5. Implement the chosen changes and run the appropriate verification.
 6. Create a focused commit for the review fix when files changed.
 7. Push the commit to the pull request branch and capture the pushed commit SHA.
-8. Re-fetch the PR state and confirm the head still includes the pushed commit before you submit review replies.
-9. Reply to each addressed thread with a short note that references the resolving commit SHA or commit URL when applicable, summarizes the fix or explanation, and states why it resolves the underlying concern.
+8. If the workflow expects another Copilot pass after the fix, explicitly request Copilot review again for the updated PR head, preferably through `scripts/github/request-copilot-review.mjs`, instead of assuming GitHub will automatically re-request it.
+9. Re-fetch the PR state and confirm the head still includes the pushed commit before you submit review replies.
+10. Reply to each addressed thread with a short note that references the resolving commit SHA or commit URL when applicable, summarizes the fix or explanation, and states why it resolves the underlying concern.
    - Prefer the deterministic helper `scripts/github/reply-resolve-review-thread.mjs` when it exists.
    - Prefer a temporary reply body file over inline shell text.
-10. Resolve the thread only after the reply is attached successfully and the concern is genuinely addressed, even if the final resolution differs from the reviewer’s suggested implementation.
+11. Resolve the thread only after the reply is attached successfully and the concern is genuinely addressed, even if the final resolution differs from the reviewer’s suggested implementation.
    - If reply/resolve is not authorized, stop and report that the PR conversation state is still unresolved rather than implying the review loop is complete.
-11. If GitHub leaves a stray pending review or rejects an inline reply because of pending review state, inspect the current review state, delete the stray pending review, recreate the reply, and retry once.
+12. If GitHub leaves a stray pending review or rejects an inline reply because of pending review state, inspect the current review state, delete the stray pending review, recreate the reply, and retry once.
 
 ## Output
 Return:

--- a/agents/fixer.agent.md
+++ b/agents/fixer.agent.md
@@ -36,12 +36,13 @@ You are a focused review-fix agent. You take an existing pull request with revie
 7. Push the commit to the pull request branch and capture the pushed commit SHA.
 8. If the workflow expects another Copilot pass after the fix, explicitly request Copilot review again for the updated PR head, preferably through `scripts/github/request-copilot-review.mjs`, instead of assuming GitHub will automatically re-request it.
 9. Re-fetch the PR state and confirm the head still includes the pushed commit before you submit review replies.
-10. Reply to each addressed thread with a short note that references the resolving commit SHA or commit URL when applicable, summarizes the fix or explanation, and states why it resolves the underlying concern.
+10. If that re-requested Copilot pass posts fresh review comments, do not treat the review loop as complete yet: return to unresolved-thread handling and close out those new comments before reporting completion when authorization exists.
+11. Reply to each addressed thread with a short note that references the resolving commit SHA or commit URL when applicable, summarizes the fix or explanation, and states why it resolves the underlying concern.
    - Prefer the deterministic helper `scripts/github/reply-resolve-review-thread.mjs` when it exists.
    - Prefer a temporary reply body file over inline shell text.
-11. Resolve the thread only after the reply is attached successfully and the concern is genuinely addressed, even if the final resolution differs from the reviewer’s suggested implementation.
+12. Resolve the thread only after the reply is attached successfully and the concern is genuinely addressed, even if the final resolution differs from the reviewer’s suggested implementation.
    - If reply/resolve is not authorized, stop and report that the PR conversation state is still unresolved rather than implying the review loop is complete.
-12. If GitHub leaves a stray pending review or rejects an inline reply because of pending review state, inspect the current review state, delete the stray pending review, recreate the reply, and retry once.
+13. If GitHub leaves a stray pending review or rejects an inline reply because of pending review state, inspect the current review state, delete the stray pending review, recreate the reply, and retry once.
 
 ## Output
 Return:

--- a/agents/fixer.agent.md
+++ b/agents/fixer.agent.md
@@ -17,6 +17,7 @@ You are a focused review-fix agent. You take an existing pull request with revie
 
 ## Expectations
 - Refresh the pull request state before acting, and check the current PR head again immediately before you submit replies or resolve threads.
+- When using a newly added or recently changed deterministic GitHub mutation helper, do one bounded smoke check against the real PR/thread before assuming the helper is safe to use for the rest of the loop.
 - Treat reviewers as signal, not instructions to follow blindly. Evaluate the underlying risk, project goals, and source evidence before deciding what to change.
 - Prefer the smallest safe resolution, but do not make a requested change if it would be incorrect, overfit, broaden scope, or create a worse design.
 - If a thread is valid but the exact reviewer suggestion is not the best fix, implement the better fix and explain the rationale in the thread reply.
@@ -35,7 +36,10 @@ You are a focused review-fix agent. You take an existing pull request with revie
 7. Push the commit to the pull request branch and capture the pushed commit SHA.
 8. Re-fetch the PR state and confirm the head still includes the pushed commit before you submit review replies.
 9. Reply to each addressed thread with a short note that references the resolving commit SHA or commit URL when applicable, summarizes the fix or explanation, and states why it resolves the underlying concern.
+   - Prefer the deterministic helper `scripts/github/reply-resolve-review-thread.mjs` when it exists.
+   - Prefer a temporary reply body file over inline shell text.
 10. Resolve the thread only after the reply is attached successfully and the concern is genuinely addressed, even if the final resolution differs from the reviewer’s suggested implementation.
+   - If reply/resolve is not authorized, stop and report that the PR conversation state is still unresolved rather than implying the review loop is complete.
 11. If GitHub leaves a stray pending review or rejects an inline reply because of pending review state, inspect the current review state, delete the stray pending review, recreate the reply, and retry once.
 
 ## Output

--- a/docs/phases/phase-7.md
+++ b/docs/phases/phase-7.md
@@ -41,6 +41,7 @@ This phase exists to answer, in one real non-bootstrap repo:
   - what remains upstream-owned
   - what manual update expectation exists downstream
 - fix only the smallest portability issues in this repo required for the pilot to succeed
+- keep package installation separate from skill installation: the extension should expose `/dev-loops`, while packaged skills are installed or refreshed explicitly through `/dev-loops install ...` and `/dev-loops update ...`
 - capture prioritized findings with explicit fixed-now vs deferred decisions
 - update durable docs only where pilot findings change durable project truth
 
@@ -116,6 +117,7 @@ This phase exists to answer, in one real non-bootstrap repo:
 - success requires discovery/readiness proof, one bounded non-mutating skill path, and one thin local override
 - success does not require publishing, multi-repo proof, watcher validation, overlay-system design, or broad agent cleanup
 - any downstream customization in this phase should stay thin, local, and explicitly documented rather than generalized prematurely
+- for the Phase 7 portability path, package install should expose the extension command surface only; packaged skills should be copied explicitly into repo-local or system-wide skill directories through `/dev-loops install ...` and `/dev-loops update ...`
 - phase refinement for this repo should default to fan-out / fan-in planning with multiple variants before converging on one merged plan
 
 ## Open questions

--- a/extension/README.md
+++ b/extension/README.md
@@ -12,10 +12,14 @@ Installing the package exposes the `/dev-loops` command surface only. It does **
   - concise readiness summary plus lightweight next steps
 - `/dev-loops doctor`
   - full diagnostic report with explicit pass/fail detail
+- `/dev-loops install`
+  - prompts for `repo` or `system` when no target is provided
 - `/dev-loops install repo`
   - copies packaged skills into the current repository under `.pi/skills`
 - `/dev-loops install system`
   - copies packaged skills into `~/.pi/agent/skills`
+- `/dev-loops update`
+  - prompts for `repo` or `system` when no target is provided
 - `/dev-loops update repo`
   - refresh installed skills in the current repository from the packaged source
 - `/dev-loops update system`

--- a/extension/README.md
+++ b/extension/README.md
@@ -43,6 +43,8 @@ The messaging distinguishes between local loop readiness and remote GitHub/Copil
 
 `/dev-loops install ...` and `/dev-loops update ...` copy the packaged skill directories only.
 
+These commands expect real directory targets. They intentionally refuse symlinked skill roots or symlinked skill directories so they do not accidentally mutate a shared source-of-truth directory through a symlink.
+
 They do **not**:
 - install `gh`
 - install `pi-subagents`

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,17 +1,25 @@
 # Extension scaffold
 
-`pi-dev-loops` ships a lightweight package extension for setup and readiness UX.
+`pi-dev-loops` ships a lightweight package extension for readiness UX and explicit skill installation/update commands.
+
+Installing the package exposes the `/dev-loops` command surface only. It does **not** automatically install packaged skills into the current repo or into `~/.pi/agent/skills`.
 
 ## Command surface
 
 - `/dev-loops`
-  - defaults to `/dev-loops status`
+  - defaults to help output for the available subcommands
 - `/dev-loops status`
   - concise readiness summary plus lightweight next steps
 - `/dev-loops doctor`
   - full diagnostic report with explicit pass/fail detail
-- `/dev-loops setup`
-  - diagnostic report plus ordered first-time setup guidance
+- `/dev-loops install repo`
+  - copies packaged skills into the current repository under `.pi/skills`
+- `/dev-loops install system`
+  - copies packaged skills into `~/.pi/agent/skills`
+- `/dev-loops update repo`
+  - refresh installed skills in the current repository from the packaged source
+- `/dev-loops update system`
+  - refresh installed skills in `~/.pi/agent/skills` from the packaged source
 - `/dev-loops hide`
   - removes the readiness widget cleanly
 
@@ -27,29 +35,31 @@ The extension currently reports on:
 
 The messaging distinguishes between local loop readiness and remote GitHub/Copilot readiness. Missing `gh` or `gh auth` blocks remote-loop readiness, but does not imply that local phase-based work is completely unavailable.
 
-## Setup contract for this phase
+## Install/update contract for this phase
 
-`/dev-loops setup` is advisory only in this phase.
+`/dev-loops install ...` and `/dev-loops update ...` copy the packaged skill directories only.
 
-It does **not**:
-- install dependencies
-- mutate the environment
-- bootstrap repositories
-- automate authentication
+They do **not**:
+- install `gh`
+- install `pi-subagents`
+- mutate GitHub authentication
+- bootstrap repositories beyond writing skill directories
+- automatically refresh the current Pi session's already-loaded command list
 
-It only reports current readiness and points users at the next manual setup steps.
+After install or update, restart Pi or refresh skill discovery before expecting `/skill:dev-loop` or `/skill:copilot-dev-loop` to appear in the current session.
 
 ## Runtime / build / test contract
 
-Current Phase 3 contract:
+Current Phase 3+ contract:
 - Node runtime floor: `>=20` (from `package.json`)
 - Pi host expectations are documented from current peer dependencies rather than a tested pinned Pi version range
 - the extension is source-loaded from `./extension/index.ts` through `package.json` `pi.extensions`
+- the package does not automatically install skills through `package.json`; skill installation is an explicit `/dev-loops install ...` step
 - this phase does not yet claim a specific supported `gh` version; it only checks `gh` presence and authentication state
 - this phase does not require a separate compiled build or `dist/` pipeline
 
 Root tests and skill-local tests are intentionally separate:
-- `npm test` runs the current root test suite (`test:assets`, `test:extension`, and `test:core`)
+- `npm test` runs the current root test suite (`test:assets`, `test:extension`, `test:scripts`, and `test:core`)
 - `npm run test:extension`
 - `npm run test:assets`
 - `npm run test:dev-loop`

--- a/extension/README.md
+++ b/extension/README.md
@@ -21,9 +21,9 @@ Installing the package exposes the `/dev-loops` command surface only. It does **
 - `/dev-loops update`
   - prompts for `repo` or `system` when no target is provided
 - `/dev-loops update repo`
-  - refresh installed skills in the current repository from the packaged source
+  - refresh installed skills in the current repository from the packaged source when they were already installed there
 - `/dev-loops update system`
-  - refresh installed skills in `~/.pi/agent/skills` from the packaged source
+  - refresh installed skills in `~/.pi/agent/skills` from the packaged source when they were already installed there
 - `/dev-loops hide`
   - removes the readiness widget cleanly
 
@@ -42,6 +42,8 @@ The messaging distinguishes between local loop readiness and remote GitHub/Copil
 ## Install/update contract for this phase
 
 `/dev-loops install ...` and `/dev-loops update ...` copy the packaged skill directories only.
+
+`install` is for first-time setup. `update` refreshes installed skills only, reports missing targets, and guides users back to `install` when first-time setup is still needed.
 
 These commands expect real directory targets. They intentionally refuse symlinked skill roots or symlinked skill directories so they do not accidentally mutate a shared source-of-truth directory through a symlink.
 

--- a/extension/checks.ts
+++ b/extension/checks.ts
@@ -108,7 +108,7 @@ export async function collectDevLoopChecks(pi: ExtensionAPI): Promise<DevLoopChe
       ok: localDevLoopAvailable,
       detail: localDevLoopAvailable
         ? "`/skill:dev-loop` is available."
-        : "The local dev-loop skill is not currently discoverable.",
+        : "Run `/dev-loops install repo` or `/dev-loops install system` to make `/skill:dev-loop` discoverable.",
     },
     {
       id: "copilot-dev-loop-skill",
@@ -116,7 +116,7 @@ export async function collectDevLoopChecks(pi: ExtensionAPI): Promise<DevLoopChe
       ok: copilotDevLoopAvailable,
       detail: copilotDevLoopAvailable
         ? "`/skill:copilot-dev-loop` is available."
-        : "The Copilot dev-loop skill is not currently discoverable.",
+        : "Run `/dev-loops install repo` or `/dev-loops install system` to make `/skill:copilot-dev-loop` discoverable.",
     },
   ];
 }

--- a/extension/index.ts
+++ b/extension/index.ts
@@ -21,10 +21,11 @@ const WIDGET_KEY = "pi-dev-loops.setup";
 
 type ParsedCommand =
   | { action: "help" | "status" | "doctor" | "hide" }
-  | { action: "install" | "update"; scope?: InstallScope };
+  | { action: "install" | "update"; scope?: InstallScope; invalidArgs?: boolean };
 
 function parseAction(args: string): ParsedCommand {
-  const [rawAction, rawScope] = args.trim().split(/\s+/).filter(Boolean);
+  const parts = args.trim().split(/\s+/).filter(Boolean);
+  const [rawAction, rawScope, ...rest] = parts;
   const action = rawAction?.toLowerCase();
 
   switch (action) {
@@ -39,11 +40,16 @@ function parseAction(args: string): ParsedCommand {
     case "hide":
       return { action: "hide" };
     case "install":
-    case "update":
+    case "update": {
+      const normalizedScope = rawScope?.toLowerCase();
+      const scope = normalizedScope === "repo" || normalizedScope === "system" ? normalizedScope : undefined;
+
       return {
         action,
-        scope: rawScope === "repo" || rawScope === "system" ? rawScope : undefined,
+        scope,
+        invalidArgs: rest.length > 0 || (rawScope !== undefined && scope === undefined),
       };
+    }
     default:
       return { action: "help" };
   }
@@ -138,6 +144,12 @@ export default function (pi: ExtensionAPI) {
 
       if (command.action === "status" || command.action === "doctor") {
         await renderStatus(ctx, pi, command.action);
+        return;
+      }
+
+      if (command.invalidArgs) {
+        ctx.ui.setWidget(WIDGET_KEY, buildInstallUsageLines(command.action), { placement: "belowEditor" });
+        ctx.ui.notify(`pi-dev-loops ${command.action}: invalid arguments`, "error");
         return;
       }
 

--- a/extension/index.ts
+++ b/extension/index.ts
@@ -6,6 +6,7 @@ import { collectDevLoopChecks } from "./checks.ts";
 import { resolveSystemSkillsRoot, syncPackagedSkills, type InstallScope } from "./installer.ts";
 import {
   buildHelpLines,
+  buildInstallFailureLines,
   buildInstallNotificationMessage,
   buildInstallResultLines,
   buildInstallUsageLines,
@@ -98,14 +99,19 @@ async function renderInstall(
     resolvedTargetRoot = path.join(repoRoot, ".pi", "skills");
   }
 
-  const result = await syncPackagedSkills({
-    mode: action,
-    scope,
-    targetRoot: resolvedTargetRoot,
-  });
+  try {
+    const result = await syncPackagedSkills({
+      mode: action,
+      scope,
+      targetRoot: resolvedTargetRoot,
+    });
 
-  ctx.ui.setWidget(WIDGET_KEY, buildInstallResultLines(result), { placement: "belowEditor" });
-  ctx.ui.notify(buildInstallNotificationMessage(result), "info");
+    ctx.ui.setWidget(WIDGET_KEY, buildInstallResultLines(result), { placement: "belowEditor" });
+    ctx.ui.notify(buildInstallNotificationMessage(result), "info");
+  } catch (error) {
+    ctx.ui.setWidget(WIDGET_KEY, buildInstallFailureLines(action, scope, error), { placement: "belowEditor" });
+    ctx.ui.notify(`pi-dev-loops ${action} ${scope}: failed`, "error");
+  }
 }
 
 export default function (pi: ExtensionAPI) {
@@ -114,7 +120,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.registerCommand("dev-loops", {
-    description: "Manage pi-dev-loops readiness and skill installation: /dev-loops [status|doctor|install repo|install system|update repo|update system|hide]",
+    description: "Manage pi-dev-loops readiness and explicit skill install/update flows: /dev-loops [help|status|doctor|install [repo|system]|update [repo|system]|hide]",
     handler: async (args, ctx) => {
       const command = parseAction(args);
 

--- a/extension/index.ts
+++ b/extension/index.ts
@@ -1,34 +1,111 @@
+import os from "node:os";
+import path from "node:path";
 import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
 
 import { collectDevLoopChecks } from "./checks.ts";
-import { buildNotificationMessage, buildWidgetLines, type DevLoopsAction } from "./presentation.ts";
+import { resolveSystemSkillsRoot, syncPackagedSkills, type InstallScope } from "./installer.ts";
+import {
+  buildHelpLines,
+  buildInstallNotificationMessage,
+  buildInstallResultLines,
+  buildInstallUsageLines,
+  buildNotificationMessage,
+  buildRepoInstallErrorLines,
+  buildWidgetLines,
+  type DevLoopsAction,
+} from "./presentation.ts";
 
 const STATUS_KEY = "pi-dev-loops";
 const WIDGET_KEY = "pi-dev-loops.setup";
 
+type ParsedCommand =
+  | { action: "help" | "status" | "doctor" | "hide" }
+  | { action: "install" | "update"; scope?: InstallScope };
 
-function parseAction(args: string): DevLoopsAction {
-  const action = args.trim().split(/\s+/, 1)[0]?.toLowerCase();
+function parseAction(args: string): ParsedCommand {
+  const [rawAction, rawScope] = args.trim().split(/\s+/).filter(Boolean);
+  const action = rawAction?.toLowerCase();
+
   switch (action) {
-    case "":
     case undefined:
+    case "":
+    case "help":
+      return { action: "help" };
     case "status":
-      return "status";
+      return { action: "status" };
     case "doctor":
-    case "setup":
+      return { action: "doctor" };
     case "hide":
-      return action;
+      return { action: "hide" };
+    case "install":
+    case "update":
+      return {
+        action,
+        scope: rawScope === "repo" || rawScope === "system" ? rawScope : undefined,
+      };
     default:
-      return "status";
+      return { action: "help" };
   }
 }
 
-async function renderStatus(ctx: ExtensionCommandContext, pi: ExtensionAPI, action: Exclude<DevLoopsAction, "hide">) {
+async function resolveRepoRoot(pi: ExtensionAPI): Promise<string | undefined> {
+  try {
+    const result = await pi.exec("bash", ["-lc", "git rev-parse --show-toplevel"], {
+      timeout: 5_000,
+    });
+
+    if (result.code !== 0) {
+      return undefined;
+    }
+
+    return result.stdout.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function renderStatus(ctx: ExtensionCommandContext, pi: ExtensionAPI, action: Extract<DevLoopsAction, "doctor" | "status">) {
   const checks = await collectDevLoopChecks(pi);
   const lines = buildWidgetLines(action, checks);
 
   ctx.ui.setWidget(WIDGET_KEY, lines, { placement: "belowEditor" });
   ctx.ui.notify(buildNotificationMessage(action, checks), "info");
+}
+
+async function renderInstall(
+  ctx: ExtensionCommandContext,
+  pi: ExtensionAPI,
+  action: Extract<DevLoopsAction, "install" | "update">,
+  scope?: InstallScope,
+) {
+  if (!scope) {
+    ctx.ui.setWidget(WIDGET_KEY, buildInstallUsageLines(action), { placement: "belowEditor" });
+    ctx.ui.notify(`pi-dev-loops ${action}: choose repo or system`, "info");
+    return;
+  }
+
+  let resolvedTargetRoot = resolveSystemSkillsRoot(os.homedir());
+
+  if (scope === "repo") {
+    const repoRoot = await resolveRepoRoot(pi);
+
+    if (!repoRoot) {
+      ctx.ui.setWidget(WIDGET_KEY, buildRepoInstallErrorLines(action), { placement: "belowEditor" });
+      ctx.ui.notify(`pi-dev-loops ${action} repo: not inside a git repository`, "error");
+      return;
+    }
+
+    resolvedTargetRoot = path.join(repoRoot, ".pi", "skills");
+  }
+
+  const result = await syncPackagedSkills({
+    mode: action,
+    scope,
+    targetRoot: resolvedTargetRoot,
+  });
+
+  ctx.ui.setWidget(WIDGET_KEY, buildInstallResultLines(result), { placement: "belowEditor" });
+  ctx.ui.notify(buildInstallNotificationMessage(result), "info");
 }
 
 export default function (pi: ExtensionAPI) {
@@ -37,17 +114,28 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.registerCommand("dev-loops", {
-    description: "Manage pi-dev-loops setup and diagnostics: /dev-loops [setup|doctor|status|hide]",
+    description: "Manage pi-dev-loops readiness and skill installation: /dev-loops [status|doctor|install repo|install system|update repo|update system|hide]",
     handler: async (args, ctx) => {
-      const action = parseAction(args);
+      const command = parseAction(args);
 
-      if (action === "hide") {
+      if (command.action === "hide") {
         ctx.ui.setWidget(WIDGET_KEY, undefined);
         ctx.ui.notify("pi-dev-loops widget hidden", "info");
         return;
       }
 
-      await renderStatus(ctx, pi, action);
+      if (command.action === "help") {
+        ctx.ui.setWidget(WIDGET_KEY, buildHelpLines(), { placement: "belowEditor" });
+        ctx.ui.notify("pi-dev-loops help", "info");
+        return;
+      }
+
+      if (command.action === "status" || command.action === "doctor") {
+        await renderStatus(ctx, pi, command.action);
+        return;
+      }
+
+      await renderInstall(ctx, pi, command.action, command.scope);
     },
   });
 }

--- a/extension/installer.ts
+++ b/extension/installer.ts
@@ -7,7 +7,7 @@ export const PACKAGED_SKILL_NAMES = ["dev-loop", "copilot-dev-loop"] as const;
 
 export type InstallScope = "repo" | "system";
 export type InstallMode = "install" | "update";
-export type InstallStatus = "installed" | "updated" | "already-installed";
+export type InstallStatus = "installed" | "updated" | "already-installed" | "missing";
 
 export type SkillInstallResult = {
   skillName: (typeof PACKAGED_SKILL_NAMES)[number];
@@ -160,7 +160,16 @@ export async function syncPackagedSkills({
       continue;
     }
 
-    if (mode === "update" && exists) {
+    if (mode === "update") {
+      if (!exists) {
+        results.push({
+          skillName,
+          status: "missing",
+          targetPath,
+        });
+        continue;
+      }
+
       await rm(targetPath, { recursive: true, force: true });
     }
 
@@ -168,7 +177,7 @@ export async function syncPackagedSkills({
 
     results.push({
       skillName,
-      status: mode === "update" && exists ? "updated" : "installed",
+      status: mode === "update" ? "updated" : "installed",
       targetPath,
     });
   }

--- a/extension/installer.ts
+++ b/extension/installer.ts
@@ -67,12 +67,7 @@ async function findSymlinkedAncestor(targetPath: string): Promise<string | undef
   while (true) {
     try {
       const stats = await lstat(currentPath);
-
-      if (stats.isSymbolicLink()) {
-        return currentPath;
-      }
-
-      return undefined;
+      return stats.isSymbolicLink() ? currentPath : undefined;
     } catch {
       // Missing path segments are fine here; keep walking upward until the first existing ancestor.
     }

--- a/extension/installer.ts
+++ b/extension/installer.ts
@@ -1,0 +1,94 @@
+import { cp, lstat, mkdir, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const PACKAGED_SKILL_NAMES = ["dev-loop", "copilot-dev-loop"] as const;
+
+export type InstallScope = "repo" | "system";
+export type InstallMode = "install" | "update";
+export type InstallStatus = "installed" | "updated" | "already-installed";
+
+export type SkillInstallResult = {
+  skillName: (typeof PACKAGED_SKILL_NAMES)[number];
+  status: InstallStatus;
+  targetPath: string;
+};
+
+export type InstallResult = {
+  mode: InstallMode;
+  scope: InstallScope;
+  targetRoot: string;
+  results: SkillInstallResult[];
+};
+
+function repoRootFromInstaller() {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+}
+
+export function resolvePackagedSkillsRoot() {
+  return path.join(repoRootFromInstaller(), "skills");
+}
+
+export function resolveSystemSkillsRoot(homeDirectory = os.homedir()) {
+  return path.join(homeDirectory, ".pi", "agent", "skills");
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await lstat(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function syncPackagedSkills({
+  mode,
+  scope,
+  targetRoot,
+  sourceRoot = resolvePackagedSkillsRoot(),
+}: {
+  mode: InstallMode;
+  scope: InstallScope;
+  targetRoot: string;
+  sourceRoot?: string;
+}): Promise<InstallResult> {
+  await mkdir(targetRoot, { recursive: true });
+
+  const results: SkillInstallResult[] = [];
+
+  for (const skillName of PACKAGED_SKILL_NAMES) {
+    const sourcePath = path.join(sourceRoot, skillName);
+    const targetPath = path.join(targetRoot, skillName);
+    const exists = await pathExists(targetPath);
+
+    if (mode === "install" && exists) {
+      results.push({
+        skillName,
+        status: "already-installed",
+        targetPath,
+      });
+      continue;
+    }
+
+    if (mode === "update" && exists) {
+      await rm(targetPath, { recursive: true, force: true });
+    }
+
+    await cp(sourcePath, targetPath, { recursive: true });
+
+    results.push({
+      skillName,
+      status: mode === "update" && exists ? "updated" : "installed",
+      targetPath,
+    });
+  }
+
+  return {
+    mode,
+    scope,
+    targetRoot,
+    results,
+  };
+}

--- a/extension/installer.ts
+++ b/extension/installer.ts
@@ -43,6 +43,52 @@ async function pathExists(targetPath: string): Promise<boolean> {
   }
 }
 
+async function pathKind(targetPath: string): Promise<"missing" | "directory" | "symlink" | "other"> {
+  try {
+    const stats = await lstat(targetPath);
+
+    if (stats.isSymbolicLink()) {
+      return "symlink";
+    }
+
+    if (stats.isDirectory()) {
+      return "directory";
+    }
+
+    return "other";
+  } catch {
+    return "missing";
+  }
+}
+
+async function assertWritableSkillRoot(targetRoot: string) {
+  const kind = await pathKind(targetRoot);
+
+  if (kind === "symlink") {
+    throw new Error(
+      `Refusing to install into symlinked skill root: ${targetRoot}. Use a real directory target or manage the symlink source directly.`,
+    );
+  }
+
+  if (kind === "other") {
+    throw new Error(`Skill root exists but is not a directory: ${targetRoot}`);
+  }
+}
+
+async function assertWritableSkillTarget(targetPath: string) {
+  const kind = await pathKind(targetPath);
+
+  if (kind === "symlink") {
+    throw new Error(
+      `Refusing to overwrite symlinked skill target: ${targetPath}. Use a real directory target or manage the symlink source directly.`,
+    );
+  }
+
+  if (kind === "other") {
+    throw new Error(`Skill target exists but is not a directory: ${targetPath}`);
+  }
+}
+
 export async function syncPackagedSkills({
   mode,
   scope,
@@ -54,6 +100,7 @@ export async function syncPackagedSkills({
   targetRoot: string;
   sourceRoot?: string;
 }): Promise<InstallResult> {
+  await assertWritableSkillRoot(targetRoot);
   await mkdir(targetRoot, { recursive: true });
 
   const results: SkillInstallResult[] = [];
@@ -61,6 +108,7 @@ export async function syncPackagedSkills({
   for (const skillName of PACKAGED_SKILL_NAMES) {
     const sourcePath = path.join(sourceRoot, skillName);
     const targetPath = path.join(targetRoot, skillName);
+    await assertWritableSkillTarget(targetPath);
     const exists = await pathExists(targetPath);
 
     if (mode === "install" && exists) {

--- a/extension/installer.ts
+++ b/extension/installer.ts
@@ -61,14 +61,42 @@ async function pathKind(targetPath: string): Promise<"missing" | "directory" | "
   }
 }
 
-async function assertWritableSkillRoot(targetRoot: string) {
-  const kind = await pathKind(targetRoot);
+async function findSymlinkedAncestor(targetPath: string): Promise<string | undefined> {
+  let currentPath = path.resolve(targetPath);
 
-  if (kind === "symlink") {
+  while (true) {
+    try {
+      const stats = await lstat(currentPath);
+
+      if (stats.isSymbolicLink()) {
+        return currentPath;
+      }
+
+      return undefined;
+    } catch {
+      // Missing path segments are fine here; keep walking upward until the first existing ancestor.
+    }
+
+    const parentPath = path.dirname(currentPath);
+
+    if (parentPath === currentPath) {
+      return undefined;
+    }
+
+    currentPath = parentPath;
+  }
+}
+
+async function assertWritableSkillRoot(targetRoot: string) {
+  const symlinkPath = await findSymlinkedAncestor(targetRoot);
+
+  if (symlinkPath) {
     throw new Error(
-      `Refusing to install into symlinked skill root: ${targetRoot}. Use a real directory target or manage the symlink source directly.`,
+      `Refusing to install into symlinked skill root: ${targetRoot}. Ancestor path is a symlink: ${symlinkPath}. Use a real directory target or manage the symlink source directly.`,
     );
   }
+
+  const kind = await pathKind(targetRoot);
 
   if (kind === "other") {
     throw new Error(`Skill root exists but is not a directory: ${targetRoot}`);

--- a/extension/installer.ts
+++ b/extension/installer.ts
@@ -61,29 +61,46 @@ async function pathKind(targetPath: string): Promise<"missing" | "directory" | "
   }
 }
 
-async function findSymlinkedAncestor(targetPath: string): Promise<string | undefined> {
-  let currentPath = path.resolve(targetPath);
+async function findSymlinkedAncestor(targetPath: string, anchorPath: string): Promise<string | undefined> {
+  const resolvedTargetPath = path.resolve(targetPath);
+  const resolvedAnchorPath = path.resolve(anchorPath);
+  const relativePath = path.relative(resolvedAnchorPath, resolvedTargetPath);
 
-  while (true) {
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    throw new Error(`Target path is outside the expected skill root anchor: ${targetPath}`);
+  }
+
+  let currentPath = resolvedAnchorPath;
+
+  for (const segment of [".", ...relativePath.split(path.sep).filter(Boolean)]) {
+    if (segment !== ".") {
+      currentPath = path.join(currentPath, segment);
+    }
+
     try {
       const stats = await lstat(currentPath);
-      return stats.isSymbolicLink() ? currentPath : undefined;
+
+      if (stats.isSymbolicLink()) {
+        return currentPath;
+      }
     } catch {
-      // Missing path segments are fine here; keep walking upward until the first existing ancestor.
-    }
-
-    const parentPath = path.dirname(currentPath);
-
-    if (parentPath === currentPath) {
       return undefined;
     }
-
-    currentPath = parentPath;
   }
+
+  return undefined;
 }
 
-async function assertWritableSkillRoot(targetRoot: string) {
-  const symlinkPath = await findSymlinkedAncestor(targetRoot);
+function resolveSymlinkCheckAnchor(scope: InstallScope, targetRoot: string) {
+  if (scope === "system") {
+    return path.resolve(targetRoot, "..", "..", "..");
+  }
+
+  return path.resolve(targetRoot, "..", "..");
+}
+
+async function assertWritableSkillRoot(scope: InstallScope, targetRoot: string) {
+  const symlinkPath = await findSymlinkedAncestor(targetRoot, resolveSymlinkCheckAnchor(scope, targetRoot));
 
   if (symlinkPath) {
     throw new Error(
@@ -123,7 +140,7 @@ export async function syncPackagedSkills({
   targetRoot: string;
   sourceRoot?: string;
 }): Promise<InstallResult> {
-  await assertWritableSkillRoot(targetRoot);
+  await assertWritableSkillRoot(scope, targetRoot);
   await mkdir(targetRoot, { recursive: true });
 
   const results: SkillInstallResult[] = [];

--- a/extension/presentation.ts
+++ b/extension/presentation.ts
@@ -40,6 +40,8 @@ function formatInstallStatus(status: InstallStatus): string {
       return "updated";
     case "already-installed":
       return "already installed";
+    default:
+      throw new Error(`Unknown install status: ${status}`);
   }
 }
 

--- a/extension/presentation.ts
+++ b/extension/presentation.ts
@@ -40,6 +40,8 @@ function formatInstallStatus(status: InstallStatus): string {
       return "updated";
     case "already-installed":
       return "already installed";
+    case "missing":
+      return "not installed";
     default:
       throw new Error(`Unknown install status: ${status}`);
   }
@@ -129,18 +131,31 @@ export function buildInstallUsageLines(action: Extract<DevLoopsAction, "install"
 }
 
 export function buildInstallResultLines(result: InstallResult): string[] {
-  const changedCount = result.results.filter((entry) => entry.status !== "already-installed").length;
+  const changedCount = result.results.filter((entry) => entry.status !== "already-installed" && entry.status !== "missing").length;
 
-  return [
+  const lines = [
     `pi-dev-loops ${result.mode} ${result.scope}: ${changedCount}/${result.results.length} skill directories changed`,
     `Target: ${result.targetRoot}`,
     ...result.results.map((entry) => `- ${entry.skillName}: ${formatInstallStatus(entry.status)} (${entry.targetPath})`),
-    "Restart Pi or refresh skill discovery before expecting `/skill:dev-loop` or `/skill:copilot-dev-loop` to appear in this session.",
   ];
+
+  if (result.mode === "update" && result.results.some((entry) => entry.status === "missing")) {
+    lines.push("Some packaged skills were not installed in this target yet; use `/dev-loops install repo|system` for first-time setup.");
+  }
+
+  lines.push("Restart Pi or refresh skill discovery before expecting `/skill:dev-loop` or `/skill:copilot-dev-loop` to appear in this session.");
+
+  return lines;
 }
 
 export function buildInstallNotificationMessage(result: InstallResult): string {
-  const changedCount = result.results.filter((entry) => entry.status !== "already-installed").length;
+  const changedCount = result.results.filter((entry) => entry.status !== "already-installed" && entry.status !== "missing").length;
+  const missingCount = result.results.filter((entry) => entry.status === "missing").length;
+
+  if (result.mode === "update" && missingCount > 0) {
+    return `pi-dev-loops ${result.mode} ${result.scope}: ${changedCount}/${result.results.length} skill directories changed, ${missingCount} not installed yet`;
+  }
+
   return `pi-dev-loops ${result.mode} ${result.scope}: ${changedCount}/${result.results.length} skill directories changed`;
 }
 

--- a/extension/presentation.ts
+++ b/extension/presentation.ts
@@ -1,15 +1,18 @@
 import type { DevLoopCheck, DevLoopCheckId } from "./checks.ts";
+import type { InstallResult, InstallScope, InstallStatus } from "./installer.ts";
 import { DEV_LOOP_CHECK_IDS, summarizeChecks, renderCheckLines } from "./checks.ts";
 
-export type DevLoopsAction = "doctor" | "setup" | "status" | "hide";
+export type DevLoopsAction = "doctor" | "help" | "install" | "status" | "update" | "hide";
+
+const INSTALL_GUIDANCE = "Run `/dev-loops install repo` for this repository or `/dev-loops install system` for `~/.pi/agent/skills`.";
 
 const SETUP_GUIDANCE: Record<(typeof DEV_LOOP_CHECK_IDS)[number], string> = {
   "gh-installed": "Install GitHub CLI to enable remote GitHub/Copilot workflows.",
   "gh-auth": "Run `gh auth login` so remote GitHub/Copilot workflows can use your GitHub session.",
   "subagent-tool": "Install or enable `pi-subagents`; the shared loop workflows assume subagent support.",
   "git-repo": "Open Pi inside a git repository checkout before using the shared loops.",
-  "local-dev-loop-skill": "Make sure `/skill:dev-loop` is discoverable before starting local phase-based work.",
-  "copilot-dev-loop-skill": "Make sure `/skill:copilot-dev-loop` is discoverable before starting remote GitHub/Copilot workflows.",
+  "local-dev-loop-skill": INSTALL_GUIDANCE,
+  "copilot-dev-loop-skill": INSTALL_GUIDANCE,
 };
 
 function readinessLabel(ready: boolean): string {
@@ -29,6 +32,17 @@ const REMOTE_READINESS_IDS: DevLoopCheckId[] = [
   "copilot-dev-loop-skill",
 ];
 
+function formatInstallStatus(status: InstallStatus): string {
+  switch (status) {
+    case "installed":
+      return "installed";
+    case "updated":
+      return "updated";
+    case "already-installed":
+      return "already installed";
+  }
+}
+
 export function describeReadiness(checks: DevLoopCheck[]) {
   const byId = checkMap(checks);
   const localReady = LOCAL_READINESS_IDS.every((id) => byId.get(id)?.ok);
@@ -42,9 +56,8 @@ export function describeReadiness(checks: DevLoopCheck[]) {
 
 export function orderedSetupSteps(checks: DevLoopCheck[]): string[] {
   const byId = checkMap(checks);
-  const steps = DEV_LOOP_CHECK_IDS.filter((id) => byId.get(id)?.ok === false).map(
-    (id, index) => `${index + 1}. ${SETUP_GUIDANCE[id]}`,
-  );
+  const uniqueSteps = [...new Set(DEV_LOOP_CHECK_IDS.filter((id) => byId.get(id)?.ok === false).map((id) => SETUP_GUIDANCE[id]))];
+  const steps = uniqueSteps.map((step, index) => `${index + 1}. ${step}`);
 
   if (steps.length > 0) {
     return steps;
@@ -52,11 +65,26 @@ export function orderedSetupSteps(checks: DevLoopCheck[]): string[] {
 
   return [
     "1. Run `/dev-loops status` whenever you want a concise readiness snapshot.",
-    "2. Use `/skill:dev-loop` for local phase-based work or `/skill:copilot-dev-loop` for remote GitHub/Copilot workflows.",
+    "2. Use `/dev-loops update repo` or `/dev-loops update system` to refresh installed skills when the package changes.",
   ];
 }
 
-export function buildWidgetLines(action: Exclude<DevLoopsAction, "hide">, checks: DevLoopCheck[]): string[] {
+export function buildHelpLines(): string[] {
+  return [
+    "pi-dev-loops help",
+    "Commands:",
+    "- /dev-loops status",
+    "- /dev-loops doctor",
+    "- /dev-loops install",
+    "  prompts for `repo` or `system` when no target is provided",
+    "- /dev-loops update",
+    "  prompts for `repo` or `system` when no target is provided",
+    "- /dev-loops hide",
+    "The package install exposes `/dev-loops` only; skills are installed explicitly through the install/update commands.",
+  ];
+}
+
+export function buildWidgetLines(action: Extract<DevLoopsAction, "doctor" | "status">, checks: DevLoopCheck[]): string[] {
   const summary = summarizeChecks(checks);
   const readiness = describeReadiness(checks);
   const lines = [
@@ -73,25 +101,52 @@ export function buildWidgetLines(action: Exclude<DevLoopsAction, "hide">, checks
     ];
   }
 
-  const detailedLines = renderCheckLines(checks);
-
-  if (action === "doctor") {
-    return [
-      ...lines,
-      ...detailedLines,
-      "Use `/dev-loops setup` for ordered first-time setup guidance.",
-    ];
-  }
-
   return [
     ...lines,
-    ...detailedLines,
-    "Ordered setup steps:",
-    ...orderedSetupSteps(checks),
+    ...renderCheckLines(checks),
+    "Use `/dev-loops install repo|system` to install packaged skills, or `/dev-loops update repo|system` to refresh them.",
   ];
 }
 
-export function buildNotificationMessage(action: Exclude<DevLoopsAction, "hide">, checks: DevLoopCheck[]): string {
+export function buildNotificationMessage(action: Extract<DevLoopsAction, "doctor" | "status">, checks: DevLoopCheck[]): string {
   const summary = summarizeChecks(checks);
   return `pi-dev-loops ${action}: ${summary.ok}/${summary.total} checks passed`;
+}
+
+export function buildInstallUsageLines(action: Extract<DevLoopsAction, "install" | "update">): string[] {
+  return [
+    `pi-dev-loops ${action}: choose a target`,
+    "Usage:",
+    `- /dev-loops ${action} repo`,
+    `- /dev-loops ${action} system`,
+    "`repo` installs into the current git repository under `.pi/skills`.",
+    "`system` installs into `~/.pi/agent/skills`.",
+  ];
+}
+
+export function buildInstallResultLines(result: InstallResult): string[] {
+  const changedCount = result.results.filter((entry) => entry.status !== "already-installed").length;
+
+  return [
+    `pi-dev-loops ${result.mode} ${result.scope}: ${changedCount}/${result.results.length} skill directories changed`,
+    `Target: ${result.targetRoot}`,
+    ...result.results.map((entry) => `- ${entry.skillName}: ${formatInstallStatus(entry.status)} (${entry.targetPath})`),
+    "Restart Pi or refresh skill discovery before expecting `/skill:dev-loop` or `/skill:copilot-dev-loop` to appear in this session.",
+  ];
+}
+
+export function buildInstallNotificationMessage(result: InstallResult): string {
+  const changedCount = result.results.filter((entry) => entry.status !== "already-installed").length;
+  return `pi-dev-loops ${result.mode} ${result.scope}: ${changedCount}/${result.results.length} skill directories changed`;
+}
+
+export function buildRepoInstallErrorLines(action: Extract<DevLoopsAction, "install" | "update">): string[] {
+  return [
+    `pi-dev-loops ${action} repo: not inside a git repository`,
+    "Run the command from a git worktree, or use `/dev-loops install system` to install globally.",
+  ];
+}
+
+export function buildScopeLabel(scope: InstallScope): string {
+  return scope;
 }

--- a/extension/presentation.ts
+++ b/extension/presentation.ts
@@ -1,5 +1,5 @@
 import type { DevLoopCheck, DevLoopCheckId } from "./checks.ts";
-import type { InstallResult, InstallScope, InstallStatus } from "./installer.ts";
+import type { InstallResult, InstallStatus } from "./installer.ts";
 import { DEV_LOOP_CHECK_IDS, summarizeChecks, renderCheckLines } from "./checks.ts";
 
 export type DevLoopsAction = "doctor" | "help" | "install" | "status" | "update" | "hide";
@@ -114,13 +114,15 @@ export function buildNotificationMessage(action: Extract<DevLoopsAction, "doctor
 }
 
 export function buildInstallUsageLines(action: Extract<DevLoopsAction, "install" | "update">): string[] {
+  const actionVerb = action === "install" ? "installs" : "updates";
+
   return [
     `pi-dev-loops ${action}: choose a target`,
     "Usage:",
     `- /dev-loops ${action} repo`,
     `- /dev-loops ${action} system`,
-    "`repo` installs into the current git repository under `.pi/skills`.",
-    "`system` installs into `~/.pi/agent/skills`.",
+    `\`repo\` ${actionVerb} skills in the current git repository under \`.pi/skills\`.`,
+    `\`system\` ${actionVerb} skills in \`~/.pi/agent/skills\`.`,
   ];
 }
 
@@ -143,10 +145,19 @@ export function buildInstallNotificationMessage(result: InstallResult): string {
 export function buildRepoInstallErrorLines(action: Extract<DevLoopsAction, "install" | "update">): string[] {
   return [
     `pi-dev-loops ${action} repo: not inside a git repository`,
-    "Run the command from a git worktree, or use `/dev-loops install system` to install globally.",
+    `Run the command from a git worktree, or use \`/dev-loops ${action} system\` for the system-wide target.`,
   ];
 }
 
-export function buildScopeLabel(scope: InstallScope): string {
-  return scope;
+export function buildInstallFailureLines(
+  action: Extract<DevLoopsAction, "install" | "update">,
+  scope: "repo" | "system",
+  error: unknown,
+): string[] {
+  const detail = error instanceof Error ? error.message : String(error);
+
+  return [
+    `pi-dev-loops ${action} ${scope}: failed`,
+    detail,
+  ];
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "test": "npm run test:assets && npm run test:extension && npm run test:scripts && npm run test:core",
     "test:assets": "node --test test/imported-assets-normalization.test.mjs test/refiner-agent-phase-planning.test.mjs test/dev-loop-init-phase-smoke.test.mjs",
-    "test:extension": "node --test test/extension-checks.test.mjs test/extension-command-contract.test.mjs test/extension-package-contract.test.mjs",
+    "test:extension": "node --test test/extension-checks.test.mjs test/extension-installer.test.mjs test/extension-command-contract.test.mjs test/extension-package-contract.test.mjs",
     "test:scripts": "node --test test/github/*.test.mjs test/loop/*.test.mjs",
     "test:core": "node --test packages/core/test/*.test.mjs",
     "test:dev-loop": "npm --prefix skills/dev-loop test"
@@ -34,9 +34,6 @@
   "pi": {
     "extensions": [
       "./extension/index.ts"
-    ],
-    "skills": [
-      "./skills"
     ]
   }
 }

--- a/packages/core/src/github/review-threads.mjs
+++ b/packages/core/src/github/review-threads.mjs
@@ -96,7 +96,7 @@ export function isActionableThread(thread) {
   return extractRawComments(thread).some((comment) => isActionableComment(comment));
 }
 
-function normalizeComment(comment, threadId, index) {
+function normalizeComment(comment, threadId, index, { isResolved = false } = {}) {
   const author = normalizeAuthor(comment?.author);
   const body = normalizeBody(comment?.body ?? comment?.bodyText ?? comment?.bodyHTML ?? "");
 
@@ -105,7 +105,7 @@ function normalizeComment(comment, threadId, index) {
     threadId,
     author,
     body,
-    isActionable: body.length > 0 && author.login.length > 0 && author.type !== "System" && !author.isBot,
+    isActionable: !isResolved && body.length > 0 && author.login.length > 0 && author.type !== "System" && !author.isBot,
   };
 }
 
@@ -114,13 +114,12 @@ export function parseReviewThreads(payload) {
   const comments = [];
   const threads = rawThreads.map((thread, threadIndex) => {
     const threadId = normalizeId(thread?.id ?? thread?.databaseId, `thread-${threadIndex + 1}`);
+    const isResolved = Boolean(thread?.isResolved);
     const normalizedComments = extractRawComments(thread)
-      .map((comment, commentIndex) => normalizeComment(comment, threadId, commentIndex))
+      .map((comment, commentIndex) => normalizeComment(comment, threadId, commentIndex, { isResolved }))
       .sort((left, right) => compareIds(left.id, right.id));
 
     comments.push(...normalizedComments);
-
-    const isResolved = Boolean(thread?.isResolved);
     const actionableCommentIds = isResolved
       ? []
       : normalizedComments

--- a/packages/core/src/github/review-threads.mjs
+++ b/packages/core/src/github/review-threads.mjs
@@ -120,14 +120,17 @@ export function parseReviewThreads(payload) {
 
     comments.push(...normalizedComments);
 
-    const actionableCommentIds = normalizedComments
-      .filter((comment) => comment.isActionable)
-      .map((comment) => comment.id);
+    const isResolved = Boolean(thread?.isResolved);
+    const actionableCommentIds = isResolved
+      ? []
+      : normalizedComments
+          .filter((comment) => comment.isActionable)
+          .map((comment) => comment.id);
 
     return {
       id: threadId,
-      isResolved: Boolean(thread?.isResolved),
-      isActionable: !Boolean(thread?.isResolved) && actionableCommentIds.length > 0,
+      isResolved,
+      isActionable: actionableCommentIds.length > 0,
       commentIds: normalizedComments.map((comment) => comment.id),
       actionableCommentIds,
     };
@@ -143,7 +146,7 @@ export function parseReviewThreads(payload) {
       totalThreads: threads.length,
       unresolvedThreads: threads.filter((thread) => !thread.isResolved).length,
       actionableThreads: threads.filter((thread) => thread.isActionable).length,
-      actionableComments: sortedComments.filter((comment) => comment.isActionable).length,
+      actionableComments: threads.reduce((count, thread) => count + thread.actionableCommentIds.length, 0),
     },
     threads,
     comments: sortedComments,

--- a/packages/core/test/review-threads-cli.test.mjs
+++ b/packages/core/test/review-threads-cli.test.mjs
@@ -53,6 +53,8 @@ test("parse-review-threads CLI emits stable machine-readable success output", as
   });
   assert.equal(output.ok, true);
   assert.equal(output.threads[0].id, "t-1");
+  assert.equal(output.comments[1].id, "c-2");
+  assert.equal(output.comments[1].isActionable, false);
   assert.equal(output.comments[3].id, "c-4");
 });
 

--- a/packages/core/test/review-threads-cli.test.mjs
+++ b/packages/core/test/review-threads-cli.test.mjs
@@ -49,7 +49,7 @@ test("parse-review-threads CLI emits stable machine-readable success output", as
     totalThreads: 3,
     unresolvedThreads: 2,
     actionableThreads: 1,
-    actionableComments: 2,
+    actionableComments: 1,
   });
   assert.equal(output.ok, true);
   assert.equal(output.threads[0].id, "t-1");

--- a/packages/core/test/review-threads.test.mjs
+++ b/packages/core/test/review-threads.test.mjs
@@ -53,7 +53,7 @@ test("parseReviewThreads normalizes fixture-backed review thread data", async ()
     totalThreads: 3,
     unresolvedThreads: 2,
     actionableThreads: 1,
-    actionableComments: 2,
+    actionableComments: 1,
   });
 
   assert.deepEqual(result.threads, [
@@ -69,7 +69,7 @@ test("parseReviewThreads normalizes fixture-backed review thread data", async ()
       isResolved: true,
       isActionable: false,
       commentIds: ["c-2"],
-      actionableCommentIds: ["c-2"],
+      actionableCommentIds: [],
     },
     {
       id: "t-3",

--- a/packages/core/test/review-threads.test.mjs
+++ b/packages/core/test/review-threads.test.mjs
@@ -93,7 +93,7 @@ test("parseReviewThreads normalizes fixture-backed review thread data", async ()
       threadId: "t-2",
       author: { login: "maintainer", type: "User", isBot: false },
       body: "Resolve after the docs update lands.",
-      isActionable: true,
+      isActionable: false,
     },
     {
       id: "c-3",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -32,6 +32,28 @@ Failure behavior:
 - malformed arguments, invalid JSON, and `gh` failures emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero
 - live capture is only allowed when both `--repo` and `--pr` are present
 
+### `scripts/github/request-copilot-review.mjs`
+
+Request Copilot review on a PR and verify the request deterministically.
+
+Required:
+- `--repo <owner/name>`
+- `--pr <number>`
+
+Contract:
+- checks `requested_reviewers` first so an existing Copilot request is detected without mutating PR state again
+- requests Copilot via `gh pr edit <pr> --repo <owner/name> --add-reviewer @copilot`
+- verifies the result through `gh api repos/<owner>/<name>/pulls/<pr>/requested_reviewers`
+- does **not** rely on `gh pr view --json reviewRequests`, which can be incomplete for Copilot reviewer state
+- normalizes known repository/tooling limitations into a machine-readable `unavailable` result instead of forcing callers to parse ad hoc stderr
+
+Success output shape:
+- `{ "ok": true, "status": "requested"|"already-requested"|"unavailable", "repo": "owner/name", "pr": 17, "reviewer": "Copilot", ... }`
+- `unavailable` also includes a `detail` string with the normalized GitHub/CLI limitation
+
+Failure behavior:
+- malformed arguments and unexpected `gh` failures emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero
+
 ### `scripts/github/watch-copilot-review.mjs`
 
 Watch for fresh Copilot-authored review/comment activity on a PR.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -43,6 +43,7 @@ Required:
 Contract:
 - checks `requested_reviewers` first so an existing Copilot request is detected without mutating PR state again
 - requests Copilot via `gh pr edit <pr> --repo <owner/name> --add-reviewer @copilot`
+- is suitable both for the first request after ready-for-review and for later explicit re-requests after follow-up fix commits land on the PR head
 - verifies the result through `gh api repos/<owner>/<name>/pulls/<pr>/requested_reviewers`
 - does **not** rely on `gh pr view --json reviewRequests`, which can be incomplete for Copilot reviewer state
 - normalizes known repository/tooling limitations into a machine-readable `unavailable` result instead of forcing callers to parse ad hoc stderr

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -83,7 +83,7 @@ For new GitHub mutation helpers in this repo, do not stop at fixture-only confid
 
 ### `scripts/github/watch-copilot-review.mjs`
 
-Watch for fresh Copilot-authored review-thread comment activity on a PR.
+Watch for fresh Copilot-authored review activity on a PR.
 
 Required:
 - `--repo <owner/name>`
@@ -95,13 +95,12 @@ Optional:
 
 Contract:
 - captures a baseline snapshot, then performs a bounded number of follow-up polls
-- returns `changed` only for fresh Copilot-authored review-thread comments that were not present in the baseline snapshot
-- ignores fresh non-Copilot review-thread activity
+- returns `changed` for any fresh Copilot-authored review-thread comments, PR review summaries, or PR issue comments that were not present in the baseline snapshot
+- ignores fresh non-Copilot review activity across those same surfaces
 - `--timeout-ms 0` performs a single immediate recheck and returns `idle` if unchanged
 
 Success output shape:
-- `{ "ok": true, "status": "changed"|"timeout"|"idle", "repo": "owner/name", "pr": 17, "attempts": 1, "newComments": [...] }`
-- this helper does not currently watch general PR review summaries or issue comments; callers that need those signals should not overclaim that coverage
+- `{ "ok": true, "status": "changed"|"timeout"|"idle", "repo": "owner/name", "pr": 17, "attempts": 1, "newComments": [...], "newReviews": [...], "newIssueComments": [...] }`
 
 Failure behavior:
 - malformed arguments and `gh` failures emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -54,6 +54,31 @@ Success output shape:
 Failure behavior:
 - malformed arguments and unexpected `gh` failures emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero
 
+### `scripts/github/reply-resolve-review-thread.mjs`
+
+Reply to a PR review comment and resolve the associated review thread deterministically.
+
+Required:
+- `--repo <owner/name>`
+- `--pr <number>`
+- `--comment-id <number>`
+- `--thread-id <node-id>`
+- `--body-file <path>`
+
+Contract:
+- reads the reply body from a file so shell quoting does not become part of the workflow logic
+- posts the reply to `repos/<owner>/<name>/pulls/<pr>/comments/<comment-id>/replies`
+- resolves the thread with the GraphQL `resolveReviewThread` mutation
+- fails if the thread does not report resolved after the mutation
+
+Success output shape:
+- `{ "ok": true, "repo": "owner/name", "pr": 17, "commentId": 123, "threadId": "...", "replyId": 456, "replyUrl": "...", "resolved": true }`
+
+Failure behavior:
+- malformed arguments, empty body files, unexpected `gh` failures, and unsuccessful resolve responses emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero
+
+For new GitHub mutation helpers in this repo, do not stop at fixture-only confidence when a real PR is available and mutation is authorized. Run a bounded real-PR smoke check before depending on the helper inside a longer async review/fix loop.
+
 ### `scripts/github/watch-copilot-review.mjs`
 
 Watch for fresh Copilot-authored review/comment activity on a PR.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -83,7 +83,7 @@ For new GitHub mutation helpers in this repo, do not stop at fixture-only confid
 
 ### `scripts/github/watch-copilot-review.mjs`
 
-Watch for fresh Copilot-authored review/comment activity on a PR.
+Watch for fresh Copilot-authored review-thread comment activity on a PR.
 
 Required:
 - `--repo <owner/name>`
@@ -95,12 +95,13 @@ Optional:
 
 Contract:
 - captures a baseline snapshot, then performs a bounded number of follow-up polls
-- returns `changed` only for fresh Copilot-authored comments that were not present in the baseline snapshot
-- ignores fresh non-Copilot review activity
+- returns `changed` only for fresh Copilot-authored review-thread comments that were not present in the baseline snapshot
+- ignores fresh non-Copilot review-thread activity
 - `--timeout-ms 0` performs a single immediate recheck and returns `idle` if unchanged
 
 Success output shape:
 - `{ "ok": true, "status": "changed"|"timeout"|"idle", "repo": "owner/name", "pr": 17, "attempts": 1, "newComments": [...] }`
+- this helper does not currently watch general PR review summaries or issue comments; callers that need those signals should not overclaim that coverage
 
 Failure behavior:
 - malformed arguments and `gh` failures emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -44,6 +44,7 @@ Contract:
 - checks `requested_reviewers` first so an existing Copilot request is detected without mutating PR state again
 - requests Copilot via `gh pr edit <pr> --repo <owner/name> --add-reviewer @copilot`
 - is suitable both for the first request after ready-for-review and for later explicit re-requests after follow-up fix commits land on the PR head
+- should be paired with a fresh unresolved-thread check after Copilot posts again; requesting review alone does not complete the loop
 - verifies the result through `gh api repos/<owner>/<name>/pulls/<pr>/requested_reviewers`
 - does **not** rely on `gh pr view --json reviewRequests`, which can be incomplete for Copilot reviewer state
 - normalizes known repository/tooling limitations into a machine-readable `unavailable` result instead of forcing callers to parse ad hoc stderr

--- a/scripts/github/reply-resolve-review-thread.mjs
+++ b/scripts/github/reply-resolve-review-thread.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { formatCliError } from "../_core-helpers.mjs";
+import { parseRepoSlug } from "./capture-review-threads.mjs";
 
 const RESOLVE_REVIEW_THREAD_MUTATION = [
   "mutation($threadId: ID!) {",
@@ -49,7 +50,7 @@ export function parseReplyResolveCliArgs(argv) {
     const token = args.shift();
 
     if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo");
+      options.repo = requireOptionValue(args, "--repo").trim();
       continue;
     }
 
@@ -81,6 +82,8 @@ export function parseReplyResolveCliArgs(argv) {
       "Replying and resolving a review thread requires --repo <owner/name>, --pr <number>, --comment-id <number>, --thread-id <node-id>, and --body-file <path>",
     );
   }
+
+  parseRepoSlug(options.repo);
 
   return options;
 }
@@ -193,9 +196,9 @@ export async function runCli(
   } = {},
 ) {
   const options = parseReplyResolveCliArgs(argv);
-  const body = (await readFile(options.bodyFile, "utf8")).trim();
+  const rawBody = await readFile(options.bodyFile, "utf8");
 
-  if (body.length === 0) {
+  if (rawBody.trim().length === 0) {
     throw new Error("--body-file must contain non-empty text");
   }
 
@@ -204,7 +207,7 @@ export async function runCli(
       repo: options.repo,
       pr: options.pr,
       commentId: options.commentId,
-      body,
+      body: rawBody,
     },
     { env, ghCommand },
   ));

--- a/scripts/github/reply-resolve-review-thread.mjs
+++ b/scripts/github/reply-resolve-review-thread.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { formatCliError } from "../_core-helpers.mjs";
+
+const RESOLVE_REVIEW_THREAD_MUTATION = [
+  "mutation($threadId: ID!) {",
+  "  resolveReviewThread(input: { threadId: $threadId }) {",
+  "    thread {",
+  "      id",
+  "      isResolved",
+  "    }",
+  "  }",
+  "}",
+].join("\n");
+
+function requireOptionValue(args, flag) {
+  const value = args.shift();
+
+  if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+
+  return value;
+}
+
+function parsePositiveInteger(value, flag) {
+  if (!/^\d+$/.test(value) || Number(value) === 0) {
+    throw new Error(`${flag} must be a positive integer`);
+  }
+
+  return Number(value);
+}
+
+export function parseReplyResolveCliArgs(argv) {
+  const args = [...argv];
+  const options = {
+    repo: undefined,
+    pr: undefined,
+    commentId: undefined,
+    threadId: undefined,
+    bodyFile: undefined,
+  };
+
+  while (args.length > 0) {
+    const token = args.shift();
+
+    if (token === "--repo") {
+      options.repo = requireOptionValue(args, "--repo");
+      continue;
+    }
+
+    if (token === "--pr") {
+      options.pr = parsePositiveInteger(requireOptionValue(args, "--pr"), "--pr");
+      continue;
+    }
+
+    if (token === "--comment-id") {
+      options.commentId = parsePositiveInteger(requireOptionValue(args, "--comment-id"), "--comment-id");
+      continue;
+    }
+
+    if (token === "--thread-id") {
+      options.threadId = requireOptionValue(args, "--thread-id");
+      continue;
+    }
+
+    if (token === "--body-file") {
+      options.bodyFile = requireOptionValue(args, "--body-file");
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${token}`);
+  }
+
+  if (!options.repo || !options.pr || !options.commentId || !options.threadId || !options.bodyFile) {
+    throw new Error(
+      "Replying and resolving a review thread requires --repo <owner/name>, --pr <number>, --comment-id <number>, --thread-id <node-id>, and --body-file <path>",
+    );
+  }
+
+  return options;
+}
+
+function runChild(command, args, env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+function parseJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`Invalid JSON from gh: ${text.trim() || "<empty>"}`);
+  }
+}
+
+async function postReply({ repo, pr, commentId, body }, { env = process.env, ghCommand = "gh" } = {}) {
+  const result = await runChild(
+    ghCommand,
+    ["api", "-X", "POST", `repos/${repo}/pulls/${pr}/comments/${commentId}/replies`, "-f", `body=${body}`],
+    env,
+  );
+
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw new Error(`gh command failed: ${detail}`);
+  }
+
+  return parseJson(result.stdout);
+}
+
+async function resolveThread(threadId, { env = process.env, ghCommand = "gh" } = {}) {
+  const result = await runChild(
+    ghCommand,
+    [
+      "api",
+      "graphql",
+      "--field",
+      `threadId=${threadId}`,
+      "--field",
+      `query=${RESOLVE_REVIEW_THREAD_MUTATION}`,
+    ],
+    env,
+  );
+
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw new Error(`gh command failed: ${detail}`);
+  }
+
+  const payload = parseJson(result.stdout);
+  return payload?.data?.resolveReviewThread?.thread;
+}
+
+export async function runCli(
+  argv = process.argv.slice(2),
+  {
+    stdout = process.stdout,
+    env = process.env,
+    ghCommand = "gh",
+  } = {},
+) {
+  const options = parseReplyResolveCliArgs(argv);
+  const body = (await readFile(options.bodyFile, "utf8")).trim();
+
+  if (body.length === 0) {
+    throw new Error("--body-file must contain non-empty text");
+  }
+
+  const reply = await postReply(
+    {
+      repo: options.repo,
+      pr: options.pr,
+      commentId: options.commentId,
+      body,
+    },
+    { env, ghCommand },
+  );
+  const resolvedThread = await resolveThread(options.threadId, { env, ghCommand });
+
+  if (!resolvedThread?.isResolved) {
+    throw new Error(`Review thread did not resolve successfully: ${options.threadId}`);
+  }
+
+  stdout.write(`${JSON.stringify({
+    ok: true,
+    repo: options.repo,
+    pr: options.pr,
+    commentId: options.commentId,
+    threadId: options.threadId,
+    replyId: reply?.id,
+    replyUrl: reply?.html_url,
+    resolved: true,
+  })}\n`);
+}
+
+const isDirectRun = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isDirectRun) {
+  runCli().catch((error) => {
+    process.stderr.write(`${formatCliError(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/github/reply-resolve-review-thread.mjs
+++ b/scripts/github/reply-resolve-review-thread.mjs
@@ -85,11 +85,11 @@ export function parseReplyResolveCliArgs(argv) {
   return options;
 }
 
-function runChild(command, args, env) {
+function runChild(command, args, env, stdinText) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       env,
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: ["pipe", "pipe", "pipe"],
     });
 
     let stdout = "";
@@ -102,6 +102,12 @@ function runChild(command, args, env) {
     child.stderr.on("data", (chunk) => {
       stderr += String(chunk);
     });
+
+    if (stdinText === undefined) {
+      child.stdin.end();
+    } else {
+      child.stdin.end(stdinText);
+    }
 
     child.on("error", reject);
     child.on("close", (code) => {
@@ -121,8 +127,16 @@ function parseJson(text) {
 async function postReply({ repo, pr, commentId, body }, { env = process.env, ghCommand = "gh" } = {}) {
   const result = await runChild(
     ghCommand,
-    ["api", "-X", "POST", `repos/${repo}/pulls/${pr}/comments/${commentId}/replies`, "-f", `body=${body}`],
+    [
+      "api",
+      "-X",
+      "POST",
+      `repos/${repo}/pulls/${pr}/comments/${commentId}/replies`,
+      "--input",
+      "-",
+    ],
     env,
+    `${JSON.stringify({ body })}\n`,
   );
 
   if (result.code !== 0) {

--- a/scripts/github/reply-resolve-review-thread.mjs
+++ b/scripts/github/reply-resolve-review-thread.mjs
@@ -124,6 +124,20 @@ function parseJson(text) {
   }
 }
 
+function parseReplyPayload(payload) {
+  const replyId = payload?.id;
+  const replyUrl = payload?.html_url;
+
+  if (!Number.isFinite(replyId) || typeof replyUrl !== "string" || replyUrl.trim().length === 0) {
+    throw new Error("Reply payload from gh did not include both id and html_url");
+  }
+
+  return {
+    replyId,
+    replyUrl,
+  };
+}
+
 async function postReply({ repo, pr, commentId, body }, { env = process.env, ghCommand = "gh" } = {}) {
   const result = await runChild(
     ghCommand,
@@ -185,7 +199,7 @@ export async function runCli(
     throw new Error("--body-file must contain non-empty text");
   }
 
-  const reply = await postReply(
+  const reply = parseReplyPayload(await postReply(
     {
       repo: options.repo,
       pr: options.pr,
@@ -193,7 +207,7 @@ export async function runCli(
       body,
     },
     { env, ghCommand },
-  );
+  ));
   const resolvedThread = await resolveThread(options.threadId, { env, ghCommand });
 
   if (!resolvedThread?.isResolved) {
@@ -206,8 +220,8 @@ export async function runCli(
     pr: options.pr,
     commentId: options.commentId,
     threadId: options.threadId,
-    replyId: reply?.id,
-    replyUrl: reply?.html_url,
+    replyId: reply.replyId,
+    replyUrl: reply.replyUrl,
     resolved: true,
   })}\n`);
 }

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -83,7 +83,14 @@ function isCopilotReviewer(login) {
 }
 
 function parseRequestedReviewersPayload(text) {
-  const payload = JSON.parse(text);
+  let payload;
+
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    throw new Error(`Invalid JSON from gh: ${text.trim() || "<empty>"}`);
+  }
+
   const users = Array.isArray(payload?.users) ? payload.users : [];
   const teams = Array.isArray(payload?.teams) ? payload.teams : [];
 

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { formatCliError } from "../_core-helpers.mjs";
+
+function requireOptionValue(args, flag) {
+  const value = args.shift();
+
+  if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+
+  return value;
+}
+
+function parsePrNumber(value) {
+  if (!/^\d+$/.test(value) || Number(value) === 0) {
+    throw new Error("--pr must be a positive integer");
+  }
+
+  return Number(value);
+}
+
+export function parseRequestCliArgs(argv) {
+  const args = [...argv];
+  const options = {
+    repo: undefined,
+    pr: undefined,
+  };
+
+  while (args.length > 0) {
+    const token = args.shift();
+
+    if (token === "--repo") {
+      options.repo = requireOptionValue(args, "--repo");
+      continue;
+    }
+
+    if (token === "--pr") {
+      options.pr = parsePrNumber(requireOptionValue(args, "--pr"));
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${token}`);
+  }
+
+  if (options.repo === undefined || options.pr === undefined) {
+    throw new Error("Requesting Copilot review requires both --repo <owner/name> and --pr <number>");
+  }
+
+  return options;
+}
+
+function runChild(command, args, env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+function isCopilotReviewer(login) {
+  return typeof login === "string" && login.toLowerCase() === "copilot";
+}
+
+function parseRequestedReviewersPayload(text) {
+  const payload = JSON.parse(text);
+  const users = Array.isArray(payload?.users) ? payload.users : [];
+  const teams = Array.isArray(payload?.teams) ? payload.teams : [];
+
+  return {
+    users,
+    teams,
+    requested: users.some((user) => isCopilotReviewer(user?.login)),
+  };
+}
+
+async function fetchRequestedReviewers({ repo, pr }, { env = process.env, ghCommand = "gh" } = {}) {
+  const result = await runChild(
+    ghCommand,
+    ["api", `repos/${repo}/pulls/${pr}/requested_reviewers`],
+    env,
+  );
+
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw new Error(`gh command failed: ${detail}`);
+  }
+
+  return parseRequestedReviewersPayload(result.stdout);
+}
+
+function classifyRequestFailure(detail) {
+  const normalized = detail.toLowerCase();
+
+  if (
+    normalized.includes("not a collaborator") ||
+    normalized.includes("not requestable") ||
+    normalized.includes("copilot review") ||
+    normalized.includes("reviews may only be requested")
+  ) {
+    return "unavailable";
+  }
+
+  return undefined;
+}
+
+async function requestCopilotReview({ repo, pr }, { env = process.env, ghCommand = "gh" } = {}) {
+  const result = await runChild(
+    ghCommand,
+    ["pr", "edit", String(pr), "--repo", repo, "--add-reviewer", "@copilot"],
+    env,
+  );
+
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    const classified = classifyRequestFailure(detail);
+
+    if (classified === "unavailable") {
+      return {
+        ok: true,
+        status: "unavailable",
+        repo,
+        pr,
+        reviewer: "Copilot",
+        detail,
+      };
+    }
+
+    throw new Error(`gh command failed: ${detail}`);
+  }
+
+  return {
+    ok: true,
+    status: "requested",
+    repo,
+    pr,
+    reviewer: "Copilot",
+  };
+}
+
+export async function runCli(
+  argv = process.argv.slice(2),
+  {
+    stdout = process.stdout,
+    env = process.env,
+    ghCommand = "gh",
+  } = {},
+) {
+  const options = parseRequestCliArgs(argv);
+  const before = await fetchRequestedReviewers(options, { env, ghCommand });
+
+  if (before.requested) {
+    stdout.write(`${JSON.stringify({
+      ok: true,
+      status: "already-requested",
+      repo: options.repo,
+      pr: options.pr,
+      reviewer: "Copilot",
+    })}\n`);
+    return;
+  }
+
+  const requestResult = await requestCopilotReview(options, { env, ghCommand });
+
+  if (requestResult.status === "unavailable") {
+    stdout.write(`${JSON.stringify(requestResult)}\n`);
+    return;
+  }
+
+  const after = await fetchRequestedReviewers(options, { env, ghCommand });
+
+  if (!after.requested) {
+    throw new Error("Copilot review request did not appear in requested reviewers after gh pr edit");
+  }
+
+  stdout.write(`${JSON.stringify(requestResult)}\n`);
+}
+
+const isDirectRun = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isDirectRun) {
+  runCli().catch((error) => {
+    process.stderr.write(`${formatCliError(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -79,7 +79,7 @@ function runChild(command, args, env) {
 }
 
 function isCopilotReviewer(login) {
-  return typeof login === "string" && login.toLowerCase() === "copilot";
+  return typeof login === "string" && /^copilot(?:[^a-z]|$)/i.test(login);
 }
 
 function parseRequestedReviewersPayload(text) {

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -101,6 +101,25 @@ function parseRequestedReviewersPayload(text) {
   };
 }
 
+function parseReviewsPayload(text) {
+  let payload;
+
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    throw new Error(`Invalid JSON from gh: ${text.trim() || "<empty>"}`);
+  }
+
+  const reviews = Array.isArray(payload?.reviews) ? payload.reviews : [];
+  const copilotReviewIds = reviews
+    .filter((review) => isCopilotReviewer(review?.author?.login))
+    .map((review) => String(review.id));
+
+  return {
+    copilotReviewIds,
+  };
+}
+
 async function fetchRequestedReviewers({ repo, pr }, { env = process.env, ghCommand = "gh" } = {}) {
   const result = await runChild(
     ghCommand,
@@ -114,6 +133,31 @@ async function fetchRequestedReviewers({ repo, pr }, { env = process.env, ghComm
   }
 
   return parseRequestedReviewersPayload(result.stdout);
+}
+
+async function fetchCopilotReviewIds({ repo, pr }, { env = process.env, ghCommand = "gh" } = {}) {
+  const result = await runChild(
+    ghCommand,
+    ["pr", "view", String(pr), "--repo", repo, "--json", "reviews"],
+    env,
+  );
+
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw new Error(`gh command failed: ${detail}`);
+  }
+
+  return parseReviewsPayload(result.stdout);
+}
+
+async function fetchCopilotReviewState(options, runtime) {
+  const requestedReviewers = await fetchRequestedReviewers(options, runtime);
+  const reviews = await fetchCopilotReviewIds(options, runtime);
+
+  return {
+    requested: requestedReviewers.requested,
+    copilotReviewIds: reviews.copilotReviewIds,
+  };
 }
 
 function classifyRequestFailure(detail) {
@@ -174,7 +218,7 @@ export async function runCli(
   } = {},
 ) {
   const options = parseRequestCliArgs(argv);
-  const before = await fetchRequestedReviewers(options, { env, ghCommand });
+  const before = await fetchCopilotReviewState(options, { env, ghCommand });
 
   if (before.requested) {
     stdout.write(`${JSON.stringify({
@@ -194,10 +238,11 @@ export async function runCli(
     return;
   }
 
-  const after = await fetchRequestedReviewers(options, { env, ghCommand });
+  const after = await fetchCopilotReviewState(options, { env, ghCommand });
+  const reviewCountIncreased = after.copilotReviewIds.length > before.copilotReviewIds.length;
 
-  if (!after.requested) {
-    throw new Error("Copilot review request did not appear in requested reviewers after gh pr edit");
+  if (!after.requested && !reviewCountIncreased) {
+    throw new Error("Copilot review request did not appear in requested reviewers or fresh Copilot reviews after gh pr edit");
   }
 
   stdout.write(`${JSON.stringify(requestResult)}\n`);

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { formatCliError } from "../_core-helpers.mjs";
+import { parseRepoSlug } from "./capture-review-threads.mjs";
 
 function requireOptionValue(args, flag) {
   const value = args.shift();
@@ -34,7 +35,7 @@ export function parseRequestCliArgs(argv) {
     const token = args.shift();
 
     if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo");
+      options.repo = requireOptionValue(args, "--repo").trim();
       continue;
     }
 
@@ -49,6 +50,8 @@ export function parseRequestCliArgs(argv) {
   if (options.repo === undefined || options.pr === undefined) {
     throw new Error("Requesting Copilot review requires both --repo <owner/name> and --pr <number>");
   }
+
+  parseRepoSlug(options.repo);
 
   return options;
 }

--- a/scripts/github/watch-copilot-review.mjs
+++ b/scripts/github/watch-copilot-review.mjs
@@ -1,10 +1,56 @@
 #!/usr/bin/env node
+import { spawn } from "node:child_process";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 
-import { formatCliError, parseReviewThreads } from "../_core-helpers.mjs";
-import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
+import { formatCliError, parseJsonText, parseReviewThreads } from "../_core-helpers.mjs";
+import { parseRepoSlug } from "./capture-review-threads.mjs";
+
+const COPILOT_ACTIVITY_QUERY = [
+  "query($owner: String!, $name: String!, $pr: Int!) {",
+  "  repository(owner: $owner, name: $name) {",
+  "    pullRequest(number: $pr) {",
+  "      reviewThreads(first: 100) {",
+  "        nodes {",
+  "          id",
+  "          isResolved",
+  "          comments(first: 100) {",
+  "            nodes {",
+  "              id",
+  "              body",
+  "              author {",
+  "                login",
+  "                __typename",
+  "              }",
+  "            }",
+  "          }",
+  "        }",
+  "      }",
+  "      reviews(first: 100) {",
+  "        nodes {",
+  "          id",
+  "          body",
+  "          author {",
+  "            login",
+  "            __typename",
+  "          }",
+  "        }",
+  "      }",
+  "      comments(first: 100) {",
+  "        nodes {",
+  "          id",
+  "          body",
+  "          author {",
+  "            login",
+  "            __typename",
+  "          }",
+  "        }",
+  "      }",
+  "    }",
+  "  }",
+  "}",
+].join("\n");
 
 function requireOptionValue(args, flag) {
   const value = args.shift();
@@ -78,11 +124,106 @@ function isCopilotLogin(login) {
   return typeof login === "string" && /^copilot(?:[^a-z]|$)/i.test(login);
 }
 
-export function findFreshCopilotComments(baseline, current) {
-  const baselineIds = new Set((baseline?.comments ?? []).map((comment) => comment.id));
+function runChild(command, args, env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
 
-  return (current?.comments ?? [])
-    .filter((comment) => !baselineIds.has(comment.id))
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+async function fetchGithubCopilotActivityPayload(
+  { repo, pr },
+  { env = process.env, ghCommand = "gh" } = {},
+) {
+  const { owner, name } = parseRepoSlug(repo);
+  const result = await runChild(
+    ghCommand,
+    [
+      "api",
+      "graphql",
+      "--field",
+      `owner=${owner}`,
+      "--field",
+      `name=${name}`,
+      "--field",
+      `pr=${pr}`,
+      "--field",
+      `query=${COPILOT_ACTIVITY_QUERY}`,
+    ],
+    env,
+  );
+
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw new Error(`gh command failed: ${detail}`);
+  }
+
+  return parseJsonText(result.stdout);
+}
+
+function normalizeAuthorLogin(author) {
+  return typeof author?.login === "string" ? author.login : "";
+}
+
+function normalizeBody(body) {
+  return typeof body === "string" ? body.trim() : "";
+}
+
+function extractCopilotReviews(payload) {
+  const reviews = payload?.data?.repository?.pullRequest?.reviews?.nodes;
+
+  if (!Array.isArray(reviews)) {
+    return [];
+  }
+
+  return reviews
+    .filter((review) => isCopilotLogin(normalizeAuthorLogin(review?.author)))
+    .map((review) => ({
+      id: String(review?.id ?? ""),
+      authorLogin: normalizeAuthorLogin(review?.author),
+      body: normalizeBody(review?.body),
+    }))
+    .filter((review) => review.id.length > 0);
+}
+
+function extractCopilotIssueComments(payload) {
+  const comments = payload?.data?.repository?.pullRequest?.comments?.nodes;
+
+  if (!Array.isArray(comments)) {
+    return [];
+  }
+
+  return comments
+    .filter((comment) => isCopilotLogin(normalizeAuthorLogin(comment?.author)))
+    .map((comment) => ({
+      id: String(comment?.id ?? ""),
+      authorLogin: normalizeAuthorLogin(comment?.author),
+      body: normalizeBody(comment?.body),
+    }))
+    .filter((comment) => comment.id.length > 0);
+}
+
+function parseCopilotActivity(payload) {
+  const parsedThreads = parseReviewThreads(payload);
+  const newComments = (parsedThreads?.comments ?? [])
     .filter((comment) => isCopilotLogin(comment.author?.login))
     .map((comment) => ({
       id: comment.id,
@@ -90,6 +231,24 @@ export function findFreshCopilotComments(baseline, current) {
       authorLogin: comment.author?.login ?? "",
       body: comment.body,
     }));
+
+  return {
+    reviewThreadComments: newComments,
+    reviews: extractCopilotReviews(payload),
+    issueComments: extractCopilotIssueComments(payload),
+  };
+}
+
+export function findFreshCopilotActivity(baseline, current) {
+  const baselineCommentIds = new Set((baseline?.reviewThreadComments ?? []).map((comment) => comment.id));
+  const baselineReviewIds = new Set((baseline?.reviews ?? []).map((review) => review.id));
+  const baselineIssueCommentIds = new Set((baseline?.issueComments ?? []).map((comment) => comment.id));
+
+  return {
+    newComments: (current?.reviewThreadComments ?? []).filter((comment) => !baselineCommentIds.has(comment.id)),
+    newReviews: (current?.reviews ?? []).filter((review) => !baselineReviewIds.has(review.id)),
+    newIssueComments: (current?.issueComments ?? []).filter((comment) => !baselineIssueCommentIds.has(comment.id)),
+  };
 }
 
 function buildNoChangePayload(status, repo, pr, attempts) {
@@ -100,6 +259,8 @@ function buildNoChangePayload(status, repo, pr, attempts) {
     pr,
     attempts,
     newComments: [],
+    newReviews: [],
+    newIssueComments: [],
   };
 }
 
@@ -120,7 +281,7 @@ export async function runCli(
   } = {},
 ) {
   const options = parseWatchCliArgs(argv);
-  const baseline = parseReviewThreads(await fetchGithubReviewThreadsPayload(
+  const baseline = parseCopilotActivity(await fetchGithubCopilotActivityPayload(
     { repo: options.repo, pr: options.pr },
     { env, ghCommand },
   ));
@@ -131,20 +292,20 @@ export async function runCli(
       await delay(options.pollIntervalMs);
     }
 
-    const current = parseReviewThreads(await fetchGithubReviewThreadsPayload(
+    const current = parseCopilotActivity(await fetchGithubCopilotActivityPayload(
       { repo: options.repo, pr: options.pr },
       { env, ghCommand },
     ));
-    const newComments = findFreshCopilotComments(baseline, current);
+    const activity = findFreshCopilotActivity(baseline, current);
 
-    if (newComments.length > 0) {
+    if (activity.newComments.length > 0 || activity.newReviews.length > 0 || activity.newIssueComments.length > 0) {
       stdout.write(`${JSON.stringify({
         ok: true,
         status: "changed",
         repo: options.repo,
         pr: options.pr,
         attempts: attempt,
-        newComments,
+        ...activity,
       })}\n`);
       return;
     }

--- a/skills/copilot-dev-loop/SKILL.md
+++ b/skills/copilot-dev-loop/SKILL.md
@@ -278,6 +278,7 @@ Preferred approach for Copilot review follow-up:
 - poll for new Copilot-authored reviews/comments
 - keep the watcher in the current Pi/TelePi session
 - after new review activity appears, launch an async Pi fixer in-session
+- do not report the loop complete while fresh Copilot comments remain unresolved; a new Copilot pass must flow back into fixer/reply/resolve work before completion when authorization exists
 - use explicit long timeouts from the timeout policy above rather than short defaults
 
 Use an existing repo-local async review-follow-up skill or deterministic watcher when available.
@@ -307,7 +308,8 @@ When actionable review feedback exists, use a narrow follow-up loop:
    - if that helper was newly added or recently changed, smoke-check it against one real thread before assuming the rest of the loop can rely on it
 7. resolve the addressed review thread only after the reply is attached successfully and the concern is genuinely addressed
    - do not stop at a local fix if GitHub-side reply/resolve is authorized
-8. if scope has broadened, stop and ask before continuing
+8. after a re-requested Copilot pass, refresh PR thread state again before reporting completion; if fresh Copilot threads exist, return to this follow-up loop rather than stopping at "review requested"
+9. if scope has broadened, stop and ask before continuing
 
 Do not treat "fix applied locally" as the end of the loop when the workflow also requires GitHub-side reviewer follow-up. If comment/reply authorization is withheld, report explicitly that the code may be fixed while the PR conversation state remains unresolved.
 

--- a/skills/copilot-dev-loop/SKILL.md
+++ b/skills/copilot-dev-loop/SKILL.md
@@ -244,6 +244,10 @@ When confirming whether Copilot is requested as a reviewer, do not rely solely o
 
 Prefer `gh api repos/<owner>/<repo>/pulls/<number>/requested_reviewers` or an equivalent GraphQL review-request query when reviewer-request confirmation matters.
 
+When a PR is moved from draft to ready, explicitly attempt to request Copilot review rather than assuming repository automation will do it.
+
+If the explicit request fails because Copilot review is not enabled for the repository, the reviewer identity is not requestable, or GitHub rejects the request because the reviewer is not a collaborator/requestable actor, record that exact limitation and continue with the documented watch/follow-up path rather than silently assuming review was requested.
+
 ## Step 6: Async watch behavior
 
 When the user wants Pi to wait for fresh Copilot review activity, prefer native GitHub watch behavior when `gh` supports the exact wait condition, and otherwise use a deterministic watcher rather than ad hoc polling.
@@ -262,6 +266,7 @@ Practical rule for this repo:
   - waiting for unresolved thread state to change in a review-aware way
 
 Preferred approach for Copilot review follow-up:
+- after a PR leaves draft, explicitly try to request Copilot review first
 - baseline current Copilot review activity
 - poll for new Copilot-authored reviews/comments
 - keep the watcher in the current Pi/TelePi session

--- a/skills/copilot-dev-loop/SKILL.md
+++ b/skills/copilot-dev-loop/SKILL.md
@@ -246,6 +246,8 @@ Prefer the deterministic helper `scripts/github/request-copilot-review.mjs` when
 
 When a PR is moved from draft to ready, explicitly attempt to request Copilot review rather than assuming repository automation will do it.
 
+After any follow-up fix commit is pushed to an open PR, explicitly decide whether another Copilot pass is desired. If yes, request Copilot review again rather than assuming GitHub will automatically re-request it for the new head.
+
 Do not web-search or rediscover this behavior during normal operation. Treat the deterministic helper and the repository docs as the source of truth unless you are explicitly debugging the tooling itself.
 
 When introducing or changing deterministic GitHub write helpers (for example review-request or reply/resolve helpers), do not rely on fixture tests alone if a real authorized PR is available. Run one bounded real-PR smoke check before entrusting a long-lived async loop to that helper.
@@ -271,6 +273,7 @@ Practical rule for this repo:
 
 Preferred approach for Copilot review follow-up:
 - after a PR leaves draft, explicitly request Copilot review first, preferably through `scripts/github/request-copilot-review.mjs`
+- after any follow-up fix commit is pushed and another Copilot pass is wanted, explicitly request Copilot review again for the updated head before waiting
 - baseline current Copilot review activity
 - poll for new Copilot-authored reviews/comments
 - keep the watcher in the current Pi/TelePi session
@@ -297,6 +300,7 @@ When actionable review feedback exists, use a narrow follow-up loop:
 3. apply only the accepted narrow fixes
 4. run the smallest validation that honestly proves the fix
 5. if files changed, push the resolving commit before any thread reply claims the fix is present
+   - after the push, if another Copilot pass is desired, explicitly re-request Copilot review for the new head rather than assuming it remains requested
 6. when a comment or thread is actually addressed, reply on GitHub with a short resolution note that references the resolving commit SHA or commit URL when applicable
    - prefer the deterministic helper `scripts/github/reply-resolve-review-thread.mjs` when it exists
    - use a body file under `tmp/` rather than inline shell text for the reply body

--- a/skills/copilot-dev-loop/SKILL.md
+++ b/skills/copilot-dev-loop/SKILL.md
@@ -248,6 +248,8 @@ When a PR is moved from draft to ready, explicitly attempt to request Copilot re
 
 Do not web-search or rediscover this behavior during normal operation. Treat the deterministic helper and the repository docs as the source of truth unless you are explicitly debugging the tooling itself.
 
+When introducing or changing deterministic GitHub write helpers (for example review-request or reply/resolve helpers), do not rely on fixture tests alone if a real authorized PR is available. Run one bounded real-PR smoke check before entrusting a long-lived async loop to that helper.
+
 If the explicit request fails because Copilot review is not enabled for the repository, the reviewer identity is not requestable, or GitHub rejects the request because the reviewer is not a collaborator/requestable actor, record that exact limitation and continue with the documented watch/follow-up path rather than silently assuming review was requested.
 
 ## Step 6: Async watch behavior
@@ -296,10 +298,14 @@ When actionable review feedback exists, use a narrow follow-up loop:
 4. run the smallest validation that honestly proves the fix
 5. if files changed, push the resolving commit before any thread reply claims the fix is present
 6. when a comment or thread is actually addressed, reply on GitHub with a short resolution note that references the resolving commit SHA or commit URL when applicable
+   - prefer the deterministic helper `scripts/github/reply-resolve-review-thread.mjs` when it exists
+   - use a body file under `tmp/` rather than inline shell text for the reply body
+   - if that helper was newly added or recently changed, smoke-check it against one real thread before assuming the rest of the loop can rely on it
 7. resolve the addressed review thread only after the reply is attached successfully and the concern is genuinely addressed
+   - do not stop at a local fix if GitHub-side reply/resolve is authorized
 8. if scope has broadened, stop and ask before continuing
 
-Do not treat "fix applied locally" as the end of the loop when the workflow also requires GitHub-side reviewer follow-up.
+Do not treat "fix applied locally" as the end of the loop when the workflow also requires GitHub-side reviewer follow-up. If comment/reply authorization is withheld, report explicitly that the code may be fixed while the PR conversation state remains unresolved.
 
 When helpful, run parallel review angles such as:
 - correctness/regressions

--- a/skills/copilot-dev-loop/SKILL.md
+++ b/skills/copilot-dev-loop/SKILL.md
@@ -242,9 +242,11 @@ Inspect:
 
 When confirming whether Copilot is requested as a reviewer, do not rely solely on `gh pr view --json reviewRequests`.
 
-Prefer `gh api repos/<owner>/<repo>/pulls/<number>/requested_reviewers` or an equivalent GraphQL review-request query when reviewer-request confirmation matters.
+Prefer the deterministic helper `scripts/github/request-copilot-review.mjs` when it exists. That helper verifies reviewer state through `gh api repos/<owner>/<repo>/pulls/<number>/requested_reviewers`, which is more reliable here than `gh pr view --json reviewRequests`.
 
 When a PR is moved from draft to ready, explicitly attempt to request Copilot review rather than assuming repository automation will do it.
+
+Do not web-search or rediscover this behavior during normal operation. Treat the deterministic helper and the repository docs as the source of truth unless you are explicitly debugging the tooling itself.
 
 If the explicit request fails because Copilot review is not enabled for the repository, the reviewer identity is not requestable, or GitHub rejects the request because the reviewer is not a collaborator/requestable actor, record that exact limitation and continue with the documented watch/follow-up path rather than silently assuming review was requested.
 
@@ -266,7 +268,7 @@ Practical rule for this repo:
   - waiting for unresolved thread state to change in a review-aware way
 
 Preferred approach for Copilot review follow-up:
-- after a PR leaves draft, explicitly try to request Copilot review first
+- after a PR leaves draft, explicitly request Copilot review first, preferably through `scripts/github/request-copilot-review.mjs`
 - baseline current Copilot review activity
 - poll for new Copilot-authored reviews/comments
 - keep the watcher in the current Pi/TelePi session

--- a/skills/copilot-dev-loop/SKILL.md
+++ b/skills/copilot-dev-loop/SKILL.md
@@ -268,16 +268,16 @@ Practical rule for this repo:
 - prefer ordinary `gh pr view`, `gh issue view`, `gh api`, and `gh pr checks` snapshots for one-time inspection
 - use deterministic custom watchers for conditions that `gh` does not natively watch well, such as:
   - waiting for a Copilot-authored PR to appear
-  - waiting for new Copilot review-thread comments after a baseline
+  - waiting for new Copilot review activity after a baseline, including review-thread comments, review summaries, or PR issue comments
   - waiting for unresolved thread state to change in a review-aware way
 
 Preferred approach for Copilot review follow-up:
 - after a PR leaves draft, explicitly request Copilot review first, preferably through `scripts/github/request-copilot-review.mjs`
 - after any follow-up fix commit is pushed and another Copilot pass is wanted, explicitly request Copilot review again for the updated head before waiting
 - baseline current Copilot review activity
-- poll for new Copilot-authored review-thread comments
+- poll for new Copilot-authored review activity across review-thread comments, review summaries, and PR issue comments
 - keep the watcher in the current Pi/TelePi session
-- after new review-thread activity appears, launch an async Pi fixer in-session
+- after new review activity appears, launch an async Pi fixer in-session
 - do not report the loop complete while fresh Copilot comments remain unresolved; a new Copilot pass must flow back into fixer/reply/resolve work before completion when authorization exists
 - use explicit long timeouts from the timeout policy above rather than short defaults
 

--- a/skills/copilot-dev-loop/SKILL.md
+++ b/skills/copilot-dev-loop/SKILL.md
@@ -268,16 +268,16 @@ Practical rule for this repo:
 - prefer ordinary `gh pr view`, `gh issue view`, `gh api`, and `gh pr checks` snapshots for one-time inspection
 - use deterministic custom watchers for conditions that `gh` does not natively watch well, such as:
   - waiting for a Copilot-authored PR to appear
-  - waiting for new Copilot review bodies/comments after a baseline
+  - waiting for new Copilot review-thread comments after a baseline
   - waiting for unresolved thread state to change in a review-aware way
 
 Preferred approach for Copilot review follow-up:
 - after a PR leaves draft, explicitly request Copilot review first, preferably through `scripts/github/request-copilot-review.mjs`
 - after any follow-up fix commit is pushed and another Copilot pass is wanted, explicitly request Copilot review again for the updated head before waiting
 - baseline current Copilot review activity
-- poll for new Copilot-authored reviews/comments
+- poll for new Copilot-authored review-thread comments
 - keep the watcher in the current Pi/TelePi session
-- after new review activity appears, launch an async Pi fixer in-session
+- after new review-thread activity appears, launch an async Pi fixer in-session
 - do not report the loop complete while fresh Copilot comments remain unresolved; a new Copilot pass must flow back into fixer/reply/resolve work before completion when authorization exists
 - use explicit long timeouts from the timeout policy above rather than short defaults
 

--- a/test/extension-command-contract.test.mjs
+++ b/test/extension-command-contract.test.mjs
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { access, mkdtemp } from "node:fs/promises";
+import { access, mkdtemp, writeFile } from "node:fs/promises";
 
 import registerExtension from "../extension/index.ts";
 
@@ -124,7 +124,7 @@ test("status keeps remote readiness blocked outside a git repo", async () => {
   assert(lines.some((line) => /Remote GitHub\/Copilot readiness: needs setup/i.test(line)));
 });
 
-test("doctor shows the full check report and install without a target shows usage", async () => {
+test("doctor shows the full check report and install/update without a target show action-specific usage", async () => {
   const pi = createPiDouble({
     commandResults: new Map([
       ["command -v gh >/dev/null 2>&1", 1],
@@ -148,10 +148,16 @@ test("doctor shows the full check report and install without a target shows usag
   const installLines = installContext.calls.widgets.at(-1).lines;
   assert(installLines.some((line) => /Usage:/i.test(line)));
   assert(installLines.some((line) => /\/dev-loops install repo/i.test(line)));
-  assert(installLines.some((line) => /\/dev-loops install system/i.test(line)));
+  assert(installLines.some((line) => /installs skills in the current git repository/i.test(line)));
+
+  const updateContext = createCommandContext();
+  await pi.registeredCommands.get("dev-loops").handler("update", updateContext.ctx);
+  const updateLines = updateContext.calls.widgets.at(-1).lines;
+  assert(updateLines.some((line) => /\/dev-loops update repo/i.test(line)));
+  assert(updateLines.some((line) => /updates skills in the current git repository/i.test(line)));
 });
 
-test("install repo copies packaged skills into the repository and hide still clears the widget", async () => {
+test("install repo copies packaged skills into the repository, repo errors stay action-specific, and hide still clears the widget", async () => {
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-repo-install-"));
   const pi = createPiDouble({
     commandResults: new Map([
@@ -168,6 +174,14 @@ test("install repo copies packaged skills into the repository and hide still cle
   await access(path.join(repoRoot, ".pi", "skills", "dev-loop", "SKILL.md"));
   await access(path.join(repoRoot, ".pi", "skills", "copilot-dev-loop", "SKILL.md"));
 
+  const repoErrorContext = createCommandContext();
+  const noRepoPi = createPiDouble({
+    commandResults: new Map([["git rev-parse --show-toplevel", { code: 1, stdout: "", stderr: "" }]]),
+  });
+  registerExtension(noRepoPi);
+  await noRepoPi.registeredCommands.get("dev-loops").handler("update repo", repoErrorContext.ctx);
+  assert(repoErrorContext.calls.widgets.at(-1).lines.some((line) => /\/dev-loops update system/i.test(line)));
+
   const hideContext = createCommandContext();
   await pi.registeredCommands.get("dev-loops").handler("hide", hideContext.ctx);
   assert.deepEqual(hideContext.calls.widgets.at(-1), {
@@ -180,4 +194,29 @@ test("install repo copies packaged skills into the repository and hide still cle
   const fallbackContext = createCommandContext();
   await pi.registeredCommands.get("dev-loops").handler("banana", fallbackContext.ctx);
   assert.match(fallbackContext.calls.widgets.at(-1).lines[0], /pi-dev-loops help/);
+});
+
+test("system install failures surface a user-facing error instead of throwing", async () => {
+  const previousHome = process.env.HOME;
+  const tempHome = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-home-"));
+  process.env.HOME = tempHome;
+
+  try {
+    await writeFile(path.join(tempHome, ".pi"), "not a directory\n");
+
+    const pi = readyPi();
+    registerExtension(pi);
+
+    const { ctx, calls } = createCommandContext();
+    await pi.registeredCommands.get("dev-loops").handler("install system", ctx);
+
+    assert.match(calls.widgets.at(-1).lines[0], /pi-dev-loops install system: failed/);
+    assert.equal(calls.notifications.at(-1).level, "error");
+  } finally {
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+  }
 });

--- a/test/extension-command-contract.test.mjs
+++ b/test/extension-command-contract.test.mjs
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { access, mkdtemp, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
 
 import registerExtension from "../extension/index.ts";
 
@@ -87,7 +87,7 @@ test("extension registers command and session_start wiring", async () => {
   assert.deepEqual(calls.statuses, [{ key: "pi-dev-loops", text: "pi-dev-loops" }]);
 });
 
-test("help is the default action and lists the command surface", async () => {
+test("help is the default action and malformed commands stay non-mutating", async () => {
   const pi = readyPi();
   registerExtension(pi);
   const { ctx, calls } = createCommandContext();
@@ -102,6 +102,11 @@ test("help is the default action and lists the command surface", async () => {
   assert(widget.lines.some((line) => /prompts for `repo` or `system`/i.test(line)));
   assert(widget.lines.some((line) => /skills are installed explicitly/i.test(line)));
   assert.equal(calls.notifications.at(-1).message, "pi-dev-loops help");
+
+  const invalidArgsContext = createCommandContext();
+  await pi.registeredCommands.get("dev-loops").handler("install moon", invalidArgsContext.ctx);
+  assert.match(invalidArgsContext.calls.widgets.at(-1).lines[0], /pi-dev-loops install: choose a target/);
+  assert.equal(invalidArgsContext.calls.notifications.at(-1).level, "error");
 });
 
 test("status keeps remote readiness blocked outside a git repo", async () => {
@@ -194,6 +199,26 @@ test("install repo copies packaged skills into the repository, repo errors stay 
   const fallbackContext = createCommandContext();
   await pi.registeredCommands.get("dev-loops").handler("banana", fallbackContext.ctx);
   assert.match(fallbackContext.calls.widgets.at(-1).lines[0], /pi-dev-loops help/);
+});
+
+test("repo install refuses symlinked skill roots with a user-facing error", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-repo-symlink-"));
+  const realSkillsRoot = path.join(repoRoot, "real-skills-root");
+  await mkdir(path.join(repoRoot, ".pi"), { recursive: true });
+  await mkdir(realSkillsRoot, { recursive: true });
+  await symlink(realSkillsRoot, path.join(repoRoot, ".pi", "skills"));
+
+  const pi = createPiDouble({
+    commandResults: new Map([["git rev-parse --show-toplevel", { code: 0, stdout: `${repoRoot}\n`, stderr: "" }]]),
+  });
+  registerExtension(pi);
+
+  const { ctx, calls } = createCommandContext();
+  await pi.registeredCommands.get("dev-loops").handler("install repo", ctx);
+
+  assert.match(calls.widgets.at(-1).lines[0], /pi-dev-loops install repo: failed/);
+  assert(calls.widgets.at(-1).lines.some((line) => /symlinked skill root/i.test(line)));
+  assert.equal(calls.notifications.at(-1).level, "error");
 });
 
 test("system install failures surface a user-facing error instead of throwing", async () => {

--- a/test/extension-command-contract.test.mjs
+++ b/test/extension-command-contract.test.mjs
@@ -1,5 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { access, mkdtemp } from "node:fs/promises";
 
 import registerExtension from "../extension/index.ts";
 
@@ -10,7 +13,13 @@ function createPiDouble({ commandResults = new Map(), tools = [], commands = [] 
   return {
     async exec(_tool, args) {
       const command = args[1];
-      return { code: commandResults.get(command) ?? 1 };
+      const result = commandResults.get(command);
+
+      if (typeof result === "number") {
+        return { code: result, stdout: "", stderr: "" };
+      }
+
+      return result ?? { code: 1, stdout: "", stderr: "" };
     },
     getAllTools() {
       return tools;
@@ -78,7 +87,7 @@ test("extension registers command and session_start wiring", async () => {
   assert.deepEqual(calls.statuses, [{ key: "pi-dev-loops", text: "pi-dev-loops" }]);
 });
 
-test("status is the default action and stays concise", async () => {
+test("help is the default action and lists the command surface", async () => {
   const pi = readyPi();
   registerExtension(pi);
   const { ctx, calls } = createCommandContext();
@@ -87,12 +96,12 @@ test("status is the default action and stays concise", async () => {
 
   const widget = calls.widgets.at(-1);
   assert.equal(widget.key, "pi-dev-loops.setup");
-  assert.match(widget.lines[0], /pi-dev-loops status: 6\/6 checks passed/);
-  assert(widget.lines.some((line) => /Local loop readiness: ready/i.test(line)));
-  assert(widget.lines.some((line) => /Remote GitHub\/Copilot readiness: ready/i.test(line)));
-  assert(widget.lines.some((line) => /Suggested next steps:/i.test(line)));
-  assert.equal(widget.lines.some((line) => /^✅ /.test(line)), false);
-  assert.equal(calls.notifications.at(-1).message, "pi-dev-loops status: 6/6 checks passed");
+  assert.match(widget.lines[0], /pi-dev-loops help/);
+  assert(widget.lines.some((line) => /\/dev-loops status/i.test(line)));
+  assert(widget.lines.some((line) => /^- \/dev-loops install$/i.test(line)));
+  assert(widget.lines.some((line) => /prompts for `repo` or `system`/i.test(line)));
+  assert(widget.lines.some((line) => /skills are installed explicitly/i.test(line)));
+  assert.equal(calls.notifications.at(-1).message, "pi-dev-loops help");
 });
 
 test("status keeps remote readiness blocked outside a git repo", async () => {
@@ -115,7 +124,7 @@ test("status keeps remote readiness blocked outside a git repo", async () => {
   assert(lines.some((line) => /Remote GitHub\/Copilot readiness: needs setup/i.test(line)));
 });
 
-test("doctor shows the full check report and setup adds ordered guidance", async () => {
+test("doctor shows the full check report and install without a target shows usage", async () => {
   const pi = createPiDouble({
     commandResults: new Map([
       ["command -v gh >/dev/null 2>&1", 1],
@@ -134,17 +143,30 @@ test("doctor shows the full check report and setup adds ordered guidance", async
   assert(doctorLines.some((line) => /^⚠️ GitHub CLI authenticated/.test(line)));
   assert.equal(doctorLines.some((line) => /Ordered setup steps:/i.test(line)), false);
 
-  const setupContext = createCommandContext();
-  await pi.registeredCommands.get("dev-loops").handler("setup", setupContext.ctx);
-  const setupLines = setupContext.calls.widgets.at(-1).lines;
-  assert(setupLines.some((line) => /Ordered setup steps:/i.test(line)));
-  assert(setupLines.some((line) => /Install GitHub CLI/i.test(line)));
-  assert(setupLines.some((line) => /Run `gh auth login`/i.test(line)));
+  const installContext = createCommandContext();
+  await pi.registeredCommands.get("dev-loops").handler("install", installContext.ctx);
+  const installLines = installContext.calls.widgets.at(-1).lines;
+  assert(installLines.some((line) => /Usage:/i.test(line)));
+  assert(installLines.some((line) => /\/dev-loops install repo/i.test(line)));
+  assert(installLines.some((line) => /\/dev-loops install system/i.test(line)));
 });
 
-test("hide clears the widget and invalid subcommands fall back to status", async () => {
-  const pi = readyPi();
+test("install repo copies packaged skills into the repository and hide still clears the widget", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-repo-install-"));
+  const pi = createPiDouble({
+    commandResults: new Map([
+      ["git rev-parse --show-toplevel", { code: 0, stdout: `${repoRoot}\n`, stderr: "" }],
+    ]),
+  });
   registerExtension(pi);
+
+  const installContext = createCommandContext();
+  await pi.registeredCommands.get("dev-loops").handler("install repo", installContext.ctx);
+  const installLines = installContext.calls.widgets.at(-1).lines;
+  assert(installLines.some((line) => /skill directories changed/i.test(line)));
+  assert(installLines.some((line) => /Restart Pi or refresh skill discovery/i.test(line)));
+  await access(path.join(repoRoot, ".pi", "skills", "dev-loop", "SKILL.md"));
+  await access(path.join(repoRoot, ".pi", "skills", "copilot-dev-loop", "SKILL.md"));
 
   const hideContext = createCommandContext();
   await pi.registeredCommands.get("dev-loops").handler("hide", hideContext.ctx);
@@ -157,5 +179,5 @@ test("hide clears the widget and invalid subcommands fall back to status", async
 
   const fallbackContext = createCommandContext();
   await pi.registeredCommands.get("dev-loops").handler("banana", fallbackContext.ctx);
-  assert.match(fallbackContext.calls.widgets.at(-1).lines[0], /pi-dev-loops status:/);
+  assert.match(fallbackContext.calls.widgets.at(-1).lines[0], /pi-dev-loops help/);
 });

--- a/test/extension-command-contract.test.mjs
+++ b/test/extension-command-contract.test.mjs
@@ -247,6 +247,30 @@ test("system install failures surface a user-facing error instead of throwing", 
   }
 });
 
+test("buildInstallResultLines reports missing update targets as not installed and guides first-time setup", () => {
+  const lines = buildInstallResultLines({
+    mode: "update",
+    scope: "repo",
+    targetRoot: "/tmp/repo/.pi/skills",
+    results: [
+      {
+        skillName: "dev-loop",
+        status: "updated",
+        targetPath: "/tmp/repo/.pi/skills/dev-loop",
+      },
+      {
+        skillName: "copilot-dev-loop",
+        status: "missing",
+        targetPath: "/tmp/repo/.pi/skills/copilot-dev-loop",
+      },
+    ],
+  });
+
+  assert.equal(lines[0], "pi-dev-loops update repo: 1/2 skill directories changed");
+  assert(lines.some((line) => /copilot-dev-loop: not installed/i.test(line)));
+  assert(lines.some((line) => /first-time setup/i.test(line)));
+});
+
 test("buildInstallResultLines throws for unknown install statuses instead of rendering undefined", () => {
   assert.throws(
     () => buildInstallResultLines({

--- a/test/extension-command-contract.test.mjs
+++ b/test/extension-command-contract.test.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { access, mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
 
 import registerExtension from "../extension/index.ts";
+import { buildInstallResultLines } from "../extension/presentation.ts";
 
 function createPiDouble({ commandResults = new Map(), tools = [], commands = [] } = {}) {
   const events = new Map();
@@ -244,4 +245,20 @@ test("system install failures surface a user-facing error instead of throwing", 
       process.env.HOME = previousHome;
     }
   }
+});
+
+test("buildInstallResultLines throws for unknown install statuses instead of rendering undefined", () => {
+  assert.throws(
+    () => buildInstallResultLines({
+      mode: "install",
+      scope: "repo",
+      targetRoot: "/tmp/repo/.pi/skills",
+      results: [{
+        skillName: "dev-loop",
+        status: "mystery-status",
+        targetPath: "/tmp/repo/.pi/skills/dev-loop",
+      }],
+    }),
+    /Unknown install status: mystery-status/,
+  );
 });

--- a/test/extension-installer.test.mjs
+++ b/test/extension-installer.test.mjs
@@ -1,0 +1,87 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+
+import { resolveSystemSkillsRoot, syncPackagedSkills } from "../extension/installer.ts";
+
+test("resolveSystemSkillsRoot targets ~/.pi/agent/skills", () => {
+  assert.equal(resolveSystemSkillsRoot("/tmp/home"), path.join("/tmp/home", ".pi", "agent", "skills"));
+});
+
+test("install copies packaged skills without overwriting existing targets", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-extension-install-"));
+  const sourceRoot = path.join(tempDir, "source");
+  const targetRoot = path.join(tempDir, "target");
+
+  await mkdir(path.join(sourceRoot, "dev-loop"), { recursive: true });
+  await mkdir(path.join(sourceRoot, "copilot-dev-loop"), { recursive: true });
+  await writeFile(path.join(sourceRoot, "dev-loop", "SKILL.md"), "dev-loop v1\n");
+  await writeFile(path.join(sourceRoot, "copilot-dev-loop", "SKILL.md"), "copilot v1\n");
+
+  const first = await syncPackagedSkills({
+    mode: "install",
+    scope: "repo",
+    sourceRoot,
+    targetRoot,
+  });
+
+  assert.deepEqual(
+    first.results.map((entry) => [entry.skillName, entry.status]),
+    [
+      ["dev-loop", "installed"],
+      ["copilot-dev-loop", "installed"],
+    ],
+  );
+
+  await writeFile(path.join(targetRoot, "dev-loop", "SKILL.md"), "repo override\n");
+
+  const second = await syncPackagedSkills({
+    mode: "install",
+    scope: "repo",
+    sourceRoot,
+    targetRoot,
+  });
+
+  assert.deepEqual(
+    second.results.map((entry) => [entry.skillName, entry.status]),
+    [
+      ["dev-loop", "already-installed"],
+      ["copilot-dev-loop", "already-installed"],
+    ],
+  );
+  assert.equal(await readFile(path.join(targetRoot, "dev-loop", "SKILL.md"), "utf8"), "repo override\n");
+});
+
+test("update refreshes existing target directories from the packaged source", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-extension-update-"));
+  const sourceRoot = path.join(tempDir, "source");
+  const targetRoot = path.join(tempDir, "target");
+
+  await mkdir(path.join(sourceRoot, "dev-loop"), { recursive: true });
+  await mkdir(path.join(sourceRoot, "copilot-dev-loop"), { recursive: true });
+  await mkdir(path.join(targetRoot, "dev-loop"), { recursive: true });
+  await mkdir(path.join(targetRoot, "copilot-dev-loop"), { recursive: true });
+  await writeFile(path.join(sourceRoot, "dev-loop", "SKILL.md"), "dev-loop v2\n");
+  await writeFile(path.join(sourceRoot, "copilot-dev-loop", "SKILL.md"), "copilot v2\n");
+  await writeFile(path.join(targetRoot, "dev-loop", "SKILL.md"), "stale local copy\n");
+  await writeFile(path.join(targetRoot, "copilot-dev-loop", "SKILL.md"), "stale local copy\n");
+
+  const result = await syncPackagedSkills({
+    mode: "update",
+    scope: "system",
+    sourceRoot,
+    targetRoot,
+  });
+
+  assert.deepEqual(
+    result.results.map((entry) => [entry.skillName, entry.status]),
+    [
+      ["dev-loop", "updated"],
+      ["copilot-dev-loop", "updated"],
+    ],
+  );
+  assert.equal(await readFile(path.join(targetRoot, "dev-loop", "SKILL.md"), "utf8"), "dev-loop v2\n");
+  assert.equal(await readFile(path.join(targetRoot, "copilot-dev-loop", "SKILL.md"), "utf8"), "copilot v2\n");
+});

--- a/test/extension-installer.test.mjs
+++ b/test/extension-installer.test.mjs
@@ -124,6 +124,18 @@ test("install refuses symlinked roots, symlinked ancestors, and skill targets to
     /Ancestor path is a symlink/i,
   );
 
+  await mkdir(path.join(realPiRoot, "skills"), { recursive: true });
+
+  await assert.rejects(
+    syncPackagedSkills({
+      mode: "update",
+      scope: "repo",
+      sourceRoot,
+      targetRoot: path.join(symlinkedAncestorRoot, ".pi", "skills"),
+    }),
+    /Ancestor path is a symlink/i,
+  );
+
   const realRepoRoot = path.join(tempDir, "real-repo-root");
   const linkedRepoRoot = path.join(tempDir, "linked-repo-root");
   await mkdir(path.join(realRepoRoot, ".pi"), { recursive: true });

--- a/test/extension-installer.test.mjs
+++ b/test/extension-installer.test.mjs
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
 
 import { resolveSystemSkillsRoot, syncPackagedSkills } from "../extension/installer.ts";
 
@@ -84,4 +84,43 @@ test("update refreshes existing target directories from the packaged source", as
   );
   assert.equal(await readFile(path.join(targetRoot, "dev-loop", "SKILL.md"), "utf8"), "dev-loop v2\n");
   assert.equal(await readFile(path.join(targetRoot, "copilot-dev-loop", "SKILL.md"), "utf8"), "copilot v2\n");
+});
+
+test("install refuses symlinked roots and skill targets to avoid mutating the symlink source unexpectedly", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-extension-symlink-"));
+  const sourceRoot = path.join(tempDir, "source");
+  const realRoot = path.join(tempDir, "real-root");
+  const linkedRoot = path.join(tempDir, "linked-root");
+
+  await mkdir(path.join(sourceRoot, "dev-loop"), { recursive: true });
+  await mkdir(path.join(sourceRoot, "copilot-dev-loop"), { recursive: true });
+  await writeFile(path.join(sourceRoot, "dev-loop", "SKILL.md"), "dev-loop v1\n");
+  await writeFile(path.join(sourceRoot, "copilot-dev-loop", "SKILL.md"), "copilot v1\n");
+
+  await mkdir(realRoot, { recursive: true });
+  await symlink(realRoot, linkedRoot);
+
+  await assert.rejects(
+    syncPackagedSkills({
+      mode: "install",
+      scope: "repo",
+      sourceRoot,
+      targetRoot: linkedRoot,
+    }),
+    /symlinked skill root/i,
+  );
+
+  const targetRoot = path.join(tempDir, "target");
+  await mkdir(path.join(targetRoot, "copilot-dev-loop"), { recursive: true });
+  await symlink(path.join(targetRoot, "copilot-dev-loop"), path.join(targetRoot, "dev-loop"));
+
+  await assert.rejects(
+    syncPackagedSkills({
+      mode: "update",
+      scope: "repo",
+      sourceRoot,
+      targetRoot,
+    }),
+    /symlinked skill target/i,
+  );
 });

--- a/test/extension-installer.test.mjs
+++ b/test/extension-installer.test.mjs
@@ -86,7 +86,7 @@ test("update refreshes existing target directories from the packaged source", as
   assert.equal(await readFile(path.join(targetRoot, "copilot-dev-loop", "SKILL.md"), "utf8"), "copilot v2\n");
 });
 
-test("install refuses symlinked roots and skill targets to avoid mutating the symlink source unexpectedly", async () => {
+test("install refuses symlinked roots, symlinked ancestors, and skill targets to avoid mutating the symlink source unexpectedly", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-extension-symlink-"));
   const sourceRoot = path.join(tempDir, "source");
   const realRoot = path.join(tempDir, "real-root");
@@ -108,6 +108,22 @@ test("install refuses symlinked roots and skill targets to avoid mutating the sy
       targetRoot: linkedRoot,
     }),
     /symlinked skill root/i,
+  );
+
+  const symlinkedAncestorRoot = path.join(tempDir, "repo-root");
+  const realPiRoot = path.join(tempDir, "real-pi-root");
+  await mkdir(symlinkedAncestorRoot, { recursive: true });
+  await mkdir(realPiRoot, { recursive: true });
+  await symlink(realPiRoot, path.join(symlinkedAncestorRoot, ".pi"));
+
+  await assert.rejects(
+    syncPackagedSkills({
+      mode: "install",
+      scope: "repo",
+      sourceRoot,
+      targetRoot: path.join(symlinkedAncestorRoot, ".pi", "skills"),
+    }),
+    /Ancestor path is a symlink/i,
   );
 
   const targetRoot = path.join(tempDir, "target");

--- a/test/extension-installer.test.mjs
+++ b/test/extension-installer.test.mjs
@@ -126,6 +126,21 @@ test("install refuses symlinked roots, symlinked ancestors, and skill targets to
     /Ancestor path is a symlink/i,
   );
 
+  const realRepoRoot = path.join(tempDir, "real-repo-root");
+  const linkedRepoRoot = path.join(tempDir, "linked-repo-root");
+  await mkdir(path.join(realRepoRoot, ".pi"), { recursive: true });
+  await symlink(realRepoRoot, linkedRepoRoot);
+
+  await assert.rejects(
+    syncPackagedSkills({
+      mode: "install",
+      scope: "repo",
+      sourceRoot,
+      targetRoot: path.join(linkedRepoRoot, ".pi", "skills"),
+    }),
+    /Ancestor path is a symlink/i,
+  );
+
   const targetRoot = path.join(tempDir, "target");
   await mkdir(path.join(targetRoot, "copilot-dev-loop"), { recursive: true });
   await symlink(path.join(targetRoot, "copilot-dev-loop"), path.join(targetRoot, "dev-loop"));

--- a/test/extension-installer.test.mjs
+++ b/test/extension-installer.test.mjs
@@ -54,7 +54,7 @@ test("install copies packaged skills without overwriting existing targets", asyn
   assert.equal(await readFile(path.join(targetRoot, "dev-loop", "SKILL.md"), "utf8"), "repo override\n");
 });
 
-test("update refreshes existing target directories from the packaged source", async () => {
+test("update refreshes existing target directories from the packaged source and skips missing targets", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-extension-update-"));
   const sourceRoot = path.join(tempDir, "source");
   const targetRoot = path.join(tempDir, "target");
@@ -62,11 +62,9 @@ test("update refreshes existing target directories from the packaged source", as
   await mkdir(path.join(sourceRoot, "dev-loop"), { recursive: true });
   await mkdir(path.join(sourceRoot, "copilot-dev-loop"), { recursive: true });
   await mkdir(path.join(targetRoot, "dev-loop"), { recursive: true });
-  await mkdir(path.join(targetRoot, "copilot-dev-loop"), { recursive: true });
   await writeFile(path.join(sourceRoot, "dev-loop", "SKILL.md"), "dev-loop v2\n");
   await writeFile(path.join(sourceRoot, "copilot-dev-loop", "SKILL.md"), "copilot v2\n");
   await writeFile(path.join(targetRoot, "dev-loop", "SKILL.md"), "stale local copy\n");
-  await writeFile(path.join(targetRoot, "copilot-dev-loop", "SKILL.md"), "stale local copy\n");
 
   const result = await syncPackagedSkills({
     mode: "update",
@@ -79,11 +77,11 @@ test("update refreshes existing target directories from the packaged source", as
     result.results.map((entry) => [entry.skillName, entry.status]),
     [
       ["dev-loop", "updated"],
-      ["copilot-dev-loop", "updated"],
+      ["copilot-dev-loop", "missing"],
     ],
   );
   assert.equal(await readFile(path.join(targetRoot, "dev-loop", "SKILL.md"), "utf8"), "dev-loop v2\n");
-  assert.equal(await readFile(path.join(targetRoot, "copilot-dev-loop", "SKILL.md"), "utf8"), "copilot v2\n");
+  await assert.rejects(readFile(path.join(targetRoot, "copilot-dev-loop", "SKILL.md"), "utf8"));
 });
 
 test("install refuses symlinked roots, symlinked ancestors, and skill targets to avoid mutating the symlink source unexpectedly", async () => {

--- a/test/extension-package-contract.test.mjs
+++ b/test/extension-package-contract.test.mjs
@@ -14,21 +14,27 @@ test("package metadata exposes the extension entrypoint and root extension test 
   assert.equal(typeof packageJson.peerDependencies["@mariozechner/pi-tui"], "string");
   assert.equal(typeof packageJson.scripts["test:extension"], "string");
   assert.match(packageJson.scripts["test:extension"], /extension-checks/);
+  assert.match(packageJson.scripts["test:extension"], /extension-installer/);
   assert.match(packageJson.scripts["test:extension"], /extension-command-contract/);
   assert.match(packageJson.scripts["test:extension"], /extension-package-contract/);
+  assert.equal(packageJson.pi.skills, undefined);
 });
 
 test("extension README documents the command surface and runtime/build/test contract", async () => {
   const readme = await readRepo("extension/README.md");
 
+  assert.match(readme, /defaults to help output/i);
   assert.match(readme, /\/dev-loops status/i);
   assert.match(readme, /concise readiness summary/i);
   assert.match(readme, /\/dev-loops doctor/i);
   assert.match(readme, /full diagnostic report/i);
-  assert.match(readme, /\/dev-loops setup/i);
-  assert.match(readme, /ordered first-time setup guidance/i);
+  assert.match(readme, /\/dev-loops install repo/i);
+  assert.match(readme, /\/dev-loops install system/i);
+  assert.match(readme, /\/dev-loops update repo/i);
+  assert.match(readme, /refresh installed skills/i);
   assert.match(readme, /Node[^\n]*>=20/i);
   assert.match(readme, /source-loaded/i);
+  assert.match(readme, /does not automatically install skills/i);
   assert.match(readme, /does not yet claim a specific supported `gh` version/i);
   assert.match(readme, /npm run test:extension/i);
   assert.match(readme, /npm run test:dev-loop/i);

--- a/test/github/capture-review-threads.test.mjs
+++ b/test/github/capture-review-threads.test.mjs
@@ -112,7 +112,7 @@ test("capture-review-threads emits deterministic JSON for --input", async () => 
     totalThreads: 3,
     unresolvedThreads: 2,
     actionableThreads: 1,
-    actionableComments: 2,
+    actionableComments: 1,
   });
   assert.equal(output.threads[0].id, "t-1");
   assert.equal(output.comments[3].id, "c-4");

--- a/test/github/reply-resolve-review-thread.test.mjs
+++ b/test/github/reply-resolve-review-thread.test.mjs
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import test from "node:test";
+
+const scriptPath = path.resolve("scripts/github/reply-resolve-review-thread.mjs");
+
+function runNode(args = [], options = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [scriptPath, ...args], {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    child.on("close", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+async function writeGhStub(tempDir, entries) {
+  const sequencePath = path.join(tempDir, "gh-sequence.json");
+  const counterPath = path.join(tempDir, "gh-counter.txt");
+  const ghPath = path.join(tempDir, "gh");
+  const ghLogPath = path.join(tempDir, "gh-log.jsonl");
+
+  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
+  await writeFile(counterPath, "0\n", "utf8");
+  await writeFile(ghLogPath, "", "utf8");
+  await writeFile(
+    ghPath,
+    [
+      "#!/usr/bin/env node",
+      'import { appendFileSync, readFileSync, writeFileSync } from "node:fs";',
+      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
+      "const counterPath = process.env.GH_COUNTER_PATH;",
+      "const ghLogPath = process.env.GH_LOG_PATH;",
+      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
+      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
+      'const entry = entries[Math.min(current, entries.length - 1)] ?? { stdout: "{}\\n" };',
+      'writeFileSync(counterPath, String(current + 1));',
+      'appendFileSync(ghLogPath, `${JSON.stringify(process.argv.slice(2))}\\n`);',
+      'const actual = process.argv.slice(2);',
+      'if (entry.assertArgs) {',
+      '  for (const expected of entry.assertArgs) {',
+      '    if (!actual.includes(expected)) {',
+      '      process.stderr.write(`missing expected gh arg: ${expected}\\n`);',
+      '      process.exit(98);',
+      '    }',
+      '  }',
+      '}',
+      'if (entry.stderr) {',
+      '  process.stderr.write(entry.stderr);',
+      '}',
+      'if (entry.stdout) {',
+      '  process.stdout.write(entry.stdout);',
+      '}',
+      'process.exit(entry.exitCode ?? 0);',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await chmod(ghPath, 0o755);
+
+  return {
+    env: {
+      ...process.env,
+      PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
+      GH_SEQUENCE_PATH: sequencePath,
+      GH_COUNTER_PATH: counterPath,
+      GH_LOG_PATH: ghLogPath,
+    },
+    ghLogPath,
+  };
+}
+
+test("reply-resolve-review-thread posts a reply then resolves the thread", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-thread-"));
+  const bodyFile = path.join(tempDir, "reply.md");
+  await writeFile(bodyFile, "Fixed in 93cd7f8. Added the missing symlinked-ancestor guard and coverage.\n", "utf8");
+
+  try {
+    const gh = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "-X", "POST", "repos/owner/repo/pulls/17/comments/123/replies"],
+        stdout: '{"id":456,"html_url":"https://github.com/owner/repo/pull/17#discussion_r456"}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "--field", "threadId=THREAD_123"],
+        stdout: '{"data":{"resolveReviewThread":{"thread":{"id":"THREAD_123","isResolved":true}}}}\n',
+      },
+    ]);
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--comment-id", "123", "--thread-id", "THREAD_123", "--body-file", bodyFile],
+      { env: gh.env },
+    );
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      repo: "owner/repo",
+      pr: 17,
+      commentId: 123,
+      threadId: "THREAD_123",
+      replyId: 456,
+      replyUrl: "https://github.com/owner/repo/pull/17#discussion_r456",
+      resolved: true,
+    });
+
+    const ghLog = (await readFile(gh.ghLogPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(ghLog.length, 2);
+    assert(ghLog[0].includes("body=Fixed in 93cd7f8. Added the missing symlinked-ancestor guard and coverage."));
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("reply-resolve-review-thread rejects malformed arguments and empty body files deterministically", async () => {
+  const missing = await runNode(["--repo", "owner/repo"]);
+  assert.equal(missing.code, 1);
+  assert.equal(missing.stdout, "");
+  assert.deepEqual(JSON.parse(missing.stderr), {
+    ok: false,
+    error: "Replying and resolving a review thread requires --repo <owner/name>, --pr <number>, --comment-id <number>, --thread-id <node-id>, and --body-file <path>",
+  });
+
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-empty-"));
+  const emptyBody = path.join(tempDir, "empty.md");
+  await writeFile(emptyBody, "   \n", "utf8");
+
+  try {
+    const empty = await runNode([
+      "--repo",
+      "owner/repo",
+      "--pr",
+      "17",
+      "--comment-id",
+      "123",
+      "--thread-id",
+      "THREAD_123",
+      "--body-file",
+      emptyBody,
+    ]);
+    assert.equal(empty.code, 1);
+    assert.equal(empty.stdout, "");
+    assert.deepEqual(JSON.parse(empty.stderr), {
+      ok: false,
+      error: "--body-file must contain non-empty text",
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("reply-resolve-review-thread reports reply and resolve failures deterministically", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-failure-"));
+  const bodyFile = path.join(tempDir, "reply.md");
+  await writeFile(bodyFile, "Resolved in 93cd7f8.\n", "utf8");
+
+  try {
+    const gh = await writeGhStub(tempDir, [
+      {
+        stderr: "gh: forbidden\n",
+        exitCode: 1,
+      },
+    ]);
+
+    const replyFailure = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--comment-id", "123", "--thread-id", "THREAD_123", "--body-file", bodyFile],
+      { env: gh.env },
+    );
+    assert.equal(replyFailure.code, 1);
+    assert.equal(replyFailure.stdout, "");
+    assert.deepEqual(JSON.parse(replyFailure.stderr), {
+      ok: false,
+      error: "gh command failed: gh: forbidden",
+    });
+
+    const ghResolve = await writeGhStub(tempDir, [
+      {
+        stdout: '{"id":456,"html_url":"https://github.com/owner/repo/pull/17#discussion_r456"}\n',
+      },
+      {
+        stdout: '{"data":{"resolveReviewThread":{"thread":{"id":"THREAD_123","isResolved":false}}}}\n',
+      },
+    ]);
+
+    const resolveFailure = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--comment-id", "123", "--thread-id", "THREAD_123", "--body-file", bodyFile],
+      { env: ghResolve.env },
+    );
+    assert.equal(resolveFailure.code, 1);
+    assert.equal(resolveFailure.stdout, "");
+    assert.deepEqual(JSON.parse(resolveFailure.stderr), {
+      ok: false,
+      error: "Review thread did not resolve successfully: THREAD_123",
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/github/reply-resolve-review-thread.test.mjs
+++ b/test/github/reply-resolve-review-thread.test.mjs
@@ -55,11 +55,23 @@ async function writeGhStub(tempDir, entries) {
       'writeFileSync(counterPath, String(current + 1));',
       'appendFileSync(ghLogPath, `${JSON.stringify(process.argv.slice(2))}\\n`);',
       'const actual = process.argv.slice(2);',
+      'let stdin = "";',
+      'process.stdin.setEncoding("utf8");',
+      'process.stdin.on("data", (chunk) => { stdin += chunk; });',
       'if (entry.assertArgs) {',
       '  for (const expected of entry.assertArgs) {',
       '    if (!actual.includes(expected)) {',
       '      process.stderr.write(`missing expected gh arg: ${expected}\\n`);',
       '      process.exit(98);',
+      '    }',
+      '  }',
+      '}',
+      'process.stdin.on("end", () => {',
+      'if (entry.assertStdinIncludes) {',
+      '  for (const expected of entry.assertStdinIncludes) {',
+      '    if (!stdin.includes(expected)) {',
+      '      process.stderr.write(`missing expected stdin text: ${expected}\\n`);',
+      '      process.exit(97);',
       '    }',
       '  }',
       '}',
@@ -70,6 +82,7 @@ async function writeGhStub(tempDir, entries) {
       '  process.stdout.write(entry.stdout);',
       '}',
       'process.exit(entry.exitCode ?? 0);',
+      '});',
       "",
     ].join("\n"),
     "utf8",
@@ -96,7 +109,8 @@ test("reply-resolve-review-thread posts a reply then resolves the thread", async
   try {
     const gh = await writeGhStub(tempDir, [
       {
-        assertArgs: ["api", "-X", "POST", "repos/owner/repo/pulls/17/comments/123/replies"],
+        assertArgs: ["api", "-X", "POST", "repos/owner/repo/pulls/17/comments/123/replies", "--input", "-"],
+        assertStdinIncludes: ['"body":"Fixed in 93cd7f8. Added the missing symlinked-ancestor guard and coverage."'],
         stdout: '{"id":456,"html_url":"https://github.com/owner/repo/pull/17#discussion_r456"}\n',
       },
       {
@@ -125,7 +139,8 @@ test("reply-resolve-review-thread posts a reply then resolves the thread", async
 
     const ghLog = (await readFile(gh.ghLogPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
     assert.equal(ghLog.length, 2);
-    assert(ghLog[0].includes("body=Fixed in 93cd7f8. Added the missing symlinked-ancestor guard and coverage."));
+    assert(ghLog[0].includes("--input"));
+    assert.equal(ghLog[0].some((entry) => entry.startsWith("body=")), false);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/github/reply-resolve-review-thread.test.mjs
+++ b/test/github/reply-resolve-review-thread.test.mjs
@@ -207,6 +207,23 @@ test("reply-resolve-review-thread reports reply and resolve failures determinist
       error: "gh command failed: gh: forbidden",
     });
 
+    const ghMissingReplyFields = await writeGhStub(tempDir, [
+      {
+        stdout: '{"id":456}\n',
+      },
+    ]);
+
+    const missingReplyFields = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--comment-id", "123", "--thread-id", "THREAD_123", "--body-file", bodyFile],
+      { env: ghMissingReplyFields.env },
+    );
+    assert.equal(missingReplyFields.code, 1);
+    assert.equal(missingReplyFields.stdout, "");
+    assert.deepEqual(JSON.parse(missingReplyFields.stderr), {
+      ok: false,
+      error: "Reply payload from gh did not include both id and html_url",
+    });
+
     const ghResolve = await writeGhStub(tempDir, [
       {
         stdout: '{"id":456,"html_url":"https://github.com/owner/repo/pull/17#discussion_r456"}\n',

--- a/test/github/reply-resolve-review-thread.test.mjs
+++ b/test/github/reply-resolve-review-thread.test.mjs
@@ -110,7 +110,7 @@ test("reply-resolve-review-thread posts a reply then resolves the thread", async
     const gh = await writeGhStub(tempDir, [
       {
         assertArgs: ["api", "-X", "POST", "repos/owner/repo/pulls/17/comments/123/replies", "--input", "-"],
-        assertStdinIncludes: ['"body":"Fixed in 93cd7f8. Added the missing symlinked-ancestor guard and coverage."'],
+        assertStdinIncludes: ['"body":"Fixed in 93cd7f8. Added the missing symlinked-ancestor guard and coverage.\\n"'],
         stdout: '{"id":456,"html_url":"https://github.com/owner/repo/pull/17#discussion_r456"}\n',
       },
       {
@@ -155,6 +155,14 @@ test("reply-resolve-review-thread rejects malformed arguments and empty body fil
     error: "Replying and resolving a review thread requires --repo <owner/name>, --pr <number>, --comment-id <number>, --thread-id <node-id>, and --body-file <path>",
   });
 
+  const badRepo = await runNode(["--repo", " owner / repo ", "--pr", "17", "--comment-id", "123", "--thread-id", "THREAD_123", "--body-file", "x.md"]);
+  assert.equal(badRepo.code, 1);
+  assert.equal(badRepo.stdout, "");
+  assert.deepEqual(JSON.parse(badRepo.stderr), {
+    ok: false,
+    error: "--repo must match <owner/name>",
+  });
+
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-empty-"));
   const emptyBody = path.join(tempDir, "empty.md");
   await writeFile(emptyBody, "   \n", "utf8");
@@ -178,6 +186,36 @@ test("reply-resolve-review-thread rejects malformed arguments and empty body fil
       ok: false,
       error: "--body-file must contain non-empty text",
     });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("reply-resolve-review-thread preserves leading whitespace in the reply body payload", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-whitespace-"));
+  const bodyFile = path.join(tempDir, "reply.md");
+  await writeFile(bodyFile, "  indented line\n", "utf8");
+
+  try {
+    const gh = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "-X", "POST", "repos/owner/repo/pulls/17/comments/123/replies", "--input", "-"],
+        assertStdinIncludes: ['"body":"  indented line\\n"'],
+        stdout: '{"id":456,"html_url":"https://github.com/owner/repo/pull/17#discussion_r456"}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "--field", "threadId=THREAD_123"],
+        stdout: '{"data":{"resolveReviewThread":{"thread":{"id":"THREAD_123","isResolved":true}}}}\n',
+      },
+    ]);
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--comment-id", "123", "--thread-id", "THREAD_123", "--body-file", bodyFile],
+      { env: gh.env },
+    );
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/github/request-copilot-review.test.mjs
+++ b/test/github/request-copilot-review.test.mjs
@@ -310,6 +310,14 @@ test("request-copilot-review rejects malformed arguments deterministically", asy
     error: "--pr must be a positive integer",
   });
 
+  const badRepo = await runNode(["--repo", " owner / repo ", "--pr", "17"]);
+  assert.equal(badRepo.code, 1);
+  assert.equal(badRepo.stdout, "");
+  assert.deepEqual(JSON.parse(badRepo.stderr), {
+    ok: false,
+    error: "--repo must match <owner/name>",
+  });
+
   const unknown = await runNode(["--repo", "owner/repo", "--pr", "17", "--wat"]);
   assert.equal(unknown.code, 1);
   assert.equal(unknown.stdout, "");

--- a/test/github/request-copilot-review.test.mjs
+++ b/test/github/request-copilot-review.test.mjs
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import test from "node:test";
+
+const scriptPath = path.resolve("scripts/github/request-copilot-review.mjs");
+
+function runNode(args = [], options = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [scriptPath, ...args], {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    child.on("close", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+async function writeGhStub(tempDir, entries) {
+  const sequencePath = path.join(tempDir, "gh-sequence.json");
+  const counterPath = path.join(tempDir, "gh-counter.txt");
+  const ghPath = path.join(tempDir, "gh");
+
+  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
+  await writeFile(counterPath, "0\n", "utf8");
+  await writeFile(
+    ghPath,
+    [
+      "#!/usr/bin/env node",
+      'import { readFileSync, writeFileSync } from "node:fs";',
+      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
+      "const counterPath = process.env.GH_COUNTER_PATH;",
+      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
+      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
+      'const entry = entries[Math.min(current, entries.length - 1)] ?? { stdout: "{}\\n" };',
+      'writeFileSync(counterPath, String(current + 1));',
+      'const actual = process.argv.slice(2);',
+      'if (entry.assertArgs) {',
+      '  for (const expected of entry.assertArgs) {',
+      '    if (!actual.includes(expected)) {',
+      '      process.stderr.write(`missing expected gh arg: ${expected}\\n`);',
+      '      process.exit(98);',
+      '    }',
+      '  }',
+      '}',
+      'if (entry.stderr) {',
+      '  process.stderr.write(entry.stderr);',
+      '}',
+      'if (entry.stdout) {',
+      '  process.stdout.write(entry.stdout);',
+      '}',
+      'process.exit(entry.exitCode ?? 0);',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await chmod(ghPath, 0o755);
+
+  return {
+    ...process.env,
+    PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
+    GH_SEQUENCE_PATH: sequencePath,
+    GH_COUNTER_PATH: counterPath,
+  };
+}
+
+test("request-copilot-review requests Copilot deterministically and verifies via requested_reviewers", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-review-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
+        stdout: "https://github.com/owner/repo/pull/17\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n',
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      status: "requested",
+      repo: "owner/repo",
+      pr: 17,
+      reviewer: "Copilot",
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("request-copilot-review reports already-requested without mutating PR state again", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-already-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n',
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      status: "already-requested",
+      repo: "owner/repo",
+      pr: 17,
+      reviewer: "Copilot",
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("request-copilot-review normalizes known unrequestable/unavailable failures", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-unavailable-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
+        stderr: "gh: Reviews may only be requested from collaborators.\n",
+        exitCode: 1,
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      status: "unavailable",
+      repo: "owner/repo",
+      pr: 17,
+      reviewer: "Copilot",
+      detail: "gh: Reviews may only be requested from collaborators.",
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("request-copilot-review rejects malformed arguments deterministically", async () => {
+  const missingPr = await runNode(["--repo", "owner/repo"]);
+  assert.equal(missingPr.code, 1);
+  assert.equal(missingPr.stdout, "");
+  assert.deepEqual(JSON.parse(missingPr.stderr), {
+    ok: false,
+    error: "Requesting Copilot review requires both --repo <owner/name> and --pr <number>",
+  });
+
+  const zeroPr = await runNode(["--repo", "owner/repo", "--pr", "0"]);
+  assert.equal(zeroPr.code, 1);
+  assert.equal(zeroPr.stdout, "");
+  assert.deepEqual(JSON.parse(zeroPr.stderr), {
+    ok: false,
+    error: "--pr must be a positive integer",
+  });
+
+  const unknown = await runNode(["--repo", "owner/repo", "--pr", "17", "--wat"]);
+  assert.equal(unknown.code, 1);
+  assert.equal(unknown.stdout, "");
+  assert.deepEqual(JSON.parse(unknown.stderr), {
+    ok: false,
+    error: "Unknown argument: --wat",
+  });
+});

--- a/test/github/request-copilot-review.test.mjs
+++ b/test/github/request-copilot-review.test.mjs
@@ -90,12 +90,20 @@ test("request-copilot-review requests Copilot deterministically and verifies via
         stdout: '{"users":[],"teams":[]}\n',
       },
       {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "reviews"],
+        stdout: '{"reviews":[]}\n',
+      },
+      {
         assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
         stdout: "https://github.com/owner/repo/pull/17\n",
       },
       {
         assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
         stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "reviews"],
+        stdout: '{"reviews":[]}\n',
       },
     ]);
 
@@ -124,6 +132,10 @@ test("request-copilot-review recognizes Copilot under the requested reviewer log
         assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
         stdout: '{"users":[{"login":"copilot-pull-request-reviewer[bot]"}],"teams":[]}\n',
       },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "reviews"],
+        stdout: '{"reviews":[]}\n',
+      },
     ]);
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
@@ -151,6 +163,10 @@ test("request-copilot-review reports already-requested without mutating PR state
         assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
         stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n',
       },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "reviews"],
+        stdout: '{"reviews":[{"id":"r-1","author":{"login":"copilot-pull-request-reviewer[bot]"}}]}\n',
+      },
     ]);
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
@@ -169,6 +185,49 @@ test("request-copilot-review reports already-requested without mutating PR state
   }
 });
 
+test("request-copilot-review accepts an immediate Copilot review as proof the request succeeded", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-immediate-review-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "reviews"],
+        stdout: '{"reviews":[]}\n',
+      },
+      {
+        assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
+        stdout: "https://github.com/owner/repo/pull/17\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "reviews"],
+        stdout: '{"reviews":[{"id":"r-2","author":{"login":"copilot-pull-request-reviewer[bot]"}}]}\n',
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      status: "requested",
+      repo: "owner/repo",
+      pr: 17,
+      reviewer: "Copilot",
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("request-copilot-review normalizes known unrequestable/unavailable failures", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-unavailable-"));
 
@@ -177,6 +236,10 @@ test("request-copilot-review normalizes known unrequestable/unavailable failures
       {
         assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
         stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "reviews"],
+        stdout: '{"reviews":[]}\n',
       },
       {
         assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
@@ -210,6 +273,10 @@ test("request-copilot-review wraps invalid gh JSON deterministically", async () 
       {
         assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
         stdout: "not-json\n",
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "reviews"],
+        stdout: '{"reviews":[]}\n',
       },
     ]);
 

--- a/test/github/request-copilot-review.test.mjs
+++ b/test/github/request-copilot-review.test.mjs
@@ -175,6 +175,30 @@ test("request-copilot-review normalizes known unrequestable/unavailable failures
   }
 });
 
+test("request-copilot-review wraps invalid gh JSON deterministically", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-json-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: "not-json\n",
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    assert.deepEqual(JSON.parse(result.stderr), {
+      ok: false,
+      error: "Invalid JSON from gh: not-json",
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("request-copilot-review rejects malformed arguments deterministically", async () => {
   const missingPr = await runNode(["--repo", "owner/repo"]);
   assert.equal(missingPr.code, 1);

--- a/test/github/request-copilot-review.test.mjs
+++ b/test/github/request-copilot-review.test.mjs
@@ -115,6 +115,33 @@ test("request-copilot-review requests Copilot deterministically and verifies via
   }
 });
 
+test("request-copilot-review recognizes Copilot under the requested reviewer login returned by GitHub", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-login-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[{"login":"copilot-pull-request-reviewer[bot]"}],"teams":[]}\n',
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      status: "already-requested",
+      repo: "owner/repo",
+      pr: 17,
+      reviewer: "Copilot",
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("request-copilot-review reports already-requested without mutating PR state again", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-already-"));
 

--- a/test/github/watch-copilot-review.test.mjs
+++ b/test/github/watch-copilot-review.test.mjs
@@ -52,6 +52,44 @@ function createThread(commentId, login, body, type = "User") {
   };
 }
 
+function createReview(id, login, body, type = "User") {
+  return {
+    id,
+    body,
+    author: {
+      login,
+      __typename: type,
+      isBot: type === "Bot",
+    },
+  };
+}
+
+function createIssueComment(id, login, body, type = "User") {
+  return {
+    id,
+    body,
+    author: {
+      login,
+      __typename: type,
+      isBot: type === "Bot",
+    },
+  };
+}
+
+function createActivityPayload({ threads = [], reviews = [], issueComments = [] } = {}) {
+  return {
+    data: {
+      repository: {
+        pullRequest: {
+          reviewThreads: { nodes: threads },
+          reviews: { nodes: reviews },
+          comments: { nodes: issueComments },
+        },
+      },
+    },
+  };
+}
+
 async function writeGhStub(tempDir, entries) {
   const sequencePath = path.join(tempDir, "gh-sequence.json");
   const counterPath = path.join(tempDir, "gh-counter.txt");
@@ -91,9 +129,22 @@ async function writeGhStub(tempDir, entries) {
   };
 }
 
+function noChangePayload(status, attempts) {
+  return {
+    ok: true,
+    status,
+    repo: "owner/repo",
+    pr: 17,
+    attempts,
+    newComments: [],
+    newReviews: [],
+    newIssueComments: [],
+  };
+}
+
 test("watch-copilot-review returns idle for a zero-timeout no-change check", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-idle-"));
-  const baseline = { threads: [createThread("c-1", "reviewer", "Please add a test.")] };
+  const baseline = createActivityPayload({ threads: [createThread("c-1", "reviewer", "Please add a test.")] });
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -107,14 +158,7 @@ test("watch-copilot-review returns idle for a zero-timeout no-change check", asy
 
     assert.equal(result.code, 0);
     assert.equal(result.stderr, "");
-    assert.deepEqual(JSON.parse(result.stdout), {
-      ok: true,
-      status: "idle",
-      repo: "owner/repo",
-      pr: 17,
-      attempts: 1,
-      newComments: [],
-    });
+    assert.deepEqual(JSON.parse(result.stdout), noChangePayload("idle", 1));
     assert(elapsedMs < 1_000, `expected immediate recheck, got ${elapsedMs}ms`);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
@@ -123,7 +167,7 @@ test("watch-copilot-review returns idle for a zero-timeout no-change check", asy
 
 test("watch-copilot-review returns timeout after bounded polling with no fresh Copilot activity", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-timeout-"));
-  const baseline = { threads: [createThread("c-1", "reviewer", "Please add a test.")] };
+  const baseline = createActivityPayload({ threads: [createThread("c-1", "reviewer", "Please add a test.")] });
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -139,33 +183,21 @@ test("watch-copilot-review returns timeout after bounded polling with no fresh C
 
     assert.equal(result.code, 0);
     assert.equal(result.stderr, "");
-    assert.deepEqual(JSON.parse(result.stdout), {
-      ok: true,
-      status: "timeout",
-      repo: "owner/repo",
-      pr: 17,
-      attempts: 2,
-      newComments: [],
-    });
+    assert.deepEqual(JSON.parse(result.stdout), noChangePayload("timeout", 2));
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
 });
 
-test("watch-copilot-review returns changed when fresh Copilot activity appears after the baseline", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-changed-"));
-  const baseline = { threads: [createThread("c-1", "reviewer", "Please add a test.")] };
-  const changed = {
+test("watch-copilot-review returns changed for fresh Copilot review-thread comments", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-thread-"));
+  const baseline = createActivityPayload({ threads: [createThread("c-1", "reviewer", "Please add a test.")] });
+  const changed = createActivityPayload({
     threads: [
       createThread("c-1", "reviewer", "Please add a test."),
-      createThread(
-        "c-2",
-        "copilot-pull-request-reviewer[bot]",
-        "Automated Copilot review feedback.",
-        "Bot",
-      ),
+      createThread("c-2", "copilot-pull-request-reviewer[bot]", "Automated Copilot review feedback.", "Bot"),
     ],
-  };
+  });
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -191,6 +223,84 @@ test("watch-copilot-review returns changed when fresh Copilot activity appears a
           body: "Automated Copilot review feedback.",
         },
       ],
+      newReviews: [],
+      newIssueComments: [],
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("watch-copilot-review returns changed for fresh Copilot review summaries", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-review-"));
+  const baseline = createActivityPayload();
+  const changed = createActivityPayload({
+    reviews: [createReview("r-1", "copilot-pull-request-reviewer[bot]", "Automated Copilot summary.", "Bot")],
+  });
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      { stdout: `${JSON.stringify(baseline)}\n` },
+      { stdout: `${JSON.stringify(changed)}\n` },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--timeout-ms", "5"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      status: "changed",
+      repo: "owner/repo",
+      pr: 17,
+      attempts: 1,
+      newComments: [],
+      newReviews: [
+        {
+          id: "r-1",
+          authorLogin: "copilot-pull-request-reviewer[bot]",
+          body: "Automated Copilot summary.",
+        },
+      ],
+      newIssueComments: [],
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("watch-copilot-review returns changed for fresh Copilot issue comments", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-issue-comment-"));
+  const baseline = createActivityPayload();
+  const changed = createActivityPayload({
+    issueComments: [createIssueComment("i-1", "Copilot", "Fresh Copilot issue comment.", "Bot")],
+  });
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      { stdout: `${JSON.stringify(baseline)}\n` },
+      { stdout: `${JSON.stringify(changed)}\n` },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--timeout-ms", "5"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      status: "changed",
+      repo: "owner/repo",
+      pr: 17,
+      attempts: 1,
+      newComments: [],
+      newReviews: [],
+      newIssueComments: [
+        {
+          id: "i-1",
+          authorLogin: "Copilot",
+          body: "Fresh Copilot issue comment.",
+        },
+      ],
     });
   } finally {
     await rm(tempDir, { recursive: true, force: true });
@@ -199,13 +309,15 @@ test("watch-copilot-review returns changed when fresh Copilot activity appears a
 
 test("watch-copilot-review ignores fresh non-Copilot activity", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-ignore-"));
-  const baseline = { threads: [createThread("c-1", "reviewer", "Please add a test.")] };
-  const changed = {
+  const baseline = createActivityPayload({ threads: [createThread("c-1", "reviewer", "Please add a test.")] });
+  const changed = createActivityPayload({
     threads: [
       createThread("c-1", "reviewer", "Please add a test."),
       createThread("c-2", "maintainer", "I will handle this comment."),
     ],
-  };
+    reviews: [createReview("r-1", "maintainer", "Human review summary.")],
+    issueComments: [createIssueComment("i-1", "maintainer", "Human issue comment.")],
+  });
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -217,14 +329,7 @@ test("watch-copilot-review ignores fresh non-Copilot activity", async () => {
 
     assert.equal(result.code, 0);
     assert.equal(result.stderr, "");
-    assert.deepEqual(JSON.parse(result.stdout), {
-      ok: true,
-      status: "timeout",
-      repo: "owner/repo",
-      pr: 17,
-      attempts: 1,
-      newComments: [],
-    });
+    assert.deepEqual(JSON.parse(result.stdout), noChangePayload("timeout", 1));
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -232,13 +337,15 @@ test("watch-copilot-review ignores fresh non-Copilot activity", async () => {
 
 test("watch-copilot-review ignores lookalike non-Copilot logins", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-lookalike-"));
-  const baseline = { threads: [createThread("c-1", "reviewer", "Please add a test.")] };
-  const changed = {
+  const baseline = createActivityPayload({ threads: [createThread("c-1", "reviewer", "Please add a test.")] });
+  const changed = createActivityPayload({
     threads: [
       createThread("c-1", "reviewer", "Please add a test."),
       createThread("c-2", "my-copilot-helper", "This should not count as Copilot."),
     ],
-  };
+    reviews: [createReview("r-1", "my-copilot-helper", "Still not Copilot.")],
+    issueComments: [createIssueComment("i-1", "my-copilot-helper", "Still not Copilot.")],
+  });
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -250,14 +357,7 @@ test("watch-copilot-review ignores lookalike non-Copilot logins", async () => {
 
     assert.equal(result.code, 0);
     assert.equal(result.stderr, "");
-    assert.deepEqual(JSON.parse(result.stdout), {
-      ok: true,
-      status: "timeout",
-      repo: "owner/repo",
-      pr: 17,
-      attempts: 1,
-      newComments: [],
-    });
+    assert.deepEqual(JSON.parse(result.stdout), noChangePayload("timeout", 1));
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/github/watch-copilot-review.test.mjs
+++ b/test/github/watch-copilot-review.test.mjs
@@ -115,7 +115,7 @@ test("watch-copilot-review returns idle for a zero-timeout no-change check", asy
       attempts: 1,
       newComments: [],
     });
-    assert(elapsedMs < 500, `expected immediate recheck, got ${elapsedMs}ms`);
+    assert(elapsedMs < 1_000, `expected immediate recheck, got ${elapsedMs}ms`);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Refine the `/dev-loops` extension contract so package installation only exposes the command surface, while skill installation and refresh happen explicitly through `/dev-loops install ...` and `/dev-loops update ...`.

This also changes bare `/dev-loops` to default to help output instead of a status report, and keeps `install`/`update` target selection interactive by showing target guidance when invoked without `repo` or `system`.

Closes #2

## Scope / context

Phase 7 needs a clearer portability story for second-repo adoption. The previous extension shape still framed install/setup too loosely and kept implying that package installation and skill installation were the same event.

This PR narrows that contract:
- the package exposes `/dev-loops`
- packaged skills are copied only when the user explicitly runs `install` or `update`
- repo-local and system-wide skill targets are both supported
- readiness and docs now point users at that explicit flow

The implementation stays extension-thin by keeping copy mechanics in a small installer helper and preserving separate presentation/check modules.

## Acceptance criteria

- `/dev-loops` defaults to help output rather than status
- `/dev-loops install` and `/dev-loops update` ask for a target when invoked without one
- `/dev-loops install repo|system` copies packaged skills into the requested target without relying on package-level auto-skill registration
- `/dev-loops update repo|system` refreshes previously installed skill copies from the packaged source
- readiness messaging for missing packaged skills points to the explicit install flow
- package metadata no longer auto-exposes `skills/` on package install
- extension docs and roadmap docs describe the explicit install/update contract consistently
- extension command and installer behavior have regression coverage

## Definition of done

- extension command wiring supports `help`, `status`, `doctor`, `install`, `update`, and `hide` with the intended default/help behavior
- packaged skill copy logic lives in a tested installer helper
- extension README, top-level README, roadmap, and Phase 7 doc reflect the new contract
- targeted extension tests pass locally
- the branch is ready for CI review on GitHub

## Non-goals

- no package publishing or release automation work
- no overlay/update merge system for downstream customizations
- no full second-repo pilot execution in this PR
- no broader watcher or GitHub loop changes outside the install/discovery contract
