### PR TITLE
Require self-assignment on issue/PR creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ These skills may be provided repo-locally or globally; this contract does not as
 - Use `npm run verify` as the default repo-level local verification path when a full local validation pass is warranted.
 - For public-facing or release-bound changes, prefer GitHub issues/PRs/CI over direct local-main finalization.
 - Use detailed structured PR descriptions, not thin placeholder summaries. At minimum include: change summary, scope/context, explicit acceptance criteria, explicit definition of done, and explicit non-goals.
+- When creating GitHub issues or PRs via `gh issue create` or `gh pr create`, always include `--assignee @me` so the new artifact is self-assigned.
 - In PR review/fix loops, do not stop at local code changes alone: after an accepted fix is pushed, reply to the addressed review comments with the resolving commit reference and resolve the corresponding threads when genuinely satisfied.
 - Do not merge directly to `main` without review when a PR-based remote loop is practical.
 

--- a/docs/sub-issue-tree-contract.md
+++ b/docs/sub-issue-tree-contract.md
@@ -34,7 +34,7 @@ When refining an umbrella issue into executable slices:
    parent issue body.
 2. **Define bounded child slices** — each slice must be independently closable and
    independently verifiable.
-3. **Create child issues** with `gh issue create` (or reuse existing issues).
+3. **Create child issues** with `gh issue create --assignee @me` (or reuse existing issues).
 4. **Attach children as real sub-issues** using `manage-sub-issues.mjs add`.
 5. **Set execution order** using `manage-sub-issues.mjs reorder` — first in the list is
    highest priority.

--- a/docs/tracker-story-pr-contract.md
+++ b/docs/tracker-story-pr-contract.md
@@ -120,7 +120,7 @@ implementations map canonical action names to tracker-native field updates.
 | PR lifecycle event | Maps to canonical state | Sync trigger |
 |---|---|---|
 | No PR created yet | `ready_no_pr` | No trigger |
-| `gh pr create --draft` succeeds | `draft_pr_open` | Apply `set_in_progress` to tracker |
+| `gh pr create --draft --assignee @me` succeeds | `draft_pr_open` | Apply `set_in_progress` to tracker |
 | PR converted from draft to ready-for-review | `pr_reviewable` | Apply `set_reviewable` to tracker |
 | PR merged | `pr_merged` | Apply `set_done` to tracker |
 | PR closed without merge | `pr_closed_unmerged` | No automatic sync; report to user |

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -335,7 +335,7 @@ Full decomposition flow:
 
 1. refine umbrella issue framing (scope, acceptance criteria, non-goals)
 2. define bounded child slices — each slice must be independently closable
