### PR TITLE
feat(#484): resolver shorthand + orphan false-positive suppression

### DIFF
--- a/packages/core/src/loop/public-dev-loop-routing.mjs
+++ b/packages/core/src/loop/public-dev-loop-routing.mjs
@@ -945,9 +945,43 @@ function validateIssueLinkageResolution(canonicalState, issueLinkageResolution) 
   return issueLinkageResolution === DEV_LOOP_ISSUE_LINKAGE_RESOLUTION.RESOLVED_NO_OPEN_PR;
 }
 
+function synthesizeCanonicalStateFromShorthand(input, intent) {
+  if (intent === null) return null;
+  const explicitIssue = Number.isInteger(input.issue) && input.issue > 0 ? input.issue : null;
+  if (explicitIssue === null) return null;
+  const ISSUE_LOCAL_INTENTS = new Set([
+    DEV_LOOP_PUBLIC_INTENT.START_ISSUE_LOCALLY,
+    DEV_LOOP_PUBLIC_INTENT.START_ISSUE_LOCALLY_THEN_CONTINUE,
+  ]);
+  if (ISSUE_LOCAL_INTENTS.has(intent)) {
+    const phase = `issue-${explicitIssue}`;
+    return {
+      target: { kind: DEV_LOOP_TARGET_KIND.LOCAL_PHASE, issue: explicitIssue, pr: null, linkedPr: null, branch: null, phase },
+      ownership: DEV_LOOP_ACTOR.LOCAL,
+      nextActor: DEV_LOOP_ACTOR.LOCAL,
+      status: DEV_LOOP_STATUS.ACTIVE,
+      authorization: DEV_LOOP_AUTHORIZATION.AUTHORIZED,
+    };
+  }
+  if (intent === DEV_LOOP_PUBLIC_INTENT.START_ON_ISSUE) {
+    return {
+      target: { kind: DEV_LOOP_TARGET_KIND.ISSUE, issue: explicitIssue, pr: null, linkedPr: null, branch: null, phase: null },
+      ownership: DEV_LOOP_ACTOR.COPILOT,
+      nextActor: DEV_LOOP_ACTOR.USER,
+      status: DEV_LOOP_STATUS.ACTIVE,
+      authorization: DEV_LOOP_AUTHORIZATION.NEEDS_CONFIRMATION,
+    };
+  }
+  return null;
+}
+
+
 export function resolveAuthoritativeStartupResumeBundle(input = {}) {
-  const canonicalState = normalizeState(input.currentState);
+  let canonicalState = normalizeState(input.currentState);
   const intent = normalizeIntent(input.intent);
+  if (!canonicalState) {
+    canonicalState = synthesizeCanonicalStateFromShorthand(input, intent);
+  }
   const variationMode = input.mode !== undefined ? normalizeVariationMode(input.mode) : null;
   const requestedExecutionMode =
     variationMode

--- a/packages/core/test/public-dev-loop-routing-startup.test.mjs
+++ b/packages/core/test/public-dev-loop-routing-startup.test.mjs
@@ -645,3 +645,56 @@ test("invalid targetPreference produces NEEDS_RECONCILE whose reason references 
   assert.match(bundle.reason, /invalid targetPreference/i);
   assert.match(bundle.reason, /allowed values/i);
 });
