### PR TITLE
fix: block gates when branch behind base (BEHIND mergeStateStatus) (#566)

### DIFF
--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -108,7 +108,7 @@ function pushUnique(values, additions) {
   }
 }
 
-const CONFLICTING_MERGE_STATE_STATUSES = new Set(["DIRTY", "CONFLICTING"]);
+const BLOCKED_MERGE_STATE_STATUSES = new Set(["DIRTY", "CONFLICTING", "BEHIND"]);
 
 function normalizeMergeStateStatus(value) {
   if (typeof value !== "string" || value.trim().length === 0) {
@@ -137,11 +137,22 @@ function normalizeConflictFiles(value) {
   return normalized;
 }
 
-function hasConflictStatus(mergeStateStatus) {
-  return mergeStateStatus !== null && CONFLICTING_MERGE_STATE_STATUSES.has(mergeStateStatus);
+function hasBlockedMergeStatus(mergeStateStatus) {
+  return mergeStateStatus !== null && BLOCKED_MERGE_STATE_STATUSES.has(mergeStateStatus);
 }
 
-function formatConflictResolutionReason(mergeStateStatus, conflictFiles) {
+function formatBlockedMergeReason(mergeStateStatus, conflictFiles) {
+  if (mergeStateStatus === "BEHIND") {
+    let reason = "Branch must be updated from base before entering any gate.";
+    if (mergeStateStatus !== null) {
+      reason += ` GitHub mergeStateStatus: ${mergeStateStatus}.`;
+    }
+    if (conflictFiles.length > 0) {
+      reason += ` Conflicting files: ${conflictFiles.join(", ")}.`;
+    }
+    return reason;
+  }
+
   let reason = "The current branch conflicts with the base branch, so resolve the conflict locally on the PR branch, rerun validation, rerun gate detection, and only then resume the normal gate path.";
 
   if (mergeStateStatus !== null) {
@@ -460,7 +471,7 @@ export function evaluatePrGateCoordination(input = {}) {
     });
   }
 
-  if (hasConflictStatus(mergeStateStatus) || conflictFiles.length > 0) {
+  if (hasBlockedMergeStatus(mergeStateStatus) || conflictFiles.length > 0) {
     pushUnique(allowedNextActions, [PR_CHECKPOINT_ACTION.RESOLVE_MERGE_CONFLICTS]);
     pushUnique(forbiddenActions, [
       PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE,
@@ -489,7 +500,7 @@ export function evaluatePrGateCoordination(input = {}) {
       allowedNextActions,
       forbiddenActions,
       nextAction: PR_CHECKPOINT_ACTION.RESOLVE_MERGE_CONFLICTS,
-      reason: formatConflictResolutionReason(mergeStateStatus, conflictFiles),
+      reason: formatBlockedMergeReason(mergeStateStatus, conflictFiles),
       mergeStateStatus,
       conflictFiles,
         refinementArtifact,

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -144,12 +144,7 @@ function hasBlockedMergeStatus(mergeStateStatus) {
 function formatBlockedMergeReason(mergeStateStatus, conflictFiles) {
   if (mergeStateStatus === "BEHIND") {
     let reason = "Branch must be updated from base before entering any gate.";
-    if (mergeStateStatus !== null) {
-      reason += ` GitHub mergeStateStatus: ${mergeStateStatus}.`;
-    }
-    if (conflictFiles.length > 0) {
-      reason += ` Conflicting files: ${conflictFiles.join(", ")}.`;
-    }
+    reason += ` GitHub mergeStateStatus: ${mergeStateStatus}.`;
     return reason;
   }
 

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -1048,3 +1048,137 @@ test("non-draft PRs do not block on missing refinement artifact (already left dr
   assert.notEqual(result.gateBoundary, PR_CHECKPOINT.BLOCKED);
   assert.equal(result.refinementArtifact?.status, "missing");
 });
+
+// ── Branch freshness (BEHIND) gate tests (#566) ─────────────────────────
+
+test("BEHIND mergeStateStatus blocks draft_gate entry (#566)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 10,
+    currentHeadSha: "abc123456789",
+    prDraft: true,
+    lifecycleState: STATE.PR_DRAFT,
+    loopDisposition: DISPOSITION.ACTION_REQUIRED,
+    ciStatus: "success",
+    mergeStateStatus: "BEHIND",
+    draftGate: gate({ visible: false }),
+    draftGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.CONFLICT_RESOLUTION);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RESOLVE_MERGE_CONFLICTS);
+  assert.equal(result.mergeStateStatus, "BEHIND");
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE));
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY));
+  assert.match(result.reason, /branch must be updated from base/i);
+});
+
+test("BEHIND mergeStateStatus blocks pre_approval_gate entry (#566)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    loopDisposition: DISPOSITION.CLEAN_CONVERGED,
+    sameHeadCleanConverged: true,
+    ciStatus: "success",
+    mergeStateStatus: "BEHIND",
+    draftGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "fedcba9", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.CONFLICT_RESOLUTION);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RESOLVE_MERGE_CONFLICTS);
+  assert.equal(result.mergeStateStatus, "BEHIND");
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL));
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY));
+  assert.match(result.reason, /branch must be updated from base/i);
+});
+
+test("BEHIND takes precedence over clean settled review cycle (#566)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 370,
+    currentHeadSha: "deadbeef1234",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    loopDisposition: DISPOSITION.CLEAN_CONVERGED,
+    sameHeadCleanConverged: true,
+    mergeStateStatus: "BEHIND",
+    draftGate: gate({ visible: true, headSha: "deadbee", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "deadbee", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: true, headSha: "deadbee", verdict: "clean" }),
+    preApprovalGateMarker: gate({ visible: true, headSha: "deadbee", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.CONFLICT_RESOLUTION);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RESOLVE_MERGE_CONFLICTS);
+  assert.equal(result.mergeStateStatus, "BEHIND");
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL));
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY));
+  assert.match(result.reason, /branch must be updated from base/i);
+});
+
+test("BEHIND blocks even when both gates have clean current-head evidence (#566)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    loopDisposition: DISPOSITION.CLEAN_CONVERGED,
+    sameHeadCleanConverged: true,
+    ciStatus: "success",
+    mergeStateStatus: "BEHIND",
+    draftGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "fedcba9", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
+    preApprovalGateMarker: gate({ visible: true, headSha: "fedcba9", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.CONFLICT_RESOLUTION);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RESOLVE_MERGE_CONFLICTS);
+  assert.match(result.reason, /branch must be updated from base/i);
+});
+
+test("CLEAN mergeStateStatus still allows gate progression (#566 regression guard)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    loopDisposition: DISPOSITION.CLEAN_CONVERGED,
+    sameHeadCleanConverged: true,
+    ciStatus: "success",
+    mergeStateStatus: "CLEAN",
+    draftGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "fedcba9", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
+    preApprovalGateMarker: gate({ visible: true, headSha: "fedcba9", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.FINAL_APPROVAL_READY);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL);
+});
+
+test("mergeStateStatus null still allows gate progression (#566 regression guard)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    loopDisposition: DISPOSITION.CLEAN_CONVERGED,
+    sameHeadCleanConverged: true,
+    ciStatus: "success",
+    mergeStateStatus: null,
+    draftGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "fedcba9", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
+    preApprovalGateMarker: gate({ visible: true, headSha: "fedcba9", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.FINAL_APPROVAL_READY);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL);
+});


### PR DESCRIPTION
Closes #566

## Problem
Draft gate and pre-approval gate run on `mergeStateStatus: CLEAN` but don't require branch to be up-to-date with base. A PR can pass gates with stale branch (behind main) and fail merge later.

## Fix
- Add `BEHIND` to `BLOCKED_MERGE_STATE_STATUSES` alongside `DIRTY` and `CONFLICTING`
- Rename `hasConflictStatus` → `hasBlockedMergeStatus`
- Add `formatBlockedMergeReason` with BEHIND-specific message: "Branch must be updated from base before entering any gate."
- `draft_gate` and `pre_approval_gate` now blocked when `mergeStateStatus: BEHIND`
- 6 new tests validating BEHIND enforcement and CLEAN/null regression guards

## Files changed
- `packages/core/src/loop/pr-gate-coordination.mjs` (+17/-6)
- `packages/core/test/pr-gate-coordination.test.mjs` (+134/-0)

## Verification
- `npm run verify` green: 2,442 tests, 0 failures
