### PR TITLE
Clarify refiner-only consolidation for issue refinement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@ These skills may be provided repo-locally or globally; this contract does not as
 - Implement one phase at a time.
 - Use fan-out / fan-in / review / merge before implementing each phase.
 - Default phase and issue refinement to multiple parallel variants before converging on a merged plan; do not rely on a single-plan synthesis when fan-out is practical.
+- Standard refinement chain pattern: run parallel fan-out with the `refiner` agent, then run the consolidation/fan-in synthesis as a `refiner` agent too.
+- Never route review-only comparison, synthesis, or consolidation steps through `dev-loop` + `local-implementation`; reserve that path for actual implementation/edit work only.
 - Keep logs under `tmp/` in deterministic phase-scoped paths.
 - Use feature branches and small commits only after local verification.
 - Use `npm run verify` as the default repo-level local verification path when a full local validation pass is warranted.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ These skills may be provided repo-locally or globally; this contract does not as
 - Implement one phase at a time.
 - Use fan-out / fan-in / review / merge before implementing each phase.
 - Default phase and issue refinement to multiple parallel variants before converging on a merged plan; do not rely on a single-plan synthesis when fan-out is practical.
-- Standard refinement chain pattern: run parallel fan-out with the `refiner` agent, then run the consolidation/fan-in synthesis as a `refiner` agent too.
+- Standard refinement chain pattern: run parallel fan-out with the `refiner` agent, then run the consolidation/fan-in synthesis with the `refiner` agent too.
 - Never route review-only comparison, synthesis, or consolidation steps through `dev-loop` + `local-implementation`; reserve that path for actual implementation/edit work only.
 - Keep logs under `tmp/` in deterministic phase-scoped paths.
 - Use feature branches and small commits only after local verification.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ These skills may be provided repo-locally or globally; this contract does not as
 - Implement one phase at a time.
 - Use fan-out / fan-in / review / merge before implementing each phase.
 - Default phase and issue refinement to multiple parallel variants before converging on a merged plan; do not rely on a single-plan synthesis when fan-out is practical.
-- Standard refinement chain pattern: run parallel fan-out with the `refiner` agent, then run the consolidation/fan-in synthesis with the `refiner` agent too.
+- Standard refinement chain pattern: run parallel fan-out with the `refiner` agent, then run the consolidation/fan-in synthesis with the `refiner` agent.
 - Never route review-only comparison, synthesis, or consolidation steps through `dev-loop` + `local-implementation`; reserve that path for actual implementation/edit work only.
 - Keep logs under `tmp/` in deterministic phase-scoped paths.
 - Use feature branches and small commits only after local verification.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ These skills may be provided repo-locally or globally; this contract does not as
 - Use fan-out / fan-in / review / merge before implementing each phase.
 - Default phase and issue refinement to multiple parallel variants before converging on a merged plan; do not rely on a single-plan synthesis when fan-out is practical.
 - Standard refinement chain pattern: run parallel fan-out with the `refiner` agent, then run the consolidation/fan-in synthesis with the `refiner` agent.
-- Never route review-only comparison, synthesis, or consolidation steps through `dev-loop` + `local-implementation`; reserve that path for actual implementation/edit work only.
+- Never route review-only comparison, synthesis, or consolidation steps through `dev-loop` + `local_implementation` (the strategy loaded by `skills/local-implementation`); reserve that path for actual implementation/edit work only.
 - Keep logs under `tmp/` in deterministic phase-scoped paths.
 - Use feature branches and small commits only after local verification.
 - Use `npm run verify` as the default repo-level local verification path when a full local validation pass is warranted.

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -319,7 +319,7 @@ Preflight verdicts:
 
 ### Phase 3 — Async issue refinement
 
-Before updating or assigning the issue, refine it asynchronously when practical. Keep issue refinement separate from the phase-scoped refiner used by the local implementation workflow. Use the `refiner` agent for this review-only issue-refinement chain, including the consolidation/fan-in step; do not route those comparison/synthesis steps through `dev-loop` + `local-implementation`.
+Before updating or assigning the issue, refine it asynchronously when practical. Keep issue refinement separate from the phase-scoped refiner used by the local implementation workflow. Use the `refiner` agent for this review-only issue-refinement chain, including the consolidation/fan-in step; do not route those comparison/synthesis steps through `dev-loop` + `local_implementation` (the strategy loaded by `skills/local-implementation`).
 
 ### Phase 3b — Epic decomposition with GitHub sub-issue trees
 

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -319,7 +319,7 @@ Preflight verdicts:
 
 ### Phase 3 — Async issue refinement
 
-Before updating or assigning the issue, refine it asynchronously when practical. Keep issue refinement separate from the phase-scoped refiner used by the local implementation workflow.
+Before updating or assigning the issue, refine it asynchronously when practical. Keep issue refinement separate from the phase-scoped refiner used by the local implementation workflow. Use the `refiner` agent for this review-only issue-refinement chain, including the consolidation/fan-in step; do not route those comparison/synthesis steps through `dev-loop` + `local-implementation`.
 
 ### Phase 3b — Epic decomposition with GitHub sub-issue trees
 

--- a/skills/issue-intake/SKILL.md
+++ b/skills/issue-intake/SKILL.md
@@ -17,6 +17,10 @@ issue-first intake procedure now lives in `copilot-pr-followup` under the
 **Issue-first intake and durable-auto overlays** section.
 
 When this skill is loaded, immediately redirect to [Copilot PR Follow-up Skill](../copilot-pr-followup/SKILL.md)
