### PR TITLE
Add conflict-resolution PR gate boundary

### DIFF
--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -109,9 +109,8 @@ function normalizeConflictFiles(value) {
       continue;
     }
 
-    const trimmed = entry.trim();
-    if (trimmed.length > 0 && !normalized.includes(trimmed)) {
-      normalized.push(trimmed);
+    if (entry.trim().length > 0 && !normalized.includes(entry)) {
+      normalized.push(entry);
     }
   }
 

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -4,6 +4,7 @@ export const PR_GATE_BOUNDARY = Object.freeze({
   DRAFT_REVIEW: "draft_review",
   POST_DRAFT_EXTERNAL_REVIEW: "post_draft_external_review",
   FEEDBACK_RESOLUTION: "feedback_resolution",
+  CONFLICT_RESOLUTION: "conflict_resolution",
   PRE_APPROVAL_GATE_WINDOW: "pre_approval_gate_window",
   FINAL_APPROVAL_READY: "final_approval_ready",
   BLOCKED: "blocked",
@@ -19,6 +20,7 @@ export const PR_GATE_ACTION = Object.freeze({
   ADDRESS_REVIEW_FEEDBACK: "address_review_feedback",
   REPLY_RESOLVE_REVIEW_THREADS: "reply_resolve_review_threads",
   REREQUEST_COPILOT_REVIEW: "rerequest_copilot_review",
+  RESOLVE_MERGE_CONFLICTS: "resolve_merge_conflicts",
   RUN_PRE_APPROVAL_GATE: "run_pre_approval_gate",
   AWAIT_FINAL_HUMAN_APPROVAL: "await_final_human_approval",
   DECLARE_MERGE_READY: "declare_merge_ready",
@@ -86,6 +88,54 @@ function pushUnique(values, additions) {
   }
 }
 
+const CONFLICTING_MERGE_STATE_STATUSES = new Set(["DIRTY", "CONFLICTING"]);
+
+function normalizeMergeStateStatus(value) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return null;
+  }
+
+  return value.trim().toUpperCase();
+}
+
+function normalizeConflictFiles(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const normalized = [];
+  for (const entry of value) {
+    if (typeof entry !== "string") {
+      continue;
+    }
+
+    const trimmed = entry.trim();
+    if (trimmed.length > 0 && !normalized.includes(trimmed)) {
+      normalized.push(trimmed);
+    }
+  }
+
+  return normalized;
+}
+
+function hasConflictStatus(mergeStateStatus) {
+  return mergeStateStatus !== null && CONFLICTING_MERGE_STATE_STATUSES.has(mergeStateStatus);
+}
+
+function formatConflictResolutionReason(mergeStateStatus, conflictFiles) {
+  let reason = "The current branch conflicts with the base branch, so resolve the conflict locally on the PR branch, rerun validation, rerun gate detection, and only then resume the normal gate path.";
+
+  if (mergeStateStatus !== null) {
+    reason += ` GitHub mergeStateStatus: ${mergeStateStatus}.`;
+  }
+
+  if (conflictFiles.length > 0) {
+    reason += ` Conflicting files: ${conflictFiles.join(", ")}.`;
+  }
+
+  return reason;
+}
+
 function buildResult({
   draftGateAlreadySatisfied = false,
   repo = null,
@@ -100,6 +150,8 @@ function buildResult({
   forbiddenActions,
   nextAction,
   reason,
+  mergeStateStatus = null,
+  conflictFiles = [],
 }) {
   return {
     ok: true,
@@ -115,6 +167,8 @@ function buildResult({
     forbiddenActions,
     nextAction,
     reason,
+    mergeStateStatus,
+    conflictFiles,
     draftGateAlreadySatisfied,
   };
 }
@@ -132,6 +186,8 @@ export function evaluatePrGateCoordination(input = {}) {
   const reviewMode = typeof input.reviewMode === "string"
     ? input.reviewMode.trim().toLowerCase()
     : null;
+  const mergeStateStatus = normalizeMergeStateStatus(input.mergeStateStatus);
+  const conflictFiles = normalizeConflictFiles(input.conflictFiles);
 
   const draftGate = toGateStatus(input.draftGate, input.draftGateMarker, currentHeadSha);
   const preApprovalGate = toGateStatus(input.preApprovalGate, input.preApprovalGateMarker, currentHeadSha);
@@ -189,6 +245,43 @@ export function evaluatePrGateCoordination(input = {}) {
       forbiddenActions,
       nextAction: PR_GATE_ACTION.REPORT_BLOCKED,
       reason: "The PR is in a blocked lifecycle state, so gate progression must stop for a user decision.",
+      mergeStateStatus,
+      conflictFiles,
+    });
+  }
+
+  if (hasConflictStatus(mergeStateStatus) || conflictFiles.length > 0) {
+    pushUnique(allowedNextActions, [PR_GATE_ACTION.RESOLVE_MERGE_CONFLICTS]);
+    pushUnique(forbiddenActions, [
+      PR_GATE_ACTION.RUN_DRAFT_GATE,
+      PR_GATE_ACTION.RECONCILE_DRAFT_GATE,
+      PR_GATE_ACTION.MARK_READY_FOR_REVIEW,
+      PR_GATE_ACTION.REQUEST_COPILOT_REVIEW,
+      PR_GATE_ACTION.WAIT_FOR_COPILOT_REVIEW,
+      PR_GATE_ACTION.WAIT_FOR_CI,
+      PR_GATE_ACTION.ADDRESS_REVIEW_FEEDBACK,
+      PR_GATE_ACTION.REPLY_RESOLVE_REVIEW_THREADS,
+      PR_GATE_ACTION.REREQUEST_COPILOT_REVIEW,
+      PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE,
+      PR_GATE_ACTION.AWAIT_FINAL_HUMAN_APPROVAL,
+      PR_GATE_ACTION.DECLARE_MERGE_READY,
+    ]);
+    return buildResult({
+      repo: input.repo ?? null,
+      pr: Number.isInteger(input.pr) ? input.pr : null,
+      currentHeadSha,
+      lifecycleState,
+      loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
+      gateBoundary: PR_GATE_BOUNDARY.CONFLICT_RESOLUTION,
+      draftGateAlreadySatisfied,
+      draftGate,
+      preApprovalGate,
+      allowedNextActions,
+      forbiddenActions,
+      nextAction: PR_GATE_ACTION.RESOLVE_MERGE_CONFLICTS,
+      reason: formatConflictResolutionReason(mergeStateStatus, conflictFiles),
+      mergeStateStatus,
+      conflictFiles,
     });
   }
 

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -219,6 +219,8 @@ export function evaluatePrGateCoordination(input = {}) {
       forbiddenActions,
       nextAction: PR_GATE_ACTION.REPORT_DONE,
       reason: "The pull request is already closed or merged, so no further gate entry is legal.",
+      mergeStateStatus,
+      conflictFiles,
     });
   }
 
@@ -314,6 +316,8 @@ export function evaluatePrGateCoordination(input = {}) {
       reason: draftGate.currentHeadClean
         ? "The PR is still draft, and current-head clean `draft_gate` evidence exists, so `gh pr ready` is now legal."
         : "The PR is still draft, so `draft_gate` is the only legal gate boundary before `gh pr ready`.",
+      mergeStateStatus,
+      conflictFiles,
     });
   }
 
@@ -351,6 +355,8 @@ export function evaluatePrGateCoordination(input = {}) {
       reason: draftGate.anyVisible
         ? `The PR is already non-draft, but visible \`draft_gate\` evidence already exists (verdict: ${draftGate.verdict ?? "unknown"}). The auto-reconcile helper intentionally fails closed rather than overwriting existing evidence, so reconcile manually or clear/supersede the visible draft-gate evidence before re-evaluating.`
         : "The PR is already non-draft and no `draft_gate` evidence is visible at all, so no draft-gate transition was ever recorded; use `scripts/github/reconcile-draft-gate.mjs` to auto-reconcile (convert to draft → post draft_gate comment → mark ready) and then re-evaluate.",
+      mergeStateStatus,
+      conflictFiles,
     });
   }
 
@@ -388,6 +394,8 @@ export function evaluatePrGateCoordination(input = {}) {
           forbiddenActions,
           nextAction: PR_GATE_ACTION.AWAIT_FINAL_HUMAN_APPROVAL,
           reason: "This is an explicitly local-first PR with clean draft_gate evidence and current-head clean pre_approval_gate, so it is ready for final human approval.",
+          mergeStateStatus,
+          conflictFiles,
         });
       }
 
