### PR TITLE
feat(#613): add mechanical guard for mandatory Copilot review request

### DIFF
--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -412,6 +412,53 @@ function buildResult({
   };
 }
 
+
+/**
+ * Guard: detect when Copilot has reviewed the PR without a formal
+ * review request and the gate boundary is pre_approval_gate territory.
+ * Returns true when the pre-approval gate should be blocked and the
+ * caller must run request-copilot-review.mjs first.
+ *
+ * Exception: round-cap clean fallback (rounds exhausted + clean converged)
+ * does not require a formal re-request (#613).
+ *
+ * @param {object} params
+ * @param {string} params.copilotReviewRequestStatus - "none"|"requested"|"already-requested"|"unavailable"|"failed"
+ * @param {number} params.copilotReviewRoundCount
+ * @param {number|null} params.maxCopilotRounds
+ * @param {boolean} params.sameHeadCleanConverged
+ * @param {string} params.gateBoundary - current gate boundary
+ * @returns {boolean}
+ */
+export function shouldGuardCopilotReviewRequest({
+  copilotReviewRequestStatus,
+  copilotReviewRoundCount = 0,
+  maxCopilotRounds = null,
+  sameHeadCleanConverged = false,
+  gateBoundary,
+}) {
+  const gateBoundariesRequiringCopilotFormalRequest = new Set([
+    PR_CHECKPOINT.PRE_APPROVAL_GATE_NEEDED,
+    PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW,
+    PR_CHECKPOINT.FINAL_APPROVAL_READY,
+  ]);
+  if (!gateBoundariesRequiringCopilotFormalRequest.has(gateBoundary)) {
+    return false;
+  }
+  if (copilotReviewRequestStatus !== "none") {
+    return false;
+  }
+  // Round-cap clean fallback: exhausted rounds + clean converged
+  // does not require a formal re-request.
+  const roundCapReached = maxCopilotRounds !== null
+    && typeof copilotReviewRoundCount === "number"
+    && copilotReviewRoundCount >= maxCopilotRounds;
+  if (roundCapReached && sameHeadCleanConverged) {
+    return false;
+  }
+  return true;
+}
+
 export function evaluatePrGateCoordination(input = {}) {
   const currentHeadSha = typeof input.currentHeadSha === "string" && input.currentHeadSha.trim().length > 0
     ? input.currentHeadSha.trim()

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -424,6 +424,7 @@ function buildResult({
  *
  * @param {object} params
  * @param {string} params.copilotReviewRequestStatus - "none"|"requested"|"already-requested"|"unavailable"|"failed"
+ * @param {boolean} [params.copilotReviewEverFormallyRequested=false] - whether Copilot was ever formally requested via GitHub review_requested mechanism
  * @param {number} params.copilotReviewRoundCount
  * @param {number|null} params.maxCopilotRounds
  * @param {boolean} params.sameHeadCleanConverged
@@ -433,6 +434,7 @@ function buildResult({
 export function shouldGuardCopilotReviewRequest({
   copilotReviewRequestStatus,
   copilotReviewRoundCount = 0,
+  copilotReviewEverFormallyRequested = false,
   maxCopilotRounds = null,
   sameHeadCleanConverged = false,
   gateBoundary,
@@ -446,6 +448,12 @@ export function shouldGuardCopilotReviewRequest({
     return false;
   }
   if (copilotReviewRequestStatus !== "none") {
+    return false;
+  }
+  // Durable signal: if Copilot was ever formally requested as a reviewer,
+  // the current "none" status is from a fulfilled request (normal cycle),
+  // not from a missing request. Do not guard the happy path (#613, round 2).
+  if (copilotReviewEverFormallyRequested) {
     return false;
   }
   // Round-cap clean fallback: exhausted rounds + clean converged

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -1366,6 +1366,38 @@ test("guard returns true when maxCopilotRounds is null (no round cap configured)
   }), true);
 });
 
+
+test("guard returns false when Copilot was ever formally requested (durable signal)", () => {
+  assert.equal(shouldGuardCopilotReviewRequest({
+    copilotReviewRequestStatus: "none",
+    copilotReviewRoundCount: 1,
+    copilotReviewEverFormallyRequested: true,
+    maxCopilotRounds: 5,
+    sameHeadCleanConverged: false,
+    gateBoundary: PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW,
+  }), false);
+});
+
+test("guard returns true when Copilot was never formally requested and status is none", () => {
+  assert.equal(shouldGuardCopilotReviewRequest({
+    copilotReviewRequestStatus: "none",
+    copilotReviewRoundCount: 1,
+    copilotReviewEverFormallyRequested: false,
+    maxCopilotRounds: 5,
+    sameHeadCleanConverged: false,
+    gateBoundary: PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW,
+  }), true);
+});
+
+test("guard uses default false for copilotReviewEverFormallyRequested (backward compat)", () => {
+  assert.equal(shouldGuardCopilotReviewRequest({
+    copilotReviewRequestStatus: "none",
+    copilotReviewRoundCount: 1,
+    maxCopilotRounds: 5,
+    sameHeadCleanConverged: false,
+    gateBoundary: PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW,
+  }), true);
+});
 test("guard returns false when review request status is unavailable", () => {
   assert.equal(shouldGuardCopilotReviewRequest({
     copilotReviewRequestStatus: "unavailable",

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -5,6 +5,7 @@ import {
   evaluatePrGateCoordination,
   PR_CHECKPOINT_ACTION,
   PR_CHECKPOINT,
+  shouldGuardCopilotReviewRequest,
 } from "../src/loop/pr-gate-coordination.mjs";
 import { DISPOSITION, STATE } from "../src/loop/copilot-loop-state.mjs";
 
@@ -1291,4 +1292,86 @@ test("mergeStateStatus null still allows gate progression (#566 regression guard
 
   assert.equal(result.gateBoundary, PR_CHECKPOINT.FINAL_APPROVAL_READY);
   assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL);
+});
+
+// --- Copilot review request guard (#613) ---
+
+test("shouldGuardCopilotReviewRequest returns true when copilot reviewed without formal request at pre_approval_gate", () => {
+  assert.equal(shouldGuardCopilotReviewRequest({
+    copilotReviewRequestStatus: "none",
+    copilotReviewRoundCount: 1,
+    maxCopilotRounds: 5,
+    sameHeadCleanConverged: false,
+    gateBoundary: PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW,
+  }), true);
+});
+
+test("guard returns false when formal request was made (requested)", () => {
+  assert.equal(shouldGuardCopilotReviewRequest({
+    copilotReviewRequestStatus: "requested",
+    copilotReviewRoundCount: 2,
+    maxCopilotRounds: 5,
+    sameHeadCleanConverged: true,
+    gateBoundary: PR_CHECKPOINT.FINAL_APPROVAL_READY,
+  }), false);
+});
+
+test("guard returns false when already-requested", () => {
+  assert.equal(shouldGuardCopilotReviewRequest({
+    copilotReviewRequestStatus: "already-requested",
+    copilotReviewRoundCount: 1,
+    maxCopilotRounds: 5,
+    sameHeadCleanConverged: false,
+    gateBoundary: PR_CHECKPOINT.PRE_APPROVAL_GATE_NEEDED,
+  }), false);
+});
+
+test("guard returns false for non-pre-approval gate boundaries", () => {
+  assert.equal(shouldGuardCopilotReviewRequest({
+    copilotReviewRequestStatus: "none",
+    copilotReviewRoundCount: 1,
+    maxCopilotRounds: 5,
+    sameHeadCleanConverged: false,
+    gateBoundary: PR_CHECKPOINT.POST_DRAFT_EXTERNAL_REVIEW,
+  }), false);
+});
+
+test("guard returns false for round-cap clean fallback (exhausted rounds + clean converged)", () => {
+  assert.equal(shouldGuardCopilotReviewRequest({
+    copilotReviewRequestStatus: "none",
+    copilotReviewRoundCount: 5,
+    maxCopilotRounds: 5,
+    sameHeadCleanConverged: true,
+    gateBoundary: PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW,
+  }), false);
+});
+
+test("guard returns true for exhausted rounds without clean converged (round cap not clean)", () => {
+  assert.equal(shouldGuardCopilotReviewRequest({
+    copilotReviewRequestStatus: "none",
+    copilotReviewRoundCount: 5,
+    maxCopilotRounds: 5,
+    sameHeadCleanConverged: false,
+    gateBoundary: PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW,
+  }), true);
+});
+
+test("guard returns false when maxCopilotRounds is null (no round cap configured)", () => {
+  assert.equal(shouldGuardCopilotReviewRequest({
+    copilotReviewRequestStatus: "none",
+    copilotReviewRoundCount: 100,
+    maxCopilotRounds: null,
+    sameHeadCleanConverged: true,
+    gateBoundary: PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW,
+  }), true);
+});
+
+test("guard returns false when review request status is unavailable", () => {
+  assert.equal(shouldGuardCopilotReviewRequest({
+    copilotReviewRequestStatus: "unavailable",
+    copilotReviewRoundCount: 1,
+    maxCopilotRounds: 5,
+    sameHeadCleanConverged: false,
+    gateBoundary: PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW,
+  }), false);
 });

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -1356,7 +1356,7 @@ test("guard returns true for exhausted rounds without clean converged (round cap
   }), true);
 });
 
-test("guard returns false when maxCopilotRounds is null (no round cap configured)", () => {
+test("guard returns true when maxCopilotRounds is null (no round cap configured)", () => {
   assert.equal(shouldGuardCopilotReviewRequest({
     copilotReviewRequestStatus: "none",
     copilotReviewRoundCount: 100,

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -16,6 +16,7 @@ import { loadDevLoopConfig, resolveGateConfig, resolveRefinementConfig, resolveW
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import { buildSnapshotFromPrFacts, interpretLoopState, summarizeLoopInterpretation } from "@pi-dev-loops/core/loop/copilot-loop-state";
 import { evaluatePrGateCoordination, PR_CHECKPOINT, PR_CHECKPOINT_ACTION } from "@pi-dev-loops/core/loop/pr-gate-coordination";
+import { shouldGuardCopilotReviewRequest } from "../../packages/core/src/loop/pr-gate-coordination.mjs";
 import { fetchGithubReviewThreadsPayload } from "../github/capture-review-threads.mjs";
 import { detectCheckpointEvidence } from "../github/detect-checkpoint-evidence.mjs";
 const UNMERGED_GIT_STATUS_CODES = new Set(["DD", "AU", "UD", "UA", "DU", "AA", "UU"]);
@@ -381,6 +382,26 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
     preApprovalGateMarker: context.gateEvidence.preApprovalGateMarker,
     refinementArtifact: context.refinementArtifact,
   });
+  // Copilot review request guard (#613): When Copilot has reviewed the PR
+  // but no formal review request was made, block pre-approval gate entry.
+  if (shouldGuardCopilotReviewRequest({
+    copilotReviewRequestStatus: context.snapshot?.copilotReviewRequestStatus ?? "none",
+    copilotReviewRoundCount: context.snapshot?.copilotReviewRoundCount ?? 0,
+    maxCopilotRounds,
+    sameHeadCleanConverged: context.interpretation?.sameHeadCleanConverged ?? false,
+    gateBoundary: result.gateBoundary,
+  })) {
+    result.gateBoundary = PR_CHECKPOINT.POST_DRAFT_EXTERNAL_REVIEW;
+    result.nextAction = PR_CHECKPOINT_ACTION.REQUEST_COPILOT_REVIEW;
+    result.reason = "No formal Copilot review request found — run request-copilot-review.mjs first.";
+    result.allowedNextActions = [PR_CHECKPOINT_ACTION.REQUEST_COPILOT_REVIEW];
+    result.forbiddenActions = [
+      PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE,
+      PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL,
+      PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY,
+    ];
+  }
+
   const preApprovalNeverEntered = !(result.preApprovalGate?.contractComplete === true);
   const gateBoundariesExpectingPreApproval = new Set([
     PR_CHECKPOINT.PRE_APPROVAL_GATE_NEEDED,

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -401,10 +401,15 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
   // Copilot review request guard (#613): When Copilot has reviewed the PR
   // but no formal review request was made, block pre-approval gate entry.
   // Only query timeline when cheap preconditions pass — avoids unnecessary
-  // API call when guard cannot possibly trigger (e.g. gate boundary not in
-  // pre-approval territory or request status is not "none").
+  // API call when guard cannot possibly trigger.
   const copilotReviewRequestStatus = context.snapshot?.copilotReviewRequestStatus ?? "none";
+  const guardBoundaries = new Set([
+    PR_CHECKPOINT.PRE_APPROVAL_GATE_NEEDED,
+    PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW,
+    PR_CHECKPOINT.FINAL_APPROVAL_READY,
+  ]);
   const copilotReviewEverFormallyRequested = copilotReviewRequestStatus === "none"
+    && guardBoundaries.has(result.gateBoundary)
     ? await fetchCopilotEverFormallyRequested(
         { repo: context.repo, pr: context.pr },
         runtime,

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -348,6 +348,22 @@ export async function loadPrGateCoordinationContext(options, runtime = {}) {
     refinementArtifact,
   };
 }
+
+async function fetchCopilotEverFormallyRequested({ repo, pr }, { env = process.env, ghCommand = "gh" } = {}) {
+  const result = await runChild(
+    ghCommand,
+    ["api", `repos/${repo}/issues/${pr}/timeline`, "--paginate", "--jq",
+      '.[] | select(.event == "review_requested") | select(.requested_reviewer.login != null) | .requested_reviewer.login'],
+    env,
+  );
+  if (result.code !== 0) return false;
+  for (const line of result.stdout.trim().split("\n")) {
+    const login = line.trim();
+    if (login && isCopilotLogin(login)) return true;
+  }
+  return false;
+}
+
 export async function detectPrGateCoordinationState(options, runtime = {}) {
   const context = await loadPrGateCoordinationContext(options, runtime);
   const repoRoot = runtime.repoRoot ?? process.cwd();
@@ -384,9 +400,14 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
   });
   // Copilot review request guard (#613): When Copilot has reviewed the PR
   // but no formal review request was made, block pre-approval gate entry.
+  const copilotReviewEverFormallyRequested = await fetchCopilotEverFormallyRequested(
+    { repo: context.repo, pr: context.pr },
+    runtime,
+  );
   if (shouldGuardCopilotReviewRequest({
     copilotReviewRequestStatus: context.snapshot?.copilotReviewRequestStatus ?? "none",
     copilotReviewRoundCount: context.snapshot?.copilotReviewRoundCount ?? 0,
+    copilotReviewEverFormallyRequested,
     maxCopilotRounds,
     sameHeadCleanConverged: context.interpretation?.sameHeadCleanConverged ?? false,
     gateBoundary: result.gateBoundary,

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -400,12 +400,18 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
   });
   // Copilot review request guard (#613): When Copilot has reviewed the PR
   // but no formal review request was made, block pre-approval gate entry.
-  const copilotReviewEverFormallyRequested = await fetchCopilotEverFormallyRequested(
-    { repo: context.repo, pr: context.pr },
-    runtime,
-  );
+  // Only query timeline when cheap preconditions pass — avoids unnecessary
+  // API call when guard cannot possibly trigger (e.g. gate boundary not in
+  // pre-approval territory or request status is not "none").
+  const copilotReviewRequestStatus = context.snapshot?.copilotReviewRequestStatus ?? "none";
+  const copilotReviewEverFormallyRequested = copilotReviewRequestStatus === "none"
+    ? await fetchCopilotEverFormallyRequested(
+        { repo: context.repo, pr: context.pr },
+        runtime,
+      )
+    : false;
   if (shouldGuardCopilotReviewRequest({
-    copilotReviewRequestStatus: context.snapshot?.copilotReviewRequestStatus ?? "none",
+    copilotReviewRequestStatus,
     copilotReviewRoundCount: context.snapshot?.copilotReviewRoundCount ?? 0,
     copilotReviewEverFormallyRequested,
     maxCopilotRounds,

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -396,6 +396,8 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
     result.reason = "No formal Copilot review request found — run request-copilot-review.mjs first.";
     result.allowedNextActions = [PR_CHECKPOINT_ACTION.REQUEST_COPILOT_REVIEW];
     result.forbiddenActions = [
+      PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE,
+      PR_CHECKPOINT_ACTION.MARK_READY_FOR_REVIEW,
       PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE,
       PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL,
       PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY,

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -408,8 +408,13 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
     PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW,
     PR_CHECKPOINT.FINAL_APPROVAL_READY,
   ]);
+  const roundCapReached = maxCopilotRounds !== null
+    && typeof (context.snapshot?.copilotReviewRoundCount) === "number"
+    && context.snapshot?.copilotReviewRoundCount >= maxCopilotRounds;
+  const sameHeadCleanConverged = context.interpretation?.sameHeadCleanConverged ?? false;
   const copilotReviewEverFormallyRequested = copilotReviewRequestStatus === "none"
     && guardBoundaries.has(result.gateBoundary)
+    && !(roundCapReached && sameHeadCleanConverged)
     ? await fetchCopilotEverFormallyRequested(
         { repo: context.repo, pr: context.pr },
         runtime,

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -820,9 +820,9 @@ test("pre-approval-gate-detector overrides to pre_approval_gate_needed when neve
     assert.equal(result.code, 0);
     assert.equal(result.stderr, "");
     const parsed = JSON.parse(result.stdout);
-    assert.equal(parsed.gateBoundary, "pre_approval_gate_needed");
-    assert.equal(parsed.nextAction, "run_pre_approval_gate");
-    assert.match(parsed.reason, /contract-complete pre_approval_gate marker/i);
+    assert.equal(parsed.gateBoundary, "post_draft_external_review");
+    assert.equal(parsed.nextAction, "request_copilot_review");
+    assert.match(parsed.reason, /No formal Copilot review request found/i);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -133,6 +133,10 @@ test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs
           },
         ]]),
       },
+      {
+        assertArgs: ["api", "--paginate", "--jq"],
+        stdout: "\n",
+      },
     ]);
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "266"], { env });
@@ -230,6 +234,10 @@ test("detect-pr-gate-coordination-state flags draft_gate_needed for non-draft PR
         assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/266/comments?per_page=100"],
         stdout: jsonLine([[]]),
       },
+      {
+        assertArgs: ["api", "--paginate", "--jq"],
+        stdout: "\n",
+      },
     ]);
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "266"], { env });
@@ -296,6 +304,10 @@ test("detect-pr-gate-coordination-state flags draft_gate_needed for converged no
             updated_at: "2026-05-31T20:00:00Z",
           },
         ]]),
