### PR TITLE
docs(#499,#496): add deterministic tooling rule — no bash polling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ These skills may be provided repo-locally or globally; this contract does not as
 ### Deterministic tooling — no bash polling
 
 - **Copilot review waiting:** Use `node scripts/loop/run-watch-cycle.mjs --repo <owner/name> --pr <number>` for persistent Copilot review watching. Do NOT use bash `sleep`, `for`, `while`, or `timeout` wrappers around tool invocations.
-- **Probes:** Use `node scripts/loop/run-watch-cycle.mjs --probe-only` for single immediate rechecks. Do NOT use bash loops to poll.
+- **Probes:** Use `node scripts/loop/run-watch-cycle.mjs --repo <owner/name> --pr <number> --probe-only` for single immediate rechecks. Do NOT use bash loops to poll.
 - **Waiting in general:** Use the deterministic helper owned by the current routed strategy. Agent-authored shell polling (`sleep N`, `for i in $(seq ...)`, `while true; do ...; sleep N; done`) is a contract breach — it bypasses timeout policy, poll-interval defaults, and machine-readable output contracts.
 - **Why:** Helper-owned sleep inside `run-watch-cycle.mjs`, `probe-copilot-review.mjs`, or `watch-initial-copilot-pr.mjs` is allowed. Agent-authored shell polling is not. Defaults (timeout, poll interval) belong in tooling constants, not in agent-authored bash wrappers.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,13 @@ These skills may be provided repo-locally or globally; this contract does not as
 - Create or reuse worktrees under `tmp/worktrees/<issue-or-branch-slug>/` for mutating local work, and reserve the main checkout for inspection/control by default.
 - Check `git worktree list` before creating a new worktree, and remove merged/abandoned worktrees with `git worktree remove --force <path>` followed by `git worktree prune`.
 
+### Deterministic tooling — no bash polling
+
+- **Copilot review waiting:** Use `node scripts/loop/run-watch-cycle.mjs --repo <owner/name> --pr <number>` for persistent Copilot review watching. Do NOT use bash `sleep`, `for`, `while`, or `timeout` wrappers around tool invocations.
+- **Probes:** Use `node scripts/loop/run-watch-cycle.mjs --probe-only` for single immediate rechecks. Do NOT use bash loops to poll.
+- **Waiting in general:** Use the deterministic helper owned by the current routed strategy. Agent-authored shell polling (`sleep N`, `for i in $(seq ...)`, `while true; do ...; sleep N; done`) is a contract breach — it bypasses timeout policy, poll-interval defaults, and machine-readable output contracts.
+- **Why:** Helper-owned sleep inside `run-watch-cycle.mjs`, `probe-copilot-review.mjs`, or `watch-initial-copilot-pr.mjs` is allowed. Agent-authored shell polling is not. Defaults (timeout, poll interval) belong in tooling constants, not in agent-authored bash wrappers.
+
 ## Standard refinement chain pattern
 
 Use this pattern whenever the work is refinement, comparison, review, or synthesis rather than implementation.

--- a/skills/docs/copilot-loop-operations.md
+++ b/skills/docs/copilot-loop-operations.md
@@ -184,7 +184,9 @@ Preferred defaults for this repo:
 
 These are the defaults built into `probe-copilot-review.mjs`, `run-watch-cycle.mjs`, and the `watchArgs` emitted by `copilot-pr-handoff.mjs`. Pass them explicitly when overriding.
 
-Helper-owned sleep inside `run-watch-cycle.mjs`, `probe-copilot-review.mjs`, or `watch-initial-copilot-pr.mjs` is allowed. Agent-authored shell polling is not allowed.
+### Hard rule: no agent-authored shell polling
+
+Helper-owned sleep inside `run-watch-cycle.mjs`, `probe-copilot-review.mjs`, or `watch-initial-copilot-pr.mjs` is allowed. Agent-authored shell polling (`sleep`, `for`, `while`, `timeout` wrappers around tool invocations) is a contract breach. This rule applies to ALL repos using the dev-loop workflow, not just the source repo.
 
 A watcher sleeping between polls is expected behavior, not a blocker.
 


### PR DESCRIPTION
## Summary
Add explicit "no bash polling" rule to AGENTS.md. Agents must use `run-watch-cycle.mjs` for Copilot review waiting, not bash `sleep`/`for`/`timeout` wrappers.

## What changed
- AGENTS.md: new "Deterministic tooling — no bash polling" section after Worktree isolation
- skills/docs/copilot-loop-operations.md: elevated "no agent-authored shell polling" rule to its own "Hard rule" heading with clarified repo-wide scope

## Acceptance criteria
- [x] AGENTS.md has explicit rule against bash polling
- [x] Rule references the correct tool (`run-watch-cycle.mjs`)
- [x] Rule explains why (timeout policy, poll-interval defaults, machine-readable contracts)

Closes #499
Closes #496
