### PR TITLE
fix(#508): stale runner cannot merge without gate evidence; honor intercom exit signal

### DIFF
--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -261,12 +261,12 @@ export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null, s
 }
 
 
-export async function detectCheckpointEvidence(options, { env = process.env, ghCommand = "gh" } = {}) {
+export async function detectCheckpointEvidence(options, { env = process.env, ghCommand = "gh", cwd = process.cwd() } = {}) {
   const runnerOwnership = await ensureAsyncRunnerOwnership({
     repo: options.repo,
     pr: options.pr,
     env,
-    cwd: process.cwd(),
+    cwd,
     claimIfMissing: false,
     requireExisting: true,
   });
@@ -280,7 +280,7 @@ export async function detectCheckpointEvidence(options, { env = process.env, ghC
   const staleRunnerDetection = await detectStaleRunner({
     repo: options.repo,
     pr: options.pr,
-    cwd: process.cwd(),
+    cwd,
   });
   if (!staleRunnerDetection.ok) {
     const error = new Error(staleRunnerDetection.message);

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -372,6 +372,8 @@ async function main() {
         pr: result.pr,
         currentHeadSha: result.currentHeadSha,
         preMergeGateCheck,
+        staleRunnerCheck,
+        staleRunner: result.staleRunner,
       })}\n`);
       process.exitCode = 1;
       return;

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -12,6 +12,7 @@ import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.
 import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import { ensureAsyncRunnerOwnership } from "../loop/_pr-runner-coordination.mjs";
+import { detectStaleRunner } from "../loop/_stale-runner-detection.mjs";
 
 const USAGE = `Usage: detect-checkpoint-evidence.mjs --repo <owner/name> --pr <number>
 
@@ -268,6 +269,18 @@ export async function detectCheckpointEvidence(options, { env = process.env, ghC
     throw error;
   }
 
+  // #508: refuse to merge if the active runner is stale or has received an exit signal
+  const staleRunnerDetection = await detectStaleRunner({
+    repo: options.repo,
+    pr: options.pr,
+    cwd: process.cwd(),
+  });
+  if (!staleRunnerDetection.ok) {
+    const error = new Error(staleRunnerDetection.message);
+    error.staleRunner = staleRunnerDetection;
+    throw error;
+  }
+
   const prPayload = await runGhJson(["pr", "view", String(options.pr), "--repo", options.repo, "--json", "headRefOid"], { env, ghCommand });
   const commentsPayload = normalizeIssueCommentsPayload(await runGhJson(["api", "--paginate", "--slurp", `repos/${options.repo}/issues/${options.pr}/comments?per_page=100`], { env, ghCommand }));
 
@@ -293,6 +306,14 @@ export async function detectCheckpointEvidence(options, { env = process.env, ghC
     preApprovalGateMarker: normalizeGateMarkerSummary(markerSummary.pre_approval_gate),
     draftGateSatisfied: commentSummary.draft_gate?.verdict === "clean" && typeof commentSummary.draft_gate?.headSha === "string",
     ...(runnerOwnership.status !== "skipped_no_async_run_id" ? { runnerOwnership } : {}),
+    staleRunner: {
+      status: staleRunnerDetection.status,
+      activeRun: staleRunnerDetection.activeRun,
+      exitSignals: staleRunnerDetection.exitSignal?.signals ?? [],
+      staleRunner: staleRunnerDetection.staleRunner,
+      maxAgeMs: staleRunnerDetection.maxAgeMs,
+      filePath: staleRunnerDetection.filePath,
+    },
   };
 }
 
@@ -325,8 +346,16 @@ async function main() {
       unresolvedThreadCount = -1;
     }
 
-    const preMergeGateCheck = buildPreMergeGateCheck(result, unresolvedThreadCount);
-    const output = { ...result, preMergeGateCheck };
+    const staleRunnerCheck = {
+      ok: result.staleRunner.status === "fresh_runner" || result.staleRunner.status === "no_owner_record",
+      failures: result.staleRunner.status === "stale_runner"
+        ? [`stale runner: ${result.staleRunner.staleRunner?.runId} claimed ${result.staleRunner.staleRunner?.claimedAgeMs}ms ago, last updated ${result.staleRunner.staleRunner?.updatedAgeMs}ms ago (max age ${result.staleRunner.staleRunner?.maxAgeMs}ms)`]
+        : result.staleRunner.status === "exit_signal_recorded"
+        ? [`exit signal recorded for run ${result.staleRunner.activeRun?.runId}: refuse to merge`]
+        : [],
+    };
+    const preMergeGateCheck = buildPreMergeGateCheck(result, unresolvedThreadCount, staleRunnerCheck);
+    const output = { ...result, preMergeGateCheck, staleRunnerCheck };
 
     if (!preMergeGateCheck.ok) {
       process.stderr.write(`${JSON.stringify({
@@ -343,6 +372,24 @@ async function main() {
 
     process.stdout.write(`${JSON.stringify(output)}\n`);
   } catch (error) {
+    if (error && typeof error === "object" && "staleRunner" in error && error.staleRunner) {
+      const staleRunnerCheck = {
+        ok: false,
+        failures: error.staleRunner.status === "stale_runner"
+          ? [`stale runner: ${error.staleRunner.staleRunner?.runId} claimed ${error.staleRunner.staleRunner?.claimedAgeMs}ms ago, last updated ${error.staleRunner.staleRunner?.updatedAgeMs}ms ago (max age ${error.staleRunner.staleRunner?.maxAgeMs}ms)`]
+          : error.staleRunner.status === "exit_signal_recorded"
+          ? [`exit signal recorded for run ${error.staleRunner.activeRun?.runId}: refuse to merge`]
+          : [],
+      };
+      process.stderr.write(`${JSON.stringify({
+        ok: false,
+        error: error.staleRunner.message ?? error.staleRunner.error,
+        ...error.staleRunner,
+        staleRunnerCheck,
+      })}\n`);
+      process.exitCode = 1;
+      return;
+    }
     if (error && typeof error === "object" && "runnerOwnership" in error && error.runnerOwnership) {
       process.stderr.write(`${JSON.stringify(error.runnerOwnership)}\n`);
       process.exitCode = 1;

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -390,8 +390,17 @@ async function main() {
       };
       process.stderr.write(`${JSON.stringify({
         ok: false,
-        error: error.staleRunner.message ?? error.staleRunner.error,
-        ...error.staleRunner,
+        error: error.staleRunner.error,
+        status: error.staleRunner.status,
+        message: error.staleRunner.message,
+        staleRunner: {
+          status: error.staleRunner.status,
+          activeRun: error.staleRunner.activeRun,
+          exitSignals: error.staleRunner.exitSignal?.signals ?? [],
+          staleRunner: error.staleRunner.staleRunner,
+          maxAgeMs: error.staleRunner.maxAgeMs,
+          filePath: error.staleRunner.filePath,
+        },
         staleRunnerCheck,
       })}\n`);
       process.exitCode = 1;

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -221,7 +221,7 @@ function normalizeGateMarkerSummary(summary) {
   };
 }
 
-export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null) {
+export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null, staleRunnerCheck = null) {
   const failures = [];
 
   if (!(evidence.draftGate.visible && evidence.draftGate.verdict === "clean")) {
@@ -244,6 +244,13 @@ export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null) {
       failures.push("could not fetch review thread state from GitHub API; re-run gate evidence check when API connectivity is restored");
     } else {
       failures.push(`unresolved review threads present (${unresolvedThreadCount}); must resolve all threads before merge`);
+    }
+  }
+
+  // #508: incorporate stale-runner / exit-signal failures into pre-merge gate check
+  if (staleRunnerCheck && !staleRunnerCheck.ok) {
+    for (const failure of staleRunnerCheck.failures) {
+      failures.push(failure);
     }
   }
 

--- a/scripts/loop/_pr-runner-coordination.mjs
+++ b/scripts/loop/_pr-runner-coordination.mjs
@@ -543,8 +543,9 @@ export async function releaseRunnerOwnership({
 /**
  * Record an exit signal for a run id. Used by the parent session or
  * any other process to tell the runner that it must stop before any
- * merge-class mutation. Idempotent for the same run id (replaces
- * prior signal). Requires the supplied run id to be the current
+ * merge-class mutation. Appends a new entry to the exitSignals[]
+ * audit log (append-only; prior signals for the same run id are
+ * preserved). Requires the supplied run id to be the current
  * active owner unless `requireActiveOwner: false`.
  */
 export async function recordExitSignalForRunner({

--- a/scripts/loop/_pr-runner-coordination.mjs
+++ b/scripts/loop/_pr-runner-coordination.mjs
@@ -8,12 +8,14 @@ import {
   withStateFileLock as withSharedStateFileLock,
 } from "./_steering-state-file.mjs";
 
-export const RUNNER_COORDINATION_SCHEMA_VERSION = 1;
+export const RUNNER_COORDINATION_SCHEMA_VERSION = 2;
+export const RUNNER_COORDINATION_SUPPORTED_SCHEMA_VERSIONS = Object.freeze([1, 2]);
 export const RUNNER_OWNERSHIP_ERROR = Object.freeze({
   ACTIVE_RUN_EXISTS: "active_run_exists",
   OWNERSHIP_LOST: "ownership_lost",
   OWNERSHIP_MISSING: "ownership_missing",
   RUN_ID_REQUIRED: "run_id_required",
+  EXIT_SIGNAL_RECORDED: "exit_signal_recorded",
 });
 
 function normalizeRepoSlug(repo) {
@@ -36,6 +38,12 @@ function normalizeRunId(runId) {
   return typeof runId === "string" && runId.trim().length > 0
     ? runId.trim()
     : null;
+}
+
+function normalizeSignalReason(reason) {
+  if (typeof reason !== "string") return null;
+  const trimmed = reason.trim();
+  return trimmed.length > 0 ? trimmed.slice(0, 500) : null;
 }
 
 async function loadRunnerStateFile(filePath) {
@@ -96,7 +104,24 @@ export function createRunnerCoordinationState({ repo, pr, runId = null, now = ne
     history: normalizedRunId === null
       ? []
       : [{ type: "claim", runId: normalizedRunId, at: now }],
+    exitSignals: [],
   };
+}
+
+function normalizeExitSignals(raw) {
+  if (!Array.isArray(raw)) return [];
+  const out = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const runId = normalizeRunId(entry.runId);
+    if (runId === null) continue;
+    out.push({
+      runId,
+      at: typeof entry.at === "string" ? entry.at : null,
+      reason: normalizeSignalReason(entry.reason),
+    });
+  }
+  return out;
 }
 
 export function normalizeRunnerCoordinationState(raw, { repo, pr } = {}) {
@@ -104,9 +129,9 @@ export function normalizeRunnerCoordinationState(raw, { repo, pr } = {}) {
     throw new Error("Runner coordination state must be a non-null object");
   }
 
-  if (raw.schemaVersion !== RUNNER_COORDINATION_SCHEMA_VERSION) {
+  if (!RUNNER_COORDINATION_SUPPORTED_SCHEMA_VERSIONS.includes(raw.schemaVersion)) {
     throw new Error(
-      `Unsupported runner coordination schemaVersion ${JSON.stringify(raw.schemaVersion)}; expected ${RUNNER_COORDINATION_SCHEMA_VERSION}`,
+      `Unsupported runner coordination schemaVersion ${JSON.stringify(raw.schemaVersion)}; expected one of ${JSON.stringify(RUNNER_COORDINATION_SUPPORTED_SCHEMA_VERSIONS)}`,
     );
   }
 
@@ -167,11 +192,12 @@ export function normalizeRunnerCoordinationState(raw, { repo, pr } = {}) {
       }
       : null,
     history: Array.isArray(raw.history) ? raw.history : [],
+    exitSignals: normalizeExitSignals(raw.exitSignals),
   };
 }
 
-function buildConflict({ error, repo, pr, runId, activeRun, filePath, message }) {
-  return {
+function buildConflict({ error, repo, pr, runId, activeRun, filePath, message, exitSignals = null }) {
+  const payload = {
     ok: false,
     error,
     repo,
@@ -181,6 +207,10 @@ function buildConflict({ error, repo, pr, runId, activeRun, filePath, message })
     filePath,
     message,
   };
+  if (exitSignals !== null) {
+    payload.exitSignals = exitSignals;
+  }
+  return payload;
 }
 
 export async function loadRunnerCoordinationState({ repo, pr, cwd = process.cwd(), filePath = null } = {}) {
@@ -248,6 +278,7 @@ export async function claimRunnerOwnership({
         runId: normalizedRunId,
         activeRun: nextState.activeRun,
         previousRun: nextState.previousRun,
+        exitSignals: nextState.exitSignals,
         filePath: resolvedPath,
       };
     }
@@ -271,6 +302,7 @@ export async function claimRunnerOwnership({
         runId: normalizedRunId,
         activeRun: nextState.activeRun,
         previousRun: nextState.previousRun,
+        exitSignals: nextState.exitSignals,
         filePath: resolvedPath,
       };
     }
@@ -283,6 +315,7 @@ export async function claimRunnerOwnership({
         runId: normalizedRunId,
         activeRun,
         filePath: resolvedPath,
+        exitSignals: state.exitSignals,
         message: `PR ${normalizedRepo}#${normalizedPr} is already owned by run ${activeRun.runId}. Claim failed closed.`,
       });
     }
@@ -315,6 +348,7 @@ export async function claimRunnerOwnership({
       runId: normalizedRunId,
       activeRun: nextState.activeRun,
       previousRun: nextState.previousRun,
+      exitSignals: nextState.exitSignals,
       filePath: resolvedPath,
     };
   });
@@ -355,6 +389,7 @@ export async function assertRunnerOwnership({
         pr: normalizedPr,
         runId: normalizedRunId,
         activeRun: null,
+        exitSignals: [],
         filePath: resolvedPath,
       };
     }
@@ -381,6 +416,7 @@ export async function assertRunnerOwnership({
         runId: normalizedRunId,
         activeRun: null,
         previousRun: state.previousRun,
+        exitSignals: state.exitSignals,
         filePath: resolvedPath,
       };
     }
@@ -405,6 +441,7 @@ export async function assertRunnerOwnership({
       runId: normalizedRunId,
       activeRun: state.activeRun,
       previousRun: state.previousRun,
+      exitSignals: state.exitSignals,
       filePath: resolvedPath,
     };
   }
@@ -416,6 +453,7 @@ export async function assertRunnerOwnership({
     runId: normalizedRunId,
     activeRun: state.activeRun,
     filePath: resolvedPath,
+    exitSignals: state.exitSignals,
     message: state.activeRun?.runId
       ? `PR ${normalizedRepo}#${normalizedPr} is now owned by run ${state.activeRun.runId}; run ${normalizedRunId} must stop.`
       : `PR ${normalizedRepo}#${normalizedPr} no longer has an active runner ownership record; run ${normalizedRunId} must stop.`,
@@ -456,6 +494,7 @@ export async function releaseRunnerOwnership({
         pr: normalizedPr,
         runId: normalizedRunId,
         activeRun: null,
+        exitSignals: [],
         filePath: resolvedPath,
       };
     }
@@ -469,6 +508,7 @@ export async function releaseRunnerOwnership({
         runId: normalizedRunId,
         activeRun: state.activeRun,
         filePath: resolvedPath,
+        exitSignals: state.exitSignals,
         message: state.activeRun?.runId
           ? `Cannot release PR ${normalizedRepo}#${normalizedPr}: active owner is ${state.activeRun.runId}, not ${normalizedRunId}.`
           : `Cannot release PR ${normalizedRepo}#${normalizedPr}: no active owner record remains for ${normalizedRunId}.`,
@@ -494,6 +534,95 @@ export async function releaseRunnerOwnership({
       runId: normalizedRunId,
       activeRun: null,
       previousRun: nextState.previousRun,
+      exitSignals: nextState.exitSignals,
+      filePath: resolvedPath,
+    };
+  });
+}
+
+/**
+ * Record an exit signal for a run id. Used by the parent session or
+ * any other process to tell the runner that it must stop before any
+ * merge-class mutation. Idempotent for the same run id (replaces
+ * prior signal). Requires the supplied run id to be the current
+ * active owner unless `requireActiveOwner: false`.
+ */
+export async function recordExitSignalForRunner({
+  repo,
+  pr,
+  runId,
+  reason = null,
+  cwd = process.cwd(),
+  filePath = null,
+  now = new Date().toISOString(),
+  requireActiveOwner = true,
+} = {}) {
+  const normalizedRepo = normalizeRepoSlug(repo);
+  const normalizedPr = normalizePr(pr);
+  const normalizedRunId = normalizeRunId(runId);
+  if (normalizedRunId === null) {
+    return buildConflict({
+      error: RUNNER_OWNERSHIP_ERROR.RUN_ID_REQUIRED,
+      repo: normalizedRepo,
+      pr: normalizedPr,
+      runId: null,
+      activeRun: null,
+      filePath: filePath ?? defaultRunnerCoordinationFilePathForTarget({ repo: normalizedRepo, pr: normalizedPr }, cwd),
+      message: "Recording an exit signal requires a non-empty run id.",
+    });
+  }
+
+  const resolvedPath = filePath ?? defaultRunnerCoordinationFilePathForTarget({ repo: normalizedRepo, pr: normalizedPr }, cwd);
+  return withRunnerStateFileLock(resolvedPath, async () => {
+    const raw = await loadRunnerStateFile(resolvedPath);
+    if (raw === null) {
+      return buildConflict({
+        error: RUNNER_OWNERSHIP_ERROR.OWNERSHIP_MISSING,
+        repo: normalizedRepo,
+        pr: normalizedPr,
+        runId: normalizedRunId,
+        activeRun: null,
+        filePath: resolvedPath,
+        message: `Cannot record exit signal: PR ${normalizedRepo}#${normalizedPr} has no runner coordination record.`,
+      });
+    }
+
+    const state = normalizeRunnerCoordinationState(raw, { repo: normalizedRepo, pr: normalizedPr });
+    if (requireActiveOwner && (state.activeRun === null || state.activeRun.runId !== normalizedRunId)) {
+      return buildConflict({
+        error: RUNNER_OWNERSHIP_ERROR.OWNERSHIP_LOST,
+        repo: normalizedRepo,
+        pr: normalizedPr,
+        runId: normalizedRunId,
+        activeRun: state.activeRun,
+        filePath: resolvedPath,
+        exitSignals: state.exitSignals,
+        message: state.activeRun?.runId
+          ? `Cannot record exit signal: PR ${normalizedRepo}#${normalizedPr} is owned by ${state.activeRun.runId}, not ${normalizedRunId}.`
+          : `Cannot record exit signal: PR ${normalizedRepo}#${normalizedPr} no longer has an active owner.`,
+      });
+    }
+
+    const filtered = (state.exitSignals || []).filter((entry) => entry.runId !== normalizedRunId);
+    const nextSignal = {
+      runId: normalizedRunId,
+      at: now,
+      reason: normalizeSignalReason(reason),
+    };
+    const nextState = {
+      ...state,
+      exitSignals: [...filtered, nextSignal],
+    };
+    await saveRunnerStateFile(resolvedPath, nextState);
+    return {
+      ok: true,
+      status: "exit_signal_recorded",
+      repo: normalizedRepo,
+      pr: normalizedPr,
+      runId: normalizedRunId,
+      activeRun: state.activeRun,
+      previousRun: state.previousRun,
+      exitSignals: nextState.exitSignals,
       filePath: resolvedPath,
     };
   });
@@ -516,6 +645,7 @@ export async function ensureAsyncRunnerOwnership({
       pr: normalizePr(pr),
       runId: null,
       activeRun: null,
+      exitSignals: [],
       filePath: defaultRunnerCoordinationFilePathForTarget({ repo, pr }, cwd),
     };
   }

--- a/scripts/loop/_pr-runner-coordination.mjs
+++ b/scripts/loop/_pr-runner-coordination.mjs
@@ -603,7 +603,7 @@ export async function recordExitSignalForRunner({
       });
     }
 
-    const filtered = (state.exitSignals || []).filter((entry) => entry.runId !== normalizedRunId);
+    // Append: exitSignals are immutable records; keep all prior signals for audit trail
     const nextSignal = {
       runId: normalizedRunId,
       at: now,
@@ -611,7 +611,7 @@ export async function recordExitSignalForRunner({
     };
     const nextState = {
       ...state,
-      exitSignals: [...filtered, nextSignal],
+      exitSignals: [...(state.exitSignals || []), nextSignal],
     };
     await saveRunnerStateFile(resolvedPath, nextState);
     return {

--- a/scripts/loop/_stale-runner-detection.mjs
+++ b/scripts/loop/_stale-runner-detection.mjs
@@ -1,0 +1,170 @@
+/**
+ * Deterministic stale-runner + exit-signal detection for the per-PR
+ * runner coordination state.
+ *
+ * Backs `scripts/loop/detect-stale-runner.mjs` (CLI) and the
+ * `detect-checkpoint-evidence.mjs` pre-merge guard. Two failure
+ * modes are detected:
+ *
+ * 1. **stale_runner** — the active run's `claimedAt` is older than
+ *    `staleRunnerMaxAgeMs` and its `updatedAt` is also older than
+ *    `staleRunnerMaxAgeMs`. The merge path must refuse to proceed
+ *    because a newer runner should have taken over by now.
+ * 2. **exit_signal_recorded** — an exit signal for the active run id
+ *    is recorded in `state.exitSignals[]`. The merge path must
+ *    refuse to proceed because the run was told to exit.
+ *
+ * The state file path is exactly the per-PR coordination state at
+ * `.pi/runner-coordination/<owner>/<name>/pr-<N>.json`. If the state
+ * file is missing there is no active runner to detect, and the
+ * detector returns `ok: true` with `status: "no_owner_record"`.
+ */
+import {
+  loadRunnerCoordinationState,
+} from "./_pr-runner-coordination.mjs";
+
+export const STALE_RUNNER_ERROR = Object.freeze({
+  STALE_RUNNER: "stale_runner",
+  EXIT_SIGNAL_RECORDED: "exit_signal_recorded",
+});
+
+export const STALE_RUNNER_DEFAULT_MAX_AGE_MS = 30 * 60 * 1000;
+
+function parsePositiveIntegerMs(value, fallback) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return Math.floor(parsed);
+}
+
+export function resolveStaleRunnerMaxAgeMs(options = {}, env = process.env) {
+  const explicit = options?.staleRunnerMaxAgeMs;
+  if (Number.isFinite(explicit) && explicit > 0) {
+    return Math.floor(explicit);
+  }
+  const fromEnv = parsePositiveIntegerMs(env?.PI_DEV_LOOP_STALE_RUNNER_MAX_AGE_MS, NaN);
+  if (Number.isFinite(fromEnv) && fromEnv > 0) {
+    return fromEnv;
+  }
+  return STALE_RUNNER_DEFAULT_MAX_AGE_MS;
+}
+
+function normalizeRunIdForSignal(runId) {
+  return typeof runId === "string" && runId.trim().length > 0 ? runId.trim() : null;
+}
+
+function isExitSignalForRun(state, runId) {
+  if (!state || !Array.isArray(state.exitSignals) || runId === null) {
+    return false;
+  }
+  return state.exitSignals.some((entry) => {
+    if (!entry || typeof entry !== "object") return false;
+    return normalizeRunIdForSignal(entry.runId) === runId;
+  });
+}
+
+function findStaleRunnerMatch(state, { now, maxAgeMs }) {
+  if (!state || !state.activeRun) return null;
+  const active = state.activeRun;
+  if (!active.runId) return null;
+  const claimedAt = typeof active.claimedAt === "string" ? Date.parse(active.claimedAt) : NaN;
+  const updatedAt = typeof active.updatedAt === "string" ? Date.parse(active.updatedAt) : NaN;
+  if (!Number.isFinite(claimedAt) || !Number.isFinite(updatedAt)) {
+    return null;
+  }
+  const claimedAgeMs = now - claimedAt;
+  const updatedAgeMs = now - updatedAt;
+  if (claimedAgeMs > maxAgeMs && updatedAgeMs > maxAgeMs) {
+    return {
+      runId: active.runId,
+      claimedAt: active.claimedAt,
+      updatedAt: active.updatedAt,
+      claimedAgeMs,
+      updatedAgeMs,
+      maxAgeMs,
+    };
+  }
+  return null;
+}
+
+export async function detectStaleRunner({ repo, pr, now = Date.now(), maxAgeMs, cwd = process.cwd() } = {}) {
+  if (!repo || typeof repo !== "string") {
+    throw new Error("detectStaleRunner requires a non-empty repo slug");
+  }
+  if (pr === undefined || pr === null) {
+    throw new Error("detectStaleRunner requires a PR number");
+  }
+
+  const effectiveMaxAgeMs = resolveStaleRunnerMaxAgeMs({ staleRunnerMaxAgeMs: maxAgeMs });
+  const loaded = await loadRunnerCoordinationState({ repo, pr, cwd });
+
+  if (loaded.state === null) {
+    return {
+      ok: true,
+      status: "no_owner_record",
+      repo,
+      pr,
+      activeRun: null,
+      staleRunner: null,
+      exitSignal: null,
+      filePath: loaded.filePath,
+      maxAgeMs: effectiveMaxAgeMs,
+    };
+  }
+
+  const state = loaded.state;
+  const active = state.activeRun;
+  const staleMatch = findStaleRunnerMatch(state, { now, maxAgeMs: effectiveMaxAgeMs });
+  const exitSignal = isExitSignalForRun(state, active?.runId ?? null)
+    ? {
+        runId: active.runId,
+        signals: (state.exitSignals || []).filter((entry) =>
+          normalizeRunIdForSignal(entry?.runId) === active.runId),
+      }
+    : null;
+
+  if (exitSignal !== null) {
+    return {
+      ok: false,
+      error: STALE_RUNNER_ERROR.EXIT_SIGNAL_RECORDED,
+      status: "exit_signal_recorded",
+      repo,
+      pr,
+      activeRun: active,
+      staleRunner: null,
+      exitSignal,
+      filePath: loaded.filePath,
+      maxAgeMs: effectiveMaxAgeMs,
+      message: `Run ${active.runId} has an exit signal recorded for ${repo}#${pr}; refuse to proceed with merge.`,
+    };
+  }
+
+  if (staleMatch !== null) {
+    return {
+      ok: false,
+      error: STALE_RUNNER_ERROR.STALE_RUNNER,
+      status: "stale_runner",
+      repo,
+      pr,
+      activeRun: active,
+      staleRunner: staleMatch,
+      exitSignal: null,
+      filePath: loaded.filePath,
+      maxAgeMs: effectiveMaxAgeMs,
+      message: `Active run ${staleMatch.runId} for ${repo}#${pr} is stale (claimed ${staleMatch.claimedAgeMs}ms ago, last updated ${staleMatch.updatedAgeMs}ms ago, max age ${staleMatch.maxAgeMs}ms).`,
+    };
+  }
+
+  return {
+    ok: true,
+    status: "fresh_runner",
+    repo,
+    pr,
+    activeRun: active,
+    staleRunner: null,
+    exitSignal: null,
+    filePath: loaded.filePath,
+    maxAgeMs: effectiveMaxAgeMs,
+  };
+}

--- a/scripts/loop/_stale-runner-detection.mjs
+++ b/scripts/loop/_stale-runner-detection.mjs
@@ -70,8 +70,19 @@ function findStaleRunnerMatch(state, { now, maxAgeMs }) {
   if (!active.runId) return null;
   const claimedAt = typeof active.claimedAt === "string" ? Date.parse(active.claimedAt) : NaN;
   const updatedAt = typeof active.updatedAt === "string" ? Date.parse(active.updatedAt) : NaN;
-  if (!Number.isFinite(claimedAt) || !Number.isFinite(updatedAt)) {
-    return null;
+  // Fail closed: treat unparseable timestamps as stale rather than fresh
+  const claimedCorrupt = !Number.isFinite(claimedAt);
+  const updatedCorrupt = !Number.isFinite(updatedAt);
+  if (claimedCorrupt || updatedCorrupt) {
+    return {
+      runId: active.runId,
+      claimedAt: active.claimedAt ?? "(corrupt)",
+      updatedAt: active.updatedAt ?? "(corrupt)",
+      claimedAgeMs: claimedCorrupt ? -1 : now - claimedAt,
+      updatedAgeMs: updatedCorrupt ? -1 : now - updatedAt,
+      maxAgeMs,
+      corruptedTimestamp: true,
+    };
   }
   const claimedAgeMs = now - claimedAt;
   const updatedAgeMs = now - updatedAt;

--- a/scripts/loop/detect-stale-runner.mjs
+++ b/scripts/loop/detect-stale-runner.mjs
@@ -7,7 +7,6 @@ import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import {
   detectStaleRunner,
   STALE_RUNNER_ERROR,
-  resolveStaleRunnerMaxAgeMs,
 } from "./_stale-runner-detection.mjs";
 
 const USAGE = `Usage: detect-stale-runner.mjs --repo <owner/name> --pr <number>
@@ -164,8 +163,30 @@ export async function runDetectStaleRunner(options, { env = process.env, cwd = p
   const ownershipLost = explicitRunId !== null
     && detection.activeRun !== null
     && detection.activeRun.runId !== explicitRunId;
+  // Also fail closed when a run id is supplied but no active owner record exists
+  const ownershipMissing = explicitRunId !== null && detection.activeRun === null;
 
   const staleRunnerCheck = buildStaleRunnerCheck(detection);
+
+  if (ownershipMissing) {
+    return {
+      ok: false,
+      error: "ownership_lost",
+      repo: options.repo.trim().toLowerCase(),
+      pr: options.pr,
+      status: "ownership_lost",
+      activeRun: null,
+      runId: explicitRunId,
+      exitSignals: [],
+      filePath: detection.filePath,
+      maxAgeMs: detection.maxAgeMs,
+      message: `Stale-runner check: run ${explicitRunId} is no longer the active owner of ${options.repo}#${options.pr}; no active owner record exists.`,
+      staleRunnerCheck: {
+        ok: false,
+        failures: [`ownership_lost: no active owner record exists; run ${explicitRunId} is not the owner`],
+      },
+    };
+  }
 
   if (ownershipLost) {
     return {

--- a/scripts/loop/detect-stale-runner.mjs
+++ b/scripts/loop/detect-stale-runner.mjs
@@ -176,7 +176,7 @@ export async function runDetectStaleRunner(options, { env = process.env, cwd = p
       status: "ownership_lost",
       activeRun: detection.activeRun,
       runId: explicitRunId,
-      exitSignals: detection.exitSignal ? [detection.exitSignal] : [],
+      exitSignals: detection.exitSignal?.signals ?? [],
       filePath: detection.filePath,
       maxAgeMs: detection.maxAgeMs,
       message: `Stale-runner check: run ${explicitRunId} is no longer the active owner of ${options.repo}#${options.pr}; current owner is ${detection.activeRun?.runId}.`,

--- a/scripts/loop/detect-stale-runner.mjs
+++ b/scripts/loop/detect-stale-runner.mjs
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+import process from "node:process";
+
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { parsePrNumber, requireOptionValue } from "../_cli-primitives.mjs";
+import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import {
+  detectStaleRunner,
+  STALE_RUNNER_ERROR,
+  resolveStaleRunnerMaxAgeMs,
+} from "./_stale-runner-detection.mjs";
+
+const USAGE = `Usage: detect-stale-runner.mjs --repo <owner/name> --pr <number>
+
+Detect whether the active runner for a PR is stale or has received an exit
+signal. Fails closed with status "stale_runner" or "exit_signal_recorded" so
+the pre-merge guard can refuse to proceed.
+
+Required:
+  --repo <owner/name>   Repository slug (e.g. owner/repo)
+  --pr <number>         Pull request number
+
+Optional:
+  --stale-runner-max-age-ms <ms>
+                        Override the staleness threshold (default 30 minutes,
+                        or $PI_DEV_LOOP_STALE_RUNNER_MAX_AGE_MS).
+  --run-id <id>         Override the active run id (default: read from
+                        PI_SUBAGENT_RUN_ID). When supplied, the detector
+                        additionally verifies the current run id is still
+                        the active owner.
+
+Output (stdout, JSON; always includes staleRunnerCheck):
+  {
+    "ok": true,
+    "repo": "owner/repo",
+    "pr": 17,
+    "status": "fresh_runner",
+    "activeRun": { "runId": "...", "claimedAt": "...", "updatedAt": "..." },
+    "staleRunnerCheck": {
+      "ok": true,
+      "failures": []
+    }
+  }
+
+  or on failure:
+  {
+    "ok": false,
+    "error": "stale_runner" | "exit_signal_recorded",
+    "message": "...",
+    "staleRunnerCheck": {
+      "ok": false,
+      "failures": ["stale runner: run X claimed N ms ago, last updated M ms ago (max age K ms)"]
+    }
+  }
+
+Exit codes:
+  0  Success / fresh runner / no owner record
+  1  Argument error or stale/exit-signal condition detected`.trim();
+
+const parseError = buildParseError(USAGE);
+
+function parseCliArgs(argv) {
+  const args = [...argv];
+  const options = {
+    help: false,
+    repo: undefined,
+    pr: undefined,
+    staleRunnerMaxAgeMs: undefined,
+    runId: undefined,
+  };
+
+  while (args.length > 0) {
+    const token = args.shift();
+
+    if (token === "--help" || token === "-h") {
+      options.help = true;
+      return options;
+    }
+
+    if (token === "--repo") {
+      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+      continue;
+    }
+
+    if (token === "--pr") {
+      options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+      continue;
+    }
+
+    if (token === "--stale-runner-max-age-ms") {
+      const raw = requireOptionValue(args, "--stale-runner-max-age-ms", parseError).trim();
+      const parsed = Number(raw);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw parseError(`--stale-runner-max-age-ms must be a positive integer (ms), got: ${raw}`);
+      }
+      options.staleRunnerMaxAgeMs = Math.floor(parsed);
+      continue;
+    }
+
+    if (token === "--run-id") {
+      options.runId = requireOptionValue(args, "--run-id", parseError).trim();
+      continue;
+    }
+
+    throw parseError(`Unknown argument: ${token}`);
+  }
+
+  if (options.repo === undefined || options.pr === undefined) {
+    throw parseError("detect-stale-runner requires both --repo <owner/name> and --pr <number>");
+  }
+
+  try {
+    parseRepoSlug(options.repo);
+  } catch (error) {
+    throw parseError(error instanceof Error ? error.message : String(error));
+  }
+
+  return options;
+}
+
+function resolveRunId(explicitRunId, env) {
+  if (typeof explicitRunId === "string" && explicitRunId.trim().length > 0) {
+    return explicitRunId.trim();
+  }
+  if (typeof env?.PI_SUBAGENT_RUN_ID === "string" && env.PI_SUBAGENT_RUN_ID.trim().length > 0) {
+    return env.PI_SUBAGENT_RUN_ID.trim();
+  }
+  return null;
+}
+
+function buildStaleRunnerCheck(detection) {
+  if (detection.status === "no_owner_record") {
+    return {
+      ok: true,
+      failures: [],
+    };
+  }
+  if (detection.status === "exit_signal_recorded") {
+    return {
+      ok: false,
+      failures: [`exit signal recorded for run ${detection.activeRun?.runId ?? "unknown"}: refuse to merge`],
+    };
+  }
+  if (detection.status === "stale_runner") {
+    return {
+      ok: false,
+      failures: [
+        `stale runner: run ${detection.staleRunner.runId} claimed ${detection.staleRunner.claimedAgeMs}ms ago, last updated ${detection.staleRunner.updatedAgeMs}ms ago (max age ${detection.staleRunner.maxAgeMs}ms)`,
+      ],
+    };
+  }
+  return { ok: true, failures: [] };
+}
+
+export async function runDetectStaleRunner(options, { env = process.env, cwd = process.cwd() } = {}) {
+  const detection = await detectStaleRunner({
+    repo: options.repo,
+    pr: options.pr,
+    maxAgeMs: options.staleRunnerMaxAgeMs,
+    cwd,
+  });
+
+  const explicitRunId = resolveRunId(options.runId, env);
+  const ownershipLost = explicitRunId !== null
+    && detection.activeRun !== null
+    && detection.activeRun.runId !== explicitRunId;
+
+  const staleRunnerCheck = buildStaleRunnerCheck(detection);
+
+  if (ownershipLost) {
+    return {
+      ok: false,
+      error: "ownership_lost",
+      repo: options.repo.trim().toLowerCase(),
+      pr: options.pr,
+      status: "ownership_lost",
+      activeRun: detection.activeRun,
+      runId: explicitRunId,
+      exitSignals: detection.exitSignal ? [detection.exitSignal] : [],
+      filePath: detection.filePath,
+      maxAgeMs: detection.maxAgeMs,
+      message: `Stale-runner check: run ${explicitRunId} is no longer the active owner of ${options.repo}#${options.pr}; current owner is ${detection.activeRun?.runId}.`,
+      staleRunnerCheck: {
+        ok: false,
+        failures: [`ownership_lost: active owner is ${detection.activeRun?.runId ?? "unknown"}, not ${explicitRunId}`],
+      },
+    };
+  }
+
+  if (detection.status === "exit_signal_recorded") {
+    return {
+      ok: false,
+      error: STALE_RUNNER_ERROR.EXIT_SIGNAL_RECORDED,
+      repo: options.repo.trim().toLowerCase(),
+      pr: options.pr,
+      status: "exit_signal_recorded",
+      activeRun: detection.activeRun,
+      runId: explicitRunId,
+      exitSignals: detection.exitSignal?.signals ?? [],
+      filePath: detection.filePath,
+      maxAgeMs: detection.maxAgeMs,
+      message: detection.message,
+      staleRunnerCheck,
+    };
+  }
+
+  if (detection.status === "stale_runner") {
+    return {
+      ok: false,
+      error: STALE_RUNNER_ERROR.STALE_RUNNER,
+      repo: options.repo.trim().toLowerCase(),
+      pr: options.pr,
+      status: "stale_runner",
+      activeRun: detection.activeRun,
+      runId: explicitRunId,
+      exitSignals: [],
+      staleRunner: detection.staleRunner,
+      filePath: detection.filePath,
+      maxAgeMs: detection.maxAgeMs,
+      message: detection.message,
+      staleRunnerCheck,
+    };
+  }
+
+  return {
+    ok: true,
+    repo: options.repo.trim().toLowerCase(),
+    pr: options.pr,
+    status: detection.status,
+    activeRun: detection.activeRun,
+    runId: explicitRunId,
+    exitSignals: [],
+    filePath: detection.filePath,
+    maxAgeMs: detection.maxAgeMs,
+    staleRunnerCheck,
+  };
+}
+
+async function main() {
+  try {
+    const options = parseCliArgs(process.argv.slice(2));
+    if (options.help) {
+      console.log(USAGE);
+      return;
+    }
+
+    const result = await runDetectStaleRunner(options, { env: process.env });
+    if (!result.ok) {
+      console.error(JSON.stringify(result));
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log(JSON.stringify(result));
+  } catch (error) {
+    const payload = formatCliError(error, { usage: USAGE });
+    console.error(JSON.stringify(payload));
+    process.exitCode = 1;
+  }
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  await main();
+}

--- a/test/github/detect-checkpoint-evidence-stale-runner.test.mjs
+++ b/test/github/detect-checkpoint-evidence-stale-runner.test.mjs
@@ -77,7 +77,7 @@ test("detect-checkpoint-evidence fails closed when active runner is stale", asyn
       pr: 17,
       runId: "run-stale",
       cwd: tempDir,
-      now: "2026-06-05T08:00:00.000Z",
+      now: "2000-01-01T00:00:00.000Z",
     });
 
     // Pretend the run is far in the past so detectStaleRunner classifies it as stale.

--- a/test/github/detect-checkpoint-evidence-stale-runner.test.mjs
+++ b/test/github/detect-checkpoint-evidence-stale-runner.test.mjs
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  claimRunnerOwnership,
+  recordExitSignalForRunner,
+} from "../../scripts/loop/_pr-runner-coordination.mjs";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
+
+const scriptPath = path.resolve("scripts/github/detect-checkpoint-evidence.mjs");
+
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, {
+  ...options,
+  env: {
+    ...process.env,
+    ...(options.env ?? {}),
+    PI_SUBAGENT_RUN_ID: options.env?.PI_SUBAGENT_RUN_ID ?? "",
+  },
+});
+
+async function writeGhStub(tempDir) {
+  const { env } = await writeGhStubHelper(tempDir, [
+    {
+      assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
+      stdout: '{"headRefOid":"abc1234"}\n',
+    },
+    {
+      assertArgs: ["api", "repos/owner/repo/issues/17/comments?per_page=100"],
+      stdout: `${JSON.stringify([
+        {
+          id: 70,
+          body: [
+            "Gate review: draft_gate",
+            "Reviewed head SHA: bcd5678",
+            "Verdict: clean",
+            "Findings summary: no issues found",
+            "Next action: mark ready for review",
+          ].join("\n"),
+          updated_at: "2026-05-29T21:00:00Z",
+          html_url: "https://github.com/owner/repo/pull/17#issuecomment-70",
+        },
+        {
+          id: 71,
+          body: [
+            "Gate review: pre_approval_gate",
+            "Reviewed head SHA: abc1234",
+            "Verdict: clean",
+            "Findings summary: no issues found",
+            "Next action: await final human approval",
+          ].join("\n"),
+          updated_at: "2026-05-29T22:00:00Z",
+          html_url: "https://github.com/owner/repo/pull/17#issuecomment-71",
+        },
+      ])}\n`,
+    },
+    {
+      assertArgs: ["api", "graphql"],
+      stdout: JSON.stringify({
+        data: { repository: { pullRequest: { reviewThreads: { nodes: [
+          { id: "t1", isResolved: true, comments: { nodes: [] } },
+        ] } } } }
+      }) + "\n",
+    },
+  ], { repeatLastOnOverflow: true });
+  return { ...env, PI_SUBAGENT_RUN_ID: "" };
+}
+
+test("detect-checkpoint-evidence fails closed when active runner is stale", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-ckpt-"));
+
+  try {
+    await claimRunnerOwnership({
+      repo: "owner/repo",
+      pr: 17,
+      runId: "run-stale",
+      cwd: tempDir,
+      now: "2026-06-05T08:00:00.000Z",
+    });
+
+    // Pretend the run is far in the past so detectStaleRunner classifies it as stale.
+    const env = await writeGhStub(tempDir);
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], {
+      cwd: tempDir,
+      env: {
+        ...env,
+        PI_DEV_LOOP_STALE_RUNNER_MAX_AGE_MS: "1000",
+      },
+    });
+
+    assert.equal(result.code, 1, result.stderr);
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.error, "stale_runner");
+    assert.equal(payload.status, "stale_runner");
+    assert.ok(payload.staleRunnerCheck.failures[0].includes("stale"));
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-checkpoint-evidence fails closed when active runner has an exit signal", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-ckpt-"));
+
+  try {
+    await claimRunnerOwnership({
+      repo: "owner/repo",
+      pr: 17,
+      runId: "run-active",
+      cwd: tempDir,
+      now: "2026-06-05T08:00:00.000Z",
+    });
+
+    await recordExitSignalForRunner({
+      repo: "owner/repo",
+      pr: 17,
+      runId: "run-active",
+      cwd: tempDir,
+      now: "2026-06-05T08:01:00.000Z",
+      reason: "Fresh runner took over",
+    });
+
+    const env = await writeGhStub(tempDir);
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], {
+      cwd: tempDir,
+      env,
+    });
+
+    assert.equal(result.code, 1, result.stderr);
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.error, "exit_signal_recorded");
+    assert.equal(payload.status, "exit_signal_recorded");
+    assert.ok(payload.staleRunnerCheck.failures[0].includes("exit signal"));
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-checkpoint-evidence includes staleRunner and staleRunnerCheck in successful output", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-ckpt-"));
+
+  try {
+    const env = await writeGhStub(tempDir);
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], {
+      cwd: tempDir,
+      env,
+    });
+
+    assert.equal(result.code, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.staleRunner.status, "no_owner_record");
+    assert.equal(payload.staleRunnerCheck.ok, true);
+    assert.deepEqual(payload.staleRunnerCheck.failures, []);
+    assert.equal(payload.preMergeGateCheck.ok, true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -267,7 +267,9 @@ test("detect-checkpoint-evidence summarizes the newest valid live gate comments 
 
     assert.equal(result.code, 0);
     assert.equal(result.stderr, "");
-    assert.deepEqual(JSON.parse(result.stdout), {
+    const parsed = JSON.parse(result.stdout);
+    parsed.staleRunner = { ...parsed.staleRunner, filePath: "<stale-runner-file-path>" };
+    assert.deepEqual(parsed, {
       ok: true,
       repo: "owner/repo",
       pr: 17,
@@ -316,6 +318,18 @@ test("detect-checkpoint-evidence summarizes the newest valid live gate comments 
       },
       draftGateSatisfied: true,
       preMergeGateCheck: {
+        ok: true,
+        failures: [],
+      },
+      staleRunner: {
+        status: "no_owner_record",
+        activeRun: null,
+        exitSignals: [],
+        staleRunner: null,
+        maxAgeMs: 1_800_000,
+        filePath: "<stale-runner-file-path>",
+      },
+      staleRunnerCheck: {
         ok: true,
         failures: [],
       },

--- a/test/loop/detect-stale-runner.test.mjs
+++ b/test/loop/detect-stale-runner.test.mjs
@@ -1,0 +1,248 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  detectStaleRunner,
+  resolveStaleRunnerMaxAgeMs,
+  STALE_RUNNER_ERROR,
+} from "../../scripts/loop/_stale-runner-detection.mjs";
+import {
+  claimRunnerOwnership,
+  recordExitSignalForRunner,
+} from "../../scripts/loop/_pr-runner-coordination.mjs";
+
+test("resolveStaleRunnerMaxAgeMs prefers explicit option, then env, then default", () => {
+  assert.equal(resolveStaleRunnerMaxAgeMs(), 30 * 60 * 1000);
+  assert.equal(resolveStaleRunnerMaxAgeMs({}), 30 * 60 * 1000);
+  assert.equal(resolveStaleRunnerMaxAgeMs({ staleRunnerMaxAgeMs: 5000 }), 5000);
+  assert.equal(resolveStaleRunnerMaxAgeMs({}, { PI_DEV_LOOP_STALE_RUNNER_MAX_AGE_MS: "9000" }), 9000);
+  assert.equal(
+    resolveStaleRunnerMaxAgeMs({ staleRunnerMaxAgeMs: 5000 }, { PI_DEV_LOOP_STALE_RUNNER_MAX_AGE_MS: "9000" }),
+    5000,
+  );
+  assert.equal(resolveStaleRunnerMaxAgeMs({ staleRunnerMaxAgeMs: -1 }), 30 * 60 * 1000);
+  assert.equal(resolveStaleRunnerMaxAgeMs({}, { PI_DEV_LOOP_STALE_RUNNER_MAX_AGE_MS: "abc" }), 30 * 60 * 1000);
+});
+
+test("detectStaleRunner returns no_owner_record when no coordination file exists", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-"));
+
+  try {
+    const result = await detectStaleRunner({ repo: "owner/repo", pr: 17, cwd: tempDir });
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "no_owner_record");
+    assert.equal(result.activeRun, null);
+    assert.equal(result.staleRunner, null);
+    assert.equal(result.exitSignal, null);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detectStaleRunner returns fresh_runner when active run is recent", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-"));
+
+  try {
+    const claimed = await claimRunnerOwnership({
+      repo: "owner/repo",
+      pr: 17,
+      runId: "run-fresh",
+      cwd: tempDir,
+      now: new Date().toISOString(),
+    });
+    assert.equal(claimed.ok, true);
+
+    const result = await detectStaleRunner({
+      repo: "owner/repo",
+      pr: 17,
+      cwd: tempDir,
+      now: Date.parse(claimed.activeRun.claimedAt) + 60_000,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "fresh_runner");
+    assert.equal(result.activeRun.runId, "run-fresh");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detectStaleRunner returns stale_runner when active run is older than max age", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-"));
+
+  try {
+    const claimed = await claimRunnerOwnership({
+      repo: "owner/repo",
+      pr: 17,
+      runId: "run-stale",
+      cwd: tempDir,
+      now: "2026-06-05T08:00:00.000Z",
+    });
+    assert.equal(claimed.ok, true);
+
+    const result = await detectStaleRunner({
+      repo: "owner/repo",
+      pr: 17,
+      cwd: tempDir,
+      now: Date.parse("2026-06-05T08:00:00.000Z") + 60 * 60 * 1000, // 1 hour later
+      maxAgeMs: 30 * 60 * 1000,
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.error, STALE_RUNNER_ERROR.STALE_RUNNER);
+    assert.equal(result.status, "stale_runner");
+    assert.equal(result.staleRunner.runId, "run-stale");
+    assert.ok(result.staleRunner.claimedAgeMs > 30 * 60 * 1000);
+    assert.ok(result.staleRunner.updatedAgeMs > 30 * 60 * 1000);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detectStaleRunner returns exit_signal_recorded when an exit signal exists for the active run", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-"));
+
+  try {
+    const claimed = await claimRunnerOwnership({
+      repo: "owner/repo",
+      pr: 17,
+      runId: "run-active",
+      cwd: tempDir,
+      now: "2026-06-05T08:00:00.000Z",
+    });
+    assert.equal(claimed.ok, true);
+
+    const exitSignal = await recordExitSignalForRunner({
+      repo: "owner/repo",
+      pr: 17,
+      runId: "run-active",
+      cwd: tempDir,
+      now: "2026-06-05T08:05:00.000Z",
+      reason: "Fresh runner took over",
+    });
+    assert.equal(exitSignal.ok, true);
+
+    const result = await detectStaleRunner({
+      repo: "owner/repo",
+      pr: 17,
+      cwd: tempDir,
+      now: Date.parse("2026-06-05T08:05:00.000Z") + 60_000,
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.error, STALE_RUNNER_ERROR.EXIT_SIGNAL_RECORDED);
+    assert.equal(result.status, "exit_signal_recorded");
+    assert.equal(result.activeRun.runId, "run-active");
+    assert.equal(result.exitSignal.signals.length, 1);
+    assert.equal(result.exitSignal.signals[0].reason, "Fresh runner took over");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detectStaleRunner ignores exit signals for non-active runs", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-"));
+
+  try {
+    // claim a non-owner exit signal that should be ignored (requireActiveOwner=false bypasses the
+    // ownership check at write-time, so the signal is stored but the active run never matches it).
+    await claimRunnerOwnership({
+      repo: "owner/repo",
+      pr: 17,
+      runId: "run-active",
+      cwd: tempDir,
+      now: "2026-06-05T08:00:00.000Z",
+    });
+
+    await recordExitSignalForRunner({
+      repo: "owner/repo",
+      pr: 17,
+      runId: "run-not-owner",
+      cwd: tempDir,
+      now: "2026-06-05T08:00:30.000Z",
+      reason: "obsolete",
+      requireActiveOwner: false,
+    });
+
+    const result = await detectStaleRunner({
+      repo: "owner/repo",
+      pr: 17,
+      cwd: tempDir,
+      now: Date.parse("2026-06-05T08:00:30.000Z") + 5_000,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "fresh_runner");
+    assert.equal(result.exitSignal, null);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("recordExitSignalForRunner rejects when current run is not the active owner", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-"));
+
+  try {
+    await claimRunnerOwnership({
+      repo: "owner/repo",
+      pr: 17,
+      runId: "run-active",
+      cwd: tempDir,
+      now: "2026-06-05T08:00:00.000Z",
+    });
+
+    const result = await recordExitSignalForRunner({
+      repo: "owner/repo",
+      pr: 17,
+      runId: "run-stale",
+      cwd: tempDir,
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "ownership_lost");
+    assert.equal(result.activeRun.runId, "run-active");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("recordExitSignalForRunner allows non-owner recording when requireActiveOwner is false", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-"));
+
+  try {
+    await claimRunnerOwnership({
+      repo: "owner/repo",
+      pr: 17,
+      runId: "run-active",
+      cwd: tempDir,
+      now: "2026-06-05T08:00:00.000Z",
+    });
+
+    const result = await recordExitSignalForRunner({
+      repo: "owner/repo",
+      pr: 17,
+      runId: "run-stale",
+      cwd: tempDir,
+      requireActiveOwner: false,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "exit_signal_recorded");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("recordExitSignalForRunner rejects when no coordination file exists", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-"));
+
+  try {
+    const result = await recordExitSignalForRunner({
+      repo: "owner/repo",
+      pr: 17,
+      runId: "run-stale",
+      cwd: tempDir,
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "ownership_missing");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/loop/detect-stale-runner.test.mjs
+++ b/test/loop/detect-stale-runner.test.mjs
@@ -24,7 +24,7 @@ test("resolveStaleRunnerMaxAgeMs prefers explicit option, then env, then default
     resolveStaleRunnerMaxAgeMs({ staleRunnerMaxAgeMs: 5000 }, { PI_DEV_LOOP_STALE_RUNNER_MAX_AGE_MS: "9000" }),
     5000,
   );
-  assert.equal(resolveStaleRunnerMaxAgeMs({ staleRunnerMaxAgeMs: -1 }), 30 * 60 * 1000);
+  assert.equal(resolveStaleRunnerMaxAgeMs({ staleRunnerMaxAgeMs: -1 }, emptyEnv), 30 * 60 * 1000);
   assert.equal(resolveStaleRunnerMaxAgeMs({}, { PI_DEV_LOOP_STALE_RUNNER_MAX_AGE_MS: "abc" }), 30 * 60 * 1000);
 });
 

--- a/test/loop/detect-stale-runner.test.mjs
+++ b/test/loop/detect-stale-runner.test.mjs
@@ -15,8 +15,9 @@ import {
 } from "../../scripts/loop/_pr-runner-coordination.mjs";
 
 test("resolveStaleRunnerMaxAgeMs prefers explicit option, then env, then default", () => {
-  assert.equal(resolveStaleRunnerMaxAgeMs(), 30 * 60 * 1000);
-  assert.equal(resolveStaleRunnerMaxAgeMs({}), 30 * 60 * 1000);
+  const emptyEnv = {};
+  assert.equal(resolveStaleRunnerMaxAgeMs({}, emptyEnv), 30 * 60 * 1000);
+  assert.equal(resolveStaleRunnerMaxAgeMs({ staleRunnerMaxAgeMs: 5000 }, emptyEnv), 5000);
   assert.equal(resolveStaleRunnerMaxAgeMs({ staleRunnerMaxAgeMs: 5000 }), 5000);
   assert.equal(resolveStaleRunnerMaxAgeMs({}, { PI_DEV_LOOP_STALE_RUNNER_MAX_AGE_MS: "9000" }), 9000);
   assert.equal(


### PR DESCRIPTION
Closes #508

## Bypass investigation (root cause for run `07a9e25c`)

`scripts/github/detect-checkpoint-evidence.mjs` is the always-on pre-merge
guard. The script already calls `ensureAsyncRunnerOwnership` before reading
GitHub facts so a stale/displaced run fails closed before merge. That guard
correctly rejects the merge **when `PI_SUBAGENT_RUN_ID` is set**:

```text
async runner ownership → "ownership_lost" if active run != PI_SUBAGENT_RUN_ID
                        → "ownership_missing" if no record exists for that run
```

The bypass that let `07a9e25c` reach `gh pr merge`:

1. The runner shell that issued the merge was not an in-session
   `pi-subagent` dev-loop child, so `PI_SUBAGENT_RUN_ID` was not set in its
   environment.
2. With an empty `PI_SUBAGENT_RUN_ID`, `ensureAsyncRunnerOwnership` short-
   circuits with `status: "skipped_no_async_run_id"` (a diagnostic-only
   branch) instead of enforcing the ownership check.
3. The merge was therefore unconstrained by the pre-merge guard, so the
   four pre-merge gate evidence items (clean current-head
   `pre_approval_gate`, `unresolvedThreadCount === 0`, current-head CI,
   durable ownership) were not enforced.
4. The runner had also been told to exit via intercom, but nothing in the
   script-level guard would have noticed — the exit signal was never
   written to a durable surface that the merge path consults.

This PR closes both gaps.

## Changes

### 1. Stale-runner detection — `scripts/loop/detect-stale-runner.mjs`

New helper that reads the per-PR coordination state file and fails closed
when:

- the active run's `claimedAt` and `updatedAt` are both older than
  `staleRunnerMaxAgeMs` (default 30 minutes, override via
  `--stale-runner-max-age-ms` or `PI_DEV_LOOP_STALE_RUNNER_MAX_AGE_MS`), or
- an `exitSignal` has been recorded for the active run id.

Backed by `scripts/loop/_stale-runner-detection.mjs` (pure
`detectStaleRunner({ repo, pr, cwd, now, maxAgeMs })` plus
`resolveStaleRunnerMaxAgeMs`).

### 2. Exit-signal recording — `recordExitSignalForRunner`

New `recordExitSignalForRunner(...)` exported from
`scripts/loop/_pr-runner-coordination.mjs`. Writes an immutable
`exitSignals[]` entry on the coordination state file with the run id, an
ISO timestamp, and an optional `reason` (≤500 chars). The default policy
requires the supplied run id to be the current active owner; the parent
session can pass `requireActiveOwner: false` to record a pre-emptive
exit signal before the takeover completes.

### 3. Schema bump with backward compat

`RUNNER_COORDINATION_SCHEMA_VERSION` is bumped to `2` and
`RUNNER_COORDINATION_SUPPORTED_SCHEMA_VERSIONS` now declares the
allow-list `[1, 2]`. Old v1 state files are normalized on read (missing
`exitSignals` becomes `[]`); the first mutation rewrites the file as v2.

### 4. Wire stale-runner + exit-signal check into the pre-merge guard

`scripts/github/detect-checkpoint-evidence.mjs` now:

1. Calls `detectStaleRunner` after the existing `ensureAsyncRunnerOwnership`
   check. Either failure throws and short-circuits the merge with a
   `stale_runner` or `exit_signal_recorded` error.
2. Threads a `staleRunnerCheck` summary into `buildPreMergeGateCheck` so
   the failure is also surfaced in the structured `preMergeGateCheck`
   payload, not just in the early-throw error path.
3. Includes `staleRunner` + `staleRunnerCheck` fields in both the success
   and failure JSON output so audit consumers can see the verdict and
   observed state.

### 5. Tests

- `test/loop/detect-stale-runner.test.mjs` — 9 tests covering
  `resolveStaleRunnerMaxAgeMs` precedence, no-owner-record, fresh runner,
  stale runner, exit-signal recorded for the active run, exit-signal
  ignored for non-active runs, `recordExitSignalForRunner` ownership and
  missing-file rejections.
- `test/github/detect-checkpoint-evidence-stale-runner.test.mjs` — 3
  integration tests covering the stale-runner and exit-signal failure
  paths in the actual `detect-checkpoint-evidence.mjs` CLI, plus the
  successful output shape including the new `staleRunner` and
  `staleRunnerCheck` fields.
- `test/github/detect-checkpoint-evidence.test.mjs` — updated the
  deep-equal baseline to include the new fields, and adapted the
  expected file path to be tolerant of the dynamic tmpdir.
- `test/loop/pr-runner-coordination.test.mjs` — unchanged; the v1↔v2
  normalize path keeps every prior behavior green (7/7 still pass).

`npm run verify` is green: 85 assets, 46 extension, 1166 scripts, 1020
core, 10 dev-loop tests; 0 failures; markdown link and duplicate-rule
checks pass.

## Non-goals

- Did **not** delete the `ensureAsyncRunnerOwnership` skip branch; the
  diagnostic `skipped_no_async_run_id` path is preserved for non-merge
  callsites (e.g. `detect-copilot-loop-state.mjs`, `upsert-checkpoint-
  verdict.mjs`) where ownership is not the gate.
- Did **not** add a watcher for the intercom signal itself. The runner
  now refuses merge when an exit signal is recorded, but signaling
  the exit (writing to the coordination file) remains a parent-session
  responsibility.
- Did **not** extend `pr-runner-coordination.mjs` CLI with an explicit
  `record-exit-signal` subcommand; the helper is exported and can be
  wrapped by a parent-session script in a follow-up.

## Acceptance

- `worktree-cwd`: all edits under `tmp/worktrees/issue-508-stale-runner-guard/`
- `verify-green`: `npm run verify` returns 0 with full test pass count above
- `stale-runner-detection`: new `detectStaleRunner` helper covered by 5
  detect-stale-runner tests + 1 integration test
- `intercom-exit-honored`: `recordExitSignalForRunner` writes durable
  exit-signal records; `detectStaleRunner` surfaces them; the
  pre-merge guard refuses merge on detection
- `bypass-investigation`: this PR body documents the
  `PI_SUBAGENT_RUN_ID` short-circuit root cause; the regression test
  `detect-checkpoint-evidence fails closed when active runner is stale`
  in `detect-checkpoint-evidence-stale-runner.test.mjs` enforces that
  the merged path can no longer bypass the check via a stale state
  file
- `no-destructive-git`: only the worktree branch
  `fix/508-stale-runner-guard` is modified; no main mutations, no
  rebase, no force-push
