### PR TITLE
fix: lenient gate comment detection to prevent duplicates from other tools (#451)

### DIFF
--- a/packages/core/src/github/copilot-helpers.mjs
+++ b/packages/core/src/github/copilot-helpers.mjs
@@ -117,12 +117,7 @@ function parseGateReviewCommentFields(body) {
   // Lenient fallback: detect gate name and head SHA anywhere in body
   // Handles comments posted via other tools without structured field format
   if (!fields.gate || !fields.headSha) {
-    // Strip GitHub issue/PR comment URLs to prevent false SHA matches
-    // (e.g. #issuecomment-4615274563 where the numeric ID looks like hex)
-    const flatBody = body
-      .replace(/\*\*/gu, "")
-      .replace(/`/gu, "")
-      .replace(/https:\/\/github\.com\/[^\s]+#issuecomment-\d+/g, "");
+    const flatBody = body.replace(/\*\*/gu, "").replace(/`/gu, "");
 
     if (!fields.gate) {
       const gateMatch = flatBody.match(/\b(draft_gate|pre_approval_gate)\b/iu);
@@ -132,9 +127,23 @@ function parseGateReviewCommentFields(body) {
     }
 
     if (!fields.headSha) {
-      const shaMatch = flatBody.match(/\b([0-9a-f]{7,64})\b/iu);
-      if (shaMatch) {
-        fields.headSha = normalizeGateReviewHeadSha(shaMatch[1]);
+      // Prefer SHA following a "head" context marker to avoid false
+      // matches on plain-text numeric IDs (issue/comment IDs, etc.)
+      // Example: "pre_approval_gate for head e284c2e341" or "commit abc1234def"
+      const ctxShaMatch = flatBody.match(
+        /(?:head|sha|commit)\s*(?:sha)?\s*[:=]?\s*`?\b([0-9a-f]{7,64})\b`?/iu
+      );
+      if (ctxShaMatch) {
+        fields.headSha = normalizeGateReviewHeadSha(ctxShaMatch[1]);
+      } else {
+        // Fallback: any hex token, strip known URL/id noise first
+        const cleanBody = flatBody.replace(
+          /https:\/\/github\.com\/[^\s]+#issuecomment-\d+/g, ""
+        );
+        const shaMatch = cleanBody.match(/\b([0-9a-f]{7,64})\b/iu);
+        if (shaMatch) {
+          fields.headSha = normalizeGateReviewHeadSha(shaMatch[1]);
+        }
       }
     }
   }

--- a/packages/core/src/github/copilot-helpers.mjs
+++ b/packages/core/src/github/copilot-helpers.mjs
@@ -114,6 +114,26 @@ function parseGateReviewCommentFields(body) {
     }
   }
 
+  // Lenient fallback: detect gate name and head SHA anywhere in body
+  // Handles comments posted via other tools without structured field format
+  if (!fields.gate || !fields.headSha) {
+    const flatBody = body.replace(/\*\*/gu, "").replace(/`/gu, "");
+
+    if (!fields.gate) {
+      const gateMatch = flatBody.match(/\b(draft_gate|pre_approval_gate)\b/iu);
+      if (gateMatch) {
+        fields.gate = normalizeGateReviewName(gateMatch[1]);
+      }
+    }
+
+    if (!fields.headSha) {
+      const shaMatch = flatBody.match(/\b([0-9a-f]{7,64})\b/iu);
+      if (shaMatch) {
+        fields.headSha = normalizeGateReviewHeadSha(shaMatch[1]);
+      }
+    }
+  }
+
   if (!fields.gate || !fields.headSha) {
     return null;
   }

--- a/packages/core/src/github/copilot-helpers.mjs
+++ b/packages/core/src/github/copilot-helpers.mjs
@@ -117,7 +117,12 @@ function parseGateReviewCommentFields(body) {
   // Lenient fallback: detect gate name and head SHA anywhere in body
   // Handles comments posted via other tools without structured field format
   if (!fields.gate || !fields.headSha) {
-    const flatBody = body.replace(/\*\*/gu, "").replace(/`/gu, "");
+    // Strip GitHub issue/PR comment URLs to prevent false SHA matches
+    // (e.g. #issuecomment-4615274563 where the numeric ID looks like hex)
+    const flatBody = body
+      .replace(/\*\*/gu, "")
+      .replace(/`/gu, "")
+      .replace(/https:\/\/github\.com\/[^\s]+#issuecomment-\d+/g, "");
 
     if (!fields.gate) {
       const gateMatch = flatBody.match(/\b(draft_gate|pre_approval_gate)\b/iu);

--- a/packages/core/src/github/copilot-helpers.mjs
+++ b/packages/core/src/github/copilot-helpers.mjs
@@ -120,7 +120,10 @@ function parseGateReviewCommentFields(body) {
     const flatBody = body.replace(/\*\*/gu, "").replace(/`/gu, "");
 
     if (!fields.gate) {
-      const gateMatch = flatBody.match(/\b(draft_gate|pre_approval_gate)\b/iu);
+      const canonicalGateNames = [...GATE_REVIEW_NAMES].join("|");
+      const gateMatch = flatBody.match(
+        new RegExp(`\\b(${canonicalGateNames})\\b`, "iu")
+      );
       if (gateMatch) {
         fields.gate = normalizeGateReviewName(gateMatch[1]);
       }
@@ -131,7 +134,7 @@ function parseGateReviewCommentFields(body) {
       // matches on plain-text numeric IDs (issue/comment IDs, etc.)
       // Example: "pre_approval_gate for head e284c2e341" or "commit abc1234def"
       const ctxShaMatch = flatBody.match(
-        /(?:head|sha|commit)\s*(?:sha)?\s*[:=]?\s*`?\b([0-9a-f]{7,64})\b`?/iu
+        /\b(?:head|sha|commit)\b\s*(?:sha)?\s*[:=]?\s*`?\b([0-9a-f]{7,64})\b`?/iu
       );
       if (ctxShaMatch) {
         fields.headSha = normalizeGateReviewHeadSha(ctxShaMatch[1]);

--- a/packages/core/test/copilot-helpers.test.mjs
+++ b/packages/core/test/copilot-helpers.test.mjs
@@ -306,3 +306,14 @@ test("parseGateReviewCommentMarkerBody lenient SHA ignores plain-text numeric ID
   assert.equal(result.headSha, "e284c2e341");
   assert.equal(result.contractComplete, false);
 });
+
+test("parseGateReviewCommentMarkerBody context matcher uses word boundaries on head/sha/commit", () => {
+  // "ahead" should NOT match the \bhead\b context matcher
+  // The real SHA follows the comma after the numeric ID
+  const body = "pre_approval_gate: ahead 4615274563, head e284c2e341 — all clear!";
+  const result = parseGateReviewCommentMarkerBody(body);
+  assert.notEqual(result, null);
+  assert.equal(result.gate, "pre_approval_gate");
+  assert.equal(result.headSha, "e284c2e341");
+  assert.equal(result.contractComplete, false);
+});

--- a/packages/core/test/copilot-helpers.test.mjs
+++ b/packages/core/test/copilot-helpers.test.mjs
@@ -284,3 +284,15 @@ test("summarizeGateReviewCommentMarkers prefers structured over lenient when bot
   assert.equal(result.draft_gate.commentId, 2);
   assert.equal(result.draft_gate.contractComplete, true);
 });
+
+test("parseGateReviewCommentMarkerBody lenient SHA ignores github comment URLs", () => {
+  // e.g. URL contains #issuecomment-4615274563 which has 10 decimal digits
+  // that would match [0-9a-f]{7,64} — ensure we strip URLs first
+  const body = "pre_approval_gate for head e284c2e341: all clear!\n\n" +
+    "See https://github.com/mfittko/pi-dev-loops/pull/450#issuecomment-4615274563 for details.";
+  const result = parseGateReviewCommentMarkerBody(body);
+  assert.notEqual(result, null);
+  assert.equal(result.gate, "pre_approval_gate");
+  assert.equal(result.headSha, "e284c2e341");
+  assert.equal(result.contractComplete, false);
+});

--- a/packages/core/test/copilot-helpers.test.mjs
+++ b/packages/core/test/copilot-helpers.test.mjs
@@ -286,10 +286,20 @@ test("summarizeGateReviewCommentMarkers prefers structured over lenient when bot
 });
 
 test("parseGateReviewCommentMarkerBody lenient SHA ignores github comment URLs", () => {
-  // e.g. URL contains #issuecomment-4615274563 which has 10 decimal digits
-  // that would match [0-9a-f]{7,64} — ensure we strip URLs first
+  // "head e284c2e341" matched by context-based parser; URL #issuecomment-4615274563 ignored
   const body = "pre_approval_gate for head e284c2e341: all clear!\n\n" +
     "See https://github.com/mfittko/pi-dev-loops/pull/450#issuecomment-4615274563 for details.";
+  const result = parseGateReviewCommentMarkerBody(body);
+  assert.notEqual(result, null);
+  assert.equal(result.gate, "pre_approval_gate");
+  assert.equal(result.headSha, "e284c2e341");
+  assert.equal(result.contractComplete, false);
+});
+
+test("parseGateReviewCommentMarkerBody lenient SHA ignores plain-text numeric ID before head SHA", () => {
+  // Plain-text "comment 4615274563" is 10 decimal digits that would match [0-9a-f]{7,64}
+  // Context-based parser picks SHA after "head", not the numeric ID
+  const body = "pre_approval_gate: comment 4615274563 for head e284c2e341 all clear!";
   const result = parseGateReviewCommentMarkerBody(body);
   assert.notEqual(result, null);
   assert.equal(result.gate, "pre_approval_gate");

--- a/packages/core/test/copilot-helpers.test.mjs
+++ b/packages/core/test/copilot-helpers.test.mjs
@@ -178,3 +178,109 @@ test("summarizeCopilotReviews ignores non-Copilot reviews", () => {
   assert.equal(result.copilotReviewPresent, false);
   assert.equal(result.hasSubmittedReviewOnCurrentHead, false);
 });
+
+// ── Lenient gate comment parsing (#451) ───────────────────────────────────
+
+test("parseGateReviewCommentMarkerBody detects gate+head in non-standard format", () => {
+  const body = "pre_approval_gate check for head e284c2e341: all clear!";
+  const result = parseGateReviewCommentMarkerBody(body);
+  assert.notEqual(result, null);
+  assert.equal(result.gate, "pre_approval_gate");
+  assert.equal(result.headSha, "e284c2e341");
+  assert.equal(result.contractComplete, false); // no verdict/next-action fields
+});
+
+test("parseGateReviewCommentMarkerBody detects draft_gate in loose format", () => {
+  const body = "draft_gate passed for abc1234def";
+  const result = parseGateReviewCommentMarkerBody(body);
+  assert.notEqual(result, null);
+  assert.equal(result.gate, "draft_gate");
+  assert.equal(result.headSha, "abc1234def");
+  assert.equal(result.contractComplete, false);
+});
+
+test("parseGateReviewCommentMarkerBody returns null when no gate or SHA found", () => {
+  const body = "just a regular comment with no gate references";
+  assert.equal(parseGateReviewCommentMarkerBody(body), null);
+});
+
+test("parseGateReviewCommentMarkerBody returns null when gate found but no SHA", () => {
+  const body = "draft_gate check passed";
+  assert.equal(parseGateReviewCommentMarkerBody(body), null);
+});
+
+test("parseGateReviewCommentMarkerBody returns null when SHA found but no gate", () => {
+  const body = "commit abc1234def5678 looks good";
+  assert.equal(parseGateReviewCommentMarkerBody(body), null);
+});
+
+test("parseGateReviewCommentBody still returns null for lenient match (needs all fields)", () => {
+  const body = "pre_approval_gate for abc1234def all clear";
+  // parseGateReviewCommentBody requires verdict, findingsSummary, AND nextAction
+  assert.equal(parseGateReviewCommentBody(body), null);
+});
+
+test("parseGateReviewCommentMarkerBody lenient fallback does not break structured format", () => {
+  const body = [
+    "### Gate review: `pre_approval_gate`",
+    "",
+    "**Reviewed head SHA:** `e284c2e341`",
+    "**Verdict:** clean",
+    "**Findings summary:** all good",
+    "**Next action:** await approval",
+  ].join("\n");
+  const result = parseGateReviewCommentMarkerBody(body);
+  assert.notEqual(result, null);
+  assert.equal(result.gate, "pre_approval_gate");
+  assert.equal(result.headSha, "e284c2e341");
+  assert.equal(result.verdict, "clean");
+  assert.equal(result.findingsSummary, "all good");
+  assert.equal(result.nextAction, "await approval");
+  assert.equal(result.contractComplete, true);
+});
+
+test("summarizeGateReviewCommentMarkers picks up lenient gate comment", () => {
+  const comments = [
+    {
+      id: 1,
+      html_url: "https://github.com/o/r/pull/1#issuecomment-1",
+      body: "pre_approval_gate for e284c2e341: approved",
+      updated_at: "2026-06-01T10:00:00Z",
+    },
+  ];
+  const result = summarizeGateReviewCommentMarkers(comments, { headSha: "e284c2e341" });
+  assert.notEqual(result.pre_approval_gate, null);
+  assert.equal(result.pre_approval_gate.gate, "pre_approval_gate");
+  assert.equal(result.pre_approval_gate.headSha, "e284c2e341");
+  assert.equal(result.pre_approval_gate.visible, true);
+  assert.equal(result.pre_approval_gate.contractComplete, false);
+});
+
+test("summarizeGateReviewCommentMarkers prefers structured over lenient when both exist", () => {
+  const comments = [
+    {
+      id: 1,
+      html_url: "https://github.com/o/r/pull/1#issuecomment-1",
+      body: "draft_gate for abc1234",  // lenient match
+      updated_at: "2026-06-01T10:00:00Z",
+    },
+    {
+      id: 2,
+      html_url: "https://github.com/o/r/pull/1#issuecomment-2",
+      body: [
+        "### Gate review: `draft_gate`",
+        "",
+        "**Reviewed head SHA:** `abc1234`",
+        "**Verdict:** clean",
+        "**Findings summary:** good",
+        "**Next action:** mark ready",
+      ].join("\n"),
+      updated_at: "2026-06-01T11:00:00Z",  // newer
+    },
+  ];
+  const result = summarizeGateReviewCommentMarkers(comments, { headSha: "abc1234" });
+  assert.notEqual(result.draft_gate, null);
+  // Should prefer the newer structured comment
+  assert.equal(result.draft_gate.commentId, 2);
+  assert.equal(result.draft_gate.contractComplete, true);
+});


### PR DESCRIPTION
## Change Summary

Fix duplicate gate comment detection when gate comments are posted via other tools. Make `parseGateReviewCommentFields` more lenient by adding a fallback regex search for gate name + head SHA anywhere in the comment body, not just in structured field format.

## Scope / Context

The `upsert-gate-review-comment.mjs` helper searches for existing gate comments by matching gate name + head SHA. When a gate comment was posted via a different tool (e.g. direct `gh pr comment`) without the exact structured format, the parser failed to detect it, causing a duplicate comment.

**Fix**: `parseGateReviewCommentFields` now includes a lenient fallback that scans the entire comment body for:
- Gate name (`draft_gate` or `pre_approval_gate`) as a whole word
- A 7-64 character hex SHA

This allows `parseGateReviewCommentMarkerBody` (used by `summarizeGateReviewCommentMarkers`) to detect gate comments regardless of format.

## Acceptance Criteria

- [x] Marker parser detects gate comments posted in non-standard format
- [x] No duplicate gate comments for same gate + head SHA  
- [x] Structured format comments still parsed correctly (no regression)
- [x] `npm test` passes (1725 tests)

## Definition of Done

- [x] Lenient fallback added to `parseGateReviewCommentFields`
- [x] 9 new tests: lenient format detection, structured format unchanged, null when no match
- [x] All existing tests pass (839 core, 886 scripts)

## Non-goals

- No changes to `parseGateReviewCommentBody` strictness (still requires all fields)
- No new API calls
- No changes to upsert-gate-review-comment CLI interface

Closes #451
