### PR TITLE
Simplify inspect-run viewer layout

### DIFF
--- a/scripts/loop/inspect-run-viewer.mjs
+++ b/scripts/loop/inspect-run-viewer.mjs
@@ -1240,7 +1240,7 @@ export function renderInspectRunViewerHtml({
   <body>
     ${renderCurrentStateBanner(normalizedSnapshot, target, stateLabel, graph)}
     ${renderCollapsedDetailsPanel(`
-      <p><strong>Snapshot state:</strong> <span class="badge">${escapeHtml(stateLabel)}</span></p>
+      <p><strong>Snapshot state:</strong> <span class="badge">${escapeHtml(stateLabel)}</span> <button type="button" onclick="window.location.reload()" title="Reload snapshot" aria-label="Reload snapshot">🔄</button></p>
       <p><strong>Refresh:</strong> manual reload only. <strong>Raw snapshot:</strong> <a href="/snapshot.json"><code>/snapshot.json</code></a></p>
       ${topSummary}
       ${renderOuterLoopSummarySection(normalizedSnapshot)}

--- a/scripts/loop/inspect-run-viewer.mjs
+++ b/scripts/loop/inspect-run-viewer.mjs
@@ -1121,7 +1121,7 @@ function renderCurrentStateNote(snapshot) {
 
 function renderCurrentStateBanner(snapshot, target, stateLabel, graph) {
   const summary = summarizeCurrentPrStatus(snapshot);
-  return `<section class="current-pr-state-banner" aria-label="Current PR state">
+  return `<section class="current-pr-state-banner" aria-label="PR #${escapeHtml(target.pr)} State">
     <h1>PR #${escapeHtml(target.pr)} State</h1>
     <p class="current-pr-state-summary-headline">${escapeHtml(summary.headline)}</p>
     <p class="current-pr-state-detail">${escapeHtml(summary.detail)}</p>

--- a/scripts/loop/inspect-run-viewer.mjs
+++ b/scripts/loop/inspect-run-viewer.mjs
@@ -248,25 +248,6 @@ function normalizeTransitions(transitions) {
   return normalizedTransitions;
 }
 
-function renderStateVisualizationIntro(snapshot) {
-  const stateLabel = renderSnapshotStateLabel(snapshot);
-
-  if (stateLabel === "authoritative") {
-    return "Authoritative graph view from the current inspection snapshot, showing the full authoritative outer, Copilot, and reviewer state graphs.";
-  }
-  if (stateLabel === "degraded") {
-    return "Degraded graph view of the full authoritative outer, Copilot, and reviewer state graphs; missing highlights stay explicitly unavailable instead of being guessed.";
-  }
-  if (stateLabel === "checkpoint-only") {
-    return "Checkpoint-only graph view of the full authoritative outer, Copilot, and reviewer state graphs; current and next highlights are advisory until live inspection is available.";
-  }
-  if (stateLabel === "conflicting") {
-    return "Conflicting graph view of the full authoritative outer, Copilot, and reviewer state graphs; resolve the evidence conflict before trusting the highlights.";
-  }
-
-  return "Graph view from the current inspection snapshot, showing the full authoritative outer, Copilot, and reviewer state graphs.";
-}
-
 const COPILOT_TERMINAL_STATES = new Set(
   Object.entries(COPILOT_TRANSITIONS)
     .filter(([, nextStates]) => Array.isArray(nextStates) && nextStates.length === 0)
@@ -765,12 +746,11 @@ function renderMermaidBootScript() {
 function renderStateVisualizationSection(snapshot, graph = buildInspectionMermaidGraph(snapshot)) {
   if (graph === null) {
     return `<div class="state-graph-block">
-      <p class="state-graph-intro">Snapshot unavailable, so no state graph can be rendered yet.</p>
+      <p>Snapshot unavailable, so no state graph can be rendered yet.</p>
     </div>`;
   }
 
   return `<div class="state-graph-block">
-    <p class="state-graph-intro">${escapeHtml(renderStateVisualizationIntro(snapshot))}</p>
     <div class="state-graph-frame" data-graph-scale="1">
       <div class="state-graph-toolbar" aria-label="Graph controls">
         <button type="button" data-graph-zoom-out aria-label="Zoom out">−</button>
@@ -1142,12 +1122,9 @@ function renderCurrentStateNote(snapshot) {
 function renderCurrentStateBanner(snapshot, target, stateLabel, graph) {
   const summary = summarizeCurrentPrStatus(snapshot);
   return `<section class="current-pr-state-banner" aria-label="Current PR state">
-    <h2>Current PR state</h2>
+    <h1>PR #${escapeHtml(target.pr)} State</h1>
     <p class="current-pr-state-summary-headline">${escapeHtml(summary.headline)}</p>
     <p class="current-pr-state-detail">${escapeHtml(summary.detail)}</p>
-    <div class="current-pr-state-visualization">
-      ${renderStateVisualizationSection(snapshot, graph)}
-    </div>
     <p class="current-pr-state-detail">${escapeHtml(renderCurrentStateNote(snapshot))}</p>
     <dl class="current-pr-state-grid">
       <dt>target</dt><dd><code>${escapeHtml(target.repo)}#${escapeHtml(target.pr)}</code></dd>
@@ -1161,6 +1138,9 @@ function renderCurrentStateBanner(snapshot, target, stateLabel, graph) {
       <dt>next action</dt><dd>${escapeHtml(summary.nextAction)}</dd>
       <dt>trust</dt><dd>${escapeHtml(snapshot?.evidence?.summary ?? "not present")}</dd>
     </dl>
+    <div class="current-pr-state-visualization">
+      ${renderStateVisualizationSection(snapshot, graph)}
+    </div>
   </section>`;
 }
 
@@ -1173,7 +1153,6 @@ export function renderInspectRunViewerHtml({
   const graph = buildInspectionMermaidGraph(normalizedSnapshot);
   const stateLabel = renderSnapshotStateLabel(normalizedSnapshot);
   const title = `${target.repo}#${target.pr} inspection snapshot`;
-  const pageHeading = `PR #${target.pr} inspection`;
   const runId = normalizedSnapshot?.runId ?? "not present";
   const topSummary = normalizedSnapshot === null
     ? `<section>
@@ -1205,18 +1184,17 @@ export function renderInspectRunViewerHtml({
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>${escapeHtml(title)}</title>
     <style>
-      body { font-family: sans-serif; margin: 1rem auto; max-width: 70rem; line-height: 1.4; }
+      body { font-family: sans-serif; margin: 1rem; max-width: none; line-height: 1.4; }
       code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre-wrap; }
       .badge { display: inline-block; padding: 0.25rem 0.5rem; border: 1px solid #666; border-radius: 0.25rem; font-weight: 600; }
-      .current-pr-state-banner { border: 1px solid #cfe0f5; background: linear-gradient(180deg, #f8fbff 0%, #eef5fd 100%); box-shadow: 0 8px 24px rgba(21, 101, 192, 0.08); }
-      .current-pr-state-banner h2 { margin: 0.2rem 0 0.5rem 0; font-size: 1.9rem; line-height: 1.15; }
+      .current-pr-state-banner { border: none; background: none; box-shadow: none; padding: 0; margin-top: 0; }
+      .current-pr-state-banner h1 { margin: 0 0 0.5rem 0; font-size: 2.2rem; line-height: 1.15; }
       .current-pr-state-summary-headline { margin: 0 0 0.4rem 0; color: #1565c0; font-weight: 700; font-size: 1.1rem; }
-      .current-pr-state-detail { margin: 0.6rem 0 0.8rem 0; color: #274766; font-size: 0.98rem; }
-      .current-pr-state-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); background: rgba(255,255,255,0.6); padding: 0.85rem; border-radius: 0.6rem; }
+      .current-pr-state-detail { margin: 0.25rem 0 0.8rem 0; color: #274766; font-size: 0.98rem; }
+      .current-pr-state-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); background: none; padding: 0; border-radius: 0; margin-bottom: 1rem; }
       .current-pr-state-grid dt { font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.03em; color: #4c6478; }
-      .current-pr-state-grid dd { margin: 0 0 0.5rem 0; }
+      .current-pr-state-grid dd { margin: 0 0 0.75rem 0; }
       .state-graph-block { margin-top: 0.4rem; }
-      .state-graph-intro { margin-top: 0; margin-bottom: 0.6rem; color: #333; font-size: 0.98rem; }
       .state-graph-frame { margin-top: 0.5rem; border: 1px solid #d7e3f4; border-radius: 0.75rem; background: linear-gradient(180deg, #fbfdff 0%, #f4f8fc 100%); overflow: hidden; }
       .state-graph-toolbar { display: flex; align-items: center; gap: 0.4rem; padding: 0.55rem 0.65rem; border-bottom: 1px solid #d7e3f4; background: rgba(255,255,255,0.85); }
       .state-graph-toolbar button { border: 1px solid #9fb6cb; background: #fff; border-radius: 0.45rem; padding: 0.3rem 0.6rem; font: inherit; cursor: pointer; }
@@ -1246,6 +1224,9 @@ export function renderInspectRunViewerHtml({
       dl { display: grid; grid-template-columns: 14rem 1fr; gap: 0.35rem 0.75rem; }
       dt { font-weight: 600; }
       section { border: 1px solid #ddd; border-radius: 0.5rem; padding: 0.75rem; margin-top: 1rem; }
+      .current-pr-state-banner section,
+      .current-pr-state-banner .state-graph-block,
+      .current-pr-state-banner .current-pr-state-visualization { border: none; padding: 0; margin-top: 0; }
       @media (max-width: 900px) {
         .current-pr-state-grid { grid-template-columns: 1fr 1fr; }
       }
@@ -1257,11 +1238,10 @@ export function renderInspectRunViewerHtml({
     </style>
   </head>
   <body>
-    <h1>${escapeHtml(pageHeading)}</h1>
-    <p><strong>Snapshot state:</strong> <span class="badge">${escapeHtml(stateLabel)}</span> <button type="button" onclick="window.location.reload()" title="Reload snapshot" aria-label="Reload snapshot">🔄</button></p>
-    <p><strong>Refresh:</strong> manual reload only. <strong>Raw snapshot:</strong> <a href="/snapshot.json"><code>/snapshot.json</code></a></p>
     ${renderCurrentStateBanner(normalizedSnapshot, target, stateLabel, graph)}
     ${renderCollapsedDetailsPanel(`
+      <p><strong>Snapshot state:</strong> <span class="badge">${escapeHtml(stateLabel)}</span></p>
+      <p><strong>Refresh:</strong> manual reload only. <strong>Raw snapshot:</strong> <a href="/snapshot.json"><code>/snapshot.json</code></a></p>
       ${topSummary}
       ${renderOuterLoopSummarySection(normalizedSnapshot)}
       ${renderCopilotLoopIterationsSection(normalizedSnapshot)}

--- a/test/loop/inspect-run-viewer.test.mjs
+++ b/test/loop/inspect-run-viewer.test.mjs
@@ -415,6 +415,7 @@ test("renderInspectRunViewerHtml renders required top-level fields for authorita
   });
 
   assert.match(html, /PR #55 State/);
+  assert.match(html, /aria-label="PR #55 State"/);
   assert.match(html, /Waiting for Copilot review/);
   assert.match(html, /Copilot review has been requested and the PR is waiting for new review activity/);
   assert.match(html, /These fields are shown directly from the loaded inspection snapshot/i);

--- a/test/loop/inspect-run-viewer.test.mjs
+++ b/test/loop/inspect-run-viewer.test.mjs
@@ -414,8 +414,7 @@ test("renderInspectRunViewerHtml renders required top-level fields for authorita
     snapshot: makeSnapshot(),
   });
 
-  assert.match(html, /PR #55 inspection/);
-  assert.match(html, /Current PR state/);
+  assert.match(html, /PR #55 State/);
   assert.match(html, /Waiting for Copilot review/);
   assert.match(html, /Copilot review has been requested and the PR is waiting for new review activity/);
   assert.match(html, /These fields are shown directly from the loaded inspection snapshot/i);
@@ -445,8 +444,7 @@ test("renderInspectRunViewerHtml renders required top-level fields for authorita
   assert.match(html, /markers\.missing/);
   assert.match(html, /markers\.stale/);
   assert.match(html, /markers\.conflicts/);
-  assert.match(html, /authoritative graph view from the current inspection snapshot/i);
-  assert.match(html, /full authoritative outer, copilot, and reviewer state graphs/i);
+  assert.doesNotMatch(html, /authoritative graph view from the current inspection snapshot/i);
   assert.match(html, /class="state-graph-cues"/);
   assert.match(html, /class="mermaid-state-graph mermaid"/);
   assert.match(html, /data-graph-zoom-in/);
@@ -474,7 +472,6 @@ test("renderInspectRunViewerHtml renders required top-level fields for authorita
   assert.match(html, /reviewer layer/);
   assert.match(html, /steering summary/);
   assert.match(html, /href="\/snapshot\.json"/);
-  assert.match(html, /title="Reload snapshot"/);
   assert.match(html, /manual reload only/i);
   assert.doesNotMatch(html, /Connected state map/);
   assert.doesNotMatch(html, /"schemaVersion": 1/);
@@ -505,7 +502,7 @@ test("renderInspectRunViewerHtml renders checkpoint-only / degraded cues and abs
   });
 
   assert.match(html, /checkpoint-only/);
-  assert.match(html, /checkpoint-only graph view[\s\S]*current and next highlights are advisory until live inspection is available\./i);
+  assert.doesNotMatch(html, /checkpoint-only graph view[\s\S]*current and next highlights are advisory until live inspection is available\./i);
   assert.match(html, /Needs attention/);
   assert.match(html, /The current snapshot is not authoritative enough to collapse to one trusted outer state/);
   assert.match(html, /This is a checkpoint-only snapshot\. The current-state fields below are advisory, not live-confirmed\./i);
@@ -564,7 +561,7 @@ test("renderInspectRunViewerHtml highlights terminal merged states", () => {
     }),
   });
 
-  assert.match(html, /Current PR state/);
+  assert.match(html, /PR #55 State/);
   assert.match(html, /PR complete/);
   assert.match(html, /The current inspection says this PR is in a terminal done state/);
   assert.match(html, /status class[\s\S]*<code>done<\/code>/);
@@ -661,7 +658,7 @@ test("renderInspectRunViewerHtml renders conflicting snapshot cues", () => {
   });
 
   assert.match(html, /Snapshot state:[\s\S]*conflicting/);
-  assert.match(html, /Conflicting graph view[\s\S]*resolve the evidence conflict before trusting the highlights\./i);
+  assert.doesNotMatch(html, /Conflicting graph view[\s\S]*resolve the evidence conflict before trusting the highlights\./i);
   assert.match(html, /Conflicting evidence is present\. Treat the current-state fields below as advisory until the snapshot is reconciled\./i);
   assert.match(html, /checkpoint outerAction/);
 });
@@ -789,7 +786,7 @@ test("createInspectRunViewerServer serves browser html from adapter snapshot wit
     assert.equal(response.statusCode, 200);
     assert.equal(response.headers["content-type"], "text/html; charset=utf-8");
     assert.equal(response.headers["cache-control"], "no-store");
-    assert.match(response.body, /PR #55 inspection/);
+    assert.match(response.body, /PR #55 State/);
     assert.match(response.body, /owner\/repo/);
     assert.match(response.body, /degraded/);
     assert.match(response.body, /manual reload only/i);

--- a/test/playwright/inspect-run-viewer.spec.mjs
+++ b/test/playwright/inspect-run-viewer.spec.mjs
@@ -98,7 +98,7 @@ test("webkit renders the Mermaid-first inspect-run viewer and captures a screens
     });
     await expect(graphBox.locator("[data-graph-zoom-value]")).toHaveText("125%");
 
-    await page.getByText(/Details/).click();
+    await page.locator(".inspection-details > summary").click();
     await expect(page.locator('a[href="/snapshot.json"]')).toBeVisible();
 
     await page.screenshot({

--- a/test/playwright/inspect-run-viewer.spec.mjs
+++ b/test/playwright/inspect-run-viewer.spec.mjs
@@ -40,12 +40,10 @@ test("webkit renders the Mermaid-first inspect-run viewer and captures a screens
   try {
     await page.goto(url, { waitUntil: "domcontentloaded" });
 
-    await expect(page.getByRole("heading", { name: "PR #55 inspection" })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Current PR state" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "PR #55 State" })).toBeVisible();
     await expect(page.getByText("Waiting for Copilot review")).toBeVisible();
     await expect(page.locator("body")).toContainText(/These fields are shown directly from the loaded inspection snapshot/i);
-    await expect(page.locator(".state-graph-intro")).toContainText(/authoritative graph view from the current inspection snapshot/i);
-    await expect(page.locator(".state-graph-intro")).toContainText(/full authoritative outer, copilot, and reviewer state graphs/i);
+    await expect(page.locator(".state-graph-intro")).toHaveCount(0);
     await expect(page.locator(".state-graph-cues")).toContainText(/Start/);
     await expect(page.locator(".state-graph-cues")).toContainText(/Current/);
     await expect(page.locator(".state-graph-cues")).toContainText(/Next/);
@@ -100,6 +98,7 @@ test("webkit renders the Mermaid-first inspect-run viewer and captures a screens
     });
     await expect(graphBox.locator("[data-graph-zoom-value]")).toHaveText("125%");
 
+    await page.getByText(/Details/).click();
     await expect(page.locator('a[href="/snapshot.json"]')).toBeVisible();
 
     await page.screenshot({
@@ -129,10 +128,10 @@ test("webkit shows checkpoint-only graph uncertainty without guessing missing tr
   try {
     await page.goto(url, { waitUntil: "domcontentloaded" });
 
-    await expect(page.getByRole("heading", { name: "Current PR state" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "PR #55 State" })).toBeVisible();
     await expect(page.locator(".current-pr-state-summary-headline")).toContainText(/Needs attention/);
     await expect(page.locator(".current-pr-state-detail").last()).toContainText(/checkpoint-only snapshot/i);
-    await expect(page.locator(".state-graph-intro")).toContainText(/checkpoint-only graph view/i);
+    await expect(page.locator(".state-graph-intro")).toHaveCount(0);
     await page.getByText(/Graph guide and lane details/).click();
     const graph = await waitForMermaidGraph(page);
     await expect(graph).toContainText(/current state unavailable/);
@@ -158,7 +157,7 @@ test("webkit shows degraded graph messaging when snapshot trust is partial", asy
   try {
     await page.goto(url, { waitUntil: "domcontentloaded" });
 
-    await expect(page.locator(".state-graph-intro")).toContainText(/degraded graph view/i);
+    await expect(page.locator(".state-graph-intro")).toHaveCount(0);
     await waitForMermaidGraph(page);
 
     await page.screenshot({
@@ -194,7 +193,7 @@ test("webkit shows terminal merged states clearly in the Mermaid graph", async (
   try {
     await page.goto(url, { waitUntil: "domcontentloaded" });
 
-    await expect(page.getByRole("heading", { name: "Current PR state" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "PR #55 State" })).toBeVisible();
     await expect(page.getByText("PR complete")).toBeVisible();
     await expect(page.locator(".current-pr-state-grid")).toContainText(/status class/);
     await expect(page.locator(".current-pr-state-grid")).toContainText(/done/);


### PR DESCRIPTION
## Summary

Simplify the `inspect-run` viewer layout so the state visual takes priority with less framing and less repeated meta information.

## Scope / context

This is a narrow viewer-polish follow-up on top of the recent state-graph work.

In scope:
- rename the main heading to `PR #XYZ State`
- remove the top visible snapshot/reload meta rows from the primary page layout
- remove the blue boxed card treatment and let the main content render full width
- move the state grid directly below the current-state detail text
- remove the `state-graph-intro` copy block
- keep raw snapshot and refresh details available under the existing details panel
- update unit/browser tests for the new layout contract

## Acceptance criteria

- the viewer heading reads `PR #XYZ State`
- the old top meta rows are no longer shown above the main viewer content
- the main state section no longer renders as the blue boxed card
- the state grid appears above the graph visual
- the graph intro paragraph is removed
- raw snapshot / refresh information remains available in the collapsed details surface
- local unit and Playwright viewer tests pass

## Definition of done

- layout updates are implemented in `inspect-run-viewer.mjs`
- unit and Playwright expectations are updated to the new layout
- local validation passes

## Non-goals

- changing viewer state semantics
- changing graph rendering behavior
- adding new controls or interaction modes
- redesigning the deeper details sections beyond relocating existing meta information

## Validation

- `node --test test/loop/inspect-run-viewer.test.mjs`
- `npm run test:playwright:viewer`
