### PR TITLE
Add opt-in docs review angle

### DIFF
--- a/.pi/dev-loop/defaults.yaml
+++ b/.pi/dev-loop/defaults.yaml
@@ -28,7 +28,7 @@ gates:
   preApproval:
     # Pre-approval gate: runs before declaring merge-ready.
     # Additional SOLID angles available as opt-in (see personas section):
-    #   ocp, lsp, isp, dip
+    #   ocp, lsp, isp, dip, docs
     angles:
       - dry
       - kiss
@@ -71,6 +71,19 @@ personas:
       Check whether the implementation matches the acceptance criteria
       and PR description. Flag logic errors, contract violations,
       and behavior mismatches.
+    defaultModel: null
+
+  docs:
+    persona: docs
+    prompt: >-
+      Review documentation correctness for the current change. Check that
+      relative markdown links resolve, symlink-backed doc pointers resolve,
+      navigable doc references are actual markdown links rather than bare
+      backtick path mentions, command/script references still exist and use
+      current names, and index/surface references match the current file tree.
+      When the repo provides `scripts/docs/validate-links.mjs`, use it for the
+      mechanical link pass; otherwise keep the review scoped to the touched doc
+      surface and current change only.
     defaultModel: null
 
   dry:

--- a/agents/docs.agent.md
+++ b/agents/docs.agent.md
@@ -1,18 +1,25 @@
 ---
 name: "docs"
-description: "Use for README updates, plan docs, architecture notes, agent docs, migration notes, and narrow documentation changes that must stay aligned with implementation work. Keywords: docs, README, plans, documentation, agent docs, rollout notes, changelog-style summary."
+description: "Use for README updates, plan docs, architecture notes, agent docs, migration notes, narrow documentation changes that must stay aligned with implementation work, and documentation-correctness review for the current change. Keywords: docs, README, plans, documentation, agent docs, rollout notes, changelog-style summary, docs review."
 tools: [read, search, execute, bash, edit, write]
-argument-hint: "Documentation task, affected files, source changes to reflect, and required level of detail."
+argument-hint: "Documentation task or documentation-correctness review, affected files, source changes to reflect, and required level of detail."
 systemPromptMode: append
 inheritProjectContext: true
 user-invocable: false
 ---
-You are a focused documentation agent. You update the narrowest correct documentation surface to reflect implementation changes.
+You are a focused documentation agent. You update the narrowest correct documentation surface to reflect implementation changes, and when invoked as a reviewer you audit documentation correctness for the current change.
 
 ## Purpose
 - Keep README, plan docs, workflow docs, and agent docs aligned with actual repository behavior.
 - Prefer precise updates over broad rewrites.
 - Record verification and no-docs rationale clearly when relevant.
+
+
+## Review mode
+- When invoked as a review persona (for example, the opt-in `docs` pre-approval angle), treat the resolved angle prompt as the primary review lens.
+- Audit documentation correctness for the current change: links, path references, command or script names, and whether doc indexes or surface references still match the current file tree.
+- Return findings with file references and concrete impact.
+- Do not silently edit files when acting as reviewer; report findings unless the caller explicitly switches you back into edit mode.
 
 ## Expectations
 - Do not invent behavior that is not implemented.
@@ -21,7 +28,7 @@ You are a focused documentation agent. You update the narrowest correct document
 
 ## Output
 Return:
-- What changed and why
-- Changed files
+- What changed and why, or the review findings and why they matter
+- Changed or reviewed files
 - Any verification or evidence used
-- Any remaining documentation gaps
+- Any remaining documentation gaps or follow-up work

--- a/extension/README.md
+++ b/extension/README.md
@@ -150,10 +150,12 @@ The shipped defaults activate these angles. Additional angles are available as o
 | `kiss` — over-engineering | `lsp` — Liskov Substitution (subtype contracts) |
 | `yagni` — speculative features | `isp` — Interface Segregation (fat interfaces) |
 | `srp` — Single Responsibility | `dip` — Dependency Inversion (abstractions) |
-| `soc` — Separation of Concerns | |
+| `soc` — Separation of Concerns | `docs` — documentation correctness (links, paths, command refs) |
 | `scope` — scope compliance (draft gate) | |
 | `coverage` — test coverage (draft gate) | |
 | `correctness` — acceptance criteria (draft gate) | |
+
+Built-in opt-in `docs` uses the packaged `.pi/agents/docs.agent.md` persona surface (symlinked to `agents/docs.agent.md` in-source), so consumers can enable the angle via `gates.preApproval.angles` without creating a second reviewer alias.
 
 ### Config precedence
 

