### PR TITLE
Bundle copilot skill runtime support during install

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -41,7 +41,7 @@ The messaging distinguishes between local loop readiness and remote GitHub/Copil
 
 ## Install/update contract for this phase
 
-`/dev-loops install ...` and `/dev-loops update ...` copy the packaged skill directories only.
+`/dev-loops install ...` and `/dev-loops update ...` copy the packaged skill directories. For `copilot-dev-loop`, they also bundle the deterministic runtime support it references: `scripts/`, the required `packages/core/src/` subset, and the reviewer-loop state-graph docs under the installed skill directory.
 
 `install` is for first-time setup. `update` refreshes installed skills only, reports missing targets, and guides users back to `install` when first-time setup is still needed.
 
@@ -51,7 +51,7 @@ They do **not**:
 - install `gh`
 - install `pi-subagents`
 - mutate GitHub authentication
-- bootstrap repositories beyond writing skill directories
+- bootstrap repositories beyond writing skill directories and the bundled support files nested under them
 - automatically refresh the current Pi session's already-loaded command list
 
 After install or update, restart Pi or refresh skill discovery before expecting `/skill:dev-loop` or `/skill:copilot-dev-loop` to appear in the current session.

--- a/extension/README.md
+++ b/extension/README.md
@@ -41,7 +41,7 @@ The messaging distinguishes between local loop readiness and remote GitHub/Copil
 
 ## Install/update contract for this phase
 
-`/dev-loops install ...` and `/dev-loops update ...` copy the packaged skill directories. For `copilot-dev-loop`, they also bundle the deterministic runtime support it references: `scripts/`, the required `packages/core/src/` subset, and the reviewer-loop state-graph docs under the installed skill directory.
+`/dev-loops install ...` and `/dev-loops update ...` copy the packaged skill directories. For `copilot-dev-loop`, they also bundle an explicit allow-listed runtime support set under the installed skill directory: the required deterministic script files, the required `packages/core/src/` files, and both loop state-graph docs.
 
 `install` is for first-time setup. `update` refreshes installed skills only, reports missing targets, and guides users back to `install` when first-time setup is still needed.
 

--- a/extension/installer.ts
+++ b/extension/installer.ts
@@ -4,6 +4,22 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const PACKAGED_SKILL_NAMES = ["dev-loop", "copilot-dev-loop"] as const;
+const COPILOT_RUNTIME_SCRIPT_FILES = [
+  "_core-helpers.mjs",
+  "github/capture-review-threads.mjs",
+  "github/reply-resolve-review-thread.mjs",
+  "github/request-copilot-review.mjs",
+  "github/stage-reviewer-draft.mjs",
+  "github/watch-copilot-review.mjs",
+  "loop/detect-copilot-loop-state.mjs",
+  "loop/detect-reviewer-loop-state.mjs",
+] as const;
+const COPILOT_RUNTIME_CORE_FILES = [
+  "github/review-threads.mjs",
+  "loop/copilot-loop-state.mjs",
+  "loop/phase-files.mjs",
+  "loop/reviewer-loop-state.mjs",
+] as const;
 const COPILOT_RUNTIME_DOCS = ["copilot-loop-state-graph.md", "reviewer-loop-state-graph.md"] as const;
 
 export type InstallScope = "repo" | "system";
@@ -142,6 +158,22 @@ async function assertWritableSkillTarget(targetPath: string) {
   }
 }
 
