### PR TITLE
feat: add config-driven workflow defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ test-results/
 *.log
 .pi/dev-loop-retrospective-checkpoint.json
 .pi/dev-loop/overrides.json
-.pi/dev-loop/overrides.yaml
 
 .pi/ui-servers/
 worktrees/

--- a/.pi/dev-loop/defaults.yaml
+++ b/.pi/dev-loop/defaults.yaml
@@ -42,6 +42,12 @@ autonomy:
   stopAt:
     - merge
 
+# Workflow defaults: optional enforcement and local-mode posture
+workflow:
+  requireRetrospective: false
+  requireDraftFirst: false
+  devModeDefault: false
+
 # Persona registry: maps each review angle to an agent persona and prompt.
 # Consumers can add custom angles with their own persona agents.
 # Each entry:

--- a/.pi/dev-loop/overrides.yaml
+++ b/.pi/dev-loop/overrides.yaml
@@ -1,0 +1,6 @@
+version: 1
+
+workflow:
+  requireRetrospective: true
+  requireDraftFirst: true
+  devModeDefault: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,13 @@ These skills may be provided repo-locally or globally; this contract does not as
 
 ## Dev loop defaults
 
-- Use the `dev-loop` skill in **dev mode by default** for all local implementation work.
+Repo-local workflow defaults are configured under `.pi/dev-loop/overrides.yaml` `workflow.*`. In this repo, that override is the source of truth for opting into:
+- `workflow.requireRetrospective: true`
+- `workflow.requireDraftFirst: true`
+- `workflow.devModeDefault: true`
+
+Current behavior notes:
+- Use the `dev-loop` skill in **dev mode by default** for local implementation work in this repo.
 - After every completed async dev loop run, run a **behavioral review**: inspect what the loop did, whether it followed the working agreement, what it got right and where it drifted, and record any corrective notes before the next loop starts.
 - The behavioral review should be brief but honest — it is not a formality. If the loop made a bad decision or skipped a step, say so explicitly.
 
@@ -52,7 +58,7 @@ These are related but distinct requirements:
 | **Formal local dev mode** | Local implementation/self-improvement phases; explicitly scoped in [Dev Loop Skill](skills/dev-loop/SKILL.md) | Skill procedure; operator choice |
 | **Required post-run behavioral retrospective** | Every qualifying async GitHub-first `dev-loop` completion in this repo (copilot PR follow-up, issue intake) | Machine-checkable enforcement seam |
 
-Routed GitHub-first async `dev-loop` runs in this repo do **not** need to be in full formal local dev mode, but they **do** require the post-run behavioral retrospective checkpoint.
+Routed GitHub-first async `dev-loop` runs in this repo do **not** need to be in full formal local dev mode, but they **do** require the post-run behavioral retrospective checkpoint when `workflow.requireRetrospective` is enabled. This repo enables that policy through `.pi/dev-loop/overrides.yaml`.
 
 Authoritative checkpoint details live in [Retrospective Checkpoint Contract](skills/docs/retrospective-checkpoint-contract.md).
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See [Extension Documentation](./extension/README.md) for the full command and pa
 
 ## Configuration
 
-Gate review angles, refinement settings, persona mappings, and review prompts are config-driven via `.pi/dev-loop/defaults.yaml`. Consumer repos can override any value through `.pi/dev-loop/overrides.yaml`.
+Gate review angles, refinement settings, persona mappings, workflow defaults, and review prompts are config-driven via `.pi/dev-loop/defaults.yaml`. Consumer repos can override any value through `.pi/dev-loop/overrides.yaml`.
 
 ```bash
 # See what reviewers will check before handing off code
@@ -58,6 +58,7 @@ Key configurable surfaces:
 - **Persona prompts** — focused instructions per angle (e.g. DRY, KISS, YAGNI, SRP, SoC)
 - **Refinement** — fan-out count and mode for parallel review variants
 - **Autonomy** — which gates require operator confirmation
+- **Workflow defaults** — retrospective enforcement, draft-first posture, and formal dev-mode default policy
 
 Full details: [Extension Documentation](extension/README.md) and `.pi/dev-loop/defaults.yaml`.
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -102,7 +102,7 @@ The dev-loop workflow is driven by a YAML config at `.pi/dev-loop/defaults.yaml`
 
 ### How consumers customize config
 
-Create `.pi/dev-loop/overrides.yaml` in your project repo. It merges on top of the shipped defaults. You can override any section:
+Create `.pi/dev-loop/overrides.yaml` in your project repo. It merges on top of the shipped defaults. You can override any section, including workflow policy defaults:
 
 ```yaml
 # Example: add a custom review angle with a dedicated persona agent
