### PR TITLE
fix(#532): draft gate must verify linked issue has refinement artifact (ACs/DoD)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,7 @@
     "./loop/copilot-ci-status": "./src/loop/copilot-ci-status.mjs",
     "./loop/copilot-loop-iterations": "./src/loop/copilot-loop-iterations.mjs",
     "./loop/copilot-loop-state": "./src/loop/copilot-loop-state.mjs",
+    "./loop/issue-refinement-artifact": "./src/loop/issue-refinement-artifact.mjs",
     "./loop/phase-files": "./src/loop/phase-files.mjs",
     "./loop/pr-gate-coordination": "./src/loop/pr-gate-coordination.mjs",
     "./loop/public-dev-loop-routing": "./src/loop/public-dev-loop-routing.mjs",

--- a/packages/core/src/loop/issue-refinement-artifact.mjs
+++ b/packages/core/src/loop/issue-refinement-artifact.mjs
@@ -122,15 +122,6 @@ export function extractChecklistItems(sectionBody) {
   return items;
 }
 
-function extractSectionText(section) {
-  if (!section) {
-    return [];
-  }
-  return section.bodyLines
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-}
-
 /**
  * Detect a linked refinement doc path from the issue body.
  * Looks for explicit `tmp/refinement/<n>-plan.md` style paths and the
@@ -157,13 +148,6 @@ export function detectLinkedRefinementDoc(body, { issueNumber = null } = {}) {
     const inlinePath = /(?:^|\s)(tmp\/refinement\/[^\s)`'"]+\.md)\b/u.exec(refinementSection.bodyLines.join("\n"));
     if (inlinePath) {
       return { found: true, path: inlinePath[1], reason: "refinement-section-path" };
-    }
-    if (Number.isInteger(issueNumber)) {
-      return {
-        found: true,
-        path: `tmp/refinement/${issueNumber}-plan.md`,
-        reason: "refinement-section-convention",
-      };
     }
   }
 
@@ -209,12 +193,6 @@ export function detectIssueRefinementArtifact({ body = "", issueNumber = null } 
 
   const acItems = acceptanceSection ? extractChecklistItems(acceptanceSection.bodyLines.join("\n")) : [];
   const dodItems = dodSection ? extractChecklistItems(dodSection.bodyLines.join("\n")) : [];
-  const acTextItems = !acceptanceSection || acItems.length === 0
-    ? extractSectionText(acceptanceSection ?? null)
-    : [];
-  const dodTextItems = !dodSection || dodItems.length === 0
-    ? extractSectionText(dodSection ?? null)
-    : [];
 
   const linkedDoc = detectLinkedRefinementDoc(body, { issueNumber });
 
@@ -248,37 +226,11 @@ export function detectIssueRefinementArtifact({ body = "", issueNumber = null } 
     return {
       hasACs: true,
       source: REFINEMENT_SOURCE.LINKED_DOC,
-      acItems: acTextItems,
-      dodItems: dodTextItems,
+      acItems: [],
+      dodItems: [],
       sections: sectionNames,
       linkedDoc,
       reason: `Issue body links a refinement doc at ${linkedDoc.path}; treating that as the refinement artifact source.`,
-      finding: null,
-    };
-  }
-
-  if (acTextItems.length > 0) {
-    return {
-      hasACs: true,
-      source: REFINEMENT_SOURCE.ISSUE_BODY_AC,
-      acItems: acTextItems,
-      dodItems: dodTextItems,
-      sections: sectionNames,
-      linkedDoc,
-      reason: `Found ${acTextItems.length} Acceptance criteria text line(s) (no checkbox) in the issue body.`,
-      finding: null,
-    };
-  }
-
-  if (dodTextItems.length > 0) {
-    return {
-      hasACs: true,
-      source: REFINEMENT_SOURCE.ISSUE_BODY_DOD,
-      acItems: acTextItems,
-      dodItems: dodTextItems,
-      sections: sectionNames,
-      linkedDoc,
-      reason: `Found ${dodTextItems.length} DoD text line(s) (no checkbox) in the issue body.`,
       finding: null,
     };
   }

--- a/packages/core/src/loop/issue-refinement-artifact.mjs
+++ b/packages/core/src/loop/issue-refinement-artifact.mjs
@@ -1,0 +1,315 @@
+/**
+ * Deterministic issue refinement-artifact detection.
+ *
+ * Implements the bounded refinement check required by the draft gate per
+ * issue #532: a draft PR cannot leave draft unless the linked issue has an
+ * explicit refinement artifact (Acceptance criteria section, DoD section,
+ * or a linked refinement doc) that the pre-approval gate can verify
+ * against. Prose-only issues (Problem / Root Cause / Fix) without an
+ * `Acceptance criteria` or `DoD` section cause the draft gate to post
+ * `verdict=blocked` with the `missing_refinement_artifact` finding.
+ *
+ * This module owns:
+ * - canonical section-name matching for AC / DoD blocks
+ * - bullet-item extraction (both `- [ ]` and `- [x]`)
+ * - linked-refinement-doc detection from issue body
+ *
+ * It deliberately does NOT:
+ * - auto-generate ACs from prose
+ * - mutate GitHub state
+ * - re-implement the issue<->PR linkage detection (callers own that)
+ */
+
+export const REFINEMENT_SOURCE = Object.freeze({
+  ISSUE_BODY_AC: "issue-body-ac",
+  ISSUE_BODY_DOD: "issue-body-dod",
+  LINKED_DOC: "linked-doc",
+  MISSING: "missing",
+});
+
+const REFINEMENT_ARTIFACT_FINDING = "missing_refinement_artifact";
+
+/**
+ * Canonical list of section headings that satisfy the refinement check.
+ * Matching is case-insensitive and tolerates trailing/leading whitespace.
+ * The two-element minimum keeps the contract explicit:
+ *   - one AC section (Acceptance criteria)
+ *   - one DoD-style section (DoD or Definition of Done)
+ */
+const ACCEPTANCE_SECTION_PATTERNS = Object.freeze([
+  /^acceptance criteria\s*$/i,
+  /^ac\b.*$/i,
+]);
+
+const DOD_SECTION_PATTERNS = Object.freeze([
+  /^definition of done\s*$/i,
+  /^done\s*$/i,
+  /^dod\s*$/i,
+]);
+
+/**
+ * Extract `## ...` heading boundaries from a Markdown body.
+ * Returns a sorted array of { level, name, bodyLines } records.
+ */
+export function parseMarkdownSections(body) {
+  if (typeof body !== "string" || body.length === 0) {
+    return [];
+  }
+
+  const lines = body.split(/\r?\n/u);
+  const sections = [];
+  let current = null;
+
+  for (const line of lines) {
+    const match = /^(#{1,6})\s+(.+?)\s*$/u.exec(line);
+    if (match) {
+      if (current) {
+        sections.push(current);
+      }
+      current = {
+        level: match[1].length,
+        name: match[2],
+        bodyLines: [],
+      };
+      continue;
+    }
+    if (current) {
+      current.bodyLines.push(line);
+    }
+  }
+
+  if (current) {
+    sections.push(current);
+  }
+
+  return sections;
+}
+
+function findSectionByPatterns(sections, patterns) {
+  for (const section of sections) {
+    for (const pattern of patterns) {
+      if (pattern.test(section.name)) {
+        return section;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract checklist bullet items (`- [ ]` and `- [x]`) from a section body.
+ * Returns trimmed item text, preserving checkbox state, with at least one
+ * non-empty item required for the section to count.
+ */
+export function extractChecklistItems(sectionBody) {
+  if (typeof sectionBody !== "string" || sectionBody.length === 0) {
+    return [];
+  }
+
+  const items = [];
+  const lines = sectionBody.split(/\r?\n/u);
+
+  for (const line of lines) {
+    const match = /^\s*-\s+\[(?:[ xX])\]\s+(.+?)\s*$/u.exec(line);
+    if (match) {
+      const text = match[1].trim();
+      if (text.length > 0) {
+        items.push(text);
+      }
+    }
+  }
+
+  return items;
+}
+
+function extractSectionText(section) {
+  if (!section) {
+    return [];
+  }
+  return section.bodyLines
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/**
+ * Detect a linked refinement doc path from the issue body.
+ * Looks for explicit `tmp/refinement/<n>-plan.md` style paths and the
+ * `## Refinement` / `## Plan` / `## Refinement doc` sections.
+ */
+export function detectLinkedRefinementDoc(body, { issueNumber = null } = {}) {
+  if (typeof body !== "string" || body.length === 0) {
+    return { found: false, path: null, reason: "empty-body" };
+  }
+
+  const pathMatch = /(?:^|\s|[`(\[<])(tmp\/refinement\/[A-Za-z0-9._/\-]+\.md)\b/u.exec(body);
+  if (pathMatch) {
+    return { found: true, path: pathMatch[1], reason: "explicit-path" };
+  }
+
+  const sections = parseMarkdownSections(body);
+  const refinementSection = findSectionByPatterns(sections, [
+    /^refinement doc\s*$/i,
+    /^refinement\s*$/i,
+    /^plan doc\s*$/i,
+    /^plan\s*$/i,
+  ]);
+  if (refinementSection) {
+    const inlinePath = /(?:^|\s)(tmp\/refinement\/[^\s)`'"]+\.md)\b/u.exec(refinementSection.bodyLines.join("\n"));
+    if (inlinePath) {
+      return { found: true, path: inlinePath[1], reason: "refinement-section-path" };
+    }
+    if (Number.isInteger(issueNumber)) {
+      return {
+        found: true,
+        path: `tmp/refinement/${issueNumber}-plan.md`,
+        reason: "refinement-section-convention",
+      };
+    }
+  }
+
+  return { found: false, path: null, reason: "no-linked-doc" };
+}
+
+/**
+ * Detect the refinement artifact on a parsed issue body.
+ *
+ * @param {object} input
+ * @param {string} [input.body]  Raw issue body Markdown.
+ * @param {number} [input.issueNumber]  Issue number, used for linked-doc convention.
+ * @returns {{
+ *   hasACs: boolean,
+ *   source: string,
+ *   acItems: string[],
+ *   dodItems: string[],
+ *   sections: string[],
+ *   linkedDoc: { found: boolean, path: string|null, reason: string },
+ *   reason: string,
+ *   finding: string|null,
+ * }}
+ */
+export function detectIssueRefinementArtifact({ body = "", issueNumber = null } = {}) {
+  if (typeof body !== "string" || body.length === 0) {
+    return {
+      hasACs: false,
+      source: REFINEMENT_SOURCE.MISSING,
+      acItems: [],
+      dodItems: [],
+      sections: [],
+      linkedDoc: { found: false, path: null, reason: "empty-body" },
+      reason: "Issue body is empty; no ACs/DoD/linked-doc can be detected.",
+      finding: REFINEMENT_ARTIFACT_FINDING,
+    };
+  }
+
+  const sections = parseMarkdownSections(body);
+  const sectionNames = sections.map((s) => s.name);
+
+  const acceptanceSection = findSectionByPatterns(sections, ACCEPTANCE_SECTION_PATTERNS);
+  const dodSection = findSectionByPatterns(sections, DOD_SECTION_PATTERNS);
+
+  const acItems = acceptanceSection ? extractChecklistItems(acceptanceSection.bodyLines.join("\n")) : [];
+  const dodItems = dodSection ? extractChecklistItems(dodSection.bodyLines.join("\n")) : [];
+  const acTextItems = !acceptanceSection || acItems.length === 0
+    ? extractSectionText(acceptanceSection ?? null)
+    : [];
+  const dodTextItems = !dodSection || dodItems.length === 0
+    ? extractSectionText(dodSection ?? null)
+    : [];
+
+  const linkedDoc = detectLinkedRefinementDoc(body, { issueNumber });
+
+  if (acItems.length > 0) {
+    return {
+      hasACs: true,
+      source: REFINEMENT_SOURCE.ISSUE_BODY_AC,
+      acItems,
+      dodItems,
+      sections: sectionNames,
+      linkedDoc,
+      reason: `Found ${acItems.length} Acceptance criteria checklist item(s) in the issue body.`,
+      finding: null,
+    };
+  }
+
+  if (dodItems.length > 0) {
+    return {
+      hasACs: true,
+      source: REFINEMENT_SOURCE.ISSUE_BODY_DOD,
+      acItems,
+      dodItems,
+      sections: sectionNames,
+      linkedDoc,
+      reason: `Found ${dodItems.length} DoD checklist item(s) in the issue body.`,
+      finding: null,
+    };
+  }
+
+  if (linkedDoc.found) {
+    return {
+      hasACs: true,
+      source: REFINEMENT_SOURCE.LINKED_DOC,
+      acItems: acTextItems,
+      dodItems: dodTextItems,
+      sections: sectionNames,
+      linkedDoc,
+      reason: `Issue body links a refinement doc at ${linkedDoc.path}; treating that as the refinement artifact source.`,
+      finding: null,
+    };
+  }
+
+  if (acTextItems.length > 0) {
+    return {
+      hasACs: true,
+      source: REFINEMENT_SOURCE.ISSUE_BODY_AC,
+      acItems: acTextItems,
+      dodItems: dodTextItems,
+      sections: sectionNames,
+      linkedDoc,
+      reason: `Found ${acTextItems.length} Acceptance criteria text line(s) (no checkbox) in the issue body.`,
+      finding: null,
+    };
+  }
+
+  if (dodTextItems.length > 0) {
+    return {
+      hasACs: true,
+      source: REFINEMENT_SOURCE.ISSUE_BODY_DOD,
+      acItems: acTextItems,
+      dodItems: dodTextItems,
+      sections: sectionNames,
+      linkedDoc,
+      reason: `Found ${dodTextItems.length} DoD text line(s) (no checkbox) in the issue body.`,
+      finding: null,
+    };
+  }
+
+  return {
+    hasACs: false,
+    source: REFINEMENT_SOURCE.MISSING,
+    acItems: [],
+    dodItems: [],
+    sections: sectionNames,
+    linkedDoc,
+    reason: "Issue body has no Acceptance criteria section, no DoD section, and no linked refinement doc.",
+    finding: REFINEMENT_ARTIFACT_FINDING,
+  };
+}
+
+/**
+ * Map a draft-gate refinement check to the result surface consumed by
+ * `evaluatePrGateCoordination`. The mapping keeps the contract
+ * deterministic: the draft gate must not produce a `clean` verdict
+ * for the current head when the refinement check is `missing`.
+ */
+export function summarizeRefinementGateCheck({ body = "", issueNumber = null } = {}) {
+  const artifact = detectIssueRefinementArtifact({ body, issueNumber });
+  const verdict = artifact.hasACs ? "clean" : "blocked";
+  const finding = artifact.finding;
+  return {
+    artifact,
+    verdict,
+    finding,
+    blocking: !artifact.hasACs,
+    reason: artifact.reason,
+  };
+}

--- a/packages/core/src/loop/issue-refinement-artifact.mjs
+++ b/packages/core/src/loop/issue-refinement-artifact.mjs
@@ -98,8 +98,9 @@ function findSectionByPatterns(sections, patterns) {
 
 /**
  * Extract checklist bullet items (`- [ ]` and `- [x]`) from a section body.
- * Returns trimmed item text, preserving checkbox state, with at least one
- * non-empty item required for the section to count.
+ * Returns the trimmed item text for each matching line. The checkbox state
+ * (checked vs unchecked) is intentionally not preserved: callers only need
+ * the item text to satisfy the refinement-artifact contract.
  */
 export function extractChecklistItems(sectionBody) {
   if (typeof sectionBody !== "string" || sectionBody.length === 0) {
@@ -127,7 +128,7 @@ export function extractChecklistItems(sectionBody) {
  * Looks for explicit `tmp/refinement/<n>-plan.md` style paths and the
  * `## Refinement` / `## Plan` / `## Refinement doc` sections.
  */
-export function detectLinkedRefinementDoc(body, { issueNumber = null } = {}) {
+export function detectLinkedRefinementDoc(body) {
   if (typeof body !== "string" || body.length === 0) {
     return { found: false, path: null, reason: "empty-body" };
   }
@@ -194,7 +195,7 @@ export function detectIssueRefinementArtifact({ body = "", issueNumber = null } 
   const acItems = acceptanceSection ? extractChecklistItems(acceptanceSection.bodyLines.join("\n")) : [];
   const dodItems = dodSection ? extractChecklistItems(dodSection.bodyLines.join("\n")) : [];
 
-  const linkedDoc = detectLinkedRefinementDoc(body, { issueNumber });
+  const linkedDoc = detectLinkedRefinementDoc(body);
 
   if (acItems.length > 0) {
     return {

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -13,6 +13,24 @@ export const PR_CHECKPOINT = Object.freeze({
   DONE: "done",
 });
 
+
+/**
+ * Refinement-artifact gate check (issue #532).
+ *
+ * The draft gate must verify the linked issue has an explicit refinement
+ * artifact (Acceptance criteria / DoD / linked refinement doc) before it
+ * can post a clean verdict. When the artifact is missing the draft gate
+ * must post verdict=blocked with the missing_refinement_artifact finding
+ * and the PR cannot leave draft.
+ */
+export const REFINEMENT_ARTIFACT_STATUS = Object.freeze({
+  MISSING: "missing",
+  PRESENT: "present",
+  UNKNOWN: "unknown",
+});
+
+export const REFINEMENT_ARTIFACT_FINDING = "missing_refinement_artifact";
+
 export const PR_CHECKPOINT_ACTION = Object.freeze({
   RUN_DRAFT_GATE: "run_draft_gate",
   MARK_READY_FOR_REVIEW: "mark_ready_for_review",
@@ -175,6 +193,20 @@ function normalizePositiveInteger(value) {
   return Math.floor(value);
 }
 
+function normalizeRefinementArtifactStatus(value) {
+  if (value === REFINEMENT_ARTIFACT_STATUS.MISSING || value === REFINEMENT_ARTIFACT_STATUS.PRESENT) {
+    return value;
+  }
+  return REFINEMENT_ARTIFACT_STATUS.UNKNOWN;
+}
+
+function formatRefinementBlockedReason(linkedIssue, status) {
+  if (linkedIssue !== null && Number.isInteger(linkedIssue)) {
+    return `Linked issue #${linkedIssue} has no refinement artifact (Acceptance criteria / DoD / linked refinement doc). Run refinement first, add ACs/DoD to the issue, then re-open the draft PR. finding=${REFINEMENT_ARTIFACT_FINDING}`;
+  }
+  return `The draft gate cannot complete: the linked issue has no detectable refinement artifact (Acceptance criteria / DoD / linked refinement doc). finding=${REFINEMENT_ARTIFACT_FINDING}`;
+}
+
 function buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds }) {
   return `Copilot review rounds exhausted (${copilotReviewRoundCount}/${maxCopilotRounds}); current head has zero unresolved threads and green or credibly green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.`;
 }
@@ -283,6 +315,9 @@ function buildRetrospectiveGatePendingResult({
   });
 }
 
+// refinementArtifact is read from the closure set by evaluatePrGateCoordination
+let activeRefinementArtifact = null;
+function setActiveRefinementArtifact(value) { activeRefinementArtifact = value; }
 function buildResult({
   draftGateAlreadySatisfied = false,
   repo = null,
@@ -300,7 +335,10 @@ function buildResult({
   mergeStateStatus = null,
   conflictFiles = [],
   gateEvidenceNote = null,
+  refinementArtifact = null,
+  inputRefinementArtifact = null,
 }) {
+  const effectiveRefinementArtifact = refinementArtifact ?? inputRefinementArtifact ?? activeRefinementArtifact;
   return {
     ok: true,
     ...(repo ? { repo } : {}),
@@ -320,6 +358,7 @@ function buildResult({
     draftGateAlreadySatisfied,
     gateEvidenceRequiredForMerge: true,
     ...(gateEvidenceNote ? { gateEvidenceNote } : {}),
+    ...(effectiveRefinementArtifact ? { refinementArtifact: effectiveRefinementArtifact } : {}),
   };
 }
 
@@ -345,6 +384,12 @@ export function evaluatePrGateCoordination(input = {}) {
   const roundCapReached = maxCopilotRounds !== null && copilotReviewRoundCount >= maxCopilotRounds;
   const requireRetrospectiveGate = input.requireRetrospectiveGate === true;
   const retrospectiveCheckpoint = input.retrospectiveCheckpoint;
+  setActiveRefinementArtifact(input.refinementArtifact && typeof input.refinementArtifact === "object" ? input.refinementArtifact : null);
+  const refinementArtifact = input.refinementArtifact && typeof input.refinementArtifact === "object"
+    ? input.refinementArtifact
+    : null;
+  const refinementArtifactStatus = normalizeRefinementArtifactStatus(refinementArtifact?.status);
+  const refinementLinkedIssue = Number.isInteger(refinementArtifact?.linkedIssue) ? refinementArtifact.linkedIssue : null;
 
   const effectiveLifecycleState = lifecycleState;
 
@@ -447,6 +492,35 @@ export function evaluatePrGateCoordination(input = {}) {
   }
 
   if (prDraft || effectiveLifecycleState === STATE.PR_DRAFT) {
+    if (refinementArtifactStatus === REFINEMENT_ARTIFACT_STATUS.MISSING) {
+      pushUnique(allowedNextActions, [PR_CHECKPOINT_ACTION.REPORT_BLOCKED]);
+      pushUnique(forbiddenActions, [
+        PR_CHECKPOINT_ACTION.MARK_READY_FOR_REVIEW,
+        PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE,
+        PR_CHECKPOINT_ACTION.REQUEST_COPILOT_REVIEW,
+        PR_CHECKPOINT_ACTION.WAIT_FOR_COPILOT_REVIEW,
+        PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE,
+        PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY,
+      ]);
+      return buildResult({
+        repo: input.repo ?? null,
+        pr: Number.isInteger(input.pr) ? input.pr : null,
+        currentHeadSha,
+        lifecycleState: STATE.BLOCKED_NEEDS_USER_DECISION,
+        loopDisposition: DISPOSITION.BLOCKED,
+        gateBoundary: PR_CHECKPOINT.BLOCKED,
+        draftGateAlreadySatisfied,
+        draftGate,
+        preApprovalGate,
+        allowedNextActions,
+        forbiddenActions,
+        nextAction: PR_CHECKPOINT_ACTION.REPORT_BLOCKED,
+        reason: formatRefinementBlockedReason(refinementLinkedIssue, refinementArtifactStatus),
+        mergeStateStatus,
+        conflictFiles,
+        refinementArtifact,
+      });
+    }
     const draftReviewForbidden = [
       ...(draftGate.currentHeadClean ? [] : [PR_CHECKPOINT_ACTION.MARK_READY_FOR_REVIEW]),
       PR_CHECKPOINT_ACTION.REQUEST_COPILOT_REVIEW,

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -283,6 +283,7 @@ function buildRetrospectiveGatePendingResult({
   mergeStateStatus,
   conflictFiles,
   reason,
+  refinementArtifact = null,
 }) {
   const allowedNextActions = [];
   const forbiddenActions = [];
@@ -312,12 +313,10 @@ function buildRetrospectiveGatePendingResult({
     reason,
     mergeStateStatus,
     conflictFiles,
+      refinementArtifact,
   });
 }
 
-// refinementArtifact is read from the closure set by evaluatePrGateCoordination
-let activeRefinementArtifact = null;
-function setActiveRefinementArtifact(value) { activeRefinementArtifact = value; }
 function buildResult({
   draftGateAlreadySatisfied = false,
   repo = null,
@@ -338,7 +337,7 @@ function buildResult({
   refinementArtifact = null,
   inputRefinementArtifact = null,
 }) {
-  const effectiveRefinementArtifact = refinementArtifact ?? inputRefinementArtifact ?? activeRefinementArtifact;
+  const effectiveRefinementArtifact = refinementArtifact ?? inputRefinementArtifact ?? null;
   return {
     ok: true,
     ...(repo ? { repo } : {}),
@@ -384,7 +383,6 @@ export function evaluatePrGateCoordination(input = {}) {
   const roundCapReached = maxCopilotRounds !== null && copilotReviewRoundCount >= maxCopilotRounds;
   const requireRetrospectiveGate = input.requireRetrospectiveGate === true;
   const retrospectiveCheckpoint = input.retrospectiveCheckpoint;
-  setActiveRefinementArtifact(input.refinementArtifact && typeof input.refinementArtifact === "object" ? input.refinementArtifact : null);
   const refinementArtifact = input.refinementArtifact && typeof input.refinementArtifact === "object"
     ? input.refinementArtifact
     : null;
@@ -425,6 +423,7 @@ export function evaluatePrGateCoordination(input = {}) {
       reason: "The pull request is already closed or merged, so no further gate entry is legal.",
       mergeStateStatus,
       conflictFiles,
+        refinementArtifact,
     });
   }
 
@@ -453,6 +452,7 @@ export function evaluatePrGateCoordination(input = {}) {
       reason: "The PR is in a blocked lifecycle state, so gate progression must stop for a user decision.",
       mergeStateStatus,
       conflictFiles,
+        refinementArtifact,
     });
   }
 
@@ -488,6 +488,7 @@ export function evaluatePrGateCoordination(input = {}) {
       reason: formatConflictResolutionReason(mergeStateStatus, conflictFiles),
       mergeStateStatus,
       conflictFiles,
+        refinementArtifact,
     });
   }
 
@@ -552,6 +553,7 @@ export function evaluatePrGateCoordination(input = {}) {
           reason: "The PR is still draft, and this repo requires green current-head CI before entering `draft_gate`. The current head is failing CI, so fix the checks before retrying the draft gate.",
           mergeStateStatus,
           conflictFiles,
+            refinementArtifact,
         });
       }
 
@@ -577,6 +579,7 @@ export function evaluatePrGateCoordination(input = {}) {
           reason: "The PR is still draft, and this repo requires green current-head CI before entering `draft_gate`, so wait for CI to settle green before running the draft gate.",
           mergeStateStatus,
           conflictFiles,
+            refinementArtifact,
         });
       }
     }
@@ -607,6 +610,7 @@ export function evaluatePrGateCoordination(input = {}) {
           : "The PR is still draft, and this repo does not require CI before `draft_gate`, so the draft gate is the next legal boundary before `gh pr ready`."),
       mergeStateStatus,
       conflictFiles,
+        refinementArtifact,
     });
   }
 
@@ -640,6 +644,7 @@ export function evaluatePrGateCoordination(input = {}) {
               mergeStateStatus,
               conflictFiles,
               reason: `Merge remains blocked: retrospective_gate_pending. ${retrospectiveGate.reason}`,
+            refinementArtifact,
             });
           }
         }
@@ -662,6 +667,7 @@ export function evaluatePrGateCoordination(input = {}) {
           reason: "This is an explicitly internal-only PR with clean draft_gate evidence and current-head clean pre_approval_gate, so it is ready for final human approval.",
           mergeStateStatus,
           conflictFiles,
+            refinementArtifact,
         });
       }
 
@@ -683,6 +689,7 @@ export function evaluatePrGateCoordination(input = {}) {
         reason: "This is an explicitly internal-only PR, so `pre_approval_gate` is the next legal boundary instead of an external Copilot review cycle.",
         mergeStateStatus,
         conflictFiles,
+          refinementArtifact,
       });
     }
 
@@ -704,6 +711,7 @@ export function evaluatePrGateCoordination(input = {}) {
       reason: "The PR is ready for review but the post-draft external review cycle has not started yet; request Copilot review before any `pre_approval_gate` entry.",
       mergeStateStatus,
       conflictFiles,
+        refinementArtifact,
     });
   }
 
@@ -732,6 +740,7 @@ export function evaluatePrGateCoordination(input = {}) {
         : "The post-draft review cycle is still pending on Copilot review, so `pre_approval_gate` remains illegal until the current-head review cycle settles.",
       mergeStateStatus,
       conflictFiles,
+        refinementArtifact,
     });
   }
 
@@ -754,6 +763,7 @@ export function evaluatePrGateCoordination(input = {}) {
       reason: "Actionable unresolved feedback exists, so follow-up work must stay in the review/fix cycle and cannot enter `pre_approval_gate` yet.",
       mergeStateStatus,
       conflictFiles,
+        refinementArtifact,
     });
   }
 
@@ -776,6 +786,7 @@ export function evaluatePrGateCoordination(input = {}) {
       reason: "Fixes were applied, but unresolved threads still need reply/resolve handling before another gate boundary is legal.",
       mergeStateStatus,
       conflictFiles,
+        refinementArtifact,
     });
   }
 
