### PR TITLE
Clarify Copilot review re-request gating in async loop

### DIFF
--- a/skills/copilot-dev-loop/SKILL.md
+++ b/skills/copilot-dev-loop/SKILL.md
@@ -252,7 +252,15 @@ Do not web-search or rediscover this behavior during normal operation. Treat the
 
 When introducing or changing deterministic GitHub write helpers (for example review-request or reply/resolve helpers), do not rely on fixture tests alone if a real authorized PR is available. Run one bounded real-PR smoke check before entrusting a long-lived async loop to that helper.
 
-If the explicit request fails because Copilot review is not enabled for the repository, the reviewer identity is not requestable, or GitHub rejects the request because the reviewer is not a collaborator/requestable actor, record that exact limitation and continue with the documented watch/follow-up path rather than silently assuming review was requested.
+If the explicit request fails because Copilot review is not enabled for the repository, the reviewer identity is not requestable, or GitHub rejects the request because the reviewer is not a collaborator/requestable actor, record that exact limitation explicitly.
+
+Do not treat an attempted request as equivalent to a confirmed request.
+
+For `scripts/github/request-copilot-review.mjs`, branch on the machine-readable result:
+- `requested`: baseline fresh state, then wait/watch when another Copilot pass is actually desired
+- `already-requested`: baseline fresh state, then wait/watch
+- `unavailable`: report the limitation and stop unless the user explicitly wants passive waiting without a fresh request
+- non-zero / unexpected failure: stop and report the error rather than entering a sleep/watch loop
 
 ## Step 6: Async watch behavior
 
@@ -274,7 +282,8 @@ Practical rule for this repo:
 Preferred approach for Copilot review follow-up:
 - after a PR leaves draft, explicitly request Copilot review first, preferably through `scripts/github/request-copilot-review.mjs`
 - after any follow-up fix commit is pushed and another Copilot pass is wanted, explicitly request Copilot review again for the updated head before waiting
-- baseline current Copilot review activity
+- only enter the watch loop after the request state is confirmed as `requested` or `already-requested`
+- baseline current Copilot review activity only after that confirmed request state, unless the user explicitly asked for passive waiting without a fresh request
 - poll for new Copilot-authored review activity across review-thread comments, review summaries, and PR issue comments
 - keep the watcher in the current Pi/TelePi session
 - after new review activity appears, launch an async Pi fixer in-session
@@ -301,15 +310,19 @@ When actionable review feedback exists, use a narrow follow-up loop:
 3. apply only the accepted narrow fixes
 4. run the smallest validation that honestly proves the fix
 5. if files changed, push the resolving commit before any thread reply claims the fix is present
-   - after the push, if another Copilot pass is desired, explicitly re-request Copilot review for the new head rather than assuming it remains requested
 6. when a comment or thread is actually addressed, reply on GitHub with a short resolution note that references the resolving commit SHA or commit URL when applicable
    - prefer the deterministic helper `scripts/github/reply-resolve-review-thread.mjs` when it exists
    - use a body file under `tmp/` rather than inline shell text for the reply body
    - if that helper was newly added or recently changed, smoke-check it against one real thread before assuming the rest of the loop can rely on it
 7. resolve the addressed review thread only after the reply is attached successfully and the concern is genuinely addressed
    - do not stop at a local fix if GitHub-side reply/resolve is authorized
-8. after a re-requested Copilot pass, refresh PR thread state again before reporting completion; if fresh Copilot threads exist, return to this follow-up loop rather than stopping at "review requested"
-9. if scope has broadened, stop and ask before continuing
+8. only after GitHub-side reply/resolve work is done for the addressed threads, decide whether another Copilot pass is desired
+   - if yes, explicitly re-request Copilot review for the new head rather than assuming it remains requested
+   - only enter a wait/watch loop if the request result is confirmed as `requested` or `already-requested`
+   - if the request result is `unavailable`, report that limitation and stop unless the user explicitly wants passive waiting anyway
+   - if the request command fails unexpectedly, stop and report the error rather than sleeping and hoping for a new review
+9. after a confirmed re-requested Copilot pass, refresh PR thread state again before reporting completion; if fresh Copilot threads exist, return to this follow-up loop rather than stopping at "review requested"
+10. if scope has broadened, stop and ask before continuing
 
 Do not treat "fix applied locally" as the end of the loop when the workflow also requires GitHub-side reviewer follow-up. If comment/reply authorization is withheld, report explicitly that the code may be fixed while the PR conversation state remains unresolved.
 

