### PR TITLE
Enforce gate evidence before PR merge

### DIFF
--- a/scripts/github/audit-merged-pr-gate-evidence.mjs
+++ b/scripts/github/audit-merged-pr-gate-evidence.mjs
@@ -18,8 +18,9 @@ const DEFAULT_LIMIT = 20;
 const USAGE = `Usage: audit-merged-pr-gate-evidence.mjs --repo <owner/name> [--limit <n>] [--output <path>]
 
 Audit the most recent merged pull requests for visible dev-loop gate evidence.
-The check fetches PRs and issue comments through gh api, then reports PRs that
-lack a clean draft_gate comment or a clean current-head pre_approval_gate comment.
+The check fetches a bounded recent closed-PR window and issue comments through
+gh api, then reports PRs that lack a clean draft_gate comment or a clean
+current-head pre_approval_gate comment.
 
 Required:
   --repo <owner/name>   Repository slug (e.g. owner/repo)
@@ -180,14 +181,30 @@ function evaluateMergedPrGateEvidence({ pr, comments }) {
   };
 }
 
+async function fetchRecentMergedPulls(options, { env, ghCommand }) {
+  const merged = [];
+  const maxPages = Math.max(1, Math.ceil(options.limit / 100) + 2);
+
+  for (let page = 1; page <= maxPages && merged.length < options.limit; page += 1) {
+    const pagePayload = await runGhJson([
+      "api",
+      `repos/${options.repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100&page=${page}`,
+    ], { env, ghCommand });
+    const pagePulls = flattenPaginatedPayload(pagePayload);
+    merged.push(...normalizeMergedPulls(pagePulls, options.limit));
+
+    if (pagePulls.length < 100) {
+      break;
+    }
+  }
+
+  return merged
+    .sort((a, b) => String(b.mergedAt).localeCompare(String(a.mergedAt)))
+    .slice(0, options.limit);
+}
+
 export async function auditMergedPrGateEvidence(options, { env = process.env, ghCommand = "gh" } = {}) {
-  const pullsPayload = await runGhJson([
-    "api",
-    "--paginate",
-    "--slurp",
-    `repos/${options.repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100`,
-  ], { env, ghCommand });
-  const prs = normalizeMergedPulls(pullsPayload, options.limit);
+  const prs = await fetchRecentMergedPulls(options, { env, ghCommand });
   const results = [];
 
   for (const pr of prs) {

--- a/scripts/github/audit-merged-pr-gate-evidence.mjs
+++ b/scripts/github/audit-merged-pr-gate-evidence.mjs
@@ -10,7 +10,7 @@ import {
   summarizeGateReviewCommentMarkers,
   summarizeGateReviewComments,
 } from "../_core-helpers.mjs";
-import { requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parsePositiveInteger, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 
 const DEFAULT_LIMIT = 20;
@@ -45,13 +45,6 @@ Exit codes:
 
 const parseError = buildParseError(USAGE);
 
-function parsePositiveInteger(value, flag) {
-  const number = Number.parseInt(String(value), 10);
-  if (!Number.isInteger(number) || String(value).trim() !== String(number) || number <= 0) {
-    throw parseError(`${flag} must be a positive integer`);
-  }
-  return number;
-}
 
 function normalizeOutputPath(value) {
   const normalized = typeof value === "string" ? value.trim() : "";
@@ -84,7 +77,7 @@ export function parseAuditMergedPrGateEvidenceCliArgs(argv) {
     }
 
     if (token === "--limit") {
-      options.limit = parsePositiveInteger(requireOptionValue(args, "--limit", parseError), "--limit");
+      options.limit = parsePositiveInteger(requireOptionValue(args, "--limit", parseError), "--limit", parseError);
       continue;
     }
 
@@ -183,9 +176,7 @@ function evaluateMergedPrGateEvidence({ pr, comments }) {
 
 async function fetchRecentMergedPulls(options, { env, ghCommand }) {
   const merged = [];
-  const maxPages = Math.max(1, Math.ceil(options.limit / 100) + 2);
-
-  for (let page = 1; page <= maxPages && merged.length < options.limit; page += 1) {
+  for (let page = 1; merged.length < options.limit; page += 1) {
     const pagePayload = await runGhJson([
       "api",
       `repos/${options.repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100&page=${page}`,

--- a/scripts/github/audit-merged-pr-gate-evidence.mjs
+++ b/scripts/github/audit-merged-pr-gate-evidence.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  buildParseError,
+  formatCliError,
+  isDirectCliRun,
+  parseJsonText,
+  summarizeGateReviewCommentMarkers,
+  summarizeGateReviewComments,
+} from "../_core-helpers.mjs";
+import { requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+
+const DEFAULT_LIMIT = 20;
+
+const USAGE = `Usage: audit-merged-pr-gate-evidence.mjs --repo <owner/name> [--limit <n>] [--output <path>]
+
+Audit the most recent merged pull requests for visible dev-loop gate evidence.
+The check fetches PRs and issue comments through gh api, then reports PRs that
+lack a clean draft_gate comment or a clean current-head pre_approval_gate comment.
+
+Required:
+  --repo <owner/name>   Repository slug (e.g. owner/repo)
+
+Optional:
+  --limit <n>           Number of recent merged PRs to audit (default: 20)
+  --output <path>       Write the JSON summary to this path as well as stdout
+
+Output (stdout, JSON):
+  {
+    "ok": true,
+    "repo": "owner/repo",
+    "limit": 20,
+    "auditedCount": 20,
+    "allHaveRequiredGateEvidence": true,
+    "missingEvidence": []
+  }
+
+Exit codes:
+  0  Audit completed, even when some PRs are missing evidence
+  1  Argument error, gh failure, malformed gh JSON, or output write failure`.trim();
+
+const parseError = buildParseError(USAGE);
+
+function parsePositiveInteger(value, flag) {
+  const number = Number.parseInt(String(value), 10);
+  if (!Number.isInteger(number) || String(value).trim() !== String(number) || number <= 0) {
+    throw parseError(`${flag} must be a positive integer`);
+  }
+  return number;
+}
+
+function normalizeOutputPath(value) {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  if (normalized.length === 0) {
+    throw parseError("--output must be a non-empty path");
+  }
+  return normalized;
+}
+
+export function parseAuditMergedPrGateEvidenceCliArgs(argv) {
+  const args = [...argv];
+  const options = {
+    help: false,
+    repo: undefined,
+    limit: DEFAULT_LIMIT,
+    outputPath: undefined,
+  };
+
+  while (args.length > 0) {
+    const token = args.shift();
+
+    if (token === "--help" || token === "-h") {
+      options.help = true;
+      return options;
+    }
+
+    if (token === "--repo") {
+      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+      continue;
+    }
+
+    if (token === "--limit") {
+      options.limit = parsePositiveInteger(requireOptionValue(args, "--limit", parseError), "--limit");
+      continue;
+    }
+
+    if (token === "--output") {
+      options.outputPath = normalizeOutputPath(requireOptionValue(args, "--output", parseError));
+      continue;
+    }
+
+    throw parseError(`Unknown argument: ${token}`);
+  }
+
+  if (options.repo === undefined) {
+    throw parseError("audit-merged-pr-gate-evidence requires --repo <owner/name>");
+  }
+
+  try {
+    parseRepoSlug(options.repo);
+  } catch (error) {
+    throw parseError(error instanceof Error ? error.message : String(error));
+  }
+
+  return options;
+}
+
+async function runGhJson(args, { env, ghCommand }) {
+  const result = await runChild(ghCommand, args, env);
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw new Error(`gh command failed: ${detail}`);
+  }
+  return parseJsonText(result.stdout, { label: `gh ${args.slice(0, 2).join(" ")}` });
+}
+
+function flattenPaginatedPayload(payload) {
+  if (!Array.isArray(payload)) {
+    throw new Error("Invalid gh api payload: expected an array");
+  }
+  return payload.every((entry) => Array.isArray(entry)) ? payload.flat() : payload;
+}
+
+function normalizeMergedPulls(payload, limit) {
+  return flattenPaginatedPayload(payload)
+    .filter((pr) => typeof pr?.merged_at === "string" && pr.merged_at.trim().length > 0)
+    .sort((a, b) => String(b.merged_at).localeCompare(String(a.merged_at)))
+    .slice(0, limit)
+    .map((pr) => ({
+      number: Number.isInteger(pr?.number) ? pr.number : null,
+      title: typeof pr?.title === "string" ? pr.title : "",
+      url: typeof pr?.html_url === "string" ? pr.html_url : null,
+      mergedAt: pr.merged_at,
+      headSha: typeof pr?.head?.sha === "string" && pr.head.sha.trim().length > 0 ? pr.head.sha.trim().toLowerCase() : null,
+    }))
+    .filter((pr) => pr.number !== null);
+}
+
+function normalizeGateSummary(summary) {
+  if (!summary) {
+    return null;
+  }
+  return {
+    headSha: summary.headSha,
+    verdict: summary.verdict,
+    commentId: summary.commentId,
+    commentUrl: summary.commentUrl,
+    updatedAt: summary.updatedAt,
+  };
+}
+
+function evaluateMergedPrGateEvidence({ pr, comments }) {
+  const gateSummary = summarizeGateReviewComments(comments);
+  const markerSummary = summarizeGateReviewCommentMarkers(comments, { headSha: pr.headSha });
+  const draftGate = gateSummary.draft_gate;
+  const preApprovalGate = markerSummary.pre_approval_gate;
+  const failures = [];
+
+  if (!(draftGate?.verdict === "clean")) {
+    failures.push("missing visible clean draft_gate comment");
+  }
+
+  if (!(preApprovalGate?.contractComplete === true && preApprovalGate.verdict === "clean" && preApprovalGate.headSha === pr.headSha)) {
+    failures.push("missing visible clean current-head pre_approval_gate comment");
+  }
+
+  return {
+    pr: pr.number,
+    title: pr.title,
+    url: pr.url,
+    mergedAt: pr.mergedAt,
+    headSha: pr.headSha,
+    ok: failures.length === 0,
+    failures,
+    draftGate: normalizeGateSummary(draftGate),
+    preApprovalGate: normalizeGateSummary(preApprovalGate),
+  };
+}
+
+export async function auditMergedPrGateEvidence(options, { env = process.env, ghCommand = "gh" } = {}) {
+  const pullsPayload = await runGhJson([
+    "api",
+    "--paginate",
+    "--slurp",
+    `repos/${options.repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100`,
+  ], { env, ghCommand });
+  const prs = normalizeMergedPulls(pullsPayload, options.limit);
+  const results = [];
+
+  for (const pr of prs) {
+    const comments = flattenPaginatedPayload(await runGhJson([
+      "api",
+      "--paginate",
+      "--slurp",
+      `repos/${options.repo}/issues/${pr.number}/comments?per_page=100`,
+    ], { env, ghCommand }));
+    results.push(evaluateMergedPrGateEvidence({ pr, comments }));
+  }
+
+  const missingEvidence = results.filter((result) => !result.ok);
+  return {
+    ok: true,
+    repo: options.repo,
+    limit: options.limit,
+    auditedCount: results.length,
+    allHaveRequiredGateEvidence: missingEvidence.length === 0,
+    missingEvidence,
+    results,
+  };
+}
+
+async function writeOutputFile(outputPath, data) {
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}
+
+async function main() {
+  let options;
+  try {
+    options = parseAuditMergedPrGateEvidenceCliArgs(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${formatCliError(error, { usage: USAGE })}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (options.help) {
+    process.stdout.write(`${USAGE}\n`);
+    return;
+  }
+
+  try {
+    const result = await auditMergedPrGateEvidence(options);
+    if (options.outputPath) {
+      await writeOutputFile(options.outputPath, result);
+    }
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  } catch (error) {
+    process.stderr.write(`${JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) })}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  await main();
+}