-3. create child issues with `gh issue create --repo <resolved-repo>`
+3. create child issues with `gh issue create --repo <resolved-repo> --assignee @me`
 4. attach each child as a real sub-issue:
    ```sh
    node <resolved-skill-scripts>/github/manage-sub-issues.mjs add \
@@ -559,7 +559,7 @@ New PRs in this workflow must be opened as **draft** PRs first when the reposito
 
 Only use `gh pr create` when authoritative issue↔PR resolution says there is no already-open linked PR. If a PR already exists, reuse/update that canonical PR instead of opening another one.
 
-MUST use `gh pr create --draft --repo <owner/name> --base <base> --head <head> --title "..." --body-file <body-file>`.
+MUST use `gh pr create --draft --repo <owner/name> --assignee @me --base <base> --head <head> --title "..." --body-file <body-file>`.
 
 ## Timeout and watch policy
 

--- a/skills/docs/workflow-handoff-template.md
+++ b/skills/docs/workflow-handoff-template.md
@@ -22,7 +22,7 @@ Every step is non-optional. Do not skip, reorder, or batch steps.
 
 - Branch off `origin/main`
 - Implement changes, write tests, run `npm run verify`
-- Create PR as **draft** via `gh pr create --draft`
+- Create PR as **draft** via `gh pr create --draft --assignee @me`
 
 ### 2. Draft gate review
 

--- a/skills/final-approval/SKILL.md
+++ b/skills/final-approval/SKILL.md
@@ -36,7 +36,7 @@ Read only what the final approval decision needs:
 - Stop at the final human approval gate by default.
 - After approval, report `waiting_for_merge_authorization` and stop again unless merge has been explicitly authorized.
 - Do not merge, push, rebase, resolve threads, or change GitHub state without explicit confirmation unless the latest user message already authorizes that exact action.
-- If an explicitly authorized recovery path needs a new GitHub issue or replacement PR, create it with `gh issue create --assignee @me ...` or `gh pr create --assignee @me ...` so the new artifact is self-assigned.
+- If an explicitly authorized recovery path needs a new GitHub issue or replacement PR, create it with `gh issue create --assignee @me ...` or `gh pr create --draft --assignee @me ...` so the new artifact is self-assigned and replacement PRs still respect the draft gate boundary.
 
 ## Stop-and-ask rules
 

--- a/skills/final-approval/SKILL.md
+++ b/skills/final-approval/SKILL.md
@@ -36,6 +36,7 @@ Read only what the final approval decision needs:
 - Stop at the final human approval gate by default.
 - After approval, report `waiting_for_merge_authorization` and stop again unless merge has been explicitly authorized.
 - Do not merge, push, rebase, resolve threads, or change GitHub state without explicit confirmation unless the latest user message already authorizes that exact action.
+- If an explicitly authorized recovery path needs a new GitHub issue or replacement PR, create it with `gh issue create --assignee @me ...` or `gh pr create --assignee @me ...` so the new artifact is self-assigned.
 
 ## Stop-and-ask rules
 

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -77,7 +77,7 @@ When the local spec already lives in a tracker issue:
 - sync durable scope / acceptance / status changes back to the tracker issue rather than maintaining a duplicate local phase doc
 - keep `tmp/` as temporary local execution state only; it does not become a second durable spec surface
 - for tracker-backed sessions, the handoff path is always: push the working branch → open a PR → merge via GitHub
-- for tracker-backed sessions, PR creation must use `gh pr create --draft`. Treat this as config-driven workflow policy via `.pi/dev-loop/settings.yaml` `workflow.requireDraftFirst` when the repo opts in. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate review is a real workflow boundary.
+- for tracker-backed sessions, PR creation must use `gh pr create --draft --assignee @me`. Treat this as config-driven workflow policy via `.pi/dev-loop/settings.yaml` `workflow.requireDraftFirst` when the repo opts in. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate review is a real workflow boundary.
 - do not suggest a direct local-main merge for tracker-backed sessions; do not merge the working branch into local `main` at phase completion
 
 ## Primary execution rules
@@ -511,7 +511,7 @@ Stop after the current phase when:
 - Rerun validation after review-driven fixes.
 - A phase is not operationally closed until its branch state is captured in commit history and the reviewed branch has been finalized according to session type (merged into local `main` for phase-doc-backed sessions; merged via GitHub PR for tracker-backed sessions), unless authorization for that finalization is still pending.
 - For tracker-backed sessions, the handoff path is always: push the working branch → open a PR → merge via GitHub; never merge the working branch into local `main`.
-- PR creation must use `gh pr create --draft`. Treat this as config-driven workflow policy via `.pi/dev-loop/settings.yaml` `workflow.requireDraftFirst` when the repo opts in. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate review is a real workflow boundary, so a new PR must exist in draft before `gh pr ready` is eligible.
+- PR creation must use `gh pr create --draft --assignee @me`. Treat this as config-driven workflow policy via `.pi/dev-loop/settings.yaml` `workflow.requireDraftFirst` when the repo opts in. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate review is a real workflow boundary, so a new PR must exist in draft before `gh pr ready` is eligible.
 - When authorization is pending, record the phase as `awaiting-finalization` and describe the exact missing step.
 - For phase-doc-backed sessions, merge the fully reviewed, locally validated branch back into local `main` when authorized.
 

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -77,7 +77,7 @@ When the local spec already lives in a tracker issue:
 - sync durable scope / acceptance / status changes back to the tracker issue rather than maintaining a duplicate local phase doc
 - keep `tmp/` as temporary local execution state only; it does not become a second durable spec surface
 - for tracker-backed sessions, the handoff path is always: push the working branch → open a PR → merge via GitHub
-- for tracker-backed sessions, PR creation must use `gh pr create --draft --assignee @me`. Treat this as config-driven workflow policy via `.pi/dev-loop/settings.yaml` `workflow.requireDraftFirst` when the repo opts in. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate review is a real workflow boundary.
+- for tracker-backed sessions, PR creation must always include `--assignee @me` so the new PR is self-assigned. When `.pi/dev-loop/settings.yaml` `workflow.requireDraftFirst` opts in, use `gh pr create --draft --assignee @me`. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate review is a real workflow boundary.
 - do not suggest a direct local-main merge for tracker-backed sessions; do not merge the working branch into local `main` at phase completion
 
 ## Primary execution rules
@@ -511,7 +511,7 @@ Stop after the current phase when:
 - Rerun validation after review-driven fixes.
 - A phase is not operationally closed until its branch state is captured in commit history and the reviewed branch has been finalized according to session type (merged into local `main` for phase-doc-backed sessions; merged via GitHub PR for tracker-backed sessions), unless authorization for that finalization is still pending.
 - For tracker-backed sessions, the handoff path is always: push the working branch → open a PR → merge via GitHub; never merge the working branch into local `main`.
-- PR creation must use `gh pr create --draft --assignee @me`. Treat this as config-driven workflow policy via `.pi/dev-loop/settings.yaml` `workflow.requireDraftFirst` when the repo opts in. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate review is a real workflow boundary, so a new PR must exist in draft before `gh pr ready` is eligible.
+- PR creation must always include `--assignee @me` so the new PR is self-assigned. When `.pi/dev-loop/settings.yaml` `workflow.requireDraftFirst` opts in, use `gh pr create --draft --assignee @me`. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate review is a real workflow boundary, so a new PR must exist in draft before `gh pr ready` is eligible.
 - When authorization is pending, record the phase as `awaiting-finalization` and describe the exact missing step.
 - For phase-doc-backed sessions, merge the fully reviewed, locally validated branch back into local `main` when authorized.
 

--- a/test/copilot-review-doc-contracts.test.mjs
+++ b/test/copilot-review-doc-contracts.test.mjs
@@ -455,7 +455,7 @@ test("sub-issue tree contract documents the workflow, helper commands, and lean-
   assert.match(contractContent, /add/i);
   assert.match(contractContent, /reorder/i);
   assert.match(contractContent, /verify/i);
-  assert.match(contractContent, /Default decomposition flow[\s\S]*verify/i);
+  assert.match(contractContent, /Default decomposition flow[\s\S]*gh issue create --assignee @me[\s\S]*verify/i);
   assert.match(contractContent, /verify.*mismatch-only.*exit 0|exits 0 for mismatch-only results/i);
   assert.match(contractContent, /lean/i);
   assert.match(contractContent, /do not maintain.*checklist.*duplicates|not.*maintain.*ordered checklist.*duplicates/i);

--- a/test/issue-intake-doc-contracts.test.mjs
+++ b/test/issue-intake-doc-contracts.test.mjs
@@ -74,7 +74,7 @@ test("issue-intake skill requires unattended resume-from-state behavior when aut
   assert.match(content, /automatically resume\/restart follow-up when continuation is feasible/i);
   assert.match(content, /New PRs in this workflow must be opened as \*\*draft\*\* PRs first/i);
   assert.match(content, /Do not create a fresh PR directly in ready-for-review state/i);
-  assert.match(content, /gh pr create --draft --repo <owner\/name> --base <base> --head <head> --title/i);
+  assert.match(content, /gh pr create --draft --repo <owner\/name> --assignee @me --base <base> --head <head> --title/i);
   assert.match(content, /pre-existing PR.*not.*stop-by-default condition/is);
   assert.match(content, /continue unattended until the final approval gate/i);
   assert.match(content, /stop for a human approval decision by default/i);
@@ -184,6 +184,7 @@ test("issue-intake flow carries the resolved repo slug through later GitHub issu
   const skillContent = await readRepo("skills/copilot-pr-followup/SKILL.md");
 
   assert.match(skillContent, /Carry that resolved repo slug through every later GitHub issue\/PR command/i);
+  assert.match(skillContent, /gh issue create --repo <resolved-repo> --assignee @me/);
   assert.match(skillContent, /gh issue edit <number> --repo <resolved-repo> --body-file <updated-body-file>/);
   assert.match(skillContent, /gh issue edit <number> --repo <resolved-repo> --add-assignee copilot-swe-agent/);
   assert.match(skillContent, /gh pr edit <pr-number> --repo <resolved-repo> --title/);

--- a/test/public-facade-doc-contracts.test.mjs
+++ b/test/public-facade-doc-contracts.test.mjs
@@ -326,7 +326,7 @@ test("gate-review sub-loop contract exists and is referenced by both gates", asy
   assert.match(subLoopContract, /does not satisfy the other gate/i);
 });
 
-test("skill docs enforce --draft flag for PR creation", async () => {
+test("skill docs enforce self-assignment and draft-first rules for create commands", async () => {
   const [copilotFollowupSkill, localImplementationSkill, finalApprovalSkill, agents, workflowHandoffTemplate, trackerStoryPrContract] = await Promise.all([
     readRepo("skills/copilot-pr-followup/SKILL.md"),
     readRepo("skills/local-implementation/SKILL.md"),
@@ -350,7 +350,7 @@ test("skill docs enforce --draft flag for PR creation", async () => {
   assert.match(localImplementationSkill, /draft gate review is a real workflow boundary/i);
 
   assert.match(finalApprovalSkill, /gh issue create --assignee @me \.\.\./i);
-  assert.match(finalApprovalSkill, /gh pr create --assignee @me \.\.\./i);
+  assert.match(finalApprovalSkill, /gh pr create --draft --assignee @me \.\.\./i);
   assert.match(agents, /gh issue create` or `gh pr create`, always include `--assignee @me`/i);
   assert.match(workflowHandoffTemplate, /gh pr create --draft --assignee @me/i);
   assert.match(trackerStoryPrContract, /gh pr create --draft --assignee @me/);