@@ -799,6 +810,7 @@ export function evaluatePrGateCoordination(input = {}) {
         reason: "The current head still has failing CI, so gate progression remains blocked until the failing checks are fixed and revalidated.",
         mergeStateStatus,
         conflictFiles,
+          refinementArtifact,
       });
     }
 
@@ -821,6 +833,7 @@ export function evaluatePrGateCoordination(input = {}) {
         reason: "The current head does not yet have green or credibly green CI, so `pre_approval_gate` remains illegal until CI settles.",
         mergeStateStatus,
         conflictFiles,
+          refinementArtifact,
       });
     }
 
@@ -847,6 +860,7 @@ export function evaluatePrGateCoordination(input = {}) {
         reason: "The review loop is between passes, but the current head does not yet have a clean settled Copilot convergence point, so `pre_approval_gate` is still forbidden.",
         mergeStateStatus,
         conflictFiles,
+          refinementArtifact,
       });
     }
 
@@ -863,6 +877,7 @@ export function evaluatePrGateCoordination(input = {}) {
             mergeStateStatus,
             conflictFiles,
             reason: `Merge remains blocked: retrospective_gate_pending. ${retrospectiveGate.reason}`,
+          refinementArtifact,
           });
         }
       }
@@ -892,6 +907,7 @@ export function evaluatePrGateCoordination(input = {}) {
           : "The current head has both a clean settled review cycle and clean `pre_approval_gate` evidence, so the PR is at the final approval boundary.",
         mergeStateStatus,
         conflictFiles,
+          refinementArtifact,
       });
     }
 
