### PR TITLE
Add canonical worktree usage guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,12 @@ These skills may be provided repo-locally or globally; this contract does not as
 - In PR review/fix loops, do not stop at local code changes alone: after an accepted fix is pushed, reply to the addressed review comments with the resolving commit reference and resolve the corresponding threads when genuinely satisfied.
 - Do not merge directly to `main` without review when a PR-based remote loop is practical.
 
+### Worktree / checkout isolation
+
+- Canonical guidance lives in [Worktree Usage Guidance](docs/worktree-guidance.md).
+- Create or reuse worktrees under `tmp/worktrees/<issue-or-branch-slug>/` for mutating local work, and reserve the main checkout for inspection/control by default.
+- Check `git worktree list` before creating a new worktree, and remove merged/abandoned worktrees with `git worktree remove --force <path>` followed by `git worktree prune`.
+
 ## Standard refinement chain pattern
 
 Use this pattern whenever the work is refinement, comparison, review, or synthesis rather than implementation.

--- a/agents/coordinator.agent.md
+++ b/agents/coordinator.agent.md
@@ -23,7 +23,7 @@ Default operating mode:
 - DO NOT push unfinished, unverified, or ambiguous work.
 - DO NOT treat a task as complete until the pull request is opened, or an exact blocker to opening it is reported along with a PR-ready branch, title, and summary, and the required documentation is ready.
 - DO NOT lose track of branch, worktree, or task ownership.
-- ONLY use worktrees when they improve isolation, parallelism, or branch hygiene.
+- Default to dedicated worktrees for mutating local work, and use the main checkout only as an explicit fallback when worktrees are unavailable.
 
 ## Responsibilities
 - Read plan documents and convert them into concrete implementation tasks.
@@ -37,7 +37,7 @@ Default operating mode:
 - Receive RFC escalations from the refiner when phase refinement surfaces an RFC-worthy technical decision.
 - Act as the coordinator-side receiving boundary and decision owner for that escalation rather than leaving the refiner to guess through it.
 - When an RFC discussion is needed, use the minimum named team boundary of: lead dev, specialized dev, and systems architect.
-- Use git branches and worktrees when parallel execution or isolation is useful.
+- Use the canonical worktree guidance in [Worktree Usage Guidance](../docs/worktree-guidance.md): prefer create-or-reuse worktrees under `tmp/worktrees/<issue-or-branch-slug>/` for mutating local work.
 - Track task status until each delegated unit is complete and incorporated into a PR-ready milestone.
 - Ensure draft PRs are opened early enough for visibility, and only mark them ready for review after scoped verification is complete.
 - Treat the draft-to-ready transition as the normal trigger point for automatic Copilot review when the repository feature is enabled. After marking a PR ready, wait for the expected Copilot review to post and inspect/respond to its comments before merging. Report clearly when that GitHub setting is not available, not enabled, delayed, or blocked by tooling/rate limits.
@@ -48,7 +48,7 @@ Default operating mode:
 1. Read the relevant plan, epic, or implementation request and identify deliverables, constraints, and missing assumptions.
 2. Break the work into small execution units with explicit acceptance criteria, dependencies, and a recommended execution order.
 3. When a refiner escalates an RFC-worthy technical decision, treat that handoff as a coordination decision point: receive the escalation, decide whether RFC treatment is actually needed, and route the discussion to the named RFC team boundary of lead dev, specialized dev, and systems architect.
-4. Decide whether each unit should run in the current worktree or in a dedicated git worktree and task branch.
+4. Check for an existing matching worktree first, then decide whether to reuse it or create a dedicated git worktree and task branch under `tmp/worktrees/<issue-or-branch-slug>/`; only fall back to the current checkout when worktrees are unavailable.
 5. Delegate each unit to the most appropriate subagent with focused context: relevant files, exact objective, constraints, verification expectations, and expected output. For review delegations, pass a compact written briefing instead of relying on inherited conversation state. Prefer dedicated specialist agents over recursively invoking the coordinator.
 6. Collect results, review whether the task is actually complete, and resolve coordination gaps before moving to the next dependent task.
 7. Run or require appropriate verification before declaring a task done.
@@ -59,10 +59,13 @@ Default operating mode:
 12. Return a concise coordination summary: task breakdown, delegation decisions, branch/worktree mapping, completion state, PR status, review-subagent status, and anything still blocked.
 
 ## Worktree Policy
