### PR TITLE
Wave 1: fix stale PLAN.md bin/ reference, duplicate bootstrap step, extension/README.md dedup

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -56,7 +56,7 @@ The public entrypoint should expose user intent; internal strategy names should 
 
 ### 3. Extension and CLI surface
 
-Thin package-level UX under `extension/`, `cli/`, and `bin/` for:
+Thin package-level UX under `extension/` and `cli/` for:
 - readiness and diagnostics
 - shell access to shared deterministic helpers
 - lightweight orchestration glue that defers real mechanics to scripts/core modules

--- a/extension/README.md
+++ b/extension/README.md
@@ -101,7 +101,7 @@ Current Phase 3+ contract:
 - the package exposes `.pi/skills` through `package.json` `pi.skills` for install-based global skill loading
 - the shell CLI is exposed through `package.json` `bin.pi-dev-loops`
 - the extension syncs packaged `.pi/agents/*.agent.md` files into `~/.agents/` on `session_start` so user-level agents are available outside this repo
-- `/dev-loops install ...` and `/dev-loops update ...` are not part of the command surface; package install/update happens through `pi install` / `pi update`
+- package install/update happens through `pi install` / `pi update`
 - this phase does not yet claim a specific supported `gh` version; it only checks `gh` presence and authentication state
 - this phase does not require a separate compiled build or `dist/` pipeline
 

--- a/skills/dev-loop/templates/bootstrap-implementation-state.md
+++ b/skills/dev-loop/templates/bootstrap-implementation-state.md
@@ -19,8 +19,7 @@ If the user says **"start implementation"**:
 
 1. read `PLAN.md`
 2. load the `dev-loop` skill
-3. read `AGENTS.md` if it exists
-4. read `AGENTS.md`
+3. read `AGENTS.md`
 5. read `docs/IMPLEMENTATION_WORKFLOW.md`
 6. read the current durable phase plan under `docs/phases/` if it exists
 7. inspect `tmp/phases/` only if it exists locally and is relevant

--- a/skills/dev-loop/templates/bootstrap-implementation-state.md
+++ b/skills/dev-loop/templates/bootstrap-implementation-state.md
@@ -19,7 +19,7 @@ If the user says **"start implementation"**:
 
 1. read `PLAN.md`
 2. load the `dev-loop` skill
-3. read `AGENTS.md`
+3. read `AGENTS.md` if it exists
 4. read `docs/IMPLEMENTATION_WORKFLOW.md`
 5. read the current durable phase plan under `docs/phases/` if it exists
 6. inspect `tmp/phases/` only if it exists locally and is relevant

--- a/skills/dev-loop/templates/bootstrap-implementation-state.md
+++ b/skills/dev-loop/templates/bootstrap-implementation-state.md
@@ -20,11 +20,11 @@ If the user says **"start implementation"**:
 1. read `PLAN.md`
 2. load the `dev-loop` skill
 3. read `AGENTS.md`
-5. read `docs/IMPLEMENTATION_WORKFLOW.md`
-6. read the current durable phase plan under `docs/phases/` if it exists
-7. inspect `tmp/phases/` only if it exists locally and is relevant
-8. read this file
-9. start with the next unfinished phase only
+4. read `docs/IMPLEMENTATION_WORKFLOW.md`
+5. read the current durable phase plan under `docs/phases/` if it exists
+6. inspect `tmp/phases/` only if it exists locally and is relevant
+7. read this file
+8. start with the next unfinished phase only
 
 ## Next unfinished phase
 


### PR DESCRIPTION
## Summary

Wave 1 of epic #329. Three low-risk doc-only fixes.

## Changes

| File | Change |
|---|---|
| `PLAN.md` | Removed stale root `bin/` reference — no root `bin/` directory exists; `package.json` `bin` maps to `./cli/index.mjs` |
| `skills/dev-loop/templates/bootstrap-implementation-state.md` | Removed duplicate "read AGENTS.md" (steps 3 and 4 were identical) |
| `extension/README.md` | Deduplicated two mentions of removed `/dev-loops install`/`update` commands |

## Scope

Doc fixes only. No behavior changes, no deletions.

## Pivot from original plan

Originally planned 11-item deletion pass. Pivoted after discovering that `roles.mjs`, `resolveRefinement`, and `resolveGateAngles` are unwired config infrastructure, not dead code. Wire-up follows in #336. Presentations and thin pointer files kept per operator preference.

## Acceptance criteria

- [x] `PLAN.md` no longer references a non-existent root `bin/` directory
- [x] `bootstrap-implementation-state.md` has no duplicate step
- [x] `extension/README.md` mentions removed commands exactly once
- [x] `npm test` passes (1 pre-existing `inspect-run-viewer-managed-instance` failure unrelated)

## Non-goals

- Config wiring (→ #336)
- Module deletions
- Skill or routing changes
