### PR TITLE
Add canonical PR lifecycle contract doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,12 @@ This repository uses `dev-loop` as the single public workflow entrypoint.
 
 For the canonical public routing and shorthand contract, see `skills/docs/public-dev-loop-contract.md`.
 
+Canonical skill-required docs rule:
+- any contract doc that is required by skills, read by skills, or intended to ship as part of the installed skill/runtime surface must live canonically under `skills/docs/`
+- do not create a second canonical copy of a skill-required contract under `docs/`
+- `docs/` may link to canonical skill docs for index/discovery purposes, but must not become a parallel source of truth for those contracts
+- when adding or moving a skill-required contract, update skill references to the `skills/docs/` path and keep any `docs/` reference as a thin pointer only if needed
+
 Repo-specific posture summary:
 - prefer the GitHub-first routed path when work should move through GitHub branches, pull requests, CI, and review
 - use the local implementation strategy only when the user explicitly wants a local phase-based path

--- a/docs/conductor-ownership-contract.md
+++ b/docs/conductor-ownership-contract.md
@@ -22,7 +22,7 @@ any point in time. This contract makes that invariant deterministic and testable
 | [#28 — conductor umbrella](https://github.com/mfittko/pi-dev-loops/issues/28) | Parent umbrella |
 | [#27 — ownership bug/example](https://github.com/mfittko/pi-dev-loops/issues/27) | Motivating example |
 | [#34 — request/watch helper contract](https://github.com/mfittko/pi-dev-loops/issues/34) | Downstream: consumers of this policy |
-| [#26 — remediation choreography](https://github.com/mfittko/pi-dev-loops/issues/26) | Downstream: uses ownership outcomes |
+| [#26 — remediation choreography](https://github.com/mfittko/pi-dev-loops/issues/26) / `skills/docs/pr-lifecycle-contract.md` | Downstream: uses ownership outcomes |
 | [#48 — visible PR projection](https://github.com/mfittko/pi-dev-loops/issues/48) | Downstream: uses ownership outcomes |
 
 ## Implementation
@@ -303,7 +303,7 @@ This contract intentionally does **not** cover:
 - distributed locking, leases, or production shared-coordination infrastructure
 - registry/storage redesign or persistence migration
 - request/watch helper routing mechanics (see issue #34)
-- review/remediation/re-review choreography, CI wait policy, or merge gating (see issue #26)
+- review/remediation/re-review choreography, CI wait policy, or merge gating (see `skills/docs/pr-lifecycle-contract.md`)
 - PR-visible lifecycle projection, comments, status rendering, or closeout artifacts (see issue #48)
 - broad reconcile CLI/tooling beyond classification rules
 - backend discovery/transport semantics for authoritative live state

--- a/docs/conductor-ownership-contract.md
+++ b/docs/conductor-ownership-contract.md
@@ -22,7 +22,7 @@ any point in time. This contract makes that invariant deterministic and testable
 | [#28 — conductor umbrella](https://github.com/mfittko/pi-dev-loops/issues/28) | Parent umbrella |
 | [#27 — ownership bug/example](https://github.com/mfittko/pi-dev-loops/issues/27) | Motivating example |
 | [#34 — request/watch helper contract](https://github.com/mfittko/pi-dev-loops/issues/34) | Downstream: consumers of this policy |
-| [#26 — remediation choreography](https://github.com/mfittko/pi-dev-loops/issues/26) / `skills/docs/pr-lifecycle-contract.md` | Downstream: uses ownership outcomes |
+| [#26 — family-local PR lifecycle contract](https://github.com/mfittko/pi-dev-loops/issues/26) / `skills/docs/pr-lifecycle-contract.md` | Downstream: uses ownership outcomes |
 | [#48 — visible PR projection](https://github.com/mfittko/pi-dev-loops/issues/48) | Downstream: uses ownership outcomes |
 
 ## Implementation

--- a/docs/conductor-routing-contract.md
+++ b/docs/conductor-routing-contract.md
@@ -14,7 +14,7 @@ already known:
 This contract starts **after**:
 - the active run has been identified (scope/target resolved)
 - ownership/idempotency has been classified (from `conductor-ownership.mjs`, issue #32)
-- family-local lifecycle states have been detected (from `copilot-loop-state.mjs`, `reviewer-loop-state.mjs`, under the broader semantics frozen in `skills/docs/pr-lifecycle-contract.md`)
+- family-local lifecycle states have been detected (from `copilot-loop-state.mjs` and `reviewer-loop-state.mjs`) and are interpreted under the broader semantics frozen in `skills/docs/pr-lifecycle-contract.md`
 
 The routing outcome is derived **directly from normalized state inputs** — the evaluator does not accept a
 pre-computed outer-loop action. It is the routing authority, not a remapper.

--- a/docs/conductor-routing-contract.md
+++ b/docs/conductor-routing-contract.md
@@ -14,7 +14,7 @@ already known:
 This contract starts **after**:
 - the active run has been identified (scope/target resolved)
 - ownership/idempotency has been classified (from `conductor-ownership.mjs`, issue #32)
-- family-local lifecycle states have been detected (from `copilot-loop-state.mjs` and `reviewer-loop-state.mjs`) and are interpreted under the broader semantics frozen in `skills/docs/pr-lifecycle-contract.md`
+- the copilot/reviewer inner-loop state-machine outputs have been detected (from `copilot-loop-state.mjs` and `reviewer-loop-state.mjs`) and are interpreted under the broader family-local PR lifecycle semantics frozen in `skills/docs/pr-lifecycle-contract.md`
 
 The routing outcome is derived **directly from normalized state inputs** — the evaluator does not accept a
 pre-computed outer-loop action. It is the routing authority, not a remapper.
@@ -25,7 +25,7 @@ pre-computed outer-loop action. It is the routing authority, not a remapper.
 |---|---|
 | [#28 — conductor umbrella](https://github.com/mfittko/pi-dev-loops/issues/28) | Parent umbrella |
 | [#32 — ownership/idempotency](https://github.com/mfittko/pi-dev-loops/issues/32) | **Upstream**: provides optional `ownershipState` input; this contract starts after ownership is settled |
-| [#26 — family-local lifecycle states](https://github.com/mfittko/pi-dev-loops/issues/26) / `skills/docs/pr-lifecycle-contract.md` | **Upstream**: provides family-local PR lifecycle semantics; the concrete `copilotState` and `reviewerState` inputs still come from the existing copilot/reviewer state machines, and this contract consumes them without redefining their semantics |
+| [#26 — family-local PR lifecycle contract](https://github.com/mfittko/pi-dev-loops/issues/26) / `skills/docs/pr-lifecycle-contract.md` | **Upstream**: provides family-local PR lifecycle semantics; the concrete `copilotState` and `reviewerState` inputs still come from the existing copilot/reviewer state machines, and this contract consumes them without redefining their semantics |
 | [#34 — request/watch helper contract](https://github.com/mfittko/pi-dev-loops/issues/34) | **Adjacent**: defines Copilot request/watch semantics inside the copilot loop family; this contract decides _which family_ gets control |
 | [#48 — visible PR projection](https://github.com/mfittko/pi-dev-loops/issues/48) | **Downstream**: routing decisions may drive PR projection artifacts |
 | [#57/#58/#59 — inspection/viewer/steering](https://github.com/mfittko/pi-dev-loops/issues/57) | **Adjacent**: read-only inspection surfaces; this contract defines routing policy, not operator UX |

--- a/docs/conductor-routing-contract.md
+++ b/docs/conductor-routing-contract.md
@@ -14,7 +14,7 @@ already known:
 This contract starts **after**:
 - the active run has been identified (scope/target resolved)
 - ownership/idempotency has been classified (from `conductor-ownership.mjs`, issue #32)
-- family-local lifecycle states have been detected (from `copilot-loop-state.mjs`, `reviewer-loop-state.mjs`, issue #26)
+- family-local lifecycle states have been detected (from `copilot-loop-state.mjs`, `reviewer-loop-state.mjs`, under the broader semantics frozen in `skills/docs/pr-lifecycle-contract.md`)
 
 The routing outcome is derived **directly from normalized state inputs** — the evaluator does not accept a
 pre-computed outer-loop action. It is the routing authority, not a remapper.
@@ -25,7 +25,7 @@ pre-computed outer-loop action. It is the routing authority, not a remapper.
 |---|---|
 | [#28 — conductor umbrella](https://github.com/mfittko/pi-dev-loops/issues/28) | Parent umbrella |
 | [#32 — ownership/idempotency](https://github.com/mfittko/pi-dev-loops/issues/32) | **Upstream**: provides optional `ownershipState` input; this contract starts after ownership is settled |
-| [#26 — family-local lifecycle states](https://github.com/mfittko/pi-dev-loops/issues/26) | **Upstream**: provides `copilotState` and `reviewerState` inputs; this contract consumes them without redefining their semantics |
+| [#26 — family-local lifecycle states](https://github.com/mfittko/pi-dev-loops/issues/26) / `skills/docs/pr-lifecycle-contract.md` | **Upstream**: provides family-local PR lifecycle semantics; the concrete `copilotState` and `reviewerState` inputs still come from the existing copilot/reviewer state machines, and this contract consumes them without redefining their semantics |
 | [#34 — request/watch helper contract](https://github.com/mfittko/pi-dev-loops/issues/34) | **Adjacent**: defines Copilot request/watch semantics inside the copilot loop family; this contract decides _which family_ gets control |
 | [#48 — visible PR projection](https://github.com/mfittko/pi-dev-loops/issues/48) | **Downstream**: routing decisions may drive PR projection artifacts |
 | [#57/#58/#59 — inspection/viewer/steering](https://github.com/mfittko/pi-dev-loops/issues/57) | **Adjacent**: read-only inspection surfaces; this contract defines routing policy, not operator UX |
@@ -36,7 +36,7 @@ This contract owns **conductor routing and handoff decisions after ownership and
 
 It does **not** define:
 - which run is active (ownership/idempotency rules from #32)
-- PR lifecycle state semantics, gate order, or draft/ready transitions (from #26)
+- PR lifecycle state semantics, gate order, or draft/ready transitions (from `skills/docs/pr-lifecycle-contract.md`)
 - Copilot request/re-request/watch helper semantics (from #34)
 - PR-visible projection artifacts (from #48)
 - inspection, viewer, or steering surfaces (from #57/#58/#59)
@@ -315,7 +315,7 @@ This contract intentionally does **not** cover:
 
 - ownership-key design, duplicate-owner handling, or start/attach/resume idempotency rules (→ #32)
 - wiring `ownershipState` into `outer-loop.mjs` or any other caller (deferred to a follow-up slice)
-- PR lifecycle states, draft/ready gate order, remediation ownership classes, or approval-gate semantics (→ #26)
+- PR lifecycle states, draft/ready gate order, remediation ownership classes, or approval-gate semantics (→ `skills/docs/pr-lifecycle-contract.md`)
 - Copilot request / re-request / watch helper semantics (→ #34)
 - inspection, viewer, or steering surface design (→ #57/#58/#59)
 - PR-visible projection / closeout artifacts (→ #48)

--- a/docs/copilot-loop-state-graph.md
+++ b/docs/copilot-loop-state-graph.md
@@ -6,6 +6,8 @@ This document defines the deterministic state machine for the async Copilot revi
 
 The state machine captures observable PR/GitHub/worktree facts (the **snapshot**) and maps them to exactly one **current state**, a list of **allowed next transitions**, and a **recommended next action**.
 
+This document is the Copilot-family inner-loop state machine. The broader family-local PR lifecycle that consumes this machine is defined in `skills/docs/pr-lifecycle-contract.md`.
+
 The implementation lives in:
 
 - **Pure logic**: `packages/core/src/loop/copilot-loop-state.mjs` — state constants, transition table, `normalizeSnapshot`, `interpretLoopState`

--- a/docs/gate-review-comment-contract.md
+++ b/docs/gate-review-comment-contract.md
@@ -12,7 +12,8 @@ the latest head — without relying on local or session-only artifacts.
 
 This document owns the visible gate-review comment evidence contract only. It does
 not restate the full PR follow-up procedure; that remains owned by the relevant
-workflow skill.
+workflow skill. The broader family-local PR lifecycle that consumes this evidence
+is defined in `skills/docs/pr-lifecycle-contract.md`.
 
 ## Scope
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ Start here for repository documentation.
 - `docs/IMPLEMENTATION_STATE.md` — current execution snapshot and fresh-session read order
 - `docs/IMPLEMENTATION_WORKFLOW.md` — workflow/process authority boundaries
 - `docs/conductor-routing-contract.md` — canonical outer-loop routing contract
+- `skills/docs/pr-lifecycle-contract.md` — canonical family-local PR lifecycle contract
 - `docs/tracker-story-pr-contract.md` — canonical tracker-first story/PR contract
 - `docs/sub-issue-tree-contract.md` — deterministic pattern for epic decomposition with GitHub sub-issue trees
 - `docs/conductor-ownership-contract.md`

--- a/docs/reviewer-loop-state-graph.md
+++ b/docs/reviewer-loop-state-graph.md
@@ -6,6 +6,8 @@ This document defines the deterministic reviewer-side PR loop state machine.
 
 The reviewer loop captures observable PR/GitHub facts plus explicit local reviewer-loop metadata (planning/run/merge status) into one snapshot and deterministically maps that snapshot to exactly one current state.
 
+This document defines the reviewer-side review production/submission boundary. The broader family-local PR lifecycle that consumes this boundary is defined in `skills/docs/pr-lifecycle-contract.md`.
+
 Implementation:
 
 - Pure logic: `packages/core/src/loop/reviewer-loop-state.mjs`

--- a/skills/docs/pr-lifecycle-contract.md
+++ b/skills/docs/pr-lifecycle-contract.md
@@ -1,0 +1,198 @@
+# PR lifecycle contract
+
+This document defines the deterministic **family-local PR lifecycle contract** for the GitHub/Copilot workflow family in `pi-dev-loops`.
+
+This canonical owner lives in the shipped `skills/docs/` surface because installed skill/runtime consumers reliably own the skills subtree.
+
+It consolidates the lifecycle boundary currently split across:
+- `docs/copilot-loop-state-graph.md`
+- `docs/reviewer-loop-state-graph.md`
+- `docs/gate-review-comment-contract.md`
+- `packages/core/src/loop/pr-gate-coordination.mjs`
+
+## Purpose
+
+This contract freezes the end-to-end lifecycle semantics for one PR as it moves through:
+
+```text
+draft-stage local gate -> draft remediation -> ready-for-review
+-> explicit Copilot request/wait -> Copilot remediation / reply-resolve / re-review
+-> final local pre-approval gate -> human approval / merge waits
+```
+
+This document owns the **family-local lifecycle semantics** only.
+It does not redefine helper transport mechanics, reviewer-loop internals, conductor routing, or merge policy.
+
+## Relationship to adjacent contracts
+
+| Surface | Relationship |
+|---|---|
+| `docs/copilot-loop-state-graph.md` | Copilot-family inner-loop state machine consumed by this lifecycle |
+| `docs/reviewer-loop-state-graph.md` | Reviewer-side review production / submission boundary consumed by this lifecycle |
+| `docs/gate-review-comment-contract.md` | Visible evidence contract for `draft_gate` and `pre_approval_gate` |
+| `docs/conductor-routing-contract.md` | Downstream consumer of family-local lifecycle outcomes |
+| `docs/conductor-ownership-contract.md` | Downstream owner/arbitration contract; not lifecycle authority |
+| issue #29 | Reviewer-loop boundary semantics |
+| issue #34 | Copilot request / re-request / watch helper mechanics |
+| issue #43 | DRY/KISS/YAGNI policy for the final local pre-approval gate |
+| issue #61 | Conductor routing and loop-family handoff above this family-local lifecycle |
+| issue #32 | Ownership/idempotency truth for active runs |
+
+## Core rules
+
+- Exactly **one current lifecycle state** must apply at a time.
+- The lifecycle must fail closed when required evidence is missing, stale, ambiguous, or unparsable.
+- Every gate-crossing decision is for the **current PR head SHA**.
+- Draft existence alone is **not** draft-gate readiness.
+- A PR must clear the draft-stage gate for the current head before Copilot review may be requested.
+- Ready -> draft resets the lifecycle back into draft-stage gating.
+- Human approval / merge are explicit external waits, not hidden remediation states.
+
+## Two required local gates
+
+### 1. `draft_gate`
+
+Applies while the PR is draft.
+
+Purpose:
+- decide whether the current draft head is materially reviewable
+- decide whether the PR stays draft for more remediation or may leave draft
+
+A clean current-head `draft_gate` result authorizes:
+- `gh pr ready` / leaving draft for that head
+
+A clean `draft_gate` result does **not** authorize:
+- final approval readiness
+- merge-ready claims
+- satisfaction of `pre_approval_gate`
+
+### 2. `pre_approval_gate`
+
+Applies after Copilot convergence and before final approval / merge claims.
+
+This gate uses the DRY/KISS/YAGNI review policy from #43.
+
+A clean current-head `pre_approval_gate` result authorizes:
+- approval-ready / final-human-approval readiness for that head
+
+A clean `pre_approval_gate` result does **not** authorize:
+- draft-stage ready-for-review decisions
+- retroactive satisfaction of `draft_gate` for a later head
+
+## Lifecycle states
+
+The family-local lifecycle should be modeled in this vocabulary (exact spelling may evolve, but the semantics are stable):
+
+| State | Meaning |
+|---|---|
+| `draft_local_review_gate` | draft PR is at the local draft-stage gate boundary |
+| `draft_local_remediation` | draft-stage findings require more local remediation while the PR remains draft |
+| `ready_state_needs_copilot_request` | draft gate is clear for the current head; Copilot request is the next legal step |
+| `waiting_for_copilot_review` | Copilot request/re-review is observably in progress for the current head |
+| `copilot_feedback_remediation` | actionable Copilot feedback exists; fixes are the next active step |
+| `copilot_reply_resolve_pending` | fixes were applied, but GitHub thread reply/resolve work still remains |
+| `final_local_preapproval_gate` | current-head post-Copilot convergence is ready for the final local gate |
+| `final_gate_remediation` | DRY/KISS/YAGNI findings require more remediation after the final gate |
+| `waiting_for_human_pr_approval` | local gates are satisfied; waiting for explicit human approval |
+| `waiting_for_merge` | approval exists; waiting for merge / merge-triggering external action |
+| `terminal_slice_complete` | merged/closed and no further owned step remains |
+| `stopped_needs_user_decision` | blocked/ambiguous state requiring explicit human decision |
+
+## Required transitions
+
+At minimum, the lifecycle must enforce these transitions:
+
+- `draft_local_review_gate` -> `draft_local_remediation`
+  - blocking `draft_gate` findings
+- `draft_local_review_gate` -> `ready_state_needs_copilot_request`
+  - clean current-head `draft_gate` evidence exists
+- `draft_local_review_gate` -> `stopped_needs_user_decision`
+  - human decision required
+- `draft_local_remediation` -> `draft_local_review_gate`
+  - fixes pushed on the draft head
+- `ready_state_needs_copilot_request` -> `waiting_for_copilot_review`
+  - explicit request/confirm succeeded
+- `ready_state_needs_copilot_request` -> `stopped_needs_user_decision`
+  - request unavailable or blocked
+- `waiting_for_copilot_review` -> `copilot_feedback_remediation`
+  - actionable Copilot feedback exists
+- `copilot_feedback_remediation` -> `copilot_reply_resolve_pending`
+  - fixes applied but reply/resolve still remains
+- `copilot_reply_resolve_pending` -> `ready_state_needs_copilot_request`
+  - reply/resolve complete and another Copilot pass is required
+- `waiting_for_copilot_review` -> `final_local_preapproval_gate`
+  - the current-head request/re-review cycle has settled cleanly with no actionable feedback and no further Copilot pass is needed
+- `final_local_preapproval_gate` -> `final_gate_remediation`
+  - DRY/KISS/YAGNI findings require changes
+- `final_local_preapproval_gate` -> `waiting_for_human_pr_approval`
+  - clean current-head `pre_approval_gate` evidence exists
+- `waiting_for_human_pr_approval` -> `waiting_for_merge`
+  - approval arrives
+- `waiting_for_human_pr_approval` -> `draft_local_review_gate`
+  - PR reset to draft
+- `waiting_for_merge` -> `terminal_slice_complete`
+  - merged/closed and the PR lifecycle is complete
+
+### Required negative boundaries
+
+- no Copilot request before clean current-head `draft_gate` evidence
+- no direct skip from fix-applied to Copilot re-request while reply/resolve remains incomplete
+- no reuse of ready-side or gate evidence after ready -> draft
+- no implicit fallthrough from approval/merge waits into remediation without a triggering event
+
+## Ownership classes
+
+The lifecycle must make the next owner/action class explicit.
+
+| Finding / state class | Next owner |
+|---|---|
+| draft-stage local findings | `draft_local_remediation` |
+| actionable Copilot feedback | `copilot_feedback_remediation` |
+| fixes applied but unresolved GitHub reply/resolve work remains | `copilot_reply_resolve_pending` |
+| final DRY/KISS/YAGNI findings | `final_gate_remediation` |
+| human approval / merge | explicit external wait |
+
+Reviewer-loop reminder:
+- reviewer-loop semantics end at a review result / submission boundary
+- this lifecycle defines what happens after that boundary without absorbing reviewer-loop planning/submission behavior
+
+## Required evidence classes
+
+The lifecycle distinguishes three evidence classes:
+
+1. **observable GitHub state**
+   - PR draft/non-draft/merged/closed state
+   - current head SHA
+   - reviews, review threads, requested reviewers
+   - any current-head validation/check freshness only where an adjacent gate/helper already makes a boundary CI-dependent
+
+2. **visible gate evidence on the PR**
+   - current-head `draft_gate` evidence when draft-gate clearance is required
+   - current-head `pre_approval_gate` evidence when final approval readiness is required
+
+### Precedence rules
+
+- current observable PR/head state beats stale local memory
+- required visible gate evidence beats local-only gate records for crossing a gate boundary
+- incomplete or conflicting evidence yields fail-closed blocked/reconcile behavior, not optimistic progression
+
+## Fail-closed rules
+
+The lifecycle must stop or reconcile rather than advance when:
+- current head SHA cannot be determined
+- required current-head `draft_gate` evidence is missing
+- required current-head `pre_approval_gate` evidence is missing
+- gate evidence exists but gate name, verdict, or reviewed SHA is missing or unparsable
+- evidence exists only for an older head SHA
+- review-thread capture failed or is incomplete, so unresolved feedback cannot safely be treated as zero
+- Copilot request status is failed, unavailable without in-progress evidence, or otherwise ambiguous for the current head
+- a required current-head wait cannot be confirmed settled
+- a boundary that is already CI/validation-dependent cannot confirm current-head freshness because the relevant status is pending, none, unknown, or stale
+- a required visible gate comment could not be confirmed posted
+
+In those cases the workflow must not:
+- leave draft
+- request or re-request Copilot review
+- declare final approval readiness
+- silently fall through to a more permissive state
+

--- a/skills/docs/pr-lifecycle-contract.md
+++ b/skills/docs/pr-lifecycle-contract.md
@@ -8,7 +8,6 @@ It consolidates the lifecycle boundary currently split across:
 - `docs/copilot-loop-state-graph.md`
 - `docs/reviewer-loop-state-graph.md`
 - `docs/gate-review-comment-contract.md`
-- `packages/core/src/loop/pr-gate-coordination.mjs`
 
 ## Purpose
 
@@ -58,13 +57,9 @@ Purpose:
 - decide whether the current draft head is materially reviewable
 - decide whether the PR stays draft for more remediation or may leave draft
 
-A clean current-head `draft_gate` result authorizes:
-- `gh pr ready` / leaving draft for that head
-
-A clean `draft_gate` result does **not** authorize:
-- final approval readiness
-- merge-ready claims
-- satisfaction of `pre_approval_gate`
+Boundary note:
+- `draft_gate` governs only the draft -> ready-for-review boundary for the reviewed head
+- visible comment schema/evidence rules stay in `docs/gate-review-comment-contract.md`
 
 ### 2. `pre_approval_gate`
 
@@ -72,12 +67,9 @@ Applies after Copilot convergence and before final approval / merge claims.
 
 This gate uses the DRY/KISS/YAGNI review policy from #43.
 
-A clean current-head `pre_approval_gate` result authorizes:
-- approval-ready / final-human-approval readiness for that head
-
-A clean `pre_approval_gate` result does **not** authorize:
-- draft-stage ready-for-review decisions
-- retroactive satisfaction of `draft_gate` for a later head
+Boundary note:
+- `pre_approval_gate` governs only final approval readiness for the reviewed head
+- visible comment schema/evidence rules stay in `docs/gate-review-comment-contract.md`
 
 ## Lifecycle states
 
@@ -140,17 +132,14 @@ At minimum, the lifecycle must enforce these transitions:
 - no reuse of ready-side or gate evidence after ready -> draft
 - no implicit fallthrough from approval/merge waits into remediation without a triggering event
 
-## Ownership classes
+## Remediation ownership boundary
 
-The lifecycle must make the next owner/action class explicit.
-
-| Finding / state class | Next owner |
-|---|---|
-| draft-stage local findings | `draft_local_remediation` |
-| actionable Copilot feedback | `copilot_feedback_remediation` |
-| fixes applied but unresolved GitHub reply/resolve work remains | `copilot_reply_resolve_pending` |
-| final DRY/KISS/YAGNI findings | `final_gate_remediation` |
-| human approval / merge | explicit external wait |
+The lifecycle must keep the next action class explicit:
+- draft-stage local findings route to `draft_local_remediation`
+- actionable Copilot feedback routes to `copilot_feedback_remediation`
+- fixes applied but unresolved GitHub reply/resolve work remains route to `copilot_reply_resolve_pending`
+- final DRY/KISS/YAGNI findings route to `final_gate_remediation`
+- human approval / merge remain explicit external waits
 
 Reviewer-loop reminder:
 - reviewer-loop semantics end at a review result / submission boundary

--- a/skills/docs/pr-lifecycle-contract.md
+++ b/skills/docs/pr-lifecycle-contract.md
@@ -158,7 +158,7 @@ Reviewer-loop reminder:
 
 ## Required evidence classes
 
-The lifecycle distinguishes three evidence classes:
+The lifecycle distinguishes two evidence classes:
 
 1. **observable GitHub state**
    - PR draft/non-draft/merged/closed state

--- a/skills/docs/pr-lifecycle-contract.md
+++ b/skills/docs/pr-lifecycle-contract.md
@@ -2,7 +2,7 @@
 
 This document defines the deterministic **family-local PR lifecycle contract** for the GitHub/Copilot workflow family in `pi-dev-loops`.
 
-This canonical owner lives in the shipped `skills/docs/` surface because installed skill/runtime consumers reliably own the skills subtree.
+The canonical contract lives in the shipped `skills/docs/` surface because installed skill/runtime consumers reliably own the skills subtree.
 
 It consolidates the lifecycle boundary currently split across:
 - `docs/copilot-loop-state-graph.md`

--- a/skills/docs/pr-lifecycle-contract.md
+++ b/skills/docs/pr-lifecycle-contract.md
@@ -81,7 +81,7 @@ A clean `pre_approval_gate` result does **not** authorize:
 
 ## Lifecycle states
 
-The family-local lifecycle should be modeled in this vocabulary (exact spelling may evolve, but the semantics are stable):
+The family-local lifecycle should be modeled in this vocabulary. These state identifiers are part of the stable contract surface for this lifecycle, even if adjacent helper implementations evolve around them:
 
 | State | Meaning |
 |---|---|

--- a/test/review-doc-contracts.test.mjs
+++ b/test/review-doc-contracts.test.mjs
@@ -96,12 +96,13 @@ test("reviewer-loop contract documents submitted-review handoff and explicit ext
 });
 
 test("consolidated PR lifecycle contract freezes the family-local lifecycle boundary", async () => {
-  const [lifecycleContract, docsIndex, copilotGraph, gateContract, conductorRouting] = await Promise.all([
+  const [lifecycleContract, docsIndex, copilotGraph, gateContract, conductorRouting, conductorOwnership] = await Promise.all([
     readRepo("skills/docs/pr-lifecycle-contract.md"),
     readRepo("docs/index.md"),
     readRepo("docs/copilot-loop-state-graph.md"),
     readRepo("docs/gate-review-comment-contract.md"),
     readRepo("docs/conductor-routing-contract.md"),
+    readRepo("docs/conductor-ownership-contract.md"),
   ]);
 
   assert.match(docsIndex, /skills\/docs\/pr-lifecycle-contract\.md/i);
@@ -117,6 +118,7 @@ test("consolidated PR lifecycle contract freezes the family-local lifecycle boun
   assert.match(copilotGraph, /skills\/docs\/pr-lifecycle-contract\.md/i);
   assert.match(gateContract, /skills\/docs\/pr-lifecycle-contract\.md/i);
   assert.match(conductorRouting, /skills\/docs\/pr-lifecycle-contract\.md/i);
+  assert.match(conductorOwnership, /skills\/docs\/pr-lifecycle-contract\.md/i);
 });
 
 test("dev-loop skill documents opt-in Playwright smoke harnesses for UI slices", async () => {

--- a/test/review-doc-contracts.test.mjs
+++ b/test/review-doc-contracts.test.mjs
@@ -90,8 +90,33 @@ test("reviewer-loop contract documents submitted-review handoff and explicit ext
   assert.match(reviewerGraph, /A pure internal reviewer pass must end in a concrete review result boundary \(`submitted_review`\)/i);
   assert.match(reviewerGraph, /If a wait state is used, it must be an explicit named external-participant boundary/i);
   assert.match(reviewerGraph, /A new review request after fixes starts a new reviewer-pass context \(`review_requested`\)/i);
+  assert.match(reviewerGraph, /skills\/docs\/pr-lifecycle-contract\.md/i);
   assert.match(scriptsReadme, /reviewer `submitted_review`\s+as outer-loop-owned `continue_wait` states at explicit external\/handoff boundaries/i);
   assert.match(scriptsReadme, /preserves compatibility for reviewer `waiting_for_author_followup` and `waiting_for_re_request`\s+as legacy named external-wait boundaries/i);
+});
+
+test("consolidated PR lifecycle contract freezes the family-local lifecycle boundary", async () => {
+  const [lifecycleContract, docsIndex, copilotGraph, gateContract, conductorRouting] = await Promise.all([
+    readRepo("skills/docs/pr-lifecycle-contract.md"),
+    readRepo("docs/index.md"),
+    readRepo("docs/copilot-loop-state-graph.md"),
+    readRepo("docs/gate-review-comment-contract.md"),
+    readRepo("docs/conductor-routing-contract.md"),
+  ]);
+
+  assert.match(docsIndex, /skills\/docs\/pr-lifecycle-contract\.md/i);
+  assert.match(lifecycleContract, /^# PR lifecycle contract$/m);
+  assert.match(lifecycleContract, /draft-stage local gate -> draft remediation -> ready-for-review/i);
+  assert.match(lifecycleContract, /Exactly \*\*one current lifecycle state\*\* must apply at a time/i);
+  assert.match(lifecycleContract, /draft_local_review_gate/i);
+  assert.match(lifecycleContract, /copilot_reply_resolve_pending/i);
+  assert.match(lifecycleContract, /final_gate_remediation/i);
+  assert.match(lifecycleContract, /waiting_for_human_pr_approval/i);
+  assert.match(lifecycleContract, /required visible gate evidence beats local-only gate records/i);
+
+  assert.match(copilotGraph, /skills\/docs\/pr-lifecycle-contract\.md/i);
+  assert.match(gateContract, /skills\/docs\/pr-lifecycle-contract\.md/i);
+  assert.match(conductorRouting, /skills\/docs\/pr-lifecycle-contract\.md/i);
 });
 
 test("dev-loop skill documents opt-in Playwright smoke harnesses for UI slices", async () => {

--- a/test/review-doc-contracts.test.mjs
+++ b/test/review-doc-contracts.test.mjs
@@ -107,13 +107,13 @@ test("consolidated PR lifecycle contract freezes the family-local lifecycle boun
 
   assert.match(docsIndex, /skills\/docs\/pr-lifecycle-contract\.md/i);
   assert.match(lifecycleContract, /^# PR lifecycle contract$/m);
-  assert.match(lifecycleContract, /draft-stage local gate -> draft remediation -> ready-for-review/i);
-  assert.match(lifecycleContract, /Exactly \*\*one current lifecycle state\*\* must apply at a time/i);
+  assert.match(lifecycleContract, /## Lifecycle states/i);
+  assert.match(lifecycleContract, /## Required transitions/i);
+  assert.match(lifecycleContract, /## Fail-closed rules/i);
   assert.match(lifecycleContract, /draft_local_review_gate/i);
   assert.match(lifecycleContract, /copilot_reply_resolve_pending/i);
   assert.match(lifecycleContract, /final_gate_remediation/i);
   assert.match(lifecycleContract, /waiting_for_human_pr_approval/i);
-  assert.match(lifecycleContract, /required visible gate evidence beats local-only gate records/i);
 
   assert.match(copilotGraph, /skills\/docs\/pr-lifecycle-contract\.md/i);
   assert.match(gateContract, /skills\/docs\/pr-lifecycle-contract\.md/i);


### PR DESCRIPTION
## Summary

Add one canonical family-local PR lifecycle contract doc under `skills/docs/` and align the adjacent docs/tests to consume it instead of leaving the lifecycle semantics split across multiple surfaces.

## Scope / context

This is the local-first consolidation contract slice for #26.

It does **not** introduce a brand-new monolithic lifecycle evaluator. Instead, it freezes the lifecycle boundary and vocabulary that the existing split surfaces already imply, then points the surrounding docs/tests at that canonical contract.

Main changes:
- add `skills/docs/pr-lifecycle-contract.md` as the canonical family-local PR lifecycle contract
- link adjacent docs back to that canonical contract
- keep the contract canonically under `skills/docs/`, not `docs/`
- add the repo rule in `AGENTS.md` that skill-required canonical docs must live under `skills/docs/`
- add doc-contract coverage that the consolidated lifecycle contract exists and is referenced from adjacent surfaces

## Acceptance criteria

- one canonical PR lifecycle contract exists under `skills/docs/`
- the contract freezes the family-local lifecycle boundary across:
  - draft gate
  - draft remediation
  - Copilot request/wait/remediation/re-review
  - final pre-approval gate
  - human approval / merge waits
- adjacent docs reference the canonical lifecycle contract instead of acting like separate lifecycle authorities
- the repo guardrail for canonical skill-required docs is explicit in `AGENTS.md`
- docs/tests stay green under repo verification

## Definition of done

- `skills/docs/pr-lifecycle-contract.md` exists and is the canonical contract location
- `docs/index.md` links to it for discovery
- `docs/copilot-loop-state-graph.md`, `docs/reviewer-loop-state-graph.md`, and `docs/gate-review-comment-contract.md` point to it as the broader lifecycle consumer
- conductor-adjacent docs reference the canonical lifecycle contract without redefining it
- doc-contract tests cover the new canonical path and key lifecycle anchors
- `npm run verify` passes

## Validation

- `npm run verify`

## Non-goals

- introducing a new monolithic lifecycle evaluator in this PR
- redefining helper-level Copilot request/watch mechanics
- redefining reviewer-loop internal planning/submission semantics
- redefining conductor routing or ownership policy
- merging to `main`

Closes #26
