### PR TITLE
fix(#509): enforce one runner per PR

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -474,12 +474,31 @@ Contract:
 - enters watch only when request state is confirmed (`requested` or `already-requested`) and emits exact `watchArgs` + `watchTimeoutPolicy`
 - watch refresh (`--watch-status`) is observational-only; rely on refreshed `loopDisposition` + `terminal` to decide whether to continue or stop
 - explicit stop/blocked routing is machine-readable via `action: "stop"` plus `requestWatchContract.stopState`
+- when `PI_SUBAGENT_RUN_ID` is present, the helper enforces one-runner-per-PR ownership and returns `runnerOwnership` details when a conflicting or displaced run must stop
 
 Success output shape:
 - `{ "ok": true, "action": "watch"|"fix"|"stop", "state": "...", "allowedTransitions": [...], "nextAction": "...", "snapshot": {...}, "reviewRequestStatus"?: "...", "watchStatus"?: "...", "autoRerequestEligible": true|false, "sameHeadCleanConverged": true|false, "loopDisposition": "...", "terminal": true|false, "requestWatchContract": { "action": "...", "nextAction": "...", "requestStatus": "requested"|"already-requested"|"unavailable"|"failed"|"none", "routingState": "copilot_request_confirmed_waiting"|"ready_state_needs_copilot_request"|"draft_reset_requires_ready_state_reentry"|"non_ready_state", "watchEntryConfirmed": true|false, "watchArgs": { ... }|null, "stopState"?: "unavailable"|"blocked"|"draft_requires_ready_state_reentry"|"no_automatic_next_step" }, "watchTimeoutPolicy"?: { "classification": "external_healthy_wait", "minimumTimeoutMs": 1800000, "defaultTimeoutMs": 1800000 }, "watchArgs"?: { ... } }`
 
 Failure behavior:
 - malformed arguments and unexpected `gh` failures emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero
+
+### `scripts/loop/pr-runner-coordination.mjs`
+
+Durable one-runner-per-PR coordination helper.
+
+Subcommands:
+- `status` — inspect current ownership record for one PR
+- `claim` — claim ownership when no active runner exists; otherwise fail closed with machine-readable conflict details
+- `takeover` — explicit replacement path that records prior/new run ids
+- `assert` — verify the current run still owns the PR; `--require-existing` fails closed when async pre-merge ownership proof is missing
+- `release` — clear ownership when the active run is done
+
+State path:
+- `.pi/runner-coordination/<owner>/<repo>/pr-<number>.json`
+
+Integration notes:
+- `copilot-pr-handoff.mjs` uses this surface for async run ownership checks
+- `detect-checkpoint-evidence.mjs` uses strict ownership assertion before async merge-time gate evaluation
 
 ### `scripts/loop/run-watch-cycle.mjs`
 
@@ -678,6 +697,7 @@ Fetches the live PR head SHA plus visible PR issue comments, then summarizes the
 latest valid `draft_gate` and `pre_approval_gate` checkpoint verdict comments.
 Use this when a fresh session needs authoritative visible gate evidence for the
 current head before running `gh pr ready` or declaring final-approval readiness.
+When `PI_SUBAGENT_RUN_ID` is present, it also enforces async runner ownership before reading GitHub facts, so stale/displaced runs fail closed before merge.
 
 Required:
 - `--repo <owner/name>`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -474,7 +474,7 @@ Contract:
 - enters watch only when request state is confirmed (`requested` or `already-requested`) and emits exact `watchArgs` + `watchTimeoutPolicy`
 - watch refresh (`--watch-status`) is observational-only; rely on refreshed `loopDisposition` + `terminal` to decide whether to continue or stop
 - explicit stop/blocked routing is machine-readable via `action: "stop"` plus `requestWatchContract.stopState`
-- when `PI_SUBAGENT_RUN_ID` is present, the helper enforces one-runner-per-PR ownership and returns `runnerOwnership` details when a conflicting or displaced run must stop
+- when `PI_SUBAGENT_RUN_ID` is set to a non-empty value, the helper enforces one-runner-per-PR ownership and returns `runnerOwnership` details when a conflicting or displaced run must stop
 
 Success output shape:
 - `{ "ok": true, "action": "watch"|"fix"|"stop", "state": "...", "allowedTransitions": [...], "nextAction": "...", "snapshot": {...}, "reviewRequestStatus"?: "...", "watchStatus"?: "...", "autoRerequestEligible": true|false, "sameHeadCleanConverged": true|false, "loopDisposition": "...", "terminal": true|false, "requestWatchContract": { "action": "...", "nextAction": "...", "requestStatus": "requested"|"already-requested"|"unavailable"|"failed"|"none", "routingState": "copilot_request_confirmed_waiting"|"ready_state_needs_copilot_request"|"draft_reset_requires_ready_state_reentry"|"non_ready_state", "watchEntryConfirmed": true|false, "watchArgs": { ... }|null, "stopState"?: "unavailable"|"blocked"|"draft_requires_ready_state_reentry"|"no_automatic_next_step" }, "watchTimeoutPolicy"?: { "classification": "external_healthy_wait", "minimumTimeoutMs": 1800000, "defaultTimeoutMs": 1800000 }, "watchArgs"?: { ... } }`
@@ -697,7 +697,7 @@ Fetches the live PR head SHA plus visible PR issue comments, then summarizes the
 latest valid `draft_gate` and `pre_approval_gate` checkpoint verdict comments.
 Use this when a fresh session needs authoritative visible gate evidence for the
 current head before running `gh pr ready` or declaring final-approval readiness.
-When `PI_SUBAGENT_RUN_ID` is present, it also enforces async runner ownership before reading GitHub facts, so stale/displaced runs fail closed before merge.
+When `PI_SUBAGENT_RUN_ID` is set to a non-empty value, it also enforces async runner ownership before reading GitHub facts, so stale/displaced runs fail closed before merge.
 
 Required:
 - `--repo <owner/name>`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -495,6 +495,7 @@ Subcommands:
 
 State path:
 - `.pi/runner-coordination/<owner>/<repo>/pr-<number>.json`
+- this is local coordination state under `.pi/`; keep it uncommitted like other repo-local runtime artifacts
 
 Integration notes:
 - `copilot-pr-handoff.mjs` uses this surface for async run ownership checks

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -11,6 +11,7 @@ import {
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { ensureAsyncRunnerOwnership } from "../loop/_pr-runner-coordination.mjs";
 
 const USAGE = `Usage: detect-checkpoint-evidence.mjs --repo <owner/name> --pr <number>
 
@@ -253,6 +254,20 @@ export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null) {
 
 
 export async function detectCheckpointEvidence(options, { env = process.env, ghCommand = "gh" } = {}) {
+  const runnerOwnership = await ensureAsyncRunnerOwnership({
+    repo: options.repo,
+    pr: options.pr,
+    env,
+    cwd: process.cwd(),
+    claimIfMissing: false,
+    requireExisting: true,
+  });
+  if (!runnerOwnership.ok) {
+    const error = new Error(runnerOwnership.message);
+    error.runnerOwnership = runnerOwnership;
+    throw error;
+  }
+
   const prPayload = await runGhJson(["pr", "view", String(options.pr), "--repo", options.repo, "--json", "headRefOid"], { env, ghCommand });
   const commentsPayload = normalizeIssueCommentsPayload(await runGhJson(["api", "--paginate", "--slurp", `repos/${options.repo}/issues/${options.pr}/comments?per_page=100`], { env, ghCommand }));
 
@@ -277,6 +292,7 @@ export async function detectCheckpointEvidence(options, { env = process.env, ghC
     draftGateMarker: normalizeGateMarkerSummary(markerSummary.draft_gate),
     preApprovalGateMarker: normalizeGateMarkerSummary(markerSummary.pre_approval_gate),
     draftGateSatisfied: commentSummary.draft_gate?.verdict === "clean" && typeof commentSummary.draft_gate?.headSha === "string",
+    ...(runnerOwnership.status !== "skipped_no_async_run_id" ? { runnerOwnership } : {}),
   };
 }
 
@@ -327,6 +343,11 @@ async function main() {
 
     process.stdout.write(`${JSON.stringify(output)}\n`);
   } catch (error) {
+    if (error && typeof error === "object" && "runnerOwnership" in error && error.runnerOwnership) {
+      process.stderr.write(`${JSON.stringify(error.runnerOwnership)}\n`);
+      process.exitCode = 1;
+      return;
+    }
     process.stderr.write(`${JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) })}\n`);
     process.exitCode = 1;
   }

--- a/scripts/loop/_pr-runner-coordination.mjs
+++ b/scripts/loop/_pr-runner-coordination.mjs
@@ -40,7 +40,8 @@ export function defaultRunnerCoordinationFilePathForTarget({ repo, pr }, cwd = p
     errorMessage: `Invalid repo slug for coordination target path: ${JSON.stringify(repo)}`,
     lowercase: true,
   });
-  return path.join(cwd, ".pi", "runner-coordination", owner, name, `pr-${pr}.json`);
+  const normalizedPr = normalizePr(pr);
+  return path.join(cwd, ".pi", "runner-coordination", owner, name, `pr-${normalizedPr}.json`);
 }
 
 export function createRunnerCoordinationState({ repo, pr, runId = null, now = new Date().toISOString() }) {

--- a/scripts/loop/_pr-runner-coordination.mjs
+++ b/scripts/loop/_pr-runner-coordination.mjs
@@ -1,0 +1,477 @@
+import path from "node:path";
+import process from "node:process";
+
+import { parseRepoSlugParts } from "@pi-dev-loops/core/github/repo-slug";
+import { loadStateFile, saveStateFile, withStateFileLock } from "./_steering-state-file.mjs";
+
+export const RUNNER_COORDINATION_SCHEMA_VERSION = 1;
+export const RUNNER_OWNERSHIP_ERROR = Object.freeze({
+  ACTIVE_RUN_EXISTS: "active_run_exists",
+  OWNERSHIP_LOST: "ownership_lost",
+  OWNERSHIP_MISSING: "ownership_missing",
+  RUN_ID_REQUIRED: "run_id_required",
+  INVALID_TARGET: "invalid_target",
+});
+
+function normalizeRepoSlug(repo) {
+  const { owner, name } = parseRepoSlugParts(repo, {
+    errorMessage: `Invalid repo slug for coordination target path: ${JSON.stringify(repo)}`,
+    lowercase: true,
+  });
+  return `${owner}/${name}`;
+}
+
+function normalizePr(pr) {
+  const number = typeof pr === "number" ? pr : Number(pr);
+  if (!Number.isInteger(number) || number <= 0) {
+    throw new Error(`Invalid pull request number for runner coordination: ${JSON.stringify(pr)}`);
+  }
+  return number;
+}
+
+function normalizeRunId(runId) {
+  return typeof runId === "string" && runId.trim().length > 0
+    ? runId.trim()
+    : null;
+}
+
+export function defaultRunnerCoordinationFilePathForTarget({ repo, pr }, cwd = process.cwd()) {
+  const { owner, name } = parseRepoSlugParts(repo, {
+    errorMessage: `Invalid repo slug for coordination target path: ${JSON.stringify(repo)}`,
+    lowercase: true,
+  });
+  return path.join(cwd, ".pi", "runner-coordination", owner, name, `pr-${pr}.json`);
+}
+
+export function createRunnerCoordinationState({ repo, pr, runId = null, now = new Date().toISOString() }) {
+  const normalizedRepo = normalizeRepoSlug(repo);
+  const normalizedPr = normalizePr(pr);
+  const normalizedRunId = normalizeRunId(runId);
+
+  return {
+    schemaVersion: RUNNER_COORDINATION_SCHEMA_VERSION,
+    target: {
+      repo: normalizedRepo,
+      pr: normalizedPr,
+    },
+    activeRun: normalizedRunId === null
+      ? null
+      : {
+        runId: normalizedRunId,
+        claimedAt: now,
+        updatedAt: now,
+      },
+    previousRun: null,
+    history: normalizedRunId === null
+      ? []
+      : [{ type: "claim", runId: normalizedRunId, at: now }],
+  };
+}
+
+export function normalizeRunnerCoordinationState(raw, { repo, pr } = {}) {
+  if (!raw || typeof raw !== "object") {
+    throw new Error("Runner coordination state must be a non-null object");
+  }
+
+  if (raw.schemaVersion !== RUNNER_COORDINATION_SCHEMA_VERSION) {
+    throw new Error(
+      `Unsupported runner coordination schemaVersion ${JSON.stringify(raw.schemaVersion)}; expected ${RUNNER_COORDINATION_SCHEMA_VERSION}`,
+    );
+  }
+
+  const target = raw.target;
+  if (!target || typeof target !== "object") {
+    throw new Error("Runner coordination state target is missing");
+  }
+
+  const normalizedRepo = normalizeRepoSlug(target.repo);
+  const normalizedPr = normalizePr(target.pr);
+
+  if (repo !== undefined && normalizeRepoSlug(repo) !== normalizedRepo) {
+    throw new Error(
+      `Runner coordination target repo ${JSON.stringify(normalizedRepo)} does not match expected ${JSON.stringify(normalizeRepoSlug(repo))}`,
+    );
+  }
+
+  if (pr !== undefined && normalizePr(pr) !== normalizedPr) {
+    throw new Error(
+      `Runner coordination target pr ${JSON.stringify(normalizedPr)} does not match expected ${JSON.stringify(normalizePr(pr))}`,
+    );
+  }
+
+  const activeRun = raw.activeRun && typeof raw.activeRun === "object"
+    ? {
+      runId: normalizeRunId(raw.activeRun.runId),
+      claimedAt: typeof raw.activeRun.claimedAt === "string" ? raw.activeRun.claimedAt : null,
+      updatedAt: typeof raw.activeRun.updatedAt === "string" ? raw.activeRun.updatedAt : null,
+    }
+    : null;
+
+  const previousRun = raw.previousRun && typeof raw.previousRun === "object"
+    ? {
+      runId: normalizeRunId(raw.previousRun.runId),
+      replacedAt: typeof raw.previousRun.replacedAt === "string" ? raw.previousRun.replacedAt : null,
+      replacedByRunId: normalizeRunId(raw.previousRun.replacedByRunId),
+    }
+    : null;
+
+  return {
+    schemaVersion: RUNNER_COORDINATION_SCHEMA_VERSION,
+    target: {
+      repo: normalizedRepo,
+      pr: normalizedPr,
+    },
+    activeRun: activeRun?.runId
+      ? {
+        runId: activeRun.runId,
+        claimedAt: activeRun.claimedAt,
+        updatedAt: activeRun.updatedAt,
+      }
+      : null,
+    previousRun: previousRun?.runId
+      ? {
+        runId: previousRun.runId,
+        replacedAt: previousRun.replacedAt,
+        replacedByRunId: previousRun.replacedByRunId,
+      }
+      : null,
+    history: Array.isArray(raw.history) ? raw.history : [],
+  };
+}
+
+function buildConflict({ error, repo, pr, runId, activeRun, filePath, message }) {
+  return {
+    ok: false,
+    error,
+    repo,
+    pr,
+    runId,
+    activeRun,
+    filePath,
+    message,
+  };
+}
+
+export async function loadRunnerCoordinationState({ repo, pr, cwd = process.cwd(), filePath = null } = {}) {
+  const normalizedRepo = normalizeRepoSlug(repo);
+  const normalizedPr = normalizePr(pr);
+  const resolvedPath = filePath ?? defaultRunnerCoordinationFilePathForTarget({ repo: normalizedRepo, pr: normalizedPr }, cwd);
+  const raw = await loadStateFile(resolvedPath);
+  if (raw === null) {
+    return { filePath: resolvedPath, state: null };
+  }
+  return {
+    filePath: resolvedPath,
+    state: normalizeRunnerCoordinationState(raw, { repo: normalizedRepo, pr: normalizedPr }),
+  };
+}
+
+export async function claimRunnerOwnership({
+  repo,
+  pr,
+  runId,
+  cwd = process.cwd(),
+  filePath = null,
+  mode = "claim",
+  now = new Date().toISOString(),
+} = {}) {
+  const normalizedRepo = normalizeRepoSlug(repo);
+  const normalizedPr = normalizePr(pr);
+  const normalizedRunId = normalizeRunId(runId);
+  if (normalizedRunId === null) {
+    return buildConflict({
+      error: RUNNER_OWNERSHIP_ERROR.RUN_ID_REQUIRED,
+      repo: normalizedRepo,
+      pr: normalizedPr,
+      runId: null,
+      activeRun: null,
+      filePath: filePath ?? defaultRunnerCoordinationFilePathForTarget({ repo: normalizedRepo, pr: normalizedPr }, cwd),
+      message: "Runner coordination claim requires a non-empty run id.",
+    });
+  }
+
+  const resolvedPath = filePath ?? defaultRunnerCoordinationFilePathForTarget({ repo: normalizedRepo, pr: normalizedPr }, cwd);
+  return withStateFileLock(resolvedPath, async () => {
+    const raw = await loadStateFile(resolvedPath);
+    const state = raw === null
+      ? createRunnerCoordinationState({ repo: normalizedRepo, pr: normalizedPr })
+      : normalizeRunnerCoordinationState(raw, { repo: normalizedRepo, pr: normalizedPr });
+    const activeRun = state.activeRun;
+
+    if (activeRun === null) {
+      const nextState = {
+        ...state,
+        activeRun: {
+          runId: normalizedRunId,
+          claimedAt: now,
+          updatedAt: now,
+        },
+        history: [...state.history, { type: "claim", runId: normalizedRunId, at: now }],
+      };
+      await saveStateFile(resolvedPath, nextState);
+      return {
+        ok: true,
+        status: "claimed_new",
+        repo: normalizedRepo,
+        pr: normalizedPr,
+        runId: normalizedRunId,
+        activeRun: nextState.activeRun,
+        previousRun: nextState.previousRun,
+        filePath: resolvedPath,
+      };
+    }
+
+    if (activeRun.runId === normalizedRunId) {
+      const nextState = {
+        ...state,
+        activeRun: {
+          ...activeRun,
+          claimedAt: activeRun.claimedAt ?? now,
+          updatedAt: now,
+        },
+        history: [...state.history, { type: "refresh", runId: normalizedRunId, at: now }],
+      };
+      await saveStateFile(resolvedPath, nextState);
+      return {
+        ok: true,
+        status: "refreshed",
+        repo: normalizedRepo,
+        pr: normalizedPr,
+        runId: normalizedRunId,
+        activeRun: nextState.activeRun,
+        previousRun: nextState.previousRun,
+        filePath: resolvedPath,
+      };
+    }
+
+    if (mode !== "takeover") {
+      return buildConflict({
+        error: RUNNER_OWNERSHIP_ERROR.ACTIVE_RUN_EXISTS,
+        repo: normalizedRepo,
+        pr: normalizedPr,
+        runId: normalizedRunId,
+        activeRun,
+        filePath: resolvedPath,
+        message: `PR ${normalizedRepo}#${normalizedPr} is already owned by run ${activeRun.runId}. Claim failed closed.`,
+      });
+    }
+
+    const nextState = {
+      ...state,
+      activeRun: {
+        runId: normalizedRunId,
+        claimedAt: now,
+        updatedAt: now,
+      },
+      previousRun: {
+        runId: activeRun.runId,
+        replacedAt: now,
+        replacedByRunId: normalizedRunId,
+      },
+      history: [...state.history, {
+        type: "takeover",
+        runId: normalizedRunId,
+        previousRunId: activeRun.runId,
+        at: now,
+      }],
+    };
+    await saveStateFile(resolvedPath, nextState);
+    return {
+      ok: true,
+      status: "taken_over",
+      repo: normalizedRepo,
+      pr: normalizedPr,
+      runId: normalizedRunId,
+      activeRun: nextState.activeRun,
+      previousRun: nextState.previousRun,
+      filePath: resolvedPath,
+    };
+  });
+}
+
+export async function assertRunnerOwnership({
+  repo,
+  pr,
+  runId,
+  cwd = process.cwd(),
+  filePath = null,
+  requireExisting = false,
+} = {}) {
+  const normalizedRepo = normalizeRepoSlug(repo);
+  const normalizedPr = normalizePr(pr);
+  const normalizedRunId = normalizeRunId(runId);
+  const resolvedPath = filePath ?? defaultRunnerCoordinationFilePathForTarget({ repo: normalizedRepo, pr: normalizedPr }, cwd);
+
+  if (normalizedRunId === null) {
+    return buildConflict({
+      error: RUNNER_OWNERSHIP_ERROR.RUN_ID_REQUIRED,
+      repo: normalizedRepo,
+      pr: normalizedPr,
+      runId: null,
+      activeRun: null,
+      filePath: resolvedPath,
+      message: "Runner coordination ownership check requires a non-empty run id.",
+    });
+  }
+
+  const raw = await loadStateFile(resolvedPath);
+  if (raw === null) {
+    if (!requireExisting) {
+      return {
+        ok: true,
+        status: "no_owner_record",
+        repo: normalizedRepo,
+        pr: normalizedPr,
+        runId: normalizedRunId,
+        activeRun: null,
+        filePath: resolvedPath,
+      };
+    }
+
+    return buildConflict({
+      error: RUNNER_OWNERSHIP_ERROR.OWNERSHIP_MISSING,
+      repo: normalizedRepo,
+      pr: normalizedPr,
+      runId: normalizedRunId,
+      activeRun: null,
+      filePath: resolvedPath,
+      message: `PR ${normalizedRepo}#${normalizedPr} has no runner ownership record for async run ${normalizedRunId}.`,
+    });
+  }
+
+  const state = normalizeRunnerCoordinationState(raw, { repo: normalizedRepo, pr: normalizedPr });
+  if (state.activeRun?.runId === normalizedRunId) {
+    return {
+      ok: true,
+      status: "owner_confirmed",
+      repo: normalizedRepo,
+      pr: normalizedPr,
+      runId: normalizedRunId,
+      activeRun: state.activeRun,
+      previousRun: state.previousRun,
+      filePath: resolvedPath,
+    };
+  }
+
+  return buildConflict({
+    error: raw === null ? RUNNER_OWNERSHIP_ERROR.OWNERSHIP_MISSING : RUNNER_OWNERSHIP_ERROR.OWNERSHIP_LOST,
+    repo: normalizedRepo,
+    pr: normalizedPr,
+    runId: normalizedRunId,
+    activeRun: state.activeRun,
+    filePath: resolvedPath,
+    message: state.activeRun?.runId
+      ? `PR ${normalizedRepo}#${normalizedPr} is now owned by run ${state.activeRun.runId}; run ${normalizedRunId} must stop.`
+      : `PR ${normalizedRepo}#${normalizedPr} no longer has an active runner ownership record; run ${normalizedRunId} must stop.`,
+  });
+}
+
+export async function releaseRunnerOwnership({
+  repo,
+  pr,
+  runId,
+  cwd = process.cwd(),
+  filePath = null,
+  now = new Date().toISOString(),
+} = {}) {
+  const normalizedRepo = normalizeRepoSlug(repo);
+  const normalizedPr = normalizePr(pr);
+  const normalizedRunId = normalizeRunId(runId);
+  if (normalizedRunId === null) {
+    return buildConflict({
+      error: RUNNER_OWNERSHIP_ERROR.RUN_ID_REQUIRED,
+      repo: normalizedRepo,
+      pr: normalizedPr,
+      runId: null,
+      activeRun: null,
+      filePath: filePath ?? defaultRunnerCoordinationFilePathForTarget({ repo: normalizedRepo, pr: normalizedPr }, cwd),
+      message: "Runner coordination release requires a non-empty run id.",
+    });
+  }
+
+  const resolvedPath = filePath ?? defaultRunnerCoordinationFilePathForTarget({ repo: normalizedRepo, pr: normalizedPr }, cwd);
+  return withStateFileLock(resolvedPath, async () => {
+    const raw = await loadStateFile(resolvedPath);
+    if (raw === null) {
+      return {
+        ok: true,
+        status: "release_noop",
+        repo: normalizedRepo,
+        pr: normalizedPr,
+        runId: normalizedRunId,
+        activeRun: null,
+        filePath: resolvedPath,
+      };
+    }
+
+    const state = normalizeRunnerCoordinationState(raw, { repo: normalizedRepo, pr: normalizedPr });
+    if (state.activeRun?.runId !== normalizedRunId) {
+      return buildConflict({
+        error: RUNNER_OWNERSHIP_ERROR.OWNERSHIP_LOST,
+        repo: normalizedRepo,
+        pr: normalizedPr,
+        runId: normalizedRunId,
+        activeRun: state.activeRun,
+        filePath: resolvedPath,
+        message: state.activeRun?.runId
+          ? `Cannot release PR ${normalizedRepo}#${normalizedPr}: active owner is ${state.activeRun.runId}, not ${normalizedRunId}.`
+          : `Cannot release PR ${normalizedRepo}#${normalizedPr}: no active owner record remains for ${normalizedRunId}.`,
+      });
+    }
+
+    const nextState = {
+      ...state,
+      activeRun: null,
+      previousRun: {
+        runId: normalizedRunId,
+        replacedAt: now,
+        replacedByRunId: null,
+      },
+      history: [...state.history, { type: "release", runId: normalizedRunId, at: now }],
+    };
+    await saveStateFile(resolvedPath, nextState);
+    return {
+      ok: true,
+      status: "released",
+      repo: normalizedRepo,
+      pr: normalizedPr,
+      runId: normalizedRunId,
+      activeRun: null,
+      previousRun: nextState.previousRun,
+      filePath: resolvedPath,
+    };
+  });
+}
+
+export async function ensureAsyncRunnerOwnership({
+  repo,
+  pr,
+  env = process.env,
+  cwd = process.cwd(),
+  claimIfMissing = true,
+  requireExisting = false,
+} = {}) {
+  const runId = normalizeRunId(env?.PI_SUBAGENT_RUN_ID);
+  if (runId === null) {
+    return {
+      ok: true,
+      status: "skipped_no_async_run_id",
+      repo: normalizeRepoSlug(repo),
+      pr: normalizePr(pr),
+      runId: null,
+      activeRun: null,
+      filePath: defaultRunnerCoordinationFilePathForTarget({ repo, pr }, cwd),
+    };
+  }
+
+  const asserted = await assertRunnerOwnership({ repo, pr, runId, cwd, requireExisting });
+  if (asserted.ok) {
+    return asserted;
+  }
+
+  if (!claimIfMissing || asserted.error !== RUNNER_OWNERSHIP_ERROR.OWNERSHIP_MISSING) {
+    return asserted;
+  }
+
+  return claimRunnerOwnership({ repo, pr, runId, cwd, mode: "claim" });
+}

