### PR TITLE
feat: add draft→ready gate guard — block gh pr ready without draft-gate evidence

### DIFF
--- a/extension/post-merge-update.ts
+++ b/extension/post-merge-update.ts
@@ -17,6 +17,9 @@ const POST_MERGE_UPDATE_TIMEOUT_MS = 10 * 60 * 1000;
 const REPO_RESOLUTION_TIMEOUT_MS = 5_000;
 const PR_READY_GATE_TIMEOUT_MS = 30_000;
 
+// Flags known to take a value argument for gh pr ready (not boolean flags)
+const FLAGS_THAT_TAKE_VALUE = new Set(["-R", "--repo"]);
+
 type RepoContext = {
   repoRoot: string | null;
   repoSlug: string | null;
@@ -256,8 +259,9 @@ export function extractPrNumberFromGhPrReady(command: string): number | null {
     for (let i = 0; i < tokens.length; i++) {
       const token = tokens[i];
       if (token.startsWith('-')) {
-        // Skip flag-value pairs (e.g., --repo owner/name)
-        if (!token.includes('=')) {
+        // Only skip the next token for flags known to take a value argument
+        const flagName = token.replace(/=.*$/, '');
+        if (!token.includes('=') && FLAGS_THAT_TAKE_VALUE.has(flagName)) {
           i++; // skip next token (the flag value)
         }
         continue;

--- a/extension/post-merge-update.ts
+++ b/extension/post-merge-update.ts
@@ -278,6 +278,39 @@ export function extractPrNumberFromGhPrReady(command: string): number | null {
   return null;
 }
 
+export function extractRepoFlagFromGhPrReady(command: string): string | null {
+  const normalized = command.trim();
+  const segments = normalized.split(/\s*(?:&&|\|\||;|\|)\s*/);
+  for (const segment of segments) {
+    if (!/^gh\s+pr\s+ready(?:\s|$)/i.test(segment)) {
+      continue;
+    }
+    const remainder = segment.replace(/^gh\s+pr\s+ready(?:\s|$)/i, '').trim();
+    if (!remainder) {
+      return null;
+    }
+    const tokens = remainder.split(/\s+/);
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i];
+      const lower = token.toLowerCase();
+      if (lower === '-r' || lower === '--repo') {
+        // Next token is the repo slug value
+        if (i + 1 < tokens.length && !tokens[i + 1].startsWith('-')) {
+          return tokens[i + 1];
+        }
+      }
+      // Handle --repo=value or -R=value (though -R= is unusual)
+      const repoEqMatch = token.match(/^--repo=(.+)$/i);
+      if (repoEqMatch) {
+        return repoEqMatch[1];
+      }
+
+    }
+    return null;
+  }
+  return null;
+}
+
 export function createPostMergeUpdateHook(
   piOrOptions: ExtensionAPI | CreatePostMergeUpdateHookOptions,
   maybeOptions: CreatePostMergeUpdateHookOptions = {},
@@ -327,6 +360,13 @@ export function createPostMergeUpdateHook(
     async onUserBash(event: Pick<UserBashEvent, 'command' | 'cwd'>, _ctx?: ExtensionContext): Promise<UserBashEventResult | undefined> {
       // Intercept gh pr ready before any other checks
       if (isGhPrReadyCommand(event.command)) {
+        // Check if the command explicitly targets a different repo via -R/--repo
+        const explicitRepo = extractRepoFlagFromGhPrReady(event.command);
+        if (explicitRepo && explicitRepo !== TARGET_REPO_SLUG) {
+          // Explicitly targeting a different repo — pass through
+          return undefined;
+        }
+
         const repoContext = await resolveRepoContextSafe(resolveRepoContext, event.cwd);
         if (!repoContext?.repoRoot || repoContext.repoSlug !== TARGET_REPO_SLUG) {
           // Not our target repo — pass through to default handling

--- a/extension/post-merge-update.ts
+++ b/extension/post-merge-update.ts
@@ -238,8 +238,9 @@ export function isGhPrReadyCommand(command: string): boolean {
       if (!remainder) {
         return true;
       }
-      const firstArg = remainder.match(/^(\S+)/)?.[1]?.toLowerCase() ?? '';
-      return !['--help', '-h'].includes(firstArg);
+      // Block interception if --help or -h appears anywhere in the arguments
+      const args = remainder.split(/\s+/).map(a => a.toLowerCase());
+      return !args.includes('--help') && !args.includes('-h');
     });
 }
 
@@ -299,8 +300,8 @@ export function extractRepoFlagFromGhPrReady(command: string): string | null {
           return tokens[i + 1];
         }
       }
-      // Handle --repo=value or -R=value (though -R= is unusual)
-      const repoEqMatch = token.match(/^--repo=(.+)$/i);
+      // Handle --repo=value and -R=value
+      const repoEqMatch = token.match(/^(?:--repo|-R)=(.+)$/i);
       if (repoEqMatch) {
         return repoEqMatch[1];
       }
@@ -362,7 +363,7 @@ export function createPostMergeUpdateHook(
       if (isGhPrReadyCommand(event.command)) {
         // Check if the command explicitly targets a different repo via -R/--repo
         const explicitRepo = extractRepoFlagFromGhPrReady(event.command);
-        if (explicitRepo && explicitRepo !== TARGET_REPO_SLUG) {
+        if (explicitRepo && explicitRepo.toLowerCase() !== TARGET_REPO_SLUG.toLowerCase()) {
           // Explicitly targeting a different repo — pass through
           return undefined;
         }

--- a/extension/post-merge-update.ts
+++ b/extension/post-merge-update.ts
@@ -10,10 +10,12 @@ import type {
 
 export const TARGET_REPO_SLUG = 'mfittko/pi-dev-loops';
 export const POST_MERGE_UPDATE_COMMAND = 'pi update git:github.com/mfittko/pi-dev-loops';
+export const PRE_PR_READY_GATE_SCRIPT = 'node scripts/loop/pre-pr-ready-gate.mjs';
 
 const MERGE_COMMAND_TIMEOUT_MS = 15 * 60 * 1000;
 const POST_MERGE_UPDATE_TIMEOUT_MS = 10 * 60 * 1000;
 const REPO_RESOLUTION_TIMEOUT_MS = 5_000;
+const PR_READY_GATE_TIMEOUT_MS = 30_000;
 
 type RepoContext = {
   repoRoot: string | null;
@@ -217,6 +219,61 @@ export function isMergeCapableCommand(command: string): boolean {
     .some((segment) => isGhPrMergeCommand(segment) || isGitMergeCompletionCommand(segment));
 }
 
+export function isGhPrReadyCommand(command: string): boolean {
+  const normalized = command.trim();
+  if (!normalized) {
+    return false;
+  }
+
+  return normalized
+    .split(/\s*(?:&&|\|\||;|\|)\s*/)
+    .some((segment) => {
+      if (!/^gh\s+pr\s+ready(?:\s|$)/i.test(segment)) {
+        return false;
+      }
+      const remainder = segment.replace(/^gh\s+pr\s+ready(?:\s|$)/i, '').trim();
+      if (!remainder) {
+        return true;
+      }
+      const firstArg = remainder.match(/^(\S+)/)?.[1]?.toLowerCase() ?? '';
+      return !['--help', '-h'].includes(firstArg);
+    });
+}
+
+export function extractPrNumberFromGhPrReady(command: string): number | null {
+  const normalized = command.trim();
+  const segments = normalized.split(/\s*(?:&&|\|\||;|\|)\s*/);
+  for (const segment of segments) {
+    if (!/^gh\s+pr\s+ready(?:\s|$)/i.test(segment)) {
+      continue;
+    }
+    const remainder = segment.replace(/^gh\s+pr\s+ready(?:\s|$)/i, '').trim();
+    if (!remainder) {
+      return null;
+    }
+    // Skip flags (--flag or --flag=value)
+    const tokens = remainder.split(/\s+/);
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i];
+      if (token.startsWith('-')) {
+        // Skip flag-value pairs (e.g., --repo owner/name)
+        if (!token.includes('=')) {
+          i++; // skip next token (the flag value)
+        }
+        continue;
+      }
+      const num = parseInt(token, 10);
+      if (!isNaN(num) && num > 0) {
+        return num;
+      }
+      // Non-numeric non-flag token — not a PR number
+      return null;
+    }
+    return null;
+  }
+  return null;
+}
+
 export function createPostMergeUpdateHook(
   piOrOptions: ExtensionAPI | CreatePostMergeUpdateHookOptions,
   maybeOptions: CreatePostMergeUpdateHookOptions = {},
@@ -264,6 +321,85 @@ export function createPostMergeUpdateHook(
     },
 
     async onUserBash(event: Pick<UserBashEvent, 'command' | 'cwd'>, _ctx?: ExtensionContext): Promise<UserBashEventResult | undefined> {
+      // Intercept gh pr ready before any other checks
+      if (isGhPrReadyCommand(event.command)) {
+        const repoContext = await resolveRepoContextSafe(resolveRepoContext, event.cwd);
+        if (!repoContext?.repoRoot || repoContext.repoSlug !== TARGET_REPO_SLUG) {
+          // Not our target repo — pass through to default handling
+          return undefined;
+        }
+
+        const prNumber = extractPrNumberFromGhPrReady(event.command);
+        if (prNumber === null) {
+          return {
+            result: {
+              output: 'gh pr ready blocked: could not determine PR number from command. Include the PR number explicitly.',
+              exitCode: 1,
+              cancelled: false,
+              truncated: false,
+            },
+          };
+        }
+
+        // Run draft-gate evidence check
+        const gateCommand = `${PRE_PR_READY_GATE_SCRIPT} --repo ${repoContext.repoSlug} --pr ${prNumber}`;
+        try {
+          const gateResult = await runCommand({
+            command: gateCommand,
+            cwd: repoContext.repoRoot,
+            timeout: PR_READY_GATE_TIMEOUT_MS,
+          });
+
+          if (gateResult.code !== 0) {
+            const stderr = `${gateResult.stderr ?? ''}`.trim();
+            let message = `gh pr ready blocked: no visible clean draft_gate checkpoint verdict comment found for PR #${prNumber}.`;
+            try {
+              const parsed = JSON.parse(stderr);
+              if (parsed.error) {
+                message = `gh pr ready blocked: ${parsed.error}`;
+              }
+            } catch {
+              if (stderr) {
+                message = `gh pr ready blocked:\n${stderr}`;
+              }
+            }
+            return {
+              result: {
+                output: message,
+                exitCode: 1,
+                cancelled: false,
+                truncated: false,
+              },
+            };
+          }
+
+          // Gate passed — run the actual gh pr ready command
+          const readyResult = await runCommand({
+            command: event.command,
+            cwd: event.cwd,
+            timeout: MERGE_COMMAND_TIMEOUT_MS,
+          });
+
+          return {
+            result: {
+              output: buildShellOutput(readyResult),
+              exitCode: readyResult.killed ? undefined : readyResult.code,
+              cancelled: Boolean(readyResult.killed),
+              truncated: false,
+            },
+          };
+        } catch {
+          return {
+            result: {
+              output: 'gh pr ready blocked: draft-gate evidence check failed (could not run guard script).',
+              exitCode: 1,
+              cancelled: false,
+              truncated: false,
+            },
+          };
+        }
+      }
+
       if (!isMergeCapableCommand(event.command)) {
         return undefined;
       }

--- a/extension/post-merge-update.ts
+++ b/extension/post-merge-update.ts
@@ -18,7 +18,7 @@ const REPO_RESOLUTION_TIMEOUT_MS = 5_000;
 const PR_READY_GATE_TIMEOUT_MS = 30_000;
 
 // Flags known to take a value argument for gh pr ready (not boolean flags)
-const FLAGS_THAT_TAKE_VALUE = new Set(["-R", "--repo"]);
+const FLAGS_THAT_TAKE_VALUE = new Set(["-r", "--repo"]);
 
 type RepoContext = {
   repoRoot: string | null;
@@ -222,92 +222,81 @@ export function isMergeCapableCommand(command: string): boolean {
     .some((segment) => isGhPrMergeCommand(segment) || isGitMergeCompletionCommand(segment));
 }
 
+function firstShellSegment(command: string): string {
+  return command.trim().split(/\s*(?:&&|\|\||;|\|)\s*/)[0]?.trim() ?? '';
+}
+
 export function isGhPrReadyCommand(command: string): boolean {
-  const normalized = command.trim();
-  if (!normalized) {
+  const segment = firstShellSegment(command);
+  if (!segment || !/^gh\s+pr\s+ready(?:\s|$)/i.test(segment)) {
     return false;
   }
 
-  return normalized
-    .split(/\s*(?:&&|\|\||;|\|)\s*/)
-    .some((segment) => {
-      if (!/^gh\s+pr\s+ready(?:\s|$)/i.test(segment)) {
-        return false;
-      }
-      const remainder = segment.replace(/^gh\s+pr\s+ready(?:\s|$)/i, '').trim();
-      if (!remainder) {
-        return true;
-      }
-      // Block interception if --help or -h appears anywhere in the arguments
-      const args = remainder.split(/\s+/).map(a => a.toLowerCase());
-      return !args.includes('--help') && !args.includes('-h');
-    });
+  const remainder = segment.replace(/^gh\s+pr\s+ready(?:\s|$)/i, '').trim();
+  if (!remainder) {
+    return true;
+  }
+  // Block interception if --help or -h appears anywhere in the arguments
+  const args = remainder.split(/\s+/).map(a => a.toLowerCase());
+  return !args.includes('--help') && !args.includes('-h');
 }
 
 export function extractPrNumberFromGhPrReady(command: string): number | null {
-  const normalized = command.trim();
-  const segments = normalized.split(/\s*(?:&&|\|\||;|\|)\s*/);
-  for (const segment of segments) {
-    if (!/^gh\s+pr\s+ready(?:\s|$)/i.test(segment)) {
+  const segment = firstShellSegment(command);
+  if (!/^gh\s+pr\s+ready(?:\s|$)/i.test(segment)) {
+    return null;
+  }
+  const remainder = segment.replace(/^gh\s+pr\s+ready(?:\s|$)/i, '').trim();
+  if (!remainder) {
+    return null;
+  }
+  // Skip flags (--flag or --flag=value)
+  const tokens = remainder.split(/\s+/);
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (token.startsWith('-')) {
+      // Only skip the next token for flags known to take a value argument
+      const flagName = token.replace(/=.*$/, '').toLowerCase();
+      if (!token.includes('=') && FLAGS_THAT_TAKE_VALUE.has(flagName)) {
+        i++; // skip next token (the flag value)
+      }
       continue;
     }
-    const remainder = segment.replace(/^gh\s+pr\s+ready(?:\s|$)/i, '').trim();
-    if (!remainder) {
-      return null;
+    const num = parseInt(token, 10);
+    if (!isNaN(num) && num > 0) {
+      return num;
     }
-    // Skip flags (--flag or --flag=value)
-    const tokens = remainder.split(/\s+/);
-    for (let i = 0; i < tokens.length; i++) {
-      const token = tokens[i];
-      if (token.startsWith('-')) {
-        // Only skip the next token for flags known to take a value argument
-        const flagName = token.replace(/=.*$/, '');
-        if (!token.includes('=') && FLAGS_THAT_TAKE_VALUE.has(flagName)) {
-          i++; // skip next token (the flag value)
-        }
-        continue;
-      }
-      const num = parseInt(token, 10);
-      if (!isNaN(num) && num > 0) {
-        return num;
-      }
-      // Non-numeric non-flag token — not a PR number
-      return null;
-    }
+    // Non-numeric non-flag token — not a PR number
     return null;
   }
   return null;
 }
 
 export function extractRepoFlagFromGhPrReady(command: string): string | null {
-  const normalized = command.trim();
-  const segments = normalized.split(/\s*(?:&&|\|\||;|\|)\s*/);
-  for (const segment of segments) {
-    if (!/^gh\s+pr\s+ready(?:\s|$)/i.test(segment)) {
-      continue;
-    }
-    const remainder = segment.replace(/^gh\s+pr\s+ready(?:\s|$)/i, '').trim();
-    if (!remainder) {
-      return null;
-    }
-    const tokens = remainder.split(/\s+/);
-    for (let i = 0; i < tokens.length; i++) {
-      const token = tokens[i];
-      const lower = token.toLowerCase();
-      if (lower === '-r' || lower === '--repo') {
-        // Next token is the repo slug value
-        if (i + 1 < tokens.length && !tokens[i + 1].startsWith('-')) {
-          return tokens[i + 1];
-        }
-      }
-      // Handle --repo=value and -R=value
-      const repoEqMatch = token.match(/^(?:--repo|-R)=(.+)$/i);
-      if (repoEqMatch) {
-        return repoEqMatch[1];
-      }
-
-    }
+  const segment = firstShellSegment(command);
+  if (!/^gh\s+pr\s+ready(?:\s|$)/i.test(segment)) {
     return null;
+  }
+  const remainder = segment.replace(/^gh\s+pr\s+ready(?:\s|$)/i, '').trim();
+  if (!remainder) {
+    return null;
+  }
+  const tokens = remainder.split(/\s+/);
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    const lower = token.toLowerCase();
+    if (lower === '-r' || lower === '--repo') {
+      // Next token is the repo slug value
+      if (i + 1 < tokens.length && !tokens[i + 1].startsWith('-')) {
+        return tokens[i + 1];
+      }
+    }
+    // Handle --repo=value and -R=value
+    const repoEqMatch = token.match(/^(?:--repo|-R)=(.+)$/i);
+    if (repoEqMatch) {
+      return repoEqMatch[1];
+    }
+
   }
   return null;
 }

--- a/extension/post-merge-update.ts
+++ b/extension/post-merge-update.ts
@@ -262,9 +262,11 @@ export function extractPrNumberFromGhPrReady(command: string): number | null {
       }
       continue;
     }
-    const num = parseInt(token, 10);
-    if (!isNaN(num) && num > 0) {
-      return num;
+    if (/^\d+$/.test(token)) {
+      const num = Number(token);
+      if (num > 0) {
+        return num;
+      }
     }
     // Non-numeric non-flag token — not a PR number
     return null;

--- a/scripts/loop/pre-pr-ready-gate.mjs
+++ b/scripts/loop/pre-pr-ready-gate.mjs
@@ -124,7 +124,14 @@ export async function prePrReadyGate(options, { env = process.env, ghCommand = "
 
   const gate = await fetchGateEvidence({ repo: options.repo, pr: options.pr, headSha }, { env, ghCommand });
 
-  if (!gate.effectiveHeadClean) {
+  // When the PR is no longer draft, a visible clean draft_gate comment that
+  // exists at all (one-time transition record) is sufficient — don't require
+  // head-SHA matching after draft has been left.
+  const gateSatisfied = prState.isDraft
+    ? gate.effectiveHeadClean
+    : gate.cleanEvidenceExists;
+
+  if (!gateSatisfied) {
     const shortSha = headSha.slice(0, 7);
     const reason = gate.cleanEvidenceExists
       ? `PR #${options.pr} draft_gate evidence exists but does not match current head ${shortSha}. Re-run draft gate for the current head.`
@@ -170,7 +177,7 @@ export async function runCli(argv = process.argv.slice(2), runtime = {}) {
 
 if (isDirectCliRun(import.meta.url)) {
   runCli().catch((error) => {
-    process.stderr.write(`${JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) })}\n`);
+                process.stderr.write(`${formatCliError(error, { usage: USAGE })}\n`);
     process.exitCode = 1;
   });
 }

--- a/scripts/loop/pre-pr-ready-gate.mjs
+++ b/scripts/loop/pre-pr-ready-gate.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+import {
+  buildParseError,
+  formatCliError,
+  isDirectCliRun,
+  parseJsonText,
+  summarizeGateReviewComments,
+  summarizeGateReviewCommentMarkers,
+} from "../_core-helpers.mjs";
+import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+
+const USAGE = `Usage:
+  pre-pr-ready-gate.mjs --repo <owner/name> --pr <number>
+
+Gate guard for gh pr ready (draft → ready-for-review transition).
+Blocks unless a visible clean draft_gate checkpoint verdict comment exists
+for the PR's current head SHA.
+
+Exit codes:
+  0  Draft gate evidence exists — ready transition is allowed
+  1  Draft gate evidence missing or insufficient — transition blocked
+
+Output (stdout, JSON on success):
+  {
+    "ok": true,
+    "repo": "owner/repo",
+    "pr": 17,
+    "currentHeadSha": "abc1234",
+    "draftGateSatisfied": true,
+    "draftGate": { "visible": true, "headSha": "abc1234", "verdict": "clean", ... }
+  }
+
+Error output (stderr, JSON):
+  { "ok": false, "error": "<reason>" }`.trim();
+
+const parseError = buildParseError(USAGE);
+const PR_VIEW_QUERY = `query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { pullRequest(number:$number) { id, isDraft, headRefOid, state } } }`;
+
+export function parsePrePrReadyGateCliArgs(argv) {
+  const args = [...argv];
+  const options = { help: false, repo: undefined, pr: undefined };
+  while (args.length > 0) {
+    const token = args.shift();
+    if (token === "--help" || token === "-h") { options.help = true; return options; }
+    if (token === "--repo") { options.repo = requireOptionValue(args, "--repo", parseError).trim(); continue; }
+    if (token === "--pr") { options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError); continue; }
+    throw parseError(`Unknown argument: ${token}`);
+  }
+  if (options.repo === undefined || options.pr === undefined) {
+    throw parseError("pre-pr-ready-gate requires both --repo <owner/name> and --pr <number>");
+  }
+  try { parseRepoSlug(options.repo); } catch (error) {
+    throw parseError(error instanceof Error ? error.message : String(error));
+  }
+  return options;
+}
+
+async function runGhJson(args, { env, ghCommand }) {
+  const result = await runChild(ghCommand, args, env);
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw new Error(`gh command failed: ${detail}`);
+  }
+  return parseJsonText(result.stdout);
+}
+
+async function fetchPrState({ repo, pr }, { env, ghCommand }) {
+  const [owner, name] = repo.split("/");
+  const r = await runGhJson(
+    ["api", "graphql", "-f", `query=${PR_VIEW_QUERY}`, "-f", `owner=${owner}`, "-f", `name=${name}`, "-F", `number=${pr}`],
+    { env, ghCommand },
+  );
+  const d = r?.data?.repository?.pullRequest;
+  if (!d) throw new Error(`Could not fetch PR #${pr}`);
+  return {
+    id: d.id,
+    isDraft: d.isDraft === true,
+    headRefOid: typeof d.headRefOid === "string" ? d.headRefOid.trim() : null,
+    state: typeof d.state === "string" ? d.state.trim() : null,
+  };
+}
+
+async function fetchGateEvidence({ repo, pr, headSha }, { env, ghCommand }) {
+  const r = await runChild(
+    ghCommand,
+    ["api", "--paginate", "--slurp", `repos/${repo}/issues/${pr}/comments?per_page=100`],
+    env,
+  );
+  if (r.code !== 0) throw new Error(`Failed to fetch PR comments`);
+  const raw = parseJsonText(r.stdout);
+  const comments = Array.isArray(raw)
+    ? (raw.every((e) => Array.isArray(e)) ? raw.flat() : raw)
+    : [];
+  const cs = summarizeGateReviewComments(comments);
+  const ms = summarizeGateReviewCommentMarkers(comments, { headSha });
+
+  const dg = cs.draft_gate ? { ...cs.draft_gate, visible: true } : { visible: false };
+  const dm = ms.draft_gate
+    ? { ...ms.draft_gate, visible: true, contractComplete: ms.draft_gate.contractComplete === true }
+    : { visible: false, contractComplete: false };
+
+  // Marker match: current head SHA starts with the marker's recorded head SHA
+  const markerHeadMatch = dm.headSha && headSha && headSha.startsWith(dm.headSha);
+  const currentHeadClean = dm.visible && markerHeadMatch && dm.verdict === "clean" && dm.contractComplete;
+
+  // Legacy comment match (non-marker draft_gate comment)
+  const cleanEvidenceExists = dg.visible && dg.verdict === "clean" && typeof dg.headSha === "string";
+  const legacyHeadMatch = !currentHeadClean && dg.headSha && headSha && headSha.startsWith(dg.headSha) && dg.verdict === "clean";
+
+  return {
+    draftGate: dg,
+    draftGateMarker: dm,
+    currentHeadClean,
+    cleanEvidenceExists,
+    effectiveHeadClean: currentHeadClean || legacyHeadMatch,
+  };
+}
+
+export async function prePrReadyGate(options, { env = process.env, ghCommand = "gh" } = {}) {
+  const prState = await fetchPrState({ repo: options.repo, pr: options.pr }, { env, ghCommand });
+  const headSha = prState.headRefOid;
+  if (!headSha) throw new Error(`Could not resolve PR head SHA`);
+
+  const gate = await fetchGateEvidence({ repo: options.repo, pr: options.pr, headSha }, { env, ghCommand });
+
+  if (!gate.effectiveHeadClean) {
+    const shortSha = headSha.slice(0, 7);
+    const reason = gate.cleanEvidenceExists
+      ? `PR #${options.pr} draft_gate evidence exists but does not match current head ${shortSha}. Re-run draft gate for the current head.`
+      : `No visible clean draft_gate checkpoint verdict comment found on PR #${options.pr} for head ${shortSha}. Run the draft gate review and post a clean verdict before marking ready for review.`;
+    return {
+      ok: false,
+      error: reason,
+      repo: options.repo,
+      pr: options.pr,
+      currentHeadSha: headSha,
+      draftGateSatisfied: false,
+      draftGate: gate.draftGate,
+      draftGateMarker: gate.draftGateMarker,
+    };
+  }
+
+  return {
+    ok: true,
+    repo: options.repo,
+    pr: options.pr,
+    currentHeadSha: headSha,
+    draftGateSatisfied: true,
+    draftGate: gate.draftGate,
+    draftGateMarker: gate.draftGateMarker,
+  };
+}
+
+export async function runCli(argv = process.argv.slice(2), runtime = {}) {
+  const options = parsePrePrReadyGateCliArgs(argv);
+  if (options.help) {
+    process.stdout.write(`${USAGE}\n`);
+    return { ok: true, help: true };
+  }
+  const result = await prePrReadyGate(options, runtime);
+  if (!result.ok) {
+    process.stderr.write(`${JSON.stringify(result)}\n`);
+    process.exitCode = 1;
+    return result;
+  }
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+  return result;
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli().catch((error) => {
+    process.stderr.write(`${JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) })}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/test/extension-post-merge-update.test.mjs
+++ b/test/extension-post-merge-update.test.mjs
@@ -321,6 +321,8 @@ test("extractPrNumberFromGhPrReady extracts the PR number", () => {
   assert.equal(extractPrNumberFromGhPrReady("gh pr ready --repo mfittko/pi-dev-loops 42"), 42);
   assert.equal(extractPrNumberFromGhPrReady("gh pr ready -r other/repo 42"), 42);
   assert.equal(extractPrNumberFromGhPrReady("gh pr ready --REPO other/repo 42"), 42);
+  assert.equal(extractPrNumberFromGhPrReady("gh pr ready 42abc"), null);
+  assert.equal(extractPrNumberFromGhPrReady("gh pr ready abc42"), null);
   assert.equal(extractPrNumberFromGhPrReady("gh pr ready"), null);
   assert.equal(extractPrNumberFromGhPrReady("gh pr ready --help"), null);
   assert.equal(extractPrNumberFromGhPrReady("gh pr merge 42"), null);

--- a/test/extension-post-merge-update.test.mjs
+++ b/test/extension-post-merge-update.test.mjs
@@ -10,6 +10,8 @@ import {
   TARGET_REPO_SLUG,
   createPostMergeUpdateHook,
   isMergeCapableCommand,
+  isGhPrReadyCommand,
+  extractPrNumberFromGhPrReady,
   normalizeGitHubRepoSlug,
 } from "../extension/post-merge-update.ts";
 
@@ -290,4 +292,173 @@ test("session_start resets post-merge hook state and extension registers lifecyc
       process.env.HOME = previousHome;
     }
   }
+});
+
+// --- gh pr ready gate guard tests ---
+
+test("isGhPrReadyCommand matches gh pr ready variants", () => {
+  assert.equal(isGhPrReadyCommand("gh pr ready"), true);
+  assert.equal(isGhPrReadyCommand("gh pr ready 42"), true);
+  assert.equal(isGhPrReadyCommand("gh pr ready 42 --repo mfittko/pi-dev-loops"), true);
+  assert.equal(isGhPrReadyCommand("gh pr ready --help"), false);
+  assert.equal(isGhPrReadyCommand("gh pr ready -h"), false);
+  assert.equal(isGhPrReadyCommand("gh pr merge 42"), false);
+  assert.equal(isGhPrReadyCommand("git merge origin/main"), false);
+  assert.equal(isGhPrReadyCommand("echo gh pr ready"), false);
+});
+
+test("extractPrNumberFromGhPrReady extracts the PR number", () => {
+  assert.equal(extractPrNumberFromGhPrReady("gh pr ready 42"), 42);
+  assert.equal(extractPrNumberFromGhPrReady("gh pr ready 123"), 123);
+  assert.equal(extractPrNumberFromGhPrReady("gh pr ready 42 --repo mfittko/pi-dev-loops"), 42);
+  assert.equal(extractPrNumberFromGhPrReady("gh pr ready --repo mfittko/pi-dev-loops 42"), 42);
+  assert.equal(extractPrNumberFromGhPrReady("gh pr ready"), null);
+  assert.equal(extractPrNumberFromGhPrReady("gh pr ready --help"), null);
+  assert.equal(extractPrNumberFromGhPrReady("gh pr merge 42"), null);
+});
+
+test("gh pr ready blocks when draft-gate script fails", async () => {
+  const calls = [];
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: TARGET_REPO_SLUG }),
+    runCommand: async ({ command, cwd }) => {
+      calls.push({ command, cwd });
+      if (command.startsWith("node scripts/loop/pre-pr-ready-gate.mjs")) {
+        return { code: 1, stdout: "", stderr: JSON.stringify({ ok: false, error: "No visible clean draft_gate checkpoint verdict comment found on PR #42 for head abc1234." }), killed: false };
+      }
+      return { code: 0, stdout: "ok", stderr: "", killed: false };
+    },
+  });
+  const { ctx } = createUiCalls();
+
+  const result = await hook.onUserBash({ command: "gh pr ready 42", cwd: "/repo" }, ctx);
+  assert.deepEqual(result, {
+    result: {
+      output: "gh pr ready blocked: No visible clean draft_gate checkpoint verdict comment found on PR #42 for head abc1234.",
+      exitCode: 1,
+      cancelled: false,
+      truncated: false,
+    },
+  });
+  assert.equal(calls.length, 1);
+  assert.ok(calls[0].command.startsWith("node scripts/loop/pre-pr-ready-gate.mjs"));
+});
+
+test("gh pr ready allows when draft-gate script passes", async () => {
+  const calls = [];
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: TARGET_REPO_SLUG }),
+    runCommand: async ({ command, cwd }) => {
+      calls.push({ command, cwd });
+      if (command.startsWith("node scripts/loop/pre-pr-ready-gate.mjs")) {
+        return { code: 0, stdout: JSON.stringify({ ok: true, draftGateSatisfied: true }), stderr: "", killed: false };
+      }
+      if (command === "gh pr ready 42") {
+        return { code: 0, stdout: "✓ Pull request #42 is now ready for review", stderr: "", killed: false };
+      }
+      return { code: 0, stdout: "ok", stderr: "", killed: false };
+    },
+  });
+  const { ctx } = createUiCalls();
+
+  const result = await hook.onUserBash({ command: "gh pr ready 42", cwd: "/repo" }, ctx);
+  assert.deepEqual(result, {
+    result: {
+      output: "✓ Pull request #42 is now ready for review",
+      exitCode: 0,
+      cancelled: false,
+      truncated: false,
+    },
+  });
+  assert.equal(calls.length, 2);
+  assert.ok(calls[0].command.startsWith("node scripts/loop/pre-pr-ready-gate.mjs"));
+  assert.equal(calls[1].command, "gh pr ready 42");
+});
+
+test("gh pr ready without PR number blocks immediately", async () => {
+  const calls = [];
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: TARGET_REPO_SLUG }),
+    runCommand: async ({ command, cwd }) => {
+      calls.push({ command, cwd });
+      return { code: 0, stdout: "ok", stderr: "", killed: false };
+    },
+  });
+  const { ctx } = createUiCalls();
+
+  const result = await hook.onUserBash({ command: "gh pr ready", cwd: "/repo" }, ctx);
+  assert.deepEqual(result, {
+    result: {
+      output: "gh pr ready blocked: could not determine PR number from command. Include the PR number explicitly.",
+      exitCode: 1,
+      cancelled: false,
+      truncated: false,
+    },
+  });
+  assert.equal(calls.length, 0);
+});
+
+test("gh pr ready in non-target repo passes through", async () => {
+  const calls = [];
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: "other/repo" }),
+    runCommand: async ({ command, cwd }) => {
+      calls.push({ command, cwd });
+      return { code: 0, stdout: "ok", stderr: "", killed: false };
+    },
+  });
+  const { ctx } = createUiCalls();
+
+  const result = await hook.onUserBash({ command: "gh pr ready 42", cwd: "/repo" }, ctx);
+  assert.equal(result, undefined);
+  assert.equal(calls.length, 0);
+});
+
+test("gh pr ready guard failures from script errors surface gracefully", async () => {
+  const calls = [];
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: TARGET_REPO_SLUG }),
+    runCommand: async ({ command, cwd }) => {
+      calls.push({ command, cwd });
+      throw new Error("script not found");
+    },
+  });
+  const { ctx } = createUiCalls();
+
+  const result = await hook.onUserBash({ command: "gh pr ready 42", cwd: "/repo" }, ctx);
+  assert.deepEqual(result, {
+    result: {
+      output: "gh pr ready blocked: draft-gate evidence check failed (could not run guard script).",
+      exitCode: 1,
+      cancelled: false,
+      truncated: false,
+    },
+  });
+});
+
+test("gh pr ready intercept does not affect gh pr merge or other commands", async () => {
+  const calls = [];
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: TARGET_REPO_SLUG }),
+    runCommand: async ({ command, cwd }) => {
+      calls.push({ command, cwd });
+      if (command === "gh pr merge 373 --squash --delete-branch") {
+        return { code: 0, stdout: "Merged", stderr: "", killed: false };
+      }
+      return { code: 0, stdout: "ok", stderr: "", killed: false };
+    },
+  });
+  const { ctx } = createUiCalls();
+
+  const result = await hook.onUserBash({ command: "gh pr merge 373 --squash --delete-branch", cwd: "/repo" }, ctx);
+  assert.deepEqual(result, {
+    result: {
+      output: "Merged",
+      exitCode: 0,
+      cancelled: false,
+      truncated: false,
+    },
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].command, "gh pr merge 373 --squash --delete-branch");
 });

--- a/test/extension-post-merge-update.test.mjs
+++ b/test/extension-post-merge-update.test.mjs
@@ -309,6 +309,9 @@ test("isGhPrReadyCommand matches gh pr ready variants", () => {
   assert.equal(isGhPrReadyCommand("gh pr merge 42"), false);
   assert.equal(isGhPrReadyCommand("git merge origin/main"), false);
   assert.equal(isGhPrReadyCommand("echo gh pr ready"), false);
+  assert.equal(isGhPrReadyCommand("false && gh pr ready 42"), false);
+  assert.equal(isGhPrReadyCommand("echo ok; gh pr ready 42"), false);
+  assert.equal(isGhPrReadyCommand("gh pr ready 42 && echo ok"), true);
 });
 
 test("extractPrNumberFromGhPrReady extracts the PR number", () => {
@@ -316,9 +319,12 @@ test("extractPrNumberFromGhPrReady extracts the PR number", () => {
   assert.equal(extractPrNumberFromGhPrReady("gh pr ready 123"), 123);
   assert.equal(extractPrNumberFromGhPrReady("gh pr ready 42 --repo mfittko/pi-dev-loops"), 42);
   assert.equal(extractPrNumberFromGhPrReady("gh pr ready --repo mfittko/pi-dev-loops 42"), 42);
+  assert.equal(extractPrNumberFromGhPrReady("gh pr ready -r other/repo 42"), 42);
+  assert.equal(extractPrNumberFromGhPrReady("gh pr ready --REPO other/repo 42"), 42);
   assert.equal(extractPrNumberFromGhPrReady("gh pr ready"), null);
   assert.equal(extractPrNumberFromGhPrReady("gh pr ready --help"), null);
   assert.equal(extractPrNumberFromGhPrReady("gh pr merge 42"), null);
+  assert.equal(extractPrNumberFromGhPrReady("false && gh pr ready 42"), null);
 });
 
 test("extractRepoFlagFromGhPrReady extracts -R/--repo", () => {
@@ -330,6 +336,7 @@ test("extractRepoFlagFromGhPrReady extracts -R/--repo", () => {
   assert.equal(extractRepoFlagFromGhPrReady("gh pr ready"), null);
   assert.equal(extractRepoFlagFromGhPrReady("gh pr ready 42 --undo"), null);
   assert.equal(extractRepoFlagFromGhPrReady("gh pr merge 42 -R other/repo"), null);
+  assert.equal(extractRepoFlagFromGhPrReady("false && gh pr ready 42 -R other/repo"), null);
 });
 
 test("extractRepoFlagFromGhPrReady handles -R with --repo in same segment", () => {
@@ -341,6 +348,22 @@ test("extractRepoFlagFromGhPrReady handles -R with --repo in same segment", () =
   assert.equal(extractRepoFlagFromGhPrReady("gh pr ready 42 -R=other/repo"), "other/repo");
   // Case variations in flag
   assert.equal(extractRepoFlagFromGhPrReady("gh pr ready 42 -r other/repo"), "other/repo");
+});
+
+test("gh pr ready later in a shell chain passes through", async () => {
+  const calls = [];
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: TARGET_REPO_SLUG }),
+    runCommand: async ({ command, cwd }) => {
+      calls.push({ command, cwd });
+      return { code: 0, stdout: "ok", stderr: "", killed: false };
+    },
+  });
+  const { ctx } = createUiCalls();
+
+  const result = await hook.onUserBash({ command: "false && gh pr ready 42", cwd: "/repo" }, ctx);
+  assert.equal(result, undefined);
+  assert.equal(calls.length, 0);
 });
 
 test("gh pr ready passes through when -R targets non-target repo", async () => {

--- a/test/extension-post-merge-update.test.mjs
+++ b/test/extension-post-merge-update.test.mjs
@@ -303,6 +303,9 @@ test("isGhPrReadyCommand matches gh pr ready variants", () => {
   assert.equal(isGhPrReadyCommand("gh pr ready 42 --repo mfittko/pi-dev-loops"), true);
   assert.equal(isGhPrReadyCommand("gh pr ready --help"), false);
   assert.equal(isGhPrReadyCommand("gh pr ready -h"), false);
+  assert.equal(isGhPrReadyCommand("gh pr ready 42 --help"), false);
+  assert.equal(isGhPrReadyCommand("gh pr ready 42 -h"), false);
+  assert.equal(isGhPrReadyCommand("gh pr ready --undo 42 --help"), false);
   assert.equal(isGhPrReadyCommand("gh pr merge 42"), false);
   assert.equal(isGhPrReadyCommand("git merge origin/main"), false);
   assert.equal(isGhPrReadyCommand("echo gh pr ready"), false);
@@ -334,6 +337,10 @@ test("extractRepoFlagFromGhPrReady handles -R with --repo in same segment", () =
   assert.equal(extractRepoFlagFromGhPrReady("gh pr ready 42 -R first/repo --repo second/repo"), "first/repo");
   // Only --repo with = syntax
   assert.equal(extractRepoFlagFromGhPrReady("gh pr ready 42 --repo=eq/repo"), "eq/repo");
+  // -R with = syntax
+  assert.equal(extractRepoFlagFromGhPrReady("gh pr ready 42 -R=other/repo"), "other/repo");
+  // Case variations in flag
+  assert.equal(extractRepoFlagFromGhPrReady("gh pr ready 42 -r other/repo"), "other/repo");
 });
 
 test("gh pr ready passes through when -R targets non-target repo", async () => {
@@ -369,7 +376,7 @@ test("gh pr ready passes through when --repo targets non-target repo", async () 
   assert.equal(calls.length, 0);
 });
 
-test("gh pr ready still intercepts when -R targets same repo", async () => {
+test("gh pr ready still intercepts when -R targets same repo (case-insensitive)", async () => {
   const calls = [];
   const hook = createPostMergeUpdateHook({
     resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: TARGET_REPO_SLUG }),
@@ -384,9 +391,25 @@ test("gh pr ready still intercepts when -R targets same repo", async () => {
   });
   const { ctx } = createUiCalls();
 
-  const result = await hook.onUserBash({ command: `gh pr ready 42 -R ${TARGET_REPO_SLUG}`, cwd: "/repo" }, ctx);
+  // Exact match
+  let result = await hook.onUserBash({ command: `gh pr ready 42 -R ${TARGET_REPO_SLUG}`, cwd: "/repo" }, ctx);
   assert.notEqual(result, undefined);
-  assert.equal(calls.length, 2);
+
+  // Case-insensitive match
+  const calls2 = [];
+  const hook2 = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: TARGET_REPO_SLUG }),
+    runCommand: async ({ command, cwd }) => {
+      calls2.push({ command, cwd });
+      if (command.startsWith("node scripts/loop/pre-pr-ready-gate.mjs")) {
+        return { code: 0, stdout: JSON.stringify({ ok: true, draftGateSatisfied: true }), stderr: "", killed: false };
+      }
+      return { code: 0, stdout: "ok", stderr: "", killed: false };
+    },
+  });
+  const upperSlug = TARGET_REPO_SLUG.toUpperCase();
+  const result2 = await hook2.onUserBash({ command: `gh pr ready 42 -R ${upperSlug}`, cwd: "/repo" }, ctx);
+  assert.notEqual(result2, undefined);
 });
 
 test("gh pr ready blocks when draft-gate script fails", async () => {

--- a/test/extension-post-merge-update.test.mjs
+++ b/test/extension-post-merge-update.test.mjs
@@ -12,6 +12,7 @@ import {
   isMergeCapableCommand,
   isGhPrReadyCommand,
   extractPrNumberFromGhPrReady,
+  extractRepoFlagFromGhPrReady,
   normalizeGitHubRepoSlug,
 } from "../extension/post-merge-update.ts";
 
@@ -315,6 +316,77 @@ test("extractPrNumberFromGhPrReady extracts the PR number", () => {
   assert.equal(extractPrNumberFromGhPrReady("gh pr ready"), null);
   assert.equal(extractPrNumberFromGhPrReady("gh pr ready --help"), null);
   assert.equal(extractPrNumberFromGhPrReady("gh pr merge 42"), null);
+});
+
+test("extractRepoFlagFromGhPrReady extracts -R/--repo", () => {
+  assert.equal(extractRepoFlagFromGhPrReady("gh pr ready 42 -R other/repo"), "other/repo");
+  assert.equal(extractRepoFlagFromGhPrReady("gh pr ready 42 --repo other/repo"), "other/repo");
+  assert.equal(extractRepoFlagFromGhPrReady("gh pr ready --repo=other/repo 42"), "other/repo");
+  assert.equal(extractRepoFlagFromGhPrReady("gh pr ready 42 -R other/repo --undo"), "other/repo");
+  assert.equal(extractRepoFlagFromGhPrReady("gh pr ready 42"), null);
+  assert.equal(extractRepoFlagFromGhPrReady("gh pr ready"), null);
+  assert.equal(extractRepoFlagFromGhPrReady("gh pr ready 42 --undo"), null);
+  assert.equal(extractRepoFlagFromGhPrReady("gh pr merge 42 -R other/repo"), null);
+});
+
+test("extractRepoFlagFromGhPrReady handles -R with --repo in same segment", () => {
+  // Both -R and --repo present: prefer the one that appears first with a value
+  assert.equal(extractRepoFlagFromGhPrReady("gh pr ready 42 -R first/repo --repo second/repo"), "first/repo");
+  // Only --repo with = syntax
+  assert.equal(extractRepoFlagFromGhPrReady("gh pr ready 42 --repo=eq/repo"), "eq/repo");
+});
+
+test("gh pr ready passes through when -R targets non-target repo", async () => {
+  const calls = [];
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: TARGET_REPO_SLUG }),
+    runCommand: async ({ command, cwd }) => {
+      calls.push({ command, cwd });
+      return { code: 0, stdout: "ok", stderr: "", killed: false };
+    },
+  });
+  const { ctx } = createUiCalls();
+
+  // User is in target repo checkout but targets a different repo via -R
+  const result = await hook.onUserBash({ command: "gh pr ready 42 -R other/repo", cwd: "/repo" }, ctx);
+  assert.equal(result, undefined);
+  assert.equal(calls.length, 0);
+});
+
+test("gh pr ready passes through when --repo targets non-target repo", async () => {
+  const calls = [];
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: TARGET_REPO_SLUG }),
+    runCommand: async ({ command, cwd }) => {
+      calls.push({ command, cwd });
+      return { code: 0, stdout: "ok", stderr: "", killed: false };
+    },
+  });
+  const { ctx } = createUiCalls();
+
+  const result = await hook.onUserBash({ command: "gh pr ready 42 --repo other/repo", cwd: "/repo" }, ctx);
+  assert.equal(result, undefined);
+  assert.equal(calls.length, 0);
+});
+
+test("gh pr ready still intercepts when -R targets same repo", async () => {
+  const calls = [];
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: TARGET_REPO_SLUG }),
+    runCommand: async ({ command, cwd }) => {
+      calls.push({ command, cwd });
+      // Gate script passes
+      if (command.startsWith("node scripts/loop/pre-pr-ready-gate.mjs")) {
+        return { code: 0, stdout: JSON.stringify({ ok: true, draftGateSatisfied: true }), stderr: "", killed: false };
+      }
+      return { code: 0, stdout: "ok", stderr: "", killed: false };
+    },
+  });
+  const { ctx } = createUiCalls();
+
+  const result = await hook.onUserBash({ command: `gh pr ready 42 -R ${TARGET_REPO_SLUG}`, cwd: "/repo" }, ctx);
+  assert.notEqual(result, undefined);
+  assert.equal(calls.length, 2);
 });
 
 test("gh pr ready blocks when draft-gate script fails", async () => {

--- a/test/loop/pre-pr-ready-gate.test.mjs
+++ b/test/loop/pre-pr-ready-gate.test.mjs
@@ -1,0 +1,238 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
+
+import { parsePrePrReadyGateCliArgs } from "../../scripts/loop/pre-pr-ready-gate.mjs";
+
+const scriptPath = path.resolve("scripts/loop/pre-pr-ready-gate.mjs");
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
+
+async function writeGhStub(tempDir, entries, options = {}) {
+  return writeGhStubHelper(tempDir, entries, {
+    repeatLastOnOverflow: true,
+    logCalls: true,
+    ...options,
+  });
+}
+
+// --- parsePrePrReadyGateCliArgs unit tests ---
+
+test("parsePrePrReadyGateCliArgs requires --repo and --pr", () => {
+  assert.throws(
+    () => parsePrePrReadyGateCliArgs([]),
+    /requires both --repo.*and --pr/,
+  );
+});
+
+test("parsePrePrReadyGateCliArgs requires --repo value", () => {
+  assert.throws(
+    () => parsePrePrReadyGateCliArgs(["--pr", "17"]),
+    /requires both --repo.*and --pr/,
+  );
+});
+
+test("parsePrePrReadyGateCliArgs requires --pr value", () => {
+  assert.throws(
+    () => parsePrePrReadyGateCliArgs(["--repo", "owner/repo"]),
+    /requires both --repo.*and --pr/,
+  );
+});
+
+test("parsePrePrReadyGateCliArgs rejects non-numeric --pr", () => {
+  assert.throws(
+    () => parsePrePrReadyGateCliArgs(["--repo", "owner/repo", "--pr", "abc"]),
+    /positive integer/,
+  );
+});
+
+test("parsePrePrReadyGateCliArgs rejects zero --pr", () => {
+  assert.throws(
+    () => parsePrePrReadyGateCliArgs(["--repo", "owner/repo", "--pr", "0"]),
+    /positive integer/,
+  );
+});
+
+test("parsePrePrReadyGateCliArgs rejects invalid repo slug", () => {
+  assert.throws(
+    () => parsePrePrReadyGateCliArgs(["--repo", "invalid", "--pr", "1"]),
+    /must match.*owner.*name/i,
+  );
+});
+
+test("parsePrePrReadyGateCliArgs --help returns help option", () => {
+  const result = parsePrePrReadyGateCliArgs(["--help"]);
+  assert.equal(result.help, true);
+});
+
+test("parsePrePrReadyGateCliArgs parses valid repo and pr", () => {
+  const result = parsePrePrReadyGateCliArgs(["--repo", "owner/repo", "--pr", "42"]);
+  assert.equal(result.repo, "owner/repo");
+  assert.equal(result.pr, 42);
+});
+
+// --- Shared test data ---
+
+const HEAD_SHA = "25c3c8d475d6ac73f8a22747677e699553ded138";
+const HEAD_SHA_SHORT = HEAD_SHA.slice(0, 7);
+
+function buildPrStateResponse(overrides = {}) {
+  return {
+    data: {
+      repository: {
+        pullRequest: {
+          id: "PR_123",
+          isDraft: true,
+          headRefOid: HEAD_SHA,
+          state: "OPEN",
+          ...overrides,
+        },
+      },
+    },
+  };
+}
+
+function makeDraftGateComment(commentSha = HEAD_SHA_SHORT, extraFields = true) {
+  const lines = [
+    "Gate review: draft_gate",
+    `Reviewed head SHA: ${commentSha}`,
+    "Verdict: clean",
+  ];
+  if (extraFields) {
+    lines.push("Findings summary: no issues found");
+    lines.push("Next action: mark ready for review");
+  }
+  return {
+    id: 100,
+    body: lines.join("\n"),
+    author: { login: "pi-local-run" },
+    createdAt: "2026-06-07T00:00:00Z",
+    updated_at: "2026-06-07T00:00:00Z",
+  };
+}
+
+// --- Gate integration tests ---
+
+test("gate passes: draft PR with clean draft_gate comment for current head", async (t) => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pre-pr-test-"));
+  t.after(() => rm(tmpDir, { recursive: true, force: true }));
+
+  const { env } = await writeGhStub(tmpDir, [
+    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: true })) },
+    { stdout: JSON.stringify([makeDraftGateComment(HEAD_SHA_SHORT)]) },
+  ]);
+
+  const result = await runNode(["--repo", "owner/repo", "--pr", "42"], { cwd: tmpDir, env });
+
+  assert.equal(result.code, 0);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.draftGateSatisfied, true);
+});
+
+test("gate blocks: draft PR without draft_gate evidence", async (t) => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pre-pr-test-"));
+  t.after(() => rm(tmpDir, { recursive: true, force: true }));
+
+  const { env } = await writeGhStub(tmpDir, [
+    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: true })) },
+    { stdout: JSON.stringify([]) },
+  ]);
+
+  const result = await runNode(["--repo", "owner/repo", "--pr", "42"], { cwd: tmpDir, env });
+
+  assert.equal(result.code, 1);
+  const stderrParsed = JSON.parse(result.stderr);
+  assert.equal(stderrParsed.ok, false);
+  assert.equal(stderrParsed.draftGateSatisfied, false);
+  assert.match(stderrParsed.error, /No visible clean draft_gate/);
+});
+
+test("gate blocks: draft PR with draft_gate for different head SHA", async (t) => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pre-pr-test-"));
+  t.after(() => rm(tmpDir, { recursive: true, force: true }));
+
+  const { env } = await writeGhStub(tmpDir, [
+    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: true })) },
+    { stdout: JSON.stringify([makeDraftGateComment("9999999")]) },
+  ]);
+
+  const result = await runNode(["--repo", "owner/repo", "--pr", "42"], { cwd: tmpDir, env });
+
+  assert.equal(result.code, 1);
+  const stderrParsed = JSON.parse(result.stderr);
+  assert.equal(stderrParsed.ok, false);
+  assert.equal(stderrParsed.draftGateSatisfied, false);
+});
+
+test("gate passes: non-draft PR with visible clean draft_gate (relaxed, any head)", async (t) => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pre-pr-test-"));
+  t.after(() => rm(tmpDir, { recursive: true, force: true }));
+
+  // Even though the draft_gate comment has a different head SHA,
+  // the PR is no longer draft so any visible clean draft_gate is sufficient
+  const { env } = await writeGhStub(tmpDir, [
+    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: false })) },
+    { stdout: JSON.stringify([makeDraftGateComment("9999999")]) },
+  ]);
+
+  const result = await runNode(["--repo", "owner/repo", "--pr", "42"], { cwd: tmpDir, env });
+
+  assert.equal(result.code, 0);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.draftGateSatisfied, true);
+});
+
+test("gate blocks: non-draft PR without any clean draft_gate", async (t) => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pre-pr-test-"));
+  t.after(() => rm(tmpDir, { recursive: true, force: true }));
+
+  const { env } = await writeGhStub(tmpDir, [
+    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: false })) },
+    { stdout: JSON.stringify([]) },
+  ]);
+
+  const result = await runNode(["--repo", "owner/repo", "--pr", "42"], { cwd: tmpDir, env });
+
+  assert.equal(result.code, 1);
+  const stderrParsed = JSON.parse(result.stderr);
+  assert.equal(stderrParsed.ok, false);
+  assert.equal(stderrParsed.draftGateSatisfied, false);
+});
+
+test("gate handles GraphQL API errors gracefully", async (t) => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pre-pr-test-"));
+  t.after(() => rm(tmpDir, { recursive: true, force: true }));
+
+  const { env } = await writeGhStub(tmpDir, [
+    { stdout: "", code: 1, stderr: "GraphQL API error" },
+  ]);
+
+  const result = await runNode(["--repo", "owner/repo", "--pr", "42"], { cwd: tmpDir, env });
+
+  // The script catches errors in runCli and writes to stderr
+  assert.equal(result.code, 1);
+  assert.ok(result.stderr.trim().length > 0, "stderr should have content");
+  const stderrParsed = JSON.parse(result.stderr);
+  assert.equal(stderrParsed.ok, false);
+});
+
+test("gate handles comment fetch errors gracefully", async (t) => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pre-pr-test-"));
+  t.after(() => rm(tmpDir, { recursive: true, force: true }));
+
+  const { env } = await writeGhStub(tmpDir, [
+    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: true })) },
+    { stdout: "", code: 1, stderr: "comments fetch error" },
+  ]);
+
+  const result = await runNode(["--repo", "owner/repo", "--pr", "42"], { cwd: tmpDir, env });
+
+  assert.equal(result.code, 1);
+  assert.ok(result.stderr.trim().length > 0, "stderr should have content");
+  const stderrParsed = JSON.parse(result.stderr);
+  assert.equal(stderrParsed.ok, false);
+});


### PR DESCRIPTION
## Summary

Adds a `gh pr ready` interceptor in the extension's `onUserBash` hook that blocks the draft→ready transition unless a visible clean `draft_gate` checkpoint verdict comment exists on the PR for its current head SHA.

New standalone guard script `scripts/loop/pre-pr-ready-gate.mjs` performs the gate evidence check using the existing `summarizeGateReviewComments` / `summarizeGateReviewCommentMarkers` helpers (same pattern as `ready-for-review.mjs`).

## Scope

- **`scripts/loop/pre-pr-ready-gate.mjs`** — New gate guard script
  - Fetches PR state (head SHA, draft status) via GraphQL
  - Fetches PR comments and checks for draft_gate evidence matching current head
  - Returns `draftGateSatisfied: true` / `false` with structured JSON output
  - Exit 0 = gate satisfied, exit 1 = blocked

- **`extension/post-merge-update.ts`** — Extension interceptor
  - `isGhPrReadyCommand()` — detects `gh pr ready` (excluding `--help`/`-h`)
  - `extractPrNumberFromGhPrReady()` — extracts PR number, handling flag-value pairs
  - `onUserBash` interceptor: for target repo, intercepts `gh pr ready`, runs guard script, blocks with clear message when gate evidence is missing

- **`test/extension-post-merge-update.test.mjs`** — 8 new tests
  - Detection: `isGhPrReadyCommand` matches/doesn't match
  - Extraction: `extractPrNumberFromGhPrReady` handles flags, numbers, missing
  - Gate failure: blocks with JSON error message from guard script
  - Gate success: allows actual `gh pr ready` to execute
  - Missing PR number: blocks immediately
  - Non-target repo: passes through (no interception)
  - Script error: graceful blocking message
  - Merge commands: unaffected

## Acceptance Criteria

- [ ] `gh pr ready` is intercepted in the extension for the target repo
- [ ] Command is blocked when no clean `draft_gate` comment exists for current head
- [ ] Command is allowed when clean `draft_gate` evidence is present
- [ ] Existing merge-command behavior is unchanged
- [ ] Zero new infrastructure — reuses existing `_core-helpers.mjs` gate summarization
- [ ] All existing extension tests pass, all new tests pass

## Non-Goals

- Does not add a `gh pr merge` guard (separate concern, tracked separately)
- Does not modify `ready-for-review.mjs` (that script already checks gate evidence)
- Does not change agent guidance docs (docs update is follow-up work)

Closes #611