--- a/test/public-facade-doc-contracts.test.mjs
+++ b/test/public-facade-doc-contracts.test.mjs
@@ -327,19 +327,31 @@ test("gate-review sub-loop contract exists and is referenced by both gates", asy
 });
 
 test("skill docs enforce --draft flag for PR creation", async () => {
-  const [copilotFollowupSkill, localImplementationSkill] = await Promise.all([
+  const [copilotFollowupSkill, localImplementationSkill, finalApprovalSkill, agents, workflowHandoffTemplate, trackerStoryPrContract] = await Promise.all([
     readRepo("skills/copilot-pr-followup/SKILL.md"),
     readRepo("skills/local-implementation/SKILL.md"),
+    readRepo("skills/final-approval/SKILL.md"),
+    readRepo("AGENTS.md"),
+    readRepo("skills/docs/workflow-handoff-template.md"),
+    readRepo("docs/tracker-story-pr-contract.md"),
   ]);
 
   // copilot-pr-followup enforces --draft in PR creation command
   assert.match(copilotFollowupSkill, /MUST use `gh pr create --draft/i);
+  assert.match(copilotFollowupSkill, /gh issue create --repo <resolved-repo> --assignee @me/i);
+  assert.match(copilotFollowupSkill, /gh pr create --draft --repo <owner\/name> --assignee @me --base <base> --head <head> --title/i);
   assert.match(copilotFollowupSkill, /New PRs in this workflow must be opened as \*\*draft\*\* PRs first/i);
   assert.match(copilotFollowupSkill, /Do not create a fresh PR directly in ready-for-review state/i);
   assert.match(copilotFollowupSkill, /draft gate review is a real workflow boundary/i);
 
   // local-implementation enforces --draft for tracker-backed PR creation
-  assert.match(localImplementationSkill, /PR creation must use `gh pr create --draft`/i);
+  assert.match(localImplementationSkill, /PR creation must use `gh pr create --draft --assignee @me`/i);
   assert.match(localImplementationSkill, /Do not create a fresh PR directly in ready-for-review state/i);
   assert.match(localImplementationSkill, /draft gate review is a real workflow boundary/i);
+
+  assert.match(finalApprovalSkill, /gh issue create --assignee @me \.\.\./i);
+  assert.match(finalApprovalSkill, /gh pr create --assignee @me \.\.\./i);
+  assert.match(agents, /gh issue create` or `gh pr create`, always include `--assignee @me`/i);
+  assert.match(workflowHandoffTemplate, /gh pr create --draft --assignee @me/i);
+  assert.match(trackerStoryPrContract, /gh pr create --draft --assignee @me/);
 });

--- a/test/public-facade-doc-contracts.test.mjs
+++ b/test/public-facade-doc-contracts.test.mjs
@@ -344,8 +344,9 @@ test("skill docs enforce self-assignment and draft-first rules for create comman
   assert.match(copilotFollowupSkill, /Do not create a fresh PR directly in ready-for-review state/i);
   assert.match(copilotFollowupSkill, /draft gate review is a real workflow boundary/i);
 
-  // local-implementation enforces --draft for tracker-backed PR creation
-  assert.match(localImplementationSkill, /PR creation must use `gh pr create --draft --assignee @me`/i);
+  // local-implementation keeps self-assignment unconditional and draft-first config-driven
+  assert.match(localImplementationSkill, /PR creation must always include `--assignee @me`/i);
+  assert.match(localImplementationSkill, /workflow\.requireDraftFirst[\s\S]{0,120}gh pr create --draft --assignee @me/i);
   assert.match(localImplementationSkill, /Do not create a fresh PR directly in ready-for-review state/i);
   assert.match(localImplementationSkill, /draft gate review is a real workflow boundary/i);
 

--- a/test/workflow-handoff-template-contract.test.mjs
+++ b/test/workflow-handoff-template-contract.test.mjs
@@ -53,8 +53,6 @@ test("workflow-handoff-template includes all 8 mandatory steps in order", async 
 test("workflow-handoff-template references required contract docs by path", async () => {
   const content = await readTemplate();
 
-  assert.match(content, /gh pr create --draft --assignee @me/i);
-
   const requiredRefs = [
     "../../docs/gate-review-comment-contract.md",
     "../copilot-pr-followup/SKILL.md",
@@ -67,6 +65,12 @@ test("workflow-handoff-template references required contract docs by path", asyn
       `template must reference "${ref}"`,
     );
   }
+});
+
+test("workflow-handoff-template requires self-assigned draft PR creation", async () => {
+  const content = await readTemplate();
+
+  assert.match(content, /gh pr create --draft --assignee @me/i);
 });
 
 test("workflow-handoff-template has Copilot review loop between draft_gate and pre_approval_gate", async () => {

--- a/test/workflow-handoff-template-contract.test.mjs
+++ b/test/workflow-handoff-template-contract.test.mjs
@@ -67,10 +67,14 @@ test("workflow-handoff-template references required contract docs by path", asyn
   }
 });
 
-test("workflow-handoff-template requires self-assigned draft PR creation", async () => {
+test("workflow-handoff-template requires self-assigned draft PR creation in the mandatory sequence", async () => {
   const content = await readTemplate();
 
-  assert.match(content, /gh pr create --draft --assignee @me/i);
+  const seqStart = content.indexOf("## Mandatory sequence");
+  const nextSection = content.indexOf("## Non-negotiable");
+  const sequenceSection = content.slice(seqStart, nextSection);
+
+  assert.match(sequenceSection, /gh pr create --draft --assignee @me/i);
 });
 
 test("workflow-handoff-template has Copilot review loop between draft_gate and pre_approval_gate", async () => {

--- a/test/workflow-handoff-template-contract.test.mjs
+++ b/test/workflow-handoff-template-contract.test.mjs
@@ -53,6 +53,8 @@ test("workflow-handoff-template includes all 8 mandatory steps in order", async 
 test("workflow-handoff-template references required contract docs by path", async () => {
   const content = await readTemplate();
 
+  assert.match(content, /gh pr create --draft --assignee @me/i);
+
   const requiredRefs = [
     "../../docs/gate-review-comment-contract.md",
     "../copilot-pr-followup/SKILL.md",

--- a/test/workflow-handoff-template-contract.test.mjs
+++ b/test/workflow-handoff-template-contract.test.mjs
@@ -71,7 +71,11 @@ test("workflow-handoff-template requires self-assigned draft PR creation in the 
   const content = await readTemplate();
 
   const seqStart = content.indexOf("## Mandatory sequence");
-  const nextSection = content.indexOf("## Non-negotiable");
+  const nextSection = content.indexOf("## Non-negotiable", seqStart);
+
+  assert.ok(seqStart >= 0, "mandatory sequence section should exist");
+  assert.ok(nextSection > seqStart, "non-negotiable section should follow mandatory sequence");
+
   const sequenceSection = content.slice(seqStart, nextSection);
 
   assert.match(sequenceSection, /gh pr create --draft --assignee @me/i);


### PR DESCRIPTION
## Summary
- require `--assignee @me` in the routed skill docs for `gh issue create` and `gh pr create`
- document the same self-assignment rule in `AGENTS.md` and related workflow contracts
- extend doc contract tests to lock the policy in place

## Scope / context
Issue #360 reported that agent-created issues and PRs were being left unassigned because the workflow docs omitted `--assignee @me`.

## Acceptance criteria
- [x] `AGENTS.md` mentions `--assignee @me` on issue and PR creation
- [x] `skills/copilot-pr-followup/SKILL.md` uses `--assignee @me` on create commands
- [x] `skills/local-implementation/SKILL.md` requires `--assignee @me` for tracker-backed PR creation
- [x] `skills/final-approval/SKILL.md` covers self-assignment for any recovery-path creation
- [x] related workflow contract docs and tests enforce the same rule

## Definition of done
- [x] docs updated
- [x] tests updated
- [x] `npm run verify` passes

## Non-goals
- changing runtime GitHub helper implementations
- altering assignment behavior for existing issues or PRs

Closes #360