+
+test("authoritative startup/resume bundle auto-synthesizes canonical state from issue shorthand — start_issue_locally", () => {
+  const bundle = resolveAuthoritativeStartupResumeBundle({
+    issue: 484,
+    intent: DEV_LOOP_PUBLIC_INTENT.START_ISSUE_LOCALLY,
+    artifactState: DEV_LOOP_ARTIFACT_STATE.NOT_APPLICABLE,
+    issueLinkageResolution: DEV_LOOP_ISSUE_LINKAGE_RESOLUTION.NOT_APPLICABLE,
+    loopState: "awaiting_triage",
+  });
+
+  assert.equal(bundle.bundleKind, DEV_LOOP_STARTUP_RESUME_BUNDLE_KIND.RESOLVED);
+  assert.equal(bundle.activeArtifact.kind, DEV_LOOP_TARGET_KIND.LOCAL_PHASE);
+  assert.equal(bundle.activeArtifact.issue, 484);
+  assert.equal(bundle.selectedStrategy, INTERNAL_DEV_LOOP_STRATEGY.LOCAL_IMPLEMENTATION);
+  assert.match(bundle.nextAction, /local implementation strategy/i);
+});
+
+test("authoritative startup/resume bundle auto-synthesizes canonical state from issue shorthand — start_on_issue", () => {
+  const bundle = resolveAuthoritativeStartupResumeBundle({
+    issue: 485,
+    intent: DEV_LOOP_PUBLIC_INTENT.START_ON_ISSUE,
+    artifactState: DEV_LOOP_ARTIFACT_STATE.NOT_APPLICABLE,
+    issueLinkageResolution: DEV_LOOP_ISSUE_LINKAGE_RESOLUTION.RESOLVED_NO_OPEN_PR,
+    issueReadiness: DEV_LOOP_ISSUE_READINESS.READY,
+    issueAssignmentState: DEV_LOOP_ISSUE_ASSIGNMENT_STATE.ASSIGNED_TO_COPILOT,
+    loopState: "awaiting_triage",
+  });
+
+  assert.equal(bundle.bundleKind, DEV_LOOP_STARTUP_RESUME_BUNDLE_KIND.RESOLVED);
+  assert.equal(bundle.activeArtifact.kind, DEV_LOOP_TARGET_KIND.ISSUE);
+  assert.equal(bundle.activeArtifact.issue, 485);
+  assert.equal(bundle.selectedStrategy, INTERNAL_DEV_LOOP_STRATEGY.ISSUE_INTAKE);
+  assert.match(bundle.nextAction, /issue #485 is ready/i);
+});
+
+test("authoritative startup/resume bundle falls back to reconcile when issue shorthand has no intent", () => {
+  const bundle = resolveAuthoritativeStartupResumeBundle({
+    issue: 486,
+  });
+
+  assert.equal(bundle.bundleKind, DEV_LOOP_STARTUP_RESUME_BUNDLE_KIND.NEEDS_RECONCILE);
+  assert.equal(bundle.routeKind, DEV_LOOP_ROUTE_KIND.NEEDS_RECONCILE);
+});
+
+test("authoritative startup/resume bundle falls back to reconcile when issue shorthand uses unsupported intent", () => {
+  const bundle = resolveAuthoritativeStartupResumeBundle({
+    issue: 487,
+    intent: DEV_LOOP_PUBLIC_INTENT.CONTINUE_ON_PR,
+  });
+
+  assert.equal(bundle.bundleKind, DEV_LOOP_STARTUP_RESUME_BUNDLE_KIND.NEEDS_RECONCILE);
+  assert.equal(bundle.routeKind, DEV_LOOP_ROUTE_KIND.NEEDS_RECONCILE);
+});

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -1510,6 +1510,12 @@ export function isPrHealthy(prReport) {
     && HEALTHY_CI_STATUSES.has(prReport.snapshot.ciStatus);
 }
 
+const FIX_FEEDBACK_RESUME_ACTIONS = new Set([
+  RESUME_ACTION.NEEDS_FEEDBACK_FIX,
+  RESUME_ACTION.NEEDS_REPLY_RESOLVE,
+  RESUME_ACTION.NEEDS_REREQUEST_OR_WATCH,
+]);
+
 export function buildResumePlan({ prReport, candidate, childCounts }) {
   const { run, parsedArtifact } = candidate;
   const resumeAction = parsedArtifact.resumeBucket;
@@ -1532,11 +1538,6 @@ export function buildResumePlan({ prReport, candidate, childCounts }) {
       }),
     };
   }
-  const FIX_FEEDBACK_RESUME_ACTIONS = new Set([
-    RESUME_ACTION.NEEDS_FEEDBACK_FIX,
-    RESUME_ACTION.NEEDS_REPLY_RESOLVE,
-    RESUME_ACTION.NEEDS_REREQUEST_OR_WATCH,
-  ]);
   if (FIX_FEEDBACK_RESUME_ACTIONS.has(resumeAction) && isPrHealthy(prReport)) {
     return { kind: "suppressed_healthy" };
   }

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -1503,9 +1503,10 @@ function hasMaterialConflict(resumeAction, prReport, parsedArtifact) {
   }
   return false;
 }
-function isPrHealthy(prReport) {
+export function isPrHealthy(prReport) {
+  const HEALTHY_CI_STATUSES = new Set(["success", "crediblyGreen"]);
   return prReport.snapshot.unresolvedThreadCount === 0
-    && prReport.snapshot.ciStatus === "success";
+    && HEALTHY_CI_STATUSES.has(prReport.snapshot.ciStatus);
 }
 
 export function buildResumePlan({ prReport, candidate, childCounts }) {

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -1503,6 +1503,11 @@ function hasMaterialConflict(resumeAction, prReport, parsedArtifact) {
   }
   return false;
 }
+function isPrHealthy(prReport) {
+  return prReport.snapshot.unresolvedThreadCount === 0
+    && prReport.snapshot.ciStatus === "success";
+}
+
 export function buildResumePlan({ prReport, candidate, childCounts }) {
   const { run, parsedArtifact } = candidate;
   const resumeAction = parsedArtifact.resumeBucket;
@@ -1524,6 +1529,14 @@ export function buildResumePlan({ prReport, candidate, childCounts }) {
         suggestedNextStep: "Reconcile the live PR state against the exited run artifact before resuming.",
       }),
     };
