### PR TITLE
feat(#561): add mandatoryAngles to gate config

### DIFF
--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -737,8 +737,10 @@ export async function resolveGateAnglesDynamic(config, gate, { diff } = {}) {
     ambiguous: analysis.ambiguous,
   });
 
-  // Merge: mandatory always included + dynamically-selected candidates
-  const recommendedAngles = [...new Set([...gateConfig.mandatoryAngles, ...dynamicResult.recommendedAngles])];
+  // Merge: mandatory always included (filtered by excludeAngles) + dynamically-selected candidates
+  const excluded = new Set(gateConfig.excludeAngles);
+  const filteredMandatory = gateConfig.mandatoryAngles.filter(a => !excluded.has(a));
+  const recommendedAngles = [...new Set([...filteredMandatory, ...dynamicResult.recommendedAngles])];
 
   return {
     recommendedAngles,

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -31,9 +31,9 @@ const RefinementConfig = z.strictObject({
 });
 
 const GateConfig = z.strictObject({
-  angles: z.array(z.string().trim().min(1)),
+  angles: z.array(z.string().trim().min(1)).optional(),
   excludeAngles: z.array(z.string().trim().min(1)).default([]),
-  mandatoryAngles: z.array(z.string().trim().min(1)).optional(),
+  mandatoryAngles: z.array(z.string().trim().min(1)).default([]),
   required: z.boolean().default(true),
   requireCi: z.boolean().default(true),
   blockCleanOnFindingSeverities: z
@@ -668,9 +668,10 @@ export function resolveLightMode(config) {
 /**
  * Resolve review angles for a specific gate from the merged dev-loop config.
  *
- * Returns the configured angle names for the given gate, or null when the
- * config does not specify angles for that gate (caller falls back to its
- * skill-defined defaults).
+ * Merges mandatoryAngles with the configured candidate angles, filters
+ * through excludeAngles, and deduplicates. Returns null only when both
+ * angles and mandatoryAngles are absent/empty for the given gate (caller
+ * falls back to skill-defined defaults).
  *
  * @param {DevLoopConfig} config
  * @param {"draft"|"preApproval"} gate

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -33,6 +33,7 @@ const RefinementConfig = z.strictObject({
 const GateConfig = z.strictObject({
   angles: z.array(z.string().trim().min(1)),
   excludeAngles: z.array(z.string().trim().min(1)).default([]),
+  mandatoryAngles: z.array(z.string().trim().min(1)).optional(),
   required: z.boolean().default(true),
   requireCi: z.boolean().default(true),
   blockCleanOnFindingSeverities: z
@@ -619,7 +620,7 @@ export function resolveRefinement(config) {
  *
  * @param {DevLoopConfig} config
  * @param {"draft"|"preApproval"} gate
- * @returns {{ angles: string[]|null, excludeAngles: string[], required: boolean, requireCi: boolean, blockCleanOnFindingSeverities: string[], dynamicAngles: boolean }}
+ * @returns {{ angles: string[]|null, excludeAngles: string[], mandatoryAngles: string[], required: boolean, requireCi: boolean, blockCleanOnFindingSeverities: string[], dynamicAngles: boolean }}
  */
 export function resolveGateConfig(config, gate) {
   const gateConfig = config?.gates?.[gate];
@@ -629,6 +630,9 @@ export function resolveGateConfig(config, gate) {
       : null,
     excludeAngles: gateConfig?.excludeAngles && Array.isArray(gateConfig.excludeAngles)
       ? gateConfig.excludeAngles.map(a => (typeof a === "string" ? a.trim() : "")).filter(a => a.length > 0)
+      : [],
+    mandatoryAngles: gateConfig?.mandatoryAngles && Array.isArray(gateConfig.mandatoryAngles)
+      ? gateConfig.mandatoryAngles.map(a => (typeof a === "string" ? a.trim() : "")).filter(a => a.length > 0)
       : [],
     required: gateConfig?.required ?? true,
     requireCi: gateConfig?.requireCi ?? true,
@@ -674,9 +678,10 @@ export function resolveLightMode(config) {
  */
 export function resolveGateAngles(config, gate) {
   const gateConfig = resolveGateConfig(config, gate);
-  if (gateConfig.angles === null) return null;
+  if (gateConfig.angles === null && gateConfig.mandatoryAngles.length === 0) return null;
   const excluded = new Set(gateConfig.excludeAngles);
-  return gateConfig.angles.filter(a => !excluded.has(a));
+  const merged = [...new Set([...gateConfig.mandatoryAngles, ...(gateConfig.angles ?? [])])];
+  return merged.filter(a => !excluded.has(a));
 }
 
 /**
@@ -695,12 +700,12 @@ export function resolveGateAngles(config, gate) {
  * @returns {{ recommendedAngles: string[] | null, skippedAngles: string[], reasons: Record<string,string>, fallbackToAll: boolean, dynamicAnglesActive: boolean }}
  */
 export async function resolveGateAnglesDynamic(config, gate, { diff } = {}) {
+  const gateConfig = resolveGateConfig(config, gate);
   const staticAngles = resolveGateAngles(config, gate);
   if (staticAngles === null) {
     return { recommendedAngles: null, skippedAngles: [], reasons: {}, fallbackToAll: false, dynamicAnglesActive: false };
   }
 
-  const gateConfig = resolveGateConfig(config, gate);
   if (!gateConfig.dynamicAngles || !diff) {
     return {
       recommendedAngles: staticAngles,
@@ -710,6 +715,11 @@ export async function resolveGateAnglesDynamic(config, gate, { diff } = {}) {
       dynamicAnglesActive: false,
     };
   }
+
+  // Split into mandatory (always run) and candidate pool (dynamic selection)
+  // staticAngles is already filtered by excludeAngles via resolveGateAngles
+  const mandatory = new Set(gateConfig.mandatoryAngles);
+  const candidatePool = staticAngles.filter(a => !mandatory.has(a));
 
   // Dynamic resolution
   const { analyzeDiff } = await import("../analysis/index.mjs");
@@ -722,13 +732,19 @@ export async function resolveGateAnglesDynamic(config, gate, { diff } = {}) {
 
   const { resolveDynamicAngles: resolve } = await import("../analysis/change-classifier.mjs");
   const dynamicResult = resolve({
-    configuredAngles: staticAngles,
+    configuredAngles: candidatePool,
     changeCategories: categories,
     ambiguous: analysis.ambiguous,
   });
 
+  // Merge: mandatory always included + dynamically-selected candidates
+  const recommendedAngles = [...new Set([...gateConfig.mandatoryAngles, ...dynamicResult.recommendedAngles])];
+
   return {
-    ...dynamicResult,
+    recommendedAngles,
+    skippedAngles: dynamicResult.skippedAngles,
+    reasons: dynamicResult.reasons,
+    fallbackToAll: dynamicResult.fallbackToAll,
     dynamicAnglesActive: true,
   };
 }

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -2394,4 +2394,25 @@ describe("resolveGateAnglesDynamic", () => {
     assert.equal(occurrences, 1);
     assert.ok(result.recommendedAngles.includes("pr-description"));
   });
+  test("excluded mandatoryAngles are NOT reintroduced in dynamic path", async () => {
+    const config = {
+      version: 1,
+      gates: {
+        draft: {
+          angles: ["scope"],
+          mandatoryAngles: ["pr-description", "correctness"],
+          excludeAngles: ["correctness"],
+          dynamicAngles: true,
+        },
+      },
+    };
+    const result = await resolveGateAnglesDynamic(config, "draft", {
+      diff: {
+        nameStatusOutput: "M\tsrc/main.mjs",
+      },
+    });
+    assert.ok(!result.recommendedAngles.includes("correctness"));
+    assert.ok(result.recommendedAngles.includes("pr-description"));
+  });
+
 });

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1433,6 +1433,7 @@ describe("role resolution", () => {
       assert.deepEqual(result, {
         angles: null,
         excludeAngles: [],
+        mandatoryAngles: [],
         required: true,
         requireCi: true,
         dynamicAngles: false,
@@ -1450,6 +1451,7 @@ describe("role resolution", () => {
       assert.deepEqual(result, {
         angles: ["scope", "coverage", "correctness"],
         excludeAngles: [],
+        mandatoryAngles: [],
         required: false,
         requireCi: false,
         dynamicAngles: false,
@@ -1698,7 +1700,97 @@ describe("role resolution", () => {
       assert.deepEqual(result, ["scope", "coverage"]);
     });
 
-    test("resolveRefinement returns new roles array (not reference to config)", () => {
+    // --- mandatoryAngles ---
+    test("resolveGateConfig returns mandatoryAngles", () => {
+      const config = {
+        version: 1,
+        gates: {
+          draft: {
+            angles: ["scope", "coverage"],
+            mandatoryAngles: ["pr-description", "correctness"],
+          },
+        },
+      };
+      const result = resolveGateConfig(config, "draft");
+      assert.deepEqual(result.mandatoryAngles, ["pr-description", "correctness"]);
+    });
+
+    test("resolveGateConfig returns empty mandatoryAngles when absent", () => {
+      const config = {
+        version: 1,
+        gates: { draft: { angles: ["scope"] } },
+      };
+      const result = resolveGateConfig(config, "draft");
+      assert.deepEqual(result.mandatoryAngles, []);
+    });
+
+    test("resolveGateAngles merges mandatoryAngles with regular angles (no duplicates)", () => {
+      const config = {
+        version: 1,
+        gates: {
+          draft: {
+            angles: ["scope", "coverage"],
+            mandatoryAngles: ["pr-description", "correctness"],
+          },
+        },
+      };
+      const result = resolveGateAngles(config, "draft");
+      assert.deepEqual(result, ["pr-description", "correctness", "scope", "coverage"]);
+    });
+
+    test("resolveGateAngles deduplicates overlap between mandatory and regular angles", () => {
+      const config = {
+        version: 1,
+        gates: {
+          draft: {
+            angles: ["scope", "coverage", "pr-description"],
+            mandatoryAngles: ["pr-description", "correctness"],
+          },
+        },
+      };
+      const result = resolveGateAngles(config, "draft");
+      assert.deepEqual(result, ["pr-description", "correctness", "scope", "coverage"]);
+    });
+
+    test("resolveGateAngles excludes mandatoryAngles matching excludeAngles", () => {
+      const config = {
+        version: 1,
+        gates: {
+          draft: {
+            angles: ["scope"],
+            mandatoryAngles: ["pr-description", "correctness", "gate-evidence"],
+            excludeAngles: ["correctness"],
+          },
+        },
+      };
+      const result = resolveGateAngles(config, "draft");
+      assert.deepEqual(result, ["pr-description", "gate-evidence", "scope"]);
+    });
+
+    test("resolveGateAngles returns null when both angles and mandatoryAngles empty", () => {
+      const config = {
+        version: 1,
+        gates: { draft: { mandatoryAngles: [] } },
+      };
+      const result = resolveGateAngles(config, "draft");
+      assert.deepEqual(result, null);
+    });
+
+    test("resolveGateAngles returns only mandatoryAngles when angles not configured", () => {
+      const config = {
+        version: 1,
+        gates: { draft: { mandatoryAngles: ["pr-description", "correctness"] } },
+      };
+      const result = resolveGateAngles(config, "draft");
+      assert.deepEqual(result, ["pr-description", "correctness"]);
+    });
+
+    test("resolveGateConfig default booleans include empty mandatoryAngles", () => {
+      const result = resolveGateConfig({ version: 1 }, "draft");
+      assert.deepEqual(result.mandatoryAngles, []);
+    });
+
+        test("resolveRefinement returns new roles array (not reference to config)", () => {
       const config = { version: 1, refinement: { fanOut: 2, mode: "parallel", roles: ["security"] } };
       const result = resolveRefinement(config);
       result.roles.push("style");
@@ -2212,5 +2304,94 @@ describe("resolveGateAnglesDynamic", () => {
     for (const angle of result.skippedAngles) {
       assert.ok(result.reasons[angle], `reason missing for ${angle}`);
     }
+  });
+
+  test("includes mandatoryAngles always regardless of diff analysis", async () => {
+    const config = {
+      version: 1,
+      gates: {
+        draft: {
+          angles: ["scope", "coverage"],
+          mandatoryAngles: ["pr-description", "correctness", "gate-evidence"],
+          dynamicAngles: true,
+        },
+      },
+    };
+    const result = await resolveGateAnglesDynamic(config, "draft", {
+      diff: {
+        nameStatusOutput: "M\tdocs/guide.md\nM\tREADME.md",
+      },
+    });
+    assert.equal(result.dynamicAnglesActive, true);
+    // mandatoryAngles always included
+    assert.ok(result.recommendedAngles.includes("pr-description"));
+    assert.ok(result.recommendedAngles.includes("correctness"));
+    assert.ok(result.recommendedAngles.includes("gate-evidence"));
+    // mandatoryAngles never appear in skipped
+    assert.ok(!result.skippedAngles.includes("pr-description"));
+    assert.ok(!result.skippedAngles.includes("correctness"));
+    assert.ok(!result.skippedAngles.includes("gate-evidence"));
+  });
+
+  test("mandatoryAngles also included in non-dynamic fallback", async () => {
+    const config = {
+      version: 1,
+      gates: {
+        draft: {
+          angles: ["scope"],
+          mandatoryAngles: ["pr-description"],
+          dynamicAngles: true,
+        },
+      },
+    };
+    // no diff → dynamicAnglesActive is false, but mandatoryAngles still in result via resolveGateAngles
+    const result = await resolveGateAnglesDynamic(config, "draft");
+    assert.equal(result.dynamicAnglesActive, false);
+    assert.deepEqual(result.recommendedAngles, ["pr-description", "scope"]);
+  });
+
+  test("backward compat: no mandatoryAngles = all angles are candidates", async () => {
+    const config = {
+      version: 1,
+      gates: {
+        draft: {
+          angles: ["scope", "coverage", "docs"],
+          dynamicAngles: true,
+        },
+      },
+    };
+    const result = await resolveGateAnglesDynamic(config, "draft", {
+      diff: {
+        nameStatusOutput: "M\tdocs/guide.md\nM\tREADME.md",
+      },
+    });
+    assert.equal(result.dynamicAnglesActive, true);
+    // No mandatoryAngles config, all angles are candidates for filtering
+    // docs change -> docs angle should be recommended
+    assert.ok(result.recommendedAngles.includes("docs"));
+    assert.ok(result.skippedAngles.includes("scope") || result.recommendedAngles.includes("scope"));
+    assert.ok(result.skippedAngles.includes("coverage") || result.recommendedAngles.includes("coverage"));
+  });
+
+  test("deduplicates mandatoryAngles and candidate pool recommendations", async () => {
+    const config = {
+      version: 1,
+      gates: {
+        draft: {
+          angles: ["scope", "pr-description"],
+          mandatoryAngles: ["pr-description", "correctness"],
+          dynamicAngles: true,
+        },
+      },
+    };
+    const result = await resolveGateAnglesDynamic(config, "draft", {
+      diff: {
+        nameStatusOutput: "M\tsrc/main.mjs",
+      },
+    });
+    // pr-description is in both mandatory and candidate pool — no duplicate
+    const occurrences = result.recommendedAngles.filter(a => a === "pr-description").length;
+    assert.equal(occurrences, 1);
+    assert.ok(result.recommendedAngles.includes("pr-description"));
   });
 });

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1686,7 +1686,45 @@ describe("role resolution", () => {
       assert.equal(result.success, false);
     });
 
-    test("resolveGateAngles filters when excludeAngles has angles not in angles list", () => {
+    test("GateConfig accepts valid mandatoryAngles", () => {
+      const config = {
+        version: 1,
+        gates: {
+          draft: {
+            angles: ["scope"],
+            mandatoryAngles: ["pr-description", "correctness"],
+          },
+        },
+      };
+      const result = FileConfigSchema.safeParse(config);
+      assert.equal(result.success, true);
+    });
+
+    test("GateConfig rejects mandatoryAngles with empty strings", () => {
+      const config = {
+        version: 1,
+        gates: {
+          draft: {
+            mandatoryAngles: [""],
+          },
+        },
+      };
+      const result = FileConfigSchema.safeParse(config);
+      assert.equal(result.success, false);
+    });
+
+    test("GateConfig accepts mandatoryAngles as optional (absent)", () => {
+      const config = {
+        version: 1,
+        gates: {
+          draft: { angles: ["scope"] },
+        },
+      };
+      const result = FileConfigSchema.safeParse(config);
+      assert.equal(result.success, true);
+    });
+
+        test("resolveGateAngles filters when excludeAngles has angles not in angles list", () => {
       const config = {
         version: 1,
         gates: {

--- a/schemas/dev-loop-config.schema.json
+++ b/schemas/dev-loop-config.schema.json
@@ -141,6 +141,14 @@
             "minLength": 1
           }
         },
+        "excludeAngles": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Angles to remove from the resolved angle list."
+        },
         "required": {
           "type": "boolean",
           "default": true
@@ -149,6 +157,16 @@
           "type": "boolean",
           "default": true,
           "description": "Draft gate CI prerequisite toggle. preApproval remains CI-gated regardless of this flag."
+        },
+        "blockCleanOnFindingSeverities": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["must-fix", "worth-fixing-now", "defer"]
+          },
+          "minItems": 1,
+          "default": ["must-fix"],
+          "description": "Finding severities that block a clean gate verdict."
         },
         "dynamicAngles": {
           "type": "boolean",

--- a/schemas/dev-loop-config.schema.json
+++ b/schemas/dev-loop-config.schema.json
@@ -154,6 +154,14 @@
           "type": "boolean",
           "default": false,
           "description": "Enable dynamic gate angle resolution based on PR diff analysis."
+        },
+        "mandatoryAngles": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Angles that always run regardless of diff-based dynamic selection."
         }
       }
     },

--- a/schemas/dev-loop-config.schema.json
+++ b/schemas/dev-loop-config.schema.json
@@ -147,6 +147,7 @@
             "type": "string",
             "minLength": 1
           },
+          "default": [],
           "description": "Angles to remove from the resolved angle list."
         },
         "required": {
@@ -179,6 +180,7 @@
             "type": "string",
             "minLength": 1
           },
+          "default": [],
           "description": "Angles that always run regardless of diff-based dynamic selection."
         }
       }


### PR DESCRIPTION
## Summary

Adds `mandatoryAngles` list to gate config — angles that always run regardless of diff-based dynamic selection.

### Changes
- **Schema**: `mandatoryAngles` field added to `GateConfig` zod schema
- **`resolveGateConfig()`**: exposes `mandatoryAngles`
- **`resolveGateAngles()`**: merges mandatory + candidate angles, deduplicates, respects `excludeAngles`
- **`resolveGateAnglesDynamic()`**: mandatory angles always included in `recommendedAngles`; only candidate pool (`angles`) gets dynamic filtering
- **JSON schema**: `mandatoryAngles` array field added to `gateConfig`
- **Tests**: 10 new tests covering merge, dedup, exclusion, dynamic resolution, backward compat

### Backward compat
When `mandatoryAngles` is absent, behavior is unchanged — all `angles` are treated as candidate pool for dynamic selection.

Closes #561