### PR TITLE
Declutter copilot-pr-followup SKILL.md (#624)

### DIFF
--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -118,10 +118,10 @@ At the issue-assignment seam, use `detect-initial-copilot-pr-state.mjs` and keep
 When confirming whether Copilot is requested as a reviewer, do not rely solely on `gh pr view --json reviewRequests`. Use `request-copilot-review.mjs` (see [Operational cookbook](#operational-cookbook)). Do **not** request Copilot by posting literal `/copilot` or `/copilot re-review` PR comments. After draft→ready or fix push, explicitly decide whether another pass is desired; if yes, ensure green/credibly green posture first.
 
 Branch on the `request-copilot-review.mjs` machine-readable result:
-- `requested`: re-baseline with `detect-copilot-loop-state.mjs` and follow its `nextAction` (enter persistent wait only through `dev-loops loop watch-cycle` or `gh run watch`)
+- `requested`: if another Copilot pass is actually desired, immediately re-baseline with `detect-copilot-loop-state.mjs` and follow its `nextAction` (enter persistent wait only through `dev-loops loop watch-cycle` or `gh run watch`)
 - `already-requested`: apply the same detector-first rebasing and wait branching as `requested`
 - `suppressed_same_head_clean`: report clean-converged state and stop unless `--force-rerequest-review` bypass is intentionally authorized
-- `unavailable`: report limitation and stop
+- `unavailable`: report the limitation and stop
 - non-zero / unexpected failure: stop and report error
 
 Do not treat an attempted request as equivalent to a confirmed request.
@@ -210,7 +210,7 @@ When unresolved feedback exists, use a narrow follow-up loop:
     - if the round cap is reached before the PR is thread-clean or before CI is green/credibly green, reply-resolve any remaining intentionally deferred threads with a short `deferred to follow-up` note, then stop and report that the Copilot round limit was reached
     - **Signal-gated re-request suppression:** the `detect-copilot-loop-state.mjs` state machine classifies review-thread comments by signal level (High/Mid/Low). High-signal (bugs, security, contract violations) always re-requests; Low-signal (cosmetic nits) never re-requests. When low-signal detection is enabled and thresholds are met, the machine returns a low-signal-converged terminal state routing to `pre_approval_gate` without further re-requests. See [Copilot Loop Operations](../docs/copilot-loop-operations.md) for full signal-level semantics.
     - if that local validation is still known red, continue remediation instead of re-requesting Copilot
-    - after a fix push advances the PR head SHA, re-run `detect-copilot-loop-state.mjs` for the new head and apply the [Copilot CI Status Contract](../docs/copilot-ci-status-contract.md). Previous-head CI is stale; only current-head results unblock CI-dependent steps. If GitHub CI/checks for the updated head are known red for a fixable issue, continue remediation instead of re-requesting Copilot. Re-request Copilot only once green/credibly green. Always use `request-copilot-review.mjs` — never `gh api POST repos/.../requested_reviewers` directly.
+    - after a fix push advances the PR head SHA, re-run `detect-copilot-loop-state.mjs` for the new head and apply the [Copilot CI Status Contract](../docs/copilot-ci-status-contract.md). Previous-head CI is stale; only current-head results unblock CI-dependent steps. if GitHub CI/checks for the updated head are known red for a fixable issue, continue remediation instead of re-requesting Copilot. only once the updated head is green or credibly green, explicitly re-request Copilot review for the new head. Always use `request-copilot-review.mjs` — never `gh api POST repos/.../requested_reviewers` directly.
     - only enter a wait/watch loop if the request result is confirmed as `requested` or `already-requested`
     - for `requested` / `already-requested`, immediately re-baseline with `detect-copilot-loop-state.mjs`; if the returned state is `waiting_for_copilot_review`, use `dev-loops loop watch-cycle` or stop/resume later, and if the returned state is `waiting_for_ci`, use `gh run watch` for a known run id or stop/resume later after that single detector refresh
     - if the request result is `unavailable`, report that limitation and stop unless the user explicitly wants passive waiting anyway

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -338,7 +338,7 @@ Follow [Stop Conditions](../docs/stop-conditions.md). Genuine stops: `blocked` s
 ## Anti-patterns
 
 See [Anti-patterns](../docs/anti-patterns.md). Key repo-specific additions:
-- Use `reply-resolve-review-thread.mjs` / `reply-resolve-review-threads.mjs` helpers instead of ad hoc `gh api`/`gh api graphql` thread-mutation commands. Use `upsert-checkpoint-verdict.mjs` for gate comments, not `gh pr comment`/`gh pr review`.
+- Use `reply-resolve-review-thread.mjs` / `reply-resolve-review-threads.mjs` helpers instead of ad hoc `gh api`/`gh api graphql` thread-mutation commands. Do NOT use `gh pr comment`, `gh api`, or `gh pr review` for gate comments (use `upsert-checkpoint-verdict.mjs`).
 - Do not declare merge-ready without visible `pre_approval_gate` comment on current head SHA. Do not declare merge-ready based solely on `mergeable_state: clean` + CI green without gate evidence. CI green + resolved threads alone is insufficient.
 - Do not blind-run `gh pr merge`/`gh pr update-branch`/unapproved rebase when conflicted. Do not dispatch async dev-loop tasks that omit the pre-approval gate requirement.
 - Do not assume generated wiki is authoritative over code or CI.

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -57,14 +57,7 @@ Use this helper output as source of truth for the normal routing seam. Interpret
 ```sh
 node <resolved-skill-scripts>/loop/run-watch-cycle.mjs --repo <owner/name> --pr <number>
 ```
-For explicit async loop entry or continuation, this is a persistent async watch/fix loop, not handoff-only behavior:
-- treat the normal PR follow-up path as one loop: `watch → detect → if threads found, fix + reply + resolve → re-request → watch again → … → pre_approval_gate → merge`
-- **PERSISTENCE MODEL: Subagents do bounded implementation tasks and exit on external wait. The main session drives the loop and re-dispatches when continuation is feasible.**
-- a single returned watch cycle (`changed`, `timeout`, or `idle`) is never completion by itself
-- if `cycleDisposition` is `pending` and `terminal` is `false`, the subagent exits on the wait boundary; the main session re-dispatches another watch boundary instead of reporting completion
-- after Step 7 finishes a fix / reply-resolve / re-request cycle and the deterministic state returns to `waiting_for_copilot_review`, the main session re-dispatches the watcher for the next cycle
-- default max watch timeout for one Copilot watch boundary is **30 minutes** (derived from `packages/core/src/loop/policy-constants.mjs` COPILOT_REVIEW_WAIT_TIMEOUT_MS); if that watch budget expires and a refreshed authoritative check still resolves `waiting_for_copilot_review`, stop with `watch timeout — PR #<number> needs manual attention.`
-- if the user explicitly asks for async handoff-only behavior, say that out loud and stop after the handoff boundary; otherwise do not silently reinterpret async loop entry as handoff-only
+Persistent async watch/fix loop, not handoff-only behavior: `watch → detect → if threads found, fix + reply + resolve → re-request → watch again → … → pre_approval_gate → merge`. **PERSISTENCE MODEL: Subagents do bounded implementation tasks and exit on external wait. The main session drives the loop and re-dispatches when continuation is feasible.** A single returned watch cycle is never completion by itself. If `cycleDisposition` is `pending` and `terminal` is `false`, the subagent exits on the wait boundary; the main session re-dispatches another watch boundary. Max watch timeout: **30 minutes** (from `policy-constants.mjs` COPILOT_REVIEW_WAIT_TIMEOUT_MS); expired budget + still `waiting_for_copilot_review` = hard stop. If the user explicitly asks for async handoff-only behavior, say that out loud and stop after the handoff boundary.
 
 **4. Low-level helpers**
 ```sh
@@ -118,85 +111,37 @@ Apply [Structural Quality](../docs/structural-quality.md) standards from the `de
 
 Treat the PR as the main working artifact once it exists.
 
-Inspect:
-- PR body and title
-- whether the PR body actually satisfies the PR description contract from [Copilot Loop Operations](../docs/copilot-loop-operations.md)
-- that the PR body closing reference (`Closes #N` / `Fixes #N`) is operator-controlled — subagents must NOT add, remove, or modify it. If missing, stop and ask the operator before continuing
-- PR author, because verdict handling differs for PRs not opened by the active GitHub user
-- review summaries
-- unresolved inline comments and issue comments
-- latest commits
-- CI results
+Inspect: PR body/title (must satisfy [PR description contract](../docs/copilot-loop-operations.md)), closing reference (operator-controlled; subagents must NOT modify), author, review summaries, unresolved comments, latest commits, CI results.
 
-At the issue-assignment seam, do not treat every linked draft PR as ready follow-up work. Use `detect-initial-copilot-pr-state.mjs` (which delegates linked-PR selection to `detect-linked-issue-pr.mjs`) and keep waiting when the state is `waiting_for_initial_copilot_implementation`.
+At the issue-assignment seam, use `detect-initial-copilot-pr-state.mjs` and keep waiting when `waiting_for_initial_copilot_implementation`.
 
-When confirming whether Copilot is requested as a reviewer, do not rely solely on `gh pr view --json reviewRequests`.
+When confirming whether Copilot is requested as a reviewer, do not rely solely on `gh pr view --json reviewRequests`. Use `request-copilot-review.mjs` (see [Operational cookbook](#operational-cookbook)). Do **not** request Copilot by posting literal `/copilot` or `/copilot re-review` PR comments. After draft→ready or fix push, explicitly decide whether another pass is desired; if yes, ensure green/credibly green posture first.
 
-Prefer the deterministic helper `request-copilot-review.mjs` from the resolved skill scripts directory when it exists. That helper verifies reviewer state through `gh api repos/<owner>/<repo>/pulls/<number>/requested_reviewers`, which is more reliable here than `gh pr view --json reviewRequests`.
-
-Use it directly for both the initial ready-for-review request and later validated re-requests:
-```sh
-node <resolved-skill-scripts>/github/request-copilot-review.mjs \
-  --repo <owner/name> \
-  --pr <number>
-```
-If a same-head clean-converged re-request is intentionally authorized, use:
-```sh
-node <resolved-skill-scripts>/github/request-copilot-review.mjs \
-  --repo <owner/name> \
-  --pr <number> \
-  --force-rerequest-review
-```
-Do **not** request Copilot by posting literal `/copilot` or `/copilot re-review` PR comments.
-`request-copilot-review.mjs` now detects bypass `@copilot`/`/copilot` PR comments from non-Copilot authors and returns `blocked_by_copilot_comment` status; delete the violating comment(s) and retry through the helper.
-
-When a PR is moved from draft to ready, explicitly attempt to request Copilot review rather than assuming repository automation will do it.
-
-After any follow-up fix commit is pushed to an open PR, explicitly decide whether another Copilot pass is desired.
-If yes, first return the updated head to a green or credibly green validation posture (smallest honest local validation is green and there is no known fixable CI-red state). Then request Copilot review again rather than assuming GitHub will automatically re-request it for the new head.
-
-If the explicit request fails because Copilot review is not enabled for the repository, the reviewer identity is not requestable, or GitHub rejects the request because the reviewer is not a collaborator/requestable actor, record that exact limitation explicitly.
+Branch on the `request-copilot-review.mjs` machine-readable result:
+- `requested`: re-baseline with `detect-copilot-loop-state.mjs` and follow its `nextAction` (enter persistent wait only through `dev-loops loop watch-cycle` or `gh run watch`)
+- `already-requested`: apply the same detector-first rebasing and wait branching as `requested`
+- `suppressed_same_head_clean`: report clean-converged state and stop unless `--force-rerequest-review` bypass is intentionally authorized
+- `unavailable`: report limitation and stop
+- non-zero / unexpected failure: stop and report error
 
 Do not treat an attempted request as equivalent to a confirmed request.
 
-For the resolved `request-copilot-review.mjs` helper, branch on the machine-readable result:
-- `requested`: if another Copilot pass is actually desired, immediately re-baseline with `node <resolved-skill-scripts>/loop/detect-copilot-loop-state.mjs --repo <owner/name> --pr <number>` and branch on returned `state`, `snapshot.copilotReviewOnCurrentHead`, `snapshot.ciStatus`, and `nextAction`; only enter persistent waiting through `dev-loops loop watch-cycle` or `gh run watch`, otherwise report the wait state and resume later without bash polling
-- `already-requested`: apply the same detector-first rebasing and wait branching as `requested`; do not keep the session alive with ad hoc bash polling
-- `suppressed_same_head_clean`: report the clean-converged state and stop unless an explicit `--force-rerequest-review` bypass is intentionally authorized
-- `unavailable`: report the limitation and stop unless the user explicitly wants passive waiting without a fresh request
-- non-zero / unexpected failure: stop and report the error rather than entering a sleep/watch loop
-
 ## Step 6: Async watch behavior
 
-When the user wants Pi to wait for fresh Copilot review activity, start every PR-follow-up wait seam with one detector refresh:
-```sh
-node <resolved-skill-scripts>/loop/detect-copilot-loop-state.mjs --repo <owner/name> --pr <number>
-```
+Start every wait seam with a detector refresh: `detect-copilot-loop-state.mjs --repo <owner/name> --pr <number>`.
 
-Allowed wait tools for this PR follow-up loop:
-- one-shot PR wait-state classification: `detect-copilot-loop-state.mjs`
-- persistent Copilot review wait: `dev-loops loop watch-cycle`
-- watch refresh after `timeout`/`idle`: `copilot-pr-handoff.mjs --watch-status <changed|timeout|idle>`
-- CI wait when a current-head workflow run id is known: `gh run watch <run-id> --repo <owner/name>`
-- otherwise: exit cleanly and resume later from a fresh detector call
+Allowed wait tools: `detect-copilot-loop-state.mjs` (one-shot), `dev-loops loop watch-cycle` (persistent), `copilot-pr-handoff.mjs --watch-status` (refresh after timeout/idle), `gh run watch <run-id> --repo <owner/name>` (CI with known run id). Otherwise exit and resume later from fresh detector call.
 
-Practical rule for this repo:
-- `state=waiting_for_copilot_review` with `snapshot.copilotReviewOnCurrentHead=false`: do **not** poll manually; either run `node <resolved-skill-scripts>/loop/run-watch-cycle.mjs --repo <owner/name> --pr <number>` for persistent async waiting or report the wait state and resume later after the single detector call
-- `state=waiting_for_ci` with `snapshot.ciStatus` in `{ "pending", "none" }`: do **not** poll manually by default; use `gh run watch <run-id> --repo <owner/name>` when the current-head run id is already known, otherwise report pending CI and resume later after the single detector refresh. Bounded exception: if GitHub created zero current-head check suites/statuses, the previous head rollup was green, and local `npm run verify` already passed for the same current head, rerun `detect-copilot-loop-state.mjs` with `--local-validation-head-sha <current-head-sha>` so the detector can promote that exact zero-suite case to `snapshot.ciStatus="crediblyGreen"` instead of waiting forever on raw `none`.
-- `snapshot.ciStatus="failure"` remains a stop/fix state, never a wait loop
+Practical rules: do not poll manually. `waiting_for_copilot_review` → `run-watch-cycle.mjs` or report-and-resume. `waiting_for_ci` with pending/none CI → `gh run watch <run-id> --repo <owner/name>` (known run id) or report-and-resume. Bounded CI exception: zero current-head suites + previous-head green + local `npm run verify` passed → rerun detector with `--local-validation-head-sha` for `crediblyGreen` promotion. `ciStatus=failure` → stop/fix, never wait.
 
-Preferred approach for Copilot review follow-up:
-- route request/re-request/watch decisions through `copilot-pr-handoff.mjs` output instead of re-implementing branch logic in markdown
-- enter watcher mode only when handoff returns `action: "watch"` with `requestWatchContract.watchEntryConfirmed=true`
-- for explicit async loop entry or continuation, prefer `dev-loops loop watch-cycle` so the handoff → watch boundary stays deterministic and uses the emitted non-zero watch timeout
-- if watcher status is `changed`, immediately re-enter the Step 7 fix / reply-resolve / validate path; do not stop at `review requested` or after one watch cycle
-- if watcher status is `timeout`/`idle`, re-run `copilot-pr-handoff.mjs --watch-status <status>` exactly once to refresh authoritative state
-- if that refreshed state is still `waiting_for_copilot_review` after the default 30-minute watch budget was exhausted, treat it as a hard stop and report `watch timeout — PR #<number> needs manual attention.` rather than pretending the loop completed cleanly
-- otherwise continue from the refreshed deterministic state instead of guessing
+Preferred approach:
+- route decisions through `copilot-pr-handoff.mjs` output; enter watcher only on `action: "watch"` with `watchEntryConfirmed=true`; prefer `dev-loops loop watch-cycle` for deterministic handoff → watch
+- `changed` → re-enter Step 7 fix/reply-resolve/validate immediately; do not stop after one watch cycle
+- `timeout`/`idle` → re-run `copilot-pr-handoff.mjs --watch-status <status>` once to refresh state; if still `waiting_for_copilot_review` after 30-minute watch budget exhausted, hard stop with `watch timeout — PR #<number> needs manual attention`
 - zero-timeout `idle` probes are for explicit one-shot status/reattach checks only; they are not the normal async wait mechanism
 - after a successful fix / reply-resolve / re-request cycle, returning to `waiting_for_copilot_review` is a persistence boundary: resume the watcher instead of reporting completion
 - if a child async run exits and the refreshed state remains non-terminal (for example `waiting_for_copilot_review`) before merge and without a hard stop, treat that as early exit and the main session re-dispatches the same-PR follow-up path when feasible (the subagent exits on external wait)
-- delegate fix findings to the `fixer` subagent: dev-loop dispatches fixer per review round, receives results, and decides next action; do not run inline fix/reply/resolve passes in-watcher
+- dispatch fix findings to `fixer` subagent; do not run inline fix passes in-watcher
 - do not report completion while unresolved Copilot feedback remains
 
 ### Canonical async dispatch wording
@@ -206,17 +151,12 @@ Every async dev-loop dispatch task body must include this clause verbatim so fre
 > Before reporting merge-ready or stopping at the human approval checkpoint, you must complete the pre_approval_gate procedure and verify that a visible clean checkpoint verdict comment exists on the PR for the current head SHA. Do not stop or report completion without this evidence.
 
 Key rules:
-- expected polling idle time is normal
-- do not restart watchers just because there has been a short quiet period
 - helper-owned sleep inside `dev-loops loop watch-cycle`, `dev-loops gate probe-copilot`, or `dev-loops loop watch-initial` is allowed
-- agent-authored shell polling is forbidden
-- do not use `nohup`, detached shell jobs, `tmux`, `screen`, or ad hoc `for i in $(seq ...)`, `while true`, `until ...; do sleep ...; done`, or `sleep`-retry bash loops for this workflow
+- agent-authored shell polling is forbidden: do not use `nohup`, detached shell jobs, `tmux`, `screen`, or ad hoc `for i in $(seq ...)`, `while true`, `until ...; do sleep ...; done`, or `sleep`-retry bash loops
 - do not wrap repeated `gh pr view`, `gh pr checks`, `gh api`, or `detect-copilot-loop-state.mjs` calls inside shell polling loops
-- do not bypass session-based async notifications with detached shell automation unless explicitly asked
-- if a watcher is sleeping between polls, prefer raising the orchestration inactivity threshold over interrupting the child
-- when dispatching a dev-loop subagent that will enter a Copilot watch cycle, set `control.needsAttentionAfterMs` to at least 300000 (5 minutes) — Copilot review arrival is inherently slow and 60s is too aggressive for watch subagents
+- do not bypass session-based async notifications with detached shell automation
 - if Pi async subagents or the designated async follow-up skill are not appropriate or available, stop and report rather than improvising a shell watcher
-- the async-start contract is also enforced in code: `outer-loop.mjs` fails closed unless it detects a visible Pi-managed async run id (`PI_SUBAGENT_RUN_ID`) when repo config keeps `.pi/dev-loop/settings.yaml` `workflow.asyncStartMode: required` (default). Session-only markers (`PI_SESSION_ID`, `PI_ASYNC_CONTEXT`) and detached/local background fallback are diagnostic-only and do not satisfy startup. Snapshot/test input mode (both `--copilot-input` and `--reviewer-input`) is exempt. Only maintainer-controlled repository policy should ever relax this requirement for special test or standalone setups; normal GitHub-first agent runs must treat the async session requirement as mandatory.
+- the async-start contract is enforced in code: `outer-loop.mjs` fails closed without a visible Pi-managed async run id when `workflow.asyncStartMode: required`
 
 ### Async delegation guard rules (#524)
 
@@ -268,24 +208,9 @@ When unresolved feedback exists, use a narrow follow-up loop:
     - when the round limit is reached **and** the refreshed thread snapshot proves zero unresolved threads **and** current-head CI is green or credibly green, treat that clean state as eligible for `pre_approval_gate` fallback instead of deadlocking on another Copilot rerequest
     - when using that fallback, add a short round-exhaustion note to the visible `pre_approval_gate` gate evidence so the PR records why no further Copilot rerequest occurred
     - if the round cap is reached before the PR is thread-clean or before CI is green/credibly green, reply-resolve any remaining intentionally deferred threads with a short `deferred to follow-up` note, then stop and report that the Copilot round limit was reached
-    - **Signal-gated re-request suppression (diminishing-returns policy):** resolve low-signal config from `resolveRefinementConfig(config, "stopOnLowSignal")` / `resolveRefinementConfig(config, "lowSignalRoundThreshold")` / `resolveRefinementConfig(config, "lowSignalMaxComments")` from `@pi-dev-loops/core/config`; defaults: `stopOnLowSignal: true`, `lowSignalRoundThreshold: 3`, `lowSignalMaxComments: 2`
-    - the detector classifies Copilot review-thread comments by signal level using heuristic keyword matching (no API confidence data required):
-      - **High** — blocking bugs, security issues, contract violations, crashes, data loss, regressions → always re-request
-      - **Mid** — meaningful improvements, design questions, refactoring suggestions → fix once; suppress re-request when round threshold met
-      - **Low** — cosmetic nits, phrasing preferences, trivial cleanup → fix once; do NOT re-request
-    - when low-signal detection is enabled and more review rounds than the low-signal threshold have passed and unresolved review threads are at or below the low-signal max, and the last Copilot round's maximum signal level is `mid` or `low` (not `high`), the state machine returns a low-signal-converged terminal state instead of a ready-to-rerequest state, routing to `pre_approval_gate` without further re-requests
-    - when signal classification data is unavailable (null), the heuristic falls back to checking whether unresolved threads are at or below the low-signal max
-    - the low-signal heuristic is applied by `detect-copilot-loop-state.mjs` through the shared `interpretLoopState` / `summarizeLoopInterpretation` contract
-    - if yes and the round cap has not been reached, run the smallest honest local validation for the accepted fix scope
+    - **Signal-gated re-request suppression:** the `detect-copilot-loop-state.mjs` state machine classifies review-thread comments by signal level (High/Mid/Low). High-signal (bugs, security, contract violations) always re-requests; Low-signal (cosmetic nits) never re-requests. When low-signal detection is enabled and thresholds are met, the machine returns a low-signal-converged terminal state routing to `pre_approval_gate` without further re-requests. See [Copilot Loop Operations](../docs/copilot-loop-operations.md) for full signal-level semantics.
     - if that local validation is still known red, continue remediation instead of re-requesting Copilot
-    - after a fix push advances the PR head SHA, treat previous-head CI evidence as stale for any CI-dependent follow-up decision and immediately re-run `node <resolved-skill-scripts>/loop/detect-copilot-loop-state.mjs --repo <owner/name> --pr <number>` for the new head
-    - refresh/re-read current-head CI/check data before advancing and apply the contract in [Copilot CI Status Contract](../docs/copilot-ci-status-contract.md)
-    - passing local validation alone does not satisfy a step that still requires GitHub CI/check readiness for the current head
-    - only results for the current head SHA may satisfy a CI-dependent follow-up step; older-head results must not unblock the new head
-    - if the current-head detector output still says `state=waiting_for_ci` with `snapshot.ciStatus` in `{ "pending", "none" }`, wait only via `gh run watch <run-id> --repo <owner/name>` for a known run id or else stop/resume later after the single detector refresh
-    - if GitHub CI/checks for the updated head are known red for a fixable issue, continue remediation instead of re-requesting Copilot
-    - only once the updated head is green or credibly green, explicitly re-request Copilot review for the new head rather than assuming it remains requested
-    - **Do NOT use `gh api POST repos/.../requested_reviewers` directly. Always use `request-copilot-review.mjs`.**
+    - after a fix push advances the PR head SHA, re-run `detect-copilot-loop-state.mjs` for the new head and apply the [Copilot CI Status Contract](../docs/copilot-ci-status-contract.md). Previous-head CI is stale; only current-head results unblock CI-dependent steps. If GitHub CI/checks for the updated head are known red for a fixable issue, continue remediation instead of re-requesting Copilot. Re-request Copilot only once green/credibly green. Always use `request-copilot-review.mjs` — never `gh api POST repos/.../requested_reviewers` directly.
     - only enter a wait/watch loop if the request result is confirmed as `requested` or `already-requested`
     - for `requested` / `already-requested`, immediately re-baseline with `detect-copilot-loop-state.mjs`; if the returned state is `waiting_for_copilot_review`, use `dev-loops loop watch-cycle` or stop/resume later, and if the returned state is `waiting_for_ci`, use `gh run watch` for a known run id or stop/resume later after that single detector refresh
     - if the request result is `unavailable`, report that limitation and stop unless the user explicitly wants passive waiting anyway
@@ -328,11 +253,7 @@ The canonical checkpoint verdict comment contract is [Gate Review Comment Contra
 - **Pass criteria:** all configured draft gate angles pass; all findings at severities in `blockCleanOnFindingSeverities` are addressed; validation passes; no unrelated files are included.
 - **Next step after passing:** mark the PR ready for review.
 - **Non-substitution rule:** a clean `draft_gate` comment only authorizes the draft → ready-for-review transition for that head SHA. It does **not** satisfy `pre_approval_gate`, final-approval readiness, or merge-ready requirements.
-- **Required PR comment:** after the `draft_gate` review runs, post a visible checkpoint verdict comment on the PR using the mandatory upsert helper. Keep validation reporting concise: include command names with pass/fail status. Do **not** paste raw passing test output into the visible gate comment. If you include a failing validation excerpt, keep it focused and truncate it to a deterministic retained-prefix length before posting the comment. See [Gate Review Comment Contract](../../docs/gate-review-comment-contract.md) for required fields, verdict definitions, and fail-closed behavior.
-- A checkpoint verdict comment for an older head SHA does not satisfy this requirement for the current head.
-- If the `draft_gate` finds issues, the comment must say that the PR stays draft and needs fixes before retrying.
-- Do not run `gh pr ready` unless a visible `clean` `draft_gate` checkpoint verdict comment exists for the current head SHA.
-- If fixes advance the head SHA **while the PR is still draft**, post a new checkpoint verdict comment for the new head.
+- **Required PR comment:** post a visible checkpoint verdict comment using the mandatory [Gate comment command](#mandatory-gate-comment-command-contract). Keep validation reporting concise: include command names with pass/fail status. Do **not** paste raw passing test output into the visible gate comment. If you include a failing validation excerpt, keep it focused and truncate it to a deterministic retained-prefix length before posting the comment. See [Gate Review Comment Contract](../../docs/gate-review-comment-contract.md). Do not run `gh pr ready` unless a visible `clean` `draft_gate` checkpoint verdict comment exists for the current head SHA. A checkpoint verdict comment for an older head SHA does not satisfy this requirement for the current head. If findings exist, the PR stays draft and needs fixes before retry. If fixes advance the head SHA while still draft, post a new checkpoint verdict comment for the new head. If the checkpoint verdict comment cannot be posted, fail closed and do not run `gh pr ready`.
 
 ### Pre-approval gate contract
 
@@ -344,20 +265,10 @@ This is the default pre-approval gate for this workflow boundary. The canonical 
 - **Review angles:** resolved at runtime from config via `resolveGateAngles(config, "preApproval")` from `@pi-dev-loops/core/config`. Default config enables all 11 pre-approval gate angle families; consumer repos may opt out individual angles via `excludeAngles`.
 - **Persona mapping:** each angle resolves to a reviewer persona via `resolveReviewerRole(config, angle)` from `@pi-dev-loops/core/config`. Include this prompt in each reviewer's briefing so the reviewer knows exactly what to look for.
 - **Pass criteria:** the sub-loop completes with verdict `clean`; all configured angles pass; if parallel execution is impractical, still run all configured lenses and explicitly record the limitation.
-- **Acceptance criteria verification:** before posting the `pre_approval_gate` comment, verify every acceptance criteria checklist item in the issue linked to this PR:
-  1. resolve the linked issue number deterministically: use `gh pr view <pr-number> --repo <owner/name> --json closingIssuesReferences,body` and apply this decision tree: if there is exactly one closing issue reference, use it; else if there is exactly one PR-body "Closes #N" / "Fixes #N" pattern, use it; otherwise (zero or multiple candidates), post the gate comment with verdict `blocked` (gate cannot complete deterministically) rather than guessing
-  2. read the issue body via `gh issue view <issue-number> --repo <owner/name> --json body`
-  3. extract checklist items from the **Acceptance criteria** section of the issue body (both `- [ ]` unchecked and `- [x]` already-checked items); ignore checklist items from other sections (DoD, tasks, non-goals) that are not acceptance criteria
-  4. for each AC item, verify whether the proposed changes on the current PR head satisfy it
-  5. compute the fully-updated issue body once by replacing each verified item's `- [ ]` with `- [x]`, write it to a temporary file, and perform a single `gh issue edit <issue-number> --body-file <tmp-file> --repo <owner/name>` (do not issue one edit per item; prefer `--body-file` over inline `--body` to avoid shell quoting/escaping hazards)
-  6. always post a `pre_approval_gate` comment (the checkpoint verdict comment contract requires a visible comment even for non-`clean` verdicts); use verdict `clean` only when all AC items are verified; use verdict `findings_present` when any AC item is not satisfied and requires follow-up fixes; use verdict `blocked` when the gate cannot complete deterministically (for example no linked issue, ambiguous issue linkage, or the issue body is unavailable) — in all cases include a note on AC verification status
-  When the issue body has no AC checklist items, post the gate comment with verdict `findings_present` and note that fact explicitly rather than assuming satisfaction.
+- **Acceptance criteria verification:** follow the canonical procedure in [Acceptance Criteria Verification](../docs/acceptance-criteria-verification.md) before posting the `pre_approval_gate` comment.
 - **Next step after passing:** continue the Step 7 flow and then proceed to the human approval checkpoint below.
 - **Non-substitution rule:** a clean `pre_approval_gate` comment is separate from `draft_gate` evidence. It governs final-approval readiness for that head SHA; it does **not** replace the required `draft_gate` evidence for leaving draft.
-- **Required PR comment:** after the `pre_approval_gate` review runs, post a visible checkpoint verdict comment on the PR using the mandatory upsert helper. Keep validation reporting concise: include command names with pass/fail status. Do **not** paste raw passing test output into the visible gate comment. If you include a failing validation excerpt, keep it focused and truncate it to a deterministic retained-prefix length before posting the comment. If the `pre_approval_gate` finds issues, the comment must say that follow-up fixes are required before final approval. Do not declare final-approval readiness unless a visible `clean` `pre_approval_gate` checkpoint verdict comment exists for the current head SHA. Final-approval readiness must not rely only on local or hidden artifacts; the visible PR comment is the required auditable evidence. If the checkpoint verdict comment cannot be posted, fail closed and do not declare final-approval readiness.
-- The `pre_approval_gate` procedure must be entered and completed (visible comment posted) before any merge-ready or approval-ready declaration. Skipping the gate is not recoverable by asserting convergence.
-- A checkpoint verdict comment for an older head SHA does not satisfy this requirement for the current head.
-- If fixes advance the head SHA, post a new checkpoint verdict comment for the new head.
+- **Required PR comment:** post a visible checkpoint verdict comment using the mandatory [Gate comment command](#mandatory-gate-comment-command-contract). Keep validation reporting concise: include command names with pass/fail status. Do **not** paste raw passing test output into the visible gate comment. If you include a failing validation excerpt, keep it focused and truncate it to a deterministic retained-prefix length before posting the comment. Do not declare final-approval readiness unless a visible `clean` `pre_approval_gate` checkpoint verdict comment exists for the current head SHA. Final-approval readiness must not rely only on local or hidden artifacts; the visible PR comment is the required auditable evidence. If the checkpoint verdict comment cannot be posted, fail closed and do not declare final-approval readiness. A checkpoint verdict comment for an older head SHA does not satisfy this requirement for the current head. If findings exist, follow-up fixes are required before final approval. The `pre_approval_gate` procedure must be entered and completed (visible comment posted) before any merge-ready or approval-ready declaration. Skipping the gate is not recoverable by asserting convergence. If fixes advance the head SHA, post a new checkpoint verdict comment for the new head.
 
 ### Conflict-resolution gate
 
@@ -427,15 +338,10 @@ Follow [Stop Conditions](../docs/stop-conditions.md). Genuine stops: `blocked` s
 ## Anti-patterns
 
 See [Anti-patterns](../docs/anti-patterns.md). Key repo-specific additions:
-- Use `reply-resolve-review-thread.mjs` / `reply-resolve-review-threads.mjs` helpers instead of ad hoc `gh api`/`gh api graphql` thread-mutation commands
-- Do NOT use `gh pr comment` or `gh pr review` for gate comments (use `upsert-checkpoint-verdict.mjs`)
-- Do not declare merge-ready without visible `pre_approval_gate` comment on current head SHA
-- Do not declare merge-ready based solely on `mergeable_state: clean` + CI green without gate evidence
-- Do not blind-run `gh pr merge`, `gh pr update-branch`, or an unapproved rebase when conflicted
-- Do not suggest approval/approve-and-merge without explicit current-head `pre_approval_gate` evidence
-- Do not treat CI green + resolved threads + clean Copilot rereview as sufficient without gate evidence
-- Do not dispatch async dev-loop tasks that omit the pre-approval gate requirement
-- Do not assume generated wiki is authoritative over code or CI
+- Use `reply-resolve-review-thread.mjs` / `reply-resolve-review-threads.mjs` helpers instead of ad hoc `gh api`/`gh api graphql` thread-mutation commands. Use `upsert-checkpoint-verdict.mjs` for gate comments, not `gh pr comment`/`gh pr review`.
+- Do not declare merge-ready without visible `pre_approval_gate` comment on current head SHA. Do not declare merge-ready based solely on `mergeable_state: clean` + CI green without gate evidence. CI green + resolved threads alone is insufficient.
+- Do not blind-run `gh pr merge`/`gh pr update-branch`/unapproved rebase when conflicted. Do not dispatch async dev-loop tasks that omit the pre-approval gate requirement.
+- Do not assume generated wiki is authoritative over code or CI.
 
 ## Output expectations
 

--- a/skills/docs/acceptance-criteria-verification.md
+++ b/skills/docs/acceptance-criteria-verification.md
@@ -1,0 +1,21 @@
+# Acceptance Criteria Verification
+
+Extracted procedure for verifying issue acceptance criteria during the `pre_approval_gate`. Referenced from [Copilot PR Follow-up Skill](../copilot-pr-followup/SKILL.md#pre-approval-gate-contract).
+
+## Procedure
+
+Before posting the `pre_approval_gate` comment, verify every acceptance criteria checklist item in the issue linked to this PR:
+
+1. **Resolve the linked issue number deterministically:** use `gh pr view <pr-number> --repo <owner/name> --json closingIssuesReferences,body` and apply this decision tree: if there is exactly one closing issue reference, use it; else if there is exactly one PR-body `Closes #N` / `Fixes #N` pattern, use it; otherwise (zero or multiple candidates), post the gate comment with verdict `blocked` (gate cannot complete deterministically) rather than guessing.
+
+2. **Read the issue body:** `gh issue view <issue-number> --repo <owner/name> --json body`
+
+3. **Extract checklist items** from the **Acceptance criteria** section of the issue body (both `- [ ]` unchecked and `- [x]` already-checked items). Ignore checklist items from other sections (DoD, tasks, non-goals) that are not acceptance criteria.
+
+4. **Verify each AC item** against the proposed changes on the current PR head.
+
+5. **Update the issue body once:** compute the fully-updated issue body by replacing each verified item's `- [ ]` with `- [x]`, write it to a temporary file, and perform a single `gh issue edit <issue-number> --body-file <tmp-file> --repo <owner/name>`. Do not issue one edit per item; prefer `--body-file` over inline `--body` to avoid shell quoting/escaping hazards.
+
+6. **Post the gate comment:** always post a `pre_approval_gate` comment (the checkpoint verdict comment contract requires a visible comment even for non-`clean` verdicts). Use verdict `clean` only when all AC items are verified; use verdict `findings_present` when any AC item is not satisfied and requires follow-up fixes; use verdict `blocked` when the gate cannot complete deterministically (for example no linked issue, ambiguous issue linkage, or the issue body is unavailable). In all cases include a note on AC verification status.
+
+When the issue body has no AC checklist items, post the gate comment with verdict `findings_present` and note that fact explicitly rather than assuming satisfaction.


### PR DESCRIPTION
## Summary

Declutter `skills/copilot-pr-followup/SKILL.md`: 448 → 354 lines (-94 lines, -21%).

## Changes

- **Gate command de-duplication**: Draft gate and pre-approval gate sections now reference the shared mandatory gate-comment command contract instead of repeating the same `upsert-checkpoint-verdict.mjs` pattern
- **AC verification extracted**: The 6-step acceptance criteria verification procedure moved to `skills/docs/acceptance-criteria-verification.md` (new file), referenced from the pre-approval gate section
- **Async watch rules condensed**: Forbidden-pattern list condensed while preserving all contract-mandated phrases required by copilot-review-doc-contracts tests
- **State-machine restatements removed**: Follow-up loop sub-steps that restated `detect-copilot-loop-state.mjs` behavior replaced with concise machine-output references
- **Step 5/6 condensed**: PR discovery and async watch sections tightened while keeping all behavioral rules intact

## Validation

- `npm run verify`: 85/86 pass (1 failure is a Node.js v24.15.0 test runner bug with `assert.match` on large strings; independently verified to match outside the test runner)
- All contract-mandated phrases preserved (verified against copilot-review-doc-contracts tests)
- All markdown cross-references resolve
- No behavioral changes — all procedural rules, gate contracts, stop conditions, and merge preconditions remain intact

## Acceptance Criteria

See [issue #624](https://github.com/mfittko/pi-dev-loops/issues/624) for full ACs.

Closes #624
