### PR TITLE
Wire autonomy.stopAt into config pipeline and conductor entrypoint (#289)

### DIFF
--- a/packages/core/src/config/index.mjs
+++ b/packages/core/src/config/index.mjs
@@ -1,4 +1,4 @@
 export { DevLoopConfigSchema, BUILT_IN_DEFAULTS, FileConfigSchema } from "./schema.mjs";
 export { loadDevLoopConfig } from "./loader.mjs";
 export { resolveReviewerRole } from "./roles.mjs";
-export { resolveConductorModel } from "./model-resolution.mjs";
+export { resolveConductorModel, resolveAutonomyStopAt } from "./model-resolution.mjs";

--- a/packages/core/src/config/model-resolution.mjs
+++ b/packages/core/src/config/model-resolution.mjs
@@ -12,9 +12,30 @@
  */
 export function resolveConductorModel(config) {
   const raw = config?.models?.conductor;
-  if (typeof raw !== "string") {
-    return null;
+  if (typeof raw === "string" && raw.trim().length > 0) {
+    return raw.trim();
   }
-  const model = raw.trim();
-  return model.length > 0 ? model : null;
+  return null;
+}
+
+/**
+ * Resolve the autonomy stop-at list from the merged dev-loop config.
+ *
+ * Returns the set of gates that require operator confirmation. Gates not in
+ * the returned list may proceed automatically once their review conditions
+ * are satisfied.
+ *
+ * Defaults to `["merge"]` when the config does not specify `autonomy.stopAt`
+ * (the conservative built-in posture: everything auto-continues until merge).
+ *
+ * Accepts the validated DevLoopConfig from {@link loadDevLoopConfig}.
+ *
+ * @param {import("./schema.mjs").DevLoopConfig} config
+ * @returns {string[]}
+ */
+export function resolveAutonomyStopAt(config) {
+  if (config?.autonomy?.stopAt && Array.isArray(config.autonomy.stopAt) && config.autonomy.stopAt.length > 0) {
+    return [...config.autonomy.stopAt];
+  }
+  return ["merge"];
 }

--- a/packages/core/src/config/model-resolution.mjs
+++ b/packages/core/src/config/model-resolution.mjs
@@ -34,7 +34,7 @@ export function resolveConductorModel(config) {
  * @returns {string[]}
  */
 export function resolveAutonomyStopAt(config) {
-  if (config?.autonomy?.stopAt && Array.isArray(config.autonomy.stopAt) && config.autonomy.stopAt.length > 0) {
+  if (config?.autonomy?.stopAt && Array.isArray(config.autonomy.stopAt)) {
     return [...config.autonomy.stopAt];
   }
   return ["merge"];

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -8,7 +8,7 @@ import {
   DevLoopConfigSchema,
   BUILT_IN_DEFAULTS,
 } from "../src/config/schema.mjs";
-import { resolveConductorModel } from "../src/config/model-resolution.mjs";
+import { resolveConductorModel, resolveAutonomyStopAt } from "../src/config/model-resolution.mjs";
 // ============================================================================
 // Schema validation tests (S1–S26)
 // ============================================================================
@@ -799,6 +799,37 @@ describe("role resolution", () => {
     test("resolveConductorModel returns null when models is empty object", () => {
       const result = resolveConductorModel({ version: 1, models: {} });
       assert.equal(result, null);
+    });
+
+    // Autonomy stop-at resolution
+    test("resolveAutonomyStopAt returns configured gates when present", () => {
+      const result = resolveAutonomyStopAt({ version: 1, autonomy: { stopAt: ["draft-pr", "merge"] } });
+      assert.deepEqual(result, ["draft-pr", "merge"]);
+    });
+
+    test("resolveAutonomyStopAt defaults to ['merge'] when autonomy key is missing", () => {
+      const result = resolveAutonomyStopAt({ version: 1 });
+      assert.deepEqual(result, ["merge"]);
+    });
+
+    test("resolveAutonomyStopAt defaults to ['merge'] when stopAt is empty array", () => {
+      const result = resolveAutonomyStopAt({ version: 1, autonomy: { stopAt: [] } });
+      assert.deepEqual(result, ["merge"]);
+    });
+
+    test("resolveAutonomyStopAt returns new array (not reference to config)", () => {
+      const config = { version: 1, autonomy: { stopAt: ["merge"] } };
+      const result = resolveAutonomyStopAt(config);
+      result.push("draft-pr");
+      assert.deepEqual(config.autonomy.stopAt, ["merge"]);
+    });
+
+    test("resolveAutonomyStopAt returns all four gates when configured", () => {
+      const result = resolveAutonomyStopAt({
+        version: 1,
+        autonomy: { stopAt: ["refinement", "draft-pr", "pre-approval", "merge"] },
+      });
+      assert.deepEqual(result, ["refinement", "draft-pr", "pre-approval", "merge"]);
     });
   });
 

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -812,9 +812,9 @@ describe("role resolution", () => {
       assert.deepEqual(result, ["merge"]);
     });
 
-    test("resolveAutonomyStopAt defaults to ['merge'] when stopAt is empty array", () => {
+    test("resolveAutonomyStopAt returns empty array when stopAt is explicitly empty", () => {
       const result = resolveAutonomyStopAt({ version: 1, autonomy: { stopAt: [] } });
-      assert.deepEqual(result, ["merge"]);
+      assert.deepEqual(result, []);
     });
 
     test("resolveAutonomyStopAt returns new array (not reference to config)", () => {

--- a/scripts/loop/outer-loop.mjs
+++ b/scripts/loop/outer-loop.mjs
@@ -59,7 +59,7 @@ import {
   buildAsyncStartRejection,
   validateAsyncStartContext,
 } from "@pi-dev-loops/core/loop/async-start-contract";
-import { loadDevLoopConfig, resolveConductorModel } from "@pi-dev-loops/core/config";
+import { loadDevLoopConfig, resolveConductorModel, resolveAutonomyStopAt } from "@pi-dev-loops/core/config";
 
 const USAGE = `Usage: outer-loop.mjs --repo <owner/name> --pr <number>
 
@@ -539,11 +539,13 @@ export async function runOuterLoop(options, { env = process.env, ghCommand = "gh
 
   // Resolve conductor model override from config
   let conductorModel = null;
+  let autonomyStopAt = null;
   if (!isSnapshotMode) {
     // Only load real config; skip for snapshot/test input mode
     const { config: devLoopConfig, errors = [] } = await loadDevLoopConfig();
     if (errors.length === 0) {
       conductorModel = resolveConductorModel(devLoopConfig);
+      autonomyStopAt = resolveAutonomyStopAt(devLoopConfig);
     }
   }
 
@@ -561,6 +563,7 @@ export async function runOuterLoop(options, { env = process.env, ghCommand = "gh
     conductorRouting,
     checkpoint,
     conductorModel,
+    autonomyStopAt,
   };
 }
 


### PR DESCRIPTION
## Change summary

Wire `autonomy.stopAt` from the dev-loop config pipeline into the outer-loop entrypoint so which gates require operator confirmation is config-driven rather than hardcoded.

## Scope

- New `resolveAutonomyStopAt()` helper — returns configured gates or defaults to `["merge"]`
- Wired into `scripts/loop/outer-loop.mjs` alongside `conductorModel`
- 5 integration tests

## Non-goals

- Changing gate review logic — only the stop/confirmation boundary
- Auto-merge behavior — still stops at merge by default

Tracker: #289