### PR TITLE
feat: add reusable WebKit UI smoke harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,4 @@ CI currently splits into a small changed-files gate plus parallel `verify` and c
 - `docs/index.md` — start here for active docs and canonical-owner pointers
 - `extension/README.md` — `/dev-loops` command and package-install contract
 - `scripts/README.md` — deterministic script contracts
+- `docs/ui-smoke-harness.md` — reusable local Playwright/WebKit smoke baseline for opted-in UI slices

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ Start here for repository documentation.
 - `docs/gate-review-comment-contract.md`
 - `docs/steering-contract.md`
 - `docs/ui-validation-contract.md`
+- `docs/ui-smoke-harness.md`
 
 ## Active local phase doc
 

--- a/docs/ui-smoke-harness.md
+++ b/docs/ui-smoke-harness.md
@@ -1,0 +1,75 @@
+# Local Playwright/WebKit smoke harness for UI slices
+
+This document defines the minimal reusable local smoke harness/template introduced for issue #124 under umbrella issue #97.
+
+## Purpose
+
+Use this harness when a `dev-loop` slice is explicitly opting into deterministic UI smoke validation for a user-facing HTML/UI/component surface.
+
+The harness is intentionally small:
+- Playwright
+- WebKit only
+- fixture-backed scenarios
+- named screenshot/state artifact capture
+- deterministic local artifact/report locations
+
+It is not a general E2E framework and it does not make browser validation mandatory for non-UI slices.
+
+## Reusable baseline
+
+The reusable baseline lives in:
+- `test/playwright/harness/webkit-smoke-harness.mjs`
+- `playwright.inspect-run-viewer.config.mjs` as the proving reference adoption
+- `test/playwright/inspect-run-viewer.spec.mjs` as the bounded fixture-backed example
+
+The harness exposes three main seams:
+- `createWebkitSmokeConfig(...)` — create the minimal WebKit-only Playwright config with deterministic output/report locations
+- `startFixtureServer(...)` / `stopFixtureServer(...)` — start and stop a bounded local fixture-backed HTTP server for the UI surface under test
+- `captureNamedUiState(...)` — write deterministic named-state artifacts for reviewer consumption
+
+## Adoption path
+
+A new UI slice should:
+
+1. add a small fixture-backed Playwright spec under `test/playwright/`
+2. create a thin config via `createWebkitSmokeConfig({ sliceId, testMatch })`
+3. start the slice-specific fixture server with `startFixtureServer(...)`
+4. exercise only the small explicit UI states needed by the slice acceptance criteria
+5. call `captureNamedUiState(...)` for each named state that should remain reviewable
+
+Keep the per-slice layer thin. The shared harness owns the repeatable WebKit/report/artifact shape; the slice should only own its fixture and explicit assertions.
+
+## Deterministic local paths
+
+Given a `sliceId` of `inspect-run-viewer`, the baseline paths are:
+- Playwright output directory: `test-results/ui-smoke/inspect-run-viewer`
+- HTML report directory: `playwright-report/ui-smoke/inspect-run-viewer`
+- named-state artifacts: `test-results/ui-smoke/inspect-run-viewer/named-states/<state-slug>/`
+
+Each named-state directory currently contains:
+- `screenshot.png`
+- `state.json`
+
+These paths are the local proving ground for later #97 artifact-contract and CI-promotion slices.
+
+## Reference example
+
+The current proving example is the inspect-run viewer smoke suite:
+- fixture input: `test/playwright/fixtures/inspect-run-viewer-fixture.mjs`
+- spec: `test/playwright/inspect-run-viewer.spec.mjs`
+- config: `playwright.inspect-run-viewer.config.mjs`
+- command: `npm run test:playwright:viewer`
+
+The example intentionally covers a small explicit set of viewer states rather than broad end-to-end workflows.
+
+## Limitations and non-goals
+
+This harness does not attempt to provide:
+- multi-browser coverage
+- generalized E2E orchestration
+- large fixture catalogs
+- visual-diff baseline management
+- mandatory CI enforcement for every UI slice
+- a second public workflow entrypoint beside `dev-loop`
+
+CI promotion remains a later bounded decision: first prove the local harness honestly, then require it in CI only when the slice contract warrants that promotion.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "verify": "npm test && npm run test:dev-loop",
     "test": "npm run test:assets && npm run test:extension && npm run test:scripts && npm run test:core",