--- a/scripts/loop/_pr-runner-coordination.mjs
+++ b/scripts/loop/_pr-runner-coordination.mjs
@@ -340,7 +340,32 @@ export async function assertRunnerOwnership({
   }
 
   const state = normalizeRunnerCoordinationState(raw, { repo: normalizedRepo, pr: normalizedPr });
-  if (state.activeRun?.runId === normalizedRunId) {
+  if (state.activeRun === null) {
+    if (!requireExisting) {
+      return {
+        ok: true,
+        status: "no_owner_record",
+        repo: normalizedRepo,
+        pr: normalizedPr,
+        runId: normalizedRunId,
+        activeRun: null,
+        previousRun: state.previousRun,
+        filePath: resolvedPath,
+      };
+    }
+
+    return buildConflict({
+      error: RUNNER_OWNERSHIP_ERROR.OWNERSHIP_MISSING,
+      repo: normalizedRepo,
+      pr: normalizedPr,
+      runId: normalizedRunId,
+      activeRun: null,
+      filePath: resolvedPath,
+      message: `PR ${normalizedRepo}#${normalizedPr} has no active runner ownership record for async run ${normalizedRunId}.`,
+    });
+  }
+
+  if (state.activeRun.runId === normalizedRunId) {
     return {
       ok: true,
       status: "owner_confirmed",
@@ -465,11 +490,19 @@ export async function ensureAsyncRunnerOwnership({
   }
 
   const asserted = await assertRunnerOwnership({ repo, pr, runId, cwd, requireExisting });
-  if (asserted.ok) {
+  if (asserted.ok && asserted.status !== "no_owner_record") {
     return asserted;
   }
 
-  if (!claimIfMissing || asserted.error !== RUNNER_OWNERSHIP_ERROR.OWNERSHIP_MISSING) {
+  if (!claimIfMissing) {
+    return asserted;
+  }
+
+  if (asserted.ok && asserted.status === "no_owner_record") {
+    return claimRunnerOwnership({ repo, pr, runId, cwd, mode: "claim" });
+  }
+
+  if (asserted.error !== RUNNER_OWNERSHIP_ERROR.OWNERSHIP_MISSING) {
     return asserted;
   }
 

--- a/scripts/loop/_pr-runner-coordination.mjs
+++ b/scripts/loop/_pr-runner-coordination.mjs
@@ -10,7 +10,6 @@ export const RUNNER_OWNERSHIP_ERROR = Object.freeze({
   OWNERSHIP_LOST: "ownership_lost",
   OWNERSHIP_MISSING: "ownership_missing",
   RUN_ID_REQUIRED: "run_id_required",
-  INVALID_TARGET: "invalid_target",
 });
 
 function normalizeRepoSlug(repo) {
@@ -355,7 +354,7 @@ export async function assertRunnerOwnership({
   }
 
   return buildConflict({
-    error: raw === null ? RUNNER_OWNERSHIP_ERROR.OWNERSHIP_MISSING : RUNNER_OWNERSHIP_ERROR.OWNERSHIP_LOST,
+    error: RUNNER_OWNERSHIP_ERROR.OWNERSHIP_LOST,
     repo: normalizedRepo,
     pr: normalizedPr,
     runId: normalizedRunId,

--- a/scripts/loop/_pr-runner-coordination.mjs
+++ b/scripts/loop/_pr-runner-coordination.mjs
@@ -2,7 +2,11 @@ import path from "node:path";
 import process from "node:process";
 
 import { parseRepoSlugParts } from "@pi-dev-loops/core/github/repo-slug";
-import { loadStateFile, saveStateFile, withStateFileLock } from "./_steering-state-file.mjs";
+import {
+  loadStateFile as loadSharedStateFile,
+  saveStateFile as saveSharedStateFile,
+  withStateFileLock as withSharedStateFileLock,
+} from "./_steering-state-file.mjs";
 
 export const RUNNER_COORDINATION_SCHEMA_VERSION = 1;
 export const RUNNER_OWNERSHIP_ERROR = Object.freeze({
@@ -32,6 +36,33 @@ function normalizeRunId(runId) {
   return typeof runId === "string" && runId.trim().length > 0
     ? runId.trim()
     : null;
+}
+
+async function loadRunnerStateFile(filePath) {
+  try {
+    return await loadSharedStateFile(filePath);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read runner coordination state file '${filePath}': ${message}`);
+  }
+}
+
+async function saveRunnerStateFile(filePath, state) {
+  try {
+    return await saveSharedStateFile(filePath, state);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to write runner coordination state file '${filePath}': ${message}`);
+  }
+}
+
+async function withRunnerStateFileLock(filePath, callback) {
+  try {
+    return await withSharedStateFileLock(filePath, callback);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to acquire runner coordination state lock for '${filePath}': ${message}`);
+  }
 }
 
 export function defaultRunnerCoordinationFilePathForTarget({ repo, pr }, cwd = process.cwd()) {
@@ -156,7 +187,7 @@ export async function loadRunnerCoordinationState({ repo, pr, cwd = process.cwd(
   const normalizedRepo = normalizeRepoSlug(repo);
   const normalizedPr = normalizePr(pr);
   const resolvedPath = filePath ?? defaultRunnerCoordinationFilePathForTarget({ repo: normalizedRepo, pr: normalizedPr }, cwd);
-  const raw = await loadStateFile(resolvedPath);
+  const raw = await loadRunnerStateFile(resolvedPath);
   if (raw === null) {
     return { filePath: resolvedPath, state: null };
   }
@@ -191,8 +222,8 @@ export async function claimRunnerOwnership({
   }
 
   const resolvedPath = filePath ?? defaultRunnerCoordinationFilePathForTarget({ repo: normalizedRepo, pr: normalizedPr }, cwd);
-  return withStateFileLock(resolvedPath, async () => {
-    const raw = await loadStateFile(resolvedPath);
+  return withRunnerStateFileLock(resolvedPath, async () => {
+    const raw = await loadRunnerStateFile(resolvedPath);
     const state = raw === null
       ? createRunnerCoordinationState({ repo: normalizedRepo, pr: normalizedPr })
       : normalizeRunnerCoordinationState(raw, { repo: normalizedRepo, pr: normalizedPr });
@@ -208,7 +239,7 @@ export async function claimRunnerOwnership({
         },
         history: [...state.history, { type: "claim", runId: normalizedRunId, at: now }],
       };
-      await saveStateFile(resolvedPath, nextState);
+      await saveRunnerStateFile(resolvedPath, nextState);
       return {
         ok: true,
         status: "claimed_new",
@@ -231,7 +262,7 @@ export async function claimRunnerOwnership({
         },
         history: [...state.history, { type: "refresh", runId: normalizedRunId, at: now }],
       };
-      await saveStateFile(resolvedPath, nextState);
+      await saveRunnerStateFile(resolvedPath, nextState);
       return {
         ok: true,
         status: "refreshed",
@@ -275,7 +306,7 @@ export async function claimRunnerOwnership({
         at: now,
       }],
     };
-    await saveStateFile(resolvedPath, nextState);
+    await saveRunnerStateFile(resolvedPath, nextState);
     return {
       ok: true,
       status: "taken_over",
@@ -314,7 +345,7 @@ export async function assertRunnerOwnership({
     });
   }
 
-  const raw = await loadStateFile(resolvedPath);
+  const raw = await loadRunnerStateFile(resolvedPath);
   if (raw === null) {
     if (!requireExisting) {
       return {
@@ -415,8 +446,8 @@ export async function releaseRunnerOwnership({
   }
 
   const resolvedPath = filePath ?? defaultRunnerCoordinationFilePathForTarget({ repo: normalizedRepo, pr: normalizedPr }, cwd);
-  return withStateFileLock(resolvedPath, async () => {
-    const raw = await loadStateFile(resolvedPath);
+  return withRunnerStateFileLock(resolvedPath, async () => {
+    const raw = await loadRunnerStateFile(resolvedPath);
     if (raw === null) {
       return {
         ok: true,
@@ -454,7 +485,7 @@ export async function releaseRunnerOwnership({
       },
       history: [...state.history, { type: "release", runId: normalizedRunId, at: now }],
     };
-    await saveStateFile(resolvedPath, nextState);
+    await saveRunnerStateFile(resolvedPath, nextState);
     return {
       ok: true,
       status: "released",

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -268,7 +268,7 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
         routingState: "non_ready_state",
         watchEntryConfirmed: false,
         watchArgs: null,
-        stopState: "runner_ownership_conflict",
+        stopState: "blocked",
       },
     };
   }

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -47,6 +47,7 @@ import { loadDevLoopConfig, resolveRefinement } from "@pi-dev-loops/core/config"
 import { autoDetectSnapshot } from "./detect-copilot-loop-state.mjs";
 import { performCopilotReviewRequest } from "../github/request-copilot-review.mjs";
 import { applyConfirmedReviewRequest, interpretLoopState, STATE, summarizeLoopInterpretation } from "@pi-dev-loops/core/loop/copilot-loop-state";
+import { ensureAsyncRunnerOwnership } from "./_pr-runner-coordination.mjs";
 import {
   EXTERNAL_HEALTHY_WAIT_TIMEOUT_POLICY,
   enforceExternalHealthyWaitTimeout,
@@ -239,6 +240,39 @@ export function parseHandoffCliArgs(argv) {
  * Returns the result payload without writing to stdout.
  */
 export async function runHandoff(options, { env = process.env, ghCommand = "gh" } = {}) {
+  const runnerOwnership = await ensureAsyncRunnerOwnership({
+    repo: options.repo,
+    pr: options.pr,
+    env,
+    cwd: path.resolve(process.cwd()),
+    claimIfMissing: true,
+  });
+  if (!runnerOwnership.ok) {
+    return {
+      ok: true,
+      action: "stop",
+      state: STATE.BLOCKED_NEEDS_USER_DECISION,
+      allowedTransitions: [],
+      nextAction: runnerOwnership.message,
+      autoRerequestEligible: false,
+      sameHeadCleanConverged: false,
+      roundCapCleanEligible: false,
+      loopDisposition: "blocked",
+      terminal: true,
+      snapshot: { repo: options.repo, pr: options.pr },
+      runnerOwnership,
+      requestWatchContract: {
+        action: "stop",
+        nextAction: runnerOwnership.message,
+        requestStatus: "none",
+        routingState: "non_ready_state",
+        watchEntryConfirmed: false,
+        watchArgs: null,
+        stopState: "runner_ownership_conflict",
+      },
+    };
+  }
+
   let snapshot = await autoDetectSnapshot(
     { repo: options.repo, pr: options.pr },
     { env, ghCommand },
@@ -304,6 +338,10 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
     terminal: interpretationSummary.terminal,
     snapshot,
   };
+
+  if (runnerOwnership.status !== "skipped_no_async_run_id") {
+    result.runnerOwnership = runnerOwnership;
+  }
 
   if (effectiveReviewRequestStatus !== undefined) {
     result.reviewRequestStatus = effectiveReviewRequestStatus;

--- a/scripts/loop/pr-runner-coordination.mjs
+++ b/scripts/loop/pr-runner-coordination.mjs
@@ -7,7 +7,6 @@ import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import {
   assertRunnerOwnership,
   claimRunnerOwnership,
-  ensureAsyncRunnerOwnership,
   loadRunnerCoordinationState,
   releaseRunnerOwnership,
 } from "./_pr-runner-coordination.mjs";
@@ -23,9 +22,9 @@ Durable one-runner-per-PR coordination helper.
 
 If --run-id is omitted for claim/assert/release/takeover, PI_SUBAGENT_RUN_ID is used.
 
-Output (stdout, JSON):
-  { "ok": true, ... }
-  { "ok": false, "error": "...", ... }
+Output:
+  stdout: { "ok": true, ... }
+  stderr: { "ok": false, "error": "...", ... }
 
 Exit codes:
   0  Success / clean stop-compatible result
@@ -146,8 +145,7 @@ export async function runPrRunnerCoordination(options, { env = process.env, cwd 
     return releaseRunnerOwnership({ repo: options.repo, pr: options.pr, runId, cwd });
   }
 
-  const fallback = await ensureAsyncRunnerOwnership({ repo: options.repo, pr: options.pr, env, cwd });
-  return fallback;
+  throw new Error(`Unhandled runner coordination command: ${options.command}`);
 }
 
 async function main() {

--- a/scripts/loop/pr-runner-coordination.mjs
+++ b/scripts/loop/pr-runner-coordination.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+import process from "node:process";
+
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { parsePrNumber, requireOptionValue } from "../_cli-primitives.mjs";
+import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import {
+  assertRunnerOwnership,
+  claimRunnerOwnership,
+  ensureAsyncRunnerOwnership,
+  loadRunnerCoordinationState,
+  releaseRunnerOwnership,
+} from "./_pr-runner-coordination.mjs";
+
+const USAGE = `Usage:
+  pr-runner-coordination.mjs status --repo <owner/name> --pr <number>
+  pr-runner-coordination.mjs claim --repo <owner/name> --pr <number> [--run-id <id>]
+  pr-runner-coordination.mjs takeover --repo <owner/name> --pr <number> [--run-id <id>]
+  pr-runner-coordination.mjs assert --repo <owner/name> --pr <number> [--run-id <id>] [--require-existing]
+  pr-runner-coordination.mjs release --repo <owner/name> --pr <number> [--run-id <id>]
+
+Durable one-runner-per-PR coordination helper.
+
+If --run-id is omitted for claim/assert/release/takeover, PI_SUBAGENT_RUN_ID is used.
+
+Output (stdout, JSON):
+  { "ok": true, ... }
+  { "ok": false, "error": "...", ... }
+
+Exit codes:
+  0  Success / clean stop-compatible result
+  1  Argument error or coordination conflict`.trim();
+
+const parseError = buildParseError(USAGE);
+
+function parseCliArgs(argv) {
+  const args = [...argv];
+  const options = {
+    help: false,
+    command: null,
+    repo: undefined,
+    pr: undefined,
+    runId: undefined,
+    requireExisting: false,
+  };
+
+  const command = args.shift();
+  if (command === undefined || command === "--help" || command === "-h") {
+    options.help = true;
+    return options;
+  }
+
+  options.command = command;
+
+  while (args.length > 0) {
+    const token = args.shift();
+
+    if (token === "--help" || token === "-h") {
+      options.help = true;
+      return options;
+    }
+
+    if (token === "--repo") {
+      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+      continue;
+    }
+
+    if (token === "--pr") {
+      options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+      continue;
+    }
+
+    if (token === "--run-id") {
+      options.runId = requireOptionValue(args, "--run-id", parseError).trim();
+      continue;
+    }
+
+    if (token === "--require-existing") {
+      options.requireExisting = true;
+      continue;
+    }
+
+    throw parseError(`Unknown argument: ${token}`);
+  }
+
+  const validCommands = new Set(["status", "claim", "takeover", "assert", "release"]);
+  if (!validCommands.has(options.command)) {
+    throw parseError(`Unknown subcommand: ${options.command}`);
+  }
+
+  if (options.repo === undefined || options.pr === undefined) {
+    throw parseError("pr-runner-coordination requires both --repo <owner/name> and --pr <number>");
+  }
+
+  try {
+    parseRepoSlug(options.repo);
+  } catch (error) {
+    throw parseError(error instanceof Error ? error.message : String(error));
+  }
+
+  return options;
+}
+
+function resolveRunId(explicitRunId, env) {
+  return typeof explicitRunId === "string" && explicitRunId.trim().length > 0
+    ? explicitRunId.trim()
+    : (typeof env?.PI_SUBAGENT_RUN_ID === "string" && env.PI_SUBAGENT_RUN_ID.trim().length > 0
+      ? env.PI_SUBAGENT_RUN_ID.trim()
+      : null);
+}
+
+export async function runPrRunnerCoordination(options, { env = process.env, cwd = process.cwd() } = {}) {
+  if (options.command === "status") {
+    const { filePath, state } = await loadRunnerCoordinationState({ repo: options.repo, pr: options.pr, cwd });
+    return {
+      ok: true,
+      command: "status",
+      repo: options.repo,
+      pr: options.pr,
+      filePath,
+      state,
+    };
+  }
+
+  const runId = resolveRunId(options.runId, env);
+
+  if (options.command === "claim") {
+    return claimRunnerOwnership({ repo: options.repo, pr: options.pr, runId, mode: "claim", cwd });
+  }
+
+  if (options.command === "takeover") {
+    return claimRunnerOwnership({ repo: options.repo, pr: options.pr, runId, mode: "takeover", cwd });
+  }
+
+  if (options.command === "assert") {
+    return assertRunnerOwnership({
+      repo: options.repo,
+      pr: options.pr,
+      runId,
+      requireExisting: options.requireExisting,
+      cwd,
+    });
+  }
+
+  if (options.command === "release") {
+    return releaseRunnerOwnership({ repo: options.repo, pr: options.pr, runId, cwd });
+  }
+
+  const fallback = await ensureAsyncRunnerOwnership({ repo: options.repo, pr: options.pr, env, cwd });
+  return fallback;
+}
+
+async function main() {
+  try {
+    const options = parseCliArgs(process.argv.slice(2));
+    if (options.help) {
+      console.log(USAGE);
+      return;
+    }
+
+    const result = await runPrRunnerCoordination(options, { env: process.env });
+    if (!result.ok) {
+      console.error(JSON.stringify(result));
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log(JSON.stringify(result));
+  } catch (error) {
+    const payload = formatCliError(error, { usage: USAGE });
+    console.error(JSON.stringify(payload));
+    process.exitCode = 1;
+  }
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  await main();
+}

--- a/scripts/loop/pr-runner-coordination.mjs
+++ b/scripts/loop/pr-runner-coordination.mjs
@@ -114,7 +114,7 @@ export async function runPrRunnerCoordination(options, { env = process.env, cwd 
     return {
       ok: true,
       command: "status",
-      repo: options.repo,
+      repo: options.repo.trim().toLowerCase(),
       pr: options.pr,
       filePath,
       state,

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -16,14 +16,22 @@ import {
   parseDetectCheckpointEvidenceCliArgs,
   buildPreMergeGateCheck,
 } from "../../scripts/github/detect-checkpoint-evidence.mjs";
+import { claimRunnerOwnership } from "../../scripts/loop/_pr-runner-coordination.mjs";
 
 const scriptPath = path.resolve("scripts/github/detect-checkpoint-evidence.mjs");
 
-const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, {
+  ...options,
+  env: {
+    ...process.env,
+    ...(options.env ?? {}),
+    PI_SUBAGENT_RUN_ID: options.env?.PI_SUBAGENT_RUN_ID ?? "",
+  },
+});
 
 async function writeGhStub(tempDir, entries) {
   const { env } = await writeGhStubHelper(tempDir, entries, { repeatLastOnOverflow: true });
-  return env;
+  return { ...env, PI_SUBAGENT_RUN_ID: "" };
 }
 
 test("parseGateReviewCommentBody parses the deterministic visible gate comment format", () => {
@@ -791,4 +799,46 @@ test("buildPreMergeGateCheck passes with zero unresolved threads", () => {
   const result = buildPreMergeGateCheck(evidence, 0);
   assert.equal(result.ok, true);
   assert.deepEqual(result.failures, []);
+});
+
+
+test("detect-checkpoint-evidence fails closed when async run no longer owns the PR", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-checkpoint-evidence-ownership-"));
+
+  try {
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-active", cwd: tempDir });
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], {
+      cwd: tempDir,
+      env: { ...process.env, PI_SUBAGENT_RUN_ID: "run-stale" },
+    });
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const error = JSON.parse(result.stderr);
+    assert.equal(error.ok, false);
+    assert.equal(error.error, "ownership_lost");
+    assert.equal(error.activeRun.runId, "run-active");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-checkpoint-evidence fails closed when async run has no ownership record", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-checkpoint-evidence-ownership-"));
+
+  try {
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], {
+      cwd: tempDir,
+      env: { ...process.env, PI_SUBAGENT_RUN_ID: "run-stale" },
+    });
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const error = JSON.parse(result.stderr);
+    assert.equal(error.ok, false);
+    assert.equal(error.error, "ownership_missing");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
 });

--- a/test/github/reconcile-draft-gate.test.mjs
+++ b/test/github/reconcile-draft-gate.test.mjs
@@ -12,11 +12,18 @@ import {
 
 const scriptPath = path.resolve("scripts/github/reconcile-draft-gate.mjs");
 
-const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, {
+  ...options,
+  env: {
+    ...process.env,
+    ...(options.env ?? {}),
+    PI_SUBAGENT_RUN_ID: options.env?.PI_SUBAGENT_RUN_ID ?? "",
+  },
+});
 
 async function writeGhStub(tempDir, entries) {
   const { env } = await writeGhStubHelper(tempDir, entries, { repeatLastOnOverflow: true });
-  return env;
+  return { ...env, PI_SUBAGENT_RUN_ID: "" };
 }
 
 async function readGhCallCount(tempDir) {

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -14,11 +14,18 @@ import {
 
 const scriptPath = path.resolve("scripts/github/upsert-checkpoint-verdict.mjs");
 
-const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, {
+  ...options,
+  env: {
+    ...process.env,
+    ...(options.env ?? {}),
+    PI_SUBAGENT_RUN_ID: options.env?.PI_SUBAGENT_RUN_ID ?? "",
+  },
+});
 
 async function writeGhStub(tempDir, entries) {
   const { env } = await writeGhStubHelper(tempDir, entries, { repeatLastOnOverflow: true });
-  return env;
+  return { ...env, PI_SUBAGENT_RUN_ID: "" };
 }
 
 function buildGateCoordinationEntries({

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -7,11 +7,19 @@ import test from "node:test";
 import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import { parseHandoffCliArgs } from "../../scripts/loop/copilot-pr-handoff.mjs";
+import { claimRunnerOwnership } from "../../scripts/loop/_pr-runner-coordination.mjs";
 import { EXTERNAL_HEALTHY_WAIT_TIMEOUT_POLICY } from "../../packages/core/src/loop/timeout-policy.mjs";
 
 const scriptPath = path.resolve("scripts/loop/copilot-pr-handoff.mjs");
 
-const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, {
+  ...options,
+  env: {
+    ...process.env,
+    ...(options.env ?? {}),
+    PI_SUBAGENT_RUN_ID: options.env?.PI_SUBAGENT_RUN_ID ?? "",
+  },
+});
 
 /**
  * Write a gh stub that responds to a sequence of calls.
@@ -19,7 +27,7 @@ const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, opt
  */
 async function writeGhStub(tempDir, entries) {
   const { env } = await writeGhStubHelper(tempDir, entries);
-  return env;
+  return { ...env, PI_SUBAGENT_RUN_ID: "" };
 }
 
 const EMPTY_THREADS = JSON.stringify({
@@ -1507,6 +1515,35 @@ test("copilot-pr-handoff classifies watch timeout with CI still pending as non-t
     assert.equal(output.terminal, false);
     assert.equal(output.sameHeadCleanConverged, false);
     assert.equal(output.watchArgs, undefined);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+
+test("copilot-pr-handoff stops cleanly when another run already owns the PR", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-ownership-"));
+
+  try {
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-active", cwd: tempDir });
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], {
+      cwd: tempDir,
+      env: { ...process.env, PI_SUBAGENT_RUN_ID: "run-new" },
+    });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.action, "stop");
+    assert.equal(output.state, "blocked_needs_user_decision");
+    assert.equal(output.loopDisposition, "blocked");
+    assert.equal(output.terminal, true);
+    assert.equal(output.runnerOwnership.ok, false);
+    assert.equal(output.runnerOwnership.error, "ownership_lost");
+    assert.equal(output.runnerOwnership.activeRun.runId, "run-active");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -10,11 +10,18 @@ import { detectPrGateCoordinationState, parseGitStatusConflictFiles } from "../.
 
 const scriptPath = path.resolve("scripts/loop/detect-pr-gate-coordination-state.mjs");
 
-const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, {
+  ...options,
+  env: {
+    ...process.env,
+    ...(options.env ?? {}),
+    PI_SUBAGENT_RUN_ID: options.env?.PI_SUBAGENT_RUN_ID ?? "",
+  },
+});
 
 async function writeGhStub(tempDir, entries) {
   const { env } = await writeGhStubHelper(tempDir, entries);
-  return env;
+  return { ...env, PI_SUBAGENT_RUN_ID: "" };
 }
 
 async function writeGitStub(tempDir, { stdout = "", stderr = "", exitCode = 0, assertArgs = [] } = {}) {

--- a/test/loop/pr-runner-coordination.test.mjs
+++ b/test/loop/pr-runner-coordination.test.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  assertRunnerOwnership,
+  claimRunnerOwnership,
+  defaultRunnerCoordinationFilePathForTarget,
+  loadRunnerCoordinationState,
+  releaseRunnerOwnership,
+} from "../../scripts/loop/_pr-runner-coordination.mjs";
+import { runPrRunnerCoordination } from "../../scripts/loop/pr-runner-coordination.mjs";
+
+test("runner coordination claims empty PR ownership and refreshes same run", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-runner-coordination-"));
+
+  try {
+    const claimed = await claimRunnerOwnership({
+      repo: "owner/repo",
+      pr: 17,
+      runId: "run-1",
+      cwd: tempDir,
+      now: "2026-06-05T08:00:00.000Z",
+    });
+    assert.equal(claimed.ok, true);
+    assert.equal(claimed.status, "claimed_new");
+    assert.equal(claimed.activeRun.runId, "run-1");
+
+    const refreshed = await claimRunnerOwnership({
+      repo: "owner/repo",
+      pr: 17,
+      runId: "run-1",
+      cwd: tempDir,
+      now: "2026-06-05T08:05:00.000Z",
+    });
+    assert.equal(refreshed.ok, true);
+    assert.equal(refreshed.status, "refreshed");
+    assert.equal(refreshed.activeRun.updatedAt, "2026-06-05T08:05:00.000Z");
+
+    const loaded = await loadRunnerCoordinationState({ repo: "owner/repo", pr: 17, cwd: tempDir });
+    assert.equal(loaded.state.activeRun.runId, "run-1");
+    assert.equal(loaded.state.history.length, 2);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("runner coordination fails closed for second claim and allows explicit takeover", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-runner-coordination-"));
+
+  try {
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-1", cwd: tempDir, now: "2026-06-05T08:00:00.000Z" });
+
+    const conflict = await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-2", cwd: tempDir });
+    assert.equal(conflict.ok, false);
+    assert.equal(conflict.error, "active_run_exists");
+    assert.equal(conflict.activeRun.runId, "run-1");
+
+    const takeover = await claimRunnerOwnership({
+      repo: "owner/repo",
+      pr: 17,
+      runId: "run-2",
+      cwd: tempDir,
+      mode: "takeover",
+      now: "2026-06-05T08:10:00.000Z",
+    });
+    assert.equal(takeover.ok, true);
+    assert.equal(takeover.status, "taken_over");
+    assert.equal(takeover.activeRun.runId, "run-2");
+    assert.equal(takeover.previousRun.runId, "run-1");
+
+    const staleAssert = await assertRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-1", cwd: tempDir, requireExisting: true });
+    assert.equal(staleAssert.ok, false);
+    assert.equal(staleAssert.error, "ownership_lost");
+    assert.equal(staleAssert.activeRun.runId, "run-2");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("runner coordination pre-merge assert requires existing owner record for async runs", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-runner-coordination-"));
+
+  try {
+    const missing = await assertRunnerOwnership({
+      repo: "owner/repo",
+      pr: 17,
+      runId: "run-1",
+      cwd: tempDir,
+      requireExisting: true,
+    });
+    assert.equal(missing.ok, false);
+    assert.equal(missing.error, "ownership_missing");
+
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-1", cwd: tempDir });
+    const asserted = await assertRunnerOwnership({
+      repo: "owner/repo",
+      pr: 17,
+      runId: "run-1",
+      cwd: tempDir,
+      requireExisting: true,
+    });
+    assert.equal(asserted.ok, true);
+    assert.equal(asserted.status, "owner_confirmed");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("runner coordination release clears active owner", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-runner-coordination-"));
+
+  try {
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-1", cwd: tempDir });
+    const released = await releaseRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-1", cwd: tempDir });
+    assert.equal(released.ok, true);
+    assert.equal(released.status, "released");
+
+    const loaded = await loadRunnerCoordinationState({ repo: "owner/repo", pr: 17, cwd: tempDir });
+    assert.equal(loaded.state.activeRun, null);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("pr-runner-coordination CLI facade returns machine-readable conflicts", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-runner-coordination-"));
+
+  try {
+    const filePath = defaultRunnerCoordinationFilePathForTarget({ repo: "owner/repo", pr: 17 }, tempDir);
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-1", cwd: tempDir });
+
+    const result = await runPrRunnerCoordination({ command: "claim", repo: "owner/repo", pr: 17, runId: "run-2", requireExisting: false }, { env: {}, cwd: tempDir });
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "active_run_exists");
+    assert.equal(result.filePath, filePath);
+
+    const status = await runPrRunnerCoordination({ command: "status", repo: "owner/repo", pr: 17 }, { env: {}, cwd: tempDir });
+    assert.equal(status.ok, true);
+    assert.equal(status.state.activeRun.runId, "run-1");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/loop/pr-runner-coordination.test.mjs
+++ b/test/loop/pr-runner-coordination.test.mjs
@@ -8,6 +8,7 @@ import {
   assertRunnerOwnership,
   claimRunnerOwnership,
   defaultRunnerCoordinationFilePathForTarget,
+  ensureAsyncRunnerOwnership,
   loadRunnerCoordinationState,
   releaseRunnerOwnership,
 } from "../../scripts/loop/_pr-runner-coordination.mjs";
@@ -140,6 +141,59 @@ test("pr-runner-coordination CLI facade returns machine-readable conflicts", asy
     const status = await runPrRunnerCoordination({ command: "status", repo: "owner/repo", pr: 17 }, { env: {}, cwd: tempDir });
     assert.equal(status.ok, true);
     assert.equal(status.state.activeRun.runId, "run-1");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+
+test("ensureAsyncRunnerOwnership auto-claims when no file exists", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-runner-coordination-"));
+
+  try {
+    const result = await ensureAsyncRunnerOwnership({
+      repo: "owner/repo",
+      pr: 17,
+      cwd: tempDir,
+      env: { PI_SUBAGENT_RUN_ID: "run-1" },
+      claimIfMissing: true,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "claimed_new");
+    assert.equal(result.activeRun.runId, "run-1");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("ensureAsyncRunnerOwnership auto-claims after release when no active owner remains", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-runner-coordination-"));
+
+  try {
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-1", cwd: tempDir });
+    await releaseRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-1", cwd: tempDir });
+
+    const result = await ensureAsyncRunnerOwnership({
+      repo: "owner/repo",
+      pr: 17,
+      cwd: tempDir,
+      env: { PI_SUBAGENT_RUN_ID: "run-2" },
+      claimIfMissing: true,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "claimed_new");
+    assert.equal(result.activeRun.runId, "run-2");
+
+    const strict = await ensureAsyncRunnerOwnership({
+      repo: "owner/repo",
+      pr: 18,
+      cwd: tempDir,
+      env: { PI_SUBAGENT_RUN_ID: "run-3" },
+      claimIfMissing: false,
+      requireExisting: true,
+    });
+    assert.equal(strict.ok, false);
+    assert.equal(strict.error, "ownership_missing");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Add durable one-runner-per-PR coordination so async dev-loop runners stop duplicating PR follow-up work and stale runners fail closed before merge.

## Scope / context

Implements issue #509 by adding a dedicated PR runner ownership record, a claim/takeover/assert/release CLI, async follow-up ownership checks in `copilot-pr-handoff`, and an async pre-merge ownership guard in `detect-checkpoint-evidence`.

## Acceptance criteria

- [x] A durable coordination helper records one active dev-loop runner per PR.
- [x] A second runner on the same PR fails closed by default with machine-readable conflict details.
- [x] An explicit takeover path can replace prior ownership and records old/new run ids.
- [x] PR follow-up entrypoints stop when the current run no longer owns the PR.
- [x] Pre-merge gate evidence checks fail closed for async runs that no longer own the PR, so stale runners cannot merge after takeover.
- [x] Tests cover duplicate claim, takeover, stale-owner refusal, and pre-merge ownership refusal.

## Definition of done

- [x] Coordination helper + CLI added under `scripts/loop/`
- [x] Async ownership guard wired into PR handoff and pre-merge evidence check
- [x] Script/docs coverage updated for new coordination behavior
- [x] `npm run verify` passes

## Non-goals

- Killing old OS processes directly
- General coordination for non-PR local-only work
- Replacing conductor monitor session scanning
- Broad fixes for unrelated worktree-loss or gate-comment issues

## Validation

- [x] `npm run verify`

Closes #509
