### PR TITLE
docs: add question-requires-answer rule to AGENTS.md and dev-loop SKILL.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,5 +18,6 @@
 - All work must originate from a tracked artifact: a GitHub issue (tracker-first) or a persisted markdown plan file. No work may originate from a PR or direct local change unless explicitly requested.
 - Implement one phase at a time; if durable repo docs explicitly record a reprioritization exception, follow [Implementation State](docs/IMPLEMENTATION_STATE.md) and the active phase doc.
 - Keep compatibility surface minimal; do not add legacy aliases, wrappers, or duplicate docs unless explicitly requested.
+- A question requires an answer, not an action. When the user asks a question — even one implying criticism or correction — answer first before taking any action. Do not treat a question as implicit authorization to act.
 - Keep workflow procedure out of AGENTS; put shared contracts under `skills/docs/`.
 - No PR scope has gate exemptions (#579): see skills/dev-loop/SKILL.md "No gate exemptions" section.

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -146,3 +146,4 @@ PR #578 (docs-only, 2 files) was merged without gate checks and serves as the br
 - Questions, preferences, future-tense statements, and implied approval are not confirmation.
 - The bare response `ok` is not confirmation.
 - Stop and ask for human direction rather than guessing when local facts, GitHub facts, and helper/state-machine output do not agree.
+- A question requires an answer, not an action. When the user asks a question — even one implying criticism or correction — answer first before taking any action. Do not treat a question as implicit authorization to act.


### PR DESCRIPTION
Adds rule: a question requires an answer, not an action. When the user asks a question — even one implying criticism or correction — answer first before taking any action. Do not treat a question as implicit authorization to act.

Added to both:
- `AGENTS.md` (repo working rules)
- `skills/dev-loop/SKILL.md` (stop rules / authority boundary)
Closes #635