### PR TITLE
docs: clarify authority ownership for workflow surfaces

### DIFF
--- a/docs/IMPLEMENTATION_WORKFLOW.md
+++ b/docs/IMPLEMENTATION_WORKFLOW.md
@@ -63,6 +63,16 @@ Use for temporary execution artifacts and audit trails:
 
 These files are normally local-only and do not need to be committed.
 
+## Authority boundary for shipped behavior
+
+For already-shipped helpers, CLIs, and extension commands:
+- shipped helper/runtime semantics stay owned by code, tests, and the relevant contract docs
+- `scripts/README.md` summarizes those semantics for operators and maintainers; it must be kept aligned with the implementation
+- the narrower state-graph/contract docs under `docs/` remain part of the authoritative shipped contract surface for their helper families
+- skills and phase docs explain workflow procedure and durable planning intent; they must not silently redefine shipped helper behavior
+
+Use workflow/phase docs to explain how to operate within the repository contract. Use code, tests, and helper contract docs to define what shipped runtime surfaces actually do.
+
 ## Documentation sync rule
 
 When a merged slice changes durable repo truth, update the affected durable docs before treating the slice as closed.

--- a/docs/workflow-remediation-prep.md
+++ b/docs/workflow-remediation-prep.md
@@ -104,6 +104,7 @@ Problem shape:
 - shipped runtime semantics should be code-owned
 - some docs still over-own or blur behavior
 - this weakens future maintenance and audits
+- chunk 6 addresses this as bounded docs/authority cleanup by clarifying that workflow docs and skills explain procedure, while code/tests plus the relevant contract docs own shipped helper behavior
 
 ## Execution tracking
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,6 +10,13 @@ Scripts here should prefer:
 
 In this source-loaded workspace repo, root scripts may consume shared package helpers through a thin local adapter rather than a published package import path so the checkout remains runnable without an install step.
 
+## Authority note
+
+For the script surfaces documented here:
+- code, tests, and the helper entrypoints themselves are authoritative for shipped runtime behavior
+- this README summarizes those contracts for operators and maintainers; if behavior changes, update the code/tests and then sync this document
+- use the more specific state-graph and contract docs under `docs/` when a helper family has a narrower machine-readable contract that this README is summarizing
+
 ## Phase 5 scripts
 
 ### `scripts/github/capture-review-threads.mjs`

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -17,6 +17,11 @@ user-invocable: true
 
 This skill is the execution engine for phased implementation in this repository.
 
+Authority boundary for this skill:
+- this skill owns the local phase procedure and artifact discipline
+- it does not redefine the shipped runtime semantics of helper CLIs, shared loop logic, or extension commands
+- when helper behavior changes, update the relevant code/tests and contract docs in addition to any skill guidance that references them
+
 Use it when the user says things like:
 - start implementation
 - continue implementation
@@ -113,7 +118,7 @@ If these files are missing, create them from `templates/` before continuing:
 - missing `docs/phases/phase-x.md` for the active phase -> create from `templates/phase-doc.md`
 - missing `tmp/phases/index.json` -> create or reinitialize it
 
-The bootstrap files are support infrastructure. `PLAN.md` remains the product source of truth, and `docs/phases/phase-x.md` is the durable source of truth for the current phase.
+The bootstrap files are support infrastructure. `PLAN.md` remains the product source of truth, and `docs/phases/phase-x.md` is the durable source of truth for the current phase's plan and acceptance boundary.
 
 For bootstrap/setup phases, do not mark the phase `completed` or `awaiting-finalization` until the expected durable support files for the chosen workflow contract actually exist in the repository. Temporary `tmp/` execution artifacts do not need to be committed.
 ## Plan sufficiency check

--- a/test/imported-assets-normalization.test.mjs
+++ b/test/imported-assets-normalization.test.mjs
@@ -77,6 +77,25 @@ test("review workflow documents DRY/KISS/YAGNI as default pre-approval gate with
   assert.match(reviewerGraph, /do not replace the state machine's supported\s+review-angle taxonomy/i);
 });
 
