### PR TITLE
docs: keep README as a landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pi-dev-loops
 
-`pi-dev-loops` is a source-loaded workspace for reusable Pi development loops.
+`pi-dev-loops` is a private, source-loaded workspace for reusable Pi development loops.
 
 ## Workflow posture
 
@@ -30,15 +30,6 @@ Its main surfaces are:
    - shared helpers, loop-state detectors, and GitHub/Copilot support code
 
 Thin workflow entrypoint agents are allowed when they only load a skill and defer policy to it.
-
-## Current status
-
-A few durable current-state facts:
-- the root package `pi-dev-loops` is currently `private: true`
-- the shared workspace package `@pi-dev-loops/core` is also `private: true`
-- the repo is currently documented as a source-loaded workspace, not a published npm-package workflow
-- MIT is the current license
-- the current implementation snapshot lives in `docs/IMPLEMENTATION_STATE.md`
 
 ## Package surface
 
@@ -97,12 +88,10 @@ CI currently runs `npm ci`, `npm run verify`, and the explicit Playwright viewer
 
 ## Where to read next
 
-- `PLAN.md` — durable repo intent and roadmap
 - `docs/index.md` — docs start-here index for active docs, history, and presentations
-- `docs/IMPLEMENTATION_STATE.md` — current implementation snapshot
+- `docs/IMPLEMENTATION_STATE.md` — current implementation snapshot and next local phase
+- `PLAN.md` — durable repo intent and roadmap
 - `docs/IMPLEMENTATION_WORKFLOW.md` — repo workflow contract and docs-sync rules
 - `skills/docs/public-dev-loop-contract.md` — public façade and routing contract
 - `extension/README.md` — `/dev-loops` command and package-install contract
 - `scripts/README.md` — deterministic script contracts
-- `skills/*/SKILL.md` — workflow-specific operating instructions
-- `skills/docs/*.md` — canonical shared runtime contract docs for packaged skills

--- a/test/imported-assets-normalization.test.mjs
+++ b/test/imported-assets-normalization.test.mjs
@@ -187,6 +187,15 @@ test("workflow docs keep helper/runtime authority code-owned and dev-loop scope 
   assert.match(devLoopSkill, /it does not redefine the shipped runtime semantics of helper CLIs, shared loop logic, or extension commands/i);
 });
 
+test("README stays a landing page and defers live execution status to docs", async () => {
+  const readme = await readRepo("README.md");
+
+  assert.doesNotMatch(readme, /^## Current status$/im, "README should not become a second owner for the live execution snapshot");
+  assert.match(readme, /docs\/index\.md/i, "README should point readers to the docs index");
+  assert.match(readme, /docs\/IMPLEMENTATION_STATE\.md/i, "README should point readers to the implementation snapshot");
+  assert.match(readme, /private, source-loaded workspace/i, "README should keep the repo posture concise without a separate status section");
+});
+
 test("repo docs define dev-loop as the public façade and keep internal routed logic behind it", async () => {
   const [readme, plan, agents, workflowDoc, publicContract, extensionReadme, devLoopSkill, copilotSkill] = await Promise.all([
     readRepo("README.md"),


### PR DESCRIPTION
## Summary
Keep `README.md` as a lean landing page instead of a second owner of live execution status.

## Scope / context
This is the first bounded slice from de-slop wave 1.

The repo already says `docs/IMPLEMENTATION_STATE.md` owns the current implementation snapshot, but `README.md` still carried a separate `## Current status` section plus extra navigation residue. This PR trims that duplicate ownership and leaves README acting as a pointer to the real owners.

## Acceptance criteria
- `README.md` no longer carries a separate live `## Current status` section
- README points readers at the real status/doc owners, especially `docs/index.md` and `docs/IMPLEMENTATION_STATE.md`
- regression coverage protects that boundary

## Definition of done
- README is a lean landing page again
- current execution status is owned by the docs surfaces that already claim it
- assets/docs regression tests stay green

## Non-goals
- no broad README rewrite
- no docs IA redesign
- no workflow-contract rewrite beyond this ownership cleanup

## Validation
- `npm run test:assets`
