### PR TITLE
docs(copilot-pr-followup): add --probe-only flag, clarify --timeout-ms ownership

### DIFF
--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -55,7 +55,7 @@ Use this helper output as source of truth for the normal routing seam. Interpret
 
 **3. Preferred async wait-boundary helper**
 ```sh
-node <resolved-skill-scripts>/loop/run-copilot-watch-cycle.mjs --repo <owner/name> --pr <number>
+node <resolved-skill-scripts>/loop/run-copilot-watch-cycle.mjs --repo <owner/name> --pr <number> [--probe-only]
 ```
 For explicit async loop entry or continuation, this is a persistent async watch/fix loop, not handoff-only behavior:
 - treat the normal PR follow-up path as one loop: `watch → detect → if threads found, fix + reply + resolve → re-request → watch again → … → pre_approval_gate → merge`
@@ -63,7 +63,7 @@ For explicit async loop entry or continuation, this is a persistent async watch/
 - a single returned watch cycle (`changed`, `timeout`, or `idle`) is never completion by itself
 - if `cycleDisposition` is `pending` and `terminal` is `false`, stay attached to the same PR and resume another watch boundary instead of reporting completion
 - after Step 7 finishes a fix / reply-resolve / re-request cycle and the deterministic state returns to `waiting_for_copilot_review`, resume this watcher again in the same async session
-- default max watch timeout for one Copilot watch boundary is **30 minutes** (`--timeout-ms 1800000`); if that watch budget expires and a refreshed authoritative check still resolves `waiting_for_copilot_review`, stop with `watch timeout — PR #<number> needs manual attention.`
+- default max watch timeout for one Copilot watch boundary is **30 minutes** (`--timeout-ms 1800000`, set on the low-level `watch-copilot-review.mjs` helper); if that watch budget expires and a refreshed authoritative check still resolves `waiting_for_copilot_review`, stop with `watch timeout — PR #<number> needs manual attention.`
 - if the user explicitly asks for async handoff-only behavior, say that out loud and stop after the handoff boundary; otherwise do not silently reinterpret async loop entry as handoff-only
 
 **4. Low-level helpers**


### PR DESCRIPTION
## Summary

Doc-only fix for the `copilot-pr-followup` SKILL.md cookbook command flags:
- Add `--probe-only` to the `run-copilot-watch-cycle.mjs` cookbook command
- Clarify `--timeout-ms` belongs to the low-level `watch-copilot-review.mjs` helper

## Scope/Context

The cookbook previously omitted the `--probe-only` flag on the preferred async wait-boundary helper, and the `--timeout-ms 1800000` reference was an orphaned flag with no clear ownership attribution.

## Acceptance Criteria

- [x] Line 58 shows `--probe-only` optional flag on `run-copilot-watch-cycle.mjs`
- [x] Line 66 clarifies `--timeout-ms` target script as `watch-copilot-review.mjs`
- [x] `npm run verify` passes

## Definition of Done

- [x] Single commit with both doc changes
- [x] All tests pass (2076 tests, 0 failures)
- [x] Draft PR created

## Non-Goals

- No runtime behavior changes
- No script changes
- No new flags or API surface

Closes #488