### PR TITLE
LLM classify uncategorized Copilot comments

### DIFF
--- a/docs/audit-copilot-comments.md
+++ b/docs/audit-copilot-comments.md
@@ -63,13 +63,14 @@ Script: `scripts/github/classify-uncategorized-comments.mjs`
 Use this one-off follow-up after `--save-uncategorized` to cluster uncategorized Copilot review comments with an LLM:
 
 ```bash
-node scripts/github/classify-uncategorized-comments.mjs --model <model> [--provider openai-compatible|anthropic] [--api-key <key>] [--input <path>] [--output-dir <path>] [--use-full-body] [--no-dedup]
+node scripts/github/classify-uncategorized-comments.mjs --model <model> [--provider openai-compatible|anthropic] [--api-key <key>] [--base-url <url>] [--input <path>] [--output-dir <path>] [--use-full-body] [--no-dedup]
 ```
 
 Key behavior:
 
 - `--model` is required; no default model is inferred.
 - API key comes from `--api-key`, `LLM_API_KEY`, or provider-specific `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`.
+- `--base-url` may point OpenAI-compatible or Anthropic requests at another valid `http(s)` endpoint.
 - Default input is `tmp/investigation/uncategorized-comments.json`; if absent, the script falls back to `tmp/investigation/copilot-comment-summary.json` and filters `primaryCategoryId === null`.
 - Default prompt mode sends `excerpt`; `--use-full-body` sends full `body`.
 - Deduplication by comment body/excerpt is on by default; `--no-dedup` disables it.

--- a/docs/audit-copilot-comments.md
+++ b/docs/audit-copilot-comments.md
@@ -71,7 +71,7 @@ Key behavior:
 - `--model` is required; no default model is inferred.
 - API key comes from `--api-key`, `LLM_API_KEY`, or provider-specific `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`.
 - `--base-url` may point OpenAI-compatible or Anthropic requests at another valid `http(s)` endpoint.
-- Default input is `tmp/investigation/uncategorized-comments.json`; if absent, the script falls back to `tmp/investigation/copilot-comment-summary.json` and filters `primaryCategoryId === null`.
+- Default input is `<output-dir>/uncategorized-comments.json`; if absent, the script falls back to `<output-dir>/copilot-comment-summary.json` and filters `primaryCategoryId === null`. With the default output dir, those paths are under `tmp/investigation`.
 - Default prompt mode sends `excerpt`; `--use-full-body` sends full `body`.
 - Deduplication by comment body/excerpt is on by default; `--no-dedup` disables it.
 - 429/5xx LLM responses retry with exponential backoff. Malformed LLM JSON retries once with stricter JSON-only instructions.

--- a/docs/audit-copilot-comments.md
+++ b/docs/audit-copilot-comments.md
@@ -9,7 +9,7 @@ Scan all pull-request review comments in a repository via the GitHub REST API, f
 ## Usage
 
 ```bash
-node scripts/github/audit-copilot-comments.mjs --repo <owner/name> [--output-dir <path>] [--sleep-ms <ms>] [--checkpoint-file <path>] [--resume]
+node scripts/github/audit-copilot-comments.mjs --repo <owner/name> [--output-dir <path>] [--sleep-ms <ms>] [--checkpoint-file <path>] [--resume] [--save-uncategorized]
 ```
 
 ### Flags
