### PR TITLE
feat(#603): add main-branch push guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,26 @@ on:
   pull_request:
 
 jobs:
+  main-branch-guard:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check that push to main is a PR merge
+        run: |
+          echo "HEAD_COMMIT_MSG<<EOF" >> "$GITHUB_ENV"
+          echo "${{ github.event.head_commit.message }}" >> "$GITHUB_ENV"
+          echo "EOF" >> "$GITHUB_ENV"
+      - name: Verify main push is from PR merge
+        run: |
+          if echo "$HEAD_COMMIT_MSG" | grep -qE '^Merge pull request #[0-9]+'; then
+            echo "PR merge detected — allowed."
+          else
+            echo "ERROR: Direct push to main detected."
+            echo "Head commit message: $HEAD_COMMIT_MSG"
+            echo "Push a feature branch and open a pull request instead."
+            exit 1
+          fi
+
   changes:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,8 @@ jobs:
           echo "EOF" >> "$GITHUB_ENV"
       - name: Verify main push is from PR merge
         run: |
-          if echo "$HEAD_COMMIT_MSG" | grep -qE '^Merge pull request #[0-9]+'; then
+          # Match regular merge ("Merge pull request #N ...") or squash merge ("...(#N)")
+          if echo "$HEAD_COMMIT_MSG" | grep -qE '(^Merge pull request #[0-9]+|\(#[0-9]+\)$)'; then
             echo "PR merge detected — allowed."
           else
             echo "ERROR: Direct push to main detected."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,27 +7,6 @@ on:
   pull_request:
 
 jobs:
-  main-branch-guard:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check that push to main is a PR merge
-        run: |
-          echo "HEAD_COMMIT_MSG<<EOF" >> "$GITHUB_ENV"
-          echo "${{ github.event.head_commit.message }}" >> "$GITHUB_ENV"
-          echo "EOF" >> "$GITHUB_ENV"
-      - name: Verify main push is from PR merge
-        run: |
-          # Match regular merge ("Merge pull request #N ...") or squash merge ("...(#N)")
-          if echo "$HEAD_COMMIT_MSG" | grep -qE '(^Merge pull request #[0-9]+|\(#[0-9]+\)$)'; then
-            echo "PR merge detected — allowed."
-          else
-            echo "ERROR: Direct push to main detected."
-            echo "Head commit message: $HEAD_COMMIT_MSG"
-            echo "Push a feature branch and open a pull request instead."
-            exit 1
-          fi
-
   changes:
     runs-on: ubuntu-latest
     outputs:

--- a/scripts/loop/pre-push-main-guard.mjs
+++ b/scripts/loop/pre-push-main-guard.mjs
@@ -23,13 +23,16 @@ const parseError = buildParseError(USAGE);
 
 /**
  * Parse pre-push hook input lines.
- * Each line: <local ref> <local sha> <remote ref> <remote sha>
  *
- * Git hook protocol is whitespace-delimited (spaces or tabs).
- * Malformed non-empty lines that do not have at least three
- * whitespace-delimited fields are treated as parse failures
- * and passed through — the guard prefers to fail-open on
- * unparseable input rather than silently blocking unknown refs.
+ * Git pre-push hook protocol: each line is four whitespace-delimited fields:
+ *   <local ref> <local sha> <remote ref> <remote sha>
+ * The fourth field (remote sha) is all-zeros for new branches.
+ *
+ * This parser accepts lines with at least three fields (treating the
+ * optional fourth field as null when absent). Malformed non-empty
+ * lines with fewer than three fields are ignored silently — the guard
+ * prefers to fail-open on unparseable input rather than silently
+ * blocking unknown refs.
  */
 async function readPushRefs(input) {
   const refs = [];

--- a/scripts/loop/pre-push-main-guard.mjs
+++ b/scripts/loop/pre-push-main-guard.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+import { createInterface } from "node:readline";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+
+const PI_PREPUSH_BYPASS_VAR = "PI_PREPUSH_BYPASS";
+const BLOCKED_REFS = ["refs/heads/main"];
+
+const USAGE = `Usage:
+  pre-push-main-guard.mjs
+
+Reads pre-push hook input from stdin (Git pre-push hook protocol).
+Blocks direct pushes to protected refs (by default: refs/heads/main).
+
+Exit codes:
+  0  Push allowed (non-main ref, or bypassed)
+  1  Push blocked (target is a protected ref)
+
+Bypass:
+  PI_PREPUSH_BYPASS=1   Skip all checks (for emergencies only).
+                         Preferred: push a feature branch and open a PR.`.trim();
+
+const parseError = buildParseError(USAGE);
+
+/**
+ * Parse pre-push hook input lines.
+ * Each line: <local ref> <local sha> <remote ref> <remote sha>
+ */
+async function readPushRefs(input) {
+  const refs = [];
+  const rl = createInterface({ input, crlfDelay: Infinity });
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const parts = trimmed.split(" ");
+    if (parts.length >= 3) {
+      refs.push({ localRef: parts[0], localSha: parts[1], remoteRef: parts[2], remoteSha: parts[3] || null });
+    }
+  }
+  return refs;
+}
+
+/**
+ * Check whether any push target is a blocked ref.
+ */
+function findBlockedRef(refs) {
+  for (const ref of refs) {
+    if (BLOCKED_REFS.includes(ref.remoteRef)) {
+      return ref.remoteRef;
+    }
+  }
+  return null;
+}
+
+export function parsePrePushGuardCliArgs(argv) {
+  const args = [...argv];
+  while (args.length > 0) {
+    const token = args.shift();
+    if (token === "--help" || token === "-h") return { help: true };
+    throw parseError(`Unknown argument: ${token}`);
+  }
+  return { help: false };
+}
+
+export async function runCli(argv = process.argv.slice(2), { stdout = process.stdout, stderr = process.stderr, stdin = process.stdin, env = process.env } = {}) {
+  const options = parsePrePushGuardCliArgs(argv);
+  if (options.help) { stdout.write(`${USAGE}\n`); return { ok: true, help: true }; }
+
+  if (env[PI_PREPUSH_BYPASS_VAR] === "1") {
+    stdout.write(JSON.stringify({ ok: true, bypassed: true, reason: `${PI_PREPUSH_BYPASS_VAR}=1` }) + "\n");
+    return { ok: true, bypassed: true };
+  }
+
+  const refs = await readPushRefs(stdin);
+  const blockedRef = findBlockedRef(refs);
+
+  if (blockedRef) {
+    const payload = {
+      ok: false,
+      error: "direct_push_to_main_blocked",
+      blockedRef,
+      message: "Direct pushes to main branch are blocked. Push a feature branch and open a pull request instead.",
+    };
+    stderr.write(`${JSON.stringify(payload)}\n`);
+    return payload;
+  }
+
+  const payload = { ok: true, blocked: false, refsChecked: refs.length };
+  stdout.write(`${JSON.stringify(payload)}\n`);
+  return payload;
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli().then((result) => { if (result?.ok === false) { process.exitCode = 1; } }).catch((error) => { process.stderr.write(`${formatCliError(error)}\n`); process.exitCode = 1; });
+}

--- a/scripts/loop/pre-push-main-guard.mjs
+++ b/scripts/loop/pre-push-main-guard.mjs
@@ -24,6 +24,12 @@ const parseError = buildParseError(USAGE);
 /**
  * Parse pre-push hook input lines.
  * Each line: <local ref> <local sha> <remote ref> <remote sha>
+ *
+ * Git hook protocol is whitespace-delimited (spaces or tabs).
+ * Malformed non-empty lines that do not have at least three
+ * whitespace-delimited fields are treated as parse failures
+ * and passed through — the guard prefers to fail-open on
+ * unparseable input rather than silently blocking unknown refs.
  */
 async function readPushRefs(input) {
   const refs = [];
@@ -31,7 +37,7 @@ async function readPushRefs(input) {
   for await (const line of rl) {
     const trimmed = line.trim();
     if (!trimmed) continue;
-    const parts = trimmed.split(" ");
+    const parts = trimmed.split(/\s+/);
     if (parts.length >= 3) {
       refs.push({ localRef: parts[0], localSha: parts[1], remoteRef: parts[2], remoteSha: parts[3] || null });
     }

--- a/test/loop/pre-push-main-guard.test.mjs
+++ b/test/loop/pre-push-main-guard.test.mjs
@@ -92,3 +92,27 @@ test("runCli blocks push when multiple refs include main", async () => {
   assert.equal(result.ok, false);
   assert.equal(result.error, "direct_push_to_main_blocked");
 });
+
+test("runCli handles tab-separated pre-push input", async () => {
+  const stdin = new PassThrough();
+  // Git hook protocol is whitespace-delimited; tabs are valid separators.
+  stdin.end("refs/heads/main\tabc123\trefs/heads/main\tdef456\n");
+  const stdout = { write: () => {} };
+  const stderr = { write: () => {} };
+  let stderrOutput = "";
+  const fakeStderr = { write: (s) => { stderrOutput += s; } };
+  const result = await runCli([], { stdout, stderr: fakeStderr, stdin });
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "direct_push_to_main_blocked");
+  assert.equal(result.blockedRef, "refs/heads/main");
+});
+
+test("runCli handles multiple-space-separated pre-push input", async () => {
+  const stdin = new PassThrough();
+  stdin.end("refs/heads/main   abc123   refs/heads/main   def456\n");
+  const stdout = { write: () => {} };
+  const stderr = { write: () => {} };
+  const result = await runCli([], { stdout, stderr, stdin });
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "direct_push_to_main_blocked");
+});

--- a/test/loop/pre-push-main-guard.test.mjs
+++ b/test/loop/pre-push-main-guard.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { PassThrough } from "node:stream";
+
+import { parsePrePushGuardCliArgs, runCli } from "../../scripts/loop/pre-push-main-guard.mjs";
+
+test("parsePrePushGuardCliArgs rejects unknown args", () => {
+  assert.throws(() => parsePrePushGuardCliArgs(["--unknown"]), /Unknown argument/i);
+});
+
+test("parsePrePushGuardCliArgs accepts --help", () => {
+  const result = parsePrePushGuardCliArgs(["--help"]);
+  assert.equal(result.help, true);
+});
+
+test("parsePrePushGuardCliArgs accepts -h", () => {
+  const result = parsePrePushGuardCliArgs(["-h"]);
+  assert.equal(result.help, true);
+});
+
+test("runCli --help returns ok with help flag", async () => {
+  const stdout = { write: () => {} };
+  const stderr = { write: () => {} };
+  let output = "";
+  const fakeStdout = { write: (s) => { output += s; } };
+  const result = await runCli(["--help"], { stdout: fakeStdout, stderr, stdin: new PassThrough() });
+  assert.ok(result.ok);
+  assert.ok(result.help);
+  assert.ok(output.includes("Usage:"));
+});
+
+test("runCli allows non-main push target", async () => {
+  const stdin = new PassThrough();
+  stdin.end("refs/heads/feature-603 abc refs/heads/feature-603 def\n");
+  const stdout = { write: () => {} };
+  const stderr = { write: () => {} };
+  let output = "";
+  const fakeStdout = { write: (s) => { output += s; } };
+  const result = await runCli([], { stdout: fakeStdout, stderr, stdin });
+  assert.ok(result.ok);
+  assert.equal(result.blocked, false);
+  assert.equal(result.refsChecked, 1);
+});
+
+test("runCli blocks push to refs/heads/main", async () => {
+  const stdin = new PassThrough();
+  stdin.end("refs/heads/main abc refs/heads/main def\n");
+  const stdout = { write: () => {} };
+  const stderr = { write: () => {} };
+  let stderrOutput = "";
+  const fakeStderr = { write: (s) => { stderrOutput += s; } };
+  const result = await runCli([], { stdout, stderr: fakeStderr, stdin });
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "direct_push_to_main_blocked");
+  assert.equal(result.blockedRef, "refs/heads/main");
+});
+
+test("runCli bypasses with PI_PREPUSH_BYPASS=1", async () => {
+  const stdin = new PassThrough();
+  stdin.end("refs/heads/main abc refs/heads/main def\n");
+  const stdout = { write: () => {} };
+  const stderr = { write: () => {} };
+  const env = { PI_PREPUSH_BYPASS: "1" };
+  let output = "";
+  const fakeStdout = { write: (s) => { output += s; } };
+  const result = await runCli([], { stdout: fakeStdout, stderr, stdin, env });
+  assert.ok(result.ok);
+  assert.equal(result.bypassed, true);
+});
+
+test("runCli handles empty stdin gracefully", async () => {
+  const stdin = new PassThrough();
+  stdin.end("");
+  const stdout = { write: () => {} };
+  const stderr = { write: () => {} };
+  let output = "";
+  const fakeStdout = { write: (s) => { output += s; } };
+  const result = await runCli([], { stdout: fakeStdout, stderr, stdin });
+  assert.ok(result.ok);
+  assert.equal(result.blocked, false);
+  assert.equal(result.refsChecked, 0);
+});
+
+test("runCli blocks push when multiple refs include main", async () => {
+  const stdin = new PassThrough();
+  stdin.end("refs/heads/feature x refs/heads/feature y\nrefs/heads/main a refs/heads/main b\n");
+  const stdout = { write: () => {} };
+  const stderr = { write: () => {} };
+  let stderrOutput = "";
+  const fakeStderr = { write: (s) => { stderrOutput += s; } };
+  const result = await runCli([], { stdout, stderr: fakeStderr, stdin });
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "direct_push_to_main_blocked");
+});


