### PR TITLE
fix(#614): return already-requested instead of unavailable on 422 when Copilot review exists

### DIFF
--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -224,7 +224,21 @@ async function requestCopilotReview({ repo, pr }, { env = process.env, ghCommand
     const detail = result.stderr.trim() || `exit code ${result.code}`;
     const classified = classifyRequestFailure(detail);
     if (classified === "unavailable") {
-      const existing = await fetchCopilotReviewIds({ repo, pr }, { env, ghCommand });
+      let existing;
+      try {
+        existing = await fetchCopilotReviewIds({ repo, pr }, { env, ghCommand });
+      } catch {
+        // Best-effort: if gh pr view fails transiently (rate limit, network, auth),
+        // return unavailable rather than throwing — the 422 failure is already stable.
+        return {
+          ok: true,
+          status: "unavailable",
+          repo,
+          pr,
+          reviewer: "Copilot",
+          detail,
+        };
+      }
       if (existing.hasCopilotPendingReviewOnCurrentHead || existing.hasCopilotSubmittedReviewOnCurrentHead) {
         return {
           ok: true,

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -224,6 +224,16 @@ async function requestCopilotReview({ repo, pr }, { env = process.env, ghCommand
     const detail = result.stderr.trim() || `exit code ${result.code}`;
     const classified = classifyRequestFailure(detail);
     if (classified === "unavailable") {
+      const existing = await fetchCopilotReviewIds({ repo, pr }, { env, ghCommand });
+      if (existing.hasCopilotPendingReviewOnCurrentHead || existing.hasCopilotSubmittedReviewOnCurrentHead) {
+        return {
+          ok: true,
+          status: "already-requested",
+          repo,
+          pr,
+          reviewer: "Copilot",
+        };
+      }
       return {
         ok: true,
         status: "unavailable",
@@ -356,7 +366,7 @@ export async function performCopilotReviewRequest(options, { env = process.env, 
   const requestResult = await requestCopilotReview(options, { env, ghCommand });
   if (requestResult.status === "unavailable") {
     const after = await fetchCopilotReviewState(options, { env, ghCommand });
-    if (after.requested || after.hasPendingReviewOnCurrentHead) {
+    if (after.requested || after.hasPendingReviewOnCurrentHead || after.hasSubmittedReviewOnCurrentHead) {
       return {
         ok: true,
         status: "already-requested",
@@ -368,6 +378,9 @@ export async function performCopilotReviewRequest(options, { env = process.env, 
     return {
       ...requestResult,
     };
+  }
+  if (requestResult.status === "already-requested") {
+    return requestResult;
   }
   const after = await fetchCopilotReviewState(options, { env, ghCommand });
   const reviewCountIncreased = after.copilotReviewIds.length > before.copilotReviewIds.length;

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -285,6 +285,7 @@ When unresolved feedback exists, use a narrow follow-up loop:
     - if the current-head detector output still says `state=waiting_for_ci` with `snapshot.ciStatus` in `{ "pending", "none" }`, wait only via `gh run watch <run-id> --repo <owner/name>` for a known run id or else stop/resume later after the single detector refresh
     - if GitHub CI/checks for the updated head are known red for a fixable issue, continue remediation instead of re-requesting Copilot
     - only once the updated head is green or credibly green, explicitly re-request Copilot review for the new head rather than assuming it remains requested
+    - **Do NOT use `gh api POST repos/.../requested_reviewers` directly. Always use `request-copilot-review.mjs`.**
     - only enter a wait/watch loop if the request result is confirmed as `requested` or `already-requested`
     - for `requested` / `already-requested`, immediately re-baseline with `detect-copilot-loop-state.mjs`; if the returned state is `waiting_for_copilot_review`, use `dev-loops loop watch-cycle` or stop/resume later, and if the returned state is `waiting_for_ci`, use `gh run watch` for a known run id or stop/resume later after that single detector refresh
     - if the request result is `unavailable`, report that limitation and stop unless the user explicitly wants passive waiting anyway

--- a/test/github/request-copilot-review.test.mjs
+++ b/test/github/request-copilot-review.test.mjs
@@ -291,6 +291,11 @@ test("request-copilot-review normalizes known unrequestable/unavailable failures
         stderr: "gh: Reviews may only be requested from collaborators.\n",
         exitCode: 1,
       },
+      // post-422: check if Copilot already has a review on current head
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+        stdout: '{"reviews":[]}\n',
+      },
       // post-failure verification: Copilot is still not in requested_reviewers
       {
         assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
@@ -340,6 +345,11 @@ test("request-copilot-review returns already-requested when 422 but Copilot is i
         stderr: "gh: Reviews may only be requested from collaborators.\n",
         exitCode: 1,
       },
+      // post-422: check if Copilot already has a review on current head
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+        stdout: '{"reviews":[]}\n',
+      },
       // post-failure verification: Copilot now appears in requested_reviewers
       {
         assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
@@ -387,11 +397,7 @@ test("request-copilot-review returns already-requested when 422 but Copilot has 
         stderr: "gh: Reviews may only be requested from collaborators.\n",
         exitCode: 1,
       },
-      // post-failure verification: Copilot not in requested_reviewers, but has a PENDING review
-      {
-        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
-        stdout: '{"users":[],"teams":[]}\n',
-      },
+      // post-422: check if Copilot already has a review on current head — finds pending review
       {
         assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
         stdout: '{"headRefOid":"abc123","reviews":[{"id":"r-1","state":"PENDING","author":{"login":"copilot-pull-request-reviewer[bot]"},"commit":{"oid":"abc123"}}]}\n',
@@ -474,6 +480,11 @@ test("request-copilot-review ignores a stale pending Copilot review after 422 an
         assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
         stderr: "gh: Reviews may only be requested from collaborators.\n",
         exitCode: 1,
+      },
+      // post-422: check if Copilot already has a review on current head — stale review on old head, no match
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+        stdout: '{"headRefOid":"newsha","reviews":[{"id":"r-1","state":"PENDING","author":{"login":"copilot-pull-request-reviewer[bot]"},"commit":{"oid":"oldsha"}}]}\n',
       },
       {
         assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -774,8 +774,8 @@ process.exit(97);
     const env = {
       ...process.env,
       PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-      GH_REREQUEST_STATE_PATH: requestedStatePath,
       GH_SEQUENCE_PATH: path.join(tempDir, "gh-sequence.json"),
+      GH_REREQUEST_STATE_PATH: requestedStatePath,
     };
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
@@ -1072,8 +1072,8 @@ process.exit(97);
     const env = {
       ...process.env,
       PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
-      GH_REREQUEST_STATE_PATH: requestedStatePath,
       GH_SEQUENCE_PATH: path.join(tempDir, "gh-sequence.json"),
+      GH_REREQUEST_STATE_PATH: requestedStatePath,
     };
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -432,6 +432,11 @@ test("copilot-pr-handoff emits stop action when Copilot review is unavailable", 
         stderr: "gh: Reviews may only be requested from collaborators.\n",
         exitCode: 1,
       },
+      // post-422: check if Copilot already has a review on current head
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+        stdout: '{"reviews":[]}\n',
+      },
       // post-failure verification: Copilot still not in requested_reviewers
       {
         assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
@@ -501,6 +506,11 @@ test("copilot-pr-handoff emits watch action when 422 but Copilot is in requested
         stderr: "gh: Reviews may only be requested from collaborators.\n",
         exitCode: 1,
       },
+      // post-422: check if Copilot already has a review on current head
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+        stdout: '{"reviews":[]}\n',
+      },
       // post-failure verification: Copilot is now in requested_reviewers (GitHub queued it internally)
       {
         assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
@@ -566,6 +576,11 @@ test("copilot-pr-handoff emits watch action when 422 but Copilot has a pending r
         assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
         stderr: "gh: Reviews may only be requested from collaborators.\n",
         exitCode: 1,
+      },
+      // post-422: check if Copilot already has a review on current head — finds pending review
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+        stdout: '{"headRefOid":"abc123","reviews":[{"id":"r-1","state":"PENDING","author":{"login":"copilot-pull-request-reviewer[bot]"},"commit":{"oid":"abc123"}}]}\n',
       },
       // post-failure verification: Copilot not in requested_reviewers but has a PENDING review
       {


### PR DESCRIPTION
Closes #614

## Changes

- : after `classifyRequestFailure` returns `unavailable` on 422, now checks `fetchCopilotReviewIds()` and returns `already-requested` if Copilot has submitted/pending review on current head
- `performCopilotReviewRequest()`: post-failure safety net now includes `hasSubmittedReviewOnCurrentHead`
- Early return in `performCopilotReviewRequest` for `already-requested` to avoid extraneous post-verification gh calls
- Skill guidance: added explicit warning against raw `gh api` calls in step 12

## Gate checklist
- [ ] Draft gate
- [ ] Copilot review
- [ ] Pre-approval gate
- [ ] Human approval