--- a/packages/core/src/config/roles.mjs
+++ b/packages/core/src/config/roles.mjs
@@ -17,6 +17,7 @@ const BUILTIN_PERSONAS = Object.freeze({
   scope:       { persona: "review", defaultModel: null },
   coverage:    { persona: "review", defaultModel: null },
   correctness: { persona: "review", defaultModel: null },
+  docs:        { persona: "docs", defaultModel: null },
   dry:         { persona: "review", defaultModel: null },
   kiss:        { persona: "review", defaultModel: null },
   srp:         { persona: "review", defaultModel: null },

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import test, { describe } from "node:test";
 
 import {
@@ -894,10 +895,33 @@ describe("role resolution", () => {
     assert.equal(result.fallback, false);
   });
 
-  test("R12: all 12 known angles resolve without fallback", () => {
-    for (const angle of ["scope", "coverage", "correctness", "dry", "kiss", "srp", "ocp", "lsp", "isp", "dip", "soc", "yagni"]) {
+  test("R11b: known opt-in docs angle resolves to docs persona", () => {
+    const result = resolveReviewerRole({}, "docs");
+    assert.equal(result.persona, "docs");
+    assert.equal(result.model, null);
+    assert.equal(result.fallback, false);
+  });
+
+  test("R12: all 13 known angles resolve without fallback", () => {
+    const expectedPersonas = {
+      scope: "review",
+      coverage: "review",
+      correctness: "review",
+      docs: "docs",
+      dry: "review",
+      kiss: "review",
+      srp: "review",
+      ocp: "review",
+      lsp: "review",
+      isp: "review",
+      dip: "review",
+      soc: "review",
+      yagni: "review",
+    };
+
+    for (const [angle, expectedPersona] of Object.entries(expectedPersonas)) {
       const result = resolveReviewerRole({}, angle);
-      assert.equal(result.persona, "review", `angle ${angle}`);
+      assert.equal(result.persona, expectedPersona, `angle ${angle}`);
       assert.equal(result.fallback, false, `angle ${angle}`);
     }
   });
@@ -1167,4 +1191,33 @@ describe("role resolution", () => {
     });
   });
 
+});
+
+describe("shipped defaults docs angle wiring", () => {
+  test("D1: shipped defaults keep docs opt-in and resolve the packaged docs persona prompt", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-D1-"));
+    try {
+      const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+      const sourceDefaults = await readFile(path.join(repoRoot, ".pi", "dev-loop", "defaults.yaml"), "utf8");
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(path.join(piDir, "defaults.yaml"), sourceDefaults);
+
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const { resolveReviewerRole } = await import("../src/config/roles.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      const preApprovalAngles = resolveGateAngles(result.config, "preApproval");
+      const docsRole = resolveReviewerRole(result.config, "docs");
+
+      assert.deepEqual(result.errors, []);
+      assert.equal(result.config.personas.docs.persona, "docs");
+      assert.match(result.config.personas.docs.prompt, /Review documentation correctness/i);
+      assert.ok(!preApprovalAngles.includes("docs"), "docs must stay opt-in for pre-approval");
+      assert.equal(docsRole.persona, "docs");
+      assert.equal(docsRole.prompt, result.config.personas.docs.prompt);
+      assert.equal(docsRole.fallback, false);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/review-doc-contracts.test.mjs
+++ b/test/review-doc-contracts.test.mjs
@@ -24,6 +24,17 @@ test("review agent does not hardcode reviewer identity or stale plan path", asyn
   assert.doesNotMatch(content, /docs\/plans\//);
 });
 
+
+test("docs agent supports docs-correctness review posture without becoming a public workflow entrypoint", async () => {
+  const content = await readRepo("agents/docs.agent.md");
+  const frontmatter = parseFrontmatter(content);
+
+  assert.equal(frontmatter.name, "docs");
+  assert.equal(frontmatter["user-invocable"], false);
+  assert.match(content, /resolved angle prompt as the primary review lens/i);
+  assert.match(content, /do not silently edit files when acting as reviewer/i);
+});
+
 test("coordinator agent does not contain stale docs/plans path and requires fresh-context review briefings", async () => {
   const content = await readRepo("agents/coordinator.agent.md");
 


### PR DESCRIPTION
## Summary
- add shipped `personas.docs` config with an opt-in documentation-correctness review prompt
- wire the built-in `docs` angle to the packaged `docs` persona
- update docs-agent and extension docs so the opt-in angle is documented and review-safe
- extend config and asset tests to cover the new angle while keeping it out of default pre-approval gates

## Scope / context
Implements #359 without changing the default pre-approval gate list. Consumers can opt into the `docs` angle through `.pi/dev-loop/overrides.yaml`.

## Acceptance criteria
- [x] `.pi/dev-loop/defaults.yaml` ships a `personas.docs` prompt
- [x] `gates.preApproval.angles` remains unchanged by default (`docs` is opt-in only)
- [x] `packages/core/src/config/roles.mjs` recognizes `docs` as a built-in angle/persona mapping
- [x] `agents/docs.agent.md` supports docs-correctness review mode while preserving normal doc-editing posture
- [x] consumer-facing angle docs mention `docs` as an available opt-in pre-approval lens
- [x] config/asset tests cover the new angle and `npm test` passes

## Definition of done
- [x] implementation committed and pushed on `fix-docs-angle-359`
- [x] `npm test`
- [x] draft PR opened for review

## Non-goals
- making `docs` a default pre-approval angle
- changing pre-approval gate orchestration or state-machine behavior
- implementing `scripts/docs/validate-links.mjs` in this PR
