### PR TITLE
Docs cross-links: symlinks for thin pointers, See Also sections (#343)

### DIFF
--- a/docs/copilot-ci-status-contract.md
+++ b/docs/copilot-ci-status-contract.md
@@ -1,10 +1,1 @@
-# Copilot PR CI/check normalization contract
-
-Canonical bundled contract:
-- `skills/docs/copilot-ci-status-contract.md`
-
-Implementation surface:
-- `@pi-dev-loops/core/loop/copilot-ci-status`
-- source file: `packages/core/src/loop/copilot-ci-status.mjs`
-
-Repo-local docs should link to the bundled `skills/docs/` contract instead of redefining CI/check interpretation rules here.
+../skills/docs/copilot-ci-status-contract.md

--- a/docs/gate-review-comment-contract.md
+++ b/docs/gate-review-comment-contract.md
@@ -140,13 +140,13 @@ required visible PR comment is confirmed posted for the current head SHA.
 
 | Contract | Relationship |
 |---|---|
-| `draft_gate` boundary | Governs the draft → ready-for-review transition in [Copilot PR Follow-up](skills/copilot-pr-followup/SKILL.md) Step 7 |
-| `pre_approval_gate` boundary | Governs final-approval readiness in [Copilot PR Follow-up](skills/copilot-pr-followup/SKILL.md) Step 7 and the narrowed [Final Approval](skills/final-approval/SKILL.md) route |
+| `draft_gate` boundary | Governs the draft → ready-for-review transition in [Copilot PR Follow-up](../skills/copilot-pr-followup/SKILL.md) Step 7 |
+| `pre_approval_gate` boundary | Governs final-approval readiness in [Copilot PR Follow-up](../skills/copilot-pr-followup/SKILL.md) Step 7 and the narrowed [Final Approval](../skills/final-approval/SKILL.md) route |
 | Local/session artifacts | These remain complementary; the visible PR comment is the minimum required auditable surface, not a replacement for all local artifacts |
 
 ## See also
 
-- [PR Lifecycle Contract](skills/docs/pr-lifecycle-contract.md) — broader lifecycle state machine
-- [Gate-Review Sub-Loop Contract](docs/gate-review-sub-loop-contract.md) — execution shape for gate review work
-- [Copilot PR Follow-up](skills/copilot-pr-followup/SKILL.md) — skill that owns gate execution
-- [Final Approval](skills/final-approval/SKILL.md) — human approval gate route
+- [PR Lifecycle Contract](../skills/docs/pr-lifecycle-contract.md) — broader lifecycle state machine
+- [Gate-Review Sub-Loop Contract](gate-review-sub-loop-contract.md) — execution shape for gate review work
+- [Copilot PR Follow-up](../skills/copilot-pr-followup/SKILL.md) — skill that owns gate execution
+- [Final Approval](../skills/final-approval/SKILL.md) — human approval gate route

--- a/docs/gate-review-comment-contract.md
+++ b/docs/gate-review-comment-contract.md
@@ -140,6 +140,13 @@ required visible PR comment is confirmed posted for the current head SHA.
 
 | Contract | Relationship |
 |---|---|
-| `draft_gate` boundary | Governs the draft → ready-for-review transition in `skills/copilot-pr-followup/SKILL.md` Step 7 |
-| `pre_approval_gate` boundary | Governs final-approval readiness in `skills/copilot-pr-followup/SKILL.md` Step 7 and the narrowed `skills/final-approval/SKILL.md` route |
+| `draft_gate` boundary | Governs the draft → ready-for-review transition in [Copilot PR Follow-up](skills/copilot-pr-followup/SKILL.md) Step 7 |
+| `pre_approval_gate` boundary | Governs final-approval readiness in [Copilot PR Follow-up](skills/copilot-pr-followup/SKILL.md) Step 7 and the narrowed [Final Approval](skills/final-approval/SKILL.md) route |
 | Local/session artifacts | These remain complementary; the visible PR comment is the minimum required auditable surface, not a replacement for all local artifacts |
+
+## See also
+
+- [PR Lifecycle Contract](skills/docs/pr-lifecycle-contract.md) — broader lifecycle state machine
+- [Gate-Review Sub-Loop Contract](docs/gate-review-sub-loop-contract.md) — execution shape for gate review work
+- [Copilot PR Follow-up](skills/copilot-pr-followup/SKILL.md) — skill that owns gate execution
+- [Final Approval](skills/final-approval/SKILL.md) — human approval gate route

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -117,3 +117,10 @@ identical; only the review angles differ.
 A clean sub-loop pass for one gate does not satisfy the other gate. Each gate requires
 its own complete sub-loop execution with its own review angles and its own visible
 gate-review comment on the PR for the reviewed head SHA.
+
+## See also
+
+- [Gate-Review Comment Contract](docs/gate-review-comment-contract.md) — visible PR comment evidence format
+- [PR Lifecycle Contract](skills/docs/pr-lifecycle-contract.md) — broader lifecycle state machine
+- [Copilot PR Follow-up](skills/copilot-pr-followup/SKILL.md) — skill that owns gate execution
+- [Local Implementation](skills/local-implementation/SKILL.md) — uses chain pattern for local phase reviews

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -120,7 +120,7 @@ gate-review comment on the PR for the reviewed head SHA.
 
 ## See also
 
-- [Gate-Review Comment Contract](docs/gate-review-comment-contract.md) — visible PR comment evidence format
-- [PR Lifecycle Contract](skills/docs/pr-lifecycle-contract.md) — broader lifecycle state machine
-- [Copilot PR Follow-up](skills/copilot-pr-followup/SKILL.md) — skill that owns gate execution
-- [Local Implementation](skills/local-implementation/SKILL.md) — uses chain pattern for local phase reviews
+- [Gate-Review Comment Contract](gate-review-comment-contract.md) — visible PR comment evidence format
+- [PR Lifecycle Contract](../skills/docs/pr-lifecycle-contract.md) — broader lifecycle state machine
+- [Copilot PR Follow-up](../skills/copilot-pr-followup/SKILL.md) — skill that owns gate execution
+- [Local Implementation](../skills/local-implementation/SKILL.md) — uses chain pattern for local phase reviews

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,5 +37,6 @@ Start here for repository documentation.
 ## Canonical-owner pointers
 
 - `docs/lib-vs-packages-core-boundary.md` — ownership boundary between `lib/`, `packages/core/`, and `scripts/_core-helpers.mjs`
-- `docs/outer-loop-state-graph.md` points to `docs/conductor-routing-contract.md`
-- `docs/tracker-first-mvp-state-graph.md` points to `docs/tracker-story-pr-contract.md`
+- `docs/outer-loop-state-graph.md` → `docs/conductor-routing-contract.md` (symlink)
+- `docs/tracker-first-mvp-state-graph.md` → `docs/tracker-story-pr-contract.md` (symlink)
+- `docs/copilot-ci-status-contract.md` → `skills/docs/copilot-ci-status-contract.md` (symlink)

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,6 @@ Start here for repository documentation.
 ## See also
 
 - [README](../README.md) — repo overview and workflow posture
-- [Extension README](extension/README.md) — command surface, package install, and configuration
-- [Dev Loop Contract](skills/docs/public-dev-loop-contract.md) — canonical routing contract
+- [Extension README](../extension/README.md) — command surface, package install, and configuration
+- [Dev Loop Contract](../skills/docs/public-dev-loop-contract.md) — canonical routing contract
 - [AGENTS.md](../AGENTS.md) — repo working agreement

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,3 +40,10 @@ Start here for repository documentation.
 - `docs/outer-loop-state-graph.md` → `docs/conductor-routing-contract.md` (symlink)
 - `docs/tracker-first-mvp-state-graph.md` → `docs/tracker-story-pr-contract.md` (symlink)
 - `docs/copilot-ci-status-contract.md` → `skills/docs/copilot-ci-status-contract.md` (symlink)
+
+## See also
+
+- [README](../README.md) — repo overview and workflow posture
+- [Extension README](extension/README.md) — command surface, package install, and configuration
+- [Dev Loop Contract](skills/docs/public-dev-loop-contract.md) — canonical routing contract
+- [AGENTS.md](../AGENTS.md) — repo working agreement

--- a/docs/outer-loop-state-graph.md
+++ b/docs/outer-loop-state-graph.md
@@ -1,9 +1,1 @@
-# Outer Loop State Graph
-
-This file is a thin pointer.
-
-The canonical outer-loop routing authority is:
-
-- `docs/conductor-routing-contract.md`
-
-Use that contract for current runtime semantics (`ROUTING_OUTCOME`, routing priority, handoff envelope, fail-closed behavior, and ownership-aware routing semantics).
+conductor-routing-contract.md

--- a/docs/tracker-first-mvp-state-graph.md
+++ b/docs/tracker-first-mvp-state-graph.md
@@ -1,9 +1,1 @@
-# Tracker-First MVP State + Artifact Graph
-
-This file is a thin pointer.
-
-The canonical tracker-first contract is:
-
-- `docs/tracker-story-pr-contract.md`
-
-That contract owns the current MVP invariant, source-of-truth ownership, projection semantics, reverse-sync contract, state machine, and scope boundaries.
+tracker-story-pr-contract.md

--- a/test/copilot-review-doc-contracts.test.mjs
+++ b/test/copilot-review-doc-contracts.test.mjs
@@ -203,10 +203,44 @@ test("tracker-first MVP state graph symlinks to canonical tracker story-PR contr
   const skillContent = await readRepo("skills/copilot-pr-followup/SKILL.md");
 
   // Symlink resolves to tracker-story-pr-contract.md content
-  assert.match(content, /canonical tracker-first contract/i);
-  assert.match(content, /deterministic pr lifecycle/i);
+  assert.match(content, /Tracker-First Story-to-PR Contract/i);
+  assert.match(content, /MVP invariant: one tracker work item → one GitHub PR/i);
 
   assert.match(skillContent, /inherits[\s\S]*source-of-truth ownership[\s\S]*work item <-> PR link[\s\S]*reverse-sync semantics from\s*`#21`/i);
+});
+
+test("new See Also markdown links resolve from docs files", async () => {
+  const linkTargetsByDoc = {
+    "docs/gate-review-comment-contract.md": [
+      "../skills/copilot-pr-followup/SKILL.md",
+      "../skills/final-approval/SKILL.md",
+      "../skills/docs/pr-lifecycle-contract.md",
+      "gate-review-sub-loop-contract.md",
+    ],
+    "docs/gate-review-sub-loop-contract.md": [
+      "gate-review-comment-contract.md",
+      "../skills/docs/pr-lifecycle-contract.md",
+      "../skills/copilot-pr-followup/SKILL.md",
+      "../skills/local-implementation/SKILL.md",
+    ],
+    "docs/index.md": [
+      "../README.md",
+      "../extension/README.md",
+      "../skills/docs/public-dev-loop-contract.md",
+      "../AGENTS.md",
+    ],
+  };
+
+  for (const [docPath, targets] of Object.entries(linkTargetsByDoc)) {
+    const doc = await readRepo(docPath);
+    for (const target of targets) {
+      assert.match(doc, new RegExp(`\\]\\(${target.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\)`));
+      const docDir = docPath.slice(0, docPath.lastIndexOf("/") + 1);
+      const targetUrl = new URL(target, fromRepoRoot(docDir));
+      const targetStat = await stat(targetUrl);
+      assert.ok(targetStat.isFile(), `${docPath} should link to existing file ${target}`);
+    }
+  }
 });
 
 test("docs index separates active docs, archived history, and presentations", async () => {

--- a/test/copilot-review-doc-contracts.test.mjs
+++ b/test/copilot-review-doc-contracts.test.mjs
@@ -198,13 +198,21 @@ test("public dev-loop agent is a thin executable entrypoint that defers to the p
   assert.match(skillContent, /public `dev-loop` façade/i);
 });
 
-test("tracker-first MVP state graph symlinks to canonical tracker story-PR contract", async () => {
-  const content = await readRepo("docs/tracker-first-mvp-state-graph.md");
-  const skillContent = await readRepo("skills/copilot-pr-followup/SKILL.md");
+test("thin pointer docs symlink to canonical contract content", async () => {
+  const [trackerContent, conductorContent, ciContent, skillContent] = await Promise.all([
+    readRepo("docs/tracker-first-mvp-state-graph.md"),
+    readRepo("docs/outer-loop-state-graph.md"),
+    readRepo("docs/copilot-ci-status-contract.md"),
+    readRepo("skills/copilot-pr-followup/SKILL.md"),
+  ]);
 
-  // Symlink resolves to tracker-story-pr-contract.md content
-  assert.match(content, /Tracker-First Story-to-PR Contract/i);
-  assert.match(content, /MVP invariant: one tracker work item → one GitHub PR/i);
+  // Symlink reads resolve to each canonical target's content.
+  assert.match(trackerContent, /Tracker-First Story-to-PR Contract/i);
+  assert.match(trackerContent, /MVP invariant: one tracker work item → one GitHub PR/i);
+  assert.match(conductorContent, /Conductor Routing Contract/i);
+  assert.match(conductorContent, /conductor routing contract/i);
+  assert.match(ciContent, /Copilot PR CI\/check normalization contract/i);
+  assert.match(ciContent, /canonical bundled contract/i);
 
   assert.match(skillContent, /inherits[\s\S]*source-of-truth ownership[\s\S]*work item <-> PR link[\s\S]*reverse-sync semantics from\s*`#21`/i);
 });

--- a/test/copilot-review-doc-contracts.test.mjs
+++ b/test/copilot-review-doc-contracts.test.mjs
@@ -198,13 +198,13 @@ test("public dev-loop agent is a thin executable entrypoint that defers to the p
   assert.match(skillContent, /public `dev-loop` façade/i);
 });
 
-test("tracker-first MVP state graph is a thin pointer to the canonical tracker story-PR contract", async () => {
+test("tracker-first MVP state graph symlinks to canonical tracker story-PR contract", async () => {
   const content = await readRepo("docs/tracker-first-mvp-state-graph.md");
   const skillContent = await readRepo("skills/copilot-pr-followup/SKILL.md");
 
-  assert.match(content, /thin pointer/i);
+  // Symlink resolves to tracker-story-pr-contract.md content
   assert.match(content, /canonical tracker-first contract/i);
-  assert.match(content, /docs\/tracker-story-pr-contract\.md/i);
+  assert.match(content, /deterministic pr lifecycle/i);
 
   assert.match(skillContent, /inherits[\s\S]*source-of-truth ownership[\s\S]*work item <-> PR link[\s\S]*reverse-sync semantics from\s*`#21`/i);
 });


### PR DESCRIPTION
## Summary

Replaces thin pointer files with symlinks and adds navigable "See also" sections to key contract docs. Previously, docs used inline backtick references (`doc.md`) which aren't clickable in rendered markdown — 0 navigable links across 25+ files.

Refs #343. This is a bounded first slice focused on symlinked thin pointers and selected high-value See Also sections; it does not close the full all-contract-doc cross-linking issue.

## Changes

### Symlinks replace thin pointer files
- `docs/outer-loop-state-graph.md` → `conductor-routing-contract.md`
- `docs/tracker-first-mvp-state-graph.md` → `tracker-story-pr-contract.md`
- `docs/copilot-ci-status-contract.md` → `../skills/docs/copilot-ci-status-contract.md`

### See Also sections added
- `gate-review-comment-contract.md`
- `gate-review-sub-loop-contract.md`
- `docs/index.md`

### Test updates
- Updated doc-contract test for symlink resolution

## Acceptance criteria

- Thin pointer files replaced with symlinks — navigation works in GitHub and locally
- Key contract docs have See Also sections with proper markdown links
- `npm test` passes
- All existing references to thin pointer file paths still resolve correctly


## Non-goals

- Completing See Also sections for every contract doc listed in #343.
- Closing #343 in this slice.
