### PR TITLE
Add configurable max Copilot review rounds (default 5) (#361)

### DIFF
--- a/.pi/dev-loop/defaults.yaml
+++ b/.pi/dev-loop/defaults.yaml
@@ -8,6 +8,7 @@ strategy:
 refinement:
   fanOut: 3
   mode: parallel
+  maxCopilotRounds: 5
   roles:
     - scope
     - coverage

--- a/packages/core/src/config/index.mjs
+++ b/packages/core/src/config/index.mjs
@@ -1,4 +1,4 @@
 export { DevLoopConfigSchema, BUILT_IN_DEFAULTS, FileConfigSchema } from "./schema.mjs";
 export { loadDevLoopConfig } from "./loader.mjs";
 export { resolveReviewerRole } from "./roles.mjs";
-export { resolveConductorModel, resolveAutonomyStopAt, resolveRefinement, resolveGateAngles } from "./model-resolution.mjs";
+export { resolveConductorModel, resolveAutonomyStopAt, resolveRefinementConfig, resolveRefinement, resolveGateAngles } from "./model-resolution.mjs";

--- a/packages/core/src/config/model-resolution.mjs
+++ b/packages/core/src/config/model-resolution.mjs
@@ -40,24 +40,62 @@ export function resolveAutonomyStopAt(config) {
   return ["merge"];
 }
 
+const DEFAULT_REFINEMENT_CONFIG = Object.freeze({
+  fanOut: 3,
+  mode: "parallel",
+  maxCopilotRounds: 5,
+});
+
+/**
+ * Resolve one refinement configuration value from the merged dev-loop config.
+ *
+ * Returns the configured value when present, or the built-in default for the
+ * requested key.
+ *
+ * @param {import("./schema.mjs").DevLoopConfig} config
+ * @param {"fanOut"|"mode"|"roles"|"maxCopilotRounds"} key
+ * @returns {number|"parallel"|"sequential"|string[]|null}
+ */
+export function resolveRefinementConfig(config, key) {
+  if (key === "roles") {
+    return config?.refinement?.roles && Array.isArray(config.refinement.roles)
+      ? [...config.refinement.roles]
+      : null;
+  }
+
+  if (key === "fanOut") {
+    return config?.refinement?.fanOut ?? DEFAULT_REFINEMENT_CONFIG.fanOut;
+  }
+
+  if (key === "mode") {
+    return config?.refinement?.mode ?? DEFAULT_REFINEMENT_CONFIG.mode;
+  }
+
+  if (key === "maxCopilotRounds") {
+    return config?.refinement?.maxCopilotRounds ?? DEFAULT_REFINEMENT_CONFIG.maxCopilotRounds;
+  }
+
+  throw new Error(`Unknown refinement config key: ${key}`);
+}
+
 /**
  * Resolve the refinement configuration from the merged dev-loop config.
  *
- * Returns `{ fanOut, mode, roles }` with sensible built-in defaults
- * (`fanOut: 3`, `mode: "parallel"`, `roles: null`).
+ * Returns `{ fanOut, mode, roles, maxCopilotRounds }` with sensible built-in
+ * defaults (`fanOut: 3`, `mode: "parallel"`, `roles: null`,
+ * `maxCopilotRounds: 5`).
  *
  * Accepts the validated DevLoopConfig from {@link loadDevLoopConfig}.
  *
  * @param {import("./schema.mjs").DevLoopConfig} config
- * @returns {{ fanOut: number, mode: "parallel"|"sequential", roles: string[]|null }}
+ * @returns {{ fanOut: number, mode: "parallel"|"sequential", roles: string[]|null, maxCopilotRounds: number }}
  */
 export function resolveRefinement(config) {
-  const fanOut = config?.refinement?.fanOut ?? 3;
-  const mode = config?.refinement?.mode ?? "parallel";
-  const roles = config?.refinement?.roles && Array.isArray(config.refinement.roles)
-    ? [...config.refinement.roles]
-    : null;
-  return { fanOut, mode, roles };
+  const fanOut = /** @type {number} */ (resolveRefinementConfig(config, "fanOut"));
+  const mode = /** @type {"parallel"|"sequential"} */ (resolveRefinementConfig(config, "mode"));
+  const roles = /** @type {string[]|null} */ (resolveRefinementConfig(config, "roles"));
+  const maxCopilotRounds = /** @type {number} */ (resolveRefinementConfig(config, "maxCopilotRounds"));
+  return { fanOut, mode, roles, maxCopilotRounds };
 }
 
 /**

--- a/packages/core/src/config/model-resolution.mjs
+++ b/packages/core/src/config/model-resolution.mjs
@@ -1,3 +1,5 @@
+import { BUILT_IN_DEFAULTS } from "./schema.mjs";
+
 /**
  * Resolve the conductor model from the merged dev-loop config.
  *
@@ -40,11 +42,7 @@ export function resolveAutonomyStopAt(config) {
   return ["merge"];
 }
 
-const DEFAULT_REFINEMENT_CONFIG = Object.freeze({
-  fanOut: 3,
-  mode: "parallel",
-  maxCopilotRounds: 5,
-});
+const DEFAULT_REFINEMENT_CONFIG = BUILT_IN_DEFAULTS.refinement;
 
 /**
  * Resolve one refinement configuration value from the merged dev-loop config.

--- a/packages/core/src/config/schema.mjs
+++ b/packages/core/src/config/schema.mjs
@@ -3,8 +3,9 @@ import { z } from "zod";
 // ============================================================================
 // Sub-schemas
 //
-// No field-level defaults. BUILT_IN_DEFAULTS is the single source of truth
-// for all default values. The loader populates missing families from it.
+// BUILT_IN_DEFAULTS remains the canonical shipped default surface for loader
+// fallbacks. Select field-level defaults may still exist where merged-schema
+// callers need a stable value even when they construct config objects directly.
 // ============================================================================
 
 const StrategyConfig = z.strictObject({
@@ -19,6 +20,7 @@ const ModelsConfig = z.strictObject({
 const RefinementConfig = z.strictObject({
   fanOut: z.number().int().min(1).max(10),
   mode: z.enum(["parallel", "sequential"]),
+  maxCopilotRounds: z.number().int().positive().default(5),
   roles: z.array(z.string().trim().min(1)).optional(),
 });
 
@@ -77,7 +79,7 @@ export const BUILT_IN_DEFAULTS = Object.freeze({
   version: 1,
   strategy: Object.freeze({ default: "github-first" }),
   models: Object.freeze({}),
-  refinement: Object.freeze({ fanOut: 3, mode: "parallel" }),
+  refinement: Object.freeze({ fanOut: 3, mode: "parallel", maxCopilotRounds: 5 }),
   gates: Object.freeze({}),
   autonomy: Object.freeze({ stopAt: Object.freeze(["merge"]) }),
   personas: Object.freeze({}),

--- a/packages/core/src/github/copilot-helpers.mjs
+++ b/packages/core/src/github/copilot-helpers.mjs
@@ -244,11 +244,16 @@ export function summarizeCopilotReviews(reviews, { headSha } = {}) {
   let hasPendingReviewOnCurrentHead = false;
   let hasSubmittedReviewOnCurrentHead = false;
   let latestSubmittedReviewOnCurrentHeadAt = null;
+  let completedCopilotReviewRounds = 0;
 
   for (const review of copilotReviews) {
     const state = typeof review?.state === "string" ? review.state.toUpperCase() : "";
     const reviewCommitSha = extractReviewCommitSha(review);
     const reviewOnCurrentHead = headSha !== null && reviewCommitSha === headSha;
+
+    if (SUBMITTED_REVIEW_STATES.has(state)) {
+      completedCopilotReviewRounds += 1;
+    }
 
     if (!reviewOnCurrentHead) {
       continue;
@@ -275,6 +280,7 @@ export function summarizeCopilotReviews(reviews, { headSha } = {}) {
       .filter((id) => id !== null && id !== undefined)
       .map((id) => String(id)),
     copilotReviewPresent: copilotReviews.length > 0,
+    completedCopilotReviewRounds,
     hasPendingReviewOnCurrentHead,
     hasSubmittedReviewOnCurrentHead,
     latestSubmittedReviewOnCurrentHeadAt,

--- a/packages/core/src/loop/copilot-loop-state.mjs
+++ b/packages/core/src/loop/copilot-loop-state.mjs
@@ -131,6 +131,7 @@ export function buildSnapshotFromPrFacts({
   copilotReviewOnCurrentHead = false,
   unresolvedThreadCount = 0,
   actionableThreadCount = 0,
+  copilotReviewRoundCount = 0,
   ciStatus,
 }) {
   const prState = typeof prData?.state === "string" ? prData.state.toUpperCase() : "OPEN";
@@ -148,6 +149,7 @@ export function buildSnapshotFromPrFacts({
     copilotReviewOnCurrentHead,
     unresolvedThreadCount,
     actionableThreadCount,
+    copilotReviewRoundCount,
     ciStatus: ciStatus ?? normalizeCiStatus(prData?.statusCheckRollup),
   });
 }
@@ -180,6 +182,7 @@ function isAutoRerequestEligible(snapshot, state) {
  *     review-request lifecycle is settled, so callers must still check request-state fields
  * - unresolvedThreadCount {number} — total unresolved review-thread count
  * - actionableThreadCount {number} — unresolved threads with non-bot actionable comments
+ * - copilotReviewRoundCount {number} — completed Copilot review rounds observed on the PR
  * - ciStatus {"success"|"failure"|"pending"|"none"} — current CI check rollup status
  * - agentFixStatus {"applied"|null} — agent-provided input: "applied" when code has been fixed
  *
@@ -213,6 +216,9 @@ export function normalizeSnapshot(raw) {
       : 0,
     actionableThreadCount: typeof raw.actionableThreadCount === "number" && raw.actionableThreadCount >= 0
       ? Math.floor(raw.actionableThreadCount)
+      : 0,
+    copilotReviewRoundCount: typeof raw.copilotReviewRoundCount === "number" && raw.copilotReviewRoundCount >= 0
+      ? Math.floor(raw.copilotReviewRoundCount)
       : 0,
     ciStatus: VALID_CI_STATUSES.has(raw.ciStatus) ? raw.ciStatus : "none",
     agentFixStatus: raw.agentFixStatus === "applied" ? "applied" : null,

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -8,7 +8,7 @@ import {
   DevLoopConfigSchema,
   BUILT_IN_DEFAULTS,
 } from "../src/config/schema.mjs";
-import { resolveConductorModel, resolveAutonomyStopAt, resolveRefinement, resolveGateAngles } from "../src/config/model-resolution.mjs";
+import { resolveConductorModel, resolveAutonomyStopAt, resolveRefinementConfig, resolveRefinement, resolveGateAngles } from "../src/config/model-resolution.mjs";
 // ============================================================================
 // Schema validation tests (S1–S26)
 // ============================================================================
@@ -151,6 +151,14 @@ describe("schema validation", () => {
     assert.ok(!result.success);
   });
 
+  test("S17b: refinement.maxCopilotRounds must be a positive integer", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      refinement: { fanOut: 3, mode: "parallel", maxCopilotRounds: 0 },
+    });
+    assert.ok(!result.success);
+  });
+
   test("S18: autonomy.stopAt contains unknown gate name", () => {
     const result = DevLoopConfigSchema.safeParse({
       version: 1,
@@ -246,9 +254,10 @@ describe("BUILT_IN_DEFAULTS", () => {
     assert.equal(BUILT_IN_DEFAULTS.strategy.default, "github-first");
   });
 
-  test("refinement.fanOut is 3 and mode is parallel", () => {
+  test("refinement defaults include fanOut 3, mode parallel, and maxCopilotRounds 5", () => {
     assert.equal(BUILT_IN_DEFAULTS.refinement.fanOut, 3);
     assert.equal(BUILT_IN_DEFAULTS.refinement.mode, "parallel");
+    assert.equal(BUILT_IN_DEFAULTS.refinement.maxCopilotRounds, 5);
   });
 
   test("autonomy.stopAt is [merge]", () => {
@@ -410,7 +419,28 @@ describe("loader — graceful degradation", () => {
       assert.equal(result.config.strategy.default, "local-first");
       assert.deepEqual(result.config.gates.draft.angles, ["scope", "coverage"]);
       assert.equal(result.config.personas.scope.prompt, "Check scope");
+      assert.equal(result.config.refinement.maxCopilotRounds, 5);
       assert.equal(result.warnings.length, 0);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("Y1b: loader fills default maxCopilotRounds when refinement omits it", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-max-rounds-default-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(path.join(piDir, "defaults.yaml"), [
+        "version: 1",
+        "refinement:",
+        "  fanOut: 2",
+        "  mode: parallel",
+      ].join("\n"));
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.equal(result.errors.length, 0);
+      assert.equal(result.config.refinement.maxCopilotRounds, 5);
     } finally {
       await rm(tmpDir, { recursive: true, force: true });
     }
@@ -1057,21 +1087,31 @@ describe("role resolution", () => {
       assert.equal(result.fanOut, 3);
       assert.equal(result.mode, "parallel");
       assert.equal(result.roles, null);
+      assert.equal(result.maxCopilotRounds, 5);
     });
 
     test("resolveRefinement returns configured values", () => {
       const result = resolveRefinement({
         version: 1,
-        refinement: { fanOut: 5, mode: "sequential", roles: ["security", "style"] }
+        refinement: { fanOut: 5, mode: "sequential", maxCopilotRounds: 7, roles: ["security", "style"] }
       });
       assert.equal(result.fanOut, 5);
       assert.equal(result.mode, "sequential");
+      assert.equal(result.maxCopilotRounds, 7);
       assert.deepEqual(result.roles, ["security", "style"]);
     });
 
     test("resolveRefinement returns empty roles array when explicitly empty", () => {
       const result = resolveRefinement({ version: 1, refinement: { fanOut: 2, mode: "parallel", roles: [] } });
       assert.deepEqual(result.roles, []);
+    });
+
+    test("resolveRefinementConfig resolves maxCopilotRounds with a default of 5", () => {
+      assert.equal(resolveRefinementConfig({ version: 1 }, "maxCopilotRounds"), 5);
+      assert.equal(resolveRefinementConfig({
+        version: 1,
+        refinement: { fanOut: 3, mode: "parallel", maxCopilotRounds: 9 },
+      }, "maxCopilotRounds"), 9);
     });
 
     // Gate angles resolution

--- a/packages/core/test/copilot-loop-state.test.mjs
+++ b/packages/core/test/copilot-loop-state.test.mjs
@@ -35,6 +35,7 @@ test("normalizeSnapshot returns safe defaults for an empty object", () => {
     copilotReviewOnCurrentHead: false,
     unresolvedThreadCount: 0,
     actionableThreadCount: 0,
+    copilotReviewRoundCount: 0,
     ciStatus: "none",
     agentFixStatus: null,
   });
@@ -92,6 +93,14 @@ test("normalizeSnapshot floors fractional thread counts and rejects negatives", 
   const negative = normalizeSnapshot({ unresolvedThreadCount: -1, actionableThreadCount: -2 });
   assert.equal(negative.unresolvedThreadCount, 0);
   assert.equal(negative.actionableThreadCount, 0);
+});
+
+test("normalizeSnapshot floors copilotReviewRoundCount and rejects negatives", () => {
+  const fractional = normalizeSnapshot({ copilotReviewRoundCount: 3.9 });
+  assert.equal(fractional.copilotReviewRoundCount, 3);
+
+  const negative = normalizeSnapshot({ copilotReviewRoundCount: -1 });
+  assert.equal(negative.copilotReviewRoundCount, 0);
 });
 
 test("normalizeSnapshot accepts all valid ciStatus values", () => {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -392,6 +392,7 @@ Snapshot schema (`--input` mode or `snapshot` field in success output):
 - `copilotReviewOnCurrentHead` {boolean} — whether a submitted (non-PENDING) Copilot review exists for the current head commit
 - `unresolvedThreadCount` {number} — total unresolved review-thread count
 - `actionableThreadCount` {number} — unresolved threads with non-bot actionable comments
+- `copilotReviewRoundCount` {number} — completed Copilot review rounds observed on the PR
 - `ciStatus` {"success"|"failure"|"pending"|"none"} — contract-owned current-head CI/check rollup
   from [Copilot CI Status Contract](../skills/docs/copilot-ci-status-contract.md); `none` means no usable readiness signal yet
 - `agentFixStatus` {"applied"|null} — agent-provided: "applied" when code has been fixed

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -142,6 +142,7 @@ function parseReviewsPayload(text) {
     copilotReviewPresent: reviewSummary.copilotReviewPresent,
     hasCopilotPendingReviewOnCurrentHead: reviewSummary.hasPendingReviewOnCurrentHead,
     hasCopilotSubmittedReviewOnCurrentHead: reviewSummary.hasSubmittedReviewOnCurrentHead,
+    completedCopilotReviewRounds: reviewSummary.completedCopilotReviewRounds,
   };
 }
 
@@ -186,6 +187,7 @@ async function fetchCopilotReviewState(options, runtime) {
     copilotReviewPresent: reviews.copilotReviewPresent,
     hasPendingReviewOnCurrentHead: reviews.hasCopilotPendingReviewOnCurrentHead,
     hasSubmittedReviewOnCurrentHead: reviews.hasCopilotSubmittedReviewOnCurrentHead,
+    completedCopilotReviewRounds: reviews.completedCopilotReviewRounds,
   };
 }
 
@@ -220,6 +222,7 @@ async function detectSameHeadCleanConvergence(options, runtime, priorReviewState
       copilotReviewOnCurrentHead: hasSubmittedReviewOnCurrentHead,
       unresolvedThreadCount: parsedThreads.summary.unresolvedThreads,
       actionableThreadCount: parsedThreads.summary.actionableThreads,
+      copilotReviewRoundCount: priorReviewState.completedCopilotReviewRounds ?? 0,
     });
     const interpretation = interpretLoopState(snapshot);
     return interpretation.sameHeadCleanConverged;

--- a/scripts/loop/detect-copilot-loop-state.mjs
+++ b/scripts/loop/detect-copilot-loop-state.mjs
@@ -34,7 +34,7 @@
  * Success output shape (no steering file):
  *   {
  *     "ok": true,
- *     "snapshot": { ... },
+ *     "snapshot": { ..., "copilotReviewRoundCount": N },
  *     "state": "...",
  *     "allowedTransitions": [...],
  *     "nextAction": "...",
@@ -45,7 +45,7 @@
  *   }
  *
  * Success output shape (with steering file):
- *   { "ok": true, "snapshot": { ... }, "state": "...", "allowedTransitions": [...], "nextAction": "...",
+ *   { "ok": true, "snapshot": { ..., "copilotReviewRoundCount": N }, "state": "...", "allowedTransitions": [...], "nextAction": "...",
  *     "autoRerequestEligible": true|false, "sameHeadCleanConverged": true|false,
  *     "loopDisposition": "...", "terminal": true|false,
  *     "steeringApplied": true|false,
@@ -131,7 +131,7 @@ Optional (auto-detect mode only):
                                              Values: requested|already-requested|unavailable|none|failed
 
 Output (stdout, JSON):
-  { "ok": true, "snapshot": {...}, "state": "...", "allowedTransitions": [...], "nextAction": "...",
+  { "ok": true, "snapshot": {..., "copilotReviewRoundCount": N}, "state": "...", "allowedTransitions": [...], "nextAction": "...",
     "autoRerequestEligible": true|false, "sameHeadCleanConverged": true|false,
     "loopDisposition": "...", "terminal": true|false }
 
@@ -498,6 +498,7 @@ export async function autoDetectSnapshot({ repo, pr, reviewRequestStatusOverride
     copilotReviewOnCurrentHead: reviewSummary.hasSubmittedReviewOnCurrentHead,
     unresolvedThreadCount,
     actionableThreadCount,
+    copilotReviewRoundCount: reviewSummary.completedCopilotReviewRounds,
     ciStatus: currentHeadCiStatus,
   });
 }

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -190,6 +190,7 @@ export async function loadPrGateCoordinationContext(options, runtime = {}) {
     copilotReviewOnCurrentHead: reviewSummary.hasSubmittedReviewOnCurrentHead,
     unresolvedThreadCount: parsedThreads.summary.unresolvedThreads,
     actionableThreadCount: parsedThreads.summary.actionableThreads,
+    copilotReviewRoundCount: reviewSummary.completedCopilotReviewRounds,
   });
 
   const interpretation = interpretLoopState(snapshot);

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -701,7 +701,11 @@ When actionable review feedback exists, use a narrow follow-up loop:
 10. after completing reply/resolve for a pass, verify `unresolvedThreadCount === 0` via `capture-review-threads.mjs` before proceeding
    - if the refreshed snapshot reports a non-zero unresolved thread count, re-enter the reply/resolve loop for the missed threads
 11. only after GitHub-side reply/resolve work is done for the addressed threads and the refreshed thread snapshot proves `unresolvedThreadCount === 0`, decide whether another Copilot pass is desired
-   - if yes, run the smallest honest local validation for the accepted fix scope
+   - resolve the review-round cap from config via `resolveRefinementConfig(config, "maxCopilotRounds")` from `@pi-dev-loops/core/config`; default config ships `maxCopilotRounds: 5`
+   - use `snapshot.copilotReviewRoundCount` from `detect-copilot-loop-state.mjs` / `copilot-pr-handoff.mjs` as the completed Copilot review-round count for the current PR
+   - if `snapshot.copilotReviewRoundCount >= maxCopilotRounds`, do **not** re-request Copilot review
+   - when the round cap is reached, reply-resolve any remaining intentionally deferred threads with a short `deferred to follow-up` note, then stop and report that the Copilot round limit was reached
+   - if yes and the round cap has not been reached, run the smallest honest local validation for the accepted fix scope
    - if that local validation is still known red, continue remediation instead of re-requesting Copilot
    - after a fix push advances the PR head SHA, treat previous-head CI evidence as stale for any CI-dependent follow-up decision
    - refresh/re-read current-head CI/check data before advancing and apply the contract in [Copilot CI Status Contract](../docs/copilot-ci-status-contract.md) (wait for `pending`/`none`, stop for `failure`, proceed only on `success`)

--- a/test/copilot-review-doc-contracts.test.mjs
+++ b/test/copilot-review-doc-contracts.test.mjs
@@ -171,6 +171,21 @@ test("copilot-pr-followup skill hardens reply-resolve, gate sequencing, and merg
   assert.match(antiPatterns, /dispatch an async dev-loop task that omits the pre-approval gate requirement/i);
 });
 
+test("copilot-pr-followup skill caps Copilot re-review rounds via config and snapshot state", async () => {
+  const skillContent = await readRepo("skills/copilot-pr-followup/SKILL.md");
+
+  const step7Match = skillContent.match(/## Step 7: Pi review\/fix follow-up loop[\s\S]*?(?=\n## Validation policy|$)/);
+  const step7 = step7Match ? step7Match[0] : "";
+  assert.ok(step7.length > 0, "copilot-pr-followup Step 7 section not found");
+
+  assert.match(step7, /resolveRefinementConfig\(config, "maxCopilotRounds"\)/i);
+  assert.match(step7, /default config ships `maxCopilotRounds: 5`/i);
+  assert.match(step7, /snapshot\.copilotReviewRoundCount/i);
+  assert.match(step7, /if `snapshot\.copilotReviewRoundCount >= maxCopilotRounds`, do \*\*not\*\* re-request Copilot review/i);
+  assert.match(step7, /`deferred to follow-up` note/i);
+  assert.match(step7, /stop and report that the Copilot round limit was reached/i);
+});
+
 test("legacy copilot workflow entrypoint agents are removed from normal executable surfaces", async () => {
   const agentFiles = (await readdir(fromRepoRoot("agents")))
     .filter((name) => name.endsWith(".agent.md"))

--- a/test/loop/detect-copilot-loop-state.test.mjs
+++ b/test/loop/detect-copilot-loop-state.test.mjs
@@ -521,6 +521,57 @@ test("detect-copilot-loop-state auto-detect returns unresolved_feedback_present 
   }
 });
 
+test("detect-copilot-loop-state auto-detect tracks completed Copilot review rounds in the snapshot", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-round-count-"));
+
+  try {
+    const { env } = await writeAutoDetectGhStub(tempDir, {
+      pr: 17,
+      prView: {
+        headRefOid: "abc123",
+        reviews: [
+          {
+            id: "r-old",
+            author: { login: "copilot-pull-request-reviewer[bot]" },
+            state: "COMMENTED",
+            commit: { oid: "old123" },
+            submittedAt: "2026-01-10T00:00:00Z",
+          },
+          {
+            id: "r-current",
+            author: { login: "copilot-pull-request-reviewer[bot]" },
+            state: "CHANGES_REQUESTED",
+            commit: { oid: "abc123" },
+            submittedAt: "2026-01-11T00:00:00Z",
+          },
+          {
+            id: "r-human",
+            author: { login: "human-reviewer" },
+            state: "APPROVED",
+            commit: { oid: "abc123" },
+            submittedAt: "2026-01-11T01:00:00Z",
+          },
+        ],
+        statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+      },
+      requestedReviewers: { users: [], teams: [] },
+      reviewThreads: [],
+    });
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.snapshot.copilotReviewRoundCount, 2);
+    assert.equal(output.snapshot.copilotReviewOnCurrentHead, true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("autoDetectSnapshot uses the default ghCommand when deps omit it", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-auto-detect-default-deps-"));
 

--- a/test/loop/inspect-run-viewer-managed-instance.test.mjs
+++ b/test/loop/inspect-run-viewer-managed-instance.test.mjs
@@ -609,24 +609,20 @@ test('open fails with a clear error when the launch seam does not return a posit
 });
 
 test('defaultHealthcheck fetches without AbortSignal (Node v24 compatibility)', async () => {
-  const { createServer } = await import('node:http');
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-healthcheck-signal-'));
 
-  // Start a real HTTP server on the default port so isManagedRecordShape passes
-  const healthServer = createServer((_req, res) => { res.writeHead(200); res.end('ok'); });
-  await new Promise((resolve) => healthServer.listen(4311, '127.0.0.1', resolve));
-
-  // Spy on global fetch to capture the options passed
+  // Spy on global fetch and short-circuit the response so the contract test
+  // stays deterministic without depending on a real HTTP server lifecycle.
   const originalFetch = globalThis.fetch;
   const fetchCalls = [];
   globalThis.fetch = async (url, options) => {
     fetchCalls.push({ url, options });
-    return originalFetch(url, options);
+    return { status: 200 };
   };
 
   try {
     // Manager with real defaultHealthcheck (healthcheckUrlImpl defaults)
-    // but stubbed lifecycle seams
+    // but stubbed lifecycle seams.
     const manager = createInspectRunViewerLifecycleManager({
       listListeningPidsImpl: async () => [42],
       isProcessAliveImpl: async () => true,
@@ -648,7 +644,8 @@ test('defaultHealthcheck fetches without AbortSignal (Node v24 compatibility)', 
       argsFingerprint: JSON.stringify({ repo: null, host: '127.0.0.1', port: 4311 }),
       startedAt: new Date().toISOString(),
       cwd: repoRoot,
-    })}\n`);
+    })}
+`);
 
     const status = await manager.status({ repoRoot });
     assert.equal(status.state, 'running');
@@ -658,7 +655,5 @@ test('defaultHealthcheck fetches without AbortSignal (Node v24 compatibility)', 
     assert.ok(!healthcheckCall.options?.signal, 'fetch must not receive an AbortSignal');
   } finally {
     globalThis.fetch = originalFetch;
-    await new Promise((resolve) => healthServer.close(resolve));
   }
 });
-


### PR DESCRIPTION
Closes #361.

## Change summary

Add configurable `refinement.maxCopilotRounds` with a shipped default of `5`, thread completed Copilot review-round counts through the PR-follow-up helpers, and document the stop-at-cap behavior in the Copilot follow-up contract.

## Scope / context

- add `maxCopilotRounds: 5` to `.pi/dev-loop/defaults.yaml`
- extend config schema/default resolution so the value is available through normal config loading and `resolveRefinementConfig(...)`
- expose completed Copilot review-round counts in the review helper and loop-state snapshot surfaces
- document the round-cap behavior in `skills/copilot-pr-followup/SKILL.md`
- keep the existing inspect-run-viewer healthcheck compatibility test deterministic on Node v24 while the validation suite stays green

## Acceptance criteria

- [x] `maxCopilotRounds` defaults to `5`
- [x] the value is configurable through the existing dev-loop config loading path
- [x] Copilot loop snapshots surface completed review-round count for cap decisions
- [x] the Copilot follow-up contract says re-requesting stops once the configured cap is reached
- [x] `npm run verify` passes

## Definition of done

- code, tests, and docs agree on the new config surface
- config helpers export the new resolver needed by callers
- loop/helper snapshots include the review-round count needed for follow-up decisions
- validation is green via `npm run verify`

## Non-goals

- changing the public workflow entrypoint away from `dev-loop`
- changing the required gate order (`draft_gate` -> Copilot follow-up -> `pre_approval_gate`)
- broad refactors outside the max-Copilot-rounds config and supporting validation surface