--- a/scripts/github/audit-merged-pr-gate-evidence.mjs
+++ b/scripts/github/audit-merged-pr-gate-evidence.mjs
@@ -18,9 +18,9 @@ const DEFAULT_LIMIT = 20;
 const USAGE = `Usage: audit-merged-pr-gate-evidence.mjs --repo <owner/name> [--limit <n>] [--output <path>]
 
 Audit the most recent merged pull requests for visible dev-loop gate evidence.
-The check fetches a bounded recent closed-PR window and issue comments through
-gh api, then reports PRs that lack a clean draft_gate comment or a clean
-current-head pre_approval_gate comment.
+The check fetches recent merged PRs through \`gh pr list\` and visible issue
+comments through \`gh api\`, then reports PRs that lack a clean draft_gate
+comment or a clean current-head pre_approval_gate comment.
 
 Required:
   --repo <owner/name>   Repository slug (e.g. owner/repo)
@@ -120,18 +120,19 @@ function flattenPaginatedPayload(payload) {
 
 function normalizeMergedPulls(payload, limit) {
   return flattenPaginatedPayload(payload)
-    .filter((pr) => typeof pr?.merged_at === "string" && pr.merged_at.trim().length > 0)
-    .sort((a, b) => String(b.merged_at).localeCompare(String(a.merged_at)))
+    .filter((pr) => typeof pr?.mergedAt === "string" && pr.mergedAt.trim().length > 0)
+    .sort((a, b) => String(b.mergedAt).localeCompare(String(a.mergedAt)))
     .slice(0, limit)
     .map((pr) => ({
       number: Number.isInteger(pr?.number) ? pr.number : null,
       title: typeof pr?.title === "string" ? pr.title : "",
-      url: typeof pr?.html_url === "string" ? pr.html_url : null,
-      mergedAt: pr.merged_at,
-      headSha: typeof pr?.head?.sha === "string" && pr.head.sha.trim().length > 0 ? pr.head.sha.trim().toLowerCase() : null,
+      url: typeof pr?.url === "string" ? pr.url : null,
+      mergedAt: pr.mergedAt,
+      headSha: typeof pr?.headRefOid === "string" && pr.headRefOid.trim().length > 0 ? pr.headRefOid.trim().toLowerCase() : null,
     }))
     .filter((pr) => pr.number !== null);
 }
+
 
 function normalizeGateSummary(summary) {
   if (!summary) {
@@ -175,24 +176,21 @@ function evaluateMergedPrGateEvidence({ pr, comments }) {
 }
 
 async function fetchRecentMergedPulls(options, { env, ghCommand }) {
-  const merged = [];
-  for (let page = 1; merged.length < options.limit; page += 1) {
-    const pagePayload = await runGhJson([
-      "api",
-      `repos/${options.repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100&page=${page}`,
-    ], { env, ghCommand });
-    const pagePulls = flattenPaginatedPayload(pagePayload);
-    merged.push(...normalizeMergedPulls(pagePulls, options.limit));
-
-    if (pagePulls.length < 100) {
-      break;
-    }
-  }
-
-  return merged
-    .sort((a, b) => String(b.mergedAt).localeCompare(String(a.mergedAt)))
-    .slice(0, options.limit);
+  const payload = await runGhJson([
+    "pr",
+    "list",
+    "--repo",
+    options.repo,
+    "--state",
+    "merged",
+    "--limit",
+    String(options.limit),
+    "--json",
+    "number,title,url,mergedAt,headRefOid",
+  ], { env, ghCommand });
+  return normalizeMergedPulls(payload, options.limit);
 }
+
 
 export async function auditMergedPrGateEvidence(options, { env = process.env, ghCommand = "gh" } = {}) {
   const prs = await fetchRecentMergedPulls(options, { env, ghCommand });

--- a/scripts/github/detect-gate-review-evidence.mjs
+++ b/scripts/github/detect-gate-review-evidence.mjs
@@ -25,7 +25,7 @@ Optional:
   --require-before-merge  Exit 1 unless a clean draft_gate comment exists and
                           a clean current-head pre_approval_gate comment exists.
 
-Output (stdout, JSON):
+Output (stdout, JSON; --require-before-merge shape includes preMergeGateCheck):
   {
     "ok": true,
     "repo": "owner/repo",
@@ -69,7 +69,7 @@ Output (stdout, JSON):
     }
   }
 
-When --require-before-merge is omitted, preMergeGateCheck is not emitted.
+When --require-before-merge is omitted, the same evidence summary is emitted without preMergeGateCheck.
 
 Error output (stderr, JSON):
   { "ok": false, "error": "...", "usage": "..." }

--- a/scripts/github/detect-gate-review-evidence.mjs
+++ b/scripts/github/detect-gate-review-evidence.mjs
@@ -213,7 +213,7 @@ function normalizeGateMarkerSummary(summary) {
   };
 }
 
-export function buildPreMergeGateCheck(evidence) {
+function buildPreMergeGateCheck(evidence) {
   const failures = [];
 
   if (!(evidence.draftGate.visible && evidence.draftGate.verdict === "clean")) {

--- a/scripts/github/detect-gate-review-evidence.mjs
+++ b/scripts/github/detect-gate-review-evidence.mjs
@@ -62,8 +62,14 @@ Output (stdout, JSON):
       "commentId": null,
       "commentUrl": null,
       "updatedAt": null
+    },
+    "preMergeGateCheck": {
+      "ok": true,
+      "failures": []
     }
   }
+
+When --require-before-merge is omitted, preMergeGateCheck is not emitted.
 
 Error output (stderr, JSON):
   { "ok": false, "error": "...", "usage": "..." }

--- a/scripts/github/detect-gate-review-evidence.mjs
+++ b/scripts/github/detect-gate-review-evidence.mjs
@@ -236,13 +236,6 @@ export function buildPreMergeGateCheck(evidence) {
   };
 }
 
-export function assertPreMergeGateEvidence(evidence) {
-  const check = buildPreMergeGateCheck(evidence);
-  if (!check.ok) {
-    throw new Error(`Pre-merge gate evidence check failed: ${check.failures.join("; ")}`);
-  }
-  return check;
-}
 
 export async function detectGateReviewEvidence(options, { env = process.env, ghCommand = "gh" } = {}) {
   const prPayload = await runGhJson(["pr", "view", String(options.pr), "--repo", options.repo, "--json", "headRefOid"], { env, ghCommand });

--- a/scripts/github/detect-gate-review-evidence.mjs
+++ b/scripts/github/detect-gate-review-evidence.mjs
@@ -10,14 +10,20 @@ import {
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 
-const USAGE = `Usage: detect-gate-review-evidence.mjs --repo <owner/name> --pr <number>
+const USAGE = `Usage: detect-gate-review-evidence.mjs --repo <owner/name> --pr <number> [--require-before-merge]
 
 Fetch the live PR head SHA and visible PR issue comments, then summarize the
-latest valid draft-gate and pre-approval gate-review comments.
+latest valid draft-gate and pre-approval gate-review comments. With
+--require-before-merge, fail closed unless the PR has visible clean gate
+comments required before \`gh pr merge\`.
 
 Required:
   --repo <owner/name>   Repository slug (e.g. owner/repo)
   --pr <number>         Pull request number
+
+Optional:
+  --require-before-merge  Exit 1 unless a clean draft_gate comment exists and
+                          a clean current-head pre_approval_gate comment exists.
 
 Output (stdout, JSON):
   {
@@ -65,7 +71,7 @@ Error output (stderr, JSON):
 
 Exit codes:
   0  Success
-  1  Argument error, gh failure, or malformed gh JSON`.trim();
+  1  Argument error, gh failure, malformed gh JSON, or missing required pre-merge gate evidence`.trim();
 
 const parseError = buildParseError(USAGE);
 
@@ -76,6 +82,7 @@ export function parseDetectGateReviewEvidenceCliArgs(argv) {
     help: false,
     repo: undefined,
     pr: undefined,
+    requireBeforeMerge: false,
   };
 
   while (args.length > 0) {
@@ -93,6 +100,11 @@ export function parseDetectGateReviewEvidenceCliArgs(argv) {
 
     if (token === "--pr") {
       options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+      continue;
+    }
+
+    if (token === "--require-before-merge") {
+      options.requireBeforeMerge = true;
       continue;
     }
 
@@ -195,6 +207,37 @@ function normalizeGateMarkerSummary(summary) {
   };
 }
 
+export function buildPreMergeGateCheck(evidence) {
+  const failures = [];
+
+  if (!(evidence.draftGate.visible && evidence.draftGate.verdict === "clean")) {
+    failures.push("missing visible clean draft_gate comment");
+  }
+
+  const preApproval = evidence.preApprovalGateMarker;
+  if (!(
+    preApproval.visible
+    && preApproval.contractComplete
+    && preApproval.verdict === "clean"
+    && preApproval.headSha === evidence.currentHeadSha
+  )) {
+    failures.push("missing visible clean current-head pre_approval_gate comment");
+  }
+
+  return {
+    ok: failures.length === 0,
+    failures,
+  };
+}
+
+export function assertPreMergeGateEvidence(evidence) {
+  const check = buildPreMergeGateCheck(evidence);
+  if (!check.ok) {
+    throw new Error(`Pre-merge gate evidence check failed: ${check.failures.join("; ")}`);
+  }
+  return check;
+}
+
 export async function detectGateReviewEvidence(options, { env = process.env, ghCommand = "gh" } = {}) {
   const prPayload = await runGhJson(["pr", "view", String(options.pr), "--repo", options.repo, "--json", "headRefOid"], { env, ghCommand });
   const commentsPayload = normalizeIssueCommentsPayload(await runGhJson(["api", "--paginate", "--slurp", `repos/${options.repo}/issues/${options.pr}/comments?per_page=100`], { env, ghCommand }));
@@ -240,7 +283,25 @@ async function main() {
 
   try {
     const result = await detectGateReviewEvidence(options);
-    process.stdout.write(`${JSON.stringify(result)}\n`);
+    const preMergeGateCheck = buildPreMergeGateCheck(result);
+    const output = options.requireBeforeMerge
+      ? { ...result, preMergeGateCheck }
+      : result;
+
+    if (options.requireBeforeMerge && !preMergeGateCheck.ok) {
+      process.stderr.write(`${JSON.stringify({
+        ok: false,
+        error: `Pre-merge gate evidence check failed: ${preMergeGateCheck.failures.join("; ")}`,
+        repo: result.repo,
+        pr: result.pr,
+        currentHeadSha: result.currentHeadSha,
+        preMergeGateCheck,
+      })}\n`);
+      process.exitCode = 1;
+      return;
+    }
+
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   } catch (error) {
     process.stderr.write(`${JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) })}\n`);
     process.exitCode = 1;

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -385,8 +385,9 @@ Before any merge-ready or final-approval claim, run `detect-pr-gate-coordination
 Do not declare merge-ready unless all of these checks pass in order:
 
 1. `unresolvedThreadCount === 0`, verified via `capture-review-threads.mjs` rather than by prose assertion alone