@@ -138,6 +138,11 @@ autonomy:
   stopAt:
     - draft-pr
     - merge        # stop for confirmation at both gates
+
+workflow:
+  requireRetrospective: true
+  requireDraftFirst: true
+  devModeDefault: true
 ```
 
 ### Available review angles
@@ -150,18 +155,31 @@ The shipped defaults activate these angles. Additional angles are available as o
 | `kiss` — over-engineering | `lsp` — Liskov Substitution (subtype contracts) |
 | `yagni` — speculative features | `isp` — Interface Segregation (fat interfaces) |
 | `srp` — Single Responsibility | `dip` — Dependency Inversion (abstractions) |
-| `soc` — Separation of Concerns | `docs` — documentation correctness (links, paths, command refs) |
+| `soc` — Separation of Concerns | |
 | `scope` — scope compliance (draft gate) | |
 | `coverage` — test coverage (draft gate) | |
 | `correctness` — acceptance criteria (draft gate) | |
 
-Built-in opt-in `docs` uses the packaged `.pi/agents/docs.agent.md` persona surface (symlinked to `agents/docs.agent.md` in-source), so consumers can enable the angle via `gates.preApproval.angles` without creating a second reviewer alias.
+### Workflow defaults
+
+The optional `workflow` family carries repo-level workflow posture without hardcoding it into prose-only guidance. Shipped defaults stay permissive:
+
+```yaml
+workflow:
+  requireRetrospective: false
+  requireDraftFirst: false
+  devModeDefault: false
+```
+
+- `requireRetrospective` — when enabled by a repo override, the next qualifying GitHub-first async start/resume must honor the retrospective checkpoint gate
+- `requireDraftFirst` — marks draft-first PR creation as required workflow policy for repos that opt in
+- `devModeDefault` — declares that local implementation should default to formal dev mode; this is config-only for now and establishes source-of-truth config plus docs for future runtime consumers
 
 ### Config precedence
 
 1. Built-in defaults (`packages/core/src/config/schema.mjs` `BUILT_IN_DEFAULTS`)
 2. Shipped defaults (`.pi/dev-loop/defaults.yaml` — committed in source repo)
-3. Consumer overrides (`.pi/dev-loop/overrides.yaml` — per-project, gitignored by default)
+3. Consumer overrides (`.pi/dev-loop/overrides.yaml` — optional repo-local override surface, commit when you want repo-wide policy)
 
 ### Adding custom review angles
 

--- a/packages/core/src/config/index.mjs
+++ b/packages/core/src/config/index.mjs
@@ -1,4 +1,11 @@
 export { DevLoopConfigSchema, BUILT_IN_DEFAULTS, FileConfigSchema } from "./schema.mjs";
 export { loadDevLoopConfig } from "./loader.mjs";
 export { resolveReviewerRole } from "./roles.mjs";
-export { resolveConductorModel, resolveAutonomyStopAt, resolveRefinementConfig, resolveRefinement, resolveGateAngles } from "./model-resolution.mjs";
+export {
+  resolveConductorModel,
+  resolveAutonomyStopAt,
+  resolveRefinementConfig,
+  resolveRefinement,
+  resolveGateAngles,
+  resolveWorkflowConfig,
+} from "./model-resolution.mjs";

--- a/packages/core/src/config/model-resolution.mjs
+++ b/packages/core/src/config/model-resolution.mjs
@@ -43,6 +43,7 @@ export function resolveAutonomyStopAt(config) {
 }
 
 const DEFAULT_REFINEMENT_CONFIG = BUILT_IN_DEFAULTS.refinement;
+const DEFAULT_WORKFLOW_CONFIG = BUILT_IN_DEFAULTS.workflow;
 
 /**
  * Resolve one refinement configuration value from the merged dev-loop config.
@@ -113,4 +114,30 @@ export function resolveGateAngles(config, gate) {
     return [...gateConfig.angles];
   }
   return null;
+}
+
+/**
+ * Resolve one workflow configuration value from the merged dev-loop config.
+ *
+ * Returns the configured boolean when present, or the built-in default for the
+ * requested key.
+ *
+ * @param {import("./schema.mjs").DevLoopConfig} config
+ * @param {"requireRetrospective"|"requireDraftFirst"|"devModeDefault"} key
+ * @returns {boolean}
+ */
+export function resolveWorkflowConfig(config, key) {
+  if (key === "requireRetrospective") {
+    return config?.workflow?.requireRetrospective ?? DEFAULT_WORKFLOW_CONFIG.requireRetrospective;
+  }
+
+  if (key === "requireDraftFirst") {
+    return config?.workflow?.requireDraftFirst ?? DEFAULT_WORKFLOW_CONFIG.requireDraftFirst;
+  }
+
+  if (key === "devModeDefault") {
+    return config?.workflow?.devModeDefault ?? DEFAULT_WORKFLOW_CONFIG.devModeDefault;
+  }
+
+  throw new Error(`Unknown workflow config key: ${key}`);
 }

--- a/packages/core/src/config/schema.mjs
+++ b/packages/core/src/config/schema.mjs
@@ -40,6 +40,12 @@ const AutonomyConfig = z.strictObject({
   ),
 });
 
+const WorkflowConfig = z.strictObject({
+  requireRetrospective: z.boolean(),
+  requireDraftFirst: z.boolean(),
+  devModeDefault: z.boolean(),
+});
+
 const PersonaEntry = z.strictObject({
   persona: z.string().min(1),
   // Optional in the merged/full schema so consumer overrides can replace
@@ -68,6 +74,7 @@ export const DevLoopConfigSchema = z.strictObject({
   refinement: RefinementConfig.optional(),
   gates: GatesConfig.optional(),
   autonomy: AutonomyConfig.optional(),
+  workflow: WorkflowConfig.optional(),
   personas: PersonasConfig.optional(),
 });
 
@@ -82,6 +89,11 @@ export const BUILT_IN_DEFAULTS = Object.freeze({
   refinement: Object.freeze({ fanOut: 3, mode: "parallel", maxCopilotRounds: 5 }),
   gates: Object.freeze({}),
   autonomy: Object.freeze({ stopAt: Object.freeze(["merge"]) }),
+  workflow: Object.freeze({
+    requireRetrospective: false,
+    requireDraftFirst: false,
+    devModeDefault: false,
+  }),
   personas: Object.freeze({}),
 });
 
@@ -96,5 +108,6 @@ export const FileConfigSchema = z.strictObject({
   refinement: RefinementConfig.partial().optional(),
   gates: GatesConfig.partial().optional(),
   autonomy: AutonomyConfig.partial().optional(),
+  workflow: WorkflowConfig.partial().optional(),
   personas: FilePersonasConfig.optional(),
 });

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -128,6 +128,8 @@ describe("schema validation", () => {
       version: 1,
       workflow: {
         requireRetrospective: true,
+        requireDraftFirst: false,
+        devModeDefault: true,
         unknownKey: true,
       },
     });

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -9,7 +9,14 @@ import {
   DevLoopConfigSchema,
   BUILT_IN_DEFAULTS,
 } from "../src/config/schema.mjs";
-import { resolveConductorModel, resolveAutonomyStopAt, resolveRefinementConfig, resolveRefinement, resolveGateAngles } from "../src/config/model-resolution.mjs";
+import {
+  resolveConductorModel,
+  resolveAutonomyStopAt,
+  resolveRefinementConfig,
+  resolveRefinement,
+  resolveGateAngles,
+  resolveWorkflowConfig,
+} from "../src/config/model-resolution.mjs";
 // ============================================================================
 // Schema validation tests (S1–S26)
 // ============================================================================
@@ -26,6 +33,11 @@ describe("schema validation", () => {
         preApproval: { angles: ["dry", "kiss", "yagni"], required: false },
       },
       autonomy: { stopAt: ["draft-pr", "merge"] },
+      workflow: {
+        requireRetrospective: true,
+        requireDraftFirst: false,
+        devModeDefault: true,
+      },
     };
     const result = DevLoopConfigSchema.safeParse(input);
     assert.ok(result.success, "full config should parse");
@@ -92,6 +104,32 @@ describe("schema validation", () => {
     const result = DevLoopConfigSchema.safeParse({
       version: 1,
       autonomy: { stopAt: ["merge"], unknownKey: true },
+    });
+    assert.ok(!result.success);
+  });
+
+  test("S10b: workflow family parses when all supported keys are present", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      workflow: {
+        requireRetrospective: true,
+        requireDraftFirst: false,
+        devModeDefault: true,
+      },
+    });
+    assert.ok(result.success);
+    assert.equal(result.data.workflow.requireRetrospective, true);
+    assert.equal(result.data.workflow.requireDraftFirst, false);
+    assert.equal(result.data.workflow.devModeDefault, true);
+  });
+
+  test("S10c: unknown nested key inside workflow rejected", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      workflow: {
+        requireRetrospective: true,
+        unknownKey: true,
+      },
     });
     assert.ok(!result.success);
   });
@@ -263,6 +301,14 @@ describe("BUILT_IN_DEFAULTS", () => {
 
   test("autonomy.stopAt is [merge]", () => {
     assert.deepEqual(BUILT_IN_DEFAULTS.autonomy.stopAt, ["merge"]);
+  });
+
+  test("workflow defaults exist and all three values are false", () => {
+    assert.deepEqual(BUILT_IN_DEFAULTS.workflow, {
+      requireRetrospective: false,
+      requireDraftFirst: false,
+      devModeDefault: false,
+    });
   });
 });
 
@@ -442,6 +488,36 @@ describe("loader — graceful degradation", () => {
       const result = await loadDevLoopConfig({ repoRoot: tmpDir });
       assert.equal(result.errors.length, 0);
       assert.equal(result.config.refinement.maxCopilotRounds, 5);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("Y1c: workflow family merges correctly from defaults.yaml and overrides.yaml", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-workflow-yaml-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(path.join(piDir, "defaults.yaml"), [
+        "version: 1",
+        "workflow:",
+        "  requireRetrospective: true",
+        "  requireDraftFirst: false",
+        "  devModeDefault: false",
+      ].join("\n"));
+      await writeFile(path.join(piDir, "overrides.yaml"), [
+        "version: 1",
+        "workflow:",
+        "  requireDraftFirst: true",
+      ].join("\n"));
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.deepEqual(result.errors, []);
+      assert.deepEqual(result.config.workflow, {
+        requireRetrospective: true,
+        requireDraftFirst: true,
+        devModeDefault: false,
+      });
     } finally {
       await rm(tmpDir, { recursive: true, force: true });
     }
@@ -795,6 +871,44 @@ describe("loader — precedence", () => {
       assert.deepEqual(result.errors, []);
       assert.equal(result.config.personas.dry.persona, "custom-dry-reviewer");
       assert.equal(result.config.personas.dry.prompt, undefined);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("M8: workflow family merges correctly from defaults.json and overrides.json", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-M8-"));
+    try {
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(
+        path.join(piDir, "defaults.json"),
+        JSON.stringify({
+          version: 1,
+          workflow: {
+            requireRetrospective: false,
+            requireDraftFirst: false,
+            devModeDefault: true,
+          },
+        }),
+      );
+      await writeFile(
+        path.join(piDir, "overrides.json"),
+        JSON.stringify({
+          version: 1,
+          workflow: {
+            requireRetrospective: true,
+          },
+        }),
+      );
+      const { loadDevLoopConfig } = await import("../src/config/loader.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.deepEqual(result.errors, []);
+      assert.deepEqual(result.config.workflow, {
+        requireRetrospective: true,
+        requireDraftFirst: false,
+        devModeDefault: true,
+      });
     } finally {
       await rm(tmpDir, { recursive: true, force: true });
     }
@@ -1188,6 +1302,37 @@ describe("role resolution", () => {
       const result = resolveRefinement(config);
       result.roles.push("style");
       assert.deepEqual(config.refinement.roles, ["security"]);
+    });
+
+    test("resolveWorkflowConfig returns built-in defaults when workflow family is absent", () => {
+      assert.equal(resolveWorkflowConfig({ version: 1 }, "requireRetrospective"), false);
+      assert.equal(resolveWorkflowConfig({ version: 1 }, "requireDraftFirst"), false);
+      assert.equal(resolveWorkflowConfig({ version: 1 }, "devModeDefault"), false);
+    });
+
+    test("resolveWorkflowConfig returns configured booleans", () => {
+      const config = {
+        version: 1,
+        workflow: {
+          requireRetrospective: true,
+          requireDraftFirst: true,
+          devModeDefault: false,
+        },
+      };
+      assert.equal(resolveWorkflowConfig(config, "requireRetrospective"), true);
+      assert.equal(resolveWorkflowConfig(config, "requireDraftFirst"), true);
+      assert.equal(resolveWorkflowConfig(config, "devModeDefault"), false);
+    });
+
+    test("resolveWorkflowConfig falls through to built-in false when an individual key is absent", () => {
+      const config = { version: 1, workflow: { requireDraftFirst: true } };
+      assert.equal(resolveWorkflowConfig(config, "requireRetrospective"), false);
+      assert.equal(resolveWorkflowConfig(config, "requireDraftFirst"), true);
+      assert.equal(resolveWorkflowConfig(config, "devModeDefault"), false);
+    });
+
+    test("resolveWorkflowConfig throws on unknown key", () => {
+      assert.throws(() => resolveWorkflowConfig({ version: 1 }, "unknownKey"), /Unknown workflow config key/);
     });
   });
 

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -555,7 +555,7 @@ When you do hand work to Copilot:
 
 Follow the PR description contract (see [Agent Instructions](../../AGENTS.md) if present; otherwise use the structure below): detailed structured descriptions, not thin placeholders. At minimum include change summary, scope/context, explicit acceptance criteria, explicit definition of done, and explicit non-goals.
 
-New PRs in this workflow must be opened as **draft** PRs first. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate review is a real workflow boundary, so a new PR must exist in draft before `gh pr ready` is even eligible.
+New PRs in this workflow must be opened as **draft** PRs first when the repository enables `.pi/dev-loop/overrides.yaml` `workflow.requireDraftFirst`. The built-in shipped default remains permissive; this repo opts in. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate review is a real workflow boundary, so a new PR must exist in draft before `gh pr ready` is even eligible.
 
 Only use `gh pr create` when authoritative issue↔PR resolution says there is no already-open linked PR. If a PR already exists, reuse/update that canonical PR instead of opening another one.
 

--- a/skills/docs/retrospective-checkpoint-contract.md
+++ b/skills/docs/retrospective-checkpoint-contract.md
@@ -41,9 +41,9 @@ A fresh session can determine the status of the required retrospective by readin
 
 ## Enforcement gate
 
-The enforcement seam is the pure function `evaluateRetrospectiveGate` in `packages/core/src/loop/retrospective-checkpoint.mjs`. The checkpoint artifact may still exist even when enforcement is disabled; the workflow config controls whether callers should block the next qualifying routed start/resume on that artifact.
+The enforcement seam is the pure function `evaluateRetrospectiveGate` in `packages/core/src/loop/retrospective-checkpoint.mjs`. The checkpoint artifact may still exist even when enforcement is disabled; callers must first consult `workflow.requireRetrospective` to decide whether the checkpoint should block the next qualifying routed start/resume or remain advisory-only.
 
-For convenience, the public routing helpers in `packages/core/src/loop/public-dev-loop-routing.mjs` also accept an optional `retrospectiveCheckpointState` input and apply the same gate internally before returning routed start/resume/status results.
+For convenience, the public routing helpers in `packages/core/src/loop/public-dev-loop-routing.mjs` also accept an optional `retrospectiveCheckpointState` input and apply the same gate internally before returning routed start/resume/status results. Callers should only pass that input when `workflow.requireRetrospective` is enabled for the active repo/workflow posture.
 
 ### Inputs
 
@@ -75,7 +75,7 @@ Callers have two supported integration options:
    - `evaluatePublicDevLoopRouting(...)`
    - `resolveAuthoritativeStartupResumeBundle(...)`
    - `resolveAuthoritativeDevLoopStatus(...)`
-4. Use the returned result directly. When the checkpoint is missing, these helpers fail closed to `needs_reconcile`.
+4. Use the returned result directly. When enforcement is enabled and the checkpoint is missing, these helpers fail closed to `needs_reconcile`.
 
 #### Option B — explicit manual gate composition
 
@@ -83,7 +83,7 @@ Callers have two supported integration options:
 2. Map the file contents to a `RETROSPECTIVE_CHECKPOINT_STATE` value.
 3. Call `evaluatePublicDevLoopRouting(...)` to get the proposed routing.
 4. Call `evaluateRetrospectiveGate({ checkpointState, proposedRouting })`.
-5. Use the gate result (not the raw routing result) as the effective routing decision.
+5. Use the gate result (not the raw routing result) as the effective routing decision when enforcement is enabled; otherwise keep the raw routing result and treat the checkpoint artifact as advisory context only.
 
 If the gate result is `needs_reconcile`, the caller must not proceed with the proposed routing. The `nextAction` field instructs the operator to complete or explicitly skip the retrospective.
 

--- a/skills/docs/retrospective-checkpoint-contract.md
+++ b/skills/docs/retrospective-checkpoint-contract.md
@@ -1,6 +1,6 @@
 # Retrospective checkpoint contract
 
-This document defines the enforcement seam for the required post-run behavioral retrospective after qualifying async `dev-loop` completions in this repository.
+This document defines the enforcement seam for the post-run behavioral retrospective checkpoint after qualifying async `dev-loop` completions in this repository. Whether a missing checkpoint blocks the next qualifying start/resume is controlled by `.pi/dev-loop/overrides.yaml` `workflow.requireRetrospective`; shipped defaults remain permissive and this repo opts in.
 
 ## Relationship to formal dev mode
 
@@ -11,7 +11,7 @@ Formal local dev mode and the required post-run behavioral retrospective are rel
 | **Formal local dev mode** | Local implementation/self-improvement work; explicitly scoped in [Dev Loop Skill](../dev-loop/SKILL.md) |
 | **Required post-run behavioral retrospective** | Every qualifying async GitHub-first `dev-loop` completion in this repo |
 
-Routed GitHub-first async `dev-loop` runs do **not** need to be in full formal local dev mode, but they **do** require the retrospective checkpoint.
+Routed GitHub-first async `dev-loop` runs do **not** need to be in full formal local dev mode. When `workflow.requireRetrospective` is enabled, they **do** require the retrospective checkpoint before the next qualifying start/resume.
 
 ## Qualifying completions
 
@@ -41,7 +41,7 @@ A fresh session can determine the status of the required retrospective by readin
 
 ## Enforcement gate
 
-The enforcement seam is the pure function `evaluateRetrospectiveGate` in `packages/core/src/loop/retrospective-checkpoint.mjs`.
+The enforcement seam is the pure function `evaluateRetrospectiveGate` in `packages/core/src/loop/retrospective-checkpoint.mjs`. The checkpoint artifact may still exist even when enforcement is disabled; the workflow config controls whether callers should block the next qualifying routed start/resume on that artifact.
 
 For convenience, the public routing helpers in `packages/core/src/loop/public-dev-loop-routing.mjs` also accept an optional `retrospectiveCheckpointState` input and apply the same gate internally before returning routed start/resume/status results.
 

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -77,7 +77,7 @@ When the local spec already lives in a tracker issue:
 - sync durable scope / acceptance / status changes back to the tracker issue rather than maintaining a duplicate local phase doc
 - keep `tmp/` as temporary local execution state only; it does not become a second durable spec surface
 - for tracker-backed sessions, the handoff path is always: push the working branch → open a PR → merge via GitHub
-- for tracker-backed sessions, PR creation must use `gh pr create --draft`. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate review is a real workflow boundary.
+- for tracker-backed sessions, PR creation must use `gh pr create --draft`. Treat this as config-driven workflow policy via `.pi/dev-loop/overrides.yaml` `workflow.requireDraftFirst` when the repo opts in. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate review is a real workflow boundary.
 - do not suggest a direct local-main merge for tracker-backed sessions; do not merge the working branch into local `main` at phase completion
 
 ## Primary execution rules
@@ -419,6 +419,8 @@ This is the infrastructure for self-improvement. Do not skip it.
 
 Dev mode is for improving the local implementation loop itself while using it.
 
+A repository may also declare a formal-dev-mode default through `.pi/dev-loop/overrides.yaml` `workflow.devModeDefault`. Treat that config as the policy source of truth when present, but explicit user opt-in or opt-out for the current run still wins. Runtime consumption of that config may be staged separately from this documentation update.
+
 Trigger it when the user explicitly asks for dev mode, self-improvement mode, or says they want the skill to refine itself as it goes.
 
 In dev mode, after the normal phase summary and retrospective are written, run one extra bounded self-improvement pass before moving on:
@@ -509,7 +511,7 @@ Stop after the current phase when:
 - Rerun validation after review-driven fixes.
 - A phase is not operationally closed until its branch state is captured in commit history and the reviewed branch has been finalized according to session type (merged into local `main` for phase-doc-backed sessions; merged via GitHub PR for tracker-backed sessions), unless authorization for that finalization is still pending.
 - For tracker-backed sessions, the handoff path is always: push the working branch → open a PR → merge via GitHub; never merge the working branch into local `main`.
-- PR creation must use `gh pr create --draft`. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate review is a real workflow boundary, so a new PR must exist in draft before `gh pr ready` is eligible.
+- PR creation must use `gh pr create --draft`. Treat this as config-driven workflow policy via `.pi/dev-loop/overrides.yaml` `workflow.requireDraftFirst` when the repo opts in. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate review is a real workflow boundary, so a new PR must exist in draft before `gh pr ready` is eligible.
 - When authorization is pending, record the phase as `awaiting-finalization` and describe the exact missing step.
 - For phase-doc-backed sessions, merge the fully reviewed, locally validated branch back into local `main` when authorized.
 


### PR DESCRIPTION
## Summary
- add a `workflow` config family to the dev-loop schema, built-in defaults, resolver exports, and shipped defaults
- commit this repo's opt-in workflow override surface at `.pi/dev-loop/overrides.yaml`
- document config-driven workflow posture in the extension README and related repo/skill docs
- extend core config coverage for workflow schema validation, loader merging, and resolver behavior

## Scope / context
This change moves workflow-enforcement defaults for retrospective gating, draft-first posture, and local dev-mode defaulting onto the existing config surface instead of leaving them as prose-only repo guidance.

Implemented here:
- `workflow` schema + built-in defaults
- `resolveWorkflowConfig(...)` export
- shipped defaults in `.pi/dev-loop/defaults.yaml`
- committed repo opt-in override in `.pi/dev-loop/overrides.yaml`
- `.gitignore` cleanup so the YAML override file is commitable
- docs updates for the new workflow config surface
- config test coverage

## Acceptance criteria
- [x] `workflow` exists in schema, file schema, and built-in defaults
- [x] `.pi/dev-loop/defaults.yaml` ships `workflow` with all values `false`
- [x] `.pi/dev-loop/overrides.yaml` is committed as the repo-local opt-in surface
- [x] `resolveWorkflowConfig(...)` resolves supported workflow booleans with built-in fallback behavior
- [x] extension and related repo docs reference config-driven workflow defaults
- [x] `packages/core/test/config.test.mjs` covers workflow schema, merge, and resolver behavior
- [x] `npm test` passes

## Definition of done
- branch pushed
- draft PR opened
- workflow config surface documented
- tests passing locally

## Non-goals
- runtime consumption of `workflow.devModeDefault`
- broader retrospective or draft enforcement mechanics beyond establishing the config source of truth
- unrelated workflow surface changes

## Validation
- `npm test`

Closes #357
