### PR TITLE
Fix inspect viewer status precedence when reviewer loop is active

### DIFF
--- a/scripts/loop/inspect-run-viewer/rendering.mjs
+++ b/scripts/loop/inspect-run-viewer/rendering.mjs
@@ -1004,14 +1004,6 @@ function summarizeCurrentPrStatus(snapshot) {
     };
   }
 
-  if (copilotState === "waiting_for_ci") {
-    return {
-      headline: "Waiting for CI",
-      detail: "The current head has progressed past review but is still waiting on CI readiness.",
-      nextAction: "Wait for CI to complete or become available.",
-    };
-  }
-
   if (reviewerState === "waiting_for_author_followup") {
     return {
       headline: "Waiting for author follow-up",
@@ -1033,6 +1025,14 @@ function summarizeCurrentPrStatus(snapshot) {
       headline: "Reviewer loop active",
       detail: `Reviewer lane is currently at ${humanizeStateToken(reviewerState)}.`,
       nextAction: "Follow the reviewer lane details below and refresh after the next review event.",
+    };
+  }
+
+  if (copilotState === "waiting_for_ci") {
+    return {
+      headline: "Waiting for CI",
+      detail: "The current head has progressed past review but is still waiting on CI readiness.",
+      nextAction: "Wait for CI to complete or become available.",
     };
   }
 

--- a/test/loop/inspect-run-viewer.test.mjs
+++ b/test/loop/inspect-run-viewer.test.mjs
@@ -717,6 +717,44 @@ test("renderInspectRunViewerHtml shows waiting inbox signal when outer routing h
   assert.match(html, /title="Waiting state"/);
 });
 
+test("renderInspectRunViewerHtml does not headline waiting_for_ci when reviewer loop is the authoritative owner", () => {
+  const reviewerActiveSnapshot = makeSnapshot({
+    target: { repo: "owner/repo", pr: 7 },
+    outerState: "handoff_to_reviewer_loop",
+    outerAction: "reenter_reviewer_loop",
+    activeFamilyState: "reenter_reviewer_loop",
+    statusClass: "active",
+    needsAttention: false,
+    layers: {
+      copilot: {
+        currentState: "waiting_for_ci",
+        allowedTransitions: ["ready_to_rerequest_review"],
+      },
+      reviewer: {
+        currentState: "review_requested",
+        scope: { mode: "all_reviewers", reviewerLogin: null },
+        allowedTransitions: ["determine_review_plan"],
+        submittedReviewState: "APPROVED",
+      },
+      steering: { status: "unavailable", reason: "no_steering_locator" },
+    },
+  });
+
+  const html = renderInspectRunViewerHtml({
+    repo: null,
+    target: { repo: "owner/repo", pr: 7 },
+    snapshot: reviewerActiveSnapshot,
+    inboxItems: [
+      { target: { repo: "owner/repo", pr: 7 }, title: "fix: reviewer beats ci wait", updatedAt: "2026-05-22T00:00:00Z", snapshot: reviewerActiveSnapshot },
+    ],
+  });
+
+  assert.match(html, /<p class="current-pr-state-summary-headline">Reviewer loop active<\/p>/);
+  assert.match(html, /<span class="assigned-pr-headline">Reviewer loop active<\/span>/);
+  assert.doesNotMatch(html, /<p class="current-pr-state-summary-headline">Waiting for CI<\/p>/);
+  assert.doesNotMatch(html, /<span class="assigned-pr-headline">Waiting for CI<\/span>/);
+});
+
 test("renderInspectRunViewerHtml keeps hard attention ahead of waiting layer inbox signals", () => {
   const attentionSnapshot = makeSnapshot({
     target: { repo: "owner/repo", pr: 3 },


### PR DESCRIPTION
## Summary
- fix the inspect-run viewer headline precedence so reviewer-active states outrank `waiting_for_ci`
- keep the existing core routing behavior unchanged
- add a regression test for the mixed snapshot where the reviewer loop owns the next action but the Copilot layer still reports `waiting_for_ci`

## Scope / context
The inspection snapshot can legitimately contain:
- `outerState = handoff_to_reviewer_loop`
- `reviewerState = review_requested`
- `copilotState = waiting_for_ci`

In that case the authoritative outer/reviewer state says the reviewer lane owns the next meaningful work. The viewer was still collapsing the banner and inbox headline to `Waiting for CI` because `summarizeCurrentPrStatus()` checked `copilotState === "waiting_for_ci"` before reviewer-active states.

## Acceptance criteria
- when reviewer-active states are present, the current-PR banner headline does not collapse to `Waiting for CI`
- the inbox headline for the same snapshot also reflects the reviewer-active summary
- existing waiting and attention inbox-signal behavior remains unchanged
- inspect-run viewer tests pass

## Definition of done
- rendering precedence updated in `scripts/loop/inspect-run-viewer/rendering.mjs`
- regression test added in `test/loop/inspect-run-viewer.test.mjs`
- local validation completed successfully

## Validation
- `node --test test/loop/inspect-run-viewer.test.mjs`
- `npm test -- --runInBand test/loop/inspect-run-viewer.test.mjs`

## Non-goals
- changing conductor routing semantics
- changing copilot/reviewer detector semantics
- redesigning inbox-signal derivation beyond this precedence fix
