### PR TITLE
Pass targetPreference through startup resolver to routeForState (#321)

### DIFF
--- a/packages/core/src/loop/public-dev-loop-routing-shared.mjs
+++ b/packages/core/src/loop/public-dev-loop-routing-shared.mjs
@@ -575,6 +575,7 @@ function routeForState(
     issueReadiness = null,
     issueAssignmentState = null,
     gateReviewEvidence = null,
+    targetPreference = null,
   } = {},
 ) {
   const routableCanonicalState = toRoutableCanonicalState(canonicalState);
@@ -680,6 +681,28 @@ function routeForState(
   }
 
   if (selectedGate === DEV_LOOP_GATE.ISSUE_INTAKE) {
+    if (targetPreference === DEV_LOOP_TARGET_PREFERENCE.PREFER_LOCAL) {
+      const localPhase = routableCanonicalState.target.issue
+        ? `issue-${routableCanonicalState.target.issue}`
+        : null;
+      const localTarget = {
+        kind: DEV_LOOP_TARGET_KIND.LOCAL_PHASE,
+        issue: routableCanonicalState.target.issue,
+        pr: null,
+        linkedPr: null,
+        branch: null,
+        phase: localPhase,
+      };
+      return buildResult({
+        selectedGate: DEV_LOOP_GATE.LOCAL_IMPLEMENTATION,
+        routeKind: DEV_LOOP_ROUTE_KIND.ROUTE,
+        selectedStrategy: INTERNAL_DEV_LOOP_STRATEGY.LOCAL_IMPLEMENTATION,
+        executionMode,
+        canonicalState: { ...routableCanonicalState, target: localTarget },
+        nextAction: `Run the local implementation strategy for issue #${routableCanonicalState.target.issue} (tracker-backed local session).`,
+        reason: "Issue targets with `targetPreference=prefer_local` route to local implementation instead of Copilot-first issue intake.",
+      });
+    }
     const copilotFirstIssueSeam = isCopilotFirstIssueFlow(routableCanonicalState)
       ? resolveCopilotFirstIssueAssignmentSeam(routableCanonicalState, issueReadiness, issueAssignmentState)
       : {

--- a/packages/core/src/loop/public-dev-loop-routing-startup.mjs
+++ b/packages/core/src/loop/public-dev-loop-routing-startup.mjs
@@ -15,6 +15,7 @@ import {
 } from "./public-dev-loop-routing-contract.mjs";
 import {
   ALLOWED_MODE_VALUES_TEXT,
+  ALLOWED_TARGET_PREFERENCE_VALUES_TEXT,
   applyRetrospectiveCheckpointGate,
   buildAuthoritativeStatusNextAction,
   buildContractTrace,
@@ -30,6 +31,7 @@ import {
   normalizeIssueReadiness,
   normalizeOptionalLoopState,
   normalizeState,
+  normalizeTargetPreference,
   normalizeVariationMode,
   routeForState,
 } from "./public-dev-loop-routing-shared.mjs";
@@ -237,6 +239,18 @@ export function resolveAuthoritativeStartupResumeBundle(input = {}) {
     ? DEV_LOOP_EXECUTION_MODE.DURABLE_AUTO
     : (variationMode ?? DEV_LOOP_EXECUTION_MODE.BOUNDED_HANDOFF);
 
+  const targetPreference = input.targetPreference !== undefined
+    ? normalizeTargetPreference(input.targetPreference)
+    : null;
+
+  if (input.targetPreference !== undefined && targetPreference === null) {
+    return buildStartupResumeBundleReconcile({
+      reason: `Authoritative startup/resume routing received an invalid targetPreference value; allowed values: ${ALLOWED_TARGET_PREFERENCE_VALUES_TEXT}.`,
+      canonicalState,
+      executionMode: effectiveMode,
+    });
+  }
+
   const issueLinkageResolution = normalizeIssueLinkageResolution(input.issueLinkageResolution);
   const issueReadiness = normalizeIssueReadiness(input.issueReadiness);
   const issueAssignmentState = normalizeIssueAssignmentState(input.issueAssignmentState);
@@ -370,6 +384,7 @@ export function resolveAuthoritativeStartupResumeBundle(input = {}) {
     issueReadiness,
     issueAssignmentState,
     gateReviewEvidence,
+    targetPreference,
   });
   if (routed.routeKind === DEV_LOOP_ROUTE_KIND.NEEDS_RECONCILE) {
     return buildStartupResumeBundleReconcile({

--- a/packages/core/src/loop/public-dev-loop-routing.mjs
+++ b/packages/core/src/loop/public-dev-loop-routing.mjs
@@ -273,6 +273,7 @@ export function evaluatePublicDevLoopRouting(input = {}) {
     issueReadiness: acceptsIssueAssignmentFacts ? issueReadiness : null,
     issueAssignmentState: acceptsIssueAssignmentFacts ? issueAssignmentState : null,
     gateReviewEvidence,
+    targetPreference,
   };
 
   const finalizeRoutingResult = (result) => {

--- a/packages/core/test/public-dev-loop-routing-startup.test.mjs
+++ b/packages/core/test/public-dev-loop-routing-startup.test.mjs
@@ -600,3 +600,48 @@ test("authoritative startup/resume bundle fails closed on invalid explicit inten
   assert.equal(bundle.bundleKind, DEV_LOOP_STARTUP_RESUME_BUNDLE_KIND.NEEDS_RECONCILE);
   assert.match(bundle.reason, /invalid public dev-loop intent/i);
 });
+
+test("targetPreference: PREFER_LOCAL with issue target produces LOCAL_IMPLEMENTATION bundle", () => {
+  const bundle = resolveAuthoritativeStartupResumeBundle({
+    targetPreference: DEV_LOOP_TARGET_PREFERENCE.PREFER_LOCAL,
+    currentState: {
+      target: { kind: DEV_LOOP_TARGET_KIND.ISSUE, issue: 99 },
+      ownership: DEV_LOOP_ACTOR.COPILOT,
+      nextActor: DEV_LOOP_ACTOR.COPILOT,
+      status: DEV_LOOP_STATUS.ACTIVE,
+      authorization: DEV_LOOP_AUTHORIZATION.NEEDS_CONFIRMATION,
+    },
+    issueLinkageResolution: DEV_LOOP_ISSUE_LINKAGE_RESOLUTION.RESOLVED_NO_OPEN_PR,
+    issueReadiness: DEV_LOOP_ISSUE_READINESS.READY,
+    issueAssignmentState: DEV_LOOP_ISSUE_ASSIGNMENT_STATE.ASSIGNED_TO_COPILOT,
+    artifactState: DEV_LOOP_ARTIFACT_STATE.NOT_APPLICABLE,
+    loopState: "awaiting_triage",
+  });
+
+  assert.equal(bundle.bundleKind, DEV_LOOP_STARTUP_RESUME_BUNDLE_KIND.RESOLVED);
+  assert.equal(bundle.routeKind, DEV_LOOP_ROUTE_KIND.ROUTE);
+  assert.equal(bundle.selectedStrategy, INTERNAL_DEV_LOOP_STRATEGY.LOCAL_IMPLEMENTATION);
+  assert.match(bundle.nextAction, /local implementation strategy/i);
+});
+
+test("invalid targetPreference produces NEEDS_RECONCILE whose reason references allowed values text", () => {
+  const bundle = resolveAuthoritativeStartupResumeBundle({
+    targetPreference: "bogus",
+    currentState: {
+      target: { kind: DEV_LOOP_TARGET_KIND.ISSUE, issue: 99 },
+      ownership: DEV_LOOP_ACTOR.COPILOT,
+      nextActor: DEV_LOOP_ACTOR.COPILOT,
+      status: DEV_LOOP_STATUS.ACTIVE,
+      authorization: DEV_LOOP_AUTHORIZATION.NEEDS_CONFIRMATION,
+    },
+    issueLinkageResolution: DEV_LOOP_ISSUE_LINKAGE_RESOLUTION.RESOLVED_NO_OPEN_PR,
+    issueReadiness: DEV_LOOP_ISSUE_READINESS.READY,
+    issueAssignmentState: DEV_LOOP_ISSUE_ASSIGNMENT_STATE.ASSIGNED_TO_COPILOT,
+    artifactState: DEV_LOOP_ARTIFACT_STATE.NOT_APPLICABLE,
+    loopState: "awaiting_triage",
+  });
+
+  assert.equal(bundle.bundleKind, DEV_LOOP_STARTUP_RESUME_BUNDLE_KIND.NEEDS_RECONCILE);
+  assert.match(bundle.reason, /invalid targetPreference/i);
+  assert.match(bundle.reason, /allowed values/i);
+});


### PR DESCRIPTION
## Change summary

The `resolveAuthoritativeStartupResumeBundle` (startup resolver) was not passing the `targetPreference` variation parameter to `routeForState`, so `prefer_local` had no effect on startup/resume routing even though `evaluatePublicDevLoopRouting` already supported it.

## Scope

- `routeForState` now accepts `targetPreference` in its options
- When the selected gate is `ISSUE_INTAKE` and `targetPreference === PREFER_LOCAL`, steers routing to `LOCAL_IMPLEMENTATION` by synthesizing a `LOCAL_PHASE` canonical target from the issue
- Startup resolver normalizes and validates `targetPreference`, fails closed on invalid values
- `evaluatePublicDevLoopRouting` now includes `targetPreference` in `routingOptions` for all call sites

## Acceptance criteria

- [x] `prefer_local` routed through startup resolver → `local_implementation`
- [x] Invalid `targetPreference` values fail closed
- [x] `prefer_github_first` preserves existing `issue_intake` routing
- [x] No regressions (584 core tests pass)

## Non-goals

- Changing the `selectGateForState` logic
- Adding `prefer_local` support beyond the `ISSUE_INTAKE` gate

Tracker: #321
