### PR TITLE
ci: update GitHub Actions for Node 24 runner compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
 
@@ -28,7 +28,7 @@ jobs:
         run: npm run verify
 
       - name: Restore Playwright WebKit runtime cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
           key: ${{ runner.os }}-playwright-webkit-${{ hashFiles('package-lock.json') }}

--- a/test/imported-assets-normalization.test.mjs
+++ b/test/imported-assets-normalization.test.mjs
@@ -129,14 +129,16 @@ test("dev-loop skill documents opt-in Playwright smoke harnesses for UI slices",
 });
 
 
-test("CI caches the Playwright WebKit runtime in a deterministic workspace-local path", async () => {
+test("CI uses Node24-ready first-party actions and caches the Playwright WebKit runtime in a deterministic workspace-local path", async () => {
   const [ciWorkflow, readme] = await Promise.all([
     readRepo(".github/workflows/ci.yml"),
     readRepo("README.md"),
   ]);
 
   assert.match(ciWorkflow, /PLAYWRIGHT_BROWSERS_PATH:\s*\$\{\{\s*github\.workspace\s*\}\}\/\.cache\/ms-playwright/i);
-  assert.match(ciWorkflow, /actions\/cache@v4/i);
+  assert.match(ciWorkflow, /actions\/checkout@v5/i);
+  assert.match(ciWorkflow, /actions\/setup-node@v5/i);
+  assert.match(ciWorkflow, /actions\/cache@v5/i);
   assert.match(ciWorkflow, /path:\s*\$\{\{\s*env\.PLAYWRIGHT_BROWSERS_PATH\s*\}\}/i);
   assert.match(ciWorkflow, /key:\s*\$\{\{\s*runner\.os\s*\}\}-playwright-webkit-\$\{\{\s*hashFiles\('package-lock\.json'\)\s*\}\}/i);
   assert.match(ciWorkflow, /npx playwright install --with-deps webkit/i);


### PR DESCRIPTION
## Summary

Update the CI workflow to the Node 24-ready major versions of GitHub's first-party checkout, setup-node, and cache actions while keeping the existing workflow behavior intact.

Closes #257.

## Scope/context

PR #256 surfaced a GitHub Actions annotation warning that `actions/checkout@v4`, `actions/setup-node@v4`, and `actions/cache@v4` are still on the Node 20 action runtime and will be forced onto Node 24 soon. This PR keeps the response narrow:

- bump the affected first-party actions to their Node 24-ready major tags
- keep the job shape, triggers, commands, and cache key/path behavior unchanged
- refresh the workflow normalization test so it asserts the new action majors

## Acceptance criteria

- CI no longer emits the Node 20 deprecation annotation for the updated actions
- the workflow remains behaviorally equivalent aside from the version bump
- the resulting change stays narrowly scoped to the affected actions versions

## Definition of done

- `.github/workflows/ci.yml` uses Node 24-ready majors for checkout, setup-node, and cache
- the deterministic Playwright-cache workflow test matches the updated action versions
- `npm run verify` passes locally
- PR CI passes on GitHub

## Non-goals

- unrelated CI redesign
- broader workflow cleanup
- changing the test matrix or command surface
