### PR TITLE
feat: define durable workflow-run subagent hand-off template (#301)

### DIFF
--- a/agents/coordinator.agent.md
+++ b/agents/coordinator.agent.md
@@ -27,6 +27,7 @@ Default operating mode:
 
 ## Responsibilities
 - Read plan documents and convert them into concrete implementation tasks.
+- When delegating a full workflow run (draft PR → gates → Copilot → merge) to a subagent, use the canonical hand-off template at `skills/docs/workflow-handoff-template.md`. Do not rely on abbreviated task summaries or operator memory.
 - Decide task ordering, dependency edges, and which work can run in parallel.
 - Prepare tailored context for each delegated subagent so it receives only the files, goals, and constraints it needs.
 - Route coding work to developer, workflow/build/test work to quality, README/plan/agent documentation work to docs, pull request review-comment follow-up to fixer, and pull request review to review unless there is a strong reason to use another specialist.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "verify": "npm test && npm run test:dev-loop",
     "test": "npm run test:assets && npm run test:extension && npm run test:scripts && npm run test:core",
-    "test:assets": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/dev-loop-init-phase-smoke.test.mjs test/public-facade-doc-contracts.test.mjs test/review-doc-contracts.test.mjs test/issue-intake-doc-contracts.test.mjs test/copilot-review-doc-contracts.test.mjs test/planning-doc-contracts.test.mjs test/ui-validation-contract.test.mjs test/ui-smoke-harness-contract.test.mjs test/ui-artifact-contract.test.mjs test/ui-designer-review-loop-contract.test.mjs",
+    "test:assets": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/dev-loop-init-phase-smoke.test.mjs test/public-facade-doc-contracts.test.mjs test/review-doc-contracts.test.mjs test/issue-intake-doc-contracts.test.mjs test/copilot-review-doc-contracts.test.mjs test/planning-doc-contracts.test.mjs test/ui-validation-contract.test.mjs test/ui-smoke-harness-contract.test.mjs test/ui-artifact-contract.test.mjs test/ui-designer-review-loop-contract.test.mjs test/workflow-handoff-template-contract.test.mjs",
     "test:extension": "node --import tsx --test --test-reporter ./test/failure-summary-reporter.mjs test/extension-checks.test.mjs test/extension-command-contract.test.mjs test/extension-package-contract.test.mjs test/dev-loops-core.test.mjs test/dev-loops-cli.test.mjs",
     "test:scripts": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/github/*.test.mjs test/loop/*.test.mjs",
     "test:core": "node --test --test-reporter ./test/failure-summary-reporter.mjs packages/core/test/*.test.mjs",

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -375,8 +375,6 @@ Each summary should record:
 
 If the subagent ran asynchronously, update its summary when results arrive so fresh sessions can understand what happened without replaying the whole conversation.
 
-## Implementation loop for the phase
-
 ## Workflow-run subagent hand-off contract
 
 When handing off a full workflow run to a subagent (draft PR → gates → Copilot → merge),

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -377,6 +377,23 @@ If the subagent ran asynchronously, update its summary when results arrive so fr
 
 ## Implementation loop for the phase
 
+## Workflow-run subagent hand-off contract
+
+When handing off a full workflow run to a subagent (draft PR → gates → Copilot → merge),
+use the canonical hand-off template. Do not rely on abbreviated task summaries or operator
+memory.
+
+The canonical template is `skills/docs/workflow-handoff-template.md`. It includes:
+- direct contract-doc references the subagent must read before executing
+- a mandatory 8-step checklist (draft PR → draft_gate → ready → Copilot → resolve → pre_approval_gate → merge)
+- non-negotiable invariants (Copilot review loop between gates, `unresolvedThreadCount === 0`, visible gate comments)
+
+For all GitHub-first routed follow-up (`copilot_pr_followup`, `issue_intake`), the
+coordinator must use this template when delegating the full run to a subagent.
+Reference it by path, not by memory.
+
+## Implementation loop for the phase
+
 After the phase plan passes review:
 
 1. Write or update tests first.

--- a/skills/docs/workflow-handoff-template.md
+++ b/skills/docs/workflow-handoff-template.md
@@ -67,10 +67,10 @@ For each Copilot review pass:
 
 ### 8. Merge
 
-- All evidence must be current-head clean:
-  - `draft_gate` clean comment exists (any head — one-time boundary)
+- Required evidence:
+  - `draft_gate` clean comment exists (any head — one-time transition boundary, no current-head requirement)
   - `pre_approval_gate` clean comment exists for **current** head SHA
-  - CI green
+  - CI green on current head
   - `unresolvedThreadCount === 0`
 - Merge only after explicit authorization
 

--- a/skills/docs/workflow-handoff-template.md
+++ b/skills/docs/workflow-handoff-template.md
@@ -1,0 +1,82 @@
+# Workflow-Run Subagent Hand-Off Template
+
+This is the canonical hand-off contract for subagents tasked with running
+the dev-loop workflow. Every hand-off must use this template — no abbreviated
+task summaries or operator-memory shortcuts.
+
+## Required contract-doc reads
+
+Before executing any step, the subagent must read these contract docs:
+
+| Doc | Purpose |
+|---|---|
+| `docs/gate-review-comment-contract.md` | `draft_gate` and `pre_approval_gate` semantics, verdict definitions, rerun rules, fail-closed behavior |
+| `.pi/skills/copilot-dev-loop/SKILL.md` | Step 7: review/fix follow-up loop, reply/resolve policy, merge-ready preconditions |
+| `scripts/README.md` | Deterministic helpers for gate evidence, thread capture, review requests |
+
+## Mandatory sequence
+
+Every step is non-optional. Do not skip, reorder, or batch steps.
+
+### 1. Create draft PR
+
+- Branch off `origin/main`
+- Implement changes, write tests, run `npm run verify`
+- Create PR as **draft** via `gh pr create --draft`
+
+### 2. Draft gate review
+
+- Run parallel subagent reviews (correctness vs AC, scope compliance, test coverage)
+- Post visible `draft_gate` comment on the PR with:
+  - gate name `draft_gate`
+  - reviewed head SHA
+  - verdict (clean / findings_present / blocked)
+  - findings summary
+  - next action
+- If findings_present or blocked → fix and re-run draft gate
+
+### 3. Mark ready for review
+
+- Only after a clean `draft_gate` comment exists for the current head SHA
+- Run: `gh pr ready`
+
+### 4. Wait for Copilot review
+
+- Poll `gh pr view --json reviews` until Copilot review appears
+- Do not proceed without Copilot feedback
+
+### 5. Address Copilot feedback
+
+For each Copilot review pass:
+- Apply fixes, verify with `npm run verify`
+- Reply to **every** inline comment with the resolving commit reference
+- **Resolve** the corresponding review threads on GitHub
+- Verify: `unresolvedThreadCount === 0` before proceeding
+
+### 6. Re-request Copilot review for new heads
+
+- After pushing fixes to a new head, re-request Copilot review
+- Repeat steps 4–6 until Copilot review has no actionable feedback
+
+### 7. Pre-approval gate review
+
+- Confirm legality: `node scripts/loop/detect-pr-gate-coordination-state.mjs --repo <owner/name> --pr <number>`
+- Run parallel subagent reviews (DRY, KISS, YAGNI lenses)
+- Post visible `pre_approval_gate` comment on the PR
+- If findings → fix, push new head, re-run pre-approval gate
+
+### 8. Merge
+
+- All evidence must be current-head clean:
+  - `draft_gate` clean comment exists (any head — one-time boundary)
+  - `pre_approval_gate` clean comment exists for **current** head SHA
+  - CI green
+  - `unresolvedThreadCount === 0`
+- Merge only after explicit authorization
+
+## Non-negotiable invariants
+
+- The Copilot review loop (steps 4–6) sits **between** `draft_gate` and `pre_approval_gate` — never reorder
+- `unresolvedThreadCount === 0` verification is required before step 7
+- Gate comments must be visible on the PR — no hidden/local-only evidence
+- Never merge without explicit authorization

--- a/skills/docs/workflow-handoff-template.md
+++ b/skills/docs/workflow-handoff-template.md
@@ -11,7 +11,7 @@ Before executing any step, the subagent must read these contract docs:
 | Doc | Purpose |
 |---|---|
 | `docs/gate-review-comment-contract.md` | `draft_gate` and `pre_approval_gate` semantics, verdict definitions, rerun rules, fail-closed behavior |
-| `.pi/skills/copilot-dev-loop/SKILL.md` | Step 7: review/fix follow-up loop, reply/resolve policy, merge-ready preconditions |
+| `skills/copilot-dev-loop/SKILL.md` | Step 7: review/fix follow-up loop, reply/resolve policy, merge-ready preconditions |
 | `scripts/README.md` | Deterministic helpers for gate evidence, thread capture, review requests |
 
 ## Mandatory sequence

--- a/test/workflow-handoff-template-contract.test.mjs
+++ b/test/workflow-handoff-template-contract.test.mjs
@@ -55,7 +55,7 @@ test("workflow-handoff-template references required contract docs by path", asyn
 
   const requiredRefs = [
     "docs/gate-review-comment-contract.md",
-    "copilot-dev-loop/SKILL.md",
+    "skills/copilot-dev-loop/SKILL.md",
     "scripts/README.md",
   ];
 
@@ -112,5 +112,37 @@ test("workflow-handoff-template includes non-negotiable invariants section", asy
     /Copilot review loop.*between.*draft_gate.*pre_approval_gate/i.test(content) ||
     /between.*draft_gate.*pre_approval_gate/i.test(content),
     "invariants must state Copilot review loop sits between draft_gate and pre_approval_gate",
+  );
+});
+
+test("unresolvedThreadCount === 0 appears before pre_approval_gate in mandatory sequence", async () => {
+  const content = await readTemplate();
+
+  const seqStart = content.indexOf("## Mandatory sequence");
+  const nextSection = content.indexOf("## Non-negotiable");
+  const sequenceSection = content.slice(seqStart, nextSection);
+
+  const unresolvedIndex = sequenceSection.indexOf("unresolvedThreadCount === 0");
+  const preApprovalIndex = sequenceSection.indexOf("### 7. Pre-approval gate review");
+
+  assert.ok(unresolvedIndex >= 0, "unresolvedThreadCount === 0 must appear in mandatory sequence");
+  assert.ok(preApprovalIndex >= 0, "pre_approval_gate step must exist in mandatory sequence");
+  assert.ok(
+    unresolvedIndex < preApprovalIndex,
+    "unresolvedThreadCount === 0 verification must appear before pre_approval_gate step",
+  );
+});
+
+test("coordinator prompt references the canonical hand-off template", async () => {
+  const coordinatorPath = path.resolve("agents/coordinator.agent.md");
+  const coordinatorContent = await readFile(coordinatorPath, "utf8");
+
+  assert.ok(
+    coordinatorContent.includes("skills/docs/workflow-handoff-template.md"),
+    "coordinator prompt must reference skills/docs/workflow-handoff-template.md",
+  );
+  assert.ok(
+    /abbreviated task summaries|operator memory/i.test(coordinatorContent),
+    "coordinator prompt must forbid abbreviated task summaries",
   );
 });

--- a/test/workflow-handoff-template-contract.test.mjs
+++ b/test/workflow-handoff-template-contract.test.mjs
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+const templatePath = path.resolve("skills/docs/workflow-handoff-template.md");
+
+let templateContent = null;
+
+async function readTemplate() {
+  if (templateContent === null) {
+    templateContent = await readFile(templatePath, "utf8");
+  }
+  return templateContent;
+}
+
+test("workflow-handoff-template exists and is non-empty", async () => {
+  const content = await readTemplate();
+  assert.ok(content.length > 100, "template should have substantial content");
+});
+
+test("workflow-handoff-template includes all 8 mandatory steps in order", async () => {
+  const content = await readTemplate();
+
+  // Scope to the mandatory sequence section only
+  const seqStart = content.indexOf("## Mandatory sequence");
+  const nextSection = content.indexOf("## Non-negotiable");
+  const sequenceSection = content.slice(seqStart, nextSection);
+
+  const stepPatterns = [
+    /### 1\. Create draft PR/i,
+    /### 2\. Draft gate review/i,
+    /### 3\. Mark ready for review/i,
+    /### 4\. Wait for Copilot review/i,
+    /### 5\. Address Copilot feedback/i,
+    /### 6\. Re-request Copilot review/i,
+    /### 7\. Pre-approval gate review/i,
+    /### 8\. Merge/i,
+  ];
+
+  let lastIndex = -1;
+  for (const pattern of stepPatterns) {
+    const match = pattern.exec(sequenceSection);
+    assert.ok(match, `missing step matching: ${pattern}`);
+    assert.ok(
+      match.index > lastIndex,
+      `step "${pattern}" appears out of order (index ${match.index}, previous at ${lastIndex})`,
+    );
+    lastIndex = match.index;
+  }
+});
+
+test("workflow-handoff-template references required contract docs by path", async () => {
+  const content = await readTemplate();
+
+  const requiredRefs = [
+    "docs/gate-review-comment-contract.md",
+    "copilot-dev-loop/SKILL.md",
+    "scripts/README.md",
+  ];
+
+  for (const ref of requiredRefs) {
+    assert.ok(
+      content.includes(ref),
+      `template must reference "${ref}"`,
+    );
+  }
+});
+
+test("workflow-handoff-template has Copilot review loop between draft_gate and pre_approval_gate", async () => {
+  const content = await readTemplate();
+
+  // Scope to the mandatory sequence section
+  const seqStart = content.indexOf("## Mandatory sequence");
+  const nextSection = content.indexOf("## Non-negotiable");
+  const sequenceSection = content.slice(seqStart, nextSection);
+
+  const draftGateIndex = sequenceSection.indexOf("draft_gate");
+  const preApprovalGateIndex = sequenceSection.indexOf("pre_approval_gate");
+  const copilotReviewIndex = sequenceSection.indexOf("Copilot review");
+
+  assert.ok(draftGateIndex >= 0, "template must mention draft_gate");
+  assert.ok(preApprovalGateIndex >= 0, "template must mention pre_approval_gate");
+  assert.ok(copilotReviewIndex >= 0, "template must mention Copilot review");
+  assert.ok(
+    draftGateIndex < copilotReviewIndex,
+    "Copilot review must appear after draft_gate in mandatory sequence",
+  );
+  assert.ok(
+    copilotReviewIndex < preApprovalGateIndex,
+    "Copilot review must appear before pre_approval_gate in mandatory sequence",
+  );
+});
+
+test("workflow-handoff-template requires unresolvedThreadCount === 0 verification", async () => {
+  const content = await readTemplate();
+
+  assert.ok(
+    content.includes("unresolvedThreadCount === 0"),
+    "template must explicitly require unresolvedThreadCount === 0 verification",
+  );
+});
+
+test("workflow-handoff-template includes non-negotiable invariants section", async () => {
+  const content = await readTemplate();
+
+  assert.ok(
+    /non-negotiable invariants/i.test(content),
+    "template must have a non-negotiable invariants section",
+  );
+  assert.ok(
+    /Copilot review loop.*between.*draft_gate.*pre_approval_gate/i.test(content) ||
+    /between.*draft_gate.*pre_approval_gate/i.test(content),
+    "invariants must state Copilot review loop sits between draft_gate and pre_approval_gate",
+  );
+});


### PR DESCRIPTION
## Summary

Defines the canonical hand-off contract for subagents tasked with running the full dev-loop workflow. No more abbreviated task summaries or operator-memory shortcuts.

Fixes #301.

## Changes

- `skills/docs/workflow-handoff-template.md`: canonical 8-step template with mandatory checklist, contract-doc references, and non-negotiable invariants
- `.pi/skills/dev-loop/SKILL.md`: references template for GitHub-first routed follow-up
- `test/workflow-handoff-template-contract.test.mjs`: 6 regression tests

## Acceptance Criteria

- [x] Single canonical template file exists
- [x] Template includes direct doc path references subagents must read
- [x] Full mandatory checklist (draft PR → draft_gate → ready → Copilot → resolve → pre_approval_gate → merge)
- [x] Explicit `unresolvedThreadCount === 0` verification before pre_approval_gate
- [x] Coordinator agent prompt references template
- [x] Regression tests lock template existence, step order, doc references, gate ordering

## Non-goals

- Changing gate contracts themselves
- Redesigning the workflow pipeline
- Making the template auto-executed