+async function copyRelativeFiles({
+  sourceRoot,
+  targetRoot,
+  relativePaths,
+}: {
+  sourceRoot: string;
+  targetRoot: string;
+  relativePaths: readonly string[];
+}) {
+  for (const relativePath of relativePaths) {
+    const targetFilePath = path.join(targetRoot, relativePath);
+    await mkdir(path.dirname(targetFilePath), { recursive: true });
+    await cp(path.join(sourceRoot, relativePath), targetFilePath);
+  }
+}
+
 async function copyCopilotRuntimeSupport({
   targetPath,
   scriptsRoot,
@@ -153,14 +185,21 @@ async function copyCopilotRuntimeSupport({
   coreSourceRoot: string;
   docsRoot: string;
 }) {
-  await cp(scriptsRoot, path.join(targetPath, "scripts"), { recursive: true });
-  await mkdir(path.join(targetPath, "packages", "core"), { recursive: true });
-  await cp(coreSourceRoot, path.join(targetPath, "packages", "core", "src"), { recursive: true });
-  await mkdir(path.join(targetPath, "docs"), { recursive: true });
-
-  for (const docName of COPILOT_RUNTIME_DOCS) {
-    await cp(path.join(docsRoot, docName), path.join(targetPath, "docs", docName));
-  }
+  await copyRelativeFiles({
+    sourceRoot: scriptsRoot,
+    targetRoot: path.join(targetPath, "scripts"),
+    relativePaths: COPILOT_RUNTIME_SCRIPT_FILES,
+  });
+  await copyRelativeFiles({
+    sourceRoot: coreSourceRoot,
+    targetRoot: path.join(targetPath, "packages", "core", "src"),
+    relativePaths: COPILOT_RUNTIME_CORE_FILES,
+  });
+  await copyRelativeFiles({
+    sourceRoot: docsRoot,
+    targetRoot: path.join(targetPath, "docs"),
+    relativePaths: COPILOT_RUNTIME_DOCS,
+  });
 }
 
 export async function syncPackagedSkills({

--- a/extension/installer.ts
+++ b/extension/installer.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const PACKAGED_SKILL_NAMES = ["dev-loop", "copilot-dev-loop"] as const;
+const COPILOT_RUNTIME_DOCS = ["copilot-loop-state-graph.md", "reviewer-loop-state-graph.md"] as const;
 
 export type InstallScope = "repo" | "system";
 export type InstallMode = "install" | "update";
@@ -28,6 +29,18 @@ function repoRootFromInstaller() {
 
 export function resolvePackagedSkillsRoot() {
   return path.join(repoRootFromInstaller(), "skills");
+}
+
+export function resolvePackagedScriptsRoot() {
+  return path.join(repoRootFromInstaller(), "scripts");
+}
+
+export function resolvePackagedCoreSourceRoot() {
+  return path.join(repoRootFromInstaller(), "packages", "core", "src");
+}
+
+export function resolvePackagedDocsRoot() {
+  return path.join(repoRootFromInstaller(), "docs");
 }
 
 export function resolveSystemSkillsRoot(homeDirectory = os.homedir()) {
@@ -129,16 +142,43 @@ async function assertWritableSkillTarget(targetPath: string) {
   }
 }
 
+async function copyCopilotRuntimeSupport({
+  targetPath,
+  scriptsRoot,
+  coreSourceRoot,
+  docsRoot,
+}: {
+  targetPath: string;
+  scriptsRoot: string;
+  coreSourceRoot: string;
+  docsRoot: string;
+}) {
+  await cp(scriptsRoot, path.join(targetPath, "scripts"), { recursive: true });
+  await mkdir(path.join(targetPath, "packages", "core"), { recursive: true });
+  await cp(coreSourceRoot, path.join(targetPath, "packages", "core", "src"), { recursive: true });
+  await mkdir(path.join(targetPath, "docs"), { recursive: true });
+
+  for (const docName of COPILOT_RUNTIME_DOCS) {
+    await cp(path.join(docsRoot, docName), path.join(targetPath, "docs", docName));
+  }
+}
+
 export async function syncPackagedSkills({
   mode,
   scope,
   targetRoot,
   sourceRoot = resolvePackagedSkillsRoot(),
+  scriptsRoot = resolvePackagedScriptsRoot(),
+  coreSourceRoot = resolvePackagedCoreSourceRoot(),
+  docsRoot = resolvePackagedDocsRoot(),
 }: {
   mode: InstallMode;
   scope: InstallScope;
   targetRoot: string;
   sourceRoot?: string;
+  scriptsRoot?: string;
+  coreSourceRoot?: string;
+  docsRoot?: string;
 }): Promise<InstallResult> {
   await assertWritableSkillRoot(scope, targetRoot);
   await mkdir(targetRoot, { recursive: true });
@@ -174,6 +214,15 @@ export async function syncPackagedSkills({
     }
 
     await cp(sourcePath, targetPath, { recursive: true });
+
+    if (skillName === "copilot-dev-loop") {
+      await copyCopilotRuntimeSupport({
+        targetPath,
+        scriptsRoot,
+        coreSourceRoot,
+        docsRoot,
+      });
+    }
 
     results.push({
       skillName,

--- a/skills/copilot-dev-loop/SKILL.md
+++ b/skills/copilot-dev-loop/SKILL.md
@@ -262,15 +262,15 @@ This workflow is intentionally long-lived.
 Do not rely on short default timeouts for unattended Copilot loops.
 
 Preferred defaults for this repo:
-- poll interval for review/activity watchers: **5 minutes**
-- unattended watch timeout: **72 hours**
-- if the user says to stay on it until done or avoid near-term timeout, prefer **168 hours**
+- poll interval for review/activity watchers: **1 minute**
+- unattended watch timeout: **24 hours**
+- if the user says to stay on it until done or avoid near-term timeout, prefer **72 hours**
 - parent/subagent no-activity threshold for watcher-style runs: at least **15 minutes**
 - active-long-running notice threshold for watcher-style runs: about **30 minutes**
 
 A watcher sleeping between polls is expected behavior, not a blocker.
 
-If the polling interval is 5 minutes, do not treat silence shorter than one full poll interval as suspicious, and do not configure needs-attention thresholds close to 60 seconds for this loop.
+If the polling interval is 1 minute, do not treat silence shorter than one full poll interval as suspicious, and do not configure needs-attention thresholds close to a few seconds for this loop.
 
 ## Step 5: PR discovery and interpretation
 

--- a/test/extension-command-contract.test.mjs
+++ b/test/extension-command-contract.test.mjs
@@ -179,6 +179,9 @@ test("install repo copies packaged skills into the repository, repo errors stay 
   assert(installLines.some((line) => /Restart Pi or refresh skill discovery/i.test(line)));
   await access(path.join(repoRoot, ".pi", "skills", "dev-loop", "SKILL.md"));
   await access(path.join(repoRoot, ".pi", "skills", "copilot-dev-loop", "SKILL.md"));
+  await access(path.join(repoRoot, ".pi", "skills", "copilot-dev-loop", "scripts", "github", "request-copilot-review.mjs"));
+  await access(path.join(repoRoot, ".pi", "skills", "copilot-dev-loop", "packages", "core", "src", "loop", "copilot-loop-state.mjs"));
+  await access(path.join(repoRoot, ".pi", "skills", "copilot-dev-loop", "docs", "copilot-loop-state-graph.md"));
 
   const repoErrorContext = createCommandContext();
   const noRepoPi = createPiDouble({

--- a/test/extension-installer.test.mjs
+++ b/test/extension-installer.test.mjs
@@ -2,27 +2,49 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
 
 import { resolveSystemSkillsRoot, syncPackagedSkills } from "../extension/installer.ts";
+
+async function seedFiles(rootPath, files) {
+  for (const [relativePath, content] of Object.entries(files)) {
+    const targetPath = path.join(rootPath, relativePath);
+    await mkdir(path.dirname(targetPath), { recursive: true });
+    await writeFile(targetPath, content);
+  }
+}
 
 async function seedPackagedSupport(tempDir) {
   const scriptsRoot = path.join(tempDir, "scripts-source");
   const coreSourceRoot = path.join(tempDir, "core-src-source");
   const docsRoot = path.join(tempDir, "docs-source");
 
-  await mkdir(path.join(scriptsRoot, "github"), { recursive: true });
-  await mkdir(path.join(scriptsRoot, "loop"), { recursive: true });
-  await mkdir(path.join(coreSourceRoot, "loop"), { recursive: true });
-  await mkdir(docsRoot, { recursive: true });
+  await seedFiles(scriptsRoot, {
+    "_core-helpers.mjs": "export const helper = true;\n",
+    "github/capture-review-threads.mjs": "export const capture = true;\n",
+    "github/reply-resolve-review-thread.mjs": "export const reply = true;\n",
+    "github/request-copilot-review.mjs": "#!/usr/bin/env node\n",
+    "github/stage-reviewer-draft.mjs": "export const stage = true;\n",
+    "github/watch-copilot-review.mjs": "export const watch = true;\n",
+    "loop/detect-copilot-loop-state.mjs": "#!/usr/bin/env node\n",
+    "loop/detect-reviewer-loop-state.mjs": "export const reviewer = true;\n",
+    "README.md": "scripts readme\n",
+    "github/extra-helper.mjs": "export const extra = true;\n",
+  });
 
-  await writeFile(path.join(scriptsRoot, "_core-helpers.mjs"), "export const helper = true;\n");
-  await writeFile(path.join(scriptsRoot, "README.md"), "scripts readme\n");
-  await writeFile(path.join(scriptsRoot, "github", "request-copilot-review.mjs"), "#!/usr/bin/env node\n");
-  await writeFile(path.join(scriptsRoot, "loop", "detect-copilot-loop-state.mjs"), "#!/usr/bin/env node\n");
-  await writeFile(path.join(coreSourceRoot, "loop", "copilot-loop-state.mjs"), "export const state = true;\n");
-  await writeFile(path.join(docsRoot, "copilot-loop-state-graph.md"), "copilot graph\n");
-  await writeFile(path.join(docsRoot, "reviewer-loop-state-graph.md"), "reviewer graph\n");
+  await seedFiles(coreSourceRoot, {
+    "github/review-threads.mjs": "export const reviewThreads = true;\n",
+    "loop/copilot-loop-state.mjs": "export const copilotState = true;\n",
+    "loop/phase-files.mjs": "export const phaseFiles = true;\n",
+    "loop/reviewer-loop-state.mjs": "export const reviewerState = true;\n",
+    "other/not-needed.mjs": "export const notNeeded = true;\n",
+  });
+
+  await seedFiles(docsRoot, {
+    "copilot-loop-state-graph.md": "copilot graph\n",
+    "reviewer-loop-state-graph.md": "reviewer graph\n",
+    "IMPLEMENTATION_STATE.md": "not bundled\n",
+  });
 
   return { scriptsRoot, coreSourceRoot, docsRoot };
 }
@@ -31,7 +53,7 @@ test("resolveSystemSkillsRoot targets ~/.pi/agent/skills", () => {
   assert.equal(resolveSystemSkillsRoot("/tmp/home"), path.join("/tmp/home", ".pi", "agent", "skills"));
 });
 
-test("install copies packaged skills and bundled copilot runtime support without overwriting existing targets", async () => {
+test("install copies packaged skills and only the allow-listed copilot runtime support without overwriting existing targets", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-extension-install-"));
   const sourceRoot = path.join(tempDir, "source");
   const targetRoot = path.join(tempDir, "target");
@@ -70,12 +92,17 @@ test("install copies packaged skills and bundled copilot runtime support without
   );
   assert.equal(
     await readFile(path.join(targetRoot, "copilot-dev-loop", "packages", "core", "src", "loop", "copilot-loop-state.mjs"), "utf8"),
-    "export const state = true;\n",
+    "export const copilotState = true;\n",
   );
   assert.equal(
     await readFile(path.join(targetRoot, "copilot-dev-loop", "docs", "copilot-loop-state-graph.md"), "utf8"),
     "copilot graph\n",
   );
+
+  await assert.rejects(access(path.join(targetRoot, "copilot-dev-loop", "scripts", "README.md")));
+  await assert.rejects(access(path.join(targetRoot, "copilot-dev-loop", "scripts", "github", "extra-helper.mjs")));
+  await assert.rejects(access(path.join(targetRoot, "copilot-dev-loop", "packages", "core", "src", "other", "not-needed.mjs")));
+  await assert.rejects(access(path.join(targetRoot, "copilot-dev-loop", "docs", "IMPLEMENTATION_STATE.md")));
 
   await writeFile(path.join(targetRoot, "dev-loop", "SKILL.md"), "repo override\n");
 

--- a/test/extension-installer.test.mjs
+++ b/test/extension-installer.test.mjs
@@ -6,14 +6,36 @@ import { mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
 
 import { resolveSystemSkillsRoot, syncPackagedSkills } from "../extension/installer.ts";
 
+async function seedPackagedSupport(tempDir) {
+  const scriptsRoot = path.join(tempDir, "scripts-source");
+  const coreSourceRoot = path.join(tempDir, "core-src-source");
+  const docsRoot = path.join(tempDir, "docs-source");
+
+  await mkdir(path.join(scriptsRoot, "github"), { recursive: true });
+  await mkdir(path.join(scriptsRoot, "loop"), { recursive: true });
+  await mkdir(path.join(coreSourceRoot, "loop"), { recursive: true });
+  await mkdir(docsRoot, { recursive: true });
+
+  await writeFile(path.join(scriptsRoot, "_core-helpers.mjs"), "export const helper = true;\n");
+  await writeFile(path.join(scriptsRoot, "README.md"), "scripts readme\n");
+  await writeFile(path.join(scriptsRoot, "github", "request-copilot-review.mjs"), "#!/usr/bin/env node\n");
+  await writeFile(path.join(scriptsRoot, "loop", "detect-copilot-loop-state.mjs"), "#!/usr/bin/env node\n");
+  await writeFile(path.join(coreSourceRoot, "loop", "copilot-loop-state.mjs"), "export const state = true;\n");
+  await writeFile(path.join(docsRoot, "copilot-loop-state-graph.md"), "copilot graph\n");
+  await writeFile(path.join(docsRoot, "reviewer-loop-state-graph.md"), "reviewer graph\n");
+
+  return { scriptsRoot, coreSourceRoot, docsRoot };
+}
+
 test("resolveSystemSkillsRoot targets ~/.pi/agent/skills", () => {
   assert.equal(resolveSystemSkillsRoot("/tmp/home"), path.join("/tmp/home", ".pi", "agent", "skills"));
 });
 
-test("install copies packaged skills without overwriting existing targets", async () => {
+test("install copies packaged skills and bundled copilot runtime support without overwriting existing targets", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-extension-install-"));
   const sourceRoot = path.join(tempDir, "source");
   const targetRoot = path.join(tempDir, "target");
+  const { scriptsRoot, coreSourceRoot, docsRoot } = await seedPackagedSupport(tempDir);
 
   await mkdir(path.join(sourceRoot, "dev-loop"), { recursive: true });
   await mkdir(path.join(sourceRoot, "copilot-dev-loop"), { recursive: true });
@@ -24,6 +46,9 @@ test("install copies packaged skills without overwriting existing targets", asyn
     mode: "install",
     scope: "repo",
     sourceRoot,
+    scriptsRoot,
+    coreSourceRoot,
+    docsRoot,
     targetRoot,
   });
 
@@ -35,12 +60,32 @@ test("install copies packaged skills without overwriting existing targets", asyn
     ],
   );
 
+  assert.equal(
+    await readFile(path.join(targetRoot, "copilot-dev-loop", "scripts", "github", "request-copilot-review.mjs"), "utf8"),
+    "#!/usr/bin/env node\n",
+  );
+  assert.equal(
+    await readFile(path.join(targetRoot, "copilot-dev-loop", "scripts", "_core-helpers.mjs"), "utf8"),
+    "export const helper = true;\n",
+  );
+  assert.equal(
+    await readFile(path.join(targetRoot, "copilot-dev-loop", "packages", "core", "src", "loop", "copilot-loop-state.mjs"), "utf8"),
+    "export const state = true;\n",
+  );
+  assert.equal(
+    await readFile(path.join(targetRoot, "copilot-dev-loop", "docs", "copilot-loop-state-graph.md"), "utf8"),
+    "copilot graph\n",
+  );
+
   await writeFile(path.join(targetRoot, "dev-loop", "SKILL.md"), "repo override\n");
 
   const second = await syncPackagedSkills({
     mode: "install",
     scope: "repo",
     sourceRoot,
+    scriptsRoot,
+    coreSourceRoot,
+    docsRoot,
     targetRoot,
   });
 
@@ -58,6 +103,7 @@ test("update refreshes existing target directories from the packaged source and 
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-extension-update-"));
   const sourceRoot = path.join(tempDir, "source");
   const targetRoot = path.join(tempDir, "target");
+  const { scriptsRoot, coreSourceRoot, docsRoot } = await seedPackagedSupport(tempDir);
 
   await mkdir(path.join(sourceRoot, "dev-loop"), { recursive: true });
   await mkdir(path.join(sourceRoot, "copilot-dev-loop"), { recursive: true });
@@ -70,6 +116,9 @@ test("update refreshes existing target directories from the packaged source and 
     mode: "update",
     scope: "system",
     sourceRoot,
+    scriptsRoot,
+    coreSourceRoot,
+    docsRoot,
     targetRoot,
   });
 
@@ -89,6 +138,7 @@ test("install refuses symlinked roots, symlinked ancestors, and skill targets to
   const sourceRoot = path.join(tempDir, "source");
   const realRoot = path.join(tempDir, "real-root");
   const linkedRoot = path.join(tempDir, "linked-root");
+  const { scriptsRoot, coreSourceRoot, docsRoot } = await seedPackagedSupport(tempDir);
 
   await mkdir(path.join(sourceRoot, "dev-loop"), { recursive: true });
   await mkdir(path.join(sourceRoot, "copilot-dev-loop"), { recursive: true });
@@ -103,6 +153,9 @@ test("install refuses symlinked roots, symlinked ancestors, and skill targets to
       mode: "install",
       scope: "repo",
       sourceRoot,
+      scriptsRoot,
+      coreSourceRoot,
+      docsRoot,
       targetRoot: linkedRoot,
     }),
     /symlinked skill root/i,
@@ -119,6 +172,9 @@ test("install refuses symlinked roots, symlinked ancestors, and skill targets to
       mode: "install",
       scope: "repo",
       sourceRoot,
+      scriptsRoot,
+      coreSourceRoot,
+      docsRoot,
       targetRoot: path.join(symlinkedAncestorRoot, ".pi", "skills"),
     }),
     /Ancestor path is a symlink/i,
@@ -131,6 +187,9 @@ test("install refuses symlinked roots, symlinked ancestors, and skill targets to
       mode: "update",
       scope: "repo",
       sourceRoot,
+      scriptsRoot,
+      coreSourceRoot,
+      docsRoot,
       targetRoot: path.join(symlinkedAncestorRoot, ".pi", "skills"),
     }),
     /Ancestor path is a symlink/i,
@@ -146,6 +205,9 @@ test("install refuses symlinked roots, symlinked ancestors, and skill targets to
       mode: "install",
       scope: "repo",
       sourceRoot,
+      scriptsRoot,
+      coreSourceRoot,
+      docsRoot,
       targetRoot: path.join(linkedRepoRoot, ".pi", "skills"),
     }),
     /Ancestor path is a symlink/i,
@@ -160,6 +222,9 @@ test("install refuses symlinked roots, symlinked ancestors, and skill targets to
       mode: "update",
       scope: "repo",
       sourceRoot,
+      scriptsRoot,
+      coreSourceRoot,
+      docsRoot,
       targetRoot,
     }),
     /symlinked skill target/i,

--- a/test/extension-package-contract.test.mjs
+++ b/test/extension-package-contract.test.mjs
@@ -32,8 +32,9 @@ test("extension README documents the command surface and runtime/build/test cont
   assert.match(readme, /\/dev-loops install system/i);
   assert.match(readme, /\/dev-loops update repo/i);
   assert.match(readme, /refresh installed skills/i);
-  assert.match(readme, /bundle the deterministic runtime support/i);
+  assert.match(readme, /explicit allow-listed runtime support set/i);
   assert.match(readme, /packages\/core\/src/i);
+  assert.match(readme, /both loop state-graph docs/i);
   assert.match(readme, /Node[^\n]*>=20/i);
   assert.match(readme, /source-loaded/i);
   assert.match(readme, /does not automatically install skills/i);

--- a/test/extension-package-contract.test.mjs
+++ b/test/extension-package-contract.test.mjs
@@ -32,6 +32,8 @@ test("extension README documents the command surface and runtime/build/test cont
   assert.match(readme, /\/dev-loops install system/i);
   assert.match(readme, /\/dev-loops update repo/i);
   assert.match(readme, /refresh installed skills/i);
+  assert.match(readme, /bundle the deterministic runtime support/i);
+  assert.match(readme, /packages\/core\/src/i);
   assert.match(readme, /Node[^\n]*>=20/i);
   assert.match(readme, /source-loaded/i);
   assert.match(readme, /does not automatically install skills/i);

--- a/test/imported-assets-normalization.test.mjs
+++ b/test/imported-assets-normalization.test.mjs
@@ -32,6 +32,8 @@ test("copilot skill still contains its core workflow guidance", async () => {
   assert.match(content, /Before planning, review, or automation:/);
   assert.match(content, /Before any GitHub mutation/);
   assert.match(content, /Preferred defaults for this repo:/);
+  assert.match(content, /1 minute/i);
+  assert.match(content, /24 hours/i);
   assert.match(content, /Default validation should match or approximate/);
 });
 


### PR DESCRIPTION
## Summary

Bundle the deterministic runtime support needed by the installed `copilot-dev-loop` skill so `/dev-loops install` and `/dev-loops update` produce a usable Copilot workflow surface instead of a skill directory with missing script dependencies.

## Scope/Context

Today the installer copies packaged skill directories, but `copilot-dev-loop` also depends on deterministic helper assets outside `skills/copilot-dev-loop/`, including root `scripts/`, selected `packages/core/src/` modules, and loop-state docs. After install, the skill can therefore reference files that are not present in the installed target.

This change keeps the explicit skill-install workflow intact while extending the installed `copilot-dev-loop` payload to include the runtime support it already documents and expects.

In scope:
- update `extension/installer.ts` so installed `copilot-dev-loop` targets also receive the deterministic runtime support bundle they require
- document the revised install/update contract in `extension/README.md`
- add installer and command-contract coverage that proves the bundled runtime support is present after repo install

## Acceptance Criteria

- `/dev-loops install repo|system` installs `copilot-dev-loop` with the deterministic runtime support it references
- the installed `copilot-dev-loop` bundle includes the required nested `scripts/` support files
- the installed `copilot-dev-loop` bundle includes the required nested `packages/core/src/` support files
- the installed `copilot-dev-loop` bundle includes the required loop-state graph docs used by the skill
- installer tests and command-contract tests fail if those runtime dependencies are missing after install
- installer/update behavior for already-installed and missing targets remains explicit and deterministic

## Definition of Done

- implementation updated
- extension install/update documentation updated
- targeted installer tests updated
- targeted extension command-contract tests updated
- package-contract README assertions updated
- full local test suite passes via `npm test`

## Non-goals

- redesigning the overall installer UX
- moving all shared workflow assets into a new packaging layout
- changing GitHub/Copilot orchestration behavior beyond making installed assets complete
- automatically requesting Copilot review from a draft PR
