### PR TITLE
fix: clarify reviewer scope contract

### DIFF
--- a/docs/reviewer-loop-state-graph.md
+++ b/docs/reviewer-loop-state-graph.md
@@ -35,10 +35,15 @@ Implementation:
 `normalizeReviewerSnapshot` canonicalizes this schema:
 
 - PR/observable: `prExists`, `prNumber`, `prDraft`, `prMerged`, `prClosed`, `prHeadSha`, `reviewRequested`
+- reviewer-scope metadata: `reviewerScope`, `reviewerLogin`
 - local planning/run/merge status: `localPlanningStatus`, `localReviewRunsStatus`, `localMergeStatus`, `draftReviewPrepared`
 - staged draft review state: `draftReviewPosted`, `draftReviewId`, `draftReviewUrl`, `draftReviewCommitSha`, `draftReviewNotificationStatus`
 - submitted review state: `submittedReviewPresent`, `submittedReviewCommitSha`
 - explicit prior action-result state: `reviewSubmissionStatus`
+
+`reviewerScope` is explicit machine-readable contract, not an inferred side note:
+- `single_reviewer` means detection was scoped to one reviewer identity and `reviewerLogin` is that normalized login
+- `all_reviewers` means `--reviewer-login` was omitted and the detector intentionally aggregated reviewer state across the PR
 
 The contract separates observable current state (`submittedReviewPresent`, `draftReviewPosted`, `reviewRequested`) from prior action-result state (`reviewSubmissionStatus`) to avoid overloading one field.
 
@@ -88,6 +93,11 @@ artifact/verdict.
 - optional: `--reviewer-login <login>`
 - optional: `--review-requested <true|false>` (inject known request result)
 - optional: `--local-state <path>` (inject local planning/run/merge metadata)
+
+Reviewer-scope contract:
+- with `--reviewer-login`, detection is for that single reviewer identity
+- without `--reviewer-login`, detection intentionally aggregates across all reviewers on the PR
+- success output snapshots always expose that choice through `snapshot.reviewerScope` and `snapshot.reviewerLogin`
 
 Success output:
 

--- a/docs/workflow-remediation-prep.md
+++ b/docs/workflow-remediation-prep.md
@@ -64,7 +64,7 @@ Problem shape:
 - this is an operator-signal / output-contract problem
 
 ### 4. Reviewer identity scoping is underspecified when `--reviewer-login` is omitted
-This is real, but it is not yet a plain bug ticket.
+This was a contract-decision problem before chunk 5 clarified the rule.
 
 Primary surfaces:
 - `scripts/loop/detect-reviewer-loop-state.mjs`
@@ -75,8 +75,8 @@ Primary surfaces:
 
 Problem shape:
 - omitted reviewer identity broadens scope to all reviewers
-- current docs make that behavior at least partly defensible
-- this needs a contract decision before any default-behavior change
+- current docs made that behavior only partly explicit
+- chunk 5 resolves the contract by making aggregate-vs-single-reviewer scope explicit in runtime output and docs, while keeping the omitted-login default unchanged for now
 
 ### 5. Ownership-aware routing exists in core but is not wired into active outer-loop routing
 This is a known seam, not a surprise bug.

--- a/packages/core/src/loop/reviewer-loop-state.mjs
+++ b/packages/core/src/loop/reviewer-loop-state.mjs
@@ -111,6 +111,12 @@ function normalizeStatus(value, allowed, fallback) {
   return allowed.has(value) ? value : fallback;
 }
 
