### PR TITLE
Fix inspect-run visibility for approved current heads

### DIFF
--- a/docs/reviewer-loop-state-graph.md
+++ b/docs/reviewer-loop-state-graph.md
@@ -38,14 +38,14 @@ Implementation:
 - reviewer-scope metadata: `reviewerScope`, `reviewerLogin`
 - local planning/run/merge status: `localPlanningStatus`, `localReviewRunsStatus`, `localMergeStatus`, `draftReviewPrepared`
 - staged draft review state: `draftReviewPosted`, `draftReviewId`, `draftReviewUrl`, `draftReviewCommitSha`, `draftReviewNotificationStatus`
-- submitted review state: `submittedReviewPresent`, `submittedReviewCommitSha`
+- submitted review state: `submittedReviewPresent`, `submittedReviewCommitSha`, `submittedReviewState`
 - explicit prior action-result state: `reviewSubmissionStatus`
 
 `reviewerScope` is explicit machine-readable contract, not an inferred side note:
 - `single_reviewer` means detection was scoped to one reviewer identity and `reviewerLogin` is that normalized login
 - `all_reviewers` means `--reviewer-login` was omitted and the detector intentionally aggregated reviewer state across the PR
 
-The contract separates observable current state (`submittedReviewPresent`, `draftReviewPosted`, `reviewRequested`) from prior action-result state (`reviewSubmissionStatus`) to avoid overloading one field.
+The contract separates observable current state (`submittedReviewPresent`, `submittedReviewCommitSha`, `submittedReviewState`, `draftReviewPosted`, `reviewRequested`) from prior action-result state (`reviewSubmissionStatus`) to avoid overloading one field.
 
 ## Deterministic Review Plan Contract
 

