### PR TITLE
Delete wrapper seams and canonicalize repo slug parsing

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -54,7 +54,7 @@ The messaging distinguishes between local loop readiness and remote GitHub/Copil
 Current Phase 3+ contract:
 - Node runtime floor: `>=20` (from `package.json`)
 - Pi host expectations are documented from current peer dependencies rather than a tested pinned Pi version range
-- the extension is source-loaded from `./index.ts` through `package.json` `pi.extensions`
+- the extension is source-loaded from `./extension/index.ts` through `package.json` `pi.extensions`
 - the package exposes `.pi/skills` through `package.json` `pi.skills` for install-based global skill loading
 - the shell CLI is exposed through `package.json` `bin.pi-dev-loops`
 - the extension syncs packaged `.pi/agents/*.agent.md` files into `~/.agents/` on `session_start` so user-level agents are available outside this repo

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./extension/index.ts";

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "pi": {
     "extensions": [
-      "./index.ts"
+      "./extension/index.ts"
     ],
     "skills": [
       ".pi/skills"

--- a/packages/core/src/github/repo-slug.mjs
+++ b/packages/core/src/github/repo-slug.mjs
@@ -7,6 +7,13 @@ export function isSafeRepoSegment(segment) {
     && !/\s/.test(segment);
 }
 
+export function parseRepoSlug(
+  repo,
+  { errorMessage = "--repo must match <owner/name>", lowercase = false } = {},
+) {
+  return parseRepoSlugParts(repo, { errorMessage, lowercase });
+}
+
 export function parseRepoSlugParts(
   repo,
   { errorMessage = "repo must match <owner/name>", lowercase = false } = {},

--- a/scripts/github/_github-helpers.mjs
+++ b/scripts/github/_github-helpers.mjs
@@ -1,5 +1,0 @@
-import { parseRepoSlugParts } from "../../packages/core/src/github/repo-slug.mjs";
-
-export function parseRepoSlug(repo) {
-  return parseRepoSlugParts(repo, { errorMessage: "--repo must match <owner/name>" });
-}

--- a/scripts/github/capture-review-threads.mjs
+++ b/scripts/github/capture-review-threads.mjs
@@ -10,7 +10,7 @@ import {
   parseReviewThreads,
   readInput,
 } from "../_core-helpers.mjs";
-import { parseRepoSlug } from "./_github-helpers.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 
 export const REVIEW_THREADS_QUERY = [
   "query($owner: String!, $name: String!, $pr: Int!) {",
@@ -105,7 +105,6 @@ export function parseCaptureCliArgs(argv) {
   return options;
 }
 
-export { parseRepoSlug };
 
 function runChild(command, args, env) {
   return new Promise((resolve, reject) => {

--- a/scripts/github/detect-gate-review-evidence.mjs
+++ b/scripts/github/detect-gate-review-evidence.mjs
@@ -7,7 +7,7 @@ import {
   parseJsonText,
   summarizeGateReviewComments,
 } from "../_core-helpers.mjs";
-import { parseRepoSlug } from "./capture-review-threads.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 
 const USAGE = `Usage: detect-gate-review-evidence.mjs --repo <owner/name> --pr <number>
 

--- a/scripts/github/detect-linked-issue-pr.mjs
+++ b/scripts/github/detect-linked-issue-pr.mjs
@@ -2,7 +2,7 @@
 import { spawn } from "node:child_process";
 
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { parseRepoSlug } from "./_github-helpers.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 
 export const LINKED_ISSUE_PR_QUERY = [
   "query($owner:String!, $name:String!, $issue:Int!, $after:String) {",

--- a/scripts/github/reply-resolve-review-thread.mjs
+++ b/scripts/github/reply-resolve-review-thread.mjs
@@ -3,7 +3,8 @@ import { readFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
 
 import { formatCliError, isDirectCliRun, parseReviewThreads } from "../_core-helpers.mjs";
-import { fetchGithubReviewThreadsPayload, parseRepoSlug } from "./capture-review-threads.mjs";
+import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 
 const RESOLVE_REVIEW_THREAD_MUTATION = [
   "mutation($threadId: ID!) {",

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -8,7 +8,8 @@ import {
   parseReviewThreads,
   summarizeCopilotReviews,
 } from "../_core-helpers.mjs";
-import { fetchGithubReviewThreadsPayload, parseRepoSlug } from "./capture-review-threads.mjs";
+import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import { buildSnapshotFromPrFacts, interpretLoopState } from "../../packages/core/src/loop/copilot-loop-state.mjs";
 
 const SUPPRESSED_SAME_HEAD_CLEAN_STATUS = "suppressed_same_head_clean";

--- a/scripts/github/stage-reviewer-draft.mjs
+++ b/scripts/github/stage-reviewer-draft.mjs
@@ -4,7 +4,7 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { parseRepoSlug } from "./capture-review-threads.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import { buildDraftReviewPayload } from "../../packages/core/src/loop/reviewer-loop-state.mjs";
 
 function requireOptionValue(args, flag) {

--- a/scripts/github/watch-copilot-review.mjs
+++ b/scripts/github/watch-copilot-review.mjs
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process";
 import { setTimeout as delay } from "node:timers/promises";
 
 import { formatCliError, isDirectCliRun, parseJsonText, parseReviewThreads } from "../_core-helpers.mjs";
-import { parseRepoSlug } from "./capture-review-threads.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 
 const USAGE = `Usage: watch-copilot-review.mjs --repo <owner/name> --pr <number> [--poll-interval-ms <ms>] [--timeout-ms <ms>]
 

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -30,7 +30,7 @@
  *   gh failures emit { "ok": false, "error": "..." } on stderr and exit non-zero.
  */
 import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { parseRepoSlug } from "../github/capture-review-threads.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import { autoDetectSnapshot } from "./detect-copilot-loop-state.mjs";
 import { performCopilotReviewRequest } from "../github/request-copilot-review.mjs";
 import { applyConfirmedReviewRequest, interpretLoopState, STATE, summarizeLoopInterpretation } from "../../packages/core/src/loop/copilot-loop-state.mjs";

--- a/scripts/loop/detect-copilot-loop-state.mjs
+++ b/scripts/loop/detect-copilot-loop-state.mjs
@@ -66,7 +66,8 @@ import {
   parseReviewThreads,
   summarizeCopilotReviews,
 } from "../_core-helpers.mjs";
-import { parseRepoSlug, fetchGithubReviewThreadsPayload } from "../github/capture-review-threads.mjs";
+import { fetchGithubReviewThreadsPayload } from "../github/capture-review-threads.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import {
   buildSnapshotFromPrFacts,
   interpretLoopState,

--- a/scripts/loop/detect-copilot-session-activity.mjs
+++ b/scripts/loop/detect-copilot-session-activity.mjs
@@ -2,7 +2,7 @@
 import { spawn } from "node:child_process";
 
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { parseRepoSlug } from "../github/_github-helpers.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 
 const USAGE = `Usage: detect-copilot-session-activity.mjs --repo <owner/name> --branch <name> [--limit <number>]
 

--- a/scripts/loop/detect-initial-copilot-pr-state.mjs
+++ b/scripts/loop/detect-initial-copilot-pr-state.mjs
@@ -2,7 +2,7 @@
 import { spawn } from "node:child_process";
 
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { parseRepoSlug } from "../github/_github-helpers.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import { detectLinkedIssuePr } from "../github/detect-linked-issue-pr.mjs";
 import { detectCopilotSessionActivity } from "./detect-copilot-session-activity.mjs";
 

--- a/scripts/loop/detect-reviewer-loop-state.mjs
+++ b/scripts/loop/detect-reviewer-loop-state.mjs
@@ -10,7 +10,7 @@ import { readFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
 
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { parseRepoSlug } from "../github/capture-review-threads.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import {
   interpretReviewerLoopState,
   normalizeReviewerSnapshot,

--- a/scripts/loop/inspect-run.mjs
+++ b/scripts/loop/inspect-run.mjs
@@ -57,7 +57,8 @@ import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 import { formatCliError, parseJsonText, parseReviewThreads } from "../_core-helpers.mjs";
-import { fetchGithubReviewThreadsPayload, parseRepoSlug } from "../github/capture-review-threads.mjs";
+import { fetchGithubReviewThreadsPayload } from "../github/capture-review-threads.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import { autoDetectSnapshot as autoDetectCopilotSnapshot } from "./detect-copilot-loop-state.mjs";
 import {
   buildCheckpointFilePath,

--- a/scripts/loop/outer-loop.mjs
+++ b/scripts/loop/outer-loop.mjs
@@ -38,7 +38,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { formatCliError, parseJsonText } from "../_core-helpers.mjs";
-import { parseRepoSlug } from "../github/capture-review-threads.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import { autoDetectSnapshot as autoDetectCopilotSnapshot } from "./detect-copilot-loop-state.mjs";
 import {
   buildCheckpointFilePath,

--- a/scripts/loop/run-copilot-watch-cycle.mjs
+++ b/scripts/loop/run-copilot-watch-cycle.mjs
@@ -3,7 +3,7 @@
 import { spawn } from "node:child_process";
 
 import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { parseRepoSlug } from "../github/capture-review-threads.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import { watchCopilotReview } from "../github/watch-copilot-review.mjs";
 import { runHandoff } from "./copilot-pr-handoff.mjs";
 import { detectCopilotSessionActivity } from "./detect-copilot-session-activity.mjs";

--- a/scripts/loop/steer-loop.mjs
+++ b/scripts/loop/steer-loop.mjs
@@ -71,7 +71,7 @@ import {
 } from "./_steering-state-file.mjs";
 
 import { formatCliError } from "../_core-helpers.mjs";
-import { parseRepoSlug } from "../github/capture-review-threads.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 
 // ---------------------------------------------------------------------------
 // Usage text

--- a/scripts/loop/watch-initial-copilot-pr.mjs
+++ b/scripts/loop/watch-initial-copilot-pr.mjs
@@ -35,7 +35,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import { spawn } from "node:child_process";
 
 import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { parseRepoSlug } from "../github/_github-helpers.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import { detectInitialCopilotPrState, LINKED_PR_STATE } from "./detect-initial-copilot-pr-state.mjs";
 
 const USAGE = `Usage: watch-initial-copilot-pr.mjs --repo <owner/name> --issue <number> [--poll-interval-ms <ms>] [--timeout-ms <ms>]

--- a/test/extension-package-contract.test.mjs
+++ b/test/extension-package-contract.test.mjs
@@ -8,7 +8,7 @@ const readRepo = (relativePath) => readFile(fromRepoRoot(relativePath), "utf8");
 test("package metadata exposes the extension entrypoint and root extension test script", async () => {
   const packageJson = JSON.parse(await readRepo("package.json"));
 
-  assert.deepEqual(packageJson.pi.extensions, ["./index.ts"]);
+  assert.deepEqual(packageJson.pi.extensions, ["./extension/index.ts"]);
   assert.equal(packageJson.bin["pi-dev-loops"], "./cli/index.mjs");
   assert.match(packageJson.engines.node, />=20/);
   assert.equal(typeof packageJson.peerDependencies["@mariozechner/pi-coding-agent"], "string");


### PR DESCRIPTION
## Summary
Delete small wrapper/helper seams that no longer earn their keep and canonicalize repo-slug parsing through one shared owner.

## Scope / context
Issue #202 remains the umbrella declutter issue. The fresh post-merge wave-4 audit identified a small, high-confidence next slice:
- delete the root extension trampoline
- delete the tiny GitHub repo-parser helper wrapper
- stop routing repo parsing through unrelated helper seams
- point runtime callers directly at the canonical parser

This PR intentionally stays smaller than the broader docs-authority collapse and tracker/conductor surface decisions.

## Acceptance criteria
- `index.ts` is deleted
- `package.json` `pi.extensions` points directly at `./extension/index.ts`
- `scripts/github/_github-helpers.mjs` is deleted
- GitHub/loop scripts use the canonical repo parser in `packages/core/src/github/repo-slug.mjs`
- `capture-review-threads.mjs` no longer acts as an unrelated repo-parser export seam
- touched docs/tests are updated
- `npm test` passes

## Definition of done
- the wrapper/helper seam deletions are landed on one bounded branch
- no dangling references remain to the deleted files
- validation passes locally
- the PR is opened as draft first and can move through the normal draft-gate → ready-for-review → follow-up loop

## Non-goals
- no docs-authority collapse in this PR
- no tracker/conductor contract-surface reduction in this PR
- no giant test-suite breakup in this PR
- no compatibility-preserving wrappers left behind

## Validation
- `npm test`
- `git diff --check`
