### PR TITLE
feat: add mandatory Copilot review comment resolution contract (#308)

### DIFF
--- a/scripts/github/reply-resolve-review-thread.mjs
+++ b/scripts/github/reply-resolve-review-thread.mjs
@@ -227,7 +227,8 @@ export async function runCli(
   }
 
   const trimmedBody = rawBody.trim();
-  const hasCommitSha = /\b[0-9a-f]{7,40}\b/i.test(trimmedBody);
+  const hexTokens = trimmedBody.match(/\b[0-9a-f]{7,40}\b/gi) ?? [];
+  const hasCommitSha = hexTokens.some((t) => /[a-f]/i.test(t));
   const hasSentenceReason = trimmedBody.length >= MIN_DISMISSAL_REASON_LENGTH;
   if (!hasCommitSha && !hasSentenceReason) {
     throw new Error(

--- a/scripts/github/reply-resolve-review-thread.mjs
+++ b/scripts/github/reply-resolve-review-thread.mjs
@@ -224,6 +224,16 @@ export async function runCli(
     throw new Error("--body-file must contain non-empty text");
   }
 
+  const trimmedBody = rawBody.trim();
+  const hasCommitSha = /\b[0-9a-f]{7,40}\b/i.test(trimmedBody);
+  const hasSentenceReason = trimmedBody.length >= 30;
+  if (!hasCommitSha && !hasSentenceReason) {
+    throw new Error(
+      "Reply body must contain either a commit SHA reference (applied fix) or a sentence-length dismissal reason (at least 30 characters). " +
+      "Bare acknowledgments like \"Acknowledged.\" are not valid resolutions.",
+    );
+  }
+
   await validateReplyTarget(
     {
       repo: options.repo,

--- a/scripts/github/reply-resolve-review-thread.mjs
+++ b/scripts/github/reply-resolve-review-thread.mjs
@@ -12,11 +12,15 @@ const MIN_DISMISSAL_REASON_LENGTH = 30;
 export function hasCommitShaReference(text) {
   const trimmed = text.trim();
   // Accept a hex token (7-40 chars) that contains at least one hex letter (a-f) — the common case.
-  // Also accept a pure-numeric hex token when it is explicitly contextualized with a
-  // commit-reference keyword (e.g. "Fixed in 1234567"), covering the rare-but-valid all-digit SHA.
+  // Also accept a pure-numeric hex token when it is explicitly contextualized as a commit reference:
+  //   - via keyword + whitespace: "Fixed in 1234567", "Commit 1234567", "SHA 1234567"
+  //   - via commit URL path:      ".../commit/1234567"
+  // This handles the rare-but-valid all-digit SHA without reopening the bare-numeric bypass vector.
   const hexTokens = trimmed.match(/\b[0-9a-f]{7,40}\b/gi) ?? [];
   const hasHexLetterToken = hexTokens.some((t) => /[a-f]/i.test(t));
-  const hasContextualNumericRef = /\b(?:fixed\s+in|commit|sha|rev(?:ision)?)\s+[0-9a-f]{7,40}\b/i.test(trimmed);
+  const hasContextualNumericRef =
+    /\b(?:fixed\s+in|commit|sha|rev(?:ision)?)\s+[0-9a-f]{7,40}\b/i.test(trimmed) ||
+    /\/commit\/[0-9a-f]{7,40}\b/i.test(trimmed);
   return hasHexLetterToken || hasContextualNumericRef;
 }
 

--- a/scripts/github/reply-resolve-review-thread.mjs
+++ b/scripts/github/reply-resolve-review-thread.mjs
@@ -8,6 +8,19 @@ import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 
 const MIN_DISMISSAL_REASON_LENGTH = 30;
 
+// Exported for unit testing
+export function hasCommitShaReference(text) {
+  const trimmed = text.trim();
+  // Accept a hex token (7-40 chars) that contains at least one hex letter (a-f) — the common case.
+  // Also accept a pure-numeric hex token when it is explicitly contextualized with a
+  // commit-reference keyword (e.g. "Fixed in 1234567"), covering the rare-but-valid all-digit SHA.
+  const hexTokens = trimmed.match(/\b[0-9a-f]{7,40}\b/gi) ?? [];
+  const hasHexLetterToken = hexTokens.some((t) => /[a-f]/i.test(t));
+  const hasContextualNumericRef = /\b(?:fixed\s+in|commit|sha|rev(?:ision)?)\s+[0-9a-f]{7,40}\b/i.test(trimmed);
+  return hasHexLetterToken || hasContextualNumericRef;
+}
+
+
 const RESOLVE_REVIEW_THREAD_MUTATION = [
   "mutation($threadId: ID!) {",
   "  resolveReviewThread(input: { threadId: $threadId }) {",
@@ -227,8 +240,7 @@ export async function runCli(
   }
 
   const trimmedBody = rawBody.trim();
-  const hexTokens = trimmedBody.match(/\b[0-9a-f]{7,40}\b/gi) ?? [];
-  const hasCommitSha = hexTokens.some((t) => /[a-f]/i.test(t));
+  const hasCommitSha = hasCommitShaReference(trimmedBody);
   const hasSentenceReason = trimmedBody.length >= MIN_DISMISSAL_REASON_LENGTH;
   if (!hasCommitSha && !hasSentenceReason) {
     throw new Error(

--- a/scripts/github/reply-resolve-review-thread.mjs
+++ b/scripts/github/reply-resolve-review-thread.mjs
@@ -6,6 +6,8 @@ import { formatCliError, isDirectCliRun, parseReviewThreads } from "../_core-hel
 import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 
+const MIN_DISMISSAL_REASON_LENGTH = 30;
+
 const RESOLVE_REVIEW_THREAD_MUTATION = [
   "mutation($threadId: ID!) {",
   "  resolveReviewThread(input: { threadId: $threadId }) {",
@@ -226,10 +228,10 @@ export async function runCli(
 
   const trimmedBody = rawBody.trim();
   const hasCommitSha = /\b[0-9a-f]{7,40}\b/i.test(trimmedBody);
-  const hasSentenceReason = trimmedBody.length >= 30;
+  const hasSentenceReason = trimmedBody.length >= MIN_DISMISSAL_REASON_LENGTH;
   if (!hasCommitSha && !hasSentenceReason) {
     throw new Error(
-      "Reply body must contain either a commit SHA reference (applied fix) or a sentence-length dismissal reason (at least 30 characters). " +
+      `Reply body (${trimmedBody.length} characters after trimming) must contain either a commit SHA reference or a sentence-length reason (at least ${MIN_DISMISSAL_REASON_LENGTH} characters after trimming). ` +
       "Bare acknowledgments like \"Acknowledged.\" are not valid resolutions.",
     );
   }

--- a/scripts/github/reply-resolve-review-thread.mjs
+++ b/scripts/github/reply-resolve-review-thread.mjs
@@ -244,8 +244,8 @@ export async function runCli(
 
   const trimmedBody = rawBody.trim();
   const hasCommitSha = hasCommitShaReference(trimmedBody);
-  const hasSentenceReason = trimmedBody.length >= MIN_DISMISSAL_REASON_LENGTH;
-  if (!hasCommitSha && !hasSentenceReason) {
+  const hasDismissalReason = trimmedBody.length >= MIN_DISMISSAL_REASON_LENGTH;
+  if (!hasCommitSha && !hasDismissalReason) {
     throw new Error(
       `Reply body (${trimmedBody.length} characters after trimming) must contain either a commit SHA reference or a dismissal reason (at least ${MIN_DISMISSAL_REASON_LENGTH} characters after trimming). ` +
       "Bare acknowledgments like \"Acknowledged.\" are not valid resolutions.",

--- a/scripts/github/reply-resolve-review-thread.mjs
+++ b/scripts/github/reply-resolve-review-thread.mjs
@@ -20,7 +20,6 @@ export function hasCommitShaReference(text) {
   return hasHexLetterToken || hasContextualNumericRef;
 }
 
-
 const RESOLVE_REVIEW_THREAD_MUTATION = [
   "mutation($threadId: ID!) {",
   "  resolveReviewThread(input: { threadId: $threadId }) {",

--- a/scripts/github/reply-resolve-review-thread.mjs
+++ b/scripts/github/reply-resolve-review-thread.mjs
@@ -247,7 +247,7 @@ export async function runCli(
   const hasSentenceReason = trimmedBody.length >= MIN_DISMISSAL_REASON_LENGTH;
   if (!hasCommitSha && !hasSentenceReason) {
     throw new Error(
-      `Reply body (${trimmedBody.length} characters after trimming) must contain either a commit SHA reference or a sentence-length reason (at least ${MIN_DISMISSAL_REASON_LENGTH} characters after trimming). ` +
+      `Reply body (${trimmedBody.length} characters after trimming) must contain either a commit SHA reference or a dismissal reason (at least ${MIN_DISMISSAL_REASON_LENGTH} characters after trimming). ` +
       "Bare acknowledgments like \"Acknowledged.\" are not valid resolutions.",
     );
   }

--- a/skills/copilot-dev-loop/SKILL.md
+++ b/skills/copilot-dev-loop/SKILL.md
@@ -718,17 +718,10 @@ When actionable review feedback exists, use a narrow follow-up loop:
    - when the intent is GitHub linkability, keep commit SHAs and issue/PR refs as plain text (for example 3ee82fc and owner/repo#70) and do not wrap them in backticks
    - keep backticks for actual code/path/CLI literals only
    - if that helper was newly added or recently changed, smoke-check it against one real thread before assuming the rest of the loop can rely on it
-
-**Copilot review comment resolution contract:** every resolution must satisfy at least one of:
-
-- **Applied**: the requested change was implemented; the reply MUST name the resolving commit SHA (e.g. "Fixed in abc1234.")
-- **Dismissed with reasoning**: the change is not applied, but the reply MUST include an explicit, well-grounded reason at least 30 characters after trimming (e.g. "Intentionally kept for downstream consumers", "Out of scope for this phase — tracked in issue #N")
-
-Invalid resolutions (must not resolve the thread):
-- Bare "Acknowledged." without reasoning
-- "Looks good", "OK", "+1", or other thin acknowledgments on actionable feedback
-- Batch-resolving without reading or without per-thread replies
-- Any reply that is too short to contain either a commit SHA reference or a dismissal reason (at least 30 characters after trimming)
+   - **resolution contract:** every resolution must satisfy at least one of:
+     - **Applied**: the requested change was implemented; the reply MUST name the resolving commit SHA (e.g. "Fixed in abc1234.")
+     - **Dismissed with reasoning**: the change is not applied, but the reply MUST include an explicit, well-grounded reason at least 30 characters after trimming (e.g. "Intentionally kept for downstream consumers", "Out of scope for this phase — tracked in issue #N")
+   - invalid resolutions (must not resolve the thread): bare "Acknowledged." without reasoning; "Looks good", "OK", "+1", or other thin acknowledgments on actionable feedback; batch-resolving without reading or without per-thread replies; any reply too short to contain either a commit SHA reference or a dismissal reason (at least 30 characters after trimming)
 9. resolve the addressed review thread only after the reply is attached successfully and the concern is genuinely addressed
    - do not stop at a local fix if GitHub-side reply/resolve is authorized
 10. after completing reply/resolve for a pass, verify `unresolvedThreadCount === 0` via `capture-review-threads.mjs` before proceeding

--- a/skills/copilot-dev-loop/SKILL.md
+++ b/skills/copilot-dev-loop/SKILL.md
@@ -718,6 +718,17 @@ When actionable review feedback exists, use a narrow follow-up loop:
    - when the intent is GitHub linkability, keep commit SHAs and issue/PR refs as plain text (for example 3ee82fc and owner/repo#70) and do not wrap them in backticks
    - keep backticks for actual code/path/CLI literals only
    - if that helper was newly added or recently changed, smoke-check it against one real thread before assuming the rest of the loop can rely on it
+
+**Copilot review comment resolution contract:** every resolution must satisfy exactly one of:
+
+- **Applied**: the requested change was implemented; the reply MUST name the resolving commit SHA (e.g. "Fixed in abc1234.")
+- **Dismissed with reasoning**: the change is not applied, but the reply MUST include an explicit, well-grounded reason at least one sentence in length (e.g. "Intentionally kept for downstream consumers", "Out of scope for this phase — tracked in issue #N")
+
+Invalid resolutions (must not resolve the thread):
+- Bare "Acknowledged." without reasoning
+- "Looks good", "OK", "+1", or other thin acknowledgments on actionable feedback
+- Batch-resolving without reading or without per-thread replies
+- Any reply that is too short to contain either a commit SHA reference or a sentence-length reason
 9. resolve the addressed review thread only after the reply is attached successfully and the concern is genuinely addressed
    - do not stop at a local fix if GitHub-side reply/resolve is authorized
 10. after completing reply/resolve for a pass, verify `unresolvedThreadCount === 0` via `capture-review-threads.mjs` before proceeding
@@ -911,6 +922,9 @@ Do not:
 - create a separate local backlog
 - broaden a Copilot PR into multiple issue scopes
 - resolve threads without checking whether the current branch actually fixes them
+- reply to review comments with bare "Acknowledged." or other thin dismissals that give no reasoning
+- resolve review threads without a commit SHA reference (applied) or a sentence-length dismissal reason (dismissed)
+- batch-resolve without reading or per-thread replies
 - use inline `gh api` to post thread replies without the resolve mutation
 - submit a merge-ready verdict without first summarizing the pending thread state
 - declare merge-ready without a visible `pre_approval_gate` comment on the current head SHA

--- a/skills/copilot-dev-loop/SKILL.md
+++ b/skills/copilot-dev-loop/SKILL.md
@@ -719,7 +719,7 @@ When actionable review feedback exists, use a narrow follow-up loop:
    - keep backticks for actual code/path/CLI literals only
    - if that helper was newly added or recently changed, smoke-check it against one real thread before assuming the rest of the loop can rely on it
 
-**Copilot review comment resolution contract:** every resolution must satisfy exactly one of:
+**Copilot review comment resolution contract:** every resolution must satisfy at least one of:
 
 - **Applied**: the requested change was implemented; the reply MUST name the resolving commit SHA (e.g. "Fixed in abc1234.")
 - **Dismissed with reasoning**: the change is not applied, but the reply MUST include an explicit, well-grounded reason at least one sentence in length (e.g. "Intentionally kept for downstream consumers", "Out of scope for this phase — tracked in issue #N")

--- a/skills/copilot-dev-loop/SKILL.md
+++ b/skills/copilot-dev-loop/SKILL.md
@@ -722,13 +722,13 @@ When actionable review feedback exists, use a narrow follow-up loop:
 **Copilot review comment resolution contract:** every resolution must satisfy at least one of:
 
 - **Applied**: the requested change was implemented; the reply MUST name the resolving commit SHA (e.g. "Fixed in abc1234.")
-- **Dismissed with reasoning**: the change is not applied, but the reply MUST include an explicit, well-grounded reason at least one sentence in length (e.g. "Intentionally kept for downstream consumers", "Out of scope for this phase — tracked in issue #N")
+- **Dismissed with reasoning**: the change is not applied, but the reply MUST include an explicit, well-grounded reason at least 30 characters after trimming (e.g. "Intentionally kept for downstream consumers", "Out of scope for this phase — tracked in issue #N")
 
 Invalid resolutions (must not resolve the thread):
 - Bare "Acknowledged." without reasoning
 - "Looks good", "OK", "+1", or other thin acknowledgments on actionable feedback
 - Batch-resolving without reading or without per-thread replies
-- Any reply that is too short to contain either a commit SHA reference or a sentence-length reason
+- Any reply that is too short to contain either a commit SHA reference or a dismissal reason (at least 30 characters after trimming)
 9. resolve the addressed review thread only after the reply is attached successfully and the concern is genuinely addressed
    - do not stop at a local fix if GitHub-side reply/resolve is authorized
 10. after completing reply/resolve for a pass, verify `unresolvedThreadCount === 0` via `capture-review-threads.mjs` before proceeding
@@ -923,7 +923,7 @@ Do not:
 - broaden a Copilot PR into multiple issue scopes
 - resolve threads without checking whether the current branch actually fixes them
 - reply to review comments with bare "Acknowledged." or other thin dismissals that give no reasoning
-- resolve review threads without a commit SHA reference (applied) or a sentence-length dismissal reason (dismissed)
+- resolve review threads without a commit SHA reference (applied) or a dismissal reason of at least 30 characters after trimming (dismissed)
 - batch-resolve without reading or per-thread replies
 - use inline `gh api` to post thread replies without the resolve mutation
 - submit a merge-ready verdict without first summarizing the pending thread state

--- a/test/github/reply-resolve-review-thread.test.mjs
+++ b/test/github/reply-resolve-review-thread.test.mjs
@@ -231,6 +231,8 @@ test("hasCommitShaReference unit — hex-with-letters accepted, bare numeric rej
   assert.equal(hasCommitShaReference("Fixed in 1234567"), true);
   assert.equal(hasCommitShaReference("Commit 1234567"), true);
   assert.equal(hasCommitShaReference("SHA 1234567"), true);
+  assert.equal(hasCommitShaReference("https://github.com/owner/repo/commit/1234567"), true);
+  assert.equal(hasCommitShaReference("See /commit/1234567 for details"), true);
 
   // Too short (6 chars) or too long (41 chars) — rejected
   assert.equal(hasCommitShaReference("abc123"), false);

--- a/test/github/reply-resolve-review-thread.test.mjs
+++ b/test/github/reply-resolve-review-thread.test.mjs
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { hasCommitShaReference } from "../../scripts/github/reply-resolve-review-thread.mjs";
 
 const scriptPath = path.resolve("scripts/github/reply-resolve-review-thread.mjs");
 
@@ -214,6 +215,30 @@ test("reply-resolve-review-thread rejects pure-numeric tokens that are not commi
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
+});
+
+test("hasCommitShaReference unit — hex-with-letters accepted, bare numeric rejected, contextualized numeric accepted", () => {
+  // Bare hex tokens with at least one hex letter — the common case
+  assert.equal(hasCommitShaReference("Fixed in abc1234."), true);
+  assert.equal(hasCommitShaReference("39add8d"), true);
+  assert.equal(hasCommitShaReference("0350a214"), true);
+
+  // Bare pure-numeric token — no hex letters, no keyword context: rejected
+  assert.equal(hasCommitShaReference("1234567"), false);
+  assert.equal(hasCommitShaReference("12345678"), false);
+
+  // Numeric token in explicit commit-reference context — rare-but-valid all-digit SHA form
+  assert.equal(hasCommitShaReference("Fixed in 1234567"), true);
+  assert.equal(hasCommitShaReference("Commit 1234567"), true);
+  assert.equal(hasCommitShaReference("SHA 1234567"), true);
+
+  // Too short (6 chars) or too long (41 chars) — rejected
+  assert.equal(hasCommitShaReference("abc123"), false);
+  assert.equal(hasCommitShaReference("a".repeat(41)), false);
+
+  // Empty / whitespace only
+  assert.equal(hasCommitShaReference(""), false);
+  assert.equal(hasCommitShaReference("   "), false);
 });
 
 test("reply-resolve-review-thread rejects malformed arguments and empty body files deterministically", async () => {

--- a/test/github/reply-resolve-review-thread.test.mjs
+++ b/test/github/reply-resolve-review-thread.test.mjs
@@ -194,6 +194,28 @@ test("reply-resolve-review-thread rejects thin replies without commit SHA or sen
   }
 });
 
+test("reply-resolve-review-thread rejects pure-numeric tokens that are not commit SHAs", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-numeric-sha-"));
+  const bodyFile = path.join(tempDir, "reply.md");
+  // "1234567" matches the 7-40 hex-char regex but contains no hex letters; must not bypass the check
+  await writeFile(bodyFile, "1234567\n", "utf8");
+
+  try {
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--comment-id", "123", "--thread-id", "THREAD_123", "--body-file", bodyFile],
+      { env: { ...process.env, PATH: process.env.PATH } },
+    );
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const parsed = JSON.parse(result.stderr);
+    assert.equal(parsed.ok, false);
+    assert.match(parsed.error, /Reply body \(7 characters after trimming\) must contain either a commit SHA reference/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("reply-resolve-review-thread rejects malformed arguments and empty body files deterministically", async () => {
   const missing = await runNode(["--repo", "owner/repo"]);
   assert.equal(missing.code, 1);

--- a/test/github/reply-resolve-review-thread.test.mjs
+++ b/test/github/reply-resolve-review-thread.test.mjs
@@ -174,7 +174,7 @@ test("reply-resolve-review-thread posts a reply then resolves the thread", async
   }
 });
 
-test("reply-resolve-review-thread rejects thin replies without commit SHA or sentence-length reasoning", async () => {
+test("reply-resolve-review-thread rejects thin replies without commit SHA or dismissal reason", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-thin-"));
   const bodyFile = path.join(tempDir, "reply.md");
   await writeFile(bodyFile, "Acknowledged.\n", "utf8");
@@ -189,7 +189,7 @@ test("reply-resolve-review-thread rejects thin replies without commit SHA or sen
     assert.equal(result.stdout, "");
     const parsed = JSON.parse(result.stderr);
     assert.equal(parsed.ok, false);
-    assert.match(parsed.error, /Reply body \(13 characters after trimming\) must contain either a commit SHA reference or a sentence-length reason/);
+    assert.match(parsed.error, /Reply body \(13 characters after trimming\) must contain either a commit SHA reference or a dismissal reason/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/github/reply-resolve-review-thread.test.mjs
+++ b/test/github/reply-resolve-review-thread.test.mjs
@@ -173,6 +173,27 @@ test("reply-resolve-review-thread posts a reply then resolves the thread", async
   }
 });
 
+test("reply-resolve-review-thread rejects thin replies without commit SHA or sentence-length reasoning", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-thin-"));
+  const bodyFile = path.join(tempDir, "reply.md");
+  await writeFile(bodyFile, "Acknowledged.\n", "utf8");
+
+  try {
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--comment-id", "123", "--thread-id", "THREAD_123", "--body-file", bodyFile],
+      { env: { ...process.env, PATH: process.env.PATH } },
+    );
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const parsed = JSON.parse(result.stderr);
+    assert.equal(parsed.ok, false);
+    assert.match(parsed.error, /Reply body \(13 characters after trimming\) must contain either a commit SHA reference or a sentence-length reason/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("reply-resolve-review-thread rejects malformed arguments and empty body files deterministically", async () => {
   const missing = await runNode(["--repo", "owner/repo"]);
   assert.equal(missing.code, 1);

--- a/test/github/reply-resolve-review-thread.test.mjs
+++ b/test/github/reply-resolve-review-thread.test.mjs
@@ -221,7 +221,7 @@ test("reply-resolve-review-thread rejects malformed arguments and empty body fil
 test("reply-resolve-review-thread preserves leading whitespace in the reply body payload", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-whitespace-"));
   const bodyFile = path.join(tempDir, "reply.md");
-  await writeFile(bodyFile, "  indented line\n", "utf8");
+  await writeFile(bodyFile, "  indented line with enough text to pass resolution contract\n", "utf8");
 
   try {
     const gh = await writeGhStub(tempDir, [
@@ -240,7 +240,7 @@ test("reply-resolve-review-thread preserves leading whitespace in the reply body
       },
       {
         assertArgs: ["api", "-X", "POST", "repos/owner/repo/pulls/17/comments/123/replies", "--input", "-"],
-        assertStdinIncludes: ['"body":"  indented line\\n"'],
+        assertStdinIncludes: ['"body":"  indented line with enough text to pass resolution contract\\n"'],
         stdout: '{"id":456,"html_url":"https://github.com/owner/repo/pull/17#discussion_r456"}\n',
       },
       {


### PR DESCRIPTION
## Summary

Defines a mandatory resolution contract for Copilot review comments and adds deterministic enforcement in the reply-resolve helper. Every resolution must be Applied (with commit SHA) or Dismissed (with sentence-length reasoning). Bare "Acknowledged." is rejected at the script level.

Fixes #308.

## Changes

- `.pi/skills/copilot-dev-loop/SKILL.md`: resolution contract in follow-up loop step 8, anti-patterns updated
- `scripts/github/reply-resolve-review-thread.mjs`: deterministic validation — body must contain commit SHA or ≥30 chars
- `test/github/reply-resolve-review-thread.test.mjs`: updated whitespace test body

## Acceptance Criteria

- [x] Resolution contract defined in copilot-dev-loop skill
- [x] Applied and Dismissed paths explicitly documented
- [x] Invalid resolutions enumerated
- [x] Anti-patterns updated
- [x] Deterministic check in reply-resolve script: rejects thin replies
- [x] 8/8 reply-resolve tests pass

## Non-goals

- Fully automated comment analysis
- Requiring code changes for every comment (dismissal with reasoning is valid)