### PR TITLE
Add extension-managed inspect-run viewer lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ test-results/
 .DS_Store
 *.log
 .pi/dev-loop-retrospective-checkpoint.json
+
+.pi/ui-servers/

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,6 +1,6 @@
 # Extension scaffold
 
-`pi-dev-loops` ships a lightweight package extension for readiness UX.
+`pi-dev-loops` ships a lightweight package extension for readiness UX plus one bounded local UI lifecycle seam.
 
 Installing the package exposes two thin wrappers over one shared deterministic core:
 - the Pi extension command family rooted at `/dev-loops`
@@ -18,6 +18,16 @@ Installing the package with `pi install git:github.com/mfittko/pi-dev-loops` exp
   - full diagnostic report with explicit pass/fail detail
 - `/dev-loops hide`
   - removes the readiness widget cleanly
+- `/dev-loops ui inspect-run open [--repo <owner/name>]`
+  - start or reuse the managed local inspect-run viewer and best-effort open it in the browser
+- `/dev-loops ui inspect-run resume [--repo <owner/name>]`
+  - reattach only to a confirmed live managed inspect-run viewer; fails closed when nothing live is managed
+- `/dev-loops ui inspect-run status [--repo <owner/name>]`
+  - report one bounded local lifecycle state plus the current URL when known
+- `/dev-loops ui inspect-run stop [--repo <owner/name>]`
+  - stop only the recorded managed inspect-run viewer process
+- `/dev-loops ui inspect-run restart [--repo <owner/name>]`
+  - explicitly restart the recorded managed inspect-run viewer; never kill an unknown listener
 - `pi-dev-loops`
   - defaults to help output for the available subcommands
 - `pi-dev-loops help`
@@ -28,6 +38,37 @@ Installing the package with `pi install git:github.com/mfittko/pi-dev-loops` exp
   - prints the full diagnostic report in shell-friendly output
 - `pi-dev-loops hide`
   - is intentionally unsupported and exits non-zero with a shell-friendly stderr message because `hide` is session-local Pi UI behavior
+
+## Inspect-run local UI lifecycle ownership
+
+This slice is intentionally narrow.
+
+Extension-owned behavior:
+- operator-facing lifecycle UX under `/dev-loops ui inspect-run ...`
+- repo-local managed-instance record at `.pi/ui-servers/inspect-run-viewer.json`
+- safe URL discovery, liveness checks, resume/reattach, stop, and explicit restart handling
+- best-effort browser open
+- fail-closed handling for stale ownership and unknown listeners
+
+Viewer-script-owned behavior:
+- HTTP server implementation
+- viewer HTML/JS rendering
+- inbox and query-state behavior
+- snapshot loading through the existing adapter
+- read-only route behavior and localhost safety rules
+
+Lifecycle states reported by the extension-managed seam are intentionally bounded to:
+- `running`
+- `stopped`
+- `stale_record`
+- `conflict_unmanaged_listener`
+
+Guard rails for this seam:
+- loopback-first local-only posture
+- no remote/public hosting
+- no generic local app platform
+- no background watcher/supervisor behavior
+- no inspect-run viewer redesign
 
 ## Current readiness checks
 
@@ -69,6 +110,7 @@ Root verification and test commands are intentionally explicit:
 - `npm test` runs the current root test suite (`test:assets`, `test:extension`, `test:scripts`, and `test:core`)
 - `npm run test:extension`
 - `npm run test:extension` currently expands to one `node --import tsx --test ...` invocation in `package.json`; prefer the script entrypoint over copying the file list into downstream docs or runbooks
+- `npm run test:scripts`
 - `npm run test:assets`
 - `npm run test:dev-loop`
 - `npm run test:playwright:viewer` remains an explicit viewer/browser smoke, not part of the default root verify path

--- a/extension/README.md
+++ b/extension/README.md
@@ -18,15 +18,15 @@ Installing the package with `pi install git:github.com/mfittko/pi-dev-loops` exp
   - full diagnostic report with explicit pass/fail detail
 - `/dev-loops hide`
   - removes the readiness widget cleanly
-- `/dev-loops ui inspect-run open [--repo <owner/name>]`
+- `/dev-loops inspect open [--repo <owner/name>]`
   - start or reuse the managed local inspect-run viewer and best-effort open it in the browser
-- `/dev-loops ui inspect-run resume [--repo <owner/name>]`
+- `/dev-loops inspect resume [--repo <owner/name>]`
   - reattach only to a confirmed live managed inspect-run viewer; fails closed when nothing live is managed
-- `/dev-loops ui inspect-run status [--repo <owner/name>]`
+- `/dev-loops inspect status [--repo <owner/name>]`
   - report one bounded local lifecycle state plus the current URL when known
-- `/dev-loops ui inspect-run stop [--repo <owner/name>]`
+- `/dev-loops inspect stop [--repo <owner/name>]`
   - stop only the recorded managed inspect-run viewer process
-- `/dev-loops ui inspect-run restart [--repo <owner/name>]`
+- `/dev-loops inspect restart [--repo <owner/name>]`
   - explicitly restart the recorded managed inspect-run viewer; never kill an unknown listener
 - `pi-dev-loops`
   - defaults to help output for the available subcommands
@@ -39,12 +39,12 @@ Installing the package with `pi install git:github.com/mfittko/pi-dev-loops` exp
 - `pi-dev-loops hide`
   - is intentionally unsupported and exits non-zero with a shell-friendly stderr message because `hide` is session-local Pi UI behavior
 
-## Inspect-run local UI lifecycle ownership
+## Inspect local UI lifecycle ownership
 
 This slice is intentionally narrow.
 
 Extension-owned behavior:
-- operator-facing lifecycle UX under `/dev-loops ui inspect-run ...`
+- operator-facing lifecycle UX under `/dev-loops inspect ...`
 - repo-local managed-instance record at `.pi/ui-servers/inspect-run-viewer.json`
 - safe URL discovery, liveness checks, resume/reattach, stop, and explicit restart handling
 - best-effort browser open

--- a/extension/checks.ts
+++ b/extension/checks.ts
@@ -1,11 +1,12 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 
 import {
   collectDevLoopChecks as collectSharedDevLoopChecks,
   DEV_LOOP_CHECK_IDS,
   renderCheckLines,
   summarizeChecks,
-} from "../lib/dev-loops-core.mjs";
+} from '../lib/dev-loops-core.mjs';
+import { createInspectRunViewerLifecycleManager } from '../scripts/loop/inspect-run-viewer/managed-instance.mjs';
 
 export { DEV_LOOP_CHECK_IDS, renderCheckLines, summarizeChecks };
 
