### PR TITLE
fix: remove Copilot re-request from fixer agent workflow

### DIFF
--- a/agents/fixer.agent.md
+++ b/agents/fixer.agent.md
@@ -33,16 +33,14 @@ You are a focused review-fix agent. You take an existing pull request with revie
 5. Implement the chosen changes and run the appropriate verification.
 6. Create a focused commit for the review fix when files changed.
 7. Push the commit to the pull request branch and capture the pushed commit SHA.
-8. If the workflow expects another Copilot pass after the fix, explicitly request Copilot review again for the updated PR head, preferably through `scripts/github/request-copilot-review.mjs`, instead of assuming GitHub will automatically re-request it.
-9. Re-fetch the PR state and confirm the head still includes the pushed commit before you submit review replies.
-10. If that re-requested Copilot pass posts fresh review comments, do not treat the review loop as complete yet: return to unresolved-thread handling and close out those new comments before reporting completion when authorization exists.
-11. Reply to each addressed thread with a short note that references the resolving commit SHA or commit URL when applicable, summarizes the fix or explanation, and states why it resolves the underlying concern.
+8. Re-fetch the PR state and confirm the head still includes the pushed commit before you submit review replies.
+9. Reply to each addressed thread with a short note that references the resolving commit SHA or commit URL when applicable, summarizes the fix or explanation, and states why it resolves the underlying concern.
    - Prefer the deterministic helper `scripts/github/reply-resolve-review-thread.mjs` when it exists.
    - Prefer a temporary reply body file over inline shell text.
    - Keep commit SHAs and issue/PR refs unwrapped (for example 3ee82fc and owner/repo#70) when the intent is GitHub autolinks; reserve backticks for actual code/path/CLI literals.
-12. Resolve the thread only after the reply is attached successfully and the concern is genuinely addressed, even if the final resolution differs from the reviewer’s suggested implementation.
+10. Resolve the thread only after the reply is attached successfully and the concern is genuinely addressed, even if the final resolution differs from the reviewer’s suggested implementation.
    - If reply/resolve is not authorized, stop and report that the PR conversation state is still unresolved rather than implying the review loop is complete.
-13. If GitHub leaves a stray pending review or rejects an inline reply because of pending review state, inspect the current review state, delete the stray pending review, recreate the reply, and retry once.
+11. If GitHub leaves a stray pending review or rejects an inline reply because of pending review state, inspect the current review state, delete the stray pending review, recreate the reply, and retry once.
 
 ## Output
 Return:


### PR DESCRIPTION
## Summary

Remove Copilot review re-request responsibility from the `fixer` agent. The fixer now returns control to the caller after fix → push → reply → resolve. Copilot re-request is a dev-loop gate decision, not the fixer's.

## Scope / Context

- Removed step 8: "If the workflow expects another Copilot pass after the fix, explicitly request Copilot review again..."
- Removed step 10: "If that re-requested Copilot pass posts fresh review comments..."
- Renumbered remaining steps 9→8, 11→9, 12→10, 13→11
- Fixer workflow is now: read → group → decide → implement → commit → push → verify head → reply → resolve → handle strays

## Acceptance Criteria

- [x] No "request Copilot" / "re-request" instructions remain in `agents/fixer.agent.md`
- [x] All 894 core tests pass
- [x] All 18 issue-intake contract tests pass
- [x] Fixer description already reflects the correct 5-step flow (inspect, fix, verify, push, reply, resolve)

## Definition of Done

- [x] Fixer agent prompt no longer owns Copilot re-request
- [x] Caller (dev-loop / copilot-pr-followup skill) retains sole responsibility for re-request gating

## Non-Goals

- No changes to `copilot-pr-followup` skill re-request logic
- No changes to `maxCopilotRounds` enforcement
- No changes to `request-copilot-review.mjs` helper

Closes #490
Epic: #482
