### PR TITLE
Add deterministic GitHub sub-issue tree helper

### DIFF
--- a/agents/coordinator.agent.md
+++ b/agents/coordinator.agent.md
@@ -13,6 +13,7 @@ Default operating mode:
 - Treat the repository's durable phase docs, implementation plans, or other explicitly linked planning documents as the primary source of truth for task breakdown.
 - Treat the active repository workflow surface as the execution backlog, whether that is GitHub Issues, local phase docs, or another explicit planning system.
 - When coordinating issue execution in a GitHub-first repo, use issue relationships, milestones, labels, and other repo-native tracking signals when they help clarify sequencing.
+- When an umbrella issue decomposes into multiple executable child slices, prefer real GitHub sub-issue trees as the durable execution structure and keep parent issue bodies lean instead of duplicating order in checklist prose.
 - The final deliverable for each completed implementation milestone or plan should match the active repository workflow, such as a pull request with documentation in GitHub-first repos or a validated local branch handoff in local-first repos.
 
 ## Constraints

--- a/docs/github-sub-issue-decomposition.md
+++ b/docs/github-sub-issue-decomposition.md
@@ -1,0 +1,82 @@
+# GitHub sub-issue decomposition pattern
+
+Use this pattern when an umbrella issue, mini-epic, or refinement pass needs a real execution tree.
+
+## Goal
+
+Keep GitHub's real sub-issue tree as the durable ownership and sequencing surface.
+
+That means:
+- parent issues hold the durable problem statement, scope, acceptance boundary, and non-goals
+- child issues hold the executable bounded slices
+- execution order lives in the sub-issue tree, not in a duplicated parent-body checklist
+- `dev-loop` remains the only public workflow entrypoint
+
+## When to use a real sub-issue tree
+
+Prefer a sub-issue tree when all of these are true:
+- the parent issue is an umbrella, mini-epic, or decomposition container rather than one executable coding task
+- there are multiple bounded child slices with real ownership boundaries
+- execution order or reprioritization matters
+- you want progress roll-up to live in GitHub's structure rather than in body prose
+
+Use plain related-issue references instead when:
+- the issue is already one bounded executable task
+- the relationship is informative rather than parent/child ownership
+- there is no meaningful execution order to maintain
+
+## Parent-body guidance
+
+Once a real sub-issue tree exists, keep the parent issue body lean:
+- preserve summary, scope, acceptance criteria, definition of done, and non-goals
+- link relevant seed PRs, prior art, or constraints
+- do **not** duplicate child sequencing as a long checklist unless there is a separate durable reason
+- do **not** use the parent body as the primary progress tracker when GitHub already owns that structure
+
+## Deterministic helper boundary
+
+Use existing `gh issue create` for child issue creation.
+
+Then use `scripts/github/sub-issue-tree.mjs` for tree ownership:
+
+```sh
+# inspect current tree
+node scripts/github/sub-issue-tree.mjs inspect \
+  --repo <owner/name> \
+  --issue <parent>
+
+# attach an existing child issue
+node scripts/github/sub-issue-tree.mjs add \
+  --repo <owner/name> \
+  --parent <parent> \
+  --child <child>
+
+# move a child before or after a sibling
+node scripts/github/sub-issue-tree.mjs reprioritize \
+  --repo <owner/name> \
+  --parent <parent> \
+  --child <child> \
+  --before <sibling>
+
+# verify expected exact order
+node scripts/github/sub-issue-tree.mjs verify \
+  --repo <owner/name> \
+  --parent <parent> \
+  --expect-children <child-a>,<child-b>,<child-c>
+```
+
+This boundary is intentionally thin:
+- child creation stays on standard GitHub tooling
+- tree linking/order/verification becomes deterministic and testable
+- the repo does **not** grow a generic hierarchy SDK or opaque planning automation
+
+## Refinement expectations
+
+When issue refinement produces multiple child slices:
+1. keep the parent focused on umbrella framing and boundaries
+2. create explicit child issues
+3. attach them as real GitHub sub-issues
+4. set the intended execution order in the tree
+5. verify the resulting tree deterministically
+
+If the work is still just one executable issue, do not force a tree.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -97,6 +97,35 @@ Success output shape:
 Failure behavior:
 - malformed arguments and unexpected `gh` failures emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero
 
+### `scripts/github/sub-issue-tree.mjs`
+
+Inspect, attach, reprioritize, and verify GitHub sub-issue trees.
+
+Required:
+- `--repo <owner/name>`
+- subcommand-specific issue numbers
+
+Commands:
+- `inspect --issue <parent>` — read the current tree
+- `add --parent <parent> --child <child> [--replace-parent]` — attach an existing child issue
+- `reprioritize --parent <parent> --child <child> (--after <sibling> | --before <sibling>)` — reorder an attached child
+- `verify --parent <parent> --expect-children <n1,n2,...>` — compare the current exact order to an expected order
+
+Contract:
+- pages through the parent issue's `subIssues` connection until `hasNextPage=false`
+- keeps child issue creation on ordinary `gh issue create` instead of wrapping it in a broader planner
+- uses GitHub GraphQL sub-issue mutations (`addSubIssue`, `reprioritizeSubIssue`) as the deterministic write boundary
+- returns machine-readable tree state so refinement/dev-loop guidance can treat the GitHub tree as the authoritative execution structure
+- prefers lean parent issue bodies once a real tree exists; use plain related-issue references when no parent/child execution tree is warranted
+
+Success output shape:
+- `inspect`: `{ "ok": true, "repo": "owner/name", "parent": { ... }, "subIssues": [ ... ], "summary": { ... } }`
+- `add` / `reprioritize`: same tree payload plus `"action": "add"|"reprioritize"`
+- `verify`: `{ "ok": true, "action": "verify", "repo": "owner/name", "parent": { ... }, "matches": true|false, "expectedOrder": [...], "actualOrder": [...], "missing": [...], "unexpected": [...], "misordered": [...] }`
+
+Failure behavior:
+- malformed arguments, missing parent/child issues, conflicting parent replacement, and unexpected `gh` failures emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero
+
 ### `scripts/github/stage-reviewer-draft.mjs`
 
 Stage a pending reviewer-side draft review from a merged deterministic review package.

