### PR TITLE
Fix inspect-run viewer headline for clean converged Copilot heads

### DIFF
--- a/packages/core/src/loop/run-inspection.mjs
+++ b/packages/core/src/loop/run-inspection.mjs
@@ -23,6 +23,7 @@
  *   3. Unknown/unavailable markers when neither is sufficient
  */
 
+import { summarizeLoopInterpretation } from "./copilot-loop-state.mjs";
 import { isKnownOuterState } from "./outer-loop-state.mjs";
 
 // ---------------------------------------------------------------------------
@@ -406,9 +407,13 @@ export function composeRunInspectionSnapshot({
   const layers = {};
 
   if (copilotLiveOk && copilotEvidence !== null) {
+    const copilotSummary = summarizeLoopInterpretation(copilotEvidence.interpretation);
     layers.copilot = {
       currentState: copilotEvidence.interpretation.state,
       allowedTransitions: copilotEvidence.interpretation.allowedTransitions,
+      sameHeadCleanConverged: copilotEvidence.interpretation.sameHeadCleanConverged === true,
+      loopDisposition: copilotSummary.loopDisposition,
+      terminal: copilotSummary.terminal,
     };
   } else if (typeof existingCheckpoint?.copilotState === "string") {
     layers.copilot = {

--- a/scripts/loop/inspect-run-viewer.mjs
+++ b/scripts/loop/inspect-run-viewer.mjs
@@ -951,6 +951,9 @@ function summarizeCurrentPrStatus(snapshot) {
   const statusClass = formatStateToken(snapshot.statusClass, "unknown");
   const outerState = formatStateToken(snapshot.outerState, "unknown");
   const outerAction = formatStateToken(snapshot.outerAction, "unknown");
+  const sameHeadCleanConverged = snapshot.layers?.copilot?.sameHeadCleanConverged === true;
+  const copilotLoopDisposition = formatStateToken(snapshot.layers?.copilot?.loopDisposition);
+  const copilotTerminal = snapshot.layers?.copilot?.terminal === true;
 
   if (outerState === OUTER_STATE.DONE_TERMINAL || statusClass === "done" || outerAction === "done" || copilotState === "done") {
     return {
@@ -1005,6 +1008,14 @@ function summarizeCurrentPrStatus(snapshot) {
       headline: "Waiting for Copilot review",
       detail: "Copilot review has been requested and the PR is waiting for new review activity.",
       nextAction: "Wait for Copilot review or refresh the snapshot after review activity lands.",
+    };
+  }
+
+  if (copilotState === "ready_to_rerequest_review" && (sameHeadCleanConverged || copilotLoopDisposition === "clean_converged" || copilotTerminal)) {
+    return {
+      headline: "Copilot pass complete",
+      detail: "The current head already has a clean submitted Copilot review with no unresolved feedback.",
+      nextAction: "Proceed to final human review or approval, or wait for a meaningful remediation event before requesting another Copilot pass.",
     };
   }
 

--- a/test/loop/inspect-run-viewer.test.mjs
+++ b/test/loop/inspect-run-viewer.test.mjs
@@ -593,6 +593,37 @@ test("renderInspectRunViewerHtml highlights terminal merged states", () => {
   assert.match(html, /copilot layer:[\s\S]*current <code>done<\/code>; done; full authoritative state machine shown; no allowed transitions/);
 });
 
+test("renderInspectRunViewerHtml shows clean convergence instead of re-request language for same-head clean Copilot reviews", () => {
+  const html = renderInspectRunViewerHtml({
+    target: { repo: "owner/repo", pr: 55 },
+    snapshot: makeSnapshot({
+      outerState: "continue_current_wait",
+      outerAction: "continue_wait",
+      statusClass: "waiting",
+      layers: {
+        copilot: {
+          currentState: "ready_to_rerequest_review",
+          allowedTransitions: ["waiting_for_copilot_review", "review_request_unavailable", "done"],
+          sameHeadCleanConverged: true,
+          loopDisposition: "clean_converged",
+          terminal: true,
+        },
+        reviewer: {
+          currentState: "waiting_for_author_followup",
+          scope: { mode: "all_reviewers", reviewerLogin: null },
+          allowedTransitions: ["waiting_for_re_request", "waiting_for_review_request"],
+        },
+        steering: { status: "unavailable", reason: "no_steering_locator" },
+      },
+    }),
+  });
+
+  assert.match(html, /Copilot pass complete/);
+  assert.match(html, /current head already has a clean submitted Copilot review with no unresolved feedback/i);
+  assert.match(html, /Proceed to final human review or approval, or wait for a meaningful remediation event before requesting another Copilot pass/i);
+  assert.doesNotMatch(html, /Ready to re-request Copilot review/);
+});
+
 test("renderInspectRunViewerHtml preserves stay_with_current_live_owner and needs_reconcile in the banner", () => {
   const liveOwnerHtml = renderInspectRunViewerHtml({
     target: { repo: "owner/repo", pr: 55 },

--- a/test/loop/inspect-run.test.mjs
+++ b/test/loop/inspect-run.test.mjs
@@ -154,7 +154,7 @@ async function withTempDir(fn) {
 }
 
 // Canonical live copilot evidence fixture
-function makeCopilotEvidence(state = "waiting_for_copilot_review") {
+function makeCopilotEvidence(state = "waiting_for_copilot_review", { sameHeadCleanConverged = false } = {}) {
   return {
     snapshot: {
       prExists: true,
@@ -174,6 +174,7 @@ function makeCopilotEvidence(state = "waiting_for_copilot_review") {
       state,
       allowedTransitions: ["unresolved_feedback_present", "ready_to_rerequest_review", "waiting_for_ci"],
       nextAction: "Wait for Copilot review",
+      sameHeadCleanConverged,
     },
   };
 }
@@ -296,6 +297,9 @@ test("composeRunInspectionSnapshot: complete live evidence returns all required 
     reason: "unavailable",
   });
   assert.equal(snapshot.layers.copilot.currentState, "waiting_for_copilot_review");
+  assert.equal(snapshot.layers.copilot.sameHeadCleanConverged, false);
+  assert.equal(snapshot.layers.copilot.loopDisposition, "pending");
+  assert.equal(snapshot.layers.copilot.terminal, false);
   assert.equal(snapshot.layers.reviewer.currentState, "waiting_for_author_followup");
   assert.equal(snapshot.layers.steering.status, "unavailable");
   assert.equal(snapshot.layers.steering.reason, "no_steering_locator");
@@ -325,6 +329,33 @@ test("composeRunInspectionSnapshot: live evidence + done → statusClass done, n
   assert.equal(snapshot.needsAttention, false);
   assert.equal(snapshot.sourceMode, SOURCE_MODE.LIVE_DETECTOR_BACKED);
   assert.equal(snapshot.trust, TRUST.AUTHORITATIVE);
+});
+
+test("composeRunInspectionSnapshot: clean-converged Copilot state carries same-head convergence flags", () => {
+  const copilotEvidence = makeCopilotEvidence("ready_to_rerequest_review", { sameHeadCleanConverged: true });
+  copilotEvidence.snapshot.copilotReviewPresent = true;
+  copilotEvidence.snapshot.copilotReviewOnCurrentHead = true;
+  const reviewerEvidence = makeReviewerEvidence("waiting_for_author_followup");
+
+  const snapshot = composeRunInspectionSnapshot({
+    target: { repo: "owner/repo", pr: 55 },
+    inspectedAt: "2026-05-18T12:00:00Z",
+    outerState: "continue_current_wait",
+    outerAllowedTransitions: ["continue_current_wait", "handoff_to_copilot_loop"],
+    outerAction: "continue_wait",
+    copilotEvidence,
+    reviewerEvidence,
+    existingCheckpoint: null,
+    liveAvailability: { copilot: "ok", reviewer: "ok" },
+    steeringLocatorPath: null,
+    steeringEvidence: null,
+    steeringLoadFailed: false,
+  });
+
+  assert.equal(snapshot.layers.copilot.currentState, "ready_to_rerequest_review");
+  assert.equal(snapshot.layers.copilot.sameHeadCleanConverged, true);
+  assert.equal(snapshot.layers.copilot.loopDisposition, "clean_converged");
+  assert.equal(snapshot.layers.copilot.terminal, true);
 });
 
 test("composeRunInspectionSnapshot: live evidence + stop → statusClass blocked, needsAttention true", () => {


### PR DESCRIPTION
## Summary

Fix the inspect-run viewer so a clean current-head Copilot pass is shown as a completed/approval-oriented state instead of the misleading headline `Ready to re-request Copilot review`.

## Scope / context

Context:
- We observed the state UI showing `ready_to_rerequest_review` for a PR whose current head had already received a clean Copilot review, with no actionable comments and same-head re-request suppression active.
- The underlying detector output was internally consistent (`sameHeadCleanConverged=true`, `loopDisposition=clean_converged`, `terminal=true`), but the viewer banner only looked at the raw Copilot state token.

In scope:
- carry clean-convergence metadata through the run-inspection snapshot's Copilot layer
- update the inspect-run viewer banner mapping to prefer a human-meaningful clean-converged headline over raw re-request language
- add regression coverage for both snapshot composition and viewer rendering

Out of scope:
- changing the underlying Copilot loop state machine
- changing the raw machine state name `ready_to_rerequest_review`
- broader state-UI redesign

## Acceptance criteria

- A clean submitted Copilot review on the current head with no unresolved feedback is exposed in the inspection snapshot as clean-converged metadata.
- The inspect-run viewer does not headline that state as `Ready to re-request Copilot review`.
- The viewer instead shows a clean-completion/final-review-oriented summary for that case.
- Regression tests cover both snapshot composition and viewer rendering.

## Definition of done

- The viewer headline for same-head clean-converged Copilot states matches the actual next action semantics.
- The snapshot includes the metadata the viewer needs to make that distinction.
- Targeted tests pass.

## Non-goals

- renaming the underlying loop state machine state
- changing merge/review policy
- touching unrelated viewer graph rendering behavior

## Validation

- `node --test test/loop/inspect-run.test.mjs` ✅
- `node --test --test-name-pattern='composeRunInspectionSnapshot: complete live evidence returns all required fields|composeRunInspectionSnapshot: clean-converged Copilot state carries same-head convergence flags|renderInspectRunViewerHtml shows clean convergence instead of re-request language for same-head clean Copilot reviews' test/loop/inspect-run.test.mjs test/loop/inspect-run-viewer.test.mjs` ✅

## Notes

- `test/loop/inspect-run-viewer.test.mjs` still has an existing Mermaid browser-asset test that is flaky in this environment and unrelated to this change; this PR avoids widening scope into that path.
