### PR TITLE
Add draft-first PR creation wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ These skills may be provided repo-locally or globally; this contract does not as
 - Use `npm run verify` as the default repo-level local verification path when a full local validation pass is warranted.
 - For public-facing or release-bound changes, prefer GitHub issues/PRs/CI over direct local-main finalization.
 - Use detailed structured PR descriptions, not thin placeholder summaries. At minimum include: change summary, scope/context, explicit acceptance criteria, explicit definition of done, and explicit non-goals.
-- When creating GitHub issues or PRs via `gh issue create` or `gh pr create`, always include `--assignee @me` so the new artifact is self-assigned.
+- When creating GitHub issues via `gh issue create`, always include `--assignee @me` so the new artifact is self-assigned. When creating PRs in this repo, use `node scripts/github/create-draft-pr.mjs --assignee @me ...` so draft-first is enforced mechanically while preserving self-assignment.
 - In PR review/fix loops, do not stop at local code changes alone: after an accepted fix is pushed, reply to the addressed review comments with the resolving commit reference and resolve the corresponding threads when genuinely satisfied.
 - Do not merge directly to `main` without review when a PR-based remote loop is practical.
 

--- a/docs/tracker-story-pr-contract.md
+++ b/docs/tracker-story-pr-contract.md
@@ -120,7 +120,7 @@ implementations map canonical action names to tracker-native field updates.
 | PR lifecycle event | Maps to canonical state | Sync trigger |
 |---|---|---|
 | No PR created yet | `ready_no_pr` | No trigger |
-| `gh pr create --draft --assignee @me` succeeds | `draft_pr_open` | Apply `set_in_progress` to tracker |
+| Draft PR creation succeeds | `draft_pr_open` | Apply `set_in_progress` to tracker |
 | PR converted from draft to ready-for-review | `pr_reviewable` | Apply `set_reviewable` to tracker |
 | PR merged | `pr_merged` | Apply `set_done` to tracker |
 | PR closed without merge | `pr_closed_unmerged` | No automatic sync; report to user |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -65,6 +65,25 @@ Failure behavior:
 - malformed arguments, invalid JSON, and `gh` failures emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero
 - live capture is only allowed when both `--repo` and `--pr` are present
 
+### `scripts/github/create-draft-pr.mjs`
+
+Thin wrapper around `gh pr create` for draft-first PR creation.
+
+Usage:
+- `node scripts/github/create-draft-pr.mjs [gh pr create args...]`
+- `node <resolved-skill-scripts>/github/create-draft-pr.mjs [gh pr create args...]`
+
+Contract:
+- injects exactly one `--draft` when the caller did not already supply it
+- rejects `--ready` before invoking `gh`; use `gh pr ready` later after draft-gate approval
+- forwards every other argument to `gh pr create` unchanged and in order
+- preserves the underlying `gh pr create` stdout, stderr, and exit code without wrapping success output
+- stays intentionally narrow: this is the prevention layer for draft-first creation, while `scripts/github/reconcile-draft-gate.mjs` remains the separate recovery path for already-open non-draft PRs
+
+Failure behavior:
+- wrapper-owned validation failures emit `{ "ok": false, "error": "...", "usage": "..." }` on stderr and exit non-zero
+- when `gh pr create` itself exits non-zero, this wrapper preserves the original stdout/stderr and propagates the same exit code
+
 ### `scripts/github/request-copilot-review.mjs`
 
 Request Copilot review on a PR and verify the request deterministically.