-2. a visible `pre_approval_gate` comment exists on the PR for the current head SHA with verdict `clean`
-3. CI is green on the current head SHA
+2. a visible `draft_gate` comment exists on the PR with verdict `clean` for the one-time draft→ready boundary
+3. a visible `pre_approval_gate` comment exists on the PR for the current head SHA with verdict `clean`
+4. CI is green on the current head SHA
 
 If any check fails, do not declare merge-ready.
 
@@ -402,12 +403,26 @@ Use this boundary after the merge-ready preconditions pass.
 
 - Before reporting merge-ready or approval-ready, verify the current-head PR state authoritatively.
 - `unresolvedThreadCount === 0` must be verified via `capture-review-threads.mjs` rather than by prose assertion alone.
+- A visible `draft_gate` comment with verdict `clean` must exist for the one-time draft→ready boundary.
 - A visible `pre_approval_gate` comment with verdict `clean` must exist on the current head SHA.
 - CI must be green, or credibly green with an explicit repository-grounded explanation.
 - Stop at the final human approval gate by default.
 - After approval, report `waiting_for_merge_authorization` and stop again unless merge has been explicitly authorized.
 - Do not merge, push, rebase, resolve threads, or change GitHub state without explicit confirmation unless the latest user message already authorizes that exact action.