--- a/skills/copilot-dev-loop/SKILL.md
+++ b/skills/copilot-dev-loop/SKILL.md
@@ -257,8 +257,8 @@ If the explicit request fails because Copilot review is not enabled for the repo
 Do not treat an attempted request as equivalent to a confirmed request.
 
 For `scripts/github/request-copilot-review.mjs`, branch on the machine-readable result:
-- `requested`: baseline fresh state, then wait/watch when another Copilot pass is actually desired
-- `already-requested`: baseline fresh state, then wait/watch
+- `requested`: if another Copilot pass is actually desired, baseline fresh state and then wait/watch; otherwise report current state without waiting
+- `already-requested`: if another Copilot pass is actually desired, baseline fresh state and then wait/watch; otherwise report current state without waiting
 - `unavailable`: report the limitation and stop unless the user explicitly wants passive waiting without a fresh request
 - non-zero / unexpected failure: stop and report the error rather than entering a sleep/watch loop
 
@@ -286,6 +286,7 @@ Preferred approach for Copilot review follow-up:
 - baseline current Copilot review activity only after that confirmed request state, unless the user explicitly asked for passive waiting without a fresh request
 - poll for new Copilot-authored review activity across review-thread comments, review summaries, and PR issue comments
 - keep the watcher in the current Pi/TelePi session
+- for unattended or long-lived waiting, prefer a Pi async subagent or the designated async follow-up skill rather than inventing a new watcher mechanism
 - after new review activity appears, launch an async Pi fixer in-session
 - do not report the loop complete while fresh Copilot comments remain unresolved; a new Copilot pass must flow back into fixer/reply/resolve work before completion when authorization exists
 - use explicit long timeouts from the timeout policy above rather than short defaults
@@ -295,8 +296,10 @@ Use an existing repo-local async review-follow-up skill or deterministic watcher
 Key rules:
 - expected polling idle time is normal
 - do not restart watchers just because there has been a short quiet period
+- do not use `nohup`, detached shell jobs, tmux/screen sessions, or ad hoc `while`/`sleep` bash loops for this workflow
 - do not bypass session-based async notifications with detached shell automation unless explicitly asked
 - if a watcher is sleeping between polls, prefer raising the orchestration inactivity threshold over interrupting the child
+- if Pi async subagents or the designated async follow-up skill are not appropriate or available, stop and report rather than improvising a shell watcher
 
 ## Step 7: Pi review/fix follow-up loop
 

--- a/test/imported-assets-normalization.test.mjs
+++ b/test/imported-assets-normalization.test.mjs
@@ -34,3 +34,12 @@ test("copilot skill still contains its core workflow guidance", async () => {
   assert.match(content, /Preferred defaults for this repo:/);
   assert.match(content, /Default validation should match or approximate/);
 });
+
+test("copilot skill requires github reply\/resolve follow-up and gates waiting on confirmed review-request state", async () => {
+  const content = await readRepo("skills/copilot-dev-loop/SKILL.md");
+
+  assert.match(content, /only after GitHub-side reply\/resolve work is done for the addressed threads, decide whether another Copilot pass is desired/);
+  assert.match(content, /only enter a wait\/watch loop if the request result is confirmed as `requested` or `already-requested`/);
+  assert.match(content, /if the request result is `unavailable`, report that limitation and stop unless the user explicitly wants passive waiting anyway/);
+  assert.match(content, /stop and report the error rather than sleeping and hoping for a new review/);
+});

