### PR TITLE
fix(#486): remove policy flags from CLI helpers

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,7 @@
     "./loop/run-inspection": "./src/loop/run-inspection.mjs",
     "./loop/steering": "./src/loop/steering.mjs",
     "./loop/timeout-policy": "./src/loop/timeout-policy.mjs",
+    "./loop/policy-constants": "./src/loop/policy-constants.mjs",
     "./loop/tracker-pr-state": "./src/loop/tracker-pr-state.mjs",
     "./debt/signal": "./src/debt/debt-signal.mjs",
     "./debt/finding": "./src/debt/debt-finding.mjs",

--- a/packages/core/src/loop/policy-constants.mjs
+++ b/packages/core/src/loop/policy-constants.mjs
@@ -1,0 +1,17 @@
+/**
+ * Centralized policy constants — single source of truth for
+ * timeout budgets, poll intervals, and related policy values.
+ *
+ * These replace the now-removed CLI policy flags (--timeout-ms,
+ * --poll-interval-ms, --probe-only, --force, --force-rerequest-review).
+ */
+export const DEFAULT_POLL_INTERVAL_MS = 60_000;
+
+/** Copilot-first durable-wait seam: bootstrap-only PR watch budget */
+export const COPILOT_FIRST_DURABLE_WAIT_TIMEOUT_MS = 3_600_000;
+
+/** Copilot review wait: external healthy-wait budget */
+export const COPILOT_REVIEW_WAIT_TIMEOUT_MS = 1_800_000;
+
+/** Explicit single-check timeout value (used only for status probes) */
+export const PROBE_ONLY_TIMEOUT_MS = 0;

--- a/scripts/github/probe-copilot-review.mjs
+++ b/scripts/github/probe-copilot-review.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Copilot review probe supporting both persistent polling (default 30-minute
- * watch) and one-shot status checks (--timeout-ms 0). Used
+ * Copilot review probe supporting persistent polling (30-minute
+ * watch) and one-shot status checks. Used
  * internally by `scripts/loop/run-watch-cycle.mjs` for persistent watch cycles.
  *
  * For new watch/fix workflows, prefer using `run-watch-cycle.mjs` as the primary
@@ -10,20 +10,25 @@
 import { setTimeout as delay } from "node:timers/promises";
 
 import { buildParseError, formatCliError, isCopilotLogin, isDirectCliRun, parseJsonText, parseReviewThreads } from "../_core-helpers.mjs";
-import { parseNonNegativeInteger, parsePositiveInteger, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parsePositiveInteger, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import {
+  DEFAULT_POLL_INTERVAL_MS,
+  COPILOT_REVIEW_WAIT_TIMEOUT_MS,
+} from "@pi-dev-loops/core/loop/policy-constants";
 
-const USAGE = `Usage: probe-copilot-review.mjs --repo <owner/name> --pr <number> [--poll-interval-ms <ms>] [--timeout-ms <ms>]
+const REMOVED_FLAGS = new Set([
+  "--poll-interval-ms",
+  "--timeout-ms",
+]);
+
+const USAGE = `Usage: probe-copilot-review.mjs --repo <owner/name> --pr <number>
 
 Poll for fresh Copilot review activity on a GitHub pull request.
 
 Required:
   --repo <owner/name>           Repository slug (e.g. owner/repo)
   --pr <number>                 Pull request number
-
-Optional:
-  --poll-interval-ms <ms>       Milliseconds between polls (default: 60000, i.e. 1 minute)
-  --timeout-ms <ms>             Total watch budget in ms; 0 = single check (default: 1800000, i.e. 30 minutes)
 
 Output (stdout, JSON):
   { "ok": true, "status": "changed"|"timeout"|"idle", "repo": "...", "pr": N, "attempts": N,
@@ -91,6 +96,11 @@ const COPILOT_ACTIVITY_QUERY = [
 
 const parseError = buildParseError(USAGE);
 
+function rejectRemovedFlag(token) {
+  throw parseError(
+    `${token} has been removed. Poll interval and timeout are centralized policy constants. Omit the flag.`,
+  );
+}
 
 export function parseWatchCliArgs(argv) {
   const args = [...argv];
@@ -98,8 +108,8 @@ export function parseWatchCliArgs(argv) {
     help: false,
     repo: undefined,
     pr: undefined,
-    pollIntervalMs: 60_000,
-    timeoutMs: 1_800_000,
+    pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
+    timeoutMs: COPILOT_REVIEW_WAIT_TIMEOUT_MS,
   };
 
   while (args.length > 0) {
@@ -110,6 +120,10 @@ export function parseWatchCliArgs(argv) {
       return options;
     }
 
+    if (REMOVED_FLAGS.has(token)) {
+      rejectRemovedFlag(token);
+    }
+
     if (token === "--repo") {
       options.repo = requireOptionValue(args, "--repo", parseError).trim();
       continue;
@@ -117,16 +131,6 @@ export function parseWatchCliArgs(argv) {
 
     if (token === "--pr") {
       options.pr = parsePositiveInteger(requireOptionValue(args, "--pr", parseError), "--pr", parseError);
-      continue;
-    }
-
-    if (token === "--poll-interval-ms") {
-      options.pollIntervalMs = parsePositiveInteger(requireOptionValue(args, "--poll-interval-ms", parseError), "--poll-interval-ms", parseError);
-      continue;
-    }
-
-    if (token === "--timeout-ms") {
-      options.timeoutMs = parseNonNegativeInteger(requireOptionValue(args, "--timeout-ms", parseError), "--timeout-ms", parseError);
       continue;
     }
 

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -17,17 +17,17 @@ const BLOCKED_BY_COPILOT_COMMENT_STATUS = "blocked_by_copilot_comment";
 const SUPPRESSED_SAME_HEAD_CLEAN_STATUS = "suppressed_same_head_clean";
 const ROUND_CAP_REACHED_STATUS = "round_cap_reached";
 
-const USAGE = `Usage: request-copilot-review.mjs --repo <owner/name> --pr <number> [--force-rerequest-review]
+const REMOVED_FLAGS = new Set([
+  "--force-rerequest-review",
+]);
+
+const USAGE = `Usage: request-copilot-review.mjs --repo <owner/name> --pr <number>
 
 Request Copilot as a reviewer on a GitHub pull request.
 
 Required:
   --repo <owner/name>   Repository slug (e.g. owner/repo)
   --pr <number>         Pull request number
-
-Optional:
-  --force-rerequest-review  Bypass same-head clean-convergence suppression and
-                            attempt another explicit Copilot request anyway
 
 Debug:
   PI_DEV_LOOPS_DEBUG=1      Emit stderr traces when best-effort same-head clean
@@ -36,13 +36,13 @@ Debug:
 Output (stdout, JSON):
   { "ok": true, "status": "requested"|"already-requested"|"unavailable"|"suppressed_same_head_clean"|"blocked_by_copilot_comment"|"round_cap_reached",
     "repo": "...", "pr": N, "reviewer": "Copilot", "detail"?: "...",
-    "sameHeadCleanConverged"?: true, "bypassedSameHeadCleanSuppression"?: true, "violationCommentIds"?: [N], "completedRounds"?: N, "maxRounds"?: N }
+    "sameHeadCleanConverged"?: true, "violationCommentIds"?: [N], "completedRounds"?: N, "maxRounds"?: N }
 
 Request statuses:
   requested           Copilot review was successfully requested
   already-requested   Copilot review was already observably in progress; no new request needed
   unavailable         Copilot review is not enabled/requestable and no in-progress evidence was found
-  suppressed_same_head_clean  Current head is already clean-converged; no new request is made unless forced
+  suppressed_same_head_clean  Current head is already clean-converged; no new request is made
   blocked_by_copilot_comment  A non-Copilot PR comment contains @copilot or /copilot; delete the comment(s) first
   round_cap_reached    Maximum Copilot review rounds reached; no further re-requests will be made
 
@@ -58,6 +58,11 @@ Exit codes:
 
 const parseError = buildParseError(USAGE);
 
+function rejectRemovedFlag(token) {
+  throw parseError(
+    `${token} has been removed. Copilot re-requests are managed internally. Omit the flag.`,
+  );
+}
 
 export function parseRequestCliArgs(argv) {
   const args = [...argv];
@@ -76,6 +81,10 @@ export function parseRequestCliArgs(argv) {
       return options;
     }
 
+    if (REMOVED_FLAGS.has(token)) {
+      rejectRemovedFlag(token);
+    }
+
     if (token === "--repo") {
       options.repo = requireOptionValue(args, "--repo", parseError).trim();
       continue;
@@ -83,11 +92,6 @@ export function parseRequestCliArgs(argv) {
 
     if (token === "--pr") {
       options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
-      continue;
-    }
-
-    if (token === "--force-rerequest-review") {
-      options.forceRerequestReview = true;
       continue;
     }
 
@@ -379,7 +383,7 @@ export async function performCopilotReviewRequest(options, { env = process.env, 
       reviewer: "Copilot",
       completedRounds: before.completedCopilotReviewRounds,
       maxRounds,
-      detail: `Round cap of ${maxRounds} reached with ${before.completedCopilotReviewRounds} completed rounds. Re-run with --force-rerequest-review to bypass.`,
+      detail: `Round cap of ${maxRounds} reached with ${before.completedCopilotReviewRounds} completed rounds. No further re-requests will be made.`,
     };
   }
 
@@ -388,7 +392,6 @@ export async function performCopilotReviewRequest(options, { env = process.env, 
     { env, ghCommand },
     before,
   );
-  const bypassedSameHeadCleanSuppression = sameHeadCleanConverged && options.forceRerequestReview === true;
 
   if (sameHeadCleanConverged && !options.forceRerequestReview) {
     return {
@@ -398,7 +401,7 @@ export async function performCopilotReviewRequest(options, { env = process.env, 
       pr: options.pr,
       reviewer: "Copilot",
       sameHeadCleanConverged: true,
-      detail: "Current head already has a clean submitted Copilot review; rerun with --force-rerequest-review to bypass same-head clean-convergence suppression.",
+      detail: "Current head already has a clean submitted Copilot review; same-head clean-convergence suppression is always enforced.",
     };
   }
 
@@ -409,16 +412,12 @@ export async function performCopilotReviewRequest(options, { env = process.env, 
       repo: options.repo,
       pr: options.pr,
       reviewer: "Copilot",
-      ...(bypassedSameHeadCleanSuppression ? { bypassedSameHeadCleanSuppression: true } : {}),
     };
   }
 
   const requestResult = await requestCopilotReview(options, { env, ghCommand });
 
   if (requestResult.status === "unavailable") {
-    // Post-failure verification: even when the explicit request path is rejected,
-    // Copilot review may already be in progress if GitHub internally queued it.
-    // Check for observable in-progress evidence before treating this as a terminal stop.
     const after = await fetchCopilotReviewState(options, { env, ghCommand });
     if (after.requested || after.hasPendingReviewOnCurrentHead) {
       return {
@@ -427,12 +426,10 @@ export async function performCopilotReviewRequest(options, { env = process.env, 
         repo: options.repo,
         pr: options.pr,
         reviewer: "Copilot",
-        ...(bypassedSameHeadCleanSuppression ? { bypassedSameHeadCleanSuppression: true } : {}),
       };
     }
     return {
       ...requestResult,
-      ...(bypassedSameHeadCleanSuppression ? { bypassedSameHeadCleanSuppression: true } : {}),
     };
   }
 
@@ -446,7 +443,6 @@ export async function performCopilotReviewRequest(options, { env = process.env, 
 
   return {
     ...requestResult,
-    ...(bypassedSameHeadCleanSuppression ? { bypassedSameHeadCleanSuppression: true } : {}),
   };
 }
 

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -70,7 +70,7 @@ export function parseRequestCliArgs(argv) {
     help: false,
     repo: undefined,
     pr: undefined,
-    forceRerequestReview: false,
+
   };
 
   while (args.length > 0) {
@@ -374,7 +374,7 @@ export async function performCopilotReviewRequest(options, { env = process.env, 
   } catch {
     // Fail closed to default 5 on config errors
   }
-  if ((before.completedCopilotReviewRounds ?? 0) >= maxRounds && !options.forceRerequestReview) {
+  if ((before.completedCopilotReviewRounds ?? 0) >= maxRounds) {
     return {
       ok: true,
       status: ROUND_CAP_REACHED_STATUS,
@@ -393,7 +393,7 @@ export async function performCopilotReviewRequest(options, { env = process.env, 
     before,
   );
 
-  if (sameHeadCleanConverged && !options.forceRerequestReview) {
+  if (sameHeadCleanConverged) {
     return {
       ok: true,
       status: SUPPRESSED_SAME_HEAD_CLEAN_STATUS,

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -408,8 +408,8 @@ function resolveGateAction(gate) {
     : PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE;
 }
 
-function buildGateEntryRefusalError({ coordination }) {
-  return `Cannot enter gate: ${coordination.reason}`;
+function buildGateEntryRefusalError({ options, coordination }) {
+  return `Cannot enter ${options.gate} on ${options.repo}#${options.pr}: ${coordination.reason}`;
 }
 
 function selectGateEvidence(evidence, gate) {
@@ -540,7 +540,7 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
   const gateActionForbidden = coordination.forbiddenActions.includes(requestedGateAction);
 
   if (gateActionForbidden) {
-    throw new Error(buildGateEntryRefusalError({ coordination }));
+    throw new Error(buildGateEntryRefusalError({ options, coordination }));
   }
 
   const activeGateConfig = options.gate === "draft_gate" ? draftGateConfig : preApprovalGateConfig;

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -4,7 +4,6 @@ import { loadDevLoopConfig, resolveGateConfig, resolveRefinementConfig } from "@
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { truncateText } from "@pi-dev-loops/core/bash-exit-one";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
-import { detectCheckpointEvidence } from "./detect-checkpoint-evidence.mjs";
 import { loadPrGateCoordinationContext } from "../loop/detect-pr-gate-coordination-state.mjs";
 import { evaluatePrGateCoordination, PR_CHECKPOINT_ACTION } from "@pi-dev-loops/core/loop/pr-gate-coordination";
 import { STATE } from "@pi-dev-loops/core/loop/copilot-loop-state";
@@ -13,9 +12,13 @@ const GATE_NAMES = new Set(["draft_gate", "pre_approval_gate"]);
 const GATE_VERDICTS = new Set(["clean", "findings_present", "blocked"]);
 const MAX_GATE_COMMENT_TEXT_LENGTH = 2000;
 const MAX_GATE_COMMENT_EXCERPT_LENGTH = 120;
-const FORCE_BYPASS = "ci_blocked_needs_user_decision";
 
-const USAGE = `Usage: upsert-checkpoint-verdict.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate> --head-sha <sha> --verdict <clean|findings_present|blocked> --findings-summary <text> --next-action <text> [--local-validation-head-sha <sha>] [--force --force-reason <text>]
+const REMOVED_FLAGS = new Set([
+  "--force",
+  "--force-reason",
+]);
+
+const USAGE = `Usage: upsert-checkpoint-verdict.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate> --head-sha <sha> --verdict <clean|findings_present|blocked> --findings-summary <text> --next-action <text> [--local-validation-head-sha <sha>]
 
 Create or update the visible checkpoint verdict comment for a gate/head pair.
 Same-head reruns are idempotent: if a visible marker already exists for the same
@@ -38,23 +41,10 @@ Optional:
                                              reuse the bounded crediblyGreen CI
                                              exception when GitHub created zero
                                              current-head suites/statuses.
-  --force                                    Allow a narrow CI-failure gate-comment
-                                             override when the helper would otherwise
-                                             refuse a gate upsert because the current
-                                             head is blocked_needs_user_decision.
   --findings-severity-counts <json>         JSON object mapping severity to count
                                              (e.g. '{"must-fix":0,"worth-fixing-now":0}').
                                              Required for --verdict clean when
                                              blockCleanOnFindingSeverities is configured.
-  --force-reason <text>                      Required with --force. Records why the
-                                             operator-authorized CI-only override is
-                                             justified for machine-readable output.
-
-Use \`--force\` only after the user explicitly authorizes ignoring the current-head
-CI failure for this one gate-comment upsert. Prefer the normal paths
-first: green CI on the current head, \`--local-validation-head-sha\` for the bounded
-\`crediblyGreen\` case, or the draft-gate policy option when the desired behavior is
-a durable policy rather than a one-off override.
 
 Output (stdout, JSON):
   {
@@ -82,6 +72,11 @@ Exit codes:
 
 const parseError = buildParseError(USAGE);
 
+function rejectRemovedFlag(token) {
+  throw parseError(
+    `${token} has been removed. Force bypass requires separate operator authorization. Omit the flag.`,
+  );
+}
 
 function normalizeGateName(value) {
   const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
@@ -107,42 +102,6 @@ function normalizeRequiredText(value, flag) {
     return summarizeCheckpointVerdictText(normalized);
   }
   return smartTruncate(collapseWhitespace(normalized), MAX_GATE_COMMENT_TEXT_LENGTH);
-}
-
-function normalizeForceReason(value) {
-  const normalized = collapseWhitespace(value);
-  if (normalized.length === 0) {
-    throw parseError("--force-reason must be a non-empty string");
-  }
-  return normalized;
-}
-
-function normalizeOptionalForceReason(value) {
-  if (value === undefined) {
-    return undefined;
-  }
-
-  const normalized = collapseWhitespace(value);
-  return normalized.length > 0 ? normalized : null;
-}
-
-function resolveRuntimeForceOptions(options) {
-  const force = options.force === true;
-  const forceReason = normalizeOptionalForceReason(options.forceReason);
-
-  if (forceReason === null) {
-    throw new Error("forceReason must be a non-empty string when calling upsertCheckpointVerdict()");
-  }
-
-  if (force && forceReason === undefined) {
-    throw new Error("force requires forceReason when calling upsertCheckpointVerdict()");
-  }
-
-  if (!force && options.forceReason !== undefined) {
-    throw new Error("forceReason requires force when calling upsertCheckpointVerdict()");
-  }
-
-  return { force, forceReason };
 }
 
 function collapseWhitespace(value) {
@@ -279,8 +238,6 @@ export function parseUpsertCheckpointVerdictCliArgs(argv) {
     nextAction: undefined,
     localValidationHeadSha: undefined,
     findingsSeverityCounts: undefined,
-    force: false,
-    forceReason: undefined,
   };
 
   while (args.length > 0) {
@@ -289,6 +246,10 @@ export function parseUpsertCheckpointVerdictCliArgs(argv) {
     if (token === "--help" || token === "-h") {
       options.help = true;
       return options;
+    }
+
+    if (REMOVED_FLAGS.has(token)) {
+      rejectRemovedFlag(token);
     }
 
     if (token === "--repo") {
@@ -369,16 +330,6 @@ export function parseUpsertCheckpointVerdictCliArgs(argv) {
       continue;
     }
 
-    if (token === "--force") {
-      options.force = true;
-      continue;
-    }
-
-    if (token === "--force-reason") {
-      options.forceReason = normalizeForceReason(requireOptionValue(args, "--force-reason", parseError));
-      continue;
-    }
-
     throw parseError(`Unknown argument: ${token}`);
   }
 
@@ -386,14 +337,6 @@ export function parseUpsertCheckpointVerdictCliArgs(argv) {
     .filter((key) => options[key] === undefined);
   if (missing.length > 0) {
     throw parseError("upsert-checkpoint-verdict requires --repo, --pr, --gate, --head-sha, --verdict, --findings-summary, and --next-action");
-  }
-
-  if (options.force && options.forceReason === undefined) {
-    throw parseError("--force requires --force-reason <text>");
-  }
-
-  if (!options.force && options.forceReason !== undefined) {
-    throw parseError("--force-reason requires --force");
   }
 
   try {
@@ -465,32 +408,8 @@ function resolveGateAction(gate) {
     : PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE;
 }
 
-function isCiBlockedGateOverrideEligible({ coordination, coordinationContext, gate }) {
-  return coordination.lifecycleState === STATE.BLOCKED_NEEDS_USER_DECISION
-    && coordinationContext.snapshot?.ciStatus === "failure"
-    && coordination.forbiddenActions.includes(resolveGateAction(gate));
-}
-
-function buildGateEntryRefusalError({ options, coordination, coordinationContext }) {
-  const baseMessage = `Cannot enter ${options.gate} on ${options.repo}#${options.pr}: ${coordination.reason}`;
-
-  if (!isCiBlockedGateOverrideEligible({ coordination, coordinationContext, gate: options.gate })) {
-    return baseMessage;
-  }
-
-  return `${baseMessage} Re-run with --force --force-reason "<why>" only when the user has explicitly authorized ignoring the current-head CI failure for this one gate-comment upsert.`;
-}
-
-function buildForcedResultMetadata({ forced, forceReason }) {
-  if (!forced) {
-    return {};
-  }
-
-  return {
-    forced: true,
-    forceReason,
-    forceBypass: FORCE_BYPASS,
-  };
+function buildGateEntryRefusalError({ coordination }) {
+  return `Cannot enter gate: ${coordination.reason}`;
 }
 
 function selectGateEvidence(evidence, gate) {
@@ -591,7 +510,6 @@ async function updateComment({ repo, commentId, body }, { env, ghCommand }) {
 }
 
 export async function upsertCheckpointVerdict(options, { env = process.env, ghCommand = "gh", repoRoot = process.cwd() } = {}) {
-  const { force, forceReason } = resolveRuntimeForceOptions(options);
   const coordinationContext = await loadPrGateCoordinationContext({ repo: options.repo, pr: options.pr, localValidationHeadSha: options.localValidationHeadSha }, { env, ghCommand });
   const evidence = coordinationContext.gateEvidence;
   const canonicalHeadSha = resolveRequestedHeadSha(options.headSha, evidence.currentHeadSha);
@@ -620,15 +538,10 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
   });
   const requestedGateAction = resolveGateAction(options.gate);
   const gateActionForbidden = coordination.forbiddenActions.includes(requestedGateAction);
-  const forcedBypass = gateActionForbidden
-    && force
-    && isCiBlockedGateOverrideEligible({ coordination, coordinationContext, gate: options.gate });
 
-  if (gateActionForbidden && !forcedBypass) {
-    throw new Error(buildGateEntryRefusalError({ options, coordination, coordinationContext }));
+  if (gateActionForbidden) {
+    throw new Error(buildGateEntryRefusalError({ coordination }));
   }
-
-  const forcedResultMetadata = buildForcedResultMetadata({ forced: forcedBypass, forceReason });
 
   const activeGateConfig = options.gate === "draft_gate" ? draftGateConfig : preApprovalGateConfig;
 
@@ -689,7 +602,6 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
       currentHeadSha: evidence.currentHeadSha,
       commentId: existing.commentId,
       commentUrl: existing.commentUrl,
-      ...forcedResultMetadata,
       blockCleanOnFindingSeverities: activeGateConfig.blockCleanOnFindingSeverities,
       ...(warning ? { warning } : {}),
     };
@@ -707,7 +619,6 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
       currentHeadSha: evidence.currentHeadSha,
       commentId: updated.commentId,
       commentUrl: updated.commentUrl,
-      ...forcedResultMetadata,
       blockCleanOnFindingSeverities: activeGateConfig.blockCleanOnFindingSeverities,
       ...(warning ? { warning } : {}),
     };
@@ -724,7 +635,6 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
     currentHeadSha: evidence.currentHeadSha,
     commentId: created.commentId,
     commentUrl: created.commentUrl,
-    ...forcedResultMetadata,
     blockCleanOnFindingSeverities: activeGateConfig.blockCleanOnFindingSeverities,
     ...(warning ? { warning } : {}),
   };

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -298,7 +298,6 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
       {
         repo: options.repo,
         pr: options.pr,
-        forceRerequestReview: false,
         sameHeadCleanConverged: interpretation.sameHeadCleanConverged,
       },
       { env, ghCommand },

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -8,7 +8,6 @@
  *      ready_to_rerequest_review when a meaningful remediation event made
  *      automatic re-request eligible), request Copilot review and re-interpret
  *      the state from the shared post-request wait-cycle snapshot.
- *      An explicit operator override can force another same-head request.
  *   3. Emit a single JSON payload describing the current state, the
  *      recommended action ("watch", "fix", or "stop"), and — when the action
  *      is "watch" — the exact watch parameters to pass to probe-copilot-review.mjs.
@@ -52,10 +51,18 @@ import {
   EXTERNAL_HEALTHY_WAIT_TIMEOUT_POLICY,
   enforceExternalHealthyWaitTimeout,
 } from "@pi-dev-loops/core/loop/timeout-policy";
+import {
+  DEFAULT_POLL_INTERVAL_MS,
+  COPILOT_REVIEW_WAIT_TIMEOUT_MS,
+} from "@pi-dev-loops/core/loop/policy-constants";
 
 const VALID_WATCH_STATUSES = new Set(["changed", "timeout", "idle"]);
 
-const USAGE = `Usage: copilot-pr-handoff.mjs --repo <owner/name> --pr <number> [--force-rerequest-review] [--watch-status <changed|timeout|idle>]
+const REMOVED_FLAGS = new Set([
+  "--force-rerequest-review",
+]);
+
+const USAGE = `Usage: copilot-pr-handoff.mjs --repo <owner/name> --pr <number> [--watch-status <changed|timeout|idle>]
 
 Detect the Copilot-loop state for a PR, request Copilot review only when
 a new request is still needed, and emit the recommended next action with
@@ -66,8 +73,6 @@ Required:
   --pr <number>         Pull request number
 
 Optional:
-  --force-rerequest-review  Force a Copilot re-request even when automatic
-                            same-head suppression is active
   --watch-status <status>   Refresh deterministic loop state after a prior
                            watcher result (changed|timeout|idle). This mode
                            never requests review; it only re-detects state.
@@ -113,9 +118,6 @@ Error output (stderr, JSON):
 Exit codes:
   0  Success
   1  Argument error or gh failure`.trim();
-
-const DEFAULT_POLL_INTERVAL_MS = 60_000;
-const DEFAULT_TIMEOUT_MS = 1_800_000;
 
 const WATCH_STATES = new Set([
   STATE.WAITING_FOR_COPILOT_REVIEW,
@@ -172,6 +174,11 @@ function summarizeRequestWatchContract({
 
 const parseError = buildParseError(USAGE);
 
+function rejectRemovedFlag(token) {
+  throw parseError(
+    `${token} has been removed. Copilot re-requests are managed internally. Omit the flag.`,
+  );
+}
 
 export function parseHandoffCliArgs(argv) {
   const args = [...argv];
@@ -179,7 +186,6 @@ export function parseHandoffCliArgs(argv) {
     help: false,
     repo: undefined,
     pr: undefined,
-    forceRerequestReview: false,
     watchStatus: undefined,
   };
 
@@ -191,6 +197,10 @@ export function parseHandoffCliArgs(argv) {
       return options;
     }
 
+    if (REMOVED_FLAGS.has(token)) {
+      rejectRemovedFlag(token);
+    }
+
     if (token === "--repo") {
       options.repo = requireOptionValue(args, "--repo", parseError).trim();
       continue;
@@ -198,11 +208,6 @@ export function parseHandoffCliArgs(argv) {
 
     if (token === "--pr") {
       options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
-      continue;
-    }
-
-    if (token === "--force-rerequest-review") {
-      options.forceRerequestReview = true;
       continue;
     }
 
@@ -220,10 +225,6 @@ export function parseHandoffCliArgs(argv) {
 
   if (options.repo === undefined || options.pr === undefined) {
     throw parseError("copilot-pr-handoff requires both --repo <owner/name> and --pr <number>");
-  }
-
-  if (options.watchStatus !== undefined && options.forceRerequestReview) {
-    throw parseError("--force-rerequest-review cannot be combined with --watch-status because watch refresh mode never requests review");
   }
 
   try {
@@ -290,14 +291,14 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
   const shouldRequestReview = options.watchStatus === undefined
     && (interpretation.state === STATE.PR_READY_NO_FEEDBACK
     || interpretation.state === STATE.READY_TO_REREQUEST_REVIEW
-    && (interpretation.autoRerequestEligible || options.forceRerequestReview));
+    && interpretation.autoRerequestEligible);
 
   if (shouldRequestReview) {
     const requestResult = await performCopilotReviewRequest(
       {
         repo: options.repo,
         pr: options.pr,
-        forceRerequestReview: options.forceRerequestReview,
+        forceRerequestReview: false,
         sameHeadCleanConverged: interpretation.sameHeadCleanConverged,
       },
       { env, ghCommand },
@@ -358,7 +359,7 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
       pr: options.pr,
       pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
       timeoutMs: enforceExternalHealthyWaitTimeout({
-        timeoutMs: DEFAULT_TIMEOUT_MS,
+        timeoutMs: COPILOT_REVIEW_WAIT_TIMEOUT_MS,
         contextLabel: "Copilot review wait",
       }),
     };

--- a/scripts/loop/run-watch-cycle.mjs
+++ b/scripts/loop/run-watch-cycle.mjs
@@ -13,21 +13,22 @@ import {
   EXTERNAL_HEALTHY_WAIT_TIMEOUT_POLICY,
   enforceExternalHealthyWaitTimeout,
 } from "@pi-dev-loops/core/loop/timeout-policy";
+import {
+  COPILOT_REVIEW_WAIT_TIMEOUT_MS,
+} from "@pi-dev-loops/core/loop/policy-constants";
 
-const USAGE = `Usage: run-watch-cycle.mjs --repo <owner/name> --pr <number> [--force-rerequest-review] [--probe-only]
+const REMOVED_FLAGS = new Set([
+  "--force-rerequest-review",
+  "--probe-only",
+]);
+
+const USAGE = `Usage: run-watch-cycle.mjs --repo <owner/name> --pr <number>
 
 Run one deterministic Copilot wait-cycle boundary.
 
 Required:
   --repo <owner/name>       Repository slug (e.g. owner/repo)
   --pr <number>             Pull request number
-
-Optional:
-  --force-rerequest-review  Force a Copilot re-request even when automatic
-                            same-head suppression is active
-  --probe-only              Use a single immediate recheck (timeout 0) for
-                            explicit status probes only; normal async waiting
-                            keeps the emitted long-lived persistent wait timeout
 
 Output (stdout, JSON):
   { "ok": true, "handoffAction": "watch"|"fix"|"stop", "state": "...",
@@ -60,6 +61,11 @@ Exit codes:
 
 const parseError = buildParseError(USAGE);
 
+function rejectRemovedFlag(token) {
+  throw parseError(
+    `${token} has been removed. Copilot re-requests and probe-only mode are managed internally. Omit the flag.`,
+  );
+}
 
 async function fetchPrHeadBranch({ repo, pr }, { env, ghCommand }) {
   const result = await runChild(
@@ -132,10 +138,9 @@ async function watchWorkflowRun({ repo, runId, timeoutMs = null }, { env, ghComm
   });
 }
 
-function determineWatchTimeout({ probeOnly, defaultTimeoutMs }) {
+function determineWatchTimeout(defaultTimeoutMs) {
   return enforceExternalHealthyWaitTimeout({
     timeoutMs: defaultTimeoutMs,
-    explicitProbe: probeOnly,
     contextLabel: "Copilot review wait",
   });
 }
@@ -144,7 +149,6 @@ function buildWatchCycleContractTrace({
   handoff,
   watchArgs = null,
   watchTimeoutPolicy = null,
-  probeOnly,
   watchStatus,
   cycleDisposition,
   sessionActivity = null,
@@ -169,7 +173,7 @@ function buildWatchCycleContractTrace({
     waitStrategy: {
       helper: handoff.action === "watch" ? "scripts/github/probe-copilot-review.mjs" : null,
       mode: handoff.action === "watch"
-        ? (probeOnly ? "one_shot_probe" : "persistent_watch")
+        ? "persistent_watch"
         : "not_applicable",
       effectiveTimeoutMs: watchArgs?.timeoutMs ?? null,
       effectivePollIntervalMs: watchArgs?.pollIntervalMs ?? null,
@@ -188,7 +192,7 @@ function buildWatchCycleContractTrace({
           refreshRequired: true,
           refreshReason: watchStatus === "changed"
             ? "Watch boundaries with fresh activity require an authoritative state refresh before routing the follow-up path."
-            : "Healthy wait boundaries are observational only; refresh authoritative state before treating timeout/idle as stop or completion.",
+            : "Healthy watch boundaries are observational only; refresh authoritative state before treating timeout/idle as stop or completion.",
         }
       : null,
     stopReason: {
@@ -210,8 +214,6 @@ export function parseWatchCycleCliArgs(argv) {
     help: false,
     repo: undefined,
     pr: undefined,
-    forceRerequestReview: false,
-    probeOnly: false,
   };
 
   while (args.length > 0) {
@@ -222,6 +224,10 @@ export function parseWatchCycleCliArgs(argv) {
       return options;
     }
 
+    if (REMOVED_FLAGS.has(token)) {
+      rejectRemovedFlag(token);
+    }
+
     if (token === "--repo") {
       options.repo = requireOptionValue(args, "--repo", parseError).trim();
       continue;
@@ -229,16 +235,6 @@ export function parseWatchCycleCliArgs(argv) {
 
     if (token === "--pr") {
       options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
-      continue;
-    }
-
-    if (token === "--force-rerequest-review") {
-      options.forceRerequestReview = true;
-      continue;
-    }
-
-    if (token === "--probe-only") {
-      options.probeOnly = true;
       continue;
     }
 
@@ -306,7 +302,6 @@ export async function runWatchCycle(
       handoff,
       watchArgs: result.watchArgs ?? null,
       watchTimeoutPolicy: result.watchTimeoutPolicy ?? null,
-      probeOnly: options.probeOnly,
       watchStatus: result.watchStatus,
       cycleDisposition: result.cycleDisposition,
     });
@@ -317,10 +312,9 @@ export async function runWatchCycle(
     result.watchTimeoutPolicy = EXTERNAL_HEALTHY_WAIT_TIMEOUT_POLICY;
   }
 
-  const persistentWatchTimeoutMs = determineWatchTimeout({
-    probeOnly: false,
-    defaultTimeoutMs: handoff.watchArgs.timeoutMs,
-  });
+  const persistentWatchTimeoutMs = determineWatchTimeout(
+    handoff.watchArgs.timeoutMs,
+  );
 
   let workflowRunWatch = null;
   if (detectSessionActivity) {
@@ -335,8 +329,7 @@ export async function runWatchCycle(
     result.sessionActivity = session;
 
     if (
-      !options.probeOnly
-      && session.activity === "active"
+      session.activity === "active"
       && Number.isInteger(session.runId)
     ) {
       const workflowWatchResult = await watchWorkflowRunImpl(
@@ -358,10 +351,7 @@ export async function runWatchCycle(
 
   const watchOptions = {
     ...handoff.watchArgs,
-    timeoutMs: determineWatchTimeout({
-      probeOnly: options.probeOnly,
-      defaultTimeoutMs: persistentWatchTimeoutMs,
-    }),
+    timeoutMs: persistentWatchTimeoutMs,
   };
   const watch = await watchCopilotReviewImpl(watchOptions, { env, ghCommand });
 
@@ -374,11 +364,10 @@ export async function runWatchCycle(
     handoff,
     watchArgs: watchOptions,
     watchTimeoutPolicy: result.watchTimeoutPolicy,
-    probeOnly: options.probeOnly,
     watchStatus: watch.status,
     cycleDisposition: result.cycleDisposition,
     sessionActivity: result.sessionActivity ?? null,
-    workflowRunWatch: detectSessionActivity && !options.probeOnly
+    workflowRunWatch: detectSessionActivity
       ? (workflowRunWatch ?? {
           attempted: false,
           timeoutMs: persistentWatchTimeoutMs,

--- a/scripts/loop/run-watch-cycle.mjs
+++ b/scripts/loop/run-watch-cycle.mjs
@@ -13,9 +13,6 @@ import {
   EXTERNAL_HEALTHY_WAIT_TIMEOUT_POLICY,
   enforceExternalHealthyWaitTimeout,
 } from "@pi-dev-loops/core/loop/timeout-policy";
-import {
-  COPILOT_REVIEW_WAIT_TIMEOUT_MS,
-} from "@pi-dev-loops/core/loop/policy-constants";
 
 const REMOVED_FLAGS = new Set([
   "--force-rerequest-review",

--- a/scripts/loop/watch-initial-copilot-pr.mjs
+++ b/scripts/loop/watch-initial-copilot-pr.mjs
@@ -7,7 +7,7 @@
  * draft, Copilot-authored), this script implements the healthy-wait boundary
  * from the public dev-loop contract:
  *
- *   - polls detect-initial-copilot-pr-state at a configurable interval
+ *   - polls detect-initial-copilot-pr-state at the default interval
  *   - returns status="ready_for_followup" as soon as the PR leaves the
  *     bootstrap-only shape, carrying the PR number for immediate follow-up
  *   - returns status="timed_out" when the watch budget is exhausted;
@@ -43,8 +43,17 @@ import { parseIssueNumber, parseNonNegativeInteger, parsePositiveInteger, requir
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import { detectInitialCopilotPrState, LINKED_PR_STATE } from "./detect-initial-copilot-pr-state.mjs";
 import { enforcePersistentInternalWaitTimeout } from "@pi-dev-loops/core/loop/timeout-policy";
+import {
+  DEFAULT_POLL_INTERVAL_MS,
+  COPILOT_FIRST_DURABLE_WAIT_TIMEOUT_MS,
+} from "@pi-dev-loops/core/loop/policy-constants";
 
-const USAGE = `Usage: watch-initial-copilot-pr.mjs --repo <owner/name> --issue <number> [--poll-interval-ms <ms>] [--timeout-ms <ms>]
+const REMOVED_FLAGS = new Set([
+  "--poll-interval-ms",
+  "--timeout-ms",
+]);
+
+const USAGE = `Usage: watch-initial-copilot-pr.mjs --repo <owner/name> --issue <number>
 
 Wait for the Copilot-first bootstrap-only draft PR to become substantive.
 
@@ -62,12 +71,6 @@ immediately so callers can surface a reconcile/block reason.
 Required:
   --repo <owner/name>           Repository slug (e.g. owner/repo)
   --issue <number>              Issue number
-
-Optional:
-  --poll-interval-ms <ms>       Milliseconds between polls (default: 60000, i.e. 1 minute)
-  --timeout-ms <ms>             Total watch budget in ms; 0 = explicit single-check status probe.
-                                Persistent unattended waits must be at least 3600000 (1 hour).
-                                Default: 3600000 (1 hour)
 
 Output (stdout, JSON):
   { "ok": true, "status": "ready_for_followup"|"timed_out"|"prior_linked_pr_closed_unmerged",
@@ -93,13 +96,13 @@ Exit codes:
   0  Success (ready_for_followup, timed_out, and prior_linked_pr_closed_unmerged are all ok:true)
   1  Argument error or gh failure`.trim();
 
-/** Default poll interval: 1 minute */
-const DEFAULT_POLL_INTERVAL_MS = 60_000;
-/** Default watch budget: 1 hour — Copilot-first durable-wait seam */
-const DEFAULT_TIMEOUT_MS = 3_600_000;
-
 const parseError = buildParseError(USAGE);
 
+function rejectRemovedFlag(token) {
+  throw parseError(
+    `${token} has been removed. Poll interval and timeout are centralized policy constants. Omit the flag.`,
+  );
+}
 
 export async function watchCopilotRunUntilComplete(
   { repo, runId, timeoutMs = null },
@@ -156,7 +159,7 @@ export function parseWatchInitialCopilotPrCliArgs(argv) {
     repo: undefined,
     issue: undefined,
     pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
-    timeoutMs: DEFAULT_TIMEOUT_MS,
+    timeoutMs: COPILOT_FIRST_DURABLE_WAIT_TIMEOUT_MS,
   };
 
   while (args.length > 0) {
@@ -167,6 +170,10 @@ export function parseWatchInitialCopilotPrCliArgs(argv) {
       return options;
     }
 
+    if (REMOVED_FLAGS.has(token)) {
+      rejectRemovedFlag(token);
+    }
+
     if (token === "--repo") {
       options.repo = requireOptionValue(args, "--repo", parseError).trim();
       continue;
@@ -174,24 +181,6 @@ export function parseWatchInitialCopilotPrCliArgs(argv) {
 
     if (token === "--issue") {
       options.issue = parseIssueNumber(requireOptionValue(args, "--issue", parseError), parseError);
-      continue;
-    }
-
-    if (token === "--poll-interval-ms") {
-      options.pollIntervalMs = parsePositiveInteger(
-        requireOptionValue(args, "--poll-interval-ms", parseError),
-        "--poll-interval-ms",
-        parseError,
-      );
-      continue;
-    }
-
-    if (token === "--timeout-ms") {
-      options.timeoutMs = parseNonNegativeInteger(
-        requireOptionValue(args, "--timeout-ms", parseError),
-        "--timeout-ms",
-        parseError,
-      );
       continue;
     }
 
@@ -212,7 +201,7 @@ export function parseWatchInitialCopilotPrCliArgs(argv) {
     options.timeoutMs = options.timeoutMs === 0
       ? 0
       : enforcePersistentInternalWaitTimeout({
-        timeoutMs: options.timeoutMs,
+        timeoutMs: COPILOT_FIRST_DURABLE_WAIT_TIMEOUT_MS,
         contextLabel: "watch-initial-copilot-pr persistent wait",
       });
   } catch (error) {

--- a/scripts/loop/watch-initial-copilot-pr.mjs
+++ b/scripts/loop/watch-initial-copilot-pr.mjs
@@ -39,7 +39,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import { spawn } from "node:child_process";
 
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { parseIssueNumber, parseNonNegativeInteger, parsePositiveInteger, requireOptionValue } from "../_cli-primitives.mjs";
+import { parseIssueNumber, requireOptionValue } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import { detectInitialCopilotPrState, LINKED_PR_STATE } from "./detect-initial-copilot-pr-state.mjs";
 import { enforcePersistentInternalWaitTimeout } from "@pi-dev-loops/core/loop/timeout-policy";

--- a/test/github/probe-copilot-review.test.mjs
+++ b/test/github/probe-copilot-review.test.mjs
@@ -6,7 +6,7 @@ import { spawn } from "node:child_process";
 import test from "node:test";
 import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
-import { buildAttemptBudget, buildPollDelayMs, parseWatchCliArgs } from "../../scripts/github/probe-copilot-review.mjs";
+import { buildAttemptBudget, buildPollDelayMs, findFreshCopilotActivity, parseWatchCliArgs, watchCopilotReview } from "../../scripts/github/probe-copilot-review.mjs";
 
 const scriptPath = path.resolve("scripts/github/probe-copilot-review.mjs");
 
@@ -103,23 +103,11 @@ test("buildPollDelayMs schedules polls on the requested watch timeline", () => {
 
 test("probe-copilot-review returns idle for a zero-timeout no-change check", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-idle-"));
-  const baseline = createActivityPayload({ threads: [createThread("c-1", "reviewer", "Please add a test.")] });
-
+  const baseline = createActivityPayload();
   try {
-    const env = await writeGhStub(tempDir, [
-      { stdout: `${JSON.stringify(baseline)}\n` },
-      { stdout: `${JSON.stringify(baseline)}\n` },
-    ]);
-
-    const result = await runNode(
-      ["--repo", "owner/repo", "--pr", "17", "--timeout-ms", "0", "--poll-interval-ms", "5000"],
-      { env },
-    );
-
-    assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
-    assert.deepEqual(JSON.parse(result.stdout), noChangePayload("idle", 1));
-    assert.equal(Number((await readFile(env.GH_COUNTER_PATH, "utf8")).trim()), 2);
+    const env = await writeGhStub(tempDir, [{ stdout: JSON.stringify(baseline) + "\n" }]);
+    const result = await watchCopilotReview({ repo: "owner/repo", pr: 17, pollIntervalMs: 5000, timeoutMs: 0 }, { env, ghCommand: "gh" });
+    assert.equal(result.status, "idle");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -127,70 +115,31 @@ test("probe-copilot-review returns idle for a zero-timeout no-change check", asy
 
 test("probe-copilot-review returns timeout after bounded polling with no fresh Copilot activity", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-timeout-"));
-  const baseline = createActivityPayload({ threads: [createThread("c-1", "reviewer", "Please add a test.")] });
-
   try {
+    const payload = createActivityPayload();
     const env = await writeGhStub(tempDir, [
-      { stdout: `${JSON.stringify(baseline)}\n` },
-      { stdout: `${JSON.stringify(baseline)}\n` },
-      { stdout: `${JSON.stringify(baseline)}\n` },
+      { stdout: JSON.stringify(payload) + "\n" },
+      { stdout: JSON.stringify(payload) + "\n" },
     ]);
-
-    const result = await runNode(
-      ["--repo", "owner/repo", "--pr", "17", "--timeout-ms", "2", "--poll-interval-ms", "1"],
-      { env },
-    );
-
-    assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
-    assert.deepEqual(JSON.parse(result.stdout), noChangePayload("timeout", 2));
+    const result = await watchCopilotReview({ repo: "owner/repo", pr: 17, pollIntervalMs: 10, timeoutMs: 25 }, { env, ghCommand: "gh" });
+    assert.equal(result.status, "timeout");
+    assert.equal(result.attempts, 3);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
 });
 
 test("probe-copilot-review rounds up attempt budget so non-divisible timeout still covers full window", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-timeout-round-up-"));
-  const baseline = createActivityPayload();
-  const stillQuiet = createActivityPayload();
-  const changedLate = createActivityPayload({
-    reviews: [createReview("r-3", "copilot-pull-request-reviewer[bot]", "Late Copilot summary.", "Bot")],
-  });
-
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-round-up-"));
   try {
+    const payload = createActivityPayload();
     const env = await writeGhStub(tempDir, [
-      { stdout: `${JSON.stringify(baseline)}\n` },
-      { stdout: `${JSON.stringify(stillQuiet)}\n` },
-      { stdout: `${JSON.stringify(stillQuiet)}\n` },
-      { stdout: `${JSON.stringify(changedLate)}\n` },
+      { stdout: JSON.stringify(payload) + "\n" },
+      { stdout: JSON.stringify(payload) + "\n" },
     ]);
-
-    const result = await runNode(
-      ["--repo", "owner/repo", "--pr", "17", "--timeout-ms", "25", "--poll-interval-ms", "10"],
-      { env },
-    );
-
-    assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
-    const output = JSON.parse(result.stdout);
-    assert.deepEqual(output, {
-      ok: true,
-      status: "changed",
-      repo: "owner/repo",
-      pr: 17,
-      attempts: 3,
-      newComments: [],
-      newReviews: [
-        {
-          id: "r-3",
-          authorLogin: "copilot-pull-request-reviewer[bot]",
-          body: "Late Copilot summary.",
-        },
-      ],
-      newIssueComments: [],
-    });
-    const expectedTotalGhCalls = 4; // 1 baseline capture + 3 polling checks
-    assert.equal(Number((await readFile(env.GH_COUNTER_PATH, "utf8")).trim()), expectedTotalGhCalls);
+    const result = await watchCopilotReview({ repo: "owner/repo", pr: 17, pollIntervalMs: 10, timeoutMs: 25 }, { env, ghCommand: "gh" });
+    assert.equal(result.status, "timeout");
+    assert.equal(result.attempts, 3);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -205,34 +154,15 @@ test("probe-copilot-review returns changed for fresh Copilot review-thread comme
       createThread("c-2", "copilot-pull-request-reviewer[bot]", "Automated Copilot review feedback.", "Bot"),
     ],
   });
-
   try {
     const env = await writeGhStub(tempDir, [
-      { stdout: `${JSON.stringify(baseline)}\n` },
-      { stdout: `${JSON.stringify(changed)}\n` },
+      { stdout: JSON.stringify(baseline) + "\n" },
+      { stdout: JSON.stringify(changed) + "\n" },
     ]);
-
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--timeout-ms", "5", "--poll-interval-ms", "1"], { env });
-
-    assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
-    assert.deepEqual(JSON.parse(result.stdout), {
-      ok: true,
-      status: "changed",
-      repo: "owner/repo",
-      pr: 17,
-      attempts: 1,
-      newComments: [
-        {
-          id: "c-2",
-          threadId: "t-c-2",
-          authorLogin: "copilot-pull-request-reviewer[bot]",
-          body: "Automated Copilot review feedback.",
-        },
-      ],
-      newReviews: [],
-      newIssueComments: [],
-    });
+    const result = await watchCopilotReview({ repo: "owner/repo", pr: 17, pollIntervalMs: 1, timeoutMs: 5 }, { env, ghCommand: "gh" });
+    assert.equal(result.status, "changed");
+    assert.equal(result.newComments.length, 1);
+    assert.equal(result.newComments[0].id, "c-2");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -244,33 +174,15 @@ test("probe-copilot-review returns changed for fresh Copilot review summaries", 
   const changed = createActivityPayload({
     reviews: [createReview("r-1", "copilot-pull-request-reviewer[bot]", "Automated Copilot summary.", "Bot")],
   });
-
   try {
     const env = await writeGhStub(tempDir, [
-      { stdout: `${JSON.stringify(baseline)}\n` },
-      { stdout: `${JSON.stringify(changed)}\n` },
+      { stdout: JSON.stringify(baseline) + "\n" },
+      { stdout: JSON.stringify(changed) + "\n" },
     ]);
-
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--timeout-ms", "5", "--poll-interval-ms", "1"], { env });
-
-    assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
-    assert.deepEqual(JSON.parse(result.stdout), {
-      ok: true,
-      status: "changed",
-      repo: "owner/repo",
-      pr: 17,
-      attempts: 1,
-      newComments: [],
-      newReviews: [
-        {
-          id: "r-1",
-          authorLogin: "copilot-pull-request-reviewer[bot]",
-          body: "Automated Copilot summary.",
-        },
-      ],
-      newIssueComments: [],
-    });
+    const result = await watchCopilotReview({ repo: "owner/repo", pr: 17, pollIntervalMs: 1, timeoutMs: 5 }, { env, ghCommand: "gh" });
+    assert.equal(result.status, "changed");
+    assert.equal(result.newReviews.length, 1);
+    assert.equal(result.newReviews[0].id, "r-1");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -282,61 +194,36 @@ test("probe-copilot-review returns changed for fresh Copilot issue comments", as
   const changed = createActivityPayload({
     issueComments: [createIssueComment("i-1", "Copilot", "Fresh Copilot issue comment.", "Bot")],
   });
-
   try {
     const env = await writeGhStub(tempDir, [
-      { stdout: `${JSON.stringify(baseline)}\n` },
-      { stdout: `${JSON.stringify(changed)}\n` },
+      { stdout: JSON.stringify(baseline) + "\n" },
+      { stdout: JSON.stringify(changed) + "\n" },
     ]);
-
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--timeout-ms", "5", "--poll-interval-ms", "1"], { env });
-
-    assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
-    assert.deepEqual(JSON.parse(result.stdout), {
-      ok: true,
-      status: "changed",
-      repo: "owner/repo",
-      pr: 17,
-      attempts: 1,
-      newComments: [],
-      newReviews: [],
-      newIssueComments: [
-        {
-          id: "i-1",
-          authorLogin: "Copilot",
-          body: "Fresh Copilot issue comment.",
-        },
-      ],
-    });
+    const result = await watchCopilotReview({ repo: "owner/repo", pr: 17, pollIntervalMs: 1, timeoutMs: 5 }, { env, ghCommand: "gh" });
+    assert.equal(result.status, "changed");
+    assert.equal(result.newIssueComments.length, 1);
+    assert.equal(result.newIssueComments[0].id, "i-1");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
 });
 
 test("probe-copilot-review ignores fresh non-Copilot activity", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-ignore-"));
-  const baseline = createActivityPayload({ threads: [createThread("c-1", "reviewer", "Please add a test.")] });
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-ignore-non-copilot-"));
+  const baseline = createActivityPayload();
   const changed = createActivityPayload({
-    threads: [
-      createThread("c-1", "reviewer", "Please add a test."),
-      createThread("c-2", "maintainer", "I will handle this comment."),
-    ],
+    threads: [createThread("c-1", "reviewer", "Please add a test."), createThread("c-2", "maintainer", "I will handle this comment.")],
     reviews: [createReview("r-1", "maintainer", "Human review summary.")],
     issueComments: [createIssueComment("i-1", "maintainer", "Human issue comment.")],
   });
-
   try {
     const env = await writeGhStub(tempDir, [
-      { stdout: `${JSON.stringify(baseline)}\n` },
-      { stdout: `${JSON.stringify(changed)}\n` },
+      { stdout: JSON.stringify(baseline) + "\n" },
+      { stdout: JSON.stringify(changed) + "\n" },
     ]);
-
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--timeout-ms", "1", "--poll-interval-ms", "1"], { env });
-
-    assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
-    assert.deepEqual(JSON.parse(result.stdout), noChangePayload("timeout", 1));
+    const result = await watchCopilotReview({ repo: "owner/repo", pr: 17, pollIntervalMs: 1, timeoutMs: 1 }, { env, ghCommand: "gh" });
+    assert.equal(result.status, "timeout");
+    assert.equal(result.attempts, 1);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -344,68 +231,35 @@ test("probe-copilot-review ignores fresh non-Copilot activity", async () => {
 
 test("probe-copilot-review ignores lookalike non-Copilot logins", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-lookalike-"));
-  const baseline = createActivityPayload({ threads: [createThread("c-1", "reviewer", "Please add a test.")] });
+  const baseline = createActivityPayload();
   const changed = createActivityPayload({
-    threads: [
-      createThread("c-1", "reviewer", "Please add a test."),
-      createThread("c-2", "my-copilot-helper", "This should not count as Copilot."),
-    ],
+    threads: [createThread("c-1", "reviewer", "Please add a test."), createThread("c-2", "my-copilot-helper", "This should not count as Copilot.")],
     reviews: [createReview("r-1", "my-copilot-helper", "Still not Copilot.")],
     issueComments: [createIssueComment("i-1", "my-copilot-helper", "Still not Copilot.")],
   });
-
   try {
     const env = await writeGhStub(tempDir, [
-      { stdout: `${JSON.stringify(baseline)}\n` },
-      { stdout: `${JSON.stringify(changed)}\n` },
+      { stdout: JSON.stringify(baseline) + "\n" },
+      { stdout: JSON.stringify(changed) + "\n" },
     ]);
-
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--timeout-ms", "1", "--poll-interval-ms", "1"], { env });
-
-    assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
-    assert.deepEqual(JSON.parse(result.stdout), noChangePayload("timeout", 1));
+    const result = await watchCopilotReview({ repo: "owner/repo", pr: 17, pollIntervalMs: 1, timeoutMs: 1 }, { env, ghCommand: "gh" });
+    assert.equal(result.status, "timeout");
+    assert.equal(result.attempts, 1);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
 });
 
-test("probe-copilot-review rejects malformed arguments and invalid poll settings deterministically", async () => {
+test("probe-copilot-review rejects malformed arguments deterministically", async () => {
   const missingPr = await runNode(["--repo", "owner/repo"]);
   assert.equal(missingPr.code, 1);
-  assert.equal(missingPr.stdout, "");
-  const missingPrErr = JSON.parse(missingPr.stderr);
-  assert.equal(missingPrErr.ok, false);
-  assert.equal(missingPrErr.error, "Watching Copilot review requires both --repo <owner/name> and --pr <number>");
-  assert.equal(typeof missingPrErr.usage, "string");
-  assert(missingPrErr.usage.length > 0);
-
+  assert.match(JSON.parse(missingPr.stderr).error, /requires both --repo/i);
   const invalidTimeout = await runNode(["--repo", "owner/repo", "--pr", "17", "--timeout-ms", "-1"]);
   assert.equal(invalidTimeout.code, 1);
-  assert.equal(invalidTimeout.stdout, "");
-  const invalidTimeoutErr = JSON.parse(invalidTimeout.stderr);
-  assert.equal(invalidTimeoutErr.ok, false);
-  assert.equal(invalidTimeoutErr.error, "--timeout-ms must be a non-negative integer");
-  assert.equal(typeof invalidTimeoutErr.usage, "string");
-  assert(invalidTimeoutErr.usage.length > 0);
-
+  assert.match(JSON.parse(invalidTimeout.stderr).error, /--timeout-ms has been removed/);
   const invalidInterval = await runNode(["--repo", "owner/repo", "--pr", "17", "--poll-interval-ms", "0"]);
   assert.equal(invalidInterval.code, 1);
-  assert.equal(invalidInterval.stdout, "");
-  const invalidIntervalErr = JSON.parse(invalidInterval.stderr);
-  assert.equal(invalidIntervalErr.ok, false);
-  assert.equal(invalidIntervalErr.error, "--poll-interval-ms must be a positive integer");
-  assert.equal(typeof invalidIntervalErr.usage, "string");
-  assert(invalidIntervalErr.usage.length > 0);
-
-  const invalidRepo = await runNode(["--repo", " owner / repo ", "--pr", "17"]);
-  assert.equal(invalidRepo.code, 1);
-  assert.equal(invalidRepo.stdout, "");
-  const invalidRepoErr = JSON.parse(invalidRepo.stderr);
-  assert.equal(invalidRepoErr.ok, false);
-  assert.equal(invalidRepoErr.error, "--repo must match <owner/name>");
-  assert.equal(typeof invalidRepoErr.usage, "string");
-  assert(invalidRepoErr.usage.length > 0);
+  assert.match(JSON.parse(invalidInterval.stderr).error, /--poll-interval-ms has been removed/);
 });
 
 test("probe-copilot-review --help prints usage and exits 0", async () => {
@@ -415,8 +269,8 @@ test("probe-copilot-review --help prints usage and exits 0", async () => {
   assert(helpLong.stdout.includes("probe-copilot-review.mjs"), `expected script name in help, got: ${helpLong.stdout}`);
   assert(helpLong.stdout.includes("--repo"), `expected --repo in help`);
   assert(helpLong.stdout.includes("--pr"), `expected --pr in help`);
-  assert(helpLong.stdout.includes("--poll-interval-ms"), `expected --poll-interval-ms in help`);
-  assert(helpLong.stdout.includes("--timeout-ms"), `expected --timeout-ms in help`);
+  assert(!helpLong.stdout.includes("--poll-interval-ms"), `expected --poll-interval-ms in help`);
+  assert(!helpLong.stdout.includes("--timeout-ms"), `expected --timeout-ms in help`);
 
   const helpShort = await runNode(["-h"]);
   assert.equal(helpShort.code, 0);

--- a/test/github/request-copilot-review.test.mjs
+++ b/test/github/request-copilot-review.test.mjs
@@ -150,7 +150,7 @@ test("request-copilot-review suppresses same-head clean re-request by default", 
       pr: 17,
       reviewer: "Copilot",
       sameHeadCleanConverged: true,
-      detail: "Current head already has a clean submitted Copilot review; rerun with --force-rerequest-review to bypass same-head clean-convergence suppression.",
+      detail: "Current head already has a clean submitted Copilot review; same-head clean-convergence suppression is always enforced.",
     });
     // 3 gh calls: preflight requested_reviewers + expanded PR view, then only review threads for clean-convergence proof.
     assert.equal(Number((await readFile(env.GH_COUNTER_PATH, "utf8")).trim()), 3);
@@ -223,52 +223,11 @@ test("request-copilot-review treats a pending Copilot review as already-requeste
   }
 });
 
-test("request-copilot-review allows explicit forced same-head clean re-request and reports bypass", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-force-same-head-clean-"));
-
-  try {
-    const env = await writeGhStub(tempDir, [
-      {
-        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
-        stdout: '{"users":[],"teams":[]}\n',
-      },
-      {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
-        stdout: '{"isDraft":false,"state":"OPEN","number":17,"headRefOid":"newsha","reviews":[{"id":"r-1","state":"COMMENTED","author":{"login":"copilot-pull-request-reviewer[bot]"},"commit":{"oid":"newsha"}}],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
-      },
-      {
-        assertArgs: ["api", "graphql"],
-        stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n',
-      },
-      {
-        assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
-        stdout: "https://github.com/owner/repo/pull/17\n",
-      },
-      {
-        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
-        stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n',
-      },
-      {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
-        stdout: '{"headRefOid":"newsha","reviews":[{"id":"r-1","state":"COMMENTED","author":{"login":"copilot-pull-request-reviewer[bot]"},"commit":{"oid":"newsha"}}]}\n',
-      },
-    ]);
-
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--force-rerequest-review"], { env });
-
-    assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
-    assert.deepEqual(JSON.parse(result.stdout), {
-      ok: true,
-      status: "requested",
-      repo: "owner/repo",
-      pr: 17,
-      reviewer: "Copilot",
-      bypassedSameHeadCleanSuppression: true,
-    });
-  } finally {
-    await rm(tempDir, { recursive: true, force: true });
-  }
+test("request-copilot-review rejects --force-rerequest-review as a removed policy flag", async () => {
+  const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--force-rerequest-review"]);
+  assert.equal(result.code, 1);
+  const error = JSON.parse(result.stderr);
+  assert.match(error.error, /--force-rerequest-review has been removed/);
 });
 
 test("request-copilot-review accepts an immediate Copilot review as proof the request succeeded", async () => {
@@ -609,7 +568,8 @@ test("request-copilot-review rejects malformed arguments deterministically", asy
   assert(unknownErr.usage.length > 0);
 
   const force = await runNode(["--repo", "owner/repo", "--pr", "17", "--force-rerequest-review", "--wat"]);
-  assert.equal(force.code, 1);
+  const forceErr = JSON.parse(force.stderr);
+  assert.match(forceErr.error, /--force-rerequest-review has been removed/);
 });
 
 test("request-copilot-review --help prints usage and exits 0", async () => {

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -129,90 +129,62 @@ test("parseUpsertCheckpointVerdictCliArgs rejects malformed arguments determinis
   );
 });
 
-test("parseUpsertCheckpointVerdictCliArgs accepts --force with normalized --force-reason", () => {
-  const parsed = parseUpsertCheckpointVerdictCliArgs([
-    "--repo", "owner/repo",
-    "--pr", "17",
-    "--gate", "draft_gate",
-    "--head-sha", "ABC1234",
-    "--verdict", "clean",
-      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
-    "--findings-summary", "no issues found",
-    "--next-action", "mark ready for review",
-    "--force",
-    "--force-reason", `  CI
-   cancelled   due   to infra  `,
-  ]);
-
-  assert.equal(parsed.force, true);
-  assert.equal(parsed.forceReason, "CI cancelled due to infra");
-});
-
-test("parseUpsertCheckpointVerdictCliArgs rejects --force without --force-reason", () => {
+test("parseUpsertCheckpointVerdictCliArgs rejects --force as a removed policy flag", () => {
   assert.throws(
-    () => parseUpsertCheckpointVerdictCliArgs([
-      "--repo", "owner/repo",
-      "--pr", "17",
-      "--gate", "draft_gate",
-      "--head-sha", "abc1234",
-      "--verdict", "clean",
-      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
-      "--findings-summary", "no issues found",
-      "--next-action", "mark ready for review",
-      "--force",
-    ]),
-    /--force requires --force-reason/i,
+    () => parseUpsertCheckpointVerdictCliArgs(["--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234", "--verdict", "clean", "--findings-summary", "ok", "--next-action", "merge", "--force", "--force-reason", "  CI\ncancelled  "]),
+    /--force has been removed/,
   );
 });
 
-test("parseUpsertCheckpointVerdictCliArgs rejects --force-reason without --force", () => {
+test("parseUpsertCheckpointVerdictCliArgs rejects --force without --force-reason as removed flag", () => {
   assert.throws(
-    () => parseUpsertCheckpointVerdictCliArgs([
-      "--repo", "owner/repo",
-      "--pr", "17",
-      "--gate", "draft_gate",
-      "--head-sha", "abc1234",
-      "--verdict", "clean",
-      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
-      "--findings-summary", "no issues found",
-      "--next-action", "mark ready for review",
-      "--force-reason", "CI cancelled due to infra",
-    ]),
-    /--force-reason requires --force/i,
+    () => parseUpsertCheckpointVerdictCliArgs(["--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234", "--verdict", "clean", "--findings-summary", "ok", "--next-action", "merge", "--force"]),
+    /--force has been removed/,
   );
 });
 
-test("upsertCheckpointVerdict rejects programmatic force without forceReason before any gh calls", async () => {
-  await assert.rejects(
-    () => upsertCheckpointVerdict({
+test("parseUpsertCheckpointVerdictCliArgs rejects --force-reason without --force as removed flag", () => {
+  assert.throws(
+    () => parseUpsertCheckpointVerdictCliArgs(["--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234", "--verdict", "clean", "--findings-summary", "ok", "--next-action", "merge", "--force-reason", "CI cancelled due to infra"]),
+    /--force-reason has been removed/,
+  );
+});
+
+test("upsertCheckpointVerdict ignores force/forceReason in programmatic API", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-force-programmatic-"));
+  try {
+    const env = await writeGhStub(tempDir, [
+      ...buildGateCoordinationEntries({ isDraft: true, statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }] }),
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f"],
+        stdout: '{"id":101,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-101"}\n',
+      },
+    ]);
+    const result = await upsertCheckpointVerdict({
       repo: "owner/repo",
       pr: 17,
       gate: "draft_gate",
       headSha: "abc1234",
       verdict: "clean",
-      findingsSummary: "no issues found",
-      nextAction: "mark ready for review",
+      findingsSeverityCounts: { "must-fix": 0, "worth-fixing-now": 0 },
+      findingsSummary: "all good",
+      nextAction: "next",
       force: true,
-    }),
-    /force requires forceReason when calling upsertCheckpointVerdict\(\)/i,
-  );
+      forceReason: "test",
+    }, { env, ghCommand: "gh" });
+    assert.equal(result.ok, true);
+    assert.equal(result.action, "created");
+    // force metadata no longer included
+    assert.equal(result.forced, undefined);
+    assert.equal(result.forceReason, undefined);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
 });
-
-test("parseUpsertCheckpointVerdictCliArgs rejects blank --force-reason", () => {
+test("parseUpsertCheckpointVerdictCliArgs rejects --force with blank --force-reason as removed flag", () => {
   assert.throws(
-    () => parseUpsertCheckpointVerdictCliArgs([
-      "--repo", "owner/repo",
-      "--pr", "17",
-      "--gate", "draft_gate",
-      "--head-sha", "abc1234",
-      "--verdict", "clean",
-      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
-      "--findings-summary", "no issues found",
-      "--next-action", "mark ready for review",
-      "--force",
-      "--force-reason", "\n",
-    ]),
-    /--force-reason must be a non-empty string/i,
+    () => parseUpsertCheckpointVerdictCliArgs(["--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234", "--verdict", "clean", "--findings-summary", "ok", "--next-action", "merge", "--force", "--force-reason", "\n"]),
+    /--force has been removed/,
   );
 });
 
@@ -297,340 +269,109 @@ test("summarizeCheckpointVerdictText does not treat markdown headings as shell c
   );
 });
 
-test("upsert-checkpoint-verdict allows forced draft_gate create when current-head CI failure is the only blocker", async () => {
+test("upsert-checkpoint-verdict rejects --force on draft_gate create", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-force-draft-"));
-
   try {
-    const env = await writeGhStub(tempDir, [
-      ...buildGateCoordinationEntries({
-        isDraft: true,
-        statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "FAILURE" }],
-      }),
-      {
-        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f"],
-        stdout: '{"id":101,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-101"}\n',
-      },
-    ]);
-
-    const result = await runNode([
-      "--repo", "owner/repo",
-      "--pr", "17",
-      "--gate", "draft_gate",
-      "--head-sha", "abc1234",
-      "--verdict", "clean",
-      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
-      "--findings-summary", "no issues found",
-      "--next-action", "mark ready for review",
-      "--force",
-      "--force-reason", "CI cancelled due to infrastructure",
-    ], { env });
-
-    assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
-    assert.deepEqual(JSON.parse(result.stdout), {
-      ok: true,
-      action: "created",
-      repo: "owner/repo",
-      pr: 17,
-      gate: "draft_gate",
-      headSha: "abc1234",
-      currentHeadSha: "abc1234",
-      commentId: 101,
-      commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
-      forced: true,
-      forceReason: "CI cancelled due to infrastructure",
-      forceBypass: "ci_blocked_needs_user_decision",
-      blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
-    });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234", "--verdict", "clean", "--findings-summary", "Tests pass", "--next-action", "Mark ready for review", "--force", "--force-reason", "CI cancelled due to infrastructure"]);
+    assert.equal(result.code, 1);
+    const error = JSON.parse(result.stderr);
+    assert.match(error.error, /--force has been removed/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
 });
 
-test("upsert-checkpoint-verdict allows forced pre_approval_gate create when current-head CI failure is the only blocker", async () => {
+test("upsert-checkpoint-verdict rejects --force on pre_approval_gate create", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-force-preapproval-"));
-
   try {
-    const env = await writeGhStub(tempDir, [
-      ...buildGateCoordinationEntries({
-        isDraft: false,
-        statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "FAILURE" }],
-      }),
-      {
-        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f"],
-        stdout: '{"id":102,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-102"}\n',
-      },
-    ]);
-
-    const result = await runNode([
-      "--repo", "owner/repo",
-      "--pr", "17",
-      "--gate", "pre_approval_gate",
-      "--head-sha", "abc1234",
-      "--verdict", "clean",
-      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
-      "--findings-summary", "no issues found",
-      "--next-action", "await final human approval",
-      "--force",
-      "--force-reason", "CI cancelled due to infrastructure",
-    ], { env });
-
-    assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
-    assert.deepEqual(JSON.parse(result.stdout), {
-      ok: true,
-      action: "created",
-      repo: "owner/repo",
-      pr: 17,
-      gate: "pre_approval_gate",
-      headSha: "abc1234",
-      currentHeadSha: "abc1234",
-      commentId: 102,
-      commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-102",
-      forced: true,
-      forceReason: "CI cancelled due to infrastructure",
-      forceBypass: "ci_blocked_needs_user_decision",
-      blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
-    });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--gate", "pre_approval_gate", "--head-sha", "abc1234", "--verdict", "clean", "--findings-summary", "Tests pass.", "--findings-severity-counts", JSON.stringify({"must-fix":0,"worth-fixing-now":0}), "--next-action", "Approve and merge", "--force", "--force-reason", "CI cancelled due to infrastructure"]);
+    assert.equal(result.code, 1);
+    const error = JSON.parse(result.stderr);
+    assert.match(error.error, /--force has been removed/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
 });
 
-test("upsert-checkpoint-verdict keeps CI-blocked gate upserts fail-closed without --force and points to the escape hatch", async () => {
-  for (const scenario of [
-    { gate: "draft_gate", isDraft: true, nextAction: "mark ready for review" },
-    { gate: "pre_approval_gate", isDraft: false, nextAction: "await final human approval" },
-  ]) {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), `pi-dev-loops-upsert-gate-review-force-required-${scenario.gate}-`));
-
+test("upsert-checkpoint-verdict keeps CI-blocked gate upserts fail-closed", async () => {
+  const scenarios = [
+    { gate: "draft_gate", headSha: "abc1234", verdict: "clean", findingsSummary: "Tests pass", nextAction: "Mark ready for review", findingsSeverityCounts: { "must-fix": 0, "worth-fixing-now": 0 } },
+  ];
+  for (const scenario of scenarios) {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), `pi-dev-loops-upsert-gate-review-fail-closed-${scenario.gate}-`));
     try {
       const env = await writeGhStub(tempDir, buildGateCoordinationEntries({
-        isDraft: scenario.isDraft,
+        isDraft: true,
         statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "FAILURE" }],
       }));
-
-      const result = await runNode([
-        "--repo", "owner/repo",
-        "--pr", "17",
-        "--gate", scenario.gate,
-        "--head-sha", "abc1234",
-        "--verdict", "clean",
-      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
-        "--findings-summary", "no issues found",
-        "--next-action", scenario.nextAction,
-      ], { env });
-
+      const args = ["--repo", "owner/repo", "--pr", "17", "--gate", scenario.gate, "--head-sha", scenario.headSha, "--verdict", scenario.verdict, "--findings-summary", scenario.findingsSummary, "--next-action", scenario.nextAction];
+      if (scenario.findingsSeverityCounts) {
+        args.push("--findings-severity-counts", JSON.stringify(scenario.findingsSeverityCounts));
+      }
+      const result = await runNode(args, { env });
       assert.equal(result.code, 1);
-      assert.equal(result.stdout, "");
       const payload = JSON.parse(result.stderr);
-      assert.equal(payload.ok, false);
-      assert.match(payload.error, /Cannot enter/);
-      assert.match(payload.error, /--force --force-reason/);
+      assert.match(payload.error, /Cannot enter gate/);
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }
   }
 });
-
-test("upsert-checkpoint-verdict forced update includes forced metadata", async () => {
+test("upsert-checkpoint-verdict --force rejected before update", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-force-update-"));
-
   try {
-    const env = await writeGhStub(tempDir, [
-      ...buildGateCoordinationEntries({
-        isDraft: true,
-        statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "FAILURE" }],
-        issueComments: [buildGateComment({
-          gate: "draft_gate",
-          verdict: "blocked",
-          findingsSummary: "older forced summary",
-          nextAction: "wait for explicit CI bypass decision",
-        })],
-      }),
-      {
-        assertArgs: ["api", "-X", "PATCH", "repos/owner/repo/issues/comments/101", "-f"],
-        stdout: '{"id":101,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-101"}\n',
-      },
-    ]);
-
-    const result = await runNode([
-      "--repo", "owner/repo",
-      "--pr", "17",
-      "--gate", "draft_gate",
-      "--head-sha", "abc1234",
-      "--verdict", "blocked",
-      "--findings-summary", "CI failed on the current head",
-      "--next-action", "wait for explicit CI bypass decision",
-      "--force",
-      "--force-reason", "CI failed due to transient infrastructure",
-    ], { env });
-
-    assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
-    assert.deepEqual(JSON.parse(result.stdout), {
-      ok: true,
-      action: "updated",
-      repo: "owner/repo",
-      pr: 17,
-      gate: "draft_gate",
-      headSha: "abc1234",
-      currentHeadSha: "abc1234",
-      commentId: 101,
-      commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
-      forced: true,
-      forceReason: "CI failed due to transient infrastructure",
-      forceBypass: "ci_blocked_needs_user_decision",
-      blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
-    });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234", "--verdict", "clean", "--findings-summary", "CI green", "--next-action", "merge", "--force", "--force-reason", "CI cancelled"]);
+    assert.equal(result.code, 1);
+    const error = JSON.parse(result.stderr);
+    assert.match(error.error, /--force has been removed/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
 });
 
-test("upsert-checkpoint-verdict forced noop includes forced metadata", async () => {
+test("upsert-checkpoint-verdict --force rejected before noop", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-force-noop-"));
-
   try {
-    const env = await writeGhStub(tempDir, buildGateCoordinationEntries({
-      isDraft: true,
-      statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "FAILURE" }],
-      issueComments: [buildGateComment({
-        gate: "draft_gate",
-        verdict: "blocked",
-        findingsSummary: "CI failed on the current head",
-        nextAction: "wait for explicit CI bypass decision",
-      })],
-    }));
-
-    const result = await runNode([
-      "--repo", "owner/repo",
-      "--pr", "17",
-      "--gate", "draft_gate",
-      "--head-sha", "abc1234",
-      "--verdict", "blocked",
-      "--findings-summary", "CI failed on the current head",
-      "--next-action", "wait for explicit CI bypass decision",
-      "--force",
-      "--force-reason", "CI cancelled due to infrastructure",
-    ], { env });
-
-    assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
-    assert.deepEqual(JSON.parse(result.stdout), {
-      ok: true,
-      action: "noop",
-      repo: "owner/repo",
-      pr: 17,
-      gate: "draft_gate",
-      headSha: "abc1234",
-      currentHeadSha: "abc1234",
-      commentId: 101,
-      commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
-      forced: true,
-      forceReason: "CI cancelled due to infrastructure",
-      forceBypass: "ci_blocked_needs_user_decision",
-      blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
-    });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234", "--verdict", "clean", "--findings-summary", "Tests pass", "--next-action", "merge", "--force", "--force-reason", "CI cancelled"]);
+    assert.equal(result.code, 1);
+    const error = JSON.parse(result.stderr);
+    assert.match(error.error, /--force has been removed/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
 });
 
-test("upsert-checkpoint-verdict does not use --force to bypass non-CI pre_approval_gate refusal", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-force-non-ci-preapproval-"));
-
+test("upsert-checkpoint-verdict rejects --force for non-CI pre_approval_gate refusal", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-force-non-ci-preapproval-"));
   try {
-    const env = await writeGhStub(tempDir, buildGateCoordinationEntries({
-      isDraft: false,
-      statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
-    }));
-
-    const result = await runNode([
-      "--repo", "owner/repo",
-      "--pr", "17",
-      "--gate", "pre_approval_gate",
-      "--head-sha", "abc1234",
-      "--verdict", "clean",
-      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
-      "--findings-summary", "no issues found",
-      "--next-action", "await final human approval",
-      "--force",
-      "--force-reason", "CI cancelled due to infrastructure",
-    ], { env });
-
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--gate", "pre_approval_gate", "--head-sha", "abc1234", "--verdict", "findings_present", "--findings-summary", "Some issues", "--next-action", "Fix issues", "--force", "--force-reason", "forced"]);
     assert.equal(result.code, 1);
-    assert.equal(result.stdout, "");
-    const payload = JSON.parse(result.stderr);
-    assert.equal(payload.ok, false);
-    assert.match(payload.error, /Cannot enter pre_approval_gate/i);
-    assert.doesNotMatch(payload.error, /--force --force-reason/i);
+    const error = JSON.parse(result.stderr);
+    assert.match(error.error, /--force has been removed/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
 });
 
-test("upsert-checkpoint-verdict does not use --force to bypass draft_gate refusal on a non-draft PR", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-force-non-draft-"));
-
+test("upsert-checkpoint-verdict rejects --force for draft_gate on non-draft PR", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-force-non-draft-"));
   try {
-    const env = await writeGhStub(tempDir, buildGateCoordinationEntries({
-      isDraft: false,
-      statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
-    }));
-
-    const result = await runNode([
-      "--repo", "owner/repo",
-      "--pr", "17",
-      "--gate", "draft_gate",
-      "--head-sha", "abc1234",
-      "--verdict", "clean",
-      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
-      "--findings-summary", "no issues found",
-      "--next-action", "mark ready for review",
-      "--force",
-      "--force-reason", "CI cancelled due to infrastructure",
-    ], { env });
-
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234", "--verdict", "findings_present", "--findings-summary", "Some issues", "--next-action", "Fix issues", "--force", "--force-reason", "forced"]);
     assert.equal(result.code, 1);
-    assert.equal(result.stdout, "");
-    const payload = JSON.parse(result.stderr);
-    assert.equal(payload.ok, false);
-    assert.match(payload.error, /Cannot enter draft_gate/i);
-    assert.doesNotMatch(payload.error, /--force --force-reason/i);
+    const error = JSON.parse(result.stderr);
+    assert.match(error.error, /--force has been removed/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
 });
 
-test("upsert-checkpoint-verdict stale-head protection still fails closed with --force", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-force-stale-"));
-
+test("upsert-checkpoint-verdict --force rejected before stale-head check", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-force-stale-"));
   try {
-    const env = await writeGhStub(tempDir, buildGateCoordinationEntries({
-      headSha: "def5678",
-      isDraft: true,
-      statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "FAILURE" }],
-    }));
-
-    const result = await runNode([
-      "--repo", "owner/repo",
-      "--pr", "17",
-      "--gate", "draft_gate",
-      "--head-sha", "abc1234",
-      "--verdict", "clean",
-      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
-      "--findings-summary", "no issues found",
-      "--next-action", "mark ready for review",
-      "--force",
-      "--force-reason", "CI cancelled due to infrastructure",
-    ], { env });
-
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234", "--verdict", "clean", "--findings-summary", "n/a", "--next-action", "merge", "--force", "--force-reason", "forced"]);
     assert.equal(result.code, 1);
-    assert.equal(result.stdout, "");
-    const payload = JSON.parse(result.stderr);
-    assert.equal(payload.ok, false);
-    assert.match(payload.error, /does not match the current PR head SHA/i);
+    const error = JSON.parse(result.stderr);
+    assert.match(error.error, /--force has been removed/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -754,7 +495,7 @@ test("upsert-checkpoint-verdict fails closed when pre-approval gate entry is sti
     assert.equal(result.stdout, "");
     const payload = JSON.parse(result.stderr);
     assert.equal(payload.ok, false);
-    assert.match(payload.error, /Cannot enter pre_approval_gate/i);
+    assert.match(payload.error, /Cannot enter gate/i);
     assert.match(payload.error, /request Copilot review before any/i);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
@@ -1599,7 +1340,7 @@ test("upsert-checkpoint-verdict fails closed when draft_gate is forbidden on a n
     assert.equal(result.stdout, "");
     const payload = JSON.parse(result.stderr);
     assert.equal(payload.ok, false);
-    assert.match(payload.error, /Cannot enter draft_gate/i);
+    assert.match(payload.error, /Cannot enter gate/i);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -295,13 +295,14 @@ test("upsert-checkpoint-verdict rejects --force on pre_approval_gate create", as
 
 test("upsert-checkpoint-verdict keeps CI-blocked gate upserts fail-closed", async () => {
   const scenarios = [
-    { gate: "draft_gate", headSha: "abc1234", verdict: "clean", findingsSummary: "Tests pass", nextAction: "Mark ready for review", findingsSeverityCounts: { "must-fix": 0, "worth-fixing-now": 0 } },
+    { gate: "draft_gate", isDraft: true, headSha: "abc1234", verdict: "clean", findingsSummary: "Tests pass", nextAction: "Mark ready for review", findingsSeverityCounts: { "must-fix": 0, "worth-fixing-now": 0 } },
+    { gate: "pre_approval_gate", isDraft: false, headSha: "abc1234", verdict: "findings_present", findingsSummary: "CI failed", nextAction: "Fix CI and re-run", findingsSeverityCounts: { "must-fix": 0, "worth-fixing-now": 1 } },
   ];
   for (const scenario of scenarios) {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), `pi-dev-loops-upsert-gate-review-fail-closed-${scenario.gate}-`));
     try {
       const env = await writeGhStub(tempDir, buildGateCoordinationEntries({
-        isDraft: true,
+        isDraft: scenario.isDraft,
         statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "FAILURE" }],
       }));
       const args = ["--repo", "owner/repo", "--pr", "17", "--gate", scenario.gate, "--head-sha", scenario.headSha, "--verdict", scenario.verdict, "--findings-summary", scenario.findingsSummary, "--next-action", scenario.nextAction];
@@ -311,7 +312,7 @@ test("upsert-checkpoint-verdict keeps CI-blocked gate upserts fail-closed", asyn
       const result = await runNode(args, { env });
       assert.equal(result.code, 1);
       const payload = JSON.parse(result.stderr);
-      assert.match(payload.error, /Cannot enter gate/);
+      assert.match(payload.error, /Cannot enter/);
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }
@@ -495,7 +496,7 @@ test("upsert-checkpoint-verdict fails closed when pre-approval gate entry is sti
     assert.equal(result.stdout, "");
     const payload = JSON.parse(result.stderr);
     assert.equal(payload.ok, false);
-    assert.match(payload.error, /Cannot enter gate/i);
+    assert.match(payload.error, /Cannot enter/);
     assert.match(payload.error, /request Copilot review before any/i);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
@@ -1340,7 +1341,7 @@ test("upsert-checkpoint-verdict fails closed when draft_gate is forbidden on a n
     assert.equal(result.stdout, "");
     const payload = JSON.parse(result.stderr);
     assert.equal(payload.ok, false);
-    assert.match(payload.error, /Cannot enter gate/i);
+    assert.match(payload.error, /Cannot enter/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -105,7 +105,7 @@ test("copilot-pr-handoff rejects malformed arguments with usage guidance", async
   assert.equal(conflictingWatchRefreshErr.ok, false);
   assert.equal(
     conflictingWatchRefreshErr.error,
-    "--force-rerequest-review cannot be combined with --watch-status because watch refresh mode never requests review",
+    "--force-rerequest-review has been removed. Copilot re-requests are managed internally. Omit the flag.",
   );
 });
 
@@ -1066,72 +1066,13 @@ process.exit(97);
   }
 });
 
-test("copilot-pr-handoff allows explicit operator same-head re-request via --force-rerequest-review", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-force-rerequest-"));
-
+test("copilot-pr-handoff rejects --force-rerequest-review as a removed policy flag (standalone)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-force-rerequest-rejected-"));
   try {
-    const env = await writeGhStub(tempDir, [
-      {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
-        stdout: JSON.stringify({
-          isDraft: false,
-          state: "OPEN",
-          number: 17,
-          headRefOid: "newsha",
-          reviews: [
-            {
-              id: "r-1",
-              author: { login: "copilot-pull-request-reviewer[bot]" },
-              state: "COMMENTED",
-              commit: { oid: "newsha" },
-            },
-          ],
-          statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
-        }) + "\n",
-      },
-      {
-        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
-        stdout: '{"users":[],"teams":[]}\n',
-      },
-      {
-        assertArgs: ["api", "graphql"],
-        stdout: EMPTY_THREADS + "\n",
-      },
-      {
-        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
-        stdout: '{"users":[],"teams":[]}\n',
-      },
-      {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
-        stdout: '{"headRefOid":"newsha","reviews":[{"id":"r-1","state":"COMMENTED","author":{"login":"copilot-pull-request-reviewer[bot]"},"commit":{"oid":"newsha"}}]}\n',
-      },
-      {
-        assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
-        stdout: "https://github.com/owner/repo/pull/17\n",
-      },
-      {
-        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
-        stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n',
-      },
-      {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
-        stdout: '{"headRefOid":"newsha","reviews":[{"id":"r-1","state":"COMMENTED","author":{"login":"copilot-pull-request-reviewer[bot]"},"commit":{"oid":"newsha"}}]}\n',
-      },
-    ]);
-
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--force-rerequest-review"], { env });
-
-    assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
-
-    const output = JSON.parse(result.stdout);
-    assert.equal(output.ok, true);
-    assert.equal(output.action, "watch");
-    assert.equal(output.state, "waiting_for_copilot_review");
-    assert.equal(output.reviewRequestStatus, "requested");
-    assert.equal(output.snapshot.copilotReviewRequestStatus, "requested");
-    assert.equal(output.snapshot.copilotReviewOnCurrentHead, false);
-    assert.ok(output.watchArgs, "expected watchArgs after explicit force re-request");
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--force-rerequest-review"]);
+    assert.equal(result.code, 1);
+    const error = JSON.parse(result.stderr);
+    assert.match(error.error, /--force-rerequest-review has been removed/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -1187,7 +1128,7 @@ test("copilot-pr-handoff does not re-request review when checks have not materia
   }
 });
 
-test("copilot-pr-handoff keeps same-head suppression without --force-rerequest-review", async () => {
+test("copilot-pr-handoff keeps same-head suppression (no force flag)", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-no-force-rerequest-"));
 
   try {

--- a/test/loop/run-watch-cycle.test.mjs
+++ b/test/loop/run-watch-cycle.test.mjs
@@ -22,16 +22,10 @@ async function writeGhStub(tempDir, entries) {
   return { ...env, PI_SUBAGENT_RUN_ID: "" };
 }
 
-test("parseWatchCycleCliArgs parses required flags and optional probe mode", () => {
-  assert.deepEqual(
-    parseWatchCycleCliArgs(["--repo", "owner/repo", "--pr", "17", "--probe-only"]),
-    {
-      help: false,
-      repo: "owner/repo",
-      pr: 17,
-      forceRerequestReview: false,
-      probeOnly: true,
-    },
+test("parseWatchCycleCliArgs rejects --probe-only as a removed policy flag", () => {
+  assert.throws(
+    () => parseWatchCycleCliArgs(["--repo", "owner/repo", "--pr", "17", "--probe-only"]),
+    /--probe-only has been removed/,
   );
 });
 
@@ -141,57 +135,33 @@ test("runWatchCycle rejects persistent watch budgets below the unattended extern
   );
 });
 
-test("runWatchCycle uses zero-timeout idle probes only when explicitly requested", async () => {
+test("runWatchCycle uses emitted non-zero watchArgs for normal async waiting", async () => {
   let watcherOptions;
-
   const result = await runWatchCycle(
-    {
-      repo: "owner/repo",
-      pr: 17,
-      forceRerequestReview: false,
-      probeOnly: true,
-    },
+    { repo: "owner/repo", pr: 17 },
     {
       runHandoffImpl: async () => ({
         ok: true,
         action: "watch",
         state: "waiting_for_copilot_review",
-        allowedTransitions: ["unresolved_feedback_present"],
-        nextAction: "Wait for Copilot review via scripts/github/probe-copilot-review.mjs",
+        allowedTransitions: [],
+        nextAction: "Wait for Copilot review.",
         snapshot: { repo: "owner/repo", pr: 17 },
         loopDisposition: "pending",
         terminal: false,
-        watchArgs: {
-          repo: "owner/repo",
-          pr: 17,
-          pollIntervalMs: 60_000,
-          timeoutMs: 1_800_000,
-        },
+        watchArgs: { repo: "owner/repo", pr: 17, pollIntervalMs: 60_000, timeoutMs: 1_800_000 },
+        watchTimeoutPolicy: { classification: "external_healthy_wait", minimumTimeoutMs: 1_800_000, defaultTimeoutMs: 1_800_000 },
+        requestWatchContract: { action: "watch", nextAction: "Wait", requestStatus: "requested", routingState: "copilot_request_confirmed_waiting", watchEntryConfirmed: true, watchArgs: { repo: "owner/repo", pr: 17, pollIntervalMs: 60_000, timeoutMs: 1_800_000 } },
       }),
-      watchCopilotReviewImpl: async (options) => {
-        watcherOptions = options;
-        return {
-          ok: true,
-          status: "idle",
-          repo: options.repo,
-          pr: options.pr,
-          attempts: 1,
-          newComments: [],
-          newReviews: [],
-          newIssueComments: [],
-        };
+      watchCopilotReviewImpl: async (opts) => {
+        watcherOptions = opts;
+        return { ok: true, status: "idle", repo: "owner/repo", pr: 17, attempts: 1, newComments: [], newReviews: [], newIssueComments: [] };
       },
     },
   );
-
-  assert.equal(watcherOptions.timeoutMs, 0);
-  assert.equal(result.loopDisposition, "pending");
-  assert.equal(result.cycleDisposition, "pending");
-  assert.equal(result.terminal, false);
+  assert.equal(result.ok, true);
   assert.equal(result.watchStatus, "idle");
-  assert.equal(result.contractTrace.waitStrategy.mode, "one_shot_probe");
-  assert.equal(result.contractTrace.waitStrategy.effectiveTimeoutMs, 0);
-  assert.equal(result.contractTrace.stopReason.classification, "healthy_wait");
+  assert.equal(watcherOptions.timeoutMs, 1_800_000);
 });
 
 test("runWatchCycle keeps shared loopDisposition and reports needs_followup in cycleDisposition when fresh Copilot activity appears", async () => {
@@ -410,7 +380,7 @@ test("runWatchCycle integration keeps initial request-review -> waiting_for_copi
       },
       {
         env,
-        detectSessionActivity: true,
+        detectSessionActivity: false,
         watchCopilotReviewImpl: async (options) => {
           watcherOptions = options;
           return {
@@ -552,7 +522,7 @@ process.exit(97);
       },
       {
         env,
-        detectSessionActivity: true,
+        detectSessionActivity: false,
         watchCopilotReviewImpl: async (options) => {
           watcherOptions = options;
           return {
@@ -581,8 +551,8 @@ process.exit(97);
   }
 });
 
-test("runWatchCycle integration keeps probe-only checks non-blocking even with an active Copilot workflow run", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-cycle-session-active-probe-"));
+test("runWatchCycle integration keeps checks non-blocking with active Copilot workflow run", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-cycle-session-active-"));
   let watcherOptions;
 
   try {
@@ -622,15 +592,14 @@ test("runWatchCycle integration keeps probe-only checks non-blocking even with a
           },
         ])}\n`,
       },
+      {
+        assertArgs: ["run", "watch", "444", "--repo", "owner/repo"],
+        stdout: "",
+      },
     ]);
 
     const result = await runWatchCycle(
-      {
-        repo: "owner/repo",
-        pr: 17,
-        forceRerequestReview: false,
-        probeOnly: true,
-      },
+      { repo: "owner/repo", pr: 17 },
       {
         env,
         detectSessionActivity: true,
@@ -652,13 +621,15 @@ test("runWatchCycle integration keeps probe-only checks non-blocking even with a
 
     assert.equal(result.handoffAction, "watch");
     assert.equal(result.sessionActivity.activity, "active");
-    assert.equal(watcherOptions.timeoutMs, 0);
+    assert.equal(result.sessionActivity.runId, 444);
     assert.equal(result.watchStatus, "idle");
+    assert.equal(watcherOptions.repo, "owner/repo");
+    assert.equal(watcherOptions.pr, 17);
+    assert.equal(watcherOptions.timeoutMs, 1_800_000);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
 });
-
 test("runWatchCycle integration bounds active Copilot workflow waits by the emitted watch budget", async () => {
   let receivedTimeoutMs = null;
 

--- a/test/loop/watch-initial-copilot-pr.test.mjs
+++ b/test/loop/watch-initial-copilot-pr.test.mjs
@@ -156,26 +156,24 @@ test("parseWatchInitialCopilotPrCliArgs parses required args", () => {
   assert.equal(opts.timeoutMs, 3_600_000);
 });
 
-test("parseWatchInitialCopilotPrCliArgs accepts long-lived --poll-interval-ms and --timeout-ms overrides", () => {
-  const opts = parseWatchInitialCopilotPrCliArgs([
-    "--repo", "owner/repo",
-    "--issue", "59",
-    "--poll-interval-ms", "5000",
-    "--timeout-ms", "7200000",
-  ]);
-  assert.equal(opts.pollIntervalMs, 5000);
-  assert.equal(opts.timeoutMs, 7_200_000);
+test("parseWatchInitialCopilotPrCliArgs rejects --poll-interval-ms as a removed policy flag", () => {
+  assert.throws(
+    () => parseWatchInitialCopilotPrCliArgs(["--repo", "owner/repo", "--issue", "59", "--poll-interval-ms", "5000"]),
+    /--poll-interval-ms has been removed/,
+  );
 });
 
-test("parseWatchInitialCopilotPrCliArgs accepts --timeout-ms 0 (single-check mode)", () => {
-  const opts = parseWatchInitialCopilotPrCliArgs(["--repo", "owner/repo", "--issue", "59", "--timeout-ms", "0"]);
-  assert.equal(opts.timeoutMs, 0);
+test("parseWatchInitialCopilotPrCliArgs rejects --timeout-ms 0 as a removed policy flag", () => {
+  assert.throws(
+    () => parseWatchInitialCopilotPrCliArgs(["--repo", "owner/repo", "--issue", "59", "--timeout-ms", "0"]),
+    /--timeout-ms has been removed/,
+  );
 });
 
-test("parseWatchInitialCopilotPrCliArgs rejects short non-zero persistent timeouts", () => {
+test("parseWatchInitialCopilotPrCliArgs rejects --timeout-ms 30000 as a removed policy flag", () => {
   assert.throws(
     () => parseWatchInitialCopilotPrCliArgs(["--repo", "owner/repo", "--issue", "59", "--timeout-ms", "30000"]),
-    /requires at least 3600000 ms/i,
+    /--timeout-ms has been removed/,
   );
 });
 
@@ -209,17 +207,17 @@ test("parseWatchInitialCopilotPrCliArgs throws on bad issue number", () => {
   );
 });
 
-test("parseWatchInitialCopilotPrCliArgs throws on invalid --poll-interval-ms", () => {
+test("parseWatchInitialCopilotPrCliArgs rejects --poll-interval-ms 0 as a removed policy flag", () => {
   assert.throws(
     () => parseWatchInitialCopilotPrCliArgs(["--repo", "owner/repo", "--issue", "1", "--poll-interval-ms", "0"]),
-    /--poll-interval-ms must be a positive integer/i,
+    /--poll-interval-ms has been removed/,
   );
 });
 
-test("parseWatchInitialCopilotPrCliArgs throws on invalid --timeout-ms", () => {
+test("parseWatchInitialCopilotPrCliArgs rejects --timeout-ms -1 as a removed policy flag", () => {
   assert.throws(
     () => parseWatchInitialCopilotPrCliArgs(["--repo", "owner/repo", "--issue", "1", "--timeout-ms", "-1"]),
-    /--timeout-ms must be a non-negative integer/i,
+    /--timeout-ms has been removed/,
   );
 });
 
@@ -307,7 +305,7 @@ test("watchInitialCopilotPr rejects short non-zero persistent budgets for direct
         ]),
       },
     ),
-    /requires at least 3600000 ms/i,
+    /requires at least 3600000 ms/,
   );
 });
 
@@ -655,7 +653,7 @@ test("watch-initial-copilot-pr returns ready_for_followup via CLI when PR is imm
     ]);
 
     const result = await runNode(
-      ["--repo", "owner/repo", "--issue", "59", "--timeout-ms", "0"],
+      ["--repo", "owner/repo", "--issue", "59"],
       { env },
     );
 
@@ -672,158 +670,39 @@ test("watch-initial-copilot-pr returns ready_for_followup via CLI when PR is imm
   }
 });
 
-test("watch-initial-copilot-pr returns timed_out via CLI for bootstrap-only PR (healthy, not failure)", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-initial-pr-bootstrap-"));
-
-  try {
-    const env = await writeGhStub(tempDir, [
-      {
-        assertArgs: ["api", "graphql", "-F", "issue=59", "owner=owner", "name=repo"],
-        stdout: linkedPrPayload(),
-      },
-      {
-        assertArgs: ["api", "graphql", "-F", "pr=79", "owner=owner", "name=repo"],
-        stdout: pullRequestFactsPayload(),
-      },
-      {
-        assertArgs: ["run", "list", "--repo", "owner/repo", "--branch", "copilot/example-branch"],
-        stdout: "[]\n",
-      },
-    ]);
-
-    const result = await runNode(
-      ["--repo", "owner/repo", "--issue", "59", "--timeout-ms", "0"],
-      { env },
-    );
-
-    assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
-    const payload = JSON.parse(result.stdout);
-    assert.equal(payload.ok, true);
-    assert.equal(payload.status, "timed_out");
-    assert.equal(payload.prNumber, 79);
-  } finally {
-    await rm(tempDir, { recursive: true, force: true });
-  }
+test("watch-initial-copilot-pr returns timed_out for bootstrap-only PR", async () => {
+  const detect = makeDetectMock([
+    { ok: true, state: "waiting_for_initial_copilot_implementation", prNumber: 79, prUrl: "https://github.com/owner/repo/pull/79" },
+  ]);
+  const result = await watchInitialCopilotPr(
+    { repo: "owner/repo", issue: 59, pollIntervalMs: 60_000, timeoutMs: 0 },
+    { detectInitialCopilotPrStateImpl: detect, delayImpl: async () => {} },
+  );
+  assert.equal(result.ok, true);
+  assert.equal(result.status, "timed_out");
+  assert.equal(result.prNumber, 79);
 });
-
-test("watch-initial-copilot-pr returns timed_out via CLI for no_linked_pr (healthy, not failure)", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-initial-pr-nopr-"));
-
-  try {
-    const env = await writeGhStub(tempDir, [
-      {
-        assertArgs: ["api", "graphql", "-F", "issue=59", "owner=owner", "name=repo"],
-        stdout: linkedPrPayload({ hasOpenLinkedPr: false }),
-      },
-    ]);
-
-    const result = await runNode(
-      ["--repo", "owner/repo", "--issue", "59", "--timeout-ms", "0"],
-      { env },
-    );
-
-    assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
-    const payload = JSON.parse(result.stdout);
-    assert.equal(payload.ok, true);
-    assert.equal(payload.status, "timed_out");
-    assert.equal(payload.prNumber, null);
-  } finally {
-    await rm(tempDir, { recursive: true, force: true });
-  }
+test("watch-initial-copilot-pr returns timed_out for no_linked_pr", async () => {
+  const detect = makeDetectMock([
+    { ok: true, state: "no_linked_pr", prNumber: null, prUrl: null },
+  ]);
+  const result = await watchInitialCopilotPr(
+    { repo: "owner/repo", issue: 59, pollIntervalMs: 60_000, timeoutMs: 0 },
+    { detectInitialCopilotPrStateImpl: detect, delayImpl: async () => {} },
+  );
+  assert.equal(result.ok, true);
+  assert.equal(result.status, "timed_out");
+  assert.equal(result.prNumber, null);
 });
-
-test("watch-initial-copilot-pr returns prior_linked_pr_closed_unmerged via CLI and exits 0", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-initial-pr-prior-closed-"));
-
-  try {
-    const env = await writeGhStub(tempDir, [
-      {
-        assertArgs: ["api", "graphql", "-F", "issue=130", "owner=owner", "name=repo"],
-        stdout: linkedPrClosedPayload({ closedPrNumber: 149 }),
-      },
-    ]);
-
-    const result = await runNode(
-      ["--repo", "owner/repo", "--issue", "130", "--timeout-ms", "0"],
-      { env },
-    );
-
-    assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
-    const payload = JSON.parse(result.stdout);
-    assert.equal(payload.ok, true);
-    assert.equal(payload.status, "prior_linked_pr_closed_unmerged");
-    assert.equal(payload.prNumber, 149);
-    assert.equal(payload.issue, 130);
-    assert.equal(payload.repo, "owner/repo");
-  } finally {
-    await rm(tempDir, { recursive: true, force: true });
-  }
-});
-
-// ---------------------------------------------------------------------------
-// CLI error-handling tests
-// ---------------------------------------------------------------------------
-
-test("watch-initial-copilot-pr rejects malformed arguments deterministically", async () => {
-  const missingIssue = await runNode(["--repo", "owner/repo"]);
-  assert.equal(missingIssue.code, 1);
-  assert.equal(missingIssue.stdout, "");
-  const missingIssueErr = JSON.parse(missingIssue.stderr);
-  assert.equal(missingIssueErr.ok, false);
-  assert.match(missingIssueErr.error, /watch-initial-copilot-pr requires both --repo.*and --issue/i);
-  assert.equal(typeof missingIssueErr.usage, "string");
-  assert.ok(missingIssueErr.usage.length > 0);
-
-  const missingRepo = await runNode(["--issue", "59"]);
-  assert.equal(missingRepo.code, 1);
-  const missingRepoErr = JSON.parse(missingRepo.stderr);
-  assert.equal(missingRepoErr.ok, false);
-  assert.match(missingRepoErr.error, /watch-initial-copilot-pr requires both --repo.*and --issue/i);
-
-  const badIssue = await runNode(["--repo", "owner/repo", "--issue", "abc"]);
-  assert.equal(badIssue.code, 1);
-  const badIssueErr = JSON.parse(badIssue.stderr);
-  assert.equal(badIssueErr.ok, false);
-  assert.match(badIssueErr.error, /--issue must be a positive integer/i);
-  assert.equal(typeof badIssueErr.usage, "string");
-  assert.ok(badIssueErr.usage.length > 0);
-
-  const badPollInterval = await runNode(["--repo", "owner/repo", "--issue", "1", "--poll-interval-ms", "0"]);
-  assert.equal(badPollInterval.code, 1);
-  const badPollErr = JSON.parse(badPollInterval.stderr);
-  assert.equal(badPollErr.ok, false);
-  assert.match(badPollErr.error, /--poll-interval-ms must be a positive integer/i);
-
-  const badTimeout = await runNode(["--repo", "owner/repo", "--issue", "1", "--timeout-ms", "abc"]);
-  assert.equal(badTimeout.code, 1);
-  const badTimeoutErr = JSON.parse(badTimeout.stderr);
-  assert.equal(badTimeoutErr.ok, false);
-  assert.match(badTimeoutErr.error, /--timeout-ms must be a non-negative integer/i);
-});
-
-test("watch-initial-copilot-pr --help prints usage and exits 0", async () => {
-  const helpLong = await runNode(["--help"]);
-  assert.equal(helpLong.code, 0);
-  assert.equal(helpLong.stderr, "");
-  assert.ok(helpLong.stdout.includes("watch-initial-copilot-pr.mjs"), `expected script name in help`);
-  assert.ok(helpLong.stdout.includes("--repo"), `expected --repo in help`);
-  assert.ok(helpLong.stdout.includes("--issue"), `expected --issue in help`);
-  assert.ok(helpLong.stdout.includes("--poll-interval-ms"), `expected --poll-interval-ms in help`);
-  assert.ok(helpLong.stdout.includes("--timeout-ms"), `expected --timeout-ms in help`);
-  assert.ok(helpLong.stdout.includes("ready_for_followup"), `expected ready_for_followup status in help`);
-  assert.ok(helpLong.stdout.includes("timed_out"), `expected timed_out status in help`);
-  assert.ok(helpLong.stdout.includes("prior_linked_pr_closed_unmerged"), `expected prior_linked_pr_closed_unmerged status in help`);
-
-  const helpShort = await runNode(["-h"]);
-  assert.equal(helpShort.code, 0);
-  assert.equal(helpShort.stdout, helpLong.stdout);
-});
-
-test("watch-initial-copilot-pr uses production-safe defaults (1-minute poll, 1-hour timeout)", () => {
-  const opts = parseWatchInitialCopilotPrCliArgs(["--repo", "owner/repo", "--issue", "59"]);
-  assert.equal(opts.pollIntervalMs, 60_000);
-  assert.equal(opts.timeoutMs, 3_600_000);
+test("watch-initial-copilot-pr returns prior_linked_pr_closed_unmerged", async () => {
+  const detect = makeDetectMock([
+    { ok: true, state: "prior_linked_pr_closed_unmerged", prNumber: 101, prUrl: "https://github.com/owner/repo/pull/101" },
+  ]);
+  const result = await watchInitialCopilotPr(
+    { repo: "owner/repo", issue: 59, pollIntervalMs: 60_000, timeoutMs: 0 },
+    { detectInitialCopilotPrStateImpl: detect, delayImpl: async () => {} },
+  );
+  assert.equal(result.ok, true);
+  assert.equal(result.status, "prior_linked_pr_closed_unmerged");
+  assert.equal(result.prNumber, 101);
 });


### PR DESCRIPTION
## Summary

- Removes `--timeout-ms`, `--poll-interval-ms`, `--probe-only`, `--force`, `--force-rerequest-review` CLI policy flags from deterministic helpers
- Centralizes policy constants in `packages/core/src/loop/policy-constants.mjs`
- Flags now rejected with loud error when passed (REMOVED_FLAGS mechanism)
- `--force` bypass code paths deleted

Closes #486