-- If merge authorization is explicit, complete one last authoritative check on current-head gate evidence, clean thread state, and green CI, then merge with the repository's intended PR strategy.
+- If merge authorization is explicit, complete one last authoritative check on current-head gate evidence, clean thread state, and green CI, then run the mechanical pre-merge gate evidence check below before merging with the repository's intended PR strategy.
+
+### Mechanical pre-merge gate evidence check
+
+Immediately before any `gh pr merge`, run:
+
+```sh
+node <resolved-skill-scripts>/github/detect-gate-review-evidence.mjs \
+  --repo <owner/name> \
+  --pr <number> \
+  --require-before-merge
+```
+
+This helper uses `gh api` to fetch visible PR issue comments and fails closed unless both required gate comments exist: a clean `draft_gate` comment for the one-time draft boundary and a clean current-head `pre_approval_gate` comment. Do not run `gh pr merge` if this command exits non-zero. Resolved threads, green CI, clean Copilot rereview, or local notes do not substitute for this successful helper output. If a final approval or merge boundary sees `gh pr merge` without a same-boundary successful `--require-before-merge` check, treat that as a workflow violation and stop.
 
 ## Validation policy for this repo
 
@@ -470,6 +485,7 @@ Do not:
 - declare merge-ready without a visible `pre_approval_gate` comment on the current head SHA
 - declare merge-ready based solely on `mergeable_state: clean` + CI green without gate evidence
 - do not blind-run `gh pr merge`, `gh pr update-branch`, or an unapproved rebase when the helper says the PR is conflicted
