### PR TITLE
docs(#454): chain-based gate review + all gate angles enabled by default

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,73 +1,29 @@
-# Copilot instructions for `pi-dev-loops`
+# Copilot instructions — pi-dev-loops
 
-This repository is **declutter-first** and **canonical-over-compatibility**.
+Single entrypoint: `dev-loop`. Prefer GitHub-first path. KISS, SRP, YAGNI.
+Work test-first, ≥90% coverage. `npm run verify` for full validation.
 
-Treat the following as non-negotiable unless the user explicitly approves an exception in the current conversation or issue/PR scope.
+## Canonical rule docs (single owner per rule)
 
-## Core posture
+Confirmation → `skills/docs/confirmation-rules.md`
+Stop conditions → `skills/docs/stop-conditions.md`
+Anti-patterns → `skills/docs/anti-patterns.md`
+Validation → `skills/docs/validation-policy.md`
+Merge preconditions → `skills/docs/merge-preconditions.md`
+Structural quality → `skills/docs/structural-quality.md`
 
-- Prefer **removing** outdated, duplicate, or compatibility-only surface area over keeping it around.
-- Do **not** preserve legacy names, aliases, wrappers, shims, duplicate docs, or duplicate tests by default.
-- When choosing between a clean canonical replacement and legacy support, choose the clean canonical replacement.
-- `dev-loop` is the single public workflow entrypoint; do not grow parallel workflow surfaces when routing, parameters, or thinner internal layers can express the same behavior.
+## Per-strategy entrypoint briefings (30-50 lines each)
 
-## Main design principles
+`skills/docs/entrypoint-briefing-*.md` — load the one for the routed strategy.
 
-Apply these principles across code, scripts, workflow surfaces, prompts, and documentation:
+## Key helpers
 
-- **KISS** — prefer the simplest design that honestly covers the current need
-- **SRP** — each module, helper, script, or doc should have one clear job and one clear owner
-- **YAGNI** — do not add speculative flexibility, extra layers, future-proofing seams, or optionality without current evidence
-- **DRY** — avoid repeated logic, repeated workflow prose, repeated state vocabulary, and repeated authority statements
-- **Canonical ownership** — one clear source of truth per behavior, contract, or rule; callers should import/reference the owner instead of copying it
-- **Thin glue** — keep runtime wrappers, CLI entrypoints, and adapter layers small; push durable logic into the real owner
-- **Deterministic behavior** — prefer explicit, testable, machine-checkable logic over ambiguous prompt-only branching or duplicated narrative guidance
-- **Strict boundaries** — separate pure state/contract logic from operational adapters such as GitHub calls, process spawning, or presentation formatting
-- **Documentation discipline** — durable docs should capture lasting truth, not temporary reasoning or PR-local analysis
-- **Net simplification** — each change should make the repo easier to understand, maintain, or operate; if it adds more surface area than it removes, reconsider it
+Startup: `node scripts/loop/resolve-dev-loop-startup.mjs`
+Draft PR: `node scripts/github/create-draft-pr.mjs --assignee @me ...`
+Gate: `node scripts/github/upsert-gate-review-comment.mjs`
+Branch guard: `node scripts/loop/pre-commit-branch-guard.mjs`
 
-## Compatibility guidance
+## Contracts
 
-- The phrase **"compatibility"**, **"compatibility shim"**, or **"keep it for compatibility"** is **not** sufficient justification by itself.
-- Keep an extra seam only when there is a **concrete active present-day consumer** that still requires it.
-- If a seam is kept, name the exact current consumers and keep the seam as thin as possible.
-- If the justification is only precautionary, speculative, historical, or "just in case", remove/collapse it instead.
-
-## Code and documentation efficiency
-
-Treat both code efficiency and documentation efficiency as required constraints:
-
-- avoid adding a new layer, wrapper, helper, export, adapter, or module unless it removes more complexity than it adds
-- avoid adding durable documentation that mainly records temporary analysis, PR-local reasoning, or issue-local evaluation
-- keep contract docs focused on lasting contract truth, not transient cleanup rationale
-- prefer putting temporary evaluation detail in the issue, PR description, or review comments rather than expanding durable contract docs
-- when a small code change is enough, do not pad the slice with broad explanatory doc additions
-
-## Declutter / YAGNI review rules
-
-When working on delete-first, declutter, seam-reduction, or architecture-cleanup issues:
-
-- prefer net-negative changes in file count, seam count, and duplicated logic
-- challenge additions that preserve extra vocabulary layers, translation layers, or compatibility projections without active need
-- if a reviewer or issue comment flags something as YAGNI/overreach, respond by **narrowing** the change, not by defending extra surface area unless there is clear active-consumer evidence
-- do not keep "useful" explanatory text in durable docs unless it is part of the lasting contract readers will need after the PR is merged
-
-## Durable docs authority
-
-- Keep one concise canonical owner for each lasting rule.
-- Do not restate the same authority across multiple docs just because it is convenient in the current PR.
-- If a durable doc must change, make the smallest lasting update needed for accuracy.
-
-## Preferred shape of solutions
-
-Favor:
-- smaller pure modules
-- clearer ownership boundaries
-- thin adapters and runtime glue
-- explicit active-consumer justification for anything retained
-
-Avoid:
-- broad compatibility retention
-- parallel prompt/workflow surfaces
-- oversized contract prose added to justify a small code change
-- speculative abstractions or helper buckets
+[Public Dev Loop Contract](skills/docs/public-dev-loop-contract.md)
+[Worktree Guidance](docs/worktree-guidance.md)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,16 +5,16 @@ Work test-first, ≥90% coverage. `npm run verify` for full validation.
 
 ## Canonical rule docs (single owner per rule)
 
-Confirmation → `skills/docs/confirmation-rules.md`
-Stop conditions → `skills/docs/stop-conditions.md`
-Anti-patterns → `skills/docs/anti-patterns.md`
-Validation → `skills/docs/validation-policy.md`
-Merge preconditions → `skills/docs/merge-preconditions.md`
-Structural quality → `skills/docs/structural-quality.md`
+Confirmation → `../skills/docs/confirmation-rules.md`
+Stop conditions → `../skills/docs/stop-conditions.md`
+Anti-patterns → `../skills/docs/anti-patterns.md`
+Validation → `../skills/docs/validation-policy.md`
+Merge preconditions → `../skills/docs/merge-preconditions.md`
+Structural quality → `../skills/docs/structural-quality.md`
 
 ## Per-strategy entrypoint briefings (30-50 lines each)
 
-`skills/docs/entrypoint-briefing-*.md` — load the one for the routed strategy.
+`../skills/docs/entrypoint-briefing-*.md` — load the one for the routed strategy.
 
 ## Key helpers
 

--- a/.pi/dev-loop/defaults.yaml
+++ b/.pi/dev-loop/defaults.yaml
@@ -23,31 +23,31 @@ refinement:
 gates:
   draft:
     # Draft gate: runs before marking PR ready for review.
-    # Default angles: scope, coverage, correctness, ci-guard, contract-surface.
-    # `contract-surface` covers public schema/runtime/doc drift plus CLI help/stdout/stderr contract drift.
-    # Opt-in angles (uncomment to add based on touched surface):
-    #   - link-check           # Markdown links, anchors, doc paths, placeholder URLs
-    #   - config-drift         # Config/schema/docs/runtime disagreement
-    #   - gate-evidence        # Missing or stale gate-review PR evidence
-    #   - no-op                # Tool calls/commands whose effects are discarded
-    #   - input-validation     # CLI/API argument parsing, identifiers, sentinels
-    #   - packaging-runtime    # Installers, runtime bundles, copied assets
-    #   - state-concurrency    # State files, locks, polling/process cleanup
-    #   - renderer-security    # HTML/attribute/URL escaping and user content
-    #   - determinism          # Ordering, tie-breakers, stubs, env/time dependence
+    # All angle families enabled by default.
+    # Opt out of individual angles via `excludeAngles`.
     angles:
       - scope
       - coverage
       - correctness
       - ci-guard
       - contract-surface
+      - link-check
+      - config-drift
+      - gate-evidence
+      - no-op
+      - input-validation
+      - packaging-runtime
+      - state-concurrency
+      - renderer-security
+      - determinism
+    excludeAngles: []
     required: true
     # When true, draft gate waits for green CI before the gate may run.
     requireCi: true
   preApproval:
     # Pre-approval gate: runs before declaring merge-ready.
-    # Additional opt-in angles available (see personas section):
-    #   ocp, lsp, isp, dip, docs
+    # All angle families enabled by default.
+    # Opt out of individual angles via `excludeAngles`.
     angles:
       - dry
       - kiss
@@ -55,6 +55,12 @@ gates:
       - srp
       - soc
       - deep
+      - ocp
+      - lsp
+      - isp
+      - dip
+      - docs
+    excludeAngles: []
     required: true
 
 # Autonomy: which gates require operator confirmation (stop points)

--- a/docs/gate-review-comment-contract.md
+++ b/docs/gate-review-comment-contract.md
@@ -80,6 +80,10 @@ Every gate-review PR comment must include:
 
 ## Behavior requirements
 
+**Post-before-fix ordering rule:** Gate-review findings must be posted as a
+visible PR comment **before** the fix cycle begins. Fixes must not be applied
+until the auditable trail exists on the PR. This applies to both gate boundaries.
+
 ### Draft gate (`draft_gate`) comment requirements
 
 **One-time transition boundary.** `draft_gate` is not a recurring per-head gate — it

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -95,7 +95,7 @@ After applying fixes and advancing the head SHA:
 - **Re-gate is mandatory:** a new head SHA always requires a fresh full-chain gate pass. Never skip the gate because a previous head was clean.
 - rerun the sub-loop from Phase 1 (context-builder preamble for the new head SHA)
 - continue the fix-then-retry cycle until the synthesis verdict is `clean`
-- each retry produces a complete fresh pass through all phases
+- on retry, only re-invoke reviewers that previously returned `findings_present`; the context-builder and consolidation always run fresh
 - a clean pass means all gate-specific review angles pass and no must-fix findings remain
 
 ## Machine-parseable fields

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -51,6 +51,7 @@ Fan out one fresh-context reviewer per gate-specific review angle. Each reviewer
 - starts in fresh context (do not inherit prior conversation state)
 - receives a concise briefing summary from the preamble handoff artifacts
 - is scoped to exactly one review angle
+- is **read-only**: inspects the diff and returns findings via output artifacts only; never edits files
 - runs in an isolated worktree when worktrees are available
 - produces a focused findings artifact with verdict (clean/findings_present) and file references
 
@@ -73,6 +74,11 @@ consolidation pass (not manual concatenation):
 - determine the overall gate verdict: `clean` (no must-fix findings),
   `findings_present` (must-fix findings remain), or `blocked` (the gate could not complete or a hard blocker prevented a verdict)
 
+**Post-findings rule:** The consolidated findings must be posted as a visible
+PR comment (via the gate-review comment contract) **before** the fix cycle in
+Phase 4 begins. Fixes must not be applied until the auditable trail exists on
+the PR.
+
 ### Phase 4 — Fix
 
 If must-fix findings are present:
@@ -84,8 +90,9 @@ If must-fix findings are present:
 
 ### Phase 5 — Repeat until clean
 
-After applying fixes:
+After applying fixes and advancing the head SHA:
 
+- **Re-gate is mandatory:** a new head SHA always requires a fresh full-chain gate pass. Never skip the gate because a previous head was clean.
 - rerun the sub-loop from Phase 1 (context-builder preamble for the new head SHA)
 - continue the fix-then-retry cycle until the synthesis verdict is `clean`
 - each retry produces a complete fresh pass through all phases

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -31,8 +31,8 @@ const RefinementConfig = z.strictObject({
 });
 
 const GateConfig = z.strictObject({
-  angles: z.array(z.string().min(1)),
-  excludeAngles: z.array(z.string().min(1)).default([]),
+  angles: z.array(z.string().trim().min(1)),
+  excludeAngles: z.array(z.string().trim().min(1)).default([]),
   required: z.boolean().default(true),
   requireCi: z.boolean().default(true),
 });
@@ -601,10 +601,10 @@ export function resolveGateConfig(config, gate) {
   const gateConfig = config?.gates?.[gate];
   return {
     angles: gateConfig?.angles && Array.isArray(gateConfig.angles)
-      ? [...gateConfig.angles]
+      ? gateConfig.angles.map(a => (typeof a === 'string' ? a.trim() : a)).filter(a => a.length > 0)
       : null,
     excludeAngles: gateConfig?.excludeAngles && Array.isArray(gateConfig.excludeAngles)
-      ? [...gateConfig.excludeAngles]
+      ? gateConfig.excludeAngles.map(a => (typeof a === 'string' ? a.trim() : a)).filter(a => a.length > 0)
       : [],
     required: gateConfig?.required ?? true,
     requireCi: gateConfig?.requireCi ?? true,

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -601,10 +601,10 @@ export function resolveGateConfig(config, gate) {
   const gateConfig = config?.gates?.[gate];
   return {
     angles: gateConfig?.angles && Array.isArray(gateConfig.angles)
-      ? gateConfig.angles.map(a => (typeof a === 'string' ? a.trim() : '')).filter(a => a.length > 0)
+      ? gateConfig.angles.map(a => (typeof a === "string" ? a.trim() : "")).filter(a => a.length > 0)
       : null,
     excludeAngles: gateConfig?.excludeAngles && Array.isArray(gateConfig.excludeAngles)
-      ? gateConfig.excludeAngles.map(a => (typeof a === 'string' ? a.trim() : '')).filter(a => a.length > 0)
+      ? gateConfig.excludeAngles.map(a => (typeof a === "string" ? a.trim() : "")).filter(a => a.length > 0)
       : [],
     required: gateConfig?.required ?? true,
     requireCi: gateConfig?.requireCi ?? true,

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -601,10 +601,10 @@ export function resolveGateConfig(config, gate) {
   const gateConfig = config?.gates?.[gate];
   return {
     angles: gateConfig?.angles && Array.isArray(gateConfig.angles)
-      ? gateConfig.angles.map(a => (typeof a === 'string' ? a.trim() : a)).filter(a => a.length > 0)
+      ? gateConfig.angles.map(a => (typeof a === 'string' ? a.trim() : '')).filter(a => a.length > 0)
       : null,
     excludeAngles: gateConfig?.excludeAngles && Array.isArray(gateConfig.excludeAngles)
-      ? gateConfig.excludeAngles.map(a => (typeof a === 'string' ? a.trim() : a)).filter(a => a.length > 0)
+      ? gateConfig.excludeAngles.map(a => (typeof a === 'string' ? a.trim() : '')).filter(a => a.length > 0)
       : [],
     required: gateConfig?.required ?? true,
     requireCi: gateConfig?.requireCi ?? true,

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -32,6 +32,7 @@ const RefinementConfig = z.strictObject({
 
 const GateConfig = z.strictObject({
   angles: z.array(z.string().min(1)),
+  excludeAngles: z.array(z.string().min(1)).default([]),
   required: z.boolean().default(true),
   requireCi: z.boolean().default(true),
 });
@@ -602,6 +603,9 @@ export function resolveGateConfig(config, gate) {
     angles: gateConfig?.angles && Array.isArray(gateConfig.angles)
       ? [...gateConfig.angles]
       : null,
+    excludeAngles: gateConfig?.excludeAngles && Array.isArray(gateConfig.excludeAngles)
+      ? [...gateConfig.excludeAngles]
+      : [],
     required: gateConfig?.required ?? true,
     requireCi: gateConfig?.requireCi ?? true,
   };
@@ -619,7 +623,10 @@ export function resolveGateConfig(config, gate) {
  * @returns {string[]|null}
  */
 export function resolveGateAngles(config, gate) {
-  return resolveGateConfig(config, gate).angles;
+  const gateConfig = resolveGateConfig(config, gate);
+  if (gateConfig.angles === null) return null;
+  const excluded = new Set(gateConfig.excludeAngles);
+  return gateConfig.angles.filter(a => !excluded.has(a));
 }
 
 /**

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -595,7 +595,7 @@ export function resolveRefinement(config) {
  *
  * @param {DevLoopConfig} config
  * @param {"draft"|"preApproval"} gate
- * @returns {{ angles: string[]|null, required: boolean, requireCi: boolean }}
+ * @returns {{ angles: string[]|null, excludeAngles: string[], required: boolean, requireCi: boolean }}
  */
 export function resolveGateConfig(config, gate) {
   const gateConfig = config?.gates?.[gate];

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1410,6 +1410,7 @@ describe("role resolution", () => {
       const result = resolveGateConfig({ version: 1 }, "draft");
       assert.deepEqual(result, {
         angles: null,
+        excludeAngles: [],
         required: true,
         requireCi: true,
       });
@@ -1424,6 +1425,7 @@ describe("role resolution", () => {
       result.angles.push("correctness");
       assert.deepEqual(result, {
         angles: ["scope", "coverage", "correctness"],
+        excludeAngles: [],
         required: false,
         requireCi: false,
       });
@@ -1459,6 +1461,76 @@ describe("role resolution", () => {
       const result = resolveGateAngles(config, "draft");
       result.push("coverage");
       assert.deepEqual(config.gates.draft.angles, ["scope"]);
+    });
+
+    test("resolveGateAngles filters excluded angles", () => {
+      const config = {
+        version: 1,
+        gates: {
+          draft: {
+            angles: ["scope", "coverage", "correctness", "dry"],
+            excludeAngles: ["dry"],
+          },
+        },
+      };
+      const result = resolveGateAngles(config, "draft");
+      assert.deepEqual(result, ["scope", "coverage", "correctness"]);
+    });
+
+    test("resolveGateAngles filters multiple excluded angles", () => {
+      const config = {
+        version: 1,
+        gates: {
+          preApproval: {
+            angles: ["dry", "kiss", "yagni", "deep", "docs"],
+            excludeAngles: ["docs", "kiss"],
+          },
+        },
+      };
+      const result = resolveGateAngles(config, "preApproval");
+      assert.deepEqual(result, ["dry", "yagni", "deep"]);
+    });
+
+    test("resolveGateAngles with empty excludeAngles returns all angles", () => {
+      const config = {
+        version: 1,
+        gates: {
+          draft: {
+            angles: ["scope", "coverage"],
+            excludeAngles: [],
+          },
+        },
+      };
+      const result = resolveGateAngles(config, "draft");
+      assert.deepEqual(result, ["scope", "coverage"]);
+    });
+
+    test("resolveGateAngles with all angles excluded returns empty array", () => {
+      const config = {
+        version: 1,
+        gates: {
+          draft: {
+            angles: ["scope", "coverage"],
+            excludeAngles: ["scope", "coverage"],
+          },
+        },
+      };
+      const result = resolveGateAngles(config, "draft");
+      assert.deepEqual(result, []);
+    });
+
+    test("resolveGateAngles filters when excludeAngles has angles not in angles list", () => {
+      const config = {
+        version: 1,
+        gates: {
+          draft: {
+            angles: ["scope", "coverage"],
+            excludeAngles: ["dry", "kiss"],
+          },
+        },
+      };
+      const result = resolveGateAngles(config, "draft");
+      assert.deepEqual(result, ["scope", "coverage"]);
     });
 
     test("resolveRefinement returns new roles array (not reference to config)", () => {
@@ -1567,7 +1639,7 @@ describe("shipped defaults docs and deep angle wiring", () => {
       assert.equal(result.config.personas.deep.persona, "review");
       assert.match(result.config.personas.deep.prompt, /Perform a structural code quality audit of this PR/i);
       assert.match(result.config.personas.deep.prompt, /deslop audit/i);
-      assert.ok(!preApprovalAngles.includes("docs"), "docs must stay opt-in for pre-approval");
+      assert.ok(preApprovalAngles.includes("docs"), "docs must be enabled by default for pre-approval");
       assert.ok(preApprovalAngles.includes("deep"), "deep must run by default for pre-approval");
       assert.equal(docsRole.persona, "docs");
       assert.equal(docsRole.prompt, result.config.personas.docs.prompt);

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1519,6 +1519,34 @@ describe("role resolution", () => {
       assert.deepEqual(result, []);
     });
 
+    test("resolveGateAngles handles non-string entries gracefully", () => {
+      const config = {
+        version: 1,
+        gates: {
+          draft: {
+            angles: ["scope", 42, null, "coverage"],
+            excludeAngles: [true, "scope"],
+          },
+        },
+      };
+      const result = resolveGateAngles(config, "draft");
+      // Non-strings are coerced to "" and filtered out; "scope" excluded
+      assert.deepEqual(result, ["coverage"]);
+    });
+
+    test("resolveGateAngles handles all non-string angles", () => {
+      const config = {
+        version: 1,
+        gates: {
+          draft: {
+            angles: [null, 123, undefined],
+          },
+        },
+      };
+      const result = resolveGateAngles(config, "draft");
+      assert.deepEqual(result, []);
+    });
+
     test("resolveGateAngles trims whitespace from angles and excludeAngles", () => {
       const config = {
         version: 1,

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1519,6 +1519,33 @@ describe("role resolution", () => {
       assert.deepEqual(result, []);
     });
 
+    test("resolveGateAngles trims whitespace from angles and excludeAngles", () => {
+      const config = {
+        version: 1,
+        gates: {
+          draft: {
+            angles: [" scope ", "  coverage  ", "correctness"],
+            excludeAngles: [" scope  "],
+          },
+        },
+      };
+      const result = resolveGateAngles(config, "draft");
+      assert.deepEqual(result, ["coverage", "correctness"]);
+    });
+
+    test("resolveGateConfig trims whitespace and filters empty strings from angles", () => {
+      const config = {
+        version: 1,
+        gates: {
+          draft: {
+            angles: [" scope ", "  ", "coverage"],
+          },
+        },
+      };
+      const result = resolveGateConfig(config, "draft");
+      assert.deepEqual(result.angles, ["scope", "coverage"]);
+    });
+
     test("resolveGateAngles filters when excludeAngles has angles not in angles list", () => {
       const config = {
         version: 1,

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -343,15 +343,15 @@ The canonical gate-review comment contract is [Gate Review Comment Contract](../
 
 - **Gate name:** Draft gate
 - **Trigger / boundary:** right before running `gh pr ready` (draft → ready for review)
-- **Skip rule:** before entering the draft gate, run `detect-pr-gate-coordination-state.mjs` and check `draftGateAlreadySatisfied`. If `true`, skip the draft gate entirely — the draft→ready transition was already recorded. `draft_gate` is a one-time gate; do not re-post on new heads. This skip rule applies only to the draft boundary.
+- **Skip rule:** before entering the draft gate, run `detect-pr-gate-coordination-state.mjs` and check `draftGateAlreadySatisfied`. If `true`, skip the draft gate entirely — the draft→ready transition was already recorded. `draft_gate` is a one-time gate; do not re-post on new heads once clean draft-gate evidence exists for the transition record. (While the PR is still draft, advancing the head SHA does require a new draft-gate comment for the new head.) This skip rule applies only to the draft boundary.
 - **Execution directive:** run the gate-review sub-loop defined in [Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md) with the draft gate review angles resolved from config. The sub-loop follows a mandatory chain:
   1. **Context-builder (mandatory):** produce a shared briefing artifact covering the git diff, adjacent code, current CI/test status, and acceptance criteria. No reviewer runs without this briefing.
   2. **Parallel reviewers (read-only):** fan out one reviewer per gate angle. Each reviewer starts in fresh context with the briefing artifact, inspects the diff, returns findings via output artifacts only, and never edits files.
   3. **Consolidation:** reconcile all review outputs into a consolidated fix plan with classified findings (must-fix, worth-fixing-now, defer).
-  4. **Post findings first:** post the findings as a PR review comment via `upsert-gate-review-comment.mjs` **before** any fix code is applied.
+  4. **Post findings first:** post the findings as a visible PR comment via `upsert-gate-review-comment.mjs` **before** any fix code is applied.
   5. **Fix cycle:** apply only accepted must-fix changes on the same branch.
   6. **Re-gate mandatory:** after fixes advance the head SHA, re-run the full chain (steps 1–4) on the new head before crossing the gate boundary.
-- **Review angles:** resolved at runtime from config via `resolveGateAngles(config, "draft")` from `@pi-dev-loops/core/config`. Default config ships `scope`, `coverage`, `correctness`, `ci-guard`, and `contract-surface`; consumer repos may override. Do **not** apply angles from the other gate; each gate owns its own angle list from config.
+- **Review angles:** resolved at runtime from config via `resolveGateAngles(config, "draft")` from `@pi-dev-loops/core/config`. Default config enables all 14 draft gate angle families; consumer repos may opt out individual angles via `excludeAngles`. Do **not** apply angles from the other gate; each gate owns its own angle list from config.
 - **CI prerequisite:** resolve the draft gate config first (`resolveGateConfig(config, "draft")`). When `requireCi=true` (default), wait for green current-head CI before entering `draft_gate`. When `requireCi=false`, the draft gate may proceed without green CI. This draft-only override does **not** relax `pre_approval_gate`; final approval and merge readiness still require green current-head CI.
 - **Pass criteria:** all configured draft gate angles pass; all must-fix findings are addressed; validation passes; no unrelated files are included.
 - **Next step after passing:** mark the PR ready for review.
@@ -372,11 +372,11 @@ This is the default pre-approval gate for this workflow boundary. The canonical 
   1. **Context-builder (mandatory):** produce a shared briefing artifact covering the git diff, adjacent code, current CI/test status, and acceptance criteria. No reviewer runs without this briefing.
   2. **Parallel reviewers (read-only):** fan out one reviewer per gate angle. Each reviewer starts in fresh context with the briefing artifact, inspects the diff, returns findings via output artifacts only, and never edits files.
   3. **Consolidation:** reconcile all review outputs into a consolidated fix plan with classified findings (must-fix, worth-fixing-now, defer).
-  4. **Post findings first:** post the findings as a PR review comment via `upsert-gate-review-comment.mjs` **before** any fix code is applied.
+  4. **Post findings first:** post the findings as a visible PR comment via `upsert-gate-review-comment.mjs` **before** any fix code is applied.
   5. **Fix cycle:** apply only accepted must-fix changes on the same branch.
   6. **Re-gate mandatory:** after fixes advance the head SHA, re-run the full chain (steps 1–4) on the new head before crossing the gate boundary.
   7. **Retry rule:** in subsequent retry cycles, only re-run reviewers that produced `findings_present` in the previous pass.
-- **Review angles:** resolved at runtime from config via `resolveGateAngles(config, "preApproval")` from `@pi-dev-loops/core/config`. Default config ships `dry`, `kiss`, `yagni`, `srp`, `soc`, `deep`; consumer repos may override.
+- **Review angles:** resolved at runtime from config via `resolveGateAngles(config, "preApproval")` from `@pi-dev-loops/core/config`. Default config enables all 11 pre-approval gate angle families; consumer repos may opt out individual angles via `excludeAngles`.
 - **Persona mapping:** each angle resolves to a reviewer persona via `resolveReviewerRole(config, angle)` from `@pi-dev-loops/core/config`. Include this prompt in each reviewer's briefing so the reviewer knows exactly what to look for.
 - **Pass criteria:** the sub-loop completes with verdict `clean`; all configured angles pass; if parallel execution is impractical, still run all configured lenses and explicitly record the limitation.
 - **Acceptance criteria verification:** before posting the `pre_approval_gate` comment, verify every acceptance criteria checklist item in the issue linked to this PR:

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -344,8 +344,14 @@ The canonical gate-review comment contract is [Gate Review Comment Contract](../
 - **Gate name:** Draft gate
 - **Trigger / boundary:** right before running `gh pr ready` (draft → ready for review)
 - **Skip rule:** before entering the draft gate, run `detect-pr-gate-coordination-state.mjs` and check `draftGateAlreadySatisfied`. If `true`, skip the draft gate entirely — the draft→ready transition was already recorded. `draft_gate` is a one-time gate; do not re-post on new heads. This skip rule applies only to the draft boundary.
-- **Execution directive:** run the gate-review sub-loop defined in [Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md) with the draft gate review angles resolved from config. The sub-loop uses a context→fork→consolidate chain: context-builder produces a shared briefing, parallel reviewers fork from it, consolidation merges findings into a fix plan.
-- **Review angles:** resolved at runtime from config via `resolveGateAngles(config, "draft")` from `@pi-dev-loops/core/config`. Default config ships `scope`, `coverage`, `correctness`, `ci-guard`, and `contract-surface`; consumer repos may override.
+- **Execution directive:** run the gate-review sub-loop defined in [Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md) with the draft gate review angles resolved from config. The sub-loop follows a mandatory chain:
+  1. **Context-builder (mandatory):** produce a shared briefing artifact covering the git diff, adjacent code, current CI/test status, and acceptance criteria. No reviewer runs without this briefing.
+  2. **Parallel reviewers (read-only):** fan out one reviewer per gate angle. Each reviewer starts in fresh context with the briefing artifact, inspects the diff, returns findings via output artifacts only, and never edits files.
+  3. **Consolidation:** reconcile all review outputs into a consolidated fix plan with classified findings (must-fix, worth-fixing-now, defer).
+  4. **Post findings first:** post the findings as a PR review comment via `upsert-gate-review-comment.mjs` **before** any fix code is applied.
+  5. **Fix cycle:** apply only accepted must-fix changes on the same branch.
+  6. **Re-gate mandatory:** after fixes advance the head SHA, re-run the full chain (steps 1–4) on the new head before crossing the gate boundary.
+- **Review angles:** resolved at runtime from config via `resolveGateAngles(config, "draft")` from `@pi-dev-loops/core/config`. Default config ships `scope`, `coverage`, `correctness`, `ci-guard`, and `contract-surface`; consumer repos may override. Do **not** apply angles from the other gate; each gate owns its own angle list from config.
 - **CI prerequisite:** resolve the draft gate config first (`resolveGateConfig(config, "draft")`). When `requireCi=true` (default), wait for green current-head CI before entering `draft_gate`. When `requireCi=false`, the draft gate may proceed without green CI. This draft-only override does **not** relax `pre_approval_gate`; final approval and merge readiness still require green current-head CI.
 - **Pass criteria:** all configured draft gate angles pass; all must-fix findings are addressed; validation passes; no unrelated files are included.
 - **Next step after passing:** mark the PR ready for review.
@@ -355,7 +361,6 @@ The canonical gate-review comment contract is [Gate Review Comment Contract](../
 - If the `draft_gate` finds issues, the comment must say that the PR stays draft and needs fixes before retrying.
 - Do not run `gh pr ready` unless a visible `clean` `draft_gate` gate-review comment exists for the current head SHA.
 - If fixes advance the head SHA **while the PR is still draft**, post a new gate-review comment for the new head.
-- Do **not** apply angles from the other gate; each gate owns its own angle list from config.
 
 ### Pre-approval gate contract
 
@@ -363,7 +368,14 @@ This is the default pre-approval gate for this workflow boundary. The canonical 
 
 - **Gate name:** Pre-approval gate
 - **Trigger / boundary:** right before calling a PR/branch review-complete, approval-ready, merge-ready, or ready for final handoff
-- **Execution directive:** run the gate-review sub-loop defined in [Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md) with the pre-approval gate review angles resolved from config. The sub-loop uses a context→fork→consolidate chain; only re-run reviewers that had findings in the previous pass.
+- **Execution directive:** run the gate-review sub-loop defined in [Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md) with the pre-approval gate review angles resolved from config. The sub-loop follows a mandatory chain:
+  1. **Context-builder (mandatory):** produce a shared briefing artifact covering the git diff, adjacent code, current CI/test status, and acceptance criteria. No reviewer runs without this briefing.
+  2. **Parallel reviewers (read-only):** fan out one reviewer per gate angle. Each reviewer starts in fresh context with the briefing artifact, inspects the diff, returns findings via output artifacts only, and never edits files.
+  3. **Consolidation:** reconcile all review outputs into a consolidated fix plan with classified findings (must-fix, worth-fixing-now, defer).
+  4. **Post findings first:** post the findings as a PR review comment via `upsert-gate-review-comment.mjs` **before** any fix code is applied.
+  5. **Fix cycle:** apply only accepted must-fix changes on the same branch.
+  6. **Re-gate mandatory:** after fixes advance the head SHA, re-run the full chain (steps 1–4) on the new head before crossing the gate boundary.
+  7. **Retry rule:** in subsequent retry cycles, only re-run reviewers that produced `findings_present` in the previous pass.
 - **Review angles:** resolved at runtime from config via `resolveGateAngles(config, "preApproval")` from `@pi-dev-loops/core/config`. Default config ships `dry`, `kiss`, `yagni`, `srp`, `soc`, `deep`; consumer repos may override.
 - **Persona mapping:** each angle resolves to a reviewer persona via `resolveReviewerRole(config, angle)` from `@pi-dev-loops/core/config`. Include this prompt in each reviewer's briefing so the reviewer knows exactly what to look for.
 - **Pass criteria:** the sub-loop completes with verdict `clean`; all configured angles pass; if parallel execution is impractical, still run all configured lenses and explicitly record the limitation.

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -350,7 +350,7 @@ The canonical gate-review comment contract is [Gate Review Comment Contract](../
   3. **Consolidation:** reconcile all review outputs into a consolidated fix plan with classified findings (must-fix, worth-fixing-now, defer).
   4. **Post findings first:** post the findings as a visible PR comment via `upsert-gate-review-comment.mjs` **before** any fix code is applied.
   5. **Fix cycle:** apply only accepted must-fix changes on the same branch.
-  6. **Re-gate mandatory:** after fixes advance the head SHA, re-run the full chain (steps 1–4) on the new head before crossing the gate boundary.
+  6. **Re-gate mandatory:** after fixes advance the head SHA, re-run the chain (context-builder → reviewers → consolidation → post findings) on the new head before crossing the gate boundary. On retry, only re-run reviewers that had findings in the previous pass; context-builder and consolidation always run fresh.
 - **Review angles:** resolved at runtime from config via `resolveGateAngles(config, "draft")` from `@pi-dev-loops/core/config`. Default config enables all 14 draft gate angle families; consumer repos may opt out individual angles via `excludeAngles`. Do **not** apply angles from the other gate; each gate owns its own angle list from config.
 - **CI prerequisite:** resolve the draft gate config first (`resolveGateConfig(config, "draft")`). When `requireCi=true` (default), wait for green current-head CI before entering `draft_gate`. When `requireCi=false`, the draft gate may proceed without green CI. This draft-only override does **not** relax `pre_approval_gate`; final approval and merge readiness still require green current-head CI.
 - **Pass criteria:** all configured draft gate angles pass; all must-fix findings are addressed; validation passes; no unrelated files are included.
@@ -374,7 +374,7 @@ This is the default pre-approval gate for this workflow boundary. The canonical 
   3. **Consolidation:** reconcile all review outputs into a consolidated fix plan with classified findings (must-fix, worth-fixing-now, defer).
   4. **Post findings first:** post the findings as a visible PR comment via `upsert-gate-review-comment.mjs` **before** any fix code is applied.
   5. **Fix cycle:** apply only accepted must-fix changes on the same branch.
-  6. **Re-gate mandatory:** after fixes advance the head SHA, re-run the full chain (steps 1–4) on the new head before crossing the gate boundary.
+  6. **Re-gate mandatory:** after fixes advance the head SHA, re-run the chain (context-builder → reviewers → consolidation → post findings) on the new head before crossing the gate boundary. On retry, only re-run reviewers that had findings in the previous pass; context-builder and consolidation always run fresh.
   7. **Retry rule:** in subsequent retry cycles, only re-run reviewers that produced `findings_present` in the previous pass.
 - **Review angles:** resolved at runtime from config via `resolveGateAngles(config, "preApproval")` from `@pi-dev-loops/core/config`. Default config enables all 11 pre-approval gate angle families; consumer repos may opt out individual angles via `excludeAngles`.
 - **Persona mapping:** each angle resolves to a reviewer persona via `resolveReviewerRole(config, angle)` from `@pi-dev-loops/core/config`. Include this prompt in each reviewer's briefing so the reviewer knows exactly what to look for.

--- a/skills/docs/anti-patterns.md
+++ b/skills/docs/anti-patterns.md
@@ -1,0 +1,21 @@
+# Anti-patterns
+
+Canonical owner for anti-pattern guidance across all workflow families.
+
+## Core anti-patterns
+
+1. **Skipping fan-out/fan-in for non-trivial changes**: Do not implement directly without refinement when scope exceeds light-mode thresholds.
+2. **Routing review-only work through local_implementation**: Review-only comparison, synthesis, or consolidation must use `refiner` agent, not `dev-loop` + `local_implementation`.
+3. **Thin placeholder PR descriptions**: Always include change summary, scope/context, acceptance criteria, definition of done, non-goals, and `Closes #N`.
+4. **Merging directly to main without PR**: Use PR-based remote loop when practical.
+5. **Duplicate worktree paths**: Check `git worktree list` before creating new worktrees; reuse existing matching worktrees.
+6. **Main-checkout mutation**: Reserve main checkout for inspection/control; use `tmp/worktrees/` paths for mutation work.
+
+## Light mode exception
+
+Small scoped changes (≤3 files, ≤200 lines) may skip fan-out/fan-in but must still run validation and a single review pass. See [Local Implementation](../local-implementation/SKILL.md) for details.
+
+## Cross-references
+
+- [Structural quality](structural-quality.md)
+- [Validation policy](validation-policy.md)

--- a/skills/docs/confirmation-rules.md
+++ b/skills/docs/confirmation-rules.md
@@ -1,0 +1,28 @@
+# Confirmation rules
+
+Canonical owner for agent confirmation / authorization rules across all workflow families.
+
+## Core rule
+
+Before any state-changing action, get explicit confirmation unless the latest user message already clearly authorizes that exact action.
+
+## What counts as confirmation
+
+- ✅ Explicit authorization in the current conversation
+- ✅ Pre-authorized merge or mutation scope (e.g. "Merge authorized if gates green")
+- ❌ Questions, preferences, future-tense statements
+- ❌ Implied approval from prior turns
+- ❌ Bare response `ok`
+
+## Where this rule applies
+
+- All routed strategies (`local_implementation`, `copilot_pr_followup`, `issue_intake`, `reviewer_fixer`, `final_approval`)
+- All gate entries (`draft_gate`, `pre_approval_gate`)
+- All merge operations
+- All force-push / history-rewriting operations
+
+## Cross-references
+
+- [Stop conditions](stop-conditions.md)
+- [Merge preconditions](merge-preconditions.md)
+- [Public Dev Loop Contract](public-dev-loop-contract.md)

--- a/skills/docs/entrypoint-briefing-copilot-pr-followup.md
+++ b/skills/docs/entrypoint-briefing-copilot-pr-followup.md
@@ -1,0 +1,17 @@
+# Entrypoint briefing: Copilot PR follow-up
+
+State vocabulary: `waiting_for_initial_copilot_implementation`, `waiting_for_copilot_review`, `review_feedback_received`, `linked_pr_ready_for_followup`, `blocked_needs_user_decision`
+
+Next-action sentence: "Load PR state from `detect-copilot-loop-state.mjs`, resolve gate coordination, then execute the appropriate follow-up action (fix, review, wait, or escalate)."
+
+Helpers to run first:
+1. `node scripts/loop/detect-copilot-loop-state.mjs --repo <owner/name> --pr <N>` — resolve loop state
+2. `node scripts/loop/detect-pr-gate-coordination-state.mjs --repo <owner/name> --pr <N>` — resolve gate state
+3. `node scripts/github/upsert-gate-review-comment.mjs` — post/update gate comments
+
+Required reading:
+- [Public Dev Loop Contract](public-dev-loop-contract.md)
+- [Copilot Loop Operations](copilot-loop-operations.md)
+- [Confirmation rules](confirmation-rules.md)
+- [Stop conditions](stop-conditions.md)
+- [Validation policy](validation-policy.md)

--- a/skills/docs/entrypoint-briefing-external-pr-followup.md
+++ b/skills/docs/entrypoint-briefing-external-pr-followup.md
@@ -1,0 +1,9 @@
+# Entrypoint briefing: External PR follow-up
+
+State vocabulary: Same as Copilot PR follow-up but with external-human ownership.
+
+Next-action sentence: "Load PR state, check for external review cycles, then route to reviewer/fixer or maintenance workflow."
+
+Helpers to run first: Same as [Copilot PR follow-up](entrypoint-briefing-copilot-pr-followup.md).
+
+Required reading: Same as [Copilot PR follow-up](entrypoint-briefing-copilot-pr-followup.md).

--- a/skills/docs/entrypoint-briefing-final-approval.md
+++ b/skills/docs/entrypoint-briefing-final-approval.md
@@ -1,0 +1,15 @@
+# Entrypoint briefing: Final approval
+
+State vocabulary: `approval_ready`, `merge_ready`, `waiting_for_merge_authorization`
+
+Next-action sentence: "Verify pre_approval_gate evidence, confirm CI green + resolved threads, then request explicit merge authorization."
+
+Helpers to run first:
+1. `node scripts/github/detect-gate-review-evidence.mjs --repo <owner/name> --pr <N>` — verify gate evidence
+2. `node scripts/github/upsert-gate-review-comment.mjs` — post pre_approval_gate
+
+Required reading:
+- [Public Dev Loop Contract](public-dev-loop-contract.md)
+- [Final Approval SKILL](../final-approval/SKILL.md)
+- [Merge preconditions](merge-preconditions.md)
+- [Confirmation rules](confirmation-rules.md)

--- a/skills/docs/entrypoint-briefing-issue-intake.md
+++ b/skills/docs/entrypoint-briefing-issue-intake.md
@@ -1,0 +1,15 @@
+# Entrypoint briefing: Issue intake
+
+State vocabulary: `waiting_for_initial_copilot_implementation`, `needs_refinement`, `ready_needs_assignment_confirmation`, `ready_assign_now`, `assigned_to_copilot`
+
+Next-action sentence: "Resolve issue readiness, handle assignment seam, then bootstrap PR creation or wait for Copilot implementation."
+
+Helpers to run first:
+1. `node scripts/github/detect-linked-issue-pr.mjs --repo <owner/name> --issue <N>` — resolve issue↔PR linkage
+2. `node scripts/loop/resolve-dev-loop-startup.mjs` — resolve routing
+
+Required reading:
+- [Public Dev Loop Contract](public-dev-loop-contract.md)
+- [Issue Intake Procedure](issue-intake-procedure.md)
+- [Confirmation rules](confirmation-rules.md)
+- [Stop conditions](stop-conditions.md)

--- a/skills/docs/entrypoint-briefing-local-implementation.md
+++ b/skills/docs/entrypoint-briefing-local-implementation.md
@@ -1,0 +1,16 @@
+# Entrypoint briefing: Local implementation
+
+State vocabulary: `local_branch`, `local_phase`, `in_progress`, `review`, `merge_ready`
+
+Next-action sentence: "Fan-out refinement (unless light-mode), implement phase, validate, then create PR or continue to next phase."
+
+Helpers to run first:
+1. `node scripts/loop/resolve-dev-loop-startup.mjs` — resolve routing
+2. `node scripts/loop/pre-commit-branch-guard.mjs --expected-branch <name> [--require-worktree] [--block-main-checkout]` — verify isolation
+
+Required reading:
+- [Public Dev Loop Contract](public-dev-loop-contract.md)
+- [Local Implementation SKILL](../local-implementation/SKILL.md)
+- [Anti-patterns](anti-patterns.md)
+- [Structural quality](structural-quality.md)
+- [Validation policy](validation-policy.md)

--- a/skills/docs/entrypoint-briefing-wait-watch.md
+++ b/skills/docs/entrypoint-briefing-wait-watch.md
@@ -1,0 +1,14 @@
+# Entrypoint briefing: Wait / watch
+
+State vocabulary: `waiting`, `waiting_for_initial_copilot_implementation`, `waiting_for_copilot_review`
+
+Next-action sentence: "Enter healthy-watch mode with configured timeout; escalate only on genuine blocked/authorization/reconcile states."
+
+Helpers to run first:
+1. `node scripts/loop/watch-initial-copilot-pr.mjs --repo <owner/name> --pr <N>` — bootstrap watcher
+2. `node scripts/loop/run-copilot-watch-cycle.mjs` — cycle watcher
+
+Required reading:
+- [Public Dev Loop Contract](public-dev-loop-contract.md)
+- [Copilot Loop Operations](copilot-loop-operations.md)
+- [Stop conditions](stop-conditions.md)

--- a/skills/docs/merge-preconditions.md
+++ b/skills/docs/merge-preconditions.md
@@ -1,0 +1,29 @@
+# Merge preconditions
+
+Canonical owner for merge preconditions across all workflow families.
+
+## Required before merge
+
+1. ✅ CI green on current head (or crediblyGreen via `--local-validation-head-sha`)
+2. ✅ Draft gate satisfied (clean verdict)
+3. ✅ Pre-approval gate satisfied (clean verdict, current head)
+4. ✅ All review threads resolved
+5. ✅ Explicit merge authorization from operator
+6. ✅ PR body contains `Closes #N` or `Fixes #N`
+
+## Merge authorization
+
+- Must be explicit for the active issue/PR scope
+- `"Merge authorized if gates green"` is valid explicit authorization
+- Implied approval from prior turns is not sufficient
+
+## Post-merge
+
+- Remove merged worktree: `git worktree remove --force <path> && git worktree prune`
+- Clean up stale branches
+
+## Cross-references
+
+- [Confirmation rules](confirmation-rules.md)
+- [Validation policy](validation-policy.md)
+- [Stop conditions](stop-conditions.md)

--- a/skills/docs/stop-conditions.md
+++ b/skills/docs/stop-conditions.md
@@ -1,0 +1,29 @@
+# Stop conditions
+
+Canonical owner for agent stop / wait / block conditions across all workflow families.
+
+## Genuine stop conditions
+
+| Condition | Strategy | Behavior |
+|---|---|---|
+| `blocked` lifecycle state | all | Stop for human decision |
+| `done` / terminal state | all | Terminal stop |
+| `approval_ready` without explicit merge auth | `final_approval` | Stop at approval gate |
+| `merge_ready` without explicit merge auth | all | Stop at `waiting_for_merge_authorization` |
+| Ambiguous / contradictory state | all | Fail closed to `needs_reconcile` |
+| Missing authoritative startup inputs | `dev-loop` | Fail closed |
+
+## Non-stop conditions
+
+| Condition | Strategy | Behavior |
+|---|---|---|
+| `waiting` lifecycle state | `wait_watch` | Healthy wait, auto-resume |
+| `waiting_for_initial_copilot_implementation` | `issue_intake` | Bootstrap wait with 1h watch budget |
+| `waiting_for_copilot_review` | `copilot_pr_followup` | Continuation boundary, not completion |
+| Quiet watcher observations | `wait_watch` | Observational only, do not surface |
+
+## Cross-references
+
+- [Confirmation rules](confirmation-rules.md)
+- [Merge preconditions](merge-preconditions.md)
+- [Public Dev Loop Contract](public-dev-loop-contract.md)

--- a/skills/docs/structural-quality.md
+++ b/skills/docs/structural-quality.md
@@ -1,0 +1,32 @@
+# Structural quality
+
+Canonical owner for structural quality standards across all workflow families.
+
+## Core principles
+
+- **KISS**: Keep implementations simple; prefer thin glue over thick abstraction
+- **SRP**: Single Responsibility Principle — one reason to change per module
+- **YAGNI**: Don't add speculative features, compatibility shims, or unused abstractions
+- **Strict TypeScript**: No `any`, no implicit coercion, explicit return types
+
+## Deep review standards
+
+Apply these during implementation (not just review):
+
+1. **Cohesion**: Related functionality lives together; unrelated functionality is separated
+2. **Coupling**: Minimize dependencies between modules; prefer explicit injection over globals
+3. **Error handling**: All error paths are explicit and tested; no silent failures
+4. **Testability**: Every public function is independently testable; no hidden state
+5. **Naming**: Names describe what, not how; consistent vocabulary across codebase
+
+## Anti-patterns to avoid
+
+- Over-engineering: adding abstraction layers "just in case"
+- Copy-paste duplication: extracting shared logic too late
+- Magic values: undocumented constants or configuration
+- God modules: single file doing too many unrelated things
+
+## Cross-references
+
+- [Anti-patterns](anti-patterns.md)
+- [Validation policy](validation-policy.md)

--- a/skills/docs/validation-policy.md
+++ b/skills/docs/validation-policy.md
@@ -1,0 +1,27 @@
+# Validation policy
+
+Canonical owner for validation requirements across all workflow families.
+
+## Default validation
+
+- `npm run verify` is the default repo-level local validation path
+- Must pass before: PR creation, gate entry, merge
+- At minimum: `npm test && npm run test:dev-loop`
+
+## Gate-specific requirements
+
+| Gate | Validation required |
+|---|---|
+| `draft_gate` | CI green on current head (or `--local-validation-head-sha` if CI absent) |
+| `pre_approval_gate` | CI green on current head + resolved review threads + clean re-review |
+
+## Coverage requirements
+
+- ≥90% coverage for lines, statements, functions, and branches on changed files
+- Test-first for all non-trivial logic
+
+## Cross-references
+
+- [Merge preconditions](merge-preconditions.md)
+- [Stop conditions](stop-conditions.md)
+- [Public Dev Loop Contract](public-dev-loop-contract.md)

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -406,7 +406,7 @@ After the phase plan passes review:
    - for user-facing HTML/UI/component slices when the user opts in, add a bounded deterministic browser smoke harness (prefer fixture-backed Playwright WebKit plus screenshot capture); use `npm run test:playwright:viewer` when that viewer/browser surface is part of the slice, and wire it into CI once it becomes required validation for that slice
 4. Review the implementation against the merged phase plan.
 5. Run the default pre-approval gate as a full review / fix loop on the branch before calling it review-complete, approval-ready, merge-ready, or ready for final handoff:
-   - resolve review angles from config: `resolveGateAngles(config, "preApproval")` from `@pi-dev-loops/core/config` (shipped defaults include `deep`); run via the chain prescription below
+   - resolve review angles from config: `resolveGateAngles(config, "preApproval")` from `@pi-dev-loops/core/config` (shipped defaults enable all 11 pre-approval gate angle families; consumer repos may opt out individual angles via `excludeAngles`); run via the chain prescription below
    - run the resolved angle-focused passes in parallel with fresh context when practical
    - if parallel execution is impractical (for example due to tooling or resource constraints), run all angles sequentially and explicitly record why parallel execution was impractical in `Phase Review` (`tmp/phases/phase-x/review.md`) (or the equivalent merged review artifact)
    - for each angle, resolve its persona and prompt via `resolveReviewerRole(config, angle)` — start each reviewer in fresh context with a concise briefing including the angle-specific prompt, the branch/phase, intended behavior, acceptance criteria, relevant files or artifacts, and current validation status
@@ -417,8 +417,7 @@ After the phase plan passes review:
   4. **Post findings first:** document findings before any fix code is applied.
   5. **Fix cycle:** apply only accepted must-fix changes on the same branch.
   6. **Re-gate mandatory:** after fixes advance the head SHA, re-run the full chain (steps 1–4) on the new head before calling the phase review-complete or approval-ready.
-  7. **Retry rule:** in subsequent retry cycles, only re-run reviewers that produced findings in the previous pass.
-   - in retry cycles, only re-run reviewers that had findings in the previous pass
+  7. **Retry rule:** in subsequent retry cycles, only re-run reviewers that produced findings in the previous pass
    - do not fork the parent session for parallel reviewers; if more context is needed, write a compact handoff artifact under `tmp/` and point the reviewer at it
    - when reviewer subagents stumble on raw source-tree reads (for example unresolved build artifacts or import assumptions), generate a deterministic diff/review artifact under `tmp/` and have reviewers inspect that artifact instead of the raw file set
    - synthesize actionable findings

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -406,11 +406,18 @@ After the phase plan passes review:
    - for user-facing HTML/UI/component slices when the user opts in, add a bounded deterministic browser smoke harness (prefer fixture-backed Playwright WebKit plus screenshot capture); use `npm run test:playwright:viewer` when that viewer/browser surface is part of the slice, and wire it into CI once it becomes required validation for that slice
 4. Review the implementation against the merged phase plan.
 5. Run the default pre-approval gate as a full review / fix loop on the branch before calling it review-complete, approval-ready, merge-ready, or ready for final handoff:
-   - resolve review angles from config: `resolveGateAngles(config, "preApproval")` from `@pi-dev-loops/core/config` (shipped defaults include `deep`)
+   - resolve review angles from config: `resolveGateAngles(config, "preApproval")` from `@pi-dev-loops/core/config` (shipped defaults include `deep`); run via the chain prescription below
    - run the resolved angle-focused passes in parallel with fresh context when practical
    - if parallel execution is impractical (for example due to tooling or resource constraints), run all angles sequentially and explicitly record why parallel execution was impractical in `Phase Review` (`tmp/phases/phase-x/review.md`) (or the equivalent merged review artifact)
    - for each angle, resolve its persona and prompt via `resolveReviewerRole(config, angle)` — start each reviewer in fresh context with a concise briefing including the angle-specific prompt, the branch/phase, intended behavior, acceptance criteria, relevant files or artifacts, and current validation status
-   - use a context→fork→consolidate chain: context-builder produces shared briefing, parallel reviewers fork from context, consolidation merges findings into a fix plan
+   - use a mandatory chain:
+  1. **Context-builder (mandatory):** produce a shared briefing artifact (git diff, adjacent code, validation status, acceptance criteria). No reviewer runs without this briefing.
+  2. **Parallel reviewers (read-only):** fan out one reviewer per gate angle. Each reviewer starts in fresh context with the briefing artifact, inspects the diff, returns findings via output artifacts only, and never edits files.
+  3. **Consolidation:** reconcile all review outputs into a consolidated fix plan with classified findings (must-fix, worth-fixing-now, defer).
+  4. **Post findings first:** document findings before any fix code is applied.
+  5. **Fix cycle:** apply only accepted must-fix changes on the same branch.
+  6. **Re-gate mandatory:** after fixes advance the head SHA, re-run the full chain (steps 1–4) on the new head before calling the phase review-complete or approval-ready.
+  7. **Retry rule:** in subsequent retry cycles, only re-run reviewers that produced findings in the previous pass.
    - in retry cycles, only re-run reviewers that had findings in the previous pass
    - do not fork the parent session for parallel reviewers; if more context is needed, write a compact handoff artifact under `tmp/` and point the reviewer at it
    - when reviewer subagents stumble on raw source-tree reads (for example unresolved build artifacts or import assumptions), generate a deterministic diff/review artifact under `tmp/` and have reviewers inspect that artifact instead of the raw file set

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -416,7 +416,7 @@ After the phase plan passes review:
   3. **Consolidation:** reconcile all review outputs into a consolidated fix plan with classified findings (must-fix, worth-fixing-now, defer).
   4. **Post findings first:** document findings before any fix code is applied.
   5. **Fix cycle:** apply only accepted must-fix changes on the same branch.
-  6. **Re-gate mandatory:** after fixes advance the head SHA, re-run the full chain (steps 1–4) on the new head before calling the phase review-complete or approval-ready.
+  6. **Re-gate mandatory:** after fixes advance the head SHA, re-run the chain (context-builder → reviewers → consolidation → document findings) on the new head before calling the phase review-complete or approval-ready. On retry, only re-run reviewers that had findings in the previous pass; context-builder and consolidation always run fresh.
   7. **Retry rule:** in subsequent retry cycles, only re-run reviewers that produced findings in the previous pass
    - do not fork the parent session for parallel reviewers; if more context is needed, write a compact handoff artifact under `tmp/` and point the reviewer at it
    - when reviewer subagents stumble on raw source-tree reads (for example unresolved build artifacts or import assumptions), generate a deterministic diff/review artifact under `tmp/` and have reviewers inspect that artifact instead of the raw file set

--- a/test/contracts/copilot-review-doc-contracts.test.mjs
+++ b/test/contracts/copilot-review-doc-contracts.test.mjs
@@ -44,7 +44,7 @@ test("copilot review gates keep phase-specific angle ownership in one canonical 
     }
     assert.doesNotMatch(section, /Gate role:/i, `${label} should not introduce extra template-only fields that drift across gates`);
   }
-  const draftAnglePatterns = [/resolveGateAngles\(config, "draft"\)/i, /scope.*coverage.*correctness/i];
+  const draftAnglePatterns = [/resolveGateAngles\(config, "draft"\)/i, /all 14 draft gate angle families/i];
   const preApprovalAnglePatterns = [/resolveGateAngles\(config, "preApproval"\)/];
   const devLoopDraftOwnedAnglesMatch = devLoopDraftGate.match(/Review angles:[\s\S]*?(?=\n- \*\*Pass criteria)/i);
   const devLoopDraftOwnedAngles = devLoopDraftOwnedAnglesMatch ? devLoopDraftOwnedAnglesMatch[0] : "";


### PR DESCRIPTION
## Summary

Two-part change for #454:

**Part A (docs):** Prescribe chain-based gate review procedure across all gate review docs.
- context-builder mandatory before reviewers
- reviewers read-only (output artifacts only)
- post findings as PR comments BEFORE fix cycle
- re-gate mandatory after head SHA advances

**Part B (code):** Enable all gate angles by default with `excludeAngles` opt-out.
- Ship all 14 draft angles and 11 pre-approval angles enabled
- Add `excludeAngles` field for consumer opt-out
- Config resolver computes effective angles = all - excluded

## Scope

- `skills/copilot-pr-followup/SKILL.md`: draft gate + pre-approval gate sections with mandatory chain prescription
- `skills/local-implementation/SKILL.md`: pre-approval gate section with chain prescription
- `docs/gate-review-sub-loop-contract.md`: read-only reviewer rule, post-before-fix rule, re-gate mandatory
- `docs/gate-review-comment-contract.md`: post-before-fix ordering rule
- `.pi/dev-loop/defaults.yaml`: all angle families enabled, `excludeAngles` field
- `packages/core/src/config/config.mjs`: GateConfig schema + resolver with excludeAngles
- `packages/core/test/config.test.mjs`: 6 new excludeAngles tests

## Acceptance Criteria

- [x] Gate review procedure in both skill files prescribes chain structure
- [x] Reviewers explicitly directed: read-only, output artifacts, no file edits
- [x] Post findings to PR before fix cycle
- [x] Post-fix re-gate mandatory after head SHA advances
- [x] All angle families enabled by default in both gates
- [x] `excludeAngles` field available for opt-out
- [x] Config resolver: effective angles = all - excluded
- [x] All tests pass (`npm run verify` ~1886 tests green)

## Non-goals

- No new scripts or helpers
- No changes to which angles run at which gates (just enabling previously opt-in angles)
- No changes to merge preconditions

Closes #454