### PR TITLE
fix: block copilot requests when ci status is unknown

### DIFF
--- a/docs/copilot-loop-state-graph.md
+++ b/docs/copilot-loop-state-graph.md
@@ -23,7 +23,7 @@ The implementation lives in:
 | `already_fixed_needs_reply_resolve` | Agent has applied a fix; threads still need reply/resolve on GitHub before re-request |
 | `ready_to_rerequest_review` | All threads resolved; Copilot has reviewed at least once; only re-request once the updated head is green or credibly green |
 | `review_request_unavailable` | Copilot review request returned `unavailable` and no observable in-progress review evidence exists; must stop/report |
-| `waiting_for_ci` | CI checks are in progress; wait before proceeding |
+| `waiting_for_ci` | CI checks are in progress or no usable CI readiness signal exists yet; wait before proceeding |
 | `blocked_needs_user_decision` | Unexpected failure (CI failure, bad request result); requires user decision |
 | `done` | PR has been merged or closed |
 
@@ -126,11 +126,11 @@ The interpreter applies rules in priority order. The first matching rule wins.
    *(Unresolved feedback always takes priority over any wait/watch path)*
 8. `(copilotReviewRequestStatus === "requested" || copilotReviewRequestStatus === "already-requested") && !copilotReviewOnCurrentHead` → `waiting_for_copilot_review`
    *(Copilot is in `requested_reviewers` or a pending review is in progress, and has not yet submitted a review on the current head; when `copilotReviewOnCurrentHead === true` the wait is concluded and the loop falls through to rule 9+)*
-9. `copilotReviewPresent && ciStatus === "pending"` → `waiting_for_ci`
-10. `copilotReviewPresent && ciStatus === "failure"` → `blocked_needs_user_decision`
+9. `copilotReviewPresent && ciStatus === "failure"` → `blocked_needs_user_decision`
+10. `copilotReviewPresent && (ciStatus === "pending" || ciStatus === "none")` → `waiting_for_ci`
 11. `copilotReviewPresent` → `ready_to_rerequest_review`
-12. `ciStatus === "pending"` → `waiting_for_ci`
-13. `ciStatus === "failure"` → `blocked_needs_user_decision`
+12. `ciStatus === "failure"` → `blocked_needs_user_decision`
+13. `ciStatus === "pending" || ciStatus === "none"` → `waiting_for_ci`
 14. Default → `pr_ready_no_feedback`
 
 When rule 11 yields `ready_to_rerequest_review`, the interpreter also emits two machine-readable flags:
@@ -172,7 +172,7 @@ Auto-detect must fail closed when review-thread state cannot be captured or pars
 
 ### Green validation precondition before follow-up re-request
 
-Re-requesting Copilot after a follow-up fix is gated on the updated head being green or credibly green. In practice: run the smallest honest local validation for the accepted fix scope, continue remediation if that validation is still known red, and continue remediation if CI/checks for the current head are known red for a fixable issue.
+Re-requesting Copilot after a follow-up fix is gated on the updated head being green or credibly green. In practice: run the smallest honest local validation for the accepted fix scope, continue remediation if that validation is still known red, continue remediation if CI/checks for the current head are known red for a fixable issue, and do not treat `ciStatus: "none"` as equivalent to green.
 
 ## Related Scripts
 

--- a/docs/copilot-loop-state-graph.md
+++ b/docs/copilot-loop-state-graph.md
@@ -42,7 +42,7 @@ pr_ready_no_feedback
 waiting_for_copilot_review
   → unresolved_feedback_present  (Copilot reviewed; unresolved threads exist)
   → ready_to_rerequest_review    (Copilot reviewed; all threads resolved)
-  → waiting_for_ci               (CI checks are running)
+  → waiting_for_ci               (CI checks are running or have not materialized yet)
 
 unresolved_feedback_present
   → already_fixed_needs_reply_resolve  (agent applied fix; threads still open on GitHub)
@@ -87,7 +87,7 @@ The snapshot is the set of observable facts that the interpreter uses to determi
 | `copilotReviewOnCurrentHead` | `boolean` | Whether a submitted (non-PENDING) Copilot review exists for the current head commit; when true the wait is done even if `requested_reviewers` has not yet cleared |
 | `unresolvedThreadCount` | `number` | Total unresolved review-thread count |
 | `actionableThreadCount` | `number` | Unresolved threads with non-bot actionable comments |
