### PR TITLE
Add conductor auto-resume planning for orphaned PRs

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -345,19 +345,58 @@ Aggregate the current Copilot-loop status for every open PR in one repository.
 Required:
 - `--repo <owner/name>`
 
+Optional:
+- `--auto-resume` — inspect documented pi-subagents async/session artifacts on disk, detect orphaned open PR follow-up runs, and emit deterministic resume plans without executing `subagent({ action: "resume" })`
+
 Contract:
 - lists all open PRs via `gh pr list --state open --limit 1000` to avoid GitHub CLI default truncation
 - reuses `detect-copilot-loop-state.mjs` logic for each PR instead of inventing a second state classifier
 - reports one queue-level summary with per-PR loop state, next action, and whether human follow-up is needed now
 - reports `queue_complete` when the open-PR queue is empty
 - keeps the current implementation human-in-the-loop; fully autonomous monitor ownership is a follow-up slice
+- when `--auto-resume` is present, scans documented async evidence sources only:
+  - pi-subagents async run dirs under `<tmpdir>/pi-subagents-*/async-subagent-runs/<runId>/`
+    (`status.json`, `events.jsonl`, `output-<n>.log`)
+  - pi-subagents async result artifacts under
+    `<tmpdir>/pi-subagents-*/async-subagent-results/`
+  - persisted session/subagent artifacts under the Pi sessions tree (for example
+    `~/.pi/agent/sessions/.../subagent-artifacts/*_dev-loop_*_{meta,output}.json|md`
+    plus matching `run-<n>/session.jsonl` files)
+- ignores non-`dev-loop` agents, other repositories, merged PRs, and any exited run superseded by a newer matching `running` or `queued` run
+- matches exited runs to open PRs only by PR number parsed from artifact text; branch names, issue numbers, or worktree paths alone are never sufficient identity
+- fail-closes to `needsManualAttention` when PR identity, artifact state, or resume inputs are missing, contradictory, or ambiguous
+- `--auto-resume` remains single-shot only; it does not poll, sleep, watch, or execute the resume itself
 
 Success output shape:
-- `{ "ok": true, "repo": "owner/name", "checkedAt": "...", "prCount": 2, "queueStatus": "queue_complete"|"monitoring"|"attention_needed", "needsAttentionCount": 0, "summary": { "waiting": 0, "needsAttention": 0, "blocked": 0, "done": 0 }, "prs": [...] }`
+- default:
+  - `{ "ok": true, "repo": "owner/name", "checkedAt": "...", "prCount": 2, "queueStatus": "queue_complete"|"monitoring"|"attention_needed", "needsAttentionCount": 0, "summary": { "waiting": 0, "needsAttention": 0, "blocked": 0, "done": 0 }, "prs": [...] }`
+- with `--auto-resume`:
+  - adds
+    `{ "autoResumeRequested": true, "orphanedPrCount": 1, "resumePlanCount": 1, "manualAttentionCount": 0, "resumePlans": [...], "needsManualAttention": [...] }`
+
+`resumePlans[]` fields:
+- `pr`
+- `runId`
+- `runState` (`completed` | `failed` | `paused`)
+- `artifactPath`
+- `sessionPath` when known
+- `parsedArtifactState`
+- `parsedLoopState`
+- `livePrState`
+- `resumeAction`
+- `resumeMessage`
+- `resumeCommandPreview`
+- `staleWorktree`
+
+`needsManualAttention[]` fields:
+- `pr` when known
+- `runId` when known
+- `reason`
+- `evidence`
+- `suggestedNextStep`
 
 Failure behavior:
 - malformed arguments and unexpected `gh` failures emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero
-
 
 ### `scripts/loop/detect-copilot-session-activity.mjs`
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -360,7 +360,8 @@ Contract:
   - pi-subagents async result artifacts under
     `<tmpdir>/pi-subagents-*/async-subagent-results/`
   - persisted session/subagent artifacts under the Pi sessions tree (for example
-    `~/.pi/agent/sessions/.../subagent-artifacts/*_dev-loop_*_{meta,output}.json|md`
+    `~/.pi/agent/sessions/.../subagent-artifacts/*_dev-loop_*_meta.json` and
+    `~/.pi/agent/sessions/.../subagent-artifacts/*_dev-loop_*_output.md`
     plus matching `run-<n>/session.jsonl` files)
 - ignores non-`dev-loop` agents, other repositories, merged PRs, and any exited run superseded by a newer matching `running` or `queued` run
 - matches exited runs to open PRs only by PR number parsed from artifact text; branch names, issue numbers, or worktree paths alone are never sufficient identity

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -454,7 +454,6 @@ function createRunRecord(runId, childIndex = 0) {
     resultPath: null,
     resultSummaryPath: null,
     resultSummaryText: null,
-    outputArtifactMissing: false,
     timestampMs: null,
     evidence: {},
   };

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -336,7 +336,11 @@ async function readJsonIfExists(filePath) {
     return null;
   }
 
