### PR TITLE
fix(#514): remove subagent auto-resume assumptions — main session drives loop

### DIFF
--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -195,7 +195,7 @@ Preferred approach for Copilot review follow-up:
 - otherwise continue from the refreshed deterministic state instead of guessing
 - zero-timeout `idle` probes are for explicit one-shot status/reattach checks only; they are not the normal async wait mechanism
 - after a successful fix / reply-resolve / re-request cycle, returning to `waiting_for_copilot_review` is a persistence boundary: resume the watcher instead of reporting completion
-- if a child async run exits and the refreshed state remains non-terminal (for example `waiting_for_copilot_review`) before merge and without a hard stop, treat that as early exit and automatically restart/resume the same-PR follow-up path when feasible
+- if a child async run exits and the refreshed state remains non-terminal (for example `waiting_for_copilot_review`) before merge and without a hard stop, treat that as early exit and the main session re-dispatches the same-PR follow-up path when feasible (the subagent exits on external wait)
 - delegate fix findings to the `fixer` subagent: dev-loop dispatches fixer per review round, receives results, and decides next action; do not run inline fix/reply/resolve passes in-watcher
 - do not report completion while unresolved Copilot feedback remains
 

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -59,7 +59,7 @@ node <resolved-skill-scripts>/loop/run-watch-cycle.mjs --repo <owner/name> --pr 
 ```
 For explicit async loop entry or continuation, this is a persistent async watch/fix loop, not handoff-only behavior:
 - treat the normal PR follow-up path as one loop: `watch → detect → if threads found, fix + reply + resolve → re-request → watch again → … → pre_approval_gate → merge`
-- **PERSISTENCE RULE: Do not exit your session until the PR is merged or you hit a hard stop that requires conductor authorization.**
+- **PERSISTENCE MODEL: Subagents do bounded implementation tasks and exit on external wait. The main session drives the loop and re-dispatches when continuation is feasible.**
 - a single returned watch cycle (`changed`, `timeout`, or `idle`) is never completion by itself
 - if `cycleDisposition` is `pending` and `terminal` is `false`, stay attached to the same PR and resume another watch boundary instead of reporting completion
 - after Step 7 finishes a fix / reply-resolve / re-request cycle and the deterministic state returns to `waiting_for_copilot_review`, resume this watcher again in the same async session

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -61,8 +61,8 @@ For explicit async loop entry or continuation, this is a persistent async watch/
 - treat the normal PR follow-up path as one loop: `watch → detect → if threads found, fix + reply + resolve → re-request → watch again → … → pre_approval_gate → merge`
 - **PERSISTENCE MODEL: Subagents do bounded implementation tasks and exit on external wait. The main session drives the loop and re-dispatches when continuation is feasible.**
 - a single returned watch cycle (`changed`, `timeout`, or `idle`) is never completion by itself
-- if `cycleDisposition` is `pending` and `terminal` is `false`, stay attached to the same PR and resume another watch boundary instead of reporting completion
-- after Step 7 finishes a fix / reply-resolve / re-request cycle and the deterministic state returns to `waiting_for_copilot_review`, resume this watcher again in the same async session
+- if `cycleDisposition` is `pending` and `terminal` is `false`, the subagent exits on the wait boundary; the main session re-dispatches another watch boundary instead of reporting completion
+- after Step 7 finishes a fix / reply-resolve / re-request cycle and the deterministic state returns to `waiting_for_copilot_review`, the main session re-dispatches the watcher for the next cycle
 - default max watch timeout for one Copilot watch boundary is **30 minutes** (`--timeout-ms 1800000`, set on the low-level `probe-copilot-review.mjs` helper); if that watch budget expires and a refreshed authoritative check still resolves `waiting_for_copilot_review`, stop with `watch timeout — PR #<number> needs manual attention.`
 - if the user explicitly asks for async handoff-only behavior, say that out loud and stop after the handoff boundary; otherwise do not silently reinterpret async loop entry as handoff-only
 

--- a/skills/docs/public-dev-loop-contract.md
+++ b/skills/docs/public-dev-loop-contract.md
@@ -380,7 +380,7 @@ When refreshed authoritative bootstrap state instead resolves `prior_linked_pr_c
 
 When that refreshed seam state advances to `linked_pr_ready_for_followup`, durable-auto continuation must re-enter the same linked PR follow-up path. If the follow-up handoff carries `conductorRouting.handoffEnvelope.requiresLocalIsolation=true`, orchestration should continue through an isolated checkout/worktree transition instead of treating that boundary as final completion.
 
-Main conductor orchestration must treat non-terminal follow-up/wait states (for example `waiting_for_copilot_review`) as continuation boundaries rather than clean completion. If an async child exits before the requested stop boundary and continuation is feasible, automatically resume/restart the same PR flow; otherwise surface the concrete blocker.
+Main conductor orchestration must treat non-terminal follow-up/wait states (for example `waiting_for_copilot_review`) as continuation boundaries rather than clean completion. If an async child exits before the requested stop boundary and continuation is feasible, re-dispatch via the main session driver (the subagent exits on external wait; the main session re-dispatches); otherwise surface the concrete blocker.
 
 ## Internal / external model
 

--- a/skills/docs/stop-conditions.md
+++ b/skills/docs/stop-conditions.md
@@ -17,7 +17,7 @@ Canonical owner for agent stop / wait / block conditions across all workflow fam
 
 | Condition | Strategy | Behavior |
 |---|---|---|
-| `waiting` lifecycle state | `wait_watch` | Healthy wait, auto-resume |
+| `waiting` lifecycle state | `wait_watch` | Healthy wait; re-dispatch from main session |
 | `waiting_for_initial_copilot_implementation` | `issue_intake` | Bootstrap wait with 1h watch budget |
 | `waiting_for_copilot_review` | `copilot_pr_followup` | Continuation boundary, not completion |
 | Quiet watcher observations | `wait_watch` | Observational only, do not surface |

--- a/skills/docs/workflow-handoff-template.md
+++ b/skills/docs/workflow-handoff-template.md
@@ -84,7 +84,7 @@ For each Copilot review pass:
 ## Non-negotiable invariants
 
 - **PERSISTENCE MODEL: Subagents do bounded implementation tasks and exit on external wait. The main session drives the loop and re-dispatches when continuation is feasible.**
-- A single watch cycle return is not completion; stay in the same loop until merge or a hard stop
+- A single watch cycle return is not completion; the main session re-dispatches until merge or a hard stop
 - The Copilot review loop (steps 4–6) sits **between** `draft_gate` and `pre_approval_gate` — never reorder
 - `unresolvedThreadCount === 0` verification is required before step 7
 - Gate comments must be visible on the PR — no hidden/local-only evidence

--- a/skills/docs/workflow-handoff-template.md
+++ b/skills/docs/workflow-handoff-template.md
@@ -83,7 +83,7 @@ For each Copilot review pass:
 
 ## Non-negotiable invariants
 
-- **PERSISTENCE RULE: Do not exit your session until the PR is merged or you hit a hard stop that requires conductor authorization.**
+- **PERSISTENCE MODEL: Subagents do bounded implementation tasks and exit on external wait. The main session drives the loop and re-dispatches when continuation is feasible.**
 - A single watch cycle return is not completion; stay in the same loop until merge or a hard stop
 - The Copilot review loop (steps 4–6) sits **between** `draft_gate` and `pre_approval_gate` — never reorder
 - `unresolvedThreadCount === 0` verification is required before step 7

--- a/test/contracts/copilot-review-doc-contracts.test.mjs
+++ b/test/contracts/copilot-review-doc-contracts.test.mjs
@@ -99,7 +99,7 @@ test("copilot-pr-followup skill keeps async watch persistence explicit", async (
   assert.match(skillContent, /zero-timeout `idle` probes are for explicit one-shot status\/reattach checks only/i);
   assert.match(skillContent, /returning to `waiting_for_copilot_review` is a persistence boundary: resume the watcher instead of reporting completion/i);
   assert.match(skillContent, /persistent async watch\/fix loop, not handoff-only behavior/i);
-  assert.match(skillContent, /if `cycleDisposition` is `pending` and `terminal` is `false`, stay attached to the same PR and resume another watch boundary/i);
+  assert.match(skillContent, /if `cycleDisposition` is `pending` and `terminal` is `false`, the subagent exits on the wait boundary; the main session re-dispatches another watch boundary/i);
   assert.match(skillContent, /if the user explicitly asks for async handoff-only behavior/i);
   assert.match(skillContent, /child async run exits[\s\S]*waiting_for_copilot_review[\s\S]*automatically restart\/resume the same-PR follow-up path when feasible/i);
   assert.match(scriptsReadme, /`cycleDisposition: "pending"` with `terminal: false` means stay attached and run another watch boundary rather than exiting as clean success/i);

--- a/test/contracts/copilot-review-doc-contracts.test.mjs
+++ b/test/contracts/copilot-review-doc-contracts.test.mjs
@@ -101,7 +101,7 @@ test("copilot-pr-followup skill keeps async watch persistence explicit", async (
   assert.match(skillContent, /persistent async watch\/fix loop, not handoff-only behavior/i);
   assert.match(skillContent, /if `cycleDisposition` is `pending` and `terminal` is `false`, the subagent exits on the wait boundary; the main session re-dispatches another watch boundary/i);
   assert.match(skillContent, /if the user explicitly asks for async handoff-only behavior/i);
-  assert.match(skillContent, /child async run exits[\s\S]*waiting_for_copilot_review[\s\S]*automatically restart\/resume the same-PR follow-up path when feasible/i);
+  assert.match(skillContent, /child async run exits[\s\S]*waiting_for_copilot_review[\s\S]*main session re-dispatches the same-PR follow-up path when feasible/i);
   assert.match(scriptsReadme, /`cycleDisposition: "pending"` with `terminal: false` means stay attached and run another watch boundary rather than exiting as clean success/i);
   assert.match(scriptsReadme, /handoff-only behavior must be explicitly requested/i);
   assert.match(stateGraph, /`waiting_for_copilot_review` is a persistence boundary for explicit async loop entry/i);

--- a/test/contracts/issue-intake-doc-contracts.test.mjs
+++ b/test/contracts/issue-intake-doc-contracts.test.mjs
@@ -141,7 +141,7 @@ test("issue-based shorthand auto dev-loop trigger is documented as one public in
   assert.match(publicContract, /inspect\/status intents may still summarize that state and exit normally/i);
   assert.match(publicContract, /linked_pr_ready_for_followup[\s\S]*isolated checkout\/worktree transition instead of treating that boundary as final completion/i);
   assert.match(publicContract, /non-terminal follow-up\/wait states[\s\S]*waiting_for_copilot_review[\s\S]*continuation boundaries/i);
-  assert.match(publicContract, /async child exits before the requested stop boundary[\s\S]*automatically resume\/restart/i);
+  assert.match(publicContract, /async child exits before the requested stop boundary[\s\S]*re-dispatch via the main session driver/i);
   assert.match(publicContract, /R --> A\[Human approval checkpoint\]/i);
   assert.match(publicContract, /R --> M\[Wait for merge authorization\]/i);
 
@@ -166,7 +166,7 @@ test("issue-intake surface requires persistent copilot follow-up loop and capped
 
   assert.match(
     content,
-    /PERSISTENCE RULE: Do not exit your session until the PR is merged or you hit a hard stop that requires conductor authorization\./i,
+    /PERSISTENCE MODEL: Subagents do bounded implementation tasks and exit on external wait. The main session drives the loop and re-dispatches when continuation is feasible./i,
   );
   assert.match(
     content,

--- a/test/workflow-handoff-template-contract.test.mjs
+++ b/test/workflow-handoff-template-contract.test.mjs
@@ -153,7 +153,7 @@ test("workflow-handoff-template includes the persistence rule and timeout escala
 
   assert.match(
     content,
-    /PERSISTENCE RULE: Do not exit your session until the PR is merged or you hit a hard stop that requires conductor authorization\./i,
+    /PERSISTENCE MODEL: Subagents do bounded implementation tasks and exit on external wait. The main session drives the loop and re-dispatches when continuation is feasible./i,
   );
   assert.match(
     content,


### PR DESCRIPTION
## Change summary

Replace subagent-based conductor auto-resume assumptions with main-session-driven re-dispatch pattern across 4 canonical docs.

## Scope/context

Issue #514 identified that conductor tooling was built assuming persistent subagents could drive dev-loop orchestration end-to-end. This is wrong — subagents have depth limits and cannot block on persistent watch. The real pattern: **main session = loop driver, subagents = bounded tasks that exit on external wait**.

## Changes (4 files + test updates)

| File | Change |
|---|---|
| `skills/docs/public-dev-loop-contract.md` L383 | `automatically resume/restart the same PR flow` → main-session re-dispatch pattern |
| `skills/docs/stop-conditions.md` L20 | `auto-resume` → `re-dispatch from main session` |
| `skills/copilot-pr-followup/SKILL.md` L62 | `PERSISTENCE RULE` → `PERSISTENCE MODEL` with bounded-task + main-session pattern |
| `skills/docs/workflow-handoff-template.md` L86 | Same `PERSISTENCE RULE` → `PERSISTENCE MODEL` replacement |
| `test/contracts/issue-intake-doc-contracts.test.mjs` | Updated 2 contract assertions to match new doc text |
| `test/workflow-handoff-template-contract.test.mjs` | Updated persistence rule assertion to match new pattern |

## Acceptance criteria

- [x] public-dev-loop-contract.md no longer says auto-resume; main-session re-dispatch
- [x] stop-conditions.md no longer says auto-resume; re-dispatch language
- [x] copilot-pr-followup/SKILL.md PERSISTENCE RULE replaced
- [x] workflow-handoff-template.md PERSISTENCE RULE replaced
- [x] `npm run verify` passes
- [x] Only 4 doc files + necessary test alignment

## Definition of done

- All 4 doc files updated
- Contract tests aligned
- `npm run verify` green
- Copilot review passed, threads resolved
- Pre-approval gate passed

## Non-goals

- Not removing conductor tools
- Not adding new tooling
- Not touching files beyond the 4 doc + test alignment

Closes #514