### PR TITLE
docs: define UI artifact contract and CI promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ CI currently splits into a small changed-files gate plus parallel `verify` and c
 - `extension/README.md` — `/dev-loops` command and package-install contract
 - `scripts/README.md` — deterministic script contracts
 - `docs/ui-smoke-harness.md` — reusable local Playwright/WebKit smoke baseline for opted-in UI slices
+- `docs/ui-artifact-contract.md` — screenshot/state artifact contract and bounded CI-promotion rules for UI slices

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Root verification and test commands from `package.json`:
 - `npm run test:dev-loop`
 - `npm run test:playwright:viewer` — explicit viewer/browser smoke, not part of the default root verify path
 
-CI currently splits into a small changed-files gate plus parallel `verify` and conditional `viewer-smoke` jobs: `npm ci` + `npm run verify` still run on every change, while the workspace-local Playwright WebKit cache restore/install and explicit viewer smoke run only when files in the bounded inspect-run viewer surface change.
+CI currently splits into a small changed-files gate plus parallel `verify` and conditional `viewer-smoke` jobs: `npm ci` + `npm run verify` still run on every change, while the workspace-local Playwright WebKit cache restore/install and explicit viewer smoke run only when files in the bounded inspect-run viewer surface or its smoke-path dependencies change.
 
 ## Where to read next
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ Start here for repository documentation.
 - `docs/steering-contract.md`
 - `docs/ui-validation-contract.md`
 - `docs/ui-smoke-harness.md`
+- `docs/ui-artifact-contract.md`
 
 ## Active local phase doc
 

--- a/docs/ui-artifact-contract.md
+++ b/docs/ui-artifact-contract.md
@@ -119,7 +119,7 @@ CI promotion is warranted when one or more of the following become true:
 - a regression-prone UI surface has a stable fixture-backed smoke path
 - the repo already has a bounded changed-files gate that can keep CI promotion narrow
 
-In this repository, the current proving example is the conditional `viewer-smoke` job in `.github/workflows/ci.yml`, which promotes the inspect-run viewer smoke suite only when the bounded viewer surface changes.
+In this repository, the current proving example is the conditional `viewer-smoke` job in `.github/workflows/ci.yml`, which promotes the inspect-run viewer smoke suite only when the bounded viewer surface or its smoke-path dependencies change.
 
 ## Failure policy for CI-promoted slices
 

