### PR TITLE
docs: add workflow remediation prep memo

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -142,19 +142,7 @@ Success for Phase 7 means:
 
 The durable phase plan lives in `docs/phases/phase-7.md`.
 
-#### Preparatory workflow-remediation track
-
-Before broader follow-up improvements continue, bounded remediation chunks under issue `#70` may land to harden the current workflow foundation.
-
-That prep track is intentionally narrow:
-- small local PR chunks
-- one bounded problem per chunk
-- no roadmap replacement
-- no silent expansion into a workflow rewrite
-
-This prep track does **not** replace Phase 7. It exists to make later work, including the Phase 7 pilot and subsequent improvements, start from a more reliable foundation.
-
-The durable prep memo lives in `docs/workflow-remediation-prep.md`.
+A separate supporting memo at `docs/workflow-remediation-prep.md` records the workflow-remediation findings behind issue `#70`. That memo supports bounded prep chunks, but it is not a roadmap phase and does not replace Phase 7.
 
 ### After Phase 7
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -142,6 +142,20 @@ Success for Phase 7 means:
 
 The durable phase plan lives in `docs/phases/phase-7.md`.
 
+#### Preparatory workflow-remediation track
+
+Before broader follow-up improvements continue, bounded remediation chunks under issue `#70` may land to harden the current workflow foundation.
+
+That prep track is intentionally narrow:
+- small local PR chunks
+- one bounded problem per chunk
+- no roadmap replacement
+- no silent expansion into a workflow rewrite
+
+This prep track does **not** replace Phase 7. It exists to make later work, including the Phase 7 pilot and subsequent improvements, start from a more reliable foundation.
+
+The durable prep memo lives in `docs/workflow-remediation-prep.md`.
+
 ### After Phase 7
 
 Do not lock later phases in detail until Phase 7 produces real evidence. Likely follow-up areas include:

--- a/PLAN.md
+++ b/PLAN.md
@@ -142,7 +142,7 @@ Success for Phase 7 means:
 
 The durable phase plan lives in `docs/phases/phase-7.md`.
 
-A separate supporting memo at `docs/workflow-remediation-prep.md` records the workflow-remediation findings behind issue `#70`. That memo supports bounded prep chunks, but it is not a roadmap phase and does not replace Phase 7.
+A separate supporting memo at `docs/workflow-remediation-prep.md` records the workflow-remediation findings behind issue #70. That memo supports bounded prep chunks, but it is not a roadmap phase and does not replace Phase 7.
 
 ### After Phase 7
 

--- a/docs/IMPLEMENTATION_STATE.md
+++ b/docs/IMPLEMENTATION_STATE.md
@@ -4,7 +4,7 @@
 
 Phase 1 imported-asset normalization is complete, locally validated, committed, and merged. Phase 2 dedicated refiner-agent work is complete, locally validated, committed, and merged. Phase 3 package extension and setup UX work is complete, locally validated, committed, and merged. Phase 4 shared deterministic library and npm support package work is complete, locally validated, committed, and merged. Phase 5 deterministic scripts work is complete, locally validated, committed, and merged. Phase 6 public release hardening is complete, merged, and synced back to local `main`. Phase 7 second-repo pilot refinement remains the next durable roadmap phase and is still in planning.
 
-Separately, issue `#70` now tracks a bounded workflow-remediation preparation chain. Those chunks are meant to harden the current workflow foundation before later improvements continue. They do **not** replace Phase 7 or the existing roadmap.
+Separately, issue #70 now tracks a bounded workflow-remediation preparation chain. Those chunks are meant to harden the current workflow foundation before later improvements continue. They do **not** replace Phase 7 or the existing roadmap.
 
 Current `main` also includes the current conductor-adjacent ownership/routing contracts plus the current inspection and steering surfaces; the next durable repo-level execution phase is still the bounded Phase 7 pilot rather than a new architecture expansion.
 
