### PR TITLE
fix: correct extension entry point path resolution

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./extension/index.ts";

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "pi": {
     "extensions": [
-      "./extension/index.ts"
+      "./index.ts"
     ]
   }
 }

--- a/test/extension-package-contract.test.mjs
+++ b/test/extension-package-contract.test.mjs
@@ -8,7 +8,7 @@ const readRepo = (relativePath) => readFile(fromRepoRoot(relativePath), "utf8");
 test("package metadata exposes the extension entrypoint and root extension test script", async () => {
   const packageJson = JSON.parse(await readRepo("package.json"));
 
-  assert.deepEqual(packageJson.pi.extensions, ["./extension/index.ts"]);
+  assert.deepEqual(packageJson.pi.extensions, ["./index.ts"]);
   assert.equal(packageJson.bin["pi-dev-loops"], "./bin/pi-dev-loops.mjs");
   assert.match(packageJson.engines.node, />=20/);
   assert.equal(typeof packageJson.peerDependencies["@mariozechner/pi-coding-agent"], "string");


### PR DESCRIPTION
To show the correct extension name on pi we need to
Add root index.ts that re-exports the extension with the correct relative path. Update package.json pi.extensions to point to the new root entry file.