### PR TITLE
Wire refinement and gates config into resolution helpers (#290)

### DIFF
--- a/packages/core/src/config/index.mjs
+++ b/packages/core/src/config/index.mjs
@@ -1,4 +1,4 @@
 export { DevLoopConfigSchema, BUILT_IN_DEFAULTS, FileConfigSchema } from "./schema.mjs";
 export { loadDevLoopConfig } from "./loader.mjs";
 export { resolveReviewerRole } from "./roles.mjs";
-export { resolveConductorModel, resolveAutonomyStopAt } from "./model-resolution.mjs";
+export { resolveConductorModel, resolveAutonomyStopAt, resolveRefinement, resolveGateAngles } from "./model-resolution.mjs";

--- a/packages/core/src/config/model-resolution.mjs
+++ b/packages/core/src/config/model-resolution.mjs
@@ -39,3 +39,42 @@ export function resolveAutonomyStopAt(config) {
   }
   return ["merge"];
 }
+
+/**
+ * Resolve the refinement configuration from the merged dev-loop config.
+ *
+ * Returns `{ fanOut, mode, roles }` with sensible built-in defaults
+ * (`fanOut: 3`, `mode: "parallel"`, `roles: null`).
+ *
+ * Accepts the validated DevLoopConfig from {@link loadDevLoopConfig}.
+ *
+ * @param {import("./schema.mjs").DevLoopConfig} config
+ * @returns {{ fanOut: number, mode: "parallel"|"sequential", roles: string[]|null }}
+ */
+export function resolveRefinement(config) {
+  const fanOut = config?.refinement?.fanOut ?? 3;
+  const mode = config?.refinement?.mode ?? "parallel";
+  const roles = config?.refinement?.roles && config.refinement.roles.length > 0
+    ? [...config.refinement.roles]
+    : null;
+  return { fanOut, mode, roles };
+}
+
+/**
+ * Resolve review angles for a specific gate from the merged dev-loop config.
+ *
+ * Returns the configured angle names for the given gate, or null when the
+ * config does not specify angles for that gate (caller falls back to its
+ * skill-defined defaults).
+ *
+ * @param {import("./schema.mjs").DevLoopConfig} config
+ * @param {"draft"|"preApproval"} gate
+ * @returns {string[]|null}
+ */
+export function resolveGateAngles(config, gate) {
+  const gateConfig = config?.gates?.[gate];
+  if (gateConfig?.angles && Array.isArray(gateConfig.angles) && gateConfig.angles.length > 0) {
+    return [...gateConfig.angles];
+  }
+  return null;
+}

