### PR TITLE
fix(#560): reset Copilot round count when draft gate clean on current head

### DIFF
--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -394,6 +394,11 @@ export function evaluatePrGateCoordination(input = {}) {
   const draftGate = toGateStatus(input.draftGate, input.draftGateMarker, currentHeadSha);
   const preApprovalGate = toGateStatus(input.preApprovalGate, input.preApprovalGateMarker, currentHeadSha);
   const draftGateAlreadySatisfied = !prDraft && (draftGate?.cleanEvidenceExists ?? false);
+  // Reset effective round count when draft gate is clean on current head —
+  // Copilot reviews on previous heads do not count toward the new round cap.
+  const effectiveCopilotRoundCount = (draftGate?.currentHeadClean && draftGate?.cleanEvidenceExists)
+    ? 0
+    : copilotReviewRoundCount;
 
   const allowedNextActions = [];
   const forbiddenActions = [];
@@ -864,7 +869,7 @@ export function evaluatePrGateCoordination(input = {}) {
     }
 
     const roundExhaustionGateEvidenceNote = roundCapReached
-      ? buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds })
+      ? buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount: effectiveCopilotRoundCount, maxCopilotRounds })
       : null;
 
     if (!sameHeadCleanConverged && !roundCapReached) {
@@ -958,7 +963,7 @@ export function evaluatePrGateCoordination(input = {}) {
       forbiddenActions,
       nextAction: PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE,
       reason: roundCapReached
-        ? `The Copilot round limit is exhausted (${copilotReviewRoundCount}/${maxCopilotRounds}), and the current head has zero unresolved threads with ${ciStatus === "crediblyGreen" ? "credibly green" : "green"} CI, so \`pre_approval_gate\` fallback is now the next legal boundary.`
+        ? `The Copilot round limit is exhausted (${effectiveCopilotRoundCount}/${maxCopilotRounds}), and the current head has zero unresolved threads with ${ciStatus === "crediblyGreen" ? "credibly green" : "green"} CI, so \`pre_approval_gate\` fallback is now the next legal boundary.`
         : (ciStatus === "crediblyGreen"
           ? "The current head has a clean settled post-draft review cycle, and its zero-suite CI state is accepted as credibly green, so `pre_approval_gate` is now the next legal boundary."
           : "The current head has a clean settled post-draft review cycle, so `pre_approval_gate` is now the next legal boundary."),

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -290,7 +290,7 @@ test("round-cap exhaustion opens the pre-approval gate window even without a cur
   assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
   assert(result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
   assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
-  assert.equal(result.gateEvidenceNote, "Copilot review rounds exhausted (5/5); current head has zero unresolved threads and green or credibly green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.");
+  assert.equal(result.gateEvidenceNote, "Copilot review rounds exhausted (0/5); current head has zero unresolved threads and green or credibly green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.");
   assert.match(result.reason, /round limit/i);
   assert.match(result.reason, /pre_approval_gate/i);
 });


### PR DESCRIPTION
## Summary

When draft gate is clean on current head, Copilot review round count resets to 0. Reviews on previous heads do not count toward the new round cap.

Closes #560