### PR TITLE
Clarify copilot skill relative path resolution

### DIFF
--- a/skills/copilot-dev-loop/SKILL.md
+++ b/skills/copilot-dev-loop/SKILL.md
@@ -108,6 +108,8 @@ Goal:
 
 ## Deterministic orchestration authority
 
+Use deterministic helper scripts from `scripts/` and reference docs from `docs/` relative to this skill directory. Paths referenced from this skill are relative to the skill directory so the workflow works from project-local `.pi/skills/`, packaged global installs under `~/.pi/agent/skills/`, or other supported Pi skill locations rather than assuming the active repository has matching root-level helper files.
+
 When operating in PR follow-up or async watch mode, use the deterministic state machines
 as the authoritative source for:
 

--- a/test/imported-assets-normalization.test.mjs
+++ b/test/imported-assets-normalization.test.mjs
@@ -33,7 +33,7 @@ test("copilot skill still contains its core workflow guidance", async () => {
   assert.match(content, /Before any GitHub mutation/);
   assert.match(content, /Preferred defaults for this repo:/);
   assert.match(content, /relative to this skill directory/i);
-  assert.match(content, /~\/.pi\/agent\/skills/i);
+  assert.match(content, /~\/\.pi\/agent\/skills/i);
   assert.match(content, /1 minute/i);
   assert.match(content, /24 hours/i);
   assert.match(content, /Default validation should match or approximate/);

--- a/test/imported-assets-normalization.test.mjs
+++ b/test/imported-assets-normalization.test.mjs
@@ -32,6 +32,8 @@ test("copilot skill still contains its core workflow guidance", async () => {
   assert.match(content, /Before planning, review, or automation:/);
   assert.match(content, /Before any GitHub mutation/);
   assert.match(content, /Preferred defaults for this repo:/);
+  assert.match(content, /relative to this skill directory/i);
+  assert.match(content, /~\/.pi\/agent\/skills/i);
   assert.match(content, /1 minute/i);
   assert.match(content, /24 hours/i);
   assert.match(content, /Default validation should match or approximate/);


### PR DESCRIPTION
## Summary

Clarify that `copilot-dev-loop` resolves its bundled helper scripts and docs relative to the installed skill directory rather than assuming those helpers exist at the active repository root.

## Scope/Context

A regression showed up after global install in another repository: the skill still instructed callers to run `node scripts/...` from the target repo, which fails when the deterministic helpers live under the installed skill bundle in `~/.pi/agent/skills/copilot-dev-loop/`.

This follow-up does not change the installer payload. It fixes the skill contract so the documented/runtime path model matches the packaged install layout that PR #9 introduced.

In scope:
- update `skills/copilot-dev-loop/SKILL.md` to state that `scripts/` and `docs/` paths are relative to the skill directory
- explicitly mention project-local and global installed skill locations
- add a regression test covering that wording

## Acceptance Criteria

- `skills/copilot-dev-loop/SKILL.md` explicitly says referenced helper paths are relative to the skill directory
- the skill text explicitly covers packaged global installs under `~/.pi/agent/skills/`
- asset tests fail if that path-resolution guidance is removed again

## Definition of Done

- skill guidance updated
- regression test updated
- `npm run test:assets` passes

## Non-goals

- changing the installer payload again
- adding new deterministic helper scripts
- redesigning the Copilot loop workflow
