### PR TITLE
feat(#563): draft blocks review, human comments pause loop

### DIFF
--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -280,6 +280,17 @@ export async function checkForCopilotComments({ repo, pr }, { env = process.env,
   };
 }
 export async function performCopilotReviewRequest(options, { env = process.env, ghCommand = "gh" } = {}) {
+  const before = await fetchCopilotReviewState(options, { env, ghCommand });
+  if (before.prData?.isDraft) {
+    return {
+      ok: true,
+      status: SUPPRESSED_DRAFT_STATUS,
+      repo: options.repo,
+      pr: options.pr,
+      reviewer: "Copilot",
+      detail: "PR is in draft state; review requests are blocked until the PR is marked ready for review.",
+    };
+  }
   if (!env.GH_SEQUENCE_PATH) {
     const copilotCommentCheck = await checkForCopilotComments(options, { env, ghCommand });
     if (copilotCommentCheck.blocked) {
@@ -293,17 +304,6 @@ export async function performCopilotReviewRequest(options, { env = process.env, 
         violationCommentIds: copilotCommentCheck.violationCommentIds,
       };
     }
-  }
-  const before = await fetchCopilotReviewState(options, { env, ghCommand });
-  if (before.prData?.isDraft) {
-    return {
-      ok: true,
-      status: SUPPRESSED_DRAFT_STATUS,
-      repo: options.repo,
-      pr: options.pr,
-      reviewer: "Copilot",
-      detail: "PR is in draft state; review requests are blocked until the PR is marked ready for review.",
-    };
   }
   let maxRounds = 5; // Built-in default; overridden by config when loadable
   try {

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -15,6 +15,7 @@ import { loadDevLoopConfig, resolveRefinementConfig } from "@pi-dev-loops/core/c
 const BLOCKED_BY_COPILOT_COMMENT_STATUS = "blocked_by_copilot_comment";
 const SUPPRESSED_SAME_HEAD_CLEAN_STATUS = "suppressed_same_head_clean";
 const ROUND_CAP_REACHED_STATUS = "round_cap_reached";
+const SUPPRESSED_DRAFT_STATUS = "suppressed_draft";
 const REMOVED_FLAGS = new Set([
   "--force-rerequest-review",
 ]);
@@ -27,7 +28,7 @@ Debug:
   PI_DEV_LOOPS_DEBUG=1      Emit stderr traces when best-effort same-head clean
                             convergence detection falls back to unsuppressed behavior
 Output (stdout, JSON):
-  { "ok": true, "status": "requested"|"already-requested"|"unavailable"|"suppressed_same_head_clean"|"blocked_by_copilot_comment"|"round_cap_reached",
+  { "ok": true, "status": "requested"|"already-requested"|"unavailable"|"suppressed_same_head_clean"|"blocked_by_copilot_comment"|"round_cap_reached"|"suppressed_draft",
     "repo": "...", "pr": N, "reviewer": "Copilot", "detail"?: "...",
     "sameHeadCleanConverged"?: true, "violationCommentIds"?: [N], "completedRounds"?: N, "maxRounds"?: N }
 Request statuses:
@@ -37,6 +38,7 @@ Request statuses:
   suppressed_same_head_clean  Current head is already clean-converged; no new request is made
   blocked_by_copilot_comment  A non-Copilot PR comment contains @copilot or /copilot; delete the comment(s) first
   round_cap_reached    Maximum Copilot review rounds reached; no further re-requests will be made
+  suppressed_draft     PR is in draft state; review requests are blocked until the PR is marked ready for review
 Error output (stderr, JSON):
   Argument/usage errors:
     { "ok": false, "error": "...", "usage": "..." }
@@ -293,6 +295,16 @@ export async function performCopilotReviewRequest(options, { env = process.env, 
     }
   }
   const before = await fetchCopilotReviewState(options, { env, ghCommand });
+  if (before.prData?.isDraft) {
+    return {
+      ok: true,
+      status: SUPPRESSED_DRAFT_STATUS,
+      repo: options.repo,
+      pr: options.pr,
+      reviewer: "Copilot",
+      detail: "PR is in draft state; review requests are blocked until the PR is marked ready for review.",
+    };
+  }
   let maxRounds = 5; // Built-in default; overridden by config when loadable
   try {
     const { config, errors } = await loadDevLoopConfig();

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { parsePrNumber, requireOptionValue } from "../_cli-primitives.mjs";
+import { buildParseError, formatCliError, isCopilotLogin, isDirectCliRun, normalizeTimestamp } from "../_core-helpers.mjs";
+import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import path from "node:path";
 import { loadDevLoopConfig, resolveRefinement } from "@pi-dev-loops/core/config";
@@ -8,8 +8,8 @@ import { autoDetectSnapshot } from "./detect-copilot-loop-state.mjs";
 import { performCopilotReviewRequest } from "../github/request-copilot-review.mjs";
 import { applyConfirmedReviewRequest, interpretLoopState, STATE, summarizeLoopInterpretation } from "@pi-dev-loops/core/loop/copilot-loop-state";
 import { ensureAsyncRunnerOwnership } from "./_pr-runner-coordination.mjs";
-import { runChild } from "../_cli-primitives.mjs";
-import { isCopilotLogin, normalizeTimestamp } from "../_core-helpers.mjs";
+
+
 import {
   EXTERNAL_HEALTHY_WAIT_TIMEOUT_POLICY,
   enforceExternalHealthyWaitTimeout,
@@ -186,7 +186,7 @@ export async function detectRecentHumanComments({ repo, pr }, { env = process.en
     }
     const lines = result.stdout.trim().split("\n").filter(Boolean);
     if (lines.length === 0) {
-      return { paused: false, error: "no_comments_fetched", detail: "No comments returned from PR; human comment detection unavailable." };
+      return { paused: false };
     }
     let comments;
     try {
@@ -195,7 +195,7 @@ export async function detectRecentHumanComments({ repo, pr }, { env = process.en
       return { paused: false, error: "comment_parse_failed", detail: "Failed to parse PR comments JSON; human comment detection unavailable." };
     }
     if (!Array.isArray(comments)) {
-      return { paused: false, error: "unexpected_comment_format", detail: "Unexpected PR comments response format; human comment detection unavailable." };
+      return { paused: false };
     }
 
     // Find the most recent bot/Copilot comment timestamp (last subagent action)
@@ -225,9 +225,9 @@ export async function detectRecentHumanComments({ repo, pr }, { env = process.en
       if (authorType === "Bot" || isCopilotLogin(authorLogin)) {
         continue;
       }
-      // Skip if comment body suggests a system action (gate post, reply-resolve)
+      // Skip if comment body is a gate verdict comment (system action, not operator input)
       const body = typeof comment?.body === "string" ? comment.body : "";
-      if (body.includes("**draft_gate**") || body.includes("**pre_approval_gate**")) {
+      if (body.includes("Gate review:") || body.includes("**draft_gate**") || body.includes("**pre_approval_gate**")) {
         continue;
       }
       const createdAt = normalizeTimestamp(comment?.created_at);
@@ -307,13 +307,16 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
     );
   }
   const TERMINAL_STATES = new Set([STATE.NO_PR, STATE.DONE, STATE.BLOCKED_NEEDS_USER_DECISION]);
-  if (humanCommentCheck.paused && !TERMINAL_STATES.has(interpretation.state)) {
+  const humanCommentUnavailable = humanCommentCheck.error && !humanCommentCheck.paused;
+  if ((humanCommentCheck.paused || humanCommentUnavailable) && !TERMINAL_STATES.has(interpretation.state)) {
     return {
       ok: true,
       action: "stop",
       state: STATE.BLOCKED_NEEDS_USER_DECISION,
       allowedTransitions: [],
-      nextAction: "Human comment detected on PR since last subagent action; review the comment(s) before continuing the automated loop.",
+      nextAction: humanCommentCheck.paused
+        ? "Human comment detected on PR since last subagent action; review the comment(s) before continuing the automated loop."
+        : "Human comment detection unavailable (${humanCommentCheck.error}); review PR comments manually before continuing.",
       autoRerequestEligible: false,
       sameHeadCleanConverged: false,
       roundCapCleanEligible: false,
@@ -322,13 +325,16 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
       snapshot,
       runnerOwnership,
       humanCommentPause: {
-        reason: "human_comment_detected",
+        reason: humanCommentCheck.paused ? "human_comment_detected" : "human_comment_check_unavailable",
+        error: humanCommentCheck.error || undefined,
         humanComments: humanCommentCheck.humanComments,
         lastBotCommentAt: humanCommentCheck.lastBotCommentAt,
       },
       requestWatchContract: {
         action: "stop",
-        nextAction: "Human comment detected on PR since last subagent action; review the comment(s) before continuing the automated loop.",
+        nextAction: humanCommentCheck.paused
+        ? "Human comment detected on PR since last subagent action; review the comment(s) before continuing the automated loop."
+        : "Human comment detection unavailable (${humanCommentCheck.error}); review PR comments manually before continuing.",
         requestStatus: "none",
         routingState: "non_ready_state",
         watchEntryConfirmed: false,

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -182,29 +182,27 @@ export async function detectRecentHumanComments({ repo, pr }, { env = process.en
       env,
     );
     if (result.code !== 0) {
-      // If we can't fetch comments, don't block — best-effort detection
-      return { paused: false };
+      return { paused: false, error: "comment_fetch_failed", detail: "Failed to fetch PR comments; human comment detection unavailable." };
     }
     const lines = result.stdout.trim().split("\n").filter(Boolean);
     if (lines.length === 0) {
-      return { paused: false };
+      return { paused: false, error: "no_comments_fetched", detail: "No comments returned from PR; human comment detection unavailable." };
     }
     let comments;
     try {
       comments = lines.map((line) => JSON.parse(line));
     } catch {
-      return { paused: false };
+      return { paused: false, error: "comment_parse_failed", detail: "Failed to parse PR comments JSON; human comment detection unavailable." };
     }
     if (!Array.isArray(comments)) {
-      return { paused: false };
+      return { paused: false, error: "unexpected_comment_format", detail: "Unexpected PR comments response format; human comment detection unavailable." };
     }
 
     // Find the most recent bot/Copilot comment timestamp (last subagent action)
     let lastBotActionMs = null;
     for (const comment of comments) {
       const authorLogin = comment?.user?.login ?? "";
-      const authorType = comment?.user?.type ?? "";
-      if (authorType !== "Bot" && !isCopilotLogin(authorLogin)) {
+      if (!isCopilotLogin(authorLogin)) {
         continue;
       }
       const createdAt = normalizeTimestamp(comment?.created_at);
@@ -249,7 +247,7 @@ export async function detectRecentHumanComments({ repo, pr }, { env = process.en
       lastBotCommentAt: lastBotActionMs !== null ? new Date(lastBotActionMs).toISOString() : undefined,
     };
   } catch {
-    return { paused: false };
+    return { paused: false, error: "unexpected_error", detail: "Unexpected error during human comment detection." };
   }
 }
 
@@ -308,7 +306,8 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
       { env, ghCommand },
     );
   }
-  if (humanCommentCheck.paused) {
+  const TERMINAL_STATES = new Set([STATE.NO_PR, STATE.DONE, STATE.BLOCKED_NEEDS_USER_DECISION]);
+  if (humanCommentCheck.paused && !TERMINAL_STATES.has(interpretation.state)) {
     return {
       ok: true,
       action: "stop",
@@ -321,6 +320,7 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
       loopDisposition: "blocked",
       terminal: true,
       snapshot,
+      runnerOwnership,
       humanCommentPause: {
         reason: "human_comment_detected",
         humanComments: humanCommentCheck.humanComments,

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -174,7 +174,7 @@ export function parseHandoffCliArgs(argv) {
  * loop should pause for operator review.
  * Returns { paused: true, humanComments: [...] } when human comments need attention.
  */
-export async function detectRecentHumanComments({ repo, pr }, { env = process.env, ghCommand = "gh" } = {}) {
+export async function detectRecentHumanComments({ repo, pr, claimedAtMs }, { env = process.env, ghCommand = "gh" } = {}) {
   try {
     const result = await runChild(
       ghCommand,
@@ -211,9 +211,13 @@ export async function detectRecentHumanComments({ repo, pr }, { env = process.en
       }
     }
 
-    // If no bot comments found, we can't determine the last action — don't pause
+    // If no Copilot comments found, use the run's claim time as baseline when available
     if (lastBotActionMs === null) {
-      return { paused: false };
+      if (typeof claimedAtMs === "number" && claimedAtMs > 0) {
+        lastBotActionMs = claimedAtMs;
+      } else {
+        return { paused: false };
+      }
     }
 
     // Find human comments after the last bot action
@@ -302,7 +306,7 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
   let humanCommentCheck = { paused: false };
   if (env.PI_SUBAGENT_RUN_ID) {
     humanCommentCheck = await detectRecentHumanComments(
-      { repo: options.repo, pr: options.pr },
+      { repo: options.repo, pr: options.pr, claimedAtMs: runnerOwnership?.activeRun?.claimedAt ? new Date(runnerOwnership.activeRun.claimedAt).getTime() : undefined },
       { env, ghCommand },
     );
   }
@@ -316,7 +320,7 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
       allowedTransitions: [],
       nextAction: humanCommentCheck.paused
         ? "Human comment detected on PR since last subagent action; review the comment(s) before continuing the automated loop."
-        : "Human comment detection unavailable (${humanCommentCheck.error}); review PR comments manually before continuing.",
+        : `Human comment detection unavailable (${humanCommentCheck.error}); review PR comments manually before continuing.`,
       autoRerequestEligible: false,
       sameHeadCleanConverged: false,
       roundCapCleanEligible: false,
@@ -334,7 +338,7 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
         action: "stop",
         nextAction: humanCommentCheck.paused
         ? "Human comment detected on PR since last subagent action; review the comment(s) before continuing the automated loop."
-        : "Human comment detection unavailable (${humanCommentCheck.error}); review PR comments manually before continuing.",
+        : `Human comment detection unavailable (${humanCommentCheck.error}); review PR comments manually before continuing.`,
         requestStatus: "none",
         routingState: "non_ready_state",
         watchEntryConfirmed: false,

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -8,6 +8,8 @@ import { autoDetectSnapshot } from "./detect-copilot-loop-state.mjs";
 import { performCopilotReviewRequest } from "../github/request-copilot-review.mjs";
 import { applyConfirmedReviewRequest, interpretLoopState, STATE, summarizeLoopInterpretation } from "@pi-dev-loops/core/loop/copilot-loop-state";
 import { ensureAsyncRunnerOwnership } from "./_pr-runner-coordination.mjs";
+import { runChild } from "../_cli-primitives.mjs";
+import { isCopilotLogin, normalizeTimestamp } from "../_core-helpers.mjs";
 import {
   EXTERNAL_HEALTHY_WAIT_TIMEOUT_POLICY,
   enforceExternalHealthyWaitTimeout,
@@ -165,6 +167,92 @@ export function parseHandoffCliArgs(argv) {
   }
   return options;
 }
+/**
+ * Detect recent human (non-bot) comments on a PR since the last subagent action.
+ * Determines "last subagent action" by finding the most recent bot/Copilot comment
+ * on the PR issue comments. If a human comment exists after that timestamp, the
+ * loop should pause for operator review.
+ * Returns { paused: true, humanComments: [...] } when human comments need attention.
+ */
+export async function detectRecentHumanComments({ repo, pr }, { env = process.env, ghCommand = "gh" } = {}) {
+  try {
+    const result = await runChild(
+      ghCommand,
+      ["api", `repos/${repo}/issues/${pr}/comments`, "--paginate", "--jq", ".[]"],
+      env,
+    );
+    if (result.code !== 0) {
+      // If we can't fetch comments, don't block — best-effort detection
+      return { paused: false };
+    }
+    const lines = result.stdout.trim().split("\n").filter(Boolean);
+    if (lines.length === 0) {
+      return { paused: false };
+    }
+    let comments;
+    try {
+      comments = lines.map((line) => JSON.parse(line));
+    } catch {
+      return { paused: false };
+    }
+    if (!Array.isArray(comments)) {
+      return { paused: false };
+    }
+
+    // Find the most recent bot/Copilot comment timestamp (last subagent action)
+    let lastBotActionMs = null;
+    for (const comment of comments) {
+      const authorLogin = comment?.user?.login ?? "";
+      const authorType = comment?.user?.type ?? "";
+      if (authorType !== "Bot" && !isCopilotLogin(authorLogin)) {
+        continue;
+      }
+      const createdAt = normalizeTimestamp(comment?.created_at);
+      if (createdAt !== null && (lastBotActionMs === null || createdAt > lastBotActionMs)) {
+        lastBotActionMs = createdAt;
+      }
+    }
+
+    // If no bot comments found, we can't determine the last action — don't pause
+    if (lastBotActionMs === null) {
+      return { paused: false };
+    }
+
+    // Find human comments after the last bot action
+    const humanComments = [];
+    for (const comment of comments) {
+      const authorLogin = comment?.user?.login ?? "";
+      const authorType = comment?.user?.type ?? "";
+      // Skip bot authors (GitHub type "Bot") and Copilot
+      if (authorType === "Bot" || isCopilotLogin(authorLogin)) {
+        continue;
+      }
+      // Skip if comment body suggests a system action (gate post, reply-resolve)
+      const body = typeof comment?.body === "string" ? comment.body : "";
+      if (body.includes("**draft_gate**") || body.includes("**pre_approval_gate**")) {
+        continue;
+      }
+      const createdAt = normalizeTimestamp(comment?.created_at);
+      if (createdAt !== null && createdAt > lastBotActionMs) {
+        humanComments.push({
+          id: comment.id,
+          author: authorLogin,
+          createdAt: comment.created_at,
+          bodyPreview: body.slice(0, 200),
+        });
+      }
+    }
+
+    return {
+      paused: humanComments.length > 0,
+      humanComments: humanComments.length > 0 ? humanComments : undefined,
+      lastBotCommentAt: lastBotActionMs !== null ? new Date(lastBotActionMs).toISOString() : undefined,
+    };
+  } catch {
+    return { paused: false };
+  }
+}
+
 export async function runHandoff(options, { env = process.env, ghCommand = "gh" } = {}) {
   const runnerOwnership = await ensureAsyncRunnerOwnership({
     repo: options.repo,
@@ -210,6 +298,46 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
     ? resolveRefinement({ version: 1 })
     : resolveRefinement(config.config);
   let interpretation = interpretLoopState(snapshot, refinementConfig);
+
+  // Check for human comments since last subagent action
+  // Only active in async subagent context (PI_SUBAGENT_RUN_ID set)
+  let humanCommentCheck = { paused: false };
+  if (env.PI_SUBAGENT_RUN_ID) {
+    humanCommentCheck = await detectRecentHumanComments(
+      { repo: options.repo, pr: options.pr },
+      { env, ghCommand },
+    );
+  }
+  if (humanCommentCheck.paused) {
+    return {
+      ok: true,
+      action: "stop",
+      state: STATE.BLOCKED_NEEDS_USER_DECISION,
+      allowedTransitions: [],
+      nextAction: "Human comment detected on PR since last subagent action; review the comment(s) before continuing the automated loop.",
+      autoRerequestEligible: false,
+      sameHeadCleanConverged: false,
+      roundCapCleanEligible: false,
+      loopDisposition: "blocked",
+      terminal: true,
+      snapshot,
+      humanCommentPause: {
+        reason: "human_comment_detected",
+        humanComments: humanCommentCheck.humanComments,
+        lastBotCommentAt: humanCommentCheck.lastBotCommentAt,
+      },
+      requestWatchContract: {
+        action: "stop",
+        nextAction: "Human comment detected on PR since last subagent action; review the comment(s) before continuing the automated loop.",
+        requestStatus: "none",
+        routingState: "non_ready_state",
+        watchEntryConfirmed: false,
+        watchArgs: null,
+        stopState: "blocked",
+      },
+    };
+  }
+
   let reviewRequestStatus;
   const shouldRequestReview = options.watchStatus === undefined
     && (interpretation.state === STATE.PR_READY_NO_FEEDBACK

--- a/test/github/request-copilot-review.test.mjs
+++ b/test/github/request-copilot-review.test.mjs
@@ -669,3 +669,98 @@ test("checkForCopilotComments reports all violation comments when multiple found
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+test("request-copilot-review blocks request when PR is in draft state", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-draft-block-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+        stdout: '{"isDraft":true,"state":"OPEN","number":17,"reviews":[]}\n',
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      status: "suppressed_draft",
+      repo: "owner/repo",
+      pr: 17,
+      reviewer: "Copilot",
+      detail: "PR is in draft state; review requests are blocked until the PR is marked ready for review.",
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("request-copilot-review does not block request when PR is not draft", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-draft-ok-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+        stdout: '{"isDraft":false,"state":"OPEN","number":17,"reviews":[]}\n',
+      },
+      {
+        assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
+        stdout: "https://github.com/owner/repo/pull/17\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+        stdout: '{"isDraft":false,"state":"OPEN","number":17,"reviews":[]}\n',
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.equal(JSON.parse(result.stdout).status, "requested");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("request-copilot-review draft check takes precedence over round cap", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-draft-roundcap-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+        stdout: '{"isDraft":true,"state":"OPEN","number":17,"reviews":[{"id":"r-1","state":"COMMENTED","author":{"login":"copilot-pull-request-reviewer[bot]"},"commit":{"oid":"abc"}},{"id":"r-2","state":"COMMENTED","author":{"login":"copilot-pull-request-reviewer[bot]"},"commit":{"oid":"def"}},{"id":"r-3","state":"COMMENTED","author":{"login":"copilot-pull-request-reviewer[bot]"},"commit":{"oid":"ghi"}},{"id":"r-4","state":"COMMENTED","author":{"login":"copilot-pull-request-reviewer[bot]"},"commit":{"oid":"jkl"}},{"id":"r-5","state":"COMMENTED","author":{"login":"copilot-pull-request-reviewer[bot]"},"commit":{"oid":"mno"}}]}\n',
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.status, "suppressed_draft");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -1641,7 +1641,7 @@ test("detectRecentHumanComments skips Gate review: format gate comments", async 
 
     const { env } = await writeGhStubHelper(tempDir, [
       {
-        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "--paginate", "--jq", "."],
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "--paginate", "--jq", ".[]"],
         stdout: BOT_COMMENT + "\n" + HUMAN_GATE + "\n",
       },
     ]);

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+
 import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
@@ -1485,6 +1486,338 @@ test("copilot-pr-handoff stops cleanly when another run already owns the PR", as
     assert.equal(output.runnerOwnership.ok, false);
     assert.equal(output.runnerOwnership.error, "ownership_lost");
     assert.equal(output.runnerOwnership.activeRun.runId, "run-active");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Human comment detection (detectRecentHumanComments) unit tests
+// ---------------------------------------------------------------------------
+
+test("detectRecentHumanComments detects human comment after last bot comment", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-detect-"));
+
+  try {
+    const { detectRecentHumanComments } = await import("../../scripts/loop/copilot-pr-handoff.mjs");
+
+    const BOT_COMMENT = JSON.stringify({
+      id: 100,
+      body: "**draft_gate** verdict=clean",
+      user: { login: "copilot-pull-request-reviewer[bot]", type: "Bot" },
+      created_at: "2026-06-07T09:00:00Z",
+    });
+    const HUMAN_COMMENT = JSON.stringify({
+      id: 101,
+      body: "Let's reconsider the approach here.",
+      user: { login: "human-dev", type: "User" },
+      created_at: "2026-06-07T10:00:00Z",
+    });
+
+    const { env } = await writeGhStubHelper(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "--paginate", "--jq", ".[]"],
+        stdout: BOT_COMMENT + "\n" + HUMAN_COMMENT + "\n",
+      },
+    ]);
+
+    const result = await detectRecentHumanComments(
+      { repo: "owner/repo", pr: 17 },
+      { env },
+    );
+
+    assert.equal(result.paused, true);
+    assert.ok(result.humanComments, "expected humanComments array");
+    assert.equal(result.humanComments.length, 1);
+    assert.equal(result.humanComments[0].author, "human-dev");
+    assert.equal(result.humanComments[0].id, 101);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detectRecentHumanComments does not pause when human comment is before bot", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-before-bot-"));
+
+  try {
+    const { detectRecentHumanComments } = await import("../../scripts/loop/copilot-pr-handoff.mjs");
+
+    const BOT_COMMENT = JSON.stringify({
+      id: 100,
+      body: "**pre_approval_gate** verdict=clean",
+      user: { login: "copilot-pull-request-reviewer[bot]", type: "Bot" },
+      created_at: "2026-06-07T10:00:00Z",
+    });
+    const HUMAN_COMMENT = JSON.stringify({
+      id: 101,
+      body: "Looks good.",
+      user: { login: "human-dev", type: "User" },
+      created_at: "2026-06-07T09:00:00Z",
+    });
+
+    const { env } = await writeGhStubHelper(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "--paginate", "--jq", ".[]"],
+        stdout: BOT_COMMENT + "\n" + HUMAN_COMMENT + "\n",
+      },
+    ]);
+
+    const result = await detectRecentHumanComments(
+      { repo: "owner/repo", pr: 17 },
+      { env },
+    );
+
+    assert.equal(result.paused, false);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detectRecentHumanComments skips gate-pattern human comments", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-gate-"));
+
+  try {
+    const { detectRecentHumanComments } = await import("../../scripts/loop/copilot-pr-handoff.mjs");
+
+    const BOT_COMMENT = JSON.stringify({
+      id: 100,
+      body: "**draft_gate** verdict=clean",
+      user: { login: "copilot-pull-request-reviewer[bot]", type: "Bot" },
+      created_at: "2026-06-07T09:00:00Z",
+    });
+    const HUMAN_GATE = JSON.stringify({
+      id: 101,
+      body: "**pre_approval_gate** manual check done",
+      user: { login: "human-dev", type: "User" },
+      created_at: "2026-06-07T10:00:00Z",
+    });
+
+    const { env } = await writeGhStubHelper(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "--paginate", "--jq", ".[]"],
+        stdout: BOT_COMMENT + "\n" + HUMAN_GATE + "\n",
+      },
+    ]);
+
+    const result = await detectRecentHumanComments(
+      { repo: "owner/repo", pr: 17 },
+      { env },
+    );
+
+    assert.equal(result.paused, false);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detectRecentHumanComments returns false when only bots commented", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-bots-"));
+
+  try {
+    const { detectRecentHumanComments } = await import("../../scripts/loop/copilot-pr-handoff.mjs");
+
+    const BOT1 = JSON.stringify({
+      id: 100,
+      body: "**draft_gate** verdict=clean",
+      user: { login: "copilot-pull-request-reviewer[bot]", type: "Bot" },
+      created_at: "2026-06-07T09:00:00Z",
+    });
+    const BOT2 = JSON.stringify({
+      id: 101,
+      body: "**pre_approval_gate** verdict=clean",
+      user: { login: "copilot-pull-request-reviewer[bot]", type: "Bot" },
+      created_at: "2026-06-07T10:00:00Z",
+    });
+
+    const { env } = await writeGhStubHelper(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "--paginate", "--jq", ".[]"],
+        stdout: BOT1 + "\n" + BOT2 + "\n",
+      },
+    ]);
+
+    const result = await detectRecentHumanComments(
+      { repo: "owner/repo", pr: 17 },
+      { env },
+    );
+
+    assert.equal(result.paused, false);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detectRecentHumanComments returns false when no bot baseline exists", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-no-baseline-"));
+
+  try {
+    const { detectRecentHumanComments } = await import("../../scripts/loop/copilot-pr-handoff.mjs");
+
+    const HUMAN_COMMENT = JSON.stringify({
+      id: 101,
+      body: "Just a regular comment.",
+      user: { login: "human-dev", type: "User" },
+      created_at: "2026-06-07T10:00:00Z",
+    });
+
+    const { env } = await writeGhStubHelper(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "--paginate", "--jq", ".[]"],
+        stdout: HUMAN_COMMENT + "\n",
+      },
+    ]);
+
+    const result = await detectRecentHumanComments(
+      { repo: "owner/repo", pr: 17 },
+      { env },
+    );
+
+    assert.equal(result.paused, false);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detectRecentHumanComments detects multiple human comments after last bot", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-multi-"));
+
+  try {
+    const { detectRecentHumanComments } = await import("../../scripts/loop/copilot-pr-handoff.mjs");
+
+    const BOT = JSON.stringify({
+      id: 100,
+      body: "bot action",
+      user: { login: "copilot-pull-request-reviewer[bot]", type: "Bot" },
+      created_at: "2026-06-07T09:00:00Z",
+    });
+    const HUMAN1 = JSON.stringify({
+      id: 101,
+      body: "First human note.",
+      user: { login: "dev-1", type: "User" },
+      created_at: "2026-06-07T10:00:00Z",
+    });
+    const HUMAN2 = JSON.stringify({
+      id: 102,
+      body: "Second human note.",
+      user: { login: "dev-2", type: "User" },
+      created_at: "2026-06-07T11:00:00Z",
+    });
+
+    const { env } = await writeGhStubHelper(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "--paginate", "--jq", ".[]"],
+        stdout: BOT + "\n" + HUMAN1 + "\n" + HUMAN2 + "\n",
+      },
+    ]);
+
+    const result = await detectRecentHumanComments(
+      { repo: "owner/repo", pr: 17 },
+      { env },
+    );
+
+    assert.equal(result.paused, true);
+    assert.equal(result.humanComments.length, 2);
+    assert.equal(result.humanComments[0].author, "dev-1");
+    assert.equal(result.humanComments[1].author, "dev-2");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("copilot-pr-handoff skips human comment check when PI_SUBAGENT_RUN_ID not set", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-skip-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: OPEN_PR + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: EMPTY_THREADS + "\n",
+      },
+    ]);
+
+    // PI_SUBAGENT_RUN_ID is "" (empty/falsy) from writeGhStub defaults
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.action, "watch");
+    // No humanCommentPause field since check was skipped
+    assert.equal(output.humanCommentPause, undefined);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+
+
+test("copilot-pr-handoff runs human comment check when PI_SUBAGENT_RUN_ID is set", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-active-"));
+
+  // Clean up any stale runner coordination state from other tests
+  try { await rm(".pi/runner-coordination", { recursive: true, force: true }); } catch {}
+  try {
+    const HUMAN_COMMENT = JSON.stringify({
+      id: 200,
+      body: "Please stop and reconsider the approach.",
+      user: { login: "human-dev", type: "User" },
+      created_at: "2026-06-07T10:00:00Z",
+    });
+    const BOT_COMMENT = JSON.stringify({
+      id: 199,
+      body: "**draft_gate** verdict=clean",
+      user: { login: "copilot-pull-request-reviewer[bot]", type: "Bot" },
+      created_at: "2026-06-07T09:00:00Z",
+    });
+
+    const { env } = await writeGhStubHelper(tempDir, [
+      // detect: pr view
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: OPEN_PR + "\n",
+      },
+      // detect: requested_reviewers
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n',
+      },
+      // detect: graphql threads
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: EMPTY_THREADS + "\n",
+      },
+      // human comment check
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "--paginate", "--jq", ".[]"],
+        stdout: BOT_COMMENT + "\n" + HUMAN_COMMENT + "\n",
+      },
+    ]);
+
+    const runEnv = { ...env, PI_SUBAGENT_RUN_ID: "run-test-human-pause" };
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env: runEnv });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.action, "stop");
+    assert.equal(output.state, "blocked_needs_user_decision");
+    assert.equal(output.loopDisposition, "blocked");
+    assert.equal(output.terminal, true);
+    assert.ok(output.humanCommentPause, "expected humanCommentPause field");
+    assert.equal(output.humanCommentPause.reason, "human_comment_detected");
+    assert.equal(output.humanCommentPause.humanComments.length, 1);
+    assert.equal(output.humanCommentPause.humanComments[0].author, "human-dev");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -1897,7 +1897,7 @@ test("copilot-pr-handoff stops when human comment check fails with non-zero exit
       },
       // human comment check: gh API fails
       {
-        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "--paginate", "--jq", "."],
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "--paginate", "--jq", ".[]"],
         stdout: "",
         stderr: "gh: API error",
         exitCode: 1,
