### PR TITLE
fix(#524): add async delegation guard rules to dev-loop skills

### DIFF
--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -218,6 +218,17 @@ Key rules:
 - if Pi async subagents or the designated async follow-up skill are not appropriate or available, stop and report rather than improvising a shell watcher
 - the async-start contract is also enforced in code: `outer-loop.mjs` fails closed unless it detects a visible Pi-managed async run id (`PI_SUBAGENT_RUN_ID`). Session-only markers (`PI_SESSION_ID`, `PI_ASYNC_CONTEXT`) and detached/local background fallback are diagnostic-only and do not satisfy startup. Snapshot/test input mode (both `--copilot-input` and `--reviewer-input`) is exempt. Use `PI_ASYNC_START_BYPASS=1` only for explicitly authorized standalone runs, never to route around the in-session async requirement.
 
+### Async delegation guard rules (#524)
+
+These rules are enforced for all async subagent dispatch in the dev-loop pipeline:
+
+- **Pre-delegation gate:** Before any async subagent delegation, run `copilot-pr-handoff.mjs`. If it returns `action: "stop"` or `watchArgs: null`, do NOT delegate — proceed inline to the next gate instead.
+- **Worktree cwd rule:** Always set `cwd` to the worktree path in `subagent()` config for dev-loop work. Never delegate with the parent's `main` branch checkout.
+- **Handoff template:** Use `workflow-handoff-template.md` for all subagent delegation. Include deterministic routing inputs, explicit `cwd`, bounded task scope, exit conditions, output artifact paths, and intercom coordination instructions.
+- **Inline-first for single-PR:** When managing one PR through its lifecycle, prefer inline commands. Use async delegation only for parallel fan-out review, bounded tasks with clear I/O, or when the parent needs to continue other work.
+- **Bounded tasks:** Break async work into discrete tasks with clear input artifacts, explicit output expectations, no shell polling loops (use `run-watch-cycle.mjs` or `gh run watch`), intercom coordination, and parent-owned loop control.
+- **Deterministic routing:** Check `copilot-pr-handoff.mjs` output before deciding delegate vs inline. When `action: "stop"` and `terminal: true`, the loop phase is complete — proceed inline to the next gate.
+
 ## Step 7: Pi review/fix follow-up loop
 
 This step covers four responsibilities: the draft gate right before `gh pr ready`, the narrower post-review follow-up loop once actionable feedback exists, the pre-approval gate before calling the PR merge-ready, and the final approval / merge boundary.

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -72,6 +72,33 @@ After the resolver selects a strategy and the route pack is loaded, the routed s
 
 Strategies where `requiresAsyncDispatch` is `false` (`local_implementation`, `final_approval`, `none`) may run inline — local phases are often interactive, and final approval requires explicit human confirmation before GitHub mutations.
 
+## Async delegation guard rules (#524)
+
+**Pre-delegation gate (#524, enforced):** Before any async subagent delegation in the dev-loop, run `copilot-pr-handoff.mjs` and abort if `action: "stop"` or `watchArgs: null`. This prevents delegating work that has no automatic next step — the handoff tool is the authority, not the parent session's judgment.
+
+**Worktree cwd rule (#524, enforced):** Always set `cwd` to the worktree when delegating dev-loop work to subagents. Never delegate with the parent's `main` branch checkout as the working directory. The worktree path is authoritative for all git operations, file reads/writes, and validation commands in delegated runs.
+
+**Handoff template rule (#524):** All subagent delegation must use the `workflow-handoff-template.md` contract. Never delegate with abbreviated task summaries. The handoff template must include:
+- Deterministic routing inputs (current state, gate boundary, next action)
+- Explicit `cwd` path to the worktree
+- Clear bounded task scope (single responsibility per delegation)
+- Exit conditions and where to write output artifacts
+- Intercom coordination instructions if cross-run signaling is needed
+
+**Inline-first rule for single-PR workflows (#524):** When managing a single PR through its lifecycle, prefer inline commands over async delegation. Inline execution is faster, avoids context serialization overhead, and has full access to the parent session's state and tool results. Use async delegation only when:
+- Parallel fan-out review is explicitly needed
+- The task is bounded with clear inputs/outputs and a deterministic exit condition
+- The parent session needs to continue other work while waiting
+
+**Bounded async task contract (#524):** When async delegation is needed, break work into discrete tasks with:
+- Clear input artifacts (file paths, PR numbers, state snapshots)
+- Explicit output expectations (file paths, JSON payloads, exit codes)
+- No shell polling loops — use `run-watch-cycle.mjs` or `gh run watch` for waiting
+- Intercom coordination for cross-run state updates
+- Parent session retains loop ownership; subagents handle bounded slices only
+
+**Deterministic routing step (#524):** The dev-loop skill checks `copilot-pr-handoff.mjs` output before deciding whether to delegate or proceed inline. When the handoff returns `action: "stop"` with `terminal: true`, the loop is complete for that phase — proceed to the next gate inline rather than delegating a polling task.
+
 ## Shorthand issue-based auto trigger contract
 
 - treat `auto dev loop on issue 112` as the public `dev-loop` intent `auto_continue_current` after authoritative current-state resolution


### PR DESCRIPTION
## Change Summary

Add async delegation guard rules to dev-loop skills, addressing the root cause of issue #518's PR #523 retrospective. The delegation failure occurred because the session bypassed the deterministic handoff tool and delegated a polling loop when there was nothing left to poll for.

## Scope / Context

This change hardens the dev-loop skill contract to prevent the class of async delegation failures documented in #524. The fixes are documentation and process-level guard rules embedded in the authoritative skill files — no code logic changes, no new helpers.

## Acceptance Criteria

- [x] Pre-delegation gate rule documented: run `copilot-pr-handoff.mjs` before any async subagent delegation; abort if `action: "stop"` or `watchArgs: null`
- [x] Worktree cwd rule documented: always set `cwd` to worktree path in subagent config
- [x] Handoff template rule documented: use `workflow-handoff-template.md` for all delegation
- [x] Inline-first rule for single-PR workflows documented
- [x] Bounded async task contract documented: discrete tasks, no shell polling, parent-owned loop control
- [x] Deterministic routing step documented: check handoff output before delegate vs inline decision
- [x] Rules added to both `skills/dev-loop/SKILL.md` and `skills/copilot-pr-followup/SKILL.md`
- [x] `npm run verify` passes

## Definition of Done

- [x] Both skill files updated with guard rules
- [x] Draft gate review completed
- [x] Pre-approval gate review completed
- [x] All tests green
- [ ] Human approval checkpoint passed
- [ ] Merged

## Non-Goals

- No changes to `copilot-pr-handoff.mjs` script logic (the script already works correctly; it was not called)
- No changes to the public dev-loop routing contract
- No new helper scripts added
- No refactoring of existing async dispatch machinery

Closes #524
