### PR TITLE
feat: add audit-derived draft-gate personas + script resilience (#418)

### DIFF
--- a/.pi/dev-loop/defaults.yaml
+++ b/.pi/dev-loop/defaults.yaml
@@ -19,11 +19,18 @@ refinement:
 # Consumers can add, remove, or reorder angles per gate.
 gates:
   draft:
-    # Draft gate: runs before marking PR ready for review
+    # Draft gate: runs before marking PR ready for review.
+    # Default angles: scope, coverage, correctness, ci-guard.
+    # Opt-in angles (uncomment to add):
+    #   - link-check
+    #   - config-drift
+    #   - gate-evidence
+    #   - no-op
     angles:
       - scope
       - coverage
       - correctness
+      - ci-guard
     required: true
     # When true, draft gate waits for green CI before the gate may run.
     requireCi: true
@@ -107,6 +114,13 @@ personas:
       Check whether tests cover the changed behavior adequately.
       Look for missing edge cases, untested error paths,
       and acceptance-criteria gaps.
+      Also flag test-name quality issues: test names that misrepresent
+      what is actually asserted, overly broad names that hide gaps, and
+      names that don't match the behavior under test.
+      Flag missing negative-case coverage: malformed-argument tests,
+      error-contract tests, and edge-case coverage for boundary
+      conditions, empty inputs, and unexpected states.
+      Do not accept happy-path-only test suites.
     defaultModel: null
 
   correctness:
@@ -125,9 +139,11 @@ personas:
       navigable doc references are actual markdown links rather than bare
       backtick path mentions, command/script references still exist and use
       current names, and index/surface references match the current file tree.
-      When the repo provides `scripts/docs/validate-links.mjs`, use it for the
-      mechanical link pass; otherwise keep the review scoped to the touched doc
-      surface and current change only.
+      Also flag stale command references: removed or renamed npm scripts,
+      CLI commands, or tool invocations that no longer match the current
+      codebase. When the repo provides `scripts/docs/validate-links.mjs`,
+      use it for the mechanical link pass; otherwise keep the review scoped
+      to the touched doc surface and current change only.
     defaultModel: null
 
   deep:
@@ -240,4 +256,83 @@ personas:
       Flag speculative features, future-proofing, and compatibility shims
       not required by the current acceptance criteria.
       YAGNI = You Aren't Gonna Need It.
+    defaultModel: null
+
+  # ── Audit-derived draft-gate personas ──────────────────────────────
+
+  ci-guard:
+    persona: review
+    prompt: >-
+      Audit CI/workflow semantics for reproducibility and correctness:
+      - Verify CI configuration is deterministic (no floating version ranges
+        in install steps, lockfile is respected).
+      - Check that branch-protection rules and status-check requirements
+        match the stated merge policy.
+      - Flag non-reproducible install steps and missing lockfile enforcement.
+      - Verify that CI failure precedence is correct: a failing required check
+        must block merge regardless of other passing checks.
+      - Flag Node.js support-floor mismatches between CI matrices,
+        package.json engines, and documented requirements.
+      - Flag pending check-run states that could silently hide failures.
+    defaultModel: null
+
+  link-check:
+    persona: review
+    prompt: >-
+      Validate link and path correctness:
+      - Check that all Markdown relative links resolve to existing files
+        or sections.
+      - Flag placeholder links (e.g. href targets still using example URLs,
+        404 references, or TODO links).
+      - When the repo provides `scripts/docs/validate-links.mjs`, run it
+        for the mechanical link pass and report any failures.
+      - Flag symlink-backed doc pointers that point to missing targets.
+      - This persona complements mechanical link validation with context-aware
+        judgment for link intent and anchor correctness.
+    defaultModel: null
+
+  config-drift:
+    persona: review
+    prompt: >-
+      Cross-check config, schema, and documentation for contract drift:
+      - Verify that configuration files (.pi/dev-loop/settings.yaml,
+        package.json, CI workflows, skill manifests) agree on canonical
+        status tokens, support floors, and required flags.
+      - Flag any instance where two sources of truth disagree about the
+        supported contract (e.g. one doc says a flag is required, another
+        says it's optional).
+      - Check that the engines.node field matches CI matrix and any
+        documented Node.js support floor.
+      - Flag inconsistencies within a single doc that could confuse
+        consumers (e.g. one section says "default: true" and another
+        section implies the opposite).
+    defaultModel: null
+
+  gate-evidence:
+    persona: review
+    prompt: >-
+      Verify that required workflow gate evidence is present and valid:
+      - Check that the draft gate review comment exists and references the
+        correct head SHA.
+      - Check that the pre-approval gate review comment exists when the PR
+        is in a ready/merge state.
+      - Flag any PR that transitions to ready/merge states without visible
+        gate evidence for the current head.
+      - When draft-first enforcement is configured, verify that a draft-gate
+        comment was posted before the PR was marked ready.
+      - This persona runs on draft gate by default; on first PR it checks for
+        any gate evidence (not only draft_gate since no prior gate exists).
+    defaultModel: null
+
+  no-op:
+    persona: review
+    prompt: >-
+      Flag workflow or tool invocations that are effectively no-ops:
+      - Check that shell commands and tool calls actually affect output,
+        state, or exit behavior rather than discarding their effect.
+      - Flag tool invocations that look successful but pass arguments in
+        a way that produces no meaningful change.
+      - Flag commands whose output is generated but never consumed.
+      - Flag patterns where a tool is called in a loop but only the last
+        iteration's result is used (or none at all).
     defaultModel: null

--- a/.pi/dev-loop/defaults.yaml
+++ b/.pi/dev-loop/defaults.yaml
@@ -320,8 +320,9 @@ personas:
         gate evidence for the current head.
       - When draft-first enforcement is configured, verify that a draft-gate
         comment was posted before the PR was marked ready.
-      - This persona runs on draft gate by default; on first PR it checks for
-        any gate evidence (not only draft_gate since no prior gate exists).
+      - This persona is opt-in for the draft gate (uncomment to add).
+        On first PR it checks for any gate evidence (not only draft_gate since
+        no prior gate exists).
     defaultModel: null
 
   no-op:

--- a/docs/audit-copilot-comments.md
+++ b/docs/audit-copilot-comments.md
@@ -1,0 +1,113 @@
+# Audit Copilot Comments
+
+Script: `scripts/github/audit-copilot-comments.mjs`
+
+## Purpose
+
+Scan all pull-request review comments in a repository via the GitHub REST API, filter to Copilot-authored comments, classify them into workflow-category buckets, and produce a JSON summary and a Markdown report. The output is designed to inform draft-gate persona decisions: which recurring comment categories should be caught by a deterministic gate review rather than consuming Copilot review budget.
+
+## Usage
+
+```bash
+node scripts/github/audit-copilot-comments.mjs --repo <owner/name> [--output-dir <path>] [--sleep-ms <ms>] [--checkpoint-file <path>] [--resume]
+```
+
+### Flags
+
+| Flag | Required | Default | Description |
+|---|---|---|---|
+| `--repo` | yes | — | Repository slug (e.g. `mfittko/pi-dev-loops`) |
+| `--output-dir` | no | `tmp/investigation` | Directory for JSON and Markdown output files |
+| `--sleep-ms` | no | `0` | Sleep this many ms between top-level fetches (non-negative int) |
+| `--checkpoint-file` | no | — | Save/load coarse-grain checkpoint for resume |
+| `--resume` | no | `false` | Resume from checkpoint (requires `--checkpoint-file`) |
+| `--help`, `-h` | no | — | Print usage and exit |
+
+### Checkpoint stages
+
+| Stage | What's saved | Resume behavior |
+|---|---|---|
+| `after-comments` | Comments fetched, saved | Re-fetch only PRs, then complete |
+| `after-prs` | Both fetched, saved | Skip both fetches, rebuild summary from checkpoint |
+
+Checkpoint corruption (missing file, invalid JSON, missing stage): `--resume` falls back to a fresh fetch.
+
+### Resilience
+
+- **403 (rate limit)** and **429 (secondary rate limit)** responses trigger exponential backoff: up to 5 retries, 1 s base delay.
+- **401 (authentication)** fails immediately with no retry.
+- **`gh` not authenticated**: fails immediately.
+
+## Output
+
+Two files written to `--output-dir`:
+
+| File | Description |
+|---|---|
+| `copilot-comment-summary.json` | Full structured JSON with totals, categories, recommendations, and per-comment classifications |
+| `copilot-comment-categories.md` | Human-readable Markdown report with top-category table, priority-ranked recommendations, and category details |
+
+Stdout also emits the same JSON summary.
+
+## Taxonomy table
+
+12 classification categories, each with pattern-matching rules, recommended lens/linter, automation fit, and priority weight:
+
+| ID | Label | Priority | Fit | Recommended lens |
+|---|---|---|---|---|
+| `placeholder_404` | 404 placeholders | 3 | strong | link validator |
+| `broken_paths` | Broken relative paths | 3 | strong | link validator |
+| `stale_commands` | Stale commands | 3 | hybrid | docs angle |
+| `gate_evidence` | Gate evidence | 5 | strong | gate evidence lens |
+| `ci_guard` | CI guard | 5 | hybrid | correctness / CI lens |
+| `unused_imports` | Unused imports | 2 | strong | ESLint / dead-code linter |
+| `incomplete_coverage` | Incomplete coverage | 5 | hybrid | coverage angle |
+| `misleading_tests` | Misleading tests | 4 | copilot | coverage / test-quality angle |
+| `config_conflicts` | Config conflicts | 4 | copilot | config drift lens |
+| `duplicate_content` | Duplicate content | 2 | hybrid | docs angle |
+| `no_op_tool_usage` | No-op tool usage | 3 | hybrid | workflow enforcement lens |
+| `grammar` | Grammar / wording | 1 | copilot | docs angle |
+
+## Recommendation lens mapping
+
+The audit groups categories into recommendations ranked by `score = Σ(count × priorityWeight)`:
+
+| Recommendation key | Categories | Owner |
+|---|---|---|
+| `coverage-angle` | incomplete_coverage, misleading_tests | review angle |
+| `docs-angle` | stale_commands, grammar, duplicate_content | review angle |
+| `link-validator` | broken_paths, placeholder_404 | validator |
+| `gate-evidence-lens` | gate_evidence | workflow gate |
+| `ci-guard-lens` | ci_guard | review angle |
+| `dead-code-lint` | unused_imports | linter |
+| `config-drift-lens` | config_conflicts | review angle |
+| `workflow-noop-lens` | no_op_tool_usage | review angle |
+
+## Draft-gate persona derivation
+
+Audit findings are the primary input for deciding which personas to add to `.pi/dev-loop/defaults.yaml` and which draft gate angles to enable. The canonical derived personas from this repo's audit:
+
+| Persona | Gate wiring | Priority | Source category |
+|---|---|---|---|
+| `ci-guard` | Default draft gate | 1 | ci_guard (67 comments) |
+| `link-check` | Opt-in draft gate | 4 | placeholder_404 + broken_paths (36) |
+| `config-drift` | Opt-in draft gate | 5 | config_conflicts (27) |
+| `gate-evidence` | Opt-in draft gate | 6 | gate_evidence (13) |
+| `no-op` | Opt-in draft gate | 7 | no_op_tool_usage (11) |
+
+## Edge cases
+
+| Case | Behavior |
+|---|---|
+| Empty repo (no PRs) | Empty comments/prs arrays, totals all zero, exit 0 |
+| Repo with only non-Copilot comments | `copilotComments: 0`, all category counts zero |
+| Checkpoint file corruption | `--resume` falls back to fresh fetch |
+| 403/429 mid-fetch | Exponential backoff, max 5 retries |
+| `gh` not authenticated (401) | Fail immediately, no retry |
+| `--resume` without `--checkpoint-file` | CLI validation error |
+
+## See also
+
+- [Public Dev Loop Contract](../skills/docs/public-dev-loop-contract.md) — canonical routing contract
+- [.pi/dev-loop/defaults.yaml](../.pi/dev-loop/defaults.yaml) — persona and gate angle registry
+- [Gate Review Comment Contract](./gate-review-comment-contract.md) — gate comment format contract

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ Start here for repository documentation.
 - [Copilot Loop State Graph](./copilot-loop-state-graph.md)
 - [Reviewer Loop State Graph](./reviewer-loop-state-graph.md)
 - [Gate Review Comment Contract](./gate-review-comment-contract.md)
+- [Audit Copilot Comments](./audit-copilot-comments.md) — Copilot comment audit script, taxonomy, and persona derivation
 - [Worktree Usage Guidance](./worktree-guidance.md) — canonical local checkout isolation and cleanup rules
 - [Steering Contract](./steering-contract.md)
 - [UI Validation Contract](./ui-validation-contract.md)

--- a/scripts/github/audit-copilot-comments.mjs
+++ b/scripts/github/audit-copilot-comments.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { buildParseError, formatCliError, isCopilotLogin, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
@@ -9,18 +9,35 @@ import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 const DEFAULT_OUTPUT_DIR = "tmp/investigation";
 const DEFAULT_JSON_NAME = "copilot-comment-summary.json";
 const DEFAULT_MARKDOWN_NAME = "copilot-comment-categories.md";
+const DEFAULT_RETRY_MAX = 5;
+const DEFAULT_RETRY_BASE_MS = 1000;
 
-const USAGE = `Usage: audit-copilot-comments.mjs --repo <owner/name> [--output-dir <path>]
+const USAGE = `Usage: audit-copilot-comments.mjs --repo <owner/name> [--output-dir <path>] [--sleep-ms <ms>] [--checkpoint-file <path>] [--resume]
 
 Scan all pull-request review comments in a repository via the GitHub REST API,
 filter to Copilot-authored comments, classify them into workflow categories, and
 write both a JSON summary and a Markdown report under the requested output directory.
 
 Required:
-  --repo <owner/name>     Repository slug (e.g. owner/repo)
+  --repo <owner/name>       Repository slug (e.g. owner/repo)
 
 Optional:
-  --output-dir <path>     Output directory (default: tmp/investigation)
+  --output-dir <path>       Output directory (default: tmp/investigation)
+  --sleep-ms <ms>           Sleep this many ms between top-level fetches (non-negative int, default: 0)
+  --checkpoint-file <path>  Save/load coarse-grain checkpoint for resume
+  --resume                  Resume from checkpoint file (requires --checkpoint-file)
+
+Checkpoint stages:
+  after-comments  — comments fetch complete, saved
+  after-prs       — PRs fetch complete, saved (full checkpoint)
+
+On --resume with a valid checkpoint:
+  - If stage is after-comments: re-fetch only PRs, then complete.
+  - If stage is after-prs: skip fetches and rebuild summary from checkpoint directly.
+
+Resilience:
+  - 403 and 429 responses trigger exponential backoff (${DEFAULT_RETRY_MAX} retries, ${DEFAULT_RETRY_BASE_MS}ms base).
+  - Auth failures (401) and other non-retryable errors fail immediately.
 
 Output (stdout, JSON summary; abbreviated example):
   {
@@ -195,7 +212,7 @@ const CATEGORY_DEFINITIONS = [
       /error-contract/i,
       /malformed-argument/i,
       /happy\s+path\s+only/i,
-      /doesn['’]t\s+exercise/i,
+      /doesn['']t\s+exercise/i,
       /should\s+test/i,
     ],
   },
@@ -213,7 +230,7 @@ const CATEGORY_DEFINITIONS = [
       /assertions?\s+match\s+very\s+long/i,
       /test\s+can\s+hang/i,
       /brittle\s+to\s+minor\s+copy\s+edits/i,
-      /doesn['’]t\s+actually\s+assert/i,
+      /doesn['']t\s+actually\s+assert/i,
       /claims?\s+.*\s+but/i,
       /confus(?:ing|e)\s+test/i,
       /helper\s+never\s+listens/i,
@@ -358,6 +375,89 @@ const RECOMMENDATION_DEFINITIONS = [
     rationale: "The workflow should flag tool invocations that look successful but do nothing or silently drop important effects.",
   },
 ];
+
+// ── Resilience helpers ──────────────────────────────────────────────
+
+function isRetryableHttpError(stderrText) {
+  return /\bHTTP 403\b/i.test(stderrText) || /\bHTTP 429\b/i.test(stderrText);
+}
+
+function isAuthError(stderrText) {
+  return /\bHTTP 401\b/i.test(stderrText);
+}
+
+/**
+ * Retry a gh JSON call with exponential backoff on 403/429.
+ * Fails immediately on 401 (auth) or other non-retryable errors.
+ */
+export async function runGhJsonWithRetry(args, { env, ghCommand, retryMax = DEFAULT_RETRY_MAX, retryBaseMs = DEFAULT_RETRY_BASE_MS } = {}) {
+  let lastError = null;
+
+  for (let attempt = 0; attempt <= retryMax; attempt += 1) {
+    const result = await runChild(ghCommand, args, env);
+
+    if (result.code === 0) {
+      const commandLabel = `${ghCommand} ${args.join(" ")}`;
+      try {
+        return parseJsonText(result.stdout);
+      } catch (parseErr) {
+        throw new Error(`Invalid JSON from ${commandLabel}`);
+      }
+    }
+
+    const stderrText = result.stderr || "";
+
+    if (isAuthError(stderrText)) {
+      throw new Error(`gh command failed: ${stderrText.trim()}`);
+    }
+
+    if (!isRetryableHttpError(stderrText) || attempt === retryMax) {
+      const detail = stderrText.trim() || `exit code ${result.code}`;
+      throw new Error(`gh command failed: ${detail}`);
+    }
+
+    lastError = new Error(`gh command failed: ${stderrText.trim()}`);
+    const delay = retryBaseMs * (2 ** attempt);
+    await new Promise((resolve) => { setTimeout(resolve, delay); });
+  }
+
+  throw lastError;
+}
+
+// ── Checkpoint helpers ──────────────────────────────────────────────
+
+async function loadCheckpoint(checkpointPath) {
+  let raw;
+  try {
+    raw = await readFile(checkpointPath, "utf8");
+  } catch {
+    return null;
+  }
+
+  try {
+    const data = JSON.parse(raw);
+    if (data && typeof data === "object" && data.stage) {
+      return data;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function saveCheckpoint(checkpointPath, data) {
+  await writeFile(checkpointPath, `${JSON.stringify(data)}\n`, "utf8");
+}
+
+// ── Sleep helper ─────────────────────────────────────────────────────
+
+async function sleepStep(sleepMs) {
+  if (sleepMs > 0) {
+    await new Promise((resolve) => { setTimeout(resolve, sleepMs); });
+  }
+}
+
+// ── Core script functions ────────────────────────────────────────────
 
 function excerptText(body, maxLength = 200) {
   const normalized = String(body ?? "").replace(/\s+/g, " ").trim();
@@ -659,31 +759,25 @@ export function renderMarkdownReport(summary) {
   return `${lines.join("\n").trimEnd()}\n`;
 }
 
-async function runGhJson(args, { env, ghCommand }) {
-  const result = await runChild(ghCommand, args, env);
+// ── Fetch with retry ─────────────────────────────────────────────────
 
-  if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw new Error(`gh command failed: ${detail}`);
-  }
-
-  const commandLabel = `${ghCommand} ${args.join(" ")}`;
-  try {
-    return parseJsonText(result.stdout);
-  } catch (error) {
-    throw new Error(`Invalid JSON from ${commandLabel}`);
-  }
-}
-
-async function fetchAllReviewComments(repo, { env, ghCommand }) {
-  const payload = await runGhJson(["api", "--paginate", "--slurp", `repos/${repo}/pulls/comments?per_page=100`], { env, ghCommand });
+async function fetchAllReviewComments(repo, { env, ghCommand, retryMax, retryBaseMs }) {
+  const payload = await runGhJsonWithRetry(
+    ["api", "--paginate", "--slurp", `repos/${repo}/pulls/comments?per_page=100`],
+    { env, ghCommand, retryMax, retryBaseMs },
+  );
   return normalizePaginatedArrayPayload(payload, "Copilot review comments");
 }
 
-async function fetchAllPullRequests(repo, { env, ghCommand }) {
-  const payload = await runGhJson(["api", "--paginate", "--slurp", `repos/${repo}/pulls?state=all&per_page=100`], { env, ghCommand });
+async function fetchAllPullRequests(repo, { env, ghCommand, retryMax, retryBaseMs }) {
+  const payload = await runGhJsonWithRetry(
+    ["api", "--paginate", "--slurp", `repos/${repo}/pulls?state=all&per_page=100`],
+    { env, ghCommand, retryMax, retryBaseMs },
+  );
   return normalizePaginatedArrayPayload(payload, "pull requests");
 }
+
+// ── Output writer ────────────────────────────────────────────────────
 
 async function writeOutputs(summary, markdown) {
   await mkdir(summary.files.outputDir, { recursive: true });
@@ -691,12 +785,17 @@ async function writeOutputs(summary, markdown) {
   await writeFile(summary.files.markdownReportPath, markdown, "utf8");
 }
 
+// ── CLI argument parsing ─────────────────────────────────────────────
+
 export function parseAuditCopilotCommentsCliArgs(argv) {
   const args = [...argv];
   const options = {
     help: false,
     repo: undefined,
     outputDir: DEFAULT_OUTPUT_DIR,
+    sleepMs: 0,
+    checkpointFile: undefined,
+    resume: false,
   };
 
   while (args.length > 0) {
@@ -717,6 +816,26 @@ export function parseAuditCopilotCommentsCliArgs(argv) {
       continue;
     }
 
+    if (token === "--sleep-ms") {
+      const raw = requireOptionValue(args, "--sleep-ms", parseError).trim();
+      const parsed = Number(raw);
+      if (!Number.isInteger(parsed) || parsed < 0) {
+        throw parseError("--sleep-ms must be a non-negative integer");
+      }
+      options.sleepMs = parsed;
+      continue;
+    }
+
+    if (token === "--checkpoint-file") {
+      options.checkpointFile = requireOptionValue(args, "--checkpoint-file", parseError).trim();
+      continue;
+    }
+
+    if (token === "--resume") {
+      options.resume = true;
+      continue;
+    }
+
     throw parseError(`Unknown argument: ${token}`);
   }
 
@@ -728,6 +847,10 @@ export function parseAuditCopilotCommentsCliArgs(argv) {
     throw parseError("--output-dir must be a non-empty path");
   }
 
+  if (options.resume && !options.checkpointFile) {
+    throw parseError("--resume requires --checkpoint-file");
+  }
+
   try {
     parseRepoSlug(options.repo);
   } catch (error) {
@@ -737,9 +860,51 @@ export function parseAuditCopilotCommentsCliArgs(argv) {
   return options;
 }
 
+// ── Main orchestration ───────────────────────────────────────────────
+
 export async function auditCopilotComments(options, { env = process.env, ghCommand = "gh" } = {}) {
-  const comments = await fetchAllReviewComments(options.repo, { env, ghCommand });
-  const prs = await fetchAllPullRequests(options.repo, { env, ghCommand });
+  const sleepMs = options.sleepMs ?? 0;
+  const checkpointFile = options.checkpointFile;
+  const resume = options.resume ?? false;
+  const retryMax = options.retryMax ?? DEFAULT_RETRY_MAX;
+  const retryBaseMs = options.retryBaseMs ?? DEFAULT_RETRY_BASE_MS;
+
+  let comments = null;
+  let prs = null;
+
+  // ── Resume path ──────────────────────────────────────────────────
+  if (resume && checkpointFile) {
+    const checkpoint = await loadCheckpoint(checkpointFile);
+    if (checkpoint && checkpoint.comments && checkpoint.repo === options.repo) {
+      comments = checkpoint.comments;
+
+      if (checkpoint.stage === "after-prs" && checkpoint.prs) {
+        prs = checkpoint.prs;
+      } else if (checkpoint.stage === "after-comments") {
+        await sleepStep(sleepMs);
+        prs = await fetchAllPullRequests(options.repo, { env, ghCommand, retryMax, retryBaseMs });
+        await saveCheckpoint(checkpointFile, { stage: "after-prs", repo: options.repo, comments, prs });
+      }
+    }
+
+    // If checkpoint was corrupted/absent, fall through to fresh fetch.
+  }
+
+  // ── Fresh fetch path ─────────────────────────────────────────────
+  if (comments === null) {
+    comments = await fetchAllReviewComments(options.repo, { env, ghCommand, retryMax, retryBaseMs });
+
+    if (checkpointFile) {
+      await saveCheckpoint(checkpointFile, { stage: "after-comments", repo: options.repo, comments });
+      await sleepStep(sleepMs);
+    }
+
+    prs = await fetchAllPullRequests(options.repo, { env, ghCommand, retryMax, retryBaseMs });
+
+    if (checkpointFile) {
+      await saveCheckpoint(checkpointFile, { stage: "after-prs", repo: options.repo, comments, prs });
+    }
+  }
 
   const summary = buildCopilotAuditSummary({
     repo: options.repo,
@@ -778,5 +943,7 @@ export {
   DEFAULT_JSON_NAME,
   DEFAULT_MARKDOWN_NAME,
   DEFAULT_OUTPUT_DIR,
+  DEFAULT_RETRY_BASE_MS,
+  DEFAULT_RETRY_MAX,
   RECOMMENDATION_DEFINITIONS,
 };

--- a/scripts/github/audit-copilot-comments.mjs
+++ b/scripts/github/audit-copilot-comments.mjs
@@ -390,7 +390,7 @@ function isAuthError(stderrText) {
  * Retry a gh JSON call with exponential backoff on 403/429.
  * Fails immediately on 401 (auth) or other non-retryable errors.
  */
-export async function runGhJsonWithRetry(args, { env, ghCommand, retryMax = DEFAULT_RETRY_MAX, retryBaseMs = DEFAULT_RETRY_BASE_MS } = {}) {
+export async function runGhJsonWithRetry(args, { env = process.env, ghCommand = "gh", retryMax = DEFAULT_RETRY_MAX, retryBaseMs = DEFAULT_RETRY_BASE_MS } = {}) {
   let lastError = null;
 
   for (let attempt = 0; attempt <= retryMax; attempt += 1) {
@@ -446,7 +446,6 @@ async function loadCheckpoint(checkpointPath) {
 }
 
 async function saveCheckpoint(checkpointPath, data) {
-  const { mkdir } = await import("node:fs/promises");
   await mkdir(path.dirname(checkpointPath), { recursive: true });
   await writeFile(checkpointPath, `${JSON.stringify(data)}\n`, "utf8");
 }
@@ -881,15 +880,19 @@ export async function auditCopilotComments(options, { env = process.env, ghComma
   // ── Resume path ──────────────────────────────────────────────────
   if (resume && checkpointFile) {
     const checkpoint = await loadCheckpoint(checkpointFile);
-    if (checkpoint && checkpoint.comments && checkpoint.repo === options.repo) {
+    if (checkpoint && Array.isArray(checkpoint.comments) && checkpoint.repo === options.repo) {
       comments = checkpoint.comments;
 
-      if (checkpoint.stage === "after-prs" && checkpoint.prs) {
+      if (checkpoint.stage === "after-prs" && Array.isArray(checkpoint.prs)) {
         prs = checkpoint.prs;
       } else if (checkpoint.stage === "after-comments") {
         await sleepStep(sleepMs);
         prs = await fetchAllPullRequests(options.repo, { env, ghCommand, retryMax, retryBaseMs });
         await saveCheckpoint(checkpointFile, { stage: "after-prs", repo: options.repo, comments, prs });
+      } else {
+        // Unrecognized stage or missing prs in after-prs — treat as corrupt, fall through to fresh fetch
+        comments = null;
+        prs = null;
       }
     }
 

--- a/scripts/github/audit-copilot-comments.mjs
+++ b/scripts/github/audit-copilot-comments.mjs
@@ -212,7 +212,7 @@ const CATEGORY_DEFINITIONS = [
       /error-contract/i,
       /malformed-argument/i,
       /happy\s+path\s+only/i,
-      /doesn['']t\s+exercise/i,
+      /doesn['’]t\s+exercise/i,
       /should\s+test/i,
     ],
   },
@@ -230,7 +230,7 @@ const CATEGORY_DEFINITIONS = [
       /assertions?\s+match\s+very\s+long/i,
       /test\s+can\s+hang/i,
       /brittle\s+to\s+minor\s+copy\s+edits/i,
-      /doesn['']t\s+actually\s+assert/i,
+      /doesn['’]t\s+actually\s+assert/i,
       /claims?\s+.*\s+but/i,
       /confus(?:ing|e)\s+test/i,
       /helper\s+never\s+listens/i,
@@ -446,6 +446,8 @@ async function loadCheckpoint(checkpointPath) {
 }
 
 async function saveCheckpoint(checkpointPath, data) {
+  const { mkdir } = await import("node:fs/promises");
+  await mkdir(path.dirname(checkpointPath), { recursive: true });
   await writeFile(checkpointPath, `${JSON.stringify(data)}\n`, "utf8");
 }
 
@@ -847,6 +849,10 @@ export function parseAuditCopilotCommentsCliArgs(argv) {
     throw parseError("--output-dir must be a non-empty path");
   }
 
+  if (options.checkpointFile !== undefined && options.checkpointFile.length === 0) {
+    throw parseError("--checkpoint-file must be a non-empty path");
+  }
+
   if (options.resume && !options.checkpointFile) {
     throw parseError("--resume requires --checkpoint-file");
   }
@@ -896,8 +902,9 @@ export async function auditCopilotComments(options, { env = process.env, ghComma
 
     if (checkpointFile) {
       await saveCheckpoint(checkpointFile, { stage: "after-comments", repo: options.repo, comments });
-      await sleepStep(sleepMs);
     }
+
+    await sleepStep(sleepMs);
 
     prs = await fetchAllPullRequests(options.repo, { env, ghCommand, retryMax, retryBaseMs });
 

--- a/test/github/audit-copilot-comments.test.mjs
+++ b/test/github/audit-copilot-comments.test.mjs
@@ -93,6 +93,13 @@ test("parseAuditCopilotCommentsCliArgs rejects bad --sleep-ms", () => {
   );
 });
 
+test("parseAuditCopilotCommentsCliArgs rejects empty --checkpoint-file", () => {
+  assert.throws(
+    () => parseAuditCopilotCommentsCliArgs(["--repo", "owner/repo", "--checkpoint-file", "   "]),
+    /non-empty path/i,
+  );
+});
+
 test("parseAuditCopilotCommentsCliArgs rejects --resume without --checkpoint-file", () => {
   assert.throws(
     () => parseAuditCopilotCommentsCliArgs(["--repo", "owner/repo", "--resume"]),

--- a/test/github/audit-copilot-comments.test.mjs
+++ b/test/github/audit-copilot-comments.test.mjs
@@ -12,6 +12,7 @@ import {
   classifyCopilotComment,
   parseAuditCopilotCommentsCliArgs,
   renderMarkdownReport,
+  runGhJsonWithRetry,
 } from "../../scripts/github/audit-copilot-comments.mjs";
 
 const scriptPath = path.resolve("scripts/github/audit-copilot-comments.mjs");
@@ -58,6 +59,45 @@ test("parseAuditCopilotCommentsCliArgs parses repo and default output dir", () =
   assert.equal(options.repo, "owner/repo");
   assert.equal(options.outputDir, "tmp/investigation");
   assert.equal(options.help, false);
+  assert.equal(options.sleepMs, 0);
+  assert.equal(options.resume, false);
+  assert.equal(options.checkpointFile, undefined);
+});
+
+test("parseAuditCopilotCommentsCliArgs parses new flags", () => {
+  const options = parseAuditCopilotCommentsCliArgs([
+    "--repo", "owner/repo",
+    "--sleep-ms", "500",
+    "--checkpoint-file", "tmp/ckpt.json",
+    "--resume",
+  ]);
+
+  assert.equal(options.repo, "owner/repo");
+  assert.equal(options.sleepMs, 500);
+  assert.equal(options.checkpointFile, "tmp/ckpt.json");
+  assert.equal(options.resume, true);
+});
+
+test("parseAuditCopilotCommentsCliArgs rejects bad --sleep-ms", () => {
+  assert.throws(
+    () => parseAuditCopilotCommentsCliArgs(["--repo", "owner/repo", "--sleep-ms", "abc"]),
+    /non-negative integer/i,
+  );
+  assert.throws(
+    () => parseAuditCopilotCommentsCliArgs(["--repo", "owner/repo", "--sleep-ms", "-1"]),
+    /non-negative integer/i,
+  );
+  assert.throws(
+    () => parseAuditCopilotCommentsCliArgs(["--repo", "owner/repo", "--sleep-ms", "1.5"]),
+    /non-negative integer/i,
+  );
+});
+
+test("parseAuditCopilotCommentsCliArgs rejects --resume without --checkpoint-file", () => {
+  assert.throws(
+    () => parseAuditCopilotCommentsCliArgs(["--repo", "owner/repo", "--resume"]),
+    /--resume requires --checkpoint-file/i,
+  );
 });
 
 test("parseAuditCopilotCommentsCliArgs rejects malformed arguments deterministically", () => {
@@ -85,6 +125,9 @@ test("audit-copilot-comments help text describes the full summary output", async
   assert.match(result.stdout, /abbreviated/i);
   assert.match(result.stdout, /same full\s+summary object/i);
   assert.match(result.stdout, /<output-dir>\/copilot-comment-summary\.json/);
+  assert.match(result.stdout, /--sleep-ms/);
+  assert.match(result.stdout, /--checkpoint-file/);
+  assert.match(result.stdout, /--resume/);
 });
 
 test("classifyCopilotComment assigns representative categories", () => {
@@ -286,6 +329,245 @@ test("audit-copilot-comments CLI writes JSON summary and markdown report", async
     assert.match(reportText, /Gate evidence/);
     assert.match(reportText, /Priority order for missing lenses/i);
     assert.match(summaryText, /"copilotComments": 3/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+// ── New resilience tests ────────────────────────────────────────────
+
+test("runGhJsonWithRetry retries on 403", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-audit-retry-403-"));
+
+  try {
+    // Sequence: 403 stderr + non-zero exit → then success
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/test/repo/pulls/comments?per_page=100"],
+        stdout: "",
+        exitCode: 1,
+        stderr: "HTTP 403: rate limit exceeded\n",
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/test/repo/pulls/comments?per_page=100"],
+        stdout: `${JSON.stringify([])}\n`,
+      },
+    ]);
+
+    const result = await runGhJsonWithRetry(
+      ["api", "--paginate", "--slurp", "repos/test/repo/pulls/comments?per_page=100"],
+      { env, ghCommand: "gh", retryMax: 2, retryBaseMs: 1 },
+    );
+
+    assert.deepEqual(result, []);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("runGhJsonWithRetry retries on 429", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-audit-retry-429-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/test/repo/pulls/comments?per_page=100"],
+        stdout: "",
+        exitCode: 1,
+        stderr: "HTTP 429: secondary rate limit\n",
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/test/repo/pulls/comments?per_page=100"],
+        stdout: `${JSON.stringify([])}\n`,
+      },
+    ]);
+
+    const result = await runGhJsonWithRetry(
+      ["api", "--paginate", "--slurp", "repos/test/repo/pulls/comments?per_page=100"],
+      { env, ghCommand: "gh", retryMax: 2, retryBaseMs: 1 },
+    );
+
+    assert.deepEqual(result, []);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("runGhJsonWithRetry throws after max retries", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-audit-retry-max-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/test/repo/pulls/comments?per_page=100"],
+        stdout: "",
+        exitCode: 1,
+        stderr: "HTTP 403\n",
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/test/repo/pulls/comments?per_page=100"],
+        stdout: "",
+        exitCode: 1,
+        stderr: "HTTP 403\n",
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/test/repo/pulls/comments?per_page=100"],
+        stdout: "",
+        exitCode: 1,
+        stderr: "HTTP 403\n",
+      },
+    ]);
+
+    await assert.rejects(
+      runGhJsonWithRetry(
+        ["api", "--paginate", "--slurp", "repos/test/repo/pulls/comments?per_page=100"],
+        { env, ghCommand: "gh", retryMax: 2, retryBaseMs: 1 },
+      ),
+      /gh command failed: HTTP 403/,
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("runGhJsonWithRetry fails immediately on 401", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-audit-retry-401-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/test/repo/pulls/comments?per_page=100"],
+        stdout: "",
+        exitCode: 1,
+        stderr: "HTTP 401: Bad credentials\n",
+      },
+    ]);
+
+    await assert.rejects(
+      runGhJsonWithRetry(
+        ["api", "--paginate", "--slurp", "repos/test/repo/pulls/comments?per_page=100"],
+        { env, ghCommand: "gh", retryMax: 2, retryBaseMs: 10 },
+      ),
+      /HTTP 401/,
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+// ── Checkpoint tests ────────────────────────────────────────────────
+
+test("audit-copilot-comments saves and resumes from checkpoint", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-audit-checkpoint-"));
+
+  try {
+    const checkpointPath = path.join(tempDir, "ckpt.json");
+
+    // First run: completes full fetch, saves checkpoint
+    const env1 = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/pulls/comments?per_page=100"],
+        stdout: `${JSON.stringify([[
+          sampleReviewComment({ id: 401, prNumber: 11, path: "a.md", body: "This relative path points to a missing file." }),
+        ]])}\n`,
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/pulls?state=all&per_page=100"],
+        stdout: `${JSON.stringify([samplePrs])}\n`,
+      },
+    ]);
+
+    const outputDir1 = path.join(tempDir, "out1");
+    const result1 = await runNode(["--repo", "owner/repo", "--output-dir", outputDir1, "--checkpoint-file", checkpointPath], { env: env1 });
+    assert.equal(result1.code, 0);
+    const summary1 = JSON.parse(result1.stdout);
+    assert.equal(summary1.totals.copilotComments, 1);
+
+    // Verify checkpoint file exists and is valid
+    const ckptRaw = await readFile(checkpointPath, "utf8");
+    const ckpt = JSON.parse(ckptRaw);
+    assert.equal(ckpt.stage, "after-prs");
+    assert.ok(Array.isArray(ckpt.comments));
+    assert.ok(Array.isArray(ckpt.prs));
+
+    // Resume: should skip fetches entirely
+    const env2 = await writeGhStub(tempDir, []); // empty — no calls expected
+    const outputDir2 = path.join(tempDir, "out2");
+    const result2 = await runNode(["--repo", "owner/repo", "--output-dir", outputDir2, "--checkpoint-file", checkpointPath, "--resume"], { env: env2 });
+    assert.equal(result2.code, 0);
+    const summary2 = JSON.parse(result2.stdout);
+    assert.equal(summary2.totals.copilotComments, 1);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("audit-copilot-comments resume from after-comments stage re-fetches only PRs", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-audit-checkpoint-comments-"));
+
+  try {
+    const checkpointPath = path.join(tempDir, "ckpt.json");
+
+    // Provide a checkpoint at after-comments stage with flat normalized comments
+    // (the same format as returned by fetchAllReviewComments after normalizePaginatedArrayPayload)
+    await writeFile(checkpointPath, JSON.stringify({
+      stage: "after-comments",
+      repo: "owner/repo",
+      comments: [
+        sampleReviewComment({ id: 501, prNumber: 11, path: "a.md", body: "This relative path points to a missing file." }),
+      ],
+    }));
+
+    // Resume: gh stub only needs PR fetch (one call)
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/pulls?state=all&per_page=100"],
+        stdout: `${JSON.stringify([samplePrs])}\n`,
+      },
+    ]);
+
+    const outputDir = path.join(tempDir, "out");
+    const result = await runNode(["--repo", "owner/repo", "--output-dir", outputDir, "--checkpoint-file", checkpointPath, "--resume"], { env });
+    assert.equal(result.code, 0);
+    const summary = JSON.parse(result.stdout);
+    assert.equal(summary.totals.copilotComments, 1);
+
+    // Verify checkpoint was updated to after-prs
+    const ckptRaw = await readFile(checkpointPath, "utf8");
+    const ckpt = JSON.parse(ckptRaw);
+    assert.equal(ckpt.stage, "after-prs");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("audit-copilot-comments resume with corrupt checkpoint falls back to fresh fetch", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-audit-checkpoint-corrupt-"));
+
+  try {
+    const checkpointPath = path.join(tempDir, "ckpt.json");
+
+    // Write garbage
+    await writeFile(checkpointPath, "not json at all");
+
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/pulls/comments?per_page=100"],
+        stdout: `${JSON.stringify([[
+          sampleReviewComment({ id: 601, prNumber: 11, path: "a.md", body: "missing file" }),
+        ]])}\n`,
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/pulls?state=all&per_page=100"],
+        stdout: `${JSON.stringify([samplePrs])}\n`,
+      },
+    ]);
+
+    const outputDir = path.join(tempDir, "out");
+    const result = await runNode(["--repo", "owner/repo", "--output-dir", outputDir, "--checkpoint-file", checkpointPath, "--resume"], { env });
+    assert.equal(result.code, 0);
+    const summary = JSON.parse(result.stdout);
+    assert.equal(summary.totals.copilotComments, 1);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/github/audit-copilot-comments.test.mjs
+++ b/test/github/audit-copilot-comments.test.mjs
@@ -437,6 +437,30 @@ test("runGhJsonWithRetry throws after max retries", async () => {
   }
 });
 
+test("runGhJsonWithRetry uses default ghCommand when omitted", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-audit-retry-default-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/test/repo/pulls/comments?per_page=100"],
+        stdout: `${JSON.stringify([])}
+`,
+      },
+    ]);
+
+    // Call without explicit ghCommand to test default
+    const result = await runGhJsonWithRetry(
+      ["api", "--paginate", "--slurp", "repos/test/repo/pulls/comments?per_page=100"],
+      { env },
+    );
+
+    assert.deepEqual(result, []);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("runGhJsonWithRetry fails immediately on 401", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-audit-retry-401-"));
 
@@ -543,6 +567,47 @@ test("audit-copilot-comments resume from after-comments stage re-fetches only PR
     const ckptRaw = await readFile(checkpointPath, "utf8");
     const ckpt = JSON.parse(ckptRaw);
     assert.equal(ckpt.stage, "after-prs");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("audit-copilot-comments resume with after-prs checkpoint missing prs falls back to fresh fetch", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-audit-checkpoint-noprs-"));
+
+  try {
+    const checkpointPath = path.join(tempDir, "ckpt.json");
+
+    // Checkpoint with stage after-prs but no prs field
+    await writeFile(checkpointPath, JSON.stringify({
+      stage: "after-prs",
+      repo: "owner/repo",
+      comments: [
+        sampleReviewComment({ id: 701, prNumber: 11, path: "a.md", body: "missing file" }),
+      ],
+      // prs missing deliberately
+    }));
+
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/pulls/comments?per_page=100"],
+        stdout: `${JSON.stringify([[
+          sampleReviewComment({ id: 702, prNumber: 11, path: "b.md", body: "missing file again" }),
+        ]])}
+`,
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/pulls?state=all&per_page=100"],
+        stdout: `${JSON.stringify([samplePrs])}
+`,
+      },
+    ]);
+
+    const outputDir = path.join(tempDir, "out");
+    const result = await runNode(["--repo", "owner/repo", "--output-dir", outputDir, "--checkpoint-file", checkpointPath, "--resume"], { env });
+    assert.equal(result.code, 0);
+    const summary = JSON.parse(result.stdout);
+    assert.equal(summary.totals.copilotComments, 1);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Act on Copilot comment audit findings (#363/#368):
- Derive 5 new draft-gate personas from audit-identified gap categories
- Make audit script resilient to rate limits and interruptible
- Document the audit script with full taxonomy and recommendation mapping

## Scope

### 1. New draft-gate personas (`.pi/dev-loop/defaults.yaml`)

| Persona | Gate wiring | Source category | Comments |
|---|---|---|---|
| `ci-guard` | **Default** draft gate | ci_guard | 67 |
| `link-check` | Opt-in draft gate | placeholder_404 + broken_paths | 36 |
| `config-drift` | Opt-in draft gate | config_conflicts | 27 |
| `gate-evidence` | Opt-in draft gate | gate_evidence | 13 |
| `no-op` | Opt-in draft gate | no_op_tool_usage | 11 |

### 2. Strengthened existing personas

- `coverage`: added test-name quality, edge-case coverage, malformed-argument tests, negative-case coverage language
- `docs`: added stale command reference language

### 3. Script resilience (`scripts/github/audit-copilot-comments.mjs`)

- Retry with exponential backoff on 403/429 (5 retries, 1s base)
- 401 fails immediately
- `--sleep-ms <ms>` flag between top-level fetches
- `--checkpoint-file <path>` + `--resume` for coarse-grain resume (after-comments / after-prs stages)
- Checkpoint corruption falls back to fresh fetch

### 4. Documentation (`docs/audit-copilot-comments.md`)

- Purpose, usage, output format
- Full 12-category taxonomy table
- Recommendation lens mapping
- Draft-gate persona derivation from audit findings
- Edge cases
- Linked from `docs/index.md`

## Acceptance criteria

- [x] `docs/audit-copilot-comments.md` exists, covers purpose/usage/output/taxonomy, linked from `docs/index.md`
- [x] 5 new draft-gate personas with prompt text in `.pi/dev-loop/defaults.yaml`
- [x] `ci-guard` wired into default draft gate angles, rest opt-in with comments
- [x] Existing `coverage` and `docs` prompts strengthened with audit-derived guidance
- [x] Retry+backoff on 403/429
- [x] Checkpoint save/resume round-trip
- [x] `--sleep-ms` flag
- [x] `npm test` passes (824 + 702 + 10 = 1536, 0 fail)
- [x] `npm run verify` passes (docs links: 61 files, 302 links OK)

## Definition of done

- [x] Docs entry covers purpose/usage/output/taxonomy
- [x] Retry+backoff tested
- [x] Checkpoint/resume tested
- [x] `--sleep-ms` tested
- [x] Strengthened coverage/docs prompts
- [x] `npm run verify` passes

## Non-goals

- Reclassifying the 76% uncategorized comments (separate follow-up)
- Modeling personas from low-frequency categories
- Adding personas to pre-approval gate (draft gate only for now)
- Re-running the full Copilot comment analysis pipeline
- Changing audit script taxonomy, classification logic, or category definitions