### PR TITLE
feat(#558): add pr-description draft gate angle

### DIFF
--- a/.pi/dev-loop/defaults.yaml
+++ b/.pi/dev-loop/defaults.yaml
@@ -349,6 +349,19 @@ personas:
         judgment for link intent and anchor correctness.
     defaultModel: null
 
+  pr-description:
+    persona: review
+    prompt: >-
+      Review the PR description for completeness and contract fitness.
+      The PR body is the implementation contract — it must have:
+      - A Summary section explaining what changed and why
+      - A Changes section listing files touched and modifications
+      - A Validation section describing how to verify
+      - Reference to the linked issue acceptance criteria
+      Flag PRs where the body is a single sentence or lacks these sections.
+      Do not block on formatting preferences — only on missing structure.
+    defaultModel: null
+
   config-drift:
     persona: review
     prompt: >-

--- a/.pi/dev-loop/defaults.yaml
+++ b/.pi/dev-loop/defaults.yaml
@@ -358,6 +358,7 @@ personas:
       - A Changes section listing files touched and modifications
       - A Validation section describing how to verify
       - Reference to the linked issue acceptance criteria
+      - The "Closes #N" line must match the linked issue; flag changes that alter or remove the operator-intended close target
       Flag PRs where the body is a single sentence or lacks these sections.
       Do not block on formatting preferences — only on missing structure.
     defaultModel: null

--- a/.pi/dev-loop/settings.yaml
+++ b/.pi/dev-loop/settings.yaml
@@ -17,6 +17,7 @@ gates:
       - state-concurrency
       - config-drift
       - gate-evidence
+      - pr-description
     requireCi: true
     blockCleanOnFindingSeverities:
       - must-fix

--- a/packages/core/src/analysis/change-classifier.mjs
+++ b/packages/core/src/analysis/change-classifier.mjs
@@ -62,7 +62,7 @@ const CATEGORY_ANGLE_MAP = {
  *
  * @type {Set<string>}
  */
-const ALWAYS_INCLUDE = new Set(["gate-evidence", "renderer-security"]);
+const ALWAYS_INCLUDE = new Set(["gate-evidence", "renderer-security", "pr-description"]);
 
 // ---------------------------------------------------------------------------
 // Resolution

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1848,6 +1848,8 @@ describe("shipped defaults docs and deep angle wiring", () => {
       assert.match(result.config.personas["pr-description"].prompt, /Changes section/i);
       assert.match(result.config.personas["pr-description"].prompt, /Validation section/i);
       assert.match(result.config.personas["pr-description"].prompt, /Do not block on formatting/i);
+      assert.match(result.config.personas["pr-description"].prompt, /Closes #N/i);
+      assert.match(result.config.personas["pr-description"].prompt, /operator-intended close target/i);
       assert.ok(draftAngles.includes("pr-description"), "pr-description must be in draft gate angles after settings opt-in");
       assert.equal(prDescRole.persona, "review");
       assert.equal(prDescRole.fallback, false);

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1825,7 +1825,7 @@ describe("shipped defaults docs and deep angle wiring", () => {
     }
   });
 
-  test("D2: pr-description persona resolves and appears in draft gate angles after settings opt-in", async () => {
+  test("D3: pr-description persona resolves and appears in draft gate angles after settings opt-in", async () => {
     const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-D2-"));
     try {
       const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
@@ -1848,6 +1848,8 @@ describe("shipped defaults docs and deep angle wiring", () => {
       assert.match(result.config.personas["pr-description"].prompt, /Changes section/i);
       assert.match(result.config.personas["pr-description"].prompt, /Validation section/i);
       assert.match(result.config.personas["pr-description"].prompt, /Do not block on formatting/i);
+      assert.match(result.config.personas["pr-description"].prompt, /linked issue acceptance criteria/i);
+      assert.match(result.config.personas["pr-description"].prompt, /single sentence/i);
       assert.match(result.config.personas["pr-description"].prompt, /Closes #N/i);
       assert.match(result.config.personas["pr-description"].prompt, /operator-intended close target/i);
       assert.ok(draftAngles.includes("pr-description"), "pr-description must be in draft gate angles after settings opt-in");

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1750,7 +1750,7 @@ describe("role resolution", () => {
 describe("shipped defaults docs and deep angle wiring", () => {
 
   test("D2: shipped defaults wire contract-surface by default and expose cluster-derived opt-in prompts", async () => {
-    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-D3-cluster-prompts-"));
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-D2-cluster-prompts-"));
     try {
       const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
       const sourceDefaults = await readFile(path.join(repoRoot, ".pi", "dev-loop", "defaults.yaml"), "utf8");

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1750,7 +1750,7 @@ describe("role resolution", () => {
 describe("shipped defaults docs and deep angle wiring", () => {
 
   test("D2: shipped defaults wire contract-surface by default and expose cluster-derived opt-in prompts", async () => {
-    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-D2-cluster-prompts-"));
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-D3-cluster-prompts-"));
     try {
       const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
       const sourceDefaults = await readFile(path.join(repoRoot, ".pi", "dev-loop", "defaults.yaml"), "utf8");
@@ -1826,7 +1826,7 @@ describe("shipped defaults docs and deep angle wiring", () => {
   });
 
   test("D3: pr-description persona resolves and appears in draft gate angles after settings opt-in", async () => {
-    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-D2-"));
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-D3-"));
     try {
       const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
       const sourceDefaults = await readFile(path.join(repoRoot, ".pi", "dev-loop", "defaults.yaml"), "utf8");

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1824,6 +1824,37 @@ describe("shipped defaults docs and deep angle wiring", () => {
       await rm(tmpDir, { recursive: true, force: true });
     }
   });
+
+  test("D2: pr-description persona resolves and appears in draft gate angles after settings opt-in", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-D2-"));
+    try {
+      const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+      const sourceDefaults = await readFile(path.join(repoRoot, ".pi", "dev-loop", "defaults.yaml"), "utf8");
+      const sourceSettings = await readFile(path.join(repoRoot, ".pi", "dev-loop", "settings.yaml"), "utf8");
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(path.join(piDir, "defaults.yaml"), sourceDefaults);
+      await writeFile(path.join(piDir, "settings.yaml"), sourceSettings);
+
+      const { loadDevLoopConfig, resolveReviewerRole, resolveGateAngles } = await import("../src/config/config.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+
+      const prDescRole = resolveReviewerRole(result.config, "pr-description");
+      const draftAngles = resolveGateAngles(result.config, "draft");
+
+      assert.deepEqual(result.errors, []);
+      assert.equal(result.config.personas["pr-description"].persona, "review");
+      assert.match(result.config.personas["pr-description"].prompt, /Summary section/i);
+      assert.match(result.config.personas["pr-description"].prompt, /Changes section/i);
+      assert.match(result.config.personas["pr-description"].prompt, /Validation section/i);
+      assert.match(result.config.personas["pr-description"].prompt, /Do not block on formatting/i);
+      assert.ok(draftAngles.includes("pr-description"), "pr-description must be in draft gate angles after settings opt-in");
+      assert.equal(prDescRole.persona, "review");
+      assert.equal(prDescRole.fallback, false);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
 // ── Integration: config wiring into actual consumers ──────────────────────
 


### PR DESCRIPTION
## Summary

Adds `pr-description` angle to draft gate. Angle checks PR body has Summary, Changes, Validation, and Closes #N preservation sections. Does not block on formatting — only missing structure.

## Changes

- `.pi/dev-loop/defaults.yaml` — new `pr-description` reviewer persona prompt
- `.pi/dev-loop/settings.yaml` — opts `pr-description` into draft gate angles
- `packages/core/src/analysis/change-classifier.mjs` — adds `pr-description` to ALWAYS_INCLUDE so it runs with dynamicAngles
- `packages/core/test/config.test.mjs` — integration test for persona resolution and angle wiring

## Validation

- `npm run verify` passes (2382+ tests green)
- CI passes on all commits
- Draft gate: all 13 angles pass, clean verdict posted
- 3 rounds of Copilot review resolved

Closes #558