+function normalizeReviewerLogin(value) {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim().toLowerCase()
+    : null;
+}
+
 /**
  * Normalize reviewer-loop snapshot data into a canonical, deterministic shape.
  *
@@ -123,6 +129,8 @@ export function normalizeReviewerSnapshot(raw) {
   }
 
   const prExists = Boolean(raw.prExists);
+  const reviewerLogin = normalizeReviewerLogin(raw.reviewerLogin);
+  const reviewerScope = reviewerLogin !== null ? "single_reviewer" : "all_reviewers";
 
   return {
     prExists,
@@ -132,6 +140,8 @@ export function normalizeReviewerSnapshot(raw) {
     prClosed: Boolean(raw.prClosed),
     prHeadSha: prExists ? normalizeSha(raw.prHeadSha) : null,
 
+    reviewerScope,
+    reviewerLogin: reviewerScope === "single_reviewer" ? reviewerLogin : null,
     reviewRequested: Boolean(raw.reviewRequested),
 
     localPlanningStatus: normalizeStatus(raw.localPlanningStatus, VALID_LOCAL_PLANNING_STATUSES, "none"),

--- a/packages/core/src/loop/run-inspection.mjs
+++ b/packages/core/src/loop/run-inspection.mjs
@@ -103,6 +103,20 @@ export function mapOuterActionToStatusClass(outerAction) {
   }
 }
 
+function buildReviewerScope(snapshotLike) {
+  if (snapshotLike?.reviewerScope === "single_reviewer") {
+    return {
+      mode: "single_reviewer",
+      reviewerLogin: typeof snapshotLike?.reviewerLogin === "string" ? snapshotLike.reviewerLogin : null,
+    };
+  }
+
+  return {
+    mode: "all_reviewers",
+    reviewerLogin: null,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Snapshot composer
 // ---------------------------------------------------------------------------
@@ -376,11 +390,13 @@ export function composeRunInspectionSnapshot({
     layers.reviewer = {
       currentState: reviewerEvidence.interpretation.state,
       allowedTransitions: reviewerEvidence.interpretation.allowedTransitions,
+      scope: buildReviewerScope(reviewerEvidence.snapshot),
     };
   } else if (typeof existingCheckpoint?.reviewerState === "string") {
     layers.reviewer = {
       currentState: existingCheckpoint.reviewerState,
       source: "checkpoint",
+      scope: buildReviewerScope(existingCheckpoint),
     };
   }
 

--- a/packages/core/test/reviewer-loop-state.test.mjs
+++ b/packages/core/test/reviewer-loop-state.test.mjs
@@ -26,6 +26,8 @@ test("normalizeReviewerSnapshot returns deterministic defaults", () => {
     prMerged: false,
     prClosed: false,
     prHeadSha: null,
+    reviewerScope: "all_reviewers",
+    reviewerLogin: null,
     reviewRequested: false,
     localPlanningStatus: "none",
     localReviewRunsStatus: "none",
@@ -40,6 +42,26 @@ test("normalizeReviewerSnapshot returns deterministic defaults", () => {
     submittedReviewCommitSha: null,
     reviewSubmissionStatus: "none",
   });
+});
+
+test("normalizeReviewerSnapshot derives reviewer scope metadata deterministically", () => {
+  assert.deepEqual(
+    normalizeReviewerSnapshot({ reviewerLogin: "Pi-Reviewer" }),
+    {
+      ...normalizeReviewerSnapshot({}),
+      reviewerScope: "single_reviewer",
+      reviewerLogin: "pi-reviewer",
+    },
+  );
+
+  assert.deepEqual(
+    normalizeReviewerSnapshot({ reviewerScope: "single_reviewer" }),
+    {
+      ...normalizeReviewerSnapshot({}),
+      reviewerScope: "all_reviewers",
+      reviewerLogin: null,
+    },
+  );
 });
 
 test("REVIEWER_TRANSITIONS covers every REVIEWER_STATE", () => {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -289,14 +289,18 @@ Two modes:
 
 - **Auto-detect**: `--repo <owner/name> --pr <number>`
   Fetches PR/open-head state, review-request status, and pending/submitted review surfaces from
-  GitHub and interprets them into deterministic reviewer-loop state.
+  GitHub and interprets them into deterministic reviewer-loop state. When `--reviewer-login` is
+  omitted, this uses aggregate all-reviewer scope for the PR.
 
 - **Snapshot interpretation**: `--input <path>`
   Reads a pre-built snapshot JSON and interprets it without any `gh` calls.
 
 Optional (auto-detect mode only):
 - `--reviewer-login <login>`
-  Scope review-request and review-surface detection to a single reviewer identity.
+  Scope review-request and review-surface detection to a single reviewer identity. Success output
+  snapshots include `reviewerScope` (`"all_reviewers"` or `"single_reviewer"`) plus
+  `reviewerLogin` (`string|null`) so callers can tell whether the detector used aggregate or
+  single-reviewer scope.
 - `--review-requested <true|false>`
   Override review-request detection with a known prior result.
 - `--local-state <path>`
@@ -327,6 +331,11 @@ Optional:
 - `--copilot-input <path>`
 - `--reviewer-input <path>`
 
+Reviewer-scope contract:
+- omitting `--reviewer-login` means aggregate all-reviewer scope for the PR
+- providing `--reviewer-login` means single-reviewer scope for that login
+- `--reviewer-input` cannot be combined with `--reviewer-login`
+
 Contract:
 - auto-detect mode calls both inner detectors, interprets their current states, and emits one
   outer action: `continue_wait`, `reenter_copilot_loop`, `reenter_reviewer_loop`, `stop`, or `done`
@@ -342,7 +351,7 @@ Contract:
 - supports snapshot-input mode for deterministic gh-free testing
 
 Success output shape:
-- `{ "ok": true, "outerAction": "...", "copilotState": "...", "reviewerState": "...", "reason"?: "...", "conductorRouting": { "routingOutcome": "...", "outerAction": "...", "stopReason": null|"...", "handoffEnvelope": { ... } }, "checkpoint": { ... } }`
+- `{ "ok": true, "outerAction": "...", "copilotState": "...", "reviewerState": "...", "reviewerScope": { "mode": "all_reviewers"|"single_reviewer", "reviewerLogin": "..."|null }, "reason"?: "...", "conductorRouting": { "routingOutcome": "...", "outerAction": "...", "stopReason": null|"...", "handoffEnvelope": { ... } }, "checkpoint": { ... } }`
 
 Failure behavior:
 - malformed arguments emit `{ "ok": false, "error": "...", "usage": "..." }` on stderr and exit non-zero
@@ -360,8 +369,9 @@ Required:
 
 Optional:
 - `--steering-state-file <path>`
+- `--reviewer-login <login>` — narrows live reviewer detection to one reviewer identity; when omitted, inspection uses aggregate all-reviewer scope for the PR
 - `--copilot-input <path>`
-- `--reviewer-input <path>`
+- `--reviewer-input <path>` — cannot be combined with `--reviewer-login`
 
 Contract:
 - is strictly read-only: it does not write checkpoints, mutate GitHub state, or create local artifacts
@@ -379,7 +389,7 @@ Contract:
 - rejects mismatched steering-state files from the targeted repo/pr instead of projecting their state onto the inspected run
 
 Success output shape:
-- `{ "ok": true, "schemaVersion": 1, "target": { "repo": "...", "pr": 17 }, "runId": "pr-17", "inspectedAt": "...", "activeStateFamily": "copilot-pr-outer-loop", "outerAction": "...", "activeFamilyState": "...", "statusClass": "...", "needsAttention": false, "sourceMode": "...", "trust": "...", "evidence": { ... }, "markers": { ... }, "layers": { ... } }`
+- `{ "ok": true, "schemaVersion": 1, "target": { "repo": "...", "pr": 17 }, "runId": "pr-17", "inspectedAt": "...", "activeStateFamily": "copilot-pr-outer-loop", "outerAction": "...", "activeFamilyState": "...", "statusClass": "...", "needsAttention": false, "sourceMode": "...", "trust": "...", "evidence": { ... }, "markers": { ... }, "layers": { "reviewer": { "currentState": "...", "scope": { "mode": "all_reviewers"|"single_reviewer", "reviewerLogin": "..."|null }, ... }, ... } }`
 
 Failure behavior:
 - malformed arguments emit `{ "ok": false, "error": "...", "usage": "..." }` on stderr and exit non-zero

--- a/scripts/loop/detect-reviewer-loop-state.mjs
+++ b/scripts/loop/detect-reviewer-loop-state.mjs
@@ -42,6 +42,14 @@ function parseBool(value, flag) {
   throw new Error(`${flag} must be true or false`);
 }
 
+function parseReviewerLogin(value) {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    throw new Error("--reviewer-login must not be empty");
+  }
+  return normalized;
+}
+
 export function parseDetectReviewerCliArgs(argv) {
   const args = [...argv];
   const options = {
@@ -72,7 +80,7 @@ export function parseDetectReviewerCliArgs(argv) {
     }
 
     if (token === "--reviewer-login") {
-      options.reviewerLogin = requireOptionValue(args, "--reviewer-login").trim();
+      options.reviewerLogin = parseReviewerLogin(requireOptionValue(args, "--reviewer-login"));
       continue;
     }
 
@@ -306,7 +314,10 @@ export async function autoDetectReviewerSnapshot(
   const prView = await fetchPrView({ repo, pr }, deps);
 
   if (prView === null) {
-    return normalizeReviewerSnapshot({ prExists: false });
+    return normalizeReviewerSnapshot({
+      prExists: false,
+      reviewerLogin,
+    });
   }
 
   const localState = await readLocalState(localStatePath);
@@ -322,6 +333,7 @@ export async function autoDetectReviewerSnapshot(
       prMerged,
       prClosed,
       prHeadSha: typeof prView.headRefOid === "string" ? prView.headRefOid : null,
+      reviewerLogin,
     });
   }
 
@@ -340,6 +352,7 @@ export async function autoDetectReviewerSnapshot(
     prMerged: false,
     prClosed: false,
     prHeadSha: typeof prView.headRefOid === "string" ? prView.headRefOid : null,
+    reviewerLogin,
     reviewRequested,
     ...reviewState,
   });

--- a/scripts/loop/inspect-run.mjs
+++ b/scripts/loop/inspect-run.mjs
@@ -101,12 +101,18 @@ Optional:
                                         file (as written by steer-loop.mjs).
                                         When absent, steering is reported as
                                         unavailable (no_steering_locator).
+  --reviewer-login <login>              Reviewer login for live reviewer-loop
+                                        detection. When omitted, reviewer
+                                        detection uses aggregate all-reviewer
+                                        scope for the PR.
 
 Test / snapshot-mode flags:
   --copilot-input <path>                Pre-built copilot snapshot JSON
                                         (skips live copilot detection)
   --reviewer-input <path>               Pre-built reviewer snapshot JSON
-                                        (skips live reviewer detection)
+                                        (skips live reviewer detection;
+                                        cannot be combined with
+                                        --reviewer-login)
 
 Output (stdout, JSON):
   Always-present fields:
@@ -150,6 +156,14 @@ function parseError(message) {
   return Object.assign(new Error(message), { usage: USAGE });
 }
 
+function parseReviewerLogin(value) {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    throw parseError("--reviewer-login must not be empty");
+  }
+  return normalized;
+}
+
 function requireOptionValue(args, flag) {
   const value = args.shift();
 
@@ -175,6 +189,7 @@ export function parseInspectRunCliArgs(argv) {
     repo: undefined,
     pr: undefined,
     steeringStateFile: undefined,
+    reviewerLogin: undefined,
     copilotInputPath: undefined,
     reviewerInputPath: undefined,
   };
@@ -202,6 +217,11 @@ export function parseInspectRunCliArgs(argv) {
       continue;
     }
 
+    if (token === "--reviewer-login") {
+      options.reviewerLogin = parseReviewerLogin(requireOptionValue(args, "--reviewer-login"));
+      continue;
+    }
+
     if (token === "--copilot-input") {
       options.copilotInputPath = requireOptionValue(args, "--copilot-input");
       continue;
@@ -218,6 +238,10 @@ export function parseInspectRunCliArgs(argv) {
   if (!options.help) {
     if (options.repo === undefined || options.pr === undefined) {
       throw parseError("inspect-run requires both --repo <owner/name> and --pr <number>");
+    }
+
+    if (options.reviewerInputPath !== undefined && options.reviewerLogin !== undefined) {
+      throw parseError("--reviewer-input cannot be combined with --reviewer-login");
     }
 
     try {
@@ -309,13 +333,13 @@ async function loadSteeringState(steeringStateFile) {
  *
  * No checkpoints are written. No GitHub state is mutated.
  *
- * @param {{ repo: string, pr: number, steeringStateFile?: string,
+ * @param {{ repo: string, pr: number, steeringStateFile?: string, reviewerLogin?: string,
  *           copilotInputPath?: string, reviewerInputPath?: string }} options
  * @param {{ env?: object, ghCommand?: string }} deps
  * @returns {Promise<object>} inspection snapshot
  */
 export async function inspectRun(options, { env = process.env, ghCommand = "gh" } = {}) {
-  const { repo, pr, steeringStateFile, copilotInputPath, reviewerInputPath } = options;
+  const { repo, pr, steeringStateFile, reviewerLogin, copilotInputPath, reviewerInputPath } = options;
   parseRepoSlug(repo);
   const inspectedAt = new Date().toISOString();
 
@@ -360,7 +384,7 @@ export async function inspectRun(options, { env = process.env, ghCommand = "gh" 
       reviewerSnapshot = normalizeReviewerSnapshot(parseJsonText(text));
     } else {
       reviewerSnapshot = await autoDetectReviewerSnapshot(
-        { repo, pr },
+        { repo, pr, reviewerLogin },
         { env, ghCommand },
       );
     }

--- a/scripts/loop/outer-loop.mjs
+++ b/scripts/loop/outer-loop.mjs
@@ -68,22 +68,28 @@ Required:
   --pr <number>                         Pull request number
 
 Optional:
-  --reviewer-login <login>              Reviewer login for reviewer-loop detection
+  --reviewer-login <login>              Reviewer login for reviewer-loop detection.
+                                        When omitted, reviewer detection uses
+                                        aggregate all-reviewer scope for the PR.
   --checkpoint-dir <dir>                Directory for checkpoint artifact
                                         (default: tmp/copilot-loop/<owner>/<repo>/pr-<n>/)
   --copilot-input <path>                Path to a pre-built copilot snapshot JSON
                                         (skips live copilot detection; for testing)
   --reviewer-input <path>               Path to a pre-built reviewer snapshot JSON
-                                        (skips live reviewer detection; for testing)
+                                        (skips live reviewer detection; for testing;
+                                        cannot be combined with --reviewer-login)
 
 Output (stdout, JSON):
   { "ok": true, "outerAction": "...", "copilotState": "...",
-    "reviewerState": "...", "reason"?: "...",
+    "reviewerState": "...", "reviewerScope": { "mode": "...",
+      "reviewerLogin": "..."|null }, "reason"?: "...",
     "conductorRouting": { "routingOutcome": "...", "outerAction": "...",
       "stopReason": null|"...", "handoffEnvelope": { ... } },
     "checkpoint": { "pr": N, "repo": "...", "outerAction": "...",
-      "copilotState": "...", "reviewerState": "...", "reason": null|"...",
-      "timestamp": "...", "waitCycles": N, "headSha": "..."|null } }
+      "copilotState": "...", "reviewerState": "...",
+      "reviewerScope": "...", "reviewerLogin": "..."|null,
+      "reason": null|"...", "timestamp": "...", "waitCycles": N,
+      "headSha": "..."|null } }
 
 Outer actions:
   continue_wait          Durable outer-loop wait state; re-run after bounded wait