@@ -21,6 +21,7 @@ node scripts/github/audit-copilot-comments.mjs --repo <owner/name> [--output-dir
 | `--sleep-ms` | no | `0` | Sleep this many ms between top-level fetches (non-negative int) |
 | `--checkpoint-file` | no | — | Save/load coarse-grain checkpoint for resume |
 | `--resume` | no | `false` | Resume from checkpoint (requires `--checkpoint-file`) |
+| `--save-uncategorized` | no | `false` | Also write `uncategorized-comments.json` containing only comments where `primaryCategoryId === null` |
 | `--help`, `-h` | no | — | Print usage and exit |
 
 ### Checkpoint stages
@@ -40,14 +41,40 @@ Checkpoint corruption (missing file, invalid JSON, missing stage): `--resume` fa
 
 ## Output
 
-Two files written to `--output-dir`:
+Default run writes two files to `--output-dir`:
 
 | File | Description |
 |---|---|
 | `copilot-comment-summary.json` | Full structured JSON with totals, categories, recommendations, and per-comment classifications |
 | `copilot-comment-categories.md` | Human-readable Markdown report with top-category table, priority-ranked recommendations, and category details |
 
+With `--save-uncategorized`, the audit also writes:
+
+| File | Description |
+|---|---|
+| `uncategorized-comments.json` | Array of only uncategorized comments, preserving `body`, `prNumber`, `path`, `line`, `htmlUrl`, and `excerpt` |
+
 Stdout also emits the same JSON summary.
+
+## LLM classification of uncategorized comments
+
+Script: `scripts/github/classify-uncategorized-comments.mjs`
+
+Use this one-off follow-up after `--save-uncategorized` to cluster uncategorized Copilot review comments with an LLM:
+
+```bash
+node scripts/github/classify-uncategorized-comments.mjs --model <model> [--provider openai-compatible|anthropic] [--api-key <key>] [--input <path>] [--output-dir <path>] [--use-full-body] [--no-dedup]
+```
+
+Key behavior:
+
+- `--model` is required; no default model is inferred.
+- API key comes from `--api-key`, `LLM_API_KEY`, or provider-specific `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`.
+- Default input is `tmp/investigation/uncategorized-comments.json`; if absent, the script falls back to `tmp/investigation/copilot-comment-summary.json` and filters `primaryCategoryId === null`.
+- Default prompt mode sends `excerpt`; `--use-full-body` sends full `body`.
+- Deduplication by comment body/excerpt is on by default; `--no-dedup` disables it.
+- 429/5xx LLM responses retry with exponential backoff. Malformed LLM JSON retries once with stricter JSON-only instructions.
+- Output files are `uncategorized-clusters.json` and `uncategorized-clusters.md`; the Markdown report includes cluster summaries, persona candidates in `.pi/dev-loop/defaults.yaml`-compatible shape, and a "Left unclustered" section.
 
 ## Taxonomy table
 
@@ -105,6 +132,10 @@ Audit findings are the primary input for deciding which personas to add to `.pi/
 | 403/429 mid-fetch | Exponential backoff, max 5 retries |
 | `gh` not authenticated (401) | Fail immediately, no retry |
 | `--resume` without `--checkpoint-file` | CLI validation error |
+| audit `--save-uncategorized` with no uncategorized comments | Writes `[]` to `uncategorized-comments.json` |
+| classifier missing `--model` | CLI validation error |
+| classifier missing API key | Clear non-zero API-key error |
+| LLM returns malformed JSON | Retry once with stricter JSON-only prompt, then fail clearly |
 
 ## See also
 

--- a/scripts/github/audit-copilot-comments.mjs
+++ b/scripts/github/audit-copilot-comments.mjs
@@ -9,10 +9,11 @@ import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 const DEFAULT_OUTPUT_DIR = "tmp/investigation";
 const DEFAULT_JSON_NAME = "copilot-comment-summary.json";
 const DEFAULT_MARKDOWN_NAME = "copilot-comment-categories.md";
+const DEFAULT_UNCATEGORIZED_NAME = "uncategorized-comments.json";
 const DEFAULT_RETRY_MAX = 5;
 const DEFAULT_RETRY_BASE_MS = 1000;
 
-const USAGE = `Usage: audit-copilot-comments.mjs --repo <owner/name> [--output-dir <path>] [--sleep-ms <ms>] [--checkpoint-file <path>] [--resume]
+const USAGE = `Usage: audit-copilot-comments.mjs --repo <owner/name> [--output-dir <path>] [--sleep-ms <ms>] [--checkpoint-file <path>] [--resume] [--save-uncategorized]
 
 Scan all pull-request review comments in a repository via the GitHub REST API,
 filter to Copilot-authored comments, classify them into workflow categories, and
@@ -26,6 +27,7 @@ Optional:
   --sleep-ms <ms>           Sleep this many ms between top-level fetches (non-negative int, default: 0)
   --checkpoint-file <path>  Save/load coarse-grain checkpoint for resume
   --resume                  Resume from checkpoint file (requires --checkpoint-file)
+  --save-uncategorized      Also write uncategorized-comments.json with only primaryCategoryId=null comments
 
 Checkpoint stages:
   after-comments  — comments fetch complete, saved
@@ -60,7 +62,8 @@ Output (stdout, JSON summary; abbreviated example):
     ],
     "files": {
       "jsonSummaryPath": "<output-dir>/copilot-comment-summary.json",
-      "markdownReportPath": "<output-dir>/copilot-comment-categories.md"
+      "markdownReportPath": "<output-dir>/copilot-comment-categories.md",
+      "uncategorizedCommentsPath": "<output-dir>/uncategorized-comments.json"
     }
   }
 
@@ -780,10 +783,31 @@ async function fetchAllPullRequests(repo, { env, ghCommand, retryMax, retryBaseM
 
 // ── Output writer ────────────────────────────────────────────────────
 
-async function writeOutputs(summary, markdown) {
+export function buildUncategorizedComments(summary) {
+  const comments = Array.isArray(summary?.comments) ? summary.comments : [];
+  return comments
+    .filter((comment) => comment?.primaryCategoryId === null)
+    .map((comment) => ({
+      prNumber: Number.isInteger(comment?.prNumber) ? comment.prNumber : null,
+      path: typeof comment?.path === "string" ? comment.path : null,
+      line: Number.isInteger(comment?.line) ? comment.line : null,
+      htmlUrl: typeof comment?.htmlUrl === "string" ? comment.htmlUrl : null,
+      excerpt: typeof comment?.excerpt === "string" ? comment.excerpt : "",
+      body: typeof comment?.body === "string" ? comment.body : "",
+    }));
+}
+
+// ── Output writer ────────────────────────────────────────────────────
+
+async function writeOutputs(summary, markdown, { saveUncategorized = false } = {}) {
   await mkdir(summary.files.outputDir, { recursive: true });
   await writeFile(summary.files.jsonSummaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
   await writeFile(summary.files.markdownReportPath, markdown, "utf8");
+
+  if (saveUncategorized) {
+    const uncategorized = buildUncategorizedComments(summary);
+    await writeFile(summary.files.uncategorizedCommentsPath, `${JSON.stringify(uncategorized, null, 2)}\n`, "utf8");
+  }
 }
 
 // ── CLI argument parsing ─────────────────────────────────────────────
@@ -797,6 +821,7 @@ export function parseAuditCopilotCommentsCliArgs(argv) {
     sleepMs: 0,
     checkpointFile: undefined,
     resume: false,
+    saveUncategorized: false,
   };
 
   while (args.length > 0) {
@@ -834,6 +859,11 @@ export function parseAuditCopilotCommentsCliArgs(argv) {
 
     if (token === "--resume") {
       options.resume = true;
+      continue;
+    }
+
+    if (token === "--save-uncategorized") {
+      options.saveUncategorized = true;
       continue;
     }
 
@@ -922,14 +952,17 @@ export async function auditCopilotComments(options, { env = process.env, ghComma
     prs,
     outputDir: options.outputDir,
   });
+  if (options.saveUncategorized === true) {
+    summary.files.uncategorizedCommentsPath = path.join(summary.files.outputDir, DEFAULT_UNCATEGORIZED_NAME);
+  }
   const markdown = renderMarkdownReport(summary);
 
-  await writeOutputs(summary, markdown);
+  await writeOutputs(summary, markdown, { saveUncategorized: options.saveUncategorized === true });
 
   return summary;
 }
 
-export async function runCli(argv = process.argv.slice(2), { stdout = process.stdout, env = process.env, ghCommand = "gh" } = {}) {
+export async function runCli(argv = process.argv.slice(2), { stdout = process.stdout, stderr = process.stderr, env = process.env, ghCommand = "gh" } = {}) {
   const options = parseAuditCopilotCommentsCliArgs(argv);
 
   if (options.help) {
@@ -938,6 +971,9 @@ export async function runCli(argv = process.argv.slice(2), { stdout = process.st
   }
 
   const summary = await auditCopilotComments(options, { env, ghCommand });
+  if (options.saveUncategorized === true && summary.totals.uncategorizedComments === 0) {
+    stderr.write(`No uncategorized Copilot comments found; wrote ${summary.files.uncategorizedCommentsPath} as an empty array.\n`);
+  }
   stdout.write(`${JSON.stringify(summary)}\n`);
 }
 
@@ -953,6 +989,7 @@ export {
   DEFAULT_JSON_NAME,
   DEFAULT_MARKDOWN_NAME,
   DEFAULT_OUTPUT_DIR,
+  DEFAULT_UNCATEGORIZED_NAME,
   DEFAULT_RETRY_BASE_MS,
   DEFAULT_RETRY_MAX,
   RECOMMENDATION_DEFINITIONS,

--- a/scripts/github/audit-copilot-comments.mjs
+++ b/scripts/github/audit-copilot-comments.mjs
@@ -62,10 +62,11 @@ Output (stdout, JSON summary; abbreviated example):
     ],
     "files": {
       "jsonSummaryPath": "<output-dir>/copilot-comment-summary.json",
-      "markdownReportPath": "<output-dir>/copilot-comment-categories.md",
-      "uncategorizedCommentsPath": "<output-dir>/uncategorized-comments.json"
+      "markdownReportPath": "<output-dir>/copilot-comment-categories.md"
     }
   }
+
+  With --save-uncategorized, the real summary also includes files.uncategorizedCommentsPath.
 
   This example is abbreviated; the real summary includes additional fields on
   categories, recommendations, comments, and files. Stdout emits the same full

--- a/scripts/github/classify-uncategorized-comments.mjs
+++ b/scripts/github/classify-uncategorized-comments.mjs
@@ -195,10 +195,11 @@ async function loadComments(inputPath) {
   return rawComments.map(normalizeComment).filter((comment) => comment.body.length > 0 || comment.excerpt.length > 0);
 }
 
-export function dedupeComments(comments) {
+export function dedupeComments(comments, { useFullBody = false } = {}) {
   const byKey = new Map();
   for (const comment of comments) {
-    const key = (comment.body || comment.excerpt || "").replace(/\s+/g, " ").trim().toLowerCase();
+    const keySource = useFullBody ? comment.body : (comment.excerpt || comment.body);
+    const key = String(keySource ?? "").replace(/\s+/g, " ").trim().toLowerCase();
     if (key.length === 0) continue;
     const existing = byKey.get(key);
     if (existing) {
@@ -440,7 +441,7 @@ export async function classifyUncategorizedComments(options, { env = process.env
   const apiKey = resolveApiKey(options, env);
   const inputPath = await resolveInputPath(options);
   const comments = await loadComments(inputPath);
-  const commentsForPrompt = options.dedup === false ? comments.map((comment) => ({ ...comment, occurrenceCount: 1, duplicatePrNumbers: Number.isInteger(comment.prNumber) ? [comment.prNumber] : [] })) : dedupeComments(comments);
+  const commentsForPrompt = options.dedup === false ? comments.map((comment) => ({ ...comment, occurrenceCount: 1, duplicatePrNumbers: Number.isInteger(comment.prNumber) ? [comment.prNumber] : [] })) : dedupeComments(comments, { useFullBody: options.useFullBody === true });
   const retryMax = options.retryMax ?? DEFAULT_RETRY_MAX;
   const retryBaseMs = options.retryBaseMs ?? DEFAULT_RETRY_BASE_MS;
 

--- a/scripts/github/classify-uncategorized-comments.mjs
+++ b/scripts/github/classify-uncategorized-comments.mjs
@@ -1,0 +1,528 @@
+#!/usr/bin/env node
+import { access, mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { requireOptionValue } from "../_cli-primitives.mjs";
+import { CATEGORY_DEFINITIONS, DEFAULT_OUTPUT_DIR } from "./audit-copilot-comments.mjs";
+
+const DEFAULT_INPUT_NAME = "uncategorized-comments.json";
+const FALLBACK_SUMMARY_NAME = "copilot-comment-summary.json";
+const DEFAULT_JSON_NAME = "uncategorized-clusters.json";
+const DEFAULT_MARKDOWN_NAME = "uncategorized-clusters.md";
+const DEFAULT_PROVIDER = "openai-compatible";
+const DEFAULT_RETRY_MAX = 3;
+const DEFAULT_RETRY_BASE_MS = 1000;
+const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
+const ANTHROPIC_DEFAULT_BASE_URL = "https://api.anthropic.com/v1";
+
+const USAGE = `Usage: classify-uncategorized-comments.mjs --model <model> [--provider <openai-compatible|anthropic>] [--api-key <key>] [--input <path>] [--output-dir <path>] [--use-full-body] [--no-dedup]
+
+Classify uncategorized Copilot review comments with a single LLM pass and write
+both JSON and Markdown cluster reports. Uses built-in fetch; no extra npm deps.
+
+Required:
+  --model <model>           LLM model to use. This flag is required.
+
+Optional:
+  --provider <provider>     openai-compatible (default) or anthropic
+  --api-key <key>           LLM API key. Falls back to LLM_API_KEY, then provider-specific env.
+  --base-url <url>          Provider base URL (defaults to OpenAI/Anthropic public API)
+  --input <path>            Input JSON. Defaults to tmp/investigation/uncategorized-comments.json,
+                            then falls back to tmp/investigation/copilot-comment-summary.json
+  --output-dir <path>       Output directory (default: tmp/investigation)
+  --use-full-body           Send full comment bodies instead of excerpts
+  --no-dedup                Disable default body/excerpt deduplication
+
+Output files:
+  <output-dir>/uncategorized-clusters.json
+  <output-dir>/uncategorized-clusters.md
+
+Error output (stderr, JSON):
+  { "ok": false, "error": "...", "usage": "..." }
+  { "ok": false, "error": "..." }
+
+Exit codes:
+  0  Success
+  1  Argument error, input error, LLM error, or malformed LLM JSON`.trim();
+
+const parseError = buildParseError(USAGE);
+
+function parseProvider(value) {
+  const normalized = String(value ?? "").trim().toLowerCase();
+  if (normalized === "openai-compatible" || normalized === "anthropic") {
+    return normalized;
+  }
+  throw parseError("--provider must be openai-compatible or anthropic");
+}
+
+export function parseClassifyUncategorizedCliArgs(argv) {
+  const args = [...argv];
+  const options = {
+    help: false,
+    provider: DEFAULT_PROVIDER,
+    model: undefined,
+    apiKey: undefined,
+    baseUrl: undefined,
+    input: undefined,
+    outputDir: DEFAULT_OUTPUT_DIR,
+    useFullBody: false,
+    dedup: true,
+  };
+
+  while (args.length > 0) {
+    const token = args.shift();
+
+    if (token === "--help" || token === "-h") {
+      options.help = true;
+      return options;
+    }
+
+    if (token === "--model") {
+      options.model = requireOptionValue(args, "--model", parseError).trim();
+      continue;
+    }
+
+    if (token === "--provider") {
+      options.provider = parseProvider(requireOptionValue(args, "--provider", parseError));
+      continue;
+    }
+
+    if (token === "--api-key") {
+      options.apiKey = requireOptionValue(args, "--api-key", parseError).trim();
+      continue;
+    }
+
+    if (token === "--base-url") {
+      options.baseUrl = requireOptionValue(args, "--base-url", parseError).trim().replace(/\/+$/u, "");
+      continue;
+    }
+
+    if (token === "--input") {
+      options.input = requireOptionValue(args, "--input", parseError).trim();
+      continue;
+    }
+
+    if (token === "--output-dir") {
+      options.outputDir = requireOptionValue(args, "--output-dir", parseError).trim();
+      continue;
+    }
+
+    if (token === "--use-full-body") {
+      options.useFullBody = true;
+      continue;
+    }
+
+    if (token === "--no-dedup") {
+      options.dedup = false;
+      continue;
+    }
+
+    throw parseError(`Unknown argument: ${token}`);
+  }
+
+  if (options.model === undefined || options.model.length === 0) {
+    throw parseError("classify-uncategorized-comments requires --model <model>");
+  }
+  if (options.outputDir.length === 0) {
+    throw parseError("--output-dir must be a non-empty path");
+  }
+  if (options.input !== undefined && options.input.length === 0) {
+    throw parseError("--input must be a non-empty path");
+  }
+
+  return options;
+}
+
+function resolveApiKey(options, env) {
+  const explicit = typeof options.apiKey === "string" && options.apiKey.trim().length > 0 ? options.apiKey.trim() : null;
+  if (explicit) return explicit;
+  const generic = typeof env.LLM_API_KEY === "string" && env.LLM_API_KEY.trim().length > 0 ? env.LLM_API_KEY.trim() : null;
+  if (generic) return generic;
+  const providerKey = options.provider === "anthropic" ? env.ANTHROPIC_API_KEY : env.OPENAI_API_KEY;
+  const normalized = typeof providerKey === "string" && providerKey.trim().length > 0 ? providerKey.trim() : null;
+  if (normalized) return normalized;
+  throw new Error("classify-uncategorized-comments requires an API key via --api-key, LLM_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY");
+}
+
+async function pathExists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveInputPath(options) {
+  if (options.input) return options.input;
+  const uncategorizedPath = path.join(options.outputDir, DEFAULT_INPUT_NAME);
+  if (await pathExists(uncategorizedPath)) return uncategorizedPath;
+  return path.join(options.outputDir, FALLBACK_SUMMARY_NAME);
+}
+
+function normalizeComment(entry) {
+  return {
+    prNumber: Number.isInteger(entry?.prNumber) ? entry.prNumber : null,
+    path: typeof entry?.path === "string" ? entry.path : null,
+    line: Number.isInteger(entry?.line) ? entry.line : null,
+    htmlUrl: typeof entry?.htmlUrl === "string" ? entry.htmlUrl : null,
+    body: typeof entry?.body === "string" ? entry.body.trim() : "",
+    excerpt: typeof entry?.excerpt === "string" && entry.excerpt.trim().length > 0
+      ? entry.excerpt.trim()
+      : String(entry?.body ?? "").replace(/\s+/g, " ").trim().slice(0, 200),
+  };
+}
+
+async function loadComments(inputPath) {
+  let parsed;
+  try {
+    parsed = JSON.parse(await readFile(inputPath, "utf8"));
+  } catch (error) {
+    throw new Error(`Unable to read input JSON at ${inputPath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  const rawComments = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.comments)
+      ? parsed.comments.filter((comment) => comment?.primaryCategoryId === null)
+      : null;
+
+  if (!rawComments) {
+    throw new Error("Input JSON must be an uncategorized comments array or an audit summary with comments[]");
+  }
+
+  return rawComments.map(normalizeComment).filter((comment) => comment.body.length > 0 || comment.excerpt.length > 0);
+}
+
+export function dedupeComments(comments) {
+  const byKey = new Map();
+  for (const comment of comments) {
+    const key = (comment.body || comment.excerpt || "").replace(/\s+/g, " ").trim().toLowerCase();
+    if (key.length === 0) continue;
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.occurrenceCount += 1;
+      if (Number.isInteger(comment.prNumber)) existing.duplicatePrNumbers.push(comment.prNumber);
+      continue;
+    }
+    byKey.set(key, {
+      ...comment,
+      occurrenceCount: 1,
+      duplicatePrNumbers: Number.isInteger(comment.prNumber) ? [comment.prNumber] : [],
+    });
+  }
+  return [...byKey.values()];
+}
+
+function formatCategoryList() {
+  return CATEGORY_DEFINITIONS
+    .map((category) => `- ${category.id}: ${category.label} — ${category.description}`)
+    .join("\n");
+}
+
+export function buildClassificationPrompt({ comments, useFullBody = false, strict = false }) {
+  const system = `You are a code review comment clusterer. Classify Copilot-authored review comments into emergent thematic clusters.\n\nAvoid clusters that merely restate these existing categories:\n${formatCategoryList()}\n\nReturn JSON only. ${strict ? "No prose, no markdown fences, no commentary." : ""}`;
+  const commentLines = comments.map((comment, index) => {
+    const text = useFullBody ? comment.body : comment.excerpt;
+    const location = [comment.path, Number.isInteger(comment.line) ? `:${comment.line}` : null].filter(Boolean).join("");
+    return `[comment ${index + 1}] occurrences=${comment.occurrenceCount ?? 1} PR#${comment.prNumber ?? "?"}${location ? ` ${location}` : ""}: ${text}`;
+  });
+  const user = `Repo context: mfittko/pi-dev-loops Copilot review comments that did not match the existing regex taxonomy.\n\nTask:\n1. Identify 5-15 emergent thematic clusters.\n2. For each cluster include name, label, description, frequency, priority (high/medium/low), recommendedPersona or null, personaRationale, and 3-5 examples with prNumber, path, excerpt.\n3. Include unclustered.frequency and unclustered.examples.\n4. Include optional commentAssignments as [{ commentIndex, clusterName }].\n5. Produce persona candidates for high/medium clusters through recommendedPersona and personaRationale.\n\nOutput exact JSON object shape:\n{ "clusters": [ { "name": "slug", "label": "Label", "description": "...", "frequency": 42, "priority": "high", "recommendedPersona": "persona-slug", "personaRationale": "...", "examples": [ { "prNumber": 1, "path": "file", "excerpt": "..." } ] } ], "unclustered": { "frequency": 0, "examples": [] }, "summary": { "totalCommentsProcessed": ${comments.length}, "totalClustersFound": 0 }, "commentAssignments": [] }\n\nComments:\n${commentLines.join("\n")}`;
+  return { system, user };
+}
+
+function requestShape({ provider, baseUrl, model, apiKey, prompt }) {
+  if (provider === "anthropic") {
+    return {
+      url: `${baseUrl ?? ANTHROPIC_DEFAULT_BASE_URL}/messages`,
+      init: {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": apiKey,
+          "anthropic-version": "2023-06-01",
+        },
+        body: JSON.stringify({
+          model,
+          max_tokens: 8192,
+          system: prompt.system,
+          messages: [{ role: "user", content: prompt.user }],
+        }),
+      },
+    };
+  }
+
+  return {
+    url: `${baseUrl ?? OPENAI_DEFAULT_BASE_URL}/chat/completions`,
+    init: {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: "system", content: prompt.system },
+          { role: "user", content: prompt.user },
+        ],
+        response_format: { type: "json_object" },
+      }),
+    },
+  };
+}
+
+function extractProviderText(provider, rawText) {
+  let payload;
+  try {
+    payload = JSON.parse(rawText);
+  } catch {
+    throw new Error("LLM provider returned non-JSON response envelope");
+  }
+  if (provider === "anthropic") {
+    if (typeof payload?.content === "string") return payload.content;
+    const text = Array.isArray(payload?.content)
+      ? payload.content.filter((part) => part?.type === "text" && typeof part?.text === "string").map((part) => part.text).join("\n")
+      : "";
+    if (text.length > 0) return text;
+  } else {
+    const text = payload?.choices?.[0]?.message?.content;
+    if (typeof text === "string" && text.length > 0) return text;
+  }
+  throw new Error("LLM provider response did not contain text content");
+}
+
+function parseLlmJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    const start = text.indexOf("{");
+    const end = text.lastIndexOf("}");
+    if (start >= 0 && end > start) {
+      return JSON.parse(text.slice(start, end + 1));
+    }
+    throw new Error("LLM response was not valid JSON");
+  }
+}
+
+function validateLlmPayload(payload) {
+  if (!payload || typeof payload !== "object" || !Array.isArray(payload.clusters)) {
+    throw new Error("LLM JSON must include clusters[]");
+  }
+  return {
+    clusters: payload.clusters.map((cluster) => ({
+      name: typeof cluster?.name === "string" ? cluster.name : "unnamed-cluster",
+      label: typeof cluster?.label === "string" ? cluster.label : String(cluster?.name ?? "Unnamed cluster"),
+      description: typeof cluster?.description === "string" ? cluster.description : "",
+      frequency: Number.isInteger(cluster?.frequency) ? cluster.frequency : 0,
+      priority: ["high", "medium", "low"].includes(cluster?.priority) ? cluster.priority : "low",
+      recommendedPersona: typeof cluster?.recommendedPersona === "string" && cluster.recommendedPersona.trim().length > 0 ? cluster.recommendedPersona.trim() : null,
+      personaRationale: typeof cluster?.personaRationale === "string" ? cluster.personaRationale : "",
+      examples: Array.isArray(cluster?.examples) ? cluster.examples.map((example) => ({
+        prNumber: Number.isInteger(example?.prNumber) ? example.prNumber : null,
+        path: typeof example?.path === "string" ? example.path : null,
+        excerpt: typeof example?.excerpt === "string" ? example.excerpt : "",
+      })) : [],
+    })),
+    unclustered: {
+      frequency: Number.isInteger(payload?.unclustered?.frequency) ? payload.unclustered.frequency : 0,
+      examples: Array.isArray(payload?.unclustered?.examples) ? payload.unclustered.examples : [],
+    },
+    summary: payload.summary && typeof payload.summary === "object" ? payload.summary : {},
+    commentAssignments: Array.isArray(payload.commentAssignments) ? payload.commentAssignments : [],
+  };
+}
+
+async function wait(ms) {
+  if (ms > 0) await new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
+async function callLlmWithRetry({ provider, baseUrl, model, apiKey, prompt, retryMax, retryBaseMs, fetchImpl }) {
+  let lastError = null;
+  for (let attempt = 0; attempt <= retryMax; attempt += 1) {
+    const { url, init } = requestShape({ provider, baseUrl, model, apiKey, prompt });
+    const response = await fetchImpl(url, init);
+    const text = await response.text();
+    if (response.ok) {
+      return extractProviderText(provider, text);
+    }
+    const retryable = response.status === 429 || (response.status >= 500 && response.status <= 599);
+    lastError = new Error(`LLM request failed with HTTP ${response.status}: ${text.trim()}`);
+    if (!retryable || attempt === retryMax) throw lastError;
+    await wait(retryBaseMs * (2 ** attempt));
+  }
+  throw lastError ?? new Error("LLM request failed");
+}
+
+function buildPersonaCandidates(clusters, model) {
+  return clusters
+    .filter((cluster) => ["high", "medium"].includes(cluster.priority) && cluster.recommendedPersona)
+    .sort((left, right) => {
+      const rank = { high: 0, medium: 1, low: 2 };
+      if (rank[left.priority] !== rank[right.priority]) return rank[left.priority] - rank[right.priority];
+      return right.frequency - left.frequency;
+    })
+    .map((cluster) => ({
+      persona: cluster.recommendedPersona,
+      prompt: `Review for ${cluster.label}: ${cluster.description} Focus on issue patterns represented by this cluster and flag concrete repo-specific risks without broadening scope.`,
+      defaultModel: model,
+      sourceCluster: cluster.name,
+      priority: cluster.priority,
+      rationale: cluster.personaRationale,
+    }));
+}
+
+function renderReport(result) {
+  const lines = [];
+  lines.push("# Uncategorized Copilot comment clusters");
+  lines.push("");
+  lines.push(`Generated: ${result.generatedAt}`);
+  lines.push(`Model: ${result.provider} / ${result.model}`);
+  lines.push(`Comments classified: ${result.totalComments}`);
+  lines.push(`Deduped comments sent: ${result.dedupedComments}`);
+  lines.push(`Clusters found: ${result.clusters.length}`);
+  lines.push(`Left unclustered: ${result.unclustered.frequency}`);
+  lines.push("");
+  lines.push("## Clusters");
+  lines.push("");
+  if (result.clusters.length === 0) {
+    lines.push("- No clusters returned.");
+  }
+  for (const cluster of result.clusters) {
+    lines.push(`### ${cluster.label}`);
+    lines.push("");
+    lines.push(`- Slug: ${cluster.name}`);
+    lines.push(`- Frequency: ${cluster.frequency}`);
+    lines.push(`- Priority: ${cluster.priority}`);
+    lines.push(`- Description: ${cluster.description}`);
+    lines.push(`- Recommended persona: ${cluster.recommendedPersona ?? "none"}`);
+    if (cluster.personaRationale) lines.push(`- Persona rationale: ${cluster.personaRationale}`);
+    if (cluster.examples.length > 0) {
+      lines.push("- Examples:");
+      for (const example of cluster.examples) {
+        lines.push(`  - PR #${example.prNumber ?? "?"}${example.path ? ` (${example.path})` : ""}: ${example.excerpt}`);
+      }
+    }
+    lines.push("");
+  }
+  lines.push("## Persona candidates");
+  lines.push("");
+  if (result.personaCandidates.length === 0) {
+    lines.push("- None recommended.");
+  } else {
+    lines.push("```yaml");
+    lines.push("personas:");
+    for (const candidate of result.personaCandidates) {
+      lines.push(`  - persona: ${candidate.persona}`);
+      lines.push(`    defaultModel: ${candidate.defaultModel}`);
+      lines.push(`    prompt: ${JSON.stringify(candidate.prompt)}`);
+    }
+    lines.push("```");
+  }
+  lines.push("");
+  lines.push("## Left unclustered");
+  lines.push("");
+  if (!Array.isArray(result.unclustered.examples) || result.unclustered.examples.length === 0) {
+    lines.push("- No examples returned.");
+  } else {
+    for (const example of result.unclustered.examples.slice(0, 10)) {
+      lines.push(`- PR #${example?.prNumber ?? "?"}${example?.path ? ` (${example.path})` : ""}: ${example?.excerpt ?? ""}`);
+    }
+  }
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+export async function classifyUncategorizedComments(options, { env = process.env, fetchImpl = globalThis.fetch } = {}) {
+  if (typeof fetchImpl !== "function") {
+    throw new Error("Built-in fetch is unavailable in this Node runtime");
+  }
+  const apiKey = resolveApiKey(options, env);
+  const inputPath = await resolveInputPath(options);
+  const comments = await loadComments(inputPath);
+  const commentsForPrompt = options.dedup === false ? comments.map((comment) => ({ ...comment, occurrenceCount: 1, duplicatePrNumbers: Number.isInteger(comment.prNumber) ? [comment.prNumber] : [] })) : dedupeComments(comments);
+  const retryMax = options.retryMax ?? DEFAULT_RETRY_MAX;
+  const retryBaseMs = options.retryBaseMs ?? DEFAULT_RETRY_BASE_MS;
+
+  let prompt = buildClassificationPrompt({ comments: commentsForPrompt, useFullBody: options.useFullBody === true });
+  let text = await callLlmWithRetry({ provider: options.provider, baseUrl: options.baseUrl, model: options.model, apiKey, prompt, retryMax, retryBaseMs, fetchImpl });
+  let llmPayload;
+  try {
+    llmPayload = validateLlmPayload(parseLlmJson(text));
+  } catch (error) {
+    prompt = buildClassificationPrompt({ comments: commentsForPrompt, useFullBody: options.useFullBody === true, strict: true });
+    text = await callLlmWithRetry({ provider: options.provider, baseUrl: options.baseUrl, model: options.model, apiKey, prompt, retryMax, retryBaseMs, fetchImpl });
+    llmPayload = validateLlmPayload(parseLlmJson(text));
+  }
+
+  const outputDir = options.outputDir ?? DEFAULT_OUTPUT_DIR;
+  const files = {
+    outputDir,
+    jsonPath: path.join(outputDir, DEFAULT_JSON_NAME),
+    markdownPath: path.join(outputDir, DEFAULT_MARKDOWN_NAME),
+  };
+  const result = {
+    ok: true,
+    generatedAt: new Date().toISOString(),
+    provider: options.provider,
+    model: options.model,
+    inputPath,
+    mode: options.useFullBody === true ? "full-body" : "excerpt",
+    dedup: options.dedup !== false,
+    totalComments: comments.length,
+    dedupedComments: commentsForPrompt.length,
+    clusters: llmPayload.clusters,
+    unclustered: llmPayload.unclustered,
+    summary: {
+      ...llmPayload.summary,
+      totalCommentsProcessed: comments.length,
+      totalClustersFound: llmPayload.clusters.length,
+    },
+    commentAssignments: llmPayload.commentAssignments,
+    personaCandidates: buildPersonaCandidates(llmPayload.clusters, options.model),
+    inputComments: commentsForPrompt.map((comment, index) => ({
+      commentIndex: index + 1,
+      prNumber: comment.prNumber,
+      path: comment.path,
+      line: comment.line,
+      htmlUrl: comment.htmlUrl,
+      excerpt: comment.excerpt,
+      occurrenceCount: comment.occurrenceCount ?? 1,
+      duplicatePrNumbers: comment.duplicatePrNumbers ?? [],
+    })),
+    files,
+  };
+
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(files.jsonPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+  await writeFile(files.markdownPath, renderReport(result), "utf8");
+
+  return result;
+}
+
+export async function runCli(argv = process.argv.slice(2), { stdout = process.stdout, env = process.env, fetchImpl = globalThis.fetch } = {}) {
+  const options = parseClassifyUncategorizedCliArgs(argv);
+  if (options.help) {
+    stdout.write(`${USAGE}\n`);
+    return;
+  }
+  const result = await classifyUncategorizedComments(options, { env, fetchImpl });
+  stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli().catch((error) => {
+    process.stderr.write(`${formatCliError(error, { usage: USAGE })}\n`);
+    process.exitCode = 1;
+  });
+}
+
+export {
+  DEFAULT_INPUT_NAME,
+  DEFAULT_JSON_NAME,
+  DEFAULT_MARKDOWN_NAME,
+  DEFAULT_PROVIDER,
+  DEFAULT_RETRY_BASE_MS,
+  DEFAULT_RETRY_MAX,
+  FALLBACK_SUMMARY_NAME,
+};

--- a/scripts/github/classify-uncategorized-comments.mjs
+++ b/scripts/github/classify-uncategorized-comments.mjs
@@ -32,7 +32,7 @@ function normalizeBaseUrl(value) {
   return trimmed;
 }
 
-const USAGE = `Usage: classify-uncategorized-comments.mjs --model <model> [--provider <openai-compatible|anthropic>] [--api-key <key>] [--input <path>] [--output-dir <path>] [--use-full-body] [--no-dedup]
+const USAGE = `Usage: classify-uncategorized-comments.mjs --model <model> [--provider <openai-compatible|anthropic>] [--api-key <key>] [--base-url <url>] [--input <path>] [--output-dir <path>] [--use-full-body] [--no-dedup]
 
 Classify uncategorized Copilot review comments with a single LLM pass and write
 both JSON and Markdown cluster reports. Uses built-in fetch; no extra npm deps.

--- a/scripts/github/classify-uncategorized-comments.mjs
+++ b/scripts/github/classify-uncategorized-comments.mjs
@@ -16,6 +16,22 @@ const DEFAULT_RETRY_BASE_MS = 1000;
 const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
 const ANTHROPIC_DEFAULT_BASE_URL = "https://api.anthropic.com/v1";
 
+function normalizeBaseUrl(value) {
+  const trimmed = String(value ?? "").trim().replace(/\/+$/u, "");
+  if (trimmed.length === 0) {
+    throw parseError("--base-url must be a non-empty http(s) URL");
+  }
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error("unsupported protocol");
+    }
+  } catch {
+    throw parseError("--base-url must be a valid http(s) URL");
+  }
+  return trimmed;
+}
+
 const USAGE = `Usage: classify-uncategorized-comments.mjs --model <model> [--provider <openai-compatible|anthropic>] [--api-key <key>] [--input <path>] [--output-dir <path>] [--use-full-body] [--no-dedup]
 
 Classify uncategorized Copilot review comments with a single LLM pass and write
@@ -94,7 +110,7 @@ export function parseClassifyUncategorizedCliArgs(argv) {
     }
 
     if (token === "--base-url") {
-      options.baseUrl = requireOptionValue(args, "--base-url", parseError).trim().replace(/\/+$/u, "");
+      options.baseUrl = normalizeBaseUrl(requireOptionValue(args, "--base-url", parseError));
       continue;
     }
 
@@ -476,7 +492,8 @@ export async function classifyUncategorizedComments(options, { env = process.env
     unclustered: llmPayload.unclustered,
     summary: {
       ...llmPayload.summary,
-      totalCommentsProcessed: comments.length,
+      totalCommentsProcessed: commentsForPrompt.length,
+      totalOriginalComments: comments.length,
       totalClustersFound: llmPayload.clusters.length,
     },
     commentAssignments: llmPayload.commentAssignments,

--- a/scripts/github/classify-uncategorized-comments.mjs
+++ b/scripts/github/classify-uncategorized-comments.mjs
@@ -44,8 +44,8 @@ Optional:
   --provider <provider>     openai-compatible (default) or anthropic
   --api-key <key>           LLM API key. Falls back to LLM_API_KEY, then provider-specific env.
   --base-url <url>          Provider base URL (defaults to OpenAI/Anthropic public API)
-  --input <path>            Input JSON. Defaults to tmp/investigation/uncategorized-comments.json,
-                            then falls back to tmp/investigation/copilot-comment-summary.json
+  --input <path>            Input JSON. Defaults to <output-dir>/uncategorized-comments.json,
+                            then falls back to <output-dir>/copilot-comment-summary.json
   --output-dir <path>       Output directory (default: tmp/investigation)
   --use-full-body           Send full comment bodies instead of excerpts
   --no-dedup                Disable default body/excerpt deduplication
@@ -328,9 +328,13 @@ function validateLlmPayload(payload) {
     throw new Error("LLM JSON must include clusters[]");
   }
   return {
-    clusters: payload.clusters.map((cluster) => ({
-      name: typeof cluster?.name === "string" ? cluster.name : "unnamed-cluster",
-      label: typeof cluster?.label === "string" ? cluster.label : String(cluster?.name ?? "Unnamed cluster"),
+    clusters: payload.clusters.map((cluster, index) => {
+      const normalizedName = typeof cluster?.name === "string" && cluster.name.trim().length > 0
+        ? cluster.name.trim()
+        : `unnamed-cluster-${index + 1}`;
+      return {
+      name: normalizedName,
+      label: typeof cluster?.label === "string" && cluster.label.trim().length > 0 ? cluster.label.trim() : normalizedName,
       description: typeof cluster?.description === "string" ? cluster.description : "",
       frequency: Number.isInteger(cluster?.frequency) ? cluster.frequency : 0,
       priority: ["high", "medium", "low"].includes(cluster?.priority) ? cluster.priority : "low",
@@ -341,7 +345,8 @@ function validateLlmPayload(payload) {
         path: typeof example?.path === "string" ? example.path : null,
         excerpt: typeof example?.excerpt === "string" ? example.excerpt : "",
       })) : [],
-    })),
+    };
+    }),
     unclustered: {
       frequency: Number.isInteger(payload?.unclustered?.frequency) ? payload.unclustered.frequency : 0,
       examples: Array.isArray(payload?.unclustered?.examples) ? payload.unclustered.examples : [],

--- a/scripts/github/classify-uncategorized-comments.mjs
+++ b/scripts/github/classify-uncategorized-comments.mjs
@@ -174,7 +174,9 @@ async function resolveInputPath(options) {
   if (options.input) return options.input;
   const uncategorizedPath = path.join(options.outputDir, DEFAULT_INPUT_NAME);
   if (await pathExists(uncategorizedPath)) return uncategorizedPath;
-  return path.join(options.outputDir, FALLBACK_SUMMARY_NAME);
+  const summaryPath = path.join(options.outputDir, FALLBACK_SUMMARY_NAME);
+  if (await pathExists(summaryPath)) return summaryPath;
+  throw new Error(`No classifier input found. Expected ${uncategorizedPath} or fallback ${summaryPath}; pass --input to use another file.`);
 }
 
 function normalizeComment(entry) {

--- a/scripts/github/classify-uncategorized-comments.mjs
+++ b/scripts/github/classify-uncategorized-comments.mjs
@@ -333,19 +333,19 @@ function validateLlmPayload(payload) {
         ? cluster.name.trim()
         : `unnamed-cluster-${index + 1}`;
       return {
-      name: normalizedName,
-      label: typeof cluster?.label === "string" && cluster.label.trim().length > 0 ? cluster.label.trim() : normalizedName,
-      description: typeof cluster?.description === "string" ? cluster.description : "",
-      frequency: Number.isInteger(cluster?.frequency) ? cluster.frequency : 0,
-      priority: ["high", "medium", "low"].includes(cluster?.priority) ? cluster.priority : "low",
-      recommendedPersona: typeof cluster?.recommendedPersona === "string" && cluster.recommendedPersona.trim().length > 0 ? cluster.recommendedPersona.trim() : null,
-      personaRationale: typeof cluster?.personaRationale === "string" ? cluster.personaRationale : "",
-      examples: Array.isArray(cluster?.examples) ? cluster.examples.map((example) => ({
-        prNumber: Number.isInteger(example?.prNumber) ? example.prNumber : null,
-        path: typeof example?.path === "string" ? example.path : null,
-        excerpt: typeof example?.excerpt === "string" ? example.excerpt : "",
-      })) : [],
-    };
+        name: normalizedName,
+        label: typeof cluster?.label === "string" && cluster.label.trim().length > 0 ? cluster.label.trim() : normalizedName,
+        description: typeof cluster?.description === "string" ? cluster.description : "",
+        frequency: Number.isInteger(cluster?.frequency) ? cluster.frequency : 0,
+        priority: ["high", "medium", "low"].includes(cluster?.priority) ? cluster.priority : "low",
+        recommendedPersona: typeof cluster?.recommendedPersona === "string" && cluster.recommendedPersona.trim().length > 0 ? cluster.recommendedPersona.trim() : null,
+        personaRationale: typeof cluster?.personaRationale === "string" ? cluster.personaRationale : "",
+        examples: Array.isArray(cluster?.examples) ? cluster.examples.map((example) => ({
+          prNumber: Number.isInteger(example?.prNumber) ? example.prNumber : null,
+          path: typeof example?.path === "string" ? example.path : null,
+          excerpt: typeof example?.excerpt === "string" ? example.excerpt : "",
+        })) : [],
+      };
     }),
     unclustered: {
       frequency: Number.isInteger(payload?.unclustered?.frequency) ? payload.unclustered.frequency : 0,

--- a/test/github/audit-copilot-comments.test.mjs
+++ b/test/github/audit-copilot-comments.test.mjs
@@ -644,3 +644,56 @@ test("audit-copilot-comments resume with corrupt checkpoint falls back to fresh 
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+test("parseAuditCopilotCommentsCliArgs parses --save-uncategorized", () => {
+  const options = parseAuditCopilotCommentsCliArgs(["--repo", "owner/repo", "--save-uncategorized"]);
+
+  assert.equal(options.saveUncategorized, true);
+});
+
+test("audit-copilot-comments --save-uncategorized writes only uncategorized comments", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-audit-uncategorized-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/pulls/comments?per_page=100"],
+        stdout: `${JSON.stringify([[
+          sampleReviewComment({
+            id: 901,
+            prNumber: 11,
+            path: "README.md",
+            body: "This relative path points to a missing file.",
+          }),
+          sampleReviewComment({
+            id: 902,
+            prNumber: 12,
+            path: "scripts/example.mjs",
+            body: "This asks for a novel guard around streamed response parsing.",
+            line: 42,
+          }),
+        ]])}\n`,
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/pulls?state=all&per_page=100"],
+        stdout: `${JSON.stringify([samplePrs])}\n`,
+      },
+    ]);
+
+    const outputDir = path.join(tempDir, "out");
+    const result = await runNode(["--repo", "owner/repo", "--output-dir", outputDir, "--save-uncategorized"], { env });
+
+    assert.equal(result.code, 0, result.stderr);
+    const stdout = JSON.parse(result.stdout);
+    assert.equal(stdout.files.uncategorizedCommentsPath, path.join(outputDir, "uncategorized-comments.json"));
+
+    const uncategorized = JSON.parse(await readFile(stdout.files.uncategorizedCommentsPath, "utf8"));
+    assert.equal(uncategorized.length, 1);
+    assert.deepEqual(Object.keys(uncategorized[0]).sort(), ["body", "excerpt", "htmlUrl", "line", "path", "prNumber"].sort());
+    assert.equal(uncategorized[0].prNumber, 12);
+    assert.equal(uncategorized[0].line, 42);
+    assert.match(uncategorized[0].body, /novel guard/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/github/classify-uncategorized-comments.test.mjs
+++ b/test/github/classify-uncategorized-comments.test.mjs
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { runNode as runNodeHelper, writeJson } from "../_helpers.mjs";
+import {
+  buildClassificationPrompt,
+  classifyUncategorizedComments,
+  dedupeComments,
+  parseClassifyUncategorizedCliArgs,
+} from "../../scripts/github/classify-uncategorized-comments.mjs";
+
+const scriptPath = path.resolve("scripts/github/classify-uncategorized-comments.mjs");
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
+
+const comments = [
+  { prNumber: 1, path: "scripts/a.mjs", line: 10, htmlUrl: "https://example.test/1", body: "JSON.parse can throw without a guard.", excerpt: "JSON.parse can throw without a guard." },
+  { prNumber: 2, path: "docs/b.md", line: 5, htmlUrl: "https://example.test/2", body: "Documented contract says ready, code says active.", excerpt: "Documented contract says ready, code says active." },
+  { prNumber: 3, path: "scripts/a.mjs", line: 10, htmlUrl: "https://example.test/3", body: "JSON.parse can throw without a guard.", excerpt: "JSON.parse can throw without a guard." },
+];
+
+function responseBody(clusters = []) {
+  return {
+    clusters,
+    unclustered: { frequency: 0, examples: [] },
+    summary: { totalCommentsProcessed: 2, totalClustersFound: clusters.length },
+  };
+}
+
+test("parseClassifyUncategorizedCliArgs requires explicit --model", () => {
+  assert.throws(
+    () => parseClassifyUncategorizedCliArgs(["--api-key", "key"]),
+    /requires --model/i,
+  );
+  assert.equal(parseClassifyUncategorizedCliArgs(["--model", "gpt-test", "--api-key", "key"]).model, "gpt-test");
+});
+
+test("dedupeComments collapses duplicate bodies by default while preserving occurrence count", () => {
+  const deduped = dedupeComments(comments);
+
+  assert.equal(deduped.length, 2);
+  assert.equal(deduped[0].occurrenceCount, 2);
+  assert.deepEqual(deduped[0].duplicatePrNumbers, [1, 3]);
+});
+
+test("buildClassificationPrompt uses excerpts by default and full bodies when requested", () => {
+  const excerptPrompt = buildClassificationPrompt({ comments: dedupeComments(comments), useFullBody: false });
+  const fullPrompt = buildClassificationPrompt({ comments: dedupeComments(comments), useFullBody: true });
+
+  assert.match(excerptPrompt.user, /\[comment 1\] occurrences=2 PR#1 scripts\/a\.mjs:10: JSON\.parse/);
+  assert.match(fullPrompt.user, /Documented contract says ready/);
+  assert.match(excerptPrompt.system, /existing categories/i);
+});
+
+test("classifyUncategorizedComments reads input, retries malformed JSON once, and writes JSON and Markdown", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-classify-uncategorized-"));
+
+  try {
+    const input = path.join(tempDir, "uncategorized-comments.json");
+    const outputDir = path.join(tempDir, "out");
+    await writeJson(input, comments);
+
+    const calls = [];
+    const fetchImpl = async (url, init) => {
+      calls.push({ url, init });
+      if (calls.length === 1) {
+        return { ok: true, status: 200, text: async () => JSON.stringify({ choices: [{ message: { content: "not-json" } }] }) };
+      }
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ choices: [{ message: { content: JSON.stringify(responseBody([
+          {
+            name: "error-guard",
+            label: "Error Guard",
+            description: "Missing error handling around parser calls.",
+            frequency: 2,
+            priority: "high",
+            recommendedPersona: "error-guard",
+            personaRationale: "Mechanical pre-review catch.",
+            examples: [{ prNumber: 1, path: "scripts/a.mjs", excerpt: "JSON.parse can throw" }],
+          },
+        ])) } }] }),
+      };
+    };
+
+    const result = await classifyUncategorizedComments({ input, outputDir, model: "gpt-test", apiKey: "key", provider: "openai-compatible" }, { fetchImpl });
+
+    assert.equal(calls.length, 2);
+    assert.equal(result.dedupedComments, 2);
+    assert.equal(result.files.jsonPath, path.join(outputDir, "uncategorized-clusters.json"));
+    assert.equal(result.files.markdownPath, path.join(outputDir, "uncategorized-clusters.md"));
+
+    const json = JSON.parse(await readFile(result.files.jsonPath, "utf8"));
+    const markdown = await readFile(result.files.markdownPath, "utf8");
+    assert.equal(json.clusters[0].name, "error-guard");
+    assert.match(markdown, /Persona candidates/);
+    assert.match(markdown, /personas:/);
+    assert.match(markdown, /Left unclustered/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("classifyUncategorizedComments falls back from summary JSON and retries 429", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-classify-summary-"));
+
+  try {
+    const input = path.join(tempDir, "copilot-comment-summary.json");
+    await writeJson(input, {
+      comments: [
+        { ...comments[0], primaryCategoryId: null },
+        { ...comments[1], primaryCategoryId: "gate_evidence" },
+      ],
+    });
+
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls += 1;
+      if (calls === 1) {
+        return { ok: false, status: 429, text: async () => "rate limited" };
+      }
+      return { ok: true, status: 200, text: async () => JSON.stringify({ content: [{ type: "text", text: JSON.stringify(responseBody()) }] }) };
+    };
+
+    const result = await classifyUncategorizedComments({ input, outputDir: path.join(tempDir, "out"), model: "claude-test", apiKey: "key", provider: "anthropic", retryBaseMs: 1 }, { fetchImpl });
+
+    assert.equal(calls, 2);
+    assert.equal(result.totalComments, 1);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("classify-uncategorized-comments CLI rejects missing API key clearly", async () => {
+  const result = await runNode(["--model", "gpt-test"], { env: { ...process.env, LLM_API_KEY: "", OPENAI_API_KEY: "", ANTHROPIC_API_KEY: "" } });
+
+  assert.equal(result.code, 1);
+  const stderr = JSON.parse(result.stderr);
+  assert.match(stderr.error, /requires an API key/i);
+});

--- a/test/github/classify-uncategorized-comments.test.mjs
+++ b/test/github/classify-uncategorized-comments.test.mjs
@@ -176,6 +176,19 @@ test("classifyUncategorizedComments falls back from summary JSON and retries 429
   }
 });
 
+test("classifyUncategorizedComments reports both default input candidates when missing", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-classify-missing-input-"));
+
+  try {
+    await assert.rejects(
+      classifyUncategorizedComments({ outputDir: path.join(tempDir, "out"), model: "gpt-test", apiKey: "key", provider: "openai-compatible" }, { fetchImpl: async () => { throw new Error("should not fetch"); } }),
+      /uncategorized-comments\.json.*copilot-comment-summary\.json/i,
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("classify-uncategorized-comments CLI rejects missing API key clearly", async () => {
   const result = await runNode(["--model", "gpt-test"], { env: { ...process.env, LLM_API_KEY: "", OPENAI_API_KEY: "", ANTHROPIC_API_KEY: "" } });
 

--- a/test/github/classify-uncategorized-comments.test.mjs
+++ b/test/github/classify-uncategorized-comments.test.mjs
@@ -37,12 +37,24 @@ test("parseClassifyUncategorizedCliArgs requires explicit --model", () => {
   assert.equal(parseClassifyUncategorizedCliArgs(["--model", "gpt-test", "--api-key", "key"]).model, "gpt-test");
 });
 
-test("dedupeComments collapses duplicate bodies by default while preserving occurrence count", () => {
+test("dedupeComments collapses duplicate prompt text by default while preserving occurrence count", () => {
   const deduped = dedupeComments(comments);
 
   assert.equal(deduped.length, 2);
   assert.equal(deduped[0].occurrenceCount, 2);
   assert.deepEqual(deduped[0].duplicatePrNumbers, [1, 3]);
+
+  const excerptDuplicates = dedupeComments([
+    { prNumber: 4, body: "same excerpt then long body A", excerpt: "same excerpt" },
+    { prNumber: 5, body: "same excerpt then long body B", excerpt: "same excerpt" },
+  ]);
+  assert.equal(excerptDuplicates.length, 1);
+
+  const fullBodyDistinct = dedupeComments([
+    { prNumber: 4, body: "same excerpt then long body A", excerpt: "same excerpt" },
+    { prNumber: 5, body: "same excerpt then long body B", excerpt: "same excerpt" },
+  ], { useFullBody: true });
+  assert.equal(fullBodyDistinct.length, 2);
 });
 
 test("buildClassificationPrompt uses excerpts by default and full bodies when requested", () => {

--- a/test/github/classify-uncategorized-comments.test.mjs
+++ b/test/github/classify-uncategorized-comments.test.mjs
@@ -35,6 +35,11 @@ test("parseClassifyUncategorizedCliArgs requires explicit --model", () => {
     /requires --model/i,
   );
   assert.equal(parseClassifyUncategorizedCliArgs(["--model", "gpt-test", "--api-key", "key"]).model, "gpt-test");
+  assert.equal(parseClassifyUncategorizedCliArgs(["--model", "gpt-test", "--base-url", "https://models.example.test/v1/"]).baseUrl, "https://models.example.test/v1");
+  assert.throws(
+    () => parseClassifyUncategorizedCliArgs(["--model", "gpt-test", "--base-url", "/"]),
+    /valid http\(s\) URL|non-empty http\(s\) URL/i,
+  );
 });
 
 test("dedupeComments collapses duplicate prompt text by default while preserving occurrence count", () => {
@@ -102,6 +107,8 @@ test("classifyUncategorizedComments reads input, retries malformed JSON once, an
 
     assert.equal(calls.length, 2);
     assert.equal(result.dedupedComments, 2);
+    assert.equal(result.summary.totalCommentsProcessed, 2);
+    assert.equal(result.summary.totalOriginalComments, 3);
     assert.equal(result.files.jsonPath, path.join(outputDir, "uncategorized-clusters.json"));
     assert.equal(result.files.markdownPath, path.join(outputDir, "uncategorized-clusters.md"));
 

--- a/test/github/classify-uncategorized-comments.test.mjs
+++ b/test/github/classify-uncategorized-comments.test.mjs
@@ -71,6 +71,29 @@ test("buildClassificationPrompt uses excerpts by default and full bodies when re
   assert.match(excerptPrompt.system, /existing categories/i);
 });
 
+test("validateLlmPayload uses unique fallback names for unnamed clusters", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-classify-unnamed-"));
+
+  try {
+    const input = path.join(tempDir, "uncategorized-comments.json");
+    await writeJson(input, comments.slice(0, 1));
+
+    const fetchImpl = async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ choices: [{ message: { content: JSON.stringify(responseBody([
+        { name: "", frequency: 1, examples: [] },
+        { frequency: 1, examples: [] },
+      ])) } }] }),
+    });
+
+    const result = await classifyUncategorizedComments({ input, outputDir: path.join(tempDir, "out"), model: "gpt-test", apiKey: "key", provider: "openai-compatible" }, { fetchImpl });
+    assert.deepEqual(result.clusters.map((cluster) => cluster.name), ["unnamed-cluster-1", "unnamed-cluster-2"]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("classifyUncategorizedComments reads input, retries malformed JSON once, and writes JSON and Markdown", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-classify-uncategorized-"));
 

--- a/test/github/classify-uncategorized-comments.test.mjs
+++ b/test/github/classify-uncategorized-comments.test.mjs
@@ -29,6 +29,13 @@ function responseBody(clusters = []) {
   };
 }
 
+test("classify-uncategorized-comments help lists --base-url", async () => {
+  const result = await runNode(["--help"]);
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /--base-url <url>/);
+});
+
 test("parseClassifyUncategorizedCliArgs requires explicit --model", () => {
   assert.throws(
     () => parseClassifyUncategorizedCliArgs(["--api-key", "key"]),


### PR DESCRIPTION
## Change summary

- Adds `--save-uncategorized` to `scripts/github/audit-copilot-comments.mjs`.
- Adds `scripts/github/classify-uncategorized-comments.mjs`, a standalone no-dependency LLM classifier for uncategorized Copilot comments.
- Documents the new audit/classifier flow and adds GitHub script tests.

## Scope / context

Fixes #420. The audit can now emit `tmp/investigation/uncategorized-comments.json` without changing normal audit behavior. The classifier reads that file, or falls back to `copilot-comment-summary.json`, sends one prompt through built-in `fetch`, deduplicates by default, and writes JSON + Markdown cluster reports.

## Acceptance criteria

- `--save-uncategorized` writes only `primaryCategoryId === null` comments with body, PR, path, line, URL, and excerpt.
- Classifier requires `--model`, supports OpenAI-compatible and Anthropic request shapes, uses built-in `fetch`, and retries 429/5xx.
- Excerpt mode is default; `--use-full-body` is opt-in.
- Dedup is enabled by default with `--no-dedup` override.
- Malformed LLM JSON triggers one stricter retry before failing.
- Markdown report includes clusters, persona candidates, and a Left unclustered section.

## Definition of done

- Tests cover flag parsing/output, classifier argument errors, dedup, fallback input, retry, malformed JSON retry, and output rendering.
- `npm run verify` passes locally.
- No new npm dependencies added.

## Non-goals

- No regex taxonomy expansion.
- No recurring pipeline automation.
- No persona implementation.
- No real LLM call in tests.
