### PR TITLE
Add deep structural audit persona

### DIFF
--- a/.pi/dev-loop/defaults.yaml
+++ b/.pi/dev-loop/defaults.yaml
@@ -29,8 +29,8 @@ gates:
     requireCi: true
   preApproval:
     # Pre-approval gate: runs before declaring merge-ready.
-    # Additional SOLID angles available as opt-in (see personas section):
-    #   ocp, lsp, isp, dip, docs
+    # Additional opt-in angles available (see personas section):
+    #   ocp, lsp, isp, dip, docs, deep
     angles:
       - dry
       - kiss
@@ -110,6 +110,42 @@ personas:
       When the repo provides `scripts/docs/validate-links.mjs`, use it for the
       mechanical link pass; otherwise keep the review scoped to the touched doc
       surface and current change only.
+    defaultModel: null
+
+  deep:
+    persona: review
+    prompt: >-
+      Perform a structural code quality audit of this PR.
+
+      Bring the same rigor as a full-codebase deslop audit, scoped to this
+      change:
+      - Question whether every new file, export, layer, or abstraction is
+        genuinely necessary. Prefer deletion over addition.
+      - Flag files crossing 1000 lines without strong justification.
+      - Flag new conditionals bolted onto unrelated paths. Push logic into its
+        own boundary instead of scattering special cases.
+      - Flag thin wrappers, re-export-only files, and identity abstractions
+        that add indirection without buying clarity.
+      - Flag feature logic leaking into shared or general-purpose modules.
+      - Question cast-heavy, optionality-heavy, or any-typed contracts that
+        obscure the real invariant.
+
+      Be ambitious about simplification:
+      - Look for "code judo" moves: restructurings that preserve behavior while
+        deleting whole categories of complexity.
+      - Prefer the simpler model. If the change adds moving parts, ask whether
+        fewer would achieve the same result.
+
+      Do not rubber-stamp working-but-messier code.
+      Approval bar:
+      - no structural regression
+      - no missed simplification opportunity
+      - no unjustified file-size explosion
+      - no spaghetti branching growth
+      - no unnecessary abstraction or indirection
+
+      This persona complements the deslop-audit skill (full-repo): same rigor,
+      applied per-PR.
     defaultModel: null
 
   dry:

--- a/.pi/dev-loop/defaults.yaml
+++ b/.pi/dev-loop/defaults.yaml
@@ -144,7 +144,7 @@ personas:
       - no spaghetti branching growth
       - no unnecessary abstraction or indirection
 
-      This persona complements the deslop-audit skill (full-repo): same rigor,
+      This persona complements full-repo deslop audits: same rigor,
       applied per-PR.
     defaultModel: null
 

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -146,6 +146,7 @@ const BUILTIN_PERSONAS = Object.freeze({
   coverage:    { persona: "review", defaultModel: null },
   correctness: { persona: "review", defaultModel: null },
   docs:        { persona: "docs", defaultModel: null },
+  deep:        { persona: "review", defaultModel: null },
   dry:         { persona: "review", defaultModel: null },
   kiss:        { persona: "review", defaultModel: null },
   srp:         { persona: "review", defaultModel: null },

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1116,12 +1116,20 @@ describe("role resolution", () => {
     assert.equal(result.fallback, false);
   });
 
-  test("R12: all 13 known angles resolve without fallback", () => {
+  test("R11c: known opt-in deep angle resolves to review persona", () => {
+    const result = resolveReviewerRole({}, "deep");
+    assert.equal(result.persona, "review");
+    assert.equal(result.model, null);
+    assert.equal(result.fallback, false);
+  });
+
+  test("R12: all 14 known angles resolve without fallback", () => {
     const expectedPersonas = {
       scope: "review",
       coverage: "review",
       correctness: "review",
       docs: "docs",
+      deep: "review",
       dry: "review",
       kiss: "review",
       srp: "review",
@@ -1463,7 +1471,7 @@ describe("role resolution", () => {
 });
 
 describe("shipped defaults docs angle wiring", () => {
-  test("D1: shipped defaults keep docs opt-in and resolve the packaged docs persona prompt", async () => {
+  test("D1: shipped defaults keep docs and deep opt-in and resolve the packaged persona prompts", async () => {
     const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-D1-"));
     try {
       const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
@@ -1477,14 +1485,22 @@ describe("shipped defaults docs angle wiring", () => {
       const result = await loadDevLoopConfig({ repoRoot: tmpDir });
       const preApprovalAngles = resolveGateAngles(result.config, "preApproval");
       const docsRole = resolveReviewerRole(result.config, "docs");
+      const deepRole = resolveReviewerRole(result.config, "deep");
 
       assert.deepEqual(result.errors, []);
       assert.equal(result.config.personas.docs.persona, "docs");
       assert.match(result.config.personas.docs.prompt, /Review documentation correctness/i);
+      assert.equal(result.config.personas.deep.persona, "review");
+      assert.match(result.config.personas.deep.prompt, /Perform a structural code quality audit of this PR/i);
+      assert.match(result.config.personas.deep.prompt, /deslop audit/i);
       assert.ok(!preApprovalAngles.includes("docs"), "docs must stay opt-in for pre-approval");
+      assert.ok(!preApprovalAngles.includes("deep"), "deep must stay opt-in for pre-approval");
       assert.equal(docsRole.persona, "docs");
       assert.equal(docsRole.prompt, result.config.personas.docs.prompt);
       assert.equal(docsRole.fallback, false);
+      assert.equal(deepRole.persona, "review");
+      assert.equal(deepRole.prompt, result.config.personas.deep.prompt);
+      assert.equal(deepRole.fallback, false);
     } finally {
       await rm(tmpDir, { recursive: true, force: true });
     }

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1470,7 +1470,7 @@ describe("role resolution", () => {
 
 });
 
-describe("shipped defaults docs angle wiring", () => {
+describe("shipped defaults docs and deep angle wiring", () => {
   test("D1: shipped defaults keep docs and deep opt-in and resolve the packaged persona prompts", async () => {
     const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-D1-"));
     try {


### PR DESCRIPTION
## Summary
- add a new `deep` review persona to the shipped dev-loop defaults
- document `deep` as an opt-in pre-approval review angle alongside the other optional lenses
- wire the built-in reviewer fallback registry and config tests so the angle resolves cleanly

## Scope / Context
Closes #402.

This change adds a per-PR structural audit lens that brings deslop-style scrutiny to gate reviews without changing the default pre-approval gate angles.

## Acceptance Criteria
- [x] `deep` persona is defined in `.pi/dev-loop/defaults.yaml`
- [x] the `deep` prompt references deslop-audit posture and structural simplification goals
- [x] `deep` is listed as an opt-in pre-approval angle in the shipped defaults comments
- [x] reviewer-role resolution recognizes `deep` as a non-fallback review angle
- [x] tests cover the shipped defaults wiring and pass

## Definition of Done
- [x] implementation is committed on the issue branch
- [x] `npm run verify` passes
- [x] draft PR is opened and assigned to `@me`
- [ ] draft gate comment is posted for the current head
- [ ] PR is marked ready and Copilot review is requested
- [ ] any review threads are addressed and resolved
- [ ] pre-approval gate comment is posted for the final head
- [ ] PR is merged

## Non-goals
- changing the default pre-approval angle list
- replacing the existing review personas
- adding the optional `audit-large-files.mjs` follow-up script in this slice
