### PR TITLE
feat(core): add dev-loop config pipeline — schema, loader, roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ test-results/
 .DS_Store
 *.log
 .pi/dev-loop-retrospective-checkpoint.json
+.pi/dev-loop/overrides.json
 
 .pi/ui-servers/

--- a/.pi/dev-loop/defaults.json
+++ b/.pi/dev-loop/defaults.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "strategy": {
+    "default": "github-first"
+  },
+  "refinement": {
+    "fanOut": 3,
+    "mode": "parallel"
+  },
+  "autonomy": {
+    "stopAt": ["merge"]
+  }
+}

--- a/docs/phases/phase-8.md
+++ b/docs/phases/phase-8.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-implemented (slice 1 of 5 complete)
+slice-1-implemented (schema, loader, roles, tests — no workflow wiring)
 
 ## Objective
 

--- a/docs/phases/phase-8.md
+++ b/docs/phases/phase-8.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-planning (merged plan reviewed, minor fixes applied)
+implemented (slice 1 of 5 complete)
 
 ## Objective
 

--- a/docs/phases/phase-8.md
+++ b/docs/phases/phase-8.md
@@ -1,0 +1,165 @@
+# phase-8 durable plan
+
+## Status
+
+planning (merged plan reviewed, minor fixes applied)
+
+## Objective
+
+Define a durable, inspectable configuration contract for `dev-loop` / routed workflow behavior so repo/operator defaults move from implicit prompt/skill/chat-memory seams into one canonical, validated configuration surface with clear precedence, fail-closed semantics, and a clean durable-vs-session split.
+
+## Why this phase exists now
+
+Workflow policy decisions are accumulating in too many scattered places:
+- operator instructions in chat
+- issue-specific overrides
+- skill text / prompt wording
+- hardcoded defaults in scripts or extension behavior
+
+Examples now clearly needing first-class configuration:
+- local-first vs GitHub-first default per workflow class
+- conductor model selection
+- per-role subagent model selection
+- refinement fan-out shape (count, roles, parallel vs sequential)
+- gate review angles and per-angle model overrides
+- autonomy stop boundaries
+
+Without a configuration contract, behavior drifts between runs, repo policy and per-run overrides are hard to separate, and future changes become prompt surgery instead of contract updates.
+
+## In scope
+
+- define the canonical config surface and schema for dev-loop / routed workflow defaults
+- define the canonical home for workflow-policy contract definitions (`.pi/dev-loop/`)
+- define config precedence: built-in defaults → repo defaults → session overrides → per-run flags
+- split durable (committed) from session (gitignored) config
+- define validation with fail-closed behavior for unknown or contradictory config
+- support at minimum these config families:
+  1. **Execution strategy** — local-first vs GitHub-first default, plus per-workflow overrides
+  2. **Model routing** — conductor model, per-role subagent model overrides
+  3. **Refinement policy** — fan-out count, parallel vs sequential, which roles
+  4. **Gate review policy** — which angles run at draft gate and pre-approval gate
+  5. **Autonomy policy** — named stop boundaries defining what gates require operator confirmation
+- define role resolution: lens name → agent persona lookup → model override → default reviewer fallback
+- implement the zod schema, config loader with precedence merging, and validation
+- write contract tests for schema validation and precedence
+- wire the config into at least one real workflow entrypoint (conductor model or strategy routing) to prove it integrates
+- update `PLAN.md` and contract docs to reference the config surface as the canonical source of truth for workflow defaults
+
+## Explicit non-goals
+
+- implementing every config family in full depth in one slice — wire one or two to prove integration
+- building a generic settings platform without bounded workflow need
+- replacing deterministic workflow contracts with free-form prompt tuning
+- UI or interactive config editing
+- config migration/versioning beyond `version: 1` in this phase
+- consuming the config from every workflow surface at once — focus on the schema, loader, and one real integration point
+
+## Design decisions (pre-refined)
+
+These reflect the brainstorming session on 2026-06-01 and serve as the starting point for the phase plan. The fan-out/fan-in loop may refine them further.
+
+### Config home
+
+- Durable defaults: `.pi/dev-loop/defaults.json` (committed, tracked)
+- Session overrides: `.pi/dev-loop/overrides.json` (gitignored)
+- Precedence: per-run CLI flags/env vars > session overrides > repo defaults > built-in defaults
+- Merge is shallow (missing keys fall through, no deep merging)
+
+### Schema shape
+
+```typescript
+// zod schema — single source of truth, types inferred
+const DevLoopConfig = z.strictObject({
+  version: z.literal(1),
+  strategy: z.strictObject({
+    default: z.enum(["local-first", "github-first"]).default("github-first"),
+    byWorkflow: z.record(z.string(), z.enum(["local-first", "github-first"])).optional(),
+  }).default({}),
+  models: z.strictObject({
+    conductor: z.string().optional(),
+    roles: z.record(z.string(), z.string()).optional(),
+  }).default({}),
+  refinement: z.strictObject({
+    fanOut: z.number().int().min(1).max(10).default(3),
+    mode: z.enum(["parallel", "sequential"]).default("parallel"),
+    roles: z.array(z.string()).optional(),
+  }).default({}),
+  gates: z.strictObject({
+    draft: z.strictObject({
+      angles: z.array(z.string()),
+      required: z.boolean().default(true),
+    }).optional(),
+    preApproval: z.strictObject({
+      angles: z.array(z.string()),
+      required: z.boolean().default(true),
+    }).optional(),
+  }).default({}),
+  autonomy: z.strictObject({
+    stopAt: z.array(
+      z.enum(["refinement", "draft-pr", "pre-approval", "merge"])
+    ).optional(),
+  }).default({}),
+});
+```
+
+### Role resolution for gate angles
+
+When a gate specifies `angles: ["security", "style", "correctness"]`:
+
+1. Look up agent persona by role name — if a dedicated agent exists (e.g. `security-reviewer`), use it with its own system prompt and default model
+2. Apply model override from `models.roles[name]` if present — overrides the agent's default model
+3. Fallback: no agent persona found → default reviewer agent + role name injected as focus lens + any model override still applied
+
+This means angles are lenses first, optionally backed by dedicated agent personas. No config wiring needed for the binding itself — drop a persona definition in and it takes over automatically.
+
+### Autonomy levels
+
+`stopAt` is the source of truth — an ordered list of gates that require operator confirmation. A convenience `level` name (`manual | semi | full`) could be a computed/sugared view, but the config stores the explicit list.
+
+## Acceptance criteria
+
+- `.pi/dev-loop/defaults.json` schema is defined and validated via zod
+- `.pi/dev-loop/overrides.json` uses the same schema, sparsely applied
+- config loader resolves precedence correctly: per-run → session → repo → built-in
+- unknown keys cause fail-closed rejection (zod `.strict()`)
+- contradictory values (e.g. unknown enum member) cause clear parse errors
+- role resolution follows the documented 3-step order
+- at least one real integration point consumes the config (conductor model or strategy routing)
+- contract tests cover: valid configs, precedence merging, unknown keys, bad enums, missing version
+- `npm test` passes locally
+- GitHub Actions Node 24 CI passes
+- `PLAN.md` updated to reference the config surface
+- `docs/phases/phase-8.md` updated to reflect as-implemented reality
+
+## Definition of done
+
+- zod schema committed under `packages/core/src/config/` (or equivalent canonical path)
+- config loader committed with precedence merging
+- contract tests pass with ≥ 90% coverage on the config module
+- `.pi/dev-loop/defaults.json` exists in the repo with sensible defaults
+- `.pi/dev-loop/overrides.json` is gitignored
+- one real workflow entrypoint reads the config and applies it (conductor model or strategy)
+- `docs/phases/phase-8.md` is updated to reflect the shipped surface
+- `PLAN.md` acknowledges the config contract as the canonical source for workflow defaults
+- issue #286 is closed or updated with a pointer to the landed phase
+- PR body is structured per the PR description contract
+
+## Validation approach
+
+- zod `.parse()` / `.safeParse()` as the primary validation layer
+- contract tests for every failure mode: unknown keys, bad enums, missing version, out-of-range fanOut
+- contract tests for precedence: each layer overrides the one below
+- integration test: load config and verify the correct model/strategy is resolved
+- run the full `npm test` suite
+
+## Resolved open questions
+
+- **Config module path:** `packages/core/src/config/` — follows the existing `src/<domain>/` pattern (`loop/`, `github/`)
+- **First integration point:** strategy routing (`public-dev-loop-routing.mjs`) — clean, non-destructive proof of the config pipeline; `models.conductor` is the natural second wire after the pipeline is proven
+- **`autonomy.stopAt` default:** `["merge"]` — matches the current auto-continue-through-gates posture; more conservative repos override with `["draft-pr", "pre-approval", "merge"]`
+- **`$schema` field:** no — Zod is the single validation source of truth; `zod-to-json-schema` exists if IDE hints become desired later
+
+## Links
+
+- GitHub issue: [#286](https://github.com/mfittko/pi-dev-loops/issues/286)
+- Local execution artifacts will live under `tmp/phases/phase-8/`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
         "packages/*"
       ],
       "dependencies": {
-        "mermaid": "11.15.0"
+        "mermaid": "11.15.0",
+        "zod": "^4.4.3"
       },
       "bin": {
         "pi-dev-loops": "cli/index.mjs"
@@ -5273,7 +5274,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     ]
   },
   "dependencies": {
-    "mermaid": "11.15.0"
+    "mermaid": "11.15.0",
+    "zod": "^4.4.3"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,10 @@
   "description": "Shared deterministic support package for Pi dev-loop skills, repo-local scripts, and GitHub automation.",
   "exports": {
     "./bash-exit-one": "./src/bash-exit-one.mjs",
+    "./config": "./src/config/index.mjs",
+    "./config/schema": "./src/config/schema.mjs",
+    "./config/loader": "./src/config/loader.mjs",
+    "./config/roles": "./src/config/roles.mjs",
     "./github/copilot-helpers": "./src/github/copilot-helpers.mjs",
     "./github/repo-slug": "./src/github/repo-slug.mjs",
     "./github/review-threads": "./src/github/review-threads.mjs",

--- a/packages/core/src/config/index.mjs
+++ b/packages/core/src/config/index.mjs
@@ -1,3 +1,3 @@
-export { DevLoopConfigSchema, BUILT_IN_DEFAULTS, validateConfig, validatePartialConfig } from "./schema.mjs";
+export { DevLoopConfigSchema, BUILT_IN_DEFAULTS, FileConfigSchema } from "./schema.mjs";
 export { loadDevLoopConfig } from "./loader.mjs";
-export { resolveReviewerRole, listBuiltinPersonas } from "./roles.mjs";
+export { resolveReviewerRole } from "./roles.mjs";

--- a/packages/core/src/config/index.mjs
+++ b/packages/core/src/config/index.mjs
@@ -1,0 +1,3 @@
+export { DevLoopConfigSchema, BUILT_IN_DEFAULTS, validateConfig, validatePartialConfig } from "./schema.mjs";
+export { loadDevLoopConfig } from "./loader.mjs";
+export { resolveReviewerRole, listBuiltinPersonas } from "./roles.mjs";

--- a/packages/core/src/config/loader.mjs
+++ b/packages/core/src/config/loader.mjs
@@ -1,0 +1,205 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { BUILT_IN_DEFAULTS, validateConfig, validatePartialConfig } from "./schema.mjs";
+
+// ============================================================================
+// Error types
+// ============================================================================
+
+/**
+ * @typedef {object} ConfigLoadError
+ * @property {string} path - Human-readable file path or layer name
+ * @property {string} message - Error description
+ * @property {"defaults"|"overrides"} layer - Which config layer failed
+ */
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Shallow-merge two objects. Keys in `source` override keys in `target`.
+ * Nested objects are replaced wholesale, not deep-merged.
+ * @param {Record<string, unknown>} target
+ * @param {Record<string, unknown>} source
+ * @returns {Record<string, unknown>}
+ */
+function shallowMerge(target, source) {
+  const result = { ...target };
+  for (const key of Object.keys(source)) {
+    if (
+      key !== "version" &&
+      typeof source[key] === "object" &&
+      source[key] !== null &&
+      !Array.isArray(source[key]) &&
+      typeof result[key] === "object" &&
+      result[key] !== null &&
+      !Array.isArray(result[key])
+    ) {
+      // Shallow-merge nested objects (strategy, models, refinement, gates, autonomy)
+      result[key] = { ...(result[key] || {}), ...(source[key] || {}) };
+    } else {
+      result[key] = source[key];
+    }
+  }
+  return result;
+}
+
+/**
+ * Try to read and parse a JSON file.
+ * Returns the parsed object or null if the file doesn't exist.
+ * Throws on read errors other than ENOENT.
+ * @param {string} filePath
+ * @returns {Promise<object|null>}
+ */
+async function readJsonFile(filePath) {
+  let raw;
+  try {
+    raw = await readFile(filePath, "utf8");
+  } catch (err) {
+    if (err.code === "ENOENT") return null;
+    // EACCES, EISDIR, etc. — rethrow as a structured error
+    throw Object.assign(
+      new Error(`Cannot read config file: ${err.message}`),
+      { code: err.code, path: filePath },
+    );
+  }
+
+  if (raw.trim() === "") {
+    throw Object.assign(
+      new Error("Config file is empty"),
+      { code: "EMPTY_FILE", path: filePath },
+    );
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw Object.assign(
+      new Error(`Invalid JSON in config file: ${err.message}`),
+      { code: "INVALID_JSON", path: filePath },
+    );
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw Object.assign(
+      new Error("Config file must be a JSON object"),
+      { code: "NOT_AN_OBJECT", path: filePath },
+    );
+  }
+
+  return parsed;
+}
+
+// ============================================================================
+// Loader
+// ============================================================================
+
+/**
+ * @typedef {object} LoadResult
+ * @property {import("zod").infer<import("./schema.mjs").DevLoopConfigSchema>} config
+ * @property {string[]} warnings
+ * @property {ConfigLoadError[]} errors
+ */
+
+/**
+ * @typedef {object} LoadOptions
+ * @property {string} [repoRoot] - Path to repository root (default: process.cwd())
+ */
+
+/**
+ * Load the dev-loop configuration with full precedence:
+ *   overrides.json > defaults.json > built-in defaults
+ *
+ * Never throws for config-related problems.
+ * Returns built-in defaults even when all files are missing or broken.
+ *
+ * @param {LoadOptions} [options]
+ * @returns {Promise<LoadResult>}
+ */
+export async function loadDevLoopConfig(options = {}) {
+  const repoRoot = options.repoRoot ?? process.cwd();
+  const configDir = path.join(repoRoot, ".pi", "dev-loop");
+  const defaultsPath = path.join(configDir, "defaults.json");
+  const overridesPath = path.join(configDir, "overrides.json");
+
+  /** @type {string[]} */
+  const warnings = [];
+  /** @type {ConfigLoadError[]} */
+  const errors = [];
+
+  // Start with built-in defaults
+  let merged = { ...BUILT_IN_DEFAULTS };
+
+  // Layer 1: repo defaults
+  let repoDefaults = null;
+  try {
+    repoDefaults = await readJsonFile(defaultsPath);
+  } catch (err) {
+    errors.push({
+      path: defaultsPath,
+      message: err.message,
+      layer: "defaults",
+    });
+  }
+
+  if (repoDefaults === null && errors.length === 0) {
+    // File doesn't exist — warn because defaults.json should be committed
+    warnings.push("Committed defaults.json not found, using built-in defaults");
+  }
+
+  if (repoDefaults !== null) {
+    const validation = validatePartialConfig(repoDefaults);
+    if (validation.success) {
+      // Merge raw data (not zod-filled) so inner defaults don't overwrite lower layers
+      merged = shallowMerge(merged, repoDefaults);
+    } else {
+      errors.push({
+        path: defaultsPath,
+        message: `Schema validation failed: ${validation.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; ")}`,
+        layer: "defaults",
+      });
+    }
+  }
+
+  // Layer 2: session overrides
+  let sessionOverrides = null;
+  try {
+    sessionOverrides = await readJsonFile(overridesPath);
+  } catch (err) {
+    errors.push({
+      path: overridesPath,
+      message: err.message,
+      layer: "overrides",
+    });
+  }
+
+  if (sessionOverrides !== null) {
+    const validation = validatePartialConfig(sessionOverrides);
+    if (validation.success) {
+      // Merge raw data (not zod-filled) so inner defaults don't overwrite lower layers
+      merged = shallowMerge(merged, sessionOverrides);
+    } else {
+      errors.push({
+        path: overridesPath,
+        message: `Schema validation failed: ${validation.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; ")}`,
+        layer: "overrides",
+      });
+    }
+  }
+
+  // Final validation of merged config (defensive — should never fail if layers were valid)
+  const finalCheck = validateConfig(merged);
+  if (!finalCheck.success) {
+    // This shouldn't happen if layers validated individually, but catch it defensively
+    errors.push({
+      path: "<merged>",
+      message: `Merged config validation failed: ${finalCheck.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; ")}`,
+      layer: "defaults",
+    });
+    return { config: { ...BUILT_IN_DEFAULTS }, warnings, errors };
+  }
+
+  return { config: finalCheck.data, warnings, errors };
+}

--- a/packages/core/src/config/loader.mjs
+++ b/packages/core/src/config/loader.mjs
@@ -10,7 +10,7 @@ import { BUILT_IN_DEFAULTS, DevLoopConfigSchema, FileConfigSchema } from "./sche
  * @typedef {object} ConfigLoadError
  * @property {string} path - Human-readable file path or layer name
  * @property {string} message - Error description
- * @property {"defaults"|"overrides"} layer - Which config layer failed
+ * @property {"defaults"|"overrides"|"merged"} layer - Which config layer failed
  */
 
 // ============================================================================
@@ -179,7 +179,7 @@ export async function loadDevLoopConfig(options = {}) {
     errors.push({
       path: "<merged>",
       message: `Config validation failed: ${result.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; ")}`,
-      layer: "defaults",
+      layer: "merged",
     });
     // Return merged as-is — caller gets validation errors but still has config with all layers applied
     return { config: /** @type {*} */ (merged), warnings, errors };

--- a/packages/core/src/config/loader.mjs
+++ b/packages/core/src/config/loader.mjs
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { BUILT_IN_DEFAULTS, validateConfig, validatePartialConfig } from "./schema.mjs";
+import { BUILT_IN_DEFAULTS, DevLoopConfigSchema, FileConfigSchema } from "./schema.mjs";
 
 // ============================================================================
 // Error types
@@ -18,13 +18,13 @@ import { BUILT_IN_DEFAULTS, validateConfig, validatePartialConfig } from "./sche
 // ============================================================================
 
 /**
- * Shallow-merge two objects. Keys in `source` override keys in `target`.
- * Nested objects are replaced wholesale, not deep-merged.
+ * Shallow-merge two config objects. Keys in `source` override keys in `target`.
+ * Nested family objects are merged at one level, not deep-merged.
  * @param {Record<string, unknown>} target
  * @param {Record<string, unknown>} source
  * @returns {Record<string, unknown>}
  */
-function shallowMerge(target, source) {
+function mergeConfigLayers(target, source) {
   const result = { ...target };
   for (const key of Object.keys(source)) {
     if (
@@ -36,7 +36,6 @@ function shallowMerge(target, source) {
       result[key] !== null &&
       !Array.isArray(result[key])
     ) {
-      // Shallow-merge nested objects (strategy, models, refinement, gates, autonomy)
       result[key] = { ...(result[key] || {}), ...(source[key] || {}) };
     } else {
       result[key] = source[key];
@@ -58,38 +57,75 @@ async function readJsonFile(filePath) {
     raw = await readFile(filePath, "utf8");
   } catch (err) {
     if (err.code === "ENOENT") return null;
-    // EACCES, EISDIR, etc. — rethrow as a structured error
-    throw Object.assign(
-      new Error(`Cannot read config file: ${err.message}`),
-      { code: err.code, path: filePath },
-    );
+    throw configError(`Cannot read config file: ${err.message}`, err.code, filePath);
   }
 
   if (raw.trim() === "") {
-    throw Object.assign(
-      new Error("Config file is empty"),
-      { code: "EMPTY_FILE", path: filePath },
-    );
+    throw configError("Config file is empty", "EMPTY_FILE", filePath);
   }
 
   let parsed;
   try {
     parsed = JSON.parse(raw);
   } catch (err) {
-    throw Object.assign(
-      new Error(`Invalid JSON in config file: ${err.message}`),
-      { code: "INVALID_JSON", path: filePath },
-    );
+    throw configError(`Invalid JSON in config file: ${err.message}`, "INVALID_JSON", filePath);
   }
 
   if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw Object.assign(
-      new Error("Config file must be a JSON object"),
-      { code: "NOT_AN_OBJECT", path: filePath },
-    );
+    throw configError("Config file must be a JSON object", "NOT_AN_OBJECT", filePath);
   }
 
   return parsed;
+}
+
+/**
+ * @param {string} message
+ * @param {string} code
+ * @param {string} filePath
+ * @returns {Error & { code: string, path: string }}
+ */
+function configError(message, code, filePath) {
+  return Object.assign(new Error(message), { code, path: filePath });
+}
+
+/**
+ * Try to load and merge one config layer (defaults or overrides).
+ * @param {Record<string, unknown>} merged - Current merged config
+ * @param {string} filePath - Path to the config file
+ * @param {"defaults"|"overrides"} layer - Layer name
+ * @param {string[]} warnings
+ * @param {ConfigLoadError[]} errors
+ * @param {{ warnOnMissing?: boolean }} [options]
+ * @returns {Promise<Record<string, unknown>>}
+ */
+async function applyLayer(merged, filePath, layer, warnings, errors, options = {}) {
+  let data = null;
+  try {
+    data = await readJsonFile(filePath);
+  } catch (err) {
+    errors.push({ path: filePath, message: err.message, layer });
+    return merged;
+  }
+
+  if (data === null) {
+    if (options.warnOnMissing) {
+      warnings.push(`Committed ${layer}.json not found, using built-in defaults`);
+    }
+    return merged;
+  }
+
+  // Validate the file's structure before merging
+  const validation = FileConfigSchema.safeParse(data);
+  if (!validation.success) {
+    errors.push({
+      path: filePath,
+      message: `Schema validation failed: ${validation.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; ")}`,
+      layer,
+    });
+    return merged;
+  }
+
+  return mergeConfigLayers(merged, data);
 }
 
 // ============================================================================
@@ -98,7 +134,7 @@ async function readJsonFile(filePath) {
 
 /**
  * @typedef {object} LoadResult
- * @property {import("zod").infer<import("./schema.mjs").DevLoopConfigSchema>} config
+ * @property {import("./schema.mjs").DevLoopConfig} config
  * @property {string[]} warnings
  * @property {ConfigLoadError[]} errors
  */
@@ -129,77 +165,25 @@ export async function loadDevLoopConfig(options = {}) {
   /** @type {ConfigLoadError[]} */
   const errors = [];
 
-  // Start with built-in defaults
   let merged = { ...BUILT_IN_DEFAULTS };
 
-  // Layer 1: repo defaults
-  let repoDefaults = null;
-  try {
-    repoDefaults = await readJsonFile(defaultsPath);
-  } catch (err) {
-    errors.push({
-      path: defaultsPath,
-      message: err.message,
-      layer: "defaults",
-    });
-  }
+  merged = await applyLayer(merged, defaultsPath, "defaults", warnings, errors, {
+    warnOnMissing: true,
+  });
 
-  if (repoDefaults === null && errors.length === 0) {
-    // File doesn't exist — warn because defaults.json should be committed
-    warnings.push("Committed defaults.json not found, using built-in defaults");
-  }
+  merged = await applyLayer(merged, overridesPath, "overrides", warnings, errors);
 
-  if (repoDefaults !== null) {
-    const validation = validatePartialConfig(repoDefaults);
-    if (validation.success) {
-      // Merge raw data (not zod-filled) so inner defaults don't overwrite lower layers
-      merged = shallowMerge(merged, repoDefaults);
-    } else {
-      errors.push({
-        path: defaultsPath,
-        message: `Schema validation failed: ${validation.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; ")}`,
-        layer: "defaults",
-      });
-    }
-  }
-
-  // Layer 2: session overrides
-  let sessionOverrides = null;
-  try {
-    sessionOverrides = await readJsonFile(overridesPath);
-  } catch (err) {
-    errors.push({
-      path: overridesPath,
-      message: err.message,
-      layer: "overrides",
-    });
-  }
-
-  if (sessionOverrides !== null) {
-    const validation = validatePartialConfig(sessionOverrides);
-    if (validation.success) {
-      // Merge raw data (not zod-filled) so inner defaults don't overwrite lower layers
-      merged = shallowMerge(merged, sessionOverrides);
-    } else {
-      errors.push({
-        path: overridesPath,
-        message: `Schema validation failed: ${validation.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; ")}`,
-        layer: "overrides",
-      });
-    }
-  }
-
-  // Final validation of merged config (defensive — should never fail if layers were valid)
-  const finalCheck = validateConfig(merged);
-  if (!finalCheck.success) {
-    // This shouldn't happen if layers validated individually, but catch it defensively
+  // Validate final merged config
+  const result = DevLoopConfigSchema.safeParse(merged);
+  if (!result.success) {
     errors.push({
       path: "<merged>",
-      message: `Merged config validation failed: ${finalCheck.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; ")}`,
+      message: `Config validation failed: ${result.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; ")}`,
       layer: "defaults",
     });
-    return { config: { ...BUILT_IN_DEFAULTS }, warnings, errors };
+    // Return merged as-is — caller gets validation errors but still has config with all layers applied
+    return { config: /** @type {*} */ (merged), warnings, errors };
   }
 
-  return { config: finalCheck.data, warnings, errors };
+  return { config: result.data, warnings, errors };
 }

--- a/packages/core/src/config/roles.mjs
+++ b/packages/core/src/config/roles.mjs
@@ -1,9 +1,10 @@
 // ============================================================================
 // Built-in persona registry
 //
-// Initially empty. Add entries as dedicated reviewer agent personas are
-// created. The resolution algorithm handles unknown angles by falling
-// back to the default reviewer with the angle as a focus lens.
+// Initially empty — no dedicated reviewer agent personas exist yet.
+// Resolution falls back to default-reviewer for all angles.
+// Add entries when persona agents are created:
+//   { "security": { persona: "security-reviewer", defaultModel: null } }
 // ============================================================================
 
 const BUILTIN_PERSONAS = Object.freeze({});

--- a/packages/core/src/config/roles.mjs
+++ b/packages/core/src/config/roles.mjs
@@ -1,0 +1,76 @@
+// ============================================================================
+// Built-in persona registry
+// ============================================================================
+
+const BUILTIN_PERSONAS = Object.freeze({
+  security: Object.freeze({ persona: "security-reviewer", defaultModel: null }),
+  style: Object.freeze({ persona: "style-reviewer", defaultModel: null }),
+  correctness: Object.freeze({ persona: "correctness-reviewer", defaultModel: null }),
+  dry: Object.freeze({ persona: "dry-reviewer", defaultModel: null }),
+  kiss: Object.freeze({ persona: "kiss-reviewer", defaultModel: null }),
+  yagni: Object.freeze({ persona: "yagni-reviewer", defaultModel: null }),
+});
+
+const DEFAULT_REVIEWER_PERSONA = "default-reviewer";
+
+// ============================================================================
+// Role resolution
+// ============================================================================
+
+/**
+ * @typedef {object} RoleResolutionResult
+ * @property {string} persona - Agent persona name to use
+ * @property {string|null} model - Effective model (null = use persona default)
+ * @property {boolean} fallback - True when no specialized persona was found
+ */
+
+/**
+ * Resolve a gate angle name to a reviewer persona and model.
+ *
+ * Resolution order:
+ * 1. Look up angle in built-in persona registry
+ * 2. If found, apply model override from config.models.roles[angle] if present
+ * 3. If not found, fall back to default reviewer with angle as focus lens,
+ *    still applying any model override from config
+ *
+ * @param {object} config - DevLoopConfig (or partial with models.roles)
+ * @param {string|null|undefined} angle - Gate angle / lens name
+ * @returns {RoleResolutionResult}
+ */
+export function resolveReviewerRole(config, angle) {
+  // Null/undefined/empty angle → fallback
+  if (angle == null || angle === "") {
+    return {
+      persona: DEFAULT_REVIEWER_PERSONA,
+      model: null,
+      fallback: true,
+    };
+  }
+
+  const persona = BUILTIN_PERSONAS[angle] ?? null;
+  const modelOverride = config?.models?.roles?.[angle] || null;
+  const effectiveModel = modelOverride || persona?.defaultModel || null;
+
+  if (persona) {
+    return {
+      persona: persona.persona,
+      model: effectiveModel,
+      fallback: false,
+    };
+  }
+
+  // Unknown angle — fall back to default reviewer, but still apply model override
+  return {
+    persona: DEFAULT_REVIEWER_PERSONA,
+    model: effectiveModel,
+    fallback: true,
+  };
+}
+
+/**
+ * Expose the built-in persona registry for inspection.
+ * @returns {Readonly<Record<string, { persona: string, defaultModel: string|null }>>}
+ */
+export function listBuiltinPersonas() {
+  return BUILTIN_PERSONAS;
+}

--- a/packages/core/src/config/roles.mjs
+++ b/packages/core/src/config/roles.mjs
@@ -1,15 +1,12 @@
 // ============================================================================
 // Built-in persona registry
+//
+// Initially empty. Add entries as dedicated reviewer agent personas are
+// created. The resolution algorithm handles unknown angles by falling
+// back to the default reviewer with the angle as a focus lens.
 // ============================================================================
 
-const BUILTIN_PERSONAS = Object.freeze({
-  security: Object.freeze({ persona: "security-reviewer", defaultModel: null }),
-  style: Object.freeze({ persona: "style-reviewer", defaultModel: null }),
-  correctness: Object.freeze({ persona: "correctness-reviewer", defaultModel: null }),
-  dry: Object.freeze({ persona: "dry-reviewer", defaultModel: null }),
-  kiss: Object.freeze({ persona: "kiss-reviewer", defaultModel: null }),
-  yagni: Object.freeze({ persona: "yagni-reviewer", defaultModel: null }),
-});
+const BUILTIN_PERSONAS = Object.freeze({});
 
 const DEFAULT_REVIEWER_PERSONA = "default-reviewer";
 
@@ -49,12 +46,11 @@ export function resolveReviewerRole(config, angle) {
 
   const persona = BUILTIN_PERSONAS[angle] ?? null;
   const modelOverride = config?.models?.roles?.[angle] || null;
-  const effectiveModel = modelOverride || persona?.defaultModel || null;
 
   if (persona) {
     return {
       persona: persona.persona,
-      model: effectiveModel,
+      model: modelOverride || persona.defaultModel || null,
       fallback: false,
     };
   }
@@ -62,15 +58,7 @@ export function resolveReviewerRole(config, angle) {
   // Unknown angle — fall back to default reviewer, but still apply model override
   return {
     persona: DEFAULT_REVIEWER_PERSONA,
-    model: effectiveModel,
+    model: modelOverride || null,
     fallback: true,
   };
-}
-
-/**
- * Expose the built-in persona registry for inspection.
- * @returns {Readonly<Record<string, { persona: string, defaultModel: string|null }>>}
- */
-export function listBuiltinPersonas() {
-  return BUILTIN_PERSONAS;
 }

--- a/packages/core/src/config/schema.mjs
+++ b/packages/core/src/config/schema.mjs
@@ -1,0 +1,91 @@
+import { z } from "zod";
+
+// ============================================================================
+// Sub-schemas (no .default() wrappers — defaults handled by BUILT_IN_DEFAULTS)
+// ============================================================================
+
+const StrategyConfig = z.strictObject({
+  default: z.enum(["local-first", "github-first"]).default("github-first"),
+  byWorkflow: z.record(z.string(), z.enum(["local-first", "github-first"])).optional(),
+});
+
+const ModelsConfig = z.strictObject({
+  conductor: z.string().min(1).optional(),
+  roles: z.record(z.string(), z.string().min(1)).optional(),
+});
+
+const RefinementConfig = z.strictObject({
+  fanOut: z.number().int().min(1).max(10).default(3),
+  mode: z.enum(["parallel", "sequential"]).default("parallel"),
+  roles: z.array(z.string().min(1)).optional(),
+});
+
+const GateConfig = z.strictObject({
+  angles: z.array(z.string().min(1)),
+  required: z.boolean().default(true),
+});
+
+const GatesConfig = z.strictObject({
+  draft: GateConfig.optional(),
+  preApproval: GateConfig.optional(),
+});
+
+const AutonomyConfig = z.strictObject({
+  stopAt: z.array(
+    z.enum(["refinement", "draft-pr", "pre-approval", "merge"])
+  ).default(["merge"]),
+});
+
+// ============================================================================
+// Full schema — families are optional (BUILT_IN_DEFAULTS provides fallback)
+// ============================================================================
+
+/**
+ * @typedef {z.infer<typeof DevLoopConfigSchema>} DevLoopConfig
+ */
+
+export const DevLoopConfigSchema = z.strictObject({
+  version: z.literal(1),
+  strategy: StrategyConfig.optional(),
+  models: ModelsConfig.optional(),
+  refinement: RefinementConfig.optional(),
+  gates: GatesConfig.optional(),
+  autonomy: AutonomyConfig.optional(),
+});
+
+// ============================================================================
+// Built-in defaults — frozen canonical fallback
+// ============================================================================
+
+export const BUILT_IN_DEFAULTS = Object.freeze({
+  version: 1,
+  strategy: Object.freeze({ default: "github-first" }),
+  models: Object.freeze({}),
+  refinement: Object.freeze({ fanOut: 3, mode: "parallel" }),
+  gates: Object.freeze({}),
+  autonomy: Object.freeze({ stopAt: Object.freeze(["merge"]) }),
+});
+
+// ============================================================================
+// Validation helpers
+// ============================================================================
+
+/**
+ * Validate a complete config object. Returns zod SafeParseReturnType.
+ * @param {unknown} input
+ * @returns {import("zod").SafeParseReturnType<unknown, import("zod").infer<typeof DevLoopConfigSchema>>}
+ */
+export function validateConfig(input) {
+  return DevLoopConfigSchema.safeParse(input);
+}
+
+/**
+ * Validate a partial config layer (e.g. a single file before merging).
+ * All top-level and nested fields are optional, but unknown keys are still rejected.
+ * @param {unknown} input
+ * @returns {import("zod").SafeParseReturnType<unknown, unknown>}
+ */
+export function validatePartialConfig(input) {
+  const partialSchema = DevLoopConfigSchema.partial().strict();
+  return partialSchema.safeParse(input);
+}

--- a/packages/core/src/config/schema.mjs
+++ b/packages/core/src/config/schema.mjs
@@ -1,12 +1,14 @@
 import { z } from "zod";
 
 // ============================================================================
-// Sub-schemas (no .default() wrappers — defaults handled by BUILT_IN_DEFAULTS)
+// Sub-schemas
+//
+// No field-level defaults. BUILT_IN_DEFAULTS is the single source of truth
+// for all default values. The loader populates missing families from it.
 // ============================================================================
 
 const StrategyConfig = z.strictObject({
-  default: z.enum(["local-first", "github-first"]).default("github-first"),
-  byWorkflow: z.record(z.string(), z.enum(["local-first", "github-first"])).optional(),
+  default: z.enum(["local-first", "github-first"]),
 });
 
 const ModelsConfig = z.strictObject({
@@ -15,8 +17,8 @@ const ModelsConfig = z.strictObject({
 });
 
 const RefinementConfig = z.strictObject({
-  fanOut: z.number().int().min(1).max(10).default(3),
-  mode: z.enum(["parallel", "sequential"]).default("parallel"),
+  fanOut: z.number().int().min(1).max(10),
+  mode: z.enum(["parallel", "sequential"]),
   roles: z.array(z.string().min(1)).optional(),
 });
 
@@ -33,7 +35,7 @@ const GatesConfig = z.strictObject({
 const AutonomyConfig = z.strictObject({
   stopAt: z.array(
     z.enum(["refinement", "draft-pr", "pre-approval", "merge"])
-  ).default(["merge"]),
+  ),
 });
 
 // ============================================================================
@@ -54,7 +56,7 @@ export const DevLoopConfigSchema = z.strictObject({
 });
 
 // ============================================================================
-// Built-in defaults — frozen canonical fallback
+// Built-in defaults — frozen canonical single source of truth
 // ============================================================================
 
 export const BUILT_IN_DEFAULTS = Object.freeze({
@@ -67,25 +69,14 @@ export const BUILT_IN_DEFAULTS = Object.freeze({
 });
 
 // ============================================================================
-// Validation helpers
+// File-level validation schema — allows partial family objects
 // ============================================================================
 
-/**
- * Validate a complete config object. Returns zod SafeParseReturnType.
- * @param {unknown} input
- * @returns {import("zod").SafeParseReturnType<unknown, import("zod").infer<typeof DevLoopConfigSchema>>}
- */
-export function validateConfig(input) {
-  return DevLoopConfigSchema.safeParse(input);
-}
-
-/**
- * Validate a partial config layer (e.g. a single file before merging).
- * All top-level and nested fields are optional, but unknown keys are still rejected.
- * @param {unknown} input
- * @returns {import("zod").SafeParseReturnType<unknown, unknown>}
- */
-export function validatePartialConfig(input) {
-  const partialSchema = DevLoopConfigSchema.partial().strict();
-  return partialSchema.safeParse(input);
-}
+export const FileConfigSchema = z.strictObject({
+  version: z.literal(1),
+  strategy: StrategyConfig.partial().optional(),
+  models: ModelsConfig.partial().optional(),
+  refinement: RefinementConfig.partial().optional(),
+  gates: GatesConfig.partial().optional(),
+  autonomy: AutonomyConfig.partial().optional(),
+});

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, rm, writeFile, chmod } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test, { describe } from "node:test";
@@ -7,10 +7,7 @@ import test, { describe } from "node:test";
 import {
   DevLoopConfigSchema,
   BUILT_IN_DEFAULTS,
-  validateConfig,
-  validatePartialConfig,
 } from "../src/config/schema.mjs";
-
 // ============================================================================
 // Schema validation tests (S1–S26)
 // ============================================================================
@@ -108,7 +105,7 @@ describe("schema validation", () => {
   test("S12: refinement.mode bad enum", () => {
     const result = DevLoopConfigSchema.safeParse({
       version: 1,
-      refinement: { mode: "async" },
+      refinement: { fanOut: 3, mode: "async" },
     });
     assert.ok(!result.success);
   });
@@ -189,13 +186,12 @@ describe("schema validation", () => {
     assert.ok(!result.success);
   });
 
-  test("S24: strategy.default missing but byWorkflow present", () => {
+  test("S24: strategy.byWorkflow rejected as unknown key", () => {
     const result = DevLoopConfigSchema.safeParse({
       version: 1,
-      strategy: { byWorkflow: { "copilot-followup": "local-first" } },
+      strategy: { default: "github-first", byWorkflow: { x: "local-first" } },
     });
-    assert.ok(result.success);
-    assert.equal(result.data.strategy.default, "github-first");
+    assert.ok(!result.success);
   });
 
   test("S25: models.roles has empty string value", () => {
@@ -216,44 +212,17 @@ describe("schema validation", () => {
 });
 
 // ============================================================================
-// Partial config validation tests (P1–P4)
+// DevLoopConfigSchema.safeParse tests
 // ============================================================================
 
-describe("partial config validation", () => {
-  test("P1: partial config with only refinement.fanOut validates ok", () => {
-    const result = validatePartialConfig({ refinement: { fanOut: 5 } });
-    assert.ok(result.success);
-  });
-
-  test("P2: partial config with unknown key rejected", () => {
-    const result = validatePartialConfig({ unknownKey: true });
-    assert.ok(!result.success);
-  });
-
-  test("P3: partial config with bad fanOut (0)", () => {
-    const result = validatePartialConfig({ refinement: { fanOut: 0 } });
-    assert.ok(!result.success);
-  });
-
-  test("P4: empty partial validates ok", () => {
-    const result = validatePartialConfig({});
-    assert.ok(result.success);
-  });
-});
-
-// ============================================================================
-// validateConfig helper tests
-// ============================================================================
-
-describe("validateConfig helper", () => {
+describe("DevLoopConfigSchema.safeParse", () => {
   test("returns { success: true, data } for valid config", () => {
-    const result = validateConfig({ version: 1 });
+    const result = DevLoopConfigSchema.safeParse({ version: 1 });
     assert.ok(result.success);
-    assert.equal(result.data.version, 1);
   });
 
   test("returns { success: false, error } for invalid config", () => {
-    const result = validateConfig({});
+    const result = DevLoopConfigSchema.safeParse({});
     assert.ok(!result.success);
     assert.ok(result.error !== undefined);
   });
@@ -730,10 +699,10 @@ describe("role resolution", () => {
     assert.ok(typeof resolveReviewerRole === "function");
   });
 
-  test("R1: known angle 'security' with built-in persona", () => {
+  test("R1: all angles fall back when registry is empty", () => {
     const result = resolveReviewerRole({}, "security");
-    assert.equal(result.persona, "security-reviewer");
-    assert.equal(result.fallback, false);
+    assert.equal(result.persona, "default-reviewer");
+    assert.equal(result.fallback, true);
   });
 
   test("R2: unknown angle falls back", () => {
@@ -742,14 +711,14 @@ describe("role resolution", () => {
     assert.equal(result.fallback, true);
   });
 
-  test("R3: known angle with model override", () => {
+  test("R3: angle with model override applies override even when falling back", () => {
     const result = resolveReviewerRole(
       { models: { roles: { style: "gpt-5" } } },
       "style",
     );
-    assert.equal(result.persona, "style-reviewer");
+    assert.equal(result.persona, "default-reviewer");
     assert.equal(result.model, "gpt-5");
-    assert.equal(result.fallback, false);
+    assert.equal(result.fallback, true);
   });
 
   test("R4: unknown angle with model override", () => {
@@ -762,16 +731,16 @@ describe("role resolution", () => {
     assert.equal(result.fallback, true);
   });
 
-  test("R5: empty config — all angles resolve to built-in defaults", () => {
+  test("R5: empty config — all angles resolve to built-in defaults (fallback)", () => {
     const result = resolveReviewerRole({}, "security");
-    assert.equal(result.persona, "security-reviewer");
+    assert.equal(result.persona, "default-reviewer");
     assert.equal(result.model, null);
-    assert.equal(result.fallback, false);
+    assert.equal(result.fallback, true);
   });
 
   test("R6: missing models.roles in config", () => {
     const result = resolveReviewerRole({ models: {} }, "security");
-    assert.equal(result.persona, "security-reviewer");
+    assert.equal(result.persona, "default-reviewer");
     assert.equal(result.model, null);
   });
 
@@ -785,21 +754,12 @@ describe("role resolution", () => {
     assert.equal(r2.fallback, true);
   });
 
-  test("R8: listBuiltinPersonas returns registry", async () => {
-    const { listBuiltinPersonas } = await import("../src/config/roles.mjs");
-    const personas = listBuiltinPersonas();
-    assert.ok(typeof personas === "object");
-    assert.ok("security" in personas);
-    assert.ok("style" in personas);
-    assert.ok("correctness" in personas);
-  });
-
   test("R9: model override with empty string ignored", () => {
     const result = resolveReviewerRole(
       { models: { roles: { security: "" } } },
       "security",
     );
-    assert.equal(result.persona, "security-reviewer");
+    assert.equal(result.persona, "default-reviewer");
     assert.equal(result.model, null);
   });
 });

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1,0 +1,805 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile, chmod } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test, { describe } from "node:test";
+
+import {
+  DevLoopConfigSchema,
+  BUILT_IN_DEFAULTS,
+  validateConfig,
+  validatePartialConfig,
+} from "../src/config/schema.mjs";
+
+// ============================================================================
+// Schema validation tests (S1–S26)
+// ============================================================================
+
+describe("schema validation", () => {
+  test("S1: full valid config parses successfully", () => {
+    const input = {
+      version: 1,
+      strategy: { default: "local-first" },
+      models: { conductor: "gpt-5", roles: { security: "gpt-5" } },
+      refinement: { fanOut: 5, mode: "sequential", roles: ["security"] },
+      gates: {
+        draft: { angles: ["style", "correctness"], required: true },
+        preApproval: { angles: ["dry", "kiss", "yagni"], required: false },
+      },
+      autonomy: { stopAt: ["draft-pr", "merge"] },
+    };
+    const result = DevLoopConfigSchema.safeParse(input);
+    assert.ok(result.success, "full config should parse");
+    assert.equal(result.data.version, 1);
+  });
+
+  test("S2: minimal config (only version: 1) parses successfully", () => {
+    const result = DevLoopConfigSchema.safeParse({ version: 1 });
+    assert.ok(result.success);
+    assert.equal(result.data.version, 1);
+    // Optional families are undefined — BUILT_IN_DEFAULTS fills gaps at load time
+    assert.equal(result.data.strategy, undefined);
+    assert.equal(result.data.refinement, undefined);
+  });
+
+  test("S3: missing version field", () => {
+    const result = DevLoopConfigSchema.safeParse({});
+    assert.ok(!result.success);
+  });
+
+  test("S4: wrong version (version: 2)", () => {
+    const result = DevLoopConfigSchema.safeParse({ version: 2 });
+    assert.ok(!result.success);
+  });
+
+  test("S5: unknown top-level key rejected", () => {
+    const result = DevLoopConfigSchema.safeParse({ version: 1, unknownKey: true });
+    assert.ok(!result.success);
+  });
+
+  test("S6: unknown nested key inside strategy rejected", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      strategy: { default: "github-first", unknownKey: true },
+    });
+    assert.ok(!result.success);
+  });
+
+  test("S7: unknown nested key inside models rejected", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      models: { conductor: "gpt-5", unknownKey: true },
+    });
+    assert.ok(!result.success);
+  });
+
+  test("S8: unknown nested key inside refinement rejected", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      refinement: { fanOut: 3, unknownKey: true },
+    });
+    assert.ok(!result.success);
+  });
+
+  test("S9: unknown nested key inside gates rejected", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      gates: { unknownKey: true },
+    });
+    assert.ok(!result.success);
+  });
+
+  test("S10: unknown nested key inside autonomy rejected", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      autonomy: { stopAt: ["merge"], unknownKey: true },
+    });
+    assert.ok(!result.success);
+  });
+
+  test("S11: strategy.default bad enum", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      strategy: { default: "neither" },
+    });
+    assert.ok(!result.success);
+  });
+
+  test("S12: refinement.mode bad enum", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      refinement: { mode: "async" },
+    });
+    assert.ok(!result.success);
+  });
+
+  test("S13: refinement.fanOut is 0", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      refinement: { fanOut: 0 },
+    });
+    assert.ok(!result.success);
+  });
+
+  test("S14: refinement.fanOut is 11", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      refinement: { fanOut: 11 },
+    });
+    assert.ok(!result.success);
+  });
+
+  test("S15: refinement.fanOut is a float", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      refinement: { fanOut: 2.5 },
+    });
+    assert.ok(!result.success);
+  });
+
+  test("S16: refinement.fanOut is negative", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      refinement: { fanOut: -1 },
+    });
+    assert.ok(!result.success);
+  });
+
+  test("S17: refinement.fanOut is a string", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      refinement: { fanOut: "three" },
+    });
+    assert.ok(!result.success);
+  });
+
+  test("S18: autonomy.stopAt contains unknown gate name", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      autonomy: { stopAt: ["bad-gate"] },
+    });
+    assert.ok(!result.success);
+  });
+
+  test("S19: autonomy.stopAt is a string instead of array", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      autonomy: { stopAt: "merge" },
+    });
+    assert.ok(!result.success);
+  });
+
+  test("S20: root is null", () => {
+    const result = DevLoopConfigSchema.safeParse(null);
+    assert.ok(!result.success);
+  });
+
+  test("S21: root is array", () => {
+    const result = DevLoopConfigSchema.safeParse([{ version: 1 }]);
+    assert.ok(!result.success);
+  });
+
+  test("S22: root is string", () => {
+    const result = DevLoopConfigSchema.safeParse("not-an-object");
+    assert.ok(!result.success);
+  });
+
+  test("S23: empty object", () => {
+    const result = DevLoopConfigSchema.safeParse({});
+    assert.ok(!result.success);
+  });
+
+  test("S24: strategy.default missing but byWorkflow present", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      strategy: { byWorkflow: { "copilot-followup": "local-first" } },
+    });
+    assert.ok(result.success);
+    assert.equal(result.data.strategy.default, "github-first");
+  });
+
+  test("S25: models.roles has empty string value", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      models: { roles: { security: "" } },
+    });
+    assert.ok(!result.success);
+  });
+
+  test("S26: deeply nested unknown key inside gates.draft", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      gates: { draft: { angles: ["style"], unknownNested: true } },
+    });
+    assert.ok(!result.success);
+  });
+});
+
+// ============================================================================
+// Partial config validation tests (P1–P4)
+// ============================================================================
+
+describe("partial config validation", () => {
+  test("P1: partial config with only refinement.fanOut validates ok", () => {
+    const result = validatePartialConfig({ refinement: { fanOut: 5 } });
+    assert.ok(result.success);
+  });
+
+  test("P2: partial config with unknown key rejected", () => {
+    const result = validatePartialConfig({ unknownKey: true });
+    assert.ok(!result.success);
+  });
+
+  test("P3: partial config with bad fanOut (0)", () => {
+    const result = validatePartialConfig({ refinement: { fanOut: 0 } });
+    assert.ok(!result.success);
+  });
+
+  test("P4: empty partial validates ok", () => {
+    const result = validatePartialConfig({});
+    assert.ok(result.success);
+  });
+});
+
+// ============================================================================
+// validateConfig helper tests
+// ============================================================================
+
+describe("validateConfig helper", () => {
+  test("returns { success: true, data } for valid config", () => {
+    const result = validateConfig({ version: 1 });
+    assert.ok(result.success);
+    assert.equal(result.data.version, 1);
+  });
+
+  test("returns { success: false, error } for invalid config", () => {
+    const result = validateConfig({});
+    assert.ok(!result.success);
+    assert.ok(result.error !== undefined);
+  });
+});
+
+// ============================================================================
+// BUILT_IN_DEFAULTS tests
+// ============================================================================
+
+describe("BUILT_IN_DEFAULTS", () => {
+  test("is frozen", () => {
+    assert.throws(() => { BUILT_IN_DEFAULTS.version = 2; }, TypeError);
+  });
+
+  test("has version 1", () => {
+    assert.equal(BUILT_IN_DEFAULTS.version, 1);
+  });
+
+  test("strategy.default is github-first", () => {
+    assert.equal(BUILT_IN_DEFAULTS.strategy.default, "github-first");
+  });
+
+  test("refinement.fanOut is 3 and mode is parallel", () => {
+    assert.equal(BUILT_IN_DEFAULTS.refinement.fanOut, 3);
+    assert.equal(BUILT_IN_DEFAULTS.refinement.mode, "parallel");
+  });
+
+  test("autonomy.stopAt is [merge]", () => {
+    assert.deepEqual(BUILT_IN_DEFAULTS.autonomy.stopAt, ["merge"]);
+  });
+});
+
+// ============================================================================
+// Loader — graceful degradation tests (L1–L17)
+// ============================================================================
+
+describe("loader — graceful degradation", () => {
+  /** @type {import("../src/config/loader.mjs").loadDevLoopConfig} */
+  let loadDevLoopConfig;
+
+  test("loader module imports without I/O", async () => {
+    // Schema module must not throw on import
+    const schema = await import("../src/config/schema.mjs");
+    assert.ok(schema.DevLoopConfigSchema);
+  });
+
+  test("L1: both defaults.json and overrides.json missing", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-L1-"));
+    try {
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.ok(result.config);
+      assert.equal(result.config.version, 1);
+      assert.ok(result.warnings.length > 0, "should warn about missing defaults.json");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("L2: only defaults.json present, valid", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-L2-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(
+        path.join(piDir, "defaults.json"),
+        JSON.stringify({ version: 1, strategy: { default: "local-first" } }),
+      );
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.ok(result.config);
+      assert.equal(result.config.strategy.default, "local-first");
+      assert.equal(result.warnings.length, 0);
+      assert.equal(result.errors.length, 0);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("L3: both files present, valid", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-L3-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(
+        path.join(piDir, "defaults.json"),
+        JSON.stringify({ version: 1, strategy: { default: "local-first" }, refinement: { fanOut: 5 } }),
+      );
+      await writeFile(
+        path.join(piDir, "overrides.json"),
+        JSON.stringify({ version: 1, strategy: { default: "github-first" } }),
+      );
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.ok(result.config);
+      // overrides.json beats defaults.json for strategy, but refinement falls through
+      assert.equal(result.config.strategy.default, "github-first");
+      assert.equal(result.config.refinement.fanOut, 5);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("L4: defaults.json exists but is not valid JSON", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-L4-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(path.join(piDir, "defaults.json"), "not json {{{");
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.ok(result.config);
+      assert.equal(result.config.version, 1);
+      assert.ok(result.errors.length > 0, "should have errors for invalid JSON");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("L5: defaults.json is valid JSON but fails schema", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-L5-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(
+        path.join(piDir, "defaults.json"),
+        JSON.stringify({ version: 1, unknownKey: true }),
+      );
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.ok(result.config);
+      assert.equal(result.config.version, 1);
+      assert.ok(result.errors.length > 0, "should error for schema violation");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("L6: overrides.json exists but is not valid JSON", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-L6-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(
+        path.join(piDir, "defaults.json"),
+        JSON.stringify({ version: 1, strategy: { default: "local-first" } }),
+      );
+      await writeFile(path.join(piDir, "overrides.json"), "broken json [[[");
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.ok(result.config);
+      assert.equal(result.config.strategy.default, "local-first");
+      assert.ok(result.errors.length > 0, "should error for broken overrides");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("L7: overrides.json is valid JSON but fails schema", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-L7-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(
+        path.join(piDir, "defaults.json"),
+        JSON.stringify({ version: 1, strategy: { default: "local-first" } }),
+      );
+      await writeFile(
+        path.join(piDir, "overrides.json"),
+        JSON.stringify({ version: 1, unknownKey: true }),
+      );
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.ok(result.config);
+      assert.equal(result.config.strategy.default, "local-first");
+      assert.ok(result.errors.length > 0, "should error for bad overrides schema");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("L8: defaults.json is a directory (EISDIR)", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-L8-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      // create a directory where defaults.json should be
+      await mkdir(path.join(piDir, "defaults.json"));
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.ok(result.config);
+      assert.equal(result.config.version, 1);
+      assert.ok(result.errors.length > 0, "should error for EISDIR");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("L10: defaults.json is empty file", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-L10-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(path.join(piDir, "defaults.json"), "");
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.ok(result.config);
+      assert.equal(result.config.version, 1);
+      assert.ok(result.errors.length > 0, "empty JSON should error");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("L12: defaults.json has only version: 1 — all else defaulted", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-L12-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(path.join(piDir, "defaults.json"), JSON.stringify({ version: 1 }));
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.ok(result.config);
+      assert.equal(result.config.strategy.default, "github-first");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("L13: overrides.json has only refinement.fanOut: 7", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-L13-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(
+        path.join(piDir, "defaults.json"),
+        JSON.stringify({ version: 1, strategy: { default: "local-first" } }),
+      );
+      await writeFile(
+        path.join(piDir, "overrides.json"),
+        JSON.stringify({ version: 1, refinement: { fanOut: 7 } }),
+      );
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.ok(result.config);
+      assert.equal(result.config.refinement.fanOut, 7);
+      assert.equal(result.config.strategy.default, "local-first");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("L14: both files invalid — still returns built-in defaults", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-L14-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(path.join(piDir, "defaults.json"), "bad json");
+      await writeFile(path.join(piDir, "overrides.json"), "also bad");
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.ok(result.config);
+      assert.equal(result.config.version, 1);
+      assert.equal(result.config.strategy.default, "github-first");
+      assert.ok(result.errors.length >= 2, "should have errors for both files");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("L15: defaults.json has version: 1 but overrides.json has version: 2", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-L15-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(
+        path.join(piDir, "defaults.json"),
+        JSON.stringify({ version: 1, strategy: { default: "local-first" } }),
+      );
+      await writeFile(
+        path.join(piDir, "overrides.json"),
+        JSON.stringify({ version: 2, strategy: { default: "github-first" } }),
+      );
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.ok(result.config);
+      // overrides.json rejected, defaults.json applied
+      assert.equal(result.config.strategy.default, "local-first");
+      assert.ok(result.errors.length > 0, "should error for version mismatch");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("L16: .pi/ exists but no dev-loop/ subdirectory", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-L16-"));
+    try {
+      await mkdir(path.join(tmpDir, ".pi"));
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.ok(result.config);
+      assert.equal(result.config.version, 1);
+      assert.ok(result.warnings.length > 0, "should warn about missing defaults");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("L17: defaults.json with only version: 1 — all families from built-in", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-L17-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(path.join(piDir, "defaults.json"), JSON.stringify({ version: 1 }));
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.ok(result.config);
+      assert.equal(result.config.strategy.default, "github-first");
+      assert.equal(result.config.refinement.fanOut, 3);
+      assert.equal(result.config.refinement.mode, "parallel");
+      assert.deepEqual(result.config.autonomy.stopAt, ["merge"]);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ============================================================================
+// Loader — precedence tests (M1–M6)
+// ============================================================================
+
+describe("loader — precedence", () => {
+  test("M1: defaults.json overrides built-in strategy.default", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-M1-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(
+        path.join(piDir, "defaults.json"),
+        JSON.stringify({ version: 1, strategy: { default: "local-first" } }),
+      );
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.equal(result.config.strategy.default, "local-first");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("M2: overrides.json beats defaults.json", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-M2-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(
+        path.join(piDir, "defaults.json"),
+        JSON.stringify({ version: 1, refinement: { fanOut: 5 } }),
+      );
+      await writeFile(
+        path.join(piDir, "overrides.json"),
+        JSON.stringify({ version: 1, refinement: { fanOut: 7 } }),
+      );
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.equal(result.config.refinement.fanOut, 7);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("M3: missing key in overrides falls through to defaults", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-M3-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(
+        path.join(piDir, "defaults.json"),
+        JSON.stringify({ version: 1, refinement: { fanOut: 5, mode: "sequential" } }),
+      );
+      await writeFile(
+        path.join(piDir, "overrides.json"),
+        JSON.stringify({ version: 1, refinement: { fanOut: 7 } }),
+      );
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.equal(result.config.refinement.fanOut, 7);
+      assert.equal(result.config.refinement.mode, "sequential");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("M4: missing key in both falls through to built-in", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-M4-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(
+        path.join(piDir, "defaults.json"),
+        JSON.stringify({ version: 1 }),
+      );
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.deepEqual(result.config.autonomy.stopAt, ["merge"]);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("M5: overrides.json sets a key defaults.json doesn't mention", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-M5-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(
+        path.join(piDir, "defaults.json"),
+        JSON.stringify({ version: 1 }),
+      );
+      await writeFile(
+        path.join(piDir, "overrides.json"),
+        JSON.stringify({ version: 1, models: { conductor: "gpt-5" } }),
+      );
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.equal(result.config.models.conductor, "gpt-5");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("M6: shallow merge — models.roles in overrides replaces entire models.roles", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-M6-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(
+        path.join(piDir, "defaults.json"),
+        JSON.stringify({
+          version: 1,
+          models: { roles: { security: "gpt-5", style: "claude" } },
+        }),
+      );
+      await writeFile(
+        path.join(piDir, "overrides.json"),
+        JSON.stringify({
+          version: 1,
+          models: { roles: { correctness: "gpt-4" } },
+        }),
+      );
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      const roles = result.config.models.roles;
+      // Shallow merge: overrides replaces entire models.roles
+      assert.ok(roles.correctness, "should have correctness from overrides");
+      assert.ok(!roles.security, "should NOT have security (replaced by shallow merge)");
+      assert.ok(!roles.style, "should NOT have style (replaced by shallow merge)");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ============================================================================
+// Role resolution tests (R1–R9)
+// ============================================================================
+
+describe("role resolution", () => {
+  /** @type {import("../src/config/roles.mjs").resolveReviewerRole} */
+  let resolveReviewerRole;
+
+  test("roles module imports without error", async () => {
+    const mod = await import("../src/config/roles.mjs");
+    resolveReviewerRole = mod.resolveReviewerRole;
+    assert.ok(typeof resolveReviewerRole === "function");
+  });
+
+  test("R1: known angle 'security' with built-in persona", () => {
+    const result = resolveReviewerRole({}, "security");
+    assert.equal(result.persona, "security-reviewer");
+    assert.equal(result.fallback, false);
+  });
+
+  test("R2: unknown angle falls back", () => {
+    const result = resolveReviewerRole({}, "custom-lens");
+    assert.equal(result.persona, "default-reviewer");
+    assert.equal(result.fallback, true);
+  });
+
+  test("R3: known angle with model override", () => {
+    const result = resolveReviewerRole(
+      { models: { roles: { style: "gpt-5" } } },
+      "style",
+    );
+    assert.equal(result.persona, "style-reviewer");
+    assert.equal(result.model, "gpt-5");
+    assert.equal(result.fallback, false);
+  });
+
+  test("R4: unknown angle with model override", () => {
+    const result = resolveReviewerRole(
+      { models: { roles: { unknown: "claude-opus" } } },
+      "unknown",
+    );
+    assert.equal(result.persona, "default-reviewer");
+    assert.equal(result.model, "claude-opus");
+    assert.equal(result.fallback, true);
+  });
+
+  test("R5: empty config — all angles resolve to built-in defaults", () => {
+    const result = resolveReviewerRole({}, "security");
+    assert.equal(result.persona, "security-reviewer");
+    assert.equal(result.model, null);
+    assert.equal(result.fallback, false);
+  });
+
+  test("R6: missing models.roles in config", () => {
+    const result = resolveReviewerRole({ models: {} }, "security");
+    assert.equal(result.persona, "security-reviewer");
+    assert.equal(result.model, null);
+  });
+
+  test("R7: null or undefined angle returns fallback", () => {
+    const r1 = resolveReviewerRole({}, null);
+    assert.equal(r1.persona, "default-reviewer");
+    assert.equal(r1.fallback, true);
+
+    const r2 = resolveReviewerRole({}, undefined);
+    assert.equal(r2.persona, "default-reviewer");
+    assert.equal(r2.fallback, true);
+  });
+
+  test("R8: listBuiltinPersonas returns registry", async () => {
+    const { listBuiltinPersonas } = await import("../src/config/roles.mjs");
+    const personas = listBuiltinPersonas();
+    assert.ok(typeof personas === "object");
+    assert.ok("security" in personas);
+    assert.ok("style" in personas);
+    assert.ok("correctness" in personas);
+  });
+
+  test("R9: model override with empty string ignored", () => {
+    const result = resolveReviewerRole(
+      { models: { roles: { security: "" } } },
+      "security",
+    );
+    assert.equal(result.persona, "security-reviewer");
+    assert.equal(result.model, null);
+  });
+});

--- a/packages/core/test/package-surface.test.mjs
+++ b/packages/core/test/package-surface.test.mjs
@@ -7,6 +7,11 @@ const packageJsonUrl = new URL("../package.json", import.meta.url);
 test("packages/core exports the sanctioned runtime boundary and de-exports unused weak-runtime surfaces", async () => {
   const packageJson = JSON.parse(await readFile(packageJsonUrl, "utf8"));
 
+  assert.equal(packageJson.exports["./bash-exit-one"], "./src/bash-exit-one.mjs");
+  assert.equal(packageJson.exports["./config"], "./src/config/index.mjs");
+  assert.equal(packageJson.exports["./config/schema"], "./src/config/schema.mjs");
+  assert.equal(packageJson.exports["./config/loader"], "./src/config/loader.mjs");
+  assert.equal(packageJson.exports["./config/roles"], "./src/config/roles.mjs");
   assert.equal(packageJson.exports["./github/copilot-helpers"], "./src/github/copilot-helpers.mjs");
   assert.equal(packageJson.exports["./github/repo-slug"], "./src/github/repo-slug.mjs");
   assert.equal(packageJson.exports["./github/review-threads"], "./src/github/review-threads.mjs");


### PR DESCRIPTION
## Summary

Implement the core dev-loop config pipeline: zod schema, precedence-respecting loader, role resolution, contract tests, and the default config file. This is slice 1 of 5 under epic #286.

## Scope/context

The config contract moves workflow policy defaults out of implicit prompt/skill/chat-memory seams into one canonical, validated configuration surface. This first slice delivers the foundation — schema, loader, and role resolution — without wiring into any workflow entrypoint (that comes in slices 2–5).

## Acceptance criteria

- [x] `DevLoopConfigSchema` validates all 5 config families with `.strict()` fail-closed
- [x] `loadDevLoopConfig()` returns `{ config, warnings, errors }`, never throws
- [x] Graceful degradation: built-in defaults returned even when all files broken
- [x] Precedence: overrides > defaults > built-in, shallow merge
- [x] `resolveReviewerRole()` follows 3-step resolution with `fallback: true` detection
- [x] `.pi/dev-loop/defaults.json` committed and valid
- [x] `.pi/dev-loop/overrides.json` gitignored
- [x] ≥ 90% coverage on config module (96.5% lines, 91.9% branches, 90.0% functions)
- [x] 69 contract tests passing

## Definition of done

- [x] 5 new source files committed (schema, loader, roles, index, test)
- [x] `packages/core/package.json` has zod + 4 config exports
- [x] Barrel export at `@pi-dev-loops/core/config`
- [x] No workflow entrypoint wiring (slices 2–5)

## Non-goals

- Wiring config into any workflow entrypoint (slices 2–5)
- Deep merging, env var parsing, config watching
- JSON Schema generation, UI, migration beyond v1

## Links

- Epic: #286
- Spec: #288
- Phase doc: `docs/phases/phase-8.md`
