### PR TITLE
Keep async Copilot waits attached

### DIFF
--- a/lib/dev-loops-installer.mjs
+++ b/lib/dev-loops-installer.mjs
@@ -19,6 +19,7 @@ const COPILOT_RUNTIME_SCRIPT_FILES = [
   "github/stage-reviewer-draft.mjs",
   "github/watch-copilot-review.mjs",
   "loop/copilot-pr-handoff.mjs",
+  "loop/run-copilot-watch-cycle.mjs",
   "loop/_steering-state-file.mjs",
   "loop/detect-initial-copilot-pr-state.mjs",
   "loop/detect-copilot-loop-state.mjs",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -242,13 +242,15 @@ Contract:
 - runs `copilot-pr-handoff.mjs` first and preserves its current state / next action / watch args
 - when handoff returns `action: "watch"`, runs `watch-copilot-review.mjs` with the emitted non-zero `watchArgs`
 - treats `waiting_for_copilot_review` as a persistence boundary, not a completion boundary
-- reports `loopDisposition: "pending"` for quiet watch results (`timeout` or explicit probe `idle`) instead of pretending the loop concluded cleanly
+- preserves the shared Copilot-loop `loopDisposition` contract from the handoff/state-machine output (`pending`, `unresolved_feedback`, `clean_converged`, `blocked`, `action_required`, `done`)
+- exposes the helper's coarser wait-cycle summary separately as `cycleDisposition`
+- reports `cycleDisposition: "pending"` for quiet watch results (`timeout` or explicit probe `idle`) instead of pretending the loop concluded cleanly
 - reserves zero-timeout `idle` probes for explicit status/reattach checks; normal async waiting should use the emitted non-zero watch timeout
-- returns `loopDisposition: "needs_followup"` when fresh Copilot activity appears or handoff already routed directly to `fix`
-- returns `loopDisposition: "terminal"` only when handoff routed to `stop`
+- returns `cycleDisposition: "needs_followup"` when fresh Copilot activity appears or handoff already routed directly to `fix`
+- returns `cycleDisposition: "terminal"` only when handoff routed to `stop`
 
 Success output shape:
-- `{ "ok": true, "handoffAction": "watch"|"fix"|"stop", "state": "...", "allowedTransitions": [...], "nextAction": "...", "snapshot": {...}, "reviewRequestStatus"?: "...", "watchArgs"?: { ... }, "watchStatus"?: "changed"|"timeout"|"idle", "watch"?: { ... }, "loopDisposition": "pending"|"needs_followup"|"terminal", "terminal": true|false }`
+- `{ "ok": true, "handoffAction": "watch"|"fix"|"stop", "state": "...", "allowedTransitions": [...], "nextAction": "...", "snapshot": {...}, "reviewRequestStatus"?: "...", "watchArgs"?: { ... }, "watchStatus"?: "changed"|"timeout"|"idle", "watch"?: { ... }, "loopDisposition": "pending"|"unresolved_feedback"|"clean_converged"|"blocked"|"action_required"|"done", "cycleDisposition": "pending"|"needs_followup"|"terminal", "terminal": true|false }`
 
 Failure behavior:
 - malformed arguments and unexpected `gh` failures emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -226,6 +226,33 @@ Success output shape:
 Failure behavior:
 - malformed arguments and unexpected `gh` failures emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero
 
+### `scripts/loop/run-copilot-watch-cycle.mjs`
+
+Deterministic handoff → watch helper for one Copilot wait-cycle boundary.
+
+Required:
+- `--repo <owner/name>`
+- `--pr <number>`
+
+Optional:
+- `--force-rerequest-review` — explicit operator/manual override that forces another Copilot request even when automatic same-head suppression is active
+- `--probe-only` — use a single immediate recheck (`timeoutMs: 0`) for explicit status probes only
+
+Contract:
+- runs `copilot-pr-handoff.mjs` first and preserves its current state / next action / watch args
+- when handoff returns `action: "watch"`, runs `watch-copilot-review.mjs` with the emitted non-zero `watchArgs`
+- treats `waiting_for_copilot_review` as a persistence boundary, not a completion boundary
+- reports `loopDisposition: "pending"` for quiet watch results (`timeout` or explicit probe `idle`) instead of pretending the loop concluded cleanly
+- reserves zero-timeout `idle` probes for explicit status/reattach checks; normal async waiting should use the emitted non-zero watch timeout
+- returns `loopDisposition: "needs_followup"` when fresh Copilot activity appears or handoff already routed directly to `fix`
+- returns `loopDisposition: "terminal"` only when handoff routed to `stop`
+
+Success output shape:
+- `{ "ok": true, "handoffAction": "watch"|"fix"|"stop", "state": "...", "allowedTransitions": [...], "nextAction": "...", "snapshot": {...}, "reviewRequestStatus"?: "...", "watchArgs"?: { ... }, "watchStatus"?: "changed"|"timeout"|"idle", "watch"?: { ... }, "loopDisposition": "pending"|"needs_followup"|"terminal", "terminal": true|false }`
+
+Failure behavior:
+- malformed arguments and unexpected `gh` failures emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero
+
 ### `scripts/loop/detect-copilot-loop-state.mjs`
 
 Deterministic Copilot-loop state detector. Captures current loop state from observable PR/GitHub

--- a/scripts/github/watch-copilot-review.mjs
+++ b/scripts/github/watch-copilot-review.mjs
@@ -309,6 +309,55 @@ function buildNoChangePayload(status, repo, pr, attempts) {
   };
 }
 
