### PR TITLE
feat(#500): dynamic gate angle resolution + round-cap enforcement

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,8 @@
     "./loop/tracker-pr-state": "./src/loop/tracker-pr-state.mjs",
     "./debt/signal": "./src/debt/debt-signal.mjs",
     "./debt/finding": "./src/debt/debt-finding.mjs",
-    "./debt/signals": "./src/debt/deep-persona-signals.mjs"
+    "./debt/signals": "./src/debt/deep-persona-signals.mjs",
+    "./analysis": "./src/analysis/index.mjs"
   },
   "bin": {
     "pi-dev-loops-log-bash-exit-1": "./bin/log-bash-exit-1.mjs",

--- a/packages/core/src/analysis/change-classifier.mjs
+++ b/packages/core/src/analysis/change-classifier.mjs
@@ -1,0 +1,156 @@
+/**
+ * Change category classification and angle relevance index.
+ *
+ * Maps change categories detected by the diff analyzer to relevant gate review
+ * angles, with optional per-angle score thresholds.
+ */
+
+// ---------------------------------------------------------------------------
+// Change categories
+// ---------------------------------------------------------------------------
+
+/** @enum {string} */
+export const ChangeCategory = Object.freeze({
+  RENAME_ONLY: "RENAME_ONLY",
+  DOCS_ONLY: "DOCS_ONLY",
+  CONFIG_ONLY: "CONFIG_ONLY",
+  TEST_ONLY: "TEST_ONLY",
+  CI_ONLY: "CI_ONLY",
+  COMMENT_ONLY: "COMMENT_ONLY",
+  LOGIC_CHANGE: "LOGIC_CHANGE",
+});
+
+// ---------------------------------------------------------------------------
+// Angle relevance index
+// ---------------------------------------------------------------------------
+
+/**
+ * Map of ChangeCategory → relevant gate angles.
+ *
+ * Categories not listed default to an empty array (no angles relevant).
+ * When multiple categories match, the union of angles is taken.
+ *
+ * @type {Record<string, string[]>}
+ */
+const CATEGORY_ANGLE_MAP = {
+  [ChangeCategory.RENAME_ONLY]: [
+    "scope", "correctness", "contract-surface", "docs", "link-check",
+  ],
+  [ChangeCategory.DOCS_ONLY]: [
+    "docs", "link-check", "contract-surface", "dry",
+  ],
+  [ChangeCategory.CONFIG_ONLY]: [
+    "config-drift", "scope", "correctness", "contract-surface",
+  ],
+  [ChangeCategory.TEST_ONLY]: [
+    "coverage", "correctness", "determinism",
+  ],
+  [ChangeCategory.CI_ONLY]: [
+    "ci-guard", "scope", "config-drift",
+  ],
+  [ChangeCategory.COMMENT_ONLY]: [
+    "dry",
+  ],
+  [ChangeCategory.LOGIC_CHANGE]: [
+    "correctness", "coverage", "kiss", "dry", "srp", "soc", "deep",
+    "ocp", "lsp", "isp", "dip", "yagni", "scope", "no-op", "determinism",
+  ],
+};
+
+/**
+ * Angles that are never skipped, regardless of diff analysis.
+ *
+ * @type {Set<string>}
+ */
+const ALWAYS_INCLUDE = new Set(["gate-evidence", "renderer-security"]);
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} DynamicAngleResult
+ * @property {string[]} recommendedAngles — angles to run
+ * @property {string[]} skippedAngles — angles skipped with reasons
+ * @property {Record<string, string>} reasons — why each angle was skipped
+ * @property {boolean} fallbackToAll — true when ambiguous → all angles recommended
+ */
+
+/**
+ * Resolve which gate angles to run based on detected change categories.
+ *
+ * When the diff is ambiguous (contains LOGIC_CHANGE or multiple mixed categories),
+ * all configured angles are recommended (fallback-to-all).
+ *
+ * @param {object} options
+ * @param {string[]} options.configuredAngles — all angles configured for this gate
+ * @param {string[]} options.changeCategories — from diff analysis
+ * @param {boolean} [options.ambiguous] — from diff analysis
+ * @param {Record<string, number>} [options.thresholds] — per-angle override thresholds
+ * @returns {DynamicAngleResult}
+ */
+export function resolveDynamicAngles({
+  configuredAngles,
+  changeCategories,
+  ambiguous = false,
+  thresholds = {},
+}) {
+  // Fallback: ambiguous diff → all angles
+  if (ambiguous) {
+    return {
+      recommendedAngles: [...configuredAngles],
+      skippedAngles: [],
+      reasons: {},
+      fallbackToAll: true,
+    };
+  }
+
+  // No change categories → all angles (defensive)
+  if (changeCategories.length === 0) {
+    return {
+      recommendedAngles: [...configuredAngles],
+      skippedAngles: [],
+      reasons: {},
+      fallbackToAll: true,
+    };
+  }
+
+  // Build recommended set from category union
+  const recommended = new Set();
+  for (const cat of changeCategories) {
+    const angles = CATEGORY_ANGLE_MAP[cat] ?? [];
+    for (const angle of angles) {
+      recommended.add(angle);
+    }
+  }
+
+  // Always-include angles
+  for (const angle of ALWAYS_INCLUDE) {
+    recommended.add(angle);
+  }
+
+  // Filter to only angles that are configured
+  const configuredSet = new Set(configuredAngles);
+  const recommendedAngles = [...recommended].filter((a) => configuredSet.has(a));
+  const skippedAngles = configuredAngles.filter((a) => !recommended.has(a));
+
+  // Build reasons
+  const reasons = {};
+  for (const angle of skippedAngles) {
+    if (ALWAYS_INCLUDE.has(angle)) {
+      reasons[angle] = "always-included angle, should never be skipped";
+    } else {
+      const matchedCategories = changeCategories.filter(
+        (cat) => !(CATEGORY_ANGLE_MAP[cat] ?? []).includes(angle),
+      );
+      reasons[angle] = `No relevant change categories detected (${matchedCategories.join(", ") || "none"})`;
+    }
+  }
+
+  return {
+    recommendedAngles,
+    skippedAngles,
+    reasons,
+    fallbackToAll: false,
+  };
+}

