### PR TITLE
fix: ghApi skip parseJsonText for empty-body PATCH/POST responses (#633)

### DIFF
--- a/scripts/github/manage-sub-issues.mjs
+++ b/scripts/github/manage-sub-issues.mjs
@@ -202,11 +202,19 @@ function normalizeSubIssue(raw) {
   }
   return { id, number, title, state };
 }
-async function ghApi(ghCommand, args, env) {
+
+/**
+ * Call gh api with optional JSON parsing.
+ * @param {boolean} [expectJson=true] - When false, skip JSON parsing (for empty-body responses like PATCH reorder).
+ */
+async function ghApi(ghCommand, args, env, expectJson = true) {
   const result = await runChild(ghCommand, ["api", ...args], env);
   if (result.code !== 0) {
     const detail = result.stderr.trim() || `exit code ${result.code}`;
     throw new Error(`gh api command failed: ${detail}`);
+  }
+  if (!expectJson) {
+    return null;
   }
   return parseJsonText(result.stdout);
 }
@@ -249,7 +257,7 @@ export async function runAdd({ repo, issue, child }, { env = process.env, ghComm
   const { owner, name } = parseRepoSlug(repo);
   const childId = await getIssueId(owner, name, child, { env, ghCommand });
   const path = buildSubIssueAddPath(owner, name, issue);
-  await ghApi(ghCommand, ["-X", "POST", path, "-F", `sub_issue_id=${childId}`], env);
+  await ghApi(ghCommand, ["-X", "POST", path, "-F", `sub_issue_id=${childId}`], env, false);
   return {
     ok: true,
     repo,
@@ -272,7 +280,7 @@ export async function runReorder({ repo, issue, order }, { env = process.env, gh
   for (const n of order) {
     const subIssueId = idByNumber.get(n);
     const fieldArgs = ["-F", `sub_issue_id=${subIssueId}`, "-F", `after_id=${afterId}`];
-    await ghApi(ghCommand, ["-X", "PATCH", reorderPath, ...fieldArgs], env);
+    await ghApi(ghCommand, ["-X", "PATCH", reorderPath, ...fieldArgs], env, false);
     afterId = subIssueId;
   }
   return {

--- a/test/github/manage-sub-issues.test.mjs
+++ b/test/github/manage-sub-issues.test.mjs
@@ -400,7 +400,7 @@ test("manage-sub-issues add resolves child id and posts to sub_issues endpoint",
           "-F",
           "sub_issue_id=5001",
         ],
-        stdout: `${JSON.stringify({ id: 5001, number: 10 })}\n`,
+        stdout: "",
       },
     ]);
 
@@ -445,7 +445,7 @@ test("manage-sub-issues reorder sets execution order via sequential PATCH calls"
           "-F",
           "after_id=0",
         ],
-        stdout: `${JSON.stringify({})}\n`,
+        stdout: "",
       },
       {
         assertArgs: [
@@ -458,7 +458,7 @@ test("manage-sub-issues reorder sets execution order via sequential PATCH calls"
           "-F",
           "after_id=1002",
         ],
-        stdout: `${JSON.stringify({})}\n`,
+        stdout: "",
       },
       {
         assertArgs: [
@@ -471,7 +471,7 @@ test("manage-sub-issues reorder sets execution order via sequential PATCH calls"
           "-F",
           "after_id=1003",
         ],
-        stdout: `${JSON.stringify({})}\n`,
+        stdout: "",
       },
     ]);
 


### PR DESCRIPTION
## Problem

`manage-sub-issues.mjs reorder` fails with:
```
{"ok":false,"error":"gh api command failed: unexpected end of JSON input"}
```

Root cause: `ghApi()` always calls `parseJsonText(result.stdout)`. The PATCH `/sub_issues/priority` endpoint returns empty body on success, so `parseJsonText("")` throws.

## Fix

Add optional `expectJson` parameter to `ghApi()` (default `true`). When `false`, skip `parseJsonText` and return `null`. Updated both `runReorder` (PATCH) and `runAdd` (POST) to pass `expectJson: false` since both endpoints return empty bodies on success.

## Changes

- `scripts/github/manage-sub-issues.mjs`: `ghApi()` now accepts `expectJson` flag; `runReorder` and `runAdd` pass `false`

## Validation

- `npm run verify`: 2604 tests pass, 0 failures

Closes #633
