### PR TITLE
fix: qualify checkpoint paths by repo and head

### DIFF
--- a/packages/core/src/loop/run-inspection.mjs
+++ b/packages/core/src/loop/run-inspection.mjs
@@ -126,6 +126,8 @@ export function mapOuterActionToStatusClass(outerAction) {
  *   Live reviewer inner-loop facts. null when live detection was unavailable.
  * @param {object | null} params.existingCheckpoint
  *   Previously persisted outer-loop checkpoint (read-only). null when not found.
+ * @param {string | null} [params.checkpointEvidencePath]
+ *   Concrete checkpoint file path used by the caller when a checkpoint was found.
  * @param {{ copilot: "ok"|"failed", reviewer: "ok"|"failed" }} params.liveAvailability
  *   Tracks whether each detector/interpreter path succeeded ("ok") or failed ("failed").
  * @param {{ copilot?: "live"|"input", reviewer?: "live"|"input" }} [params.evidenceSourceKinds]
@@ -149,6 +151,7 @@ export function composeRunInspectionSnapshot({
   copilotEvidence,
   reviewerEvidence,
   existingCheckpoint,
+  checkpointEvidencePath = null,
   liveAvailability,
   evidenceSourceKinds = { copilot: "live", reviewer: "live" },
   explicitTargetMissing = false,
@@ -235,7 +238,9 @@ export function composeRunInspectionSnapshot({
   // -------------------------------------------------------------------------
 
   if (existingCheckpoint !== null) {
-    evidenceCheckpoint.push(`tmp/copilot-loop/pr-${pr}/outer-loop-state.json`);
+    if (checkpointEvidencePath !== null) {
+      evidenceCheckpoint.push(checkpointEvidencePath);
+    }
 
     if (bothLiveOk && outerAction !== undefined) {
       // Check for conflicts between live-derived action and checkpoint

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -330,7 +330,7 @@ Contract:
   and reviewer `waiting_for_re_request` as outer-loop-owned `continue_wait` states
 - stops with `unsafe_local_edit_requires_isolation` when the next step needs local execution or
   mutation and the checkout is dirty or detached
-- persists bounded checkpoint state to `tmp/copilot-loop/pr-<n>/outer-loop-state.json` for
+- persists bounded checkpoint state to `tmp/copilot-loop/<owner>/<repo>/pr-<n>/outer-loop-state.json` for
   async continuation and false-positive wakeup detection
 - emits an additive `conductorRouting` field with the conductor-owned routing outcome, derived
   outer action, stop reason when relevant, and any machine-readable handoff envelope

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -364,6 +364,8 @@ Contract:
   status class, trust/source semantics, evidence, markers, and best-effort drill-down layers
 - reports not-found or unavailable targets as structured success output with `statusClass: "unknown"`
   rather than by throwing a synthetic blocked-run error
+- looks for checkpoints at the repo-qualified default path `tmp/copilot-loop/<owner>/<repo>/pr-<n>/outer-loop-state.json`
+- during transition, may read the legacy default path `tmp/copilot-loop/pr-<n>/outer-loop-state.json` only when the checkpoint file's embedded `repo` and `pr` match the explicit target
 - surfaces steering as a best-effort drill-down layer when `--steering-state-file` is provided
 
 Success output shape:

--- a/scripts/loop/_checkpoint-paths.mjs
+++ b/scripts/loop/_checkpoint-paths.mjs
@@ -1,0 +1,37 @@
+import path from "node:path";
+
+function splitRepo(repo) {
+  if (typeof repo !== "string") {
+    throw new Error("repo must be a string");
+  }
+
+  const normalized = repo.trim().toLowerCase();
+  const parts = normalized.split("/");
+
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new Error(`repo must be owner/name, received ${repo}`);
+  }
+
+  return { owner: parts[0], name: parts[1], normalized };
+}
+
+export function buildDefaultCheckpointDir(repo, pr) {
+  const { owner, name } = splitRepo(repo);
+  return path.join("tmp", "copilot-loop", owner, name, `pr-${pr}`);
+}
+
+export function buildLegacyDefaultCheckpointDir(pr) {
+  return path.join("tmp", "copilot-loop", `pr-${pr}`);
+}
+
+export function buildCheckpointFilePath(checkpointDir) {
+  return path.join(checkpointDir, "outer-loop-state.json");
+}
+
+export function buildDefaultCheckpointFilePath(repo, pr) {
+  return buildCheckpointFilePath(buildDefaultCheckpointDir(repo, pr));
+}
+
+export function buildLegacyDefaultCheckpointFilePath(pr) {
+  return buildCheckpointFilePath(buildLegacyDefaultCheckpointDir(pr));
+}

--- a/scripts/loop/inspect-run.mjs
+++ b/scripts/loop/inspect-run.mjs
@@ -56,6 +56,11 @@ import { fileURLToPath } from "node:url";
 import { formatCliError, parseJsonText } from "../_core-helpers.mjs";
 import { parseRepoSlug } from "../github/capture-review-threads.mjs";
 import { autoDetectSnapshot as autoDetectCopilotSnapshot } from "./detect-copilot-loop-state.mjs";
+import {
+  buildCheckpointFilePath,
+  buildDefaultCheckpointDir,
+  buildLegacyDefaultCheckpointDir,
+} from "./_checkpoint-paths.mjs";
 import { autoDetectReviewerSnapshot } from "./detect-reviewer-loop-state.mjs";
 import {
   interpretLoopState,
@@ -217,30 +222,42 @@ export function parseInspectRunCliArgs(argv) {
 // Checkpoint read (read-only; no writes)
 // ---------------------------------------------------------------------------
 
-function defaultCheckpointDir(pr) {
-  return path.join("tmp", "copilot-loop", `pr-${pr}`);
+function defaultCheckpointDir(repo, pr) {
+  return buildDefaultCheckpointDir(repo, pr);
 }
 
 /**
  * Read the existing checkpoint if it exists. Returns null if not found.
  * This is a read-only operation; the checkpoint is never written here.
  *
+ * @param {string} repo
  * @param {number} pr
- * @returns {Promise<object|null>}
+ * @returns {Promise<{ checkpoint: object|null, filePath: string|null }>}
  */
-async function readExistingCheckpoint(pr) {
-  const filePath = path.join(defaultCheckpointDir(pr), "outer-loop-state.json");
+async function readExistingCheckpoint(repo, pr) {
+  const normalizedRepo = repo.trim().toLowerCase();
+  const preferredDir = defaultCheckpointDir(normalizedRepo, pr);
+  const preferredPath = buildCheckpointFilePath(preferredDir);
 
   try {
-    const text = await readFile(filePath, "utf8");
-    return parseJsonText(text);
+    const text = await readFile(preferredPath, "utf8");
+    return { checkpoint: parseJsonText(text), filePath: preferredPath };
   } catch (error) {
-    if (error && error.code === "ENOENT") {
-      return null;
+    if (!error || error.code !== "ENOENT") {
+      return { checkpoint: null, filePath: null };
     }
-    // Non-ENOENT failures (e.g. corrupt JSON, permissions) are surfaced as
-    // missing rather than fatal so the inspector degrades gracefully.
-    return null;
+  }
+
+  const legacyPath = buildCheckpointFilePath(buildLegacyDefaultCheckpointDir(pr));
+  try {
+    const text = await readFile(legacyPath, "utf8");
+    const checkpoint = parseJsonText(text);
+    if (checkpoint?.repo === normalizedRepo && checkpoint?.pr === pr) {
+      return { checkpoint, filePath: legacyPath };
+    }
+    return { checkpoint: null, filePath: null };
+  } catch {
+    return { checkpoint: null, filePath: null };
   }
 }
 
@@ -345,7 +362,7 @@ export async function inspectRun(options, { env = process.env, ghCommand = "gh" 
   // Read existing checkpoint (read-only)
   // -------------------------------------------------------------------------
 
-  const existingCheckpoint = await readExistingCheckpoint(pr);
+  const { checkpoint: existingCheckpoint, filePath: checkpointEvidencePath } = await readExistingCheckpoint(repo, pr);
 
   // -------------------------------------------------------------------------
   // Derive outerAction from best-available states
@@ -407,6 +424,7 @@ export async function inspectRun(options, { env = process.env, ghCommand = "gh" 
     copilotEvidence,
     reviewerEvidence,
     existingCheckpoint,
+    checkpointEvidencePath,
     liveAvailability: { copilot: copilotLiveStatus, reviewer: reviewerLiveStatus },
     evidenceSourceKinds,
     explicitTargetMissing,

--- a/scripts/loop/outer-loop.mjs
+++ b/scripts/loop/outer-loop.mjs
@@ -83,7 +83,7 @@ Output (stdout, JSON):
       "stopReason": null|"...", "handoffEnvelope": { ... } },
     "checkpoint": { "pr": N, "repo": "...", "outerAction": "...",
       "copilotState": "...", "reviewerState": "...", "reason": null|"...",
-      "timestamp": "...", "waitCycles": N } }
+      "timestamp": "...", "waitCycles": N, "headSha": "..."|null } }
 
 Outer actions:
   continue_wait          Durable outer-loop wait state; re-run after bounded wait

--- a/scripts/loop/outer-loop.mjs
+++ b/scripts/loop/outer-loop.mjs
@@ -14,7 +14,7 @@
  *   - done                   PR is merged or closed
  *
  * A minimal checkpoint is persisted to
- *   tmp/copilot-loop/pr-<n>/outer-loop-state.json
+ *   tmp/copilot-loop/<owner>/<repo>/pr-<n>/outer-loop-state.json
  * to support async continuation and debugging.  GitHub/PR state is always
  * authoritative; the checkpoint is advisory only.
  *
@@ -25,7 +25,7 @@
  *       "stopReason": null|"...", "handoffEnvelope": { ... } },
  *     "checkpoint": { "pr": N, "repo": "...", "outerAction": "...",
  *       "copilotState": "...", "reviewerState": "...", "reason": null|"...",
- *       "timestamp": "...", "waitCycles": N } }
+ *       "timestamp": "...", "waitCycles": N, "headSha": "..."|null } }
  *
  * Failure behavior:
  *   Argument/usage errors emit { "ok": false, "error": "...", "usage": "..." }
@@ -40,6 +40,11 @@ import { fileURLToPath } from "node:url";
 import { formatCliError, parseJsonText } from "../_core-helpers.mjs";
 import { parseRepoSlug } from "../github/capture-review-threads.mjs";
 import { autoDetectSnapshot as autoDetectCopilotSnapshot } from "./detect-copilot-loop-state.mjs";
+import {
+  buildCheckpointFilePath,
+  buildDefaultCheckpointDir,
+  buildLegacyDefaultCheckpointDir,
+} from "./_checkpoint-paths.mjs";
 import { autoDetectReviewerSnapshot } from "./detect-reviewer-loop-state.mjs";
 import {
   interpretLoopState,
@@ -65,7 +70,7 @@ Required:
 Optional:
   --reviewer-login <login>              Reviewer login for reviewer-loop detection
   --checkpoint-dir <dir>                Directory for checkpoint artifact
-                                        (default: tmp/copilot-loop/pr-<n>/)
+                                        (default: tmp/copilot-loop/<owner>/<repo>/pr-<n>/)
   --copilot-input <path>                Path to a pre-built copilot snapshot JSON
                                         (skips live copilot detection; for testing)
   --reviewer-input <path>               Path to a pre-built reviewer snapshot JSON
@@ -262,8 +267,8 @@ async function checkGitStatus({ env = process.env, gitCommand = "git" } = {}) {
 /**
  * Build the default checkpoint directory path from repo/pr.
  */
-function defaultCheckpointDir(pr) {
-  return path.join("tmp", "copilot-loop", `pr-${pr}`);
+function defaultCheckpointDir(repo, pr) {
+  return buildDefaultCheckpointDir(repo, pr);
 }
 
 /**
@@ -273,7 +278,7 @@ function defaultCheckpointDir(pr) {
  * @returns {Promise<object|null>}
  */
 async function readCheckpoint(checkpointDir) {
-  const filePath = path.join(checkpointDir, "outer-loop-state.json");
+  const filePath = buildCheckpointFilePath(checkpointDir);
 
   try {
     const text = await readFile(filePath, "utf8");
@@ -294,8 +299,52 @@ async function readCheckpoint(checkpointDir) {
  */
 async function writeCheckpoint(checkpointDir, checkpoint) {
   await mkdir(checkpointDir, { recursive: true });
-  const filePath = path.join(checkpointDir, "outer-loop-state.json");
+  const filePath = buildCheckpointFilePath(checkpointDir);
   await writeFile(filePath, `${JSON.stringify(checkpoint, null, 2)}\n`, "utf8");
+}
+
+async function readResolvedCheckpoint({ repo, pr, checkpointDir }) {
+  if (checkpointDir !== undefined) {
+    return { checkpoint: await readCheckpoint(checkpointDir), filePath: buildCheckpointFilePath(checkpointDir) };
+  }
+
+  const preferredDir = defaultCheckpointDir(repo, pr);
+  const preferredCheckpoint = await readCheckpoint(preferredDir);
+  if (preferredCheckpoint !== null) {
+    return {
+      checkpoint: preferredCheckpoint,
+      filePath: buildCheckpointFilePath(preferredDir),
+    };
+  }
+
+  const legacyDir = buildLegacyDefaultCheckpointDir(pr);
+  const legacyCheckpoint = await readCheckpoint(legacyDir);
+  if (legacyCheckpoint !== null
+    && legacyCheckpoint.repo === repo
+    && legacyCheckpoint.pr === pr) {
+    return {
+      checkpoint: legacyCheckpoint,
+      filePath: buildCheckpointFilePath(legacyDir),
+    };
+  }
+
+  return {
+    checkpoint: null,
+    filePath: buildCheckpointFilePath(preferredDir),
+  };
+}
+
+function shouldCarryForwardWaitCycles(previousCheckpoint, { repo, pr, headSha, outerAction }) {
+  return previousCheckpoint !== null
+    && previousCheckpoint.outerAction === "continue_wait"
+    && outerAction === "continue_wait"
+    && previousCheckpoint.repo === repo
+    && previousCheckpoint.pr === pr
+    && typeof previousCheckpoint.headSha === "string"
+    && previousCheckpoint.headSha.length > 0
+    && typeof headSha === "string"
+    && headSha.length > 0
+    && previousCheckpoint.headSha === headSha;
 }
 
 // ---------------------------------------------------------------------------
@@ -345,7 +394,7 @@ export function decideOuterAction({ copilotState, reviewerState, gitStatus }) {
 export async function runOuterLoop(options, { env = process.env, ghCommand = "gh", gitCommand = "git" } = {}) {
   const { repo, pr, reviewerLogin, copilotInputPath, reviewerInputPath } = options;
   const normalizedRepo = repo.trim().toLowerCase();
-  const checkpointDir = options.checkpointDir ?? defaultCheckpointDir(pr);
+  const checkpointDir = options.checkpointDir ?? defaultCheckpointDir(normalizedRepo, pr);
 
   // Detect copilot state
   let copilotSnapshot;
@@ -369,6 +418,9 @@ export async function runOuterLoop(options, { env = process.env, ghCommand = "gh
     );
   }
   const reviewerInterpretation = interpretReviewerLoopState(reviewerSnapshot);
+  const currentHeadSha = typeof reviewerSnapshot?.prHeadSha === "string" && reviewerSnapshot.prHeadSha.length > 0
+    ? reviewerSnapshot.prHeadSha
+    : null;
 
   // Check git status
   const gitStatus = await checkGitStatus({ env, gitCommand });
@@ -392,9 +444,20 @@ export async function runOuterLoop(options, { env = process.env, ghCommand = "gh
   const outerReason = conductorRouting.stopReason;
 
   // Read previous checkpoint to track wait cycles
-  const prevCheckpoint = await readCheckpoint(checkpointDir);
+  const { checkpoint: prevCheckpoint } = await readResolvedCheckpoint({
+    repo: normalizedRepo,
+    pr,
+    checkpointDir: options.checkpointDir,
+  });
   const prevWaitCycles = typeof prevCheckpoint?.waitCycles === "number" ? prevCheckpoint.waitCycles : 0;
-  const waitCycles = outerAction === "continue_wait" ? prevWaitCycles + 1 : 0;
+  const waitCycles = shouldCarryForwardWaitCycles(prevCheckpoint, {
+    repo: normalizedRepo,
+    pr,
+    headSha: currentHeadSha,
+    outerAction,
+  })
+    ? prevWaitCycles + 1
+    : (outerAction === "continue_wait" ? 1 : 0);
 
   // Build and persist checkpoint
   const checkpoint = {
@@ -406,6 +469,7 @@ export async function runOuterLoop(options, { env = process.env, ghCommand = "gh
     reason: outerReason ?? null,
     timestamp: new Date().toISOString(),
     waitCycles,
+    headSha: currentHeadSha,
   };
 
   await writeCheckpoint(checkpointDir, checkpoint);

--- a/test/loop/inspect-run.test.mjs
+++ b/test/loop/inspect-run.test.mjs
@@ -989,6 +989,48 @@ test("inspect-run CLI: reads checkpoint from repo-qualified default path", async
   });
 });
 
+test("inspect-run CLI: reads the repo-qualified checkpoint for the targeted repo when two repos share a PR number", async () => {
+  await withTempDir(async (tempDir) => {
+    const checkpointPathA = path.join(tempDir, "tmp", "copilot-loop", "owner", "repo-a", "pr-55", "outer-loop-state.json");
+    const checkpointPathB = path.join(tempDir, "tmp", "copilot-loop", "owner", "repo-b", "pr-55", "outer-loop-state.json");
+    await mkdir(path.dirname(checkpointPathA), { recursive: true });
+    await mkdir(path.dirname(checkpointPathB), { recursive: true });
+    await writeJson(checkpointPathA, {
+      pr: 55,
+      repo: "owner/repo-a",
+      outerAction: "continue_wait",
+      copilotState: "waiting_for_copilot_review",
+      reviewerState: "waiting_for_author_followup",
+      reason: null,
+      timestamp: "2026-05-17T10:00:00Z",
+      waitCycles: 3,
+      headSha: "abc123",
+    });
+    await writeJson(checkpointPathB, {
+      pr: 55,
+      repo: "owner/repo-b",
+      outerAction: "stop",
+      copilotState: "review_request_unavailable",
+      reviewerState: "waiting_for_author_followup",
+      reason: "review_unavailable",
+      timestamp: "2026-05-17T10:00:00Z",
+      waitCycles: 1,
+      headSha: "def456",
+    });
+
+    const result = await runNode(["--repo", "owner/repo-b", "--pr", "55"], {
+      cwd: tempDir,
+      env: { ...process.env, PATH: tempDir },
+    });
+
+    assert.equal(result.code, 0, `stderr: ${result.stderr}`);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.sourceMode, SOURCE_MODE.CHECKPOINT_ONLY);
+    assert.equal(output.evidence.checkpoint[0], path.join("tmp", "copilot-loop", "owner", "repo-b", "pr-55", "outer-loop-state.json"));
+    assert.equal(output.outerAction, "stop");
+  });
+});
+
 test("inspect-run CLI: reads matching legacy checkpoint as fallback when repo input casing differs", async () => {
   await withTempDir(async (tempDir) => {
     const checkpointPath = path.join(tempDir, "tmp", "copilot-loop", "pr-55", "outer-loop-state.json");

--- a/test/loop/inspect-run.test.mjs
+++ b/test/loop/inspect-run.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
@@ -294,6 +294,7 @@ test("composeRunInspectionSnapshot: checkpoint-only → checkpoint-only sourceMo
     copilotEvidence: null,
     reviewerEvidence: null,
     existingCheckpoint,
+    checkpointEvidencePath: "tmp/copilot-loop/owner/repo/pr-55/outer-loop-state.json",
     liveAvailability: { copilot: "failed", reviewer: "failed" },
     steeringLocatorPath: null,
     steeringEvidence: null,
@@ -318,7 +319,7 @@ test("composeRunInspectionSnapshot: checkpoint-only → checkpoint-only sourceMo
 
   // Checkpoint listed in evidence.checkpoint
   assert.ok(snapshot.evidence.checkpoint.length > 0);
-  assert.ok(snapshot.evidence.checkpoint[0].includes("pr-55"));
+  assert.equal(snapshot.evidence.checkpoint[0], "tmp/copilot-loop/owner/repo/pr-55/outer-loop-state.json");
 });
 
 test("composeRunInspectionSnapshot: no live and no checkpoint → unavailable, unknown statusClass", () => {
@@ -957,6 +958,132 @@ test("inspect-run CLI: --steering-state-file given and file exists → available
     assert.equal(output.layers.steering.status, "available");
     assert.equal(output.layers.steering.locatorPath, steeringPath);
     assert.ok(typeof output.layers.steering.state === "object");
+  });
+});
+
+test("inspect-run CLI: reads checkpoint from repo-qualified default path", async () => {
+  await withTempDir(async (tempDir) => {
+    const checkpointPath = path.join(tempDir, "tmp", "copilot-loop", "owner", "repo", "pr-55", "outer-loop-state.json");
+    await mkdir(path.dirname(checkpointPath), { recursive: true });
+    await writeJson(checkpointPath, {
+      pr: 55,
+      repo: "owner/repo",
+      outerAction: "continue_wait",
+      copilotState: "waiting_for_copilot_review",
+      reviewerState: "waiting_for_author_followup",
+      reason: null,
+      timestamp: "2026-05-17T10:00:00Z",
+      waitCycles: 3,
+      headSha: "abc123",
+    });
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "55"], {
+      cwd: tempDir,
+      env: { ...process.env, PATH: tempDir },
+    });
+
+    assert.equal(result.code, 0, `stderr: ${result.stderr}`);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.sourceMode, SOURCE_MODE.CHECKPOINT_ONLY);
+    assert.equal(output.evidence.checkpoint[0], path.join("tmp", "copilot-loop", "owner", "repo", "pr-55", "outer-loop-state.json"));
+  });
+});
+
+test("inspect-run CLI: reads matching legacy checkpoint as fallback when repo input casing differs", async () => {
+  await withTempDir(async (tempDir) => {
+    const checkpointPath = path.join(tempDir, "tmp", "copilot-loop", "pr-55", "outer-loop-state.json");
+    await mkdir(path.dirname(checkpointPath), { recursive: true });
+    await writeJson(checkpointPath, {
+      pr: 55,
+      repo: "owner/repo",
+      outerAction: "continue_wait",
+      copilotState: "waiting_for_copilot_review",
+      reviewerState: "waiting_for_author_followup",
+      reason: null,
+      timestamp: "2026-05-17T10:00:00Z",
+      waitCycles: 3,
+      headSha: "abc123",
+    });
+
+    const result = await runNode(["--repo", "Owner/Repo", "--pr", "55"], {
+      cwd: tempDir,
+      env: { ...process.env, PATH: tempDir },
+    });
+
+    assert.equal(result.code, 0, `stderr: ${result.stderr}`);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.sourceMode, SOURCE_MODE.CHECKPOINT_ONLY);
+    assert.equal(output.evidence.checkpoint[0], path.join("tmp", "copilot-loop", "pr-55", "outer-loop-state.json"));
+  });
+});
+
+test("inspect-run CLI: prefers repo-qualified checkpoint when both new and legacy files exist", async () => {
+  await withTempDir(async (tempDir) => {
+    const repoQualifiedPath = path.join(tempDir, "tmp", "copilot-loop", "owner", "repo", "pr-55", "outer-loop-state.json");
+    const legacyPath = path.join(tempDir, "tmp", "copilot-loop", "pr-55", "outer-loop-state.json");
+    await mkdir(path.dirname(repoQualifiedPath), { recursive: true });
+    await mkdir(path.dirname(legacyPath), { recursive: true });
+    await writeJson(repoQualifiedPath, {
+      pr: 55,
+      repo: "owner/repo",
+      outerAction: "continue_wait",
+      copilotState: "waiting_for_copilot_review",
+      reviewerState: "waiting_for_author_followup",
+      reason: null,
+      timestamp: "2026-05-17T10:00:00Z",
+      waitCycles: 3,
+      headSha: "abc123",
+    });
+    await writeJson(legacyPath, {
+      pr: 55,
+      repo: "owner/repo",
+      outerAction: "stop",
+      copilotState: "review_request_unavailable",
+      reviewerState: "waiting_for_author_followup",
+      reason: "review_unavailable",
+      timestamp: "2026-05-16T10:00:00Z",
+      waitCycles: 9,
+      headSha: "oldsha",
+    });
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "55"], {
+      cwd: tempDir,
+      env: { ...process.env, PATH: tempDir },
+    });
+
+    assert.equal(result.code, 0, `stderr: ${result.stderr}`);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.sourceMode, SOURCE_MODE.CHECKPOINT_ONLY);
+    assert.equal(output.evidence.checkpoint[0], path.join("tmp", "copilot-loop", "owner", "repo", "pr-55", "outer-loop-state.json"));
+    assert.equal(output.outerAction, "continue_wait");
+  });
+});
+
+test("inspect-run CLI: ignores legacy fallback checkpoint when repo does not match target", async () => {
+  await withTempDir(async (tempDir) => {
+    const checkpointPath = path.join(tempDir, "tmp", "copilot-loop", "pr-55", "outer-loop-state.json");
+    await mkdir(path.dirname(checkpointPath), { recursive: true });
+    await writeJson(checkpointPath, {
+      pr: 55,
+      repo: "other/repo",
+      outerAction: "continue_wait",
+      copilotState: "waiting_for_copilot_review",
+      reviewerState: "waiting_for_author_followup",
+      reason: null,
+      timestamp: "2026-05-17T10:00:00Z",
+      waitCycles: 3,
+      headSha: "abc123",
+    });
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "55"], {
+      cwd: tempDir,
+      env: { ...process.env, PATH: tempDir },
+    });
+
+    assert.equal(result.code, 0, `stderr: ${result.stderr}`);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.sourceMode, SOURCE_MODE.UNAVAILABLE);
+    assert.deepEqual(output.evidence.checkpoint, []);
   });
 });
 

--- a/test/loop/outer-loop.test.mjs
+++ b/test/loop/outer-loop.test.mjs
@@ -1182,6 +1182,69 @@ test("outer-loop: legacy default checkpoint fallback is used only for matching r
   }
 });
 
+test("outer-loop: prefers repo-qualified checkpoint when both new and legacy checkpoints exist", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-outer-prefer-repo-qualified-"));
+
+  try {
+    const copilotSnapshotPath = path.join(tempDir, "copilot-snapshot.json");
+    const reviewerSnapshotPath = path.join(tempDir, "reviewer-snapshot.json");
+    const legacyCheckpointPath = path.join(tempDir, "tmp", "copilot-loop", "pr-47", "outer-loop-state.json");
+    const repoQualifiedPath = path.join(tempDir, "tmp", "copilot-loop", "owner", "repo", "pr-47", "outer-loop-state.json");
+
+    await writeJson(copilotSnapshotPath, {
+      prExists: true,
+      prNumber: 47,
+      prDraft: false,
+      prMerged: false,
+      prClosed: false,
+      copilotReviewRequestStatus: "requested",
+      copilotReviewPresent: false,
+      unresolvedThreadCount: 0,
+      actionableThreadCount: 0,
+      ciStatus: "success",
+    });
+    await writeJson(reviewerSnapshotPath, {
+      prExists: true,
+      prNumber: 47,
+      prHeadSha: "abc123",
+    });
+    await mkdir(path.dirname(legacyCheckpointPath), { recursive: true });
+    await mkdir(path.dirname(repoQualifiedPath), { recursive: true });
+    await writeJson(legacyCheckpointPath, {
+      pr: 47,
+      repo: "owner/repo",
+      outerAction: "continue_wait",
+      copilotState: "waiting_for_copilot_review",
+      reviewerState: "waiting_for_author_followup",
+      reason: null,
+      timestamp: "2026-05-16T10:00:00Z",
+      waitCycles: 9,
+      headSha: "abc123",
+    });
+    await writeJson(repoQualifiedPath, {
+      pr: 47,
+      repo: "owner/repo",
+      outerAction: "continue_wait",
+      copilotState: "waiting_for_copilot_review",
+      reviewerState: "waiting_for_author_followup",
+      reason: null,
+      timestamp: "2026-05-17T10:00:00Z",
+      waitCycles: 2,
+      headSha: "abc123",
+    });
+
+    const env = await writeGitStub(tempDir, { porcelainOutput: "", headRef: "main" });
+    const run = await runNode([
+      "--repo", "owner/repo", "--pr", "47",
+      "--copilot-input", copilotSnapshotPath,
+      "--reviewer-input", reviewerSnapshotPath,
+    ], { env, cwd: tempDir });
+    assert.equal(JSON.parse(run.stdout).checkpoint.waitCycles, 3);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("outer-loop: wait cycles reset to 0 when outer action changes from continue_wait to reenter_copilot_loop", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-outer-wait-reset-"));
 

--- a/test/loop/outer-loop.test.mjs
+++ b/test/loop/outer-loop.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
@@ -918,6 +918,265 @@ test("outer-loop: wait cycles accumulate correctly across multiple re-detect run
     const out3 = JSON.parse(run3.stdout);
     assert.equal(out3.outerAction, "continue_wait");
     assert.equal(out3.checkpoint.waitCycles, 3);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("outer-loop: default checkpoint path is repo-qualified", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-outer-default-checkpoint-path-"));
+
+  try {
+    const copilotSnapshotPath = path.join(tempDir, "copilot-snapshot.json");
+    const reviewerSnapshotPath = path.join(tempDir, "reviewer-snapshot.json");
+
+    await writeJson(copilotSnapshotPath, {
+      prExists: true,
+      prNumber: 47,
+      prDraft: false,
+      prMerged: false,
+      prClosed: false,
+      copilotReviewRequestStatus: "requested",
+      copilotReviewPresent: false,
+      unresolvedThreadCount: 0,
+      actionableThreadCount: 0,
+      ciStatus: "success",
+    });
+    await writeJson(reviewerSnapshotPath, {
+      prExists: true,
+      prNumber: 47,
+      prHeadSha: "abc123",
+    });
+
+    const env = await writeGitStub(tempDir, { porcelainOutput: "", headRef: "main" });
+    const result = await runNode([
+      "--repo", "Owner/Repo", "--pr", "47",
+      "--copilot-input", copilotSnapshotPath,
+      "--reviewer-input", reviewerSnapshotPath,
+    ], { env, cwd: tempDir });
+
+    assert.equal(result.code, 0);
+    const output = JSON.parse(result.stdout);
+    const checkpointPath = path.join(tempDir, "tmp", "copilot-loop", "owner", "repo", "pr-47", "outer-loop-state.json");
+    const { readFile: rf } = await import("node:fs/promises");
+    const checkpointText = await rf(checkpointPath, "utf8");
+    assert.ok(checkpointText.includes('"repo": "owner/repo"'));
+    assert.equal(output.checkpoint.headSha, "abc123");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("outer-loop: cross-repo default checkpoints do not share waitCycles", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-outer-repo-qualified-wait-"));
+
+  try {
+    const copilotSnapshotPath = path.join(tempDir, "copilot-snapshot.json");
+    const reviewerSnapshotPath = path.join(tempDir, "reviewer-snapshot.json");
+
+    await writeJson(copilotSnapshotPath, {
+      prExists: true,
+      prNumber: 47,
+      prDraft: false,
+      prMerged: false,
+      prClosed: false,
+      copilotReviewRequestStatus: "requested",
+      copilotReviewPresent: false,
+      unresolvedThreadCount: 0,
+      actionableThreadCount: 0,
+      ciStatus: "success",
+    });
+    await writeJson(reviewerSnapshotPath, {
+      prExists: true,
+      prNumber: 47,
+      prHeadSha: "abc123",
+    });
+
+    const env = await writeGitStub(tempDir, { porcelainOutput: "", headRef: "main" });
+
+    const run1 = await runNode([
+      "--repo", "owner/repo-a", "--pr", "47",
+      "--copilot-input", copilotSnapshotPath,
+      "--reviewer-input", reviewerSnapshotPath,
+    ], { env, cwd: tempDir });
+    assert.equal(JSON.parse(run1.stdout).checkpoint.waitCycles, 1);
+
+    const run2 = await runNode([
+      "--repo", "owner/repo-b", "--pr", "47",
+      "--copilot-input", copilotSnapshotPath,
+      "--reviewer-input", reviewerSnapshotPath,
+    ], { env, cwd: tempDir });
+    assert.equal(JSON.parse(run2.stdout).checkpoint.waitCycles, 1);
+
+    const { readFile: rf } = await import("node:fs/promises");
+    const repoACheckpoint = JSON.parse(await rf(path.join(tempDir, "tmp", "copilot-loop", "owner", "repo-a", "pr-47", "outer-loop-state.json"), "utf8"));
+    const repoBCheckpoint = JSON.parse(await rf(path.join(tempDir, "tmp", "copilot-loop", "owner", "repo-b", "pr-47", "outer-loop-state.json"), "utf8"));
+    assert.equal(repoACheckpoint.repo, "owner/repo-a");
+    assert.equal(repoBCheckpoint.repo, "owner/repo-b");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("outer-loop: wait cycles carry forward on same repo/pr/head using the default checkpoint path", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-outer-default-path-same-head-"));
+
+  try {
+    const copilotSnapshotPath = path.join(tempDir, "copilot-snapshot.json");
+    const reviewerSnapshotPath = path.join(tempDir, "reviewer-snapshot.json");
+
+    await writeJson(copilotSnapshotPath, {
+      prExists: true,
+      prNumber: 47,
+      prDraft: false,
+      prMerged: false,
+      prClosed: false,
+      copilotReviewRequestStatus: "requested",
+      copilotReviewPresent: false,
+      unresolvedThreadCount: 0,
+      actionableThreadCount: 0,
+      ciStatus: "success",
+    });
+    await writeJson(reviewerSnapshotPath, {
+      prExists: true,
+      prNumber: 47,
+      prHeadSha: "abc123",
+    });
+
+    const env = await writeGitStub(tempDir, { porcelainOutput: "", headRef: "main" });
+    const baseArgs = [
+      "--repo", "owner/repo", "--pr", "47",
+      "--copilot-input", copilotSnapshotPath,
+      "--reviewer-input", reviewerSnapshotPath,
+    ];
+
+    const run1 = await runNode(baseArgs, { env, cwd: tempDir });
+    assert.equal(JSON.parse(run1.stdout).checkpoint.waitCycles, 1);
+
+    const run2 = await runNode(baseArgs, { env, cwd: tempDir });
+    assert.equal(JSON.parse(run2.stdout).checkpoint.waitCycles, 2);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("outer-loop: wait cycles reset to 1 when head changes but outer action stays continue_wait", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-outer-wait-head-reset-"));
+
+  try {
+    const copilotSnapshotPath = path.join(tempDir, "copilot-snapshot.json");
+    const reviewerSnapshotPath = path.join(tempDir, "reviewer-snapshot.json");
+
+    await writeJson(copilotSnapshotPath, {
+      prExists: true,
+      prNumber: 47,
+      prDraft: false,
+      prMerged: false,
+      prClosed: false,
+      copilotReviewRequestStatus: "requested",
+      copilotReviewPresent: false,
+      unresolvedThreadCount: 0,
+      actionableThreadCount: 0,
+      ciStatus: "success",
+    });
+    await writeJson(reviewerSnapshotPath, {
+      prExists: true,
+      prNumber: 47,
+      prHeadSha: "abc123",
+    });
+
+    const env = await writeGitStub(tempDir, { porcelainOutput: "", headRef: "main" });
+    const baseArgs = [
+      "--repo", "owner/repo", "--pr", "47",
+      "--copilot-input", copilotSnapshotPath,
+      "--reviewer-input", reviewerSnapshotPath,
+    ];
+
+    const run1 = await runNode(baseArgs, { env, cwd: tempDir });
+    assert.equal(JSON.parse(run1.stdout).checkpoint.waitCycles, 1);
+
+    await writeJson(reviewerSnapshotPath, {
+      prExists: true,
+      prNumber: 47,
+      prHeadSha: "def456",
+    });
+
+    const run2 = await runNode(baseArgs, { env, cwd: tempDir });
+    const out2 = JSON.parse(run2.stdout);
+    assert.equal(out2.checkpoint.waitCycles, 1);
+    assert.equal(out2.checkpoint.headSha, "def456");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("outer-loop: legacy default checkpoint fallback is used only for matching repo/pr", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-outer-legacy-fallback-"));
+
+  try {
+    const copilotSnapshotPath = path.join(tempDir, "copilot-snapshot.json");
+    const reviewerSnapshotPath = path.join(tempDir, "reviewer-snapshot.json");
+    const legacyCheckpointPath = path.join(tempDir, "tmp", "copilot-loop", "pr-47", "outer-loop-state.json");
+
+    await writeJson(copilotSnapshotPath, {
+      prExists: true,
+      prNumber: 47,
+      prDraft: false,
+      prMerged: false,
+      prClosed: false,
+      copilotReviewRequestStatus: "requested",
+      copilotReviewPresent: false,
+      unresolvedThreadCount: 0,
+      actionableThreadCount: 0,
+      ciStatus: "success",
+    });
+    await writeJson(reviewerSnapshotPath, {
+      prExists: true,
+      prNumber: 47,
+      prHeadSha: "abc123",
+    });
+    await mkdir(path.dirname(legacyCheckpointPath), { recursive: true });
+    await writeJson(legacyCheckpointPath, {
+      pr: 47,
+      repo: "owner/repo",
+      outerAction: "continue_wait",
+      copilotState: "waiting_for_copilot_review",
+      reviewerState: "waiting_for_author_followup",
+      reason: null,
+      timestamp: "2026-05-17T10:00:00Z",
+      waitCycles: 2,
+      headSha: "abc123",
+    });
+
+    const env = await writeGitStub(tempDir, { porcelainOutput: "", headRef: "main" });
+    const run1 = await runNode([
+      "--repo", "owner/repo", "--pr", "47",
+      "--copilot-input", copilotSnapshotPath,
+      "--reviewer-input", reviewerSnapshotPath,
+    ], { env, cwd: tempDir });
+    assert.equal(JSON.parse(run1.stdout).checkpoint.waitCycles, 3);
+
+    await writeJson(legacyCheckpointPath, {
+      pr: 47,
+      repo: "other/repo",
+      outerAction: "continue_wait",
+      copilotState: "waiting_for_copilot_review",
+      reviewerState: "waiting_for_author_followup",
+      reason: null,
+      timestamp: "2026-05-17T10:00:00Z",
+      waitCycles: 9,
+      headSha: "abc123",
+    });
+
+    const repoQualifiedPath = path.join(tempDir, "tmp", "copilot-loop", "owner", "repo", "pr-47", "outer-loop-state.json");
+    await rm(repoQualifiedPath, { force: true });
+
+    const run2 = await runNode([
+      "--repo", "owner/repo", "--pr", "47",
+      "--copilot-input", copilotSnapshotPath,
+      "--reviewer-input", reviewerSnapshotPath,
+    ], { env, cwd: tempDir });
+    assert.equal(JSON.parse(run2.stdout).checkpoint.waitCycles, 1);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Harden outer-loop checkpoint identity and freshness by repo-qualifying the default checkpoint path and making wait-cycle carry-forward head-aware.

Refs #70

## Scope / context

This is issue #70 chunk 3.

Problem:
- the default checkpoint path was keyed only by PR number
- different repos with the same PR number could collide on the same default checkpoint location
- `waitCycles` could carry forward too loosely across a new PR head
- inspect-run needed to keep working against the new default path without broadening into a larger trust/honesty redesign

This slice:
- changes the default checkpoint path to `tmp/copilot-loop/<owner>/<repo>/pr-<n>/outer-loop-state.json`
- persists `headSha` in the checkpoint payload
- carries `waitCycles` forward only for the same repo, PR, and head while staying in `continue_wait`
- resets stale/mismatched wait continuity conservatively
- keeps explicit `--checkpoint-dir` semantics unchanged
- keeps inspect-run compatible with the new path and a bounded legacy fallback

Files touched:
- `scripts/loop/_checkpoint-paths.mjs`
- `scripts/loop/outer-loop.mjs`
- `scripts/loop/inspect-run.mjs`
- `packages/core/src/loop/run-inspection.mjs`
- `test/loop/outer-loop.test.mjs`
- `test/loop/inspect-run.test.mjs`
- `scripts/README.md`

## Acceptance criteria

- default checkpoint identity is repo + PR, not PR alone
- checkpoints persist `headSha`
- waitCycles carry forward only for the same repo, PR, and head SHA while staying in `continue_wait`
- waitCycles reset to 1 when head changes but wait state continues
- inspect-run finds repo-qualified checkpoints
- inspect-run may use matching legacy fallback during transition
- inspect-run ignores mismatched legacy fallback checkpoints
- no broader inspect-run trust/source semantics change is introduced in this chunk

## Definition of done

- bounded code/tests/docs slice is committed on a dedicated branch
- a draft PR exists
- local review gate is run on the PR/diff
- accepted fixes are applied if needed
- validation is rerun
- the PR is moved to ready for review once we are happy
- Copilot review is requested and the follow-up loop is started for the fresh head

## Non-goals

- no broader inspect-run honesty/trust redesign
- no reviewer-scope or ownership-routing changes
- no checkpoint migration tool
- no new CLI flags
- no timeout/escalation policy based on waitCycles
- no broad docs cleanup