@@ -19,7 +19,7 @@ Current `main` also includes the current conductor-adjacent ownership/routing co
 
 ## Supporting context
 
-- Workflow-remediation findings memo for issue `#70`: `docs/workflow-remediation-prep.md`
+- Workflow-remediation findings memo for issue #70: `docs/workflow-remediation-prep.md`
 
 ## Current phase
 
@@ -42,7 +42,7 @@ If the user says **"continue implementation"**:
    - explicit local phase-bounded work -> use `dev-loop`
 8. inspect `tmp/phases/index.json` and any useful prior artifacts only if prior context helps
 9. if durable repo truth changed during the work, sync `README.md`, `PLAN.md`, `docs/IMPLEMENTATION_STATE.md`, and any affected contract docs before closing the slice
-10. if the request is about workflow-remediation preparation, read `docs/workflow-remediation-prep.md` and work the next bounded `#70` chunk without widening scope
+10. if the request is about workflow-remediation preparation, read `docs/workflow-remediation-prep.md` and work the next bounded #70 chunk without widening scope
 11. for Phase 7 specifically, clarify the target repository and pilot path if they are still unset before implementation starts
 
 ## Next unfinished phase

--- a/docs/IMPLEMENTATION_STATE.md
+++ b/docs/IMPLEMENTATION_STATE.md
@@ -14,9 +14,12 @@ Current `main` also includes the current conductor-adjacent ownership/routing co
 - Product/repo roadmap: `PLAN.md`
 - Repo contract: `AGENTS.md`
 - Workflow explainer: `docs/IMPLEMENTATION_WORKFLOW.md`
-- Durable remediation prep memo: `docs/workflow-remediation-prep.md`
 - Durable local phase plan: `docs/phases/phase-7.md`
 - tmp index for fresh-context inspection if present locally: `tmp/phases/index.json`
+
+## Supporting context
+
+- Workflow-remediation findings memo for issue `#70`: `docs/workflow-remediation-prep.md`
 
 ## Current phase
 

--- a/docs/IMPLEMENTATION_STATE.md
+++ b/docs/IMPLEMENTATION_STATE.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Phase 1 imported-asset normalization is complete, locally validated, committed, and merged. Phase 2 dedicated refiner-agent work is complete, locally validated, committed, and merged. Phase 3 package extension and setup UX work is complete, locally validated, committed, and merged. Phase 4 shared deterministic library and npm support package work is complete, locally validated, committed, and merged. Phase 5 deterministic scripts work is complete, locally validated, committed, and merged. Phase 6 public release hardening is complete, merged, and synced back to local `main`. Phase 7 second-repo pilot refinement is now in planning.
+Phase 1 imported-asset normalization is complete, locally validated, committed, and merged. Phase 2 dedicated refiner-agent work is complete, locally validated, committed, and merged. Phase 3 package extension and setup UX work is complete, locally validated, committed, and merged. Phase 4 shared deterministic library and npm support package work is complete, locally validated, committed, and merged. Phase 5 deterministic scripts work is complete, locally validated, committed, and merged. Phase 6 public release hardening is complete, merged, and synced back to local `main`. Phase 7 second-repo pilot refinement remains the next durable roadmap phase and is still in planning.
+
+Separately, issue `#70` now tracks a bounded workflow-remediation preparation chain. Those chunks are meant to harden the current workflow foundation before later improvements continue. They do **not** replace Phase 7 or the existing roadmap.
 
 Current `main` also includes the current conductor-adjacent ownership/routing contracts plus the current inspection and steering surfaces; the next durable repo-level execution phase is still the bounded Phase 7 pilot rather than a new architecture expansion.
 
@@ -12,6 +14,7 @@ Current `main` also includes the current conductor-adjacent ownership/routing co
 - Product/repo roadmap: `PLAN.md`
 - Repo contract: `AGENTS.md`
 - Workflow explainer: `docs/IMPLEMENTATION_WORKFLOW.md`
