### PR TITLE
fix: tighten inspect-run fallback honesty

### DIFF
--- a/packages/core/src/loop/run-inspection.mjs
+++ b/packages/core/src/loop/run-inspection.mjs
@@ -47,7 +47,7 @@ export const SOURCE_MODE = Object.freeze({
   LIVE_DETECTOR_BACKED: "live-detector-backed",
   /** Live detection failed for all inner loops; state is checkpoint-derived only. */
   CHECKPOINT_ONLY: "checkpoint-only",
-  /** Some live facts available; remaining are checkpoint-derived or missing. */
+  /** Degraded mode: caller-supplied snapshot inputs and/or checkpoint-backed fallback contributed to the inspection result. */
   PARTIAL: "partial",
   /** No live facts and no valid checkpoint available. */
   UNAVAILABLE: "unavailable",
@@ -279,25 +279,12 @@ export function composeRunInspectionSnapshot({
   // Effective outerAction for unavailable source mode
   // -------------------------------------------------------------------------
 
-  // When no live evidence is available but a valid checkpoint exists, fall back
-  // to checkpoint outerAction (already captured above in sourceMode logic).
-  const effectiveOuterAction =
-    outerAction !== undefined
-      ? outerAction
-      : (
-        sourceMode === SOURCE_MODE.CHECKPOINT_ONLY && typeof existingCheckpoint?.outerAction === "string"
-          ? existingCheckpoint.outerAction
-          : undefined
-      );
+  // Top-level outer action is only surfaced when the caller derived it from a
+  // complete current evidence set. Checkpoint-backed or mixed fallback remains
+  // available only as advisory drill-down evidence in this chunk.
+  const effectiveOuterAction = outerAction;
 
-  const effectiveOuterReason =
-    outerReason !== undefined
-      ? outerReason
-      : (
-        sourceMode === SOURCE_MODE.CHECKPOINT_ONLY && existingCheckpoint?.reason != null
-          ? existingCheckpoint.reason
-          : undefined
-      );
+  const effectiveOuterReason = outerReason;
 
   // -------------------------------------------------------------------------
   // Determine statusClass
@@ -346,11 +333,11 @@ export function composeRunInspectionSnapshot({
     }
   } else if (sourceMode === SOURCE_MODE.CHECKPOINT_ONLY) {
     evidenceSummary =
-      "No live detector facts available; using checkpoint state only (degraded confidence).";
+      "No live detector facts are available. Checkpoint state is shown as advisory drill-down only, and the current top-level run state could not be confirmed.";
   } else if (sourceMode === SOURCE_MODE.PARTIAL) {
     evidenceSummary = inputSnapshotMode
-      ? "Caller-supplied snapshot inputs were used; no live detection was performed (degraded confidence)."
-      : "Partial live evidence available; some facts are checkpoint-derived (degraded confidence).";
+      ? "One or more caller-supplied snapshot inputs were used. The result reflects the complete current-state picture provided to inspection, but remains degraded because it was not fully live-detector-backed."
+      : "Only partial live evidence is available. Any checkpoint-backed state is advisory only, so the current top-level run state could not be confirmed.";
   } else {
     evidenceSummary = "No evidence available to determine current run state.";
   }

--- a/packages/core/src/loop/run-inspection.mjs
+++ b/packages/core/src/loop/run-inspection.mjs
@@ -45,9 +45,9 @@ export const STATUS_CLASS = Object.freeze({
 export const SOURCE_MODE = Object.freeze({
   /** Both inner-loop detectors returned live facts. */
   LIVE_DETECTOR_BACKED: "live-detector-backed",
-  /** Live detection failed for all inner loops; state is checkpoint-derived only. */
+  /** Live detection failed for all inner loops; checkpoint-backed drill-down remains available, but the top-level state stays unknown. */
   CHECKPOINT_ONLY: "checkpoint-only",
-  /** Degraded mode: caller-supplied snapshot inputs and/or checkpoint-backed fallback contributed to the inspection result. */
+  /** Degraded mode: mixed live + checkpoint fallback keeps the top-level state unknown; complete caller-supplied current-state inputs can still derive a top-level state. */
   PARTIAL: "partial",
   /** No live facts and no valid checkpoint available. */
   UNAVAILABLE: "unavailable",
@@ -276,7 +276,7 @@ export function composeRunInspectionSnapshot({
   }
 
   // -------------------------------------------------------------------------
-  // Effective outerAction for unavailable source mode
+  // Top-level outerAction surfacing eligibility
   // -------------------------------------------------------------------------
 
   // Top-level outer action is only surfaced when the caller derived it from a

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -362,6 +362,8 @@ Contract:
 - is strictly read-only: it does not write checkpoints, mutate GitHub state, or create local artifacts
 - returns a stable top-level inspection shape with target identity, outer action, active family state,
   status class, trust/source semantics, evidence, markers, and best-effort drill-down layers
+- only derives top-level `outerAction` / `activeFamilyState` / `statusClass` when inspection has a complete current inner-loop picture, whether from live detectors and/or caller-supplied snapshot inputs
+- when inspection falls back to checkpoint-only data or mixed live + checkpoint evidence, checkpoint-backed drill-down layers and checkpoint evidence paths remain available as advisory context while the top-level state stays `"unknown"`
 - reports not-found or unavailable targets as structured success output with `statusClass: "unknown"`
   rather than by throwing a synthetic blocked-run error
 - looks for checkpoints at the repo-qualified default path `tmp/copilot-loop/<owner>/<repo>/pr-<n>/outer-loop-state.json`

--- a/scripts/loop/inspect-run.mjs
+++ b/scripts/loop/inspect-run.mjs
@@ -116,8 +116,11 @@ statusClass values:
 
 sourceMode values:
   live-detector-backed   All facts from live detectors (authoritative)
-  checkpoint-only        Facts from existing checkpoint only (degraded)
-  partial                Mixed live and checkpoint-derived (degraded)
+  checkpoint-only        Checkpoint drill-down only; top-level state stays unknown
+  partial                Degraded mode. Mixed live + checkpoint fallback keeps top-level
+                         state unknown; complete current-state input supplied by the
+                         caller (including mixed live + input coverage) can still derive
+                         a top-level state.
   unavailable            No usable evidence available
 
 Error output (stderr, JSON):
@@ -378,20 +381,17 @@ export async function inspectRun(options, { env = process.env, ghCommand = "gh" 
     copilotEvidence?.snapshot?.prExists === false
     || reviewerEvidence?.snapshot?.prExists === false;
 
-  const effectiveCopilotState =
-    !explicitTargetMissing && copilotLiveStatus === "ok" && copilotEvidence !== null
-      ? copilotEvidence.interpretation.state
-      : (typeof existingCheckpoint?.copilotState === "string" ? existingCheckpoint.copilotState : undefined);
+  const hasCompleteCurrentInnerLoopState =
+    !explicitTargetMissing
+    && copilotLiveStatus === "ok"
+    && reviewerLiveStatus === "ok"
+    && copilotEvidence !== null
+    && reviewerEvidence !== null;
 
-  const effectiveReviewerState =
-    !explicitTargetMissing && reviewerLiveStatus === "ok" && reviewerEvidence !== null
-      ? reviewerEvidence.interpretation.state
-      : (typeof existingCheckpoint?.reviewerState === "string" ? existingCheckpoint.reviewerState : undefined);
-
-  if (!explicitTargetMissing && effectiveCopilotState !== undefined && effectiveReviewerState !== undefined) {
+  if (hasCompleteCurrentInnerLoopState) {
     const decision = decideOuterAction({
-      copilotState: effectiveCopilotState,
-      reviewerState: effectiveReviewerState,
+      copilotState: copilotEvidence.interpretation.state,
+      reviewerState: reviewerEvidence.interpretation.state,
       gitStatus: { isDirty: false, isDetached: false },
     });
     outerAction = decision.outerAction;

--- a/test/loop/inspect-run.test.mjs
+++ b/test/loop/inspect-run.test.mjs
@@ -853,7 +853,7 @@ test("inspect-run CLI: mixed live + input coverage can still derive a degraded t
       "--copilot-input", copilotPath,
     ], {
       cwd: tempDir,
-      env: { ...process.env, PATH: `${tempDir}:${process.env.PATH ?? ""}` },
+      env: { ...process.env, PATH: [tempDir, process.env.PATH ?? ""].filter(Boolean).join(path.delimiter) },
     });
 
     assert.equal(result.code, 0, `stderr: ${result.stderr}`);
@@ -876,7 +876,7 @@ test("inspect-run CLI: successful live detectors still derive authoritative top-
       "--pr", "55",
     ], {
       cwd: tempDir,
-      env: { ...process.env, PATH: `${tempDir}:${process.env.PATH ?? ""}` },
+      env: { ...process.env, PATH: [tempDir, process.env.PATH ?? ""].filter(Boolean).join(path.delimiter) },
     });
 
     assert.equal(result.code, 0, `stderr: ${result.stderr}`);

--- a/test/loop/inspect-run.test.mjs
+++ b/test/loop/inspect-run.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
@@ -52,6 +52,68 @@ function runNode(args = [], options = {}) {
 
 async function writeJson(filePath, data) {
   await writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}
+
+async function writeGhStub(tempDir) {
+  const ghPath = path.join(tempDir, "gh");
+  const script = `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const out = (value) => process.stdout.write(JSON.stringify(value));
+
+if (args[0] === "pr" && args[1] === "view") {
+  const fields = args[args.indexOf("--json") + 1] || "";
+  if (fields.includes("reviews")) {
+    out({
+      headRefOid: "abc123",
+      isDraft: false,
+      state: "OPEN",
+      number: 55,
+      reviews: [],
+      statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS" }],
+    });
+  } else {
+    out({
+      isDraft: false,
+      state: "OPEN",
+      number: 55,
+      headRefOid: "abc123",
+    });
+  }
+  process.exit(0);
+}
+
+if (args[0] === "api" && args[1] === "repos/owner/repo/pulls/55/requested_reviewers") {
+  out({ users: [{ login: "copilot-pull-request-reviewer[bot]" }, { login: "reviewer-user" }] });
+  process.exit(0);
+}
+
+if (args[0] === "api" && args[1] === "repos/owner/repo/pulls/55/reviews") {
+  out([{ id: 41, state: "COMMENTED", user: { login: "reviewer-user" }, commit_id: "abc123", html_url: "https://example.test/review/41" }]);
+  process.exit(0);
+}
+
+if (args[0] === "api" && args[1] === "graphql") {
+  out({
+    data: {
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            nodes: [],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      },
+    },
+  });
+  process.exit(0);
+}
+
+process.stderr.write("unexpected gh args: " + args.join(" ") + "\\n");
+process.exit(1);
+`;
+  await writeFile(ghPath, script, "utf8");
+  await chmod(ghPath, 0o755);
+  return ghPath;
 }
 
 async function withTempDir(fn) {
@@ -275,7 +337,7 @@ test("composeRunInspectionSnapshot: live evidence + reenter_copilot_loop → act
 // Unit tests: checkpoint-only fixture
 // ---------------------------------------------------------------------------
 
-test("composeRunInspectionSnapshot: checkpoint-only → checkpoint-only sourceMode, checkpoint trust", () => {
+test("composeRunInspectionSnapshot: checkpoint-only stays advisory and leaves top-level state unknown", () => {
   const existingCheckpoint = {
     pr: 55,
     repo: "owner/repo",
@@ -290,7 +352,7 @@ test("composeRunInspectionSnapshot: checkpoint-only → checkpoint-only sourceMo
   const snapshot = composeRunInspectionSnapshot({
     target: { repo: "owner/repo", pr: 55 },
     inspectedAt: "2026-05-18T12:00:00Z",
-    outerAction: "continue_wait",
+    outerAction: undefined,
     copilotEvidence: null,
     reviewerEvidence: null,
     existingCheckpoint,
@@ -305,8 +367,11 @@ test("composeRunInspectionSnapshot: checkpoint-only → checkpoint-only sourceMo
   assert.equal(snapshot.sourceMode, SOURCE_MODE.CHECKPOINT_ONLY);
   assert.equal(snapshot.trust, TRUST.CHECKPOINT);
   assert.equal(snapshot.needsAttention, true);
-  assert.equal(snapshot.outerAction, "continue_wait");
-  assert.equal(snapshot.statusClass, STATUS_CLASS.WAITING);
+  assert.equal(snapshot.outerAction, "unknown");
+  assert.equal(snapshot.activeFamilyState, "unknown");
+  assert.equal(snapshot.statusClass, STATUS_CLASS.UNKNOWN);
+  assert.match(snapshot.evidence.summary, /advisory/i);
+  assert.match(snapshot.evidence.summary, /could not be determined|could not be confirmed/i);
 
   // Checkpoint layer is populated
   assert.equal(snapshot.layers.copilot.currentState, "waiting_for_copilot_review");
@@ -433,7 +498,7 @@ test("composeRunInspectionSnapshot: live copilot state matches checkpoint — no
 // Unit tests: partial live evidence
 // ---------------------------------------------------------------------------
 
-test("composeRunInspectionSnapshot: reviewer live fails, copilot ok → partial sourceMode", () => {
+test("composeRunInspectionSnapshot: mixed live + checkpoint stays advisory and leaves top-level state unknown", () => {
   const copilotEvidence = makeCopilotEvidence("waiting_for_copilot_review");
 
   const existingCheckpoint = {
@@ -450,7 +515,7 @@ test("composeRunInspectionSnapshot: reviewer live fails, copilot ok → partial 
   const snapshot = composeRunInspectionSnapshot({
     target: { repo: "owner/repo", pr: 55 },
     inspectedAt: "2026-05-18T12:00:00Z",
-    outerAction: "continue_wait",
+    outerAction: undefined,
     copilotEvidence,
     reviewerEvidence: null,
     existingCheckpoint,
@@ -463,6 +528,10 @@ test("composeRunInspectionSnapshot: reviewer live fails, copilot ok → partial 
   assert.equal(snapshot.sourceMode, SOURCE_MODE.PARTIAL);
   assert.equal(snapshot.trust, TRUST.DEGRADED);
   assert.equal(snapshot.needsAttention, true);
+  assert.equal(snapshot.outerAction, "unknown");
+  assert.equal(snapshot.activeFamilyState, "unknown");
+  assert.equal(snapshot.statusClass, STATUS_CLASS.UNKNOWN);
+  assert.match(snapshot.evidence.summary, /insufficient|advisory/i);
   assert.ok(snapshot.markers.missing.length > 0 || snapshot.markers.stale.length > 0);
 
   // Copilot layer from live
@@ -759,6 +828,68 @@ test("inspect-run CLI: complete snapshot inputs -> partial sourceMode (degraded 
   });
 });
 
+test("inspect-run CLI: mixed live + input coverage can still derive a degraded top-level state", async () => {
+  await withTempDir(async (tempDir) => {
+    await writeGhStub(tempDir);
+    const copilotPath = path.join(tempDir, "copilot.json");
+    await writeJson(copilotPath, {
+      prExists: true,
+      prNumber: 55,
+      prDraft: false,
+      prMerged: false,
+      prClosed: false,
+      copilotReviewRequestStatus: "requested",
+      copilotReviewPresent: false,
+      copilotReviewOnCurrentHead: false,
+      unresolvedThreadCount: 0,
+      actionableThreadCount: 0,
+      ciStatus: "success",
+      agentFixStatus: null,
+    });
+
+    const result = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "55",
+      "--copilot-input", copilotPath,
+    ], {
+      cwd: tempDir,
+      env: { ...process.env, PATH: `${tempDir}:${process.env.PATH ?? ""}` },
+    });
+
+    assert.equal(result.code, 0, `stderr: ${result.stderr}`);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.sourceMode, SOURCE_MODE.PARTIAL);
+    assert.equal(output.trust, TRUST.DEGRADED);
+    assert.equal(output.outerAction, "continue_wait");
+    assert.equal(output.activeFamilyState, "continue_wait");
+    assert.equal(output.statusClass, STATUS_CLASS.WAITING);
+    assert.match(output.evidence.summary, /caller-supplied snapshot inputs|provided to inspection/i);
+  });
+});
+
+test("inspect-run CLI: successful live detectors still derive authoritative top-level state", async () => {
+  await withTempDir(async (tempDir) => {
+    await writeGhStub(tempDir);
+
+    const result = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "55",
+    ], {
+      cwd: tempDir,
+      env: { ...process.env, PATH: `${tempDir}:${process.env.PATH ?? ""}` },
+    });
+
+    assert.equal(result.code, 0, `stderr: ${result.stderr}`);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.sourceMode, SOURCE_MODE.LIVE_DETECTOR_BACKED);
+    assert.equal(output.trust, TRUST.AUTHORITATIVE);
+    assert.equal(output.outerAction, "continue_wait");
+    assert.equal(output.activeFamilyState, "continue_wait");
+    assert.equal(output.statusClass, STATUS_CLASS.WAITING);
+    assert.equal(output.needsAttention, false);
+  });
+});
+
 test("inspect-run CLI: waiting copilot → continue_wait, statusClass waiting", async () => {
   await withTempDir(async (tempDir) => {
     const copilotPath = path.join(tempDir, "copilot.json");
@@ -961,7 +1092,7 @@ test("inspect-run CLI: --steering-state-file given and file exists → available
   });
 });
 
-test("inspect-run CLI: reads checkpoint from repo-qualified default path", async () => {
+test("inspect-run CLI: checkpoint-only repo-qualified path stays advisory and top-level unknown", async () => {
   await withTempDir(async (tempDir) => {
     const checkpointPath = path.join(tempDir, "tmp", "copilot-loop", "owner", "repo", "pr-55", "outer-loop-state.json");
     await mkdir(path.dirname(checkpointPath), { recursive: true });
@@ -985,11 +1116,15 @@ test("inspect-run CLI: reads checkpoint from repo-qualified default path", async
     assert.equal(result.code, 0, `stderr: ${result.stderr}`);
     const output = JSON.parse(result.stdout);
     assert.equal(output.sourceMode, SOURCE_MODE.CHECKPOINT_ONLY);
+    assert.equal(output.outerAction, "unknown");
+    assert.equal(output.activeFamilyState, "unknown");
+    assert.equal(output.statusClass, STATUS_CLASS.UNKNOWN);
+    assert.match(output.evidence.summary, /advisory/i);
     assert.equal(output.evidence.checkpoint[0], path.join("tmp", "copilot-loop", "owner", "repo", "pr-55", "outer-loop-state.json"));
   });
 });
 
-test("inspect-run CLI: reads the repo-qualified checkpoint for the targeted repo when two repos share a PR number", async () => {
+test("inspect-run CLI: checkpoint-only selection still picks the targeted repo when two repos share a PR number", async () => {
   await withTempDir(async (tempDir) => {
     const checkpointPathA = path.join(tempDir, "tmp", "copilot-loop", "owner", "repo-a", "pr-55", "outer-loop-state.json");
     const checkpointPathB = path.join(tempDir, "tmp", "copilot-loop", "owner", "repo-b", "pr-55", "outer-loop-state.json");
@@ -1027,11 +1162,67 @@ test("inspect-run CLI: reads the repo-qualified checkpoint for the targeted repo
     const output = JSON.parse(result.stdout);
     assert.equal(output.sourceMode, SOURCE_MODE.CHECKPOINT_ONLY);
     assert.equal(output.evidence.checkpoint[0], path.join("tmp", "copilot-loop", "owner", "repo-b", "pr-55", "outer-loop-state.json"));
-    assert.equal(output.outerAction, "stop");
+    assert.equal(output.outerAction, "unknown");
+    assert.equal(output.activeFamilyState, "unknown");
+    assert.equal(output.statusClass, STATUS_CLASS.UNKNOWN);
   });
 });
 
-test("inspect-run CLI: reads matching legacy checkpoint as fallback when repo input casing differs", async () => {
+test("inspect-run CLI: mixed live + checkpoint fallback stays advisory and top-level unknown", async () => {
+  await withTempDir(async (tempDir) => {
+    const copilotPath = path.join(tempDir, "copilot.json");
+    const checkpointPath = path.join(tempDir, "tmp", "copilot-loop", "owner", "repo", "pr-55", "outer-loop-state.json");
+    await mkdir(path.dirname(checkpointPath), { recursive: true });
+    await writeJson(copilotPath, {
+      prExists: true,
+      prNumber: 55,
+      prDraft: false,
+      prMerged: false,
+      prClosed: false,
+      copilotReviewRequestStatus: "requested",
+      copilotReviewPresent: false,
+      copilotReviewOnCurrentHead: false,
+      unresolvedThreadCount: 0,
+      actionableThreadCount: 0,
+      ciStatus: "success",
+      agentFixStatus: null,
+    });
+    await writeJson(checkpointPath, {
+      pr: 55,
+      repo: "owner/repo",
+      outerAction: "continue_wait",
+      copilotState: "waiting_for_copilot_review",
+      reviewerState: "waiting_for_author_followup",
+      reason: null,
+      timestamp: "2026-05-17T10:00:00Z",
+      waitCycles: 3,
+      headSha: "abc123",
+    });
+
+    const result = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "55",
+      "--copilot-input", copilotPath,
+    ], {
+      cwd: tempDir,
+      env: { ...process.env, PATH: tempDir },
+    });
+
+    assert.equal(result.code, 0, `stderr: ${result.stderr}`);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.sourceMode, SOURCE_MODE.PARTIAL);
+    assert.equal(output.trust, TRUST.DEGRADED);
+    assert.equal(output.outerAction, "unknown");
+    assert.equal(output.activeFamilyState, "unknown");
+    assert.equal(output.statusClass, STATUS_CLASS.UNKNOWN);
+    assert.equal(output.layers.copilot.currentState, "waiting_for_copilot_review");
+    assert.equal(output.layers.reviewer.currentState, "waiting_for_author_followup");
+    assert.equal(output.layers.reviewer.source, "checkpoint");
+    assert.match(output.evidence.summary, /insufficient|advisory/i);
+  });
+});
+
+test("inspect-run CLI: matching legacy checkpoint fallback stays advisory when repo input casing differs", async () => {
   await withTempDir(async (tempDir) => {
     const checkpointPath = path.join(tempDir, "tmp", "copilot-loop", "pr-55", "outer-loop-state.json");
     await mkdir(path.dirname(checkpointPath), { recursive: true });
@@ -1055,11 +1246,14 @@ test("inspect-run CLI: reads matching legacy checkpoint as fallback when repo in
     assert.equal(result.code, 0, `stderr: ${result.stderr}`);
     const output = JSON.parse(result.stdout);
     assert.equal(output.sourceMode, SOURCE_MODE.CHECKPOINT_ONLY);
+    assert.equal(output.outerAction, "unknown");
+    assert.equal(output.activeFamilyState, "unknown");
+    assert.equal(output.statusClass, STATUS_CLASS.UNKNOWN);
     assert.equal(output.evidence.checkpoint[0], path.join("tmp", "copilot-loop", "pr-55", "outer-loop-state.json"));
   });
 });
 
-test("inspect-run CLI: prefers repo-qualified checkpoint when both new and legacy files exist", async () => {
+test("inspect-run CLI: prefers repo-qualified checkpoint when both new and legacy files exist and keeps top-level unknown", async () => {
   await withTempDir(async (tempDir) => {
     const repoQualifiedPath = path.join(tempDir, "tmp", "copilot-loop", "owner", "repo", "pr-55", "outer-loop-state.json");
     const legacyPath = path.join(tempDir, "tmp", "copilot-loop", "pr-55", "outer-loop-state.json");
@@ -1097,7 +1291,9 @@ test("inspect-run CLI: prefers repo-qualified checkpoint when both new and legac
     const output = JSON.parse(result.stdout);
     assert.equal(output.sourceMode, SOURCE_MODE.CHECKPOINT_ONLY);
     assert.equal(output.evidence.checkpoint[0], path.join("tmp", "copilot-loop", "owner", "repo", "pr-55", "outer-loop-state.json"));
-    assert.equal(output.outerAction, "continue_wait");
+    assert.equal(output.outerAction, "unknown");
+    assert.equal(output.activeFamilyState, "unknown");
+    assert.equal(output.statusClass, STATUS_CLASS.UNKNOWN);
   });
 });
 


### PR DESCRIPTION
## Summary

Tighten `inspect-run` fallback honesty for issue #70 chunk 4.

This change stops `inspect-run` from promoting checkpoint-backed fallback into the top-level current-state answer when inspection does not have a complete current inner-loop picture. Checkpoint-backed details remain available as advisory drill-down evidence.

## Scope / context

This is the next bounded remediation slice under #70 after chunk 3.

Problem addressed in this PR:
- `inspect-run` could present checkpoint-only or mixed live + checkpoint fallback as if it were a confident current outer-loop answer
- that made degraded inspection output look more actionable than it really was

What this PR does:
- only derives top-level `outerAction`, `activeFamilyState`, and `statusClass` when inspection has a complete current inner-loop picture
- keeps checkpoint-only and mixed live + checkpoint fallback advisory-only at the top level
- preserves checkpoint-backed drill-down layers and checkpoint evidence paths
- preserves complete live behavior
- preserves complete current-state input supplied by the caller, including mixed live + input coverage
- aligns `scripts/README.md` and CLI/help wording with the tightened contract

## Acceptance criteria

- checkpoint-only fallback no longer reports checkpoint-derived top-level run state
- mixed live + checkpoint fallback no longer reports derived top-level run state
- checkpoint-backed layers and `evidence.checkpoint` remain visible when available
- degraded summaries clearly say top-level current state could not be confirmed
- complete live paths behave as before
- complete current-state input supplied by the caller remains usable in degraded mode
- no new CLI flags, schema fields, or unrelated workflow changes are introduced

## Definition of done

- bounded inspect-run honesty change implemented
- targeted tests cover checkpoint-only honesty, mixed live + checkpoint honesty, mixed live + input coverage, and unchanged live behavior
- local validation passes:
  - `node --test test/loop/inspect-run.test.mjs`
  - `npm test`
  - `git diff --check`
- docs wording in `scripts/README.md` matches behavior
- diff stays limited to inspect-run honesty surfaces

## Non-goals

- no reviewer identity scoping changes
- no ownership-routing wiring work
- no broader `sourceMode` / `trust` taxonomy redesign
- no new CLI flags, schema fields, or schema-version changes
- no checkpoint write/path behavior changes
- no `outer-loop.mjs` execution changes
- no broad docs-authority cleanup
- no special incomplete-evidence terminal-state exceptions
