### PR TITLE
fix: coordinate PR gate entry before pre-approval

### DIFF
--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -182,6 +182,7 @@ export function evaluatePrGateCoordination(input = {}) {
       pushUnique(allowedNextActions, [PR_GATE_ACTION.MARK_READY_FOR_REVIEW]);
     }
     pushUnique(forbiddenActions, [
+      ...(draftGate.currentHeadClean ? [] : [PR_GATE_ACTION.MARK_READY_FOR_REVIEW]),
       PR_GATE_ACTION.REQUEST_COPILOT_REVIEW,
       PR_GATE_ACTION.WAIT_FOR_COPILOT_REVIEW,
       PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE,

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -1,0 +1,381 @@
+import { LOOP_DISPOSITION, STATE } from "./copilot-loop-state.mjs";
+
+export const PR_GATE_BOUNDARY = Object.freeze({
+  DRAFT_REVIEW: "draft_review",
+  POST_DRAFT_EXTERNAL_REVIEW: "post_draft_external_review",
+  FEEDBACK_RESOLUTION: "feedback_resolution",
+  PRE_APPROVAL_GATE_WINDOW: "pre_approval_gate_window",
+  FINAL_APPROVAL_READY: "final_approval_ready",
+  BLOCKED: "blocked",
+  DONE: "done",
+});
+
+export const PR_GATE_ACTION = Object.freeze({
+  RUN_DRAFT_GATE: "run_draft_gate",
+  MARK_READY_FOR_REVIEW: "mark_ready_for_review",
+  REQUEST_COPILOT_REVIEW: "request_copilot_review",
+  WAIT_FOR_COPILOT_REVIEW: "wait_for_copilot_review",
+  ADDRESS_REVIEW_FEEDBACK: "address_review_feedback",
+  REPLY_RESOLVE_REVIEW_THREADS: "reply_resolve_review_threads",
+  REREQUEST_COPILOT_REVIEW: "rerequest_copilot_review",
+  RUN_PRE_APPROVAL_GATE: "run_pre_approval_gate",
+  AWAIT_FINAL_HUMAN_APPROVAL: "await_final_human_approval",
+  DECLARE_MERGE_READY: "declare_merge_ready",
+  REPORT_BLOCKED: "report_blocked",
+  REPORT_DONE: "report_done",
+});
+
+function normalizeGateComment(summary = null) {
+  if (!summary || typeof summary !== "object") {
+    return {
+      visible: false,
+      headSha: null,
+      verdict: null,
+      findingsSummary: null,
+      nextAction: null,
+      contractComplete: false,
+    };
+  }
+
+  return {
+    visible: summary.visible === true,
+    headSha: typeof summary.headSha === "string" && summary.headSha.trim().length > 0 ? summary.headSha.trim() : null,
+    verdict: typeof summary.verdict === "string" && summary.verdict.trim().length > 0 ? summary.verdict.trim().toLowerCase() : null,
+    findingsSummary: typeof summary.findingsSummary === "string" && summary.findingsSummary.trim().length > 0
+      ? summary.findingsSummary.trim()
+      : null,
+    nextAction: typeof summary.nextAction === "string" && summary.nextAction.trim().length > 0
+      ? summary.nextAction.trim()
+      : null,
+    contractComplete: summary.contractComplete === true,
+  };
+}
+
+function toGateStatus(comment, marker, currentHeadSha) {
+  const normalizedComment = normalizeGateComment(comment);
+  const normalizedMarker = normalizeGateComment(marker);
+  const markerHeadMatches = normalizedMarker.headSha !== null
+    && typeof currentHeadSha === "string"
+    && currentHeadSha.startsWith(normalizedMarker.headSha);
+
+  return {
+    visible: normalizedComment.visible,
+    currentHead: normalizedMarker.visible && markerHeadMatches,
+    headSha: normalizedComment.headSha,
+    verdict: normalizedComment.verdict,
+    findingsSummary: normalizedComment.findingsSummary,
+    nextAction: normalizedComment.nextAction,
+    contractComplete: normalizedMarker.contractComplete,
+    currentHeadClean: normalizedMarker.visible && markerHeadMatches && normalizedMarker.verdict === "clean" && normalizedMarker.contractComplete,
+  };
+}
+
+function pushUnique(values, additions) {
+  for (const value of additions) {
+    if (typeof value === "string" && value.length > 0 && !values.includes(value)) {
+      values.push(value);
+    }
+  }
+}
+
+function buildResult({
+  repo = null,
+  pr = null,
+  currentHeadSha = null,
+  lifecycleState,
+  loopDisposition,
+  gateBoundary,
+  draftGate,
+  preApprovalGate,
+  allowedNextActions,
+  forbiddenActions,
+  nextAction,
+  reason,
+}) {
+  return {
+    ok: true,
+    ...(repo ? { repo } : {}),
+    ...(pr !== null ? { pr } : {}),
+    currentHeadSha,
+    lifecycleState,
+    loopDisposition,
+    gateBoundary,
+    draftGate,
+    preApprovalGate,
+    allowedNextActions,
+    forbiddenActions,
+    nextAction,
+    reason,
+  };
+}
+
+export function evaluatePrGateCoordination(input = {}) {
+  const currentHeadSha = typeof input.currentHeadSha === "string" && input.currentHeadSha.trim().length > 0
+    ? input.currentHeadSha.trim()
+    : null;
+  const lifecycleState = typeof input.lifecycleState === "string" ? input.lifecycleState.trim().toLowerCase() : "";
+  const loopDisposition = typeof input.loopDisposition === "string" ? input.loopDisposition.trim().toLowerCase() : null;
+  const prDraft = input.prDraft === true;
+  const prClosed = input.prClosed === true;
+  const prMerged = input.prMerged === true;
+  const sameHeadCleanConverged = input.sameHeadCleanConverged === true;
+
+  const draftGate = toGateStatus(input.draftGate, input.draftGateMarker, currentHeadSha);
+  const preApprovalGate = toGateStatus(input.preApprovalGate, input.preApprovalGateMarker, currentHeadSha);
+
+  const allowedNextActions = [];
+  const forbiddenActions = [];
+
+  if (prMerged || prClosed || lifecycleState === STATE.DONE) {
+    pushUnique(allowedNextActions, [PR_GATE_ACTION.REPORT_DONE]);
+    pushUnique(forbiddenActions, [
+      PR_GATE_ACTION.RUN_DRAFT_GATE,
+      PR_GATE_ACTION.MARK_READY_FOR_REVIEW,
+      PR_GATE_ACTION.REQUEST_COPILOT_REVIEW,
+      PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE,
+      PR_GATE_ACTION.DECLARE_MERGE_READY,
+    ]);
+    return buildResult({
+      repo: input.repo ?? null,
+      pr: Number.isInteger(input.pr) ? input.pr : null,
+      currentHeadSha,
+      lifecycleState,
+      loopDisposition: loopDisposition ?? LOOP_DISPOSITION.DONE,
+      gateBoundary: PR_GATE_BOUNDARY.DONE,
+      draftGate,
+      preApprovalGate,
+      allowedNextActions,
+      forbiddenActions,
+      nextAction: PR_GATE_ACTION.REPORT_DONE,
+      reason: "The pull request is already closed or merged, so no further gate entry is legal.",
+    });
+  }
+
+  if (lifecycleState === STATE.BLOCKED_NEEDS_USER_DECISION || lifecycleState === STATE.REVIEW_REQUEST_UNAVAILABLE) {
+    pushUnique(allowedNextActions, [PR_GATE_ACTION.REPORT_BLOCKED]);
+    pushUnique(forbiddenActions, [
+      PR_GATE_ACTION.RUN_DRAFT_GATE,
+      PR_GATE_ACTION.MARK_READY_FOR_REVIEW,
+      PR_GATE_ACTION.REQUEST_COPILOT_REVIEW,
+      PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE,
+      PR_GATE_ACTION.DECLARE_MERGE_READY,
+    ]);
+    return buildResult({
+      repo: input.repo ?? null,
+      pr: Number.isInteger(input.pr) ? input.pr : null,
+      currentHeadSha,
+      lifecycleState,
+      loopDisposition: loopDisposition ?? LOOP_DISPOSITION.BLOCKED,
+      gateBoundary: PR_GATE_BOUNDARY.BLOCKED,
+      draftGate,
+      preApprovalGate,
+      allowedNextActions,
+      forbiddenActions,
+      nextAction: PR_GATE_ACTION.REPORT_BLOCKED,
+      reason: "The PR is in a blocked lifecycle state, so gate progression must stop for a user decision.",
+    });
+  }
+
+  if (prDraft || lifecycleState === STATE.PR_DRAFT) {
+    pushUnique(allowedNextActions, [PR_GATE_ACTION.RUN_DRAFT_GATE]);
+    if (draftGate.currentHeadClean) {
+      pushUnique(allowedNextActions, [PR_GATE_ACTION.MARK_READY_FOR_REVIEW]);
+    }
+    pushUnique(forbiddenActions, [
+      PR_GATE_ACTION.REQUEST_COPILOT_REVIEW,
+      PR_GATE_ACTION.WAIT_FOR_COPILOT_REVIEW,
+      PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE,
+      PR_GATE_ACTION.DECLARE_MERGE_READY,
+    ]);
+
+    return buildResult({
+      repo: input.repo ?? null,
+      pr: Number.isInteger(input.pr) ? input.pr : null,
+      currentHeadSha,
+      lifecycleState: lifecycleState || STATE.PR_DRAFT,
+      loopDisposition: loopDisposition ?? LOOP_DISPOSITION.ACTION_REQUIRED,
+      gateBoundary: PR_GATE_BOUNDARY.DRAFT_REVIEW,
+      draftGate,
+      preApprovalGate,
+      allowedNextActions,
+      forbiddenActions,
+      nextAction: draftGate.currentHeadClean ? PR_GATE_ACTION.MARK_READY_FOR_REVIEW : PR_GATE_ACTION.RUN_DRAFT_GATE,
+      reason: draftGate.currentHeadClean
+        ? "The PR is still draft, and current-head clean `draft_gate` evidence exists, so `gh pr ready` is now legal."
+        : "The PR is still draft, so `draft_gate` is the only legal gate boundary before `gh pr ready`.",
+    });
+  }
+
+  const postDraftForbidden = [
+    PR_GATE_ACTION.RUN_DRAFT_GATE,
+    PR_GATE_ACTION.MARK_READY_FOR_REVIEW,
+    PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE,
+    PR_GATE_ACTION.DECLARE_MERGE_READY,
+  ];
+
+  if (lifecycleState === STATE.PR_READY_NO_FEEDBACK) {
+    pushUnique(allowedNextActions, [PR_GATE_ACTION.REQUEST_COPILOT_REVIEW]);
+    pushUnique(forbiddenActions, postDraftForbidden);
+    return buildResult({
+      repo: input.repo ?? null,
+      pr: Number.isInteger(input.pr) ? input.pr : null,
+      currentHeadSha,
+      lifecycleState,
+      loopDisposition: loopDisposition ?? LOOP_DISPOSITION.ACTION_REQUIRED,
+      gateBoundary: PR_GATE_BOUNDARY.POST_DRAFT_EXTERNAL_REVIEW,
+      draftGate,
+      preApprovalGate,
+      allowedNextActions,
+      forbiddenActions,
+      nextAction: PR_GATE_ACTION.REQUEST_COPILOT_REVIEW,
+      reason: "The PR is ready for review but the post-draft external review cycle has not started yet; request Copilot review before any `pre_approval_gate` entry.",
+    });
+  }
+
+  if (lifecycleState === STATE.WAITING_FOR_COPILOT_REVIEW || lifecycleState === STATE.WAITING_FOR_CI) {
+    pushUnique(allowedNextActions, [PR_GATE_ACTION.WAIT_FOR_COPILOT_REVIEW]);
+    pushUnique(forbiddenActions, postDraftForbidden);
+    return buildResult({
+      repo: input.repo ?? null,
+      pr: Number.isInteger(input.pr) ? input.pr : null,
+      currentHeadSha,
+      lifecycleState,
+      loopDisposition: loopDisposition ?? LOOP_DISPOSITION.PENDING,
+      gateBoundary: PR_GATE_BOUNDARY.POST_DRAFT_EXTERNAL_REVIEW,
+      draftGate,
+      preApprovalGate,
+      allowedNextActions,
+      forbiddenActions,
+      nextAction: PR_GATE_ACTION.WAIT_FOR_COPILOT_REVIEW,
+      reason: "The post-draft review cycle is still pending, so `pre_approval_gate` remains illegal until the current-head review cycle settles.",
+    });
+  }
+
+  if (lifecycleState === STATE.UNRESOLVED_FEEDBACK_PRESENT) {
+    pushUnique(allowedNextActions, [PR_GATE_ACTION.ADDRESS_REVIEW_FEEDBACK]);
+    pushUnique(forbiddenActions, postDraftForbidden);
+    return buildResult({
+      repo: input.repo ?? null,
+      pr: Number.isInteger(input.pr) ? input.pr : null,
+      currentHeadSha,
+      lifecycleState,
+      loopDisposition: loopDisposition ?? LOOP_DISPOSITION.UNRESOLVED_FEEDBACK,
+      gateBoundary: PR_GATE_BOUNDARY.FEEDBACK_RESOLUTION,
+      draftGate,
+      preApprovalGate,
+      allowedNextActions,
+      forbiddenActions,
+      nextAction: PR_GATE_ACTION.ADDRESS_REVIEW_FEEDBACK,
+      reason: "Actionable unresolved feedback exists, so follow-up work must stay in the review/fix cycle and cannot enter `pre_approval_gate` yet.",
+    });
+  }
+
+  if (lifecycleState === STATE.ALREADY_FIXED_NEEDS_REPLY_RESOLVE) {
+    pushUnique(allowedNextActions, [PR_GATE_ACTION.REPLY_RESOLVE_REVIEW_THREADS]);
+    pushUnique(forbiddenActions, postDraftForbidden);
+    return buildResult({
+      repo: input.repo ?? null,
+      pr: Number.isInteger(input.pr) ? input.pr : null,
+      currentHeadSha,
+      lifecycleState,
+      loopDisposition: loopDisposition ?? LOOP_DISPOSITION.UNRESOLVED_FEEDBACK,
+      gateBoundary: PR_GATE_BOUNDARY.FEEDBACK_RESOLUTION,
+      draftGate,
+      preApprovalGate,
+      allowedNextActions,
+      forbiddenActions,
+      nextAction: PR_GATE_ACTION.REPLY_RESOLVE_REVIEW_THREADS,
+      reason: "Fixes were applied, but unresolved threads still need reply/resolve handling before another gate boundary is legal.",
+    });
+  }
+
+  if (lifecycleState === STATE.READY_TO_REREQUEST_REVIEW) {
+    if (!sameHeadCleanConverged) {
+      pushUnique(allowedNextActions, [PR_GATE_ACTION.REREQUEST_COPILOT_REVIEW]);
+      pushUnique(forbiddenActions, postDraftForbidden);
+      return buildResult({
+        repo: input.repo ?? null,
+        pr: Number.isInteger(input.pr) ? input.pr : null,
+        currentHeadSha,
+        lifecycleState,
+        loopDisposition: loopDisposition ?? LOOP_DISPOSITION.ACTION_REQUIRED,
+        gateBoundary: PR_GATE_BOUNDARY.POST_DRAFT_EXTERNAL_REVIEW,
+        draftGate,
+        preApprovalGate,
+        allowedNextActions,
+        forbiddenActions,
+        nextAction: PR_GATE_ACTION.REREQUEST_COPILOT_REVIEW,
+        reason: "The review loop is between passes, but the current head does not yet have a clean settled Copilot convergence point, so `pre_approval_gate` is still forbidden.",
+      });
+    }
+
+    if (preApprovalGate.currentHeadClean) {
+      pushUnique(allowedNextActions, [PR_GATE_ACTION.AWAIT_FINAL_HUMAN_APPROVAL]);
+      pushUnique(forbiddenActions, [
+        PR_GATE_ACTION.RUN_DRAFT_GATE,
+        PR_GATE_ACTION.MARK_READY_FOR_REVIEW,
+        PR_GATE_ACTION.REQUEST_COPILOT_REVIEW,
+        PR_GATE_ACTION.DECLARE_MERGE_READY,
+      ]);
+      return buildResult({
+        repo: input.repo ?? null,
+        pr: Number.isInteger(input.pr) ? input.pr : null,
+        currentHeadSha,
+        lifecycleState,
+        loopDisposition: loopDisposition ?? LOOP_DISPOSITION.CLEAN_CONVERGED,
+        gateBoundary: PR_GATE_BOUNDARY.FINAL_APPROVAL_READY,
+        draftGate,
+        preApprovalGate,
+        allowedNextActions,
+        forbiddenActions,
+        nextAction: PR_GATE_ACTION.AWAIT_FINAL_HUMAN_APPROVAL,
+        reason: "The current head has both a clean settled review cycle and clean `pre_approval_gate` evidence, so the PR is at the final approval boundary.",
+      });
+    }
+
+    pushUnique(allowedNextActions, [PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE]);
+    pushUnique(forbiddenActions, [
+      PR_GATE_ACTION.RUN_DRAFT_GATE,
+      PR_GATE_ACTION.MARK_READY_FOR_REVIEW,
+      PR_GATE_ACTION.REQUEST_COPILOT_REVIEW,
+      PR_GATE_ACTION.DECLARE_MERGE_READY,
+    ]);
+    return buildResult({
+      repo: input.repo ?? null,
+      pr: Number.isInteger(input.pr) ? input.pr : null,
+      currentHeadSha,
+      lifecycleState,
+      loopDisposition: loopDisposition ?? LOOP_DISPOSITION.CLEAN_CONVERGED,
+      gateBoundary: PR_GATE_BOUNDARY.PRE_APPROVAL_GATE_WINDOW,
+      draftGate,
+      preApprovalGate,
+      allowedNextActions,
+      forbiddenActions,
+      nextAction: PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE,
+      reason: "The current head has a clean settled post-draft review cycle, so `pre_approval_gate` is now the next legal boundary.",
+    });
+  }
+
+  pushUnique(allowedNextActions, [PR_GATE_ACTION.REPORT_BLOCKED]);
+  pushUnique(forbiddenActions, [
+    PR_GATE_ACTION.RUN_DRAFT_GATE,
+    PR_GATE_ACTION.MARK_READY_FOR_REVIEW,
+    PR_GATE_ACTION.REQUEST_COPILOT_REVIEW,
+    PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE,
+    PR_GATE_ACTION.DECLARE_MERGE_READY,
+  ]);
+  return buildResult({
+    repo: input.repo ?? null,
+    pr: Number.isInteger(input.pr) ? input.pr : null,
+    currentHeadSha,
+    lifecycleState,
+    loopDisposition: loopDisposition ?? LOOP_DISPOSITION.BLOCKED,
+    gateBoundary: PR_GATE_BOUNDARY.BLOCKED,
+    draftGate,
+    preApprovalGate,
+    allowedNextActions,
+    forbiddenActions,
+    nextAction: PR_GATE_ACTION.REPORT_BLOCKED,
+    reason: "The PR gate-boundary evaluator could not map this lifecycle state to a legal gate transition; reconcile before continuing.",
+  });
+}

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -15,6 +15,7 @@ export const PR_GATE_ACTION = Object.freeze({
   MARK_READY_FOR_REVIEW: "mark_ready_for_review",
   REQUEST_COPILOT_REVIEW: "request_copilot_review",
   WAIT_FOR_COPILOT_REVIEW: "wait_for_copilot_review",
+  WAIT_FOR_CI: "wait_for_ci",
   ADDRESS_REVIEW_FEEDBACK: "address_review_feedback",
   REPLY_RESOLVE_REVIEW_THREADS: "reply_resolve_review_threads",
   REREQUEST_COPILOT_REVIEW: "rerequest_copilot_review",
@@ -234,7 +235,11 @@ export function evaluatePrGateCoordination(input = {}) {
   }
 
   if (lifecycleState === STATE.WAITING_FOR_COPILOT_REVIEW || lifecycleState === STATE.WAITING_FOR_CI) {
-    pushUnique(allowedNextActions, [PR_GATE_ACTION.WAIT_FOR_COPILOT_REVIEW]);
+    const waitAction = lifecycleState === STATE.WAITING_FOR_CI
+      ? PR_GATE_ACTION.WAIT_FOR_CI
+      : PR_GATE_ACTION.WAIT_FOR_COPILOT_REVIEW;
+
+    pushUnique(allowedNextActions, [waitAction]);
     pushUnique(forbiddenActions, postDraftForbidden);
     return buildResult({
       repo: input.repo ?? null,
@@ -247,8 +252,10 @@ export function evaluatePrGateCoordination(input = {}) {
       preApprovalGate,
       allowedNextActions,
       forbiddenActions,
-      nextAction: PR_GATE_ACTION.WAIT_FOR_COPILOT_REVIEW,
-      reason: "The post-draft review cycle is still pending, so `pre_approval_gate` remains illegal until the current-head review cycle settles.",
+      nextAction: waitAction,
+      reason: lifecycleState === STATE.WAITING_FOR_CI
+        ? "The post-draft review cycle is waiting on current-head CI, so `pre_approval_gate` remains illegal until CI settles cleanly."
+        : "The post-draft review cycle is still pending on Copilot review, so `pre_approval_gate` remains illegal until the current-head review cycle settles.",
     });
   }
 

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -65,7 +65,7 @@ function toGateStatus(comment, marker, currentHeadSha) {
     verdict: normalizedComment.verdict,
     findingsSummary: normalizedComment.findingsSummary,
     nextAction: normalizedComment.nextAction,
-    contractComplete: normalizedMarker.contractComplete,
+    contractComplete: normalizedMarker.visible && markerHeadMatches && normalizedMarker.contractComplete,
     currentHeadClean: normalizedMarker.visible && markerHeadMatches && normalizedMarker.verdict === "clean" && normalizedMarker.contractComplete,
   };
 }

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -53,6 +53,22 @@ test("draft PR forbids mark-ready until current-head clean draft gate evidence e
   assert(result.forbiddenActions.includes(PR_GATE_ACTION.MARK_READY_FOR_REVIEW));
 });
 
+test("stale gate markers do not report current-head contract completeness", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "def56789abcdef",
+    prDraft: false,
+    lifecycleState: STATE.PR_READY_NO_FEEDBACK,
+    loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
+    draftGate: gate({ visible: true, headSha: "c94679e", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "c94679e", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.equal(result.draftGate.currentHead, false);
+  assert.equal(result.draftGate.contractComplete, false);
+  assert.equal(result.draftGate.currentHeadClean, false);
+});
+
 test("ready PR with no review yet forbids pre-approval gate and requests Copilot review next", () => {
   const result = evaluatePrGateCoordination({
     pr: 266,

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  evaluatePrGateCoordination,
+  PR_GATE_ACTION,
+  PR_GATE_BOUNDARY,
+} from "../src/loop/pr-gate-coordination.mjs";
+import { LOOP_DISPOSITION, STATE } from "../src/loop/copilot-loop-state.mjs";
+
+function gate({ visible = false, headSha = null, verdict = null, contractComplete = false } = {}) {
+  return {
+    visible,
+    headSha,
+    verdict,
+    contractComplete,
+  };
+}
+
+test("draft PR only allows mark-ready after current-head clean draft gate evidence", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 10,
+    currentHeadSha: "abc123456789",
+    prDraft: true,
+    lifecycleState: STATE.PR_DRAFT,
+    loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
+    draftGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.equal(result.gateBoundary, PR_GATE_BOUNDARY.DRAFT_REVIEW);
+  assert.equal(result.nextAction, PR_GATE_ACTION.MARK_READY_FOR_REVIEW);
+  assert(result.allowedNextActions.includes(PR_GATE_ACTION.RUN_DRAFT_GATE));
+  assert(result.allowedNextActions.includes(PR_GATE_ACTION.MARK_READY_FOR_REVIEW));
+  assert(result.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert.equal(result.draftGate.currentHead, true);
+  assert.equal(result.draftGate.currentHeadClean, true);
+});
+
+test("ready PR with no review yet forbids pre-approval gate and requests Copilot review next", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "def56789",
+    prDraft: false,
+    lifecycleState: STATE.PR_READY_NO_FEEDBACK,
+    loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
+    draftGate: gate({ visible: true, headSha: "c94679e", verdict: "clean" }),
+    draftGateMarker: gate({ visible: false }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.gateBoundary, PR_GATE_BOUNDARY.POST_DRAFT_EXTERNAL_REVIEW);
+  assert.equal(result.nextAction, PR_GATE_ACTION.REQUEST_COPILOT_REVIEW);
+  assert(result.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert.equal(result.draftGate.visible, true);
+  assert.equal(result.draftGate.currentHead, false);
+});
+
+test("clean settled current-head review opens the pre-approval gate window", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    loopDisposition: LOOP_DISPOSITION.CLEAN_CONVERGED,
+    sameHeadCleanConverged: true,
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.gateBoundary, PR_GATE_BOUNDARY.PRE_APPROVAL_GATE_WINDOW);
+  assert.equal(result.nextAction, PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE);
+  assert(result.allowedNextActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert(!result.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
+});
+
+test("current-head clean pre-approval evidence advances to final approval boundary", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    loopDisposition: LOOP_DISPOSITION.CLEAN_CONVERGED,
+    sameHeadCleanConverged: true,
+    preApprovalGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
+    preApprovalGateMarker: gate({ visible: true, headSha: "fedcba9", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.equal(result.gateBoundary, PR_GATE_BOUNDARY.FINAL_APPROVAL_READY);
+  assert.equal(result.nextAction, PR_GATE_ACTION.AWAIT_FINAL_HUMAN_APPROVAL);
+  assert.equal(result.preApprovalGate.currentHead, true);
+  assert.equal(result.preApprovalGate.currentHeadClean, true);
+});

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -89,6 +89,20 @@ test("ready PR with no review yet forbids pre-approval gate and requests Copilot
   assert.equal(result.draftGate.currentHead, false);
 });
 
+test("waiting_for_ci recommends a dedicated wait-for-ci action", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "def56789abcdef",
+    prDraft: false,
+    lifecycleState: STATE.WAITING_FOR_CI,
+    loopDisposition: LOOP_DISPOSITION.PENDING,
+  });
+
+  assert.equal(result.nextAction, PR_GATE_ACTION.WAIT_FOR_CI);
+  assert(result.allowedNextActions.includes(PR_GATE_ACTION.WAIT_FOR_CI));
+  assert.match(result.reason, /waiting on current-head CI/i);
+});
+
 test("clean settled current-head review opens the pre-approval gate window", () => {
   const result = evaluatePrGateCoordination({
     pr: 266,

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -32,9 +32,25 @@ test("draft PR only allows mark-ready after current-head clean draft gate eviden
   assert.equal(result.nextAction, PR_GATE_ACTION.MARK_READY_FOR_REVIEW);
   assert(result.allowedNextActions.includes(PR_GATE_ACTION.RUN_DRAFT_GATE));
   assert(result.allowedNextActions.includes(PR_GATE_ACTION.MARK_READY_FOR_REVIEW));
+  assert(!result.forbiddenActions.includes(PR_GATE_ACTION.MARK_READY_FOR_REVIEW));
   assert(result.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
   assert.equal(result.draftGate.currentHead, true);
   assert.equal(result.draftGate.currentHeadClean, true);
+});
+
+test("draft PR forbids mark-ready until current-head clean draft gate evidence exists", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 10,
+    currentHeadSha: "abc123456789",
+    prDraft: true,
+    lifecycleState: STATE.PR_DRAFT,
+    loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
+    draftGate: gate({ visible: true, headSha: "old1111", verdict: "clean" }),
+    draftGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.nextAction, PR_GATE_ACTION.RUN_DRAFT_GATE);
+  assert(result.forbiddenActions.includes(PR_GATE_ACTION.MARK_READY_FOR_REVIEW));
 });
 
 test("ready PR with no review yet forbids pre-approval gate and requests Copilot review next", () => {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -417,6 +417,24 @@ Success output shape:
 Failure behavior:
 - malformed arguments emit `{ "ok": false, "error": "...", "usage": "..." }` on stderr and exit non-zero
 - contradictory head-SHA requests or unexpected `gh` failures emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero
+- `pre_approval_gate` upserts fail closed when `detect-pr-gate-coordination-state.mjs` reports that `run_pre_approval_gate` is still illegal for the current head
+
+### `scripts/loop/detect-pr-gate-coordination-state.mjs`
+
+Fetches the live PR facts needed to answer which gate/transition is legal next for a pull request. It combines the shared Copilot loop-state machine with visible `draft_gate` / `pre_approval_gate` evidence, then emits one explicit gate boundary, allowed/forbidden next actions, and a single recommended next step. Use this before entering `pre_approval_gate` and when deciding whether a ready PR should request Copilot review, keep waiting, or stay in feedback resolution.
+
+Required:
+- `--repo <owner/name>`
+- `--pr <number>`
+
+Success output shape:
+- `{ "ok": true, "repo": "owner/repo", "pr": 266, "currentHeadSha": "...", "lifecycleState": "pr_ready_no_feedback", "loopDisposition": "action_required", "gateBoundary": "post_draft_external_review", "draftGate": { ... }, "preApprovalGate": { ... }, "allowedNextActions": [ ... ], "forbiddenActions": [ ... ], "nextAction": "request_copilot_review", "reason": "..." }`
+- `draftGate` / `preApprovalGate` report both latest visible evidence (`visible`, `headSha`, `verdict`, `findingsSummary`, `nextAction`) and whether the evidence is current-head + contract-complete (`currentHead`, `contractComplete`, `currentHeadClean`)
+- `forbiddenActions` includes `run_pre_approval_gate` whenever the post-draft review cycle has not yet settled for the current head
+
+Failure behavior:
+- malformed arguments emit `{ "ok": false, "error": "...", "usage": "..." }` on stderr and exit non-zero
+- `gh` failures and malformed `gh` JSON emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero
 
 ### `scripts/github/detect-gate-review-evidence.mjs`
 

--- a/scripts/github/upsert-gate-review-comment.mjs
+++ b/scripts/github/upsert-gate-review-comment.mjs
@@ -4,8 +4,8 @@ import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.
 import { truncateText } from "../../packages/core/src/bash-exit-one.mjs";
 import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import { detectGateReviewEvidence } from "./detect-gate-review-evidence.mjs";
-import { detectPrGateCoordinationState } from "../loop/detect-pr-gate-coordination-state.mjs";
-import { PR_GATE_ACTION } from "../../packages/core/src/loop/pr-gate-coordination.mjs";
+import { loadPrGateCoordinationContext } from "../loop/detect-pr-gate-coordination-state.mjs";
+import { evaluatePrGateCoordination, PR_GATE_ACTION } from "../../packages/core/src/loop/pr-gate-coordination.mjs";
 
 const GATE_NAMES = new Set(["draft_gate", "pre_approval_gate"]);
 const GATE_VERDICTS = new Set(["clean", "findings_present", "blocked"]);
@@ -385,14 +385,32 @@ async function updateComment({ repo, commentId, body }, { env, ghCommand }) {
 }
 
 export async function upsertGateReviewComment(options, { env = process.env, ghCommand = "gh" } = {}) {
-  if (options.gate === "pre_approval_gate") {
-    const coordination = await detectPrGateCoordinationState({ repo: options.repo, pr: options.pr }, { env, ghCommand });
+  const coordinationContext = options.gate === "pre_approval_gate"
+    ? await loadPrGateCoordinationContext({ repo: options.repo, pr: options.pr }, { env, ghCommand })
+    : null;
+
+  if (coordinationContext) {
+    const coordination = evaluatePrGateCoordination({
+      repo: coordinationContext.repo,
+      pr: coordinationContext.pr,
+      currentHeadSha: coordinationContext.currentHeadSha,
+      prDraft: Boolean(coordinationContext.prData?.isDraft),
+      prClosed: String(coordinationContext.prData?.state || "").toUpperCase() === "CLOSED",
+      prMerged: String(coordinationContext.prData?.state || "").toUpperCase() === "MERGED",
+      lifecycleState: coordinationContext.interpretation.state,
+      loopDisposition: coordinationContext.disposition.loopDisposition,
+      sameHeadCleanConverged: coordinationContext.interpretation.sameHeadCleanConverged,
+      draftGate: coordinationContext.gateEvidence.draftGate,
+      draftGateMarker: coordinationContext.gateEvidence.draftGateMarker,
+      preApprovalGate: coordinationContext.gateEvidence.preApprovalGate,
+      preApprovalGateMarker: coordinationContext.gateEvidence.preApprovalGateMarker,
+    });
     if (coordination.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE)) {
       throw new Error(`Cannot enter ${options.gate} on ${options.repo}#${options.pr}: ${coordination.reason}`);
     }
   }
 
-  const evidence = await detectGateReviewEvidence({ repo: options.repo, pr: options.pr }, { env, ghCommand });
+  const evidence = coordinationContext?.gateEvidence ?? await detectGateReviewEvidence({ repo: options.repo, pr: options.pr }, { env, ghCommand });
   const canonicalHeadSha = resolveRequestedHeadSha(options.headSha, evidence.currentHeadSha);
   const desiredBody = renderGateReviewCommentBody({ ...options, headSha: canonicalHeadSha });
 

--- a/scripts/github/upsert-gate-review-comment.mjs
+++ b/scripts/github/upsert-gate-review-comment.mjs
@@ -4,6 +4,8 @@ import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.
 import { truncateText } from "../../packages/core/src/bash-exit-one.mjs";
 import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import { detectGateReviewEvidence } from "./detect-gate-review-evidence.mjs";
+import { detectPrGateCoordinationState } from "../loop/detect-pr-gate-coordination-state.mjs";
+import { PR_GATE_ACTION } from "../../packages/core/src/loop/pr-gate-coordination.mjs";
 
 const GATE_NAMES = new Set(["draft_gate", "pre_approval_gate"]);
 const GATE_VERDICTS = new Set(["clean", "findings_present", "blocked"]);
@@ -383,6 +385,13 @@ async function updateComment({ repo, commentId, body }, { env, ghCommand }) {
 }
 
 export async function upsertGateReviewComment(options, { env = process.env, ghCommand = "gh" } = {}) {
+  if (options.gate === "pre_approval_gate") {
+    const coordination = await detectPrGateCoordinationState({ repo: options.repo, pr: options.pr }, { env, ghCommand });
+    if (coordination.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE)) {
+      throw new Error(`Cannot enter ${options.gate} on ${options.repo}#${options.pr}: ${coordination.reason}`);
+    }
+  }
+
   const evidence = await detectGateReviewEvidence({ repo: options.repo, pr: options.pr }, { env, ghCommand });
   const canonicalHeadSha = resolveRequestedHeadSha(options.headSha, evidence.currentHeadSha);
   const desiredBody = renderGateReviewCommentBody({ ...options, headSha: canonicalHeadSha });

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -145,7 +145,7 @@ async function fetchPrFacts({ repo, pr }, { env = process.env, ghCommand = "gh" 
   return parseJsonText(result.stdout, { label: "gh pr view" });
 }
 
-export async function detectPrGateCoordinationState(options, runtime = {}) {
+export async function loadPrGateCoordinationContext(options, runtime = {}) {
   const prData = await fetchPrFacts(options, runtime);
   const requestedReviewers = await fetchRequestedReviewers(options, runtime);
   const threadsPayload = await fetchGithubReviewThreadsPayload(options, runtime);
@@ -157,6 +157,10 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
     : null;
   if (!currentHeadSha) {
     throw new Error("Invalid gh pr view payload: missing headRefOid");
+  }
+
+  if (gateEvidence.currentHeadSha !== currentHeadSha) {
+    throw new Error(`PR head changed while loading gate coordination facts for ${options.repo}#${options.pr}; refuse to evaluate mixed-head gate state.`);
   }
 
   const reviewSummary = summarizeCopilotReviews(prData?.reviews, { headSha: currentHeadSha });
@@ -177,20 +181,33 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
   const interpretation = interpretLoopState(snapshot);
   const disposition = summarizeLoopInterpretation(interpretation);
 
-  return evaluatePrGateCoordination({
+  return {
     repo: options.repo,
     pr: options.pr,
     currentHeadSha,
-    prDraft: Boolean(prData?.isDraft),
-    prClosed: String(prData?.state || "").toUpperCase() === "CLOSED",
-    prMerged: String(prData?.state || "").toUpperCase() === "MERGED",
-    lifecycleState: interpretation.state,
-    loopDisposition: disposition.loopDisposition,
-    sameHeadCleanConverged: interpretation.sameHeadCleanConverged,
-    draftGate: gateEvidence.draftGate,
-    draftGateMarker: gateEvidence.draftGateMarker,
-    preApprovalGate: gateEvidence.preApprovalGate,
-    preApprovalGateMarker: gateEvidence.preApprovalGateMarker,
+    prData,
+    gateEvidence,
+    interpretation,
+    disposition,
+  };
+}
+
+export async function detectPrGateCoordinationState(options, runtime = {}) {
+  const context = await loadPrGateCoordinationContext(options, runtime);
+  return evaluatePrGateCoordination({
+    repo: context.repo,
+    pr: context.pr,
+    currentHeadSha: context.currentHeadSha,
+    prDraft: Boolean(context.prData?.isDraft),
+    prClosed: String(context.prData?.state || "").toUpperCase() === "CLOSED",
+    prMerged: String(context.prData?.state || "").toUpperCase() === "MERGED",
+    lifecycleState: context.interpretation.state,
+    loopDisposition: context.disposition.loopDisposition,
+    sameHeadCleanConverged: context.interpretation.sameHeadCleanConverged,
+    draftGate: context.gateEvidence.draftGate,
+    draftGateMarker: context.gateEvidence.draftGateMarker,
+    preApprovalGate: context.gateEvidence.preApprovalGate,
+    preApprovalGateMarker: context.gateEvidence.preApprovalGateMarker,
   });
 }
 

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -236,5 +236,5 @@ async function main() {
 }
 
 if (isDirectCliRun(import.meta.url)) {
-  main();
+  await main();
 }

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+import {
+  formatCliError,
+  isCopilotLogin,
+  isDirectCliRun,
+  parseJsonText,
+  parseReviewThreads,
+  summarizeCopilotReviews,
+} from "../_core-helpers.mjs";
+import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
+import { buildSnapshotFromPrFacts, interpretLoopState, summarizeLoopInterpretation } from "../../packages/core/src/loop/copilot-loop-state.mjs";
+import { evaluatePrGateCoordination } from "../../packages/core/src/loop/pr-gate-coordination.mjs";
+import { fetchGithubReviewThreadsPayload } from "../github/capture-review-threads.mjs";
+import { detectGateReviewEvidence } from "../github/detect-gate-review-evidence.mjs";
+
+const USAGE = `Usage: detect-pr-gate-coordination-state.mjs --repo <owner/name> --pr <number>
+
+Determine which PR gate/transition is legal next for a pull request.
+
+Required:
+  --repo <owner/name>   Repository slug (e.g. owner/repo)
+  --pr <number>         Pull request number
+
+Output (stdout, JSON):
+  {
+    "ok": true,
+    "repo": "owner/repo",
+    "pr": 266,
+    "currentHeadSha": "...",
+    "lifecycleState": "pr_ready_no_feedback",
+    "loopDisposition": "action_required",
+    "gateBoundary": "post_draft_external_review",
+    "draftGate": {
+      "visible": true,
+      "currentHead": false,
+      "contractComplete": false,
+      "currentHeadClean": false,
+      "headSha": "c94679e",
+      "verdict": "clean"
+    },
+    "preApprovalGate": {
+      "visible": false,
+      "currentHead": false,
+      "contractComplete": false,
+      "currentHeadClean": false,
+      "headSha": null,
+      "verdict": null
+    },
+    "allowedNextActions": ["request_copilot_review"],
+    "forbiddenActions": ["run_pre_approval_gate", "declare_merge_ready"],
+    "nextAction": "request_copilot_review",
+    "reason": "..."
+  }
+
+Error output (stderr, JSON):
+  { "ok": false, "error": "...", "usage": "..." }
+  { "ok": false, "error": "..." }
+
+Exit codes:
+  0  Success
+  1  Argument error or gh/runtime failure`.trim();
+
+function parseError(message) {
+  return Object.assign(new Error(message), { usage: USAGE });
+}
+
+export function parseDetectPrGateCoordinationCliArgs(argv) {
+  const args = [...argv];
+  const options = {
+    help: false,
+    repo: undefined,
+    pr: undefined,
+  };
+
+  while (args.length > 0) {
+    const token = args.shift();
+
+    if (token === "--help" || token === "-h") {
+      options.help = true;
+      return options;
+    }
+
+    if (token === "--repo") {
+      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+      continue;
+    }
+
+    if (token === "--pr") {
+      options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+      continue;
+    }
+
+    throw parseError(`Unknown argument: ${token}`);
+  }
+
+  if (options.repo === undefined || options.pr === undefined) {
+    throw parseError("detect-pr-gate-coordination-state requires both --repo <owner/name> and --pr <number>");
+  }
+
+  try {
+    parseRepoSlug(options.repo);
+  } catch (error) {
+    throw parseError(error instanceof Error ? error.message : String(error));
+  }
+
+  return options;
+}
+
+function parseRequestedReviewersPayload(text) {
+  const payload = parseJsonText(text, { label: "gh requested reviewers" });
+  const users = Array.isArray(payload?.users) ? payload.users : [];
+  return {
+    requested: users.some((user) => isCopilotLogin(user?.login)),
+  };
+}
+
+async function fetchRequestedReviewers({ repo, pr }, { env = process.env, ghCommand = "gh" } = {}) {
+  const result = await runChild(
+    ghCommand,
+    ["api", `repos/${repo}/pulls/${pr}/requested_reviewers`],
+    env,
+  );
+
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw new Error(`gh command failed: ${detail}`);
+  }
+
+  return parseRequestedReviewersPayload(result.stdout);
+}
+
+async function fetchPrFacts({ repo, pr }, { env = process.env, ghCommand = "gh" } = {}) {
+  const result = await runChild(
+    ghCommand,
+    ["pr", "view", String(pr), "--repo", repo, "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+    env,
+  );
+
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw new Error(`gh command failed: ${detail}`);
+  }
+
+  return parseJsonText(result.stdout, { label: "gh pr view" });
+}
+
+export async function detectPrGateCoordinationState(options, runtime = {}) {
+  const prData = await fetchPrFacts(options, runtime);
+  const requestedReviewers = await fetchRequestedReviewers(options, runtime);
+  const threadsPayload = await fetchGithubReviewThreadsPayload(options, runtime);
+  const parsedThreads = parseReviewThreads(threadsPayload);
+  const gateEvidence = await detectGateReviewEvidence(options, runtime);
+
+  const currentHeadSha = typeof prData?.headRefOid === "string" && prData.headRefOid.trim().length > 0
+    ? prData.headRefOid.trim()
+    : null;
+  if (!currentHeadSha) {
+    throw new Error("Invalid gh pr view payload: missing headRefOid");
+  }
+
+  const reviewSummary = summarizeCopilotReviews(prData?.reviews, { headSha: currentHeadSha });
+  const reviewRequestStatus = requestedReviewers.requested
+    ? "requested"
+    : (reviewSummary.hasPendingReviewOnCurrentHead ? "already-requested" : "none");
+
+  const snapshot = buildSnapshotFromPrFacts({
+    prData,
+    prNumber: options.pr,
+    copilotReviewRequestStatus: reviewRequestStatus,
+    copilotReviewPresent: reviewSummary.copilotReviewPresent,
+    copilotReviewOnCurrentHead: reviewSummary.hasSubmittedReviewOnCurrentHead,
+    unresolvedThreadCount: parsedThreads.summary.unresolvedThreads,
+    actionableThreadCount: parsedThreads.summary.actionableThreads,
+  });
+
+  const interpretation = interpretLoopState(snapshot);
+  const disposition = summarizeLoopInterpretation(interpretation);
+
+  return evaluatePrGateCoordination({
+    repo: options.repo,
+    pr: options.pr,
+    currentHeadSha,
+    prDraft: Boolean(prData?.isDraft),
+    prClosed: String(prData?.state || "").toUpperCase() === "CLOSED",
+    prMerged: String(prData?.state || "").toUpperCase() === "MERGED",
+    lifecycleState: interpretation.state,
+    loopDisposition: disposition.loopDisposition,
+    sameHeadCleanConverged: interpretation.sameHeadCleanConverged,
+    draftGate: gateEvidence.draftGate,
+    draftGateMarker: gateEvidence.draftGateMarker,
+    preApprovalGate: gateEvidence.preApprovalGate,
+    preApprovalGateMarker: gateEvidence.preApprovalGateMarker,
+  });
+}
+
+async function main() {
+  let options;
+  try {
+    options = parseDetectPrGateCoordinationCliArgs(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${formatCliError(error, { usage: USAGE })}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (options.help) {
+    process.stdout.write(`${USAGE}\n`);
+    return;
+  }
+
+  try {
+    const result = await detectPrGateCoordinationState(options);
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  } catch (error) {
+    process.stderr.write(`${formatCliError(error)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  main();
+}

--- a/skills/copilot-dev-loop/SKILL.md
+++ b/skills/copilot-dev-loop/SKILL.md
@@ -765,6 +765,7 @@ This is the draft-stage gate for the draft → ready-for-review boundary.
   - if you include a failing validation excerpt, keep it focused and truncate it to a deterministic retained-prefix length before posting the comment; the rendered text may include a short truncation marker suffix
   - If the `draft_gate` finds issues, the comment must say that the PR stays draft and needs fixes before retrying.
   - Do not run `gh pr ready` unless a visible `clean` `draft_gate` gate-review comment exists for the current head SHA.
+  - Before any `pre_approval_gate` entry, confirm legality with `node <resolved-skill-scripts>/loop/detect-pr-gate-coordination-state.mjs --repo <owner/name> --pr <number>` and fail closed if `run_pre_approval_gate` is currently forbidden.
   - If the required comment cannot be posted (fail-closed), do not mark the PR ready for review.
   - A gate-review comment for an older head SHA does not satisfy this requirement for the current head.
   - If fixes advance the head SHA, post a new gate-review comment for the new head.

--- a/test/github/upsert-gate-review-comment.test.mjs
+++ b/test/github/upsert-gate-review-comment.test.mjs
@@ -346,14 +346,6 @@ test("upsert-gate-review-comment truncates verbose findings summary before comme
         stdout: '[]\n',
       },
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
-        stdout: '{"headRefOid":"abc1234"}\n',
-      },
-      {
-        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/17/comments?per_page=100"],
-        stdout: '[]\n',
-      },
-      {
         assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f"],
         assertArgContains: [
           "body=Gate review: pre_approval_gate",

--- a/test/github/upsert-gate-review-comment.test.mjs
+++ b/test/github/upsert-gate-review-comment.test.mjs
@@ -261,11 +261,90 @@ test("upsert-gate-review-comment creates a new comment when no same-head marker 
   }
 });
 
+test("upsert-gate-review-comment fails closed when pre-approval gate entry is still illegal", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-illegal-preapproval-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        stdout: '{"number":266,"state":"OPEN","isDraft":false,"headRefOid":"def56789abcdef","reviews":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]}\n',
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/266/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=266"],
+        stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n',
+      },
+      {
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "headRefOid"],
+        stdout: '{"headRefOid":"def56789abcdef"}\n',
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/266/comments?per_page=100"],
+        stdout: `${JSON.stringify([[{
+          id: 11,
+          body: [
+            "Gate review: draft_gate",
+            "Reviewed head SHA: c94679e",
+            "Verdict: clean",
+            "Findings summary: no issues found",
+            "Next action: mark ready for review",
+          ].join("\n"),
+          html_url: "https://github.com/owner/repo/pull/266#issuecomment-11",
+          updated_at: "2026-05-31T20:00:00Z",
+        }]])}\n`,
+      },
+    ]);
+
+    const result = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "266",
+      "--gate", "pre_approval_gate",
+      "--head-sha", "def56789",
+      "--verdict", "clean",
+      "--findings-summary", "no issues found",
+      "--next-action", "await final human approval",
+    ], { env });
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /Cannot enter pre_approval_gate/i);
+    assert.match(payload.error, /post-draft external review cycle has not started yet/i);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("upsert-gate-review-comment truncates verbose findings summary before comment creation", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-verbose-"));
 
   try {
     const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        stdout: '{"number":17,"state":"OPEN","isDraft":false,"headRefOid":"abc1234","reviews":[{"author":{"login":"copilot-pull-request-reviewer"},"state":"COMMENTED","submittedAt":"2026-05-31T20:00:00Z","commit":{"oid":"abc1234"}}],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]}\n',
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=17"],
+        stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n',
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
+        stdout: '{"headRefOid":"abc1234"}\n',
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/17/comments?per_page=100"],
+        stdout: '[]\n',
+      },
       {
         assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
         stdout: '{"headRefOid":"abc1234"}\n',
@@ -284,7 +363,6 @@ test("upsert-gate-review-comment truncates verbose findings summary before comme
         stdout: '{"id":101,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-101"}\n',
       },
     ]);
-
     const result = await runNode([
       "--repo", "owner/repo",
       "--pr", "17",

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import test from "node:test";
+
+const scriptPath = path.resolve("scripts/loop/detect-pr-gate-coordination-state.mjs");
+
+function runNode(args = [], options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(options.execPath ?? process.execPath, [scriptPath, ...args], {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+async function writeGhStub(tempDir, entries) {
+  const sequencePath = path.join(tempDir, "gh-sequence.json");
+  const counterPath = path.join(tempDir, "gh-counter.txt");
+  const ghPath = path.join(tempDir, "gh");
+
+  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
+  await writeFile(counterPath, "0\n", "utf8");
+  await writeFile(
+    ghPath,
+    [
+      "#!/usr/bin/env node",
+      'import { readFileSync, writeFileSync } from "node:fs";',
+      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
+      "const counterPath = process.env.GH_COUNTER_PATH;",
+      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
+      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
+      'if (current >= entries.length) {',
+      '  process.stderr.write(`unexpected extra gh call #${current + 1}: ${process.argv.slice(2).join(" ")}\\n`);',
+      '  process.exit(97);',
+      '}',
+      'const entry = entries[current] ?? { stdout: "{}\\n" };',
+      'writeFileSync(counterPath, String(current + 1));',
+      'const actual = process.argv.slice(2);',
+      'if (entry.assertArgs) {',
+      '  for (const expected of entry.assertArgs) {',
+      '    if (!actual.includes(expected)) {',
+      '      process.stderr.write(`missing expected gh arg: ${expected}\\nactual: ${actual.join(" ")}\\n`);',
+      '      process.exit(98);',
+      '    }',
+      '  }',
+      '}',
+      'if (entry.stderr) process.stderr.write(entry.stderr);',
+      'if (entry.stdout) process.stdout.write(entry.stdout);',
+      'process.exit(entry.exitCode ?? 0);',
+      '',
+    ].join("\n"),
+    "utf8",
+  );
+  await chmod(ghPath, 0o755);
+
+  return {
+    ...process.env,
+    PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
+    GH_SEQUENCE_PATH: sequencePath,
+    GH_COUNTER_PATH: counterPath,
+  };
+}
+
+function jsonLine(value) {
+  return `${JSON.stringify(value)}\n`;
+}
+
+test("detect-pr-gate-coordination-state forbids pre-approval before the post-draft review cycle settles", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-state-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        stdout: jsonLine({
+          number: 266,
+          state: "OPEN",
+          isDraft: false,
+          headRefOid: "def56789abcdef",
+          statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+          reviews: [],
+        }),
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/266/requested_reviewers"],
+        stdout: jsonLine({ users: [], teams: [] }),
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=266"],
+        stdout: jsonLine({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [],
+                },
+              },
+            },
+          },
+        }),
+      },
+      {
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "headRefOid"],
+        stdout: jsonLine({ headRefOid: "def56789abcdef" }),
+      },
+      {
+        assertArgs: ["api", "--paginate", "repos/owner/repo/issues/266/comments?per_page=100"],
+        stdout: jsonLine([[
+          {
+            id: 11,
+            body: [
+              "Gate review: draft_gate",
+              "Reviewed head SHA: c94679e",
+              "Verdict: clean",
+              "Findings summary: no issues found",
+              "Next action: mark ready for review",
+            ].join("\n"),
+            html_url: "https://example.test/comment/11",
+            updated_at: "2026-05-31T20:00:00Z",
+          },
+        ]]),
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "266"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      repo: "owner/repo",
+      pr: 266,
+      currentHeadSha: "def56789abcdef",
+      lifecycleState: "pr_ready_no_feedback",
+      loopDisposition: "action_required",
+      gateBoundary: "post_draft_external_review",
+      draftGate: {
+        visible: true,
+        currentHead: false,
+        headSha: "c94679e",
+        verdict: "clean",
+        findingsSummary: "no issues found",
+        nextAction: "mark ready for review",
+        contractComplete: false,
+        currentHeadClean: false,
+      },
+      preApprovalGate: {
+        visible: false,
+        currentHead: false,
+        headSha: null,
+        verdict: null,
+        findingsSummary: null,
+        nextAction: null,
+        contractComplete: false,
+        currentHeadClean: false,
+      },
+      allowedNextActions: ["request_copilot_review"],
+      forbiddenActions: ["run_draft_gate", "mark_ready_for_review", "run_pre_approval_gate", "declare_merge_ready"],
+      nextAction: "request_copilot_review",
+      reason: "The PR is ready for review but the post-draft external review cycle has not started yet; request Copilot review before any `pre_approval_gate` entry.",
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -181,3 +181,50 @@ test("detect-pr-gate-coordination-state forbids pre-approval before the post-dra
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+
+test("detect-pr-gate-coordination-state fails closed when the PR head changes mid-read", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-head-drift-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        stdout: jsonLine({
+          number: 266,
+          state: "OPEN",
+          isDraft: false,
+          headRefOid: "aaaaaaa1234567",
+          statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+          reviews: [],
+        }),
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/266/requested_reviewers"],
+        stdout: jsonLine({ users: [], teams: [] }),
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=266"],
+        stdout: jsonLine({ data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } }),
+      },
+      {
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "headRefOid"],
+        stdout: jsonLine({ headRefOid: "bbbbbbb7654321" }),
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/266/comments?per_page=100"],
+        stdout: '[]\n',
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "266"], { env });
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /PR head changed while loading gate coordination facts/i);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Add a deterministic PR gate-boundary evaluator for `repo + pr`, wire `pre_approval_gate` comment upserts to fail closed when that boundary is still illegal, and document the new helper on the gate workflow surface.

Closes #268.

## Scope/context

PR #266 showed a sequencing gap: after a clean `draft_gate` and `gh pr ready`, orchestration was still able to jump straight into `pre_approval_gate` before the post-draft review cycle had actually settled. The repo already had strong pieces — loop-state interpretation, gate-evidence detection, and final-approval routing — but it did not yet have one deterministic evaluator that said which boundary was legal next for the current head.

This PR keeps the fix bounded to that missing coordination layer:
- add a pure gate-boundary evaluator in `packages/core`
- expose it through a `repo + pr` CLI helper
- consume it in `upsert-gate-review-comment.mjs` so early `pre_approval_gate` entry fails closed instead of posting misleading current-head evidence
- document the helper and reference it from the gate guidance

## Acceptance criteria

- a deterministic helper exists that answers which PR gate/transition is legal next for a given `repo + pr`
- `pre_approval_gate` entry fails closed while the PR is still draft, immediately post-draft, waiting on review/CI, or still in unresolved feedback resolution
- at least one production caller consumes that deterministic decision instead of relying only on prose sequencing
- regression coverage blocks the PR #266 failure shape with a stale old-head `draft_gate` marker and an unstarted post-draft review cycle
- the change remains scoped to deterministic gate coordination rather than a broad workflow rewrite

## Definition of done

- `packages/core/src/loop/pr-gate-coordination.mjs` models gate-boundary legality as a pure reusable evaluator
- `scripts/loop/detect-pr-gate-coordination-state.mjs` reports the live gate boundary, allowed/forbidden next actions, and recommended next step for a PR
- `scripts/github/upsert-gate-review-comment.mjs` refuses `pre_approval_gate` comment creation when the evaluator still forbids that boundary
- regression tests cover the pure evaluator, the live CLI shape, and the fail-closed upsert path
- `npm run verify` passes locally

## Non-goals

- redefining the entire Copilot PR lifecycle contract from scratch
- broad conductor or approval-flow rewrites
- replacing `detect-copilot-loop-state` or `detect-gate-review-evidence`
- solving every approval/merge policy concern in the same slice
