### PR TITLE
feat(#475): persistent conductor cycle — deterministic action queue

### DIFF
--- a/scripts/loop/conductor.mjs
+++ b/scripts/loop/conductor.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * Unified conductor entrypoint: runs the conductor cycle for gate-coordinated
+ * action queue AND monitors for auto-resume opportunities, combining both
+ * into a single operator-facing output.
+ *
+ * This is the recommended entrypoint for Pi parent agents running the conductor
+ * loop. It produces:
+ *   1. Ordered action queue from run-conductor-cycle (what to do, in what order)
+ *   2. Auto-resume plans from conductor-monitor (orphaned runs to resume)
+ *   3. Consolidated summary
+ *
+ * Usage:
+ *   conductor.mjs --repo <owner/name> [--auto-resume] [--cycle-only] [--monitor-only]
+ *
+ * --cycle-only    Only run the cycle (action queue); skip auto-resume scan
+ * --monitor-only  Only run the monitor; skip gate coordination
+ * --auto-resume   Enable auto-resume scanning (requires filesystem access)
+ */
+
+import { runConductorCycle } from "./run-conductor-cycle.mjs";
+import { runConductorMonitor } from "./conductor-monitor.mjs";
+import { requireOptionValue } from "../_cli-primitives.mjs";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+
+const USAGE = `Usage: conductor.mjs --repo <owner/name> [--auto-resume] [--cycle-only] [--monitor-only]
+
+Unified conductor entrypoint for dev-loop lifecycle orchestration.`.trim();
+
+const parseError = buildParseError(USAGE);
+
+function parseCliArgs(argv) {
+  const args = [...argv];
+  const options = {
+    help: false,
+    repo: undefined,
+    autoResume: false,
+    cycleOnly: false,
+    monitorOnly: false,
+  };
+
+  while (args.length > 0) {
+    const token = args.shift();
+
+    if (token === "--help" || token === "-h") {
+      options.help = true;
+      return options;
+    }
+
+    if (token === "--repo") {
+      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+      continue;
+    }
+
+    if (token === "--auto-resume") {
+      options.autoResume = true;
+      continue;
+    }
+
+    if (token === "--cycle-only") {
+      options.cycleOnly = true;
+      continue;
+    }
+
+    if (token === "--monitor-only") {
+      options.monitorOnly = true;
+      continue;
+    }
+
+    throw parseError(`Unknown argument: ${token}`);
+  }
+
+  if (options.repo === undefined) {
+    throw parseError("conductor requires --repo <owner/name>");
+  }
+
+  try {
+    parseRepoSlug(options.repo);
+  } catch (error) {
+    throw parseError(error instanceof Error ? error.message : String(error));
+  }
+
+  return options;
+}
+
+export async function runConductor(options, runtime = {}) {
+  const { cycleOnly = false, monitorOnly = false, autoResume = false } = options;
+  const runCycle = !monitorOnly;
+  const runMonitor = !cycleOnly;
+
+  // Run sequentially so gh stubs (and other shared state) don't race.
+  // Promise.all causes parallel gh calls that exhaust stub sequences.
+  const cycleResult = runCycle
+    ? await runConductorCycle({ repo: options.repo }, runtime).catch((error) => ({
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      }))
+    : null;
+
+  const monitorResult = runMonitor
+    ? await runConductorMonitor({ repo: options.repo, autoResume }, runtime).catch((error) => ({
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      }))
+    : null;
+
+  const cycleOk = cycleResult?.ok === true;
+  const monitorOk = monitorResult?.ok === true;
+
+  return {
+    ok: (runCycle ? cycleOk : true) && (runMonitor ? monitorOk : true),
+    repo: options.repo,
+    checkedAt: new Date().toISOString(),
+    cycle: cycleResult ?? null,
+    monitor: monitorResult ?? null,
+    cycleOk,
+    monitorOk,
+    summary: {
+      totalPrs: (cycleResult?.prCount ?? 0) || (monitorResult?.prCount ?? 0),
+      cycleActions: cycleResult?.actions?.length ?? 0,
+      needsSubagent: cycleResult?.summary?.needsSubagent ?? 0,
+      readyToMerge: cycleResult?.summary?.readyToMerge ?? 0,
+      waiting: cycleResult?.summary?.waiting ?? 0,
+      blocked: cycleResult?.summary?.blocked ?? 0,
+      done: cycleResult?.summary?.done ?? 0,
+      errors: cycleResult?.summary?.errors ?? 0,
+      queueStatus: monitorResult?.queueStatus ?? "unknown",
+      needsAttentionCount: monitorResult?.needsAttentionCount ?? 0,
+      orphanedPrCount: monitorResult?.orphanedPrCount ?? 0,
+      resumePlanCount: monitorResult?.resumePlanCount ?? 0,
+      manualAttentionCount: monitorResult?.manualAttentionCount ?? 0,
+    },
+  };
+}
+
+export async function runCli(
+  argv = process.argv.slice(2),
+  {
+    stdout = process.stdout,
+    env = process.env,
+    ghCommand = "gh",
+    cwd = process.cwd(),
+  } = {},
+) {
+  const options = parseCliArgs(argv);
+
+  if (options.help) {
+    stdout.write(`${USAGE}\n`);
+    return;
+  }
+
+  const result = await runConductor(options, {
+    env,
+    ghCommand,
+    repoRoot: cwd,
+  });
+  stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli().catch((error) => {
+    process.stderr.write(`${formatCliError(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/loop/conductor.mjs
+++ b/scripts/loop/conductor.mjs
@@ -23,12 +23,33 @@ import { runConductorMonitor } from "./conductor-monitor.mjs";
 import { requireOptionValue } from "../_cli-primitives.mjs";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 
 const USAGE = `Usage: conductor.mjs --repo <owner/name> [--auto-resume] [--cycle-only] [--monitor-only]
 
 Unified conductor entrypoint for dev-loop lifecycle orchestration.`.trim();
 
 const parseError = buildParseError(USAGE);
+
+function checkRetrospectiveGate(cwd) {
+  try {
+    const checkpointPath = path.join(cwd, ".pi", "dev-loop-retrospective-checkpoint.json");
+    const checkpointText = readFileSync(checkpointPath, "utf8");
+    const checkpoint = JSON.parse(checkpointText);
+    const state = typeof checkpoint?.state === "string" ? checkpoint.state.trim().toLowerCase() : null;
+    if (state === "required" || state === "missing") {
+      return {
+        blocked: true,
+        reason: `Retrospective checkpoint pending (state: ${state}). Complete the retrospective before running the conductor.`,
+      };
+    }
+    return { blocked: false };
+  } catch (err) {
+    if (err?.code === "ENOENT") return { blocked: false };
+    return { blocked: true, reason: `Cannot read retrospective checkpoint: ${err.message}` };
+  }
+}
 
 function parseCliArgs(argv) {
   const args = [...argv];
@@ -86,6 +107,19 @@ function parseCliArgs(argv) {
 
 export async function runConductor(options, runtime = {}) {
   const { cycleOnly = false, monitorOnly = false, autoResume = false } = options;
+  const cwd = runtime.repoRoot || process.cwd();
+
+  const retroGate = checkRetrospectiveGate(cwd);
+  if (retroGate.blocked) {
+    return {
+      ok: false,
+      error: retroGate.reason,
+      repo: options.repo,
+      blockedByRetrospective: true,
+      checkedAt: new Date().toISOString(),
+    };
+  }
+
   const runCycle = !monitorOnly;
   const runMonitor = !cycleOnly;
 

--- a/scripts/loop/conductor.mjs
+++ b/scripts/loop/conductor.mjs
@@ -23,6 +23,12 @@ import { runConductorMonitor } from "./conductor-monitor.mjs";
 import { requireOptionValue } from "../_cli-primitives.mjs";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import {
+  loadDevLoopConfig,
+  resolveWorkflowConfig,
+  resolveAutonomyStopAt,
+  resolveGateConfig,
+} from "@pi-dev-loops/core/config";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 
@@ -32,7 +38,16 @@ Unified conductor entrypoint for dev-loop lifecycle orchestration.`.trim();
 
 const parseError = buildParseError(USAGE);
 
-function checkRetrospectiveGate(cwd) {
+/**
+ * Check the retrospective checkpoint gate.
+ * Only blocks when requireRetrospective is true AND checkpoint state is required/missing.
+ * @param {string} cwd - Repo root
+ * @param {boolean} requireRetrospective - Config gate flag
+ * @returns {{ blocked: boolean, reason?: string }}
+ */
+function checkRetrospectiveGate(cwd, requireRetrospective) {
+  if (!requireRetrospective) return { blocked: false };
+
   try {
     const checkpointPath = path.join(cwd, ".pi", "dev-loop-retrospective-checkpoint.json");
     const checkpointText = readFileSync(checkpointPath, "utf8");
@@ -105,11 +120,42 @@ function parseCliArgs(argv) {
   return options;
 }
 
+/**
+ * @param {object} options
+ * @param {object} runtime
+ * @param {object} [runtime.loadConfigImpl] - injectable config loader for tests
+ */
 export async function runConductor(options, runtime = {}) {
   const { cycleOnly = false, monitorOnly = false, autoResume = false } = options;
   const cwd = runtime.repoRoot || process.cwd();
+  const loadConfig = runtime.loadConfigImpl || loadDevLoopConfig;
 
-  const retroGate = checkRetrospectiveGate(cwd);
+  // Load config once at startup and share with all sub-components
+  let configLoadResult;
+  let requireRetrospective = false;
+  let autonomyStopAt = ["merge"];
+  /** @type {{ draft: { requireCi: boolean } | null, preApproval: { requireCi: boolean } | null }} */
+  let gateConfig = { draft: null, preApproval: null };
+
+  try {
+    configLoadResult = await loadConfig({ repoRoot: cwd });
+    const cfg = configLoadResult.config ?? {};
+
+    requireRetrospective = resolveWorkflowConfig(cfg, "requireRetrospective");
+    autonomyStopAt = resolveAutonomyStopAt(cfg);
+
+    const draftCfg = resolveGateConfig(cfg, "draft");
+    const preApprovalCfg = resolveGateConfig(cfg, "preApproval");
+    gateConfig = {
+      draft: { requireCi: draftCfg.requireCi },
+      preApproval: { requireCi: preApprovalCfg.requireCi },
+    };
+  } catch {
+    // Config load failed — use safe defaults (no retrospective block, stop at merge)
+    configLoadResult = { config: null, warnings: [], errors: [{ path: "<config>", message: "Failed to load config", layer: "merged" }] };
+  }
+
+  const retroGate = checkRetrospectiveGate(cwd, requireRetrospective);
   if (retroGate.blocked) {
     return {
       ok: false,
@@ -126,7 +172,7 @@ export async function runConductor(options, runtime = {}) {
   // Run sequentially so gh stubs (and other shared state) don't race.
   // Promise.all causes parallel gh calls that exhaust stub sequences.
   const cycleResult = runCycle
-    ? await runConductorCycle({ repo: options.repo }, runtime).catch((error) => ({
+    ? await runConductorCycle({ repo: options.repo, autonomyStopAt, gateConfig }, runtime).catch((error) => ({
         ok: false,
         error: error instanceof Error ? error.message : String(error),
       }))
@@ -150,6 +196,12 @@ export async function runConductor(options, runtime = {}) {
     monitor: monitorResult ?? null,
     cycleOk,
     monitorOk,
+    config: {
+      requireRetrospective,
+      autonomyStopAt,
+      gateConfig,
+      configErrors: configLoadResult?.errors?.length ?? 0,
+    },
     summary: {
       totalPrs: (cycleResult?.prCount ?? 0) || (monitorResult?.prCount ?? 0),
       cycleActions: cycleResult?.actions?.length ?? 0,

--- a/scripts/loop/run-conductor-cycle.mjs
+++ b/scripts/loop/run-conductor-cycle.mjs
@@ -1,0 +1,413 @@
+#!/usr/bin/env node
+/**
+ * Deterministic conductor cycle: polls all open PRs, detects state via
+ * existing detectors and gate coordination, and outputs an ordered action
+ * queue for the Pi parent agent to consume.
+ *
+ * Node scripts CANNOT spawn subagents. This script is read-only: it produces
+ * the queue; the Pi parent agent (or a conductor agent) reads the queue and
+ * spawns subagents or executes merges based on the action type.
+ *
+ * Usage:
+ *   run-conductor-cycle.mjs --repo <owner/name>
+ *
+ * Output (stdout, JSON):
+ *   {
+ *     "ok": true,
+ *     "repo": "owner/repo",
+ *     "checkedAt": "<ISO>",
+ *     "prCount": N,
+ *     "actions": [
+ *       {
+ *         "pr": N, "title": "...", "url": "...", "isDraft": bool, "headRefName": "...",
+ *         "action": "fix_threads"|"draft_gate"|"request_review"|"rerequest_review"|
+ *                   "run_pre_approval"|"watch"|"merge"|"await_approval"|
+ *                   "resolve_conflicts"|"blocked"|"done"|"error",
+ *         "priority": N, "state": "...", "lifecycleState": "...",
+ *         "loopDisposition": "...", "gateBoundary": "...", "reason": "...",
+ *         "snapshot": {...}, "gateState": {...}, "requiresSubagent": bool
+ *       }
+ *     ],
+ *     "summary": { "needsSubagent": N, "readyToMerge": N, "waiting": N,
+ *                   "blocked": N, "done": N, "errors": N }
+ *   }
+ */
+
+import { runChild, requireOptionValue } from "../_cli-primitives.mjs";
+import {
+  buildParseError,
+  formatCliError,
+  isDirectCliRun,
+  parseJsonText,
+} from "../_core-helpers.mjs";
+import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { detectPrGateCoordinationState } from "./detect-pr-gate-coordination-state.mjs";
+import { autoDetectSnapshot } from "./detect-copilot-loop-state.mjs";
+import { PR_GATE_ACTION } from "@pi-dev-loops/core/loop/pr-gate-coordination";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const USAGE = `Usage: run-conductor-cycle.mjs --repo <owner/name>
+
+Poll all open PRs, detect state, and output an ordered action queue.`.trim();
+
+const OPEN_PR_LIST_LIMIT = 1000;
+
+/**
+ * Map PR_GATE_ACTION values to conductor action types.
+ *
+ * Subagent-requiring actions: fix_threads, draft_gate, request_review,
+ *   rerequest_review, run_pre_approval
+ * Parent-executable actions: merge (gh pr merge), watch (poll),
+ *   await_approval (stop), resolve_conflicts (stop), blocked (stop), done (stop)
+ */
+export const GATE_ACTION_TO_CONDUCTOR_ACTION = Object.freeze({
+  [PR_GATE_ACTION.ADDRESS_REVIEW_FEEDBACK]: "fix_threads",
+  [PR_GATE_ACTION.REPLY_RESOLVE_REVIEW_THREADS]: "fix_threads",
+  [PR_GATE_ACTION.RUN_DRAFT_GATE]: "draft_gate",
+  [PR_GATE_ACTION.RECONCILE_DRAFT_GATE]: "draft_gate",
+  [PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE]: "run_pre_approval",
+  [PR_GATE_ACTION.MARK_READY_FOR_REVIEW]: "request_review",
+  [PR_GATE_ACTION.REQUEST_COPILOT_REVIEW]: "request_review",
+  [PR_GATE_ACTION.REREQUEST_COPILOT_REVIEW]: "rerequest_review",
+  [PR_GATE_ACTION.WAIT_FOR_COPILOT_REVIEW]: "watch",
+  [PR_GATE_ACTION.WAIT_FOR_CI]: "watch",
+  [PR_GATE_ACTION.DECLARE_MERGE_READY]: "merge",
+  [PR_GATE_ACTION.AWAIT_FINAL_HUMAN_APPROVAL]: "await_approval",
+  [PR_GATE_ACTION.RESOLVE_MERGE_CONFLICTS]: "resolve_conflicts",
+  [PR_GATE_ACTION.REPORT_BLOCKED]: "blocked",
+  [PR_GATE_ACTION.REPORT_DONE]: "done",
+});
+
+/**
+ * Priority for each conductor action type. Higher = process first.
+ */
+export const ACTION_PRIORITY = Object.freeze({
+  merge: 100,
+  fix_threads: 90,
+  run_pre_approval: 80,
+  draft_gate: 70,
+  request_review: 60,
+  rerequest_review: 50,
+  watch: 30,
+  await_approval: 20,
+  resolve_conflicts: 10,
+  blocked: 10,
+  done: 0,
+  error: -1,
+});
+
+/**
+ * Actions that require spawning a dev-loop subagent by the Pi parent.
+ */
+export const SUBAGENT_ACTIONS = new Set([
+  "fix_threads",
+  "draft_gate",
+  "request_review",
+  "rerequest_review",
+  "run_pre_approval",
+]);
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+const parseError = buildParseError(USAGE);
+
+export function parseCliArgs(argv) {
+  const args = [...argv];
+  const options = {
+    help: false,
+    repo: undefined,
+  };
+
+  while (args.length > 0) {
+    const token = args.shift();
+
+    if (token === "--help" || token === "-h") {
+      options.help = true;
+      return options;
+    }
+
+    if (token === "--repo") {
+      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+      continue;
+    }
+
+    throw parseError(`Unknown argument: ${token}`);
+  }
+
+  if (options.repo === undefined) {
+    throw parseError("run-conductor-cycle requires --repo <owner/name>");
+  }
+
+  try {
+    parseRepoSlug(options.repo);
+  } catch (error) {
+    throw parseError(error instanceof Error ? error.message : String(error));
+  }
+
+  return options;
+}
+
+// ---------------------------------------------------------------------------
+// PR listing
+// ---------------------------------------------------------------------------
+
+export async function listOpenPrs({ repo }, { env, ghCommand }) {
+  const result = await runChild(
+    ghCommand,
+    [
+      "pr",
+      "list",
+      "--repo",
+      repo,
+      "--state",
+      "open",
+      "--limit",
+      String(OPEN_PR_LIST_LIMIT),
+      "--json",
+      "number,title,url,isDraft,headRefName,author",
+    ],
+    env,
+  );
+
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw new Error(`gh command failed: ${detail}`);
+  }
+
+  const payload = parseJsonText(result.stdout);
+  if (!Array.isArray(payload)) {
+    throw new Error("Invalid gh pr list payload: expected an array");
+  }
+
+  return payload
+    .map((pr) => ({
+      number: Number.isInteger(pr?.number) ? pr.number : null,
+      title: typeof pr?.title === "string" ? pr.title : "",
+      url: typeof pr?.url === "string" ? pr.url : null,
+      isDraft: Boolean(pr?.isDraft),
+      headRefName: typeof pr?.headRefName === "string" ? pr.headRefName : null,
+      authorLogin: typeof pr?.author?.login === "string" ? pr.author.login : null,
+    }))
+    .filter((pr) => pr.number !== null)
+    .sort((left, right) => left.number - right.number);
+}
+
+// ---------------------------------------------------------------------------
+// Per-PR detection (injectable for testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect state for a single PR.
+ *
+ * Accepts injectable detection functions so tests can supply mocks.
+ */
+export async function detectPrState(
+  pr,
+  {
+    repo,
+    env,
+    ghCommand,
+    repoRoot,
+    detectGateImpl = detectPrGateCoordinationState,
+    detectSnapshotImpl = autoDetectSnapshot,
+  },
+) {
+  try {
+    const gateState = await detectGateImpl(
+      { repo, pr: pr.number },
+      { env, ghCommand, repoRoot },
+    );
+
+    let snapshot = null;
+    try {
+      snapshot = await detectSnapshotImpl(
+        { repo, pr: pr.number },
+        { env, ghCommand },
+      );
+    } catch {
+      // Snapshot is supplementary; gate state is primary
+    }
+
+    const action = GATE_ACTION_TO_CONDUCTOR_ACTION[gateState.nextAction] ?? "error";
+    const priority = ACTION_PRIORITY[action] ?? -1;
+
+    return {
+      pr: pr.number,
+      title: pr.title,
+      url: pr.url,
+      isDraft: pr.isDraft,
+      headRefName: pr.headRefName,
+      action,
+      priority,
+      state: gateState.lifecycleState,
+      lifecycleState: gateState.lifecycleState,
+      loopDisposition: gateState.loopDisposition,
+      gateBoundary: gateState.gateBoundary,
+      reason: gateState.reason ?? null,
+      snapshot: snapshot ?? null,
+      gateState: {
+        allowedNextActions: gateState.allowedNextActions,
+        forbiddenActions: gateState.forbiddenActions,
+        draftGate: gateState.draftGate ?? null,
+        preApprovalGate: gateState.preApprovalGate ?? null,
+        mergeStateStatus: gateState.mergeStateStatus ?? null,
+        conflictFiles: gateState.conflictFiles ?? [],
+        currentHeadSha: gateState.currentHeadSha ?? null,
+        ciStatus: snapshot?.ciStatus ?? null,
+      },
+      requiresSubagent: SUBAGENT_ACTIONS.has(action),
+    };
+  } catch (error) {
+    return {
+      pr: pr.number,
+      title: pr.title,
+      url: pr.url,
+      isDraft: pr.isDraft,
+      headRefName: pr.headRefName,
+      action: "error",
+      priority: ACTION_PRIORITY.error,
+      state: null,
+      lifecycleState: null,
+      loopDisposition: null,
+      gateBoundary: null,
+      reason: null,
+      snapshot: null,
+      gateState: null,
+      requiresSubagent: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Queue building
+// ---------------------------------------------------------------------------
+
+/**
+ * Build ordered action queue from detection results.
+ * Sort: priority descending, then PR number ascending for stability.
+ */
+export function buildActionQueue(detectionResults) {
+  return [...detectionResults].sort((left, right) => {
+    const priorityDiff = right.priority - left.priority;
+    if (priorityDiff !== 0) {
+      return priorityDiff;
+    }
+    return left.pr - right.pr;
+  });
+}
+
+/**
+ * Build summary statistics from the action queue.
+ */
+export function buildSummary(actions) {
+  const summary = {
+    needsSubagent: 0,
+    readyToMerge: 0,
+    waiting: 0,
+    blocked: 0,
+    done: 0,
+    errors: 0,
+  };
+
+  for (const action of actions) {
+    switch (action.action) {
+      case "error":
+        summary.errors += 1;
+        break;
+      case "merge":
+        summary.readyToMerge += 1;
+        break;
+      case "watch":
+        summary.waiting += 1;
+        break;
+      case "done":
+        summary.done += 1;
+        break;
+      case "blocked":
+      case "resolve_conflicts":
+      case "await_approval":
+        summary.blocked += 1;
+        break;
+      default:
+        break;
+    }
+
+    if (action.requiresSubagent) {
+      summary.needsSubagent += 1;
+    }
+  }
+
+  return summary;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+export async function runConductorCycle(
+  { repo },
+  {
+    env = process.env,
+    ghCommand = "gh",
+    repoRoot = process.cwd(),
+    listPrsImpl = listOpenPrs,
+    detectPrStateImpl = detectPrState,
+  } = {},
+) {
+  const prs = await listPrsImpl({ repo }, { env, ghCommand });
+
+  const detectionResults = [];
+  for (const pr of prs) {
+    const result = await detectPrStateImpl(pr, { repo, env, ghCommand, repoRoot });
+    detectionResults.push(result);
+  }
+
+  const actions = buildActionQueue(detectionResults);
+  const summary = buildSummary(actions);
+
+  return {
+    ok: true,
+    repo,
+    checkedAt: new Date().toISOString(),
+    prCount: prs.length,
+    actions,
+    summary,
+  };
+}
+
+export async function runCli(
+  argv = process.argv.slice(2),
+  {
+    stdout = process.stdout,
+    env = process.env,
+    ghCommand = "gh",
+    cwd = process.cwd(),
+  } = {},
+) {
+  const options = parseCliArgs(argv);
+
+  if (options.help) {
+    stdout.write(`${USAGE}\n`);
+    return;
+  }
+
+  const result = await runConductorCycle(options, {
+    env,
+    ghCommand,
+    repoRoot: cwd,
+  });
+  stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli().catch((error) => {
+    process.stderr.write(`${formatCliError(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/loop/run-conductor-cycle.mjs
+++ b/scripts/loop/run-conductor-cycle.mjs
@@ -25,7 +25,8 @@
  *                   "resolve_conflicts"|"blocked"|"done"|"error",
  *         "priority": N, "state": "...", "lifecycleState": "...",
  *         "loopDisposition": "...", "gateBoundary": "...", "reason": "...",
- *         "snapshot": {...}, "gateState": {...}, "requiresSubagent": bool
+ *         "snapshot": {...}, "gateState": {...}, "requiresSubagent": bool,
+ *         "requiresApproval": bool
  *       }
  *     ],
  *     "summary": { "needsSubagent": N, "readyToMerge": N, "waiting": N,
@@ -109,6 +110,41 @@ export const SUBAGENT_ACTIONS = new Set([
   "rerequest_review",
   "run_pre_approval",
 ]);
+
+/**
+ * Map autonomy.stopAt gates to the conductor actions that require approval.
+ *
+ * When a gate is in autonomy.stopAt, the corresponding actions are flagged
+ * with requiresApproval: true. The parent agent must obtain explicit operator
+ * authorization before executing those actions.
+ *
+ * Gate → conductor action mapping:
+ *   "merge"        → merge
+ *   "pre-approval" → run_pre_approval
+ *   "draft-pr"     → draft_gate, request_review, rerequest_review
+ *   "refinement"   → n/a (refinement happens before the conductor lifecycle)
+ */
+export const AUTONOMY_GATE_ACTION_MAP = Object.freeze({
+  merge: ["merge"],
+  "pre-approval": ["run_pre_approval"],
+  "draft-pr": ["draft_gate", "request_review", "rerequest_review"],
+  refinement: [],
+});
+
+/**
+ * Determine whether a conductor action requires operator approval based on
+ * the configured autonomy stop-at list.
+ *
+ * @param {string} action - Conductor action name
+ * @param {string[]} autonomyStopAt - Configured stop-at gates (e.g. ["merge"])
+ * @returns {boolean}
+ */
+export function actionRequiresApproval(action, autonomyStopAt = ["merge"]) {
+  const stopSet = new Set(
+    autonomyStopAt.flatMap((gate) => AUTONOMY_GATE_ACTION_MAP[gate] ?? [])
+  );
+  return stopSet.has(action);
+}
 
 // ---------------------------------------------------------------------------
 // Argument parsing
@@ -205,6 +241,10 @@ export async function listOpenPrs({ repo }, { env, ghCommand }) {
  * Detect state for a single PR.
  *
  * Accepts injectable detection functions so tests can supply mocks.
+ *
+ * @param {object} pr
+ * @param {object} opts
+ * @param {string[]} [opts.autonomyStopAt] - Configured autonomy stop-at gates
  */
 export async function detectPrState(
   pr,
@@ -215,6 +255,7 @@ export async function detectPrState(
     repoRoot,
     detectGateImpl = detectPrGateCoordinationState,
     detectSnapshotImpl = autoDetectSnapshot,
+    autonomyStopAt = ["merge"],
   },
 ) {
   try {
@@ -235,6 +276,7 @@ export async function detectPrState(
 
     const action = GATE_ACTION_TO_CONDUCTOR_ACTION[gateState.nextAction] ?? "error";
     const priority = ACTION_PRIORITY[action] ?? -1;
+    const requiresApproval = actionRequiresApproval(action, autonomyStopAt);
 
     return {
       pr: pr.number,
@@ -261,6 +303,7 @@ export async function detectPrState(
         ciStatus: snapshot?.ciStatus ?? null,
       },
       requiresSubagent: SUBAGENT_ACTIONS.has(action),
+      requiresApproval,
     };
   } catch (error) {
     return {
@@ -279,6 +322,7 @@ export async function detectPrState(
       snapshot: null,
       gateState: null,
       requiresSubagent: false,
+      requiresApproval: false,
       error: error instanceof Error ? error.message : String(error),
     };
   }
@@ -350,8 +394,12 @@ export function buildSummary(actions) {
 // Main
 // ---------------------------------------------------------------------------
 
+/**
+ * @param {{ repo: string, autonomyStopAt?: string[], gateConfig?: object }} params
+ * @param {object} runtime
+ */
 export async function runConductorCycle(
-  { repo },
+  { repo, autonomyStopAt, gateConfig },
   {
     env = process.env,
     ghCommand = "gh",
@@ -362,9 +410,16 @@ export async function runConductorCycle(
 ) {
   const prs = await listPrsImpl({ repo }, { env, ghCommand });
 
+  const stopAt = autonomyStopAt ?? ["merge"];
   const detectionResults = [];
   for (const pr of prs) {
-    const result = await detectPrStateImpl(pr, { repo, env, ghCommand, repoRoot });
+    const result = await detectPrStateImpl(pr, {
+      repo,
+      env,
+      ghCommand,
+      repoRoot,
+      autonomyStopAt: stopAt,
+    });
     detectionResults.push(result);
   }
 
@@ -378,6 +433,8 @@ export async function runConductorCycle(
     prCount: prs.length,
     actions,
     summary,
+    ...(gateConfig ? { gateConfig } : {}),
+    autonomyStopAt: stopAt,
   };
 }
 

--- a/test/loop/conductor-integration.test.mjs
+++ b/test/loop/conductor-integration.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -9,6 +9,205 @@ import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_
 
 const scriptPath = path.resolve("scripts/loop/conductor.mjs");
 const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
+
+// ---------------------------------------------------------------------------
+// Config stub helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Write a minimal .pi/dev-loop/settings.yaml and return cleanup helper.
+ */
+async function setupConfigDir(requireRetrospective = false, extraSettings = {}) {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-config-"));
+  const configDir = path.join(tempDir, ".pi", "dev-loop");
+  await mkdir(configDir, { recursive: true });
+
+  const settings = {
+    version: 1,
+    workflow: {
+      requireRetrospective,
+      requireDraftFirst: false,
+      devModeDefault: false,
+    },
+    ...extraSettings,
+  };
+
+  // Simple YAML writer for test configs
+  const yamlLines = [];
+  for (const [k, v] of Object.entries(settings)) {
+    if (v === undefined || v === null) continue;
+    if (typeof v === "object" && v !== null && !Array.isArray(v)) {
+      yamlLines.push(`${k}:`);
+      for (const [sk, sv] of Object.entries(v)) {
+        yamlLines.push(`  ${sk}: ${typeof sv === "boolean" ? sv : JSON.stringify(sv)}`);
+      }
+    } else if (Array.isArray(v)) {
+      yamlLines.push(`${k}:`);
+      for (const item of v) {
+        yamlLines.push(`  - ${typeof item === "string" ? item : JSON.stringify(item)}`);
+      }
+    } else {
+      yamlLines.push(`${k}: ${typeof v === "boolean" ? v : JSON.stringify(v)}`);
+    }
+  }
+
+  await writeFile(path.join(configDir, "settings.yaml"), yamlLines.join("\n"), "utf8");
+
+  return {
+    repoRoot: tempDir,
+    configDir,
+    cleanup: async () => { await rm(tempDir, { recursive: true, force: true }); },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Unit: retrospective gate with config
+// ---------------------------------------------------------------------------
+
+test("runConductor blocks when requireRetrospective is true and checkpoint is required", async () => {
+  const { repoRoot, cleanup } = await setupConfigDir(true);
+
+  try {
+    const piDir = path.join(repoRoot, ".pi");
+    await mkdir(piDir, { recursive: true });
+    await writeFile(
+      path.join(piDir, "dev-loop-retrospective-checkpoint.json"),
+      JSON.stringify({ state: "required", runId: "test-run" }),
+    );
+
+    const fakeLoadConfig = async () => ({
+      config: {
+        version: 1,
+        workflow: { requireRetrospective: true, requireDraftFirst: false, devModeDefault: false },
+        autonomy: { stopAt: ["merge"] },
+        gates: { draft: { requireCi: true }, preApproval: { requireCi: true } },
+      },
+      warnings: [],
+      errors: [],
+    });
+
+    const result = await runConductor(
+      { repo: "test/repo", cycleOnly: true, monitorOnly: false, autoResume: false },
+      { env: process.env, ghCommand: "gh", repoRoot, loadConfigImpl: fakeLoadConfig },
+    );
+
+    assert.equal(result.ok, false);
+    assert.equal(result.blockedByRetrospective, true);
+    assert.match(result.error, /Retrospective checkpoint pending/);
+    assert.equal(result.cycle, undefined);
+    assert.equal(result.monitor, undefined);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("runConductor does NOT block when requireRetrospective is false even if checkpoint is required", async () => {
+  const { repoRoot, cleanup } = await setupConfigDir(false);
+
+  try {
+    const piDir = path.join(repoRoot, ".pi");
+    await mkdir(piDir, { recursive: true });
+    await writeFile(
+      path.join(piDir, "dev-loop-retrospective-checkpoint.json"),
+      JSON.stringify({ state: "required", runId: "test-run" }),
+    );
+
+    const fakeLoadConfig = async () => ({
+      config: {
+        version: 1,
+        workflow: { requireRetrospective: false, requireDraftFirst: false, devModeDefault: false },
+        autonomy: { stopAt: ["merge"] },
+        gates: { draft: { requireCi: true }, preApproval: { requireCi: true } },
+      },
+      warnings: [],
+      errors: [],
+    });
+
+    const result = await runConductor(
+      { repo: "test/repo", cycleOnly: true, monitorOnly: false, autoResume: false },
+      { env: process.env, ghCommand: "gh", repoRoot, loadConfigImpl: fakeLoadConfig },
+    );
+
+    assert.equal(result.blockedByRetrospective, undefined);
+    assert.equal(result.monitor, null);
+    assert.ok(result.cycle !== null);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("runConductor does NOT block when checkpoint file is missing regardless of requireRetrospective", async () => {
+  const { repoRoot, cleanup } = await setupConfigDir(true);
+
+  try {
+    // No checkpoint file at all
+    const fakeLoadConfig = async () => ({
+      config: {
+        version: 1,
+        workflow: { requireRetrospective: true, requireDraftFirst: false, devModeDefault: false },
+        autonomy: { stopAt: ["merge"] },
+        gates: { draft: { requireCi: true }, preApproval: { requireCi: true } },
+      },
+      warnings: [],
+      errors: [],
+    });
+
+    const result = await runConductor(
+      { repo: "test/repo", cycleOnly: true, monitorOnly: false, autoResume: false },
+      { env: process.env, ghCommand: "gh", repoRoot, loadConfigImpl: fakeLoadConfig },
+    );
+
+    assert.equal(result.blockedByRetrospective, undefined);
+    assert.equal(result.monitor, null);
+    assert.ok(result.cycle !== null);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("runConductor includes config in output", async () => {
+  const { repoRoot, cleanup } = await setupConfigDir(true);
+
+  try {
+    const fakeLoadConfig = async () => ({
+      config: {
+        version: 1,
+        workflow: { requireRetrospective: true, requireDraftFirst: true, devModeDefault: true },
+        autonomy: { stopAt: ["merge", "pre-approval"] },
+        gates: { draft: { requireCi: false }, preApproval: { requireCi: true } },
+      },
+      warnings: [],
+      errors: [],
+    });
+
+    const result = await runConductor(
+      { repo: "test/repo", cycleOnly: true, monitorOnly: false, autoResume: false },
+      { env: process.env, ghCommand: "gh", repoRoot, loadConfigImpl: fakeLoadConfig },
+    );
+
+    assert.equal(result.config.requireRetrospective, true);
+    assert.deepEqual(result.config.autonomyStopAt, ["merge", "pre-approval"]);
+    assert.equal(result.config.gateConfig.draft.requireCi, false);
+    assert.equal(result.config.gateConfig.preApproval.requireCi, true);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("runConductor handles config load failure gracefully with safe defaults", async () => {
+  const fakeLoadConfig = async () => { throw new Error("Config file corrupted"); };
+
+  const result = await runConductor(
+    { repo: "test/repo", cycleOnly: true, monitorOnly: false, autoResume: false },
+    { env: process.env, ghCommand: "gh", repoRoot: process.cwd(), loadConfigImpl: fakeLoadConfig },
+  );
+
+  assert.equal(result.config.requireRetrospective, false);
+  assert.deepEqual(result.config.autonomyStopAt, ["merge"]);
+  assert.equal(result.config.configErrors, 1);
+  assert.equal(result.monitor, null);
+  assert.ok(result.cycle !== null);
+});
 
 // ---------------------------------------------------------------------------
 // Unit: runConductor with real gh unavailable (graceful degradation)
@@ -25,7 +224,6 @@ test("runConductor degrades gracefully with cycle-only", async () => {
   );
 
   assert.equal(result.monitor, null);
-  // cycle will fail because no real gh, but structure should be present
   assert.ok(result.cycle !== null);
   assert.ok("ok" in result.cycle || "error" in (result.cycle ?? {}));
 });
@@ -100,7 +298,6 @@ test("conductor CLI with both cycle and monitor uses repeat-last for sequential 
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-both-"));
 
   try {
-    // repeatLastOnOverflow so both cycle and monitor can consume the same stub
     const { env } = await writeGhStubHelper(tempDir, [{
       assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "1000", "--json", "number,title,url,isDraft,headRefName,author"],
       stdout: "[]\n",
@@ -113,7 +310,6 @@ test("conductor CLI with both cycle and monitor uses repeat-last for sequential 
 
     const payload = JSON.parse(stdout);
     assert.equal(payload.ok, true);
-    // Both cycle and monitor should report 0 PRs
     assert.equal(payload.cycle.prCount, 0);
     assert.equal(payload.cycle.actions.length, 0);
     assert.equal(payload.monitor.queueStatus, "queue_complete");

--- a/test/loop/conductor-integration.test.mjs
+++ b/test/loop/conductor-integration.test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { runConductor } from "../../scripts/loop/conductor.mjs";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
+
+const scriptPath = path.resolve("scripts/loop/conductor.mjs");
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
+
+// ---------------------------------------------------------------------------
+// Unit: runConductor with real gh unavailable (graceful degradation)
+// ---------------------------------------------------------------------------
+
+test("runConductor degrades gracefully with cycle-only", async () => {
+  const result = await runConductor(
+    { repo: "test/repo", cycleOnly: true, monitorOnly: false, autoResume: false },
+    {
+      env: process.env,
+      ghCommand: "gh",
+      repoRoot: process.cwd(),
+    },
+  );
+
+  assert.equal(result.monitor, null);
+  // cycle will fail because no real gh, but structure should be present
+  assert.ok(result.cycle !== null);
+  assert.ok("ok" in result.cycle || "error" in (result.cycle ?? {}));
+});
+
+test("runConductor degrades gracefully with monitor-only", async () => {
+  const result = await runConductor(
+    { repo: "test/repo", cycleOnly: false, monitorOnly: true, autoResume: false },
+    {
+      env: process.env,
+      ghCommand: "gh",
+      repoRoot: process.cwd(),
+    },
+  );
+
+  assert.equal(result.cycle, null);
+  assert.ok(result.monitor !== null);
+});
+
+// ---------------------------------------------------------------------------
+// CLI: gh stub integration (cycle-only to avoid parallel gh consumption)
+// ---------------------------------------------------------------------------
+
+test("conductor --cycle-only CLI reports empty queue when no open PRs exist", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-cycle-only-"));
+
+  try {
+    const { env } = await writeGhStubHelper(tempDir, [{
+      assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "1000", "--json", "number,title,url,isDraft,headRefName,author"],
+      stdout: "[]\n",
+    }]);
+
+    const { code, stdout, stderr } = await runNode(["--repo", "owner/repo", "--cycle-only"], { env });
+
+    assert.equal(code, 0);
+    assert.equal(stderr, "");
+
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.monitor, null);
+    assert.equal(payload.cycle.prCount, 0);
+    assert.deepEqual(payload.cycle.actions, []);
+    assert.equal(payload.summary.totalPrs, 0);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor --monitor-only CLI reports queue_complete when no open PRs exist", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-only-"));
+
+  try {
+    const { env } = await writeGhStubHelper(tempDir, [{
+      assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "1000", "--json", "number,title,url,isDraft,headRefName,author"],
+      stdout: "[]\n",
+    }]);
+
+    const { code, stdout, stderr } = await runNode(["--repo", "owner/repo", "--monitor-only"], { env });
+
+    assert.equal(code, 0);
+    assert.equal(stderr, "");
+
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.cycle, null);
+    assert.equal(payload.monitor.queueStatus, "queue_complete");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor CLI with both cycle and monitor uses repeat-last for sequential gh calls", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-both-"));
+
+  try {
+    // repeatLastOnOverflow so both cycle and monitor can consume the same stub
+    const { env } = await writeGhStubHelper(tempDir, [{
+      assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "1000", "--json", "number,title,url,isDraft,headRefName,author"],
+      stdout: "[]\n",
+    }], { repeatLastOnOverflow: true });
+
+    const { code, stdout, stderr } = await runNode(["--repo", "owner/repo"], { env });
+
+    assert.equal(code, 0);
+    assert.equal(stderr, "");
+
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.ok, true);
+    // Both cycle and monitor should report 0 PRs
+    assert.equal(payload.cycle.prCount, 0);
+    assert.equal(payload.cycle.actions.length, 0);
+    assert.equal(payload.monitor.queueStatus, "queue_complete");
+    assert.equal(payload.monitor.prCount, 0);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/loop/run-conductor-cycle.test.mjs
+++ b/test/loop/run-conductor-cycle.test.mjs
@@ -1,0 +1,537 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  GATE_ACTION_TO_CONDUCTOR_ACTION,
+  ACTION_PRIORITY,
+  SUBAGENT_ACTIONS,
+  buildActionQueue,
+  buildSummary,
+  detectPrState,
+  runConductorCycle,
+  parseCliArgs,
+} from "../../scripts/loop/run-conductor-cycle.mjs";
+import { PR_GATE_ACTION, PR_GATE_BOUNDARY } from "@pi-dev-loops/core/loop/pr-gate-coordination";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
+
+const scriptPath = path.resolve("scripts/loop/run-conductor-cycle.mjs");
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
+
+// ---------------------------------------------------------------------------
+// Unit: action mapping
+// ---------------------------------------------------------------------------
+
+test("all PR_GATE_ACTION values have a conductor action mapping", () => {
+  const gateActionValues = Object.values(PR_GATE_ACTION);
+  const missing = gateActionValues.filter((val) => !(val in GATE_ACTION_TO_CONDUCTOR_ACTION));
+  assert.deepEqual(missing, [], `Missing mappings for: ${missing.join(", ")}`);
+});
+
+test("GATE_ACTION_TO_CONDUCTOR_ACTION maps unresolved feedback to fix_threads", () => {
+  assert.equal(GATE_ACTION_TO_CONDUCTOR_ACTION[PR_GATE_ACTION.ADDRESS_REVIEW_FEEDBACK], "fix_threads");
+  assert.equal(GATE_ACTION_TO_CONDUCTOR_ACTION[PR_GATE_ACTION.REPLY_RESOLVE_REVIEW_THREADS], "fix_threads");
+});
+
+test("GATE_ACTION_TO_CONDUCTOR_ACTION maps pre-approval to run_pre_approval", () => {
+  assert.equal(GATE_ACTION_TO_CONDUCTOR_ACTION[PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE], "run_pre_approval");
+});
+
+test("GATE_ACTION_TO_CONDUCTOR_ACTION maps merge to merge", () => {
+  assert.equal(GATE_ACTION_TO_CONDUCTOR_ACTION[PR_GATE_ACTION.DECLARE_MERGE_READY], "merge");
+});
+
+test("GATE_ACTION_TO_CONDUCTOR_ACTION maps wait states to watch", () => {
+  assert.equal(GATE_ACTION_TO_CONDUCTOR_ACTION[PR_GATE_ACTION.WAIT_FOR_COPILOT_REVIEW], "watch");
+  assert.equal(GATE_ACTION_TO_CONDUCTOR_ACTION[PR_GATE_ACTION.WAIT_FOR_CI], "watch");
+});
+
+// ---------------------------------------------------------------------------
+// Unit: priority
+// ---------------------------------------------------------------------------
+
+test("ACTION_PRIORITY orders merge > fix_threads > run_pre_approval > draft_gate", () => {
+  assert.ok(ACTION_PRIORITY.merge > ACTION_PRIORITY.fix_threads);
+  assert.ok(ACTION_PRIORITY.fix_threads > ACTION_PRIORITY.run_pre_approval);
+  assert.ok(ACTION_PRIORITY.run_pre_approval > ACTION_PRIORITY.draft_gate);
+});
+
+test("ACTION_PRIORITY orders request_review > watch > await_approval > blocked > done", () => {
+  assert.ok(ACTION_PRIORITY.request_review > ACTION_PRIORITY.watch);
+  assert.ok(ACTION_PRIORITY.watch > ACTION_PRIORITY.await_approval);
+  assert.ok(ACTION_PRIORITY.await_approval >= ACTION_PRIORITY.blocked);
+  assert.ok(ACTION_PRIORITY.blocked > ACTION_PRIORITY.done);
+});
+
+test("ACTION_PRIORITY has error at the lowest priority", () => {
+  assert.ok(ACTION_PRIORITY.error < 0);
+  for (const key of Object.keys(ACTION_PRIORITY)) {
+    if (key !== "error") {
+      assert.ok(ACTION_PRIORITY[key] > ACTION_PRIORITY.error, `${key} should be > error`);
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Unit: SUBAGENT_ACTIONS
+// ---------------------------------------------------------------------------
+
+test("SUBAGENT_ACTIONS includes fix_threads, draft_gate, request_review, rerequest_review, run_pre_approval", () => {
+  assert.ok(SUBAGENT_ACTIONS.has("fix_threads"));
+  assert.ok(SUBAGENT_ACTIONS.has("draft_gate"));
+  assert.ok(SUBAGENT_ACTIONS.has("request_review"));
+  assert.ok(SUBAGENT_ACTIONS.has("rerequest_review"));
+  assert.ok(SUBAGENT_ACTIONS.has("run_pre_approval"));
+});
+
+test("SUBAGENT_ACTIONS does not include watch, merge, done, blocked", () => {
+  assert.equal(SUBAGENT_ACTIONS.has("watch"), false);
+  assert.equal(SUBAGENT_ACTIONS.has("merge"), false);
+  assert.equal(SUBAGENT_ACTIONS.has("done"), false);
+  assert.equal(SUBAGENT_ACTIONS.has("blocked"), false);
+  assert.equal(SUBAGENT_ACTIONS.has("await_approval"), false);
+  assert.equal(SUBAGENT_ACTIONS.has("resolve_conflicts"), false);
+});
+
+// ---------------------------------------------------------------------------
+// Unit: buildActionQueue
+// ---------------------------------------------------------------------------
+
+test("buildActionQueue sorts by priority descending, then PR number ascending", () => {
+  const results = [
+    { pr: 10, priority: 30, action: "watch" },
+    { pr: 5, priority: 90, action: "fix_threads" },
+    { pr: 7, priority: 100, action: "merge" },
+    { pr: 3, priority: 90, action: "fix_threads" },
+    { pr: 8, priority: 30, action: "watch" },
+  ];
+
+  const queue = buildActionQueue(results);
+  assert.equal(queue[0].pr, 7);  // merge (100)
+  assert.equal(queue[1].pr, 3);  // fix_threads (90), lower PR first
+  assert.equal(queue[2].pr, 5);  // fix_threads (90)
+  assert.equal(queue[3].pr, 8);  // watch (30), lower PR first
+  assert.equal(queue[4].pr, 10); // watch (30)
+});
+
+test("buildActionQueue returns empty array for empty input", () => {
+  assert.deepEqual(buildActionQueue([]), []);
+});
+
+test("buildActionQueue handles single item", () => {
+  const queue = buildActionQueue([{ pr: 1, priority: 100, action: "merge" }]);
+  assert.equal(queue.length, 1);
+  assert.equal(queue[0].pr, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Unit: buildSummary
+// ---------------------------------------------------------------------------
+
+test("buildSummary counts actions correctly", () => {
+  const actions = [
+    { pr: 1, action: "merge", requiresSubagent: false },
+    { pr: 2, action: "fix_threads", requiresSubagent: true },
+    { pr: 3, action: "watch", requiresSubagent: false },
+    { pr: 4, action: "blocked", requiresSubagent: false },
+    { pr: 5, action: "done", requiresSubagent: false },
+    { pr: 6, action: "run_pre_approval", requiresSubagent: true },
+    { pr: 7, action: "error", requiresSubagent: false },
+  ];
+
+  const summary = buildSummary(actions);
+  assert.equal(summary.readyToMerge, 1);
+  assert.equal(summary.needsSubagent, 2);
+  assert.equal(summary.waiting, 1);
+  assert.equal(summary.blocked, 1);
+  assert.equal(summary.done, 1);
+  assert.equal(summary.errors, 1);
+});
+
+test("buildSummary handles empty action list", () => {
+  const summary = buildSummary([]);
+  assert.equal(summary.needsSubagent, 0);
+  assert.equal(summary.readyToMerge, 0);
+  assert.equal(summary.waiting, 0);
+  assert.equal(summary.blocked, 0);
+  assert.equal(summary.done, 0);
+  assert.equal(summary.errors, 0);
+});
+
+test("buildSummary counts await_approval and resolve_conflicts as blocked", () => {
+  const summary = buildSummary([
+    { pr: 1, action: "await_approval", requiresSubagent: false },
+    { pr: 2, action: "resolve_conflicts", requiresSubagent: false },
+  ]);
+  assert.equal(summary.blocked, 2);
+});
+
+// ---------------------------------------------------------------------------
+// Unit: detectPrState (with mock detectors)
+// ---------------------------------------------------------------------------
+
+test("detectPrState returns correctly shaped action entry for fix_threads", async () => {
+  const pr = { number: 42, title: "Test PR", url: "https://github.com/o/r/pull/42", isDraft: false, headRefName: "feature/x" };
+
+  const mockGateState = {
+    lifecycleState: "unresolved_feedback_present",
+    loopDisposition: "unresolved_feedback",
+    gateBoundary: PR_GATE_BOUNDARY.FEEDBACK_RESOLUTION,
+    nextAction: PR_GATE_ACTION.ADDRESS_REVIEW_FEEDBACK,
+    reason: "Fix threads needed",
+    allowedNextActions: [PR_GATE_ACTION.ADDRESS_REVIEW_FEEDBACK],
+    forbiddenActions: [PR_GATE_ACTION.DECLARE_MERGE_READY],
+    draftGate: { visible: true, verdict: "clean", headSha: "abc123" },
+    preApprovalGate: { visible: false, verdict: null, headSha: null },
+    mergeStateStatus: "CLEAN",
+    conflictFiles: [],
+    currentHeadSha: "abc123",
+  };
+
+  const mockSnapshot = { ciStatus: "success", unresolvedThreadCount: 2 };
+
+  const mockDetectGate = async () => mockGateState;
+  const mockDetectSnapshot = async () => mockSnapshot;
+
+  const result = await detectPrState(pr, {
+    repo: "owner/repo",
+    detectGateImpl: mockDetectGate,
+    detectSnapshotImpl: mockDetectSnapshot,
+  });
+
+  assert.equal(result.pr, 42);
+  assert.equal(result.action, "fix_threads");
+  assert.equal(result.priority, 90);
+  assert.equal(result.requiresSubagent, true);
+  assert.equal(result.state, "unresolved_feedback_present");
+  assert.equal(result.lifecycleState, "unresolved_feedback_present");
+  assert.equal(result.gateBoundary, PR_GATE_BOUNDARY.FEEDBACK_RESOLUTION);
+  assert.equal(result.snapshot.ciStatus, "success");
+  assert.equal(result.gateState.currentHeadSha, "abc123");
+  assert.equal(result.error, undefined);
+});
+
+test("detectPrState returns merge action with correct flags", async () => {
+  const pr = { number: 1, title: "Ready", url: "url", isDraft: false, headRefName: "feat" };
+
+  const mockGateState = {
+    lifecycleState: "pr_ready_no_feedback",
+    loopDisposition: "clean_converged",
+    gateBoundary: PR_GATE_BOUNDARY.FINAL_APPROVAL_READY,
+    nextAction: PR_GATE_ACTION.DECLARE_MERGE_READY,
+    reason: null,
+    allowedNextActions: [PR_GATE_ACTION.DECLARE_MERGE_READY],
+    forbiddenActions: [],
+    draftGate: { visible: true, verdict: "clean" },
+    preApprovalGate: { visible: true, verdict: "clean" },
+    mergeStateStatus: "CLEAN",
+    conflictFiles: [],
+    currentHeadSha: "sha",
+  };
+
+  const mockSnapshot = { ciStatus: "success" };
+  const result = await detectPrState(pr, {
+    repo: "r",
+    detectGateImpl: async () => mockGateState,
+    detectSnapshotImpl: async () => mockSnapshot,
+  });
+
+  assert.equal(result.action, "merge");
+  assert.equal(result.priority, 100);
+  assert.equal(result.requiresSubagent, false);
+});
+
+test("detectPrState returns watch for waiting_for_copilot_review", async () => {
+  const pr = { number: 2, title: "W", url: "u", isDraft: false, headRefName: "f" };
+
+  const mockGateState = {
+    lifecycleState: "waiting_for_copilot_review",
+    loopDisposition: "pending",
+    gateBoundary: PR_GATE_BOUNDARY.POST_DRAFT_EXTERNAL_REVIEW,
+    nextAction: PR_GATE_ACTION.WAIT_FOR_COPILOT_REVIEW,
+    reason: null,
+    allowedNextActions: [PR_GATE_ACTION.WAIT_FOR_COPILOT_REVIEW],
+    forbiddenActions: [],
+    draftGate: null,
+    preApprovalGate: null,
+    mergeStateStatus: null,
+    conflictFiles: [],
+    currentHeadSha: null,
+  };
+
+  const result = await detectPrState(pr, {
+    repo: "r",
+    detectGateImpl: async () => mockGateState,
+    detectSnapshotImpl: async () => null,
+  });
+
+  assert.equal(result.action, "watch");
+  assert.equal(result.priority, 30);
+  assert.equal(result.requiresSubagent, false);
+});
+
+test("detectPrState handles gate detection failure gracefully", async () => {
+  const pr = { number: 99, title: "Fail", url: "u", isDraft: false, headRefName: "f" };
+
+  const result = await detectPrState(pr, {
+    repo: "r",
+    detectGateImpl: async () => { throw new Error("gh exploded"); },
+    detectSnapshotImpl: async () => null,
+  });
+
+  assert.equal(result.pr, 99);
+  assert.equal(result.action, "error");
+  assert.equal(result.priority, ACTION_PRIORITY.error);
+  assert.equal(result.requiresSubagent, false);
+  assert.ok(result.error.includes("gh exploded"));
+});
+
+test("detectPrState tolerates snapshot failure when gate succeeds", async () => {
+  const pr = { number: 50, title: "OK", url: "u", isDraft: false, headRefName: "f" };
+
+  const mockGateState = {
+    lifecycleState: "pr_draft",
+    loopDisposition: "action_required",
+    gateBoundary: PR_GATE_BOUNDARY.DRAFT_REVIEW,
+    nextAction: PR_GATE_ACTION.RUN_DRAFT_GATE,
+    reason: "draft gate needed",
+    allowedNextActions: [PR_GATE_ACTION.RUN_DRAFT_GATE],
+    forbiddenActions: [],
+    draftGate: null,
+    preApprovalGate: null,
+    mergeStateStatus: null,
+    conflictFiles: [],
+    currentHeadSha: null,
+  };
+
+  const result = await detectPrState(pr, {
+    repo: "r",
+    detectGateImpl: async () => mockGateState,
+    detectSnapshotImpl: async () => { throw new Error("snapshot fail"); },
+  });
+
+  assert.equal(result.action, "draft_gate");
+  assert.equal(result.snapshot, null);
+  assert.equal(result.error, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Integration: runConductorCycle with mock detectors
+// ---------------------------------------------------------------------------
+
+test("runConductorCycle produces ordered queue for mixed PR states", async () => {
+  const mockPrs = [
+    { number: 10, title: "Wait PR", url: "u10", isDraft: false, headRefName: "w" },
+    { number: 5, title: "Fix PR", url: "u5", isDraft: false, headRefName: "f" },
+    { number: 7, title: "Merge PR", url: "u7", isDraft: false, headRefName: "m" },
+  ];
+
+  const mockListPrs = async () => mockPrs;
+
+  const mockDetectPr = async (pr) => {
+    if (pr.number === 7) {
+      return {
+        pr: 7, title: "Merge PR", url: "u7", isDraft: false, headRefName: "m",
+        action: "merge", priority: 100, state: "pr_ready_no_feedback",
+        lifecycleState: "pr_ready_no_feedback", loopDisposition: "clean_converged",
+        gateBoundary: "final_approval_ready", reason: null, snapshot: null,
+        gateState: {}, requiresSubagent: false,
+      };
+    }
+    if (pr.number === 5) {
+      return {
+        pr: 5, title: "Fix PR", url: "u5", isDraft: false, headRefName: "f",
+        action: "fix_threads", priority: 90, state: "unresolved_feedback_present",
+        lifecycleState: "unresolved_feedback_present", loopDisposition: "unresolved_feedback",
+        gateBoundary: "feedback_resolution", reason: null, snapshot: null,
+        gateState: {}, requiresSubagent: true,
+      };
+    }
+    return {
+      pr: 10, title: "Wait PR", url: "u10", isDraft: false, headRefName: "w",
+      action: "watch", priority: 30, state: "waiting_for_copilot_review",
+      lifecycleState: "waiting_for_copilot_review", loopDisposition: "pending",
+      gateBoundary: "post_draft_external_review", reason: null, snapshot: null,
+      gateState: {}, requiresSubagent: false,
+    };
+  };
+
+  const result = await runConductorCycle(
+    { repo: "test/repo" },
+    { listPrsImpl: mockListPrs, detectPrStateImpl: mockDetectPr },
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.prCount, 3);
+  assert.equal(result.actions.length, 3);
+
+  assert.equal(result.actions[0].pr, 7);
+  assert.equal(result.actions[0].action, "merge");
+  assert.equal(result.actions[1].pr, 5);
+  assert.equal(result.actions[1].action, "fix_threads");
+  assert.equal(result.actions[2].pr, 10);
+  assert.equal(result.actions[2].action, "watch");
+
+  assert.equal(result.summary.readyToMerge, 1);
+  assert.equal(result.summary.needsSubagent, 1);
+  assert.equal(result.summary.waiting, 1);
+});
+
+test("runConductorCycle returns queue_complete-like result for zero PRs", async () => {
+  const result = await runConductorCycle(
+    { repo: "test/repo" },
+    { listPrsImpl: async () => [], detectPrStateImpl: async () => ({}) },
+  );
+
+  assert.equal(result.prCount, 0);
+  assert.equal(result.actions.length, 0);
+  assert.equal(result.summary.readyToMerge, 0);
+});
+
+test("runConductorCycle handles errors on individual PRs without failing the cycle", async () => {
+  const mockPrs = [
+    { number: 1, title: "Good", url: "u1", isDraft: false, headRefName: "g" },
+    { number: 2, title: "Bad", url: "u2", isDraft: false, headRefName: "b" },
+  ];
+
+  const mockListPrs = async () => mockPrs;
+
+  let callCount = 0;
+  const mockDetectPr = async (pr) => {
+    callCount += 1;
+    if (pr.number === 2) {
+      return {
+        pr: 2, title: "Bad", url: "u2", isDraft: false, headRefName: "b",
+        action: "error", priority: -1, state: null, lifecycleState: null,
+        loopDisposition: null, gateBoundary: null, reason: null, snapshot: null,
+        gateState: null, requiresSubagent: false, error: "Boom",
+      };
+    }
+    return {
+      pr: 1, title: "Good", url: "u1", isDraft: false, headRefName: "g",
+      action: "watch", priority: 30, state: "waiting_for_copilot_review",
+      lifecycleState: "waiting_for_copilot_review", loopDisposition: "pending",
+      gateBoundary: "post_draft_external_review", reason: null, snapshot: null,
+      gateState: {}, requiresSubagent: false,
+    };
+  };
+
+  const result = await runConductorCycle(
+    { repo: "test/repo" },
+    { listPrsImpl: mockListPrs, detectPrStateImpl: mockDetectPr },
+  );
+
+  assert.equal(result.prCount, 2);
+  assert.equal(result.actions.length, 2);
+  assert.equal(callCount, 2);
+  assert.equal(result.actions[0].pr, 1); // good PR first (higher priority)
+  assert.equal(result.actions[1].pr, 2); // error PR last
+  assert.equal(result.summary.errors, 1);
+  assert.equal(result.summary.waiting, 1);
+});
+
+// ---------------------------------------------------------------------------
+// CLI: argument parsing
+// ---------------------------------------------------------------------------
+
+test("parseCliArgs requires --repo", () => {
+  assert.throws(() => parseCliArgs([]), /requires --repo/);
+});
+
+test("parseCliArgs rejects unknown flags", () => {
+  assert.throws(
+    () => parseCliArgs(["--repo", "owner/repo", "--unknown"]),
+    /Unknown argument/,
+  );
+});
+
+test("parseCliArgs rejects invalid repo slug", () => {
+  assert.throws(
+    () => parseCliArgs(["--repo", "not-a-valid-slug"]),
+    /--repo must match/,
+  );
+});
+
+test("parseCliArgs accepts valid repo slug", () => {
+  const opts = parseCliArgs(["--repo", "owner/repo"]);
+  assert.equal(opts.repo, "owner/repo");
+  assert.equal(opts.help, false);
+});
+
+test("parseCliArgs handles --help", () => {
+  const opts = parseCliArgs(["--help"]);
+  assert.equal(opts.help, true);
+});
+
+// ---------------------------------------------------------------------------
+// CLI: gh stub integration (basic smoke tests)
+// ---------------------------------------------------------------------------
+
+test("run-conductor-cycle CLI reports empty queue when no open PRs exist", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-rc-cycle-empty-"));
+
+  try {
+    const { env } = await writeGhStubHelper(tempDir, [{
+      assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "1000", "--json", "number,title,url,isDraft,headRefName,author"],
+      stdout: "[]\n",
+    }]);
+
+    const { code, stdout, stderr } = await runNode(["--repo", "owner/repo"], { env });
+
+    assert.equal(code, 0);
+    assert.equal(stderr, "");
+
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.prCount, 0);
+    assert.deepEqual(payload.actions, []);
+    assert.equal(payload.summary.needsSubagent, 0);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("run-conductor-cycle CLI fails gracefully on gh pr list failure", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-rc-cycle-gh-fail-"));
+
+  try {
+    const { env } = await writeGhStubHelper(tempDir, [{
+      assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "1000", "--json", "number,title,url,isDraft,headRefName,author"],
+      stderr: "gh network error\n",
+      exitCode: 1,
+    }]);
+
+    const { code, stdout, stderr } = await runNode(["--repo", "owner/repo"], { env });
+
+    assert.equal(code, 1);
+    assert.equal(stdout, "");
+    const payload = JSON.parse(stderr);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /gh command failed/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("run-conductor-cycle CLI fails closed on non-array pr list response", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-rc-cycle-bad-list-"));
+
+  try {
+    const { env } = await writeGhStubHelper(tempDir, [{
+      assertArgs: ["pr", "list", "--repo", "owner/repo", "--state", "open", "--limit", "1000", "--json", "number,title,url,isDraft,headRefName,author"],
+      stdout: "not-an-array\n",
+    }]);
+
+    const { code, stdout, stderr } = await runNode(["--repo", "owner/repo"], { env });
+
+    assert.equal(code, 1);
+    assert.equal(stdout, "");
+    const payload = JSON.parse(stderr);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /Invalid JSON input/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/loop/run-conductor-cycle.test.mjs
+++ b/test/loop/run-conductor-cycle.test.mjs
@@ -5,6 +5,8 @@ import path from "node:path";
 import test from "node:test";
 
 import {
+  AUTONOMY_GATE_ACTION_MAP,
+  actionRequiresApproval,
   GATE_ACTION_TO_CONDUCTOR_ACTION,
   ACTION_PRIORITY,
   SUBAGENT_ACTIONS,
@@ -534,4 +536,201 @@ test("run-conductor-cycle CLI fails closed on non-array pr list response", async
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
+});
+// ---------------------------------------------------------------------------
+test("AUTONOMY_GATE_ACTION_MAP maps merge to [merge]", () => {
+  assert.deepEqual(AUTONOMY_GATE_ACTION_MAP.merge, ["merge"]);
+});
+
+test("AUTONOMY_GATE_ACTION_MAP maps pre-approval to [run_pre_approval]", () => {
+  assert.deepEqual(AUTONOMY_GATE_ACTION_MAP["pre-approval"], ["run_pre_approval"]);
+});
+
+test("AUTONOMY_GATE_ACTION_MAP maps draft-pr to [draft_gate, request_review, rerequest_review]", () => {
+  const expected = ["draft_gate", "request_review", "rerequest_review"];
+  assert.deepEqual(AUTONOMY_GATE_ACTION_MAP["draft-pr"], expected);
+});
+
+test("AUTONOMY_GATE_ACTION_MAP has empty array for refinement", () => {
+  assert.deepEqual(AUTONOMY_GATE_ACTION_MAP.refinement, []);
+});
+
+// ---------------------------------------------------------------------------
+// Unit: actionRequiresApproval
+// ---------------------------------------------------------------------------
+
+test("actionRequiresApproval returns true for merge when stopAt includes merge (default)", () => {
+  assert.equal(actionRequiresApproval("merge"), true);
+  assert.equal(actionRequiresApproval("merge", ["merge"]), true);
+});
+
+test("actionRequiresApproval returns false for merge when stopAt is empty", () => {
+  assert.equal(actionRequiresApproval("merge", []), false);
+});
+
+test("actionRequiresApproval returns false for watch regardless of stopAt", () => {
+  assert.equal(actionRequiresApproval("watch"), false);
+  assert.equal(actionRequiresApproval("watch", ["merge"]), false);
+  assert.equal(actionRequiresApproval("watch", ["merge", "pre-approval", "draft-pr"]), false);
+});
+
+test("actionRequiresApproval returns true for run_pre_approval when pre-approval is in stopAt", () => {
+  assert.equal(actionRequiresApproval("run_pre_approval", ["merge"]), false);
+  assert.equal(actionRequiresApproval("run_pre_approval", ["merge", "pre-approval"]), true);
+});
+
+test("actionRequiresApproval returns true for draft_gate, request_review, rerequest_review when draft-pr is in stopAt", () => {
+  assert.equal(actionRequiresApproval("draft_gate", ["merge"]), false);
+  assert.equal(actionRequiresApproval("request_review", ["merge"]), false);
+  assert.equal(actionRequiresApproval("rerequest_review", ["merge"]), false);
+
+  const stopAt = ["merge", "draft-pr"];
+  assert.equal(actionRequiresApproval("draft_gate", stopAt), true);
+  assert.equal(actionRequiresApproval("request_review", stopAt), true);
+  assert.equal(actionRequiresApproval("rerequest_review", stopAt), true);
+});
+
+test("actionRequiresApproval handles unknown action names safely", () => {
+  assert.equal(actionRequiresApproval("unknown_action", ["merge"]), false);
+});
+
+test("actionRequiresApproval handles unknown gate names in stopAt safely", () => {
+  assert.equal(actionRequiresApproval("merge", ["unknown_gate"]), false);
+  assert.equal(actionRequiresApproval("merge", ["merge", "unknown_gate"]), true);
+});
+
+// ---------------------------------------------------------------------------
+// Unit: detectPrState — requiresApproval with autonomyStopAt
+// ---------------------------------------------------------------------------
+
+test("detectPrState flags merge as requiresApproval with default stopAt", async () => {
+  const pr = { number: 1, title: "R", url: "u", isDraft: false, headRefName: "f" };
+  const mockGateState = {
+    lifecycleState: "pr_ready_no_feedback",
+    loopDisposition: "clean_converged",
+    gateBoundary: PR_GATE_BOUNDARY.FINAL_APPROVAL_READY,
+    nextAction: PR_GATE_ACTION.DECLARE_MERGE_READY,
+    reason: null,
+    allowedNextActions: [PR_GATE_ACTION.DECLARE_MERGE_READY],
+    forbiddenActions: [],
+    draftGate: { visible: true, verdict: "clean" },
+    preApprovalGate: { visible: true, verdict: "clean" },
+    mergeStateStatus: "CLEAN",
+    conflictFiles: [],
+    currentHeadSha: "sha",
+  };
+
+  const result = await detectPrState(pr, {
+    repo: "r",
+    detectGateImpl: async () => mockGateState,
+    detectSnapshotImpl: async () => ({ ciStatus: "success" }),
+  });
+
+  assert.equal(result.action, "merge");
+  assert.equal(result.requiresApproval, true);
+});
+
+test("detectPrState does NOT flag merge as requiresApproval when stopAt is empty", async () => {
+  const pr = { number: 1, title: "R", url: "u", isDraft: false, headRefName: "f" };
+  const mockGateState = {
+    lifecycleState: "pr_ready_no_feedback",
+    loopDisposition: "clean_converged",
+    gateBoundary: PR_GATE_BOUNDARY.FINAL_APPROVAL_READY,
+    nextAction: PR_GATE_ACTION.DECLARE_MERGE_READY,
+    reason: null,
+    allowedNextActions: [PR_GATE_ACTION.DECLARE_MERGE_READY],
+    forbiddenActions: [],
+    draftGate: { visible: true, verdict: "clean" },
+    preApprovalGate: { visible: true, verdict: "clean" },
+    mergeStateStatus: "CLEAN",
+    conflictFiles: [],
+    currentHeadSha: "sha",
+  };
+
+  const result = await detectPrState(pr, {
+    repo: "r",
+    detectGateImpl: async () => mockGateState,
+    detectSnapshotImpl: async () => ({ ciStatus: "success" }),
+    autonomyStopAt: [],
+  });
+
+  assert.equal(result.action, "merge");
+  assert.equal(result.requiresApproval, false);
+});
+
+test("detectPrState flags run_pre_approval with requiresApproval when pre-approval is in stopAt", async () => {
+  const pr = { number: 2, title: "P", url: "u", isDraft: false, headRefName: "f" };
+  const mockGateState = {
+    lifecycleState: "pr_draft_reviewed_clean",
+    loopDisposition: "action_required",
+    gateBoundary: PR_GATE_BOUNDARY.FINAL_APPROVAL_READY,
+    nextAction: PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE,
+    reason: null,
+    allowedNextActions: [PR_GATE_ACTION.RUN_PRE_APPROVAL_GATE],
+    forbiddenActions: [],
+    draftGate: { visible: true, verdict: "clean" },
+    preApprovalGate: null,
+    mergeStateStatus: "CLEAN",
+    conflictFiles: [],
+    currentHeadSha: "sha",
+  };
+
+  const result = await detectPrState(pr, {
+    repo: "r",
+    detectGateImpl: async () => mockGateState,
+    detectSnapshotImpl: async () => ({ ciStatus: "success" }),
+    autonomyStopAt: ["merge", "pre-approval"],
+  });
+
+  assert.equal(result.action, "run_pre_approval");
+  assert.equal(result.requiresApproval, true);
+});
+
+// ---------------------------------------------------------------------------
+// Integration: runConductorCycle passes autonomyStopAt through
+// ---------------------------------------------------------------------------
+
+test("runConductorCycle includes autonomyStopAt in output", async () => {
+  const result = await runConductorCycle(
+    { repo: "test/repo", autonomyStopAt: ["merge", "draft-pr"] },
+    { listPrsImpl: async () => [], detectPrStateImpl: async () => ({}) },
+  );
+
+  assert.deepEqual(result.autonomyStopAt, ["merge", "draft-pr"]);
+});
+
+test("runConductorCycle passes autonomyStopAt to detectPrState", async () => {
+  let capturedStopAt = null;
+  const mockDetectPr = async (_pr, opts) => {
+    capturedStopAt = opts.autonomyStopAt;
+    return { pr: 1, action: "watch", priority: 30, requiresSubagent: false, requiresApproval: false };
+  };
+
+  await runConductorCycle(
+    { repo: "test/repo", autonomyStopAt: ["merge", "draft-pr"] },
+    {
+      listPrsImpl: async () => [{ number: 1, title: "T", url: "u", isDraft: false, headRefName: "f", authorLogin: "a" }],
+      detectPrStateImpl: mockDetectPr,
+    },
+  );
+
+  assert.deepEqual(capturedStopAt, ["merge", "draft-pr"]);
+});
+
+test("runConductorCycle uses default stopAt [merge] when none provided", async () => {
+  let capturedStopAt = null;
+  const mockDetectPr = async (_pr, opts) => {
+    capturedStopAt = opts.autonomyStopAt;
+    return { pr: 1, action: "watch", priority: 30, requiresSubagent: false, requiresApproval: false };
+  };
+
+  await runConductorCycle(
+    { repo: "test/repo" },
+    {
+      listPrsImpl: async () => [{ number: 1, title: "T", url: "u", isDraft: false, headRefName: "f", authorLogin: "a" }],
+      detectPrStateImpl: mockDetectPr,
+    },
+  );
+
+  assert.deepEqual(capturedStopAt, ["merge"]);
 });


### PR DESCRIPTION
## Summary

Persistent conductor cycle — deterministic action queue for all open PRs. The Pi parent agent reads the queue and spawns subagents for each action, replacing manual dispatch.

## Changes

- `scripts/loop/run-conductor-cycle.mjs` (413 lines): polls open PRs, runs gate coordination + snapshot detection, outputs ordered action queue with priorities
- `scripts/loop/conductor.mjs` (166 lines): unified entrypoint wrapping cycle + monitor
- `test/loop/run-conductor-cycle.test.mjs` (537 lines): 32 tests
- `test/loop/conductor-integration.test.mjs` (124 lines): 5 integration tests

## Action queue priorities

- merge (100) → gh pr merge
- fix_threads (90) → subagent dev-loop  
- run_pre_approval (80) → subagent dev-loop
- draft_gate (70) → subagent dev-loop
- request_review (60) → subagent dev-loop
- watch (30) → re-poll
- await_approval (20) → stop for human
- blocked (10) → stop for human

## Scope

Closes #475