+- Durable remediation prep memo: `docs/workflow-remediation-prep.md`
 - Durable local phase plan: `docs/phases/phase-7.md`
 - tmp index for fresh-context inspection if present locally: `tmp/phases/index.json`
 
@@ -36,7 +39,8 @@ If the user says **"continue implementation"**:
    - explicit local phase-bounded work -> use `dev-loop`
 8. inspect `tmp/phases/index.json` and any useful prior artifacts only if prior context helps
 9. if durable repo truth changed during the work, sync `README.md`, `PLAN.md`, `docs/IMPLEMENTATION_STATE.md`, and any affected contract docs before closing the slice
-10. for Phase 7 specifically, clarify the target repository and pilot path if they are still unset before implementation starts
+10. if the request is about workflow-remediation preparation, read `docs/workflow-remediation-prep.md` and work the next bounded `#70` chunk without widening scope
+11. for Phase 7 specifically, clarify the target repository and pilot path if they are still unset before implementation starts
 
 ## Next unfinished phase
 

--- a/docs/phases/phase-7.md
+++ b/docs/phases/phase-7.md
@@ -132,7 +132,7 @@ This phase exists to answer, in one real non-bootstrap repo:
 
 Phase 7 refinement has started and the merged bounded plan is recorded here.
 
-Before pilot implementation begins, it is acceptable to land bounded workflow-remediation prep slices under issue `#70` so later work starts from a more reliable foundation. Those slices do not replace this phase.
+Bounded workflow-remediation prep slices under issue `#70` may land independently to improve shared workflow footing. They are not part of this phase and do not replace it.
 
 Implementation should not begin until the target repository is chosen and the GitHub issue is opened with the selected pilot path.
 

--- a/docs/phases/phase-7.md
+++ b/docs/phases/phase-7.md
@@ -119,6 +119,7 @@ This phase exists to answer, in one real non-bootstrap repo:
 - any downstream customization in this phase should stay thin, local, and explicitly documented rather than generalized prematurely
 - for the Phase 7 portability path, package install should expose the extension command surface only; packaged skills should be copied explicitly into repo-local or system-wide skill directories through `/dev-loops install ...` and `/dev-loops update ...`
 - phase refinement for this repo should default to fan-out / fan-in planning with multiple variants before converging on one merged plan
+- bounded workflow-remediation prep slices under issue `#70` may land first to harden the current workflow foundation, but they do not change this phase's scope or success criteria
 
 ## Open questions
 
@@ -130,6 +131,8 @@ This phase exists to answer, in one real non-bootstrap repo:
 ## Operational closure status
 
 Phase 7 refinement has started and the merged bounded plan is recorded here.
+
+Before pilot implementation begins, it is acceptable to land bounded workflow-remediation prep slices under issue `#70` so later work starts from a more reliable foundation. Those slices do not replace this phase.
 
 Implementation should not begin until the target repository is chosen and the GitHub issue is opened with the selected pilot path.
 

--- a/docs/phases/phase-7.md
+++ b/docs/phases/phase-7.md
@@ -119,7 +119,6 @@ This phase exists to answer, in one real non-bootstrap repo:
 - any downstream customization in this phase should stay thin, local, and explicitly documented rather than generalized prematurely
 - for the Phase 7 portability path, package install should expose the extension command surface only; packaged skills should be copied explicitly into repo-local or system-wide skill directories through `/dev-loops install ...` and `/dev-loops update ...`
 - phase refinement for this repo should default to fan-out / fan-in planning with multiple variants before converging on one merged plan
-- bounded workflow-remediation prep slices under issue `#70` may land first to harden the current workflow foundation, but they do not change this phase's scope or success criteria
 
 ## Open questions
 
@@ -132,7 +131,7 @@ This phase exists to answer, in one real non-bootstrap repo:
 
 Phase 7 refinement has started and the merged bounded plan is recorded here.
 
