### PR TITLE
Split inspect-run viewer into dedicated HTML and JSON endpoints

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -459,8 +459,8 @@ Contract:
   - `/` → operator-facing HTML with the top summary, compact outer-loop summary, copilot layer, reviewer layer, and steering summary
   - `/snapshot.json` → the full authoritative inspection snapshot JSON returned by the adapter
 - HTML includes a visible link to `/snapshot.json` so machine-readable state no longer depends on an inline full-snapshot dump in the page itself
-- `/snapshot.json` returns `application/json; charset=utf-8` on success and deterministic JSON error output with non-2xx status when snapshot loading throws
-- unsupported paths return deterministic `404`; `/favicon.ico` returns deterministic `204`; unsupported methods return `405 Allow: GET`; these paths do not load a snapshot
+- `/snapshot.json` returns `application/json; charset=utf-8` on success and deterministic JSON error output with non-2xx status when snapshot loading throws or yields no snapshot
+- unsupported paths return deterministic `404` without loading a snapshot (even for unsupported methods on unknown paths); `/favicon.ico` returns deterministic `204`; unsupported methods on supported routes return `405 Allow: GET`
 - both primary endpoints send `Cache-Control: no-store` to match the manual-reload workflow
 - manual reload only (`window.location.reload()`); no polling/watch/timeout/control semantics
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -444,6 +444,7 @@ Optional:
 - `--host <host>` (default: `127.0.0.1`; non-loopback binds require `--allow-non-localhost`)
 - `--port <port>` (default: `4311`)
 - `--allow-non-localhost` (explicit opt-in for non-loopback binds such as `0.0.0.0` or LAN IPs)
+- `--restart` (stop any existing listener on the chosen port before starting)
 - `--steering-state-file <path>` (pass-through to `inspect-run`)
 - `--reviewer-login <login>` (pass-through to `inspect-run`)
 - `--copilot-input <path>` (pass-through to `inspect-run`)
@@ -462,6 +463,7 @@ Contract:
 - `/snapshot.json` returns `application/json; charset=utf-8` on success and deterministic JSON error output with non-2xx status when snapshot loading throws or yields no snapshot
 - unsupported paths return deterministic `404` without loading a snapshot (even for unsupported methods on unknown paths); `/favicon.ico` returns deterministic `204`; unsupported methods on supported routes return `405 Allow: GET`
 - both primary endpoints send `Cache-Control: no-store` to match the manual-reload workflow
+- `--restart` is a local convenience flag that attempts to stop any existing listener already bound to the chosen port before starting the new server process
 - manual reload only (`window.location.reload()`); no polling/watch/timeout/control semantics
 
 Local manual verification path:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -444,7 +444,7 @@ Optional:
 - `--host <host>` (default: `127.0.0.1`; non-loopback binds require `--allow-non-localhost`)
 - `--port <port>` (default: `4311`)
 - `--allow-non-localhost` (explicit opt-in for non-loopback binds such as `0.0.0.0` or LAN IPs)
-- `--restart` (stop any existing listener on the chosen port before starting)
+- `--restart` (stop any existing listener on the chosen port before starting; requires `lsof` / POSIX support and sends `SIGTERM` to every listener already bound to that port)
 - `--steering-state-file <path>` (pass-through to `inspect-run`)
 - `--reviewer-login <login>` (pass-through to `inspect-run`)
 - `--copilot-input <path>` (pass-through to `inspect-run`)
@@ -463,7 +463,7 @@ Contract:
 - `/snapshot.json` returns `application/json; charset=utf-8` on success and deterministic JSON error output with non-2xx status when snapshot loading throws or yields no snapshot
 - unsupported paths return deterministic `404` without loading a snapshot (even for unsupported methods on unknown paths); `/favicon.ico` returns deterministic `204`; unsupported methods on supported routes return `405 Allow: GET`
 - both primary endpoints send `Cache-Control: no-store` to match the manual-reload workflow
-- `--restart` is a local convenience flag that attempts to stop any existing listener already bound to the chosen port before starting the new server process
+- `--restart` is a local convenience flag that requires `lsof` / POSIX support and attempts to stop every listener already bound to the chosen port with `SIGTERM` before starting the new server process
 - manual reload only (`window.location.reload()`); no polling/watch/timeout/control semantics
 
 Local manual verification path:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -455,16 +455,23 @@ Contract:
 - GitHub-first launch boundary: one explicit target (`repo` + `pr`)
 - uses one thin adapter module (`scripts/loop/_inspect-run-viewer-adapter.mjs`) to load the normalized inspection snapshot
 - adapter is the only viewer integration seam that calls the existing `inspect-run` contract in this source-loaded workspace
-- renders top summary fields directly from inspection snapshot (`runId` when present, `inspectedAt`, `activeStateFamily`, `outerAction`, `activeFamilyState`, `statusClass`, `needsAttention`, `sourceMode`, `trust`, `evidence.summary`, and markers)
-- renders separate read-only sections for outer-loop summary, copilot layer, reviewer layer, and steering summary, including explicit "not present / unavailable" output when a section is absent
+- serves two explicit read-only endpoints for the same target:
+  - `/` → operator-facing HTML with the top summary, compact outer-loop summary, copilot layer, reviewer layer, and steering summary
+  - `/snapshot.json` → the full authoritative inspection snapshot JSON returned by the adapter
+- HTML includes a visible link to `/snapshot.json` so machine-readable state no longer depends on an inline full-snapshot dump in the page itself
+- `/snapshot.json` returns `application/json; charset=utf-8` on success and deterministic JSON error output with non-2xx status when snapshot loading throws
+- unsupported paths return deterministic `404`; `/favicon.ico` returns deterministic `204`; unsupported methods return `405 Allow: GET`; these paths do not load a snapshot
+- both primary endpoints send `Cache-Control: no-store` to match the manual-reload workflow
 - manual reload only (`window.location.reload()`); no polling/watch/timeout/control semantics
 
 Local manual verification path:
 1. Start viewer for one explicit target:
    - `node scripts/loop/inspect-run-viewer.mjs --repo <owner/name> --pr <number>`
-2. Open printed URL in a local browser
-3. Use browser refresh or the reload button for point-in-time re-inspection
-4. For deterministic/local test mode, pass `--copilot-input` and `--reviewer-input` fixtures to viewer; these are forwarded to `inspect-run`
+2. Open the printed URL in a local browser and verify the human-oriented `/` page
+3. Open `<printed-url>/snapshot.json` and verify it returns the full inspection snapshot JSON for the same target
+4. Use browser refresh or the reload button for point-in-time re-inspection
+5. Optionally hit `/favicon.ico` or an unsupported path to confirm those paths stay deterministic and do not perform snapshot rendering
+6. For deterministic/local test mode, pass `--copilot-input` and `--reviewer-input` fixtures to viewer; these are forwarded to `inspect-run`
 
 ### `scripts/loop/steer-loop.mjs`
 

--- a/scripts/loop/inspect-run-viewer.mjs
+++ b/scripts/loop/inspect-run-viewer.mjs
@@ -187,6 +187,10 @@ function renderList(items) {
   return `<ul>${items.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>`;
 }
 