+      },
+      {
+        assertArgs: ["api", "--paginate", "--jq"],
+        stdout: "\n",
       },
     ]);
 
@@ -389,6 +401,10 @@ test("detect-pr-gate-coordination-state flags draft_gate_needed when Copilot rou
             updated_at: "2026-05-31T20:00:00Z",
           },
         ]]),
+      },
+      {
+        assertArgs: ["api", "--paginate", "--jq"],
+        stdout: "\n",
       },
     ]);
 
@@ -490,6 +506,10 @@ test("detect-pr-gate-coordination-state auto-detects local-fix-without-reply (#4
           ],
         ]),
       },
+      {
+        assertArgs: ["api", "--paginate", "--jq"],
+        stdout: "\n",
+      },
     ]);
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "269"], { env });
@@ -536,6 +556,10 @@ test("detectPrGateCoordinationState tolerates missing local git binary and falls
       {
         assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/266/comments?per_page=100"],
         stdout: jsonLine([[]]),
+      },
+      {
+        assertArgs: ["api", "--paginate", "--jq"],
+        stdout: "\n",
       },
     ]);
 
@@ -597,6 +621,10 @@ test("detect-pr-gate-coordination-state preserves non-conflict mergeStateStatus 
             updated_at: "2026-05-31T20:00:00Z",
           },
         ]]),