-Bounded workflow-remediation prep slices under issue `#70` may land independently to improve shared workflow footing. They are not part of this phase and do not replace it.
+Bounded workflow-remediation prep slices under issue #70 may land independently to improve shared workflow footing. They are not part of this phase and do not replace it.
 
 Implementation should not begin until the target repository is chosen and the GitHub issue is opened with the selected pilot path.
 

--- a/docs/workflow-remediation-prep.md
+++ b/docs/workflow-remediation-prep.md
@@ -1,0 +1,135 @@
+# Workflow remediation preparation
+
+Related issue: #70
+
+## Purpose
+
+This document turns the 2026-05-19 workflow audit into durable repo guidance.
+
+It is a **preparation track** for later improvements, not a roadmap reset.
+
+It exists to harden the current workflow foundation before broader follow-up work proceeds, while keeping the existing planned work intact — especially the bounded Phase 7 second-repo pilot.
+
+## What this does not change
+
+- it does **not** replace `PLAN.md`
+- it does **not** replace `docs/phases/phase-7.md`
+- it does **not** declare a one-shot workflow rewrite
+- it does **not** commit the raw local audit scratch artifacts under `tmp/`, `fanout/`, `fanin/`, `final/`, or `validation/`
+
+## Concrete findings
+
+### 1. Premature Copilot request when CI is effectively unknown
+Current behavior can treat a fresh head with no materialized checks as ready for Copilot review.
+
+Primary surfaces:
+- `scripts/loop/detect-copilot-loop-state.mjs`
+- `packages/core/src/loop/copilot-loop-state.mjs`
+- `scripts/loop/copilot-pr-handoff.mjs`
+- `test/loop/detect-copilot-loop-state.test.mjs`
+
+Problem shape:
+- empty `statusCheckRollup` becomes `ciStatus: "none"`
+- only `pending` and `failure` block request flow
+- handoff can request Copilot review too early
+
+### 2. Checkpoint identity / freshness is under-scoped
+Checkpoint state is not keyed strongly enough and can be reused too loosely.
+
+Primary surfaces:
+- `scripts/loop/outer-loop.mjs`
+- `scripts/loop/inspect-run.mjs`
+- `packages/core/src/loop/run-inspection.mjs`
+- `test/loop/outer-loop.test.mjs`
+- `test/loop/inspect-run.test.mjs`
+
+Problem shape:
+- default checkpoint path is keyed too weakly
+- prior checkpoint state can influence later cycles too loosely
+- both execution and inspection are affected
+
+### 3. `inspect-run` can over-trust checkpoint-derived fallback
+Inspection can present checkpoint-derived state as usable when live detection is unavailable.
+
+Primary surfaces:
+- `scripts/loop/inspect-run.mjs`
+- `packages/core/src/loop/run-inspection.mjs`
+- `scripts/loop/outer-loop.mjs`
+- `test/loop/inspect-run.test.mjs`
+
+Problem shape:
+- fallback behavior is broader than corrupt JSON handling
+- valid-but-stale checkpoint state is also a risk
+- this is an operator-signal / output-contract problem
+
+### 4. Reviewer identity scoping is underspecified when `--reviewer-login` is omitted
+This is real, but it is not yet a plain bug ticket.
+
+Primary surfaces:
+- `scripts/loop/detect-reviewer-loop-state.mjs`
+- `scripts/loop/outer-loop.mjs`
+- `scripts/loop/inspect-run.mjs`
+- `scripts/README.md`
+- `docs/reviewer-loop-state-graph.md`
+
+Problem shape:
+- omitted reviewer identity broadens scope to all reviewers
+- current docs make that behavior at least partly defensible
+- this needs a contract decision before any default-behavior change
+
+### 5. Ownership-aware routing exists in core but is not wired into active outer-loop routing
+This is a known seam, not a surprise bug.
+
+Primary surfaces:
+- `packages/core/src/loop/conductor-routing.mjs`
+- `docs/conductor-routing-contract.md`
+- `scripts/loop/outer-loop.mjs`
+
+Problem shape:
+- ownership-aware routing exists as a core concept
+- active outer-loop does not yet consume it
+- backlog dedupe should happen before filing any new issue for this
+
+### 6. Docs / authority ownership is still too blurry
+This is cleanup work, not the root-cause explanation for the runtime bugs.
+
+Primary surfaces:
+- `docs/IMPLEMENTATION_WORKFLOW.md`
+- `skills/dev-loop/SKILL.md`
+- `scripts/README.md`
+- relevant state/contract docs under `docs/`
+
+Problem shape:
+- shipped runtime semantics should be code-owned
+- some docs still over-own or blur behavior
+- this weakens future maintenance and audits
+
+## Implementation chain
+
+```mermaid
+flowchart TD
+    A[Chunk 1\nCommit distilled audit memo\nand prep phase docs] --> B[Chunk 2\nFix premature Copilot\nrequest gating]
+    B --> C[Chunk 3\nTighten checkpoint\nidentity and freshness]
+    C --> D[Chunk 4\nTighten inspect-run\nfallback honesty]
+    D --> E[Chunk 5\nDecide reviewer\nidentity scoping contract]
+    E --> F[Chunk 6\nDocs and authority\ncleanup]
+    F --> G[Resume later planned improvements\non stronger workflow footing]
+```
+
+## Working rules for chunks
+
+Each follow-up PR should:
+- reference `#70`
+- stay bounded to one chunk
+- include explicit non-goals
+- include focused validation
+- update docs/contracts only where that chunk changes shipped behavior
+
+## Non-goals
+
+- no one-shot workflow rewrite
+- no giant mixed PR
+- no premature filing of weakly evidenced watcher/pagination issues
+- no treating reviewer-scope omission as a solved bug before deciding the contract
+- no pretending one checkpoint-path fix solves every freshness/epoch problem
+- no replacing or deleting already-planned work