@@ -946,6 +962,7 @@ export function evaluatePrGateCoordination(input = {}) {
         reason: "The low-signal heuristic indicates convergence, but the current head still has failing CI, so gate progression remains blocked.",
         mergeStateStatus,
         conflictFiles,
+          refinementArtifact,
       });
     }
     if (ciStatus === "pending" || ciStatus === "none") {
@@ -967,6 +984,7 @@ export function evaluatePrGateCoordination(input = {}) {
         reason: "The low-signal heuristic indicates convergence, but the current head does not yet have green or credibly green CI.",
         mergeStateStatus,
         conflictFiles,
+          refinementArtifact,
       });
     }
     if (preApprovalGate.currentHeadClean) {
@@ -982,6 +1000,7 @@ export function evaluatePrGateCoordination(input = {}) {
             mergeStateStatus,
             conflictFiles,
             reason: `Merge remains blocked: retrospective_gate_pending. ${retrospectiveGate.reason}`,
+          refinementArtifact,
           });
         }
       }
@@ -1009,6 +1028,7 @@ export function evaluatePrGateCoordination(input = {}) {
         reason: "Low-signal heuristic indicates convergence and current-head clean pre_approval_gate evidence exists.",
         mergeStateStatus,
         conflictFiles,
+          refinementArtifact,
       });
     }
     pushUnique(allowedNextActions, [PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE]);
