### PR TITLE
Wire auditing into refinement chain

### DIFF
--- a/.pi/dev-loop/defaults.yaml
+++ b/.pi/dev-loop/defaults.yaml
@@ -73,6 +73,24 @@ personas:
       If no explicit definition of done exists, add a `Proposed DoD` subsection before the matrix.
       Treat any `Partial`, `Unmet`, or `Unverified` row as incomplete refinement.
       A refinement is complete only when no item has `Partial`, `Unmet`, or `Unverified` status.
+
+      When a bounded audit artifact is supplied, add an `Audit inputs` subsection.
+      Summarize the audited scope, list prioritized findings, include the highest-value follow-up candidates,
+      and add an explicit `Will not rewrite/broaden in this phase` statement.
+      For each prioritized finding, classify it as exactly one of: current-phase scope/AC,
+      DoD expectation, explicit non-goal/defer, or risk/watchpoint.
+      Do not fabricate audit evidence when none was provided.
+    defaultModel: null
+
+  audit:
+    persona: review
+    prompt: >-
+      Run a bounded refinement audit. Audit only the named files/areas.
+      Prefer delete / merge / trim / defer framing over additive rewrite plans.
+      Produce prioritized findings and highest-value follow-up candidates,
+      not a whole-repo essay.
+      Always include a bounded-scope statement and a `not rewriting in this phase`
+      statement. Findings are planning inputs, not automatic rewrite authorization.
     defaultModel: null
 
   scope:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,10 @@ These skills may be provided repo-locally or globally; this contract does not as
 
 Use this pattern whenever the work is refinement, comparison, review, or synthesis rather than implementation.
 
+- When the issue or phase has likely slop risk, structural drift risk, or adjacent cleanup risk, refinement may start with an **opt-in bounded audit pre-step**. When used, the sequence is explicitly `audit -> refine -> implement`.
+- Any audit pre-step must stay bounded to named files/areas. It must never silently widen into a full-repo scan.
+- Audit output must be prioritized and passed into refiner fan-out/fan-in as an input artifact, not pasted as an unstructured aside.
+- The audit handoff must say explicitly what the current phase will **not** rewrite or broaden.
 - Parallel fan-out uses the `refiner` agent with bounded aliases such as `{agent: "refiner", as: "refine-NNN", task: "Refine issue #NNN..."}`.
 - Consolidation/fan-in also uses the `refiner` agent, for example `{agent: "refiner", task: "Review {outputs.refine-NNN}... Report readiness."}`. Treat this as review-only consolidation; no code edits are expected from that step.
 - Keep the fan-out and consolidation chain inside the reusable `refiner` role. Do not route those refinement/review steps through `dev-loop` + `local_implementation`; that path is only for actual implementation/edit work.

--- a/agents/refiner.agent.md
+++ b/agents/refiner.agent.md
@@ -42,6 +42,8 @@ For the active phase, require and produce:
 - validation steps and tests to write first
 - durable decisions that should be preserved in the phase doc
 - when the phase includes a bounded audit or scan: prioritized findings, the highest-value follow-up candidates, and an explicit statement of what the current phase will not rewrite or broaden
+- When an audit artifact is provided, treat it as a first-class planning input: summarize the audited scope, list prioritized findings, include the highest-value follow-up candidates, and classify each meaningful finding as exactly one of current-phase scope/AC, DoD expectation, explicit non-goal / defer, or risk/watchpoint
+- Do not invent audit findings when no audit artifact was provided
 - when the phase includes watcher or predicate-driven behavior: explicit timeout semantics and negative-case expectations for non-target identities/events
 - when the phase relies on package-first shared helpers inside a source-loaded workspace: explicit integration expectations about whether local callers use published package imports or a thin source/workspace adapter during development
 
@@ -74,6 +76,7 @@ Return:
 - Complete acceptance criteria
 - Complete definition of done
 - Explicit non-goals, risks, and unresolved questions
+- When an audit artifact is provided: an `Audit inputs` subsection with prioritized findings, highest-value follow-up candidates, and an explicit `Will not rewrite/broaden in this phase` statement
 - An AC/DoD/Non-goal coverage matrix that uses exact source wording for every explicit item
 - If the source has no explicit definition of done, a `Proposed DoD` subsection
 - Tests to write first and validation steps

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -546,6 +546,35 @@ Failure behavior:
 
 Use `--force` only after the user explicitly authorizes ignoring the current-head CI failure for this one gate-comment upsert. Prefer the normal paths first: green current-head CI, `--local-validation-head-sha` for the bounded `crediblyGreen` case, or the draft-gate policy knob from issue #351 when the desired behavior is a durable draft-gate policy rather than a one-off override.
 
+### `scripts/loop/run-refinement-audit.mjs`
+
+Runs one deterministic bounded refinement audit over explicit repo paths and emits one machine-readable planning artifact.
+Use this before refiner fan-out when a local phase or GitHub issue would benefit from scoped slop-risk discovery.
+
+Required:
+- exactly one of:
+  - `--paths <comma-separated path list>`
+  - `--paths-file <file>`
+
+Optional:
+- `--root <path>` — override the repo root (defaults to `git rev-parse --show-toplevel`)
+- `--max-lines <n>` — oversized-file threshold (default `1000`)
+- `--duplicate-window-lines <n>` — duplicate-block window size (default `4`)
+- `--branch-threshold <n>` — branching-hotspot threshold (default `25` control-flow tokens)
+- `--thin-wrapper-max-lines <n>` — thin-wrapper threshold (default `40`)
+- `--output <path>` — writes the same success JSON emitted on stdout
+
+Success output shape:
+- `{ "ok": true, "repoRoot": "/repo", "paths": ["AGENTS.md"], "auditedFiles": [...], "findings": [...], "highestValueFollowUpCandidates": [...], "scopeBoundary": { "mode": "bounded_paths_only", "fullRepoScan": false } }`
+- `auditedFiles[]` reports per-file line count, branch-token count, duplicate-block match count, thin-wrapper classification, and deterministic skip notes for binary/unreadable files
+- `findings[]` uses bounded heuristic ids: `oversized_file`, `duplicate_block_candidate`, `branching_hotspot`, `thin_wrapper_candidate`
+- `highestValueFollowUpCandidates[]` is the concise planning handoff surface for refiner fan-out/fan-in; findings are planning inputs, not auto-authorized rewrites
+
+Failure behavior:
+- malformed arguments, blank paths, invalid thresholds, unreadable `--paths-file` input, or zero auditable files after tracked-file expansion emit `{ "ok": false, "error": "...", ... }` on stderr and exit non-zero
+- findings do **not** fail the process; findings return exit `0`
+- `--paths*` is required; the helper never silently scans the whole repo
+
 ### `scripts/loop/detect-pr-gate-coordination-state.mjs`
 
 Fetches the live PR facts needed to answer which gate/transition is legal next for a pull request. It combines the shared Copilot loop-state machine with visible `draft_gate` / `pre_approval_gate` evidence, GitHub `mergeStateStatus`, and local `git -c core.quotepath=false status --porcelain=v1 -z --untracked-files=no` conflict detection, then emits one explicit gate boundary, allowed/forbidden next actions, and a single recommended next step. Use this before entering `pre_approval_gate` and when deciding whether a ready PR should request Copilot review, keep waiting, stay in feedback resolution, or stop for conflict resolution.

