### PR TITLE
Add CI-only --force override to gate review upsert

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -525,7 +525,7 @@ Failure behavior:
 - when that refusal is specifically `lifecycleState=blocked_needs_user_decision` plus current-head `ciStatus="failure"`, the unforced error now points operators to `--force --force-reason` as the explicit CI-only escape hatch
 - `--force` does **not** bypass stale-head protection, non-draft `draft_gate` refusal, unresolved-feedback / unsettled-review `pre_approval_gate` refusal, merge-conflict handling, or closed/merged PR protection
 
-Use `--force` only after the user explicitly authorizes ignoring the current-head CI failure/cancellation for this one gate-comment upsert. Prefer the normal paths first: green current-head CI, `--local-validation-head-sha` for the bounded `crediblyGreen` case, or the draft-gate policy knob from issue #351 when the desired behavior is a durable draft-gate policy rather than a one-off override.
+Use `--force` only after the user explicitly authorizes ignoring the current-head CI failure for this one gate-comment upsert. Prefer the normal paths first: green current-head CI, `--local-validation-head-sha` for the bounded `crediblyGreen` case, or the draft-gate policy knob from issue #351 when the desired behavior is a durable draft-gate policy rather than a one-off override.
 
 ### `scripts/loop/detect-pr-gate-coordination-state.mjs`
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -510,13 +510,22 @@ Required:
 - `--findings-summary <text>`
 - `--next-action <text>`
 
+Optional:
+- `--local-validation-head-sha <sha>` — reuse the bounded `crediblyGreen` exception when GitHub created zero current-head suites/statuses and local verification already passed for that exact head
+- `--force --force-reason <text>` — narrow operator-authorized CI override for the helper-local gate-entry refusal only; `--force-reason` is required with `--force`, `--force-reason` without `--force` is rejected, and the reason text is whitespace-normalized for machine-readable output
+
 Success output shape:
-- `{ "ok": true, "action": "created"|"updated"|"noop", "repo": "owner/repo", "pr": 17, "gate": "draft_gate", "headSha": "abc1234", "currentHeadSha": "abc1234", "commentId": 101, "commentUrl": "https://github.com/owner/repo/pull/17#issuecomment-101" }`
+- standard path: `{ "ok": true, "action": "created"|"updated"|"noop", "repo": "owner/repo", "pr": 17, "gate": "draft_gate", "headSha": "abc1234", "currentHeadSha": "abc1234", "commentId": 101, "commentUrl": "https://github.com/owner/repo/pull/17#issuecomment-101" }`
+- forced CI-override path: the same shape plus `{ "forced": true, "forceReason": "CI cancelled due to infrastructure", "forceBypass": "ci_blocked_needs_user_decision" }`
 
 Failure behavior:
 - malformed arguments emit `{ "ok": false, "error": "...", "usage": "..." }` on stderr and exit non-zero
 - contradictory head-SHA requests or unexpected `gh` failures emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero
-- `pre_approval_gate` upserts fail closed when `detect-pr-gate-coordination-state.mjs` reports that `run_pre_approval_gate` is still illegal for the current head
+- gate upserts still fail closed when `detect-pr-gate-coordination-state.mjs` reports that the requested gate action is illegal for the current head
+- when that refusal is specifically `lifecycleState=blocked_needs_user_decision` plus current-head `ciStatus="failure"`, the unforced error now points operators to `--force --force-reason` as the explicit CI-only escape hatch
+- `--force` does **not** bypass stale-head protection, non-draft `draft_gate` refusal, unresolved-feedback / unsettled-review `pre_approval_gate` refusal, merge-conflict handling, or closed/merged PR protection
+
+Use `--force` only after the user explicitly authorizes ignoring the current-head CI failure/cancellation for this one gate-comment upsert. Prefer the normal paths first: green current-head CI, `--local-validation-head-sha` for the bounded `crediblyGreen` case, or the draft-gate policy knob from issue #351 when the desired behavior is a durable draft-gate policy rather than a one-off override.
 
 ### `scripts/loop/detect-pr-gate-coordination-state.mjs`
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -516,7 +516,7 @@ Optional:
 
 Success output shape:
 - standard path: `{ "ok": true, "action": "created"|"updated"|"noop", "repo": "owner/repo", "pr": 17, "gate": "draft_gate", "headSha": "abc1234", "currentHeadSha": "abc1234", "commentId": 101, "commentUrl": "https://github.com/owner/repo/pull/17#issuecomment-101" }`
-- forced CI-override path: the same shape plus `{ "forced": true, "forceReason": "CI cancelled due to infrastructure", "forceBypass": "ci_blocked_needs_user_decision" }`
+- forced CI-override path: the same shape plus `{ "forced": true, "forceReason": "CI failed due to transient infrastructure", "forceBypass": "ci_blocked_needs_user_decision" }`
 
 Failure behavior:
 - malformed arguments emit `{ "ok": false, "error": "...", "usage": "..." }` on stderr and exit non-zero

