### PR TITLE
feat(core): capture deep persona PR review output as debt_signal artifacts (#412)

### DIFF
--- a/packages/core/bin/capture-deep-persona-signals.mjs
+++ b/packages/core/bin/capture-deep-persona-signals.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 import { mkdir, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
-import { parseReviewThreads, parseCliArgs, readInput, parseJsonText, formatCliError } from "../src/github/review-threads.mjs";
+import { fileURLToPath } from "node:url";
+import { parseReviewThreads, readInput, parseJsonText, formatCliError } from "../src/github/review-threads.mjs";
 import { extractDeepPersonaSignals } from "../src/debt/deep-persona-signals.mjs";
 
-const USAGE = [
+export const USAGE = [
   "Usage: capture-deep-persona-signals.mjs --input <path> --pr-number <n> --pr-url <url> [--output-dir <path>]",
   "",
   "Arguments:",
@@ -15,10 +16,12 @@ const USAGE = [
 ].join("\n");
 
 /**
- * @param {string[]} argv
+ * Parse CLI arguments for the capture-deep-persona-signals CLI.
+ *
+ * @param {string[]} argv - Argument list (e.g. process.argv.slice(2))
  * @returns {{ inputPath: string, prNumber: string, prUrl: string, outputDir: string }}
  */
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const args = [...argv];
   const options = {
     inputPath: undefined,
@@ -89,12 +92,12 @@ function parseArgs(argv) {
  * @param {string} prNumber
  * @returns {string}
  */
-function outputFilename(prNumber) {
+export function outputFilename(prNumber) {
   const ts = new Date().toISOString().replace(/[:.]/g, "-");
   return `deep-persona-signals-${prNumber}-${ts}.json`;
 }
 
-async function run(argv = process.argv.slice(2)) {
+export async function run(argv = process.argv.slice(2)) {
   const options = parseArgs(argv);
 
   // Read and parse the review-thread input
@@ -127,10 +130,14 @@ async function run(argv = process.argv.slice(2)) {
   process.stdout.write(JSON.stringify({ ok: true, outputPath: outPath, signalCount: signals.length }) + "\n");
 }
 
-run().catch((error) => {
-  if (error.usage) {
-    process.stderr.write(error.usage + "\n\n");
-  }
-  process.stderr.write(formatCliError(error) + "\n");
-  process.exitCode = 1;
-});
+// Only auto-run when executed directly (not imported)
+const scriptPath = fileURLToPath(import.meta.url);
+if (process.argv[1] === scriptPath) {
+  run().catch((error) => {
+    if (error.usage) {
+      process.stderr.write(error.usage + "\n\n");
+    }
+    process.stderr.write(formatCliError(error) + "\n");
+    process.exitCode = 1;
+  });
+}

--- a/packages/core/bin/capture-deep-persona-signals.mjs
+++ b/packages/core/bin/capture-deep-persona-signals.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { parseReviewThreads, parseCliArgs, readInput, parseJsonText, formatCliError } from "../src/github/review-threads.mjs";
+import { extractDeepPersonaSignals } from "../src/debt/deep-persona-signals.mjs";
+
+const USAGE = [
+  "Usage: capture-deep-persona-signals.mjs --input <path> --pr-number <n> --pr-url <url> [--output-dir <path>]",
+  "",
+  "Arguments:",
+  "  --input <path>        Path to normalized review-thread JSON (required)",
+  "  --pr-number <n>       PR number for metadata (required)",
+  "  --pr-url <url>        PR URL for metadata (required)",
+  "  --output-dir <path>   Output directory for emitted artifact (default: .pi/debt/signals/)",
+].join("\n");
+
+/**
+ * @param {string[]} argv
+ * @returns {{ inputPath: string, prNumber: string, prUrl: string, outputDir: string }}
+ */
+function parseArgs(argv) {
+  const args = [...argv];
+  const options = {
+    inputPath: undefined,
+    prNumber: undefined,
+    prUrl: undefined,
+    outputDir: ".pi/debt/signals",
+  };
+
+  while (args.length > 0) {
+    const token = args.shift();
+
+    switch (token) {
+      case "--input": {
+        const value = args.shift();
+        if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
+          throw Object.assign(new Error("Missing value for --input"), { usage: USAGE });
+        }
+        options.inputPath = value;
+        break;
+      }
+      case "--pr-number": {
+        const value = args.shift();
+        if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
+          throw Object.assign(new Error("Missing value for --pr-number"), { usage: USAGE });
+        }
+        if (!/^\d+$/.test(value)) {
+          throw Object.assign(new Error(`--pr-number must be a positive integer, got: ${value}`), { usage: USAGE });
+        }
+        options.prNumber = value;
+        break;
+      }
+      case "--pr-url": {
+        const value = args.shift();
+        if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
+          throw Object.assign(new Error("Missing value for --pr-url"), { usage: USAGE });
+        }
+        options.prUrl = value;
+        break;
+      }
+      case "--output-dir": {
+        const value = args.shift();
+        if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
+          throw Object.assign(new Error("Missing value for --output-dir"), { usage: USAGE });
+        }
+        options.outputDir = value;
+        break;
+      }
+      default:
+        throw Object.assign(new Error(`Unknown argument: ${token}`), { usage: USAGE });
+    }
+  }
+
+  if (!options.inputPath) {
+    throw Object.assign(new Error("--input is required"), { usage: USAGE });
+  }
+  if (!options.prNumber) {
+    throw Object.assign(new Error("--pr-number is required"), { usage: USAGE });
+  }
+  if (!options.prUrl) {
+    throw Object.assign(new Error("--pr-url is required"), { usage: USAGE });
+  }
+
+  return /** @type {{ inputPath: string, prNumber: string, prUrl: string, outputDir: string }} */ (options);
+}
+
+/**
+ * Generate the output filename.
+ * @param {string} prNumber
+ * @returns {string}
+ */
+function outputFilename(prNumber) {
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  return `deep-persona-signals-${prNumber}-${ts}.json`;
+}
+
+async function run(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+
+  // Read and parse the review-thread input
+  const rawText = await readInput({ inputPath: options.inputPath });
+  const parsed = parseReviewThreads(parseJsonText(rawText));
+
+  // Extract deep-persona signals
+  const signals = extractDeepPersonaSignals(parsed, {
+    prNumber: options.prNumber,
+    prUrl: options.prUrl,
+  });
+
+  // Build artifact envelope
+  const artifact = {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    prNumber: Number(options.prNumber),
+    prUrl: options.prUrl,
+    source: "pr_review_deep_persona",
+    signalCount: signals.length,
+    signals,
+  };
+
+  // Write to output directory
+  const outDir = resolve(options.outputDir);
+  await mkdir(outDir, { recursive: true });
+  const outPath = join(outDir, outputFilename(options.prNumber));
+  await writeFile(outPath, JSON.stringify(artifact, null, 2) + "\n", "utf8");
+
+  process.stdout.write(JSON.stringify({ ok: true, outputPath: outPath, signalCount: signals.length }) + "\n");
+}
+
+run().catch((error) => {
+  if (error.usage) {
+    process.stderr.write(error.usage + "\n\n");
+  }
+  process.stderr.write(formatCliError(error) + "\n");
+  process.exitCode = 1;
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,12 +23,14 @@
     "./loop/timeout-policy": "./src/loop/timeout-policy.mjs",
     "./loop/tracker-pr-state": "./src/loop/tracker-pr-state.mjs",
     "./debt/signal": "./src/debt/debt-signal.mjs",
-    "./debt/finding": "./src/debt/debt-finding.mjs"
+    "./debt/finding": "./src/debt/debt-finding.mjs",
+    "./debt/signals": "./src/debt/deep-persona-signals.mjs"
   },
   "bin": {
     "pi-dev-loops-log-bash-exit-1": "./bin/log-bash-exit-1.mjs",
     "pi-dev-loops-ensure-phase-files": "./bin/ensure-phase-files.mjs",
-    "pi-dev-loops-parse-review-threads": "./bin/parse-review-threads.mjs"
+    "pi-dev-loops-parse-review-threads": "./bin/parse-review-threads.mjs",
+    "pi-dev-loops-capture-deep-persona-signals": "./bin/capture-deep-persona-signals.mjs"
   },
   "scripts": {
     "test": "node --test ./test/*.test.mjs"

--- a/packages/core/src/debt/deep-persona-signals.mjs
+++ b/packages/core/src/debt/deep-persona-signals.mjs
@@ -12,7 +12,7 @@ import { loadDevLoopConfig } from "../config/config.mjs";
 /** @type {Array<{ phrase: RegExp, category: string, severity: string, confidence: number }>} */
 const FLAG_PATTERNS = [
   {
-    phrase: /(?:crossing|crossed|exceeds?)\s+\d{3,}\s+lines/i,
+    phrase: /(?:crossing|crossed|exceeds?)\s+(?:1000|1,000)\+?\s+lines/i,
     category: "file_size",
     severity: "high",
     confidence: 0.9,

--- a/packages/core/src/debt/deep-persona-signals.mjs
+++ b/packages/core/src/debt/deep-persona-signals.mjs
@@ -91,7 +91,7 @@ const FLAG_PATTERNS = [
   },
 ];
 
-const FILE_PATH_RE = /[\w/\-]+\.(?:m?js|ts|tsx|jsx|mjs)/i;
+const FILE_PATH_RE = /[\w/\-.]+\.(?:m?js|ts|tsx|jsx|mjs)/i;
 
 // ============================================================================
 // Helpers

--- a/packages/core/src/debt/deep-persona-signals.mjs
+++ b/packages/core/src/debt/deep-persona-signals.mjs
@@ -226,11 +226,8 @@ export function extractDeepPersonaSignals(parsedOutput, prMeta) {
       prMeta,
     );
 
-    // Validate against canonical schema
-    const parsed = DebtSignalSchema.safeParse(signal);
-    if (parsed.success) {
-      signals.push(parsed.data);
-    }
+    // Validate against canonical schema — throw on regression
+    signals.push(DebtSignalSchema.parse(signal));
   }
 
   return signals;

--- a/packages/core/src/debt/deep-persona-signals.mjs
+++ b/packages/core/src/debt/deep-persona-signals.mjs
@@ -4,6 +4,9 @@ import { loadDevLoopConfig } from "../config/config.mjs";
 
 // ============================================================================
 // Flag phrase inventory — derived from personas.deep prompt in defaults.yaml
+//
+// Confidence values use the canonical DebtSignalSchema 0..1 range (0.9 = 90%).
+// This matches the schema default: z.number().min(0).max(1).default(1).
 // ============================================================================
 
 /** @type {Array<{ phrase: RegExp, category: string, severity: string, confidence: number }>} */
@@ -250,7 +253,11 @@ export function getDeepPersonaFlagPhrases() {
  * @returns {Promise<Array<string>>}
  */
 export async function verifyPromptStability() {
-  const { config } = await loadDevLoopConfig();
+  const { config, errors } = await loadDevLoopConfig();
+  if (errors.length > 0) {
+    throw new Error("Cannot verify prompt stability: config load errors: " +
+      errors.map(e => e.message).join("; "));
+  }
   const deepPrompt = config?.personas?.deep?.prompt ?? "";
 
   return FLAG_PATTERNS

--- a/packages/core/src/debt/deep-persona-signals.mjs
+++ b/packages/core/src/debt/deep-persona-signals.mjs
@@ -1,0 +1,263 @@
+import { randomUUID } from "node:crypto";
+import { DebtSignalSchema } from "./debt-signal.mjs";
+import { loadDevLoopConfig } from "../config/config.mjs";
+
+// ============================================================================
+// Flag phrase inventory — derived from personas.deep prompt in defaults.yaml
+// ============================================================================
+
+/** @type {Array<{ phrase: RegExp, category: string, severity: string, confidence: number }>} */
+const FLAG_PATTERNS = [
+  {
+    phrase: /(?:crossing|crossed|exceeds?)\s+\d{3,}\s+lines/i,
+    category: "file_size",
+    severity: "high",
+    confidence: 0.9,
+  },
+  {
+    phrase: /conditionals?\s+bolted\s+onto\s+unrelated\s+paths/i,
+    category: "spaghetti_branching",
+    severity: "high",
+    confidence: 0.9,
+  },
+  {
+    phrase: /\bspaghetti\b/i,
+    category: "spaghetti_branching",
+    severity: "high",
+    confidence: 0.9,
+  },
+  {
+    phrase: /thin\s+wrapper/i,
+    category: "thin_wrapper",
+    severity: "medium",
+    confidence: 0.9,
+  },
+  {
+    phrase: /re-export\s*[- ]?only/i,
+    category: "thin_wrapper",
+    severity: "medium",
+    confidence: 0.9,
+  },
+  {
+    phrase: /identity\s+abstraction/i,
+    category: "thin_wrapper",
+    severity: "medium",
+    confidence: 0.9,
+  },
+  {
+    phrase: /feature\s+logic\s+leaking\s+into/i,
+    category: "leaky_feature_logic",
+    severity: "high",
+    confidence: 0.9,
+  },
+  {
+    phrase: /leaking\s+into\s+shared/i,
+    category: "leaky_feature_logic",
+    severity: "high",
+    confidence: 0.9,
+  },
+  {
+    phrase: /cast[- ]?heavy/i,
+    category: "weak_contract",
+    severity: "medium",
+    confidence: 0.9,
+  },
+  {
+    phrase: /optionality[- ]?heavy/i,
+    category: "weak_contract",
+    severity: "medium",
+    confidence: 0.9,
+  },
+  {
+    phrase: /any[- ]?typed\s+contract/i,
+    category: "weak_contract",
+    severity: "medium",
+    confidence: 0.9,
+  },
+  {
+    phrase: /code\s+judo/i,
+    category: "simplification_opportunity",
+    severity: "medium",
+    confidence: 0.9,
+  },
+  {
+    phrase: /prefer\s+deletion\s+over\s+addition/i,
+    category: "simplification_opportunity",
+    severity: "medium",
+    confidence: 0.9,
+  },
+];
+
+const FILE_PATH_RE = /[\w/\-]+\.(?:m?js|ts|tsx|jsx|mjs)/i;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Match a comment body against known deep-persona flag phrases.
+ * Returns the highest-confidence match, or a general fallback when no specific
+ * phrase matches but the comment body is non-empty.
+ *
+ * @param {string} body
+ * @returns {{ category: string, severity: string, confidence: number, matchedPhrase: string|null }|null}
+ */
+function matchDeepPersonaFlags(body) {
+  for (const pattern of FLAG_PATTERNS) {
+    if (pattern.phrase.test(body)) {
+      return {
+        category: pattern.category,
+        severity: pattern.severity,
+        confidence: pattern.confidence,
+        matchedPhrase: pattern.phrase.source,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Extract a file path from a comment body, or return an empty string if none found.
+ *
+ * @param {string} body
+ * @returns {string}
+ */
+function extractFilePath(body) {
+  const match = body.match(FILE_PATH_RE);
+  return match ? match[0] : "";
+}
+
+/**
+ * Build a debt_signal object from a matched deep-persona comment.
+ *
+ * @param {object} comment - Normalized comment from parseReviewThreads output
+ * @param {string} category - Inferred category
+ * @param {string} severity - Severity hint
+ * @param {number} confidence - Confidence score (0..1)
+ * @param {string|null} matchedPhrase - The regex source that matched
+ * @param {{ prNumber: string|number, prUrl: string }} prMeta
+ * @returns {object}
+ */
+function buildDebtSignal(comment, category, severity, confidence, matchedPhrase, prMeta) {
+  const filePath = extractFilePath(comment.body);
+
+  return {
+    id: randomUUID(),
+    sourceType: "pr_review_deep_persona",
+    signalKind: category,
+    location: filePath ? { filePath } : {},
+    severityHint: severity,
+    timestamp: new Date().toISOString(),
+    confidence,
+    rawPayload: {
+      description: comment.body,
+      metadata: {
+        prNumber: String(prMeta.prNumber),
+        prUrl: prMeta.prUrl,
+        commentId: comment.id,
+        threadId: comment.threadId,
+        isResolved: comment.isResolved ?? false,
+        category,
+        matchedPhrase,
+      },
+    },
+  };
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Extract deep-persona debt_signal artifacts from normalized review-thread JSON.
+ *
+ * Accepts the output of `parseReviewThreads()` (the `comments` array with
+ * normalized `{ id, threadId, author, body, isActionable }` entries).
+ *
+ * Filters to only bot-authored comments that match known deep-persona flag
+ * phrases. Bots are identified by `author.isBot === true` or `author.type === "Bot"`.
+ *
+ * @param {{ comments: Array<{ id: string, threadId: string, author: { login: string, type: string, isBot: boolean }, body: string, isActionable?: boolean, isResolved?: boolean }>, threads?: Array<{ id: string, isResolved: boolean }> }} parsedOutput - parseReviewThreads() output
+ * @param {{ prNumber: string|number, prUrl: string }} prMeta
+ * @returns {Array<object>} Array of debt_signal objects compatible with DebtSignalSchema
+ */
+export function extractDeepPersonaSignals(parsedOutput, prMeta) {
+  if (!parsedOutput || !Array.isArray(parsedOutput.comments)) {
+    throw new Error("Invalid parsed output: expected { comments: [...] } from parseReviewThreads()");
+  }
+
+  // Build a thread-id → isResolved map for fast lookup
+  const threadResolved = new Map();
+  if (Array.isArray(parsedOutput.threads)) {
+    for (const thread of parsedOutput.threads) {
+      threadResolved.set(thread.id, Boolean(thread.isResolved));
+    }
+  }
+
+  const signals = [];
+
+  for (const comment of parsedOutput.comments) {
+    // Only process bot-authored comments (all Copilot personas emit as bots)
+    if (!comment.author || (!comment.author.isBot && comment.author.type !== "Bot")) {
+      continue;
+    }
+
+    if (!comment.body || comment.body.trim().length === 0) {
+      continue;
+    }
+
+    const match = matchDeepPersonaFlags(comment.body);
+    if (!match) {
+      continue;
+    }
+
+    // Enrich comment with isResolved from thread data
+    const isResolved = threadResolved.has(comment.threadId)
+      ? threadResolved.get(comment.threadId)
+      : (comment.isResolved ?? false);
+
+    const signal = buildDebtSignal(
+      { ...comment, isResolved },
+      match.category,
+      match.severity,
+      match.confidence,
+      match.matchedPhrase,
+      prMeta,
+    );
+
+    // Validate against canonical schema
+    const parsed = DebtSignalSchema.safeParse(signal);
+    if (parsed.success) {
+      signals.push(parsed.data);
+    }
+  }
+
+  return signals;
+}
+
+/**
+ * Get the known deep-persona flag phrases from the loaded dev-loop config
+ * for prompt stability verification.
+ *
+ * @returns {Promise<Array<string>>}
+ */
+export async function getDeepPersonaFlagPhrases() {
+  const { config } = await loadDevLoopConfig();
+  return FLAG_PATTERNS.map((p) => p.phrase.source);
+}
+
+/**
+ * Verify that all known flag phrases appear in the loaded deep persona prompt.
+ * Returns an array of missing phrases (empty = all good).
+ *
+ * @returns {Promise<Array<string>>}
+ */
+export async function verifyPromptStability() {
+  const { config } = await loadDevLoopConfig();
+  const deepPrompt = config?.personas?.deep?.prompt ?? "";
+
+  return FLAG_PATTERNS
+    .filter((p) => !deepPrompt.includes(p.phrase.source))
+    .map((p) => p.phrase.source);
+}

--- a/packages/core/src/debt/deep-persona-signals.mjs
+++ b/packages/core/src/debt/deep-persona-signals.mjs
@@ -96,8 +96,8 @@ const FILE_PATH_RE = /[\w/\-]+\.(?:m?js|ts|tsx|jsx|mjs)/i;
 
 /**
  * Match a comment body against known deep-persona flag phrases.
- * Returns the highest-confidence match, or a general fallback when no specific
- * phrase matches but the comment body is non-empty.
+ * Returns the match when a specific pattern matches, or null when no
+ * patterns match the body.
  *
  * @param {string} body
  * @returns {{ category: string, severity: string, confidence: number, matchedPhrase: string|null }|null}
@@ -237,19 +237,18 @@ export function extractDeepPersonaSignals(parsedOutput, prMeta) {
 }
 
 /**
- * Get the known deep-persona flag phrases from the loaded dev-loop config
- * for prompt stability verification.
+ * Return the known deep-persona flag phrase regex sources for inspection.
  *
- * @returns {Promise<Array<string>>}
+ * @returns {Array<string>}
  */
-export async function getDeepPersonaFlagPhrases() {
-  const { config } = await loadDevLoopConfig();
+export function getDeepPersonaFlagPhrases() {
   return FLAG_PATTERNS.map((p) => p.phrase.source);
 }
 
 /**
- * Verify that all known flag phrases appear in the loaded deep persona prompt.
- * Returns an array of missing phrases (empty = all good).
+ * Verify that all known deep-persona flag phrase regex patterns match
+ * the loaded deep persona prompt text. Returns an array of regex sources
+ * whose patterns did not find any match in the prompt (empty = all match).
  *
  * @returns {Promise<Array<string>>}
  */
@@ -258,6 +257,6 @@ export async function verifyPromptStability() {
   const deepPrompt = config?.personas?.deep?.prompt ?? "";
 
   return FLAG_PATTERNS
-    .filter((p) => !deepPrompt.includes(p.phrase.source))
+    .filter((p) => !p.phrase.test(deepPrompt))
     .map((p) => p.phrase.source);
 }

--- a/packages/core/test/deep-persona-signals.test.mjs
+++ b/packages/core/test/deep-persona-signals.test.mjs
@@ -1,12 +1,8 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 import { readFile } from "node:fs/promises";
-import { mkdtemp, rm } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { tmpdir } from "node:os";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 
 import { DebtSignalSchema } from "../src/debt/debt-signal.mjs";
 import {
@@ -18,10 +14,8 @@ import { parseReviewThreads, parseJsonText } from "../src/github/review-threads.
 import {
   parseArgs,
   outputFilename as cliOutputFilename,
-  USAGE,
 } from "../bin/capture-deep-persona-signals.mjs";
 
-const execFileAsync = promisify(execFile);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_PATH = join(__dirname, "fixtures", "github", "review-threads", "deep-persona-threads.json");
 
@@ -47,7 +41,6 @@ describe("deep-persona signal extraction", () => {
       const parsed = await loadAndParseFixture();
       const signals = extractDeepPersonaSignals(parsed, PR_META);
 
-      // Fixture has 7 bot comments: 6 with deep patterns, 1 non-deep bot, 1 human
       assert.equal(signals.length, 6, "Expected 6 deep-persona signals");
     });
 
@@ -192,8 +185,8 @@ describe("deep-persona signal extraction", () => {
 
       assert.ok(signals.length > 0, "Should have at least one signal");
       for (const signal of signals) {
-        const result = DebtSignalSchema.safeParse(signal);
-        assert.ok(result.success, `Signal ${signal.id} should validate: ${result.success ? "" : JSON.stringify(result.error?.issues)}`);
+        // parse() is used now — throws on failure, so reaching here is validation
+        DebtSignalSchema.parse(signal);
       }
     });
 
@@ -228,7 +221,6 @@ describe("deep-persona signal extraction", () => {
 
     test("schema rejects signal with missing required field", () => {
       const badSignal = {
-        // missing id
         sourceType: "pr_review_deep_persona",
         signalKind: "file_size",
         location: {},
@@ -325,7 +317,6 @@ describe("deep-persona signal extraction", () => {
     test("outputFilename format is deterministic", () => {
       const filename = cliOutputFilename("42");
       const parts = filename.split("-");
-      // deep-persona-signals-<prNumber>-<timestamp>.json
       assert.ok(parts.length >= 5);
       assert.equal(parts[0], "deep");
       assert.equal(parts[1], "persona");
@@ -341,13 +332,10 @@ describe("deep-persona signal extraction", () => {
 
       assert.equal(signals.length, 6, "Should extract 6 signals from fixture");
 
-      // Verify each signal is valid
       for (const signal of signals) {
-        const result = DebtSignalSchema.safeParse(signal);
-        assert.ok(result.success, `Signal ${signal.signalKind} should validate`);
+        DebtSignalSchema.parse(signal);
       }
 
-      // Verify signal kinds are distinct across the fixture
       const kinds = new Set(signals.map((s) => s.signalKind));
       assert.ok(kinds.size >= 5, "Should cover at least 5 distinct categories");
     });
@@ -358,16 +346,20 @@ describe("deep-persona signal extraction", () => {
       const phrases = getDeepPersonaFlagPhrases();
       assert.ok(Array.isArray(phrases));
       assert.ok(phrases.length >= 13, "Should have at least 13 known flag phrases");
-      // All phrases should be non-empty strings
       for (const phrase of phrases) {
         assert.ok(typeof phrase === "string" && phrase.length > 0);
       }
     });
 
-    test("verifyPromptStability returns array (may be empty)", async () => {
+    test("verifyPromptStability: all flag phrase regex patterns match the deep persona prompt", async () => {
       const missing = await verifyPromptStability();
-      assert.ok(Array.isArray(missing));
-      // missing may be empty (all patterns match prompt) or contain entries (patterns don't match prompt)
+      assert.deepEqual(
+        missing,
+        [],
+        "All flag phrase regex patterns must match the deep persona prompt. " +
+        "Missing (prompt drift): " + JSON.stringify(missing) +
+        ". Update FLAG_PATTERNS or the deep persona prompt to realign."
+      );
     });
   });
 

--- a/packages/core/test/deep-persona-signals.test.mjs
+++ b/packages/core/test/deep-persona-signals.test.mjs
@@ -314,7 +314,7 @@ describe("deep-persona signal extraction", () => {
       assert.ok(filename.endsWith(".json"));
     });
 
-    test("outputFilename format is deterministic", () => {
+    test("outputFilename has stable structure (prefix, prNumber, timestamp, .json)", () => {
       const filename = cliOutputFilename("42");
       const parts = filename.split("-");
       assert.ok(parts.length >= 5);
@@ -369,7 +369,7 @@ describe("deep-persona signal extraction", () => {
       assert.deepEqual(signals, []);
     });
 
-    test("null body in comment is handled", () => {
+    test("empty body in comment is handled", () => {
       const parsed = {
         comments: [
           {

--- a/packages/core/test/deep-persona-signals.test.mjs
+++ b/packages/core/test/deep-persona-signals.test.mjs
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 import { readFile } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 
 import { DebtSignalSchema } from "../src/debt/debt-signal.mjs";
 import {
@@ -10,8 +14,14 @@ import {
   getDeepPersonaFlagPhrases,
   verifyPromptStability,
 } from "../src/debt/deep-persona-signals.mjs";
-import { parseCliArgs, parseReviewThreads, parseJsonText } from "../src/github/review-threads.mjs";
+import { parseReviewThreads, parseJsonText } from "../src/github/review-threads.mjs";
+import {
+  parseArgs,
+  outputFilename as cliOutputFilename,
+  USAGE,
+} from "../bin/capture-deep-persona-signals.mjs";
 
+const execFileAsync = promisify(execFile);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_PATH = join(__dirname, "fixtures", "github", "review-threads", "deep-persona-threads.json");
 
@@ -238,33 +248,89 @@ describe("deep-persona signal extraction", () => {
 
   describe("CLI args parsing", () => {
     test("valid flags parse correctly", () => {
-      // Test through the parseReviewThreads export; our CLI module also exports parseArgs but it's internal
-      const options = parseCliArgs(["--input", "test.json"]);
-      assert.equal(options.inputPath, "test.json");
+      const opts = parseArgs([
+        "--input", "test.json",
+        "--pr-number", "42",
+        "--pr-url", "https://github.com/owner/repo/pull/42",
+      ]);
+      assert.equal(opts.inputPath, "test.json");
+      assert.equal(opts.prNumber, "42");
+      assert.equal(opts.prUrl, "https://github.com/owner/repo/pull/42");
+      assert.equal(opts.outputDir, ".pi/debt/signals");
     });
 
-    test("unknown flags throw", () => {
+    test("valid flags with custom output-dir parse correctly", () => {
+      const opts = parseArgs([
+        "--input", "test.json",
+        "--pr-number", "42",
+        "--pr-url", "https://github.com/owner/repo/pull/42",
+        "--output-dir", "custom/path",
+      ]);
+      assert.equal(opts.inputPath, "test.json");
+      assert.equal(opts.prNumber, "42");
+      assert.equal(opts.prUrl, "https://github.com/owner/repo/pull/42");
+      assert.equal(opts.outputDir, "custom/path");
+    });
+
+    test("missing required --input throws", () => {
       assert.throws(
-        () => parseCliArgs(["--unknown", "value"]),
+        () => parseArgs(["--pr-number", "42", "--pr-url", "https://example.com"]),
+        /--input is required/,
+      );
+    });
+
+    test("missing required --pr-number throws", () => {
+      assert.throws(
+        () => parseArgs(["--input", "test.json", "--pr-url", "https://example.com"]),
+        /--pr-number is required/,
+      );
+    });
+
+    test("missing required --pr-url throws", () => {
+      assert.throws(
+        () => parseArgs(["--input", "test.json", "--pr-number", "42"]),
+        /--pr-url is required/,
+      );
+    });
+
+    test("unknown flag throws", () => {
+      assert.throws(
+        () => parseArgs(["--input", "test.json", "--pr-number", "42", "--pr-url", "https://example.com", "--unknown"]),
         /Unknown argument/,
       );
     });
 
-    test("missing flag value throws", () => {
+    test("missing value for flagged option throws", () => {
       assert.throws(
-        () => parseCliArgs(["--input"]),
-        /Missing value/,
+        () => parseArgs(["--input", "--pr-number", "42", "--pr-url", "https://example.com"]),
+        /Missing value for --input/,
+      );
+    });
+
+    test("non-numeric pr-number throws", () => {
+      assert.throws(
+        () => parseArgs(["--input", "test.json", "--pr-number", "abc", "--pr-url", "https://example.com"]),
+        /--pr-number must be a positive integer/,
       );
     });
   });
 
   describe("output path generation", () => {
-    test("output filename includes prNumber and ISO timestamp", () => {
-      // We can verify the import works and the outputFilename function exists
-      // The actual format is deterministic: deep-persona-signals-<prNumber>-<ISO-timestamp>.json
-      assert.doesNotThrow(async () => {
-        await import("../src/debt/deep-persona-signals.mjs");
-      });
+    test("outputFilename includes prNumber", () => {
+      const filename = cliOutputFilename("42");
+      assert.ok(filename.startsWith("deep-persona-signals-42-"));
+      assert.ok(filename.endsWith(".json"));
+    });
+
+    test("outputFilename format is deterministic", () => {
+      const filename = cliOutputFilename("42");
+      const parts = filename.split("-");
+      // deep-persona-signals-<prNumber>-<timestamp>.json
+      assert.ok(parts.length >= 5);
+      assert.equal(parts[0], "deep");
+      assert.equal(parts[1], "persona");
+      assert.equal(parts[2], "signals");
+      assert.equal(parts[3], "42");
     });
   });
 
@@ -288,17 +354,20 @@ describe("deep-persona signal extraction", () => {
   });
 
   describe("persona prompt stability guard", () => {
-    test("known flag phrases are defined", async () => {
-      const phrases = await getDeepPersonaFlagPhrases();
+    test("getDeepPersonaFlagPhrases returns known phrase sources", () => {
+      const phrases = getDeepPersonaFlagPhrases();
       assert.ok(Array.isArray(phrases));
       assert.ok(phrases.length >= 13, "Should have at least 13 known flag phrases");
+      // All phrases should be non-empty strings
+      for (const phrase of phrases) {
+        assert.ok(typeof phrase === "string" && phrase.length > 0);
+      }
     });
 
     test("verifyPromptStability returns array (may be empty)", async () => {
       const missing = await verifyPromptStability();
       assert.ok(Array.isArray(missing));
-      // missing may be empty (all phrases found) or contain entries (phrases missing from prompt)
-      // Either is valid; we're asserting the function runs without error
+      // missing may be empty (all patterns match prompt) or contain entries (patterns don't match prompt)
     });
   });
 

--- a/packages/core/test/deep-persona-signals.test.mjs
+++ b/packages/core/test/deep-persona-signals.test.mjs
@@ -1,0 +1,355 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { DebtSignalSchema } from "../src/debt/debt-signal.mjs";
+import {
+  extractDeepPersonaSignals,
+  getDeepPersonaFlagPhrases,
+  verifyPromptStability,
+} from "../src/debt/deep-persona-signals.mjs";
+import { parseCliArgs, parseReviewThreads, parseJsonText } from "../src/github/review-threads.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = join(__dirname, "fixtures", "github", "review-threads", "deep-persona-threads.json");
+
+const PR_META = { prNumber: "412", prUrl: "https://github.com/mfittko/pi-dev-loops/pull/412" };
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+async function loadAndParseFixture() {
+  const raw = await readFile(FIXTURE_PATH, "utf8");
+  const json = parseJsonText(raw);
+  return parseReviewThreads(json);
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("deep-persona signal extraction", () => {
+  describe("mixed-thread identification", () => {
+    test("only bot-authored comments with deep-persona patterns are extracted", async () => {
+      const parsed = await loadAndParseFixture();
+      const signals = extractDeepPersonaSignals(parsed, PR_META);
+
+      // Fixture has 7 bot comments: 6 with deep patterns, 1 non-deep bot, 1 human
+      assert.equal(signals.length, 6, "Expected 6 deep-persona signals");
+    });
+
+    test("human comments are never extracted", async () => {
+      const parsed = await loadAndParseFixture();
+      const signals = extractDeepPersonaSignals(parsed, PR_META);
+
+      const humanSignals = signals.filter(
+        (s) => s.rawPayload?.metadata?.commentId === "c-human-a",
+      );
+      assert.equal(humanSignals.length, 0, "Human comment should not be extracted");
+    });
+
+    test("non-deep bot comments without matching patterns are not extracted", async () => {
+      const parsed = await loadAndParseFixture();
+      const signals = extractDeepPersonaSignals(parsed, PR_META);
+
+      const nonDeepSignals = signals.filter(
+        (s) => s.rawPayload?.metadata?.commentId === "c-bot-nondeep",
+      );
+      assert.equal(nonDeepSignals.length, 0, "Non-deep bot comment should not be extracted");
+    });
+
+    test("resolved thread comments are still extracted", async () => {
+      const parsed = await loadAndParseFixture();
+      const signals = extractDeepPersonaSignals(parsed, PR_META);
+
+      const resolvedSignal = signals.find(
+        (s) => s.rawPayload?.metadata?.commentId === "c-deep-d",
+      );
+      assert.ok(resolvedSignal, "Resolved thread comment should be extracted");
+      assert.equal(resolvedSignal.rawPayload.metadata.isResolved, true);
+    });
+  });
+
+  describe("category mapping", () => {
+    test("file_size: crossing 1000 lines pattern", async () => {
+      const parsed = await loadAndParseFixture();
+      const signals = extractDeepPersonaSignals(parsed, PR_META);
+
+      const fileSizeSignal = signals.find(
+        (s) => s.rawPayload?.metadata?.commentId === "c-deep-a",
+      );
+      assert.ok(fileSizeSignal, "file_size signal should be found");
+      assert.equal(fileSizeSignal.signalKind, "file_size");
+      assert.equal(fileSizeSignal.severityHint, "high");
+      assert.equal(fileSizeSignal.confidence, 0.9);
+    });
+
+    test("spaghetti_branching: conditionals bolted onto unrelated paths", async () => {
+      const parsed = await loadAndParseFixture();
+      const signals = extractDeepPersonaSignals(parsed, PR_META);
+
+      const spaghettiSignal = signals.find(
+        (s) => s.rawPayload?.metadata?.commentId === "c-deep-b",
+      );
+      assert.ok(spaghettiSignal, "spaghetti_branching signal should be found");
+      assert.equal(spaghettiSignal.signalKind, "spaghetti_branching");
+      assert.equal(spaghettiSignal.severityHint, "high");
+    });
+
+    test("thin_wrapper: thin wrapper pattern", async () => {
+      const parsed = await loadAndParseFixture();
+      const signals = extractDeepPersonaSignals(parsed, PR_META);
+
+      const thinSignal = signals.find(
+        (s) => s.rawPayload?.metadata?.commentId === "c-deep-c",
+      );
+      assert.ok(thinSignal, "thin_wrapper signal should be found");
+      assert.equal(thinSignal.signalKind, "thin_wrapper");
+      assert.equal(thinSignal.severityHint, "medium");
+    });
+
+    test("leaky_feature_logic: leaking into shared pattern", async () => {
+      const parsed = await loadAndParseFixture();
+      const signals = extractDeepPersonaSignals(parsed, PR_META);
+
+      const leakySignal = signals.find(
+        (s) => s.rawPayload?.metadata?.commentId === "c-deep-d",
+      );
+      assert.ok(leakySignal, "leaky_feature_logic signal should be found");
+      assert.equal(leakySignal.signalKind, "leaky_feature_logic");
+      assert.equal(leakySignal.severityHint, "high");
+    });
+
+    test("weak_contract: cast-heavy and any-typed contracts", async () => {
+      const parsed = await loadAndParseFixture();
+      const signals = extractDeepPersonaSignals(parsed, PR_META);
+
+      const weakSignal = signals.find(
+        (s) => s.rawPayload?.metadata?.commentId === "c-deep-e",
+      );
+      assert.ok(weakSignal, "weak_contract signal should be found");
+      assert.equal(weakSignal.signalKind, "weak_contract");
+      assert.equal(weakSignal.severityHint, "medium");
+    });
+
+    test("simplification_opportunity: code judo and prefer deletion", async () => {
+      const parsed = await loadAndParseFixture();
+      const signals = extractDeepPersonaSignals(parsed, PR_META);
+
+      const simplificationSignal = signals.find(
+        (s) => s.rawPayload?.metadata?.commentId === "c-deep-f",
+      );
+      assert.ok(simplificationSignal, "simplification_opportunity signal should be found");
+      assert.equal(simplificationSignal.signalKind, "simplification_opportunity");
+      assert.equal(simplificationSignal.severityHint, "medium");
+    });
+  });
+
+  describe("location extraction", () => {
+    test("file path extracted from comment body", async () => {
+      const parsed = await loadAndParseFixture();
+      const signals = extractDeepPersonaSignals(parsed, PR_META);
+
+      const fileSizeSignal = signals.find(
+        (s) => s.rawPayload?.metadata?.commentId === "c-deep-a",
+      );
+      assert.ok(fileSizeSignal);
+      assert.equal(
+        fileSizeSignal.location.filePath,
+        "packages/core/src/loop/conductor.mjs",
+      );
+    });
+
+    test("empty location when no file path in comment", async () => {
+      const parsed = await loadAndParseFixture();
+      const signals = extractDeepPersonaSignals(parsed, PR_META);
+
+      const spaghettiSignal = signals.find(
+        (s) => s.rawPayload?.metadata?.commentId === "c-deep-b",
+      );
+      assert.ok(spaghettiSignal);
+      assert.deepEqual(spaghettiSignal.location, {});
+    });
+  });
+
+  describe("schema compatibility", () => {
+    test("generated signals validate against DebtSignalSchema", async () => {
+      const parsed = await loadAndParseFixture();
+      const signals = extractDeepPersonaSignals(parsed, PR_META);
+
+      assert.ok(signals.length > 0, "Should have at least one signal");
+      for (const signal of signals) {
+        const result = DebtSignalSchema.safeParse(signal);
+        assert.ok(result.success, `Signal ${signal.id} should validate: ${result.success ? "" : JSON.stringify(result.error?.issues)}`);
+      }
+    });
+
+    test("all required fields are present in generated signals", async () => {
+      const parsed = await loadAndParseFixture();
+      const signals = extractDeepPersonaSignals(parsed, PR_META);
+
+      const firstSignal = signals[0];
+      assert.ok(typeof firstSignal.id === "string" && firstSignal.id.length > 0, "id required");
+      assert.equal(firstSignal.sourceType, "pr_review_deep_persona", "sourceType required");
+      assert.ok(typeof firstSignal.signalKind === "string" && firstSignal.signalKind.length > 0, "signalKind required");
+      assert.ok(typeof firstSignal.location === "object" && firstSignal.location !== null, "location required");
+      assert.ok(["info", "low", "medium", "high", "critical"].includes(firstSignal.severityHint), "severityHint required and valid");
+      assert.ok(typeof firstSignal.timestamp === "string", "timestamp required");
+    });
+
+    test("metadata includes prNumber, prUrl, commentId, threadId, isResolved, category, matchedPhrase", async () => {
+      const parsed = await loadAndParseFixture();
+      const signals = extractDeepPersonaSignals(parsed, PR_META);
+
+      const firstSignal = signals[0];
+      const meta = firstSignal.rawPayload?.metadata;
+      assert.ok(meta, "metadata should exist in rawPayload");
+      assert.equal(meta.prNumber, "412");
+      assert.equal(meta.prUrl, "https://github.com/mfittko/pi-dev-loops/pull/412");
+      assert.ok(typeof meta.commentId === "string");
+      assert.ok(typeof meta.threadId === "string");
+      assert.ok(typeof meta.isResolved === "boolean");
+      assert.ok(typeof meta.category === "string");
+      assert.ok(meta.matchedPhrase !== null && meta.matchedPhrase !== undefined);
+    });
+
+    test("schema rejects signal with missing required field", () => {
+      const badSignal = {
+        // missing id
+        sourceType: "pr_review_deep_persona",
+        signalKind: "file_size",
+        location: {},
+        severityHint: "high",
+        timestamp: "2026-06-03T12:00:00Z",
+      };
+      const result = DebtSignalSchema.safeParse(badSignal);
+      assert.equal(result.success, false);
+      if (!result.success) {
+        assert.ok(
+          result.error.issues.some((i) => i.path.includes("id")),
+          "Should flag missing id",
+        );
+      }
+    });
+  });
+
+  describe("CLI args parsing", () => {
+    test("valid flags parse correctly", () => {
+      // Test through the parseReviewThreads export; our CLI module also exports parseArgs but it's internal
+      const options = parseCliArgs(["--input", "test.json"]);
+      assert.equal(options.inputPath, "test.json");
+    });
+
+    test("unknown flags throw", () => {
+      assert.throws(
+        () => parseCliArgs(["--unknown", "value"]),
+        /Unknown argument/,
+      );
+    });
+
+    test("missing flag value throws", () => {
+      assert.throws(
+        () => parseCliArgs(["--input"]),
+        /Missing value/,
+      );
+    });
+  });
+
+  describe("output path generation", () => {
+    test("output filename includes prNumber and ISO timestamp", () => {
+      // We can verify the import works and the outputFilename function exists
+      // The actual format is deterministic: deep-persona-signals-<prNumber>-<ISO-timestamp>.json
+      assert.doesNotThrow(async () => {
+        await import("../src/debt/deep-persona-signals.mjs");
+      });
+    });
+  });
+
+  describe("end-to-end fixture flow", () => {
+    test("fixture → parse → extract → validate completes without error", async () => {
+      const parsed = await loadAndParseFixture();
+      const signals = extractDeepPersonaSignals(parsed, PR_META);
+
+      assert.equal(signals.length, 6, "Should extract 6 signals from fixture");
+
+      // Verify each signal is valid
+      for (const signal of signals) {
+        const result = DebtSignalSchema.safeParse(signal);
+        assert.ok(result.success, `Signal ${signal.signalKind} should validate`);
+      }
+
+      // Verify signal kinds are distinct across the fixture
+      const kinds = new Set(signals.map((s) => s.signalKind));
+      assert.ok(kinds.size >= 5, "Should cover at least 5 distinct categories");
+    });
+  });
+
+  describe("persona prompt stability guard", () => {
+    test("known flag phrases are defined", async () => {
+      const phrases = await getDeepPersonaFlagPhrases();
+      assert.ok(Array.isArray(phrases));
+      assert.ok(phrases.length >= 13, "Should have at least 13 known flag phrases");
+    });
+
+    test("verifyPromptStability returns array (may be empty)", async () => {
+      const missing = await verifyPromptStability();
+      assert.ok(Array.isArray(missing));
+      // missing may be empty (all phrases found) or contain entries (phrases missing from prompt)
+      // Either is valid; we're asserting the function runs without error
+    });
+  });
+
+  describe("edge cases", () => {
+    test("empty comments array returns empty signals", () => {
+      const signals = extractDeepPersonaSignals({ comments: [] }, PR_META);
+      assert.deepEqual(signals, []);
+    });
+
+    test("null body in comment is handled", () => {
+      const parsed = {
+        comments: [
+          {
+            id: "c-1",
+            threadId: "t-1",
+            author: { login: "copilot-pull-request-reviewer[bot]", type: "Bot", isBot: true },
+            body: "",
+            isActionable: true,
+          },
+        ],
+      };
+      const signals = extractDeepPersonaSignals(parsed, PR_META);
+      assert.deepEqual(signals, []);
+    });
+
+    test("invalid parsed output throws", () => {
+      assert.throws(
+        () => extractDeepPersonaSignals(null, PR_META),
+        /Invalid parsed output/,
+      );
+      assert.throws(
+        () => extractDeepPersonaSignals({}, PR_META),
+        /Invalid parsed output/,
+      );
+    });
+
+    test("spaghetti keyword matches without full phrase", () => {
+      const parsed = {
+        comments: [
+          {
+            id: "c-spaghetti",
+            threadId: "t-1",
+            author: { login: "copilot-pull-request-reviewer[bot]", type: "Bot", isBot: true },
+            body: "This module has spaghetti code that needs refactoring.",
+            isActionable: true,
+          },
+        ],
+      };
+      const signals = extractDeepPersonaSignals(parsed, PR_META);
+      assert.equal(signals.length, 1);
+      assert.equal(signals[0].signalKind, "spaghetti_branching");
+    });
+  });
+});

--- a/packages/core/test/fixtures/github/review-threads/deep-persona-threads.json
+++ b/packages/core/test/fixtures/github/review-threads/deep-persona-threads.json
@@ -1,0 +1,156 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "reviewThreads": {
+          "nodes": [
+            {
+              "id": "t-deep-1",
+              "isResolved": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "id": "c-deep-a",
+                    "body": "Flag: packages/core/src/loop/conductor.mjs is crossing 1000 lines without strong justification. This file needs splitting.",
+                    "author": {
+                      "login": "copilot-pull-request-reviewer[bot]",
+                      "__typename": "Bot"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "id": "t-deep-2",
+              "isResolved": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "id": "c-deep-b",
+                    "body": "This PR adds conditionals bolted onto unrelated paths. The retry logic is scattered across three different modules — please consolidate into one boundary.",
+                    "author": {
+                      "login": "copilot-pull-request-reviewer[bot]",
+                      "__typename": "Bot"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "id": "t-deep-3",
+              "isResolved": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "id": "c-deep-c",
+                    "body": "The new middlewares/auth.mjs module is a thin wrapper around the existing auth helper. Consider inlining or removing the extra layer.",
+                    "author": {
+                      "login": "copilot-pull-request-reviewer[bot]",
+                      "__typename": "Bot"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "id": "t-deep-4",
+              "isResolved": true,
+              "comments": {
+                "nodes": [
+                  {
+                    "id": "c-deep-d",
+                    "body": "Feature logic leaking into shared utilities. The shared/config.mjs now contains user-role awareness that belongs in a dedicated authorization module.",
+                    "author": {
+                      "login": "copilot-pull-request-reviewer[bot]",
+                      "__typename": "Bot"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "id": "t-deep-5",
+              "isResolved": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "id": "c-deep-e",
+                    "body": "The handler signature uses cast-heavy and any-typed contracts. The real invariant is a string→Result pipeline; express that explicitly.",
+                    "author": {
+                      "login": "copilot-pull-request-reviewer[bot]",
+                      "__typename": "Bot"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "id": "t-deep-6",
+              "isResolved": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "id": "c-deep-f",
+                    "body": "Code judo opportunity: the new validation layer duplicates checks already present in the schema. Prefer deletion over addition here.",
+                    "author": {
+                      "login": "copilot-pull-request-reviewer[bot]",
+                      "__typename": "Bot"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "id": "t-deep-7",
+              "isResolved": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "id": "c-deep-g",
+                    "body": "General feedback about the PR structure.",
+                    "author": {
+                      "login": "copilot-pull-request-reviewer[bot]",
+                      "__typename": "Bot"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "id": "t-human-1",
+              "isResolved": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "id": "c-human-a",
+                    "body": "Please add more tests for the edge cases.",
+                    "author": {
+                      "login": "human-reviewer",
+                      "__typename": "User"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "id": "t-bot-nondeep",
+              "isResolved": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "id": "c-bot-nondeep",
+                    "body": "Automated CI check: coverage dropped by 2%.",
+                    "author": {
+                      "login": "codecov[bot]",
+                      "__typename": "Bot"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Change summary

Add a deterministic signal extraction module and CLI that consume normalized review-thread JSON, identify deep-persona structural quality flags via pattern matching, and emit validated `debt_signal` artifacts to `.pi/debt/signals/`.

## Scope / context

- Implements issue #412
- Depends on #411 (`debt_signal` canonical schema) — already landed
- New module: `packages/core/src/debt/deep-persona-signals.mjs`
- New CLI: `packages/core/bin/capture-deep-persona-signals.mjs`
- New tests: `packages/core/test/deep-persona-signals.test.mjs` (27 tests)
- New fixture: `packages/core/test/fixtures/github/review-threads/deep-persona-threads.json`
- Updated `packages/core/package.json`: exports `./debt/signals`, bin entry `pi-dev-loops-capture-deep-persona-signals`

### Pattern matching categories

| Category | Trigger phrases | Severity |
|---|---|---|
| `file_size` | "crossing 1000 lines" | high |
| `spaghetti_branching` | "conditionals bolted onto unrelated paths", "spaghetti" | high |
| `thin_wrapper` | "thin wrappers", "re-export-only", "identity abstractions" | medium |
| `leaky_feature_logic` | "feature logic leaking into", "leaking into shared" | high |
| `weak_contract` | "cast-heavy", "optionality-heavy", "any-typed contracts" | medium |
| `simplification_opportunity` | "code judo", "prefer deletion over addition" | medium |

## Acceptance criteria

- [x] Script/helper extracts deep persona flags from review output
- [x] Output validates against debt_signal schema (#411)
- [x] npm test passes locally (27 new tests all pass; 6 pre-existing failures in worktree-path env)
- [ ] CI passes on Node 24

## Definition of done

- [x] `packages/core/src/debt/deep-persona-signals.mjs` committed with extraction logic
- [x] `packages/core/bin/capture-deep-persona-signals.mjs` committed with CLI surface
- [x] `packages/core/package.json` exports and bin entries updated
- [x] `.pi/debt/signals/` output path conventions documented (CLI default)
- [x] Contract tests committed (27 tests covering identification, category mapping, location extraction, schema compatibility, CLI args, E2E fixture flow, prompt stability guard, edge cases)
- [ ] Coverage ≥ 90% on `packages/core/src/debt/`
- [x] Integration test proving end-to-end flow from fixture to validated artifact
- [ ] `npm test` passes at repo root
- [ ] CI passes on Node 24

## Non-goals

- Generalizing to all PR review personas (future)
- Automated remediation from signals
- Full debt_finding aggregation (next issue)
- Changing the deep persona prompt text to emit structured output
- Building a generic debt dashboard or UI
- Scoring, ranking, or prioritizing signals beyond severity classification