### PR TITLE
Wire models.conductor into config pipeline and conductor entrypoint (#291)

### DIFF
--- a/packages/core/src/config/index.mjs
+++ b/packages/core/src/config/index.mjs
@@ -1,3 +1,4 @@
 export { DevLoopConfigSchema, BUILT_IN_DEFAULTS, FileConfigSchema } from "./schema.mjs";
 export { loadDevLoopConfig } from "./loader.mjs";
 export { resolveReviewerRole } from "./roles.mjs";
+export { resolveConductorModel } from "./model-resolution.mjs";

--- a/packages/core/src/config/model-resolution.mjs
+++ b/packages/core/src/config/model-resolution.mjs
@@ -11,9 +11,10 @@
  * @returns {string|null}
  */
 export function resolveConductorModel(config) {
-  const model = config?.models?.conductor;
-  if (typeof model === "string" && model.length > 0) {
-    return model;
+  const raw = config?.models?.conductor;
+  if (typeof raw !== "string") {
+    return null;
   }
-  return null;
+  const model = raw.trim();
+  return model.length > 0 ? model : null;
 }

--- a/packages/core/src/config/model-resolution.mjs
+++ b/packages/core/src/config/model-resolution.mjs
@@ -11,7 +11,7 @@
  * @returns {string|null}
  */
 export function resolveConductorModel(config) {
-  if (config?.models?.conductor && typeof config.models.conductor === "string" && config.models.conductor.length > 0) {
+  if (config?.models?.conductor && typeof config.models.conductor === "string" && config.models.conductor.trim().length > 0) {
     return config.models.conductor;
   }
   return null;

--- a/packages/core/src/config/model-resolution.mjs
+++ b/packages/core/src/config/model-resolution.mjs
@@ -12,7 +12,7 @@
  */
 export function resolveConductorModel(config) {
   if (config?.models?.conductor && typeof config.models.conductor === "string" && config.models.conductor.trim().length > 0) {
-    return config.models.conductor;
+    return config.models.conductor.trim();
   }
   return null;
 }

--- a/packages/core/src/config/model-resolution.mjs
+++ b/packages/core/src/config/model-resolution.mjs
@@ -11,8 +11,9 @@
  * @returns {string|null}
  */
 export function resolveConductorModel(config) {
-  if (config?.models?.conductor && typeof config.models.conductor === "string" && config.models.conductor.trim().length > 0) {
-    return config.models.conductor.trim();
+  const model = config?.models?.conductor;
+  if (typeof model === "string" && model.length > 0) {
+    return model;
   }
   return null;
 }

--- a/packages/core/src/config/model-resolution.mjs
+++ b/packages/core/src/config/model-resolution.mjs
@@ -1,0 +1,18 @@
+/**
+ * Resolve the conductor model from the merged dev-loop config.
+ *
+ * Returns the configured model string if present, or null when the config
+ * does not specify a conductor model override (caller falls back to its
+ * own built-in default).
+ *
+ * Accepts the validated DevLoopConfig from {@link loadDevLoopConfig}.
+ *
+ * @param {import("./schema.mjs").DevLoopConfig} config
+ * @returns {string|null}
+ */
+export function resolveConductorModel(config) {
+  if (config?.models?.conductor && typeof config.models.conductor === "string" && config.models.conductor.length > 0) {
+    return config.models.conductor;
+  }
+  return null;
+}

--- a/packages/core/src/config/schema.mjs
+++ b/packages/core/src/config/schema.mjs
@@ -13,13 +13,13 @@ const StrategyConfig = z.strictObject({
 
 const ModelsConfig = z.strictObject({
   conductor: z.string().trim().min(1).optional(),
-  roles: z.record(z.string(), z.string().min(1)).optional(),
+  roles: z.record(z.string(), z.string().trim().min(1)).optional(),
 });
 
 const RefinementConfig = z.strictObject({
   fanOut: z.number().int().min(1).max(10),
   mode: z.enum(["parallel", "sequential"]),
-  roles: z.array(z.string().min(1)).optional(),
+  roles: z.array(z.string().trim().min(1)).optional(),
 });
 
 const GateConfig = z.strictObject({

--- a/packages/core/src/config/schema.mjs
+++ b/packages/core/src/config/schema.mjs
@@ -12,7 +12,7 @@ const StrategyConfig = z.strictObject({
 });
 
 const ModelsConfig = z.strictObject({
-  conductor: z.string().min(1).optional(),
+  conductor: z.string().trim().min(1).optional(),
   roles: z.record(z.string(), z.string().min(1)).optional(),
 });
 

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -765,43 +765,31 @@ describe("role resolution", () => {
   });
 
   describe("conductor model resolution", () => {
-  test("resolveConductorModel returns model when present in config", () => {
-    const result = resolveConductorModel({ version: 1, models: { conductor: "gpt-5" } });
-    assert.equal(result, "gpt-5");
-  });
+    test("resolveConductorModel returns model when present in config", () => {
+      const result = resolveConductorModel({ version: 1, models: { conductor: "gpt-5" } });
+      assert.equal(result, "gpt-5");
+    });
 
-  test("resolveConductorModel returns null when models key is missing", () => {
-    const result = resolveConductorModel({ version: 1 });
-    assert.equal(result, null);
-  });
+    test("resolveConductorModel returns null when models key is missing", () => {
+      const result = resolveConductorModel({ version: 1 });
+      assert.equal(result, null);
+    });
 
-  test("resolveConductorModel returns null when models.conductor is absent", () => {
-    const result = resolveConductorModel({ version: 1, models: { roles: { security: "gpt-5" } } });
-    assert.equal(result, null);
-  });
+    test("resolveConductorModel returns null when models.conductor is absent", () => {
+      const result = resolveConductorModel({ version: 1, models: { roles: { security: "gpt-5" } } });
+      assert.equal(result, null);
+    });
 
-  test("resolveConductorModel returns null for empty string", () => {
-    const result = resolveConductorModel({ version: 1, models: { conductor: "" } });
-    assert.equal(result, null);
-  });
-
-
-  test("resolveConductorModel returns trimmed value for whitespace-padded string", () => {
-    const result = resolveConductorModel({ version: 1, models: { conductor: "  gpt-5  " } });
-    assert.equal(result, "gpt-5");
-  });
-
-  test("resolveConductorModel returns null for whitespace-only string", () => {
-    const result = resolveConductorModel({ version: 1, models: { conductor: "   " } });
-    assert.equal(result, null);
-  });
+    test("resolveConductorModel returns null for empty string", () => {
+      const result = resolveConductorModel({ version: 1, models: { conductor: "" } });
+      assert.equal(result, null);
+    });
 
 
-
-  test("resolveConductorModel returns null when models is empty object", () => {
-    const result = resolveConductorModel({ version: 1, models: {} });
-    assert.equal(result, null);
-  });
+    test("resolveConductorModel returns null when models is empty object", () => {
+      const result = resolveConductorModel({ version: 1, models: {} });
+      assert.equal(result, null);
+    });
   });
 
 });

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -785,7 +785,7 @@ describe("role resolution", () => {
     assert.equal(result, null);
   });
 
-  
+
   test("resolveConductorModel returns trimmed value for whitespace-padded string", () => {
     const result = resolveConductorModel({ version: 1, models: { conductor: "  gpt-5  " } });
     assert.equal(result, "gpt-5");

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -764,7 +764,7 @@ describe("role resolution", () => {
     assert.equal(result.model, null);
   });
 
-  // Conductor model resolution
+  describe("conductor model resolution", () => {
   test("resolveConductorModel returns model when present in config", () => {
     const result = resolveConductorModel({ version: 1, models: { conductor: "gpt-5" } });
     assert.equal(result, "gpt-5");
@@ -796,8 +796,12 @@ describe("role resolution", () => {
     assert.equal(result, null);
   });
 
+
+
   test("resolveConductorModel returns null when models is empty object", () => {
     const result = resolveConductorModel({ version: 1, models: {} });
     assert.equal(result, null);
   });
+  });
+
 });

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -785,6 +785,16 @@ describe("role resolution", () => {
       assert.equal(result, null);
     });
 
+    test("resolveConductorModel returns null for whitespace-only string", () => {
+      const result = resolveConductorModel({ version: 1, models: { conductor: "   " } });
+      assert.equal(result, null);
+    });
+
+    test("resolveConductorModel returns trimmed value for whitespace-padded string", () => {
+      const result = resolveConductorModel({ version: 1, models: { conductor: "  gpt-5  " } });
+      assert.equal(result, "gpt-5");
+    });
+
 
     test("resolveConductorModel returns null when models is empty object", () => {
       const result = resolveConductorModel({ version: 1, models: {} });

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -785,6 +785,11 @@ describe("role resolution", () => {
     assert.equal(result, null);
   });
 
+  test("resolveConductorModel returns null for whitespace-only string", () => {
+    const result = resolveConductorModel({ version: 1, models: { conductor: "   " } });
+    assert.equal(result, null);
+  });
+
   test("resolveConductorModel returns null when models is empty object", () => {
     const result = resolveConductorModel({ version: 1, models: {} });
     assert.equal(result, null);

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -785,6 +785,12 @@ describe("role resolution", () => {
     assert.equal(result, null);
   });
 
+  
+  test("resolveConductorModel returns trimmed value for whitespace-padded string", () => {
+    const result = resolveConductorModel({ version: 1, models: { conductor: "  gpt-5  " } });
+    assert.equal(result, "gpt-5");
+  });
+
   test("resolveConductorModel returns null for whitespace-only string", () => {
     const result = resolveConductorModel({ version: 1, models: { conductor: "   " } });
     assert.equal(result, null);

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -8,6 +8,7 @@ import {
   DevLoopConfigSchema,
   BUILT_IN_DEFAULTS,
 } from "../src/config/schema.mjs";
+import { resolveConductorModel } from "../src/config/model-resolution.mjs";
 // ============================================================================
 // Schema validation tests (S1–S26)
 // ============================================================================
@@ -761,5 +762,31 @@ describe("role resolution", () => {
     );
     assert.equal(result.persona, "default-reviewer");
     assert.equal(result.model, null);
+  });
+
+  // Conductor model resolution
+  test("resolveConductorModel returns model when present in config", () => {
+    const result = resolveConductorModel({ version: 1, models: { conductor: "gpt-5" } });
+    assert.equal(result, "gpt-5");
+  });
+
+  test("resolveConductorModel returns null when models key is missing", () => {
+    const result = resolveConductorModel({ version: 1 });
+    assert.equal(result, null);
+  });
+
+  test("resolveConductorModel returns null when models.conductor is absent", () => {
+    const result = resolveConductorModel({ version: 1, models: { roles: { security: "gpt-5" } } });
+    assert.equal(result, null);
+  });
+
+  test("resolveConductorModel returns null for empty string", () => {
+    const result = resolveConductorModel({ version: 1, models: { conductor: "" } });
+    assert.equal(result, null);
+  });
+
+  test("resolveConductorModel returns null when models is empty object", () => {
+    const result = resolveConductorModel({ version: 1, models: {} });
+    assert.equal(result, null);
   });
 });

--- a/scripts/loop/outer-loop.mjs
+++ b/scripts/loop/outer-loop.mjs
@@ -57,6 +57,7 @@ import {
   buildAsyncStartRejection,
   validateAsyncStartContext,
 } from "@pi-dev-loops/core/loop/async-start-contract";
+import { loadDevLoopConfig, resolveConductorModel } from "@pi-dev-loops/core/config";
 
 const USAGE = `Usage: outer-loop.mjs --repo <owner/name> --pr <number>
 
@@ -533,6 +534,14 @@ export async function runOuterLoop(options, { env = process.env, ghCommand = "gh
 
   await writeCheckpoint(checkpointDir, checkpoint);
 
+  // Resolve conductor model override from config
+  let conductorModel = null;
+  if (!copilotInputProvided && !reviewerInputProvided) {
+    // Only load real config; skip for snapshot/test input mode
+    const { config: devLoopConfig } = await loadDevLoopConfig();
+    conductorModel = resolveConductorModel(devLoopConfig);
+  }
+
   return {
     ok: true,
     outerAction,
@@ -546,6 +555,7 @@ export async function runOuterLoop(options, { env = process.env, ghCommand = "gh
     ...(branchIdentity !== null ? { branchIdentity } : {}),
     conductorRouting,
     checkpoint,
+    conductorModel,
   };
 }
 

--- a/scripts/loop/outer-loop.mjs
+++ b/scripts/loop/outer-loop.mjs
@@ -536,7 +536,7 @@ export async function runOuterLoop(options, { env = process.env, ghCommand = "gh
 
   // Resolve conductor model override from config
   let conductorModel = null;
-  if (!copilotInputProvided && !reviewerInputProvided) {
+  if (!isSnapshotMode) {
     // Only load real config; skip for snapshot/test input mode
     const { config: devLoopConfig } = await loadDevLoopConfig();
     conductorModel = resolveConductorModel(devLoopConfig);

--- a/scripts/loop/outer-loop.mjs
+++ b/scripts/loop/outer-loop.mjs
@@ -25,7 +25,9 @@
  *       "stopReason": null|"...", "handoffEnvelope": { ... } },
  *     "checkpoint": { "pr": N, "repo": "...", "outerAction": "...",
  *       "copilotState": "...", "reviewerState": "...", "reason": null|"...",
- *       "timestamp": "...", "waitCycles": N, "headSha": "..."|null } }
+ *       "timestamp": "...", "waitCycles": N, "headSha": "..."|null },
+ *     "conductorModel": "..."|null,
+ *     ...(branchIdentity for reenter actions) }
  *
  * Failure behavior:
  *   Argument/usage errors emit { "ok": false, "error": "...", "usage": "..." }
@@ -92,7 +94,8 @@ Output (stdout, JSON):
       "copilotState": "...", "reviewerState": "...",
       "reviewerScope": "...", "reviewerLogin": "..."|null,
       "reason": null|"...", "timestamp": "...", "waitCycles": N,
-      "headSha": "..."|null } }
+      "headSha": "..."|null },
+    "conductorModel": "..."|null }
 
 Outer actions:
   continue_wait          Durable outer-loop wait state; re-run after bounded wait

--- a/scripts/loop/outer-loop.mjs
+++ b/scripts/loop/outer-loop.mjs
@@ -538,8 +538,10 @@ export async function runOuterLoop(options, { env = process.env, ghCommand = "gh
   let conductorModel = null;
   if (!isSnapshotMode) {
     // Only load real config; skip for snapshot/test input mode
-    const { config: devLoopConfig } = await loadDevLoopConfig();
-    conductorModel = resolveConductorModel(devLoopConfig);
+    const { config: devLoopConfig, errors = [] } = await loadDevLoopConfig();
+    if (errors.length === 0) {
+      conductorModel = resolveConductorModel(devLoopConfig);
+    }
   }
 
   return {


### PR DESCRIPTION
## Change summary

Wire `models.conductor` from the dev-loop config pipeline into the conductor workflow entrypoint so the conductor's model is config-driven rather than hardcoded.

## Scope

- New `resolveConductorModel()` helper in `packages/core/src/config/model-resolution.mjs`
- Returns configured model string or `null` when absent/empty/whitespace
- Schema enforces `.trim().min(1)` on `models.conductor` for single-source validation
- Wired into `scripts/loop/outer-loop.mjs` — emits `conductorModel` in output
- Skips config loading in snapshot/test input mode
- Checks config load errors before applying model (fail-closed)
- 7 unit tests proving config → model selection

## Acceptance criteria

- [x] `models.conductor` overrides the conductor's model when present
- [x] Falls back to `null` (built-in default) when absent
- [x] Invalid/empty/whitespace values return `null` (fail closed)
- [x] Unit tests prove config-driven model selection

## Non-goals

- Wiring per-role model overrides (`models.roles`)
- Changing conductor behavior beyond model selection

Tracker: #291 (sub-issue of #286)
