### PR TITLE
Add conductor monitor queue report helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,17 @@ Practical rule:
 - the next qualifying `dev-loop` start/resume must honor that checkpoint gate
 - complete or explicitly skip the retrospective before starting the next qualifying run
 
+## Conductor monitor pattern
+
+Use a conductor monitor as the queue-level human-in-the-loop watcher for active `dev-loop` work:
+- the conductor monitors all active `dev-loop` subagents and open PRs
+- if a subagent exits before merge and the routed state is still non-terminal, auto-resume the same loop
+- if new Copilot review threads arrive after a watcher/fixer session exits, auto-resume the same PR follow-up loop
+- when the queue completes, report that completion instead of silently idling
+- run periodic status probes for active subagents via `subagent({action:"status"})` alongside PR-state checks
+- for open PR queue checks, prefer the aggregate helper `node scripts/loop/conductor-monitor.mjs --repo <owner/name>`
+- this is a human-in-the-loop pattern for now; fully autonomous conductor ownership is a follow-up slice
+
 ## Core guard rails
 
 - KISS

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -334,7 +334,7 @@ Contract:
 - keeps the current implementation human-in-the-loop; fully autonomous monitor ownership is a follow-up slice
 
 Success output shape:
-- `{ "ok": true, "repo": "owner/name", "queueStatus": "queue_complete"|"monitoring"|"attention_needed", "needsAttentionCount": 0, "summary": { "waiting": 0, "needsAttention": 0, "blocked": 0, "done": 0 }, "prs": [...] }`
+- `{ "ok": true, "repo": "owner/name", "checkedAt": "...", "prCount": 2, "queueStatus": "queue_complete"|"monitoring"|"attention_needed", "needsAttentionCount": 0, "summary": { "waiting": 0, "needsAttention": 0, "blocked": 0, "done": 0 }, "prs": [...] }`
 
 Failure behavior:
 - malformed arguments and unexpected `gh` failures emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -327,7 +327,7 @@ Required:
 - `--repo <owner/name>`
 
 Contract:
-- lists all open PRs via `gh pr list --state open`
+- lists all open PRs via `gh pr list --state open --limit 1000` to avoid GitHub CLI default truncation
 - reuses `detect-copilot-loop-state.mjs` logic for each PR instead of inventing a second state classifier
 - reports one queue-level summary with per-PR loop state, next action, and whether human follow-up is needed now
 - reports `queue_complete` when the open-PR queue is empty

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -319,6 +319,27 @@ Contract:
 Success output shape:
 - `{ "ok": true, "repo": "owner/name", "issue": 59, "state": "...", "prNumber": 79|null, "prUrl": "..."|null, "headBranch": "..."|null, "authorLogin": "Copilot"|null, "isDraft": true|false|null, "changedFiles": 0|null, "commitCount": 1|null, "soleCommitHeadline": "Initial plan"|null, "sessionActivity": "active"|"concluded"|"idle"|null, "sessionRunId": 123|null, "sessionRunName": "..."|null, "sessionRunStatus": "..."|null, "sessionRunConclusion": string|null, "sessionRunCreatedAt": "..."|null, "sessionConfidence": "high"|null }`
 
+### `scripts/loop/conductor-monitor.mjs`
+
+Aggregate the current Copilot-loop status for every open PR in one repository.
+
+Required:
+- `--repo <owner/name>`
+
+Contract:
+- lists all open PRs via `gh pr list --state open`
+- reuses `detect-copilot-loop-state.mjs` logic for each PR instead of inventing a second state classifier
+- reports one queue-level summary with per-PR loop state, next action, and whether human follow-up is needed now
+- reports `queue_complete` when the open-PR queue is empty
+- keeps the current implementation human-in-the-loop; fully autonomous monitor ownership is a follow-up slice
+
+Success output shape:
+- `{ "ok": true, "repo": "owner/name", "queueStatus": "queue_complete"|"monitoring"|"attention_needed", "needsAttentionCount": 0, "summary": { "waiting": 0, "needsAttention": 0, "blocked": 0, "done": 0 }, "prs": [...] }`
+
+Failure behavior:
+- malformed arguments and unexpected `gh` failures emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero
+
+
 ### `scripts/loop/detect-copilot-session-activity.mjs`
 
 Detect deterministic Copilot workflow session activity on a branch.

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -57,7 +57,10 @@ Queue status values:
   attention_needed At least one open PR needs human-in-the-loop follow-up
 
 Error output (stderr, JSON):
