### PR TITLE
Fix Copilot PR follow-up watch persistence

### DIFF
--- a/packages/core/src/loop/timeout-policy.mjs
+++ b/packages/core/src/loop/timeout-policy.mjs
@@ -12,13 +12,17 @@ export const PERSISTENT_INTERNAL_WAIT_TIMEOUT_POLICY = Object.freeze({
 
 export const EXTERNAL_HEALTHY_WAIT_TIMEOUT_POLICY = Object.freeze({
   classification: DEV_LOOP_TIMEOUT_CLASSIFICATION.EXTERNAL_HEALTHY_WAIT,
-  minimumTimeoutMs: 86_400_000,
-  defaultTimeoutMs: 86_400_000,
+  minimumTimeoutMs: 1_800_000,
+  defaultTimeoutMs: 1_800_000,
 });
 
 function formatTimeoutDuration(timeoutMs) {
   if (timeoutMs === 3_600_000) {
     return "1 hour";
+  }
+
+  if (timeoutMs === 1_800_000) {
+    return "30 minutes";
   }
 
   if (timeoutMs === 86_400_000) {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -271,7 +271,7 @@ Required:
 
 Optional:
 - `--poll-interval-ms <positive-integer>` (default `60000`, i.e. 1 minute)
-- `--timeout-ms <non-negative-integer>` (default `86400000`, i.e. 24 hours)
+- `--timeout-ms <non-negative-integer>` (default `1800000`, i.e. 30 minutes)
 
 Contract:
 - captures a baseline snapshot, then performs a bounded number of follow-up polls
@@ -362,7 +362,7 @@ Contract:
 - explicit stop/blocked routing is machine-readable via `action: "stop"` plus `requestWatchContract.stopState`
 
 Success output shape:
-- `{ "ok": true, "action": "watch"|"fix"|"stop", "state": "...", "allowedTransitions": [...], "nextAction": "...", "snapshot": {...}, "reviewRequestStatus"?: "...", "watchStatus"?: "...", "autoRerequestEligible": true|false, "sameHeadCleanConverged": true|false, "loopDisposition": "...", "terminal": true|false, "requestWatchContract": { "action": "...", "nextAction": "...", "requestStatus": "requested"|"already-requested"|"unavailable"|"failed"|"none", "routingState": "copilot_request_confirmed_waiting"|"ready_state_needs_copilot_request"|"draft_reset_requires_ready_state_reentry"|"non_ready_state", "watchEntryConfirmed": true|false, "watchArgs": { ... }|null, "stopState"?: "unavailable"|"blocked"|"draft_requires_ready_state_reentry"|"no_automatic_next_step" }, "watchTimeoutPolicy"?: { "classification": "external_healthy_wait", "minimumTimeoutMs": 86400000, "defaultTimeoutMs": 86400000 }, "watchArgs"?: { ... } }`
+- `{ "ok": true, "action": "watch"|"fix"|"stop", "state": "...", "allowedTransitions": [...], "nextAction": "...", "snapshot": {...}, "reviewRequestStatus"?: "...", "watchStatus"?: "...", "autoRerequestEligible": true|false, "sameHeadCleanConverged": true|false, "loopDisposition": "...", "terminal": true|false, "requestWatchContract": { "action": "...", "nextAction": "...", "requestStatus": "requested"|"already-requested"|"unavailable"|"failed"|"none", "routingState": "copilot_request_confirmed_waiting"|"ready_state_needs_copilot_request"|"draft_reset_requires_ready_state_reentry"|"non_ready_state", "watchEntryConfirmed": true|false, "watchArgs": { ... }|null, "stopState"?: "unavailable"|"blocked"|"draft_requires_ready_state_reentry"|"no_automatic_next_step" }, "watchTimeoutPolicy"?: { "classification": "external_healthy_wait", "minimumTimeoutMs": 1800000, "defaultTimeoutMs": 1800000 }, "watchArgs"?: { ... } }`
 
 Failure behavior:
 - malformed arguments and unexpected `gh` failures emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero
@@ -396,7 +396,7 @@ Contract:
 - returns `cycleDisposition: "terminal"` only when handoff routed to `stop`
 
 Success output shape:
-- `{ "ok": true, "handoffAction": "watch"|"fix"|"stop", "state": "...", "allowedTransitions": [...], "nextAction": "...", "snapshot": {...}, "reviewRequestStatus"?: "...", "watchArgs"?: { ... }, "watchTimeoutPolicy"?: { "classification": "external_healthy_wait", "minimumTimeoutMs": 86400000, "defaultTimeoutMs": 86400000 }, "watchStatus"?: "changed"|"timeout"|"idle", "watch"?: { ... }, "loopDisposition": "pending"|"unresolved_feedback"|"clean_converged"|"blocked"|"action_required"|"done", "cycleDisposition": "pending"|"needs_followup"|"terminal", "terminal": true|false }`
+- `{ "ok": true, "handoffAction": "watch"|"fix"|"stop", "state": "...", "allowedTransitions": [...], "nextAction": "...", "snapshot": {...}, "reviewRequestStatus"?: "...", "watchArgs"?: { ... }, "watchTimeoutPolicy"?: { "classification": "external_healthy_wait", "minimumTimeoutMs": 1800000, "defaultTimeoutMs": 1800000 }, "watchStatus"?: "changed"|"timeout"|"idle", "watch"?: { ... }, "loopDisposition": "pending"|"unresolved_feedback"|"clean_converged"|"blocked"|"action_required"|"done", "cycleDisposition": "pending"|"needs_followup"|"terminal", "terminal": true|false }`
 
 Failure behavior:
 - malformed arguments and unexpected `gh` failures emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero

--- a/scripts/github/watch-copilot-review.mjs
+++ b/scripts/github/watch-copilot-review.mjs
@@ -15,7 +15,7 @@ Required:
 
 Optional:
   --poll-interval-ms <ms>       Milliseconds between polls (default: 60000, i.e. 1 minute)
-  --timeout-ms <ms>             Total watch budget in ms; 0 = single check (default: 86400000, i.e. 24 hours)
+  --timeout-ms <ms>             Total watch budget in ms; 0 = single check (default: 1800000, i.e. 30 minutes)
 
 Output (stdout, JSON):
   { "ok": true, "status": "changed"|"timeout"|"idle", "repo": "...", "pr": N, "attempts": N,
@@ -91,7 +91,7 @@ export function parseWatchCliArgs(argv) {
     repo: undefined,
     pr: undefined,
     pollIntervalMs: 60_000,
-    timeoutMs: 86_400_000,
+    timeoutMs: 1_800_000,
   };
 
   while (args.length > 0) {

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -99,7 +99,7 @@ Watch refresh rule:
 
 Watch defaults:
   pollIntervalMs  60000  (1 minute)
-  timeoutMs       86400000  (24 hours)
+  timeoutMs       1800000   (30 minutes)
 
 Error output (stderr, JSON):
   Argument/usage errors:
@@ -112,7 +112,7 @@ Exit codes:
   1  Argument error or gh failure`.trim();
 
 const DEFAULT_POLL_INTERVAL_MS = 60_000;
-const DEFAULT_TIMEOUT_MS = 86_400_000;
+const DEFAULT_TIMEOUT_MS = 1_800_000;
 
 const WATCH_STATES = new Set([
   STATE.WAITING_FOR_COPILOT_REVIEW,

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -58,8 +58,12 @@ Use this helper output as source of truth for the normal routing seam. Interpret
 node <resolved-skill-scripts>/loop/run-copilot-watch-cycle.mjs --repo <owner/name> --pr <number>
 ```
 For explicit async loop entry or continuation, this is a persistent async watch/fix loop, not handoff-only behavior:
+- treat the normal PR follow-up path as one loop: `watch → detect → if threads found, fix + reply + resolve → re-request → watch again → … → pre_approval_gate → merge`
+- **PERSISTENCE RULE: Do not exit your session until the PR is merged or you hit a hard stop that requires conductor authorization.**
+- a single returned watch cycle (`changed`, `timeout`, or `idle`) is never completion by itself
 - if `cycleDisposition` is `pending` and `terminal` is `false`, stay attached to the same PR and resume another watch boundary instead of reporting completion
 - after Step 7 finishes a fix / reply-resolve / re-request cycle and the deterministic state returns to `waiting_for_copilot_review`, resume this watcher again in the same async session
+- default max watch timeout for one Copilot watch boundary is **30 minutes** (`--timeout-ms 1800000`); if that watch budget expires and a refreshed authoritative check still resolves `waiting_for_copilot_review`, stop with `watch timeout — PR #<number> needs manual attention.`
 - if the user explicitly asks for async handoff-only behavior, say that out loud and stop after the handoff boundary; otherwise do not silently reinterpret async loop entry as handoff-only
 
 **4. Low-level helpers**
@@ -201,10 +205,13 @@ Preferred approach for Copilot review follow-up:
 - route request/re-request/watch decisions through `copilot-pr-handoff.mjs` output instead of re-implementing branch logic in markdown
 - enter watcher mode only when handoff returns `action: "watch"` with `requestWatchContract.watchEntryConfirmed=true`
 - for explicit async loop entry or continuation, prefer `run-copilot-watch-cycle.mjs` so the handoff → watch boundary stays deterministic and uses the emitted non-zero watch timeout
-- if watcher status is `timeout`/`idle`, re-run `copilot-pr-handoff.mjs --watch-status <status>` and continue unless refreshed output is terminal
+- if watcher status is `changed`, immediately re-enter the Step 7 fix / reply-resolve / validate path; do not stop at `review requested` or after one watch cycle
+- if watcher status is `timeout`/`idle`, re-run `copilot-pr-handoff.mjs --watch-status <status>` exactly once to refresh authoritative state
+- if that refreshed state is still `waiting_for_copilot_review` after the default 30-minute watch budget was exhausted, treat it as a hard stop and report `watch timeout — PR #<number> needs manual attention.` rather than pretending the loop completed cleanly
+- otherwise continue from the refreshed deterministic state instead of guessing
 - zero-timeout `idle` probes are for explicit one-shot status/reattach checks only; they are not the normal async wait mechanism
 - after a successful fix / reply-resolve / re-request cycle, returning to `waiting_for_copilot_review` is a persistence boundary: resume the watcher instead of reporting completion
-- if a child async run exits and the refreshed state remains non-terminal (for example `waiting_for_copilot_review`), treat that as early exit and automatically restart/resume the same-PR follow-up path when feasible
+- if a child async run exits and the refreshed state remains non-terminal (for example `waiting_for_copilot_review`) before merge and without a hard stop, treat that as early exit and automatically restart/resume the same-PR follow-up path when feasible
 - keep watcher and fixer flow in-session; do not replace with ad hoc detached polling
 - do not report completion while unresolved Copilot feedback remains
 
@@ -286,7 +293,8 @@ When actionable review feedback exists, use a narrow follow-up loop:
     - if the request result is `unavailable`, report that limitation and stop unless the user explicitly wants passive waiting anyway
     - if the request command fails unexpectedly, stop and report the error rather than sleeping and hoping for a new review
 13. after a confirmed re-requested Copilot pass, refresh PR thread state again before reporting completion; if fresh Copilot threads exist, return to this follow-up loop rather than stopping at `review requested`
-14. if scope has broadened, stop and ask before continuing
+14. after a confirmed re-request returns the PR to `waiting_for_copilot_review`, jump back to Step 6 and keep the same session alive; do not exit on `review requested` alone
+15. if scope has broadened, stop and ask before continuing
 
 Do not treat `fix applied locally` as the end of the loop when the workflow also requires GitHub-side reviewer follow-up. If comment/reply authorization is withheld, report explicitly that the code may be fixed while the PR conversation state remains unresolved.
 

--- a/skills/docs/copilot-loop-operations.md
+++ b/skills/docs/copilot-loop-operations.md
@@ -172,14 +172,13 @@ MUST use `gh pr create --draft --repo <owner/name> --assignee @me --base <base> 
 
 ## Timeout and watch policy
 
-This workflow is intentionally long-lived.
-
-Do not rely on short default timeouts for unattended Copilot loops.
+This workflow is intentionally long-lived, but one Copilot review watch boundary must still be capped.
 
 Preferred defaults for this repo:
 - poll interval for review/activity watchers: **1 minute** (`--poll-interval-ms 60000`)
-- unattended watch timeout: **24 hours** (`--timeout-ms 86400000`)
-- if the user says to stay on it until done or avoid near-term timeout, prefer **72 hours** (`--timeout-ms 259200000`)
+- max watch timeout per Copilot review boundary: **30 minutes** (`--timeout-ms 1800000`)
+- if that 30-minute watch budget expires, refresh authoritative state once; if the refreshed state still resolves `waiting_for_copilot_review`, stop with `watch timeout — PR #<number> needs manual attention`
+- do not silently extend that 30-minute cap unless the user or conductor explicitly authorizes a longer watch budget for the active PR
 - parent/subagent no-activity threshold for watcher-style runs: at least **15 minutes**
 - active-long-running notice threshold for watcher-style runs: about **30 minutes**
 

--- a/skills/docs/workflow-handoff-template.md
+++ b/skills/docs/workflow-handoff-template.md
@@ -42,8 +42,12 @@ Every step is non-optional. Do not skip, reorder, or batch steps.
 
 ### 4. Wait for Copilot review
 
-- Poll `gh pr view --json reviews` until Copilot review appears
-- Do not proceed without Copilot feedback
+- Use the deterministic wait boundary: `node scripts/loop/run-copilot-watch-cycle.mjs --repo <owner/name> --pr <number>`
+- Treat the PR follow-up as a loop, not a one-shot watch: `watch → detect → if threads found, fix + reply + resolve → re-request → watch again → …`
+- If the watch cycle returns fresh Copilot activity / `cycleDisposition: "needs_followup"`, continue immediately to step 5
+- If the watch cycle returns `watchStatus: "timeout"`, refresh once with `node scripts/loop/copilot-pr-handoff.mjs --repo <owner/name> --pr <number> --watch-status timeout`
+- If the refreshed state still waits on Copilot, stop with `watch timeout — PR #<number> needs manual attention`
+- Default max watch timeout per Copilot watch boundary is **30 minutes** (`--timeout-ms 1800000`)
 
 ### 5. Address Copilot feedback
 
@@ -56,6 +60,7 @@ For each Copilot review pass:
 ### 6. Re-request Copilot review for new heads
 
 - After pushing fixes to a new head, re-request Copilot review
+- Return immediately to step 4 after the re-request; do not stop at `review requested` or after a single watch cycle
 - Repeat steps 4–6 until Copilot review has no actionable feedback
 
 ### 7. Pre-approval gate review
@@ -77,6 +82,8 @@ For each Copilot review pass:
 
 ## Non-negotiable invariants
 
+- **PERSISTENCE RULE: Do not exit your session until the PR is merged or you hit a hard stop that requires conductor authorization.**
+- A single watch cycle return is not completion; stay in the same loop until merge or a hard stop
 - The Copilot review loop (steps 4–6) sits **between** `draft_gate` and `pre_approval_gate` — never reorder
 - `unresolvedThreadCount === 0` verification is required before step 7
 - Gate comments must be visible on the PR — no hidden/local-only evidence

--- a/test/contracts/issue-intake-doc-contracts.test.mjs
+++ b/test/contracts/issue-intake-doc-contracts.test.mjs
@@ -155,6 +155,26 @@ test("issue-based shorthand auto dev-loop trigger is documented as one public in
   assert.match(devLoopAgent, /not a second public workflow entrypoint/i);
 });
 
+
+
+test("issue-intake surface requires persistent copilot follow-up loop and capped watch timeout", async () => {
+  const content = await readIssueIntakeSurface();
+
+  assert.match(
+    content,
+    /PERSISTENCE RULE: Do not exit your session until the PR is merged or you hit a hard stop that requires conductor authorization\./i,
+  );
+  assert.match(
+    content,
+    /watch → detect → if threads found, fix \+ reply \+ resolve → re-request → watch again/i,
+  );
+  assert.match(content, /30 minutes[\s\S]*1800000/i);
+  assert.match(
+    content,
+    /watch timeout\s+[—-]\s+PR #<number> needs manual attention/i,
+  );
+});
+
 test("issue-intake surface keeps issue refinement separate from the phase-scoped refiner and explains thin entrypoint agents", async () => {
   const skillContent = await readIssueIntakeSurface();
   const planContent = await readRepo("PLAN.md");

--- a/test/github/watch-copilot-review.test.mjs
+++ b/test/github/watch-copilot-review.test.mjs
@@ -424,10 +424,10 @@ test("watch-copilot-review --help prints usage and exits 0", async () => {
   assert.equal(helpShort.stdout, helpLong.stdout);
 });
 
-test("watch-copilot-review uses production-safe defaults (1-minute poll, 24-hour timeout)", () => {
+test("watch-copilot-review uses production-safe defaults (1-minute poll, 30-minute timeout)", () => {
   const options = parseWatchCliArgs(["--repo", "owner/repo", "--pr", "17"]);
   assert.equal(options.pollIntervalMs, 60_000);
-  assert.equal(options.timeoutMs, 86_400_000);
+  assert.equal(options.timeoutMs, 1_800_000);
 });
 
 test("watch-copilot-review trims surrounding whitespace from --repo", () => {

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -171,7 +171,7 @@ test("copilot-pr-handoff requests review and emits watch action for pr_ready_no_
     assert.equal(output.watchArgs.repo, "owner/repo");
     assert.equal(output.watchArgs.pr, 17);
     assert.equal(output.watchArgs.pollIntervalMs, 60_000);
-    assert.equal(output.watchArgs.timeoutMs, 86_400_000);
+    assert.equal(output.watchArgs.timeoutMs, 1_800_000);
     assert.equal(output.requestWatchContract.requestStatus, "requested");
     assert.equal(output.requestWatchContract.routingState, "copilot_request_confirmed_waiting");
     assert.equal(output.requestWatchContract.watchEntryConfirmed, true);
@@ -218,7 +218,7 @@ test("copilot-pr-handoff emits watch action when Copilot is already requested", 
     assert.deepEqual(output.watchTimeoutPolicy, EXTERNAL_HEALTHY_WAIT_TIMEOUT_POLICY);
     assert.ok(output.watchArgs, "expected watchArgs");
     assert.equal(output.watchArgs.pollIntervalMs, 60_000);
-    assert.equal(output.watchArgs.timeoutMs, 86_400_000);
+    assert.equal(output.watchArgs.timeoutMs, 1_800_000);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -517,7 +517,7 @@ test("copilot-pr-handoff emits watch action when 422 but Copilot is in requested
     assert.equal(output.watchArgs.repo, "owner/repo");
     assert.equal(output.watchArgs.pr, 17);
     assert.equal(output.watchArgs.pollIntervalMs, 60_000);
-    assert.equal(output.watchArgs.timeoutMs, 86_400_000);
+    assert.equal(output.watchArgs.timeoutMs, 1_800_000);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -583,7 +583,7 @@ test("copilot-pr-handoff emits watch action when 422 but Copilot has a pending r
     assert.equal(output.watchArgs.repo, "owner/repo");
     assert.equal(output.watchArgs.pr, 17);
     assert.equal(output.watchArgs.pollIntervalMs, 60_000);
-    assert.equal(output.watchArgs.timeoutMs, 86_400_000);
+    assert.equal(output.watchArgs.timeoutMs, 1_800_000);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/run-copilot-watch-cycle.test.mjs
+++ b/test/loop/run-copilot-watch-cycle.test.mjs
@@ -65,14 +65,14 @@ test("runWatchCycle uses emitted non-zero watchArgs for normal async waiting", a
             repo: "owner/repo",
             pr: 17,
             pollIntervalMs: 60_000,
-            timeoutMs: 86_400_000,
+            timeoutMs: 1_800_000,
           },
         },
         watchArgs: {
           repo: "owner/repo",
           pr: 17,
           pollIntervalMs: 60_000,
-          timeoutMs: 86_400_000,
+          timeoutMs: 1_800_000,
         },
       }),
       watchCopilotReviewImpl: async (options) => {
@@ -82,7 +82,7 @@ test("runWatchCycle uses emitted non-zero watchArgs for normal async waiting", a
           status: "timeout",
           repo: options.repo,
           pr: options.pr,
-          attempts: 1440,
+          attempts: 30,
           newComments: [],
           newReviews: [],
           newIssueComments: [],
@@ -91,9 +91,9 @@ test("runWatchCycle uses emitted non-zero watchArgs for normal async waiting", a
     },
   );
 
-  assert.equal(watcherOptions.timeoutMs, 86_400_000);
+  assert.equal(watcherOptions.timeoutMs, 1_800_000);
   assert.notEqual(watcherOptions.timeoutMs, 0);
-  assert.equal(result.watchTimeoutPolicy.minimumTimeoutMs, 86_400_000);
+  assert.equal(result.watchTimeoutPolicy.minimumTimeoutMs, 1_800_000);
   assert.equal(result.loopDisposition, "pending");
   assert.equal(result.cycleDisposition, "pending");
   assert.equal(result.terminal, false);
@@ -101,10 +101,10 @@ test("runWatchCycle uses emitted non-zero watchArgs for normal async waiting", a
   assert.equal(result.state, "waiting_for_copilot_review");
   assert.equal(result.requestWatchContract.routingState, "copilot_request_confirmed_waiting");
   assert.equal(result.contractTrace.waitStrategy.mode, "persistent_watch");
-  assert.equal(result.contractTrace.waitStrategy.effectiveTimeoutMs, 86_400_000);
+  assert.equal(result.contractTrace.waitStrategy.effectiveTimeoutMs, 1_800_000);
   assert.equal(result.contractTrace.waitStrategy.effectivePollIntervalMs, 60_000);
-  assert.equal(result.contractTrace.orchestration.emittedWatchArgs.timeoutMs, 86_400_000);
-  assert.equal(result.contractTrace.orchestration.effectiveWatchArgs.timeoutMs, 86_400_000);
+  assert.equal(result.contractTrace.orchestration.emittedWatchArgs.timeoutMs, 1_800_000);
+  assert.equal(result.contractTrace.orchestration.effectiveWatchArgs.timeoutMs, 1_800_000);
   assert.equal(result.contractTrace.stateRefresh.boundaryKind, "post_watch_or_probe");
   assert.equal(result.contractTrace.stopReason.classification, "healthy_wait");
 });
@@ -137,7 +137,7 @@ test("runWatchCycle rejects persistent watch budgets below the unattended extern
         }),
       },
     ),
-    /requires at least 86400000 ms/i,
+    /requires at least 1800000 ms/i,
   );
 });
 
@@ -165,7 +165,7 @@ test("runWatchCycle uses zero-timeout idle probes only when explicitly requested
           repo: "owner/repo",
           pr: 17,
           pollIntervalMs: 60_000,
-          timeoutMs: 86_400_000,
+          timeoutMs: 1_800_000,
         },
       }),
       watchCopilotReviewImpl: async (options) => {
@@ -216,7 +216,7 @@ test("runWatchCycle keeps shared loopDisposition and reports needs_followup in c
           repo: "owner/repo",
           pr: 17,
           pollIntervalMs: 60_000,
-          timeoutMs: 86_400_000,
+          timeoutMs: 1_800_000,
         },
       }),
       watchCopilotReviewImpl: async (options) => ({
@@ -418,7 +418,7 @@ test("runWatchCycle integration keeps initial request-review -> waiting_for_copi
             status: "timeout",
             repo: options.repo,
             pr: options.pr,
-            attempts: 1440,
+            attempts: 30,
             newComments: [],
             newReviews: [],
             newIssueComments: [],
@@ -433,7 +433,7 @@ test("runWatchCycle integration keeps initial request-review -> waiting_for_copi
     assert.equal(result.loopDisposition, "pending");
     assert.equal(result.terminal, false);
     assert.equal(result.watchStatus, "timeout");
-    assert.equal(watcherOptions.timeoutMs, 86_400_000);
+    assert.equal(watcherOptions.timeoutMs, 1_800_000);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -558,7 +558,7 @@ process.exit(97);
             status: "timeout",
             repo: options.repo,
             pr: options.pr,
-            attempts: 1440,
+            attempts: 30,
             newComments: [],
             newReviews: [],
             newIssueComments: [],
@@ -573,7 +573,7 @@ process.exit(97);
     assert.equal(result.loopDisposition, "pending");
     assert.equal(result.terminal, false);
     assert.equal(result.watchStatus, "timeout");
-    assert.equal(watcherOptions.timeoutMs, 86_400_000);
+    assert.equal(watcherOptions.timeoutMs, 1_800_000);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -681,7 +681,7 @@ test("runWatchCycle integration bounds active Copilot workflow waits by the emit
           repo: "owner/repo",
           pr: 17,
           pollIntervalMs: 60_000,
-          timeoutMs: 86_400_000,
+          timeoutMs: 1_800_000,
         },
       }),
       detectSessionActivity: true,
@@ -714,11 +714,11 @@ test("runWatchCycle integration bounds active Copilot workflow waits by the emit
     },
   );
 
-  assert.equal(receivedTimeoutMs, 86_400_000);
+  assert.equal(receivedTimeoutMs, 1_800_000);
   assert.equal(result.sessionActivity.activity, "active");
   assert.equal(result.watchStatus, "idle");
   assert.equal(result.contractTrace.orchestration.workflowRunWatch.attempted, true);
-  assert.equal(result.contractTrace.orchestration.workflowRunWatch.timeoutMs, 86_400_000);
+  assert.equal(result.contractTrace.orchestration.workflowRunWatch.timeoutMs, 1_800_000);
   assert.equal(result.contractTrace.orchestration.workflowRunWatch.runId, 444);
   assert.equal(result.contractTrace.orchestration.workflowRunWatch.status, "timed_out");
 });
@@ -798,7 +798,7 @@ test("runWatchCycle integration keeps the full persistent watch timeout after ac
 
     assert.equal(result.handoffAction, "watch");
     assert.equal(result.sessionActivity.activity, "active");
-    assert.equal(watcherOptions.timeoutMs, 86_400_000);
+    assert.equal(watcherOptions.timeoutMs, 1_800_000);
     assert.equal(result.watchStatus, "idle");
   } finally {
     await rm(tempDir, { recursive: true, force: true });

--- a/test/workflow-handoff-template-contract.test.mjs
+++ b/test/workflow-handoff-template-contract.test.mjs
@@ -147,6 +147,26 @@ test("unresolvedThreadCount === 0 appears before pre_approval_gate in mandatory 
   );
 });
 
+
+
+test("workflow-handoff-template includes the persistence rule and timeout escalation", async () => {
+  const content = await readTemplate();
+
+  assert.match(
+    content,
+    /PERSISTENCE RULE: Do not exit your session until the PR is merged or you hit a hard stop that requires conductor authorization\./i,
+  );
+  assert.match(
+    content,
+    /watch → detect → if threads found, fix \+ reply \+ resolve → re-request → watch again/i,
+  );
+  assert.match(content, /30 minutes[\s\S]*1800000/i);
+  assert.match(
+    content,
+    /watch timeout\s+[—-]\s+PR #<number> needs manual attention/i,
+  );
+});
+
 test("coordinator prompt references the canonical hand-off template", async () => {
   const coordinatorPath = path.resolve("agents/coordinator.agent.md");
   const coordinatorContent = await readFile(coordinatorPath, "utf8");


### PR DESCRIPTION
## Summary
- keep the Copilot PR follow-up session alive across watch/fix/re-request cycles instead of treating a single watch boundary as completion
- add an explicit persistence rule + timeout escalation to the Copilot follow-up skill and workflow handoff template
- cap the default Copilot review watch budget at 30 minutes across the shared timeout helpers/docs/tests

## Scope / Context
- fixes #382
- updates the canonical Copilot follow-up/operator docs that guide subagent behavior
- aligns the shared timeout policy, helper defaults, README docs, and contract tests with the new 30-minute watch cap

## Acceptance Criteria
- subagent instructions now describe the loop as `watch -> detect -> fix/reply/resolve -> re-request -> watch again -> ... -> pre_approval_gate -> merge`
- the skill and handoff template include: `PERSISTENCE RULE: Do not exit your session until the PR is merged or you hit a hard stop that requires conductor authorization.`
- the default Copilot watch timeout is 30 minutes and docs/tests cover the `watch timeout — PR #<number> needs manual attention` hard stop
- affected validation/tests stay green

## Definition of Done
- skill/docs/test changes are committed on this branch
- `npm run verify` passes
- draft PR is opened for the issue with the updated workflow contract

## Non-goals
- no rewrite of the Copilot loop state machine routing semantics beyond the default timeout policy/value alignment
- no changes to bootstrap-only `watch-initial-copilot-pr` behavior