@@ -1034,6 +1054,7 @@ export function evaluatePrGateCoordination(input = {}) {
       reason: "Low-signal heuristic indicates convergence (diminishing-returns signal detected), routing to pre_approval_gate instead of re-requesting Copilot.",
       mergeStateStatus,
       conflictFiles,
+        refinementArtifact,
     });
   }
 
@@ -1061,5 +1082,6 @@ export function evaluatePrGateCoordination(input = {}) {
     reason: "The PR gate-boundary evaluator could not map this lifecycle state to a legal gate transition; reconcile before continuing.",
     mergeStateStatus,
     conflictFiles,
+      refinementArtifact,
   });
 }

--- a/packages/core/test/issue-refinement-artifact.test.mjs
+++ b/packages/core/test/issue-refinement-artifact.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  REFINEMENT_SOURCE,
+  detectIssueRefinementArtifact,
+  detectLinkedRefinementDoc,
+  extractChecklistItems,
+  parseMarkdownSections,
+  summarizeRefinementGateCheck,
+} from "../src/loop/issue-refinement-artifact.mjs";
+
+test("parseMarkdownSections returns heading boundaries", () => {
+  const sections = parseMarkdownSections("## Problem\n\nText.\n\n## Acceptance criteria\n\n- [ ] AC1\n");
+  assert.deepEqual(
+    sections.map((s) => ({ name: s.name, level: s.level, itemCount: extractChecklistItems(s.bodyLines.join("\n")).length })),
+    [
+      { name: "Problem", level: 2, itemCount: 0 },
+      { name: "Acceptance criteria", level: 2, itemCount: 1 },
+    ],
+  );
+});
+
+test("detectIssueRefinementArtifact returns missing for prose-only bodies", () => {
+  const result = detectIssueRefinementArtifact({ body: "## Problem\n\nNo ACs.\n\n## Root Cause\n\nBug.\n\n## Fix\n\nCode." });
+  assert.equal(result.hasACs, false);
+  assert.equal(result.source, REFINEMENT_SOURCE.MISSING);
+  assert.equal(result.finding, "missing_refinement_artifact");
+  assert.deepEqual(result.acItems, []);
+  assert.deepEqual(result.dodItems, []);
+});
+
+test("detectIssueRefinementArtifact detects Acceptance criteria with checkboxes", () => {
+  const result = detectIssueRefinementArtifact({
+    body: "## Problem\n\nX\n\n## Acceptance criteria\n\n- [ ] First AC\n- [x] Second AC\n",
+  });
+  assert.equal(result.hasACs, true);
+  assert.equal(result.source, REFINEMENT_SOURCE.ISSUE_BODY_AC);
+  assert.equal(result.finding, null);
+  assert.deepEqual(result.acItems, ["First AC", "Second AC"]);
+});
+
+test("detectIssueRefinementArtifact detects DoD section when AC is absent", () => {
+  const result = detectIssueRefinementArtifact({
+    body: "## Problem\n\nX\n\n## Definition of Done\n\n- [ ] DoD1\n- [x] DoD2\n",
+  });
+  assert.equal(result.hasACs, true);
+  assert.equal(result.source, REFINEMENT_SOURCE.ISSUE_BODY_DOD);
+  assert.deepEqual(result.dodItems, ["DoD1", "DoD2"]);
+});
+
+test("detectIssueRefinementArtifact detects a linked refinement doc path", () => {
+  const result = detectIssueRefinementArtifact({
+    body: "## Problem\n\nX\n\nSee `tmp/refinement/532-plan.md` for ACs.\n",
+    issueNumber: 532,
+  });
+  assert.equal(result.hasACs, true);
+  assert.equal(result.source, REFINEMENT_SOURCE.LINKED_DOC);
+  assert.equal(result.linkedDoc.found, true);
+  assert.equal(result.linkedDoc.path, "tmp/refinement/532-plan.md");
+});
+
+test("detectIssueRefinementArtifact treats a Refinement section as a linked-doc convention", () => {
+  const result = detectIssueRefinementArtifact({
+    body: "## Refinement\n\nA plan lives here.\n",
+    issueNumber: 527,
+  });
+  assert.equal(result.hasACs, true);
+  assert.equal(result.source, REFINEMENT_SOURCE.LINKED_DOC);
+  assert.equal(result.linkedDoc.path, "tmp/refinement/527-plan.md");
+});
+
+test("detectIssueRefinementArtifact falls back to AC text lines without checkboxes", () => {
+  const result = detectIssueRefinementArtifact({
+    body: "## Acceptance criteria\n\nFirst AC without checkbox\nSecond AC also without checkbox\n",
+  });
+  assert.equal(result.hasACs, true);
+  assert.equal(result.source, REFINEMENT_SOURCE.ISSUE_BODY_AC);
+  assert.deepEqual(result.acItems, ["First AC without checkbox", "Second AC also without checkbox"]);
+});
+
+test("detectIssueRefinementArtifact returns finding for empty body", () => {
+  const result = detectIssueRefinementArtifact({ body: "" });
+  assert.equal(result.hasACs, false);
+  assert.equal(result.source, REFINEMENT_SOURCE.MISSING);
+  assert.equal(result.finding, "missing_refinement_artifact");
+});
+
+test("detectLinkedRefinementDoc finds explicit tmp/refinement path", () => {
+  const linked = detectLinkedRefinementDoc("See `tmp/refinement/532-plan.md` for ACs.");
+  assert.equal(linked.found, true);
+  assert.equal(linked.path, "tmp/refinement/532-plan.md");
+});
+
+test("summarizeRefinementGateCheck maps to clean verdict when artifact present", () => {
+  const summary = summarizeRefinementGateCheck({
+    body: "## Acceptance criteria\n\n- [ ] AC1\n",
+  });
+  assert.equal(summary.verdict, "clean");
+  assert.equal(summary.finding, null);
+  assert.equal(summary.blocking, false);
+});
+
+test("summarizeRefinementGateCheck maps to blocked verdict when artifact missing", () => {
+  const summary = summarizeRefinementGateCheck({
+    body: "## Problem\n\nX\n",
+  });
+  assert.equal(summary.verdict, "blocked");
+  assert.equal(summary.finding, "missing_refinement_artifact");
+  assert.equal(summary.blocking, true);
+});

--- a/packages/core/test/issue-refinement-artifact.test.mjs
+++ b/packages/core/test/issue-refinement-artifact.test.mjs
@@ -60,23 +60,30 @@ test("detectIssueRefinementArtifact detects a linked refinement doc path", () =>
   assert.equal(result.linkedDoc.path, "tmp/refinement/532-plan.md");
 });
 