-  { "ok": false, "error": "...", "usage": "..." }
+  Argument/usage errors:
+    { "ok": false, "error": "...", "usage": "..." }
+  gh/runtime failures:
+    { "ok": false, "error": "..." }
 
 Exit codes:
   0  Success

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+import { runChild, requireOptionValue } from "../_cli-primitives.mjs";
+import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { autoDetectSnapshot } from "./detect-copilot-loop-state.mjs";
+import { interpretLoopState, summarizeLoopInterpretation } from "@pi-dev-loops/core/loop/copilot-loop-state";
+
+const USAGE = `Usage: conductor-monitor.mjs --repo <owner/name>
+
+Aggregate Copilot-loop status across all open PRs in one repo.
+
+Required:
+  --repo <owner/name>   Repository slug (e.g. owner/repo)
+
+Success output (stdout, JSON):
+  {
+    "ok": true,
+    "repo": "owner/repo",
+    "checkedAt": "...",
+    "prCount": 2,
+    "queueStatus": "queue_complete"|"monitoring"|"attention_needed",
+    "needsAttentionCount": 1,
+    "summary": {
+      "waiting": 1,
+      "needsAttention": 1,
+      "blocked": 0,
+      "done": 0
+    },
+    "prs": [
+      {
+        "number": 17,
+        "title": "...",
+        "url": "...",
+        "isDraft": false,
+        "headRefName": "...",
+        "authorLogin": "...",
+        "state": "waiting_for_copilot_review",
+        "nextAction": "...",
+        "loopDisposition": "pending",
+        "terminal": false,
+        "needsAttention": false,
+        "snapshot": {
+          "ciStatus": "none",
+          "copilotReviewRequestStatus": "requested",
+          "copilotReviewOnCurrentHead": false,
+          "unresolvedThreadCount": 0,
+          "actionableThreadCount": 0,
+          "copilotReviewRoundCount": 0
+        }
+      }
+    ]
+  }
+
+Queue status values:
+  queue_complete   No open PRs remain in the repo queue
+  monitoring       Open PRs exist, but all are in healthy wait states
+  attention_needed At least one open PR needs human-in-the-loop follow-up
+
+Error output (stderr, JSON):
+  { "ok": false, "error": "...", "usage": "..." }
+
+Exit codes:
+  0  Success
+  1  Argument error, gh failure, or indeterminate PR status`.trim();
+
+const parseError = buildParseError(USAGE);
+
+function parseCliArgs(argv) {
+  const args = [...argv];
+  const options = {
+    help: false,
+    repo: undefined,
+  };
+
+  while (args.length > 0) {
+    const token = args.shift();
+
+    if (token === "--help" || token === "-h") {
+      options.help = true;
+      return options;
+    }
+
+    if (token === "--repo") {
+      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+      continue;
+    }
+
+    throw parseError(`Unknown argument: ${token}`);
+  }
+
+  if (options.repo === undefined) {
+    throw parseError("conductor-monitor requires --repo <owner/name>");
+  }
+
+  try {
+    parseRepoSlug(options.repo);
+  } catch (error) {
+    throw parseError(error instanceof Error ? error.message : String(error));
+  }
+
+  return options;
+}
+
+async function listOpenPrs({ repo }, { env, ghCommand }) {
+  const result = await runChild(
+    ghCommand,
+    [
+      "pr",
+      "list",
+      "--repo",
+      repo,
+      "--state",
+      "open",
+      "--json",
+      "number,title,url,isDraft,headRefName,author",
+    ],
+    env,
+  );
+
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw new Error(`gh command failed: ${detail}`);
+  }
+
+  const payload = parseJsonText(result.stdout);
+  const prs = Array.isArray(payload) ? payload : [];
+
+  return prs
+    .map((pr) => ({
+      number: Number.isInteger(pr?.number) ? pr.number : null,
+      title: typeof pr?.title === "string" ? pr.title : "",
+      url: typeof pr?.url === "string" ? pr.url : null,
+      isDraft: Boolean(pr?.isDraft),
+      headRefName: typeof pr?.headRefName === "string" ? pr.headRefName : null,
+      authorLogin: typeof pr?.author?.login === "string" ? pr.author.login : null,
+    }))
+    .filter((pr) => pr.number !== null)
+    .sort((left, right) => left.number - right.number);
+}
+
+function summarizePrDisposition(loopDisposition) {
+  switch (loopDisposition) {
+    case "pending":
+      return { bucket: "waiting", needsAttention: false };
+    case "blocked":
+      return { bucket: "blocked", needsAttention: true };
+    case "done":
+      return { bucket: "done", needsAttention: false };
+    case "unresolved_feedback":
+    case "clean_converged":
+    case "action_required":
+      return { bucket: "needsAttention", needsAttention: true };
+    default:
+      return { bucket: "needsAttention", needsAttention: true };
+  }
+}
+
+function buildPrReport(pr, interpretation, interpretationSummary, snapshot) {
+  const disposition = summarizePrDisposition(interpretationSummary.loopDisposition);
+
+  return {
+    number: pr.number,
+    title: pr.title,
+    url: pr.url,
+    isDraft: pr.isDraft,
+    headRefName: pr.headRefName,
+    authorLogin: pr.authorLogin,
+    state: interpretation.state,
+    nextAction: interpretation.nextAction,
+    loopDisposition: interpretationSummary.loopDisposition,
+    terminal: interpretationSummary.terminal,
+    needsAttention: disposition.needsAttention,
+    bucket: disposition.bucket,
+    snapshot: {
+      ciStatus: snapshot.ciStatus,
+      copilotReviewRequestStatus: snapshot.copilotReviewRequestStatus,
+      copilotReviewOnCurrentHead: snapshot.copilotReviewOnCurrentHead,
+      unresolvedThreadCount: snapshot.unresolvedThreadCount,
+      actionableThreadCount: snapshot.actionableThreadCount,
+      copilotReviewRoundCount: snapshot.copilotReviewRoundCount,
+    },
+  };
+}
+
+export async function runConductorMonitor({ repo }, { env = process.env, ghCommand = "gh" } = {}) {
+  const prs = await listOpenPrs({ repo }, { env, ghCommand });
+
+  if (prs.length === 0) {
+    return {
+      ok: true,
+      repo,
+      checkedAt: new Date().toISOString(),
+      prCount: 0,
+      queueStatus: "queue_complete",
+      needsAttentionCount: 0,
+      summary: {
+        waiting: 0,
+        needsAttention: 0,
+        blocked: 0,
+        done: 0,
+      },
+      prs: [],
+    };
+  }
+
+  const reports = [];
+  for (const pr of prs) {
+    const snapshot = await autoDetectSnapshot({ repo, pr: pr.number }, { env, ghCommand });
+    const interpretation = interpretLoopState(snapshot);
+    const interpretationSummary = summarizeLoopInterpretation(interpretation);
+    reports.push(buildPrReport(pr, interpretation, interpretationSummary, snapshot));
+  }
+
+  const summary = reports.reduce((accumulator, pr) => {
+    accumulator[pr.bucket] += 1;
+    return accumulator;
+  }, {
+    waiting: 0,
+    needsAttention: 0,
+    blocked: 0,
+    done: 0,
+  });
+
+  const needsAttentionCount = summary.needsAttention + summary.blocked;
+  const queueStatus = needsAttentionCount > 0 ? "attention_needed" : "monitoring";
+
+  return {
+    ok: true,
+    repo,
+    checkedAt: new Date().toISOString(),
+    prCount: reports.length,
+    queueStatus,
+    needsAttentionCount,
+    summary,
+    prs: reports.map(({ bucket, ...pr }) => pr),
+  };
+}
+
+export async function runCli(
+  argv = process.argv.slice(2),
+  { stdout = process.stdout, env = process.env, ghCommand = "gh" } = {},
+) {
+  const options = parseCliArgs(argv);
+
+  if (options.help) {
+    stdout.write(`${USAGE}\n`);
+    return;
+  }
+
+  const result = await runConductorMonitor(options, { env, ghCommand });
+  stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli().catch((error) => {
+    process.stderr.write(`${formatCliError(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -126,9 +126,11 @@ async function listOpenPrs({ repo }, { env, ghCommand }) {
   }
 
   const payload = parseJsonText(result.stdout);
-  const prs = Array.isArray(payload) ? payload : [];
+  if (!Array.isArray(payload)) {
+    throw new Error("Invalid gh pr list payload: expected an array");
+  }
 
-  return prs
+  return payload
     .map((pr) => ({
       number: Number.isInteger(pr?.number) ? pr.number : null,
       title: typeof pr?.title === "string" ? pr.title : "",

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -64,6 +64,7 @@ Exit codes:
   1  Argument error, gh failure, or indeterminate PR status`.trim();
 
 const parseError = buildParseError(USAGE);
+const OPEN_PR_LIST_LIMIT = 1000;
 
 function parseCliArgs(argv) {
   const args = [...argv];
@@ -111,6 +112,8 @@ async function listOpenPrs({ repo }, { env, ghCommand }) {
       repo,
       "--state",
       "open",
+      "--limit",
+      String(OPEN_PR_LIST_LIMIT),
       "--json",
       "number,title,url,isDraft,headRefName,author",
     ],

--- a/test/contracts/planning-doc-contracts.test.mjs
+++ b/test/contracts/planning-doc-contracts.test.mjs
@@ -239,3 +239,19 @@ test("phase-truth docs agree that Phase 8 is active and Phase 7 is deferred", as
   assert.doesNotMatch(phase8, /session \(gitignored\) config/i);
   assert.doesNotMatch(phase8, /defaults\.json|overrides\.json/i);
 });
+
+test("AGENTS documents the conductor monitor pattern as human-in-the-loop queue oversight", async () => {
+  const agents = await readRepo("AGENTS.md");
+
+  assertMatchesAll(agents, [
+    /## Conductor monitor pattern/i,
+    /monitors all active `dev-loop` subagents and open PRs/i,
+    /subagent exits before merge[\s\S]*auto-resume/i,
+    /Copilot review threads arrive[\s\S]*auto-resume/i,
+    /when the queue completes[\s\S]*report/i,
+    /subagent\(\{action:\\?"status\\?"\}\)/i,
+    /scripts\/loop\/conductor-monitor\.mjs/i,
+    /human-in-the-loop pattern for now/i,
+    /follow-up slice/i,
+  ], "AGENTS.md");
+});

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -35,7 +35,7 @@ test("conductor-monitor reports queue_complete when no open PRs exist", async ()
 
   try {
     const env = await writeGhStub(tempDir, [{
-      assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open"],
+      assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "1000"],
       stdout: "[]\n",
     }]);
 
@@ -62,7 +62,7 @@ test("conductor-monitor reports monitoring when open PRs are still in healthy wa
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open"],
+        assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "1000"],
         stdout: `${JSON.stringify([
           {
             number: 17,
@@ -121,7 +121,7 @@ test("conductor-monitor flags unresolved-feedback PRs as needing attention while
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open"],
+        assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "1000"],
         stdout: `${JSON.stringify([
           {
             number: 17,

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -56,6 +56,29 @@ test("conductor-monitor reports queue_complete when no open PRs exist", async ()
   }
 });
 
+test("conductor-monitor reports gh runtime failures without a usage payload", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-gh-failure-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [{
+      assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "1000", "--json", "number,title,url,isDraft,headRefName,author"],
+      stderr: "gh exploded\n",
+      exitCode: 1,
+    }]);
+
+    const result = await runNode(["--repo", "owner/repo"], { env });
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /gh command failed/i);
+    assert.equal(Object.hasOwn(payload, "usage"), false);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("conductor-monitor fails closed when gh pr list returns non-array JSON", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-invalid-list-"));
 

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -56,6 +56,27 @@ test("conductor-monitor reports queue_complete when no open PRs exist", async ()
   }
 });
 
+test("conductor-monitor fails closed when gh pr list returns non-array JSON", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-invalid-list-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [{
+      assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "1000", "--json", "number,title,url,isDraft,headRefName,author"],
+      stdout: "{}\n",
+    }]);
+
+    const result = await runNode(["--repo", "owner/repo"], { env });
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /expected an array/i);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("conductor-monitor reports monitoring when open PRs are still in healthy wait states", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-waiting-"));
 

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
+
+const scriptPath = path.resolve("scripts/loop/conductor-monitor.mjs");
+const mixedThreadsFixturePath = path.resolve("packages/core/test/fixtures/github/review-threads/mixed-threads.json");
+
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
+
+async function writeGhStub(tempDir, entries) {
+  const { env } = await writeGhStubHelper(tempDir, entries);
+  return env;
+}
+
+function emptyThreadsPayload() {
+  return JSON.stringify({
+    data: {
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            nodes: [],
+          },
+        },
+      },
+    },
+  });
+}
+
+test("conductor-monitor reports queue_complete when no open PRs exist", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-empty-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [{
+      assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open"],
+      stdout: "[]\n",
+    }]);
+
+    const result = await runNode(["--repo", "owner/repo"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.repo, "owner/repo");
+    assert.equal(payload.prCount, 0);
+    assert.equal(payload.queueStatus, "queue_complete");
+    assert.equal(payload.needsAttentionCount, 0);
+    assert.deepEqual(payload.prs, []);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor reports monitoring when open PRs are still in healthy wait states", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-waiting-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open"],
+        stdout: `${JSON.stringify([
+          {
+            number: 17,
+            title: "Add monitor status report",
+            url: "https://github.com/owner/repo/pull/17",
+            isDraft: false,
+            headRefName: "copilot/issue-383",
+            author: { login: "copilot-swe-agent" },
+          },
+        ])}\n`,
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: `${JSON.stringify({
+          isDraft: false,
+          state: "OPEN",
+          number: 17,
+          reviews: [],
+          statusCheckRollup: [],
+        })}\n`,
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[{"login":"copilot-pull-request-reviewer[bot]"}],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: `${emptyThreadsPayload()}\n`,
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.queueStatus, "monitoring");
+    assert.equal(payload.needsAttentionCount, 0);
+    assert.equal(payload.summary.waiting, 1);
+    assert.equal(payload.summary.needsAttention, 0);
+    assert.equal(payload.prs[0].number, 17);
+    assert.equal(payload.prs[0].state, "waiting_for_copilot_review");
+    assert.equal(payload.prs[0].loopDisposition, "pending");
+    assert.equal(payload.prs[0].needsAttention, false);
+    assert.equal(payload.prs[0].snapshot.copilotReviewRequestStatus, "requested");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor flags unresolved-feedback PRs as needing attention while preserving pending waits", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-attention-"));
+  const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open"],
+        stdout: `${JSON.stringify([
+          {
+            number: 17,
+            title: "Add conductor monitor wrapper",
+            url: "https://github.com/owner/repo/pull/17",
+            isDraft: false,
+            headRefName: "copilot/issue-383-wrapper",
+            author: { login: "copilot-swe-agent" },
+          },
+          {
+            number: 18,
+            title: "Document monitor pattern",
+            url: "https://github.com/owner/repo/pull/18",
+            isDraft: false,
+            headRefName: "copilot/issue-383-docs",
+            author: { login: "copilot-swe-agent" },
+          },
+        ])}\n`,
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: `${JSON.stringify({
+          isDraft: false,
+          state: "OPEN",
+          number: 17,
+          reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
+          statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+        })}\n`,
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: mixedThreadsFixture,
+      },
+      {
+        assertArgs: ["pr", "view", "18", "--repo", "owner/repo"],
+        stdout: `${JSON.stringify({
+          isDraft: false,
+          state: "OPEN",
+          number: 18,
+          reviews: [],
+          statusCheckRollup: [],
+        })}\n`,
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/18/requested_reviewers"],
+        stdout: '{"users":[{"login":"copilot-pull-request-reviewer[bot]"}],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: `${emptyThreadsPayload()}\n`,
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.queueStatus, "attention_needed");
+    assert.equal(payload.needsAttentionCount, 1);
+    assert.equal(payload.summary.waiting, 1);
+    assert.equal(payload.summary.needsAttention, 1);
+    assert.equal(payload.summary.blocked, 0);
+
+    const actionable = payload.prs.find((pr) => pr.number === 17);
+    const waiting = payload.prs.find((pr) => pr.number === 18);
+
+    assert.equal(actionable.state, "unresolved_feedback_present");
+    assert.equal(actionable.loopDisposition, "unresolved_feedback");
+    assert.equal(actionable.needsAttention, true);
+    assert.equal(actionable.snapshot.unresolvedThreadCount, 2);
+    assert.equal(actionable.snapshot.actionableThreadCount, 1);
+
+    assert.equal(waiting.state, "waiting_for_copilot_review");
+    assert.equal(waiting.loopDisposition, "pending");
+    assert.equal(waiting.needsAttention, false);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -35,7 +35,7 @@ test("conductor-monitor reports queue_complete when no open PRs exist", async ()
 
   try {
     const env = await writeGhStub(tempDir, [{
-      assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "1000"],
+      assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "1000", "--json", "number,title,url,isDraft,headRefName,author"],
       stdout: "[]\n",
     }]);
 