@@ -20,7 +21,7 @@ export type DevLoopCheck = {
 
 async function commandExists(pi: ExtensionAPI, command: string): Promise<boolean> {
   try {
-    const result = await pi.exec("bash", ["-lc", `command -v ${command} >/dev/null 2>&1`], {
+    const result = await pi.exec('bash', ['-lc', `command -v ${command} >/dev/null 2>&1`], {
       timeout: 5_000,
     });
     return result.code === 0;
@@ -31,7 +32,7 @@ async function commandExists(pi: ExtensionAPI, command: string): Promise<boolean
 
 async function ghAuthOk(pi: ExtensionAPI): Promise<boolean> {
   try {
-    const result = await pi.exec("bash", ["-lc", "gh auth status >/dev/null 2>&1"], {
+    const result = await pi.exec('bash', ['-lc', 'gh auth status >/dev/null 2>&1'], {
       timeout: 10_000,
     });
     return result.code === 0;
@@ -43,8 +44,8 @@ async function ghAuthOk(pi: ExtensionAPI): Promise<boolean> {
 async function insideGitRepo(pi: ExtensionAPI): Promise<boolean> {
   try {
     const result = await pi.exec(
-      "bash",
-      ["-lc", "git rev-parse --is-inside-work-tree >/dev/null 2>&1"],
+      'bash',
+      ['-lc', 'git rev-parse --is-inside-work-tree >/dev/null 2>&1'],
       { timeout: 5_000 },
     );
     return result.code === 0;
@@ -53,18 +54,43 @@ async function insideGitRepo(pi: ExtensionAPI): Promise<boolean> {
   }
 }
 
-export function createExtensionCoreRuntime(pi: ExtensionAPI) {
+async function getRepoRoot(pi: ExtensionAPI): Promise<string> {
+  const result = await pi.exec('bash', ['-lc', 'git rev-parse --show-toplevel'], {
+    timeout: 10_000,
+  });
+  if (result.code !== 0) {
+    throw new Error('Open Pi inside a git repository before using `/dev-loops ui inspect-run`.');
+  }
+  const repoRoot = `${result.stdout ?? ''}`.trim();
+  if (!repoRoot) {
+    throw new Error('Could not determine the repository root for `/dev-loops ui inspect-run`.');
+  }
+  return repoRoot;
+}
+
+export function createExtensionCoreRuntime(
+  pi: ExtensionAPI,
+  {
+    uiLifecycle = createInspectRunViewerLifecycleManager(),
+    getRepoRoot: getRepoRootOverride,
+  }: {
+    uiLifecycle?: ReturnType<typeof createInspectRunViewerLifecycleManager>;
+    getRepoRoot?: () => Promise<string>;
+  } = {},
+) {
   return {
-    surface: "extension" as const,
+    surface: 'extension' as const,
     commandExists: (command: string) => commandExists(pi, command),
     ghAuthOk: () => ghAuthOk(pi),
     insideGitRepo: () => insideGitRepo(pi),
+    getRepoRoot: () => (getRepoRootOverride ? getRepoRootOverride() : getRepoRoot(pi)),
+    uiLifecycle,
     async getSubagentAvailability() {
-      const ok = await commandExists(pi, "subagent");
+      const ok = await commandExists(pi, 'subagent');
       return {
         ok,
-        availableDetail: "`subagent` command is available.",
-        unavailableDetail: "Install or enable subagent support so `subagent` is available.",
+        availableDetail: '`subagent` command is available.',
+        unavailableDetail: 'Install or enable subagent support so `subagent` is available.',
       };
     },
   };

--- a/extension/checks.ts
+++ b/extension/checks.ts
@@ -59,11 +59,11 @@ async function getRepoRoot(pi: ExtensionAPI): Promise<string> {
     timeout: 10_000,
   });
   if (result.code !== 0) {
-    throw new Error('Open Pi inside a git repository before using `/dev-loops ui inspect-run`.');
+    throw new Error('Open Pi inside a git repository before using `/dev-loops inspect`.');
   }
   const repoRoot = `${result.stdout ?? ''}`.trim();
   if (!repoRoot) {
-    throw new Error('Could not determine the repository root for `/dev-loops ui inspect-run`.');
+    throw new Error('Could not determine the repository root for `/dev-loops inspect`.');
   }
   return repoRoot;
 }

--- a/extension/index.ts
+++ b/extension/index.ts
@@ -74,9 +74,13 @@ export default function (pi: ExtensionAPI, runtimeOverrides = {}) {
           ctx.ui.notify(buildNotificationMessage(result.action as Extract<DevLoopsAction, 'doctor' | 'status'>, result.checks), 'info');
           return;
         case 'ui_inspect_run_result': {
-          const informationalStopped = result.state === 'stopped'
+          const structuredStoppedSuccess = result.state === 'stopped'
+            && result.record === null
+            && (result.action === 'stop' || result.action === 'status');
+          const fallbackStoppedSuccess = result.state === 'stopped'
             && ((result.action === 'stop' && /stopped the managed inspect-run viewer/i.test(result.detail ?? ''))
               || (result.action === 'status' && /no managed inspect-run viewer is recorded/i.test(result.detail ?? '')));
+          const informationalStopped = structuredStoppedSuccess || fallbackStoppedSuccess;
           const notificationLevel = informationalStopped || result.state === 'running' ? 'info' : 'error';
           ctx.ui.setWidget(WIDGET_KEY, buildInspectRunUiLines(result.action as InspectRunUiAction, result), {
             placement: 'belowEditor',

--- a/extension/index.ts
+++ b/extension/index.ts
@@ -74,7 +74,11 @@ export default function (pi: ExtensionAPI, runtimeOverrides = {}) {
           ctx.ui.notify(buildNotificationMessage(result.action as Extract<DevLoopsAction, 'doctor' | 'status'>, result.checks), 'info');
           return;
         case 'ui_inspect_run_result': {
-          const notificationLevel = result.state === 'running' ? 'info' : 'error';
+          const notificationLevel = (result.action === 'stop' && result.state === 'stopped')
+            || (result.action === 'status' && result.state === 'stopped')
+            || result.state === 'running'
+            ? 'info'
+            : 'error';
           ctx.ui.setWidget(WIDGET_KEY, buildInspectRunUiLines(result.action as InspectRunUiAction, result), {
             placement: 'belowEditor',
           });

--- a/extension/index.ts
+++ b/extension/index.ts
@@ -8,12 +8,12 @@ import { executeDevLoopsCommand } from '../lib/dev-loops-core.mjs';
 import { createExtensionCoreRuntime } from './checks.ts';
 import {
   buildHelpLines,
-  buildInspectRunNotification,
-  buildInspectRunUiLines,
+  buildInspectLines,
+  buildInspectNotification,
   buildNotificationMessage,
   buildWidgetLines,
   type DevLoopsAction,
-  type InspectRunUiAction,
+  type InspectAction,
 } from './presentation.ts';
 
 const STATUS_KEY = 'pi-dev-loops';
@@ -50,7 +50,7 @@ export default function (pi: ExtensionAPI, runtimeOverrides = {}) {
   });
 
   pi.registerCommand('dev-loops', {
-    description: 'Manage pi-dev-loops readiness and inspect-run local UI lifecycle: /dev-loops [help|status|doctor|hide|ui inspect-run ...]',
+    description: 'Manage pi-dev-loops readiness and inspect-run local UI lifecycle: /dev-loops [help|status|doctor|hide|inspect ...]',
     handler: async (args, ctx) => {
       const result = await executeDevLoopsCommand({
         input: args,
@@ -73,7 +73,7 @@ export default function (pi: ExtensionAPI, runtimeOverrides = {}) {
           });
           ctx.ui.notify(buildNotificationMessage(result.action as Extract<DevLoopsAction, 'doctor' | 'status'>, result.checks), 'info');
           return;
-        case 'ui_inspect_run_result': {
+        case 'inspect_result': {
           const structuredStoppedSuccess = result.state === 'stopped'
             && result.record === null
             && (result.action === 'stop' || result.action === 'status');
@@ -82,10 +82,10 @@ export default function (pi: ExtensionAPI, runtimeOverrides = {}) {
               || (result.action === 'status' && /no managed inspect-run viewer is recorded/i.test(result.detail ?? '')));
           const informationalStopped = structuredStoppedSuccess || fallbackStoppedSuccess;
           const notificationLevel = informationalStopped || result.state === 'running' ? 'info' : 'error';
-          ctx.ui.setWidget(WIDGET_KEY, buildInspectRunUiLines(result.action as InspectRunUiAction, result), {
+          ctx.ui.setWidget(WIDGET_KEY, buildInspectLines(result.action as InspectAction, result), {
             placement: 'belowEditor',
           });
-          ctx.ui.notify(buildInspectRunNotification(result.action as InspectRunUiAction, result.state), notificationLevel);
+          ctx.ui.notify(buildInspectNotification(result.action as InspectAction, result.state), notificationLevel);
           return;
         }
         case 'malformed':

--- a/extension/index.ts
+++ b/extension/index.ts
@@ -74,11 +74,10 @@ export default function (pi: ExtensionAPI, runtimeOverrides = {}) {
           ctx.ui.notify(buildNotificationMessage(result.action as Extract<DevLoopsAction, 'doctor' | 'status'>, result.checks), 'info');
           return;
         case 'ui_inspect_run_result': {
-          const notificationLevel = (result.action === 'stop' && result.state === 'stopped')
-            || (result.action === 'status' && result.state === 'stopped')
-            || result.state === 'running'
-            ? 'info'
-            : 'error';
+          const informationalStopped = result.state === 'stopped'
+            && ((result.action === 'stop' && /stopped the managed inspect-run viewer/i.test(result.detail ?? ''))
+              || (result.action === 'status' && /no managed inspect-run viewer is recorded/i.test(result.detail ?? '')));
+          const notificationLevel = informationalStopped || result.state === 'running' ? 'info' : 'error';
           ctx.ui.setWidget(WIDGET_KEY, buildInspectRunUiLines(result.action as InspectRunUiAction, result), {
             placement: 'belowEditor',
           });

--- a/extension/index.ts
+++ b/extension/index.ts
@@ -1,25 +1,28 @@
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 
-import { executeDevLoopsCommand } from "../lib/dev-loops-core.mjs";
-import { createExtensionCoreRuntime } from "./checks.ts";
+import { executeDevLoopsCommand } from '../lib/dev-loops-core.mjs';
+import { createExtensionCoreRuntime } from './checks.ts';
 import {
   buildHelpLines,
+  buildInspectRunNotification,
+  buildInspectRunUiLines,
   buildNotificationMessage,
   buildWidgetLines,
   type DevLoopsAction,
-} from "./presentation.ts";
+  type InspectRunUiAction,
+} from './presentation.ts';
 
-const STATUS_KEY = "pi-dev-loops";
-const WIDGET_KEY = "pi-dev-loops.setup";
-const PACKAGED_AGENTS_ROOT = new URL("../.pi/agents/", import.meta.url);
+const STATUS_KEY = 'pi-dev-loops';
+const WIDGET_KEY = 'pi-dev-loops.setup';
+const PACKAGED_AGENTS_ROOT = new URL('../.pi/agents/', import.meta.url);
 
 export function syncPackagedAgents({
   sourceRoot = fileURLToPath(PACKAGED_AGENTS_ROOT),
-  targetRoot = path.join(os.homedir(), ".agents"),
+  targetRoot = path.join(os.homedir(), '.agents'),
 } = {}) {
   if (!fs.existsSync(sourceRoot)) {
     return;
@@ -28,7 +31,7 @@ export function syncPackagedAgents({
   fs.mkdirSync(targetRoot, { recursive: true });
 
   for (const entry of fs.readdirSync(sourceRoot, { withFileTypes: true })) {
-    if (!entry.isFile() || !entry.name.endsWith(".agent.md")) {
+    if (!entry.isFile() || !entry.name.endsWith('.agent.md')) {
       continue;
     }
 
@@ -36,8 +39,8 @@ export function syncPackagedAgents({
   }
 }
 
-export default function (pi: ExtensionAPI) {
-  pi.on("session_start", async (_event, ctx) => {
+export default function (pi: ExtensionAPI, runtimeOverrides = {}) {
+  pi.on('session_start', async (_event, ctx) => {
     try {
       syncPackagedAgents();
     } catch {
@@ -46,38 +49,46 @@ export default function (pi: ExtensionAPI) {
     ctx.ui.setStatus(STATUS_KEY, undefined);
   });
 
-  pi.registerCommand("dev-loops", {
-    description: "Manage pi-dev-loops readiness and compatibility guidance: /dev-loops [help|status|doctor|hide]",
+  pi.registerCommand('dev-loops', {
+    description: 'Manage pi-dev-loops readiness and inspect-run local UI lifecycle: /dev-loops [help|status|doctor|hide|ui inspect-run ...]',
     handler: async (args, ctx) => {
       const result = await executeDevLoopsCommand({
         input: args,
-        surface: "extension",
-        runtime: createExtensionCoreRuntime(pi),
+        surface: 'extension',
+        runtime: createExtensionCoreRuntime(pi, runtimeOverrides),
       });
 
       switch (result.kind) {
-        case "hide":
+        case 'hide':
           ctx.ui.setWidget(WIDGET_KEY, undefined);
-          ctx.ui.notify("pi-dev-loops widget hidden", "info");
+          ctx.ui.notify('pi-dev-loops widget hidden', 'info');
           return;
-        case "help":
-          ctx.ui.setWidget(WIDGET_KEY, buildHelpLines(), { placement: "belowEditor" });
-          ctx.ui.notify("pi-dev-loops help", "info");
+        case 'help':
+          ctx.ui.setWidget(WIDGET_KEY, buildHelpLines(), { placement: 'belowEditor' });
+          ctx.ui.notify('pi-dev-loops help', 'info');
           return;
-        case "checks":
-          ctx.ui.setWidget(WIDGET_KEY, buildWidgetLines(result.action as Extract<DevLoopsAction, "doctor" | "status">, result.checks), {
-            placement: "belowEditor",
+        case 'checks':
+          ctx.ui.setWidget(WIDGET_KEY, buildWidgetLines(result.action as Extract<DevLoopsAction, 'doctor' | 'status'>, result.checks), {
+            placement: 'belowEditor',
           });
-          ctx.ui.notify(buildNotificationMessage(result.action as Extract<DevLoopsAction, "doctor" | "status">, result.checks), "info");
+          ctx.ui.notify(buildNotificationMessage(result.action as Extract<DevLoopsAction, 'doctor' | 'status'>, result.checks), 'info');
           return;
-        case "malformed":
-          ctx.ui.setWidget(WIDGET_KEY, [result.message, ...buildHelpLines()], { placement: "belowEditor" });
-          ctx.ui.notify(`pi-dev-loops ${result.usageAction ?? "help"}: invalid arguments`, "error");
+        case 'ui_inspect_run_result': {
+          const notificationLevel = result.state === 'running' ? 'info' : 'error';
+          ctx.ui.setWidget(WIDGET_KEY, buildInspectRunUiLines(result.action as InspectRunUiAction, result), {
+            placement: 'belowEditor',
+          });
+          ctx.ui.notify(buildInspectRunNotification(result.action as InspectRunUiAction, result.state), notificationLevel);
           return;
-        case "unsupported": {
-          const message = result.message || "This command is not supported here.";
-          ctx.ui.setWidget(WIDGET_KEY, [message, ...buildHelpLines()], { placement: "belowEditor" });
-          ctx.ui.notify(message, "error");
+        }
+        case 'malformed':
+          ctx.ui.setWidget(WIDGET_KEY, [result.message, ...buildHelpLines()], { placement: 'belowEditor' });
+          ctx.ui.notify(`pi-dev-loops ${result.usageAction ?? 'help'}: invalid arguments`, 'error');
+          return;
+        case 'unsupported': {
+          const message = result.message || 'This command is not supported here.';
+          ctx.ui.setWidget(WIDGET_KEY, [message, ...buildHelpLines()], { placement: 'belowEditor' });
+          ctx.ui.notify(message, 'error');
           return;
         }
         default: {

--- a/extension/presentation.ts
+++ b/extension/presentation.ts
@@ -3,7 +3,7 @@ import { DEV_LOOP_CHECK_IDS, summarizeChecks, renderCheckLines } from './checks.
 import { describeReadiness } from '../lib/dev-loops-core.mjs';
 
 export type DevLoopsAction = 'doctor' | 'help' | 'status' | 'hide';
-export type InspectRunUiAction = 'open' | 'resume' | 'status' | 'stop' | 'restart';
+export type InspectAction = 'open' | 'resume' | 'status' | 'stop' | 'restart';
 
 const SETUP_GUIDANCE: Record<(typeof DEV_LOOP_CHECK_IDS)[number], string> = {
   'gh-installed': 'Install GitHub CLI to enable remote GitHub/Copilot workflows.',
@@ -45,11 +45,11 @@ export function buildHelpLines(): string[] {
     '- /dev-loops status',
     '- /dev-loops doctor',
     '- /dev-loops hide',
-    '- /dev-loops ui inspect-run open [--repo <owner/name>]',
-    '- /dev-loops ui inspect-run resume [--repo <owner/name>]',
-    '- /dev-loops ui inspect-run status [--repo <owner/name>]',
-    '- /dev-loops ui inspect-run stop [--repo <owner/name>]',
-    '- /dev-loops ui inspect-run restart [--repo <owner/name>]',
+    '- /dev-loops inspect open [--repo <owner/name>]',
+    '- /dev-loops inspect resume [--repo <owner/name>]',
+    '- /dev-loops inspect status [--repo <owner/name>]',
+    '- /dev-loops inspect stop [--repo <owner/name>]',
+    '- /dev-loops inspect restart [--repo <owner/name>]',
     'Use `pi install git:github.com/mfittko/pi-dev-loops` to install skills and agents; packaged agents sync into `~/.agents/` on session start.',
   ];
 }
@@ -78,9 +78,9 @@ export function buildWidgetLines(action: Extract<DevLoopsAction, 'doctor' | 'sta
   ];
 }
 
-export function buildInspectRunUiLines(action: InspectRunUiAction, result: { state: string; url?: string | null; detail?: string | null; warning?: string | null; repo?: string | null }): string[] {
+export function buildInspectLines(action: InspectAction, result: { state: string; url?: string | null; detail?: string | null; warning?: string | null; repo?: string | null }): string[] {
   const lines = [
-    `inspect-run ${action}`,
+    `inspect ${action}`,
     `State: ${result.state}`,
   ];
   if (result.repo) {
@@ -103,6 +103,6 @@ export function buildNotificationMessage(action: Extract<DevLoopsAction, 'doctor
   return `pi-dev-loops ${action}: ${summary.ok}/${summary.total} checks passed`;
 }
 
-export function buildInspectRunNotification(action: InspectRunUiAction, state: string): string {
-  return `inspect-run viewer ${action}: ${state}`;
+export function buildInspectNotification(action: InspectAction, state: string): string {
+  return `inspect viewer ${action}: ${state}`;
 }

--- a/extension/presentation.ts
+++ b/extension/presentation.ts
@@ -1,18 +1,19 @@
-import type { DevLoopCheck, DevLoopCheckId } from "./checks.ts";
-import { DEV_LOOP_CHECK_IDS, summarizeChecks, renderCheckLines } from "./checks.ts";
-import { describeReadiness } from "../lib/dev-loops-core.mjs";
+import type { DevLoopCheck, DevLoopCheckId } from './checks.ts';
+import { DEV_LOOP_CHECK_IDS, summarizeChecks, renderCheckLines } from './checks.ts';
+import { describeReadiness } from '../lib/dev-loops-core.mjs';
 
-export type DevLoopsAction = "doctor" | "help" | "status" | "hide";
+export type DevLoopsAction = 'doctor' | 'help' | 'status' | 'hide';
+export type InspectRunUiAction = 'open' | 'resume' | 'status' | 'stop' | 'restart';
 
 const SETUP_GUIDANCE: Record<(typeof DEV_LOOP_CHECK_IDS)[number], string> = {
-  "gh-installed": "Install GitHub CLI to enable remote GitHub/Copilot workflows.",
-  "gh-auth": "Run `gh auth login` so remote GitHub/Copilot workflows can use your GitHub session.",
-  "subagent-command": "Install or enable subagent support so the `subagent` command is available.",
-  "git-repo": "Open Pi inside a git repository checkout before using the shared loops.",
+  'gh-installed': 'Install GitHub CLI to enable remote GitHub/Copilot workflows.',
+  'gh-auth': 'Run `gh auth login` so remote GitHub/Copilot workflows can use your GitHub session.',
+  'subagent-command': 'Install or enable subagent support so the `subagent` command is available.',
+  'git-repo': 'Open Pi inside a git repository checkout before using the shared loops.',
 };
 
 function readinessLabel(ready: boolean): string {
-  return ready ? "ready" : "needs setup";
+  return ready ? 'ready' : 'needs setup';
 }
 
 function checkMap(checks: DevLoopCheck[]): Map<DevLoopCheckId, DevLoopCheck> {
@@ -29,26 +30,31 @@ export function orderedSetupSteps(checks: DevLoopCheck[]): string[] {
   }
 
   return [
-    "1. Use `/skill:dev-loop` to start or continue a dev loop — the single public entry; routing handles the rest.",
-    "2. Run `/dev-loops status` whenever you want a concise readiness snapshot.",
-    "3. Use `pi install git:github.com/mfittko/pi-dev-loops` to install the package, or `pi update git:github.com/mfittko/pi-dev-loops` to refresh it.",
+    '1. Use `/skill:dev-loop` to start or continue a dev loop — the single public entry; routing handles the rest.',
+    '2. Run `/dev-loops status` whenever you want a concise readiness snapshot.',
+    '3. Use `pi install git:github.com/mfittko/pi-dev-loops` to install the package, or `pi update git:github.com/mfittko/pi-dev-loops` to refresh it.',
   ];
 }
 
 export function buildHelpLines(): string[] {
   return [
-    "pi-dev-loops help",
-    "Workflow entry:",
-    "- /skill:dev-loop — single public entrypoint; routing handles the rest",
-    "Commands:",
-    "- /dev-loops status",
-    "- /dev-loops doctor",
-    "- /dev-loops hide",
-    "Use `pi install git:github.com/mfittko/pi-dev-loops` to install skills and agents; packaged agents sync into `~/.agents/` on session start.",
+    'pi-dev-loops help',
+    'Workflow entry:',
+    '- /skill:dev-loop — single public entrypoint; routing handles the rest',
+    'Commands:',
+    '- /dev-loops status',
+    '- /dev-loops doctor',
+    '- /dev-loops hide',
+    '- /dev-loops ui inspect-run open [--repo <owner/name>]',
+    '- /dev-loops ui inspect-run resume [--repo <owner/name>]',
+    '- /dev-loops ui inspect-run status [--repo <owner/name>]',
+    '- /dev-loops ui inspect-run stop [--repo <owner/name>]',
+    '- /dev-loops ui inspect-run restart [--repo <owner/name>]',
+    'Use `pi install git:github.com/mfittko/pi-dev-loops` to install skills and agents; packaged agents sync into `~/.agents/` on session start.',
   ];
 }
 
-export function buildWidgetLines(action: Extract<DevLoopsAction, "doctor" | "status">, checks: DevLoopCheck[]): string[] {
+export function buildWidgetLines(action: Extract<DevLoopsAction, 'doctor' | 'status'>, checks: DevLoopCheck[]): string[] {
   const summary = summarizeChecks(checks);
   const readiness = describeReadiness(checks);
   const lines = [
@@ -57,10 +63,10 @@ export function buildWidgetLines(action: Extract<DevLoopsAction, "doctor" | "sta
     `Remote GitHub/Copilot readiness: ${readinessLabel(readiness.remoteReady)}`,
   ];
 
-  if (action === "status") {
+  if (action === 'status') {
     return [
       ...lines,
-      "Suggested next steps:",
+      'Suggested next steps:',
       ...orderedSetupSteps(checks),
     ];
   }
@@ -68,11 +74,35 @@ export function buildWidgetLines(action: Extract<DevLoopsAction, "doctor" | "sta
   return [
     ...lines,
     ...renderCheckLines(checks),
-    "Skills load via `pi install git:github.com/mfittko/pi-dev-loops`; packaged agents sync into `~/.agents/` on session start.",
+    'Skills load via `pi install git:github.com/mfittko/pi-dev-loops`; packaged agents sync into `~/.agents/` on session start.',
   ];
 }
 
-export function buildNotificationMessage(action: Extract<DevLoopsAction, "doctor" | "status">, checks: DevLoopCheck[]): string {
+export function buildInspectRunUiLines(action: InspectRunUiAction, result: { state: string; url?: string | null; detail?: string | null; warning?: string | null; repo?: string | null }): string[] {
+  const lines = [
+    `inspect-run ${action}`,
+    `State: ${result.state}`,
+  ];
+  if (result.repo) {
+    lines.push(`Repo: ${result.repo}`);
+  }
+  if (result.url) {
+    lines.push(`URL: ${result.url}`);
+  }
+  if (result.detail) {
+    lines.push(`Detail: ${result.detail}`);
+  }
+  if (result.warning) {
+    lines.push(`Warning: ${result.warning}`);
+  }
+  return lines;
+}
+
+export function buildNotificationMessage(action: Extract<DevLoopsAction, 'doctor' | 'status'>, checks: DevLoopCheck[]): string {
   const summary = summarizeChecks(checks);
   return `pi-dev-loops ${action}: ${summary.ok}/${summary.total} checks passed`;
+}
+
+export function buildInspectRunNotification(action: InspectRunUiAction, state: string): string {
+  return `inspect-run viewer ${action}: ${state}`;
 }

--- a/lib/dev-loops-core.mjs
+++ b/lib/dev-loops-core.mjs
@@ -208,8 +208,22 @@ export async function executeDevLoopsCommand({ input, surface = 'extension', run
         tokens: parsed.tokens,
       };
     }
+    let repoRoot = null;
     try {
-      const repoRoot = await runtime.getRepoRoot();
+      repoRoot = await runtime.getRepoRoot();
+    } catch (error) {
+      return {
+        kind: 'ui_inspect_run_result',
+        action: parsed.action,
+        repo: parsed.repo ?? null,
+        repoRoot: null,
+        state: 'stopped',
+        url: null,
+        detail: error instanceof Error ? error.message : String(error),
+        warning: null,
+      };
+    }
+    try {
       const result = await runtime.uiLifecycle[parsed.action]({ repoRoot, repo: parsed.repo });
       return {
         kind: 'ui_inspect_run_result',
@@ -223,7 +237,7 @@ export async function executeDevLoopsCommand({ input, surface = 'extension', run
         kind: 'ui_inspect_run_result',
         action: parsed.action,
         repo: parsed.repo ?? null,
-        repoRoot: null,
+        repoRoot,
         state: 'stopped',
         url: null,
         detail: error instanceof Error ? error.message : String(error),

--- a/lib/dev-loops-core.mjs
+++ b/lib/dev-loops-core.mjs
@@ -7,7 +7,7 @@ export const DEV_LOOP_CHECK_IDS = [
 
 const LOCAL_READINESS_IDS = ['subagent-command', 'git-repo'];
 const REMOTE_READINESS_IDS = ['gh-installed', 'gh-auth', 'subagent-command', 'git-repo'];
-const INSPECT_RUN_UI_ACTIONS = new Set(['open', 'resume', 'status', 'stop', 'restart']);
+const INSPECT_ACTIONS = new Set(['open', 'resume', 'status', 'stop', 'restart']);
 
 function normalizeInput(input) {
   if (Array.isArray(input)) {
@@ -43,19 +43,15 @@ function invalidCommand(message, usageAction, tokens) {
   };
 }
 
-function parseInspectRunUiCommand(tokens, { surface }) {
+function parseInspectCommand(tokens, { surface }) {
   if (surface !== 'extension') {
-    return invalidCommand('Unrecognized command: ui.', undefined, tokens);
+    return invalidCommand('Unrecognized command: inspect.', undefined, tokens);
   }
 
-  const [, family, rawAction, ...rawArgs] = tokens;
-  if (family !== 'inspect-run') {
-    return invalidCommand('`/dev-loops ui` currently supports only `inspect-run`.', 'ui inspect-run', tokens);
-  }
-
+  const [, rawAction, ...rawArgs] = tokens;
   const action = rawAction?.toLowerCase();
-  if (!INSPECT_RUN_UI_ACTIONS.has(action)) {
-    return invalidCommand('`/dev-loops ui inspect-run` only supports: open, resume, status, stop, restart.', 'ui inspect-run', tokens);
+  if (!INSPECT_ACTIONS.has(action)) {
+    return invalidCommand('`/dev-loops inspect` only supports: open, resume, status, stop, restart.', 'inspect', tokens);
   }
 
   let repo;
@@ -64,16 +60,16 @@ function parseInspectRunUiCommand(tokens, { surface }) {
     if (token === '--repo') {
       const value = rawArgs.shift();
       if (typeof value !== 'string' || value.length === 0 || value.startsWith('--')) {
-        return invalidCommand('`--repo` requires `<owner/name>`.', 'ui inspect-run', tokens);
+        return invalidCommand('`--repo` requires `<owner/name>`.', 'inspect', tokens);
       }
       repo = value;
       continue;
     }
-    return invalidCommand(`Unrecognized inspect-run UI argument: ${token}.`, 'ui inspect-run', tokens);
+    return invalidCommand(`Unrecognized inspect argument: ${token}.`, 'inspect', tokens);
   }
 
   return {
-    kind: 'ui_inspect_run_action',
+    kind: 'inspect_action',
     action,
     repo,
     tokens,
@@ -86,8 +82,8 @@ export function parseDevLoopsCommand(input, { surface = 'extension' } = {}) {
   const action = rawAction?.toLowerCase();
   const extensionSurface = surface === 'extension';
 
-  if (action === 'ui') {
-    return parseInspectRunUiCommand(tokens, { surface });
+  if (action === 'inspect') {
+    return parseInspectCommand(tokens, { surface });
   }
 
   switch (action) {
@@ -200,11 +196,11 @@ export function describeReadiness(checks) {
 export async function executeDevLoopsCommand({ input, surface = 'extension', runtime }) {
   const parsed = parseDevLoopsCommand(input, { surface });
 
-  if (parsed.kind === 'ui_inspect_run_action') {
+  if (parsed.kind === 'inspect_action') {
     if (surface !== 'extension' || typeof runtime?.uiLifecycle?.[parsed.action] !== 'function') {
       return {
         kind: 'unsupported',
-        message: 'Inspect-run UI lifecycle commands are only available inside the Pi extension.',
+        message: 'Inspect lifecycle commands are only available inside the Pi extension.',
         tokens: parsed.tokens,
       };
     }
@@ -213,7 +209,7 @@ export async function executeDevLoopsCommand({ input, surface = 'extension', run
       repoRoot = await runtime.getRepoRoot();
     } catch (error) {
       return {
-        kind: 'ui_inspect_run_result',
+        kind: 'inspect_result',
         action: parsed.action,
         repo: parsed.repo ?? null,
         repoRoot: null,
@@ -226,7 +222,7 @@ export async function executeDevLoopsCommand({ input, surface = 'extension', run
     try {
       const result = await runtime.uiLifecycle[parsed.action]({ repoRoot, repo: parsed.repo });
       return {
-        kind: 'ui_inspect_run_result',
+        kind: 'inspect_result',
         action: parsed.action,
         repo: parsed.repo ?? null,
         repoRoot,
@@ -234,7 +230,7 @@ export async function executeDevLoopsCommand({ input, surface = 'extension', run
       };
     } catch (error) {
       return {
-        kind: 'ui_inspect_run_result',
+        kind: 'inspect_result',
         action: parsed.action,
         repo: parsed.repo ?? null,
         repoRoot,

--- a/lib/dev-loops-core.mjs
+++ b/lib/dev-loops-core.mjs
@@ -1,22 +1,24 @@
 export const DEV_LOOP_CHECK_IDS = [
-  "gh-installed",
-  "gh-auth",
-  "subagent-command",
-  "git-repo",
+  'gh-installed',
+  'gh-auth',
+  'subagent-command',
+  'git-repo',
 ];
 
-const LOCAL_READINESS_IDS = ["subagent-command", "git-repo"];
-const REMOTE_READINESS_IDS = ["gh-installed", "gh-auth", "subagent-command", "git-repo"];
+const LOCAL_READINESS_IDS = ['subagent-command', 'git-repo'];
+const REMOTE_READINESS_IDS = ['gh-installed', 'gh-auth', 'subagent-command', 'git-repo'];
+const INSPECT_RUN_UI_ACTIONS = new Set(['open', 'resume', 'status', 'stop', 'restart']);
+
 function normalizeInput(input) {
   if (Array.isArray(input)) {
     return input.map((part) => `${part}`.trim()).filter(Boolean);
   }
 
-  return `${input ?? ""}`.trim().split(/\s+/).filter(Boolean);
+  return `${input ?? ''}`.trim().split(/\s+/).filter(Boolean);
 }
 
 function normalizeProbe(probe, availableDetail, unavailableDetail) {
-  if (typeof probe === "boolean") {
+  if (typeof probe === 'boolean') {
     return {
       ok: probe,
       detail: probe ? availableDetail : unavailableDetail,
@@ -34,54 +36,95 @@ function normalizeProbe(probe, availableDetail, unavailableDetail) {
 
 function invalidCommand(message, usageAction, tokens) {
   return {
-    kind: "malformed",
+    kind: 'malformed',
     message,
     usageAction,
     tokens,
   };
 }
 
-export function parseDevLoopsCommand(input, { surface = "extension" } = {}) {
+function parseInspectRunUiCommand(tokens, { surface }) {
+  if (surface !== 'extension') {
+    return invalidCommand('Unrecognized command: ui.', undefined, tokens);
+  }
+
+  const [, family, rawAction, ...rawArgs] = tokens;
+  if (family !== 'inspect-run') {
+    return invalidCommand('`/dev-loops ui` currently supports only `inspect-run`.', 'ui inspect-run', tokens);
+  }
+
+  const action = rawAction?.toLowerCase();
+  if (!INSPECT_RUN_UI_ACTIONS.has(action)) {
+    return invalidCommand('`/dev-loops ui inspect-run` only supports: open, resume, status, stop, restart.', 'ui inspect-run', tokens);
+  }
+
+  let repo;
+  while (rawArgs.length > 0) {
+    const token = rawArgs.shift();
+    if (token === '--repo') {
+      const value = rawArgs.shift();
+      if (typeof value !== 'string' || value.length === 0 || value.startsWith('--')) {
+        return invalidCommand('`--repo` requires `<owner/name>`.', 'ui inspect-run', tokens);
+      }
+      repo = value;
+      continue;
+    }
+    return invalidCommand(`Unrecognized inspect-run UI argument: ${token}.`, 'ui inspect-run', tokens);
+  }
+
+  return {
+    kind: 'ui_inspect_run_action',
+    action,
+    repo,
+    tokens,
+  };
+}
+
+export function parseDevLoopsCommand(input, { surface = 'extension' } = {}) {
   const tokens = normalizeInput(input);
   const [rawAction, rawScope, ...rest] = tokens;
   const action = rawAction?.toLowerCase();
-  const extensionSurface = surface === "extension";
+  const extensionSurface = surface === 'extension';
+
+  if (action === 'ui') {
+    return parseInspectRunUiCommand(tokens, { surface });
+  }
 
   switch (action) {
     case undefined:
-    case "":
-    case "help":
+    case '':
+    case 'help':
       return extensionSurface || (rest.length === 0 && rawScope === undefined)
-        ? { kind: "action", action: "help", tokens }
-        : invalidCommand("`help` does not accept additional arguments.", "help", tokens);
-    case "status":
-    case "doctor":
+        ? { kind: 'action', action: 'help', tokens }
+        : invalidCommand('`help` does not accept additional arguments.', 'help', tokens);
+    case 'status':
+    case 'doctor':
       return extensionSurface || (rest.length === 0 && rawScope === undefined)
-        ? { kind: "action", action, tokens }
+        ? { kind: 'action', action, tokens }
         : invalidCommand(`\`${action}\` does not accept additional arguments.`, action, tokens);
-    case "hide":
+    case 'hide':
       if (!extensionSurface && (rest.length > 0 || rawScope !== undefined)) {
-        return invalidCommand("`hide` does not accept additional arguments.", "hide", tokens);
+        return invalidCommand('`hide` does not accept additional arguments.', 'hide', tokens);
       }
 
       return extensionSurface
-        ? { kind: "action", action: "hide", tokens }
+        ? { kind: 'action', action: 'hide', tokens }
         : {
-            kind: "unsupported",
-            action: "hide",
-            message: "`pi-dev-loops hide` is not supported outside the Pi extension; use `/dev-loops hide` inside Pi instead.",
+            kind: 'unsupported',
+            action: 'hide',
+            message: '`pi-dev-loops hide` is not supported outside the Pi extension; use `/dev-loops hide` inside Pi instead.',
             tokens,
           };
     default:
       return extensionSurface
-        ? { kind: "action", action: "help", tokens }
+        ? { kind: 'action', action: 'help', tokens }
         : invalidCommand(`Unrecognized command: ${rawAction}.`, undefined, tokens);
   }
 }
 
 export async function collectDevLoopChecks(runtime) {
   const [ghInstalled, ghAuthenticated, inGitRepo, subagentProbe] = await Promise.all([
-    runtime.commandExists("gh"),
+    runtime.commandExists('gh'),
     runtime.ghAuthOk(),
     runtime.insideGitRepo(),
     runtime.getSubagentAvailability(),
@@ -89,41 +132,41 @@ export async function collectDevLoopChecks(runtime) {
 
   const subagent = normalizeProbe(
     subagentProbe,
-    "`subagent` command is available.",
-    "Install or enable subagent support so `subagent` is available.",
+    '`subagent` command is available.',
+    'Install or enable subagent support so `subagent` is available.',
   );
 
   return [
     {
-      id: "gh-installed",
-      label: "GitHub CLI installed",
+      id: 'gh-installed',
+      label: 'GitHub CLI installed',
       ok: ghInstalled,
-      detail: ghInstalled ? "`gh` is available." : "Install GitHub CLI to use remote GitHub/Copilot loops.",
+      detail: ghInstalled ? '`gh` is available.' : 'Install GitHub CLI to use remote GitHub/Copilot loops.',
     },
     {
-      id: "gh-auth",
-      label: "GitHub CLI authenticated",
+      id: 'gh-auth',
+      label: 'GitHub CLI authenticated',
       ok: ghInstalled && ghAuthenticated,
       detail:
         ghInstalled && ghAuthenticated
-          ? "`gh auth status` succeeded."
+          ? '`gh auth status` succeeded.'
           : ghInstalled
-            ? "Run `gh auth login` before using remote GitHub/Copilot loops."
-            : "GitHub CLI is not installed yet.",
+            ? 'Run `gh auth login` before using remote GitHub/Copilot loops.'
+            : 'GitHub CLI is not installed yet.',
     },
     {
-      id: "subagent-command",
-      label: "Subagent command available",
+      id: 'subagent-command',
+      label: 'Subagent command available',
       ok: subagent.ok,
       detail: subagent.detail,
     },
     {
-      id: "git-repo",
-      label: "Inside a git repository",
+      id: 'git-repo',
+      label: 'Inside a git repository',
       ok: inGitRepo,
       detail: inGitRepo
-        ? "Current working directory is inside a git repo."
-        : "Local and GitHub loops work best inside a git repository checkout.",
+        ? 'Current working directory is inside a git repo.'
+        : 'Local and GitHub loops work best inside a git repository checkout.',
     },
   ];
 }
@@ -137,7 +180,7 @@ export function summarizeChecks(checks) {
 
 export function renderCheckLines(checks) {
   return checks.flatMap((check) => {
-    const marker = check.ok ? "✅" : "⚠️";
+    const marker = check.ok ? '✅' : '⚠️';
     return [`${marker} ${check.label}`, `   ${check.detail}`];
   });
 }
@@ -154,23 +197,42 @@ export function describeReadiness(checks) {
   };
 }
 
-export async function executeDevLoopsCommand({ input, surface = "extension", runtime }) {
+export async function executeDevLoopsCommand({ input, surface = 'extension', runtime }) {
   const parsed = parseDevLoopsCommand(input, { surface });
 
-  if (parsed.kind !== "action") {
+  if (parsed.kind === 'ui_inspect_run_action') {
+    if (surface !== 'extension' || typeof runtime?.uiLifecycle?.[parsed.action] !== 'function') {
+      return {
+        kind: 'unsupported',
+        message: 'Inspect-run UI lifecycle commands are only available inside the Pi extension.',
+        tokens: parsed.tokens,
+      };
+    }
+    const repoRoot = await runtime.getRepoRoot();
+    const result = await runtime.uiLifecycle[parsed.action]({ repoRoot, repo: parsed.repo });
+    return {
+      kind: 'ui_inspect_run_result',
+      action: parsed.action,
+      repo: parsed.repo ?? null,
+      repoRoot,
+      ...result,
+    };
+  }
+
+  if (parsed.kind !== 'action') {
     return parsed;
   }
 
   switch (parsed.action) {
-    case "help":
-      return { kind: "help" };
-    case "hide":
-      return { kind: "hide" };
-    case "status":
-    case "doctor": {
+    case 'help':
+      return { kind: 'help' };
+    case 'hide':
+      return { kind: 'hide' };
+    case 'status':
+    case 'doctor': {
       const checks = await collectDevLoopChecks(runtime);
       return {
-        kind: "checks",
+        kind: 'checks',
         action: parsed.action,
         checks,
       };

--- a/lib/dev-loops-core.mjs
+++ b/lib/dev-loops-core.mjs
@@ -208,15 +208,28 @@ export async function executeDevLoopsCommand({ input, surface = 'extension', run
         tokens: parsed.tokens,
       };
     }
-    const repoRoot = await runtime.getRepoRoot();
-    const result = await runtime.uiLifecycle[parsed.action]({ repoRoot, repo: parsed.repo });
-    return {
-      kind: 'ui_inspect_run_result',
-      action: parsed.action,
-      repo: parsed.repo ?? null,
-      repoRoot,
-      ...result,
-    };
+    try {
+      const repoRoot = await runtime.getRepoRoot();
+      const result = await runtime.uiLifecycle[parsed.action]({ repoRoot, repo: parsed.repo });
+      return {
+        kind: 'ui_inspect_run_result',
+        action: parsed.action,
+        repo: parsed.repo ?? null,
+        repoRoot,
+        ...result,
+      };
+    } catch (error) {
+      return {
+        kind: 'ui_inspect_run_result',
+        action: parsed.action,
+        repo: parsed.repo ?? null,
+        repoRoot: null,
+        state: 'stopped',
+        url: null,
+        detail: error instanceof Error ? error.message : String(error),
+        warning: null,
+      };
+    }
   }
 
   if (parsed.kind !== 'action') {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -659,6 +659,7 @@ Contract:
 - read-only: no GitHub mutations, no checkpoint writes, no steering writes, no worker attachment
 - ownership boundary: `inspect-run` owns authoritative inspection/status state; viewer owns local inbox discovery plus read-only operator presentation/prioritization
 - extension-managed lifecycle remains loopback-first and local-only; no remote/public hosting support
+- the script fallback still requires explicit `--allow-non-localhost` opt-in for non-loopback binds; do not expose inspection state on the network by default
 - GitHub-first launch boundary: repo scope is optional and PR selection happens through the viewer URL/query state, not a CLI `--pr` flag
 - uses one adapter module (`scripts/loop/_inspect-run-viewer-adapter.mjs`) to load the normalized inspection snapshot
 - adapter is the only viewer integration seam that calls the existing `inspect-run` contract in this source-loaded workspace

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -640,6 +640,7 @@ The extension-managed seam stores one narrow repo-local managed-instance record 
 
 Ownership split for this slice:
 - extension owns lifecycle UX, URL discovery, liveness checks, reattach logic, stop/restart, and best-effort browser opening
+- when a repo-scoped command reuses an inbox-first managed viewer, the surfaced URL may include `?scope=<owner/name>` to pre-scope the inbox without replacing the managed instance
 - viewer script still owns HTTP server behavior, rendering, inbox/query behavior, and snapshot loading
 
 Optional:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -629,11 +629,11 @@ Owned read-only local/operator inspection dashboard layered on `inspect-run`.
 `inspect-run` remains authoritative for inspection/status state; the viewer owns local inbox discovery and read-only presentation/prioritization.
 
 Primary local lifecycle UX now lives in the Pi extension under:
-- `/dev-loops ui inspect-run open [--repo <owner/name>]`
-- `/dev-loops ui inspect-run resume [--repo <owner/name>]`
-- `/dev-loops ui inspect-run status [--repo <owner/name>]`
-- `/dev-loops ui inspect-run stop [--repo <owner/name>]`
-- `/dev-loops ui inspect-run restart [--repo <owner/name>]`
+- `/dev-loops inspect open [--repo <owner/name>]`
+- `/dev-loops inspect resume [--repo <owner/name>]`
+- `/dev-loops inspect status [--repo <owner/name>]`
+- `/dev-loops inspect stop [--repo <owner/name>]`
+- `/dev-loops inspect restart [--repo <owner/name>]`
 
 The extension-managed seam stores one narrow repo-local managed-instance record at:
 - `.pi/ui-servers/inspect-run-viewer.json`
@@ -674,10 +674,10 @@ Contract:
 
 Local manual verification path:
 1. Preferred extension-managed path:
-   - `/dev-loops ui inspect-run open`
-   - `/dev-loops ui inspect-run status`
-   - `/dev-loops ui inspect-run resume`
-   - `/dev-loops ui inspect-run stop`
+   - `/dev-loops inspect open`
+   - `/dev-loops inspect status`
+   - `/dev-loops inspect resume`
+   - `/dev-loops inspect stop`
 2. Script fallback for manual/debug verification:
    - `node scripts/loop/inspect-run-viewer.mjs`
    - `node scripts/loop/inspect-run-viewer.mjs --repo <owner/name>`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -628,12 +628,26 @@ Failure behavior:
 Owned read-only local/operator inspection dashboard layered on `inspect-run`.
 `inspect-run` remains authoritative for inspection/status state; the viewer owns local inbox discovery and read-only presentation/prioritization.
 
+Primary local lifecycle UX now lives in the Pi extension under:
+- `/dev-loops ui inspect-run open [--repo <owner/name>]`
+- `/dev-loops ui inspect-run resume [--repo <owner/name>]`
+- `/dev-loops ui inspect-run status [--repo <owner/name>]`
+- `/dev-loops ui inspect-run stop [--repo <owner/name>]`
+- `/dev-loops ui inspect-run restart [--repo <owner/name>]`
+
+The extension-managed seam stores one narrow repo-local managed-instance record at:
+- `.pi/ui-servers/inspect-run-viewer.json`
+
+Ownership split for this slice:
+- extension owns lifecycle UX, URL discovery, liveness checks, reattach logic, stop/restart, and best-effort browser opening
+- viewer script still owns HTTP server behavior, rendering, inbox/query behavior, and snapshot loading
+
 Optional:
 - `--repo <owner/name>` (repo-scope the inbox; otherwise the viewer starts in inbox-first mode)
 - `--host <host>` (default: `127.0.0.1`; non-loopback binds require `--allow-non-localhost`)
 - `--port <port>` (default: `4311`)
 - `--allow-non-localhost` (explicit opt-in for non-loopback binds such as `0.0.0.0` or LAN IPs)
-- `--restart` (stop any existing listener on the chosen port before starting; requires `lsof` / POSIX support and sends `SIGTERM` to every listener already bound to that port)
+- `--restart` (manual/debug convenience only; requires `lsof` / POSIX support and sends `SIGTERM` to every listener already bound to that port)
 - `--steering-state-file <path>` (pass-through to `inspect-run`)
 - `--reviewer-login <login>` (pass-through to `inspect-run`)
 - `--copilot-input <path>` (pass-through to `inspect-run`)
@@ -643,7 +657,7 @@ Contract:
 - current-slice posture: kept/promoted as an explicitly owned local/operator inspection dashboard (not a second public workflow entrypoint)
 - read-only: no GitHub mutations, no checkpoint writes, no steering writes, no worker attachment
 - ownership boundary: `inspect-run` owns authoritative inspection/status state; viewer owns local inbox discovery plus read-only operator presentation/prioritization
-- local-viewer safety: default host remains loopback-only; non-loopback binds require explicit `--allow-non-localhost` because they may expose local inspection state on the network
+- extension-managed lifecycle remains loopback-first and local-only; no remote/public hosting support
 - GitHub-first launch boundary: repo scope is optional and PR selection happens through the viewer URL/query state, not a CLI `--pr` flag
 - uses one adapter module (`scripts/loop/_inspect-run-viewer-adapter.mjs`) to load the normalized inspection snapshot
 - adapter is the only viewer integration seam that calls the existing `inspect-run` contract in this source-loaded workspace
@@ -654,17 +668,22 @@ Contract:
 - `/snapshot.json` returns `application/json; charset=utf-8` on success and deterministic JSON error output with non-2xx status when snapshot loading throws or yields no snapshot
 - unsupported paths return deterministic `404` without loading a snapshot (even for unsupported methods on unknown paths); `/favicon.ico` returns deterministic `204`; unsupported methods on supported routes return `405 Allow: GET`
 - both primary endpoints send `Cache-Control: no-store` to match the manual-reload workflow
-- `--restart` is a local convenience flag that requires `lsof` / POSIX support and attempts to stop every listener already bound to the chosen port with `SIGTERM` before starting the new server process
+- the script-local `--restart` flag remains a manual/debug fallback only; the extension-managed path must not depend on killing unknown listeners
 - manual reload only (`window.location.reload()`); no polling/watch/timeout/control semantics
 
 Local manual verification path:
-1. Start the viewer in inbox-first or repo-scoped mode:
+1. Preferred extension-managed path:
+   - `/dev-loops ui inspect-run open`
+   - `/dev-loops ui inspect-run status`
+   - `/dev-loops ui inspect-run resume`
+   - `/dev-loops ui inspect-run stop`
+2. Script fallback for manual/debug verification:
    - `node scripts/loop/inspect-run-viewer.mjs`
    - `node scripts/loop/inspect-run-viewer.mjs --repo <owner/name>`
-2. Open the printed URL in a local browser and verify the human-oriented `/` page
-3. Select a PR via the sidebar or by adding `?repo=<owner/name>&pr=<number>` to the viewer URL
-4. Open `/snapshot.json` for that selected/query-targeted PR and verify it returns the matching full inspection snapshot JSON
-5. Use browser refresh or the reload button for point-in-time re-inspection
+3. Open the printed/resolved URL in a local browser and verify the human-oriented `/` page
+4. Select a PR via the sidebar or by adding `?repo=<owner/name>&pr=<number>` to the viewer URL
+5. Open `/snapshot.json` for that selected/query-targeted PR and verify it returns the matching full inspection snapshot JSON
+6. Use browser refresh or the reload button for point-in-time re-inspection
 
 Local WebKit/Playwright smoke path:
 1. Install the Safari/WebKit browser runtime once:

--- a/scripts/loop/inspect-run-viewer/managed-instance.mjs
+++ b/scripts/loop/inspect-run-viewer/managed-instance.mjs
@@ -49,6 +49,19 @@ function buildRecordPayload({ repoRoot, launchArgs, pid, startedAt }) {
   };
 }
 
+function isManagedRecordShape(record) {
+  return Boolean(record)
+    && record.surfaceId === INSPECT_RUN_VIEWER_SURFACE_ID
+    && record.schemaVersion === 1
+    && typeof record.pid === 'number'
+    && typeof record.host === 'string'
+    && Number.isInteger(record.port)
+    && record.port > 0
+    && record.launchArgs
+    && record.launchArgs.host === record.host
+    && record.launchArgs.port === record.port;
+}
+
 function baseUrlForRecord(record) {
   const host = record?.host ?? DEFAULT_HOST;
   const port = record?.port ?? DEFAULT_PORT;
@@ -208,7 +221,7 @@ export function createInspectRunViewerLifecycleManager({
   async function inspectRecord({ repoRoot }) {
     const recordPath = path.join(repoRoot, INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH);
     const record = await readManagedRecord(recordPath);
-    if (record?.invalidRecord === true) {
+    if (record?.invalidRecord === true || (record !== null && !isManagedRecordShape(record))) {
       return {
         recordPath,
         record: null,
@@ -292,33 +305,50 @@ export function createInspectRunViewerLifecycleManager({
     });
     const record = buildRecordPayload({ repoRoot, launchArgs, pid, startedAt: nowImpl() });
 
-    const deadline = Date.now() + 8000;
-    while (Date.now() < deadline) {
-      const [alive, healthy] = await Promise.all([
-        isProcessAliveImpl(pid),
-        healthcheckUrlImpl(baseUrl),
-      ]);
-      if (!alive) {
-        throw new Error('inspect-run viewer exited before becoming healthy');
+    try {
+      const deadline = Date.now() + 8000;
+      while (Date.now() < deadline) {
+        const [alive, healthy] = await Promise.all([
+          isProcessAliveImpl(pid),
+          healthcheckUrlImpl(baseUrl),
+        ]);
+        if (!alive) {
+          throw new Error('inspect-run viewer exited before becoming healthy');
+        }
+        if (healthy) {
+          await writeManagedRecord(recordPath, record);
+          return {
+            state: 'running',
+            url: buildOperatorUrl(record, requestedRepo),
+            detail: 'Started a managed inspect-run viewer.',
+            warning: null,
+            recordPath,
+            record,
+            startedFresh: true,
+            reusedExisting: false,
+            resumedExisting: false,
+          };
+        }
+        await waitImpl(100);
       }
-      if (healthy) {
-        await writeManagedRecord(recordPath, record);
-        return {
-          state: 'running',
-          url: buildOperatorUrl(record, requestedRepo),
-          detail: 'Started a managed inspect-run viewer.',
-          warning: null,
-          recordPath,
-          record,
-          startedFresh: true,
-          reusedExisting: false,
-          resumedExisting: false,
-        };
+      throw new Error('inspect-run viewer did not become healthy before the startup timeout');
+    } catch (error) {
+      if (await isProcessAliveImpl(pid)) {
+        try {
+          await stopManagedProcessImpl(pid);
+        } catch (stopError) {
+          if (stopError?.code !== 'ESRCH') {
+            throw stopError;
+          }
+        }
       }
-      await waitImpl(100);
+      await waitForManagedExit(record, {
+        isProcessAliveImpl,
+        listListeningPidsImpl,
+        waitImpl,
+      });
+      throw error;
     }
-
-    throw new Error('inspect-run viewer did not become healthy before the startup timeout');
   }
 
   async function maybeOpenBrowser(result) {
@@ -361,7 +391,9 @@ export function createInspectRunViewerLifecycleManager({
         });
         await removeManagedRecord(snapshot.recordPath);
       } else if (snapshot.state === 'stale_record') {
-        if (snapshot.record?.pid && await isProcessAliveImpl(snapshot.record.pid)) {
+        if (snapshot.record?.pid
+          && snapshot.listeners.includes(snapshot.record.pid)
+          && await isProcessAliveImpl(snapshot.record.pid)) {
           await stopManagedProcessImpl(snapshot.record.pid);
           await waitForManagedExit(snapshot.record, {
             isProcessAliveImpl,

--- a/scripts/loop/inspect-run-viewer/managed-instance.mjs
+++ b/scripts/loop/inspect-run-viewer/managed-instance.mjs
@@ -436,6 +436,7 @@ export function createInspectRunViewerLifecycleManager({
             isProcessAliveImpl,
             listListeningPidsImpl: listListeningPids,
             waitImpl,
+            nowMsImpl,
           });
         }
         await removeManagedRecord(snapshot.recordPath);

--- a/scripts/loop/inspect-run-viewer/managed-instance.mjs
+++ b/scripts/loop/inspect-run-viewer/managed-instance.mjs
@@ -227,7 +227,7 @@ async function stopManagedProcessSafely(pid, { stopManagedProcessImpl }) {
 
 async function waitForManagedExit(record, { isProcessAliveImpl, listListeningPidsImpl: listListeningPids, waitImpl, nowMsImpl, timeoutMs = 3000, pollIntervalMs = 100 }) {
   if (!record?.pid) {
-    return;
+    return true;
   }
   const deadline = nowMsImpl() + timeoutMs;
   while (nowMsImpl() < deadline) {
@@ -236,10 +236,27 @@ async function waitForManagedExit(record, { isProcessAliveImpl, listListeningPid
       listListeningPids(record.port ?? DEFAULT_PORT),
     ]);
     if (!alive && !listeners.includes(record.pid)) {
-      return;
+      return true;
     }
     await waitImpl(pollIntervalMs);
   }
+
+  const [alive, listeners] = await Promise.all([
+    isProcessAliveImpl(record.pid),
+    listListeningPids(record.port ?? DEFAULT_PORT),
+  ]);
+  return !alive && !listeners.includes(record.pid);
+}
+
+function buildFailedStopResult({ record, recordPath, detail }) {
+  return {
+    state: 'stale_record',
+    url: baseUrlForRecord(record),
+    detail,
+    warning: null,
+    recordPath,
+    record,
+  };
 }
 
 function summarizeRunning(record, requestedRepo) {
@@ -433,24 +450,48 @@ export function createInspectRunViewerLifecycleManager({
 
       if (snapshot.state === 'running' && snapshot.record) {
         await stopManagedProcessSafely(snapshot.record.pid, { stopManagedProcessImpl });
-        await waitForManagedExit(snapshot.record, {
+        const exited = await waitForManagedExit(snapshot.record, {
           isProcessAliveImpl,
           listListeningPidsImpl: listListeningPids,
           waitImpl,
           nowMsImpl,
         });
+        if (!exited) {
+          return {
+            ...buildFailedStopResult({
+              record: snapshot.record,
+              recordPath: snapshot.recordPath,
+              detail: 'Managed inspect-run viewer did not stop after SIGTERM; keeping the managed record instead of replacing it.',
+            }),
+            startedFresh: false,
+            reusedExisting: false,
+            resumedExisting: false,
+          };
+        }
         await removeManagedRecord(snapshot.recordPath);
       } else if (snapshot.state === 'stale_record') {
         if (snapshot.record?.pid
           && snapshot.listeners.includes(snapshot.record.pid)
           && await isProcessAliveImpl(snapshot.record.pid)) {
           await stopManagedProcessSafely(snapshot.record.pid, { stopManagedProcessImpl });
-          await waitForManagedExit(snapshot.record, {
+          const exited = await waitForManagedExit(snapshot.record, {
             isProcessAliveImpl,
             listListeningPidsImpl: listListeningPids,
             waitImpl,
             nowMsImpl,
           });
+          if (!exited) {
+            return {
+              ...buildFailedStopResult({
+                record: snapshot.record,
+                recordPath: snapshot.recordPath,
+                detail: 'Managed inspect-run viewer stayed bound to the port after SIGTERM; keeping the stale record for manual cleanup.',
+              }),
+              startedFresh: false,
+              reusedExisting: false,
+              resumedExisting: false,
+            };
+          }
         }
         await removeManagedRecord(snapshot.recordPath);
       }
@@ -521,12 +562,19 @@ export function createInspectRunViewerLifecycleManager({
       const snapshot = await inspectRecord({ repoRoot });
       if (snapshot.state === 'running' && snapshot.record && canServeRequestedRepo(snapshot.record, requestedRepo)) {
         await stopManagedProcessSafely(snapshot.record.pid, { stopManagedProcessImpl });
-        await waitForManagedExit(snapshot.record, {
+        const exited = await waitForManagedExit(snapshot.record, {
           isProcessAliveImpl,
           listListeningPidsImpl: listListeningPids,
           waitImpl,
           nowMsImpl,
         });
+        if (!exited) {
+          return buildFailedStopResult({
+            record: snapshot.record,
+            recordPath: snapshot.recordPath,
+            detail: 'Managed inspect-run viewer did not stop after SIGTERM; keeping the managed record.',
+          });
+        }
         await removeManagedRecord(snapshot.recordPath);
         const listeners = await listListeningPids(snapshot.record.port ?? DEFAULT_PORT);
         if (listeners.length > 0) {
@@ -561,6 +609,24 @@ export function createInspectRunViewerLifecycleManager({
       }
 
       if (snapshot.state === 'stale_record') {
+        if (snapshot.record?.pid
+          && snapshot.listeners.includes(snapshot.record.pid)
+          && await isProcessAliveImpl(snapshot.record.pid)) {
+          await stopManagedProcessSafely(snapshot.record.pid, { stopManagedProcessImpl });
+          const exited = await waitForManagedExit(snapshot.record, {
+            isProcessAliveImpl,
+            listListeningPidsImpl: listListeningPids,
+            waitImpl,
+            nowMsImpl,
+          });
+          if (!exited) {
+            return buildFailedStopResult({
+              record: snapshot.record,
+              recordPath: snapshot.recordPath,
+              detail: 'Managed inspect-run viewer stayed bound to the port after SIGTERM; keeping the stale record for manual cleanup.',
+            });
+          }
+        }
         await removeManagedRecord(snapshot.recordPath);
         const listeners = await listListeningPids(snapshot.record?.port ?? DEFAULT_PORT);
         return {
@@ -602,14 +668,39 @@ export function createInspectRunViewerLifecycleManager({
           };
         }
         await stopManagedProcessSafely(snapshot.record.pid, { stopManagedProcessImpl });
-        await waitForManagedExit(snapshot.record, {
+        const exited = await waitForManagedExit(snapshot.record, {
           isProcessAliveImpl,
           listListeningPidsImpl: listListeningPids,
           waitImpl,
           nowMsImpl,
         });
+        if (!exited) {
+          return buildFailedStopResult({
+            record: snapshot.record,
+            recordPath: snapshot.recordPath,
+            detail: 'Managed inspect-run viewer did not stop after SIGTERM; keeping the managed record instead of restarting it.',
+          });
+        }
         await removeManagedRecord(snapshot.recordPath);
       } else if (snapshot.state === 'stale_record') {
+        if (snapshot.record?.pid
+          && snapshot.listeners.includes(snapshot.record.pid)
+          && await isProcessAliveImpl(snapshot.record.pid)) {
+          await stopManagedProcessSafely(snapshot.record.pid, { stopManagedProcessImpl });
+          const exited = await waitForManagedExit(snapshot.record, {
+            isProcessAliveImpl,
+            listListeningPidsImpl: listListeningPids,
+            waitImpl,
+            nowMsImpl,
+          });
+          if (!exited) {
+            return buildFailedStopResult({
+              record: snapshot.record,
+              recordPath: snapshot.recordPath,
+              detail: 'Managed inspect-run viewer stayed bound to the port after SIGTERM; keeping the stale record for manual cleanup.',
+            });
+          }
+        }
         await removeManagedRecord(snapshot.recordPath);
       } else if (snapshot.state === 'conflict_unmanaged_listener') {
         return {

--- a/scripts/loop/inspect-run-viewer/managed-instance.mjs
+++ b/scripts/loop/inspect-run-viewer/managed-instance.mjs
@@ -183,7 +183,7 @@ async function readManagedRecord(recordPath) {
     if (error?.code === 'ENOENT') {
       return null;
     }
-    if (error instanceof SyntaxError) {
+    if (error instanceof SyntaxError || error?.code === 'EISDIR') {
       return {
         invalidRecord: true,
         parseError: error.message,
@@ -199,7 +199,7 @@ async function writeManagedRecord(recordPath, payload) {
 }
 
 async function removeManagedRecord(recordPath) {
-  await rm(recordPath, { force: true });
+  await rm(recordPath, { force: true, recursive: true });
 }
 
 async function stopManagedProcessSafely(pid, { stopManagedProcessImpl }) {

--- a/scripts/loop/inspect-run-viewer/managed-instance.mjs
+++ b/scripts/loop/inspect-run-viewer/managed-instance.mjs
@@ -152,9 +152,14 @@ async function defaultOpenBrowser(url) {
       args = [url];
       break;
   }
-  const child = spawn(command, args, options);
-  child.on('error', () => {});
-  child.unref();
+  await new Promise((resolve, reject) => {
+    const child = spawn(command, args, options);
+    child.once('error', reject);
+    child.once('spawn', () => {
+      child.unref();
+      resolve(undefined);
+    });
+  });
 }
 
 async function readManagedRecord(recordPath) {
@@ -461,7 +466,7 @@ export function createInspectRunViewerLifecycleManager({
       }
       return {
         state: snapshot.state,
-        url: snapshot.state === 'stopped' ? null : buildOperatorUrl(snapshot.record ?? undefined, requestedRepo),
+        url: snapshot.state === 'running' ? buildOperatorUrl(snapshot.record ?? undefined, requestedRepo) : snapshot.url,
         detail: snapshot.detail,
         warning: null,
         recordPath: snapshot.recordPath,

--- a/scripts/loop/inspect-run-viewer/managed-instance.mjs
+++ b/scripts/loop/inspect-run-viewer/managed-instance.mjs
@@ -154,25 +154,31 @@ async function defaultStopManagedProcess(pid) {
   process.kill(pid, 'SIGTERM');
 }
 
-async function defaultOpenBrowser(url) {
+export function buildOpenBrowserInvocation(url, platform = process.platform) {
   let command;
   let args;
   let options = { detached: true, stdio: 'ignore' };
-  switch (process.platform) {
+  switch (platform) {
     case 'darwin':
       command = 'open';
       args = [url];
       break;
     case 'win32':
       command = 'cmd';
-      args = ['/c', 'start', '', url];
-      options = { detached: true, stdio: 'ignore', windowsHide: true };
+      args = ['/c', 'start', '""', `"${`${url}`.replaceAll('"', '""')}"`];
+      options = { detached: true, stdio: 'ignore', windowsHide: true, windowsVerbatimArguments: true };
       break;
     default:
       command = 'xdg-open';
       args = [url];
       break;
   }
+
+  return { command, args, options };
+}
+
+async function defaultOpenBrowser(url) {
+  const { command, args, options } = buildOpenBrowserInvocation(url);
   await new Promise((resolve, reject) => {
     const child = spawn(command, args, options);
     child.once('error', reject);

--- a/scripts/loop/inspect-run-viewer/managed-instance.mjs
+++ b/scripts/loop/inspect-run-viewer/managed-instance.mjs
@@ -183,6 +183,16 @@ async function removeManagedRecord(recordPath) {
   await rm(recordPath, { force: true });
 }
 
+async function stopManagedProcessSafely(pid, { stopManagedProcessImpl }) {
+  try {
+    await stopManagedProcessImpl(pid);
+  } catch (error) {
+    if (error?.code !== 'ESRCH') {
+      throw error;
+    }
+  }
+}
+
 async function waitForManagedExit(record, { isProcessAliveImpl, listListeningPidsImpl, waitImpl, timeoutMs = 3000, pollIntervalMs = 100 }) {
   if (!record?.pid) {
     return;
@@ -334,13 +344,7 @@ export function createInspectRunViewerLifecycleManager({
       throw new Error('inspect-run viewer did not become healthy before the startup timeout');
     } catch (error) {
       if (await isProcessAliveImpl(pid)) {
-        try {
-          await stopManagedProcessImpl(pid);
-        } catch (stopError) {
-          if (stopError?.code !== 'ESRCH') {
-            throw stopError;
-          }
-        }
+        await stopManagedProcessSafely(pid, { stopManagedProcessImpl });
       }
       await waitForManagedExit(record, {
         isProcessAliveImpl,
@@ -383,7 +387,7 @@ export function createInspectRunViewerLifecycleManager({
       }
 
       if (snapshot.state === 'running' && snapshot.record) {
-        await stopManagedProcessImpl(snapshot.record.pid);
+        await stopManagedProcessSafely(snapshot.record.pid, { stopManagedProcessImpl });
         await waitForManagedExit(snapshot.record, {
           isProcessAliveImpl,
           listListeningPidsImpl,
@@ -394,7 +398,7 @@ export function createInspectRunViewerLifecycleManager({
         if (snapshot.record?.pid
           && snapshot.listeners.includes(snapshot.record.pid)
           && await isProcessAliveImpl(snapshot.record.pid)) {
-          await stopManagedProcessImpl(snapshot.record.pid);
+          await stopManagedProcessSafely(snapshot.record.pid, { stopManagedProcessImpl });
           await waitForManagedExit(snapshot.record, {
             isProcessAliveImpl,
             listListeningPidsImpl,
@@ -469,7 +473,7 @@ export function createInspectRunViewerLifecycleManager({
       const requestedRepo = normalizeRequestedRepo(repo);
       const snapshot = await inspectRecord({ repoRoot });
       if (snapshot.state === 'running' && snapshot.record && canServeRequestedRepo(snapshot.record, requestedRepo)) {
-        await stopManagedProcessImpl(snapshot.record.pid);
+        await stopManagedProcessSafely(snapshot.record.pid, { stopManagedProcessImpl });
         await waitForManagedExit(snapshot.record, {
           isProcessAliveImpl,
           listListeningPidsImpl,
@@ -549,7 +553,7 @@ export function createInspectRunViewerLifecycleManager({
             record: snapshot.record,
           };
         }
-        await stopManagedProcessImpl(snapshot.record.pid);
+        await stopManagedProcessSafely(snapshot.record.pid, { stopManagedProcessImpl });
         await waitForManagedExit(snapshot.record, {
           isProcessAliveImpl,
           listListeningPidsImpl,

--- a/scripts/loop/inspect-run-viewer/managed-instance.mjs
+++ b/scripts/loop/inspect-run-viewer/managed-instance.mjs
@@ -462,7 +462,7 @@ export function createInspectRunViewerLifecycleManager({
       return {
         state: snapshot.state === 'conflict_unmanaged_listener' ? 'conflict_unmanaged_listener' : 'stopped',
         url: snapshot.state === 'conflict_unmanaged_listener' ? snapshot.url : null,
-        detail: 'No managed inspect-run viewer is running; use `/dev-loops ui inspect-run open`.',
+        detail: 'No managed inspect-run viewer is running; use `/dev-loops inspect open`.',
         warning: null,
         recordPath: snapshot.recordPath,
         record: snapshot.record,

--- a/scripts/loop/inspect-run-viewer/managed-instance.mjs
+++ b/scripts/loop/inspect-run-viewer/managed-instance.mjs
@@ -63,12 +63,11 @@ function isManagedRecordShape(record) {
     && record.surfaceId === INSPECT_RUN_VIEWER_SURFACE_ID
     && record.schemaVersion === 1
     && typeof record.pid === 'number'
-    && typeof record.host === 'string'
-    && Number.isInteger(record.port)
-    && record.port > 0
+    && record.host === DEFAULT_HOST
+    && record.port === DEFAULT_PORT
     && record.launchArgs
-    && record.launchArgs.host === record.host
-    && record.launchArgs.port === record.port;
+    && record.launchArgs.host === DEFAULT_HOST
+    && record.launchArgs.port === DEFAULT_PORT;
 }
 
 function baseUrlForRecord(record) {

--- a/scripts/loop/inspect-run-viewer/managed-instance.mjs
+++ b/scripts/loop/inspect-run-viewer/managed-instance.mjs
@@ -128,14 +128,19 @@ async function defaultLaunchManagedServer({ repoRoot, repo, host, port }) {
   if (repo !== null) {
     args.push('--repo', repo);
   }
-  const child = spawn(process.execPath, args, {
-    cwd: repoRoot,
-    detached: true,
-    stdio: 'ignore',
-    env: process.env,
+  return await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, args, {
+      cwd: repoRoot,
+      detached: true,
+      stdio: 'ignore',
+      env: process.env,
+    });
+    child.once('error', reject);
+    child.once('spawn', () => {
+      child.unref();
+      resolve({ pid: child.pid });
+    });
   });
-  child.unref();
-  return { pid: child.pid };
 }
 
 async function defaultStopManagedProcess(pid) {
@@ -335,6 +340,9 @@ export function createInspectRunViewerLifecycleManager({
       port: launchArgs.port,
       url: baseUrl,
     });
+    if (!Number.isInteger(pid) || pid <= 0) {
+      throw new Error('inspect-run viewer launch must return a positive integer pid');
+    }
     const record = buildRecordPayload({ repoRoot, launchArgs, pid, startedAt: nowImpl() });
 
     try {

--- a/scripts/loop/inspect-run-viewer/managed-instance.mjs
+++ b/scripts/loop/inspect-run-viewer/managed-instance.mjs
@@ -264,7 +264,7 @@ export function createInspectRunViewerLifecycleManager({
         record: null,
         state: 'stale_record',
         url: formatInspectRunViewerUrl(DEFAULT_HOST, DEFAULT_PORT),
-        detail: 'The managed inspect-run viewer record is unreadable; delete `.pi/ui-servers/inspect-run-viewer.json` and reopen the viewer.',
+        detail: 'The managed inspect-run viewer record is invalid or unreadable; delete `.pi/ui-servers/inspect-run-viewer.json` and reopen the viewer.',
         listeners: await listListeningPids(DEFAULT_PORT),
       };
     }

--- a/scripts/loop/inspect-run-viewer/managed-instance.mjs
+++ b/scripts/loop/inspect-run-viewer/managed-instance.mjs
@@ -622,10 +622,13 @@ export function createInspectRunViewerLifecycleManager({
         };
       }
 
-      return {
-        ...(await startFresh({ repoRoot, requestedRepo: restartRepo })),
-        detail: 'Restarted the managed inspect-run viewer.',
-      };
+      const restarted = await startFresh({ repoRoot, requestedRepo: restartRepo });
+      return restarted.state === 'running'
+        ? {
+            ...restarted,
+            detail: 'Restarted the managed inspect-run viewer.',
+          }
+        : restarted;
     },
   };
 }

--- a/scripts/loop/inspect-run-viewer/managed-instance.mjs
+++ b/scripts/loop/inspect-run-viewer/managed-instance.mjs
@@ -151,6 +151,12 @@ async function readManagedRecord(recordPath) {
     if (error?.code === 'ENOENT') {
       return null;
     }
+    if (error instanceof SyntaxError) {
+      return {
+        invalidRecord: true,
+        parseError: error.message,
+      };
+    }
     throw error;
   }
 }
@@ -202,6 +208,16 @@ export function createInspectRunViewerLifecycleManager({
   async function inspectRecord({ repoRoot }) {
     const recordPath = path.join(repoRoot, INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH);
     const record = await readManagedRecord(recordPath);
+    if (record?.invalidRecord === true) {
+      return {
+        recordPath,
+        record: null,
+        state: 'stale_record',
+        url: formatInspectRunViewerUrl(DEFAULT_HOST, DEFAULT_PORT),
+        detail: 'The managed inspect-run viewer record is unreadable; delete `.pi/ui-servers/inspect-run-viewer.json` and reopen the viewer.',
+        listeners: await listListeningPidsImpl(DEFAULT_PORT),
+      };
+    }
     if (!record) {
       const listeners = await listListeningPidsImpl(DEFAULT_PORT);
       if (listeners.length > 0) {
@@ -306,6 +322,9 @@ export function createInspectRunViewerLifecycleManager({
   }
 
   async function maybeOpenBrowser(result) {
+    if (result.state !== 'running' || typeof result.url !== 'string' || result.url.length === 0) {
+      return result;
+    }
     try {
       await openBrowserImpl(result.url);
       return result;
@@ -443,6 +462,17 @@ export function createInspectRunViewerLifecycleManager({
           warning: null,
           recordPath: snapshot.recordPath,
           record: null,
+        };
+      }
+
+      if (snapshot.state === 'running' && snapshot.record && !canServeRequestedRepo(snapshot.record, requestedRepo)) {
+        return {
+          state: 'stopped',
+          url: null,
+          detail: 'A different managed inspect-run viewer is running; stop without `--repo` or use `open` to replace it for this repo.',
+          warning: null,
+          recordPath: snapshot.recordPath,
+          record: snapshot.record,
         };
       }
 

--- a/scripts/loop/inspect-run-viewer/managed-instance.mjs
+++ b/scripts/loop/inspect-run-viewer/managed-instance.mjs
@@ -1,0 +1,516 @@
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { normalizeCliRepoOption } from './cli.mjs';
+import { DEFAULT_HOST, DEFAULT_PORT } from './constants.mjs';
+import { formatInspectRunViewerUrl, listListeningPidsForPort } from './server.mjs';
+
+export const INSPECT_RUN_VIEWER_SURFACE_ID = 'inspect-run-viewer';
+export const INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH = '.pi/ui-servers/inspect-run-viewer.json';
+const VIEWER_SCRIPT_PATH = fileURLToPath(new URL('../inspect-run-viewer.mjs', import.meta.url));
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function normalizeRequestedRepo(repo) {
+  if (repo === undefined || repo === null || `${repo}`.trim() === '') {
+    return null;
+  }
+  return normalizeCliRepoOption(`${repo}`);
+}
+
+function buildLaunchArgs(repo) {
+  return {
+    repo,
+    host: DEFAULT_HOST,
+    port: DEFAULT_PORT,
+  };
+}
+
+function buildArgsFingerprint(launchArgs) {
+  return JSON.stringify({ repo: launchArgs.repo, host: launchArgs.host, port: launchArgs.port });
+}
+
+function buildRecordPayload({ repoRoot, launchArgs, pid, startedAt }) {
+  return {
+    schemaVersion: 1,
+    surfaceId: INSPECT_RUN_VIEWER_SURFACE_ID,
+    argsFingerprint: buildArgsFingerprint(launchArgs),
+    launchArgs,
+    host: launchArgs.host,
+    port: launchArgs.port,
+    url: formatInspectRunViewerUrl(launchArgs.host, launchArgs.port),
+    pid,
+    startedAt,
+    cwd: repoRoot,
+  };
+}
+
+function baseUrlForRecord(record) {
+  const host = record?.host ?? DEFAULT_HOST;
+  const port = record?.port ?? DEFAULT_PORT;
+  return formatInspectRunViewerUrl(host, port);
+}
+
+function buildOperatorUrl(record, requestedRepo) {
+  const baseUrl = baseUrlForRecord(record);
+  const managedRepo = record?.launchArgs?.repo ?? null;
+  if (requestedRepo === null || managedRepo !== null) {
+    return baseUrl;
+  }
+  const url = new URL(baseUrl);
+  url.searchParams.set('scope', requestedRepo);
+  return url.toString().replace(/\/$/, '');
+}
+
+function canServeRequestedRepo(record, requestedRepo) {
+  if (!record) {
+    return false;
+  }
+  if (requestedRepo === null) {
+    return true;
+  }
+  const managedRepo = record.launchArgs?.repo ?? null;
+  return managedRepo === null || managedRepo === requestedRepo;
+}
+
+async function defaultIsProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === 'ESRCH') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function defaultHealthcheck(url) {
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      signal: AbortSignal.timeout(1500),
+    });
+    return response.status === 200;
+  } catch {
+    return false;
+  }
+}
+
+async function defaultLaunchManagedServer({ repoRoot, repo, host, port }) {
+  const args = [VIEWER_SCRIPT_PATH, '--host', host, '--port', String(port)];
+  if (repo !== null) {
+    args.push('--repo', repo);
+  }
+  const child = spawn(process.execPath, args, {
+    cwd: repoRoot,
+    detached: true,
+    stdio: 'ignore',
+    env: process.env,
+  });
+  child.unref();
+  return { pid: child.pid };
+}
+
+async function defaultStopManagedProcess(pid) {
+  process.kill(pid, 'SIGTERM');
+}
+
+async function defaultOpenBrowser(url) {
+  let command;
+  let args;
+  let options = { detached: true, stdio: 'ignore' };
+  switch (process.platform) {
+    case 'darwin':
+      command = 'open';
+      args = [url];
+      break;
+    case 'win32':
+      command = 'cmd';
+      args = ['/c', 'start', '', url];
+      options = { detached: true, stdio: 'ignore', windowsHide: true };
+      break;
+    default:
+      command = 'xdg-open';
+      args = [url];
+      break;
+  }
+  const child = spawn(command, args, options);
+  child.on('error', () => {});
+  child.unref();
+}
+
+async function readManagedRecord(recordPath) {
+  try {
+    return JSON.parse(await readFile(recordPath, 'utf8'));
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function writeManagedRecord(recordPath, payload) {
+  await mkdir(path.dirname(recordPath), { recursive: true });
+  await writeFile(recordPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+async function removeManagedRecord(recordPath) {
+  await rm(recordPath, { force: true });
+}
+
+async function waitForManagedExit(record, { isProcessAliveImpl, listListeningPidsImpl, waitImpl, timeoutMs = 3000, pollIntervalMs = 100 }) {
+  if (!record?.pid) {
+    return;
+  }
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const [alive, listeners] = await Promise.all([
+      isProcessAliveImpl(record.pid),
+      listListeningPidsImpl(record.port ?? DEFAULT_PORT),
+    ]);
+    if (!alive && !listeners.includes(record.pid)) {
+      return;
+    }
+    await waitImpl(pollIntervalMs);
+  }
+}
+
+function summarizeRunning(record, requestedRepo) {
+  return {
+    state: 'running',
+    url: buildOperatorUrl(record, requestedRepo),
+    detail: 'Managed inspect-run viewer is running.',
+  };
+}
+
+export function createInspectRunViewerLifecycleManager({
+  listListeningPidsImpl = listListeningPidsForPort,
+  isProcessAliveImpl = defaultIsProcessAlive,
+  healthcheckUrlImpl = defaultHealthcheck,
+  launchManagedServerImpl = defaultLaunchManagedServer,
+  stopManagedProcessImpl = defaultStopManagedProcess,
+  openBrowserImpl = defaultOpenBrowser,
+  nowImpl = () => new Date().toISOString(),
+  waitImpl = sleep,
+} = {}) {
+  async function inspectRecord({ repoRoot }) {
+    const recordPath = path.join(repoRoot, INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH);
+    const record = await readManagedRecord(recordPath);
+    if (!record) {
+      const listeners = await listListeningPidsImpl(DEFAULT_PORT);
+      if (listeners.length > 0) {
+        return {
+          recordPath,
+          record: null,
+          state: 'conflict_unmanaged_listener',
+          url: formatInspectRunViewerUrl(DEFAULT_HOST, DEFAULT_PORT),
+          detail: 'Port 4311 is occupied by an unmanaged listener.',
+          listeners,
+        };
+      }
+      return {
+        recordPath,
+        record: null,
+        state: 'stopped',
+        url: null,
+        detail: 'No managed inspect-run viewer is recorded.',
+        listeners: [],
+      };
+    }
+
+    const listeners = await listListeningPidsImpl(record.port ?? DEFAULT_PORT);
+    const alive = typeof record.pid === 'number' && record.pid > 0
+      ? await isProcessAliveImpl(record.pid)
+      : false;
+    const listening = alive && listeners.includes(record.pid);
+    const healthy = listening ? await healthcheckUrlImpl(baseUrlForRecord(record)) : false;
+
+    if (alive && listening && healthy) {
+      return {
+        recordPath,
+        record,
+        state: 'running',
+        url: baseUrlForRecord(record),
+        detail: 'Managed inspect-run viewer is running.',
+        listeners,
+      };
+    }
+
+    return {
+      recordPath,
+      record,
+      state: 'stale_record',
+      url: baseUrlForRecord(record),
+      detail: 'The managed inspect-run viewer record is stale.',
+      listeners,
+    };
+  }
+
+  async function startFresh({ repoRoot, requestedRepo }) {
+    const launchArgs = buildLaunchArgs(requestedRepo);
+    const recordPath = path.join(repoRoot, INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH);
+    const baseUrl = formatInspectRunViewerUrl(launchArgs.host, launchArgs.port);
+    const listeners = await listListeningPidsImpl(launchArgs.port);
+    if (listeners.length > 0) {
+      return {
+        state: 'conflict_unmanaged_listener',
+        url: baseUrl,
+        detail: 'Port 4311 is occupied by an unmanaged listener.',
+        warning: null,
+        recordPath,
+      };
+    }
+
+    const { pid } = await launchManagedServerImpl({
+      repoRoot,
+      repo: requestedRepo,
+      host: launchArgs.host,
+      port: launchArgs.port,
+      url: baseUrl,
+    });
+    const record = buildRecordPayload({ repoRoot, launchArgs, pid, startedAt: nowImpl() });
+
+    const deadline = Date.now() + 8000;
+    while (Date.now() < deadline) {
+      const [alive, healthy] = await Promise.all([
+        isProcessAliveImpl(pid),
+        healthcheckUrlImpl(baseUrl),
+      ]);
+      if (!alive) {
+        throw new Error('inspect-run viewer exited before becoming healthy');
+      }
+      if (healthy) {
+        await writeManagedRecord(recordPath, record);
+        return {
+          state: 'running',
+          url: buildOperatorUrl(record, requestedRepo),
+          detail: 'Started a managed inspect-run viewer.',
+          warning: null,
+          recordPath,
+          record,
+          startedFresh: true,
+          reusedExisting: false,
+          resumedExisting: false,
+        };
+      }
+      await waitImpl(100);
+    }
+
+    throw new Error('inspect-run viewer did not become healthy before the startup timeout');
+  }
+
+  async function maybeOpenBrowser(result) {
+    try {
+      await openBrowserImpl(result.url);
+      return result;
+    } catch (error) {
+      return {
+        ...result,
+        warning: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  return {
+    async open({ repoRoot, repo } = {}) {
+      const requestedRepo = normalizeRequestedRepo(repo);
+      const snapshot = await inspectRecord({ repoRoot });
+      if (snapshot.state === 'running' && canServeRequestedRepo(snapshot.record, requestedRepo)) {
+        return maybeOpenBrowser({
+          ...summarizeRunning(snapshot.record, requestedRepo),
+          warning: null,
+          recordPath: snapshot.recordPath,
+          record: snapshot.record,
+          startedFresh: false,
+          reusedExisting: true,
+          resumedExisting: false,
+        });
+      }
+
+      if (snapshot.state === 'running' && snapshot.record) {
+        await stopManagedProcessImpl(snapshot.record.pid);
+        await waitForManagedExit(snapshot.record, {
+          isProcessAliveImpl,
+          listListeningPidsImpl,
+          waitImpl,
+        });
+        await removeManagedRecord(snapshot.recordPath);
+      } else if (snapshot.state === 'stale_record') {
+        if (snapshot.record?.pid && await isProcessAliveImpl(snapshot.record.pid)) {
+          await stopManagedProcessImpl(snapshot.record.pid);
+          await waitForManagedExit(snapshot.record, {
+            isProcessAliveImpl,
+            listListeningPidsImpl,
+            waitImpl,
+          });
+        }
+        await removeManagedRecord(snapshot.recordPath);
+      }
+
+      return maybeOpenBrowser(await startFresh({ repoRoot, requestedRepo }));
+    },
+
+    async resume({ repoRoot, repo } = {}) {
+      const requestedRepo = normalizeRequestedRepo(repo);
+      const snapshot = await inspectRecord({ repoRoot });
+      if (snapshot.state === 'running' && canServeRequestedRepo(snapshot.record, requestedRepo)) {
+        return {
+          ...summarizeRunning(snapshot.record, requestedRepo),
+          warning: null,
+          recordPath: snapshot.recordPath,
+          record: snapshot.record,
+          startedFresh: false,
+          reusedExisting: false,
+          resumedExisting: true,
+        };
+      }
+      return {
+        state: snapshot.state === 'conflict_unmanaged_listener' ? 'conflict_unmanaged_listener' : 'stopped',
+        url: snapshot.state === 'conflict_unmanaged_listener' ? snapshot.url : null,
+        detail: 'No managed inspect-run viewer is running; use `/dev-loops ui inspect-run open`.',
+        warning: null,
+        recordPath: snapshot.recordPath,
+        record: snapshot.record,
+        startedFresh: false,
+        reusedExisting: false,
+        resumedExisting: false,
+      };
+    },
+
+    async status({ repoRoot, repo } = {}) {
+      const requestedRepo = normalizeRequestedRepo(repo);
+      const snapshot = await inspectRecord({ repoRoot });
+      if (snapshot.state === 'running') {
+        if (!canServeRequestedRepo(snapshot.record, requestedRepo)) {
+          return {
+            state: 'stopped',
+            url: null,
+            detail: 'A different managed inspect-run viewer is running; use `open` to replace it for this repo.',
+            warning: null,
+            recordPath: snapshot.recordPath,
+            record: snapshot.record,
+          };
+        }
+        return {
+          ...summarizeRunning(snapshot.record, requestedRepo),
+          warning: null,
+          recordPath: snapshot.recordPath,
+          record: snapshot.record,
+        };
+      }
+      return {
+        state: snapshot.state,
+        url: snapshot.state === 'stopped' ? null : buildOperatorUrl(snapshot.record ?? undefined, requestedRepo),
+        detail: snapshot.detail,
+        warning: null,
+        recordPath: snapshot.recordPath,
+        record: snapshot.record,
+      };
+    },
+
+    async stop({ repoRoot, repo } = {}) {
+      const requestedRepo = normalizeRequestedRepo(repo);
+      const snapshot = await inspectRecord({ repoRoot });
+      if (snapshot.state === 'running' && snapshot.record && canServeRequestedRepo(snapshot.record, requestedRepo)) {
+        await stopManagedProcessImpl(snapshot.record.pid);
+        await waitForManagedExit(snapshot.record, {
+          isProcessAliveImpl,
+          listListeningPidsImpl,
+          waitImpl,
+        });
+        await removeManagedRecord(snapshot.recordPath);
+        const listeners = await listListeningPidsImpl(snapshot.record.port ?? DEFAULT_PORT);
+        if (listeners.length > 0) {
+          return {
+            state: 'conflict_unmanaged_listener',
+            url: baseUrlForRecord(snapshot.record),
+            detail: 'Stopped the managed inspect-run viewer, but another listener is still using the port.',
+            warning: null,
+            recordPath: snapshot.recordPath,
+            record: null,
+          };
+        }
+        return {
+          state: 'stopped',
+          url: null,
+          detail: 'Stopped the managed inspect-run viewer.',
+          warning: null,
+          recordPath: snapshot.recordPath,
+          record: null,
+        };
+      }
+
+      if (snapshot.state === 'stale_record') {
+        await removeManagedRecord(snapshot.recordPath);
+        const listeners = await listListeningPidsImpl(snapshot.record?.port ?? DEFAULT_PORT);
+        return {
+          state: listeners.length > 0 ? 'conflict_unmanaged_listener' : 'stopped',
+          url: listeners.length > 0 ? baseUrlForRecord(snapshot.record) : null,
+          detail: listeners.length > 0
+            ? 'Cleared the stale managed record, but the port is still occupied by an unmanaged listener.'
+            : 'Cleared the stale managed inspect-run viewer record.',
+          warning: null,
+          recordPath: snapshot.recordPath,
+          record: null,
+        };
+      }
+
+      return {
+        state: snapshot.state,
+        url: snapshot.state === 'conflict_unmanaged_listener' ? snapshot.url : null,
+        detail: snapshot.detail,
+        warning: null,
+        recordPath: snapshot.recordPath,
+        record: null,
+      };
+    },
+
+    async restart({ repoRoot, repo } = {}) {
+      const requestedRepo = normalizeRequestedRepo(repo);
+      const snapshot = await inspectRecord({ repoRoot });
+      const restartRepo = snapshot.record?.launchArgs?.repo ?? requestedRepo;
+
+      if (snapshot.state === 'running' && snapshot.record) {
+        if (requestedRepo !== null && !canServeRequestedRepo(snapshot.record, requestedRepo)) {
+          return {
+            state: 'stopped',
+            url: null,
+            detail: 'Restart uses the managed instance arguments; stop/open to switch repos.',
+            warning: null,
+            recordPath: snapshot.recordPath,
+            record: snapshot.record,
+          };
+        }
+        await stopManagedProcessImpl(snapshot.record.pid);
+        await waitForManagedExit(snapshot.record, {
+          isProcessAliveImpl,
+          listListeningPidsImpl,
+          waitImpl,
+        });
+        await removeManagedRecord(snapshot.recordPath);
+      } else if (snapshot.state === 'stale_record') {
+        await removeManagedRecord(snapshot.recordPath);
+      } else if (snapshot.state === 'conflict_unmanaged_listener') {
+        return {
+          state: 'conflict_unmanaged_listener',
+          url: snapshot.url,
+          detail: 'Restart refused to stop an unmanaged listener on the inspect-run viewer port.',
+          warning: null,
+          recordPath: snapshot.recordPath,
+          record: snapshot.record,
+        };
+      }
+
+      return {
+        ...(await startFresh({ repoRoot, requestedRepo: restartRepo })),
+        detail: 'Restarted the managed inspect-run viewer.',
+      };
+    },
+  };
+}

--- a/scripts/loop/inspect-run-viewer/managed-instance.mjs
+++ b/scripts/loop/inspect-run-viewer/managed-instance.mjs
@@ -212,12 +212,12 @@ async function stopManagedProcessSafely(pid, { stopManagedProcessImpl }) {
   }
 }
 
-async function waitForManagedExit(record, { isProcessAliveImpl, listListeningPidsImpl: listListeningPids, waitImpl, timeoutMs = 3000, pollIntervalMs = 100 }) {
+async function waitForManagedExit(record, { isProcessAliveImpl, listListeningPidsImpl: listListeningPids, waitImpl, nowMsImpl, timeoutMs = 3000, pollIntervalMs = 100 }) {
   if (!record?.pid) {
     return;
   }
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
+  const deadline = nowMsImpl() + timeoutMs;
+  while (nowMsImpl() < deadline) {
     const [alive, listeners] = await Promise.all([
       isProcessAliveImpl(record.pid),
       listListeningPids(record.port ?? DEFAULT_PORT),
@@ -245,6 +245,7 @@ export function createInspectRunViewerLifecycleManager({
   stopManagedProcessImpl = defaultStopManagedProcess,
   openBrowserImpl = defaultOpenBrowser,
   nowImpl = () => new Date().toISOString(),
+  nowMsImpl = () => Date.now(),
   waitImpl = sleep,
 } = {}) {
   async function listListeningPids(port) {
@@ -346,8 +347,8 @@ export function createInspectRunViewerLifecycleManager({
     const record = buildRecordPayload({ repoRoot, launchArgs, pid, startedAt: nowImpl() });
 
     try {
-      const deadline = Date.now() + 8000;
-      while (Date.now() < deadline) {
+      const deadline = nowMsImpl() + 8000;
+      while (nowMsImpl() < deadline) {
         const [alive, healthy] = await Promise.all([
           isProcessAliveImpl(pid),
           healthcheckUrlImpl(baseUrl),
@@ -380,6 +381,7 @@ export function createInspectRunViewerLifecycleManager({
         isProcessAliveImpl,
         listListeningPidsImpl: listListeningPids,
         waitImpl,
+        nowMsImpl,
       });
       throw error;
     }
@@ -422,6 +424,7 @@ export function createInspectRunViewerLifecycleManager({
           isProcessAliveImpl,
           listListeningPidsImpl: listListeningPids,
           waitImpl,
+          nowMsImpl,
         });
         await removeManagedRecord(snapshot.recordPath);
       } else if (snapshot.state === 'stale_record') {
@@ -508,6 +511,7 @@ export function createInspectRunViewerLifecycleManager({
           isProcessAliveImpl,
           listListeningPidsImpl: listListeningPids,
           waitImpl,
+          nowMsImpl,
         });
         await removeManagedRecord(snapshot.recordPath);
         const listeners = await listListeningPids(snapshot.record.port ?? DEFAULT_PORT);
@@ -588,6 +592,7 @@ export function createInspectRunViewerLifecycleManager({
           isProcessAliveImpl,
           listListeningPidsImpl: listListeningPids,
           waitImpl,
+          nowMsImpl,
         });
         await removeManagedRecord(snapshot.recordPath);
       } else if (snapshot.state === 'stale_record') {

--- a/scripts/loop/inspect-run-viewer/managed-instance.mjs
+++ b/scripts/loop/inspect-run-viewer/managed-instance.mjs
@@ -15,6 +15,15 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function normalizeListenerDiscoveryError(error) {
+  const missingLsof = error?.code === 'ENOENT'
+    && (error?.path === 'lsof' || /(^|\b)lsof(\b|$)/i.test(String(error?.message ?? '')));
+  if (!missingLsof) {
+    return error;
+  }
+  return new Error('inspect-run viewer lifecycle requires lsof/POSIX support to inspect local listeners; install lsof or use the script fallback.');
+}
+
 function normalizeRequestedRepo(repo) {
   if (repo === undefined || repo === null || `${repo}`.trim() === '') {
     return null;
@@ -198,7 +207,7 @@ async function stopManagedProcessSafely(pid, { stopManagedProcessImpl }) {
   }
 }
 
-async function waitForManagedExit(record, { isProcessAliveImpl, listListeningPidsImpl, waitImpl, timeoutMs = 3000, pollIntervalMs = 100 }) {
+async function waitForManagedExit(record, { isProcessAliveImpl, listListeningPidsImpl: listListeningPids, waitImpl, timeoutMs = 3000, pollIntervalMs = 100 }) {
   if (!record?.pid) {
     return;
   }
@@ -206,7 +215,7 @@ async function waitForManagedExit(record, { isProcessAliveImpl, listListeningPid
   while (Date.now() < deadline) {
     const [alive, listeners] = await Promise.all([
       isProcessAliveImpl(record.pid),
-      listListeningPidsImpl(record.port ?? DEFAULT_PORT),
+      listListeningPids(record.port ?? DEFAULT_PORT),
     ]);
     if (!alive && !listeners.includes(record.pid)) {
       return;
@@ -233,6 +242,14 @@ export function createInspectRunViewerLifecycleManager({
   nowImpl = () => new Date().toISOString(),
   waitImpl = sleep,
 } = {}) {
+  async function listListeningPids(port) {
+    try {
+      return await listListeningPidsImpl(port);
+    } catch (error) {
+      throw normalizeListenerDiscoveryError(error);
+    }
+  }
+
   async function inspectRecord({ repoRoot }) {
     const recordPath = path.join(repoRoot, INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH);
     const record = await readManagedRecord(recordPath);
@@ -243,11 +260,11 @@ export function createInspectRunViewerLifecycleManager({
         state: 'stale_record',
         url: formatInspectRunViewerUrl(DEFAULT_HOST, DEFAULT_PORT),
         detail: 'The managed inspect-run viewer record is unreadable; delete `.pi/ui-servers/inspect-run-viewer.json` and reopen the viewer.',
-        listeners: await listListeningPidsImpl(DEFAULT_PORT),
+        listeners: await listListeningPids(DEFAULT_PORT),
       };
     }
     if (!record) {
-      const listeners = await listListeningPidsImpl(DEFAULT_PORT);
+      const listeners = await listListeningPids(DEFAULT_PORT);
       if (listeners.length > 0) {
         return {
           recordPath,
@@ -268,7 +285,7 @@ export function createInspectRunViewerLifecycleManager({
       };
     }
 
-    const listeners = await listListeningPidsImpl(record.port ?? DEFAULT_PORT);
+    const listeners = await listListeningPids(record.port ?? DEFAULT_PORT);
     const alive = typeof record.pid === 'number' && record.pid > 0
       ? await isProcessAliveImpl(record.pid)
       : false;
@@ -300,7 +317,7 @@ export function createInspectRunViewerLifecycleManager({
     const launchArgs = buildLaunchArgs(requestedRepo);
     const recordPath = path.join(repoRoot, INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH);
     const baseUrl = formatInspectRunViewerUrl(launchArgs.host, launchArgs.port);
-    const listeners = await listListeningPidsImpl(launchArgs.port);
+    const listeners = await listListeningPids(launchArgs.port);
     if (listeners.length > 0) {
       return {
         state: 'conflict_unmanaged_listener',
@@ -353,7 +370,7 @@ export function createInspectRunViewerLifecycleManager({
       }
       await waitForManagedExit(record, {
         isProcessAliveImpl,
-        listListeningPidsImpl,
+        listListeningPidsImpl: listListeningPids,
         waitImpl,
       });
       throw error;
@@ -395,7 +412,7 @@ export function createInspectRunViewerLifecycleManager({
         await stopManagedProcessSafely(snapshot.record.pid, { stopManagedProcessImpl });
         await waitForManagedExit(snapshot.record, {
           isProcessAliveImpl,
-          listListeningPidsImpl,
+          listListeningPidsImpl: listListeningPids,
           waitImpl,
         });
         await removeManagedRecord(snapshot.recordPath);
@@ -406,7 +423,7 @@ export function createInspectRunViewerLifecycleManager({
           await stopManagedProcessSafely(snapshot.record.pid, { stopManagedProcessImpl });
           await waitForManagedExit(snapshot.record, {
             isProcessAliveImpl,
-            listListeningPidsImpl,
+            listListeningPidsImpl: listListeningPids,
             waitImpl,
           });
         }
@@ -466,7 +483,7 @@ export function createInspectRunViewerLifecycleManager({
       }
       return {
         state: snapshot.state,
-        url: snapshot.state === 'running' ? buildOperatorUrl(snapshot.record ?? undefined, requestedRepo) : snapshot.url,
+        url: snapshot.url,
         detail: snapshot.detail,
         warning: null,
         recordPath: snapshot.recordPath,
@@ -481,11 +498,11 @@ export function createInspectRunViewerLifecycleManager({
         await stopManagedProcessSafely(snapshot.record.pid, { stopManagedProcessImpl });
         await waitForManagedExit(snapshot.record, {
           isProcessAliveImpl,
-          listListeningPidsImpl,
+          listListeningPidsImpl: listListeningPids,
           waitImpl,
         });
         await removeManagedRecord(snapshot.recordPath);
-        const listeners = await listListeningPidsImpl(snapshot.record.port ?? DEFAULT_PORT);
+        const listeners = await listListeningPids(snapshot.record.port ?? DEFAULT_PORT);
         if (listeners.length > 0) {
           return {
             state: 'conflict_unmanaged_listener',
@@ -519,7 +536,7 @@ export function createInspectRunViewerLifecycleManager({
 
       if (snapshot.state === 'stale_record') {
         await removeManagedRecord(snapshot.recordPath);
-        const listeners = await listListeningPidsImpl(snapshot.record?.port ?? DEFAULT_PORT);
+        const listeners = await listListeningPids(snapshot.record?.port ?? DEFAULT_PORT);
         return {
           state: listeners.length > 0 ? 'conflict_unmanaged_listener' : 'stopped',
           url: listeners.length > 0 ? baseUrlForRecord(snapshot.record) : null,
@@ -561,7 +578,7 @@ export function createInspectRunViewerLifecycleManager({
         await stopManagedProcessSafely(snapshot.record.pid, { stopManagedProcessImpl });
         await waitForManagedExit(snapshot.record, {
           isProcessAliveImpl,
-          listListeningPidsImpl,
+          listListeningPidsImpl: listListeningPids,
           waitImpl,
         });
         await removeManagedRecord(snapshot.recordPath);

--- a/scripts/loop/inspect-run-viewer/managed-instance.mjs
+++ b/scripts/loop/inspect-run-viewer/managed-instance.mjs
@@ -62,7 +62,8 @@ function isManagedRecordShape(record) {
   return Boolean(record)
     && record.surfaceId === INSPECT_RUN_VIEWER_SURFACE_ID
     && record.schemaVersion === 1
-    && typeof record.pid === 'number'
+    && Number.isInteger(record.pid)
+    && record.pid > 0
     && record.host === DEFAULT_HOST
     && record.port === DEFAULT_PORT
     && record.launchArgs

--- a/scripts/loop/inspect-run-viewer/managed-instance.mjs
+++ b/scripts/loop/inspect-run-viewer/managed-instance.mjs
@@ -276,7 +276,7 @@ export function createInspectRunViewerLifecycleManager({
           record: null,
           state: 'conflict_unmanaged_listener',
           url: formatInspectRunViewerUrl(DEFAULT_HOST, DEFAULT_PORT),
-          detail: 'Port 4311 is occupied by an unmanaged listener.',
+          detail: `Port ${DEFAULT_PORT} is occupied by an unmanaged listener.`,
           listeners,
         };
       }
@@ -327,7 +327,7 @@ export function createInspectRunViewerLifecycleManager({
       return {
         state: 'conflict_unmanaged_listener',
         url: baseUrl,
-        detail: 'Port 4311 is occupied by an unmanaged listener.',
+        detail: `Port ${DEFAULT_PORT} is occupied by an unmanaged listener.`,
         warning: null,
         recordPath,
       };

--- a/scripts/loop/inspect-run-viewer/managed-instance.mjs
+++ b/scripts/loop/inspect-run-viewer/managed-instance.mjs
@@ -31,6 +31,13 @@ function normalizeRequestedRepo(repo) {
   return normalizeCliRepoOption(`${repo}`);
 }
 
+function requireRepoRoot(repoRoot) {
+  if (typeof repoRoot !== 'string' || repoRoot.trim() === '') {
+    throw new Error('inspect-run viewer lifecycle requires a repoRoot.');
+  }
+  return repoRoot;
+}
+
 function buildLaunchArgs(repo) {
   return {
     repo,
@@ -257,7 +264,7 @@ export function createInspectRunViewerLifecycleManager({
   }
 
   async function inspectRecord({ repoRoot }) {
-    const recordPath = path.join(repoRoot, INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH);
+    const recordPath = path.join(requireRepoRoot(repoRoot), INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH);
     const record = await readManagedRecord(recordPath);
     if (record?.invalidRecord === true || (record !== null && !isManagedRecordShape(record))) {
       return {

--- a/test/dev-loops-core.test.mjs
+++ b/test/dev-loops-core.test.mjs
@@ -148,3 +148,26 @@ test("collectDevLoopChecks no longer reports a dev-loop skill readiness check", 
   const checks = await collectDevLoopChecks(createRuntime());
   assert.equal(checks.some((check) => check.id === "local-dev-loop-skill"), false);
 });
+
+test("parser accepts the bounded inspect-run UI lifecycle command family only on the extension surface", () => {
+  for (const action of ["open", "resume", "status", "stop", "restart"]) {
+    const parsed = parseDevLoopsCommand(["ui", "inspect-run", action, "--repo", "mfittko/pi-dev-loops"], { surface: "extension" });
+    assert.equal(parsed.kind, "ui_inspect_run_action");
+    assert.equal(parsed.action, action);
+    assert.equal(parsed.repo, "mfittko/pi-dev-loops");
+  }
+
+  assert.deepEqual(parseDevLoopsCommand(["ui", "inspect-run", "launch"], { surface: "extension" }), {
+    kind: "malformed",
+    message: "`/dev-loops ui inspect-run` only supports: open, resume, status, stop, restart.",
+    usageAction: "ui inspect-run",
+    tokens: ["ui", "inspect-run", "launch"],
+  });
+
+  assert.deepEqual(parseDevLoopsCommand(["ui", "inspect-run", "open"], { surface: "cli" }), {
+    kind: "malformed",
+    message: "Unrecognized command: ui.",
+    usageAction: undefined,
+    tokens: ["ui", "inspect-run", "open"],
+  });
+});

--- a/test/dev-loops-core.test.mjs
+++ b/test/dev-loops-core.test.mjs
@@ -199,3 +199,31 @@ test('executor returns a structured inspect-run UI result when repo-root lookup 
     warning: null,
   });
 });
+
+test('executor preserves repoRoot when the inspect-run lifecycle action throws after repo-root lookup succeeds', async () => {
+  const result = await executeDevLoopsCommand({
+    input: ['ui', 'inspect-run', 'open'],
+    surface: 'extension',
+    runtime: {
+      async getRepoRoot() {
+        return '/repo/root';
+      },
+      uiLifecycle: {
+        async open() {
+          throw new Error('launch failed');
+        },
+      },
+    },
+  });
+
+  assert.deepEqual(result, {
+    kind: 'ui_inspect_run_result',
+    action: 'open',
+    repo: null,
+    repoRoot: '/repo/root',
+    state: 'stopped',
+    url: null,
+    detail: 'launch failed',
+    warning: null,
+  });
+});

--- a/test/dev-loops-core.test.mjs
+++ b/test/dev-loops-core.test.mjs
@@ -149,32 +149,32 @@ test("collectDevLoopChecks no longer reports a dev-loop skill readiness check", 
   assert.equal(checks.some((check) => check.id === "local-dev-loop-skill"), false);
 });
 
-test("parser accepts the bounded inspect-run UI lifecycle command family only on the extension surface", () => {
+test("parser accepts the bounded inspect lifecycle command family only on the extension surface", () => {
   for (const action of ["open", "resume", "status", "stop", "restart"]) {
-    const parsed = parseDevLoopsCommand(["ui", "inspect-run", action, "--repo", "mfittko/pi-dev-loops"], { surface: "extension" });
-    assert.equal(parsed.kind, "ui_inspect_run_action");
+    const parsed = parseDevLoopsCommand(["inspect", action, "--repo", "mfittko/pi-dev-loops"], { surface: "extension" });
+    assert.equal(parsed.kind, "inspect_action");
     assert.equal(parsed.action, action);
     assert.equal(parsed.repo, "mfittko/pi-dev-loops");
   }
 
-  assert.deepEqual(parseDevLoopsCommand(["ui", "inspect-run", "launch"], { surface: "extension" }), {
+  assert.deepEqual(parseDevLoopsCommand(["inspect", "launch"], { surface: "extension" }), {
     kind: "malformed",
-    message: "`/dev-loops ui inspect-run` only supports: open, resume, status, stop, restart.",
-    usageAction: "ui inspect-run",
-    tokens: ["ui", "inspect-run", "launch"],
+    message: "`/dev-loops inspect` only supports: open, resume, status, stop, restart.",
+    usageAction: "inspect",
+    tokens: ["inspect", "launch"],
   });
 
-  assert.deepEqual(parseDevLoopsCommand(["ui", "inspect-run", "open"], { surface: "cli" }), {
+  assert.deepEqual(parseDevLoopsCommand(["inspect", "open"], { surface: "cli" }), {
     kind: "malformed",
-    message: "Unrecognized command: ui.",
+    message: "Unrecognized command: inspect.",
     usageAction: undefined,
-    tokens: ["ui", "inspect-run", "open"],
+    tokens: ["inspect", "open"],
   });
 });
 
 test('executor returns a structured inspect-run UI result when repo-root lookup or lifecycle execution throws', async () => {
   const repoRootFailure = await executeDevLoopsCommand({
-    input: ['ui', 'inspect-run', 'open'],
+    input: ['inspect', 'open'],
     surface: 'extension',
     runtime: {
       async getRepoRoot() {
@@ -189,7 +189,7 @@ test('executor returns a structured inspect-run UI result when repo-root lookup 
   });
 
   assert.deepEqual(repoRootFailure, {
-    kind: 'ui_inspect_run_result',
+    kind: 'inspect_result',
     action: 'open',
     repo: null,
     repoRoot: null,
@@ -202,7 +202,7 @@ test('executor returns a structured inspect-run UI result when repo-root lookup 
 
 test('executor preserves repoRoot when the inspect-run lifecycle action throws after repo-root lookup succeeds', async () => {
   const result = await executeDevLoopsCommand({
-    input: ['ui', 'inspect-run', 'open'],
+    input: ['inspect', 'open'],
     surface: 'extension',
     runtime: {
       async getRepoRoot() {
@@ -217,7 +217,7 @@ test('executor preserves repoRoot when the inspect-run lifecycle action throws a
   });
 
   assert.deepEqual(result, {
-    kind: 'ui_inspect_run_result',
+    kind: 'inspect_result',
     action: 'open',
     repo: null,
     repoRoot: '/repo/root',

--- a/test/dev-loops-core.test.mjs
+++ b/test/dev-loops-core.test.mjs
@@ -171,3 +171,31 @@ test("parser accepts the bounded inspect-run UI lifecycle command family only on
     tokens: ["ui", "inspect-run", "open"],
   });
 });
+
+test('executor returns a structured inspect-run UI result when repo-root lookup or lifecycle execution throws', async () => {
+  const repoRootFailure = await executeDevLoopsCommand({
+    input: ['ui', 'inspect-run', 'open'],
+    surface: 'extension',
+    runtime: {
+      async getRepoRoot() {
+        throw new Error('not in a git repo');
+      },
+      uiLifecycle: {
+        async open() {
+          throw new Error('should not run');
+        },
+      },
+    },
+  });
+
+  assert.deepEqual(repoRootFailure, {
+    kind: 'ui_inspect_run_result',
+    action: 'open',
+    repo: null,
+    repoRoot: null,
+    state: 'stopped',
+    url: null,
+    detail: 'not in a git repo',
+    warning: null,
+  });
+});

--- a/test/extension-command-contract.test.mjs
+++ b/test/extension-command-contract.test.mjs
@@ -297,3 +297,26 @@ test('extension treats successful inspect-run stop as an info notification', asy
   assert.equal(calls.notifications.at(-1).message, 'inspect-run viewer stop: stopped');
   assert.equal(calls.notifications.at(-1).level, 'info');
 });
+
+test('extension keeps fail-closed stopped inspect-run results on error severity', async () => {
+  const pi = readyPi();
+  registerExtension(pi, {
+    uiLifecycle: {
+      async stop() {
+        return {
+          state: 'stopped',
+          url: null,
+          detail: 'A different managed inspect-run viewer is running; stop without `--repo` or use `open` to replace it for this repo.',
+          warning: null,
+        };
+      },
+    },
+    getRepoRoot: async () => '/repo/root',
+  });
+
+  const { ctx, calls } = createCommandContext();
+  await pi.registeredCommands.get('dev-loops').handler('ui inspect-run stop --repo other/repo', ctx);
+
+  assert.equal(calls.notifications.at(-1).message, 'inspect-run viewer stop: stopped');
+  assert.equal(calls.notifications.at(-1).level, 'error');
+});

--- a/test/extension-command-contract.test.mjs
+++ b/test/extension-command-contract.test.mjs
@@ -274,3 +274,26 @@ test("extension surfaces fail-closed resume guidance when no managed viewer is l
   assert.equal(calls.notifications.at(-1).message, 'inspect-run viewer resume: stopped');
   assert.equal(calls.notifications.at(-1).level, 'error');
 });
+
+test('extension treats successful inspect-run stop as an info notification', async () => {
+  const pi = readyPi();
+  registerExtension(pi, {
+    uiLifecycle: {
+      async stop() {
+        return {
+          state: 'stopped',
+          url: null,
+          detail: 'Stopped the managed inspect-run viewer.',
+          warning: null,
+        };
+      },
+    },
+    getRepoRoot: async () => '/repo/root',
+  });
+
+  const { ctx, calls } = createCommandContext();
+  await pi.registeredCommands.get('dev-loops').handler('ui inspect-run stop', ctx);
+
+  assert.equal(calls.notifications.at(-1).message, 'inspect-run viewer stop: stopped');
+  assert.equal(calls.notifications.at(-1).level, 'info');
+});

--- a/test/extension-command-contract.test.mjs
+++ b/test/extension-command-contract.test.mjs
@@ -236,15 +236,15 @@ test("extension dispatches inspect-run open and surfaces browser warnings withou
   });
 
   const { ctx, calls } = createCommandContext();
-  await pi.registeredCommands.get('dev-loops').handler('ui inspect-run open --repo mfittko/pi-dev-loops', ctx);
+  await pi.registeredCommands.get('dev-loops').handler('inspect open --repo mfittko/pi-dev-loops', ctx);
 
   const widget = calls.widgets.at(-1);
   assert.equal(widget.key, 'pi-dev-loops.setup');
-  assert(widget.lines.some((line) => /inspect-run open/i.test(line)));
+  assert(widget.lines.some((line) => /inspect open/i.test(line)));
   assert(widget.lines.some((line) => /running/i.test(line)));
   assert(widget.lines.some((line) => /http:\/\/127\.0\.0\.1:4311/i.test(line)));
   assert(widget.lines.some((line) => /browser unavailable/i.test(line)));
-  assert.equal(calls.notifications.at(-1).message, 'inspect-run viewer open: running');
+  assert.equal(calls.notifications.at(-1).message, 'inspect viewer open: running');
   assert.equal(calls.notifications.at(-1).level, 'info');
 });
 
@@ -256,7 +256,7 @@ test("extension surfaces fail-closed resume guidance when no managed viewer is l
         return {
           state: 'stopped',
           url: null,
-          detail: 'No managed inspect-run viewer is running; use `/dev-loops ui inspect-run open`.',
+          detail: 'No managed inspect-run viewer is running; use `/dev-loops inspect open`.',
           warning: null,
         };
       },
@@ -265,13 +265,13 @@ test("extension surfaces fail-closed resume guidance when no managed viewer is l
   });
 
   const { ctx, calls } = createCommandContext();
-  await pi.registeredCommands.get('dev-loops').handler('ui inspect-run resume', ctx);
+  await pi.registeredCommands.get('dev-loops').handler('inspect resume', ctx);
 
   const widget = calls.widgets.at(-1);
-  assert(widget.lines.some((line) => /inspect-run resume/i.test(line)));
+  assert(widget.lines.some((line) => /inspect resume/i.test(line)));
   assert(widget.lines.some((line) => /stopped/i.test(line)));
-  assert(widget.lines.some((line) => /use `\/dev-loops ui inspect-run open`/i.test(line)));
-  assert.equal(calls.notifications.at(-1).message, 'inspect-run viewer resume: stopped');
+  assert(widget.lines.some((line) => /use `\/dev-loops inspect open`/i.test(line)));
+  assert.equal(calls.notifications.at(-1).message, 'inspect viewer resume: stopped');
   assert.equal(calls.notifications.at(-1).level, 'error');
 });
 
@@ -292,9 +292,9 @@ test('extension treats successful inspect-run stop as an info notification', asy
   });
 
   const { ctx, calls } = createCommandContext();
-  await pi.registeredCommands.get('dev-loops').handler('ui inspect-run stop', ctx);
+  await pi.registeredCommands.get('dev-loops').handler('inspect stop', ctx);
 
-  assert.equal(calls.notifications.at(-1).message, 'inspect-run viewer stop: stopped');
+  assert.equal(calls.notifications.at(-1).message, 'inspect viewer stop: stopped');
   assert.equal(calls.notifications.at(-1).level, 'info');
 });
 
@@ -315,9 +315,9 @@ test('extension keeps fail-closed stopped inspect-run results on error severity'
   });
 
   const { ctx, calls } = createCommandContext();
-  await pi.registeredCommands.get('dev-loops').handler('ui inspect-run stop --repo other/repo', ctx);
+  await pi.registeredCommands.get('dev-loops').handler('inspect stop --repo other/repo', ctx);
 
-  assert.equal(calls.notifications.at(-1).message, 'inspect-run viewer stop: stopped');
+  assert.equal(calls.notifications.at(-1).message, 'inspect viewer stop: stopped');
   assert.equal(calls.notifications.at(-1).level, 'error');
 });
 
@@ -339,9 +339,9 @@ test('extension renders inspect-run status as an info notification when the mana
   });
 
   const { ctx, calls } = createCommandContext();
-  await pi.registeredCommands.get('dev-loops').handler('ui inspect-run status', ctx);
+  await pi.registeredCommands.get('dev-loops').handler('inspect status', ctx);
 
-  assert.equal(calls.notifications.at(-1).message, 'inspect-run viewer status: running');
+  assert.equal(calls.notifications.at(-1).message, 'inspect viewer status: running');
   assert.equal(calls.notifications.at(-1).level, 'info');
   assert(calls.widgets.at(-1).lines.some((line) => /Managed inspect-run viewer is running/i.test(line)));
 });
@@ -364,8 +364,8 @@ test('extension keeps inspect-run restart conflicts on error severity', async ()
   });
 
   const { ctx, calls } = createCommandContext();
-  await pi.registeredCommands.get('dev-loops').handler('ui inspect-run restart', ctx);
+  await pi.registeredCommands.get('dev-loops').handler('inspect restart', ctx);
 
-  assert.equal(calls.notifications.at(-1).message, 'inspect-run viewer restart: conflict_unmanaged_listener');
+  assert.equal(calls.notifications.at(-1).message, 'inspect viewer restart: conflict_unmanaged_listener');
   assert.equal(calls.notifications.at(-1).level, 'error');
 });

--- a/test/extension-command-contract.test.mjs
+++ b/test/extension-command-contract.test.mjs
@@ -216,3 +216,61 @@ test("hide still clears the widget and unknown commands fall back to help", asyn
   assert.match(fallbackContext.calls.widgets.at(-1).lines[0], /pi-dev-loops help/);
   assert.equal(fallbackContext.calls.notifications.at(-1).message, "pi-dev-loops help");
 });
+
+test("extension dispatches inspect-run open and surfaces browser warnings without failing the launch", async () => {
+  const pi = readyPi();
+  registerExtension(pi, {
+    uiLifecycle: {
+      async open({ repoRoot, repo }) {
+        assert.equal(repoRoot, '/repo/root');
+        assert.equal(repo, 'mfittko/pi-dev-loops');
+        return {
+          state: 'running',
+          url: 'http://127.0.0.1:4311/?scope=mfittko%2Fpi-dev-loops',
+          detail: 'Reused the managed inspect-run viewer.',
+          warning: 'browser unavailable',
+        };
+      },
+    },
+    getRepoRoot: async () => '/repo/root',
+  });
+
+  const { ctx, calls } = createCommandContext();
+  await pi.registeredCommands.get('dev-loops').handler('ui inspect-run open --repo mfittko/pi-dev-loops', ctx);
+
+  const widget = calls.widgets.at(-1);
+  assert.equal(widget.key, 'pi-dev-loops.setup');
+  assert(widget.lines.some((line) => /inspect-run open/i.test(line)));
+  assert(widget.lines.some((line) => /running/i.test(line)));
+  assert(widget.lines.some((line) => /http:\/\/127\.0\.0\.1:4311/i.test(line)));
+  assert(widget.lines.some((line) => /browser unavailable/i.test(line)));
+  assert.equal(calls.notifications.at(-1).message, 'inspect-run viewer open: running');
+  assert.equal(calls.notifications.at(-1).level, 'info');
+});
+
+test("extension surfaces fail-closed resume guidance when no managed viewer is live", async () => {
+  const pi = readyPi();
+  registerExtension(pi, {
+    uiLifecycle: {
+      async resume() {
+        return {
+          state: 'stopped',
+          url: null,
+          detail: 'No managed inspect-run viewer is running; use `/dev-loops ui inspect-run open`.',
+          warning: null,
+        };
+      },
+    },
+    getRepoRoot: async () => '/repo/root',
+  });
+
+  const { ctx, calls } = createCommandContext();
+  await pi.registeredCommands.get('dev-loops').handler('ui inspect-run resume', ctx);
+
+  const widget = calls.widgets.at(-1);
+  assert(widget.lines.some((line) => /inspect-run resume/i.test(line)));
+  assert(widget.lines.some((line) => /stopped/i.test(line)));
+  assert(widget.lines.some((line) => /use `\/dev-loops ui inspect-run open`/i.test(line)));
+  assert.equal(calls.notifications.at(-1).message, 'inspect-run viewer resume: stopped');
+  assert.equal(calls.notifications.at(-1).level, 'error');
+});

--- a/test/extension-command-contract.test.mjs
+++ b/test/extension-command-contract.test.mjs
@@ -320,3 +320,52 @@ test('extension keeps fail-closed stopped inspect-run results on error severity'
   assert.equal(calls.notifications.at(-1).message, 'inspect-run viewer stop: stopped');
   assert.equal(calls.notifications.at(-1).level, 'error');
 });
+
+test('extension renders inspect-run status as an info notification when the managed viewer is running', async () => {
+  const pi = readyPi();
+  registerExtension(pi, {
+    uiLifecycle: {
+      async status() {
+        return {
+          state: 'running',
+          url: 'http://127.0.0.1:4311',
+          detail: 'Managed inspect-run viewer is running.',
+          warning: null,
+          record: { pid: 1234 },
+        };
+      },
+    },
+    getRepoRoot: async () => '/repo/root',
+  });
+
+  const { ctx, calls } = createCommandContext();
+  await pi.registeredCommands.get('dev-loops').handler('ui inspect-run status', ctx);
+
+  assert.equal(calls.notifications.at(-1).message, 'inspect-run viewer status: running');
+  assert.equal(calls.notifications.at(-1).level, 'info');
+  assert(calls.widgets.at(-1).lines.some((line) => /Managed inspect-run viewer is running/i.test(line)));
+});
+
+test('extension keeps inspect-run restart conflicts on error severity', async () => {
+  const pi = readyPi();
+  registerExtension(pi, {
+    uiLifecycle: {
+      async restart() {
+        return {
+          state: 'conflict_unmanaged_listener',
+          url: 'http://127.0.0.1:4311',
+          detail: 'Restart refused to stop an unmanaged listener on the inspect-run viewer port.',
+          warning: null,
+          record: null,
+        };
+      },
+    },
+    getRepoRoot: async () => '/repo/root',
+  });
+
+  const { ctx, calls } = createCommandContext();
+  await pi.registeredCommands.get('dev-loops').handler('ui inspect-run restart', ctx);
+
+  assert.equal(calls.notifications.at(-1).message, 'inspect-run viewer restart: conflict_unmanaged_listener');
+  assert.equal(calls.notifications.at(-1).level, 'error');
+});

--- a/test/loop/inspect-run-viewer-managed-instance.test.mjs
+++ b/test/loop/inspect-run-viewer-managed-instance.test.mjs
@@ -6,6 +6,7 @@ import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 
 import {
   INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH,
+  buildOpenBrowserInvocation,
   createInspectRunViewerLifecycleManager,
 } from '../../scripts/loop/inspect-run-viewer/managed-instance.mjs';
 
@@ -435,6 +436,20 @@ test('status rejects a missing repoRoot with a clear lifecycle error', async () 
   const { manager } = createManager();
 
   await assert.rejects(manager.status(), /requires a repoRoot/i);
+});
+
+test('buildOpenBrowserInvocation quotes Windows URLs as one literal argument', () => {
+  const invocation = buildOpenBrowserInvocation('http://127.0.0.1:4311/?scope=owner/repo&view=current', 'win32');
+
+  assert.equal(invocation.command, 'cmd');
+  assert.deepEqual(invocation.args, [
+    '/c',
+    'start',
+    '""',
+    '"http://127.0.0.1:4311/?scope=owner/repo&view=current"',
+  ]);
+  assert.equal(invocation.options.windowsHide, true);
+  assert.equal(invocation.options.windowsVerbatimArguments, true);
 });
 
 test('status treats a record with a non-default host or port as stale_record', async () => {

--- a/test/loop/inspect-run-viewer-managed-instance.test.mjs
+++ b/test/loop/inspect-run-viewer-managed-instance.test.mjs
@@ -1,0 +1,197 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, readFile } from 'node:fs/promises';
+
+import {
+  INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH,
+  createInspectRunViewerLifecycleManager,
+} from '../../scripts/loop/inspect-run-viewer/managed-instance.mjs';
+
+function createManager(overrides = {}) {
+  const listenersByPort = new Map();
+  const processes = new Map();
+  const browserOpens = [];
+  const launches = [];
+  const stopped = [];
+  let nextPid = 4000;
+
+  const manager = createInspectRunViewerLifecycleManager({
+    nowImpl: () => '2026-06-01T12:00:00.000Z',
+    async listListeningPidsImpl(port) {
+      return [...(listenersByPort.get(port) ?? [])];
+    },
+    async isProcessAliveImpl(pid) {
+      return processes.get(pid)?.alive === true;
+    },
+    async healthcheckUrlImpl(url) {
+      return [...processes.values()].some((entry) => entry.url === url && entry.healthy === true);
+    },
+    async launchManagedServerImpl({ repoRoot, repo, host, port, url }) {
+      const pid = nextPid++;
+      launches.push({ repoRoot, repo, host, port, url, pid });
+      processes.set(pid, { alive: true, healthy: true, port, url, repo });
+      listenersByPort.set(port, [pid]);
+      return { pid };
+    },
+    async stopManagedProcessImpl(pid) {
+      stopped.push(pid);
+      const processEntry = processes.get(pid);
+      if (processEntry) {
+        processEntry.alive = false;
+        processEntry.healthy = false;
+        listenersByPort.set(processEntry.port, (listenersByPort.get(processEntry.port) ?? []).filter((value) => value !== pid));
+      }
+    },
+    async openBrowserImpl(url) {
+      browserOpens.push(url);
+    },
+    ...overrides,
+  });
+
+  return {
+    manager,
+    listenersByPort,
+    processes,
+    browserOpens,
+    launches,
+    stopped,
+  };
+}
+
+test('managed seam writes and reads the repo-local record on open/status', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-managed-'));
+  const { manager, browserOpens, launches } = createManager();
+
+  const opened = await manager.open({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  assert.equal(opened.state, 'running');
+  assert.equal(opened.startedFresh, true);
+  assert.equal(opened.reusedExisting, false);
+  assert.equal(opened.url, 'http://127.0.0.1:4311');
+  assert.deepEqual(browserOpens, ['http://127.0.0.1:4311']);
+  assert.equal(launches.length, 1);
+
+  const recordPath = path.join(repoRoot, INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH);
+  const record = JSON.parse(await readFile(recordPath, 'utf8'));
+  assert.equal(record.surfaceId, 'inspect-run-viewer');
+  assert.equal(record.launchArgs.repo, 'mfittko/pi-dev-loops');
+  assert.equal(record.pid, launches[0].pid);
+  assert.equal(record.cwd, repoRoot);
+
+  const status = await manager.status({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  assert.equal(status.state, 'running');
+  assert.equal(status.url, 'http://127.0.0.1:4311');
+  assert.match(status.detail, /managed/i);
+});
+
+test('status reports stale_record when the saved pid is dead', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-stale-'));
+  const { manager, processes, launches, listenersByPort } = createManager();
+
+  await manager.open({ repoRoot });
+  processes.get(launches[0].pid).alive = false;
+  processes.get(launches[0].pid).healthy = false;
+  listenersByPort.set(4311, []);
+
+  const status = await manager.status({ repoRoot });
+  assert.equal(status.state, 'stale_record');
+  assert.equal(status.url, 'http://127.0.0.1:4311');
+});
+
+test('status reports conflict_unmanaged_listener when no managed record exists but the port is occupied', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-conflict-'));
+  const { manager, listenersByPort, processes } = createManager();
+  listenersByPort.set(4311, [9001]);
+  processes.set(9001, { alive: true, healthy: true, port: 4311, url: 'http://127.0.0.1:4311' });
+
+  const status = await manager.status({ repoRoot });
+  assert.equal(status.state, 'conflict_unmanaged_listener');
+  assert.equal(status.url, 'http://127.0.0.1:4311');
+});
+
+test('open reuses a matching live managed instance instead of relaunching', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-reuse-'));
+  const { manager, launches, browserOpens } = createManager();
+
+  await manager.open({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  const reopened = await manager.open({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+
+  assert.equal(reopened.state, 'running');
+  assert.equal(reopened.reusedExisting, true);
+  assert.equal(reopened.startedFresh, false);
+  assert.equal(launches.length, 1);
+  assert.equal(browserOpens.length, 2);
+});
+
+test('resume fails closed and does not auto-start when nothing live is managed', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-resume-'));
+  const { manager, launches, browserOpens } = createManager();
+
+  const resumed = await manager.resume({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  assert.equal(resumed.state, 'stopped');
+  assert.equal(resumed.resumedExisting, false);
+  assert.equal(resumed.url, null);
+  assert.equal(resumed.detail.includes('open'), true);
+  assert.equal(launches.length, 0);
+  assert.equal(browserOpens.length, 0);
+});
+
+test('stop only terminates the recorded managed pid', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-stop-'));
+  const { manager, listenersByPort, processes, stopped, launches } = createManager();
+
+  await manager.open({ repoRoot });
+  listenersByPort.set(4311, [launches[0].pid, 9002]);
+  processes.set(9002, { alive: true, healthy: true, port: 4311, url: 'http://127.0.0.1:4311' });
+
+  const stoppedResult = await manager.stop({ repoRoot });
+  assert.equal(stoppedResult.state, 'conflict_unmanaged_listener');
+  assert.deepEqual(stopped, [launches[0].pid]);
+  assert.equal(processes.get(9002).alive, true);
+});
+
+test('restart only replaces managed ownership and fails closed on an unknown listener conflict', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-restart-'));
+  const { manager, listenersByPort, processes, stopped, launches } = createManager();
+
+  await manager.open({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  const managedPid = launches[0].pid;
+  processes.get(managedPid).alive = false;
+  processes.get(managedPid).healthy = false;
+  listenersByPort.set(4311, [9111]);
+  processes.set(9111, { alive: true, healthy: true, port: 4311, url: 'http://127.0.0.1:4311' });
+
+  const restarted = await manager.restart({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  assert.equal(restarted.state, 'conflict_unmanaged_listener');
+  assert.deepEqual(stopped, []);
+  assert.equal(launches.length, 1);
+});
+
+test('open recovers from a stale record by replacing it with a fresh managed instance', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-open-stale-'));
+  const { manager, launches, processes, listenersByPort } = createManager();
+
+  await manager.open({ repoRoot });
+  processes.get(launches[0].pid).alive = false;
+  processes.get(launches[0].pid).healthy = false;
+  listenersByPort.set(4311, []);
+
+  const reopened = await manager.open({ repoRoot });
+  assert.equal(reopened.state, 'running');
+  assert.equal(reopened.startedFresh, true);
+  assert.equal(launches.length, 2);
+});
+
+test('open reports a warning instead of failing when browser auto-open errors', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-browser-warning-'));
+  const { manager } = createManager({
+    async openBrowserImpl() {
+      throw new Error('browser unavailable');
+    },
+  });
+
+  const opened = await manager.open({ repoRoot });
+  assert.equal(opened.state, 'running');
+  assert.equal(opened.warning, 'browser unavailable');
+});

--- a/test/loop/inspect-run-viewer-managed-instance.test.mjs
+++ b/test/loop/inspect-run-viewer-managed-instance.test.mjs
@@ -381,3 +381,14 @@ test('stop and restart treat ESRCH as already-stopped', async () => {
   assert.equal(restarted.state, 'running');
   assert.equal(stopCalls, 2);
 });
+
+test('status returns the raw conflict URL instead of appending a scoped query to an unmanaged listener', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-conflict-raw-url-'));
+  const { manager, listenersByPort, processes } = createManager();
+  listenersByPort.set(4311, [9444]);
+  processes.set(9444, { alive: true, healthy: true, port: 4311, url: 'http://127.0.0.1:4311' });
+
+  const status = await manager.status({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  assert.equal(status.state, 'conflict_unmanaged_listener');
+  assert.equal(status.url, 'http://127.0.0.1:4311');
+});

--- a/test/loop/inspect-run-viewer-managed-instance.test.mjs
+++ b/test/loop/inspect-run-viewer-managed-instance.test.mjs
@@ -269,6 +269,7 @@ test('open does not kill a stale recorded pid when it is alive but not listening
 test('open cleans up the spawned process when startup never becomes healthy', async () => {
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-launch-timeout-'));
   const stopped = [];
+  let nowMs = 0;
   const manager = createInspectRunViewerLifecycleManager({
     async listListeningPidsImpl() {
       return [];
@@ -285,10 +286,11 @@ test('open cleans up the spawned process when startup never becomes healthy', as
     async stopManagedProcessImpl(pid) {
       stopped.push(pid);
     },
-    async waitImpl() {
-      // keep the timeout loop fast
+    async waitImpl(ms = 0) {
+      nowMs += ms || 100;
     },
     nowImpl: () => '2026-06-01T12:00:00.000Z',
+    nowMsImpl: () => nowMs,
     async openBrowserImpl() {},
   });
 
@@ -302,6 +304,7 @@ test('open tolerates ESRCH while replacing a managed instance', async () => {
   let listenerPid = null;
   const alive = new Set();
   const stopCalls = [];
+  let nowMs = 0;
   const manager = createInspectRunViewerLifecycleManager({
     async listListeningPidsImpl() {
       return listenerPid === null ? [] : [listenerPid];
@@ -326,7 +329,10 @@ test('open tolerates ESRCH while replacing a managed instance', async () => {
       error.code = 'ESRCH';
       throw error;
     },
-    async waitImpl() {},
+    async waitImpl(ms = 0) {
+      nowMs += ms || 100;
+    },
+    nowMsImpl: () => nowMs,
     nowImpl: () => '2026-06-01T12:00:00.000Z',
     async openBrowserImpl() {},
   });
@@ -343,6 +349,7 @@ test('stop and restart treat ESRCH as already-stopped', async () => {
   let listenerPid = null;
   const alive = new Set();
   let stopCalls = 0;
+  let nowMs = 0;
   const manager = createInspectRunViewerLifecycleManager({
     async listListeningPidsImpl() {
       return listenerPid === null ? [] : [listenerPid];
@@ -367,7 +374,10 @@ test('stop and restart treat ESRCH as already-stopped', async () => {
       error.code = 'ESRCH';
       throw error;
     },
-    async waitImpl() {},
+    async waitImpl(ms = 0) {
+      nowMs += ms || 100;
+    },
+    nowMsImpl: () => nowMs,
     nowImpl: () => '2026-06-01T12:00:00.000Z',
     async openBrowserImpl() {},
   });

--- a/test/loop/inspect-run-viewer-managed-instance.test.mjs
+++ b/test/loop/inspect-run-viewer-managed-instance.test.mjs
@@ -165,6 +165,8 @@ test('restart only replaces managed ownership and fails closed on an unknown lis
 
   const restarted = await manager.restart({ repoRoot, repo: 'mfittko/pi-dev-loops' });
   assert.equal(restarted.state, 'conflict_unmanaged_listener');
+  assert.match(restarted.detail, /port 4311 is occupied/i);
+  assert.doesNotMatch(restarted.detail, /restarted the managed inspect-run viewer/i);
   assert.deepEqual(stopped, []);
   assert.equal(launches.length, 1);
 });

--- a/test/loop/inspect-run-viewer-managed-instance.test.mjs
+++ b/test/loop/inspect-run-viewer-managed-instance.test.mjs
@@ -444,3 +444,18 @@ test('status treats a record with a non-integer pid as stale_record', async () =
   assert.equal(status.state, 'stale_record');
   assert.match(status.detail, /delete/i);
 });
+
+test('open fails with a clear error when the launch seam does not return a positive integer pid', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-invalid-launch-pid-'));
+  const manager = createInspectRunViewerLifecycleManager({
+    async listListeningPidsImpl() {
+      return [];
+    },
+    async launchManagedServerImpl() {
+      return { pid: undefined };
+    },
+    async openBrowserImpl() {},
+  });
+
+  await assert.rejects(manager.open({ repoRoot }), /positive integer pid/i);
+});

--- a/test/loop/inspect-run-viewer-managed-instance.test.mjs
+++ b/test/loop/inspect-run-viewer-managed-instance.test.mjs
@@ -231,3 +231,67 @@ test('open does not attempt to auto-open a browser for conflict_unmanaged_listen
   assert.equal(result.state, 'conflict_unmanaged_listener');
   assert.deepEqual(browserOpens, []);
 });
+
+test('status treats a record with the wrong surface identity as stale_record', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-wrong-surface-'));
+  await mkdir(path.join(repoRoot, '.pi', 'ui-servers'), { recursive: true });
+  await writeFile(path.join(repoRoot, INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH), `${JSON.stringify({
+    schemaVersion: 99,
+    surfaceId: 'something-else',
+    pid: 123,
+    host: '127.0.0.1',
+    port: 4311,
+    url: 'http://127.0.0.1:4311',
+    launchArgs: { repo: null, host: '127.0.0.1', port: 4311 },
+  })}\n`);
+  const { manager } = createManager();
+
+  const status = await manager.status({ repoRoot });
+  assert.equal(status.state, 'stale_record');
+  assert.match(status.detail, /delete/i);
+});
+
+test('open does not kill a stale recorded pid when it is alive but not listening on the viewer port', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-stale-pid-reuse-'));
+  const { manager, processes, launches, stopped, listenersByPort } = createManager();
+
+  await manager.open({ repoRoot });
+  const stalePid = launches[0].pid;
+  processes.get(stalePid).healthy = false;
+  processes.get(stalePid).port = 9999;
+  listenersByPort.set(4311, []);
+
+  const reopened = await manager.open({ repoRoot });
+  assert.equal(reopened.state, 'running');
+  assert.deepEqual(stopped, []);
+});
+
+test('open cleans up the spawned process when startup never becomes healthy', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-launch-timeout-'));
+  const stopped = [];
+  const manager = createInspectRunViewerLifecycleManager({
+    async listListeningPidsImpl() {
+      return [];
+    },
+    async isProcessAliveImpl(pid) {
+      return pid === 7123;
+    },
+    async healthcheckUrlImpl() {
+      return false;
+    },
+    async launchManagedServerImpl() {
+      return { pid: 7123 };
+    },
+    async stopManagedProcessImpl(pid) {
+      stopped.push(pid);
+    },
+    async waitImpl() {
+      // keep the timeout loop fast
+    },
+    nowImpl: () => '2026-06-01T12:00:00.000Z',
+    async openBrowserImpl() {},
+  });
+
+  await assert.rejects(manager.open({ repoRoot }), /startup timeout/i);
+  assert.deepEqual(stopped, [7123]);
+});

--- a/test/loop/inspect-run-viewer-managed-instance.test.mjs
+++ b/test/loop/inspect-run-viewer-managed-instance.test.mjs
@@ -19,6 +19,7 @@ function createManager(overrides = {}) {
   let nextPid = 4000;
 
   const manager = createInspectRunViewerLifecycleManager({
+  // standard happy-path manager used by the bounded lifecycle tests
     nowImpl: () => '2026-06-01T12:00:00.000Z',
     async listListeningPidsImpl(port) {
       return [...(listenersByPort.get(port) ?? [])];
@@ -58,6 +59,58 @@ function createManager(overrides = {}) {
     browserOpens,
     launches,
     stopped,
+  };
+}
+
+
+function createStubbornManagedProcessManager() {
+  let nextPid = 7000;
+  let listenerPid = null;
+  let nowMs = 0;
+  const alive = new Set();
+  const healthy = new Set();
+  const launches = [];
+  const stopCalls = [];
+
+  const manager = createInspectRunViewerLifecycleManager({
+    nowImpl: () => '2026-06-01T12:00:00.000Z',
+    nowMsImpl: () => nowMs,
+    async waitImpl(ms = 0) {
+      nowMs += ms || 100;
+    },
+    async listListeningPidsImpl() {
+      return listenerPid === null ? [] : [listenerPid];
+    },
+    async isProcessAliveImpl(pid) {
+      return alive.has(pid);
+    },
+    async healthcheckUrlImpl() {
+      return listenerPid !== null && alive.has(listenerPid) && healthy.has(listenerPid);
+    },
+    async launchManagedServerImpl({ repoRoot, repo, host, port, url }) {
+      const pid = nextPid++;
+      listenerPid = pid;
+      alive.add(pid);
+      healthy.add(pid);
+      launches.push({ repoRoot, repo, host, port, url, pid });
+      return { pid };
+    },
+    async stopManagedProcessImpl(pid) {
+      stopCalls.push(pid);
+    },
+    async openBrowserImpl() {},
+  });
+
+  return {
+    manager,
+    launches,
+    stopCalls,
+    markUnhealthy(pid) {
+      healthy.delete(pid);
+    },
+    currentPid() {
+      return listenerPid;
+    },
   };
 }
 
@@ -125,6 +178,22 @@ test('open reuses a matching live managed instance instead of relaunching', asyn
   assert.equal(browserOpens.length, 2);
 });
 
+test('open keeps the managed record when a running viewer ignores SIGTERM during replacement', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-open-running-stubborn-'));
+  const { manager, launches, stopCalls, currentPid } = createStubbornManagedProcessManager();
+
+  await manager.open({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  const result = await manager.open({ repoRoot, repo: 'other/repo' });
+
+  assert.equal(result.state, 'stale_record');
+  assert.match(result.detail, /keeping the managed record instead of replacing it/i);
+  assert.deepEqual(stopCalls, [currentPid()]);
+  assert.equal(launches.length, 1);
+
+  const record = JSON.parse(await readFile(path.join(repoRoot, INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH), 'utf8'));
+  assert.equal(record.pid, currentPid());
+});
+
 test('resume fails closed and does not auto-start when nothing live is managed', async () => {
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-resume-'));
   const { manager, launches, browserOpens } = createManager();
@@ -150,6 +219,22 @@ test('stop only terminates the recorded managed pid', async () => {
   assert.equal(stoppedResult.state, 'conflict_unmanaged_listener');
   assert.deepEqual(stopped, [launches[0].pid]);
   assert.equal(processes.get(9002).alive, true);
+});
+
+test('restart keeps the managed record when a running viewer ignores SIGTERM', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-restart-running-stubborn-'));
+  const { manager, launches, stopCalls, currentPid } = createStubbornManagedProcessManager();
+
+  await manager.open({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  const result = await manager.restart({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+
+  assert.equal(result.state, 'stale_record');
+  assert.match(result.detail, /keeping the managed record instead of restarting it/i);
+  assert.deepEqual(stopCalls, [currentPid()]);
+  assert.equal(launches.length, 1);
+
+  const record = JSON.parse(await readFile(path.join(repoRoot, INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH), 'utf8'));
+  assert.equal(record.pid, currentPid());
 });
 
 test('restart only replaces managed ownership and fails closed on an unknown listener conflict', async () => {
@@ -197,6 +282,22 @@ test('open reports a warning instead of failing when browser auto-open errors', 
   const opened = await manager.open({ repoRoot });
   assert.equal(opened.state, 'running');
   assert.equal(opened.warning, 'browser unavailable');
+});
+
+test('stop keeps a stale managed record when the recorded pid stays alive on the viewer port', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-stop-stale-stubborn-'));
+  const { manager, stopCalls, markUnhealthy, currentPid } = createStubbornManagedProcessManager();
+
+  await manager.open({ repoRoot });
+  markUnhealthy(currentPid());
+
+  const result = await manager.stop({ repoRoot });
+  assert.equal(result.state, 'stale_record');
+  assert.match(result.detail, /keeping the stale record for manual cleanup/i);
+  assert.deepEqual(stopCalls, [currentPid()]);
+
+  const record = JSON.parse(await readFile(path.join(repoRoot, INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH), 'utf8'));
+  assert.equal(record.pid, currentPid());
 });
 
 test('status treats an unreadable managed record as stale_record with delete guidance', async () => {

--- a/test/loop/inspect-run-viewer-managed-instance.test.mjs
+++ b/test/loop/inspect-run-viewer-managed-instance.test.mjs
@@ -406,3 +406,22 @@ test('status surfaces a friendly lsof guidance error when listener discovery sup
 
   await assert.rejects(manager.status({ repoRoot }), /lsof\/POSIX support/i);
 });
+
+test('status treats a record with a non-default host or port as stale_record', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-wrong-host-port-'));
+  await mkdir(path.join(repoRoot, '.pi', 'ui-servers'), { recursive: true });
+  await writeFile(path.join(repoRoot, INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH), `${JSON.stringify({
+    schemaVersion: 1,
+    surfaceId: 'inspect-run-viewer',
+    pid: 123,
+    host: '0.0.0.0',
+    port: 9999,
+    url: 'http://0.0.0.0:9999',
+    launchArgs: { repo: null, host: '0.0.0.0', port: 9999 },
+  })}\n`);
+  const { manager } = createManager();
+
+  const status = await manager.status({ repoRoot });
+  assert.equal(status.state, 'stale_record');
+  assert.match(status.detail, /delete/i);
+});

--- a/test/loop/inspect-run-viewer-managed-instance.test.mjs
+++ b/test/loop/inspect-run-viewer-managed-instance.test.mjs
@@ -431,6 +431,12 @@ test('status surfaces a friendly lsof guidance error when listener discovery sup
   await assert.rejects(manager.status({ repoRoot }), /lsof\/POSIX support/i);
 });
 
+test('status rejects a missing repoRoot with a clear lifecycle error', async () => {
+  const { manager } = createManager();
+
+  await assert.rejects(manager.status(), /requires a repoRoot/i);
+});
+
 test('status treats a record with a non-default host or port as stale_record', async () => {
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-wrong-host-port-'));
   await mkdir(path.join(repoRoot, '.pi', 'ui-servers'), { recursive: true });

--- a/test/loop/inspect-run-viewer-managed-instance.test.mjs
+++ b/test/loop/inspect-run-viewer-managed-instance.test.mjs
@@ -425,3 +425,22 @@ test('status treats a record with a non-default host or port as stale_record', a
   assert.equal(status.state, 'stale_record');
   assert.match(status.detail, /delete/i);
 });
+
+test('status treats a record with a non-integer pid as stale_record', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-bad-pid-'));
+  await mkdir(path.join(repoRoot, '.pi', 'ui-servers'), { recursive: true });
+  await writeFile(path.join(repoRoot, INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH), `${JSON.stringify({
+    schemaVersion: 1,
+    surfaceId: 'inspect-run-viewer',
+    pid: 12.5,
+    host: '127.0.0.1',
+    port: 4311,
+    url: 'http://127.0.0.1:4311',
+    launchArgs: { repo: null, host: '127.0.0.1', port: 4311 },
+  })}\n`);
+  const { manager } = createManager();
+
+  const status = await manager.status({ repoRoot });
+  assert.equal(status.state, 'stale_record');
+  assert.match(status.detail, /delete/i);
+});

--- a/test/loop/inspect-run-viewer-managed-instance.test.mjs
+++ b/test/loop/inspect-run-viewer-managed-instance.test.mjs
@@ -295,3 +295,89 @@ test('open cleans up the spawned process when startup never becomes healthy', as
   await assert.rejects(manager.open({ repoRoot }), /startup timeout/i);
   assert.deepEqual(stopped, [7123]);
 });
+
+test('open tolerates ESRCH while replacing a managed instance', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-open-esrch-'));
+  let nextPid = 5000;
+  let listenerPid = null;
+  const alive = new Set();
+  const stopCalls = [];
+  const manager = createInspectRunViewerLifecycleManager({
+    async listListeningPidsImpl() {
+      return listenerPid === null ? [] : [listenerPid];
+    },
+    async isProcessAliveImpl(pid) {
+      return alive.has(pid);
+    },
+    async healthcheckUrlImpl() {
+      return listenerPid !== null && alive.has(listenerPid);
+    },
+    async launchManagedServerImpl() {
+      const pid = nextPid++;
+      listenerPid = pid;
+      alive.add(pid);
+      return { pid };
+    },
+    async stopManagedProcessImpl(pid) {
+      stopCalls.push(pid);
+      alive.delete(pid);
+      listenerPid = null;
+      const error = new Error('gone');
+      error.code = 'ESRCH';
+      throw error;
+    },
+    async waitImpl() {},
+    nowImpl: () => '2026-06-01T12:00:00.000Z',
+    async openBrowserImpl() {},
+  });
+
+  await manager.open({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  const reopened = await manager.open({ repoRoot, repo: 'other/repo' });
+  assert.equal(reopened.state, 'running');
+  assert.deepEqual(stopCalls, [5000]);
+});
+
+test('stop and restart treat ESRCH as already-stopped', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-stop-restart-esrch-'));
+  let nextPid = 6000;
+  let listenerPid = null;
+  const alive = new Set();
+  let stopCalls = 0;
+  const manager = createInspectRunViewerLifecycleManager({
+    async listListeningPidsImpl() {
+      return listenerPid === null ? [] : [listenerPid];
+    },
+    async isProcessAliveImpl(pid) {
+      return alive.has(pid);
+    },
+    async healthcheckUrlImpl() {
+      return listenerPid !== null && alive.has(listenerPid);
+    },
+    async launchManagedServerImpl() {
+      const pid = nextPid++;
+      listenerPid = pid;
+      alive.add(pid);
+      return { pid };
+    },
+    async stopManagedProcessImpl(pid) {
+      stopCalls += 1;
+      alive.delete(pid);
+      listenerPid = null;
+      const error = new Error('gone');
+      error.code = 'ESRCH';
+      throw error;
+    },
+    async waitImpl() {},
+    nowImpl: () => '2026-06-01T12:00:00.000Z',
+    async openBrowserImpl() {},
+  });
+
+  await manager.open({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  const stopped = await manager.stop({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  assert.equal(stopped.state, 'stopped');
+
+  await manager.open({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  const restarted = await manager.restart({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  assert.equal(restarted.state, 'running');
+  assert.equal(stopCalls, 2);
+});

--- a/test/loop/inspect-run-viewer-managed-instance.test.mjs
+++ b/test/loop/inspect-run-viewer-managed-instance.test.mjs
@@ -207,6 +207,20 @@ test('status treats an unreadable managed record as stale_record with delete gui
   assert.match(status.detail, /delete/i);
 });
 
+test('open clears a directory-shaped managed record path and starts fresh', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-record-directory-'));
+  await mkdir(path.join(repoRoot, INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH), { recursive: true });
+  const { manager, launches } = createManager();
+
+  const opened = await manager.open({ repoRoot });
+  assert.equal(opened.state, 'running');
+  assert.equal(launches.length, 1);
+
+  const record = JSON.parse(await readFile(path.join(repoRoot, INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH), 'utf8'));
+  assert.equal(record.surfaceId, 'inspect-run-viewer');
+  assert.equal(record.pid, launches[0].pid);
+});
+
 test('stop fails closed with explicit guidance when --repo does not match the managed instance', async () => {
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-stop-mismatch-'));
   const { manager, launches, stopped } = createManager();

--- a/test/loop/inspect-run-viewer-managed-instance.test.mjs
+++ b/test/loop/inspect-run-viewer-managed-instance.test.mjs
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import os from 'node:os';
 import path from 'node:path';
-import { mkdtemp, readFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 
 import {
   INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH,
@@ -194,4 +194,40 @@ test('open reports a warning instead of failing when browser auto-open errors', 
   const opened = await manager.open({ repoRoot });
   assert.equal(opened.state, 'running');
   assert.equal(opened.warning, 'browser unavailable');
+});
+
+test('status treats an unreadable managed record as stale_record with delete guidance', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-corrupt-record-'));
+  await mkdir(path.join(repoRoot, '.pi', 'ui-servers'), { recursive: true });
+  await writeFile(path.join(repoRoot, INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH), '{not json\n');
+  const { manager } = createManager();
+
+  const status = await manager.status({ repoRoot });
+  assert.equal(status.state, 'stale_record');
+  assert.match(status.detail, /delete/i);
+});
+
+test('stop fails closed with explicit guidance when --repo does not match the managed instance', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-stop-mismatch-'));
+  const { manager, launches, stopped } = createManager();
+
+  await manager.open({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  const result = await manager.stop({ repoRoot, repo: 'other/repo' });
+
+  assert.equal(result.state, 'stopped');
+  assert.equal(result.url, null);
+  assert.match(result.detail, /different managed inspect-run viewer/i);
+  assert.equal(stopped.length, 0);
+  assert.equal(launches.length, 1);
+});
+
+test('open does not attempt to auto-open a browser for conflict_unmanaged_listener results', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-open-conflict-'));
+  const { manager, listenersByPort, processes, browserOpens } = createManager();
+  listenersByPort.set(4311, [9555]);
+  processes.set(9555, { alive: true, healthy: true, port: 4311, url: 'http://127.0.0.1:4311' });
+
+  const result = await manager.open({ repoRoot });
+  assert.equal(result.state, 'conflict_unmanaged_listener');
+  assert.deepEqual(browserOpens, []);
 });

--- a/test/loop/inspect-run-viewer-managed-instance.test.mjs
+++ b/test/loop/inspect-run-viewer-managed-instance.test.mjs
@@ -392,3 +392,17 @@ test('status returns the raw conflict URL instead of appending a scoped query to
   assert.equal(status.state, 'conflict_unmanaged_listener');
   assert.equal(status.url, 'http://127.0.0.1:4311');
 });
+
+test('status surfaces a friendly lsof guidance error when listener discovery support is unavailable', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-lsof-guidance-'));
+  const manager = createInspectRunViewerLifecycleManager({
+    async listListeningPidsImpl() {
+      const error = new Error('spawn lsof ENOENT');
+      error.code = 'ENOENT';
+      error.path = 'lsof';
+      throw error;
+    },
+  });
+
+  await assert.rejects(manager.status({ repoRoot }), /lsof\/POSIX support/i);
+});


### PR DESCRIPTION
## Summary
- add `/dev-loops inspect {open,resume,status,stop,restart}` as the bounded extension-owned local lifecycle surface for the inspect-run viewer
- add one repo-local managed-instance seam at `.pi/ui-servers/inspect-run-viewer.json` with fail-closed stale/conflict handling and best-effort browser open
- keep the viewer script focused on read-only HTTP/rendering behavior while documenting the new ownership split

## Scope/context
- implements the single-PR LOCAL-FIRST slice refined in `tmp/issue-127-refined.md`
- issue: closes #127
- first and only consumer in this slice: `inspect-run-viewer`
- keeps the public surface under `/dev-loops inspect ...`; no generic service platform or parallel workflow family is introduced
- keeps the viewer script as the deterministic HTTP/rendering implementation and treats the script CLI as a manual/debug fallback rather than the primary lifecycle UX

## Acceptance criteria
- [x] A documented extension-owned local UI lifecycle seam exists for the inspect-run viewer in LOCAL-FIRST mode.
- [x] The documented seam explicitly distinguishes extension-owned lifecycle behavior from script-owned viewer/data behavior.
- [x] The extension exposes exactly the bounded operator actions required by #127: open, resume, status, stop, restart.
- [x] `inspect-run-viewer` is the first concrete consumer of that seam.
- [x] The extension-managed path persists enough repo-local metadata to reattach/status-stop safely after a fresh Pi session.
- [x] `resume` never guesses through missing or stale ownership; it only reattaches to a confirmed live managed instance.
- [x] `restart` is explicit and bounded; it never kills an unknown listener merely because the port is occupied.
- [x] Browser-open failures degrade to warnings while still returning the running URL.
- [x] The slice stays bounded and does not introduce a generic local app platform, remote hosting path, or viewer redesign.
- [x] Relevant docs/tests are updated so lifecycle ownership does not drift back into script-local ad hoc UX.

## Definition of done
- [x] `/dev-loops` includes the bounded local inspect lifecycle commands for the inspect-run viewer.
- [x] `.pi/ui-servers/inspect-run-viewer.json` is the managed-instance record used for safe reattach/status/stop decisions.
- [x] The extension owns the primary lifecycle UX and browser-open behavior.
- [x] The inspect-run viewer script remains the deterministic read-only server/rendering implementation.
- [x] Ownership conflicts and stale-record cases fail closed with explicit operator-facing status.
- [x] Tests cover open/resume/status/stop/restart behavior and the ownership split.
- [x] Docs describe the supported local-first path and explicitly note what remains out of scope.
- [x] The implementation stays reviewable as one PR.

## Non-goals
- generic service/platform management for arbitrary local web servers
- remote or public hosting
- multi-user or network deployment semantics
- inspect-run viewer UI redesign
- new dashboard behavior unrelated to lifecycle ownership
- browser polling/auto-refresh/watch/supervisor behavior