--- a/test/imported-assets-normalization.test.mjs
+++ b/test/imported-assets-normalization.test.mjs
@@ -35,11 +35,21 @@ test("copilot skill still contains its core workflow guidance", async () => {
   assert.match(content, /Default validation should match or approximate/);
 });
 
-test("copilot skill requires github reply\/resolve follow-up and gates waiting on confirmed review-request state", async () => {
+test("copilot skill requires github reply/resolve follow-up and gates waiting on confirmed review-request state", async () => {
   const content = await readRepo("skills/copilot-dev-loop/SKILL.md");
 
-  assert.match(content, /only after GitHub-side reply\/resolve work is done for the addressed threads, decide whether another Copilot pass is desired/);
-  assert.match(content, /only enter a wait\/watch loop if the request result is confirmed as `requested` or `already-requested`/);
-  assert.match(content, /if the request result is `unavailable`, report that limitation and stop unless the user explicitly wants passive waiting anyway/);
-  assert.match(content, /stop and report the error rather than sleeping and hoping for a new review/);
+  assert.match(content, /reply\/resolve work is done for the addressed threads/);
+  assert.match(content, /wait\/watch loop if the request result is confirmed as `requested` or `already-requested`/);
+  assert.match(content, /`requested`: if another Copilot pass is actually desired/);
+  assert.match(content, /`already-requested`: if another Copilot pass is actually desired/);
+  assert.match(content, /`unavailable`: report the limitation and stop/);
+  assert.match(content, /stop and report the error rather than (?:entering a sleep\/watch loop|sleeping and hoping for a new review)/);
+});
+
+test("copilot skill forbids detached bash watcher loops for async follow-up", async () => {
+  const content = await readRepo("skills/copilot-dev-loop/SKILL.md");
+
+  assert.match(content, /Pi async subagent|designated async follow-up skill/);
+  assert.match(content, /do not use `nohup`, detached shell jobs, tmux\/screen sessions, or ad hoc `while`\/`sleep` bash loops/);
+  assert.match(content, /stop and report rather than improvising a shell watcher/);
 });


### PR DESCRIPTION
## Summary
- tighten the `copilot-dev-loop` skill guidance around post-fix Copilot re-request handling
- require GitHub reply/resolve follow-up before deciding whether to request another Copilot pass
- gate any wait/watch loop on a confirmed review-request state instead of an attempted request alone
- add an asset-level contract test that preserves this guidance

## Scope / Context
A recent review surfaced two workflow gaps in the current installed skill guidance:
- the loop summary omitted the GitHub reply-with-resolving-commit and thread-resolution steps before another Copilot re-request
- the async loop could read like it should sleep and wait immediately after a re-request attempt, even when that request was unavailable or failed unexpectedly

This change narrows the skill contract so follow-up behavior is explicit:
- push first
- reply and resolve addressed threads on GitHub when authorized
- then decide whether another Copilot pass is desired
- only wait when the review-request state is confirmed as `requested` or `already-requested`

## Acceptance Criteria
- the `copilot-dev-loop` skill explicitly requires GitHub reply/resolve follow-up before deciding on another Copilot pass for addressed threads
- the skill explicitly distinguishes `requested`, `already-requested`, `unavailable`, and unexpected request failures for `request-copilot-review.mjs`
- the skill instructs Pi not to enter a sleep/watch loop after an unavailable or failed request unless passive waiting was explicitly requested
- a repository test locks in that guidance so future edits do not regress it silently

## Definition of Done
- skill text updated in `skills/copilot-dev-loop/SKILL.md`
- asset normalization test updated in `test/imported-assets-normalization.test.mjs`
- validation run: `npm run test:assets`
- branch pushed and PR opened against `main`

## Non-goals
- changing the runtime behavior of `scripts/github/request-copilot-review.mjs`
- adding new GitHub API helpers or watcher scripts
- refactoring the broader Copilot loop beyond this guidance and guardrail clarification
