### PR TITLE
Batch deterministic Copilot follow-up fixes

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -206,6 +206,35 @@ Success output shape:
 Failure behavior:
 - malformed arguments, empty body files, missing threads, missing comments, comment/thread mismatches, unexpected `gh` failures, and unsuccessful resolve responses emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero
 
+### `scripts/github/reply-resolve-review-threads.mjs`
+
+Reply to all matching unresolved review threads on one PR and optionally resolve them with one bounded note.
+
+Required:
+- `--repo <owner/name>`
+- `--pr <number>`
+
+Optional:
+- `--author <login>` (default `Copilot`)
+- exactly one message source: `--message <text>` or stdin
+- `--resolve`
+
+Contract:
+- captures one authoritative review-thread snapshot via `capture-review-threads.mjs`
+- filters to unresolved threads containing at least one comment by the selected author
+- chooses the newest matching author-authored comment in each matched thread as the REST reply target
+- processes matched threads sequentially in deterministic snapshot order
+- reuses the shared single-thread reply/resolve primitives instead of duplicating GitHub mutation logic
+- with `--resolve`, re-captures the review-thread snapshot at the end and fails closed if any targeted thread remains unresolved
+- zero-match runs are deterministic no-ops with success JSON
+
+Success output shape:
+- `{ "ok": true, "repo": "owner/name", "pr": 17, "author": "Copilot", "resolve": true|false, "matchedThreadCount": 2, "repliedThreadCount": 2, "resolvedThreadCount": 2, "skippedThreadCount": 1, "results": [{ "threadId": "...", "commentId": 123, "replyId": 456, "replyUrl": "...", "resolved": true }] }`
+
+Failure behavior:
+- malformed arguments, empty/conflicting message input, malformed thread snapshots, unexpected `gh` failures, reply failures, resolve failures, and failed post-resolve verification emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero
+- when partial progress exists, stderr JSON also includes `partialProgress`
+
 For new GitHub mutation helpers in this repo, do not stop at fixture-only confidence when a real PR is available and mutation is authorized. Run a bounded real-PR smoke check before depending on the helper inside a longer async review/fix loop.
 
 ### `scripts/github/watch-copilot-review.mjs`

--- a/scripts/github/_review-thread-mutations.mjs
+++ b/scripts/github/_review-thread-mutations.mjs
@@ -1,0 +1,254 @@
+import { spawn } from "node:child_process";
+
+import { isCopilotLogin, parseReviewThreads } from "../_core-helpers.mjs";
+import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
+
+export const MIN_DISMISSAL_REASON_LENGTH = 30;
+
+export function hasCommitShaReference(text) {
+  const trimmed = text.trim();
+  const hexTokens = trimmed.match(/\b[0-9a-f]{7,40}\b/gi) ?? [];
+  const hasHexLetterToken = hexTokens.some((token) => /[a-f]/i.test(token));
+  const hasContextualNumericRef =
+    /\b(?:fixed\s+in|commit|sha|rev(?:ision)?)\s+[0-9a-f]{7,40}\b/i.test(trimmed)
+    || /\/commit\/[0-9a-f]{7,40}\b/i.test(trimmed);
+  return hasHexLetterToken || hasContextualNumericRef;
+}
+
+export function validateResolutionMessage(body) {
+  const trimmedBody = body.trim();
+  const hasCommitSha = hasCommitShaReference(trimmedBody);
+  const hasDismissalReason = trimmedBody.length >= MIN_DISMISSAL_REASON_LENGTH;
+
+  if (!hasCommitSha && !hasDismissalReason) {
+    throw new Error(
+      `Reply body (${trimmedBody.length} characters after trimming) must contain either a commit SHA reference or a dismissal reason (at least ${MIN_DISMISSAL_REASON_LENGTH} characters after trimming). `
+      + 'Bare acknowledgments like "Acknowledged." are not valid resolutions.',
+    );
+  }
+
+  return {
+    trimmedBody,
+    hasCommitSha,
+    hasDismissalReason,
+  };
+}
+
+function runChildWithInput(command, args, env, stdinText) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    if (stdinText === undefined) {
+      child.stdin.end();
+    } else {
+      child.stdin.end(stdinText);
+    }
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+function parseJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`Invalid JSON from gh: ${text.trim() || "<empty>"}`);
+  }
+}
+
+export function parseReplyPayload(payload) {
+  const replyId = payload?.id;
+  const replyUrl = payload?.html_url;
+
+  if (!Number.isFinite(replyId) || typeof replyUrl !== "string" || replyUrl.trim().length === 0) {
+    throw new Error("Reply payload from gh did not include both id and html_url");
+  }
+
+  return {
+    replyId,
+    replyUrl,
+  };
+}
+
+const RESOLVE_REVIEW_THREAD_MUTATION = [
+  "mutation($threadId: ID!) {",
+  "  resolveReviewThread(input: { threadId: $threadId }) {",
+  "    thread {",
+  "      id",
+  "      isResolved",
+  "    }",
+  "  }",
+  "}",
+].join("\n");
+
+export async function captureParsedReviewThreads(
+  { repo, pr },
+  { env = process.env, ghCommand = "gh" } = {},
+) {
+  const payload = await fetchGithubReviewThreadsPayload({ repo, pr }, { env, ghCommand });
+  return parseReviewThreads(payload);
+}
+
+export function assertReplyTargetFromSnapshot(parsed, { repo, pr, commentId, threadId }) {
+  const targetCommentId = String(commentId);
+  const thread = parsed.threads.find((entry) => entry.id === threadId) ?? null;
+  const comment = parsed.comments.find((entry) => entry.databaseId === targetCommentId) ?? null;
+
+  if (thread === null) {
+    throw new Error(`Review thread ${threadId} was not found on pull request ${repo}#${pr}`);
+  }
+
+  if (comment === null) {
+    throw new Error(`Review comment ${commentId} was not found on pull request ${repo}#${pr}`);
+  }
+
+  if (comment.threadId !== threadId) {
+    throw new Error(`Review comment ${commentId} does not belong to review thread ${threadId} on pull request ${repo}#${pr}`);
+  }
+
+  return {
+    thread,
+    comment,
+  };
+}
+
+export async function validateReplyTarget(
+  { repo, pr, commentId, threadId },
+  { env = process.env, ghCommand = "gh" } = {},
+) {
+  const parsed = await captureParsedReviewThreads({ repo, pr }, { env, ghCommand });
+  return {
+    parsed,
+    ...assertReplyTargetFromSnapshot(parsed, { repo, pr, commentId, threadId }),
+  };
+}
+
+export async function postReply(
+  { repo, pr, commentId, body },
+  { env = process.env, ghCommand = "gh" } = {},
+) {
+  const result = await runChildWithInput(
+    ghCommand,
+    [
+      "api",
+      "-X",
+      "POST",
+      `repos/${repo}/pulls/${pr}/comments/${commentId}/replies`,
+      "--input",
+      "-",
+    ],
+    env,
+    `${JSON.stringify({ body })}\n`,
+  );
+
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw new Error(`gh command failed: ${detail}`);
+  }
+
+  return parseJson(result.stdout);
+}
+
+export async function resolveThread(threadId, { env = process.env, ghCommand = "gh" } = {}) {
+  const result = await runChildWithInput(
+    ghCommand,
+    [
+      "api",
+      "graphql",
+      "--field",
+      `threadId=${threadId}`,
+      "--field",
+      `query=${RESOLVE_REVIEW_THREAD_MUTATION}`,
+    ],
+    env,
+  );
+
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw new Error(`gh command failed: ${detail}`);
+  }
+
+  const payload = parseJson(result.stdout);
+  return payload?.data?.resolveReviewThread?.thread;
+}
+
+export async function replyAndMaybeResolve(
+  {
+    repo,
+    pr,
+    commentId,
+    threadId,
+    body,
+    resolve = true,
+    validatedSnapshot = null,
+  },
+  { env = process.env, ghCommand = "gh" } = {},
+) {
+  if (validatedSnapshot) {
+    assertReplyTargetFromSnapshot(validatedSnapshot, { repo, pr, commentId, threadId });
+  } else {
+    await validateReplyTarget({ repo, pr, commentId, threadId }, { env, ghCommand });
+  }
+
+  const reply = parseReplyPayload(await postReply(
+    {
+      repo,
+      pr,
+      commentId,
+      body,
+    },
+    { env, ghCommand },
+  ));
+
+  if (!resolve) {
+    return {
+      replyId: reply.replyId,
+      replyUrl: reply.replyUrl,
+      resolved: false,
+    };
+  }
+
+  const resolvedThread = await resolveThread(threadId, { env, ghCommand });
+
+  if (!resolvedThread?.isResolved) {
+    throw new Error(`Review thread did not resolve successfully: ${threadId}`);
+  }
+
+  return {
+    replyId: reply.replyId,
+    replyUrl: reply.replyUrl,
+    resolved: true,
+  };
+}
+
+export function authorMatchesFilter(commentAuthorLogin, authorFilter) {
+  const normalizedLogin = typeof commentAuthorLogin === "string" ? commentAuthorLogin.trim() : "";
+  const normalizedFilter = typeof authorFilter === "string" ? authorFilter.trim() : "";
+
+  if (normalizedLogin.length === 0 || normalizedFilter.length === 0) {
+    return false;
+  }
+
+  if (normalizedFilter.toLowerCase() === "copilot") {
+    return isCopilotLogin(normalizedLogin) || normalizedLogin.toLowerCase() === "copilot";
+  }
+
+  return normalizedLogin.toLowerCase() === normalizedFilter.toLowerCase();
+}

--- a/scripts/github/reply-resolve-review-thread.mjs
+++ b/scripts/github/reply-resolve-review-thread.mjs
@@ -1,39 +1,15 @@
 #!/usr/bin/env node
 import { readFile } from "node:fs/promises";
-import { spawn } from "node:child_process";
 
-import { formatCliError, isDirectCliRun, parseReviewThreads } from "../_core-helpers.mjs";
-import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
+import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import {
+  hasCommitShaReference,
+  replyAndMaybeResolve,
+  validateResolutionMessage,
+} from "./_review-thread-mutations.mjs";
 
