### PR TITLE
feat: warn when gate comment exists on different head SHA (#299)

### DIFF
--- a/scripts/github/upsert-gate-review-comment.mjs
+++ b/scripts/github/upsert-gate-review-comment.mjs
@@ -41,7 +41,7 @@ Output (stdout, JSON):
     "commentUrl": "https://github.com/owner/repo/pull/17#issuecomment-101"
   }
 
-A `warning` field is included when a gate comment for the same gate already
+A \`warning\` field is included when a gate comment for the same gate already
 exists on a different head SHA (the old comment is stale for the current head).
 
 Error output (stderr, JSON):

--- a/scripts/github/upsert-gate-review-comment.mjs
+++ b/scripts/github/upsert-gate-review-comment.mjs
@@ -368,7 +368,7 @@ function detectStaleGateCommentWarning({ strict, marker, headSha, gate }) {
   }
 
   const stale = staleStrict ?? staleMarker;
-  return `A gate comment for \`${gate}\` already exists on a different head SHA \`${stale.headSha}\` (comment ${stale.commentId}). The old comment is stale for the current head and a new comment will be created.`;
+  return `A gate comment for \`${gate}\` already exists on a different head SHA \`${stale.headSha}\` (comment ${stale.commentId}). The old comment is stale for the current head.`;
 }
 
 async function runGhJson(args, { env, ghCommand }) {

--- a/scripts/github/upsert-gate-review-comment.mjs
+++ b/scripts/github/upsert-gate-review-comment.mjs
@@ -355,20 +355,12 @@ function summarizeExistingComment({ strict, marker, headSha }) {
   return null;
 }
 
-function detectStaleGateCommentWarning({ strict, marker, headSha, gate }) {
-  const staleStrict = strict?.visible === true && strict.headSha !== null && strict.headSha !== headSha
-    ? strict
-    : null;
-  const staleMarker = marker?.visible === true && marker.headSha !== null && marker.headSha !== headSha
-    ? marker
-    : null;
-
-  if (!staleStrict && !staleMarker) {
+function detectStaleGateCommentWarning({ strict, headSha, gate }) {
+  if (!(strict?.visible === true && strict.headSha !== null && strict.headSha !== headSha)) {
     return null;
   }
 
-  const stale = staleStrict ?? staleMarker;
-  return `A gate comment for \`${gate}\` already exists on a different head SHA \`${stale.headSha}\` (comment ${stale.commentId}). The old comment is stale for the current head.`;
+  return `A gate comment for \`${gate}\` already exists on a different head SHA \`${strict.headSha}\` (comment ${strict.commentId}). The old comment is stale for the current head.`;
 }
 
 async function runGhJson(args, { env, ghCommand }) {
@@ -433,7 +425,7 @@ export async function upsertGateReviewComment(options, { env = process.env, ghCo
 
   const gateEvidence = selectGateEvidence(evidence, options.gate);
   const existing = summarizeExistingComment({ ...gateEvidence, headSha: canonicalHeadSha });
-  const warning = detectStaleGateCommentWarning({ ...gateEvidence, headSha: canonicalHeadSha, gate: options.gate });
+  const warning = detectStaleGateCommentWarning({ strict: gateEvidence.strict, headSha: canonicalHeadSha, gate: options.gate });
 
   if (
     existing

--- a/scripts/github/upsert-gate-review-comment.mjs
+++ b/scripts/github/upsert-gate-review-comment.mjs
@@ -41,6 +41,9 @@ Output (stdout, JSON):
     "commentUrl": "https://github.com/owner/repo/pull/17#issuecomment-101"
   }
 
+A `warning` field is included when a gate comment for the same gate already
+exists on a different head SHA (the old comment is stale for the current head).
+
 Error output (stderr, JSON):
   { "ok": false, "error": "...", "usage": "..." }
   { "ok": false, "error": "..." }
@@ -352,6 +355,22 @@ function summarizeExistingComment({ strict, marker, headSha }) {
   return null;
 }
 
+function detectStaleGateCommentWarning({ strict, marker, headSha, gate }) {
+  const staleStrict = strict?.visible === true && strict.headSha !== null && strict.headSha !== headSha
+    ? strict
+    : null;
+  const staleMarker = marker?.visible === true && marker.headSha !== null && marker.headSha !== headSha
+    ? marker
+    : null;
+
+  if (!staleStrict && !staleMarker) {
+    return null;
+  }
+
+  const stale = staleStrict ?? staleMarker;
+  return `A gate comment for \`${gate}\` already exists on a different head SHA \`${stale.headSha}\` (comment ${stale.commentId}). The old comment is stale for the current head and a new comment will be created.`;
+}
+
 async function runGhJson(args, { env, ghCommand }) {
   const result = await runChild(ghCommand, args, env);
   if (result.code !== 0) {
@@ -412,7 +431,9 @@ export async function upsertGateReviewComment(options, { env = process.env, ghCo
   const canonicalHeadSha = resolveRequestedHeadSha(options.headSha, evidence.currentHeadSha);
   const desiredBody = renderGateReviewCommentBody({ ...options, headSha: canonicalHeadSha });
 
-  const existing = summarizeExistingComment({ ...selectGateEvidence(evidence, options.gate), headSha: canonicalHeadSha });
+  const gateEvidence = selectGateEvidence(evidence, options.gate);
+  const existing = summarizeExistingComment({ ...gateEvidence, headSha: canonicalHeadSha });
+  const warning = detectStaleGateCommentWarning({ ...gateEvidence, headSha: canonicalHeadSha, gate: options.gate });
 
   if (
     existing
@@ -431,6 +452,7 @@ export async function upsertGateReviewComment(options, { env = process.env, ghCo
       currentHeadSha: evidence.currentHeadSha,
       commentId: existing.commentId,
       commentUrl: existing.commentUrl,
+      ...(warning ? { warning } : {}),
     };
   }
 
@@ -446,6 +468,7 @@ export async function upsertGateReviewComment(options, { env = process.env, ghCo
       currentHeadSha: evidence.currentHeadSha,
       commentId: updated.commentId,
       commentUrl: updated.commentUrl,
+      ...(warning ? { warning } : {}),
     };
   }
 
@@ -460,6 +483,7 @@ export async function upsertGateReviewComment(options, { env = process.env, ghCo
     currentHeadSha: evidence.currentHeadSha,
     commentId: created.commentId,
     commentUrl: created.commentUrl,
+    ...(warning ? { warning } : {}),
   };
 }
 

--- a/test/github/upsert-gate-review-comment.test.mjs
+++ b/test/github/upsert-gate-review-comment.test.mjs
@@ -484,6 +484,81 @@ test("upsert-gate-review-comment suppresses duplicate repost when the current sa
   }
 });
 
+test("upsert-gate-review-comment noop still warns when a stale comment exists on a different head", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-noop-warn-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[]}\n',
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=17"],
+        stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n',
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
+        stdout: '{"headRefOid":"abc1234"}\n',
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/17/comments?per_page=100"],
+        stdout: `${JSON.stringify([
+          {
+            id: 101,
+            body: [
+              "Gate review: draft_gate",
+              "Reviewed head SHA: abc1234",
+              "Verdict: clean",
+              "Findings summary: no issues found",
+              "Next action: mark ready for review",
+            ].join("\n"),
+            html_url: "https://github.com/owner/repo/pull/17#issuecomment-101",
+            updated_at: "2026-05-30T17:00:00Z",
+          },
+          {
+            id: 202,
+            body: [
+              "Gate review: draft_gate",
+              "Reviewed head SHA: def5678",
+              "Verdict: clean",
+              "Findings summary: older review",
+              "Next action: mark ready for review",
+            ].join("\n"),
+            html_url: "https://github.com/owner/repo/pull/17#issuecomment-202",
+            updated_at: "2026-05-30T18:00:00Z",
+          },
+        ])}\n`,
+      },
+    ]);
+
+    const result = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "17",
+      "--gate", "draft_gate",
+      "--head-sha", "abc1234",
+      "--verdict", "clean",
+      "--findings-summary", "no issues found",
+      "--next-action", "mark ready for review",
+    ], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.action, "noop");
+    assert.equal(parsed.headSha, "abc1234");
+    assert.match(parsed.warning, /different head SHA/i);
+    assert.match(parsed.warning, /def5678/);
+    assert.match(parsed.warning, /comment 202/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("upsert-gate-review-comment updates an incomplete same-head marker in place", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-update-"));
 
@@ -632,7 +707,7 @@ test("upsert-gate-review-comment updates the current same-head marker even when 
       currentHeadSha: "abc1234",
       commentId: 101,
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
-      warning: "A gate comment for \`draft_gate\` already exists on a different head SHA \`def5678\` (comment 202). The old comment is stale for the current head and a new comment will be created.",
+      warning: "A gate comment for \`draft_gate\` already exists on a different head SHA \`def5678\` (comment 202). The old comment is stale for the current head.",
     });
   } finally {
     await rm(tempDir, { recursive: true, force: true });

--- a/test/github/upsert-gate-review-comment.test.mjs
+++ b/test/github/upsert-gate-review-comment.test.mjs
@@ -873,7 +873,7 @@ test("upsert-gate-review-comment warns when a gate comment exists on a different
         ])}\n`,
       },
       {
-        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f", "body=..."],
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f"],
         stdout: '{"id":102,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-102"}\n',
       },
     ]);

--- a/test/github/upsert-gate-review-comment.test.mjs
+++ b/test/github/upsert-gate-review-comment.test.mjs
@@ -632,6 +632,7 @@ test("upsert-gate-review-comment updates the current same-head marker even when 
       currentHeadSha: "abc1234",
       commentId: 101,
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
+      warning: "A gate comment for \`draft_gate\` already exists on a different head SHA \`def5678\` (comment 202). The old comment is stale for the current head and a new comment will be created.",
     });
   } finally {
     await rm(tempDir, { recursive: true, force: true });

--- a/test/github/upsert-gate-review-comment.test.mjs
+++ b/test/github/upsert-gate-review-comment.test.mjs
@@ -834,6 +834,73 @@ test("upsert-gate-review-comment fails closed when the requested head SHA is sta
   }
 });
 
+test("upsert-gate-review-comment warns when a gate comment exists on a different head SHA", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-warn-stale-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"def5678","reviews":[],"statusCheckRollup":[]}\n',
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=17"],
+        stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n',
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
+        stdout: '{"headRefOid":"def5678"}\n',
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/17/comments?per_page=100"],
+        stdout: `${JSON.stringify([
+          {
+            id: 99,
+            body: [
+              "Gate review: draft_gate",
+              "Reviewed head SHA: abc1234",
+              "Verdict: clean",
+              "Findings summary: previous review",
+              "Next action: mark ready for review",
+            ].join("\n"),
+            html_url: "https://github.com/owner/repo/pull/17#issuecomment-99",
+            updated_at: "2026-05-30T17:00:00Z",
+          },
+        ])}\n`,
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f", "body=..."],
+        stdout: '{"id":102,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-102"}\n',
+      },
+    ]);
+
+    const result = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "17",
+      "--gate", "draft_gate",
+      "--head-sha", "def5678",
+      "--verdict", "clean",
+      "--findings-summary", "no issues found",
+      "--next-action", "mark ready for review",
+    ], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.action, "created");
+    assert.equal(parsed.gate, "draft_gate");
+    assert.equal(parsed.headSha, "def5678");
+    assert.match(parsed.warning, /different head SHA/i);
+    assert.match(parsed.warning, /abc1234/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("upsert-gate-review-comment fails closed when draft_gate is forbidden on a non-draft PR", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-draft-forbidden-"));
 


### PR DESCRIPTION
## Summary

Adds stale-head warning to `upsert-gate-review-comment.mjs`. When a gate comment for the same gate already exists on a different head SHA, the output now includes a `warning` field describing the stale comment.

Fixes #299.

## Problem

During PR #295, 5 gate comments accumulated — 3 were duplicates/errors. While same-head duplicate prevention already exists (noop/update), there was no warning when gate comments existed on stale heads.

## Changes

- `scripts/github/upsert-gate-review-comment.mjs`: new `detectStaleGateCommentWarning` helper, warning in all 3 return paths
- `test/github/upsert-gate-review-comment.test.mjs`: integration test for stale-head warning

## Acceptance Criteria

- [x] Warning emitted when gate comment exists on different head SHA
- [x] Warning includes stale head SHA and comment ID
- [x] Warning does not block comment creation
- [x] Same-head noop/update unchanged (regression)

## Non-goals

- Full comment management UI
- Automatic comment editing without operator confirmation