### PR TITLE
Add refiner coverage matrix contract

### DIFF
--- a/.pi/dev-loop/defaults.yaml
+++ b/.pi/dev-loop/defaults.yaml
@@ -50,13 +50,31 @@ workflow:
   requireDraftFirst: false
   devModeDefault: false
 
-# Persona registry: maps each review angle to an agent persona and prompt.
-# Consumers can add custom angles with their own persona agents.
+# Persona registry: maps named workflow personas/angles to agents and prompts.
+# Gate review angles resolve through this registry, and non-gate personas such
+# as `refiner` may also live here so consuming repos can customize prompt text.
+# Consumers can add custom angles or reusable persona prompts.
 # Each entry:
 #   persona      — agent persona name (must exist in .pi/agents/)
-#   prompt       — focused instruction for the reviewer agent
+#   prompt       — focused instruction for the agent
 #   defaultModel — optional model override (null = use persona default)
 personas:
+  refiner:
+    persona: refiner
+    prompt: |-
+      For every refinement, include an AC/DoD/Non-goal coverage matrix:
+
+      | Item | Type (AC/DoD/Non-goal) | Status (Met/Partial/Unmet/Unverified) | Evidence | Notes |
+      |---|---|---|---|---|
+      | <exact item text> | AC | Unverified | <reference> | |
+
+      Use exact wording from the source issue(s); when the governing input is a phase doc or other spec instead of an issue, use that source wording exactly for every explicit item.
+      Include every explicit acceptance criterion, definition-of-done item, and non-goal; do not skip items.
+      If no explicit definition of done exists, add a `Proposed DoD` subsection before the matrix.
+      Treat any `Partial`, `Unmet`, or `Unverified` row as incomplete refinement.
+      A refinement is complete only when no item has `Partial`, `Unmet`, or `Unverified` status.
+    defaultModel: null
+
   scope:
     persona: review
     prompt: >-

--- a/agents/refiner.agent.md
+++ b/agents/refiner.agent.md
@@ -29,6 +29,15 @@ For the active phase, require and produce:
 - explicit non-goals
 - complete acceptance criteria that are concrete and testable
 - a complete definition-of-done list that covers implementation, validation, documentation, and review expectations
+- a structured AC/DoD/Non-goal coverage matrix using this format:
+
+  | Item | Type (AC/DoD/Non-goal) | Status (Met/Partial/Unmet/Unverified) | Evidence | Notes |
+  |---|---|---|---|---|
+  | <exact item text> | AC | Unverified | <reference> | |
+
+- use exact wording from the source issue(s); when the governing input is a phase doc or other spec instead of an issue, use that source wording exactly for every explicit item in the matrix
+- include every explicit acceptance criterion, definition-of-done item, and non-goal; do not skip items
+- if no explicit definition of done exists, add a `Proposed DoD` subsection before the matrix
 - explicit risks, watchpoints, and unresolved questions
 - validation steps and tests to write first
 - durable decisions that should be preserved in the phase doc
@@ -65,5 +74,11 @@ Return:
 - Complete acceptance criteria
 - Complete definition of done
 - Explicit non-goals, risks, and unresolved questions
+- An AC/DoD/Non-goal coverage matrix that uses exact source wording for every explicit item
+- If the source has no explicit definition of done, a `Proposed DoD` subsection
 - Tests to write first and validation steps
 - Any RFC escalation needed through the coordinator
+
+## Completion quality bar
+- A refinement is complete only when no item in the AC/DoD/Non-goal coverage matrix has status `Partial`, `Unmet`, or `Unverified`.
+- Any `Partial`, `Unmet`, or `Unverified` item means the refinement is still incomplete and must not be presented as ready.

--- a/test/planning-doc-contracts.test.mjs
+++ b/test/planning-doc-contracts.test.mjs
@@ -33,6 +33,12 @@ test("refiner agent defines the approved phase-refinement contract", async () =>
     /## RFC escalation boundary/i,
     /complete acceptance criteria/i,
     /complete definition of done/i,
+    /coverage matrix/i,
+    /Type \(AC\/DoD\/Non-goal\)/i,
+    /Status \(Met\/Partial\/Unmet\/Unverified\)/i,
+    /use exact wording from the source issue\(s\)/i,
+    /include every explicit acceptance criterion, definition-of-done item, and non-goal/i,
+    /Proposed DoD/i,
     /explicit non-goals/i,
     /explicit risks, watchpoints, and unresolved questions/i,
     /validation steps and tests to write first/i,
@@ -44,8 +50,24 @@ test("refiner agent defines the approved phase-refinement contract", async () =>
     /lead dev/i,
     /specialized dev/i,
     /systems architect/i,
+    /A refinement is complete only when no item.+Partial.+Unmet.+Unverified/is,
   ], "agents/refiner.agent.md");
   assert.doesNotMatch(content, /execute RFC work itself|run the RFC team|implement the RFC team/i);
+});
+
+
+test("defaults config exposes a customizable refiner coverage-matrix prompt", async () => {
+  const content = await readRepo(".pi/dev-loop/defaults.yaml");
+
+  assertMatchesAll(content, [
+    /personas:\n  refiner:\n    persona: refiner/m,
+    /AC\/DoD\/Non-goal coverage matrix/i,
+    /\| Item \| Type \(AC\/DoD\/Non-goal\) \| Status \(Met\/Partial\/Unmet\/Unverified\) \| Evidence \| Notes \|/i,
+    /Use exact wording from the source issue\(s\); when the governing input is a phase doc or other spec instead of an issue, use that source wording exactly for every explicit item/i,
+    /Include every explicit acceptance criterion, definition-of-done item, and non-goal; do not skip items/i,
+    /If no explicit definition of done exists, add a `Proposed DoD` subsection before the matrix/i,
+    /A refinement is complete only when no item has `Partial`, `Unmet`, or `Unverified` status/i,
+  ], ".pi/dev-loop/defaults.yaml");
 });
 
 test("local-implementation skill uses the refiner for phase planning without replacing the coordinator", async () => {


### PR DESCRIPTION
## Summary
- add the AC/DoD/Non-goal coverage-matrix contract to the refiner agent prompt
- add the shipped default `personas.refiner.prompt` entry so consuming repos can customize the matrix prompt surface
- lock the new contract in with planning doc tests

## Scope / context
This implements #377 by extending the refiner persona with a verifiable coverage matrix for acceptance criteria, definition of done items, and non-goals. The change keeps the current refiner persona shape, adds the completion quality bar, and exposes the prompt through the shipped defaults config so downstream repos can override the matrix wording without rewriting the whole agent surface.

Closes #377.

## Acceptance criteria
- [x] Refiner prompt includes an AC/DoD/Non-goal coverage matrix
- [x] Refiner prompt includes the completion quality bar (no unresolved status rows)
- [x] Default config exposes a customizable `personas.refiner.prompt` entry
- [x] `npm test` passes

## Definition of done
- [x] `agents/refiner.agent.md` requires the coverage matrix, exact-source wording, and Proposed DoD fallback
- [x] `.pi/dev-loop/defaults.yaml` ships the same refiner prompt contract under `personas.refiner`
- [x] `test/planning-doc-contracts.test.mjs` covers the new agent/defaults contract
- [x] Branch changes are pushed in a reviewable draft PR

## Non-goals
- replacing the refiner persona wholesale
- changing non-refiner review angle behavior
- introducing runtime config-loader changes beyond the existing `personas` surface
