### PR TITLE
docs: let docs index own deep doc navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,6 @@ CI currently runs `npm ci`, `npm run verify`, and the explicit Playwright viewer
 
 ## Where to read next
 
-- `docs/index.md` — docs start-here index for active docs, history, and presentations
-- `docs/IMPLEMENTATION_STATE.md` — current implementation snapshot and next local phase
-- `PLAN.md` — durable repo intent and roadmap
-- `docs/IMPLEMENTATION_WORKFLOW.md` — repo workflow contract and docs-sync rules
-- `skills/docs/public-dev-loop-contract.md` — public façade and routing contract
+- `docs/index.md` — start here for active docs and canonical-owner pointers
 - `extension/README.md` — `/dev-loops` command and package-install contract
 - `scripts/README.md` — deterministic script contracts

--- a/test/imported-assets-normalization.test.mjs
+++ b/test/imported-assets-normalization.test.mjs
@@ -187,12 +187,13 @@ test("workflow docs keep helper/runtime authority code-owned and dev-loop scope 
   assert.match(devLoopSkill, /it does not redefine the shipped runtime semantics of helper CLIs, shared loop logic, or extension commands/i);
 });
 
-test("README stays a landing page and defers live execution status to docs", async () => {
+test("README stays a landing page and lets docs/index own deeper doc navigation", async () => {
   const readme = await readRepo("README.md");
 
   assert.doesNotMatch(readme, /^## Current status$/im, "README should not become a second owner for the live execution snapshot");
   assert.match(readme, /docs\/index\.md/i, "README should point readers to the docs index");
-  assert.match(readme, /docs\/IMPLEMENTATION_STATE\.md/i, "README should point readers to the implementation snapshot");
+  assert.doesNotMatch(readme, /docs\/IMPLEMENTATION_STATE\.md/i, "README should not duplicate docs/index deep links for the implementation snapshot");
+  assert.doesNotMatch(readme, /docs\/IMPLEMENTATION_WORKFLOW\.md/i, "README should not duplicate docs/index deep links for workflow docs");
   assert.match(readme, /private, source-loaded workspace/i, "README should keep the repo posture concise without a separate status section");
 });
 


### PR DESCRIPTION
## Summary
Trim the remaining README/docs-index navigation overlap so `README.md` stays a landing page and `docs/index.md` owns the deeper docs menu.

## Scope / context
This is de-slop wave 1, slice 2.

PR #250 removed README's duplicate live-status section. README still re-listed deep docs that `docs/index.md` already owns, which left the landing page acting like a second docs menu. This PR trims that overlap.

## Acceptance criteria
- README points readers to `docs/index.md` for deeper docs navigation
- README no longer re-lists `docs/IMPLEMENTATION_STATE.md` and `docs/IMPLEMENTATION_WORKFLOW.md`
- regression coverage protects that boundary

## Definition of done
- README stays lean
- `docs/index.md` remains the owner of deeper docs navigation
- assets/docs regression tests stay green

## Non-goals
- no broad README rewrite
- no docs IA redesign
- no workflow-contract rewrite beyond this ownership cleanup

## Validation
- `npm run test:assets`