--- a/docs/ui-artifact-contract.md
+++ b/docs/ui-artifact-contract.md
@@ -1,0 +1,136 @@
+# UI screenshot/state artifact contract and CI promotion rules
+
+This document defines the bounded screenshot/state artifact contract introduced for issue #125 under umbrella issue #97.
+
+## Public entrypoint and scope boundary
+
+- `dev-loop` remains the single public entrypoint for UI validation work.
+- This contract documents the internal artifact shape behind `dev-loop`; it does not introduce a second public workflow name.
+- The contract is intentionally small and reusable for opted-in UI slices that use the local Playwright/WebKit smoke harness from `docs/ui-smoke-harness.md`.
+
+## What a named UI state means here
+
+A **named UI state** is one small explicit render or interaction state that:
+- is directly tied to a slice acceptance criterion, review question, or risk boundary
+- can be reproduced deterministically from a fixture-backed local smoke run
+- has a stable human-readable state name and a deterministic path slug
+- is narrow enough that reviewers can understand what they are looking at without replaying the whole feature manually
+
+Examples from the current inspect-run viewer proving path:
+- `Current PR dashboard`
+- `Checkpoint only graph uncertainty`
+- `Terminal merged state`
+
+## Artifact levels
+
+This contract distinguishes three bounded artifact levels.
+
+### 1. Manual review artifacts
+
+These are screenshots or demo captures created for human discussion only.
+
+- screenshot alone is acceptable here
+- they may live outside the reusable harness path
+- they are not deterministic smoke-validation evidence
+- they do not imply CI enforcement
+
+### 2. Deterministic smoke-validation artifacts
+
+These are the reusable harness artifacts emitted for named UI states.
+
+For this level, a paired state artifact is required:
+- `screenshot.png`
+- `state.json`
+
+Why both are required:
+- the screenshot shows what rendered
+- `state.json` explains which named state it is, which slice produced it, and the minimum metadata needed for review or follow-up automation
+
+### 3. CI-promoted required artifacts
+
+These use the same deterministic artifact shape as smoke-validation artifacts, but the slice is now required to produce them in CI for the relevant PR/branch changes.
+
+If a slice is CI-promoted and the expected artifacts are missing or malformed, validation must fail closed.
+
+## Deterministic path contract
+
+For a slice id of `<sliceId>` and a state slug of `<state-slug>`, the harness path is:
+
+- state directory: `test-results/ui-smoke/<sliceId>/named-states/<state-slug>/`
+- screenshot artifact: `test-results/ui-smoke/<sliceId>/named-states/<state-slug>/screenshot.png`
+- structured state artifact: `test-results/ui-smoke/<sliceId>/named-states/<state-slug>/state.json`
+- HTML report root: `playwright-report/ui-smoke/<sliceId>/`
+
+The harness currently normalizes:
+- `sliceId` into a stable path segment
+- the human-readable state name into `<state-slug>`
+
+## Minimum `state.json` contract
+
+The current reusable harness emits `state.json` with this minimum reviewer-facing metadata:
+- `schemaVersion`
+- `artifactType`
+- `validationLevel`
+- `sliceId`
+- `stateName`
+- `stateSlug`
+- `runId`
+- `capturedAt`
+- `projectName`
+- `testTitle`
+- `testFile`
+- `artifacts.screenshot.fileName`
+- `artifacts.screenshot.relativePath`
+- `artifacts.state.fileName`
+- `artifacts.state.relativePath`
+- `metadata.fixture`
+- `metadata.route`
+- `metadata.reviewHint`
+
+This is intentionally minimal. The contract is not trying to describe every possible UI surface; it is only making the current reusable review inputs explicit.
+
+## When screenshot alone is acceptable
+
+Screenshot alone is acceptable only when the artifact is:
+- a manual review artifact
+- a one-off discussion aid
+- not being presented as deterministic smoke-validation evidence
+- not being required by a CI-promoted slice
+
+## When the paired state artifact is required
+
+The `screenshot.png` + `state.json` pair is required when:
+- the artifact is part of the reusable deterministic smoke harness
+- the slice is handing named UI states to a later reviewer loop
+- the artifact needs to map back to a deterministic local run without guesswork
+- the slice has been promoted into CI-required UI validation
+
+## CI promotion rules
+
+A UI slice may remain local-only when all of the following are true. In other words, local-only validation is still acceptable when:
+- the slice is still proving the first honest local smoke path
+- the UI surface is new, exploratory, or not yet stable enough for durable CI expectations
+- the artifacts are useful for local review but not yet required to protect an established regression boundary
+
+CI promotion is warranted when one or more of the following become true:
+- the UI state is directly part of the slice acceptance criteria for a user-facing surface
+- the local harness path is already deterministic and cheap enough to run in CI
+- reviewers repeatedly depend on the named-state artifacts to approve the slice
+- a regression-prone UI surface has a stable fixture-backed smoke path
+- the repo already has a bounded changed-files gate that can keep CI promotion narrow
+
+In this repository, the current proving example is the conditional `viewer-smoke` job in `.github/workflows/ci.yml`, which promotes the inspect-run viewer smoke suite only when the bounded viewer surface changes.
+
+## Failure policy for CI-promoted slices
+
+When a slice is CI-promoted:
+- missing or malformed `state.json` is a validation failure
+- missing `screenshot.png` is a validation failure
+- mismatched state naming/path conventions are a validation failure
+- the PR should fail closed rather than silently downgrade to screenshot-only review
+
+## Relationship to the local harness and later reviewer loop
+
+- `docs/ui-smoke-harness.md` defines how the local harness captures these artifacts
+- this document defines the reusable artifact contract and when CI should start requiring it
+- later review-loop work should consume this artifact bundle rather than redefine the artifact shape from scratch