+      },
+      {
+        assertArgs: ["api", "--paginate", "--jq"],
+        stdout: "\n",
       },
     ]);
 
@@ -741,6 +769,10 @@ test.skip("detect-pr-gate-coordination-state with --review-mode internal_only sk
           },
         ]]),
       },
+      {
+        assertArgs: ["api", "--paginate", "--jq"],
+        stdout: "\n",
+      },
     ]);
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "267", "--review-mode", "internal_only"], { env });
@@ -812,6 +844,10 @@ test("pre-approval-gate-detector overrides to pre_approval_gate_needed when neve
             },
           ],
         ]),
+      },
+      {
+        assertArgs: ["api", "--paginate", "--jq"],
+        stdout: "\n",
       },
     ]);
 
@@ -904,6 +940,10 @@ test("detect-pr-gate-coordination-state blocks merge readiness when retrospectiv
           },
         ]]),
       },
+      {
+        assertArgs: ["api", "--paginate", "--jq"],
+        stdout: "\n",
+      },
     ]);
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "271"], { env, cwd: tempDir });
@@ -952,6 +992,10 @@ test("detect-pr-gate-coordination-state fails closed when the PR head changes mi
         assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/266/comments?per_page=100"],
         stdout: "[]\n",
       },
+      {
+        assertArgs: ["api", "--paginate", "--jq"],
+        stdout: "\n",
+      },
     ]);
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "266"], { env });
@@ -997,6 +1041,10 @@ test("detect-pr-gate-coordination-state surfaces linked-issue + refinement via g
         stdout: JSON.stringify({
           body: "## Problem\n\nProse only.\n\n## Root Cause\n\nBug.\n\n## Fix\n\nChange.\n",
         }) + "\n",
+      },
+      {
+        assertArgs: ["api", "--paginate", "--jq"],
+        stdout: "\n",
       },
     ]);
 
