### PR TITLE
fix(#594): collapse review CLI category into gate

### DIFF
--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -252,10 +252,15 @@ function parseTopLevelCommand(argv) {
     if (args.slice(1).some((a) => a === "--help" || a === "-h")) {
       const scriptPath = reviewRoutes[sub];
       if (!scriptPath) return { kind: "review_deprecation_help" };
-      return { kind: "review_deprecation_subcommand_help", scriptPath: path.resolve(REPO_ROOT, scriptPath) };
+      return { kind: "review_deprecation_subcommand_help", subcommand: sub, scriptPath: path.resolve(REPO_ROOT, scriptPath) };
     }
     const route = resolveSubcommandRoute(["review", ...args.slice(1)]);
-    if (route) return { kind: "review_deprecation_subcommand", ...route };
+    if (route) {
+      if (route.error) {
+        return { kind: "review_deprecation_subcommand_error", error: route.error };
+      }
+      return { kind: "review_deprecation_subcommand", subcommand: sub, ...route };
+    }
     return { kind: "review_deprecation_help" };
   }
 
@@ -342,7 +347,7 @@ export async function runCli({
       return 0;
     }
     case "review_deprecation_subcommand_help": {
-      writeLines(stderr, ["Note: `dev-loops review` is deprecated. Use `dev-loops gate` instead."]);
+      writeLines(stderr, [`Note: \`dev-loops review\` is deprecated. Use \`dev-loops gate ${fromTop.subcommand}\` instead.`]);
       const result = spawnSync("node", [fromTop.scriptPath, "--help"], {
         cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
       });
@@ -350,9 +355,15 @@ export async function runCli({
       if (result.stderr) stderr.write(result.stderr);
       return result.status ?? (result.signal ? 1 : result.error ? 1 : 0);
     }
+    case "review_deprecation_subcommand_error": {
+      writeLines(stderr, [
+        `Note: \`dev-loops review\` is deprecated. Use \`dev-loops gate\` instead.`,
+        fromTop.error,
+      ]);
+      return 1;
+    }
     case "review_deprecation_subcommand": {
-      writeLines(stderr, ["Note: `dev-loops review` is deprecated. Use `dev-loops gate ${fromTop.forwardedArgs?.[0] ?? '<sub>'}` instead."]);
-      if (fromTop.error) { writeLines(stderr, [fromTop.error]); return 1; }
+      writeLines(stderr, [`Note: \`dev-loops review\` is deprecated. Use \`dev-loops gate ${fromTop.subcommand}\` instead.`]);
       const scriptArgs = fromTop.forwardedArgs || [];
       const result = spawnSync("node", [fromTop.scriptPath, ...scriptArgs], {
         cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -18,10 +18,15 @@ const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 
 const SUBCOMMAND_ROUTES = {
   gate: {
-    "upsert-verdict":   "scripts/github/upsert-checkpoint-verdict.mjs",
-    "detect-evidence":  "scripts/github/detect-checkpoint-evidence.mjs",
+    "upsert-verdict":     "scripts/github/upsert-checkpoint-verdict.mjs",
+    "detect-evidence":    "scripts/github/detect-checkpoint-evidence.mjs",
     "write-findings-log": "scripts/github/write-gate-findings-log.mjs",
+    "request-copilot":    "scripts/github/request-copilot-review.mjs",
+    "probe-copilot":      "scripts/github/probe-copilot-review.mjs",
+    "capture-threads":    "scripts/github/capture-review-threads.mjs",
+    "reply-resolve":      "scripts/github/reply-resolve-review-threads.mjs",
   },
+  // Backward-compat alias: dev-loops review <sub> → dev-loops gate <sub> (deprecated)
   review: {
     "request-copilot":  "scripts/github/request-copilot-review.mjs",
     "probe-copilot":    "scripts/github/probe-copilot-review.mjs",
@@ -117,11 +122,10 @@ function buildCliHelpLines() {
     "- dev-loops gates                  Print gate state",
     "",
     "Subcommands:",
-    "- dev-loops gate <sub> [...]       Gate verdicts and evidence",
+    "- dev-loops gate <sub> [...]       Gate verdicts, evidence, and review operations",
     "    upsert-verdict    Post/update gate review comment",
     "    detect-evidence   Check merge preconditions",
     "    write-findings-log Write disposition ledger",
-    "- dev-loops review <sub> [...]     Copilot review operations",
     "    request-copilot   Request Copilot review",
     "    probe-copilot     Poll for Copilot review activity",
     "    capture-threads   Capture review threads",
@@ -237,6 +241,24 @@ function parseTopLevelCommand(argv) {
     return { kind: "action", action: cmd };
   }
 
+  // Backward compat: dev-loops review <sub> → dev-loops gate <sub> (deprecated)
+  if (cmd === "review") {
+    const reviewRoutes = SUBCOMMAND_ROUTES["review"];
+    // If second arg is --help/-h or missing, show deprecation + gate category help
+    if (!sub || sub === "--help" || sub === "-h") {
+      return { kind: "review_deprecation_help" };
+    }
+    // Check if any remaining arg is --help — delegate to script
+    if (args.slice(1).some((a) => a === "--help" || a === "-h")) {
+      const scriptPath = reviewRoutes[sub];
+      if (!scriptPath) return { kind: "review_deprecation_help" };
+      return { kind: "review_deprecation_subcommand_help", scriptPath: path.resolve(REPO_ROOT, scriptPath) };
+    }
+    const route = resolveSubcommandRoute(["review", ...args.slice(1)]);
+    if (route) return { kind: "review_deprecation_subcommand", ...route };
+    return { kind: "review_deprecation_help" };
+  }
+
   // Subcommand routing
   const routes = SUBCOMMAND_ROUTES[cmd];
   if (routes) {
@@ -313,6 +335,42 @@ export async function runCli({
         }
         default: throw new Error(`Unhandled CLI result: ${result.kind}`);
       }
+    }
+    case "review_deprecation_help": {
+      writeLines(stderr, ["Note: `dev-loops review` is deprecated. Use `dev-loops gate` instead."]);
+      writeLines(stdout, buildCategoryHelp("gate"));
+      return 0;
+    }
+    case "review_deprecation_subcommand_help": {
+      writeLines(stderr, ["Note: `dev-loops review` is deprecated. Use `dev-loops gate` instead."]);
+      const result = spawnSync("node", [fromTop.scriptPath, "--help"], {
+        cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+      });
+      if (result.stdout) stdout.write(result.stdout);
+      if (result.stderr) stderr.write(result.stderr);
+      return result.status ?? (result.signal ? 1 : result.error ? 1 : 0);
+    }
+    case "review_deprecation_subcommand": {
+      writeLines(stderr, ["Note: `dev-loops review` is deprecated. Use `dev-loops gate ${fromTop.forwardedArgs?.[0] ?? '<sub>'}` instead."]);
+      if (fromTop.error) { writeLines(stderr, [fromTop.error]); return 1; }
+      const scriptArgs = fromTop.forwardedArgs || [];
+      const result = spawnSync("node", [fromTop.scriptPath, ...scriptArgs], {
+        cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+      });
+      if (result.status !== 0 && isUsageError(result.stderr)) {
+        const correctedArgs = buildCorrectedArgs(scriptArgs, result.stderr);
+        if (correctedArgs && correctedArgs.length > 0) {
+          const retryResult = spawnSync("node", [fromTop.scriptPath, ...correctedArgs], {
+            cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+          });
+          if (retryResult.stdout) stdout.write(retryResult.stdout);
+          if (retryResult.stderr) stderr.write(retryResult.stderr);
+          return retryResult.status ?? (retryResult.signal ? 1 : retryResult.error ? 1 : 0);
+        }
+      }
+      if (result.stdout) stdout.write(result.stdout);
+      if (result.stderr) stderr.write(result.stderr);
+      return result.status ?? (result.signal ? 1 : result.error ? 1 : 0);
     }
     case "subcommand": {
       if (fromTop.error) { writeLines(stderr, [fromTop.error]); return 1; }

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -247,6 +247,15 @@ function parseTopLevelCommand(argv) {
     if (!sub || sub === "--help" || sub === "-h") {
       return { kind: "review_deprecation_help" };
     }
+    // review <sub> --help → show deprecation + script help
+    if (args.slice(1).some((a) => a === "--help" || a === "-h")) {
+      const gateRoutes = SUBCOMMAND_ROUTES["gate"];
+      const scriptPath = gateRoutes[sub];
+      if (!scriptPath) {
+        return { kind: "review_deprecation_subcommand_error", error: `Unknown subcommand '${sub}' for 'gate'. Available: ${Object.keys(gateRoutes).join(', ')}` };
+      }
+      return { kind: "review_deprecation_subcommand_help", subcommand: sub, scriptPath: path.resolve(REPO_ROOT, scriptPath) };
+    }
     // Route through gate routes so all 7 subcommands are available
     const route = resolveSubcommandRoute(["gate", ...args.slice(1)]);
     if (route) {

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -257,7 +257,7 @@ function parseTopLevelCommand(argv) {
     const route = resolveSubcommandRoute(["review", ...args.slice(1)]);
     if (route) {
       if (route.error) {
-        return { kind: "review_deprecation_subcommand_error", error: route.error };
+        return { kind: "review_deprecation_subcommand_error", error: route.error.replace("'review'", "'gate'") };
       }
       return { kind: "review_deprecation_subcommand", subcommand: sub, ...route };
     }

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -243,21 +243,15 @@ function parseTopLevelCommand(argv) {
 
   // Backward compat: dev-loops review <sub> → dev-loops gate <sub> (deprecated)
   if (cmd === "review") {
-    const reviewRoutes = SUBCOMMAND_ROUTES["review"];
-    // If second arg is --help/-h or missing, show deprecation + gate category help
+    // Bare review / review --help → show deprecation + gate help
     if (!sub || sub === "--help" || sub === "-h") {
       return { kind: "review_deprecation_help" };
     }
-    // Check if any remaining arg is --help — delegate to script
-    if (args.slice(1).some((a) => a === "--help" || a === "-h")) {
-      const scriptPath = reviewRoutes[sub];
-      if (!scriptPath) return { kind: "review_deprecation_help" };
-      return { kind: "review_deprecation_subcommand_help", subcommand: sub, scriptPath: path.resolve(REPO_ROOT, scriptPath) };
-    }
-    const route = resolveSubcommandRoute(["review", ...args.slice(1)]);
+    // Route through gate routes so all 7 subcommands are available
+    const route = resolveSubcommandRoute(["gate", ...args.slice(1)]);
     if (route) {
       if (route.error) {
-        return { kind: "review_deprecation_subcommand_error", error: route.error.replace("'review'", "'gate'") };
+        return { kind: "review_deprecation_subcommand_error", error: route.error };
       }
       return { kind: "review_deprecation_subcommand", subcommand: sub, ...route };
     }

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -208,7 +208,7 @@ Every async dev-loop dispatch task body must include this clause verbatim so fre
 Key rules:
 - expected polling idle time is normal
 - do not restart watchers just because there has been a short quiet period
-- helper-owned sleep inside `dev-loops loop watch-cycle`, `dev-loops review probe-copilot`, or `dev-loops loop watch-initial` is allowed
+- helper-owned sleep inside `dev-loops loop watch-cycle`, `dev-loops gate probe-copilot`, or `dev-loops loop watch-initial` is allowed
 - agent-authored shell polling is forbidden
 - do not use `nohup`, detached shell jobs, `tmux`, `screen`, or ad hoc `for i in $(seq ...)`, `while true`, `until ...; do sleep ...; done`, or `sleep`-retry bash loops for this workflow
 - do not wrap repeated `gh pr view`, `gh pr checks`, `gh api`, or `detect-copilot-loop-state.mjs` calls inside shell polling loops
@@ -255,11 +255,11 @@ When actionable review feedback exists, use a narrow follow-up loop:
 9. before resolving an addressed review thread, run a post-fix verification checkpoint
    - confirm the GitHub reply actually exists on the intended thread/comment, not only in local notes or helper stdout
    - confirm the pushed current-head diff genuinely addresses the reviewer concern on the flagged lines or pattern; if the concern is only partially addressed, leave the thread open and explain what remains
-   - refresh the API-backed thread snapshot via `dev-loops review capture-threads` and use that refreshed data — including the unresolved thread count — for follow-up decisions rather than prose assumptions
+   - refresh the API-backed thread snapshot via `dev-loops gate capture-threads` and use that refreshed data — including the unresolved thread count — for follow-up decisions rather than prose assumptions
    - if any verification check fails, do **not** resolve the thread; leave it open, add a short explanation when needed, and re-enter the fix/reply loop
 10. resolve the addressed review thread only after the reply is attached successfully, the verification checkpoint passes, and the concern is genuinely addressed
     - do not stop at a local fix if GitHub-side reply/resolve is authorized
-11. after completing reply/resolve for a pass, verify zero unresolved threads remain via `dev-loops review capture-threads` before proceeding
+11. after completing reply/resolve for a pass, verify zero unresolved threads remain via `dev-loops gate capture-threads` before proceeding
     - if the refreshed snapshot reports unresolved threads, re-enter the reply/resolve loop for the missed threads
 12. only after GitHub-side reply/resolve work is done for the addressed threads and the refreshed thread snapshot proves zero unresolved threads remain, decide whether another Copilot pass is desired
     - resolve the review-round cap from config via `resolveRefinementConfig(config, "maxCopilotRounds")` from `@pi-dev-loops/core/config`; default config ships `maxCopilotRounds: 5`
@@ -376,11 +376,11 @@ Before any merge-ready or final-approval claim, run `detect-pr-gate-coordination
 
 ### Merge-ready preconditions
 
-See [Merge Preconditions](../docs/merge-preconditions.md). Verify: zero unresolved threads (via `dev-loops review capture-threads`), visible clean `draft_gate` + current-head `pre_approval_gate`, green CI. Fresh-context review follows [Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md).
+See [Merge Preconditions](../docs/merge-preconditions.md). Verify: zero unresolved threads (via `dev-loops gate capture-threads`), visible clean `draft_gate` + current-head `pre_approval_gate`, green CI. Fresh-context review follows [Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md).
 
 ### Human approval checkpoint
 
-After merge-ready preconditions pass, verify [Merge Preconditions](../docs/merge-preconditions.md) authoritatively before reporting merge-ready. Stop at the human approval checkpoint by default. Cross-check via `dev-loops review capture-threads` (not prose assertion).
+After merge-ready preconditions pass, verify [Merge Preconditions](../docs/merge-preconditions.md) authoritatively before reporting merge-ready. Stop at the human approval checkpoint by default. Cross-check via `dev-loops gate capture-threads` (not prose assertion).
 Follow [Merge Preconditions](../docs/merge-preconditions.md): stop at `waiting_for_merge_authorization` after approval unless merge explicitly authorized. Run pre-merge gate evidence check before any `gh pr merge`.
 
 ### Mechanical pre-merge gate evidence check

--- a/test/contracts/copilot-review-doc-contracts.test.mjs
+++ b/test/contracts/copilot-review-doc-contracts.test.mjs
@@ -82,7 +82,7 @@ test("copilot-pr-followup skill routes review requests and wait seams through de
   assert.match(step6, /detect-copilot-loop-state\.mjs/i);
   assert.match(step6, /dev-loops loop watch-cycle/i);
   assert.match(step6, /gh run watch <run-id> --repo <owner\/name>/i);
-  assert.match(step6, /helper-owned sleep inside `dev-loops loop watch-cycle`, `dev-loops review probe-copilot`, or `dev-loops loop watch-initial` is allowed/i);
+  assert.match(step6, /helper-owned sleep inside `dev-loops loop watch-cycle`, `dev-loops gate probe-copilot`, or `dev-loops loop watch-initial` is allowed/i);
   assert.match(step6, /agent-authored shell polling is forbidden/i);
   assert.match(step6, /for i in \$\(seq \.\.\.\)/i);
   assert.match(step6, /while true/i);
@@ -170,7 +170,7 @@ test("copilot-pr-followup skill hardens reply-resolve, gate sequencing, and merg
   assert.ok(verificationIndex >= 0 && resolveIndex > verificationIndex, "verification checkpoint must appear before the resolve step");
   assert.match(
     step7,
-    /verify zero unresolved threads remain via `dev-loops review capture-threads` before proceeding/i,
+    /verify zero unresolved threads remain via `dev-loops gate capture-threads` before proceeding/i,
     "Step 7 should require deterministic unresolved-thread verification before advancing",
   );
   assert.match(
@@ -195,7 +195,7 @@ test("copilot-pr-followup skill hardens reply-resolve, gate sequencing, and merg
   );
   assert.match(
     step7,
-    /zero unresolved threads.*dev-loops review capture-threads/i,
+    /zero unresolved threads.*dev-loops gate capture-threads/i,
     "merge-ready preconditions should require deterministic thread-state verification",
   );
   assert.match(


### PR DESCRIPTION
## Summary

Collapses the `review` CLI category into `gate` — gate management and review operations are the same concept.

## Changes

- **cli/index.mjs**: Moved 4 review subcommands into gate category. Gate now has 7 subcommands: `upsert-verdict`, `detect-evidence`, `write-findings-log`, `request-copilot`, `probe-copilot`, `capture-threads`, `reply-resolve`. Old `dev-loops review <sub>` still works as backward-compat alias with deprecation notice.
- **skills/copilot-pr-followup/SKILL.md**: Updated `dev-loops review` → `dev-loops gate` references.
- **test/contracts/copilot-review-doc-contracts.test.mjs**: Updated test assertions.

## Verification

- `npm run verify` — 2577 tests pass, 0 failures
- Manual smoke: `dev-loops gate` shows 7 subcommands; `dev-loops review` emits deprecation and routes to gate

Closes #594