@@ -118,6 +124,14 @@ Exit codes:
 
 function parseError(message) {
   return Object.assign(new Error(message), { usage: USAGE });
+}
+
+function parseReviewerLogin(value) {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    throw parseError("--reviewer-login must not be empty");
+  }
+  return normalized;
 }
 
 function requireOptionValue(args, flag) {
@@ -169,7 +183,7 @@ export function parseOuterLoopCliArgs(argv) {
     }
 
     if (token === "--reviewer-login") {
-      options.reviewerLogin = requireOptionValue(args, "--reviewer-login").trim();
+      options.reviewerLogin = parseReviewerLogin(requireOptionValue(args, "--reviewer-login"));
       continue;
     }
 
@@ -194,6 +208,10 @@ export function parseOuterLoopCliArgs(argv) {
   if (!options.help) {
     if (options.repo === undefined || options.pr === undefined) {
       throw parseError("outer-loop requires both --repo <owner/name> and --pr <number>");
+    }
+
+    if (options.reviewerInputPath !== undefined && options.reviewerLogin !== undefined) {
+      throw parseError("--reviewer-input cannot be combined with --reviewer-login");
     }
 
     try {
@@ -466,6 +484,8 @@ export async function runOuterLoop(options, { env = process.env, ghCommand = "gh
     outerAction,
     copilotState: copilotInterpretation.state,
     reviewerState: reviewerInterpretation.state,
+    reviewerScope: reviewerSnapshot.reviewerScope,
+    reviewerLogin: reviewerSnapshot.reviewerLogin,
     reason: outerReason ?? null,
     timestamp: new Date().toISOString(),
     waitCycles,
@@ -479,6 +499,10 @@ export async function runOuterLoop(options, { env = process.env, ghCommand = "gh
     outerAction,
     copilotState: copilotInterpretation.state,
     reviewerState: reviewerInterpretation.state,
+    reviewerScope: {
+      mode: reviewerSnapshot.reviewerScope,
+      reviewerLogin: reviewerSnapshot.reviewerLogin,
+    },
     ...(outerReason !== null && outerReason !== undefined ? { reason: outerReason } : {}),
     conductorRouting,
     checkpoint,

--- a/test/loop/detect-reviewer-loop-state.test.mjs
+++ b/test/loop/detect-reviewer-loop-state.test.mjs
@@ -243,6 +243,8 @@ test("detect-reviewer-loop-state auto-detect returns review_requested when revie
     const output = JSON.parse(result.stdout);
     assert.equal(output.state, "review_requested");
     assert.equal(output.snapshot.reviewRequested, true);
+    assert.equal(output.snapshot.reviewerScope, "single_reviewer");
+    assert.equal(output.snapshot.reviewerLogin, "pi-reviewer");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -334,6 +336,8 @@ test("detect-reviewer-loop-state auto-detect treats missing local state as empty
     const output = JSON.parse(result.stdout);
     assert.equal(output.state, "waiting_for_review_request");
     assert.equal(output.snapshot.prExists, true);
+    assert.equal(output.snapshot.reviewerScope, "all_reviewers");
+    assert.equal(output.snapshot.reviewerLogin, null);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -482,6 +486,13 @@ test("detect-reviewer-loop-state rejects malformed arguments deterministically",
   assert.deepEqual(JSON.parse(badBool.stderr), {
     ok: false,
     error: "--review-requested must be true or false",
+  });
+
+  const blankReviewerLogin = await runNode(["--repo", "owner/repo", "--pr", "17", "--reviewer-login", "   "]);
+  assert.equal(blankReviewerLogin.code, 1);
+  assert.deepEqual(JSON.parse(blankReviewerLogin.stderr), {
+    ok: false,
+    error: "--reviewer-login must not be empty",
   });
 
   const unknown = await runNode(["--repo", "owner/repo", "--pr", "17", "--wat"]);

--- a/test/loop/inspect-run.test.mjs
+++ b/test/loop/inspect-run.test.mjs
@@ -711,6 +711,7 @@ test("parseInspectRunCliArgs: parses required flags", () => {
   assert.equal(opts.steeringStateFile, undefined);
   assert.equal(opts.copilotInputPath, undefined);
   assert.equal(opts.reviewerInputPath, undefined);
+  assert.equal(opts.reviewerLogin, undefined);
 });
 
 test("parseInspectRunCliArgs: parses all optional flags", () => {
@@ -724,6 +725,26 @@ test("parseInspectRunCliArgs: parses all optional flags", () => {
   assert.equal(opts.steeringStateFile, "/tmp/steering.json");
   assert.equal(opts.copilotInputPath, "/tmp/copilot.json");
   assert.equal(opts.reviewerInputPath, "/tmp/reviewer.json");
+});
+
+test("parseInspectRunCliArgs: parses reviewer-login for live reviewer detection", () => {
+  const opts = parseInspectRunCliArgs([
+    "--repo", "owner/repo",
+    "--pr", "55",
+    "--reviewer-login", "pi-reviewer",
+  ]);
+  assert.equal(opts.reviewerLogin, "pi-reviewer");
+});
+
+test("parseInspectRunCliArgs: rejects blank reviewer-login", () => {
+  assert.throws(
+    () => parseInspectRunCliArgs([
+      "--repo", "owner/repo",
+      "--pr", "55",
+      "--reviewer-login", "   ",
+    ]),
+    (err) => err.message.includes("--reviewer-login") && err.message.includes("empty"),
+  );
 });
 
 test("parseInspectRunCliArgs: --help returns help flag", () => {
@@ -763,6 +784,18 @@ test("parseInspectRunCliArgs: unknown flag throws", () => {
   assert.throws(
     () => parseInspectRunCliArgs(["--repo", "owner/repo", "--pr", "55", "--unknown-flag"]),
     (err) => err.message.includes("Unknown argument"),
+  );
+});
+
+test("parseInspectRunCliArgs: rejects reviewer-input combined with reviewer-login", () => {
+  assert.throws(
+    () => parseInspectRunCliArgs([
+      "--repo", "owner/repo",
+      "--pr", "55",
+      "--reviewer-input", "/tmp/reviewer.json",
+      "--reviewer-login", "pi-reviewer",
+    ]),
+    (err) => err.message.includes("--reviewer-input") && err.message.includes("--reviewer-login"),
   );
 });
 
@@ -894,6 +927,101 @@ test("inspect-run CLI: successful live detectors still derive authoritative top-
     assert.equal(output.activeFamilyState, "continue_wait");
     assert.equal(output.statusClass, STATUS_CLASS.WAITING);
     assert.equal(output.needsAttention, false);
+    assert.equal(output.layers.reviewer.scope.mode, "all_reviewers");
+    assert.equal(output.layers.reviewer.scope.reviewerLogin, null);
+  });
+});
+
+test("inspect-run CLI: reviewer-login narrows live reviewer detection to one reviewer identity", async () => {
+  await withTempDir(async (tempDir) => {
+    const ghPath = path.join(tempDir, "gh");
+    await writeFile(
+      ghPath,
+      `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const out = (value) => process.stdout.write(JSON.stringify(value));
+
+if (args[0] === "pr" && args[1] === "view") {
+  const fields = args[args.indexOf("--json") + 1] || "";
+  if (fields.includes("reviews")) {
+    out({
+      headRefOid: "abc123",
+      isDraft: false,
+      state: "OPEN",
+      number: 55,
+      reviews: [],
+      statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS" }],
+    });
+  } else {
+    out({ isDraft: false, state: "OPEN", number: 55, headRefOid: "abc123" });
+  }
+  process.exit(0);
+}
+
+if (args[0] === "api" && args[1] === "repos/owner/repo/pulls/55/requested_reviewers") {
+  out({ users: [{ login: "reviewer-user" }], teams: [] });
+  process.exit(0);
+}
+
+if (args[0] === "api" && args[1] === "repos/owner/repo/pulls/55/reviews") {
+  out([{ id: 41, state: "COMMENTED", user: { login: "other-reviewer" }, commit_id: "abc123", html_url: "https://example.test/review/41" }]);
+  process.exit(0);
+}
+
+if (args[0] === "api" && args[1] === "graphql") {
+  out({
+    data: {
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            nodes: [],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      },
+    },
+  });
+  process.exit(0);
+}
+
+process.stderr.write("unexpected gh args: " + args.join(" ") + "\\n");
+process.exit(1);
+`,
+      "utf8",
+    );
+    await chmod(ghPath, 0o755);
+
+    const baseEnv = {
+      ...process.env,
+      PATH: [tempDir, process.env.PATH ?? ""].filter(Boolean).join(path.delimiter),
+    };
+
+    const aggregate = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "55",
+    ], {
+      cwd: tempDir,
+      env: baseEnv,
+    });
+    assert.equal(aggregate.code, 0, `stderr: ${aggregate.stderr}`);
+    const aggregateOutput = JSON.parse(aggregate.stdout);
+    assert.equal(aggregateOutput.layers.reviewer.currentState, "waiting_for_author_followup");
+    assert.equal(aggregateOutput.layers.reviewer.scope.mode, "all_reviewers");
+    assert.equal(aggregateOutput.layers.reviewer.scope.reviewerLogin, null);
+
+    const scoped = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "55",
+      "--reviewer-login", "reviewer-user",
+    ], {
+      cwd: tempDir,
+      env: baseEnv,
+    });
+    assert.equal(scoped.code, 0, `stderr: ${scoped.stderr}`);
+    const scopedOutput = JSON.parse(scoped.stdout);
+    assert.equal(scopedOutput.layers.reviewer.currentState, "review_requested");
+    assert.equal(scopedOutput.layers.reviewer.scope.mode, "single_reviewer");
+    assert.equal(scopedOutput.layers.reviewer.scope.reviewerLogin, "reviewer-user");
   });
 });
 
@@ -1189,6 +1317,8 @@ test("inspect-run CLI: checkpoint-only repo-qualified path stays advisory and to
       outerAction: "continue_wait",
       copilotState: "waiting_for_copilot_review",
       reviewerState: "waiting_for_author_followup",
+      reviewerScope: "single_reviewer",
+      reviewerLogin: "reviewer-user",
       reason: null,
       timestamp: "2026-05-17T10:00:00Z",
       waitCycles: 3,
@@ -1206,6 +1336,8 @@ test("inspect-run CLI: checkpoint-only repo-qualified path stays advisory and to
     assert.equal(output.outerAction, "unknown");
     assert.equal(output.activeFamilyState, "unknown");
     assert.equal(output.statusClass, STATUS_CLASS.UNKNOWN);
+    assert.equal(output.layers.reviewer.scope.mode, "single_reviewer");
+    assert.equal(output.layers.reviewer.scope.reviewerLogin, "reviewer-user");
     assert.match(output.evidence.summary, /advisory/i);
     assert.equal(output.evidence.checkpoint[0], path.join("tmp", "copilot-loop", "owner", "repo", "pr-55", "outer-loop-state.json"));
   });

--- a/test/loop/outer-loop.test.mjs
+++ b/test/loop/outer-loop.test.mjs
@@ -388,6 +388,29 @@ test("outer-loop rejects malformed arguments with usage guidance", async () => {
   const unknownErr = JSON.parse(unknown.stderr);
   assert.equal(unknownErr.ok, false);
   assert.equal(unknownErr.error, "Unknown argument: --unexpected");
+
+  const conflictingReviewerScope = await runNode([
+    "--repo", "owner/repo",
+    "--pr", "17",
+    "--reviewer-input", "/tmp/reviewer.json",
+    "--reviewer-login", "pi-reviewer",
+  ]);
+  assert.equal(conflictingReviewerScope.code, 1);
+  const conflictingErr = JSON.parse(conflictingReviewerScope.stderr);
+  assert.equal(conflictingErr.ok, false);
+  assert.match(conflictingErr.error, /--reviewer-input/);
+  assert.match(conflictingErr.error, /--reviewer-login/);
+
+  const blankReviewerLogin = await runNode([
+    "--repo", "owner/repo",
+    "--pr", "17",
+    "--reviewer-login", "   ",
+  ]);
+  assert.equal(blankReviewerLogin.code, 1);
+  const blankReviewerLoginErr = JSON.parse(blankReviewerLogin.stderr);
+  assert.equal(blankReviewerLoginErr.ok, false);
+  assert.match(blankReviewerLoginErr.error, /--reviewer-login/);
+  assert.match(blankReviewerLoginErr.error, /empty/);
 });
 
 // ---------------------------------------------------------------------------
@@ -636,6 +659,10 @@ test("outer-loop: reviewer waiting_for_author_followup â†’ continue_wait", async
     assert.equal(output.ok, true);
     assert.equal(output.outerAction, "continue_wait");
     assert.equal(output.reviewerState, "waiting_for_author_followup");
+    assert.equal(output.reviewerScope.mode, "all_reviewers");
+    assert.equal(output.reviewerScope.reviewerLogin, null);
+    assert.equal(output.checkpoint.reviewerScope, "all_reviewers");
+    assert.equal(output.checkpoint.reviewerLogin, null);
     assert.equal(output.checkpoint.waitCycles, 1);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
@@ -726,6 +753,8 @@ test("outer-loop: waiting_for_re_request â†’ review_requested after re-detect â†
       prExists: true,
       prNumber: 47,
       prHeadSha: "def456",
+      reviewerScope: "single_reviewer",
+      reviewerLogin: "pi-reviewer",
       submittedReviewPresent: true,
       submittedReviewCommitSha: "abc123",
       reviewRequested: true,
@@ -747,6 +776,10 @@ test("outer-loop: waiting_for_re_request â†’ review_requested after re-detect â†
     assert.equal(output.ok, true);
     assert.equal(output.outerAction, "reenter_reviewer_loop");
     assert.equal(output.reviewerState, "review_requested");
+    assert.equal(output.reviewerScope.mode, "single_reviewer");
+    assert.equal(output.reviewerScope.reviewerLogin, "pi-reviewer");
+    assert.equal(output.checkpoint.reviewerScope, "single_reviewer");
+    assert.equal(output.checkpoint.reviewerLogin, "pi-reviewer");
     assert.equal(output.checkpoint.waitCycles, 0);
   } finally {
     await rm(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Clarify the reviewer identity scoping contract for reviewer-loop detection and inspection surfaces.

This slice keeps the existing default behavior when `--reviewer-login` is omitted, but makes that behavior explicit and machine-readable.

## Scope / context

Problem addressed in this slice:
- reviewer-loop detection broadened to all reviewers when `--reviewer-login` was omitted
- that default was not explicit enough in runtime output
- `inspect-run` could not accept `--reviewer-login`, so inspection always used aggregate reviewer scope

What this slice does:
- defines the contract that omitted `--reviewer-login` means aggregate all-reviewer scope for the PR
- adds reviewer-scope metadata to normalized reviewer snapshots and downstream inspection/output surfaces
- adds `inspect-run --reviewer-login` for live reviewer detection parity
- rejects `--reviewer-input` combined with `--reviewer-login` where the login would otherwise be ignored
- rejects blank / whitespace-only `--reviewer-login` values at the CLI boundary
- persists reviewer-scope metadata into outer-loop checkpoint/output for later inspection

Issue / remediation track context:
- issue #70 umbrella remediation
- chunk 5: reviewer identity scoping contract

## Acceptance criteria

- aggregate-vs-single-reviewer scope is explicit in machine-readable output
- `inspect-run` can scope live reviewer detection to one reviewer identity
- `outer-loop` and `inspect-run` reject `--reviewer-input` + `--reviewer-login`
- blank / whitespace-only `--reviewer-login` values are rejected deterministically
- omitted `--reviewer-login` remains aggregate scope by contract; no default-behavior change is introduced
- docs match the shipped contract

## Definition of done

- reviewer-scope metadata is propagated through normalization, inspection, and outer-loop output/checkpoint surfaces
- targeted regression coverage exists for:
  - aggregate reviewer scope
  - single-reviewer scope
  - `--reviewer-input` + `--reviewer-login` rejection
  - blank `--reviewer-login` rejection
- `git diff --check` passes
- `npm test` passes
- local final pre-approval review gate is clean

## Non-goals

- no change to the omitted-login default behavior
- no ownership-routing wiring work
- no multi-reviewer prioritization logic
- no checkpoint migration for older files
- no broader docs/authority cleanup beyond what is needed to match this shipped contract
