### PR TITLE
test: cover installed linked-pr helper execution

### DIFF
--- a/test/extension-installer.test.mjs
+++ b/test/extension-installer.test.mjs
@@ -117,6 +117,12 @@ async function assertInstalledCopilotHelpersExecute(targetRoot, skillName = "cop
   assert.match(detectResult.stdout, /Usage:/);
   assert.doesNotMatch(detectResult.stderr, /ERR_MODULE_NOT_FOUND/);
 
+  const linkedIssuePrScriptPath = path.join(targetRoot, skillName, "scripts", "github", "detect-linked-issue-pr.mjs");
+  const linkedIssuePrResult = await runNodeScript(linkedIssuePrScriptPath, ["--help"]);
+  assert.equal(linkedIssuePrResult.code, 0);
+  assert.match(linkedIssuePrResult.stdout, /Usage: detect-linked-issue-pr\.mjs/);
+  assert.doesNotMatch(linkedIssuePrResult.stderr, /ERR_MODULE_NOT_FOUND/);
+
   const handoffScriptPath = path.join(targetRoot, skillName, "scripts", "loop", "copilot-pr-handoff.mjs");
   const handoffResult = await runNodeScript(handoffScriptPath, ["--help"]);
   assert.equal(handoffResult.code, 0);


### PR DESCRIPTION
## Summary
- add installed-layout execution coverage for `scripts/github/detect-linked-issue-pr.mjs`
- exercise the actual `_github-helpers.mjs -> packages/core/src/github/repo-slug.mjs` import chain in the shared installer regression suite
- keep the fix tightly scoped to the real consumer regression from #154

## Scope / context
Issue #154 came from a real installed consumer failure in `~/.pi/agent/skills/copilot-autopilot/` where:

```bash
node ~/.pi/agent/skills/copilot-autopilot/scripts/github/detect-linked-issue-pr.mjs --repo mfittko/repo-wiki --issue 103
```

failed with `ERR_MODULE_NOT_FOUND` because `packages/core/src/github/repo-slug.mjs` was missing from the installed skill tree.

The bundled runtime support allow-list already intends to carry that file, but the installed-layout execution regression suite did not actually execute `detect-linked-issue-pr.mjs`, so this exact import chain could drift without a direct test catching it.

This PR hardens that gap by validating the shipped installed-layout helper entrypoint itself.

Closes #154.

## Acceptance criteria
- [x] add installed-layout execution coverage for the linked-PR helper path
- [x] prove `detect-linked-issue-pr.mjs --help` succeeds from an installed skill tree without `ERR_MODULE_NOT_FOUND`
- [x] preserve the existing installed helper execution coverage for the other bundled Copilot helper entrypoints
- [x] keep source-repo validation green
- [x] revalidate the real installed consumer path after updating the installed system skill copy

## Definition of done
- [x] regression coverage now exercises the installed linked-PR helper entrypoint directly
- [x] local tests pass
- [x] the repaired installed system skill path executes successfully in the real consumer scenario
- [x] scope remains limited to the installed helper portability regression

## Non-goals
- broad packaging redesign
- npm publication changes
- unrelated workflow-surface cleanup
- helper architecture rewrites outside this regression boundary

## Validation
- `node --import tsx --test test/extension-installer.test.mjs`
- `git diff --check`
- `npm test`
- `node ./bin/pi-dev-loops.mjs update system`
- `node ~/.pi/agent/skills/copilot-autopilot/scripts/github/detect-linked-issue-pr.mjs --help`
- `node ~/.pi/agent/skills/copilot-autopilot/scripts/github/detect-linked-issue-pr.mjs --repo mfittko/repo-wiki --issue 103`