+function renderDefinitionList(entries) {
+  return `<dl>${entries.map(([label, value]) => `<dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd>`).join("")}</dl>`;
+}
+
 function renderLayerSection({ title, layer }) {
   if (layer === null || layer === undefined) {
     return `<section><h2>${escapeHtml(title)}</h2><p>not present / unavailable</p></section>`;
@@ -195,6 +199,30 @@ function renderLayerSection({ title, layer }) {
   return `<section>
     <h2>${escapeHtml(title)}</h2>
     <pre>${escapeHtml(JSON.stringify(layer, null, 2))}</pre>
+  </section>`;
+}
+
+function renderOuterLoopSummarySection(snapshot) {
+  if (snapshot === null || snapshot === undefined) {
+    return renderLayerSection({ title: "outer-loop summary", layer: null });
+  }
+
+  return `<section>
+    <h2>outer-loop summary</h2>
+    ${renderDefinitionList([
+      ["activeStateFamily", snapshot.activeStateFamily ?? "not present"],
+      ["outerAction", snapshot.outerAction ?? "not present"],
+      ["activeFamilyState", snapshot.activeFamilyState ?? "not present"],
+      ["statusClass", snapshot.statusClass ?? "not present"],
+      ["needsAttention", String(snapshot.needsAttention ?? "not present")],
+      ["sourceMode", snapshot.sourceMode ?? "not present"],
+      ["trust", snapshot.trust ?? "not present"],
+      ["evidence.summary", snapshot.evidence?.summary ?? "not present"],
+    ])}
+    <h3>evidence.authoritative</h3>
+    ${renderList(snapshot.evidence?.authoritative)}
+    <h3>evidence.checkpoint</h3>
+    ${renderList(snapshot.evidence?.checkpoint)}
   </section>`;
 }
 
@@ -234,20 +262,12 @@ export function renderInspectRunViewerHtml({
     </section>`
     : `<section>
       <h2>Top summary</h2>
-      <dl>
-        <dt>target.repo</dt><dd>${escapeHtml(normalizedSnapshot.target?.repo ?? target.repo)}</dd>
-        <dt>target.pr</dt><dd>${escapeHtml(normalizedSnapshot.target?.pr ?? target.pr)}</dd>
-        <dt>runId</dt><dd>${escapeHtml(runId)}</dd>
-        <dt>inspectedAt</dt><dd>${escapeHtml(normalizedSnapshot.inspectedAt ?? "not present")}</dd>
-        <dt>activeStateFamily</dt><dd>${escapeHtml(normalizedSnapshot.activeStateFamily ?? "not present")}</dd>
-        <dt>outerAction</dt><dd>${escapeHtml(normalizedSnapshot.outerAction ?? "not present")}</dd>
-        <dt>activeFamilyState</dt><dd>${escapeHtml(normalizedSnapshot.activeFamilyState ?? "not present")}</dd>
-        <dt>statusClass</dt><dd>${escapeHtml(normalizedSnapshot.statusClass ?? "not present")}</dd>
-        <dt>needsAttention</dt><dd>${escapeHtml(String(normalizedSnapshot.needsAttention ?? "not present"))}</dd>
-        <dt>sourceMode</dt><dd>${escapeHtml(normalizedSnapshot.sourceMode ?? "not present")}</dd>
-        <dt>trust</dt><dd>${escapeHtml(normalizedSnapshot.trust ?? "not present")}</dd>
-        <dt>evidence.summary</dt><dd>${escapeHtml(normalizedSnapshot.evidence?.summary ?? "not present")}</dd>
-      </dl>
+      ${renderDefinitionList([
+        ["target.repo", normalizedSnapshot.target?.repo ?? target.repo],
+        ["target.pr", normalizedSnapshot.target?.pr ?? target.pr],
+        ["runId", runId],
+        ["inspectedAt", normalizedSnapshot.inspectedAt ?? "not present"],
+      ])}
       <h3>Markers</h3>
       <h4>markers.missing</h4>
       ${renderList(normalizedSnapshot.markers?.missing)}
@@ -277,8 +297,9 @@ export function renderInspectRunViewerHtml({
     <p><strong>Target:</strong> <code>${escapeHtml(target.repo)}</code> PR <code>${escapeHtml(target.pr)}</code></p>
     <p><strong>Snapshot state:</strong> <span class="badge">${escapeHtml(stateLabel)}</span></p>
     <p><button type="button" onclick="window.location.reload()">Reload snapshot</button> (manual reload only)</p>
+    <p><strong>Raw snapshot:</strong> <a href="/snapshot.json"><code>/snapshot.json</code></a></p>
     ${topSummary}
-    ${renderLayerSection({ title: "outer-loop summary", layer: normalizedSnapshot })}
+    ${renderOuterLoopSummarySection(normalizedSnapshot)}
     ${renderLayerSection({ title: "copilot layer", layer: normalizedSnapshot?.layers?.copilot })}
     ${renderLayerSection({ title: "reviewer layer", layer: normalizedSnapshot?.layers?.reviewer })}
     ${renderLayerSection({ title: "steering summary", layer: normalizedSnapshot?.layers?.steering })}
@@ -303,6 +324,43 @@ function makeAdapterOptions(options) {
   return adapterOptions;
 }
 
+function setNoStore(response) {
+  response.setHeader("cache-control", "no-store");
+}
+
+function writeText(response, statusCode, body, headers = {}) {
+  response.statusCode = statusCode;
+  for (const [name, value] of Object.entries(headers)) {
+    response.setHeader(name, value);
+  }
+  response.end(body);
+}
+
+function writeJson(response, statusCode, payload) {
+  setNoStore(response);
+  writeText(
+    response,
+    statusCode,
+    `${JSON.stringify(payload, null, 2)}\n`,
+    { "content-type": "application/json; charset=utf-8" },
+  );
+}
+
+function writeHtml(response, html) {
+  setNoStore(response);
+  writeText(response, 200, html, { "content-type": "text/html; charset=utf-8" });
+}
+
+function jsonErrorPayload(target, error) {
+  return {
+    ok: false,
+    target,
+    error: {
+      message: error instanceof Error ? error.message : String(error),
+    },
+  };
+}
+
 export function formatInspectRunViewerUrl(host, port) {
   const formattedHost = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
   return new URL(`http://${formattedHost}:${port}`).toString().replace(/\/$/, "");
@@ -316,9 +374,36 @@ export function createInspectRunViewerServer(options, deps = {}) {
   return createServer(async (request, response) => {
     try {
       const requestPath = request.url ? new URL(request.url, "http://localhost").pathname : "/";
-      if (requestPath !== "/") {
-        response.statusCode = requestPath === "/favicon.ico" ? 204 : 404;
+      const method = request.method ?? "GET";
+
+      if (method !== "GET") {
+        writeText(response, 405, "Method Not Allowed", {
+          allow: "GET",
+          "content-type": "text/plain; charset=utf-8",
+        });
+        return;
+      }
+
+      if (requestPath === "/favicon.ico") {
+        response.statusCode = 204;
         response.end();
+        return;
+      }
+
+      if (requestPath === "/snapshot.json") {
+        try {
+          const snapshot = await adapter.loadSnapshot(target, adapterOptions);
+          writeJson(response, 200, snapshot ?? null);
+        } catch (error) {
+          writeJson(response, 500, jsonErrorPayload(target, error));
+        }
+        return;
+      }
+
+      if (requestPath !== "/") {
+        writeText(response, 404, "Not Found", {
+          "content-type": "text/plain; charset=utf-8",
+        });
         return;
       }
 
@@ -331,9 +416,7 @@ export function createInspectRunViewerServer(options, deps = {}) {
       }
 
       const html = renderInspectRunViewerHtml({ target, snapshot: snapshot ?? null, error });
-      response.statusCode = 200;
-      response.setHeader("content-type", "text/html; charset=utf-8");
-      response.end(html);
+      writeHtml(response, html);
     } catch (caught) {
       const message = caught instanceof Error ? caught.message : String(caught);
       const malformedRequest = /invalid url|uri malformed/i.test(message);

--- a/scripts/loop/inspect-run-viewer.mjs
+++ b/scripts/loop/inspect-run-viewer.mjs
@@ -191,25 +191,29 @@ function renderDefinitionList(entries) {
   return `<dl>${entries.map(([label, value]) => `<dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd>`).join("")}</dl>`;
 }
 
-function renderLayerSection({ title, layer }) {
-  if (layer === null || layer === undefined) {
+function renderCompactSection({ title, entries = [], lists = [] }) {
+  if (entries.length === 0 && lists.length === 0) {
     return `<section><h2>${escapeHtml(title)}</h2><p>not present / unavailable</p></section>`;
   }
 
   return `<section>
     <h2>${escapeHtml(title)}</h2>
-    <pre>${escapeHtml(JSON.stringify(layer, null, 2))}</pre>
+    ${entries.length > 0 ? renderDefinitionList(entries) : "<p>not present / unavailable</p>"}
+    ${lists.map(({ title: listTitle, items }) => `
+      <h3>${escapeHtml(listTitle)}</h3>
+      ${renderList(items)}
+    `).join("")}
   </section>`;
 }
 
 function renderOuterLoopSummarySection(snapshot) {
   if (snapshot === null || snapshot === undefined) {
-    return renderLayerSection({ title: "outer-loop summary", layer: null });
+    return renderCompactSection({ title: "outer-loop summary" });
   }
 
-  return `<section>
-    <h2>outer-loop summary</h2>
-    ${renderDefinitionList([
+  return renderCompactSection({
+    title: "outer-loop summary",
+    entries: [
       ["activeStateFamily", snapshot.activeStateFamily ?? "not present"],
       ["outerAction", snapshot.outerAction ?? "not present"],
       ["activeFamilyState", snapshot.activeFamilyState ?? "not present"],
@@ -218,12 +222,60 @@ function renderOuterLoopSummarySection(snapshot) {
       ["sourceMode", snapshot.sourceMode ?? "not present"],
       ["trust", snapshot.trust ?? "not present"],
       ["evidence.summary", snapshot.evidence?.summary ?? "not present"],
-    ])}
-    <h3>evidence.authoritative</h3>
-    ${renderList(snapshot.evidence?.authoritative)}
-    <h3>evidence.checkpoint</h3>
-    ${renderList(snapshot.evidence?.checkpoint)}
-  </section>`;
+    ],
+    lists: [
+      { title: "evidence.authoritative", items: snapshot.evidence?.authoritative },
+      { title: "evidence.checkpoint", items: snapshot.evidence?.checkpoint },
+    ],
+  });
+}
+
+function renderCopilotLayerSection(layer) {
+  if (layer === null || layer === undefined) {
+    return renderCompactSection({ title: "copilot layer" });
+  }
+
+  return renderCompactSection({
+    title: "copilot layer",
+    entries: [
+      ["currentState", layer.currentState ?? "not present"],
+    ],
+    lists: [
+      { title: "allowedTransitions", items: layer.allowedTransitions },
+    ],
+  });
+}
+
+function renderReviewerLayerSection(layer) {
+  if (layer === null || layer === undefined) {
+    return renderCompactSection({ title: "reviewer layer" });
+  }
+
+  return renderCompactSection({
+    title: "reviewer layer",
+    entries: [
+      ["currentState", layer.currentState ?? "not present"],
+      ["scope.mode", layer.scope?.mode ?? "not present"],
+      ["scope.reviewerLogin", layer.scope?.reviewerLogin ?? "not present"],
+    ],
+    lists: [
+      { title: "allowedTransitions", items: layer.allowedTransitions },
+    ],
+  });
+}
+
+function renderSteeringSummarySection(layer) {
+  if (layer === null || layer === undefined) {
+    return renderCompactSection({ title: "steering summary" });
+  }
+
+  return renderCompactSection({
+    title: "steering summary",
+    entries: [
+      ["status", layer.status ?? "not present"],
+      ["reason", layer.reason ?? "not present"],
+    ],
+  });
 }
 
 function renderSnapshotStateLabel(snapshot) {
@@ -295,14 +347,13 @@ export function renderInspectRunViewerHtml({
   <body>
     <h1>Read-only run viewer</h1>
     <p><strong>Target:</strong> <code>${escapeHtml(target.repo)}</code> PR <code>${escapeHtml(target.pr)}</code></p>
-    <p><strong>Snapshot state:</strong> <span class="badge">${escapeHtml(stateLabel)}</span></p>
-    <p><button type="button" onclick="window.location.reload()">Reload snapshot</button> (manual reload only)</p>
+    <p><strong>Snapshot state:</strong> <span class="badge">${escapeHtml(stateLabel)}</span> <button type="button" onclick="window.location.reload()" title="Reload snapshot" aria-label="Reload snapshot">🔄</button></p>
     <p><strong>Raw snapshot:</strong> <a href="/snapshot.json"><code>/snapshot.json</code></a></p>
     ${topSummary}
     ${renderOuterLoopSummarySection(normalizedSnapshot)}
-    ${renderLayerSection({ title: "copilot layer", layer: normalizedSnapshot?.layers?.copilot })}
-    ${renderLayerSection({ title: "reviewer layer", layer: normalizedSnapshot?.layers?.reviewer })}
-    ${renderLayerSection({ title: "steering summary", layer: normalizedSnapshot?.layers?.steering })}
+    ${renderCopilotLayerSection(normalizedSnapshot?.layers?.copilot)}
+    ${renderReviewerLayerSection(normalizedSnapshot?.layers?.reviewer)}
+    ${renderSteeringSummarySection(normalizedSnapshot?.layers?.steering)}
   </body>
 </html>`;
 }

--- a/scripts/loop/inspect-run-viewer.mjs
+++ b/scripts/loop/inspect-run-viewer.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
+import { execFile as execFileCallback } from "node:child_process";
 import { createServer } from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 
 import { formatCliError } from "../_core-helpers.mjs";
 import {
@@ -10,7 +12,7 @@ import {
 } from "./_inspect-run-viewer-adapter.mjs";
 
 const USAGE = `Usage: inspect-run-viewer.mjs --repo <owner/name> --pr <number>
-  [--host <host>] [--port <port>] [--allow-non-localhost]
+  [--host <host>] [--port <port>] [--allow-non-localhost] [--restart]
   [--steering-state-file <path>] [--reviewer-login <login>]
   [--copilot-input <path>] [--reviewer-input <path>]
 
@@ -25,6 +27,8 @@ Optional:
   --port <port>                         Bind port (default: 4311)
   --allow-non-localhost                 Permit non-loopback binds
                                         (otherwise rejected)
+  --restart                             Stop any existing listener on the
+                                        chosen port before starting
   --steering-state-file <path>          Pass-through to inspect-run
   --reviewer-login <login>              Pass-through to inspect-run
   --copilot-input <path>                Pass-through to inspect-run
@@ -34,6 +38,7 @@ Optional:
 
 const DEFAULT_HOST = "127.0.0.1";
 const DEFAULT_PORT = 4311;
+const execFile = promisify(execFileCallback);
 
 function parseError(message) {
   return Object.assign(new Error(message), { usage: USAGE });
@@ -105,6 +110,7 @@ export function parseInspectRunViewerCliArgs(argv) {
     copilotInputPath: undefined,
     reviewerInputPath: undefined,
     allowNonLocalhost: false,
+    restart: false,
   };
 
   while (args.length > 0) {
@@ -131,6 +137,10 @@ export function parseInspectRunViewerCliArgs(argv) {
     }
     if (token === "--allow-non-localhost") {
       options.allowNonLocalhost = true;
+      continue;
+    }
+    if (token === "--restart") {
+      options.restart = true;
       continue;
     }
     if (token === "--steering-state-file") {
@@ -428,6 +438,59 @@ export function formatInspectRunViewerUrl(host, port) {
   return new URL(`http://${formattedHost}:${port}`).toString().replace(/\/$/, "");
 }
 
+async function listListeningPidsForPort(port, { execFileImpl = execFile } = {}) {
+  try {
+    const { stdout } = await execFileImpl("lsof", [`-tiTCP:${port}`, "-sTCP:LISTEN"]);
+    return stdout
+      .split(/\r?\n/)
+      .map((line) => Number(line.trim()))
+      .filter((pid) => Number.isInteger(pid) && pid > 0);
+  } catch (error) {
+    if (error && error.code === 1) {
+      return [];
+    }
+    throw error;
+  }
+}
+
+export async function restartExistingPortListener(
+  port,
+  {
+    listListeningPidsImpl = listListeningPidsForPort,
+    killProcessImpl = (pid, signal) => process.kill(pid, signal),
+    isProcessAliveImpl = (pid) => {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    sleepImpl = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    timeoutMs = 1500,
+    pollIntervalMs = 50,
+  } = {},
+) {
+  const pids = (await listListeningPidsImpl(port)).filter((pid) => pid !== process.pid);
+  if (pids.length === 0) {
+    return [];
+  }
+
+  for (const pid of pids) {
+    killProcessImpl(pid, "SIGTERM");
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (pids.every((pid) => !isProcessAliveImpl(pid))) {
+      return pids;
+    }
+    await sleepImpl(pollIntervalMs);
+  }
+
+  throw new Error(`--restart could not stop existing listener on port ${port}`);
+}
+
 export function createInspectRunViewerServer(options, deps = {}) {
   const adapter = deps.adapter ?? createInspectionViewerAdapter();
   const target = normalizeInspectionTarget({ repo: options.repo, pr: options.pr });
@@ -499,6 +562,10 @@ export async function runCli(
   if (options.help) {
     stdout.write(`${USAGE}\n`);
     return null;
+  }
+
+  if (options.restart) {
+    await restartExistingPortListener(options.port);
   }
 
   const server = createInspectRunViewerServer(options);

--- a/scripts/loop/inspect-run-viewer.mjs
+++ b/scripts/loop/inspect-run-viewer.mjs
@@ -305,6 +305,7 @@ export function renderInspectRunViewerHtml({
   const normalizedSnapshot = snapshot ?? null;
   const stateLabel = renderSnapshotStateLabel(normalizedSnapshot);
   const title = `${target.repo}#${target.pr} inspection snapshot`;
+  const pageHeading = `PR #${target.pr} inspection`;
   const runId = normalizedSnapshot?.runId ?? "not present";
   const topSummary = normalizedSnapshot === null
     ? `<section>
@@ -345,8 +346,8 @@ export function renderInspectRunViewerHtml({
     </style>
   </head>
   <body>
-    <h1>Read-only run viewer</h1>
-    <p><strong>Target:</strong> <code>${escapeHtml(target.repo)}</code> PR <code>${escapeHtml(target.pr)}</code></p>
+    <h1>${escapeHtml(pageHeading)}</h1>
+    <p><strong>Target:</strong> <code>${escapeHtml(target.repo)}</code></p>
     <p><strong>Snapshot state:</strong> <span class="badge">${escapeHtml(stateLabel)}</span> <button type="button" onclick="window.location.reload()" title="Reload snapshot" aria-label="Reload snapshot">🔄</button></p>
     <p><strong>Raw snapshot:</strong> <a href="/snapshot.json"><code>/snapshot.json</code></a></p>
     ${topSummary}

--- a/scripts/loop/inspect-run-viewer.mjs
+++ b/scripts/loop/inspect-run-viewer.mjs
@@ -382,6 +382,7 @@ function setNoStore(response) {
 }
 
 function writeText(response, statusCode, body, headers = {}) {
+  setNoStore(response);
   response.statusCode = statusCode;
   for (const [name, value] of Object.entries(headers)) {
     response.setHeader(name, value);

--- a/scripts/loop/inspect-run-viewer.mjs
+++ b/scripts/loop/inspect-run-viewer.mjs
@@ -440,7 +440,16 @@ export function formatInspectRunViewerUrl(host, port) {
   return new URL(`http://${formattedHost}:${port}`).toString().replace(/\/$/, "");
 }
 
-async function listListeningPidsForPort(port, { execFileImpl = execFile } = {}) {
+function isLsofNoListenerResult(error) {
+  if (!error || error.code !== 1) {
+    return false;
+  }
+
+  const stderr = typeof error.stderr === "string" ? error.stderr.trim() : "";
+  return stderr.length === 0;
+}
+
+export async function listListeningPidsForPort(port, { execFileImpl = execFile } = {}) {
   try {
     const { stdout } = await execFileImpl("lsof", [`-tiTCP:${port}`, "-sTCP:LISTEN"]);
     return stdout
@@ -448,7 +457,7 @@ async function listListeningPidsForPort(port, { execFileImpl = execFile } = {}) 
       .map((line) => Number(line.trim()))
       .filter((pid) => Number.isInteger(pid) && pid > 0);
   } catch (error) {
-    if (error && error.code === 1) {
+    if (isLsofNoListenerResult(error)) {
       return [];
     }
     throw error;
@@ -556,10 +565,25 @@ export function createInspectRunViewerServer(options, deps = {}) {
   });
 }
 
+function normalizeRestartCapabilityError(error) {
+  const missingLsof = error?.code === "ENOENT"
+    && (error?.path === "lsof" || /(^|\b)lsof(\b|$)/i.test(String(error?.message ?? "")));
+  if (!missingLsof) {
+    return error;
+  }
+
+  const parseFriendlyError = parseError(
+    "--restart requires lsof/POSIX support; install lsof or rerun without --restart",
+  );
+  parseFriendlyError.cause = error;
+  return parseFriendlyError;
+}
+
 export async function runCli(
   argv = process.argv.slice(2),
   {
     stdout = process.stdout,
+    restartExistingPortListenerImpl = restartExistingPortListener,
   } = {},
 ) {
   const options = parseInspectRunViewerCliArgs(argv);
@@ -569,7 +593,11 @@ export async function runCli(
   }
 
   if (options.restart) {
-    await restartExistingPortListener(options.port);
+    try {
+      await restartExistingPortListenerImpl(options.port);
+    } catch (error) {
+      throw normalizeRestartCapabilityError(error);
+    }
   }
 
   const server = createInspectRunViewerServer(options);

--- a/scripts/loop/inspect-run-viewer.mjs
+++ b/scripts/loop/inspect-run-viewer.mjs
@@ -460,14 +460,6 @@ export async function restartExistingPortListener(
   {
     listListeningPidsImpl = listListeningPidsForPort,
     killProcessImpl = (pid, signal) => process.kill(pid, signal),
-    isProcessAliveImpl = (pid) => {
-      try {
-        process.kill(pid, 0);
-        return true;
-      } catch {
-        return false;
-      }
-    },
     sleepImpl = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
     timeoutMs = 1500,
     pollIntervalMs = 50,
@@ -490,7 +482,8 @@ export async function restartExistingPortListener(
 
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (pids.every((pid) => !isProcessAliveImpl(pid))) {
+    const remainingListeners = (await listListeningPidsImpl(port)).filter((pid) => pid !== process.pid);
+    if (remainingListeners.length === 0) {
       return pids;
     }
     await sleepImpl(pollIntervalMs);

--- a/scripts/loop/inspect-run-viewer.mjs
+++ b/scripts/loop/inspect-run-viewer.mjs
@@ -349,6 +349,7 @@ export function renderInspectRunViewerHtml({
     <h1>${escapeHtml(pageHeading)}</h1>
     <p><strong>Target:</strong> <code>${escapeHtml(target.repo)}</code></p>
     <p><strong>Snapshot state:</strong> <span class="badge">${escapeHtml(stateLabel)}</span> <button type="button" onclick="window.location.reload()" title="Reload snapshot" aria-label="Reload snapshot">🔄</button></p>
+    <p><strong>Refresh:</strong> manual reload only.</p>
     <p><strong>Raw snapshot:</strong> <a href="/snapshot.json"><code>/snapshot.json</code></a></p>
     ${topSummary}
     ${renderOuterLoopSummarySection(normalizedSnapshot)}

--- a/scripts/loop/inspect-run-viewer.mjs
+++ b/scripts/loop/inspect-run-viewer.mjs
@@ -29,6 +29,8 @@ Optional:
                                         (otherwise rejected)
   --restart                             Stop any existing listener on the
                                         chosen port before starting
+                                        (requires lsof/POSIX; sends
+                                        SIGTERM to all listeners)
   --steering-state-file <path>          Pass-through to inspect-run
   --reviewer-login <login>              Pass-through to inspect-run
   --copilot-input <path>                Pass-through to inspect-run
@@ -545,9 +547,12 @@ export function createInspectRunViewerServer(options, deps = {}) {
     } catch (caught) {
       const message = caught instanceof Error ? caught.message : String(caught);
       const malformedRequest = /invalid url|uri malformed/i.test(message);
-      response.statusCode = malformedRequest ? 400 : 500;
-      response.setHeader("content-type", "text/plain; charset=utf-8");
-      response.end(malformedRequest ? "Bad Request" : "Internal Server Error");
+      writeText(
+        response,
+        malformedRequest ? 400 : 500,
+        malformedRequest ? "Bad Request" : "Internal Server Error",
+        { "content-type": "text/plain; charset=utf-8" },
+      );
     }
   });
 }

--- a/scripts/loop/inspect-run-viewer.mjs
+++ b/scripts/loop/inspect-run-viewer.mjs
@@ -361,6 +361,14 @@ function jsonErrorPayload(target, error) {
   };
 }
 
+function requireSnapshotForJson(snapshot) {
+  if (snapshot === null || snapshot === undefined) {
+    throw new Error("inspection snapshot unavailable");
+  }
+
+  return snapshot;
+}
+
 export function formatInspectRunViewerUrl(host, port) {
   const formattedHost = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
   return new URL(`http://${formattedHost}:${port}`).toString().replace(/\/$/, "");
@@ -376,6 +384,19 @@ export function createInspectRunViewerServer(options, deps = {}) {
       const requestPath = request.url ? new URL(request.url, "http://localhost").pathname : "/";
       const method = request.method ?? "GET";
 
+      if (requestPath === "/favicon.ico") {
+        response.statusCode = 204;
+        response.end();
+        return;
+      }
+
+      if (requestPath !== "/" && requestPath !== "/snapshot.json") {
+        writeText(response, 404, "Not Found", {
+          "content-type": "text/plain; charset=utf-8",
+        });
+        return;
+      }
+
       if (method !== "GET") {
         writeText(response, 405, "Method Not Allowed", {
           allow: "GET",
@@ -384,26 +405,13 @@ export function createInspectRunViewerServer(options, deps = {}) {
         return;
       }
 
-      if (requestPath === "/favicon.ico") {
-        response.statusCode = 204;
-        response.end();
-        return;
-      }
-
       if (requestPath === "/snapshot.json") {
         try {
-          const snapshot = await adapter.loadSnapshot(target, adapterOptions);
-          writeJson(response, 200, snapshot ?? null);
+          const snapshot = requireSnapshotForJson(await adapter.loadSnapshot(target, adapterOptions));
+          writeJson(response, 200, snapshot);
         } catch (error) {
           writeJson(response, 500, jsonErrorPayload(target, error));
         }
-        return;
-      }
-
-      if (requestPath !== "/") {
-        writeText(response, 404, "Not Found", {
-          "content-type": "text/plain; charset=utf-8",
-        });
         return;
       }
 

--- a/scripts/loop/inspect-run-viewer.mjs
+++ b/scripts/loop/inspect-run-viewer.mjs
@@ -479,7 +479,13 @@ export async function restartExistingPortListener(
   }
 
   for (const pid of pids) {
-    killProcessImpl(pid, "SIGTERM");
+    try {
+      killProcessImpl(pid, "SIGTERM");
+    } catch (error) {
+      if (error?.code !== "ESRCH") {
+        throw error;
+      }
+    }
   }
 
   const deadline = Date.now() + timeoutMs;

--- a/test/loop/inspect-run-viewer.test.mjs
+++ b/test/loop/inspect-run-viewer.test.mjs
@@ -6,9 +6,11 @@ import test from "node:test";
 import {
   createInspectRunViewerServer,
   formatInspectRunViewerUrl,
+  listListeningPidsForPort,
   parseInspectRunViewerCliArgs,
   renderInspectRunViewerHtml,
   restartExistingPortListener,
+  runCli,
 } from "../../scripts/loop/inspect-run-viewer.mjs";
 import { createInspectionViewerAdapter } from "../../scripts/loop/_inspect-run-viewer-adapter.mjs";
 
@@ -125,6 +127,32 @@ test("restartExistingPortListener is a no-op when nothing is listening", async (
   });
 
   assert.deepEqual(restarted, []);
+});
+
+
+test("listListeningPidsForPort only treats empty-stderr lsof exit 1 as no listeners", async () => {
+  const emptyResult = await listListeningPidsForPort(4311, {
+    execFileImpl: async () => {
+      const error = new Error("no listeners");
+      error.code = 1;
+      error.stderr = "";
+      throw error;
+    },
+  });
+
+  assert.deepEqual(emptyResult, []);
+
+  await assert.rejects(
+    () => listListeningPidsForPort(4311, {
+      execFileImpl: async () => {
+        const error = new Error("unsupported flag");
+        error.code = 1;
+        error.stderr = "lsof: illegal option";
+        throw error;
+      },
+    }),
+    /unsupported flag/,
+  );
 });
 
 test("restartExistingPortListener stops existing listeners on the chosen port", async () => {
@@ -595,4 +623,30 @@ test("createInspectRunViewerServer guards malformed request URLs and undefined s
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }
+});
+
+test("runCli explains missing lsof when --restart is requested", async () => {
+  await assert.rejects(
+    () => runCli([
+      "--repo",
+      "owner/repo",
+      "--pr",
+      "55",
+      "--restart",
+    ], {
+      stdout: { write() {} },
+      restartExistingPortListenerImpl: async () => {
+        const error = new Error("spawn lsof ENOENT");
+        error.code = "ENOENT";
+        error.path = "lsof";
+        throw error;
+      },
+    }),
+    (error) => {
+      assert.match(error.message, /--restart requires lsof\/POSIX support/i);
+      assert.equal(typeof error.usage, "string");
+      assert.match(error.usage, /--restart/);
+      return true;
+    },
+  );
 });

--- a/test/loop/inspect-run-viewer.test.mjs
+++ b/test/loop/inspect-run-viewer.test.mjs
@@ -153,6 +153,8 @@ test("renderInspectRunViewerHtml renders required top-level fields for authorita
   assert.match(html, /reviewer layer/);
   assert.match(html, /steering summary/);
   assert.match(html, /href="\/snapshot\.json"/);
+  assert.match(html, /title="Reload snapshot"/);
+  assert.doesNotMatch(html, /<pre>/);
   assert.doesNotMatch(html, /"schemaVersion": 1/);
   assert.doesNotMatch(html, /"ok": true/);
 });

--- a/test/loop/inspect-run-viewer.test.mjs
+++ b/test/loop/inspect-run-viewer.test.mjs
@@ -148,6 +148,33 @@ test("restartExistingPortListener stops existing listeners on the chosen port", 
   ]);
 });
 
+
+test("restartExistingPortListener tolerates listeners that exit before SIGTERM", async () => {
+  const alive = new Set([222]);
+  const killed = [];
+
+  const restarted = await restartExistingPortListener(4311, {
+    listListeningPidsImpl: async () => [111, 222],
+    killProcessImpl: (pid, signal) => {
+      killed.push([pid, signal]);
+      if (pid === 111) {
+        const error = new Error("process already exited");
+        error.code = "ESRCH";
+        throw error;
+      }
+      alive.delete(pid);
+    },
+    isProcessAliveImpl: (pid) => alive.has(pid),
+    sleepImpl: async () => {},
+  });
+
+  assert.deepEqual(restarted, [111, 222]);
+  assert.deepEqual(killed, [
+    [111, "SIGTERM"],
+    [222, "SIGTERM"],
+  ]);
+});
+
 test("formatInspectRunViewerUrl formats IPv4 and IPv6 hosts for copy-pasteable output", () => {
   assert.equal(formatInspectRunViewerUrl("127.0.0.1", 4311), "http://127.0.0.1:4311");
   assert.equal(formatInspectRunViewerUrl("::1", 4311), "http://[::1]:4311");

--- a/test/loop/inspect-run-viewer.test.mjs
+++ b/test/loop/inspect-run-viewer.test.mjs
@@ -8,6 +8,7 @@ import {
   formatInspectRunViewerUrl,
   parseInspectRunViewerCliArgs,
   renderInspectRunViewerHtml,
+  restartExistingPortListener,
 } from "../../scripts/loop/inspect-run-viewer.mjs";
 import { createInspectionViewerAdapter } from "../../scripts/loop/_inspect-run-viewer-adapter.mjs";
 
@@ -78,9 +79,11 @@ test("parseInspectRunViewerCliArgs normalizes target values and rejects malforme
     "--host",
     "0.0.0.0",
     "--allow-non-localhost",
+    "--restart",
   ]);
   assert.equal(nonLocalhostOptIn.host, "0.0.0.0");
   assert.equal(nonLocalhostOptIn.allowNonLocalhost, true);
+  assert.equal(nonLocalhostOptIn.restart, true);
 
   let malformedTargetError;
   try {
@@ -114,6 +117,35 @@ test("parseInspectRunViewerCliArgs normalizes target values and rejects malforme
     () => parseInspectRunViewerCliArgs(["--repo", "owner/repo", "--pr", "55", "--host", "   "]),
     /--host must not be empty/i,
   );
+});
+
+test("restartExistingPortListener is a no-op when nothing is listening", async () => {
+  const restarted = await restartExistingPortListener(4311, {
+    listListeningPidsImpl: async () => [],
+  });
+
+  assert.deepEqual(restarted, []);
+});
+
+test("restartExistingPortListener stops existing listeners on the chosen port", async () => {
+  const alive = new Set([111, 222]);
+  const killed = [];
+
+  const restarted = await restartExistingPortListener(4311, {
+    listListeningPidsImpl: async () => [111, 222],
+    killProcessImpl: (pid, signal) => {
+      killed.push([pid, signal]);
+      alive.delete(pid);
+    },
+    isProcessAliveImpl: (pid) => alive.has(pid),
+    sleepImpl: async () => {},
+  });
+
+  assert.deepEqual(restarted, [111, 222]);
+  assert.deepEqual(killed, [
+    [111, "SIGTERM"],
+    [222, "SIGTERM"],
+  ]);
 });
 
 test("formatInspectRunViewerUrl formats IPv4 and IPv6 hosts for copy-pasteable output", () => {

--- a/test/loop/inspect-run-viewer.test.mjs
+++ b/test/loop/inspect-run-viewer.test.mjs
@@ -128,16 +128,17 @@ test("restartExistingPortListener is a no-op when nothing is listening", async (
 });
 
 test("restartExistingPortListener stops existing listeners on the chosen port", async () => {
-  const alive = new Set([111, 222]);
   const killed = [];
+  let pollCount = 0;
 
   const restarted = await restartExistingPortListener(4311, {
-    listListeningPidsImpl: async () => [111, 222],
+    listListeningPidsImpl: async () => {
+      pollCount += 1;
+      return pollCount === 1 ? [111, 222] : [];
+    },
     killProcessImpl: (pid, signal) => {
       killed.push([pid, signal]);
-      alive.delete(pid);
     },
-    isProcessAliveImpl: (pid) => alive.has(pid),
     sleepImpl: async () => {},
   });
 
@@ -150,11 +151,14 @@ test("restartExistingPortListener stops existing listeners on the chosen port", 
 
 
 test("restartExistingPortListener tolerates listeners that exit before SIGTERM", async () => {
-  const alive = new Set([222]);
   const killed = [];
+  let pollCount = 0;
 
   const restarted = await restartExistingPortListener(4311, {
-    listListeningPidsImpl: async () => [111, 222],
+    listListeningPidsImpl: async () => {
+      pollCount += 1;
+      return pollCount === 1 ? [111, 222] : [];
+    },
     killProcessImpl: (pid, signal) => {
       killed.push([pid, signal]);
       if (pid === 111) {
@@ -162,9 +166,7 @@ test("restartExistingPortListener tolerates listeners that exit before SIGTERM",
         error.code = "ESRCH";
         throw error;
       }
-      alive.delete(pid);
     },
-    isProcessAliveImpl: (pid) => alive.has(pid),
     sleepImpl: async () => {},
   });
 
@@ -173,6 +175,27 @@ test("restartExistingPortListener tolerates listeners that exit before SIGTERM",
     [111, "SIGTERM"],
     [222, "SIGTERM"],
   ]);
+});
+
+
+test("restartExistingPortListener waits for the port to become free, not for the process to exit", async () => {
+  const killed = [];
+  let pollCount = 0;
+
+  const restarted = await restartExistingPortListener(4311, {
+    listListeningPidsImpl: async () => {
+      pollCount += 1;
+      return pollCount === 1 ? [111] : [];
+    },
+    killProcessImpl: (pid, signal) => {
+      killed.push([pid, signal]);
+    },
+    sleepImpl: async () => {},
+  });
+
+  assert.deepEqual(restarted, [111]);
+  assert.deepEqual(killed, [[111, "SIGTERM"]]);
+  assert.equal(pollCount, 2);
 });
 
 test("formatInspectRunViewerUrl formats IPv4 and IPv6 hosts for copy-pasteable output", () => {

--- a/test/loop/inspect-run-viewer.test.mjs
+++ b/test/loop/inspect-run-viewer.test.mjs
@@ -429,19 +429,23 @@ test("createInspectRunViewerServer keeps favicon, unsupported paths, and unsuppo
 
     const missingResponse = await requestOnce(`http://127.0.0.1:${address.port}/nope`);
     assert.equal(missingResponse.statusCode, 404);
+    assert.equal(missingResponse.headers["cache-control"], "no-store");
     assert.equal(loadCount, 0);
 
     const postHtmlResponse = await requestOnce(`http://127.0.0.1:${address.port}/`, { method: "POST" });
     assert.equal(postHtmlResponse.statusCode, 405);
     assert.equal(postHtmlResponse.headers.allow, "GET");
+    assert.equal(postHtmlResponse.headers["cache-control"], "no-store");
     assert.equal(loadCount, 0);
 
     const postJsonResponse = await requestOnce(`http://127.0.0.1:${address.port}/snapshot.json`, { method: "POST" });
     assert.equal(postJsonResponse.statusCode, 405);
     assert.equal(postJsonResponse.headers.allow, "GET");
+    assert.equal(postJsonResponse.headers["cache-control"], "no-store");
 
     const postMissingPathResponse = await requestOnce(`http://127.0.0.1:${address.port}/nope`, { method: "POST" });
     assert.equal(postMissingPathResponse.statusCode, 404);
+    assert.equal(postMissingPathResponse.headers["cache-control"], "no-store");
     assert.equal(loadCount, 0);
   } finally {
     await new Promise((resolve) => server.close(resolve));

--- a/test/loop/inspect-run-viewer.test.mjs
+++ b/test/loop/inspect-run-viewer.test.mjs
@@ -539,6 +539,7 @@ test("createInspectRunViewerServer guards malformed request URLs and undefined s
 
     assert.equal(malformedResponse.statusCode, 400);
     assert.equal(malformedResponse.headers["content-type"], "text/plain; charset=utf-8");
+    assert.equal(malformedResponse.headers["cache-control"], "no-store");
     assert.equal(malformedResponse.body, "Bad Request");
     assert.equal(loadCount, 1);
   } finally {

--- a/test/loop/inspect-run-viewer.test.mjs
+++ b/test/loop/inspect-run-viewer.test.mjs
@@ -154,6 +154,7 @@ test("renderInspectRunViewerHtml renders required top-level fields for authorita
   assert.match(html, /steering summary/);
   assert.match(html, /href="\/snapshot\.json"/);
   assert.match(html, /title="Reload snapshot"/);
+  assert.match(html, /manual reload only/i);
   assert.doesNotMatch(html, /<pre>/);
   assert.doesNotMatch(html, /"schemaVersion": 1/);
   assert.doesNotMatch(html, /"ok": true/);
@@ -283,6 +284,7 @@ test("createInspectRunViewerServer serves browser html from adapter snapshot wit
     assert.match(response.body, /PR #55 inspection/);
     assert.match(response.body, /owner\/repo/);
     assert.match(response.body, /degraded/);
+    assert.match(response.body, /manual reload only/i);
     assert.match(response.body, /href="\/snapshot\.json"/);
     assert.doesNotMatch(response.body, /"schemaVersion": 1/);
     assert.equal(loadCount, 1);

--- a/test/loop/inspect-run-viewer.test.mjs
+++ b/test/loop/inspect-run-viewer.test.mjs
@@ -129,7 +129,7 @@ test("renderInspectRunViewerHtml renders required top-level fields for authorita
     snapshot: makeSnapshot(),
   });
 
-  assert.match(html, /Read-only run viewer/);
+  assert.match(html, /PR #55 inspection/);
   assert.match(html, /target\.repo/);
   assert.match(html, /owner\/repo/);
   assert.match(html, /target\.pr/);
@@ -280,7 +280,7 @@ test("createInspectRunViewerServer serves browser html from adapter snapshot wit
     assert.equal(response.statusCode, 200);
     assert.equal(response.headers["content-type"], "text/html; charset=utf-8");
     assert.equal(response.headers["cache-control"], "no-store");
-    assert.match(response.body, /Read-only run viewer/);
+    assert.match(response.body, /PR #55 inspection/);
     assert.match(response.body, /owner\/repo/);
     assert.match(response.body, /degraded/);
     assert.match(response.body, /href="\/snapshot\.json"/);

--- a/test/loop/inspect-run-viewer.test.mjs
+++ b/test/loop/inspect-run-viewer.test.mjs
@@ -320,6 +320,40 @@ test("createInspectRunViewerServer serves authoritative snapshot JSON on /snapsh
   }
 });
 
+test("createInspectRunViewerServer treats missing JSON snapshots as machine-readable failures", async () => {
+  let loadCount = 0;
+  const adapter = {
+    async loadSnapshot() {
+      loadCount += 1;
+      return undefined;
+    },
+  };
+
+  const server = createInspectRunViewerServer(
+    { repo: "owner/repo", pr: "55", host: "127.0.0.1", port: 0 },
+    { adapter },
+  );
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+
+  try {
+    const address = server.address();
+    const response = await requestOnce(`http://127.0.0.1:${address.port}/snapshot.json`);
+
+    assert.equal(response.statusCode, 500);
+    assert.equal(response.headers["content-type"], "application/json; charset=utf-8");
+    assert.equal(response.headers["cache-control"], "no-store");
+    assert.deepEqual(JSON.parse(response.body), {
+      ok: false,
+      target: { repo: "owner/repo", pr: 55 },
+      error: { message: "inspection snapshot unavailable" },
+    });
+    assert.equal(loadCount, 1);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
 test("createInspectRunViewerServer keeps JSON failures machine-readable and HTML failures browser-friendly", async () => {
   let loadCount = 0;
   const adapter = {
@@ -401,6 +435,9 @@ test("createInspectRunViewerServer keeps favicon, unsupported paths, and unsuppo
     const postJsonResponse = await requestOnce(`http://127.0.0.1:${address.port}/snapshot.json`, { method: "POST" });
     assert.equal(postJsonResponse.statusCode, 405);
     assert.equal(postJsonResponse.headers.allow, "GET");
+
+    const postMissingPathResponse = await requestOnce(`http://127.0.0.1:${address.port}/nope`, { method: "POST" });
+    assert.equal(postMissingPathResponse.statusCode, 404);
     assert.equal(loadCount, 0);
   } finally {
     await new Promise((resolve) => server.close(resolve));

--- a/test/loop/inspect-run-viewer.test.mjs
+++ b/test/loop/inspect-run-viewer.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { once } from "node:events";
-import { get } from "node:http";
+import { get, request } from "node:http";
 import test from "node:test";
 
 import {
@@ -34,6 +34,27 @@ function makeSnapshot(overrides = {}) {
     },
     ...overrides,
   };
+}
+
+function requestOnce(url, { method = "GET" } = {}) {
+  return new Promise((resolve, reject) => {
+    const req = request(url, { method }, (response) => {
+      let body = "";
+      response.setEncoding("utf8");
+      response.on("data", (chunk) => {
+        body += chunk;
+      });
+      response.on("end", () => {
+        resolve({
+          statusCode: response.statusCode,
+          headers: response.headers,
+          body,
+        });
+      });
+    });
+    req.on("error", reject);
+    req.end();
+  });
 }
 
 test("parseInspectRunViewerCliArgs normalizes target values and rejects malformed input with usage", () => {
@@ -102,7 +123,7 @@ test("formatInspectRunViewerUrl formats IPv4 and IPv6 hosts for copy-pasteable o
   assert.equal(formatInspectRunViewerUrl("0.0.0.0", 4311), "http://0.0.0.0:4311");
 });
 
-test("renderInspectRunViewerHtml renders required top-level fields for authoritative snapshot", () => {
+test("renderInspectRunViewerHtml renders required top-level fields for authoritative snapshot and links to raw JSON", () => {
   const html = renderInspectRunViewerHtml({
     target: { repo: "owner/repo", pr: 55 },
     snapshot: makeSnapshot(),
@@ -131,6 +152,9 @@ test("renderInspectRunViewerHtml renders required top-level fields for authorita
   assert.match(html, /copilot layer/);
   assert.match(html, /reviewer layer/);
   assert.match(html, /steering summary/);
+  assert.match(html, /href="\/snapshot\.json"/);
+  assert.doesNotMatch(html, /"schemaVersion": 1/);
+  assert.doesNotMatch(html, /"ok": true/);
 });
 
 test("renderInspectRunViewerHtml renders checkpoint-only / degraded cues and absent sections", () => {
@@ -181,6 +205,7 @@ test("renderInspectRunViewerHtml renders unavailable snapshot and malformed targ
   assert.match(html, /Snapshot unavailable/);
   assert.match(html, /target\.pr must be a positive integer/);
   assert.match(html, /manual reload only/i);
+  assert.match(html, /href="\/snapshot\.json"/);
 });
 
 
@@ -230,7 +255,7 @@ test("createInspectionViewerAdapter keeps normalized target authoritative over o
   });
 });
 
-test("createInspectRunViewerServer serves browser html from adapter snapshot", async () => {
+test("createInspectRunViewerServer serves browser html from adapter snapshot without inline full snapshot dump", async () => {
   let loadCount = 0;
   const adapter = {
     async loadSnapshot() {
@@ -248,30 +273,135 @@ test("createInspectRunViewerServer serves browser html from adapter snapshot", a
 
   try {
     const address = server.address();
-    const body = await new Promise((resolve, reject) => {
-      get(`http://127.0.0.1:${address.port}`, (response) => {
-        let text = "";
-        response.on("data", (chunk) => {
-          text += String(chunk);
-        });
-        response.on("end", () => resolve(text));
-      }).on("error", reject);
+    const response = await requestOnce(`http://127.0.0.1:${address.port}/`);
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.headers["content-type"], "text/html; charset=utf-8");
+    assert.equal(response.headers["cache-control"], "no-store");
+    assert.match(response.body, /Read-only run viewer/);
+    assert.match(response.body, /owner\/repo/);
+    assert.match(response.body, /degraded/);
+    assert.match(response.body, /href="\/snapshot\.json"/);
+    assert.doesNotMatch(response.body, /"schemaVersion": 1/);
+    assert.equal(loadCount, 1);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("createInspectRunViewerServer serves authoritative snapshot JSON on /snapshot.json", async () => {
+  let loadCount = 0;
+  const snapshot = makeSnapshot({ sourceMode: "partial", trust: "degraded" });
+  const adapter = {
+    async loadSnapshot() {
+      loadCount += 1;
+      return snapshot;
+    },
+  };
+
+  const server = createInspectRunViewerServer(
+    { repo: "owner/repo", pr: "55", host: "127.0.0.1", port: 0 },
+    { adapter },
+  );
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+
+  try {
+    const address = server.address();
+    const response = await requestOnce(`http://127.0.0.1:${address.port}/snapshot.json`);
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.headers["content-type"], "application/json; charset=utf-8");
+    assert.equal(response.headers["cache-control"], "no-store");
+    assert.deepEqual(JSON.parse(response.body), snapshot);
+    assert.equal(loadCount, 1);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("createInspectRunViewerServer keeps JSON failures machine-readable and HTML failures browser-friendly", async () => {
+  let loadCount = 0;
+  const adapter = {
+    async loadSnapshot() {
+      loadCount += 1;
+      throw new Error("inspection snapshot unavailable");
+    },
+  };
+
+  const server = createInspectRunViewerServer(
+    { repo: "owner/repo", pr: "55", host: "127.0.0.1", port: 0 },
+    { adapter },
+  );
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+
+  try {
+    const address = server.address();
+
+    const htmlResponse = await requestOnce(`http://127.0.0.1:${address.port}/`);
+    assert.equal(htmlResponse.statusCode, 200);
+    assert.equal(htmlResponse.headers["content-type"], "text/html; charset=utf-8");
+    assert.match(htmlResponse.body, /Snapshot unavailable/);
+    assert.match(htmlResponse.body, /inspection snapshot unavailable/);
+
+    const jsonResponse = await requestOnce(`http://127.0.0.1:${address.port}/snapshot.json`);
+    assert.equal(jsonResponse.statusCode, 500);
+    assert.equal(jsonResponse.headers["content-type"], "application/json; charset=utf-8");
+    assert.equal(jsonResponse.headers["cache-control"], "no-store");
+    assert.deepEqual(JSON.parse(jsonResponse.body), {
+      ok: false,
+      target: { repo: "owner/repo", pr: 55 },
+      error: { message: "inspection snapshot unavailable" },
     });
 
-    assert.match(body, /Read-only run viewer/);
-    assert.match(body, /owner\/repo/);
-    assert.match(body, /degraded/);
-    assert.equal(loadCount, 1);
+    assert.equal(loadCount, 2);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
 
-    const faviconStatus = await new Promise((resolve, reject) => {
+test("createInspectRunViewerServer keeps favicon, unsupported paths, and unsupported methods load-free", async () => {
+  let loadCount = 0;
+  const adapter = {
+    async loadSnapshot() {
+      loadCount += 1;
+      return makeSnapshot();
+    },
+  };
+
+  const server = createInspectRunViewerServer(
+    { repo: "owner/repo", pr: "55", host: "127.0.0.1", port: 0 },
+    { adapter },
+  );
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+
+  try {
+    const address = server.address();
+
+    const faviconResponse = await new Promise((resolve, reject) => {
       get(`http://127.0.0.1:${address.port}/favicon.ico`, (response) => {
         response.resume();
-        response.on("end", () => resolve(response.statusCode));
+        response.on("end", () => resolve({ statusCode: response.statusCode, headers: response.headers }));
       }).on("error", reject);
     });
+    assert.equal(faviconResponse.statusCode, 204);
+    assert.equal(loadCount, 0);
 
-    assert.equal(faviconStatus, 204);
-    assert.equal(loadCount, 1);
+    const missingResponse = await requestOnce(`http://127.0.0.1:${address.port}/nope`);
+    assert.equal(missingResponse.statusCode, 404);
+    assert.equal(loadCount, 0);
+
+    const postHtmlResponse = await requestOnce(`http://127.0.0.1:${address.port}/`, { method: "POST" });
+    assert.equal(postHtmlResponse.statusCode, 405);
+    assert.equal(postHtmlResponse.headers.allow, "GET");
+    assert.equal(loadCount, 0);
+
+    const postJsonResponse = await requestOnce(`http://127.0.0.1:${address.port}/snapshot.json`, { method: "POST" });
+    assert.equal(postJsonResponse.statusCode, 405);
+    assert.equal(postJsonResponse.headers.allow, "GET");
+    assert.equal(loadCount, 0);
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }
@@ -296,18 +426,11 @@ test("createInspectRunViewerServer guards malformed request URLs and undefined s
 
   try {
     const address = server.address();
-    const response = await new Promise((resolve, reject) => {
-      get(`http://127.0.0.1:${address.port}`, (incoming) => {
-        let text = "";
-        incoming.on("data", (chunk) => {
-          text += String(chunk);
-        });
-        incoming.on("end", () => resolve({ statusCode: incoming.statusCode, body: text }));
-      }).on("error", reject);
-    });
+    const response = await requestOnce(`http://127.0.0.1:${address.port}/`);
 
     assert.equal(response.statusCode, 200);
     assert.match(response.body, /Snapshot unavailable/);
+    assert.match(response.body, /href="\/snapshot\.json"/);
     assert.equal(loadCount, 1);
 
     const malformedResponse = await new Promise((resolve) => {
@@ -323,6 +446,7 @@ test("createInspectRunViewerServer guards malformed request URLs and undefined s
         body: "",
       };
       const fakeResponse = {
+        statusCode: undefined,
         setHeader(name, value) {
           result.headers[name] = value;
         },


### PR DESCRIPTION
## Summary

This PR follows up issue #83 by splitting `inspect-run-viewer` into distinct read-only HTML and JSON endpoints for the same explicit `repo + pr` target.

Shipped behavior in this slice:
- `GET /` remains the human-oriented local operator view
- `GET /snapshot.json` now returns the authoritative machine-readable `inspect-run` snapshot
- the viewer stays read-only, single-target, and manual-reload only
- the HTML page is less cluttered and links directly to the raw JSON snapshot route

## Scope / context

PR #79 established the initial local browser viewer, but the page still mixed operator-facing presentation with large inline raw snapshot output. This slice keeps the same CLI and adapter seam while separating the HTTP surface into two explicit contracts:
- HTML for human inspection
- JSON for authoritative downstream consumption

The implementation stays bounded to the viewer server, viewer tests, and viewer docs.

Fixes #83.

## Acceptance criteria

- the viewer still launches via:
  - `node scripts/loop/inspect-run-viewer.mjs --repo <owner/name> --pr <number>`
- `/` serves the human-oriented HTML view
- `/snapshot.json` serves the full authoritative inspect-run snapshot as JSON
- the HTML route remains read-only and manual-reload only
- unsupported paths and methods are deterministic and do not trigger unnecessary snapshot loads
- the HTML page no longer relies on a full inline raw top-level snapshot dump as the primary way to expose machine-readable state
- tests cover HTML, JSON, and negative-path route behavior
- docs describe the updated endpoint contract

## Definition of done

- tests were updated first to lock the split-endpoint contract
- `scripts/loop/inspect-run-viewer.mjs` now serves distinct HTML and JSON routes without changing the CLI or adapter seam
- `/snapshot.json` returns the authoritative snapshot object on success and deterministic JSON error output on failure
- `/` remains browser-friendly and manual-reload only
- `scripts/README.md` documents the new two-endpoint contract and manual verification path
- local validation passes:
  - `node --test test/loop/inspect-run-viewer.test.mjs`
  - `npm run test:scripts`
  - `npm test`
  - `git diff --check`

## Non-goals

- multi-run discovery or dashboards
- state-graph visualization redesign (tracked separately in #84)
- workflow controls or steering actions from the page
- polling/watch behavior or auto-refresh
- inspect-run schema redesign
- broader viewer/frontend architecture work beyond the endpoint split