+- run `gh pr merge` without a same-boundary successful `detect-gate-review-evidence.mjs --require-before-merge` check
 - suggest approval, approve and merge, or any approval-ready statement without explicit current-head `pre_approval_gate` gate-review evidence
 - treat CI green + resolved review threads + clean Copilot rereview as sufficient for approval or merge without an explicit current-head `pre_approval_gate` gate-review comment
 - dispatch an async dev-loop task that omits the pre-approval gate requirement

--- a/skills/docs/issue-intake-procedure.md
+++ b/skills/docs/issue-intake-procedure.md
@@ -221,6 +221,7 @@ node <resolved-skill-scripts>/loop/copilot-pr-handoff.mjs --repo <resolved-repo>
 gh pr edit <pr-number> --repo <resolved-repo> --title "..." --body-file <body-file>
 gh pr ready <pr-number> --repo <resolved-repo>
 gh pr review <pr-number> --repo <resolved-repo> --approve --body "..."
+node <resolved-skill-scripts>/github/detect-gate-review-evidence.mjs --repo <resolved-repo> --pr <pr-number> --require-before-merge
 gh pr merge <pr-number> --repo <resolved-repo> --squash --delete-branch
 ```
 

--- a/skills/docs/workflow-handoff-template.md
+++ b/skills/docs/workflow-handoff-template.md
@@ -73,6 +73,7 @@ For each Copilot review pass:
 
 ### 8. Merge
 
+- Immediately before merge, run `node scripts/github/detect-gate-review-evidence.mjs --repo <owner/name> --pr <number> --require-before-merge` and stop if it fails.
 - Required evidence:
   - `draft_gate` clean comment exists (any head — one-time transition boundary, no current-head requirement)
   - `pre_approval_gate` clean comment exists for **current** head SHA
@@ -88,3 +89,4 @@ For each Copilot review pass:
 - `unresolvedThreadCount === 0` verification is required before step 7
 - Gate comments must be visible on the PR — no hidden/local-only evidence
 - Never merge without explicit authorization
+- Never run `gh pr merge` without a same-boundary successful `--require-before-merge` gate evidence check

--- a/test/contracts/copilot-review-doc-contracts.test.mjs
+++ b/test/contracts/copilot-review-doc-contracts.test.mjs
@@ -200,18 +200,38 @@ test("copilot-pr-followup skill hardens reply-resolve, gate sequencing, and merg
   );
   assert.match(
     step7,
-    /2\.\s+a visible `pre_approval_gate` comment exists on the PR for the current head SHA with verdict `clean`/i,
+    /2\.\s+a visible `draft_gate` comment exists on the PR with verdict `clean`/i,
+    "merge-ready preconditions should require draft gate evidence",
+  );
+  assert.match(
+    step7,
+    /3\.\s+a visible `pre_approval_gate` comment exists on the PR for the current head SHA with verdict `clean`/i,
     "merge-ready preconditions should require current-head clean gate evidence",
   );
   assert.match(
     step7,
-    /3\.\s+CI is green on the current head SHA/i,
+    /4\.\s+CI is green on the current head SHA/i,
     "merge-ready preconditions should require current-head green CI",
   );
   assert.match(
     step7,
     /If any check fails, do not declare merge-ready\./i,
     "merge-ready preconditions should be a hard gate",
+  );
+  assert.match(
+    step7,
+    /### Mechanical pre-merge gate evidence check/i,
+    "Step 7 should include a mechanical pre-merge evidence check",
+  );
+  assert.match(
+    step7,
+    /detect-gate-review-evidence\.mjs[\s\S]*--require-before-merge/i,
+    "mechanical pre-merge check should use the gate evidence helper",
+  );
+  assert.match(
+    step7,
+    /Do not run `gh pr merge` if this command exits non-zero/i,
+    "mechanical pre-merge check should block merge on missing evidence",
   );
   assert.match(
     step7,
@@ -270,6 +290,7 @@ test("copilot-pr-followup skill hardens reply-resolve, gate sequencing, and merg
   assert.match(antiPatterns, /declare merge-ready without a visible `pre_approval_gate` comment on the current head SHA/i);
   assert.match(antiPatterns, /declare merge-ready based solely on `mergeable_state: clean` \+ CI green without gate evidence/i);
   assert.match(antiPatterns, /do not blind-run `gh pr merge`, `gh pr update-branch`, or an unapproved rebase when the helper says the PR is conflicted/i);
+  assert.match(antiPatterns, /run `gh pr merge` without a same-boundary successful `detect-gate-review-evidence\.mjs --require-before-merge` check/i);
   assert.match(antiPatterns, /dispatch an async dev-loop task that omits the pre-approval gate requirement/i);
 });
 

--- a/test/contracts/issue-intake-doc-contracts.test.mjs
+++ b/test/contracts/issue-intake-doc-contracts.test.mjs
@@ -220,6 +220,7 @@ test("issue-intake flow carries the resolved repo slug through later GitHub issu
   assert.match(skillContent, /gh pr edit <pr-number> --repo <resolved-repo> --title/);
   assert.match(skillContent, /gh pr ready <pr-number> --repo <resolved-repo>/);
   assert.match(skillContent, /gh pr review <pr-number> --repo <resolved-repo> --approve/);
+  assert.match(skillContent, /detect-gate-review-evidence\.mjs --repo <resolved-repo> --pr <pr-number> --require-before-merge/);
   assert.match(skillContent, /gh pr merge <pr-number> --repo <resolved-repo> --squash --delete-branch/);
 });
 

--- a/test/github/audit-merged-pr-gate-evidence.test.mjs
+++ b/test/github/audit-merged-pr-gate-evidence.test.mjs
@@ -72,29 +72,27 @@ test("audit-merged-pr-gate-evidence reports missing gate evidence among recent m
       {
         assertArgs: ["api", "repos/owner/repo/pulls?state=closed&sort=updated&direction=desc&per_page=100&page=1"],
         stdout: `${JSON.stringify([
-          [
-            {
-              number: 10,
-              title: "Clean PR",
-              html_url: "https://github.com/owner/repo/pull/10",
-              merged_at: "2026-06-03T12:00:00Z",
-              head: { sha: "abc1234" },
-            },
-            {
-              number: 9,
-              title: "Missing gates",
-              html_url: "https://github.com/owner/repo/pull/9",
-              merged_at: "2026-06-03T11:00:00Z",
-              head: { sha: "def5678" },
-            },
-            {
-              number: 8,
-              title: "Closed unmerged",
-              html_url: "https://github.com/owner/repo/pull/8",
-              merged_at: null,
-              head: { sha: "9999999" },
-            },
-          ],
+          {
+            number: 10,
+            title: "Clean PR",
+            html_url: "https://github.com/owner/repo/pull/10",
+            merged_at: "2026-06-03T12:00:00Z",
+            head: { sha: "abc1234" },
+          },
+          {
+            number: 9,
+            title: "Missing gates",
+            html_url: "https://github.com/owner/repo/pull/9",
+            merged_at: "2026-06-03T11:00:00Z",
+            head: { sha: "def5678" },
+          },
+          {
+            number: 8,
+            title: "Closed unmerged",
+            html_url: "https://github.com/owner/repo/pull/8",
+            merged_at: null,
+            head: { sha: "9999999" },
+          },
         ])}\n`,
       },
       {

--- a/test/github/audit-merged-pr-gate-evidence.test.mjs
+++ b/test/github/audit-merged-pr-gate-evidence.test.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
+
+import {
+  parseAuditMergedPrGateEvidenceCliArgs,
+} from "../../scripts/github/audit-merged-pr-gate-evidence.mjs";
+
+const scriptPath = path.resolve("scripts/github/audit-merged-pr-gate-evidence.mjs");
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
+
+async function writeGhStub(tempDir, entries) {
+  const { env } = await writeGhStubHelper(tempDir, entries);
+  return env;
+}
+
+function gateComment({ gate, sha, verdict = "clean", id }) {
+  return {
+    id,
+    body: [
+      `Gate review: ${gate}`,
+      `Reviewed head SHA: ${sha}`,
+      `Verdict: ${verdict}`,
+      "Findings summary: no issues found",
+      gate === "draft_gate" ? "Next action: mark ready for review" : "Next action: await final human approval",
+    ].join("\n"),
+    updated_at: "2026-06-03T10:00:00Z",
+    html_url: `https://github.com/owner/repo/pull/1#issuecomment-${id}`,
+  };
+}
+
+test("parseAuditMergedPrGateEvidenceCliArgs parses defaults", () => {
+  const options = parseAuditMergedPrGateEvidenceCliArgs(["--repo", "owner/repo"]);
+
+  assert.equal(options.repo, "owner/repo");
+  assert.equal(options.limit, 20);
+  assert.equal(options.outputPath, undefined);
+});
+
+test("parseAuditMergedPrGateEvidenceCliArgs rejects malformed arguments", () => {
+  assert.throws(
+    () => parseAuditMergedPrGateEvidenceCliArgs([]),
+    /requires --repo <owner\/name>/i,
+  );
+  assert.throws(
+    () => parseAuditMergedPrGateEvidenceCliArgs(["--repo", "owner/repo", "--limit", "0"]),
+    /positive integer/i,
+  );
+  assert.throws(
+    () => parseAuditMergedPrGateEvidenceCliArgs(["--repo", "bad slug"]),
+    /owner\/name/i,
+  );
+  assert.throws(
+    () => parseAuditMergedPrGateEvidenceCliArgs(["--repo", "owner/repo", "--output", "   "]),
+    /non-empty path/i,
+  );
+});
+
+test("audit-merged-pr-gate-evidence reports missing gate evidence among recent merged PRs", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-audit-merged-gates-"));
+  const outputPath = path.join(tempDir, "audit.json");
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/pulls?state=closed&sort=updated&direction=desc&per_page=100"],
+        stdout: `${JSON.stringify([
+          [
+            {
+              number: 10,
+              title: "Clean PR",
+              html_url: "https://github.com/owner/repo/pull/10",
+              merged_at: "2026-06-03T12:00:00Z",
+              head: { sha: "abc1234" },
+            },
+            {
+              number: 9,
+              title: "Missing gates",
+              html_url: "https://github.com/owner/repo/pull/9",
+              merged_at: "2026-06-03T11:00:00Z",
+              head: { sha: "def5678" },
+            },
+            {
+              number: 8,
+              title: "Closed unmerged",
+              html_url: "https://github.com/owner/repo/pull/8",
+              merged_at: null,
+              head: { sha: "9999999" },
+            },
+          ],
+        ])}\n`,
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/10/comments?per_page=100"],
+        stdout: `${JSON.stringify([
+          gateComment({ gate: "draft_gate", sha: "bcd1111", id: 100 }),
+          gateComment({ gate: "pre_approval_gate", sha: "abc1234", id: 101 }),
+        ])}\n`,
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/9/comments?per_page=100"],
+        stdout: "[]\n",
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--limit", "2", "--output", outputPath], { env });
+
+    assert.equal(result.code, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.auditedCount, 2);
+    assert.equal(payload.allHaveRequiredGateEvidence, false);
+    assert.equal(payload.missingEvidence.length, 1);
+    assert.equal(payload.missingEvidence[0].pr, 9);
+    assert.deepEqual(payload.missingEvidence[0].failures, [
+      "missing visible clean draft_gate comment",
+      "missing visible clean current-head pre_approval_gate comment",
+    ]);
+    assert.deepEqual(JSON.parse(await readFile(outputPath, "utf8")), payload);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("audit-merged-pr-gate-evidence reports gh failures deterministically", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-audit-merged-gates-fail-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls?state=closed&sort=updated&direction=desc&per_page=100"],
+        stderr: "boom\n",
+        exitCode: 1,
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo"], { env });
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    assert.match(JSON.parse(result.stderr).error, /gh command failed: boom/i);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/github/audit-merged-pr-gate-evidence.test.mjs
+++ b/test/github/audit-merged-pr-gate-evidence.test.mjs
@@ -66,7 +66,7 @@ test("audit-merged-pr-gate-evidence reports missing gate evidence among recent m
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/pulls?state=closed&sort=updated&direction=desc&per_page=100"],
+        assertArgs: ["api", "repos/owner/repo/pulls?state=closed&sort=updated&direction=desc&per_page=100&page=1"],
         stdout: `${JSON.stringify([
           [
             {
@@ -130,7 +130,7 @@ test("audit-merged-pr-gate-evidence reports gh failures deterministically", asyn
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["api", "repos/owner/repo/pulls?state=closed&sort=updated&direction=desc&per_page=100"],
+        assertArgs: ["api", "repos/owner/repo/pulls?state=closed&sort=updated&direction=desc&per_page=100&page=1"],
         stderr: "boom\n",
         exitCode: 1,
       },

--- a/test/github/audit-merged-pr-gate-evidence.test.mjs
+++ b/test/github/audit-merged-pr-gate-evidence.test.mjs
@@ -49,6 +49,10 @@ test("parseAuditMergedPrGateEvidenceCliArgs rejects malformed arguments", () => 
     () => parseAuditMergedPrGateEvidenceCliArgs(["--repo", "owner/repo", "--limit", "0"]),
     /positive integer/i,
   );
+  assert.equal(
+    parseAuditMergedPrGateEvidenceCliArgs(["--repo", "owner/repo", "--limit", "02"]).limit,
+    2,
+  );
   assert.throws(
     () => parseAuditMergedPrGateEvidenceCliArgs(["--repo", "bad slug"]),
     /owner\/name/i,
@@ -123,6 +127,57 @@ test("audit-merged-pr-gate-evidence reports missing gate evidence among recent m
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+
+test("audit-merged-pr-gate-evidence keeps paging until the requested merged PR limit is satisfied", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-audit-merged-gates-paging-"));
+
+  try {
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({
+      number: 200 - index,
+      title: `Closed unmerged ${index}`,
+      html_url: `https://github.com/owner/repo/pull/${200 - index}`,
+      merged_at: null,
+      head: { sha: "aaa1111" },
+    }));
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls?state=closed&sort=updated&direction=desc&per_page=100&page=1"],
+        stdout: `${JSON.stringify(firstPage)}\n`,
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls?state=closed&sort=updated&direction=desc&per_page=100&page=2"],
+        stdout: `${JSON.stringify([
+          {
+            number: 99,
+            title: "Later merged",
+            html_url: "https://github.com/owner/repo/pull/99",
+            merged_at: "2026-06-03T09:00:00Z",
+            head: { sha: "abc1234" },
+          },
+        ])}\n`,
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/99/comments?per_page=100"],
+        stdout: `${JSON.stringify([
+          gateComment({ gate: "draft_gate", sha: "bcd1111", id: 990 }),
+          gateComment({ gate: "pre_approval_gate", sha: "abc1234", id: 991 }),
+        ])}\n`,
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--limit", "1"], { env });
+
+    assert.equal(result.code, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.auditedCount, 1);
+    assert.equal(payload.results[0].pr, 99);
+    assert.equal(payload.allHaveRequiredGateEvidence, true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 
 test("audit-merged-pr-gate-evidence reports gh failures deterministically", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-audit-merged-gates-fail-"));

--- a/test/github/audit-merged-pr-gate-evidence.test.mjs
+++ b/test/github/audit-merged-pr-gate-evidence.test.mjs
@@ -70,28 +70,21 @@ test("audit-merged-pr-gate-evidence reports missing gate evidence among recent m
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["api", "repos/owner/repo/pulls?state=closed&sort=updated&direction=desc&per_page=100&page=1"],
+        assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "merged", "--limit", "2", "--json", "number,title,url,mergedAt,headRefOid"],
         stdout: `${JSON.stringify([
           {
             number: 10,
             title: "Clean PR",
-            html_url: "https://github.com/owner/repo/pull/10",
-            merged_at: "2026-06-03T12:00:00Z",
-            head: { sha: "abc1234" },
+            url: "https://github.com/owner/repo/pull/10",
+            mergedAt: "2026-06-03T12:00:00Z",
+            headRefOid: "abc1234",
           },
           {
             number: 9,
             title: "Missing gates",
-            html_url: "https://github.com/owner/repo/pull/9",
-            merged_at: "2026-06-03T11:00:00Z",
-            head: { sha: "def5678" },
-          },
-          {
-            number: 8,
-            title: "Closed unmerged",
-            html_url: "https://github.com/owner/repo/pull/8",
-            merged_at: null,
-            head: { sha: "9999999" },
+            url: "https://github.com/owner/repo/pull/9",
+            mergedAt: "2026-06-03T11:00:00Z",
+            headRefOid: "def5678",
           },
         ])}\n`,
       },
@@ -127,63 +120,13 @@ test("audit-merged-pr-gate-evidence reports missing gate evidence among recent m
 });
 
 