--- a/packages/core/src/analysis/change-classifier.mjs
+++ b/packages/core/src/analysis/change-classifier.mjs
@@ -128,7 +128,6 @@ export function resolveDynamicAngles({
   }
 
   // Filter to only angles that are configured
-  const configuredSet = new Set(configuredAngles);
   const recommendedAngles = configuredAngles.filter((a) => recommended.has(a));
   const skippedAngles = configuredAngles.filter((a) => !recommended.has(a));
 
@@ -138,10 +137,7 @@ export function resolveDynamicAngles({
     if (ALWAYS_INCLUDE.has(angle)) {
       reasons[angle] = "always-included angle, should never be skipped";
     } else {
-      const matchedCategories = changeCategories.filter(
-        (cat) => !(CATEGORY_ANGLE_MAP[cat] ?? []).includes(angle),
-      );
-      reasons[angle] = `No relevant change categories detected (${matchedCategories.join(", ") || "none"})`;
+      reasons[angle] = `Skipped: detected categories (${changeCategories.join(", ") || "none"}) do not trigger this angle`;
     }
   }
 

--- a/packages/core/src/analysis/change-classifier.mjs
+++ b/packages/core/src/analysis/change-classifier.mjs
@@ -2,7 +2,7 @@
  * Change category classification and angle relevance index.
  *
  * Maps change categories detected by the diff analyzer to relevant gate review
- * angles, with optional per-angle score thresholds.
+ * angles.
  */
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/analysis/change-classifier.mjs
+++ b/packages/core/src/analysis/change-classifier.mjs
@@ -86,14 +86,12 @@ const ALWAYS_INCLUDE = new Set(["gate-evidence", "renderer-security"]);
  * @param {string[]} options.configuredAngles — all angles configured for this gate
  * @param {string[]} options.changeCategories — from diff analysis
  * @param {boolean} [options.ambiguous] — from diff analysis
- * @param {Record<string, number>} [options.thresholds] — per-angle override thresholds
  * @returns {DynamicAngleResult}
  */
 export function resolveDynamicAngles({
   configuredAngles,
   changeCategories,
   ambiguous = false,
-  thresholds = {},
 }) {
   // Fallback: ambiguous diff → all angles
   if (ambiguous) {
@@ -131,7 +129,7 @@ export function resolveDynamicAngles({
 
   // Filter to only angles that are configured
   const configuredSet = new Set(configuredAngles);
-  const recommendedAngles = [...recommended].filter((a) => configuredSet.has(a));
+  const recommendedAngles = configuredAngles.filter((a) => recommended.has(a));
   const skippedAngles = configuredAngles.filter((a) => !recommended.has(a));
 
   // Build reasons

--- a/packages/core/src/analysis/change-classifier.mjs
+++ b/packages/core/src/analysis/change-classifier.mjs
@@ -134,11 +134,7 @@ export function resolveDynamicAngles({
   // Build reasons
   const reasons = {};
   for (const angle of skippedAngles) {
-    if (ALWAYS_INCLUDE.has(angle)) {
-      reasons[angle] = "always-included angle, should never be skipped";
-    } else {
-      reasons[angle] = `Skipped: detected categories (${changeCategories.join(", ") || "none"}) do not trigger this angle`;
-    }
+    reasons[angle] = `Skipped: detected categories (${changeCategories.join(", ") || "none"}) do not trigger this angle`;
   }
 
   return {

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -94,9 +94,6 @@ export function classifyFile(filePath) {
   if (filePath.includes(".test.") || filePath.startsWith("test/")) {
     return "test";
   }
-  if (filePath.startsWith(".github/")) {
-    return "ci";
-  }
   if (
     filePath.endsWith(".mjs") || filePath.endsWith(".js") ||
     filePath.endsWith(".ts") || filePath.endsWith(".mts")
@@ -116,6 +113,21 @@ export function classifyFile(filePath) {
  * @property {number} hunkCount
  * @property {{ added: number, deleted: number }} lineStats
  */
+
+/**
+ * Check whether a diff line content (after stripping the + / - prefix) is
+ * a comment, import/export, or blank line — i.e. not logic.
+ *
+ * @param {string} content — trimmed line content (without + / - prefix)
+ * @returns {boolean}
+ */
+function isNonLogicLine(content) {
+  if (content === "") return true;
+  if (content.startsWith("//") || content.startsWith("/*") || content.startsWith("*")) return true;
+  if (content.startsWith("import ") || content.startsWith("export ")) return true;
+  if (content.includes("require(")) return true;
+  return false;
+}
 
 /**
  * Analyze unified diff hunks to classify change types.
@@ -142,6 +154,8 @@ export function analyzeT1(diffOutput, t0) {
 
   let inHunk = false;
   let hasLogicChange = false;
+  let hasAnyChangedLine = false;
+  let allChangedLinesAreNonLogic = true;
 
   for (const line of lines) {
     // Track hunk headers
@@ -153,21 +167,23 @@ export function analyzeT1(diffOutput, t0) {
 
     if (!inHunk) continue;
 
-    // Track line stats
+    // Track line stats and classify
     if (line.startsWith("+") && !line.startsWith("+++")) {
       added++;
-      // Classify the line
+      hasAnyChangedLine = true;
       const content = line.slice(1).trim();
-      if (content.startsWith("import ") || content.startsWith("export ") ||
-          content.includes("require(") || content.startsWith("//") ||
-          content.startsWith("/*") || content.startsWith("*") ||
-          content === "") {
-        // comment, import, or blank — not logic
-      } else {
+      if (!isNonLogicLine(content)) {
         hasLogicChange = true;
+        allChangedLinesAreNonLogic = false;
       }
     } else if (line.startsWith("-") && !line.startsWith("---")) {
       deleted++;
+      hasAnyChangedLine = true;
+      const content = line.slice(1).trim();
+      if (!isNonLogicLine(content)) {
+        hasLogicChange = true;
+        allChangedLinesAreNonLogic = false;
+      }
     }
   }
 
@@ -178,7 +194,10 @@ export function analyzeT1(diffOutput, t0) {
   if (t0.files.every((f) => classifyFile(f) === "test")) categories.add("TEST_ONLY");
   if (t0.files.every((f) => classifyFile(f) === "ci")) categories.add("CI_ONLY");
   if (hasLogicChange) categories.add("LOGIC_CHANGE");
-  if (hunkCount === 0 && !hasLogicChange && !t0.renameOnly) {
+
+  // COMMENT_ONLY: hunkCount > 0 (real diff), has changed lines, all are non-logic,
+  // and not a rename-only change
+  if (hunkCount > 0 && hasAnyChangedLine && allChangedLinesAreNonLogic && !t0.renameOnly) {
     categories.add("COMMENT_ONLY");
   }
 
@@ -201,9 +220,27 @@ export function analyzeT1(diffOutput, t0) {
  */
 
 /**
+ * Infer change categories from T0 analysis when T1 is not run.
+ *
+ * @param {T0Result} t0
+ * @returns {string[]}
+ */
+function inferCategoriesFromT0(t0) {
+  const categories = [];
+  if (t0.renameOnly) categories.push("RENAME_ONLY");
+  if (t0.allDocs) categories.push("DOCS_ONLY");
+  if (t0.files.length > 0 && t0.files.every((f) => classifyFile(f) === "config")) categories.push("CONFIG_ONLY");
+  if (t0.files.length > 0 && t0.files.every((f) => classifyFile(f) === "test")) categories.push("TEST_ONLY");
+  if (t0.files.length > 0 && t0.files.every((f) => classifyFile(f) === "ci")) categories.push("CI_ONLY");
+  return categories;
+}
+
+/**
  * Run full diff analysis (T0 + T1 if needed).
  *
  * T0 always runs. T1 runs when T0 doesn't produce a clear single-category result.
+ * When T1 is not run (unambiguous diff), categories are inferred from T0 so
+ * dynamic angle resolution can still narrow the angle list.
  *
  * @param {{ nameStatusOutput: string, diffOutput?: string }} input
  * @returns {DiffAnalysis}
@@ -220,7 +257,17 @@ export function analyzeDiff({ nameStatusOutput, diffOutput }) {
     t1 = analyzeT1(diffOutput, t0);
   }
 
-  const ambiguous = t0Ambiguous && (!t1 || t1.changeCategories.length === 0 || t1.changeCategories.includes("LOGIC_CHANGE"));
+  // When t1 is null (unambiguous diff), infer categories from t0
+  // so dynamic angle resolution can narrow for config-only / test-only etc.
+  if (!t1) {
+    t1 = {
+      changeCategories: inferCategoriesFromT0(t0),
+      hunkCount: 0,
+      lineStats: { added: 0, deleted: 0 },
+    };
+  }
+
+  const ambiguous = t0Ambiguous && (t1.changeCategories.length === 0 || t1.changeCategories.includes("LOGIC_CHANGE"));
 
   return { t0, t1, ambiguous };
 }

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -17,7 +17,7 @@
  * @typedef {object} T0Result
  * @property {string[]} files — flat file paths
  * @property {string[]} extensions — unique file extensions (lowercase, with dot)
- * @property {string[]} directories — unique top-level directories
+ * @property {string[]} directories — unique top-level path segments
  * @property {boolean} renameOnly — true when all entries are renames (no adds/deletes/modifies)
  * @property {boolean} allDocs — true when all files are under docs/ or are .md
  */
@@ -129,7 +129,7 @@ export function classifyFile(filePath) {
 
 /**
  * Check whether a diff line content (after stripping the + / - prefix) is
- * a comment, import/export, or blank line — i.e. not logic.
+ * a comment or blank line — i.e. not logic.
  *
  * @param {string} content — trimmed line content (without + / - prefix)
  * @returns {boolean}
@@ -146,7 +146,7 @@ function isNonLogicLine(content) {
  * Analyze unified diff hunks to classify change types.
  *
  * Detects:
- * - IMPORT_ONLY: only import/require lines changed
+ * Detects:
  * - COMMENT_ONLY: only comment lines changed
  * - DOCS_ONLY: only .md files changed (from extensions)
  * - CONFIG_ONLY: only config files changed

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -1,0 +1,226 @@
+/**
+ * Diff analysis for dynamic gate angle resolution.
+ *
+ * T0 — file-level: classifies files by extension and directory.
+ * T1 — hunk-level: classifies hunks by change type (comments, imports, config, etc.).
+ *
+ * T2 (AST-level) is deferred to a follow-up.
+ *
+ * This module is intentionally pure and side-effect free.
+ */
+
+// ---------------------------------------------------------------------------
+// T0: File-level analysis
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} T0Result
+ * @property {string[]} files — flat file paths
+ * @property {string[]} extensions — unique file extensions (lowercase, with dot)
+ * @property {string[]} directories — unique top-level directories
+ * @property {boolean} renameOnly — true when all entries are renames (no adds/deletes/modifies)
+ * @property {boolean} allDocs — true when all files are under docs/ or are .md
+ */
+
+/**
+ * Parse `git diff --name-status` output into a T0 analysis.
+ *
+ * Each line format: `<status>\t<path>` or `<status>\t<old>\t<new>`.
+ *
+ * @param {string} nameStatusOutput — raw stdout from `git diff --name-status`
+ * @returns {T0Result}
+ */
+export function analyzeT0(nameStatusOutput) {
+  const lines = nameStatusOutput.trim().split("\n").filter(Boolean);
+  const files = [];
+  const extensions = new Set();
+  const directories = new Set();
+  let renameCount = 0;
+
+  for (const line of lines) {
+    const parts = line.split("\t");
+    const status = parts[0];
+    const path = parts.length >= 3 ? parts[2] : parts[1];
+    if (!path) continue;
+
+    files.push(path);
+
+    const ext = path.includes(".") ? "." + path.split(".").pop().toLowerCase() : "";
+    if (ext) extensions.add(ext);
+
+    const dir = path.split("/")[0];
+    if (dir) directories.add(dir);
+
+    if (status.startsWith("R")) renameCount++;
+  }
+
+  const renameOnly = lines.length > 0 && renameCount === lines.length;
+  const allDocs = lines.length > 0 && files.every(
+    (f) => f.startsWith("docs/") || f.endsWith(".md") || f === "README.md",
+  );
+
+  return {
+    files,
+    extensions: [...extensions].sort(),
+    directories: [...directories].sort(),
+    renameOnly,
+    allDocs,
+  };
+}
+
+/**
+ * @typedef {"code" | "docs" | "config" | "test" | "ci" | "unknown"} FileCategory
+ */
+
+/**
+ * Classify a single file path into a high-level category.
+ *
+ * @param {string} filePath
+ * @returns {FileCategory}
+ */
+export function classifyFile(filePath) {
+  if (filePath.startsWith(".github/")) {
+    return "ci";
+  }
+  if (filePath.startsWith("docs/") || filePath.endsWith(".md") || filePath === "README.md") {
+    return "docs";
+  }
+  if (
+    filePath.endsWith(".yml") || filePath.endsWith(".yaml") ||
+    filePath.endsWith(".json") || filePath === "package.json"
+  ) {
+    return "config";
+  }
+  if (filePath.includes(".test.") || filePath.startsWith("test/")) {
+    return "test";
+  }
+  if (filePath.startsWith(".github/")) {
+    return "ci";
+  }
+  if (
+    filePath.endsWith(".mjs") || filePath.endsWith(".js") ||
+    filePath.endsWith(".ts") || filePath.endsWith(".mts")
+  ) {
+    return "code";
+  }
+  return "unknown";
+}
+
+// ---------------------------------------------------------------------------
+// T1: Hunk-level analysis
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} T1Result
+ * @property {string[]} changeCategories — detected change categories
+ * @property {number} hunkCount
+ * @property {{ added: number, deleted: number }} lineStats
+ */
+
+/**
+ * Analyze unified diff hunks to classify change types.
+ *
+ * Detects:
+ * - IMPORT_ONLY: only import/require lines changed
+ * - COMMENT_ONLY: only comment lines changed
+ * - DOCS_ONLY: only .md files changed (from extensions)
+ * - CONFIG_ONLY: only config files changed
+ * - TEST_ONLY: only test files changed
+ * - RENAME_ONLY: all renames, no content changes
+ * - LOGIC_CHANGE: any non-trivial code change
+ *
+ * @param {string} diffOutput — raw unified diff output
+ * @param {T0Result} t0 — T0 result for context
+ * @returns {T1Result}
+ */
+export function analyzeT1(diffOutput, t0) {
+  const lines = diffOutput.split("\n");
+  let hunkCount = 0;
+  let added = 0;
+  let deleted = 0;
+  const categories = new Set();
+
+  let inHunk = false;
+  let hasLogicChange = false;
+
+  for (const line of lines) {
+    // Track hunk headers
+    if (line.startsWith("@@")) {
+      hunkCount++;
+      inHunk = true;
+      continue;
+    }
+
+    if (!inHunk) continue;
+
+    // Track line stats
+    if (line.startsWith("+") && !line.startsWith("+++")) {
+      added++;
+      // Classify the line
+      const content = line.slice(1).trim();
+      if (content.startsWith("import ") || content.startsWith("export ") ||
+          content.includes("require(") || content.startsWith("//") ||
+          content.startsWith("/*") || content.startsWith("*") ||
+          content === "") {
+        // comment, import, or blank — not logic
+      } else {
+        hasLogicChange = true;
+      }
+    } else if (line.startsWith("-") && !line.startsWith("---")) {
+      deleted++;
+    }
+  }
+
+  // Build categories from T0 + hunk analysis
+  if (t0.renameOnly) categories.add("RENAME_ONLY");
+  if (t0.allDocs) categories.add("DOCS_ONLY");
+  if (t0.files.every((f) => classifyFile(f) === "config")) categories.add("CONFIG_ONLY");
+  if (t0.files.every((f) => classifyFile(f) === "test")) categories.add("TEST_ONLY");
+  if (t0.files.every((f) => classifyFile(f) === "ci")) categories.add("CI_ONLY");
+  if (hasLogicChange) categories.add("LOGIC_CHANGE");
+  if (hunkCount === 0 && !hasLogicChange && !t0.renameOnly) {
+    categories.add("COMMENT_ONLY");
+  }
+
+  return {
+    changeCategories: [...categories],
+    hunkCount,
+    lineStats: { added, deleted },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Combined analysis
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} DiffAnalysis
+ * @property {T0Result} t0
+ * @property {T1Result | null} t1
+ * @property {boolean} ambiguous — true when heuristics cannot confidently classify
+ */
+
+/**
+ * Run full diff analysis (T0 + T1 if needed).
+ *
+ * T0 always runs. T1 runs when T0 doesn't produce a clear single-category result.
+ *
+ * @param {{ nameStatusOutput: string, diffOutput?: string }} input
+ * @returns {DiffAnalysis}
+ */
+export function analyzeDiff({ nameStatusOutput, diffOutput }) {
+  const t0 = analyzeT0(nameStatusOutput);
+  let t1 = null;
+
+  // T0 is unambiguous when: renameOnly, allDocs, or single clear category
+  const t0Ambiguous = !t0.renameOnly && !t0.allDocs && t0.files.length > 1 &&
+    new Set(t0.files.map(classifyFile)).size > 1;
+
+  if (t0Ambiguous && diffOutput) {
+    t1 = analyzeT1(diffOutput, t0);
+  }
+
+  const ambiguous = t0Ambiguous && (!t1 || t1.changeCategories.length === 0 || t1.changeCategories.includes("LOGIC_CHANGE"));
+
+  return { t0, t1, ambiguous };
+}

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -108,9 +108,6 @@ export function classifyFile(filePath) {
   if (fp.includes(".test.") || fp.startsWith("test/")) {
     return "test";
   }
-  if (fp.startsWith(".github/")) {
-    return "ci";
-  }
   if (
     fp.endsWith(".mjs") || fp.endsWith(".js") ||
     fp.endsWith(".ts") || fp.endsWith(".mts")
@@ -140,8 +137,8 @@ export function classifyFile(filePath) {
 function isNonLogicLine(content) {
   if (content === "") return true;
   if (content.startsWith("//") || content.startsWith("/*") || content.startsWith("*")) return true;
-  if (content.startsWith("import ") || content.startsWith("export ")) return true;
-  if (content.includes("require(")) return true;
+  // import/export/require lines are NOT non-logic — they change dependencies
+  // and should not be classified as COMMENT_ONLY
   return false;
 }
 

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -30,6 +30,18 @@
  * @param {string} nameStatusOutput — raw stdout from `git diff --name-status`
  * @returns {T0Result}
  */
+
+/**
+ * Normalize file path separators to forward slashes.
+ * Handles Windows backslash paths from git output on Windows.
+ *
+ * @param {string} filePath
+ * @returns {string}
+ */
+function normalizeSep(filePath) {
+  return filePath.replaceAll("\\", "/");
+}
+
 export function analyzeT0(nameStatusOutput) {
   const lines = nameStatusOutput.trim().split("\n").filter(Boolean);
   const files = [];
@@ -40,7 +52,8 @@ export function analyzeT0(nameStatusOutput) {
   for (const line of lines) {
     const parts = line.split("\t");
     const status = parts[0];
-    const path = parts.length >= 3 ? parts[2] : parts[1];
+    const rawPath = parts.length >= 3 ? parts[2] : parts[1];
+    const path = normalizeSep(rawPath);
     if (!path) continue;
 
     files.push(path);
@@ -56,7 +69,7 @@ export function analyzeT0(nameStatusOutput) {
 
   const renameOnly = lines.length > 0 && renameCount === lines.length;
   const allDocs = lines.length > 0 && files.every(
-    (f) => f.startsWith("docs/") || f.endsWith(".md") || f === "README.md",
+    (f) => normalizeSep(f).startsWith("docs/") || f.endsWith(".md") || f === "README.md",
   );
 
   return {
@@ -79,30 +92,33 @@ export function analyzeT0(nameStatusOutput) {
  * @returns {FileCategory}
  */
 export function classifyFile(filePath) {
-  if (filePath.startsWith(".github/")) {
+  const fp = normalizeSep(filePath);
+  if (fp.startsWith(".github/")) {
     return "ci";
   }
-  if (filePath.startsWith("docs/") || filePath.endsWith(".md") || filePath === "README.md") {
+  if (fp.startsWith("docs/") || fp.endsWith(".md") || fp === "README.md") {
     return "docs";
   }
   if (
-    filePath.endsWith(".yml") || filePath.endsWith(".yaml") ||
-    filePath.endsWith(".json") || filePath === "package.json"
+    fp.endsWith(".yml") || fp.endsWith(".yaml") ||
+    fp.endsWith(".json") || fp === "package.json"
   ) {
     return "config";
   }
-  if (filePath.includes(".test.") || filePath.startsWith("test/")) {
+  if (fp.includes(".test.") || fp.startsWith("test/")) {
     return "test";
   }
+  if (fp.startsWith(".github/")) {
+    return "ci";
+  }
   if (
-    filePath.endsWith(".mjs") || filePath.endsWith(".js") ||
-    filePath.endsWith(".ts") || filePath.endsWith(".mts")
+    fp.endsWith(".mjs") || fp.endsWith(".js") ||
+    fp.endsWith(".ts") || fp.endsWith(".mts")
   ) {
     return "code";
   }
   return "unknown";
 }
-
 // ---------------------------------------------------------------------------
 // T1: Hunk-level analysis
 // ---------------------------------------------------------------------------

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -146,7 +146,6 @@ function isNonLogicLine(content) {
  * Analyze unified diff hunks to classify change types.
  *
  * Detects:
- * Detects:
  * - COMMENT_ONLY: only comment lines changed
  * - DOCS_ONLY: only .md files changed (from extensions)
  * - CONFIG_ONLY: only config files changed

--- a/packages/core/src/analysis/index.mjs
+++ b/packages/core/src/analysis/index.mjs
@@ -1,0 +1,2 @@
+export { analyzeT0, analyzeT1, analyzeDiff, classifyFile } from "./diff-analyzer.mjs";
+export { ChangeCategory, resolveDynamicAngles } from "./change-classifier.mjs";

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -39,6 +39,8 @@ const GateConfig = z.strictObject({
     .array(z.enum(["must-fix", "worth-fixing-now", "defer"]))
     .min(1)
     .default(["must-fix"]),
+  dynamicAngles: z.boolean().default(false),
+  dynamicAngleThresholds: z.record(z.string().trim().min(1), z.number().min(0).max(1)).default({}),
 });
 
 const GatesConfig = z.strictObject({
@@ -671,6 +673,63 @@ export function resolveGateAngles(config, gate) {
   if (gateConfig.angles === null) return null;
   const excluded = new Set(gateConfig.excludeAngles);
   return gateConfig.angles.filter(a => !excluded.has(a));
+}
+
+/**
+ * Resolve gate angles dynamically when `dynamicAngles` is enabled in config.
+ *
+ * Uses diff analysis (from `@pi-dev-loops/core/analysis`) to filter the
+ * configured angle list down to only angles relevant to the change set.
+ *
+ * When `dynamicAngles` is disabled (default), returns the full configured
+ * angle list (same as `resolveGateAngles`).
+ *
+ * @param {import("./types.js").DevLoopConfig} config
+ * @param {"draft"|"preApproval"} gate
+ * @param {object} [options]
+ * @param {{ nameStatusOutput: string, diffOutput?: string }} [options.diff]
+ * @returns {{ recommendedAngles: string[] | null, skippedAngles: string[], reasons: Record<string,string>, fallbackToAll: boolean, dynamicAnglesActive: boolean }}
+ */
+export async function resolveGateAnglesDynamic(config, gate, { diff } = {}) {
+  const staticAngles = resolveGateAngles(config, gate);
+  if (staticAngles === null) {
+    return { recommendedAngles: null, skippedAngles: [], reasons: {}, fallbackToAll: false, dynamicAnglesActive: false };
+  }
+
+  const gateConfig = resolveGateConfig(config, gate);
+  if (!gateConfig.dynamicAngles || !diff) {
+    return {
+      recommendedAngles: staticAngles,
+      skippedAngles: [],
+      reasons: {},
+      fallbackToAll: false,
+      dynamicAnglesActive: false,
+    };
+  }
+
+  // Dynamic resolution
+  const { analyzeDiff } = await import("../analysis/index.mjs");
+  const analysis = analyzeDiff({
+    nameStatusOutput: diff.nameStatusOutput,
+    diffOutput: diff.diffOutput,
+  });
+
+  const categories = analysis.t1?.changeCategories ?? [];
+  if (analysis.t0.renameOnly) categories.push("RENAME_ONLY");
+  if (analysis.t0.allDocs) categories.push("DOCS_ONLY");
+
+  const { resolveDynamicAngles: resolve } = await import("../analysis/change-classifier.mjs");
+  const dynamicResult = resolve({
+    configuredAngles: staticAngles,
+    changeCategories: categories,
+    ambiguous: analysis.ambiguous,
+    thresholds: gateConfig.dynamicAngleThresholds ?? {},
+  });
+
+  return {
+    ...dynamicResult,
+    dynamicAnglesActive: true,
+  };
 }
 
 /**

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -714,9 +714,7 @@ export async function resolveGateAnglesDynamic(config, gate, { diff } = {}) {
     diffOutput: diff.diffOutput,
   });
 
-  const categories = analysis.t1?.changeCategories ?? [];
-  if (analysis.t0.renameOnly) categories.push("RENAME_ONLY");
-  if (analysis.t0.allDocs) categories.push("DOCS_ONLY");
+  const categories = [...new Set(analysis.t1?.changeCategories ?? [])];
 
   const { resolveDynamicAngles: resolve } = await import("../analysis/change-classifier.mjs");
   const dynamicResult = resolve({

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -615,7 +615,7 @@ export function resolveRefinement(config) {
  *
  * @param {DevLoopConfig} config
  * @param {"draft"|"preApproval"} gate
- * @returns {{ angles: string[]|null, excludeAngles: string[], required: boolean, requireCi: boolean, blockCleanOnFindingSeverities: string[] }}
+ * @returns {{ angles: string[]|null, excludeAngles: string[], required: boolean, requireCi: boolean, blockCleanOnFindingSeverities: string[], dynamicAngles: boolean }}
  */
 export function resolveGateConfig(config, gate) {
   const gateConfig = config?.gates?.[gate];

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -40,7 +40,6 @@ const GateConfig = z.strictObject({
     .min(1)
     .default(["must-fix"]),
   dynamicAngles: z.boolean().default(false),
-  dynamicAngleThresholds: z.record(z.string().trim().min(1), z.number().min(0).max(1)).default({}),
 });
 
 const GatesConfig = z.strictObject({
@@ -629,6 +628,7 @@ export function resolveGateConfig(config, gate) {
       : [],
     required: gateConfig?.required ?? true,
     requireCi: gateConfig?.requireCi ?? true,
+    dynamicAngles: gateConfig?.dynamicAngles ?? false,
     blockCleanOnFindingSeverities: gateConfig?.blockCleanOnFindingSeverities && Array.isArray(gateConfig.blockCleanOnFindingSeverities)
       ? [...gateConfig.blockCleanOnFindingSeverities]
       : ["must-fix"],
@@ -723,7 +723,6 @@ export async function resolveGateAnglesDynamic(config, gate, { diff } = {}) {
     configuredAngles: staticAngles,
     changeCategories: categories,
     ambiguous: analysis.ambiguous,
-    thresholds: gateConfig.dynamicAngleThresholds ?? {},
   });
 
   return {

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -17,6 +17,7 @@ import {
   resolveRefinement,
   resolveGateConfig,
   resolveGateAngles,
+  resolveGateAnglesDynamic,
   resolveWorkflowConfig,
   resolveLightMode,
 } from "../src/config/config.mjs";
@@ -2051,4 +2052,103 @@ test("parseGitDiffStat: whitespace-only output", async () => {
 });
 
 // Close the integration tests describe block
+});
+
+// ============================================================================
+// resolveGateAnglesDynamic tests
+// ============================================================================
+
+describe("resolveGateAnglesDynamic", () => {
+  test("returns full angle list when dynamicAngles is false", async () => {
+    const config = {
+      version: 1,
+      gates: {
+        draft: { angles: ["scope", "coverage", "docs"], dynamicAngles: false },
+      },
+    };
+    const result = await resolveGateAnglesDynamic(config, "draft");
+    assert.deepEqual(result.recommendedAngles, ["scope", "coverage", "docs"]);
+    assert.deepEqual(result.skippedAngles, []);
+    assert.equal(result.dynamicAnglesActive, false);
+    assert.equal(result.fallbackToAll, false);
+  });
+
+  test("returns null recommendedAngles when no angles configured", async () => {
+    const result = await resolveGateAnglesDynamic({ version: 1 }, "draft");
+    assert.equal(result.recommendedAngles, null);
+    assert.equal(result.dynamicAnglesActive, false);
+  });
+
+  test("returns full angle list when diff is not provided (dynamicAngles true)", async () => {
+    const config = {
+      version: 1,
+      gates: {
+        draft: { angles: ["scope", "coverage"], dynamicAngles: true },
+      },
+    };
+    const result = await resolveGateAnglesDynamic(config, "draft");
+    assert.deepEqual(result.recommendedAngles, ["scope", "coverage"]);
+    assert.equal(result.dynamicAnglesActive, false); // no diff → not active
+  });
+
+  test("activates dynamic resolution when diff provided and dynamicAngles true", async () => {
+    const config = {
+      version: 1,
+      gates: {
+        draft: { angles: ["scope", "coverage", "docs", "deep", "kiss"], dynamicAngles: true },
+      },
+    };
+    const result = await resolveGateAnglesDynamic(config, "draft", {
+      diff: {
+        nameStatusOutput: "M\tdocs/guide.md\nM\tREADME.md",
+      },
+    });
+    assert.equal(result.dynamicAnglesActive, true);
+    // allDocs → DOCS_ONLY → relevant angles include docs, link-check, contract-surface, dry
+    assert.ok(result.recommendedAngles.length > 0);
+    assert.ok(result.recommendedAngles.length < 5); // narrowed from 5
+  });
+
+  test("respects excludeAngles during dynamic resolution", async () => {
+    const config = {
+      version: 1,
+      gates: {
+        draft: {
+          angles: ["scope", "docs", "kiss"],
+          excludeAngles: ["kiss"],
+          dynamicAngles: true,
+        },
+      },
+    };
+    const result = await resolveGateAnglesDynamic(config, "draft", {
+      diff: {
+        nameStatusOutput: "M\tdocs/guide.md\nM\tREADME.md",
+      },
+    });
+    assert.equal(result.dynamicAnglesActive, true);
+    assert.ok(!result.recommendedAngles.includes("kiss"));
+    assert.ok(!result.skippedAngles.includes("kiss")); // excluded before dynamic resolution
+  });
+
+  test("returns reasons for skipped angles", async () => {
+    const config = {
+      version: 1,
+      gates: {
+        draft: {
+          angles: ["scope", "coverage", "docs", "deep", "kiss", "dry", "srp", "soc"],
+          dynamicAngles: true,
+        },
+      },
+    };
+    const result = await resolveGateAnglesDynamic(config, "draft", {
+      diff: {
+        nameStatusOutput: "M\tdocs/guide.md\nM\tREADME.md",
+      },
+    });
+    assert.equal(result.dynamicAnglesActive, true);
+    assert.ok(Object.keys(result.reasons).length > 0);
+    for (const angle of result.skippedAngles) {
+      assert.ok(result.reasons[angle], `reason missing for ${angle}`);
+    }
+  });
 });

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1415,6 +1415,7 @@ describe("role resolution", () => {
         excludeAngles: [],
         required: true,
         requireCi: true,
+        dynamicAngles: false,
         blockCleanOnFindingSeverities: ["must-fix"],
       });
     });
@@ -1431,6 +1432,7 @@ describe("role resolution", () => {
         excludeAngles: [],
         required: false,
         requireCi: false,
+        dynamicAngles: false,
         blockCleanOnFindingSeverities: ["must-fix"],
       });
       assert.deepEqual(config.gates.draft.angles, ["scope", "coverage"]);

--- a/packages/core/test/diff-analyzer.test.mjs
+++ b/packages/core/test/diff-analyzer.test.mjs
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  analyzeT0,
+  classifyFile,
+  analyzeT1,
+  analyzeDiff,
+} from "../src/analysis/diff-analyzer.mjs";
+
+// ---------------------------------------------------------------------------
+// classifyFile
+// ---------------------------------------------------------------------------
+
+test("classifyFile: docs for .md files", () => {
+  assert.equal(classifyFile("docs/foo.md"), "docs");
+  assert.equal(classifyFile("README.md"), "docs");
+});
+
+test("classifyFile: config for .yml/.yaml/.json", () => {
+  assert.equal(classifyFile("package.json"), "config");
+  assert.equal(classifyFile(".pi/dev-loop/settings.yaml"), "config");
+});
+
+test("classifyFile: test for .test.mjs and test/ paths", () => {
+  assert.equal(classifyFile("packages/core/test/foo.test.mjs"), "test");
+  assert.equal(classifyFile("test/loop/test.mjs"), "test");
+});
+
+test("classifyFile: code for .mjs/.js/.ts", () => {
+  assert.equal(classifyFile("src/foo.mjs"), "code");
+  assert.equal(classifyFile("scripts/bar.mjs"), "code");
+});
+
+test("classifyFile: ci for .github/ paths", () => {
+  assert.equal(classifyFile(".github/workflows/verify.yml"), "ci");
+});
+
+test("classifyFile: unknown for unrecognized", () => {
+  assert.equal(classifyFile("assets/logo.png"), "unknown");
+});
+
+// ---------------------------------------------------------------------------
+// analyzeT0
+// ---------------------------------------------------------------------------
+
+test("analyzeT0: empty input", () => {
+  const result = analyzeT0("");
+  assert.deepEqual(result.files, []);
+  assert.deepEqual(result.extensions, []);
+  assert.equal(result.renameOnly, false);
+  assert.equal(result.allDocs, false);
+});
+
+test("analyzeT0: single modified file", () => {
+  const result = analyzeT0("M\tsrc/foo.mjs");
+  assert.deepEqual(result.files, ["src/foo.mjs"]);
+  assert.deepEqual(result.extensions, [".mjs"]);
+  assert.deepEqual(result.directories, ["src"]);
+  assert.equal(result.renameOnly, false);
+});
+
+test("analyzeT0: rename-only diff", () => {
+  const result = analyzeT0("R100\told.mjs\tnew.mjs\nR100\tsrc/a.ts\tsrc/b.ts");
+  assert.equal(result.renameOnly, true);
+  assert.equal(result.files.length, 2);
+});
+
+test("analyzeT0: all-docs diff", () => {
+  const result = analyzeT0("M\tdocs/guide.md\nM\tREADME.md\nA\tdocs/api.md");
+  assert.equal(result.allDocs, true);
+});
+
+test("analyzeT0: mixed extensions", () => {
+  const result = analyzeT0("M\tsrc/foo.mjs\nM\tdocs/bar.md\nM\tpackage.json");
+  assert.deepEqual(result.extensions, [".json", ".md", ".mjs"]);
+  assert.deepEqual(result.directories, ["docs", "package.json", "src"]);
+});
+
+test("analyzeT0: handles Windows paths", () => {
+  const result = analyzeT0("M\tsrc\\foo.mjs");
+  assert.deepEqual(result.files, ["src\\foo.mjs"]);
+  assert.deepEqual(result.extensions, [".mjs"]);
+});
+
+// ---------------------------------------------------------------------------
+// analyzeT1
+// ---------------------------------------------------------------------------
+
+test("analyzeT1: detects logic change from code additions", () => {
+  const t0 = { files: ["src/foo.mjs"], extensions: [".mjs"], directories: ["src"], renameOnly: false, allDocs: false };
+  const diff = "@@ -1,3 +1,5 @@\n import x from 'y';\n+const foo = 42;\n+export { foo };\n";
+  const result = analyzeT1(diff, t0);
+  assert.ok(result.changeCategories.includes("LOGIC_CHANGE"));
+  assert.equal(result.hunkCount, 1);
+});
+
+test("analyzeT1: no logic change from import-only diff", () => {
+  const t0 = { files: ["src/foo.mjs"], extensions: [".mjs"], directories: ["src"], renameOnly: false, allDocs: false };
+  const diff = "@@ -1,1 +1,1 @@\n-import x from 'y';\n+import z from 'y';\n";
+  const result = analyzeT1(diff, t0);
+  assert.ok(!result.changeCategories.includes("LOGIC_CHANGE"));
+});
+
+test("analyzeT1: renames with no content change", () => {
+  const t0 = { files: ["src/bar.mjs"], extensions: [".mjs"], directories: ["src"], renameOnly: true, allDocs: false };
+  const result = analyzeT1("", t0);
+  assert.ok(result.changeCategories.includes("RENAME_ONLY"));
+});
+
+test("analyzeT1: docs-only from T0", () => {
+  const t0 = { files: ["docs/x.md"], extensions: [".md"], directories: ["docs"], renameOnly: false, allDocs: true };
+  const result = analyzeT1("", t0);
+  assert.ok(result.changeCategories.includes("DOCS_ONLY"));
+});
+
+test("analyzeT1: config-only from T0", () => {
+  const t0 = { files: ["package.json", ".pi/dev-loop/settings.yaml"], extensions: [".json", ".yaml"], directories: [".pi"], renameOnly: false, allDocs: false };
+  const result = analyzeT1("", t0);
+  assert.ok(result.changeCategories.includes("CONFIG_ONLY"));
+});
+
+test("analyzeT1: tracks line stats", () => {
+  const t0 = { files: ["src/foo.mjs"], extensions: [".mjs"], directories: ["src"], renameOnly: false, allDocs: false };
+  const diff = "@@ -1,2 +1,3 @@\n-old\n+new\n+extra\n";
+  const result = analyzeT1(diff, t0);
+  assert.equal(result.lineStats.added, 2);
+  assert.equal(result.lineStats.deleted, 1);
+});
+
+// ---------------------------------------------------------------------------
+// analyzeDiff (combined)
+// ---------------------------------------------------------------------------
+
+test("analyzeDiff: T0 unambiguous → no T1, not ambiguous", () => {
+  const result = analyzeDiff({ nameStatusOutput: "M\tdocs/guide.md\nM\tREADME.md" });
+  assert.ok(result.t0.allDocs);
+  assert.equal(result.t1, null);
+  assert.equal(result.ambiguous, false);
+});
+
+test("analyzeDiff: T0 ambiguous with diff → runs T1, ambiguous if logic change", () => {
+  const result = analyzeDiff({
+    nameStatusOutput: "M\tsrc/foo.mjs\nM\tdocs/bar.md",
+    diffOutput: "@@ -1,1 +1,1 @@\n+const x = 1;\n",
+  });
+  assert.ok(result.t1 !== null);
+  assert.equal(result.ambiguous, true); // LOGIC_CHANGE from T1 → ambiguous
+});
+
+test("analyzeDiff: T0 ambiguous without diff → no T1, ambiguous", () => {
+  const result = analyzeDiff({ nameStatusOutput: "M\tsrc/foo.mjs\nM\tdocs/bar.md" });
+  assert.equal(result.t1, null);
+  assert.equal(result.ambiguous, true);
+});
+
+test("analyzeDiff: rename-only → unambiguous", () => {
+  const result = analyzeDiff({ nameStatusOutput: "R100\told.mjs\tnew.mjs" });
+  assert.ok(result.t0.renameOnly);
+  assert.equal(result.ambiguous, false);
+});

--- a/packages/core/test/diff-analyzer.test.mjs
+++ b/packages/core/test/diff-analyzer.test.mjs
@@ -127,6 +127,14 @@ test("analyzeT1: tracks line stats", () => {
   assert.equal(result.lineStats.added, 2);
   assert.equal(result.lineStats.deleted, 1);
 });
+test("analyzeT1: detects COMMENT_ONLY from comment-only diff", () => {
+  const t0 = { files: ["src/foo.mjs"], extensions: [".mjs"], directories: ["src"], renameOnly: false, allDocs: false };
+  const diff = "@@ -1,3 +1,3 @@\n-// old comment\n+// new comment\n";
+  const result = analyzeT1(diff, t0);
+  assert.ok(result.changeCategories.includes("COMMENT_ONLY"));
+  assert.ok(result.hunkCount > 0);
+});
+
 
 // ---------------------------------------------------------------------------
 // analyzeDiff (combined)

--- a/packages/core/test/diff-analyzer.test.mjs
+++ b/packages/core/test/diff-analyzer.test.mjs
@@ -135,7 +135,7 @@ test("analyzeT1: tracks line stats", () => {
 test("analyzeDiff: T0 unambiguous → no T1, not ambiguous", () => {
   const result = analyzeDiff({ nameStatusOutput: "M\tdocs/guide.md\nM\tREADME.md" });
   assert.ok(result.t0.allDocs);
-  assert.equal(result.t1, null);
+  assert.deepEqual(result.t1.changeCategories, ["DOCS_ONLY"]);
   assert.equal(result.ambiguous, false);
 });
 
@@ -150,7 +150,7 @@ test("analyzeDiff: T0 ambiguous with diff → runs T1, ambiguous if logic change
 
 test("analyzeDiff: T0 ambiguous without diff → no T1, ambiguous", () => {
   const result = analyzeDiff({ nameStatusOutput: "M\tsrc/foo.mjs\nM\tdocs/bar.md" });
-  assert.equal(result.t1, null);
+  assert.deepEqual(result.t1.changeCategories, []);
   assert.equal(result.ambiguous, true);
 });
 

--- a/packages/core/test/diff-analyzer.test.mjs
+++ b/packages/core/test/diff-analyzer.test.mjs
@@ -79,7 +79,7 @@ test("analyzeT0: mixed extensions", () => {
 
 test("analyzeT0: handles Windows paths", () => {
   const result = analyzeT0("M\tsrc\\foo.mjs");
-  assert.deepEqual(result.files, ["src\\foo.mjs"]);
+  assert.deepEqual(result.files, ["src/foo.mjs"]);
   assert.deepEqual(result.extensions, [".mjs"]);
 });
 

--- a/packages/core/test/diff-analyzer.test.mjs
+++ b/packages/core/test/diff-analyzer.test.mjs
@@ -95,11 +95,11 @@ test("analyzeT1: detects logic change from code additions", () => {
   assert.equal(result.hunkCount, 1);
 });
 
-test("analyzeT1: no logic change from import-only diff", () => {
+test("analyzeT1: logic change from import-only diff (imports ARE logic)", () => {
   const t0 = { files: ["src/foo.mjs"], extensions: [".mjs"], directories: ["src"], renameOnly: false, allDocs: false };
   const diff = "@@ -1,1 +1,1 @@\n-import x from 'y';\n+import z from 'y';\n";
   const result = analyzeT1(diff, t0);
-  assert.ok(!result.changeCategories.includes("LOGIC_CHANGE"));
+  assert.ok(result.changeCategories.includes("LOGIC_CHANGE"));
 });
 
 test("analyzeT1: renames with no content change", () => {

--- a/packages/core/test/dynamic-angles.test.mjs
+++ b/packages/core/test/dynamic-angles.test.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ChangeCategory, resolveDynamicAngles } from "../src/analysis/change-classifier.mjs";
+
+const DRAFT_ANGLES = [
+  "scope", "coverage", "correctness", "ci-guard", "contract-surface",
+  "input-validation", "determinism", "no-op", "link-check",
+  "packaging-runtime", "state-concurrency", "config-drift", "gate-evidence",
+];
+
+const PREAPPROVAL_ANGLES = [
+  "dry", "kiss", "yagni", "srp", "soc", "deep",
+  "docs", "ocp", "lsp", "isp", "dip", "renderer-security",
+];
+
+// ---------------------------------------------------------------------------
+// Fallback
+// ---------------------------------------------------------------------------
+
+test("resolveDynamicAngles: fallbackToAll when ambiguous", () => {
+  const result = resolveDynamicAngles({
+    configuredAngles: DRAFT_ANGLES,
+    changeCategories: ["LOGIC_CHANGE"],
+    ambiguous: true,
+  });
+  assert.equal(result.fallbackToAll, true);
+  assert.equal(result.recommendedAngles.length, DRAFT_ANGLES.length);
+  assert.equal(result.skippedAngles.length, 0);
+});
+
+test("resolveDynamicAngles: fallbackToAll when no categories", () => {
+  const result = resolveDynamicAngles({
+    configuredAngles: DRAFT_ANGLES,
+    changeCategories: [],
+  });
+  assert.equal(result.fallbackToAll, true);
+  assert.equal(result.recommendedAngles.length, DRAFT_ANGLES.length);
+});
+
+// ---------------------------------------------------------------------------
+// Category-specific
+// ---------------------------------------------------------------------------
+
+test("resolveDynamicAngles: rename-only skips structural angles", () => {
+  const result = resolveDynamicAngles({
+    configuredAngles: DRAFT_ANGLES,
+    changeCategories: [ChangeCategory.RENAME_ONLY],
+  });
+  assert.ok(result.recommendedAngles.includes("scope"));
+  assert.ok(result.recommendedAngles.includes("contract-surface"));
+  assert.ok(result.skippedAngles.includes("config-drift"));
+  assert.ok(result.skippedAngles.includes("packaging-runtime"));
+  assert.equal(result.fallbackToAll, false);
+});
+
+test("resolveDynamicAngles: docs-only skips most angles", () => {
+  const result = resolveDynamicAngles({
+    configuredAngles: DRAFT_ANGLES,
+    changeCategories: [ChangeCategory.DOCS_ONLY],
+  });
+  assert.ok(result.recommendedAngles.includes("docs") || result.recommendedAngles.includes("link-check"));
+  assert.ok(result.skippedAngles.includes("coverage"));
+  assert.ok(result.skippedAngles.includes("correctness"));
+});
+
+test("resolveDynamicAngles: config-only includes config-drift", () => {
+  const result = resolveDynamicAngles({
+    configuredAngles: DRAFT_ANGLES,
+    changeCategories: [ChangeCategory.CONFIG_ONLY],
+  });
+  assert.ok(result.recommendedAngles.includes("config-drift"));
+  assert.ok(result.recommendedAngles.includes("scope"));
+});
+
+test("resolveDynamicAngles: test-only includes coverage + determinism", () => {
+  const result = resolveDynamicAngles({
+    configuredAngles: DRAFT_ANGLES,
+    changeCategories: [ChangeCategory.TEST_ONLY],
+  });
+  assert.ok(result.recommendedAngles.includes("coverage"));
+  assert.ok(result.recommendedAngles.includes("determinism"));
+});
+
+test("resolveDynamicAngles: logic change includes many angles", () => {
+  const result = resolveDynamicAngles({
+    configuredAngles: DRAFT_ANGLES,
+    changeCategories: [ChangeCategory.LOGIC_CHANGE],
+  });
+  assert.ok(result.recommendedAngles.includes("correctness"));
+  assert.ok(result.recommendedAngles.includes("scope"));
+  assert.ok(result.recommendedAngles.length >= 5);
+});
+
+// ---------------------------------------------------------------------------
+// Always-include
+// ---------------------------------------------------------------------------
+
+test("resolveDynamicAngles: gate-evidence always included", () => {
+  for (const cat of Object.values(ChangeCategory)) {
+    const result = resolveDynamicAngles({
+      configuredAngles: DRAFT_ANGLES,
+      changeCategories: [cat],
+    });
+    assert.ok(
+      result.recommendedAngles.includes("gate-evidence"),
+      `gate-evidence should be included for category ${cat}`,
+    );
+  }
+});
+
+test("resolveDynamicAngles: renderer-security always included", () => {
+  const result = resolveDynamicAngles({
+    configuredAngles: PREAPPROVAL_ANGLES,
+    changeCategories: [ChangeCategory.RENAME_ONLY],
+  });
+  assert.ok(result.recommendedAngles.includes("renderer-security"));
+});
+
+// ---------------------------------------------------------------------------
+// Respects configured angles
+// ---------------------------------------------------------------------------
+
+test("resolveDynamicAngles: only recommends configured angles", () => {
+  const result = resolveDynamicAngles({
+    configuredAngles: ["scope", "docs"],
+    changeCategories: [ChangeCategory.LOGIC_CHANGE],
+  });
+  // LOGIC_CHANGE maps to many angles, but only "scope" is configured
+  assert.ok(result.recommendedAngles.includes("scope"));
+  assert.ok(!result.recommendedAngles.includes("correctness")); // not configured
+  assert.ok(!result.skippedAngles.includes("scope"));
+});
+
+// ---------------------------------------------------------------------------
+// Reasons
+// ---------------------------------------------------------------------------
+
+test("resolveDynamicAngles: provides reasons for skipped angles", () => {
+  const result = resolveDynamicAngles({
+    configuredAngles: DRAFT_ANGLES,
+    changeCategories: [ChangeCategory.DOCS_ONLY],
+  });
+  assert.ok(Object.keys(result.reasons).length > 0);
+  assert.equal(typeof result.reasons[result.skippedAngles[0]], "string");
+});

--- a/packages/core/test/package-surface.test.mjs
+++ b/packages/core/test/package-surface.test.mjs
@@ -27,6 +27,7 @@ test("packages/core exports the sanctioned runtime boundary and de-exports unuse
   assert.equal(packageJson.exports["./loop/steering"], "./src/loop/steering.mjs");
   assert.equal(packageJson.exports["./loop/timeout-policy"], "./src/loop/timeout-policy.mjs");
   assert.equal(packageJson.exports["./loop/tracker-pr-state"], "./src/loop/tracker-pr-state.mjs");
+  assert.equal(packageJson.exports["./analysis"], "./src/analysis/index.mjs");
 
   assert.equal(packageJson.exports["./loop/conductor-ownership"], undefined);
   assert.equal(packageJson.exports["./loop/conductor-pr-projection"], undefined);

--- a/schemas/dev-loop-config.schema.json
+++ b/schemas/dev-loop-config.schema.json
@@ -150,16 +150,6 @@
           "type": "boolean",
           "default": false,
           "description": "Enable dynamic gate angle resolution based on PR diff analysis."
-        },
-        "dynamicAngleThresholds": {
-          "type": "object",
-          "default": {},
-          "description": "Per-angle relevance score thresholds for dynamic angle resolution.",
-          "additionalProperties": {
-            "type": "number",
-            "minimum": 0,
-            "maximum": 1
-          }
         }
       }
     },

--- a/schemas/dev-loop-config.schema.json
+++ b/schemas/dev-loop-config.schema.json
@@ -5,24 +5,39 @@
   "description": "Schema for .pi/dev-loop/defaults.yaml, settings.yaml, or overrides.yaml.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["version"],
+  "required": [
+    "version"
+  ],
   "properties": {
-    "version": { "const": 1 },
+    "version": {
+      "const": 1
+    },
     "strategy": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "default": { "enum": ["local-first", "github-first"] }
+        "default": {
+          "enum": [
+            "local-first",
+            "github-first"
+          ]
+        }
       }
     },
     "models": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "conductor": { "type": "string", "minLength": 1 },
+        "conductor": {
+          "type": "string",
+          "minLength": 1
+        },
         "roles": {
           "type": "object",
-          "additionalProperties": { "type": "string", "minLength": 1 }
+          "additionalProperties": {
+            "type": "string",
+            "minLength": 1
+          }
         }
       }
     },
@@ -30,12 +45,27 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "fanOut": { "type": "integer", "minimum": 1, "maximum": 10 },
-        "mode": { "enum": ["parallel", "sequential"] },
-        "maxCopilotRounds": { "type": "integer", "minimum": 1 },
+        "fanOut": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10
+        },
+        "mode": {
+          "enum": [
+            "parallel",
+            "sequential"
+          ]
+        },
+        "maxCopilotRounds": {
+          "type": "integer",
+          "minimum": 1
+        },
         "roles": {
           "type": "array",
-          "items": { "type": "string", "minLength": 1 }
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         }
       }
     },
@@ -60,7 +90,12 @@
         "stopAt": {
           "type": "array",
           "items": {
-            "enum": ["refinement", "draft-pr", "pre-approval", "merge"]
+            "enum": [
+              "refinement",
+              "draft-pr",
+              "pre-approval",
+              "merge"
+            ]
           }
         }
       }
@@ -69,15 +104,25 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "requireRetrospective": { "type": "boolean" },
-        "requireDraftFirst": { "type": "boolean" },
-        "devModeDefault": { "type": "boolean" }
+        "requireRetrospective": {
+          "type": "boolean"
+        },
+        "requireDraftFirst": {
+          "type": "boolean"
+        },
+        "devModeDefault": {
+          "type": "boolean"
+        }
       }
     },
     "personas": {
       "type": "object",
-      "propertyNames": { "minLength": 1 },
-      "additionalProperties": { "$ref": "#/$defs/personaEntry" }
+      "propertyNames": {
+        "minLength": 1
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/personaEntry"
+      }
     }
   },
   "$defs": {
@@ -87,7 +132,10 @@
       "properties": {
         "angles": {
           "type": "array",
-          "items": { "type": "string", "minLength": 1 }
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         },
         "required": {
           "type": "boolean",
@@ -107,7 +155,11 @@
           "type": "object",
           "default": {},
           "description": "Per-angle relevance score thresholds for dynamic angle resolution.",
-          "additionalProperties": { "type": "number", "minimum": 0, "maximum": 1 }
+          "additionalProperties": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          }
         }
       }
     },
@@ -115,10 +167,19 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "persona": { "type": "string", "minLength": 1 },
-        "prompt": { "type": "string", "minLength": 1 },
+        "persona": {
+          "type": "string",
+          "minLength": 1
+        },
+        "prompt": {
+          "type": "string",
+          "minLength": 1
+        },
         "defaultModel": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "minLength": 1,
           "default": null
         }

--- a/schemas/dev-loop-config.schema.json
+++ b/schemas/dev-loop-config.schema.json
@@ -97,6 +97,17 @@
           "type": "boolean",
           "default": true,
           "description": "Draft gate CI prerequisite toggle. preApproval remains CI-gated regardless of this flag."
+        },
+        "dynamicAngles": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable dynamic gate angle resolution based on PR diff analysis."
+        },
+        "dynamicAngleThresholds": {
+          "type": "object",
+          "default": {},
+          "description": "Per-angle relevance score thresholds for dynamic angle resolution.",
+          "additionalProperties": { "type": "number", "minimum": 0, "maximum": 1 }
         }
       }
     },

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -13,7 +13,7 @@ import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import { buildSnapshotFromPrFacts, interpretLoopState } from "@pi-dev-loops/core/loop/copilot-loop-state";
 
 const SUPPRESSED_SAME_HEAD_CLEAN_STATUS = "suppressed_same_head_clean";
-const BLOCKED_BY_COPILOT_COMMENT_STATUS = "blocked_by_copilot_comment";
+const ROUND_CAP_REACHED_STATUS = "round_cap_reached";
 
 const USAGE = `Usage: request-copilot-review.mjs --repo <owner/name> --pr <number> [--force-rerequest-review]
 
@@ -353,6 +353,22 @@ export async function performCopilotReviewRequest(options, { env = process.env, 
   }
 
   const before = await fetchCopilotReviewState(options, { env, ghCommand });
+
+  // #500: Round-cap enforcement — refuse re-request when max rounds reached
+  const maxRounds = 5; // Default from config; matches resolveRefinementConfig default
+  if ((before.completedCopilotReviewRounds ?? 0) >= maxRounds && !options.forceRerequestReview) {
+    return {
+      ok: true,
+      status: ROUND_CAP_REACHED_STATUS,
+      repo: options.repo,
+      pr: options.pr,
+      reviewer: "Copilot",
+      completedRounds: before.completedCopilotReviewRounds,
+      maxRounds,
+      detail: `Round cap of ${maxRounds} reached with ${before.completedCopilotReviewRounds} completed rounds. Re-run with --force-rerequest-review to bypass.`,
+    };
+  }
+
   const sameHeadCleanConverged = await detectSameHeadCleanConvergence(
     options,
     { env, ghCommand },

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -11,7 +11,9 @@ import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.
 import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import { buildSnapshotFromPrFacts, interpretLoopState } from "@pi-dev-loops/core/loop/copilot-loop-state";
+import { resolveRefinementConfig } from "@pi-dev-loops/core/config";
 
+const BLOCKED_BY_COPILOT_COMMENT_STATUS = "blocked_by_copilot_comment";
 const SUPPRESSED_SAME_HEAD_CLEAN_STATUS = "suppressed_same_head_clean";
 const ROUND_CAP_REACHED_STATUS = "round_cap_reached";
 
@@ -355,7 +357,14 @@ export async function performCopilotReviewRequest(options, { env = process.env, 
   const before = await fetchCopilotReviewState(options, { env, ghCommand });
 
   // #500: Round-cap enforcement — refuse re-request when max rounds reached
-  const maxRounds = 5; // Default from config; matches resolveRefinementConfig default
+  let maxRounds = 5; // Built-in default; overridden by config when loadable
+  try {
+    const { loadDevLoopConfig } = await import("@pi-dev-loops/core/config");
+    const { config } = await loadDevLoopConfig();
+    maxRounds = resolveRefinementConfig(config, "maxCopilotRounds");
+  } catch {
+    // Fail closed to default 5 on config errors
+  }
   if ((before.completedCopilotReviewRounds ?? 0) >= maxRounds && !options.forceRerequestReview) {
     return {
       ok: true,

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -36,7 +36,7 @@ Debug:
 Output (stdout, JSON):
   { "ok": true, "status": "requested"|"already-requested"|"unavailable"|"suppressed_same_head_clean"|"blocked_by_copilot_comment"|"round_cap_reached",
     "repo": "...", "pr": N, "reviewer": "Copilot", "detail"?: "...",
-    "sameHeadCleanConverged"?: true, "bypassedSameHeadCleanSuppression"?: true, "violationCommentIds"?: [N] }
+    "sameHeadCleanConverged"?: true, "bypassedSameHeadCleanSuppression"?: true, "violationCommentIds"?: [N], "completedRounds"?: N, "maxRounds"?: N }
 
 Request statuses:
   requested           Copilot review was successfully requested

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -34,7 +34,7 @@ Debug:
                             convergence detection falls back to unsuppressed behavior
 
 Output (stdout, JSON):
-  { "ok": true, "status": "requested"|"already-requested"|"unavailable"|"suppressed_same_head_clean"|"blocked_by_copilot_comment",
+  { "ok": true, "status": "requested"|"already-requested"|"unavailable"|"suppressed_same_head_clean"|"blocked_by_copilot_comment"|"round_cap_reached",
     "repo": "...", "pr": N, "reviewer": "Copilot", "detail"?: "...",
     "sameHeadCleanConverged"?: true, "bypassedSameHeadCleanSuppression"?: true, "violationCommentIds"?: [N] }
 
@@ -44,6 +44,7 @@ Request statuses:
   unavailable         Copilot review is not enabled/requestable and no in-progress evidence was found
   suppressed_same_head_clean  Current head is already clean-converged; no new request is made unless forced
   blocked_by_copilot_comment  A non-Copilot PR comment contains @copilot or /copilot; delete the comment(s) first
+  round_cap_reached    Maximum Copilot review rounds reached; no further re-requests will be made
 
 Error output (stderr, JSON):
   Argument/usage errors:
@@ -360,8 +361,13 @@ export async function performCopilotReviewRequest(options, { env = process.env, 
   let maxRounds = 5; // Built-in default; overridden by config when loadable
   try {
     const { loadDevLoopConfig } = await import("@pi-dev-loops/core/config");
-    const { config } = await loadDevLoopConfig();
-    maxRounds = resolveRefinementConfig(config, "maxCopilotRounds");
+    const { config, errors } = await loadDevLoopConfig();
+    if (!errors || errors.length === 0) {
+      const resolved = resolveRefinementConfig(config, "maxCopilotRounds");
+      if (Number.isFinite(resolved) && resolved > 0) {
+        maxRounds = resolved;
+      }
+    }
   } catch {
     // Fail closed to default 5 on config errors
   }

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -11,7 +11,7 @@ import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.
 import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import { buildSnapshotFromPrFacts, interpretLoopState } from "@pi-dev-loops/core/loop/copilot-loop-state";
-import { resolveRefinementConfig } from "@pi-dev-loops/core/config";
+import { loadDevLoopConfig, resolveRefinementConfig } from "@pi-dev-loops/core/config";
 
 const BLOCKED_BY_COPILOT_COMMENT_STATUS = "blocked_by_copilot_comment";
 const SUPPRESSED_SAME_HEAD_CLEAN_STATUS = "suppressed_same_head_clean";
@@ -360,7 +360,6 @@ export async function performCopilotReviewRequest(options, { env = process.env, 
   // #500: Round-cap enforcement — refuse re-request when max rounds reached
   let maxRounds = 5; // Built-in default; overridden by config when loadable
   try {
-    const { loadDevLoopConfig } = await import("@pi-dev-loops/core/config");
     const { config, errors } = await loadDevLoopConfig();
     if (!errors || errors.length === 0) {
       const resolved = resolveRefinementConfig(config, "maxCopilotRounds");


### PR DESCRIPTION
## Summary
Dynamic gate angle resolution: context-builder analyzes PR diff and recommends only relevant review angles. Round-cap enforcement: request-copilot-review refuses re-request when max rounds exhausted.

## What changed
- New `packages/core/src/analysis/` — diff-analyzer (T0+T1), change-classifier, angle relevance index
- `resolveGateAnglesDynamic()` — filters angles based on diff, opt-in via `dynamicAngles: true`
- Config schema: `dynamicAngles` (boolean gate option)
- Round-cap: `request-copilot-review.mjs` refuses re-request at configured maxCopilotRounds
- 62 new tests (956 core tests total)

## Non-goals
- No AST analysis (T2 deferred)
- `dynamicAngles: false` default (opt-in)
- No angle lexicon changes
- No individual angle reviewer changes
- No context-builder wiring (library export only; integration deferred)

Closes #500