### PR TITLE
Wire deep persona into pre-approval gate

### DIFF
--- a/.pi/dev-loop/defaults.yaml
+++ b/.pi/dev-loop/defaults.yaml
@@ -37,13 +37,14 @@ gates:
   preApproval:
     # Pre-approval gate: runs before declaring merge-ready.
     # Additional opt-in angles available (see personas section):
-    #   ocp, lsp, isp, dip, docs, deep
+    #   ocp, lsp, isp, dip, docs
     angles:
       - dry
       - kiss
       - yagni
       - srp
       - soc
+      - deep
     required: true
 
 # Autonomy: which gates require operator confirmation (stop points)

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1471,7 +1471,7 @@ describe("role resolution", () => {
 });
 
 describe("shipped defaults docs and deep angle wiring", () => {
-  test("D1: shipped defaults keep docs and deep opt-in and resolve the packaged persona prompts", async () => {
+  test("D1: shipped defaults keep docs opt-in, deep enabled by default, and resolve packaged persona prompts", async () => {
     const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-D1-"));
     try {
       const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
@@ -1494,7 +1494,7 @@ describe("shipped defaults docs and deep angle wiring", () => {
       assert.match(result.config.personas.deep.prompt, /Perform a structural code quality audit of this PR/i);
       assert.match(result.config.personas.deep.prompt, /deslop audit/i);
       assert.ok(!preApprovalAngles.includes("docs"), "docs must stay opt-in for pre-approval");
-      assert.ok(!preApprovalAngles.includes("deep"), "deep must stay opt-in for pre-approval");
+      assert.ok(preApprovalAngles.includes("deep"), "deep must run by default for pre-approval");
       assert.equal(docsRole.persona, "docs");
       assert.equal(docsRole.prompt, result.config.personas.docs.prompt);
       assert.equal(docsRole.fallback, false);

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -344,7 +344,7 @@ This is the default pre-approval gate for this workflow boundary. The canonical 
 - **Gate name:** Pre-approval gate
 - **Trigger / boundary:** right before calling a PR/branch review-complete, approval-ready, merge-ready, or ready for final handoff
 - **Execution directive:** run the gate-review sub-loop defined in [Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md) with the pre-approval gate review angles resolved from config. The sub-loop uses a context→fork→consolidate chain; only re-run reviewers that had findings in the previous pass.
-- **Review angles:** resolved at runtime from config via `resolveGateAngles(config, "preApproval")` from `@pi-dev-loops/core/config`. Default config ships `dry`, `kiss`, `yagni`, `srp`, `soc`; consumer repos may override.
+- **Review angles:** resolved at runtime from config via `resolveGateAngles(config, "preApproval")` from `@pi-dev-loops/core/config`. Default config ships `dry`, `kiss`, `yagni`, `srp`, `soc`, `deep`; consumer repos may override.
 - **Persona mapping:** each angle resolves to a reviewer persona via `resolveReviewerRole(config, angle)` from `@pi-dev-loops/core/config`. Include this prompt in each reviewer's briefing so the reviewer knows exactly what to look for.
 - **Pass criteria:** the sub-loop completes with verdict `clean`; all configured angles pass; if parallel execution is impractical, still run all configured lenses and explicitly record the limitation.
 - **Next step after passing:** continue the Step 7 flow and then proceed to the final approval gate below.

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -94,7 +94,7 @@ When the local spec already lives in a tracker issue:
 - Do implementation work on a dedicated local branch, not directly on `main`.
 - If the repo has no commits yet, still create the working branch first so the first commits land off `main`; only move `main` forward after review and validation.
 - Use small atomic local commits as progress checkpoints whenever a coherent slice is green and reviewable.
-- Before a branch is considered review-complete, approval-ready, merge-ready, or ready for final handoff, run the default pre-approval gate as a full review / fix loop with the review angles resolved from config (`resolveGateAngles(config, "preApproval")`; shipped defaults include `deep`), then apply accepted fixes and rerun validation.
+- Before a branch is considered review-complete, approval-ready, merge-ready, or ready for final handoff, run the default pre-approval gate as a full review / fix loop with the review angles resolved from config (`resolveGateAngles(config, "preApproval")`), then apply accepted fixes and rerun validation. Shipped defaults include the `deep` angle.
 - A phase is only fully complete when its scoped work, required support files, artifacts, validation, review/fix pass, commit(s), and finalization (merge into local `main` for phase-doc-backed sessions; PR merge for tracker-backed sessions) are done, or when the only remaining step is an explicitly noted authorization-gated finalization action.
 - When subagents are used, log what each subagent was asked to do and what it concluded.
 - If [Project Plan](../../PLAN.md) is too rough or ambiguous to safely start the current phase, do not guess: run a clarification/interview step with the user first.

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -94,7 +94,7 @@ When the local spec already lives in a tracker issue:
 - Do implementation work on a dedicated local branch, not directly on `main`.
 - If the repo has no commits yet, still create the working branch first so the first commits land off `main`; only move `main` forward after review and validation.
 - Use small atomic local commits as progress checkpoints whenever a coherent slice is green and reviewable.
-- Before a branch is considered review-complete, approval-ready, merge-ready, or ready for final handoff, run the default pre-approval gate as a full review / fix loop with the review angles resolved from config (`resolveGateAngles(config, "preApproval")`), then apply accepted fixes and rerun validation.
+- Before a branch is considered review-complete, approval-ready, merge-ready, or ready for final handoff, run the default pre-approval gate as a full review / fix loop with the review angles resolved from config (`resolveGateAngles(config, "preApproval")`; shipped defaults include `deep`), then apply accepted fixes and rerun validation.
 - A phase is only fully complete when its scoped work, required support files, artifacts, validation, review/fix pass, commit(s), and finalization (merge into local `main` for phase-doc-backed sessions; PR merge for tracker-backed sessions) are done, or when the only remaining step is an explicitly noted authorization-gated finalization action.
 - When subagents are used, log what each subagent was asked to do and what it concluded.
 - If [Project Plan](../../PLAN.md) is too rough or ambiguous to safely start the current phase, do not guess: run a clarification/interview step with the user first.
@@ -396,7 +396,7 @@ After the phase plan passes review:
    - for user-facing HTML/UI/component slices when the user opts in, add a bounded deterministic browser smoke harness (prefer fixture-backed Playwright WebKit plus screenshot capture); use `npm run test:playwright:viewer` when that viewer/browser surface is part of the slice, and wire it into CI once it becomes required validation for that slice
 4. Review the implementation against the merged phase plan.
 5. Run the default pre-approval gate as a full review / fix loop on the branch before calling it review-complete, approval-ready, merge-ready, or ready for final handoff:
-   - resolve review angles from config: `resolveGateAngles(config, "preApproval")` from `@pi-dev-loops/core/config`
+   - resolve review angles from config: `resolveGateAngles(config, "preApproval")` from `@pi-dev-loops/core/config` (shipped defaults include `deep`)
    - run the resolved angle-focused passes in parallel with fresh context when practical
    - if parallel execution is impractical (for example due to tooling or resource constraints), run all angles sequentially and explicitly record why parallel execution was impractical in `Phase Review` (`tmp/phases/phase-x/review.md`) (or the equivalent merged review artifact)
    - for each angle, resolve its persona and prompt via `resolveReviewerRole(config, angle)` — start each reviewer in fresh context with a concise briefing including the angle-specific prompt, the branch/phase, intended behavior, acceptance criteria, relevant files or artifacts, and current validation status


### PR DESCRIPTION
## Change summary

- Adds `deep` to the shipped default `preApproval` gate angle list.
- Updates the Copilot PR follow-up pre-approval gate docs to name `deep` as a default angle.
- Updates the local implementation gate procedure to call out that shipped pre-approval defaults include `deep`.
- Updates config coverage so shipped defaults must keep `deep` enabled by default while `docs` remains opt-in.

## Scope / context

Issue #415 reports that the `deep` persona exists in `.pi/dev-loop/defaults.yaml` but is not invoked by default gate execution. This PR wires that persona into the default pre-approval gate path without changing the persona prompt or other gate behavior.

## Acceptance criteria

- `deep` appears in default `preApproval` gate angles.
- `skills/copilot-pr-followup/SKILL.md` references `deep` in the pre-approval gate procedure.
- `skills/local-implementation/SKILL.md` references `deep` in the local pre-approval gate procedure.
- Tests prove shipped defaults include `deep` by default.

## Definition of done

- Full repo verification passes locally with `npm run verify`.
- Draft gate passes before marking ready for review.
- Copilot review/fix loop has zero unresolved threads.
- Pre-approval gate passes on the current head.
- PR merges through the normal GitHub path.

## Non-goals

- No prompt rewrite for the existing `deep` persona.
- No changes to optional `docs` pre-approval behavior.
- No changes to gate state machines or reviewer execution mechanics.

Closes #415
