### PR TITLE
fix(#482): fixer agent stops owning Copilot re-request

### DIFF
--- a/agents/fixer.agent.md
+++ b/agents/fixer.agent.md
@@ -14,6 +14,7 @@ You are a focused review-fix agent. You take an existing pull request with revie
 - Implement narrowly scoped code, test, workflow, or documentation changes when they are the right resolution.
 - Verify the resolution locally before updating review threads.
 - Push the resolving commit before replying to and resolving review threads when files changed.
+- After reply and resolve, return control to the caller. The caller (dev-loop) gate-decides whether to re-request Copilot review.
 
 ## Expectations
 - Refresh the pull request state before acting, and check the current PR head again immediately before you submit replies or resolve threads.
@@ -25,6 +26,7 @@ You are a focused review-fix agent. You take an existing pull request with revie
 - When unsure about correctness, architecture, security, or product tradeoffs, pause and ask for expert judgment rather than guessing. Use the available project workflow for expert review when possible, or clearly report the decision needed.
 - Keep fixes tightly scoped to the review feedback unless a small adjacent change is required for correctness.
 - Do not delegate back to the coordinator.
+- Do not re-request Copilot review. The caller owns the Copilot re-request gate decision, including enforcing maxCopilotRounds.
 
 ## Review Workflow
 1. Read unresolved review threads and any general review comments.
@@ -34,16 +36,14 @@ You are a focused review-fix agent. You take an existing pull request with revie
 5. Implement the chosen changes and run the appropriate verification.
 6. Create a focused commit for the review fix when files changed.
 7. Push the commit to the pull request branch and capture the pushed commit SHA.
-8. If the workflow expects another Copilot pass after the fix, explicitly request Copilot review again for the updated PR head, preferably through `scripts/github/request-copilot-review.mjs`, instead of assuming GitHub will automatically re-request it.
-9. Re-fetch the PR state and confirm the head still includes the pushed commit before you submit review replies.
-10. If that re-requested Copilot pass posts fresh review comments, do not treat the review loop as complete yet: return to unresolved-thread handling and close out those new comments before reporting completion when authorization exists.
-11. Reply to each addressed thread with a short note that references the resolving commit SHA or commit URL when applicable, summarizes the fix or explanation, and states why it resolves the underlying concern.
+8. Re-fetch the PR state and confirm the head still includes the pushed commit before you submit review replies.
+9. Reply to each addressed thread with a short note that references the resolving commit SHA or commit URL when applicable, summarizes the fix or explanation, and states why it resolves the underlying concern.
    - Prefer the deterministic helper `scripts/github/reply-resolve-review-thread.mjs` when it exists.
    - Prefer a temporary reply body file over inline shell text.
    - Keep commit SHAs and issue/PR refs unwrapped (for example 3ee82fc and owner/repo#70) when the intent is GitHub autolinks; reserve backticks for actual code/path/CLI literals.
-12. Resolve the thread only after the reply is attached successfully and the concern is genuinely addressed, even if the final resolution differs from the reviewer’s suggested implementation.
+10. Resolve the thread only after the reply is attached successfully and the concern is genuinely addressed, even if the final resolution differs from the reviewer's suggested implementation.
    - If reply/resolve is not authorized, stop and report that the PR conversation state is still unresolved rather than implying the review loop is complete.
-13. If GitHub leaves a stray pending review or rejects an inline reply because of pending review state, inspect the current review state, delete the stray pending review, recreate the reply, and retry once.
+11. If GitHub leaves a stray pending review or rejects an inline reply because of pending review state, inspect the current review state, delete the stray pending review, recreate the reply, and retry once.
 
 ## Output
 Return:

--- a/test/contracts/fixer-agent-contract.test.mjs
+++ b/test/contracts/fixer-agent-contract.test.mjs
@@ -1,0 +1,56 @@
+import { assert, readRepo, test } from "../imported-assets-helpers.mjs";
+
+test("fixer agent does not re-request Copilot; returns control after reply-resolve", async () => {
+  const content = await readRepo("agents/fixer.agent.md");
+
+  assert.doesNotMatch(
+    content,
+    /explicitly request Copilot review again/i,
+    "fixer agent must not contain instruction to re-request Copilot review"
+  );
+  assert.doesNotMatch(
+    content,
+    /request-copilot-review\.mjs/i,
+    "fixer agent must not reference request-copilot-review.mjs"
+  );
+  assert.doesNotMatch(
+    content,
+    /If that re-requested Copilot pass posts fresh review comments/i,
+    "fixer must not loop on re-requested Copilot reviews"
+  );
+  assert.match(
+    content,
+    /return control to the caller/i,
+    "fixer must hand control back to the caller"
+  );
+  assert.match(
+    content,
+    /Do not re-request Copilot review/i,
+    "fixer must explicitly forbid re-requesting Copilot"
+  );
+});
+
+test("fixer procedure returns control after fix → push → reply → resolve", async () => {
+  const content = await readRepo("agents/fixer.agent.md");
+
+  assert.doesNotMatch(
+    content,
+    /If the workflow expects another Copilot pass/i,
+    "fixer must not conditionally re-request Copilot"
+  );
+  assert.match(
+    content,
+    /reply.*resolve/i,
+    "fixer must still handle reply and resolve for addressed threads"
+  );
+});
+
+test("fixer agent description reflects four-step scope without re-request", async () => {
+  const content = await readRepo("agents/fixer.agent.md");
+
+  assert.match(
+    content,
+    /narrow fix.*verify.*push.*reply.*resolve/i,
+    "fixer description must describe fix → verify → push → reply → resolve without re-request"
+  );
+});


### PR DESCRIPTION
## Summary
Remove Copilot re-request responsibility from fixer agent. Fixer now returns control to caller after fix → push → reply → resolve. The caller (dev-loop) gate-decides whether to re-request Copilot review, including enforcing maxCopilotRounds.

## Scope / Context
Fixer's default procedure previously bundled 5 steps: fix → push → reply → resolve → re-request Copilot. The re-request happened before dev-loop could enforce maxCopilotRounds, causing uncontrolled review loops. This change moves the re-request gate to the caller.

## Changes
- Removed "explicitly request Copilot review again" step (old step 8)
- Removed "re-requested Copilot pass posts fresh review comments" loop (old step 10)
- Added: return control to caller after reply-resolve (Purpose section)
- Added: explicit "do not re-request Copilot review" rule (Expectations section)
- Renumbered remaining workflow steps 8–13 → 8–11

## Acceptance Criteria
- Fixer agent does not re-request Copilot; hands back control after reply-resolve
- Fixer agent prompt contains no instruction to request/re-request Copilot review
- All existing tests pass (`npm run verify`)

## Definition of Done
- [x] Fixer agent doc updated
- [x] Contract tests pass (3/3 fixer-agent-contract)
- [x] Full verify pass (2159 tests)
- [ ] PR reviewed and merged

## Non-Goals
- Does not change coordinator or dev-loop Copilot re-request logic
- Does not add new Copilot re-request enforcement to dev-loop
- Does not modify any shell scripts or GitHub helpers

Closes #482