--- a/scripts/github/upsert-gate-review-comment.mjs
+++ b/scripts/github/upsert-gate-review-comment.mjs
@@ -112,6 +112,34 @@ function normalizeForceReason(value) {
   return normalized;
 }
 
+function normalizeOptionalForceReason(value) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const normalized = collapseWhitespace(value);
+  return normalized.length > 0 ? normalized : null;
+}
+
+function resolveRuntimeForceOptions(options) {
+  const force = options.force === true;
+  const forceReason = normalizeOptionalForceReason(options.forceReason);
+
+  if (forceReason === null) {
+    throw new Error("forceReason must be a non-empty string when calling upsertGateReviewComment()");
+  }
+
+  if (force && forceReason === undefined) {
+    throw new Error("force requires forceReason when calling upsertGateReviewComment()");
+  }
+
+  if (!force && options.forceReason !== undefined) {
+    throw new Error("forceReason requires force when calling upsertGateReviewComment()");
+  }
+
+  return { force, forceReason };
+}
+
 function collapseWhitespace(value) {
   return String(value).replace(/\s+/gu, " ").trim();
 }
@@ -525,6 +553,7 @@ async function updateComment({ repo, commentId, body }, { env, ghCommand }) {
 }
 
 export async function upsertGateReviewComment(options, { env = process.env, ghCommand = "gh", repoRoot = process.cwd() } = {}) {
+  const { force, forceReason } = resolveRuntimeForceOptions(options);
   const coordinationContext = await loadPrGateCoordinationContext({ repo: options.repo, pr: options.pr, localValidationHeadSha: options.localValidationHeadSha }, { env, ghCommand });
   const evidence = coordinationContext.gateEvidence;
   const canonicalHeadSha = resolveRequestedHeadSha(options.headSha, evidence.currentHeadSha);
@@ -553,14 +582,14 @@ export async function upsertGateReviewComment(options, { env = process.env, ghCo
   const requestedGateAction = resolveGateAction(options.gate);
   const gateActionForbidden = coordination.forbiddenActions.includes(requestedGateAction);
   const forcedBypass = gateActionForbidden
-    && options.force
+    && force
     && isCiBlockedGateOverrideEligible({ coordination, coordinationContext, gate: options.gate });
 
   if (gateActionForbidden && !forcedBypass) {
     throw new Error(buildGateEntryRefusalError({ options, coordination, coordinationContext }));
   }
 
-  const forcedResultMetadata = buildForcedResultMetadata({ forced: forcedBypass, forceReason: options.forceReason });
+  const forcedResultMetadata = buildForcedResultMetadata({ forced: forcedBypass, forceReason });
 
   const effectiveFindingsSummary = appendGateEvidenceNote(options.findingsSummary, coordination.gateEvidenceNote ?? null);
   const desiredBody = renderGateReviewCommentBody({ ...options, headSha: canonicalHeadSha, findingsSummary: effectiveFindingsSummary });

--- a/scripts/github/upsert-gate-review-comment.mjs
+++ b/scripts/github/upsert-gate-review-comment.mjs
@@ -7,6 +7,7 @@ import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import { detectGateReviewEvidence } from "./detect-gate-review-evidence.mjs";
 import { loadPrGateCoordinationContext } from "../loop/detect-pr-gate-coordination-state.mjs";
 import { evaluatePrGateCoordination, PR_GATE_ACTION } from "@pi-dev-loops/core/loop/pr-gate-coordination";
+import { STATE } from "@pi-dev-loops/core/loop/copilot-loop-state";
 
 const GATE_NAMES = new Set(["draft_gate", "pre_approval_gate"]);
 const GATE_VERDICTS = new Set(["clean", "findings_present", "blocked"]);
@@ -428,7 +429,7 @@ function resolveGateAction(gate) {
 }
 
 function isCiBlockedGateOverrideEligible({ coordination, coordinationContext, gate }) {
-  return coordination.lifecycleState === "blocked_needs_user_decision"
+  return coordination.lifecycleState === STATE.BLOCKED_NEEDS_USER_DECISION
     && coordinationContext.snapshot?.ciStatus === "failure"
     && coordination.forbiddenActions.includes(resolveGateAction(gate));
 }

--- a/scripts/github/upsert-gate-review-comment.mjs
+++ b/scripts/github/upsert-gate-review-comment.mjs
@@ -46,7 +46,7 @@ Optional:
                                              justified for machine-readable output.
 
 Use \`--force\` only after the user explicitly authorizes ignoring the current-head
-CI failure/cancellation for this one gate-comment upsert. Prefer the normal paths
+CI failure for this one gate-comment upsert. Prefer the normal paths
 first: green CI on the current head, \`--local-validation-head-sha\` for the bounded
 \`crediblyGreen\` case, or the draft-gate policy option when the desired behavior is
 a durable policy rather than a one-off override.
@@ -412,7 +412,7 @@ function buildGateEntryRefusalError({ options, coordination, coordinationContext
     return baseMessage;
   }
 
-  return `${baseMessage} Re-run with --force --force-reason "<why>" only when the user has explicitly authorized ignoring the current-head CI failure/cancellation for this one gate-comment upsert.`;
+  return `${baseMessage} Re-run with --force --force-reason "<why>" only when the user has explicitly authorized ignoring the current-head CI failure for this one gate-comment upsert.`;
 }
 
 function buildForcedResultMetadata({ forced, forceReason }) {

--- a/scripts/github/upsert-gate-review-comment.mjs
+++ b/scripts/github/upsert-gate-review-comment.mjs
@@ -12,8 +12,9 @@ const GATE_NAMES = new Set(["draft_gate", "pre_approval_gate"]);
 const GATE_VERDICTS = new Set(["clean", "findings_present", "blocked"]);
 const MAX_GATE_COMMENT_TEXT_LENGTH = 2000;
 const MAX_GATE_COMMENT_EXCERPT_LENGTH = 120;
+const FORCE_BYPASS = "ci_blocked_needs_user_decision";
 
-const USAGE = `Usage: upsert-gate-review-comment.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate> --head-sha <sha> --verdict <clean|findings_present|blocked> --findings-summary <text> --next-action <text> [--local-validation-head-sha <sha>]
+const USAGE = `Usage: upsert-gate-review-comment.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate> --head-sha <sha> --verdict <clean|findings_present|blocked> --findings-summary <text> --next-action <text> [--local-validation-head-sha <sha>] [--force --force-reason <text>]
 
 Create or update the visible gate-review PR comment for a gate/head pair.
 Same-head reruns are idempotent: if a visible marker already exists for the same
@@ -36,6 +37,19 @@ Optional:
                                              reuse the bounded crediblyGreen CI
                                              exception when GitHub created zero
                                              current-head suites/statuses.
+  --force                                    Allow a narrow CI-failure gate-comment
+                                             override when the helper would otherwise
+                                             refuse a gate upsert because the current
+                                             head is blocked_needs_user_decision.
+  --force-reason <text>                      Required with --force. Records why the
+                                             operator-authorized CI-only override is
+                                             justified for machine-readable output.
+
+Use \`--force\` only after the user explicitly authorizes ignoring the current-head
+CI failure/cancellation for this one gate-comment upsert. Prefer the normal paths
+first: green CI on the current head, \`--local-validation-head-sha\` for the bounded
+\`crediblyGreen\` case, or the draft-gate policy option when the desired behavior is
+a durable policy rather than a one-off override.
 
 Output (stdout, JSON):
   {
@@ -88,6 +102,14 @@ function normalizeRequiredText(value, flag) {
     return summarizeGateReviewText(normalized);
   }
   return smartTruncate(collapseWhitespace(normalized), MAX_GATE_COMMENT_TEXT_LENGTH);
+}
+
+function normalizeForceReason(value) {
+  const normalized = collapseWhitespace(value);
+  if (normalized.length === 0) {
+    throw parseError("--force-reason must be a non-empty string");
+  }
+  return normalized;
 }
 
 function collapseWhitespace(value) {
@@ -223,6 +245,8 @@ export function parseUpsertGateReviewCommentCliArgs(argv) {
     findingsSummary: undefined,
     nextAction: undefined,
     localValidationHeadSha: undefined,
+    force: false,
+    forceReason: undefined,
   };
 
   while (args.length > 0) {
@@ -289,6 +313,16 @@ export function parseUpsertGateReviewCommentCliArgs(argv) {
       continue;
     }
 
+    if (token === "--force") {
+      options.force = true;
+      continue;
+    }
+
+    if (token === "--force-reason") {
+      options.forceReason = normalizeForceReason(requireOptionValue(args, "--force-reason", parseError));
+      continue;
+    }
+
     throw parseError(`Unknown argument: ${token}`);
   }
 
@@ -296,6 +330,14 @@ export function parseUpsertGateReviewCommentCliArgs(argv) {
     .filter((key) => options[key] === undefined);
   if (missing.length > 0) {
     throw parseError("upsert-gate-review-comment requires --repo, --pr, --gate, --head-sha, --verdict, --findings-summary, and --next-action");
+  }
+
+  if (options.force && options.forceReason === undefined) {
+    throw parseError("--force requires --force-reason <text>");
+  }
+
+  if (!options.force && options.forceReason !== undefined) {
+    throw parseError("--force-reason requires --force");
   }
 
   try {
@@ -349,6 +391,40 @@ function resolveRequestedHeadSha(requestedHeadSha, currentHeadSha) {
   }
 
   throw new Error(`Requested head SHA ${requestedHeadSha} does not match the current PR head SHA ${currentHeadSha}; refuse to mutate stale gate evidence.`);
+}
+
+function resolveGateAction(gate) {
+  return gate === "draft_gate"
+    ? PR_GATE_ACTION.RUN_DRAFT_GATE
+    : PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE;
+}
+
+function isCiBlockedGateOverrideEligible({ coordination, coordinationContext, gate }) {
+  return coordination.lifecycleState === "blocked_needs_user_decision"
+    && coordinationContext.snapshot?.ciStatus === "failure"
+    && coordination.forbiddenActions.includes(resolveGateAction(gate));
+}
+
+function buildGateEntryRefusalError({ options, coordination, coordinationContext }) {
+  const baseMessage = `Cannot enter ${options.gate} on ${options.repo}#${options.pr}: ${coordination.reason}`;
+
+  if (!isCiBlockedGateOverrideEligible({ coordination, coordinationContext, gate: options.gate })) {
+    return baseMessage;
+  }
+
+  return `${baseMessage} Re-run with --force --force-reason "<why>" only when the user has explicitly authorized ignoring the current-head CI failure/cancellation for this one gate-comment upsert.`;
+}
+
+function buildForcedResultMetadata({ forced, forceReason }) {
+  if (!forced) {
+    return {};
+  }
+
+  return {
+    forced: true,
+    forceReason,
+    forceBypass: FORCE_BYPASS,
+  };
 }
 
 function selectGateEvidence(evidence, gate) {
@@ -474,12 +550,17 @@ export async function upsertGateReviewComment(options, { env = process.env, ghCo
     preApprovalGate: coordinationContext.gateEvidence.preApprovalGate,
     preApprovalGateMarker: coordinationContext.gateEvidence.preApprovalGateMarker,
   });
-  if (options.gate === "draft_gate" && coordination.forbiddenActions.includes(PR_GATE_ACTION.RUN_DRAFT_GATE)) {
-    throw new Error(`Cannot enter ${options.gate} on ${options.repo}#${options.pr}: ${coordination.reason}`);
+  const requestedGateAction = resolveGateAction(options.gate);
+  const gateActionForbidden = coordination.forbiddenActions.includes(requestedGateAction);
+  const forcedBypass = gateActionForbidden
+    && options.force
+    && isCiBlockedGateOverrideEligible({ coordination, coordinationContext, gate: options.gate });
+
+  if (gateActionForbidden && !forcedBypass) {
+    throw new Error(buildGateEntryRefusalError({ options, coordination, coordinationContext }));
   }
-  if (options.gate === "pre_approval_gate" && coordination.forbiddenActions.includes(PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE)) {
-    throw new Error(`Cannot enter ${options.gate} on ${options.repo}#${options.pr}: ${coordination.reason}`);
-  }
+
+  const forcedResultMetadata = buildForcedResultMetadata({ forced: forcedBypass, forceReason: options.forceReason });
 
   const effectiveFindingsSummary = appendGateEvidenceNote(options.findingsSummary, coordination.gateEvidenceNote ?? null);
   const desiredBody = renderGateReviewCommentBody({ ...options, headSha: canonicalHeadSha, findingsSummary: effectiveFindingsSummary });
@@ -505,6 +586,7 @@ export async function upsertGateReviewComment(options, { env = process.env, ghCo
       currentHeadSha: evidence.currentHeadSha,
       commentId: existing.commentId,
       commentUrl: existing.commentUrl,
+      ...forcedResultMetadata,
       ...(warning ? { warning } : {}),
     };
   }
@@ -521,6 +603,7 @@ export async function upsertGateReviewComment(options, { env = process.env, ghCo
       currentHeadSha: evidence.currentHeadSha,
       commentId: updated.commentId,
       commentUrl: updated.commentUrl,
+      ...forcedResultMetadata,
       ...(warning ? { warning } : {}),
     };
   }
@@ -536,6 +619,7 @@ export async function upsertGateReviewComment(options, { env = process.env, ghCo
     currentHeadSha: evidence.currentHeadSha,
     commentId: created.commentId,
     commentUrl: created.commentUrl,
+    ...forcedResultMetadata,
     ...(warning ? { warning } : {}),
   };
 }

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -315,6 +315,8 @@ node <resolved-skill-scripts>/github/upsert-gate-review-comment.mjs \
 
 Do NOT use `gh pr comment`, `gh api`, or `gh pr review` for gate comments.
 
+`--force --force-reason` on `upsert-gate-review-comment.mjs` is a narrow operator-authorized CI override for the helper itself, not the default gate path. Use it only when the helper refuses gate entry solely because the current head is `blocked_needs_user_decision` with `ciStatus="failure"`, and only after the user explicitly authorizes ignoring that current-head CI failure/cancellation for this one gate-comment upsert. It does **not** bypass stale-head checks, unresolved-thread / unsettled-review refusal, non-draft `draft_gate` refusal, merge conflicts, or other legality checks.
+
 ### Draft gate contract (before marking PR ready for review)
 
 The canonical gate-review comment contract is [Gate Review Comment Contract](../../docs/gate-review-comment-contract.md). This section summarizes the procedural integration only.

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -315,7 +315,7 @@ node <resolved-skill-scripts>/github/upsert-gate-review-comment.mjs \
 
 Do NOT use `gh pr comment`, `gh api`, or `gh pr review` for gate comments.
 
-`--force --force-reason` on `upsert-gate-review-comment.mjs` is a narrow operator-authorized CI override for the helper itself, not the default gate path. Use it only when the helper refuses gate entry solely because the current head is `blocked_needs_user_decision` with `ciStatus="failure"`, and only after the user explicitly authorizes ignoring that current-head CI failure/cancellation for this one gate-comment upsert. It does **not** bypass stale-head checks, unresolved-thread / unsettled-review refusal, non-draft `draft_gate` refusal, merge conflicts, or other legality checks.
+`--force --force-reason` on `upsert-gate-review-comment.mjs` is a narrow operator-authorized CI override for the helper itself, not the default gate path. Use it only when the helper refuses gate entry solely because the current head is `blocked_needs_user_decision` with `ciStatus="failure"`, and only after the user explicitly authorizes ignoring that current-head CI failure for this one gate-comment upsert. It does **not** bypass stale-head checks, unresolved-thread / unsettled-review refusal, non-draft `draft_gate` refusal, merge conflicts, or other legality checks.
 
 ### Draft gate contract (before marking PR ready for review)
 

--- a/test/github/upsert-gate-review-comment.test.mjs
+++ b/test/github/upsert-gate-review-comment.test.mjs
@@ -9,6 +9,7 @@ import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson a
 import {
   parseUpsertGateReviewCommentCliArgs,
   summarizeGateReviewText,
+  upsertGateReviewComment,
 } from "../../scripts/github/upsert-gate-review-comment.mjs";
 
 const scriptPath = path.resolve("scripts/github/upsert-gate-review-comment.mjs");
@@ -166,6 +167,22 @@ test("parseUpsertGateReviewCommentCliArgs rejects --force-reason without --force
       "--force-reason", "CI cancelled due to infra",
     ]),
     /--force-reason requires --force/i,
+  );
+});
+
+test("upsertGateReviewComment rejects programmatic force without forceReason before any gh calls", async () => {
+  await assert.rejects(
+    () => upsertGateReviewComment({
+      repo: "owner/repo",
+      pr: 17,
+      gate: "draft_gate",
+      headSha: "abc1234",
+      verdict: "clean",
+      findingsSummary: "no issues found",
+      nextAction: "mark ready for review",
+      force: true,
+    }),
+    /force requires forceReason when calling upsertGateReviewComment\(\)/i,
   );
 });
 

