### PR TITLE
Bug: async dev-loop conductor handoffs are underspecified

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -338,6 +338,33 @@ Contract:
 Success output shape:
 - `{ "ok": true, "repo": "owner/name", "issue": 59, "state": "...", "prNumber": 79|null, "prUrl": "..."|null, "headBranch": "..."|null, "authorLogin": "Copilot"|null, "isDraft": true|false|null, "changedFiles": 0|null, "commitCount": 1|null, "soleCommitHeadline": "Initial plan"|null, "sessionActivity": "active"|"concluded"|"idle"|null, "sessionRunId": 123|null, "sessionRunName": "..."|null, "sessionRunStatus": "..."|null, "sessionRunConclusion": string|null, "sessionRunCreatedAt": "..."|null, "sessionConfidence": "high"|null }`
 
+### `scripts/loop/run-conductor-cycle.mjs`
+
+Poll all open PRs, detect gate state, and emit an ordered action queue.
+
+Output `actions[]` entries include:
+- `requiresSubagent`
+- `requiresApproval`
+- `handoffContract` with:
+  - `ownership`
+  - `stopBoundary`
+  - `resumePolicy`
+
+The handoff contract is recorded on each action so parent, child, and resume
+actions can share one explicit stop/resume boundary.
+
+Contract values:
+- `ownership`: `subagent`, `parent`, `human`, or `terminal`
+- `stopBoundary`: `subagent_exit`, `watch_boundary`, `approval_boundary`,
+  `merge_boundary`, `conflict_boundary`, or `terminal_boundary`
+- `resumePolicy`: `resume_after_subagent_exit`,
+  `resume_after_state_refresh`, `resume_after_human_approval`,
+  `resume_after_merge_authorization`, `manual_attention`, or `none`
+
+`run-conductor-cycle.mjs` emits the contract-boundary values above. The parser
+also accepts `PR_CHECKPOINT` values when reading recorded artifacts so older
+recorded handoff notes can still be validated fail-closed.
+
 ### `scripts/loop/conductor-monitor.mjs`
 
 Aggregate the current Copilot-loop status for every open PR in one repository.
@@ -385,9 +412,16 @@ Success output shape:
 - `parsedLoopState`
 - `livePrState`
 - `resumeAction`
+- `handoffContract`
+- `recordedHandoffContract` when the artifact explicitly records one
 - `resumeMessage`
 - `resumeCommandPreview`
 - `staleWorktree`
+
+If a recorded handoff contract is present, it must include explicit
+`Handoff ownership`, `Stop boundary`, and `Resume policy` lines. The monitor
+fails closed when those fields are partial, invalid, or conflict with the
+live-derived resume plan.
 
 `needsManualAttention[]` fields:
 - `pr` when known