### PR DESCRIPTION
## Summary

Add a pre-push Git hook (`pre-push-main-guard.mjs`) that blocks direct pushes to `refs/heads/main`. PR merges via GitHub UI bypass local hooks naturally, so legitimate PR merges are unaffected.

## Scope / Context

Part of #441 (Doc rules audit). The existing worktree guard blocks commits *from* the main checkout, but doesn't block commits *to* the main branch. This adds the missing push-to-main guard.

- `scripts/loop/pre-push-main-guard.mjs` — new pre-push hook script
- `test/loop/pre-push-main-guard.test.mjs` — 11 tests covering all paths

## Acceptance Criteria

- [ ] Direct commits to main branch blocked
- [ ] PR merges to main still work
- [ ] Worktree checkouts still work
- [ ] npm run verify green

## Definition of Done

- [ ] Pre-push hook script implemented and tested
- [ ] All tests pass (pre-existing failure in detect-checkpoint-evidence unrelated)
- [ ] Draft gate passed, pre-approval gate passed
- [ ] PR reviewed, all threads resolved

## Non-Goals

- Does not modify existing `pre-commit-branch-guard.mjs` or `pre-flight-gate.mjs`
- Does not install the hook automatically (users install via `.git/hooks/pre-push`)
- Does not add branch protection rules (GitHub repo settings, out of scope)
- Does not add CI guard (removed per user feedback — pre-push hook is the primary guard)

Closes #603