+test("workflow docs keep helper/runtime authority code-owned and dev-loop scope procedure-owned", async () => {
+  const [workflowDoc, scriptsReadme, devLoopSkill] = await Promise.all([
+    readRepo("docs/IMPLEMENTATION_WORKFLOW.md"),
+    readRepo("scripts/README.md"),
+    readRepo("skills/dev-loop/SKILL.md"),
+  ]);
+
+  assert.match(workflowDoc, /shipped helper\/runtime semantics stay owned by code, tests, and the relevant contract docs/i);
+  assert.match(workflowDoc, /`scripts\/README\.md` summarizes those semantics/i);
+  assert.match(workflowDoc, /state-graph\/contract docs under `docs\/` remain part of the authoritative shipped contract surface/i);
+  assert.match(workflowDoc, /skills and phase docs explain workflow procedure and durable planning intent; they must not silently redefine shipped helper behavior/i);
+
+  assert.match(scriptsReadme, /code, tests, and the helper entrypoints themselves are authoritative for shipped runtime behavior/i);
+  assert.match(scriptsReadme, /this README summarizes those contracts for operators and maintainers; if behavior changes, update the code\/tests and then sync this document/i);
+
+  assert.match(devLoopSkill, /this skill owns the local phase procedure and artifact discipline/i);
+  assert.match(devLoopSkill, /it does not redefine the shipped runtime semantics of helper CLIs, shared loop logic, or extension commands/i);
+});
+
 test("copilot skill still contains its core workflow guidance", async () => {
   const content = await readRepo("skills/copilot-dev-loop/SKILL.md");
 


### PR DESCRIPTION
## Summary

Clarify docs and authority ownership for shipped helper/runtime behavior in the local workflow surfaces.

This slice keeps runtime behavior unchanged and tightens the wording so workflow docs, skill docs, and helper docs no longer blur which surfaces are authoritative.

## Scope / context

Problem addressed in this slice:
- finding 6 in the workflow remediation memo identified docs/authority ownership as still too blurry
- some docs over-owned or blurred shipped helper/runtime behavior
- that weakened audits and future maintenance even when runtime behavior itself was already correct

What this slice does:
- updates `docs/IMPLEMENTATION_WORKFLOW.md` to distinguish workflow/process docs from code-owned shipped helper/runtime semantics
- updates `scripts/README.md` to frame itself as a contract summary rather than the sole owner of helper behavior
- updates `skills/dev-loop/SKILL.md` to state that it owns local phase procedure/artifact discipline, not shipped helper/runtime semantics
- updates `docs/workflow-remediation-prep.md` to record chunk 6 as the bounded cleanup for finding 6
- adds one regression test to keep those authority boundaries aligned

Issue / remediation track context:
- issue #70 umbrella remediation
- chunk 6: docs / authority cleanup

## Acceptance criteria

- the local workflow explainer explicitly distinguishes durable workflow/process docs from code-owned helper/runtime semantics
- `scripts/README.md` no longer reads like the sole owner of helper behavior; it clearly summarizes contracts that remain code/test owned
- `skills/dev-loop/SKILL.md` clearly owns local dev-loop procedure and artifact expectations, not shipped runtime behavior
- `docs/workflow-remediation-prep.md` records finding 6 as docs/authority cleanup rather than a hidden runtime change
- one targeted regression test protects the new authority-boundary wording
- no runtime behavior changes occur in this chunk

## Definition of done

- bounded docs cleanup implemented
- new docs regression test added and passing after doc updates
- targeted validation passes locally
- `git diff --check` passes
- full `npm test` pass is green
- diff remains limited to the planned docs surfaces plus the single regression test
- final local pre-approval review gate is clean

## Non-goals

- no runtime code changes
- no CLI/output-schema changes
- no README-wide wording sweep
- no `copilot-dev-loop` or `copilot-autopilot` docs rewrite in this chunk
- no ownership-routing wiring
- no new workflow policy beyond clarifying authority boundaries for already-shipped surfaces