-and follow its procedure. The `issue_intake` routing still differentiates from
-`copilot_pr_followup` in the public router; this redirect preserves that contract
-while keeping the procedure text canonical in one file.
+and follow its procedure. For issue-refinement chains on that path, the `refiner`
+agent is the preferred tool for both the parallel fan-out variants and the
+review-only consolidation/fan-in step. Never route review-only consolidation
+through `dev-loop` or `local-implementation`, because those routes imply
+implementation/edit work. The `issue_intake` routing still differentiates from
+`copilot_pr_followup` in the public router; this redirect preserves that
+contract while keeping the procedure text canonical in one file.

--- a/skills/issue-intake/SKILL.md
+++ b/skills/issue-intake/SKILL.md
@@ -20,7 +20,8 @@ When this skill is loaded, immediately redirect to [Copilot PR Follow-up Skill](
 and follow its procedure. For issue-refinement chains on that path, the `refiner`
 agent is the preferred tool for both the parallel fan-out variants and the
 review-only consolidation/fan-in step. Never route review-only consolidation
-through `dev-loop` or `local-implementation`, because those routes imply
+through `dev-loop` + `local-implementation` (the
+`local_implementation` route), because that route implies
 implementation/edit work. The `issue_intake` routing still differentiates from
 `copilot_pr_followup` in the public router; this redirect preserves that
 contract while keeping the procedure text canonical in one file.

--- a/skills/issue-intake/SKILL.md
+++ b/skills/issue-intake/SKILL.md
@@ -17,7 +17,8 @@ issue-first intake procedure now lives in `copilot-pr-followup` under the
 **Issue-first intake and durable-auto overlays** section.
 
 When this skill is loaded, immediately redirect to [Copilot PR Follow-up Skill](../copilot-pr-followup/SKILL.md)
-and follow its procedure. On that route, the `refiner` agent is the preferred
-tool for issue-refinement work. The `issue_intake` routing still differentiates
-from `copilot_pr_followup` in the public router; this redirect preserves that
-contract while keeping the procedure text canonical in one file.
+and follow its procedure. On the redirected `issue_intake` route, the
+`refiner` agent is the preferred tool for issue-refinement work. The
+`issue_intake` routing still differentiates from `copilot_pr_followup` in the
+public router; this redirect preserves that contract while keeping the
+procedure text canonical in one file.

--- a/skills/issue-intake/SKILL.md
+++ b/skills/issue-intake/SKILL.md
@@ -17,11 +17,7 @@ issue-first intake procedure now lives in `copilot-pr-followup` under the
 **Issue-first intake and durable-auto overlays** section.
 
 When this skill is loaded, immediately redirect to [Copilot PR Follow-up Skill](../copilot-pr-followup/SKILL.md)
-and follow its procedure. For issue-refinement chains on that path, the `refiner`
-agent is the preferred tool for both the parallel fan-out variants and the
-review-only consolidation/fan-in step. Never route review-only consolidation
-through `dev-loop` + `local-implementation` (the
-`local_implementation` route), because that route implies
-implementation/edit work. The `issue_intake` routing still differentiates from
-`copilot_pr_followup` in the public router; this redirect preserves that
+and follow its procedure. On that route, the `refiner` agent is the preferred
+tool for issue-refinement work. The `issue_intake` routing still differentiates
+from `copilot_pr_followup` in the public router; this redirect preserves that
 contract while keeping the procedure text canonical in one file.

--- a/skills/issue-intake/SKILL.md
+++ b/skills/issue-intake/SKILL.md
@@ -17,8 +17,7 @@ issue-first intake procedure now lives in `copilot-pr-followup` under the
 **Issue-first intake and durable-auto overlays** section.
 
 When this skill is loaded, immediately redirect to [Copilot PR Follow-up Skill](../copilot-pr-followup/SKILL.md)
-and follow its procedure. On the redirected `issue_intake` route, the
-`refiner` agent is the preferred tool for issue-refinement work. The
-`issue_intake` routing still differentiates from `copilot_pr_followup` in the
-public router; this redirect preserves that contract while keeping the
-procedure text canonical in one file.
+and follow its procedure. Use the `refiner` agent for issue-refinement
+work on the redirected `issue_intake` route. The `issue_intake` routing still
+differentiates from `copilot_pr_followup` in the public router; this redirect
+preserves that contract while keeping the procedure text canonical in one file.


### PR DESCRIPTION
## Summary
- add working-agreement guidance that refinement-chain consolidation/fan-in stays on the `refiner` agent
- document that review-only comparison/synthesis steps must not route through `dev-loop` + `local-implementation`
- update the `issue-intake` redirect so issue refinement explicitly prefers the `refiner` agent

## Scope / context
Fixes #375. This issue is a documentation/pattern correction for refinement chains that only compare or synthesize outputs and should not be treated as implementation tasks.

## Acceptance criteria
- [x] AGENTS.md working agreement says refinement-chain consolidation uses the `refiner` agent
- [x] AGENTS.md says review-only refinement steps must not use `dev-loop` + `local-implementation`
- [x] `skills/issue-intake/SKILL.md` says the `refiner` agent is the preferred tool for issue refinement on that route

## Definition of done
- [x] Requested docs updated
- [x] No code or test files changed
- [x] `npm run verify` passes

## Non-goals
- adding a new review-only runtime mode
- changing implementation code or test contracts