-    "test:assets": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/dev-loop-init-phase-smoke.test.mjs test/public-facade-doc-contracts.test.mjs test/review-doc-contracts.test.mjs test/issue-intake-doc-contracts.test.mjs test/copilot-review-doc-contracts.test.mjs test/planning-doc-contracts.test.mjs test/ui-validation-contract.test.mjs",
+    "test:assets": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/dev-loop-init-phase-smoke.test.mjs test/public-facade-doc-contracts.test.mjs test/review-doc-contracts.test.mjs test/issue-intake-doc-contracts.test.mjs test/copilot-review-doc-contracts.test.mjs test/planning-doc-contracts.test.mjs test/ui-validation-contract.test.mjs test/ui-smoke-harness-contract.test.mjs",
     "test:extension": "node --import tsx --test --test-reporter ./test/failure-summary-reporter.mjs test/extension-checks.test.mjs test/extension-command-contract.test.mjs test/extension-package-contract.test.mjs test/dev-loops-core.test.mjs test/dev-loops-cli.test.mjs",
     "test:scripts": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/github/*.test.mjs test/loop/*.test.mjs",
     "test:core": "node --test --test-reporter ./test/failure-summary-reporter.mjs packages/core/test/*.test.mjs",

--- a/playwright.inspect-run-viewer.config.mjs
+++ b/playwright.inspect-run-viewer.config.mjs
@@ -1,25 +1,8 @@
 import { defineConfig } from "@playwright/test";
 
-export default defineConfig({
-  testDir: "./test/playwright",
+import { createWebkitSmokeConfig } from "./test/playwright/harness/webkit-smoke-harness.mjs";
+
+export default defineConfig(createWebkitSmokeConfig({
+  sliceId: "inspect-run-viewer",
   testMatch: ["inspect-run-viewer.spec.mjs"],
-  timeout: 30_000,
-  fullyParallel: false,
-  retries: 0,
-  outputDir: "test-results/playwright",
-  reporter: [["list"], ["html", { open: "never", outputFolder: "playwright-report/inspect-run-viewer" }]],
-  use: {
-    headless: true,
-    screenshot: "only-on-failure",
-    trace: "retain-on-failure",
-    video: "off",
-  },
-  projects: [
-    {
-      name: "webkit",
-      use: {
-        browserName: "webkit",
-      },
-    },
-  ],
-});
+}));

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -671,7 +671,7 @@ Local WebKit/Playwright smoke path:
    - `npm run playwright:install:safari`
 2. Run the viewer smoke suite:
    - `npm run test:playwright:viewer`
-3. Review screenshots/traces under `test-results/` and the HTML report under `playwright-report/inspect-run-viewer/`
+3. Review screenshots/traces under `test-results/` and the HTML report under `playwright-report/ui-smoke/inspect-run-viewer/`
 4. Optionally hit `/favicon.ico` or an unsupported path to confirm those paths stay deterministic and do not perform snapshot rendering
 5. For deterministic/local test mode, pass `--copilot-input` and `--reviewer-input` fixtures to viewer; these are forwarded to `inspect-run`
 

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -23,7 +23,7 @@ This skill is the public `dev-loop` façade for this repository. It should route
 ## First-slice public routing contract
 
 The authoritative contract is `skills/docs/public-dev-loop-contract.md`; the executable evaluator is exported as `@pi-dev-loops/core/loop/public-dev-loop-routing` and lives in the source repository at `packages/core/src/loop/public-dev-loop-routing.mjs`.
-For UI validation under `dev-loop`, see `docs/ui-validation-contract.md`.
+For UI validation under `dev-loop`, see `docs/ui-validation-contract.md` and `docs/ui-smoke-harness.md`.
 
 Required installed runtime contract docs for this skill are the shared bundled copies under `../docs/` from this skill directory:
 - `../docs/public-dev-loop-contract.md`

--- a/test/loop/ui-smoke-harness.test.mjs
+++ b/test/loop/ui-smoke-harness.test.mjs
@@ -35,6 +35,11 @@ test('createWebkitSmokeConfig returns the minimal reusable WebKit smoke baseline
   assert.equal(config.projects[0].use.browserName, 'webkit');
 });
 
+test('createWebkitSmokeConfig rejects missing testMatch up front', () => {
+  assert.throws(() => createWebkitSmokeConfig({ sliceId: 'inspect-run-viewer' }), /testMatch must include at least one/i);
+  assert.throws(() => createWebkitSmokeConfig({ sliceId: 'inspect-run-viewer', testMatch: [] }), /testMatch must include at least one/i);
+});
+
 test('buildNamedUiStateArtifactPaths derives deterministic screenshot and state paths', () => {
   const paths = buildNamedUiStateArtifactPaths({
     outputDir: 'test-results/ui-smoke/inspect-run-viewer',
@@ -88,6 +93,28 @@ test('captureNamedUiState writes the deterministic screenshot and state artifact
     assert.equal(stateJson.artifacts.state.fileName, 'state.json');
     assert.equal(stateJson.metadata.fixture, 'makeInspectionSnapshot');
     assert.match(stateJson.capturedAt, /^\d{4}-\d{2}-\d{2}T/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('captureNamedUiState accepts an explicit outputDir without testInfo metadata', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ui-smoke-harness-explicit-'));
+
+  try {
+    const artifact = await captureNamedUiState({
+      page: {
+        async screenshot() {},
+      },
+      outputDir: tempDir,
+      sliceId: 'inspect-run-viewer',
+      stateName: 'Fallback only',
+    });
+
+    const stateJson = JSON.parse(await readFile(artifact.statePath, 'utf8'));
+    assert.equal(stateJson.projectName, null);
+    assert.equal(stateJson.testTitle, null);
+    assert.equal(stateJson.testFile, null);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/ui-smoke-harness.test.mjs
+++ b/test/loop/ui-smoke-harness.test.mjs
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+
+import {
+  buildNamedUiStateArtifactPaths,
+  captureNamedUiState,
+  createWebkitSmokeConfig,
+  normalizeUiStateSegment,
+} from '../playwright/harness/webkit-smoke-harness.mjs';
+
+test('normalizeUiStateSegment collapses UI state names into stable path segments', () => {
+  assert.equal(normalizeUiStateSegment(' Current PR / Dashboard '), 'current-pr-dashboard');
+  assert.equal(normalizeUiStateSegment('100% zoom'), '100-zoom');
+  assert.equal(normalizeUiStateSegment('a__b'), 'a-b');
+  assert.throws(() => normalizeUiStateSegment('!!!'), /must contain at least one/i);
+});
+
+test('createWebkitSmokeConfig returns the minimal reusable WebKit smoke baseline', () => {
+  const config = createWebkitSmokeConfig({
+    sliceId: 'inspect-run-viewer',
+    testMatch: ['inspect-run-viewer.spec.mjs'],
+  });
+
+  assert.equal(config.testDir, './test/playwright');
+  assert.deepEqual(config.testMatch, ['inspect-run-viewer.spec.mjs']);
+  assert.equal(config.outputDir, 'test-results/ui-smoke/inspect-run-viewer');
+  assert.deepEqual(config.reporter, [['list'], ['html', { open: 'never', outputFolder: 'playwright-report/ui-smoke/inspect-run-viewer' }]]);
+  assert.equal(config.use.headless, true);
+  assert.equal(config.use.screenshot, 'only-on-failure');
+  assert.equal(config.projects.length, 1);
+  assert.equal(config.projects[0].name, 'webkit');
+  assert.equal(config.projects[0].use.browserName, 'webkit');
+});
+
+test('buildNamedUiStateArtifactPaths derives deterministic screenshot and state paths', () => {
+  const paths = buildNamedUiStateArtifactPaths({
+    outputDir: 'test-results/ui-smoke/inspect-run-viewer',
+    sliceId: 'inspect-run-viewer',
+    stateName: 'Current PR dashboard',
+  });
+
+  assert.equal(paths.stateSlug, 'current-pr-dashboard');
+  assert.equal(paths.artifactDir, path.join('test-results/ui-smoke/inspect-run-viewer', 'named-states', 'current-pr-dashboard'));
+  assert.equal(paths.screenshotPath, path.join(paths.artifactDir, 'screenshot.png'));
+  assert.equal(paths.statePath, path.join(paths.artifactDir, 'state.json'));
+});
+
+test('captureNamedUiState writes the deterministic screenshot and state artifact bundle', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ui-smoke-harness-'));
+  const screenshots = [];
+
+  try {
+    const artifact = await captureNamedUiState({
+      page: {
+        async screenshot(options) {
+          screenshots.push(options);
+        },
+      },
+      testInfo: {
+        config: { outputDir: tempDir },
+        project: { name: 'webkit', outputDir: tempDir },
+        title: 'viewer smoke generates named artifacts',
+        file: 'test/playwright/inspect-run-viewer.spec.mjs',
+      },
+      sliceId: 'inspect-run-viewer',
+      stateName: 'Current PR dashboard',
+      metadata: {
+        reviewHint: 'Use this state for the initial dashboard pass.',
+        fixture: 'makeInspectionSnapshot',
+      },
+    });
+
+    assert.equal(screenshots.length, 1);
+    assert.equal(screenshots[0].path, artifact.screenshotPath);
+    assert.equal(screenshots[0].fullPage, true);
+    await stat(artifact.artifactDir);
+
+    const stateJson = JSON.parse(await readFile(artifact.statePath, 'utf8'));
+    assert.equal(stateJson.schemaVersion, 1);
+    assert.equal(stateJson.sliceId, 'inspect-run-viewer');
+    assert.equal(stateJson.stateName, 'Current PR dashboard');
+    assert.equal(stateJson.stateSlug, 'current-pr-dashboard');
+    assert.equal(stateJson.projectName, 'webkit');
+    assert.equal(stateJson.artifacts.screenshot.fileName, 'screenshot.png');
+    assert.equal(stateJson.artifacts.state.fileName, 'state.json');
+    assert.equal(stateJson.metadata.fixture, 'makeInspectionSnapshot');
+    assert.match(stateJson.capturedAt, /^\d{4}-\d{2}-\d{2}T/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/playwright/harness/webkit-smoke-harness.mjs
+++ b/test/playwright/harness/webkit-smoke-harness.mjs
@@ -17,11 +17,26 @@ export function normalizeUiStateSegment(value) {
   return normalized;
 }
 
+function normalizeTestMatch(testMatch) {
+  const normalized = (Array.isArray(testMatch) ? testMatch : [testMatch]).filter((entry) => typeof entry === 'string' && entry.trim().length > 0);
+  if (normalized.length === 0) {
+    throw new Error('testMatch must include at least one non-empty spec pattern');
+  }
+  return normalized;
+}
+
+function requireOutputDir(outputDir) {
+  if (typeof outputDir !== 'string' || outputDir.trim().length === 0) {
+    throw new Error('A deterministic outputDir is required for named UI state artifacts');
+  }
+  return outputDir;
+}
+
 export function createWebkitSmokeConfig({ sliceId, testMatch, testDir = './test/playwright' }) {
   const normalizedSliceId = normalizeUiStateSegment(sliceId);
   return {
     testDir,
-    testMatch: Array.isArray(testMatch) ? testMatch : [testMatch],
+    testMatch: normalizeTestMatch(testMatch),
     timeout: 30_000,
     fullyParallel: false,
     retries: 0,
@@ -47,7 +62,7 @@ export function createWebkitSmokeConfig({ sliceId, testMatch, testDir = './test/
 export function buildNamedUiStateArtifactPaths({ outputDir, sliceId, stateName }) {
   const normalizedSliceId = normalizeUiStateSegment(sliceId);
   const stateSlug = normalizeUiStateSegment(stateName);
-  const artifactDir = path.join(outputDir, 'named-states', stateSlug);
+  const artifactDir = path.join(requireOutputDir(outputDir), 'named-states', stateSlug);
 
   return {
     sliceId: normalizedSliceId,
@@ -75,9 +90,9 @@ export async function captureNamedUiState({ page, testInfo, sliceId, stateName, 
     stateName,
     stateSlug: paths.stateSlug,
     capturedAt: new Date().toISOString(),
-    projectName: testInfo.project?.name ?? null,
-    testTitle: testInfo.title ?? null,
-    testFile: testInfo.file ?? null,
+    projectName: testInfo?.project?.name ?? null,
+    testTitle: testInfo?.title ?? null,
+    testFile: testInfo?.file ?? null,
     artifacts: {
       screenshot: {
         fileName: path.basename(paths.screenshotPath),

--- a/test/playwright/harness/webkit-smoke-harness.mjs
+++ b/test/playwright/harness/webkit-smoke-harness.mjs
@@ -1,0 +1,112 @@
+import { once } from 'node:events';
+import path from 'node:path';
+import { mkdir, writeFile } from 'node:fs/promises';
+
+export function normalizeUiStateSegment(value) {
+  const normalized = String(value ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, '-')
+    .replace(/^-+|-+$/gu, '')
+    .replace(/-{2,}/gu, '-');
+
+  if (normalized.length === 0) {
+    throw new Error('UI state segment must contain at least one alphanumeric character');
+  }
+
+  return normalized;
+}
+
+export function createWebkitSmokeConfig({ sliceId, testMatch, testDir = './test/playwright' }) {
+  const normalizedSliceId = normalizeUiStateSegment(sliceId);
+  return {
+    testDir,
+    testMatch: Array.isArray(testMatch) ? testMatch : [testMatch],
+    timeout: 30_000,
+    fullyParallel: false,
+    retries: 0,
+    outputDir: `test-results/ui-smoke/${normalizedSliceId}`,
+    reporter: [['list'], ['html', { open: 'never', outputFolder: `playwright-report/ui-smoke/${normalizedSliceId}` }]],
+    use: {
+      headless: true,
+      screenshot: 'only-on-failure',
+      trace: 'retain-on-failure',
+      video: 'off',
+    },
+    projects: [
+      {
+        name: 'webkit',
+        use: {
+          browserName: 'webkit',
+        },
+      },
+    ],
+  };
+}
+
+export function buildNamedUiStateArtifactPaths({ outputDir, sliceId, stateName }) {
+  const normalizedSliceId = normalizeUiStateSegment(sliceId);
+  const stateSlug = normalizeUiStateSegment(stateName);
+  const artifactDir = path.join(outputDir, 'named-states', stateSlug);
+
+  return {
+    sliceId: normalizedSliceId,
+    stateSlug,
+    artifactDir,
+    screenshotPath: path.join(artifactDir, 'screenshot.png'),
+    statePath: path.join(artifactDir, 'state.json'),
+  };
+}
+
+export async function captureNamedUiState({ page, testInfo, sliceId, stateName, metadata = {}, fullPage = true, outputDir } = {}) {
+  const resolvedOutputDir = outputDir ?? testInfo?.project?.outputDir ?? testInfo?.config?.outputDir ?? testInfo?.outputDir;
+  const paths = buildNamedUiStateArtifactPaths({
+    outputDir: resolvedOutputDir,
+    sliceId,
+    stateName,
+  });
+
+  await mkdir(paths.artifactDir, { recursive: true });
+  await page.screenshot({ path: paths.screenshotPath, fullPage });
+
+  const stateArtifact = {
+    schemaVersion: 1,
+    sliceId: paths.sliceId,
+    stateName,
+    stateSlug: paths.stateSlug,
+    capturedAt: new Date().toISOString(),
+    projectName: testInfo.project?.name ?? null,
+    testTitle: testInfo.title ?? null,
+    testFile: testInfo.file ?? null,
+    artifacts: {
+      screenshot: {
+        fileName: path.basename(paths.screenshotPath),
+        path: paths.screenshotPath,
+      },
+      state: {
+        fileName: path.basename(paths.statePath),
+        path: paths.statePath,
+      },
+    },
+    metadata,
+  };
+
+  await writeFile(paths.statePath, `${JSON.stringify(stateArtifact, null, 2)}\n`, 'utf8');
+  return paths;
+}
+
+export async function startFixtureServer(createServer) {
+  const server = await createServer();
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address();
+  return {
+    server,
+    url: `http://127.0.0.1:${address.port}`,
+  };
+}
+
+export async function stopFixtureServer(server) {
+  server.closeAllConnections?.();
+  await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+}

--- a/test/playwright/inspect-run-viewer.spec.mjs
+++ b/test/playwright/inspect-run-viewer.spec.mjs
@@ -1,15 +1,15 @@
-import { once } from "node:events";
-
 import { test, expect } from "@playwright/test";
 
 import { createInspectRunViewerServer } from "../../scripts/loop/inspect-run-viewer.mjs";
+import { captureNamedUiState, startFixtureServer, stopFixtureServer } from "./harness/webkit-smoke-harness.mjs";
 import { makeInspectionSnapshot } from "./fixtures/inspect-run-viewer-fixture.mjs";
 
 async function startViewer(snapshot = makeInspectionSnapshot(), assignedPullRequests = []) {
   const normalizedAssignedPullRequests = assignedPullRequests.some((entry) => entry?.target?.repo === "owner/repo" && entry?.target?.pr === 55)
     ? assignedPullRequests
     : [{ target: { repo: "owner/repo", pr: 55 }, title: "Current PR" }, ...assignedPullRequests];
-  const server = createInspectRunViewerServer(
+
+  return startFixtureServer(() => createInspectRunViewerServer(
     { repo: "owner/repo", pr: "55", host: "127.0.0.1", port: 0 },
     {
       adapter: {
@@ -21,16 +21,7 @@ async function startViewer(snapshot = makeInspectionSnapshot(), assignedPullRequ
         },
       },
     },
-  );
-
-  server.listen(0, "127.0.0.1");
-  await once(server, "listening");
-
-  const address = server.address();
-  return {
-    server,
-    url: `http://127.0.0.1:${address.port}`,
-  };
+  ));
 }
 
 async function waitForMermaidGraph(page) {
@@ -173,13 +164,19 @@ test("webkit renders the Mermaid-first inspect-run viewer and captures a screens
     await page.locator(".inspection-details > summary").click();
     await expect(page.getByRole("link", { name: /\/snapshot\.json\?repo=owner%2Frepo&pr=55/ })).toBeVisible();
 
-    await page.screenshot({
-      path: testInfo.outputPath("inspect-run-viewer-webkit.png"),
-      fullPage: true,
+    await captureNamedUiState({
+      page,
+      testInfo,
+      sliceId: "inspect-run-viewer",
+      stateName: "Current PR dashboard",
+      metadata: {
+        fixture: "makeInspectionSnapshot",
+        route: "/",
+        reviewHint: "Use this state for the reusable dashboard smoke baseline.",
+      },
     });
   } finally {
-    server.closeAllConnections?.();
-    await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    await stopFixtureServer(server);
   }
 });
 
@@ -210,13 +207,19 @@ test("webkit shows checkpoint-only graph uncertainty without guessing missing tr
     await expect(page.getByText(/copilot layer:\s*current\s*current state unavailable; current state unavailable; full authoritative state machine shown; transition data unavailable in this snapshot/i)).toBeVisible();
     await expect(page.getByText(/reviewer layer:\s*current\s*current state unavailable; current state unavailable; full authoritative state machine shown; transition data unavailable in this snapshot/i)).toBeVisible();
 
-    await page.screenshot({
-      path: testInfo.outputPath("inspect-run-viewer-checkpoint-webkit.png"),
-      fullPage: true,
+    await captureNamedUiState({
+      page,
+      testInfo,
+      sliceId: "inspect-run-viewer",
+      stateName: "Checkpoint only graph uncertainty",
+      metadata: {
+        fixture: "makeInspectionSnapshot",
+        route: "/",
+        reviewHint: "Confirms the harness can capture an uncertainty state without inferred transitions.",
+      },
     });
   } finally {
-    server.closeAllConnections?.();
-    await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    await stopFixtureServer(server);
   }
 });
 
@@ -232,13 +235,19 @@ test("webkit shows degraded graph messaging when snapshot trust is partial", asy
     await expect(page.locator(".state-graph-intro")).toHaveCount(0);
     await waitForMermaidGraph(page);
 
-    await page.screenshot({
-      path: testInfo.outputPath("inspect-run-viewer-degraded-webkit.png"),
-      fullPage: true,
+    await captureNamedUiState({
+      page,
+      testInfo,
+      sliceId: "inspect-run-viewer",
+      stateName: "Degraded graph messaging",
+      metadata: {
+        fixture: "makeInspectionSnapshot",
+        route: "/",
+        reviewHint: "Demonstrates the partial-trust path for reusable smoke coverage.",
+      },
     });
   } finally {
-    server.closeAllConnections?.();
-    await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    await stopFixtureServer(server);
   }
 });
 
@@ -276,13 +285,19 @@ test("webkit shows terminal merged states clearly in the Mermaid graph", async (
     await expect(graph).toContainText(/done/);
     await expect(page.getByText(/copilot layer:\s*current\s*done; done; full authoritative state machine shown; no allowed transitions/i)).toBeVisible();
 
-    await page.screenshot({
-      path: testInfo.outputPath("inspect-run-viewer-merged-webkit.png"),
-      fullPage: true,
+    await captureNamedUiState({
+      page,
+      testInfo,
+      sliceId: "inspect-run-viewer",
+      stateName: "Terminal merged state",
+      metadata: {
+        fixture: "makeInspectionSnapshot",
+        route: "/",
+        reviewHint: "Confirms the terminal merged state remains reviewable in WebKit.",
+      },
     });
   } finally {
-    server.closeAllConnections?.();
-    await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    await stopFixtureServer(server);
   }
 });
 
@@ -302,12 +317,18 @@ test("webkit shows the unavailable-state fallback for unavailable snapshots", as
     await expect(page.locator(".mermaid-state-graph")).toHaveCount(0);
     await expect(page.getByText(/Snapshot unavailable, so no state graph can be rendered yet/i)).toBeVisible();
 
-    await page.screenshot({
-      path: testInfo.outputPath("inspect-run-viewer-unavailable-webkit.png"),
-      fullPage: true,
+    await captureNamedUiState({
+      page,
+      testInfo,
+      sliceId: "inspect-run-viewer",
+      stateName: "Unavailable snapshot fallback",
+      metadata: {
+        fixture: "makeInspectionSnapshot",
+        route: "/",
+        reviewHint: "Captures the no-graph fallback for unavailable snapshots.",
+      },
     });
   } finally {
-    server.closeAllConnections?.();
-    await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    await stopFixtureServer(server);
   }
 });

--- a/test/ui-smoke-harness-contract.test.mjs
+++ b/test/ui-smoke-harness-contract.test.mjs
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const fromRepoRoot = (relativePath) => new URL(`../${relativePath}`, import.meta.url);
+const readRepo = (relativePath) => readFile(fromRepoRoot(relativePath), 'utf8');
+
+test('ui smoke harness doc defines the bounded reusable local Playwright/WebKit baseline', async () => {
+  const [doc, readme, indexDoc, devLoopSkill] = await Promise.all([
+    readRepo('docs/ui-smoke-harness.md'),
+    readRepo('README.md'),
+    readRepo('docs/index.md'),
+    readRepo('skills/dev-loop/SKILL.md'),
+  ]);
+
+  assert.match(doc, /minimal reusable local smoke harness\/template/i);
+  assert.match(doc, /Playwright/i);
+  assert.match(doc, /WebKit only/i);
+  assert.match(doc, /fixture-backed/i);
+  assert.match(doc, /named screenshot\/state artifact capture/i);
+  assert.match(doc, /test-results\/ui-smoke\/inspect-run-viewer/i);
+  assert.match(doc, /playwright-report\/ui-smoke\/inspect-run-viewer/i);
+  assert.match(doc, /not a general E2E framework/i);
+  assert.match(doc, /does not make browser validation mandatory for non-UI slices/i);
+
+  assert.match(readme, /docs\/ui-smoke-harness\.md/i);
+  assert.match(indexDoc, /docs\/ui-smoke-harness\.md/i);
+  assert.match(devLoopSkill, /docs\/ui-smoke-harness\.md/i);
+});


### PR DESCRIPTION
## Summary

Add a minimal reusable local Playwright/WebKit smoke harness for opted-in UI slices under `dev-loop`, and prove the pattern against the inspect-run viewer reference suite.

Closes #124.

## Scope/context

This is the first concrete implementation slice under umbrella issue #97 after the UI-validation boundary contract. It keeps `dev-loop` as the only public entrypoint while extracting a reusable local-only harness/template for fixture-backed WebKit smoke coverage.

Scope in this PR:
- add a reusable Playwright/WebKit smoke harness helper for local UI slices
- switch the inspect-run viewer smoke config/spec over to that shared harness
- capture deterministic named-state screenshot/state artifacts plus HTML reports
- document the adoption path, artifact/report locations, and non-goals
- add contract and helper tests for the reusable harness

## Acceptance criteria

- [x] A minimal reusable local Playwright/WebKit smoke harness/template exists in-repo for UI-facing slices.
- [x] The harness/template is explicitly documented as local smoke coverage, not a broad E2E framework.
- [x] The harness/template uses fixture-backed inputs/states rather than nondeterministic live setup.
- [x] The baseline smoke path captures screenshots and writes artifacts/reports to deterministic locations.
- [x] At least one bounded example/reference test demonstrates how a UI slice adopts the harness/template.
- [x] No new public workflow entrypoint is introduced; `dev-loop` remains the only public entrypoint.

## Definition of done

- [x] Reusable minimal harness/template code is added.
- [x] A bounded example/reference smoke test is added.
- [x] Relevant docs are updated for purpose, adoption path, artifact locations, and limitations.
- [x] Durable repo truth is updated in the narrowest correct docs.
- [x] Local validation remains runnable through the existing repo commands plus the explicit viewer smoke command.
- [x] The slice stays bounded to a minimal local harness/template rather than broad browser-test architecture.

## Non-goals

- broad Playwright framework design
- multi-browser coverage beyond the minimal WebKit smoke baseline
- full end-to-end workflow automation
- visual-regression baseline management
- mandatory browser validation for non-UI slices
- introducing a second public workflow entrypoint beside `dev-loop`