--- a/docs/workflow-remediation-prep.md
+++ b/docs/workflow-remediation-prep.md
@@ -4,16 +4,17 @@ Related issue: #70
 
 ## Purpose
 
-This document turns the 2026-05-19 workflow audit into durable repo guidance.
+This document turns the 2026-05-19 workflow audit into a durable supporting memo for issue `#70`.
 
-It is a **preparation track** for later improvements, not a roadmap reset.
+It is **supporting context**, not a new roadmap phase and not a backlog replacement.
 
-It exists to harden the current workflow foundation before broader follow-up work proceeds, while keeping the existing planned work intact — especially the bounded Phase 7 second-repo pilot.
+It exists to capture the concrete workflow-remediation findings in-repo while keeping the existing planned work intact — especially the bounded Phase 7 second-repo pilot.
 
 ## What this does not change
 
 - it does **not** replace `PLAN.md`
 - it does **not** replace `docs/phases/phase-7.md`
+- it does **not** replace issue `#70` as the execution-tracking surface for remediation chunks
 - it does **not** declare a one-shot workflow rewrite
 - it does **not** commit the raw local audit scratch artifacts under `tmp/`, `fanout/`, `fanin/`, `final/`, or `validation/`
 
@@ -104,26 +105,11 @@ Problem shape:
 - some docs still over-own or blur behavior
 - this weakens future maintenance and audits
 
-## Implementation chain
+## Execution tracking
 
-```mermaid
-flowchart TD
-    A[Chunk 1\nCommit distilled audit memo\nand prep phase docs] --> B[Chunk 2\nFix premature Copilot\nrequest gating]
-    B --> C[Chunk 3\nTighten checkpoint\nidentity and freshness]
-    C --> D[Chunk 4\nTighten inspect-run\nfallback honesty]
-    D --> E[Chunk 5\nDecide reviewer\nidentity scoping contract]
-    E --> F[Chunk 6\nDocs and authority\ncleanup]
-    F --> G[Resume later planned improvements\non stronger workflow footing]
-```
+Issue `#70` owns the current chunk order, Mermaid implementation chain, and follow-up PR rules.
 