@@ -407,6 +415,8 @@ export function evaluatePrGateCoordination(input = {}) {
         forbiddenActions,
         nextAction: PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE,
         reason: "This is an explicitly local-first PR, so `pre_approval_gate` is the next legal boundary instead of an external Copilot review cycle.",
+        mergeStateStatus,
+        conflictFiles,
       });
     }
 
@@ -426,6 +436,8 @@ export function evaluatePrGateCoordination(input = {}) {
       forbiddenActions,
       nextAction: PR_GATE_ACTION.REQUEST_COPILOT_REVIEW,
       reason: "The PR is ready for review but the post-draft external review cycle has not started yet; request Copilot review before any `pre_approval_gate` entry.",
+      mergeStateStatus,
+      conflictFiles,
     });
   }
 
@@ -452,6 +464,8 @@ export function evaluatePrGateCoordination(input = {}) {
       reason: lifecycleState === STATE.WAITING_FOR_CI
         ? "The post-draft review cycle is waiting on current-head CI, so `pre_approval_gate` remains illegal until CI settles cleanly."
         : "The post-draft review cycle is still pending on Copilot review, so `pre_approval_gate` remains illegal until the current-head review cycle settles.",
+      mergeStateStatus,
+      conflictFiles,
     });
   }
 
@@ -472,6 +486,8 @@ export function evaluatePrGateCoordination(input = {}) {
       forbiddenActions,
       nextAction: PR_GATE_ACTION.ADDRESS_REVIEW_FEEDBACK,
       reason: "Actionable unresolved feedback exists, so follow-up work must stay in the review/fix cycle and cannot enter `pre_approval_gate` yet.",
+      mergeStateStatus,
+      conflictFiles,
     });
   }
 
@@ -492,6 +508,8 @@ export function evaluatePrGateCoordination(input = {}) {
       forbiddenActions,
       nextAction: PR_GATE_ACTION.REPLY_RESOLVE_REVIEW_THREADS,
       reason: "Fixes were applied, but unresolved threads still need reply/resolve handling before another gate boundary is legal.",
+      mergeStateStatus,
+      conflictFiles,
     });
   }
 
@@ -513,6 +531,8 @@ export function evaluatePrGateCoordination(input = {}) {
         forbiddenActions,
         nextAction: PR_GATE_ACTION.REREQUEST_COPILOT_REVIEW,
         reason: "The review loop is between passes, but the current head does not yet have a clean settled Copilot convergence point, so `pre_approval_gate` is still forbidden.",
+        mergeStateStatus,
+        conflictFiles,
       });
     }
 
@@ -538,6 +558,8 @@ export function evaluatePrGateCoordination(input = {}) {
         forbiddenActions,
         nextAction: PR_GATE_ACTION.AWAIT_FINAL_HUMAN_APPROVAL,
         reason: "The current head has both a clean settled review cycle and clean `pre_approval_gate` evidence, so the PR is at the final approval boundary.",
+        mergeStateStatus,
+        conflictFiles,
       });
     }
 
@@ -562,6 +584,8 @@ export function evaluatePrGateCoordination(input = {}) {
       forbiddenActions,
       nextAction: PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE,
       reason: "The current head has a clean settled post-draft review cycle, so `pre_approval_gate` is now the next legal boundary.",
+      mergeStateStatus,
+      conflictFiles,
     });
   }
 
@@ -587,5 +611,7 @@ export function evaluatePrGateCoordination(input = {}) {
     forbiddenActions,
     nextAction: PR_GATE_ACTION.REPORT_BLOCKED,
     reason: "The PR gate-boundary evaluator could not map this lifecycle state to a legal gate transition; reconcile before continuing.",
+    mergeStateStatus,
+    conflictFiles,
   });
 }

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -236,6 +236,77 @@ test("non-draft PR with visible non-clean draft_gate evidence blocks without sug
   assert.doesNotMatch(result.reason, /reconcile-draft-gate\.mjs/i);
 });
 