-const MIN_DISMISSAL_REASON_LENGTH = 30;
-
-// Exported for unit testing
-export function hasCommitShaReference(text) {
-  const trimmed = text.trim();
-  // Accept a hex token (7-40 chars) that contains at least one hex letter (a-f) — the common case.
-  // Also accept a pure-numeric hex token when it is explicitly contextualized as a commit reference:
-  //   - via keyword + whitespace: "Fixed in 1234567", "Commit 1234567", "SHA 1234567"
-  //   - via commit URL path:      ".../commit/1234567"
-  // This handles the rare-but-valid all-digit SHA without reopening the bare-numeric bypass vector.
-  const hexTokens = trimmed.match(/\b[0-9a-f]{7,40}\b/gi) ?? [];
-  const hasHexLetterToken = hexTokens.some((t) => /[a-f]/i.test(t));
-  const hasContextualNumericRef =
-    /\b(?:fixed\s+in|commit|sha|rev(?:ision)?)\s+[0-9a-f]{7,40}\b/i.test(trimmed) ||
-    /\/commit\/[0-9a-f]{7,40}\b/i.test(trimmed);
-  return hasHexLetterToken || hasContextualNumericRef;
-}
-
-const RESOLVE_REVIEW_THREAD_MUTATION = [
-  "mutation($threadId: ID!) {",
-  "  resolveReviewThread(input: { threadId: $threadId }) {",
-  "    thread {",
-  "      id",
-  "      isResolved",
-  "    }",
-  "  }",
-  "}",
-].join("\n");
+export { hasCommitShaReference } from "./_review-thread-mutations.mjs";
 
 function requireOptionValue(args, flag) {
   const value = args.shift();
@@ -105,128 +81,6 @@ export function parseReplyResolveCliArgs(argv) {
   return options;
 }
 
-function runChild(command, args, env, stdinText) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      env,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    if (stdinText === undefined) {
-      child.stdin.end();
-    } else {
-      child.stdin.end(stdinText);
-    }
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
-
-function parseJson(text) {
-  try {
-    return JSON.parse(text);
-  } catch {
-    throw new Error(`Invalid JSON from gh: ${text.trim() || "<empty>"}`);
-  }
-}
-
-function parseReplyPayload(payload) {
-  const replyId = payload?.id;
-  const replyUrl = payload?.html_url;
-
-  if (!Number.isFinite(replyId) || typeof replyUrl !== "string" || replyUrl.trim().length === 0) {
-    throw new Error("Reply payload from gh did not include both id and html_url");
-  }
-
-  return {
-    replyId,
-    replyUrl,
-  };
-}
-
-async function validateReplyTarget(
-  { repo, pr, commentId, threadId },
-  { env = process.env, ghCommand = "gh" } = {},
-) {
-  const payload = await fetchGithubReviewThreadsPayload({ repo, pr }, { env, ghCommand });
-  const parsed = parseReviewThreads(payload);
-  const targetCommentId = String(commentId);
-  const thread = parsed.threads.find((entry) => entry.id === threadId) ?? null;
-  const comment = parsed.comments.find((entry) => entry.databaseId === targetCommentId) ?? null;
-
-  if (thread === null) {
-    throw new Error(`Review thread ${threadId} was not found on pull request ${repo}#${pr}`);
-  }
-
-  if (comment === null) {
-    throw new Error(`Review comment ${commentId} was not found on pull request ${repo}#${pr}`);
-  }
-
-  if (comment.threadId !== threadId) {
-    throw new Error(`Review comment ${commentId} does not belong to review thread ${threadId} on pull request ${repo}#${pr}`);
-  }
-}
-
-async function postReply({ repo, pr, commentId, body }, { env = process.env, ghCommand = "gh" } = {}) {
-  const result = await runChild(
-    ghCommand,
-    [
-      "api",
-      "-X",
-      "POST",
-      `repos/${repo}/pulls/${pr}/comments/${commentId}/replies`,
-      "--input",
-      "-",
-    ],
-    env,
-    `${JSON.stringify({ body })}\n`,
-  );
-
-  if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw new Error(`gh command failed: ${detail}`);
-  }
-
-  return parseJson(result.stdout);
-}
-
-async function resolveThread(threadId, { env = process.env, ghCommand = "gh" } = {}) {
-  const result = await runChild(
-    ghCommand,
-    [
-      "api",
-      "graphql",
-      "--field",
-      `threadId=${threadId}`,
-      "--field",
-      `query=${RESOLVE_REVIEW_THREAD_MUTATION}`,
-    ],
-    env,
-  );
-
-  if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw new Error(`gh command failed: ${detail}`);
-  }
-
-  const payload = parseJson(result.stdout);
-  return payload?.data?.resolveReviewThread?.thread;
-}
-
 export async function runCli(
   argv = process.argv.slice(2),
   {
@@ -242,40 +96,19 @@ export async function runCli(
     throw new Error("--body-file must contain non-empty text");
   }
 
-  const trimmedBody = rawBody.trim();
-  const hasCommitSha = hasCommitShaReference(trimmedBody);
-  const hasDismissalReason = trimmedBody.length >= MIN_DISMISSAL_REASON_LENGTH;
-  if (!hasCommitSha && !hasDismissalReason) {
-    throw new Error(
-      `Reply body (${trimmedBody.length} characters after trimming) must contain either a commit SHA reference or a dismissal reason (at least ${MIN_DISMISSAL_REASON_LENGTH} characters after trimming). ` +
-      "Bare acknowledgments like \"Acknowledged.\" are not valid resolutions.",
-    );
-  }
+  validateResolutionMessage(rawBody);
 
-  await validateReplyTarget(
+  const result = await replyAndMaybeResolve(
     {
       repo: options.repo,
       pr: options.pr,
       commentId: options.commentId,
       threadId: options.threadId,
+      body: rawBody,
+      resolve: true,
     },
     { env, ghCommand },
   );
-
-  const reply = parseReplyPayload(await postReply(
-    {
-      repo: options.repo,
-      pr: options.pr,
-      commentId: options.commentId,
-      body: rawBody,
-    },
-    { env, ghCommand },
-  ));
-  const resolvedThread = await resolveThread(options.threadId, { env, ghCommand });
-
-  if (!resolvedThread?.isResolved) {
-    throw new Error(`Review thread did not resolve successfully: ${options.threadId}`);
-  }
 
   stdout.write(`${JSON.stringify({
     ok: true,
@@ -283,8 +116,8 @@ export async function runCli(
     pr: options.pr,
     commentId: options.commentId,
     threadId: options.threadId,
-    replyId: reply.replyId,
-    replyUrl: reply.replyUrl,
+    replyId: result.replyId,
+    replyUrl: result.replyUrl,
     resolved: true,
   })}\n`);
 }

--- a/scripts/github/reply-resolve-review-thread.mjs
+++ b/scripts/github/reply-resolve-review-thread.mjs
@@ -4,7 +4,6 @@ import { readFile } from "node:fs/promises";
 import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import {
-  hasCommitShaReference,
   replyAndMaybeResolve,
   validateResolutionMessage,
 } from "./_review-thread-mutations.mjs";

--- a/scripts/github/reply-resolve-review-threads.mjs
+++ b/scripts/github/reply-resolve-review-threads.mjs
@@ -1,0 +1,394 @@
+#!/usr/bin/env node
+import {
+  formatCliError,
+  isDirectCliRun,
+} from "../_core-helpers.mjs";
+import {
+  parsePrNumber,
+  requireOptionValue,
+} from "../_cli-primitives.mjs";
+import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import {
+  authorMatchesFilter,
+  captureParsedReviewThreads,
+  replyAndMaybeResolve,
+  validateResolutionMessage,
+} from "./_review-thread-mutations.mjs";
+
+const USAGE = `Usage: reply-resolve-review-threads.mjs --repo <owner/name> --pr <number> [--author <login>] [--message <text>] [--resolve]
+
+Reply to all matching unresolved review threads on one PR and optionally resolve them.
+
+Required:
+  --repo <owner/name>   Repository slug (e.g. owner/repo)
+  --pr <number>         Pull request number
+
+Optional:
+  --author <login>      Match threads containing a comment from this author (default: Copilot)
+  --message <text>      Reply body text; provide exactly one message source via --message or stdin
+  --resolve             Resolve each matched thread after the reply succeeds
+
+Output (stdout, JSON):
+  { "ok": true, "repo": "owner/name", "pr": 17, "author": "Copilot", "resolve": true,
+    "matchedThreadCount": 2, "repliedThreadCount": 2, "resolvedThreadCount": 2,
+    "skippedThreadCount": 1, "results": [{ ... }] }
+
+Error output (stderr, JSON):
+  Argument/usage errors:
+    { "ok": false, "error": "...", "usage": "..." }
+  Runtime/gh failures:
+    { "ok": false, "error": "...", "partialProgress"?: { ... } }
+
+Exit codes:
+  0  Success
+  1  Argument error or gh/runtime failure`.trim();
+
+function parseError(message) {
+  return Object.assign(new Error(message), { usage: USAGE });
+}
+
+export function parseReplyResolveThreadsCliArgs(argv) {
+  const args = [...argv];
+  const options = {
+    help: false,
+    repo: undefined,
+    pr: undefined,
+    author: "Copilot",
+    message: undefined,
+    resolve: false,
+  };
+
+  while (args.length > 0) {
+    const token = args.shift();
+
+    if (token === "--help" || token === "-h") {
+      options.help = true;
+      return options;
+    }
+
+    if (token === "--repo") {
+      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+      continue;
+    }
+
+    if (token === "--pr") {
+      options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+      continue;
+    }
+
+    if (token === "--author") {
+      options.author = requireOptionValue(args, "--author", parseError).trim();
+      continue;
+    }
+
+    if (token === "--message") {
+      options.message = requireOptionValue(args, "--message", parseError);
+      continue;
+    }
+
+    if (token === "--resolve") {
+      options.resolve = true;
+      continue;
+    }
+
+    throw parseError(`Unknown argument: ${token}`);
+  }
+
+  if (options.repo === undefined || options.pr === undefined) {
+    throw parseError("Replying and resolving review threads requires both --repo <owner/name> and --pr <number>");
+  }
+
+  if (options.author.length === 0) {
+    throw parseError("--author must contain non-empty text");
+  }
+
+  try {
+    parseRepoSlug(options.repo);
+  } catch (error) {
+    throw parseError(error instanceof Error ? error.message : String(error));
+  }
+
+  return options;
+}
+
+async function readStdinText(stdin) {
+  let text = "";
+  stdin.setEncoding?.("utf8");
+  for await (const chunk of stdin) {
+    text += chunk;
+  }
+  return text;
+}
+
+async function resolveMessageInput(options, { stdin = process.stdin } = {}) {
+  if (typeof options.message === "string") {
+    if (stdin.isTTY) {
+      if (options.message.trim().length === 0) {
+        throw parseError("Reply message must contain non-empty text");
+      }
+      return options.message;
+    }
+
+    const stdinText = await readStdinText(stdin);
+    if (stdinText.trim().length > 0) {
+      throw parseError("Choose exactly one message source: --message <text> or stdin");
+    }
+    if (options.message.trim().length === 0) {
+      throw parseError("Reply message must contain non-empty text");
+    }
+    return options.message;
+  }
+
+  if (stdin.isTTY) {
+    throw parseError("Choose exactly one message source: --message <text> or stdin");
+  }
+
+  const stdinText = await readStdinText(stdin);
+  if (stdinText.trim().length === 0) {
+    throw parseError("Reply message must contain non-empty text");
+  }
+  return stdinText;
+}
+
+function commentRecencyValue(comment) {
+  if (typeof comment?.databaseId === "string" && /^\d+$/.test(comment.databaseId)) {
+    return Number(comment.databaseId);
+  }
+  return Number.NaN;
+}
+
+function selectNewestMatchingComment(parsed, threadId, author) {
+  const candidates = parsed.comments.filter((comment) => (
+    comment.threadId === threadId
+    && authorMatchesFilter(comment.author?.login, author)
+  ));
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  return candidates.reduce((latest, comment) => {
+    if (latest === null) {
+      return comment;
+    }
+
+    const latestRecency = commentRecencyValue(latest);
+    const commentRecency = commentRecencyValue(comment);
+
+    if (Number.isFinite(latestRecency) && Number.isFinite(commentRecency) && commentRecency !== latestRecency) {
+      return commentRecency > latestRecency ? comment : latest;
+    }
+
+    if (!Number.isFinite(latestRecency) && Number.isFinite(commentRecency)) {
+      return comment;
+    }
+
+    if (comment.id.localeCompare(latest.id, undefined, { numeric: true }) > 0) {
+      return comment;
+    }
+
+    return latest;
+  }, null);
+}
+
+export function planBatchReplyTargets(parsed, author) {
+  const unresolvedThreads = parsed.threads.filter((thread) => !thread.isResolved);
+  const matchedTargets = [];
+  let skippedThreadCount = 0;
+
+  for (const thread of unresolvedThreads) {
+    const comment = selectNewestMatchingComment(parsed, thread.id, author);
+
+    if (comment === null) {
+      skippedThreadCount += 1;
+      continue;
+    }
+
+    if (typeof comment.databaseId !== "string" || !/^\d+$/.test(comment.databaseId)) {
+      throw new Error(`Matched review thread ${thread.id} did not include a REST-safe numeric comment id for the newest ${author} comment`);
+    }
+
+    matchedTargets.push({
+      threadId: thread.id,
+      commentId: Number(comment.databaseId),
+    });
+  }
+
+  return {
+    matchedTargets,
+    skippedThreadCount,
+  };
+}
+
+function createSuccessPayload({ repo, pr, author, resolve, matchedThreadCount, repliedThreadCount, resolvedThreadCount, skippedThreadCount, results }) {
+  return {
+    ok: true,
+    repo,
+    pr,
+    author,
+    resolve,
+    matchedThreadCount,
+    repliedThreadCount,
+    resolvedThreadCount,
+    skippedThreadCount,
+    results,
+  };
+}
+
+function buildPartialProgress({ repo, pr, author, resolve, matchedThreadCount, skippedThreadCount, results }) {
+  const resolvedThreadCount = results.filter((entry) => entry.resolved).length;
+  return {
+    repo,
+    pr,
+    author,
+    resolve,
+    matchedThreadCount,
+    repliedThreadCount: results.length,
+    resolvedThreadCount,
+    skippedThreadCount,
+    results,
+  };
+}
+
+function toCliFailurePayload(error) {
+  const payload = JSON.parse(formatCliError(error));
+
+  if (error instanceof Error && error.partialProgress) {
+    payload.partialProgress = error.partialProgress;
+  }
+
+  return payload;
+}
+
+function attachPartialProgress(error, partialProgress) {
+  if (error instanceof Error) {
+    error.partialProgress = partialProgress;
+    return error;
+  }
+
+  const wrapped = new Error(String(error));
+  wrapped.partialProgress = partialProgress;
+  return wrapped;
+}
+
+export async function runCli(
+  argv = process.argv.slice(2),
+  {
+    stdin = process.stdin,
+    stdout = process.stdout,
+    env = process.env,
+    ghCommand = "gh",
+  } = {},
+) {
+  const options = parseReplyResolveThreadsCliArgs(argv);
+
+  if (options.help) {
+    stdout.write(`${USAGE}\n`);
+    return;
+  }
+
+  const message = await resolveMessageInput(options, { stdin });
+  validateResolutionMessage(message);
+
+  const parsed = await captureParsedReviewThreads(
+    { repo: options.repo, pr: options.pr },
+    { env, ghCommand },
+  );
+  const { matchedTargets, skippedThreadCount } = planBatchReplyTargets(parsed, options.author);
+
+  if (matchedTargets.length === 0) {
+    stdout.write(`${JSON.stringify(createSuccessPayload({
+      repo: options.repo,
+      pr: options.pr,
+      author: options.author,
+      resolve: options.resolve,
+      matchedThreadCount: 0,
+      repliedThreadCount: 0,
+      resolvedThreadCount: 0,
+      skippedThreadCount,
+      results: [],
+    }))}\n`);
+    return;
+  }
+
+  const results = [];
+  const partialBase = {
+    repo: options.repo,
+    pr: options.pr,
+    author: options.author,
+    resolve: options.resolve,
+    matchedThreadCount: matchedTargets.length,
+    skippedThreadCount,
+  };
+
+  try {
+    for (const target of matchedTargets) {
+      const result = await replyAndMaybeResolve(
+        {
+          repo: options.repo,
+          pr: options.pr,
+          commentId: target.commentId,
+          threadId: target.threadId,
+          body: message,
+          resolve: options.resolve,
+          validatedSnapshot: parsed,
+        },
+        { env, ghCommand },
+      );
+
+      results.push({
+        threadId: target.threadId,
+        commentId: target.commentId,
+        replyId: result.replyId,
+        replyUrl: result.replyUrl,
+        resolved: result.resolved,
+      });
+    }
+
+    if (options.resolve) {
+      const refreshed = await captureParsedReviewThreads(
+        { repo: options.repo, pr: options.pr },
+        { env, ghCommand },
+      );
+      const stillUnresolvedThreadIds = matchedTargets
+        .map((target) => target.threadId)
+        .filter((threadId) => refreshed.threads.some((thread) => thread.id === threadId && !thread.isResolved));
+
+      if (stillUnresolvedThreadIds.length > 0) {
+        throw attachPartialProgress(
+          new Error(`Post-resolve verification failed; targeted thread(s) remain unresolved: ${stillUnresolvedThreadIds.join(", ")}`),
+          {
+            ...buildPartialProgress({ ...partialBase, results }),
+            stillUnresolvedThreadIds,
+          },
+        );
+      }
+    }
+  } catch (error) {
+    if (error instanceof Error && error.partialProgress) {
+      throw error;
+    }
+    throw attachPartialProgress(error, buildPartialProgress({ ...partialBase, results }));
+  }
+
+  const repliedThreadCount = results.length;
+  const resolvedThreadCount = results.filter((entry) => entry.resolved).length;
+  stdout.write(`${JSON.stringify(createSuccessPayload({
+    repo: options.repo,
+    pr: options.pr,
+    author: options.author,
+    resolve: options.resolve,
+    matchedThreadCount: matchedTargets.length,
+    repliedThreadCount,
+    resolvedThreadCount,
+    skippedThreadCount,
+    results,
+  }))}\n`);
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli().catch((error) => {
+    process.stderr.write(`${JSON.stringify(toCliFailurePayload(error))}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -576,7 +576,7 @@ Preferred defaults for this repo:
 
 These are the defaults built into `watch-copilot-review.mjs`, `run-copilot-watch-cycle.mjs`, and the `watchArgs` emitted by `copilot-pr-handoff.mjs`. Pass them explicitly when overriding.
 
-Helper-owned sleep inside `run-copilot-watch-cycle.mjs`, `watch-copilot-review.mjs`, or `watch-initial-copilot-pr.mjs` is allowed. Agent-authored shell polling is not.
+Helper-owned sleep inside `run-copilot-watch-cycle.mjs`, `watch-copilot-review.mjs`, or `watch-initial-copilot-pr.mjs` is allowed. Agent-authored shell polling is not allowed.
 
 A watcher sleeping between polls is expected behavior, not a blocker.
 

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -158,8 +158,9 @@ Goal:
 Use when the user wants Pi to wait for fresh Copilot review activity and then react.
 
 Goal:
-- baseline current Copilot activity
-- poll deterministically for new Copilot comments/reviews
+- baseline the current PR wait state with `detect-copilot-loop-state.mjs`
+- if the detector returns `waiting_for_copilot_review`, either enter persistent waiting via `run-copilot-watch-cycle.mjs` or stop cleanly and resume later after that single detector call
+- if the detector returns `waiting_for_ci`, use the detector snapshot plus `gh run watch` for a known current-head run id; otherwise stop cleanly and resume later instead of polling in-shell
 - launch an in-session Pi fixer only after fresh review activity appears
 
 ### 4. Fixer mode
@@ -430,7 +431,7 @@ states for this narrower MVP slice.
 **How to use the state machine in practice:**
 
 1. Run `node <resolved-skill-scripts>/loop/detect-copilot-loop-state.mjs --repo <owner/name> --pr <number>`
-   to get the current Copilot-loop state and recommended next action.
+   to get the current Copilot-loop state, decisive snapshot fields, and recommended next action.
 
 2. If you already ran `<resolved-skill-scripts>/github/request-copilot-review.mjs` and got a known status,
    inject it without re-probing: add `--review-request-status <status>`.
@@ -438,7 +439,12 @@ states for this narrower MVP slice.
 3. When the agent has applied a fix and wants to signal reply/resolve is next, build a snapshot
    with `agentFixStatus: "applied"` and use `--input <snapshot.json>` for interpretation.
 
-4. For reviewer-side draft-review work, run `node <resolved-skill-scripts>/loop/detect-reviewer-loop-state.mjs --repo <owner/name> --pr <number> [--reviewer-login <login>] [--local-state <path>]`.
+4. Branch on the detector output instead of inventing a polling loop:
+   - `state=waiting_for_copilot_review` with `snapshot.copilotReviewOnCurrentHead=false`: do **not** poll manually; either run `node <resolved-skill-scripts>/loop/run-copilot-watch-cycle.mjs --repo <owner/name> --pr <number>` for persistent async waiting or report the wait state and resume later after the single detector call
+   - `state=waiting_for_ci` with `snapshot.ciStatus` in `{ "pending", "none" }`: do **not** poll manually; use `gh run watch <run-id> --repo <owner/name>` when the current-head run id is already known, otherwise report pending CI and resume later after the single detector refresh
+   - `snapshot.ciStatus="failure"` remains a stop/fix state, never a wait loop
+
+5. For reviewer-side draft-review work, run `node <resolved-skill-scripts>/loop/detect-reviewer-loop-state.mjs --repo <owner/name> --pr <number> [--reviewer-login <login>] [--local-state <path>]`.
    If the state reaches `draft_review_ready`, stage the pending review with
    `node <resolved-skill-scripts>/github/stage-reviewer-draft.mjs --repo <owner/name> --pr <number> --review-file <merged-review.json> --local-state-output <state.json>`,
    then re-run the detector with `--local-state <state.json>`.
@@ -446,7 +452,7 @@ states for this narrower MVP slice.
    In the `pi-dev-loops` source repository, `<resolved-skill-scripts>` is `../../scripts` relative to this file.
    In normalized installed skill copies, it may instead be `scripts` inside the installed skill directory.
 
-5. Follow the `nextAction` from the machine output. For stop states (`review_request_unavailable`,
+6. Follow the `nextAction` from the machine output. For stop states (`review_request_unavailable`,
    `blocked_needs_user_decision`), report to the user and do not proceed.
 
 **Judgment calls that remain in the agent layer (not encoded in the machine):**
@@ -568,7 +574,9 @@ Preferred defaults for this repo:
 - parent/subagent no-activity threshold for watcher-style runs: at least **15 minutes**
 - active-long-running notice threshold for watcher-style runs: about **30 minutes**
 
-These are the defaults built into `watch-copilot-review.mjs` and the `watchArgs` emitted by `copilot-pr-handoff.mjs`. Pass them explicitly when overriding.
+These are the defaults built into `watch-copilot-review.mjs`, `run-copilot-watch-cycle.mjs`, and the `watchArgs` emitted by `copilot-pr-handoff.mjs`. Pass them explicitly when overriding.
+
+Helper-owned sleep inside `run-copilot-watch-cycle.mjs`, `watch-copilot-review.mjs`, or `watch-initial-copilot-pr.mjs` is allowed. Agent-authored shell polling is not.
 
 A watcher sleeping between polls is expected behavior, not a blocker.
 
@@ -602,6 +610,21 @@ When confirming whether Copilot is requested as a reviewer, do not rely solely o
 
 Prefer the deterministic helper `request-copilot-review.mjs` from the resolved skill scripts directory when it exists. That helper verifies reviewer state through `gh api repos/<owner>/<repo>/pulls/<number>/requested_reviewers`, which is more reliable here than `gh pr view --json reviewRequests`.
 
+Use it directly for both the initial ready-for-review request and later validated re-requests:
+```sh
+node <resolved-skill-scripts>/github/request-copilot-review.mjs \
+  --repo <owner/name> \
+  --pr <number>
+```
+If a same-head clean-converged re-request is intentionally authorized, use:
+```sh
+node <resolved-skill-scripts>/github/request-copilot-review.mjs \
+  --repo <owner/name> \
+  --pr <number> \
+  --force-rerequest-review
+```
+Do **not** request Copilot by posting literal `/copilot` or `/copilot re-review` PR comments.
+
 When a PR is moved from draft to ready, explicitly attempt to request Copilot review rather than assuming repository automation will do it.
 
 After any follow-up fix commit is pushed to an open PR, explicitly decide whether another Copilot pass is desired.
@@ -616,28 +639,30 @@ If the explicit request fails because Copilot review is not enabled for the repo
 Do not treat an attempted request as equivalent to a confirmed request.
 
 For the resolved `request-copilot-review.mjs` helper, branch on the machine-readable result:
-- `requested`: if another Copilot pass is actually desired, baseline fresh state and then wait/watch; otherwise report current state without waiting
-- `already-requested`: if another Copilot pass is actually desired, baseline fresh state and then wait/watch; otherwise report current state without waiting
+- `requested`: if another Copilot pass is actually desired, immediately re-baseline with `node <resolved-skill-scripts>/loop/detect-copilot-loop-state.mjs --repo <owner/name> --pr <number>` and branch on returned `state`, `snapshot.copilotReviewOnCurrentHead`, `snapshot.ciStatus`, and `nextAction`; only enter persistent waiting through `run-copilot-watch-cycle.mjs` or `gh run watch`, otherwise report the wait state and resume later without bash polling
+- `already-requested`: apply the same detector-first rebasing and wait branching as `requested`; do not keep the session alive with ad hoc bash polling
 - `suppressed_same_head_clean`: report the clean-converged state and stop unless an explicit `--force-rerequest-review` bypass is intentionally authorized
 - `unavailable`: report the limitation and stop unless the user explicitly wants passive waiting without a fresh request
 - non-zero / unexpected failure: stop and report the error rather than entering a sleep/watch loop
 
 ## Step 6: Async watch behavior
 
-When the user wants Pi to wait for fresh Copilot review activity, prefer native GitHub watch behavior when `gh` supports the exact wait condition, and otherwise use a deterministic watcher rather than ad hoc polling.
+When the user wants Pi to wait for fresh Copilot review activity, start every PR-follow-up wait seam with one detector refresh:
+```sh
+node <resolved-skill-scripts>/loop/detect-copilot-loop-state.mjs --repo <owner/name> --pr <number>
+```
 
-Preferred order:
-1. use `gh ... --watch` / `gh ... watch` when GitHub CLI has a native watch mode for the exact thing you need
-2. otherwise use the existing deterministic watcher pattern
-3. only fall back to custom ad hoc polling when neither of the above can express the required condition safely
+Allowed wait tools for this PR follow-up loop:
+- one-shot PR wait-state classification: `detect-copilot-loop-state.mjs`
+- persistent Copilot review wait: `run-copilot-watch-cycle.mjs`
+- watch refresh after `timeout`/`idle`: `copilot-pr-handoff.mjs --watch-status <changed|timeout|idle>`
+- CI wait when a current-head workflow run id is known: `gh run watch <run-id> --repo <owner/name>`
+- otherwise: exit cleanly and resume later from a fresh detector call
 
 Practical rule for this repo:
-- prefer `gh run watch` for GitHub Actions / check-run waiting when you already know the run ID
-- prefer ordinary `gh pr view`, `gh issue view`, `gh api`, and `gh pr checks` snapshots for one-time inspection
-- use deterministic custom watchers for conditions that `gh` does not natively watch well, such as:
-  - waiting for a Copilot-authored PR to appear
-  - waiting for new Copilot review activity after a baseline, including review-thread comments, review summaries, or PR issue comments
-  - waiting for unresolved thread state to change in a review-aware way
+- `state=waiting_for_copilot_review` with `snapshot.copilotReviewOnCurrentHead=false`: do **not** poll manually; either run `node <resolved-skill-scripts>/loop/run-copilot-watch-cycle.mjs --repo <owner/name> --pr <number>` for persistent async waiting or report the wait state and resume later after the single detector call
+- `state=waiting_for_ci` with `snapshot.ciStatus` in `{ "pending", "none" }`: do **not** poll manually; use `gh run watch <run-id> --repo <owner/name>` when the current-head run id is already known, otherwise report pending CI and resume later after the single detector refresh
+- `snapshot.ciStatus="failure"` remains a stop/fix state, never a wait loop
 
 Preferred approach for Copilot review follow-up:
 - route request/re-request/watch decisions through `copilot-pr-handoff.mjs` output instead of re-implementing branch logic in markdown
@@ -661,7 +686,10 @@ Every async dev-loop dispatch task body must include this clause verbatim so fre
 Key rules:
 - expected polling idle time is normal
 - do not restart watchers just because there has been a short quiet period
-- do not use `nohup`, detached shell jobs, tmux/screen sessions, or ad hoc `while`/`sleep` bash loops for this workflow
+- helper-owned sleep inside `run-copilot-watch-cycle.mjs`, `watch-copilot-review.mjs`, or `watch-initial-copilot-pr.mjs` is allowed
+- agent-authored shell polling is forbidden
+- do not use `nohup`, detached shell jobs, `tmux`, `screen`, or ad hoc `for i in $(seq ...)`, `while true`, `until ...; do sleep ...; done`, or `sleep`-retry bash loops for this workflow
+- do not wrap repeated `gh pr view`, `gh pr checks`, `gh api`, or `detect-copilot-loop-state.mjs` calls inside shell polling loops
 - do not bypass session-based async notifications with detached shell automation unless explicitly asked
 - if a watcher is sleeping between polls, prefer raising the orchestration inactivity threshold over interrupting the child
 - if Pi async subagents or the designated async follow-up skill are not appropriate or available, stop and report rather than improvising a shell watcher
@@ -690,34 +718,42 @@ When actionable review feedback exists, use a narrow follow-up loop:
    - if the guard exits non-zero (`branch_mismatch`), stop and realign to the expected branch before staging or committing
 7. if files changed, push the resolving commit before any thread reply claims the fix is present
 8. when a comment or thread is actually addressed, reply on GitHub with a short resolution note that references the resolving commit SHA or commit URL when applicable
-   - must use the deterministic helper `reply-resolve-review-thread.mjs` from the resolved skill scripts directory for thread reply/resolve work
-   - when using that helper, pair `--comment-id` and `--thread-id` from the same fresh PR thread snapshot rather than mixing ids across review rounds
-   - use a body file under `tmp/` rather than inline shell text for the reply body
+   - for one thread, must use the deterministic helper `reply-resolve-review-thread.mjs` from the resolved skill scripts directory
+   - when the same bounded resolution note applies to multiple matching unresolved threads, use `reply-resolve-review-threads.mjs` instead of ad hoc inline `gh api` / `gh api graphql` mutations
+   - when using the single-thread helper, pair `--comment-id` and `--thread-id` from the same fresh PR thread snapshot rather than mixing ids across review rounds
+   - use a body file under `tmp/` rather than inline shell text for the single-thread reply body; for the batch helper, prefer stdin from that same `tmp/` body file rather than inline shell text
    - when the intent is GitHub linkability, keep commit SHAs and issue/PR refs as plain text (for example 3ee82fc and owner/repo#70) and do not wrap them in backticks
    - keep backticks for actual code/path/CLI literals only
-   - if that helper was newly added or recently changed, smoke-check it against one real thread before assuming the rest of the loop can rely on it
-9. resolve the addressed review thread only after the reply is attached successfully and the concern is genuinely addressed
+   - if either helper was newly added or recently changed, smoke-check it against one real thread before assuming the rest of the loop can rely on it
+9. before resolving an addressed review thread, run a post-fix verification checkpoint
+   - confirm the GitHub reply actually exists on the intended thread/comment, not only in local notes or helper stdout
+   - confirm the pushed current-head diff genuinely addresses the reviewer concern on the flagged lines or pattern; if the concern is only partially addressed, leave the thread open and explain what remains
+   - refresh the API-backed thread snapshot via `capture-review-threads.mjs` and use that refreshed data — including `unresolvedThreadCount` — for follow-up decisions rather than prose assumptions
+   - if any verification check fails, do **not** resolve the thread; leave it open, add a short explanation when needed, and re-enter the fix/reply loop
+10. resolve the addressed review thread only after the reply is attached successfully, the verification checkpoint passes, and the concern is genuinely addressed
    - do not stop at a local fix if GitHub-side reply/resolve is authorized
-10. after completing reply/resolve for a pass, verify `unresolvedThreadCount === 0` via `capture-review-threads.mjs` before proceeding
+11. after completing reply/resolve for a pass, verify `unresolvedThreadCount === 0` via `capture-review-threads.mjs` before proceeding
    - if the refreshed snapshot reports a non-zero unresolved thread count, re-enter the reply/resolve loop for the missed threads
-11. only after GitHub-side reply/resolve work is done for the addressed threads and the refreshed thread snapshot proves `unresolvedThreadCount === 0`, decide whether another Copilot pass is desired
+12. only after GitHub-side reply/resolve work is done for the addressed threads and the refreshed thread snapshot proves `unresolvedThreadCount === 0`, decide whether another Copilot pass is desired
    - resolve the review-round cap from config via `resolveRefinementConfig(config, "maxCopilotRounds")` from `@pi-dev-loops/core/config`; default config ships `maxCopilotRounds: 5`
    - use `snapshot.copilotReviewRoundCount` from `detect-copilot-loop-state.mjs` / `copilot-pr-handoff.mjs` as the completed Copilot review-round count for the current PR
    - if `snapshot.copilotReviewRoundCount >= maxCopilotRounds`, do **not** re-request Copilot review
    - when the round cap is reached, reply-resolve any remaining intentionally deferred threads with a short `deferred to follow-up` note, then stop and report that the Copilot round limit was reached
    - if yes and the round cap has not been reached, run the smallest honest local validation for the accepted fix scope
    - if that local validation is still known red, continue remediation instead of re-requesting Copilot
-   - after a fix push advances the PR head SHA, treat previous-head CI evidence as stale for any CI-dependent follow-up decision
+   - after a fix push advances the PR head SHA, treat previous-head CI evidence as stale for any CI-dependent follow-up decision and immediately re-run `node <resolved-skill-scripts>/loop/detect-copilot-loop-state.mjs --repo <owner/name> --pr <number>` for the new head
    - refresh/re-read current-head CI/check data before advancing and apply the contract in [Copilot CI Status Contract](../docs/copilot-ci-status-contract.md) (wait for `pending`/`none`, stop for `failure`, proceed only on `success`)
    - passing local validation alone does not satisfy a step that still requires GitHub CI/check readiness for the current head
    - only results for the current head SHA may satisfy a CI-dependent follow-up step; older-head results must not unblock the new head
+   - if the current-head detector output still says `state=waiting_for_ci` with `snapshot.ciStatus` in `{ "pending", "none" }`, wait only via `gh run watch <run-id> --repo <owner/name>` for a known run id or else stop/resume later after the single detector refresh; do not use shell polling while waiting for CI to become green
    - if GitHub CI/checks for the updated head are known red for a fixable issue, continue remediation instead of re-requesting Copilot
    - only once the updated head is green or credibly green, explicitly re-request Copilot review for the new head rather than assuming it remains requested
    - only enter a wait/watch loop if the request result is confirmed as `requested` or `already-requested`
+   - for `requested` / `already-requested`, immediately re-baseline with `detect-copilot-loop-state.mjs`; if the returned state is `waiting_for_copilot_review`, use `run-copilot-watch-cycle.mjs` or stop/resume later, and if the returned state is `waiting_for_ci`, use `gh run watch` for a known run id or stop/resume later after that single detector refresh
    - if the request result is `unavailable`, report that limitation and stop unless the user explicitly wants passive waiting anyway
    - if the request command fails unexpectedly, stop and report the error rather than sleeping and hoping for a new review
-12. after a confirmed re-requested Copilot pass, refresh PR thread state again before reporting completion; if fresh Copilot threads exist, return to this follow-up loop rather than stopping at "review requested"
-13. if scope has broadened, stop and ask before continuing
+13. after a confirmed re-requested Copilot pass, refresh PR thread state again before reporting completion; if fresh Copilot threads exist, return to this follow-up loop rather than stopping at "review requested"
+14. if scope has broadened, stop and ask before continuing
 
 Do not treat "fix applied locally" as the end of the loop when the workflow also requires GitHub-side reviewer follow-up. If comment/reply authorization is withheld, report explicitly that the code may be fixed while the PR conversation state remains unresolved.
 
@@ -809,7 +845,8 @@ Useful examples in this repository:
 
 When GitHub Actions runs already exist and the next step is to wait for them rather than rerun them locally, prefer native GitHub CLI watch support where available:
 - use `gh run watch` for a known workflow run ID
-- fall back to snapshot inspection when no watchable run ID is known yet
+- otherwise refresh once with `node <resolved-skill-scripts>/loop/detect-copilot-loop-state.mjs --repo <owner/name> --pr <number>` and report the current wait state from that detector snapshot
+- do not add `sleep`-based retries around `gh pr checks`, `gh pr view`, or `gh api`
 
 When reporting status, distinguish between:
 - locally validated narrowly
@@ -883,7 +920,7 @@ Do not:
 - create a separate local backlog
 - broaden a Copilot PR into multiple issue scopes
 - resolve threads without checking whether the current branch actually fixes them
-- use inline `gh api` to post thread replies without the resolve mutation
+- use ad hoc inline `gh api` or `gh api graphql` thread-mutation commands instead of the deterministic `reply-resolve-review-thread.mjs` / `reply-resolve-review-threads.mjs` helpers
 - submit a merge-ready verdict without first summarizing the pending thread state
 - declare merge-ready without a visible `pre_approval_gate` comment on the current head SHA
 - declare merge-ready based solely on `mergeable_state: clean` + CI green without gate evidence

--- a/test/copilot-review-doc-contracts.test.mjs
+++ b/test/copilot-review-doc-contracts.test.mjs
@@ -8,29 +8,23 @@ import {
   test,
   USER_FACING_AGENT_SURFACE,
 } from "./imported-assets-helpers.mjs";
-
 test("copilot review gates keep phase-specific angle ownership in one canonical internal skill", async () => {
   const [copilotPrFollowupSkill, gateContract] = await Promise.all([
     readRepo("skills/copilot-pr-followup/SKILL.md"),
     readRepo("docs/gate-review-comment-contract.md"),
   ]);
-
   const devLoopStep7Match = copilotPrFollowupSkill.match(/## Step 7: Pi review\/fix follow-up loop[\s\S]*?(?=\n## Step 8|$)/);
   const devLoopStep7 = devLoopStep7Match ? devLoopStep7Match[0] : "";
   assert.ok(devLoopStep7.length > 0, "copilot-pr-followup Step 7 section not found");
-
   const devLoopDraftGateMatch = devLoopStep7.match(/### Draft gate contract[\s\S]*?(?=\n### |$)/);
   const devLoopDraftGate = devLoopDraftGateMatch ? devLoopDraftGateMatch[0] : "";
   assert.ok(devLoopDraftGate.length > 0, "copilot-pr-followup draft-gate section not found inside Step 7");
-
   const devLoopPreApprovalMatch = devLoopStep7.match(/### Pre-approval gate contract[\s\S]*?(?=\n## |\n### |$)/);
   const devLoopPreApproval = devLoopPreApprovalMatch ? devLoopPreApprovalMatch[0] : "";
   assert.ok(devLoopPreApproval.length > 0, "copilot-pr-followup pre-approval gate section not found inside Step 7");
-
   assert.match(copilotPrFollowupSkill, /canonical internal `copilot_pr_followup` route behind the public `dev-loop` façade/i);
   assert.match(copilotPrFollowupSkill, /canonical internal owner of the shared post-PR mechanics/i);
   assert.match(gateContract, /visible gate-review comment evidence contract only/i);
-
   const expectedDevLoopShape = [/Gate name:/i, /Trigger \/ boundary:/i, /Review angles:/i, /Pass criteria:/i, /Next step after passing:/i];
   for (const [label, section] of [
     ["copilot-pr-followup draft gate", devLoopDraftGate],
@@ -41,15 +35,12 @@ test("copilot review gates keep phase-specific angle ownership in one canonical 
     }
     assert.doesNotMatch(section, /Gate role:/i, `${label} should not introduce extra template-only fields that drift across gates`);
   }
-
   const draftAnglePatterns = [/resolveGateAngles\(config, "draft"\)/i, /scope.*coverage.*correctness/i];
   const preApprovalAnglePatterns = [/resolveGateAngles\(config, "preApproval"\)/];
-
   const devLoopDraftOwnedAnglesMatch = devLoopDraftGate.match(/Review angles:[\s\S]*?(?=\n- \*\*Pass criteria)/i);
   const devLoopDraftOwnedAngles = devLoopDraftOwnedAnglesMatch ? devLoopDraftOwnedAnglesMatch[0] : "";
   const devLoopPreApprovalOwnedAnglesMatch = devLoopPreApproval.match(/Review angles:[\s\S]*?(?=\n- \*\*Pass criteria)/i);
   const devLoopPreApprovalOwnedAngles = devLoopPreApprovalOwnedAnglesMatch ? devLoopPreApprovalOwnedAnglesMatch[0] : "";
-
   for (const pattern of draftAnglePatterns) {
     assert.match(devLoopDraftOwnedAngles, pattern);
   }
@@ -64,14 +55,37 @@ test("copilot review gates keep phase-specific angle ownership in one canonical 
     assert.doesNotMatch(devLoopPreApprovalOwnedAngles, pattern);
   }
 });
-
+test("copilot-pr-followup skill routes review requests and wait seams through deterministic helpers", async () => {
+  const skillContent = await readRepo("skills/copilot-pr-followup/SKILL.md");
+  const requestSectionMatch = skillContent.match(/When confirming whether Copilot is requested as a reviewer,[\s\S]*?## Step 6: Async watch behavior/);
+  const requestSection = requestSectionMatch ? requestSectionMatch[0] : "";
+  assert.ok(requestSection.length > 0, "request/wait section not found");
+  assert.match(requestSection, /request-copilot-review\.mjs/i);
+  assert.match(requestSection, /--force-rerequest-review/i);
+  assert.match(requestSection, /Do \*\*not\*\* request Copilot by posting literal `\/copilot` or `\/copilot re-review` PR comments\./i);
+  assert.match(requestSection, /`requested`:/i);
+  assert.match(requestSection, /`already-requested`:/i);
+  assert.match(requestSection, /`suppressed_same_head_clean`:/i);
+  assert.match(requestSection, /`unavailable`:/i);
+  const step6Match = skillContent.match(/## Step 6: Async watch behavior[\s\S]*?(?=\n## Step 7|$)/);
+  const step6 = step6Match ? step6Match[0] : "";
+  assert.ok(step6.length > 0, "copilot-pr-followup Step 6 section not found");
+  assert.match(step6, /detect-copilot-loop-state\.mjs/i);
+  assert.match(step6, /run-copilot-watch-cycle\.mjs/i);
+  assert.match(step6, /gh run watch <run-id> --repo <owner\/name>/i);
+  assert.match(step6, /helper-owned sleep inside `run-copilot-watch-cycle\.mjs`, `watch-copilot-review\.mjs`, or `watch-initial-copilot-pr\.mjs` is allowed/i);
+  assert.match(step6, /agent-authored shell polling is forbidden/i);
+  assert.match(step6, /for i in \$\(seq \.\.\.\)/i);
+  assert.match(step6, /while true/i);
+  assert.match(step6, /until \.\.\.; do sleep \.\.\.; done/i);
+  assert.match(step6, /do not wrap repeated `gh pr view`, `gh pr checks`, `gh api`, or `detect-copilot-loop-state\.mjs` calls inside shell polling loops/i);
+});
 test("copilot-pr-followup skill keeps async watch persistence explicit", async () => {
   const [skillContent, scriptsReadme, stateGraph] = await Promise.all([
     readRepo("skills/copilot-pr-followup/SKILL.md"),
     readRepo("scripts/README.md"),
     readRepo("docs/copilot-loop-state-graph.md"),
   ]);
-
   assert.match(skillContent, /run-copilot-watch-cycle\.mjs/i);
   assert.match(skillContent, /zero-timeout `idle` probes are for explicit one-shot status\/reattach checks only/i);
   assert.match(skillContent, /returning to `waiting_for_copilot_review` is a persistence boundary: resume the watcher instead of reporting completion/i);
@@ -84,10 +98,8 @@ test("copilot-pr-followup skill keeps async watch persistence explicit", async (
   assert.match(stateGraph, /`waiting_for_copilot_review` is a persistence boundary for explicit async loop entry/i);
   assert.match(stateGraph, /If the next deterministic state returns to `waiting_for_copilot_review`, resume watch mode again instead of treating the re-request handoff as the end of the async run/i);
 });
-
 test("copilot-pr-followup skill hardens reply-resolve, gate sequencing, and merge-ready checks", async () => {
   const skillContent = await readRepo("skills/copilot-pr-followup/SKILL.md");
-
   const step6Match = skillContent.match(/## Step 6: Async watch behavior[\s\S]*?(?=\n## Step 7|$)/);
   const step6 = step6Match ? step6Match[0] : "";
   assert.ok(step6.length > 0, "copilot-pr-followup Step 6 section not found");
@@ -101,21 +113,52 @@ test("copilot-pr-followup skill hardens reply-resolve, gate sequencing, and merg
     /Before reporting merge-ready or stopping at the human approval gate, you must complete the pre_approval_gate procedure and verify that a visible clean gate-review comment exists on the PR for the current head SHA\. Do not stop or report completion without this evidence\./i,
     "Step 6 should embed the required pre-approval gate dispatch clause verbatim",
   );
-
   const step7Match = skillContent.match(/## Step 7: Pi review\/fix follow-up loop[\s\S]*?(?=\n## Validation policy|$)/);
   const step7 = step7Match ? step7Match[0] : "";
   assert.ok(step7.length > 0, "copilot-pr-followup Step 7 section not found");
-
   assert.match(
     step7,
     /must use the deterministic helper `reply-resolve-review-thread\.mjs`/i,
     "Step 7 should require the reply-resolve helper",
+  );
+  assert.match(
+    step7,
+    /reply-resolve-review-threads\.mjs/i,
+    "Step 7 should reference the deterministic batch reply-resolve helper for multi-thread follow-up",
   );
   assert.doesNotMatch(
     step7,
     /prefer the deterministic helper `reply-resolve-review-thread\.mjs`/i,
     "Step 7 should not leave the reply-resolve helper optional",
   );
+  assert.match(
+    step7,
+    /before resolving an addressed review thread, run a post-fix verification checkpoint/i,
+    "Step 7 should require a post-fix verification checkpoint before thread resolution",
+  );
+  assert.match(
+    step7,
+    /confirm the GitHub reply actually exists on the intended thread\/comment/i,
+    "verification checkpoint should require confirming the GitHub reply exists",
+  );
+  assert.match(
+    step7,
+    /confirm the pushed current-head diff genuinely addresses the reviewer concern/i,
+    "verification checkpoint should require confirming the pushed fix addresses the concern",
+  );
+  assert.match(
+    step7,
+    /including `unresolvedThreadCount`/i,
+    "verification checkpoint should require refreshed API-backed unresolvedThreadCount data",
+  );
+  assert.match(
+    step7,
+    /if any verification check fails, do \*\*not\*\* resolve the thread; leave it open/i,
+    "verification checkpoint should keep threads open when verification fails",
+  );
+  const verificationIndex = step7.indexOf("before resolving an addressed review thread, run a post-fix verification checkpoint");
+  const resolveIndex = step7.indexOf("resolve the addressed review thread only after the reply is attached successfully");
+  assert.ok(verificationIndex >= 0 && resolveIndex > verificationIndex, "verification checkpoint must appear before the resolve step");
   assert.match(
     step7,
     /verify `unresolvedThreadCount === 0` via `capture-review-threads\.mjs` before proceeding/i,
@@ -161,11 +204,10 @@ test("copilot-pr-followup skill hardens reply-resolve, gate sequencing, and merg
     /If any check fails, do not declare merge-ready\./i,
     "merge-ready preconditions should be a hard gate",
   );
-
   const antiPatternsMatch = skillContent.match(/## Anti-patterns[\s\S]*?(?=\n## Recommended companion skills|$)/);
   const antiPatterns = antiPatternsMatch ? antiPatternsMatch[0] : "";
   assert.ok(antiPatterns.length > 0, "copilot-pr-followup anti-patterns section not found");
-  assert.match(antiPatterns, /use inline `gh api` to post thread replies without the resolve mutation/i);
+  assert.match(antiPatterns, /use ad hoc inline `gh api` or `gh api graphql` thread-mutation commands instead of the deterministic `reply-resolve-review-thread\.mjs` \/ `reply-resolve-review-threads\.mjs` helpers/i);
   assert.match(antiPatterns, /declare merge-ready without a visible `pre_approval_gate` comment on the current head SHA/i);
   assert.match(antiPatterns, /declare merge-ready based solely on `mergeable_state: clean` \+ CI green without gate evidence/i);
   assert.match(antiPatterns, /dispatch an async dev-loop task that omits the pre-approval gate requirement/i);
@@ -190,17 +232,14 @@ test("legacy copilot workflow entrypoint agents are removed from normal executab
   const agentFiles = (await readdir(fromRepoRoot("agents")))
     .filter((name) => name.endsWith(".agent.md"))
     .sort();
-
   assert.equal(agentFiles.includes("copilot-pr-followup.agent.md"), false);
   assert.equal(agentFiles.includes("copilot-autopilot.agent.md"), false);
 });
-
 test("public dev-loop agent is a thin executable entrypoint that defers to the public skill router", async () => {
   const [agentContent, skillContent] = await Promise.all([
     readRepo("agents/dev-loop.agent.md"),
     readRepo("skills/dev-loop/SKILL.md"),
   ]);
-
   assert.match(agentContent, /name:\s*"dev-loop"/);
   assert.match(agentContent, /user-invocable:\s*true/);
   assert.match(agentContent, /skills\/dev-loop\/SKILL\.md/);
@@ -212,7 +251,6 @@ test("public dev-loop agent is a thin executable entrypoint that defers to the p
   assert.match(agentContent, /local facts, GitHub facts, and helper\/state-machine output do not agree/i);
   assert.match(skillContent, /public `dev-loop` façade/i);
 });
-
 test("thin pointer docs symlink to canonical contract content", async () => {
   const [trackerContent, conductorContent, ciContent, skillContent] = await Promise.all([
     readRepo("docs/tracker-first-mvp-state-graph.md"),
@@ -220,7 +258,6 @@ test("thin pointer docs symlink to canonical contract content", async () => {
     readRepo("docs/copilot-ci-status-contract.md"),
     readRepo("skills/copilot-pr-followup/SKILL.md"),
   ]);
-
   // Symlink reads resolve to each canonical target's content.
   assert.match(trackerContent, /Tracker-First Story-to-PR Contract/i);
   assert.match(trackerContent, /MVP invariant: one tracker work item → one GitHub PR/i);
@@ -228,10 +265,8 @@ test("thin pointer docs symlink to canonical contract content", async () => {
   assert.match(conductorContent, /conductor routing contract/i);
   assert.match(ciContent, /Copilot PR CI\/check normalization contract/i);
   assert.match(ciContent, /canonical bundled contract/i);
-
   assert.match(skillContent, /inherits[\s\S]*source-of-truth ownership[\s\S]*work item <-> PR link[\s\S]*reverse-sync semantics from\s*`#21`/i);
 });
-
 test("new See Also markdown links resolve from docs files", async () => {
   const linkTargetsByDoc = {
     "docs/gate-review-comment-contract.md": [
@@ -253,7 +288,6 @@ test("new See Also markdown links resolve from docs files", async () => {
       "../AGENTS.md",
     ],
   };
-
   for (const [docPath, targets] of Object.entries(linkTargetsByDoc)) {
     const doc = await readRepo(docPath);
     for (const target of targets) {
@@ -265,10 +299,8 @@ test("new See Also markdown links resolve from docs files", async () => {
     }
   }
 });
-
 test("docs index separates active docs, archived history, and presentations", async () => {
   const content = await readRepo("docs/index.md");
-
   assert.match(content, /Start here/i);
   assert.match(content, /phases\/phase-7\.md/i);
   assert.match(content, /archive\/phases\/phase-0\.md/i);
@@ -276,13 +308,10 @@ test("docs index separates active docs, archived history, and presentations", as
   assert.match(content, /presentations\/applied-dev-loops-presentation\.md/i);
   assert.match(content, /presentations\/style\.css/i);
 });
-
 test("gate-review comment contract documents required fields, verdict values, rerun rules, and fail-closed behavior", async () => {
   const contractContent = await readRepo("docs/gate-review-comment-contract.md");
-
   assert.match(contractContent, /visible gate-review comment evidence contract only/i);
   assert.match(contractContent, /does[\s\S]*not restate the full PR follow-up procedure/i);
-
   // Required fields
   assert.match(contractContent, /gate name/i);
   assert.match(contractContent, /head SHA/i);
@@ -296,11 +325,9 @@ test("gate-review comment contract documents required fields, verdict values, re
   assert.match(contractContent, /rerun gate/i);
   assert.match(contractContent, /mark ready for review/i);
   assert.match(contractContent, /await final human approval/i);
-
   // Both gate names must appear
   assert.match(contractContent, /draft_gate/);
   assert.match(contractContent, /pre_approval_gate/);
-
   // Rerun rules: same-head idempotent, new-head → new comment
   assert.match(contractContent, /same.head/i);
   assert.match(contractContent, /idempotent/i);
@@ -312,22 +339,18 @@ test("gate-review comment contract documents required fields, verdict values, re
   assert.match(contractContent, /raw passing log streams|raw passing test output/i);
   assert.match(contractContent, /deterministic retained-prefix length/i);
   assert.match(contractContent, /focused relevant excerpt/i);
-
   // Findings-specific and fail-closed behavior
   assert.match(contractContent, /stays draft and fixes are required before retrying/i);
   assert.match(contractContent, /follow-up fixes are required before final approval/i);
   assert.match(contractContent, /fail.closed|cannot be posted/i);
   assert.match(contractContent, /do not run `gh pr ready`|do not mark the PR ready/i);
   assert.match(contractContent, /do not declare final.approval readiness/i);
-
   // Draft vs pre-approval distinction must stay explicit
   assert.match(contractContent, /A clean `draft_gate` comment does \*\*not\*\* satisfy `pre_approval_gate` requirements/i);
   assert.match(contractContent, /A clean `pre_approval_gate` comment does \*\*not\*\* retroactively replace the required `draft_gate` evidence/i);
 });
-
 test("gate-review comment ownership stays explicit in the canonical internal skill file", async () => {
   const copilotPrFollowupSkill = await readRepo("skills/copilot-pr-followup/SKILL.md");
-
   const devLoopDraftGateMatch = copilotPrFollowupSkill.match(/### Draft gate contract[\s\S]*?(?=\n### |\n## |$)/);
   const devLoopDraftGate = devLoopDraftGateMatch ? devLoopDraftGateMatch[0] : "";
   assert.ok(devLoopDraftGate.length > 0, "copilot-pr-followup draft gate section not found");
@@ -343,7 +366,6 @@ test("gate-review comment ownership stays explicit in the canonical internal ski
   assert.match(devLoopDraftGate, /command names with pass.fail status/i);
   assert.match(devLoopDraftGate, /raw passing test output/i);
   assert.match(devLoopDraftGate, /truncate it to a deterministic retained-prefix length/i);
-
   const devLoopPreApprovalGateMatch = copilotPrFollowupSkill.match(/### Pre-approval gate contract[\s\S]*?(?=\n### |\n## |$)/);
   const devLoopPreApprovalGate = devLoopPreApprovalGateMatch ? devLoopPreApprovalGateMatch[0] : "";
   assert.ok(devLoopPreApprovalGate.length > 0, "copilot-pr-followup pre-approval gate section not found");
@@ -361,10 +383,8 @@ test("gate-review comment ownership stays explicit in the canonical internal ski
   assert.match(devLoopPreApprovalGate, /raw passing test output/i);
   assert.match(devLoopPreApprovalGate, /truncate it to a deterministic retained-prefix length/i);
 });
-
 test("issue-intake skill documents epic decomposition with GitHub sub-issue trees", async () => {
   const skillContent = await readRepo("skills/copilot-pr-followup/SKILL.md");
-
   assert.match(skillContent, /GitHub sub-issue trees/i);
   assert.match(skillContent, /Prefer real sub-issue linkage over parent-body checklists/i);
   assert.match(skillContent, /parent issue body should stay lean/i);
@@ -377,10 +397,8 @@ test("issue-intake skill documents epic decomposition with GitHub sub-issue tree
   assert.match(skillContent, /sub-issue-tree-contract\.md/i);
   assert.match(skillContent, /\.\.\/\.\.\/docs\/sub-issue-tree-contract\.md/i);
 });
-
 test("sub-issue tree contract documents the workflow, helper commands, and lean-body rule", async () => {
   const contractContent = await readRepo("docs/sub-issue-tree-contract.md");
-
   assert.match(contractContent, /manage-sub-issues\.mjs/i);
   assert.match(contractContent, /list/i);
   assert.match(contractContent, /add/i);
@@ -393,9 +411,7 @@ test("sub-issue tree contract documents the workflow, helper commands, and lean-
   assert.match(contractContent, /When to use sub-issues vs plain related-issue references/i);
   assert.match(contractContent, /dev-loop/i);
 });
-
 test("docs index references sub-issue-tree-contract.md", async () => {
   const indexContent = await readRepo("docs/index.md");
-
   assert.match(indexContent, /sub-issue-tree-contract\.md/i);
 });

--- a/test/github/reply-resolve-review-threads.test.mjs
+++ b/test/github/reply-resolve-review-threads.test.mjs
@@ -1,0 +1,684 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import test from "node:test";
+
+import { parseReplyResolveThreadsCliArgs } from "../../scripts/github/reply-resolve-review-threads.mjs";
+
+const scriptPath = path.resolve("scripts/github/reply-resolve-review-threads.mjs");
+
+function runNode(args = [], options = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [scriptPath, ...args], {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    child.stdin.end(options.stdinText ?? "");
+
+    child.on("close", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+function createReviewThreadsPayload(threads) {
+  return `${JSON.stringify({
+    data: {
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            nodes: threads,
+          },
+        },
+      },
+    },
+  })}\n`;
+}
+
+async function writeGhStub(tempDir, entries) {
+  const sequencePath = path.join(tempDir, "gh-sequence.json");
+  const counterPath = path.join(tempDir, "gh-counter.txt");
+  const ghPath = path.join(tempDir, "gh");
+  const ghLogPath = path.join(tempDir, "gh-log.jsonl");
+
+  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
+  await writeFile(counterPath, "0\n", "utf8");
+  await writeFile(ghLogPath, "", "utf8");
+  await writeFile(
+    ghPath,
+    [
+      "#!/usr/bin/env node",
+      'import { appendFileSync, readFileSync, writeFileSync } from "node:fs";',
+      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
+      "const counterPath = process.env.GH_COUNTER_PATH;",
+      "const ghLogPath = process.env.GH_LOG_PATH;",
+      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
+      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
+      'const entry = entries[Math.min(current, entries.length - 1)] ?? { stdout: "{}\\n" };',
+      'writeFileSync(counterPath, String(current + 1));',
+      'appendFileSync(ghLogPath, `${JSON.stringify(process.argv.slice(2))}\\n`);',
+      'const actual = process.argv.slice(2);',
+      'let stdin = "";',
+      'process.stdin.setEncoding("utf8");',
+      'process.stdin.on("data", (chunk) => { stdin += chunk; });',
+      'if (entry.assertArgs) {',
+      '  for (const expected of entry.assertArgs) {',
+      '    if (!actual.includes(expected)) {',
+      '      process.stderr.write(`missing expected gh arg: ${expected}\\n`);',
+      '      process.exit(98);',
+      '    }',
+      '  }',
+      '}',
+      'process.stdin.on("end", () => {',
+      'if (entry.assertStdinIncludes) {',
+      '  for (const expected of entry.assertStdinIncludes) {',
+      '    if (!stdin.includes(expected)) {',
+      '      process.stderr.write(`missing expected stdin text: ${expected}\\n`);',
+      '      process.exit(97);',
+      '    }',
+      '  }',
+      '}',
+      'if (entry.stderr) {',
+      '  process.stderr.write(entry.stderr);',
+      '}',
+      'if (entry.stdout) {',
+      '  process.stdout.write(entry.stdout);',
+      '}',
+      'process.exit(entry.exitCode ?? 0);',
+      '});',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await chmod(ghPath, 0o755);
+
+  return {
+    env: {
+      ...process.env,
+      PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
+      GH_SEQUENCE_PATH: sequencePath,
+      GH_COUNTER_PATH: counterPath,
+      GH_LOG_PATH: ghLogPath,
+    },
+    ghLogPath,
+  };
+}
+
+test("parseReplyResolveThreadsCliArgs sets defaults and parses optional flags", () => {
+  assert.deepEqual(
+    parseReplyResolveThreadsCliArgs(["--repo", "owner/repo", "--pr", "17"]),
+    {
+      help: false,
+      repo: "owner/repo",
+      pr: 17,
+      author: "Copilot",
+      message: undefined,
+      resolve: false,
+    },
+  );
+
+  assert.deepEqual(
+    parseReplyResolveThreadsCliArgs(["--repo", "owner/repo", "--pr", "17", "--author", "reviewer-x", "--message", "Fixed in abc1234", "--resolve"]),
+    {
+      help: false,
+      repo: "owner/repo",
+      pr: 17,
+      author: "reviewer-x",
+      message: "Fixed in abc1234",
+      resolve: true,
+    },
+  );
+});
+
+test("reply-resolve-review-threads rejects malformed arguments and conflicting or empty message input", async () => {
+  const missing = await runNode(["--repo", "owner/repo"]);
+  assert.equal(missing.code, 1);
+  assert.equal(missing.stdout, "");
+  const missingParsed = JSON.parse(missing.stderr);
+  assert.equal(missingParsed.ok, false);
+  assert.match(missingParsed.error, /requires both --repo <owner\/name> and --pr <number>/);
+  assert.match(missingParsed.usage, /reply-resolve-review-threads\.mjs/);
+
+  const conflicting = await runNode(
+    ["--repo", "owner/repo", "--pr", "17", "--message", "Fixed in 93cd7f8 with enough detail to satisfy the contract"],
+    { stdinText: "Also from stdin\n" },
+  );
+  assert.equal(conflicting.code, 1);
+  assert.equal(conflicting.stdout, "");
+  const conflictingParsed = JSON.parse(conflicting.stderr);
+  assert.equal(conflictingParsed.ok, false);
+  assert.equal(conflictingParsed.error, "Choose exactly one message source: --message <text> or stdin");
+  assert.match(conflictingParsed.usage, /reply-resolve-review-threads\.mjs/);
+
+  const emptyMessage = await runNode(
+    ["--repo", "owner/repo", "--pr", "17", "--message", "   "],
+    { stdinText: "" },
+  );
+  assert.equal(emptyMessage.code, 1);
+  assert.equal(emptyMessage.stdout, "");
+  const emptyParsed = JSON.parse(emptyMessage.stderr);
+  assert.equal(emptyParsed.ok, false);
+  assert.equal(emptyParsed.error, "Reply message must contain non-empty text");
+  assert.match(emptyParsed.usage, /reply-resolve-review-threads\.mjs/);
+});
+
+test("reply-resolve-review-threads replies to matching unresolved threads without resolving by default", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-threads-reply-only-"));
+
+  try {
+    const gh = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "graphql", "--field", "owner=owner", "--field", "name=repo", "--field", "pr=17"],
+        stdout: createReviewThreadsPayload([
+          {
+            id: "THREAD_1",
+            isResolved: false,
+            comments: {
+              nodes: [
+                { id: "PRRC_node_101", databaseId: 101, body: "copilot note", author: { login: "Copilot", __typename: "Bot" } },
+                { id: "PRRC_node_102", databaseId: 102, body: "human note", author: { login: "reviewer", __typename: "User" } },
+              ],
+            },
+          },
+          {
+            id: "THREAD_2",
+            isResolved: false,
+            comments: {
+              nodes: [
+                { id: "PRRC_node_201", databaseId: 201, body: "another copilot note", author: { login: "Copilot", __typename: "Bot" } },
+              ],
+            },
+          },
+          {
+            id: "THREAD_3",
+            isResolved: false,
+            comments: {
+              nodes: [
+                { id: "PRRC_node_301", databaseId: 301, body: "human only", author: { login: "reviewer", __typename: "User" } },
+              ],
+            },
+          },
+          {
+            id: "THREAD_4",
+            isResolved: true,
+            comments: {
+              nodes: [
+                { id: "PRRC_node_401", databaseId: 401, body: "already done", author: { login: "Copilot", __typename: "Bot" } },
+              ],
+            },
+          },
+        ]),
+      },
+      {
+        assertArgs: ["api", "-X", "POST", "repos/owner/repo/pulls/17/comments/101/replies", "--input", "-"],
+        assertStdinIncludes: ['"body":"Fixed in 93cd7f8 with enough detail to satisfy the resolution contract."'],
+        stdout: '{"id":501,"html_url":"https://github.com/owner/repo/pull/17#discussion_r501"}\n',
+      },
+      {
+        assertArgs: ["api", "-X", "POST", "repos/owner/repo/pulls/17/comments/201/replies", "--input", "-"],
+        assertStdinIncludes: ['"body":"Fixed in 93cd7f8 with enough detail to satisfy the resolution contract."'],
+        stdout: '{"id":502,"html_url":"https://github.com/owner/repo/pull/17#discussion_r502"}\n',
+      },
+    ]);
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--message", "Fixed in 93cd7f8 with enough detail to satisfy the resolution contract."],
+      { env: gh.env },
+    );
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      repo: "owner/repo",
+      pr: 17,
+      author: "Copilot",
+      resolve: false,
+      matchedThreadCount: 2,
+      repliedThreadCount: 2,
+      resolvedThreadCount: 0,
+      skippedThreadCount: 1,
+      results: [
+        {
+          threadId: "THREAD_1",
+          commentId: 101,
+          replyId: 501,
+          replyUrl: "https://github.com/owner/repo/pull/17#discussion_r501",
+          resolved: false,
+        },
+        {
+          threadId: "THREAD_2",
+          commentId: 201,
+          replyId: 502,
+          replyUrl: "https://github.com/owner/repo/pull/17#discussion_r502",
+          resolved: false,
+        },
+      ],
+    });
+
+    const ghLog = (await readFile(gh.ghLogPath, "utf8")).trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
+    assert.equal(ghLog.length, 3);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("reply-resolve-review-threads resolves matched threads and verifies they stay resolved", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-threads-resolve-"));
+
+  try {
+    const gh = await writeGhStub(tempDir, [
+      {
+        stdout: createReviewThreadsPayload([
+          {
+            id: "THREAD_1",
+            isResolved: false,
+            comments: {
+              nodes: [
+                { id: "PRRC_node_201", databaseId: 201, body: "copilot note", author: { login: "Copilot", __typename: "Bot" } },
+              ],
+            },
+          },
+          {
+            id: "THREAD_2",
+            isResolved: false,
+            comments: {
+              nodes: [
+                { id: "PRRC_node_302", databaseId: 302, body: "copilot note 2", author: { login: "Copilot", __typename: "Bot" } },
+              ],
+            },
+          },
+        ]),
+      },
+      {
+        assertArgs: ["repos/owner/repo/pulls/17/comments/201/replies"],
+        stdout: '{"id":601,"html_url":"https://github.com/owner/repo/pull/17#discussion_r601"}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "--field", "threadId=THREAD_1"],
+        stdout: '{"data":{"resolveReviewThread":{"thread":{"id":"THREAD_1","isResolved":true}}}}\n',
+      },
+      {
+        assertArgs: ["repos/owner/repo/pulls/17/comments/302/replies"],
+        stdout: '{"id":602,"html_url":"https://github.com/owner/repo/pull/17#discussion_r602"}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "--field", "threadId=THREAD_2"],
+        stdout: '{"data":{"resolveReviewThread":{"thread":{"id":"THREAD_2","isResolved":true}}}}\n',
+      },
+      {
+        stdout: createReviewThreadsPayload([
+          {
+            id: "THREAD_1",
+            isResolved: true,
+            comments: { nodes: [] },
+          },
+          {
+            id: "THREAD_2",
+            isResolved: true,
+            comments: { nodes: [] },
+          },
+        ]),
+      },
+    ]);
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--message", "Fixed in 93cd7f8 with enough detail to satisfy the resolution contract.", "--resolve"],
+      { env: gh.env },
+    );
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      repo: "owner/repo",
+      pr: 17,
+      author: "Copilot",
+      resolve: true,
+      matchedThreadCount: 2,
+      repliedThreadCount: 2,
+      resolvedThreadCount: 2,
+      skippedThreadCount: 0,
+      results: [
+        {
+          threadId: "THREAD_1",
+          commentId: 201,
+          replyId: 601,
+          replyUrl: "https://github.com/owner/repo/pull/17#discussion_r601",
+          resolved: true,
+        },
+        {
+          threadId: "THREAD_2",
+          commentId: 302,
+          replyId: 602,
+          replyUrl: "https://github.com/owner/repo/pull/17#discussion_r602",
+          resolved: true,
+        },
+      ],
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("reply-resolve-review-threads chooses the newest matching author-authored comment as the reply target", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-threads-newest-comment-"));
+
+  try {
+    const gh = await writeGhStub(tempDir, [
+      {
+        stdout: createReviewThreadsPayload([
+          {
+            id: "THREAD_1",
+            isResolved: false,
+            comments: {
+              nodes: [
+                { id: "PRRC_node_101", databaseId: 101, body: "older note", author: { login: "Copilot", __typename: "Bot" } },
+                { id: "PRRC_node_105", databaseId: 105, body: "reviewer note", author: { login: "reviewer", __typename: "User" } },
+                { id: "PRRC_node_109", databaseId: 109, body: "newest note", author: { login: "Copilot", __typename: "Bot" } },
+              ],
+            },
+          },
+        ]),
+      },
+      {
+        assertArgs: ["repos/owner/repo/pulls/17/comments/109/replies"],
+        stdout: '{"id":701,"html_url":"https://github.com/owner/repo/pull/17#discussion_r701"}\n',
+      },
+    ]);
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--message", "Fixed in 93cd7f8 with enough detail to satisfy the resolution contract."],
+      { env: gh.env },
+    );
+
+    assert.equal(result.code, 0);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.results[0].commentId, 109);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("reply-resolve-review-threads returns deterministic success when nothing matches", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-threads-noop-"));
+
+  try {
+    const gh = await writeGhStub(tempDir, [
+      {
+        stdout: createReviewThreadsPayload([
+          {
+            id: "THREAD_DONE",
+            isResolved: true,
+            comments: {
+              nodes: [
+                { id: "PRRC_node_901", databaseId: 901, body: "done", author: { login: "Copilot", __typename: "Bot" } },
+              ],
+            },
+          },
+        ]),
+      },
+    ]);
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--message", "Fixed in 93cd7f8 with enough detail to satisfy the resolution contract."],
+      { env: gh.env },
+    );
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      repo: "owner/repo",
+      pr: 17,
+      author: "Copilot",
+      resolve: false,
+      matchedThreadCount: 0,
+      repliedThreadCount: 0,
+      resolvedThreadCount: 0,
+      skippedThreadCount: 0,
+      results: [],
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("reply-resolve-review-threads fails closed on malformed capture payloads", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-threads-bad-payload-"));
+
+  try {
+    const gh = await writeGhStub(tempDir, [
+      {
+        stdout: '{"data":{"repository":{"pullRequest":{"notReviewThreads":[]}}}}\n',
+      },
+    ]);
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--message", "Fixed in 93cd7f8 with enough detail to satisfy the resolution contract."],
+      { env: gh.env },
+    );
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    assert.deepEqual(JSON.parse(result.stderr), {
+      ok: false,
+      error: "Could not find review threads in payload",
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("reply-resolve-review-threads stops on reply failure and reports partial progress", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-threads-partial-"));
+
+  try {
+    const gh = await writeGhStub(tempDir, [
+      {
+        stdout: createReviewThreadsPayload([
+          {
+            id: "THREAD_1",
+            isResolved: false,
+            comments: { nodes: [{ id: "PRRC_node_101", databaseId: 101, body: "note", author: { login: "Copilot", __typename: "Bot" } }] },
+          },
+          {
+            id: "THREAD_2",
+            isResolved: false,
+            comments: { nodes: [{ id: "PRRC_node_202", databaseId: 202, body: "note", author: { login: "Copilot", __typename: "Bot" } }] },
+          },
+        ]),
+      },
+      {
+        assertArgs: ["repos/owner/repo/pulls/17/comments/101/replies"],
+        stdout: '{"id":801,"html_url":"https://github.com/owner/repo/pull/17#discussion_r801"}\n',
+      },
+      {
+        assertArgs: ["repos/owner/repo/pulls/17/comments/202/replies"],
+        stderr: 'gh: forbidden\n',
+        exitCode: 1,
+      },
+    ]);
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--message", "Fixed in 93cd7f8 with enough detail to satisfy the resolution contract."],
+      { env: gh.env },
+    );
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const parsed = JSON.parse(result.stderr);
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.error, "gh command failed: gh: forbidden");
+    assert.deepEqual(parsed.partialProgress, {
+      repo: "owner/repo",
+      pr: 17,
+      author: "Copilot",
+      resolve: false,
+      matchedThreadCount: 2,
+      repliedThreadCount: 1,
+      resolvedThreadCount: 0,
+      skippedThreadCount: 0,
+      results: [
+        {
+          threadId: "THREAD_1",
+          commentId: 101,
+          replyId: 801,
+          replyUrl: "https://github.com/owner/repo/pull/17#discussion_r801",
+          resolved: false,
+        },
+      ],
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("reply-resolve-review-threads fails closed when post-resolve verification still finds targeted unresolved threads", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-threads-verify-fail-"));
+
+  try {
+    const gh = await writeGhStub(tempDir, [
+      {
+        stdout: createReviewThreadsPayload([
+          {
+            id: "THREAD_1",
+            isResolved: false,
+            comments: { nodes: [{ id: "PRRC_node_101", databaseId: 101, body: "note", author: { login: "Copilot", __typename: "Bot" } }] },
+          },
+        ]),
+      },
+      {
+        assertArgs: ["repos/owner/repo/pulls/17/comments/101/replies"],
+        stdout: '{"id":901,"html_url":"https://github.com/owner/repo/pull/17#discussion_r901"}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "--field", "threadId=THREAD_1"],
+        stdout: '{"data":{"resolveReviewThread":{"thread":{"id":"THREAD_1","isResolved":true}}}}\n',
+      },
+      {
+        stdout: createReviewThreadsPayload([
+          {
+            id: "THREAD_1",
+            isResolved: false,
+            comments: { nodes: [{ id: "PRRC_node_101", databaseId: 101, body: "note", author: { login: "Copilot", __typename: "Bot" } }] },
+          },
+        ]),
+      },
+    ]);
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--message", "Fixed in 93cd7f8 with enough detail to satisfy the resolution contract.", "--resolve"],
+      { env: gh.env },
+    );
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const parsed = JSON.parse(result.stderr);
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.error, "Post-resolve verification failed; targeted thread(s) remain unresolved: THREAD_1");
+    assert.deepEqual(parsed.partialProgress, {
+      repo: "owner/repo",
+      pr: 17,
+      author: "Copilot",
+      resolve: true,
+      matchedThreadCount: 1,
+      repliedThreadCount: 1,
+      resolvedThreadCount: 1,
+      skippedThreadCount: 0,
+      results: [
+        {
+          threadId: "THREAD_1",
+          commentId: 101,
+          replyId: 901,
+          replyUrl: "https://github.com/owner/repo/pull/17#discussion_r901",
+          resolved: true,
+        },
+      ],
+      stillUnresolvedThreadIds: ["THREAD_1"],
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("reply-resolve-review-threads preserves leading whitespace and newlines from stdin", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-threads-stdin-whitespace-"));
+
+  try {
+    const gh = await writeGhStub(tempDir, [
+      {
+        stdout: createReviewThreadsPayload([
+          {
+            id: "THREAD_1",
+            isResolved: false,
+            comments: { nodes: [{ id: "PRRC_node_101", databaseId: 101, body: "note", author: { login: "Copilot", __typename: "Bot" } }] },
+          },
+        ]),
+      },
+      {
+        assertArgs: ["repos/owner/repo/pulls/17/comments/101/replies"],
+        assertStdinIncludes: ['"body":"\\n  Fixed in 93cd7f8 with enough detail to satisfy the resolution contract.'],
+        stdout: '{"id":1001,"html_url":"https://github.com/owner/repo/pull/17#discussion_r1001"}\n',
+      },
+    ]);
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17"],
+      { env: gh.env, stdinText: "\n  Fixed in 93cd7f8 with enough detail to satisfy the resolution contract.\n" },
+    );
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("reply-resolve-review-threads preserves leading whitespace from --message", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-threads-message-whitespace-"));
+
+  try {
+    const gh = await writeGhStub(tempDir, [
+      {
+        stdout: createReviewThreadsPayload([
+          {
+            id: "THREAD_1",
+            isResolved: false,
+            comments: { nodes: [{ id: "PRRC_node_101", databaseId: 101, body: "note", author: { login: "Copilot", __typename: "Bot" } }] },
+          },
+        ]),
+      },
+      {
+        assertArgs: ["repos/owner/repo/pulls/17/comments/101/replies"],
+        assertStdinIncludes: ['"body":"  Fixed in 93cd7f8 with enough detail to satisfy the resolution contract."'],
+        stdout: '{"id":1002,"html_url":"https://github.com/owner/repo/pull/17#discussion_r1002"}\n',
+      },
+    ]);
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--message", "  Fixed in 93cd7f8 with enough detail to satisfy the resolution contract."],
+      { env: gh.env },
+    );
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/issue-intake-doc-contracts.test.mjs
+++ b/test/issue-intake-doc-contracts.test.mjs
@@ -32,8 +32,8 @@ test("issue-intake skill requires github reply/resolve follow-up and gates waiti
   assert.match(content, /if GitHub CI\/checks for the updated head are known red for a fixable issue, continue remediation instead of re-requesting Copilot/);
   assert.match(content, /only once the updated head is green or credibly green, explicitly re-request Copilot review for the new head/);
   assert.match(content, /wait\/watch loop if the request result is confirmed as `requested` or `already-requested`/);
-  assert.match(content, /`requested`: if another Copilot pass is actually desired/);
-  assert.match(content, /`already-requested`: if another Copilot pass is actually desired/);
+  assert.match(content, /`requested`: if another Copilot pass is actually desired, immediately re-baseline/i);
+  assert.match(content, /`already-requested`: apply the same detector-first rebasing and wait branching as `requested`/i);
   assert.match(content, /`unavailable`: report the limitation and stop/);
   assert.match(content, /stop and report the error rather than (?:entering a sleep\/watch loop|sleeping and hoping for a new review)/);
   assert.match(content, /keep commit SHAs and issue\/PR refs as plain text/i);
@@ -53,7 +53,8 @@ test("issue-intake skill forbids detached bash watcher loops for async follow-up
   const content = await readRepo("skills/copilot-pr-followup/SKILL.md");
 
   assert.match(content, /Pi async subagent|designated async follow-up skill/);
-  assert.match(content, /do not use `nohup`, detached shell jobs, tmux\/screen sessions, or ad hoc `while`\/`sleep` bash loops/);
+  assert.match(content, /do not use `nohup`, detached shell jobs, `tmux`, `screen`, or ad hoc `for i in \$\(seq \.\.\.\)`, `while true`, `until \.\.\.; do sleep \.\.\.; done`, or `sleep`-retry bash loops/);
+  assert.match(content, /agent-authored shell polling is forbidden/i);
   assert.match(content, /stop and report rather than improvising a shell watcher/);
 });
 


### PR DESCRIPTION
## Summary
- add `reply-resolve-review-threads.mjs` plus shared review-thread mutation primitives and batch coverage
- tighten `skills/copilot-pr-followup/SKILL.md` around deterministic Copilot rerequesting, detector-first wait seams, and post-fix verification before thread resolution
- extend doc-contract coverage for no-op `/copilot` comments, wait-loop anti-patterns, and Step 7 verification guidance
- stabilize the Node v24 inspect-run viewer healthcheck test so repo verification stays green

## Scope / context
This batches issues #355, #364, #354, and #362 because they all touch `skills/copilot-pr-followup/SKILL.md` and related deterministic helper/test surfaces.

Key changes:
- #355: canonical skill docs now require `request-copilot-review.mjs`, document `--force-rerequest-review`, and explicitly forbid literal `/copilot` or `/copilot re-review` PR comments as the request mechanism
- #364: wait seams now name `detect-copilot-loop-state.mjs`, `run-copilot-watch-cycle.mjs`, `copilot-pr-handoff.mjs --watch-status ...`, and `gh run watch`; agent-authored `sleep` / `seq` / `for` / `while` / `until` polling is explicitly forbidden
- #354: Step 7 now inserts a post-fix verification checkpoint between reply and resolve, requiring reply existence, concern-addressed verification, and refreshed API-backed thread state including `unresolvedThreadCount`
- #362: new `reply-resolve-review-threads.mjs` batches matched review-thread replies/resolution on one PR and reuses shared single-thread primitives

## Acceptance criteria
- [x] no canonical follow-up skill path tells agents to request Copilot review via literal `/copilot` comments
- [x] PR follow-up wait seams explicitly route through detector/watch helpers instead of shell polling
- [x] Step 7 requires post-fix verification before resolving addressed threads
- [x] `scripts/github/reply-resolve-review-threads.mjs` exists with CLI, deterministic no-op output, fail-closed verification, and tests
- [x] repo verification passes (`npm run verify`)

## Definition of done
- [x] implementation committed on a dedicated branch
- [x] targeted runtime and doc-contract tests added/updated
- [x] `npm run verify` passes locally
- [x] branch pushed and draft PR opened

## Non-goals
- changing gate-comment helper behavior
- redesigning the broader PR loop beyond the bounded Step 7 / wait-seam updates above
- adding compatibility shims for legacy text-comment or ad hoc API mutation flows
