### PR TITLE
fix(#543): verify draft_gate timing enforcement; add pre_approval_gate-on-draft rejection test

### DIFF
--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -91,6 +91,32 @@ test("draft PR forbids mark-ready until current-head clean draft gate evidence e
   assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.MARK_READY_FOR_REVIEW));
 });
 
+test("draft PR rejects pre_approval_gate entry — must pass draft gate before pre-approval", () => {
+  // A draft PR with no draft-gate evidence at all must forbid pre_approval_gate.
+  const result = evaluatePrGateCoordination({
+    pr: 543,
+    currentHeadSha: "f7a611b723",
+    prDraft: true,
+    lifecycleState: STATE.PR_DRAFT,
+    loopDisposition: DISPOSITION.ACTION_REQUIRED,
+    ciStatus: "success",
+    draftGate: gate({ visible: false }),
+    draftGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.DRAFT_REVIEW);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE);
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert(!result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert.match(
+    result.reason,
+    /`draft_gate` is now the legal gate boundary before `gh pr ready`/i,
+  );
+  // Mark-ready is also forbidden (no current-head clean draft gate evidence yet).
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.MARK_READY_FOR_REVIEW));
+  assert(!result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.MARK_READY_FOR_REVIEW));
+});
+
 test("stale gate markers do not report current-head contract completeness", () => {
   const result = evaluatePrGateCoordination({
     pr: 266,

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -708,6 +708,55 @@ test("upsert-checkpoint-verdict fails closed when pre-approval gate entry is sti
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
+
+test("upsert-checkpoint-verdict rejects pre_approval_gate when PR is still draft", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-draft-preapproval-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "543", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        stdout: '{"number":543,"state":"OPEN","isDraft":true,"headRefOid":"f7a611b7234af479","reviews":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]}\n',
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/543/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=543"],
+        stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n',
+      },
+      {
+        assertArgs: ["pr", "view", "543", "--repo", "owner/repo", "--json", "headRefOid"],
+        stdout: '{"headRefOid":"f7a611b7234af479"}\n',
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/543/comments?per_page=100"],
+        stdout: '[]\n',
+      },
+    ]);
+
+    const result = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "543",
+      "--gate", "pre_approval_gate",
+      "--head-sha", "f7a611b",
+      "--verdict", "clean",
+      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
+      "--findings-summary", "no issues found",
+      "--next-action", "await final human approval",
+    ], { env });
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /Cannot enter/);
+    assert.match(payload.error, /draft_gate.*is now the legal gate boundary/i);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
 });
 
 test("upsert-checkpoint-verdict appends the round-cap fallback note to pre-approval evidence", async () => {


### PR DESCRIPTION
## Summary

Adds tests for draft_gate enforcement on non-draft PRs. The enforcement already exists via forbiddenActions — these tests cement the contract.

Ref: #543