--- a/packages/core/src/config/model-resolution.mjs
+++ b/packages/core/src/config/model-resolution.mjs
@@ -73,7 +73,7 @@ export function resolveRefinement(config) {
  */
 export function resolveGateAngles(config, gate) {
   const gateConfig = config?.gates?.[gate];
-  if (gateConfig?.angles && Array.isArray(gateConfig.angles) && gateConfig.angles.length > 0) {
+  if (gateConfig?.angles && Array.isArray(gateConfig.angles)) {
     return [...gateConfig.angles];
   }
   return null;

--- a/packages/core/src/config/model-resolution.mjs
+++ b/packages/core/src/config/model-resolution.mjs
@@ -54,7 +54,7 @@ export function resolveAutonomyStopAt(config) {
 export function resolveRefinement(config) {
   const fanOut = config?.refinement?.fanOut ?? 3;
   const mode = config?.refinement?.mode ?? "parallel";
-  const roles = config?.refinement?.roles && config.refinement.roles.length > 0
+  const roles = config?.refinement?.roles && Array.isArray(config.refinement.roles)
     ? [...config.refinement.roles]
     : null;
   return { fanOut, mode, roles };

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -877,12 +877,20 @@ describe("role resolution", () => {
       assert.deepEqual(result, ["dry", "kiss"]);
     });
 
-    test("resolveGateAngles returns null for unknown gate", () => {
+    test("resolveGateAngles returns null for missing gate config", () => {
       const result = resolveGateAngles({
         version: 1,
         gates: { draft: { angles: ["scope"], required: true } }
       }, "preApproval");
       assert.equal(result, null);
+    });
+
+    test("resolveGateAngles returns empty array when angles explicitly empty", () => {
+      const result = resolveGateAngles({
+        version: 1,
+        gates: { draft: { angles: [], required: true } }
+      }, "draft");
+      assert.deepEqual(result, []);
     });
   });
 

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -764,7 +764,7 @@ describe("role resolution", () => {
     assert.equal(result.model, null);
   });
 
-  describe("conductor model resolution", () => {
+  describe("model and config resolution", () => {
     test("resolveConductorModel returns model when present in config", () => {
       const result = resolveConductorModel({ version: 1, models: { conductor: "gpt-5" } });
       assert.equal(result, "gpt-5");
@@ -891,6 +891,20 @@ describe("role resolution", () => {
         gates: { draft: { angles: [], required: true } }
       }, "draft");
       assert.deepEqual(result, []);
+    });
+
+    test("resolveGateAngles returns new array (not reference to config)", () => {
+      const config = { version: 1, gates: { draft: { angles: ["scope"] } } };
+      const result = resolveGateAngles(config, "draft");
+      result.push("coverage");
+      assert.deepEqual(config.gates.draft.angles, ["scope"]);
+    });
+
+    test("resolveRefinement returns new roles array (not reference to config)", () => {
+      const config = { version: 1, refinement: { fanOut: 2, mode: "parallel", roles: ["security"] } };
+      const result = resolveRefinement(config);
+      result.roles.push("style");
+      assert.deepEqual(config.refinement.roles, ["security"]);
     });
   });
 

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -850,15 +850,15 @@ describe("role resolution", () => {
       assert.deepEqual(result.roles, ["security", "style"]);
     });
 
-    test("resolveRefinement returns null roles for empty array", () => {
+    test("resolveRefinement returns empty roles array when explicitly empty", () => {
       const result = resolveRefinement({ version: 1, refinement: { fanOut: 2, mode: "parallel", roles: [] } });
-      assert.equal(result.roles, null);
+      assert.deepEqual(result.roles, []);
     });
 
     // Gate angles resolution
     test("resolveGateAngles returns null when gates config is absent", () => {
       const result = resolveGateAngles({ version: 1 }, "draft");
-      assert.equal(result, null);
+      assert.deepEqual(result, null);
     });
 
     test("resolveGateAngles returns configured draft angles", () => {
@@ -882,7 +882,7 @@ describe("role resolution", () => {
         version: 1,
         gates: { draft: { angles: ["scope"], required: true } }
       }, "preApproval");
-      assert.equal(result, null);
+      assert.deepEqual(result, null);
     });
 
     test("resolveGateAngles returns empty array when angles explicitly empty", () => {

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -8,7 +8,7 @@ import {
   DevLoopConfigSchema,
   BUILT_IN_DEFAULTS,
 } from "../src/config/schema.mjs";
-import { resolveConductorModel, resolveAutonomyStopAt } from "../src/config/model-resolution.mjs";
+import { resolveConductorModel, resolveAutonomyStopAt, resolveRefinement, resolveGateAngles } from "../src/config/model-resolution.mjs";
 // ============================================================================
 // Schema validation tests (S1–S26)
 // ============================================================================
@@ -830,6 +830,59 @@ describe("role resolution", () => {
         autonomy: { stopAt: ["refinement", "draft-pr", "pre-approval", "merge"] },
       });
       assert.deepEqual(result, ["refinement", "draft-pr", "pre-approval", "merge"]);
+    });
+
+    // Refinement resolution
+    test("resolveRefinement returns defaults when config is absent", () => {
+      const result = resolveRefinement({ version: 1 });
+      assert.equal(result.fanOut, 3);
+      assert.equal(result.mode, "parallel");
+      assert.equal(result.roles, null);
+    });
+
+    test("resolveRefinement returns configured values", () => {
+      const result = resolveRefinement({
+        version: 1,
+        refinement: { fanOut: 5, mode: "sequential", roles: ["security", "style"] }
+      });
+      assert.equal(result.fanOut, 5);
+      assert.equal(result.mode, "sequential");
+      assert.deepEqual(result.roles, ["security", "style"]);
+    });
+
+    test("resolveRefinement returns null roles for empty array", () => {
+      const result = resolveRefinement({ version: 1, refinement: { fanOut: 2, mode: "parallel", roles: [] } });
+      assert.equal(result.roles, null);
+    });
+
+    // Gate angles resolution
+    test("resolveGateAngles returns null when gates config is absent", () => {
+      const result = resolveGateAngles({ version: 1 }, "draft");
+      assert.equal(result, null);
+    });
+
+    test("resolveGateAngles returns configured draft angles", () => {
+      const result = resolveGateAngles({
+        version: 1,
+        gates: { draft: { angles: ["scope", "coverage"], required: true } }
+      }, "draft");
+      assert.deepEqual(result, ["scope", "coverage"]);
+    });
+
+    test("resolveGateAngles returns configured preApproval angles", () => {
+      const result = resolveGateAngles({
+        version: 1,
+        gates: { preApproval: { angles: ["dry", "kiss"], required: false } }
+      }, "preApproval");
+      assert.deepEqual(result, ["dry", "kiss"]);
+    });
+
+    test("resolveGateAngles returns null for unknown gate", () => {
+      const result = resolveGateAngles({
+        version: 1,
+        gates: { draft: { angles: ["scope"], required: true } }
+      }, "preApproval");
+      assert.equal(result, null);
     });
   });
 


### PR DESCRIPTION
## Change summary

Add `resolveRefinement()` and `resolveGateAngles()` helpers to consume the `refinement` and `gates` config families from the dev-loop config pipeline.

## Scope

- `resolveRefinement()` — returns `{fanOut, mode, roles}` with sensible defaults
- `resolveGateAngles(config, gate)` — returns configured angles or `null`
- Exported from config index alongside existing resolution helpers
- 7 integration tests

## Non-goals

- Changing gate review logic beyond angle selection
- Adding new review angles — only consuming what's configured

Tracker: #290