-  return parseJsonText(text);
+  try {
+    return parseJsonText(text);
+  } catch {
+    return null;
+  }
 }
 
 function normalizeRunState(value) {

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -517,10 +517,11 @@ async function scanSessionRunRoot(root, records) {
     }
 
     const topLevelPath = path.join(root, topLevelEntry.name);
+    await scanSessionArtifactRoot(path.join(topLevelPath, "subagent-artifacts"), records).catch(() => {});
     const runIdEntries = await readdir(topLevelPath, { withFileTypes: true }).catch(() => []);
 
     for (const runIdEntry of runIdEntries) {
-      if (!runIdEntry.isDirectory()) {
+      if (!runIdEntry.isDirectory() || runIdEntry.name === "subagent-artifacts") {
         continue;
       }
 
@@ -1241,10 +1242,6 @@ function buildManualAttentionEntry({
 
 export function selectLatestExitedRunForPr({ pr, exitedRuns, activeRuns }) {
   const activeMatch = activeRuns.filter((candidate) => candidate.parsedArtifact?.ok && candidate.parsedArtifact.pr === pr.number);
-  if (activeMatch.length > 0) {
-    return { kind: "suppressed_by_active_run", runIds: activeMatch.map((candidate) => candidate.run.runId) };
-  }
-
   const matches = exitedRuns.filter((candidate) => candidate.parsedArtifact?.ok && candidate.parsedArtifact.pr === pr.number);
   if (matches.length === 0) {
     return { kind: "none" };
@@ -1274,7 +1271,23 @@ export function selectLatestExitedRunForPr({ pr, exitedRuns, activeRuns }) {
     }
   }
 
-  return { kind: "selected", candidate: sorted[0] };
+  const selected = sorted[0];
+  const selectedTimestamp = selected.run.timestampMs;
+  const newerActiveRuns = activeMatch.filter((candidate) => {
+    const activeTimestamp = candidate.run.timestampMs;
+    return typeof activeTimestamp === "number"
+      && typeof selectedTimestamp === "number"
+      && activeTimestamp > selectedTimestamp;
+  });
+
+  if (newerActiveRuns.length > 0) {
+    return {
+      kind: "suppressed_by_active_run",
+      runIds: newerActiveRuns.map((candidate) => candidate.run.runId),
+    };
+  }
+
+  return { kind: "selected", candidate: selected };
 }
 
 function classifyLiveStateForResume(resumeAction, prReport) {

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -1144,19 +1144,10 @@ function buildSourceSelection(record, outputArtifactText, resultSummaryText, out
   }
 
   if (record.outputArtifactPath) {
-    if (resultSummaryText !== null) {
-      return {
-        primaryText: resultSummaryText,
-        primarySource: "grouped_result_summary",
-        fallbackText: null,
-        weakFallbackText: outputLogText,
-      };
-    }
-
     return {
       primaryText: null,
       primarySource: "missing_output_artifact",
-      fallbackText: null,
+      fallbackText: resultSummaryText,
       weakFallbackText: outputLogText,
     };
   }

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { existsSync } from "node:fs";
-import { access, readFile, readdir } from "node:fs/promises";
+import { access, open, readFile, readdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -330,6 +330,41 @@ async function readTextIfExists(filePath) {
   }
 }
 
+
+async function readFirstLineIfExists(filePath, chunkSize = 4096) {
+  if (typeof filePath !== "string" || filePath.length === 0) {
+    return null;
+  }
+
+  let handle;
+  try {
+    handle = await open(filePath, "r");
+    let position = 0;
+    let collected = "";
+
+    while (true) {
+      const buffer = Buffer.alloc(chunkSize);
+      const { bytesRead } = await handle.read(buffer, 0, chunkSize, position);
+      if (bytesRead === 0) {
+        return collected.length > 0 ? collected : null;
+      }
+
+      const chunk = buffer.toString("utf8", 0, bytesRead);
+      const newlineIndex = chunk.search(/\r?\n/u);
+      if (newlineIndex >= 0) {
+        return `${collected}${chunk.slice(0, newlineIndex)}`;
+      }
+
+      collected += chunk;
+      position += bytesRead;
+    }
+  } catch {
+    return null;
+  } finally {
+    await handle?.close().catch(() => {});
+  }
+}
+
 async function readJsonIfExists(filePath) {
   const text = await readTextIfExists(filePath);
   if (text === null) {
@@ -567,8 +602,7 @@ async function scanSessionRunRoot(root, records) {
 
         const childIndex = Number(indexMatch[1]);
         const sessionPath = path.join(runRoot, runDirectory.name, "session.jsonl");
-        const headerText = await readTextIfExists(sessionPath);
-        const firstLine = headerText?.split(/\r?\n/u, 1)[0] ?? null;
+        const firstLine = await readFirstLineIfExists(sessionPath);
         let header = null;
         if (firstLine) {
           try {
@@ -1160,10 +1194,11 @@ export async function parseDevLoopArtifact(record) {
   const selection = buildSourceSelection(record, outputArtifactText, resultSummaryText, outputLogText);
 
   if (selection.primaryText === null) {
+    const weakFallbackPr = parseWeakFallbackPr(selection.weakFallbackText);
     return {
       ok: false,
       reason: MANUAL_REASON.MISSING_OUTPUT_ARTIFACT,
-      ...(Number.isInteger(parseWeakFallbackPr(selection.weakFallbackText)) ? { pr: parseWeakFallbackPr(selection.weakFallbackText) } : {}),
+      ...(Number.isInteger(weakFallbackPr) ? { pr: weakFallbackPr } : {}),
       evidence: {
         outputArtifactPath: record.outputArtifactPath,
         resultSummaryPath: record.resultSummaryPath,

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -386,6 +386,23 @@ function isExitedState(value) {
     || normalized === RUN_STATE.PAUSED;
 }
 
+function runStatePriority(value) {
+  switch (normalizeRunState(value)) {
+    case RUN_STATE.RUNNING:
+      return 5;
+    case RUN_STATE.QUEUED:
+      return 4;
+    case RUN_STATE.FAILED:
+      return 3;
+    case RUN_STATE.PAUSED:
+      return 2;
+    case RUN_STATE.COMPLETED:
+      return 1;
+    default:
+      return 0;
+  }
+}
+
 function createRunRecord(runId, childIndex = 0) {
   return {
     runId,
@@ -433,11 +450,7 @@ function mergeRunRecord(target, patch) {
 
     if (key === "runState") {
       const normalized = normalizeRunState(value);
-      if (
-        merged.runState === RUN_STATE.UNKNOWN
-        || (isRunningLikeState(normalized) && !isRunningLikeState(merged.runState))
-        || (isExitedState(normalized) && !isRunningLikeState(merged.runState))
-      ) {
+      if (runStatePriority(normalized) > runStatePriority(merged.runState)) {
         merged.runState = normalized;
       }
       continue;
@@ -1452,7 +1465,7 @@ export function buildResumePlan({ prReport, candidate, childCounts }) {
       pr: prReport.number,
       runId: run.runId,
       runState: normalizeRunStateForPlan(run.runState),
-      artifactPath: run.outputArtifactPath ?? null,
+      artifactPath: run.outputArtifactPath ?? run.resultSummaryPath ?? run.resultPath ?? null,
       ...(run.sessionPath ? { sessionPath: run.sessionPath } : {}),
       parsedArtifactState: parsedArtifact.parsedArtifactState,
       parsedLoopState: parsedArtifact.parsedLoopState,

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -516,7 +516,10 @@ async function scanSessionArtifactRoot(artifactsDir, records) {
 }
 
 async function scanSessionRunRoot(root, records) {
-  const topLevelEntries = await readdir(root, { withFileTypes: true });
+  const topLevelEntries = await readdir(root, { withFileTypes: true }).catch(() => null);
+  if (topLevelEntries === null) {
+    return;
+  }
 
   for (const topLevelEntry of topLevelEntries) {
     if (!topLevelEntry.isDirectory()) {

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -1298,7 +1298,7 @@ function buildResumeMessage({ pr, runId, resumeAction, livePrState }) {
 }
 
 function buildResumeCommandPreview({ runId, childIndex, childCount, resumeMessage }) {
-  if (childCount > 1) {
+  if (childCount > 1 || childIndex !== 0) {
     return `subagent({ action: "resume", id: "${runId}", index: ${childIndex}, message: ${JSON.stringify(resumeMessage)} })`;
   }
 

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -1,16 +1,25 @@
 #!/usr/bin/env node
+import { existsSync } from "node:fs";
+import { access, readFile, readdir } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
 import { runChild, requireOptionValue } from "../_cli-primitives.mjs";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import { autoDetectSnapshot } from "./detect-copilot-loop-state.mjs";
 import { interpretLoopState, summarizeLoopInterpretation } from "@pi-dev-loops/core/loop/copilot-loop-state";
 
-const USAGE = `Usage: conductor-monitor.mjs --repo <owner/name>
+const USAGE = `Usage: conductor-monitor.mjs --repo <owner/name> [--auto-resume]
 
 Aggregate Copilot-loop status across all open PRs in one repo.
 
 Required:
   --repo <owner/name>   Repository slug (e.g. owner/repo)
+
+Optional:
+  --auto-resume         Inspect documented async run artifacts, detect orphaned
+                        PR follow-up runs, and emit deterministic resume plans.
 
 Success output (stdout, JSON):
   {
@@ -51,6 +60,16 @@ Success output (stdout, JSON):
     ]
   }
 
+Additional success fields when --auto-resume is present:
+  {
+    "autoResumeRequested": true,
+    "orphanedPrCount": 1,
+    "resumePlanCount": 1,
+    "manualAttentionCount": 0,
+    "resumePlans": [...],
+    "needsManualAttention": [...]
+  }
+
 Queue status values:
   queue_complete   No open PRs remain in the repo queue
   monitoring       Open PRs exist, but all are in healthy wait states
@@ -68,12 +87,41 @@ Exit codes:
 
 const parseError = buildParseError(USAGE);
 const OPEN_PR_LIST_LIMIT = 1000;
+const DEFAULT_SESSION_ROOT = path.join(os.homedir(), ".pi", "agent", "sessions");
+const RUN_STATE = {
+  COMPLETED: "completed",
+  FAILED: "failed",
+  PAUSED: "paused",
+  RUNNING: "running",
+  QUEUED: "queued",
+  UNKNOWN: "unknown",
+};
+const RESUME_ACTION = {
+  NEEDS_FEEDBACK_FIX: "needs_feedback_fix",
+  NEEDS_REPLY_RESOLVE: "needs_reply_resolve",
+  NEEDS_REREQUEST_OR_WATCH: "needs_rerequest_or_watch",
+  AWAIT_FINAL_APPROVAL: "await_final_approval",
+  AWAIT_MERGE_AUTHORIZATION: "await_merge_authorization",
+  AWAIT_READY_FOR_REVIEW_AUTHORIZATION: "await_ready_for_review_authorization",
+  DONE_OR_MERGED: "done_or_merged",
+  NEEDS_MANUAL_ATTENTION: "needs_manual_attention",
+};
+const MANUAL_REASON = {
+  AMBIGUOUS_PR_IDENTITY: "ambiguous_pr_identity",
+  MISSING_PR_IDENTITY: "missing_pr_identity",
+  ARTIFACT_LIVE_STATE_CONFLICT: "artifact_live_state_conflict",
+  MISSING_OUTPUT_ARTIFACT: "missing_output_artifact",
+  UNCLASSIFIED_ARTIFACT_STATE: "unclassified_artifact_state",
+  MULTIPLE_CANDIDATE_RUNS: "multiple_candidate_runs",
+  STALE_WORKTREE_MISSING_RESUME_INPUTS: "stale_worktree_missing_resume_inputs",
+};
 
 function parseCliArgs(argv) {
   const args = [...argv];
   const options = {
     help: false,
     repo: undefined,
+    autoResume: false,
   };
 
   while (args.length > 0) {
@@ -86,6 +134,11 @@ function parseCliArgs(argv) {
 
     if (token === "--repo") {
       options.repo = requireOptionValue(args, "--repo", parseError).trim();
+      continue;
+    }
+
+    if (token === "--auto-resume") {
+      options.autoResume = true;
       continue;
     }
 
@@ -190,28 +243,9 @@ function buildPrReport(pr, interpretation, interpretationSummary, snapshot) {
   };
 }
 
-export async function runConductorMonitor({ repo }, { env = process.env, ghCommand = "gh" } = {}) {
-  const prs = await listOpenPrs({ repo }, { env, ghCommand });
-
-  if (prs.length === 0) {
-    return {
-      ok: true,
-      repo,
-      checkedAt: new Date().toISOString(),
-      prCount: 0,
-      queueStatus: "queue_complete",
-      needsAttentionCount: 0,
-      summary: {
-        waiting: 0,
-        needsAttention: 0,
-        blocked: 0,
-        done: 0,
-      },
-      prs: [],
-    };
-  }
-
+async function buildPrReports(prs, { repo, env, ghCommand }) {
   const reports = [];
+
   for (const pr of prs) {
     const snapshot = await autoDetectSnapshot({ repo, pr: pr.number }, { env, ghCommand });
     const interpretation = interpretLoopState(snapshot);
@@ -219,7 +253,11 @@ export async function runConductorMonitor({ repo }, { env = process.env, ghComma
     reports.push(buildPrReport(pr, interpretation, interpretationSummary, snapshot));
   }
 
-  const summary = reports.reduce((accumulator, pr) => {
+  return reports;
+}
+
+function buildQueueSummary(reports) {
+  return reports.reduce((accumulator, pr) => {
     accumulator[pr.bucket] += 1;
     return accumulator;
   }, {
@@ -228,9 +266,14 @@ export async function runConductorMonitor({ repo }, { env = process.env, ghComma
     blocked: 0,
     done: 0,
   });
+}
 
+function buildBaseResult(repo, reports) {
+  const summary = buildQueueSummary(reports);
   const needsAttentionCount = summary.needsAttention + summary.blocked;
-  const queueStatus = needsAttentionCount > 0 ? "attention_needed" : "monitoring";
+  const queueStatus = reports.length === 0
+    ? "queue_complete"
+    : (needsAttentionCount > 0 ? "attention_needed" : "monitoring");
 
   return {
     ok: true,
@@ -244,9 +287,1302 @@ export async function runConductorMonitor({ repo }, { env = process.env, ghComma
   };
 }
 
+function splitPathList(value) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return [];
+  }
+
+  return value
+    .split(path.delimiter)
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+}
+
+async function pathExists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function listDirectoriesIfExists(root) {
+  try {
+    const entries = await readdir(root, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(root, entry.name));
+  } catch {
+    return [];
+  }
+}
+
+async function readTextIfExists(filePath) {
+  if (typeof filePath !== "string" || filePath.length === 0) {
+    return null;
+  }
+
+  try {
+    return await readFile(filePath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+async function readJsonIfExists(filePath) {
+  const text = await readTextIfExists(filePath);
+  if (text === null) {
+    return null;
+  }
+
+  return parseJsonText(text);
+}
+
+function normalizeRunState(value) {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  switch (normalized) {
+    case "complete":
+    case "completed":
+      return RUN_STATE.COMPLETED;
+    case "failed":
+    case "failure":
+    case "error":
+      return RUN_STATE.FAILED;
+    case "paused":
+    case "interrupted":
+      return RUN_STATE.PAUSED;
+    case "running":
+      return RUN_STATE.RUNNING;
+    case "queued":
+    case "pending":
+      return RUN_STATE.QUEUED;
+    default:
+      return RUN_STATE.UNKNOWN;
+  }
+}
+
+function normalizeRunStateForPlan(value) {
+  const normalized = normalizeRunState(value);
+  if (normalized === RUN_STATE.UNKNOWN) {
+    return RUN_STATE.COMPLETED;
+  }
+  return normalized;
+}
+
+function isRunningLikeState(value) {
+  const normalized = normalizeRunState(value);
+  return normalized === RUN_STATE.RUNNING || normalized === RUN_STATE.QUEUED;
+}
+
+function isExitedState(value) {
+  const normalized = normalizeRunState(value);
+  return normalized === RUN_STATE.COMPLETED
+    || normalized === RUN_STATE.FAILED
+    || normalized === RUN_STATE.PAUSED;
+}
+
+function createRunRecord(runId, childIndex = 0) {
+  return {
+    runId,
+    childIndex,
+    agent: null,
+    runState: RUN_STATE.UNKNOWN,
+    cwd: null,
+    sessionPath: null,
+    statusPath: null,
+    eventsPath: null,
+    outputLogPath: null,
+    outputArtifactPath: null,
+    metaPath: null,
+    resultPath: null,
+    resultSummaryPath: null,
+    resultSummaryText: null,
+    outputArtifactMissing: false,
+    timestampMs: null,
+    evidence: {},
+  };
+}
+
+function mergeRunRecord(target, patch) {
+  const merged = { ...target };
+
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    if (key === "evidence") {
+      merged.evidence = { ...merged.evidence, ...value };
+      continue;
+    }
+
+    if (key === "timestampMs") {
+      const numeric = Number.isFinite(value) ? value : null;
+      if (numeric !== null) {
+        merged.timestampMs = merged.timestampMs === null
+          ? numeric
+          : Math.max(merged.timestampMs, numeric);
+      }
+      continue;
+    }
+
+    if (key === "runState") {
+      const normalized = normalizeRunState(value);
+      if (
+        merged.runState === RUN_STATE.UNKNOWN
+        || (isRunningLikeState(normalized) && !isRunningLikeState(merged.runState))
+        || (isExitedState(normalized) && !isRunningLikeState(merged.runState))
+      ) {
+        merged.runState = normalized;
+      }
+      continue;
+    }
+
+    merged[key] = value;
+  }
+
+  return merged;
+}
+
+function recordKey(runId, childIndex) {
+  return `${runId}:${childIndex}`;
+}
+
+function parseChildIndexFromArtifactName(name) {
+  const match = name.match(/_(\d+)_/u);
+  return match ? Number(match[1]) : 0;
+}
+
+function parseRunIdFromArtifactName(name) {
+  const match = name.match(/^([^_]+)_/u);
+  return match ? match[1] : null;
+}
+
+async function scanSessionArtifactRoot(artifactsDir, records) {
+  const entries = await readdir(artifactsDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    const runId = parseRunIdFromArtifactName(entry.name);
+    if (runId === null) {
+      continue;
+    }
+
+    const childIndex = parseChildIndexFromArtifactName(entry.name);
+    const key = recordKey(runId, childIndex);
+    const record = records.get(key) ?? createRunRecord(runId, childIndex);
+    const filePath = path.join(artifactsDir, entry.name);
+
+    if (entry.name.endsWith("_meta.json")) {
+      const meta = await readJsonIfExists(filePath);
+      if (meta && typeof meta === "object") {
+        records.set(key, mergeRunRecord(record, {
+          agent: typeof meta.agent === "string" ? meta.agent : record.agent,
+          metaPath: filePath,
+          runState: Number(meta.exitCode) === 0 ? RUN_STATE.COMPLETED : RUN_STATE.FAILED,
+          timestampMs: typeof meta.timestamp === "number" ? meta.timestamp : null,
+          evidence: {
+            metaPath: filePath,
+            exitCode: Number.isInteger(meta.exitCode) ? meta.exitCode : null,
+          },
+        }));
+      }
+      continue;
+    }
+
+    if (entry.name.endsWith("_output.md")) {
+      records.set(key, mergeRunRecord(record, {
+        outputArtifactPath: filePath,
+        evidence: { outputArtifactPath: filePath },
+      }));
+    }
+  }
+}
+
+async function scanSessionRunRoot(root, records) {
+  const topLevelEntries = await readdir(root, { withFileTypes: true });
+
+  for (const topLevelEntry of topLevelEntries) {
+    if (!topLevelEntry.isDirectory()) {
+      continue;
+    }
+
+    if (topLevelEntry.name === "subagent-artifacts") {
+      await scanSessionArtifactRoot(path.join(root, topLevelEntry.name), records);
+      continue;
+    }
+
+    const topLevelPath = path.join(root, topLevelEntry.name);
+    const runIdEntries = await readdir(topLevelPath, { withFileTypes: true }).catch(() => []);
+
+    for (const runIdEntry of runIdEntries) {
+      if (!runIdEntry.isDirectory()) {
+        continue;
+      }
+
+      const runId = runIdEntry.name;
+      const runRoot = path.join(topLevelPath, runId);
+      const runDirectories = await readdir(runRoot, { withFileTypes: true }).catch(() => []);
+
+      for (const runDirectory of runDirectories) {
+        const indexMatch = runDirectory.name.match(/^run-(\d+)$/u);
+        if (!runDirectory.isDirectory() || indexMatch === null) {
+          continue;
+        }
+
+        const childIndex = Number(indexMatch[1]);
+        const sessionPath = path.join(runRoot, runDirectory.name, "session.jsonl");
+        const headerText = await readTextIfExists(sessionPath);
+        const firstLine = headerText?.split(/\r?\n/u, 1)[0] ?? null;
+        const header = firstLine ? parseJsonText(firstLine) : null;
+        const key = recordKey(runId, childIndex);
+        const record = records.get(key) ?? createRunRecord(runId, childIndex);
+
+        records.set(key, mergeRunRecord(record, {
+          sessionPath,
+          cwd: typeof header?.cwd === "string" ? header.cwd : null,
+          evidence: { sessionPath },
+        }));
+      }
+    }
+  }
+}
+
+async function scanAsyncRunRoot(asyncRoot, records) {
+  const runDirs = await readdir(asyncRoot, { withFileTypes: true }).catch(() => []);
+
+  for (const runDirEntry of runDirs) {
+    if (!runDirEntry.isDirectory()) {
+      continue;
+    }
+
+    const asyncDir = path.join(asyncRoot, runDirEntry.name);
+    const statusPath = path.join(asyncDir, "status.json");
+    const eventsPath = path.join(asyncDir, "events.jsonl");
+    const status = await readJsonIfExists(statusPath);
+    if (!status || typeof status !== "object") {
+      continue;
+    }
+
+    const runId = typeof status.runId === "string" && status.runId.trim().length > 0
+      ? status.runId.trim()
+      : runDirEntry.name;
+    const rootState = normalizeRunState(status.state);
+    const cwd = typeof status.cwd === "string" ? status.cwd : null;
+    const defaultSessionPath = typeof status.sessionFile === "string" ? status.sessionFile : null;
+    const baseTimestamp = [status.endedAt, status.lastUpdate, status.lastActivityAt, status.startedAt]
+      .find((value) => typeof value === "number");
+
+    const steps = Array.isArray(status.steps) && status.steps.length > 0
+      ? status.steps
+      : [{
+        agent: typeof status.agent === "string" ? status.agent : null,
+        status: status.state,
+        sessionFile: status.sessionFile,
+      }];
+
+    steps.forEach((step, index) => {
+      if (typeof step?.agent !== "string" || step.agent !== "dev-loop") {
+        return;
+      }
+
+      const key = recordKey(runId, index);
+      const record = records.get(key) ?? createRunRecord(runId, index);
+      const explicitOutputFile = typeof status.outputFile === "string"
+        ? status.outputFile
+        : path.join(asyncDir, `output-${index}.log`);
+
+      records.set(key, mergeRunRecord(record, {
+        agent: step.agent,
+        runState: step.status ?? rootState,
+        cwd,
+        sessionPath: typeof step.sessionFile === "string" ? step.sessionFile : defaultSessionPath,
+        statusPath,
+        eventsPath,
+        outputLogPath: explicitOutputFile,
+        timestampMs: typeof baseTimestamp === "number" ? baseTimestamp : null,
+        evidence: {
+          asyncDir,
+          statusPath,
+          eventsPath,
+          outputLogPath: explicitOutputFile,
+        },
+      }));
+    });
+  }
+}
+
+function extractResultOutputArtifactPath(result) {
+  const value = result?.artifactPaths;
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  if (typeof value.outputPath === "string") {
+    return value.outputPath;
+  }
+
+  if (typeof value.output === "string") {
+    return value.output;
+  }
+
+  for (const entry of Object.values(value)) {
+    if (typeof entry === "string" && entry.endsWith("_output.md")) {
+      return entry;
+    }
+  }
+
+  return null;
+}
+
+function parseRunIdFromTextSummary(text, fallbackName) {
+  const runLine = text.match(/^Run(?: ID)?:\s*(.+)$/imu);
+  if (runLine && typeof runLine[1] === "string" && runLine[1].trim().length > 0) {
+    return runLine[1].trim();
+  }
+
+  return fallbackName;
+}
+
+function parseSummaryPointers(text) {
+  const outputArtifactMatch = text.match(/^Output artifact:\s*(.+)$/imu);
+  const sessionMatch = text.match(/^Session:\s*(.+)$/imu);
+  const stateMatch = text.match(/^State:\s*(.+)$/imu);
+  const agentMatch = text.match(/^Agent:\s*(.+)$/imu);
+
+  return {
+    outputArtifactPath: outputArtifactMatch?.[1]?.trim() || null,
+    sessionPath: sessionMatch?.[1]?.trim() || null,
+    runState: stateMatch?.[1]?.trim() || null,
+    agent: agentMatch?.[1]?.trim() || null,
+  };
+}
+
+async function scanAsyncResultRoot(resultsRoot, records) {
+  const entries = await readdir(resultsRoot, { withFileTypes: true }).catch(() => []);
+
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    const filePath = path.join(resultsRoot, entry.name);
+    if (entry.name.endsWith(".json")) {
+      const result = await readJsonIfExists(filePath);
+      if (!result || typeof result !== "object") {
+        continue;
+      }
+
+      const runId = typeof result.runId === "string" && result.runId.trim().length > 0
+        ? result.runId.trim()
+        : (typeof result.id === "string" && result.id.trim().length > 0 ? result.id.trim() : null);
+      if (runId === null) {
+        continue;
+      }
+
+      const resultEntries = Array.isArray(result.results) && result.results.length > 0
+        ? result.results
+        : [{
+          agent: typeof result.agent === "string" ? result.agent : null,
+          sessionFile: typeof result.sessionFile === "string" ? result.sessionFile : null,
+          artifactPaths: result.artifactPaths,
+          output: typeof result.summary === "string" ? result.summary : undefined,
+        }];
+      const baseTimestamp = typeof result.timestamp === "number" ? result.timestamp : null;
+      const cwd = typeof result.cwd === "string" ? result.cwd : null;
+
+      resultEntries.forEach((child, index) => {
+        if (typeof child?.agent !== "string" || child.agent !== "dev-loop") {
+          return;
+        }
+
+        const key = recordKey(runId, index);
+        const record = records.get(key) ?? createRunRecord(runId, index);
+        records.set(key, mergeRunRecord(record, {
+          agent: child.agent,
+          runState: result.state,
+          cwd,
+          sessionPath: typeof child.sessionFile === "string" ? child.sessionFile : (typeof result.sessionFile === "string" ? result.sessionFile : null),
+          outputArtifactPath: extractResultOutputArtifactPath(child),
+          resultPath: filePath,
+          resultSummaryText: typeof child.output === "string" ? child.output : (typeof result.summary === "string" ? result.summary : null),
+          timestampMs: baseTimestamp,
+          evidence: { resultPath: filePath },
+        }));
+      });
+
+      continue;
+    }
+
+    if (!/\.(md|txt)$/iu.test(entry.name)) {
+      continue;
+    }
+
+    const text = await readTextIfExists(filePath);
+    if (text === null || (!text.includes("Output artifact:") && !text.includes("Session:"))) {
+      continue;
+    }
+
+    const runId = parseRunIdFromTextSummary(text, path.parse(entry.name).name);
+    const childIndex = 0;
+    const key = recordKey(runId, childIndex);
+    const record = records.get(key) ?? createRunRecord(runId, childIndex);
+    const pointers = parseSummaryPointers(text);
+
+    records.set(key, mergeRunRecord(record, {
+      agent: pointers.agent,
+      runState: pointers.runState,
+      sessionPath: pointers.sessionPath,
+      outputArtifactPath: pointers.outputArtifactPath,
+      resultSummaryPath: filePath,
+      resultSummaryText: text,
+      evidence: { resultSummaryPath: filePath },
+    }));
+  }
+}
+
+function collectConfiguredRoots(explicitRoots, envValue, fallbackRoots) {
+  if (Array.isArray(explicitRoots) && explicitRoots.length > 0) {
+    return [...new Set(explicitRoots.map((root) => path.resolve(root)))];
+  }
+
+  const fromEnv = splitPathList(envValue);
+  if (fromEnv.length > 0) {
+    return [...new Set(fromEnv.map((root) => path.resolve(root)))];
+  }
+
+  return [...new Set((fallbackRoots ?? []).map((root) => path.resolve(root)))];
+}
+
+async function detectDefaultAsyncRoots(kind) {
+  const tempDir = os.tmpdir();
+  const entries = await readdir(tempDir, { withFileTypes: true }).catch(() => []);
+  return entries
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith("pi-subagents-"))
+    .map((entry) => path.join(tempDir, entry.name, kind))
+    .filter((candidate) => existsSync(candidate));
+}
+
+async function resolveRepoIsolation(repoRoot) {
+  const normalizedRepoRoot = path.resolve(repoRoot);
+  const worktreeRoot = path.join(normalizedRepoRoot, "tmp", "worktrees");
+  const existingWorktrees = await listDirectoriesIfExists(worktreeRoot);
+
+  return {
+    repoRoot: normalizedRepoRoot,
+    worktreeRoot,
+    worktrees: existingWorktrees.map((entry) => path.resolve(entry)),
+  };
+}
+
+function isPathWithinRoot(candidate, root) {
+  if (typeof candidate !== "string" || typeof root !== "string") {
+    return false;
+  }
+
+  const normalizedCandidate = path.resolve(candidate);
+  const normalizedRoot = path.resolve(root);
+  return normalizedCandidate === normalizedRoot || normalizedCandidate.startsWith(`${normalizedRoot}${path.sep}`);
+}
+
+function recordMatchesRepo(record, repoIsolation) {
+  if (typeof record.cwd !== "string" || record.cwd.trim().length === 0) {
+    return false;
+  }
+
+  if (isPathWithinRoot(record.cwd, repoIsolation.repoRoot)) {
+    return true;
+  }
+
+  if (isPathWithinRoot(record.cwd, repoIsolation.worktreeRoot)) {
+    return true;
+  }
+
+  return repoIsolation.worktrees.some((worktree) => isPathWithinRoot(record.cwd, worktree));
+}
+
+function isStaleWorktreePath(filePath, repoIsolation) {
+  if (typeof filePath !== "string" || filePath.trim().length === 0) {
+    return false;
+  }
+
+  if (!isPathWithinRoot(filePath, repoIsolation.worktreeRoot)) {
+    return false;
+  }
+
+  return !existsSync(filePath);
+}
+
+export async function listRepoAsyncRuns(
+  { repo },
+  {
+    repoRoot = process.cwd(),
+    env = process.env,
+    sessionRoots,
+    asyncRunRoots,
+    asyncResultRoots,
+  } = {},
+) {
+  parseRepoSlug(repo);
+  const repoIsolation = await resolveRepoIsolation(repoRoot);
+  const resolvedSessionRoots = collectConfiguredRoots(
+    sessionRoots,
+    env.PI_AGENT_SESSIONS_DIR ?? env.PI_SUBAGENT_SESSIONS_DIR,
+    [DEFAULT_SESSION_ROOT],
+  );
+  const resolvedAsyncRunRoots = collectConfiguredRoots(
+    asyncRunRoots,
+    env.PI_SUBAGENT_ASYNC_RUNS_DIR,
+    await detectDefaultAsyncRoots("async-subagent-runs"),
+  );
+  const resolvedAsyncResultRoots = collectConfiguredRoots(
+    asyncResultRoots,
+    env.PI_SUBAGENT_ASYNC_RESULTS_DIR,
+    await detectDefaultAsyncRoots("async-subagent-results"),
+  );
+
+  const records = new Map();
+
+  for (const sessionRoot of resolvedSessionRoots) {
+    if (await pathExists(sessionRoot)) {
+      await scanSessionRunRoot(sessionRoot, records);
+    }
+  }
+
+  for (const asyncRoot of resolvedAsyncRunRoots) {
+    if (await pathExists(asyncRoot)) {
+      await scanAsyncRunRoot(asyncRoot, records);
+    }
+  }
+
+  for (const resultsRoot of resolvedAsyncResultRoots) {
+    if (await pathExists(resultsRoot)) {
+      await scanAsyncResultRoot(resultsRoot, records);
+    }
+  }
+
+  return [...records.values()]
+    .filter((record) => record.agent === "dev-loop")
+    .filter((record) => recordMatchesRepo(record, repoIsolation))
+    .map((record) => ({
+      ...record,
+      staleWorktree: isStaleWorktreePath(record.cwd, repoIsolation),
+      repoRoot: repoIsolation.repoRoot,
+      worktreeRoot: repoIsolation.worktreeRoot,
+    }));
+}
+
+function stripFormatting(value) {
+  return value
+    .replace(/`/gu, "")
+    .replace(/^\*+|\*+$/gu, "")
+    .trim();
+}
+
+function extractPrNumberFromLine(line) {
+  const trimmed = stripFormatting(line);
+  if (/\bActive PR:\s*none\b/i.test(trimmed)) {
+    return null;
+  }
+
+  const urlMatch = trimmed.match(/\/pull\/(\d+)\b/u);
+  if (urlMatch) {
+    return Number(urlMatch[1]);
+  }
+
+  const hashMatch = trimmed.match(/\bPR\s*#(\d+)\b/u);
+  if (hashMatch) {
+    return Number(hashMatch[1]);
+  }
+
+  const activePrMatch = trimmed.match(/^Active PR:\s*.+#(\d+)\b/ui);
+  if (activePrMatch) {
+    return Number(activePrMatch[1]);
+  }
+
+  const prLineMatch = trimmed.match(/^PR:\s*.+#(\d+)\b/ui);
+  if (prLineMatch) {
+    return Number(prLineMatch[1]);
+  }
+
+  const artifactMatch = trimmed.match(/^[-*]\s*Artifact(?:\/state)? inspected:\s*PR\s*#(\d+)\b/ui);
+  if (artifactMatch) {
+    return Number(artifactMatch[1]);
+  }
+
+  const mergedMatch = trimmed.match(/^PR merged:\s*#(\d+)\b/ui);
+  if (mergedMatch) {
+    return Number(mergedMatch[1]);
+  }
+
+  const statusMatch = trimmed.match(/^Status:.*\bPR\s*#(\d+)\b/ui);
+  if (statusMatch) {
+    return Number(statusMatch[1]);
+  }
+
+  return null;
+}
+
+function extractPrNumbersFromArtifactText(text) {
+  const numbers = new Set();
+  const lines = text.split(/\r?\n/u);
+
+  for (const line of lines) {
+    const number = extractPrNumberFromLine(line);
+    if (Number.isInteger(number)) {
+      numbers.add(number);
+    }
+  }
+
+  return [...numbers].sort((left, right) => left - right);
+}
+
+function parseArtifactState(text) {
+  const artifactStateLine = text.match(/^\**Artifact state:\**\s*(.+)$/imu)?.[1];
+  const statusLine = text.match(/^Status:\s*(.+)$/imu)?.[1];
+  const normalizedArtifact = stripFormatting(artifactStateLine ?? "").toLowerCase();
+  const normalizedStatus = stripFormatting(statusLine ?? "").toLowerCase();
+
+  const combined = `${normalizedArtifact}\n${normalizedStatus}`;
+  if (/\bmerged\b/u.test(combined)) {
+    return "merged";
+  }
+  if (/\bclosed\b/u.test(combined)) {
+    return "closed";
+  }
+  if (/\bopen\b/u.test(combined)) {
+    return "open";
+  }
+
+  return null;
+}
+
+function parseLoopState(text) {
+  const patterns = [
+    /^\**Loop state:\**\s*(.+)$/imu,
+    /^Current routed state:\s*(.+)$/imu,
+    /^-?\s*Copilot loop state:\s*(.+)$/imu,
+    /^-?\s*Routed strategy:\s*(.+)$/imu,
+  ];
+
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (match?.[1]) {
+      return stripFormatting(match[1]);
+    }
+  }
+
+  return null;
+}
+
+function parseNextActionText(text) {
+  const match = text.match(/^(?:Next action|Next recommended action):\s*(.+)$/imu);
+  if (match?.[1]) {
+    return stripFormatting(match[1]);
+  }
+
+  return null;
+}
+
+function classifyResumeBucket(text, parsedArtifactState) {
+  const normalized = text.toLowerCase();
+
+  if (
+    parsedArtifactState === "merged"
+    || /\bpr merged:\s*#\d+\b/u.test(normalized)
+    || /\bartifact state:\s*merged\b/u.test(normalized)
+  ) {
+    return RESUME_ACTION.DONE_OR_MERGED;
+  }
+
+  if (
+    /\bstop(?:ped)? at waiting_for_merge_authorization\b/u.test(normalized)
+    || /\bcurrent stop boundary:\s*waiting_for_merge_authorization\b/u.test(normalized)
+    || /\bstopping at waiting_for_merge_authorization\b/u.test(normalized)
+    || /\basking for explicit merge authorization\b/u.test(normalized)
+  ) {
+    return RESUME_ACTION.AWAIT_MERGE_AUTHORIZATION;
+  }
+
+  if (
+    /\bfinal human approval boundary\b/u.test(normalized)
+    || /\bfinal human approval readiness\b/u.test(normalized)
+    || /\brouted strategy:\s*`?final_approval`?/u.test(normalized)
+    || /\bhuman reviews\/approves pr\b/u.test(normalized)
+    || /\bawait final human approval\b/u.test(normalized)
+  ) {
+    return RESUME_ACTION.AWAIT_FINAL_APPROVAL;
+  }
+
+  if (
+    /\balready_fixed_needs_reply_resolve\b/u.test(normalized)
+    || /\breply(?:ing)? to and resolving the addressed github threads\b/u.test(normalized)
+    || /\breply to and resolve each github thread\b/u.test(normalized)
+  ) {
+    return RESUME_ACTION.NEEDS_REPLY_RESOLVE;
+  }
+
+  if (
+    /\bunresolved_feedback_present\b/u.test(normalized)
+    || /\baddress(?:ing)? review feedback\b/u.test(normalized)
+    || /\bfix(?:ing)? the remaining review feedback\b/u.test(normalized)
+    || /\bremaining review feedback\b/u.test(normalized)
+  ) {
+    return RESUME_ACTION.NEEDS_FEEDBACK_FIX;
+  }
+
+  if (
+    /\bwaiting_for_copilot_review\b/u.test(normalized)
+    || /\bready_to_rerequest_review\b/u.test(normalized)
+    || /\brequest(?:ing)? another copilot pass\b/u.test(normalized)
+    || /\bwatch(?:ing)? the next copilot review cycle\b/u.test(normalized)
+    || /\bcopilot review cycle\b/u.test(normalized)
+  ) {
+    return RESUME_ACTION.NEEDS_REREQUEST_OR_WATCH;
+  }
+
+  if (
+    /\bauthorization boundary\b/u.test(normalized)
+    || /\bdo not perform the next mutation without explicit approval\b/u.test(normalized)
+    || /\bready-for-review\b/u.test(normalized)
+    || /\bdraft review\b/u.test(normalized)
+    || /\bdraft_gate\b/u.test(normalized)
+  ) {
+    return RESUME_ACTION.AWAIT_READY_FOR_REVIEW_AUTHORIZATION;
+  }
+
+  return null;
+}
+
+function buildSourceSelection(record, outputArtifactText, resultSummaryText, outputLogText) {
+  if (outputArtifactText !== null) {
+    return {
+      primaryText: outputArtifactText,
+      primarySource: "output_artifact",
+      fallbackText: resultSummaryText,
+      weakFallbackText: outputLogText,
+    };
+  }
+
+  if (record.outputArtifactPath) {
+    if (resultSummaryText !== null) {
+      return {
+        primaryText: resultSummaryText,
+        primarySource: "grouped_result_summary",
+        fallbackText: null,
+        weakFallbackText: outputLogText,
+      };
+    }
+
+    return {
+      primaryText: null,
+      primarySource: "missing_output_artifact",
+      fallbackText: null,
+      weakFallbackText: outputLogText,
+    };
+  }
+
+  if (resultSummaryText !== null) {
+    return {
+      primaryText: resultSummaryText,
+      primarySource: "grouped_result_summary",
+      fallbackText: null,
+      weakFallbackText: outputLogText,
+    };
+  }
+
+  return {
+    primaryText: null,
+    primarySource: "weak_fallback_only",
+    fallbackText: null,
+    weakFallbackText: outputLogText,
+  };
+}
+
+function parseWeakFallbackPr(text) {
+  if (typeof text !== "string" || text.trim().length === 0) {
+    return null;
+  }
+
+  const prNumbers = extractPrNumbersFromArtifactText(text);
+  return prNumbers.length === 1 ? prNumbers[0] : null;
+}
+
+export async function parseDevLoopArtifact(record) {
+  const outputArtifactText = await readTextIfExists(record.outputArtifactPath);
+  const resultSummaryText = record.resultSummaryText ?? await readTextIfExists(record.resultSummaryPath);
+  const outputLogText = await readTextIfExists(record.outputLogPath);
+  const selection = buildSourceSelection(record, outputArtifactText, resultSummaryText, outputLogText);
+
+  if (selection.primaryText === null) {
+    return {
+      ok: false,
+      reason: MANUAL_REASON.MISSING_OUTPUT_ARTIFACT,
+      ...(Number.isInteger(parseWeakFallbackPr(selection.weakFallbackText)) ? { pr: parseWeakFallbackPr(selection.weakFallbackText) } : {}),
+      evidence: {
+        outputArtifactPath: record.outputArtifactPath,
+        resultSummaryPath: record.resultSummaryPath,
+        outputLogPath: record.outputLogPath,
+        sessionPath: record.sessionPath,
+      },
+      weakFallbackText: selection.weakFallbackText,
+      source: selection.primarySource,
+    };
+  }
+
+  const prNumbers = extractPrNumbersFromArtifactText(selection.primaryText);
+  if (prNumbers.length > 1) {
+    return {
+      ok: false,
+      reason: MANUAL_REASON.AMBIGUOUS_PR_IDENTITY,
+      evidence: {
+        prNumbers,
+        source: selection.primarySource,
+        outputArtifactPath: record.outputArtifactPath,
+        resultSummaryPath: record.resultSummaryPath,
+      },
+      source: selection.primarySource,
+    };
+  }
+
+  if (prNumbers.length === 0) {
+    return {
+      ok: false,
+      reason: MANUAL_REASON.MISSING_PR_IDENTITY,
+      evidence: {
+        source: selection.primarySource,
+        outputArtifactPath: record.outputArtifactPath,
+        resultSummaryPath: record.resultSummaryPath,
+      },
+      source: selection.primarySource,
+    };
+  }
+
+  const parsedArtifactState = parseArtifactState(selection.primaryText) ?? "open";
+  const parsedLoopState = parseLoopState(selection.primaryText);
+  const nextAction = parseNextActionText(selection.primaryText);
+  const resumeBucket = classifyResumeBucket(selection.primaryText, parsedArtifactState);
+
+  if (resumeBucket === null) {
+    return {
+      ok: false,
+      reason: MANUAL_REASON.UNCLASSIFIED_ARTIFACT_STATE,
+      pr: prNumbers[0],
+      evidence: {
+        source: selection.primarySource,
+        parsedArtifactState,
+        parsedLoopState,
+        nextAction,
+        outputArtifactPath: record.outputArtifactPath,
+        resultSummaryPath: record.resultSummaryPath,
+      },
+      source: selection.primarySource,
+    };
+  }
+
+  return {
+    ok: true,
+    pr: prNumbers[0],
+    parsedArtifactState,
+    parsedLoopState,
+    nextAction,
+    resumeBucket,
+    source: selection.primarySource,
+    text: selection.primaryText,
+  };
+}
+
+function buildResumeMessage({ pr, runId, resumeAction, livePrState }) {
+  switch (resumeAction) {
+    case RESUME_ACTION.NEEDS_FEEDBACK_FIX:
+      return `PR #${pr} is orphaned. Live state: unresolved_feedback_present. Resume the prior dev-loop from run ${runId}. Continue by fixing the remaining review feedback, then reply to and resolve each GitHub thread. Do not merge.`;
+    case RESUME_ACTION.NEEDS_REPLY_RESOLVE:
+      return `PR #${pr} is orphaned. Live state: already_fixed_needs_reply_resolve. Resume the prior dev-loop from run ${runId}. Continue by replying to and resolving the addressed GitHub threads before requesting another Copilot pass. Do not merge.`;
+    case RESUME_ACTION.NEEDS_REREQUEST_OR_WATCH:
+      return `PR #${pr} is orphaned. Live state: ${livePrState}. Resume the prior dev-loop from run ${runId}. Continue by requesting or watching the next Copilot review cycle on the current head. Do not enter gate or merge until the review settles.`;
+    case RESUME_ACTION.AWAIT_FINAL_APPROVAL:
+      return `PR #${pr} is orphaned. Live state: final_approval_ready. Resume the prior dev-loop from run ${runId}. Continue by summarizing the clean current-head evidence and stop at final human approval. Do not merge without explicit authorization.`;
+    case RESUME_ACTION.AWAIT_MERGE_AUTHORIZATION:
+      return `PR #${pr} is orphaned. Live state: clean current-head gate evidence + green CI. Resume the prior dev-loop from run ${runId}. Continue by stopping at waiting_for_merge_authorization and asking for explicit merge authorization. Do not merge automatically.`;
+    case RESUME_ACTION.AWAIT_READY_FOR_REVIEW_AUTHORIZATION:
+      return `PR #${pr} is orphaned. Live state: ${livePrState}. Resume the prior dev-loop from run ${runId}. Continue by staying at the current authorization boundary (assignment, ready-for-review, or draft review) and do not perform the next mutation without explicit approval.`;
+    default:
+      return `PR #${pr} is orphaned. Resume the prior dev-loop from run ${runId}. Continue from the last deterministic state and do not merge.`;
+  }
+}
+
+function buildResumeCommandPreview({ runId, childIndex, childCount, resumeMessage }) {
+  if (childCount > 1) {
+    return `subagent({ action: "resume", id: "${runId}", index: ${childIndex}, message: ${JSON.stringify(resumeMessage)} })`;
+  }
+
+  return `subagent({ action: "resume", id: "${runId}", message: ${JSON.stringify(resumeMessage)} })`;
+}
+
+function buildManualAttentionEntry({
+  pr = null,
+  runId = null,
+  reason,
+  evidence,
+  suggestedNextStep,
+}) {
+  return {
+    ...(Number.isInteger(pr) ? { pr } : {}),
+    ...(typeof runId === "string" && runId.length > 0 ? { runId } : {}),
+    reason,
+    evidence,
+    suggestedNextStep,
+  };
+}
+
+export function selectLatestExitedRunForPr({ pr, exitedRuns, activeRuns }) {
+  const activeMatch = activeRuns.filter((candidate) => candidate.parsedArtifact?.ok && candidate.parsedArtifact.pr === pr.number);
+  if (activeMatch.length > 0) {
+    return { kind: "suppressed_by_active_run", runIds: activeMatch.map((candidate) => candidate.run.runId) };
+  }
+
+  const matches = exitedRuns.filter((candidate) => candidate.parsedArtifact?.ok && candidate.parsedArtifact.pr === pr.number);
+  if (matches.length === 0) {
+    return { kind: "none" };
+  }
+
+  const sorted = [...matches].sort((left, right) => {
+    const leftTs = left.run.timestampMs ?? Number.NEGATIVE_INFINITY;
+    const rightTs = right.run.timestampMs ?? Number.NEGATIVE_INFINITY;
+    return rightTs - leftTs;
+  });
+
+  if (sorted.length > 1) {
+    const firstTimestamp = sorted[0].run.timestampMs;
+    const secondTimestamp = sorted[1].run.timestampMs;
+    if (firstTimestamp === null || secondTimestamp === null || firstTimestamp === secondTimestamp) {
+      return {
+        kind: "manual_attention",
+        reason: MANUAL_REASON.MULTIPLE_CANDIDATE_RUNS,
+        runs: sorted.map((candidate) => ({
+          runId: candidate.run.runId,
+          childIndex: candidate.run.childIndex,
+          timestampMs: candidate.run.timestampMs,
+          outputArtifactPath: candidate.run.outputArtifactPath,
+          sessionPath: candidate.run.sessionPath,
+        })),
+      };
+    }
+  }
+
+  return { kind: "selected", candidate: sorted[0] };
+}
+
+function classifyLiveStateForResume(resumeAction, prReport) {
+  switch (resumeAction) {
+    case RESUME_ACTION.NEEDS_FEEDBACK_FIX:
+      return "unresolved_feedback_present";
+    case RESUME_ACTION.NEEDS_REPLY_RESOLVE:
+      return "already_fixed_needs_reply_resolve";
+    case RESUME_ACTION.NEEDS_REREQUEST_OR_WATCH:
+      return prReport.state;
+    case RESUME_ACTION.AWAIT_FINAL_APPROVAL:
+      return "final_approval_ready";
+    case RESUME_ACTION.AWAIT_MERGE_AUTHORIZATION:
+      return "clean current-head gate evidence + green CI";
+    case RESUME_ACTION.AWAIT_READY_FOR_REVIEW_AUTHORIZATION:
+      return prReport.isDraft ? "pr_draft" : prReport.state;
+    default:
+      return prReport.state;
+  }
+}
+
+function hasMaterialConflict(resumeAction, prReport, parsedArtifact) {
+  if (parsedArtifact.parsedArtifactState === "merged" || resumeAction === RESUME_ACTION.DONE_OR_MERGED) {
+    return true;
+  }
+
+  if (resumeAction === RESUME_ACTION.AWAIT_FINAL_APPROVAL) {
+    return prReport.snapshot.unresolvedThreadCount > 0 || prReport.snapshot.ciStatus === "failure";
+  }
+
+  if (resumeAction === RESUME_ACTION.AWAIT_MERGE_AUTHORIZATION) {
+    return prReport.snapshot.unresolvedThreadCount > 0 || prReport.snapshot.ciStatus !== "success";
+  }
+
+  if (resumeAction === RESUME_ACTION.NEEDS_REREQUEST_OR_WATCH) {
+    return prReport.state === "unresolved_feedback_present" && parsedArtifact.resumeBucket !== RESUME_ACTION.NEEDS_REPLY_RESOLVE;
+  }
+
+  return false;
+}
+
+export function buildResumePlan({ prReport, candidate, childCounts }) {
+  const { run, parsedArtifact } = candidate;
+  const resumeAction = parsedArtifact.resumeBucket;
+
+  if (hasMaterialConflict(resumeAction, prReport, parsedArtifact)) {
+    return {
+      kind: "manual_attention",
+      entry: buildManualAttentionEntry({
+        pr: prReport.number,
+        runId: run.runId,
+        reason: MANUAL_REASON.ARTIFACT_LIVE_STATE_CONFLICT,
+        evidence: {
+          parsedArtifactState: parsedArtifact.parsedArtifactState,
+          parsedLoopState: parsedArtifact.parsedLoopState,
+          resumeAction,
+          livePrState: prReport.state,
+          outputArtifactPath: run.outputArtifactPath,
+          sessionPath: run.sessionPath,
+        },
+        suggestedNextStep: "Reconcile the live PR state against the exited run artifact before resuming.",
+      }),
+    };
+  }
+
+  if (run.staleWorktree && !run.sessionPath && !run.outputArtifactPath && !run.resultSummaryPath) {
+    return {
+      kind: "manual_attention",
+      entry: buildManualAttentionEntry({
+        pr: prReport.number,
+        runId: run.runId,
+        reason: MANUAL_REASON.STALE_WORKTREE_MISSING_RESUME_INPUTS,
+        evidence: {
+          cwd: run.cwd,
+          sessionPath: run.sessionPath,
+          outputArtifactPath: run.outputArtifactPath,
+          resultSummaryPath: run.resultSummaryPath,
+        },
+        suggestedNextStep: "Recover or recreate the missing worktree/session inputs before attempting resume.",
+      }),
+    };
+  }
+
+  const livePrState = classifyLiveStateForResume(resumeAction, prReport);
+  const resumeMessage = buildResumeMessage({
+    pr: prReport.number,
+    runId: run.runId,
+    resumeAction,
+    livePrState,
+  });
+  const childCount = childCounts.get(run.runId) ?? 1;
+
+  return {
+    kind: "resume_plan",
+    entry: {
+      pr: prReport.number,
+      runId: run.runId,
+      runState: normalizeRunStateForPlan(run.runState),
+      artifactPath: run.outputArtifactPath ?? null,
+      ...(run.sessionPath ? { sessionPath: run.sessionPath } : {}),
+      parsedArtifactState: parsedArtifact.parsedArtifactState,
+      parsedLoopState: parsedArtifact.parsedLoopState,
+      livePrState,
+      resumeAction,
+      resumeMessage,
+      resumeCommandPreview: buildResumeCommandPreview({
+        runId: run.runId,
+        childIndex: run.childIndex,
+        childCount,
+        resumeMessage,
+      }),
+      staleWorktree: run.staleWorktree,
+    },
+  };
+}
+
+async function analyzeAutoResume({ repo, reports }, options) {
+  const runs = await listRepoAsyncRuns({ repo }, options);
+  const childCounts = runs.reduce((map, run) => {
+    map.set(run.runId, (map.get(run.runId) ?? 0) + 1);
+    return map;
+  }, new Map());
+
+  const activeRuns = [];
+  const exitedRuns = [];
+  const manualAttention = [];
+
+  for (const run of runs) {
+    const parsedArtifact = await parseDevLoopArtifact(run);
+    let candidate = { run, parsedArtifact };
+
+    if (!parsedArtifact.ok) {
+      if (isRunningLikeState(run.runState)) {
+        const runningPr = parseWeakFallbackPr(parsedArtifact.weakFallbackText ?? null);
+        if (Number.isInteger(runningPr)) {
+          activeRuns.push({
+            run,
+            parsedArtifact: {
+              ok: true,
+              pr: runningPr,
+              parsedArtifactState: "open",
+              parsedLoopState: null,
+              nextAction: null,
+              resumeBucket: RESUME_ACTION.NEEDS_REREQUEST_OR_WATCH,
+              source: "weak_fallback_output_log",
+              text: parsedArtifact.weakFallbackText,
+            },
+          });
+        }
+        continue;
+      }
+
+      if (run.runState === RUN_STATE.UNKNOWN || isExitedState(run.runState)) {
+        manualAttention.push(buildManualAttentionEntry({
+          pr: Number.isInteger(parsedArtifact.pr) ? parsedArtifact.pr : null,
+          runId: run.runId,
+          reason: parsedArtifact.reason,
+          evidence: {
+            ...parsedArtifact.evidence,
+            cwd: run.cwd,
+            sessionPath: run.sessionPath,
+            outputLogPath: run.outputLogPath,
+          },
+          suggestedNextStep: parsedArtifact.reason === MANUAL_REASON.MISSING_OUTPUT_ARTIFACT
+            ? "Locate the missing output artifact or inspect the saved session before attempting resume."
+            : "Inspect the saved artifact/session manually and reconcile the PR identity/state before resuming.",
+        }));
+      }
+      continue;
+    }
+
+    candidate = { run, parsedArtifact };
+    if (isRunningLikeState(run.runState)) {
+      activeRuns.push(candidate);
+      continue;
+    }
+
+    if (isExitedState(run.runState) || run.runState === RUN_STATE.UNKNOWN) {
+      exitedRuns.push(candidate);
+    }
+  }
+
+  const resumePlans = [];
+  for (const prReport of reports) {
+    const selection = selectLatestExitedRunForPr({ pr: prReport, exitedRuns, activeRuns });
+
+    if (selection.kind === "manual_attention") {
+      manualAttention.push(buildManualAttentionEntry({
+        pr: prReport.number,
+        reason: selection.reason,
+        evidence: { runs: selection.runs },
+        suggestedNextStep: "Choose the correct exited run manually before attempting resume.",
+      }));
+      continue;
+    }
+
+    if (selection.kind !== "selected") {
+      continue;
+    }
+
+    const built = buildResumePlan({
+      prReport,
+      candidate: selection.candidate,
+      childCounts,
+    });
+
+    if (built.kind === "manual_attention") {
+      manualAttention.push(built.entry);
+      continue;
+    }
+
+    resumePlans.push(built.entry);
+  }
+
+  const orphanedPrs = new Set();
+  resumePlans.forEach((plan) => orphanedPrs.add(plan.pr));
+  manualAttention.forEach((entry) => {
+    if (Number.isInteger(entry.pr)) {
+      orphanedPrs.add(entry.pr);
+    }
+  });
+
+  return {
+    orphanedPrCount: orphanedPrs.size,
+    resumePlanCount: resumePlans.length,
+    manualAttentionCount: manualAttention.length,
+    resumePlans,
+    needsManualAttention: manualAttention,
+  };
+}
+
+function applyAutoResumeToBaseResult(baseResult, autoResume) {
+  const orphanAttentionPrs = new Set();
+  autoResume.resumePlans.forEach((entry) => orphanAttentionPrs.add(entry.pr));
+  autoResume.needsManualAttention.forEach((entry) => {
+    if (Number.isInteger(entry.pr)) {
+      orphanAttentionPrs.add(entry.pr);
+    }
+  });
+
+  const queueNeedsAttention = baseResult.queueStatus === "attention_needed"
+    || autoResume.resumePlanCount > 0
+    || autoResume.manualAttentionCount > 0;
+  const queueStatus = baseResult.prCount === 0
+    ? "queue_complete"
+    : (queueNeedsAttention ? "attention_needed" : "monitoring");
+  const liveAttentionPrs = new Set(baseResult.prs.filter((pr) => pr.needsAttention).map((pr) => pr.number));
+  const needsAttentionCount = new Set([...liveAttentionPrs, ...orphanAttentionPrs]).size;
+
+  return {
+    ...baseResult,
+    queueStatus,
+    needsAttentionCount,
+    autoResumeRequested: true,
+    orphanedPrCount: autoResume.orphanedPrCount,
+    resumePlanCount: autoResume.resumePlanCount,
+    manualAttentionCount: autoResume.manualAttentionCount,
+    resumePlans: autoResume.resumePlans,
+    needsManualAttention: autoResume.needsManualAttention,
+  };
+}
+
+export async function runConductorMonitor(
+  { repo, autoResume = false },
+  {
+    env = process.env,
+    ghCommand = "gh",
+    repoRoot = process.cwd(),
+    sessionRoots,
+    asyncRunRoots,
+    asyncResultRoots,
+  } = {},
+) {
+  const prs = await listOpenPrs({ repo }, { env, ghCommand });
+  if (prs.length === 0) {
+    const baseResult = buildBaseResult(repo, []);
+    if (!autoResume) {
+      return baseResult;
+    }
+
+    return applyAutoResumeToBaseResult(baseResult, {
+      orphanedPrCount: 0,
+      resumePlanCount: 0,
+      manualAttentionCount: 0,
+      resumePlans: [],
+      needsManualAttention: [],
+    });
+  }
+
+  const reports = await buildPrReports(prs, { repo, env, ghCommand });
+  const baseResult = buildBaseResult(repo, reports);
+  if (!autoResume) {
+    return baseResult;
+  }
+
+  const autoResumeResult = await analyzeAutoResume({ repo, reports }, {
+    env,
+    repoRoot,
+    sessionRoots,
+    asyncRunRoots,
+    asyncResultRoots,
+  });
+  return applyAutoResumeToBaseResult(baseResult, autoResumeResult);
+}
+
 export async function runCli(
   argv = process.argv.slice(2),
-  { stdout = process.stdout, env = process.env, ghCommand = "gh" } = {},
+  { stdout = process.stdout, env = process.env, ghCommand = "gh", cwd = process.cwd() } = {},
 ) {
   const options = parseCliArgs(argv);
 
@@ -255,7 +1591,11 @@ export async function runCli(
     return;
   }
 
-  const result = await runConductorMonitor(options, { env, ghCommand });
+  const result = await runConductorMonitor(options, {
+    env,
+    ghCommand,
+    repoRoot: cwd,
+  });
   stdout.write(`${JSON.stringify(result)}\n`);
 }
 

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -464,7 +464,10 @@ function parseRunIdFromArtifactName(name) {
 }
 
 async function scanSessionArtifactRoot(artifactsDir, records) {
-  const entries = await readdir(artifactsDir, { withFileTypes: true });
+  const entries = await readdir(artifactsDir, { withFileTypes: true }).catch(() => null);
+  if (entries === null) {
+    return;
+  }
 
   for (const entry of entries) {
     if (!entry.isFile()) {
@@ -543,7 +546,14 @@ async function scanSessionRunRoot(root, records) {
         const sessionPath = path.join(runRoot, runDirectory.name, "session.jsonl");
         const headerText = await readTextIfExists(sessionPath);
         const firstLine = headerText?.split(/\r?\n/u, 1)[0] ?? null;
-        const header = firstLine ? parseJsonText(firstLine) : null;
+        let header = null;
+        if (firstLine) {
+          try {
+            header = parseJsonText(firstLine);
+          } catch {
+            header = null;
+          }
+        }
         const key = recordKey(runId, childIndex);
         const record = records.get(key) ?? createRunRecord(runId, childIndex);
 
@@ -1277,12 +1287,38 @@ export function selectLatestExitedRunForPr({ pr, exitedRuns, activeRuns }) {
 
   const selected = sorted[0];
   const selectedTimestamp = selected.run.timestampMs;
-  const newerActiveRuns = activeMatch.filter((candidate) => {
-    const activeTimestamp = candidate.run.timestampMs;
-    return typeof activeTimestamp === "number"
-      && typeof selectedTimestamp === "number"
-      && activeTimestamp > selectedTimestamp;
-  });
+  if (activeMatch.length > 0) {
+    const indeterminateActiveRuns = activeMatch.filter((candidate) => (
+      typeof candidate.run.timestampMs !== "number"
+      || typeof selectedTimestamp !== "number"
+    ));
+
+    if (indeterminateActiveRuns.length > 0) {
+      return {
+        kind: "manual_attention",
+        reason: MANUAL_REASON.ARTIFACT_LIVE_STATE_CONFLICT,
+        runs: [
+          {
+            runId: selected.run.runId,
+            childIndex: selected.run.childIndex,
+            timestampMs: selected.run.timestampMs,
+            outputArtifactPath: selected.run.outputArtifactPath,
+            sessionPath: selected.run.sessionPath,
+          },
+          ...indeterminateActiveRuns.map((candidate) => ({
+            runId: candidate.run.runId,
+            childIndex: candidate.run.childIndex,
+            timestampMs: candidate.run.timestampMs,
+            outputArtifactPath: candidate.run.outputArtifactPath,
+            sessionPath: candidate.run.sessionPath,
+            runState: candidate.run.runState,
+          })),
+        ],
+      };
+    }
+  }
+
+  const newerActiveRuns = activeMatch.filter((candidate) => candidate.run.timestampMs > selectedTimestamp);
 
   if (newerActiveRuns.length > 0) {
     return {
@@ -1409,6 +1445,7 @@ export function buildResumePlan({ prReport, candidate, childCounts }) {
 }
 
 async function analyzeAutoResume({ repo, reports }, options) {
+  const openPrNumbers = new Set(reports.map((report) => report.number));
   const runs = await listRepoAsyncRuns({ repo }, options);
   const childCounts = runs.reduce((map, run) => {
     map.set(run.runId, (map.get(run.runId) ?? 0) + 1);
@@ -1444,7 +1481,12 @@ async function analyzeAutoResume({ repo, reports }, options) {
         continue;
       }
 
-      if (run.runState === RUN_STATE.UNKNOWN || isExitedState(run.runState)) {
+      const parsedNumbers = Array.isArray(parsedArtifact.evidence?.prNumbers)
+        ? parsedArtifact.evidence.prNumbers.filter((value) => Number.isInteger(value))
+        : [];
+      const touchesOpenPr = openPrNumbers.has(parsedArtifact.pr)
+        || parsedNumbers.some((value) => openPrNumbers.has(value));
+      if ((run.runState === RUN_STATE.UNKNOWN || isExitedState(run.runState)) && touchesOpenPr) {
         manualAttention.push(buildManualAttentionEntry({
           pr: Number.isInteger(parsedArtifact.pr) ? parsedArtifact.pr : null,
           runId: run.runId,

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -453,14 +453,18 @@ function recordKey(runId, childIndex) {
   return `${runId}:${childIndex}`;
 }
 
-function parseChildIndexFromArtifactName(name) {
-  const match = name.match(/_(\d+)_/u);
-  return match ? Number(match[1]) : 0;
-}
+function parseArtifactFileName(name) {
+  const match = name.match(/^(?<runId>.+)_(?<agent>[^_]+)_(?<index>\d+)_(?<kind>meta\.json|output\.md|input\.md)$/u);
+  if (!match?.groups) {
+    return null;
+  }
 
-function parseRunIdFromArtifactName(name) {
-  const match = name.match(/^([^_]+)_/u);
-  return match ? match[1] : null;
+  return {
+    runId: match.groups.runId,
+    agent: match.groups.agent,
+    childIndex: Number(match.groups.index),
+    kind: match.groups.kind,
+  };
 }
 
 async function scanSessionArtifactRoot(artifactsDir, records) {
@@ -474,12 +478,12 @@ async function scanSessionArtifactRoot(artifactsDir, records) {
       continue;
     }
 
-    const runId = parseRunIdFromArtifactName(entry.name);
-    if (runId === null) {
+    const parsedName = parseArtifactFileName(entry.name);
+    if (parsedName === null) {
       continue;
     }
 
-    const childIndex = parseChildIndexFromArtifactName(entry.name);
+    const { runId, childIndex, agent } = parsedName;
     const key = recordKey(runId, childIndex);
     const record = records.get(key) ?? createRunRecord(runId, childIndex);
     const filePath = path.join(artifactsDir, entry.name);
@@ -488,7 +492,7 @@ async function scanSessionArtifactRoot(artifactsDir, records) {
       const meta = await readJsonIfExists(filePath);
       if (meta && typeof meta === "object") {
         records.set(key, mergeRunRecord(record, {
-          agent: typeof meta.agent === "string" ? meta.agent : record.agent,
+          agent: typeof meta.agent === "string" ? meta.agent : (record.agent ?? agent),
           metaPath: filePath,
           runState: Number(meta.exitCode) === 0 ? RUN_STATE.COMPLETED : RUN_STATE.FAILED,
           timestampMs: typeof meta.timestamp === "number" ? meta.timestamp : null,
@@ -504,6 +508,7 @@ async function scanSessionArtifactRoot(artifactsDir, records) {
     if (entry.name.endsWith("_output.md")) {
       records.set(key, mergeRunRecord(record, {
         outputArtifactPath: filePath,
+        agent: record.agent ?? agent,
         evidence: { outputArtifactPath: filePath },
       }));
     }
@@ -972,6 +977,9 @@ function parseArtifactState(text) {
   if (/\bopen\b/u.test(combined)) {
     return "open";
   }
+  if (/final human approval|waiting_for_merge_authorization|advanced to the final human approval boundary|inspected and advanced/u.test(combined)) {
+    return "open";
+  }
 
   return null;
 }
@@ -1177,9 +1185,24 @@ export async function parseDevLoopArtifact(record) {
     };
   }
 
-  const parsedArtifactState = parseArtifactState(selection.primaryText) ?? "open";
+  const parsedArtifactState = parseArtifactState(selection.primaryText);
   const parsedLoopState = parseLoopState(selection.primaryText);
   const nextAction = parseNextActionText(selection.primaryText);
+  if (parsedArtifactState === null) {
+    return {
+      ok: false,
+      reason: MANUAL_REASON.UNCLASSIFIED_ARTIFACT_STATE,
+      pr: prNumbers[0],
+      evidence: {
+        source: selection.primarySource,
+        parsedLoopState,
+        nextAction,
+        outputArtifactPath: record.outputArtifactPath,
+        resultSummaryPath: record.resultSummaryPath,
+      },
+      source: selection.primarySource,
+    };
+  }
   const resumeBucket = classifyResumeBucket(selection.primaryText, parsedArtifactState);
 
   if (resumeBucket === null) {
@@ -1511,8 +1534,23 @@ async function analyzeAutoResume({ repo, reports }, options) {
       continue;
     }
 
-    if (isExitedState(run.runState) || run.runState === RUN_STATE.UNKNOWN) {
+    if (isExitedState(run.runState)) {
       exitedRuns.push(candidate);
+      continue;
+    }
+
+    if (run.runState === RUN_STATE.UNKNOWN && openPrNumbers.has(parsedArtifact.pr)) {
+      manualAttention.push(buildManualAttentionEntry({
+        pr: parsedArtifact.pr,
+        runId: run.runId,
+        reason: MANUAL_REASON.ARTIFACT_LIVE_STATE_CONFLICT,
+        evidence: {
+          runState: run.runState,
+          outputArtifactPath: run.outputArtifactPath,
+          sessionPath: run.sessionPath,
+        },
+        suggestedNextStep: "Resolve the run state for this candidate before preparing a resume plan.",
+      }));
     }
   }
 

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -507,7 +507,9 @@ async function scanSessionArtifactRoot(artifactsDir, records) {
         records.set(key, mergeRunRecord(record, {
           agent: typeof meta.agent === "string" ? meta.agent : (record.agent ?? agent),
           metaPath: filePath,
-          runState: Number(meta.exitCode) === 0 ? RUN_STATE.COMPLETED : RUN_STATE.FAILED,
+          ...(Number.isInteger(meta.exitCode) ? {
+            runState: meta.exitCode === 0 ? RUN_STATE.COMPLETED : RUN_STATE.FAILED,
+          } : {}),
           timestampMs: typeof meta.timestamp === "number" ? meta.timestamp : null,
           evidence: {
             metaPath: filePath,
@@ -1357,6 +1359,31 @@ export function selectLatestExitedRunForPr({ pr, exitedRuns, activeRuns }) {
     }
   }
 
+  const sameTimestampActiveRuns = activeMatch.filter((candidate) => candidate.run.timestampMs === selectedTimestamp);
+  if (sameTimestampActiveRuns.length > 0) {
+    return {
+      kind: "manual_attention",
+      reason: MANUAL_REASON.ARTIFACT_LIVE_STATE_CONFLICT,
+      runs: [
+        {
+          runId: selected.run.runId,
+          childIndex: selected.run.childIndex,
+          timestampMs: selected.run.timestampMs,
+          outputArtifactPath: selected.run.outputArtifactPath,
+          sessionPath: selected.run.sessionPath,
+        },
+        ...sameTimestampActiveRuns.map((candidate) => ({
+          runId: candidate.run.runId,
+          childIndex: candidate.run.childIndex,
+          timestampMs: candidate.run.timestampMs,
+          outputArtifactPath: candidate.run.outputArtifactPath,
+          sessionPath: candidate.run.sessionPath,
+          runState: candidate.run.runState,
+        })),
+      ],
+    };
+  }
+
   const newerActiveRuns = activeMatch.filter((candidate) => candidate.run.timestampMs > selectedTimestamp);
 
   if (newerActiveRuns.length > 0) {
@@ -1432,7 +1459,7 @@ export function buildResumePlan({ prReport, candidate, childCounts }) {
     };
   }
 
-  if (run.staleWorktree && !run.sessionPath && !run.outputArtifactPath && !run.resultSummaryPath) {
+  if (run.staleWorktree && !run.sessionPath && !run.outputArtifactPath && !run.resultSummaryPath && !run.resultPath) {
     return {
       kind: "manual_attention",
       entry: buildManualAttentionEntry({

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -773,6 +773,38 @@ test("conductor-monitor --auto-resume keeps stale-worktree runs resumable when J
   }
 });
 
+test("conductor-monitor --auto-resume includes a non-zero child index in the resume preview even when only one child matches", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-nonzero-child-index-"));
+  const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    await writeSessionRun({
+      sessionsRoot,
+      runId: "run-child-62",
+      childIndex: 1,
+      cwd: repoRoot,
+      timestampMs: 1700000017000,
+      outputText: "Active PR: owner/repo#62\nArtifact state: open\nLoop state: unresolved_feedback_present\n",
+    });
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{
+        number: 62,
+        reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
+        statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+        threadsPayload: mixedThreadsFixture,
+      }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.resumePlanCount, 1);
+    assert.match(payload.resumePlans[0].resumeCommandPreview, /index: 1/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("conductor-monitor --auto-resume emits a feedback-fix resume plan for an orphaned unresolved-feedback PR", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-fix-"));
   const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -652,6 +652,127 @@ test("conductor-monitor --auto-resume uses grouped result summaries as the artif
   }
 });
 
+test("conductor-monitor --auto-resume fails closed when an active matching run has the same timestamp as the exited candidate", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-same-timestamp-active-run-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const { sessionPath } = await writeSessionRun({
+      sessionsRoot,
+      runId: "run-complete-59",
+      cwd: repoRoot,
+      timestampMs: 1700000015000,
+      outputText: "Active PR: owner/repo#59\nArtifact state: open\nLoop state: waiting_for_copilot_review\n",
+    });
+    await writeAsyncRun({
+      asyncRunsRoot,
+      runId: "run-active-59",
+      state: "running",
+      cwd: repoRoot,
+      sessionPath,
+      timestampMs: 1700000015000,
+      outputText: "Active PR: owner/repo#59\nLoop state: waiting_for_copilot_review\n",
+    });
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{ number: 59, requestCopilot: true }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.resumePlanCount, 0);
+    assert.equal(payload.manualAttentionCount, 1);
+    assert.equal(payload.needsManualAttention[0].pr, 59);
+    assert.equal(payload.needsManualAttention[0].reason, "artifact_live_state_conflict");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume does not invent a failed run state from meta without an integer exitCode", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-invalid-meta-exitcode-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const sessionRoot = path.join(sessionsRoot, "2026-06-03T00-00-00-000Z_session");
+    const artifactsDir = path.join(sessionRoot, "subagent-artifacts");
+    const runDir = path.join(sessionRoot, "run-meta-60", "run-0");
+    const statusPath = path.join(asyncRunsRoot, "run-meta-60", "status.json");
+    await mkdir(artifactsDir, { recursive: true });
+    await mkdir(runDir, { recursive: true });
+    await writeFile(path.join(artifactsDir, "run-meta-60_dev-loop_0_meta.json"), `${JSON.stringify({ runId: "run-meta-60", agent: "dev-loop", timestamp: 1700000016000 }, null, 2)}
+`, "utf8");
+    await writeFile(path.join(artifactsDir, "run-meta-60_dev-loop_0_output.md"), "Active PR: owner/repo#60\nArtifact state: open\nLoop state: waiting_for_copilot_review\n", "utf8");
+    await writeFile(path.join(runDir, "session.jsonl"), `${JSON.stringify({ type: "session", version: 3, id: "run-meta-60-session", timestamp: "2026-06-03T00:00:00.000Z", cwd: repoRoot })}\n`, "utf8");
+    await writeAsyncRun({
+      asyncRunsRoot,
+      runId: "run-meta-60",
+      state: "complete",
+      cwd: repoRoot,
+      sessionPath: path.join(runDir, "session.jsonl"),
+      timestampMs: 1700000016500,
+      outputText: "Active PR: owner/repo#60\nLoop state: waiting_for_copilot_review\n",
+    });
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{ number: 60, requestCopilot: true }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.resumePlanCount, 1);
+    assert.equal(payload.resumePlans[0].runState, "completed");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume keeps stale-worktree runs resumable when JSON result evidence is the only surviving artifact", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-stale-worktree-result-json-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const staleWorktreePath = path.join(repoRoot, "tmp", "worktrees", "issue-61-stale");
+    const resultPath = path.join(asyncResultsRoot, "run-result-61.json");
+    await writeFile(resultPath, `${JSON.stringify({
+      runId: "run-result-61",
+      agent: "dev-loop",
+      state: "complete",
+      cwd: staleWorktreePath,
+      summary: [
+        "Run: run-result-61",
+        "State: complete",
+        "Agent: dev-loop",
+        "Active PR: owner/repo#61",
+        "Artifact state: open",
+        "Loop state: waiting_for_copilot_review",
+      ].join("\n"),
+      results: [{
+        agent: "dev-loop",
+        output: [
+          "Run: run-result-61",
+          "State: complete",
+          "Agent: dev-loop",
+          "Active PR: owner/repo#61",
+          "Artifact state: open",
+          "Loop state: waiting_for_copilot_review",
+        ].join("\n"),
+      }],
+    }, null, 2)}
+`, "utf8");
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{ number: 61, requestCopilot: true }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.resumePlanCount, 1);
+    assert.equal(payload.resumePlans[0].pr, 61);
+    assert.equal(payload.resumePlans[0].staleWorktree, true);
+    assert.equal(payload.resumePlans[0].artifactPath, resultPath);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("conductor-monitor --auto-resume emits a feedback-fix resume plan for an orphaned unresolved-feedback PR", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-fix-"));
   const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import { runConductorMonitor } from "../../scripts/loop/conductor-monitor.mjs";
 import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
 
 const scriptPath = path.resolve("scripts/loop/conductor-monitor.mjs");
@@ -30,6 +31,165 @@ function emptyThreadsPayload() {
   });
 }
 
+function buildPrListEntry(pr) {
+  return {
+    number: pr.number,
+    title: pr.title ?? `PR ${pr.number}`,
+    url: pr.url ?? `https://github.com/${pr.repo ?? "owner/repo"}/pull/${pr.number}`,
+    isDraft: Boolean(pr.isDraft),
+    headRefName: pr.headRefName ?? `copilot/pr-${pr.number}`,
+    author: { login: pr.authorLogin ?? "copilot-swe-agent" },
+  };
+}
+
+function buildPrViewEntry(pr) {
+  return {
+    isDraft: Boolean(pr.isDraft),
+    state: pr.state ?? "OPEN",
+    number: pr.number,
+    reviews: pr.reviews ?? [],
+    statusCheckRollup: pr.statusCheckRollup ?? [],
+  };
+}
+
+function buildRequestedReviewersPayload(pr) {
+  if (Array.isArray(pr.requestedReviewers)) {
+    return JSON.stringify({ users: pr.requestedReviewers, teams: [] });
+  }
+
+  return pr.requestCopilot === true
+    ? JSON.stringify({ users: [{ login: "copilot-pull-request-reviewer[bot]" }], teams: [] })
+    : JSON.stringify({ users: [], teams: [] });
+}
+
+function buildGhEntries({ repo = "owner/repo", prs }) {
+  const entries = [{
+    assertArgs: ["pr", "list", "--repo", repo, "--state", "open", "--limit", "1000", "--json", "number,title,url,isDraft,headRefName,author"],
+    stdout: `${JSON.stringify(prs.map((pr) => buildPrListEntry({ ...pr, repo })))}\n`,
+  }];
+
+  for (const pr of prs) {
+    entries.push(
+      {
+        assertArgs: ["pr", "view", String(pr.number), "--repo", repo],
+        stdout: `${JSON.stringify(buildPrViewEntry(pr))}\n`,
+      },
+      {
+        assertArgs: ["api", `repos/${repo}/pulls/${pr.number}/requested_reviewers`],
+        stdout: `${buildRequestedReviewersPayload(pr)}\n`,
+      },
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: `${pr.threadsPayload ?? emptyThreadsPayload()}\n`,
+      },
+    );
+  }
+
+  return entries;
+}
+
+async function createAutoResumeRoots(tempDir) {
+  const repoRoot = path.join(tempDir, "repo");
+  const sessionsRoot = path.join(tempDir, "sessions-root");
+  const asyncRunsRoot = path.join(tempDir, "async-runs-root");
+  const asyncResultsRoot = path.join(tempDir, "async-results-root");
+
+  await mkdir(path.join(repoRoot, "tmp", "worktrees"), { recursive: true });
+  await mkdir(sessionsRoot, { recursive: true });
+  await mkdir(asyncRunsRoot, { recursive: true });
+  await mkdir(asyncResultsRoot, { recursive: true });
+
+  return { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot };
+}
+
+async function writeSessionRun({
+  sessionsRoot,
+  runId,
+  childIndex = 0,
+  agent = "dev-loop",
+  cwd,
+  outputText = null,
+  exitCode = 0,
+  timestampMs = 1700000000000,
+  writeOutputArtifact = true,
+}) {
+  const artifactsDir = path.join(sessionsRoot, "subagent-artifacts");
+  const sessionDir = path.join(sessionsRoot, "2026-06-03T00-00-00-000Z_session", runId, `run-${childIndex}`);
+  const artifactBase = `${runId}_${agent}_${childIndex}`;
+  const metaPath = path.join(artifactsDir, `${artifactBase}_meta.json`);
+  const outputArtifactPath = path.join(artifactsDir, `${artifactBase}_output.md`);
+  const sessionPath = path.join(sessionDir, "session.jsonl");
+
+  await mkdir(artifactsDir, { recursive: true });
+  await mkdir(sessionDir, { recursive: true });
+  await writeFile(metaPath, `${JSON.stringify({ runId, agent, exitCode, timestamp: timestampMs }, null, 2)}\n`, "utf8");
+  if (writeOutputArtifact && outputText !== null) {
+    await writeFile(outputArtifactPath, outputText, "utf8");
+  }
+  await writeFile(
+    sessionPath,
+    `${JSON.stringify({ type: "session", version: 3, id: `${runId}-session`, timestamp: "2026-06-03T00:00:00.000Z", cwd })}\n`,
+    "utf8",
+  );
+
+  return { metaPath, outputArtifactPath, sessionPath };
+}
+
+async function writeAsyncRun({
+  asyncRunsRoot,
+  runId,
+  state = "running",
+  childIndex = 0,
+  childStatus = state,
+  agent = "dev-loop",
+  cwd,
+  outputText = null,
+  sessionPath = null,
+  timestampMs = 1700000000000,
+}) {
+  const asyncDir = path.join(asyncRunsRoot, runId);
+  const statusPath = path.join(asyncDir, "status.json");
+  const outputPath = path.join(asyncDir, `output-${childIndex}.log`);
+  const eventsPath = path.join(asyncDir, "events.jsonl");
+
+  await mkdir(asyncDir, { recursive: true });
+  await writeFile(statusPath, `${JSON.stringify({
+    runId,
+    mode: "single",
+    state,
+    cwd,
+    lastUpdate: timestampMs,
+    startedAt: timestampMs - 5000,
+    steps: [
+      {
+        agent,
+        status: childStatus,
+        sessionFile: sessionPath,
+      },
+    ],
+    outputFile: outputPath,
+  }, null, 2)}\n`, "utf8");
+  await writeFile(eventsPath, "", "utf8");
+  if (outputText !== null) {
+    await writeFile(outputPath, outputText, "utf8");
+  }
+
+  return { statusPath, outputPath, eventsPath };
+}
+
+async function runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo, env }) {
+  return runConductorMonitor(
+    { repo, autoResume: true },
+    {
+      env,
+      repoRoot,
+      sessionRoots: [sessionsRoot],
+      asyncRunRoots: [asyncRunsRoot],
+      asyncResultRoots: [asyncResultsRoot],
+    },
+  );
+}
+
 test("conductor-monitor reports queue_complete when no open PRs exist", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-empty-"));
 
@@ -51,6 +211,36 @@ test("conductor-monitor reports queue_complete when no open PRs exist", async ()
     assert.equal(payload.queueStatus, "queue_complete");
     assert.equal(payload.needsAttentionCount, 0);
     assert.deepEqual(payload.prs, []);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume keeps queue_complete semantics when no open PRs exist", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-auto-resume-empty-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const env = await writeGhStub(tempDir, [{
+      assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "1000", "--json", "number,title,url,isDraft,headRefName,author"],
+      stdout: "[]\n",
+    }]);
+    env.PI_AGENT_SESSIONS_DIR = sessionsRoot;
+    env.PI_SUBAGENT_ASYNC_RUNS_DIR = asyncRunsRoot;
+    env.PI_SUBAGENT_ASYNC_RESULTS_DIR = asyncResultsRoot;
+
+    const result = await runNode(["--repo", "owner/repo", "--auto-resume"], { env, cwd: repoRoot });
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.queueStatus, "queue_complete");
+    assert.equal(payload.autoResumeRequested, true);
+    assert.equal(payload.orphanedPrCount, 0);
+    assert.equal(payload.resumePlanCount, 0);
+    assert.equal(payload.manualAttentionCount, 0);
+    assert.deepEqual(payload.resumePlans, []);
+    assert.deepEqual(payload.needsManualAttention, []);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -104,39 +294,15 @@ test("conductor-monitor reports monitoring when open PRs are still in healthy wa
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-waiting-"));
 
   try {
-    const env = await writeGhStub(tempDir, [
-      {
-        assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "1000", "--json", "number,title,url,isDraft,headRefName,author"],
-        stdout: `${JSON.stringify([
-          {
-            number: 17,
-            title: "Add monitor status report",
-            url: "https://github.com/owner/repo/pull/17",
-            isDraft: false,
-            headRefName: "copilot/issue-383",
-            author: { login: "copilot-swe-agent" },
-          },
-        ])}\n`,
-      },
-      {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
-        stdout: `${JSON.stringify({
-          isDraft: false,
-          state: "OPEN",
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [
+        {
           number: 17,
-          reviews: [],
-          statusCheckRollup: [],
-        })}\n`,
-      },
-      {
-        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
-        stdout: '{"users":[{"login":"copilot-pull-request-reviewer[bot]"}],"teams":[]}\n',
-      },
-      {
-        assertArgs: ["api", "graphql"],
-        stdout: `${emptyThreadsPayload()}\n`,
-      },
-    ]);
+          title: "Add monitor status report",
+          requestCopilot: true,
+        },
+      ],
+    }));
 
     const result = await runNode(["--repo", "owner/repo"], { env });
 
@@ -163,65 +329,22 @@ test("conductor-monitor flags unresolved-feedback PRs as needing attention while
   const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");
 
   try {
-    const env = await writeGhStub(tempDir, [
-      {
-        assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "1000", "--json", "number,title,url,isDraft,headRefName,author"],
-        stdout: `${JSON.stringify([
-          {
-            number: 17,
-            title: "Add conductor monitor wrapper",
-            url: "https://github.com/owner/repo/pull/17",
-            isDraft: false,
-            headRefName: "copilot/issue-383-wrapper",
-            author: { login: "copilot-swe-agent" },
-          },
-          {
-            number: 18,
-            title: "Document monitor pattern",
-            url: "https://github.com/owner/repo/pull/18",
-            isDraft: false,
-            headRefName: "copilot/issue-383-docs",
-            author: { login: "copilot-swe-agent" },
-          },
-        ])}\n`,
-      },
-      {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
-        stdout: `${JSON.stringify({
-          isDraft: false,
-          state: "OPEN",
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [
+        {
           number: 17,
+          title: "Add conductor monitor wrapper",
           reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
           statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
-        })}\n`,
-      },
-      {
-        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
-        stdout: '{"users":[],"teams":[]}\n',
-      },
-      {
-        assertArgs: ["api", "graphql"],
-        stdout: mixedThreadsFixture,
-      },
-      {
-        assertArgs: ["pr", "view", "18", "--repo", "owner/repo"],
-        stdout: `${JSON.stringify({
-          isDraft: false,
-          state: "OPEN",
+          threadsPayload: mixedThreadsFixture,
+        },
+        {
           number: 18,
-          reviews: [],
-          statusCheckRollup: [],
-        })}\n`,
-      },
-      {
-        assertArgs: ["api", "repos/owner/repo/pulls/18/requested_reviewers"],
-        stdout: '{"users":[{"login":"copilot-pull-request-reviewer[bot]"}],"teams":[]}\n',
-      },
-      {
-        assertArgs: ["api", "graphql"],
-        stdout: `${emptyThreadsPayload()}\n`,
-      },
-    ]);
+          title: "Document monitor pattern",
+          requestCopilot: true,
+        },
+      ],
+    }));
 
     const result = await runNode(["--repo", "owner/repo"], { env });
 
@@ -247,6 +370,329 @@ test("conductor-monitor flags unresolved-feedback PRs as needing attention while
     assert.equal(waiting.state, "waiting_for_copilot_review");
     assert.equal(waiting.loopDisposition, "pending");
     assert.equal(waiting.needsAttention, false);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume emits a feedback-fix resume plan for an orphaned unresolved-feedback PR", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-fix-"));
+  const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    await writeSessionRun({
+      sessionsRoot,
+      runId: "run-fix-17",
+      cwd: repoRoot,
+      timestampMs: 1700000001000,
+      outputText: [
+        "Active PR: owner/repo#17",
+        "Artifact state: open",
+        "Loop state: unresolved_feedback_present",
+        "Next action: address review feedback",
+      ].join("\n"),
+    });
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{
+        number: 17,
+        reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
+        statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+        threadsPayload: mixedThreadsFixture,
+      }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+
+    assert.equal(payload.autoResumeRequested, true);
+    assert.equal(payload.resumePlanCount, 1);
+    assert.equal(payload.manualAttentionCount, 0);
+    assert.equal(payload.orphanedPrCount, 1);
+    assert.equal(payload.queueStatus, "attention_needed");
+
+    const plan = payload.resumePlans[0];
+    assert.equal(plan.pr, 17);
+    assert.equal(plan.runId, "run-fix-17");
+    assert.equal(plan.runState, "completed");
+    assert.equal(plan.parsedArtifactState, "open");
+    assert.equal(plan.parsedLoopState, "unresolved_feedback_present");
+    assert.equal(plan.livePrState, "unresolved_feedback_present");
+    assert.equal(plan.resumeAction, "needs_feedback_fix");
+    assert.equal(
+      plan.resumeMessage,
+      "PR #17 is orphaned. Live state: unresolved_feedback_present. Resume the prior dev-loop from run run-fix-17. Continue by fixing the remaining review feedback, then reply to and resolve each GitHub thread. Do not merge.",
+    );
+    assert.equal(
+      plan.resumeCommandPreview,
+      'subagent({ action: "resume", id: "run-fix-17", message: "PR #17 is orphaned. Live state: unresolved_feedback_present. Resume the prior dev-loop from run run-fix-17. Continue by fixing the remaining review feedback, then reply to and resolve each GitHub thread. Do not merge." })',
+    );
+    assert.equal(plan.staleWorktree, false);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume emits a final-approval resume plan for an orphaned approval-boundary PR", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-final-approval-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    await writeSessionRun({
+      sessionsRoot,
+      runId: "run-final-22",
+      cwd: repoRoot,
+      timestampMs: 1700000002000,
+      outputText: [
+        "Status: stopped at final human approval boundary",
+        "Routed strategy: final_approval",
+        "PR: https://github.com/owner/repo/pull/22",
+        "Next recommended action: human reviews/approves PR #22",
+      ].join("\n"),
+    });
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{
+        number: 22,
+        reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
+        statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+      }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.resumePlanCount, 1);
+    const plan = payload.resumePlans[0];
+    assert.equal(plan.pr, 22);
+    assert.equal(plan.resumeAction, "await_final_approval");
+    assert.equal(plan.livePrState, "final_approval_ready");
+    assert.equal(
+      plan.resumeMessage,
+      "PR #22 is orphaned. Live state: final_approval_ready. Resume the prior dev-loop from run run-final-22. Continue by summarizing the clean current-head evidence and stop at final human approval. Do not merge without explicit authorization.",
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume emits a merge-authorization resume plan for an orphaned merge-ready PR", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-merge-auth-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    await writeSessionRun({
+      sessionsRoot,
+      runId: "run-merge-24",
+      cwd: repoRoot,
+      timestampMs: 1700000003000,
+      outputText: [
+        "Status: stopped at waiting_for_merge_authorization",
+        "PR #24",
+        "Next action: ask for explicit merge authorization",
+      ].join("\n"),
+    });
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{
+        number: 24,
+        reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
+        statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+      }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.resumePlanCount, 1);
+    const plan = payload.resumePlans[0];
+    assert.equal(plan.pr, 24);
+    assert.equal(plan.resumeAction, "await_merge_authorization");
+    assert.equal(plan.livePrState, "clean current-head gate evidence + green CI");
+    assert.equal(
+      plan.resumeMessage,
+      "PR #24 is orphaned. Live state: clean current-head gate evidence + green CI. Resume the prior dev-loop from run run-merge-24. Continue by stopping at waiting_for_merge_authorization and asking for explicit merge authorization. Do not merge automatically.",
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume ignores an older completed run when a newer running run matches the same PR", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-suppressed-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const { sessionPath } = await writeSessionRun({
+      sessionsRoot,
+      runId: "run-complete-30",
+      cwd: repoRoot,
+      timestampMs: 1700000001000,
+      outputText: [
+        "Active PR: owner/repo#30",
+        "Artifact state: open",
+        "Loop state: waiting_for_copilot_review",
+      ].join("\n"),
+    });
+    await writeAsyncRun({
+      asyncRunsRoot,
+      runId: "run-active-30",
+      state: "running",
+      cwd: repoRoot,
+      sessionPath,
+      timestampMs: 1700000005000,
+      outputText: "Active PR: owner/repo#30\nLoop state: waiting_for_copilot_review\n",
+    });
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{ number: 30, requestCopilot: true }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.resumePlanCount, 0);
+    assert.equal(payload.manualAttentionCount, 0);
+    assert.equal(payload.orphanedPrCount, 0);
+    assert.equal(payload.queueStatus, "monitoring");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume fails closed when the output artifact is missing", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-missing-artifact-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const { sessionPath } = await writeSessionRun({
+      sessionsRoot,
+      runId: "run-missing-31",
+      cwd: repoRoot,
+      timestampMs: 1700000004000,
+      outputText: "Active PR: owner/repo#31\n",
+      writeOutputArtifact: false,
+    });
+    await writeAsyncRun({
+      asyncRunsRoot,
+      runId: "run-missing-31",
+      state: "complete",
+      cwd: repoRoot,
+      sessionPath,
+      timestampMs: 1700000004500,
+      outputText: "Active PR: owner/repo#31\n",
+    });
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{
+        number: 31,
+        reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
+        statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+      }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.resumePlanCount, 0);
+    assert.equal(payload.manualAttentionCount, 1);
+    assert.equal(payload.needsManualAttention[0].pr, 31);
+    assert.equal(payload.needsManualAttention[0].runId, "run-missing-31");
+    assert.equal(payload.needsManualAttention[0].reason, "missing_output_artifact");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume fails closed on ambiguous PR identity inside one artifact", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-ambiguous-pr-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    await writeSessionRun({
+      sessionsRoot,
+      runId: "run-ambiguous-33",
+      cwd: repoRoot,
+      timestampMs: 1700000005000,
+      outputText: [
+        "Active PR: owner/repo#33",
+        "Status: still discussing PR #34",
+      ].join("\n"),
+    });
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{ number: 33 }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.resumePlanCount, 0);
+    assert.equal(payload.manualAttentionCount, 1);
+    assert.equal(payload.needsManualAttention[0].reason, "ambiguous_pr_identity");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume keeps a stale-worktree run resumable when artifact and session evidence are still present", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-stale-worktree-"));
+  const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const staleWorktreePath = path.join(repoRoot, "tmp", "worktrees", "issue-35-stale");
+    await writeSessionRun({
+      sessionsRoot,
+      runId: "run-stale-35",
+      cwd: staleWorktreePath,
+      timestampMs: 1700000006000,
+      outputText: [
+        "Active PR: owner/repo#35",
+        "Artifact state: open",
+        "Loop state: unresolved_feedback_present",
+      ].join("\n"),
+    });
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{
+        number: 35,
+        reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
+        statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+        threadsPayload: mixedThreadsFixture,
+      }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.resumePlanCount, 1);
+    assert.equal(payload.resumePlans[0].pr, 35);
+    assert.equal(payload.resumePlans[0].staleWorktree, true);
+    assert.equal(payload.manualAttentionCount, 0);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume ignores non-dev-loop runs and runs from other repos", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-ignore-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    await writeSessionRun({
+      sessionsRoot,
+      runId: "run-reviewer-36",
+      agent: "reviewer",
+      cwd: repoRoot,
+      timestampMs: 1700000007000,
+      outputText: "Active PR: owner/repo#36\n",
+    });
+    await writeSessionRun({
+      sessionsRoot,
+      runId: "run-other-repo-36",
+      cwd: path.join(tempDir, "different-repo"),
+      timestampMs: 1700000008000,
+      outputText: "Active PR: owner/repo#36\n",
+    });
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{ number: 36, requestCopilot: true }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.resumePlanCount, 0);
+    assert.equal(payload.manualAttentionCount, 0);
+    assert.equal(payload.orphanedPrCount, 0);
+    assert.equal(payload.queueStatus, "monitoring");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -400,6 +400,114 @@ test("conductor-monitor flags unresolved-feedback PRs as needing attention while
   }
 });
 
+test("conductor-monitor --auto-resume ignores malformed session headers instead of crashing the scan", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-invalid-session-json-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const badSessionRoot = path.join(sessionsRoot, "2026-06-03T00-00-00-000Z_session", "run-bad-session-41", "run-0");
+    const badArtifactsDir = path.join(sessionsRoot, "2026-06-03T00-00-00-000Z_session", "subagent-artifacts");
+    await mkdir(badSessionRoot, { recursive: true });
+    await mkdir(badArtifactsDir, { recursive: true });
+    await writeFile(path.join(badSessionRoot, "session.jsonl"), "{bad session header\n", "utf8");
+    await writeFile(
+      path.join(badArtifactsDir, "run-bad-session-41_dev-loop_0_meta.json"),
+      `${JSON.stringify({ runId: "run-bad-session-41", agent: "dev-loop", exitCode: 0, timestamp: 1700000009000 }, null, 2)}
+`,
+      "utf8",
+    );
+    await writeFile(path.join(badArtifactsDir, "run-bad-session-41_dev-loop_0_output.md"), "Active PR: owner/repo#41\n", "utf8");
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{ number: 41, requestCopilot: true }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.queueStatus, "monitoring");
+    assert.equal(payload.resumePlanCount, 0);
+    assert.equal(payload.manualAttentionCount, 0);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume ignores parse-failed artifacts that do not match the live open PR set", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-nonopen-manual-ignore-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const { sessionPath } = await writeSessionRun({
+      sessionsRoot,
+      runId: "run-missing-99",
+      cwd: repoRoot,
+      timestampMs: 1700000010000,
+      outputText: "Active PR: owner/repo#99\n",
+      writeOutputArtifact: false,
+    });
+    await writeAsyncRun({
+      asyncRunsRoot,
+      runId: "run-missing-99",
+      state: "complete",
+      cwd: repoRoot,
+      sessionPath,
+      timestampMs: 1700000010500,
+      outputText: "Active PR: owner/repo#99\n",
+    });
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{ number: 42, requestCopilot: true }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.queueStatus, "monitoring");
+    assert.equal(payload.resumePlanCount, 0);
+    assert.equal(payload.manualAttentionCount, 0);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume fails closed when an active matching run cannot be proven newer by timestamp", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-indeterminate-active-run-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const { sessionPath } = await writeSessionRun({
+      sessionsRoot,
+      runId: "run-complete-43",
+      cwd: repoRoot,
+      timestampMs: 1700000011000,
+      outputText: "Active PR: owner/repo#43\nArtifact state: open\nLoop state: waiting_for_copilot_review\n",
+    });
+    const { statusPath } = await writeAsyncRun({
+      asyncRunsRoot,
+      runId: "run-active-43",
+      state: "running",
+      cwd: repoRoot,
+      sessionPath,
+      timestampMs: 1700000012000,
+      outputText: "Active PR: owner/repo#43\nLoop state: waiting_for_copilot_review\n",
+    });
+    const activeStatus = JSON.parse(await readFile(statusPath, "utf8"));
+    delete activeStatus.lastUpdate;
+    delete activeStatus.startedAt;
+    await writeFile(statusPath, `${JSON.stringify(activeStatus, null, 2)}
+`, "utf8");
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{ number: 43, requestCopilot: true }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.resumePlanCount, 0);
+    assert.equal(payload.manualAttentionCount, 1);
+    assert.equal(payload.needsManualAttention[0].pr, 43);
+    assert.equal(payload.needsManualAttention[0].reason, "artifact_live_state_conflict");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("conductor-monitor --auto-resume emits a feedback-fix resume plan for an orphaned unresolved-feedback PR", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-fix-"));
   const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -566,6 +566,92 @@ test("conductor-monitor --auto-resume fails closed when run exit state cannot be
   }
 });
 
+test("conductor-monitor --auto-resume preserves the stronger failed run state when evidence conflicts", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-run-state-priority-"));
+  const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const { sessionPath } = await writeSessionRun({
+      sessionsRoot,
+      runId: "run-failed-57",
+      cwd: repoRoot,
+      timestampMs: 1700000014000,
+      exitCode: 1,
+      outputText: "Active PR: owner/repo#57\nArtifact state: open\nLoop state: unresolved_feedback_present\n",
+    });
+    await writeAsyncRun({
+      asyncRunsRoot,
+      runId: "run-failed-57",
+      state: "complete",
+      cwd: repoRoot,
+      sessionPath,
+      timestampMs: 1700000014500,
+      outputText: "Active PR: owner/repo#57\nLoop state: unresolved_feedback_present\n",
+    });
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{
+        number: 57,
+        reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
+        statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+        threadsPayload: mixedThreadsFixture,
+      }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.resumePlanCount, 1);
+    assert.equal(payload.resumePlans[0].runState, "failed");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume uses grouped result summaries as the artifactPath when no output artifact exists", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-grouped-summary-path-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const summaryPath = path.join(asyncResultsRoot, "run-summary-58.json");
+    await writeFile(summaryPath, `${JSON.stringify({
+      runId: "run-summary-58",
+      agent: "dev-loop",
+      state: "complete",
+      cwd: repoRoot,
+      summary: [
+        "Run: run-summary-58",
+        "State: complete",
+        "Agent: dev-loop",
+        "Active PR: owner/repo#58",
+        "Artifact state: open",
+        "Loop state: waiting_for_copilot_review",
+      ].join("\n"),
+      results: [{
+        agent: "dev-loop",
+        output: [
+          "Run: run-summary-58",
+          "State: complete",
+          "Agent: dev-loop",
+          "Active PR: owner/repo#58",
+          "Artifact state: open",
+          "Loop state: waiting_for_copilot_review",
+        ].join("\n"),
+      }],
+    }, null, 2)}
+`, "utf8");
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{ number: 58, requestCopilot: true }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.resumePlanCount, 1);
+    assert.equal(payload.resumePlans[0].artifactPath, summaryPath);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("conductor-monitor --auto-resume emits a feedback-fix resume plan for an orphaned unresolved-feedback PR", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-fix-"));
   const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -508,6 +508,64 @@ test("conductor-monitor --auto-resume fails closed when an active matching run c
   }
 });
 
+test("conductor-monitor --auto-resume preserves artifact run ids that contain underscores", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-underscore-run-id-"));
+  const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    await writeSessionRun({
+      sessionsRoot,
+      runId: "pr_55",
+      cwd: repoRoot,
+      timestampMs: 1700000013000,
+      outputText: "Active PR: owner/repo#55\nArtifact state: open\nLoop state: unresolved_feedback_present\n",
+    });
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{
+        number: 55,
+        reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
+        statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+        threadsPayload: mixedThreadsFixture,
+      }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.resumePlanCount, 1);
+    assert.equal(payload.resumePlans[0].runId, "pr_55");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume fails closed when run exit state cannot be proven", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-unknown-run-state-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const sessionRoot = path.join(sessionsRoot, "2026-06-03T00-00-00-000Z_session");
+    const artifactsDir = path.join(sessionRoot, "subagent-artifacts");
+    const runDir = path.join(sessionRoot, "run-unknown-56", "run-0");
+    await mkdir(artifactsDir, { recursive: true });
+    await mkdir(runDir, { recursive: true });
+    await writeFile(path.join(artifactsDir, "run-unknown-56_dev-loop_0_output.md"), "Active PR: owner/repo#56\nArtifact state: open\nLoop state: waiting_for_copilot_review\n", "utf8");
+    await writeFile(path.join(runDir, "session.jsonl"), `${JSON.stringify({ type: "session", version: 3, id: "run-unknown-56-session", timestamp: "2026-06-03T00:00:00.000Z", cwd: repoRoot })}\n`, "utf8");
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{ number: 56, requestCopilot: true }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.resumePlanCount, 0);
+    assert.equal(payload.manualAttentionCount, 1);
+    assert.equal(payload.needsManualAttention[0].pr, 56);
+    assert.equal(payload.needsManualAttention[0].reason, "artifact_live_state_conflict");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("conductor-monitor --auto-resume emits a feedback-fix resume plan for an orphaned unresolved-feedback PR", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-fix-"));
   const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -113,8 +113,9 @@ async function writeSessionRun({
   timestampMs = 1700000000000,
   writeOutputArtifact = true,
 }) {
-  const artifactsDir = path.join(sessionsRoot, "subagent-artifacts");
-  const sessionDir = path.join(sessionsRoot, "2026-06-03T00-00-00-000Z_session", runId, `run-${childIndex}`);
+  const sessionRoot = path.join(sessionsRoot, "2026-06-03T00-00-00-000Z_session");
+  const artifactsDir = path.join(sessionRoot, "subagent-artifacts");
+  const sessionDir = path.join(sessionRoot, runId, `run-${childIndex}`);
   const artifactBase = `${runId}_${agent}_${childIndex}`;
   const metaPath = path.join(artifactsDir, `${artifactBase}_meta.json`);
   const outputArtifactPath = path.join(artifactsDir, `${artifactBase}_output.md`);

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -325,6 +325,30 @@ test("conductor-monitor reports monitoring when open PRs are still in healthy wa
   }
 });
 
+test("conductor-monitor --auto-resume ignores invalid async JSON side artifacts instead of crashing the scan", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-invalid-async-json-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const badAsyncDir = path.join(asyncRunsRoot, "run-bad-json-40");
+    await mkdir(badAsyncDir, { recursive: true });
+    await writeFile(path.join(badAsyncDir, "status.json"), "{not valid json\n", "utf8");
+    await writeFile(path.join(badAsyncDir, "events.jsonl"), "", "utf8");
+    await writeFile(path.join(badAsyncDir, "output-0.log"), "Active PR: owner/repo#40\n", "utf8");
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{ number: 40, requestCopilot: true }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.queueStatus, "monitoring");
+    assert.equal(payload.resumePlanCount, 0);
+    assert.equal(payload.manualAttentionCount, 0);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("conductor-monitor flags unresolved-feedback PRs as needing attention while preserving pending waits", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-attention-"));
   const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");


### PR DESCRIPTION
## Summary
- add `conductor-monitor.mjs --auto-resume` orphaned-PR detection and resume-plan reporting
- scan documented Pi async/session artifacts on disk without importing private runtime modules
- document the shipped auto-resume contract and cover it with fixture-based tests

## Scope / context
Implements #408.

This stays inside the incremental conductor slice:
- preserve the existing queue summary behavior when `--auto-resume` is absent
- read documented async/session artifacts from disk
- detect orphaned open PR follow-up runs
- emit deterministic `resumePlans[]` / `needsManualAttention[]`
- do **not** execute `subagent({ action: "resume" })` from the Node script

## Acceptance criteria
- `conductor-monitor.mjs --auto-resume` detects orphaned PRs with exited `dev-loop` runs by reading documented async/session artifacts from disk
- each matched orphaned PR emits one deterministic resume plan with run/artifact/live-state context and conductor-ready resume messaging
- newer `running` / `queued` matching runs suppress older exited runs for the same PR
- ambiguous or missing artifact identity / state fails closed to `needsManualAttention`
- stale worktrees remain resumable when artifact/session evidence is still clear
- `scripts/README.md` documents the `--auto-resume` contract and fail-closed behavior
- tests cover orphan detection, artifact parsing, resume-plan generation, and fail-closed edge cases

## Definition of done
- runtime logic implemented in `scripts/loop/conductor-monitor.mjs`
- docs updated in `scripts/README.md`
- targeted auto-resume tests added in `test/loop/conductor-monitor.test.mjs`
- `npm run verify` passes

## Non-goals
- not a daemon, poller, or persistent conductor process
- not stale-worktree cleanup or async-dir garbage collection
- not a public resume bridge
- not automatic merge or automatic `subagent({ action: "resume" })` execution