-test("audit-merged-pr-gate-evidence keeps paging until the requested merged PR limit is satisfied", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-audit-merged-gates-paging-"));
-
-  try {
-    const firstPage = Array.from({ length: 100 }, (_, index) => ({
-      number: 200 - index,
-      title: `Closed unmerged ${index}`,
-      html_url: `https://github.com/owner/repo/pull/${200 - index}`,
-      merged_at: null,
-      head: { sha: "aaa1111" },
-    }));
-    const env = await writeGhStub(tempDir, [
-      {
-        assertArgs: ["api", "repos/owner/repo/pulls?state=closed&sort=updated&direction=desc&per_page=100&page=1"],
-        stdout: `${JSON.stringify(firstPage)}\n`,
-      },
-      {
-        assertArgs: ["api", "repos/owner/repo/pulls?state=closed&sort=updated&direction=desc&per_page=100&page=2"],
-        stdout: `${JSON.stringify([
-          {
-            number: 99,
-            title: "Later merged",
-            html_url: "https://github.com/owner/repo/pull/99",
-            merged_at: "2026-06-03T09:00:00Z",
-            head: { sha: "abc1234" },
-          },
-        ])}\n`,
-      },
-      {
-        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/99/comments?per_page=100"],
-        stdout: `${JSON.stringify([
-          gateComment({ gate: "draft_gate", sha: "bcd1111", id: 990 }),
-          gateComment({ gate: "pre_approval_gate", sha: "abc1234", id: 991 }),
-        ])}\n`,
-      },
-    ]);
-
-    const result = await runNode(["--repo", "owner/repo", "--limit", "1"], { env });
-
-    assert.equal(result.code, 0, result.stderr);
-    const payload = JSON.parse(result.stdout);
-    assert.equal(payload.auditedCount, 1);
-    assert.equal(payload.results[0].pr, 99);
-    assert.equal(payload.allHaveRequiredGateEvidence, true);
-  } finally {
-    await rm(tempDir, { recursive: true, force: true });
-  }
-});
-
-
 test("audit-merged-pr-gate-evidence reports gh failures deterministically", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-audit-merged-gates-fail-"));
 
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["api", "repos/owner/repo/pulls?state=closed&sort=updated&direction=desc&per_page=100&page=1"],
+        assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "merged", "--limit", "20", "--json", "number,title,url,mergedAt,headRefOid"],
         stderr: "boom\n",
         exitCode: 1,
       },

