### PR TITLE
feat(#457): CI guardrail for duplicated imperative rules across skill docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:dev-loop": "node --test --test-reporter ./test/failure-summary-reporter.mjs skills/dev-loop/scripts/dev-mode-context.test.mjs skills/dev-loop/scripts/render-template.test.mjs",
     "playwright:install:safari": "playwright install webkit",
     "test:playwright:viewer": "playwright test -c playwright.inspect-run-viewer.config.mjs",
-    "test:docs": "node scripts/docs/validate-links.mjs && (node scripts/docs/validate-no-duplicate-rules.mjs || echo \"[validate-no-duplicate-rules] Known cross-skill duplicates exist; non-fatal for now\")"
+    "test:docs": "node scripts/docs/validate-links.mjs && node scripts/docs/validate-no-duplicate-rules.mjs"
   },
   "bin": {
     "pi-dev-loops": "./cli/index.mjs"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:dev-loop": "node --test --test-reporter ./test/failure-summary-reporter.mjs skills/dev-loop/scripts/dev-mode-context.test.mjs skills/dev-loop/scripts/render-template.test.mjs",
     "playwright:install:safari": "playwright install webkit",
     "test:playwright:viewer": "playwright test -c playwright.inspect-run-viewer.config.mjs",
-    "test:docs": "node scripts/docs/validate-links.mjs"
+    "test:docs": "node scripts/docs/validate-links.mjs && (node scripts/docs/validate-no-duplicate-rules.mjs || echo \"[validate-no-duplicate-rules] Known cross-skill duplicates exist; non-fatal for now\")"
   },
   "bin": {
     "pi-dev-loops": "./cli/index.mjs"

--- a/scripts/docs/validate-no-duplicate-rules.mjs
+++ b/scripts/docs/validate-no-duplicate-rules.mjs
@@ -79,8 +79,13 @@ export async function* collectMarkdownFiles(dir, repoRoot = REPO_ROOT) {
   let entries;
   try {
     entries = await readdir(dir, { withFileTypes: true });
-  } catch {
-    return;
+  } catch (err) {
+    // Ignore ENOENT (missing directory) silently; other errors must fail loudly
+    // so the CI guardrail doesn't silently pass with 0 files scanned.
+    if (err?.code === "ENOENT") {
+      return;
+    }
+    throw err;
   }
 
   for (const entry of entries) {

--- a/scripts/docs/validate-no-duplicate-rules.mjs
+++ b/scripts/docs/validate-no-duplicate-rules.mjs
@@ -56,6 +56,8 @@ const KNOWN_INTENTIONAL_DUPLICATES = new Set([
   "Each reviewer starts in fresh context with the briefing artifact, inspects the diff, returns findings via output artifacts only, and never edits files.",
   "3. **Consolidation:** reconcile all review outputs into a consolidated fix plan with classified findings (must-fix, worth-fixing-now, defer).",
   "5. **Fix cycle:** apply only accepted must-fix changes on the same branch.",
+  "- remains a stop/fix state, never a wait loop",
+  "Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope.",
 ]);
 
 const IMPERATIVE_PATTERNS = [

--- a/scripts/docs/validate-no-duplicate-rules.mjs
+++ b/scripts/docs/validate-no-duplicate-rules.mjs
@@ -231,8 +231,7 @@ async function main(argv = process.argv.slice(2)) {
 }
 
 // Only run main() when executed directly, not when imported for testing.
-const isDirect = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
-if (isDirect) {
+if (isDirectCliRun(import.meta.url)) {
   const exitCode = await main();
   process.exitCode = exitCode;
 }

--- a/scripts/docs/validate-no-duplicate-rules.mjs
+++ b/scripts/docs/validate-no-duplicate-rules.mjs
@@ -21,6 +21,9 @@
  * Exclusion list:
  *   Canonical contract docs that own their content by design are excluded
  *   from cross-file duplicate detection.
+ *   Known intentional duplicates (mirrored skill procedure text) are also
+ *   excluded so that the guardrail enforces new duplication without failing
+ *   on deliberate mirrors.
  *
  * Exit 0 when clean, exit 1 when duplicates found.
  */
@@ -36,6 +39,20 @@ const SKILLS_DIR = path.join(REPO_ROOT, "skills");
 const CANONICAL_CONTRACT_DOCS = new Set([
   "skills/docs/copilot-loop-operations.md",
   "skills/docs/public-dev-loop-contract.md",
+]);
+
+/**
+ * Known intentional duplicates: text that appears in multiple skill files
+ * because it is deliberately mirrored (shared procedure sections, template
+ * mirrors, etc.). These are excluded from cross-file duplicate reporting so
+ * the guardrail stays fatal for new duplicates without noise from mirrors.
+ */
+const KNOWN_INTENTIONAL_DUPLICATES = new Set([
+  "- **PERSISTENCE RULE: Do not exit your session until the PR is merged or you hit a hard stop that requires conductor authorization.**",
+  "If any required bundled contract doc is missing from the installed skill layout, treat that as a packaging/installer bug.",
+  "Each reviewer starts in fresh context with the briefing artifact, inspects the diff, returns findings via output artifacts only, and never edits files.",
+  "3. **Consolidation:** reconcile all review outputs into a consolidated fix plan with classified findings (must-fix, worth-fixing-now, defer).",
+  "5. **Fix cycle:** apply only accepted must-fix changes on the same branch.",
 ]);
 
 const IMPERATIVE_PATTERNS = [
@@ -85,6 +102,15 @@ export function isImperativeSentence(sentence) {
 
 export function normalizeSentence(text) {
   return text.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Normalize a repo-relative path to POSIX separators.
+ * On Windows, path.relative() produces backslashes, which would break
+ * comparisons against CANONICAL_CONTRACT_DOCS and report formatting.
+ */
+function toPosixPath(p) {
+  return p.replace(/\\/g, "/");
 }
 
 export function extractSentences(content) {
@@ -141,9 +167,11 @@ export function extractSentences(content) {
 
 export async function scanSkills(skillsDir = SKILLS_DIR, repoRoot = REPO_ROOT) {
   const fileMap = new Map();
+  let totalFilesScanned = 0;
 
   for await (const filePath of collectMarkdownFiles(skillsDir, repoRoot)) {
-    const relativePath = path.relative(repoRoot, filePath);
+    totalFilesScanned++;
+    const relativePath = toPosixPath(path.relative(repoRoot, filePath));
 
     if (CANONICAL_CONTRACT_DOCS.has(relativePath)) {
       continue;
@@ -162,13 +190,16 @@ export async function scanSkills(skillsDir = SKILLS_DIR, repoRoot = REPO_ROOT) {
 
   const duplicates = new Map();
   for (const [text, occurrences] of fileMap) {
+    if (KNOWN_INTENTIONAL_DUPLICATES.has(text)) {
+      continue;
+    }
     const uniqueFiles = new Set(occurrences.map((o) => o.file));
     if (uniqueFiles.size > 1) {
       duplicates.set(text, occurrences);
     }
   }
 
-  return { fileMap, duplicates };
+  return { fileMap, duplicates, totalFilesScanned };
 }
 
 async function main(argv = process.argv.slice(2)) {
@@ -177,16 +208,7 @@ async function main(argv = process.argv.slice(2)) {
     return 0;
   }
 
-  const { fileMap, duplicates } = await scanSkills();
-
-  let totalFilesScanned = 0;
-  const seenFiles = new Set();
-  for (const [, occurrences] of fileMap) {
-    for (const { file } of occurrences) {
-      seenFiles.add(file);
-    }
-  }
-  totalFilesScanned = seenFiles.size;
+  const { fileMap, duplicates, totalFilesScanned } = await scanSkills();
 
   if (duplicates.size === 0) {
     process.stdout.write(`No duplicate imperative rules found across skill docs.\n`);
@@ -210,5 +232,5 @@ async function main(argv = process.argv.slice(2)) {
 const isDirect = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
 if (isDirect) {
   const exitCode = await main();
-  process.exit(exitCode);
+  process.exitCode = exitCode;
 }

--- a/scripts/docs/validate-no-duplicate-rules.mjs
+++ b/scripts/docs/validate-no-duplicate-rules.mjs
@@ -32,6 +32,8 @@ import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { isDirectCliRun } from "../_core-helpers.mjs";
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..", "..");
 const SKILLS_DIR = path.join(REPO_ROOT, "skills");
@@ -212,7 +214,7 @@ async function main(argv = process.argv.slice(2)) {
 
   if (duplicates.size === 0) {
     process.stdout.write(`No duplicate imperative rules found across skill docs.\n`);
-    process.stdout.write(`\n${totalFilesScanned} files scanned, ${fileMap.size} imperative sentences extracted, 0 duplicates found.\n`);
+    process.stdout.write(`\n${totalFilesScanned} files scanned, ${fileMap.size} unique imperative sentences extracted, 0 duplicates found.\n`);
     return 0;
   }
 
@@ -224,7 +226,7 @@ async function main(argv = process.argv.slice(2)) {
     process.stdout.write(`    "${text}"\n\n`);
   }
 
-  process.stdout.write(`${totalFilesScanned} files scanned, ${fileMap.size} imperative sentences extracted, ${duplicates.size} duplicates found.\n`);
+  process.stdout.write(`${totalFilesScanned} files scanned, ${fileMap.size} unique imperative sentences extracted, ${duplicates.size} duplicates found.\n`);
   return 1;
 }
 

--- a/scripts/docs/validate-no-duplicate-rules.mjs
+++ b/scripts/docs/validate-no-duplicate-rules.mjs
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+/**
+ * validate-no-duplicate-rules.mjs — CI guardrail: detect duplicated imperative
+ * rule text across skill doc files under skills/.
+ *
+ * Scans skills/ for Markdown files, extracts imperative sentences (those
+ * containing "must", "never", "do not", or "require"/"required"), and reports
+ * any sentence that appears in more than one file.
+ *
+ * Symlink note:
+ *   .pi/skills/ -> ../skills on this repo, so scanning skills/ covers both.
+ *
+ * False-positive suppression:
+ *   - Fenced code blocks (``` or ~~~)
+ *   - Inline code spans (`)
+ *   - Blockquotes (lines starting with ">")
+ *   - Markdown link URLs (text inside (...))
+ *   - Headings (lines starting with "#")
+ *   - Only cross-file duplicates reported (same-file dupes are intentional)
+ *
+ * Exclusion list:
+ *   Canonical contract docs that own their content by design are excluded
+ *   from cross-file duplicate detection.
+ *
+ * Exit 0 when clean, exit 1 when duplicates found.
+ */
+
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const SKILLS_DIR = path.join(REPO_ROOT, "skills");
+
+const CANONICAL_CONTRACT_DOCS = new Set([
+  "skills/docs/copilot-loop-operations.md",
+  "skills/docs/public-dev-loop-contract.md",
+]);
+
+const IMPERATIVE_PATTERNS = [
+  /\bmust\b/i,
+  /\bnever\b/i,
+  /\bdo not\b/i,
+  /\brequire[sd]?\b(?!DraftFirst)/i,
+];
+
+const MIN_SENTENCE_LENGTH = 20;
+
+const USAGE = `Usage: validate-no-duplicate-rules.mjs [--help]
+
+Scan skills/ for duplicated imperative rule text across Markdown files.
+Exit 0 when no duplicates found. Exit 1 when duplicates found.
+
+Options:
+  --help, -h   Show this help`.trim();
+
+
+export async function* collectMarkdownFiles(dir, repoRoot = REPO_ROOT) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      yield* collectMarkdownFiles(fullPath, repoRoot);
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      yield fullPath;
+    }
+  }
+}
+
+export function isImperativeSentence(sentence) {
+  return IMPERATIVE_PATTERNS.some((pattern) => pattern.test(sentence));
+}
+
+export function normalizeSentence(text) {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+export function extractSentences(content) {
+  const lines = content.split(/\r?\n/);
+  const sentences = [];
+  let inFencedBlock = false;
+  let fencedDelimiter = "";
+
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i];
+
+    const rawTrimmed = line.trim();
+
+    if (/^\s*#/.test(line)) {
+      continue;
+    }
+
+    if (/^\s*>/.test(line)) {
+      continue;
+    }
+
+    const fenceMatch = rawTrimmed.match(/^(```|~~~)/);
+    if (fenceMatch) {
+      if (!inFencedBlock) {
+        inFencedBlock = true;
+        fencedDelimiter = fenceMatch[1];
+        continue;
+      } else if (rawTrimmed.startsWith(fencedDelimiter)) {
+        inFencedBlock = false;
+        fencedDelimiter = "";
+        continue;
+      }
+    }
+
+    if (inFencedBlock) {
+      continue;
+    }
+
+    line = line
+      .replace(/`[^`]*`/g, "")
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1");
+
+    const parts = line.split(/(?<=[.!?])\s+(?=[A-Z])/);
+    for (const part of parts) {
+      const normalized = normalizeSentence(part);
+      if (normalized.length >= MIN_SENTENCE_LENGTH && isImperativeSentence(normalized)) {
+        sentences.push({ text: normalized, line: i + 1 });
+      }
+    }
+  }
+
+  return sentences;
+}
+
+export async function scanSkills(skillsDir = SKILLS_DIR, repoRoot = REPO_ROOT) {
+  const fileMap = new Map();
+
+  for await (const filePath of collectMarkdownFiles(skillsDir, repoRoot)) {
+    const relativePath = path.relative(repoRoot, filePath);
+
+    if (CANONICAL_CONTRACT_DOCS.has(relativePath)) {
+      continue;
+    }
+
+    const content = await readFile(filePath, "utf8");
+    const sentences = extractSentences(content);
+
+    for (const { text, line } of sentences) {
+      if (!fileMap.has(text)) {
+        fileMap.set(text, []);
+      }
+      fileMap.get(text).push({ file: relativePath, line });
+    }
+  }
+
+  const duplicates = new Map();
+  for (const [text, occurrences] of fileMap) {
+    const uniqueFiles = new Set(occurrences.map((o) => o.file));
+    if (uniqueFiles.size > 1) {
+      duplicates.set(text, occurrences);
+    }
+  }
+
+  return { fileMap, duplicates };
+}
+
+async function main(argv = process.argv.slice(2)) {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    process.stdout.write(`${USAGE}\n`);
+    return 0;
+  }
+
+  const { fileMap, duplicates } = await scanSkills();
+
+  let totalFilesScanned = 0;
+  const seenFiles = new Set();
+  for (const [, occurrences] of fileMap) {
+    for (const { file } of occurrences) {
+      seenFiles.add(file);
+    }
+  }
+  totalFilesScanned = seenFiles.size;
+
+  if (duplicates.size === 0) {
+    process.stdout.write(`No duplicate imperative rules found across skill docs.\n`);
+    process.stdout.write(`\n${totalFilesScanned} files scanned, ${fileMap.size} imperative sentences extracted, 0 duplicates found.\n`);
+    return 0;
+  }
+
+  process.stdout.write(`Duplicate imperative rules found across skill docs:\n\n`);
+  for (const [text, occurrences] of duplicates) {
+    for (const { file, line } of occurrences) {
+      process.stdout.write(`  ${file}:${line}\n`);
+    }
+    process.stdout.write(`    "${text}"\n\n`);
+  }
+
+  process.stdout.write(`${totalFilesScanned} files scanned, ${fileMap.size} imperative sentences extracted, ${duplicates.size} duplicates found.\n`);
+  return 1;
+}
+
+// Only run main() when executed directly, not when imported for testing.
+const isDirect = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isDirect) {
+  const exitCode = await main();
+  process.exit(exitCode);
+}

--- a/scripts/docs/validate-no-duplicate-rules.mjs
+++ b/scripts/docs/validate-no-duplicate-rules.mjs
@@ -61,7 +61,7 @@ const IMPERATIVE_PATTERNS = [
   /\bmust\b/i,
   /\bnever\b/i,
   /\bdo not\b/i,
-  /\brequire[sd]?\b(?!DraftFirst)/i,
+  /\brequire[sd]?\b/i,
 ];
 
 const MIN_SENTENCE_LENGTH = 20;

--- a/scripts/docs/validate-no-duplicate-rules.mjs
+++ b/scripts/docs/validate-no-duplicate-rules.mjs
@@ -19,8 +19,9 @@
  *   - Only cross-file duplicates reported (same-file dupes are intentional)
  *
  * Exclusion list:
- *   Canonical contract docs that own their content by design are excluded
- *   from cross-file duplicate detection.
+ *   Duplicates where all occurrences are within canonical contract docs
+ *   (which own their content by design) are suppressed. Duplicates involving
+ *   any non-canonical file are still reported.
  *   Known intentional duplicates (mirrored skill procedure text) are also
  *   excluded so that the guardrail enforces new duplication without failing
  *   on deliberate mirrors.
@@ -177,13 +178,9 @@ export async function scanSkills(skillsDir = SKILLS_DIR, repoRoot = REPO_ROOT) {
   let totalFilesScanned = 0;
 
   for await (const filePath of collectMarkdownFiles(skillsDir, repoRoot)) {
-    totalFilesScanned++;
     const relativePath = toPosixPath(path.relative(repoRoot, filePath));
 
-    if (CANONICAL_CONTRACT_DOCS.has(relativePath)) {
-      continue;
-    }
-
+    totalFilesScanned++;
     const content = await readFile(filePath, "utf8");
     const sentences = extractSentences(content);
 
@@ -202,7 +199,14 @@ export async function scanSkills(skillsDir = SKILLS_DIR, repoRoot = REPO_ROOT) {
     }
     const uniqueFiles = new Set(occurrences.map((o) => o.file));
     if (uniqueFiles.size > 1) {
-      duplicates.set(text, occurrences);
+      // Suppress duplicates where all occurrences are within canonical
+      // contract docs (these own their content by design and may mirror
+      // each other).  Duplicates that involve any non-canonical file
+      // are still reported.
+      const allCanonical = [...uniqueFiles].every((f) => CANONICAL_CONTRACT_DOCS.has(f));
+      if (!allCanonical) {
+        duplicates.set(text, occurrences);
+      }
     }
   }
 

--- a/scripts/docs/validate-no-duplicate-rules.mjs
+++ b/scripts/docs/validate-no-duplicate-rules.mjs
@@ -58,6 +58,7 @@ const KNOWN_INTENTIONAL_DUPLICATES = new Set([
   "5. **Fix cycle:** apply only accepted must-fix changes on the same branch.",
   "- remains a stop/fix state, never a wait loop",
   "Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope.",
+  "Each reviewer starts in fresh context (subagent({context:\"fresh\"}) mandatory), inspects the diff, returns findings via output artifacts only, and never edits files. **Before starting:** run to self-verify fresh context; refuse to proceed on contamination.",
 ]);
 
 const IMPERATIVE_PATTERNS = [

--- a/test/docs/validate-no-duplicate-rules.test.mjs
+++ b/test/docs/validate-no-duplicate-rules.test.mjs
@@ -1,0 +1,255 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  collectMarkdownFiles,
+  extractSentences,
+  isImperativeSentence,
+  normalizeSentence,
+  scanSkills,
+} from "../../scripts/docs/validate-no-duplicate-rules.mjs";
+
+async function writeSkillsDir(tempDir, files) {
+  const skillsDir = path.join(tempDir, "skills");
+  for (const [relativePath, content] of Object.entries(files)) {
+    const fullPath = path.join(skillsDir, relativePath);
+    await mkdir(path.dirname(fullPath), { recursive: true });
+    await writeFile(fullPath, `${content}\n`, "utf8");
+  }
+  return skillsDir;
+}
+
+test("isImperativeSentence detects must/never/do not/require", () => {
+  assert.ok(isImperativeSentence("You must always run tests before every push."));
+  assert.ok(isImperativeSentence("Never push directly to the main branch."));
+  assert.ok(isImperativeSentence("Do not bypass the gate check mechanism."));
+  assert.ok(isImperativeSentence("This step requires explicit verification."));
+  assert.ok(isImperativeSentence("Required startup reads are listed below."));
+  assert.ok(!isImperativeSentence("This is a simple statement."));
+  assert.ok(!isImperativeSentence("Hello world."));
+});
+
+test("normalizeSentence collapses whitespace", () => {
+  assert.equal(normalizeSentence("  hello   world  "), "hello world");
+  assert.equal(normalizeSentence("line1\nline2"), "line1 line2");
+  assert.equal(normalizeSentence("a\tb"), "a b");
+});
+
+test("extractSentences finds imperative sentences", () => {
+  const result = extractSentences("You must run tests before every push. This is optional.");
+  assert.equal(result.length, 1);
+  assert.ok(result[0].text.includes("must"));
+});
+
+test("extractSentences finds multiple imperative sentences in line", () => {
+  const result = extractSentences("You must always lint. Never skip verification.");
+  assert.equal(result.length, 2);
+});
+
+test("extractSentences skips short imperative fragments", () => {
+  // "Must do." is only 7 chars after normalization — below MIN_SENTENCE_LENGTH
+  const result = extractSentences("Must do.");
+  assert.equal(result.length, 0);
+});
+
+test("extractSentences skips fenced code blocks", () => {
+  const content = [
+    "You must check the configuration before every run.",
+    "```",
+    "You must also check this inside code block.",
+    "```",
+    "Normal text after block.",
+  ].join("\n");
+  const result = extractSentences(content);
+  const texts = result.map((s) => s.text);
+  assert.ok(texts.some((t) => t.includes("configuration")));
+  const codeContent = texts.filter((t) => t.includes("inside code"));
+  assert.equal(codeContent.length, 0);
+});
+
+test("extractSentences skips inline code", () => {
+  const result = extractSentences("Run `npm test --must-flag` before every push and always must verify.");
+  assert.equal(result.length, 1);
+  assert.ok(!result[0].text.includes("npm test"));
+});
+
+test("extractSentences skips markdown link URLs", () => {
+  const result = extractSentences(
+    "See [the guide about required steps](https://example.com/must-read) for details. You must read the full documentation guide."
+  );
+  // Both sentences contain imperative keywords; link URLs removed
+  assert.ok(result.length >= 1);
+  assert.ok(result.some((s) => s.text.includes("must read")));
+});
+
+test("extractSentences skips blockquote lines", () => {
+  const content = [
+    "> You must follow this quoted rule in the block.",
+    "You must follow the non-quoted actual rule.",
+  ].join("\n");
+  const result = extractSentences(content);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].text, "You must follow the non-quoted actual rule.");
+});
+
+test("extractSentences skips headings", () => {
+  const content = [
+    "# Required Startup Reads and Configuration",
+    "You must read the documentation before starting.",
+  ].join("\n");
+  const result = extractSentences(content);
+  assert.equal(result.length, 1);
+  assert.ok(result[0].text.includes("read the documentation"));
+});
+
+test("extractSentences preserves line numbers", () => {
+  const content = [
+    "First line is just filler.",
+    "You must check configuration before every push.",
+  ].join("\n");
+  const result = extractSentences(content);
+  assert.equal(result[0].line, 2);
+});
+
+test("extractSentences handles ~~~ fenced blocks", () => {
+  const content = [
+    "You must check outside block.",
+    "~~~",
+    "You must ignore this inside tilde block.",
+    "~~~",
+    "Normal text after tilde block.",
+  ].join("\n");
+  const result = extractSentences(content);
+  const texts = result.map((s) => s.text);
+  assert.ok(texts.some((t) => t.includes("outside block")));
+  assert.ok(!texts.some((t) => t.includes("tilde block")));
+});
+
+test("scanSkills detects cross-file duplicates", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-validate-rules-"));
+  try {
+    const skillsDir = await writeSkillsDir(tempDir, {
+      "doc-a/SKILL.md": "You must always run tests before pushing changes to main.",
+      "doc-b/SKILL.md": "You must always run tests before pushing changes to main. Another unique statement.",
+    });
+    const repoRoot = tempDir;
+    const { fileMap, duplicates } = await scanSkills(skillsDir, repoRoot);
+
+    assert.equal(duplicates.size, 1);
+    const dupEntries = [...duplicates.entries()];
+    assert.equal(dupEntries[0][0], "You must always run tests before pushing changes to main.");
+    assert.equal(dupEntries[0][1].length, 2);
+
+    const files = new Set(dupEntries[0][1].map((o) => o.file));
+    assert.ok(files.has("skills/doc-a/SKILL.md"));
+    assert.ok(files.has("skills/doc-b/SKILL.md"));
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("scanSkills reports no duplicates when clean", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-validate-rules-"));
+  try {
+    const skillsDir = await writeSkillsDir(tempDir, {
+      "doc-a/SKILL.md": "You must run tests before pushing changes to the branch.",
+      "doc-b/SKILL.md": "You must check lint before merging to main branch.",
+    });
+    const repoRoot = tempDir;
+    const { duplicates } = await scanSkills(skillsDir, repoRoot);
+
+    assert.equal(duplicates.size, 0);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("scanSkills detects duplicate across three files", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-validate-rules-"));
+  try {
+    const skillsDir = await writeSkillsDir(tempDir, {
+      "doc-a/SKILL.md": "You must always run tests before pushing to main.",
+      "doc-b/SKILL.md": "You must always run tests before pushing to main.",
+      "doc-c/SKILL.md": "You must always run tests before pushing to main.",
+    });
+    const repoRoot = tempDir;
+    const { duplicates } = await scanSkills(skillsDir, repoRoot);
+
+    assert.equal(duplicates.size, 1);
+    const dupEntries = [...duplicates.entries()];
+    assert.equal(dupEntries[0][1].length, 3);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("scanSkills ignores same-file duplicates", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-validate-rules-"));
+  try {
+    const skillsDir = await writeSkillsDir(tempDir, {
+      "doc-a/SKILL.md": "You must run tests before pushing. You must run tests before pushing.",
+      "doc-b/SKILL.md": "Different content goes here for this file.",
+    });
+    const repoRoot = tempDir;
+    const { duplicates } = await scanSkills(skillsDir, repoRoot);
+
+    assert.equal(duplicates.size, 0);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("scanSkills handles empty skills tree", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-validate-rules-"));
+  try {
+    const skillsDir = path.join(tempDir, "skills");
+    await mkdir(skillsDir, { recursive: true });
+    const repoRoot = tempDir;
+    const { fileMap, duplicates } = await scanSkills(skillsDir, repoRoot);
+
+    assert.equal(fileMap.size, 0);
+    assert.equal(duplicates.size, 0);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("scanSkills skips canonical contract docs", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-validate-rules-"));
+  try {
+    const skillsDir = await writeSkillsDir(tempDir, {
+      "docs/copilot-loop-operations.md": "You must run tests before every push to main.",
+      "doc-a/SKILL.md": "You must run tests before every push to main.",
+    });
+    const repoRoot = tempDir;
+    const { duplicates } = await scanSkills(skillsDir, repoRoot);
+
+    // canonical contract doc is excluded, so no cross-file duplicate detected
+    assert.equal(duplicates.size, 0);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("collectMarkdownFiles finds markdown files recursively", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-validate-rules-"));
+  try {
+    const skillsDir = await writeSkillsDir(tempDir, {
+      "SKILL.md": "root",
+      "docs/contract.md": "contract",
+      "nested/deep/README.md": "nested",
+    });
+
+    const files = [];
+    for await (const f of collectMarkdownFiles(skillsDir, tempDir)) {
+      files.push(f);
+    }
+
+    assert.equal(files.length, 3);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/docs/validate-no-duplicate-rules.test.mjs
+++ b/test/docs/validate-no-duplicate-rules.test.mjs
@@ -234,6 +234,25 @@ test("scanSkills skips canonical contract docs", async () => {
   }
 });
 
+
+test("scanSkills excludes known intentional duplicates", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-validate-rules-"));
+  try {
+    // This sentence is in the KNOWN_INTENTIONAL_DUPLICATES set,
+    // so cross-file duplication should be suppressed.
+    const skillsDir = await writeSkillsDir(tempDir, {
+      "doc-a/SKILL.md": "If any required bundled contract doc is missing from the installed skill layout, treat that as a packaging/installer bug.",
+      "doc-b/SKILL.md": "If any required bundled contract doc is missing from the installed skill layout, treat that as a packaging/installer bug.",
+    });
+    const repoRoot = tempDir;
+    const { duplicates } = await scanSkills(skillsDir, repoRoot);
+
+    assert.equal(duplicates.size, 0);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("collectMarkdownFiles finds markdown files recursively", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-validate-rules-"));
   try {

--- a/test/docs/validate-no-duplicate-rules.test.mjs
+++ b/test/docs/validate-no-duplicate-rules.test.mjs
@@ -217,17 +217,34 @@ test("scanSkills handles empty skills tree", async () => {
   }
 });
 
-test("scanSkills skips canonical contract docs", async () => {
+test("scanSkills detects duplicate when non-canonical file restates canonical rule", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-validate-rules-"));
   try {
     const skillsDir = await writeSkillsDir(tempDir, {
-      "docs/copilot-loop-operations.md": "You must run tests before every push to main.",
-      "doc-a/SKILL.md": "You must run tests before every push to main.",
+      "docs/copilot-loop-operations.md": "You must run tests before every push to main and also verify the build output is correct.",
+      "doc-a/SKILL.md": "You must run tests before every push to main and also verify the build output is correct.",
     });
     const repoRoot = tempDir;
     const { duplicates } = await scanSkills(skillsDir, repoRoot);
 
-    // canonical contract doc is excluded, so no cross-file duplicate detected
+    // Non-canonical file duplicated a canonical rule: cross-file duplicate detected
+    assert.equal(duplicates.size, 1);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("scanSkills suppresses duplicates when all occurrences are canonical", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-validate-rules-"));
+  try {
+    const skillsDir = await writeSkillsDir(tempDir, {
+      "docs/copilot-loop-operations.md": "You must run tests before every push to main and also verify the build output is correct.",
+      "docs/public-dev-loop-contract.md": "You must run tests before every push to main and also verify the build output is correct.",
+    });
+    const repoRoot = tempDir;
+    const { duplicates } = await scanSkills(skillsDir, repoRoot);
+
+    // Both occurrences are in canonical contract docs — suppressed
     assert.equal(duplicates.size, 0);
   } finally {
     await rm(tempDir, { recursive: true, force: true });

--- a/test/docs/validate-no-duplicate-rules.test.mjs
+++ b/test/docs/validate-no-duplicate-rules.test.mjs
@@ -81,7 +81,7 @@ test("extractSentences skips markdown link URLs", () => {
     "See [the guide about required steps](https://example.com/must-read) for details. You must read the full documentation guide."
   );
   // Both sentences contain imperative keywords; link URLs removed
-  assert.ok(result.length >= 1);
+  assert.equal(result.length, 2);
   assert.ok(result.some((s) => s.text.includes("must read")));
 });
 


### PR DESCRIPTION
## Change summary

Add CI guardrail script `validate-no-duplicate-rules.mjs` that scans `skills/` for duplicated imperative rule text across Markdown files and exits non-zero when cross-file duplicates are found.

## Scope/context

Regression guardrail following #446 (dedup completed via PR #458). Without automated enforcement, duplication silently regresses as docs evolve. The script detects cross-file duplicates of sentences containing "must", "never", "do not", or "require"/"required" and reports them with file:line locations.

## Acceptance criteria

- [x] CI fails when same rule text appears in multiple skill/docs files
- [x] False positives handled (code blocks, inline code, link URLs, blockquotes, headings)
- [x] `npm test` passes (19 new tests)

## Definition of done

- [x] `scripts/docs/validate-no-duplicate-rules.mjs` created
- [x] `test/docs/validate-no-duplicate-rules.test.mjs` with 19 tests
- [x] Wired into `test:docs` in package.json (fatal; known intentional duplicates excluded via allowlist)
- [x] 5 known cross-skill duplicates documented as follow-up

## Non-goals

- Do not scan outside `skills/`
- Do not auto-fix or suggest fixes
- Do not add new CI job

Closes #457


