### PR TITLE
fix(#500): enable dynamic gate angle resolution in repo settings

### DIFF
--- a/.pi/dev-loop/settings.yaml
+++ b/.pi/dev-loop/settings.yaml
@@ -2,6 +2,7 @@ version: 1
 
 gates:
   draft:
+    dynamicAngles: true
     angles:
       - scope
       - coverage


### PR DESCRIPTION
## Problem

Issue #500 ("Context-builder should dynamically resolve which gate angles to run based on diff analysis") was closed via PR #503 with the `resolveGateAnglesDynamic` function implemented and tested, and the opt-in config key `gates.draft.dynamicAngles` added. However, the repo's own `.pi/dev-loop/settings.yaml` never set `dynamicAngles: true`, so all 13 draft angles continue to run by default — defeating the optimization the issue was filed for.

## Fix

One-line config flip in `.pi/dev-loop/settings.yaml`: add `dynamicAngles: true` under `gates.draft`. Opt in to the diff-based dynamic angle resolution that #500 implemented.

## Why now

PR #498 (a mechanical rename) triggered 9 of 13 trivially-clean draft angles. #500's design — and the dynamicAngles function — was meant to short-circuit that. Without this opt-in, the implementation is dead code from a runtime-cost perspective.

## Behavior change

- Before: all 13 angles fan out per draft gate (~13 reviewers, ~13 parallel subagent runs).
- After: context-builder analyzes the diff and recommends a focused angle subset; reviewers fan out only over recommended angles.
- Fallback: empty/ambiguous diff analysis → all angles (safe default, already implemented in `resolveGateAnglesDynamic`).

## Verification

- `npm run verify` is green.
- New config value loaded via `loadConfig` (already covered by config tests in `packages/core/test/config.test.mjs`).

## Out of scope

- `preApproval.dynamicAngles` is intentionally left off — pre-approval gates are rare and the cost of running all 12 angles is acceptable for the merge-time criticality.
- No changes to the angle lexicon, the `resolveGateAnglesDynamic` function, or the round-cap enforcement (those were landed in PR #503).

## Related

- #500 — parent issue (closed)
- PR #503 — implementation of `resolveGateAnglesDynamic`
- PR #498 — mechanical rename that motivated #500