### PR TITLE
Add post-merge pi update hook

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -5,6 +5,7 @@
 Installing the package exposes two thin wrappers over one shared deterministic core:
 - the Pi extension command family rooted at `/dev-loops`
 - the shell CLI entrypoint `pi-dev-loops`
+- a bounded post-merge helper that queues one `pi update git:github.com/mfittko/pi-dev-loops` after a successful in-session `gh pr merge ...` or `git merge ...` inside this repo and flushes it on `agent_end`
 
 Installing the package with `pi install git:github.com/mfittko/pi-dev-loops` exposes the packaged skills through `package.json` `pi.skills`, and the extension syncs packaged agent files (`.pi/agents/*.agent.md`) into `~/.agents/` on `session_start`.
 

--- a/extension/index.ts
+++ b/extension/index.ts
@@ -6,6 +6,7 @@ import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 
 import { executeDevLoopsCommand } from '../lib/dev-loops-core.mjs';
 import { createExtensionCoreRuntime } from './checks.ts';
+import { createPostMergeUpdateHook } from './post-merge-update.ts';
 import {
   buildHelpLines,
   buildInspectLines,
@@ -15,6 +16,10 @@ import {
   type DevLoopsAction,
   type InspectAction,
 } from './presentation.ts';
+
+type ExtensionRuntimeOverrides = NonNullable<Parameters<typeof createExtensionCoreRuntime>[1]> & {
+  postMergeUpdateHook?: ReturnType<typeof createPostMergeUpdateHook>;
+};
 
 const STATUS_KEY = 'pi-dev-loops';
 const WIDGET_KEY = 'pi-dev-loops.setup';
@@ -39,14 +44,29 @@ export function syncPackagedAgents({
   }
 }
 
-export default function (pi: ExtensionAPI, runtimeOverrides = {}) {
+export default function (pi: ExtensionAPI, runtimeOverrides: ExtensionRuntimeOverrides = {}) {
+  const postMergeUpdateHook = runtimeOverrides.postMergeUpdateHook ?? createPostMergeUpdateHook(pi);
+
   pi.on('session_start', async (_event, ctx) => {
+    postMergeUpdateHook.onSessionStart();
     try {
       syncPackagedAgents();
     } catch {
       // Best-effort agent sync — do not break session start
     }
     ctx.ui.setStatus(STATUS_KEY, undefined);
+  });
+
+  pi.on('tool_result', async (event, ctx) => {
+    await postMergeUpdateHook.onToolResult(event, ctx);
+  });
+
+  pi.on('user_bash', async (event, ctx) => {
+    return postMergeUpdateHook.onUserBash(event, ctx);
+  });
+
+  pi.on('agent_end', async (event, ctx) => {
+    await postMergeUpdateHook.onAgentEnd(event, ctx);
   });
 
   pi.registerCommand('dev-loops', {

--- a/extension/post-merge-update.ts
+++ b/extension/post-merge-update.ts
@@ -31,7 +31,6 @@ type RunCommandResult = ExecResult;
 type PostMergeUpdateHookState = {
   pendingPostMergeUpdate: boolean;
   updateInFlight: boolean;
-  lastTriggerToken: string | null;
   pendingRepoRoot: string | null;
 };
 
@@ -43,10 +42,6 @@ type CreatePostMergeUpdateHookOptions = {
 function trimToNull(value: string | null | undefined): string | null {
   const trimmed = `${value ?? ''}`.trim();
   return trimmed ? trimmed : null;
-}
-
-function buildMergeTriggerToken(command: string, repoRoot: string, repoSlug: string): string {
-  return `${repoSlug}\n${repoRoot}\n${command.trim()}`;
 }
 
 function buildShellOutput(result: Pick<RunCommandResult, 'stdout' | 'stderr'>): string {
@@ -120,16 +115,13 @@ function markPendingUpdate(state: PostMergeUpdateHookState, command: string, rep
     return;
   }
 
-  const triggerToken = buildMergeTriggerToken(command, repoContext.repoRoot, repoContext.repoSlug);
   if (state.pendingPostMergeUpdate) {
-    state.lastTriggerToken = triggerToken;
     state.pendingRepoRoot ??= repoContext.repoRoot;
     return;
   }
 
   state.pendingPostMergeUpdate = true;
   state.pendingRepoRoot = repoContext.repoRoot;
-  state.lastTriggerToken = triggerToken;
 }
 
 async function resolveRepoContextSafe(
@@ -245,14 +237,12 @@ export function createPostMergeUpdateHook(
   const state: PostMergeUpdateHookState = {
     pendingPostMergeUpdate: false,
     updateInFlight: false,
-    lastTriggerToken: null,
     pendingRepoRoot: null,
   };
 
   function reset(): void {
     state.pendingPostMergeUpdate = false;
     state.updateInFlight = false;
-    state.lastTriggerToken = null;
     state.pendingRepoRoot = null;
   }
 

--- a/extension/post-merge-update.ts
+++ b/extension/post-merge-update.ts
@@ -158,10 +158,28 @@ export function normalizeGitHubRepoSlug(remoteUrl: string): string | null {
     if (!match) {
       continue;
     }
-    return trimToNull(match[1]);
+    return trimToNull(match[1])?.toLowerCase() ?? null;
   }
 
   return null;
+}
+
+function isGhPrMergeCommand(segment: string): boolean {
+  return /^gh\s+pr\s+merge(?:\s|$)/i.test(segment);
+}
+
+function isGitMergeCompletionCommand(segment: string): boolean {
+  if (!/^git\s+merge(?:\s|$)/i.test(segment)) {
+    return false;
+  }
+
+  const remainder = segment.replace(/^git\s+merge(?:\s|$)/i, '').trim();
+  if (!remainder) {
+    return true;
+  }
+
+  const firstArg = remainder.match(/^(\S+)/)?.[1]?.toLowerCase() ?? '';
+  return !['--abort', '--continue', '--quit'].includes(firstArg);
 }
 
 export function isMergeCapableCommand(command: string): boolean {
@@ -170,7 +188,9 @@ export function isMergeCapableCommand(command: string): boolean {
     return false;
   }
 
-  return /(?:^|[;&|]\s*|&&\s*)(?:gh\s+pr\s+merge|git\s+merge)\b/i.test(normalized);
+  return normalized
+    .split(/\s*(?:&&|\|\||;|\|)\s*/)
+    .some((segment) => isGhPrMergeCommand(segment) || isGitMergeCompletionCommand(segment));
 }
 
 export function createPostMergeUpdateHook(

--- a/extension/post-merge-update.ts
+++ b/extension/post-merge-update.ts
@@ -113,17 +113,7 @@ async function defaultRunCommand(pi: ExtensionAPI, args: RunCommandArgs): Promis
   });
 }
 
-async function queueIfEligible(
-  state: PostMergeUpdateHookState,
-  resolveRepoContext: (cwd: string) => Promise<RepoContext>,
-  command: string,
-  cwd: string,
-): Promise<void> {
-  if (!isMergeCapableCommand(command)) {
-    return;
-  }
-
-  const repoContext = await resolveRepoContext(cwd);
+function markPendingUpdate(state: PostMergeUpdateHookState, command: string, repoContext: RepoContext): void {
   if (!repoContext.repoRoot || repoContext.repoSlug !== TARGET_REPO_SLUG) {
     return;
   }
@@ -138,6 +128,36 @@ async function queueIfEligible(
   state.pendingPostMergeUpdate = true;
   state.pendingRepoRoot = repoContext.repoRoot;
   state.lastTriggerToken = triggerToken;
+}
+
+async function resolveRepoContextSafe(
+  resolveRepoContext: (cwd: string) => Promise<RepoContext>,
+  cwd: string,
+): Promise<RepoContext | null> {
+  try {
+    return await resolveRepoContext(cwd);
+  } catch {
+    return null;
+  }
+}
+
+async function queueIfEligible(
+  state: PostMergeUpdateHookState,
+  resolveRepoContext: (cwd: string) => Promise<RepoContext>,
+  command: string,
+  cwd: string,
+): Promise<boolean> {
+  if (!isMergeCapableCommand(command)) {
+    return false;
+  }
+
+  const repoContext = await resolveRepoContextSafe(resolveRepoContext, cwd);
+  if (!repoContext?.repoRoot || repoContext.repoSlug !== TARGET_REPO_SLUG) {
+    return false;
+  }
+
+  markPendingUpdate(state, command, repoContext);
+  return true;
 }
 
 export function normalizeGitHubRepoSlug(remoteUrl: string): string | null {
@@ -246,6 +266,11 @@ export function createPostMergeUpdateHook(
         return undefined;
       }
 
+      const repoContext = await resolveRepoContextSafe(resolveRepoContext, event.cwd);
+      if (!repoContext?.repoRoot || repoContext.repoSlug !== TARGET_REPO_SLUG) {
+        return undefined;
+      }
+
       try {
         const result = await runCommand({
           command: event.command,
@@ -254,7 +279,7 @@ export function createPostMergeUpdateHook(
         });
 
         if (result.code === 0) {
-          await queueIfEligible(state, resolveRepoContext, event.command, event.cwd);
+          markPendingUpdate(state, event.command, repoContext);
         }
 
         return {

--- a/extension/post-merge-update.ts
+++ b/extension/post-merge-update.ts
@@ -1,0 +1,293 @@
+import type {
+  AgentEndEvent,
+  ExecResult,
+  ExtensionAPI,
+  ExtensionContext,
+  ToolResultEvent,
+  UserBashEvent,
+  UserBashEventResult,
+} from '@mariozechner/pi-coding-agent';
+
+export const TARGET_REPO_SLUG = 'mfittko/pi-dev-loops';
+export const POST_MERGE_UPDATE_COMMAND = 'pi update git:github.com/mfittko/pi-dev-loops';
+
+const MERGE_COMMAND_TIMEOUT_MS = 15 * 60 * 1000;
+const POST_MERGE_UPDATE_TIMEOUT_MS = 10 * 60 * 1000;
+const REPO_RESOLUTION_TIMEOUT_MS = 5_000;
+
+type RepoContext = {
+  repoRoot: string | null;
+  repoSlug: string | null;
+};
+
+type RunCommandArgs = {
+  command: string;
+  cwd?: string;
+  timeout?: number;
+};
+
+type RunCommandResult = ExecResult;
+
+type PostMergeUpdateHookState = {
+  pendingPostMergeUpdate: boolean;
+  updateInFlight: boolean;
+  lastTriggerToken: string | null;
+  pendingRepoRoot: string | null;
+};
+
+type CreatePostMergeUpdateHookOptions = {
+  resolveRepoContext?: (cwd: string) => Promise<RepoContext>;
+  runCommand?: (args: RunCommandArgs) => Promise<RunCommandResult>;
+};
+
+function trimToNull(value: string | null | undefined): string | null {
+  const trimmed = `${value ?? ''}`.trim();
+  return trimmed ? trimmed : null;
+}
+
+function buildMergeTriggerToken(command: string, repoRoot: string, repoSlug: string): string {
+  return `${repoSlug}\n${repoRoot}\n${command.trim()}`;
+}
+
+function buildShellOutput(result: Pick<RunCommandResult, 'stdout' | 'stderr'>): string {
+  const stdout = `${result.stdout ?? ''}`.trimEnd();
+  const stderr = `${result.stderr ?? ''}`.trimEnd();
+  if (stdout && stderr) {
+    return `${stdout}\n${stderr}`;
+  }
+  return stdout || stderr;
+}
+
+function buildFailureSummary(result: Pick<RunCommandResult, 'stdout' | 'stderr' | 'code'>): string {
+  return trimToNull(result.stderr)
+    ?? trimToNull(result.stdout)
+    ?? `exit code ${result.code}`;
+}
+
+function getBashCommandFromToolResult(event: ToolResultEvent): string | null {
+  if (event.toolName !== 'bash') {
+    return null;
+  }
+  const command = event.input?.command;
+  return typeof command === 'string' ? command : null;
+}
+
+function notify(ctx: ExtensionContext, message: string, level: 'info' | 'warning' | 'error' = 'info'): void {
+  if (ctx.hasUI) {
+    ctx.ui.notify(message, level);
+  }
+}
+
+async function defaultResolveRepoContext(pi: ExtensionAPI, cwd: string): Promise<RepoContext> {
+  const rootResult = await pi.exec('bash', ['-lc', 'git rev-parse --show-toplevel'], {
+    cwd,
+    timeout: REPO_RESOLUTION_TIMEOUT_MS,
+  });
+  if (rootResult.code !== 0) {
+    return { repoRoot: null, repoSlug: null };
+  }
+
+  const repoRoot = trimToNull(rootResult.stdout);
+  if (!repoRoot) {
+    return { repoRoot: null, repoSlug: null };
+  }
+
+  const remoteResult = await pi.exec('bash', ['-lc', 'git config --get remote.origin.url'], {
+    cwd: repoRoot,
+    timeout: REPO_RESOLUTION_TIMEOUT_MS,
+  });
+  if (remoteResult.code !== 0) {
+    return { repoRoot, repoSlug: null };
+  }
+
+  return {
+    repoRoot,
+    repoSlug: normalizeGitHubRepoSlug(remoteResult.stdout),
+  };
+}
+
+async function defaultRunCommand(pi: ExtensionAPI, args: RunCommandArgs): Promise<RunCommandResult> {
+  return pi.exec('bash', ['-lc', args.command], {
+    cwd: args.cwd,
+    timeout: args.timeout,
+  });
+}
+
+async function queueIfEligible(
+  state: PostMergeUpdateHookState,
+  resolveRepoContext: (cwd: string) => Promise<RepoContext>,
+  command: string,
+  cwd: string,
+): Promise<void> {
+  if (!isMergeCapableCommand(command)) {
+    return;
+  }
+
+  const repoContext = await resolveRepoContext(cwd);
+  if (!repoContext.repoRoot || repoContext.repoSlug !== TARGET_REPO_SLUG) {
+    return;
+  }
+
+  const triggerToken = buildMergeTriggerToken(command, repoContext.repoRoot, repoContext.repoSlug);
+  if (state.lastTriggerToken === triggerToken || state.pendingPostMergeUpdate) {
+    state.lastTriggerToken = triggerToken;
+    state.pendingRepoRoot ??= repoContext.repoRoot;
+    return;
+  }
+
+  state.pendingPostMergeUpdate = true;
+  state.pendingRepoRoot = repoContext.repoRoot;
+  state.lastTriggerToken = triggerToken;
+}
+
+export function normalizeGitHubRepoSlug(remoteUrl: string): string | null {
+  const normalized = trimToNull(remoteUrl);
+  if (!normalized) {
+    return null;
+  }
+
+  const patterns = [
+    /^git@github\.com:([^\s]+?)(?:\.git)?$/i,
+    /^https:\/\/github\.com\/([^\s]+?)(?:\.git)?$/i,
+    /^ssh:\/\/git@github\.com\/([^\s]+?)(?:\.git)?$/i,
+    /^git:github\.com\/([^\s]+?)(?:\.git)?$/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = normalized.match(pattern);
+    if (!match) {
+      continue;
+    }
+    return trimToNull(match[1]);
+  }
+
+  return null;
+}
+
+export function isMergeCapableCommand(command: string): boolean {
+  const normalized = command.trim();
+  if (!normalized) {
+    return false;
+  }
+
+  return /(?:^|[;&|]\s*|&&\s*)(?:gh\s+pr\s+merge|git\s+merge)\b/i.test(normalized);
+}
+
+export function createPostMergeUpdateHook(
+  piOrOptions: ExtensionAPI | CreatePostMergeUpdateHookOptions,
+  maybeOptions: CreatePostMergeUpdateHookOptions = {},
+) {
+  const hasPiExec = typeof (piOrOptions as ExtensionAPI)?.exec === 'function';
+  const pi = hasPiExec ? piOrOptions as ExtensionAPI : null;
+  const options = hasPiExec ? maybeOptions : (piOrOptions as CreatePostMergeUpdateHookOptions);
+
+  const resolveRepoContext = options.resolveRepoContext
+    ?? (pi ? ((cwd: string) => defaultResolveRepoContext(pi, cwd)) : null);
+  const runCommand = options.runCommand
+    ?? (pi ? ((args: RunCommandArgs) => defaultRunCommand(pi, args)) : null);
+
+  if (!resolveRepoContext || !runCommand) {
+    throw new Error('createPostMergeUpdateHook requires an ExtensionAPI or explicit resolveRepoContext/runCommand overrides.');
+  }
+
+  const state: PostMergeUpdateHookState = {
+    pendingPostMergeUpdate: false,
+    updateInFlight: false,
+    lastTriggerToken: null,
+    pendingRepoRoot: null,
+  };
+
+  function reset(): void {
+    state.pendingPostMergeUpdate = false;
+    state.updateInFlight = false;
+    state.lastTriggerToken = null;
+    state.pendingRepoRoot = null;
+  }
+
+  return {
+    getState(): PostMergeUpdateHookState {
+      return { ...state };
+    },
+
+    onSessionStart(): void {
+      reset();
+    },
+
+    async onToolResult(event: Pick<ToolResultEvent, 'toolName' | 'input' | 'isError'>, ctx: Pick<ExtensionContext, 'cwd'>): Promise<void> {
+      const command = getBashCommandFromToolResult(event as ToolResultEvent);
+      if (!command || event.isError) {
+        return;
+      }
+      await queueIfEligible(state, resolveRepoContext, command, ctx.cwd);
+    },
+
+    async onUserBash(event: Pick<UserBashEvent, 'command' | 'cwd'>, _ctx?: ExtensionContext): Promise<UserBashEventResult | undefined> {
+      if (!isMergeCapableCommand(event.command)) {
+        return undefined;
+      }
+
+      try {
+        const result = await runCommand({
+          command: event.command,
+          cwd: event.cwd,
+          timeout: MERGE_COMMAND_TIMEOUT_MS,
+        });
+
+        if (result.code === 0) {
+          await queueIfEligible(state, resolveRepoContext, event.command, event.cwd);
+        }
+
+        return {
+          result: {
+            output: buildShellOutput(result),
+            exitCode: result.killed ? undefined : result.code,
+            cancelled: Boolean(result.killed),
+            truncated: false,
+          },
+        };
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        return {
+          result: {
+            output: detail,
+            exitCode: 1,
+            cancelled: false,
+            truncated: false,
+          },
+        };
+      }
+    },
+
+    async onAgentEnd(_event: AgentEndEvent, ctx: Pick<ExtensionContext, 'cwd' | 'hasUI' | 'ui'>): Promise<void> {
+      if (!state.pendingPostMergeUpdate || state.updateInFlight) {
+        return;
+      }
+
+      state.updateInFlight = true;
+      notify(ctx as ExtensionContext, `Post-merge update running: ${POST_MERGE_UPDATE_COMMAND}`, 'info');
+
+      try {
+        const result = await runCommand({
+          command: POST_MERGE_UPDATE_COMMAND,
+          cwd: state.pendingRepoRoot ?? ctx.cwd,
+          timeout: POST_MERGE_UPDATE_TIMEOUT_MS,
+        });
+
+        if (result.code === 0) {
+          notify(ctx as ExtensionContext, `Post-merge update completed: ${POST_MERGE_UPDATE_COMMAND}`, 'info');
+        } else {
+          notify(
+            ctx as ExtensionContext,
+            `Post-merge update failed (warning only): ${buildFailureSummary(result)}`,
+            'warning',
+          );
+        }
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        notify(ctx as ExtensionContext, `Post-merge update failed (warning only): ${detail}`, 'warning');
+      } finally {
+        reset();
+      }
+    },
+  };
+}

--- a/extension/post-merge-update.ts
+++ b/extension/post-merge-update.ts
@@ -187,7 +187,17 @@ export function normalizeGitHubRepoSlug(remoteUrl: string): string | null {
 }
 
 function isGhPrMergeCommand(segment: string): boolean {
-  return /^gh\s+pr\s+merge(?:\s|$)/i.test(segment);
+  if (!/^gh\s+pr\s+merge(?:\s|$)/i.test(segment)) {
+    return false;
+  }
+
+  const remainder = segment.replace(/^gh\s+pr\s+merge(?:\s|$)/i, '').trim();
+  if (!remainder) {
+    return true;
+  }
+
+  const firstArg = remainder.match(/^(\S+)/)?.[1]?.toLowerCase() ?? '';
+  return !['--help', '-h'].includes(firstArg);
 }
 
 function isGitMergeCompletionCommand(segment: string): boolean {
@@ -201,7 +211,7 @@ function isGitMergeCompletionCommand(segment: string): boolean {
   }
 
   const firstArg = remainder.match(/^(\S+)/)?.[1]?.toLowerCase() ?? '';
-  return !['--abort', '--continue', '--quit'].includes(firstArg);
+  return !['--abort', '--continue', '--quit', '--help', '-h'].includes(firstArg);
 }
 
 export function isMergeCapableCommand(command: string): boolean {

--- a/extension/post-merge-update.ts
+++ b/extension/post-merge-update.ts
@@ -121,7 +121,7 @@ function markPendingUpdate(state: PostMergeUpdateHookState, command: string, rep
   }
 
   const triggerToken = buildMergeTriggerToken(command, repoContext.repoRoot, repoContext.repoSlug);
-  if (state.lastTriggerToken === triggerToken || state.pendingPostMergeUpdate) {
+  if (state.pendingPostMergeUpdate) {
     state.lastTriggerToken = triggerToken;
     state.pendingRepoRoot ??= repoContext.repoRoot;
     return;

--- a/extension/post-merge-update.ts
+++ b/extension/post-merge-update.ts
@@ -58,10 +58,12 @@ function buildShellOutput(result: Pick<RunCommandResult, 'stdout' | 'stderr'>): 
   return stdout || stderr;
 }
 
-function buildFailureSummary(result: Pick<RunCommandResult, 'stdout' | 'stderr' | 'code'>): string {
+function buildFailureSummary(result: Pick<RunCommandResult, 'stdout' | 'stderr' | 'code' | 'killed'>): string {
   return trimToNull(result.stderr)
     ?? trimToNull(result.stdout)
-    ?? `exit code ${result.code}`;
+    ?? (result.killed
+      ? 'command was killed before completing'
+      : (typeof result.code === 'number' ? `exit code ${result.code}` : 'exit code unavailable'));
 }
 
 function getBashCommandFromToolResult(event: ToolResultEvent): string | null {
@@ -278,7 +280,7 @@ export function createPostMergeUpdateHook(
           timeout: MERGE_COMMAND_TIMEOUT_MS,
         });
 
-        if (result.code === 0) {
+        if (result.code === 0 && !result.killed) {
           markPendingUpdate(state, event.command, repoContext);
         }
 
@@ -318,7 +320,7 @@ export function createPostMergeUpdateHook(
           timeout: POST_MERGE_UPDATE_TIMEOUT_MS,
         });
 
-        if (result.code === 0) {
+        if (result.code === 0 && !result.killed) {
           notify(ctx as ExtensionContext, `Post-merge update completed: ${POST_MERGE_UPDATE_COMMAND}`, 'info');
         } else {
           notify(

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "verify": "npm test && npm run test:dev-loop",
     "test": "npm run test:assets && npm run test:extension && npm run test:scripts && npm run test:core && npm run test:docs",
     "test:assets": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/dev-loop-init-phase-smoke.test.mjs test/public-facade-doc-contracts.test.mjs test/review-doc-contracts.test.mjs test/issue-intake-doc-contracts.test.mjs test/copilot-review-doc-contracts.test.mjs test/planning-doc-contracts.test.mjs test/ui-validation-contract.test.mjs test/ui-smoke-harness-contract.test.mjs test/ui-artifact-contract.test.mjs test/ui-designer-review-loop-contract.test.mjs test/workflow-handoff-template-contract.test.mjs",
-    "test:extension": "node --import tsx --test --test-reporter ./test/failure-summary-reporter.mjs test/extension-checks.test.mjs test/extension-command-contract.test.mjs test/extension-package-contract.test.mjs test/dev-loops-core.test.mjs test/dev-loops-cli.test.mjs",
+    "test:extension": "node --import tsx --test --test-reporter ./test/failure-summary-reporter.mjs test/extension-checks.test.mjs test/extension-post-merge-update.test.mjs test/extension-command-contract.test.mjs test/extension-package-contract.test.mjs test/dev-loops-core.test.mjs test/dev-loops-cli.test.mjs",
     "test:scripts": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/github/*.test.mjs test/loop/*.test.mjs test/docs/*.test.mjs",
     "test:core": "node --test --test-reporter ./test/failure-summary-reporter.mjs packages/core/test/*.test.mjs",
     "test:dev-loop": "node --test --test-reporter ./test/failure-summary-reporter.mjs skills/dev-loop/scripts/dev-mode-context.test.mjs skills/dev-loop/scripts/render-template.test.mjs",

--- a/test/extension-package-contract.test.mjs
+++ b/test/extension-package-contract.test.mjs
@@ -16,6 +16,7 @@ test("package metadata exposes the extension entrypoint and root extension test 
   assert.equal(typeof packageJson.scripts["test:extension"], "string");
   assert.match(packageJson.scripts["test:extension"], /--import tsx/);
   assert.match(packageJson.scripts["test:extension"], /extension-checks/);
+  assert.match(packageJson.scripts["test:extension"], /extension-post-merge-update/);
   assert.match(packageJson.scripts["test:extension"], /extension-command-contract/);
   assert.match(packageJson.scripts["test:extension"], /extension-package-contract/);
   assert.equal(packageJson.dependencies.mermaid, "11.15.0");

--- a/test/extension-post-merge-update.test.mjs
+++ b/test/extension-post-merge-update.test.mjs
@@ -172,10 +172,28 @@ test("non-merge commands and non-target repos never trigger the update", async (
   const { ctx } = createUiCalls();
 
   await hook.onToolResult({ toolName: "bash", input: { command: "git status" }, isError: false }, ctx);
-  await hook.onUserBash({ command: "git merge feature", cwd: "/repo" }, ctx);
+  const result = await hook.onUserBash({ command: "git merge feature", cwd: "/repo" }, ctx);
   await hook.onAgentEnd({ type: "agent_end", messages: [] }, ctx);
 
-  assert.deepEqual(calls, [{ command: "git merge feature", cwd: "/repo" }]);
+  assert.equal(result, undefined);
+  assert.deepEqual(calls, []);
+  assert.equal(hook.getState().pendingPostMergeUpdate, false);
+});
+
+
+test("repo-resolution failures are swallowed so the hook stays best-effort", async () => {
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async () => {
+      throw new Error("git unavailable");
+    },
+    runCommand: async () => ({ code: 0, stdout: "ok", stderr: "", killed: false }),
+  });
+  const { ctx } = createUiCalls();
+
+  await hook.onToolResult({ toolName: "bash", input: { command: "gh pr merge 373" }, isError: false }, ctx);
+  const result = await hook.onUserBash({ command: "git merge origin/main", cwd: "/repo" }, ctx);
+
+  assert.equal(result, undefined);
   assert.equal(hook.getState().pendingPostMergeUpdate, false);
 });
 

--- a/test/extension-post-merge-update.test.mjs
+++ b/test/extension-post-merge-update.test.mjs
@@ -46,6 +46,7 @@ function createPiDouble() {
 test("normalizeGitHubRepoSlug recognizes GitHub remote variants", () => {
   assert.equal(normalizeGitHubRepoSlug("git@github.com:mfittko/pi-dev-loops.git"), TARGET_REPO_SLUG);
   assert.equal(normalizeGitHubRepoSlug("https://github.com/mfittko/pi-dev-loops.git"), TARGET_REPO_SLUG);
+  assert.equal(normalizeGitHubRepoSlug("git@github.com:Mfittko/Pi-Dev-Loops.git"), TARGET_REPO_SLUG);
   assert.equal(normalizeGitHubRepoSlug("ssh://git@github.com/mfittko/pi-dev-loops.git"), TARGET_REPO_SLUG);
   assert.equal(normalizeGitHubRepoSlug("git:github.com/mfittko/pi-dev-loops"), TARGET_REPO_SLUG);
   assert.equal(normalizeGitHubRepoSlug("https://gitlab.com/mfittko/pi-dev-loops.git"), null);
@@ -55,6 +56,11 @@ test("isMergeCapableCommand only matches bounded merge commands", () => {
   assert.equal(isMergeCapableCommand("gh pr merge 373 --squash --delete-branch"), true);
   assert.equal(isMergeCapableCommand("git merge origin/main"), true);
   assert.equal(isMergeCapableCommand("npm test && gh pr merge 373"), true);
+  assert.equal(isMergeCapableCommand("git merge --abort"), false);
+  assert.equal(isMergeCapableCommand("git merge --continue"), false);
+  assert.equal(isMergeCapableCommand("git merge --quit"), false);
+  assert.equal(isMergeCapableCommand("git merge-base HEAD origin/main"), false);
+  assert.equal(isMergeCapableCommand("git merge-tree HEAD origin/main"), false);
   assert.equal(isMergeCapableCommand("git status"), false);
   assert.equal(isMergeCapableCommand("echo gh pr merge"), false);
 });

--- a/test/extension-post-merge-update.test.mjs
+++ b/test/extension-post-merge-update.test.mjs
@@ -59,6 +59,10 @@ test("isMergeCapableCommand only matches bounded merge commands", () => {
   assert.equal(isMergeCapableCommand("gh pr merge 373 --squash --delete-branch"), true);
   assert.equal(isMergeCapableCommand("git merge origin/main"), true);
   assert.equal(isMergeCapableCommand("npm test && gh pr merge 373"), true);
+  assert.equal(isMergeCapableCommand("gh pr merge --help"), false);
+  assert.equal(isMergeCapableCommand("gh pr merge -h"), false);
+  assert.equal(isMergeCapableCommand("git merge --help"), false);
+  assert.equal(isMergeCapableCommand("git merge -h"), false);
   assert.equal(isMergeCapableCommand("git merge --abort"), false);
   assert.equal(isMergeCapableCommand("git merge --continue"), false);
   assert.equal(isMergeCapableCommand("git merge --quit"), false);

--- a/test/extension-post-merge-update.test.mjs
+++ b/test/extension-post-merge-update.test.mjs
@@ -1,5 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp } from "node:fs/promises";
 
 import registerExtension from "../extension/index.ts";
 import {
@@ -234,24 +237,53 @@ test("update failure is warning-only and leaves the session healthy", async () =
   ]);
 });
 
-test("session_start resets post-merge hook state and extension registers lifecycle listeners", async () => {
-  const pi = createPiDouble();
+
+test("killed post-merge updates surface a clear warning message", async () => {
   const hook = createPostMergeUpdateHook({
     resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: TARGET_REPO_SLUG }),
-    runCommand: async () => ({ code: 0, stdout: "", stderr: "", killed: false }),
+    runCommand: async () => ({ code: 0, stdout: "", stderr: "", killed: true }),
   });
-  registerExtension(pi, { postMergeUpdateHook: hook });
+  const { ctx, notifications } = createUiCalls();
 
-  assert.equal(typeof pi.events.get("session_start"), "function");
-  assert.equal(typeof pi.events.get("tool_result"), "function");
-  assert.equal(typeof pi.events.get("user_bash"), "function");
-  assert.equal(typeof pi.events.get("agent_end"), "function");
-  assert.equal(pi.registeredCommands.has("dev-loops"), true);
+  await hook.onToolResult({ toolName: "bash", input: { command: "gh pr merge 373" }, isError: false }, ctx);
+  await hook.onAgentEnd({ type: "agent_end", messages: [] }, ctx);
 
-  const { ctx } = createUiCalls();
-  await pi.events.get("tool_result")({ toolName: "bash", input: { command: "gh pr merge 373" }, isError: false }, ctx);
-  assert.equal(hook.getState().pendingPostMergeUpdate, true);
+  assert.deepEqual(notifications, [
+    { message: `Post-merge update running: ${POST_MERGE_UPDATE_COMMAND}`, level: "info" },
+    { message: "Post-merge update failed (warning only): command was killed before completing", level: "warning" },
+  ]);
+});
 
-  await pi.events.get("session_start")({}, ctx);
-  assert.equal(hook.getState().pendingPostMergeUpdate, false);
+test("session_start resets post-merge hook state and extension registers lifecycle listeners", async () => {
+  const previousHome = process.env.HOME;
+  const tempHome = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-post-merge-home-"));
+  process.env.HOME = tempHome;
+
+  try {
+    const pi = createPiDouble();
+    const hook = createPostMergeUpdateHook({
+      resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: TARGET_REPO_SLUG }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "", killed: false }),
+    });
+    registerExtension(pi, { postMergeUpdateHook: hook });
+
+    assert.equal(typeof pi.events.get("session_start"), "function");
+    assert.equal(typeof pi.events.get("tool_result"), "function");
+    assert.equal(typeof pi.events.get("user_bash"), "function");
+    assert.equal(typeof pi.events.get("agent_end"), "function");
+    assert.equal(pi.registeredCommands.has("dev-loops"), true);
+
+    const { ctx } = createUiCalls();
+    await pi.events.get("tool_result")({ toolName: "bash", input: { command: "gh pr merge 373" }, isError: false }, ctx);
+    assert.equal(hook.getState().pendingPostMergeUpdate, true);
+
+    await pi.events.get("session_start")({}, ctx);
+    assert.equal(hook.getState().pendingPostMergeUpdate, false);
+  } finally {
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+  }
 });

--- a/test/extension-post-merge-update.test.mjs
+++ b/test/extension-post-merge-update.test.mjs
@@ -1,0 +1,233 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import registerExtension from "../extension/index.ts";
+import {
+  POST_MERGE_UPDATE_COMMAND,
+  TARGET_REPO_SLUG,
+  createPostMergeUpdateHook,
+  isMergeCapableCommand,
+  normalizeGitHubRepoSlug,
+} from "../extension/post-merge-update.ts";
+
+function createUiCalls() {
+  const notifications = [];
+  return {
+    notifications,
+    ctx: {
+      hasUI: true,
+      cwd: "/repo",
+      ui: {
+        notify(message, level = "info") {
+          notifications.push({ message, level });
+        },
+        setStatus() {},
+        setWidget() {},
+      },
+    },
+  };
+}
+
+function createPiDouble() {
+  const events = new Map();
+  const registeredCommands = new Map();
+  return {
+    on(event, handler) {
+      events.set(event, handler);
+    },
+    registerCommand(name, config) {
+      registeredCommands.set(name, config);
+    },
+    events,
+    registeredCommands,
+  };
+}
+
+test("normalizeGitHubRepoSlug recognizes GitHub remote variants", () => {
+  assert.equal(normalizeGitHubRepoSlug("git@github.com:mfittko/pi-dev-loops.git"), TARGET_REPO_SLUG);
+  assert.equal(normalizeGitHubRepoSlug("https://github.com/mfittko/pi-dev-loops.git"), TARGET_REPO_SLUG);
+  assert.equal(normalizeGitHubRepoSlug("ssh://git@github.com/mfittko/pi-dev-loops.git"), TARGET_REPO_SLUG);
+  assert.equal(normalizeGitHubRepoSlug("git:github.com/mfittko/pi-dev-loops"), TARGET_REPO_SLUG);
+  assert.equal(normalizeGitHubRepoSlug("https://gitlab.com/mfittko/pi-dev-loops.git"), null);
+});
+
+test("isMergeCapableCommand only matches bounded merge commands", () => {
+  assert.equal(isMergeCapableCommand("gh pr merge 373 --squash --delete-branch"), true);
+  assert.equal(isMergeCapableCommand("git merge origin/main"), true);
+  assert.equal(isMergeCapableCommand("npm test && gh pr merge 373"), true);
+  assert.equal(isMergeCapableCommand("git status"), false);
+  assert.equal(isMergeCapableCommand("echo gh pr merge"), false);
+});
+
+test("successful bash-tool gh pr merge queues and flushes one post-merge update on agent_end", async () => {
+  const calls = [];
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: TARGET_REPO_SLUG }),
+    runCommand: async ({ command, cwd }) => {
+      calls.push({ command, cwd });
+      return { code: 0, stdout: "updated", stderr: "", killed: false };
+    },
+  });
+  const { ctx, notifications } = createUiCalls();
+
+  await hook.onToolResult({
+    toolName: "bash",
+    input: { command: "gh pr merge 373 --squash --delete-branch" },
+    isError: false,
+  }, ctx);
+
+  assert.equal(hook.getState().pendingPostMergeUpdate, true);
+  await hook.onAgentEnd({ type: "agent_end", messages: [] }, ctx);
+
+  assert.deepEqual(calls, [{ command: POST_MERGE_UPDATE_COMMAND, cwd: "/repo" }]);
+  assert.deepEqual(notifications, [
+    { message: `Post-merge update running: ${POST_MERGE_UPDATE_COMMAND}`, level: "info" },
+    { message: `Post-merge update completed: ${POST_MERGE_UPDATE_COMMAND}`, level: "info" },
+  ]);
+  assert.equal(hook.getState().pendingPostMergeUpdate, false);
+
+  await hook.onAgentEnd({ type: "agent_end", messages: [] }, ctx);
+  assert.equal(calls.length, 1);
+});
+
+test("successful user_bash git merge queues and flushes one update", async () => {
+  const calls = [];
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: TARGET_REPO_SLUG }),
+    runCommand: async ({ command, cwd }) => {
+      calls.push({ command, cwd });
+      if (command === "git merge origin/main") {
+        return { code: 0, stdout: "Already up to date.", stderr: "", killed: false };
+      }
+      return { code: 0, stdout: "updated", stderr: "", killed: false };
+    },
+  });
+  const { ctx } = createUiCalls();
+
+  const result = await hook.onUserBash({ command: "git merge origin/main", cwd: "/repo" }, ctx);
+  assert.deepEqual(result, {
+    result: {
+      output: "Already up to date.",
+      exitCode: 0,
+      cancelled: false,
+      truncated: false,
+    },
+  });
+  assert.equal(hook.getState().pendingPostMergeUpdate, true);
+
+  await hook.onAgentEnd({ type: "agent_end", messages: [] }, ctx);
+  assert.deepEqual(calls, [
+    { command: "git merge origin/main", cwd: "/repo" },
+    { command: POST_MERGE_UPDATE_COMMAND, cwd: "/repo" },
+  ]);
+});
+
+test("failed merge commands do not trigger the post-merge update", async () => {
+  const calls = [];
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: TARGET_REPO_SLUG }),
+    runCommand: async ({ command, cwd }) => {
+      calls.push({ command, cwd });
+      return { code: 1, stdout: "", stderr: "merge failed", killed: false };
+    },
+  });
+  const { ctx } = createUiCalls();
+
+  const result = await hook.onUserBash({ command: "git merge conflict-branch", cwd: "/repo" }, ctx);
+  assert.deepEqual(result, {
+    result: {
+      output: "merge failed",
+      exitCode: 1,
+      cancelled: false,
+      truncated: false,
+    },
+  });
+  assert.equal(hook.getState().pendingPostMergeUpdate, false);
+
+  await hook.onToolResult({
+    toolName: "bash",
+    input: { command: "gh pr merge 373" },
+    isError: true,
+  }, ctx);
+  await hook.onAgentEnd({ type: "agent_end", messages: [] }, ctx);
+
+  assert.deepEqual(calls, [{ command: "git merge conflict-branch", cwd: "/repo" }]);
+});
+
+test("non-merge commands and non-target repos never trigger the update", async () => {
+  const calls = [];
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: "other/repo" }),
+    runCommand: async ({ command, cwd }) => {
+      calls.push({ command, cwd });
+      return { code: 0, stdout: "ok", stderr: "", killed: false };
+    },
+  });
+  const { ctx } = createUiCalls();
+
+  await hook.onToolResult({ toolName: "bash", input: { command: "git status" }, isError: false }, ctx);
+  await hook.onUserBash({ command: "git merge feature", cwd: "/repo" }, ctx);
+  await hook.onAgentEnd({ type: "agent_end", messages: [] }, ctx);
+
+  assert.deepEqual(calls, [{ command: "git merge feature", cwd: "/repo" }]);
+  assert.equal(hook.getState().pendingPostMergeUpdate, false);
+});
+
+test("multiple merge signals in one turn still run only one update", async () => {
+  const calls = [];
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: TARGET_REPO_SLUG }),
+    runCommand: async ({ command, cwd }) => {
+      calls.push({ command, cwd });
+      return { code: 0, stdout: "ok", stderr: "", killed: false };
+    },
+  });
+  const { ctx } = createUiCalls();
+
+  await hook.onToolResult({ toolName: "bash", input: { command: "gh pr merge 373" }, isError: false }, ctx);
+  await hook.onToolResult({ toolName: "bash", input: { command: "git merge origin/main" }, isError: false }, ctx);
+  assert.equal(hook.getState().pendingPostMergeUpdate, true);
+
+  await hook.onAgentEnd({ type: "agent_end", messages: [] }, ctx);
+  assert.deepEqual(calls, [{ command: POST_MERGE_UPDATE_COMMAND, cwd: "/repo" }]);
+});
+
+test("update failure is warning-only and leaves the session healthy", async () => {
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: TARGET_REPO_SLUG }),
+    runCommand: async () => ({ code: 1, stdout: "", stderr: "permission denied", killed: false }),
+  });
+  const { ctx, notifications } = createUiCalls();
+
+  await hook.onToolResult({ toolName: "bash", input: { command: "gh pr merge 373" }, isError: false }, ctx);
+  await hook.onAgentEnd({ type: "agent_end", messages: [] }, ctx);
+
+  assert.equal(hook.getState().pendingPostMergeUpdate, false);
+  assert.equal(hook.getState().updateInFlight, false);
+  assert.deepEqual(notifications, [
+    { message: `Post-merge update running: ${POST_MERGE_UPDATE_COMMAND}`, level: "info" },
+    { message: "Post-merge update failed (warning only): permission denied", level: "warning" },
+  ]);
+});
+
+test("session_start resets post-merge hook state and extension registers lifecycle listeners", async () => {
+  const pi = createPiDouble();
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: TARGET_REPO_SLUG }),
+    runCommand: async () => ({ code: 0, stdout: "", stderr: "", killed: false }),
+  });
+  registerExtension(pi, { postMergeUpdateHook: hook });
+
+  assert.equal(typeof pi.events.get("session_start"), "function");
+  assert.equal(typeof pi.events.get("tool_result"), "function");
+  assert.equal(typeof pi.events.get("user_bash"), "function");
+  assert.equal(typeof pi.events.get("agent_end"), "function");
+  assert.equal(pi.registeredCommands.has("dev-loops"), true);
+
+  const { ctx } = createUiCalls();
+  await pi.events.get("tool_result")({ toolName: "bash", input: { command: "gh pr merge 373" }, isError: false }, ctx);
+  assert.equal(hook.getState().pendingPostMergeUpdate, true);
+
+  await pi.events.get("session_start")({}, ctx);
+  assert.equal(hook.getState().pendingPostMergeUpdate, false);
+});


### PR DESCRIPTION
## Summary
- add a bounded extension-owned post-merge helper in `extension/post-merge-update.ts`
- register `tool_result`, `user_bash`, `agent_end`, and `session_start` listeners from `extension/index.ts`
- queue one `pi update git:github.com/mfittko/pi-dev-loops` after successful in-session `gh pr merge ...` or `git merge ...` inside `mfittko/pi-dev-loops`
- keep update failures warning-only and document the hook briefly in `extension/README.md`
- add focused extension coverage and wire it into `npm run test:extension`

## Scope / context
Issue #373 asks for the extension-hook route rather than a loop-only post-merge step. This PR keeps `extension/index.ts` thin and moves the hook logic into a testable helper module.

## Acceptance criteria
- [x] extension hook is the chosen route
- [x] successful `gh pr merge` and `git merge` inside Pi queue a post-merge update path
- [x] only one `pi update git:github.com/mfittko/pi-dev-loops` runs per merge completion boundary
- [x] the hook is scoped to `mfittko/pi-dev-loops`
- [x] update failure is warning-only and does not break the session
- [x] `npm run test:extension` passes
- [x] `npm test` passes

## Definition of done
- helper logic lives in `extension/post-merge-update.ts`
- extension lifecycle listeners are registered and exercised by tests
- package test wiring includes the new extension test file
- repo verification passes locally via `npm run verify`

## Non-goals
- generic git hook framework
- external/background merge detection outside the active Pi session
- triggering updates on arbitrary git state changes
- adding a second loop-only post-merge path

## Validation
- `npm run test:extension`
- `npm test`
- `npm run verify`

Closes #373
