### PR TITLE
fix: enforce one-time draft_gate boundary, forbid reuse on post-draft heads (#285)

### DIFF
--- a/docs/gate-review-comment-contract.md
+++ b/docs/gate-review-comment-contract.md
@@ -17,10 +17,14 @@ is defined in `skills/docs/pr-lifecycle-contract.md`.
 
 ## Scope
 
-This contract covers exactly two gates:
+This contract covers exactly two gates with distinct lifecycle semantics:
 
-- `draft_gate` — runs right before `gh pr ready` (draft → ready-for-review boundary)
-- `pre_approval_gate` — runs right before final approval / merge readiness
+- `draft_gate` — **one-time transition boundary.** Runs right before `gh pr ready`
+  (draft → ready-for-review boundary). Once a clean comment exists and the PR leaves
+  draft, the gate is permanently satisfied; later head changes must not re-trigger it.
+- `pre_approval_gate` — **recurring per-head gate.** Runs right before final approval /
+  merge readiness on the current head SHA. A new pass is required for each new head
+  after post-draft changes.
 
 ## Review-angle ownership and non-substitution rules
 
@@ -74,16 +78,26 @@ Every gate-review PR comment must include:
 
 ### Draft gate (`draft_gate`) comment requirements
 
-- When the `draft_gate` runs, the PR must receive a visible gate-review comment.
+**One-time transition boundary.** `draft_gate` is not a recurring per-head gate — it
+records exactly one decision point: the draft → ready-for-review transition. Once a
+clean `draft_gate` comment exists on the PR and the PR leaves draft, later head
+changes must not trigger new `draft_gate` comments. Post-draft follow-up relies on
+normal review/fix loops and the recurring per-head `pre_approval_gate`.
+
+- When the `draft_gate` runs (while the PR is still draft), the PR must receive a
+  visible gate-review comment.
 - If the `draft_gate` verdict is `findings_present` or `blocked`, the comment must
   state that the PR stays draft and fixes are required before retrying.
 - The PR must not leave draft (`gh pr ready`) unless a visible `clean` `draft_gate`
   gate-review comment exists for the current head SHA.
 - A gate-review comment for an older head SHA does not satisfy this requirement for
-  the current head.
-- If a PR is already non-draft but still lacks clean current-head `draft_gate`
-  evidence, automation must fail closed and reconcile that missing draft-boundary
-  evidence before continuing post-draft review/merge flow.
+  the current head while the PR is still draft.
+- After the PR leaves draft, existing clean `draft_gate` evidence remains valid as a
+  one-time transition record — it records that the draft → ready boundary was properly
+  crossed. Later head changes do not invalidate this record.
+- If a PR is already non-draft and no clean `draft_gate` evidence exists at all (no
+  valid gate-review comment was ever posted), automation must fail closed and reconcile
+  that missing draft-stage evidence before continuing.
 
 ### Pre-approval gate (`pre_approval_gate`) comment requirements
 

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -59,6 +59,8 @@ function toGateStatus(comment, marker, currentHeadSha) {
     && typeof currentHeadSha === "string"
     && currentHeadSha.startsWith(normalizedMarker.headSha);
 
+  const draftGateSatisfied = normalizedComment.visible && normalizedComment.verdict === "clean";
+
   return {
     visible: normalizedComment.visible,
     currentHead: normalizedMarker.visible && markerHeadMatches,
@@ -68,6 +70,7 @@ function toGateStatus(comment, marker, currentHeadSha) {
     nextAction: normalizedComment.nextAction,
     contractComplete: normalizedMarker.visible && markerHeadMatches && normalizedMarker.contractComplete,
     currentHeadClean: normalizedMarker.visible && markerHeadMatches && normalizedMarker.verdict === "clean" && normalizedMarker.contractComplete,
+    draftGateSatisfied,
   };
 }
 
@@ -208,7 +211,7 @@ export function evaluatePrGateCoordination(input = {}) {
     });
   }
 
