### PR TITLE
fix(#569): make runner ownership advisory for gate operations

### DIFF
--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -230,7 +230,7 @@ export async function detectCheckpointEvidence(options, { env = process.env, ghC
     env,
     cwd,
     claimIfMissing: false,
-    requireExisting: true,
+    requireExisting: false,
   });
   if (!runnerOwnership.ok) {
     const error = new Error(runnerOwnership.message);

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -838,7 +838,7 @@ test("detect-checkpoint-evidence fails closed when async run no longer owns the 
   }
 });
 
-test("detect-checkpoint-evidence fails closed when async run has no ownership record", async () => {
+test("detect-checkpoint-evidence does not fail closed when async run has no ownership record", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-checkpoint-evidence-ownership-"));
 
   try {
@@ -847,11 +847,10 @@ test("detect-checkpoint-evidence fails closed when async run has no ownership re
       env: { ...process.env, PI_SUBAGENT_RUN_ID: "run-stale" },
     });
 
-    assert.equal(result.code, 1);
-    assert.equal(result.stdout, "");
-    const error = JSON.parse(result.stderr);
-    assert.equal(error.ok, false);
-    assert.equal(error.error, "ownership_missing");
+    // With #569, missing ownership is advisory — gate operations should not
+    // be blocked when no runner record exists. The call succeeds even without
+    // an ownership record (it may fail for other reasons like missing gh data).
+    assert.notEqual(result.code, 1, "should not exit with code 1 for missing ownership");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -850,7 +850,15 @@ test("detect-checkpoint-evidence does not fail closed when async run has no owne
     // With #569, missing ownership is advisory — gate operations should not
     // be blocked when no runner record exists. The call succeeds even without
     // an ownership record (it may fail for other reasons like missing gh data).
-    assert.notEqual(result.code, 1, "should not exit with code 1 for missing ownership");
+    if (result.stderr) {
+      try {
+        const err = JSON.parse(result.stderr);
+        assert.notEqual(err.error, "ownership_missing", "should not block on missing ownership");
+        assert.notEqual(err.error, "ownership_lost", "should not block on ownership lost");
+      } catch {
+        // stderr may not be JSON; that's fine as long as it's not ownership-related
+      }
+    }
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -842,23 +842,37 @@ test("detect-checkpoint-evidence does not fail closed when async run has no owne
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-checkpoint-evidence-ownership-"));
 
   try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
+        stdout: '{"headRefOid":"abc1234"}\n',
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/17/comments?per_page=100"],
+        stdout: "[]\n",
+      },
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: JSON.stringify({
+          data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } }
+        }) + "\n",
+      },
+    ]);
+
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], {
       cwd: tempDir,
-      env: { ...process.env, PI_SUBAGENT_RUN_ID: "run-stale" },
+      env: { ...env, PI_SUBAGENT_RUN_ID: "run-stale" },
     });
 
     // With #569, missing ownership is advisory — gate operations should not
-    // be blocked when no runner record exists. The call succeeds even without
-    // an ownership record (it may fail for other reasons like missing gh data).
-    if (result.stderr) {
-      try {
-        const err = JSON.parse(result.stderr);
-        assert.notEqual(err.error, "ownership_missing", "should not block on missing ownership");
-        assert.notEqual(err.error, "ownership_lost", "should not block on ownership lost");
-      } catch {
-        // stderr may not be JSON; that's fine as long as it's not ownership-related
-      }
-    }
+    // be blocked when no runner record exists. The command proceeds past
+    // ownership and reaches the pre-merge gate check (which fails because
+    // no gate comments exist), reporting staleRunner.status: no_owner_record.
+    assert.equal(result.code, 1);
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /Pre-merge gate evidence check failed/i);
+    assert.equal(payload.staleRunner.status, "no_owner_record");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Change `requireExisting` from `true` to `false` in `detectCheckpointEvidence` so gate operations don't fail when no runner coordination record exists.

## Problem

Runner ownership validator blocked legitimate subagent gate execution. Subagents dispatched directly (not through conductor) couldn't post draft gate or pre-approval gate comments because they lacked a runner coordination record. This forced gate skips.

## Root Cause

`detectCheckpointEvidence` called `ensureAsyncRunnerOwnership` with `requireExisting: true`, making ownership mandatory for all gate evidence detection.

## Fix

- `requireExisting: true` → `requireExisting: false` in `detectCheckpointEvidence`
- Ownership is now advisory: gate operations proceed without a runner record
- Stale runner checks still apply when a record DOES exist
- Test updated: `ownership_missing` is no longer a blocking error

Closes #569