--- a/packages/core/src/loop/reviewer-loop-state.mjs
+++ b/packages/core/src/loop/reviewer-loop-state.mjs
@@ -86,6 +86,7 @@ const VALID_LOCAL_RUN_STATUSES = new Set(["none", "running", "completed", "faile
 const VALID_LOCAL_MERGE_STATUSES = new Set(["none", "ready", "failed"]);
 const VALID_DRAFT_NOTIFICATION_STATUSES = new Set(["none", "notified"]);
 const VALID_SUBMISSION_STATUSES = new Set(["none", "submitted", "failed"]);
+const VALID_SUBMITTED_REVIEW_STATES = new Set(["APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED"]);
 
 const SUPPORTED_REVIEW_ANGLES = Object.freeze([
   "correctness",
@@ -115,6 +116,15 @@ function normalizeReviewerLogin(value) {
   return typeof value === "string" && value.trim().length > 0
     ? value.trim().toLowerCase()
     : null;
+}
+
+function normalizeSubmittedReviewState(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim().toUpperCase();
+  return VALID_SUBMITTED_REVIEW_STATES.has(normalized) ? normalized : null;
 }
 
 /**
@@ -163,6 +173,7 @@ export function normalizeReviewerSnapshot(raw) {
 
     submittedReviewPresent: Boolean(raw.submittedReviewPresent),
     submittedReviewCommitSha: normalizeSha(raw.submittedReviewCommitSha),
+    submittedReviewState: normalizeSubmittedReviewState(raw.submittedReviewState),
     reviewSubmissionStatus: normalizeStatus(raw.reviewSubmissionStatus, VALID_SUBMISSION_STATUSES, "none"),
   };
 }

--- a/packages/core/src/loop/run-inspection.mjs
+++ b/packages/core/src/loop/run-inspection.mjs
@@ -423,10 +423,18 @@ export function composeRunInspectionSnapshot({
   }
 
   if (reviewerLiveOk && reviewerEvidence !== null) {
+    const reviewerSubmittedReviewState = reviewerEvidence.snapshot.submittedReviewState ?? null;
+    const reviewerApprovedOnCurrentHead = reviewerSubmittedReviewState === "APPROVED"
+      && reviewerEvidence.snapshot.prHeadSha !== null
+      && reviewerEvidence.snapshot.submittedReviewCommitSha !== null
+      && reviewerEvidence.snapshot.prHeadSha === reviewerEvidence.snapshot.submittedReviewCommitSha;
+
     layers.reviewer = {
       currentState: reviewerEvidence.interpretation.state,
       allowedTransitions: reviewerEvidence.interpretation.allowedTransitions,
       scope: buildReviewerScope(reviewerEvidence.snapshot),
+      submittedReviewState: reviewerSubmittedReviewState,
+      approvedOnCurrentHead: reviewerApprovedOnCurrentHead,
     };
   } else if (typeof existingCheckpoint?.reviewerState === "string") {
     layers.reviewer = {

--- a/packages/core/src/loop/run-inspection.mjs
+++ b/packages/core/src/loop/run-inspection.mjs
@@ -424,7 +424,8 @@ export function composeRunInspectionSnapshot({
 
   if (reviewerLiveOk && reviewerEvidence !== null) {
     const reviewerSubmittedReviewState = reviewerEvidence.snapshot.submittedReviewState ?? null;
-    const reviewerApprovedOnCurrentHead = reviewerSubmittedReviewState === "APPROVED"
+    const reviewerApprovedOnCurrentHead = reviewerEvidence.snapshot.submittedReviewPresent === true
+      && reviewerSubmittedReviewState === "APPROVED"
       && reviewerEvidence.snapshot.prHeadSha !== null
       && reviewerEvidence.snapshot.submittedReviewCommitSha !== null
       && reviewerEvidence.snapshot.prHeadSha === reviewerEvidence.snapshot.submittedReviewCommitSha;

--- a/packages/core/test/reviewer-loop-state.test.mjs
+++ b/packages/core/test/reviewer-loop-state.test.mjs
@@ -65,6 +65,23 @@ test("normalizeReviewerSnapshot derives reviewer scope metadata deterministicall
   );
 });
 
+test("normalizeReviewerSnapshot canonicalizes submittedReviewState and drops unknown values", () => {
+  assert.equal(
+    normalizeReviewerSnapshot({ submittedReviewState: " approved " }).submittedReviewState,
+    "APPROVED",
+  );
+
+  assert.equal(
+    normalizeReviewerSnapshot({ submittedReviewState: "cHaNgEs_ReQuEsTeD" }).submittedReviewState,
+    "CHANGES_REQUESTED",
+  );
+
+  assert.equal(
+    normalizeReviewerSnapshot({ submittedReviewState: "needs-work" }).submittedReviewState,
+    null,
+  );
+});
+
 test("REVIEWER_TRANSITIONS covers every REVIEWER_STATE", () => {
   const valid = new Set(Object.values(REVIEWER_STATE));
   for (const state of valid) {

--- a/packages/core/test/reviewer-loop-state.test.mjs
+++ b/packages/core/test/reviewer-loop-state.test.mjs
@@ -40,6 +40,7 @@ test("normalizeReviewerSnapshot returns deterministic defaults", () => {
     draftReviewNotificationStatus: "none",
     submittedReviewPresent: false,
     submittedReviewCommitSha: null,
+    submittedReviewState: null,
     reviewSubmissionStatus: "none",
   });
 });

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -390,6 +390,7 @@ Optional (auto-detect mode only):
 
 Success output shape:
 - `{ "ok": true, "snapshot": { ... }, "state": "...", "allowedTransitions": [...], "nextAction": "..." }`
+- reviewer snapshots preserve the latest submitted review identity surface via `submittedReviewPresent`, `submittedReviewCommitSha`, and `submittedReviewState` so read-only inspection UIs can distinguish an approved current head from generic author-followup waiting
 
 Failure behavior:
 - malformed arguments, unexpected `gh` failures, and invalid input/local-state JSON emit

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -390,7 +390,8 @@ Optional (auto-detect mode only):
 
 Success output shape:
 - `{ "ok": true, "snapshot": { ... }, "state": "...", "allowedTransitions": [...], "nextAction": "..." }`
-- reviewer snapshots preserve the latest submitted review identity surface via `submittedReviewPresent`, `submittedReviewCommitSha`, and `submittedReviewState` so read-only inspection UIs can distinguish an approved current head from generic author-followup waiting
+- reviewer snapshots preserve the latest submitted review metadata via `submittedReviewPresent`, `submittedReviewCommitSha`, and `submittedReviewState`
+- together those fields let read-only inspection UIs distinguish an approved current head from generic author-followup waiting
 
 Failure behavior:
 - malformed arguments, unexpected `gh` failures, and invalid input/local-state JSON emit

--- a/scripts/loop/detect-reviewer-loop-state.mjs
+++ b/scripts/loop/detect-reviewer-loop-state.mjs
@@ -278,6 +278,7 @@ async function fetchReviewState({ repo, pr, reviewerLogin }, deps) {
     draftReviewCommitSha: typeof pendingReview?.commit_id === "string" ? pendingReview.commit_id : null,
     submittedReviewPresent: Boolean(submittedReview),
     submittedReviewCommitSha: typeof submittedReview?.commit_id === "string" ? submittedReview.commit_id : null,
+    submittedReviewState: typeof submittedReview?.state === "string" ? submittedReview.state.toUpperCase() : null,
   };
 }
 

--- a/scripts/loop/inspect-run-viewer.mjs
+++ b/scripts/loop/inspect-run-viewer.mjs
@@ -937,6 +937,19 @@ function titleCaseWords(value) {
     .join(" ");
 }
 
+function renderReviewerVerdict(snapshot) {
+  if (!snapshot) {
+    return "not present";
+  }
+
+  if (snapshot.layers?.reviewer?.approvedOnCurrentHead === true) {
+    return "approved on current head";
+  }
+
+  const submittedReviewState = formatStateToken(snapshot.layers?.reviewer?.submittedReviewState);
+  return submittedReviewState;
+}
+
 function summarizeCurrentPrStatus(snapshot) {
   if (!snapshot) {
     return {
@@ -954,6 +967,7 @@ function summarizeCurrentPrStatus(snapshot) {
   const sameHeadCleanConverged = snapshot.layers?.copilot?.sameHeadCleanConverged === true;
   const copilotLoopDisposition = formatStateToken(snapshot.layers?.copilot?.loopDisposition);
   const copilotTerminal = snapshot.layers?.copilot?.terminal === true;
+  const reviewerApprovedOnCurrentHead = snapshot.layers?.reviewer?.approvedOnCurrentHead === true;
 
   if (outerState === OUTER_STATE.DONE_TERMINAL || statusClass === "done" || outerAction === "done" || copilotState === "done") {
     return {
@@ -1008,6 +1022,14 @@ function summarizeCurrentPrStatus(snapshot) {
       headline: "Waiting for Copilot review",
       detail: "Copilot review has been requested and the PR is waiting for new review activity.",
       nextAction: "Wait for Copilot review or refresh the snapshot after review activity lands.",
+    };
+  }
+
+  if (copilotState === "ready_to_rerequest_review" && reviewerApprovedOnCurrentHead && (sameHeadCleanConverged || copilotLoopDisposition === "clean_converged" || copilotTerminal)) {
+    return {
+      headline: "Approved current head",
+      detail: "The current head has both a clean submitted Copilot review and an approved human review.",
+      nextAction: "Proceed to merge if authorized, or wait for any additional required review/approval signal before merging.",
     };
   }
 
@@ -1145,6 +1167,7 @@ function renderCurrentStateBanner(snapshot, target, stateLabel, graph) {
       <dt>outerAction (compatibility)</dt><dd><code>${escapeHtml(formatStateToken(snapshot?.outerAction))}</code></dd>
       <dt>current Copilot state</dt><dd><code>${escapeHtml(formatStateToken(snapshot?.layers?.copilot?.currentState))}</code></dd>
       <dt>current reviewer state</dt><dd><code>${escapeHtml(formatStateToken(snapshot?.layers?.reviewer?.currentState))}</code></dd>
+      <dt>reviewer verdict</dt><dd>${escapeHtml(renderReviewerVerdict(snapshot))}</dd>
       <dt>needs attention</dt><dd>${escapeHtml(String(snapshot?.needsAttention ?? "not present"))}</dd>
       <dt>next action</dt><dd>${escapeHtml(summary.nextAction)}</dd>
       <dt>trust</dt><dd>${escapeHtml(snapshot?.evidence?.summary ?? "not present")}</dd>

--- a/test/loop/detect-reviewer-loop-state.test.mjs
+++ b/test/loop/detect-reviewer-loop-state.test.mjs
@@ -397,6 +397,7 @@ test("detect-reviewer-loop-state auto-detect keeps fresh pending review ahead of
     assert.equal(output.state, "waiting_for_user_submit");
     assert.equal(output.snapshot.submittedReviewPresent, true);
     assert.equal(output.snapshot.submittedReviewCommitSha, "oldsha");
+    assert.equal(output.snapshot.submittedReviewState, "COMMENTED");
     assert.equal(output.snapshot.draftReviewCommitSha, "newsha");
   } finally {
     await rm(tempDir, { recursive: true, force: true });

--- a/test/loop/inspect-run-viewer.test.mjs
+++ b/test/loop/inspect-run-viewer.test.mjs
@@ -424,6 +424,7 @@ test("renderInspectRunViewerHtml renders required top-level fields for authorita
   assert.match(html, /outerAction \(compatibility\)/);
   assert.match(html, /current Copilot state/);
   assert.match(html, /current reviewer state/);
+  assert.match(html, /reviewer verdict/);
   assert.match(html, /next action/);
   assert.match(html, /Graph guide and lane details/);
   assert.match(html, /Details/);
@@ -591,6 +592,40 @@ test("renderInspectRunViewerHtml highlights terminal merged states", () => {
   assert.match(graph.definition, /class outer_loop_family_done_terminal,copilot_layer_done currentTerminal;/);
   assert.match(graph.definition, /copilot_layer_done --> copilot_layer_end/);
   assert.match(html, /copilot layer:[\s\S]*current <code>done<\/code>; done; full authoritative state machine shown; no allowed transitions/);
+});
+
+test("renderInspectRunViewerHtml shows approved current head when clean convergence also has human approval", () => {
+  const html = renderInspectRunViewerHtml({
+    target: { repo: "owner/repo", pr: 55 },
+    snapshot: makeSnapshot({
+      outerState: "continue_current_wait",
+      outerAction: "continue_wait",
+      statusClass: "waiting",
+      layers: {
+        copilot: {
+          currentState: "ready_to_rerequest_review",
+          allowedTransitions: ["waiting_for_copilot_review", "review_request_unavailable", "done"],
+          sameHeadCleanConverged: true,
+          loopDisposition: "clean_converged",
+          terminal: true,
+        },
+        reviewer: {
+          currentState: "waiting_for_author_followup",
+          submittedReviewState: "APPROVED",
+          approvedOnCurrentHead: true,
+          scope: { mode: "all_reviewers", reviewerLogin: null },
+          allowedTransitions: ["waiting_for_re_request", "waiting_for_review_request"],
+        },
+        steering: { status: "unavailable", reason: "no_steering_locator" },
+      },
+    }),
+  });
+
+  assert.match(html, /Approved current head/);
+  assert.match(html, /clean submitted Copilot review and an approved human review/i);
+  assert.match(html, /Proceed to merge if authorized/i);
+  assert.match(html, /reviewer verdict[\s\S]*approved on current head/i);
+  assert.doesNotMatch(html, /Copilot pass complete/);
 });
 
 test("renderInspectRunViewerHtml shows clean convergence instead of re-request language for same-head clean Copilot reviews", () => {

--- a/test/loop/inspect-run.test.mjs
+++ b/test/loop/inspect-run.test.mjs
@@ -180,7 +180,7 @@ function makeCopilotEvidence(state = "waiting_for_copilot_review", { sameHeadCle
 }
 
 // Canonical live reviewer evidence fixture
-function makeReviewerEvidence(state = "waiting_for_author_followup") {
+function makeReviewerEvidence(state = "waiting_for_author_followup", { submittedReviewState = "COMMENTED" } = {}) {
   return {
     snapshot: {
       prExists: true,
@@ -201,6 +201,7 @@ function makeReviewerEvidence(state = "waiting_for_author_followup") {
       draftReviewNotificationStatus: "none",
       submittedReviewPresent: true,
       submittedReviewCommitSha: "abc123",
+      submittedReviewState,
       reviewSubmissionStatus: "submitted",
     },
     interpretation: {
@@ -301,6 +302,8 @@ test("composeRunInspectionSnapshot: complete live evidence returns all required 
   assert.equal(snapshot.layers.copilot.loopDisposition, "pending");
   assert.equal(snapshot.layers.copilot.terminal, false);
   assert.equal(snapshot.layers.reviewer.currentState, "waiting_for_author_followup");
+  assert.equal(snapshot.layers.reviewer.submittedReviewState, "COMMENTED");
+  assert.equal(snapshot.layers.reviewer.approvedOnCurrentHead, false);
   assert.equal(snapshot.layers.steering.status, "unavailable");
   assert.equal(snapshot.layers.steering.reason, "no_steering_locator");
 });
@@ -356,6 +359,32 @@ test("composeRunInspectionSnapshot: clean-converged Copilot state carries same-h
   assert.equal(snapshot.layers.copilot.sameHeadCleanConverged, true);
   assert.equal(snapshot.layers.copilot.loopDisposition, "clean_converged");
   assert.equal(snapshot.layers.copilot.terminal, true);
+});
+
+test("composeRunInspectionSnapshot: approved reviewer verdict on current head is surfaced in reviewer layer", () => {
+  const copilotEvidence = makeCopilotEvidence("ready_to_rerequest_review", { sameHeadCleanConverged: true });
+  copilotEvidence.snapshot.copilotReviewPresent = true;
+  copilotEvidence.snapshot.copilotReviewOnCurrentHead = true;
+  const reviewerEvidence = makeReviewerEvidence("waiting_for_author_followup", { submittedReviewState: "APPROVED" });
+
+  const snapshot = composeRunInspectionSnapshot({
+    target: { repo: "owner/repo", pr: 55 },
+    inspectedAt: "2026-05-18T12:00:00Z",
+    outerState: "continue_current_wait",
+    outerAllowedTransitions: ["continue_current_wait", "handoff_to_copilot_loop"],
+    outerAction: "continue_wait",
+    copilotEvidence,
+    reviewerEvidence,
+    existingCheckpoint: null,
+    liveAvailability: { copilot: "ok", reviewer: "ok" },
+    steeringLocatorPath: null,
+    steeringEvidence: null,
+    steeringLoadFailed: false,
+  });
+
+  assert.equal(snapshot.layers.reviewer.currentState, "waiting_for_author_followup");
+  assert.equal(snapshot.layers.reviewer.submittedReviewState, "APPROVED");
+  assert.equal(snapshot.layers.reviewer.approvedOnCurrentHead, true);
 });
 
 test("composeRunInspectionSnapshot: live evidence + stop → statusClass blocked, needsAttention true", () => {

--- a/test/loop/inspect-run.test.mjs
+++ b/test/loop/inspect-run.test.mjs
@@ -180,7 +180,7 @@ function makeCopilotEvidence(state = "waiting_for_copilot_review", { sameHeadCle
 }
 
 // Canonical live reviewer evidence fixture
-function makeReviewerEvidence(state = "waiting_for_author_followup", { submittedReviewState = "COMMENTED" } = {}) {
+function makeReviewerEvidence(state = "waiting_for_author_followup", { submittedReviewState = "COMMENTED", submittedReviewPresent = true } = {}) {
   return {
     snapshot: {
       prExists: true,
@@ -199,7 +199,7 @@ function makeReviewerEvidence(state = "waiting_for_author_followup", { submitted
       draftReviewUrl: null,
       draftReviewCommitSha: null,
       draftReviewNotificationStatus: "none",
-      submittedReviewPresent: true,
+      submittedReviewPresent,
       submittedReviewCommitSha: "abc123",
       submittedReviewState,
       reviewSubmissionStatus: "submitted",
@@ -385,6 +385,32 @@ test("composeRunInspectionSnapshot: approved reviewer verdict on current head is
   assert.equal(snapshot.layers.reviewer.currentState, "waiting_for_author_followup");
   assert.equal(snapshot.layers.reviewer.submittedReviewState, "APPROVED");
   assert.equal(snapshot.layers.reviewer.approvedOnCurrentHead, true);
+});
+
+test("composeRunInspectionSnapshot: approved reviewer verdict without a submitted review does not count as current-head approval", () => {
+  const copilotEvidence = makeCopilotEvidence("ready_to_rerequest_review", { sameHeadCleanConverged: true });
+  const reviewerEvidence = makeReviewerEvidence("waiting_for_author_followup", {
+    submittedReviewState: "APPROVED",
+    submittedReviewPresent: false,
+  });
+
+  const snapshot = composeRunInspectionSnapshot({
+    target: { repo: "owner/repo", pr: 55 },
+    inspectedAt: "2026-05-18T12:00:00Z",
+    outerState: "continue_current_wait",
+    outerAllowedTransitions: ["continue_current_wait", "handoff_to_copilot_loop"],
+    outerAction: "continue_wait",
+    copilotEvidence,
+    reviewerEvidence,
+    existingCheckpoint: null,
+    liveAvailability: { copilot: "ok", reviewer: "ok" },
+    steeringLocatorPath: null,
+    steeringEvidence: null,
+    steeringLoadFailed: false,
+  });
+
+  assert.equal(snapshot.layers.reviewer.submittedReviewState, "APPROVED");
+  assert.equal(snapshot.layers.reviewer.approvedOnCurrentHead, false);
 });
 
 test("composeRunInspectionSnapshot: live evidence + stop → statusClass blocked, needsAttention true", () => {


### PR DESCRIPTION
## Summary

Surface human review approval in the inspect-run snapshot/viewer so an approved current head is visibly different from a generic `waiting_for_author_followup` reviewer state.

## Scope / context

Context:
- After PR approval, the inspect-run viewer still looked unchanged because the reviewer lane collapsed all submitted-review outcomes into generic author-followup waiting.
- The Copilot lane already showed clean convergence, but the human approval itself was not visible in the banner or current-state fields.

In scope:
- preserve the latest submitted reviewer verdict in reviewer detection/snapshot data
- carry reviewer approval metadata through the run-inspection snapshot
- show approval explicitly in the inspect-run viewer banner/current-state fields when the current head is approved
- add regression coverage for reviewer snapshot normalization, detection, snapshot composition, and viewer rendering
- document the new submitted-review-state snapshot field in the reviewer loop docs/README

Out of scope:
- changing the underlying reviewer loop state machine to add a new approval state
- broader state-graph redesign
- changing merge policy or merge automation

## Acceptance criteria

- Reviewer snapshots preserve the latest submitted review state.
- The run-inspection snapshot can distinguish an approved current head from generic follow-up waiting.
- The inspect-run viewer visibly surfaces approval when the current head has an approved human review.
- Existing reviewer-loop / inspect-run regression coverage stays green.

## Definition of done

- Approval is visible in the inspect-run UI for approved current-head cases.
- The viewer headline/current-state fields no longer hide approval behind generic author-followup waiting.
- Regression tests cover the new reviewer-approval visibility path.

## Non-goals

- inventing a new reviewer state token in this PR
- changing Copilot loop semantics
- implementing merge automation

## Validation

- `node --test packages/core/test/reviewer-loop-state.test.mjs test/loop/detect-reviewer-loop-state.test.mjs test/loop/inspect-run.test.mjs` ✅
- `node --test --test-name-pattern='renderInspectRunViewerHtml shows approved current head when clean convergence also has human approval|renderInspectRunViewerHtml shows clean convergence instead of re-request language for same-head clean Copilot reviews|renderInspectRunViewerHtml renders required top-level fields for authoritative snapshot and links to raw JSON' test/loop/inspect-run-viewer.test.mjs` ✅

## Notes

- `test/loop/inspect-run-viewer.test.mjs` still has an existing unrelated Mermaid browser-asset failure in this environment; this PR stays scoped away from that path.