--- a/test/github/upsert-gate-review-comment.test.mjs
+++ b/test/github/upsert-gate-review-comment.test.mjs
@@ -415,6 +415,60 @@ test("upsert-gate-review-comment keeps CI-blocked gate upserts fail-closed witho
   }
 });
 
+test("upsert-gate-review-comment forced update includes forced metadata", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-force-update-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      ...buildGateCoordinationEntries({
+        isDraft: true,
+        statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "FAILURE" }],
+        issueComments: [buildGateComment({
+          gate: "draft_gate",
+          verdict: "blocked",
+          findingsSummary: "older forced summary",
+          nextAction: "wait for explicit CI bypass decision",
+        })],
+      }),
+      {
+        assertArgs: ["api", "-X", "PATCH", "repos/owner/repo/issues/comments/101", "-f"],
+        stdout: '{"id":101,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-101"}\n',
+      },
+    ]);
+
+    const result = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "17",
+      "--gate", "draft_gate",
+      "--head-sha", "abc1234",
+      "--verdict", "blocked",
+      "--findings-summary", "CI failed on the current head",
+      "--next-action", "wait for explicit CI bypass decision",
+      "--force",
+      "--force-reason", "CI failed due to transient infrastructure",
+    ], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      action: "updated",
+      repo: "owner/repo",
+      pr: 17,
+      gate: "draft_gate",
+      headSha: "abc1234",
+      currentHeadSha: "abc1234",
+      commentId: 101,
+      commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
+      forced: true,
+      forceReason: "CI failed due to transient infrastructure",
+      forceBypass: "ci_blocked_needs_user_decision",
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("upsert-gate-review-comment forced noop includes forced metadata", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-force-noop-"));
 

--- a/test/github/upsert-gate-review-comment.test.mjs
+++ b/test/github/upsert-gate-review-comment.test.mjs
@@ -20,6 +20,74 @@ async function writeGhStub(tempDir, entries) {
   return env;
 }
 
+function buildGateCoordinationEntries({
+  repo = "owner/repo",
+  pr = 17,
+  headSha = "abc1234",
+  isDraft = true,
+  statusCheckRollup = [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "FAILURE" }],
+  reviews = [],
+  reviewThreadsPayload = { data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } },
+  issueComments = [],
+}) {
+  return [
+    {
+      assertArgs: ["pr", "view", String(pr), "--repo", repo, "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+      stdout: JSON.stringify({
+        number: pr,
+        state: "OPEN",
+        isDraft,
+        headRefOid: headSha,
+        reviews,
+        statusCheckRollup,
+      }) + "\n",
+    },
+    {
+      assertArgs: ["api", `repos/${repo}/pulls/${pr}/requested_reviewers`],
+      stdout: '{"users":[],"teams":[]}\n',
+    },
+    {
+      assertArgs: ["api", "graphql", `pr=${pr}`],
+      stdout: JSON.stringify(reviewThreadsPayload) + "\n",
+    },
+    {
+      assertArgs: ["pr", "view", String(pr), "--repo", repo, "--json", "headRefOid"],
+      stdout: JSON.stringify({ headRefOid: headSha }) + "\n",
+    },
+    {
+      assertArgs: ["api", "--paginate", "--slurp", `repos/${repo}/issues/${pr}/comments?per_page=100`],
+      stdout: JSON.stringify(issueComments) + "\n",
+    },
+  ];
+}
+
+function buildGateComment({
+  gate = "draft_gate",
+  headSha = "abc1234",
+  verdict = "clean",
+  findingsSummary = "no issues found",
+  nextAction = "mark ready for review",
+  commentId = 101,
+  pr = 17,
+  updatedAt = "2026-05-30T17:00:00Z",
+}) {
+  return {
+    id: commentId,
+    body: [
+      `### Gate review: \`${gate}\``,
+      "",
+      `**Reviewed head SHA:** \`${headSha}\``,
+      `**Verdict:** ${verdict}`,
+      "",
+      `**Findings summary:** ${findingsSummary}`,
+      "",
+      `**Next action:** ${nextAction}`,
+    ].join("\n"),
+    html_url: `https://github.com/owner/repo/pull/${pr}#issuecomment-${commentId}`,
+    updated_at: updatedAt,
+  };
+}
+
 test("parseUpsertGateReviewCommentCliArgs rejects malformed arguments deterministically", () => {
   assert.throws(
     () => parseUpsertGateReviewCommentCliArgs([]),
@@ -48,6 +116,73 @@ test("parseUpsertGateReviewCommentCliArgs rejects malformed arguments determinis
       "--next-action", "mark ready for review",
     ]),
     /7-64 character hexadecimal SHA/i,
+  );
+});
+
+test("parseUpsertGateReviewCommentCliArgs accepts --force with normalized --force-reason", () => {
+  const parsed = parseUpsertGateReviewCommentCliArgs([
+    "--repo", "owner/repo",
+    "--pr", "17",
+    "--gate", "draft_gate",
+    "--head-sha", "ABC1234",
+    "--verdict", "clean",
+    "--findings-summary", "no issues found",
+    "--next-action", "mark ready for review",
+    "--force",
+    "--force-reason", `  CI
+   cancelled   due   to infra  `,
+  ]);
+
+  assert.equal(parsed.force, true);
+  assert.equal(parsed.forceReason, "CI cancelled due to infra");
+});
+
+test("parseUpsertGateReviewCommentCliArgs rejects --force without --force-reason", () => {
+  assert.throws(
+    () => parseUpsertGateReviewCommentCliArgs([
+      "--repo", "owner/repo",
+      "--pr", "17",
+      "--gate", "draft_gate",
+      "--head-sha", "abc1234",
+      "--verdict", "clean",
+      "--findings-summary", "no issues found",
+      "--next-action", "mark ready for review",
+      "--force",
+    ]),
+    /--force requires --force-reason/i,
+  );
+});
+
+test("parseUpsertGateReviewCommentCliArgs rejects --force-reason without --force", () => {
+  assert.throws(
+    () => parseUpsertGateReviewCommentCliArgs([
+      "--repo", "owner/repo",
+      "--pr", "17",
+      "--gate", "draft_gate",
+      "--head-sha", "abc1234",
+      "--verdict", "clean",
+      "--findings-summary", "no issues found",
+      "--next-action", "mark ready for review",
+      "--force-reason", "CI cancelled due to infra",
+    ]),
+    /--force-reason requires --force/i,
+  );
+});
+
+test("parseUpsertGateReviewCommentCliArgs rejects blank --force-reason", () => {
+  assert.throws(
+    () => parseUpsertGateReviewCommentCliArgs([
+      "--repo", "owner/repo",
+      "--pr", "17",
+      "--gate", "draft_gate",
+      "--head-sha", "abc1234",
+      "--verdict", "clean",
+      "--findings-summary", "no issues found",
+      "--next-action", "mark ready for review",
+      "--force",
+      "--force-reason", "\n",
+    ]),
+    /--force-reason must be a non-empty string/i,
   );
 });
 