@@ -1044,6 +1092,10 @@ test("detect-pr-gate-coordination-state leaves refinement=present when linked is
         stdout: JSON.stringify({
           body: "## Acceptance criteria\n\n- [ ] First AC\n- [x] Second AC\n",
         }) + "\n",
+      },
+      {
+        assertArgs: ["api", "--paginate", "--jq"],
+        stdout: "\n",
       },
     ]);
 
@@ -1098,6 +1150,10 @@ test("detect-pr-gate-coordination-state resets Copilot round count when draft_ga
       {
         assertArgs: ["issue", "view", "527", "--repo", "owner/repo", "--json", "body"],
         stdout: jsonLine({ body: "## Acceptance criteria\n\n- [ ] Round count resets on new head\n- [ ] No reset on same head\n" }),
+      },
+      {
+        assertArgs: ["api", "--paginate", "--jq"],
+        stdout: "\n",
       },
     ]);
 
@@ -1155,6 +1211,10 @@ test("detect-pr-gate-coordination-state does NOT reset round count when draft_ga
       {
         assertArgs: ["issue", "view", "527", "--repo", "owner/repo", "--json", "body"],
         stdout: jsonLine({ body: "## Acceptance criteria\n\n- [ ] Round count resets on new head\n- [ ] No reset on same head\n" }),
+      },
+      {
+        assertArgs: ["api", "--paginate", "--jq"],
+        stdout: "\n",
       },
     ]);
 

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -134,7 +134,7 @@ test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs
         ]]),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
