### PR TITLE
fix(#527): enforce per-iteration round-cap budget check in dev-loop

### DIFF
--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -99,9 +99,10 @@ Strategies where `requiresAsyncDispatch` is `false` (`local_implementation`, `fi
 - Intercom coordination for cross-run state updates
 - Parent session retains loop ownership; subagents handle bounded slices only
 
-**Round-cap budget check (#524, enforced):** After every watch cycle, fix pass, or reply-resolve — and **before** any `request-copilot-review.mjs` re-request — check `detect-copilot-loop-state.mjs` output for `snapshot.copilotReviewRoundCount >= maxCopilotRounds` (default: 5). When the cap is reached, the detector (`interpretLoopState` in `packages/core/src/loop/copilot-loop-state.mjs`) selects one of two explicit `state` values:
+**Round-cap budget check (#524, enforced):** After every watch cycle, fix pass, or reply-resolve — and **before** any `request-copilot-review.mjs` re-request — check `detect-copilot-loop-state.mjs` output for `snapshot.copilotReviewRoundCount >= maxCopilotRounds` (default: 5). When the cap is reached AND no Copilot review request is in flight (i.e., `copilotReviewRequestStatus` is not `"requested"` or `"already-requested"`), the detector (`interpretLoopState` in `packages/core/src/loop/copilot-loop-state.mjs`) selects one of two explicit `state` values:
 - `state: "round_cap_clean_fallback"` — when `unresolvedThreadCount === 0` AND `ciStatus` is `"success"` or `"crediblyGreen"`. Treat this as the `pre_approval_gate` entry signal (do not re-request Copilot review).
 - `state: "round_cap_reached"` — when `unresolvedThreadCount > 0` OR `ciStatus` is not `"success"`/`"crediblyGreen"`. Reply-resolve any remaining intentionally deferred threads with a short `deferred to follow-up` note and stop; do **not** re-request Copilot review.
+- While a Copilot review request is in flight the round-cap routing is suppressed (the state machine preserves the active request instead); only after that request settles does the cap take effect.
 - The round-cap check is a per-iteration gate, not an end-of-loop assertion
 
 **Deterministic routing step (#524):** The pre-delegation gate above determines whether delegation is appropriate. When it returns `action: "stop"` with `terminal: true`, the loop phase is complete — proceed inline to the next gate rather than delegating a polling task.

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -99,9 +99,9 @@ Strategies where `requiresAsyncDispatch` is `false` (`local_implementation`, `fi
 - Intercom coordination for cross-run state updates
 - Parent session retains loop ownership; subagents handle bounded slices only
 
-**Round-cap budget check (#524, enforced):** After every watch cycle, fix pass, or reply-resolve — and **before** any `request-copilot-review.mjs` re-request — check `detect-copilot-loop-state.mjs` output for `snapshot.copilotReviewRoundCount >= maxCopilotRounds` (default: 5). If the cap is reached:
-- With `unresolvedThreadCount === 0` and CI green → use `round_cap_clean_fallback` to enter `pre_approval_gate`
-- With unresolved threads remaining → reply-resolve as `deferred to follow-up` and stop; do **not** re-request Copilot review
+**Round-cap budget check (#524, enforced):** After every watch cycle, fix pass, or reply-resolve — and **before** any `request-copilot-review.mjs` re-request — check `detect-copilot-loop-state.mjs` output for `snapshot.copilotReviewRoundCount >= maxCopilotRounds` (default: 5). When the cap is reached, the detector (`interpretLoopState` in `packages/core/src/loop/copilot-loop-state.mjs`) selects one of two explicit `state` values:
+- `state: "round_cap_clean_fallback"` — when `unresolvedThreadCount === 0` AND `ciStatus` is `"success"` or `"crediblyGreen"`. Treat this as the `pre_approval_gate` entry signal (do not re-request Copilot review).
+- `state: "round_cap_reached"` — when `unresolvedThreadCount > 0` OR `ciStatus` is not `"success"`/`"crediblyGreen"`. Reply-resolve any remaining intentionally deferred threads with a short `deferred to follow-up` note and stop; do **not** re-request Copilot review.
 - The round-cap check is a per-iteration gate, not an end-of-loop assertion
 
 **Deterministic routing step (#524):** The pre-delegation gate above determines whether delegation is appropriate. When it returns `action: "stop"` with `terminal: true`, the loop phase is complete — proceed inline to the next gate rather than delegating a polling task.

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -99,6 +99,11 @@ Strategies where `requiresAsyncDispatch` is `false` (`local_implementation`, `fi
 - Intercom coordination for cross-run state updates
 - Parent session retains loop ownership; subagents handle bounded slices only
 
+**Round-cap budget check (#524, enforced):** After every watch cycle, fix pass, or reply-resolve — and **before** any `request-copilot-review.mjs` re-request — check `detect-copilot-loop-state.mjs` output for `snapshot.copilotReviewRoundCount >= maxCopilotRounds` (default: 5). If the cap is reached:
+- With `unresolvedThreadCount === 0` and CI green → use `round_cap_clean_fallback` to enter `pre_approval_gate`
+- With unresolved threads remaining → reply-resolve as `deferred to follow-up` and stop; do **not** re-request Copilot review
+- The round-cap check is a per-iteration gate, not an end-of-loop assertion
+
 **Deterministic routing step (#524):** The pre-delegation gate above determines whether delegation is appropriate. When it returns `action: "stop"` with `terminal: true`, the loop phase is complete — proceed inline to the next gate rather than delegating a polling task.
 
 ## Shorthand issue-based auto trigger contract

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -99,10 +99,13 @@ Strategies where `requiresAsyncDispatch` is `false` (`local_implementation`, `fi
 - Intercom coordination for cross-run state updates
 - Parent session retains loop ownership; subagents handle bounded slices only
 
-**Round-cap budget check (#524, enforced):** After every watch cycle, fix pass, or reply-resolve — and **before** any `request-copilot-review.mjs` re-request — check `detect-copilot-loop-state.mjs` output for `snapshot.copilotReviewRoundCount >= maxCopilotRounds` (default: 5). When the cap is reached AND no Copilot review request is in flight (i.e., `copilotReviewRequestStatus` is not `"requested"` or `"already-requested"`), the detector (`interpretLoopState` in `packages/core/src/loop/copilot-loop-state.mjs`) selects one of two explicit `state` values:
+**Round-cap budget check (#524, enforced):** After every watch cycle, fix pass, or reply-resolve — and **before** any `request-copilot-review.mjs` re-request — check `detect-copilot-loop-state.mjs` output for `snapshot.copilotReviewRoundCount >= maxCopilotRounds` (default: 5). The detector (`interpretLoopState` in `packages/core/src/loop/copilot-loop-state.mjs`) only emits a `round_cap_*` state when ALL of these are true:
+- the round cap is reached (`copilotReviewRoundCount >= maxCopilotRounds`)
+- no Copilot review request is in flight (`copilotReviewRequestStatus` is not `"requested"` or `"already-requested"`)
+- the detector has not already selected a higher-priority terminal/draft state (`no_pr`, `done`, `pr_draft`, `review_request_unavailable`, `blocked_needs_user_decision`) — those take precedence and round-cap routing is skipped in those cases
+- Given all that, the detector selects one of two explicit `state` values:
 - `state: "round_cap_clean_fallback"` — when `unresolvedThreadCount === 0` AND `ciStatus` is `"success"` or `"crediblyGreen"`. Treat this as the `pre_approval_gate` entry signal (do not re-request Copilot review).
 - `state: "round_cap_reached"` — when `unresolvedThreadCount > 0` OR `ciStatus` is not `"success"`/`"crediblyGreen"`. Reply-resolve any remaining intentionally deferred threads with a short `deferred to follow-up` note and stop; do **not** re-request Copilot review.
-- While a Copilot review request is in flight the round-cap routing is suppressed (the state machine preserves the active request instead); only after that request settles does the cap take effect.
 - The round-cap check is a per-iteration gate, not an end-of-loop assertion
 
 **Deterministic routing step (#524):** The pre-delegation gate above determines whether delegation is appropriate. When it returns `action: "stop"` with `terminal: true`, the loop phase is complete — proceed inline to the next gate rather than delegating a polling task.


### PR DESCRIPTION
Fixes #527

## Problem

During PR #526 (fix for #524), the Copilot review loop went to **7 rounds** despite `maxCopilotRounds: 5` in config. The fix loop (watch → detect → fix → reply-resolve → re-request) only discovered the cap was blown at the end via `detect-copilot-loop-state.mjs` returning `state: "round_cap_reached"`. It never checked the budget **between iterations**.

## Fix

Add an explicit **round-cap budget check** as a per-iteration enforced guard rule in `skills/dev-loop/SKILL.md`. The rule enforces:

- The check runs after every watch cycle, fix pass, or reply-resolve — **before** any `request-copilot-review.mjs` re-request
- It reads `snapshot.copilotReviewRoundCount` from `detect-copilot-loop-state.mjs` output
- When the cap is reached with `unresolvedThreadCount === 0` and CI green → use `round_cap_clean_fallback` to enter `pre_approval_gate`
- When unresolved threads remain → reply-resolve as `deferred to follow-up` and stop; do **not** re-request Copilot review
- The check is a per-iteration gate, not an end-of-loop assertion

## Scope

- `skills/dev-loop/SKILL.md` — adds the guard rule block

The fix mirrors the locally-committed `989e332` on `origin/fix/524-dev-loop-subagent-delegation` (post #526 merge) that was never pushed.

## Verification

- `npm run verify` green (85 assets + 46 extension + 1134 scripts + 1005 core + docs + 10 dev-loop tests)
- No new tests required: this is a procedural guard rule in skill documentation, the underlying helpers (`detect-copilot-loop-state.mjs`, `round_cap_clean_fallback`) already exist

## Related

- PR #526 (merged) — original fix for #524
- Issue #524 — async delegation guard rules (parent issue)
- Issue #527 — this fix