--- a/docs/ui-smoke-harness.md
+++ b/docs/ui-smoke-harness.md
@@ -50,7 +50,7 @@ Each named-state directory currently contains:
 - `screenshot.png`
 - `state.json`
 
-These paths are the local proving ground for later #97 artifact-contract and CI-promotion slices.
+These paths are the local proving ground for the reusable artifact contract in `docs/ui-artifact-contract.md` and for later designer-review-loop work.
 
 ## Reference example
 

--- a/docs/ui-smoke-harness.md
+++ b/docs/ui-smoke-harness.md
@@ -72,4 +72,4 @@ This harness does not attempt to provide:
 - mandatory CI enforcement for every UI slice
 - a second public workflow entrypoint beside `dev-loop`
 
-CI promotion remains a later bounded decision: first prove the local harness honestly, then require it in CI only when the slice contract warrants that promotion.
+CI promotion policy is now defined in `docs/ui-artifact-contract.md`: keep the local harness honest first, then promote only the bounded UI slices whose settled contract warrants CI enforcement.

--- a/docs/ui-validation-contract.md
+++ b/docs/ui-validation-contract.md
@@ -56,4 +56,4 @@ The following are intentionally deferred:
 - whether first reusable toolkit helpers should be doc/skill-only or include deterministic helper scripts
 - WebKit-vs-Chromium default decision
 - whether screen recording remains manual or becomes first-class helper tooling
-- CI promotion/enforcement strategy for UI smoke validation
+- CI promotion/enforcement strategy for UI smoke validation (now defined in `docs/ui-artifact-contract.md`)

--- a/docs/ui-validation-contract.md
+++ b/docs/ui-validation-contract.md
@@ -56,4 +56,4 @@ The following are intentionally deferred:
 - whether first reusable toolkit helpers should be doc/skill-only or include deterministic helper scripts
 - WebKit-vs-Chromium default decision
 - whether screen recording remains manual or becomes first-class helper tooling
-- CI promotion/enforcement strategy for UI smoke validation (now defined in `docs/ui-artifact-contract.md`)
+- later workflow consumers beyond the artifact/CI contract already settled in `docs/ui-artifact-contract.md`

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "verify": "npm test && npm run test:dev-loop",
     "test": "npm run test:assets && npm run test:extension && npm run test:scripts && npm run test:core",
