### PR TITLE
fix(#593): demote internal loop concepts from public skill docs

### DIFF
--- a/docs/copilot-loop-state-graph.md
+++ b/docs/copilot-loop-state-graph.md
@@ -137,8 +137,8 @@ The interpreter applies rules in priority order. The first matching rule wins.
 
 When rule 11 yields `ready_to_rerequest_review`, the interpreter also emits two machine-readable flags:
 
-- `autoRerequestEligible` — `true` only when a meaningful remediation event has occurred since the last Copilot review basis (deterministically: there is no submitted Copilot review on the current head).
-- `sameHeadCleanConverged` — `true` when the current head already has a clean submitted Copilot review and no unresolved/actionable threads remain, so automatic same-head re-request must be suppressed.
+- Automatic re-request eligibility — available only when a meaningful remediation event has occurred since the last Copilot review basis (deterministically: there is no submitted Copilot review on the current head).
+- Clean convergence on current head — when the current head already has a clean submitted Copilot review and no unresolved/actionable threads remain, automatic same-head re-request is suppressed.
 
 ## Key Behavioral Guarantees
 
@@ -152,7 +152,7 @@ Rule 8 routes to `waiting_for_copilot_review` whenever the effective request sta
 
 ### Automatic same-head re-request suppression after clean convergence
 
-When the current head already has a submitted Copilot review, unresolved/actionable thread counts are 0, and CI is not in a blocked wait/failure state, automatic follow-up re-request is suppressed for that head (`sameHeadCleanConverged: true`, `autoRerequestEligible: false`). Automatic re-request becomes eligible again only after a meaningful remediation event changes the review basis (for this loop: a newer head without a submitted Copilot review on that head). Explicit operator/manual re-request remains allowed, but the direct request helper now suppresses same-head clean re-requests by default unless `--force-rerequest-review` is provided.
+When the current head already has a submitted Copilot review, unresolved/actionable thread counts are 0, and CI is not in a blocked wait/failure state, automatic follow-up re-request is suppressed for that head (clean convergence on current head, automatic re-request suppressed). Automatic re-request becomes eligible again only after a meaningful remediation event changes the review basis (for this loop: a newer head without a submitted Copilot review on that head). Explicit operator/manual re-request remains allowed, but the direct request helper now suppresses same-head clean re-requests by default unless `--force-rerequest-review` is provided.
 
 ### `unavailable` stops the loop only when no in-progress evidence exists
 

--- a/docs/copilot-loop-state-graph.md
+++ b/docs/copilot-loop-state-graph.md
@@ -135,7 +135,7 @@ The interpreter applies rules in priority order. The first matching rule wins.
 13. `ciStatus === "pending" || ciStatus === "none"` → `waiting_for_ci`
 14. Default → `pr_ready_no_feedback`
 
-When rule 11 yields `ready_to_rerequest_review`, the interpreter also emits two machine-readable flags:
+When rule 11 yields `ready_to_rerequest_review`, the interpreter also emits two behavioral indicators:
 
 - Automatic re-request eligibility — available only when a meaningful remediation event has occurred since the last Copilot review basis (deterministically: there is no submitted Copilot review on the current head).
 - Clean convergence on current head — when the current head already has a clean submitted Copilot review and no unresolved/actionable threads remain, automatic same-head re-request is suppressed.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -108,7 +108,7 @@ Contract:
 Success output shape:
 - `{ "ok": true, "status": "requested"|"already-requested"|"unavailable"|"suppressed_same_head_clean", "repo": "owner/name", "pr": 17, "reviewer": "Copilot", ... }`
 - `unavailable` also includes a `detail` string with the normalized GitHub/CLI limitation
-- `suppressed_same_head_clean` indicates clean convergence on the current head and includes an override hint
+- `suppressed_same_head_clean` indicates clean convergence on the current head (suppression is always enforced; bypass requires --force-rerequest-review)
 - forced bypass results include `bypassedSameHeadCleanSuppression: true`
 
 Failure behavior:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -108,7 +108,7 @@ Contract:
 Success output shape:
 - `{ "ok": true, "status": "requested"|"already-requested"|"unavailable"|"suppressed_same_head_clean", "repo": "owner/name", "pr": 17, "reviewer": "Copilot", ... }`
 - `unavailable` also includes a `detail` string with the normalized GitHub/CLI limitation
-- `suppressed_same_head_clean` includes `sameHeadCleanConverged: true` and an override hint
+- `suppressed_same_head_clean` indicates clean convergence on the current head and includes an override hint
 - forced bypass results include `bypassedSameHeadCleanSuppression: true`
 
 Failure behavior:
@@ -590,7 +590,7 @@ Success output shape:
 - `allowedTransitions` is the list of states reachable from `state`
 - `nextAction` is a human-readable recommended next step
 - `autoRerequestEligible` is `true` only when a meaningful remediation event has made automatic re-request valid again
-- `sameHeadCleanConverged` is `true` when the current head already has a clean submitted Copilot review and automatic same-head re-request must be suppressed
+- `sameHeadCleanConverged` is `true` when the current head has clean convergence (a submitted Copilot review with no unresolved threads), suppressing automatic same-head re-request
 - `loopDisposition` is the high-level refreshed classification: `pending`, `unresolved_feedback`, `clean_converged`, `blocked`, `action_required`, or `done`
 - `terminal` is `true` only for clean-converged, blocked, or done states; watcher timeout/idle must be treated as non-terminal until a refreshed detector output proves `terminal=true`
 
@@ -601,7 +601,7 @@ Key behavioral guarantees:
 - When `unresolvedThreadCount > 0`, the state is always in the fix/reply-resolve family — never `waiting_for_copilot_review` or any wait state
 - When `copilotReviewRequestStatus` is `unavailable` or `failed`, the state is a terminal stop/report state with no allowed transitions
 - When `agentFixStatus` is `"applied"` and unresolved threads exist, the state is `already_fixed_needs_reply_resolve`, and `allowedTransitions` includes only `ready_to_rerequest_review`
-- When the current head already has a clean submitted Copilot review, `sameHeadCleanConverged=true` and automatic same-head re-request is suppressed until a meaningful remediation event occurs
+- When the current head has clean convergence (a submitted Copilot review with no unresolved threads), automatic same-head re-request is suppressed until a meaningful remediation event occurs
 - If review-thread state cannot be determined during auto-detect, the script fails closed instead of assuming zero unresolved threads
 - When `--steering-state-file` is provided, steering is surfaced as a read-only overlay;
   queued steering promotion/persistence is owned explicitly by `steer-loop.mjs promote`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -590,7 +590,7 @@ Success output shape:
 - `allowedTransitions` is the list of states reachable from `state`
 - `nextAction` is a human-readable recommended next step
 - `autoRerequestEligible` is `true` only when a meaningful remediation event has made automatic re-request valid again
-- `sameHeadCleanConverged` is `true` when the current head has clean convergence (a submitted Copilot review with no unresolved threads), suppressing automatic same-head re-request
+- `sameHeadCleanConverged` is `true` when the current head has clean convergence (a submitted Copilot review, zero unresolved and actionable threads, and CI not blocked), suppressing automatic same-head re-request
 - `loopDisposition` is the high-level refreshed classification: `pending`, `unresolved_feedback`, `clean_converged`, `blocked`, `action_required`, or `done`
 - `terminal` is `true` only for clean-converged, blocked, or done states; watcher timeout/idle must be treated as non-terminal until a refreshed detector output proves `terminal=true`
 
@@ -601,7 +601,7 @@ Key behavioral guarantees:
 - When `unresolvedThreadCount > 0`, the state is always in the fix/reply-resolve family — never `waiting_for_copilot_review` or any wait state
 - When `copilotReviewRequestStatus` is `unavailable` or `failed`, the state is a terminal stop/report state with no allowed transitions
 - When `agentFixStatus` is `"applied"` and unresolved threads exist, the state is `already_fixed_needs_reply_resolve`, and `allowedTransitions` includes only `ready_to_rerequest_review`
-- When the current head has clean convergence (a submitted Copilot review with no unresolved threads), automatic same-head re-request is suppressed until a meaningful remediation event occurs
+- When the current head has clean convergence (a submitted Copilot review, zero unresolved and actionable threads, and CI not blocked), automatic same-head re-request is suppressed until a meaningful remediation event occurs
 - If review-thread state cannot be determined during auto-detect, the script fails closed instead of assuming zero unresolved threads
 - When `--steering-state-file` is provided, steering is surfaced as a read-only overlay;
   queued steering promotion/persistence is owned explicitly by `steer-loop.mjs promote`

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -255,13 +255,13 @@ When actionable review feedback exists, use a narrow follow-up loop:
 9. before resolving an addressed review thread, run a post-fix verification checkpoint
    - confirm the GitHub reply actually exists on the intended thread/comment, not only in local notes or helper stdout
    - confirm the pushed current-head diff genuinely addresses the reviewer concern on the flagged lines or pattern; if the concern is only partially addressed, leave the thread open and explain what remains
-   - refresh the API-backed thread snapshot via `dev-loops review capture-threads` and use that refreshed data — including `unresolvedThreadCount` — for follow-up decisions rather than prose assumptions
+   - refresh the API-backed thread snapshot via `dev-loops review capture-threads` and use that refreshed data — including the unresolved thread count — for follow-up decisions rather than prose assumptions
    - if any verification check fails, do **not** resolve the thread; leave it open, add a short explanation when needed, and re-enter the fix/reply loop
 10. resolve the addressed review thread only after the reply is attached successfully, the verification checkpoint passes, and the concern is genuinely addressed
     - do not stop at a local fix if GitHub-side reply/resolve is authorized
-11. after completing reply/resolve for a pass, verify `unresolvedThreadCount === 0` via `dev-loops review capture-threads` before proceeding
-    - if the refreshed snapshot reports a non-zero unresolved thread count, re-enter the reply/resolve loop for the missed threads
-12. only after GitHub-side reply/resolve work is done for the addressed threads and the refreshed thread snapshot proves `unresolvedThreadCount === 0`, decide whether another Copilot pass is desired
+11. after completing reply/resolve for a pass, verify zero unresolved threads remain via `dev-loops review capture-threads` before proceeding
+    - if the refreshed snapshot reports unresolved threads, re-enter the reply/resolve loop for the missed threads
+12. only after GitHub-side reply/resolve work is done for the addressed threads and the refreshed thread snapshot proves zero unresolved threads remain, decide whether another Copilot pass is desired
     - resolve the review-round cap from config via `resolveRefinementConfig(config, "maxCopilotRounds")` from `@pi-dev-loops/core/config`; default config ships `maxCopilotRounds: 5`
     - use the completed Copilot review-round count from `detect-copilot-loop-state.mjs` / `copilot-pr-handoff.mjs` as the current PR's review-round count
     - if completed review rounds have reached the maximum (default: 5), do **not** re-request Copilot review
@@ -274,7 +274,7 @@ When actionable review feedback exists, use a narrow follow-up loop:
       - **Mid** — meaningful improvements, design questions, refactoring suggestions → fix once; suppress re-request when round threshold met
       - **Low** — cosmetic nits, phrasing preferences, trivial cleanup → fix once; do NOT re-request
     - when low-signal detection is enabled and more review rounds than the low-signal threshold have passed and actionable review threads are at or below the low-signal max, and the last Copilot round's maximum signal level is `mid` or `low` (not `high`), the state machine returns a low-signal-converged terminal state instead of a ready-to-rerequest state, routing to `pre_approval_gate` without further re-requests
-    - when signal classification data is unavailable (null), the heuristic falls back to the `actionableThreadCount <= lowSignalMaxComments` check
+    - when signal classification data is unavailable (null), the heuristic falls back to checking whether actionable threads are at or below the low-signal max
     - the low-signal heuristic is applied by `detect-copilot-loop-state.mjs` through the shared `interpretLoopState` / `summarizeLoopInterpretation` contract
     - if yes and the round cap has not been reached, run the smallest honest local validation for the accepted fix scope
     - if that local validation is still known red, continue remediation instead of re-requesting Copilot
@@ -372,11 +372,11 @@ Before any merge-ready or final-approval claim, run `detect-pr-gate-coordination
 8. wait for current-head CI again before retrying merge evaluation
 9. if the chosen reconciliation rewrote branch history (for example rebase), ask for explicit authorization before `git push --force-with-lease`, then continue the loop on the updated head
 
-`mergeStateStatus: CLEAN` alone is not enough to resume approval or merge claims. The existing merge-ready preconditions still apply: `unresolvedThreadCount === 0`, a clean current-head `pre_approval_gate`, and green current-head CI.
+`mergeStateStatus: CLEAN` alone is not enough to resume approval or merge claims. The existing merge-ready preconditions still apply: zero unresolved review threads, a clean current-head `pre_approval_gate`, and green current-head CI.
 
 ### Merge-ready preconditions
 
-See [Merge Preconditions](../docs/merge-preconditions.md). Verify: `unresolvedThreadCount === 0` (via `dev-loops review capture-threads`), visible clean `draft_gate` + current-head `pre_approval_gate`, green CI. Fresh-context review follows [Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md).
+See [Merge Preconditions](../docs/merge-preconditions.md). Verify: zero unresolved threads (via `dev-loops review capture-threads`), visible clean `draft_gate` + current-head `pre_approval_gate`, green CI. Fresh-context review follows [Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md).
 
 ### Human approval checkpoint
 

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -263,9 +263,9 @@ When actionable review feedback exists, use a narrow follow-up loop:
     - if the refreshed snapshot reports a non-zero unresolved thread count, re-enter the reply/resolve loop for the missed threads
 12. only after GitHub-side reply/resolve work is done for the addressed threads and the refreshed thread snapshot proves `unresolvedThreadCount === 0`, decide whether another Copilot pass is desired
     - resolve the review-round cap from config via `resolveRefinementConfig(config, "maxCopilotRounds")` from `@pi-dev-loops/core/config`; default config ships `maxCopilotRounds: 5`
-    - use `snapshot.copilotReviewRoundCount` from `detect-copilot-loop-state.mjs` / `copilot-pr-handoff.mjs` as the completed Copilot review-round count for the current PR
-    - if `snapshot.copilotReviewRoundCount >= maxCopilotRounds`, do **not** re-request Copilot review
-    - when the round cap is reached **and** the refreshed thread snapshot proves `unresolvedThreadCount === 0` **and** current-head CI is `success` or `crediblyGreen`, treat that clean state as eligible for `pre_approval_gate` fallback instead of deadlocking on another Copilot rerequest
+    - use the completed Copilot review-round count from `detect-copilot-loop-state.mjs` / `copilot-pr-handoff.mjs` as the current PR's review-round count
+    - if completed review rounds have reached the maximum (default: 5), do **not** re-request Copilot review
+    - when the round limit is reached **and** the refreshed thread snapshot proves zero unresolved threads **and** current-head CI is green or credibly green, treat that clean state as eligible for `pre_approval_gate` fallback instead of deadlocking on another Copilot rerequest
     - when using that fallback, add a short round-exhaustion note to the visible `pre_approval_gate` gate evidence so the PR records why no further Copilot rerequest occurred
     - if the round cap is reached before the PR is thread-clean or before CI is green/credibly green, reply-resolve any remaining intentionally deferred threads with a short `deferred to follow-up` note, then stop and report that the Copilot round limit was reached
     - **Signal-gated re-request suppression (diminishing-returns policy):** resolve low-signal config from `resolveRefinementConfig(config, "stopOnLowSignal")` / `resolveRefinementConfig(config, "lowSignalRoundThreshold")` / `resolveRefinementConfig(config, "lowSignalMaxComments")` from `@pi-dev-loops/core/config`; defaults: `stopOnLowSignal: true`, `lowSignalRoundThreshold: 3`, `lowSignalMaxComments: 2`
@@ -273,7 +273,7 @@ When actionable review feedback exists, use a narrow follow-up loop:
       - **High** — blocking bugs, security issues, contract violations, crashes, data loss, regressions → always re-request
       - **Mid** — meaningful improvements, design questions, refactoring suggestions → fix once; suppress re-request when round threshold met
       - **Low** — cosmetic nits, phrasing preferences, trivial cleanup → fix once; do NOT re-request
-    - when `stopOnLowSignal` is enabled and `copilotReviewRoundCount > lowSignalRoundThreshold` and `actionableThreadCount <= lowSignalMaxComments` and the last Copilot round's maximum signal level is `mid` or `low` (not `high`), the state machine returns `LOW_SIGNAL_CONVERGED` (terminal) instead of `READY_TO_REREQUEST_REVIEW`, routing to `pre_approval_gate` without further re-requests
+    - when low-signal detection is enabled and more review rounds than the low-signal threshold have passed and actionable review threads are at or below the low-signal max, and the last Copilot round's maximum signal level is `mid` or `low` (not `high`), the state machine returns a low-signal-converged terminal state instead of a ready-to-rerequest state, routing to `pre_approval_gate` without further re-requests
     - when signal classification data is unavailable (null), the heuristic falls back to the `actionableThreadCount <= lowSignalMaxComments` check
     - the low-signal heuristic is applied by `detect-copilot-loop-state.mjs` through the shared `interpretLoopState` / `summarizeLoopInterpretation` contract
     - if yes and the round cap has not been reached, run the smallest honest local validation for the accepted fix scope

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -107,14 +107,15 @@ Strategies where `requiresAsyncDispatch` is `false` (`local_implementation`, `fi
 - Intercom coordination for cross-run state updates
 - Parent session retains loop ownership; subagents handle bounded slices only
 
-**Round-cap budget check (#524, enforced):** After every watch cycle, fix pass, or reply-resolve — and **before** any `request-copilot-review.mjs` re-request — check `detect-copilot-loop-state.mjs` output for `snapshot.copilotReviewRoundCount >= maxCopilotRounds` (default: 5). The detector (`interpretLoopState` in `packages/core/src/loop/copilot-loop-state.mjs`) only emits a `round_cap_*` state when ALL of these are true:
-- the round cap is reached (`copilotReviewRoundCount >= maxCopilotRounds`)
-- no Copilot review request is in flight (`copilotReviewRequestStatus` is not `"requested"` or `"already-requested"`)
-- the detector has not already selected a higher-priority terminal/draft state (`no_pr`, `done`, `pr_draft`, `review_request_unavailable`, `blocked_needs_user_decision`) — those take precedence and round-cap routing is skipped in those cases
-- Given all that, the detector selects one of two explicit `state` values:
-- `state: "round_cap_clean_fallback"` — when `unresolvedThreadCount === 0` AND `ciStatus` is `"success"` or `"crediblyGreen"`. Treat this as the `pre_approval_gate` entry signal (do not re-request Copilot review).
-- `state: "round_cap_reached"` — when `unresolvedThreadCount > 0` OR `ciStatus` is not `"success"`/`"crediblyGreen"`. Reply-resolve any remaining intentionally deferred threads with a short `deferred to follow-up` note and stop; do **not** re-request Copilot review.
+**Round-cap budget check (#524, enforced):** After every watch cycle, fix pass, or reply-resolve — and **before** any `request-copilot-review.mjs` re-request — check that completed Copilot review rounds have not exceeded the maximum (default: 5). The detector (`interpretLoopState` in `packages/core/src/loop/copilot-loop-state.mjs`) only emits a round-limit state when ALL of these are true:
+- completed review rounds have reached the maximum
+- no Copilot review request is in flight
+- the detector has not already selected a higher-priority terminal/draft state (`no_pr`, `done`, `pr_draft`, `review_request_unavailable`, `blocked_needs_user_decision`) — those take precedence and round-limit routing is skipped in those cases
+- Given all that, the detector selects one of two paths:
+- **Clean fallback** — when there are zero unresolved review threads AND CI is green (or credibly green). Treat this as the `pre_approval_gate` entry signal (do not re-request Copilot review).
+- **Round limit reached** — when unresolved threads remain OR CI is not green. Reply-resolve any remaining intentionally deferred threads with a short `deferred to follow-up` note and stop; do **not** re-request Copilot review.
 - The round-cap check is a per-iteration gate, not an end-of-loop assertion
+
 
 **Deterministic routing step (#524):** The pre-delegation gate above determines whether delegation is appropriate. When it returns `action: "stop"` with `terminal: true`, the loop phase is complete — proceed inline to the next gate rather than delegating a polling task.
 

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -107,7 +107,7 @@ Strategies where `requiresAsyncDispatch` is `false` (`local_implementation`, `fi
 - Intercom coordination for cross-run state updates
 - Parent session retains loop ownership; subagents handle bounded slices only
 
-**Round-cap budget check (#524, enforced):** After every watch cycle, fix pass, or reply-resolve — and **before** any `request-copilot-review.mjs` re-request — check that completed Copilot review rounds have not exceeded the maximum (default: 5). The detector (`interpretLoopState` in `packages/core/src/loop/copilot-loop-state.mjs`) only emits a round-limit state when ALL of these are true:
+**Round-cap budget check (#524, enforced):** After every watch cycle, fix pass, or reply-resolve — and **before** any `request-copilot-review.mjs` re-request — check whether completed Copilot review rounds have reached the maximum (default: 5). The detector (`interpretLoopState` in `packages/core/src/loop/copilot-loop-state.mjs`) only emits a round-limit state when ALL of these are true:
 - completed review rounds have reached the maximum
 - no Copilot review request is in flight
 - the detector has not already selected a higher-priority terminal/draft state (`no_pr`, `done`, `pr_draft`, `review_request_unavailable`, `blocked_needs_user_decision`) — those take precedence and round-limit routing is skipped in those cases

--- a/test/contracts/copilot-review-doc-contracts.test.mjs
+++ b/test/contracts/copilot-review-doc-contracts.test.mjs
@@ -158,7 +158,7 @@ test("copilot-pr-followup skill hardens reply-resolve, gate sequencing, and merg
   assert.match(
     step7,
     /including the unresolved thread count/i,
-    "verification checkpoint should require refreshed API-backed unresolvedThreadCount data",
+    "verification checkpoint should require refreshed API-backed unresolved thread count data",
   );
   assert.match(
     step7,

--- a/test/contracts/copilot-review-doc-contracts.test.mjs
+++ b/test/contracts/copilot-review-doc-contracts.test.mjs
@@ -157,7 +157,7 @@ test("copilot-pr-followup skill hardens reply-resolve, gate sequencing, and merg
   );
   assert.match(
     step7,
-    /including `unresolvedThreadCount`/i,
+    /including the unresolved thread count/i,
     "verification checkpoint should require refreshed API-backed unresolvedThreadCount data",
   );
   assert.match(
@@ -170,12 +170,12 @@ test("copilot-pr-followup skill hardens reply-resolve, gate sequencing, and merg
   assert.ok(verificationIndex >= 0 && resolveIndex > verificationIndex, "verification checkpoint must appear before the resolve step");
   assert.match(
     step7,
-    /verify `unresolvedThreadCount === 0` via `dev-loops review capture-threads` before proceeding/i,
+    /verify zero unresolved threads remain via `dev-loops review capture-threads` before proceeding/i,
     "Step 7 should require deterministic unresolved-thread verification before advancing",
   );
   assert.match(
     step7,
-    /if the refreshed snapshot reports a non-zero unresolved thread count, re-enter the reply\/resolve loop for the missed threads/i,
+    /if the refreshed snapshot reports unresolved threads, re-enter the reply\/resolve loop for the missed threads/i,
     "Step 7 should require re-entering the reply-resolve loop when unresolved threads remain",
   );
   assert.match(
@@ -195,7 +195,7 @@ test("copilot-pr-followup skill hardens reply-resolve, gate sequencing, and merg
   );
   assert.match(
     step7,
-    /unresolvedThreadCount === 0.*dev-loops review capture-threads/i,
+    /zero unresolved threads.*dev-loops review capture-threads/i,
     "merge-ready preconditions should require deterministic thread-state verification",
   );
   assert.match(

--- a/test/contracts/copilot-review-doc-contracts.test.mjs
+++ b/test/contracts/copilot-review-doc-contracts.test.mjs
@@ -308,8 +308,8 @@ test("copilot-pr-followup skill caps Copilot re-review rounds via config and sna
 
   assert.match(step7, /resolveRefinementConfig\(config, "maxCopilotRounds"\)/i);
   assert.match(step7, /default config ships `maxCopilotRounds: 5`/i);
-  assert.match(step7, /snapshot\.copilotReviewRoundCount/i);
-  assert.match(step7, /if `snapshot\.copilotReviewRoundCount >= maxCopilotRounds`, do \*\*not\*\* re-request Copilot review/i);
+  assert.match(step7, /completed Copilot review-round count/i);
+  assert.match(step7, /if completed review rounds have reached the maximum/i);
   assert.match(step7, /`deferred to follow-up` note/i);
   assert.match(step7, /stop and report that the Copilot round limit was reached/i);
 });


### PR DESCRIPTION
## What
Replace raw internal state machine terms in user-facing skill docs, CLI help text, and docs with plain-language behavioral descriptions. Internal code definitions remain in `packages/core/src/loop/`.

## Why
Internal terms (`copilotReviewRoundCount`, `sameHeadCleanConverged`, `roundCapClean`, `LOW_SIGNAL_CONVERGED`) leaked into the public workflow surface, making docs harder to read and maintain. These are narrow mechanical details that don't belong in skill docs and CLI output.

## Changes
- **skills/dev-loop/SKILL.md** — round-cap section rewritten with plain behavioral descriptions
- **skills/copilot-pr-followup/SKILL.md** — round-cap and signal-gating sections rewritten
- **docs/copilot-loop-state-graph.md** — flag names replaced with plain descriptions
- **scripts/README.md** — field descriptions updated to plain language
- **test/contracts/copilot-review-doc-contracts.test.mjs** — assertions updated to match

## Verification
- `npm run verify` green (all 2577 tests pass)
- No internal code changes (`packages/core/src/loop/`, scripts/*.mjs untouched)

Closes #593