### PR TITLE
Docs: add structural quality posture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ Use a conductor monitor as the queue-level human-in-the-loop watcher for active 
 - KISS
 - SRP
 - YAGNI
-- Structural quality: apply `deep` review angle standards during implementation; prefer deletion, justify files over ~1k lines, avoid spaghetti branching, thin wrappers, identity abstractions, and leaky shared-module abstractions.
+- Structural quality: apply `deep` review angle standards during implementation; see [Local Implementation](skills/local-implementation/SKILL.md#structural-quality-from-deep-review-angle).
 - for workflow surface and agent guidance decisions, YAGNI-driven simplification takes priority over preserving speculative compatibility or extra entrypoint names
 - one concise canonical version of each workflow contract, prompt surface, and operator path; delete superseded variants instead of keeping them around for comfort
 - no backwards-compatibility-by-default posture: do not add or preserve legacy names, aliases, compatibility shims, compatibility entrypoints, or duplicate docs/tests unless that compatibility is explicitly required and approved

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ Use a conductor monitor as the queue-level human-in-the-loop watcher for active 
 - KISS
 - SRP
 - YAGNI
-- Structural quality: apply deep persona standards during implementation; prefer deletion, justify files over ~1k lines, avoid spaghetti branching, thin wrappers, identity abstractions, and leaky shared-module abstractions.
+- Structural quality: apply `deep` review angle standards during implementation; prefer deletion, justify files over ~1k lines, avoid spaghetti branching, thin wrappers, identity abstractions, and leaky shared-module abstractions.
 - for workflow surface and agent guidance decisions, YAGNI-driven simplification takes priority over preserving speculative compatibility or extra entrypoint names
 - one concise canonical version of each workflow contract, prompt surface, and operator path; delete superseded variants instead of keeping them around for comfort
 - no backwards-compatibility-by-default posture: do not add or preserve legacy names, aliases, compatibility shims, compatibility entrypoints, or duplicate docs/tests unless that compatibility is explicitly required and approved

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ Use a conductor monitor as the queue-level human-in-the-loop watcher for active 
 - KISS
 - SRP
 - YAGNI
+- Structural quality: apply deep persona standards during implementation; prefer deletion, justify files over ~1k lines, avoid spaghetti branching, thin wrappers, identity abstractions, and leaky shared-module abstractions.
 - for workflow surface and agent guidance decisions, YAGNI-driven simplification takes priority over preserving speculative compatibility or extra entrypoint names
 - one concise canonical version of each workflow contract, prompt surface, and operator path; delete superseded variants instead of keeping them around for comfort
 - no backwards-compatibility-by-default posture: do not add or preserve legacy names, aliases, compatibility shims, compatibility entrypoints, or duplicate docs/tests unless that compatibility is explicitly required and approved

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -132,9 +132,9 @@ Do not assume `scripts/...` is repo-local to the target codebase you are operati
 - For GitHub issue or PR comments, prefer `--body-file` / `-F` or stdin via `-F -` over inline shell strings.
 - Keep scope tight to the issue/PR at hand.
 
-## Structural quality (from deep persona)
+## Structural quality (from `deep` angle)
 
-During implementation and follow-up fixes, apply the `deep` persona standards before waiting for review:
+During implementation and follow-up fixes, apply the `deep` review angle standards before waiting for review:
 
 - Prefer deletion over addition; question every new file, export, layer, and moving part.
 - Files over ~1k lines need extraction or an explicit justification.

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -132,6 +132,16 @@ Do not assume `scripts/...` is repo-local to the target codebase you are operati
 - For GitHub issue or PR comments, prefer `--body-file` / `-F` or stdin via `-F -` over inline shell strings.
 - Keep scope tight to the issue/PR at hand.
 
+## Structural quality (from deep persona)
+
+During implementation and follow-up fixes, apply the `deep` persona standards before waiting for review:
+
+- Prefer deletion over addition; question every new file, export, layer, and moving part.
+- Files over ~1k lines need extraction or an explicit justification.
+- Do not bolt conditionals onto unrelated paths; push logic into dedicated boundaries.
+- Avoid spaghetti branching, thin wrappers, re-export-only files, and identity abstractions.
+- Do not leak feature logic into shared modules or create leaky abstractions.
+
 ## Step 5: PR discovery and interpretation
 
 Treat the PR as the main working artifact once it exists.

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -132,7 +132,7 @@ Do not assume `scripts/...` is repo-local to the target codebase you are operati
 - For GitHub issue or PR comments, prefer `--body-file` / `-F` or stdin via `-F -` over inline shell strings.
 - Keep scope tight to the issue/PR at hand.
 
-## Structural quality (from `deep` angle)
+## Structural quality (from `deep` review angle)
 
 During implementation and follow-up fixes, apply the `deep` review angle standards before waiting for review:
 

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -99,7 +99,7 @@ When the local spec already lives in a tracker issue:
 - When subagents are used, log what each subagent was asked to do and what it concluded.
 - If [Project Plan](../../PLAN.md) is too rough or ambiguous to safely start the current phase, do not guess: run a clarification/interview step with the user first.
 
-## Structural quality (from `deep` angle)
+## Structural quality (from `deep` review angle)
 
 Implementation agents should self-apply the `deep` review angle standards before reviewer gates:
 

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -99,6 +99,16 @@ When the local spec already lives in a tracker issue:
 - When subagents are used, log what each subagent was asked to do and what it concluded.
 - If [Project Plan](../../PLAN.md) is too rough or ambiguous to safely start the current phase, do not guess: run a clarification/interview step with the user first.
 
+## Structural quality (from deep persona)
+
+Implementation agents should self-apply the `deep` persona standards before reviewer gates:
+
+- Prefer deletion over addition; question every new file, export, layer, and moving part.
+- Files over ~1k lines need extraction or an explicit justification.
+- Do not bolt conditionals onto unrelated paths; push logic into dedicated boundaries.
+- Avoid spaghetti branching, thin wrappers, re-export-only files, and identity abstractions.
+- Do not leak feature logic into shared modules or create leaky abstractions.
+
 ## Deterministic logging structure
 
 Treat the workflow as three layers:

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -99,9 +99,9 @@ When the local spec already lives in a tracker issue:
 - When subagents are used, log what each subagent was asked to do and what it concluded.
 - If [Project Plan](../../PLAN.md) is too rough or ambiguous to safely start the current phase, do not guess: run a clarification/interview step with the user first.
 
-## Structural quality (from deep persona)
+## Structural quality (from `deep` angle)
 
-Implementation agents should self-apply the `deep` persona standards before reviewer gates:
+Implementation agents should self-apply the `deep` review angle standards before reviewer gates:
 
 - Prefer deletion over addition; question every new file, export, layer, and moving part.
 - Files over ~1k lines need extraction or an explicit justification.


### PR DESCRIPTION
## Change summary

- Add a concise `Structural quality (from deep persona)` subsection to `skills/local-implementation/SKILL.md`.
- Add the same posture to `skills/copilot-pr-followup/SKILL.md` for implementation and follow-up fixes.
- Reference the deep structural principles in `AGENTS.md` core guard rails.

## Scope / context

Closes #417. This is docs-only guidance so implementation agents self-apply deep structural standards before review gates catch problems.

## Acceptance criteria

- [x] Structural principles injected into `skills/local-implementation/SKILL.md`.
- [x] Structural principles injected into `skills/copilot-pr-followup/SKILL.md`.
- [x] `AGENTS.md` references the principles.
- [x] `npm test` passes.

## Definition of done

- [x] Dedicated branch used.
- [x] Changes are limited to requested documentation surfaces.
- [x] Whitespace checked with `git diff --check`.
- [x] Local test suite passes with `npm test`.

## Non-goals

- Not rewriting all skill docs with full deep persona content.
- Not replacing existing KISS/SRP/YAGNI guard rails.
- Not changing runtime code or tests.