+
+test("conflicted PR returns the conflict-resolution boundary and reports conflicted files", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 370,
+    currentHeadSha: "deadbeef1234",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    loopDisposition: LOOP_DISPOSITION.CLEAN_CONVERGED,
+    sameHeadCleanConverged: true,
+    mergeStateStatus: "DIRTY",
+    conflictFiles: ["config.test.mjs", "extension/README.md"],
+    draftGate: gate({ visible: true, headSha: "deadbee", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "deadbee", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: true, headSha: "deadbee", verdict: "clean" }),
+    preApprovalGateMarker: gate({ visible: true, headSha: "deadbee", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.equal(result.gateBoundary, PR_GATE_BOUNDARY.CONFLICT_RESOLUTION);
+  assert.equal(result.nextAction, PR_GATE_ACTION.RESOLVE_MERGE_CONFLICTS);
+  assert.equal(result.mergeStateStatus, "DIRTY");
+  assert.deepEqual(result.conflictFiles, ["config.test.mjs", "extension/README.md"]);
+  assert.deepEqual(result.allowedNextActions, [PR_GATE_ACTION.RESOLVE_MERGE_CONFLICTS]);
+  assert(result.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert(result.forbiddenActions.includes(PR_GATE_ACTION.AWAIT_FINAL_HUMAN_APPROVAL));
+  assert(result.forbiddenActions.includes(PR_GATE_ACTION.DECLARE_MERGE_READY));
+  assert.match(result.reason, /resolve the conflict locally on the PR branch/i);
+  assert.match(result.reason, /config\.test\.mjs/i);
+});
+
+test("conflict state takes precedence over otherwise merge-ready current-head evidence", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 370,
+    currentHeadSha: "deadbeef1234",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    loopDisposition: LOOP_DISPOSITION.CLEAN_CONVERGED,
+    sameHeadCleanConverged: true,
+    mergeStateStatus: "CONFLICTING",
+    draftGate: gate({ visible: true, headSha: "deadbee", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "deadbee", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: true, headSha: "deadbee", verdict: "clean" }),
+    preApprovalGateMarker: gate({ visible: true, headSha: "deadbee", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.equal(result.gateBoundary, PR_GATE_BOUNDARY.CONFLICT_RESOLUTION);
+  assert.equal(result.nextAction, PR_GATE_ACTION.RESOLVE_MERGE_CONFLICTS);
+  assert(result.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert(result.forbiddenActions.includes(PR_GATE_ACTION.AWAIT_FINAL_HUMAN_APPROVAL));
+  assert(result.forbiddenActions.includes(PR_GATE_ACTION.DECLARE_MERGE_READY));
+});
+
+test("local git conflict files trigger the conflict-resolution boundary even without DIRTY mergeStateStatus", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 370,
+    currentHeadSha: "deadbeef1234",
+    prDraft: false,
+    lifecycleState: STATE.PR_READY_NO_FEEDBACK,
+    loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
+    mergeStateStatus: "CLEAN",
+    conflictFiles: [".pi/dev-loop/defaults.yaml"],
+    draftGate: gate({ visible: true, headSha: "deadbee", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "deadbee", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.gateBoundary, PR_GATE_BOUNDARY.CONFLICT_RESOLUTION);
+  assert.equal(result.nextAction, PR_GATE_ACTION.RESOLVE_MERGE_CONFLICTS);
+  assert.deepEqual(result.conflictFiles, [".pi/dev-loop/defaults.yaml"]);
+});
+
 test("local-first PR with explicit reviewMode skips to pre-approval gate after draft→ready", () => {
   const result = evaluatePrGateCoordination({
     pr: 298,

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -310,6 +310,24 @@ test("local git conflict files trigger the conflict-resolution boundary even wit
   assert.deepEqual(result.conflictFiles, [".pi/dev-loop/defaults.yaml"]);
 });
 
+test("normalizeConflictFiles preserves opaque path strings while still rejecting blank entries", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 370,
+    currentHeadSha: "deadbeef1234",
+    prDraft: false,
+    lifecycleState: STATE.PR_READY_NO_FEEDBACK,
+    loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
+    mergeStateStatus: "CLEAN",
+    conflictFiles: ["  spaced-path.txt  ", "   ", "  spaced-path.txt  "],
+    draftGate: gate({ visible: true, headSha: "deadbee", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "deadbee", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.deepEqual(result.conflictFiles, ["  spaced-path.txt  "]);
+});
+
 test("local-first PR with explicit reviewMode skips to pre-approval gate after draft→ready", () => {
   const result = evaluatePrGateCoordination({
     pr: 298,

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -155,6 +155,7 @@ test("current-head clean pre-approval evidence advances to final approval bounda
     lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
     loopDisposition: LOOP_DISPOSITION.CLEAN_CONVERGED,
     sameHeadCleanConverged: true,
+    mergeStateStatus: "CLEAN",
     draftGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
     draftGateMarker: gate({ visible: true, headSha: "fedcba9", verdict: "clean", contractComplete: true }),
     preApprovalGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
@@ -165,6 +166,8 @@ test("current-head clean pre-approval evidence advances to final approval bounda
   assert.equal(result.nextAction, PR_GATE_ACTION.AWAIT_FINAL_HUMAN_APPROVAL);
   assert.equal(result.preApprovalGate.currentHead, true);
   assert.equal(result.preApprovalGate.currentHeadClean, true);
+  assert.equal(result.mergeStateStatus, "CLEAN");
+  assert.deepEqual(result.conflictFiles, []);
 });
 
 test("non-draft PR with clean draft_gate on a different head still allows post-draft flow (one-time boundary)", () => {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -506,9 +506,9 @@ Required:
 - `--pr <number>`
 
 Success output shape:
-- `{ "ok": true, "repo": "owner/repo", "pr": 266, "currentHeadSha": "...", "mergeStateStatus": "DIRTY"|null, "conflictFiles": ["path"]|[], "lifecycleState": "pr_ready_no_feedback", "loopDisposition": "action_required", "gateBoundary": "post_draft_external_review"|"conflict_resolution", "draftGate": { ... }, "preApprovalGate": { ... }, "draftGateAlreadySatisfied": true, "allowedNextActions": [ ... ], "forbiddenActions": [ ... ], "nextAction": "request_copilot_review"|"resolve_merge_conflicts", "reason": "..." }`
+- `{ "ok": true, "repo": "owner/repo", "pr": 266, "currentHeadSha": "...", "mergeStateStatus": "CLEAN"|"DIRTY"|"BLOCKED"|"BEHIND"|null, "conflictFiles": ["path"]|[], "lifecycleState": "pr_ready_no_feedback", "loopDisposition": "action_required", "gateBoundary": "post_draft_external_review"|"conflict_resolution", "draftGate": { ... }, "preApprovalGate": { ... }, "draftGateAlreadySatisfied": true, "allowedNextActions": [ ... ], "forbiddenActions": [ ... ], "nextAction": "request_copilot_review"|"resolve_merge_conflicts", "reason": "..." }`
 - `draftGate` / `preApprovalGate` report both latest visible evidence (`visible`, `headSha`, `verdict`, `findingsSummary`, `nextAction`) and whether the evidence is current-head + contract-complete (`currentHead`, `contractComplete`, `currentHeadClean`)
-- `mergeStateStatus` preserves the current GitHub merge-conflict signal from `gh pr view`; `DIRTY` and explicit `CONFLICTING` inputs are treated as conflict-required states
+- `mergeStateStatus` preserves the current GitHub `gh pr view` signal in helper output even when the PR is not in the conflict boundary; `DIRTY` and explicit `CONFLICTING` inputs are treated as conflict-required states
 - `conflictFiles` lists unmerged local paths from `git status --porcelain=v1 --untracked-files=no` when local conflict reconciliation is already in progress
 - when `mergeStateStatus` is conflicted or `conflictFiles` is non-empty, the evaluator emits `gateBoundary=conflict_resolution`, `nextAction=resolve_merge_conflicts`, and forbids gate/approval/merge progression until reconciliation completes
 - `draftGateAlreadySatisfied` — true when the draft→ready transition was already recorded (non-draft + clean evidence exists); callers must skip draft gate when this is true

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -506,10 +506,10 @@ Required:
 - `--pr <number>`
 
 Success output shape:
-- `{ "ok": true, "repo": "owner/repo", "pr": 266, "currentHeadSha": "...", "mergeStateStatus": "CLEAN"|"DIRTY"|"BLOCKED"|"BEHIND"|null, "conflictFiles": ["path"]|[], "lifecycleState": "pr_ready_no_feedback", "loopDisposition": "action_required", "gateBoundary": "post_draft_external_review"|"conflict_resolution", "draftGate": { ... }, "preApprovalGate": { ... }, "draftGateAlreadySatisfied": true, "allowedNextActions": [ ... ], "forbiddenActions": [ ... ], "nextAction": "request_copilot_review"|"resolve_merge_conflicts", "reason": "..." }`
+- `{ "ok": true, "repo": "owner/repo", "pr": 266, "currentHeadSha": "...", "mergeStateStatus": string|null, "conflictFiles": ["path"]|[], "lifecycleState": "pr_ready_no_feedback", "loopDisposition": "action_required", "gateBoundary": "post_draft_external_review"|"conflict_resolution", "draftGate": { ... }, "preApprovalGate": { ... }, "draftGateAlreadySatisfied": true, "allowedNextActions": [ ... ], "forbiddenActions": [ ... ], "nextAction": "request_copilot_review"|"resolve_merge_conflicts", "reason": "..." }`
 - `draftGate` / `preApprovalGate` report both latest visible evidence (`visible`, `headSha`, `verdict`, `findingsSummary`, `nextAction`) and whether the evidence is current-head + contract-complete (`currentHead`, `contractComplete`, `currentHeadClean`)
 - `mergeStateStatus` preserves the current GitHub `gh pr view` signal in helper output even when the PR is not in the conflict boundary; `DIRTY` and explicit `CONFLICTING` inputs are treated as conflict-required states
-- `conflictFiles` lists unmerged local paths from `git status --porcelain=v1 --untracked-files=no` when local conflict reconciliation is already in progress
+- `conflictFiles` lists unmerged local paths from `git -c core.quotepath=false status --porcelain=v1 -z --untracked-files=no` when local conflict reconciliation is already in progress
 - when `mergeStateStatus` is conflicted or `conflictFiles` is non-empty, the evaluator emits `gateBoundary=conflict_resolution`, `nextAction=resolve_merge_conflicts`, and forbids gate/approval/merge progression until reconciliation completes
 - `draftGateAlreadySatisfied` — true when the draft→ready transition was already recorded (non-draft + clean evidence exists); callers must skip draft gate when this is true
 - `forbiddenActions` includes `run_pre_approval_gate` whenever the post-draft review cycle has not yet settled for the current head, and conflicted PRs keep it forbidden until reconciliation is complete

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -499,14 +499,14 @@ Failure behavior:
 
 ### `scripts/loop/detect-pr-gate-coordination-state.mjs`
 
-Fetches the live PR facts needed to answer which gate/transition is legal next for a pull request. It combines the shared Copilot loop-state machine with visible `draft_gate` / `pre_approval_gate` evidence, GitHub `mergeStateStatus`, and local `git status --porcelain=v1 --untracked-files=no` conflict detection, then emits one explicit gate boundary, allowed/forbidden next actions, and a single recommended next step. Use this before entering `pre_approval_gate` and when deciding whether a ready PR should request Copilot review, keep waiting, stay in feedback resolution, or stop for conflict resolution.
+Fetches the live PR facts needed to answer which gate/transition is legal next for a pull request. It combines the shared Copilot loop-state machine with visible `draft_gate` / `pre_approval_gate` evidence, GitHub `mergeStateStatus`, and local `git -c core.quotepath=false status --porcelain=v1 -z --untracked-files=no` conflict detection, then emits one explicit gate boundary, allowed/forbidden next actions, and a single recommended next step. Use this before entering `pre_approval_gate` and when deciding whether a ready PR should request Copilot review, keep waiting, stay in feedback resolution, or stop for conflict resolution.
 
 Required:
 - `--repo <owner/name>`
 - `--pr <number>`
 
 Success output shape:
-- `{ "ok": true, "repo": "owner/repo", "pr": 266, "currentHeadSha": "...", "mergeStateStatus": string|null, "conflictFiles": ["path"]|[], "lifecycleState": "pr_ready_no_feedback", "loopDisposition": "action_required", "gateBoundary": "post_draft_external_review"|"conflict_resolution", "draftGate": { ... }, "preApprovalGate": { ... }, "draftGateAlreadySatisfied": true, "allowedNextActions": [ ... ], "forbiddenActions": [ ... ], "nextAction": "request_copilot_review"|"resolve_merge_conflicts", "reason": "..." }`
+- `{ "ok": true, "repo": "owner/repo", "pr": 266, "currentHeadSha": "...", "mergeStateStatus": string|null, "conflictFiles": ["path"]|[], "lifecycleState": string, "loopDisposition": string, "gateBoundary": string, "draftGate": { ... }, "preApprovalGate": { ... }, "draftGateAlreadySatisfied": true, "allowedNextActions": [ ... ], "forbiddenActions": [ ... ], "nextAction": string, "reason": "..." }`
 - `draftGate` / `preApprovalGate` report both latest visible evidence (`visible`, `headSha`, `verdict`, `findingsSummary`, `nextAction`) and whether the evidence is current-head + contract-complete (`currentHead`, `contractComplete`, `currentHeadClean`)
 - `mergeStateStatus` preserves the current GitHub `gh pr view` signal in helper output even when the PR is not in the conflict boundary; `DIRTY` and explicit `CONFLICTING` inputs are treated as conflict-required states
 - `conflictFiles` lists unmerged local paths from `git -c core.quotepath=false status --porcelain=v1 -z --untracked-files=no` when local conflict reconciliation is already in progress

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -499,18 +499,22 @@ Failure behavior:
 
 ### `scripts/loop/detect-pr-gate-coordination-state.mjs`
 
-Fetches the live PR facts needed to answer which gate/transition is legal next for a pull request. It combines the shared Copilot loop-state machine with visible `draft_gate` / `pre_approval_gate` evidence, then emits one explicit gate boundary, allowed/forbidden next actions, and a single recommended next step. Use this before entering `pre_approval_gate` and when deciding whether a ready PR should request Copilot review, keep waiting, or stay in feedback resolution.
+Fetches the live PR facts needed to answer which gate/transition is legal next for a pull request. It combines the shared Copilot loop-state machine with visible `draft_gate` / `pre_approval_gate` evidence, GitHub `mergeStateStatus`, and local `git status --porcelain=v1 --untracked-files=no` conflict detection, then emits one explicit gate boundary, allowed/forbidden next actions, and a single recommended next step. Use this before entering `pre_approval_gate` and when deciding whether a ready PR should request Copilot review, keep waiting, stay in feedback resolution, or stop for conflict resolution.
 
 Required:
 - `--repo <owner/name>`
 - `--pr <number>`
 
 Success output shape:
-- `{ "ok": true, "repo": "owner/repo", "pr": 266, "currentHeadSha": "...", "lifecycleState": "pr_ready_no_feedback", "loopDisposition": "action_required", "gateBoundary": "post_draft_external_review", "draftGate": { ... }, "preApprovalGate": { ... }, "draftGateAlreadySatisfied": true, "allowedNextActions": [ ... ], "forbiddenActions": [ ... ], "nextAction": "request_copilot_review", "reason": "..." }`
+- `{ "ok": true, "repo": "owner/repo", "pr": 266, "currentHeadSha": "...", "mergeStateStatus": "DIRTY"|null, "conflictFiles": ["path"]|[], "lifecycleState": "pr_ready_no_feedback", "loopDisposition": "action_required", "gateBoundary": "post_draft_external_review"|"conflict_resolution", "draftGate": { ... }, "preApprovalGate": { ... }, "draftGateAlreadySatisfied": true, "allowedNextActions": [ ... ], "forbiddenActions": [ ... ], "nextAction": "request_copilot_review"|"resolve_merge_conflicts", "reason": "..." }`
 - `draftGate` / `preApprovalGate` report both latest visible evidence (`visible`, `headSha`, `verdict`, `findingsSummary`, `nextAction`) and whether the evidence is current-head + contract-complete (`currentHead`, `contractComplete`, `currentHeadClean`)
+- `mergeStateStatus` preserves the current GitHub merge-conflict signal from `gh pr view`; `DIRTY` and explicit `CONFLICTING` inputs are treated as conflict-required states
+- `conflictFiles` lists unmerged local paths from `git status --porcelain=v1 --untracked-files=no` when local conflict reconciliation is already in progress
+- when `mergeStateStatus` is conflicted or `conflictFiles` is non-empty, the evaluator emits `gateBoundary=conflict_resolution`, `nextAction=resolve_merge_conflicts`, and forbids gate/approval/merge progression until reconciliation completes
 - `draftGateAlreadySatisfied` — true when the draft→ready transition was already recorded (non-draft + clean evidence exists); callers must skip draft gate when this is true
-- `forbiddenActions` includes `run_pre_approval_gate` whenever the post-draft review cycle has not yet settled for the current head
+- `forbiddenActions` includes `run_pre_approval_gate` whenever the post-draft review cycle has not yet settled for the current head, and conflicted PRs keep it forbidden until reconciliation is complete
 - if a PR is already non-draft but lacks current-head clean `draft_gate` evidence, the evaluator fails closed (`gateBoundary=blocked`, `nextAction=report_blocked`) until draft-gate evidence is reconciled
+- if the PR head changes while gate/conflict facts are loading, the helper still fails closed rather than evaluating mixed-head evidence
 
 Failure behavior:
 - malformed arguments emit `{ "ok": false, "error": "...", "usage": "..." }` on stderr and exit non-zero

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -14,6 +14,8 @@ import { evaluatePrGateCoordination } from "@pi-dev-loops/core/loop/pr-gate-coor
 import { fetchGithubReviewThreadsPayload } from "../github/capture-review-threads.mjs";
 import { detectGateReviewEvidence } from "../github/detect-gate-review-evidence.mjs";
 
+const UNMERGED_GIT_STATUS_CODES = new Set(["DD", "AU", "UD", "UA", "DU", "AA", "UU"]);
+
 const USAGE = `Usage: detect-pr-gate-coordination-state.mjs --repo <owner/name> --pr <number> [--review-mode local_first]
 
 Determine which PR gate/transition is legal next for a pull request.
@@ -28,9 +30,11 @@ Output (stdout, JSON):
     "repo": "owner/repo",
     "pr": 266,
     "currentHeadSha": "...",
+    "mergeStateStatus": "DIRTY",
+    "conflictFiles": ["config.test.mjs", "extension/README.md"],
     "lifecycleState": "pr_ready_no_feedback",
     "loopDisposition": "action_required",
-    "gateBoundary": "post_draft_external_review",
+    "gateBoundary": "conflict_resolution",
     "draftGate": {
       "visible": true,
       "markerVisible": false,
@@ -51,9 +55,9 @@ Output (stdout, JSON):
       "headSha": null,
       "verdict": null
     },
-    "allowedNextActions": ["request_copilot_review"],
+    "allowedNextActions": ["resolve_merge_conflicts"],
     "forbiddenActions": ["run_pre_approval_gate", "declare_merge_ready"],
-    "nextAction": "request_copilot_review",
+    "nextAction": "resolve_merge_conflicts",
     "reason": "..."
   }
 
@@ -129,6 +133,39 @@ function parseRequestedReviewersPayload(text) {
   };
 }
 
+export function parseGitStatusConflictFiles(text) {
+  if (typeof text !== "string" || text.trim().length === 0) {
+    return [];
+  }
+
+  const conflictFiles = [];
+  for (const rawLine of text.split(/\r?\n/)) {
+    if (rawLine.length < 4) {
+      continue;
+    }
+
+    const status = rawLine.slice(0, 2);
+    if (!UNMERGED_GIT_STATUS_CODES.has(status)) {
+      continue;
+    }
+
+    const rawPath = rawLine.slice(3).trim();
+    if (rawPath.length === 0) {
+      continue;
+    }
+
+    const normalizedPath = rawPath.includes(" -> ")
+      ? rawPath.split(" -> ").at(-1)?.trim() ?? rawPath
+      : rawPath;
+
+    if (normalizedPath.length > 0 && !conflictFiles.includes(normalizedPath)) {
+      conflictFiles.push(normalizedPath);
+    }
+  }
+
+  return conflictFiles;
+}
+
 async function fetchRequestedReviewers({ repo, pr }, { env = process.env, ghCommand = "gh" } = {}) {
   const result = await runChild(
     ghCommand,
@@ -147,7 +184,7 @@ async function fetchRequestedReviewers({ repo, pr }, { env = process.env, ghComm
 async function fetchPrFacts({ repo, pr }, { env = process.env, ghCommand = "gh" } = {}) {
   const result = await runChild(
     ghCommand,
-    ["pr", "view", String(pr), "--repo", repo, "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+    ["pr", "view", String(pr), "--repo", repo, "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
     env,
   );
 
@@ -159,12 +196,27 @@ async function fetchPrFacts({ repo, pr }, { env = process.env, ghCommand = "gh" 
   return parseJsonText(result.stdout, { label: "gh pr view" });
 }
 
+async function fetchLocalConflictFiles({ env = process.env, gitCommand = "git" } = {}) {
+  const result = await runChild(
+    gitCommand,
+    ["status", "--porcelain=v1", "--untracked-files=no"],
+    env,
+  );
+
+  if (result.code !== 0) {
+    return [];
+  }
+
+  return parseGitStatusConflictFiles(result.stdout);
+}
+
 export async function loadPrGateCoordinationContext(options, runtime = {}) {
   const prData = await fetchPrFacts(options, runtime);
   const requestedReviewers = await fetchRequestedReviewers(options, runtime);
   const threadsPayload = await fetchGithubReviewThreadsPayload(options, runtime);
   const parsedThreads = parseReviewThreads(threadsPayload);
   const gateEvidence = await detectGateReviewEvidence(options, runtime);
+  const conflictFiles = await fetchLocalConflictFiles(runtime);
 
   const currentHeadSha = typeof prData?.headRefOid === "string" && prData.headRefOid.trim().length > 0
     ? prData.headRefOid.trim()
@@ -195,11 +247,16 @@ export async function loadPrGateCoordinationContext(options, runtime = {}) {
 
   const interpretation = interpretLoopState(snapshot);
   const disposition = summarizeLoopInterpretation(interpretation);
+  const mergeStateStatus = typeof prData?.mergeStateStatus === "string" && prData.mergeStateStatus.trim().length > 0
+    ? prData.mergeStateStatus.trim().toUpperCase()
+    : null;
 
   return {
     repo: options.repo,
     pr: options.pr,
     currentHeadSha,
+    mergeStateStatus,
+    conflictFiles,
     prData,
     gateEvidence,
     interpretation,
@@ -216,6 +273,8 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
     prDraft: Boolean(context.prData?.isDraft),
     prClosed: String(context.prData?.state || "").toUpperCase() === "CLOSED",
     prMerged: String(context.prData?.state || "").toUpperCase() === "MERGED",
+    mergeStateStatus: context.mergeStateStatus,
+    conflictFiles: context.conflictFiles,
     lifecycleState: context.interpretation.state,
     loopDisposition: context.disposition.loopDisposition,
     sameHeadCleanConverged: context.interpretation.sameHeadCleanConverged,

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -153,9 +153,9 @@ export function parseGitStatusConflictFiles(text) {
       continue;
     }
 
-    const normalizedPath = rawRecord.slice(3).trim();
-    if (normalizedPath.length > 0 && !conflictFiles.includes(normalizedPath)) {
-      conflictFiles.push(normalizedPath);
+    const rawPath = rawRecord.slice(3);
+    if (rawPath.trim().length > 0 && !conflictFiles.includes(rawPath)) {
+      conflictFiles.push(rawPath);
     }
   }
 
@@ -193,11 +193,16 @@ async function fetchPrFacts({ repo, pr }, { env = process.env, ghCommand = "gh" 
 }
 
 async function fetchLocalConflictFiles({ env = process.env, gitCommand = "git" } = {}) {
-  const result = await runChild(
-    gitCommand,
-    ["-c", "core.quotepath=false", "status", "--porcelain=v1", "-z", "--untracked-files=no"],
-    env,
-  );
+  let result;
+  try {
+    result = await runChild(
+      gitCommand,
+      ["-c", "core.quotepath=false", "status", "--porcelain=v1", "-z", "--untracked-files=no"],
+      env,
+    );
+  } catch {
+    return [];
+  }
 
   if (result.code !== 0) {
     return [];

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -134,30 +134,26 @@ function parseRequestedReviewersPayload(text) {
 }
 
 export function parseGitStatusConflictFiles(text) {
-  if (typeof text !== "string" || text.trim().length === 0) {
+  if (typeof text !== "string" || text.length === 0) {
     return [];
   }
 
+  const records = text.includes("\0")
+    ? text.split("\0")
+    : text.split(/\r?\n/);
+
   const conflictFiles = [];
-  for (const rawLine of text.split(/\r?\n/)) {
-    if (rawLine.length < 4) {
+  for (const rawRecord of records) {
+    if (rawRecord.length < 4) {
       continue;
     }
 
-    const status = rawLine.slice(0, 2);
+    const status = rawRecord.slice(0, 2);
     if (!UNMERGED_GIT_STATUS_CODES.has(status)) {
       continue;
     }
 
-    const rawPath = rawLine.slice(3).trim();
-    if (rawPath.length === 0) {
-      continue;
-    }
-
-    const normalizedPath = rawPath.includes(" -> ")
-      ? rawPath.split(" -> ").at(-1)?.trim() ?? rawPath
-      : rawPath;
-
+    const normalizedPath = rawRecord.slice(3).trim();
     if (normalizedPath.length > 0 && !conflictFiles.includes(normalizedPath)) {
       conflictFiles.push(normalizedPath);
     }
@@ -199,7 +195,7 @@ async function fetchPrFacts({ repo, pr }, { env = process.env, ghCommand = "gh" 
 async function fetchLocalConflictFiles({ env = process.env, gitCommand = "git" } = {}) {
   const result = await runChild(
     gitCommand,
-    ["status", "--porcelain=v1", "--untracked-files=no"],
+    ["-c", "core.quotepath=false", "status", "--porcelain=v1", "-z", "--untracked-files=no"],
     env,
   );
 

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -810,6 +810,22 @@ This is the default pre-approval gate for this workflow boundary. The canonical 
 - A gate-review comment for an older head SHA does not satisfy this requirement for the current head.
 - If fixes advance the head SHA, post a new gate-review comment for the new head.
 
+### Conflict-resolution gate
+
+Before any merge-ready or final-approval claim, run `detect-pr-gate-coordination-state.mjs` for the current PR. If it reports `gateBoundary=conflict_resolution` or `mergeStateStatus` is conflicted, stop the normal gate path immediately and use this recovery flow:
+
+1. fetch fresh `origin/main`, confirm the current PR head SHA, and summarize the conflict scope from `mergeStateStatus` plus any reported `conflictFiles`
+2. ask for explicit authorization before any rebase or other branch-state-changing reconciliation command
+3. after authorization, reconcile locally on the PR branch; default to rebase onto latest `origin/main`, unless the operator explicitly chooses another conflict-resolution command
+4. auto-resolve simple conflicts when the correct fix is mechanical and clearly in scope; report complex ones explicitly and fix them manually only for in-scope files
+5. rerun the smallest honest local validation for the touched conflict slice
+6. rerun `detect-pr-gate-coordination-state.mjs` for the new head
+7. because the head changed, rerun `pre_approval_gate` for the new head before any approval-ready or merge-ready claim
+8. wait for current-head CI again before retrying merge evaluation
+9. if the chosen reconciliation rewrote branch history (for example rebase), ask for explicit authorization before `git push --force-with-lease`, then continue the loop on the updated head
+
+`mergeStateStatus: CLEAN` alone is not enough to resume approval or merge claims. The existing merge-ready preconditions still apply: `unresolvedThreadCount === 0`, a clean current-head `pre_approval_gate`, and green current-head CI.
+
 ### Merge-ready preconditions
 
 Do not declare merge-ready unless all of these checks pass in order:
@@ -924,6 +940,7 @@ Do not:
 - submit a merge-ready verdict without first summarizing the pending thread state
 - declare merge-ready without a visible `pre_approval_gate` comment on the current head SHA
 - declare merge-ready based solely on `mergeable_state: clean` + CI green without gate evidence
+- do not blind-run `gh pr merge`, `gh pr update-branch`, or an unapproved rebase when the helper says the PR is conflicted
 - suggest approval, approve and merge, or any approval-ready statement without explicit current-head `pre_approval_gate` gate-review evidence
 - treat CI green + resolved review threads + clean Copilot rereview as sufficient for approval or merge without an explicit current-head `pre_approval_gate` gate-review comment
 - dispatch an async dev-loop task that omits the pre-approval gate requirement

--- a/skills/docs/pr-lifecycle-contract.md
+++ b/skills/docs/pr-lifecycle-contract.md
@@ -82,6 +82,7 @@ The family-local lifecycle should be modeled in this vocabulary. These state ide
 | `waiting_for_copilot_review` | Copilot request/re-review is observably in progress for the current head |
 | `copilot_feedback_remediation` | actionable Copilot feedback exists; fixes are the next active step |
 | `copilot_reply_resolve_pending` | fixes were applied, but GitHub thread reply/resolve work still remains |
+| `merge_conflict_resolution` | current PR head conflicts with base or local reconcile is in progress; resolve conflicts before any further gate progression |
 | `final_local_preapproval_gate` | current-head post-Copilot convergence is ready for the final local gate |
 | `final_gate_remediation` | Pre-approval gate findings require more remediation after the final gate |
 | `waiting_for_human_pr_approval` | local gates are satisfied; waiting for explicit human approval |
@@ -111,6 +112,10 @@ At minimum, the lifecycle must enforce these transitions:
   - fixes applied but reply/resolve still remains
 - `copilot_reply_resolve_pending` -> `ready_state_needs_copilot_request`
   - reply/resolve complete and another Copilot pass is required
+- any open non-terminal lifecycle slice -> `merge_conflict_resolution`
+  - current-head merge state is conflicted (`DIRTY` / `CONFLICTING`) or local conflict reconciliation is already in progress
+- `merge_conflict_resolution` -> normal lifecycle re-entry state
+  - only after local conflict resolution produces a new head, validation is rerun for the touched conflict slice, and gate state is re-detected for that new head
 - `waiting_for_copilot_review` -> `final_local_preapproval_gate`
   - the current-head request/re-review cycle has settled cleanly with no actionable feedback and no further Copilot pass is needed
 - `final_local_preapproval_gate` -> `final_gate_remediation`
@@ -129,6 +134,7 @@ At minimum, the lifecycle must enforce these transitions:
 - no Copilot request before clean current-head `draft_gate` evidence
 - no direct skip from fix-applied to Copilot re-request while reply/resolve remains incomplete
 - no reuse of ready-side or gate evidence after ready -> draft
+- a conflicted PR must not be treated as `waiting_for_human_pr_approval`, `waiting_for_merge`, or merge-ready, even if older gate comments and CI were previously green
 - no implicit fallthrough from approval/merge waits into remediation without a triggering event
 
 ## Remediation ownership boundary
@@ -138,6 +144,7 @@ The lifecycle must keep the next action class explicit:
 - actionable Copilot feedback routes to `copilot_feedback_remediation`
 - fixes applied but unresolved GitHub reply/resolve work remains route to `copilot_reply_resolve_pending`
 - pre-approval gate findings route to `final_gate_remediation`
+- merge conflicts route to `merge_conflict_resolution` and must be reconciled locally on the PR branch before lifecycle re-entry
 - human approval / merge remain explicit external waits
 
 Reviewer-loop reminder:
@@ -175,6 +182,7 @@ The lifecycle must stop or reconcile rather than advance when:
 - review-thread capture failed or is incomplete, so unresolved feedback cannot safely be treated as zero
 - Copilot request status is failed, unavailable without in-progress evidence, or otherwise ambiguous for the current head
 - a required current-head wait cannot be confirmed settled
+- the current head reports conflicted merge state (`DIRTY` / `CONFLICTING`) or local git conflict markers are present; enter `merge_conflict_resolution` instead of progressing
 - a boundary that is already CI/validation-dependent cannot confirm current-head freshness because the relevant status is pending, none, unknown, or stale
 - a required visible gate comment could not be confirmed posted
 

--- a/skills/docs/workflow-handoff-template.md
+++ b/skills/docs/workflow-handoff-template.md
@@ -61,6 +61,7 @@ For each Copilot review pass:
 ### 7. Pre-approval gate review
 
 - Confirm legality: `node scripts/loop/detect-pr-gate-coordination-state.mjs --repo <owner/name> --pr <number>`
+- If legality returns `gateBoundary=conflict_resolution`, stop the gate, resolve conflicts on the PR branch, rerun validation, re-detect gate state for the new head, and only then rerun `pre_approval_gate`
 - Run parallel subagent reviews with angles resolved from config (`resolveGateAngles(config, "preApproval")`)
 - Post visible `pre_approval_gate` comment on the PR
 - If findings → fix, push new head, re-run pre-approval gate

--- a/test/copilot-review-doc-contracts.test.mjs
+++ b/test/copilot-review-doc-contracts.test.mjs
@@ -204,12 +204,63 @@ test("copilot-pr-followup skill hardens reply-resolve, gate sequencing, and merg
     /If any check fails, do not declare merge-ready\./i,
     "merge-ready preconditions should be a hard gate",
   );
+  assert.match(
+    step7,
+    /### Conflict-resolution gate/i,
+    "Step 7 should include a conflict-resolution subsection",
+  );
+  assert.match(
+    step7,
+    /`gateBoundary=conflict_resolution`|`mergeStateStatus` is conflicted/i,
+    "conflict-resolution subsection should key off the deterministic helper boundary",
+  );
+  assert.match(
+    step7,
+    /fetch fresh `origin\/main`/i,
+    "conflict-resolution flow should refresh origin/main first",
+  );
+  assert.match(
+    step7,
+    /ask for explicit authorization before any rebase/i,
+    "conflict-resolution flow should require explicit rebase authorization",
+  );
+  assert.match(
+    step7,
+    /rebase onto latest `origin\/main`/i,
+    "conflict-resolution flow should document the default rebase path",
+  );
+  assert.match(
+    step7,
+    /auto-resolve simple conflicts/i,
+    "conflict-resolution flow should allow simple auto-resolution",
+  );
+  assert.match(
+    step7,
+    /report complex ones|report complex conflicts/i,
+    "conflict-resolution flow should surface complex conflicts for manual handling",
+  );
+  assert.match(
+    step7,
+    /rerun `detect-pr-gate-coordination-state\.mjs`/i,
+    "conflict-resolution flow should require gate re-detection",
+  );
+  assert.match(
+    step7,
+    /rerun `pre_approval_gate` for the new head/i,
+    "conflict-resolution flow should require a fresh pre-approval gate on the new head",
+  );
+  assert.match(
+    step7,
+    /wait for current-head CI again/i,
+    "conflict-resolution flow should require fresh CI on the new head",
+  );
   const antiPatternsMatch = skillContent.match(/## Anti-patterns[\s\S]*?(?=\n## Recommended companion skills|$)/);
   const antiPatterns = antiPatternsMatch ? antiPatternsMatch[0] : "";
   assert.ok(antiPatterns.length > 0, "copilot-pr-followup anti-patterns section not found");
   assert.match(antiPatterns, /use ad hoc inline `gh api` or `gh api graphql` thread-mutation commands instead of the deterministic `reply-resolve-review-thread\.mjs` \/ `reply-resolve-review-threads\.mjs` helpers/i);
   assert.match(antiPatterns, /declare merge-ready without a visible `pre_approval_gate` comment on the current head SHA/i);
   assert.match(antiPatterns, /declare merge-ready based solely on `mergeable_state: clean` \+ CI green without gate evidence/i);
+  assert.match(antiPatterns, /do not blind-run `gh pr merge`, `gh pr update-branch`, or an unapproved rebase when the helper says the PR is conflicted/i);
   assert.match(antiPatterns, /dispatch an async dev-loop task that omits the pre-approval gate requirement/i);
 });
 

--- a/test/github/reconcile-draft-gate.test.mjs
+++ b/test/github/reconcile-draft-gate.test.mjs
@@ -330,7 +330,7 @@ test("reconcile-draft-gate skips the draft conversion mutation when the PR is al
         stdout: '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOScHU78000017","isDraft":true}}}}\n',
       },
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc123456789","reviews":[],"statusCheckRollup":[]}\n',
       },
       {
@@ -405,7 +405,7 @@ test("reconcile-draft-gate does not mark ready when upsert throws and the PR was
         stdout: '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOScHU78000017","isDraft":true}}}}\n',
       },
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc123456789","reviews":[],"statusCheckRollup":[]}\n',
       },
       {
@@ -471,7 +471,7 @@ test("reconcile-draft-gate marks the PR ready again if gate-comment upsert throw
         stdout: '{"data":{"convertPullRequestToDraft":{"pullRequest":{"id":"PR_kwDOScHU78000017","isDraft":true}}}}\n',
       },
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc123456789","reviews":[],"statusCheckRollup":[]}\n',
       },
       {
@@ -541,7 +541,7 @@ test("reconcile-draft-gate converts to draft, posts clean evidence, and marks re
         stdout: '{"data":{"convertPullRequestToDraft":{"pullRequest":{"id":"PR_kwDOScHU78000017","isDraft":true}}}}\n',
       },
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc123456789","reviews":[],"statusCheckRollup":[]}\n',
       },
       {

--- a/test/github/upsert-gate-review-comment.test.mjs
+++ b/test/github/upsert-gate-review-comment.test.mjs
@@ -219,7 +219,7 @@ test("upsert-gate-review-comment creates a new comment when no same-head marker 
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[]}\n',
       },
       {
@@ -279,7 +279,7 @@ test("upsert-gate-review-comment fails closed when pre-approval gate entry is st
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
         stdout: '{"number":266,"state":"OPEN","isDraft":false,"headRefOid":"def56789abcdef","reviews":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]}\n',
       },
       {
@@ -341,7 +341,7 @@ test("upsert-gate-review-comment truncates verbose findings summary before comme
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":false,"headRefOid":"abc1234","reviews":[{"author":{"login":"copilot-pull-request-reviewer"},"state":"COMMENTED","submittedAt":"2026-05-31T20:00:00Z","commit":{"oid":"abc1234"}}],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]}\n',
       },
       {
@@ -426,7 +426,7 @@ test("upsert-gate-review-comment suppresses duplicate repost when the current sa
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[]}\n',
       },
       {
@@ -499,7 +499,7 @@ test("upsert-gate-review-comment noop still warns when a stale comment exists on
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[]}\n',
       },
       {
@@ -580,7 +580,7 @@ test("upsert-gate-review-comment updates an incomplete same-head marker in place
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[]}\n',
       },
       {
@@ -653,7 +653,7 @@ test("upsert-gate-review-comment updates the current same-head marker even when 
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[]}\n',
       },
       {
@@ -742,7 +742,7 @@ test("upsert-gate-review-comment prefers the latest same-head marker when it dif
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[]}\n',
       },
       {
@@ -830,7 +830,7 @@ test("upsert-gate-review-comment expands an abbreviated current-head SHA before 
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abcdef1234567890abcdef1234567890abcdef12","reviews":[],"statusCheckRollup":[]}\n',
       },
       {
@@ -902,7 +902,7 @@ test("upsert-gate-review-comment fails closed when the requested head SHA is sta
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"def5678","reviews":[],"statusCheckRollup":[]}\n',
       },
       {
@@ -946,7 +946,7 @@ test("upsert-gate-review-comment warns when a gate comment exists on a different
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"def5678","reviews":[],"statusCheckRollup":[]}\n',
       },
       {
@@ -1016,7 +1016,7 @@ test("upsert-gate-review-comment fails closed when draft_gate is forbidden on a 
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
         stdout: '{"number":266,"state":"OPEN","isDraft":false,"headRefOid":"def56789abcdef","reviews":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]}\n',
       },
       {

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -79,6 +79,38 @@ async function writeGhStub(tempDir, entries) {
   };
 }
 
+async function writeGitStub(tempDir, { stdout = "", stderr = "", exitCode = 0, assertArgs = [] } = {}) {
+  const gitPath = path.join(tempDir, "git");
+
+  await writeFile(
+    gitPath,
+    [
+      "#!/usr/bin/env node",
+      'const actual = process.argv.slice(2);',
+      'const assertArgs = JSON.parse(process.env.GIT_ASSERT_ARGS || "[]");',
+      'for (const expected of assertArgs) {',
+      '  if (!actual.includes(expected)) {',
+      '    process.stderr.write(`missing expected git arg: ${expected}\\nactual: ${actual.join(" ")}\\n`);',
+      '    process.exit(98);',
+      '  }',
+      '}',
+      'if (process.env.GIT_STDERR) process.stderr.write(process.env.GIT_STDERR);',
+      'if (process.env.GIT_STDOUT) process.stdout.write(process.env.GIT_STDOUT);',
+      'process.exit(Number(process.env.GIT_EXIT_CODE || "0"));',
+      '',
+    ].join("\n"),
+    "utf8",
+  );
+  await chmod(gitPath, 0o755);
+
+  return {
+    GIT_ASSERT_ARGS: JSON.stringify(assertArgs),
+    GIT_STDOUT: stdout,
+    GIT_STDERR: stderr,
+    GIT_EXIT_CODE: String(exitCode),
+  };
+}
+
 function jsonLine(value) {
   return `${JSON.stringify(value)}\n`;
 }
@@ -89,7 +121,7 @@ test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 266,
           state: "OPEN",
@@ -149,6 +181,8 @@ test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs
       repo: "owner/repo",
       pr: 266,
       currentHeadSha: "def56789abcdef",
+      mergeStateStatus: null,
+      conflictFiles: [],
       lifecycleState: "pr_ready_no_feedback",
       loopDisposition: "action_required",
       gateBoundary: "post_draft_external_review",
@@ -194,6 +228,68 @@ test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs
   }
 });
 
+test("detect-pr-gate-coordination-state surfaces conflict_resolution for conflicted PRs and reports conflict files", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-conflict-"));
+
+  try {
+    const ghEnv = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "370", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        stdout: jsonLine({
+          number: 370,
+          state: "OPEN",
+          isDraft: false,
+          headRefOid: "deadbeef1234",
+          mergeStateStatus: "DIRTY",
+          statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+          reviews: [],
+        }),
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/370/requested_reviewers"],
+        stdout: jsonLine({ users: [], teams: [] }),
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=370"],
+        stdout: jsonLine({ data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } }),
+      },
+      {
+        assertArgs: ["pr", "view", "370", "--repo", "owner/repo", "--json", "headRefOid"],
+        stdout: jsonLine({ headRefOid: "deadbeef1234" }),
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/370/comments?per_page=100"],
+        stdout: "[]\n",
+      },
+    ]);
+    const gitEnv = await writeGitStub(tempDir, {
+      assertArgs: ["status", "--porcelain=v1", "--untracked-files=no"],
+      stdout: [
+        "UU config.test.mjs",
+        "AA extension/README.md",
+      ].join("\n") + "\n",
+    });
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "370"], {
+      env: { ...ghEnv, ...gitEnv },
+    });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.gateBoundary, "conflict_resolution");
+    assert.equal(parsed.nextAction, "resolve_merge_conflicts");
+    assert.equal(parsed.mergeStateStatus, "DIRTY");
+    assert.deepEqual(parsed.conflictFiles, ["config.test.mjs", "extension/README.md"]);
+    assert.deepEqual(parsed.allowedNextActions, ["resolve_merge_conflicts"]);
+    assert(parsed.forbiddenActions.includes("run_pre_approval_gate"));
+    assert(parsed.forbiddenActions.includes("await_final_human_approval"));
+    assert(parsed.forbiddenActions.includes("declare_merge_ready"));
+    assert.match(parsed.reason, /config\.test\.mjs/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
 
 test("detect-pr-gate-coordination-state with --review-mode local_first skips Copilot review", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-local-"));
@@ -201,7 +297,7 @@ test("detect-pr-gate-coordination-state with --review-mode local_first skips Cop
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "267", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "267", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 267,
           state: "OPEN",
@@ -266,14 +362,13 @@ test("detect-pr-gate-coordination-state with --review-mode local_first skips Cop
   }
 });
 
-
 test("detect-pr-gate-coordination-state fails closed when the PR head changes mid-read", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-head-drift-"));
 
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 266,
           state: "OPEN",
@@ -297,7 +392,7 @@ test("detect-pr-gate-coordination-state fails closed when the PR head changes mi
       },
       {
         assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/266/comments?per_page=100"],
-        stdout: '[]\n',
+        stdout: "[]\n",
       },
     ]);
 

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
 
-import { parseGitStatusConflictFiles } from "../../scripts/loop/detect-pr-gate-coordination-state.mjs";
+import { detectPrGateCoordinationState, parseGitStatusConflictFiles } from "../../scripts/loop/detect-pr-gate-coordination-state.mjs";
 
 const scriptPath = path.resolve("scripts/loop/detect-pr-gate-coordination-state.mjs");
 
@@ -124,13 +124,14 @@ test("parseGitStatusConflictFiles parses NUL-delimited porcelain output with det
   const parsed = parseGitStatusConflictFiles([
     "UU config.test.mjs",
     "AA extension/README with spaces.md",
+    "UU  spaced-at-both-ends.txt ",
     " M ignored.txt",
     "R  old-name.md",
     "new-name.md",
     "",
   ].join("\0"));
 
-  assert.deepEqual(parsed, ["config.test.mjs", "extension/README with spaces.md"]);
+  assert.deepEqual(parsed, ["config.test.mjs", "extension/README with spaces.md", " spaced-at-both-ends.txt "]);
 });
 
 test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs with clean draft_gate on a different head (one-time boundary)", async () => {
@@ -241,6 +242,54 @@ test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs
       reason: "The PR is ready for review but the post-draft external review cycle has not started yet; request Copilot review before any `pre_approval_gate` entry.",
       draftGateAlreadySatisfied: true,
     });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detectPrGateCoordinationState tolerates missing local git binary and falls back to GitHub-only facts", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-missing-git-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        stdout: jsonLine({
+          number: 266,
+          state: "OPEN",
+          isDraft: false,
+          headRefOid: "fedcba987654",
+          mergeStateStatus: "CLEAN",
+          statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+          reviews: [],
+        }),
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/266/requested_reviewers"],
+        stdout: jsonLine({ users: [], teams: [] }),
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=266"],
+        stdout: jsonLine({ data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } }),
+      },
+      {
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "headRefOid"],
+        stdout: jsonLine({ headRefOid: "fedcba987654" }),
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/266/comments?per_page=100"],
+        stdout: jsonLine([[]]),
+      },
+    ]);
+
+    const result = await detectPrGateCoordinationState(
+      { repo: "owner/repo", pr: 266 },
+      { env, gitCommand: "definitely-missing-git" },
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.mergeStateStatus, "CLEAN");
+    assert.deepEqual(result.conflictFiles, []);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -5,6 +5,8 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
 
+import { parseGitStatusConflictFiles } from "../../scripts/loop/detect-pr-gate-coordination-state.mjs";
+
 const scriptPath = path.resolve("scripts/loop/detect-pr-gate-coordination-state.mjs");
 
 function runNode(args = [], options = {}) {
@@ -81,21 +83,24 @@ async function writeGhStub(tempDir, entries) {
 
 async function writeGitStub(tempDir, { stdout = "", stderr = "", exitCode = 0, assertArgs = [] } = {}) {
   const gitPath = path.join(tempDir, "git");
+  const stdoutPath = path.join(tempDir, "git-stdout.txt");
 
+  await writeFile(stdoutPath, stdout, "utf8");
   await writeFile(
     gitPath,
     [
       "#!/usr/bin/env node",
+      'import { readFileSync } from "node:fs";',
       'const actual = process.argv.slice(2);',
       'const assertArgs = JSON.parse(process.env.GIT_ASSERT_ARGS || "[]");',
       'for (const expected of assertArgs) {',
       '  if (!actual.includes(expected)) {',
-      '    process.stderr.write(`missing expected git arg: ${expected}\\nactual: ${actual.join(" ")}\\n`);',
+      '    process.stderr.write(`missing expected git arg: ${expected}\nactual: ${actual.join(" ")}\n`);',
       '    process.exit(98);',
       '  }',
       '}',
       'if (process.env.GIT_STDERR) process.stderr.write(process.env.GIT_STDERR);',
-      'if (process.env.GIT_STDOUT) process.stdout.write(process.env.GIT_STDOUT);',
+      'if (process.env.GIT_STDOUT_PATH) process.stdout.write(readFileSync(process.env.GIT_STDOUT_PATH, "utf8"));',
       'process.exit(Number(process.env.GIT_EXIT_CODE || "0"));',
       '',
     ].join("\n"),
@@ -105,7 +110,7 @@ async function writeGitStub(tempDir, { stdout = "", stderr = "", exitCode = 0, a
 
   return {
     GIT_ASSERT_ARGS: JSON.stringify(assertArgs),
-    GIT_STDOUT: stdout,
+    GIT_STDOUT_PATH: stdoutPath,
     GIT_STDERR: stderr,
     GIT_EXIT_CODE: String(exitCode),
   };
@@ -114,6 +119,19 @@ async function writeGitStub(tempDir, { stdout = "", stderr = "", exitCode = 0, a
 function jsonLine(value) {
   return `${JSON.stringify(value)}\n`;
 }
+
+test("parseGitStatusConflictFiles parses NUL-delimited porcelain output with deterministic paths", () => {
+  const parsed = parseGitStatusConflictFiles([
+    "UU config.test.mjs",
+    "AA extension/README with spaces.md",
+    " M ignored.txt",
+    "R  old-name.md",
+    "new-name.md",
+    "",
+  ].join("\0"));
+
+  assert.deepEqual(parsed, ["config.test.mjs", "extension/README with spaces.md"]);
+});
 
 test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs with clean draft_gate on a different head (one-time boundary)", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-state-"));
@@ -325,11 +343,8 @@ test("detect-pr-gate-coordination-state surfaces conflict_resolution for conflic
       },
     ]);
     const gitEnv = await writeGitStub(tempDir, {
-      assertArgs: ["status", "--porcelain=v1", "--untracked-files=no"],
-      stdout: [
-        "UU config.test.mjs",
-        "AA extension/README.md",
-      ].join("\n") + "\n",
+      assertArgs: ["-c", "core.quotepath=false", "status", "--porcelain=v1", "-z", "--untracked-files=no"],
+      stdout: "UU config.test.mjs\0AA extension/README.md\0",
     });
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "370"], {

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -228,6 +228,68 @@ test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs
   }
 });
 
+test("detect-pr-gate-coordination-state preserves non-conflict mergeStateStatus values in helper output", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-merge-state-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        stdout: jsonLine({
+          number: 266,
+          state: "OPEN",
+          isDraft: false,
+          headRefOid: "fedcba987654",
+          mergeStateStatus: "CLEAN",
+          statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+          reviews: [],
+        }),
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/266/requested_reviewers"],
+        stdout: jsonLine({ users: [], teams: [] }),
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=266"],
+        stdout: jsonLine({ data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } }),
+      },
+      {
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "headRefOid"],
+        stdout: jsonLine({ headRefOid: "fedcba987654" }),
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/266/comments?per_page=100"],
+        stdout: jsonLine([[
+          {
+            id: 21,
+            body: [
+              "Gate review: draft_gate",
+              "Reviewed head SHA: fedcba9",
+              "Verdict: clean",
+              "Findings summary: no issues found",
+              "Next action: request Copilot review",
+            ].join("\n"),
+            html_url: "https://example.test/comment/21",
+            updated_at: "2026-05-31T20:00:00Z",
+          },
+        ]]),
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "266"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.gateBoundary, "post_draft_external_review");
+    assert.equal(parsed.nextAction, "request_copilot_review");
+    assert.equal(parsed.mergeStateStatus, "CLEAN");
+    assert.deepEqual(parsed.conflictFiles, []);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("detect-pr-gate-coordination-state surfaces conflict_resolution for conflicted PRs and reports conflict files", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-conflict-"));
 

--- a/test/review-doc-contracts.test.mjs
+++ b/test/review-doc-contracts.test.mjs
@@ -129,7 +129,9 @@ test("consolidated PR lifecycle contract freezes the family-local lifecycle boun
   assert.match(lifecycleContract, /draft_local_review_gate/i);
   assert.match(lifecycleContract, /copilot_reply_resolve_pending/i);
   assert.match(lifecycleContract, /final_gate_remediation/i);
+  assert.match(lifecycleContract, /merge_conflict_resolution/i);
   assert.match(lifecycleContract, /waiting_for_human_pr_approval/i);
+  assert.match(lifecycleContract, /must not be treated as `waiting_for_human_pr_approval`, `waiting_for_merge`, or merge-ready/i);
 
   assert.match(copilotGraph, /skills\/docs\/pr-lifecycle-contract\.md/i);
   assert.match(gateContract, /skills\/docs\/pr-lifecycle-contract\.md/i);


### PR DESCRIPTION
## Summary
- add a `conflict_resolution` PR gate boundary and `resolve_merge_conflicts` next action in the core gate coordinator
- propagate GitHub `mergeStateStatus` plus local conflicted-file detection from `git status` through the gate detector helper
- document and test the conflict reconcile -> validate -> re-gate flow across the Copilot follow-up skill and PR lifecycle contract

## Scope / context
Fixes #371. This closes the retry gap where concurrent PRs touching the same files can loop indefinitely after a conflicting rebase or merge attempt.

## Acceptance criteria
- `detect-pr-gate-coordination-state.mjs` loads and emits `mergeStateStatus`
- conflicted PRs or local unmerged files route to `gateBoundary=conflict_resolution`
- `nextAction=resolve_merge_conflicts` is recommended and approval/merge progression stays forbidden until reconciliation completes
- conflicted files are surfaced in helper output when local git status shows them
- `copilot-pr-followup` and the PR lifecycle contract document the reconcile -> validate -> re-gate -> retry flow, including explicit rebase / force-push authorization
- unit, CLI, and doc-contract coverage exercises the new boundary

## Definition of done
- implementation and docs are updated on this branch
- `npm run verify` passes
- draft PR is open for the normal draft-gate / Copilot / pre-approval follow-up loop

## Non-goals
- automatic branch-update or conflict-resolution bots
- bypassing explicit authorization for rebases, force-pushes, or merges
- adding a new public workflow entrypoint or changing merge-ready policy beyond the missing conflict seam
