### PR TITLE
fix(#552): block crediblyGreen CI on pre-approval gate entry

### DIFF
--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -631,6 +631,28 @@ export function evaluatePrGateCoordination(input = {}) {
   if (effectiveLifecycleState === STATE.PR_READY_NO_FEEDBACK) {
     if (reviewMode === "internal_only") {
       // Explicitly internal-only PR: skip the external Copilot review cycle
+      if (ciStatus === "failure") {
+        pushUnique(allowedNextActions, [PR_CHECKPOINT_ACTION.REPORT_BLOCKED]);
+        pushUnique(forbiddenActions, internalOnlyPostDraftForbidden);
+        return buildResult({
+          repo: input.repo ?? null,
+          pr: Number.isInteger(input.pr) ? input.pr : null,
+          currentHeadSha,
+          lifecycleState: STATE.BLOCKED_NEEDS_USER_DECISION,
+          loopDisposition: DISPOSITION.BLOCKED,
+          gateBoundary: PR_CHECKPOINT.BLOCKED,
+          draftGateAlreadySatisfied,
+          draftGate,
+          preApprovalGate,
+          allowedNextActions,
+          forbiddenActions,
+          nextAction: PR_CHECKPOINT_ACTION.REPORT_BLOCKED,
+          reason: "The current head has failing CI, so gate progression remains blocked until the failing checks are fixed and revalidated.",
+          mergeStateStatus,
+          conflictFiles,
+            refinementArtifact,
+        });
+      }
       if (preApprovalGate.currentHeadClean) {
         if (requireRetrospectiveGate) {
           const retrospectiveGate = evaluateRetrospectiveMergeApproval(retrospectiveCheckpoint);

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -531,7 +531,7 @@ export function evaluatePrGateCoordination(input = {}) {
     ];
 
     if (!draftGate.currentHeadClean && draftGateRequireCi) {
-      if (ciStatus === "failure") {
+      if (ciStatus === "failure" || ciStatus === "crediblyGreen") {
         pushUnique(allowedNextActions, [PR_CHECKPOINT_ACTION.REPORT_BLOCKED]);
         pushUnique(forbiddenActions, [
           PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE,
@@ -791,7 +791,7 @@ export function evaluatePrGateCoordination(input = {}) {
   }
 
   if (effectiveLifecycleState === STATE.READY_TO_REREQUEST_REVIEW) {
-    if (ciStatus === "failure") {
+    if (ciStatus === "failure" || ciStatus === "crediblyGreen") {
       pushUnique(allowedNextActions, [PR_CHECKPOINT_ACTION.REPORT_BLOCKED]);
       pushUnique(forbiddenActions, postDraftForbidden);
       return buildResult({
@@ -943,7 +943,7 @@ export function evaluatePrGateCoordination(input = {}) {
   }
 
   if (effectiveLifecycleState === STATE.LOW_SIGNAL_CONVERGED) {
-    if (ciStatus === "failure") {
+    if (ciStatus === "failure" || ciStatus === "crediblyGreen") {
       pushUnique(allowedNextActions, [PR_CHECKPOINT_ACTION.REPORT_BLOCKED]);
       pushUnique(forbiddenActions, postDraftForbidden);
       return buildResult({

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -808,7 +808,7 @@ export function evaluatePrGateCoordination(input = {}) {
         forbiddenActions,
         nextAction: PR_CHECKPOINT_ACTION.REPORT_BLOCKED,
         reason: ciStatus === "crediblyGreen"
-          ? "The current head has unconfirmed CI (credibly green), so gate progression remains blocked until verified green CI is confirmed."
+          ? "The current head has unconfirmed CI (credibly green), so gate progression remains blocked until CI is confirmed green."
           : "The current head still has failing CI, so gate progression remains blocked until the failing checks are fixed and revalidated.",
         mergeStateStatus,
         conflictFiles,
@@ -962,7 +962,7 @@ export function evaluatePrGateCoordination(input = {}) {
         forbiddenActions,
         nextAction: PR_CHECKPOINT_ACTION.REPORT_BLOCKED,
         reason: ciStatus === "crediblyGreen"
-          ? "The low-signal heuristic indicates convergence, but the current head has unconfirmed CI (credibly green), so gate progression remains blocked until verified green CI is confirmed."
+          ? "The low-signal heuristic indicates convergence, but the current head has unconfirmed CI (credibly green), so gate progression remains blocked until CI is confirmed green."
           : "The low-signal heuristic indicates convergence, but the current head still has failing CI, so gate progression remains blocked.",
         mergeStateStatus,
         conflictFiles,

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -631,7 +631,7 @@ export function evaluatePrGateCoordination(input = {}) {
   if (effectiveLifecycleState === STATE.PR_READY_NO_FEEDBACK) {
     if (reviewMode === "internal_only") {
       // Explicitly internal-only PR: skip the external Copilot review cycle
-      if (ciStatus === "failure") {
+      if (ciStatus === "failure" || ciStatus === "crediblyGreen") {
         pushUnique(allowedNextActions, [PR_CHECKPOINT_ACTION.REPORT_BLOCKED]);
         pushUnique(forbiddenActions, internalOnlyPostDraftForbidden);
         return buildResult({
@@ -647,7 +647,9 @@ export function evaluatePrGateCoordination(input = {}) {
           allowedNextActions,
           forbiddenActions,
           nextAction: PR_CHECKPOINT_ACTION.REPORT_BLOCKED,
-          reason: "The current head has failing CI, so gate progression remains blocked until the failing checks are fixed and revalidated.",
+          reason: ciStatus === "crediblyGreen"
+            ? "The current head has unconfirmed CI (credibly green), so gate progression remains blocked until CI is confirmed green."
+            : "The current head has failing CI, so gate progression remains blocked until the failing checks are fixed and revalidated.",
           mergeStateStatus,
           conflictFiles,
             refinementArtifact,

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -550,7 +550,9 @@ export function evaluatePrGateCoordination(input = {}) {
           allowedNextActions,
           forbiddenActions,
           nextAction: PR_CHECKPOINT_ACTION.REPORT_BLOCKED,
-          reason: "The PR is still draft, and this repo requires green current-head CI before entering `draft_gate`. The current head is failing CI, so fix the checks before retrying the draft gate.",
+          reason: ciStatus === "crediblyGreen"
+          ? "The PR is still draft, and this repo requires green current-head CI before entering `draft_gate`. The current head has unconfirmed CI (credibly green), so verified green CI is required before retrying the draft gate."
+          : "The PR is still draft, and this repo requires green current-head CI before entering `draft_gate`. The current head is failing CI, so fix the checks before retrying the draft gate.",
           mergeStateStatus,
           conflictFiles,
             refinementArtifact,
@@ -807,7 +809,9 @@ export function evaluatePrGateCoordination(input = {}) {
         allowedNextActions,
         forbiddenActions,
         nextAction: PR_CHECKPOINT_ACTION.REPORT_BLOCKED,
-        reason: "The current head still has failing CI, so gate progression remains blocked until the failing checks are fixed and revalidated.",
+        reason: ciStatus === "crediblyGreen"
+          ? "The current head has unconfirmed CI (credibly green), so gate progression remains blocked until verified green CI is confirmed."
+          : "The current head still has failing CI, so gate progression remains blocked until the failing checks are fixed and revalidated.",
         mergeStateStatus,
         conflictFiles,
           refinementArtifact,
@@ -959,7 +963,9 @@ export function evaluatePrGateCoordination(input = {}) {
         allowedNextActions,
         forbiddenActions,
         nextAction: PR_CHECKPOINT_ACTION.REPORT_BLOCKED,
-        reason: "The low-signal heuristic indicates convergence, but the current head still has failing CI, so gate progression remains blocked.",
+        reason: ciStatus === "crediblyGreen"
+          ? "The low-signal heuristic indicates convergence, but the current head has unconfirmed CI (credibly green), so gate progression remains blocked until verified green CI is confirmed."
+          : "The low-signal heuristic indicates convergence, but the current head still has failing CI, so gate progression remains blocked.",
         mergeStateStatus,
         conflictFiles,
           refinementArtifact,

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -531,7 +531,7 @@ export function evaluatePrGateCoordination(input = {}) {
     ];
 
     if (!draftGate.currentHeadClean && draftGateRequireCi) {
-      if (ciStatus === "failure" || ciStatus === "crediblyGreen") {
+      if (ciStatus === "failure") {
         pushUnique(allowedNextActions, [PR_CHECKPOINT_ACTION.REPORT_BLOCKED]);
         pushUnique(forbiddenActions, [
           PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE,
@@ -550,9 +550,7 @@ export function evaluatePrGateCoordination(input = {}) {
           allowedNextActions,
           forbiddenActions,
           nextAction: PR_CHECKPOINT_ACTION.REPORT_BLOCKED,
-          reason: ciStatus === "crediblyGreen"
-          ? "The PR is still draft, and this repo requires green current-head CI before entering `draft_gate`. The current head has unconfirmed CI (credibly green), so verified green CI is required before retrying the draft gate."
-          : "The PR is still draft, and this repo requires green current-head CI before entering `draft_gate`. The current head is failing CI, so fix the checks before retrying the draft gate.",
+          reason: "The PR is still draft, and this repo requires green current-head CI before entering `draft_gate`. The current head is failing CI, so fix the checks before retrying the draft gate.",
           mergeStateStatus,
           conflictFiles,
             refinementArtifact,

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -212,7 +212,7 @@ test("clean settled current-head review opens the pre-approval gate window", () 
   assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
 });
 
-test("crediblyGreen CI allows pre-approval progression once the review loop is already settled", () => {
+test("crediblyGreen CI blocks pre-approval progression — CI must be confirmed before gate entry", () => {
   const result = evaluatePrGateCoordination({
     pr: 266,
     currentHeadSha: "fedcba987654",
@@ -227,10 +227,10 @@ test("crediblyGreen CI allows pre-approval progression once the review loop is a
     preApprovalGateMarker: gate({ visible: false }),
   });
 
-  assert.equal(result.lifecycleState, STATE.READY_TO_REREQUEST_REVIEW);
-  assert.equal(result.gateBoundary, PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW);
-  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
-  assert.match(result.reason, /credibly green/i);
+  assert.equal(result.lifecycleState, STATE.BLOCKED_NEEDS_USER_DECISION);
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.BLOCKED);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
+  assert.match(result.reason, /failing/i);
 });
 
 test("round-cap exhaustion opens the pre-approval gate window even without a current-head Copilot rereview", () => {

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -212,7 +212,7 @@ test("clean settled current-head review opens the pre-approval gate window", () 
   assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
 });
 
-test("draft gate does not block on crediblyGreen CI — documented absent-CI exception", () => {
+test("draft gate with crediblyGreen CI routes to WAIT_FOR_CI — unconfirmed CI is not a hard block", () => {
   const result = evaluatePrGateCoordination({
     pr: 266,
     currentHeadSha: "abc123456789",
@@ -223,8 +223,9 @@ test("draft gate does not block on crediblyGreen CI — documented absent-CI exc
     draftGate: gate({ visible: false }),
     preApprovalGate: gate({ visible: false }),
   });
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.WAIT_FOR_CI);
   assert.notEqual(result.gateBoundary, PR_CHECKPOINT.BLOCKED);
-  assert.notEqual(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
+  assert.match(result.reason, /so wait for CI to settle green/i);
 });
 
 test("crediblyGreen CI blocks pre-approval progression — CI must be confirmed before gate entry", () => {

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -724,6 +724,47 @@ test("internal-only PR with retrospective gate blocks when checkpoint missing", 
   assert.match(result.reason, /retrospective_gate_pending/i);
 });
 
+
+test("PR_READY_NO_FEEDBACK internal_only blocks on CI failure", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 553,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    reviewMode: "internal_only",
+    lifecycleState: STATE.PR_READY_NO_FEEDBACK,
+    loopDisposition: DISPOSITION.ACTION_REQUIRED,
+    ciStatus: "failure",
+    draftGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "fedcba9", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+  assert.equal(result.lifecycleState, STATE.BLOCKED_NEEDS_USER_DECISION);
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.BLOCKED);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
+  assert.match(result.reason, /failing CI/i);
+});
+
+test("PR_READY_NO_FEEDBACK internal_only blocks on crediblyGreen CI", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 553,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    reviewMode: "internal_only",
+    lifecycleState: STATE.PR_READY_NO_FEEDBACK,
+    loopDisposition: DISPOSITION.ACTION_REQUIRED,
+    ciStatus: "crediblyGreen",
+    draftGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "fedcba9", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+  assert.equal(result.lifecycleState, STATE.BLOCKED_NEEDS_USER_DECISION);
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.BLOCKED);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
+  assert.match(result.reason, /unconfirmed/i);
+});
+
 test("internal-only PR with retrospective gate allows when approved", () => {
   const result = evaluatePrGateCoordination({
     pr: 298,

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -248,6 +248,25 @@ test("crediblyGreen CI blocks pre-approval progression — CI must be confirmed 
   assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
   assert.match(result.reason, /unconfirmed/i);
 });
+test("ciStatus failure blocks READY_TO_REREQUEST_REVIEW — primary issue-#552 scenario", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    loopDisposition: DISPOSITION.CLEAN_CONVERGED,
+    sameHeadCleanConverged: true,
+    ciStatus: "failure",
+    draftGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "fedcba9", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+  assert.equal(result.lifecycleState, STATE.BLOCKED_NEEDS_USER_DECISION);
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.BLOCKED);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
+  assert.match(result.reason, /failing/i);
+});
 
 test("round-cap exhaustion opens the pre-approval gate window even without a current-head Copilot rereview", () => {
   const result = evaluatePrGateCoordination({

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -212,6 +212,21 @@ test("clean settled current-head review opens the pre-approval gate window", () 
   assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
 });
 
+test("draft gate does not block on crediblyGreen CI — documented absent-CI exception", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "abc123456789",
+    prDraft: true,
+    lifecycleState: STATE.PR_DRAFT,
+    loopDisposition: DISPOSITION.ACTION_REQUIRED,
+    ciStatus: "crediblyGreen",
+    draftGate: gate({ visible: false }),
+    preApprovalGate: gate({ visible: false }),
+  });
+  assert.notEqual(result.gateBoundary, PR_CHECKPOINT.BLOCKED);
+  assert.notEqual(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
+});
+
 test("crediblyGreen CI blocks pre-approval progression — CI must be confirmed before gate entry", () => {
   const result = evaluatePrGateCoordination({
     pr: 266,
@@ -834,6 +849,18 @@ test("LOW_SIGNAL_CONVERGED blocks on CI failure", () => {
   });
   assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
   assert.equal(result.gateBoundary, PR_CHECKPOINT.BLOCKED);
+});
+test("LOW_SIGNAL_CONVERGED blocks on crediblyGreen CI", () => {
+  const result = evaluatePrGateCoordination({
+    repo: "owner/repo", pr: 17,
+    lifecycleState: STATE.LOW_SIGNAL_CONVERGED, loopDisposition: DISPOSITION.DONE,
+    prDraft: false, ciStatus: "crediblyGreen",
+    draftGate: { visible: true, verdict: "clean", headSha: "abc1234" },
+    preApprovalGate: {},
+  });
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.BLOCKED);
+  assert.match(result.reason, /unconfirmed/i);
 });
 
 test("normalizeSnapshot preserves valid lastCopilotRoundMaxSignal", () => {

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -230,7 +230,7 @@ test("crediblyGreen CI blocks pre-approval progression — CI must be confirmed 
   assert.equal(result.lifecycleState, STATE.BLOCKED_NEEDS_USER_DECISION);
   assert.equal(result.gateBoundary, PR_CHECKPOINT.BLOCKED);
   assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
-  assert.match(result.reason, /failing/i);
+  assert.match(result.reason, /unconfirmed/i);
 });
 
 test("round-cap exhaustion opens the pre-approval gate window even without a current-head Copilot rereview", () => {


### PR DESCRIPTION
## Summary

`crediblyGreen` CI status (from `--local-validation-head-sha`) was allowing pre-approval gate to pass despite unconfirmed CI. This fix treats `crediblyGreen` like `failure` for gate entry — gates require confirmed green CI.

Round-cap fallback paths still use `crediblyGreen` for status reporting, but gate entry checks now block on it.

Closes #552