### PR TITLE
docs: prohibit direct main commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ These skills may be provided repo-locally or globally; this contract does not as
 
 ## Working agreement
 
-- **No direct commits to `main`. No exceptions.** All changes — including docs, config, and single-line fixes — go through a feature branch, worktree isolation, and a pull request. This is not a judgment call; it is a hard rule enforced as a required workflow step — pre-commit-branch-guard.mjs blocks commits on unexpected branches.
+- **No direct commits to `main`. No exceptions.** All changes — including docs, config, and single-line fixes — go through a feature branch, worktree isolation, and a pull request. This is not a judgment call; it is a hard rule enforced as a required guard step — `node scripts/loop/pre-commit-branch-guard.mjs` exits non-zero on branch mismatch, blocking the commit.
 - Work test-first for all non-trivial logic.
 - Maintain at least 90% coverage for lines, statements, functions, and branches.
 - Implement one phase at a time.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ These skills may be provided repo-locally or globally; this contract does not as
 
 ## Working agreement
 
-- **No direct commits to `main`. No exceptions.** All changes — including docs, config, and single-line fixes — go through a feature branch, worktree isolation, and a pull request. This is not a judgment call; it is a hard rule enforced by the pre-commit-branch-guard.mjs check and the project contract.
+- **No direct commits to `main`. No exceptions.** All changes — including docs, config, and single-line fixes — go through a feature branch, worktree isolation, and a pull request. This is not a judgment call; it is a hard rule enforced as a required workflow step — pre-commit-branch-guard.mjs blocks commits on unexpected branches.
 - Work test-first for all non-trivial logic.
 - Maintain at least 90% coverage for lines, statements, functions, and branches.
 - Implement one phase at a time.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ These skills may be provided repo-locally or globally; this contract does not as
 
 ## Working agreement
 
-- **No direct commits to `main`. No exceptions.** All changes — including docs, config, and single-line fixes — go through a feature branch, worktree isolation, and a pull request. This is not a judgment call; it is a hard rule enforced as a required guard step — `node scripts/loop/pre-commit-branch-guard.mjs` exits non-zero on branch mismatch, blocking the commit.
+- **No direct commits to `main`. No exceptions.** All changes — including docs, config, and single-line fixes — go through a feature branch, worktree isolation, and a pull request. This is not a judgment call; it is a hard rule enforced as a required guard step — `node scripts/loop/pre-commit-branch-guard.mjs --expected-branch <branch-name>` exits non-zero on branch mismatch, blocking the commit.
 - Work test-first for all non-trivial logic.
 - Maintain at least 90% coverage for lines, statements, functions, and branches.
 - Implement one phase at a time.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ These skills may be provided repo-locally or globally; this contract does not as
 
 ## Working agreement
 
-- **No direct commits to `main`. No exceptions.** All changes — including docs, config, and single-line fixes — go through a feature branch, worktree isolation, and a pull request. This is not a judgment call; it is a hard rule enforced by the pre-flight gate and the project contract.
+- **No direct commits to `main`. No exceptions.** All changes — including docs, config, and single-line fixes — go through a feature branch, worktree isolation, and a pull request. This is not a judgment call; it is a hard rule enforced by the pre-commit-branch-guard.mjs check and the project contract.
 - Work test-first for all non-trivial logic.
 - Maintain at least 90% coverage for lines, statements, functions, and branches.
 - Implement one phase at a time.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ These skills may be provided repo-locally or globally; this contract does not as
 
 ## Working agreement
 
+- **No direct commits to `main`. No exceptions.** All changes — including docs, config, and single-line fixes — go through a feature branch, worktree isolation, and a pull request. This is not a judgment call; it is a hard rule enforced by the pre-flight gate and the project contract.
 - Work test-first for all non-trivial logic.
 - Maintain at least 90% coverage for lines, statements, functions, and branches.
 - Implement one phase at a time.


### PR DESCRIPTION
## Summary
Single documentation fix: prohibit direct commits to main.

## Changes
- **AGENTS.md**: Add explicit working agreement rule — no direct commits to main. All changes go through feature branches, worktree isolation, and PRs. Enforced by `node scripts/loop/pre-commit-branch-guard.mjs --expected-branch <branch-name>`.

## Why
- Session discovered the rule existed implicitly but wasn't documented as a hard constraint
- Prevents accidental direct-to-main pushes during development

Closes #504