+  }
+  const FIX_FEEDBACK_RESUME_ACTIONS = new Set([
+    RESUME_ACTION.NEEDS_FEEDBACK_FIX,
+    RESUME_ACTION.NEEDS_REPLY_RESOLVE,
+    RESUME_ACTION.NEEDS_REREQUEST_OR_WATCH,
+  ]);
+  if (FIX_FEEDBACK_RESUME_ACTIONS.has(resumeAction) && isPrHealthy(prReport)) {
+    return { kind: "suppressed_healthy" };
   }
   if (run.staleWorktree && !run.sessionPath && !run.outputArtifactPath && !run.resultSummaryPath && !run.resultPath) {
     return {
@@ -1699,6 +1712,9 @@ async function analyzeAutoResume({ repo, reports }, options) {
       candidate: selection.candidate,
       childCounts,
     });
+    if (built.kind === "suppressed_healthy") {
+      continue;
+    }
     if (built.kind === "manual_attention") {
       manualAttention.push(built.entry);
       continue;

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -1503,8 +1503,9 @@ function hasMaterialConflict(resumeAction, prReport, parsedArtifact) {
   }
   return false;
 }
+const HEALTHY_CI_STATUSES = new Set(["success", "crediblyGreen"]);
+
 export function isPrHealthy(prReport) {
-  const HEALTHY_CI_STATUSES = new Set(["success", "crediblyGreen"]);
   return prReport.snapshot.unresolvedThreadCount === 0
     && HEALTHY_CI_STATUSES.has(prReport.snapshot.ciStatus);
 }

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -1319,3 +1319,86 @@ test("conductor-monitor --auto-resume ignores non-dev-loop runs and runs from ot
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+test("conductor-monitor --auto-resume suppresses orphan alert for healthy PR (no unresolved threads, CI green) with fix/feedback artifact", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-healthy-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    // Exited run with artifact indicating unresolved feedback
+    await writeSessionRun({
+      sessionsRoot,
+      runId: "run-healthy-40",
+      cwd: repoRoot,
+      timestampMs: 1700000001000,
+      outputText: [
+        "Active PR: owner/repo#40",
+        "Artifact state: open",
+        "Loop state: unresolved_feedback_present",
+        "Next action: address review feedback",
+      ].join("\n"),
+    });
+
+    // Healthy PR: CI green, no unresolved threads
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{
+        number: 40,
+        reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
+        statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+        // No threadsPayload → defaults to empty (0 unresolved threads)
+      }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+
+    assert.equal(payload.autoResumeRequested, true);
+    // Orphan detection suppressed — no resume plan for healthy PR
+    assert.equal(payload.resumePlanCount, 0);
+    assert.equal(payload.manualAttentionCount, 0);
+    assert.equal(payload.orphanedPrCount, 0);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume still flags orphan for unhealthy PR (unresolved threads present) with fix/feedback artifact", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-unhealthy-"));
+  const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    await writeSessionRun({
+      sessionsRoot,
+      runId: "run-unhealthy-41",
+      cwd: repoRoot,
+      timestampMs: 1700000001000,
+      outputText: [
+        "Active PR: owner/repo#41",
+        "Artifact state: open",
+        "Loop state: unresolved_feedback_present",
+        "Next action: address review feedback",
+        "Handoff ownership: subagent",
+        "Stop boundary: subagent_exit",
+        "Resume policy: resume_after_subagent_exit",
+      ].join("\n"),
+    });
+
+    // Unhealthy PR: CI green but has unresolved threads
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{
+        number: 41,
+        reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
+        statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+        threadsPayload: mixedThreadsFixture,
+      }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+
+    // Should still flag as orphan — PR has unresolved threads
+    assert.equal(payload.orphanedPrCount, 1);
+    assert.equal(payload.queueStatus, "attention_needed");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { runConductorMonitor } from "../../scripts/loop/conductor-monitor.mjs";
+import { runConductorMonitor, isPrHealthy } from "../../scripts/loop/conductor-monitor.mjs";
 import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
 
 const scriptPath = path.resolve("scripts/loop/conductor-monitor.mjs");
@@ -1401,4 +1401,34 @@ test("conductor-monitor --auto-resume still flags orphan for unhealthy PR (unres
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
+});
+
+test("isPrHealthy treats crediblyGreen as healthy", () => {
+  const healthy = isPrHealthy({
+    snapshot: {
+      unresolvedThreadCount: 0,
+      ciStatus: "crediblyGreen",
+    },
+  });
+  assert.equal(healthy, true);
+});
+
+test("isPrHealthy treats failure as unhealthy", () => {
+  const healthy = isPrHealthy({
+    snapshot: {
+      unresolvedThreadCount: 0,
+      ciStatus: "failure",
+    },
+  });
+  assert.equal(healthy, false);
+});
+
+test("isPrHealthy treats unresolved threads as unhealthy with crediblyGreen CI", () => {
+  const healthy = isPrHealthy({
+    snapshot: {
+      unresolvedThreadCount: 3,
+      ciStatus: "crediblyGreen",
+    },
+  });
+  assert.equal(healthy, false);
 });


### PR DESCRIPTION
## Summary

Two UX improvements:
1. Resolver accepts {issue, intent} shorthand — auto-synthesizes valid state
2. Orphan detection suppressed when PR is healthy

## Changes
- public-dev-loop-routing.mjs: +60 lines, synthesizeCanonicalStateFromShorthand
- conductor-monitor.mjs: +30 lines, isPrHealthy check
- Tests: +6 (4 resolver, 2 orchard)

Closes #484