### PR TITLE
docs: simplify GitHub-first skill startup reads

### DIFF
--- a/skills/copilot-dev-loop/SKILL.md
+++ b/skills/copilot-dev-loop/SKILL.md
@@ -101,19 +101,22 @@ Treat these as the primary workflow surfaces:
 
 Do **not** default to a local `tmp/phases/phase-x` implementation workflow here.
 
-## Required read order
+## Required startup reads
+
+Read only the constitution / contract docs and runtime surface needed for the current step.
 
 Before planning, review, or automation:
 
-1. `README.md`
-2. `PLAN.md` if present
-3. `AGENTS.md` if present
+1. `AGENTS.md` if present
+2. `docs/public-dev-loop-contract.md`
+3. if the current step depends on async start/resume/status or retrospective enforcement, `docs/retrospective-checkpoint-contract.md`
 4. the relevant GitHub issue or PR
-5. the repository's actual validation surface:
+5. the repository's actual validation/runtime surface:
    - root `package.json`
    - relevant package-level `package.json` files
    - CI/workflow configuration if present
-6. task-relevant source files, tests, configuration, and any repo-local documentation or generated context
+   - touched helper contract docs when the PR changes a documented contract
+6. task-relevant source files, tests, and configuration
 
 If the repo includes generated wiki or LLM context files, treat them as orientation aids only.
 

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -66,13 +66,28 @@ For a new project, the only required inputs are:
 
 Everything else is optional and may be bootstrapped by this skill.
 
-## Required read order
+## Required startup reads
 
-Before doing any planning or coding:
+Read only what the current routed step actually needs.
 
-1. read `PLAN.md`
-2. read this skill
-3. if `AGENTS.md` exists, read it
+### GitHub-first routed requests (`issue_intake`, `copilot_pr_followup`, `reviewer_fixer`, `wait_watch`, `final_approval`)
+
+Before acting on a GitHub-first issue/PR request:
+
+1. read this skill
+2. if `AGENTS.md` exists, read it first as the repo constitution / working agreement
+3. read `docs/public-dev-loop-contract.md`
+4. if the current step depends on async start/resume/status or retrospective enforcement, read `docs/retrospective-checkpoint-contract.md`
+5. read the relevant GitHub issue or PR
+6. inspect the actual validation/runtime surface needed for the current step (`package.json`, CI/workflows, touched files, helper contracts)
+
+### Local implementation routed requests (`local_implementation`)
+
+Before local phase planning or coding:
+
+1. read this skill
+2. if `AGENTS.md` exists, read it
+3. read `PLAN.md`
 4. if `docs/IMPLEMENTATION_WORKFLOW.md` exists, read it
 5. if `docs/IMPLEMENTATION_STATE.md` exists, read it
 6. if `docs/phases/phase-x.md` exists for the active phase, read it


### PR DESCRIPTION
## Summary
Simplify the startup-read guidance in the `dev-loop` and `copilot-dev-loop` skills for GitHub-first flows.

## Scope / context
This PR removes broad startup-read guidance that front-loaded repo docs not required for GitHub-first issue/PR follow-up.

The updated guidance now tells GitHub-first paths to read only:
- the skill itself
- `AGENTS.md`
- `docs/public-dev-loop-contract.md`
- `docs/retrospective-checkpoint-contract.md` only when relevant
- the relevant issue/PR
- the actual runtime / validation surface needed for the current step

The local-implementation path still keeps its broader local-phase read set.

## Acceptance criteria
- GitHub-first startup guidance is leaner and contract-focused
- `PLAN.md` and local workflow/state docs are no longer front-loaded for GitHub-first flows
- the guidance stays explicit about what GitHub-first requests do need to read
- local-implementation guidance remains intact

## Definition of done
- both skill docs are updated consistently
- the GitHub-first startup section is simpler and narrower
- no unrelated workflow changes are bundled into this PR

## Non-goals
- changing runtime behavior
- redesigning local implementation workflow guidance
- broader skill refactoring beyond startup-read instructions

## Validation
- docs-only change; no code/runtime behavior changed