@@ -1965,7 +1965,7 @@ test("copilot-pr-handoff stops when human comment check fails with invalid JSON"
       },
       // human comment check: returns invalid JSON
       {
-        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "--paginate", "--jq", "."],
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "--paginate", "--jq", ".[]"],
         stdout: "not valid json { broken\n",
       },
       // performCopilotReviewRequest → fetchCopilotReviewIds
@@ -2003,8 +2003,7 @@ test("copilot-pr-handoff stops when human comment check fails with invalid JSON"
     assert.equal(output.terminal, true);
     assert.ok(output.humanCommentPause, "expected humanCommentPause field");
     assert.equal(output.humanCommentPause.reason, "human_comment_check_unavailable");
-    // Note: comment_parse_failed tested at unit level in detectRecentHumanComments tests
-    assert.equal(output.humanCommentPause.error, "comment_fetch_failed");
+    assert.equal(output.humanCommentPause.error, "comment_parse_failed");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -744,6 +744,11 @@ if (args[0] === "pr" && args[1] === "edit" && args.includes("--add-reviewer") &&
   process.exit(0);
 }
 
+if (args[0] === "api" && args[1] && args[1].includes("issues/") && args[1].includes("/comments")) {
+  // No comments — human comment check returns no pause
+  process.exit(0);
+}
+
 process.stderr.write("unexpected gh args: " + args.join(" ") + "\\n");
 process.exit(97);
 `,
@@ -1034,6 +1039,11 @@ if (args[0] === "pr" && args[1] === "view" && args.includes("--json") && args.in
 if (args[0] === "pr" && args[1] === "edit" && args.includes("--add-reviewer") && args.includes("@copilot")) {
   writeFileSync(requestedStatePath, "requested\\n");
   write("https://github.com/owner/repo/pull/17\\n");
+  process.exit(0);
+}
+
+if (args[0] === "api" && args[1] && args[1].includes("issues/") && args[1].includes("/comments")) {
+  // No comments — human comment check returns no pause
   process.exit(0);
 }
 
@@ -1595,6 +1605,43 @@ test("detectRecentHumanComments skips gate-pattern human comments", async () => 
     const { env } = await writeGhStubHelper(tempDir, [
       {
         assertArgs: ["api", "repos/owner/repo/issues/17/comments", "--paginate", "--jq", ".[]"],
+        stdout: BOT_COMMENT + "\n" + HUMAN_GATE + "\n",
+      },
+    ]);
+
+    const result = await detectRecentHumanComments(
+      { repo: "owner/repo", pr: 17 },
+      { env },
+    );
+
+    assert.equal(result.paused, false);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detectRecentHumanComments skips Gate review: format gate comments", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-gate-format-"));
+
+  try {
+    const { detectRecentHumanComments } = await import("../../scripts/loop/copilot-pr-handoff.mjs");
+
+    const BOT_COMMENT = JSON.stringify({
+      id: 100,
+      body: "Gate review: draft_gate\n\nReviewed head SHA: abc1234\nVerdict: clean",
+      user: { login: "copilot-pull-request-reviewer[bot]", type: "Bot" },
+      created_at: "2026-06-07T09:00:00Z",
+    });
+    const HUMAN_GATE = JSON.stringify({
+      id: 101,
+      body: "Gate review: pre_approval_gate\n\nReviewed head SHA: abc1234\nVerdict: clean",
+      user: { login: "human-dev", type: "User" },
+      created_at: "2026-06-07T10:00:00Z",
+    });
+
+    const { env } = await writeGhStubHelper(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "--paginate", "--jq", "."],
         stdout: BOT_COMMENT + "\n" + HUMAN_GATE + "\n",
       },
     ]);

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -1867,3 +1867,145 @@ test("copilot-pr-handoff runs human comment check when PI_SUBAGENT_RUN_ID is set
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+test("copilot-pr-handoff stops when human comment check fails with non-zero exit", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-fetch-fail-"));
+
+  try {
+    const BOT_COMMENT = JSON.stringify({
+      id: 199,
+      body: "Gate review: draft_gate verdict=clean",
+      user: { login: "copilot-pull-request-reviewer[bot]", type: "Bot" },
+      created_at: "2026-06-07T09:00:00Z",
+    });
+
+    const { env } = await writeGhStubHelper(tempDir, [
+      // detect: pr view
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: OPEN_PR + "\n",
+      },
+      // detect: requested_reviewers
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      // detect: graphql threads
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: EMPTY_THREADS + "\n",
+      },
+      // human comment check: gh API fails
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "--paginate", "--jq", "."],
+        stdout: "",
+        stderr: "gh: API error",
+        exitCode: 1,
+      },
+      // performCopilotReviewRequest → fetchCopilotReviewIds
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+        stdout: OPEN_PR + "\n",
+      },
+      // performCopilotReviewRequest → edit reviewer
+      {
+        assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
+        stdout: "https://github.com/owner/repo/pull/17\n",
+      },
+      // performCopilotReviewRequest → confirm requested_reviewers
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n',
+      },
+      // performCopilotReviewRequest → final pr view
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+        stdout: OPEN_PR + "\n",
+      },
+    ], { matchMode: "claims" });
+
+    const runEnv = { ...env, PI_SUBAGENT_RUN_ID: "run-test-fetch-fail" };
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { cwd: tempDir, env: runEnv });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.action, "stop");
+    assert.equal(output.state, "blocked_needs_user_decision");
+    assert.equal(output.loopDisposition, "blocked");
+    assert.equal(output.terminal, true);
+    assert.ok(output.humanCommentPause, "expected humanCommentPause field");
+    assert.equal(output.humanCommentPause.reason, "human_comment_check_unavailable");
+    assert.equal(output.humanCommentPause.error, "comment_fetch_failed");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("copilot-pr-handoff stops when human comment check fails with invalid JSON", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-parse-fail-"));
+
+  try {
+    const { env } = await writeGhStubHelper(tempDir, [
+      // detect: pr view
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: OPEN_PR + "\n",
+      },
+      // detect: requested_reviewers
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      // detect: graphql threads
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: EMPTY_THREADS + "\n",
+      },
+      // human comment check: returns invalid JSON
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "--paginate", "--jq", "."],
+        stdout: "not valid json { broken\n",
+      },
+      // performCopilotReviewRequest → fetchCopilotReviewIds
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+        stdout: OPEN_PR + "\n",
+      },
+      // performCopilotReviewRequest → edit reviewer
+      {
+        assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
+        stdout: "https://github.com/owner/repo/pull/17\n",
+      },
+      // performCopilotReviewRequest → confirm requested_reviewers  
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n',
+      },
+      // performCopilotReviewRequest → final pr view
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+        stdout: OPEN_PR + "\n",
+      },
+    ], { matchMode: "claims", logCalls: true });
+
+    const runEnv = { ...env, PI_SUBAGENT_RUN_ID: "run-test-parse-fail" };
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { cwd: tempDir, env: runEnv });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.action, "stop");
+    assert.equal(output.state, "blocked_needs_user_decision");
+    assert.equal(output.loopDisposition, "blocked");
+    assert.equal(output.terminal, true);
+    assert.ok(output.humanCommentPause, "expected humanCommentPause field");
+    assert.equal(output.humanCommentPause.reason, "human_comment_check_unavailable");
+    // Note: comment_parse_failed tested at unit level in detectRecentHumanComments tests
+    assert.equal(output.humanCommentPause.error, "comment_fetch_failed");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -1764,8 +1764,6 @@ test("copilot-pr-handoff skips human comment check when PI_SUBAGENT_RUN_ID not s
 test("copilot-pr-handoff runs human comment check when PI_SUBAGENT_RUN_ID is set", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-active-"));
 
-  // Clean up any stale runner coordination state from other tests
-  try { await rm(".pi/runner-coordination", { recursive: true, force: true }); } catch {}
   try {
     const HUMAN_COMMENT = JSON.stringify({
       id: 200,
@@ -1804,7 +1802,7 @@ test("copilot-pr-handoff runs human comment check when PI_SUBAGENT_RUN_ID is set
     ]);
 
     const runEnv = { ...env, PI_SUBAGENT_RUN_ID: "run-test-human-pause" };
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env: runEnv });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { cwd: tempDir, env: runEnv });
 
     assert.equal(result.code, 0);
     assert.equal(result.stderr, "");


### PR DESCRIPTION
## Summary

Two fixes for subagent discipline:
1. Draft state blocks Copilot review request
2. Human comments on PR pause automated loop

## Changes
- request-copilot-review.mjs: +13 lines, blocks review when isDraft
- copilot-pr-handoff.mjs: +40 lines, detectRecentHumanComments()
- Tests: +11 (3 draft block, 8 human pause)

Closes #563