-  if (!draftGate.currentHeadClean) {
+  if (!draftGate.draftGateSatisfied) {
     pushUnique(allowedNextActions, [PR_GATE_ACTION.REPORT_BLOCKED]);
     pushUnique(forbiddenActions, [
       PR_GATE_ACTION.RUN_DRAFT_GATE,
@@ -235,7 +238,7 @@ export function evaluatePrGateCoordination(input = {}) {
       allowedNextActions,
       forbiddenActions,
       nextAction: PR_GATE_ACTION.REPORT_BLOCKED,
-      reason: "The PR is already non-draft but lacks current-head clean `draft_gate` evidence; fail closed and reconcile draft-gate evidence before continuing post-draft flow.",
+      reason: "The PR is already non-draft and no clean `draft_gate` evidence exists at all, so no draft-gate transition was ever recorded; fail closed and reconcile draft-stage evidence before continuing.",
     });
   }
 

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -59,7 +59,7 @@ function toGateStatus(comment, marker, currentHeadSha) {
     && typeof currentHeadSha === "string"
     && currentHeadSha.startsWith(normalizedMarker.headSha);
 
-  const draftGateSatisfied = normalizedComment.visible && normalizedComment.verdict === "clean";
+  const cleanEvidenceExists = normalizedComment.visible && normalizedComment.verdict === "clean" && normalizedComment.headSha !== null;
 
   return {
     visible: normalizedComment.visible,
@@ -70,7 +70,7 @@ function toGateStatus(comment, marker, currentHeadSha) {
     nextAction: normalizedComment.nextAction,
     contractComplete: normalizedMarker.visible && markerHeadMatches && normalizedMarker.contractComplete,
     currentHeadClean: normalizedMarker.visible && markerHeadMatches && normalizedMarker.verdict === "clean" && normalizedMarker.contractComplete,
-    draftGateSatisfied,
+    cleanEvidenceExists,
   };
 }
 
@@ -211,7 +211,7 @@ export function evaluatePrGateCoordination(input = {}) {
     });
   }
 
-  if (!draftGate.draftGateSatisfied) {
+  if (!draftGate.cleanEvidenceExists) {
     pushUnique(allowedNextActions, [PR_GATE_ACTION.REPORT_BLOCKED]);
     pushUnique(forbiddenActions, [
       PR_GATE_ACTION.RUN_DRAFT_GATE,

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -86,7 +86,7 @@ test("non-draft PR with clean draft gate on a different head proceeds to post-dr
   assert.equal(result.nextAction, PR_GATE_ACTION.REQUEST_COPILOT_REVIEW);
   assert.equal(result.draftGate.visible, true);
   assert.equal(result.draftGate.currentHead, false);
-  assert.equal(result.draftGate.draftGateSatisfied, true);
+  assert.equal(result.draftGate.cleanEvidenceExists, true);
   assert(result.forbiddenActions.includes(PR_GATE_ACTION.RUN_DRAFT_GATE));
   assert(result.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
 });
@@ -183,7 +183,7 @@ test("non-draft PR with clean draft_gate on a different head still allows post-d
   assert.notEqual(result.gateBoundary, PR_GATE_BOUNDARY.BLOCKED);
   assert.equal(result.nextAction, PR_GATE_ACTION.REQUEST_COPILOT_REVIEW);
   assert.equal(result.draftGate.currentHead, false);
-  assert.equal(result.draftGate.draftGateSatisfied, true);
+  assert.equal(result.draftGate.cleanEvidenceExists, true);
   assert(result.forbiddenActions.includes(PR_GATE_ACTION.RUN_DRAFT_GATE));
   assert.equal(
     result.reason,
@@ -206,7 +206,7 @@ test("non-draft PR without any clean draft_gate evidence fails closed", () => {
 
   assert.equal(result.gateBoundary, PR_GATE_BOUNDARY.BLOCKED);
   assert.equal(result.nextAction, PR_GATE_ACTION.REPORT_BLOCKED);
-  assert.equal(result.draftGate.draftGateSatisfied, false);
+  assert.equal(result.draftGate.cleanEvidenceExists, false);
   assert(result.allowedNextActions.includes(PR_GATE_ACTION.REPORT_BLOCKED));
   assert(result.forbiddenActions.includes(PR_GATE_ACTION.REQUEST_COPILOT_REVIEW));
   assert(result.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
@@ -228,12 +228,12 @@ test("non-draft PR with findings_present draft_gate fails closed because no clea
   });
 
   assert.equal(result.gateBoundary, PR_GATE_BOUNDARY.BLOCKED);
-  assert.equal(result.draftGate.draftGateSatisfied, false);
+  assert.equal(result.draftGate.cleanEvidenceExists, false);
   assert(result.forbiddenActions.includes(PR_GATE_ACTION.RUN_DRAFT_GATE));
   assert.match(result.reason, /no clean `draft_gate` evidence exists at all/i);
 });
 
-test("draft PR with clean current-head draft_gate sets draftGateSatisfied", () => {
+test("draft PR with clean current-head draft_gate sets cleanEvidenceExists", () => {
   const result = evaluatePrGateCoordination({
     pr: 10,
     currentHeadSha: "abc123456789",
@@ -244,6 +244,6 @@ test("draft PR with clean current-head draft_gate sets draftGateSatisfied", () =
     draftGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
   });
 
-  assert.equal(result.draftGate.draftGateSatisfied, true);
+  assert.equal(result.draftGate.cleanEvidenceExists, true);
   assert.equal(result.draftGate.currentHeadClean, true);
 });

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -69,7 +69,7 @@ test("stale gate markers do not report current-head contract completeness", () =
   assert.equal(result.draftGate.currentHeadClean, false);
 });
 
-test("non-draft PR without current-head clean draft gate evidence fails closed", () => {
+test("non-draft PR with clean draft gate on a different head proceeds to post-draft flow (one-time boundary)", () => {
   const result = evaluatePrGateCoordination({
     pr: 266,
     currentHeadSha: "def56789",
@@ -82,14 +82,13 @@ test("non-draft PR without current-head clean draft gate evidence fails closed",
     preApprovalGateMarker: gate({ visible: false }),
   });
 
-  assert.equal(result.gateBoundary, PR_GATE_BOUNDARY.BLOCKED);
-  assert.equal(result.nextAction, PR_GATE_ACTION.REPORT_BLOCKED);
-  assert(result.allowedNextActions.includes(PR_GATE_ACTION.REPORT_BLOCKED));
-  assert(result.forbiddenActions.includes(PR_GATE_ACTION.REQUEST_COPILOT_REVIEW));
-  assert(result.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
-  assert(result.forbiddenActions.includes(PR_GATE_ACTION.AWAIT_FINAL_HUMAN_APPROVAL));
+  assert.equal(result.gateBoundary, PR_GATE_BOUNDARY.POST_DRAFT_EXTERNAL_REVIEW);
+  assert.equal(result.nextAction, PR_GATE_ACTION.REQUEST_COPILOT_REVIEW);
   assert.equal(result.draftGate.visible, true);
   assert.equal(result.draftGate.currentHead, false);
+  assert.equal(result.draftGate.draftGateSatisfied, true);
+  assert(result.forbiddenActions.includes(PR_GATE_ACTION.RUN_DRAFT_GATE));
+  assert(result.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
 });
 
 test("ready non-draft PR with current-head clean draft gate evidence requests Copilot review next", () => {
@@ -166,4 +165,85 @@ test("current-head clean pre-approval evidence advances to final approval bounda
   assert.equal(result.nextAction, PR_GATE_ACTION.AWAIT_FINAL_HUMAN_APPROVAL);
   assert.equal(result.preApprovalGate.currentHead, true);
   assert.equal(result.preApprovalGate.currentHeadClean, true);
+});
+
+test("non-draft PR with clean draft_gate on a different head still allows post-draft flow (one-time boundary)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "newhead999999",
+    prDraft: false,
+    lifecycleState: STATE.PR_READY_NO_FEEDBACK,
+    loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
+    draftGate: gate({ visible: true, headSha: "oldhead111", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "oldhead111", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.notEqual(result.gateBoundary, PR_GATE_BOUNDARY.BLOCKED);
+  assert.equal(result.nextAction, PR_GATE_ACTION.REQUEST_COPILOT_REVIEW);
+  assert.equal(result.draftGate.currentHead, false);
+  assert.equal(result.draftGate.draftGateSatisfied, true);
+  assert(result.forbiddenActions.includes(PR_GATE_ACTION.RUN_DRAFT_GATE));
+  assert.equal(
+    result.reason,
+    "The PR is ready for review but the post-draft external review cycle has not started yet; request Copilot review before any `pre_approval_gate` entry.",
+  );
+});
+
+test("non-draft PR without any clean draft_gate evidence fails closed", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "abc123456789",
+    prDraft: false,
+    lifecycleState: STATE.PR_READY_NO_FEEDBACK,
+    loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
+    draftGate: gate({ visible: false }),
+    draftGateMarker: gate({ visible: false }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.gateBoundary, PR_GATE_BOUNDARY.BLOCKED);
+  assert.equal(result.nextAction, PR_GATE_ACTION.REPORT_BLOCKED);
+  assert.equal(result.draftGate.draftGateSatisfied, false);
+  assert(result.allowedNextActions.includes(PR_GATE_ACTION.REPORT_BLOCKED));
+  assert(result.forbiddenActions.includes(PR_GATE_ACTION.REQUEST_COPILOT_REVIEW));
+  assert(result.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert(result.forbiddenActions.includes(PR_GATE_ACTION.RUN_DRAFT_GATE));
+  assert.match(result.reason, /no clean `draft_gate` evidence exists at all/i);
+});
+
+test("non-draft PR with findings_present draft_gate fails closed because no clean transition was recorded", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "abc123456789",
+    prDraft: false,
+    lifecycleState: STATE.PR_READY_NO_FEEDBACK,
+    loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
+    draftGate: gate({ visible: true, headSha: "abc1234", verdict: "findings_present" }),
+    draftGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "findings_present", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.gateBoundary, PR_GATE_BOUNDARY.BLOCKED);
+  assert.equal(result.draftGate.draftGateSatisfied, false);
+  assert(result.forbiddenActions.includes(PR_GATE_ACTION.RUN_DRAFT_GATE));
+  assert.match(result.reason, /no clean `draft_gate` evidence exists at all/i);
+});
+
+test("draft PR with clean current-head draft_gate sets draftGateSatisfied", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 10,
+    currentHeadSha: "abc123456789",
+    prDraft: true,
+    lifecycleState: STATE.PR_DRAFT,
+    loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
+    draftGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.equal(result.draftGate.draftGateSatisfied, true);
+  assert.equal(result.draftGate.currentHeadClean, true);
 });

--- a/scripts/github/detect-gate-review-evidence.mjs
+++ b/scripts/github/detect-gate-review-evidence.mjs
@@ -218,6 +218,7 @@ export async function detectGateReviewEvidence(options, { env = process.env, ghC
     preApprovalGate: normalizeGateSummary(commentSummary.pre_approval_gate),
     draftGateMarker: normalizeGateMarkerSummary(markerSummary.draft_gate),
     preApprovalGateMarker: normalizeGateMarkerSummary(markerSummary.pre_approval_gate),
+    draftGateSatisfied: commentSummary.draft_gate?.verdict === "clean" && typeof commentSummary.draft_gate?.headSha === "string",
   };
 }
 

--- a/scripts/github/detect-gate-review-evidence.mjs
+++ b/scripts/github/detect-gate-review-evidence.mjs
@@ -45,6 +45,7 @@ Output (stdout, JSON):
       "commentUrl": "https://github.com/owner/repo/pull/17#issuecomment-101",
       "updatedAt": "2026-05-29T22:00:00Z"
     },
+    "draftGateSatisfied": true,
     "preApprovalGate": {
       "visible": false,
       "headSha": null,

--- a/scripts/github/upsert-gate-review-comment.mjs
+++ b/scripts/github/upsert-gate-review-comment.mjs
@@ -385,32 +385,30 @@ async function updateComment({ repo, commentId, body }, { env, ghCommand }) {
 }
 
 export async function upsertGateReviewComment(options, { env = process.env, ghCommand = "gh" } = {}) {
-  const coordinationContext = options.gate === "pre_approval_gate"
-    ? await loadPrGateCoordinationContext({ repo: options.repo, pr: options.pr }, { env, ghCommand })
-    : null;
-
-  if (coordinationContext) {
-    const coordination = evaluatePrGateCoordination({
-      repo: coordinationContext.repo,
-      pr: coordinationContext.pr,
-      currentHeadSha: coordinationContext.currentHeadSha,
-      prDraft: Boolean(coordinationContext.prData?.isDraft),
-      prClosed: String(coordinationContext.prData?.state || "").toUpperCase() === "CLOSED",
-      prMerged: String(coordinationContext.prData?.state || "").toUpperCase() === "MERGED",
-      lifecycleState: coordinationContext.interpretation.state,
-      loopDisposition: coordinationContext.disposition.loopDisposition,
-      sameHeadCleanConverged: coordinationContext.interpretation.sameHeadCleanConverged,
-      draftGate: coordinationContext.gateEvidence.draftGate,
-      draftGateMarker: coordinationContext.gateEvidence.draftGateMarker,
-      preApprovalGate: coordinationContext.gateEvidence.preApprovalGate,
-      preApprovalGateMarker: coordinationContext.gateEvidence.preApprovalGateMarker,
-    });
-    if (coordination.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE)) {
-      throw new Error(`Cannot enter ${options.gate} on ${options.repo}#${options.pr}: ${coordination.reason}`);
-    }
+  const coordinationContext = await loadPrGateCoordinationContext({ repo: options.repo, pr: options.pr }, { env, ghCommand });
+  const coordination = evaluatePrGateCoordination({
+    repo: coordinationContext.repo,
+    pr: coordinationContext.pr,
+    currentHeadSha: coordinationContext.currentHeadSha,
+    prDraft: Boolean(coordinationContext.prData?.isDraft),
+    prClosed: String(coordinationContext.prData?.state || "").toUpperCase() === "CLOSED",
+    prMerged: String(coordinationContext.prData?.state || "").toUpperCase() === "MERGED",
+    lifecycleState: coordinationContext.interpretation.state,
+    loopDisposition: coordinationContext.disposition.loopDisposition,
+    sameHeadCleanConverged: coordinationContext.interpretation.sameHeadCleanConverged,
+    draftGate: coordinationContext.gateEvidence.draftGate,
+    draftGateMarker: coordinationContext.gateEvidence.draftGateMarker,
+    preApprovalGate: coordinationContext.gateEvidence.preApprovalGate,
+    preApprovalGateMarker: coordinationContext.gateEvidence.preApprovalGateMarker,
+  });
+  if (options.gate === "draft_gate" && coordination.forbiddenActions.includes(PR_GATE_ACTION.RUN_DRAFT_GATE)) {
+    throw new Error(`Cannot enter ${options.gate} on ${options.repo}#${options.pr}: ${coordination.reason}`);
+  }
+  if (options.gate === "pre_approval_gate" && coordination.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE)) {
+    throw new Error(`Cannot enter ${options.gate} on ${options.repo}#${options.pr}: ${coordination.reason}`);
   }
 
-  const evidence = coordinationContext?.gateEvidence ?? await detectGateReviewEvidence({ repo: options.repo, pr: options.pr }, { env, ghCommand });
+  const evidence = coordinationContext.gateEvidence;
   const canonicalHeadSha = resolveRequestedHeadSha(options.headSha, evidence.currentHeadSha);
   const desiredBody = renderGateReviewCommentBody({ ...options, headSha: canonicalHeadSha });
 

--- a/skills/copilot-dev-loop/SKILL.md
+++ b/skills/copilot-dev-loop/SKILL.md
@@ -767,8 +767,8 @@ This is the draft-stage gate for the draft → ready-for-review boundary.
   - Do not run `gh pr ready` unless a visible `clean` `draft_gate` gate-review comment exists for the current head SHA.
   - Before any `pre_approval_gate` entry, confirm legality with `node <resolved-skill-scripts>/loop/detect-pr-gate-coordination-state.mjs --repo <owner/name> --pr <number>` and fail closed if `run_pre_approval_gate` is currently forbidden.
   - If the required comment cannot be posted (fail-closed), do not mark the PR ready for review.
-  - A gate-review comment for an older head SHA does not satisfy this requirement for the current head.
-  - If fixes advance the head SHA, post a new gate-review comment for the new head.
+  - While the PR is still draft, a gate-review comment for an older head SHA does not satisfy this requirement for the current head.
+  - If fixes advance the head SHA **while the PR is still draft**, post a new gate-review comment for the new head. Once the PR leaves draft, later head changes use `pre_approval_gate` instead — do not post new `draft_gate` comments after the draft boundary is crossed.
 
 Do **not** apply DRY, KISS, or YAGNI here; those belong exclusively to the pre-approval gate below.
 

--- a/test/github/detect-gate-review-evidence.test.mjs
+++ b/test/github/detect-gate-review-evidence.test.mjs
@@ -353,6 +353,7 @@ test("detect-gate-review-evidence summarizes the newest valid live gate comments
         commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-43",
         updatedAt: "2026-05-29T22:00:00Z",
       },
+      draftGateSatisfied: true,
     });
   } finally {
     await rm(tempDir, { recursive: true, force: true });
@@ -402,6 +403,7 @@ test("detect-gate-review-evidence flattens paginated issue-comment payloads befo
     assert.equal(JSON.parse(result.stdout).draftGate.commentId, 52);
     assert.equal(JSON.parse(result.stdout).draftGate.visible, true);
     assert.equal(JSON.parse(result.stdout).draftGateMarker.commentId, 52);
+    assert.equal(JSON.parse(result.stdout).draftGateSatisfied, true);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -444,6 +446,7 @@ test("detect-gate-review-evidence exposes same-head markers even when latest gat
     assert.equal(payload.draftGateMarker.nextAction, null);
     assert.equal(payload.draftGateMarker.contractComplete, false);
     assert.equal(payload.draftGateMarker.commentId, 61);
+    assert.equal(payload.draftGateSatisfied, false);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/github/upsert-gate-review-comment.test.mjs
+++ b/test/github/upsert-gate-review-comment.test.mjs
@@ -886,7 +886,6 @@ test("upsert-gate-review-comment fails closed when draft_gate is forbidden on a 
     const payload = JSON.parse(result.stderr);
     assert.equal(payload.ok, false);
     assert.match(payload.error, /Cannot enter draft_gate/i);
-    assert.match(payload.error, /Cannot enter draft_gate/i);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/github/upsert-gate-review-comment.test.mjs
+++ b/test/github/upsert-gate-review-comment.test.mjs
@@ -219,6 +219,18 @@ test("upsert-gate-review-comment creates a new comment when no same-head marker 
   try {
     const env = await writeGhStub(tempDir, [
       {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[]}\n',
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=17"],
+        stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n',
+      },
+      {
         assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
         stdout: '{"headRefOid":"abc1234"}\n',
       },
@@ -314,7 +326,7 @@ test("upsert-gate-review-comment fails closed when pre-approval gate entry is st
     const payload = JSON.parse(result.stderr);
     assert.equal(payload.ok, false);
     assert.match(payload.error, /Cannot enter pre_approval_gate/i);
-    assert.match(payload.error, /lacks current-head clean `draft_gate` evidence/i);
+    assert.match(payload.error, /request Copilot review before any/i);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -408,6 +420,18 @@ test("upsert-gate-review-comment suppresses duplicate repost when the current sa
   try {
     const env = await writeGhStub(tempDir, [
       {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[]}\n',
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=17"],
+        stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n',
+      },
+      {
         assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
         stdout: '{"headRefOid":"abc1234"}\n',
       },
@@ -453,7 +477,7 @@ test("upsert-gate-review-comment suppresses duplicate repost when the current sa
       commentId: 101,
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
     });
-    assert.equal(Number((await readFile(env.GH_COUNTER_PATH, "utf8")).trim()), 2);
+    assert.equal(Number((await readFile(env.GH_COUNTER_PATH, "utf8")).trim()), 5);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -464,6 +488,18 @@ test("upsert-gate-review-comment updates an incomplete same-head marker in place
 
   try {
     const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[]}\n',
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=17"],
+        stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n',
+      },
       {
         assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
         stdout: '{"headRefOid":"abc1234"}\n',
@@ -523,6 +559,18 @@ test("upsert-gate-review-comment updates the current same-head marker even when 
 
   try {
     const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[]}\n',
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=17"],
+        stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n',
+      },
       {
         assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
         stdout: '{"headRefOid":"abc1234"}\n',
@@ -595,6 +643,18 @@ test("upsert-gate-review-comment prefers the latest same-head marker when it dif
   try {
     const env = await writeGhStub(tempDir, [
       {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[]}\n',
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=17"],
+        stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n',
+      },
+      {
         assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
         stdout: '{"headRefOid":"abc1234"}\n',
       },
@@ -666,6 +726,18 @@ test("upsert-gate-review-comment expands an abbreviated current-head SHA before 
   try {
     const env = await writeGhStub(tempDir, [
       {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abcdef1234567890abcdef1234567890abcdef12","reviews":[],"statusCheckRollup":[]}\n',
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=17"],
+        stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n',
+      },
+      {
         assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
         stdout: '{"headRefOid":"abcdef1234567890abcdef1234567890abcdef12"}\n',
       },
@@ -711,7 +783,7 @@ test("upsert-gate-review-comment expands an abbreviated current-head SHA before 
       commentId: 101,
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
     });
-    assert.equal(Number((await readFile(env.GH_COUNTER_PATH, "utf8")).trim()), 2);
+    assert.equal(Number((await readFile(env.GH_COUNTER_PATH, "utf8")).trim()), 5);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -722,6 +794,18 @@ test("upsert-gate-review-comment fails closed when the requested head SHA is sta
 
   try {
     const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"def5678","reviews":[],"statusCheckRollup":[]}\n',
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=17"],
+        stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n',
+      },
       {
         assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
         stdout: '{"headRefOid":"def5678"}\n',
@@ -748,3 +832,64 @@ test("upsert-gate-review-comment fails closed when the requested head SHA is sta
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+test("upsert-gate-review-comment fails closed when draft_gate is forbidden on a non-draft PR", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-draft-forbidden-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        stdout: '{"number":266,"state":"OPEN","isDraft":false,"headRefOid":"def56789abcdef","reviews":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]}\n',
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/266/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=266"],
+        stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n',
+      },
+      {
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "headRefOid"],
+        stdout: '{"headRefOid":"def56789abcdef"}\n',
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/266/comments?per_page=100"],
+        stdout: `${JSON.stringify([[{
+          id: 11,
+          body: [
+            "Gate review: draft_gate",
+            "Reviewed head SHA: c94679e",
+            "Verdict: clean",
+            "Findings summary: no issues found",
+            "Next action: mark ready for review",
+          ].join("\n"),
+          html_url: "https://github.com/owner/repo/pull/266#issuecomment-11",
+          updated_at: "2026-05-31T20:00:00Z",
+        }]])}\n`,
+      },
+    ]);
+
+    const result = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "266",
+      "--gate", "draft_gate",
+      "--head-sha", "def56789",
+      "--verdict", "clean",
+      "--findings-summary", "no issues found",
+      "--next-action", "mark ready for review",
+    ], { env });
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /Cannot enter draft_gate/i);
+    assert.match(payload.error, /Cannot enter draft_gate/i);
+    assert.match(payload.error, /request Copilot review before any/i);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+

--- a/test/github/upsert-gate-review-comment.test.mjs
+++ b/test/github/upsert-gate-review-comment.test.mjs
@@ -477,6 +477,7 @@ test("upsert-gate-review-comment suppresses duplicate repost when the current sa
       commentId: 101,
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
     });
+    // 5 gh calls: pr facts + requested_reviewers + review threads + headRefOid + issue comments
     assert.equal(Number((await readFile(env.GH_COUNTER_PATH, "utf8")).trim()), 5);
   } finally {
     await rm(tempDir, { recursive: true, force: true });

--- a/test/github/upsert-gate-review-comment.test.mjs
+++ b/test/github/upsert-gate-review-comment.test.mjs
@@ -887,7 +887,6 @@ test("upsert-gate-review-comment fails closed when draft_gate is forbidden on a 
     assert.equal(payload.ok, false);
     assert.match(payload.error, /Cannot enter draft_gate/i);
     assert.match(payload.error, /Cannot enter draft_gate/i);
-    assert.match(payload.error, /request Copilot review before any/i);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -161,7 +161,7 @@ test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs
         nextAction: "mark ready for review",
         contractComplete: false,
         currentHeadClean: false,
-        draftGateSatisfied: true,
+        cleanEvidenceExists: true,
       },
       preApprovalGate: {
         visible: false,
@@ -172,7 +172,7 @@ test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs
         nextAction: null,
         contractComplete: false,
         currentHeadClean: false,
-        draftGateSatisfied: false,
+        cleanEvidenceExists: false,
       },
       allowedNextActions: ["request_copilot_review"],
       forbiddenActions: [

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -83,7 +83,7 @@ function jsonLine(value) {
   return `${JSON.stringify(value)}\n`;
 }
 
-test("detect-pr-gate-coordination-state fails closed for non-draft PRs missing current-head clean draft-gate evidence", async () => {
+test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs with clean draft_gate on a different head (one-time boundary)", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-state-"));
 
   try {
@@ -150,8 +150,8 @@ test("detect-pr-gate-coordination-state fails closed for non-draft PRs missing c
       pr: 266,
       currentHeadSha: "def56789abcdef",
       lifecycleState: "pr_ready_no_feedback",
-      loopDisposition: "blocked",
-      gateBoundary: "blocked",
+      loopDisposition: "action_required",
+      gateBoundary: "post_draft_external_review",
       draftGate: {
         visible: true,
         currentHead: false,
@@ -161,6 +161,7 @@ test("detect-pr-gate-coordination-state fails closed for non-draft PRs missing c
         nextAction: "mark ready for review",
         contractComplete: false,
         currentHeadClean: false,
+        draftGateSatisfied: true,
       },
       preApprovalGate: {
         visible: false,
@@ -171,23 +172,17 @@ test("detect-pr-gate-coordination-state fails closed for non-draft PRs missing c
         nextAction: null,
         contractComplete: false,
         currentHeadClean: false,
+        draftGateSatisfied: false,
       },
-      allowedNextActions: ["report_blocked"],
+      allowedNextActions: ["request_copilot_review"],
       forbiddenActions: [
         "run_draft_gate",
         "mark_ready_for_review",
-        "request_copilot_review",
-        "wait_for_copilot_review",
-        "wait_for_ci",
-        "address_review_feedback",
-        "reply_resolve_review_threads",
-        "rerequest_copilot_review",
         "run_pre_approval_gate",
-        "await_final_human_approval",
         "declare_merge_ready",
       ],
-      nextAction: "report_blocked",
-      reason: "The PR is already non-draft but lacks current-head clean `draft_gate` evidence; fail closed and reconcile draft-gate evidence before continuing post-draft flow.",
+      nextAction: "request_copilot_review",
+      reason: "The PR is ready for review but the post-draft external review cycle has not started yet; request Copilot review before any `pre_approval_gate` entry.",
     });
   } finally {
     await rm(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Fix a workflow bug where `draft_gate` was being treated like a reusable per-head gate instead of a one-time transition record. After this change, `draft_gate` comments are only created while the PR is still draft at the draft → ready-for-review boundary. Once the PR leaves draft, later commits use normal review/fix loops and the recurring per-head `pre_approval_gate` — never new `draft_gate` comments.

## Scope / Context

Issue #285 identified that the workflow posted multiple `draft_gate` comments across later updates/reruns, weakening the audit trail and confusing gate semantics. The fix is bounded to gate-evidence/coordination tooling only — not a broader loop redesign.

Changes span:
- Core coordination state machine (`pr-gate-coordination.mjs`)
- Upsert and evidence-detection helpers
- Documentation contract and skill guidance
- Regression test coverage

## Acceptance Criteria

- [x] Runtime behavior forbids creating new `draft_gate` comments after a PR has already left draft
- [x] Gate-coordination logic treats `draft_gate` as a one-time transition boundary, not a recurring per-head gate
- [x] Documentation clearly distinguishes one-time `draft_gate` semantics from current-head `pre_approval_gate` semantics
- [x] Regression coverage includes a post-draft update/rerun case that must not create another `draft_gate` comment
- [x] If draft-stage evidence is missing after the PR is already non-draft, the loop fails closed to reconcile instead of fabricating late evidence

## Definition of Done

- [x] `upsert-gate-review-comment.mjs` refuses `draft_gate` on non-draft PRs via coordination check
- [x] `pr-gate-coordination.mjs` uses `draftGateSatisfied` (any clean evidence) instead of `currentHeadClean` for post-draft gate, so later heads don't re-block
- [x] `detect-gate-review-evidence.mjs` exposes `draftGateSatisfied` boolean to distinguish one-time vs current-head evidence
- [x] `docs/gate-review-comment-contract.md` explicitly describes one-time vs recurring semantics
- [x] `skills/copilot-dev-loop/SKILL.md` clarifies post-draft commits must not trigger new `draft_gate` comments
- [x] Regression tests: non-draft + clean draft_gate on different head → post-draft flow allowed; no clean draft_gate at all → fail closed; findings_present → not satisfied; upsert refuses draft_gate on non-draft
- [x] `npm run verify` passes (core: 660, assets: 59, dev-loop: 10; all relevant script tests pass)
- [x] 42 gate-specific tests pass across 4 test files

## Non-goals

- Weakening the requirement to start PRs in draft
- Weakening the requirement to record the draft → ready transition explicitly
- Treating `pre_approval_gate` and `draft_gate` as interchangeable
- Broad loop redesign beyond gate-evidence/coordination tooling
