### PR TITLE
ci: cache Playwright WebKit runtime for viewer smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
 
     steps:
       - name: Check out repository
@@ -24,6 +26,12 @@ jobs:
 
       - name: Run canonical verify suite
         run: npm run verify
+
+      - name: Restore Playwright WebKit runtime cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+          key: ${{ runner.os }}-playwright-webkit-${{ hashFiles('package-lock.json') }}
 
       - name: Install Playwright WebKit runtime
         run: npx playwright install --with-deps webkit

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Root verification and test commands from `package.json`:
 - `npm run test:dev-loop`
 - `npm run test:playwright:viewer` — explicit viewer/browser smoke, not part of the default root verify path
 
-CI currently runs `npm ci`, `npm run verify`, and the explicit Playwright viewer smoke in `.github/workflows/ci.yml`.
+CI currently runs `npm ci`, `npm run verify`, restores a workspace-local Playwright WebKit runtime cache keyed by `package-lock.json`, and runs the explicit Playwright viewer smoke in `.github/workflows/ci.yml`.
 
 ## Where to read next
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Root verification and test commands from `package.json`:
 - `npm run test:dev-loop`
 - `npm run test:playwright:viewer` — explicit viewer/browser smoke, not part of the default root verify path
 
-CI currently runs `npm ci`, `npm run verify`, restores a workspace-local Playwright WebKit runtime cache keyed by `package-lock.json`, and runs the explicit Playwright viewer smoke in `.github/workflows/ci.yml`.
+CI currently runs `npm ci`, `npm run verify`, restores a workspace-local Playwright WebKit runtime cache keyed by runner OS + `package-lock.json`, and runs the explicit Playwright viewer smoke in `.github/workflows/ci.yml`.
 
 ## Where to read next
 

--- a/test/imported-assets-normalization.test.mjs
+++ b/test/imported-assets-normalization.test.mjs
@@ -128,7 +128,7 @@ test("CI caches the Playwright WebKit runtime in a deterministic workspace-local
   assert.match(ciWorkflow, /key:\s*\$\{\{\s*runner\.os\s*\}\}-playwright-webkit-\$\{\{\s*hashFiles\('package-lock\.json'\)\s*\}\}/i);
   assert.match(ciWorkflow, /npx playwright install --with-deps webkit/i);
 
-  assert.match(readme, /workspace-local Playwright WebKit runtime cache keyed by `package-lock\.json`/i);
+  assert.match(readme, /workspace-local Playwright WebKit runtime cache keyed by runner OS \+ `package-lock\.json`/i);
 });
 
 test("installed skill guidance owns packaging guarantees and contract docs stay contract-focused", async () => {

--- a/test/imported-assets-normalization.test.mjs
+++ b/test/imported-assets-normalization.test.mjs
@@ -116,6 +116,21 @@ test("dev-loop skill documents opt-in Playwright smoke harnesses for UI slices",
 });
 
 
+test("CI caches the Playwright WebKit runtime in a deterministic workspace-local path", async () => {
+  const [ciWorkflow, readme] = await Promise.all([
+    readRepo(".github/workflows/ci.yml"),
+    readRepo("README.md"),
+  ]);
+
+  assert.match(ciWorkflow, /PLAYWRIGHT_BROWSERS_PATH:\s*\$\{\{\s*github\.workspace\s*\}\}\/\.cache\/ms-playwright/i);
+  assert.match(ciWorkflow, /actions\/cache@v4/i);
+  assert.match(ciWorkflow, /path:\s*\$\{\{\s*env\.PLAYWRIGHT_BROWSERS_PATH\s*\}\}/i);
+  assert.match(ciWorkflow, /key:\s*\$\{\{\s*runner\.os\s*\}\}-playwright-webkit-\$\{\{\s*hashFiles\('package-lock\.json'\)\s*\}\}/i);
+  assert.match(ciWorkflow, /npx playwright install --with-deps webkit/i);
+
+  assert.match(readme, /workspace-local Playwright WebKit runtime cache keyed by `package-lock\.json`/i);
+});
+
 test("installed skill guidance owns packaging guarantees and contract docs stay contract-focused", async () => {
   const [devLoopSkill, copilotSkill, publicContract, retrospectiveContract, projectionContract] = await Promise.all([
     readRepo(".pi/skills/dev-loop/SKILL.md"),


### PR DESCRIPTION
## Summary
- cache the Playwright WebKit browser runtime in a workspace-local CI path
- keep the existing `playwright install --with-deps webkit` step so cold-cache behavior stays deterministic
- lock the workflow/doc contract with a regression test and README note

## Scope / context
Issue #254 asked for the smallest honest CI optimization slice for the inspect-run viewer WebKit smoke path.

This PR stays narrowly scoped to that first slice:
- `.github/workflows/ci.yml`
- `README.md`
- `test/imported-assets-normalization.test.mjs`

Before:
- CI always ran `npx playwright install --with-deps webkit` against the default browser cache location
- the workflow did not restore a repo-scoped Playwright runtime cache first

After:
- CI restores `${{ github.workspace }}/.cache/ms-playwright` via `actions/cache@v4`
- the cache key is tied to `runner.os` + `hashFiles('package-lock.json')`
- CI still runs `npx playwright install --with-deps webkit`, so cold-cache and invalid-cache runs remain deterministic while warm-cache runs can reuse the browser payload

## Acceptance criteria
- [x] CI caches the Playwright browser runtime used by `npm run test:playwright:viewer`
- [x] cache keying is explicit and safe for version changes
- [x] cold-cache behavior still works cleanly
- [x] warm-cache runs avoid re-downloading the same browser payload when inputs are unchanged
- [x] docs/workflow notes stay aligned with the resulting CI behavior

## Definition of done
- [x] the change stays narrowly scoped to the Playwright runtime setup path
- [x] deterministic install behavior is preserved by keeping the install step after cache restore
- [x] local verification passed: `npm run verify`
- [x] local viewer smoke passed: `npm run test:playwright:viewer`

## Non-goals
- generic CI caching cleanup
- npm dependency caching changes
- broader CI redesign
- unrelated dependency/runtime optimization
- viewer behavior changes

Closes #254
