### PR TITLE
feat: add designer persona UI review loop contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,4 @@ CI currently splits into a small changed-files gate plus parallel `verify` and c
 - `scripts/README.md` — deterministic script contracts
 - `docs/ui-smoke-harness.md` — reusable local Playwright/WebKit smoke baseline for opted-in UI slices
 - `docs/ui-artifact-contract.md` — screenshot/state artifact contract and bounded CI-promotion rules for UI slices
+- `docs/ui-designer-review-loop.md` — designer-persona review loop contract for UI slices

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ Start here for repository documentation.
 - `docs/ui-validation-contract.md`
 - `docs/ui-smoke-harness.md`
 - `docs/ui-artifact-contract.md`
+- `docs/ui-designer-review-loop.md`
 
 ## Active local phase doc
 

--- a/docs/ui-artifact-contract.md
+++ b/docs/ui-artifact-contract.md
@@ -134,3 +134,4 @@ When a slice is CI-promoted:
 - `docs/ui-smoke-harness.md` defines how the local harness captures these artifacts
 - this document defines the reusable artifact contract and when CI should start requiring it
 - later review-loop work should consume this artifact bundle rather than redefine the artifact shape from scratch
+- the current designer-review-loop consumer contract lives in `docs/ui-designer-review-loop.md`

--- a/docs/ui-designer-review-loop.md
+++ b/docs/ui-designer-review-loop.md
@@ -1,0 +1,116 @@
+# Designer-persona review loop for UI slices
+
+This document defines the bounded designer-persona review loop introduced for issue #122 under umbrella issue #97.
+
+## Public entrypoint and dependency boundary
+
+- `dev-loop` remains the single public entrypoint.
+- This review loop is an internal capability behind `dev-loop`; it does not introduce a second public workflow name.
+- The loop depends on the reusable harness from `docs/ui-smoke-harness.md` and the artifact contract from `docs/ui-artifact-contract.md`.
+- The loop is a **consumer** of those earlier slices. It does not redefine browser capture, artifact naming, or CI promotion policy.
+
+## Purpose
+
+The designer-persona review loop turns deterministic UI artifacts into a repeatable next-iteration handoff.
+
+It exists for UI-heavy work where code correctness and smoke-test success are necessary but not sufficient to answer:
+- what visual or interaction problems remain
+- which named UI states still miss the intended bar
+- what the next UI-fix iteration should focus on
+- when the design-review side is satisfied enough to stop iterating
+
+## Required input bundle
+
+The loop requires all of the following inputs before it may run:
+
+1. **Acceptance criteria**
+   - the slice-level UI acceptance criteria the review is judging
+2. **Short review brief**
+   - one bounded note describing what the designer-persona should pay extra attention to
+3. **Deterministic artifact bundle** from the reusable harness/artifact path
+   - `sliceId`
+   - optional report root such as `playwright-report/ui-smoke/<sliceId>/index.html`
+   - one or more named states under `test-results/ui-smoke/<sliceId>/named-states/<state-slug>/`
+   - for each named state:
+     - `stateName`
+     - `screenshotPath`
+     - `statePath`
+
+If any required part of this bundle is missing, incomplete, or ambiguous, the loop fails closed instead of guessing.
+
+## Required output bundle
+
+Every designer-persona pass must produce a bounded structured result with:
+- **Findings**
+  - what is visually or interaction-wise wrong or unclear
+  - which named state it affects
+  - the evidence path(s) that support the finding
+- **Corrective actions**
+  - what should be changed next
+- **Next-iteration focus areas**
+  - the small set of UI items the fixer/developer should prioritize next
+- **Outcome**
+  - exactly one of:
+    - `continue_ui_fix_loop`
+    - `ui_review_satisfied`
+    - `blocked_needs_human_decision`
+
+## Outcome semantics
+
+### `continue_ui_fix_loop`
+
+Use this when findings remain and a normal UI fix iteration should continue.
+
+The handoff goes back to the fixer/developer with:
+- the findings
+- the corrective actions
+- the next-iteration focus areas
+- the same acceptance criteria and artifact contract for the next pass
+
+### `ui_review_satisfied`
+
+Use this when:
+- the named states in scope satisfy the review brief and acceptance criteria closely enough to stop iterating on the UI/design side
+- any remaining issues are minor enough that they do not justify another dedicated UI-fix pass
+
+This does **not** replace normal engineering validation; it only means the designer-persona review loop is satisfied.
+
+### `blocked_needs_human_decision`
+
+Use this when the loop finds a genuine design/product decision that cannot be resolved by another normal UI-fix iteration alone.
+
+Examples:
+- conflicting acceptance cues
+- a tradeoff that requires a product or design decision
+- artifacts that expose a scope contradiction rather than a normal implementation defect
+
+## Fail-closed behavior
+
+The loop fails closed when:
+- required acceptance criteria are missing
+- the review brief is missing or empty
+- the artifact bundle is missing
+- the artifact bundle has no named states
+- a named state lacks `screenshotPath` or `statePath`
+- the work is not actually a UI slice and the loop was requested anyway
+
+When the work is non-UI, the loop does not trigger for non-UI work; it returns a skip outcome instead of pretending to review unrelated artifacts.
+
+## Handoff sequence under `dev-loop`
+
+1. Run or reuse the deterministic local UI smoke path.
+2. Collect the named-state artifact bundle from `test-results/ui-smoke/<sliceId>/named-states/<state-slug>/` and the optional HTML report.
+3. Run the designer-persona review against the acceptance criteria and review brief.
+4. If the outcome is `continue_ui_fix_loop`, hand findings back to the fixer/developer.
+5. Regenerate the artifact bundle after the fix iteration.
+6. Re-run the designer-persona review until the outcome is `ui_review_satisfied` or `blocked_needs_human_decision`.
+
+## Current minimal validation seam
+
+The pure validation helper at `scripts/loop/ui-designer-review-contract.mjs` codifies the fail-closed entry conditions for this loop:
+- non-UI or not-requested work is skipped
+- missing required inputs are blocked
+- incomplete artifact bundles are blocked
+- only a complete artifact bundle is eligible for designer review
+
+This keeps the boundary testable before any later higher-level reviewer orchestration is layered on top.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "verify": "npm test && npm run test:dev-loop",
     "test": "npm run test:assets && npm run test:extension && npm run test:scripts && npm run test:core",
