### PR TITLE
fix(#555): PR body Closes #N is operator-controlled — subagents must not modify

### DIFF
--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -121,7 +121,7 @@ Treat the PR as the main working artifact once it exists.
 Inspect:
 - PR body and title
 - whether the PR body actually satisfies the PR description contract from [Copilot Loop Operations](../docs/copilot-loop-operations.md)
-- that the PR body contains `Closes #N` (or `Fixes #N`) for the linked issue; if missing, stop and require it before continuing
+- that the PR body closing reference (`Closes #N` / `Fixes #N`) is operator-controlled — subagents must NOT add, remove, or modify it. If missing, stop and ask the operator before continuing
 - PR author, because verdict handling differs for PRs not opened by the active GitHub user
 - review summaries
 - unresolved inline comments and issue comments


### PR DESCRIPTION
## Summary

Updates the copilot-pr-followup skill to clarify that the PR body closing reference (`Closes #N` / `Fixes #N`) is operator-controlled. Subagents must NOT add, remove, or modify it during PR inspection and follow-up. If the reference is missing, the subagent must stop and ask the operator rather than assuming it should be present.

## Changes

- `skills/copilot-pr-followup/SKILL.md` (+1/-1): Replaced "that the PR body contains `Closes #N` (or `Fixes #N`) for the linked issue; if missing, stop and require it before continuing" with "that the PR body closing reference (`Closes #N` / `Fixes #N`) is operator-controlled — subagents must NOT add, remove, or modify it. If missing, stop and ask the operator before continuing" in the Step 5 PR discovery and interpretation checklist.

## Validation

- `npm run verify` passes (docs link validation, dedup, dev-loop tests)
- CI green (changes + verify jobs)
- Manual inspection of the changed line confirms it correctly reflects the acceptance criteria from issue #555

## Acceptance criteria (from #555)

- [x] Subagents never rewrite PR body "Closes #N" after operator explicitly removed it — enforced by updated skill docs
- [x] Skill docs clarify operator ownership of PR body closing references — updated in copilot-pr-followup SKILL.md

Closes #555