-test("detectIssueRefinementArtifact treats a Refinement section as a linked-doc convention", () => {
+test("detectIssueRefinementArtifact rejects a Refinement section without explicit path", () => {
+  // Per #532 review feedback: a `## Refinement` heading alone is not a
+  // verifiable artifact; the body must reference a real tmp/refinement/*.md
+  // path. The old convention-path fallback was removed.
   const result = detectIssueRefinementArtifact({
     body: "## Refinement\n\nA plan lives here.\n",
     issueNumber: 527,
   });
-  assert.equal(result.hasACs, true);
-  assert.equal(result.source, REFINEMENT_SOURCE.LINKED_DOC);
-  assert.equal(result.linkedDoc.path, "tmp/refinement/527-plan.md");
+  assert.equal(result.hasACs, false);
+  assert.equal(result.source, REFINEMENT_SOURCE.MISSING);
+  assert.equal(result.linkedDoc.found, false);
+  assert.equal(result.finding, "missing_refinement_artifact");
 });
 
-test("detectIssueRefinementArtifact falls back to AC text lines without checkboxes", () => {
+test("detectIssueRefinementArtifact rejects AC section without checkboxes", () => {
+  // Per #532 review feedback: prose-only AC/DoD sections must not satisfy
+  // the refinement artifact; the section must contain at least one
+  // `- [ ]` / `- [x]` checklist item.
   const result = detectIssueRefinementArtifact({
     body: "## Acceptance criteria\n\nFirst AC without checkbox\nSecond AC also without checkbox\n",
   });
-  assert.equal(result.hasACs, true);
-  assert.equal(result.source, REFINEMENT_SOURCE.ISSUE_BODY_AC);
-  assert.deepEqual(result.acItems, ["First AC without checkbox", "Second AC also without checkbox"]);
+  assert.equal(result.hasACs, false);
+  assert.equal(result.source, REFINEMENT_SOURCE.MISSING);
+  assert.equal(result.finding, "missing_refinement_artifact");
 });
 
 test("detectIssueRefinementArtifact returns finding for empty body", () => {

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -835,3 +835,102 @@ test("gateEvidenceRequiredForMerge is always true in coordination output", () =>
 
   assert.equal(result.gateEvidenceRequiredForMerge, true);
 });
+
+test("draft PR is blocked when refinement artifact is missing on linked issue (#532)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 532,
+    currentHeadSha: "abc1234567",
+    prDraft: true,
+    lifecycleState: STATE.PR_DRAFT,
+    loopDisposition: DISPOSITION.ACTION_REQUIRED,
+    draftGate: gate({ visible: false }),
+    draftGateMarker: gate({ visible: false }),
+    refinementArtifact: {
+      status: "missing",
+      linkedIssue: 532,
+      source: "missing",
+      reason: "Issue body has no Acceptance criteria section, no DoD section, and no linked refinement doc.",
+      finding: "missing_refinement_artifact",
+    },
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.BLOCKED);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.MARK_READY_FOR_REVIEW));
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE));
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY));
+  assert(result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.REPORT_BLOCKED));
+  assert.match(result.reason, /no refinement artifact/i);
+  assert.match(result.reason, /#532/);
+  assert.match(result.reason, /missing_refinement_artifact/);
+  assert.equal(result.refinementArtifact?.status, "missing");
+  assert.equal(result.refinementArtifact?.linkedIssue, 532);
+});
+
+test("draft PR is not blocked when refinement artifact is present (#532)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 532,
+    currentHeadSha: "abc1234567",
+    prDraft: true,
+    lifecycleState: STATE.PR_DRAFT,
+    loopDisposition: DISPOSITION.ACTION_REQUIRED,
+    ciStatus: "success",
+    draftGate: gate({ visible: false }),
+    draftGateMarker: gate({ visible: false }),
+    refinementArtifact: {
+      status: "present",
+      linkedIssue: 532,
+      source: "issue-body-ac",
+      acItems: ["First AC", "Second AC"],
+      reason: "Found 2 Acceptance criteria checklist item(s) in the issue body.",
+    },
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.DRAFT_REVIEW);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE);
+  assert(result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE));
+  assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE));
+  assert.equal(result.refinementArtifact?.status, "present");
+});
+
+test("refinement block takes precedence over non-draft branches for draft PRs", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 10,
+    currentHeadSha: "abc1234567",
+    prDraft: true,
+    lifecycleState: STATE.PR_DRAFT,
+    loopDisposition: DISPOSITION.ACTION_REQUIRED,
+    mergeStateStatus: "CLEAN",
+    conflictFiles: [],
+    refinementArtifact: {
+      status: "missing",
+      linkedIssue: 10,
+      source: "missing",
+      reason: "no artifact",
+      finding: "missing_refinement_artifact",
+    },
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.BLOCKED);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
+});
+
+test("non-draft PRs do not block on missing refinement artifact (already left draft)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 10,
+    currentHeadSha: "abc1234567",
+    prDraft: false,
+    lifecycleState: STATE.PR_READY_NO_FEEDBACK,
+    loopDisposition: DISPOSITION.ACTION_REQUIRED,
+    refinementArtifact: {
+      status: "missing",
+      linkedIssue: 10,
+      source: "missing",
+      reason: "no artifact",
+    },
+  });
+
+  assert.notEqual(result.gateBoundary, PR_CHECKPOINT.BLOCKED);
+  assert.equal(result.refinementArtifact?.status, "missing");
+});

