### PR TITLE
fix(#571): scope binary rename to bin field only (replaces #572)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -114,7 +114,7 @@ Whenever a merged slice changes durable project truth, update the affected durab
 Today the repository already includes:
 - reusable role agents
 - packaged workflow skills for local and GitHub-first work
-- a `/dev-loops` extension and `pi-dev-loops` shell CLI
+- a `/dev-loops` extension and `dev-loops` shell CLI
 - deterministic GitHub helpers for review-thread capture, Copilot request/watch, issue-to-PR detection, and reviewer draft staging
 - deterministic loop-state helpers for Copilot, reviewer, tracker, and outer-loop orchestration
 - conductor-adjacent ownership, routing, inspection, and steering contracts in the source tree

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Its main surfaces are:
 2. **Workflow skills** in `skills/`
    - `dev-loop` is the public façade; internal routed logic stays internal
 3. **Extension and CLI UX** in `extension/` and `cli/`
-   - `/dev-loops` readiness checks plus the `pi-dev-loops` shell command
+   - `/dev-loops` readiness checks plus the `dev-loops` shell command
 4. **Deterministic support code** in `packages/core/`, `scripts/`, and `lib/`
    - shared helpers, loop-state detectors, and GitHub/Copilot support code
 
@@ -35,7 +35,7 @@ Thin workflow entrypoint agents are allowed when they only load a skill and defe
 
 Installing the package with `pi install git:github.com/mfittko/pi-dev-loops` exposes:
 - the `/dev-loops` extension command surface
-- the `pi-dev-loops` shell CLI
+- the `dev-loops` shell CLI
 - the packaged skills from `package.json` `pi.skills`
 
 For project-local installs, use `pi install -l git:github.com/mfittko/pi-dev-loops`.
@@ -50,7 +50,7 @@ Gate review angles, refinement settings, persona mappings, workflow defaults, an
 
 ```bash
 # See what reviewers will check before handing off code
-pi-dev-loops gates
+dev-loops gates
 ```
 
 Key configurable surfaces:
@@ -89,7 +89,7 @@ Notes:
 
 - `agents/` — reusable role-agent definitions
 - `docs/` — durable workflow contracts, implementation status, and phase docs
-- `cli/` — shell-facing `pi-dev-loops` entrypoint
+- `cli/` — shell-facing `dev-loops` entrypoint
 - `extension/` — `/dev-loops` extension implementation and docs
 - `lib/` — shared command helpers used by the extension and shell CLI
 - `packages/core/` — private deterministic support package

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -95,53 +95,53 @@ async function commandExists(
 function buildCategoryHelp(category) {
   const routes = SUBCOMMAND_ROUTES[category];
   if (!routes) return [`Unknown category: ${category}`];
-  return [`pi-dev-loops ${category} <subcommand> [...]`, "", "Available subcommands:", ...Object.keys(routes).map((s) => `  ${s}`)];
+  return [`dev-loops ${category} <subcommand> [...]`, "", "Available subcommands:", ...Object.keys(routes).map((s) => `  ${s}`)];
 }
 
 function buildCliHelpLines() {
   return [
-    "pi-dev-loops help",
+    "dev-loops help",
     "",
     "Workflow entry:",
     "- /skill:dev-loop (in Pi) or `subagent dev-loop` — single public entrypoint; routing handles the rest",
     "",
     "Commands:",
-    "- pi-dev-loops help                   Show this help",
-    "- pi-dev-loops status                 Show readiness snapshot",
-    "- pi-dev-loops doctor                 Show full diagnostic checks",
-    "- pi-dev-loops gates                  Print gate state",
+    "- dev-loops help                   Show this help",
+    "- dev-loops status                 Show readiness snapshot",
+    "- dev-loops doctor                 Show full diagnostic checks",
+    "- dev-loops gates                  Print gate state",
     "",
     "Subcommands:",
-    "- pi-dev-loops gate <sub> [...]       Gate verdicts and evidence",
+    "- dev-loops gate <sub> [...]       Gate verdicts and evidence",
     "    upsert-verdict    Post/update gate review comment",
     "    detect-evidence   Check merge preconditions",
     "    write-findings-log Write disposition ledger",
-    "- pi-dev-loops review <sub> [...]     Copilot review operations",
+    "- dev-loops review <sub> [...]     Copilot review operations",
     "    request-copilot   Request Copilot review",
     "    probe-copilot     Poll for Copilot review activity",
     "    capture-threads   Capture review threads",
     "    reply-resolve     Reply and resolve review threads",
-    "- pi-dev-loops detect <sub> [...]     State detection",
+    "- dev-loops detect <sub> [...]     State detection",
     "    loop-state        Detect Copilot loop state",
     "    reviewer-state    Detect reviewer loop state",
     "    gate-coordination Detect PR gate coordination state",
     "    linked-issue-pr   Detect linked issue ↔ PR",
     "    issue-refinement  Detect issue refinement artifact",
-    "- pi-dev-loops loop <sub> [...]       Loop lifecycle",
+    "- dev-loops loop <sub> [...]       Loop lifecycle",
     "    startup           Resolve dev-loop startup bundle",
     "    outer             Run outer-loop detection",
     "    watch-cycle       Run Copilot wait cycle",
     "    handoff           Copilot PR handoff",
     "    watch-initial     Watch initial Copilot PR",
-    "- pi-dev-loops pr <sub> [...]         PR helpers",
+    "- dev-loops pr <sub> [...]         PR helpers",
     "    create-draft      Create draft PR",
     "    ready-for-review  Mark PR ready for review",
     "    reconcile-draft   Reconcile non-draft PR",
-    "- pi-dev-loops inspect <sub> [...]    Inspection (Pi extension only)",
+    "- dev-loops inspect <sub> [...]    Inspection (Pi extension only)",
     "    run               Inspect run state",
     "    viewer            Start inspection viewer",
     "",
-    "Use `pi-dev-loops <category> <subcommand> --help` for per-subcommand usage.",
+    "Use `dev-loops <category> <subcommand> --help` for per-subcommand usage.",
     "",
     "`/dev-loops hide` remains an extension-only Pi command.",
     "Use `pi install git:github.com/mfittko/pi-dev-loops` to install skills and agents, or",
@@ -152,9 +152,9 @@ function buildCliHelpLines() {
 function buildCliUsageLines(action) {
   switch (action) {
     case "help": case "status": case "doctor": case "gates":
-      return ["Usage:", `- pi-dev-loops ${action}`];
+      return ["Usage:", `- dev-loops ${action}`];
     case "hide":
-      return ["Usage:", "- pi-dev-loops hide", "`hide` is only supported without extra arguments, and only inside the Pi extension."];
+      return ["Usage:", "- dev-loops hide", "`hide` is only supported without extra arguments, and only inside the Pi extension."];
     default:
       throw new Error(`Unknown CLI usage action: ${action}`);
   }
@@ -166,7 +166,7 @@ function orderedCliSetupSteps(checks) {
   if (steps.length > 0) return steps.map((step, i) => `${i + 1}. ${step}`);
   return [
     "1. Use `/skill:dev-loop` (in Pi) or `subagent dev-loop` to start or continue a dev loop — the single public entry.",
-    "2. Run `pi-dev-loops status` whenever you want a concise readiness snapshot.",
+    "2. Run `dev-loops status` whenever you want a concise readiness snapshot.",
     "3. Use `pi install git:github.com/mfittko/pi-dev-loops` to install the package, or `pi update git:github.com/mfittko/pi-dev-loops` to refresh it.",
   ];
 }
@@ -289,7 +289,7 @@ export async function runCli({
           const summary = summarizeChecks(result.checks);
           const readiness = describeReadiness(result.checks);
           const lines = [
-            `pi-dev-loops ${result.action}: ${summary.ok}/${summary.total} checks passed`,
+            `dev-loops ${result.action}: ${summary.ok}/${summary.total} checks passed`,
             `Local loop readiness: ${readiness.localReady ? "ready" : "needs setup"}`,
             `Remote GitHub/Copilot readiness: ${readiness.remoteReady ? "ready" : "needs setup"}`,
           ];

--- a/extension/README.md
+++ b/extension/README.md
@@ -4,7 +4,7 @@
 
 Installing the package exposes two thin wrappers over one shared deterministic core:
 - the Pi extension command family rooted at `/dev-loops`
-- the shell CLI entrypoint `pi-dev-loops`
+- the shell CLI entrypoint `dev-loops`
 - a bounded post-merge helper that queues one `pi update git:github.com/mfittko/pi-dev-loops` after a successful in-session `gh pr merge ...` or `git merge ...` inside this repo and flushes it on `agent_end`
 
 Installing the package with `pi install git:github.com/mfittko/pi-dev-loops` exposes the packaged skills through `package.json` `pi.skills`, and the extension syncs packaged agent files (`.pi/agents/*.agent.md`) into `~/.agents/` on `session_start`.
@@ -29,19 +29,19 @@ Installing the package with `pi install git:github.com/mfittko/pi-dev-loops` exp
   - stop only the recorded managed inspect-run viewer process
 - `/dev-loops inspect restart [--repo <owner/name>]`
   - explicitly restart the recorded managed inspect-run viewer; never kill an unknown listener
-- `pi-dev-loops`
+- `dev-loops`
   - defaults to help output for the available subcommands
-- `pi-dev-loops help`
+- `dev-loops help`
   - prints shell help for the shared command family
-- `pi-dev-loops status`
+- `dev-loops status`
   - prints the concise readiness summary in shell-friendly output
-- `pi-dev-loops doctor`
+- `dev-loops doctor`
   - prints the full diagnostic report in shell-friendly output
-- `pi-dev-loops gates`
+- `dev-loops gates`
   - prints active review angles with their prompts from config
 - `/dev-loops gates`
   - same as above, but inside the Pi extension
-- `pi-dev-loops hide`
+- `dev-loops hide`
   - is intentionally unsupported and exits non-zero with a shell-friendly stderr message because `hide` is session-local Pi UI behavior
 
 ## Inspect local UI lifecycle ownership
@@ -212,7 +212,7 @@ Current Phase 3+ contract:
 - Pi host expectations are documented from current peer dependencies rather than a tested pinned Pi version range
 - the extension is source-loaded from `./extension/index.ts` through `package.json` `pi.extensions`
 - the package exposes `.pi/skills` through `package.json` `pi.skills` for install-based global skill loading
-- the shell CLI is exposed through `package.json` `bin.pi-dev-loops`
+- the shell CLI is exposed through `package.json` `bin.dev-loops`
 - the extension syncs packaged agent files (`.pi/agents/*.agent.md`) into `~/.agents/` on `session_start` so user-level agents are available outside this repo
 - package install/update happens through `pi install` / `pi update`
 - this phase does not yet claim a specific supported `gh` version; it only checks `gh` presence and authentication state

--- a/extension/index.ts
+++ b/extension/index.ts
@@ -81,11 +81,11 @@ export default function (pi: ExtensionAPI, runtimeOverrides: ExtensionRuntimeOve
       switch (result.kind) {
         case 'hide':
           ctx.ui.setWidget(WIDGET_KEY, undefined);
-          ctx.ui.notify('pi-dev-loops widget hidden', 'info');
+          ctx.ui.notify('dev-loops widget hidden', 'info');
           return;
         case 'help':
           ctx.ui.setWidget(WIDGET_KEY, buildHelpLines(), { placement: 'belowEditor' });
-          ctx.ui.notify('pi-dev-loops help', 'info');
+          ctx.ui.notify('dev-loops help', 'info');
           return;
         case 'checks':
           ctx.ui.setWidget(WIDGET_KEY, buildWidgetLines(result.action as Extract<DevLoopsAction, 'doctor' | 'status'>, result.checks), {
@@ -113,7 +113,7 @@ export default function (pi: ExtensionAPI, runtimeOverrides: ExtensionRuntimeOve
         }
         case 'malformed':
           ctx.ui.setWidget(WIDGET_KEY, [result.message, ...buildHelpLines()], { placement: 'belowEditor' });
-          ctx.ui.notify(`pi-dev-loops ${result.usageAction ?? 'help'}: invalid arguments`, 'error');
+          ctx.ui.notify(`dev-loops ${result.usageAction ?? 'help'}: invalid arguments`, 'error');
           return;
         case 'unsupported': {
           const message = result.message || 'This command is not supported here.';

--- a/extension/index.ts
+++ b/extension/index.ts
@@ -94,7 +94,7 @@ export default function (pi: ExtensionAPI, runtimeOverrides: ExtensionRuntimeOve
           ctx.ui.notify(buildNotificationMessage(result.action as Extract<DevLoopsAction, 'doctor' | 'status'>, result.checks), 'info');
           return;
         case 'gates':
-          ctx.ui.notify('Gate angles printed to console. Run `pi-dev-loops gates` in a terminal to see review prompts.', 'info');
+          ctx.ui.notify('Gate angles printed to console. Run `dev-loops gates` in a terminal to see review prompts.', 'info');
           return;
         case 'inspect_result': {
           const structuredStoppedSuccess = result.state === 'stopped'

--- a/extension/presentation.ts
+++ b/extension/presentation.ts
@@ -37,7 +37,7 @@ export function orderedSetupSteps(checks: DevLoopCheck[]): string[] {
 
 export function buildHelpLines(): string[] {
   return [
-    'pi-dev-loops help',
+    'dev-loops help',
     'Workflow entry:',
     '- /skill:dev-loop — single public entrypoint; routing handles the rest',
     'Commands:',
@@ -57,7 +57,7 @@ export function buildWidgetLines(action: Extract<DevLoopsAction, 'doctor' | 'sta
   const summary = summarizeChecks(checks);
   const readiness = describeReadiness(checks);
   const lines = [
-    `pi-dev-loops ${action}: ${summary.ok}/${summary.total} checks passed`,
+    `dev-loops ${action}: ${summary.ok}/${summary.total} checks passed`,
     `Local loop readiness: ${readinessLabel(readiness.localReady)}`,
     `Remote GitHub/Copilot readiness: ${readinessLabel(readiness.remoteReady)}`,
   ];
@@ -99,7 +99,7 @@ export function buildInspectLines(action: InspectAction, result: { state: string
 
 export function buildNotificationMessage(action: Extract<DevLoopsAction, 'doctor' | 'status'>, checks: DevLoopCheck[]): string {
   const summary = summarizeChecks(checks);
-  return `pi-dev-loops ${action}: ${summary.ok}/${summary.total} checks passed`;
+  return `dev-loops ${action}: ${summary.ok}/${summary.total} checks passed`;
 }
 
 export function buildInspectNotification(action: InspectAction, state: string): string {

--- a/lib/dev-loops-core.mjs
+++ b/lib/dev-loops-core.mjs
@@ -121,7 +121,7 @@ export function parseDevLoopsCommand(input, { surface = 'extension' } = {}) {
         : {
             kind: 'unsupported',
             action: 'hide',
-            message: '`pi-dev-loops hide` is not supported outside the Pi extension; use `/dev-loops hide` inside Pi instead.',
+            message: '`dev-loops hide` is not supported outside the Pi extension; use `/dev-loops hide` inside Pi instead.',
             tokens,
           };
     default:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "zod": "^4.4.3"
       },
       "bin": {
-        "pi-dev-loops": "cli/index.mjs"
+        "dev-loops": "cli/index.mjs"
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:docs": "node scripts/docs/validate-links.mjs && node scripts/docs/validate-no-duplicate-rules.mjs"
   },
   "bin": {
-    "pi-dev-loops": "./cli/index.mjs"
+    "dev-loops": "./cli/index.mjs"
   },
   "peerDependencies": {
     "@mariozechner/pi-coding-agent": "*",

--- a/packages/core/src/cli/subcommand-runner.mjs
+++ b/packages/core/src/cli/subcommand-runner.mjs
@@ -72,7 +72,7 @@ export function defineSubcommand(def) {
   const requiredOpts = options.filter((o) => o.required);
   const optionalOpts = options.filter((o) => !o.required);
 
-  const usageLines = [`Usage: pi-dev-loops ${name}`];
+  const usageLines = [`Usage: dev-loops ${name}`];
   for (const opt of requiredOpts) {
     usageLines.push(`  ${optionUsageFragment(opt)}`);
   }

--- a/test/dev-loops-cli.test.mjs
+++ b/test/dev-loops-cli.test.mjs
@@ -54,8 +54,8 @@ test("package CLI entrypoint prints help and rejects hide as unsupported", () =>
     encoding: "utf8",
   });
   assert.equal(help.status, 0);
-  assert.match(help.stdout, /pi-dev-loops help/);
-  assert.match(help.stdout, /pi-dev-loops status/);
+  assert.match(help.stdout, /dev-loops help/);
+  assert.match(help.stdout, /dev-loops status/);
   assert.equal(help.stderr, "");
 
   const hide = spawnSync("node", ["./cli/index.mjs", "hide"], {
@@ -95,7 +95,7 @@ test("CLI renderer keeps shared status behavior and shell-friendly argument erro
   assert.equal(removedExitCode, 1);
   assert.equal(removedStdout.read(), "");
   assert.match(removedStderr.read(), /Unrecognized command: install\./);
-  assert.match(removedStderr.read(), /pi-dev-loops help/);
+  assert.match(removedStderr.read(), /dev-loops help/);
 
   const malformedStdout = createBufferStream();
   const malformedStderr = createBufferStream();
@@ -109,7 +109,7 @@ test("CLI renderer keeps shared status behavior and shell-friendly argument erro
   assert.equal(malformedExitCode, 1);
   assert.equal(malformedStdout.read(), "");
   assert.match(malformedStderr.read(), /`status` does not accept additional arguments\./);
-  assert.match(malformedStderr.read(), /Usage:\n- pi-dev-loops status/);
+  assert.match(malformedStderr.read(), /Usage:\n- dev-loops status/);
 });
 
 test("CLI help leads with dev-loop as the primary workflow entry", async () => {
@@ -253,7 +253,7 @@ test("CLI rejects removed update command", async () => {
     assert.equal(exitCode, 1);
     assert.equal(stdout.read(), "");
     assert.match(stderr.read(), /Unrecognized command: update\./);
-    assert.match(stderr.read(), /pi-dev-loops help/);
+    assert.match(stderr.read(), /dev-loops help/);
   } finally {
     await rm(tempRoot, { recursive: true, force: true });
   }

--- a/test/dev-loops-core.test.mjs
+++ b/test/dev-loops-core.test.mjs
@@ -46,7 +46,7 @@ test("parser maintains extension and CLI parity with the hide exception", () => 
   assert.deepEqual(parseDevLoopsCommand(["hide"], { surface: "cli" }), {
     kind: "unsupported",
     action: "hide",
-    message: "`pi-dev-loops hide` is not supported outside the Pi extension; use `/dev-loops hide` inside Pi instead.",
+    message: "`dev-loops hide` is not supported outside the Pi extension; use `/dev-loops hide` inside Pi instead.",
     tokens: ["hide"],
   });
   assert.deepEqual(parseDevLoopsCommand(["install", "moon"], { surface: "extension" }), {

--- a/test/extension-command-contract.test.mjs
+++ b/test/extension-command-contract.test.mjs
@@ -134,7 +134,7 @@ test("help is the default action and removed install/update commands fall back t
 
   const widget = calls.widgets.at(-1);
   assert.equal(widget.key, "pi-dev-loops.setup");
-  assert.match(widget.lines[0], /pi-dev-loops help/);
+  assert.match(widget.lines[0], /dev-loops help/);
   assert(widget.lines.some((line) => /\/dev-loops status/i.test(line)));
   assert(widget.lines.some((line) => /pi install git:github.com\/mfittko\/pi-dev-loops/i.test(line)));
   assert(widget.lines.some((line) => /\/skill:dev-loop/i.test(line)), "help should mention /skill:dev-loop as workflow entry");
@@ -145,28 +145,28 @@ test("help is the default action and removed install/update commands fall back t
 
   const installContext = createCommandContext();
   await pi.registeredCommands.get("dev-loops").handler("install repo", installContext.ctx);
-  assert.match(installContext.calls.widgets.at(-1).lines[0], /pi-dev-loops help/);
+  assert.match(installContext.calls.widgets.at(-1).lines[0], /dev-loops help/);
   assert.equal(installContext.calls.notifications.at(-1).message, "pi-dev-loops help");
 
   const bareInstallContext = createCommandContext();
   await pi.registeredCommands.get("dev-loops").handler("install", bareInstallContext.ctx);
-  assert.match(bareInstallContext.calls.widgets.at(-1).lines[0], /pi-dev-loops help/);
+  assert.match(bareInstallContext.calls.widgets.at(-1).lines[0], /dev-loops help/);
   assert.equal(bareInstallContext.calls.notifications.at(-1).message, "pi-dev-loops help");
 
   const updateContext = createCommandContext();
   await pi.registeredCommands.get("dev-loops").handler("update", updateContext.ctx);
-  assert.match(updateContext.calls.widgets.at(-1).lines[0], /pi-dev-loops help/);
+  assert.match(updateContext.calls.widgets.at(-1).lines[0], /dev-loops help/);
   assert.equal(updateContext.calls.notifications.at(-1).message, "pi-dev-loops help");
 
   const bareUpdateContext = createCommandContext();
   await pi.registeredCommands.get("dev-loops").handler("update system", bareUpdateContext.ctx);
-  assert.match(bareUpdateContext.calls.widgets.at(-1).lines[0], /pi-dev-loops help/);
+  assert.match(bareUpdateContext.calls.widgets.at(-1).lines[0], /dev-loops help/);
   assert.equal(bareUpdateContext.calls.notifications.at(-1).message, "pi-dev-loops help");
 
   const statusWithExtraArgsContext = createCommandContext();
   await pi.registeredCommands.get("dev-loops").handler("status extra", statusWithExtraArgsContext.ctx);
-  assert.match(statusWithExtraArgsContext.calls.widgets.at(-1).lines[0], /pi-dev-loops status:/);
-  assert.equal(statusWithExtraArgsContext.calls.notifications.at(-1).message, "pi-dev-loops status: 4/4 checks passed");
+  assert.match(statusWithExtraArgsContext.calls.widgets.at(-1).lines[0], /dev-loops status:/);
+  assert.equal(statusWithExtraArgsContext.calls.notifications.at(-1).message, "dev-loops status: 4/4 checks passed");
 });
 
 test("status and doctor use the reduced readiness surface", async () => {
@@ -213,7 +213,7 @@ test("hide still clears the widget and unknown commands fall back to help", asyn
 
   const fallbackContext = createCommandContext();
   await pi.registeredCommands.get("dev-loops").handler("banana", fallbackContext.ctx);
-  assert.match(fallbackContext.calls.widgets.at(-1).lines[0], /pi-dev-loops help/);
+  assert.match(fallbackContext.calls.widgets.at(-1).lines[0], /dev-loops help/);
   assert.equal(fallbackContext.calls.notifications.at(-1).message, "pi-dev-loops help");
 });
 

--- a/test/extension-command-contract.test.mjs
+++ b/test/extension-command-contract.test.mjs
@@ -141,27 +141,27 @@ test("help is the default action and removed install/update commands fall back t
   assert(widget.lines.some((line) => /single public entry/i.test(line)), "help should describe dev-loop as single public entry");
   assert.equal(widget.lines.some((line) => /copilot-dev-loop|copilot-autopilot/i.test(line)), false, "help should not surface internal seam names");
   assert.doesNotMatch(widget.lines.join("\n"), /\/dev-loops (?:install|update)/i);
-  assert.equal(calls.notifications.at(-1).message, "pi-dev-loops help");
+  assert.equal(calls.notifications.at(-1).message, "dev-loops help");
 
   const installContext = createCommandContext();
   await pi.registeredCommands.get("dev-loops").handler("install repo", installContext.ctx);
   assert.match(installContext.calls.widgets.at(-1).lines[0], /dev-loops help/);
-  assert.equal(installContext.calls.notifications.at(-1).message, "pi-dev-loops help");
+  assert.equal(installContext.calls.notifications.at(-1).message, "dev-loops help");
 
   const bareInstallContext = createCommandContext();
   await pi.registeredCommands.get("dev-loops").handler("install", bareInstallContext.ctx);
   assert.match(bareInstallContext.calls.widgets.at(-1).lines[0], /dev-loops help/);
-  assert.equal(bareInstallContext.calls.notifications.at(-1).message, "pi-dev-loops help");
+  assert.equal(bareInstallContext.calls.notifications.at(-1).message, "dev-loops help");
 
   const updateContext = createCommandContext();
   await pi.registeredCommands.get("dev-loops").handler("update", updateContext.ctx);
   assert.match(updateContext.calls.widgets.at(-1).lines[0], /dev-loops help/);
-  assert.equal(updateContext.calls.notifications.at(-1).message, "pi-dev-loops help");
+  assert.equal(updateContext.calls.notifications.at(-1).message, "dev-loops help");
 
   const bareUpdateContext = createCommandContext();
   await pi.registeredCommands.get("dev-loops").handler("update system", bareUpdateContext.ctx);
   assert.match(bareUpdateContext.calls.widgets.at(-1).lines[0], /dev-loops help/);
-  assert.equal(bareUpdateContext.calls.notifications.at(-1).message, "pi-dev-loops help");
+  assert.equal(bareUpdateContext.calls.notifications.at(-1).message, "dev-loops help");
 
   const statusWithExtraArgsContext = createCommandContext();
   await pi.registeredCommands.get("dev-loops").handler("status extra", statusWithExtraArgsContext.ctx);
@@ -209,12 +209,12 @@ test("hide still clears the widget and unknown commands fall back to help", asyn
     lines: undefined,
     options: undefined,
   });
-  assert.equal(hideContext.calls.notifications.at(-1).message, "pi-dev-loops widget hidden");
+  assert.equal(hideContext.calls.notifications.at(-1).message, "dev-loops widget hidden");
 
   const fallbackContext = createCommandContext();
   await pi.registeredCommands.get("dev-loops").handler("banana", fallbackContext.ctx);
   assert.match(fallbackContext.calls.widgets.at(-1).lines[0], /dev-loops help/);
-  assert.equal(fallbackContext.calls.notifications.at(-1).message, "pi-dev-loops help");
+  assert.equal(fallbackContext.calls.notifications.at(-1).message, "dev-loops help");
 });
 
 test("extension dispatches inspect-run open and surfaces browser warnings without failing the launch", async () => {

--- a/test/extension-package-contract.test.mjs
+++ b/test/extension-package-contract.test.mjs
@@ -9,7 +9,7 @@ test("package metadata exposes the extension entrypoint and root extension test 
   const packageJson = JSON.parse(await readRepo("package.json"));
 
   assert.deepEqual(packageJson.pi.extensions, ["./extension/index.ts"]);
-  assert.equal(packageJson.bin["pi-dev-loops"], "./cli/index.mjs");
+  assert.equal(packageJson.bin["dev-loops"], "./cli/index.mjs");
   assert.match(packageJson.engines.node, />=20/);
   assert.equal(typeof packageJson.peerDependencies["@mariozechner/pi-coding-agent"], "string");
   assert.equal(typeof packageJson.peerDependencies["@mariozechner/pi-tui"], "string");
@@ -29,7 +29,7 @@ test("extension README documents the supported command, install, and verificatio
   for (const commandPattern of [
     /\/dev-loops status/i,
     /\/dev-loops doctor/i,
-    /pi-dev-loops status/i,
+    /dev-loops status/i,
   ]) {
     assert.match(readme, commandPattern);
   }

--- a/test/extension-package-contract.test.mjs
+++ b/test/extension-package-contract.test.mjs
@@ -29,7 +29,7 @@ test("extension README documents the supported command, install, and verificatio
   for (const commandPattern of [
     /\/dev-loops status/i,
     /\/dev-loops doctor/i,
-    /dev-loops status/i,
+    /`dev-loops status`/i,
   ]) {
     assert.match(readme, commandPattern);
   }


### PR DESCRIPTION
## Summary

Replaces #572 with correct scope. Only renames the CLI binary entrypoint — not the npm package name, GitHub repo references, internal `@pi-dev-loops/core` package references, or project documentation titles.

## Changes

- `package.json` — bin field: `pi-dev-loops` → `dev-loops`
- `package-lock.json` — regenerated with correct bin mapping
- `cli/index.mjs` — help text binary references
- `lib/dev-loops-core.mjs` — hide unsupported message
- `extension/index.ts` — notification messages
- `extension/presentation.ts` — help/widget/notification binary refs
- `extension/README.md` — binary command docs
- `packages/core/src/cli/subcommand-runner.mjs` — usage template
- `README.md` — binary refs in project docs
- `PLAN.md` — binary ref in product summary
- Test files: `test/extension-package-contract.test.mjs`, `test/dev-loops-cli.test.mjs`, `test/dev-loops-core.test.mjs`, `test/extension-command-contract.test.mjs`

## What #572 got wrong

Renamed every occurrence of `pi-dev-loops` across 99 files.

## Draft gate gap

Existing gate angles (dry, kiss, yagni, etc.) are diff-scoped. Rename PRs need a cross-repo sweep angle to catch stale refs in unchanged files. Potential addition: `sweep`/`grep-consistency` opt-in angle.

Closes #571