### PR TITLE
Allow pre_approval_gate after Copilot round exhaustion

### DIFF
--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -157,6 +157,26 @@ function normalizeCiStatus(value) {
   return "none";
 }
 
+function normalizeNonNegativeInteger(value) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return 0;
+  }
+
+  return Math.floor(value);
+}
+
+function normalizePositiveInteger(value) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+
+  return Math.floor(value);
+}
+
+function buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds }) {
+  return `Copilot review rounds exhausted (${copilotReviewRoundCount}/${maxCopilotRounds}); current head has zero unresolved threads and green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.`;
+}
+
 function buildResult({
   draftGateAlreadySatisfied = false,
   repo = null,
@@ -173,6 +193,7 @@ function buildResult({
   reason,
   mergeStateStatus = null,
   conflictFiles = [],
+  gateEvidenceNote = null,
 }) {
   return {
     ok: true,
@@ -191,6 +212,7 @@ function buildResult({
     mergeStateStatus,
     conflictFiles,
     draftGateAlreadySatisfied,
+    ...(gateEvidenceNote ? { gateEvidenceNote } : {}),
   };
 }
 
@@ -211,6 +233,9 @@ export function evaluatePrGateCoordination(input = {}) {
   const conflictFiles = normalizeConflictFiles(input.conflictFiles);
   const ciStatus = normalizeCiStatus(input.ciStatus);
   const draftGateRequireCi = input.draftGateRequireCi !== false;
+  const copilotReviewRoundCount = normalizeNonNegativeInteger(input.copilotReviewRoundCount);
+  const maxCopilotRounds = normalizePositiveInteger(input.maxCopilotRounds);
+  const roundCapReached = maxCopilotRounds !== null && copilotReviewRoundCount >= maxCopilotRounds;
 
   const effectiveLifecycleState = lifecycleState;
 
@@ -600,7 +625,11 @@ export function evaluatePrGateCoordination(input = {}) {
       });
     }
 
-    if (!sameHeadCleanConverged) {
+    const roundExhaustionGateEvidenceNote = roundCapReached
+      ? buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds })
+      : null;
+
+    if (!sameHeadCleanConverged && !roundCapReached) {
       pushUnique(allowedNextActions, [PR_GATE_ACTION.REREQUEST_COPILOT_REVIEW]);
       pushUnique(forbiddenActions, postDraftForbidden);
       return buildResult({
@@ -671,11 +700,14 @@ export function evaluatePrGateCoordination(input = {}) {
       allowedNextActions,
       forbiddenActions,
       nextAction: PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE,
-      reason: ciStatus === "crediblyGreen"
-        ? "The current head has a clean settled post-draft review cycle, and its zero-suite CI state is accepted as credibly green, so `pre_approval_gate` is now the next legal boundary."
-        : "The current head has a clean settled post-draft review cycle, so `pre_approval_gate` is now the next legal boundary.",
+      reason: roundCapReached
+        ? `The Copilot round limit is exhausted (${copilotReviewRoundCount}/${maxCopilotRounds}), and the current head has zero unresolved threads with ${ciStatus === "crediblyGreen" ? "credibly green" : "green"} CI, so \`pre_approval_gate\` fallback is now the next legal boundary.`
+        : (ciStatus === "crediblyGreen"
+          ? "The current head has a clean settled post-draft review cycle, and its zero-suite CI state is accepted as credibly green, so `pre_approval_gate` is now the next legal boundary."
+          : "The current head has a clean settled post-draft review cycle, so `pre_approval_gate` is now the next legal boundary."),
       mergeStateStatus,
       conflictFiles,
+      gateEvidenceNote: roundCapReached ? roundExhaustionGateEvidenceNote : null,
     });
   }
 

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -174,7 +174,7 @@ function normalizePositiveInteger(value) {
 }
 
 function buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds }) {
-  return `Copilot review rounds exhausted (${copilotReviewRoundCount}/${maxCopilotRounds}); current head has zero unresolved threads and green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.`;
+  return `Copilot review rounds exhausted (${copilotReviewRoundCount}/${maxCopilotRounds}); current head has zero unresolved threads and green or credibly green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.`;
 }
 
 function buildResult({

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -207,6 +207,33 @@ test("crediblyGreen CI allows pre-approval progression once the review loop is a
   assert.match(result.reason, /credibly green/i);
 });
 
+test("round-cap exhaustion opens the pre-approval gate window even without a current-head Copilot rereview", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
+    sameHeadCleanConverged: false,
+    ciStatus: "success",
+    copilotReviewRoundCount: 5,
+    maxCopilotRounds: 5,
+    draftGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "fedcba9", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.lifecycleState, STATE.READY_TO_REREQUEST_REVIEW);
+  assert.equal(result.gateBoundary, PR_GATE_BOUNDARY.PRE_APPROVAL_GATE_WINDOW);
+  assert.equal(result.nextAction, PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE);
+  assert(result.allowedNextActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert(!result.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert.equal(result.gateEvidenceNote, "Copilot review rounds exhausted (5/5); current head has zero unresolved threads and green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.");
+  assert.match(result.reason, /round limit/i);
+  assert.match(result.reason, /pre_approval_gate/i);
+});
+
 test("missing ciStatus fails closed to wait_for_ci instead of reopening gate progression", () => {
   const result = evaluatePrGateCoordination({
     pr: 266,

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -229,7 +229,7 @@ test("round-cap exhaustion opens the pre-approval gate window even without a cur
   assert.equal(result.nextAction, PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE);
   assert(result.allowedNextActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
   assert(!result.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE));
-  assert.equal(result.gateEvidenceNote, "Copilot review rounds exhausted (5/5); current head has zero unresolved threads and green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.");
+  assert.equal(result.gateEvidenceNote, "Copilot review rounds exhausted (5/5); current head has zero unresolved threads and green or credibly green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.");
   assert.match(result.reason, /round limit/i);
   assert.match(result.reason, /pre_approval_gate/i);
 });

--- a/scripts/github/upsert-gate-review-comment.mjs
+++ b/scripts/github/upsert-gate-review-comment.mjs
@@ -323,7 +323,7 @@ function appendGateEvidenceNote(summary, note) {
     return normalizedSummary;
   }
 
-  return smartTruncate(`${normalizedSummary} ${normalizedNote}`, MAX_GATE_COMMENT_TEXT_LENGTH);
+  return smartTruncate(`${normalizedSummary}; ${normalizedNote}`, MAX_GATE_COMMENT_TEXT_LENGTH);
 }
 
 export function renderGateReviewCommentBody({ gate, headSha, verdict, findingsSummary, nextAction }) {

--- a/scripts/github/upsert-gate-review-comment.mjs
+++ b/scripts/github/upsert-gate-review-comment.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { loadDevLoopConfig, resolveGateConfig } from "@pi-dev-loops/core/config";
+import { loadDevLoopConfig, resolveGateConfig, resolveRefinementConfig } from "@pi-dev-loops/core/config";
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { truncateText } from "@pi-dev-loops/core/bash-exit-one";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
@@ -307,6 +307,25 @@ export function parseUpsertGateReviewCommentCliArgs(argv) {
   return options;
 }
 
+function appendGateEvidenceNote(summary, note) {
+  const normalizedSummary = summarizeGateReviewText(summary);
+  const normalizedNote = typeof note === "string" ? collapseWhitespace(note) : "";
+
+  if (normalizedNote.length === 0) {
+    return normalizedSummary;
+  }
+
+  if (normalizedSummary.length === 0) {
+    return smartTruncate(normalizedNote, MAX_GATE_COMMENT_TEXT_LENGTH);
+  }
+
+  if (normalizedSummary.includes(normalizedNote)) {
+    return normalizedSummary;
+  }
+
+  return smartTruncate(`${normalizedSummary} ${normalizedNote}`, MAX_GATE_COMMENT_TEXT_LENGTH);
+}
+
 export function renderGateReviewCommentBody({ gate, headSha, verdict, findingsSummary, nextAction }) {
   return [
     `### Gate review: \`${gate}\``,
@@ -435,6 +454,7 @@ export async function upsertGateReviewComment(options, { env = process.env, ghCo
   const canonicalHeadSha = resolveRequestedHeadSha(options.headSha, evidence.currentHeadSha);
   const { config } = await loadDevLoopConfig({ repoRoot });
   const draftGateConfig = resolveGateConfig(config, "draft");
+  const maxCopilotRounds = resolveRefinementConfig(config, "maxCopilotRounds");
   const coordination = evaluatePrGateCoordination({
     repo: coordinationContext.repo,
     pr: coordinationContext.pr,
@@ -445,6 +465,8 @@ export async function upsertGateReviewComment(options, { env = process.env, ghCo
     lifecycleState: coordinationContext.interpretation.state,
     loopDisposition: coordinationContext.disposition.loopDisposition,
     ciStatus: coordinationContext.snapshot?.ciStatus ?? null,
+    copilotReviewRoundCount: coordinationContext.snapshot?.copilotReviewRoundCount ?? 0,
+    maxCopilotRounds,
     sameHeadCleanConverged: coordinationContext.interpretation.sameHeadCleanConverged,
     draftGateRequireCi: draftGateConfig.requireCi,
     draftGate: coordinationContext.gateEvidence.draftGate,
@@ -459,7 +481,8 @@ export async function upsertGateReviewComment(options, { env = process.env, ghCo
     throw new Error(`Cannot enter ${options.gate} on ${options.repo}#${options.pr}: ${coordination.reason}`);
   }
 
-  const desiredBody = renderGateReviewCommentBody({ ...options, headSha: canonicalHeadSha });
+  const effectiveFindingsSummary = appendGateEvidenceNote(options.findingsSummary, coordination.gateEvidenceNote ?? null);
+  const desiredBody = renderGateReviewCommentBody({ ...options, headSha: canonicalHeadSha, findingsSummary: effectiveFindingsSummary });
 
   const gateEvidence = selectGateEvidence(evidence, options.gate);
   const existing = summarizeExistingComment({ ...gateEvidence, headSha: canonicalHeadSha });
@@ -469,7 +492,7 @@ export async function upsertGateReviewComment(options, { env = process.env, ghCo
     existing
     && existing.contractComplete
     && existing.verdict === options.verdict
-    && existing.findingsSummary === options.findingsSummary
+    && existing.findingsSummary === effectiveFindingsSummary
     && existing.nextAction === options.nextAction
   ) {
     return {

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -9,7 +9,7 @@ import {
   summarizeCopilotReviews,
 } from "../_core-helpers.mjs";
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
-import { loadDevLoopConfig, resolveGateConfig } from "@pi-dev-loops/core/config";
+import { loadDevLoopConfig, resolveGateConfig, resolveRefinementConfig } from "@pi-dev-loops/core/config";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import { buildSnapshotFromPrFacts, interpretLoopState, summarizeLoopInterpretation } from "@pi-dev-loops/core/loop/copilot-loop-state";
 import { evaluatePrGateCoordination } from "@pi-dev-loops/core/loop/pr-gate-coordination";
@@ -309,6 +309,7 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
   const context = await loadPrGateCoordinationContext(options, runtime);
   const { config } = await loadDevLoopConfig({ repoRoot: runtime.repoRoot ?? process.cwd() });
   const draftGateConfig = resolveGateConfig(config, "draft");
+  const maxCopilotRounds = resolveRefinementConfig(config, "maxCopilotRounds");
   return evaluatePrGateCoordination({
     repo: context.repo,
     pr: context.pr,
@@ -321,6 +322,8 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
     lifecycleState: context.interpretation.state,
     loopDisposition: context.disposition.loopDisposition,
     ciStatus: context.snapshot?.ciStatus ?? null,
+    copilotReviewRoundCount: context.snapshot?.copilotReviewRoundCount ?? 0,
+    maxCopilotRounds,
     sameHeadCleanConverged: context.interpretation.sameHeadCleanConverged,
     draftGateRequireCi: draftGateConfig.requireCi,
     reviewMode: options.reviewMode ?? null,

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -269,7 +269,9 @@ When actionable review feedback exists, use a narrow follow-up loop:
     - resolve the review-round cap from config via `resolveRefinementConfig(config, "maxCopilotRounds")` from `@pi-dev-loops/core/config`; default config ships `maxCopilotRounds: 5`
     - use `snapshot.copilotReviewRoundCount` from `detect-copilot-loop-state.mjs` / `copilot-pr-handoff.mjs` as the completed Copilot review-round count for the current PR
     - if `snapshot.copilotReviewRoundCount >= maxCopilotRounds`, do **not** re-request Copilot review
-    - when the round cap is reached, reply-resolve any remaining intentionally deferred threads with a short `deferred to follow-up` note, then stop and report that the Copilot round limit was reached
+    - when the round cap is reached **and** the refreshed thread snapshot proves `unresolvedThreadCount === 0` **and** current-head CI is `success` or `crediblyGreen`, treat that clean state as eligible for `pre_approval_gate` fallback instead of deadlocking on another Copilot rerequest
+    - when using that fallback, add a short round-exhaustion note to the visible `pre_approval_gate` gate evidence so the PR records why no further Copilot rerequest occurred
+    - if the round cap is reached before the PR is thread-clean or before CI is green/credibly green, reply-resolve any remaining intentionally deferred threads with a short `deferred to follow-up` note, then stop and report that the Copilot round limit was reached
     - if yes and the round cap has not been reached, run the smallest honest local validation for the accepted fix scope
     - if that local validation is still known red, continue remediation instead of re-requesting Copilot
     - after a fix push advances the PR head SHA, treat previous-head CI evidence as stale for any CI-dependent follow-up decision and immediately re-run `node <resolved-skill-scripts>/loop/detect-copilot-loop-state.mjs --repo <owner/name> --pr <number>` for the new head

--- a/test/github/upsert-gate-review-comment.test.mjs
+++ b/test/github/upsert-gate-review-comment.test.mjs
@@ -310,7 +310,7 @@ test("upsert-gate-review-comment appends the round-cap fallback note to pre-appr
         assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f"],
         assertArgContains: [
           "body=### Gate review: `pre_approval_gate`",
-          "**Findings summary:** no issues found; Copilot review rounds exhausted (5/5); current head has zero unresolved threads and green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.",
+          "**Findings summary:** no issues found; Copilot review rounds exhausted (5/5); current head has zero unresolved threads and green or credibly green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.",
         ],
         stdout: '{"id":101,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-101"}\n',
       },

--- a/test/github/upsert-gate-review-comment.test.mjs
+++ b/test/github/upsert-gate-review-comment.test.mjs
@@ -310,7 +310,7 @@ test("upsert-gate-review-comment appends the round-cap fallback note to pre-appr
         assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f"],
         assertArgContains: [
           "body=### Gate review: `pre_approval_gate`",
-          "**Findings summary:** no issues found Copilot review rounds exhausted (5/5); current head has zero unresolved threads and green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.",
+          "**Findings summary:** no issues found; Copilot review rounds exhausted (5/5); current head has zero unresolved threads and green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.",
         ],
         stdout: '{"id":101,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-101"}\n',
       },

--- a/test/github/upsert-gate-review-comment.test.mjs
+++ b/test/github/upsert-gate-review-comment.test.mjs
@@ -254,6 +254,96 @@ test("upsert-gate-review-comment fails closed when pre-approval gate entry is st
   }
 });
 
+test("upsert-gate-review-comment appends the round-cap fallback note to pre-approval evidence", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-round-cap-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        stdout: JSON.stringify({
+          number: 17,
+          state: "OPEN",
+          isDraft: false,
+          headRefOid: "abc1234",
+          reviews: [
+            { author: { login: "copilot-pull-request-reviewer[bot]" }, state: "COMMENTED", submittedAt: "2026-05-31T20:00:00Z", commit: { oid: "1111111111111111111111111111111111111111" } },
+            { author: { login: "copilot-pull-request-reviewer[bot]" }, state: "COMMENTED", submittedAt: "2026-05-31T20:05:00Z", commit: { oid: "2222222222222222222222222222222222222222" } },
+            { author: { login: "copilot-pull-request-reviewer[bot]" }, state: "COMMENTED", submittedAt: "2026-05-31T20:10:00Z", commit: { oid: "3333333333333333333333333333333333333333" } },
+            { author: { login: "copilot-pull-request-reviewer[bot]" }, state: "COMMENTED", submittedAt: "2026-05-31T20:15:00Z", commit: { oid: "4444444444444444444444444444444444444444" } },
+            { author: { login: "copilot-pull-request-reviewer[bot]" }, state: "COMMENTED", submittedAt: "2026-05-31T20:20:00Z", commit: { oid: "5555555555555555555555555555555555555555" } },
+          ],
+          statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+        }) + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=17"],
+        stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n',
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
+        stdout: '{"headRefOid":"abc1234"}\n',
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/17/comments?per_page=100"],
+        stdout: `${JSON.stringify([[{
+          id: 91,
+          body: [
+            "### Gate review: `draft_gate`",
+            "",
+            "**Reviewed head SHA:** `abc1234`",
+            "**Verdict:** clean",
+            "",
+            "**Findings summary:** no issues found",
+            "",
+            "**Next action:** mark ready for review",
+          ].join("\n"),
+          html_url: "https://github.com/owner/repo/pull/17#issuecomment-91",
+          updated_at: "2026-05-31T20:10:00Z",
+        }]])}\n`,
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f"],
+        assertArgContains: [
+          "body=### Gate review: `pre_approval_gate`",
+          "**Findings summary:** no issues found Copilot review rounds exhausted (5/5); current head has zero unresolved threads and green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.",
+        ],
+        stdout: '{"id":101,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-101"}\n',
+      },
+    ]);
+
+    const result = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "17",
+      "--gate", "pre_approval_gate",
+      "--head-sha", "abc1234",
+      "--verdict", "clean",
+      "--findings-summary", "no issues found",
+      "--next-action", "await final human approval",
+    ], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      action: "created",
+      repo: "owner/repo",
+      pr: 17,
+      gate: "pre_approval_gate",
+      headSha: "abc1234",
+      currentHeadSha: "abc1234",
+      commentId: 101,
+      commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("upsert-gate-review-comment truncates verbose findings summary before comment creation", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-verbose-"));
 

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -360,7 +360,7 @@ test("detect-pr-gate-coordination-state allows pre-approval fallback when the Co
     assert.equal(parsed.lifecycleState, "ready_to_rerequest_review");
     assert.equal(parsed.gateBoundary, "pre_approval_gate_window");
     assert.equal(parsed.nextAction, "run_pre_approval_gate");
-    assert.equal(parsed.gateEvidenceNote, "Copilot review rounds exhausted (5/5); current head has zero unresolved threads and green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.");
+    assert.equal(parsed.gateEvidenceNote, "Copilot review rounds exhausted (5/5); current head has zero unresolved threads and green or credibly green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.");
     assert.match(parsed.reason, /round limit/i);
   } finally {
     await rm(tempDir, { recursive: true, force: true });

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -287,6 +287,86 @@ test("detect-pr-gate-coordination-state allows pre-approval flow for converged n
   }
 });
 
+test("detect-pr-gate-coordination-state allows pre-approval fallback when the Copilot round cap is exhausted", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-round-cap-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        stdout: jsonLine({
+          number: 266,
+          state: "OPEN",
+          isDraft: false,
+          headRefOid: "def56789abcdef",
+          statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+          reviews: [
+            {
+              author: { login: "copilot-pull-request-reviewer[bot]" },
+              state: "COMMENTED",
+              commit: { oid: "1111111111111111111111111111111111111111" },
+              submittedAt: "2026-05-31T20:00:00Z",
+            },
+            {
+              author: { login: "copilot-pull-request-reviewer[bot]" },
+              state: "COMMENTED",
+              commit: { oid: "2222222222222222222222222222222222222222" },
+              submittedAt: "2026-05-31T20:05:00Z",
+            },
+            {
+              author: { login: "copilot-pull-request-reviewer[bot]" },
+              state: "COMMENTED",
+              commit: { oid: "3333333333333333333333333333333333333333" },
+              submittedAt: "2026-05-31T20:10:00Z",
+            },
+            {
+              author: { login: "copilot-pull-request-reviewer[bot]" },
+              state: "COMMENTED",
+              commit: { oid: "4444444444444444444444444444444444444444" },
+              submittedAt: "2026-05-31T20:15:00Z",
+            },
+            {
+              author: { login: "copilot-pull-request-reviewer[bot]" },
+              state: "COMMENTED",
+              commit: { oid: "5555555555555555555555555555555555555555" },
+              submittedAt: "2026-05-31T20:20:00Z",
+            },
+          ],
+        }),
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/266/requested_reviewers"],
+        stdout: jsonLine({ users: [], teams: [] }),
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=266"],
+        stdout: jsonLine({ data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } }),
+      },
+      {
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "headRefOid"],
+        stdout: jsonLine({ headRefOid: "def56789abcdef" }),
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/266/comments?per_page=100"],
+        stdout: jsonLine([[]]),
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "266"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.lifecycleState, "ready_to_rerequest_review");
+    assert.equal(parsed.gateBoundary, "pre_approval_gate_window");
+    assert.equal(parsed.nextAction, "run_pre_approval_gate");
+    assert.equal(parsed.gateEvidenceNote, "Copilot review rounds exhausted (5/5); current head has zero unresolved threads and green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.");
+    assert.match(parsed.reason, /round limit/i);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("detectPrGateCoordinationState tolerates missing local git binary and falls back to GitHub-only facts", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-missing-git-"));
 


### PR DESCRIPTION
## Summary
- allow `pre_approval_gate` when `maxCopilotRounds` is exhausted but the PR is thread-clean and CI is green/credibly green
- surface a round-exhaustion note in `pre_approval_gate` evidence comments so the fallback is auditable on the PR
- document the fallback policy in `skills/copilot-pr-followup/SKILL.md`

## Scope / context
Fixes the deadlock from issue #385 where the gate coordinator required another current-head Copilot review before `pre_approval_gate`, while the follow-up skill simultaneously forbade another re-request after the configured round cap was reached.

## Acceptance criteria
- `packages/core/src/loop/pr-gate-coordination.mjs` allows `pre_approval_gate` when `copilotReviewRoundCount >= maxCopilotRounds`, `unresolvedThreadCount === 0`, and CI is `success` or `crediblyGreen`
- visible gate evidence records the round-exhaustion fallback
- `skills/copilot-pr-followup/SKILL.md` documents the fallback policy
- regression coverage exists for gate coordination, gate-state detection, and gate-comment upsert behavior

## Definition of done
- [x] targeted regression tests added for round-cap -> `pre_approval_gate` progression
- [x] `npm run verify` passes
- [x] docs updated to match shipped behavior

## Non-goals
- changing the configured `maxCopilotRounds` default
- relaxing unresolved-thread or CI prerequisites for `pre_approval_gate`
- changing the final approval or merge authorization policy

Closes #385.
