### PR TITLE
Standardize refiner-only refinement chain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ These skills may be provided repo-locally or globally; this contract does not as
 - Implement one phase at a time.
 - Use fan-out / fan-in / review / merge before implementing each phase.
 - Default phase and issue refinement to multiple parallel variants before converging on a merged plan; do not rely on a single-plan synthesis when fan-out is practical.
-- Standard refinement chain pattern: use the dedicated `refiner` agent for parallel fan-out and for consolidation/fan-in synthesis.
+- For refinement work, follow the dedicated **Standard refinement chain pattern** section below.
 - Never route review-only comparison, synthesis, or consolidation steps through `dev-loop` + `local_implementation` (the strategy loaded by `skills/local-implementation`); reserve that path for actual implementation/edit work only.
 - Keep logs under `tmp/` in deterministic phase-scoped paths.
 - Use feature branches and small commits only after local verification.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ These skills may be provided repo-locally or globally; this contract does not as
 - Implement one phase at a time.
 - Use fan-out / fan-in / review / merge before implementing each phase.
 - Default phase and issue refinement to multiple parallel variants before converging on a merged plan; do not rely on a single-plan synthesis when fan-out is practical.
-- Standard refinement chain pattern: run parallel fan-out with the `refiner` agent, then run the consolidation/fan-in synthesis with the `refiner` agent.
+- Standard refinement chain pattern: use the dedicated `refiner` agent for parallel fan-out and for consolidation/fan-in synthesis.
 - Never route review-only comparison, synthesis, or consolidation steps through `dev-loop` + `local_implementation` (the strategy loaded by `skills/local-implementation`); reserve that path for actual implementation/edit work only.
 - Keep logs under `tmp/` in deterministic phase-scoped paths.
 - Use feature branches and small commits only after local verification.
@@ -38,6 +38,14 @@ These skills may be provided repo-locally or globally; this contract does not as
 - Use detailed structured PR descriptions, not thin placeholder summaries. At minimum include: change summary, scope/context, explicit acceptance criteria, explicit definition of done, and explicit non-goals.
 - In PR review/fix loops, do not stop at local code changes alone: after an accepted fix is pushed, reply to the addressed review comments with the resolving commit reference and resolve the corresponding threads when genuinely satisfied.
 - Do not merge directly to `main` without review when a PR-based remote loop is practical.
+
+## Standard refinement chain pattern
+
+Use this pattern whenever the work is refinement, comparison, review, or synthesis rather than implementation.
+
+- Parallel fan-out uses the `refiner` agent with bounded aliases such as `{agent: "refiner", as: "refine-NNN", task: "Refine issue #NNN..."}`.
+- Consolidation/fan-in also uses the `refiner` agent, for example `{agent: "refiner", task: "Review {outputs.refine-NNN}... Report readiness."}`. Treat this as review-only consolidation; no code edits are expected from that step.
+- Keep the fan-out and consolidation chain inside the reusable `refiner` role. Do not route those refinement/review steps through `dev-loop` + `local_implementation`; that path is only for actual implementation/edit work.
 
 ## Dev loop defaults
 

--- a/skills/issue-intake/SKILL.md
+++ b/skills/issue-intake/SKILL.md
@@ -17,7 +17,9 @@ issue-first intake procedure now lives in `copilot-pr-followup` under the
 **Issue-first intake and durable-auto overlays** section.
 
 When this skill is loaded, immediately redirect to [Copilot PR Follow-up Skill](../copilot-pr-followup/SKILL.md)
-and follow its procedure. Use the `refiner` agent for issue-refinement
-work on the redirected `issue_intake` route. The `issue_intake` routing still
+and follow its procedure. For issue-refinement work on the redirected `issue_intake`
+route, invoke the `refiner` agent directly for both the parallel fan-out steps and
+the consolidation/fan-in step; do not route those review-only refinement steps
+through `dev-loop` + `local_implementation`. The `issue_intake` routing still
 differentiates from `copilot_pr_followup` in the public router; this redirect
 preserves that contract while keeping the procedure text canonical in one file.

--- a/skills/issue-intake/SKILL.md
+++ b/skills/issue-intake/SKILL.md
@@ -17,9 +17,9 @@ issue-first intake procedure now lives in `copilot-pr-followup` under the
 **Issue-first intake and durable-auto overlays** section.
 
 When this skill is loaded, immediately redirect to [Copilot PR Follow-up Skill](../copilot-pr-followup/SKILL.md)
-and follow its procedure. For issue-refinement work on the redirected `issue_intake`
-route, invoke the `refiner` agent directly for both the parallel fan-out steps and
-the consolidation/fan-in step; do not route those review-only refinement steps
-through `dev-loop` + `local_implementation`. The `issue_intake` routing still
-differentiates from `copilot_pr_followup` in the public router; this redirect
-preserves that contract while keeping the procedure text canonical in one file.
+and follow its procedure. Treat **Phase 3 — Async issue refinement** there as the
+canonical refiner-only path for the redirected `issue_intake` route; do not restate
+that procedure here or route those review-only refinement steps through `dev-loop` +
+`local_implementation`. The `issue_intake` routing still differentiates from
+`copilot_pr_followup` in the public router; this redirect preserves that contract
+while keeping the procedure text canonical in one file.


### PR DESCRIPTION
## Summary
- document the standard refiner-only refinement chain in `AGENTS.md`
- specify the parallel fan-out alias pattern and refiner-based consolidation step
- update `skills/issue-intake/SKILL.md` to direct issue refinement through `refiner` instead of `dev-loop` + `local_implementation`

## Scope / context
Implements #376. This is a docs-only cleanup that aligns the repo's documented refinement workflow with the existing `agents/refiner.agent.md` persona and the existing issue-intake redirect structure.

## Acceptance criteria
- [x] Standard refinement chain pattern documented in `AGENTS.md`
- [x] Consolidation step uses `refiner` agent with no code-edit expectation
- [x] `skills/issue-intake/SKILL.md` points issue refinement at the `refiner` agent directly

## Definition of done
- [x] Requested docs updated on a feature branch
- [x] Validation passed with `npm run verify`
- [x] Draft PR opened for review

## Non-goals
- No runtime code changes
- No test file changes
- No workflow-surface expansion beyond the documented refinement chain
