### PR TITLE
feat: add local-first PR path to gate coordination state machine (#298)

### DIFF
--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -277,7 +277,7 @@ export function evaluatePrGateCoordination(input = {}) {
           allowedNextActions,
           forbiddenActions,
           nextAction: PR_GATE_ACTION.AWAIT_FINAL_HUMAN_APPROVAL,
-          reason: "This is an explicitly local-first PR with clean draft_gate and pre_approval_gate evidence on the current head, so it is ready for final human approval.",
+          reason: "This is an explicitly local-first PR with clean draft_gate evidence and current-head clean pre_approval_gate, so it is ready for final human approval.",
         });
       }
 

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -123,6 +123,9 @@ export function evaluatePrGateCoordination(input = {}) {
   const prClosed = input.prClosed === true;
   const prMerged = input.prMerged === true;
   const sameHeadCleanConverged = input.sameHeadCleanConverged === true;
+  const copilotReviewRequestStatus = typeof input.copilotReviewRequestStatus === "string"
+    ? input.copilotReviewRequestStatus.trim().toLowerCase()
+    : null;
 
   const draftGate = toGateStatus(input.draftGate, input.draftGateMarker, currentHeadSha);
   const preApprovalGate = toGateStatus(input.preApprovalGate, input.preApprovalGateMarker, currentHeadSha);
@@ -250,6 +253,55 @@ export function evaluatePrGateCoordination(input = {}) {
   ];
 
   if (lifecycleState === STATE.PR_READY_NO_FEEDBACK) {
+    if (copilotReviewRequestStatus === "none") {
+      // Local-first PR: no Copilot review was ever requested, so skip the external review cycle
+      if (preApprovalGate.currentHeadClean) {
+        pushUnique(allowedNextActions, [PR_GATE_ACTION.AWAIT_FINAL_HUMAN_APPROVAL]);
+        pushUnique(forbiddenActions, [
+          PR_GATE_ACTION.RUN_DRAFT_GATE,
+          PR_GATE_ACTION.MARK_READY_FOR_REVIEW,
+          PR_GATE_ACTION.REQUEST_COPILOT_REVIEW,
+          PR_GATE_ACTION.DECLARE_MERGE_READY,
+        ]);
+        return buildResult({
+          repo: input.repo ?? null,
+          pr: Number.isInteger(input.pr) ? input.pr : null,
+          currentHeadSha,
+          lifecycleState,
+          loopDisposition: loopDisposition ?? LOOP_DISPOSITION.CLEAN_CONVERGED,
+          gateBoundary: PR_GATE_BOUNDARY.FINAL_APPROVAL_READY,
+          draftGate,
+          preApprovalGate,
+          allowedNextActions,
+          forbiddenActions,
+          nextAction: PR_GATE_ACTION.AWAIT_FINAL_HUMAN_APPROVAL,
+          reason: "This is a self-reviewed local-first PR with clean draft_gate and pre_approval_gate evidence on the current head, so it is ready for final human approval.",
+        });
+      }
+
+      pushUnique(allowedNextActions, [PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE]);
+      pushUnique(forbiddenActions, [
+        PR_GATE_ACTION.RUN_DRAFT_GATE,
+        PR_GATE_ACTION.MARK_READY_FOR_REVIEW,
+        PR_GATE_ACTION.REQUEST_COPILOT_REVIEW,
+        PR_GATE_ACTION.DECLARE_MERGE_READY,
+      ]);
+      return buildResult({
+        repo: input.repo ?? null,
+        pr: Number.isInteger(input.pr) ? input.pr : null,
+        currentHeadSha,
+        lifecycleState,
+        loopDisposition: loopDisposition ?? LOOP_DISPOSITION.ACTION_REQUIRED,
+        gateBoundary: PR_GATE_BOUNDARY.PRE_APPROVAL_GATE_WINDOW,
+        draftGate,
+        preApprovalGate,
+        allowedNextActions,
+        forbiddenActions,
+        nextAction: PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE,
+        reason: "This is a self-reviewed local-first PR, so `pre_approval_gate` is the next legal boundary instead of an external Copilot review cycle.",
+      });
+    }
+
     pushUnique(allowedNextActions, [PR_GATE_ACTION.REQUEST_COPILOT_REVIEW]);
     pushUnique(forbiddenActions, postDraftForbidden);
     return buildResult({

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -123,8 +123,8 @@ export function evaluatePrGateCoordination(input = {}) {
   const prClosed = input.prClosed === true;
   const prMerged = input.prMerged === true;
   const sameHeadCleanConverged = input.sameHeadCleanConverged === true;
-  const copilotReviewRequestStatus = typeof input.copilotReviewRequestStatus === "string"
-    ? input.copilotReviewRequestStatus.trim().toLowerCase()
+  const reviewMode = typeof input.reviewMode === "string"
+    ? input.reviewMode.trim().toLowerCase()
     : null;
 
   const draftGate = toGateStatus(input.draftGate, input.draftGateMarker, currentHeadSha);
@@ -253,8 +253,8 @@ export function evaluatePrGateCoordination(input = {}) {
   ];
 
   if (lifecycleState === STATE.PR_READY_NO_FEEDBACK) {
-    if (copilotReviewRequestStatus === "none") {
-      // Local-first PR: no Copilot review was ever requested, so skip the external review cycle
+    if (reviewMode === "local_first") {
+      // Explicitly local-first PR: skip the external Copilot review cycle
       if (preApprovalGate.currentHeadClean) {
         pushUnique(allowedNextActions, [PR_GATE_ACTION.AWAIT_FINAL_HUMAN_APPROVAL]);
         pushUnique(forbiddenActions, [
@@ -275,7 +275,7 @@ export function evaluatePrGateCoordination(input = {}) {
           allowedNextActions,
           forbiddenActions,
           nextAction: PR_GATE_ACTION.AWAIT_FINAL_HUMAN_APPROVAL,
-          reason: "This is a self-reviewed local-first PR with clean draft_gate and pre_approval_gate evidence on the current head, so it is ready for final human approval.",
+          reason: "This is an explicitly local-first PR with clean draft_gate and pre_approval_gate evidence on the current head, so it is ready for final human approval.",
         });
       }
 
@@ -298,7 +298,7 @@ export function evaluatePrGateCoordination(input = {}) {
         allowedNextActions,
         forbiddenActions,
         nextAction: PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE,
-        reason: "This is a self-reviewed local-first PR, so `pre_approval_gate` is the next legal boundary instead of an external Copilot review cycle.",
+        reason: "This is an explicitly local-first PR, so `pre_approval_gate` is the next legal boundary instead of an external Copilot review cycle.",
       });
     }
 

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -252,17 +252,19 @@ export function evaluatePrGateCoordination(input = {}) {
     PR_GATE_ACTION.DECLARE_MERGE_READY,
   ];
 
+  const localFirstPostDraftForbidden = [
+    PR_GATE_ACTION.RUN_DRAFT_GATE,
+    PR_GATE_ACTION.MARK_READY_FOR_REVIEW,
+    PR_GATE_ACTION.REQUEST_COPILOT_REVIEW,
+    PR_GATE_ACTION.DECLARE_MERGE_READY,
+  ];
+
   if (lifecycleState === STATE.PR_READY_NO_FEEDBACK) {
     if (reviewMode === "local_first") {
       // Explicitly local-first PR: skip the external Copilot review cycle
       if (preApprovalGate.currentHeadClean) {
         pushUnique(allowedNextActions, [PR_GATE_ACTION.AWAIT_FINAL_HUMAN_APPROVAL]);
-        pushUnique(forbiddenActions, [
-          PR_GATE_ACTION.RUN_DRAFT_GATE,
-          PR_GATE_ACTION.MARK_READY_FOR_REVIEW,
-          PR_GATE_ACTION.REQUEST_COPILOT_REVIEW,
-          PR_GATE_ACTION.DECLARE_MERGE_READY,
-        ]);
+        pushUnique(forbiddenActions, localFirstPostDraftForbidden);
         return buildResult({
           repo: input.repo ?? null,
           pr: Number.isInteger(input.pr) ? input.pr : null,
@@ -280,12 +282,7 @@ export function evaluatePrGateCoordination(input = {}) {
       }
 
       pushUnique(allowedNextActions, [PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE]);
-      pushUnique(forbiddenActions, [
-        PR_GATE_ACTION.RUN_DRAFT_GATE,
-        PR_GATE_ACTION.MARK_READY_FOR_REVIEW,
-        PR_GATE_ACTION.REQUEST_COPILOT_REVIEW,
-        PR_GATE_ACTION.DECLARE_MERGE_READY,
-      ]);
+      pushUnique(forbiddenActions, localFirstPostDraftForbidden);
       return buildResult({
         repo: input.repo ?? null,
         pr: Number.isInteger(input.pr) ? input.pr : null,

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -233,14 +233,14 @@ test("non-draft PR with findings_present draft_gate fails closed because no clea
   assert.match(result.reason, /no clean `draft_gate` evidence exists at all/i);
 });
 
-test("local-first PR with no Copilot review ever requested skips to pre-approval gate after draft→ready", () => {
+test("local-first PR with explicit reviewMode skips to pre-approval gate after draft→ready", () => {
   const result = evaluatePrGateCoordination({
     pr: 298,
     currentHeadSha: "abc123456789",
     prDraft: false,
     lifecycleState: STATE.PR_READY_NO_FEEDBACK,
     loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
-    copilotReviewRequestStatus: "none",
+    reviewMode: "local_first",
     draftGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
     draftGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
     preApprovalGate: gate({ visible: false }),
@@ -253,7 +253,7 @@ test("local-first PR with no Copilot review ever requested skips to pre-approval
   assert(result.allowedNextActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
   assert(!result.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
   assert(result.forbiddenActions.includes(PR_GATE_ACTION.REQUEST_COPILOT_REVIEW));
-  assert.match(result.reason, /self-reviewed/i);
+  assert.match(result.reason, /local-first/i);
 });
 
 test("local-first PR with both gates clean goes straight to final approval", () => {
@@ -263,7 +263,7 @@ test("local-first PR with both gates clean goes straight to final approval", () 
     prDraft: false,
     lifecycleState: STATE.PR_READY_NO_FEEDBACK,
     loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
-    copilotReviewRequestStatus: "none",
+    reviewMode: "local_first",
     draftGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
     draftGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
     preApprovalGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
@@ -273,43 +273,24 @@ test("local-first PR with both gates clean goes straight to final approval", () 
   assert.equal(result.gateBoundary, PR_GATE_BOUNDARY.FINAL_APPROVAL_READY);
   assert.equal(result.nextAction, PR_GATE_ACTION.AWAIT_FINAL_HUMAN_APPROVAL);
   assert(result.forbiddenActions.includes(PR_GATE_ACTION.REQUEST_COPILOT_REVIEW));
-  assert.match(result.reason, /self-reviewed/i);
+  assert.match(result.reason, /local-first/i);
 });
 
-test("PR with Copilot previously requested still requires Copilot review (not local-first)", () => {
+test("PR without explicit reviewMode uses standard Copilot review path (default)", () => {
   const result = evaluatePrGateCoordination({
     pr: 298,
     currentHeadSha: "abc123456789",
     prDraft: false,
     lifecycleState: STATE.PR_READY_NO_FEEDBACK,
     loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
-    copilotReviewRequestStatus: "requested",
     draftGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
     draftGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
     preApprovalGate: gate({ visible: false }),
     preApprovalGateMarker: gate({ visible: false }),
   });
 
-  // Copilot-requested PRs stay on the standard Copilot review path
+  // Without reviewMode, default to Copilot review (hybrid local-first + external review)
   assert.equal(result.gateBoundary, PR_GATE_BOUNDARY.POST_DRAFT_EXTERNAL_REVIEW);
-  assert.equal(result.nextAction, PR_GATE_ACTION.REQUEST_COPILOT_REVIEW);
-  assert(result.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
-});
-
-test("PR with Copilot already-reviewed still uses standard review path", () => {
-  const result = evaluatePrGateCoordination({
-    pr: 298,
-    currentHeadSha: "abc123456789",
-    prDraft: false,
-    lifecycleState: STATE.PR_READY_NO_FEEDBACK,
-    loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
-    copilotReviewRequestStatus: "already-requested",
-    draftGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
-    draftGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
-    preApprovalGate: gate({ visible: false }),
-    preApprovalGateMarker: gate({ visible: false }),
-  });
-
   assert.equal(result.nextAction, PR_GATE_ACTION.REQUEST_COPILOT_REVIEW);
   assert(result.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
 });
@@ -321,7 +302,7 @@ test("local-first PR without clean draft gate still blocks at post-draft", () =>
     prDraft: false,
     lifecycleState: STATE.PR_READY_NO_FEEDBACK,
     loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
-    copilotReviewRequestStatus: "none",
+    reviewMode: "local_first",
     draftGate: gate({ visible: false }),
     draftGateMarker: gate({ visible: false }),
     preApprovalGate: gate({ visible: false }),

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -233,6 +233,106 @@ test("non-draft PR with findings_present draft_gate fails closed because no clea
   assert.match(result.reason, /no clean `draft_gate` evidence exists at all/i);
 });
 
+test("local-first PR with no Copilot review ever requested skips to pre-approval gate after draft→ready", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 298,
+    currentHeadSha: "abc123456789",
+    prDraft: false,
+    lifecycleState: STATE.PR_READY_NO_FEEDBACK,
+    loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
+    copilotReviewRequestStatus: "none",
+    draftGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  // Local-first PRs skip Copilot review and go straight to pre-approval gate
+  assert.equal(result.gateBoundary, PR_GATE_BOUNDARY.PRE_APPROVAL_GATE_WINDOW);
+  assert.equal(result.nextAction, PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE);
+  assert(result.allowedNextActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert(!result.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert(result.forbiddenActions.includes(PR_GATE_ACTION.REQUEST_COPILOT_REVIEW));
+  assert.match(result.reason, /self-reviewed/i);
+});
+
+test("local-first PR with both gates clean goes straight to final approval", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 298,
+    currentHeadSha: "abc123456789",
+    prDraft: false,
+    lifecycleState: STATE.PR_READY_NO_FEEDBACK,
+    loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
+    copilotReviewRequestStatus: "none",
+    draftGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
+    preApprovalGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.equal(result.gateBoundary, PR_GATE_BOUNDARY.FINAL_APPROVAL_READY);
+  assert.equal(result.nextAction, PR_GATE_ACTION.AWAIT_FINAL_HUMAN_APPROVAL);
+  assert(result.forbiddenActions.includes(PR_GATE_ACTION.REQUEST_COPILOT_REVIEW));
+  assert.match(result.reason, /self-reviewed/i);
+});
+
+test("PR with Copilot previously requested still requires Copilot review (not local-first)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 298,
+    currentHeadSha: "abc123456789",
+    prDraft: false,
+    lifecycleState: STATE.PR_READY_NO_FEEDBACK,
+    loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
+    copilotReviewRequestStatus: "requested",
+    draftGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  // Copilot-requested PRs stay on the standard Copilot review path
+  assert.equal(result.gateBoundary, PR_GATE_BOUNDARY.POST_DRAFT_EXTERNAL_REVIEW);
+  assert.equal(result.nextAction, PR_GATE_ACTION.REQUEST_COPILOT_REVIEW);
+  assert(result.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
+});
+
+test("PR with Copilot already-reviewed still uses standard review path", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 298,
+    currentHeadSha: "abc123456789",
+    prDraft: false,
+    lifecycleState: STATE.PR_READY_NO_FEEDBACK,
+    loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
+    copilotReviewRequestStatus: "already-requested",
+    draftGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.nextAction, PR_GATE_ACTION.REQUEST_COPILOT_REVIEW);
+  assert(result.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
+});
+
+test("local-first PR without clean draft gate still blocks at post-draft", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 298,
+    currentHeadSha: "abc123456789",
+    prDraft: false,
+    lifecycleState: STATE.PR_READY_NO_FEEDBACK,
+    loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
+    copilotReviewRequestStatus: "none",
+    draftGate: gate({ visible: false }),
+    draftGateMarker: gate({ visible: false }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  // No clean draft_gate → blocked regardless of review mode
+  assert.equal(result.gateBoundary, PR_GATE_BOUNDARY.BLOCKED);
+  assert.equal(result.nextAction, PR_GATE_ACTION.REPORT_BLOCKED);
+});
+
 test("draft PR with clean current-head draft_gate sets cleanEvidenceExists", () => {
   const result = evaluatePrGateCoordination({
     pr: 10,

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -189,6 +189,7 @@ export async function loadPrGateCoordinationContext(options, runtime = {}) {
     gateEvidence,
     interpretation,
     disposition,
+    reviewRequestStatus,
   };
 }
 
@@ -204,6 +205,7 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
     lifecycleState: context.interpretation.state,
     loopDisposition: context.disposition.loopDisposition,
     sameHeadCleanConverged: context.interpretation.sameHeadCleanConverged,
+    copilotReviewRequestStatus: context.reviewRequestStatus,
     draftGate: context.gateEvidence.draftGate,
     draftGateMarker: context.gateEvidence.draftGateMarker,
     preApprovalGate: context.gateEvidence.preApprovalGate,

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -14,7 +14,7 @@ import { evaluatePrGateCoordination } from "@pi-dev-loops/core/loop/pr-gate-coor
 import { fetchGithubReviewThreadsPayload } from "../github/capture-review-threads.mjs";
 import { detectGateReviewEvidence } from "../github/detect-gate-review-evidence.mjs";
 
-const USAGE = `Usage: detect-pr-gate-coordination-state.mjs --repo <owner/name> --pr <number>
+const USAGE = `Usage: detect-pr-gate-coordination-state.mjs --repo <owner/name> --pr <number> [--review-mode local_first]
 
 Determine which PR gate/transition is legal next for a pull request.
 
@@ -71,6 +71,7 @@ export function parseDetectPrGateCoordinationCliArgs(argv) {
     help: false,
     repo: undefined,
     pr: undefined,
+    reviewMode: undefined,
   };
 
   while (args.length > 0) {
@@ -89,6 +90,15 @@ export function parseDetectPrGateCoordinationCliArgs(argv) {
     if (token === "--pr") {
       options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
       continue;
+    }
+
+    if (token === "--review-mode") {
+      const raw = requireOptionValue(args, "--review-mode", parseError).trim().toLowerCase();
+      if (raw === "local_first") {
+        options.reviewMode = "local_first";
+        continue;
+      }
+      throw parseError(`--review-mode must be "local_first", got: ${raw}`);
     }
 
     throw parseError(`Unknown argument: ${token}`);
@@ -189,7 +199,6 @@ export async function loadPrGateCoordinationContext(options, runtime = {}) {
     gateEvidence,
     interpretation,
     disposition,
-    reviewRequestStatus,
   };
 }
 
@@ -205,7 +214,7 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
     lifecycleState: context.interpretation.state,
     loopDisposition: context.disposition.loopDisposition,
     sameHeadCleanConverged: context.interpretation.sameHeadCleanConverged,
-    copilotReviewRequestStatus: context.reviewRequestStatus,
+    reviewMode: options.reviewMode ?? null,
     draftGate: context.gateEvidence.draftGate,
     draftGateMarker: context.gateEvidence.draftGateMarker,
     preApprovalGate: context.gateEvidence.preApprovalGate,

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -190,6 +190,78 @@ test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs
 });
 
 
+test("detect-pr-gate-coordination-state with --review-mode local_first skips Copilot review", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-local-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "267", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        stdout: jsonLine({
+          number: 267,
+          state: "OPEN",
+          isDraft: false,
+          headRefOid: "ccc1234567890",
+          statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+          reviews: [],
+        }),
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/267/requested_reviewers"],
+        stdout: jsonLine({ users: [], teams: [] }),
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=267"],
+        stdout: jsonLine({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [],
+                },
+              },
+            },
+          },
+        }),
+      },
+      {
+        assertArgs: ["pr", "view", "267", "--repo", "owner/repo", "--json", "headRefOid"],
+        stdout: jsonLine({ headRefOid: "ccc1234567890" }),
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/267/comments?per_page=100"],
+        stdout: jsonLine([[
+          {
+            id: 12,
+            body: [
+              "Gate review: draft_gate",
+              "Reviewed head SHA: ccc1234",
+              "Verdict: clean",
+              "Findings summary: no issues found",
+              "Next action: mark ready for review",
+            ].join("\n"),
+            html_url: "https://example.test/comment/12",
+            updated_at: "2026-05-31T20:00:00Z",
+          },
+        ]]),
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "267", "--review-mode", "local_first"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.gateBoundary, "pre_approval_gate_window");
+    assert.equal(parsed.nextAction, "run_pre_approval_gate");
+    assert(parsed.forbiddenActions.includes("request_copilot_review"));
+    assert(parsed.allowedNextActions.includes("run_pre_approval_gate"));
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+
 test("detect-pr-gate-coordination-state fails closed when the PR head changes mid-read", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-head-drift-"));
 


### PR DESCRIPTION
## Summary

Adds an explicit `reviewMode: "local_first"` opt-in to the gate coordination state machine so self-reviewed PRs can skip Copilot review and go directly from draft→ready to pre-approval gate.

Fixes #298.

## Problem

`evaluatePrGateCoordination` assumes all PRs go through a Copilot review cycle. Local-first PRs where both gates are clean get blocked: the state machine requires `wait_for_copilot_review` and forbids `declare_merge_ready`.

## Design decision

The local-first path is **explicit/opt-in** via `reviewMode: "local_first"` — not auto-detected from Copilot request status. The hybrid default (local implementation + external Copilot review) stays unchanged.

## Changes

- `packages/core/src/loop/pr-gate-coordination.mjs`: `reviewMode` parameter, `local_first` routing in `PR_READY_NO_FEEDBACK` branch
- `packages/core/test/pr-gate-coordination.test.mjs`: 5 new tests (local-first with/without pre-approval, default Copilot path regression, no-draft-gate block)
- `scripts/loop/detect-pr-gate-coordination-state.mjs`: `--review-mode local_first` CLI flag
- `test/loop/detect-pr-gate-coordination-state.test.mjs`: 1 new integration test for `--review-mode`

## Acceptance Criteria

- [x] Explicit `reviewMode="local_first"` skips Copilot review → pre-approval gate
- [x] Both gates clean → final approval
- [x] Default (no reviewMode) stays on Copilot path (hybrid regression)
- [x] No clean draft_gate still blocks
- [x] `--review-mode local_first` CLI flag wired end-to-end
- [x] 677/678 tests pass (pre-existing Node.js internal assertion)

## Non-goals

- Auto-detecting local-first from Copilot request status
- Changing the Copilot PR lifecycle