### PR TITLE
fix(viewer): align sidebar signal with banner for waiting layer states

### DIFF
--- a/scripts/loop/inspect-run-viewer.mjs
+++ b/scripts/loop/inspect-run-viewer.mjs
@@ -1410,26 +1410,30 @@ function deriveInboxSignalFromSnapshot(snapshot) {
   const copilotLoopDisposition = formatStateToken(snapshot.layers?.copilot?.loopDisposition);
   const copilotTerminal = snapshot.layers?.copilot?.terminal === true;
 
+  const reviewerState = formatStateToken(snapshot.layers?.reviewer?.currentState);
+
+  if (snapshot.needsAttention === true
+    || outerState === OUTER_STATE.NEEDS_RECONCILE
+    || outerState === OUTER_STATE.STOP_NEEDS_HUMAN
+    || outerAction === "stop"
+    || statusClass === "blocked"
+    || copilotState === "unresolved_feedback_present"
+    || copilotState === "already_fixed_needs_reply_resolve") {
+    return "attention";
+  }
+
   // Layer states that represent genuine waiting take priority over outer routing signals
   // (e.g. waiting_for_copilot_review beats handoff_to_reviewer_loop so sidebar and banner agree).
-  const reviewerState = formatStateToken(snapshot.layers?.reviewer?.currentState);
   if (copilotState === "waiting_for_copilot_review"
     || reviewerState === "waiting_for_author_followup"
     || reviewerState === "waiting_for_re_request") {
     return "waiting";
   }
 
-  if (snapshot.needsAttention === true
-    || outerState === OUTER_STATE.NEEDS_RECONCILE
-    || outerState === OUTER_STATE.STOP_NEEDS_HUMAN
-    || outerState === OUTER_STATE.HANDOFF_TO_COPILOT_LOOP
+  if (outerState === OUTER_STATE.HANDOFF_TO_COPILOT_LOOP
     || outerState === OUTER_STATE.HANDOFF_TO_REVIEWER_LOOP
-    || outerAction === "stop"
     || outerAction === "reenter_copilot_loop"
-    || outerAction === "reenter_reviewer_loop"
-    || statusClass === "blocked"
-    || copilotState === "unresolved_feedback_present"
-    || copilotState === "already_fixed_needs_reply_resolve") {
+    || outerAction === "reenter_reviewer_loop") {
     return "attention";
   }
 

--- a/scripts/loop/inspect-run-viewer.mjs
+++ b/scripts/loop/inspect-run-viewer.mjs
@@ -1410,6 +1410,15 @@ function deriveInboxSignalFromSnapshot(snapshot) {
   const copilotLoopDisposition = formatStateToken(snapshot.layers?.copilot?.loopDisposition);
   const copilotTerminal = snapshot.layers?.copilot?.terminal === true;
 
+  // Layer states that represent genuine waiting take priority over outer routing signals
+  // (e.g. waiting_for_copilot_review beats handoff_to_reviewer_loop so sidebar and banner agree).
+  const reviewerState = formatStateToken(snapshot.layers?.reviewer?.currentState);
+  if (copilotState === "waiting_for_copilot_review"
+    || reviewerState === "waiting_for_author_followup"
+    || reviewerState === "waiting_for_re_request") {
+    return "waiting";
+  }
+
   if (snapshot.needsAttention === true
     || outerState === OUTER_STATE.NEEDS_RECONCILE
     || outerState === OUTER_STATE.STOP_NEEDS_HUMAN

--- a/test/loop/inspect-run-viewer.test.mjs
+++ b/test/loop/inspect-run-viewer.test.mjs
@@ -678,6 +678,77 @@ test("renderInspectRunViewerHtml keeps selected handoff-to-copilot rows on the a
   assert.match(html, /🔁/);
 });
 
+test("renderInspectRunViewerHtml shows waiting inbox signal when outer routing hands off a waiting Copilot state", () => {
+  const waitingSnapshot = makeSnapshot({
+    target: { repo: "owner/repo", pr: 3 },
+    outerState: "handoff_to_reviewer_loop",
+    outerAction: "reenter_reviewer_loop",
+    activeFamilyState: "reenter_reviewer_loop",
+    statusClass: "active",
+    needsAttention: false,
+    layers: {
+      copilot: {
+        currentState: "waiting_for_copilot_review",
+        allowedTransitions: ["unresolved_feedback_present", "ready_to_rerequest_review", "waiting_for_ci"],
+      },
+      reviewer: {
+        currentState: "review_requested",
+        scope: { mode: "all_reviewers", reviewerLogin: null },
+        allowedTransitions: ["waiting_for_author_followup"],
+      },
+      steering: { status: "unavailable", reason: "no_steering_locator" },
+    },
+  });
+  const html = renderInspectRunViewerHtml({
+    repo: null,
+    target: { repo: "owner/repo", pr: 3 },
+    snapshot: waitingSnapshot,
+    inboxItems: [
+      { target: { repo: "owner/repo", pr: 3 }, title: "fix: wait signal", updatedAt: "2026-05-22T00:00:00Z", snapshot: waitingSnapshot },
+    ],
+  });
+
+  assert.match(html, /assigned-pr-row assigned-pr-row-waiting is-selected/);
+  assert.match(html, /data-inbox-signal="waiting"/);
+  assert.match(html, /<span class="assigned-pr-signal-emoji" aria-label="Waiting">⏳<\/span>/);
+  assert.match(html, /title="Waiting state"/);
+});
+
+test("renderInspectRunViewerHtml keeps hard attention ahead of waiting layer inbox signals", () => {
+  const attentionSnapshot = makeSnapshot({
+    target: { repo: "owner/repo", pr: 3 },
+    outerState: "needs_reconcile",
+    outerAction: "stop",
+    activeFamilyState: "stop",
+    statusClass: "blocked",
+    needsAttention: true,
+    layers: {
+      copilot: {
+        currentState: "waiting_for_copilot_review",
+        allowedTransitions: ["unresolved_feedback_present", "ready_to_rerequest_review", "waiting_for_ci"],
+      },
+      reviewer: {
+        currentState: "waiting_for_author_followup",
+        scope: { mode: "all_reviewers", reviewerLogin: null },
+        allowedTransitions: ["waiting_for_re_request"],
+      },
+      steering: { status: "unavailable", reason: "no_steering_locator" },
+    },
+  });
+  const html = renderInspectRunViewerHtml({
+    repo: null,
+    target: { repo: "owner/repo", pr: 3 },
+    snapshot: attentionSnapshot,
+    inboxItems: [
+      { target: { repo: "owner/repo", pr: 3 }, title: "fix: attention signal", updatedAt: "2026-05-22T00:00:00Z", snapshot: attentionSnapshot },
+    ],
+  });
+
+  assert.match(html, /assigned-pr-row assigned-pr-row-attention is-selected/);
+  assert.match(html, /data-inbox-signal="attention"/);
+  assert.match(html, /<span class="assigned-pr-signal-emoji" aria-label="Needs attention">🔴<\/span>/);
+});
+
 test("renderInspectRunViewerHtml keeps selected closed inbox rows on the closed border", () => {
   const html = renderInspectRunViewerHtml({
     repo: null,


### PR DESCRIPTION
## Summary

Fixes a mismatch between the sidebar signal emoji and the banner mode indicator in the inspect-run viewer.

## Problem

`deriveInboxSignalFromSnapshot` checked outer routing states first, so `handoff_to_reviewer_loop` / `reenter_reviewer_loop` returned `"attention"` (🔴) even when the copilot layer state was `waiting_for_copilot_review`. `summarizeCurrentPrMode` checks the copilot layer first and returned ⏳, causing sidebar and banner to show different signals for the same PR.

## Fix

Add a waiting-state guard before the attention block in `deriveInboxSignalFromSnapshot` that checks copilot/reviewer layer states (`waiting_for_copilot_review`, `waiting_for_author_followup`, `waiting_for_re_request`) and returns `"waiting"` early. Mirrors the priority order in `summarizeCurrentPrMode` so both functions agree on the same snapshot.

## Scope / context

- One file changed: `scripts/loop/inspect-run-viewer.mjs`
- 9 lines added, 0 deleted
- No new surface, no API changes

## Acceptance criteria

- `waiting_for_copilot_review` renders ⏳ in both sidebar and banner
- `waiting_for_author_followup` and `waiting_for_re_request` render ⏳ in sidebar (consistent with banner)
- States that are genuinely attention (unresolved feedback, blocked, needs reconcile) still render 🔴
- All tests pass

## Definition of done

- All tests pass (`npm test`)
- Fix is bounded to the mismatched signal derivation only
- No new logic surface introduced

## Non-goals

- Changing semantics of any other signal
- Touching `summarizeCurrentPrMode`
- Adding new signals or emojis