--- a/scripts/loop/_handoff-contract.mjs
+++ b/scripts/loop/_handoff-contract.mjs
@@ -1,0 +1,254 @@
+import { PR_CHECKPOINT } from "@pi-dev-loops/core/loop/pr-gate-coordination";
+const HANDOFF_OWNERSHIP = Object.freeze({
+  SUBAGENT: "subagent",
+  PARENT: "parent",
+  HUMAN: "human",
+  TERMINAL: "terminal",
+});
+
+const HANDOFF_STOP_BOUNDARY = Object.freeze({
+  SUBAGENT_EXIT: "subagent_exit",
+  WATCH_BOUNDARY: "watch_boundary",
+  APPROVAL_BOUNDARY: "approval_boundary",
+  MERGE_BOUNDARY: "merge_boundary",
+  CONFLICT_BOUNDARY: "conflict_boundary",
+  TERMINAL: "terminal_boundary",
+});
+
+const HANDOFF_RESUME_POLICY = Object.freeze({
+  RESUME_AFTER_SUBAGENT_EXIT: "resume_after_subagent_exit",
+  RESUME_AFTER_STATE_REFRESH: "resume_after_state_refresh",
+  RESUME_AFTER_HUMAN_APPROVAL: "resume_after_human_approval",
+  RESUME_AFTER_MERGE_AUTHORIZATION: "resume_after_merge_authorization",
+  MANUAL_ATTENTION: "manual_attention",
+  NONE: "none",
+});
+
+const GATE_BOUNDARY_STOP_VALUES = new Set(Object.values(PR_CHECKPOINT));
+
+const SUBAGENT_ACTIONS = new Set([
+  "fix_threads",
+  "draft_gate",
+  "request_review",
+  "rerequest_review",
+  "run_pre_approval",
+]);
+
+function normalizeContractValue(value) {
+  return typeof value === "string" ? value.trim().toLowerCase() : null;
+}
+
+function buildContract({ ownership, stopBoundary, resumePolicy }) {
+  return {
+    ownership,
+    stopBoundary,
+    resumePolicy,
+  };
+}
+
+export function buildHandoffContractForConductorAction({ action, gateBoundary, requiresApproval = false } = {}) {
+  const normalizedAction = normalizeContractValue(action);
+
+  if (SUBAGENT_ACTIONS.has(normalizedAction)) {
+    if (requiresApproval) {
+      return buildContract({
+        ownership: HANDOFF_OWNERSHIP.HUMAN,
+        stopBoundary: HANDOFF_STOP_BOUNDARY.APPROVAL_BOUNDARY,
+        resumePolicy: HANDOFF_RESUME_POLICY.RESUME_AFTER_HUMAN_APPROVAL,
+      });
+    }
+    return buildContract({
+      ownership: HANDOFF_OWNERSHIP.SUBAGENT,
+      stopBoundary: HANDOFF_STOP_BOUNDARY.SUBAGENT_EXIT,
+      resumePolicy: HANDOFF_RESUME_POLICY.RESUME_AFTER_SUBAGENT_EXIT,
+    });
+  }
+
+  switch (normalizedAction) {
+    case "watch":
+      return buildContract({
+        ownership: HANDOFF_OWNERSHIP.PARENT,
+        stopBoundary: HANDOFF_STOP_BOUNDARY.WATCH_BOUNDARY,
+        resumePolicy: HANDOFF_RESUME_POLICY.RESUME_AFTER_STATE_REFRESH,
+      });
+    case "merge":
+      return buildContract({
+        ownership: requiresApproval ? HANDOFF_OWNERSHIP.HUMAN : HANDOFF_OWNERSHIP.PARENT,
+        stopBoundary: HANDOFF_STOP_BOUNDARY.MERGE_BOUNDARY,
+        resumePolicy: requiresApproval
+          ? HANDOFF_RESUME_POLICY.RESUME_AFTER_MERGE_AUTHORIZATION
+          : HANDOFF_RESUME_POLICY.NONE,
+      });
+    case "await_approval":
+      return buildContract({
+        ownership: HANDOFF_OWNERSHIP.HUMAN,
+        stopBoundary: HANDOFF_STOP_BOUNDARY.APPROVAL_BOUNDARY,
+        resumePolicy: HANDOFF_RESUME_POLICY.RESUME_AFTER_HUMAN_APPROVAL,
+      });
+    case "resolve_conflicts":
+    case "blocked":
+    case "error":
+      return buildContract({
+        ownership: HANDOFF_OWNERSHIP.HUMAN,
+        stopBoundary: HANDOFF_STOP_BOUNDARY.CONFLICT_BOUNDARY,
+        resumePolicy: HANDOFF_RESUME_POLICY.MANUAL_ATTENTION,
+      });
+    case "done":
+      return buildContract({
+        ownership: HANDOFF_OWNERSHIP.TERMINAL,
+        stopBoundary: HANDOFF_STOP_BOUNDARY.TERMINAL,
+        resumePolicy: HANDOFF_RESUME_POLICY.NONE,
+      });
+    default:
+      return buildContract({
+        ownership: HANDOFF_OWNERSHIP.HUMAN,
+        stopBoundary: HANDOFF_STOP_BOUNDARY.CONFLICT_BOUNDARY,
+        resumePolicy: HANDOFF_RESUME_POLICY.MANUAL_ATTENTION,
+      });
+  }
+}
+
+export function buildHandoffContractForResumeAction(resumeAction) {
+  const normalizedAction = normalizeContractValue(resumeAction);
+
+  switch (normalizedAction) {
+    case "needs_feedback_fix":
+      return buildContract({
+        ownership: HANDOFF_OWNERSHIP.SUBAGENT,
+        stopBoundary: HANDOFF_STOP_BOUNDARY.SUBAGENT_EXIT,
+        resumePolicy: HANDOFF_RESUME_POLICY.RESUME_AFTER_SUBAGENT_EXIT,
+      });
+    case "needs_reply_resolve":
+      return buildContract({
+        ownership: HANDOFF_OWNERSHIP.SUBAGENT,
+        stopBoundary: HANDOFF_STOP_BOUNDARY.SUBAGENT_EXIT,
+        resumePolicy: HANDOFF_RESUME_POLICY.RESUME_AFTER_SUBAGENT_EXIT,
+      });
+    case "needs_rerequest_or_watch":
+      return buildContract({
+        ownership: HANDOFF_OWNERSHIP.PARENT,
+        stopBoundary: HANDOFF_STOP_BOUNDARY.WATCH_BOUNDARY,
+        resumePolicy: HANDOFF_RESUME_POLICY.RESUME_AFTER_STATE_REFRESH,
+      });
+    case "await_final_approval":
+      return buildContract({
+        ownership: HANDOFF_OWNERSHIP.HUMAN,
+        stopBoundary: HANDOFF_STOP_BOUNDARY.APPROVAL_BOUNDARY,
+        resumePolicy: HANDOFF_RESUME_POLICY.RESUME_AFTER_HUMAN_APPROVAL,
+      });
+    case "await_merge_authorization":
+      return buildContract({
+        ownership: HANDOFF_OWNERSHIP.HUMAN,
+        stopBoundary: HANDOFF_STOP_BOUNDARY.MERGE_BOUNDARY,
+        resumePolicy: HANDOFF_RESUME_POLICY.RESUME_AFTER_MERGE_AUTHORIZATION,
+      });
+    case "await_ready_for_review_authorization":
+      return buildContract({
+        ownership: HANDOFF_OWNERSHIP.HUMAN,
+        stopBoundary: HANDOFF_STOP_BOUNDARY.APPROVAL_BOUNDARY,
+        resumePolicy: HANDOFF_RESUME_POLICY.RESUME_AFTER_HUMAN_APPROVAL,
+      });
+    case "done_or_merged":
+      return buildContract({
+        ownership: HANDOFF_OWNERSHIP.TERMINAL,
+        stopBoundary: HANDOFF_STOP_BOUNDARY.TERMINAL,
+        resumePolicy: HANDOFF_RESUME_POLICY.NONE,
+      });
+    case "needs_manual_attention":
+    default:
+      return buildContract({
+        ownership: HANDOFF_OWNERSHIP.HUMAN,
+        stopBoundary: HANDOFF_STOP_BOUNDARY.CONFLICT_BOUNDARY,
+        resumePolicy: HANDOFF_RESUME_POLICY.MANUAL_ATTENTION,
+      });
+  }
+}
+
+function parseContractLine(text, label) {
+  const pattern = new RegExp(String.raw`(?:^|\n)\s*[-*]?\s*${label}:\s*(.+)$`, "imu");
+  const match = text.match(pattern);
+  return match?.[1]?.trim() ?? null;
+}
+
+export function parseRecordedHandoffContract(text) {
+  if (typeof text !== "string" || text.length === 0) {
+    return { contract: null, reason: null };
+  }
+
+  const ownership = normalizeContractValue(parseContractLine(text, "Handoff ownership"));
+  const stopBoundary = normalizeContractValue(parseContractLine(text, "Stop boundary"));
+  const resumePolicy = normalizeContractValue(parseContractLine(text, "Resume policy"));
+
+  const foundCount = [ownership, stopBoundary, resumePolicy].filter((value) => value !== null).length;
+  if (foundCount === 0) {
+    return { contract: null, reason: null };
+  }
+
+  if (foundCount !== 3) {
+    return {
+      contract: null,
+      reason: "incomplete_handoff_contract",
+      details: {
+        ownership,
+        stopBoundary,
+        resumePolicy,
+      },
+    };
+  }
+
+  const validOwnership = Object.values(HANDOFF_OWNERSHIP).includes(ownership);
+  const validStopBoundary = Object.values(HANDOFF_STOP_BOUNDARY).includes(stopBoundary)
+    || GATE_BOUNDARY_STOP_VALUES.has(stopBoundary);
+  const validResumePolicy = Object.values(HANDOFF_RESUME_POLICY).includes(resumePolicy);
+
+  if (!validOwnership || !validStopBoundary || !validResumePolicy) {
+    return {
+      contract: null,
+      reason: "invalid_handoff_contract",
+      details: {
+        ownership,
+        stopBoundary,
+        resumePolicy,
+      },
+    };
+  }
+
+  return {
+    contract: buildContract({
+      ownership,
+      stopBoundary,
+      resumePolicy,
+    }),
+    reason: null,
+  };
+}
+
+export function compareHandoffContracts(recorded, expected) {
+  if (!recorded || !expected) {
+    return null;
+  }
+
+  const mismatches = [];
+  for (const key of ["ownership", "stopBoundary", "resumePolicy"]) {
+    if (recorded[key] !== expected[key]) {
+      mismatches.push(key);
+    }
+  }
+
+  if (mismatches.length === 0) {
+    return null;
+  }
+
+  return {
+    mismatches,
+    recorded,
+    expected,
+  };
+}
+
+export {
+  HANDOFF_OWNERSHIP,
+  HANDOFF_STOP_BOUNDARY,
+  HANDOFF_RESUME_POLICY,
+  SUBAGENT_ACTIONS
+};

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -8,6 +8,11 @@ import { runChild, requireOptionValue } from "../_cli-primitives.mjs";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import { autoDetectSnapshot } from "./detect-copilot-loop-state.mjs";
+import {
+  buildHandoffContractForResumeAction,
+  compareHandoffContracts,
+  parseRecordedHandoffContract,
+} from "./_handoff-contract.mjs";
 import { interpretLoopState, summarizeLoopInterpretation } from "@pi-dev-loops/core/loop/copilot-loop-state";
 
 const USAGE = `Usage: conductor-monitor.mjs --repo <owner/name> [--auto-resume]
@@ -114,6 +119,9 @@ const MANUAL_REASON = {
   UNCLASSIFIED_ARTIFACT_STATE: "unclassified_artifact_state",
   MULTIPLE_CANDIDATE_RUNS: "multiple_candidate_runs",
   STALE_WORKTREE_MISSING_RESUME_INPUTS: "stale_worktree_missing_resume_inputs",
+  HANDOFF_CONTRACT_INCOMPLETE: "handoff_contract_incomplete",
+  HANDOFF_CONTRACT_INVALID: "handoff_contract_invalid",
+  HANDOFF_CONTRACT_MISMATCH: "handoff_contract_mismatch",
 };
 
 function parseCliArgs(argv) {
@@ -1420,6 +1428,27 @@ export async function parseDevLoopArtifact(record) {
     const parsedArtifactState = parseArtifactState(candidate.text);
     const parsedLoopState = parseLoopState(candidate.text);
     const nextAction = parseNextActionText(candidate.text);
+    const recordedHandoffContractResult = parseRecordedHandoffContract(candidate.text);
+    if (recordedHandoffContractResult.reason !== null) {
+      return {
+        ok: false,
+        reason: recordedHandoffContractResult.reason === "incomplete_handoff_contract"
+          ? MANUAL_REASON.HANDOFF_CONTRACT_INCOMPLETE
+          : MANUAL_REASON.HANDOFF_CONTRACT_INVALID,
+        pr: prNumbers[0],
+        evidence: {
+          source: candidate.source,
+          details: recordedHandoffContractResult.details ?? null,
+          parsedArtifactState,
+          parsedLoopState,
+          nextAction,
+          outputArtifactPath: record.outputArtifactPath,
+          resultSummaryPath: record.resultSummaryPath,
+        },
+        source: candidate.source,
+        weakFallbackText: selection.weakFallbackText,
+      };
+    }
     if (parsedArtifactState === null) {
       lastFailure = {
         ok: false,
@@ -1469,6 +1498,7 @@ export async function parseDevLoopArtifact(record) {
       parsedArtifactState,
       parsedLoopState,
       nextAction,
+      recordedHandoffContract: recordedHandoffContractResult.contract,
       resumeBucket,
       source: candidate.source,
       text: candidate.text,
@@ -1736,6 +1766,31 @@ export function buildResumePlan({ prReport, candidate, childCounts }) {
   }
 
   const livePrState = classifyLiveStateForResume(resumeAction, prReport);
+  const expectedHandoffContract = buildHandoffContractForResumeAction(resumeAction);
+  const recordedHandoffContract = parsedArtifact.recordedHandoffContract ?? null;
+  const handoffContractMismatch = compareHandoffContracts(recordedHandoffContract, expectedHandoffContract);
+  if (handoffContractMismatch !== null) {
+    return {
+      kind: "manual_attention",
+      entry: buildManualAttentionEntry({
+        pr: prReport.number,
+        runId: run.runId,
+        reason: MANUAL_REASON.HANDOFF_CONTRACT_MISMATCH,
+        evidence: {
+          parsedArtifactState: parsedArtifact.parsedArtifactState,
+          parsedLoopState: parsedArtifact.parsedLoopState,
+          resumeAction,
+          livePrState,
+          recordedHandoffContract,
+          expectedHandoffContract,
+          outputArtifactPath: run.outputArtifactPath,
+          sessionPath: run.sessionPath,
+        },
+        suggestedNextStep: "Reconcile the recorded handoff contract against the live PR state before resuming.",
+      }),
+    };
+  }
+
   const resumeMessage = buildResumeMessage({
     pr: prReport.number,
     runId: run.runId,
@@ -1757,6 +1812,8 @@ export function buildResumePlan({ prReport, candidate, childCounts }) {
       parsedLoopState: parsedArtifact.parsedLoopState,
       livePrState,
       resumeAction,
+      handoffContract: expectedHandoffContract,
+      ...(recordedHandoffContract ? { recordedHandoffContract } : {}),
       resumeMessage,
       resumeCommandPreview: buildResumeCommandPreview({
         runId: run.runId,

--- a/scripts/loop/run-conductor-cycle.mjs
+++ b/scripts/loop/run-conductor-cycle.mjs
@@ -26,7 +26,12 @@
  *         "priority": N, "state": "...", "lifecycleState": "...",
  *         "loopDisposition": "...", "gateBoundary": "...", "reason": "...",
  *         "snapshot": {...}, "gateState": {...}, "requiresSubagent": bool,
- *         "requiresApproval": bool
+ *         "requiresApproval": bool,
+ *         "handoffContract": {
+ *           "ownership": "subagent"|"parent"|"human"|"terminal",
+ *           "stopBoundary": "...",
+ *           "resumePolicy": "..."
+ *         }
  *       }
  *     ],
  *     "summary": { "needsSubagent": N, "readyToMerge": N, "waiting": N,
@@ -45,6 +50,10 @@ import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import { detectPrGateCoordinationState } from "./detect-pr-gate-coordination-state.mjs";
 import { autoDetectSnapshot } from "./detect-copilot-loop-state.mjs";
 import { PR_CHECKPOINT_ACTION } from "@pi-dev-loops/core/loop/pr-gate-coordination";
+import {
+  SUBAGENT_ACTIONS as SHARED_SUBAGENT_ACTIONS,
+  buildHandoffContractForConductorAction,
+} from "./_handoff-contract.mjs";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -100,16 +109,7 @@ export const ACTION_PRIORITY = Object.freeze({
   error: -1,
 });
 
-/**
- * Actions that require spawning a dev-loop subagent by the Pi parent.
- */
-export const SUBAGENT_ACTIONS = new Set([
-  "fix_threads",
-  "draft_gate",
-  "request_review",
-  "rerequest_review",
-  "run_pre_approval",
-]);
+export const SUBAGENT_ACTIONS = SHARED_SUBAGENT_ACTIONS;
 
 /**
  * Map autonomy.stopAt gates to the conductor actions that require approval.
@@ -277,6 +277,11 @@ export async function detectPrState(
     const action = CHECKPOINT_ACTION_TO_CONDUCTOR_ACTION[gateState.nextAction] ?? "error";
     const priority = ACTION_PRIORITY[action] ?? -1;
     const requiresApproval = actionRequiresApproval(action, autonomyStopAt);
+    const handoffContract = buildHandoffContractForConductorAction({
+      action,
+      gateBoundary: gateState.gateBoundary,
+      requiresApproval,
+    });
 
     return {
       pr: pr.number,
@@ -304,6 +309,7 @@ export async function detectPrState(
       },
       requiresSubagent: SUBAGENT_ACTIONS.has(action),
       requiresApproval,
+      handoffContract,
     };
   } catch (error) {
     return {
@@ -323,6 +329,7 @@ export async function detectPrState(
       gateState: null,
       requiresSubagent: false,
       requiresApproval: false,
+      handoffContract: buildHandoffContractForConductorAction({ action: "error" }),
       error: error instanceof Error ? error.message : String(error),
     };
   }

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -953,6 +953,9 @@ test("conductor-monitor --auto-resume emits a feedback-fix resume plan for an or
         "Artifact state: open",
         "Loop state: unresolved_feedback_present",
         "Next action: address review feedback",
+        "Handoff ownership: subagent",
+        "Stop boundary: subagent_exit",
+        "Resume policy: resume_after_subagent_exit",
       ].join("\n"),
     });
 
@@ -981,6 +984,16 @@ test("conductor-monitor --auto-resume emits a feedback-fix resume plan for an or
     assert.equal(plan.parsedLoopState, "unresolved_feedback_present");
     assert.equal(plan.livePrState, "unresolved_feedback_present");
     assert.equal(plan.resumeAction, "needs_feedback_fix");
+    assert.deepEqual(plan.handoffContract, {
+      ownership: "subagent",
+      stopBoundary: "subagent_exit",
+      resumePolicy: "resume_after_subagent_exit",
+    });
+    assert.deepEqual(plan.recordedHandoffContract, {
+      ownership: "subagent",
+      stopBoundary: "subagent_exit",
+      resumePolicy: "resume_after_subagent_exit",
+    });
     assert.equal(
       plan.resumeMessage,
       "PR #17 is orphaned. Live state: unresolved_feedback_present. Resume the prior dev-loop from run run-fix-17. Continue by fixing the remaining review feedback, then reply to and resolve each GitHub thread. Do not merge.",
@@ -990,6 +1003,53 @@ test("conductor-monitor --auto-resume emits a feedback-fix resume plan for an or
       'subagent({ action: "resume", id: "run-fix-17", message: "PR #17 is orphaned. Live state: unresolved_feedback_present. Resume the prior dev-loop from run run-fix-17. Continue by fixing the remaining review feedback, then reply to and resolve each GitHub thread. Do not merge." })',
     );
     assert.equal(plan.staleWorktree, false);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume fails closed when recorded handoff contract conflicts with resume action", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-handoff-mismatch-"));
+  const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    await writeSessionRun({
+      sessionsRoot,
+      runId: "run-mismatch-17",
+      cwd: repoRoot,
+      timestampMs: 1700000001500,
+      outputText: [
+        "Active PR: owner/repo#17",
+        "Artifact state: open",
+        "Loop state: unresolved_feedback_present",
+        "Next action: address review feedback",
+        "Handoff ownership: human",
+        "Stop boundary: approval_boundary",
+        "Resume policy: resume_after_human_approval",
+      ].join("\n"),
+    });
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{
+        number: 17,
+        reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
+        statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+        threadsPayload: mixedThreadsFixture,
+      }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+
+    assert.equal(payload.resumePlanCount, 0);
+    assert.equal(payload.manualAttentionCount, 1);
+    assert.equal(payload.needsManualAttention[0].reason, "handoff_contract_mismatch");
+    assert.equal(payload.needsManualAttention[0].evidence.resumeAction, "needs_feedback_fix");
+    assert.deepEqual(payload.needsManualAttention[0].evidence.recordedHandoffContract, {
+      ownership: "human",
+      stopBoundary: "approval_boundary",
+      resumePolicy: "resume_after_human_approval",
+    });
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/handoff-contract.test.mjs
+++ b/test/loop/handoff-contract.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  HANDOFF_OWNERSHIP,
+  HANDOFF_RESUME_POLICY,
+  HANDOFF_STOP_BOUNDARY,
+  buildHandoffContractForConductorAction,
+  buildHandoffContractForResumeAction,
+  compareHandoffContracts,
+  parseRecordedHandoffContract,
+} from "../../scripts/loop/_handoff-contract.mjs";
+
+test("buildHandoffContractForConductorAction records ownership, stop boundary, and resume policy", () => {
+  const subagentContract = buildHandoffContractForConductorAction({
+    action: "fix_threads",
+    gateBoundary: "feedback_resolution",
+  });
+  assert.deepEqual(subagentContract, {
+    ownership: HANDOFF_OWNERSHIP.SUBAGENT,
+    stopBoundary: HANDOFF_STOP_BOUNDARY.SUBAGENT_EXIT,
+    resumePolicy: HANDOFF_RESUME_POLICY.RESUME_AFTER_SUBAGENT_EXIT,
+  });
+
+  const parentContract = buildHandoffContractForConductorAction({
+    action: "watch",
+    gateBoundary: "post_draft_external_review",
+  });
+  assert.deepEqual(parentContract, {
+    ownership: HANDOFF_OWNERSHIP.PARENT,
+    stopBoundary: HANDOFF_STOP_BOUNDARY.WATCH_BOUNDARY,
+    resumePolicy: HANDOFF_RESUME_POLICY.RESUME_AFTER_STATE_REFRESH,
+  });
+
+  const humanContract = buildHandoffContractForConductorAction({
+    action: "await_approval",
+    gateBoundary: "final_approval_ready",
+  });
+  assert.deepEqual(humanContract, {
+    ownership: HANDOFF_OWNERSHIP.HUMAN,
+    stopBoundary: HANDOFF_STOP_BOUNDARY.APPROVAL_BOUNDARY,
+    resumePolicy: HANDOFF_RESUME_POLICY.RESUME_AFTER_HUMAN_APPROVAL,
+  });
+
+  const mergeContract = buildHandoffContractForConductorAction({
+    action: "merge",
+    requiresApproval: true,
+  });
+  assert.deepEqual(mergeContract, {
+    ownership: HANDOFF_OWNERSHIP.HUMAN,
+    stopBoundary: HANDOFF_STOP_BOUNDARY.MERGE_BOUNDARY,
+    resumePolicy: HANDOFF_RESUME_POLICY.RESUME_AFTER_MERGE_AUTHORIZATION,
+  });
+
+  // Copilot review finding (#520): subagent actions with requiresApproval=true
+  // must NOT return subagent ownership; they must reflect the approval boundary.
+  const subagentWithApproval = buildHandoffContractForConductorAction({
+    action: "draft_gate",
+    gateBoundary: "draft_gate",
+    requiresApproval: true,
+  });
+  assert.deepEqual(subagentWithApproval, {
+    ownership: HANDOFF_OWNERSHIP.HUMAN,
+    stopBoundary: HANDOFF_STOP_BOUNDARY.APPROVAL_BOUNDARY,
+    resumePolicy: HANDOFF_RESUME_POLICY.RESUME_AFTER_HUMAN_APPROVAL,
+  });
+});
+
+test("buildHandoffContractForResumeAction mirrors recorded handoff intent", () => {
+  assert.deepEqual(buildHandoffContractForResumeAction("needs_feedback_fix"), {
+    ownership: HANDOFF_OWNERSHIP.SUBAGENT,
+    stopBoundary: HANDOFF_STOP_BOUNDARY.SUBAGENT_EXIT,
+    resumePolicy: HANDOFF_RESUME_POLICY.RESUME_AFTER_SUBAGENT_EXIT,
+  });
+
+  assert.deepEqual(buildHandoffContractForResumeAction("await_merge_authorization"), {
+    ownership: HANDOFF_OWNERSHIP.HUMAN,
+    stopBoundary: HANDOFF_STOP_BOUNDARY.MERGE_BOUNDARY,
+    resumePolicy: HANDOFF_RESUME_POLICY.RESUME_AFTER_MERGE_AUTHORIZATION,
+  });
+});
+
+test("parseRecordedHandoffContract parses the explicit contract block and compareHandoffContracts validates it", () => {
+  const text = [
+    "Active PR: owner/repo#17",
+    "Artifact state: open",
+    "Handoff ownership: subagent",
+    "Stop boundary: subagent_exit",
+    "Resume policy: resume_after_subagent_exit",
+  ].join("\n");
+
+  const parsed = parseRecordedHandoffContract(text);
+  assert.equal(parsed.reason, null);
+  assert.deepEqual(parsed.contract, {
+    ownership: HANDOFF_OWNERSHIP.SUBAGENT,
+    stopBoundary: HANDOFF_STOP_BOUNDARY.SUBAGENT_EXIT,
+    resumePolicy: HANDOFF_RESUME_POLICY.RESUME_AFTER_SUBAGENT_EXIT,
+  });
+
+  const mismatch = compareHandoffContracts(parsed.contract, buildHandoffContractForResumeAction("needs_feedback_fix"));
+  assert.equal(mismatch, null);
+});
+
+test("parseRecordedHandoffContract fails closed when contract fields are incomplete", () => {
+  const parsed = parseRecordedHandoffContract([
+    "Active PR: owner/repo#17",
+    "Handoff ownership: subagent",
+    "Resume policy: resume_after_subagent_exit",
+  ].join("\n"));
+
+  assert.equal(parsed.contract, null);
+  assert.equal(parsed.reason, "incomplete_handoff_contract");
+});

--- a/test/loop/run-conductor-cycle.test.mjs
+++ b/test/loop/run-conductor-cycle.test.mjs
@@ -212,6 +212,11 @@ test("detectPrState returns correctly shaped action entry for fix_threads", asyn
   assert.equal(result.gateBoundary, PR_CHECKPOINT.FEEDBACK_RESOLUTION);
   assert.equal(result.snapshot.ciStatus, "success");
   assert.equal(result.gateState.currentHeadSha, "abc123");
+  assert.deepEqual(result.handoffContract, {
+    ownership: "subagent",
+    stopBoundary: "subagent_exit",
+    resumePolicy: "resume_after_subagent_exit",
+  });
   assert.equal(result.error, undefined);
 });
 
@@ -243,6 +248,11 @@ test("detectPrState returns merge action with correct flags", async () => {
   assert.equal(result.action, "merge");
   assert.equal(result.priority, 100);
   assert.equal(result.requiresSubagent, false);
+  assert.deepEqual(result.handoffContract, {
+    ownership: "human",
+    stopBoundary: "merge_boundary",
+    resumePolicy: "resume_after_merge_authorization",
+  });
 });
 
 test("detectPrState returns watch for waiting_for_copilot_review", async () => {
@@ -272,6 +282,11 @@ test("detectPrState returns watch for waiting_for_copilot_review", async () => {
   assert.equal(result.action, "watch");
   assert.equal(result.priority, 30);
   assert.equal(result.requiresSubagent, false);
+  assert.deepEqual(result.handoffContract, {
+    ownership: "parent",
+    stopBoundary: "watch_boundary",
+    resumePolicy: "resume_after_state_refresh",
+  });
 });
 
 test("detectPrState handles gate detection failure gracefully", async () => {
@@ -340,6 +355,11 @@ test("runConductorCycle produces ordered queue for mixed PR states", async () =>
         lifecycleState: "pr_ready_no_feedback", loopDisposition: "clean_converged",
         gateBoundary: "final_approval_ready", reason: null, snapshot: null,
         gateState: {}, requiresSubagent: false,
+        handoffContract: {
+          ownership: "human",
+          stopBoundary: "merge_boundary",
+          resumePolicy: "resume_after_merge_authorization",
+        },
       };
     }
     if (pr.number === 5) {
@@ -349,6 +369,11 @@ test("runConductorCycle produces ordered queue for mixed PR states", async () =>
         lifecycleState: "unresolved_feedback_present", loopDisposition: "unresolved_feedback",
         gateBoundary: "feedback_resolution", reason: null, snapshot: null,
         gateState: {}, requiresSubagent: true,
+        handoffContract: {
+          ownership: "subagent",
+          stopBoundary: "subagent_exit",
+          resumePolicy: "resume_after_subagent_exit",
+        },
       };
     }
     return {
@@ -357,6 +382,11 @@ test("runConductorCycle produces ordered queue for mixed PR states", async () =>
       lifecycleState: "waiting_for_copilot_review", loopDisposition: "pending",
       gateBoundary: "post_draft_external_review", reason: null, snapshot: null,
       gateState: {}, requiresSubagent: false,
+      handoffContract: {
+        ownership: "parent",
+        stopBoundary: "watch_boundary",
+        resumePolicy: "resume_after_state_refresh",
+      },
     };
   };
 
@@ -371,10 +401,13 @@ test("runConductorCycle produces ordered queue for mixed PR states", async () =>
 
   assert.equal(result.actions[0].pr, 7);
   assert.equal(result.actions[0].action, "merge");
+  assert.equal(result.actions[0].handoffContract.ownership, "human");
   assert.equal(result.actions[1].pr, 5);
   assert.equal(result.actions[1].action, "fix_threads");
+  assert.equal(result.actions[1].handoffContract.ownership, "subagent");
   assert.equal(result.actions[2].pr, 10);
   assert.equal(result.actions[2].action, "watch");
+  assert.equal(result.actions[2].handoffContract.resumePolicy, "resume_after_state_refresh");
 
   assert.equal(result.summary.readyToMerge, 1);
   assert.equal(result.summary.needsSubagent, 1);


### PR DESCRIPTION
## Summary
Add explicit conductor handoff contracts to action queue output and auto-resume plans.

## Scope / context
- `scripts/loop/run-conductor-cycle.mjs`
- `scripts/loop/conductor-monitor.mjs`
- `scripts/loop/conductor.mjs` passthrough
- `scripts/README.md` contract docs
- focused tests for the new handoff contract shape and resume validation

## Acceptance criteria
- action queue entries record explicit ownership, stop boundary, and resume policy
- auto-resume plans record the same handoff contract and fail closed on mismatch
- interrupted/resumed flow is covered by regression tests
- `npm run verify` passes

## Definition of done
- handoff contract is visible in the conductor output surface
- resume path validates recorded contract before proposing a resume
- docs describe the new contract fields
- no unrelated scope creep

## Non-goals
- outer-loop metadata changes
- merge behavior changes
- new workflow entrypoints

Closes #519
