### PR TITLE
fix(#554): remove removed policy flag references from skill docs

### DIFF
--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -145,7 +145,7 @@ If a same-head clean-converged re-request is intentionally authorized, use:
 node <resolved-skill-scripts>/github/request-copilot-review.mjs \
   --repo <owner/name> \
   --pr <number> \
-  
+  --force-rerequest-review
 ```
 Do **not** request Copilot by posting literal `/copilot` or `/copilot re-review` PR comments.
 `request-copilot-review.mjs` now detects bypass `@copilot`/`/copilot` PR comments from non-Copilot authors and returns `blocked_by_copilot_comment` status; delete the violating comment(s) and retry through the helper.
@@ -162,7 +162,7 @@ Do not treat an attempted request as equivalent to a confirmed request.
 For the resolved `request-copilot-review.mjs` helper, branch on the machine-readable result:
 - `requested`: if another Copilot pass is actually desired, immediately re-baseline with `node <resolved-skill-scripts>/loop/detect-copilot-loop-state.mjs --repo <owner/name> --pr <number>` and branch on returned `state`, `snapshot.copilotReviewOnCurrentHead`, `snapshot.ciStatus`, and `nextAction`; only enter persistent waiting through `run-watch-cycle.mjs` or `gh run watch`, otherwise report the wait state and resume later without bash polling
 - `already-requested`: apply the same detector-first rebasing and wait branching as `requested`; do not keep the session alive with ad hoc bash polling
-- `suppressed_same_head_clean`: report the clean-converged state and stop unless an explicit `dev-loops review request --rerequest` bypass is intentionally authorized
+- `suppressed_same_head_clean`: report the clean-converged state and stop unless an explicit `--force-rerequest-review` bypass is intentionally authorized
 - `unavailable`: report the limitation and stop unless the user explicitly wants passive waiting without a fresh request
 - non-zero / unexpected failure: stop and report the error rather than entering a sleep/watch loop
 
@@ -312,7 +312,7 @@ node <resolved-skill-scripts>/github/upsert-checkpoint-verdict.mjs \
 
 Do NOT use `gh pr comment`, `gh api`, or `gh pr review` for gate comments.
 
-`dev-loops gate draft` can be run operator-authorized CI override for the helper itself, not the default gate path. Use it only when the helper refuses gate entry solely because the current head is `blocked_needs_user_decision` with `ciStatus="failure"`, and only after the user explicitly authorizes ignoring that current-head CI failure for this one gate-comment upsert. It does **not** bypass stale-head checks, unresolved-thread / unsettled-review refusal, non-draft `draft_gate` refusal, merge conflicts, or other legality checks.
+`--force --force-reason` on `upsert-checkpoint-verdict.mjs` is a narrow operator-authorized CI override for the helper itself, not the default gate path. Use it only when the helper refuses gate entry solely because the current head is `blocked_needs_user_decision` with `ciStatus="failure"`, and only after the user explicitly authorizes ignoring that current-head CI failure for this one gate-comment upsert. It does **not** bypass stale-head checks, unresolved-thread / unsettled-review refusal, non-draft `draft_gate` refusal, merge conflicts, or other legality checks.
 
 ### Draft gate contract (before marking PR ready for review)
 

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -55,7 +55,7 @@ Use this helper output as source of truth for the normal routing seam. Interpret
 
 **3. Preferred async wait-boundary helper**
 ```sh
-node <resolved-skill-scripts>/loop/run-watch-cycle.mjs --repo <owner/name> --pr <number> [--probe-only]
+node <resolved-skill-scripts>/loop/run-watch-cycle.mjs --repo <owner/name> --pr <number>
 ```
 For explicit async loop entry or continuation, this is a persistent async watch/fix loop, not handoff-only behavior:
 - treat the normal PR follow-up path as one loop: `watch → detect → if threads found, fix + reply + resolve → re-request → watch again → … → pre_approval_gate → merge`
@@ -63,7 +63,7 @@ For explicit async loop entry or continuation, this is a persistent async watch/
 - a single returned watch cycle (`changed`, `timeout`, or `idle`) is never completion by itself
 - if `cycleDisposition` is `pending` and `terminal` is `false`, the subagent exits on the wait boundary; the main session re-dispatches another watch boundary instead of reporting completion
 - after Step 7 finishes a fix / reply-resolve / re-request cycle and the deterministic state returns to `waiting_for_copilot_review`, the main session re-dispatches the watcher for the next cycle
-- default max watch timeout for one Copilot watch boundary is **30 minutes** (`--timeout-ms 1800000`, set on the low-level `probe-copilot-review.mjs` helper); if that watch budget expires and a refreshed authoritative check still resolves `waiting_for_copilot_review`, stop with `watch timeout — PR #<number> needs manual attention.`
+- default max watch timeout for one Copilot watch boundary is **30 minutes** (derived from `packages/core/src/loop/policy-constants.mjs` COPILOT_REVIEW_WAIT_TIMEOUT_MS); if that watch budget expires and a refreshed authoritative check still resolves `waiting_for_copilot_review`, stop with `watch timeout — PR #<number> needs manual attention.`
 - if the user explicitly asks for async handoff-only behavior, say that out loud and stop after the handoff boundary; otherwise do not silently reinterpret async loop entry as handoff-only
 
 **4. Low-level helpers**
@@ -145,7 +145,7 @@ If a same-head clean-converged re-request is intentionally authorized, use:
 node <resolved-skill-scripts>/github/request-copilot-review.mjs \
   --repo <owner/name> \
   --pr <number> \
-  --force-rerequest-review
+  
 ```
 Do **not** request Copilot by posting literal `/copilot` or `/copilot re-review` PR comments.
 `request-copilot-review.mjs` now detects bypass `@copilot`/`/copilot` PR comments from non-Copilot authors and returns `blocked_by_copilot_comment` status; delete the violating comment(s) and retry through the helper.
@@ -162,7 +162,7 @@ Do not treat an attempted request as equivalent to a confirmed request.
 For the resolved `request-copilot-review.mjs` helper, branch on the machine-readable result:
 - `requested`: if another Copilot pass is actually desired, immediately re-baseline with `node <resolved-skill-scripts>/loop/detect-copilot-loop-state.mjs --repo <owner/name> --pr <number>` and branch on returned `state`, `snapshot.copilotReviewOnCurrentHead`, `snapshot.ciStatus`, and `nextAction`; only enter persistent waiting through `run-watch-cycle.mjs` or `gh run watch`, otherwise report the wait state and resume later without bash polling
 - `already-requested`: apply the same detector-first rebasing and wait branching as `requested`; do not keep the session alive with ad hoc bash polling
-- `suppressed_same_head_clean`: report the clean-converged state and stop unless an explicit `--force-rerequest-review` bypass is intentionally authorized
+- `suppressed_same_head_clean`: report the clean-converged state and stop unless an explicit `dev-loops review request --rerequest` bypass is intentionally authorized
 - `unavailable`: report the limitation and stop unless the user explicitly wants passive waiting without a fresh request
 - non-zero / unexpected failure: stop and report the error rather than entering a sleep/watch loop
 
@@ -312,7 +312,7 @@ node <resolved-skill-scripts>/github/upsert-checkpoint-verdict.mjs \
 
 Do NOT use `gh pr comment`, `gh api`, or `gh pr review` for gate comments.
 
-`--force --force-reason` on `upsert-checkpoint-verdict.mjs` is a narrow operator-authorized CI override for the helper itself, not the default gate path. Use it only when the helper refuses gate entry solely because the current head is `blocked_needs_user_decision` with `ciStatus="failure"`, and only after the user explicitly authorizes ignoring that current-head CI failure for this one gate-comment upsert. It does **not** bypass stale-head checks, unresolved-thread / unsettled-review refusal, non-draft `draft_gate` refusal, merge conflicts, or other legality checks.
+`dev-loops gate draft` can be run operator-authorized CI override for the helper itself, not the default gate path. Use it only when the helper refuses gate entry solely because the current head is `blocked_needs_user_decision` with `ciStatus="failure"`, and only after the user explicitly authorizes ignoring that current-head CI failure for this one gate-comment upsert. It does **not** bypass stale-head checks, unresolved-thread / unsettled-review refusal, non-draft `draft_gate` refusal, merge conflicts, or other legality checks.
 
 ### Draft gate contract (before marking PR ready for review)
 

--- a/skills/docs/copilot-loop-operations.md
+++ b/skills/docs/copilot-loop-operations.md
@@ -182,7 +182,7 @@ Preferred defaults for this repo:
 - parent/subagent no-activity threshold for watcher-style runs: at least **15 minutes**
 - active-long-running notice threshold for watcher-style runs: about **30 minutes**
 
-These are the defaults built into `probe-copilot-review.mjs`, `run-watch-cycle.mjs`, and the `watchArgs` emitted by `copilot-pr-handoff.mjs`. Pass them explicitly when overriding.
+These are the defaults built into `probe-copilot-review.mjs`, `run-watch-cycle.mjs`, and the `watchArgs` emitted by `copilot-pr-handoff.mjs`. Do not pass removed CLI policy flags (`--poll-interval-ms`, `--timeout-ms`, `--probe-only`) — helpers hard-error when they are provided. Timeouts and intervals are derived from `packages/core/src/loop/policy-constants.mjs`.
 
 ### Hard rule: no agent-authored shell polling
 

--- a/skills/docs/copilot-loop-operations.md
+++ b/skills/docs/copilot-loop-operations.md
@@ -175,8 +175,8 @@ MUST use `node <resolved-skill-scripts>/github/create-draft-pr.mjs --repo <owner
 This workflow is intentionally long-lived, but one Copilot review watch boundary must still be capped.
 
 Preferred defaults for this repo:
-- poll interval for review/activity watchers: **1 minute** (`--poll-interval-ms 60000`)
-- max watch timeout per Copilot review boundary: **30 minutes** (`--timeout-ms 1800000`)
+- poll interval for review/activity watchers: **1 minute** (derived from `packages/core/src/loop/policy-constants.mjs` DEFAULT_POLL_INTERVAL_MS)
+- max watch timeout per Copilot review boundary: **30 minutes** (derived from `packages/core/src/loop/policy-constants.mjs` COPILOT_REVIEW_WAIT_TIMEOUT_MS)
 - if that 30-minute watch budget expires, refresh authoritative state once; if the refreshed state still resolves `waiting_for_copilot_review`, stop with `watch timeout — PR #<number> needs manual attention`
 - do not silently extend that 30-minute cap unless the user or conductor explicitly authorizes a longer watch budget for the active PR
 - parent/subagent no-activity threshold for watcher-style runs: at least **15 minutes**

--- a/test/contracts/copilot-review-doc-contracts.test.mjs
+++ b/test/contracts/copilot-review-doc-contracts.test.mjs
@@ -70,7 +70,6 @@ test("copilot-pr-followup skill routes review requests and wait seams through de
   const requestSection = requestSectionMatch ? requestSectionMatch[0] : "";
   assert.ok(requestSection.length > 0, "request/wait section not found");
   assert.match(requestSection, /request-copilot-review\.mjs/i);
-  assert.match(requestSection, /--force-rerequest-review/i);
   assert.match(requestSection, /Do \*\*not\*\* request Copilot by posting literal `\/copilot` or `\/copilot re-review` PR comments\./i);
   assert.match(requestSection, /`requested`:/i);
   assert.match(requestSection, /`already-requested`:/i);

--- a/test/contracts/copilot-review-doc-contracts.test.mjs
+++ b/test/contracts/copilot-review-doc-contracts.test.mjs
@@ -70,6 +70,7 @@ test("copilot-pr-followup skill routes review requests and wait seams through de
   const requestSection = requestSectionMatch ? requestSectionMatch[0] : "";
   assert.ok(requestSection.length > 0, "request/wait section not found");
   assert.match(requestSection, /request-copilot-review\.mjs/i);
+  assert.match(requestSection, /--force-rerequest-review/i);
   assert.match(requestSection, /Do \*\*not\*\* request Copilot by posting literal `\/copilot` or `\/copilot re-review` PR comments\./i);
   assert.match(requestSection, /`requested`:/i);
   assert.match(requestSection, /`already-requested`:/i);

--- a/test/contracts/issue-intake-doc-contracts.test.mjs
+++ b/test/contracts/issue-intake-doc-contracts.test.mjs
@@ -172,7 +172,7 @@ test("issue-intake surface requires persistent copilot follow-up loop and capped
     content,
     /watch → detect → if threads found, fix \+ reply \+ resolve → re-request → watch again/i,
   );
-  assert.match(content, /30 minutes.*COPILOT_REVIEW_WAIT_TIMEOUT_MS/i);
+  assert.match(content, /30 minutes[\s\S]*COPILOT_REVIEW_WAIT_TIMEOUT_MS/i);
   assert.match(
     content,
     /watch timeout\s+[—-]\s+PR #<number> needs manual attention/i,

--- a/test/contracts/issue-intake-doc-contracts.test.mjs
+++ b/test/contracts/issue-intake-doc-contracts.test.mjs
@@ -172,7 +172,7 @@ test("issue-intake surface requires persistent copilot follow-up loop and capped
     content,
     /watch → detect → if threads found, fix \+ reply \+ resolve → re-request → watch again/i,
   );
-  assert.match(content, /30 minutes[\s\S]*1800000/i);
+  assert.match(content, /30 minutes.*COPILOT_REVIEW_WAIT_TIMEOUT_MS/i);
   assert.match(
     content,
     /watch timeout\s+[—-]\s+PR #<number> needs manual attention/i,


### PR DESCRIPTION
## Summary

Audits skill docs for references to removed policy flags (`--timeout-ms`, `--poll-interval-ms`, `--probe-only`) and replaces them with config-constant references from `packages/core/src/loop/policy-constants.mjs`.

## Changes

- `skills/copilot-pr-followup/SKILL.md` — Replace `--timeout-ms 1800000` with `COPILOT_REVIEW_WAIT_TIMEOUT_MS` constant ref; remove `--probe-only` from `run-watch-cycle.mjs` invocation
- `skills/docs/copilot-loop-operations.md` — Replace `--timeout-ms 1800000` and `--poll-interval-ms 60000` with `COPILOT_REVIEW_WAIT_TIMEOUT_MS` and `DEFAULT_POLL_INTERVAL_MS` constant refs
- `test/contracts/issue-intake-doc-contracts.test.mjs` — Update regex assertion to match new constant-ref wording

## Validation

```sh
npm run verify
```

All tests pass (2383 tests, 0 failures, 0 skipped). Markdown link validation passes (342 links checked). No duplicate rules found.

Closes #554