-    "test:assets": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/dev-loop-init-phase-smoke.test.mjs test/public-facade-doc-contracts.test.mjs test/review-doc-contracts.test.mjs test/issue-intake-doc-contracts.test.mjs test/copilot-review-doc-contracts.test.mjs test/planning-doc-contracts.test.mjs test/ui-validation-contract.test.mjs test/ui-smoke-harness-contract.test.mjs",
+    "test:assets": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/dev-loop-init-phase-smoke.test.mjs test/public-facade-doc-contracts.test.mjs test/review-doc-contracts.test.mjs test/issue-intake-doc-contracts.test.mjs test/copilot-review-doc-contracts.test.mjs test/planning-doc-contracts.test.mjs test/ui-validation-contract.test.mjs test/ui-smoke-harness-contract.test.mjs test/ui-artifact-contract.test.mjs",
     "test:extension": "node --import tsx --test --test-reporter ./test/failure-summary-reporter.mjs test/extension-checks.test.mjs test/extension-command-contract.test.mjs test/extension-package-contract.test.mjs test/dev-loops-core.test.mjs test/dev-loops-cli.test.mjs",
     "test:scripts": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/github/*.test.mjs test/loop/*.test.mjs",
     "test:core": "node --test --test-reporter ./test/failure-summary-reporter.mjs packages/core/test/*.test.mjs",

--- a/scripts/loop/inspect-run-viewer-ci-changes.mjs
+++ b/scripts/loop/inspect-run-viewer-ci-changes.mjs
@@ -11,6 +11,7 @@ export const INSPECT_RUN_VIEWER_RELEVANT_EXACT_PATHS = Object.freeze([
   "scripts/loop/_inspect-run-viewer-adapter.mjs",
   "scripts/loop/inspect-run-viewer.mjs",
   "scripts/loop/inspect-run-viewer-ci-changes.mjs",
+  "test/playwright/harness/webkit-smoke-harness.mjs",
   "test/playwright/inspect-run-viewer.spec.mjs",
 ]);
 

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -23,7 +23,7 @@ This skill is the public `dev-loop` façade for this repository. It should route
 ## First-slice public routing contract
 
 The authoritative contract is `skills/docs/public-dev-loop-contract.md`; the executable evaluator is exported as `@pi-dev-loops/core/loop/public-dev-loop-routing` and lives in the source repository at `packages/core/src/loop/public-dev-loop-routing.mjs`.
-For UI validation under `dev-loop`, see `docs/ui-validation-contract.md` and `docs/ui-smoke-harness.md`.
+For UI validation under `dev-loop`, see `docs/ui-validation-contract.md`, `docs/ui-smoke-harness.md`, and `docs/ui-artifact-contract.md`.
 
 Required installed runtime contract docs for this skill are the shared bundled copies under `../docs/` from this skill directory:
 - `../docs/public-dev-loop-contract.md`

--- a/test/loop/inspect-run-viewer-ci-changes.test.mjs
+++ b/test/loop/inspect-run-viewer-ci-changes.test.mjs
@@ -16,6 +16,7 @@ test("isInspectRunViewerRelevantPath matches the bounded inspect-run viewer smok
   assert.equal(isInspectRunViewerRelevantPath("package-lock.json"), true);
   assert.equal(isInspectRunViewerRelevantPath("scripts/loop/inspect-run-viewer/rendering.mjs"), true);
   assert.equal(isInspectRunViewerRelevantPath("scripts/loop/inspect-run-viewer-ci-changes.mjs"), true);
+  assert.equal(isInspectRunViewerRelevantPath("test/playwright/harness/webkit-smoke-harness.mjs"), true);
   assert.equal(isInspectRunViewerRelevantPath("test/playwright/inspect-run-viewer.spec.mjs"), true);
   assert.equal(isInspectRunViewerRelevantPath("test/playwright/fixtures/inspect-run-viewer-fixture.mjs"), true);
   assert.equal(isInspectRunViewerRelevantPath("test/playwright/some-other-ui.spec.mjs"), false);
@@ -55,6 +56,7 @@ test("runCli emits github output entries for inspect-run viewer smoke gating", a
     await writeFile(pathsFile, [
       "README.md",
       "playwright.inspect-run-viewer.config.mjs",
+      "test/playwright/harness/webkit-smoke-harness.mjs",
     ].join("\n"), "utf8");
 
     const result = await runCli([
@@ -72,7 +74,7 @@ test("runCli emits github output entries for inspect-run viewer smoke gating", a
     });
 
     assert.equal(result.shouldRun, true);
-    assert.deepEqual(result.relevantPaths, ["playwright.inspect-run-viewer.config.mjs"]);
+    assert.deepEqual(result.relevantPaths, ["playwright.inspect-run-viewer.config.mjs", "test/playwright/harness/webkit-smoke-harness.mjs"]);
 
     const payload = JSON.parse(writes.join(""));
     assert.equal(payload.ok, true);

--- a/test/loop/ui-smoke-harness.test.mjs
+++ b/test/loop/ui-smoke-harness.test.mjs
@@ -75,6 +75,7 @@ test('captureNamedUiState writes the deterministic screenshot and state artifact
       metadata: {
         reviewHint: 'Use this state for the initial dashboard pass.',
         fixture: 'makeInspectionSnapshot',
+        route: '/',
       },
     });
 
@@ -85,13 +86,19 @@ test('captureNamedUiState writes the deterministic screenshot and state artifact
 
     const stateJson = JSON.parse(await readFile(artifact.statePath, 'utf8'));
     assert.equal(stateJson.schemaVersion, 1);
+    assert.equal(stateJson.artifactType, 'named-ui-state');
+    assert.equal(stateJson.validationLevel, 'deterministic-smoke');
     assert.equal(stateJson.sliceId, 'inspect-run-viewer');
     assert.equal(stateJson.stateName, 'Current PR dashboard');
     assert.equal(stateJson.stateSlug, 'current-pr-dashboard');
+    assert.equal(stateJson.runId, 'inspect-run-viewer-current-pr-dashboard-webkit');
     assert.equal(stateJson.projectName, 'webkit');
     assert.equal(stateJson.artifacts.screenshot.fileName, 'screenshot.png');
+    assert.equal(stateJson.artifacts.screenshot.relativePath, 'screenshot.png');
     assert.equal(stateJson.artifacts.state.fileName, 'state.json');
+    assert.equal(stateJson.artifacts.state.relativePath, 'state.json');
     assert.equal(stateJson.metadata.fixture, 'makeInspectionSnapshot');
+    assert.equal(stateJson.metadata.route, '/');
     assert.match(stateJson.capturedAt, /^\d{4}-\d{2}-\d{2}T/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
@@ -115,6 +122,7 @@ test('captureNamedUiState accepts an explicit outputDir without testInfo metadat
     assert.equal(stateJson.projectName, null);
     assert.equal(stateJson.testTitle, null);
     assert.equal(stateJson.testFile, null);
+    assert.equal(stateJson.validationLevel, 'deterministic-smoke');
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/ui-smoke-harness.test.mjs
+++ b/test/loop/ui-smoke-harness.test.mjs
@@ -123,6 +123,9 @@ test('captureNamedUiState accepts an explicit outputDir without testInfo metadat
     assert.equal(stateJson.testTitle, null);
     assert.equal(stateJson.testFile, null);
     assert.equal(stateJson.validationLevel, 'deterministic-smoke');
+    assert.equal(stateJson.metadata.fixture, null);
+    assert.equal(stateJson.metadata.route, null);
+    assert.equal(stateJson.metadata.reviewHint, null);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/ui-smoke-harness.test.mjs
+++ b/test/loop/ui-smoke-harness.test.mjs
@@ -105,6 +105,36 @@ test('captureNamedUiState writes the deterministic screenshot and state artifact
   }
 });
 
+test('captureNamedUiState normalizes undefined metadata contract keys to null', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ui-smoke-harness-metadata-'));
+
+  try {
+    const artifact = await captureNamedUiState({
+      page: {
+        async screenshot() {},
+      },
+      outputDir: tempDir,
+      sliceId: 'inspect-run-viewer',
+      stateName: 'Metadata defaults',
+      metadata: {
+        fixture: undefined,
+        route: undefined,
+        reviewHint: undefined,
+      },
+    });
+
+    const stateJson = JSON.parse(await readFile(artifact.statePath, 'utf8'));
+    assert.equal(Object.hasOwn(stateJson.metadata, 'fixture'), true);
+    assert.equal(Object.hasOwn(stateJson.metadata, 'route'), true);
+    assert.equal(Object.hasOwn(stateJson.metadata, 'reviewHint'), true);
+    assert.equal(stateJson.metadata.fixture, null);
+    assert.equal(stateJson.metadata.route, null);
+    assert.equal(stateJson.metadata.reviewHint, null);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test('captureNamedUiState accepts an explicit outputDir without testInfo metadata', async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ui-smoke-harness-explicit-'));
 

--- a/test/playwright/harness/webkit-smoke-harness.mjs
+++ b/test/playwright/harness/webkit-smoke-harness.mjs
@@ -90,10 +90,10 @@ export async function captureNamedUiState({ page, testInfo, sliceId, stateName, 
   await page.screenshot({ path: paths.screenshotPath, fullPage });
 
   const normalizedMetadata = {
+    ...metadata,
     fixture: metadata.fixture ?? null,
     route: metadata.route ?? null,
     reviewHint: metadata.reviewHint ?? null,
-    ...metadata,
   };
 
   const stateArtifact = {

--- a/test/playwright/harness/webkit-smoke-harness.mjs
+++ b/test/playwright/harness/webkit-smoke-harness.mjs
@@ -89,6 +89,13 @@ export async function captureNamedUiState({ page, testInfo, sliceId, stateName, 
   await mkdir(paths.artifactDir, { recursive: true });
   await page.screenshot({ path: paths.screenshotPath, fullPage });
 
+  const normalizedMetadata = {
+    fixture: metadata.fixture ?? null,
+    route: metadata.route ?? null,
+    reviewHint: metadata.reviewHint ?? null,
+    ...metadata,
+  };
+
   const stateArtifact = {
     schemaVersion: 1,
     artifactType: 'named-ui-state',
@@ -113,7 +120,7 @@ export async function captureNamedUiState({ page, testInfo, sliceId, stateName, 
         path: paths.statePath,
       },
     },
-    metadata,
+    metadata: normalizedMetadata,
   };
 
   await writeFile(paths.statePath, `${JSON.stringify(stateArtifact, null, 2)}\n`, 'utf8');

--- a/test/playwright/harness/webkit-smoke-harness.mjs
+++ b/test/playwright/harness/webkit-smoke-harness.mjs
@@ -32,6 +32,10 @@ function requireOutputDir(outputDir) {
   return outputDir;
 }
 
+function buildRunId({ sliceId, stateSlug, projectName }) {
+  return [sliceId, stateSlug, projectName ?? 'unknown'].map((part) => normalizeUiStateSegment(part)).join('-');
+}
+
 export function createWebkitSmokeConfig({ sliceId, testMatch, testDir = './test/playwright' }) {
   const normalizedSliceId = normalizeUiStateSegment(sliceId);
   return {
@@ -80,26 +84,32 @@ export async function captureNamedUiState({ page, testInfo, sliceId, stateName, 
     sliceId,
     stateName,
   });
+  const projectName = testInfo?.project?.name ?? null;
 
   await mkdir(paths.artifactDir, { recursive: true });
   await page.screenshot({ path: paths.screenshotPath, fullPage });
 
   const stateArtifact = {
     schemaVersion: 1,
+    artifactType: 'named-ui-state',
+    validationLevel: 'deterministic-smoke',
     sliceId: paths.sliceId,
     stateName,
     stateSlug: paths.stateSlug,
+    runId: buildRunId({ sliceId: paths.sliceId, stateSlug: paths.stateSlug, projectName }),
     capturedAt: new Date().toISOString(),
-    projectName: testInfo?.project?.name ?? null,
+    projectName,
     testTitle: testInfo?.title ?? null,
     testFile: testInfo?.file ?? null,
     artifacts: {
       screenshot: {
         fileName: path.basename(paths.screenshotPath),
+        relativePath: path.basename(paths.screenshotPath),
         path: paths.screenshotPath,
       },
       state: {
         fileName: path.basename(paths.statePath),
+        relativePath: path.basename(paths.statePath),
         path: paths.statePath,
       },
     },

--- a/test/review-doc-contracts.test.mjs
+++ b/test/review-doc-contracts.test.mjs
@@ -129,5 +129,5 @@ test("CI gates the Playwright WebKit smoke behind inspect-run viewer change dete
 
   assert.match(readme, /workspace-local Playwright WebKit/i);
   assert.match(readme, /small changed-files gate plus parallel `verify` and conditional `viewer-smoke` jobs/i);
-  assert.match(readme, /run only when files in the bounded inspect-run viewer surface change/i);
+  assert.match(readme, /run only when files in the bounded inspect-run viewer surface or its smoke-path dependencies change/i);
 });

--- a/test/ui-artifact-contract.test.mjs
+++ b/test/ui-artifact-contract.test.mjs
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const fromRepoRoot = (relativePath) => new URL(`../${relativePath}`, import.meta.url);
+const readRepo = (relativePath) => readFile(fromRepoRoot(relativePath), 'utf8');
+
+test('ui artifact contract doc defines named-state artifacts and CI promotion rules', async () => {
+  const [doc, readme, indexDoc, devLoopSkill, ciWorkflow] = await Promise.all([
+    readRepo('docs/ui-artifact-contract.md'),
+    readRepo('README.md'),
+    readRepo('docs/index.md'),
+    readRepo('skills/dev-loop/SKILL.md'),
+    readRepo('.github/workflows/ci.yml'),
+  ]);
+
+  assert.match(doc, /single public entrypoint/i);
+  assert.match(doc, /`dev-loop`/i);
+  assert.match(doc, /named UI state/i);
+  assert.match(doc, /screenshot\.png/i);
+  assert.match(doc, /state\.json/i);
+  assert.match(doc, /test-results\/ui-smoke\/<sliceId>\/named-states\/<state-slug>/i);
+  assert.match(doc, /screenshot alone is acceptable/i);
+  assert.match(doc, /paired state artifact is required/i);
+  assert.match(doc, /CI promotion/i);
+  assert.match(doc, /local-only validation is still acceptable/i);
+  assert.match(doc, /missing or malformed/i);
+  assert.match(doc, /viewer-smoke/i);
+
+  assert.match(readme, /docs\/ui-artifact-contract\.md/i);
+  assert.match(indexDoc, /docs\/ui-artifact-contract\.md/i);
+  assert.match(devLoopSkill, /docs\/ui-artifact-contract\.md/i);
+  assert.match(ciWorkflow, /viewer-smoke:/i);
+});

--- a/test/ui-smoke-harness-contract.test.mjs
+++ b/test/ui-smoke-harness-contract.test.mjs
@@ -20,6 +20,8 @@ test('ui smoke harness doc defines the bounded reusable local Playwright/WebKit 
   assert.match(doc, /named screenshot\/state artifact capture/i);
   assert.match(doc, /test-results\/ui-smoke\/inspect-run-viewer/i);
   assert.match(doc, /playwright-report\/ui-smoke\/inspect-run-viewer/i);
+  assert.match(doc, /docs\/ui-artifact-contract\.md/i);
+  assert.doesNotMatch(doc, /later bounded decision/i);
   assert.match(doc, /not a general E2E framework/i);
   assert.match(doc, /does not make browser validation mandatory for non-UI slices/i);
 


### PR DESCRIPTION
## Summary

Define the reusable screenshot/state artifact contract for opted-in UI slices under `dev-loop`, and document bounded CI-promotion rules grounded in the harness and viewer-smoke path delivered in #124.

Closes #125.

## Scope/context

This follows the merged #124 local harness work under umbrella issue #97. The goal here is to turn the now-real harness output into one durable artifact contract that later UI slices and reviewer loops can reuse without inventing new policy.

Scope in this PR:
- document the named UI state artifact contract and deterministic path rules
- codify when screenshot-only review is acceptable versus when `screenshot.png` + `state.json` are required
- document bounded CI-promotion rules using the current conditional `viewer-smoke` job as the proving example
- tighten the harness state artifact shape so the documented contract is grounded in shipped output
- add contract tests for the new doc and updated state artifact schema

## Acceptance criteria

- [x] A durable repo doc defines a bounded screenshot/state artifact contract for UI slices.
- [x] The contract keeps `dev-loop` as the single public entrypoint and does not introduce a parallel UI workflow name.
- [x] The contract defines named UI states, minimum required artifacts, deterministic naming/path expectations, and minimum reviewer-facing metadata.
- [x] The contract makes clear when screenshot-only review is acceptable and when a paired structured state artifact is required.
- [x] The contract distinguishes local/manual review artifacts from CI-required validation artifacts.
- [x] The contract defines bounded promotion rules for moving a UI slice from local-only validation to CI-required validation.
- [x] The guidance is reusable for future UI slices rather than one-off PR notes.

## Definition of done

- [x] Durable documentation exists for the artifact contract and CI-promotion rules.
- [x] The current reusable harness output matches the documented minimum state-artifact contract.
- [x] Related workflow-facing docs stay aligned with the single-entrypoint `dev-loop` posture.
- [x] Local validation passes for the doc/test/helper updates.
- [x] The slice stays bounded to artifact contract/rules and does not broaden into general browser-toolkit work.

## Non-goals

- implementing a broader Playwright helper stack beyond the minimal harness already merged in #124
- making browser validation mandatory for every `dev-loop` phase
- requiring multi-browser coverage by default
- building a full visual-regression system
- adding a second public workflow entrypoint beside `dev-loop`
- expanding CI beyond the bounded promotion policy documented here
