### PR TITLE
Bug: keep async dev-loop state visible when final reporting fails

### DIFF
--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -1283,38 +1283,66 @@ function classifyResumeBucket(text, parsedArtifactState) {
 }
 
 function buildSourceSelection(record, outputArtifactText, resultSummaryText, outputLogText) {
-  if (outputArtifactText !== null) {
-    return {
-      primaryText: outputArtifactText,
-      primarySource: "output_artifact",
-      fallbackText: resultSummaryText,
-      weakFallbackText: outputLogText,
-    };
-  }
+  const resultSummaryPath = record.resultSummaryPath ?? record.resultPath ?? null;
+  const candidates = [];
 
-  if (record.outputArtifactPath) {
+  if (outputArtifactText !== null) {
+    candidates.push({
+      text: outputArtifactText,
+      source: "output_artifact",
+      artifactPath: record.outputArtifactPath ?? null,
+      reportingIssue: null,
+    });
+  } else if (record.outputArtifactPath) {
+    if (resultSummaryText !== null) {
+      candidates.push({
+        text: resultSummaryText,
+        source: "grouped_result_summary",
+        artifactPath: resultSummaryPath,
+        reportingIssue: MANUAL_REASON.MISSING_OUTPUT_ARTIFACT,
+      });
+    }
+
+    if (outputLogText !== null) {
+      candidates.push({
+        text: outputLogText,
+        source: "weak_fallback_output_log",
+        artifactPath: record.outputLogPath ?? null,
+        reportingIssue: MANUAL_REASON.MISSING_OUTPUT_ARTIFACT,
+      });
+    }
+
     return {
-      primaryText: null,
+      candidates,
       primarySource: "missing_output_artifact",
-      fallbackText: resultSummaryText,
       weakFallbackText: outputLogText,
+      outputArtifactMissing: true,
     };
   }
 
   if (resultSummaryText !== null) {
-    return {
-      primaryText: resultSummaryText,
-      primarySource: "grouped_result_summary",
-      fallbackText: null,
-      weakFallbackText: outputLogText,
-    };
+    candidates.push({
+      text: resultSummaryText,
+      source: "grouped_result_summary",
+      artifactPath: resultSummaryPath,
+      reportingIssue: null,
+    });
+  }
+
+  if (resultSummaryText !== null && outputLogText !== null) {
+    candidates.push({
+      text: outputLogText,
+      source: "weak_fallback_output_log",
+      artifactPath: record.outputLogPath ?? null,
+      reportingIssue: null,
+    });
   }
 
   return {
-    primaryText: null,
-    primarySource: "weak_fallback_only",
-    fallbackText: null,
+    candidates,
+    primarySource: candidates.length > 0 ? candidates[0].source : "weak_fallback_only",
     weakFallbackText: outputLogText,
+    outputArtifactMissing: false,
   };
 }
 
@@ -1333,7 +1361,7 @@ export async function parseDevLoopArtifact(record) {
   const outputLogText = await readTextIfExists(record.outputLogPath);
   const selection = buildSourceSelection(record, outputArtifactText, resultSummaryText, outputLogText);
 
-  if (selection.primaryText === null) {
+  if (selection.candidates.length === 0) {
     const weakFallbackPr = parseWeakFallbackPr(selection.weakFallbackText);
     return {
       ok: false,
@@ -1342,6 +1370,7 @@ export async function parseDevLoopArtifact(record) {
       evidence: {
         outputArtifactPath: record.outputArtifactPath,
         resultSummaryPath: record.resultSummaryPath,
+        resultPath: record.resultPath,
         outputLogPath: record.outputLogPath,
         sessionPath: record.sessionPath,
       },
@@ -1350,80 +1379,134 @@ export async function parseDevLoopArtifact(record) {
     };
   }
 
-  const prNumbers = extractPrNumbersFromArtifactText(selection.primaryText);
-  if (prNumbers.length > 1) {
-    return {
-      ok: false,
-      reason: MANUAL_REASON.AMBIGUOUS_PR_IDENTITY,
-      evidence: {
-        prNumbers,
-        source: selection.primarySource,
-        outputArtifactPath: record.outputArtifactPath,
-        resultSummaryPath: record.resultSummaryPath,
-      },
-      source: selection.primarySource,
-    };
-  }
+  let lastFailure = null;
+  for (const candidate of selection.candidates) {
+    const prNumbers = extractPrNumbersFromArtifactText(candidate.text);
+    if (prNumbers.length > 1) {
+      lastFailure = {
+        ok: false,
+        reason: MANUAL_REASON.AMBIGUOUS_PR_IDENTITY,
+        evidence: {
+          prNumbers,
+          source: candidate.source,
+          outputArtifactPath: record.outputArtifactPath,
+          resultSummaryPath: record.resultSummaryPath,
+          resultPath: record.resultPath,
+          artifactPath: candidate.artifactPath,
+        },
+        source: candidate.source,
+        weakFallbackText: selection.weakFallbackText,
+      };
+      continue;
+    }
 
-  if (prNumbers.length === 0) {
-    return {
-      ok: false,
-      reason: MANUAL_REASON.MISSING_PR_IDENTITY,
-      evidence: {
-        source: selection.primarySource,
-        outputArtifactPath: record.outputArtifactPath,
-        resultSummaryPath: record.resultSummaryPath,
-      },
-      source: selection.primarySource,
-    };
-  }
+    if (prNumbers.length === 0) {
+      lastFailure = {
+        ok: false,
+        reason: MANUAL_REASON.MISSING_PR_IDENTITY,
+        evidence: {
+          source: candidate.source,
+          outputArtifactPath: record.outputArtifactPath,
+          resultSummaryPath: record.resultSummaryPath,
+          resultPath: record.resultPath,
+          artifactPath: candidate.artifactPath,
+        },
+        source: candidate.source,
+        weakFallbackText: selection.weakFallbackText,
+      };
+      continue;
+    }
 
-  const parsedArtifactState = parseArtifactState(selection.primaryText);
-  const parsedLoopState = parseLoopState(selection.primaryText);
-  const nextAction = parseNextActionText(selection.primaryText);
-  if (parsedArtifactState === null) {
+    const parsedArtifactState = parseArtifactState(candidate.text);
+    const parsedLoopState = parseLoopState(candidate.text);
+    const nextAction = parseNextActionText(candidate.text);
+    if (parsedArtifactState === null) {
+      lastFailure = {
+        ok: false,
+        reason: MANUAL_REASON.UNCLASSIFIED_ARTIFACT_STATE,
+        pr: prNumbers[0],
+        evidence: {
+          source: candidate.source,
+          parsedLoopState,
+          nextAction,
+          outputArtifactPath: record.outputArtifactPath,
+          resultSummaryPath: record.resultSummaryPath,
+          resultPath: record.resultPath,
+          artifactPath: candidate.artifactPath,
+        },
+        source: candidate.source,
+        weakFallbackText: selection.weakFallbackText,
+      };
+      continue;
+    }
+
+    const resumeBucket = classifyResumeBucket(candidate.text, parsedArtifactState);
+
+    if (resumeBucket === null) {
+      lastFailure = {
+        ok: false,
+        reason: MANUAL_REASON.UNCLASSIFIED_ARTIFACT_STATE,
+        pr: prNumbers[0],
+        evidence: {
+          source: candidate.source,
+          parsedArtifactState,
+          parsedLoopState,
+          nextAction,
+          outputArtifactPath: record.outputArtifactPath,
+          resultSummaryPath: record.resultSummaryPath,
+          resultPath: record.resultPath,
+          artifactPath: candidate.artifactPath,
+        },
+        source: candidate.source,
+        weakFallbackText: selection.weakFallbackText,
+      };
+      continue;
+    }
+
     return {
-      ok: false,
-      reason: MANUAL_REASON.UNCLASSIFIED_ARTIFACT_STATE,
+      ok: true,
       pr: prNumbers[0],
-      evidence: {
-        source: selection.primarySource,
-        parsedLoopState,
-        nextAction,
-        outputArtifactPath: record.outputArtifactPath,
-        resultSummaryPath: record.resultSummaryPath,
-      },
-      source: selection.primarySource,
+      parsedArtifactState,
+      parsedLoopState,
+      nextAction,
+      resumeBucket,
+      source: candidate.source,
+      text: candidate.text,
+      artifactPath: candidate.artifactPath,
+      reportingIssue: candidate.reportingIssue,
     };
   }
-  const resumeBucket = classifyResumeBucket(selection.primaryText, parsedArtifactState);
 
-  if (resumeBucket === null) {
+  if (selection.outputArtifactMissing) {
+    const weakFallbackPr = parseWeakFallbackPr(selection.weakFallbackText);
     return {
       ok: false,
-      reason: MANUAL_REASON.UNCLASSIFIED_ARTIFACT_STATE,
-      pr: prNumbers[0],
+      reason: MANUAL_REASON.MISSING_OUTPUT_ARTIFACT,
+      ...(Number.isInteger(weakFallbackPr) ? { pr: weakFallbackPr } : {}),
       evidence: {
-        source: selection.primarySource,
-        parsedArtifactState,
-        parsedLoopState,
-        nextAction,
         outputArtifactPath: record.outputArtifactPath,
         resultSummaryPath: record.resultSummaryPath,
+        resultPath: record.resultPath,
+        outputLogPath: record.outputLogPath,
+        sessionPath: record.sessionPath,
       },
+      weakFallbackText: selection.weakFallbackText,
       source: selection.primarySource,
     };
   }
 
-  return {
-    ok: true,
-    pr: prNumbers[0],
-    parsedArtifactState,
-    parsedLoopState,
-    nextAction,
-    resumeBucket,
+  return lastFailure ?? {
+    ok: false,
+    reason: MANUAL_REASON.UNCLASSIFIED_ARTIFACT_STATE,
+    evidence: {
+      outputArtifactPath: record.outputArtifactPath,
+      resultSummaryPath: record.resultSummaryPath,
+      resultPath: record.resultPath,
+      outputLogPath: record.outputLogPath,
+      sessionPath: record.sessionPath,
+    },
     source: selection.primarySource,
-    text: selection.primaryText,
+    weakFallbackText: selection.weakFallbackText,
   };
 }
 
@@ -1667,7 +1750,8 @@ export function buildResumePlan({ prReport, candidate, childCounts }) {
       pr: prReport.number,
       runId: run.runId,
       runState: normalizeRunStateForPlan(run.runState),
-      artifactPath: run.outputArtifactPath ?? run.resultSummaryPath ?? run.resultPath ?? null,
+      artifactPath: parsedArtifact.artifactPath ?? run.outputArtifactPath ?? run.resultSummaryPath ?? run.resultPath ?? null,
+      ...(parsedArtifact.reportingIssue ? { reportingIssue: parsedArtifact.reportingIssue } : {}),
       ...(run.sessionPath ? { sessionPath: run.sessionPath } : {}),
       parsedArtifactState: parsedArtifact.parsedArtifactState,
       parsedLoopState: parsedArtifact.parsedLoopState,

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -1329,7 +1329,7 @@ function buildSourceSelection(record, outputArtifactText, resultSummaryText, out
     });
   }
 
-  if (resultSummaryText !== null && outputLogText !== null) {
+  if (outputLogText !== null) {
     candidates.push({
       text: outputLogText,
       source: "weak_fallback_output_log",

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -720,6 +720,70 @@ test("conductor-monitor --auto-resume reuses grouped result summaries when accep
   }
 });
 
+test("conductor-monitor --auto-resume falls back to deterministic output logs when grouped summaries are absent", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-output-log-fallback-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const resultPath = path.join(asyncResultsRoot, "run-output-log-58c.json");
+    const finalApprovalSummary = [
+      "Status: stopped at final human approval boundary",
+      "Routed strategy: final_approval",
+      "PR: https://github.com/owner/repo/pull/58",
+      "Next recommended action: human reviews/approves PR #58",
+    ].join("\n");
+
+    const { sessionPath } = await writeSessionRun({
+      sessionsRoot,
+      runId: "run-output-log-58c",
+      cwd: repoRoot,
+      timestampMs: 1700000014650,
+      exitCode: 1,
+      outputText: finalApprovalSummary,
+      writeOutputArtifact: false,
+    });
+    await writeAsyncRun({
+      asyncRunsRoot,
+      runId: "run-output-log-58c",
+      state: "complete",
+      cwd: repoRoot,
+      sessionPath,
+      timestampMs: 1700000014700,
+      outputText: finalApprovalSummary,
+    });
+    await writeFile(resultPath, `${JSON.stringify({
+      runId: "run-output-log-58c",
+      agent: "dev-loop",
+      state: "complete",
+      cwd: repoRoot,
+      results: [{
+        agent: "dev-loop",
+        artifactPaths: {
+          output: path.join(asyncResultsRoot, "missing-run-output-log-58c_output.md"),
+        },
+      }],
+    }, null, 2)}
+`, "utf8");
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{
+        number: 58,
+        reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
+        statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+      }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.resumePlanCount, 1);
+    assert.equal(payload.manualAttentionCount, 0);
+    assert.equal(payload.resumePlans[0].pr, 58);
+    assert.equal(payload.resumePlans[0].artifactPath.endsWith("output-0.log"), true);
+    assert.equal(payload.resumePlans[0].resumeAction, "await_final_approval");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("conductor-monitor --auto-resume fails closed when an active matching run has the same timestamp as the exited candidate", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-same-timestamp-active-run-"));
 
@@ -1088,7 +1152,7 @@ test("conductor-monitor --auto-resume fails closed when the output artifact is m
     assert.equal(payload.manualAttentionCount, 1);
     assert.equal(payload.needsManualAttention[0].pr, 31);
     assert.equal(payload.needsManualAttention[0].runId, "run-missing-31");
-    assert.equal(payload.needsManualAttention[0].reason, "missing_output_artifact");
+    assert.equal(payload.needsManualAttention[0].reason, "unclassified_artifact_state");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -652,6 +652,74 @@ test("conductor-monitor --auto-resume uses grouped result summaries as the artif
   }
 });
 
+test("conductor-monitor --auto-resume reuses grouped result summaries when acceptance reporting drops the output artifact", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-reporting-fallback-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const resultPath = path.join(asyncResultsRoot, "run-reporting-58b.json");
+    const finalApprovalSummary = [
+      "Status: stopped at final human approval boundary",
+      "Routed strategy: final_approval",
+      "PR: https://github.com/owner/repo/pull/58",
+      "Next recommended action: human reviews/approves PR #58",
+    ].join("\n");
+
+    const { sessionPath } = await writeSessionRun({
+      sessionsRoot,
+      runId: "run-reporting-58b",
+      cwd: repoRoot,
+      timestampMs: 1700000014550,
+      exitCode: 1,
+      outputText: finalApprovalSummary,
+      writeOutputArtifact: false,
+    });
+    await writeAsyncRun({
+      asyncRunsRoot,
+      runId: "run-reporting-58b",
+      state: "complete",
+      cwd: repoRoot,
+      sessionPath,
+      timestampMs: 1700000014600,
+      outputText: finalApprovalSummary,
+    });
+    await writeFile(resultPath, `${JSON.stringify({
+      runId: "run-reporting-58b",
+      agent: "dev-loop",
+      state: "complete",
+      cwd: repoRoot,
+      summary: finalApprovalSummary,
+      results: [{
+        agent: "dev-loop",
+        artifactPaths: {
+          output: path.join(asyncResultsRoot, "missing-run-reporting-58b_output.md"),
+        },
+        output: finalApprovalSummary,
+      }],
+    }, null, 2)}
+`, "utf8");
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{
+        number: 58,
+        reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
+        statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+      }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.resumePlanCount, 1);
+    assert.equal(payload.manualAttentionCount, 0);
+    assert.equal(payload.resumePlans[0].pr, 58);
+    assert.equal(payload.resumePlans[0].runState, "failed");
+    assert.equal(payload.resumePlans[0].artifactPath, resultPath);
+    assert.equal(payload.resumePlans[0].resumeAction, "await_final_approval");
+    assert.equal(payload.resumePlans[0].reportingIssue, "missing_output_artifact");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("conductor-monitor --auto-resume fails closed when an active matching run has the same timestamp as the exited candidate", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-same-timestamp-active-run-"));
 


### PR DESCRIPTION
## Summary
Keep dev-loop run state resumable when final reporting drops the output artifact.

## Scope / context
- `scripts/loop/conductor-monitor.mjs`
- `test/loop/conductor-monitor.test.mjs`
- grouped-result fallback when async result summaries survive but `_output.md` does not

## Acceptance criteria
- Completed work remains visible when reporting/output-artifact emission fails after the run already reached a stable PR state
- Auto-resume uses surviving grouped result summaries instead of failing closed solely because `_output.md` is missing
- Regression coverage proves a failed-finalization / successful-work scenario still produces a deterministic resume plan

## Definition of done
- conductor-monitor prefers surviving grouped result summaries or output logs only when they carry enough deterministic state
- missing-artifact fallback keeps prior fail-closed behavior when no durable summary can classify the run
- `npm run verify` passes

## Non-goals
- no changes to Pi runtime acceptance-report parsing
- no merge behavior changes
- no new workflow entrypoints

Closes #521
