### PR TITLE
fix(#543): reject draft_gate re-post when draftGateAlreadySatisfied

### DIFF
--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -563,6 +563,13 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
     throw new Error(buildGateEntryRefusalError({ options, coordination }));
   }
 
+  if (options.gate === "draft_gate" && coordination.draftGateAlreadySatisfied) {
+    throw new Error(
+      `draft_gate was already satisfied for this PR (clean evidence exists, PR is no longer draft). ` +
+      `Do not re-post draft_gate. The draft→ready transition was already recorded.`,
+    );
+  }
+
   const activeGateConfig = options.gate === "draft_gate" ? draftGateConfig : preApprovalGateConfig;
 
   if (

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -557,17 +557,19 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
     preApprovalGateMarker: coordinationContext.gateEvidence.preApprovalGateMarker,
   });
   const requestedGateAction = resolveGateAction(options.gate);
+
+  if (options.gate === "draft_gate" && coordination.draftGateAlreadySatisfied) {
+    throw new Error(
+      `Cannot enter draft_gate on ${options.repo}#${options.pr}: draft gate was already satisfied ` +
+      `(clean evidence exists, PR is no longer draft). ` +
+      `Do not re-post draft_gate. The draft→ready transition was already recorded.`,
+    );
+  }
+
   const gateActionForbidden = coordination.forbiddenActions.includes(requestedGateAction);
 
   if (gateActionForbidden) {
     throw new Error(buildGateEntryRefusalError({ options, coordination }));
-  }
-
-  if (options.gate === "draft_gate" && coordination.draftGateAlreadySatisfied) {
-    throw new Error(
-      `draft_gate was already satisfied for this PR (clean evidence exists, PR is no longer draft). ` +
-      `Do not re-post draft_gate. The draft→ready transition was already recorded.`,
-    );
   }
 
   const activeGateConfig = options.gate === "draft_gate" ? draftGateConfig : preApprovalGateConfig;

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -1736,3 +1736,53 @@ test("upsert-checkpoint-verdict rejects clean verdict when --findings-severity-c
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+test("upsert-checkpoint-verdict rejects draft_gate when draftGateAlreadySatisfied is true", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-already-satisfied-"));
+
+  try {
+    // Simulate a non-draft PR with an existing clean draft_gate comment
+    const cleanDraftGateComment = {
+      id: 101,
+      body: [
+        "### Gate review: `draft_gate`",
+        "",
+        "**Reviewed head SHA:** `abc1234`",
+        "**Verdict:** clean",
+        "",
+        "**Findings summary:** no issues found",
+        "",
+        "**Next action:** mark ready for review",
+      ].join("\n"),
+      html_url: "https://github.com/owner/repo/pull/17#issuecomment-101",
+      updated_at: "2026-05-30T17:00:00Z",
+    };
+
+    const env = await writeGhStub(tempDir, buildGateCoordinationEntries({
+      isDraft: false,
+      statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+      issueComments: [cleanDraftGateComment],
+    }));
+
+    const result = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "17",
+      "--gate", "draft_gate",
+      "--head-sha", "abc1234",
+      "--verdict", "clean",
+      "--findings-summary", "no issues found",
+      "--next-action", "mark ready for review",
+      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
+    ], { env });
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /Cannot enter draft_gate on owner\/repo#17/);
+    assert.match(payload.error, /draft gate was already satisfied/);
+    assert.match(payload.error, /Do not re-post draft_gate/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Adds enforcement: `upsert-checkpoint-verdict.mjs` now rejects `draft_gate` calls when `draftGateAlreadySatisfied` is true. The wrapper already blocks wrong-order posting via `forbiddenActions` — this adds a second layer: even if the PR is still draft, re-posting draft_gate after clean evidence exists is now an error, not a noop.

Closes #543