### PR TITLE
feat: audit Copilot review comments for gate/linter gaps

### DIFF
--- a/scripts/github/audit-copilot-comments.mjs
+++ b/scripts/github/audit-copilot-comments.mjs
@@ -22,7 +22,7 @@ Required:
 Optional:
   --output-dir <path>     Output directory (default: tmp/investigation)
 
-Output (stdout, JSON summary):
+Output (stdout, JSON summary; abbreviated example):
   {
     "ok": true,
     "repo": "owner/repo",
@@ -47,8 +47,10 @@ Output (stdout, JSON summary):
     }
   }
 
-  Stdout emits the same full summary object that is written to
-  <output-dir>/copilot-comment-summary.json (default output dir: tmp/investigation).
+  This example is abbreviated; the real summary includes additional fields on
+  categories, recommendations, comments, and files. Stdout emits the same full
+  summary object that is written to <output-dir>/copilot-comment-summary.json
+  (default output dir: tmp/investigation).
 
 Error output (stderr, JSON):
   { "ok": false, "error": "...", "usage": "..." }
@@ -666,7 +668,7 @@ async function runGhJson(args, { env, ghCommand }) {
     throw new Error(`gh command failed: ${detail}`);
   }
 
-  const commandLabel = `gh ${args.join(" ")}`;
+  const commandLabel = `${ghCommand} ${args.join(" ")}`;
   try {
     return parseJsonText(result.stdout);
   } catch (error) {

--- a/scripts/github/audit-copilot-comments.mjs
+++ b/scripts/github/audit-copilot-comments.mjs
@@ -1,0 +1,764 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { formatCliError, isCopilotLogin, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+
+const DEFAULT_OUTPUT_DIR = "tmp/investigation";
+const DEFAULT_JSON_NAME = "copilot-comment-summary.json";
+const DEFAULT_MARKDOWN_NAME = "copilot-comment-categories.md";
+
+const USAGE = `Usage: audit-copilot-comments.mjs --repo <owner/name> [--output-dir <path>]
+
+Scan all pull-request review comments in a repository via the GitHub REST API,
+filter to Copilot-authored comments, classify them into workflow categories, and
+write both a JSON summary and a Markdown report under tmp/investigation/.
+
+Required:
+  --repo <owner/name>     Repository slug (e.g. owner/repo)
+
+Optional:
+  --output-dir <path>     Output directory (default: tmp/investigation)
+
+Output (stdout, JSON):
+  {
+    "ok": true,
+    "repo": "owner/repo",
+    "generatedAt": "2026-06-02T00:00:00.000Z",
+    "totals": {
+      "copilotComments": 123,
+      "prsWithCopilotComments": 17,
+      "uncategorizedComments": 5
+    },
+    "files": {
+      "jsonSummaryPath": "tmp/investigation/copilot-comment-summary.json",
+      "markdownReportPath": "tmp/investigation/copilot-comment-categories.md"
+    }
+  }
+
+Error output (stderr, JSON):
+  { "ok": false, "error": "...", "usage": "..." }
+  { "ok": false, "error": "..." }
+
+Exit codes:
+  0  Success
+  1  Argument error, gh failure, or malformed gh JSON`.trim();
+
+function parseError(message) {
+  return Object.assign(new Error(message), { usage: USAGE });
+}
+
+const CATEGORY_DEFINITIONS = [
+  {
+    id: "placeholder_404",
+    label: "404 placeholders",
+    description: "Placeholder or dead links that resolve to missing pages/resources.",
+    recommendedLens: "link validator",
+    suggestedChecks: ["Validate Markdown/HTML links", "Reject placeholder href targets"],
+    automationFit: "strong",
+    priorityWeight: 3,
+    patterns: [
+      /\b404\b/i,
+      /placeholder\s+(?:link|url|href)/i,
+      /dead\s+link/i,
+      /not\s+found/i,
+      /does\s+not\s+resolve/i,
+      /missing\s+page/i,
+    ],
+  },
+  {
+    id: "broken_paths",
+    label: "Broken relative paths",
+    description: "Relative doc/code paths that no longer point at a real file or section.",
+    recommendedLens: "link validator",
+    suggestedChecks: ["Validate relative Markdown paths", "Check file/anchor existence in repo"],
+    automationFit: "strong",
+    priorityWeight: 3,
+    patterns: [
+      /broken\s+relative\s+path/i,
+      /relative\s+(?:path|link)/i,
+      /wrong\s+relative\s+path/i,
+      /incorrect\s+relative\s+path/i,
+      /(?:link|target)\s+(?:does\s+not|doesn't)\s+exist/i,
+      /(?:link|path)\s+points?\s+to\s+(?:a\s+)?(?:missing|non[- ]existent)/i,
+      /points?\s+to\s+(?:a\s+)?missing\s+(?:file|section|anchor)/i,
+      /missing\s+(?:file|anchor)\b/i,
+    ],
+  },
+  {
+    id: "stale_commands",
+    label: "Stale commands",
+    description: "Removed or outdated commands/scripts still referenced in docs or workflow text.",
+    recommendedLens: "docs angle",
+    suggestedChecks: ["Verify documented npm scripts/CLI commands exist", "Flag removed or renamed command references"],
+    automationFit: "hybrid",
+    priorityWeight: 3,
+    patterns: [
+      /stale\s+(?:command|script|reference)/i,
+      /(?:removed|renamed|outdated)\s+(?:command|script)/i,
+      /(?:command|script)\s+no\s+longer\s+exists/i,
+      /(?:documentation|docs?|readme|usage|help\s+text).*(?:command|script|npm\s+run).*(?:stale|wrong|outdated|removed|renamed)/i,
+      /npm\s+run\s+\S+.*(?:missing|not\s+defined|not\s+found)/i,
+      /(?:command|script)\s+(?:reference|name).*(?:stale|wrong|outdated)/i,
+      /references?\s+an?\s+(?:old|removed|renamed)\s+(?:command|script)/i,
+    ],
+  },
+  {
+    id: "gate_evidence",
+    label: "Gate evidence",
+    description: "Missing or weak evidence that a required workflow gate ran on the intended head.",
+    recommendedLens: "gate evidence lens",
+    suggestedChecks: ["Require visible draft/pre-approval gate evidence", "Validate head SHA + verdict markers before ready/merge states"],
+    automationFit: "strong",
+    priorityWeight: 5,
+    patterns: [
+      /gate\s+evidence/i,
+      /missing\s+(?:draft|pre-approval|gate)\s+(?:evidence|comment|marker)/i,
+      /cannot\s+find\s+(?:any\s+)?(?:draft|pre-approval)\s+gate/i,
+      /visible\s+(?:draft|pre-approval)\s+gate/i,
+      /gate\s+review\s+comment/i,
+      /(?:draft|pre-approval)\s+gate.*head\s+sha/i,
+      /head\s+sha.*(?:draft|pre-approval|gate)/i,
+      /(?:ready|merge|approval).*(?:without|lacks?).*(?:draft|pre-approval|gate)/i,
+      /draft-first\s+enforcement/i,
+    ],
+  },
+  {
+    id: "ci_guard",
+    label: "CI guard",
+    description: "CI/workflow semantics that a correctness or release guard should catch before review.",
+    recommendedLens: "correctness / CI lens",
+    suggestedChecks: ["Verify CI semantics, reproducibility, and failure precedence", "Treat workflow drift as a dedicated review angle"],
+    automationFit: "hybrid",
+    priorityWeight: 5,
+    patterns: [
+      /\bCI\b/i,
+      /github\s+actions?/i,
+      /status\s+check/i,
+      /check\s+has\s+.*conclusion/i,
+      /non-reproducible/i,
+      /deterministic\s+install/i,
+      /npm\s+ci/i,
+      /lockfile/i,
+      /branch\s+protection/i,
+      /pending\s+.*failure/i,
+      /check\s+run/i,
+      /node(?:\.js)?\s+support\s+floor/i,
+    ],
+  },
+  {
+    id: "unused_imports",
+    label: "Unused imports",
+    description: "Dead imports, dead locals, or never-used reads that linters can catch mechanically.",
+    recommendedLens: "ESLint / dead-code linter",
+    suggestedChecks: ["Enable no-unused-vars/no-unused-imports coverage", "Flag dead locals and unused I/O in tests/scripts"],
+    automationFit: "strong",
+    priorityWeight: 2,
+    patterns: [
+      /unused\s+import/i,
+      /never\s+used/i,
+      /unused\s+(?:read|variable|local)/i,
+      /remove\s+the\s+unused/i,
+      /imported\s+.*\s+but\s+never\s+used/i,
+    ],
+  },
+  {
+    id: "incomplete_coverage",
+    label: "Incomplete coverage",
+    description: "Missing negative cases, malformed-argument tests, or other gaps in validation coverage.",
+    recommendedLens: "coverage angle",
+    suggestedChecks: ["Require explicit negative-case and error-contract tests", "Track coverage gaps in review gate output"],
+    automationFit: "hybrid",
+    priorityWeight: 5,
+    patterns: [
+      /incomplete\s+(?:test\s+)?coverage/i,
+      /coverage\s+gap/i,
+      /missing\s+(?:test|coverage)/i,
+      /add\s+(?:an?\s+)?(?:regression\s+)?test/i,
+      /not\s+covered/i,
+      /negative-case/i,
+      /error-contract/i,
+      /malformed-argument/i,
+      /happy\s+path\s+only/i,
+      /doesn['’]t\s+exercise/i,
+      /should\s+test/i,
+    ],
+  },
+  {
+    id: "misleading_tests",
+    label: "Misleading tests",
+    description: "Tests whose names, assertions, or helpers misrepresent what is actually being verified.",
+    recommendedLens: "coverage / test-quality angle",
+    suggestedChecks: ["Review test names vs asserted behavior", "Flag brittle assertion wording and misleading helpers"],
+    automationFit: "copilot",
+    priorityWeight: 4,
+    patterns: [
+      /misleading\s+test/i,
+      /test\s+name/i,
+      /assertions?\s+match\s+very\s+long/i,
+      /test\s+can\s+hang/i,
+      /brittle\s+to\s+minor\s+copy\s+edits/i,
+      /doesn['’]t\s+actually\s+assert/i,
+      /claims?\s+.*\s+but/i,
+      /confus(?:ing|e)\s+test/i,
+      /helper\s+never\s+listens/i,
+    ],
+  },
+  {
+    id: "config_conflicts",
+    label: "Config conflicts",
+    description: "Schema/config/docs drift where two sources disagree about the supported contract.",
+    recommendedLens: "config drift lens",
+    suggestedChecks: ["Cross-check config/schema/docs invariants", "Flag canonical-token and support-floor mismatches"],
+    automationFit: "copilot",
+    priorityWeight: 4,
+    patterns: [
+      /config\s+(?:conflict|drift|mismatch)/i,
+      /schema\s+(?:conflict|drift|mismatch)/i,
+      /conflicts\s+with\s+the\s+stated\s+contract/i,
+      /mismatch/i,
+      /inconsistent\s+within\s+this\s+doc/i,
+      /canonical\s+status\s+token/i,
+      /support\s+floor/i,
+      /engines\.node/i,
+      /two\s+sources\s+of\s+truth/i,
+    ],
+  },
+  {
+    id: "duplicate_content",
+    label: "Duplicate content",
+    description: "Redundant or duplicated text/docs that should be consolidated.",
+    recommendedLens: "docs angle",
+    suggestedChecks: ["Detect duplicate contract wording", "Prefer one canonical wording/source over repeated copies"],
+    automationFit: "hybrid",
+    priorityWeight: 2,
+    patterns: [
+      /duplicate\s+(?:content|wording|text|docs?|helper)/i,
+      /duplicated\s+here\s+and\s+in/i,
+      /redundant\s+(?:content|wording|docs?|branch|helper)/i,
+      /repeated\s+(?:content|wording)/i,
+      /copy[- ]paste/i,
+      /parallel\s+source\s+of\s+truth/i,
+      /same\s+helper/i,
+      /centraliz(?:e|ing)\s+this/i,
+    ],
+  },
+  {
+    id: "no_op_tool_usage",
+    label: "No-op tool usage",
+    description: "Workflow/tool invocations that are effectively no-ops or discard the intended effect.",
+    recommendedLens: "workflow enforcement lens",
+    suggestedChecks: ["Validate tool invocations actually affect output/state", "Flag no-op shell/tool usage patterns"],
+    automationFit: "hybrid",
+    priorityWeight: 3,
+    patterns: [
+      /no-op/i,
+      /no\s+effect/i,
+      /does\s+nothing/i,
+      /tool\s+usage/i,
+      /tool\s+call/i,
+      /invocation\s+.*ignored/i,
+      /discards?\s+the\s+.*effect/i,
+      /still\s+passes\s+the\s+entire\s+body\s+as\s+a\s+single\s+command-line\s+argument/i,
+    ],
+  },
+  {
+    id: "grammar",
+    label: "Grammar / wording",
+    description: "Copy-editing, casing, or clarity issues in user-facing docs/comments.",
+    recommendedLens: "docs angle",
+    suggestedChecks: ["Add a docs-copy review angle", "Normalize casing/token wording in rendered docs"],
+    automationFit: "copilot",
+    priorityWeight: 1,
+    patterns: [
+      /grammar/i,
+      /wording/i,
+      /typo/i,
+      /spelling/i,
+      /casing/i,
+      /copy\s+edit/i,
+      /awkward/i,
+      /rephrase/i,
+      /capitali[sz]e/i,
+      /punctuation/i,
+    ],
+  },
+];
+
+const RECOMMENDATION_DEFINITIONS = [
+  {
+    key: "coverage-angle",
+    label: "Strengthen the coverage/test-quality lens",
+    categories: ["incomplete_coverage", "misleading_tests"],
+    owner: "review angle",
+    rationale: "A dedicated coverage/test-quality pass should catch missing negative cases, misleading test names, and brittle assertions before Copilot does.",
+  },
+  {
+    key: "docs-angle",
+    label: "Strengthen docs and command-surface review",
+    categories: ["stale_commands", "grammar", "duplicate_content"],
+    owner: "review angle",
+    rationale: "Docs-focused review should validate command references, canonical wording, and duplicated contract text in one pass.",
+  },
+  {
+    key: "link-validator",
+    label: "Add or tighten link/path validation",
+    categories: ["broken_paths", "placeholder_404"],
+    owner: "validator",
+    rationale: "Broken relative paths and placeholder links are deterministic and should be caught mechanically rather than via Copilot review.",
+  },
+  {
+    key: "gate-evidence-lens",
+    label: "Add explicit gate-evidence enforcement",
+    categories: ["gate_evidence"],
+    owner: "workflow gate",
+    rationale: "The loop should reject ready/merge transitions when draft/pre-approval evidence is missing or points at the wrong head SHA.",
+  },
+  {
+    key: "ci-guard-lens",
+    label: "Strengthen CI guard semantics",
+    categories: ["ci_guard"],
+    owner: "review angle",
+    rationale: "CI and workflow semantics need a dedicated correctness lens so reproducibility and failure-precedence issues surface before Copilot review.",
+  },
+  {
+    key: "dead-code-lint",
+    label: "Enable dead-code linting",
+    categories: ["unused_imports"],
+    owner: "linter",
+    rationale: "Unused imports and dead locals are cheap to catch with lint rules and should not consume Copilot review budget.",
+  },
+  {
+    key: "config-drift-lens",
+    label: "Add a config/schema drift review lens",
+    categories: ["config_conflicts"],
+    owner: "review angle",
+    rationale: "Cross-artifact contract drift is recurring enough to deserve its own review pass, even if some cases remain advisory.",
+  },
+  {
+    key: "workflow-noop-lens",
+    label: "Add workflow no-op tool enforcement",
+    categories: ["no_op_tool_usage"],
+    owner: "review angle",
+    rationale: "The workflow should flag tool invocations that look successful but do nothing or silently drop important effects.",
+  },
+];
+
+function excerptText(body, maxLength = 200) {
+  const normalized = String(body ?? "").replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
+}
+
+function parsePrNumberFromPullRequestUrl(pullRequestUrl) {
+  const match = String(pullRequestUrl ?? "").match(/\/pulls\/(\d+)$/u);
+  return match ? Number(match[1]) : null;
+}
+
+function normalizePaginatedArrayPayload(payload, label) {
+  if (!Array.isArray(payload)) {
+    throw new Error(`Invalid ${label} payload: expected an array`);
+  }
+
+  if (payload.every((entry) => Array.isArray(entry))) {
+    return payload.flat();
+  }
+
+  return payload;
+}
+
+function matchesCategory(comment, definition) {
+  const haystack = typeof comment?.body === "string" ? comment.body.trim() : "";
+  return haystack.length > 0 && definition.patterns.some((pattern) => pattern.test(haystack));
+}
+
+export function classifyCopilotComment(comment, definitions = CATEGORY_DEFINITIONS) {
+  const matched = definitions
+    .filter((definition) => matchesCategory(comment, definition))
+    .map((definition) => definition.id);
+
+  const primaryCategory = matched.length > 0
+    ? definitions.find((definition) => definition.id === matched[0]) ?? null
+    : null;
+
+  return {
+    matchedCategoryIds: matched,
+    primaryCategoryId: primaryCategory?.id ?? null,
+  };
+}
+
+function normalizeComment(comment, prMap) {
+  const prNumber = parsePrNumberFromPullRequestUrl(comment?.pull_request_url);
+  const pr = prNumber !== null ? prMap.get(prNumber) ?? null : null;
+  const classification = classifyCopilotComment(comment);
+
+  return {
+    id: Number.isInteger(comment?.id) ? comment.id : null,
+    prNumber,
+    prTitle: pr?.title ?? null,
+    prUrl: pr?.html_url ?? comment?.html_url ?? null,
+    prState: pr?.merged_at ? "merged" : (pr?.state ?? null),
+    path: typeof comment?.path === "string" ? comment.path : null,
+    line: Number.isInteger(comment?.line) ? comment.line : (Number.isInteger(comment?.original_line) ? comment.original_line : null),
+    body: typeof comment?.body === "string" ? comment.body.trim() : "",
+    excerpt: excerptText(comment?.body),
+    htmlUrl: typeof comment?.html_url === "string" ? comment.html_url : null,
+    createdAt: typeof comment?.created_at === "string" ? comment.created_at : null,
+    updatedAt: typeof comment?.updated_at === "string" ? comment.updated_at : null,
+    authorLogin: typeof comment?.user?.login === "string" ? comment.user.login : null,
+    matchedCategoryIds: classification.matchedCategoryIds,
+    primaryCategoryId: classification.primaryCategoryId,
+  };
+}
+
+function buildPrMap(prs) {
+  const map = new Map();
+  for (const pr of prs) {
+    if (!Number.isInteger(pr?.number)) {
+      continue;
+    }
+    map.set(pr.number, pr);
+  }
+  return map;
+}
+
+function buildCategorySummaries(normalizedComments) {
+  const summaries = CATEGORY_DEFINITIONS.map((definition) => {
+    const matches = normalizedComments.filter((comment) => comment.primaryCategoryId === definition.id);
+    const prSet = new Set(matches.map((comment) => comment.prNumber).filter((value) => Number.isInteger(value)));
+
+    return {
+      id: definition.id,
+      label: definition.label,
+      description: definition.description,
+      recommendedLens: definition.recommendedLens,
+      suggestedChecks: definition.suggestedChecks,
+      automationFit: definition.automationFit,
+      priorityWeight: definition.priorityWeight,
+      count: matches.length,
+      prCount: prSet.size,
+      prNumbers: [...prSet].sort((left, right) => left - right),
+      examples: matches.slice(0, 3).map((comment) => ({
+        prNumber: comment.prNumber,
+        prTitle: comment.prTitle,
+        path: comment.path,
+        line: comment.line,
+        excerpt: comment.excerpt,
+        htmlUrl: comment.htmlUrl,
+      })),
+    };
+  });
+
+  return summaries.sort((left, right) => {
+    if (right.count !== left.count) {
+      return right.count - left.count;
+    }
+    if (right.priorityWeight !== left.priorityWeight) {
+      return right.priorityWeight - left.priorityWeight;
+    }
+    return left.label.localeCompare(right.label);
+  });
+}
+
+function rankRecommendations(categorySummaries) {
+  const countsByCategory = new Map(categorySummaries.map((summary) => [summary.id, summary]));
+
+  const active = RECOMMENDATION_DEFINITIONS
+    .map((definition) => {
+      const related = definition.categories
+        .map((categoryId) => countsByCategory.get(categoryId))
+        .filter(Boolean);
+      const commentCount = related.reduce((sum, summary) => sum + summary.count, 0);
+      const prCount = new Set(related.flatMap((summary) => summary.prNumbers ?? [])).size;
+      const score = related.reduce((sum, summary) => sum + (summary.count * summary.priorityWeight), 0);
+
+      return {
+        key: definition.key,
+        label: definition.label,
+        owner: definition.owner,
+        rationale: definition.rationale,
+        categories: related.filter((summary) => summary.count > 0).map((summary) => summary.id),
+        commentCount,
+        prCount,
+        score,
+      };
+    })
+    .filter((entry) => entry.commentCount > 0)
+    .sort((left, right) => {
+      if (right.score !== left.score) {
+        return right.score - left.score;
+      }
+      if (right.commentCount !== left.commentCount) {
+        return right.commentCount - left.commentCount;
+      }
+      return left.label.localeCompare(right.label);
+    })
+    .map((entry, index) => ({
+      ...entry,
+      priorityOrder: index + 1,
+      priorityBand: index < 3 ? "high" : index < 6 ? "medium" : "low",
+    }));
+
+  return active;
+}
+
+function buildCopilotOwnedCategories(categorySummaries) {
+  return categorySummaries
+    .filter((summary) => summary.count > 0 && (summary.automationFit === "copilot" || summary.automationFit === "hybrid"))
+    .slice(0, 5)
+    .map((summary) => ({
+      id: summary.id,
+      label: summary.label,
+      commentCount: summary.count,
+      automationFit: summary.automationFit,
+      reason: summary.automationFit === "copilot"
+        ? "These comments usually require cross-file judgment or subjective review, so Copilot should stay in the loop even if we add advisory heuristics."
+        : "A deterministic check can catch part of this category, but Copilot/human review still adds value for nuance and false-positive control.",
+    }));
+}
+
+export function buildCopilotAuditSummary({ repo, comments, prs, outputDir = DEFAULT_OUTPUT_DIR, generatedAt = new Date().toISOString() }) {
+  const prMap = buildPrMap(prs);
+  const normalizedComments = comments
+    .filter((comment) => isCopilotLogin(comment?.user?.login))
+    .map((comment) => normalizeComment(comment, prMap));
+
+  const categorySummaries = buildCategorySummaries(normalizedComments);
+  const uncategorizedComments = normalizedComments.filter((comment) => comment.primaryCategoryId === null);
+  const recommendations = rankRecommendations(categorySummaries);
+  const prsWithCopilotComments = new Set(normalizedComments.map((comment) => comment.prNumber).filter((value) => Number.isInteger(value))).size;
+  const matchedComments = normalizedComments.length - uncategorizedComments.length;
+
+  return {
+    ok: true,
+    repo,
+    generatedAt,
+    scope: {
+      source: "GitHub REST review comments endpoint",
+      includes: "PR review comments authored by Copilot",
+      excludes: "PR review summaries and general issue comments",
+    },
+    totals: {
+      reviewCommentsScanned: comments.length,
+      copilotComments: normalizedComments.length,
+      matchedComments,
+      classificationCoverage: normalizedComments.length === 0 ? 0 : Number((matchedComments / normalizedComments.length).toFixed(3)),
+      prsWithCopilotComments,
+      uncategorizedComments: uncategorizedComments.length,
+    },
+    categories: categorySummaries,
+    uncategorizedExamples: uncategorizedComments.slice(0, 10).map((comment) => ({
+      prNumber: comment.prNumber,
+      path: comment.path,
+      excerpt: comment.excerpt,
+      htmlUrl: comment.htmlUrl,
+    })),
+    recommendations,
+    copilotOwnedCategories: buildCopilotOwnedCategories(categorySummaries),
+    comments: normalizedComments,
+    files: {
+      outputDir,
+      jsonSummaryPath: path.join(outputDir, DEFAULT_JSON_NAME),
+      markdownReportPath: path.join(outputDir, DEFAULT_MARKDOWN_NAME),
+    },
+  };
+}
+
+export function renderMarkdownReport(summary) {
+  const lines = [];
+  const topCategories = summary.categories.filter((category) => category.count > 0).slice(0, 10);
+
+  lines.push(`# Copilot review comment audit — ${summary.repo}`);
+  lines.push("");
+  lines.push(`Generated: ${summary.generatedAt}`);
+  lines.push("");
+  lines.push("## Scope");
+  lines.push("");
+  lines.push(`- Source: ${summary.scope.source}`);
+  lines.push(`- Included: ${summary.scope.includes}`);
+  lines.push(`- Excluded: ${summary.scope.excludes}`);
+  lines.push(`- Copilot comments: ${summary.totals.copilotComments}`);
+  lines.push(`- Matched to requested taxonomy: ${summary.totals.matchedComments} (${Math.round(summary.totals.classificationCoverage * 100)}%)`);
+  lines.push(`- PRs with Copilot comments: ${summary.totals.prsWithCopilotComments}`);
+  lines.push(`- Uncategorized comments: ${summary.totals.uncategorizedComments}`);
+  lines.push(`- Note: the taxonomy is intentionally limited to the issue's requested categories; broader correctness/refactor comments remain uncategorized.`);
+  lines.push("");
+  lines.push("## Top categories");
+  lines.push("");
+  lines.push("| Category | Comments | PRs | Catch earlier with | Fit |",);
+  lines.push("| --- | ---: | ---: | --- | --- |",);
+  for (const category of topCategories) {
+    lines.push(`| ${category.label} | ${category.count} | ${category.prCount} | ${category.recommendedLens} | ${category.automationFit} |`);
+  }
+  lines.push("");
+  lines.push("## Priority order for missing lenses / linters");
+  lines.push("");
+  for (const recommendation of summary.recommendations) {
+    lines.push(`${recommendation.priorityOrder}. **${recommendation.label}** (${recommendation.priorityBand}) — ${recommendation.commentCount} comments across categories: ${recommendation.categories.join(", ")}.`);
+    lines.push(`   - Owner: ${recommendation.owner}`);
+    lines.push(`   - Why: ${recommendation.rationale}`);
+  }
+  lines.push("");
+  lines.push("## Category details");
+  lines.push("");
+  for (const category of summary.categories.filter((entry) => entry.count > 0)) {
+    lines.push(`### ${category.label}`);
+    lines.push("");
+    lines.push(`- Comments: ${category.count}`);
+    lines.push(`- PRs: ${category.prCount}`);
+    lines.push(`- Recommended lens/linter: ${category.recommendedLens}`);
+    lines.push(`- Automation fit: ${category.automationFit}`);
+    lines.push(`- Suggested checks: ${category.suggestedChecks.join("; ")}`);
+    if (category.examples.length > 0) {
+      lines.push("- Example comments:");
+      for (const example of category.examples) {
+        const location = [example.path, Number.isInteger(example.line) ? `:${example.line}` : null].filter(Boolean).join("");
+        lines.push(`  - PR #${example.prNumber}${example.prTitle ? ` — ${example.prTitle}` : ""}${location ? ` (${location})` : ""}: ${example.excerpt}`);
+      }
+    }
+    lines.push("");
+  }
+
+  lines.push("## Categories Copilot should still own");
+  lines.push("");
+  if (summary.copilotOwnedCategories.length === 0) {
+    lines.push("- None in this run; the observed issues were mostly deterministic/mechanical.");
+  } else {
+    for (const category of summary.copilotOwnedCategories) {
+      lines.push(`- **${category.label}** (${category.commentCount} comments, ${category.automationFit}) — ${category.reason}`);
+    }
+  }
+  lines.push("");
+
+  if (summary.uncategorizedExamples.length > 0) {
+    lines.push("## Uncategorized sample");
+    lines.push("");
+    for (const example of summary.uncategorizedExamples) {
+      lines.push(`- PR #${example.prNumber}${example.path ? ` (${example.path})` : ""}: ${example.excerpt}`);
+    }
+    lines.push("");
+  }
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+async function runGhJson(args, { env, ghCommand }) {
+  const result = await runChild(ghCommand, args, env);
+
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw new Error(`gh command failed: ${detail}`);
+  }
+
+  return parseJsonText(result.stdout, { label: `gh ${args.slice(0, 2).join(" ")}` });
+}
+
+async function fetchAllReviewComments(repo, { env, ghCommand }) {
+  const payload = await runGhJson(["api", "--paginate", "--slurp", `repos/${repo}/pulls/comments?per_page=100`], { env, ghCommand });
+  return normalizePaginatedArrayPayload(payload, "Copilot review comments");
+}
+
+async function fetchAllPullRequests(repo, { env, ghCommand }) {
+  const payload = await runGhJson(["api", "--paginate", "--slurp", `repos/${repo}/pulls?state=all&per_page=100`], { env, ghCommand });
+  return normalizePaginatedArrayPayload(payload, "pull requests");
+}
+
+async function writeOutputs(summary, markdown) {
+  await mkdir(summary.files.outputDir, { recursive: true });
+  await writeFile(summary.files.jsonSummaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+  await writeFile(summary.files.markdownReportPath, markdown, "utf8");
+}
+
+export function parseAuditCopilotCommentsCliArgs(argv) {
+  const args = [...argv];
+  const options = {
+    help: false,
+    repo: undefined,
+    outputDir: DEFAULT_OUTPUT_DIR,
+  };
+
+  while (args.length > 0) {
+    const token = args.shift();
+
+    if (token === "--help" || token === "-h") {
+      options.help = true;
+      return options;
+    }
+
+    if (token === "--repo") {
+      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+      continue;
+    }
+
+    if (token === "--output-dir") {
+      options.outputDir = requireOptionValue(args, "--output-dir", parseError).trim();
+      continue;
+    }
+
+    throw parseError(`Unknown argument: ${token}`);
+  }
+
+  if (options.repo === undefined) {
+    throw parseError("audit-copilot-comments requires --repo <owner/name>");
+  }
+
+  if (options.outputDir.length === 0) {
+    throw parseError("--output-dir must be a non-empty path");
+  }
+
+  try {
+    parseRepoSlug(options.repo);
+  } catch (error) {
+    throw parseError(error instanceof Error ? error.message : String(error));
+  }
+
+  return options;
+}
+
+export async function auditCopilotComments(options, { env = process.env, ghCommand = "gh" } = {}) {
+  const comments = await fetchAllReviewComments(options.repo, { env, ghCommand });
+  const prs = await fetchAllPullRequests(options.repo, { env, ghCommand });
+
+  const summary = buildCopilotAuditSummary({
+    repo: options.repo,
+    comments,
+    prs,
+    outputDir: options.outputDir,
+  });
+  const markdown = renderMarkdownReport(summary);
+
+  await writeOutputs(summary, markdown);
+
+  return summary;
+}
+
+export async function runCli(argv = process.argv.slice(2), { stdout = process.stdout, env = process.env, ghCommand = "gh" } = {}) {
+  const options = parseAuditCopilotCommentsCliArgs(argv);
+
+  if (options.help) {
+    stdout.write(`${USAGE}\n`);
+    return;
+  }
+
+  const summary = await auditCopilotComments(options, { env, ghCommand });
+  stdout.write(`${JSON.stringify(summary)}\n`);
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli().catch((error) => {
+    process.stderr.write(`${formatCliError(error, { usage: USAGE })}\n`);
+    process.exitCode = 1;
+  });
+}
+
+export {
+  CATEGORY_DEFINITIONS,
+  DEFAULT_JSON_NAME,
+  DEFAULT_MARKDOWN_NAME,
+  DEFAULT_OUTPUT_DIR,
+  RECOMMENDATION_DEFINITIONS,
+};

--- a/scripts/github/audit-copilot-comments.mjs
+++ b/scripts/github/audit-copilot-comments.mjs
@@ -22,7 +22,7 @@ Required:
 Optional:
   --output-dir <path>     Output directory (default: tmp/investigation)
 
-Output (stdout, JSON):
+Output (stdout, JSON summary):
   {
     "ok": true,
     "repo": "owner/repo",
@@ -32,11 +32,23 @@ Output (stdout, JSON):
       "prsWithCopilotComments": 17,
       "uncategorizedComments": 5
     },
+    "categories": [
+      { "id": "grammar", "count": 92 }
+    ],
+    "recommendations": [
+      { "key": "coverage-angle", "priorityOrder": 1 }
+    ],
+    "comments": [
+      { "id": 101, "prNumber": 12, "primaryCategoryId": "grammar" }
+    ],
     "files": {
       "jsonSummaryPath": "tmp/investigation/copilot-comment-summary.json",
       "markdownReportPath": "tmp/investigation/copilot-comment-categories.md"
     }
   }
+
+  Stdout emits the same full summary object that is written to
+  tmp/investigation/copilot-comment-summary.json.
 
 Error output (stderr, JSON):
   { "ok": false, "error": "...", "usage": "..." }
@@ -589,8 +601,8 @@ export function renderMarkdownReport(summary) {
   lines.push("");
   lines.push("## Top categories");
   lines.push("");
-  lines.push("| Category | Comments | PRs | Catch earlier with | Fit |",);
-  lines.push("| --- | ---: | ---: | --- | --- |",);
+  lines.push("| Category | Comments | PRs | Catch earlier with | Fit |");
+  lines.push("| --- | ---: | ---: | --- | --- |");
   for (const category of topCategories) {
     lines.push(`| ${category.label} | ${category.count} | ${category.prCount} | ${category.recommendedLens} | ${category.automationFit} |`);
   }
@@ -654,7 +666,12 @@ async function runGhJson(args, { env, ghCommand }) {
     throw new Error(`gh command failed: ${detail}`);
   }
 
-  return parseJsonText(result.stdout, { label: `gh ${args.slice(0, 2).join(" ")}` });
+  const commandLabel = `gh ${args.join(" ")}`;
+  try {
+    return parseJsonText(result.stdout);
+  } catch (error) {
+    throw new Error(`Invalid JSON from ${commandLabel}`);
+  }
 }
 
 async function fetchAllReviewComments(repo, { env, ghCommand }) {

--- a/scripts/github/audit-copilot-comments.mjs
+++ b/scripts/github/audit-copilot-comments.mjs
@@ -14,7 +14,7 @@ const USAGE = `Usage: audit-copilot-comments.mjs --repo <owner/name> [--output-d
 
 Scan all pull-request review comments in a repository via the GitHub REST API,
 filter to Copilot-authored comments, classify them into workflow categories, and
-write both a JSON summary and a Markdown report under tmp/investigation/.
+write both a JSON summary and a Markdown report under the requested output directory.
 
 Required:
   --repo <owner/name>     Repository slug (e.g. owner/repo)
@@ -42,13 +42,13 @@ Output (stdout, JSON summary):
       { "id": 101, "prNumber": 12, "primaryCategoryId": "grammar" }
     ],
     "files": {
-      "jsonSummaryPath": "tmp/investigation/copilot-comment-summary.json",
-      "markdownReportPath": "tmp/investigation/copilot-comment-categories.md"
+      "jsonSummaryPath": "<output-dir>/copilot-comment-summary.json",
+      "markdownReportPath": "<output-dir>/copilot-comment-categories.md"
     }
   }
 
   Stdout emits the same full summary object that is written to
-  tmp/investigation/copilot-comment-summary.json.
+  <output-dir>/copilot-comment-summary.json (default output dir: tmp/investigation).
 
 Error output (stderr, JSON):
   { "ok": false, "error": "...", "usage": "..." }

--- a/test/github/audit-copilot-comments.test.mjs
+++ b/test/github/audit-copilot-comments.test.mjs
@@ -6,6 +6,7 @@ import { spawn } from "node:child_process";
 import test from "node:test";
 
 import {
+  auditCopilotComments,
   buildCopilotAuditSummary,
   classifyCopilotComment,
   parseAuditCopilotCommentsCliArgs,
@@ -57,10 +58,10 @@ function runNode(args = [], options = {}) {
   });
 }
 
-async function writeGhStub(tempDir, entries) {
+async function writeGhStub(tempDir, entries, { commandName = "gh" } = {}) {
   const sequencePath = path.join(tempDir, "gh-sequence.json");
   const counterPath = path.join(tempDir, "gh-counter.txt");
-  const ghPath = path.join(tempDir, "gh");
+  const ghPath = path.join(tempDir, commandName);
 
   await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
   await writeFile(counterPath, "0\n", "utf8");
@@ -162,9 +163,10 @@ test("audit-copilot-comments help text describes the full summary output", async
   const result = await runNode(["--help"]);
 
   assert.equal(result.code, 0, result.stderr);
-  assert.match(result.stdout, /Output \(stdout, JSON summary\)/);
+  assert.match(result.stdout, /Output \(stdout, JSON summary; abbreviated example\)/);
   assert.match(result.stdout, /"categories"/);
-  assert.match(result.stdout, /same full summary object/i);
+  assert.match(result.stdout, /abbreviated/i);
+  assert.match(result.stdout, /same full\s+summary object/i);
   assert.match(result.stdout, /<output-dir>\/copilot-comment-summary\.json/);
 });
 
@@ -285,6 +287,27 @@ test("audit-copilot-comments surfaces malformed gh JSON with command context", a
     const stderr = JSON.parse(result.stderr);
     assert.equal(stderr.ok, false);
     assert.match(stderr.error, /Invalid JSON from gh api --paginate --slurp repos\/owner\/repo\/pulls\/comments\?per_page=100/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+
+test("auditCopilotComments includes the configured gh command in parse errors", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-audit-copilot-comments-custom-gh-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/pulls/comments?per_page=100"],
+        stdout: "not-json\n",
+      },
+    ], { commandName: "pi-gh" });
+
+    await assert.rejects(
+      auditCopilotComments({ repo: "owner/repo", outputDir: path.join(tempDir, "out") }, { env, ghCommand: "pi-gh" }),
+      /Invalid JSON from pi-gh api --paginate --slurp repos\/owner\/repo\/pulls\/comments\?per_page=100/,
+    );
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/github/audit-copilot-comments.test.mjs
+++ b/test/github/audit-copilot-comments.test.mjs
@@ -1,0 +1,318 @@
+import assert from "node:assert/strict";
+import { access, chmod, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import test from "node:test";
+
+import {
+  buildCopilotAuditSummary,
+  classifyCopilotComment,
+  parseAuditCopilotCommentsCliArgs,
+  renderMarkdownReport,
+} from "../../scripts/github/audit-copilot-comments.mjs";
+
+const scriptPath = path.resolve("scripts/github/audit-copilot-comments.mjs");
+
+function runNode(args = [], options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(options.execPath ?? process.execPath, [scriptPath, ...args], {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const resolveOnce = (value) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(value);
+    };
+
+    const rejectOnce = (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      reject(error);
+    };
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    child.on("error", rejectOnce);
+    child.on("close", (code) => {
+      resolveOnce({ code, stdout, stderr });
+    });
+  });
+}
+
+async function writeGhStub(tempDir, entries) {
+  const sequencePath = path.join(tempDir, "gh-sequence.json");
+  const counterPath = path.join(tempDir, "gh-counter.txt");
+  const ghPath = path.join(tempDir, "gh");
+
+  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
+  await writeFile(counterPath, "0\n", "utf8");
+  await writeFile(
+    ghPath,
+    [
+      "#!/usr/bin/env node",
+      'import { readFileSync, writeFileSync } from "node:fs";',
+      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
+      "const counterPath = process.env.GH_COUNTER_PATH;",
+      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
+      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
+      'if (current >= entries.length) {',
+      '  process.stderr.write(`unexpected extra gh call #${current + 1}: ${process.argv.slice(2).join(" ")}\\n`);',
+      '  process.exit(97);',
+      '}',
+      'const entry = entries[current] ?? { stdout: "{}\\n" };',
+      'writeFileSync(counterPath, String(current + 1));',
+      'const actual = process.argv.slice(2);',
+      'if (entry.assertArgs) {',
+      '  for (const expected of entry.assertArgs) {',
+      '    if (!actual.includes(expected)) {',
+      '      process.stderr.write(`missing expected gh arg: ${expected}\\nactual: ${actual.join(" ")}\\n`);',
+      '      process.exit(98);',
+      '    }',
+      '  }',
+      '}',
+      'if (entry.stderr) process.stderr.write(entry.stderr);',
+      'if (entry.stdout) process.stdout.write(entry.stdout);',
+      'process.exit(entry.exitCode ?? 0);',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await chmod(ghPath, 0o755);
+
+  return {
+    ...process.env,
+    PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
+    GH_SEQUENCE_PATH: sequencePath,
+    GH_COUNTER_PATH: counterPath,
+  };
+}
+
+function sampleReviewComment({
+  id,
+  prNumber,
+  path: filePath,
+  body,
+  userLogin = "Copilot",
+  line = 1,
+}) {
+  return {
+    id,
+    pull_request_url: `https://api.github.com/repos/owner/repo/pulls/${prNumber}`,
+    html_url: `https://github.com/owner/repo/pull/${prNumber}#discussion_r${id}`,
+    path: filePath,
+    body,
+    line,
+    user: {
+      login: userLogin,
+    },
+    created_at: "2026-06-02T10:00:00Z",
+    updated_at: "2026-06-02T10:00:00Z",
+  };
+}
+
+const samplePrs = [
+  { number: 11, title: "Fix docs links", html_url: "https://github.com/owner/repo/pull/11", state: "closed", merged_at: "2026-06-01T10:00:00Z" },
+  { number: 12, title: "Tighten tests", html_url: "https://github.com/owner/repo/pull/12", state: "open", merged_at: null },
+  { number: 13, title: "Gate fixes", html_url: "https://github.com/owner/repo/pull/13", state: "open", merged_at: null },
+];
+
+test("parseAuditCopilotCommentsCliArgs parses repo and default output dir", () => {
+  const options = parseAuditCopilotCommentsCliArgs(["--repo", "owner/repo"]);
+
+  assert.equal(options.repo, "owner/repo");
+  assert.equal(options.outputDir, "tmp/investigation");
+  assert.equal(options.help, false);
+});
+
+test("parseAuditCopilotCommentsCliArgs rejects malformed arguments deterministically", () => {
+  assert.throws(
+    () => parseAuditCopilotCommentsCliArgs([]),
+    /requires --repo <owner\/name>/i,
+  );
+  assert.throws(
+    () => parseAuditCopilotCommentsCliArgs(["--repo", "bad slug"]),
+    /owner\/name/i,
+  );
+  assert.throws(
+    () => parseAuditCopilotCommentsCliArgs(["--repo", "owner/repo", "--output-dir", "   "]),
+    /non-empty path/i,
+  );
+});
+
+test("classifyCopilotComment assigns representative categories", () => {
+  assert.equal(
+    classifyCopilotComment(sampleReviewComment({
+      id: 1,
+      prNumber: 11,
+      path: "README.md",
+      body: "This relative path points to a missing file and should be fixed.",
+    })).primaryCategoryId,
+    "broken_paths",
+  );
+
+  assert.equal(
+    classifyCopilotComment(sampleReviewComment({
+      id: 2,
+      prNumber: 12,
+      path: "test/example.test.mjs",
+      body: "This only covers the happy path; please add a malformed-argument test for the negative-case.",
+    })).primaryCategoryId,
+    "incomplete_coverage",
+  );
+
+  assert.equal(
+    classifyCopilotComment(sampleReviewComment({
+      id: 3,
+      prNumber: 13,
+      path: "scripts/loop.mjs",
+      body: "The ready state lacks visible gate evidence for the reviewed head SHA.",
+    })).primaryCategoryId,
+    "gate_evidence",
+  );
+
+  assert.equal(
+    classifyCopilotComment(sampleReviewComment({
+      id: 4,
+      prNumber: 13,
+      path: "docs/plan.md",
+      body: "The header uses inconsistent casing and wording compared with the canonical status token.",
+    })).primaryCategoryId,
+    "config_conflicts",
+  );
+});
+
+test("buildCopilotAuditSummary counts categories and ranks recommendations", () => {
+  const summary = buildCopilotAuditSummary({
+    repo: "owner/repo",
+    prs: samplePrs,
+    comments: [
+      sampleReviewComment({
+        id: 101,
+        prNumber: 11,
+        path: "README.md",
+        body: "This relative path points to a missing file and will 404 in docs.",
+      }),
+      sampleReviewComment({
+        id: 102,
+        prNumber: 12,
+        path: "test/audit.test.mjs",
+        body: "This only covers the happy path; add a malformed-argument test for the negative-case.",
+      }),
+      sampleReviewComment({
+        id: 103,
+        prNumber: 12,
+        path: "test/audit.test.mjs",
+        body: "The assertions match very long exact sentences, which makes the test brittle to minor copy edits.",
+      }),
+      sampleReviewComment({
+        id: 104,
+        prNumber: 13,
+        path: "docs/workflow.md",
+        body: "The ready state lacks visible gate evidence for the reviewed head SHA.",
+      }),
+      sampleReviewComment({
+        id: 105,
+        prNumber: 13,
+        path: "scripts/example.mjs",
+        body: "The variable is read from disk but never used after parsing.",
+      }),
+      sampleReviewComment({
+        id: 106,
+        prNumber: 13,
+        path: "scripts/example.mjs",
+        body: "This comment is from a human and should not be included.",
+        userLogin: "mfittko",
+      }),
+    ],
+  });
+
+  assert.equal(summary.totals.copilotComments, 5);
+  assert.equal(summary.totals.prsWithCopilotComments, 3);
+  assert.equal(summary.categories.find((entry) => entry.id === "incomplete_coverage")?.count, 1);
+  assert.equal(summary.categories.find((entry) => entry.id === "gate_evidence")?.count, 1);
+  assert.equal(summary.recommendations[0].key, "coverage-angle");
+  assert.equal(summary.files.markdownReportPath, path.join("tmp/investigation", "copilot-comment-categories.md"));
+
+  const markdown = renderMarkdownReport(summary);
+  assert.match(markdown, /Top categories/);
+  assert.match(markdown, /Priority order for missing lenses/i);
+  assert.match(markdown, /Categories Copilot should still own/i);
+});
+
+test("audit-copilot-comments CLI writes JSON summary and markdown report", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-audit-copilot-comments-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/pulls/comments?per_page=100"],
+        stdout: `${JSON.stringify([[
+          sampleReviewComment({
+            id: 201,
+            prNumber: 11,
+            path: "README.md",
+            body: "This relative path points to a missing file.",
+          }),
+          sampleReviewComment({
+            id: 202,
+            prNumber: 12,
+            path: "docs/workflow.md",
+            body: "The ready state lacks visible gate evidence for the reviewed head SHA.",
+          }),
+          sampleReviewComment({
+            id: 203,
+            prNumber: 12,
+            path: "test/example.test.mjs",
+            body: "This only covers the happy path; add a malformed-argument test.",
+          }),
+        ]])}\n`,
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/pulls?state=all&per_page=100"],
+        stdout: `${JSON.stringify([samplePrs])}\n`,
+      },
+    ]);
+
+    const outputDir = path.join(tempDir, "out");
+    const result = await runNode(["--repo", "owner/repo", "--output-dir", outputDir], { env });
+
+    assert.equal(result.code, 0, result.stderr);
+    const stdout = JSON.parse(result.stdout);
+
+    assert.equal(stdout.ok, true);
+    assert.equal(stdout.totals.copilotComments, 3);
+    assert.equal(stdout.files.outputDir, outputDir);
+
+    await access(stdout.files.jsonSummaryPath);
+    await access(stdout.files.markdownReportPath);
+    const summaryStat = await stat(stdout.files.jsonSummaryPath);
+    const reportText = await readFile(stdout.files.markdownReportPath, "utf8");
+    const summaryText = await readFile(stdout.files.jsonSummaryPath, "utf8");
+
+    assert.ok(summaryStat.size > 0);
+    assert.match(reportText, /Broken relative paths/);
+    assert.match(reportText, /Gate evidence/);
+    assert.match(reportText, /Priority order for missing lenses/i);
+    assert.match(summaryText, /"copilotComments": 3/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/github/audit-copilot-comments.test.mjs
+++ b/test/github/audit-copilot-comments.test.mjs
@@ -68,7 +68,7 @@ async function writeGhStub(tempDir, entries) {
     ghPath,
     [
       "#!/usr/bin/env node",
-      'import { readFileSync, writeFileSync } from "node:fs";',
+      'const { readFileSync, writeFileSync } = require("node:fs");',
       "const sequencePath = process.env.GH_SEQUENCE_PATH;",
       "const counterPath = process.env.GH_COUNTER_PATH;",
       'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
@@ -165,6 +165,7 @@ test("audit-copilot-comments help text describes the full summary output", async
   assert.match(result.stdout, /Output \(stdout, JSON summary\)/);
   assert.match(result.stdout, /"categories"/);
   assert.match(result.stdout, /same full summary object/i);
+  assert.match(result.stdout, /<output-dir>\/copilot-comment-summary\.json/);
 });
 
 test("classifyCopilotComment assigns representative categories", () => {

--- a/test/github/audit-copilot-comments.test.mjs
+++ b/test/github/audit-copilot-comments.test.mjs
@@ -157,6 +157,16 @@ test("parseAuditCopilotCommentsCliArgs rejects malformed arguments deterministic
   );
 });
 
+
+test("audit-copilot-comments help text describes the full summary output", async () => {
+  const result = await runNode(["--help"]);
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Output \(stdout, JSON summary\)/);
+  assert.match(result.stdout, /"categories"/);
+  assert.match(result.stdout, /same full summary object/i);
+});
+
 test("classifyCopilotComment assigns representative categories", () => {
   assert.equal(
     classifyCopilotComment(sampleReviewComment({
@@ -256,6 +266,29 @@ test("buildCopilotAuditSummary counts categories and ranks recommendations", () 
   assert.match(markdown, /Priority order for missing lenses/i);
   assert.match(markdown, /Categories Copilot should still own/i);
 });
+
+test("audit-copilot-comments surfaces malformed gh JSON with command context", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-audit-copilot-comments-json-error-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/pulls/comments?per_page=100"],
+        stdout: "not-json\n",
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo"], { env });
+
+    assert.equal(result.code, 1);
+    const stderr = JSON.parse(result.stderr);
+    assert.equal(stderr.ok, false);
+    assert.match(stderr.error, /Invalid JSON from gh api --paginate --slurp repos\/owner\/repo\/pulls\/comments\?per_page=100/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 
 test("audit-copilot-comments CLI writes JSON summary and markdown report", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-audit-copilot-comments-"));

--- a/test/loop/inspect-run-viewer-managed-instance.test.mjs
+++ b/test/loop/inspect-run-viewer-managed-instance.test.mjs
@@ -609,24 +609,16 @@ test('open fails with a clear error when the launch seam does not return a posit
 });
 
 test('defaultHealthcheck fetches without AbortSignal (Node v24 compatibility)', async () => {
-  const { createServer } = await import('node:http');
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-healthcheck-signal-'));
 
-  // Start a real HTTP server on the default port so isManagedRecordShape passes
-  const healthServer = createServer((_req, res) => { res.writeHead(200); res.end('ok'); });
-  await new Promise((resolve) => healthServer.listen(4311, '127.0.0.1', resolve));
-
-  // Spy on global fetch to capture the options passed
   const originalFetch = globalThis.fetch;
   const fetchCalls = [];
   globalThis.fetch = async (url, options) => {
     fetchCalls.push({ url, options });
-    return originalFetch(url, options);
+    return { status: 200 };
   };
 
   try {
-    // Manager with real defaultHealthcheck (healthcheckUrlImpl defaults)
-    // but stubbed lifecycle seams
     const manager = createInspectRunViewerLifecycleManager({
       listListeningPidsImpl: async () => [42],
       isProcessAliveImpl: async () => true,
@@ -655,10 +647,10 @@ test('defaultHealthcheck fetches without AbortSignal (Node v24 compatibility)', 
 
     const healthcheckCall = fetchCalls.find((c) => String(c.url).includes('4311'));
     assert.ok(healthcheckCall, 'healthcheck should call fetch');
+    assert.equal(healthcheckCall.options?.method, 'GET');
     assert.ok(!healthcheckCall.options?.signal, 'fetch must not receive an AbortSignal');
   } finally {
     globalThis.fetch = originalFetch;
-    await new Promise((resolve) => healthServer.close(resolve));
   }
 });
 

--- a/test/loop/inspect-run-viewer-managed-instance.test.mjs
+++ b/test/loop/inspect-run-viewer-managed-instance.test.mjs
@@ -611,6 +611,8 @@ test('open fails with a clear error when the launch seam does not return a posit
 test('defaultHealthcheck fetches without AbortSignal (Node v24 compatibility)', async () => {
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-healthcheck-signal-'));
 
+  // Spy on global fetch and short-circuit the response so the contract test
+  // stays deterministic without depending on a real HTTP server lifecycle.
   const originalFetch = globalThis.fetch;
   const fetchCalls = [];
   globalThis.fetch = async (url, options) => {
@@ -619,6 +621,8 @@ test('defaultHealthcheck fetches without AbortSignal (Node v24 compatibility)', 
   };
 
   try {
+    // Manager with real defaultHealthcheck (healthcheckUrlImpl defaults)
+    // but stubbed lifecycle seams.
     const manager = createInspectRunViewerLifecycleManager({
       listListeningPidsImpl: async () => [42],
       isProcessAliveImpl: async () => true,
@@ -640,7 +644,8 @@ test('defaultHealthcheck fetches without AbortSignal (Node v24 compatibility)', 
       argsFingerprint: JSON.stringify({ repo: null, host: '127.0.0.1', port: 4311 }),
       startedAt: new Date().toISOString(),
       cwd: repoRoot,
-    })}\n`);
+    })}
+`);
 
     const status = await manager.status({ repoRoot });
     assert.equal(status.state, 'running');


### PR DESCRIPTION
## Summary

Add `scripts/github/audit-copilot-comments.mjs` to scan all REST review comments in a repo, filter Copilot-authored PR comments, classify them into the issue taxonomy, and write:

- `tmp/investigation/copilot-comment-summary.json`
- `tmp/investigation/copilot-comment-categories.md`

Also add focused script coverage and stabilize the Node v24 healthcheck test so `npm test` passes reliably.

## Scope / context

Issue #363 asks for a repo-wide audit of Copilot review comments to identify missing gate lenses and linting gaps.

Current live run on `mfittko/pi-dev-loops` produced:

- 1,170 Copilot review comments across 123 PRs
- 284 comments matched the requested taxonomy (24%)
- top matched categories:
  - Grammar / wording: 92
  - CI guard: 55
  - Misleading tests: 28
  - Config conflicts: 26
  - Broken relative paths: 21

Priority order from the generated report:

1. Strengthen CI guard semantics
2. Strengthen the coverage / test-quality lens
3. Strengthen docs / command-surface review
4. Add or tighten link/path validation
5. Add a config/schema drift lens
6. Add explicit gate-evidence enforcement
7. Add workflow no-op tool enforcement
8. Enable dead-code linting

## Acceptance criteria

- [x] Script exists and scans all PRs with Copilot review comments via REST API
- [x] Script writes JSON summary + markdown report under `tmp/investigation/`
- [x] Report includes top categories, recommended lenses/linters, and priority order
- [x] `npm test` passes

## Definition of done

- The repo has a reusable audit CLI for future reruns.
- Running the CLI on `mfittko/pi-dev-loops` produces the requested investigation artifacts.
- Tests cover CLI parsing, classification, output writing, and the Node v24 healthcheck seam.

## Non-goals

- Auto-fixing the historical Copilot comments.
- Expanding the taxonomy beyond the issue’s requested categories.
- Checking in generated `tmp/` investigation artifacts.

Refs #363
