### PR TITLE
feat(#483): CLI retry wrapper for usage/flag error self-recovery

### DIFF
--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -12,6 +12,7 @@ import {
   summarizeChecks,
   DEV_LOOP_CHECK_IDS,
 } from "../lib/dev-loops-core.mjs";
+import { isUsageError, buildCorrectedArgs } from "../packages/core/src/cli/retry-wrapper.mjs";
 
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 
@@ -319,6 +320,18 @@ export async function runCli({
       const result = spawnSync("node", [fromTop.scriptPath, ...scriptArgs], {
         cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
       });
+      // Retry on usage/flag errors: parse usage for valid flags, retry once (#483)
+      if (result.status !== 0 && isUsageError(result.stderr)) {
+        const correctedArgs = buildCorrectedArgs(scriptArgs, result.stderr);
+        if (correctedArgs && correctedArgs.length > 0) {
+          const retryResult = spawnSync("node", [fromTop.scriptPath, ...correctedArgs], {
+            cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+          });
+          if (retryResult.stdout) stdout.write(retryResult.stdout);
+          if (retryResult.stderr) stderr.write(retryResult.stderr);
+          return retryResult.status ?? (retryResult.signal ? 1 : retryResult.error ? 1 : 0);
+        }
+      }
       if (result.stdout) stdout.write(result.stdout);
       if (result.stderr) stderr.write(result.stderr);
       return result.status ?? (result.signal ? 1 : result.error ? 1 : 0);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,8 @@
     "./analysis": "./src/analysis/index.mjs",
     "./cli/primitives": "./src/cli/primitives.mjs",
     "./cli/helpers": "./src/cli/helpers.mjs",
-    "./cli/subcommand-runner": "./src/cli/subcommand-runner.mjs"
+    "./cli/subcommand-runner": "./src/cli/subcommand-runner.mjs",
+    "./cli/retry-wrapper": "./src/cli/retry-wrapper.mjs"
   },
   "bin": {
     "pi-dev-loops-log-bash-exit-1": "./bin/log-bash-exit-1.mjs",

--- a/packages/core/src/cli/retry-wrapper.mjs
+++ b/packages/core/src/cli/retry-wrapper.mjs
@@ -1,0 +1,169 @@
+/**
+ * Deterministic retry wrapper for CLI usage/flag errors.
+ *
+ * When a script receives unknown flags, it emits a usage/flag error to stderr.
+ * This wrapper detects such errors, parses the usage output for valid flags,
+ * and retries once with corrected args.
+ *
+ * Only retries on usage/flag errors — NOT on network/auth/data errors.
+ *
+ * Detection contract:
+ *   A usage/flag error is stderr JSON with { ok: false, usage: "..." }
+ *   OR stderr text matching known argument-error patterns.
+ *
+ * Non-retryable: runtime errors ({ ok: false } without usage field),
+ *   network errors, auth errors, data errors, signal exits.
+ *
+ * Issue: #483
+ */
+
+const USAGE_PATTERNS = [
+  /\bUnknown argument:/i,
+  /\bMissing required option:/i,
+  /\bMissing value for\b/i,
+  /\bhas been removed/i,
+  /\bUnrecognized\b/i,
+  /\bMissing command\b/i,
+];
+
+/**
+ * Check if stderr represents a CLI usage/flag error that is retryable.
+ * @param {string|null|undefined} stderr
+ * @returns {boolean}
+ */
+export function isUsageError(stderr) {
+  if (!stderr || stderr.trim().length === 0) return false;
+
+  const trimmed = stderr.trim();
+
+  // Try JSON parse first: { ok: false, usage: "..." }
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (parsed && parsed.ok === false && typeof parsed.usage === 'string' && parsed.usage.length > 0) {
+      return true;
+    }
+  } catch {
+    // Not JSON — fall through to pattern matching
+  }
+
+  return USAGE_PATTERNS.some((p) => p.test(trimmed));
+}
+
+/**
+ * Extract valid flag names from usage text.
+ * Finds all --flag-name patterns and returns them as a Set.
+ *
+ * Only matches flags that look like valid CLI option names:
+ * letters and hyphens after --, minimum 2 chars (--x is not a valid flag).
+ *
+ * @param {string} usageText
+ * @returns {Set<string>}
+ */
+export function extractValidFlags(usageText) {
+  const flags = new Set();
+  if (!usageText || usageText.length === 0) return flags;
+
+  // Match --flag-name (letters and hyphens after --)
+  const flagPattern = /--([a-z][a-z0-9-]*)/gi;
+  let match;
+  while ((match = flagPattern.exec(usageText)) !== null) {
+    flags.add(`--${match[1]}`);
+  }
+  return flags;
+}
+
+/**
+ * Extract the canonical usage text from stderr.
+ *
+ * For JSON stderr: returns the `usage` field value.
+ * For non-JSON stderr: tries to find a "Usage:" section and returns that;
+ *   if no Usage: section is found, returns null to avoid false positives.
+ *
+ * @param {string} stderr
+ * @returns {string|null}
+ */
+export function extractUsageText(stderr) {
+  if (!stderr || stderr.trim().length === 0) return null;
+
+  try {
+    const parsed = JSON.parse(stderr.trim());
+    if (parsed && typeof parsed.usage === 'string' && parsed.usage.length > 0) {
+      return parsed.usage;
+    }
+    // JSON but no usage field — not a usage error, don't return raw text
+    return null;
+  } catch {
+    // Not JSON — try to find a "Usage:" section
+  }
+
+  const trimmed = stderr.trim();
+
+  // Find "Usage:" line and take from there to end
+  const usageIdx = trimmed.search(/^Usage:/im);
+  if (usageIdx >= 0) {
+    return trimmed.slice(usageIdx);
+  }
+
+  // No usage marker — can't reliably extract
+  return null;
+}
+
+/**
+ * Filter original args to keep only recognized flags and their value args.
+ * A value arg is the token immediately following a recognized flag
+ * that does not start with '-'.
+ *
+ * @param {string[]} originalArgs
+ * @param {Set<string>} validFlags
+ * @returns {string[]}
+ */
+export function filterArgs(originalArgs, validFlags) {
+  const filtered = [];
+  for (let i = 0; i < originalArgs.length; i++) {
+    const arg = originalArgs[i];
+    if (validFlags.has(arg)) {
+      filtered.push(arg);
+      // If next arg exists and doesn't look like a flag, it's a value
+      if (i + 1 < originalArgs.length && !originalArgs[i + 1].startsWith('-')) {
+        filtered.push(originalArgs[i + 1]);
+        i++; // consume the value
+      }
+    }
+  }
+  return filtered;
+}
+
+/**
+ * Build a corrected args array from the original args and the stderr usage error.
+ * Returns null if no correction is possible or needed.
+ *
+ * Steps:
+ * 1. Extract canonical usage text from stderr.
+ * 2. Extract valid flags from usage text.
+ * 3. Filter original args to keep only recognized flags + values.
+ * 4. If filtered args differ from original, return them; otherwise return null.
+ *
+ * @param {string[]} originalArgs
+ * @param {string} stderr
+ * @returns {string[]|null} Corrected args, or null if no correction needed.
+ */
+export function buildCorrectedArgs(originalArgs, stderr) {
+  if (!originalArgs || originalArgs.length === 0) return null;
+
+  const usageText = extractUsageText(stderr);
+  if (!usageText) return null;
+
+  const validFlags = extractValidFlags(usageText);
+  if (validFlags.size === 0) return null;
+
+  const corrected = filterArgs(originalArgs, validFlags);
+  if (corrected.length === 0) return null;
+
+  // Only retry if args actually changed
+  if (corrected.length === originalArgs.length &&
+      corrected.every((v, i) => v === originalArgs[i])) {
+    return null;
+  }
+
+  return corrected;
+}

--- a/packages/core/test/retry-wrapper.test.mjs
+++ b/packages/core/test/retry-wrapper.test.mjs
@@ -1,0 +1,274 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isUsageError,
+  extractValidFlags,
+  extractUsageText,
+  filterArgs,
+  buildCorrectedArgs,
+} from "../src/cli/retry-wrapper.mjs";
+
+// ── isUsageError ──
+
+test("isUsageError — JSON usage error with usage field", () => {
+  const stderr = JSON.stringify({
+    ok: false,
+    error: "Unknown argument: --timeout-ms",
+    usage: "Usage: run-watch-cycle.mjs --repo <owner/name> --pr <number>",
+  });
+  assert.equal(isUsageError(stderr), true);
+});
+
+test("isUsageError — JSON runtime error without usage field", () => {
+  const stderr = JSON.stringify({
+    ok: false,
+    error: "gh command failed: Bad credentials",
+  });
+  assert.equal(isUsageError(stderr), false);
+});
+
+test("isUsageError — unknown argument text pattern", () => {
+  assert.equal(isUsageError("Unknown argument: --timeout-ms"), true);
+});
+
+test("isUsageError — missing required option text pattern", () => {
+  assert.equal(isUsageError("Missing required option: --repo"), true);
+});
+
+test("isUsageError — missing value text pattern", () => {
+  assert.equal(isUsageError("Missing value for --pr"), true);
+});
+
+test("isUsageError — removed flag text pattern", () => {
+  assert.equal(isUsageError("--probe-only has been removed"), true);
+});
+
+test("isUsageError — unrecognized text pattern", () => {
+  assert.equal(isUsageError("Unrecognized command: xyz"), true);
+});
+
+test("isUsageError — network error not usage", () => {
+  assert.equal(isUsageError("ECONNREFUSED: Connection refused"), false);
+});
+
+test("isUsageError — auth error not usage", () => {
+  assert.equal(isUsageError("401 Unauthorized"), false);
+});
+
+test("isUsageError — empty stderr", () => {
+  assert.equal(isUsageError(""), false);
+  assert.equal(isUsageError("  "), false);
+});
+
+test("isUsageError — null/undefined stderr", () => {
+  assert.equal(isUsageError(null), false);
+  assert.equal(isUsageError(undefined), false);
+});
+
+test("isUsageError — runtime JSON error without usage", () => {
+  const stderr = JSON.stringify({ ok: false, error: "Something went wrong" });
+  assert.equal(isUsageError(stderr), false);
+});
+
+// ── extractValidFlags ──
+
+test("extractValidFlags — typical usage text", () => {
+  const usage = "Usage: run-watch-cycle.mjs --repo <owner/name> --pr <number>";
+  const flags = extractValidFlags(usage);
+  assert.deepEqual(flags, new Set(["--repo", "--pr"]));
+});
+
+test("extractValidFlags — usage with optional flags in brackets", () => {
+  const usage = "Usage: detect.mjs [--input <file>] [--verbose]";
+  const flags = extractValidFlags(usage);
+  assert.deepEqual(flags, new Set(["--input", "--verbose"]));
+});
+
+test("extractValidFlags — usage with repeated flags (deduplication)", () => {
+  const usage = "  --repo <owner/name>    Repository slug\n  --pr <number>          PR number\n  --repo <owner/name>    (duplicate)";
+  const flags = extractValidFlags(usage);
+  assert.deepEqual(flags, new Set(["--repo", "--pr"]));
+});
+
+test("extractValidFlags — multi-line conductor usage", () => {
+  const usage = `Usage: run-conductor-cycle.mjs --repo <owner/name>
+Poll all open PRs, detect state, and output an ordered action queue.`;
+  const flags = extractValidFlags(usage);
+  assert.deepEqual(flags, new Set(["--repo"]));
+});
+
+test("extractValidFlags — empty usage", () => {
+  const flags = extractValidFlags("");
+  assert.equal(flags.size, 0);
+});
+
+test("extractValidFlags — no flags in text", () => {
+  const flags = extractValidFlags("This is just a description");
+  assert.equal(flags.size, 0);
+});
+
+test("extractValidFlags — flags with numbers and hyphens", () => {
+  const usage = "--head-sha <sha> --max-retries <num> --timeout-ms <ms>";
+  const flags = extractValidFlags(usage);
+  assert.deepEqual(flags, new Set(["--head-sha", "--max-retries", "--timeout-ms"]));
+});
+
+// ── extractUsageText ──
+
+test("extractUsageText — from JSON with usage field", () => {
+  const stderr = JSON.stringify({
+    ok: false,
+    error: "Unknown argument",
+    usage: "Usage: script.mjs --repo <name>",
+  });
+  assert.equal(extractUsageText(stderr), "Usage: script.mjs --repo <name>");
+});
+
+test("extractUsageText — from plain text with Usage: marker", () => {
+  const stderr = "Unknown argument: --bogus\n\nUsage: script.mjs --repo <owner/name>";
+  assert.equal(extractUsageText(stderr), "Usage: script.mjs --repo <owner/name>");
+});
+
+test("extractUsageText — JSON without usage field returns null", () => {
+  const stderr = JSON.stringify({ ok: false, error: "Failed" });
+  assert.equal(extractUsageText(stderr), null);
+});
+
+test("extractUsageText — plain text without Usage: marker returns null", () => {
+  const stderr = "Something went wrong, no usage info";
+  assert.equal(extractUsageText(stderr), null);
+});
+
+test("extractUsageText — empty stderr returns null", () => {
+  assert.equal(extractUsageText(""), null);
+  assert.equal(extractUsageText("  "), null);
+});
+
+// ── filterArgs ──
+
+test("filterArgs — keeps recognized flags and their values", () => {
+  const args = ["--repo", "owner/repo", "--pr", "483", "--timeout-ms", "5000"];
+  const validFlags = new Set(["--repo", "--pr"]);
+  const result = filterArgs(args, validFlags);
+  assert.deepEqual(result, ["--repo", "owner/repo", "--pr", "483"]);
+});
+
+test("filterArgs — drops unknown flags and their values", () => {
+  const args = ["--repo", "owner/repo", "--bogus", "value", "--pr", "42"];
+  const validFlags = new Set(["--repo", "--pr"]);
+  const result = filterArgs(args, validFlags);
+  assert.deepEqual(result, ["--repo", "owner/repo", "--pr", "42"]);
+});
+
+test("filterArgs — drops unknown boolean flags", () => {
+  const args = ["--repo", "owner/repo", "--verbose", "--pr", "42"];
+  const validFlags = new Set(["--repo", "--pr"]);
+  const result = filterArgs(args, validFlags);
+  assert.deepEqual(result, ["--repo", "owner/repo", "--pr", "42"]);
+});
+
+test("filterArgs — keeps only flag present when no value follows", () => {
+  const args = ["--repo", "--pr", "42"];
+  const validFlags = new Set(["--repo", "--pr"]);
+  // --repo has no value (--pr is a flag), --pr gets value "42"
+  const result = filterArgs(args, validFlags);
+  assert.deepEqual(result, ["--repo", "--pr", "42"]);
+});
+
+test("filterArgs — empty validFlags set", () => {
+  const args = ["--repo", "owner/repo"];
+  const result = filterArgs(args, new Set());
+  assert.deepEqual(result, []);
+});
+
+// ── buildCorrectedArgs ──
+
+test("buildCorrectedArgs — corrects unknown flag and retries", () => {
+  const args = ["--repo", "owner/repo", "--timeout-ms", "5000"];
+  const stderr = JSON.stringify({
+    ok: false,
+    error: "Unknown argument: --timeout-ms",
+    usage: "Usage: script.mjs --repo <owner/name>",
+  });
+  const result = buildCorrectedArgs(args, stderr);
+  assert.deepEqual(result, ["--repo", "owner/repo"]);
+});
+
+test("buildCorrectedArgs — returns null when args unchanged (already correct)", () => {
+  const args = ["--repo", "owner/repo"];
+  const stderr = JSON.stringify({
+    ok: false,
+    error: "Missing required option: --pr",
+    usage: "Usage: script.mjs --repo <owner/name> --pr <number>",
+  });
+  const result = buildCorrectedArgs(args, stderr);
+  // args unchanged — args only have --repo which is valid, no --pr to fix
+  // Since filtered == original, returns null
+  assert.equal(result, null);
+});
+
+test("buildCorrectedArgs — returns null for runtime error (no usage field)", () => {
+  const args = ["--repo", "owner/repo"];
+  const stderr = JSON.stringify({ ok: false, error: "Network error" });
+  const result = buildCorrectedArgs(args, stderr);
+  assert.equal(result, null);
+});
+
+test("buildCorrectedArgs — returns null for empty args", () => {
+  const result = buildCorrectedArgs([], "some error");
+  assert.equal(result, null);
+});
+
+test("buildCorrectedArgs — returns null when no flags in usage", () => {
+  const args = ["--repo", "owner/repo"];
+  const stderr = JSON.stringify({
+    ok: false,
+    error: "Unknown argument: --bogus",
+    usage: "Usage: This script takes no arguments",
+  });
+  const result = buildCorrectedArgs(args, stderr);
+  assert.equal(result, null);
+});
+
+test("buildCorrectedArgs — plain text stderr with Usage: marker", () => {
+  const args = ["--repo", "owner/repo", "--bogus-flag"];
+  const stderr = "Unknown argument: --bogus-flag\n\nUsage: script.mjs --repo <owner/name>";
+  const result = buildCorrectedArgs(args, stderr);
+  assert.deepEqual(result, ["--repo", "owner/repo"]);
+});
+
+test("buildCorrectedArgs — plain text stderr without Usage: marker returns null", () => {
+  const args = ["--repo", "owner/repo"];
+  const stderr = "Unknown argument: --bogus";
+  const result = buildCorrectedArgs(args, stderr);
+  assert.equal(result, null);
+});
+
+// ── End-to-end scenario: #483 reproduction ──
+
+test("buildCorrectedArgs — #483 scenario: --timeout-ms on run-watch-cycle", () => {
+  const args = ["--repo", "owner/repo", "--pr", "42", "--timeout-ms", "5000"];
+  const stderr = JSON.stringify({
+    ok: false,
+    error: "Unknown argument: --timeout-ms",
+    usage: `Usage: run-watch-cycle.mjs --repo <owner/name> --pr <number>
+Run one deterministic Copilot wait-cycle boundary.
+Required:
+  --repo <owner/name>       Repository slug (e.g. owner/repo)
+  --pr <number>             Pull request number`,
+  });
+  const result = buildCorrectedArgs(args, stderr);
+  assert.deepEqual(result, ["--repo", "owner/repo", "--pr", "42"]);
+});
+
+test("buildCorrectedArgs — #483 scenario: conductor with wrong flag", () => {
+  const args = ["--repo", "owner/repo", "--pr", "42"];
+  const stderr = JSON.stringify({
+    ok: false,
+    error: "Unknown argument: --pr",
+    usage: "Usage: run-conductor-cycle.mjs --repo <owner/name>",
+  });
+  const result = buildCorrectedArgs(args, stderr);
+  assert.deepEqual(result, ["--repo", "owner/repo"]);
+});


### PR DESCRIPTION
## Summary

Adds deterministic retry wrapper that catches CLI usage/flag errors, parses usage output for valid flags, and retries once with corrected args.

### Problem (#483)
Agent hit CLI flag error (`--timeout-ms` on wrong script) and got permanently stuck. Agent saw usage output with valid flags but didn't self-correct. Non-interactive mode prevented recovery.

### Fix
- New `packages/core/src/cli/retry-wrapper.mjs`: detects usage errors, extracts valid flags from usage text, filters args
- Integration in `cli/index.mjs` subcommand dispatch: on non-zero exit + usage error, retries once with corrected args
- Only retries on usage/flag errors (JSON with `usage` field or text patterns like "Unknown argument:")
- Does NOT retry on network/auth/data errors

### AC
- [x] Retry wrapper catches usage/flag errors from scripts
- [x] Parses usage output to extract valid flags
- [x] Retries once with corrected args
- [x] Does NOT retry on network/auth/data errors
- [x] `npm run verify` green (2575 tests passing)

### Changes
- `cli/index.mjs`: +13 lines for retry integration
- `packages/core/src/cli/retry-wrapper.mjs`: new 196-line module
- `packages/core/test/retry-wrapper.test.mjs`: 38 tests
- `packages/core/package.json`: +1 export entry

Closes #483