-    "test:assets": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/dev-loop-init-phase-smoke.test.mjs test/public-facade-doc-contracts.test.mjs test/review-doc-contracts.test.mjs test/issue-intake-doc-contracts.test.mjs test/copilot-review-doc-contracts.test.mjs test/planning-doc-contracts.test.mjs test/ui-validation-contract.test.mjs test/ui-smoke-harness-contract.test.mjs test/ui-artifact-contract.test.mjs",
+    "test:assets": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/dev-loop-init-phase-smoke.test.mjs test/public-facade-doc-contracts.test.mjs test/review-doc-contracts.test.mjs test/issue-intake-doc-contracts.test.mjs test/copilot-review-doc-contracts.test.mjs test/planning-doc-contracts.test.mjs test/ui-validation-contract.test.mjs test/ui-smoke-harness-contract.test.mjs test/ui-artifact-contract.test.mjs test/ui-designer-review-loop-contract.test.mjs",
     "test:extension": "node --import tsx --test --test-reporter ./test/failure-summary-reporter.mjs test/extension-checks.test.mjs test/extension-command-contract.test.mjs test/extension-package-contract.test.mjs test/dev-loops-core.test.mjs test/dev-loops-cli.test.mjs",
     "test:scripts": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/github/*.test.mjs test/loop/*.test.mjs",
     "test:core": "node --test --test-reporter ./test/failure-summary-reporter.mjs packages/core/test/*.test.mjs",

--- a/scripts/loop/ui-designer-review-contract.mjs
+++ b/scripts/loop/ui-designer-review-contract.mjs
@@ -1,0 +1,68 @@
+export function validateUiDesignerReviewInput(input = {}) {
+  if (input.workType !== 'ui' || input.uiReviewRequested !== true) {
+    return {
+      ok: true,
+      status: 'skip_non_ui',
+      reason: 'non_ui_or_not_requested',
+      missing: [],
+    };
+  }
+
+  const missing = [];
+  const acceptanceCriteria = Array.isArray(input.acceptanceCriteria) ? input.acceptanceCriteria.filter((entry) => typeof entry === 'string' && entry.trim().length > 0) : [];
+  if (acceptanceCriteria.length === 0) {
+    missing.push('acceptanceCriteria');
+  }
+
+  if (typeof input.reviewBrief !== 'string' || input.reviewBrief.trim().length === 0) {
+    missing.push('reviewBrief');
+  }
+
+  const artifactBundle = input.artifactBundle ?? {};
+  if (typeof artifactBundle.sliceId !== 'string' || artifactBundle.sliceId.trim().length === 0) {
+    missing.push('artifactBundle.sliceId');
+  }
+
+  const namedStates = Array.isArray(artifactBundle.namedStates) ? artifactBundle.namedStates : [];
+  if (namedStates.length === 0) {
+    missing.push('artifactBundle.namedStates');
+  }
+
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      status: 'blocked_missing_required_inputs',
+      reason: 'required_inputs_missing',
+      missing,
+    };
+  }
+
+  const incompleteArtifacts = [];
+  namedStates.forEach((state, index) => {
+    if (typeof state.stateName !== 'string' || state.stateName.trim().length === 0) {
+      incompleteArtifacts.push(`artifactBundle.namedStates[${index}].stateName`);
+    }
+    if (typeof state.screenshotPath !== 'string' || state.screenshotPath.trim().length === 0) {
+      incompleteArtifacts.push(`artifactBundle.namedStates[${index}].screenshotPath`);
+    }
+    if (typeof state.statePath !== 'string' || state.statePath.trim().length === 0) {
+      incompleteArtifacts.push(`artifactBundle.namedStates[${index}].statePath`);
+    }
+  });
+
+  if (incompleteArtifacts.length > 0) {
+    return {
+      ok: false,
+      status: 'blocked_incomplete_artifact_bundle',
+      reason: 'artifact_bundle_incomplete',
+      missing: incompleteArtifacts,
+    };
+  }
+
+  return {
+    ok: true,
+    status: 'ready_for_designer_review',
+    reason: 'artifact_bundle_complete',
+    missing: [],
+  };
+}

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -23,7 +23,7 @@ This skill is the public `dev-loop` façade for this repository. It should route
 ## First-slice public routing contract
 
 The authoritative contract is `skills/docs/public-dev-loop-contract.md`; the executable evaluator is exported as `@pi-dev-loops/core/loop/public-dev-loop-routing` and lives in the source repository at `packages/core/src/loop/public-dev-loop-routing.mjs`.
-For UI validation under `dev-loop`, see `docs/ui-validation-contract.md`, `docs/ui-smoke-harness.md`, and `docs/ui-artifact-contract.md`.
+For UI validation under `dev-loop`, see `docs/ui-validation-contract.md`, `docs/ui-smoke-harness.md`, `docs/ui-artifact-contract.md`, and `docs/ui-designer-review-loop.md`.
 
 Required installed runtime contract docs for this skill are the shared bundled copies under `../docs/` from this skill directory:
 - `../docs/public-dev-loop-contract.md`

--- a/skills/dev-loop/templates/ui-designer-review.md
+++ b/skills/dev-loop/templates/ui-designer-review.md
@@ -1,0 +1,27 @@
+# UI designer-persona review
+
+## Input bundle
+- Acceptance criteria:
+- Review brief:
+- Artifact bundle root:
+- Named states reviewed:
+
+## Findings
+- state:
+  - observation:
+  - evidence:
+
+## Corrective actions
+- action:
+
+## Next-iteration focus areas
+- focus:
+
+## Outcome
+- choose exactly one:
+  - continue_ui_fix_loop
+  - ui_review_satisfied
+  - blocked_needs_human_decision
+
+## Blocker details when applicable
+- blocker:

--- a/test/loop/ui-designer-review-contract.test.mjs
+++ b/test/loop/ui-designer-review-contract.test.mjs
@@ -1,0 +1,88 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { validateUiDesignerReviewInput } from '../../scripts/loop/ui-designer-review-contract.mjs';
+
+test('validateUiDesignerReviewInput skips non-UI work instead of triggering the designer loop', () => {
+  const result = validateUiDesignerReviewInput({
+    workType: 'cli',
+    uiReviewRequested: false,
+  });
+
+  assert.deepEqual(result, {
+    ok: true,
+    status: 'skip_non_ui',
+    reason: 'non_ui_or_not_requested',
+    missing: [],
+  });
+});
+
+test('validateUiDesignerReviewInput fails closed when required review inputs are missing', () => {
+  const result = validateUiDesignerReviewInput({
+    workType: 'ui',
+    uiReviewRequested: true,
+    acceptanceCriteria: [],
+    reviewBrief: '',
+    artifactBundle: {
+      sliceId: 'inspect-run-viewer',
+      namedStates: [],
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 'blocked_missing_required_inputs');
+  assert.deepEqual(result.missing, [
+    'acceptanceCriteria',
+    'reviewBrief',
+    'artifactBundle.namedStates',
+  ]);
+});
+
+test('validateUiDesignerReviewInput rejects incomplete named-state artifacts', () => {
+  const result = validateUiDesignerReviewInput({
+    workType: 'ui',
+    uiReviewRequested: true,
+    acceptanceCriteria: ['named dashboard state renders'],
+    reviewBrief: 'Check layout and visual hierarchy.',
+    artifactBundle: {
+      sliceId: 'inspect-run-viewer',
+      namedStates: [
+        {
+          stateName: 'Current PR dashboard',
+          screenshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/screenshot.png',
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 'blocked_incomplete_artifact_bundle');
+  assert.deepEqual(result.missing, ['artifactBundle.namedStates[0].statePath']);
+});
+
+test('validateUiDesignerReviewInput accepts the artifact bundle from the reusable harness path', () => {
+  const result = validateUiDesignerReviewInput({
+    workType: 'ui',
+    uiReviewRequested: true,
+    acceptanceCriteria: ['named dashboard state renders'],
+    reviewBrief: 'Check layout and visual hierarchy.',
+    artifactBundle: {
+      sliceId: 'inspect-run-viewer',
+      reportPath: 'playwright-report/ui-smoke/inspect-run-viewer/index.html',
+      namedStates: [
+        {
+          stateName: 'Current PR dashboard',
+          screenshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/screenshot.png',
+          statePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/state.json',
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(result, {
+    ok: true,
+    status: 'ready_for_designer_review',
+    reason: 'artifact_bundle_complete',
+    missing: [],
+  });
+});

--- a/test/ui-designer-review-loop-contract.test.mjs
+++ b/test/ui-designer-review-loop-contract.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const fromRepoRoot = (relativePath) => new URL(`../${relativePath}`, import.meta.url);
+const readRepo = (relativePath) => readFile(fromRepoRoot(relativePath), 'utf8');
+
+test('designer review loop doc and template define the bounded UI review handoff contract', async () => {
+  const [doc, template, readme, indexDoc, devLoopSkill] = await Promise.all([
+    readRepo('docs/ui-designer-review-loop.md'),
+    readRepo('skills/dev-loop/templates/ui-designer-review.md'),
+    readRepo('README.md'),
+    readRepo('docs/index.md'),
+    readRepo('skills/dev-loop/SKILL.md'),
+  ]);
+
+  assert.match(doc, /designer-persona review loop/i);
+  assert.match(doc, /single public entrypoint/i);
+  assert.match(doc, /`dev-loop`/i);
+  assert.match(doc, /acceptance criteria/i);
+  assert.match(doc, /review brief/i);
+  assert.match(doc, /artifact bundle/i);
+  assert.match(doc, /test-results\/ui-smoke\/<sliceId>\/named-states\/<state-slug>/i);
+  assert.match(doc, /continue_ui_fix_loop/i);
+  assert.match(doc, /ui_review_satisfied/i);
+  assert.match(doc, /blocked_needs_human_decision/i);
+  assert.match(doc, /fails closed/i);
+  assert.match(doc, /does not trigger for non-UI work/i);
+
+  assert.match(template, /continue_ui_fix_loop/i);
+  assert.match(template, /ui_review_satisfied/i);
+  assert.match(template, /blocked_needs_human_decision/i);
+  assert.match(template, /Next-iteration focus areas/i);
+
+  assert.match(readme, /docs\/ui-designer-review-loop\.md/i);
+  assert.match(indexDoc, /docs\/ui-designer-review-loop\.md/i);
+  assert.match(devLoopSkill, /docs\/ui-designer-review-loop\.md/i);
+});


### PR DESCRIPTION
## Summary

Add the bounded designer-persona review loop contract for opted-in UI slices under `dev-loop`, consuming the reusable harness and artifact path already landed in #124 and #125.

Closes #122.

## Scope/context

This is the final planned child slice under umbrella issue #97. It does not build a new UI capture toolkit; instead it defines the review-loop contract that consumes the now-real artifact bundle from the local WebKit smoke harness and screenshot/state artifact contract.

Scope in this PR:
- document the designer-persona review loop and its handoff sequence under `dev-loop`
- codify the required input bundle, output bundle, stop/continue/block outcomes, and fail-closed behavior
- add a minimal pure validation helper for the review-loop entry seam
- add a reusable template for recording designer-persona review outputs
- add contract tests and doc links for the new review-loop surface

## Acceptance criteria

- [x] The repo documents a bounded designer-persona review loop for UI work as a child slice under #97.
- [x] The public workflow entrypoint remains `dev-loop` only.
- [x] The loop explicitly depends on the earlier harness/artifact slices for deterministic capture and artifact naming.
- [x] The input contract is explicit and testable: acceptance criteria, review brief, and deterministic artifact bundle.
- [x] The output contract is explicit and testable: findings, corrective actions, next-iteration focus areas, and explicit continue/stop/block outcomes.
- [x] The loop hands work back to a fixer/developer when findings remain.
- [x] The loop defines fail-closed behavior for missing artifacts, incomplete bundles, and non-UI work.

## Definition of done

- [x] Durable documentation exists for the review-loop contract.
- [x] The review-loop boundary is explicit: this slice owns review consumption, not the underlying capture toolkit.
- [x] The dependency on earlier artifact-producing slices is concrete enough to keep sequencing unambiguous.
- [x] A testable validation seam exists for the fail-closed entry conditions.
- [x] Local validation passes for docs/tests/helpers, plus the existing local UI smoke still proves the artifact path.

## Non-goals

- rebuilding the screenshot/browser toolkit from #124 or the artifact contract from #125
- adding a second public workflow entrypoint beside `dev-loop`
- making designer review mandatory for every `dev-loop` run
- replacing engineering review with design review
- building a general multimodal review-orchestration platform