--- a/scripts/github/create-draft-pr.mjs
+++ b/scripts/github/create-draft-pr.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+
+const USAGE = `Usage: create-draft-pr.mjs [gh pr create args...]
+
+Thin wrapper around \`gh pr create\` that enforces draft-first PR creation.
+
+Behavior:
+  - injects exactly one \`--draft\` when absent
+  - rejects \`--ready\` before invoking \`gh\`
+  - forwards every other argument to \`gh pr create\` unchanged
+  - preserves the underlying \`gh pr create\` stdout, stderr, and exit code
+
+Examples:
+  node scripts/github/create-draft-pr.mjs --repo owner/repo --assignee @me --base main --head feature --title "..." --body-file pr.md
+  node <resolved-skill-scripts>/github/create-draft-pr.mjs --repo owner/repo --assignee @me --base main --head feature --title "..." --body-file pr.md
+
+Notes:
+  - Use \`gh pr ready\` later to leave draft state; this wrapper never opens a ready PR.
+  - Wrapper-owned validation is limited to \`--ready\`; all other argument validation is left to \`gh pr create\`.
+
+Exit codes:
+  0  \`gh pr create\` succeeded
+  1  wrapper validation failed or \`gh\` could not be spawned
+  N  same non-zero exit code returned by \`gh pr create\``.trim();
+
+const parseError = buildParseError(USAGE);
+const READY_FLAG_PATTERN = /^--ready(?:$|=)/u;
+
+export function buildCreateDraftPrArgs(argv) {
+  const args = [...argv];
+
+  if (args.includes("--help") || args.includes("-h")) {
+    return {
+      help: true,
+      ghArgs: null,
+    };
+  }
+
+  if (args.some((token) => READY_FLAG_PATTERN.test(token))) {
+    throw parseError("create-draft-pr rejects --ready; open the PR as draft first, then run `gh pr ready` after the draft gate is satisfied");
+  }
+
+  return {
+    help: false,
+    ghArgs: ["pr", "create", ...(args.includes("--draft") ? [] : ["--draft"]), ...args],
+  };
+}
+
+export function spawnCreateDraftPr(ghArgs, { ghCommand = "gh", env = process.env } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(ghCommand, ghArgs, {
+      env,
+      stdio: "inherit",
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve(typeof code === "number" ? code : 1);
+    });
+  });
+}
+
+export async function main(argv = process.argv.slice(2), runtime = {}) {
+  const { help, ghArgs } = buildCreateDraftPrArgs(argv);
+
+  if (help) {
+    process.stdout.write(`${USAGE}\n`);
+    return 0;
+  }
+
+  return spawnCreateDraftPr(ghArgs, runtime);
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  try {
+    const exitCode = await main();
+    process.exit(exitCode);
+  } catch (error) {
+    process.stderr.write(`${formatCliError(error)}\n`);
+    process.exit(1);
+  }
+}