+        assertArgContains: ["api", "--paginate", "--jq", 'event == "review_requested"'],
         stdout: "\n",
       },
     ]);
@@ -235,7 +235,7 @@ test("detect-pr-gate-coordination-state flags draft_gate_needed for non-draft PR
         stdout: jsonLine([[]]),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
+        assertArgContains: ["api", "--paginate", "--jq", 'event == "review_requested"'],
         stdout: "\n",
       },
     ]);
@@ -306,7 +306,7 @@ test("detect-pr-gate-coordination-state flags draft_gate_needed for converged no
         ]]),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
+        assertArgContains: ["api", "--paginate", "--jq", 'event == "review_requested"'],
         stdout: "\n",
       },
     ]);
@@ -403,7 +403,7 @@ test("detect-pr-gate-coordination-state flags draft_gate_needed when Copilot rou
         ]]),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
+        assertArgContains: ["api", "--paginate", "--jq", 'event == "review_requested"'],
         stdout: "\n",
       },
     ]);
@@ -507,7 +507,7 @@ test("detect-pr-gate-coordination-state auto-detects local-fix-without-reply (#4
         ]),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
+        assertArgContains: ["api", "--paginate", "--jq", 'event == "review_requested"'],
         stdout: "\n",
       },
     ]);
@@ -558,7 +558,7 @@ test("detectPrGateCoordinationState tolerates missing local git binary and falls
         stdout: jsonLine([[]]),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
+        assertArgContains: ["api", "--paginate", "--jq", 'event == "review_requested"'],
         stdout: "\n",
       },
     ]);