--- a/test/github/detect-gate-review-evidence.test.mjs
+++ b/test/github/detect-gate-review-evidence.test.mjs
@@ -182,6 +182,10 @@ test("parseDetectGateReviewEvidenceCliArgs rejects malformed arguments determini
     () => parseDetectGateReviewEvidenceCliArgs(["--repo", "bad slug", "--pr", "17"]),
     /match <owner\/name>/i,
   );
+  assert.equal(
+    parseDetectGateReviewEvidenceCliArgs(["--repo", "owner/repo", "--pr", "17", "--require-before-merge"]).requireBeforeMerge,
+    true,
+  );
 });
 
 test("detect-gate-review-evidence summarizes the newest valid live gate comments", async () => {
@@ -200,7 +204,7 @@ test("detect-gate-review-evidence summarizes the newest valid live gate comments
             id: 41,
             body: [
               "Gate review: draft_gate",
-              "Reviewed head SHA: old5678",
+              "Reviewed head SHA: bcd5678",
               "Verdict: findings_present",
               "Findings summary: missing tests",
               "Next action: stay draft and fix",
@@ -390,6 +394,90 @@ test("detect-gate-review-evidence exposes same-head markers even when latest gat
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+
+test("detect-gate-review-evidence --require-before-merge fails before merge when gate comments are missing", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-gate-review-premerge-missing-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
+        stdout: '{"headRefOid":"abc1234"}\n',
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/17/comments?per_page=100"],
+        stdout: "[]\n",
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--require-before-merge"], { env });
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /Pre-merge gate evidence check failed/i);
+    assert.deepEqual(payload.preMergeGateCheck.failures, [
+      "missing visible clean draft_gate comment",
+      "missing visible clean current-head pre_approval_gate comment",
+    ]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-gate-review-evidence --require-before-merge passes only with draft and current-head pre-approval gate comments", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-gate-review-premerge-clean-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
+        stdout: '{"headRefOid":"abc1234"}\n',
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/17/comments?per_page=100"],
+        stdout: `${JSON.stringify([
+          {
+            id: 70,
+            body: [
+              "Gate review: draft_gate",
+              "Reviewed head SHA: bcd5678",
+              "Verdict: clean",
+              "Findings summary: no issues found",
+              "Next action: mark ready for review",
+            ].join("\n"),
+            updated_at: "2026-05-29T21:00:00Z",
+            html_url: "https://github.com/owner/repo/pull/17#issuecomment-70",
+          },
+          {
+            id: 71,
+            body: [
+              "Gate review: pre_approval_gate",
+              "Reviewed head SHA: abc1234",
+              "Verdict: clean",
+              "Findings summary: no issues found",
+              "Next action: await final human approval",
+            ].join("\n"),
+            updated_at: "2026-05-29T22:00:00Z",
+            html_url: "https://github.com/owner/repo/pull/17#issuecomment-71",
+          },
+        ])}\n`,
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--require-before-merge"], { env });
+
+    assert.equal(result.code, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.preMergeGateCheck.ok, true);
+    assert.deepEqual(payload.preMergeGateCheck.failures, []);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 
 test("detect-gate-review-evidence reports gh failures deterministically", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-gate-review-evidence-fail-"));


### PR DESCRIPTION
## Summary

Fixes #424 by adding a deterministic pre-merge gate evidence check and tightening the dev-loop procedure so merge cannot be treated as allowed after threads resolve alone.

## Scope / context

- Extends `detect-gate-review-evidence.mjs` with `--require-before-merge`.
- Adds `audit-merged-pr-gate-evidence.mjs` for the required recent-merged-PR regression audit.
- Updates Copilot PR follow-up / handoff / issue-intake docs to require the pre-merge helper immediately before `gh pr merge`.
- Adds regression tests for missing gate comments and the merged-PR audit.

## Acceptance criteria

- [x] Root cause documented: loop merged after threads resolved without visible gate comments.
- [x] Skill procedure has unambiguous gate posting and pre-merge verification requirements.
- [x] Mechanical enforcement blocks merge flow when gate evidence is missing.
- [x] Recent 20 merged PRs audited for gate evidence.
- [x] `npm run verify` passes locally.

## Definition of done

- Pre-merge helper fails closed unless a clean `draft_gate` comment exists and a clean current-head `pre_approval_gate` comment exists.
- Procedure tells agents to run the helper before any `gh pr merge` and stop on non-zero exit.
- Regression coverage proves missing gate comments fail the pre-merge check.
- Audit helper can check the latest merged PRs via `gh api`.
- CI passes and PR completes draft gate, Copilot review loop, pre-approval gate, and merge.

## Non-goals

- No broad redesign of the Copilot loop state machine.
- No compatibility path for merging PRs that lack required gate evidence.
- No changes to GitHub branch protection settings.