@@ -130,6 +265,281 @@ test("summarizeGateReviewText does not treat markdown headings as shell commands
     summarizeGateReviewText(narrative),
     "# Summary Validation recap passed through manual review. ## Notes This is prose, not a shell transcript.",
   );
+});
+
+test("upsert-gate-review-comment allows forced draft_gate create when current-head CI failure is the only blocker", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-force-draft-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      ...buildGateCoordinationEntries({
+        isDraft: true,
+        statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "FAILURE" }],
+      }),
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f"],
+        stdout: '{"id":101,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-101"}\n',
+      },
+    ]);
+
+    const result = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "17",
+      "--gate", "draft_gate",
+      "--head-sha", "abc1234",
+      "--verdict", "clean",
+      "--findings-summary", "no issues found",
+      "--next-action", "mark ready for review",
+      "--force",
+      "--force-reason", "CI cancelled due to infrastructure",
+    ], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      action: "created",
+      repo: "owner/repo",
+      pr: 17,
+      gate: "draft_gate",
+      headSha: "abc1234",
+      currentHeadSha: "abc1234",
+      commentId: 101,
+      commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
+      forced: true,
+      forceReason: "CI cancelled due to infrastructure",
+      forceBypass: "ci_blocked_needs_user_decision",
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("upsert-gate-review-comment allows forced pre_approval_gate create when current-head CI failure is the only blocker", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-force-preapproval-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      ...buildGateCoordinationEntries({
+        isDraft: false,
+        statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "FAILURE" }],
+      }),
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f"],
+        stdout: '{"id":102,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-102"}\n',
+      },
+    ]);
+
+    const result = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "17",
+      "--gate", "pre_approval_gate",
+      "--head-sha", "abc1234",
+      "--verdict", "clean",
+      "--findings-summary", "no issues found",
+      "--next-action", "await final human approval",
+      "--force",
+      "--force-reason", "CI cancelled due to infrastructure",
+    ], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      action: "created",
+      repo: "owner/repo",
+      pr: 17,
+      gate: "pre_approval_gate",
+      headSha: "abc1234",
+      currentHeadSha: "abc1234",
+      commentId: 102,
+      commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-102",
+      forced: true,
+      forceReason: "CI cancelled due to infrastructure",
+      forceBypass: "ci_blocked_needs_user_decision",
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("upsert-gate-review-comment keeps CI-blocked gate upserts fail-closed without --force and points to the escape hatch", async () => {
+  for (const scenario of [
+    { gate: "draft_gate", isDraft: true, nextAction: "mark ready for review" },
+    { gate: "pre_approval_gate", isDraft: false, nextAction: "await final human approval" },
+  ]) {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), `pi-dev-loops-upsert-gate-review-force-required-${scenario.gate}-`));
+
+    try {
+      const env = await writeGhStub(tempDir, buildGateCoordinationEntries({
+        isDraft: scenario.isDraft,
+        statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "FAILURE" }],
+      }));
+
+      const result = await runNode([
+        "--repo", "owner/repo",
+        "--pr", "17",
+        "--gate", scenario.gate,
+        "--head-sha", "abc1234",
+        "--verdict", "clean",
+        "--findings-summary", "no issues found",
+        "--next-action", scenario.nextAction,
+      ], { env });
+
+      assert.equal(result.code, 1);
+      assert.equal(result.stdout, "");
+      const payload = JSON.parse(result.stderr);
+      assert.equal(payload.ok, false);
+      assert.match(payload.error, /Cannot enter/);
+      assert.match(payload.error, /--force --force-reason/);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  }
+});
+
+test("upsert-gate-review-comment forced noop includes forced metadata", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-force-noop-"));
+
+  try {
+    const env = await writeGhStub(tempDir, buildGateCoordinationEntries({
+      isDraft: true,
+      statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "FAILURE" }],
+      issueComments: [buildGateComment({
+        gate: "draft_gate",
+        verdict: "blocked",
+        findingsSummary: "CI failed on the current head",
+        nextAction: "wait for explicit CI bypass decision",
+      })],
+    }));
+
+    const result = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "17",
+      "--gate", "draft_gate",
+      "--head-sha", "abc1234",
+      "--verdict", "blocked",
+      "--findings-summary", "CI failed on the current head",
+      "--next-action", "wait for explicit CI bypass decision",
+      "--force",
+      "--force-reason", "CI cancelled due to infrastructure",
+    ], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      action: "noop",
+      repo: "owner/repo",
+      pr: 17,
+      gate: "draft_gate",
+      headSha: "abc1234",
+      currentHeadSha: "abc1234",
+      commentId: 101,
+      commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
+      forced: true,
+      forceReason: "CI cancelled due to infrastructure",
+      forceBypass: "ci_blocked_needs_user_decision",
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("upsert-gate-review-comment does not use --force to bypass non-CI pre_approval_gate refusal", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-force-non-ci-preapproval-"));
+
+  try {
+    const env = await writeGhStub(tempDir, buildGateCoordinationEntries({
+      isDraft: false,
+      statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+    }));
+
+    const result = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "17",
+      "--gate", "pre_approval_gate",
+      "--head-sha", "abc1234",
+      "--verdict", "clean",
+      "--findings-summary", "no issues found",
+      "--next-action", "await final human approval",
+      "--force",
+      "--force-reason", "CI cancelled due to infrastructure",
+    ], { env });
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /Cannot enter pre_approval_gate/i);
+    assert.doesNotMatch(payload.error, /--force --force-reason/i);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("upsert-gate-review-comment does not use --force to bypass draft_gate refusal on a non-draft PR", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-force-non-draft-"));
+
+  try {
+    const env = await writeGhStub(tempDir, buildGateCoordinationEntries({
+      isDraft: false,
+      statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+    }));
+
+    const result = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "17",
+      "--gate", "draft_gate",
+      "--head-sha", "abc1234",
+      "--verdict", "clean",
+      "--findings-summary", "no issues found",
+      "--next-action", "mark ready for review",
+      "--force",
+      "--force-reason", "CI cancelled due to infrastructure",
+    ], { env });
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /Cannot enter draft_gate/i);
+    assert.doesNotMatch(payload.error, /--force --force-reason/i);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("upsert-gate-review-comment stale-head protection still fails closed with --force", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-force-stale-"));
+
+  try {
+    const env = await writeGhStub(tempDir, buildGateCoordinationEntries({
+      headSha: "def5678",
+      isDraft: true,
+      statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "FAILURE" }],
+    }));
+
+    const result = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "17",
+      "--gate", "draft_gate",
+      "--head-sha", "abc1234",
+      "--verdict", "clean",
+      "--findings-summary", "no issues found",
+      "--next-action", "mark ready for review",
+      "--force",
+      "--force-reason", "CI cancelled due to infrastructure",
+    ], { env });
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /does not match the current PR head SHA/i);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
 });
 
 test("upsert-gate-review-comment creates a new comment when no same-head marker exists", async () => {


### PR DESCRIPTION
Closes #353

## Summary
- add `--force` and `--force-reason` parsing to `scripts/github/upsert-gate-review-comment.mjs`
- allow a helper-local override only when gate entry is blocked by current-head CI failure (`blocked_needs_user_decision` + `ciStatus="failure"`)
- preserve other gate legality checks, stale-head protection, and visible gate-comment rendering
- document the new flags in `scripts/README.md` and `skills/copilot-pr-followup/SKILL.md`
- add targeted tests for parsing, forced/unforced CI-blocked paths, non-CI refusals, and stale-head behavior

## Scope / context
This keeps the override local to `upsert-gate-review-comment.mjs` so operators can still use the canonical same-head upsert helper when CI failure/cancellation is intentionally bypassed for one gate-comment upsert.

## Acceptance criteria
- `--force` requires `--force-reason`, and `--force-reason` without `--force` fails closed
- forced gate upserts succeed only for CI-failure-derived `blocked_needs_user_decision` refusals
- unforced CI-blocked gate upserts still fail closed and point operators to the explicit escape hatch
- non-CI refusals, stale-head mismatches, and other legality checks remain fail-closed
- forced success results include `forced`, `forceReason`, and `forceBypass`

## Definition of done
- implementation updated in `scripts/github/upsert-gate-review-comment.mjs`
- targeted tests added in `test/github/upsert-gate-review-comment.test.mjs`
- script and skill docs updated
- `npm run verify` passes

## Non-goals
- no changes to shared gate-coordination legality semantics
- no new repo-wide CI policy surface
- no change to the visible gate-comment field contract