-## Working rules for chunks
-
-Each follow-up PR should:
-- reference `#70`
-- stay bounded to one chunk
-- include explicit non-goals
-- include focused validation
-- update docs/contracts only where that chunk changes shipped behavior
+Use this memo for the durable findings; use the GitHub issue for the active execution sequence.
 
 ## Non-goals
 

--- a/docs/workflow-remediation-prep.md
+++ b/docs/workflow-remediation-prep.md
@@ -1,10 +1,10 @@
 # Workflow remediation preparation
 
-Related issue: `#70`
+Related issue: #70
 
 ## Purpose
 
-This document turns the 2026-05-19 workflow audit into a durable supporting memo for issue `#70`.
+This document turns the 2026-05-19 workflow audit into a durable supporting memo for issue #70.
 
 It is **supporting context**, not a new roadmap phase and not a backlog replacement.
 
@@ -14,7 +14,7 @@ It exists to capture the concrete workflow-remediation findings in-repo while ke
 
 - it does **not** replace `PLAN.md`
 - it does **not** replace `docs/phases/phase-7.md`
-- it does **not** replace issue `#70` as the execution-tracking surface for remediation chunks
+- it does **not** replace issue #70 as the execution-tracking surface for remediation chunks
 - it does **not** declare a one-shot workflow rewrite
 - it does **not** commit the raw local audit scratch artifacts under `tmp/`, `fanout/`, `fanin/`, `final/`, or `validation/`
 
@@ -107,9 +107,9 @@ Problem shape:
 
 ## Execution tracking
 
-Issue `#70` owns the current chunk order, Mermaid implementation chain, and follow-up PR rules.
+Issue #70 owns the active execution sequence for remediation chunks.
 
-Use this memo for the durable findings; use the GitHub issue for the active execution sequence.
+Use this memo for the durable findings; use the GitHub issue for the active chunk order and follow-up PR handling.
 
 ## Non-goals
 

--- a/docs/workflow-remediation-prep.md
+++ b/docs/workflow-remediation-prep.md
@@ -1,6 +1,6 @@
 # Workflow remediation preparation
 
-Related issue: #70
+Related issue: `#70`
 
 ## Purpose
 


### PR DESCRIPTION
## Summary

Add a durable workflow-remediation prep memo and align the planning/state docs around issue #70.

This chunk is docs-only. It does not change runtime behavior.

Refs #70

## Scope / context

Issue #70 now acts as the umbrella for small workflow-remediation PR chunks. This first chunk makes that work durable in the repo by:
- committing a distilled audit/prep memo
- making clear that the remediation track is preparatory hardening
- preserving the existing Phase 7 second-repo pilot instead of replacing it

Files touched:
- `docs/workflow-remediation-prep.md`
- `PLAN.md`
- `docs/IMPLEMENTATION_STATE.md`
- `docs/phases/phase-7.md`

## Acceptance criteria

- a committed durable memo captures the concrete findings behind `#70`
- the docs clearly state that the remediation track is preparatory hardening for later improvements
- the docs clearly preserve the existing Phase 7 pilot instead of replacing it
- issue `#70` remains the execution-tracking surface for the active chunk order and follow-up PR rules
- future chunk PRs have a stable committed document to reference alongside `#70`

## Definition of done

- docs-only changes are committed on a dedicated branch
- a draft PR exists
- a first local review pass is run on the PR/diff
- accepted fixes are applied
- validation is rerun
- the PR is moved to ready for review
- Copilot follow-up review/loop is started from that PR

## Non-goals

- no runtime behavior changes
- no broad docs cleanup
- no renumbering or replacement of Phase 7
- no commitment of raw `tmp/`, `fanout/`, `fanin/`, `final/`, or `validation/` artifacts