--- a/scripts/github/create-draft-pr.mjs
+++ b/scripts/github/create-draft-pr.mjs
@@ -76,9 +76,9 @@ export async function main(argv = process.argv.slice(2), runtime = {}) {
 if (isDirectCliRun(import.meta.url)) {
   try {
     const exitCode = await main();
-    process.exit(exitCode);
+    process.exitCode = exitCode;
   } catch (error) {
     process.stderr.write(`${formatCliError(error)}\n`);
-    process.exit(1);
+    process.exitCode = 1;
   }
 }

--- a/scripts/github/create-draft-pr.mjs
+++ b/scripts/github/create-draft-pr.mjs
@@ -27,6 +27,7 @@ Exit codes:
 
 const parseError = buildParseError(USAGE);
 const READY_FLAG_PATTERN = /^--ready(?:$|=)/u;
+const DRAFT_TRUE_FLAG_PATTERN = /^--draft(?:=(?:true|1))?$/iu;
 
 export function buildCreateDraftPrArgs(argv) {
   const args = [...argv];
@@ -42,9 +43,11 @@ export function buildCreateDraftPrArgs(argv) {
     throw parseError("create-draft-pr rejects --ready; open the PR as draft first, then run `gh pr ready` after the draft gate is satisfied");
   }
 
+  const hasExplicitDraft = args.some((token) => DRAFT_TRUE_FLAG_PATTERN.test(token));
+
   return {
     help: false,
-    ghArgs: ["pr", "create", ...args, ...(args.includes("--draft") ? [] : ["--draft"])],
+    ghArgs: ["pr", "create", ...args, ...(hasExplicitDraft ? [] : ["--draft"])],
   };
 }
 

--- a/scripts/github/create-draft-pr.mjs
+++ b/scripts/github/create-draft-pr.mjs
@@ -44,7 +44,7 @@ export function buildCreateDraftPrArgs(argv) {
 
   return {
     help: false,
-    ghArgs: ["pr", "create", ...(args.includes("--draft") ? [] : ["--draft"]), ...args],
+    ghArgs: ["pr", "create", ...args, ...(args.includes("--draft") ? [] : ["--draft"])],
   };
 }
 

--- a/scripts/github/create-draft-pr.mjs
+++ b/scripts/github/create-draft-pr.mjs
@@ -27,7 +27,8 @@ Exit codes:
 
 const parseError = buildParseError(USAGE);
 const READY_FLAG_PATTERN = /^--ready(?:$|=)/u;
-const DRAFT_TRUE_FLAG_PATTERN = /^--draft(?:=(?:true|1))?$/iu;
+const DRAFT_FLAG_PATTERN = /^--draft(?:=(.*))?$/iu;
+const DRAFT_TRUE_VALUE_PATTERN = /^(?:true|1)$/iu;
 
 export function buildCreateDraftPrArgs(argv) {
   const args = [...argv];
@@ -43,11 +44,13 @@ export function buildCreateDraftPrArgs(argv) {
     throw parseError("create-draft-pr rejects --ready; open the PR as draft first, then run `gh pr ready` after the draft gate is satisfied");
   }
 
-  const hasExplicitDraft = args.some((token) => DRAFT_TRUE_FLAG_PATTERN.test(token));
+  const draftTokens = args.filter((token) => DRAFT_FLAG_PATTERN.test(token));
+  const lastDraftToken = draftTokens.length > 0 ? draftTokens.at(-1) : null;
+  const lastDraftSuppliesDraft = lastDraftToken === "--draft" || (typeof lastDraftToken === "string" && DRAFT_TRUE_VALUE_PATTERN.test(lastDraftToken.slice("--draft=".length)));
 
   return {
     help: false,
-    ghArgs: ["pr", "create", ...args, ...(hasExplicitDraft ? [] : ["--draft"])],
+    ghArgs: ["pr", "create", ...args, ...(lastDraftSuppliesDraft ? [] : ["--draft"])],
   };
 }
 

--- a/skills/docs/copilot-loop-operations.md
+++ b/skills/docs/copilot-loop-operations.md
@@ -166,9 +166,9 @@ Follow the PR description contract (see [Agent Instructions](../../AGENTS.md) if
 
 New PRs in this workflow must be opened as **draft** PRs first when the repository enables `.pi/dev-loop/settings.yaml` `workflow.requireDraftFirst`. The built-in shipped default remains permissive; this repo opts in. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate review is a real workflow boundary, so a new PR must exist in draft before `gh pr ready` is even eligible.
 
-Only use `gh pr create` when authoritative issue↔PR resolution says there is no already-open linked PR. If a PR already exists, reuse/update that canonical PR instead of opening another one.
+Only use `node <resolved-skill-scripts>/github/create-draft-pr.mjs` when authoritative issue↔PR resolution says there is no already-open linked PR. If a PR already exists, reuse/update that canonical PR instead of opening another one. This wrapper preserves the underlying `gh pr create` output contract while enforcing draft-first mechanically.
 
-MUST use `gh pr create --draft --repo <owner/name> --assignee @me --base <base> --head <head> --title "..." --body-file <body-file>`.
+MUST use `node <resolved-skill-scripts>/github/create-draft-pr.mjs --repo <owner/name> --assignee @me --base <base> --head <head> --title "..." --body-file <body-file>`.
 
 ## Timeout and watch policy
 

--- a/skills/docs/workflow-handoff-template.md
+++ b/skills/docs/workflow-handoff-template.md
@@ -22,7 +22,7 @@ Every step is non-optional. Do not skip, reorder, or batch steps.
 
 - Branch off `origin/main`
 - Implement changes, write tests, run `npm run verify`
-- Create PR as **draft** via `gh pr create --draft --assignee @me`
+- Create PR as **draft** via `node scripts/github/create-draft-pr.mjs --assignee @me ...`
 
 ### 2. Draft gate review
 

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -77,7 +77,7 @@ When the local spec already lives in a tracker issue:
 - sync durable scope / acceptance / status changes back to the tracker issue rather than maintaining a duplicate local phase doc
 - keep `tmp/` as temporary local execution state only; it does not become a second durable spec surface
 - for tracker-backed sessions, the handoff path is always: push the working branch → open a PR → merge via GitHub
-- for tracker-backed sessions, PR creation must always include `--assignee @me` so the new PR is self-assigned. When `.pi/dev-loop/settings.yaml` `workflow.requireDraftFirst` opts in, use `gh pr create --draft --assignee @me`. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate review is a real workflow boundary.
+- for tracker-backed sessions, PR creation must always include `--assignee @me` so the new PR is self-assigned. When `.pi/dev-loop/settings.yaml` `workflow.requireDraftFirst` opts in, use `node scripts/github/create-draft-pr.mjs --assignee @me ...`. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate review is a real workflow boundary.
 - do not suggest a direct local-main merge for tracker-backed sessions; do not merge the working branch into local `main` at phase completion
 
 ## Primary execution rules
@@ -511,7 +511,7 @@ Stop after the current phase when:
 - Rerun validation after review-driven fixes.
 - A phase is not operationally closed until its branch state is captured in commit history and the reviewed branch has been finalized according to session type (merged into local `main` for phase-doc-backed sessions; merged via GitHub PR for tracker-backed sessions), unless authorization for that finalization is still pending.
 - For tracker-backed sessions, the handoff path is always: push the working branch → open a PR → merge via GitHub; never merge the working branch into local `main`.
-- PR creation must always include `--assignee @me` so the new PR is self-assigned. When `.pi/dev-loop/settings.yaml` `workflow.requireDraftFirst` opts in, use `gh pr create --draft --assignee @me`. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate review is a real workflow boundary, so a new PR must exist in draft before `gh pr ready` is eligible.
+- PR creation must always include `--assignee @me` so the new PR is self-assigned. When `.pi/dev-loop/settings.yaml` `workflow.requireDraftFirst` opts in, use `node scripts/github/create-draft-pr.mjs --assignee @me ...`. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate review is a real workflow boundary, so a new PR must exist in draft before `gh pr ready` is eligible.
 - When authorization is pending, record the phase as `awaiting-finalization` and describe the exact missing step.
 - For phase-doc-backed sessions, merge the fully reviewed, locally validated branch back into local `main` when authorized.
 

--- a/test/contracts/issue-intake-doc-contracts.test.mjs
+++ b/test/contracts/issue-intake-doc-contracts.test.mjs
@@ -83,7 +83,8 @@ test("issue-intake surface requires unattended resume-from-state behavior when a
   assert.match(content, /automatically resume\/restart follow-up when continuation is feasible/i);
   assert.match(content, /New PRs in this workflow must be opened as \*\*draft\*\* PRs first/i);
   assert.match(content, /Do not create a fresh PR directly in ready-for-review state/i);
-  assert.match(content, /gh pr create --draft --repo <owner\/name> --assignee @me --base <base> --head <head> --title/i);
+  assert.match(content, /node <resolved-skill-scripts>\/github\/create-draft-pr\.mjs --repo <owner\/name> --assignee @me --base <base> --head <head> --title/i);
+  assert.doesNotMatch(content, /gh pr create --draft --repo <owner\/name> --assignee @me --base <base> --head <head> --title/i);
   assert.match(content, /pre-existing PR.*not.*stop-by-default condition/is);
   assert.match(content, /continue unattended until the final approval gate/i);
   assert.match(content, /stop for a human approval decision by default/i);

--- a/test/contracts/public-facade-doc-contracts.test.mjs
+++ b/test/contracts/public-facade-doc-contracts.test.mjs
@@ -369,5 +369,6 @@ test("skill docs enforce self-assignment and draft-first rules for create comman
   assert.doesNotMatch(agents, /gh issue create` or `gh pr create`/i);
   assert.match(workflowHandoffTemplate, /node scripts\/github\/create-draft-pr\.mjs --assignee @me/i);
   assert.doesNotMatch(workflowHandoffTemplate, /gh pr create --draft --assignee @me/i);
-  assert.match(trackerStoryPrContract, /gh pr create --draft --assignee @me/);
+  assert.match(trackerStoryPrContract, /Draft PR creation succeeds \| `draft_pr_open` \| Apply `set_in_progress` to tracker/i);
+  assert.doesNotMatch(trackerStoryPrContract, /gh pr create --draft --assignee @me/i);
 });

--- a/test/contracts/public-facade-doc-contracts.test.mjs
+++ b/test/contracts/public-facade-doc-contracts.test.mjs
@@ -345,24 +345,29 @@ test("skill docs enforce self-assignment and draft-first rules for create comman
     readRepo("docs/tracker-story-pr-contract.md"),
   ]);
 
-  // copilot-pr-followup enforces --draft in PR creation command
-  assert.match(copilotFollowupSkill, /MUST use `gh pr create --draft/i);
+  // copilot-pr-followup routes PR creation through the draft wrapper
+  assert.match(copilotFollowupSkill, /MUST use `node <resolved-skill-scripts>\/github\/create-draft-pr\.mjs/i);
   assert.match(copilotFollowupSkill, /gh issue create --repo <resolved-repo> --assignee @me/i);
-  assert.match(copilotFollowupSkill, /gh pr create --draft --repo <owner\/name> --assignee @me --base <base> --head <head> --title/i);
+  assert.match(copilotFollowupSkill, /node <resolved-skill-scripts>\/github\/create-draft-pr\.mjs --repo <owner\/name> --assignee @me --base <base> --head <head> --title/i);
+  assert.doesNotMatch(copilotFollowupSkill, /gh pr create --draft --repo <owner\/name> --assignee @me --base <base> --head <head> --title/i);
   assert.match(copilotFollowupSkill, /New PRs in this workflow must be opened as \*\*draft\*\* PRs first/i);
   assert.match(copilotFollowupSkill, /Do not create a fresh PR directly in ready-for-review state/i);
   assert.match(copilotFollowupSkill, /draft gate review is a real workflow boundary/i);
 
-  // local-implementation keeps self-assignment unconditional and draft-first config-driven
+  // local-implementation keeps self-assignment unconditional and draft-first config-driven via the wrapper
   assert.match(localImplementationSkill, /PR creation must always include `--assignee @me`/i);
-  assert.match(localImplementationSkill, /workflow\.requireDraftFirst[\s\S]{0,120}gh pr create --draft --assignee @me/i);
+  assert.match(localImplementationSkill, /workflow\.requireDraftFirst[\s\S]{0,160}node scripts\/github\/create-draft-pr\.mjs --assignee @me/i);
+  assert.doesNotMatch(localImplementationSkill, /workflow\.requireDraftFirst[\s\S]{0,160}gh pr create --draft --assignee @me/i);
   assert.match(localImplementationSkill, /Do not create a fresh PR directly in ready-for-review state/i);
   assert.match(localImplementationSkill, /draft gate review is a real workflow boundary/i);
 
   assert.match(finalApprovalSkill, /redirect/i);
   assert.match(finalApprovalSkill, /Final approval gate/i);
   assert.match(finalApprovalSkill, /Do not restate merge-ready preconditions/i);
-  assert.match(agents, /gh issue create` or `gh pr create`, always include `--assignee @me`/i);
-  assert.match(workflowHandoffTemplate, /gh pr create --draft --assignee @me/i);
+  assert.match(agents, /When creating GitHub issues via `gh issue create`, always include `--assignee @me`/i);
+  assert.match(agents, /node scripts\/github\/create-draft-pr\.mjs --assignee @me/i);
+  assert.doesNotMatch(agents, /gh issue create` or `gh pr create`/i);
+  assert.match(workflowHandoffTemplate, /node scripts\/github\/create-draft-pr\.mjs --assignee @me/i);
+  assert.doesNotMatch(workflowHandoffTemplate, /gh pr create --draft --assignee @me/i);
   assert.match(trackerStoryPrContract, /gh pr create --draft --assignee @me/);
 });

--- a/test/github/create-draft-pr.test.mjs
+++ b/test/github/create-draft-pr.test.mjs
@@ -31,7 +31,7 @@ test("buildCreateDraftPrArgs injects --draft when absent", () => {
     buildCreateDraftPrArgs(["--repo", "owner/repo", "--assignee", "@me"]),
     {
       help: false,
-      ghArgs: ["pr", "create", "--draft", "--repo", "owner/repo", "--assignee", "@me"],
+      ghArgs: ["pr", "create", "--repo", "owner/repo", "--assignee", "@me", "--draft"],
     },
   );
 });
@@ -50,6 +50,16 @@ test("buildCreateDraftPrArgs rejects --ready before gh is invoked", () => {
   assert.throws(
     () => buildCreateDraftPrArgs(["--repo", "owner/repo", "--ready"]),
     /rejects --ready/i,
+  );
+});
+
+test("buildCreateDraftPrArgs appends --draft after a false-valued draft token", () => {
+  assert.deepEqual(
+    buildCreateDraftPrArgs(["--repo", "owner/repo", "--draft=false"]),
+    {
+      help: false,
+      ghArgs: ["pr", "create", "--repo", "owner/repo", "--draft=false", "--draft"],
+    },
   );
 });
 
@@ -88,7 +98,7 @@ test("create-draft-pr forwards args in order and preserves gh stdout on success"
     assert.equal(result.stderr, "");
     assert.equal(result.stdout, "https://github.com/owner/repo/pull/17\n");
     assert.deepEqual(await readGhCalls(ghLogPath), [[
-      "pr", "create", "--draft",
+      "pr", "create",
       "--repo", "owner/repo",
       "--assignee", "@me",
       "--base", "main",
@@ -96,6 +106,7 @@ test("create-draft-pr forwards args in order and preserves gh stdout on success"
       "--title", "Add draft wrapper",
       "--body-file", "tmp/pr-body.md",
       "positional-token",
+      "--draft",
     ]]);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
@@ -123,6 +134,29 @@ test("create-draft-pr preserves an existing --draft without adding another copy"
     assert.equal(result.stdout, "https://github.com/owner/repo/pull/17\n");
     assert.deepEqual(await readGhCalls(ghLogPath), [[
       "pr", "create", "--draft", "--repo", "owner/repo", "--assignee", "@me",
+    ]]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("create-draft-pr appends --draft after --draft=false so draft-first still wins", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-create-draft-pr-false-draft-"));
+
+  try {
+    const { env, ghLogPath } = await writeGhStub(tempDir, [
+      {
+        stdout: "https://github.com/owner/repo/pull/17\n",
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--draft=false"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.equal(result.stdout, "https://github.com/owner/repo/pull/17\n");
+    assert.deepEqual(await readGhCalls(ghLogPath), [[
+      "pr", "create", "--repo", "owner/repo", "--draft=false", "--draft",
     ]]);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
@@ -166,7 +200,7 @@ test("create-draft-pr preserves gh stdout, stderr, and exit code on failure", as
     assert.equal(result.stdout, "partial gh stdout\n");
     assert.equal(result.stderr, "gh create failed\n");
     assert.deepEqual(await readGhCalls(ghLogPath), [[
-      "pr", "create", "--draft", "--repo", "owner/repo", "--assignee", "@me",
+      "pr", "create", "--repo", "owner/repo", "--assignee", "@me", "--draft",
     ]]);
   } finally {
     await rm(tempDir, { recursive: true, force: true });

--- a/test/github/create-draft-pr.test.mjs
+++ b/test/github/create-draft-pr.test.mjs
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
+
+import { buildCreateDraftPrArgs } from "../../scripts/github/create-draft-pr.mjs";
+
+const scriptPath = path.resolve("scripts/github/create-draft-pr.mjs");
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
+
+async function writeGhStub(tempDir, entries, options = {}) {
+  return writeGhStubHelper(tempDir, entries, {
+    repeatLastOnOverflow: true,
+    logCalls: true,
+    ...options,
+  });
+}
+
+async function readGhCalls(logPath) {
+  const lines = (await readFile(logPath, "utf8"))
+    .trim()
+    .split("\n")
+    .filter(Boolean);
+  return lines.map((line) => JSON.parse(line));
+}
+
+test("buildCreateDraftPrArgs injects --draft when absent", () => {
+  assert.deepEqual(
+    buildCreateDraftPrArgs(["--repo", "owner/repo", "--assignee", "@me"]),
+    {
+      help: false,
+      ghArgs: ["pr", "create", "--draft", "--repo", "owner/repo", "--assignee", "@me"],
+    },
+  );
+});
+
+test("buildCreateDraftPrArgs avoids adding a duplicate --draft", () => {
+  assert.deepEqual(
+    buildCreateDraftPrArgs(["--draft", "--repo", "owner/repo", "--assignee", "@me"]),
+    {
+      help: false,
+      ghArgs: ["pr", "create", "--draft", "--repo", "owner/repo", "--assignee", "@me"],
+    },
+  );
+});
+
+test("buildCreateDraftPrArgs rejects --ready before gh is invoked", () => {
+  assert.throws(
+    () => buildCreateDraftPrArgs(["--repo", "owner/repo", "--ready"]),
+    /rejects --ready/i,
+  );
+});
+
+test("create-draft-pr --help documents draft-only behavior and --ready rejection", async () => {
+  const result = await runNode(["--help"]);
+
+  assert.equal(result.code, 0);
+  assert.equal(result.stderr, "");
+  assert.match(result.stdout, /Thin wrapper around `gh pr create`/i);
+  assert.match(result.stdout, /injects exactly one `--draft` when absent/i);
+  assert.match(result.stdout, /rejects `--ready` before invoking `gh`/i);
+  assert.match(result.stdout, /preserves the underlying `gh pr create` stdout, stderr, and exit code/i);
+});
+
+test("create-draft-pr forwards args in order and preserves gh stdout on success", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-create-draft-pr-success-"));
+
+  try {
+    const { env, ghLogPath } = await writeGhStub(tempDir, [
+      {
+        stdout: "https://github.com/owner/repo/pull/17\n",
+      },
+    ]);
+
+    const result = await runNode([
+      "--repo", "owner/repo",
+      "--assignee", "@me",
+      "--base", "main",
+      "--head", "issue-349-create-draft-pr",
+      "--title", "Add draft wrapper",
+      "--body-file", "tmp/pr-body.md",
+      "positional-token",
+    ], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.equal(result.stdout, "https://github.com/owner/repo/pull/17\n");
+    assert.deepEqual(await readGhCalls(ghLogPath), [[
+      "pr", "create", "--draft",
+      "--repo", "owner/repo",
+      "--assignee", "@me",
+      "--base", "main",
+      "--head", "issue-349-create-draft-pr",
+      "--title", "Add draft wrapper",
+      "--body-file", "tmp/pr-body.md",
+      "positional-token",
+    ]]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("create-draft-pr preserves an existing --draft without adding another copy", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-create-draft-pr-existing-draft-"));
+
+  try {
+    const { env, ghLogPath } = await writeGhStub(tempDir, [
+      {
+        stdout: "https://github.com/owner/repo/pull/17\n",
+      },
+    ]);
+
+    const result = await runNode([
+      "--draft",
+      "--repo", "owner/repo",
+      "--assignee", "@me",
+    ], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.equal(result.stdout, "https://github.com/owner/repo/pull/17\n");
+    assert.deepEqual(await readGhCalls(ghLogPath), [[
+      "pr", "create", "--draft", "--repo", "owner/repo", "--assignee", "@me",
+    ]]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("create-draft-pr rejects --ready without invoking gh", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-create-draft-pr-ready-reject-"));
+
+  try {
+    const { env, counterPath, ghLogPath } = await writeGhStub(tempDir, []);
+    const result = await runNode(["--repo", "owner/repo", "--ready"], { env });
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const stderrPayload = JSON.parse(result.stderr);
+    assert.match(stderrPayload.error, /rejects --ready/i);
+    assert.match(stderrPayload.usage, /Usage: create-draft-pr\.mjs/i);
+    assert.equal((await readFile(counterPath, "utf8")).trim(), "0");
+    assert.deepEqual(await readGhCalls(ghLogPath), []);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("create-draft-pr preserves gh stdout, stderr, and exit code on failure", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-create-draft-pr-gh-failure-"));
+
+  try {
+    const { env, ghLogPath } = await writeGhStub(tempDir, [
+      {
+        stdout: "partial gh stdout\n",
+        stderr: "gh create failed\n",
+        exitCode: 3,
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--assignee", "@me"], { env });
+
+    assert.equal(result.code, 3);
+    assert.equal(result.stdout, "partial gh stdout\n");
+    assert.equal(result.stderr, "gh create failed\n");
+    assert.deepEqual(await readGhCalls(ghLogPath), [[
+      "pr", "create", "--draft", "--repo", "owner/repo", "--assignee", "@me",
+    ]]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/github/create-draft-pr.test.mjs
+++ b/test/github/create-draft-pr.test.mjs
@@ -63,6 +63,16 @@ test("buildCreateDraftPrArgs appends --draft after a false-valued draft token", 
   );
 });
 
+test("buildCreateDraftPrArgs treats --draft=true as already supplied", () => {
+  assert.deepEqual(
+    buildCreateDraftPrArgs(["--repo", "owner/repo", "--draft=true"]),
+    {
+      help: false,
+      ghArgs: ["pr", "create", "--repo", "owner/repo", "--draft=true"],
+    },
+  );
+});
+
 test("create-draft-pr --help documents draft-only behavior and --ready rejection", async () => {
   const result = await runNode(["--help"]);
 
@@ -157,6 +167,29 @@ test("create-draft-pr appends --draft after --draft=false so draft-first still w
     assert.equal(result.stdout, "https://github.com/owner/repo/pull/17\n");
     assert.deepEqual(await readGhCalls(ghLogPath), [[
       "pr", "create", "--repo", "owner/repo", "--draft=false", "--draft",
+    ]]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("create-draft-pr treats --draft=true as already supplied and avoids a duplicate", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-create-draft-pr-true-draft-"));
+
+  try {
+    const { env, ghLogPath } = await writeGhStub(tempDir, [
+      {
+        stdout: "https://github.com/owner/repo/pull/17\n",
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--draft=true"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.equal(result.stdout, "https://github.com/owner/repo/pull/17\n");
+    assert.deepEqual(await readGhCalls(ghLogPath), [[
+      "pr", "create", "--repo", "owner/repo", "--draft=true",
     ]]);
   } finally {
     await rm(tempDir, { recursive: true, force: true });

--- a/test/github/create-draft-pr.test.mjs
+++ b/test/github/create-draft-pr.test.mjs
@@ -63,6 +63,16 @@ test("buildCreateDraftPrArgs appends --draft after a false-valued draft token", 
   );
 });
 
+test("buildCreateDraftPrArgs re-appends --draft when a later token disables it", () => {
+  assert.deepEqual(
+    buildCreateDraftPrArgs(["--draft", "--repo", "owner/repo", "--draft=false"]),
+    {
+      help: false,
+      ghArgs: ["pr", "create", "--draft", "--repo", "owner/repo", "--draft=false", "--draft"],
+    },
+  );
+});
+
 test("buildCreateDraftPrArgs treats --draft=true as already supplied", () => {
   assert.deepEqual(
     buildCreateDraftPrArgs(["--repo", "owner/repo", "--draft=true"]),
@@ -167,6 +177,29 @@ test("create-draft-pr appends --draft after --draft=false so draft-first still w
     assert.equal(result.stdout, "https://github.com/owner/repo/pull/17\n");
     assert.deepEqual(await readGhCalls(ghLogPath), [[
       "pr", "create", "--repo", "owner/repo", "--draft=false", "--draft",
+    ]]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("create-draft-pr re-appends --draft when a later token disables it", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-create-draft-pr-reappend-"));
+
+  try {
+    const { env, ghLogPath } = await writeGhStub(tempDir, [
+      {
+        stdout: "https://github.com/owner/repo/pull/17\n",
+      },
+    ]);
+
+    const result = await runNode(["--draft", "--repo", "owner/repo", "--draft=false"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.equal(result.stdout, "https://github.com/owner/repo/pull/17\n");
+    assert.deepEqual(await readGhCalls(ghLogPath), [[
+      "pr", "create", "--draft", "--repo", "owner/repo", "--draft=false", "--draft",
     ]]);
   } finally {
     await rm(tempDir, { recursive: true, force: true });

--- a/test/workflow-handoff-template-contract.test.mjs
+++ b/test/workflow-handoff-template-contract.test.mjs
@@ -78,7 +78,8 @@ test("workflow-handoff-template requires self-assigned draft PR creation in the 
 
   const sequenceSection = content.slice(seqStart, nextSection);
 
-  assert.match(sequenceSection, /gh pr create --draft --assignee @me/i);
+  assert.match(sequenceSection, /node scripts\/github\/create-draft-pr\.mjs --assignee @me/i);
+  assert.doesNotMatch(sequenceSection, /gh pr create --draft --assignee @me/i);
 });
 
 test("workflow-handoff-template has Copilot review loop between draft_gate and pre_approval_gate", async () => {


### PR DESCRIPTION
## Summary
- add `scripts/github/create-draft-pr.mjs` as a thin wrapper around `gh pr create`
- route authoritative draft-first instruction surfaces through the wrapper
- add script and doc-contract coverage for draft injection, `--ready` rejection, passthrough, and raw `gh` output propagation

## Scope / context
- implements issue #349 as the prevention layer for draft-first PR creation
- keeps `scripts/github/reconcile-draft-gate.mjs` as the separate recovery layer for already-open non-draft PRs
- updates only the active instruction surfaces called out in the issue

## Acceptance criteria
- [x] `scripts/github/create-draft-pr.mjs` injects exactly one `--draft` when absent
- [x] `--ready` is rejected before `gh` is invoked
- [x] other `gh pr create` args are forwarded unchanged and in order
- [x] underlying `gh pr create` stdout/stderr/exit code are preserved
- [x] active instruction surfaces now reference the wrapper
- [x] `scripts/README.md` documents the wrapper contract
- [x] unit + contract tests cover wrapper/runtime/doc regressions
- [x] `npm test` passes

## Definition of done
- [x] thin prevention wrapper added without duplicating recovery logic
- [x] wrapper help/usage makes draft-only behavior explicit
- [x] active instruction surfaces have one canonical executable create-PR command
- [x] repo validation evidence includes targeted tests plus `npm run verify`
- [x] PR notes call out prevention vs recovery split

## Non-goals
- no git hook or GitHub Actions enforcement
- no expansion into assignee/label/template policy beyond draft-first enforcement
- no compatibility alias such as `create-pr.mjs`
- no rewrite of historical non-authoritative docs beyond the scoped active surfaces

Closes #349
