### PR TITLE
fix: remove redundant timeout from defaultHealthcheck (#303)

### DIFF
--- a/scripts/loop/inspect-run-viewer/managed-instance.mjs
+++ b/scripts/loop/inspect-run-viewer/managed-instance.mjs
@@ -118,19 +118,11 @@ async function defaultIsProcessAlive(pid) {
   }
 }
 
-async function defaultHealthcheck(url, timeoutMs = 3000) {
-  let timer;
+async function defaultHealthcheck(url) {
   try {
-    const response = await Promise.race([
-      fetch(url, { method: 'GET' }),
-      new Promise((_, reject) => {
-        timer = setTimeout(() => reject(new Error('healthcheck timeout')), timeoutMs);
-      }),
-    ]);
-    clearTimeout(timer);
+    const response = await fetch(url, { method: 'GET' });
     return response.status === 200;
   } catch {
-    clearTimeout(timer);
     return false;
   }
 }


### PR DESCRIPTION
## Summary

Remove the inner `Promise.race` / timeout from `defaultHealthcheck` in `scripts/loop/inspect-run-viewer/managed-instance.mjs`. The outer `startFresh` loop already enforces a deadline (8000ms with 100ms polling), making the inner timeout redundant and prone to nested-timeout races.

## Scope / Context

- Issue: #303
- File changed: `scripts/loop/inspect-run-viewer/managed-instance.mjs` — `defaultHealthcheck` function only
- No test changes needed; the existing `defaultHealthcheck fetches without AbortSignal` test continues to pass

## Acceptance Criteria

- `defaultHealthcheck` no longer accepts or uses a `timeoutMs` parameter
- The function uses bare `fetch(url, { method: 'GET' })` with no `Promise.race` wrapper
- All 29 managed-instance tests pass (verified)
- No caller passes a timeout argument to `defaultHealthcheck` (no references found)

## Definition of Done

- [x] `defaultHealthcheck` simplified to bare fetch
- [x] All managed-instance tests pass (`node --test test/loop/inspect-run-viewer-managed-instance.test.mjs`)
- [x] No test references the removed `timeoutMs` parameter (verified with rg)
- [x] Push to `issue-303-fix` branch
- [x] Draft PR opened
- [ ] draft_gate pass
- [ ] Mark ready for review
- [ ] Copilot review pass
- [ ] pre_approval_gate pass
- [ ] Merge
- [ ] Close #303

## Non-Goals

- Not modifying `startFresh` or any outer deadline logic
- Not adding new tests
- Not changing any other function