--- a/scripts/loop/run-refinement-audit.mjs
+++ b/scripts/loop/run-refinement-audit.mjs
@@ -178,7 +178,16 @@ async function loadConfiguredPaths(options, cwd) {
   }
 
   const filePath = path.resolve(cwd, options.pathsFile);
-  const raw = await readFile(filePath, "utf8");
+  let raw;
+  try {
+    raw = await readFile(filePath, "utf8");
+  } catch (error) {
+    const detail = error instanceof Error && typeof error.message === "string"
+      ? error.message
+      : String(error);
+    throw parseError(`Unreadable --paths-file input: ${detail}`);
+  }
+
   const entries = raw.split(/\r?\n/u);
   if (entries.at(-1) === "") {
     entries.pop();

--- a/scripts/loop/run-refinement-audit.mjs
+++ b/scripts/loop/run-refinement-audit.mjs
@@ -1,0 +1,593 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { parsePositiveInteger, requireOptionValue, runCommand } from "../_cli-primitives.mjs";
+
+const DEFAULT_MAX_LINES = 1000;
+const DEFAULT_DUPLICATE_WINDOW_LINES = 4;
+const DEFAULT_BRANCH_THRESHOLD = 25;
+const DEFAULT_THIN_WRAPPER_MAX_LINES = 40;
+
+const USAGE = `Usage:
+  run-refinement-audit.mjs --paths <comma-separated paths> [--root <path>] [--max-lines <n>] [--duplicate-window-lines <n>] [--branch-threshold <n>] [--thin-wrapper-max-lines <n>] [--output <path>]
+  run-refinement-audit.mjs --paths-file <file> [--root <path>] [--max-lines <n>] [--duplicate-window-lines <n>] [--branch-threshold <n>] [--thin-wrapper-max-lines <n>] [--output <path>]
+
+Run a bounded refinement audit for explicit repo paths only. The helper never falls back to a whole-repo scan.
+
+Required:
+  exactly one of:
+    --paths <comma-separated paths>
+    --paths-file <file>
+
+Optional:
+  --root <path>                  Repo root (defaults to git rev-parse --show-toplevel)
+  --max-lines <n>               Oversized-file threshold (default: ${DEFAULT_MAX_LINES})
+  --duplicate-window-lines <n>  Duplicate-block window size (default: ${DEFAULT_DUPLICATE_WINDOW_LINES})
+  --branch-threshold <n>        Branching-hotspot threshold (default: ${DEFAULT_BRANCH_THRESHOLD})
+  --thin-wrapper-max-lines <n>  Thin-wrapper line threshold (default: ${DEFAULT_THIN_WRAPPER_MAX_LINES})
+  --output <path>               Write the same success JSON emitted on stdout
+
+Success output (stdout, JSON):
+  {
+    "ok": true,
+    "repoRoot": "/repo",
+    "paths": ["AGENTS.md", "agents/refiner.agent.md"],
+    "auditedFiles": [...],
+    "findings": [...],
+    "highestValueFollowUpCandidates": [...],
+    "scopeBoundary": { "mode": "bounded_paths_only", "fullRepoScan": false }
+  }
+
+Failure behavior (stderr, JSON, exit 1):
+  - malformed arguments, blank paths, invalid thresholds, and zero auditable files fail closed
+  - findings are not a process failure; findings still return exit 0`.trim();
+
+const parseError = buildParseError(USAGE);
+const BRANCH_TOKEN_PATTERN = /\b(?:if|else|switch|case|for|while|catch|finally|break|continue)\b|&&|\|\||\?(?![?.])/gu;
+const PRIORITY_ORDER = new Map([
+  ["high", 0],
+  ["medium", 1],
+  ["low", 2],
+]);
+
+export function parseRefinementAuditCliArgs(argv) {
+  const args = [...argv];
+  const options = {
+    help: false,
+    paths: undefined,
+    pathsFile: undefined,
+    root: undefined,
+    maxLines: DEFAULT_MAX_LINES,
+    duplicateWindowLines: DEFAULT_DUPLICATE_WINDOW_LINES,
+    branchThreshold: DEFAULT_BRANCH_THRESHOLD,
+    thinWrapperMaxLines: DEFAULT_THIN_WRAPPER_MAX_LINES,
+    output: undefined,
+  };
+
+  while (args.length > 0) {
+    const token = args.shift();
+
+    if (token === "--help" || token === "-h") {
+      options.help = true;
+      return options;
+    }
+
+    if (token === "--paths") {
+      options.paths = requireOptionValue(args, "--paths", parseError, { flagPattern: /^-/u });
+      continue;
+    }
+
+    if (token === "--paths-file") {
+      options.pathsFile = requireOptionValue(args, "--paths-file", parseError, { flagPattern: /^-/u });
+      continue;
+    }
+
+    if (token === "--root") {
+      options.root = requireOptionValue(args, "--root", parseError, { flagPattern: /^-/u });
+      continue;
+    }
+
+    if (token === "--max-lines") {
+      options.maxLines = parsePositiveInteger(requireOptionValue(args, "--max-lines", parseError), "--max-lines", parseError);
+      continue;
+    }
+
+    if (token === "--duplicate-window-lines") {
+      options.duplicateWindowLines = parsePositiveInteger(
+        requireOptionValue(args, "--duplicate-window-lines", parseError),
+        "--duplicate-window-lines",
+        parseError,
+      );
+      continue;
+    }
+
+    if (token === "--branch-threshold") {
+      options.branchThreshold = parsePositiveInteger(
+        requireOptionValue(args, "--branch-threshold", parseError),
+        "--branch-threshold",
+        parseError,
+      );
+      continue;
+    }
+
+    if (token === "--thin-wrapper-max-lines") {
+      options.thinWrapperMaxLines = parsePositiveInteger(
+        requireOptionValue(args, "--thin-wrapper-max-lines", parseError),
+        "--thin-wrapper-max-lines",
+        parseError,
+      );
+      continue;
+    }
+
+    if (token === "--output") {
+      options.output = requireOptionValue(args, "--output", parseError, { flagPattern: /^-/u });
+      continue;
+    }
+
+    throw parseError(`Unknown argument: ${token}`);
+  }
+
+  if (options.paths !== undefined && options.pathsFile !== undefined) {
+    throw parseError("Specify exactly one of --paths or --paths-file");
+  }
+
+  if (options.paths === undefined && options.pathsFile === undefined) {
+    throw parseError("run-refinement-audit requires exactly one of --paths or --paths-file");
+  }
+
+  return options;
+}
+
+function toPosixPath(value) {
+  return value.split(path.sep).join("/");
+}
+
+function countLines(text) {
+  if (text.length === 0) {
+    return 0;
+  }
+
+  const lines = text.split(/\r?\n/u);
+  if (lines.at(-1) === "") {
+    lines.pop();
+  }
+  return lines.length;
+}
+
+function countBranchTokens(text) {
+  const matches = text.match(BRANCH_TOKEN_PATTERN);
+  return Array.isArray(matches) ? matches.length : 0;
+}
+
+function splitConfiguredPaths(raw) {
+  return raw.split(",").map((entry) => entry.trim());
+}
+
+function assertNoBlankPaths(entries) {
+  if (entries.length === 0 || entries.some((entry) => entry.length === 0)) {
+    throw parseError("Audit paths must be non-empty; blank paths are not allowed");
+  }
+  return entries;
+}
+
+async function loadConfiguredPaths(options, cwd) {
+  if (options.paths !== undefined) {
+    return assertNoBlankPaths(splitConfiguredPaths(options.paths));
+  }
+
+  const filePath = path.resolve(cwd, options.pathsFile);
+  const raw = await readFile(filePath, "utf8");
+  const entries = raw.split(/\r?\n/u);
+  if (entries.at(-1) === "") {
+    entries.pop();
+  }
+  return assertNoBlankPaths(entries.map((entry) => entry.trim()));
+}
+
+async function resolveRepoRoot(options, { cwd, env, gitCommand }) {
+  if (typeof options.root === "string") {
+    return path.resolve(cwd, options.root);
+  }
+
+  const { stdout } = await runCommand(gitCommand, ["rev-parse", "--show-toplevel"], { cwd, env });
+  const repoRoot = stdout.trim();
+  if (repoRoot.length === 0) {
+    throw new Error("Unable to resolve repo root");
+  }
+  return repoRoot;
+}
+
+function normalizeRequestedPath(requestedPath, repoRoot) {
+  const resolvedPath = path.isAbsolute(requestedPath)
+    ? path.normalize(requestedPath)
+    : path.resolve(repoRoot, requestedPath);
+  const relativePath = path.relative(repoRoot, resolvedPath);
+
+  if (relativePath.length === 0) {
+    return ".";
+  }
+
+  if (relativePath.startsWith(`..${path.sep}`) || relativePath === ".." || path.isAbsolute(relativePath)) {
+    throw parseError(`Path is outside the repo root: ${requestedPath}`);
+  }
+
+  return toPosixPath(relativePath);
+}
+
+async function expandTrackedFiles(requestedPaths, { repoRoot, env, gitCommand }) {
+  const normalizedRequestedPaths = [];
+  const seenRequestedPaths = new Set();
+  const expandedTrackedFiles = [];
+  const seenTrackedFiles = new Set();
+
+  for (const requestedPath of requestedPaths) {
+    const normalizedPath = normalizeRequestedPath(requestedPath, repoRoot);
+    if (!seenRequestedPaths.has(normalizedPath)) {
+      seenRequestedPaths.add(normalizedPath);
+      normalizedRequestedPaths.push(normalizedPath);
+    }
+
+    const { stdout } = await runCommand(gitCommand, ["ls-files", "--", normalizedPath], { cwd: repoRoot, env });
+    const trackedFiles = stdout
+      .split(/\r?\n/u)
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+
+    for (const trackedFile of trackedFiles) {
+      const normalizedTrackedFile = toPosixPath(trackedFile);
+      if (!seenTrackedFiles.has(normalizedTrackedFile)) {
+        seenTrackedFiles.add(normalizedTrackedFile);
+        expandedTrackedFiles.push(normalizedTrackedFile);
+      }
+    }
+  }
+
+  return {
+    normalizedRequestedPaths,
+    expandedTrackedFiles,
+  };
+}
+
+function isBinaryBuffer(buffer) {
+  return buffer.includes(0);
+}
+
+function normalizeDuplicateLine(line) {
+  return line.replace(/\s+/gu, " ").trim();
+}
+
+function shouldConsiderDuplicateWindow(lines) {
+  const normalizedLines = lines.map(normalizeDuplicateLine);
+  const joined = normalizedLines.join("\n").trim();
+  const linesWithWordChars = normalizedLines.filter((line) => /[A-Za-z0-9]/u.test(line));
+
+  return joined.length >= 20 && linesWithWordChars.length >= 2;
+}
+
+function collectDuplicateBlockCounts(auditableRecords, duplicateWindowLines) {
+  const occurrences = new Map();
+
+  for (const record of auditableRecords) {
+    const lines = record.text.split(/\r?\n/u);
+    if (lines.length < duplicateWindowLines) {
+      continue;
+    }
+
+    for (let startIndex = 0; startIndex <= lines.length - duplicateWindowLines; startIndex += 1) {
+      const window = lines.slice(startIndex, startIndex + duplicateWindowLines);
+      if (!shouldConsiderDuplicateWindow(window)) {
+        continue;
+      }
+
+      const normalizedBlock = window.map(normalizeDuplicateLine).join("\n");
+      const values = occurrences.get(normalizedBlock) ?? [];
+      values.push({ path: record.path, startLine: startIndex + 1 });
+      occurrences.set(normalizedBlock, values);
+    }
+  }
+
+  const duplicateCountsByPath = new Map();
+
+  for (const values of occurrences.values()) {
+    if (values.length < 2) {
+      continue;
+    }
+
+    for (const value of values) {
+      duplicateCountsByPath.set(value.path, (duplicateCountsByPath.get(value.path) ?? 0) + 1);
+    }
+  }
+
+  return duplicateCountsByPath;
+}
+
+function isCommentLine(line) {
+  return line.startsWith("#") || line.startsWith("//") || line.startsWith("/*") || line.startsWith("*") || line.startsWith("*/");
+}
+
+function isWrapperLikeLine(line) {
+  return [
+    /^import\s.+\sfrom\s+["'][^"']+["'];?$/u,
+    /^export\s+\*\s+from\s+["'][^"']+["'];?$/u,
+    /^export\s+\*\s+as\s+[A-Za-z_$][\w$]*\s+from\s+["'][^"']+["'];?$/u,
+    /^export\s+(?:type\s+)?\{[^}]+\}\s+from\s+["'][^"']+["'];?$/u,
+    /^export\s+(?:type\s+)?\{[^}]+\};?$/u,
+    /^export\s+default\s+[A-Za-z_$][\w$]*;?$/u,
+  ].some((pattern) => pattern.test(line));
+}
+
+function detectThinWrapperCandidate(text, { lineCount, branchTokenCount, thinWrapperMaxLines }) {
+  if (lineCount === 0 || lineCount > thinWrapperMaxLines || branchTokenCount > 0) {
+    return false;
+  }
+
+  const meaningfulLines = text
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !isCommentLine(line));
+
+  if (meaningfulLines.length === 0) {
+    return false;
+  }
+
+  return meaningfulLines.every(isWrapperLikeLine);
+}
+
+function compareFindings(left, right) {
+  const priorityDelta = (PRIORITY_ORDER.get(left.priority) ?? 99) - (PRIORITY_ORDER.get(right.priority) ?? 99);
+  if (priorityDelta !== 0) {
+    return priorityDelta;
+  }
+
+  const pathDelta = left.path.localeCompare(right.path);
+  if (pathDelta !== 0) {
+    return pathDelta;
+  }
+
+  return left.id.localeCompare(right.id);
+}
+
+function summarizeFollowUpReason(finding) {
+  switch (finding.id) {
+    case "oversized_file":
+      return "Trim or split only if the current refinement scope explicitly chooses to; keep the audit as planning input, not rewrite authorization.";
+    case "duplicate_block_candidate":
+      return "Check whether duplication should become current-scope cleanup, a risk/watchpoint, or an explicit defer; do not broaden silently.";
+    case "branching_hotspot":
+      return "Review whether branching complexity should affect AC/DoD or become a watchpoint for the current bounded slice.";
+    case "thin_wrapper_candidate":
+      return "Consider delete/merge/trim framing before preserving glue-only wrapper layers; defer if out of scope.";
+    default:
+      return finding.summary;
+  }
+}
+
+function buildFindings(auditableRecords, duplicateCountsByPath, thresholds) {
+  const findings = [];
+
+  for (const record of auditableRecords) {
+    if (record.lineCount > thresholds.maxLines) {
+      findings.push({
+        id: "oversized_file",
+        priority: "high",
+        path: record.path,
+        summary: "File exceeds the bounded audit line threshold.",
+        evidence: { lineCount: record.lineCount, threshold: thresholds.maxLines },
+      });
+    }
+
+    const duplicateBlockMatches = duplicateCountsByPath.get(record.path) ?? 0;
+    if (duplicateBlockMatches > 0) {
+      findings.push({
+        id: "duplicate_block_candidate",
+        priority: "medium",
+        path: record.path,
+        summary: "Normalized repeated text blocks appear more than once within the bounded audit scope.",
+        evidence: {
+          duplicateBlockMatches,
+          duplicateWindowLines: thresholds.duplicateWindowLines,
+        },
+      });
+    }
+
+    if (record.branchTokenCount > thresholds.branchThreshold) {
+      findings.push({
+        id: "branching_hotspot",
+        priority: "medium",
+        path: record.path,
+        summary: "Control-flow token count exceeds the bounded branching threshold.",
+        evidence: { branchTokenCount: record.branchTokenCount, threshold: thresholds.branchThreshold },
+      });
+    }
+
+    if (record.thinWrapperCandidate) {
+      findings.push({
+        id: "thin_wrapper_candidate",
+        priority: "low",
+        path: record.path,
+        summary: "Small file looks dominated by re-exports or passthrough-only wrapper glue.",
+        evidence: { lineCount: record.lineCount, threshold: thresholds.thinWrapperMaxLines },
+      });
+    }
+  }
+
+  return findings.sort(compareFindings);
+}
+
+function buildHighestValueFollowUpCandidates(findings) {
+  const candidates = [];
+  const seenPaths = new Set();
+
+  for (const finding of findings) {
+    if (seenPaths.has(finding.path)) {
+      continue;
+    }
+
+    seenPaths.add(finding.path);
+    candidates.push({
+      path: finding.path,
+      reason: summarizeFollowUpReason(finding),
+    });
+  }
+
+  return candidates;
+}
+
+async function auditTrackedFiles(trackedFiles, options, { repoRoot }) {
+  const auditableRecords = [];
+  const skippedRecords = [];
+
+  for (const trackedFile of trackedFiles) {
+    const absolutePath = path.join(repoRoot, trackedFile);
+
+    try {
+      const buffer = await readFile(absolutePath);
+      if (isBinaryBuffer(buffer)) {
+        skippedRecords.push({
+          path: trackedFile,
+          lineCount: null,
+          branchTokenCount: null,
+          duplicateBlockMatches: 0,
+          thinWrapperCandidate: false,
+          skipped: true,
+          skipReason: "binary_file",
+        });
+        continue;
+      }
+
+      const text = buffer.toString("utf8");
+      const lineCount = countLines(text);
+      const branchTokenCount = countBranchTokens(text);
+      const thinWrapperCandidate = detectThinWrapperCandidate(text, {
+        lineCount,
+        branchTokenCount,
+        thinWrapperMaxLines: options.thinWrapperMaxLines,
+      });
+
+      auditableRecords.push({
+        path: trackedFile,
+        text,
+        lineCount,
+        branchTokenCount,
+        thinWrapperCandidate,
+      });
+    } catch (error) {
+      skippedRecords.push({
+        path: trackedFile,
+        lineCount: null,
+        branchTokenCount: null,
+        duplicateBlockMatches: 0,
+        thinWrapperCandidate: false,
+        skipped: true,
+        skipReason: "unreadable_file",
+        skipDetail: error instanceof Error ? error.code ?? error.message : String(error),
+      });
+    }
+  }
+
+  if (auditableRecords.length === 0) {
+    throw parseError("Zero auditable files remain after expansion; provide tracked text files in the bounded scope");
+  }
+
+  const duplicateCountsByPath = collectDuplicateBlockCounts(auditableRecords, options.duplicateWindowLines);
+  const findings = buildFindings(auditableRecords, duplicateCountsByPath, {
+    maxLines: options.maxLines,
+    duplicateWindowLines: options.duplicateWindowLines,
+    branchThreshold: options.branchThreshold,
+    thinWrapperMaxLines: options.thinWrapperMaxLines,
+  });
+  const followUpCandidates = buildHighestValueFollowUpCandidates(findings);
+
+  const auditedFileByPath = new Map();
+  for (const record of auditableRecords) {
+    auditedFileByPath.set(record.path, {
+      path: record.path,
+      lineCount: record.lineCount,
+      branchTokenCount: record.branchTokenCount,
+      duplicateBlockMatches: duplicateCountsByPath.get(record.path) ?? 0,
+      thinWrapperCandidate: record.thinWrapperCandidate,
+      skipped: false,
+    });
+  }
+  for (const record of skippedRecords) {
+    auditedFileByPath.set(record.path, record);
+  }
+
+  const auditedFiles = trackedFiles.map((trackedFile) => auditedFileByPath.get(trackedFile));
+
+  return {
+    auditedFiles,
+    findings,
+    highestValueFollowUpCandidates: followUpCandidates,
+  };
+}
+
+export async function runCli(
+  argv = process.argv.slice(2),
+  {
+    stdout = process.stdout,
+    stderr = process.stderr,
+    cwd = process.cwd(),
+    env = process.env,
+    gitCommand = "git",
+  } = {},
+) {
+  const options = parseRefinementAuditCliArgs(argv);
+
+  if (options.help) {
+    stdout.write(`${USAGE}\n`);
+    return { ok: true, help: true };
+  }
+
+  const repoRoot = await resolveRepoRoot(options, { cwd, env, gitCommand });
+  const configuredPaths = await loadConfiguredPaths(options, cwd);
+  const { normalizedRequestedPaths, expandedTrackedFiles } = await expandTrackedFiles(configuredPaths, {
+    repoRoot,
+    env,
+    gitCommand,
+  });
+
+  if (expandedTrackedFiles.length === 0) {
+    throw parseError("Zero auditable files remain after expansion; provide tracked files in the bounded scope");
+  }
+
+  const auditResult = await auditTrackedFiles(expandedTrackedFiles, options, { repoRoot });
+  const payload = {
+    ok: true,
+    repoRoot,
+    paths: normalizedRequestedPaths,
+    auditedFiles: auditResult.auditedFiles,
+    findings: auditResult.findings,
+    highestValueFollowUpCandidates: auditResult.highestValueFollowUpCandidates,
+    scopeBoundary: {
+      mode: "bounded_paths_only",
+      fullRepoScan: false,
+    },
+  };
+
+  const serializedPayload = `${JSON.stringify(payload)}\n`;
+
+  if (typeof options.output === "string") {
+    const outputPath = path.resolve(cwd, options.output);
+    await mkdir(path.dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, serializedPayload, "utf8");
+  }
+
+  stdout.write(serializedPayload);
+  return payload;
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli()
+    .then((result) => {
+      if (result?.ok === false) {
+        process.exitCode = 1;
+      }
+    })
+    .catch((error) => {
+      process.stderr.write(`${formatCliError(error)}\n`);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/loop/run-refinement-audit.mjs
+++ b/scripts/loop/run-refinement-audit.mjs
@@ -215,7 +215,7 @@ function normalizeRequestedPath(requestedPath, repoRoot) {
   const relativePath = path.relative(repoRoot, resolvedPath);
 
   if (relativePath.length === 0) {
-    return ".";
+    throw parseError("Repo root is not a valid bounded audit path; name a specific file or subdirectory");
   }
 
   if (relativePath.startsWith(`..${path.sep}`) || relativePath === ".." || path.isAbsolute(relativePath)) {
@@ -313,7 +313,13 @@ function collectDuplicateBlockCounts(auditableRecords, duplicateWindowLines) {
 }
 
 function isCommentLine(line) {
-  return line.startsWith("#") || line.startsWith("//") || line.startsWith("/*") || line.startsWith("*") || line.startsWith("*/");
+  return line.startsWith("#")
+    || line.startsWith("//")
+    || line.startsWith("/*")
+    || line === "*"
+    || line.startsWith("* ")
+    || line.startsWith("*	")
+    || line.startsWith("*/");
 }
 
 function isWrapperLikeLine(line) {

--- a/skills/docs/issue-intake-procedure.md
+++ b/skills/docs/issue-intake-procedure.md
@@ -153,6 +153,13 @@ Preflight verdicts:
 
 Before updating or assigning the issue, refine it asynchronously when practical. Keep issue refinement separate from the phase-scoped refiner used by the local implementation workflow. Use the `refiner` agent for this review-only issue-refinement chain, including the consolidation/fan-in step; do not route those comparison/synthesis steps through `dev-loop` + `local_implementation` (the strategy loaded by `skills/local-implementation`).
 
+When issue refinement would benefit from structural/slop discovery and the likely code/doc surface is knowable, run the bounded audit first.
+- write the issue-refinement audit artifact to `tmp/issues/issue-<number>/audit/refinement-audit-summary.json`
+- use the same audit artifact shape as local phase refinement
+- keep the audit bounded to the named files/areas for this issue; do not widen into a full-repo scan
+- pass a concise audit summary into refiner fan-out and fan-in
+- require the issue-refinement write-up to translate audit findings into scope, AC/DoD, risks, and explicit non-goals without silently broadening the issue
+
 ## Phase 3b — Epic decomposition with GitHub sub-issue trees
 
 When the work item is an umbrella/epic issue that must be decomposed into bounded child slices,

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -230,6 +230,18 @@ If a previous phase exists, read:
 
 Use those lessons to improve the current phase plan.
 
+### 2b. Optional bounded refinement audit
+
+Before variant fan-out, optionally run one bounded audit when the active phase would benefit from slop-risk discovery, structural drift discovery, or adjacent cleanup discovery.
+
+When used:
+- run one bounded audit before variant fan-out
+- write the audit artifact to `tmp/phases/phase-x/audit/refinement-audit-summary.json`
+- use `node scripts/loop/run-refinement-audit.mjs --paths ... --output tmp/phases/phase-x/audit/refinement-audit-summary.json`
+- pass a concise audit summary into every refiner briefing
+- keep the audit opt-in; do not turn it into a mandatory precondition
+- preserve prioritized findings, the highest-value follow-up candidates, and an explicit statement of what this phase will not rewrite or broaden in the merged plan and review artifacts
+
 ### 3. Fan out short plan variants
 
 Write 2-3 short variants:
@@ -246,6 +258,7 @@ Each refiner variant should make room for:
 - complete acceptance criteria
 - a complete definition of done
 - risks and unresolved questions
+- when a bounded audit artifact exists: prioritized findings, highest-value follow-up candidates, and what the phase will not rewrite or broaden
 - RFC escalation notes when technical decisions should go through the coordinator
 - for watcher/predicate-heavy phases: explicit negative-case tests and timeout semantics, including any zero-timeout or single-check contract
 
@@ -291,6 +304,7 @@ The merged plan must include:
 - validation steps
 - acceptance criteria
 - definition of done
+- when a bounded audit artifact exists: prioritized findings, highest-value follow-up candidates, and an explicit statement of what this phase will not rewrite or broaden
 - RFC escalation notes for any RFC-worthy technical decisions that must go through the coordinator instead of being silently resolved during refinement
 - for any new CLI surface: explicit success-output and malformed-argument/error-contract expectations
 - for any watcher/predicate-driven behavior: explicit timeout semantics plus negative-case detection rules for non-target identities or events

--- a/test/contracts/planning-doc-contracts.test.mjs
+++ b/test/contracts/planning-doc-contracts.test.mjs
@@ -240,6 +240,59 @@ test("phase-truth docs agree that Phase 8 is active and Phase 7 is deferred", as
   assert.doesNotMatch(phase8, /defaults\.json|overrides\.json/i);
 });
 
+test("refinement docs and prompts wire the optional audit handoff into the refiner chain", async () => {
+  const [agentsDoc, refinerAgent, defaultsConfig, localImplementationSkill, issueIntakeDoc] = await Promise.all([
+    readRepo("AGENTS.md"),
+    readRepo("agents/refiner.agent.md"),
+    readRepo(".pi/dev-loop/defaults.yaml"),
+    readRepo("skills/local-implementation/SKILL.md"),
+    readRepo("skills/docs/issue-intake-procedure.md"),
+  ]);
+
+  assertMatchesAll(agentsDoc, [
+    /audit -> refine -> implement/i,
+    /bounded to named files\/areas/i,
+    /input artifact/i,
+    /not.+rewrite or broaden/i,
+  ], "AGENTS.md");
+
+  assertMatchesAll(refinerAgent, [
+    /When an audit artifact is provided/i,
+    /highest-value follow-up candidates/i,
+    /scope\/AC/i,
+    /DoD/i,
+    /explicit non-goal \/ defer|non-goal\/defer/i,
+    /risk\/watchpoint/i,
+    /not.+rewrite or broaden/i,
+    /Do not invent audit findings when no audit artifact was provided/i,
+  ], "agents/refiner.agent.md");
+
+  assertMatchesAll(defaultsConfig, [
+    /Audit inputs/i,
+    /highest-value follow-up candidates/i,
+    /Will not rewrite\/broaden in this phase/i,
+    /do not fabricate audit evidence when none was provided/i,
+    /\n  audit:\n    persona: review/i,
+    /audit only the named files\/areas/i,
+  ], ".pi/dev-loop/defaults.yaml");
+
+  assertMatchesAll(localImplementationSkill, [
+    /run one bounded audit before variant fan-out/i,
+    /tmp\/phases\/phase-x\/audit\/refinement-audit-summary\.json/i,
+    /pass a concise audit summary into every refiner briefing/i,
+    /highest-value follow-up candidates/i,
+    /not.+rewrite or broaden/i,
+  ], "skills/local-implementation/SKILL.md");
+
+  assertMatchesAll(issueIntakeDoc, [
+    /run the bounded audit first/i,
+    /same audit artifact shape/i,
+    /tmp\/issues\/issue-<number>\/audit\/refinement-audit-summary\.json/i,
+    /translate audit findings into scope, AC\/DoD, risks, and explicit non-goals/i,
+    /without silently broadening the issue/i,
+  ], "skills/docs/issue-intake-procedure.md");
+});
+
 test("AGENTS documents the conductor monitor pattern as human-in-the-loop queue oversight", async () => {
   const agents = await readRepo("AGENTS.md");
 

--- a/test/loop/refinement-audit-chain-contract.test.mjs
+++ b/test/loop/refinement-audit-chain-contract.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { runNode } from "../_helpers.mjs";
+
+const execFileAsync = promisify(execFile);
+const scriptPath = path.resolve("scripts/loop/run-refinement-audit.mjs");
+const runAudit = (args = [], options = {}) => runNode(scriptPath, args, options);
+
+async function writeRepoFile(repoRoot, relativePath, content) {
+  const filePath = path.join(repoRoot, relativePath);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, content, "utf8");
+}
+
+async function initRepo() {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "refinement-audit-chain-"));
+  await execFileAsync("git", ["init", "-q"], { cwd: repoRoot });
+  return repoRoot;
+}
+
+test("refinement audit emits the deterministic handoff fields and key order expected by the refiner chain", async () => {
+  const repoRoot = await initRepo();
+
+  try {
+    await writeRepoFile(
+      repoRoot,
+      "scope/dup.md",
+      [
+        "one alpha line",
+        "two beta line",
+        "three gamma line",
+        "four delta line",
+        "",
+        "one alpha line",
+        "two beta line",
+        "three gamma line",
+        "four delta line",
+      ].join("\n"),
+    );
+    await execFileAsync("git", ["add", "--", "scope/dup.md"], { cwd: repoRoot });
+
+    const result = await runAudit(["--root", repoRoot, "--paths", "scope"]);
+    assert.equal(result.code, 0, result.stderr);
+
+    const parsed = JSON.parse(result.stdout.trim());
+    assert.deepEqual(Object.keys(parsed), [
+      "ok",
+      "repoRoot",
+      "paths",
+      "auditedFiles",
+      "findings",
+      "highestValueFollowUpCandidates",
+      "scopeBoundary",
+    ]);
+    assert.equal(parsed.ok, true);
+    assert.deepEqual(parsed.paths, ["scope"]);
+    assert.ok(Array.isArray(parsed.findings));
+    assert.ok(Array.isArray(parsed.highestValueFollowUpCandidates));
+    assert.deepEqual(parsed.scopeBoundary, { mode: "bounded_paths_only", fullRepoScan: false });
+    assert.ok(parsed.findings.some((entry) => entry.id === "duplicate_block_candidate"));
+    assert.ok(parsed.highestValueFollowUpCandidates.some((entry) => entry.path === "scope/dup.md"));
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});

--- a/test/loop/run-refinement-audit.test.mjs
+++ b/test/loop/run-refinement-audit.test.mjs
@@ -103,6 +103,17 @@ test("missing scope args fail closed", async () => {
   assert.match(parsed.usage, /run-refinement-audit\.mjs/);
 });
 
+test("unreadable --paths-file input fails closed with usage", async () => {
+  const missingFile = path.join(os.tmpdir(), `missing-audit-paths-${Date.now()}.txt`);
+  const result = await runAudit(["--paths-file", missingFile]);
+
+  assert.equal(result.code, 1);
+  const parsed = JSON.parse(result.stderr.trim());
+  assert.equal(parsed.ok, false);
+  assert.match(parsed.error, /Unreadable --paths-file input/i);
+  assert.match(parsed.usage, /run-refinement-audit\.mjs/);
+});
+
 test("untracked-only scope fails closed after expansion", async () => {
   const repoRoot = await initTrackedRepo([["tracked.md", "tracked\n"]]);
 

--- a/test/loop/run-refinement-audit.test.mjs
+++ b/test/loop/run-refinement-audit.test.mjs
@@ -1,0 +1,332 @@
+import assert from "node:assert/strict";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { runNode } from "../_helpers.mjs";
+import { parseRefinementAuditCliArgs } from "../../scripts/loop/run-refinement-audit.mjs";
+
+const execFileAsync = promisify(execFile);
+const scriptPath = path.resolve("scripts/loop/run-refinement-audit.mjs");
+const runAudit = (args = [], options = {}) => runNode(scriptPath, args, options);
+
+async function writeRepoFile(repoRoot, relativePath, content) {
+  const filePath = path.join(repoRoot, relativePath);
+  await writeFile(filePath, content);
+}
+
+async function initTrackedRepo(files, { chmodAfterTrack = [] } = {}) {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "run-refinement-audit-"));
+  try {
+    await execFileAsync("git", ["init", "-q"], { cwd: repoRoot });
+
+    for (const [relativePath, content] of files) {
+      const directory = path.dirname(path.join(repoRoot, relativePath));
+      await mkdir(directory, { recursive: true });
+      await writeRepoFile(repoRoot, relativePath, content);
+    }
+
+    await execFileAsync("git", ["add", "--", ...files.map(([relativePath]) => relativePath)], { cwd: repoRoot });
+
+    for (const [relativePath, mode] of chmodAfterTrack) {
+      await chmod(path.join(repoRoot, relativePath), mode);
+    }
+
+    return repoRoot;
+  } catch (error) {
+    await rm(repoRoot, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+async function cleanupRepo(repoRoot, resetModes = []) {
+  for (const [relativePath, mode] of resetModes) {
+    try {
+      await chmod(path.join(repoRoot, relativePath), mode);
+    } catch {}
+  }
+  await rm(repoRoot, { recursive: true, force: true });
+}
+
+test("parseRefinementAuditCliArgs rejects missing bounded scope args", () => {
+  assert.throws(() => parseRefinementAuditCliArgs([]), /exactly one of --paths or --paths-file/i);
+});
+
+test("parseRefinementAuditCliArgs rejects both --paths and --paths-file", () => {
+  assert.throws(
+    () => parseRefinementAuditCliArgs(["--paths", "AGENTS.md", "--paths-file", "paths.txt"]),
+    /exactly one of --paths or --paths-file/i,
+  );
+});
+
+test("parseRefinementAuditCliArgs parses numeric thresholds and output path", () => {
+  const options = parseRefinementAuditCliArgs([
+    "--paths",
+    "AGENTS.md,skills/local-implementation/SKILL.md",
+    "--max-lines",
+    "50",
+    "--duplicate-window-lines",
+    "5",
+    "--branch-threshold",
+    "6",
+    "--thin-wrapper-max-lines",
+    "7",
+    "--output",
+    "tmp/audit.json",
+  ]);
+
+  assert.equal(options.paths, "AGENTS.md,skills/local-implementation/SKILL.md");
+  assert.equal(options.maxLines, 50);
+  assert.equal(options.duplicateWindowLines, 5);
+  assert.equal(options.branchThreshold, 6);
+  assert.equal(options.thinWrapperMaxLines, 7);
+  assert.equal(options.output, "tmp/audit.json");
+});
+
+test("parseRefinementAuditCliArgs rejects invalid threshold values", () => {
+  assert.throws(
+    () => parseRefinementAuditCliArgs(["--paths", "AGENTS.md", "--max-lines", "0"]),
+    /--max-lines must be a positive integer/i,
+  );
+});
+
+test("missing scope args fail closed", async () => {
+  const result = await runAudit([]);
+  assert.equal(result.code, 1);
+
+  const parsed = JSON.parse(result.stderr.trim());
+  assert.equal(parsed.ok, false);
+  assert.match(parsed.error, /exactly one of --paths or --paths-file/i);
+  assert.match(parsed.usage, /run-refinement-audit\.mjs/);
+});
+
+test("untracked-only scope fails closed after expansion", async () => {
+  const repoRoot = await initTrackedRepo([["tracked.md", "tracked\n"]]);
+
+  try {
+    await writeRepoFile(repoRoot, "untracked.md", "untracked\n");
+    const result = await runAudit(["--root", repoRoot, "--paths", "untracked.md"]);
+
+    assert.equal(result.code, 1);
+    const parsed = JSON.parse(result.stderr.trim());
+    assert.equal(parsed.ok, false);
+    assert.match(parsed.error, /Zero auditable files remain after expansion/i);
+  } finally {
+    await cleanupRepo(repoRoot);
+  }
+});
+
+test("directory expansion uses tracked files only", async () => {
+  const repoRoot = await initTrackedRepo([["scope/tracked.md", "bounded\nscope\n"]]);
+
+  try {
+    await writeRepoFile(repoRoot, "scope/untracked.md", "should not appear\n");
+    const result = await runAudit(["--root", repoRoot, "--paths", "scope"]);
+
+    assert.equal(result.code, 0, result.stderr);
+    const parsed = JSON.parse(result.stdout.trim());
+    assert.deepEqual(parsed.paths, ["scope"]);
+    assert.deepEqual(parsed.auditedFiles.map((entry) => entry.path), ["scope/tracked.md"]);
+    assert.deepEqual(parsed.findings, []);
+  } finally {
+    await cleanupRepo(repoRoot);
+  }
+});
+
+test("oversized-file finding is emitted", async () => {
+  const repoRoot = await initTrackedRepo([["big.md", "1\n2\n3\n4\n5\n6\n"]]);
+
+  try {
+    const result = await runAudit(["--root", repoRoot, "--paths", "big.md", "--max-lines", "5"]);
+    assert.equal(result.code, 0, result.stderr);
+
+    const parsed = JSON.parse(result.stdout.trim());
+    const finding = parsed.findings.find((entry) => entry.id === "oversized_file");
+    assert.ok(finding, "expected oversized_file finding");
+    assert.equal(finding.path, "big.md");
+    assert.equal(finding.priority, "high");
+    assert.deepEqual(finding.evidence, { lineCount: 6, threshold: 5 });
+  } finally {
+    await cleanupRepo(repoRoot);
+  }
+});
+
+test("duplicate-block candidate is emitted", async () => {
+  const repoRoot = await initTrackedRepo([[
+    "dup.md",
+    [
+      "alpha section line one",
+      "beta section line two",
+      "gamma section line three",
+      "delta section line four",
+      "",
+      "alpha section line one",
+      "beta section line two",
+      "gamma section line three",
+      "delta section line four",
+      "",
+    ].join("\n"),
+  ]]);
+
+  try {
+    const result = await runAudit(["--root", repoRoot, "--paths", "dup.md"]);
+    assert.equal(result.code, 0, result.stderr);
+
+    const parsed = JSON.parse(result.stdout.trim());
+    const finding = parsed.findings.find((entry) => entry.id === "duplicate_block_candidate");
+    assert.ok(finding, "expected duplicate_block_candidate finding");
+    assert.equal(finding.path, "dup.md");
+    assert.equal(finding.evidence.duplicateWindowLines, 4);
+    assert.ok(finding.evidence.duplicateBlockMatches >= 2);
+  } finally {
+    await cleanupRepo(repoRoot);
+  }
+});
+
+test("branching-hotspot finding is emitted", async () => {
+  const repoRoot = await initTrackedRepo([[
+    "branch.js",
+    [
+      "if (a) {}",
+      "if (b) {} else {}",
+      "switch (value) { case 'x': break; case 'y': break; }",
+      "for (const item of items) {}",
+      "while (flag) { break; }",
+      "try {} catch (error) {} finally {}",
+      "ready && set() || fallback();",
+    ].join("\n"),
+  ]]);
+
+  try {
+    const result = await runAudit(["--root", repoRoot, "--paths", "branch.js", "--branch-threshold", "8"]);
+    assert.equal(result.code, 0, result.stderr);
+
+    const parsed = JSON.parse(result.stdout.trim());
+    const finding = parsed.findings.find((entry) => entry.id === "branching_hotspot");
+    assert.ok(finding, "expected branching_hotspot finding");
+    assert.equal(finding.path, "branch.js");
+    assert.ok(finding.evidence.branchTokenCount > 8);
+  } finally {
+    await cleanupRepo(repoRoot);
+  }
+});
+
+test("thin-wrapper candidate is emitted", async () => {
+  const repoRoot = await initTrackedRepo([[
+    "index.js",
+    [
+      "import { api } from './api.js';",
+      "export { api };",
+      "export { createThing } from './create-thing.js';",
+      "export * from './shared.js';",
+    ].join("\n"),
+  ]]);
+
+  try {
+    const result = await runAudit(["--root", repoRoot, "--paths", "index.js", "--thin-wrapper-max-lines", "10"]);
+    assert.equal(result.code, 0, result.stderr);
+
+    const parsed = JSON.parse(result.stdout.trim());
+    const finding = parsed.findings.find((entry) => entry.id === "thin_wrapper_candidate");
+    assert.ok(finding, "expected thin_wrapper_candidate finding");
+    assert.equal(finding.path, "index.js");
+  } finally {
+    await cleanupRepo(repoRoot);
+  }
+});
+
+test("binary and unreadable files are skipped deterministically", async () => {
+  const repoRoot = await initTrackedRepo(
+    [
+      ["scope/text.md", "safe text\n"],
+      ["scope/binary.bin", Buffer.from([0, 1, 2, 3])],
+      ["scope/secret.txt", "hidden\n"],
+    ],
+    { chmodAfterTrack: [["scope/secret.txt", 0o000]] },
+  );
+
+  try {
+    const result = await runAudit(["--root", repoRoot, "--paths", "scope"]);
+    assert.equal(result.code, 0, result.stderr);
+
+    const parsed = JSON.parse(result.stdout.trim());
+    const binaryEntry = parsed.auditedFiles.find((entry) => entry.path === "scope/binary.bin");
+    const unreadableEntry = parsed.auditedFiles.find((entry) => entry.path === "scope/secret.txt");
+    const textEntry = parsed.auditedFiles.find((entry) => entry.path === "scope/text.md");
+
+    assert.equal(binaryEntry.skipped, true);
+    assert.equal(binaryEntry.skipReason, "binary_file");
+    assert.equal(unreadableEntry.skipped, true);
+    assert.equal(unreadableEntry.skipReason, "unreadable_file");
+    assert.equal(textEntry.skipped, false);
+  } finally {
+    await cleanupRepo(repoRoot, [["scope/secret.txt", 0o644]]);
+  }
+});
+
+test("--paths-file is supported", async () => {
+  const repoRoot = await initTrackedRepo([
+    ["a.md", "alpha\n"],
+    ["b.md", "beta\n"],
+  ]);
+
+  try {
+    const pathsFile = path.join(repoRoot, "paths.txt");
+    await writeFile(pathsFile, "a.md\nb.md\n", "utf8");
+
+    const result = await runAudit(["--root", repoRoot, "--paths-file", pathsFile]);
+    assert.equal(result.code, 0, result.stderr);
+
+    const parsed = JSON.parse(result.stdout.trim());
+    assert.deepEqual(parsed.paths, ["a.md", "b.md"]);
+    assert.deepEqual(parsed.auditedFiles.map((entry) => entry.path), ["a.md", "b.md"]);
+  } finally {
+    await cleanupRepo(repoRoot);
+  }
+});
+
+test("--output writes the same JSON returned on stdout", async () => {
+  const repoRoot = await initTrackedRepo([["clean.md", "simple\ncontent\n"]]);
+
+  try {
+    const outputPath = path.join(repoRoot, "tmp", "audit.json");
+    const result = await runAudit(["--root", repoRoot, "--paths", "clean.md", "--output", outputPath]);
+    assert.equal(result.code, 0, result.stderr);
+
+    const written = await readFile(outputPath, "utf8");
+    assert.equal(written.trim(), result.stdout.trim());
+  } finally {
+    await cleanupRepo(repoRoot);
+  }
+});
+
+test("clean bounded scopes return ok true with empty findings", async () => {
+  const repoRoot = await initTrackedRepo([["clean.md", "brief\ntext\n"]]);
+
+  try {
+    const result = await runAudit([
+      "--root",
+      repoRoot,
+      "--paths",
+      "clean.md",
+      "--max-lines",
+      "50",
+      "--branch-threshold",
+      "50",
+      "--thin-wrapper-max-lines",
+      "1",
+    ]);
+    assert.equal(result.code, 0, result.stderr);
+
+    const parsed = JSON.parse(result.stdout.trim());
+    assert.equal(parsed.ok, true);
+    assert.deepEqual(parsed.findings, []);
+    assert.deepEqual(parsed.highestValueFollowUpCandidates, []);
+    assert.deepEqual(parsed.scopeBoundary, { mode: "bounded_paths_only", fullRepoScan: false });
+  } finally {
+    await cleanupRepo(repoRoot);
+  }
+});

--- a/test/loop/run-refinement-audit.test.mjs
+++ b/test/loop/run-refinement-audit.test.mjs
@@ -130,6 +130,22 @@ test("untracked-only scope fails closed after expansion", async () => {
   }
 });
 
+test("repo-root path is rejected to preserve bounded audit scope", async () => {
+  const repoRoot = await initTrackedRepo([["tracked.md", "tracked\n"]]);
+
+  try {
+    const result = await runAudit(["--root", repoRoot, "--paths", "."]);
+    assert.equal(result.code, 1);
+
+    const parsed = JSON.parse(result.stderr.trim());
+    assert.equal(parsed.ok, false);
+    assert.match(parsed.error, /Repo root is not a valid bounded audit path/i);
+    assert.match(parsed.usage, /run-refinement-audit\.mjs/);
+  } finally {
+    await cleanupRepo(repoRoot);
+  }
+});
+
 test("directory expansion uses tracked files only", async () => {
   const repoRoot = await initTrackedRepo([["scope/tracked.md", "bounded\nscope\n"]]);
 
@@ -225,25 +241,45 @@ test("branching-hotspot finding is emitted", async () => {
   }
 });
 
-test("thin-wrapper candidate is emitted", async () => {
-  const repoRoot = await initTrackedRepo([[
-    "index.js",
+test("thin-wrapper candidate is emitted without misclassifying generator syntax as a comment", async () => {
+  const repoRoot = await initTrackedRepo([
     [
-      "import { api } from './api.js';",
-      "export { api };",
-      "export { createThing } from './create-thing.js';",
-      "export * from './shared.js';",
-    ].join("\n"),
-  ]]);
+      "index.js",
+      [
+        "import { api } from './api.js';",
+        "export { api };",
+        "export { createThing } from './create-thing.js';",
+        "export * from './shared.js';",
+      ].join("\n"),
+    ],
+    [
+      "generator.js",
+      [
+        "export const hooks = {",
+        "  *values() {",
+        "    yield 1;",
+        "  },",
+        "};",
+      ].join("\n"),
+    ],
+  ]);
 
   try {
-    const result = await runAudit(["--root", repoRoot, "--paths", "index.js", "--thin-wrapper-max-lines", "10"]);
+    const result = await runAudit([
+      "--root",
+      repoRoot,
+      "--paths",
+      "index.js,generator.js",
+      "--thin-wrapper-max-lines",
+      "10",
+    ]);
     assert.equal(result.code, 0, result.stderr);
 
     const parsed = JSON.parse(result.stdout.trim());
-    const finding = parsed.findings.find((entry) => entry.id === "thin_wrapper_candidate");
-    assert.ok(finding, "expected thin_wrapper_candidate finding");
-    assert.equal(finding.path, "index.js");
+    const wrapperFinding = parsed.findings.find((entry) => entry.id === "thin_wrapper_candidate" && entry.path === "index.js");
+    const generatorFinding = parsed.findings.find((entry) => entry.id === "thin_wrapper_candidate" && entry.path === "generator.js");
+    assert.ok(wrapperFinding, "expected thin_wrapper_candidate finding for index.js");
+    assert.equal(generatorFinding, undefined);
   } finally {
     await cleanupRepo(repoRoot);
   }


### PR DESCRIPTION
## Summary
- add a deterministic bounded refinement audit helper at `scripts/loop/run-refinement-audit.mjs`
- wire the opt-in `audit -> refine -> implement` refinement seam into repo docs and refiner prompts
- add CLI, chain-contract, and planning-doc contract coverage for the audit handoff

## Scope / context
Implements #405 by making refinement-side auditing a first-class planning input without changing review-side PR follow-up behavior.

## Acceptance criteria
- `AGENTS.md` documents the opt-in bounded `audit -> refine -> implement` sequence.
- `agents/refiner.agent.md` and `.pi/dev-loop/defaults.yaml` explain how audit findings are consumed.
- `.pi/dev-loop/defaults.yaml` includes a reusable `personas.audit` prompt.
- `skills/local-implementation/SKILL.md` and `skills/docs/issue-intake-procedure.md` document where the audit artifact is created/consumed before refinement hardening.
- `scripts/loop/run-refinement-audit.mjs` implements the bounded audit helper contract.
- Tests cover CLI behavior, planning-doc drift, and the audit-artifact handoff shape into refinement.

## Definition of done
- local `npm run verify` passes
- the new audit helper emits deterministic success/error JSON and never silently scans the whole repo
- docs/prompts preserve the opt-in, bounded, non-broadening posture
- review-side behavior remains unchanged and stays with #402

## Non-goals
- replacing `codebase-deslop-audit`
- making refinement audit mandatory
- changing `skills/copilot-pr-followup/SKILL.md` or review-side gate behavior

## Validation
- `node --test test/loop/run-refinement-audit.test.mjs test/loop/refinement-audit-chain-contract.test.mjs test/contracts/planning-doc-contracts.test.mjs`
- `npm run verify`

Closes #405