@@ -623,7 +623,7 @@ test("detect-pr-gate-coordination-state preserves non-conflict mergeStateStatus 
         ]]),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
+        assertArgContains: ["api", "--paginate", "--jq", 'event == "review_requested"'],
         stdout: "\n",
       },
     ]);
@@ -770,7 +770,7 @@ test.skip("detect-pr-gate-coordination-state with --review-mode internal_only sk
         ]]),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
+        assertArgContains: ["api", "--paginate", "--jq", 'event == "review_requested"'],
         stdout: "\n",
       },
     ]);
@@ -846,7 +846,7 @@ test("pre-approval-gate-detector overrides to pre_approval_gate_needed when neve
         ]),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
+        assertArgContains: ["api", "--paginate", "--jq", 'event == "review_requested"'],
         stdout: "\n",
       },
     ]);
@@ -941,7 +941,7 @@ test("detect-pr-gate-coordination-state blocks merge readiness when retrospectiv
         ]]),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
+        assertArgContains: ["api", "--paginate", "--jq", 'event == "review_requested"'],
         stdout: "\n",
       },
     ]);
@@ -993,7 +993,7 @@ test("detect-pr-gate-coordination-state fails closed when the PR head changes mi
         stdout: "[]\n",
       },
       {
-        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
+        assertArgContains: ["api", "--paginate", "--jq", 'event == "review_requested"'],
         stdout: "\n",
       },
     ]);
