### PR TITLE
docs(#446): deduplicate skill rules + Phase 8 config wiring (#447)

### DIFF
--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1707,3 +1707,80 @@ describe("shipped defaults docs and deep angle wiring", () => {
     }
   });
 });
+// ── Integration: config wiring into actual consumers ──────────────────────
+
+test("print-gates uses resolveGateAngles (not raw gateConfig.angles)", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const source = await readFile(
+    new URL("../../../scripts/loop/print-gates.mjs", import.meta.url),
+    "utf8"
+  );
+  // Must import resolveGateAngles
+  assert.match(source, /resolveGateAngles/);
+  // Must use resolveGateAngles to get angles, not gateConfig.angles directly
+  assert.match(source, /resolveGateAngles\(config,\s*gate\)/);
+});
+
+test("existing wired scripts: outer-loop uses resolveAutonomyStopAt", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const source = await readFile(
+    new URL("../../../scripts/loop/outer-loop.mjs", import.meta.url),
+    "utf8"
+  );
+  assert.match(source, /resolveAutonomyStopAt/);
+  assert.match(source, /resolveAutonomyStopAt\(devLoopConfig\)/);
+});
+
+test("existing wired scripts: detect-copilot-loop-state uses resolveRefinement", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const source = await readFile(
+    new URL("../../../scripts/loop/detect-copilot-loop-state.mjs", import.meta.url),
+    "utf8"
+  );
+  assert.match(source, /resolveRefinement/);
+});
+
+test("existing wired scripts: upsert-gate-review-comment uses resolveRefinementConfig", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const source = await readFile(
+    new URL("../../../scripts/github/upsert-gate-review-comment.mjs", import.meta.url),
+    "utf8"
+  );
+  assert.match(source, /resolveRefinementConfig/);
+});
+
+test("existing wired scripts: detect-pr-gate-coordination-state uses resolveRefinementConfig", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const source = await readFile(
+    new URL("../../../scripts/loop/detect-pr-gate-coordination-state.mjs", import.meta.url),
+    "utf8"
+  );
+  assert.match(source, /resolveRefinementConfig/);
+});
+
+test("existing wired scripts: reconcile-draft-gate imports loadDevLoopConfig", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const source = await readFile(
+    new URL("../../../scripts/github/reconcile-draft-gate.mjs", import.meta.url),
+    "utf8"
+  );
+  assert.match(source, /loadDevLoopConfig/);
+});
+
+test("print-gates resolves excluded angles correctly via resolveGateAngles", async () => {
+  // Unit-level integration: resolveGateAngles with excludeAngles
+  const config = {
+    version: 1,
+    gates: {
+      preApproval: {
+        description: "pre-approval gate",
+        angles: ["deep", "dry", "scope"],
+        excludeAngles: ["dry"],
+      },
+    },
+  };
+  const angles = resolveGateAngles(config, "preApproval");
+  assert.deepStrictEqual(angles, ["deep", "scope"]);
+  // "dry" should be excluded
+  assert.ok(!angles.includes("dry"));
+});

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1719,6 +1719,8 @@ test("print-gates uses resolveGateAngles (not raw gateConfig.angles)", async () 
   assert.match(source, /resolveGateAngles/);
   // Must use resolveGateAngles to get angles, not gateConfig.angles directly
   assert.match(source, /resolveGateAngles\(config,\s*gate\)/);
+  // Negative: gateConfig.angles must not be used directly
+  assert.ok(!/gateConfig\.angles/.test(source), "print-gates.mjs should not use gateConfig.angles directly");
 });
 
 test("existing wired scripts: outer-loop uses resolveAutonomyStopAt", async () => {

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1769,7 +1769,7 @@ test("existing wired scripts: reconcile-draft-gate imports loadDevLoopConfig", a
   assert.match(source, /loadDevLoopConfig/);
 });
 
-test("print-gates resolves excluded angles correctly via resolveGateAngles", async () => {
+test("resolveGateAngles filters excluded angles (unit integration)", async () => {
   // Unit-level integration: resolveGateAngles with excludeAngles
   const config = {
     version: 1,

--- a/scripts/loop/print-gates.mjs
+++ b/scripts/loop/print-gates.mjs
@@ -22,7 +22,7 @@ import { fileURLToPath } from "node:url";
 
 import { loadDevLoopConfig } from "../../packages/core/src/config/config.mjs";
 import { resolveGateConfig } from "../../packages/core/src/config/config.mjs";
-import { resolveReviewerRole } from "../../packages/core/src/config/config.mjs";
+import { resolveGateAngles, resolveReviewerRole } from "../../packages/core/src/config/config.mjs";
 
 async function run({ stdout = process.stdout, repoRoot = process.cwd() } = {}) {
   const { config } = await loadDevLoopConfig({ repoRoot });
@@ -34,7 +34,7 @@ async function run({ stdout = process.stdout, repoRoot = process.cwd() } = {}) {
 
   for (const { label, gate } of gates) {
     const gateConfig = resolveGateConfig(config, gate);
-    const angles = gateConfig.angles;
+    const angles = resolveGateAngles(config, gate);
     const ciLabel = gate === "draft"
       ? String(gateConfig.requireCi)
       : "true (always enforced)";

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -112,7 +112,7 @@ Source code, tests, CI, and config are authoritative. Generated wiki is navigati
 
 ## Structural quality
 
-Apply [Structural Quality](../docs/structural-quality.md) standards from the `deep` review angle during implementation and follow-up fixes. Core: prefer deletion over addition, keep files under ~1k lines, avoid leaky abstractions and spaghetti branching.
+Apply [Structural Quality](../docs/structural-quality.md) standards from the `deep` review angle during implementation and follow-up fixes.
 
 ## Step 5: PR discovery and interpretation
 

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -85,7 +85,7 @@ Read the canonical entrypoint briefing first: [Entrypoint Briefing (Copilot PR F
 - Active GitHub issue/PR
 - Task-relevant source, tests, config, and CI
 
-Route-dependent: see [Copilot Loop Operations](../docs/copilot-loop-operations.md) and [Issue Intake Procedure](../docs/issue-intake-procedure.md) when relevant.`
+Route-dependent: see [Copilot Loop Operations](../docs/copilot-loop-operations.md) and [Issue Intake Procedure](../docs/issue-intake-procedure.md) when relevant.
 Verify all material claims against source, tests, configuration, and CI.
 
 ## Skill asset path resolution

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -77,27 +77,15 @@ For detailed machine guarantees, judgment calls, pre-follow-up planning rules, P
 
 ## Required startup reads
 
-Before planning, review, or automation:
+Read the canonical entrypoint briefing first: [Entrypoint Briefing (Copilot PR Follow-up)](../docs/entrypoint-briefing-copilot-pr-followup.md). Then read only the contract docs needed for the current step:
 
-Read only the contract docs and runtime surface needed for the current routed step.
+- [Agent Instructions](../../AGENTS.md) (repo constitution)
+- [Public Dev Loop Contract](../docs/public-dev-loop-contract.md) (always)
+- [Retrospective Checkpoint Contract](../docs/retrospective-checkpoint-contract.md) (when async state/resume applies)
+- Active GitHub issue/PR
+- Task-relevant source, tests, config, and CI
 
-Read in every routed flow unless a line explicitly says otherwise:
-1. [Agent Instructions](../../AGENTS.md) if present
-2. [Public Dev Loop Contract](../docs/public-dev-loop-contract.md)
-3. [Retrospective Checkpoint Contract](../docs/retrospective-checkpoint-contract.md) when the current step depends on async start/resume/status or retrospective enforcement
-4. the active GitHub issue or PR
-5. the repository's actual validation/runtime surface:
-   - root `package.json`
-   - relevant package-level `package.json` files
-   - CI/workflow configuration if present
-   - touched helper contract docs when the PR changes a documented contract
-6. task-relevant source files, tests, and configuration
-
-Route-dependent extra reads:
-- routed `issue_intake`: [Copilot Loop Operations](../docs/copilot-loop-operations.md) + [Issue Intake Procedure](../docs/issue-intake-procedure.md)
-- PR follow-up / wait-watch / reviewer-fixer / final approval seams: [Copilot Loop Operations](../docs/copilot-loop-operations.md)
-
-If the repo includes generated wiki or LLM context files, treat them as orientation aids only.
+Route-dependent: see [Copilot Loop Operations](../docs/copilot-loop-operations.md) and [Issue Intake Procedure](../docs/issue-intake-procedure.md) when relevant.`
 Verify all material claims against source, tests, configuration, and CI.
 
 ## Skill asset path resolution
@@ -120,27 +108,11 @@ Do not assume `scripts/...` is repo-local to the target codebase you are operati
 
 ## Authority and safety rules
 
-- Source code, tests, CI, and config are authoritative.
-- The generated wiki is a navigation aid, not the source of truth.
-- GitHub Issues are the backlog. Do not invent a parallel backlog file.
-- Before any state-changing action, get explicit confirmation unless the user's latest message already clearly authorizes that action.
-- Questions, preferences, future-tense statements, and implied approval are not confirmation.
-- The bare response `ok` is not confirmation.
-- State-changing actions include local edits, commits, pushes, merges, rebases, branch deletion, issue assignment, label or milestone changes, PR reviews, thread resolution, workflow triggers, and publication.
-- When handing work to Copilot, assign `copilot-swe-agent` directly, not `copilot`.
-- Prefer single commands where practical. If the logic is too involved for one command, write a temporary `.mjs` script under `tmp/` instead of building up fragile shell sequences.
-- For GitHub issue or PR comments, prefer `--body-file` / `-F` or stdin via `-F -` over inline shell strings.
-- Keep scope tight to the issue/PR at hand.
+Source code, tests, CI, and config are authoritative. Generated wiki is navigation aid only. See [Confirmation Rules](../docs/confirmation-rules.md), [Stop Conditions](../docs/stop-conditions.md), and [Merge Preconditions](../docs/merge-preconditions.md) for authorization boundaries.
 
-## Structural quality (from `deep` review angle)
+## Structural quality
 
-During implementation and follow-up fixes, apply the `deep` review angle standards before waiting for review:
-
-- Prefer deletion over addition; question every new file, export, layer, and moving part.
-- Files over ~1k lines need extraction or an explicit justification.
-- Do not bolt conditionals onto unrelated paths; push logic into dedicated boundaries.
-- Avoid spaghetti branching, thin wrappers, re-export-only files, and identity abstractions.
-- Do not leak feature logic into shared modules or create leaky abstractions.
+Apply [Structural Quality](../docs/structural-quality.md) standards from the `deep` review angle during implementation and follow-up fixes. Core: prefer deletion over addition, keep files under ~1k lines, avoid leaky abstractions and spaghetti branching.
 
 ## Step 5: PR discovery and interpretation
 
@@ -412,34 +384,12 @@ Before any merge-ready or final-approval claim, run `detect-pr-gate-coordination
 
 ### Merge-ready preconditions
 
-Do not declare merge-ready unless all of these checks pass in order:
-
-1. `unresolvedThreadCount === 0`, verified via `capture-review-threads.mjs` rather than by prose assertion alone
-2. a visible `draft_gate` comment exists on the PR with verdict `clean` for the one-time draft→ready boundary
-3. a visible `pre_approval_gate` comment exists on the PR for the current head SHA with verdict `clean`
-4. CI is green on the current head SHA
-
-If any check fails, do not declare merge-ready.
-
-For any parallel review pass:
-- start each reviewer in fresh context
-- give each reviewer a concise focus-specific briefing summary instead of relying on inherited conversation state
-- include the PR/branch, intended scope, relevant issue or plan link, current validation/check status, key files or artifacts, and the exact review angle
-- do not fork the parent session just to preserve prior chat state; write a compact handoff artifact under `tmp/copilot-loop/` when a reviewer needs more shared context
+See [Merge Preconditions](../docs/merge-preconditions.md). Verify: `unresolvedThreadCount === 0` (via `capture-review-threads.mjs`), visible clean `draft_gate` + current-head `pre_approval_gate`, green CI. For parallel review passes: start each reviewer in fresh context with a concise focus-specific briefing summary; do not fork the parent session just to preserve chat state (write a compact handoff artifact under `tmp/copilot-loop/` instead).
 
 ### Final approval gate
 
-Use this boundary after the merge-ready preconditions pass.
-
-- Before reporting merge-ready or approval-ready, verify the current-head PR state authoritatively.
-- `unresolvedThreadCount === 0` must be verified via `capture-review-threads.mjs` rather than by prose assertion alone.
-- A visible `draft_gate` comment with verdict `clean` must exist for the one-time draft→ready boundary.
-- A visible `pre_approval_gate` comment with verdict `clean` must exist on the current head SHA.
-- CI must be green, or credibly green with an explicit repository-grounded explanation.
-- Stop at the final human approval gate by default.
-- After approval, report `waiting_for_merge_authorization` and stop again unless merge has been explicitly authorized.
-- Do not merge, push, rebase, resolve threads, or change GitHub state without explicit confirmation unless the latest user message already authorizes that exact action.
-- If merge authorization is explicit, complete one last authoritative check on current-head gate evidence, clean thread state, and green CI, then run the mechanical pre-merge gate evidence check below before merging with the repository's intended PR strategy.
+After merge-ready preconditions pass, verify [Merge Preconditions](../docs/merge-preconditions.md) authoritatively before reporting merge-ready. Stop at the final human approval gate by default. Cross-check via `capture-review-threads.mjs` (not prose assertion).
+Follow [Merge Preconditions](../docs/merge-preconditions.md): stop at `waiting_for_merge_authorization` after approval unless merge explicitly authorized. Run pre-merge gate evidence check before any `gh pr merge`.
 
 ### Mechanical pre-merge gate evidence check
 
@@ -453,74 +403,30 @@ node <resolved-skill-scripts>/github/detect-gate-review-evidence.mjs \
 
 This helper is always-on: it uses `gh api` to fetch visible PR issue comments and fails closed unless both required gate comments exist: a clean `draft_gate` comment for the one-time draft boundary and a clean current-head `pre_approval_gate` comment. Do not run `gh pr merge` if this command exits non-zero. There is no opt-out flag. Resolved threads, green CI, clean Copilot rereview, or local notes do not substitute for this successful helper output. If a final approval or merge boundary sees `gh pr merge` without a same-boundary successful check, treat that as a workflow violation and stop.
 
-## Validation policy for this repo
+## Validation policy
 
-Default validation should match or approximate the active repository's PR CI.
-
-Strong defaults:
-- prefer the repo's declared root scripts when they exist
-- prefer package-local test/check scripts when the change is isolated to one Pi package surface
-- if the repo does not yet define CI-equivalent scripts, say so explicitly and run the narrowest honest validation available
-
-Useful examples in this repository:
-- changes under `skills/dev-loop/scripts/`: `npm run test:dev-loop`
-- changes under `skills/dev-loop/templates/`: run the relevant root smoke/contract tests (for example `npm run test:assets`) because `test:dev-loop` currently covers the surviving script-level tests only
-- docs-only changes: `git diff --check` and targeted markdown review
-- frontmatter or skill-only changes: parse/inspect the updated [this skill file](SKILL.md) files and note any remaining gaps
-
-When GitHub Actions runs already exist and the next step is to wait for them rather than rerun them locally, prefer native GitHub CLI watch support where available:
-- use `gh run watch` for a known workflow run ID
-- otherwise refresh once with `node <resolved-skill-scripts>/loop/detect-copilot-loop-state.mjs --repo <owner/name> --pr <number>` and report the current wait state from that detector snapshot
-- do not add `sleep`-based retries around `gh pr checks`, `gh pr view`, or `gh api`
-
-When reporting status, distinguish between:
-- locally validated narrowly
-- locally validated with full PR-equivalent checks
-- still awaiting GitHub CI confirmation
+Follow [Validation Policy](../docs/validation-policy.md). Default: `npm run verify` before PR creation, gate entry, and merge. For repo-local examples: `npm run test:dev-loop` for skill scripts, contract tests for templates, `git diff --check` for docs. When CI runs exist, use `gh run watch` or `detect-copilot-loop-state.mjs` instead of `sleep`-based polling. Distinguish: locally validated, full PR-equivalent checks, awaiting CI.
 
 ## Confirmation checkpoints
 
-Always stop and ask before these actions unless explicitly authorized already:
-- editing repository files
-- assigning or reassigning an issue
-- changing labels or milestones
-- posting GitHub comments or review replies
-- submitting a PR review
-- resolving review threads
-- committing local changes
-- pushing a branch
-- merging a PR
-- triggering workflows
+See [Confirmation Rules](../docs/confirmation-rules.md). Stop and ask before GitHub mutations (edits, assignments, labels, comments, reviews, thread resolution, commits, pushes, merges, workflows) unless explicitly authorized.
 
 ## Stop conditions
 
-Stop and report instead of acting when:
-- the next step requires a GitHub mutation that is not yet authorized
-- issue scope is ambiguous
-- the PR has no actionable unresolved feedback
-- CI failures are unrelated and require maintainer judgment
-- the branch contains unrelated local changes
-- a proposed fix would broaden scope beyond the issue/PR
+Follow [Stop Conditions](../docs/stop-conditions.md). Genuine stops: `blocked` state, `done`/terminal, `approval_ready` without merge auth, ambiguous state, scope drift. Non-stops: `waiting` watcher states, quiet observations.
 
 ## Anti-patterns
 
-Do not:
-- treat this repo like a local phase-by-phase prototype workflow
-- create a separate local backlog
-- broaden a Copilot PR into multiple issue scopes
-- resolve threads without checking whether the current branch actually fixes them
-- use ad hoc inline `gh api` or `gh api graphql` thread-mutation commands instead of the deterministic `reply-resolve-review-thread.mjs` / `reply-resolve-review-threads.mjs` helpers
-- submit a merge-ready verdict without first summarizing the pending thread state
-- declare merge-ready without a visible `pre_approval_gate` comment on the current head SHA
-- declare merge-ready based solely on `mergeable_state: clean` + CI green without gate evidence
-- do not blind-run `gh pr merge`, `gh pr update-branch`, or an unapproved rebase when the helper says the PR is conflicted
-- run `gh pr merge` without a same-boundary successful `detect-gate-review-evidence.mjs` check (always-on, no opt-out flag)
-- suggest approval, approve and merge, or any approval-ready statement without explicit current-head `pre_approval_gate` gate-review evidence
-- treat CI green + resolved review threads + clean Copilot rereview as sufficient for approval or merge without an explicit current-head `pre_approval_gate` gate-review comment
-- dispatch an async dev-loop task that omits the pre-approval gate requirement
-- post gate review comments with gh pr comment or gh pr review instead of upsert-gate-review-comment.mjs
-- bypass Pi async notifications with detached automation when the user wants in-session async behavior
-- assume the generated wiki is authoritative over code or CI
+See [Anti-patterns](../docs/anti-patterns.md). Key repo-specific additions:
+- Use `reply-resolve-review-thread.mjs` / `reply-resolve-review-threads.mjs` helpers instead of ad hoc `gh api`/`gh api graphql` thread-mutation commands
+- Do NOT use `gh pr comment` or `gh pr review` for gate comments (use `upsert-gate-review-comment.mjs`)
+- Do not declare merge-ready without visible `pre_approval_gate` comment on current head SHA
+- Do not declare merge-ready based solely on `mergeable_state: clean` + CI green without gate evidence
+- Do not blind-run `gh pr merge`, `gh pr update-branch`, or an unapproved rebase when conflicted
+- Do not suggest approval/approve-and-merge without explicit current-head `pre_approval_gate` evidence
+- Do not treat CI green + resolved threads + clean Copilot rereview as sufficient without gate evidence
+- Do not dispatch async dev-loop tasks that omit the pre-approval gate requirement
+- Do not assume generated wiki is authoritative over code or CI
 
 ## Output expectations
 

--- a/skills/docs/structural-quality.md
+++ b/skills/docs/structural-quality.md
@@ -19,6 +19,16 @@ Apply these during implementation (not just review):
 4. **Testability**: Every public function is independently testable; no hidden state
 5. **Naming**: Names describe what, not how; consistent vocabulary across codebase
 
+## Implementation self-check rules
+
+Apply these during implementation (not just at review time):
+
+- **Prefer deletion over addition**: Question every new file, export, layer, and moving part. If it does not earn its keep, remove it.
+- **File size ceiling**: Files over ~1k lines need extraction or an explicit justification kept in a code comment or doc reference.
+- **Logic placement**: Do not bolt conditionals onto unrelated paths; push logic into its own dedicated boundary.
+- **Avoid thin abstractions**: No thin wrappers, re-export-only files, or identity abstractions that add indirection without clarity.
+- **No leaky abstractions**: Do not leak feature-specific logic into shared or general-purpose modules.
+
 ## Anti-patterns to avoid
 
 - Over-engineering: adding abstraction layers "just in case"

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -48,7 +48,7 @@ Local implementation supports two durable spec inputs:
 - phase-doc-backed local sessions ([Phase Plan](../../docs/phases/phase-x.md) is canonical)
 - tracker-backed local sessions (the tracker issue is canonical)
 
-Tracker-backed local implementation stays inside the existing `local_implementation` path. For sub-issue tree decomposition, see [Sub-Issue Tree Contract](../../docs/sub-issue-tree-contract.md). It does not introduce a new routing mode.
+Tracker-backed local implementation stays inside the existing `local_implementation` path. For sub-issue tree decomposition, see [Sub-Issue Tree Contract](../../docs/sub-issue-tree-contract.md) (this is a source-repo reference; it is not part of the bundled `../docs/` runtime contract surface for installed skill copies). It does not introduce a new routing mode.
 
 When the local spec already lives in a tracker issue:
 

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -83,7 +83,7 @@ When the local spec already lives in a tracker issue:
 
 ## Structural quality
 
-Apply [Structural Quality](../docs/structural-quality.md) from the `deep` review angle: prefer deletion over addition, keep files under ~1k lines, avoid leaky abstractions and spaghetti branching.
+Apply [Structural Quality](../docs/structural-quality.md) from the `deep` review angle.
 
 ## Deterministic logging structure
 

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -31,33 +31,15 @@ Everything else is optional and may be bootstrapped by this skill.
 
 ## Required startup reads
 
-Read only what the current routed step actually needs.
+Read the canonical entrypoint briefing first: [Entrypoint Briefing (Local Implementation)](../docs/entrypoint-briefing-local-implementation.md). Then read only what the current step needs:
 
-### GitHub-first routed requests (`issue_intake`, `copilot_pr_followup`, `reviewer_fixer`, `wait_watch`, `final_approval`)
+- [Agent Instructions](../../AGENTS.md) (repo constitution)
+- [Public Dev Loop Contract](../docs/public-dev-loop-contract.md)
+- [Retrospective Checkpoint Contract](../docs/retrospective-checkpoint-contract.md) (when async state applies)
+- [Project Plan](../../PLAN.md) and phase/tracker docs when relevant
+- Relevant issue/PR, validation surface, and task files
 
-Before acting on a GitHub-first issue/PR request:
-
-1. read this skill
-2. if [Agent Instructions](../../AGENTS.md) exists, read it first as the repo constitution / working agreement
-3. read [Public Dev Loop Contract](../docs/public-dev-loop-contract.md)
-4. if the current step depends on async start/resume/status or retrospective enforcement, read [Retrospective Checkpoint Contract](../docs/retrospective-checkpoint-contract.md)
-5. read the relevant GitHub issue or PR
-6. inspect the actual validation/runtime surface needed for the current step (`package.json`, CI/workflows, touched files, helper contracts)
-7. when GitHub-first refinement produces multiple bounded child slices, prefer real GitHub sub-issue trees as the durable execution structure; keep parent issue bodies lean once the tree exists and use plain related-issue references when no tree is warranted
-
-### Local implementation routed requests (`local_implementation`)
-
-Before local phase planning or coding:
-
-1. read this skill
-2. if [Agent Instructions](../../AGENTS.md) exists, read it
-3. read [Project Plan](../../PLAN.md)
-4. if [Implementation Workflow](../../docs/IMPLEMENTATION_WORKFLOW.md) exists, read it
-5. if [Implementation State](../../docs/IMPLEMENTATION_STATE.md) exists, read it
-6. if the active local session is phase-doc-backed and [Phase Plan](../../docs/phases/phase-x.md) exists for the active phase, read it
-7. if the active local session is tracker-backed, deterministically resolve the tracker issue spec first via `scripts/github/resolve-tracker-local-spec.mjs` (or the equivalent `gh issue view <number> --repo <owner/name> --json number,title,body,url,state` call), then treat that tracker issue as canonical for the rest of the local session
-
-Treat missing optional files as normal bootstrap conditions, not as errors.
+Treat missing optional files as normal bootstrap conditions, not errors.
 
 ### Tracker-backed local implementation
 
@@ -66,7 +48,7 @@ Local implementation supports two durable spec inputs:
 - phase-doc-backed local sessions ([Phase Plan](../../docs/phases/phase-x.md) is canonical)
 - tracker-backed local sessions (the tracker issue is canonical)
 
-Tracker-backed local implementation stays inside the existing `local_implementation` path. It does not introduce a new routing mode.
+Tracker-backed local implementation stays inside the existing `local_implementation` path. For sub-issue tree decomposition, see [Sub-Issue Tree Contract](../../docs/sub-issue-tree-contract.md). It does not introduce a new routing mode.
 
 When the local spec already lives in a tracker issue:
 
@@ -99,15 +81,9 @@ When the local spec already lives in a tracker issue:
 - When subagents are used, log what each subagent was asked to do and what it concluded.
 - If [Project Plan](../../PLAN.md) is too rough or ambiguous to safely start the current phase, do not guess: run a clarification/interview step with the user first.
 
-## Structural quality (from `deep` review angle)
+## Structural quality
 
-Implementation agents should self-apply the `deep` review angle standards before reviewer gates:
-
-- Prefer deletion over addition; question every new file, export, layer, and moving part.
-- Files over ~1k lines need extraction or an explicit justification.
-- Do not bolt conditionals onto unrelated paths; push logic into dedicated boundaries.
-- Avoid spaghetti branching, thin wrappers, re-export-only files, and identity abstractions.
-- Do not leak feature logic into shared modules or create leaky abstractions.
+Apply [Structural Quality](../docs/structural-quality.md) from the `deep` review angle: prefer deletion over addition, keep files under ~1k lines, avoid leaky abstractions and spaghetti branching.
 
 ## Deterministic logging structure
 
@@ -525,11 +501,7 @@ If useful, also include truncated `stdout` and `stderr` fields or a path to a la
 
 ## Stop conditions
 
-Stop after the current phase when:
-- the current phase is implemented, validated, and fully finalized, or is explicitly marked `awaiting-finalization`
-- the next step would require refining the next phase
-- a decision requires user or coordination/main-agent approval
-- validation fails in a way that needs a direction change
+See [Stop Conditions](../docs/stop-conditions.md). Local-specific stops: phase completed & finalized, next-phase refinement needed, user/main-agent approval required, validation failure needing direction change.
 
 ## Branch / review / merge policy
 
@@ -557,15 +529,4 @@ Stop after the current phase when:
 
 ## Anti-patterns
 
-Do not:
-- assume a project must already have [Agent Instructions](../../AGENTS.md), [Implementation State](../../docs/IMPLEMENTATION_STATE.md), [Implementation Workflow](../../docs/IMPLEMENTATION_WORKFLOW.md), or [Phase Plan](../../docs/phases/phase-x.md)
-- guess through missing plan details when a short clarification step would resolve them
-- implement multiple future phases in one pass
-- skip the fan-out/fan-in/review loop
-- treat rough notes as implementation authorization
-- expand scope because a helper may be useful later
-- rely on Pi private internals when public hooks exist
-- skip updating [Phase Plan](../../docs/phases/phase-x.md) when the accepted phase plan changes
-- skip updating [Implementation State](../../docs/IMPLEMENTATION_STATE.md)
-- skip writing `tmp/` artifacts
-- use subagents without leaving readable summaries of what they did
+See [Anti-patterns](../docs/anti-patterns.md). Local-specific: don't assume optional plan docs exist, don't guess through missing plan details, don't skip fan-out/fan-in, don't skip `tmp/` artifacts, don't use subagents without readable summaries.

--- a/test/contracts/copilot-review-doc-contracts.test.mjs
+++ b/test/contracts/copilot-review-doc-contracts.test.mjs
@@ -296,7 +296,6 @@ test("copilot-pr-followup skill hardens reply-resolve, gate sequencing, and merg
   assert.match(antiPatterns, /declare merge-ready without visible.*pre_approval_gate/i);
   assert.match(antiPatterns, /declare merge-ready based solely.*mergeable_state.*clean.*CI green/i);
   assert.match(antiPatterns, /Do not blind-run.*gh pr merge.*gh pr update-branch.*unapproved rebase/i);
-  assert.match(antiPatterns, /Do not blind-run.*gh pr merge.*gh pr update-branch.*unapproved rebase/i);
   assert.match(antiPatterns, /Do not dispatch async dev-loop.*omit.*pre-approval gate/i);
 });
 

--- a/test/contracts/copilot-review-doc-contracts.test.mjs
+++ b/test/contracts/copilot-review-doc-contracts.test.mjs
@@ -195,28 +195,29 @@ test("copilot-pr-followup skill hardens reply-resolve, gate sequencing, and merg
   );
   assert.match(
     step7,
-    /1\.\s+`unresolvedThreadCount === 0`, verified via `capture-review-threads\.mjs` rather than by prose assertion alone/i,
+    /unresolvedThreadCount === 0.*capture-review-threads\.mjs/i,
     "merge-ready preconditions should require deterministic thread-state verification",
   );
   assert.match(
     step7,
-    /2\.\s+a visible `draft_gate` comment exists on the PR with verdict `clean`/i,
+    /draft_gate.*clean|clean.*draft_gate/i,
     "merge-ready preconditions should require draft gate evidence",
   );
   assert.match(
     step7,
-    /3\.\s+a visible `pre_approval_gate` comment exists on the PR for the current head SHA with verdict `clean`/i,
+    /pre_approval_gate.*clean|clean.*pre_approval_gate/i,
     "merge-ready preconditions should require current-head clean gate evidence",
   );
   assert.match(
     step7,
-    /4\.\s+CI is green on the current head SHA/i,
+    /green CI/i,
     "merge-ready preconditions should require current-head green CI",
   );
+  // Hard-gate rule now in canonical merge-preconditions.md
   assert.match(
     step7,
-    /If any check fails, do not declare merge-ready\./i,
-    "merge-ready preconditions should be a hard gate",
+    /Merge Preconditions/i,
+    "merge-ready preconditions should be a hard gate (canonical reference)",
   );
   assert.match(
     step7,
@@ -291,12 +292,12 @@ test("copilot-pr-followup skill hardens reply-resolve, gate sequencing, and merg
   const antiPatternsMatch = skillContent.match(/## Anti-patterns[\s\S]*?(?=\n## Recommended companion skills|$)/);
   const antiPatterns = antiPatternsMatch ? antiPatternsMatch[0] : "";
   assert.ok(antiPatterns.length > 0, "copilot-pr-followup anti-patterns section not found");
-  assert.match(antiPatterns, /use ad hoc inline `gh api` or `gh api graphql` thread-mutation commands instead of the deterministic `reply-resolve-review-thread\.mjs` \/ `reply-resolve-review-threads\.mjs` helpers/i);
-  assert.match(antiPatterns, /declare merge-ready without a visible `pre_approval_gate` comment on the current head SHA/i);
-  assert.match(antiPatterns, /declare merge-ready based solely on `mergeable_state: clean` \+ CI green without gate evidence/i);
-  assert.match(antiPatterns, /do not blind-run `gh pr merge`, `gh pr update-branch`, or an unapproved rebase when the helper says the PR is conflicted/i);
-  assert.match(antiPatterns, /run `gh pr merge` without a same-boundary successful `detect-gate-review-evidence\.mjs` check \(always-on, no opt-out flag\)/i);
-  assert.match(antiPatterns, /dispatch an async dev-loop task that omits the pre-approval gate requirement/i);
+  assert.match(antiPatterns, /Use.*reply-resolve-review-thread.*instead of ad hoc.*gh api.*thread/i);
+  assert.match(antiPatterns, /declare merge-ready without visible.*pre_approval_gate/i);
+  assert.match(antiPatterns, /declare merge-ready based solely.*mergeable_state.*clean.*CI green/i);
+  assert.match(antiPatterns, /Do not blind-run.*gh pr merge.*gh pr update-branch.*unapproved rebase/i);
+  assert.match(antiPatterns, /Do not blind-run.*gh pr merge.*gh pr update-branch.*unapproved rebase/i);
+  assert.match(antiPatterns, /Do not dispatch async dev-loop.*omit.*pre-approval gate/i);
 });
 
 test("copilot-pr-followup skill caps Copilot re-review rounds via config and snapshot state", async () => {

--- a/test/contracts/issue-intake-doc-contracts.test.mjs
+++ b/test/contracts/issue-intake-doc-contracts.test.mjs
@@ -21,13 +21,13 @@ async function readIssueIntakeSurface() {
 test("issue-intake surface still contains its core workflow guidance", async () => {
   const content = await readIssueIntakeSurface();
 
-  assert.match(content, /Before planning, review, or automation:/);
+  // Required startup reads now references entrypoint briefing first\n  assert.match(content, /entrypoint briefing/i);\n  assert.match(content, /Read.*contract docs needed for the current step/i);
   assert.match(content, /Skill asset path resolution/);
   assert.match(content, /Do not assume `scripts\/\.\.\.` is repo-local to the target codebase/i);
   assert.match(content, /source-repo helper scripts live two levels up at `\.\.\/\.\.\/scripts\/`/i);
   assert.match(content, /Before any GitHub mutation/);
   assert.match(content, /Preferred defaults for this repo:/);
-  assert.match(content, /Default validation should match or approximate/);
+  // Validation policy now in canonical doc; skill references it\n  assert.match(content, /Validation Policy|validation policy/i);
   assert.match(content, /start each reviewer in fresh context/i);
   assert.match(content, /concise focus-specific briefing summary/i);
   assert.match(content, /do not fork the parent session/i);

--- a/test/contracts/issue-intake-doc-contracts.test.mjs
+++ b/test/contracts/issue-intake-doc-contracts.test.mjs
@@ -21,13 +21,16 @@ async function readIssueIntakeSurface() {
 test("issue-intake surface still contains its core workflow guidance", async () => {
   const content = await readIssueIntakeSurface();
 
-  // Required startup reads now references entrypoint briefing first\n  assert.match(content, /entrypoint briefing/i);\n  assert.match(content, /Read.*contract docs needed for the current step/i);
+  // Required startup reads now references entrypoint briefing first
+  assert.match(content, /entrypoint briefing/i);
+  assert.match(content, /Read.*contract docs needed for the current step/i);
   assert.match(content, /Skill asset path resolution/);
   assert.match(content, /Do not assume `scripts\/\.\.\.` is repo-local to the target codebase/i);
   assert.match(content, /source-repo helper scripts live two levels up at `\.\.\/\.\.\/scripts\/`/i);
   assert.match(content, /Before any GitHub mutation/);
   assert.match(content, /Preferred defaults for this repo:/);
-  // Validation policy now in canonical doc; skill references it\n  assert.match(content, /Validation Policy|validation policy/i);
+  // Validation policy now in canonical doc; skill references it
+  assert.match(content, /Validation Policy|validation policy/i);
   assert.match(content, /start each reviewer in fresh context/i);
   assert.match(content, /concise focus-specific briefing summary/i);
   assert.match(content, /do not fork the parent session/i);

--- a/test/contracts/planning-doc-contracts.test.mjs
+++ b/test/contracts/planning-doc-contracts.test.mjs
@@ -109,7 +109,7 @@ test("planning guidance keeps sub-issue trees as the durable decomposition owner
   ]);
 
   // Sub-issue tree guidance canonical in sub-issue-tree-contract.md; SKILL.md references it
-  assert.match(localImplementationSkill, /sub-issue/i);
+  assert.match(localImplementationSkill, /sub-issue-tree-contract\.md/i);
   assertMatchesAll(subIssueTreeContract, [
     /real GitHub[\s\S]*?sub-issue tree[\s\S]*?default durable/i,
     /keep.*parent.*lean/i,

--- a/test/contracts/planning-doc-contracts.test.mjs
+++ b/test/contracts/planning-doc-contracts.test.mjs
@@ -108,10 +108,13 @@ test("planning guidance keeps sub-issue trees as the durable decomposition owner
     readRepo("docs/index.md"),
   ]);
 
-  assertMatchesAll(localImplementationSkill, [
-    ...SUB_ISSUE_TREE_GUIDANCE,
+  // Sub-issue tree guidance canonical in sub-issue-tree-contract.md; SKILL.md references it
+  assert.match(localImplementationSkill, /sub-issue/i);
+  assertMatchesAll(subIssueTreeContract, [
+    /real GitHub[\s\S]*?sub-issue tree[\s\S]*?default durable/i,
+    /keep.*parent.*lean/i,
     /plain related-issue references/i,
-  ], "skills/local-implementation/SKILL.md");
+  ], "docs/sub-issue-tree-contract.md (canonical owner)");
   assertMatchesAll(coordinatorAgent, [
     ...SUB_ISSUE_TREE_GUIDANCE,
     /duplicating order in checklist prose/i,

--- a/test/contracts/public-facade-doc-contracts.test.mjs
+++ b/test/contracts/public-facade-doc-contracts.test.mjs
@@ -254,7 +254,7 @@ test("copilot-pr-followup mandates upsert helper command for gate comments", asy
   assert.match(copilotFollowupSkill, /--verdict\s+<clean\|findings_present\|blocked>/);
   assert.match(copilotFollowupSkill, /--gate\s+<draft_gate\|pre_approval_gate>/);
   assert.match(copilotFollowupSkill, /Do NOT use `gh pr comment`, `gh api`, or `gh pr review` for gate comments\./);
-  assert.match(copilotFollowupSkill, /post gate review comments with gh pr comment or gh pr review instead of upsert-gate-review-comment\.mjs/i);
+  assert.match(copilotFollowupSkill, /Do NOT use.*gh pr comment.*gh pr review.*gate comments.*upsert-gate-review-comment/i);
 });
 
 test("public dev-loop contract keeps conflict reconciliation local and context-first", async () => {


### PR DESCRIPTION
## Change Summary

Combined PR for #446 (doc quality dedup) and #447 (Phase 8 config wiring closure).

### #446: Doc quality dedup

Replace inline restatements of confirmation rules, stop conditions, anti-patterns, structural quality, validation policy, and merge preconditions with pointers to canonical docs in `skills/docs/`.

- `skills/copilot-pr-followup/SKILL.md`: 533 → 439 lines (-18%)
- `skills/local-implementation/SKILL.md`: 571 → 532 lines (-7%)
- Required startup reads reference entrypoint briefings first
- Sub-issue tree guidance reference added to tracker section

### #447: Phase 8 config wiring

Wired `resolveGateAngles` (with excludeAngles filtering) into `print-gates.mjs`, replacing raw `gateConfig.angles`. Added 7 integration tests verifying all 6 previously-wired scripts still import their config resolvers plus the new wiring.

Existing wiring verified:
- `outer-loop.mjs` → resolveAutonomyStopAt ✅
- `detect-copilot-loop-state.mjs` → resolveRefinement ✅
- `upsert-gate-review-comment.mjs` → resolveRefinementConfig ✅
- `detect-pr-gate-coordination-state.mjs` → resolveRefinementConfig ✅
- `reconcile-draft-gate.mjs` → loadDevLoopConfig ✅
- `print-gates.mjs` → resolveReviewerRole ✅ (now also resolveGateAngles)

## Scope / Context

Part of epic #445 (harden agent entrypoint clarity + state-graph parity).

## Acceptance Criteria

### #446
- [x] `skills/copilot-pr-followup/SKILL.md` deduped (rules replaced with canonical pointers)
- [x] `skills/local-implementation/SKILL.md` deduped
- [x] `Required startup reads` reference entrypoint briefings
- [x] `npm run verify` passes (all 72 contract tests + 1816 unit tests)

### #447
- [x] `resolveGateAngles(config, gate)` consumed in gate review path (print-gates.mjs)
- [x] All 6 previously-wired scripts verified correct
- [x] Integration tests per wiring point
- [x] `npm run verify` passes

## Definition of Done

- All acceptance criteria met
- `npm run verify` passes (1816 tests, 0 failures)
- Config schema unchanged — no new config families

## Non-goals

- No new config families — only wiring existing resolvers
- No config UI
- No runtime config hot-reload

Closes #446
Closes #447
