### PR TITLE
feat(#497): enforce worktree-isolation and contract-compliance pre-flight checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ These skills may be provided repo-locally or globally; this contract does not as
 - Canonical guidance lives in [Worktree Usage Guidance](docs/worktree-guidance.md).
 - Create or reuse worktrees under `tmp/worktrees/<issue-or-branch-slug>/` for mutating local work, and reserve the main checkout for inspection/control by default.
 - Check `git worktree list` before creating a new worktree, and remove merged/abandoned worktrees with `git worktree remove --force <path>` followed by `git worktree prune`.
+- **Enforcement:** The local-implementation skill mandates `scripts/loop/pre-flight-gate.mjs` as step 0 before any mutation. The startup resolver (`resolve-dev-loop-startup.mjs`) rejects `local_implementation` routing when the working directory is the main git checkout. Use `PI_WORKTREE_BYPASS=1` or `PI_PREFLIGHT_BYPASS=1` for development/testing only.
 
 ## Standard refinement chain pattern
 

--- a/packages/core/src/loop/worktree-guard.mjs
+++ b/packages/core/src/loop/worktree-guard.mjs
@@ -99,9 +99,15 @@ export function isListedWorktree(cwd, worktreePaths) {
   return worktreePaths.some((p) => {
     let resolvedP;
     try { resolvedP = realpathSync(p); } catch { resolvedP = p; }
-    return resolvedP.replace(/\\/g, "/").replace(/\/+$/u, "") === normalized;
+    const normalizedP = resolvedP.replace(/\\/g, "/").replace(/\/+$/u, "");
+    // Only match worktree paths that are under tmp/worktrees/ (exclude main checkout).
+    if (!isUnderWorktreePath(normalizedP)) return false;
+    // Accept exact match or cwd is a subdirectory of a listed worktree root.
+    return normalized === normalizedP || normalized.startsWith(normalizedP + "/");
   });
 }
+
+
 
 // ---------------------------------------------------------------------------
 // Subagent availability

--- a/packages/core/src/loop/worktree-guard.mjs
+++ b/packages/core/src/loop/worktree-guard.mjs
@@ -51,8 +51,12 @@ export function parseMainWorktreePath(worktreeListOutput) {
  */
 export function isMainCheckout(cwd, mainWorktreePath) {
   if (!mainWorktreePath) return false;
-  const normalizedCwd = cwd.replace(/\\/g, "/").replace(/\/+$/u, "");
-  const normalizedMain = mainWorktreePath.replace(/\\/g, "/").replace(/\/+$/u, "");
+  let resolvedCwd;
+  try { resolvedCwd = realpathSync(cwd); } catch { resolvedCwd = cwd; }
+  let resolvedMain;
+  try { resolvedMain = realpathSync(mainWorktreePath); } catch { resolvedMain = mainWorktreePath; }
+  const normalizedCwd = resolvedCwd.replace(/\\/g, "/").replace(/\/+$/u, "");
+  const normalizedMain = resolvedMain.replace(/\\/g, "/").replace(/\/+$/u, "");
   return normalizedCwd === normalizedMain || normalizedCwd.startsWith(normalizedMain + "/");
 }
 

--- a/packages/core/src/loop/worktree-guard.mjs
+++ b/packages/core/src/loop/worktree-guard.mjs
@@ -7,6 +7,8 @@
  * This module is intentionally pure and side-effect free.
  */
 
+import { realpathSync } from "node:fs";
+
 // ---------------------------------------------------------------------------
 // Worktree path helpers
 // ---------------------------------------------------------------------------
@@ -52,6 +54,53 @@ export function isMainCheckout(cwd, mainWorktreePath) {
   const normalizedCwd = cwd.replace(/\\/g, "/").replace(/\/+$/u, "");
   const normalizedMain = mainWorktreePath.replace(/\\/g, "/").replace(/\/+$/u, "");
   return normalizedCwd === normalizedMain || normalizedCwd.startsWith(normalizedMain + "/");
+}
+
+/**
+ * Parse all worktree paths from `git worktree list` output.
+ *
+ * Each line in the output has the format `<path>  <sha> [<branch>]`.
+ * Returns absolute paths (one per worktree), preserving list order.
+ *
+ * @param {string} worktreeListOutput - Raw stdout from `git worktree list`.
+ * @returns {string[]}
+ */
+export function parseAllWorktreePaths(worktreeListOutput) {
+  const paths = [];
+  for (const line of worktreeListOutput.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const shaIdx = trimmed.search(/\s[0-9a-f]{7,64}\b/iu);
+    if (shaIdx === -1) continue;
+    paths.push(trimmed.slice(0, shaIdx).trim());
+  }
+  return paths;
+}
+
+/**
+ * Check whether `cwd` is listed as a git worktree by `git worktree list`.
+ *
+ * This is stricter than `isUnderWorktreePath()` — a manually-created
+ * `tmp/worktrees/<slug>/` directory inside the main checkout passes
+ * `isUnderWorktreePath()` but fails `isListedWorktree()` because it is
+ * not a real git worktree.
+ *
+ * Resolves symlinks via realpathSync so that /var vs /private/var
+ * differences on macOS do not cause false negatives.
+ *
+ * @param {string} cwd - Absolute or relative path to the current working directory.
+ * @param {string[]} worktreePaths - Array of paths from `parseAllWorktreePaths`.
+ * @returns {boolean}
+ */
+export function isListedWorktree(cwd, worktreePaths) {
+  let resolvedCwd;
+  try { resolvedCwd = realpathSync(cwd); } catch { resolvedCwd = cwd; }
+  const normalized = resolvedCwd.replace(/\\/g, "/").replace(/\/+$/u, "");
+  return worktreePaths.some((p) => {
+    let resolvedP;
+    try { resolvedP = realpathSync(p); } catch { resolvedP = p; }
+    return resolvedP.replace(/\\/g, "/").replace(/\/+$/u, "") === normalized;
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/loop/worktree-guard.mjs
+++ b/packages/core/src/loop/worktree-guard.mjs
@@ -1,0 +1,82 @@
+/**
+ * Shared worktree and subagent guard primitives.
+ *
+ * Extracted from `scripts/loop/pre-commit-branch-guard.mjs` so that both the
+ * pre-commit guard and the new pre-flight gate share one implementation.
+ *
+ * This module is intentionally pure and side-effect free.
+ */
+
+// ---------------------------------------------------------------------------
+// Worktree path helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether `cwd` is under a tmp/worktrees path segment.
+ *
+ * @param {string} cwd - Absolute or relative path to the current working directory.
+ * @returns {boolean}
+ */
+export function isUnderWorktreePath(cwd) {
+  const normalized = cwd.replace(/\\/g, "/");
+  return /(?:^|\/)tmp\/worktrees(?:\/|$)/.test(normalized);
+}
+
+/**
+ * Parse the main (primary) git worktree path from `git worktree list` output.
+ *
+ * The first line of `git worktree list` is the primary worktree.
+ * Format: `<path>  <sha> [<branch>]`
+ *
+ * @param {string} worktreeListOutput - Raw stdout from `git worktree list`.
+ * @returns {string | null} The main worktree path, or null if it cannot be parsed.
+ */
+export function parseMainWorktreePath(worktreeListOutput) {
+  const firstLine = worktreeListOutput.split("\n")[0].trim();
+  if (!firstLine) return null;
+  // Find the last hex SHA (7+ chars) in the line and take everything before it as the path.
+  const shaIdx = firstLine.search(/\s[0-9a-f]{7,64}\b/iu);
+  if (shaIdx === -1) return null;
+  return firstLine.slice(0, shaIdx).trim();
+}
+
+/**
+ * Check whether `cwd` is the main git checkout (or a subdirectory of it).
+ *
+ * @param {string} cwd - Absolute or relative path to the current working directory.
+ * @param {string | null} mainWorktreePath - The main worktree path from `parseMainWorktreePath`.
+ * @returns {boolean}
+ */
+export function isMainCheckout(cwd, mainWorktreePath) {
+  if (!mainWorktreePath) return false;
+  const normalizedCwd = cwd.replace(/\\/g, "/").replace(/\/+$/u, "");
+  const normalizedMain = mainWorktreePath.replace(/\\/g, "/").replace(/\/+$/u, "");
+  return normalizedCwd === normalizedMain || normalizedCwd.startsWith(normalizedMain + "/");
+}
+
+// ---------------------------------------------------------------------------
+// Subagent availability
+// ---------------------------------------------------------------------------
+
+/**
+ * Environment variable name checked by `detectSubagentAvailability`.
+ *
+ * Set `PI_SUBAGENT_AVAILABLE=1` when the runtime supports subagent dispatch.
+ * This is consistent with the `PI_WORKTREE_BYPASS` and `PI_ASYNC_START_BYPASS`
+ * patterns already present in the repo.
+ */
+export const PI_SUBAGENT_AVAILABLE_VAR = "PI_SUBAGENT_AVAILABLE";
+
+/**
+ * Detect whether subagent dispatch is available in the current runtime.
+ *
+ * This is an env-var-based heuristic, consistent with other bypass/availability
+ * patterns in the repo. It is intentionally simple — the gate's subagent check
+ * is advisory (fails-open) and never hard-blocks on subagent absence.
+ *
+ * @param {{ env?: Record<string, string | undefined> }} [options]
+ * @returns {boolean}
+ */
+export function detectSubagentAvailability({ env = process.env } = {}) {
+  return (env[PI_SUBAGENT_AVAILABLE_VAR] ?? "").trim() === "1";
+}

--- a/packages/core/src/loop/worktree-guard.mjs
+++ b/packages/core/src/loop/worktree-guard.mjs
@@ -36,7 +36,7 @@ export function isUnderWorktreePath(cwd) {
 export function parseMainWorktreePath(worktreeListOutput) {
   const firstLine = worktreeListOutput.split("\n")[0].trim();
   if (!firstLine) return null;
-  // Find the last hex SHA (7+ chars) in the line and take everything before it as the path.
+  // Find the first hex SHA (7+ chars) preceded by whitespace; take everything before it as the path.
   const shaIdx = firstLine.search(/\s[0-9a-f]{7,64}\b/iu);
   if (shaIdx === -1) return null;
   return firstLine.slice(0, shaIdx).trim();

--- a/packages/core/test/worktree-guard.test.mjs
+++ b/packages/core/test/worktree-guard.test.mjs
@@ -5,6 +5,8 @@ import {
   isUnderWorktreePath,
   parseMainWorktreePath,
   isMainCheckout,
+  parseAllWorktreePaths,
+  isListedWorktree,
   detectSubagentAvailability,
   PI_SUBAGENT_AVAILABLE_VAR,
 } from "../src/loop/worktree-guard.mjs";
@@ -118,6 +120,90 @@ test("isMainCheckout: false when mainWorktreePath is empty", () => {
   assert.equal(isMainCheckout("/home/user/repo", ""), false);
 });
 
+// ---------------------------------------------------------------------------
+// parseAllWorktreePaths
+// ---------------------------------------------------------------------------
+
+test("parseAllWorktreePaths: parses multiple worktree paths", () => {
+  const output = "/home/user/repo  535a18a [main]\n/home/user/repo/tmp/worktrees/issue-1  535a18a [issue-1]\n";
+  const paths = parseAllWorktreePaths(output);
+  assert.deepEqual(paths, ["/home/user/repo", "/home/user/repo/tmp/worktrees/issue-1"]);
+});
+
+test("parseAllWorktreePaths: handles paths with spaces", () => {
+  const output = "/home/user/my repo  535a18a [main]\n";
+  assert.deepEqual(parseAllWorktreePaths(output), ["/home/user/my repo"]);
+});
+
+test("parseAllWorktreePaths: skips empty lines", () => {
+  const output = "\n/home/user/repo  535a18a [main]\n\n";
+  assert.deepEqual(parseAllWorktreePaths(output), ["/home/user/repo"]);
+});
+
+test("parseAllWorktreePaths: returns empty array for empty output", () => {
+  assert.deepEqual(parseAllWorktreePaths(""), []);
+});
+
+test("parseAllWorktreePaths: skips lines without SHA", () => {
+  const output = "/home/user/repo\n/home/user/repo  535a18a [main]\n";
+  assert.deepEqual(parseAllWorktreePaths(output), ["/home/user/repo"]);
+});
+
+// ---------------------------------------------------------------------------
+// isListedWorktree
+// ---------------------------------------------------------------------------
+
+test("isListedWorktree: true when cwd matches a listed worktree root exactly", () => {
+  assert.equal(isListedWorktree("/home/user/repo/tmp/worktrees/issue-1", [
+    "/home/user/repo",
+    "/home/user/repo/tmp/worktrees/issue-1",
+  ]), true);
+});
+
+test("isListedWorktree: true when cwd is a subdirectory of a listed worktree", () => {
+  assert.equal(isListedWorktree("/home/user/repo/tmp/worktrees/issue-1/src", [
+    "/home/user/repo",
+    "/home/user/repo/tmp/worktrees/issue-1",
+  ]), true);
+});
+
+test("isListedWorktree: true with trailing slash on cwd", () => {
+  assert.equal(isListedWorktree("/home/user/repo/tmp/worktrees/issue-1/", [
+    "/home/user/repo",
+    "/home/user/repo/tmp/worktrees/issue-1",
+  ]), true);
+});
+
+test("isListedWorktree: true with Windows backslashes", () => {
+  assert.equal(isListedWorktree("C:\\repo\\tmp\\worktrees\\issue-1\\src", [
+    "C:\\repo",
+    "C:\\repo\\tmp\\worktrees\\issue-1",
+  ]), true);
+});
+
+test("isListedWorktree: false when cwd is main checkout (not a worktree)", () => {
+  assert.equal(isListedWorktree("/home/user/repo", [
+    "/home/user/repo",
+    "/home/user/repo/tmp/worktrees/issue-1",
+  ]), false);  // false because main checkout is excluded from worktree matching
+});
+
+test("isListedWorktree: false when cwd is not in list", () => {
+  assert.equal(isListedWorktree("/home/user/other", [
+    "/home/user/repo",
+    "/home/user/repo/tmp/worktrees/issue-1",
+  ]), false);
+});
+
+test("isListedWorktree: false when cwd is under a non-worktree directory", () => {
+  assert.equal(isListedWorktree("/home/user/repo/tmp/worktrees/fake/src", [
+    "/home/user/repo",
+    "/home/user/repo/tmp/worktrees/issue-1",
+  ]), false);
+});
+
+// ---------------------------------------------------------------------------
+// detectSubagentAvailability
 // ---------------------------------------------------------------------------
 // detectSubagentAvailability
 // ---------------------------------------------------------------------------

--- a/packages/core/test/worktree-guard.test.mjs
+++ b/packages/core/test/worktree-guard.test.mjs
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isUnderWorktreePath,
+  parseMainWorktreePath,
+  isMainCheckout,
+  detectSubagentAvailability,
+  PI_SUBAGENT_AVAILABLE_VAR,
+} from "../src/loop/worktree-guard.mjs";
+
+// ---------------------------------------------------------------------------
+// isUnderWorktreePath
+// ---------------------------------------------------------------------------
+
+test("isUnderWorktreePath: true when under tmp/worktrees/foo", () => {
+  assert.equal(isUnderWorktreePath("/home/user/repo/tmp/worktrees/issue-1"), true);
+});
+
+test("isUnderWorktreePath: true when exactly tmp/worktrees", () => {
+  assert.equal(isUnderWorktreePath("/home/user/repo/tmp/worktrees"), true);
+});
+
+test("isUnderWorktreePath: true with trailing slash", () => {
+  assert.equal(isUnderWorktreePath("/home/user/repo/tmp/worktrees/issue-1/"), true);
+});
+
+test("isUnderWorktreePath: true with Windows backslashes", () => {
+  assert.equal(isUnderWorktreePath("C:\\repo\\tmp\\worktrees\\issue-1"), true);
+});
+
+test("isUnderWorktreePath: false for main checkout", () => {
+  assert.equal(isUnderWorktreePath("/home/user/repo"), false);
+});
+
+test("isUnderWorktreePath: false for tmp/ but not worktrees", () => {
+  assert.equal(isUnderWorktreePath("/home/user/repo/tmp/phases"), false);
+});
+
+test("isUnderWorktreePath: false for path containing worktrees as substring elsewhere", () => {
+  assert.equal(isUnderWorktreePath("/home/user/not-tmp/worktrees/issue-1"), false);
+});
+
+// ---------------------------------------------------------------------------
+// parseMainWorktreePath
+// ---------------------------------------------------------------------------
+
+test("parseMainWorktreePath: parses standard git worktree list output", () => {
+  const output = "/home/user/repo  535a18a [main]\n/home/user/repo/tmp/worktrees/issue-1  535a18a [issue-1]\n";
+  assert.equal(parseMainWorktreePath(output), "/home/user/repo");
+});
+
+test("parseMainWorktreePath: parses without branch annotation", () => {
+  const output = "/home/user/repo  535a18a\n";
+  assert.equal(parseMainWorktreePath(output), "/home/user/repo");
+});
+
+test("parseMainWorktreePath: parses path with spaces", () => {
+  const output = "/home/user/my repo  535a18a [main]\n";
+  assert.equal(parseMainWorktreePath(output), "/home/user/my repo");
+});
+
+test("parseMainWorktreePath: returns null for empty output", () => {
+  assert.equal(parseMainWorktreePath(""), null);
+});
+
+test("parseMainWorktreePath: returns null for whitespace-only output", () => {
+  assert.equal(parseMainWorktreePath("   \n  "), null);
+});
+
+test("parseMainWorktreePath: returns null for malformed output (no SHA)", () => {
+  assert.equal(parseMainWorktreePath("/home/user/repo"), null);
+});
+
+test("parseMainWorktreePath: returns null for output without path", () => {
+  assert.equal(parseMainWorktreePath("535a18a [main]"), null);
+});
+
+// ---------------------------------------------------------------------------
+// isMainCheckout
+// ---------------------------------------------------------------------------
+
+test("isMainCheckout: true when cwd matches main worktree path exactly", () => {
+  assert.equal(isMainCheckout("/home/user/repo", "/home/user/repo"), true);
+});
+
+test("isMainCheckout: true when cwd is subdirectory of main worktree", () => {
+  assert.equal(isMainCheckout("/home/user/repo/src", "/home/user/repo"), true);
+});
+
+test("isMainCheckout: true with trailing slash on cwd", () => {
+  assert.equal(isMainCheckout("/home/user/repo/", "/home/user/repo"), true);
+});
+
+test("isMainCheckout: true with trailing slash on main path", () => {
+  assert.equal(isMainCheckout("/home/user/repo", "/home/user/repo/"), true);
+});
+
+test("isMainCheckout: true with Windows separators", () => {
+  assert.equal(isMainCheckout("C:\\repo\\src", "C:\\repo"), true);
+});
+
+test("isMainCheckout: false when cwd is a sibling directory", () => {
+  assert.equal(isMainCheckout("/home/user/other-repo", "/home/user/repo"), false);
+});
+
+test("isMainCheckout: true even for worktree path (caller filters with isUnderWorktreePath)", () => {
+  // isMainCheckout uses startsWith — worktree paths are technically subdirectories.
+  // Callers must combine with !isUnderWorktreePath() to exclude worktree paths.
+  assert.equal(isMainCheckout("/home/user/repo/tmp/worktrees/issue-1", "/home/user/repo"), true);
+});
+
+test("isMainCheckout: false when mainWorktreePath is null", () => {
+  assert.equal(isMainCheckout("/home/user/repo", null), false);
+});
+
+test("isMainCheckout: false when mainWorktreePath is empty", () => {
+  assert.equal(isMainCheckout("/home/user/repo", ""), false);
+});
+
+// ---------------------------------------------------------------------------
+// detectSubagentAvailability
+// ---------------------------------------------------------------------------
+
+test("detectSubagentAvailability: true when PI_SUBAGENT_AVAILABLE=1", () => {
+  assert.equal(detectSubagentAvailability({ env: { PI_SUBAGENT_AVAILABLE: "1" } }), true);
+});
+
+test("detectSubagentAvailability: false when PI_SUBAGENT_AVAILABLE is not set", () => {
+  assert.equal(detectSubagentAvailability({ env: {} }), false);
+});
+
+test("detectSubagentAvailability: false when PI_SUBAGENT_AVAILABLE is empty", () => {
+  assert.equal(detectSubagentAvailability({ env: { PI_SUBAGENT_AVAILABLE: "" } }), false);
+});
+
+test("detectSubagentAvailability: false when PI_SUBAGENT_AVAILABLE is zero", () => {
+  assert.equal(detectSubagentAvailability({ env: { PI_SUBAGENT_AVAILABLE: "0" } }), false);
+});
+
+test("detectSubagentAvailability: false when PI_SUBAGENT_AVAILABLE is whitespace", () => {
+  assert.equal(detectSubagentAvailability({ env: { PI_SUBAGENT_AVAILABLE: "  " } }), false);
+});
+
+test("detectSubagentAvailability: defaults to process.env when no arg", () => {
+  // Trivial smoke: call without args to confirm no throw.
+  const result = detectSubagentAvailability();
+  assert.equal(typeof result, "boolean");
+});
+
+// ---------------------------------------------------------------------------
+// PI_SUBAGENT_AVAILABLE_VAR constant
+// ---------------------------------------------------------------------------
+
+test("PI_SUBAGENT_AVAILABLE_VAR: matches the env var name", () => {
+  assert.equal(PI_SUBAGENT_AVAILABLE_VAR, "PI_SUBAGENT_AVAILABLE");
+});

--- a/scripts/loop/pre-commit-branch-guard.mjs
+++ b/scripts/loop/pre-commit-branch-guard.mjs
@@ -1,6 +1,11 @@
 #!/usr/bin/env node
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { requireOptionValue, runCommand } from "../_cli-primitives.mjs";
+import {
+  isUnderWorktreePath,
+  parseMainWorktreePath,
+  isMainCheckout,
+} from "../../packages/core/src/loop/worktree-guard.mjs";
 
 const USAGE = `Usage:
   pre-commit-branch-guard.mjs --expected-branch <name> [--require-worktree] [--block-main-checkout]
@@ -80,28 +85,7 @@ export function parseBranchGuardCliArgs(argv) {
   return options;
 }
 
-export function isUnderWorktreePath(cwd) {
-  const normalized = cwd.replace(/\\/g, "/");
-  // Match tmp/worktrees as a path segment; allow cwd to be exactly the worktrees dir
-  return /(?:^|\/)tmp\/worktrees(?:\/|$)/.test(normalized);
-}
 
-export function parseMainWorktreePath(worktreeListOutput) {
-  const firstLine = worktreeListOutput.split("\n")[0].trim();
-  if (!firstLine) return null;
-  // git worktree list format: "<path>  <sha> [<branch>]"
-  // Find the last hex SHA (7+ chars) in the line and take everything before it as the path.
-  const shaIdx = firstLine.search(/\s[0-9a-f]{7,64}\b/iu);
-  if (shaIdx === -1) return null;
-  return firstLine.slice(0, shaIdx).trim();
-}
-
-export function isMainCheckout(cwd, mainWorktreePath) {
-  if (!mainWorktreePath) return false;
-  const normalizedCwd = cwd.replace(/\\/g, "/").replace(/\/+$/u, "");
-  const normalizedMain = mainWorktreePath.replace(/\\/g, "/").replace(/\/+$/u, "");
-  return normalizedCwd === normalizedMain || normalizedCwd.startsWith(normalizedMain + "/");
-}
 
 export async function runCli(
   argv = process.argv.slice(2),

--- a/scripts/loop/pre-flight-gate.mjs
+++ b/scripts/loop/pre-flight-gate.mjs
@@ -180,7 +180,7 @@ function checkWorktreeIsolation({ cwd, env, gitCommand = "git" }) {
  * @param {Record<string, string | undefined>} opts.env
  * @param {string | undefined} opts.expectedBranch
  * @param {string} [opts.gitCommand]
- * @returns {{ ok: true, status: "matched" | "skipped", branch?: string } | { ok: false, error: string, guidance: string }}
+ * @returns {{ ok: true, status: "matched" | "skipped", branch?: string } | { ok: false, status: "error" | "mismatch", error: string, guidance: string }}
  */
 function checkBranchIdentity({ cwd, env, expectedBranch, gitCommand = "git" }) {
   if (!expectedBranch) {

--- a/scripts/loop/pre-flight-gate.mjs
+++ b/scripts/loop/pre-flight-gate.mjs
@@ -22,6 +22,8 @@ import {
   isUnderWorktreePath,
   parseMainWorktreePath,
   isMainCheckout,
+  parseAllWorktreePaths,
+  isListedWorktree,
   detectSubagentAvailability,
 } from "../../packages/core/src/loop/worktree-guard.mjs";
 
@@ -153,6 +155,22 @@ function checkWorktreeIsolation({ cwd, env, gitCommand = "git" }) {
     };
   }
 
+  // Even if cwd is under tmp/worktrees/, verify it is actually a listed git worktree
+  // (not just a manually-created directory inside the main checkout).
+  const allPaths = parseAllWorktreePaths(worktreeListOutput);
+  if (!isListedWorktree(cwd, allPaths)) {
+    return {
+      ok: false,
+      error: "not_in_worktree",
+      guidance:
+        "Current directory is under tmp/worktrees/ but is not a real git worktree.\n" +
+        "Create a worktree with:\n" +
+        "  git worktree add -b <branch> tmp/worktrees/<slug>/ origin/main\n" +
+        "Then re-run from the worktree directory.",
+      mainWorktreePath: mainWorktreePath ?? undefined,
+    };
+  }
+
   return { ok: true, mainWorktreePath: mainWorktreePath ?? undefined };
 }
 
@@ -180,6 +198,7 @@ function checkBranchIdentity({ cwd, env, expectedBranch, gitCommand = "git" }) {
   } catch {
     return {
       ok: false,
+      status: "error",
       error: "branch_check_failed",
       guidance: "Could not determine current branch. Verify the repository is a valid git working directory.",
     };
@@ -188,6 +207,7 @@ function checkBranchIdentity({ cwd, env, expectedBranch, gitCommand = "git" }) {
   if (currentBranch !== expectedBranch) {
     return {
       ok: false,
+      status: "mismatch",
       error: "branch_mismatch",
       guidance: `Expected branch "${expectedBranch}" but current branch is "${currentBranch}". Switch to the working branch and re-run.`,
     };

--- a/scripts/loop/pre-flight-gate.mjs
+++ b/scripts/loop/pre-flight-gate.mjs
@@ -110,7 +110,7 @@ export function parsePreFlightGateCliArgs(argv) {
  * @param {string} opts.cwd
  * @param {Record<string, string | undefined>} opts.env
  * @param {string} [opts.gitCommand]
- * @returns {{ ok: true, mainWorktreePath: string } | { ok: false, error: string, guidance: string, mainWorktreePath?: string }}
+ * @returns {{ ok: true, mainWorktreePath?: string } | { ok: false, error: string, guidance: string, mainWorktreePath?: string }}
  */
 function checkWorktreeIsolation({ cwd, env, gitCommand = "git" }) {
   let worktreeListOutput;

--- a/scripts/loop/pre-flight-gate.mjs
+++ b/scripts/loop/pre-flight-gate.mjs
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+/**
+ * Pre-flight gate for local implementation mutations.
+ *
+ * Runs before any planning or implementation work to enforce:
+ * 1. Worktree isolation (current directory is under tmp/worktrees/)
+ * 2. Branch identity (current branch matches --expected-branch when provided)
+ * 3. Subagent availability (advisory; fails-open when --require-subagents set)
+ *
+ * Fails closed on any violation: exit code 1 + machine-readable JSON on stderr.
+ *
+ * Usage:
+ *   pre-flight-gate.mjs [--expected-branch <name>] [--require-subagents]
+ *
+ * Bypass: PI_PREFLIGHT_BYPASS=1
+ */
+
+import { execFileSync } from "node:child_process";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { requireOptionValue } from "../_cli-primitives.mjs";
+import {
+  isUnderWorktreePath,
+  parseMainWorktreePath,
+  isMainCheckout,
+  detectSubagentAvailability,
+} from "../../packages/core/src/loop/worktree-guard.mjs";
+
+const PI_PREFLIGHT_BYPASS_VAR = "PI_PREFLIGHT_BYPASS";
+
+const USAGE = `Usage:
+  pre-flight-gate.mjs [--expected-branch <name>] [--require-subagents]
+
+Gate local implementation mutations before planning or editing.
+
+Required environment:
+  (none)
+
+Optional:
+  --expected-branch <name>   Expected current branch (for branch identity check).
+  --require-subagents        Require subagent availability (advisory; fails-open).
+
+Success output (stdout, JSON):
+  { "ok": true, "checks": { "worktree": true, "branch": "matched",
+    "subagents": "available" } }
+
+Violation output (stderr, JSON, exit 1):
+  { "ok": false, "error": "<error_code>", "checks": { ... },
+    "guidance": "<actionable instruction for the agent>" }
+
+Bypass:
+  PI_PREFLIGHT_BYPASS=1   Skip all checks (for development/testing only).`.trim();
+
+const parseError = buildParseError(USAGE);
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} PreFlightGateOptions
+ * @property {boolean} help
+ * @property {string | undefined} expectedBranch
+ * @property {boolean} requireSubagents
+ */
+
+/**
+ * @param {string[]} argv
+ * @returns {PreFlightGateOptions}
+ */
+export function parsePreFlightGateCliArgs(argv) {
+  const args = [...argv];
+  const options = {
+    help: false,
+    expectedBranch: undefined,
+    requireSubagents: false,
+  };
+
+  while (args.length > 0) {
+    const token = args.shift();
+
+    if (token === "--help" || token === "-h") {
+      options.help = true;
+      return options;
+    }
+
+    if (token === "--expected-branch") {
+      options.expectedBranch = requireOptionValue(args, "--expected-branch", parseError, { flagPattern: /^-/u });
+      continue;
+    }
+
+    if (token === "--require-subagents") {
+      options.requireSubagents = true;
+      continue;
+    }
+
+    throw parseError(`Unknown argument: ${token}`);
+  }
+
+  return options;
+}
+
+// ---------------------------------------------------------------------------
+// Check runners
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {object} opts
+ * @param {string} opts.cwd
+ * @param {Record<string, string | undefined>} opts.env
+ * @param {string} [opts.gitCommand]
+ * @returns {{ ok: true, mainWorktreePath: string } | { ok: false, error: string, guidance: string, mainWorktreePath?: string }}
+ */
+function checkWorktreeIsolation({ cwd, env, gitCommand = "git" }) {
+  let worktreeListOutput;
+  try {
+    worktreeListOutput = execFileSync(gitCommand, ["worktree", "list"], {
+      cwd,
+      env,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch {
+    return {
+      ok: false,
+      error: "worktree_list_failed",
+      guidance: "Could not run `git worktree list`. Verify the repository is a valid git working directory.",
+    };
+  }
+
+  const mainWorktreePath = parseMainWorktreePath(worktreeListOutput);
+
+  if (!isUnderWorktreePath(cwd)) {
+    if (mainWorktreePath !== null && isMainCheckout(cwd, mainWorktreePath)) {
+      return {
+        ok: false,
+        error: "main_checkout_detected",
+        guidance:
+          `Current directory appears to be the main git checkout (${mainWorktreePath}).\n` +
+          "Local implementation requires worktree isolation. Create a worktree:\n" +
+          "  git worktree add -b <branch> tmp/worktrees/<slug>/ origin/main\n" +
+          "Then re-run from the worktree directory.",
+        mainWorktreePath,
+      };
+    }
+    return {
+      ok: false,
+      error: "not_in_worktree",
+      guidance:
+        "Local implementation requires worktree isolation. Create a worktree:\n" +
+        "  git worktree add -b <branch> tmp/worktrees/<slug>/ origin/main\n" +
+        "Then re-run from the worktree directory.",
+      mainWorktreePath: mainWorktreePath ?? undefined,
+    };
+  }
+
+  return { ok: true, mainWorktreePath: mainWorktreePath ?? undefined };
+}
+
+/**
+ * @param {object} opts
+ * @param {string} opts.cwd
+ * @param {Record<string, string | undefined>} opts.env
+ * @param {string | undefined} opts.expectedBranch
+ * @param {string} [opts.gitCommand]
+ * @returns {{ ok: true, status: "matched" | "skipped", branch?: string } | { ok: false, error: string, guidance: string }}
+ */
+function checkBranchIdentity({ cwd, env, expectedBranch, gitCommand = "git" }) {
+  if (!expectedBranch) {
+    return { ok: true, status: "skipped" };
+  }
+
+  let currentBranch;
+  try {
+    currentBranch = execFileSync(gitCommand, ["branch", "--show-current"], {
+      cwd,
+      env,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return {
+      ok: false,
+      error: "branch_check_failed",
+      guidance: "Could not determine current branch. Verify the repository is a valid git working directory.",
+    };
+  }
+
+  if (currentBranch !== expectedBranch) {
+    return {
+      ok: false,
+      error: "branch_mismatch",
+      guidance: `Expected branch "${expectedBranch}" but current branch is "${currentBranch}". Switch to the working branch and re-run.`,
+    };
+  }
+
+  return { ok: true, status: "matched", branch: currentBranch };
+}
+
+/**
+ * @param {object} opts
+ * @param {Record<string, string | undefined>} opts.env
+ * @param {boolean} opts.requireSubagents
+ * @returns {{ ok: true, status: "available" | "unavailable" | "skipped" }}
+ */
+function checkSubagentAvailability({ env, requireSubagents }) {
+  if (!requireSubagents) {
+    return { ok: true, status: "skipped" };
+  }
+
+  const available = detectSubagentAvailability({ env });
+  return { ok: true, status: available ? "available" : "unavailable" };
+}
+
+// ---------------------------------------------------------------------------
+// Main runner
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string[]} argv
+ * @param {object} [io]
+ * @param {NodeJS.WriteStream} [io.stdout]
+ * @param {NodeJS.WriteStream} [io.stderr]
+ * @param {string} [io.cwd]
+ * @param {Record<string, string | undefined>} [io.env]
+ * @param {string} [io.gitCommand]
+ * @returns {Promise<{ ok: boolean }>}
+ */
+export async function runCli(
+  argv = process.argv.slice(2),
+  {
+    stdout = process.stdout,
+    stderr = process.stderr,
+    cwd = process.cwd(),
+    env = process.env,
+    gitCommand = "git",
+  } = {},
+) {
+  const options = parsePreFlightGateCliArgs(argv);
+
+  if (options.help) {
+    stdout.write(`${USAGE}\n`);
+    return { ok: true, help: true };
+  }
+
+  // Bypass
+  if ((env[PI_PREFLIGHT_BYPASS_VAR] ?? "").trim() === "1") {
+    const payload = {
+      ok: true,
+      checks: { worktree: true, branch: "skipped", subagents: "skipped" },
+      summary: "pre-flight gate bypassed via PI_PREFLIGHT_BYPASS=1",
+    };
+    stdout.write(`${JSON.stringify(payload)}\n`);
+    return payload;
+  }
+
+  const checks = { worktree: false, branch: "skipped", subagents: "skipped" };
+  const errors = [];
+
+  // 1. Worktree isolation (always runs)
+  const worktreeResult = checkWorktreeIsolation({ cwd, env, gitCommand });
+  checks.worktree = worktreeResult.ok;
+  if (!worktreeResult.ok) {
+    errors.push({
+      check: "worktree",
+      error: worktreeResult.error,
+      guidance: worktreeResult.guidance,
+    });
+  }
+
+  // 2. Branch identity (when --expected-branch provided)
+  const branchResult = checkBranchIdentity({
+    cwd,
+    env,
+    expectedBranch: options.expectedBranch,
+    gitCommand,
+  });
+  checks.branch = branchResult.status;
+  if (!branchResult.ok) {
+    errors.push({
+      check: "branch",
+      error: branchResult.error,
+      guidance: branchResult.guidance,
+    });
+  }
+
+  // 3. Subagent availability (advisory; fails-open)
+  const subagentResult = checkSubagentAvailability({
+    env,
+    requireSubagents: options.requireSubagents,
+  });
+  checks.subagents = subagentResult.status;
+
+  if (errors.length > 0) {
+    const payload = {
+      ok: false,
+      error: errors[0].error,
+      checks,
+      guidance: errors.map((e) => e.guidance).join("\n\n"),
+      errors,
+    };
+    stderr.write(`${JSON.stringify(payload)}\n`);
+    return payload;
+  }
+
+  const payload = {
+    ok: true,
+    checks,
+    summary: "all checks passed",
+  };
+  stdout.write(`${JSON.stringify(payload)}\n`);
+  return payload;
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli()
+    .then((result) => {
+      if (result?.ok === false) {
+        process.exitCode = 1;
+      }
+    })
+    .catch((error) => {
+      process.stderr.write(`${formatCliError(error)}\n`);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/loop/pre-flight-gate.mjs
+++ b/scripts/loop/pre-flight-gate.mjs
@@ -5,12 +5,12 @@
  * Runs before any planning or implementation work to enforce:
  * 1. Worktree isolation (current directory is under tmp/worktrees/)
  * 2. Branch identity (current branch matches --expected-branch when provided)
- * 3. Subagent availability (advisory; fails-open when --require-subagents set)
+ * 3. Subagent availability (advisory; fails-open when --check-subagents set)
  *
  * Fails closed on any violation: exit code 1 + machine-readable JSON on stderr.
  *
  * Usage:
- *   pre-flight-gate.mjs [--expected-branch <name>] [--require-subagents]
+ *   pre-flight-gate.mjs [--expected-branch <name>] [--check-subagents]
  *
  * Bypass: PI_PREFLIGHT_BYPASS=1
  */
@@ -30,7 +30,7 @@ import {
 const PI_PREFLIGHT_BYPASS_VAR = "PI_PREFLIGHT_BYPASS";
 
 const USAGE = `Usage:
-  pre-flight-gate.mjs [--expected-branch <name>] [--require-subagents]
+  pre-flight-gate.mjs [--expected-branch <name>] [--check-subagents]
 
 Gate local implementation mutations before planning or editing.
 
@@ -39,7 +39,7 @@ Required environment:
 
 Optional:
   --expected-branch <name>   Expected current branch (for branch identity check).
-  --require-subagents        Require subagent availability (advisory; fails-open).
+  --check-subagents        Check subagent availability (advisory; fails-open).
 
 Success output (stdout, JSON):
   { "ok": true, "checks": { "worktree": true, "branch": "matched",
@@ -62,7 +62,7 @@ const parseError = buildParseError(USAGE);
  * @typedef {object} PreFlightGateOptions
  * @property {boolean} help
  * @property {string | undefined} expectedBranch
- * @property {boolean} requireSubagents
+ * @property {boolean} checkSubagents
  */
 
 /**
@@ -74,7 +74,7 @@ export function parsePreFlightGateCliArgs(argv) {
   const options = {
     help: false,
     expectedBranch: undefined,
-    requireSubagents: false,
+    checkSubagents: false,
   };
 
   while (args.length > 0) {
@@ -90,8 +90,8 @@ export function parsePreFlightGateCliArgs(argv) {
       continue;
     }
 
-    if (token === "--require-subagents") {
-      options.requireSubagents = true;
+    if (token === "--check-subagents") {
+      options.checkSubagents = true;
       continue;
     }
 
@@ -219,11 +219,11 @@ function checkBranchIdentity({ cwd, env, expectedBranch, gitCommand = "git" }) {
 /**
  * @param {object} opts
  * @param {Record<string, string | undefined>} opts.env
- * @param {boolean} opts.requireSubagents
+ * @param {boolean} opts.checkSubagents
  * @returns {{ ok: true, status: "available" | "unavailable" | "skipped" }}
  */
-function checkSubagentAvailability({ env, requireSubagents }) {
-  if (!requireSubagents) {
+function checkSubagentAvailability({ env, checkSubagents }) {
+  if (!checkSubagents) {
     return { ok: true, status: "skipped" };
   }
 
@@ -306,7 +306,7 @@ export async function runCli(
   // 3. Subagent availability (advisory; fails-open)
   const subagentResult = checkSubagentAvailability({
     env,
-    requireSubagents: options.requireSubagents,
+    checkSubagents: options.checkSubagents,
   });
   checks.subagents = subagentResult.status;
 

--- a/scripts/loop/resolve-dev-loop-startup.mjs
+++ b/scripts/loop/resolve-dev-loop-startup.mjs
@@ -281,10 +281,22 @@ export function buildResolveDevLoopStartupResult(input, { env = process.env, cwd
       });
       const mainPath = parseMainWorktreePath(worktreeOutput);
       const allPaths = parseAllWorktreePaths(worktreeOutput);
-      if (!isUnderWorktreePath(cwd) || !isListedWorktree(cwd, allPaths)) {
+      if (!isUnderWorktreePath(cwd)) {
         const reason = mainPath !== null && isMainCheckout(cwd, mainPath)
           ? `Local implementation requires worktree isolation. Current directory is the main git checkout (${mainPath}). Create a worktree under tmp/worktrees/<slug>/ and re-run.`
           : "Local implementation requires worktree isolation. Current directory is not under tmp/worktrees/. Create a worktree and re-run.";
+        return {
+          ok: true,
+          bundleKind: "needs_reconcile",
+          selectedStrategy: "none",
+          requiredReads: STRATEGY_REQUIRED_READS["none"],
+          nextAction: reason,
+          canonicalStateSummary: summarizeCanonicalState(bundle),
+          bundle,
+        };
+      }
+      if (!isListedWorktree(cwd, allPaths)) {
+        const reason = `Local implementation requires worktree isolation. Current directory is under tmp/worktrees/ but is not listed as a git worktree by \`git worktree list\`. Create a proper worktree with \`git worktree add\` and re-run.`;
         return {
           ok: true,
           bundleKind: "needs_reconcile",

--- a/scripts/loop/resolve-dev-loop-startup.mjs
+++ b/scripts/loop/resolve-dev-loop-startup.mjs
@@ -11,6 +11,8 @@ import {
   isUnderWorktreePath,
   parseMainWorktreePath,
   isMainCheckout,
+  parseAllWorktreePaths,
+  isListedWorktree,
 } from "../../packages/core/src/loop/worktree-guard.mjs";
 
 import {
@@ -278,7 +280,8 @@ export function buildResolveDevLoopStartupResult(input, { env = process.env, cwd
         stdio: ["ignore", "pipe", "pipe"],
       });
       const mainPath = parseMainWorktreePath(worktreeOutput);
-      if (!isUnderWorktreePath(cwd)) {
+      const allPaths = parseAllWorktreePaths(worktreeOutput);
+      if (!isUnderWorktreePath(cwd) || !isListedWorktree(cwd, allPaths)) {
         const reason = mainPath !== null && isMainCheckout(cwd, mainPath)
           ? `Local implementation requires worktree isolation. Current directory is the main git checkout (${mainPath}). Create a worktree under tmp/worktrees/<slug>/ and re-run.`
           : "Local implementation requires worktree isolation. Current directory is not under tmp/worktrees/. Create a worktree and re-run.";

--- a/scripts/loop/resolve-dev-loop-startup.mjs
+++ b/scripts/loop/resolve-dev-loop-startup.mjs
@@ -296,8 +296,19 @@ export function buildResolveDevLoopStartupResult(input, { env = process.env, cwd
         };
       }
     } catch {
-      // If git worktree list fails, pass through — don't block routing on
-      // a git command failure. The pre-flight gate will catch this later.
+      // If git worktree list fails, fail closed — we cannot validate worktree
+      // isolation so we must not allow local_implementation routing from an unknown
+      // directory. The pre-flight gate provides a secondary guard for the actual
+      // implementation session.
+      return {
+        ok: true,
+        bundleKind: "needs_reconcile",
+        selectedStrategy: "none",
+        requiredReads: STRATEGY_REQUIRED_READS["none"],
+        nextAction: "Local implementation requires worktree isolation but git worktree list failed. Verify the repository and re-run from a worktree under tmp/worktrees/.",
+        canonicalStateSummary: summarizeCanonicalState(bundle),
+        bundle,
+      };
     }
   }
 

--- a/scripts/loop/resolve-dev-loop-startup.mjs
+++ b/scripts/loop/resolve-dev-loop-startup.mjs
@@ -6,6 +6,12 @@ import path from "node:path";
 import { resolveAuthoritativeStartupResumeBundle } from "../../packages/core/src/loop/public-dev-loop-routing.mjs";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { requireOptionValue } from "../_cli-primitives.mjs";
+import { execFileSync } from "node:child_process";
+import {
+  isUnderWorktreePath,
+  parseMainWorktreePath,
+  isMainCheckout,
+} from "../../packages/core/src/loop/worktree-guard.mjs";
 
 import {
   validateAsyncStartContext,
@@ -253,6 +259,42 @@ export function buildResolveDevLoopStartupResult(input, { env = process.env, cwd
     const validation = validateAsyncStartContext({ env });
     if (validation.status === ASYNC_START_STATUS.REJECTED) {
       return buildAsyncStartRejection(validation);
+    }
+  }
+
+  // #497: Worktree isolation enforcement for local implementation.
+  // Reject local_implementation routing when the working directory is the
+  // main git checkout (not a worktree under tmp/worktrees/).
+  const PI_WORKTREE_BYPASS_VAR = "PI_WORKTREE_BYPASS";
+  if (
+    strategyKey === "local_implementation" &&
+    (env[PI_WORKTREE_BYPASS_VAR] ?? "").trim() !== "1"
+  ) {
+    try {
+      const worktreeOutput = execFileSync("git", ["worktree", "list"], {
+        cwd,
+        env,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const mainPath = parseMainWorktreePath(worktreeOutput);
+      if (!isUnderWorktreePath(cwd)) {
+        const reason = mainPath !== null && isMainCheckout(cwd, mainPath)
+          ? `Local implementation requires worktree isolation. Current directory is the main git checkout (${mainPath}). Create a worktree under tmp/worktrees/<slug>/ and re-run.`
+          : "Local implementation requires worktree isolation. Current directory is not under tmp/worktrees/. Create a worktree and re-run.";
+        return {
+          ok: true,
+          bundleKind: "needs_reconcile",
+          selectedStrategy: "none",
+          requiredReads: STRATEGY_REQUIRED_READS["none"],
+          nextAction: reason,
+          canonicalStateSummary: summarizeCanonicalState(bundle),
+          bundle,
+        };
+      }
+    } catch {
+      // If git worktree list fails, pass through — don't block routing on
+      // a git command failure. The pre-flight gate will catch this later.
     }
   }
 

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -64,9 +64,9 @@ When the local spec already lives in a tracker issue:
 
 ## Primary execution rules
 
-### Step 0: Pre-flight gate (mandatory)
+### Step 0: Pre-flight gate (mandatory for local_implementation)
 
-Before any planning or implementation mutation, run the pre-flight gate:
+For the `local_implementation` strategy, before any planning or implementation mutation, run the pre-flight gate:
 
 ```sh
 node scripts/loop/pre-flight-gate.mjs --expected-branch <working-branch> --require-subagents
@@ -78,6 +78,8 @@ This validates:
 - Subagent availability (subagents should be used for fan-out when available)
 
 If the gate fails, **stop and fix the violation** before proceeding. Do not bypass the gate.
+
+This gate does **not** apply to other routed strategies (`copilot_pr_followup`, `external_pr_followup`, `reviewer_fixer`, `wait_watch`, `final_approval`, `issue_intake`). Those strategies have their own execution rules and may edit code from any checkout as needed.
 
 Bypass for development/testing only: `PI_PREFLIGHT_BYPASS=1`.
 

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -79,6 +79,8 @@ This validates:
 
 If the gate fails, **stop and fix the violation** before proceeding. Do not bypass the gate in normal workflow execution.
 
+Note: `--check-subagents` is advisory — it reports availability but does not block the gate. The worktree and branch checks are the mandatory gates.
+
 This gate does **not** apply to other routed strategies (`copilot_pr_followup`, `external_pr_followup`, `reviewer_fixer`, `wait_watch`, `final_approval`, `issue_intake`). Those strategies have their own execution rules and may edit code from any checkout as needed.
 
 Development-only bypass (`PI_PREFLIGHT_BYPASS=1`) exists for testing the gate itself but must not be used in production workflow runs. The bypass variable is a testing convenience, not an operational escape hatch.

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -69,7 +69,7 @@ When the local spec already lives in a tracker issue:
 For the `local_implementation` strategy, before any planning or implementation mutation, run the pre-flight gate:
 
 ```sh
-node scripts/loop/pre-flight-gate.mjs --expected-branch <working-branch> --require-subagents
+node scripts/loop/pre-flight-gate.mjs --expected-branch <working-branch> --check-subagents
 ```
 
 This validates:

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -83,7 +83,7 @@ This gate does **not** apply to other routed strategies (`copilot_pr_followup`, 
 
 Development-only bypass (`PI_PREFLIGHT_BYPASS=1`) exists for testing the gate itself but must not be used in production workflow runs. The bypass variable is a testing convenience, not an operational escape hatch.
 
-### Primary execution rules
+### Step 1
 
 - Implement **one phase at a time**.
 - Do not refine later phases in detail before the current phase is complete.

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -64,6 +64,25 @@ When the local spec already lives in a tracker issue:
 
 ## Primary execution rules
 
+### Step 0: Pre-flight gate (mandatory)
+
+Before any planning or implementation mutation, run the pre-flight gate:
+
+```sh
+node scripts/loop/pre-flight-gate.mjs --expected-branch <working-branch> --require-subagents
+```
+
+This validates:
+- Worktree isolation (current directory is under `tmp/worktrees/`)
+- Branch identity (current branch matches the working branch)
+- Subagent availability (subagents should be used for fan-out when available)
+
+If the gate fails, **stop and fix the violation** before proceeding. Do not bypass the gate.
+
+Bypass for development/testing only: `PI_PREFLIGHT_BYPASS=1`.
+
+### Primary execution rules
+
 - Implement **one phase at a time**.
 - Do not refine later phases in detail before the current phase is complete.
 - Use the `refiner` agent for phase-refinement work when subagents are available; escalate RFC-worthy technical decisions to the parent session / human operator.

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -77,11 +77,11 @@ This validates:
 - Branch identity (current branch matches the working branch)
 - Subagent availability (subagents should be used for fan-out when available)
 
-If the gate fails, **stop and fix the violation** before proceeding. Do not bypass the gate.
+If the gate fails, **stop and fix the violation** before proceeding. Do not bypass the gate in normal workflow execution.
 
 This gate does **not** apply to other routed strategies (`copilot_pr_followup`, `external_pr_followup`, `reviewer_fixer`, `wait_watch`, `final_approval`, `issue_intake`). Those strategies have their own execution rules and may edit code from any checkout as needed.
 
-Bypass for development/testing only: `PI_PREFLIGHT_BYPASS=1`.
+Development-only bypass (`PI_PREFLIGHT_BYPASS=1`) exists for testing the gate itself but must not be used in production workflow runs. The bypass variable is a testing convenience, not an operational escape hatch.
 
 ### Primary execution rules
 

--- a/test/loop/pre-commit-branch-guard.test.mjs
+++ b/test/loop/pre-commit-branch-guard.test.mjs
@@ -209,7 +209,7 @@ import {
   isUnderWorktreePath,
   parseMainWorktreePath,
   isMainCheckout,
-} from "../../scripts/loop/pre-commit-branch-guard.mjs";
+} from "../../packages/core/src/loop/worktree-guard.mjs";
 
 async function writeWorktreeGitStub(tempDir, {
   branch = "copilot/feature-branch",

--- a/test/loop/pre-flight-gate.test.mjs
+++ b/test/loop/pre-flight-gate.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import path from "node:path";
-import { mkdtempSync, mkdirSync, realpathSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, realpathSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import test from "node:test";
@@ -22,7 +22,7 @@ function writeGitStub(tempDir, {
   logFile,
 } = {}) {
   const gitPath = path.join(tempDir, "git");
-  const lines = ["#!/usr/bin/env bash"];
+  const lines = ["#!/usr/bin/env sh"];
   lines.push(`echo "$@" >> ${JSON.stringify(logFile)}`);
 
   if (branch !== null) {
@@ -135,7 +135,7 @@ test("gate passes with PI_PREFLIGHT_BYPASS=1 from main checkout", () => {
     assert.equal(payload.checks.worktree, true);
     assert.equal(payload.summary.includes("bypassed"), true);
   } finally {
-    // Clean up
+    rmSync(tempDir, { recursive: true, force: true });
   }
 });
 
@@ -164,7 +164,7 @@ test("gate passes when cwd is under tmp/worktrees/", () => {
     assert.equal(payload.ok, true);
     assert.equal(payload.checks.worktree, true);
   } finally {
-    // clean up
+    rmSync(tempDir, { recursive: true, force: true });
   }
 });
 
@@ -189,7 +189,7 @@ test("gate fails when cwd is main checkout (detects main_checkout_detected)", ()
     assert.equal(payload.error, "main_checkout_detected");
     assert.ok(payload.guidance.includes("main git checkout"));
   } finally {
-    // clean up
+    rmSync(tempDir, { recursive: true, force: true });
   }
 });
 
@@ -214,7 +214,7 @@ test("gate fails when cwd is main checkout with main-checkout-detected error (un
       `expected not_in_worktree or main_checkout_detected, got ${payload.error}`,
     );
   } finally {
-    // clean up
+    rmSync(tempDir, { recursive: true, force: true });
   }
 });
 
@@ -222,7 +222,7 @@ test("gate fails when git worktree list fails", () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-git-fail-"));
   try {
     const gitPath = path.join(tempDir, "git");
-    writeFileSync(gitPath, "#!/usr/bin/env bash\nexit 1\n", { mode: 0o755 });
+    writeFileSync(gitPath, "#!/usr/bin/env sh\nexit 1\n", { mode: 0o755 });
 
     const result = runGate([], { cwd: tempDir });
 
@@ -231,7 +231,33 @@ test("gate fails when git worktree list fails", () => {
     assert.equal(payload.ok, false);
     assert.equal(payload.error, "worktree_list_failed");
   } finally {
-    // clean up
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("gate fails when cwd is under tmp/worktrees/ but not a real git worktree", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-fake-worktree-"));
+  try {
+    const fakeWorktreeDir = path.join(tempDir, "tmp", "worktrees", "fake-issue");
+    mkdirSync(fakeWorktreeDir, { recursive: true });
+
+    const logFile = path.join(tempDir, "git.log");
+    const worktreeListOut = realpathSync(tempDir) + "  535a18a [main]";
+
+    writeGitStub(tempDir, { worktreeListOut, logFile });
+
+    const result = runGate([], { cwd: fakeWorktreeDir, gitDir: tempDir });
+
+    assert.equal(result.exitCode, 1);
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.error, "not_in_worktree");
+    assert.ok(
+      payload.guidance.includes("not a real git worktree"),
+      "guidance should mention not a real worktree",
+    );
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
   }
 });
 
@@ -255,7 +281,7 @@ test("gate passes when --expected-branch matches current branch", () => {
     // Overwrite with branch-aware stub
     const gitPath = path.join(tempDir, "git");
     const lines = [
-      "#!/usr/bin/env bash",
+      "#!/usr/bin/env sh",
       `echo "$@" >> ${JSON.stringify(logFile)}`,
       'if [ "$1" = "worktree" ]; then',
       `  cat <<'WTEOF'`,
@@ -275,7 +301,7 @@ test("gate passes when --expected-branch matches current branch", () => {
     assert.equal(payload.ok, true);
     assert.equal(payload.checks.branch, "matched");
   } finally {
-    // clean up
+    rmSync(tempDir, { recursive: true, force: true });
   }
 });
 
@@ -293,7 +319,7 @@ test("gate fails when --expected-branch does not match current branch", () => {
 
     const gitPath = path.join(tempDir, "git");
     const lines = [
-      "#!/usr/bin/env bash",
+      "#!/usr/bin/env sh",
       `echo "$@" >> ${JSON.stringify(logFile)}`,
       'if [ "$1" = "worktree" ]; then',
       `  cat <<'WTEOF'`,
@@ -313,7 +339,7 @@ test("gate fails when --expected-branch does not match current branch", () => {
     assert.equal(payload.ok, false);
     assert.equal(payload.error, "branch_mismatch");
   } finally {
-    // clean up
+    rmSync(tempDir, { recursive: true, force: true });
   }
 });
 
@@ -337,7 +363,7 @@ test("gate skips branch check when --expected-branch not provided", () => {
     const payload = JSON.parse(result.stdout);
     assert.equal(payload.checks.branch, "skipped");
   } finally {
-    // clean up
+    rmSync(tempDir, { recursive: true, force: true });
   }
 });
 
@@ -369,7 +395,7 @@ test("gate reports subagent status skipped when --require-subagents not set", ()
     const payload = JSON.parse(result.stdout);
     assert.equal(payload.checks.subagents, "skipped");
   } finally {
-    // clean up
+    rmSync(tempDir, { recursive: true, force: true });
   }
 });
 
@@ -397,7 +423,7 @@ test("gate reports subagent available when PI_SUBAGENT_AVAILABLE=1 and --require
     const payload = JSON.parse(result.stdout);
     assert.equal(payload.checks.subagents, "available");
   } finally {
-    // clean up
+    rmSync(tempDir, { recursive: true, force: true });
   }
 });
 
@@ -421,7 +447,7 @@ test("gate reports subagent unavailable when --require-subagents and env var not
     const payload = JSON.parse(result.stdout);
     assert.equal(payload.checks.subagents, "unavailable");
   } finally {
-    // clean up
+    rmSync(tempDir, { recursive: true, force: true });
   }
 });
 
@@ -443,7 +469,7 @@ test("success output is valid JSON on stdout", () => {
 
     const gitPath = path.join(tempDir, "git");
     const branchAwareLines = [
-      "#!/usr/bin/env bash",
+      "#!/usr/bin/env sh",
       `echo "$@" >> ${JSON.stringify(logFile)}`,
       'if [ "$1" = "worktree" ]; then',
       `  cat <<'WTEOF'`,
@@ -469,7 +495,7 @@ test("success output is valid JSON on stdout", () => {
     assert.equal(typeof payload.checks, "object");
     assert.equal(typeof payload.summary, "string");
   } finally {
-    // clean up
+    rmSync(tempDir, { recursive: true, force: true });
   }
 });
 
@@ -493,7 +519,7 @@ test("failure output is valid JSON on stderr with error + guidance + checks", ()
     assert.equal(payload.checks.worktree, false);
     assert.ok(Array.isArray(payload.errors));
   } finally {
-    // clean up
+    rmSync(tempDir, { recursive: true, force: true });
   }
 });
 
@@ -508,7 +534,7 @@ test("gate prints usage with --help", () => {
     assert.equal(result.exitCode, 0);
     assert.ok(result.stdout.includes("Usage"), "stdout should contain usage text");
   } finally {
-    // clean up
+    rmSync(tempDir, { recursive: true, force: true });
   }
 });
 
@@ -519,6 +545,6 @@ test("gate prints usage with -h", () => {
     assert.equal(result.exitCode, 0);
     assert.ok(result.stdout.includes("Usage"), "stdout should contain usage text");
   } finally {
-    // clean up
+    rmSync(tempDir, { recursive: true, force: true });
   }
 });

--- a/test/loop/pre-flight-gate.test.mjs
+++ b/test/loop/pre-flight-gate.test.mjs
@@ -1,0 +1,524 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { mkdtempSync, mkdirSync, realpathSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import test from "node:test";
+
+import { parsePreFlightGateCliArgs } from "../../scripts/loop/pre-flight-gate.mjs";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a fake git script as a shell script that writes its arguments
+ * to a log file and optionally emits configured stdout/stderr/exit code.
+ */
+function writeGitStub(tempDir, {
+  branch = null,
+  worktreeListOut = null,
+  exitCode = 0,
+  logFile,
+} = {}) {
+  const gitPath = path.join(tempDir, "git");
+  const lines = ["#!/usr/bin/env bash"];
+  lines.push(`echo "$@" >> ${JSON.stringify(logFile)}`);
+
+  if (branch !== null) {
+    lines.push(`echo ${JSON.stringify(branch)}`);
+    lines.push(`exit ${exitCode}`);
+  } else if (worktreeListOut !== null) {
+    lines.push(`cat <<'WTEOF'`);
+    lines.push(...worktreeListOut.split("\n"));
+    lines.push("WTEOF");
+    lines.push(`exit ${exitCode}`);
+  } else {
+    lines.push(`exit ${exitCode}`);
+  }
+
+  writeFileSync(gitPath, lines.join("\n"), { mode: 0o755 });
+  return gitPath;
+}
+
+const PREFLIGHT_SCRIPT = path.resolve("scripts/loop/pre-flight-gate.mjs");
+
+function runGate(args = [], { cwd, env = {}, gitDir, logFile } = {}) {
+  const fullEnv = { ...process.env, ...env };
+  // Ensure PATH includes cwd and gitDir so the git stub is found
+  const paths = [];
+  if (cwd) paths.push(cwd);
+  if (gitDir && gitDir !== cwd) paths.push(gitDir);
+  if (paths.length > 0) {
+    fullEnv.PATH = `${paths.join(path.delimiter)}${path.delimiter}${fullEnv.PATH || ""}`;
+  }
+  try {
+    const stdout = execFileSync(
+      process.execPath,
+      [PREFLIGHT_SCRIPT, ...args],
+      { cwd, env: fullEnv, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    return { exitCode: 0, stdout: stdout.trim(), stderr: "" };
+  } catch (err) {
+    const code = err.status ?? 1;
+    const stdout = (err.stdout ?? "").trim();
+    const stderr = (err.stderr ?? err.message ?? "").trim();
+    return { exitCode: code, stdout, stderr };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+test("parsePreFlightGateCliArgs: parses --expected-branch", () => {
+  const opts = parsePreFlightGateCliArgs(["--expected-branch", "my-branch"]);
+  assert.equal(opts.expectedBranch, "my-branch");
+  assert.equal(opts.requireSubagents, false);
+});
+
+test("parsePreFlightGateCliArgs: parses --require-subagents", () => {
+  const opts = parsePreFlightGateCliArgs(["--require-subagents"]);
+  assert.equal(opts.requireSubagents, true);
+});
+
+test("parsePreFlightGateCliArgs: parses both flags", () => {
+  const opts = parsePreFlightGateCliArgs(["--expected-branch", "br", "--require-subagents"]);
+  assert.equal(opts.expectedBranch, "br");
+  assert.equal(opts.requireSubagents, true);
+});
+
+test("parsePreFlightGateCliArgs: no flags", () => {
+  const opts = parsePreFlightGateCliArgs([]);
+  assert.equal(opts.expectedBranch, undefined);
+  assert.equal(opts.requireSubagents, false);
+});
+
+test("parsePreFlightGateCliArgs: --help", () => {
+  const opts = parsePreFlightGateCliArgs(["--help"]);
+  assert.equal(opts.help, true);
+});
+
+test("parsePreFlightGateCliArgs: -h", () => {
+  const opts = parsePreFlightGateCliArgs(["-h"]);
+  assert.equal(opts.help, true);
+});
+
+test("parsePreFlightGateCliArgs: rejects unknown argument", () => {
+  assert.throws(
+    () => parsePreFlightGateCliArgs(["--unknown"]),
+    /Unknown argument: --unknown/i,
+  );
+});
+
+test("parsePreFlightGateCliArgs: rejects --expected-branch with missing value", () => {
+  assert.throws(
+    () => parsePreFlightGateCliArgs(["--expected-branch"]),
+    /Missing value for --expected-branch/i,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Bypass
+// ---------------------------------------------------------------------------
+
+test("gate passes with PI_PREFLIGHT_BYPASS=1 from main checkout", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-bypass-"));
+  try {
+    const result = runGate([], {
+      cwd: tempDir,
+      env: { PI_PREFLIGHT_BYPASS: "1" },
+    });
+    assert.equal(result.exitCode, 0);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.checks.worktree, true);
+    assert.equal(payload.summary.includes("bypassed"), true);
+  } finally {
+    // Clean up
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Worktree isolation: pass
+// ---------------------------------------------------------------------------
+
+test("gate passes when cwd is under tmp/worktrees/", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-worktree-ok-"));
+  try {
+    const worktreeDir = path.join(tempDir, "tmp", "worktrees", "issue-497");
+    mkdirSync(worktreeDir, { recursive: true });
+
+    const logFile = path.join(tempDir, "git.log");
+    const worktreeListOut = [
+      `${realpathSync(tempDir)}  535a18a [main]`,
+      `${realpathSync(worktreeDir)}  535a18a [issue-497]`,
+    ].join("\n");
+
+    writeGitStub(tempDir, { worktreeListOut, logFile });
+
+    const result = runGate([], { cwd: worktreeDir, gitDir: tempDir });
+
+    assert.equal(result.exitCode, 0);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.checks.worktree, true);
+  } finally {
+    // clean up
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Worktree isolation: fail
+// ---------------------------------------------------------------------------
+
+test("gate fails when cwd is main checkout (detects main_checkout_detected)", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-main-fail-"));
+  try {
+    const logFile = path.join(tempDir, "git.log");
+    const worktreeListOut = `${realpathSync(tempDir)}  535a18a [main]`;
+
+    writeGitStub(tempDir, { worktreeListOut, logFile });
+
+    const result = runGate([], { cwd: tempDir });
+
+    assert.equal(result.exitCode, 1);
+    assert.ok(result.stderr.length > 0, "stderr should have content");
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.error, "main_checkout_detected");
+    assert.ok(payload.guidance.includes("main git checkout"));
+  } finally {
+    // clean up
+  }
+});
+
+test("gate fails when cwd is main checkout with main-checkout-detected error (under main)", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-main-subdir-"));
+  try {
+    const subDir = path.join(tempDir, "src");
+    mkdirSync(subDir, { recursive: true });
+
+    const logFile = path.join(tempDir, "git.log");
+    const worktreeListOut = `${realpathSync(tempDir)}  535a18a [main]`;
+
+    writeGitStub(tempDir, { worktreeListOut, logFile });
+
+    const result = runGate([], { cwd: subDir, gitDir: tempDir });
+
+    assert.equal(result.exitCode, 1);
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.ok(
+      payload.error === "not_in_worktree" || payload.error === "main_checkout_detected",
+      `expected not_in_worktree or main_checkout_detected, got ${payload.error}`,
+    );
+  } finally {
+    // clean up
+  }
+});
+
+test("gate fails when git worktree list fails", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-git-fail-"));
+  try {
+    const gitPath = path.join(tempDir, "git");
+    writeFileSync(gitPath, "#!/usr/bin/env bash\nexit 1\n", { mode: 0o755 });
+
+    const result = runGate([], { cwd: tempDir });
+
+    assert.equal(result.exitCode, 1);
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.error, "worktree_list_failed");
+  } finally {
+    // clean up
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Branch identity
+// ---------------------------------------------------------------------------
+
+test("gate passes when --expected-branch matches current branch", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-branch-ok-"));
+  try {
+    const worktreeDir = path.join(tempDir, "tmp", "worktrees", "issue-497");
+    mkdirSync(worktreeDir, { recursive: true });
+
+    const logFile = path.join(tempDir, "git.log");
+    const worktreeListOut = [
+      `${realpathSync(tempDir)}  535a18a [main]`,
+      `${realpathSync(worktreeDir)}  535a18a [issue-497]`,
+    ].join("\n");
+
+    writeGitStub(tempDir, { worktreeListOut, logFile });
+    // Overwrite with branch-aware stub
+    const gitPath = path.join(tempDir, "git");
+    const lines = [
+      "#!/usr/bin/env bash",
+      `echo "$@" >> ${JSON.stringify(logFile)}`,
+      'if [ "$1" = "worktree" ]; then',
+      `  cat <<'WTEOF'`,
+      ...worktreeListOut.split("\n"),
+      "WTEOF",
+      'elif [ "$1" = "branch" ]; then',
+      '  echo "issue-497"',
+      "fi",
+      "exit 0",
+    ];
+    writeFileSync(gitPath, lines.join("\n"), { mode: 0o755 });
+
+    const result = runGate(["--expected-branch", "issue-497"], { cwd: worktreeDir, gitDir: tempDir });
+
+    assert.equal(result.exitCode, 0);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.checks.branch, "matched");
+  } finally {
+    // clean up
+  }
+});
+
+test("gate fails when --expected-branch does not match current branch", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-branch-mismatch-"));
+  try {
+    const worktreeDir = path.join(tempDir, "tmp", "worktrees", "issue-497");
+    mkdirSync(worktreeDir, { recursive: true });
+
+    const logFile = path.join(tempDir, "git.log");
+    const worktreeListOut = [
+      `${realpathSync(tempDir)}  535a18a [main]`,
+      `${realpathSync(worktreeDir)}  535a18a [issue-497]`,
+    ].join("\n");
+
+    const gitPath = path.join(tempDir, "git");
+    const lines = [
+      "#!/usr/bin/env bash",
+      `echo "$@" >> ${JSON.stringify(logFile)}`,
+      'if [ "$1" = "worktree" ]; then',
+      `  cat <<'WTEOF'`,
+      ...worktreeListOut.split("\n"),
+      "WTEOF",
+      'elif [ "$1" = "branch" ]; then',
+      '  echo "wrong-branch"',
+      "fi",
+      "exit 0",
+    ];
+    writeFileSync(gitPath, lines.join("\n"), { mode: 0o755 });
+
+    const result = runGate(["--expected-branch", "issue-497"], { cwd: worktreeDir, gitDir: tempDir });
+
+    assert.equal(result.exitCode, 1);
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.error, "branch_mismatch");
+  } finally {
+    // clean up
+  }
+});
+
+test("gate skips branch check when --expected-branch not provided", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-no-branch-"));
+  try {
+    const worktreeDir = path.join(tempDir, "tmp", "worktrees", "issue-497");
+    mkdirSync(worktreeDir, { recursive: true });
+
+    const logFile = path.join(tempDir, "git.log");
+    const worktreeListOut = [
+      `${realpathSync(tempDir)}  535a18a [main]`,
+      `${realpathSync(worktreeDir)}  535a18a [issue-497]`,
+    ].join("\n");
+
+    writeGitStub(tempDir, { worktreeListOut, logFile });
+
+    const result = runGate([], { cwd: worktreeDir, gitDir: tempDir });
+
+    assert.equal(result.exitCode, 0);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.checks.branch, "skipped");
+  } finally {
+    // clean up
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Subagent availability
+// ---------------------------------------------------------------------------
+
+test("gate reports subagent status skipped when --require-subagents not set", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-subagent-skip-"));
+  try {
+    const worktreeDir = path.join(tempDir, "tmp", "worktrees", "issue-497");
+    mkdirSync(worktreeDir, { recursive: true });
+
+    const logFile = path.join(tempDir, "git.log");
+    const worktreeListOut = [
+      `${realpathSync(tempDir)}  535a18a [main]`,
+      `${realpathSync(worktreeDir)}  535a18a [issue-497]`,
+    ].join("\n");
+
+    writeGitStub(tempDir, { worktreeListOut, logFile });
+
+    const result = runGate([], {
+      cwd: worktreeDir,
+      gitDir: tempDir,
+      env: { PI_SUBAGENT_AVAILABLE: "1" },
+    });
+
+    assert.equal(result.exitCode, 0);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.checks.subagents, "skipped");
+  } finally {
+    // clean up
+  }
+});
+
+test("gate reports subagent available when PI_SUBAGENT_AVAILABLE=1 and --require-subagents", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-subagent-ok-"));
+  try {
+    const worktreeDir = path.join(tempDir, "tmp", "worktrees", "issue-497");
+    mkdirSync(worktreeDir, { recursive: true });
+
+    const logFile = path.join(tempDir, "git.log");
+    const worktreeListOut = [
+      `${realpathSync(tempDir)}  535a18a [main]`,
+      `${realpathSync(worktreeDir)}  535a18a [issue-497]`,
+    ].join("\n");
+
+    writeGitStub(tempDir, { worktreeListOut, logFile });
+
+    const result = runGate(["--require-subagents"], {
+      cwd: worktreeDir,
+      gitDir: tempDir,
+      env: { PI_SUBAGENT_AVAILABLE: "1" },
+    });
+
+    assert.equal(result.exitCode, 0);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.checks.subagents, "available");
+  } finally {
+    // clean up
+  }
+});
+
+test("gate reports subagent unavailable when --require-subagents and env var not set", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-subagent-unavail-"));
+  try {
+    const worktreeDir = path.join(tempDir, "tmp", "worktrees", "issue-497");
+    mkdirSync(worktreeDir, { recursive: true });
+
+    const logFile = path.join(tempDir, "git.log");
+    const worktreeListOut = [
+      `${realpathSync(tempDir)}  535a18a [main]`,
+      `${realpathSync(worktreeDir)}  535a18a [issue-497]`,
+    ].join("\n");
+
+    writeGitStub(tempDir, { worktreeListOut, logFile });
+
+    const result = runGate(["--require-subagents"], { cwd: worktreeDir, gitDir: tempDir });
+
+    assert.equal(result.exitCode, 0);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.checks.subagents, "unavailable");
+  } finally {
+    // clean up
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Output contract
+// ---------------------------------------------------------------------------
+
+test("success output is valid JSON on stdout", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-output-ok-"));
+  try {
+    const worktreeDir = path.join(tempDir, "tmp", "worktrees", "issue-497");
+    mkdirSync(worktreeDir, { recursive: true });
+
+    const logFile = path.join(tempDir, "git.log");
+    const worktreeListOut = [
+      `${realpathSync(tempDir)}  535a18a [main]`,
+      `${realpathSync(worktreeDir)}  535a18a [issue-497]`,
+    ].join("\n");
+
+    const gitPath = path.join(tempDir, "git");
+    const branchAwareLines = [
+      "#!/usr/bin/env bash",
+      `echo "$@" >> ${JSON.stringify(logFile)}`,
+      'if [ "$1" = "worktree" ]; then',
+      `  cat <<'WTEOF'`,
+      ...worktreeListOut.split("\n"),
+      "WTEOF",
+      'elif [ "$1" = "branch" ]; then',
+      '  echo "issue-497"',
+      "fi",
+      "exit 0",
+    ];
+    writeFileSync(gitPath, branchAwareLines.join("\n"), { mode: 0o755 });
+
+    const result = runGate(["--expected-branch", "issue-497"], {
+      cwd: worktreeDir,
+      gitDir: tempDir,
+      env: { PI_SUBAGENT_AVAILABLE: "1" },
+    });
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stderr, "");
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(typeof payload.checks, "object");
+    assert.equal(typeof payload.summary, "string");
+  } finally {
+    // clean up
+  }
+});
+
+test("failure output is valid JSON on stderr with error + guidance + checks", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-output-fail-"));
+  try {
+    const logFile = path.join(tempDir, "git.log");
+    const worktreeListOut = `${realpathSync(tempDir)}  535a18a [main]`;
+
+    writeGitStub(tempDir, { worktreeListOut, logFile });
+
+    const result = runGate([], { cwd: tempDir });
+
+    assert.equal(result.exitCode, 1);
+    assert.ok(result.stderr.length > 0, "stderr should have content");
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.equal(typeof payload.error, "string");
+    assert.equal(typeof payload.guidance, "string");
+    assert.equal(typeof payload.checks, "object");
+    assert.equal(payload.checks.worktree, false);
+    assert.ok(Array.isArray(payload.errors));
+  } finally {
+    // clean up
+  }
+});
+
+// ---------------------------------------------------------------------------
+// --help
+// ---------------------------------------------------------------------------
+
+test("gate prints usage with --help", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-help-"));
+  try {
+    const result = runGate(["--help"], { cwd: tempDir });
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.stdout.includes("Usage"), "stdout should contain usage text");
+  } finally {
+    // clean up
+  }
+});
+
+test("gate prints usage with -h", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-h-"));
+  try {
+    const result = runGate(["-h"], { cwd: tempDir });
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.stdout.includes("Usage"), "stdout should contain usage text");
+  } finally {
+    // clean up
+  }
+});

--- a/test/loop/pre-flight-gate.test.mjs
+++ b/test/loop/pre-flight-gate.test.mjs
@@ -74,24 +74,24 @@ function runGate(args = [], { cwd, env = {}, gitDir, logFile } = {}) {
 test("parsePreFlightGateCliArgs: parses --expected-branch", () => {
   const opts = parsePreFlightGateCliArgs(["--expected-branch", "my-branch"]);
   assert.equal(opts.expectedBranch, "my-branch");
-  assert.equal(opts.requireSubagents, false);
+  assert.equal(opts.checkSubagents, false);
 });
 
-test("parsePreFlightGateCliArgs: parses --require-subagents", () => {
-  const opts = parsePreFlightGateCliArgs(["--require-subagents"]);
-  assert.equal(opts.requireSubagents, true);
+test("parsePreFlightGateCliArgs: parses --check-subagents", () => {
+  const opts = parsePreFlightGateCliArgs(["--check-subagents"]);
+  assert.equal(opts.checkSubagents, true);
 });
 
 test("parsePreFlightGateCliArgs: parses both flags", () => {
-  const opts = parsePreFlightGateCliArgs(["--expected-branch", "br", "--require-subagents"]);
+  const opts = parsePreFlightGateCliArgs(["--expected-branch", "br", "--check-subagents"]);
   assert.equal(opts.expectedBranch, "br");
-  assert.equal(opts.requireSubagents, true);
+  assert.equal(opts.checkSubagents, true);
 });
 
 test("parsePreFlightGateCliArgs: no flags", () => {
   const opts = parsePreFlightGateCliArgs([]);
   assert.equal(opts.expectedBranch, undefined);
-  assert.equal(opts.requireSubagents, false);
+  assert.equal(opts.checkSubagents, false);
 });
 
 test("parsePreFlightGateCliArgs: --help", () => {
@@ -371,7 +371,7 @@ test("gate skips branch check when --expected-branch not provided", () => {
 // Subagent availability
 // ---------------------------------------------------------------------------
 
-test("gate reports subagent status skipped when --require-subagents not set", () => {
+test("gate reports subagent status skipped when --check-subagents not set", () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-subagent-skip-"));
   try {
     const worktreeDir = path.join(tempDir, "tmp", "worktrees", "issue-497");
@@ -399,7 +399,7 @@ test("gate reports subagent status skipped when --require-subagents not set", ()
   }
 });
 
-test("gate reports subagent available when PI_SUBAGENT_AVAILABLE=1 and --require-subagents", () => {
+test("gate reports subagent available when PI_SUBAGENT_AVAILABLE=1 and --check-subagents", () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-subagent-ok-"));
   try {
     const worktreeDir = path.join(tempDir, "tmp", "worktrees", "issue-497");
@@ -413,7 +413,7 @@ test("gate reports subagent available when PI_SUBAGENT_AVAILABLE=1 and --require
 
     writeGitStub(tempDir, { worktreeListOut, logFile });
 
-    const result = runGate(["--require-subagents"], {
+    const result = runGate(["--check-subagents"], {
       cwd: worktreeDir,
       gitDir: tempDir,
       env: { PI_SUBAGENT_AVAILABLE: "1" },
@@ -427,7 +427,7 @@ test("gate reports subagent available when PI_SUBAGENT_AVAILABLE=1 and --require
   }
 });
 
-test("gate reports subagent unavailable when --require-subagents and env var not set", () => {
+test("gate reports subagent unavailable when --check-subagents and env var not set", () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-subagent-unavail-"));
   try {
     const worktreeDir = path.join(tempDir, "tmp", "worktrees", "issue-497");
@@ -441,7 +441,7 @@ test("gate reports subagent unavailable when --require-subagents and env var not
 
     writeGitStub(tempDir, { worktreeListOut, logFile });
 
-    const result = runGate(["--require-subagents"], { cwd: worktreeDir, gitDir: tempDir });
+    const result = runGate(["--check-subagents"], { cwd: worktreeDir, gitDir: tempDir });
 
     assert.equal(result.exitCode, 0);
     const payload = JSON.parse(result.stdout);

--- a/test/loop/resolve-dev-loop-startup.test.mjs
+++ b/test/loop/resolve-dev-loop-startup.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtempSync, mkdirSync, realpathSync, writeFileSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -483,4 +484,174 @@ test("buildResolveDevLoopStartupResult does not enforce async-start on local_imp
 
   assert.equal(result.ok, true);
   assert.equal(result.selectedStrategy, "local_implementation");
+});
+
+// ---------------------------------------------------------------------------
+// #497: Worktree isolation enforcement for local_implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a temporary directory structure that simulates a git repo with
+ * a worktree under tmp/worktrees/. Also creates a fake git script that
+ * returns the expected `git worktree list` output.
+ */
+function writeWorktreeEnv(tempDir) {
+  const worktreeDir = path.join(tempDir, "tmp", "worktrees", "issue-test");
+  mkdirSync(worktreeDir, { recursive: true });
+
+  const actualTemp = realpathSync(tempDir);
+  const actualWorktree = realpathSync(worktreeDir);
+
+  const gitPath = path.join(tempDir, "git");
+  const worktreeListOut = `${actualTemp}  535a18a [main]\n${actualWorktree}  535a18a [issue-test]`;
+  const lines = [
+    "#!/usr/bin/env bash",
+    'if [ "$1" = "worktree" ] && [ "$2" = "list" ]; then',
+    `  cat <<'WTEOF'`,
+    worktreeListOut,
+    "WTEOF",
+    "fi",
+    "exit 0",
+  ];
+  writeFileSync(gitPath, lines.join("\n"), { mode: 0o755 });
+
+  return { tempDir, worktreeDir, gitPath };
+}
+
+test("resolver returns needs_reconcile for local_implementation from main checkout", () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "resolver-main-"));
+  try {
+    const { gitPath } = writeWorktreeEnv(tempDir);
+    const env = {
+      ...process.env,
+      PATH: `${tempDir}${path.delimiter}${process.env.PATH || ""}`,
+    };
+
+    const result = buildResolveDevLoopStartupResult(
+      {
+        currentState: {
+          target: { kind: "local_phase", issue: 497, phase: "issue-497" },
+          ownership: "local",
+          nextActor: "local",
+          status: "active",
+          authorization: "authorized",
+        },
+        loopState: "implementation_pending",
+        artifactState: "not_applicable",
+        issueLinkageResolution: "not_applicable",
+      },
+      { env, cwd: tempDir },
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.bundleKind, "needs_reconcile");
+    assert.equal(result.selectedStrategy, "none");
+    assert.ok(
+      result.nextAction.includes("worktree isolation"),
+      `nextAction should mention worktree isolation, got: ${result.nextAction}`,
+    );
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("resolver resolves normally for local_implementation from worktree", () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "resolver-wt-"));
+  try {
+    const { worktreeDir } = writeWorktreeEnv(tempDir);
+    const env = {
+      ...process.env,
+      PATH: `${tempDir}${path.delimiter}${process.env.PATH || ""}`,
+    };
+
+    const result = buildResolveDevLoopStartupResult(
+      {
+        currentState: {
+          target: { kind: "local_phase", issue: 497, phase: "issue-497" },
+          ownership: "local",
+          nextActor: "local",
+          status: "active",
+          authorization: "authorized",
+        },
+        loopState: "implementation_pending",
+        artifactState: "not_applicable",
+        issueLinkageResolution: "not_applicable",
+      },
+      { env, cwd: worktreeDir },
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.bundleKind, "resolved");
+    assert.equal(result.selectedStrategy, "local_implementation");
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("resolver bypasses worktree check with PI_WORKTREE_BYPASS=1 from main checkout", () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "resolver-bypass-"));
+  try {
+    const { gitPath } = writeWorktreeEnv(tempDir);
+    const env = {
+      ...process.env,
+      PATH: `${tempDir}${path.delimiter}${process.env.PATH || ""}`,
+      PI_WORKTREE_BYPASS: "1",
+    };
+
+    const result = buildResolveDevLoopStartupResult(
+      {
+        currentState: {
+          target: { kind: "local_phase", issue: 497, phase: "issue-497" },
+          ownership: "local",
+          nextActor: "local",
+          status: "active",
+          authorization: "authorized",
+        },
+        loopState: "implementation_pending",
+        artifactState: "not_applicable",
+        issueLinkageResolution: "not_applicable",
+      },
+      { env, cwd: tempDir },
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.bundleKind, "resolved");
+    assert.equal(result.selectedStrategy, "local_implementation");
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("resolver does not block non-local_implementation strategies from main checkout", () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "resolver-nonlocal-"));
+  try {
+    const { gitPath } = writeWorktreeEnv(tempDir);
+    const env = {
+      ...process.env,
+      PATH: `${tempDir}${path.delimiter}${process.env.PATH || ""}`,
+      PI_SUBAGENT_RUN_ID: "test-run-123",
+    };
+
+    const result = buildResolveDevLoopStartupResult(
+      {
+        currentState: {
+          target: { kind: "issue", issue: 89, linkedPr: 92 },
+          ownership: "copilot",
+          nextActor: "copilot",
+          status: "active",
+          authorization: "needs_confirmation",
+        },
+        artifactState: "open",
+        issueLinkageResolution: "resolved_linked_pr",
+        loopState: "unresolved_feedback_present",
+      },
+      { env, cwd: tempDir },
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.bundleKind, "resolved");
+    assert.equal(result.selectedStrategy, "copilot_pr_followup");
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
 });

--- a/test/loop/resolve-dev-loop-startup.test.mjs
+++ b/test/loop/resolve-dev-loop-startup.test.mjs
@@ -247,7 +247,8 @@ test("buildResolveDevLoopStartupResult passes through when no checkpoint file ex
     assert.equal(result.code, 0, `expected exit 0, got stderr: ${result.stderr}`);
     const parsed = JSON.parse(result.stdout.trim());
     assert.equal(parsed.ok, true);
-    assert.equal(parsed.selectedStrategy, "local_implementation");
+    assert.equal(parsed.bundleKind, "needs_reconcile");
+    assert.equal(parsed.selectedStrategy, "none");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/resolve-dev-loop-startup.test.mjs
+++ b/test/loop/resolve-dev-loop-startup.test.mjs
@@ -505,7 +505,7 @@ function writeWorktreeEnv(tempDir) {
   const gitPath = path.join(tempDir, "git");
   const worktreeListOut = `${actualTemp}  535a18a [main]\n${actualWorktree}  535a18a [issue-test]`;
   const lines = [
-    "#!/usr/bin/env bash",
+    "#!/usr/bin/env sh",
     'if [ "$1" = "worktree" ] && [ "$2" = "list" ]; then',
     `  cat <<'WTEOF'`,
     worktreeListOut,

--- a/test/loop/resolve-dev-loop-startup.test.mjs
+++ b/test/loop/resolve-dev-loop-startup.test.mjs
@@ -49,7 +49,7 @@ test("buildResolveDevLoopStartupResult maps local implementation to the local ro
     },
     artifactState: "not_applicable",
     loopState: "active",
-  });
+  }, { env: { PI_WORKTREE_BYPASS: "1" } });
 
   assert.equal(result.bundleKind, "resolved");
   assert.equal(result.selectedStrategy, "local_implementation");

--- a/test/loop/resolve-dev-loop-startup.test.mjs
+++ b/test/loop/resolve-dev-loop-startup.test.mjs
@@ -522,7 +522,7 @@ function writeWorktreeEnv(tempDir) {
 test("resolver returns needs_reconcile for local_implementation from main checkout", () => {
   const tempDir = mkdtempSync(path.join(os.tmpdir(), "resolver-main-"));
   try {
-    const { gitPath } = writeWorktreeEnv(tempDir);
+    writeWorktreeEnv(tempDir);
     const env = {
       ...process.env,
       PATH: `${tempDir}${path.delimiter}${process.env.PATH || ""}`,
@@ -592,7 +592,7 @@ test("resolver resolves normally for local_implementation from worktree", () => 
 test("resolver bypasses worktree check with PI_WORKTREE_BYPASS=1 from main checkout", () => {
   const tempDir = mkdtempSync(path.join(os.tmpdir(), "resolver-bypass-"));
   try {
-    const { gitPath } = writeWorktreeEnv(tempDir);
+    writeWorktreeEnv(tempDir);
     const env = {
       ...process.env,
       PATH: `${tempDir}${path.delimiter}${process.env.PATH || ""}`,
@@ -626,7 +626,7 @@ test("resolver bypasses worktree check with PI_WORKTREE_BYPASS=1 from main check
 test("resolver does not block non-local_implementation strategies from main checkout", () => {
   const tempDir = mkdtempSync(path.join(os.tmpdir(), "resolver-nonlocal-"));
   try {
-    const { gitPath } = writeWorktreeEnv(tempDir);
+    writeWorktreeEnv(tempDir);
     const env = {
       ...process.env,
       PATH: `${tempDir}${path.delimiter}${process.env.PATH || ""}`,

--- a/test/loop/resolve-dev-loop-startup.test.mjs
+++ b/test/loop/resolve-dev-loop-startup.test.mjs
@@ -227,7 +227,7 @@ test("buildResolveDevLoopStartupResult auto-injects retrospectiveCheckpointState
   }
 });
 
-test("buildResolveDevLoopStartupResult passes through when no checkpoint file exists", async () => {
+test("buildResolveDevLoopStartupResult fails closed when no checkpoint file exists and cwd is not a worktree", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "resolve-dev-loop-startup-"));
   try {
     const inputPath = await writeTempJson(tempDir, "startup.json", {

--- a/test/loop/resolve-dev-loop-startup.test.mjs
+++ b/test/loop/resolve-dev-loop-startup.test.mjs
@@ -479,7 +479,7 @@ test("buildResolveDevLoopStartupResult does not enforce async-start on local_imp
       artifactState: "not_applicable",
       loopState: "active",
     },
-    { env: {} },
+    { env: { PI_WORKTREE_BYPASS: "1" } },
   );
 
   assert.equal(result.ok, true);


### PR DESCRIPTION
## Summary
Add pre-flight gate script + resolver worktree enforcement to prevent local implementation mutations on main checkout.

## Scope
9 production files (4 new, 5 modified), 4 test files (2 new, 2 modified).

## What changed
- **New:** `scripts/loop/pre-flight-gate.mjs` — validates worktree isolation, branch identity, subagent availability before any local mutation
- **New:** `packages/core/src/loop/worktree-guard.mjs` — shared worktree/branch check primitives extracted from `pre-commit-branch-guard.mjs`
- **Modified:** `scripts/loop/resolve-dev-loop-startup.mjs` — rejects `local_implementation` routing from main checkout
- **Modified:** `scripts/loop/pre-commit-branch-guard.mjs` — refactored to import from shared core (no behavior change)
- **Docs:** SKILL.md step 0 mandate + AGENTS.md enforcement reference

## Bypass vars
- `PI_PREFLIGHT_BYPASS=1` — skip pre-flight gate
- `PI_WORKTREE_BYPASS=1` — skip resolver worktree check
- `PI_SUBAGENT_AVAILABLE=1` — signal subagent availability

## Acceptance criteria (from #497)
- [x] `scripts/loop/pre-flight-gate.mjs` exists and validates worktree isolation, branch identity, and subagent availability
- [x] Resolver rejects `local_implementation` routing when working directory is the main checkout (unless bypassed)
- [x] Local-implementation SKILL.md updated to mandate pre-flight gate as step 0
- [x] AGENTS.md worktree section references the enforcement mechanism
- [x] `npm run verify` passes (2,167 tests, 0 failures)

## Non-goals
- Not changing worktree guidance itself
- Not adding new subagent requirements (check is advisory, fails-open)
- No markers/contract-doc freshness (deferred)
- No gate extension beyond `local_implementation`

Closes #497