-- Prefer the current working tree for a single small task with low collision risk.
-- Prefer dedicated worktrees for parallel tasks, risky refactors, or when multiple subagents need isolation.
-- Name branches and worktrees after the task or story when possible.
-- Keep a clear mapping between task, branch, worktree path, and owning subagent.
+- Follow the canonical repo guidance in [Worktree Usage Guidance](../docs/worktree-guidance.md).
+- Before creating a new worktree, run `git worktree list` and reuse an existing matching branch/worktree when practical.
+- Create new worktrees under `tmp/worktrees/<issue-or-branch-slug>/`, typically from `origin/main`.
+- Treat the main checkout as inspection/control space by default, not the normal mutation surface.
+- Name branches and worktrees after the task or story when possible, and keep a clear mapping between task, branch, worktree path, and owning subagent.
+- After merge or abandonment, remove the worktree with `git worktree remove --force <path>` and run `git worktree prune`.
+- If worktrees are unavailable, say so explicitly and fall back to a dedicated branch in the current checkout.
 
 ## Git Policy
 - Default to one task branch per delegated implementation unit.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ Start here for repository documentation.
 - [Copilot Loop State Graph](./copilot-loop-state-graph.md)
 - [Reviewer Loop State Graph](./reviewer-loop-state-graph.md)
 - [Gate Review Comment Contract](./gate-review-comment-contract.md)
+- [Worktree Usage Guidance](./worktree-guidance.md) — canonical local checkout isolation and cleanup rules
 - [Steering Contract](./steering-contract.md)
 - [UI Validation Contract](./ui-validation-contract.md)
 - [UI Smoke Harness](./ui-smoke-harness.md)

--- a/docs/worktree-guidance.md
+++ b/docs/worktree-guidance.md
@@ -1,0 +1,94 @@
+# Worktree usage guidance
+
+## Purpose and scope
+
+This document is the canonical repo-level owner for local worktree usage guidance in
+`pi-dev-loops`.
+
+Use it to keep local mutation work isolated, predictable, and easy to clean up.
+This guidance covers where worktrees live, when to create or reuse them, how to
+handle dependencies inside them, and how to clean them up after the work is done.
+It does not add new automation.
+
+## Canonical location and naming
+
+- Create local worktrees under `tmp/worktrees/<issue-or-branch-slug>/`.
+- Prefer a stable slug derived from the active issue or branch, such as
+  `issue-374-worktree-guidance`.
+- Treat this as the canonical location for repo-local worktrees.
+- Deprecate ad hoc locations such as `tmp/copilot-loop/`, repo-root `worktrees/`,
+  and `/private/tmp/...` for normal repository worktree usage.
+
+## Default rule: use a worktree for mutating local work
+
+- Do not use the main checkout as the default mutation surface.
+- Reserve the main checkout for inspection, control, and lightweight status checks.
+- For non-trivial local edits, PR follow-up, or delegated/parallel work, create or
+  reuse a dedicated git worktree first.
+- The default creation flow should start from `origin/main`.
+
+## Create or reuse flow
+
+1. Before creating anything, run `git worktree list`.
+2. Reuse an existing matching branch/worktree when the path and branch already fit
+   the task.
+3. When no matching worktree exists, create one in the canonical location, for
+   example:
+
+   ```sh
+   git worktree add -b <branch> tmp/worktrees/<issue-or-branch-slug> origin/main
+   ```
+
+4. Do the local editing, validation, commit, and PR follow-up work from that
+   worktree rather than from the main checkout.
+
+## Dependency and install expectations
+
+- If the worktree needs dependencies, or its installed state is stale, run
+  `npm install` or `npm ci` inside the worktree.
+- Do not assume the main checkout's `node_modules` are present or valid for a
+  separate worktree.
+- Re-run worktree-local installs when the dependency state is missing or clearly
+  out of date for the branch you are working on.
+
+## Coordination and collision checks
+
+- Always check `git worktree list` before creating a new worktree.
+- Reuse an existing matching worktree when practical instead of creating a second
+  path for the same branch.
+- Avoid branch-name and filesystem-path collisions by checking both branch intent
+  and target path before `git worktree add`.
+- When multiple agents or operators may touch the same issue, record which branch
+  and worktree path are already in use before starting new mutation work.
+
+## Cleanup and prune flow
+
+- After a PR is merged or the work is abandoned, remove the worktree with:
+
+  ```sh
+  git worktree remove --force <path>
+  ```
+
+- After removal, run:
+
+  ```sh
+  git worktree prune
+  ```
+
+- Cleanup should happen promptly after merge so stale worktrees do not accumulate
+  under `tmp/worktrees/`.
+
+## Fallback when worktrees are unavailable
+
+- If `git worktree` is unavailable or the local environment cannot create a
+  worktree, say so explicitly.
+- In that fallback case, use a dedicated branch in the current checkout instead of
+  failing closed.
+- Even in fallback mode, treat the current checkout as an exception path rather
+  than the normal default for mutating local work.
+
+## Non-goals
+
+- No new worktree automation scripts.
+- No runtime behavior changes to loop helpers.
+- No expansion of this guidance into a second backlog or planning system.

