### PR TITLE
docs: reconcile phase 7 vs phase 8 truth (#332)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ These skills may be provided repo-locally or globally; this contract does not as
 - Work test-first for all non-trivial logic.
 - Maintain at least 90% coverage for lines, statements, functions, and branches.
 - Implement one phase at a time.
+- If durable repo docs explicitly record a reprioritization exception, follow [Implementation State](docs/IMPLEMENTATION_STATE.md) and the active phase doc as the canonical current-phase source rather than assuming numeric phase order alone.
 - Use fan-out / fan-in / review / merge before implementing each phase.
 - Default phase and issue refinement to multiple parallel variants before converging on a merged plan; do not rely on a single-plan synthesis when fan-out is practical.
 - For refinement work, follow the dedicated **Standard refinement chain pattern** section below.

--- a/PLAN.md
+++ b/PLAN.md
@@ -134,26 +134,37 @@ The initial foundation phases are complete:
 
 See [Implementation State](docs/IMPLEMENTATION_STATE.md) for the current execution snapshot.
 
-### Current next phase
+### Current active phase
 
-#### Phase 7 — bounded second-repo pilot
+#### Phase 8 — workflow configuration contract stabilization
 
-The next durable phase is a single bounded second-repo pilot to prove that the current source-loaded GitHub-first workflow actually works outside this repository.
+Phase 8 is the current active durable phase. `main` already includes a partial Phase 8 implementation: the dev-loop config schema/loader, reviewer-role resolution, strategy-default routing integration, conductor model wiring, and the supporting contract tests.
 
-Success for Phase 7 means:
+The durable phase plan lives in [Phase 8 Plan](./docs/phases/phase-8.md).
+
+This ordering is an explicit deviation from the repo's normal one-phase-at-a-time posture: Phase 8 was pulled forward before the planned Phase 7 pilot executed. The durable docs now record that deviation directly instead of leaving contradictory claims about which phase is current.
+
+### Deferred earlier phase
+
+#### Phase 7 — bounded second-repo pilot (deferred)
+
+Phase 7 is still a valid planned pilot, but it is currently deferred rather than completed. No target repository has been chosen yet and the bounded second-repo portability proof has not run.
+
+Success for Phase 7 still means:
 - one real non-bootstrap target repo
 - one bounded non-mutating pilot path
 - one thin downstream override example
 - only the smallest portability fixes required for that pilot
 
-The durable phase plan lives in [Phase 7 Plan](./docs/phases/phase-7.md).
+Keep the durable plan parked at [Phase 7 Plan](./docs/phases/phase-7.md) until the repo is ready to resume that portability proof.
 
-A separate supporting memo at [Workflow Remediation Prep](./docs/archive/workflow-remediation-prep.md) records the workflow-remediation findings behind issue #70. That memo supports bounded prep chunks, but it is not a roadmap phase and does not replace Phase 7.
+A separate supporting memo at [Workflow Remediation Prep](./docs/archive/workflow-remediation-prep.md) records the workflow-remediation findings behind issue #70. That memo supports bounded prep chunks, but it is not a roadmap phase and does not replace the deferred Phase 7 pilot.
 
-### After Phase 7
+### After Phase 8
 
-Do not lock later phases in detail until Phase 7 produces real evidence. Likely follow-up areas include:
-- downstream portability fixes revealed by the pilot
+Once Phase 8 closes, either resume the deferred Phase 7 pilot or deliberately replan from current GitHub evidence instead of letting both phases stay half-active in durable docs. Likely follow-up areas still include:
+- finishing any remaining Phase 8 closure work
+- the downstream portability proof preserved in Phase 7
 - further shrinkage of markdown-owned operational logic
 - clearer operator-facing inspection / steering / projection surfaces
 - broader multi-repo and tracker-first adoption only after the bounded pilot proves the basics

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ Key configurable surfaces:
 
 Full details: [Extension Documentation](extension/README.md) and `.pi/dev-loop/defaults.yaml`.
 
+## Current phase status
+
+Phase 8 is the active durable phase. It owns the workflow-configuration contract and its first shipped wiring slices, and `main` already includes a slice-1-implemented Phase 8 surface.
+
+Phase 7 second-repo pilot is deferred, not completed. Its bounded pilot plan remains in [Phase 7 Plan](./docs/phases/phase-7.md), but Phase 8 was pulled forward ahead of it as an explicit exception to the repo's normal one-phase-at-a-time posture.
+
+See [Docs Index](./docs/index.md) for the current execution snapshot and [Phase 8 Plan](./docs/phases/phase-8.md) for the active durable phase plan.
+
 ## Requirements and assumptions
 
 Current code and docs assume:

--- a/docs/IMPLEMENTATION_STATE.md
+++ b/docs/IMPLEMENTATION_STATE.md
@@ -2,11 +2,15 @@
 
 ## Status
 
-Phase 1 imported-asset normalization is complete, locally validated, committed, and merged. Phase 2 dedicated refiner-agent work is complete, locally validated, committed, and merged. Phase 3 package extension and setup UX work is complete, locally validated, committed, and merged. Phase 4 shared deterministic library and npm support package work is complete, locally validated, committed, and merged. Phase 5 deterministic scripts work is complete, locally validated, committed, and merged. Phase 6 public release hardening is complete, merged, and synced back to local `main`. Phase 7 second-repo pilot refinement shipped ahead of schedule (the code landed before the formal Phase 7 doc was started). Phase 8 (current) is the post-pilot stabilization and cleanup pass.
+Phase 1 imported-asset normalization is complete, locally validated, committed, and merged. Phase 2 dedicated refiner-agent work is complete, locally validated, committed, and merged. Phase 3 package extension and setup UX work is complete, locally validated, committed, and merged. Phase 4 shared deterministic library and npm support package work is complete, locally validated, committed, and merged. Phase 5 deterministic scripts work is complete, locally validated, committed, and merged. Phase 6 public release hardening is complete, merged, and synced back to local `main`.
 
-Separately, issue #70 tracks a bounded workflow-remediation preparation chain. Those chunks harden the current workflow foundation before later improvements continue. They do **not** replace Phase 7 or the existing roadmap.
+Phase 7 second-repo pilot is deferred, not completed. No target repository has been chosen yet and the bounded external portability proof has not run.
 
-Current `main` also includes the current conductor-adjacent ownership/routing contracts plus the inspection and steering surfaces. The next durable repo-level execution phase is still the bounded Phase 7 pilot rather than a new architecture expansion.
+Phase 8 is the active durable phase. `main` already includes slice 1 of Phase 8: the dev-loop config schema/loader, reviewer-role resolution, strategy-default routing integration, conductor model wiring, and supporting tests. Additional Phase 8 closure work is still pending.
+
+This is an explicit deviation from the repo's normal one-phase-at-a-time guidance: Phase 8 was pulled forward ahead of the planned Phase 7 pilot. The repo now documents that deviation directly instead of leaving contradictory phase claims in multiple files.
+
+Separately, issue #70 tracks a bounded workflow-remediation preparation chain. Those chunks harden the current workflow foundation before later improvements continue. They do **not** replace the deferred Phase 7 pilot or the active Phase 8 work.
 
 ## Current source of truth
 
@@ -14,7 +18,8 @@ Current `main` also includes the current conductor-adjacent ownership/routing co
 - Product/repo roadmap: [Project Plan](../PLAN.md)
 - Repo contract: [Agent Instructions](../AGENTS.md)
 - Workflow explainer: [Implementation Workflow](./IMPLEMENTATION_WORKFLOW.md)
-- Durable local phase plan: [Phase 7 Plan](./phases/phase-7.md)
+- Active durable local phase plan: [Phase 8 Plan](./phases/phase-8.md)
+- Deferred earlier phase plan: [Phase 7 Plan](./phases/phase-7.md)
 - tmp index for fresh-context inspection if present locally: `tmp/phases/index.json`
 
 ## Supporting context
@@ -23,9 +28,11 @@ Current `main` also includes the current conductor-adjacent ownership/routing co
 
 ## Current phase
 
-- Active phase: `phase-7`
-- Durable phase plan: [Phase 7 Plan](phases/phase-7.md)
-- Status: `planning`
+- Active phase: `phase-8`
+- Durable phase plan: [Phase 8 Plan](phases/phase-8.md)
+- Status: `active (slice-1-implemented; additional Phase 8 closure work pending)`
+- Deferred earlier phase: `phase-7`
+- Deviation note: Phase 8 was pulled forward ahead of the planned Phase 7 pilot and that exception is now documented explicitly.
 
 ## Next action for a fresh session
 
@@ -36,19 +43,22 @@ If the user says **"continue implementation"**:
 3. read [Agent Instructions](../AGENTS.md)
 4. read [Implementation Workflow](IMPLEMENTATION_WORKFLOW.md)
 5. read this file
-6. read [Phase 7 Plan](phases/phase-7.md)
+6. read [Phase 8 Plan](phases/phase-8.md)
 7. start from the public `dev-loop` entrypoint and let routing choose the right internal path
 8. inspect `tmp/phases/index.json` and any useful prior artifacts only if prior context helps
 9. if durable repo truth changed during the work, sync [README](../README.md), [Project Plan](../PLAN.md), [Implementation State](./IMPLEMENTATION_STATE.md), and any affected contract docs before closing the slice
 10. if the request is about workflow-remediation preparation, read [Workflow Remediation Prep](archive/workflow-remediation-prep.md) and work the next bounded #70 chunk without widening scope
-11. for Phase 7 specifically, clarify the target repository and pilot path if they are still unset before implementation starts
+11. if the request reopens the deferred Phase 7 pilot, explicitly confirm that reprioritization before treating [Phase 7 Plan](phases/phase-7.md) as the active phase again
 
 ## Next unfinished phase
 
-Phase 7 — second-repo pilot.
+Phase 8 — workflow configuration contract stabilization.
+
+After Phase 8 closes, revisit the deferred Phase 7 second-repo pilot deliberately rather than assuming it already happened.
 
 ## Phase summary
 
 - Completed: `phase-0` through `phase-6`
-- Active: `phase-7` (`planning`)
-- Later phases remain intentionally undescribed here until Phase 7 is settled
+- Deferred: `phase-7` (`not started; Phase 8 pulled forward ahead of it`)
+- Active: `phase-8` (`slice-1-implemented; additional Phase 8 closure work pending`)
+- Later phases remain intentionally undescribed here until Phase 8 closes and the deferred Phase 7 pilot is either resumed or formally replanned

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,11 @@ Start here for repository documentation.
 
 ## Active local phase doc
 
-- [Phase 7 Plan](./phases/phase-7.md) — active phase plan
+- [Phase 8 Plan](./phases/phase-8.md) — active phase plan
+
+## Deferred local phase docs
+
+- [Phase 7 Plan](./phases/phase-7.md) — deferred second-repo pilot plan
 
 ## Archived history
 

--- a/docs/phases/phase-7.md
+++ b/docs/phases/phase-7.md
@@ -2,7 +2,11 @@
 
 ## Status
 
-planning
+deferred
+
+## Reconciliation note
+
+Phase 7 remains a valid planned second-repo pilot, but it is not the active phase. No target repository has been chosen yet and the bounded external pilot has not started. Phase 8 was pulled forward ahead of this pilot, so this document is now a deferred plan rather than an in-progress phase.
 
 ## Objective
 
@@ -129,11 +133,11 @@ This phase exists to answer, in one real non-bootstrap repo:
 
 ## Operational closure status
 
-Phase 7 refinement has started and the merged bounded plan is recorded here.
+Phase 7 is currently deferred before execution. The merged bounded plan remains recorded here for later reuse, but the pilot itself has not started and no target repository has been selected.
 
 Bounded workflow-remediation prep slices under issue #70 may land independently to improve shared workflow footing. They are not part of this phase and do not replace it.
 
-Implementation should not begin until the target repository is chosen and the GitHub issue is opened with the selected pilot path.
+Do not treat this plan as the active phase again unless the repo explicitly reprioritizes back to the second-repo pilot.
 
 ## Links to execution artifacts
 

--- a/docs/phases/phase-8.md
+++ b/docs/phases/phase-8.md
@@ -2,7 +2,11 @@
 
 ## Status
 
-slice-1-implemented (schema, loader, roles, tests — no workflow wiring)
+active (slice-1-implemented; additional Phase 8 closure work pending)
+
+## Reconciliation note
+
+Phase 8 is the active durable phase on `main`. Phase 8 was pulled forward ahead of the deferred Phase 7 pilot, so this document now owns the active phase truth until the repo either closes Phase 8 or deliberately reprioritizes again.
 
 ## Objective
 
@@ -10,7 +14,7 @@ Define a durable, inspectable configuration contract for `dev-loop` / routed wor
 
 ## Why this phase exists now
 
-Workflow policy decisions are accumulating in too many scattered places:
+Workflow policy decisions are accumulating in too many scattered places, and enough of the config-contract surface has already shipped on `main` that the durable docs need to treat Phase 8 as the active phase rather than a future idea:
 - operator instructions in chat
 - issue-specific overrides
 - skill text / prompt wording

--- a/docs/phases/phase-8.md
+++ b/docs/phases/phase-8.md
@@ -34,7 +34,7 @@ Without a configuration contract, behavior drifts between runs, repo policy and 
 
 - define the canonical config surface and schema for dev-loop / routed workflow defaults
 - define the canonical home for workflow-policy contract definitions (`.pi/dev-loop/`)
-- define config precedence: built-in defaults → repo defaults → session overrides → per-run flags
+- define loader precedence for config files: built-in defaults → shipped defaults → repo-local settings (preferred `settings.*`, with legacy `overrides.*` fallback); higher-level per-run flags remain above this loader contract
 - split durable (committed) from session (gitignored) config
 - define validation with fail-closed behavior for unknown or contradictory config
 - support at minimum these config families:
@@ -124,7 +124,7 @@ This means angles are lenses first, optionally backed by dedicated agent persona
 
 - `.pi/dev-loop/defaults.yaml` is defined and validated through the same zod-backed config contract
 - `.pi/dev-loop/settings.yaml` (plus accepted `.yml` / `.json` forms) uses the same schema as the shipped defaults
-- config loader resolves precedence correctly: per-run → session → repo → built-in
+- config loader resolves file-surface precedence correctly: `settings.*` → legacy `overrides.*` → `defaults.*` → built-in defaults
 - unknown keys cause fail-closed rejection (zod `.strict()`)
 - contradictory values (e.g. unknown enum member) cause clear parse errors
 - role resolution follows the documented 3-step order

--- a/docs/phases/phase-8.md
+++ b/docs/phases/phase-8.md
@@ -10,7 +10,7 @@ Phase 8 is the active durable phase on `main`. Phase 8 was pulled forward ahead 
 
 ## Objective
 
-Define a durable, inspectable configuration contract for `dev-loop` / routed workflow behavior so repo/operator defaults move from implicit prompt/skill/chat-memory seams into one canonical, validated configuration surface with clear precedence, fail-closed semantics, and a clean durable-vs-session split.
+Define a durable, inspectable configuration contract for `dev-loop` / routed workflow behavior so repo/operator defaults move from implicit prompt/skill/chat-memory seams into one canonical, validated configuration surface with clear precedence, fail-closed semantics, and explicit shipped-defaults vs repo-local-settings ownership.
 
 ## Why this phase exists now
 
@@ -35,7 +35,7 @@ Without a configuration contract, behavior drifts between runs, repo policy and 
 - define the canonical config surface and schema for dev-loop / routed workflow defaults
 - define the canonical home for workflow-policy contract definitions (`.pi/dev-loop/`)
 - define loader precedence for config files: built-in defaults → shipped defaults → repo-local settings (preferred `settings.*`, with legacy `overrides.*` fallback); higher-level per-run flags remain above this loader contract
-- split durable (committed) from session (gitignored) config
+- distinguish shipped defaults from repo-local settings and higher-level per-run overrides without inventing a second gitignored session-only layer
 - define validation with fail-closed behavior for unknown or contradictory config
 - support at minimum these config families:
   1. **Execution strategy** — local-first vs GitHub-first default, plus per-workflow overrides

--- a/docs/phases/phase-8.md
+++ b/docs/phases/phase-8.md
@@ -64,9 +64,9 @@ These reflect the brainstorming session on 2026-06-01 and serve as the starting 
 
 ### Config home
 
-- Durable defaults: `.pi/dev-loop/defaults.json` (committed, tracked)
-- Session overrides: `.pi/dev-loop/overrides.json` (gitignored)
-- Precedence: per-run CLI flags/env vars > session overrides > repo defaults > built-in defaults
+- Shipped defaults: `.pi/dev-loop/defaults.yaml` (committed, tracked with the package)
+- Repo-local override surface: `.pi/dev-loop/settings.yaml` (preferred); the loader also accepts `.pi/dev-loop/settings.yml` and `.pi/dev-loop/settings.json`, and legacy `overrides.*` still load as fallbacks
+- Precedence: per-run CLI flags/env vars > repo-local settings > shipped defaults > built-in defaults
 - Merge is shallow (missing keys fall through, no deep merging)
 
 ### Schema shape
@@ -122,8 +122,8 @@ This means angles are lenses first, optionally backed by dedicated agent persona
 
 ## Acceptance criteria
 
-- `.pi/dev-loop/defaults.json` schema is defined and validated via zod
-- `.pi/dev-loop/overrides.json` uses the same schema, sparsely applied
+- `.pi/dev-loop/defaults.yaml` is defined and validated through the same zod-backed config contract
+- `.pi/dev-loop/settings.yaml` (plus accepted `.yml` / `.json` forms) uses the same schema as the shipped defaults
 - config loader resolves precedence correctly: per-run → session → repo → built-in
 - unknown keys cause fail-closed rejection (zod `.strict()`)
 - contradictory values (e.g. unknown enum member) cause clear parse errors
@@ -140,8 +140,8 @@ This means angles are lenses first, optionally backed by dedicated agent persona
 - zod schema committed under `packages/core/src/config/` (or equivalent canonical path)
 - config loader committed with precedence merging
 - contract tests pass with ≥ 90% coverage on the config module
-- `.pi/dev-loop/defaults.json` exists in the repo with sensible defaults
-- `.pi/dev-loop/overrides.json` is gitignored
+- `.pi/dev-loop/defaults.yaml` exists in the repo with sensible defaults
+- `.pi/dev-loop/settings.yaml` is the preferred repo-local override surface (with `.yml` / `.json` accepted by the loader)
 - one real workflow entrypoint reads the config and applies it (conductor model or strategy)
 - [Phase 8 Plan](phase-8.md) is updated to reflect the shipped surface
 - [Project Plan](../../PLAN.md) acknowledges the config contract as the canonical source for workflow defaults

--- a/test/copilot-review-doc-contracts.test.mjs
+++ b/test/copilot-review-doc-contracts.test.mjs
@@ -353,7 +353,7 @@ test("new See Also markdown links resolve from docs files", async () => {
 test("docs index separates active docs, archived history, and presentations", async () => {
   const content = await readRepo("docs/index.md");
   assert.match(content, /Start here/i);
-  assert.match(content, /phases\/phase-7\.md/i);
+  assert.match(content, /phases\/phase-8\.md/i);
   assert.match(content, /archive\/phases\/phase-0\.md/i);
   assert.match(content, /archive\/workflow-remediation-prep\.md/i);
   assert.match(content, /presentations\/applied-dev-loops-presentation\.md/i);

--- a/test/planning-doc-contracts.test.mjs
+++ b/test/planning-doc-contracts.test.mjs
@@ -197,13 +197,14 @@ test("worktree guidance docs define the canonical checkout-isolation contract", 
 
 
 test("phase-truth docs agree that Phase 8 is active and Phase 7 is deferred", async () => {
-  const [plan, readme, docsIndex, implementationState, phase7, phase8] = await Promise.all([
+  const [plan, readme, docsIndex, implementationState, phase7, phase8, agents] = await Promise.all([
     readRepo("PLAN.md"),
     readRepo("README.md"),
     readRepo("docs/index.md"),
     readRepo("docs/IMPLEMENTATION_STATE.md"),
     readRepo("docs/phases/phase-7.md"),
     readRepo("docs/phases/phase-8.md"),
+    readRepo("AGENTS.md"),
   ]);
 
   assert.match(plan, /Current active phase[\s\S]*Phase 8/i);
@@ -213,6 +214,10 @@ test("phase-truth docs agree that Phase 8 is active and Phase 7 is deferred", as
   assert.match(readme, /Phase 7 second-repo pilot is deferred/i);
 
   assert.match(docsIndex, /Active local phase doc[\s\S]*phase-8\.md/i);
+
+  assert.match(agents, /Implement one phase at a time/i);
+  assert.match(agents, /reprioritization exception/i);
+  assert.match(agents, /Implementation State\]\(docs\/IMPLEMENTATION_STATE\.md\)/i);
 
   assert.match(implementationState, /Phase 7 second-repo pilot is deferred, not completed/i);
   assert.match(implementationState, /Phase 8 is the active durable phase/i);

--- a/test/planning-doc-contracts.test.mjs
+++ b/test/planning-doc-contracts.test.mjs
@@ -194,3 +194,36 @@ test("worktree guidance docs define the canonical checkout-isolation contract", 
   assert.doesNotMatch(coordinatorAgent, /ONLY use worktrees when they improve isolation/i);
   assert.doesNotMatch(coordinatorAgent, /Prefer the current working tree for a single small task/i);
 });
+
+
+test("phase-truth docs agree that Phase 8 is active and Phase 7 is deferred", async () => {
+  const [plan, readme, docsIndex, implementationState, phase7, phase8] = await Promise.all([
+    readRepo("PLAN.md"),
+    readRepo("README.md"),
+    readRepo("docs/index.md"),
+    readRepo("docs/IMPLEMENTATION_STATE.md"),
+    readRepo("docs/phases/phase-7.md"),
+    readRepo("docs/phases/phase-8.md"),
+  ]);
+
+  assert.match(plan, /Current active phase[\s\S]*Phase 8/i);
+  assert.match(plan, /Phase 7[\s\S]*deferred/i);
+
+  assert.match(readme, /Phase 8 is the active durable phase/i);
+  assert.match(readme, /Phase 7 second-repo pilot is deferred/i);
+
+  assert.match(docsIndex, /Active local phase doc[\s\S]*phase-8\.md/i);
+
+  assert.match(implementationState, /Phase 7 second-repo pilot is deferred, not completed/i);
+  assert.match(implementationState, /Phase 8 is the active durable phase/i);
+  assert.match(implementationState, /explicit deviation from the repo's normal one-phase-at-a-time guidance/i);
+  assert.match(implementationState, /Active phase: `phase-8`/i);
+  assert.match(implementationState, /Status: `active \(slice-1-implemented; additional Phase 8 closure work pending\)`/i);
+  assert.doesNotMatch(implementationState, /Active phase: `phase-7`/i);
+
+  assert.match(phase7, /## Status[\s\S]*deferred/i);
+  assert.match(phase7, /Phase 8 was pulled forward ahead of this pilot/i);
+
+  assert.match(phase8, /## Status[\s\S]*active \(slice-1-implemented; additional Phase 8 closure work pending\)/i);
+  assert.match(phase8, /Phase 8 was pulled forward ahead of the deferred Phase 7 pilot/i);
+});

--- a/test/planning-doc-contracts.test.mjs
+++ b/test/planning-doc-contracts.test.mjs
@@ -226,4 +226,7 @@ test("phase-truth docs agree that Phase 8 is active and Phase 7 is deferred", as
 
   assert.match(phase8, /## Status[\s\S]*active \(slice-1-implemented; additional Phase 8 closure work pending\)/i);
   assert.match(phase8, /Phase 8 was pulled forward ahead of the deferred Phase 7 pilot/i);
+  assert.match(phase8, /\.pi\/dev-loop\/defaults\.yaml/i);
+  assert.match(phase8, /\.pi\/dev-loop\/settings\.yaml/i);
+  assert.doesNotMatch(phase8, /defaults\.json|overrides\.json/i);
 });

--- a/test/planning-doc-contracts.test.mjs
+++ b/test/planning-doc-contracts.test.mjs
@@ -229,5 +229,8 @@ test("phase-truth docs agree that Phase 8 is active and Phase 7 is deferred", as
   assert.match(phase8, /\.pi\/dev-loop\/defaults\.yaml/i);
   assert.match(phase8, /\.pi\/dev-loop\/settings\.yaml/i);
   assert.match(phase8, /settings\.\*`?[^\n]*overrides\.\*`?[^\n]*defaults\.\*`?[^\n]*built-in defaults/i);
+  assert.match(phase8, /shipped-defaults vs repo-local-settings ownership/i);
+  assert.doesNotMatch(phase8, /durable-vs-session split/i);
+  assert.doesNotMatch(phase8, /session \(gitignored\) config/i);
   assert.doesNotMatch(phase8, /defaults\.json|overrides\.json/i);
 });

--- a/test/planning-doc-contracts.test.mjs
+++ b/test/planning-doc-contracts.test.mjs
@@ -228,5 +228,6 @@ test("phase-truth docs agree that Phase 8 is active and Phase 7 is deferred", as
   assert.match(phase8, /Phase 8 was pulled forward ahead of the deferred Phase 7 pilot/i);
   assert.match(phase8, /\.pi\/dev-loop\/defaults\.yaml/i);
   assert.match(phase8, /\.pi\/dev-loop\/settings\.yaml/i);
+  assert.match(phase8, /settings\.\*`?[^\n]*overrides\.\*`?[^\n]*defaults\.\*`?[^\n]*built-in defaults/i);
   assert.doesNotMatch(phase8, /defaults\.json|overrides\.json/i);
 });


### PR DESCRIPTION
## Change summary

Reconcile the repo's contradictory Phase 7 vs Phase 8 documentation so the durable docs now agree that Phase 8 is active and Phase 7 is deferred.

## Scope/context

Issue #332 called out six conflicting phase-truth surfaces plus stale fresh-session guidance. This PR makes one coordinated docs pass across the roadmap, implementation snapshot, phase docs, README/docs index, and contract tests.

What changed:
- promote Phase 8 as the active durable phase in `PLAN.md`, `README.md`, `docs/index.md`, and `docs/IMPLEMENTATION_STATE.md`
- mark Phase 7 as deferred rather than completed or still-current
- document the explicit deviation from the repo's normal one-phase-at-a-time posture
- update fresh-session guidance to read `phase-8.md` first and require explicit reprioritization before reopening Phase 7
- add a doc-contract test that fails if phase-truth surfaces drift apart again

## Acceptance criteria

- [x] All affected phase-truth docs agree that Phase 8 is active
- [x] `docs/IMPLEMENTATION_STATE.md` has no internal contradiction about the active phase
- [x] Fresh-session "continue implementation" guidance points to `docs/phases/phase-8.md`
- [x] `README.md` and `docs/index.md` acknowledge the current phase accurately
- [x] The repo documents the explicit Phase 8-before-Phase 7 exception to the normal one-phase-at-a-time posture
- [x] Contract tests cover the reconciled phase truth

## Definition of done

- [x] Targeted doc-contract tests pass
- [x] Full `npm run verify` passes
- [x] No stale active-phase references to `phase-7` remain in the reconciled surfaces
- [x] Draft PR created for review

## Non-goals

- redesigning Phase 7 or Phase 8 scope
- claiming the deferred Phase 7 pilot already happened
- roadmap changes beyond reconciling the current documented reality

Closes #332