--- a/scripts/loop/detect-issue-refinement-artifact.mjs
+++ b/scripts/loop/detect-issue-refinement-artifact.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+/**
+ * Deterministic issue refinement-artifact detector.
+ *
+ * Inspects a GitHub issue body (or a pre-fetched JSON payload) and reports
+ * whether the issue carries an explicit refinement artifact that the
+ * draft gate can verify against. The check is the bounded contract from
+ * issue #532:
+ *
+ *   - Acceptance criteria section with at least one `- [ ]` / `- [x]` item
+ *   - DoD / Definition of Done section with at least one `- [ ]` / `- [x]`
+ *   - A linked refinement doc referenced from the body
+ *
+ * When none of those are present the helper emits
+ *   { source: "missing", finding: "missing_refinement_artifact" }
+ * so the draft gate can post `verdict=blocked` deterministically.
+ *
+ * Usage:
+ *   detect-issue-refinement-artifact.mjs --repo <owner/name> --issue <number>
+ *   detect-issue-refinement-artifact.mjs --input <path>
+ *
+ *   --input <path>  Path to a JSON file with shape:
+ *                    { "repo": "...", "issue": <n>, "body": "..." }
+ *                   Useful for offline detection and unit tests.
+ *
+ * Success output (stdout, JSON):
+ *   {
+ *     "ok": true,
+ *     "repo": "owner/name",
+ *     "issue": 532,
+ *     "source": "issue-body-ac" | "issue-body-dod" | "linked-doc" | "missing",
+ *     "hasACs": true | false,
+ *     "acItems": ["..."],
+ *     "dodItems": ["..."],
+ *     "linkedDoc": { "found": true, "path": "...", "reason": "..." },
+ *     "sections": ["Problem", "Acceptance criteria", ...],
+ *     "finding": "missing_refinement_artifact" | null,
+ *     "reason": "..."
+ *   }
+ *
+ * Error output (stderr, JSON):
+ *   Argument/usage errors: { "ok": false, "error": "...", "usage": "..." }
+ *   Runtime failures:      { "ok": false, "error": "..." }
+ */
+import { readFile } from "node:fs/promises";
+import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import {
+  detectIssueRefinementArtifact,
+  REFINEMENT_SOURCE,
+} from "@pi-dev-loops/core/loop/issue-refinement-artifact";
+
+const USAGE = `Usage:
+  detect-issue-refinement-artifact.mjs --repo <owner/name> --issue <number>
+  detect-issue-refinement-artifact.mjs --input <path>
+
+Detect whether a GitHub issue carries an explicit refinement artifact
+(Acceptance criteria section, DoD section, or linked refinement doc).
+
+Required (exactly one):
+  --repo <owner/name>   Repository slug (e.g. owner/name)
+  --issue <number>      Issue number
+  --input <path>        Path to a JSON file with { "repo", "issue", "body" }
+
+Success output (stdout, JSON):
+  {
+    "ok": true,
+    "repo": "owner/name",
+    "issue": 532,
+    "source": "issue-body-ac" | "issue-body-dod" | "linked-doc" | "missing",
+    "hasACs": true | false,
+    "acItems": [...],
+    "dodItems": [...],
+    "linkedDoc": { "found": true, "path": "...", "reason": "..." },
+    "finding": "missing_refinement_artifact" | null,
+    "reason": "..."
+  }
+
+Error output (stderr, JSON):
+  { "ok": false, "error": "...", "usage": "..." }`.trim();
+
+const parseError = buildParseError(USAGE);
+
+export function parseDetectIssueRefinementArtifactCliArgs(argv) {
+  const args = [...argv];
+  const options = {
+    help: false,
+    repo: undefined,
+    issue: undefined,
+    input: undefined,
+  };
+
+  while (args.length > 0) {
+    const token = args.shift();
+
+    if (token === "--help" || token === "-h") {
+      options.help = true;
+      return options;
+    }
+    if (token === "--repo") {
+      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+      continue;
+    }
+    if (token === "--issue") {
+      const value = requireOptionValue(args, "--issue", parseError);
+      if (!/^\d+$/.test(value) || Number(value) === 0) {
+        throw parseError("--issue must be a positive integer");
+      }
+      options.issue = Number(value);
+      continue;
+    }
+    if (token === "--input") {
+      options.input = requireOptionValue(args, "--input", parseError).trim();
+      continue;
+    }
+    throw parseError(`Unknown argument: ${token}`);
+  }
+
+  const hasInput = typeof options.input === "string" && options.input.length > 0;
+  const hasRemote = typeof options.repo === "string" && options.repo.length > 0 && Number.isInteger(options.issue);
+  if (options.help) {
+    return options;
+  }
+  if (hasInput === hasRemote) {
+    throw parseError("Provide exactly one of --input <path> or --repo <owner/name> --issue <number>");
+  }
+  return options;
+}
+
+async function fetchIssueBody({ repo, issue }, { env = process.env, ghCommand = "gh" } = {}) {
+  const result = await runChild(
+    ghCommand,
+    ["issue", "view", String(issue), "--repo", repo, "--json", "body"],
+    env,
+  );
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw new Error(`gh command failed: ${detail}`);
+  }
+  const payload = parseJsonText(result.stdout, { label: "gh issue view" });
+  if (!payload || typeof payload !== "object") {
+    throw new Error("Invalid gh issue view payload: missing body");
+  }
+  return typeof payload.body === "string" ? payload.body : "";
+}
+
+async function loadInputPayload(inputPath) {
+  const text = await readFile(inputPath, "utf8");
+  const payload = parseJsonText(text, { label: `input file ${inputPath}` });
+  if (!payload || typeof payload !== "object") {
+    throw new Error(`Input file ${inputPath} must be a JSON object`);
+  }
+  return payload;
+}
+
+function toOutput(repo, issue, artifact) {
+  return {
+    ok: true,
+    repo: repo ?? null,
+    issue: issue ?? null,
+    source: artifact.source,
+    hasACs: artifact.hasACs,
+    acItems: artifact.acItems,
+    dodItems: artifact.dodItems,
+    linkedDoc: artifact.linkedDoc,
+    sections: artifact.sections,
+    finding: artifact.finding,
+    reason: artifact.reason,
+    sources: REFINEMENT_SOURCE,
+  };
+}
+
+export async function detectIssueRefinementArtifactFromOptions(options, { env = process.env, ghCommand = "gh" } = {}) {
+  if (typeof options.input === "string" && options.input.length > 0) {
+    const payload = await loadInputPayload(options.input);
+    const body = typeof payload.body === "string" ? payload.body : "";
+    const issue = Number.isInteger(payload.issue) ? payload.issue : options.issue ?? null;
+    const repo = typeof payload.repo === "string" ? payload.repo : options.repo ?? null;
+    const artifact = detectIssueRefinementArtifact({ body, issueNumber: issue });
+    return toOutput(repo, issue, artifact);
+  }
+
+  if (typeof options.repo === "string" && options.repo.length > 0 && Number.isInteger(options.issue)) {
+    parseRepoSlug(options.repo);
+    const body = await fetchIssueBody({ repo: options.repo, issue: options.issue }, { env, ghCommand });
+    const artifact = detectIssueRefinementArtifact({ body, issueNumber: options.issue });
+    return toOutput(options.repo, options.issue, artifact);
+  }
+
+  throw new Error("detect-issue-refinement-artifact requires either --input <path> or --repo/--issue");
+}
+
+export async function runCli(
+  argv = process.argv.slice(2),
+  { stdout = process.stdout, stderr = process.stderr, env = process.env, ghCommand = "gh" } = {},
+) {
+  let options;
+  try {
+    options = parseDetectIssueRefinementArtifactCliArgs(argv);
+  } catch (error) {
+    stderr.write(`${formatCliError(error, { usage: USAGE })}\n`);
+    return 1;
+  }
+
+  if (options.help) {
+    stdout.write(`${USAGE}\n`);
+    return 0;
+  }
+
+  try {
+    const result = await detectIssueRefinementArtifactFromOptions(options, { env, ghCommand });
+    stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  } catch (error) {
+    stderr.write(`${formatCliError(error)}\n`);
+    return 1;
+  }
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  const code = await runCli();
+  if (code !== 0) {
+    process.exitCode = code;
+  }
+}

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -203,7 +203,7 @@ async function fetchRequestedReviewers({ repo, pr }, { env = process.env, ghComm
 async function fetchPrFacts({ repo, pr }, { env = process.env, ghCommand = "gh" } = {}) {
   const result = await runChild(
     ghCommand,
-    ["pr", "view", String(pr), "--repo", repo, "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+    ["pr", "view", String(pr), "--repo", repo, "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
     env,
   );
 
@@ -213,6 +213,100 @@ async function fetchPrFacts({ repo, pr }, { env = process.env, ghCommand = "gh" 
   }
 
   return parseJsonText(result.stdout, { label: "gh pr view" });
+}
+
+
+/**
+ * Resolve the canonical linked issue number for a PR.
+ *
+ * Per the pre-approval gate AC-verification contract:
+ *   - if there is exactly one closing issue reference, use it
+ *   - else if the body contains a single Closes #N / Fixes #N pattern, use it
+ *   - otherwise return null (ambiguous)
+ */
+export function resolveLinkedIssueFromPr(prData) {
+  if (!prData || typeof prData !== "object") return null;
+  const closing = Array.isArray(prData.closingIssuesReferences) ? prData.closingIssuesReferences : [];
+  const closingNumbers = closing
+    .map((entry) => Number(entry?.number))
+    .filter((n) => Number.isInteger(n) && n > 0);
+  if (closingNumbers.length === 1) {
+    return closingNumbers[0];
+  }
+  const body = typeof prData.body === "string" ? prData.body : "";
+  if (body.length === 0) return null;
+  const matches = body.match(/(?:closes|fixes|resolves)\s+#(\d+)/gi) || [];
+  const bodyNumbers = matches
+    .map((m) => Number((/(\d+)/.exec(m) || [])[1]))
+    .filter((n) => Number.isInteger(n) && n > 0);
+  if (bodyNumbers.length === 1) {
+    return bodyNumbers[0];
+  }
+  return null;
+}
+
+async function fetchIssueBody({ repo, issue }, { env = process.env, ghCommand = "gh" } = {}) {
+  const result = await runChild(
+    ghCommand,
+    ["issue", "view", String(issue), "--repo", repo, "--json", "body"],
+    env,
+  );
+  if (result.code !== 0) {
+    return null;
+  }
+  try {
+    const payload = parseJsonText(result.stdout, { label: "gh issue view" });
+    return typeof payload?.body === "string" ? payload.body : "";
+  } catch {
+    return null;
+  }
+}
+
+async function loadRefinementArtifact({ repo, prData, prDraft, prClosed, prMerged }, { env = process.env, ghCommand = "gh" } = {}) {
+  // The refinement check is a draft-gate boundary (#532).
+  // For non-draft PRs we still surface the artifact so the result is
+  // complete, but the evaluator will not block on it for non-draft PRs.
+  // To avoid an extra gh call for non-draft PRs (where the check is
+  // a no-op for routing), we resolve the linked issue from the cached
+  // PR data only and skip the linked-issue body fetch unless we know
+  // we are looking at a draft PR.
+  const linkedIssue = resolveLinkedIssueFromPr(prData);
+  if (linkedIssue === null) {
+    return {
+      status: "unknown",
+      linkedIssue: null,
+      reason: "No deterministically resolvable linked issue (no closingIssuesReferences, no unique Closes/Fixes pattern in body).",
+    };
+  }
+  if (!prDraft && !prClosed && !prMerged) {
+    return {
+      status: "unknown",
+      linkedIssue,
+      reason: `Linked issue #${linkedIssue} detected; refinement check is a draft-gate boundary and the PR is not draft, so the check is informational only and does not fetch the issue body.`,
+    };
+  }
+  const body = await fetchIssueBody({ repo, issue: linkedIssue }, { env, ghCommand });
+  if (body === null) {
+    return {
+      status: "unknown",
+      linkedIssue,
+      reason: `Failed to fetch body for linked issue #${linkedIssue}; refinement status is unknown.`,
+    };
+  }
+  const { detectIssueRefinementArtifact } = await import("@pi-dev-loops/core/loop/issue-refinement-artifact");
+  const artifact = detectIssueRefinementArtifact({ body, issueNumber: linkedIssue });
+  return {
+    status: artifact.hasACs ? "present" : "missing",
+    linkedIssue,
+    source: artifact.source,
+    acItems: artifact.acItems,
+    dodItems: artifact.dodItems,
+    sections: artifact.sections,
+    linkedDoc: artifact.linkedDoc,
+    reason: artifact.reason,
+    finding: artifact.finding,
+    _onlyEnforcedWhenDraft: prDraft || prClosed || prMerged ? false : true,
+  };
 }
 
 async function fetchLocalConflictFiles({ env = process.env, gitCommand = "git" } = {}) {
@@ -316,6 +410,14 @@ export async function loadPrGateCoordinationContext(options, runtime = {}) {
     ? prData.mergeStateStatus.trim().toUpperCase()
     : null;
 
+  const isDraft = Boolean(prData?.isDraft);
+  const isClosed = String(prData?.state || "").toUpperCase() === "CLOSED";
+  const isMerged = String(prData?.state || "").toUpperCase() === "MERGED";
+  const refinementArtifact = await loadRefinementArtifact(
+    { repo: options.repo, prData, prDraft: isDraft, prClosed: isClosed, prMerged: isMerged },
+    runtime,
+  );
+
   return {
     repo: options.repo,
     pr: options.pr,
@@ -327,6 +429,7 @@ export async function loadPrGateCoordinationContext(options, runtime = {}) {
     gateEvidence,
     interpretation,
     disposition,
+    refinementArtifact,
   };
 }
 
@@ -363,6 +466,7 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
     draftGateMarker: context.gateEvidence.draftGateMarker,
     preApprovalGate: context.gateEvidence.preApprovalGate,
     preApprovalGateMarker: context.gateEvidence.preApprovalGateMarker,
+    refinementArtifact: context.refinementArtifact,
   });
 
   // #442: pre_approval_gate detector — if pre_approval_gate was never entered

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -272,6 +272,18 @@ async function loadRefinementArtifact({ repo, prData, prDraft, prClosed, prMerge
   // we are looking at a draft PR.
   const linkedIssue = resolveLinkedIssueFromPr(prData);
   if (linkedIssue === null) {
+    // Draft PRs with no deterministically resolvable linked issue must fail
+    // closed: the draft gate cannot verify any refinement artifact, so
+    // `gh pr ready` is forbidden. For non-draft PRs the check is informational
+    // only and stays `unknown` so the evaluator does not block on it.
+    if (prDraft) {
+      return {
+        status: "missing",
+        linkedIssue: null,
+        reason: "Draft PR has no deterministically resolvable linked issue (no closingIssuesReferences, no unique Closes/Fixes pattern in body); draft gate cannot verify a refinement artifact.",
+        finding: "missing_refinement_artifact",
+      };
+    }
     return {
       status: "unknown",
       linkedIssue: null,
@@ -287,6 +299,16 @@ async function loadRefinementArtifact({ repo, prData, prDraft, prClosed, prMerge
   }
   const body = await fetchIssueBody({ repo, issue: linkedIssue }, { env, ghCommand });
   if (body === null) {
+    // Fail-closed for draft PRs: a transient `gh issue view` failure must not
+    // allow `gh pr ready` without verifying a refinement artifact.
+    if (prDraft) {
+      return {
+        status: "missing",
+        linkedIssue,
+        reason: `Failed to fetch body for linked issue #${linkedIssue}; draft gate cannot verify a refinement artifact, treating as missing.`,
+        finding: "missing_refinement_artifact",
+      };
+    }
     return {
       status: "unknown",
       linkedIssue,
@@ -305,7 +327,7 @@ async function loadRefinementArtifact({ repo, prData, prDraft, prClosed, prMerge
     linkedDoc: artifact.linkedDoc,
     reason: artifact.reason,
     finding: artifact.finding,
-    _onlyEnforcedWhenDraft: prDraft || prClosed || prMerged ? false : true,
+    _onlyEnforcedWhenDraft: prDraft === true,
   };
 }
 

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -280,14 +280,14 @@ async function loadRefinementArtifact({ repo, prData, prDraft, prClosed, prMerge
       return {
         status: "missing",
         linkedIssue: null,
-        reason: "Draft PR has no deterministically resolvable linked issue (no closingIssuesReferences, no unique Closes/Fixes pattern in body); draft gate cannot verify a refinement artifact.",
+        reason: "Draft PR has no deterministically resolvable linked issue (no closingIssuesReferences, no unique Closes/Fixes/Resolves pattern in body); draft gate cannot verify a refinement artifact.",
         finding: "missing_refinement_artifact",
       };
     }
     return {
       status: "unknown",
       linkedIssue: null,
-      reason: "No deterministically resolvable linked issue (no closingIssuesReferences, no unique Closes/Fixes pattern in body).",
+      reason: "No deterministically resolvable linked issue (no closingIssuesReferences, no unique Closes/Fixes/Resolves pattern in body).",
     };
   }
   if (!prDraft && !prClosed && !prMerged) {

--- a/test/github/reconcile-draft-gate.test.mjs
+++ b/test/github/reconcile-draft-gate.test.mjs
@@ -280,7 +280,7 @@ test("reconcile-draft-gate skips CI checks when config disables draft requireCi"
         stdout: '{"data":{"convertPullRequestToDraft":{"pullRequest":{"id":"PR_kwDOScHU78000017","isDraft":true}}}}\n',
       },
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc123456789","reviews":[],"statusCheckRollup":[]}\n',
       },
       {
@@ -354,7 +354,7 @@ test("reconcile-draft-gate skips the draft conversion mutation when the PR is al
         stdout: '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOScHU78000017","isDraft":true}}}}\n',
       },
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc123456789","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -429,7 +429,7 @@ test("reconcile-draft-gate does not mark ready when upsert throws and the PR was
         stdout: '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOScHU78000017","isDraft":true}}}}\n',
       },
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc123456789","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -495,7 +495,7 @@ test("reconcile-draft-gate marks the PR ready again if gate-comment upsert throw
         stdout: '{"data":{"convertPullRequestToDraft":{"pullRequest":{"id":"PR_kwDOScHU78000017","isDraft":true}}}}\n',
       },
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc123456789","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -565,7 +565,7 @@ test("reconcile-draft-gate converts to draft, posts clean evidence, and marks re
         stdout: '{"data":{"convertPullRequestToDraft":{"pullRequest":{"id":"PR_kwDOScHU78000017","isDraft":true}}}}\n',
       },
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc123456789","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -40,7 +40,7 @@ function buildGateCoordinationEntries({
 }) {
   return [
     {
-      assertArgs: ["pr", "view", String(pr), "--repo", repo, "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+      assertArgs: ["pr", "view", String(pr), "--repo", repo, "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
       stdout: JSON.stringify({
         number: pr,
         state: "OPEN",
@@ -642,7 +642,7 @@ test("upsert-checkpoint-verdict creates a new comment when no same-head marker e
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -704,7 +704,7 @@ test("upsert-checkpoint-verdict fails closed when pre-approval gate entry is sti
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":266,"state":"OPEN","isDraft":false,"headRefOid":"def56789abcdef","reviews":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]}\n',
       },
       {
@@ -767,7 +767,7 @@ test("upsert-checkpoint-verdict appends the round-cap fallback note to pre-appro
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: JSON.stringify({
           number: 17,
           state: "OPEN",
@@ -859,7 +859,7 @@ test("upsert-checkpoint-verdict truncates verbose findings summary before commen
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":false,"headRefOid":"abc1234","reviews":[{"author":{"login":"copilot-pull-request-reviewer"},"state":"COMMENTED","submittedAt":"2026-05-31T20:00:00Z","commit":{"oid":"abc1234"}}],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]}\n',
       },
       {
@@ -946,7 +946,7 @@ test("upsert-checkpoint-verdict suppresses duplicate repost when the current sam
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -1021,7 +1021,7 @@ test("upsert-checkpoint-verdict noop still warns when a stale comment exists on 
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -1103,7 +1103,7 @@ test("upsert-checkpoint-verdict updates an incomplete same-head marker in place"
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -1178,7 +1178,7 @@ test("upsert-checkpoint-verdict updates the current same-head marker even when a
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -1269,7 +1269,7 @@ test("upsert-checkpoint-verdict prefers the latest same-head marker when it diff
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -1359,7 +1359,7 @@ test("upsert-checkpoint-verdict expands an abbreviated current-head SHA before m
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abcdef1234567890abcdef1234567890abcdef12","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -1433,7 +1433,7 @@ test("upsert-checkpoint-verdict fails closed when the requested head SHA is stal
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"def5678","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -1478,7 +1478,7 @@ test("upsert-checkpoint-verdict warns when a gate comment exists on a different 
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"def5678","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -1549,7 +1549,7 @@ test("upsert-checkpoint-verdict fails closed when draft_gate is forbidden on a n
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":266,"state":"OPEN","isDraft":false,"headRefOid":"def56789abcdef","reviews":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]}\n',
       },
       {

--- a/test/loop/detect-issue-refinement-artifact.test.mjs
+++ b/test/loop/detect-issue-refinement-artifact.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  parseDetectIssueRefinementArtifactCliArgs,
+  detectIssueRefinementArtifactFromOptions,
+} from "../../scripts/loop/detect-issue-refinement-artifact.mjs";
+
+const scriptPath = path.resolve("scripts/loop/detect-issue-refinement-artifact.mjs");
+
+test("parseDetectIssueRefinementArtifactCliArgs parses --input", () => {
+  const opts = parseDetectIssueRefinementArtifactCliArgs(["--input", "/tmp/x.json"]);
+  assert.equal(opts.input, "/tmp/x.json");
+  assert.equal(opts.repo, undefined);
+  assert.equal(opts.issue, undefined);
+});
+
+test("parseDetectIssueRefinementArtifactCliArgs parses --repo and --issue", () => {
+  const opts = parseDetectIssueRefinementArtifactCliArgs(["--repo", "owner/repo", "--issue", "532"]);
+  assert.equal(opts.repo, "owner/repo");
+  assert.equal(opts.issue, 532);
+});
+
+test("parseDetectIssueRefinementArtifactCliArgs rejects both --input and remote args", () => {
+  assert.throws(
+    () => parseDetectIssueRefinementArtifactCliArgs(["--input", "/tmp/x.json", "--repo", "owner/repo", "--issue", "1"]),
+    /exactly one/i,
+  );
+});
+
+test("parseDetectIssueRefinementArtifactCliArgs rejects neither --input nor remote args", () => {
+  assert.throws(
+    () => parseDetectIssueRefinementArtifactCliArgs([]),
+    /exactly one/i,
+  );
+});
+
+test("parseDetectIssueRefinementArtifactCliArgs rejects non-positive issue", () => {
+  assert.throws(
+    () => parseDetectIssueRefinementArtifactCliArgs(["--repo", "owner/repo", "--issue", "0"]),
+    /positive integer/i,
+  );
+});
+
+test("detectIssueRefinementArtifactFromOptions handles --input with ACs", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "refine-test-"));
+  try {
+    const input = path.join(tmp, "issue.json");
+    await writeFile(
+      input,
+      JSON.stringify({
+        repo: "owner/repo",
+        issue: 532,
+        body: "## Acceptance criteria\n\n- [ ] First AC\n- [x] Second AC\n",
+      }),
+      "utf8",
+    );
+    const result = await detectIssueRefinementArtifactFromOptions({ input });
+    assert.equal(result.ok, true);
+    assert.equal(result.repo, "owner/repo");
+    assert.equal(result.issue, 532);
+    assert.equal(result.hasACs, true);
+    assert.equal(result.source, "issue-body-ac");
+    assert.deepEqual(result.acItems, ["First AC", "Second AC"]);
+    assert.equal(result.finding, null);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("detectIssueRefinementArtifactFromOptions handles --input with prose only", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "refine-test-"));
+  try {
+    const input = path.join(tmp, "issue.json");
+    await writeFile(
+      input,
+      JSON.stringify({
+        repo: "owner/repo",
+        issue: 527,
+        body: "## Problem\n\nNo ACs here.\n\n## Root Cause\n\nBug.\n",
+      }),
+      "utf8",
+    );
+    const result = await detectIssueRefinementArtifactFromOptions({ input });
+    assert.equal(result.ok, true);
+    assert.equal(result.hasACs, false);
+    assert.equal(result.source, "missing");
+    assert.equal(result.finding, "missing_refinement_artifact");
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("detectIssueRefinementArtifactFromOptions rejects --input with malformed JSON", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "refine-test-"));
+  try {
+    const input = path.join(tmp, "issue.json");
+    await writeFile(input, "not json at all", "utf8");
+    await assert.rejects(
+      () => detectIssueRefinementArtifactFromOptions({ input }),
+      /JSON/i,
+    );
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test";
 import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import { detectPrGateCoordinationState, parseGitStatusConflictFiles } from "../../scripts/loop/detect-pr-gate-coordination-state.mjs";
+import { PR_CHECKPOINT, PR_CHECKPOINT_ACTION } from "@pi-dev-loops/core/loop/pr-gate-coordination";
 
 const scriptPath = path.resolve("scripts/loop/detect-pr-gate-coordination-state.mjs");
 
@@ -83,7 +84,7 @@ test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 266,
           state: "OPEN",
@@ -185,6 +186,11 @@ test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs
       reason: "The PR is ready for review but the post-draft external review cycle has not started yet; request Copilot review before any `pre_approval_gate` entry.",
       draftGateAlreadySatisfied: true,
       gateEvidenceRequiredForMerge: true,
+      refinementArtifact: {
+        status: "unknown",
+        linkedIssue: null,
+        reason: "No deterministically resolvable linked issue (no closingIssuesReferences, no unique Closes/Fixes pattern in body).",
+      },
     });
   } finally {
     await rm(tempDir, { recursive: true, force: true });
@@ -197,7 +203,7 @@ test("detect-pr-gate-coordination-state flags draft_gate_needed for non-draft PR
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 266,
           state: "OPEN",
@@ -244,7 +250,7 @@ test("detect-pr-gate-coordination-state flags draft_gate_needed for converged no
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 266,
           state: "OPEN",
@@ -312,7 +318,7 @@ test("detect-pr-gate-coordination-state flags draft_gate_needed when Copilot rou
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 266,
           state: "OPEN",
@@ -408,7 +414,7 @@ test("detect-pr-gate-coordination-state auto-detects local-fix-without-reply (#4
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "269", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "269", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 269,
           state: "OPEN",
@@ -501,7 +507,7 @@ test("detectPrGateCoordinationState tolerates missing local git binary and falls
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 266,
           state: "OPEN",
@@ -549,7 +555,7 @@ test("detect-pr-gate-coordination-state preserves non-conflict mergeStateStatus 
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 266,
           state: "OPEN",
@@ -611,7 +617,7 @@ test("detect-pr-gate-coordination-state surfaces conflict_resolution for conflic
   try {
     const ghEnv = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "370", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "370", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 370,
           state: "OPEN",
@@ -671,7 +677,7 @@ test("detect-pr-gate-coordination-state with --review-mode internal_only skips C
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "267", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "267", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 267,
           state: "OPEN",
@@ -755,7 +761,7 @@ test("pre-approval-gate-detector overrides to pre_approval_gate_needed when neve
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "268", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "268", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 268,
           state: "OPEN",
@@ -836,7 +842,7 @@ test("detect-pr-gate-coordination-state blocks merge readiness when retrospectiv
 
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "271", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "271", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 271,
           state: "OPEN",
@@ -917,7 +923,7 @@ test("detect-pr-gate-coordination-state fails closed when the PR head changes mi
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 266,
           state: "OPEN",
@@ -954,5 +960,100 @@ test("detect-pr-gate-coordination-state fails closed when the PR head changes mi
     assert.match(payload.error, /PR head changed while loading gate coordination facts/i);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-pr-gate-coordination-state surfaces linked-issue + refinement via gh pr view", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "gate-coord-test-"));
+  try {
+    const env = await writeGhStub(tmp, [
+      // 1) PR facts (draft, with body + closingIssuesReferences)
+      {
+        stdout: JSON.stringify({
+          number: 10,
+          state: "OPEN",
+          isDraft: true,
+          headRefOid: "abc1234567",
+          mergeStateStatus: "CLEAN",
+          body: "Closes #527\n\nImplements the fix.\n",
+          closingIssuesReferences: [{ number: 527 }],
+          reviews: [],
+          statusCheckRollup: { state: "SUCCESS" },
+        }) + "\n",
+      },
+      // 2) requested reviewers
+      { stdout: "{\"users\":[]}\n" },
+      // 3) review threads (no comments)
+      { stdout: jsonLine({ data: { repository: { pullRequest: { reviewThreads: { nodes: [], pageInfo: { hasNextPage: false } } } } } }) },
+      // 4) detect-checkpoint-evidence: pr view head SHA
+      { stdout: jsonLine({ headRefOid: "abc1234567" }) },
+      // 5) detect-checkpoint-evidence: issue comments list
+      { stdout: jsonLine([[]]) },
+      // 6) issue view for #527 — body has no ACs/DoD
+      {
+        stdout: JSON.stringify({
+          body: "## Problem\n\nProse only.\n\n## Root Cause\n\nBug.\n\n## Fix\n\nChange.\n",
+        }) + "\n",
+      },
+    ]);
+
+    const result = await detectPrGateCoordinationState(
+      { repo: "owner/repo", pr: 10 },
+      { env: { ...env, PI_SUBAGENT_RUN_ID: "" } },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.gateBoundary, PR_CHECKPOINT.BLOCKED);
+    assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
+    assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.MARK_READY_FOR_REVIEW));
+    assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE));
+    assert.match(result.reason, /no refinement artifact/i);
+    assert.match(result.reason, /#527/);
+    assert.equal(result.refinementArtifact?.status, "missing");
+    assert.equal(result.refinementArtifact?.linkedIssue, 527);
+    assert.equal(result.refinementArtifact?.finding, "missing_refinement_artifact");
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("detect-pr-gate-coordination-state leaves refinement=present when linked issue has ACs", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "gate-coord-test-"));
+  try {
+    const env = await writeGhStub(tmp, [
+      {
+        stdout: JSON.stringify({
+          number: 10,
+          state: "OPEN",
+          isDraft: true,
+          headRefOid: "abc1234567",
+          mergeStateStatus: "CLEAN",
+          body: "Closes #527\n",
+          closingIssuesReferences: [{ number: 527 }],
+          reviews: [],
+          statusCheckRollup: { state: "SUCCESS" },
+        }) + "\n",
+      },
+      { stdout: "{\"users\":[]}\n" },
+      { stdout: jsonLine({ data: { repository: { pullRequest: { reviewThreads: { nodes: [], pageInfo: { hasNextPage: false } } } } } }) },
+      { stdout: jsonLine({ headRefOid: "abc1234567" }) },
+      { stdout: jsonLine([[]]) },
+      {
+        stdout: JSON.stringify({
+          body: "## Acceptance criteria\n\n- [ ] First AC\n- [x] Second AC\n",
+        }) + "\n",
+      },
+    ]);
+
+    const result = await detectPrGateCoordinationState(
+      { repo: "owner/repo", pr: 10 },
+      { env: { ...env, PI_SUBAGENT_RUN_ID: "" } },
+    );
+    assert.equal(result.ok, true);
+    assert.notEqual(result.gateBoundary, PR_CHECKPOINT.BLOCKED);
+    assert.equal(result.gateBoundary, PR_CHECKPOINT.DRAFT_REVIEW);
+    assert.equal(result.refinementArtifact?.status, "present");
+    assert.deepEqual(result.refinementArtifact?.acItems, ["First AC", "Second AC"]);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
   }
 });

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -189,7 +189,7 @@ test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs
       refinementArtifact: {
         status: "unknown",
         linkedIssue: null,
-        reason: "No deterministically resolvable linked issue (no closingIssuesReferences, no unique Closes/Fixes pattern in body).",
+        reason: "No deterministically resolvable linked issue (no closingIssuesReferences, no unique Closes/Fixes/Resolves pattern in body).",
       },
     });
   } finally {


### PR DESCRIPTION
## Problem

Issue #527 was prose-only (no Acceptance criteria section). PR #529 was merged through the draft gate cleanly because the draft gate never verified the linked issue had an AC/DoD artifact. The gap surfaced only at the pre-approval gate, which failed closed with `missing visible clean current-head pre_approval_gate comment` (the gate correctly posted `verdict=findings_present` per the AC-verification rule, but the evidence check requires `clean`).

**The fix should be caught at the draft gate**, not the pre-approval gate. Without an enforcement at the draft boundary, the loop lets through work that cannot be objectively verified at the merge gate.

## Fix

Add a **refinement-artifact check** to the draft gate. The gate must verify, before posting its verdict, that the linked issue has:

- An `Acceptance criteria` section with at least one `- [ ]` / `- [x]` item, OR
- A `DoD` / `Definition of done` section with checklist items, OR
- A linked refinement doc (e.g., `tmp/refinement/<n>-plan.md`) referenced from the issue body

If none exist, the draft gate posts `gateBoundary=BLOCKED` and `gh pr ready` is forbidden. The PR cannot leave draft until refinement is complete.

## Implementation

- **New helper:** `packages/core/src/loop/issue-refinement-artifact.mjs` — canonical section matching, checklist extraction, linked-doc detection. `scripts/loop/detect-issue-refinement-artifact.mjs` is the CLI wrapper.
- **Wired into** `scripts/loop/detect-pr-gate-coordination-state.mjs`: the gate coordination now resolves the linked issue from `closingIssuesReferences` or a `Closes #N` /`Fixes #N` pattern in the PR body, fetches the issue body, runs the refinement check, and surfaces `refinementArtifact` in the result.
- **For draft PRs only:** the check blocks (`gateBoundary=BLOCKED`, `gh pr ready` forbidden). For non-draft PRs the check is informational.
- **Test fixtures** updated to include `body` and `closingIssuesReferences` in `gh pr view` assertions (needed for the linked-issue resolver).

## Behavior

- Issue with no ACs/DoD/linked-doc + draft PR → `gateBoundary=BLOCKED`, `gh pr ready` forbidden, reason: "no refinement artifact"
- Issue with ACs (any source) + draft PR → refinement check passes, normal draft gate flow
- Non-draft PR → refinement status surfaced as `unknown` (informational only, no extra gh call for issue body)

## Acceptance criteria (from #532)

- [x] `detect-issue-refinement-artifact.mjs` returns `source: 'missing'` for issue bodies without ACs/DoD/linked-doc
- [x] Draft gate surfaces `gateBoundary=BLOCKED` with `refinementArtifact.finding: 'missing_refinement_artifact'` when no artifact
- [x] `gh pr ready` blocked while `gateBoundary=BLOCKED` (`forbiddenActions` includes `mark_ready_for_review`)
- [x] Test reproduces #529 scenario: prose-only issue → draft gate cannot return clean
- [x] `npm run verify` is green (2315 tests, 0 failures)

## Related

- #527 — the issue that exposed this gap (prose-only)
- #529 — the PR that surfaced the gap during merge
- #527 / #529 remediation: re-run refinement (add ACs to issue #527), update PR #529, re-run pre-approval, merge

Closes #532