--- a/scripts/github/sub-issue-tree.mjs
+++ b/scripts/github/sub-issue-tree.mjs
@@ -498,7 +498,21 @@ function normalizeSubIssue(issue, index) {
 }
 
 function readInspectConnection(payload) {
-  const issue = readIssueNode(payload, "data.repository.issue");
+  const issue = payload?.data?.repository?.issue;
+
+  if (issue === null) {
+    return {
+      issue: null,
+      nodes: [],
+      hasNextPage: false,
+      endCursor: null,
+    };
+  }
+
+  if (!issue || typeof issue !== "object") {
+    throw new Error("Invalid sub-issue-tree GraphQL payload: missing data.repository.issue");
+  }
+
   const connection = issue?.subIssues;
 
   if (!connection || typeof connection !== "object") {

--- a/scripts/github/sub-issue-tree.mjs
+++ b/scripts/github/sub-issue-tree.mjs
@@ -242,7 +242,17 @@ function parseCommaSeparatedIssueNumbers(value) {
     throw parseError("--expect-children must include at least one issue number");
   }
 
-  return tokens.map((token) => parsePositiveInt("--expect-children", token));
+  const numbers = tokens.map((token) => parsePositiveInt("--expect-children", token));
+  const seen = new Set();
+
+  for (const number of numbers) {
+    if (seen.has(number)) {
+      throw parseError(`--expect-children must not include duplicate issue number ${number}`);
+    }
+    seen.add(number);
+  }
+
+  return numbers;
 }
 
 export function parseSubIssueTreeCliArgs(argv) {
@@ -447,7 +457,8 @@ async function runGhJson(args, env) {
 
   if (result.code !== 0) {
     const stderr = result.stderr.trim();
-    throw new Error(stderr.length > 0 ? stderr : `gh exited with code ${result.code}`);
+    const detail = stderr.length > 0 ? stderr : `gh exited with code ${result.code}`;
+    throw new Error(`gh command failed: ${detail}`);
   }
 
   return parseJsonText(result.stdout);

--- a/scripts/github/sub-issue-tree.mjs
+++ b/scripts/github/sub-issue-tree.mjs
@@ -1,0 +1,762 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+
+import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
+
+const INSPECT_QUERY = [
+  "query($owner:String!, $name:String!, $parent:Int!, $after:String) {",
+  "  repository(owner:$owner, name:$name) {",
+  "    issue(number:$parent) {",
+  "      id",
+  "      number",
+  "      title",
+  "      url",
+  "      state",
+  "      subIssues(first:100, after:$after) {",
+  "        pageInfo {",
+  "          hasNextPage",
+  "          endCursor",
+  "        }",
+  "        nodes {",
+  "          id",
+  "          number",
+  "          title",
+  "          url",
+  "          state",
+  "          repository { nameWithOwner }",
+  "          parent { number }",
+  "        }",
+  "      }",
+  "    }",
+  "  }",
+  "}",
+].join("\n");
+
+const RESOLVE_ADD_QUERY = [
+  "query($owner:String!, $name:String!, $parent:Int!, $child:Int!) {",
+  "  repository(owner:$owner, name:$name) {",
+  "    parentIssue: issue(number:$parent) {",
+  "      id",
+  "      number",
+  "      title",
+  "      url",
+  "      state",
+  "    }",
+  "    childIssue: issue(number:$child) {",
+  "      id",
+  "      number",
+  "      title",
+  "      url",
+  "      state",
+  "      repository { nameWithOwner }",
+  "      parent { number }",
+  "    }",
+  "  }",
+  "}",
+].join("\n");
+
+const RESOLVE_REPRIORITIZE_BEFORE_QUERY = [
+  "query($owner:String!, $name:String!, $parent:Int!, $child:Int!, $before:Int!) {",
+  "  repository(owner:$owner, name:$name) {",
+  "    parentIssue: issue(number:$parent) {",
+  "      id",
+  "      number",
+  "      title",
+  "      url",
+  "      state",
+  "    }",
+  "    childIssue: issue(number:$child) {",
+  "      id",
+  "      number",
+  "      title",
+  "      url",
+  "      state",
+  "      repository { nameWithOwner }",
+  "      parent { number }",
+  "    }",
+  "    beforeIssue: issue(number:$before) {",
+  "      id",
+  "      number",
+  "      title",
+  "      url",
+  "      state",
+  "      repository { nameWithOwner }",
+  "      parent { number }",
+  "    }",
+  "  }",
+  "}",
+].join("\n");
+
+const RESOLVE_REPRIORITIZE_AFTER_QUERY = [
+  "query($owner:String!, $name:String!, $parent:Int!, $child:Int!, $after:Int!) {",
+  "  repository(owner:$owner, name:$name) {",
+  "    parentIssue: issue(number:$parent) {",
+  "      id",
+  "      number",
+  "      title",
+  "      url",
+  "      state",
+  "    }",
+  "    childIssue: issue(number:$child) {",
+  "      id",
+  "      number",
+  "      title",
+  "      url",
+  "      state",
+  "      repository { nameWithOwner }",
+  "      parent { number }",
+  "    }",
+  "    afterIssue: issue(number:$after) {",
+  "      id",
+  "      number",
+  "      title",
+  "      url",
+  "      state",
+  "      repository { nameWithOwner }",
+  "      parent { number }",
+  "    }",
+  "  }",
+  "}",
+].join("\n");
+
+const ADD_SUB_ISSUE_MUTATION = [
+  "mutation($issueId:ID!, $subIssueId:ID!, $replaceParent:Boolean) {",
+  "  addSubIssue(input: { issueId: $issueId, subIssueId: $subIssueId, replaceParent: $replaceParent }) {",
+  "    clientMutationId",
+  "  }",
+  "}",
+].join("\n");
+
+const REPRIORITIZE_SUB_ISSUE_BEFORE_MUTATION = [
+  "mutation($issueId:ID!, $subIssueId:ID!, $beforeId:ID!) {",
+  "  reprioritizeSubIssue(input: { issueId: $issueId, subIssueId: $subIssueId, beforeId: $beforeId }) {",
+  "    clientMutationId",
+  "  }",
+  "}",
+].join("\n");
+
+const REPRIORITIZE_SUB_ISSUE_AFTER_MUTATION = [
+  "mutation($issueId:ID!, $subIssueId:ID!, $afterId:ID!) {",
+  "  reprioritizeSubIssue(input: { issueId: $issueId, subIssueId: $subIssueId, afterId: $afterId }) {",
+  "    clientMutationId",
+  "  }",
+  "}",
+].join("\n");
+
+const USAGE = `Usage:
+  sub-issue-tree.mjs inspect --repo <owner/name> --issue <number>
+  sub-issue-tree.mjs add --repo <owner/name> --parent <number> --child <number> [--replace-parent]
+  sub-issue-tree.mjs reprioritize --repo <owner/name> --parent <number> --child <number> (--after <number> | --before <number>)
+  sub-issue-tree.mjs verify --repo <owner/name> --parent <number> --expect-children <n1,n2,...>
+
+Read, mutate, and verify a GitHub sub-issue tree through thin deterministic helpers.
+Keep issue creation on existing \`gh issue create\`; use this helper for tree ownership.
+
+Commands:
+  inspect         Print the current parent/sub-issue tree as JSON.
+  add             Attach an existing child issue to a parent issue.
+  reprioritize    Move an attached sub-issue before or after another attached sub-issue.
+  verify          Compare the current tree order to an expected exact child order.
+
+Required:
+  --repo <owner/name>         Repository slug (e.g. owner/repo)
+
+inspect:
+  --issue <number>            Parent issue number to inspect
+
+add:
+  --parent <number>           Parent issue number
+  --child <number>            Existing child issue number
+  --replace-parent            Allow replacing an existing different parent
+
+reprioritize:
+  --parent <number>           Parent issue number
+  --child <number>            Existing attached child issue number
+  --after <number>            Move child after this attached sibling
+  --before <number>           Move child before this attached sibling
+
+verify:
+  --parent <number>           Parent issue number
+  --expect-children <list>    Exact expected child order, e.g. 123,124,125
+
+Success output (stdout, JSON):
+  inspect:
+    {
+      "ok": true,
+      "repo": "owner/name",
+      "parent": { "number": 97, "title": "...", "url": "...", "state": "OPEN" },
+      "subIssues": [
+        { "number": 123, "title": "...", "url": "...", "state": "OPEN", "parentNumber": 97, "position": 1 }
+      ],
+      "summary": { "total": 1, "completed": 0, "percentCompleted": 0 }
+    }
+  add / reprioritize:
+    { "ok": true, "action": "add|reprioritize", ...inspect output }
+  verify:
+    {
+      "ok": true,
+      "action": "verify",
+      "repo": "owner/name",
+      "parent": { "number": 97, "title": "...", "url": "...", "state": "OPEN" },
+      "matches": true|false,
+      "expectedOrder": [123, 124],
+      "actualOrder": [123, 124],
+      "missing": [],
+      "unexpected": [],
+      "misordered": []
+    }
+
+Error output (stderr, JSON):
+  Argument/usage errors:
+    { "ok": false, "error": "...", "usage": "..." }
+  gh/runtime failures:
+    { "ok": false, "error": "..." }`.trim();
+
+function parseError(message) {
+  return Object.assign(new Error(message), { usage: USAGE });
+}
+
+function requireOptionValue(args, flag) {
+  const value = args.shift();
+
+  if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
+    throw parseError(`Missing value for ${flag}`);
+  }
+
+  return value;
+}
+
+function parsePositiveInt(flag, value) {
+  if (!/^\d+$/.test(value) || Number(value) === 0) {
+    throw parseError(`${flag} must be a positive integer`);
+  }
+
+  return Number(value);
+}
+
+function parseCommaSeparatedIssueNumbers(value) {
+  const tokens = value.split(",").map((entry) => entry.trim()).filter(Boolean);
+
+  if (tokens.length === 0) {
+    throw parseError("--expect-children must include at least one issue number");
+  }
+
+  return tokens.map((token) => parsePositiveInt("--expect-children", token));
+}
+
+export function parseSubIssueTreeCliArgs(argv) {
+  const args = [...argv];
+  const command = args.shift();
+
+  if (command === undefined || command === "--help" || command === "-h") {
+    return { help: true };
+  }
+
+  if (!["inspect", "add", "reprioritize", "verify"].includes(command)) {
+    throw parseError(`Unknown command: ${command}`);
+  }
+
+  const options = {
+    help: false,
+    command,
+    repo: undefined,
+    issue: undefined,
+    parent: undefined,
+    child: undefined,
+    replaceParent: false,
+    before: undefined,
+    after: undefined,
+    expectChildren: undefined,
+  };
+
+  while (args.length > 0) {
+    const token = args.shift();
+
+    if (token === "--help" || token === "-h") {
+      options.help = true;
+      return options;
+    }
+
+    if (token === "--repo") {
+      options.repo = requireOptionValue(args, "--repo").trim();
+      continue;
+    }
+
+    if (token === "--issue") {
+      options.issue = parsePositiveInt("--issue", requireOptionValue(args, "--issue"));
+      continue;
+    }
+
+    if (token === "--parent") {
+      options.parent = parsePositiveInt("--parent", requireOptionValue(args, "--parent"));
+      continue;
+    }
+
+    if (token === "--child") {
+      options.child = parsePositiveInt("--child", requireOptionValue(args, "--child"));
+      continue;
+    }
+
+    if (token === "--before") {
+      options.before = parsePositiveInt("--before", requireOptionValue(args, "--before"));
+      continue;
+    }
+
+    if (token === "--after") {
+      options.after = parsePositiveInt("--after", requireOptionValue(args, "--after"));
+      continue;
+    }
+
+    if (token === "--expect-children") {
+      options.expectChildren = parseCommaSeparatedIssueNumbers(requireOptionValue(args, "--expect-children"));
+      continue;
+    }
+
+    if (token === "--replace-parent") {
+      options.replaceParent = true;
+      continue;
+    }
+
+    throw parseError(`Unknown argument: ${token}`);
+  }
+
+  if (typeof options.repo !== "string") {
+    throw parseError(`${command} requires --repo <owner/name>`);
+  }
+
+  try {
+    parseRepoSlug(options.repo);
+  } catch (error) {
+    throw parseError(error instanceof Error ? error.message : String(error));
+  }
+
+  if (command === "inspect") {
+    if (options.issue === undefined) {
+      throw parseError("inspect requires --issue <number>");
+    }
+
+    return {
+      help: false,
+      command,
+      repo: options.repo,
+      issue: options.issue,
+    };
+  }
+
+  if (command === "add") {
+    if (options.parent === undefined || options.child === undefined) {
+      throw parseError("add requires --parent <number> and --child <number>");
+    }
+
+    return {
+      help: false,
+      command,
+      repo: options.repo,
+      parent: options.parent,
+      child: options.child,
+      replaceParent: options.replaceParent,
+    };
+  }
+
+  if (command === "reprioritize") {
+    if (options.parent === undefined || options.child === undefined) {
+      throw parseError("reprioritize requires --parent <number> and --child <number>");
+    }
+
+    if ((options.before === undefined) === (options.after === undefined)) {
+      throw parseError("reprioritize requires exactly one of --after <number> or --before <number>");
+    }
+
+    return {
+      help: false,
+      command,
+      repo: options.repo,
+      parent: options.parent,
+      child: options.child,
+      before: options.before,
+      after: options.after,
+    };
+  }
+
+  if (options.parent === undefined || options.expectChildren === undefined) {
+    throw parseError("verify requires --parent <number> and --expect-children <n1,n2,...>");
+  }
+
+  return {
+    help: false,
+    command,
+    repo: options.repo,
+    parent: options.parent,
+    expectChildren: options.expectChildren,
+  };
+}
+
+function runChild(command, args, env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+function buildGraphqlArgs(query, fields = []) {
+  const args = [
+    "api",
+    "graphql",
+    "--field",
+    `query=${query}`,
+  ];
+
+  for (const field of fields) {
+    if (!field || typeof field !== "object") {
+      continue;
+    }
+
+    const { mode = "field", name, value } = field;
+    if (typeof name !== "string" || name.length === 0) {
+      continue;
+    }
+
+    const flag = mode === "typed" ? "-F" : "--field";
+    args.push(flag, `${name}=${value}`);
+  }
+
+  return args;
+}
+
+async function runGhJson(args, env) {
+  const result = await runChild("gh", args, env);
+
+  if (result.code !== 0) {
+    const stderr = result.stderr.trim();
+    throw new Error(stderr.length > 0 ? stderr : `gh exited with code ${result.code}`);
+  }
+
+  return parseJsonText(result.stdout);
+}
+
+function readIssueNode(payload, pathDescription) {
+  const issue = payload?.data?.repository?.issue;
+
+  if (!issue || typeof issue !== "object") {
+    throw new Error(`Invalid sub-issue-tree GraphQL payload: missing ${pathDescription}`);
+  }
+
+  return issue;
+}
+
+function readAliasedIssueNode(payload, alias) {
+  const issue = payload?.data?.repository?.[alias];
+
+  if (issue === null) {
+    return null;
+  }
+
+  if (!issue || typeof issue !== "object") {
+    throw new Error(`Invalid sub-issue-tree GraphQL payload: missing data.repository.${alias}`);
+  }
+
+  return issue;
+}
+
+function normalizeIssueSummary(issue) {
+  return {
+    number: issue.number,
+    title: issue.title,
+    url: issue.url,
+    state: issue.state,
+  };
+}
+
+function normalizeSubIssue(issue, index) {
+  return {
+    number: issue.number,
+    title: issue.title,
+    url: issue.url,
+    state: issue.state,
+    parentNumber: issue?.parent?.number ?? null,
+    position: index + 1,
+  };
+}
+
+function readInspectConnection(payload) {
+  const issue = readIssueNode(payload, "data.repository.issue");
+  const connection = issue?.subIssues;
+
+  if (!connection || typeof connection !== "object") {
+    throw new Error("Invalid sub-issue-tree GraphQL payload: missing data.repository.issue.subIssues");
+  }
+
+  const pageInfo = connection.pageInfo ?? {};
+
+  return {
+    issue,
+    nodes: Array.isArray(connection.nodes) ? connection.nodes : [],
+    hasNextPage: Boolean(pageInfo.hasNextPage),
+    endCursor: typeof pageInfo.endCursor === "string" ? pageInfo.endCursor : null,
+  };
+}
+
+async function inspectSubIssueTree({ repo, parent, env }) {
+  const { owner, name } = parseRepoSlug(repo);
+  const nodes = [];
+  let parentIssue = null;
+  let after = null;
+
+  for (;;) {
+    const payload = await runGhJson(buildGraphqlArgs(INSPECT_QUERY, [
+      { name: "owner", value: owner },
+      { name: "name", value: name },
+      { mode: "typed", name: "parent", value: parent },
+      ...(after ? [{ name: "after", value: after }] : []),
+    ]), env);
+    const connection = readInspectConnection(payload);
+
+    if (parentIssue === null) {
+      parentIssue = connection.issue;
+    }
+
+    nodes.push(...connection.nodes);
+
+    if (!connection.hasNextPage) {
+      break;
+    }
+
+    if (connection.endCursor === null) {
+      throw new Error("Invalid sub-issue-tree GraphQL payload: missing endCursor for next page");
+    }
+
+    after = connection.endCursor;
+  }
+
+  if (parentIssue === null) {
+    throw new Error(`Could not resolve issue #${parent} in ${repo}`);
+  }
+
+  const normalizedSubIssues = nodes.map((node, index) => normalizeSubIssue(node, index));
+  const completed = normalizedSubIssues.filter((entry) => entry.state === "CLOSED").length;
+  const total = normalizedSubIssues.length;
+
+  return {
+    ok: true,
+    repo,
+    parent: normalizeIssueSummary(parentIssue),
+    subIssues: normalizedSubIssues,
+    summary: {
+      total,
+      completed,
+      percentCompleted: total === 0 ? 0 : Math.round((completed / total) * 100),
+    },
+  };
+}
+
+function ensureIssueResolved(issue, number, role, repo) {
+  if (!issue) {
+    throw new Error(`Could not resolve ${role} issue #${number} in ${repo}`);
+  }
+
+  return issue;
+}
+
+async function resolveAddTargets({ repo, parent, child, env }) {
+  const { owner, name } = parseRepoSlug(repo);
+  const payload = await runGhJson(buildGraphqlArgs(RESOLVE_ADD_QUERY, [
+    { name: "owner", value: owner },
+    { name: "name", value: name },
+    { mode: "typed", name: "parent", value: parent },
+    { mode: "typed", name: "child", value: child },
+  ]), env);
+
+  return {
+    parentIssue: ensureIssueResolved(readAliasedIssueNode(payload, "parentIssue"), parent, "parent", repo),
+    childIssue: ensureIssueResolved(readAliasedIssueNode(payload, "childIssue"), child, "child", repo),
+  };
+}
+
+async function resolveReprioritizeTargets({ repo, parent, child, before, after, env }) {
+  const { owner, name } = parseRepoSlug(repo);
+  const usesBefore = before !== undefined;
+  const payload = await runGhJson(buildGraphqlArgs(
+    usesBefore ? RESOLVE_REPRIORITIZE_BEFORE_QUERY : RESOLVE_REPRIORITIZE_AFTER_QUERY,
+    [
+      { name: "owner", value: owner },
+      { name: "name", value: name },
+      { mode: "typed", name: "parent", value: parent },
+      { mode: "typed", name: "child", value: child },
+      usesBefore
+        ? { mode: "typed", name: "before", value: before }
+        : { mode: "typed", name: "after", value: after },
+    ],
+  ), env);
+
+  return {
+    parentIssue: ensureIssueResolved(readAliasedIssueNode(payload, "parentIssue"), parent, "parent", repo),
+    childIssue: ensureIssueResolved(readAliasedIssueNode(payload, "childIssue"), child, "child", repo),
+    referenceIssue: ensureIssueResolved(
+      readAliasedIssueNode(payload, usesBefore ? "beforeIssue" : "afterIssue"),
+      usesBefore ? before : after,
+      usesBefore ? "before" : "after",
+      repo,
+    ),
+    referenceKey: usesBefore ? "beforeId" : "afterId",
+  };
+}
+
+function ensureAttachedToParent(issue, parent, role) {
+  if (issue?.parent?.number !== parent) {
+    throw new Error(`Issue #${issue?.number ?? "?"} must already be attached to parent #${parent} for ${role}`);
+  }
+}
+
+async function addSubIssue({ repo, parent, child, replaceParent, env }) {
+  const { parentIssue, childIssue } = await resolveAddTargets({ repo, parent, child, env });
+  const currentParent = childIssue?.parent?.number ?? null;
+
+  if (currentParent !== null && currentParent !== parent && !replaceParent) {
+    throw new Error(`Issue #${child} already has parent #${currentParent}; rerun with --replace-parent to move it under #${parent}`);
+  }
+
+  if (currentParent !== parent) {
+    await runGhJson(buildGraphqlArgs(ADD_SUB_ISSUE_MUTATION, [
+      { name: "issueId", value: parentIssue.id },
+      { name: "subIssueId", value: childIssue.id },
+      { mode: "typed", name: "replaceParent", value: replaceParent ? "true" : "false" },
+    ]), env);
+  }
+
+  const tree = await inspectSubIssueTree({ repo, parent, env });
+
+  return {
+    ...tree,
+    action: "add",
+  };
+}
+
+async function reprioritizeSubIssue({ repo, parent, child, before, after, env }) {
+  const { parentIssue, childIssue, referenceIssue, referenceKey } = await resolveReprioritizeTargets({
+    repo,
+    parent,
+    child,
+    before,
+    after,
+    env,
+  });
+
+  ensureAttachedToParent(childIssue, parent, "reprioritize");
+  ensureAttachedToParent(referenceIssue, parent, "reprioritize reference");
+
+  if (childIssue.number === referenceIssue.number) {
+    throw new Error("reprioritize requires the child and reference issue numbers to differ");
+  }
+
+  await runGhJson(buildGraphqlArgs(
+    referenceKey === "beforeId"
+      ? REPRIORITIZE_SUB_ISSUE_BEFORE_MUTATION
+      : REPRIORITIZE_SUB_ISSUE_AFTER_MUTATION,
+    [
+      { name: "issueId", value: parentIssue.id },
+      { name: "subIssueId", value: childIssue.id },
+      { name: referenceKey, value: referenceIssue.id },
+    ],
+  ), env);
+
+  const tree = await inspectSubIssueTree({ repo, parent, env });
+
+  return {
+    ...tree,
+    action: "reprioritize",
+  };
+}
+
+export function compareExpectedSubIssueTree(tree, expectedOrder) {
+  const actualOrder = Array.isArray(tree?.subIssues)
+    ? tree.subIssues.map((entry) => entry.number)
+    : [];
+  const expectedSet = new Set(expectedOrder);
+  const actualSet = new Set(actualOrder);
+  const missing = expectedOrder.filter((number) => !actualSet.has(number));
+  const unexpected = actualOrder.filter((number) => !expectedSet.has(number));
+  const misordered = [];
+
+  for (const number of expectedOrder) {
+    if (!actualSet.has(number)) {
+      continue;
+    }
+
+    const expectedIndex = expectedOrder.indexOf(number) + 1;
+    const actualIndex = actualOrder.indexOf(number) + 1;
+
+    if (expectedIndex !== actualIndex) {
+      misordered.push({ number, expectedIndex, actualIndex });
+    }
+  }
+
+  return {
+    matches: missing.length === 0 && unexpected.length === 0 && misordered.length === 0,
+    expectedOrder: [...expectedOrder],
+    actualOrder,
+    missing,
+    unexpected,
+    misordered,
+  };
+}
+
+async function verifySubIssueTree({ repo, parent, expectChildren, env }) {
+  const tree = await inspectSubIssueTree({ repo, parent, env });
+  const comparison = compareExpectedSubIssueTree(tree, expectChildren);
+
+  return {
+    ok: true,
+    action: "verify",
+    repo,
+    parent: tree.parent,
+    ...comparison,
+  };
+}
+
+export async function runSubIssueTreeCli(argv = process.argv.slice(2), { env = process.env, stdout = process.stdout } = {}) {
+  const options = parseSubIssueTreeCliArgs(argv);
+
+  if (options.help) {
+    stdout.write(`${USAGE}\n`);
+    return;
+  }
+
+  let result;
+  if (options.command === "inspect") {
+    result = await inspectSubIssueTree({ repo: options.repo, parent: options.issue, env });
+  } else if (options.command === "add") {
+    result = await addSubIssue({ ...options, env });
+  } else if (options.command === "reprioritize") {
+    result = await reprioritizeSubIssue({ ...options, env });
+  } else {
+    result = await verifySubIssueTree({ ...options, env });
+  }
+
+  stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runSubIssueTreeCli().catch((error) => {
+    process.stderr.write(`${formatCliError(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/skills/copilot-dev-loop/SKILL.md
+++ b/skills/copilot-dev-loop/SKILL.md
@@ -324,6 +324,12 @@ Preflight verdicts:
 
 Before updating or assigning the issue, refine it asynchronously when practical. Keep issue refinement separate from the phase-scoped refiner used by the local implementation workflow.
 
+When refinement produces multiple bounded child slices for an umbrella/mini-epic, prefer a real GitHub sub-issue tree as the durable execution structure:
+- keep the parent issue body focused on umbrella framing, scope, acceptance criteria, and non-goals
+- create explicit child issues with standard GitHub tooling
+- attach / order / verify them with `scripts/github/sub-issue-tree.mjs`
+- prefer plain related-issue references instead when no parent/child execution tree is actually needed
+
 ### Phase 4 — Copilot handoff and bootstrap wait
 
 Before updating the GitHub issue body, show the diff and get explicit confirmation.
@@ -467,6 +473,12 @@ If the work item is phase-like, ambiguous, or likely to shape more than one down
 - compare the variants explicitly
 - merge them into one bounded execution plan
 - only then proceed with GitHub execution
+
+When that refinement turns an umbrella issue into multiple bounded child slices, prefer real GitHub sub-issue linkage over a parent-body execution checklist:
+- keep the parent issue body lean once the tree exists
+- use `gh issue create` for child issue creation
+- use `scripts/github/sub-issue-tree.mjs` to attach, order, and verify the tree
+- use plain related-issue references when the relationship is informative rather than a real parent/child execution boundary
 
 If the issue text is too vague, stop and ask a short clarification question rather than guessing.
 

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -85,6 +85,7 @@ Before acting on a GitHub-first issue/PR request:
 4. if the current step depends on async start/resume/status or retrospective enforcement, read `../docs/retrospective-checkpoint-contract.md`
 5. read the relevant GitHub issue or PR
 6. inspect the actual validation/runtime surface needed for the current step (`package.json`, CI/workflows, touched files, helper contracts)
+7. when GitHub-first refinement produces multiple bounded child slices, prefer real GitHub sub-issue trees as the durable execution structure; keep parent issue bodies lean once the tree exists and use plain related-issue references when no tree is warranted
 
 ### Local implementation routed requests (`local_implementation`)
 

--- a/test/github/sub-issue-tree-guidance.test.mjs
+++ b/test/github/sub-issue-tree-guidance.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+async function readRepo(path) {
+  return readFile(new URL(`../../${path}`, import.meta.url), "utf8");
+}
+
+test("sub-issue decomposition docs keep dev-loop public surface and thin helper boundary explicit", async () => {
+  const content = await readRepo("docs/github-sub-issue-decomposition.md");
+
+  assert.match(content, /`dev-loop` remains the only public workflow entrypoint/i);
+  assert.match(content, /Use existing `gh issue create` for child issue creation/i);
+  assert.match(content, /scripts\/github\/sub-issue-tree\.mjs/i);
+  assert.match(content, /parent issue body lean/i);
+  assert.match(content, /plain related-issue references/i);
+});
+
+test("GitHub-first skill guidance prefers real sub-issue trees over parent-body checklists", async () => {
+  const content = await readRepo("skills/copilot-dev-loop/SKILL.md");
+
+  assert.match(content, /prefer a real GitHub sub-issue tree as the durable execution structure/i);
+  assert.match(content, /sub-issue linkage over a parent-body execution checklist/i);
+  assert.match(content, /use `gh issue create` for child issue creation/i);
+  assert.match(content, /keep the parent issue body lean once the tree exists/i);
+});

--- a/test/github/sub-issue-tree.test.mjs
+++ b/test/github/sub-issue-tree.test.mjs
@@ -217,6 +217,19 @@ test("parseSubIssueTreeCliArgs rejects malformed reprioritize arguments", () => 
     ]),
     /requires exactly one of --after <number> or --before <number>/i,
   );
+
+  assert.throws(
+    () => parseSubIssueTreeCliArgs([
+      "verify",
+      "--repo",
+      "owner/repo",
+      "--parent",
+      "97",
+      "--expect-children",
+      "123,123",
+    ]),
+    /duplicate issue number/i,
+  );
 });
 
 test("compareExpectedSubIssueTree reports exact-order mismatches", () => {
@@ -311,6 +324,32 @@ test("sub-issue-tree inspect paginates and returns normalized tree output", asyn
 });
 
 
+
+
+
+test("sub-issue-tree wraps gh failures with a stable prefix", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-sub-issue-tree-gh-failure-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "graphql", "owner=owner", "name=repo", "parent=97"],
+        stderr: "api down\n",
+        exitCode: 42,
+      },
+    ]);
+
+    const result = await runNode(["inspect", "--repo", "owner/repo", "--issue", "97"], { env });
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /gh command failed: api down/i);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
 
 test("sub-issue-tree inspect reports a missing parent issue clearly", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-sub-issue-tree-missing-parent-"));

--- a/test/github/sub-issue-tree.test.mjs
+++ b/test/github/sub-issue-tree.test.mjs
@@ -310,6 +310,37 @@ test("sub-issue-tree inspect paginates and returns normalized tree output", asyn
   }
 });
 
+
+
+test("sub-issue-tree inspect reports a missing parent issue clearly", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-sub-issue-tree-missing-parent-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "graphql", "owner=owner", "name=repo", "parent=97"],
+        stdout: `${JSON.stringify({
+          data: {
+            repository: {
+              issue: null,
+            },
+          },
+        })}\n`,
+      },
+    ]);
+
+    const result = await runNode(["inspect", "--repo", "owner/repo", "--issue", "97"], { env });
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /Could not resolve issue #97 in owner\/repo/i);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("sub-issue-tree add attaches an existing child and returns refreshed tree", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-sub-issue-tree-add-"));
 

--- a/test/github/sub-issue-tree.test.mjs
+++ b/test/github/sub-issue-tree.test.mjs
@@ -1,0 +1,464 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import test from "node:test";
+
+import {
+  compareExpectedSubIssueTree,
+  parseSubIssueTreeCliArgs,
+} from "../../scripts/github/sub-issue-tree.mjs";
+
+const scriptPath = path.resolve("scripts/github/sub-issue-tree.mjs");
+
+function runNode(args = [], options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(options.execPath ?? process.execPath, [scriptPath, ...args], {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const resolveOnce = (value) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(value);
+    };
+
+    const rejectOnce = (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      reject(error);
+    };
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    child.on("error", rejectOnce);
+    child.on("close", (code) => {
+      resolveOnce({ code, stdout, stderr });
+    });
+  });
+}
+
+async function writeGhStub(tempDir, entries) {
+  const sequencePath = path.join(tempDir, "gh-sequence.json");
+  const counterPath = path.join(tempDir, "gh-counter.txt");
+  const ghPath = path.join(tempDir, "gh");
+
+  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
+  await writeFile(counterPath, "0\n", "utf8");
+  await writeFile(
+    ghPath,
+    [
+      "#!/usr/bin/env node",
+      'import { readFileSync, writeFileSync } from "node:fs";',
+      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
+      "const counterPath = process.env.GH_COUNTER_PATH;",
+      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
+      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
+      'if (current >= entries.length) {',
+      '  process.stderr.write(`unexpected extra gh call #${current + 1}: ${process.argv.slice(2).join(" ")}\\n`);',
+      '  process.exit(97);',
+      '}',
+      'const entry = entries[current] ?? { stdout: "{}\\n" };',
+      'writeFileSync(counterPath, String(current + 1));',
+      'const actual = process.argv.slice(2);',
+      'if (entry.assertArgs) {',
+      '  for (const expected of entry.assertArgs) {',
+      '    if (!actual.includes(expected)) {',
+      '      process.stderr.write(`missing expected gh arg: ${expected}\\nactual: ${actual.join(" ")}\\n`);',
+      '      process.exit(98);',
+      '    }',
+      '  }',
+      '}',
+      'if (entry.stderr) {',
+      '  process.stderr.write(entry.stderr);',
+      '}',
+      'if (entry.stdout) {',
+      '  process.stdout.write(entry.stdout);',
+      '}',
+      'process.exit(entry.exitCode ?? 0);',
+      '',
+    ].join("\n"),
+    "utf8",
+  );
+  await chmod(ghPath, 0o755);
+
+  return {
+    ...process.env,
+    PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
+    GH_SEQUENCE_PATH: sequencePath,
+    GH_COUNTER_PATH: counterPath,
+  };
+}
+
+function inspectPayload({ hasNextPage = false, endCursor = null, issue, subIssues }) {
+  return `${JSON.stringify({
+    data: {
+      repository: {
+        issue: {
+          ...issue,
+          subIssuesSummary: {
+            total: subIssues.length,
+            completed: subIssues.filter((entry) => entry.state === "CLOSED").length,
+            percentCompleted: subIssues.length === 0
+              ? 0
+              : Math.round((subIssues.filter((entry) => entry.state === "CLOSED").length / subIssues.length) * 100),
+          },
+          subIssues: {
+            pageInfo: { hasNextPage, endCursor },
+            nodes: subIssues,
+          },
+        },
+      },
+    },
+  })}\n`;
+}
+
+function issueNode(number, title, state = "OPEN") {
+  return {
+    id: `ISSUE_${number}`,
+    number,
+    title,
+    url: `https://github.com/owner/repo/issues/${number}`,
+    state,
+    repository: { nameWithOwner: "owner/repo" },
+    parent: null,
+  };
+}
+
+function subIssueNode(number, title, parentNumber, state = "OPEN") {
+  return {
+    id: `ISSUE_${number}`,
+    number,
+    title,
+    url: `https://github.com/owner/repo/issues/${number}`,
+    state,
+    repository: { nameWithOwner: "owner/repo" },
+    parent: parentNumber === null ? null : { number: parentNumber },
+  };
+}
+
+function resolveIssuesPayload(entries) {
+  const repository = {};
+  for (const [alias, node] of Object.entries(entries)) {
+    repository[alias] = node;
+  }
+
+  return `${JSON.stringify({ data: { repository } })}\n`;
+}
+
+function mutationPayload(name) {
+  return `${JSON.stringify({ data: { [name]: { clientMutationId: null } } })}\n`;
+}
+
+test("parseSubIssueTreeCliArgs parses inspect and verify commands", () => {
+  assert.deepEqual(parseSubIssueTreeCliArgs(["inspect", "--repo", "owner/repo", "--issue", "97"]), {
+    help: false,
+    command: "inspect",
+    repo: "owner/repo",
+    issue: 97,
+  });
+
+  assert.deepEqual(
+    parseSubIssueTreeCliArgs([
+      "verify",
+      "--repo",
+      "owner/repo",
+      "--parent",
+      "97",
+      "--expect-children",
+      "123,124,125",
+    ]),
+    {
+      help: false,
+      command: "verify",
+      repo: "owner/repo",
+      parent: 97,
+      expectChildren: [123, 124, 125],
+    },
+  );
+});
+
+test("parseSubIssueTreeCliArgs rejects malformed reprioritize arguments", () => {
+  assert.throws(
+    () => parseSubIssueTreeCliArgs(["reprioritize", "--repo", "owner/repo", "--parent", "97", "--child", "123"]),
+    /requires exactly one of --after <number> or --before <number>/i,
+  );
+
+  assert.throws(
+    () => parseSubIssueTreeCliArgs([
+      "reprioritize",
+      "--repo",
+      "owner/repo",
+      "--parent",
+      "97",
+      "--child",
+      "123",
+      "--after",
+      "124",
+      "--before",
+      "125",
+    ]),
+    /requires exactly one of --after <number> or --before <number>/i,
+  );
+});
+
+test("compareExpectedSubIssueTree reports exact-order mismatches", () => {
+  const result = compareExpectedSubIssueTree({
+    parent: { number: 97 },
+    subIssues: [{ number: 123 }, { number: 125 }, { number: 124 }],
+  }, [123, 124, 125]);
+
+  assert.equal(result.matches, false);
+  assert.deepEqual(result.actualOrder, [123, 125, 124]);
+  assert.deepEqual(result.missing, []);
+  assert.deepEqual(result.unexpected, []);
+  assert.deepEqual(result.misordered, [
+    { number: 124, expectedIndex: 2, actualIndex: 3 },
+    { number: 125, expectedIndex: 3, actualIndex: 2 },
+  ]);
+});
+
+test("sub-issue-tree inspect paginates and returns normalized tree output", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-sub-issue-tree-inspect-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "graphql", "owner=owner", "name=repo", "parent=97"],
+        stdout: inspectPayload({
+          hasNextPage: true,
+          endCursor: "cursor-1",
+          issue: issueNode(97, "Mini-epic"),
+          subIssues: [subIssueNode(123, "Contract", 97)],
+        }),
+      },
+      {
+        assertArgs: ["api", "graphql", "after=cursor-1"],
+        stdout: inspectPayload({
+          hasNextPage: false,
+          endCursor: null,
+          issue: issueNode(97, "Mini-epic"),
+          subIssues: [subIssueNode(124, "Harness", 97), subIssueNode(125, "Artifacts", 97, "CLOSED")],
+        }),
+      },
+    ]);
+
+    const result = await runNode(["inspect", "--repo", "owner/repo", "--issue", "97"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      repo: "owner/repo",
+      parent: {
+        number: 97,
+        title: "Mini-epic",
+        url: "https://github.com/owner/repo/issues/97",
+        state: "OPEN",
+      },
+      subIssues: [
+        {
+          number: 123,
+          title: "Contract",
+          url: "https://github.com/owner/repo/issues/123",
+          state: "OPEN",
+          parentNumber: 97,
+          position: 1,
+        },
+        {
+          number: 124,
+          title: "Harness",
+          url: "https://github.com/owner/repo/issues/124",
+          state: "OPEN",
+          parentNumber: 97,
+          position: 2,
+        },
+        {
+          number: 125,
+          title: "Artifacts",
+          url: "https://github.com/owner/repo/issues/125",
+          state: "CLOSED",
+          parentNumber: 97,
+          position: 3,
+        },
+      ],
+      summary: {
+        total: 3,
+        completed: 1,
+        percentCompleted: 33,
+      },
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("sub-issue-tree add attaches an existing child and returns refreshed tree", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-sub-issue-tree-add-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "graphql", "owner=owner", "name=repo", "parent=97", "child=126"],
+        stdout: resolveIssuesPayload({
+          parentIssue: issueNode(97, "Mini-epic"),
+          childIssue: subIssueNode(126, "Sub-issue tree tooling", null),
+        }),
+      },
+      {
+        assertArgs: ["api", "graphql", "issueId=ISSUE_97", "subIssueId=ISSUE_126"],
+        stdout: mutationPayload("addSubIssue"),
+      },
+      {
+        assertArgs: ["api", "graphql", "owner=owner", "name=repo", "parent=97"],
+        stdout: inspectPayload({
+          hasNextPage: false,
+          endCursor: null,
+          issue: issueNode(97, "Mini-epic"),
+          subIssues: [subIssueNode(126, "Sub-issue tree tooling", 97)],
+        }),
+      },
+    ]);
+
+    const result = await runNode(["add", "--repo", "owner/repo", "--parent", "97", "--child", "126"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.action, "add");
+    assert.equal(payload.parent.number, 97);
+    assert.deepEqual(payload.subIssues.map((entry) => entry.number), [126]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("sub-issue-tree reprioritize reorders by before/after reference and returns refreshed tree", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-sub-issue-tree-reprioritize-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "graphql", "owner=owner", "name=repo", "parent=97", "child=125", "before=123"],
+        stdout: resolveIssuesPayload({
+          parentIssue: issueNode(97, "Mini-epic"),
+          childIssue: subIssueNode(125, "Artifacts", 97),
+          beforeIssue: subIssueNode(123, "Contract", 97),
+        }),
+      },
+      {
+        assertArgs: ["api", "graphql", "issueId=ISSUE_97", "subIssueId=ISSUE_125", "beforeId=ISSUE_123"],
+        stdout: mutationPayload("reprioritizeSubIssue"),
+      },
+      {
+        assertArgs: ["api", "graphql", "owner=owner", "name=repo", "parent=97"],
+        stdout: inspectPayload({
+          hasNextPage: false,
+          endCursor: null,
+          issue: issueNode(97, "Mini-epic"),
+          subIssues: [
+            subIssueNode(125, "Artifacts", 97),
+            subIssueNode(123, "Contract", 97),
+            subIssueNode(124, "Harness", 97),
+          ],
+        }),
+      },
+    ]);
+
+    const result = await runNode([
+      "reprioritize",
+      "--repo",
+      "owner/repo",
+      "--parent",
+      "97",
+      "--child",
+      "125",
+      "--before",
+      "123",
+    ], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.action, "reprioritize");
+    assert.deepEqual(payload.subIssues.map((entry) => entry.number), [125, 123, 124]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("sub-issue-tree verify reports mismatches deterministically", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-sub-issue-tree-verify-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "graphql", "owner=owner", "name=repo", "parent=97"],
+        stdout: inspectPayload({
+          hasNextPage: false,
+          endCursor: null,
+          issue: issueNode(97, "Mini-epic"),
+          subIssues: [
+            subIssueNode(123, "Contract", 97),
+            subIssueNode(125, "Artifacts", 97),
+            subIssueNode(124, "Harness", 97),
+          ],
+        }),
+      },
+    ]);
+
+    const result = await runNode([
+      "verify",
+      "--repo",
+      "owner/repo",
+      "--parent",
+      "97",
+      "--expect-children",
+      "123,124,125",
+    ], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      action: "verify",
+      repo: "owner/repo",
+      parent: {
+        number: 97,
+        title: "Mini-epic",
+        url: "https://github.com/owner/repo/issues/97",
+        state: "OPEN",
+      },
+      matches: false,
+      expectedOrder: [123, 124, 125],
+      actualOrder: [123, 125, 124],
+      missing: [],
+      unexpected: [],
+      misordered: [
+        { number: 124, expectedIndex: 2, actualIndex: 3 },
+        { number: 125, expectedIndex: 3, actualIndex: 2 },
+      ],
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Add a thin deterministic GitHub sub-issue tree helper and the bounded guidance needed to make real GitHub sub-issue trees the default execution structure for decomposition work.

Closes #126.

## Scope/context

Issue #126 is intentionally broader than one generic project-management automation pass. This PR keeps the first slice to the smallest honest move that makes the ownership boundary real:

- keep child issue creation on standard `gh issue create`
- add one deterministic helper for sub-issue tree inspect / attach / reprioritize / verify
- document when umbrella issues should use real sub-issue trees versus plain related-issue references
- update GitHub-first `dev-loop` / coordinator guidance so parent bodies stay lean once the tree exists

This avoids building a generic hierarchy SDK or opaque planner while still making GitHub's real issue tree the durable execution surface.

## Acceptance criteria

- The repo has a documented deterministic pattern for epic/umbrella decomposition using GitHub sub-issues.
- Refinement/dev-loop guidance explicitly prefers real sub-issue linkage over parent-body checklists when a work tree is intended.
- There is a deterministic way to attach existing sub-issues, set or update their execution order, and verify the resulting tree.
- The documented pattern clarifies when the parent issue body should stay lean because structure now lives in the tree.
- Any non-trivial helper/tooling added for sub-issue management is covered by tests.
- The approach stays compatible with `dev-loop` as the single public workflow entrypoint.

## Definition of done

- `scripts/github/sub-issue-tree.mjs` exists with deterministic JSON contracts for inspect / add / reprioritize / verify.
- `docs/github-sub-issue-decomposition.md` explains the thin helper boundary and when to use a real sub-issue tree.
- GitHub-first workflow guidance now points decomposition toward the sub-issue tree instead of parent-body execution checklists.
- Regression tests cover helper parsing, GraphQL plumbing, verify semantics, and guidance contract wording.
- `npm run verify` passes.

## Non-goals

- wrapping general child issue creation in a larger planner
- broad GitHub project-board or milestone automation
- adding a new public workflow name
- forcing parent/child trees for every issue relationship
