### PR TITLE
feat: make pre_approval_gate evidence enforcement always-on (#436, #437)

### DIFF
--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -212,6 +212,7 @@ function buildResult({
     mergeStateStatus,
     conflictFiles,
     draftGateAlreadySatisfied,
+    gateEvidenceRequiredForMerge: true,
     ...(gateEvidenceNote ? { gateEvidenceNote } : {}),
   };
 }

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -648,3 +648,17 @@ test("normalizeSnapshot rejects invalid lastCopilotRoundMaxSignal values", () =>
   assert.equal(normalizeSnapshot({ prExists: true, prNumber: 17, lastCopilotRoundMaxSignal: "" }).lastCopilotRoundMaxSignal, null);
   assert.equal(normalizeSnapshot({ prExists: true, prNumber: 17 }).lastCopilotRoundMaxSignal, null);
 });
+
+test("gateEvidenceRequiredForMerge is always true in coordination output", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 10,
+    currentHeadSha: "abc1234",
+    prDraft: true,
+    lifecycleState: STATE.PR_DRAFT,
+    loopDisposition: LOOP_DISPOSITION.ACTION_REQUIRED,
+    draftGate: gate({ visible: false }),
+    draftGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.gateEvidenceRequiredForMerge, true);
+});

--- a/scripts/github/detect-gate-review-evidence.mjs
+++ b/scripts/github/detect-gate-review-evidence.mjs
@@ -83,7 +83,7 @@ Error output (stderr, JSON):
 
 Exit codes:
   0  Success (gate evidence is valid)
-  1  Argument error, gh failure, malformed gh JSON, or missing required pre-merge gate evidence`.trim();
+  1  Argument error, gh failure, malformed gh JSON, or missing required pre-merge gate evidence.`.trim();
 
 const parseError = buildParseError(USAGE);
 

--- a/scripts/github/detect-gate-review-evidence.mjs
+++ b/scripts/github/detect-gate-review-evidence.mjs
@@ -66,8 +66,6 @@ Output (stdout, JSON; always includes preMergeGateCheck):
     }
   }
 
-When --require-before-merge is omitted, the same evidence summary is emitted without preMergeGateCheck.
-
 Error output (stderr, JSON):
   { "ok": false, "error": "...", "usage": "..." }
   { "ok": false, "error": "..." }