@@ -1043,7 +1043,7 @@ test("detect-pr-gate-coordination-state surfaces linked-issue + refinement via g
         }) + "\n",
       },
       {
-        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
+        assertArgContains: ["api", "--paginate", "--jq", 'event == "review_requested"'],
         stdout: "\n",
       },
     ]);
@@ -1094,7 +1094,7 @@ test("detect-pr-gate-coordination-state leaves refinement=present when linked is
         }) + "\n",
       },
       {
-        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
+        assertArgContains: ["api", "--paginate", "--jq", 'event == "review_requested"'],
         stdout: "\n",
       },
     ]);
@@ -1152,7 +1152,7 @@ test("detect-pr-gate-coordination-state resets Copilot round count when draft_ga
         stdout: jsonLine({ body: "## Acceptance criteria\n\n- [ ] Round count resets on new head\n- [ ] No reset on same head\n" }),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
+        assertArgContains: ["api", "--paginate", "--jq", 'event == "review_requested"'],
         stdout: "\n",
       },
     ]);
@@ -1213,7 +1213,7 @@ test("detect-pr-gate-coordination-state does NOT reset round count when draft_ga
         stdout: jsonLine({ body: "## Acceptance criteria\n\n- [ ] Round count resets on new head\n- [ ] No reset on same head\n" }),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
+        assertArgContains: ["api", "--paginate", "--jq", 'event == "review_requested"'],
         stdout: "\n",
       },
     ]);

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -134,7 +134,7 @@ test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs
         ]]),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq"],
+        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
         stdout: "\n",
       },
     ]);
@@ -235,7 +235,7 @@ test("detect-pr-gate-coordination-state flags draft_gate_needed for non-draft PR
         stdout: jsonLine([[]]),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq"],
+        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
         stdout: "\n",
       },
     ]);
@@ -306,7 +306,7 @@ test("detect-pr-gate-coordination-state flags draft_gate_needed for converged no
         ]]),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq"],
+        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
         stdout: "\n",
       },
     ]);
@@ -403,7 +403,7 @@ test("detect-pr-gate-coordination-state flags draft_gate_needed when Copilot rou
         ]]),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq"],
+        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
         stdout: "\n",
       },
     ]);
