### PR TITLE
ci: skip viewer smoke when inspect-run surface is untouched

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
       - name: Determine whether inspect-run viewer smoke is required
         id: inspect-run-viewer-scope
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,27 +7,17 @@ on:
   pull_request:
 
 jobs:
-  test:
+  changes:
     runs-on: ubuntu-latest
-    env:
-      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
+    outputs:
+      inspect_run_viewer: ${{ steps.inspect-run-viewer-scope.outputs.inspect_run_viewer }}
+      inspect_run_viewer_relevant_paths_json: ${{ steps.inspect-run-viewer-scope.outputs.inspect_run_viewer_relevant_paths_json }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-
-      - name: Install workspace dependencies
-        run: npm ci
-
-      - name: Run canonical verify suite
-        run: npm run verify
 
       - name: Determine whether inspect-run viewer smoke is required
         id: inspect-run-viewer-scope
@@ -52,21 +42,57 @@ jobs:
           echo "inspect-run viewer smoke required: ${{ steps.inspect-run-viewer-scope.outputs.inspect_run_viewer }}"
           echo "matched paths: ${{ steps.inspect-run-viewer-scope.outputs.inspect_run_viewer_relevant_paths_json }}"
 
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install workspace dependencies
+        run: npm ci
+
+      - name: Run canonical verify suite
+        run: npm run verify
+
+  viewer-smoke:
+    needs:
+      - changes
+    if: needs.changes.outputs.inspect_run_viewer == 'true'
+    runs-on: ubuntu-latest
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install workspace dependencies
+        run: npm ci
+
+      - name: Report inspect-run viewer smoke scope
+        run: |
+          echo "inspect-run viewer smoke required: ${{ needs.changes.outputs.inspect_run_viewer }}"
+          echo "matched paths: ${{ needs.changes.outputs.inspect_run_viewer_relevant_paths_json }}"
+
       - name: Restore Playwright WebKit runtime cache
-        if: steps.inspect-run-viewer-scope.outputs.inspect_run_viewer == 'true'
         uses: actions/cache@v4
         with:
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
           key: ${{ runner.os }}-playwright-webkit-${{ hashFiles('package-lock.json') }}
 
       - name: Install Playwright WebKit runtime
-        if: steps.inspect-run-viewer-scope.outputs.inspect_run_viewer == 'true'
         run: npx playwright install --with-deps webkit
 
       - name: Run inspect-run viewer WebKit smoke
-        if: steps.inspect-run-viewer-scope.outputs.inspect_run_viewer == 'true'
         run: npm run test:playwright:viewer
-
-      - name: Skip inspect-run viewer WebKit smoke
-        if: steps.inspect-run-viewer-scope.outputs.inspect_run_viewer != 'true'
-        run: echo "No inspect-run viewer or Playwright-surface changes detected; skipping browser smoke."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       inspect_run_viewer: ${{ steps.inspect-run-viewer-scope.outputs.inspect_run_viewer }}
-      inspect_run_viewer_relevant_paths_json: ${{ steps.inspect-run-viewer-scope.outputs.inspect_run_viewer_relevant_paths_json }}
 
     steps:
       - name: Check out repository
@@ -27,20 +26,12 @@ jobs:
         run: |
           if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
             echo 'inspect_run_viewer=true' >> "$GITHUB_OUTPUT"
-            echo 'inspect_run_viewer_relevant_paths_json=[".github/workflows/ci.yml"]' >> "$GITHUB_OUTPUT"
             echo "No usable diff base detected; forcing inspect-run viewer smoke."
             exit 0
           fi
 
           git diff --name-only "$BASE_SHA" "$HEAD_SHA" > .inspect-run-viewer-changed-files.txt
-          node scripts/loop/inspect-run-viewer-ci-changes.mjs \
-            --paths-file .inspect-run-viewer-changed-files.txt \
-            --github-output "$GITHUB_OUTPUT"
-
-      - name: Report inspect-run viewer smoke decision
-        run: |
-          echo "inspect-run viewer smoke required: ${{ steps.inspect-run-viewer-scope.outputs.inspect_run_viewer }}"
-          echo "matched paths: ${{ steps.inspect-run-viewer-scope.outputs.inspect_run_viewer_relevant_paths_json }}"
+          GITHUB_OUTPUT="$GITHUB_OUTPUT" node scripts/loop/inspect-run-viewer-ci-changes.mjs .inspect-run-viewer-changed-files.txt
 
   verify:
     runs-on: ubuntu-latest
@@ -79,11 +70,6 @@ jobs:
 
       - name: Install workspace dependencies
         run: npm ci
-
-      - name: Report inspect-run viewer smoke scope
-        run: |
-          echo "inspect-run viewer smoke required: ${{ needs.changes.outputs.inspect_run_viewer }}"
-          echo "matched paths: ${{ needs.changes.outputs.inspect_run_viewer_relevant_paths_json }}"
 
       - name: Restore Playwright WebKit runtime cache
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -27,14 +29,44 @@ jobs:
       - name: Run canonical verify suite
         run: npm run verify
 
+      - name: Determine whether inspect-run viewer smoke is required
+        id: inspect-run-viewer-scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            echo 'inspect_run_viewer=true' >> "$GITHUB_OUTPUT"
+            echo 'inspect_run_viewer_relevant_paths_json=[".github/workflows/ci.yml"]' >> "$GITHUB_OUTPUT"
+            echo "No usable diff base detected; forcing inspect-run viewer smoke."
+            exit 0
+          fi
+
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > .inspect-run-viewer-changed-files.txt
+          node scripts/loop/inspect-run-viewer-ci-changes.mjs \
+            --paths-file .inspect-run-viewer-changed-files.txt \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Report inspect-run viewer smoke decision
+        run: |
+          echo "inspect-run viewer smoke required: ${{ steps.inspect-run-viewer-scope.outputs.inspect_run_viewer }}"
+          echo "matched paths: ${{ steps.inspect-run-viewer-scope.outputs.inspect_run_viewer_relevant_paths_json }}"
+
       - name: Restore Playwright WebKit runtime cache
+        if: steps.inspect-run-viewer-scope.outputs.inspect_run_viewer == 'true'
         uses: actions/cache@v4
         with:
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
           key: ${{ runner.os }}-playwright-webkit-${{ hashFiles('package-lock.json') }}
 
       - name: Install Playwright WebKit runtime
+        if: steps.inspect-run-viewer-scope.outputs.inspect_run_viewer == 'true'
         run: npx playwright install --with-deps webkit
 
       - name: Run inspect-run viewer WebKit smoke
+        if: steps.inspect-run-viewer-scope.outputs.inspect_run_viewer == 'true'
         run: npm run test:playwright:viewer
+
+      - name: Skip inspect-run viewer WebKit smoke
+        if: steps.inspect-run-viewer-scope.outputs.inspect_run_viewer != 'true'
+        run: echo "No inspect-run viewer or Playwright-surface changes detected; skipping browser smoke."

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Root verification and test commands from `package.json`:
 - `npm run test:dev-loop`
 - `npm run test:playwright:viewer` — explicit viewer/browser smoke, not part of the default root verify path
 
-CI currently runs `npm ci`, `npm run verify`, restores a workspace-local Playwright WebKit runtime cache keyed by runner OS + `package-lock.json`, and runs the explicit Playwright viewer smoke in `.github/workflows/ci.yml`.
+CI currently runs `npm ci` and `npm run verify` on every change, then restores the workspace-local Playwright WebKit runtime cache keyed by runner OS + `package-lock.json` and runs the explicit Playwright viewer smoke only when inspect-run viewer or Playwright-surface paths changed in `.github/workflows/ci.yml`.
 
 ## Where to read next
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Root verification and test commands from `package.json`:
 - `npm run test:dev-loop`
 - `npm run test:playwright:viewer` — explicit viewer/browser smoke, not part of the default root verify path
 
-CI currently runs `npm ci` and `npm run verify` on every change, then restores the workspace-local Playwright WebKit runtime cache keyed by runner OS + `package-lock.json` and runs the explicit Playwright viewer smoke only when inspect-run viewer or Playwright-surface paths changed in `.github/workflows/ci.yml`.
+CI currently splits into a deterministic changed-files gate plus parallel `verify` and conditional `viewer-smoke` jobs: `npm ci` + `npm run verify` still run on every change, while the workspace-local Playwright WebKit cache restore/install and explicit viewer smoke run only when inspect-run viewer or Playwright-surface paths changed in `.github/workflows/ci.yml`.
 
 ## Where to read next
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Root verification and test commands from `package.json`:
 - `npm run test:dev-loop`
 - `npm run test:playwright:viewer` — explicit viewer/browser smoke, not part of the default root verify path
 
-CI currently splits into a small changed-files gate plus parallel `verify` and conditional `viewer-smoke` jobs: `npm ci` + `npm run verify` still run on every change, while the workspace-local Playwright WebKit cache restore/install and explicit viewer smoke run only when the bounded inspect-run viewer surface changed in `.github/workflows/ci.yml`.
+CI currently splits into a small changed-files gate plus parallel `verify` and conditional `viewer-smoke` jobs: `npm ci` + `npm run verify` still run on every change, while the workspace-local Playwright WebKit cache restore/install and explicit viewer smoke run only when files in the bounded inspect-run viewer surface change.
 
 ## Where to read next
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Root verification and test commands from `package.json`:
 - `npm run test:dev-loop`
 - `npm run test:playwright:viewer` — explicit viewer/browser smoke, not part of the default root verify path
 
-CI currently splits into a deterministic changed-files gate plus parallel `verify` and conditional `viewer-smoke` jobs: `npm ci` + `npm run verify` still run on every change, while the workspace-local Playwright WebKit cache restore/install and explicit viewer smoke run only when inspect-run viewer or Playwright-surface paths changed in `.github/workflows/ci.yml`.
+CI currently splits into a small changed-files gate plus parallel `verify` and conditional `viewer-smoke` jobs: `npm ci` + `npm run verify` still run on every change, while the workspace-local Playwright WebKit cache restore/install and explicit viewer smoke run only when the bounded inspect-run viewer surface changed in `.github/workflows/ci.yml`.
 
 ## Where to read next
 

--- a/scripts/loop/inspect-run-viewer-ci-changes.mjs
+++ b/scripts/loop/inspect-run-viewer-ci-changes.mjs
@@ -1,24 +1,27 @@
 #!/usr/bin/env node
-import path from "node:path";
 import { appendFile, readFile } from "node:fs/promises";
-import { fileURLToPath } from "node:url";
 
-import { formatCliError } from "../_core-helpers.mjs";
+import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 
 export const INSPECT_RUN_VIEWER_RELEVANT_EXACT_PATHS = Object.freeze([
   ".github/workflows/ci.yml",
   "package.json",
-  "package-lock.json",
   "playwright.inspect-run-viewer.config.mjs",
   "scripts/loop/_inspect-run-viewer-adapter.mjs",
   "scripts/loop/inspect-run-viewer.mjs",
   "scripts/loop/inspect-run-viewer-ci-changes.mjs",
+  "test/playwright/inspect-run-viewer.spec.mjs",
 ]);
 
 export const INSPECT_RUN_VIEWER_RELEVANT_PREFIXES = Object.freeze([
   "scripts/loop/inspect-run-viewer/",
-  "test/playwright/",
 ]);
+
+const USAGE = "Usage: inspect-run-viewer-ci-changes.mjs <changed-files-path>";
+
+function parseError(message) {
+  return Object.assign(new Error(message), { usage: USAGE });
+}
 
 export function normalizeInspectRunViewerPath(filePath) {
   return String(filePath ?? "")
@@ -37,92 +40,38 @@ export function isInspectRunViewerRelevantPath(filePath) {
 }
 
 export function classifyInspectRunViewerCiChanges(changedPaths = []) {
-  const normalizedPaths = changedPaths
+  const relevantPaths = [...new Set(changedPaths
     .map((entry) => normalizeInspectRunViewerPath(entry))
-    .filter(Boolean);
-
-  const relevantPaths = [...new Set(normalizedPaths.filter((entry) => isInspectRunViewerRelevantPath(entry)))].sort();
-  const ignoredPaths = [...new Set(normalizedPaths.filter((entry) => !isInspectRunViewerRelevantPath(entry)))].sort();
+    .filter((entry) => isInspectRunViewerRelevantPath(entry)))].sort();
 
   return {
     shouldRun: relevantPaths.length > 0,
     relevantPaths,
-    ignoredPaths,
   };
 }
 
-function parseCliArgs(argv) {
-  const options = {
-    githubOutput: null,
-    pathsFile: null,
-  };
-
-  for (let index = 0; index < argv.length; index += 1) {
-    const argument = argv[index];
-
-    if (argument === "--paths-file") {
-      options.pathsFile = argv[index + 1] ?? null;
-      index += 1;
-      continue;
-    }
-
-    if (argument === "--github-output") {
-      options.githubOutput = argv[index + 1] ?? null;
-      index += 1;
-      continue;
-    }
-
-    if (argument === "--help") {
-      options.help = true;
-      continue;
-    }
-
-    throw new Error(`Unknown argument: ${argument}`);
+export async function runCli(
+  argv = process.argv.slice(2),
+  { env = process.env, stdout = process.stdout } = {},
+) {
+  if (argv.length !== 1) {
+    throw parseError("inspect-run-viewer-ci-changes requires exactly one changed-files path argument");
   }
 
-  if (!options.help && !options.pathsFile) {
-    throw new Error("Missing required --paths-file <file>");
-  }
+  const rawPaths = await readFile(argv[0], "utf8");
+  const result = classifyInspectRunViewerCiChanges(rawPaths.split(/\r?\n/u));
 
-  return options;
-}
-
-const USAGE = `Usage: inspect-run-viewer-ci-changes.mjs --paths-file <file> [--github-output <file>]`;
-
-export async function runCli(argv = process.argv.slice(2), { stdout = process.stdout } = {}) {
-  const options = parseCliArgs(argv);
-  if (options.help) {
-    stdout.write(`${USAGE}\n`);
-    return null;
-  }
-
-  const rawPaths = await readFile(options.pathsFile, "utf8");
-  const changedPaths = rawPaths
-    .split(/\r?\n/u)
-    .filter(Boolean);
-  const result = classifyInspectRunViewerCiChanges(changedPaths);
-
-  if (options.githubOutput) {
-    await appendFile(
-      options.githubOutput,
-      [
-        `inspect_run_viewer=${result.shouldRun}`,
-        `inspect_run_viewer_relevant_paths_json=${JSON.stringify(result.relevantPaths)}`,
-      ].join("\n") + "\n",
-      "utf8",
-    );
+  if (env.GITHUB_OUTPUT) {
+    await appendFile(env.GITHUB_OUTPUT, `inspect_run_viewer=${result.shouldRun}\n`, "utf8");
   }
 
   stdout.write(`${JSON.stringify({ ok: true, ...result })}\n`);
   return result;
 }
 
-const isDirectRun = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
-if (isDirectRun) {
+if (isDirectCliRun(import.meta.url)) {
   runCli().catch((error) => {
-    const cliError = new Error(error?.message ?? String(error));
-    cliError.usage = USAGE;
-    process.stderr.write(`${formatCliError(cliError)}\n`);
+    process.stderr.write(`${formatCliError(error)}\n`);
     process.exitCode = 1;
   });
 }

--- a/scripts/loop/inspect-run-viewer-ci-changes.mjs
+++ b/scripts/loop/inspect-run-viewer-ci-changes.mjs
@@ -6,6 +6,7 @@ import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 export const INSPECT_RUN_VIEWER_RELEVANT_EXACT_PATHS = Object.freeze([
   ".github/workflows/ci.yml",
   "package.json",
+  "package-lock.json",
   "playwright.inspect-run-viewer.config.mjs",
   "scripts/loop/_inspect-run-viewer-adapter.mjs",
   "scripts/loop/inspect-run-viewer.mjs",
@@ -15,6 +16,7 @@ export const INSPECT_RUN_VIEWER_RELEVANT_EXACT_PATHS = Object.freeze([
 
 export const INSPECT_RUN_VIEWER_RELEVANT_PREFIXES = Object.freeze([
   "scripts/loop/inspect-run-viewer/",
+  "test/playwright/fixtures/",
 ]);
 
 const USAGE = "Usage: inspect-run-viewer-ci-changes.mjs <changed-files-path>";

--- a/scripts/loop/inspect-run-viewer-ci-changes.mjs
+++ b/scripts/loop/inspect-run-viewer-ci-changes.mjs
@@ -31,20 +31,21 @@ export function normalizeInspectRunViewerPath(filePath) {
     .replace(/^\.\/+/u, "");
 }
 
-export function isInspectRunViewerRelevantPath(filePath) {
-  const normalizedPath = normalizeInspectRunViewerPath(filePath);
-  if (!normalizedPath) {
-    return false;
-  }
+function isInspectRunViewerRelevantNormalizedPath(normalizedPath) {
+  return normalizedPath.length > 0 && (
+    INSPECT_RUN_VIEWER_RELEVANT_EXACT_PATHS.includes(normalizedPath)
+    || INSPECT_RUN_VIEWER_RELEVANT_PREFIXES.some((prefix) => normalizedPath.startsWith(prefix))
+  );
+}
 
-  return INSPECT_RUN_VIEWER_RELEVANT_EXACT_PATHS.includes(normalizedPath)
-    || INSPECT_RUN_VIEWER_RELEVANT_PREFIXES.some((prefix) => normalizedPath.startsWith(prefix));
+export function isInspectRunViewerRelevantPath(filePath) {
+  return isInspectRunViewerRelevantNormalizedPath(normalizeInspectRunViewerPath(filePath));
 }
 
 export function classifyInspectRunViewerCiChanges(changedPaths = []) {
   const relevantPaths = [...new Set(changedPaths
     .map((entry) => normalizeInspectRunViewerPath(entry))
-    .filter((entry) => isInspectRunViewerRelevantPath(entry)))].sort();
+    .filter((entry) => isInspectRunViewerRelevantNormalizedPath(entry)))].sort();
 
   return {
     shouldRun: relevantPaths.length > 0,

--- a/scripts/loop/inspect-run-viewer-ci-changes.mjs
+++ b/scripts/loop/inspect-run-viewer-ci-changes.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+import path from "node:path";
+import { appendFile, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+import { formatCliError } from "../_core-helpers.mjs";
+
+export const INSPECT_RUN_VIEWER_RELEVANT_EXACT_PATHS = Object.freeze([
+  ".github/workflows/ci.yml",
+  "package.json",
+  "package-lock.json",
+  "playwright.inspect-run-viewer.config.mjs",
+  "scripts/loop/_inspect-run-viewer-adapter.mjs",
+  "scripts/loop/inspect-run-viewer.mjs",
+  "scripts/loop/inspect-run-viewer-ci-changes.mjs",
+]);
+
+export const INSPECT_RUN_VIEWER_RELEVANT_PREFIXES = Object.freeze([
+  "scripts/loop/inspect-run-viewer/",
+  "test/playwright/",
+]);
+
+export function normalizeInspectRunViewerPath(filePath) {
+  return String(filePath ?? "")
+    .trim()
+    .replace(/^\.\/+/u, "");
+}
+
+export function isInspectRunViewerRelevantPath(filePath) {
+  const normalizedPath = normalizeInspectRunViewerPath(filePath);
+  if (!normalizedPath) {
+    return false;
+  }
+
+  return INSPECT_RUN_VIEWER_RELEVANT_EXACT_PATHS.includes(normalizedPath)
+    || INSPECT_RUN_VIEWER_RELEVANT_PREFIXES.some((prefix) => normalizedPath.startsWith(prefix));
+}
+
+export function classifyInspectRunViewerCiChanges(changedPaths = []) {
+  const normalizedPaths = changedPaths
+    .map((entry) => normalizeInspectRunViewerPath(entry))
+    .filter(Boolean);
+
+  const relevantPaths = [...new Set(normalizedPaths.filter((entry) => isInspectRunViewerRelevantPath(entry)))].sort();
+  const ignoredPaths = [...new Set(normalizedPaths.filter((entry) => !isInspectRunViewerRelevantPath(entry)))].sort();
+
+  return {
+    shouldRun: relevantPaths.length > 0,
+    relevantPaths,
+    ignoredPaths,
+  };
+}
+
+function parseCliArgs(argv) {
+  const options = {
+    githubOutput: null,
+    pathsFile: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
+    if (argument === "--paths-file") {
+      options.pathsFile = argv[index + 1] ?? null;
+      index += 1;
+      continue;
+    }
+
+    if (argument === "--github-output") {
+      options.githubOutput = argv[index + 1] ?? null;
+      index += 1;
+      continue;
+    }
+
+    if (argument === "--help") {
+      options.help = true;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${argument}`);
+  }
+
+  if (!options.help && !options.pathsFile) {
+    throw new Error("Missing required --paths-file <file>");
+  }
+
+  return options;
+}
+
+const USAGE = `Usage: inspect-run-viewer-ci-changes.mjs --paths-file <file> [--github-output <file>]`;
+
+export async function runCli(argv = process.argv.slice(2), { stdout = process.stdout } = {}) {
+  const options = parseCliArgs(argv);
+  if (options.help) {
+    stdout.write(`${USAGE}\n`);
+    return null;
+  }
+
+  const rawPaths = await readFile(options.pathsFile, "utf8");
+  const changedPaths = rawPaths
+    .split(/\r?\n/u)
+    .filter(Boolean);
+  const result = classifyInspectRunViewerCiChanges(changedPaths);
+
+  if (options.githubOutput) {
+    await appendFile(
+      options.githubOutput,
+      [
+        `inspect_run_viewer=${result.shouldRun}`,
+        `inspect_run_viewer_relevant_paths_json=${JSON.stringify(result.relevantPaths)}`,
+      ].join("\n") + "\n",
+      "utf8",
+    );
+  }
+
+  stdout.write(`${JSON.stringify({ ok: true, ...result })}\n`);
+  return result;
+}
+
+const isDirectRun = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isDirectRun) {
+  runCli().catch((error) => {
+    const cliError = new Error(error?.message ?? String(error));
+    cliError.usage = USAGE;
+    process.stderr.write(`${formatCliError(cliError)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/test/imported-assets-normalization.test.mjs
+++ b/test/imported-assets-normalization.test.mjs
@@ -129,19 +129,24 @@ test("dev-loop skill documents opt-in Playwright smoke harnesses for UI slices",
 });
 
 
-test("CI caches the Playwright WebKit runtime in a deterministic workspace-local path", async () => {
+test("CI gates the Playwright WebKit smoke behind inspect-run viewer change detection", async () => {
   const [ciWorkflow, readme] = await Promise.all([
     readRepo(".github/workflows/ci.yml"),
     readRepo("README.md"),
   ]);
 
+  assert.match(ciWorkflow, /fetch-depth:\s*0/i);
+  assert.match(ciWorkflow, /node scripts\/loop\/inspect-run-viewer-ci-changes\.mjs/i);
+  assert.match(ciWorkflow, /inspect_run_viewer_relevant_paths_json/i);
+  assert.match(ciWorkflow, /if:\s*steps\.inspect-run-viewer-scope\.outputs\.inspect_run_viewer\s*==\s*'true'[\s\S]*actions\/cache@v4/i);
+  assert.match(ciWorkflow, /if:\s*steps\.inspect-run-viewer-scope\.outputs\.inspect_run_viewer\s*==\s*'true'[\s\S]*npx playwright install --with-deps webkit/i);
+  assert.match(ciWorkflow, /if:\s*steps\.inspect-run-viewer-scope\.outputs\.inspect_run_viewer\s*==\s*'true'[\s\S]*npm run test:playwright:viewer/i);
+  assert.match(ciWorkflow, /No inspect-run viewer or Playwright-surface changes detected; skipping browser smoke\./i);
   assert.match(ciWorkflow, /PLAYWRIGHT_BROWSERS_PATH:\s*\$\{\{\s*github\.workspace\s*\}\}\/\.cache\/ms-playwright/i);
-  assert.match(ciWorkflow, /actions\/cache@v4/i);
-  assert.match(ciWorkflow, /path:\s*\$\{\{\s*env\.PLAYWRIGHT_BROWSERS_PATH\s*\}\}/i);
   assert.match(ciWorkflow, /key:\s*\$\{\{\s*runner\.os\s*\}\}-playwright-webkit-\$\{\{\s*hashFiles\('package-lock\.json'\)\s*\}\}/i);
-  assert.match(ciWorkflow, /npx playwright install --with-deps webkit/i);
 
   assert.match(readme, /workspace-local Playwright WebKit runtime cache keyed by runner OS \+ `package-lock\.json`/i);
+  assert.match(readme, /runs the explicit Playwright viewer smoke only when inspect-run viewer or Playwright-surface paths changed/i);
 });
 
 test("installed skill guidance owns packaging guarantees and contract docs stay contract-focused", async () => {

--- a/test/imported-assets-normalization.test.mjs
+++ b/test/imported-assets-normalization.test.mjs
@@ -153,7 +153,7 @@ test("CI gates the Playwright WebKit smoke behind inspect-run viewer change dete
 
   assert.match(readme, /workspace-local Playwright WebKit/i);
   assert.match(readme, /small changed-files gate plus parallel `verify` and conditional `viewer-smoke` jobs/i);
-  assert.match(readme, /run only when the bounded inspect-run viewer surface changed/i);
+  assert.match(readme, /run only when files in the bounded inspect-run viewer surface change/i);
 });
 
 test("installed skill guidance owns packaging guarantees and contract docs stay contract-focused", async () => {

--- a/test/imported-assets-normalization.test.mjs
+++ b/test/imported-assets-normalization.test.mjs
@@ -139,8 +139,8 @@ test("CI gates the Playwright WebKit smoke behind inspect-run viewer change dete
   assert.match(ciWorkflow, /^\s{2}verify:\s*$/m);
   assert.match(ciWorkflow, /^\s{2}viewer-smoke:\s*$/m);
   assert.match(ciWorkflow, /fetch-depth:\s*0/i);
-  assert.match(ciWorkflow, /node scripts\/loop\/inspect-run-viewer-ci-changes\.mjs/i);
-  assert.match(ciWorkflow, /inspect_run_viewer_relevant_paths_json/i);
+  assert.match(ciWorkflow, /GITHUB_OUTPUT="\$GITHUB_OUTPUT" node scripts\/loop\/inspect-run-viewer-ci-changes\.mjs \.inspect-run-viewer-changed-files\.txt/i);
+  assert.doesNotMatch(ciWorkflow, /inspect_run_viewer_relevant_paths_json/i);
   assert.match(ciWorkflow, /viewer-smoke:[\s\S]*needs:[\s\S]*- changes/i);
   assert.match(ciWorkflow, /viewer-smoke:[\s\S]*if:\s*needs\.changes\.outputs\.inspect_run_viewer\s*==\s*'true'/i);
   assert.match(ciWorkflow, /viewer-smoke:[\s\S]*actions\/cache@v4/i);
@@ -151,8 +151,8 @@ test("CI gates the Playwright WebKit smoke behind inspect-run viewer change dete
   assert.match(ciWorkflow, /key:\s*\$\{\{\s*runner\.os\s*\}\}-playwright-webkit-\$\{\{\s*hashFiles\('package-lock\.json'\)\s*\}\}/i);
 
   assert.match(readme, /workspace-local Playwright WebKit/i);
-  assert.match(readme, /parallel `verify` and conditional `viewer-smoke` jobs/i);
-  assert.match(readme, /run only when inspect-run viewer or Playwright-surface paths changed/i);
+  assert.match(readme, /small changed-files gate plus parallel `verify` and conditional `viewer-smoke` jobs/i);
+  assert.match(readme, /run only when the bounded inspect-run viewer surface changed/i);
 });
 
 test("installed skill guidance owns packaging guarantees and contract docs stay contract-focused", async () => {

--- a/test/imported-assets-normalization.test.mjs
+++ b/test/imported-assets-normalization.test.mjs
@@ -139,6 +139,7 @@ test("CI gates the Playwright WebKit smoke behind inspect-run viewer change dete
   assert.match(ciWorkflow, /^\s{2}verify:\s*$/m);
   assert.match(ciWorkflow, /^\s{2}viewer-smoke:\s*$/m);
   assert.match(ciWorkflow, /fetch-depth:\s*0/i);
+  assert.match(ciWorkflow, /changes:[\s\S]*Set up Node\.js[\s\S]*node-version:\s*24/i);
   assert.match(ciWorkflow, /GITHUB_OUTPUT="\$GITHUB_OUTPUT" node scripts\/loop\/inspect-run-viewer-ci-changes\.mjs \.inspect-run-viewer-changed-files\.txt/i);
   assert.doesNotMatch(ciWorkflow, /inspect_run_viewer_relevant_paths_json/i);
   assert.match(ciWorkflow, /viewer-smoke:[\s\S]*needs:[\s\S]*- changes/i);

--- a/test/imported-assets-normalization.test.mjs
+++ b/test/imported-assets-normalization.test.mjs
@@ -129,24 +129,30 @@ test("dev-loop skill documents opt-in Playwright smoke harnesses for UI slices",
 });
 
 
-test("CI gates the Playwright WebKit smoke behind inspect-run viewer change detection", async () => {
+test("CI gates the Playwright WebKit smoke behind inspect-run viewer change detection and runs it in a separate job", async () => {
   const [ciWorkflow, readme] = await Promise.all([
     readRepo(".github/workflows/ci.yml"),
     readRepo("README.md"),
   ]);
 
+  assert.match(ciWorkflow, /^\s{2}changes:\s*$/m);
+  assert.match(ciWorkflow, /^\s{2}verify:\s*$/m);
+  assert.match(ciWorkflow, /^\s{2}viewer-smoke:\s*$/m);
   assert.match(ciWorkflow, /fetch-depth:\s*0/i);
   assert.match(ciWorkflow, /node scripts\/loop\/inspect-run-viewer-ci-changes\.mjs/i);
   assert.match(ciWorkflow, /inspect_run_viewer_relevant_paths_json/i);
-  assert.match(ciWorkflow, /if:\s*steps\.inspect-run-viewer-scope\.outputs\.inspect_run_viewer\s*==\s*'true'[\s\S]*actions\/cache@v4/i);
-  assert.match(ciWorkflow, /if:\s*steps\.inspect-run-viewer-scope\.outputs\.inspect_run_viewer\s*==\s*'true'[\s\S]*npx playwright install --with-deps webkit/i);
-  assert.match(ciWorkflow, /if:\s*steps\.inspect-run-viewer-scope\.outputs\.inspect_run_viewer\s*==\s*'true'[\s\S]*npm run test:playwright:viewer/i);
-  assert.match(ciWorkflow, /No inspect-run viewer or Playwright-surface changes detected; skipping browser smoke\./i);
+  assert.match(ciWorkflow, /viewer-smoke:[\s\S]*needs:[\s\S]*- changes/i);
+  assert.match(ciWorkflow, /viewer-smoke:[\s\S]*if:\s*needs\.changes\.outputs\.inspect_run_viewer\s*==\s*'true'/i);
+  assert.match(ciWorkflow, /viewer-smoke:[\s\S]*actions\/cache@v4/i);
+  assert.match(ciWorkflow, /viewer-smoke:[\s\S]*npx playwright install --with-deps webkit/i);
+  assert.match(ciWorkflow, /viewer-smoke:[\s\S]*npm run test:playwright:viewer/i);
+  assert.match(ciWorkflow, /verify:[\s\S]*npm run verify/i);
   assert.match(ciWorkflow, /PLAYWRIGHT_BROWSERS_PATH:\s*\$\{\{\s*github\.workspace\s*\}\}\/\.cache\/ms-playwright/i);
   assert.match(ciWorkflow, /key:\s*\$\{\{\s*runner\.os\s*\}\}-playwright-webkit-\$\{\{\s*hashFiles\('package-lock\.json'\)\s*\}\}/i);
 
-  assert.match(readme, /workspace-local Playwright WebKit runtime cache keyed by runner OS \+ `package-lock\.json`/i);
-  assert.match(readme, /runs the explicit Playwright viewer smoke only when inspect-run viewer or Playwright-surface paths changed/i);
+  assert.match(readme, /workspace-local Playwright WebKit/i);
+  assert.match(readme, /parallel `verify` and conditional `viewer-smoke` jobs/i);
+  assert.match(readme, /run only when inspect-run viewer or Playwright-surface paths changed/i);
 });
 
 test("installed skill guidance owns packaging guarantees and contract docs stay contract-focused", async () => {

--- a/test/imported-assets-normalization.test.mjs
+++ b/test/imported-assets-normalization.test.mjs
@@ -144,12 +144,8 @@ test("CI gates the Playwright WebKit smoke behind inspect-run viewer change dete
   assert.doesNotMatch(ciWorkflow, /inspect_run_viewer_relevant_paths_json/i);
   assert.match(ciWorkflow, /viewer-smoke:[\s\S]*needs:[\s\S]*- changes/i);
   assert.match(ciWorkflow, /viewer-smoke:[\s\S]*if:\s*needs\.changes\.outputs\.inspect_run_viewer\s*==\s*'true'/i);
-  assert.match(ciWorkflow, /viewer-smoke:[\s\S]*actions\/cache@v4/i);
-  assert.match(ciWorkflow, /viewer-smoke:[\s\S]*npx playwright install --with-deps webkit/i);
   assert.match(ciWorkflow, /viewer-smoke:[\s\S]*npm run test:playwright:viewer/i);
   assert.match(ciWorkflow, /verify:[\s\S]*npm run verify/i);
-  assert.match(ciWorkflow, /PLAYWRIGHT_BROWSERS_PATH:\s*\$\{\{\s*github\.workspace\s*\}\}\/\.cache\/ms-playwright/i);
-  assert.match(ciWorkflow, /key:\s*\$\{\{\s*runner\.os\s*\}\}-playwright-webkit-\$\{\{\s*hashFiles\('package-lock\.json'\)\s*\}\}/i);
 
   assert.match(readme, /workspace-local Playwright WebKit/i);
   assert.match(readme, /small changed-files gate plus parallel `verify` and conditional `viewer-smoke` jobs/i);

--- a/test/loop/inspect-run-viewer-ci-changes.test.mjs
+++ b/test/loop/inspect-run-viewer-ci-changes.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+
+import {
+  classifyInspectRunViewerCiChanges,
+  isInspectRunViewerRelevantPath,
+  runCli,
+} from "../../scripts/loop/inspect-run-viewer-ci-changes.mjs";
+
+test("isInspectRunViewerRelevantPath matches the bounded inspect-run viewer smoke surface", () => {
+  assert.equal(isInspectRunViewerRelevantPath(".github/workflows/ci.yml"), true);
+  assert.equal(isInspectRunViewerRelevantPath("package-lock.json"), true);
+  assert.equal(isInspectRunViewerRelevantPath("scripts/loop/inspect-run-viewer/rendering.mjs"), true);
+  assert.equal(isInspectRunViewerRelevantPath("scripts/loop/inspect-run-viewer-ci-changes.mjs"), true);
+  assert.equal(isInspectRunViewerRelevantPath("test/playwright/inspect-run-viewer.spec.mjs"), true);
+
+  assert.equal(isInspectRunViewerRelevantPath("README.md"), false);
+  assert.equal(isInspectRunViewerRelevantPath("docs/index.md"), false);
+  assert.equal(isInspectRunViewerRelevantPath("test/loop/inspect-run-viewer.test.mjs"), false);
+});
+
+test("classifyInspectRunViewerCiChanges only requests browser smoke when relevant paths changed", () => {
+  const relevant = classifyInspectRunViewerCiChanges([
+    "README.md",
+    "scripts/loop/inspect-run-viewer/server.mjs",
+    "docs/index.md",
+  ]);
+  assert.equal(relevant.shouldRun, true);
+  assert.deepEqual(relevant.relevantPaths, ["scripts/loop/inspect-run-viewer/server.mjs"]);
+  assert.deepEqual(relevant.ignoredPaths, ["README.md", "docs/index.md"]);
+
+  const irrelevant = classifyInspectRunViewerCiChanges([
+    "README.md",
+    "docs/IMPLEMENTATION_WORKFLOW.md",
+  ]);
+  assert.equal(irrelevant.shouldRun, false);
+  assert.deepEqual(irrelevant.relevantPaths, []);
+});
+
+test("runCli emits github output entries for inspect-run viewer smoke gating", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "inspect-run-viewer-ci-changes-"));
+  const pathsFile = path.join(tempDir, "changed-files.txt");
+  const githubOutputFile = path.join(tempDir, "github-output.txt");
+  const writes = [];
+
+  try {
+    await writeFile(pathsFile, [
+      "README.md",
+      "playwright.inspect-run-viewer.config.mjs",
+    ].join("\n"), "utf8");
+
+    const result = await runCli([
+      "--paths-file",
+      pathsFile,
+      "--github-output",
+      githubOutputFile,
+    ], {
+      stdout: {
+        write(chunk) {
+          writes.push(String(chunk));
+        },
+      },
+    });
+
+    assert.equal(result.shouldRun, true);
+    assert.deepEqual(result.relevantPaths, ["playwright.inspect-run-viewer.config.mjs"]);
+
+    const payload = JSON.parse(writes.join(""));
+    assert.equal(payload.ok, true);
+    assert.equal(payload.shouldRun, true);
+
+    const githubOutput = await readFile(githubOutputFile, "utf8");
+    assert.match(githubOutput, /^inspect_run_viewer=true$/m);
+    assert.match(githubOutput, /^inspect_run_viewer_relevant_paths_json=\["playwright\.inspect-run-viewer\.config\.mjs"\]$/m);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/loop/inspect-run-viewer-ci-changes.test.mjs
+++ b/test/loop/inspect-run-viewer-ci-changes.test.mjs
@@ -12,10 +12,11 @@ import {
 
 test("isInspectRunViewerRelevantPath matches the bounded inspect-run viewer smoke surface", () => {
   assert.equal(isInspectRunViewerRelevantPath(".github/workflows/ci.yml"), true);
-  assert.equal(isInspectRunViewerRelevantPath("package-lock.json"), true);
+  assert.equal(isInspectRunViewerRelevantPath("package.json"), true);
   assert.equal(isInspectRunViewerRelevantPath("scripts/loop/inspect-run-viewer/rendering.mjs"), true);
   assert.equal(isInspectRunViewerRelevantPath("scripts/loop/inspect-run-viewer-ci-changes.mjs"), true);
   assert.equal(isInspectRunViewerRelevantPath("test/playwright/inspect-run-viewer.spec.mjs"), true);
+  assert.equal(isInspectRunViewerRelevantPath("test/playwright/some-other-ui.spec.mjs"), false);
 
   assert.equal(isInspectRunViewerRelevantPath("README.md"), false);
   assert.equal(isInspectRunViewerRelevantPath("docs/index.md"), false);
@@ -30,8 +31,6 @@ test("classifyInspectRunViewerCiChanges only requests browser smoke when relevan
   ]);
   assert.equal(relevant.shouldRun, true);
   assert.deepEqual(relevant.relevantPaths, ["scripts/loop/inspect-run-viewer/server.mjs"]);
-  assert.deepEqual(relevant.ignoredPaths, ["README.md", "docs/index.md"]);
-
   const irrelevant = classifyInspectRunViewerCiChanges([
     "README.md",
     "docs/IMPLEMENTATION_WORKFLOW.md",
@@ -53,11 +52,12 @@ test("runCli emits github output entries for inspect-run viewer smoke gating", a
     ].join("\n"), "utf8");
 
     const result = await runCli([
-      "--paths-file",
       pathsFile,
-      "--github-output",
-      githubOutputFile,
     ], {
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: githubOutputFile,
+      },
       stdout: {
         write(chunk) {
           writes.push(String(chunk));
@@ -74,7 +74,6 @@ test("runCli emits github output entries for inspect-run viewer smoke gating", a
 
     const githubOutput = await readFile(githubOutputFile, "utf8");
     assert.match(githubOutput, /^inspect_run_viewer=true$/m);
-    assert.match(githubOutput, /^inspect_run_viewer_relevant_paths_json=\["playwright\.inspect-run-viewer\.config\.mjs"\]$/m);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/inspect-run-viewer-ci-changes.test.mjs
+++ b/test/loop/inspect-run-viewer-ci-changes.test.mjs
@@ -13,9 +13,11 @@ import {
 test("isInspectRunViewerRelevantPath matches the bounded inspect-run viewer smoke surface", () => {
   assert.equal(isInspectRunViewerRelevantPath(".github/workflows/ci.yml"), true);
   assert.equal(isInspectRunViewerRelevantPath("package.json"), true);
+  assert.equal(isInspectRunViewerRelevantPath("package-lock.json"), true);
   assert.equal(isInspectRunViewerRelevantPath("scripts/loop/inspect-run-viewer/rendering.mjs"), true);
   assert.equal(isInspectRunViewerRelevantPath("scripts/loop/inspect-run-viewer-ci-changes.mjs"), true);
   assert.equal(isInspectRunViewerRelevantPath("test/playwright/inspect-run-viewer.spec.mjs"), true);
+  assert.equal(isInspectRunViewerRelevantPath("test/playwright/fixtures/inspect-run-viewer-fixture.mjs"), true);
   assert.equal(isInspectRunViewerRelevantPath("test/playwright/some-other-ui.spec.mjs"), false);
 
   assert.equal(isInspectRunViewerRelevantPath("README.md"), false);
@@ -27,10 +29,14 @@ test("classifyInspectRunViewerCiChanges only requests browser smoke when relevan
   const relevant = classifyInspectRunViewerCiChanges([
     "README.md",
     "scripts/loop/inspect-run-viewer/server.mjs",
+    "test/playwright/fixtures/inspect-run-viewer-fixture.mjs",
     "docs/index.md",
   ]);
   assert.equal(relevant.shouldRun, true);
-  assert.deepEqual(relevant.relevantPaths, ["scripts/loop/inspect-run-viewer/server.mjs"]);
+  assert.deepEqual(relevant.relevantPaths, [
+    "scripts/loop/inspect-run-viewer/server.mjs",
+    "test/playwright/fixtures/inspect-run-viewer-fixture.mjs",
+  ]);
   const irrelevant = classifyInspectRunViewerCiChanges([
     "README.md",
     "docs/IMPLEMENTATION_WORKFLOW.md",


### PR DESCRIPTION
## Summary
- keep `npm run verify` as the always-on CI path
- gate the Playwright inspect-run viewer smoke behind a deterministic changed-files classifier
- keep the viewer smoke step self-validating by forcing it on workflow or smoke-scope changes

## Scope / context
This is a local-first follow-up to the ineffective cache-only attempt from #255.

The new slice does **not** try to squeeze more speed out of `playwright install --with-deps webkit` itself. Instead, it avoids paying that cost on PRs that do not touch the inspect-run viewer / Playwright smoke surface.

Files in scope:
- `.github/workflows/ci.yml`
- `scripts/loop/inspect-run-viewer-ci-changes.mjs`
- `test/loop/inspect-run-viewer-ci-changes.test.mjs`
- `test/imported-assets-normalization.test.mjs`
- `README.md`

## Acceptance criteria
- [x] CI still runs `npm ci` and `npm run verify` on every PR / main push
- [x] Playwright runtime restore/install + viewer smoke only run when the changed-files set touches the bounded inspect-run viewer / Playwright surface
- [x] workflow changes that affect the smoke gate force the smoke path to run rather than skipping itself
- [x] the change-detection contract is covered by local tests
- [x] repo docs stay aligned with the resulting CI behavior

## Definition of done
- [x] local `npm run verify` passes
- [x] local `npm run test:playwright:viewer` passes
- [x] PR CI shows the gated viewer-smoke path behaving as expected
- [ ] decide after CI evidence whether the relevant-path set is still too broad or too narrow

## Non-goals
- caching APT/system packages
- broad CI matrix redesign
- changing the default `npm run verify` contract
- making Playwright part of the default local verify path

Supersedes the ineffective cache-only direction from #255.