--- a/test/planning-doc-contracts.test.mjs
+++ b/test/planning-doc-contracts.test.mjs
@@ -152,3 +152,45 @@ test("local workflow docs define tracker-backed local canonicality and no-dup ru
     /localPhaseDocAllowed: false/i,
   ], "scripts/README.md");
 });
+
+test("worktree guidance docs define the canonical checkout-isolation contract", async () => {
+  const [worktreeGuidance, agentsDoc, docsIndex, coordinatorAgent] = await Promise.all([
+    readRepo("docs/worktree-guidance.md"),
+    readRepo("AGENTS.md"),
+    readRepo("docs/index.md"),
+    readRepo("agents/coordinator.agent.md"),
+  ]);
+
+  assertMatchesAll(worktreeGuidance, [
+    /## Purpose and scope/i,
+    /## Canonical location and naming/i,
+    /## Default rule: use a worktree for mutating local work/i,
+    /## Create or reuse flow/i,
+    /## Dependency and install expectations/i,
+    /## Coordination and collision checks/i,
+    /## Cleanup and prune flow/i,
+    /## Fallback when worktrees are unavailable/i,
+    /## Non-goals/i,
+    /tmp\/worktrees\//i,
+    /git worktree list/i,
+    /origin\/main/i,
+    /npm install|npm ci/i,
+    /git worktree remove --force/i,
+    /git worktree prune/i,
+    /worktrees are unavailable/i,
+  ], "docs/worktree-guidance.md");
+
+  assert.match(agentsDoc, /docs\/worktree-guidance\.md/i);
+  assert.match(docsIndex, /worktree-guidance\.md/i);
+
+  assertMatchesAll(coordinatorAgent, [
+    /docs\/worktree-guidance\.md/i,
+    /tmp\/worktrees\/<issue-or-branch-slug>\//i,
+    /git worktree list/i,
+    /git worktree remove --force/i,
+    /git worktree prune/i,
+    /worktrees are unavailable/i,
+  ], "agents/coordinator.agent.md");
+  assert.doesNotMatch(coordinatorAgent, /ONLY use worktrees when they improve isolation/i);
+  assert.doesNotMatch(coordinatorAgent, /Prefer the current working tree for a single small task/i);
+});


### PR DESCRIPTION
## Summary

- add `docs/worktree-guidance.md` as the canonical repo-level worktree guidance doc
- add short pointers in `AGENTS.md`, `docs/index.md`, and `agents/coordinator.agent.md`
- add a docs contract test that locks the new guidance surface

## Scope/context

Closes #374.

This is a docs/prompt-contract refinement slice only. It standardizes where worktrees
belong, when to create or reuse them, how to handle worktree-local installs, and how
to clean them up after merge or abandonment.

## Acceptance criteria

- canonical guidance lives in `docs/worktree-guidance.md`
- `AGENTS.md`, `docs/index.md`, and `agents/coordinator.agent.md` point to or align with that guidance
- guidance covers location, default use rule, dependency handling, collision avoidance, cleanup, and fallback behavior
- a docs contract test locks the guidance surface
- `npm run test:assets` passes

## Definition of done

- required worktree guidance headings are present in `docs/worktree-guidance.md`
- the doc mentions `tmp/worktrees/`, `git worktree list`, `origin/main`, `npm install`/`npm ci`, `git worktree remove --force`, and `git worktree prune`
- AGENTS and coordinator guidance no longer contradict the canonical worktree rule
- docs index links to the new guidance doc

## Non-goals

- no new worktree automation scripts
- no runtime behavior changes to loop helpers
- no README expansion beyond the existing landing-page posture