@@ -507,7 +507,7 @@ test("detect-pr-gate-coordination-state auto-detects local-fix-without-reply (#4
         ]),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq"],
+        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
         stdout: "\n",
       },
     ]);
@@ -558,7 +558,7 @@ test("detectPrGateCoordinationState tolerates missing local git binary and falls
         stdout: jsonLine([[]]),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq"],
+        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
         stdout: "\n",
       },
     ]);
@@ -623,7 +623,7 @@ test("detect-pr-gate-coordination-state preserves non-conflict mergeStateStatus 
         ]]),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq"],
+        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
         stdout: "\n",
       },
     ]);
@@ -770,7 +770,7 @@ test.skip("detect-pr-gate-coordination-state with --review-mode internal_only sk
         ]]),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq"],
+        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
         stdout: "\n",
       },
     ]);
@@ -846,7 +846,7 @@ test("pre-approval-gate-detector overrides to pre_approval_gate_needed when neve
         ]),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq"],
+        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
         stdout: "\n",
       },
     ]);
@@ -941,7 +941,7 @@ test("detect-pr-gate-coordination-state blocks merge readiness when retrospectiv
         ]]),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq"],
+        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
         stdout: "\n",
       },
     ]);
@@ -993,7 +993,7 @@ test("detect-pr-gate-coordination-state fails closed when the PR head changes mi
         stdout: "[]\n",
       },
       {
-        assertArgs: ["api", "--paginate", "--jq"],
+        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
         stdout: "\n",
       },
     ]);
@@ -1043,7 +1043,7 @@ test("detect-pr-gate-coordination-state surfaces linked-issue + refinement via g
         }) + "\n",
       },
       {
-        assertArgs: ["api", "--paginate", "--jq"],
+        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
         stdout: "\n",
       },
     ]);
@@ -1094,7 +1094,7 @@ test("detect-pr-gate-coordination-state leaves refinement=present when linked is
         }) + "\n",
       },
       {
-        assertArgs: ["api", "--paginate", "--jq"],
+        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
         stdout: "\n",
       },
     ]);
@@ -1152,7 +1152,7 @@ test("detect-pr-gate-coordination-state resets Copilot round count when draft_ga
         stdout: jsonLine({ body: "## Acceptance criteria\n\n- [ ] Round count resets on new head\n- [ ] No reset on same head\n" }),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq"],
+        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
         stdout: "\n",
       },
     ]);
@@ -1213,7 +1213,7 @@ test("detect-pr-gate-coordination-state does NOT reset round count when draft_ga
         stdout: jsonLine({ body: "## Acceptance criteria\n\n- [ ] Round count resets on new head\n- [ ] No reset on same head\n" }),
       },
       {
-        assertArgs: ["api", "--paginate", "--jq"],
+        assertArgs: ["api", "--paginate", "--jq", "event == \"review_requested\""],
         stdout: "\n",
       },
     ]);


### PR DESCRIPTION
Closes #613

## Summary

Adds a mechanical guard that blocks pre-approval gate entry when Copilot has reviewed the PR without a formal review request (`request-copilot-review.mjs` was never called).

## Problem

During Wave 2, a child agent skipped the formal Copilot review request after the draft gate passed. The state machine blocked the pre-approval gate — but only after significant wasted time. No tooling said "you have not formally requested Copilot review" and stopped the child early.

## Changes

- **`packages/core/src/loop/pr-gate-coordination.mjs`**: Added `shouldGuardCopilotReviewRequest()` guard function with round-cap clean fallback exception
- **`packages/core/test/pr-gate-coordination.test.mjs`**: 8 unit tests covering all guard scenarios
- **`scripts/loop/detect-pr-gate-coordination-state.mjs`**: Wire guard into post-hoc checks in `detectPrGateCoordinationState`
- **`test/loop/detect-pr-gate-coordination-state.test.mjs`**: Updated integration test

## Guard behavior

- Triggers at PRE_APPROVAL_GATE boundaries when `copilotReviewRequestStatus === "none"`
- Exception: round-cap clean fallback (exhausted rounds + clean converged) skips guard
- Redirects to `post_draft_external_review` with "run request-copilot-review.mjs first" message