### PR TITLE
Wave 2: normalize duplicated script and test helpers

### DIFF
--- a/scripts/_cli-primitives.mjs
+++ b/scripts/_cli-primitives.mjs
@@ -8,25 +8,41 @@ function toCliError(message, parseError) {
   return new Error(message);
 }
 
-export function requireOptionValue(args, flag, parseError = null) {
+export function requireOptionValue(args, flag, parseError = null, { flagPattern = /^--/u } = {}) {
   const value = args.shift();
 
-  if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
+  if (typeof value !== "string" || value.length === 0 || flagPattern.test(value)) {
     throw toCliError(`Missing value for ${flag}`, parseError);
   }
 
   return value;
 }
 
-export function parsePrNumber(value, parseError = null) {
+export function parsePositiveInteger(value, flag, parseError = null) {
   if (!/^\d+$/.test(value) || Number(value) === 0) {
-    throw toCliError("--pr must be a positive integer", parseError);
+    throw toCliError(`${flag} must be a positive integer`, parseError);
   }
 
   return Number(value);
 }
 
-export function runChild(command, args, env) {
+export function parseNonNegativeInteger(value, flag, parseError = null) {
+  if (!/^\d+$/.test(value)) {
+    throw toCliError(`${flag} must be a non-negative integer`, parseError);
+  }
+
+  return Number(value);
+}
+
+export function parsePrNumber(value, parseError = null) {
+  return parsePositiveInteger(value, "--pr", parseError);
+}
+
+export function parseIssueNumber(value, parseError = null) {
+  return parsePositiveInteger(value, "--issue", parseError);
+}
+
+export function runChild(command, args, env = process.env) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       env,
@@ -47,6 +63,37 @@ export function runChild(command, args, env) {
     child.on("error", reject);
     child.on("close", (code) => {
       resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+export function runCommand(command, args, { cwd = process.cwd(), env = process.env } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+
+      reject(new Error(stderr.trim().length > 0 ? stderr.trim() : `${command} exited with code ${code}`));
     });
   });
 }

--- a/scripts/_core-helpers.mjs
+++ b/scripts/_core-helpers.mjs
@@ -24,6 +24,12 @@ export {
   summarizeGateReviewComments,
 } from "@pi-dev-loops/core/github/copilot-helpers";
 
+export function buildParseError(usage) {
+  return function parseError(message) {
+    return Object.assign(new Error(message), { usage });
+  };
+}
+
 export function isDirectCliRun(importMetaUrl, argv1 = process.argv[1]) {
   if (typeof argv1 !== "string" || argv1.length === 0) {
     return false;

--- a/scripts/github/audit-copilot-comments.mjs
+++ b/scripts/github/audit-copilot-comments.mjs
@@ -2,7 +2,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import { formatCliError, isCopilotLogin, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, isCopilotLogin, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 
@@ -60,9 +60,8 @@ Exit codes:
   0  Success
   1  Argument error, gh failure, or malformed gh JSON`.trim();
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
+
 
 const CATEGORY_DEFINITIONS = [
   {

--- a/scripts/github/detect-gate-review-evidence.mjs
+++ b/scripts/github/detect-gate-review-evidence.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import {
+  buildParseError,
   formatCliError,
   isDirectCliRun,
   parseJsonText,
@@ -66,9 +67,8 @@ Exit codes:
   0  Success
   1  Argument error, gh failure, or malformed gh JSON`.trim();
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
+
 
 export function parseDetectGateReviewEvidenceCliArgs(argv) {
   const args = [...argv];

--- a/scripts/github/detect-linked-issue-pr.mjs
+++ b/scripts/github/detect-linked-issue-pr.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
-import { spawn } from "node:child_process";
-
-import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { parseIssueNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 
 export const LINKED_ISSUE_PR_QUERY = [
@@ -82,27 +81,8 @@ Error output (stderr, JSON):
   gh/runtime failures:
     { "ok": false, "error": "..." }`.trim();
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
 
-function requireOptionValue(args, flag) {
-  const value = args.shift();
-
-  if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
-    throw parseError(`Missing value for ${flag}`);
-  }
-
-  return value;
-}
-
-function parseIssueNumber(value) {
-  if (!/^\d+$/.test(value) || Number(value) === 0) {
-    throw parseError("--issue must be a positive integer");
-  }
-
-  return Number(value);
-}
 
 export function parseDetectLinkedIssuePrCliArgs(argv) {
   const args = [...argv];
@@ -121,12 +101,12 @@ export function parseDetectLinkedIssuePrCliArgs(argv) {
     }
 
     if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo").trim();
+      options.repo = requireOptionValue(args, "--repo", parseError).trim();
       continue;
     }
 
     if (token === "--issue") {
-      options.issue = parseIssueNumber(requireOptionValue(args, "--issue"));
+      options.issue = parseIssueNumber(requireOptionValue(args, "--issue", parseError), parseError);
       continue;
     }
 
@@ -144,31 +124,6 @@ export function parseDetectLinkedIssuePrCliArgs(argv) {
   }
 
   return options;
-}
-
-function runChild(command, args, env) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
 }
 
 function buildQueryArgs({ owner, name, issue, after }) {

--- a/scripts/github/manage-sub-issues.mjs
+++ b/scripts/github/manage-sub-issues.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { parsePositiveInteger, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 
 const USAGE = `Usage: manage-sub-issues.mjs <command> --repo <owner/name> --issue <number> [options]
@@ -51,17 +51,8 @@ Error output (stderr, JSON):
   gh/runtime failures:
     { "ok": false, "error": "..." }`.trim();
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
 
-function parseIssueNumber(value) {
-  if (!/^\d+$/.test(value) || Number(value) === 0) {
-    throw parseError("Issue number must be a positive integer");
-  }
-
-  return Number(value);
-}
 
 function parseIssueList(value) {
   if (typeof value !== "string" || value.trim().length === 0) {
@@ -128,12 +119,12 @@ export function parseManageSubIssuesCliArgs(argv) {
     }
 
     if (token === "--issue") {
-      options.issue = parseIssueNumber(requireOptionValue(args, "--issue", parseError));
+      options.issue = parsePositiveInteger(requireOptionValue(args, "--issue", parseError), "Issue number", parseError);
       continue;
     }
 
     if (token === "--child") {
-      options.child = parseIssueNumber(requireOptionValue(args, "--child", parseError));
+      options.child = parsePositiveInteger(requireOptionValue(args, "--child", parseError), "Issue number", parseError);
       continue;
     }
 

--- a/scripts/github/reconcile-draft-gate.mjs
+++ b/scripts/github/reconcile-draft-gate.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { loadDevLoopConfig, resolveGateConfig } from "@pi-dev-loops/core/config";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
@@ -47,9 +47,8 @@ Exit codes:
   0  Success — PR was reconciled and gate evidence posted
   1  Argument error, gh failure, or unrecoverable state`.trim();
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
+
 
 export function parseReconcileDraftGateCliArgs(argv) {
   const args = [...argv];

--- a/scripts/github/reply-resolve-review-thread.mjs
+++ b/scripts/github/reply-resolve-review-thread.mjs
@@ -2,6 +2,7 @@
 import { readFile } from "node:fs/promises";
 
 import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { parsePositiveInteger, requireOptionValue } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import {
   replyAndMaybeResolve,
@@ -9,24 +10,6 @@ import {
 } from "./_review-thread-mutations.mjs";
 
 export { hasCommitShaReference } from "./_review-thread-mutations.mjs";
-
-function requireOptionValue(args, flag) {
-  const value = args.shift();
-
-  if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
-    throw new Error(`Missing value for ${flag}`);
-  }
-
-  return value;
-}
-
-function parsePositiveInteger(value, flag) {
-  if (!/^\d+$/.test(value) || Number(value) === 0) {
-    throw new Error(`${flag} must be a positive integer`);
-  }
-
-  return Number(value);
-}
 
 export function parseReplyResolveCliArgs(argv) {
   const args = [...argv];

--- a/scripts/github/reply-resolve-review-threads.mjs
+++ b/scripts/github/reply-resolve-review-threads.mjs
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
-import {
-  formatCliError,
-  isDirectCliRun,
-} from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import {
   parsePrNumber,
   requireOptionValue,
@@ -43,9 +40,8 @@ Exit codes:
   0  Success
   1  Argument error or gh/runtime failure`.trim();
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
+
 
 export function parseReplyResolveThreadsCliArgs(argv) {
   const args = [...argv];

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import {
+  buildParseError,
   formatCliError,
   isCopilotLogin,
   isDirectCliRun,
@@ -50,9 +51,8 @@ Exit codes:
   0  Success (including unavailable)
   1  Argument error or gh failure`.trim();
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
+
 
 export function parseRequestCliArgs(argv) {
   const args = [...argv];

--- a/scripts/github/resolve-tracker-local-spec.mjs
+++ b/scripts/github/resolve-tracker-local-spec.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
-import { spawn } from "node:child_process";
-
-import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { parseIssueNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 
 const ISSUE_JSON_FIELDS = "number,title,body,url,state";
@@ -38,27 +37,8 @@ Error output (stderr, JSON):
   gh/runtime failures:
     { "ok": false, "error": "..." }`.trim();
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
 
-function requireOptionValue(args, flag) {
-  const value = args.shift();
-
-  if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
-    throw parseError(`Missing value for ${flag}`);
-  }
-
-  return value;
-}
-
-function parseIssueNumber(value) {
-  if (!/^\d+$/.test(value) || Number(value) === 0) {
-    throw parseError("--issue must be a positive integer");
-  }
-
-  return Number(value);
-}
 
 export function parseGitHubIssueUrl(value) {
   let parsedUrl;
@@ -112,17 +92,17 @@ export function parseResolveTrackerLocalSpecCliArgs(argv) {
     }
 
     if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo").trim();
+      options.repo = requireOptionValue(args, "--repo", parseError).trim();
       continue;
     }
 
     if (token === "--issue") {
-      options.issue = parseIssueNumber(requireOptionValue(args, "--issue"));
+      options.issue = parseIssueNumber(requireOptionValue(args, "--issue", parseError), parseError);
       continue;
     }
 
     if (token === "--issue-url") {
-      options.issueUrl = requireOptionValue(args, "--issue-url").trim();
+      options.issueUrl = requireOptionValue(args, "--issue-url", parseError).trim();
       continue;
     }
 
@@ -157,31 +137,6 @@ export function parseResolveTrackerLocalSpecCliArgs(argv) {
   }
 
   return options;
-}
-
-function runChild(command, args, env) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
 }
 
 function buildIssueViewArgs({ repo, issue }) {

--- a/scripts/github/stage-reviewer-draft.mjs
+++ b/scripts/github/stage-reviewer-draft.mjs
@@ -4,26 +4,9 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { parsePositiveInteger, requireOptionValue } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import { buildDraftReviewPayload } from "@pi-dev-loops/core/loop/reviewer-loop-state";
-
-function requireOptionValue(args, flag) {
-  const value = args.shift();
-
-  if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
-    throw new Error(`Missing value for ${flag}`);
-  }
-
-  return value;
-}
-
-function parsePositiveInteger(value, flag) {
-  if (!/^\d+$/.test(value) || Number(value) === 0) {
-    throw new Error(`${flag} must be a positive integer`);
-  }
-
-  return Number(value);
-}
 
 export function parseStageDraftCliArgs(argv) {
   const args = [...argv];

--- a/scripts/github/upsert-gate-review-comment.mjs
+++ b/scripts/github/upsert-gate-review-comment.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { loadDevLoopConfig, resolveGateConfig } from "@pi-dev-loops/core/config";
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { truncateText } from "@pi-dev-loops/core/bash-exit-one";
@@ -61,9 +61,8 @@ Exit codes:
   0  Success
   1  Argument error, gh failure, or contradictory gate evidence`.trim();
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
+
 
 function normalizeGateName(value) {
   const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";

--- a/scripts/github/watch-copilot-review.mjs
+++ b/scripts/github/watch-copilot-review.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
-import { spawn } from "node:child_process";
 import { setTimeout as delay } from "node:timers/promises";
 
-import { formatCliError, isCopilotLogin, isDirectCliRun, parseJsonText, parseReviewThreads } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, isCopilotLogin, isDirectCliRun, parseJsonText, parseReviewThreads } from "../_core-helpers.mjs";
+import { parseNonNegativeInteger, parsePositiveInteger, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 
 const USAGE = `Usage: watch-copilot-review.mjs --repo <owner/name> --pr <number> [--poll-interval-ms <ms>] [--timeout-ms <ms>]
@@ -81,35 +81,8 @@ const COPILOT_ACTIVITY_QUERY = [
   "}",
 ].join("\n");
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
 
-function requireOptionValue(args, flag) {
-  const value = args.shift();
-
-  if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
-    throw parseError(`Missing value for ${flag}`);
-  }
-
-  return value;
-}
-
-function parseNonNegativeInteger(value, flag) {
-  if (!/^\d+$/.test(value)) {
-    throw parseError(`${flag} must be a non-negative integer`);
-  }
-
-  return Number(value);
-}
-
-function parsePositiveInteger(value, flag) {
-  if (!/^\d+$/.test(value) || Number(value) === 0) {
-    throw parseError(`${flag} must be a positive integer`);
-  }
-
-  return Number(value);
-}
 
 export function parseWatchCliArgs(argv) {
   const args = [...argv];
@@ -130,22 +103,22 @@ export function parseWatchCliArgs(argv) {
     }
 
     if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo").trim();
+      options.repo = requireOptionValue(args, "--repo", parseError).trim();
       continue;
     }
 
     if (token === "--pr") {
-      options.pr = parsePositiveInteger(requireOptionValue(args, "--pr"), "--pr");
+      options.pr = parsePositiveInteger(requireOptionValue(args, "--pr", parseError), "--pr", parseError);
       continue;
     }
 
     if (token === "--poll-interval-ms") {
-      options.pollIntervalMs = parsePositiveInteger(requireOptionValue(args, "--poll-interval-ms"), "--poll-interval-ms");
+      options.pollIntervalMs = parsePositiveInteger(requireOptionValue(args, "--poll-interval-ms", parseError), "--poll-interval-ms", parseError);
       continue;
     }
 
     if (token === "--timeout-ms") {
-      options.timeoutMs = parseNonNegativeInteger(requireOptionValue(args, "--timeout-ms"), "--timeout-ms");
+      options.timeoutMs = parseNonNegativeInteger(requireOptionValue(args, "--timeout-ms", parseError), "--timeout-ms", parseError);
       continue;
     }
 
@@ -163,31 +136,6 @@ export function parseWatchCliArgs(argv) {
   }
 
   return options;
-}
-
-function runChild(command, args, env) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
 }
 
 async function fetchGithubCopilotActivityPayload(

--- a/scripts/loop/_inspect-run-viewer-adapter.mjs
+++ b/scripts/loop/_inspect-run-viewer-adapter.mjs
@@ -1,6 +1,6 @@
 import { parseRepoSlugParts } from "@pi-dev-loops/core/github/repo-slug";
 import { inspectRun } from "./inspect-run.mjs";
-import { spawn } from "node:child_process";
+import { runChild } from "../_cli-primitives.mjs";
 
 const ASSIGNED_PR_LIST_CACHE_TTL_MS = 15_000;
 const DEFAULT_UPDATED_WITHIN_DAYS = 7;
@@ -228,39 +228,13 @@ export function normalizeInspectionTarget(target) {
 }
 
 export function createInspectionViewerAdapter({ inspectRunImpl = inspectRun, runGhJsonImpl = null, nowImpl = () => Date.now() } = {}) {
-  const runChild = (command, args, env = process.env) => new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (chunk) => {
-      stdout += chunk.toString();
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += chunk.toString();
-    });
-
-    child.on("error", reject);
-    child.on("close", (status, signal) => resolve({
-      status,
-      signal,
-      stdout,
-      stderr,
-      command,
-      args,
-    }));
-  });
-
   const runGhJson = async (args, { env = process.env, ghCommand = "gh" } = {}) => {
     if (typeof runGhJsonImpl === "function") {
       return runGhJsonImpl(args, { env, ghCommand });
     }
     const result = await runChild(ghCommand, args, env);
-    if (result.status !== 0) {
-      throw new Error(`Command failed: ${result.command} ${result.args.join(" ")}\n${result.stderr.trim() || "(no stderr output)"}`);
+    if (result.code !== 0) {
+      throw new Error(`Command failed: ${ghCommand} ${args.join(" ")}\n${result.stderr.trim() || "(no stderr output)"}`);
     }
     return parseGhJsonOutput(result.stdout);
   };

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -39,7 +39,8 @@
  *   on stderr and exit non-zero.
  *   gh failures emit { "ok": false, "error": "..." } on stderr and exit non-zero.
  */
-import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { parsePrNumber, requireOptionValue } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import { autoDetectSnapshot } from "./detect-copilot-loop-state.mjs";
 import { performCopilotReviewRequest } from "../github/request-copilot-review.mjs";
@@ -166,27 +167,8 @@ function summarizeRequestWatchContract({
   };
 }
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
 
-function requireOptionValue(args, flag) {
-  const value = args.shift();
-
-  if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
-    throw parseError(`Missing value for ${flag}`);
-  }
-
-  return value;
-}
-
-function parsePrNumber(value) {
-  if (!/^\d+$/.test(value) || Number(value) === 0) {
-    throw parseError("--pr must be a positive integer");
-  }
-
-  return Number(value);
-}
 
 export function parseHandoffCliArgs(argv) {
   const args = [...argv];
@@ -207,12 +189,12 @@ export function parseHandoffCliArgs(argv) {
     }
 
     if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo").trim();
+      options.repo = requireOptionValue(args, "--repo", parseError).trim();
       continue;
     }
 
     if (token === "--pr") {
-      options.pr = parsePrNumber(requireOptionValue(args, "--pr"));
+      options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
       continue;
     }
 
@@ -222,7 +204,7 @@ export function parseHandoffCliArgs(argv) {
     }
 
     if (token === "--watch-status") {
-      const watchStatus = requireOptionValue(args, "--watch-status").trim().toLowerCase();
+      const watchStatus = requireOptionValue(args, "--watch-status", parseError).trim().toLowerCase();
       if (!VALID_WATCH_STATUSES.has(watchStatus)) {
         throw parseError(`--watch-status must be one of: ${[...VALID_WATCH_STATUSES].join(", ")}`);
       }

--- a/scripts/loop/detect-copilot-loop-state.mjs
+++ b/scripts/loop/detect-copilot-loop-state.mjs
@@ -70,6 +70,7 @@ import { readFile } from "node:fs/promises";
 
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import {
+  buildParseError,
   formatCliError,
   isCopilotLogin,
   isDirectCliRun,
@@ -166,9 +167,8 @@ Exit codes:
 
 const VALID_OVERRIDE_STATUSES = new Set(["requested", "already-requested", "unavailable", "none", "failed"]);
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
+
 
 export function parseDetectCliArgs(argv) {
   const args = [...argv];

--- a/scripts/loop/detect-copilot-session-activity.mjs
+++ b/scripts/loop/detect-copilot-session-activity.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
-import { spawn } from "node:child_process";
-
-import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { parsePositiveInteger, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 
 const USAGE = `Usage: detect-copilot-session-activity.mjs --repo <owner/name> --branch <name> [--limit <number>]
@@ -49,27 +48,8 @@ const COPILOT_RUN_NAME_PATTERNS = Object.freeze([
   /^addressing review on pr\b/i,
 ]);
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
 
-function requireOptionValue(args, flag) {
-  const value = args.shift();
-
-  if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
-    throw parseError(`Missing value for ${flag}`);
-  }
-
-  return value;
-}
-
-function parsePositiveInteger(value, flag) {
-  if (!/^\d+$/.test(value) || Number(value) === 0) {
-    throw parseError(`${flag} must be a positive integer`);
-  }
-
-  return Number(value);
-}
 
 export function parseDetectCopilotSessionActivityCliArgs(argv) {
   const args = [...argv];
@@ -89,17 +69,17 @@ export function parseDetectCopilotSessionActivityCliArgs(argv) {
     }
 
     if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo").trim();
+      options.repo = requireOptionValue(args, "--repo", parseError).trim();
       continue;
     }
 
     if (token === "--branch") {
-      options.branch = requireOptionValue(args, "--branch").trim();
+      options.branch = requireOptionValue(args, "--branch", parseError).trim();
       continue;
     }
 
     if (token === "--limit") {
-      options.limit = parsePositiveInteger(requireOptionValue(args, "--limit"), "--limit");
+      options.limit = parsePositiveInteger(requireOptionValue(args, "--limit", parseError), "--limit", parseError);
       continue;
     }
 
@@ -117,31 +97,6 @@ export function parseDetectCopilotSessionActivityCliArgs(argv) {
   }
 
   return options;
-}
-
-function runChild(command, args, env) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
 }
 
 function isCopilotRunName(name) {

--- a/scripts/loop/detect-initial-copilot-pr-state.mjs
+++ b/scripts/loop/detect-initial-copilot-pr-state.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
-import { spawn } from "node:child_process";
-
-import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { parseIssueNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import { detectLinkedIssuePr } from "../github/detect-linked-issue-pr.mjs";
 import { detectCopilotSessionActivity } from "./detect-copilot-session-activity.mjs";
@@ -87,27 +86,8 @@ const INITIAL_COPILOT_PR_FACTS_QUERY = [
   "}",
 ].join("\n");
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
 
-function requireOptionValue(args, flag) {
-  const value = args.shift();
-
-  if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
-    throw parseError(`Missing value for ${flag}`);
-  }
-
-  return value;
-}
-
-function parseIssueNumber(value) {
-  if (!/^\d+$/.test(value) || Number(value) === 0) {
-    throw parseError("--issue must be a positive integer");
-  }
-
-  return Number(value);
-}
 
 export function parseDetectInitialCopilotPrStateCliArgs(argv) {
   const args = [...argv];
@@ -126,12 +106,12 @@ export function parseDetectInitialCopilotPrStateCliArgs(argv) {
     }
 
     if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo").trim();
+      options.repo = requireOptionValue(args, "--repo", parseError).trim();
       continue;
     }
 
     if (token === "--issue") {
-      options.issue = parseIssueNumber(requireOptionValue(args, "--issue"));
+      options.issue = parseIssueNumber(requireOptionValue(args, "--issue", parseError), parseError);
       continue;
     }
 
@@ -149,31 +129,6 @@ export function parseDetectInitialCopilotPrStateCliArgs(argv) {
   }
 
   return options;
-}
-
-function runChild(command, args, env) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
 }
 
 function buildQueryArgs({ owner, name, pr }) {

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import {
+  buildParseError,
   formatCliError,
   isCopilotLogin,
   isDirectCliRun,
@@ -80,9 +81,8 @@ Exit codes:
   0  Success
   1  Argument error or gh/runtime failure`.trim();
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
+
 
 export function parseDetectPrGateCoordinationCliArgs(argv) {
   const args = [...argv];

--- a/scripts/loop/detect-tracker-pr-state.mjs
+++ b/scripts/loop/detect-tracker-pr-state.mjs
@@ -36,7 +36,8 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { formatCliError, parseJsonText } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, parseJsonText } from "../_core-helpers.mjs";
+import { requireOptionValue } from "../_cli-primitives.mjs";
 import {
   interpretTrackerPrState,
   normalizeTrackerPrSnapshot,
@@ -92,19 +93,8 @@ Exit codes:
   0  Success
   1  Argument error or runtime failure`.trim();
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
 
-function requireOptionValue(args, flag) {
-  const value = args.shift();
-
-  if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
-    throw parseError(`Missing value for ${flag}`);
-  }
-
-  return value;
-}
 
 export function parseDetectTrackerPrCliArgs(argv) {
   const args = [...argv];
@@ -122,7 +112,7 @@ export function parseDetectTrackerPrCliArgs(argv) {
     }
 
     if (token === "--input") {
-      options.inputPath = requireOptionValue(args, "--input");
+      options.inputPath = requireOptionValue(args, "--input", parseError);
       continue;
     }
 

--- a/scripts/loop/inspect-run-viewer-ci-changes.mjs
+++ b/scripts/loop/inspect-run-viewer-ci-changes.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { appendFile, readFile } from "node:fs/promises";
 
-import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 
 export const INSPECT_RUN_VIEWER_RELEVANT_EXACT_PATHS = Object.freeze([
   ".github/workflows/ci.yml",
@@ -22,9 +22,8 @@ export const INSPECT_RUN_VIEWER_RELEVANT_PREFIXES = Object.freeze([
 
 const USAGE = "Usage: inspect-run-viewer-ci-changes.mjs <changed-files-path>";
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
+
 
 export function normalizeInspectRunViewerPath(filePath) {
   return String(filePath ?? "")

--- a/scripts/loop/inspect-run-viewer/cli.mjs
+++ b/scripts/loop/inspect-run-viewer/cli.mjs
@@ -3,19 +3,11 @@ import {
   DEFAULT_PORT,
   USAGE,
 } from "./constants.mjs";
+import { requireOptionValue } from "../../_cli-primitives.mjs";
 import { normalizeInspectionTarget } from "../_inspect-run-viewer-adapter.mjs";
 
 export function parseInspectRunViewerCliError(message) {
   return Object.assign(new Error(message), { usage: USAGE });
-}
-
-function requireOptionValue(args, flag) {
-  const value = args.shift();
-  const missing = typeof value !== "string" || value.length === 0 || value.startsWith("--");
-  if (missing) {
-    throw parseInspectRunViewerCliError(`Missing value for ${flag}`);
-  }
-  return value;
 }
 
 function parsePort(rawPort) {
@@ -84,18 +76,18 @@ export function parseInspectRunViewerCliArgs(argv) {
       return options;
     }
     if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo");
+      options.repo = requireOptionValue(args, "--repo", parseInspectRunViewerCliError);
       continue;
     }
     if (token === "--pr") {
       throw parseInspectRunViewerCliError("--pr is no longer supported on the CLI; choose a PR with ?pr=<number> in the viewer URL");
     }
     if (token === "--host") {
-      options.host = parseHost(requireOptionValue(args, "--host"));
+      options.host = parseHost(requireOptionValue(args, "--host", parseInspectRunViewerCliError));
       continue;
     }
     if (token === "--port") {
-      options.port = parsePort(requireOptionValue(args, "--port"));
+      options.port = parsePort(requireOptionValue(args, "--port", parseInspectRunViewerCliError));
       continue;
     }
     if (token === "--allow-non-localhost") {
@@ -107,19 +99,19 @@ export function parseInspectRunViewerCliArgs(argv) {
       continue;
     }
     if (token === "--steering-state-file") {
-      options.steeringStateFile = requireOptionValue(args, "--steering-state-file");
+      options.steeringStateFile = requireOptionValue(args, "--steering-state-file", parseInspectRunViewerCliError);
       continue;
     }
     if (token === "--reviewer-login") {
-      options.reviewerLogin = parseReviewerLogin(requireOptionValue(args, "--reviewer-login"));
+      options.reviewerLogin = parseReviewerLogin(requireOptionValue(args, "--reviewer-login", parseInspectRunViewerCliError));
       continue;
     }
     if (token === "--copilot-input") {
-      options.copilotInputPath = requireOptionValue(args, "--copilot-input");
+      options.copilotInputPath = requireOptionValue(args, "--copilot-input", parseInspectRunViewerCliError);
       continue;
     }
     if (token === "--reviewer-input") {
-      options.reviewerInputPath = requireOptionValue(args, "--reviewer-input");
+      options.reviewerInputPath = requireOptionValue(args, "--reviewer-input", parseInspectRunViewerCliError);
       continue;
     }
     throw parseInspectRunViewerCliError(`Unknown argument: ${token}`);

--- a/scripts/loop/inspect-run.mjs
+++ b/scripts/loop/inspect-run.mjs
@@ -56,7 +56,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
-import { formatCliError, parseJsonText, parseReviewThreads } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, parseJsonText, parseReviewThreads } from "../_core-helpers.mjs";
 import { fetchGithubReviewThreadsPayload } from "../github/capture-review-threads.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import { readExistingCheckpoint } from "./_checkpoint-io.mjs";
@@ -145,9 +145,8 @@ Exit codes:
 // Argument parsing
 // ---------------------------------------------------------------------------
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
+
 
 function parseReviewerLogin(value) {
   const normalized = value.trim();

--- a/scripts/loop/outer-loop.mjs
+++ b/scripts/loop/outer-loop.mjs
@@ -39,7 +39,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
-import { formatCliError, parseJsonText } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, parseJsonText } from "../_core-helpers.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import {
   buildCheckpointFilePath,
@@ -141,9 +141,8 @@ Exit codes:
 // Argument parsing
 // ---------------------------------------------------------------------------
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
+
 
 function parseReviewerLogin(value) {
   const normalized = value.trim();

--- a/scripts/loop/pre-commit-branch-guard.mjs
+++ b/scripts/loop/pre-commit-branch-guard.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
-import { spawn } from "node:child_process";
-
-import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { requireOptionValue, runCommand } from "../_cli-primitives.mjs";
 
 const USAGE = `Usage:
   pre-commit-branch-guard.mjs --expected-branch <name>
@@ -20,17 +19,8 @@ Branch mismatch output (stderr, JSON, exit 1):
 Usage errors (stderr, JSON, exit 1):
   { "ok": false, "error": "...", "usage": "..." }`.trim();
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
 
-function requireOptionValue(args, flag) {
-  const value = args.shift();
-  if (typeof value !== "string" || value.length === 0 || value.startsWith("-")) {
-    throw parseError(`Missing value for ${flag}`);
-  }
-  return value;
-}
 
 export function parseBranchGuardCliArgs(argv) {
   const args = [...argv];
@@ -48,7 +38,7 @@ export function parseBranchGuardCliArgs(argv) {
     }
 
     if (token === "--expected-branch") {
-      options.expectedBranch = requireOptionValue(args, "--expected-branch");
+      options.expectedBranch = requireOptionValue(args, "--expected-branch", parseError, { flagPattern: /^-/u });
       continue;
     }
 
@@ -60,37 +50,6 @@ export function parseBranchGuardCliArgs(argv) {
   }
 
   return options;
-}
-
-function runCommand(command, args, { cwd = process.cwd(), env = process.env } = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      cwd,
-      env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      if (code === 0) {
-        resolve({ stdout, stderr });
-        return;
-      }
-
-      reject(new Error(stderr.trim().length > 0 ? stderr.trim() : `${command} exited with code ${code}`));
-    });
-  });
 }
 
 

--- a/scripts/loop/pre-write-remote-freshness-guard.mjs
+++ b/scripts/loop/pre-write-remote-freshness-guard.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
-import { spawn } from "node:child_process";
-
-import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { requireOptionValue, runCommand } from "../_cli-primitives.mjs";
 
 const USAGE = `Usage:
   pre-write-remote-freshness-guard.mjs --branch <name>
@@ -20,17 +19,8 @@ Remote ahead output (stderr, JSON, exit 1):
 Usage errors (stderr, JSON, exit 1):
   { "ok": false, "error": "...", "usage": "..." }`.trim();
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
 
-function requireOptionValue(args, flag) {
-  const value = args.shift();
-  if (typeof value !== "string" || value.length === 0 || value.startsWith("-")) {
-    throw parseError(`Missing value for ${flag}`);
-  }
-  return value;
-}
 
 export function parseRemoteFreshnessGuardCliArgs(argv) {
   const args = [...argv];
@@ -48,7 +38,7 @@ export function parseRemoteFreshnessGuardCliArgs(argv) {
     }
 
     if (token === "--branch") {
-      options.branch = requireOptionValue(args, "--branch");
+      options.branch = requireOptionValue(args, "--branch", parseError, { flagPattern: /^-/u });
       continue;
     }
 
@@ -60,37 +50,6 @@ export function parseRemoteFreshnessGuardCliArgs(argv) {
   }
 
   return options;
-}
-
-function runCommand(command, args, { cwd = process.cwd(), env = process.env } = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      cwd,
-      env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      if (code === 0) {
-        resolve({ stdout, stderr });
-        return;
-      }
-
-      reject(new Error(stderr.trim().length > 0 ? stderr.trim() : `${command} exited with code ${code}`));
-    });
-  });
 }
 
 

--- a/scripts/loop/resolve-dev-loop-startup.mjs
+++ b/scripts/loop/resolve-dev-loop-startup.mjs
@@ -3,7 +3,8 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 
 import { resolveAuthoritativeStartupResumeBundle } from "../../packages/core/src/loop/public-dev-loop-routing.mjs";
-import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { requireOptionValue } from "../_cli-primitives.mjs";
 
 const USAGE = `Usage:
   resolve-dev-loop-startup.mjs --input <path>
@@ -95,17 +96,8 @@ const STRATEGY_ASYNC_DISPATCH = {
   none: false,
 };
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
 
-function requireOptionValue(args, flag) {
-  const value = args.shift();
-  if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
-    throw parseError(`Missing value for ${flag}`);
-  }
-  return value;
-}
 
 export function parseResolveDevLoopStartupCliArgs(argv) {
   const args = [...argv];
@@ -123,7 +115,7 @@ export function parseResolveDevLoopStartupCliArgs(argv) {
     }
 
     if (token === "--input") {
-      options.inputPath = requireOptionValue(args, "--input");
+      options.inputPath = requireOptionValue(args, "--input", parseError);
       continue;
     }
 

--- a/scripts/loop/run-copilot-watch-cycle.mjs
+++ b/scripts/loop/run-copilot-watch-cycle.mjs
@@ -3,7 +3,7 @@
 import { spawn } from "node:child_process";
 
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
-import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import { DEV_LOOP_CONTRACT_TRACE_CLASSIFICATION } from "@pi-dev-loops/core/loop/public-dev-loop-routing";
 import { watchCopilotReview } from "../github/watch-copilot-review.mjs";
@@ -57,9 +57,8 @@ Exit codes:
   0  Success
   1  Argument error or runtime failure`.trim();
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
+
 
 async function fetchPrHeadBranch({ repo, pr }, { env, ghCommand }) {
   const result = await runChild(

--- a/scripts/loop/steer-loop.mjs
+++ b/scripts/loop/steer-loop.mjs
@@ -78,6 +78,7 @@ import {
 } from "./_steering-state-file.mjs";
 
 import { formatCliError } from "../_core-helpers.mjs";
+import { requireOptionValue as readSharedOptionValue } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 
 // ---------------------------------------------------------------------------
@@ -186,7 +187,7 @@ const SAFE_RUN_ID_RE = /^[A-Za-z0-9._-]+$/;
 // Argument parsing
 // ---------------------------------------------------------------------------
 
-function parseError(message, usage) {
+function usageError(message, usage) {
   return Object.assign(new Error(message), { usage });
 }
 
@@ -196,18 +197,18 @@ function runIdMismatchError(persistedRunId, requestedRunId) {
   );
 }
 
-function requireOptionValue(args, flag, usage, { allowFlagLike = false } = {}) {
-  const value = args.shift();
-  const missing = typeof value !== "string" || value.length === 0 || (!allowFlagLike && value.startsWith("--"));
-  if (missing) {
-    throw parseError(`Missing value for ${flag}`, usage);
-  }
-  return value;
+function readRequiredOptionValue(args, flag, usage, { allowFlagLike = false } = {}) {
+  return readSharedOptionValue(
+    args,
+    flag,
+    (message) => usageError(message, usage),
+    { flagPattern: allowFlagLike ? /$^/u : /^--/u },
+  );
 }
 
 function validateSafeRunId(runId, usage) {
   if (!SAFE_RUN_ID_RE.test(runId)) {
-    throw parseError("--run-id must contain only letters, numbers, dot, underscore, or hyphen", usage);
+    throw usageError("--run-id must contain only letters, numbers, dot, underscore, or hyphen", usage);
   }
 }
 
@@ -215,13 +216,13 @@ function parseRepoSlugOption(rawRepo, usage) {
   try {
     parseRepoSlug(rawRepo);
   } catch (error) {
-    throw parseError(error instanceof Error ? error.message : String(error), usage);
+    throw usageError(error instanceof Error ? error.message : String(error), usage);
   }
 }
 
 function parsePositiveIntegerOption(raw, flag, usage) {
   if (!/^\d+$/.test(raw) || Number(raw) === 0) {
-    throw parseError(`${flag} must be a positive integer`, usage);
+    throw usageError(`${flag} must be a positive integer`, usage);
   }
   return Number(raw);
 }
@@ -254,90 +255,90 @@ export function parseSubmitCliArgs(argv) {
     }
 
     if (token === "--run-id") {
-      options.runId = requireOptionValue(args, "--run-id", SUBMIT_USAGE).trim();
+      options.runId = readRequiredOptionValue(args, "--run-id", SUBMIT_USAGE).trim();
       validateSafeRunId(options.runId, SUBMIT_USAGE);
       continue;
     }
     if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", SUBMIT_USAGE).trim();
+      options.repo = readRequiredOptionValue(args, "--repo", SUBMIT_USAGE).trim();
       parseRepoSlugOption(options.repo, SUBMIT_USAGE);
       continue;
     }
     if (token === "--pr") {
-      options.pr = parsePositiveIntegerOption(requireOptionValue(args, "--pr", SUBMIT_USAGE), "--pr", SUBMIT_USAGE);
+      options.pr = parsePositiveIntegerOption(readRequiredOptionValue(args, "--pr", SUBMIT_USAGE), "--pr", SUBMIT_USAGE);
       continue;
     }
     if (token === "--kind") {
-      const val = requireOptionValue(args, "--kind", SUBMIT_USAGE);
+      const val = readRequiredOptionValue(args, "--kind", SUBMIT_USAGE);
       if (!VALID_KINDS.has(val)) {
-        throw parseError(`--kind must be one of: ${[...VALID_KINDS].join(", ")}`, SUBMIT_USAGE);
+        throw usageError(`--kind must be one of: ${[...VALID_KINDS].join(", ")}`, SUBMIT_USAGE);
       }
       options.kind = val;
       continue;
     }
     if (token === "--directive") {
-      options.directive = requireOptionValue(args, "--directive", SUBMIT_USAGE, { allowFlagLike: true }).trim();
+      options.directive = readRequiredOptionValue(args, "--directive", SUBMIT_USAGE, { allowFlagLike: true }).trim();
       continue;
     }
     if (token === "--seq") {
-      options.seq = parsePositiveIntegerOption(requireOptionValue(args, "--seq", SUBMIT_USAGE), "--seq", SUBMIT_USAGE);
+      options.seq = parsePositiveIntegerOption(readRequiredOptionValue(args, "--seq", SUBMIT_USAGE), "--seq", SUBMIT_USAGE);
       continue;
     }
     if (token === "--state-file") {
-      options.stateFile = requireOptionValue(args, "--state-file", SUBMIT_USAGE);
+      options.stateFile = readRequiredOptionValue(args, "--state-file", SUBMIT_USAGE);
       continue;
     }
     if (token === "--loop-state") {
-      const val = requireOptionValue(args, "--loop-state", SUBMIT_USAGE);
+      const val = readRequiredOptionValue(args, "--loop-state", SUBMIT_USAGE);
       if (!VALID_LOOP_STATES.has(val)) {
-        throw parseError(`--loop-state must be one of: ${[...VALID_LOOP_STATES].join(", ")}`, SUBMIT_USAGE);
+        throw usageError(`--loop-state must be one of: ${[...VALID_LOOP_STATES].join(", ")}`, SUBMIT_USAGE);
       }
       options.loopState = val;
       options.loopStateExplicit = true;
       continue;
     }
     if (token === "--apply-mode") {
-      const val = requireOptionValue(args, "--apply-mode", SUBMIT_USAGE);
+      const val = readRequiredOptionValue(args, "--apply-mode", SUBMIT_USAGE);
       if (!VALID_APPLY_MODES.has(val)) {
-        throw parseError(`--apply-mode must be one of: ${[...VALID_APPLY_MODES].join(", ")}`, SUBMIT_USAGE);
+        throw usageError(`--apply-mode must be one of: ${[...VALID_APPLY_MODES].join(", ")}`, SUBMIT_USAGE);
       }
       options.applyMode = val;
       continue;
     }
     if (token === "--event-id") {
-      options.eventId = requireOptionValue(args, "--event-id", SUBMIT_USAGE);
+      options.eventId = readRequiredOptionValue(args, "--event-id", SUBMIT_USAGE);
       continue;
     }
     if (token === "--copilot-input") {
-      options.copilotInputPath = requireOptionValue(args, "--copilot-input", SUBMIT_USAGE);
+      options.copilotInputPath = readRequiredOptionValue(args, "--copilot-input", SUBMIT_USAGE);
       continue;
     }
     if (token === "--reviewer-input") {
-      options.reviewerInputPath = requireOptionValue(args, "--reviewer-input", SUBMIT_USAGE);
+      options.reviewerInputPath = readRequiredOptionValue(args, "--reviewer-input", SUBMIT_USAGE);
       continue;
     }
 
-    throw parseError(`Unknown argument: ${token}`, SUBMIT_USAGE);
+    throw usageError(`Unknown argument: ${token}`, SUBMIT_USAGE);
   }
 
   if (!options.help) {
     if ((options.repo === undefined) !== (options.pr === undefined)) {
-      throw parseError("--repo and --pr must be provided together", SUBMIT_USAGE);
+      throw usageError("--repo and --pr must be provided together", SUBMIT_USAGE);
     }
     if (!options.runId && options.repo === undefined) {
-      throw parseError("--run-id is required, or both --repo and --pr must be provided together", SUBMIT_USAGE);
+      throw usageError("--run-id is required, or both --repo and --pr must be provided together", SUBMIT_USAGE);
     }
     if (options.repo !== undefined && options.loopStateExplicit) {
-      throw parseError("--loop-state is low-level/testing mode only; omit it when using --repo/--pr operator mode", SUBMIT_USAGE);
+      throw usageError("--loop-state is low-level/testing mode only; omit it when using --repo/--pr operator mode", SUBMIT_USAGE);
     }
     if (!options.kind) {
-      throw parseError("--kind is required", SUBMIT_USAGE);
+      throw usageError("--kind is required", SUBMIT_USAGE);
     }
     if (!options.directive || options.directive.length === 0) {
-      throw parseError("--directive is required and must be non-empty", SUBMIT_USAGE);
+      throw usageError("--directive is required and must be non-empty", SUBMIT_USAGE);
     }
     if (options.seq === undefined) {
-      throw parseError("--seq is required", SUBMIT_USAGE);
+      throw usageError("--seq is required", SUBMIT_USAGE);
     }
   }
 
@@ -363,36 +364,36 @@ export function parseStatusCliArgs(argv) {
     }
 
     if (token === "--run-id") {
-      options.runId = requireOptionValue(args, "--run-id", STATUS_USAGE).trim();
+      options.runId = readRequiredOptionValue(args, "--run-id", STATUS_USAGE).trim();
       validateSafeRunId(options.runId, STATUS_USAGE);
       continue;
     }
     if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", STATUS_USAGE).trim();
+      options.repo = readRequiredOptionValue(args, "--repo", STATUS_USAGE).trim();
       parseRepoSlugOption(options.repo, STATUS_USAGE);
       continue;
     }
     if (token === "--pr") {
-      options.pr = parsePositiveIntegerOption(requireOptionValue(args, "--pr", STATUS_USAGE), "--pr", STATUS_USAGE);
+      options.pr = parsePositiveIntegerOption(readRequiredOptionValue(args, "--pr", STATUS_USAGE), "--pr", STATUS_USAGE);
       continue;
     }
     if (token === "--state-file") {
-      options.stateFile = requireOptionValue(args, "--state-file", STATUS_USAGE);
+      options.stateFile = readRequiredOptionValue(args, "--state-file", STATUS_USAGE);
       continue;
     }
 
-    throw parseError(`Unknown argument: ${token}`, STATUS_USAGE);
+    throw usageError(`Unknown argument: ${token}`, STATUS_USAGE);
   }
 
   if (!options.help) {
     if ((options.repo === undefined) !== (options.pr === undefined)) {
-      throw parseError("--repo and --pr must be provided together", STATUS_USAGE);
+      throw usageError("--repo and --pr must be provided together", STATUS_USAGE);
     }
     if (options.runId && options.repo !== undefined) {
-      throw parseError("Choose exactly one target mode: either --run-id or --repo/--pr", STATUS_USAGE);
+      throw usageError("Choose exactly one target mode: either --run-id or --repo/--pr", STATUS_USAGE);
     }
     if (!options.runId && options.repo === undefined) {
-      throw parseError("--run-id is required, or both --repo and --pr must be provided together", STATUS_USAGE);
+      throw usageError("--run-id is required, or both --repo and --pr must be provided together", STATUS_USAGE);
     }
   }
 
@@ -419,47 +420,47 @@ export function parsePromoteCliArgs(argv) {
     }
 
     if (token === "--run-id") {
-      options.runId = requireOptionValue(args, "--run-id", PROMOTE_USAGE).trim();
+      options.runId = readRequiredOptionValue(args, "--run-id", PROMOTE_USAGE).trim();
       validateSafeRunId(options.runId, PROMOTE_USAGE);
       continue;
     }
     if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", PROMOTE_USAGE).trim();
+      options.repo = readRequiredOptionValue(args, "--repo", PROMOTE_USAGE).trim();
       parseRepoSlugOption(options.repo, PROMOTE_USAGE);
       continue;
     }
     if (token === "--pr") {
-      options.pr = parsePositiveIntegerOption(requireOptionValue(args, "--pr", PROMOTE_USAGE), "--pr", PROMOTE_USAGE);
+      options.pr = parsePositiveIntegerOption(readRequiredOptionValue(args, "--pr", PROMOTE_USAGE), "--pr", PROMOTE_USAGE);
       continue;
     }
     if (token === "--state-file") {
-      options.stateFile = requireOptionValue(args, "--state-file", PROMOTE_USAGE);
+      options.stateFile = readRequiredOptionValue(args, "--state-file", PROMOTE_USAGE);
       continue;
     }
     if (token === "--loop-state") {
-      const val = requireOptionValue(args, "--loop-state", PROMOTE_USAGE);
+      const val = readRequiredOptionValue(args, "--loop-state", PROMOTE_USAGE);
       if (!VALID_LOOP_STATES.has(val)) {
-        throw parseError(`--loop-state must be one of: ${[...VALID_LOOP_STATES].join(", ")}`, PROMOTE_USAGE);
+        throw usageError(`--loop-state must be one of: ${[...VALID_LOOP_STATES].join(", ")}`, PROMOTE_USAGE);
       }
       options.loopState = val;
       continue;
     }
 
-    throw parseError(`Unknown argument: ${token}`, PROMOTE_USAGE);
+    throw usageError(`Unknown argument: ${token}`, PROMOTE_USAGE);
   }
 
   if (!options.help) {
     if ((options.repo === undefined) !== (options.pr === undefined)) {
-      throw parseError("--repo and --pr must be provided together", PROMOTE_USAGE);
+      throw usageError("--repo and --pr must be provided together", PROMOTE_USAGE);
     }
     if (options.runId && options.repo !== undefined) {
-      throw parseError("Choose exactly one target mode: either --run-id or --repo/--pr", PROMOTE_USAGE);
+      throw usageError("Choose exactly one target mode: either --run-id or --repo/--pr", PROMOTE_USAGE);
     }
     if (!options.runId && options.repo === undefined) {
-      throw parseError("--run-id is required, or both --repo and --pr must be provided together", PROMOTE_USAGE);
+      throw usageError("--run-id is required, or both --repo and --pr must be provided together", PROMOTE_USAGE);
     }
     if (options.loopState === undefined) {
-      throw parseError("--loop-state is required", PROMOTE_USAGE);
+      throw usageError("--loop-state is required", PROMOTE_USAGE);
     }
   }
 
@@ -480,7 +481,7 @@ function quoteCliValue(value) {
 function resolveRequestedRunId(options, usage) {
   const derivedRunId = deriveTargetRunId(options);
   if (options.runId && options.repo !== undefined && options.pr !== undefined && options.runId !== derivedRunId) {
-    throw parseError(
+    throw usageError(
       `run-id mismatch: explicit --run-id ${JSON.stringify(options.runId)} does not match derived run ${JSON.stringify(derivedRunId)} for --repo/--pr target`,
       usage,
     );
@@ -998,7 +999,7 @@ export async function runCli(
     return runStatus(rest, { stdout, cwd });
   }
 
-  const error = parseError(`Unknown subcommand: ${subcommand}`, TOP_USAGE);
+  const error = usageError(`Unknown subcommand: ${subcommand}`, TOP_USAGE);
   throw error;
 }
 

--- a/scripts/loop/watch-initial-copilot-pr.mjs
+++ b/scripts/loop/watch-initial-copilot-pr.mjs
@@ -38,7 +38,8 @@
 import { setTimeout as delay } from "node:timers/promises";
 import { spawn } from "node:child_process";
 
-import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { parseIssueNumber, parseNonNegativeInteger, parsePositiveInteger, requireOptionValue } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import { detectInitialCopilotPrState, LINKED_PR_STATE } from "./detect-initial-copilot-pr-state.mjs";
 import { enforcePersistentInternalWaitTimeout } from "@pi-dev-loops/core/loop/timeout-policy";
@@ -97,43 +98,8 @@ const DEFAULT_POLL_INTERVAL_MS = 60_000;
 /** Default watch budget: 1 hour — Copilot-first durable-wait seam */
 const DEFAULT_TIMEOUT_MS = 3_600_000;
 
-function parseError(message) {
-  return Object.assign(new Error(message), { usage: USAGE });
-}
+const parseError = buildParseError(USAGE);
 
-function requireOptionValue(args, flag) {
-  const value = args.shift();
-
-  if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
-    throw parseError(`Missing value for ${flag}`);
-  }
-
-  return value;
-}
-
-function parsePositiveInteger(value, flag) {
-  if (!/^\d+$/.test(value) || Number(value) === 0) {
-    throw parseError(`${flag} must be a positive integer`);
-  }
-
-  return Number(value);
-}
-
-function parseNonNegativeInteger(value, flag) {
-  if (!/^\d+$/.test(value)) {
-    throw parseError(`${flag} must be a non-negative integer`);
-  }
-
-  return Number(value);
-}
-
-function parseIssueNumber(value) {
-  if (!/^\d+$/.test(value) || Number(value) === 0) {
-    throw parseError("--issue must be a positive integer");
-  }
-
-  return Number(value);
-}
 
 export async function watchCopilotRunUntilComplete(
   { repo, runId, timeoutMs = null },
@@ -202,27 +168,29 @@ export function parseWatchInitialCopilotPrCliArgs(argv) {
     }
 
     if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo").trim();
+      options.repo = requireOptionValue(args, "--repo", parseError).trim();
       continue;
     }
 
     if (token === "--issue") {
-      options.issue = parseIssueNumber(requireOptionValue(args, "--issue"));
+      options.issue = parseIssueNumber(requireOptionValue(args, "--issue", parseError), parseError);
       continue;
     }
 
     if (token === "--poll-interval-ms") {
       options.pollIntervalMs = parsePositiveInteger(
-        requireOptionValue(args, "--poll-interval-ms"),
+        requireOptionValue(args, "--poll-interval-ms", parseError),
         "--poll-interval-ms",
+        parseError,
       );
       continue;
     }
 
     if (token === "--timeout-ms") {
       options.timeoutMs = parseNonNegativeInteger(
-        requireOptionValue(args, "--timeout-ms"),
+        requireOptionValue(args, "--timeout-ms", parseError),
         "--timeout-ms",
+        parseError,
       );
       continue;
     }

--- a/test/_helpers.mjs
+++ b/test/_helpers.mjs
@@ -1,0 +1,172 @@
+import { spawn } from "node:child_process";
+import { chmod, mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export function runNode(scriptPath, args = [], options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(options.execPath ?? process.execPath, [scriptPath, ...args], {
+      cwd: options.cwd,
+      env: options.env ?? process.env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+
+    child.stdin.end(options.stdinText ?? options.stdin ?? "");
+  });
+}
+
+export async function writeJson(filePath, data) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}
+
+function buildGhStubScript() {
+  return [
+    "#!/usr/bin/env node",
+    'const { appendFileSync, mkdirSync, readFileSync, writeFileSync } = require("node:fs");',
+    'const path = require("node:path");',
+    'const sequencePath = process.env.GH_SEQUENCE_PATH;',
+    'const counterPath = process.env.GH_COUNTER_PATH;',
+    'const claimsDir = process.env.GH_CLAIMS_DIR;',
+    'const ghLogPath = process.env.GH_LOG_PATH;',
+    'const mode = process.env.GH_STUB_MODE || "sequential";',
+    'const repeatLast = process.env.GH_REPEAT_LAST_ON_OVERFLOW === "1";',
+    'const overflowMessageMode = process.env.GH_OVERFLOW_MESSAGE_MODE || "numbered";',
+    'const defaultStdout = process.env.GH_DEFAULT_STDOUT ?? "{}\\n";',
+    'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
+    'const actual = process.argv.slice(2);',
+    'const fail = (code, message) => { process.stderr.write(`${message}\\n`); process.exit(code); };',
+    'let entry = null;',
+    'if (mode === "claims") {',
+    '  for (let index = 0; index < entries.length; index += 1) {',
+    '    const candidate = entries[index] ?? { stdout: defaultStdout };',
+    '    const expectedArgs = Array.isArray(candidate.assertArgs) ? candidate.assertArgs : [];',
+    '    if (!expectedArgs.every((expected) => actual.includes(expected))) continue;',
+    '    try {',
+    '      mkdirSync(path.join(claimsDir, String(index)));',
+    '      entry = candidate;',
+    '      break;',
+    '    } catch {',
+    '      continue;',
+    '    }',
+    '  }',
+    '  if (entry == null) {',
+    '    fail(97, `unexpected gh args: ${actual.join(" ")}`);',
+    '  }',
+    '} else {',
+    '  const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
+    '  if (current >= entries.length && !repeatLast) {',
+    '    const message = overflowMessageMode === "generic" ? "unexpected gh call beyond scripted sequence" : `unexpected extra gh call #${current + 1}: ${actual.join(" ")}`;',
+    '    fail(97, message);',
+    '  }',
+    '  const index = entries.length === 0 ? -1 : Math.min(current, entries.length - 1);',
+    '  entry = index >= 0 ? (entries[index] ?? { stdout: defaultStdout }) : { stdout: defaultStdout };',
+    '  writeFileSync(counterPath, String(current + 1));',
+    '}',
+    'if (ghLogPath) {',
+    '  appendFileSync(ghLogPath, `${JSON.stringify(actual)}\\n`);',
+    '}',
+    'let stdin = "";',
+    'process.stdin.setEncoding("utf8");',
+    'process.stdin.on("data", (chunk) => { stdin += chunk; });',
+    'process.stdin.on("end", () => {',
+    '  if (entry.assertArgs) {',
+    '    for (const expected of entry.assertArgs) {',
+    '      if (!actual.includes(expected)) {',
+    '        fail(98, `missing expected gh arg: ${expected}${actual.length > 0 ? `\\nactual: ${actual.join(" ")}` : ""}`);',
+    '      }',
+    '    }',
+    '  }',
+    '  if (entry.assertStdinIncludes) {',
+    '    for (const expected of entry.assertStdinIncludes) {',
+    '      if (!stdin.includes(expected)) {',
+    '        fail(96, `missing expected stdin text: ${expected}`);',
+    '      }',
+    '    }',
+    '  }',
+    '  if (entry.assertStdinExcludes) {',
+    '    for (const forbidden of entry.assertStdinExcludes) {',
+    '      if (stdin.includes(forbidden)) {',
+    '        fail(95, `unexpected stdin text: ${forbidden}`);',
+    '      }',
+    '    }',
+    '  }',
+    '  if (entry.stderr) process.stderr.write(entry.stderr);',
+    '  if (entry.stdout) process.stdout.write(entry.stdout);',
+    '  process.exit(entry.exitCode ?? 0);',
+    '});',
+    "",
+  ].join("\n");
+}
+
+export async function writeGhStub(tempDir, entries = [], {
+  commandName = "gh",
+  matchMode = "sequential",
+  repeatLastOnOverflow = false,
+  defaultStdout = "{}\n",
+  logCalls = false,
+  overflowMessageMode = "numbered",
+} = {}) {
+  const sequencePath = path.join(tempDir, `${commandName}-sequence.json`);
+  const ghPath = path.join(tempDir, commandName);
+  const counterPath = matchMode === "claims" ? null : path.join(tempDir, `${commandName}-counter.txt`);
+  const claimsDir = matchMode === "claims" ? path.join(tempDir, `${commandName}-claims`) : null;
+  const ghLogPath = logCalls ? path.join(tempDir, `${commandName}-log.jsonl`) : null;
+
+  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
+  if (counterPath) {
+    await writeFile(counterPath, "0\n", "utf8");
+  }
+  if (claimsDir) {
+    await mkdir(claimsDir, { recursive: true });
+  }
+  if (ghLogPath) {
+    await writeFile(ghLogPath, "", "utf8");
+  }
+  await writeFile(ghPath, buildGhStubScript(), "utf8");
+  await chmod(ghPath, 0o755);
+
+  const env = {
+    ...process.env,
+    PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
+    GH_SEQUENCE_PATH: sequencePath,
+    GH_STUB_MODE: matchMode,
+    GH_REPEAT_LAST_ON_OVERFLOW: repeatLastOnOverflow ? "1" : "0",
+    GH_DEFAULT_STDOUT: defaultStdout,
+    GH_OVERFLOW_MESSAGE_MODE: overflowMessageMode,
+  };
+
+  if (counterPath) {
+    env.GH_COUNTER_PATH = counterPath;
+  }
+  if (claimsDir) {
+    env.GH_CLAIMS_DIR = claimsDir;
+  }
+  if (ghLogPath) {
+    env.GH_LOG_PATH = ghLogPath;
+  }
+
+  return {
+    env,
+    ghPath,
+    ghLogPath,
+    sequencePath,
+    counterPath,
+    claimsDir,
+  };
+}

--- a/test/_helpers.mjs
+++ b/test/_helpers.mjs
@@ -143,7 +143,7 @@ export async function writeGhStub(tempDir, entries = [], {
 
   const env = {
     ...process.env,
-    PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
+    PATH: [tempDir, process.env.PATH ?? ""].filter(Boolean).join(path.delimiter),
     GH_SEQUENCE_PATH: sequencePath,
     GH_STUB_MODE: matchMode,
     GH_REPEAT_LAST_ON_OVERFLOW: repeatLastOnOverflow ? "1" : "0",

--- a/test/github/audit-copilot-comments.test.mjs
+++ b/test/github/audit-copilot-comments.test.mjs
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import {
   auditCopilotComments,
@@ -15,95 +16,11 @@ import {
 
 const scriptPath = path.resolve("scripts/github/audit-copilot-comments.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(options.execPath ?? process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
-    let stdout = "";
-    let stderr = "";
-    let settled = false;
-
-    const resolveOnce = (value) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      resolve(value);
-    };
-
-    const rejectOnce = (error) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      reject(error);
-    };
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", rejectOnce);
-    child.on("close", (code) => {
-      resolveOnce({ code, stdout, stderr });
-    });
-  });
-}
-
-async function writeGhStub(tempDir, entries, { commandName = "gh" } = {}) {
-  const sequencePath = path.join(tempDir, "gh-sequence.json");
-  const counterPath = path.join(tempDir, "gh-counter.txt");
-  const ghPath = path.join(tempDir, commandName);
-
-  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await writeFile(counterPath, "0\n", "utf8");
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      'const { readFileSync, writeFileSync } = require("node:fs");',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const counterPath = process.env.GH_COUNTER_PATH;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
-      'if (current >= entries.length) {',
-      '  process.stderr.write(`unexpected extra gh call #${current + 1}: ${process.argv.slice(2).join(" ")}\\n`);',
-      '  process.exit(97);',
-      '}',
-      'const entry = entries[current] ?? { stdout: "{}\\n" };',
-      'writeFileSync(counterPath, String(current + 1));',
-      'const actual = process.argv.slice(2);',
-      'if (entry.assertArgs) {',
-      '  for (const expected of entry.assertArgs) {',
-      '    if (!actual.includes(expected)) {',
-      '      process.stderr.write(`missing expected gh arg: ${expected}\\nactual: ${actual.join(" ")}\\n`);',
-      '      process.exit(98);',
-      '    }',
-      '  }',
-      '}',
-      'if (entry.stderr) process.stderr.write(entry.stderr);',
-      'if (entry.stdout) process.stdout.write(entry.stdout);',
-      'process.exit(entry.exitCode ?? 0);',
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    ...process.env,
-    PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-    GH_SEQUENCE_PATH: sequencePath,
-    GH_COUNTER_PATH: counterPath,
-  };
+async function writeGhStub(tempDir, entries, options = {}) {
+  const { env } = await writeGhStubHelper(tempDir, entries, options);
+  return env;
 }
 
 function sampleReviewComment({

--- a/test/github/capture-review-threads.test.mjs
+++ b/test/github/capture-review-threads.test.mjs
@@ -5,92 +5,15 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 const scriptPath = path.resolve("scripts/github/capture-review-threads.mjs");
 const fixturePath = path.resolve("packages/core/test/fixtures/github/review-threads/mixed-threads.json");
 const { REVIEW_THREADS_QUERY } = await import(pathToFileURL(scriptPath).href);
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    if (options.stdin !== undefined) {
-      child.stdin.end(options.stdin);
-    } else {
-      child.stdin.end();
-    }
-
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
-
-async function writeGhStub(tempDir, entries) {
-  const sequencePath = path.join(tempDir, "gh-sequence.json");
-  const counterPath = path.join(tempDir, "gh-counter.txt");
-  const ghPath = path.join(tempDir, "gh");
-
-  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await writeFile(counterPath, "0\n", "utf8");
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      'import { readFileSync, writeFileSync } from "node:fs";',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const counterPath = process.env.GH_COUNTER_PATH;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
-      'const entry = entries[Math.min(current, entries.length - 1)] ?? { stdout: "null\\n" };',
-      'writeFileSync(counterPath, String(current + 1));',
-      "if (entry.assertArgs) {",
-      '  const actual = process.argv.slice(2);',
-      '  for (const expected of entry.assertArgs) {',
-      '    if (!actual.includes(expected)) {',
-      '      process.stderr.write(`missing expected gh arg: ${expected}\\n`);',
-      '      process.exit(98);',
-      '    }',
-      '  }',
-      '}',
-      'if (entry.stderr) {',
-      '  process.stderr.write(entry.stderr);',
-      '}',
-      'if (entry.stdout) {',
-      '  process.stdout.write(entry.stdout);',
-      '}',
-      'process.exit(entry.exitCode ?? 0);',
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    env: {
-      ...process.env,
-      PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-      GH_SEQUENCE_PATH: sequencePath,
-      GH_COUNTER_PATH: counterPath,
-    },
-    counterPath,
-  };
-}
+const writeGhStub = (tempDir, entries) => writeGhStubHelper(tempDir, entries, { repeatLastOnOverflow: true, defaultStdout: "null\n" });
 
 test("capture-review-threads GraphQL query avoids unsupported Bot fields", () => {
   assert.equal(REVIEW_THREADS_QUERY.includes("isBot"), false);

--- a/test/github/detect-gate-review-evidence.test.mjs
+++ b/test/github/detect-gate-review-evidence.test.mjs
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import {
   parseGateReviewCommentMarkerBody,
@@ -17,73 +18,11 @@ import {
 
 const scriptPath = path.resolve("scripts/github/detect-gate-review-evidence.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 async function writeGhStub(tempDir, entries) {
-  const sequencePath = path.join(tempDir, "gh-sequence.json");
-  const counterPath = path.join(tempDir, "gh-counter.txt");
-  const ghPath = path.join(tempDir, "gh");
-
-  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await writeFile(counterPath, "0\n", "utf8");
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      'import { readFileSync, writeFileSync } from "node:fs";',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const counterPath = process.env.GH_COUNTER_PATH;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
-      'const entry = entries[Math.min(current, entries.length - 1)] ?? { stdout: "{}\\n" };',
-      'writeFileSync(counterPath, String(current + 1));',
-      'const actual = process.argv.slice(2);',
-      'if (entry.assertArgs) {',
-      '  for (const expected of entry.assertArgs) {',
-      '    if (!actual.includes(expected)) {',
-      '      process.stderr.write(`missing expected gh arg: ${expected}\\n`);',
-      '      process.exit(98);',
-      '    }',
-      '  }',
-      '}',
-      'if (entry.stderr) process.stderr.write(entry.stderr);',
-      'if (entry.stdout) process.stdout.write(entry.stdout);',
-      'process.exit(entry.exitCode ?? 0);',
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    ...process.env,
-    PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-    GH_SEQUENCE_PATH: sequencePath,
-    GH_COUNTER_PATH: counterPath,
-  };
+  const { env } = await writeGhStubHelper(tempDir, entries, { repeatLastOnOverflow: true });
+  return env;
 }
 
 test("parseGateReviewCommentBody parses the deterministic visible gate comment format", () => {

--- a/test/github/detect-linked-issue-pr.test.mjs
+++ b/test/github/detect-linked-issue-pr.test.mjs
@@ -4,104 +4,17 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import { selectLinkedIssuePr } from "../../scripts/github/detect-linked-issue-pr.mjs";
 
 const scriptPath = path.resolve("scripts/github/detect-linked-issue-pr.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(options.execPath ?? process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-    let settled = false;
-
-    const resolveOnce = (value) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      resolve(value);
-    };
-
-    const rejectOnce = (error) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      reject(error);
-    };
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", rejectOnce);
-    child.on("close", (code) => {
-      resolveOnce({ code, stdout, stderr });
-    });
-  });
-}
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 async function writeGhStub(tempDir, entries) {
-  const sequencePath = path.join(tempDir, "gh-sequence.json");
-  const counterPath = path.join(tempDir, "gh-counter.txt");
-  const ghPath = path.join(tempDir, "gh");
-
-  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await writeFile(counterPath, "0\n", "utf8");
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      'import { readFileSync, writeFileSync } from "node:fs";',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const counterPath = process.env.GH_COUNTER_PATH;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
-      'if (current >= entries.length) {',
-      '  process.stderr.write(`unexpected extra gh call #${current + 1}: ${process.argv.slice(2).join(" ")}\\n`);',
-      '  process.exit(97);',
-      '}',
-      'const entry = entries[current] ?? { stdout: "{}\\n" };',
-      'writeFileSync(counterPath, String(current + 1));',
-      'const actual = process.argv.slice(2);',
-      'if (entry.assertArgs) {',
-      '  for (const expected of entry.assertArgs) {',
-      '    if (!actual.includes(expected)) {',
-      '      process.stderr.write(`missing expected gh arg: ${expected}\\nactual: ${actual.join(" ")}\\n`);',
-      "      process.exit(98);",
-      "    }",
-      "  }",
-      "}",
-      'if (entry.stderr) {',
-      "  process.stderr.write(entry.stderr);",
-      "}",
-      'if (entry.stdout) {',
-      "  process.stdout.write(entry.stdout);",
-      "}",
-      "process.exit(entry.exitCode ?? 0);",
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    ...process.env,
-    PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-    GH_SEQUENCE_PATH: sequencePath,
-    GH_COUNTER_PATH: counterPath,
-  };
+  const { env } = await writeGhStubHelper(tempDir, entries);
+  return env;
 }
 
 function graphqlPayload({ hasNextPage, endCursor, nodes }) {

--- a/test/github/manage-sub-issues.test.mjs
+++ b/test/github/manage-sub-issues.test.mjs
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import {
   computeVerifyResult,
@@ -12,99 +13,11 @@ import {
 
 const scriptPath = path.resolve("scripts/github/manage-sub-issues.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(options.execPath ?? process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-    let settled = false;
-
-    const resolveOnce = (value) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      resolve(value);
-    };
-
-    const rejectOnce = (error) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      reject(error);
-    };
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", rejectOnce);
-    child.on("close", (code) => {
-      resolveOnce({ code, stdout, stderr });
-    });
-  });
-}
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 async function writeGhStub(tempDir, entries) {
-  const sequencePath = path.join(tempDir, "gh-sequence.json");
-  const counterPath = path.join(tempDir, "gh-counter.txt");
-  const ghPath = path.join(tempDir, "gh");
-
-  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await writeFile(counterPath, "0\n", "utf8");
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      'import { readFileSync, writeFileSync } from "node:fs";',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const counterPath = process.env.GH_COUNTER_PATH;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
-      'if (current >= entries.length) {',
-      '  process.stderr.write(`unexpected extra gh call #${current + 1}: ${process.argv.slice(2).join(" ")}\\n`);',
-      '  process.exit(97);',
-      '}',
-      'const entry = entries[current] ?? { stdout: "{}\\n" };',
-      'writeFileSync(counterPath, String(current + 1));',
-      'const actual = process.argv.slice(2);',
-      'if (entry.assertArgs) {',
-      '  for (const expected of entry.assertArgs) {',
-      '    if (!actual.includes(expected)) {',
-      '      process.stderr.write(`missing expected gh arg: ${expected}\\nactual: ${actual.join(" ")}\\n`);',
-      "      process.exit(98);",
-      "    }",
-      "  }",
-      "}",
-      'if (entry.stderr) {',
-      "  process.stderr.write(entry.stderr);",
-      "}",
-      'if (entry.stdout) {',
-      "  process.stdout.write(entry.stdout);",
-      "}",
-      "process.exit(entry.exitCode ?? 0);",
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    ...process.env,
-    PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-    GH_SEQUENCE_PATH: sequencePath,
-    GH_COUNTER_PATH: counterPath,
-  };
+  const { env } = await writeGhStubHelper(tempDir, entries);
+  return env;
 }
 
 function subIssuePayload(subIssues) {

--- a/test/github/reconcile-draft-gate.test.mjs
+++ b/test/github/reconcile-draft-gate.test.mjs
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import {
   parseReconcileDraftGateCliArgs,
@@ -11,91 +12,11 @@ import {
 
 const scriptPath = path.resolve("scripts/github/reconcile-draft-gate.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 async function writeGhStub(tempDir, entries) {
-  const sequencePath = path.join(tempDir, "gh-sequence.json");
-  const counterPath = path.join(tempDir, "gh-counter.txt");
-  const ghPath = path.join(tempDir, "gh");
-
-  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await writeFile(counterPath, "0\n", "utf8");
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      'import { readFileSync, writeFileSync } from "node:fs";',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const counterPath = process.env.GH_COUNTER_PATH;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
-      'const entry = entries[Math.min(current, entries.length - 1)] ?? { stdout: "{}\\n" };',
-      'writeFileSync(counterPath, String(current + 1));',
-      'const actual = process.argv.slice(2);',
-      'if (entry.assertArgs) {',
-      '  for (const expected of entry.assertArgs) {',
-      '    if (!actual.includes(expected)) {',
-      '      process.stderr.write(`missing expected gh arg: ${expected}\\n`);',
-      '      process.exit(98);',
-      '    }',
-      '  }',
-      '}',
-      'if (entry.assertArgContains) {',
-      '  for (const expected of entry.assertArgContains) {',
-      '    if (!actual.some((value) => value.includes(expected))) {',
-      '      process.stderr.write(`missing expected gh arg fragment: ${expected}\\n`);',
-      '      process.exit(97);',
-      '    }',
-      '  }',
-      '}',
-      'if (entry.assertArgNotContains) {',
-      '  for (const unexpected of entry.assertArgNotContains) {',
-      '    if (actual.some((value) => value.includes(unexpected))) {',
-      '      process.stderr.write(`unexpected gh arg fragment: ${unexpected}\\n`);',
-      '      process.exit(96);',
-      '    }',
-      '  }',
-      '}',
-      'if (entry.stderr) process.stderr.write(entry.stderr);',
-      'if (entry.stdout) process.stdout.write(entry.stdout);',
-      'process.exit(entry.exitCode ?? 0);',
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    ...process.env,
-    PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-    GH_SEQUENCE_PATH: sequencePath,
-    GH_COUNTER_PATH: counterPath,
-  };
+  const { env } = await writeGhStubHelper(tempDir, entries, { repeatLastOnOverflow: true });
+  return env;
 }
 
 async function readGhCallCount(tempDir) {

--- a/test/github/reply-resolve-review-thread.test.mjs
+++ b/test/github/reply-resolve-review-thread.test.mjs
@@ -4,34 +4,12 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 import { hasCommitShaReference } from "../../scripts/github/reply-resolve-review-thread.mjs";
 
 const scriptPath = path.resolve("scripts/github/reply-resolve-review-thread.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 function createReviewThreadsPayload(threads) {
   return `${JSON.stringify({
@@ -47,74 +25,7 @@ function createReviewThreadsPayload(threads) {
   })}\n`;
 }
 
-async function writeGhStub(tempDir, entries) {
-  const sequencePath = path.join(tempDir, "gh-sequence.json");
-  const counterPath = path.join(tempDir, "gh-counter.txt");
-  const ghPath = path.join(tempDir, "gh");
-  const ghLogPath = path.join(tempDir, "gh-log.jsonl");
-
-  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await writeFile(counterPath, "0\n", "utf8");
-  await writeFile(ghLogPath, "", "utf8");
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      'import { appendFileSync, readFileSync, writeFileSync } from "node:fs";',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const counterPath = process.env.GH_COUNTER_PATH;",
-      "const ghLogPath = process.env.GH_LOG_PATH;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
-      'const entry = entries[Math.min(current, entries.length - 1)] ?? { stdout: "{}\\n" };',
-      'writeFileSync(counterPath, String(current + 1));',
-      'appendFileSync(ghLogPath, `${JSON.stringify(process.argv.slice(2))}\\n`);',
-      'const actual = process.argv.slice(2);',
-      'let stdin = "";',
-      'process.stdin.setEncoding("utf8");',
-      'process.stdin.on("data", (chunk) => { stdin += chunk; });',
-      'if (entry.assertArgs) {',
-      '  for (const expected of entry.assertArgs) {',
-      '    if (!actual.includes(expected)) {',
-      '      process.stderr.write(`missing expected gh arg: ${expected}\\n`);',
-      '      process.exit(98);',
-      '    }',
-      '  }',
-      '}',
-      'process.stdin.on("end", () => {',
-      'if (entry.assertStdinIncludes) {',
-      '  for (const expected of entry.assertStdinIncludes) {',
-      '    if (!stdin.includes(expected)) {',
-      '      process.stderr.write(`missing expected stdin text: ${expected}\\n`);',
-      '      process.exit(97);',
-      '    }',
-      '  }',
-      '}',
-      'if (entry.stderr) {',
-      '  process.stderr.write(entry.stderr);',
-      '}',
-      'if (entry.stdout) {',
-      '  process.stdout.write(entry.stdout);',
-      '}',
-      'process.exit(entry.exitCode ?? 0);',
-      '});',
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    env: {
-      ...process.env,
-      PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-      GH_SEQUENCE_PATH: sequencePath,
-      GH_COUNTER_PATH: counterPath,
-      GH_LOG_PATH: ghLogPath,
-    },
-    ghLogPath,
-  };
-}
+const writeGhStub = (tempDir, entries) => writeGhStubHelper(tempDir, entries, { repeatLastOnOverflow: true, logCalls: true });
 
 test("reply-resolve-review-thread posts a reply then resolves the thread", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-thread-"));

--- a/test/github/reply-resolve-review-threads.test.mjs
+++ b/test/github/reply-resolve-review-threads.test.mjs
@@ -4,37 +4,13 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import { parseReplyResolveThreadsCliArgs } from "../../scripts/github/reply-resolve-review-threads.mjs";
 
 const scriptPath = path.resolve("scripts/github/reply-resolve-review-threads.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.stdin.end(options.stdinText ?? "");
-
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 function createReviewThreadsPayload(threads) {
   return `${JSON.stringify({
@@ -50,74 +26,7 @@ function createReviewThreadsPayload(threads) {
   })}\n`;
 }
 
-async function writeGhStub(tempDir, entries) {
-  const sequencePath = path.join(tempDir, "gh-sequence.json");
-  const counterPath = path.join(tempDir, "gh-counter.txt");
-  const ghPath = path.join(tempDir, "gh");
-  const ghLogPath = path.join(tempDir, "gh-log.jsonl");
-
-  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await writeFile(counterPath, "0\n", "utf8");
-  await writeFile(ghLogPath, "", "utf8");
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      'import { appendFileSync, readFileSync, writeFileSync } from "node:fs";',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const counterPath = process.env.GH_COUNTER_PATH;",
-      "const ghLogPath = process.env.GH_LOG_PATH;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
-      'const entry = entries[Math.min(current, entries.length - 1)] ?? { stdout: "{}\\n" };',
-      'writeFileSync(counterPath, String(current + 1));',
-      'appendFileSync(ghLogPath, `${JSON.stringify(process.argv.slice(2))}\\n`);',
-      'const actual = process.argv.slice(2);',
-      'let stdin = "";',
-      'process.stdin.setEncoding("utf8");',
-      'process.stdin.on("data", (chunk) => { stdin += chunk; });',
-      'if (entry.assertArgs) {',
-      '  for (const expected of entry.assertArgs) {',
-      '    if (!actual.includes(expected)) {',
-      '      process.stderr.write(`missing expected gh arg: ${expected}\\n`);',
-      '      process.exit(98);',
-      '    }',
-      '  }',
-      '}',
-      'process.stdin.on("end", () => {',
-      'if (entry.assertStdinIncludes) {',
-      '  for (const expected of entry.assertStdinIncludes) {',
-      '    if (!stdin.includes(expected)) {',
-      '      process.stderr.write(`missing expected stdin text: ${expected}\\n`);',
-      '      process.exit(97);',
-      '    }',
-      '  }',
-      '}',
-      'if (entry.stderr) {',
-      '  process.stderr.write(entry.stderr);',
-      '}',
-      'if (entry.stdout) {',
-      '  process.stdout.write(entry.stdout);',
-      '}',
-      'process.exit(entry.exitCode ?? 0);',
-      '});',
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    env: {
-      ...process.env,
-      PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-      GH_SEQUENCE_PATH: sequencePath,
-      GH_COUNTER_PATH: counterPath,
-      GH_LOG_PATH: ghLogPath,
-    },
-    ghLogPath,
-  };
-}
+const writeGhStub = (tempDir, entries) => writeGhStubHelper(tempDir, entries, { repeatLastOnOverflow: true, logCalls: true });
 
 test("parseReplyResolveThreadsCliArgs sets defaults and parses optional flags", () => {
   assert.deepEqual(

--- a/test/github/request-copilot-review.test.mjs
+++ b/test/github/request-copilot-review.test.mjs
@@ -4,80 +4,15 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 const scriptPath = path.resolve("scripts/github/request-copilot-review.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 async function writeGhStub(tempDir, entries) {
-  const sequencePath = path.join(tempDir, "gh-sequence.json");
-  const counterPath = path.join(tempDir, "gh-counter.txt");
-  const ghPath = path.join(tempDir, "gh");
-
-  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await writeFile(counterPath, "0\n", "utf8");
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      'import { readFileSync, writeFileSync } from "node:fs";',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const counterPath = process.env.GH_COUNTER_PATH;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
-      'const entry = entries[Math.min(current, entries.length - 1)] ?? { stdout: "{}\\n" };',
-      'writeFileSync(counterPath, String(current + 1));',
-      'const actual = process.argv.slice(2);',
-      'if (entry.assertArgs) {',
-      '  for (const expected of entry.assertArgs) {',
-      '    if (!actual.includes(expected)) {',
-      '      process.stderr.write(`missing expected gh arg: ${expected}\\n`);',
-      '      process.exit(98);',
-      '    }',
-      '  }',
-      '}',
-      'if (entry.stderr) {',
-      '  process.stderr.write(entry.stderr);',
-      '}',
-      'if (entry.stdout) {',
-      '  process.stdout.write(entry.stdout);',
-      '}',
-      'process.exit(entry.exitCode ?? 0);',
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    ...process.env,
-    PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-    GH_SEQUENCE_PATH: sequencePath,
-    GH_COUNTER_PATH: counterPath,
-  };
+  const { env } = await writeGhStubHelper(tempDir, entries, { repeatLastOnOverflow: true });
+  return env;
 }
 
 test("request-copilot-review requests Copilot deterministically and verifies via requested_reviewers", async () => {

--- a/test/github/resolve-tracker-local-spec.test.mjs
+++ b/test/github/resolve-tracker-local-spec.test.mjs
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import {
   parseGitHubIssueUrl,
@@ -12,99 +13,11 @@ import {
 
 const scriptPath = path.resolve("scripts/github/resolve-tracker-local-spec.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(options.execPath ?? process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-    let settled = false;
-
-    const resolveOnce = (value) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      resolve(value);
-    };
-
-    const rejectOnce = (error) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      reject(error);
-    };
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", rejectOnce);
-    child.on("close", (code) => {
-      resolveOnce({ code, stdout, stderr });
-    });
-  });
-}
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 async function writeGhStub(tempDir, entries) {
-  const sequencePath = path.join(tempDir, "gh-sequence.json");
-  const counterPath = path.join(tempDir, "gh-counter.txt");
-  const ghPath = path.join(tempDir, "gh");
-
-  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await writeFile(counterPath, "0\n", "utf8");
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      'import { readFileSync, writeFileSync } from "node:fs";',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const counterPath = process.env.GH_COUNTER_PATH;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
-      'if (current >= entries.length) {',
-      '  process.stderr.write(`unexpected extra gh call #${current + 1}: ${process.argv.slice(2).join(" ")}\\n`);',
-      '  process.exit(97);',
-      '}',
-      'const entry = entries[current] ?? { stdout: "{}\\n" };',
-      'writeFileSync(counterPath, String(current + 1));',
-      'const actual = process.argv.slice(2);',
-      'if (entry.assertArgs) {',
-      '  for (const expected of entry.assertArgs) {',
-      '    if (!actual.includes(expected)) {',
-      '      process.stderr.write(`missing expected gh arg: ${expected}\\nactual: ${actual.join(" ")}\\n`);',
-      "      process.exit(98);",
-      "    }",
-      "  }",
-      "}",
-      'if (entry.stderr) {',
-      "  process.stderr.write(entry.stderr);",
-      "}",
-      'if (entry.stdout) {',
-      "  process.stdout.write(entry.stdout);",
-      "}",
-      "process.exit(entry.exitCode ?? 0);",
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    ...process.env,
-    PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-    GH_SEQUENCE_PATH: sequencePath,
-    GH_COUNTER_PATH: counterPath,
-  };
+  const { env } = await writeGhStubHelper(tempDir, entries);
+  return env;
 }
 
 test("parseGitHubIssueUrl accepts full GitHub issue URLs", () => {

--- a/test/github/stage-reviewer-draft.test.mjs
+++ b/test/github/stage-reviewer-draft.test.mjs
@@ -4,115 +4,15 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 const scriptPath = path.resolve("scripts/github/stage-reviewer-draft.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
-    let stdout = "";
-    let stderr = "";
+const writeJson = writeJsonHelper;
 
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
-
-async function writeJson(filePath, value) {
-  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
-}
-
-async function writeGhStub(tempDir, entries) {
-  const sequencePath = path.join(tempDir, "gh-sequence.json");
-  const counterPath = path.join(tempDir, "gh-counter.txt");
-  const ghPath = path.join(tempDir, "gh");
-  const ghLogPath = path.join(tempDir, "gh-log.jsonl");
-
-  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await writeFile(counterPath, "0\n", "utf8");
-  await writeFile(ghLogPath, "", "utf8");
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      'import { appendFileSync, readFileSync, writeFileSync } from "node:fs";',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const counterPath = process.env.GH_COUNTER_PATH;",
-      "const ghLogPath = process.env.GH_LOG_PATH;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
-      "if (current >= entries.length) {",
-      '  process.stderr.write("unexpected gh call beyond scripted sequence\\n");',
-      "  process.exit(97);",
-      "}",
-      "const actual = process.argv.slice(2);",
-      'appendFileSync(ghLogPath, `${JSON.stringify(actual)}\\n`);',
-      'const entry = entries[current] ?? { stdout: "{}\\n" };',
-      'writeFileSync(counterPath, String(current + 1));',
-      'let stdin = "";',
-      'process.stdin.setEncoding("utf8");',
-      'process.stdin.on("data", (chunk) => { stdin += chunk; });',
-      'process.stdin.on("end", () => {',
-      '  if (entry.assertArgs) {',
-      '    for (const expected of entry.assertArgs) {',
-      '      if (!actual.includes(expected)) {',
-      '        process.stderr.write(`missing expected gh arg: ${expected}\\n`);',
-      '        process.exit(98);',
-      '      }',
-      '    }',
-      '  }',
-      '  if (entry.assertStdinIncludes) {',
-      '    for (const expected of entry.assertStdinIncludes) {',
-      '      if (!stdin.includes(expected)) {',
-      '        process.stderr.write(`missing expected stdin text: ${expected}\\n`);',
-      '        process.exit(96);',
-      '      }',
-      '    }',
-      '  }',
-      '  if (entry.assertStdinExcludes) {',
-      '    for (const forbidden of entry.assertStdinExcludes) {',
-      '      if (stdin.includes(forbidden)) {',
-      '        process.stderr.write(`unexpected stdin text: ${forbidden}\\n`);',
-      '        process.exit(95);',
-      '      }',
-      '    }',
-      '  }',
-      '  if (entry.stderr) process.stderr.write(entry.stderr);',
-      '  if (entry.stdout) process.stdout.write(entry.stdout);',
-      '  process.exit(entry.exitCode ?? 0);',
-      '});',
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    env: {
-      ...process.env,
-      PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-      GH_SEQUENCE_PATH: sequencePath,
-      GH_COUNTER_PATH: counterPath,
-      GH_LOG_PATH: ghLogPath,
-    },
-    ghLogPath,
-  };
-}
+const writeGhStub = (tempDir, entries) => writeGhStubHelper(tempDir, entries, { logCalls: true });
 
 test("stage-reviewer-draft posts a deterministic pending review and writes local state", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stage-reviewer-draft-"));

--- a/test/github/upsert-gate-review-comment.test.mjs
+++ b/test/github/upsert-gate-review-comment.test.mjs
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import {
   parseUpsertGateReviewCommentCliArgs,
@@ -12,93 +13,11 @@ import {
 
 const scriptPath = path.resolve("scripts/github/upsert-gate-review-comment.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 async function writeGhStub(tempDir, entries) {
-  const sequencePath = path.join(tempDir, "gh-sequence.json");
-  const counterPath = path.join(tempDir, "gh-counter.txt");
-  const ghPath = path.join(tempDir, "gh");
-
-  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await writeFile(counterPath, "0\n", "utf8");
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      'import { readFileSync, writeFileSync } from "node:fs";',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const counterPath = process.env.GH_COUNTER_PATH;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
-      'const entry = entries[Math.min(current, entries.length - 1)] ?? { stdout: "{}\\n" };',
-      'writeFileSync(counterPath, String(current + 1));',
-      'const actual = process.argv.slice(2);',
-      'if (entry.assertArgs) {',
-      '  for (const expected of entry.assertArgs) {',
-      '    if (!actual.includes(expected)) {',
-      '      process.stderr.write(`missing expected gh arg: ${expected}\\n`);',
-      '      process.exit(98);',
-      '    }',
-      '  }',
-      '}',
-      'if (entry.assertArgContains) {',
-      '  for (const expected of entry.assertArgContains) {',
-      '    if (!actual.some((value) => value.includes(expected))) {',
-      '      process.stderr.write(`missing expected gh arg fragment: ${expected}\\n`);',
-      '      process.exit(97);',
-      '    }',
-      '  }',
-      '}',
-      'if (entry.assertArgNotContains) {',
-      '  for (const unexpected of entry.assertArgNotContains) {',
-      '    if (actual.some((value) => value.includes(unexpected))) {',
-      '      process.stderr.write(`unexpected gh arg fragment: ${unexpected}\\n`);',
-      '      process.exit(96);',
-      '    }',
-      '  }',
-      '}',
-      'if (entry.stderr) {',
-      '  process.stderr.write(entry.stderr);',
-      '}',
-      'if (entry.stdout) {',
-      '  process.stdout.write(entry.stdout);',
-      '}',
-      'process.exit(entry.exitCode ?? 0);',
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    ...process.env,
-    PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-    GH_SEQUENCE_PATH: sequencePath,
-    GH_COUNTER_PATH: counterPath,
-  };
+  const { env } = await writeGhStubHelper(tempDir, entries, { repeatLastOnOverflow: true });
+  return env;
 }
 
 test("parseUpsertGateReviewCommentCliArgs rejects malformed arguments deterministically", () => {

--- a/test/github/watch-copilot-review.test.mjs
+++ b/test/github/watch-copilot-review.test.mjs
@@ -4,35 +4,13 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import { buildAttemptBudget, buildPollDelayMs, parseWatchCliArgs } from "../../scripts/github/watch-copilot-review.mjs";
 
 const scriptPath = path.resolve("scripts/github/watch-copilot-review.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 function createThread(commentId, login, body, type = "User") {
   return {
@@ -93,42 +71,8 @@ function createActivityPayload({ threads = [], reviews = [], issueComments = [] 
 }
 
 async function writeGhStub(tempDir, entries) {
-  const sequencePath = path.join(tempDir, "gh-sequence.json");
-  const counterPath = path.join(tempDir, "gh-counter.txt");
-  const ghPath = path.join(tempDir, "gh");
-
-  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await writeFile(counterPath, "0\n", "utf8");
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      'import { readFileSync, writeFileSync } from "node:fs";',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const counterPath = process.env.GH_COUNTER_PATH;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
-      'const entry = entries[Math.min(current, entries.length - 1)] ?? { stdout: "null\\n" };',
-      'writeFileSync(counterPath, String(current + 1));',
-      'if (entry.stderr) {',
-      '  process.stderr.write(entry.stderr);',
-      '}',
-      'if (entry.stdout) {',
-      '  process.stdout.write(entry.stdout);',
-      '}',
-      'process.exit(entry.exitCode ?? 0);',
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    ...process.env,
-    PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-    GH_SEQUENCE_PATH: sequencePath,
-    GH_COUNTER_PATH: counterPath,
-  };
+  const { env } = await writeGhStubHelper(tempDir, entries, { repeatLastOnOverflow: true, defaultStdout: "null\n" });
+  return env;
 }
 
 function noChangePayload(status, attempts) {

--- a/test/loop/_checkpoint-io.test.mjs
+++ b/test/loop/_checkpoint-io.test.mjs
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import { readExistingCheckpoint } from "../../scripts/loop/_checkpoint-io.mjs";
 
@@ -21,10 +22,7 @@ async function withTempDir(fn) {
   }
 }
 
-async function writeJson(filePath, data) {
-  await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
-}
+const writeJson = writeJsonHelper;
 
 // ---------------------------------------------------------------------------
 // readExistingCheckpoint: default path resolution

--- a/test/loop/cli-primitives.test.mjs
+++ b/test/loop/cli-primitives.test.mjs
@@ -1,7 +1,24 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { parsePrNumber, requireOptionValue, runChild } from "../../scripts/_cli-primitives.mjs";
+import { buildParseError } from "../../scripts/_core-helpers.mjs";
+import {
+  parseIssueNumber,
+  parseNonNegativeInteger,
+  parsePositiveInteger,
+  parsePrNumber,
+  requireOptionValue,
+  runChild,
+  runCommand,
+} from "../../scripts/_cli-primitives.mjs";
+
+test("buildParseError attaches usage to returned errors", () => {
+  const parseError = buildParseError("usage text");
+  const error = parseError("bad flag");
+
+  assert.equal(error.message, "bad flag");
+  assert.equal(error.usage, "usage text");
+});
 
 test("requireOptionValue returns next value", () => {
   const args = ["abc"];
@@ -13,6 +30,38 @@ test("requireOptionValue uses provided parseError", () => {
     () => requireOptionValue([], "--repo", (message) => Object.assign(new Error(message), { usage: "usage" })),
     (error) => error.message === "Missing value for --repo" && error.usage === "usage",
   );
+});
+
+test("requireOptionValue can reject short flag-like values when configured", () => {
+  const parseError = buildParseError("usage");
+  assert.throws(
+    () => requireOptionValue(["-h"], "--branch", parseError, { flagPattern: /^-/u }),
+    (error) => error.message === "Missing value for --branch" && error.usage === "usage",
+  );
+});
+
+test("parsePositiveInteger validates positive integers with custom error", () => {
+  assert.throws(
+    () => parsePositiveInteger("0", "--limit", (message) => Object.assign(new Error(message), { usage: "usage" })),
+    (error) => error.message === "--limit must be a positive integer" && error.usage === "usage",
+  );
+  assert.equal(parsePositiveInteger("7", "--limit"), 7);
+});
+
+test("parseNonNegativeInteger accepts zero and rejects invalid values", () => {
+  assert.equal(parseNonNegativeInteger("0", "--timeout-ms"), 0);
+  assert.throws(
+    () => parseNonNegativeInteger("abc", "--timeout-ms", (message) => Object.assign(new Error(message), { usage: "usage" })),
+    (error) => error.message === "--timeout-ms must be a non-negative integer" && error.usage === "usage",
+  );
+});
+
+test("parseIssueNumber validates issue numbers with custom error", () => {
+  assert.throws(
+    () => parseIssueNumber("0", (message) => Object.assign(new Error(message), { usage: "usage" })),
+    (error) => error.message === "--issue must be a positive integer" && error.usage === "usage",
+  );
+  assert.equal(parseIssueNumber("42"), 42);
 });
 
 test("parsePrNumber validates positive integer with custom error", () => {
@@ -32,4 +81,25 @@ test("runChild captures stdout and stderr", async () => {
   assert.equal(result.code, 0);
   assert.equal(result.stdout, "ok");
   assert.equal(result.stderr, "warn");
+});
+
+test("runCommand resolves stdout/stderr with cwd and env", async () => {
+  const result = await runCommand(
+    process.execPath,
+    [
+      "-e",
+      "process.stdout.write(process.cwd()); process.stderr.write(process.env.TEST_TOKEN);",
+    ],
+    { cwd: process.cwd(), env: { ...process.env, TEST_TOKEN: "seen" } },
+  );
+
+  assert.equal(result.stdout, process.cwd());
+  assert.equal(result.stderr, "seen");
+});
+
+test("runCommand rejects with stderr detail on non-zero exit", async () => {
+  await assert.rejects(
+    () => runCommand(process.execPath, ["-e", "process.stderr.write('boom'); process.exit(4);"]),
+    /boom/,
+  );
 });

--- a/test/loop/conductor-routing.test.mjs
+++ b/test/loop/conductor-routing.test.mjs
@@ -11,38 +11,13 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 const scriptPath = path.resolve("scripts/loop/outer-loop.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env ?? process.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
-
-async function writeJson(filePath, data) {
-  await writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
-}
+const writeJson = writeJsonHelper;
 
 async function writeGitStub(tempDir, { porcelainOutput = "", headRef = "main" } = {}) {
   const gitPath = path.join(tempDir, "git");

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -4,92 +4,22 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import { parseHandoffCliArgs } from "../../scripts/loop/copilot-pr-handoff.mjs";
 import { EXTERNAL_HEALTHY_WAIT_TIMEOUT_POLICY } from "../../packages/core/src/loop/timeout-policy.mjs";
 
 const scriptPath = path.resolve("scripts/loop/copilot-pr-handoff.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 /**
  * Write a gh stub that responds to a sequence of calls.
  * Each entry: { assertArgs?, stdout?, stderr?, exitCode? }
  */
 async function writeGhStub(tempDir, entries) {
-  const sequencePath = path.join(tempDir, "gh-sequence.json");
-  const counterPath = path.join(tempDir, "gh-counter.txt");
-  const ghPath = path.join(tempDir, "gh");
-
-  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await writeFile(counterPath, "0\n", "utf8");
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      'import { readFileSync, writeFileSync } from "node:fs";',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const counterPath = process.env.GH_COUNTER_PATH;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
-      'if (current >= entries.length) {',
-      '  process.stderr.write("unexpected gh call beyond scripted sequence\\n");',
-      '  process.exit(97);',
-      '}',
-      'const entry = entries[current] ?? { stdout: "{}\\n" };',
-      'writeFileSync(counterPath, String(current + 1));',
-      'const actual = process.argv.slice(2);',
-      'if (entry.assertArgs) {',
-      '  for (const expected of entry.assertArgs) {',
-      '    if (!actual.includes(expected)) {',
-      '      process.stderr.write(`missing expected gh arg: ${expected}\\n`);',
-      '      process.exit(98);',
-      '    }',
-      '  }',
-      '}',
-      'if (entry.stderr) {',
-      '  process.stderr.write(entry.stderr);',
-      '}',
-      'if (entry.stdout) {',
-      '  process.stdout.write(entry.stdout);',
-      '}',
-      'process.exit(entry.exitCode ?? 0);',
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    ...process.env,
-    PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-    GH_SEQUENCE_PATH: sequencePath,
-    GH_COUNTER_PATH: counterPath,
-  };
+  const { env } = await writeGhStubHelper(tempDir, entries);
+  return env;
 }
 
 const EMPTY_THREADS = JSON.stringify({

--- a/test/loop/detect-copilot-loop-state.test.mjs
+++ b/test/loop/detect-copilot-loop-state.test.mjs
@@ -5,107 +5,23 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import { autoDetectSnapshot, parseDetectCliArgs } from "../../scripts/loop/detect-copilot-loop-state.mjs";
 
 const scriptPath = path.resolve("scripts/loop/detect-copilot-loop-state.mjs");
 const fixturePath = path.resolve("packages/core/test/fixtures/github/review-threads/mixed-threads.json");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
-
-async function writeJson(filePath, value) {
-  const dir = path.dirname(filePath);
-  const { mkdir } = await import("node:fs/promises");
-  await mkdir(dir, { recursive: true });
-  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
-}
+const writeJson = writeJsonHelper;
 
 /**
  * Write a gh stub that matches scripted gh invocations in any order.
  * Each matching entry is claimed at most once via the claims directory.
  * Each entry: { assertArgs?, stdout?, stderr?, exitCode? }
  */
-async function writeGhStub(tempDir, entries) {
-  const sequencePath = path.join(tempDir, "gh-sequence.json");
-  const claimsDir = path.join(tempDir, "gh-claims");
-  const ghPath = path.join(tempDir, "gh");
-
-  const { mkdir } = await import("node:fs/promises");
-  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await mkdir(claimsDir, { recursive: true });
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      'import { mkdirSync, readFileSync } from "node:fs";',
-      'import path from "node:path";',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const claimsDir = process.env.GH_CLAIMS_DIR;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const actual = process.argv.slice(2);',
-      'let selected = null;',
-      'for (let index = 0; index < entries.length; index += 1) {',
-      '  const entry = entries[index] ?? { stdout: "{}\\n" };',
-      '  const expectedArgs = Array.isArray(entry.assertArgs) ? entry.assertArgs : [];',
-      '  if (!expectedArgs.every((expected) => actual.includes(expected))) continue;',
-      '  try {',
-      '    mkdirSync(path.join(claimsDir, String(index)));',
-      '    selected = entry;',
-      '    break;',
-      '  } catch {',
-      '    continue;',
-      '  }',
-      '}',
-      'if (selected == null) {',
-      '  process.stderr.write("unexpected gh args: " + actual.join(" ") + "\\n");',
-      '  process.exit(97);',
-      '}',
-      'if (selected.stderr) {',
-      '  process.stderr.write(selected.stderr);',
-      '}',
-      'if (selected.stdout) {',
-      '  process.stdout.write(selected.stdout);',
-      '}',
-      'process.exit(selected.exitCode ?? 0);',
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    env: {
-      ...process.env,
-      PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-      GH_SEQUENCE_PATH: sequencePath,
-      GH_CLAIMS_DIR: claimsDir,
-    },
-  };
-}
+const writeGhStub = (tempDir, entries) => writeGhStubHelper(tempDir, entries, { matchMode: "claims" });
 
 function makeReviewThreadsPayload(nodes = []) {
   return {

--- a/test/loop/detect-copilot-session-activity.test.mjs
+++ b/test/loop/detect-copilot-session-activity.test.mjs
@@ -4,85 +4,15 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 const scriptPath = path.resolve("scripts/loop/detect-copilot-session-activity.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 async function writeGhStub(tempDir, entries) {
-  const sequencePath = path.join(tempDir, "gh-sequence.json");
-  const counterPath = path.join(tempDir, "gh-counter.txt");
-  const ghPath = path.join(tempDir, "gh");
-
-  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await writeFile(counterPath, "0\n", "utf8");
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      'import { readFileSync, writeFileSync } from "node:fs";',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const counterPath = process.env.GH_COUNTER_PATH;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
-      'if (current >= entries.length) {',
-      '  process.stderr.write(`unexpected extra gh call #${current + 1}: ${process.argv.slice(2).join(" ")}\\n`);',
-      "  process.exit(97);",
-      "}",
-      'const entry = entries[current] ?? { stdout: "{}\\n" };',
-      'writeFileSync(counterPath, String(current + 1));',
-      'const actual = process.argv.slice(2);',
-      'if (entry.assertArgs) {',
-      "  for (const expected of entry.assertArgs) {",
-      "    if (!actual.includes(expected)) {",
-      '      process.stderr.write(`missing expected gh arg: ${expected}\\nactual: ${actual.join(" ")}\\n`);',
-      "      process.exit(98);",
-      "    }",
-      "  }",
-      "}",
-      'if (entry.stderr) {',
-      "  process.stderr.write(entry.stderr);",
-      "}",
-      'if (entry.stdout) {',
-      "  process.stdout.write(entry.stdout);",
-      "}",
-      "process.exit(entry.exitCode ?? 0);",
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    ...process.env,
-    PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-    GH_SEQUENCE_PATH: sequencePath,
-    GH_COUNTER_PATH: counterPath,
-  };
+  const { env } = await writeGhStubHelper(tempDir, entries);
+  return env;
 }
 
 test("detect-copilot-session-activity reports active when matching run is in progress", async () => {

--- a/test/loop/detect-initial-copilot-pr-state.test.mjs
+++ b/test/loop/detect-initial-copilot-pr-state.test.mjs
@@ -4,85 +4,15 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 const scriptPath = path.resolve("scripts/loop/detect-initial-copilot-pr-state.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 async function writeGhStub(tempDir, entries) {
-  const sequencePath = path.join(tempDir, "gh-sequence.json");
-  const counterPath = path.join(tempDir, "gh-counter.txt");
-  const ghPath = path.join(tempDir, "gh");
-
-  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await writeFile(counterPath, "0\n", "utf8");
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      'import { readFileSync, writeFileSync } from "node:fs";',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const counterPath = process.env.GH_COUNTER_PATH;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
-      'if (current >= entries.length) {',
-      '  process.stderr.write(`unexpected extra gh call #${current + 1}: ${process.argv.slice(2).join(" ")}\\n`);',
-      "  process.exit(97);",
-      "}",
-      'const entry = entries[current] ?? { stdout: "{}\\n" };',
-      'writeFileSync(counterPath, String(current + 1));',
-      'const actual = process.argv.slice(2);',
-      'if (entry.assertArgs) {',
-      '  for (const expected of entry.assertArgs) {',
-      '    if (!actual.includes(expected)) {',
-      '      process.stderr.write(`missing expected gh arg: ${expected}\\nactual: ${actual.join(" ")}\\n`);',
-      "      process.exit(98);",
-      "    }",
-      "  }",
-      "}",
-      'if (entry.stderr) {',
-      "  process.stderr.write(entry.stderr);",
-      "}",
-      'if (entry.stdout) {',
-      "  process.stdout.write(entry.stdout);",
-      "}",
-      "process.exit(entry.exitCode ?? 0);",
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    ...process.env,
-    PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-    GH_SEQUENCE_PATH: sequencePath,
-    GH_COUNTER_PATH: counterPath,
-  };
+  const { env } = await writeGhStubHelper(tempDir, entries);
+  return env;
 }
 
 function linkedPrPayload({ hasOpenLinkedPr = true, prNumber = 79, prUrl = "https://github.com/owner/repo/pull/79" } = {}) {

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -4,81 +4,17 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import { detectPrGateCoordinationState, parseGitStatusConflictFiles } from "../../scripts/loop/detect-pr-gate-coordination-state.mjs";
 
 const scriptPath = path.resolve("scripts/loop/detect-pr-gate-coordination-state.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(options.execPath ?? process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
-  });
-}
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 async function writeGhStub(tempDir, entries) {
-  const sequencePath = path.join(tempDir, "gh-sequence.json");
-  const counterPath = path.join(tempDir, "gh-counter.txt");
-  const ghPath = path.join(tempDir, "gh");
-
-  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await writeFile(counterPath, "0\n", "utf8");
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      'import { readFileSync, writeFileSync } from "node:fs";',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const counterPath = process.env.GH_COUNTER_PATH;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
-      'if (current >= entries.length) {',
-      '  process.stderr.write(`unexpected extra gh call #${current + 1}: ${process.argv.slice(2).join(" ")}\\n`);',
-      '  process.exit(97);',
-      '}',
-      'const entry = entries[current] ?? { stdout: "{}\\n" };',
-      'writeFileSync(counterPath, String(current + 1));',
-      'const actual = process.argv.slice(2);',
-      'if (entry.assertArgs) {',
-      '  for (const expected of entry.assertArgs) {',
-      '    if (!actual.includes(expected)) {',
-      '      process.stderr.write(`missing expected gh arg: ${expected}\\nactual: ${actual.join(" ")}\\n`);',
-      '      process.exit(98);',
-      '    }',
-      '  }',
-      '}',
-      'if (entry.stderr) process.stderr.write(entry.stderr);',
-      'if (entry.stdout) process.stdout.write(entry.stdout);',
-      'process.exit(entry.exitCode ?? 0);',
-      '',
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    ...process.env,
-    PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-    GH_SEQUENCE_PATH: sequencePath,
-    GH_COUNTER_PATH: counterPath,
-  };
+  const { env } = await writeGhStubHelper(tempDir, entries);
+  return env;
 }
 
 async function writeGitStub(tempDir, { stdout = "", stderr = "", exitCode = 0, assertArgs = [] } = {}) {

--- a/test/loop/detect-reviewer-loop-state.test.mjs
+++ b/test/loop/detect-reviewer-loop-state.test.mjs
@@ -4,88 +4,15 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 const scriptPath = path.resolve("scripts/loop/detect-reviewer-loop-state.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
-    let stdout = "";
-    let stderr = "";
+const writeJson = writeJsonHelper;
 
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
-
-async function writeJson(filePath, value) {
-  await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
-}
-
-async function writeGhStub(tempDir, entries) {
-  const ghSequenceFilePath = path.join(tempDir, "gh-sequence.json");
-  const ghCallCounterFilePath = path.join(tempDir, "gh-counter.txt");
-  const ghStubScriptPath = path.join(tempDir, "gh");
-
-  await writeFile(ghSequenceFilePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await writeFile(ghCallCounterFilePath, "0\n", "utf8");
-  await writeFile(
-    ghStubScriptPath,
-    [
-      "#!/usr/bin/env node",
-      'import { readFileSync, writeFileSync } from "node:fs";',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const counterPath = process.env.GH_COUNTER_PATH;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
-      "if (current >= entries.length) {",
-      '  process.stderr.write("unexpected gh call beyond scripted sequence\\n");',
-      "  process.exit(97);",
-      "}",
-      'const entry = entries[current] ?? { stdout: "{}\\n" };',
-      "writeFileSync(counterPath, String(current + 1));",
-      "const actual = process.argv.slice(2);",
-      "if (entry.assertArgs) {",
-      "  for (const expected of entry.assertArgs) {",
-      "    if (!actual.includes(expected)) {",
-      "      process.stderr.write(`missing expected gh arg: ${expected}\\n`);",
-      "      process.exit(98);",
-      "    }",
-      "  }",
-      "}",
-      "if (entry.stderr) process.stderr.write(entry.stderr);",
-      "if (entry.stdout) process.stdout.write(entry.stdout);",
-      "process.exit(entry.exitCode ?? 0);",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghStubScriptPath, 0o755);
-
-  return {
-    env: {
-      ...process.env,
-      PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-      GH_SEQUENCE_PATH: ghSequenceFilePath,
-      GH_COUNTER_PATH: ghCallCounterFilePath,
-    },
-  };
-}
+const writeGhStub = (tempDir, entries) => writeGhStubHelper(tempDir, entries, { overflowMessageMode: "generic" });
 
 test("detect-reviewer-loop-state --input returns correct states for planning/running/merge snapshots", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reviewer-state-detect-"));

--- a/test/loop/detect-tracker-pr-state.test.mjs
+++ b/test/loop/detect-tracker-pr-state.test.mjs
@@ -4,36 +4,13 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import { parseDetectTrackerPrCliArgs } from "../../scripts/loop/detect-tracker-pr-state.mjs";
 
 const scriptPath = path.resolve("scripts/loop/detect-tracker-pr-state.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env ?? process.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 async function writeTempJson(tempDir, name, value) {
   const filePath = path.join(tempDir, name);

--- a/test/loop/inspect-run.test.mjs
+++ b/test/loop/inspect-run.test.mjs
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import {
   composeRunInspectionSnapshot,
@@ -26,122 +27,92 @@ const scriptPath = path.resolve("scripts/loop/inspect-run.mjs");
 // Helpers
 // ---------------------------------------------------------------------------
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env ?? process.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-    child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
-
-async function writeJson(filePath, data) {
-  await writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
-}
+const writeJson = writeJsonHelper;
 
 async function writeGhStub(tempDir) {
-  const ghPath = path.join(tempDir, "gh");
-  const script = `#!/usr/bin/env node
-const args = process.argv.slice(2);
-const out = (value) => process.stdout.write(JSON.stringify(value));
-const apiPath = args[0] === "api" ? args.find((arg) => arg.startsWith("repos/")) : null;
-
-if (args[0] === "pr" && args[1] === "view") {
-  const fields = args[args.indexOf("--json") + 1] || "";
-  if (fields.includes("reviews")) {
-    out({
+  const prViewEntry = {
+    assertArgs: ["pr", "view", "55", "--repo", "owner/repo", "--json"],
+    stdout: JSON.stringify({
       headRefOid: "abc123",
       isDraft: false,
       state: "OPEN",
       number: 55,
       reviews: [],
       statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS" }],
-    });
-  } else {
-    out({
-      isDraft: false,
-      state: "OPEN",
-      number: 55,
-      headRefOid: "abc123",
-    });
-  }
-  process.exit(0);
-}
-
-if (args[0] === "api" && args[1] === "repos/owner/repo/pulls/55/requested_reviewers") {
-  out({ users: [{ login: "copilot-pull-request-reviewer[bot]" }, { login: "reviewer-user" }] });
-  process.exit(0);
-}
-
-if (apiPath === "repos/owner/repo/pulls/55/reviews" || apiPath === "repos/owner/repo/pulls/55/reviews?per_page=100") {
-  out([
-    { id: 40, state: "COMMENTED", user: { login: "copilot-pull-request-reviewer[bot]" }, submitted_at: "2026-05-20T09:00:00Z", commit_id: "oldsha", html_url: "https://example.test/review/40" },
-    { id: 41, state: "COMMENTED", user: { login: "reviewer-user" }, submitted_at: "2026-05-20T10:00:00Z", commit_id: "abc123", html_url: "https://example.test/review/41" },
-  ]);
-  process.exit(0);
-}
-
-if (apiPath === "repos/owner/repo/issues/55/timeline?per_page=100") {
-  out([
-    { event: "review_requested", created_at: "2026-05-20T08:55:00Z", requested_reviewer: { login: "copilot-pull-request-reviewer[bot]" } },
-    { event: "review_requested", created_at: "2026-05-20T11:00:00Z", requested_reviewer: { login: "copilot-pull-request-reviewer[bot]" } },
-  ]);
-  process.exit(0);
-}
-
-if (apiPath === "repos/owner/repo/pulls/55/comments?per_page=100") {
-  out([
-    { id: 101, created_at: "2026-05-20T09:01:00Z", user: { login: "copilot-pull-request-reviewer[bot]" } },
-    { id: 102, created_at: "2026-05-20T09:02:00Z", user: { login: "copilot-pull-request-reviewer[bot]" } },
-  ]);
-  process.exit(0);
-}
-
-if (apiPath === "repos/owner/repo/pulls/55/commits?per_page=100") {
-  out([
-    { sha: "oldsha", commit: { committer: { date: "2026-05-20T08:00:00Z" } }, author: { login: "copilot-swe-agent" } },
-    { sha: "abc123", commit: { committer: { date: "2026-05-20T10:30:00Z" } }, author: { login: "author-user" } },
-  ]);
-  process.exit(0);
-}
-
-if (args[0] === "api" && args[1] === "graphql") {
-  out({
-    data: {
-      repository: {
-        pullRequest: {
-          reviewThreads: {
-            nodes: [],
-            pageInfo: { hasNextPage: false, endCursor: null },
+    }) + "\n",
+  };
+  const requestedReviewersEntry = {
+    assertArgs: ["api", "repos/owner/repo/pulls/55/requested_reviewers"],
+    stdout: JSON.stringify({ users: [{ login: "copilot-pull-request-reviewer[bot]" }, { login: "reviewer-user" }] }) + "\n",
+  };
+  const reviewsEntry = {
+    assertArgs: ["api", "repos/owner/repo/pulls/55/reviews"],
+    stdout: JSON.stringify([
+      { id: 40, state: "COMMENTED", user: { login: "copilot-pull-request-reviewer[bot]" }, submitted_at: "2026-05-20T09:00:00Z", commit_id: "oldsha", html_url: "https://example.test/review/40" },
+      { id: 41, state: "COMMENTED", user: { login: "reviewer-user" }, submitted_at: "2026-05-20T10:00:00Z", commit_id: "abc123", html_url: "https://example.test/review/41" },
+    ]) + "\n",
+  };
+  const reviewsEntryWithPage = { ...reviewsEntry, assertArgs: ["api", "repos/owner/repo/pulls/55/reviews?per_page=100"] };
+  const timelineEntry = {
+    assertArgs: ["api", "repos/owner/repo/issues/55/timeline"],
+    stdout: JSON.stringify([
+      { event: "review_requested", created_at: "2026-05-20T08:55:00Z", requested_reviewer: { login: "copilot-pull-request-reviewer[bot]" } },
+      { event: "review_requested", created_at: "2026-05-20T11:00:00Z", requested_reviewer: { login: "copilot-pull-request-reviewer[bot]" } },
+    ]) + "\n",
+  };
+  const timelineEntryWithPage = { ...timelineEntry, assertArgs: ["api", "repos/owner/repo/issues/55/timeline?per_page=100"] };
+  const commentsEntry = {
+    assertArgs: ["api", "repos/owner/repo/pulls/55/comments"],
+    stdout: JSON.stringify([
+      { id: 101, created_at: "2026-05-20T09:01:00Z", user: { login: "copilot-pull-request-reviewer[bot]" } },
+      { id: 102, created_at: "2026-05-20T09:02:00Z", user: { login: "copilot-pull-request-reviewer[bot]" } },
+    ]) + "\n",
+  };
+  const commentsEntryWithPage = { ...commentsEntry, assertArgs: ["api", "repos/owner/repo/pulls/55/comments?per_page=100"] };
+  const commitsEntry = {
+    assertArgs: ["api", "repos/owner/repo/pulls/55/commits"],
+    stdout: JSON.stringify([
+      { sha: "oldsha", commit: { committer: { date: "2026-05-20T08:00:00Z" } }, author: { login: "copilot-swe-agent" } },
+      { sha: "abc123", commit: { committer: { date: "2026-05-20T10:30:00Z" } }, author: { login: "author-user" } },
+    ]) + "\n",
+  };
+  const commitsEntryWithPage = { ...commitsEntry, assertArgs: ["api", "repos/owner/repo/pulls/55/commits?per_page=100"] };
+  const graphqlEntry = {
+    assertArgs: ["api", "graphql"],
+    stdout: JSON.stringify({
+      data: {
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              nodes: [],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
           },
         },
       },
-    },
-  });
-  process.exit(0);
-}
+    }) + "\n",
+  };
 
-process.stderr.write("unexpected gh args: " + args.join(" ") + "\\n");
-process.exit(1);
-`;
-  await writeFile(ghPath, script, "utf8");
-  await chmod(ghPath, 0o755);
-  return ghPath;
+  return await writeGhStubHelper(
+    tempDir,
+    [
+      ...Array.from({ length: 6 }, () => prViewEntry),
+      ...Array.from({ length: 4 }, () => requestedReviewersEntry),
+      ...Array.from({ length: 6 }, () => reviewsEntry),
+      ...Array.from({ length: 6 }, () => reviewsEntryWithPage),
+      ...Array.from({ length: 4 }, () => timelineEntry),
+      ...Array.from({ length: 4 }, () => timelineEntryWithPage),
+      ...Array.from({ length: 4 }, () => commentsEntry),
+      ...Array.from({ length: 4 }, () => commentsEntryWithPage),
+      ...Array.from({ length: 4 }, () => commitsEntry),
+      ...Array.from({ length: 4 }, () => commitsEntryWithPage),
+      ...Array.from({ length: 6 }, () => graphqlEntry),
+    ],
+    { matchMode: "claims" },
+  );
+
 }
 
 async function withTempDir(fn) {
@@ -1144,7 +1115,7 @@ test("inspect-run CLI: complete snapshot inputs -> partial sourceMode (degraded 
 
 test("inspect-run CLI: mixed live + input coverage can still derive a degraded top-level state", async () => {
   await withTempDir(async (tempDir) => {
-    await writeGhStub(tempDir);
+    const gh = await writeGhStub(tempDir);
     const copilotPath = path.join(tempDir, "copilot.json");
     await writeJson(copilotPath, {
       prExists: true,
@@ -1167,7 +1138,7 @@ test("inspect-run CLI: mixed live + input coverage can still derive a degraded t
       "--copilot-input", copilotPath,
     ], {
       cwd: tempDir,
-      env: { ...process.env, PATH: [tempDir, process.env.PATH ?? ""].filter(Boolean).join(path.delimiter) },
+      env: gh.env,
     });
 
     assert.equal(result.code, 0, `stderr: ${result.stderr}`);
@@ -1183,14 +1154,14 @@ test("inspect-run CLI: mixed live + input coverage can still derive a degraded t
 
 test("inspect-run CLI: successful live detectors still derive authoritative top-level state", async () => {
   await withTempDir(async (tempDir) => {
-    await writeGhStub(tempDir);
+    const gh = await writeGhStub(tempDir);
 
     const result = await runNode([
       "--repo", "owner/repo",
       "--pr", "55",
     ], {
       cwd: tempDir,
-      env: { ...process.env, PATH: [tempDir, process.env.PATH ?? ""].filter(Boolean).join(path.delimiter) },
+      env: gh.env,
     });
 
     assert.equal(result.code, 0, `stderr: ${result.stderr}`);
@@ -1840,9 +1811,9 @@ test("inspect-run CLI: --steering-state-file with snapshot-mode inputs fails clo
 test("inspect-run CLI: --steering-state-file with live authoritative evidence advertises steering availability", async () => {
   await withTempDir(async (tempDir) => {
     const steeringPath = path.join(tempDir, "steering.json");
-    const ghPath = await writeGhStub(tempDir);
-    const env = { ...process.env, PATH: `${tempDir}${path.delimiter}${process.env.PATH}` };
-    assert.ok(ghPath.endsWith(path.join(tempDir, "gh")));
+    const gh = await writeGhStub(tempDir);
+    const env = gh.env;
+    assert.ok(gh.ghPath.endsWith(path.join(tempDir, "gh")));
 
     await writeJson(steeringPath, {
       runId: "pr-55",

--- a/test/loop/outer-loop.test.mjs
+++ b/test/loop/outer-loop.test.mjs
@@ -4,40 +4,15 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import { decideOuterAction, runOuterLoop } from "../../scripts/loop/outer-loop.mjs";
 
 const scriptPath = path.resolve("scripts/loop/outer-loop.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env ?? process.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
-
-async function writeJson(filePath, data) {
-  await writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
-}
+const writeJson = writeJsonHelper;
 
 const MINIMAL_COPILOT_SNAPSHOT = Object.freeze({
   prExists: true,
@@ -96,45 +71,35 @@ async function writeGhStub(tempDir, {
   headSha = "abc123",
   headRefName = "copilot/example-branch",
 } = {}) {
-  const ghPath = path.join(tempDir, "gh");
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      "const args = process.argv.slice(2);",
-      "const joined = args.join(' ');",
-      `const repo = ${JSON.stringify(repo)};`,
-      `const pr = ${JSON.stringify(pr)};`,
-      `const headSha = ${JSON.stringify(headSha)};`,
-      `const headRefName = ${JSON.stringify(headRefName)};`,
-      "if (joined.includes('pr view') && joined.includes('--json')) {",
-      "  process.stdout.write(JSON.stringify({ isDraft: false, state: 'OPEN', number: pr, headRefOid: headSha, headRefName, reviews: [], statusCheckRollup: [] }));",
-      "  process.exit(0);",
-      "}",
-      "if (joined.includes('requested_reviewers')) {",
-      "  process.stdout.write(JSON.stringify({ users: [] }));",
-      "  process.exit(0);",
-      "}",
-      "if (joined.includes(`/pulls/${pr}/reviews`)) {",
-      "  process.stdout.write(JSON.stringify([]));",
-      "  process.exit(0);",
-      "}",
-      "if (joined.includes('graphql')) {",
-      "  process.stdout.write(JSON.stringify({ data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } }));",
-      "  process.exit(0);",
-      "}",
-      "process.stderr.write(`unexpected gh args: ${joined}\\n`);",
-      "process.exit(1);",
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    ...process.env,
-    PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
+  const prViewEntry = {
+    assertArgs: ["pr", "view", String(pr), "--repo", repo, "--json"],
+    stdout: JSON.stringify({ isDraft: false, state: "OPEN", number: pr, headRefOid: headSha, headRefName, reviews: [], statusCheckRollup: [] }) + "\n",
   };
+  const requestedReviewersEntry = {
+    assertArgs: ["api", `repos/${repo}/pulls/${pr}/requested_reviewers`],
+    stdout: JSON.stringify({ users: [] }) + "\n",
+  };
+  const reviewsEntry = {
+    assertArgs: ["api", `repos/${repo}/pulls/${pr}/reviews`],
+    stdout: "[]\n",
+  };
+  const graphqlEntry = {
+    assertArgs: ["api", "graphql"],
+    stdout: JSON.stringify({ data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } }) + "\n",
+  };
+
+  const { env } = await writeGhStubHelper(
+    tempDir,
+    [
+      ...Array.from({ length: 6 }, () => prViewEntry),
+      ...Array.from({ length: 4 }, () => requestedReviewersEntry),
+      ...Array.from({ length: 4 }, () => reviewsEntry),
+      ...Array.from({ length: 6 }, () => graphqlEntry),
+    ],
+    { matchMode: "claims" },
+  );
+
+  return env;
 }
 
 // ---------------------------------------------------------------------------

--- a/test/loop/pre-commit-branch-guard.test.mjs
+++ b/test/loop/pre-commit-branch-guard.test.mjs
@@ -4,36 +4,13 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import { parseBranchGuardCliArgs, runCli } from "../../scripts/loop/pre-commit-branch-guard.mjs";
 
 const scriptPath = path.resolve("scripts/loop/pre-commit-branch-guard.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env ?? process.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 async function writeGitStub(tempDir, { branch = "copilot/feature-branch", logFile } = {}) {
   const gitPath = path.join(tempDir, "git");

--- a/test/loop/pre-write-remote-freshness-guard.test.mjs
+++ b/test/loop/pre-write-remote-freshness-guard.test.mjs
@@ -4,36 +4,13 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import { parseRemoteFreshnessGuardCliArgs, runCli } from "../../scripts/loop/pre-write-remote-freshness-guard.mjs";
 
 const scriptPath = path.resolve("scripts/loop/pre-write-remote-freshness-guard.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env ?? process.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 async function writeGitStub(tempDir, { commits = [], logFile } = {}) {
   const gitPath = path.join(tempDir, "git");

--- a/test/loop/resolve-dev-loop-startup.test.mjs
+++ b/test/loop/resolve-dev-loop-startup.test.mjs
@@ -4,6 +4,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import {
   buildResolveDevLoopStartupResult,
@@ -13,31 +14,7 @@ import {
 
 const scriptPath = path.resolve("scripts/loop/resolve-dev-loop-startup.mjs");
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env ?? process.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 async function writeTempJson(tempDir, name, value) {
   const filePath = path.join(tempDir, name);

--- a/test/loop/run-copilot-watch-cycle.test.mjs
+++ b/test/loop/run-copilot-watch-cycle.test.mjs
@@ -1,4 +1,5 @@
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 import assert from "node:assert/strict";
 import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
@@ -17,55 +18,8 @@ const EMPTY_THREADS = JSON.stringify({
 });
 
 async function writeGhStub(tempDir, entries) {
-  const sequencePath = path.join(tempDir, "gh-sequence.json");
-  const counterPath = path.join(tempDir, "gh-counter.txt");
-  const ghPath = path.join(tempDir, "gh");
-
-  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await writeFile(counterPath, "0\n", "utf8");
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      'import { readFileSync, writeFileSync } from "node:fs";',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const counterPath = process.env.GH_COUNTER_PATH;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
-      'if (current >= entries.length) {',
-      '  process.stderr.write("unexpected gh call beyond scripted sequence\\n");',
-      '  process.exit(97);',
-      '}',
-      'const entry = entries[current] ?? { stdout: "{}\\n" };',
-      'writeFileSync(counterPath, String(current + 1));',
-      'const actual = process.argv.slice(2);',
-      'if (entry.assertArgs) {',
-      '  for (const expected of entry.assertArgs) {',
-      '    if (!actual.includes(expected)) {',
-      '      process.stderr.write(`missing expected gh arg: ${expected}\\n`);',
-      '      process.exit(98);',
-      '    }',
-      '  }',
-      '}',
-      'if (entry.stderr) {',
-      '  process.stderr.write(entry.stderr);',
-      '}',
-      'if (entry.stdout) {',
-      '  process.stdout.write(entry.stdout);',
-      '}',
-      'process.exit(entry.exitCode ?? 0);',
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    ...process.env,
-    PATH: `${tempDir}${path.delimiter}${process.env.PATH ?? ""}`,
-    GH_SEQUENCE_PATH: sequencePath,
-    GH_COUNTER_PATH: counterPath,
-  };
+  const { env } = await writeGhStubHelper(tempDir, entries);
+  return env;
 }
 
 test("parseWatchCycleCliArgs parses required flags and optional probe mode", () => {

--- a/test/loop/steer-loop.test.mjs
+++ b/test/loop/steer-loop.test.mjs
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import {
   parsePromoteCliArgs,
@@ -23,27 +24,7 @@ const scriptPath = path.resolve("scripts/loop/steer-loop.mjs");
 // Helpers
 // ---------------------------------------------------------------------------
 
-function runNode(args = []) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-    child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 function makeStdout() {
   let written = "";
@@ -65,64 +46,9 @@ async function withTempDir(fn) {
   }
 }
 
-async function writeJson(filePath, value) {
-  await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
-}
+const writeJson = writeJsonHelper;
 
-async function writeGhStub(tempDir, entries) {
-  const sequencePath = path.join(tempDir, "gh-sequence.json");
-  const counterPath = path.join(tempDir, "gh-counter.txt");
-  const ghPath = path.join(tempDir, "gh");
-
-  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await writeFile(counterPath, "0\n", "utf8");
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      'import { readFileSync, writeFileSync } from "node:fs";',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const counterPath = process.env.GH_COUNTER_PATH;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
-      'if (current >= entries.length) {',
-      '  process.stderr.write("unexpected gh call beyond scripted sequence\\n");',
-      '  process.exit(97);',
-      '}',
-      'const entry = entries[current] ?? { stdout: "{}\\n" };',
-      'writeFileSync(counterPath, String(current + 1));',
-      'const actual = process.argv.slice(2);',
-      'if (entry.assertArgs) {',
-      '  for (const expected of entry.assertArgs) {',
-      '    if (!actual.includes(expected)) {',
-      '      process.stderr.write(`missing expected gh arg: ${expected}\\n`);',
-      '      process.exit(98);',
-      '    }',
-      '  }',
-      '}',
-      'if (entry.stderr) {',
-      '  process.stderr.write(entry.stderr);',
-      '}',
-      'if (entry.stdout) {',
-      '  process.stdout.write(entry.stdout);',
-      '}',
-      'process.exit(entry.exitCode ?? 0);',
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    env: {
-      ...process.env,
-      PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-      GH_SEQUENCE_PATH: sequencePath,
-      GH_COUNTER_PATH: counterPath,
-    },
-  };
-}
+const writeGhStub = (tempDir, entries) => writeGhStubHelper(tempDir, entries);
 
 // ---------------------------------------------------------------------------
 // parseSubmitCliArgs

--- a/test/loop/watch-initial-copilot-pr.test.mjs
+++ b/test/loop/watch-initial-copilot-pr.test.mjs
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import {
   parseWatchInitialCopilotPrCliArgs,
@@ -16,86 +17,15 @@ const scriptPath = path.resolve("scripts/loop/watch-initial-copilot-pr.mjs");
 // Subprocess helper
 // ---------------------------------------------------------------------------
 
-function runNode(args = [], options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [scriptPath, ...args], {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 // ---------------------------------------------------------------------------
 // gh stub helpers (for subprocess / CLI integration tests)
 // ---------------------------------------------------------------------------
 
 async function writeGhStub(tempDir, entries) {
-  const sequencePath = path.join(tempDir, "gh-sequence.json");
-  const counterPath = path.join(tempDir, "gh-counter.txt");
-  const ghPath = path.join(tempDir, "gh");
-
-  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
-  await writeFile(counterPath, "0\n", "utf8");
-  await writeFile(
-    ghPath,
-    [
-      "#!/usr/bin/env node",
-      'import { readFileSync, writeFileSync } from "node:fs";',
-      "const sequencePath = process.env.GH_SEQUENCE_PATH;",
-      "const counterPath = process.env.GH_COUNTER_PATH;",
-      'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
-      'const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
-      'if (current >= entries.length) {',
-      '  process.stderr.write(`unexpected extra gh call #${current + 1}: ${process.argv.slice(2).join(" ")}\\n`);',
-      "  process.exit(97);",
-      "}",
-      'const entry = entries[current] ?? { stdout: "{}\\n" };',
-      'writeFileSync(counterPath, String(current + 1));',
-      'const actual = process.argv.slice(2);',
-      'if (entry.assertArgs) {',
-      '  for (const expected of entry.assertArgs) {',
-      '    if (!actual.includes(expected)) {',
-      '      process.stderr.write(`missing expected gh arg: ${expected}\\nactual: ${actual.join(" ")}\\n`);',
-      "      process.exit(98);",
-      "    }",
-      "  }",
-      "}",
-      'if (entry.stderr) {',
-      "  process.stderr.write(entry.stderr);",
-      "}",
-      'if (entry.stdout) {',
-      "  process.stdout.write(entry.stdout);",
-      "}",
-      "process.exit(entry.exitCode ?? 0);",
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(ghPath, 0o755);
-
-  return {
-    ...process.env,
-    PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-    GH_SEQUENCE_PATH: sequencePath,
-    GH_COUNTER_PATH: counterPath,
-  };
+  const { env } = await writeGhStubHelper(tempDir, entries);
+  return env;
 }
 
 function linkedPrPayload({ hasOpenLinkedPr = true, prNumber = 79, prUrl = "https://github.com/owner/repo/pull/79" } = {}) {


### PR DESCRIPTION
## Summary
- add shared CLI parsing/runtime helpers for command execution and integer parsing
- replace duplicated script-level helper implementations across `scripts/github/` and `scripts/loop/`
- extract shared test helpers in `test/_helpers.mjs` and migrate duplicated test primitives to wrapper usage

## Scope / context
Implements issue #331 from epic #329.
This is a deduplication-only cleanup wave: consolidate duplicated helper primitives without changing the intended script or test behavior.

## Acceptance criteria
- `_cli-primitives.mjs` exports `runCommand`, `parsePositiveInteger`, `parseIssueNumber`, and `parseNonNegativeInteger`
- `_core-helpers.mjs` exports `buildParseError`
- script helpers now import shared CLI/core primitives instead of inlining duplicate `requireOptionValue`, `runChild`, `parseError`, and integer parsers (stdin-capable child-process variants remain local)
- `test/_helpers.mjs` exists and is used by test files that previously duplicated `writeGhStub`, `runNode`, or `writeJson`
- existing script and test behavior stays green under the repo verification suite

## Definition of done
- issue #331 implementation is on this branch
- local verification passes via `npm run verify`
- PR is ready for review and linked to the issue

## Non-goals
- no module renames or broader restructuring
- no behavior changes to stdin-capable `runChild` variants
- no test reorganization beyond helper deduplication

## Validation
- `npm run verify`

Closes #331
Related to #329