@@ -62,7 +62,7 @@ test("conductor-monitor reports monitoring when open PRs are still in healthy wa
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "1000"],
+        assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "1000", "--json", "number,title,url,isDraft,headRefName,author"],
         stdout: `${JSON.stringify([
           {
             number: 17,
@@ -121,7 +121,7 @@ test("conductor-monitor flags unresolved-feedback PRs as needing attention while
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "1000"],
+        assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "1000", "--json", "number,title,url,isDraft,headRefName,author"],
         stdout: `${JSON.stringify([
           {
             number: 17,


### PR DESCRIPTION
## Summary
- add a lightweight `scripts/loop/conductor-monitor.mjs` helper that aggregates `detect-copilot-loop-state` across all open PRs in one repo
- document the conductor-monitor pattern in `AGENTS.md`, including auto-resume expectations and the current human-in-the-loop boundary
- cover the new helper and docs contract with loop tests and an AGENTS contract test

## Scope / context
Issue: #383

This change implements the issue's near-term monitor slice without introducing detached autonomous ownership yet. The new helper gives the conductor one command for queue status across open PRs, while AGENTS records the intended monitor behavior and its current human-in-the-loop posture.

## Acceptance criteria
- [x] AGENTS.md documents the conductor-monitor pattern
- [x] `scripts/loop/conductor-monitor.mjs` reports queue status for all open PRs in one command
- [x] tests cover queue-complete, healthy-wait, and needs-attention monitor outcomes

## Definition of done
- [x] helper added under `scripts/loop/`
- [x] AGENTS and scripts docs updated
- [x] targeted tests added and `npm run verify` passes
- [x] PR opened as draft for gate review

## Non-goals
- fully autonomous detached monitor ownership or self-scheduling
- intercom reporting transport changes
- subagent lifecycle mutations beyond documenting the pattern

## Validation
- `npm run verify`

Closes #383