+export async function watchCopilotReview(
+  options,
+  {
+    env = process.env,
+    ghCommand = "gh",
+  } = {},
+) {
+  const baseline = parseCopilotActivity(await fetchGithubCopilotActivityPayload(
+    { repo: options.repo, pr: options.pr },
+    { env, ghCommand },
+  ));
+  const attemptBudget = buildAttemptBudget(options.timeoutMs, options.pollIntervalMs);
+  const watchStartedAtMs = Date.now();
+
+  for (let attempt = 1; attempt <= attemptBudget; attempt += 1) {
+    if (!(options.timeoutMs === 0 && attempt === 1)) {
+      const pollDelayMs = buildPollDelayMs(
+        watchStartedAtMs,
+        options.timeoutMs,
+        options.pollIntervalMs,
+        attempt,
+      );
+      if (pollDelayMs > 0) {
+        await delay(pollDelayMs);
+      }
+    }
+
+    const current = parseCopilotActivity(await fetchGithubCopilotActivityPayload(
+      { repo: options.repo, pr: options.pr },
+      { env, ghCommand },
+    ));
+    const activity = findFreshCopilotActivity(baseline, current);
+
+    if (activity.newComments.length > 0 || activity.newReviews.length > 0 || activity.newIssueComments.length > 0) {
+      return {
+        ok: true,
+        status: "changed",
+        repo: options.repo,
+        pr: options.pr,
+        attempts: attempt,
+        ...activity,
+      };
+    }
+  }
+
+  const status = options.timeoutMs === 0 ? "idle" : "timeout";
+  return buildNoChangePayload(status, options.repo, options.pr, attemptBudget);
+}
+
 export function buildAttemptBudget(timeoutMs, pollIntervalMs) {
   if (timeoutMs === 0) {
     return 1;
@@ -341,47 +390,8 @@ export async function runCli(
     return;
   }
 
-  const baseline = parseCopilotActivity(await fetchGithubCopilotActivityPayload(
-    { repo: options.repo, pr: options.pr },
-    { env, ghCommand },
-  ));
-  const attemptBudget = buildAttemptBudget(options.timeoutMs, options.pollIntervalMs);
-  const watchStartedAtMs = Date.now();
-
-  for (let attempt = 1; attempt <= attemptBudget; attempt += 1) {
-    if (!(options.timeoutMs === 0 && attempt === 1)) {
-      const pollDelayMs = buildPollDelayMs(
-        watchStartedAtMs,
-        options.timeoutMs,
-        options.pollIntervalMs,
-        attempt,
-      );
-      if (pollDelayMs > 0) {
-        await delay(pollDelayMs);
-      }
-    }
-
-    const current = parseCopilotActivity(await fetchGithubCopilotActivityPayload(
-      { repo: options.repo, pr: options.pr },
-      { env, ghCommand },
-    ));
-    const activity = findFreshCopilotActivity(baseline, current);
-
-    if (activity.newComments.length > 0 || activity.newReviews.length > 0 || activity.newIssueComments.length > 0) {
-      stdout.write(`${JSON.stringify({
-        ok: true,
-        status: "changed",
-        repo: options.repo,
-        pr: options.pr,
-        attempts: attempt,
-        ...activity,
-      })}\n`);
-      return;
-    }
-  }
-
-  const status = options.timeoutMs === 0 ? "idle" : "timeout";
-  stdout.write(`${JSON.stringify(buildNoChangePayload(status, options.repo, options.pr, attemptBudget))}\n`);
+  const result = await watchCopilotReview(options, { env, ghCommand });
+  stdout.write(`${JSON.stringify(result)}\n`);
 }
 
 if (isDirectCliRun(import.meta.url)) {

--- a/scripts/loop/run-copilot-watch-cycle.mjs
+++ b/scripts/loop/run-copilot-watch-cycle.mjs
@@ -25,10 +25,11 @@ Output (stdout, JSON):
     "allowedTransitions": [...], "nextAction": "...", "snapshot": {...},
     "reviewRequestStatus"?: "...", "watchArgs"?: { ... },
     "watchStatus"?: "changed"|"timeout"|"idle", "watch"?: { ... },
-    "loopDisposition": "pending"|"needs_followup"|"terminal",
+    "loopDisposition": "pending"|"unresolved_feedback"|"clean_converged"|"blocked"|"action_required"|"done",
+    "cycleDisposition": "pending"|"needs_followup"|"terminal",
     "terminal": true|false }
 
-Loop disposition:
+Cycle disposition:
   pending         Watch state persists; keep waiting or re-enter later
   needs_followup  Fresh review activity or fix-state follow-up needs action
   terminal        No automatic next step remains
@@ -136,8 +137,9 @@ export async function runWatchCycle(
     allowedTransitions: handoff.allowedTransitions,
     nextAction: handoff.nextAction,
     snapshot: handoff.snapshot,
-    loopDisposition: handoff.action === "stop" ? "terminal" : "needs_followup",
-    terminal: handoff.action === "stop",
+    loopDisposition: handoff.loopDisposition,
+    cycleDisposition: handoff.action === "stop" ? "terminal" : "needs_followup",
+    terminal: Boolean(handoff.terminal),
   };
 
   if (handoff.reviewRequestStatus !== undefined) {
@@ -161,7 +163,7 @@ export async function runWatchCycle(
   result.watchArgs = watchOptions;
   result.watchStatus = watch.status;
   result.watch = watch;
-  result.loopDisposition = watch.status === "changed" ? "needs_followup" : "pending";
+  result.cycleDisposition = watch.status === "changed" ? "needs_followup" : "pending";
   result.terminal = false;
   return result;
 }

--- a/scripts/loop/run-copilot-watch-cycle.mjs
+++ b/scripts/loop/run-copilot-watch-cycle.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+
+import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { parseRepoSlug } from "../github/capture-review-threads.mjs";
+import { watchCopilotReview } from "../github/watch-copilot-review.mjs";
+import { runHandoff } from "./copilot-pr-handoff.mjs";
+
+const USAGE = `Usage: run-copilot-watch-cycle.mjs --repo <owner/name> --pr <number> [--force-rerequest-review] [--probe-only]
+
+Run one deterministic Copilot wait-cycle boundary.
+
+Required:
+  --repo <owner/name>       Repository slug (e.g. owner/repo)
+  --pr <number>             Pull request number
+
+Optional:
+  --force-rerequest-review  Force a Copilot re-request even when automatic
+                            same-head suppression is active
+  --probe-only              Use a single immediate recheck (timeout 0) for
+                            explicit status probes only; normal async waiting
+                            keeps the emitted non-zero watch timeout
+
+Output (stdout, JSON):
+  { "ok": true, "handoffAction": "watch"|"fix"|"stop", "state": "...",
+    "allowedTransitions": [...], "nextAction": "...", "snapshot": {...},
+    "reviewRequestStatus"?: "...", "watchArgs"?: { ... },
+    "watchStatus"?: "changed"|"timeout"|"idle", "watch"?: { ... },
+    "loopDisposition": "pending"|"needs_followup"|"terminal",
+    "terminal": true|false }
+
+Loop disposition:
+  pending         Watch state persists; keep waiting or re-enter later
+  needs_followup  Fresh review activity or fix-state follow-up needs action
+  terminal        No automatic next step remains
+
+Error output (stderr, JSON):
+  Argument/usage errors:
+    { "ok": false, "error": "...", "usage": "..." }
+  runtime failures:
+    { "ok": false, "error": "..." }
+
+Exit codes:
+  0  Success
+  1  Argument error or runtime failure`.trim();
+
+function parseError(message) {
+  return Object.assign(new Error(message), { usage: USAGE });
+}
+
+function requireOptionValue(args, flag) {
+  const value = args.shift();
+
+  if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
+    throw parseError(`Missing value for ${flag}`);
+  }
+
+  return value;
+}
+
+function parsePrNumber(value) {
+  if (!/^\d+$/.test(value) || Number(value) === 0) {
+    throw parseError("--pr must be a positive integer");
+  }
+
+  return Number(value);
+}
+
+export function parseWatchCycleCliArgs(argv) {
+  const args = [...argv];
+  const options = {
+    help: false,
+    repo: undefined,
+    pr: undefined,
+    forceRerequestReview: false,
+    probeOnly: false,
+  };
+
+  while (args.length > 0) {
+    const token = args.shift();
+
+    if (token === "--help" || token === "-h") {
+      options.help = true;
+      return options;
+    }
+
+    if (token === "--repo") {
+      options.repo = requireOptionValue(args, "--repo").trim();
+      continue;
+    }
+
+    if (token === "--pr") {
+      options.pr = parsePrNumber(requireOptionValue(args, "--pr"));
+      continue;
+    }
+
+    if (token === "--force-rerequest-review") {
+      options.forceRerequestReview = true;
+      continue;
+    }
+
+    if (token === "--probe-only") {
+      options.probeOnly = true;
+      continue;
+    }
+
+    throw parseError(`Unknown argument: ${token}`);
+  }
+
+  if (options.repo === undefined || options.pr === undefined) {
+    throw parseError("run-copilot-watch-cycle requires both --repo <owner/name> and --pr <number>");
+  }
+
+  try {
+    parseRepoSlug(options.repo);
+  } catch (error) {
+    throw parseError(error instanceof Error ? error.message : String(error));
+  }
+
+  return options;
+}
+
+export async function runWatchCycle(
+  options,
+  {
+    env = process.env,
+    ghCommand = "gh",
+    runHandoffImpl = runHandoff,
+    watchCopilotReviewImpl = watchCopilotReview,
+  } = {},
+) {
+  const handoff = await runHandoffImpl(options, { env, ghCommand });
+  const result = {
+    ok: true,
+    handoffAction: handoff.action,
+    state: handoff.state,
+    allowedTransitions: handoff.allowedTransitions,
+    nextAction: handoff.nextAction,
+    snapshot: handoff.snapshot,
+    loopDisposition: handoff.action === "stop" ? "terminal" : "needs_followup",
+    terminal: handoff.action === "stop",
+  };
+
+  if (handoff.reviewRequestStatus !== undefined) {
+    result.reviewRequestStatus = handoff.reviewRequestStatus;
+  }
+
+  if (handoff.watchArgs !== undefined) {
+    result.watchArgs = handoff.watchArgs;
+  }
+
+  if (handoff.action !== "watch") {
+    return result;
+  }
+
+  const watchOptions = {
+    ...handoff.watchArgs,
+    timeoutMs: options.probeOnly ? 0 : handoff.watchArgs.timeoutMs,
+  };
+  const watch = await watchCopilotReviewImpl(watchOptions, { env, ghCommand });
+
+  result.watchArgs = watchOptions;
+  result.watchStatus = watch.status;
+  result.watch = watch;
+  result.loopDisposition = watch.status === "changed" ? "needs_followup" : "pending";
+  result.terminal = false;
+  return result;
+}
+
+export async function runCli(
+  argv = process.argv.slice(2),
+  {
+    stdout = process.stdout,
+    env = process.env,
+    ghCommand = "gh",
+    runHandoffImpl = runHandoff,
+    watchCopilotReviewImpl = watchCopilotReview,
+  } = {},
+) {
+  const options = parseWatchCycleCliArgs(argv);
+
+  if (options.help) {
+    stdout.write(`${USAGE}\n`);
+    return;
+  }
+
+  const result = await runWatchCycle(options, {
+    env,
+    ghCommand,
+    runHandoffImpl,
+    watchCopilotReviewImpl,
+  });
+  stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli().catch((error) => {
+    process.stderr.write(`${formatCliError(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/skills/copilot-dev-loop/SKILL.md
+++ b/skills/copilot-dev-loop/SKILL.md
@@ -64,6 +64,13 @@ node <resolved-skill-scripts>/loop/copilot-pr-handoff.mjs --repo <owner/name> --
 Detects state, requests review when appropriate, and emits JSON including `{ ok: true, action, state, allowedTransitions, nextAction, snapshot, reviewRequestStatus?, watchStatus?, autoRerequestEligible, sameHeadCleanConverged, loopDisposition, terminal, watchArgs? }`.
 When `action` is `"watch"`, use the returned `watchArgs` with `watch-copilot-review.mjs` directly.
 
+**5. Preferred async wait-boundary helper**
+```sh
+node <resolved-skill-scripts>/loop/run-copilot-watch-cycle.mjs --repo <owner/name> --pr <number>
+```
+Runs the handoff first, then — when the state is still `waiting_for_copilot_review` — keeps the emitted non-zero watch timeout instead of degrading normal async waiting into a zero-timeout `idle` probe. The result includes `{ ok: true, handoffAction, state, watchStatus?, loopDisposition, terminal }`.
+Use `--probe-only` only for an explicit one-shot status/reattach probe; it is not the normal async wait path.
+
 **Request status reference**
 | Status | Meaning | Next step |
 | --- | --- | --- |
@@ -75,6 +82,7 @@ When `action` is `"watch"`, use the returned `watchArgs` with `watch-copilot-rev
 **Pass `--help` to any helper for full usage:**
 ```sh
 node <resolved-skill-scripts>/loop/copilot-pr-handoff.mjs --help
+node <resolved-skill-scripts>/loop/run-copilot-watch-cycle.mjs --help
 node <resolved-skill-scripts>/github/request-copilot-review.mjs --help
 node <resolved-skill-scripts>/github/watch-copilot-review.mjs --help
 node <resolved-skill-scripts>/loop/detect-copilot-loop-state.mjs --help
@@ -431,6 +439,7 @@ Preferred approach for Copilot review follow-up:
 - after a PR leaves draft, explicitly request Copilot review first, preferably through the resolved `request-copilot-review.mjs` helper
 - after any follow-up fix commit is pushed and another Copilot pass is wanted, first return the updated head to a green or credibly green validation posture, then explicitly request Copilot review again for that head before waiting
 - only enter the watch loop after the request state is confirmed as `requested` or `already-requested`
+- for explicit async loop entry or continuation, prefer `run-copilot-watch-cycle.mjs` so the handoff → watch boundary stays deterministic and uses the emitted non-zero watch timeout
 - baseline current Copilot review activity only after that confirmed request state, unless the user explicitly asked for passive waiting without a fresh request
 - poll for new Copilot-authored review activity across review-thread comments, review summaries, and PR issue comments
 - keep the watcher in the current Pi/TelePi session
@@ -438,6 +447,8 @@ Preferred approach for Copilot review follow-up:
 - after new review activity appears, launch an async Pi fixer in-session
 - if the watcher returns `timeout` or `idle`, immediately refresh deterministic state with `copilot-pr-handoff.mjs --watch-status <status>` (or `detect-copilot-loop-state.mjs`) before deciding anything about completion
 - watcher timeout/idle is observational only; it is non-terminal unless the refreshed detector output proves `terminal=true`
+- zero-timeout `idle` probes are for explicit one-shot status/reattach checks only; they are not the normal async wait mechanism
+- after a successful fix / reply-resolve / re-request cycle, returning to `waiting_for_copilot_review` is a persistence boundary: resume the watcher instead of reporting completion
 - do not report the loop complete while fresh Copilot comments remain unresolved; a new Copilot pass must flow back into fixer/reply/resolve work before completion when authorization exists
 - use explicit long timeouts from the timeout policy above rather than short defaults
 

--- a/skills/copilot-dev-loop/SKILL.md
+++ b/skills/copilot-dev-loop/SKILL.md
@@ -68,7 +68,7 @@ When `action` is `"watch"`, use the returned `watchArgs` with `watch-copilot-rev
 ```sh
 node <resolved-skill-scripts>/loop/run-copilot-watch-cycle.mjs --repo <owner/name> --pr <number>
 ```
-Runs the handoff first, then — when the state is still `waiting_for_copilot_review` — keeps the emitted non-zero watch timeout instead of degrading normal async waiting into a zero-timeout `idle` probe. The result includes `{ ok: true, handoffAction, state, watchStatus?, loopDisposition, terminal }`.
+Runs the handoff first, then — when the state is still `waiting_for_copilot_review` — keeps the emitted non-zero watch timeout instead of degrading normal async waiting into a zero-timeout `idle` probe. The result preserves the shared `loopDisposition` contract from the Copilot state machine and adds a separate coarse `cycleDisposition` field for the helper's wait-boundary summary: `{ ok: true, handoffAction, state, watchStatus?, loopDisposition, cycleDisposition, terminal }`.
 Use `--probe-only` only for an explicit one-shot status/reattach probe; it is not the normal async wait path.
 
 **Request status reference**

--- a/test/extension-command-contract.test.mjs
+++ b/test/extension-command-contract.test.mjs
@@ -222,6 +222,7 @@ test("install repo copies packaged skills into the repository, repo errors stay 
   await access(path.join(repoRoot, ".pi", "skills", "copilot-dev-loop", "SKILL.md"));
   await access(path.join(repoRoot, ".pi", "skills", "copilot-autopilot", "SKILL.md"));
   await access(path.join(repoRoot, ".pi", "skills", "copilot-dev-loop", "scripts", "github", "request-copilot-review.mjs"));
+  await access(path.join(repoRoot, ".pi", "skills", "copilot-dev-loop", "scripts", "loop", "run-copilot-watch-cycle.mjs"));
   await access(path.join(repoRoot, ".pi", "skills", "copilot-dev-loop", "packages", "core", "src", "loop", "copilot-loop-state.mjs"));
   await access(path.join(repoRoot, ".pi", "skills", "copilot-dev-loop", "docs", "copilot-loop-state-graph.md"));
   await access(path.join(repoRoot, ".pi", "skills", "copilot-dev-loop", "docs", "outer-loop-state-graph.md"));

--- a/test/extension-installer.test.mjs
+++ b/test/extension-installer.test.mjs
@@ -30,6 +30,7 @@ async function seedPackagedSupport(tempDir) {
     "github/stage-reviewer-draft.mjs": "export const stage = true;\n",
     "github/watch-copilot-review.mjs": "export const watch = true;\n",
     "loop/copilot-pr-handoff.mjs": "export const handoff = true;\n",
+    "loop/run-copilot-watch-cycle.mjs": "export const watchCycle = true;\n",
     "loop/_steering-state-file.mjs": "export const steeringFile = true;\n",
     "loop/detect-initial-copilot-pr-state.mjs": "export const initialState = true;\n",
     "loop/detect-copilot-loop-state.mjs": "#!/usr/bin/env node\n",
@@ -121,6 +122,12 @@ async function assertInstalledCopilotHelpersExecute(targetRoot, skillName = "cop
   assert.equal(handoffResult.code, 0);
   assert.match(handoffResult.stdout, /Usage:/);
   assert.doesNotMatch(handoffResult.stderr, /ERR_MODULE_NOT_FOUND/);
+
+  const watchCycleScriptPath = path.join(targetRoot, skillName, "scripts", "loop", "run-copilot-watch-cycle.mjs");
+  const watchCycleResult = await runNodeScript(watchCycleScriptPath, ["--help"]);
+  assert.equal(watchCycleResult.code, 0);
+  assert.match(watchCycleResult.stdout, /Usage:/);
+  assert.doesNotMatch(watchCycleResult.stderr, /ERR_MODULE_NOT_FOUND/);
 }
 
 async function assertInstalledOuterLoopContractImports(targetRoot, skillName = "copilot-autopilot") {
@@ -206,6 +213,10 @@ test("install copies packaged skills and only the allow-listed copilot runtime s
   assert.equal(
     await readFile(path.join(targetRoot, "copilot-autopilot", "scripts", "loop", "copilot-pr-handoff.mjs"), "utf8"),
     "export const handoff = true;\n",
+  );
+  assert.equal(
+    await readFile(path.join(targetRoot, "copilot-autopilot", "scripts", "loop", "run-copilot-watch-cycle.mjs"), "utf8"),
+    "export const watchCycle = true;\n",
   );
   assert.equal(
     await readFile(path.join(targetRoot, "copilot-autopilot", "scripts", "github", "detect-linked-issue-pr.mjs"), "utf8"),

--- a/test/imported-assets-normalization.test.mjs
+++ b/test/imported-assets-normalization.test.mjs
@@ -379,6 +379,14 @@ test("copilot-autopilot safety layer contract is documented", async () => {
   assert.match(planContent, /stopped_overlap_needs_decision`, `stopped_low_confidence`, `stopped_explicit_reject`/i);
 });
 
+test("copilot-dev-loop skill keeps async watch persistence explicit", async () => {
+  const skillContent = await readRepo("skills/copilot-dev-loop/SKILL.md");
+
+  assert.match(skillContent, /run-copilot-watch-cycle\.mjs/i);
+  assert.match(skillContent, /zero-timeout `idle` probes are for explicit one-shot status\/reattach checks only/i);
+  assert.match(skillContent, /returning to `waiting_for_copilot_review` is a persistence boundary: resume the watcher instead of reporting completion/i);
+});
+
 test("copilot-dev-loop agent is a thin executable entrypoint that defers to the skill", async () => {
   const content = await readRepo("agents/copilot-dev-loop.agent.md");
 

--- a/test/loop/run-copilot-watch-cycle.test.mjs
+++ b/test/loop/run-copilot-watch-cycle.test.mjs
@@ -1,0 +1,458 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { parseWatchCycleCliArgs, runWatchCycle } from "../../scripts/loop/run-copilot-watch-cycle.mjs";
+
+const EMPTY_THREADS = JSON.stringify({
+  data: {
+    repository: {
+      pullRequest: {
+        reviewThreads: { nodes: [] },
+      },
+    },
+  },
+});
+
+async function writeGhStub(tempDir, entries) {
+  const sequencePath = path.join(tempDir, "gh-sequence.json");
+  const counterPath = path.join(tempDir, "gh-counter.txt");
+  const ghPath = path.join(tempDir, "gh");
+
+  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
+  await writeFile(counterPath, "0\n", "utf8");
+  await writeFile(
+    ghPath,
+    [
+      "#!/usr/bin/env node",
+      'import { readFileSync, writeFileSync } from "node:fs";',
+      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
+      "const counterPath = process.env.GH_COUNTER_PATH;",
+      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
+      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
+      'if (current >= entries.length) {',
+      '  process.stderr.write("unexpected gh call beyond scripted sequence\\n");',
+      '  process.exit(97);',
+      '}',
+      'const entry = entries[current] ?? { stdout: "{}\\n" };',
+      'writeFileSync(counterPath, String(current + 1));',
+      'const actual = process.argv.slice(2);',
+      'if (entry.assertArgs) {',
+      '  for (const expected of entry.assertArgs) {',
+      '    if (!actual.includes(expected)) {',
+      '      process.stderr.write(`missing expected gh arg: ${expected}\\n`);',
+      '      process.exit(98);',
+      '    }',
+      '  }',
+      '}',
+      'if (entry.stderr) {',
+      '  process.stderr.write(entry.stderr);',
+      '}',
+      'if (entry.stdout) {',
+      '  process.stdout.write(entry.stdout);',
+      '}',
+      'process.exit(entry.exitCode ?? 0);',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await chmod(ghPath, 0o755);
+
+  return {
+    ...process.env,
+    PATH: `${tempDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    GH_SEQUENCE_PATH: sequencePath,
+    GH_COUNTER_PATH: counterPath,
+  };
+}
+
+test("parseWatchCycleCliArgs parses required flags and optional probe mode", () => {
+  assert.deepEqual(
+    parseWatchCycleCliArgs(["--repo", "owner/repo", "--pr", "17", "--probe-only"]),
+    {
+      help: false,
+      repo: "owner/repo",
+      pr: 17,
+      forceRerequestReview: false,
+      probeOnly: true,
+    },
+  );
+});
+
+test("runWatchCycle uses emitted non-zero watchArgs for normal async waiting", async () => {
+  let watcherOptions;
+
+  const result = await runWatchCycle(
+    {
+      repo: "owner/repo",
+      pr: 17,
+      forceRerequestReview: false,
+      probeOnly: false,
+    },
+    {
+      runHandoffImpl: async () => ({
+        ok: true,
+        action: "watch",
+        state: "waiting_for_copilot_review",
+        allowedTransitions: ["unresolved_feedback_present"],
+        nextAction: "Wait for Copilot review via scripts/github/watch-copilot-review.mjs",
+        snapshot: { repo: "owner/repo", pr: 17 },
+        watchArgs: {
+          repo: "owner/repo",
+          pr: 17,
+          pollIntervalMs: 60_000,
+          timeoutMs: 86_400_000,
+        },
+      }),
+      watchCopilotReviewImpl: async (options) => {
+        watcherOptions = options;
+        return {
+          ok: true,
+          status: "timeout",
+          repo: options.repo,
+          pr: options.pr,
+          attempts: 1440,
+          newComments: [],
+          newReviews: [],
+          newIssueComments: [],
+        };
+      },
+    },
+  );
+
+  assert.equal(watcherOptions.timeoutMs, 86_400_000);
+  assert.notEqual(watcherOptions.timeoutMs, 0);
+  assert.equal(result.loopDisposition, "pending");
+  assert.equal(result.terminal, false);
+  assert.equal(result.watchStatus, "timeout");
+  assert.equal(result.state, "waiting_for_copilot_review");
+});
+
+test("runWatchCycle uses zero-timeout idle probes only when explicitly requested", async () => {
+  let watcherOptions;
+
+  const result = await runWatchCycle(
+    {
+      repo: "owner/repo",
+      pr: 17,
+      forceRerequestReview: false,
+      probeOnly: true,
+    },
+    {
+      runHandoffImpl: async () => ({
+        ok: true,
+        action: "watch",
+        state: "waiting_for_copilot_review",
+        allowedTransitions: ["unresolved_feedback_present"],
+        nextAction: "Wait for Copilot review via scripts/github/watch-copilot-review.mjs",
+        snapshot: { repo: "owner/repo", pr: 17 },
+        watchArgs: {
+          repo: "owner/repo",
+          pr: 17,
+          pollIntervalMs: 60_000,
+          timeoutMs: 86_400_000,
+        },
+      }),
+      watchCopilotReviewImpl: async (options) => {
+        watcherOptions = options;
+        return {
+          ok: true,
+          status: "idle",
+          repo: options.repo,
+          pr: options.pr,
+          attempts: 1,
+          newComments: [],
+          newReviews: [],
+          newIssueComments: [],
+        };
+      },
+    },
+  );
+
+  assert.equal(watcherOptions.timeoutMs, 0);
+  assert.equal(result.loopDisposition, "pending");
+  assert.equal(result.terminal, false);
+  assert.equal(result.watchStatus, "idle");
+});
+
+test("runWatchCycle returns needs_followup when fresh Copilot activity appears", async () => {
+  const result = await runWatchCycle(
+    {
+      repo: "owner/repo",
+      pr: 17,
+      forceRerequestReview: false,
+      probeOnly: false,
+    },
+    {
+      runHandoffImpl: async () => ({
+        ok: true,
+        action: "watch",
+        state: "waiting_for_copilot_review",
+        allowedTransitions: ["unresolved_feedback_present"],
+        nextAction: "Wait for Copilot review via scripts/github/watch-copilot-review.mjs",
+        snapshot: { repo: "owner/repo", pr: 17 },
+        watchArgs: {
+          repo: "owner/repo",
+          pr: 17,
+          pollIntervalMs: 60_000,
+          timeoutMs: 86_400_000,
+        },
+      }),
+      watchCopilotReviewImpl: async (options) => ({
+        ok: true,
+        status: "changed",
+        repo: options.repo,
+        pr: options.pr,
+        attempts: 3,
+        newComments: [{ id: "comment-1" }],
+        newReviews: [],
+        newIssueComments: [],
+      }),
+    },
+  );
+
+  assert.equal(result.loopDisposition, "needs_followup");
+  assert.equal(result.terminal, false);
+  assert.equal(result.watchStatus, "changed");
+});
+
+test("runWatchCycle returns needs_followup immediately for fix states without invoking the watcher", async () => {
+  let watcherCalled = false;
+
+  const result = await runWatchCycle(
+    {
+      repo: "owner/repo",
+      pr: 17,
+      forceRerequestReview: false,
+      probeOnly: false,
+    },
+    {
+      runHandoffImpl: async () => ({
+        ok: true,
+        action: "fix",
+        state: "unresolved_feedback_present",
+        allowedTransitions: ["already_fixed_needs_reply_resolve"],
+        nextAction: "Address unresolved feedback",
+        snapshot: { repo: "owner/repo", pr: 17 },
+      }),
+      watchCopilotReviewImpl: async () => {
+        watcherCalled = true;
+        return { ok: true, status: "timeout", repo: "owner/repo", pr: 17, attempts: 1, newComments: [], newReviews: [], newIssueComments: [] };
+      },
+    },
+  );
+
+  assert.equal(watcherCalled, false);
+  assert.equal(result.loopDisposition, "needs_followup");
+  assert.equal(result.terminal, false);
+  assert.equal(result.watchStatus, undefined);
+});
+
+test("runWatchCycle returns terminal for stop states without invoking the watcher", async () => {
+  let watcherCalled = false;
+
+  const result = await runWatchCycle(
+    {
+      repo: "owner/repo",
+      pr: 17,
+      forceRerequestReview: false,
+      probeOnly: false,
+    },
+    {
+      runHandoffImpl: async () => ({
+        ok: true,
+        action: "stop",
+        state: "done",
+        allowedTransitions: [],
+        nextAction: "Report completion",
+        snapshot: { repo: "owner/repo", pr: 17 },
+      }),
+      watchCopilotReviewImpl: async () => {
+        watcherCalled = true;
+        return { ok: true, status: "timeout", repo: "owner/repo", pr: 17, attempts: 1, newComments: [], newReviews: [], newIssueComments: [] };
+      },
+    },
+  );
+
+  assert.equal(watcherCalled, false);
+  assert.equal(result.loopDisposition, "terminal");
+  assert.equal(result.terminal, true);
+  assert.equal(result.watchStatus, undefined);
+});
+
+test("runWatchCycle integration keeps initial request-review -> waiting_for_copilot_review non-terminal", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-cycle-initial-request-"));
+  let watcherOptions;
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: JSON.stringify({
+          isDraft: false,
+          state: "OPEN",
+          number: 17,
+          headRefOid: "newsha",
+          reviews: [],
+          statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+        }) + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: `${EMPTY_THREADS}\n`,
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+        stdout: '{"headRefOid":"newsha","reviews":[]}\n',
+      },
+      {
+        assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
+        stdout: "https://github.com/owner/repo/pull/17\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+        stdout: '{"headRefOid":"newsha","reviews":[]}\n',
+      },
+    ]);
+
+    const result = await runWatchCycle(
+      {
+        repo: "owner/repo",
+        pr: 17,
+        forceRerequestReview: false,
+        probeOnly: false,
+      },
+      {
+        env,
+        watchCopilotReviewImpl: async (options) => {
+          watcherOptions = options;
+          return {
+            ok: true,
+            status: "timeout",
+            repo: options.repo,
+            pr: options.pr,
+            attempts: 1440,
+            newComments: [],
+            newReviews: [],
+            newIssueComments: [],
+          };
+        },
+      },
+    );
+
+    assert.equal(result.handoffAction, "watch");
+    assert.equal(result.state, "waiting_for_copilot_review");
+    assert.equal(result.reviewRequestStatus, "requested");
+    assert.equal(result.loopDisposition, "pending");
+    assert.equal(result.terminal, false);
+    assert.equal(result.watchStatus, "timeout");
+    assert.equal(watcherOptions.timeoutMs, 86_400_000);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("runWatchCycle integration keeps re-requested newer-head wait state non-terminal", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-cycle-rerequest-"));
+  let watcherOptions;
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: JSON.stringify({
+          isDraft: false,
+          state: "OPEN",
+          number: 17,
+          headRefOid: "newsha",
+          reviews: [
+            {
+              id: "r-1",
+              author: { login: "copilot-pull-request-reviewer[bot]" },
+              state: "COMMENTED",
+              commit: { oid: "oldsha" },
+            },
+          ],
+          statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+        }) + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: `${EMPTY_THREADS}\n`,
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+        stdout: '{"headRefOid":"newsha","reviews":[{"id":"r-1","state":"COMMENTED","author":{"login":"copilot-pull-request-reviewer[bot]"},"commit":{"oid":"oldsha"}}]}\n',
+      },
+      {
+        assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
+        stdout: "https://github.com/owner/repo/pull/17\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+        stdout: '{"headRefOid":"newsha","reviews":[{"id":"r-1","state":"COMMENTED","author":{"login":"copilot-pull-request-reviewer[bot]"},"commit":{"oid":"oldsha"}}]}\n',
+      },
+    ]);
+
+    const result = await runWatchCycle(
+      {
+        repo: "owner/repo",
+        pr: 17,
+        forceRerequestReview: false,
+        probeOnly: false,
+      },
+      {
+        env,
+        watchCopilotReviewImpl: async (options) => {
+          watcherOptions = options;
+          return {
+            ok: true,
+            status: "timeout",
+            repo: options.repo,
+            pr: options.pr,
+            attempts: 1440,
+            newComments: [],
+            newReviews: [],
+            newIssueComments: [],
+          };
+        },
+      },
+    );
+
+    assert.equal(result.handoffAction, "watch");
+    assert.equal(result.state, "waiting_for_copilot_review");
+    assert.equal(result.reviewRequestStatus, "requested");
+    assert.equal(result.loopDisposition, "pending");
+    assert.equal(result.terminal, false);
+    assert.equal(result.watchStatus, "timeout");
+    assert.equal(watcherOptions.timeoutMs, 86_400_000);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/loop/run-copilot-watch-cycle.test.mjs
+++ b/test/loop/run-copilot-watch-cycle.test.mjs
@@ -99,6 +99,8 @@ test("runWatchCycle uses emitted non-zero watchArgs for normal async waiting", a
         allowedTransitions: ["unresolved_feedback_present"],
         nextAction: "Wait for Copilot review via scripts/github/watch-copilot-review.mjs",
         snapshot: { repo: "owner/repo", pr: 17 },
+        loopDisposition: "pending",
+        terminal: false,
         watchArgs: {
           repo: "owner/repo",
           pr: 17,
@@ -125,6 +127,7 @@ test("runWatchCycle uses emitted non-zero watchArgs for normal async waiting", a
   assert.equal(watcherOptions.timeoutMs, 86_400_000);
   assert.notEqual(watcherOptions.timeoutMs, 0);
   assert.equal(result.loopDisposition, "pending");
+  assert.equal(result.cycleDisposition, "pending");
   assert.equal(result.terminal, false);
   assert.equal(result.watchStatus, "timeout");
   assert.equal(result.state, "waiting_for_copilot_review");
@@ -148,6 +151,8 @@ test("runWatchCycle uses zero-timeout idle probes only when explicitly requested
         allowedTransitions: ["unresolved_feedback_present"],
         nextAction: "Wait for Copilot review via scripts/github/watch-copilot-review.mjs",
         snapshot: { repo: "owner/repo", pr: 17 },
+        loopDisposition: "pending",
+        terminal: false,
         watchArgs: {
           repo: "owner/repo",
           pr: 17,
@@ -173,11 +178,12 @@ test("runWatchCycle uses zero-timeout idle probes only when explicitly requested
 
   assert.equal(watcherOptions.timeoutMs, 0);
   assert.equal(result.loopDisposition, "pending");
+  assert.equal(result.cycleDisposition, "pending");
   assert.equal(result.terminal, false);
   assert.equal(result.watchStatus, "idle");
 });
 
-test("runWatchCycle returns needs_followup when fresh Copilot activity appears", async () => {
+test("runWatchCycle keeps shared loopDisposition and reports needs_followup in cycleDisposition when fresh Copilot activity appears", async () => {
   const result = await runWatchCycle(
     {
       repo: "owner/repo",
@@ -193,6 +199,8 @@ test("runWatchCycle returns needs_followup when fresh Copilot activity appears",
         allowedTransitions: ["unresolved_feedback_present"],
         nextAction: "Wait for Copilot review via scripts/github/watch-copilot-review.mjs",
         snapshot: { repo: "owner/repo", pr: 17 },
+        loopDisposition: "pending",
+        terminal: false,
         watchArgs: {
           repo: "owner/repo",
           pr: 17,
@@ -213,12 +221,13 @@ test("runWatchCycle returns needs_followup when fresh Copilot activity appears",
     },
   );
 
-  assert.equal(result.loopDisposition, "needs_followup");
+  assert.equal(result.loopDisposition, "pending");
+  assert.equal(result.cycleDisposition, "needs_followup");
   assert.equal(result.terminal, false);
   assert.equal(result.watchStatus, "changed");
 });
 
-test("runWatchCycle returns needs_followup immediately for fix states without invoking the watcher", async () => {
+test("runWatchCycle preserves unresolved_feedback loopDisposition for fix states without invoking the watcher", async () => {
   let watcherCalled = false;
 
   const result = await runWatchCycle(
@@ -236,6 +245,8 @@ test("runWatchCycle returns needs_followup immediately for fix states without in
         allowedTransitions: ["already_fixed_needs_reply_resolve"],
         nextAction: "Address unresolved feedback",
         snapshot: { repo: "owner/repo", pr: 17 },
+        loopDisposition: "unresolved_feedback",
+        terminal: false,
       }),
       watchCopilotReviewImpl: async () => {
         watcherCalled = true;
@@ -245,12 +256,13 @@ test("runWatchCycle returns needs_followup immediately for fix states without in
   );
 
   assert.equal(watcherCalled, false);
-  assert.equal(result.loopDisposition, "needs_followup");
+  assert.equal(result.loopDisposition, "unresolved_feedback");
+  assert.equal(result.cycleDisposition, "needs_followup");
   assert.equal(result.terminal, false);
   assert.equal(result.watchStatus, undefined);
 });
 
-test("runWatchCycle returns terminal for stop states without invoking the watcher", async () => {
+test("runWatchCycle preserves done loopDisposition for stop states without invoking the watcher", async () => {
   let watcherCalled = false;
 
   const result = await runWatchCycle(
@@ -268,6 +280,8 @@ test("runWatchCycle returns terminal for stop states without invoking the watche
         allowedTransitions: [],
         nextAction: "Report completion",
         snapshot: { repo: "owner/repo", pr: 17 },
+        loopDisposition: "done",
+        terminal: true,
       }),
       watchCopilotReviewImpl: async () => {
         watcherCalled = true;
@@ -277,7 +291,8 @@ test("runWatchCycle returns terminal for stop states without invoking the watche
   );
 
   assert.equal(watcherCalled, false);
-  assert.equal(result.loopDisposition, "terminal");
+  assert.equal(result.loopDisposition, "done");
+  assert.equal(result.cycleDisposition, "terminal");
   assert.equal(result.terminal, true);
   assert.equal(result.watchStatus, undefined);
 });


### PR DESCRIPTION
## Summary

Fix issue #99 by making async Copilot wait-boundary handling explicit and deterministic instead of letting async loop entry/re-entry degrade into zero-timeout idle probes.

## Scope / context

This stacks on PR #98.

The observed bug was not in the Copilot state machine itself and not in the watcher CLI itself. The repeated failures came from the handoff/watch boundary: the loop kept returning to `waiting_for_copilot_review`, but async follow-up still completed instead of staying attached through the wait state.

This change adds a thin deterministic helper for that boundary and updates the packaged skill/runtime surface so installed copies can use it too.

## Acceptance criteria

- explicit async Copilot loop entry/re-entry uses a deterministic watch-boundary helper instead of relying on ad hoc zero-timeout probes
- request-review -> `waiting_for_copilot_review` stays non-terminal and enters a real watch cycle
- post-fix re-request -> `waiting_for_copilot_review` also stays non-terminal and re-enters a real watch cycle
- zero-timeout `idle` is reserved for explicit probe/status checks, not the main async wait path
- packaged/install-layout skill copies include the new helper runtime
- tests cover both the initial request-review path and the re-request-after-fix path

## Definition of done

- deterministic helper added
- skill/docs updated to point async watch behavior at the helper
- installer/runtime allow-lists updated
- regression tests added and passing
- full repo test suite passing

## Non-goals

- changing the underlying Copilot state machine semantics
- changing merge authorization rules
- changing history-rewrite protections
- building a whole new fixer state machine inside the helper

## Validation

- `node --test test/loop/run-copilot-watch-cycle.test.mjs`
- `npm test`
- `git diff --check`