-| `ciStatus` | `"success" \| "failure" \| "pending" \| "none"` | Current CI check rollup |
+| `ciStatus` | `"success" \| "failure" \| "pending" \| "none"` | Current CI check rollup; `none` means no usable CI readiness signal yet and is not treated as green |
 | `agentFixStatus` | `"applied" \| null` | Agent-provided: `"applied"` when code has been fixed |
 
 ### Review request status values

--- a/packages/core/src/loop/copilot-loop-state.mjs
+++ b/packages/core/src/loop/copilot-loop-state.mjs
@@ -39,7 +39,7 @@ export const STATE = Object.freeze({
    * Do not sleep or watch as if review were requested.
    */
   REVIEW_REQUEST_UNAVAILABLE: "review_request_unavailable",
-  /** CI checks are in progress; wait before proceeding. */
+  /** CI checks are in progress or no usable CI readiness signal exists yet; wait before proceeding. */
   WAITING_FOR_CI: "waiting_for_ci",
   /**
    * An unexpected failure occurred (bad review-request result, CI failure, etc.)

--- a/packages/core/src/loop/copilot-loop-state.mjs
+++ b/packages/core/src/loop/copilot-loop-state.mjs
@@ -96,7 +96,7 @@ const NEXT_ACTIONS = Object.freeze({
   [STATE.ALREADY_FIXED_NEEDS_REPLY_RESOLVE]: "Reply to and resolve addressed threads on GitHub via scripts/github/reply-resolve-review-thread.mjs before re-requesting review",
   [STATE.READY_TO_REREQUEST_REVIEW]: "Re-request Copilot review via scripts/github/request-copilot-review.mjs only after smallest honest local validation is green and no known fixable CI-red state remains, or confirm the PR is done",
   [STATE.REVIEW_REQUEST_UNAVAILABLE]: "Report that Copilot review is unavailable and stop; do not sleep or watch as if review were requested",
-  [STATE.WAITING_FOR_CI]: "Wait for CI checks to complete",
+  [STATE.WAITING_FOR_CI]: "Wait for CI checks to complete or become available",
   [STATE.BLOCKED_NEEDS_USER_DECISION]: "Report the blocked state to the user and stop; do not proceed without explicit authorization",
   [STATE.DONE]: "Loop is complete; confirm merge-readiness or close",
 });
@@ -253,19 +253,19 @@ export function interpretLoopState(snapshot) {
     state = STATE.WAITING_FOR_COPILOT_REVIEW;
   } else if (s.copilotReviewPresent) {
     // Copilot has reviewed at least once; all threads resolved
-    if (s.ciStatus === "pending") {
-      state = STATE.WAITING_FOR_CI;
-    } else if (s.ciStatus === "failure") {
+    if (s.ciStatus === "failure") {
       state = STATE.BLOCKED_NEEDS_USER_DECISION;
+    } else if (s.ciStatus === "pending" || s.ciStatus === "none") {
+      state = STATE.WAITING_FOR_CI;
     } else {
       state = STATE.READY_TO_REREQUEST_REVIEW;
     }
   } else {
     // No Copilot review yet; not currently requested
-    if (s.ciStatus === "pending") {
-      state = STATE.WAITING_FOR_CI;
-    } else if (s.ciStatus === "failure") {
+    if (s.ciStatus === "failure") {
       state = STATE.BLOCKED_NEEDS_USER_DECISION;
+    } else if (s.ciStatus === "pending" || s.ciStatus === "none") {
+      state = STATE.WAITING_FOR_CI;
     } else {
       state = STATE.PR_READY_NO_FEEDBACK;
     }

--- a/packages/core/test/copilot-loop-state.test.mjs
+++ b/packages/core/test/copilot-loop-state.test.mjs
@@ -307,6 +307,20 @@ test("interpretLoopState returns pr_ready_no_feedback for open ready PR with no 
   assert.deepEqual(result.allowedTransitions, [STATE.WAITING_FOR_COPILOT_REVIEW]);
 });
 
+test("interpretLoopState returns waiting_for_ci for open PR with no review when ciStatus is none", () => {
+  const result = interpretLoopState({
+    prExists: true,
+    prNumber: 17,
+    prDraft: false,
+    copilotReviewRequestStatus: "none",
+    copilotReviewPresent: false,
+    unresolvedThreadCount: 0,
+    ciStatus: "none",
+  });
+  assert.equal(result.state, STATE.WAITING_FOR_CI);
+  assert.notEqual(result.state, STATE.PR_READY_NO_FEEDBACK);
+});
+
 test("interpretLoopState returns waiting_for_copilot_review when Copilot is in requested_reviewers", () => {
   for (const status of ["requested", "already-requested"]) {
     const result = interpretLoopState({
@@ -418,6 +432,19 @@ test("interpretLoopState returns ready_to_rerequest_review when Copilot has revi
   assert.ok(result.allowedTransitions.includes(STATE.DONE));
   assert.equal(result.autoRerequestEligible, true);
   assert.equal(result.sameHeadCleanConverged, false);
+});
+
+test("interpretLoopState returns waiting_for_ci when Copilot has reviewed and ciStatus is none", () => {
+  const result = interpretLoopState({
+    prExists: true,
+    prNumber: 17,
+    copilotReviewRequestStatus: "none",
+    copilotReviewPresent: true,
+    unresolvedThreadCount: 0,
+    ciStatus: "none",
+  });
+  assert.equal(result.state, STATE.WAITING_FOR_CI);
+  assert.notEqual(result.state, STATE.READY_TO_REREQUEST_REVIEW);
 });
 
 test("interpretLoopState returns waiting_for_ci when CI is pending and no unresolved threads", () => {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -170,6 +170,7 @@ Contract:
 - detects the current Copilot-loop state for the PR
 - requests Copilot review automatically for `pr_ready_no_feedback`
 - requests Copilot review automatically for `ready_to_rerequest_review` only when `autoRerequestEligible=true`
+- does not request or re-request Copilot review when `ciStatus` is `none`; that path remains gated as `waiting_for_ci`
 - suppresses automatic same-head clean re-request when `sameHeadCleanConverged=true`, unless `--force-rerequest-review` is used
 - when a review request is successfully issued or confirmed (including the explicit force path), re-interprets from the shared post-request wait-cycle snapshot and emits `action: "watch"` with exact `watchArgs`
 - emits one machine-readable action: `watch`, `fix`, or `stop` (`stop` means no automatic next step; terminal, blocked, or operator-decision-required states all use this action)
@@ -218,7 +219,7 @@ Snapshot schema (`--input` mode or `snapshot` field in success output):
 - `copilotReviewOnCurrentHead` {boolean} — whether a submitted (non-PENDING) Copilot review exists for the current head commit
 - `unresolvedThreadCount` {number} — total unresolved review-thread count
 - `actionableThreadCount` {number} — unresolved threads with non-bot actionable comments
-- `ciStatus` {"success"|"failure"|"pending"|"none"} — current CI check rollup
+- `ciStatus` {"success"|"failure"|"pending"|"none"} — current CI check rollup; `none` means no usable readiness signal yet and is not treated as green
 - `agentFixStatus` {"applied"|null} — agent-provided: "applied" when code has been fixed
 
 Success output shape:

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -306,6 +306,47 @@ test("copilot-pr-handoff does not request review when checks have not materializ
   }
 });
 
+test("copilot-pr-handoff does not request review when statusCheckRollup is missing on the first-request path", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-missing-rollup-first-request-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: JSON.stringify({
+          isDraft: false,
+          state: "OPEN",
+          number: 17,
+          reviews: [],
+        }) + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: EMPTY_THREADS + "\n",
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.action, "stop");
+    assert.equal(output.state, "waiting_for_ci");
+    assert.equal(output.reviewRequestStatus, undefined);
+    assert.equal(output.watchArgs, undefined);
+    assert.equal(output.snapshot.ciStatus, "none");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Handoff: unavailable → stop
 // ---------------------------------------------------------------------------

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -264,6 +264,48 @@ test("copilot-pr-handoff emits watch action when Copilot is already requested", 
   }
 });
 
+test("copilot-pr-handoff does not request review when checks have not materialized on the first-request path", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-no-checks-first-request-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: JSON.stringify({
+          isDraft: false,
+          state: "OPEN",
+          number: 17,
+          reviews: [],
+          statusCheckRollup: [],
+        }) + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: EMPTY_THREADS + "\n",
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.action, "stop");
+    assert.equal(output.state, "waiting_for_ci");
+    assert.equal(output.reviewRequestStatus, undefined);
+    assert.equal(output.watchArgs, undefined);
+    assert.equal(output.snapshot.ciStatus, "none");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Handoff: unavailable → stop
 // ---------------------------------------------------------------------------
@@ -467,7 +509,7 @@ test("copilot-pr-handoff emits watch action when 422 but Copilot has a pending r
   }
 });
 
-test("copilot-pr-handoff stops when 422 only finds a stale pending Copilot review on an older commit", async () => {
+test("copilot-pr-handoff treats stale pending Copilot review on an older commit plus no checks as waiting_for_ci", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-422-stale-pending-"));
 
   try {
@@ -504,6 +546,61 @@ test("copilot-pr-handoff stops when 422 only finds a stale pending Copilot revie
         assertArgs: ["api", "graphql"],
         stdout: `${EMPTY_THREADS}\n`,
       },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.action, "stop");
+    assert.equal(output.state, "waiting_for_ci");
+    assert.equal(output.reviewRequestStatus, undefined);
+    assert.equal(output.watchArgs, undefined);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("copilot-pr-handoff still re-requests review when a stale pending Copilot review exists on an older commit and CI is green", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-stale-pending-success-rerequest-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: JSON.stringify({
+          isDraft: false,
+          state: "OPEN",
+          number: 17,
+          headRefOid: "newsha",
+          reviews: [
+            {
+              id: "r-0",
+              author: { login: "copilot-pull-request-reviewer[bot]" },
+              state: "COMMENTED",
+              commit: { oid: "oldsha" },
+            },
+            {
+              id: "r-1",
+              author: { login: "copilot-pull-request-reviewer[bot]" },
+              state: "PENDING",
+              commit: { oid: "oldsha" },
+            },
+          ],
+          statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+        }) + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: `${EMPTY_THREADS}\n`,
+      },
       {
         assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
         stdout: '{"users":[],"teams":[]}\n',
@@ -514,12 +611,11 @@ test("copilot-pr-handoff stops when 422 only finds a stale pending Copilot revie
       },
       {
         assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
-        stderr: "gh: Reviews may only be requested from collaborators.\n",
-        exitCode: 1,
+        stdout: "https://github.com/owner/repo/pull/17\n",
       },
       {
         assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
-        stdout: '{"users":[],"teams":[]}\n',
+        stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n',
       },
       {
         assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,reviews"],
@@ -534,10 +630,10 @@ test("copilot-pr-handoff stops when 422 only finds a stale pending Copilot revie
 
     const output = JSON.parse(result.stdout);
     assert.equal(output.ok, true);
-    assert.equal(output.action, "stop");
-    assert.equal(output.state, "review_request_unavailable");
-    assert.equal(output.reviewRequestStatus, "unavailable");
-    assert.equal(output.watchArgs, undefined);
+    assert.equal(output.action, "watch");
+    assert.equal(output.state, "waiting_for_copilot_review");
+    assert.equal(output.reviewRequestStatus, "requested");
+    assert.ok(output.watchArgs, "expected watchArgs after green re-request path");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -793,6 +889,56 @@ test("copilot-pr-handoff allows explicit operator same-head re-request via --for
     assert.equal(output.snapshot.copilotReviewRequestStatus, "requested");
     assert.equal(output.snapshot.copilotReviewOnCurrentHead, false);
     assert.ok(output.watchArgs, "expected watchArgs after explicit force re-request");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("copilot-pr-handoff does not re-request review when checks have not materialized on the re-request path", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-no-checks-rerequest-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: JSON.stringify({
+          isDraft: false,
+          state: "OPEN",
+          number: 17,
+          headRefOid: "newsha",
+          reviews: [
+            {
+              id: "r-1",
+              author: { login: "copilot-pull-request-reviewer[bot]" },
+              state: "COMMENTED",
+              commit: { oid: "oldsha" },
+            },
+          ],
+          statusCheckRollup: [],
+        }) + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: EMPTY_THREADS + "\n",
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.action, "stop");
+    assert.equal(output.state, "waiting_for_ci");
+    assert.equal(output.reviewRequestStatus, undefined);
+    assert.equal(output.watchArgs, undefined);
+    assert.equal(output.snapshot.ciStatus, "none");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/detect-copilot-loop-state.test.mjs
+++ b/test/loop/detect-copilot-loop-state.test.mjs
@@ -253,7 +253,7 @@ test("detect-copilot-loop-state --input returns done for merged PR snapshot", as
 // Auto-detect mode via gh stubs
 // ---------------------------------------------------------------------------
 
-test("detect-copilot-loop-state auto-detect returns pr_ready_no_feedback for open PR with no review", async () => {
+test("detect-copilot-loop-state auto-detect returns waiting_for_ci for open PR with no review when checks have not materialized", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-ready-"));
 
   try {
@@ -299,11 +299,12 @@ test("detect-copilot-loop-state auto-detect returns pr_ready_no_feedback for ope
 
     const output = JSON.parse(result.stdout);
     assert.equal(output.ok, true);
-    assert.equal(output.state, "pr_ready_no_feedback");
+    assert.equal(output.state, "waiting_for_ci");
     assert.equal(output.snapshot.prExists, true);
     assert.equal(output.snapshot.prNumber, 17);
     assert.equal(output.snapshot.copilotReviewRequestStatus, "none");
     assert.equal(output.snapshot.copilotReviewPresent, false);
+    assert.equal(output.snapshot.ciStatus, "none");
     assert.equal(output.snapshot.unresolvedThreadCount, 0);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
@@ -531,11 +532,12 @@ test("detect-copilot-loop-state auto-detect ignores stale pending Copilot review
     assert.equal(result.code, 0);
 
     const output = JSON.parse(result.stdout);
-    assert.equal(output.state, "ready_to_rerequest_review");
+    assert.equal(output.state, "waiting_for_ci");
     assert.equal(output.snapshot.copilotReviewPresent, true);
     assert.equal(output.snapshot.copilotReviewRequestStatus, "none");
     assert.equal(output.snapshot.copilotReviewOnCurrentHead, false);
-    assert.equal(output.autoRerequestEligible, true);
+    assert.equal(output.snapshot.ciStatus, "none");
+    assert.equal(output.autoRerequestEligible, false);
     assert.equal(output.sameHeadCleanConverged, false);
   } finally {
     await rm(tempDir, { recursive: true, force: true });

--- a/test/loop/detect-copilot-loop-state.test.mjs
+++ b/test/loop/detect-copilot-loop-state.test.mjs
@@ -311,6 +311,48 @@ test("detect-copilot-loop-state auto-detect returns waiting_for_ci for open PR w
   }
 });
 
+test("detect-copilot-loop-state auto-detect returns waiting_for_ci when statusCheckRollup is missing", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-missing-rollup-"));
+
+  try {
+    const emptyThreads = JSON.stringify({
+      data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } },
+    });
+
+    const { env } = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: JSON.stringify({
+          isDraft: false,
+          state: "OPEN",
+          number: 17,
+          reviews: [],
+        }) + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: emptyThreads + "\n",
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.state, "waiting_for_ci");
+    assert.equal(output.snapshot.ciStatus, "none");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("detect-copilot-loop-state auto-detect returns unresolved_feedback_present when threads exist", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-unresolved-"));
   const fixtureText = await readFile(fixturePath, "utf8");


### PR DESCRIPTION
## Summary

Block automatic Copilot request/re-request flow when CI is effectively unknown because `statusCheckRollup` is empty or absent.

Refs #70

## Scope / context

This is issue #70 chunk 2: the first bounded runtime fix after the merged prep memo/docs slice.

Problem:
- `detect-copilot-loop-state` normalizes empty/missing `statusCheckRollup` to `ciStatus: "none"`
- the shared interpreter previously treated that like green in request-eligible branches
- `copilot-pr-handoff` could therefore request or re-request Copilot review too early

This slice keeps the detector shape unchanged, but changes the shared interpreter contract so `ciStatus: "none"` is non-green and remains gated as `waiting_for_ci`.

Files touched:
- `packages/core/src/loop/copilot-loop-state.mjs`
- `packages/core/test/copilot-loop-state.test.mjs`
- `test/loop/detect-copilot-loop-state.test.mjs`
- `test/loop/copilot-pr-handoff.test.mjs`
- `docs/copilot-loop-state-graph.md`
- `scripts/README.md`

## Acceptance criteria

- empty/missing `statusCheckRollup` still normalizes to `snapshot.ciStatus === "none"`
- `ciStatus: "none"` no longer behaves like green in request-eligible branches
- no-review + `none` => `waiting_for_ci`
- prior-review + `none` => `waiting_for_ci`
- handoff does not request or re-request Copilot review when state is `waiting_for_ci` due to `none`
- green/pending/failure behavior remains unchanged otherwise
- no new public state, snapshot field, or CLI surface is added

## Definition of done

- bounded code/tests/docs slice is committed on a dedicated branch
- a draft PR exists
- local review gate is run on the PR/diff
- accepted fixes are applied if needed
- validation is rerun
- the PR is moved to ready for review once we are happy
- Copilot review is requested and the follow-up loop is started for the fresh head

## Non-goals

- no checkpoint freshness work
- no inspect-run fallback work
- no reviewer-scope or ownership-routing changes
- no new public `ciStatus` value
- no new loop state
- no repo-policy solution for intentionally no-CI repos
- no broad docs cleanup