--- a/scripts/github/detect-gate-review-evidence.mjs
+++ b/scripts/github/detect-gate-review-evidence.mjs
@@ -10,22 +10,19 @@ import {
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 
-const USAGE = `Usage: detect-gate-review-evidence.mjs --repo <owner/name> --pr <number> [--require-before-merge]
+const USAGE = `Usage: detect-gate-review-evidence.mjs --repo <owner/name> --pr <number>
 
 Fetch the live PR head SHA and visible PR issue comments, then summarize the
-latest valid draft-gate and pre-approval gate-review comments. With
---require-before-merge, fail closed unless the PR has visible clean gate
-comments required before \`gh pr merge\`.
+latest valid draft-gate and pre-approval gate-review comments. Always fail
+closed (exit 1) unless both required gate comments exist: a clean draft_gate
+comment for the one-time draft boundary and a clean current-head
+pre_approval_gate comment.
 
 Required:
   --repo <owner/name>   Repository slug (e.g. owner/repo)
   --pr <number>         Pull request number
 
-Optional:
-  --require-before-merge  Exit 1 unless a clean draft_gate comment exists and
-                          a clean current-head pre_approval_gate comment exists.
-
-Output (stdout, JSON; --require-before-merge shape includes preMergeGateCheck):
+Output (stdout, JSON; always includes preMergeGateCheck):
   {
     "ok": true,
     "repo": "owner/repo",
@@ -76,7 +73,7 @@ Error output (stderr, JSON):
   { "ok": false, "error": "..." }
 
 Exit codes:
-  0  Success
+  0  Success (gate evidence is valid)
   1  Argument error, gh failure, malformed gh JSON, or missing required pre-merge gate evidence`.trim();
 
 const parseError = buildParseError(USAGE);
@@ -88,7 +85,6 @@ export function parseDetectGateReviewEvidenceCliArgs(argv) {
     help: false,
     repo: undefined,
     pr: undefined,
-    requireBeforeMerge: false,
   };
 
   while (args.length > 0) {
@@ -110,8 +106,7 @@ export function parseDetectGateReviewEvidenceCliArgs(argv) {
     }
 
     if (token === "--require-before-merge") {
-      options.requireBeforeMerge = true;
-      continue;
+      throw parseError(`--require-before-merge has been removed: gate evidence enforcement is now always-on by default. Omit the flag.`);
     }
 
     throw parseError(`Unknown argument: ${token}`);
@@ -283,11 +278,9 @@ async function main() {
   try {
     const result = await detectGateReviewEvidence(options);
     const preMergeGateCheck = buildPreMergeGateCheck(result);
-    const output = options.requireBeforeMerge
-      ? { ...result, preMergeGateCheck }
-      : result;
+    const output = { ...result, preMergeGateCheck };
 
-    if (options.requireBeforeMerge && !preMergeGateCheck.ok) {
+    if (!preMergeGateCheck.ok) {
       process.stderr.write(`${JSON.stringify({
         ok: false,
         error: `Pre-merge gate evidence check failed: ${preMergeGateCheck.failures.join("; ")}`,

--- a/scripts/github/detect-gate-review-evidence.mjs
+++ b/scripts/github/detect-gate-review-evidence.mjs
@@ -51,14 +51,25 @@ Output (stdout, JSON; always includes preMergeGateCheck):
     },
     "draftGateSatisfied": true,
     "preApprovalGate": {
-      "visible": false,
-      "headSha": null,
-      "verdict": null,
-      "findingsSummary": null,
-      "nextAction": null,
-      "commentId": null,
-      "commentUrl": null,
-      "updatedAt": null
+      "visible": true,
+      "headSha": "abc1234",
+      "verdict": "clean",
+      "findingsSummary": "no issues found",
+      "nextAction": "await final human approval",
+      "commentId": 102,
+      "commentUrl": "https://github.com/owner/repo/pull/17#issuecomment-102",
+      "updatedAt": "2026-05-29T22:00:00Z"
+    },
+    "preApprovalGateMarker": {
+      "visible": true,
+      "headSha": "abc1234",
+      "verdict": "clean",
+      "findingsSummary": "no issues found",
+      "nextAction": "await final human approval",
+      "contractComplete": true,
+      "commentId": 102,
+      "commentUrl": "https://github.com/owner/repo/pull/17#issuecomment-102",
+      "updatedAt": "2026-05-29T22:00:00Z"
     },
     "preMergeGateCheck": {
       "ok": true,

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -435,11 +435,10 @@ Immediately before any `gh pr merge`, run:
 ```sh
 node <resolved-skill-scripts>/github/detect-gate-review-evidence.mjs \
   --repo <owner/name> \
-  --pr <number> \
-  --require-before-merge
+  --pr <number>
 ```
 
-This helper uses `gh api` to fetch visible PR issue comments and fails closed unless both required gate comments exist: a clean `draft_gate` comment for the one-time draft boundary and a clean current-head `pre_approval_gate` comment. Do not run `gh pr merge` if this command exits non-zero. Resolved threads, green CI, clean Copilot rereview, or local notes do not substitute for this successful helper output. If a final approval or merge boundary sees `gh pr merge` without a same-boundary successful `--require-before-merge` check, treat that as a workflow violation and stop.
+This helper is always-on: it uses `gh api` to fetch visible PR issue comments and fails closed unless both required gate comments exist: a clean `draft_gate` comment for the one-time draft boundary and a clean current-head `pre_approval_gate` comment. Do not run `gh pr merge` if this command exits non-zero. There is no opt-out flag. Resolved threads, green CI, clean Copilot rereview, or local notes do not substitute for this successful helper output. If a final approval or merge boundary sees `gh pr merge` without a same-boundary successful check, treat that as a workflow violation and stop.
 
 ## Validation policy for this repo
 
@@ -502,7 +501,7 @@ Do not:
 - declare merge-ready without a visible `pre_approval_gate` comment on the current head SHA
 - declare merge-ready based solely on `mergeable_state: clean` + CI green without gate evidence
 - do not blind-run `gh pr merge`, `gh pr update-branch`, or an unapproved rebase when the helper says the PR is conflicted
-- run `gh pr merge` without a same-boundary successful `detect-gate-review-evidence.mjs --require-before-merge` check
+- run `gh pr merge` without a same-boundary successful `detect-gate-review-evidence.mjs` check (always-on, no opt-out flag)
 - suggest approval, approve and merge, or any approval-ready statement without explicit current-head `pre_approval_gate` gate-review evidence
 - treat CI green + resolved review threads + clean Copilot rereview as sufficient for approval or merge without an explicit current-head `pre_approval_gate` gate-review comment
 - dispatch an async dev-loop task that omits the pre-approval gate requirement

--- a/skills/docs/issue-intake-procedure.md
+++ b/skills/docs/issue-intake-procedure.md
@@ -221,7 +221,7 @@ node <resolved-skill-scripts>/loop/copilot-pr-handoff.mjs --repo <resolved-repo>
 gh pr edit <pr-number> --repo <resolved-repo> --title "..." --body-file <body-file>
 gh pr ready <pr-number> --repo <resolved-repo>
 gh pr review <pr-number> --repo <resolved-repo> --approve --body "..."
-node <resolved-skill-scripts>/github/detect-gate-review-evidence.mjs --repo <resolved-repo> --pr <pr-number> --require-before-merge
+node <resolved-skill-scripts>/github/detect-gate-review-evidence.mjs --repo <resolved-repo> --pr <pr-number>
 gh pr merge <pr-number> --repo <resolved-repo> --squash --delete-branch
 ```
 

--- a/skills/docs/workflow-handoff-template.md
+++ b/skills/docs/workflow-handoff-template.md
@@ -73,7 +73,7 @@ For each Copilot review pass:
 
 ### 8. Merge
 
-- Immediately before merge, run `node scripts/github/detect-gate-review-evidence.mjs --repo <owner/name> --pr <number> --require-before-merge` and stop if it fails.
+- Immediately before merge, run `node scripts/github/detect-gate-review-evidence.mjs --repo <owner/name> --pr <number>` and stop if it fails. Gate evidence enforcement is always-on; there is no opt-out flag.
 - Required evidence:
   - `draft_gate` clean comment exists (any head — one-time transition boundary, no current-head requirement)
   - `pre_approval_gate` clean comment exists for **current** head SHA
@@ -89,4 +89,4 @@ For each Copilot review pass:
 - `unresolvedThreadCount === 0` verification is required before step 7
 - Gate comments must be visible on the PR — no hidden/local-only evidence
 - Never merge without explicit authorization
-- Never run `gh pr merge` without a same-boundary successful `--require-before-merge` gate evidence check
+- Never run `gh pr merge` without a same-boundary successful gate evidence check (always-on, no opt-out)

--- a/test/contracts/copilot-review-doc-contracts.test.mjs
+++ b/test/contracts/copilot-review-doc-contracts.test.mjs
@@ -228,6 +228,11 @@ test("copilot-pr-followup skill hardens reply-resolve, gate sequencing, and merg
     /detect-gate-review-evidence\.mjs[\s\S]*always-on/i,
     "mechanical pre-merge check should use the gate evidence helper with always-on enforcement",
   );
+  assert.doesNotMatch(
+    step7,
+    /--require-before-merge/,
+    "the removed opt-in flag must not appear in the skill text",
+  );
   assert.match(
     step7,
     /Do not run `gh pr merge` if this command exits non-zero/i,

--- a/test/contracts/copilot-review-doc-contracts.test.mjs
+++ b/test/contracts/copilot-review-doc-contracts.test.mjs
@@ -225,8 +225,8 @@ test("copilot-pr-followup skill hardens reply-resolve, gate sequencing, and merg
   );
   assert.match(
     step7,
-    /detect-gate-review-evidence\.mjs[\s\S]*--require-before-merge/i,
-    "mechanical pre-merge check should use the gate evidence helper",
+    /detect-gate-review-evidence\.mjs[\s\S]*always-on/i,
+    "mechanical pre-merge check should use the gate evidence helper with always-on enforcement",
   );
   assert.match(
     step7,
@@ -290,7 +290,7 @@ test("copilot-pr-followup skill hardens reply-resolve, gate sequencing, and merg
   assert.match(antiPatterns, /declare merge-ready without a visible `pre_approval_gate` comment on the current head SHA/i);
   assert.match(antiPatterns, /declare merge-ready based solely on `mergeable_state: clean` \+ CI green without gate evidence/i);
   assert.match(antiPatterns, /do not blind-run `gh pr merge`, `gh pr update-branch`, or an unapproved rebase when the helper says the PR is conflicted/i);
-  assert.match(antiPatterns, /run `gh pr merge` without a same-boundary successful `detect-gate-review-evidence\.mjs --require-before-merge` check/i);
+  assert.match(antiPatterns, /run `gh pr merge` without a same-boundary successful `detect-gate-review-evidence\.mjs` check \(always-on, no opt-out flag\)/i);
   assert.match(antiPatterns, /dispatch an async dev-loop task that omits the pre-approval gate requirement/i);
 });
 

--- a/test/contracts/issue-intake-doc-contracts.test.mjs
+++ b/test/contracts/issue-intake-doc-contracts.test.mjs
@@ -221,6 +221,7 @@ test("issue-intake flow carries the resolved repo slug through later GitHub issu
   assert.match(skillContent, /gh pr ready <pr-number> --repo <resolved-repo>/);
   assert.match(skillContent, /gh pr review <pr-number> --repo <resolved-repo> --approve/);
   assert.match(skillContent, /detect-gate-review-evidence\.mjs --repo <resolved-repo> --pr <pr-number>/);
+  assert.doesNotMatch(skillContent, /--require-before-merge/, "the removed opt-in flag must not appear in the docs");
   assert.match(skillContent, /gh pr merge <pr-number> --repo <resolved-repo> --squash --delete-branch/);
 });
 

--- a/test/contracts/issue-intake-doc-contracts.test.mjs
+++ b/test/contracts/issue-intake-doc-contracts.test.mjs
@@ -220,7 +220,7 @@ test("issue-intake flow carries the resolved repo slug through later GitHub issu
   assert.match(skillContent, /gh pr edit <pr-number> --repo <resolved-repo> --title/);
   assert.match(skillContent, /gh pr ready <pr-number> --repo <resolved-repo>/);
   assert.match(skillContent, /gh pr review <pr-number> --repo <resolved-repo> --approve/);
-  assert.match(skillContent, /detect-gate-review-evidence\.mjs --repo <resolved-repo> --pr <pr-number> --require-before-merge/);
+  assert.match(skillContent, /detect-gate-review-evidence\.mjs --repo <resolved-repo> --pr <pr-number>/);
   assert.match(skillContent, /gh pr merge <pr-number> --repo <resolved-repo> --squash --delete-branch/);
 });
 

--- a/test/github/detect-gate-review-evidence.test.mjs
+++ b/test/github/detect-gate-review-evidence.test.mjs
@@ -182,13 +182,13 @@ test("parseDetectGateReviewEvidenceCliArgs rejects malformed arguments determini
     () => parseDetectGateReviewEvidenceCliArgs(["--repo", "bad slug", "--pr", "17"]),
     /match <owner\/name>/i,
   );
-  assert.equal(
-    parseDetectGateReviewEvidenceCliArgs(["--repo", "owner/repo", "--pr", "17", "--require-before-merge"]).requireBeforeMerge,
-    true,
+  assert.throws(
+    () => parseDetectGateReviewEvidenceCliArgs(["--repo", "owner/repo", "--pr", "17", "--require-before-merge"]),
+    /--require-before-merge has been removed/i,
   );
 });
 
-test("detect-gate-review-evidence summarizes the newest valid live gate comments", async () => {
+test("detect-gate-review-evidence summarizes the newest valid live gate comments and passes pre-merge check", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-gate-review-evidence-"));
 
   try {
@@ -297,13 +297,17 @@ test("detect-gate-review-evidence summarizes the newest valid live gate comments
         updatedAt: "2026-05-29T22:00:00Z",
       },
       draftGateSatisfied: true,
+      preMergeGateCheck: {
+        ok: true,
+        failures: [],
+      },
     });
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
 });
 
-test("detect-gate-review-evidence flattens paginated issue-comment payloads before summarizing gates", async () => {
+test("detect-gate-review-evidence fails pre-merge check when only draft gate exists (no pre-approval)", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-gate-review-evidence-pages-"));
 
   try {
@@ -342,17 +346,20 @@ test("detect-gate-review-evidence flattens paginated issue-comment payloads befo
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
-    assert.equal(result.code, 0);
-    assert.equal(JSON.parse(result.stdout).draftGate.commentId, 52);
-    assert.equal(JSON.parse(result.stdout).draftGate.visible, true);
-    assert.equal(JSON.parse(result.stdout).draftGateMarker.commentId, 52);
-    assert.equal(JSON.parse(result.stdout).draftGateSatisfied, true);
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /Pre-merge gate evidence check failed/i);
+    assert.deepEqual(payload.preMergeGateCheck.failures, [
+      "missing visible clean current-head pre_approval_gate comment",
+    ]);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
 });
 
-test("detect-gate-review-evidence exposes same-head markers even when latest gate contract fields are partial", async () => {
+test("detect-gate-review-evidence fails pre-merge check when only partial draft gate marker exists (no pre-approval)", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-gate-review-evidence-marker-"));
 
   try {
@@ -380,23 +387,22 @@ test("detect-gate-review-evidence exposes same-head markers even when latest gat
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
-    assert.equal(result.code, 0);
-    const payload = JSON.parse(result.stdout);
-    assert.equal(payload.draftGate.visible, false);
-    assert.equal(payload.draftGateMarker.visible, true);
-    assert.equal(payload.draftGateMarker.headSha, "abc1234");
-    assert.equal(payload.draftGateMarker.findingsSummary, null);
-    assert.equal(payload.draftGateMarker.nextAction, null);
-    assert.equal(payload.draftGateMarker.contractComplete, false);
-    assert.equal(payload.draftGateMarker.commentId, 61);
-    assert.equal(payload.draftGateSatisfied, false);
+    assert.equal(result.code, 1);
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /Pre-merge gate evidence check failed/i);
+    const failures = payload.preMergeGateCheck.failures;
+    assert.ok(failures.some(f => f.includes("draft_gate")),
+      `expected draft_gate failure in ${JSON.stringify(failures)}`);
+    assert.ok(failures.some(f => f.includes("pre_approval_gate")),
+      `expected pre_approval_gate failure in ${JSON.stringify(failures)}`);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
 });
 
 
-test("detect-gate-review-evidence --require-before-merge fails before merge when gate comments are missing", async () => {
+test("detect-gate-review-evidence always fails before merge when gate comments are missing", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-gate-review-premerge-missing-"));
 
   try {
@@ -411,7 +417,7 @@ test("detect-gate-review-evidence --require-before-merge fails before merge when
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--require-before-merge"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
     assert.equal(result.code, 1);
     assert.equal(result.stdout, "");
@@ -427,7 +433,7 @@ test("detect-gate-review-evidence --require-before-merge fails before merge when
   }
 });
 
-test("detect-gate-review-evidence --require-before-merge passes only with draft and current-head pre-approval gate comments", async () => {
+test("detect-gate-review-evidence always passes pre-merge check with clean draft and current-head pre-approval gate comments", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-gate-review-premerge-clean-"));
 
   try {
@@ -467,7 +473,7 @@ test("detect-gate-review-evidence --require-before-merge passes only with draft 
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--require-before-merge"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
     assert.equal(result.code, 0, result.stderr);
     const payload = JSON.parse(result.stdout);

--- a/test/github/detect-gate-review-evidence.test.mjs
+++ b/test/github/detect-gate-review-evidence.test.mjs
@@ -484,6 +484,60 @@ test("detect-gate-review-evidence always passes pre-merge check with clean draft
   }
 });
 
+test("detect-gate-review-evidence fails pre-merge check when pre-approval gate is for a stale head SHA", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-gate-review-stale-head-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
+        stdout: '{"headRefOid":"feed99999999"}\n',
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/17/comments?per_page=100"],
+        stdout: `${JSON.stringify([
+          {
+            id: 80,
+            body: [
+              "Gate review: draft_gate",
+              "Reviewed head SHA: abcdef12345",
+              "Verdict: clean",
+              "Findings summary: no issues found",
+              "Next action: mark ready for review",
+            ].join("\n"),
+            updated_at: "2026-05-29T21:00:00Z",
+            html_url: "https://github.com/owner/repo/pull/17#issuecomment-80",
+          },
+          {
+            id: 81,
+            body: [
+              "Gate review: pre_approval_gate",
+              "Reviewed head SHA: abcdef12345",
+              "Verdict: clean",
+              "Findings summary: no issues found",
+              "Next action: await final human approval",
+            ].join("\n"),
+            updated_at: "2026-05-29T22:00:00Z",
+            html_url: "https://github.com/owner/repo/pull/17#issuecomment-81",
+          },
+        ])}\n`,
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 1);
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /Pre-merge gate evidence check failed/i);
+    assert.deepEqual(payload.preMergeGateCheck.failures, [
+      "missing visible clean current-head pre_approval_gate comment",
+    ]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 
 test("detect-gate-review-evidence reports gh failures deterministically", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-gate-review-evidence-fail-"));

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -177,6 +177,7 @@ test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs
       nextAction: "request_copilot_review",
       reason: "The PR is ready for review but the post-draft external review cycle has not started yet; request Copilot review before any `pre_approval_gate` entry.",
       draftGateAlreadySatisfied: true,
+      gateEvidenceRequiredForMerge: true,
     });
   } finally {
     await rm(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Make gate evidence enforcement always-on by removing the `--require-before-merge` opt-in flag from `detect-gate-review-evidence.mjs`. The script now always checks and exits 1 when gate evidence is missing — subagents can no longer skip the check by omitting a flag.

This is the 3rd occurrence of subagents merging without gate evidence (#398, #423, #435).

## Changes

- **`scripts/github/detect-gate-review-evidence.mjs`**: Remove `--require-before-merge` flag. Gate evidence check is always-on. Passing the old flag produces a clear error message.
- **`packages/core/src/loop/pr-gate-coordination.mjs`**: Add `gateEvidenceRequiredForMerge: true` to coordination output for explicit merge-gate awareness.
- **Skill/docs**: Update copilot-pr-followup SKILL.md, workflow-handoff-template.md, and issue-intake-procedure.md to remove the flag and document always-on enforcement.
- **Tests**: Updated detect-gate-review-evidence tests, contract tests, and pr-gate-coordination tests for default-on behavior. Added coverage for new `gateEvidenceRequiredForMerge` field.

## Scope/context

Fixes the root cause behind #436: subagents find a direct path to `gh pr merge` by not passing `--require-before-merge`. With the flag removed and enforcement always-on, there is no path to skip the gate evidence check.

## Acceptance criteria

- [x] Gate evidence check runs by default — no flag needed
- [x] Missing gate evidence → merge blocked (exit 1)
- [x] Subagent cannot merge without gate evidence via deterministic script
- [x] npm test passes (1,839 tests)

## Definition of done

- [x] `detect-gate-review-evidence.mjs` always enforces, rejects old flag
- [x] `pr-gate-coordination.mjs` outputs `gateEvidenceRequiredForMerge: true`
- [x] Skill docs updated, no more "optional" language
- [x] All tests pass
- [x] Contract tests updated for new always-on behavior

## Non-goals

- No changes to `detectGateReviewEvidence` exported function (imported callers unaffected — CLI-only change)
- No broader gate-procedure restructuring
- No CI or workflow config changes

Closes #436
Closes #437
