### PR TITLE
Add pi-dev-loops gates CLI — print active review angles with prompts (#341)

### DIFF
--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -101,6 +101,7 @@ function buildCliUsageLines(action) {
     case "help":
     case "status":
     case "doctor":
+    case "gates":
       return ["Usage:", `- pi-dev-loops ${action}`];
     case "hide":
       return [
@@ -210,6 +211,8 @@ export async function runCli({
     case "unsupported":
       writeLines(stderr, [result.message]);
       return 1;
+    case "gates":
+      return 0;
     case "malformed": {
       const lines = [result.message, ...buildCliHelpLines()];
       if (result.usageAction) {

--- a/extension/README.md
+++ b/extension/README.md
@@ -36,6 +36,10 @@ Installing the package with `pi install git:github.com/mfittko/pi-dev-loops` exp
   - prints the concise readiness summary in shell-friendly output
 - `pi-dev-loops doctor`
   - prints the full diagnostic report in shell-friendly output
+- `pi-dev-loops gates`
+  - prints active review angles with their prompts from config
+- `/dev-loops gates`
+  - same as above, but inside the Pi extension
 - `pi-dev-loops hide`
   - is intentionally unsupported and exits non-zero with a shell-friendly stderr message because `hide` is session-local Pi UI behavior
 

--- a/extension/index.ts
+++ b/extension/index.ts
@@ -50,7 +50,7 @@ export default function (pi: ExtensionAPI, runtimeOverrides = {}) {
   });
 
   pi.registerCommand('dev-loops', {
-    description: 'Manage pi-dev-loops readiness and inspect-run local UI lifecycle: /dev-loops [help|status|doctor|hide|inspect ...]',
+    description: 'Manage pi-dev-loops readiness and inspect-run local UI lifecycle: /dev-loops [help|status|doctor|gates|hide|inspect ...]',
     handler: async (args, ctx) => {
       const result = await executeDevLoopsCommand({
         input: args,
@@ -72,6 +72,9 @@ export default function (pi: ExtensionAPI, runtimeOverrides = {}) {
             placement: 'belowEditor',
           });
           ctx.ui.notify(buildNotificationMessage(result.action as Extract<DevLoopsAction, 'doctor' | 'status'>, result.checks), 'info');
+          return;
+        case 'gates':
+          ctx.ui.notify('Gate angles printed to console. Run `pi-dev-loops gates` in a terminal to see review prompts.', 'info');
           return;
         case 'inspect_result': {
           const structuredStoppedSuccess = result.state === 'stopped'

--- a/lib/dev-loops-core.mjs
+++ b/lib/dev-loops-core.mjs
@@ -107,6 +107,7 @@ export function parseDevLoopsCommand(input, { surface = 'extension' } = {}) {
         : invalidCommand('`help` does not accept additional arguments.', 'help', tokens);
     case 'status':
     case 'doctor':
+    case 'gates':
       return extensionSurface || (rest.length === 0 && rawScope === undefined)
         ? { kind: 'action', action, tokens }
         : invalidCommand(`\`${action}\` does not accept additional arguments.`, action, tokens);
@@ -271,6 +272,11 @@ export async function executeDevLoopsCommand({ input, surface = 'extension', run
         action: parsed.action,
         checks,
       };
+    }
+    case 'gates': {
+      const { run } = await import('../scripts/loop/print-gates.mjs');
+      await run({ repoRoot: runtime.getRepoRoot ? await runtime.getRepoRoot() : process.cwd() });
+      return { kind: 'gates' };
     }
     default:
       throw new Error(`Unhandled action: ${parsed.action}`);

--- a/scripts/loop/print-gates.mjs
+++ b/scripts/loop/print-gates.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Print active gate review angles with their resolved prompts.
+ *
+ * Usage:
+ *   node scripts/loop/print-gates.mjs [--repo-root <path>]
+ *
+ * Output:
+ *   draft gate:
+ *     scope        Check whether every changed file belongs in this PR...
+ *     coverage     Check whether tests cover the changed behavior adequately...
+ *     correctness  Check whether the implementation matches the acceptance criteria...
+ *
+ *   pre-approval gate:
+ *     dry    Flag duplicated logic, repeated patterns, and copy-pasted code...
+ *     kiss   Flag over-engineering and unnecessary complexity...
+ *     ...
+ */
+import process from "node:process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { loadDevLoopConfig } from "../../packages/core/src/config/loader.mjs";
+import { resolveGateAngles } from "../../packages/core/src/config/model-resolution.mjs";
+import { resolveReviewerRole } from "../../packages/core/src/config/roles.mjs";
+
+async function run({ stdout = process.stdout, repoRoot = process.cwd() } = {}) {
+  const { config } = await loadDevLoopConfig({ repoRoot });
+
+  const gates = [
+    { name: "draft_gate", label: "draft gate", gate: "draft" },
+    { name: "pre_approval_gate", label: "pre-approval gate", gate: "preApproval" },
+  ];
+
+  for (const { label, gate } of gates) {
+    const angles = resolveGateAngles(config, gate);
+    stdout.write(`${label}:\n`);
+
+    if (!angles || angles.length === 0) {
+      stdout.write("  (no angles configured)\n\n");
+      continue;
+    }
+
+    const maxLen = Math.max(...angles.map(a => a.length));
+    for (const angle of angles) {
+      const { prompt } = resolveReviewerRole(config, angle);
+      const displayPrompt = prompt ?? "(no prompt — add to config personas)";
+      stdout.write(`  ${angle.padEnd(maxLen + 2)} ${displayPrompt}\n`);
+    }
+    stdout.write("\n");
+  }
+}
+
+const isDirectRun = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isDirectRun) {
+  run().catch(err => {
+    process.stderr.write(`${err.message}\n`);
+    process.exitCode = 1;
+  });
+}
+
+export { run };


### PR DESCRIPTION
## Summary

`pi-dev-loops gates` loads the config and prints every active gate review angle with its resolved prompt. Implementers can run it before handoff to know exactly what reviewers will check.

Closes #341.

## Changes

- `scripts/loop/print-gates.mjs`: standalone script, loads config via `loadDevLoopConfig`, resolves angles and prompts
- `lib/dev-loops-core.mjs`: add `gates` to command parser and executor
- `cli/index.mjs`: add `gates` to usage and result handler
- `extension/index.ts`: add `gates` notification in Pi extension
- `extension/README.md`: document `pi-dev-loops gates` and `/dev-loops gates`

## Example output

```
$ pi-dev-loops gates
draft gate:
  scope         Check whether every changed file belongs in this PR...
  coverage      Check whether tests cover the changed behavior adequately...
  correctness   Check whether the implementation matches the acceptance criteria...

pre-approval gate:
  dry     Flag duplicated logic, repeated patterns, and copy-pasted code...
  kiss    Flag over-engineering and unnecessary complexity...
  yagni   Flag speculative features, future-proofing...
  srp     Single Responsibility Principle: check that each module...
  soc     Separation of Concerns: flag modules that mix distinct concerns...
```

## Acceptance criteria

- `pi-dev-loops gates` prints all active draft and pre-approval angles with prompts
- Angles and prompts are resolved from config (not hardcoded)
- `/dev-loops gates` works inside the Pi extension
- `npm test` passes