### PR TITLE
fix: clarify copilot-pr-followup SKILL.md cookbook flags ambiguity (#482 F3)

### DIFF
--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -55,7 +55,7 @@ Use this helper output as source of truth for the normal routing seam. Interpret
 
 **3. Preferred async wait-boundary helper**
 ```sh
-node <resolved-skill-scripts>/loop/run-copilot-watch-cycle.mjs --repo <owner/name> --pr <number>
+node <resolved-skill-scripts>/loop/run-copilot-watch-cycle.mjs --repo <owner/name> --pr <number> --probe-only
 ```
 For explicit async loop entry or continuation, this is a persistent async watch/fix loop, not handoff-only behavior:
 - treat the normal PR follow-up path as one loop: `watch → detect → if threads found, fix + reply + resolve → re-request → watch again → … → pre_approval_gate → merge`
@@ -63,7 +63,7 @@ For explicit async loop entry or continuation, this is a persistent async watch/
 - a single returned watch cycle (`changed`, `timeout`, or `idle`) is never completion by itself
 - if `cycleDisposition` is `pending` and `terminal` is `false`, stay attached to the same PR and resume another watch boundary instead of reporting completion
 - after Step 7 finishes a fix / reply-resolve / re-request cycle and the deterministic state returns to `waiting_for_copilot_review`, resume this watcher again in the same async session
-- default max watch timeout for one Copilot watch boundary is **30 minutes** (`--timeout-ms 1800000`); if that watch budget expires and a refreshed authoritative check still resolves `waiting_for_copilot_review`, stop with `watch timeout — PR #<number> needs manual attention.`
+- default max watch timeout for one Copilot watch boundary is **30 minutes** (`--timeout-ms 1800000` on the low-level `watch-copilot-review.mjs` helper); if that watch budget expires and a refreshed authoritative check still resolves `waiting_for_copilot_review`, stop with `watch timeout — PR #<number> needs manual attention.`
 - if the user explicitly asks for async handoff-only behavior, say that out loud and stop after the handoff boundary; otherwise do not silently reinterpret async loop entry as handoff-only
 
 **4. Low-level helpers**

--- a/test/contracts/copilot-review-doc-contracts.test.mjs
+++ b/test/contracts/copilot-review-doc-contracts.test.mjs
@@ -504,3 +504,23 @@ test("docs index references sub-issue-tree-contract.md", async () => {
   const indexContent = await readRepo("docs/index.md");
   assert.match(indexContent, /sub-issue-tree-contract\.md/i);
 });
+
+test("copilot-pr-followup SKILL.md cookbook lines 58 and 66 are unambiguous", async () => {
+  const skillContent = await readRepo("skills/copilot-pr-followup/SKILL.md");
+  const lines = skillContent.split("\n");
+
+  // Line 58 (0-indexed 57): run-copilot-watch-cycle.mjs must show --repo/--pr flags
+  const line58 = lines[57] ?? "";
+  assert.match(line58, /--repo <owner\/name>/);
+  assert.match(line58, /--pr <number>/);
+  assert.match(line58, /run-copilot-watch-cycle\.mjs/);
+  assert.match(line58, /--probe-only/);
+
+  // Line 66 (0-indexed 65): --timeout-ms reference must be unambiguous
+  // -- it must clarify that --timeout-ms belongs to the low-level watch-copilot-review.mjs helper
+  const line66 = lines[65] ?? "";
+  assert.match(line66, /--timeout-ms/);
+  assert.match(line66, /watch-copilot-review\.mjs/i);
+  // Must not be ambiguous about which script owns the flag
+  assert.match(line66, /low.level/i);
+});


### PR DESCRIPTION
## Summary

Fix the copilot-pr-followup SKILL.md cookbook flags ambiguity that caused agents to pass `--timeout-ms` to the wrong script.

## Scope/Context

Issue #482 identified a root cause: SKILL.md line 58 showed `run-copilot-watch-cycle.mjs` with no flags, while line 66 referenced `--timeout-ms 1800000` as orphan prose. Agents read them together and passed `--timeout-ms` to `run-copilot-watch-cycle.mjs`, which didn't accept it.

## Changes

- **SKILL.md line 58**: Add `--probe-only` flag to `run-copilot-watch-cycle.mjs` command
- **SKILL.md line 66**: Clarify `--timeout-ms` belongs to the low-level `watch-copilot-review.mjs` helper
- **Test**: Add assertion for `--probe-only` on line 58 and `watch-copilot-review.mjs` / `low-level` on line 66

No script flag surfaces changed. The flags serve different purposes by design:
- `run-copilot-watch-cycle.mjs`: `--probe-only` (single immediate probe)
- `watch-copilot-review.mjs`: `--timeout-ms` (persistent watch budget)

## Acceptance Criteria

- [x] SKILL.md line 58 shows `--probe-only` flag with `run-copilot-watch-cycle.mjs`
- [x] SKILL.md line 66 clarifies `--timeout-ms` belongs to `watch-copilot-review.mjs`
- [x] No script flag surfaces changed
- [x] `npm run verify` passes (all 2057 tests green)

## Definition of Done

- SKILL.md cookbook lines no longer ambiguous
- Contract test asserts correct flag ownership
- All tests pass

## Non-goals

- No script flag surface changes
- No behavioral changes to watch cycle or Copilot review flow

Closes #482 (partial — F3 only)