### PR TITLE
feat: add queue board setup docs and idempotent bootstrap wrapper (#632)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -52,3 +52,8 @@ Start here for repository documentation.
 - [Extension README](../extension/README.md) — command surface, package install, and configuration
 - [Dev Loop Contract](../skills/docs/public-dev-loop-contract.md) — canonical routing contract
 - [AGENTS.md](../AGENTS.md) — repo working agreement
+
+## Queue mode
+
+- [Queue Board Setup](./queue-board-setup.md) — one-time GitHub Projects V2 board setup for dev-loop queue
+- [Queue Mode SPEC](./specs/queue-mode/SPEC.md) — queue mode specification

--- a/docs/queue-board-setup.md
+++ b/docs/queue-board-setup.md
@@ -1,0 +1,114 @@
+# GitHub Projects V2 queue board setup
+
+One-time manual setup for the GitHub Projects V2 board that `dev-loop queue` helpers will read and write.
+
+## Why a Projects V2 board?
+
+The board provides durable, visible, shared state for queue ordering and item status — without introducing local queue persistence files. Board state is:
+
+- **Durable** — survives CI restarts, local machine wipes, and session boundaries
+- **Visible** — operators can inspect and reorder the queue from the GitHub UI
+- **Optional** — queue helpers treat board state as an optional scheduling input, not mandatory authority. Without the board, `dev-loop queue` falls back to positional argument ordering.
+
+## Setup
+
+### 1. Create the project board
+
+Run the idempotent bootstrap wrapper:
+
+```sh
+node scripts/projects/ensure-queue-board.mjs --repo mfittko/pi-dev-loops
+```
+
+This creates a project named "Dev Loop Queue" (default) under the `mfittko` user:
+
+```json
+{
+  "ok": true,
+  "project": {
+    "id": "PVT_kwDO...",
+    "number": 1,
+    "title": "Dev Loop Queue",
+    "url": "https://github.com/users/mfittko/projects/1",
+    "statusFieldId": "PVTSSF_lADO..."
+  }
+}
+```
+
+Safe to re-run — exits clean if the board already exists.
+
+#### Custom title
+
+```sh
+node scripts/projects/ensure-queue-board.mjs --repo mfittko/pi-dev-loops --title "My Queue"
+```
+
+### 2. Verify the Status field
+
+The wrapper creates a **Status** single-select field with these columns:
+
+| Column | Meaning |
+|---|---|
+| **Backlog** | Not yet scheduled |
+| **Next Up** | Next item(s) the queue should pick up |
+| **In Progress** | Currently running through the dev-loop |
+| **Done** | Completed (merged or explicitly closed) |
+
+After creation, verify in the GitHub UI: open the project URL from the wrapper output, confirm the Status field exists with all four columns.
+
+### 3. Manual setup alternative
+
+To create the board manually via GitHub UI:
+
+1. Go to your GitHub profile → **Projects** tab
+2. Click **New project**
+3. Select **Board** layout
+4. Name it "Dev Loop Queue"
+5. Add a **Status** field (type: Single select)
+6. Add options: `Backlog`, `Next Up`, `In Progress`, `Done`
+7. Record the project number from the URL: `https://github.com/users/<owner>/projects/<number>`
+
+After manual creation, the wrapper's idempotent re-run will detect the existing board and Status field and emit the same machine-readable JSON payload.
+
+## How queue helpers use the board
+
+Dev-loop queue wrappers will:
+
+- **List** items from the board ordered by position
+- **Add** new items to the `Backlog` column when issues are queued
+- **Move** items to `In Progress` when processing starts, `Done` when complete
+- **Reorder** items when the operator adjusts priority via `--after` dependencies or manual intervention
+- **Fall back** gracefully when the board is absent: positional argument order takes over, and no board mutations are attempted
+
+Helper commands for these operations live in `scripts/projects/` alongside the bootstrap wrapper.
+
+### Fail-closed behavior
+
+Queue helpers never silently assume board state is correct:
+
+| What | Behavior |
+|---|---|
+| Board not found | Fall back to positional argument ordering; no board mutations |
+| Board found but Status field missing | Error — must be reconciled before queue operations |
+| Board found but Status column missing expected option | Warning — item stays in current column |
+| GitHub API returns an error | Operation fails; queue continues with next item |
+
+## Configuration
+
+Queue mode configuration lives under `.pi/dev-loop/settings.yaml`:
+
+```yaml
+queue:
+  maxParallel: 3
+  maxAutoFiledIssues: 10
+  reDispatchMaxRetries: 1
+```
+
+The queue board URL and number are discoverable at runtime — no explicit config entry required.
+
+## See also
+
+- [Queue mode SPEC](./specs/queue-mode/SPEC.md) — full queue mode specification
+- Issue [#632](https://github.com/mfittko/pi-dev-loops/issues/632) — this setup task
+- Issue [#625](https://github.com/mfittko/pi-dev-loops/issues/625) — parent epic
+- Issue [#631](https://github.com/mfittko/pi-dev-loops/issues/631) — queue workflow documentation

--- a/docs/queue-board-setup.md
+++ b/docs/queue-board-setup.md
@@ -4,7 +4,7 @@ One-time manual setup for the GitHub Projects V2 board that `dev-loop queue` hel
 
 ## Why a Projects V2 board?
 
-The board provides durable, visible, shared state for queue ordering and item status — complementing the local queue persistence in `.pi/dev-loop-queue.json`. Board state is Board state is:
+The board provides durable, visible, shared state for queue ordering and item status — complementing the local queue persistence in `.pi/dev-loop-queue.json`. Board state is:
 
 - **Durable** — survives CI restarts, local machine wipes, and session boundaries
 - **Visible** — operators can inspect and reorder the queue from the GitHub UI
@@ -48,7 +48,7 @@ node scripts/projects/ensure-queue-board.mjs --repo mfittko/pi-dev-loops --title
 The wrapper creates a **Status** single-select field with these columns:
 
 | Column | Meaning |
-|---|---|
+| --- | --- |
 | **Backlog** | Not yet scheduled |
 | **Next Up** | Next item(s) the queue should pick up |
 | **In Progress** | Currently running through the dev-loop |
@@ -87,10 +87,10 @@ Helper commands for these operations will be added in future PRs alongside the b
 Queue helpers never silently assume board state is correct:
 
 | What | Behavior |
-|---|---|
+| --- | --- |
 | Board not found | Fall back to positional argument ordering; no board mutations |
 | Board found but Status field missing | Error — must be reconciled before queue operations |
-| Board found but Status column missing expected option | Warning — item stays in current column |
+| Board found but Status column missing expected option | Error (exit code 3) — manual reconciliation needed; bootstrap wrapper fails closed |
 | GitHub API returns an error | Operation fails; queue continues with next item |
 
 ## Configuration

--- a/docs/queue-board-setup.md
+++ b/docs/queue-board-setup.md
@@ -4,7 +4,7 @@ One-time manual setup for the GitHub Projects V2 board that `dev-loop queue` hel
 
 ## Why a Projects V2 board?
 
-The board provides durable, visible, shared state for queue ordering and item status — without introducing local queue persistence files. Board state is:
+The board provides durable, visible, shared state for queue ordering and item status — complementing the local queue persistence in `.pi/dev-loop-queue.json`. Board state is Board state is:
 
 - **Durable** — survives CI restarts, local machine wipes, and session boundaries
 - **Visible** — operators can inspect and reorder the queue from the GitHub UI

--- a/docs/queue-board-setup.md
+++ b/docs/queue-board-setup.md
@@ -80,7 +80,7 @@ Dev-loop queue wrappers will:
 - **Reorder** items when the operator adjusts priority via `--after` dependencies or manual intervention
 - **Fall back** gracefully when the board is absent: positional argument order takes over, and no board mutations are attempted
 
-Helper commands for these operations live in `scripts/projects/` alongside the bootstrap wrapper.
+Helper commands for these operations will be added in future PRs alongside the bootstrap wrapper.
 
 ### Fail-closed behavior
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "npm run test:assets && npm run test:extension && npm run test:scripts && npm run test:core && npm run test:docs",
     "test:assets": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/dev-loop-init-phase-smoke.test.mjs test/contracts/*.test.mjs test/workflow-handoff-contract.test.mjs",
     "test:extension": "node --import tsx --test --test-reporter ./test/failure-summary-reporter.mjs test/extension-checks.test.mjs test/extension-post-merge-update.test.mjs test/extension-command-contract.test.mjs test/extension-package-contract.test.mjs test/dev-loops-core.test.mjs test/dev-loops-cli.test.mjs",
-    "test:scripts": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/github/*.test.mjs test/loop/*.test.mjs test/docs/*.test.mjs",
+    "test:scripts": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/github/*.test.mjs test/loop/*.test.mjs test/docs/*.test.mjs test/projects/*.test.mjs",
     "test:core": "node --test --test-reporter ./test/failure-summary-reporter.mjs packages/core/test/*.test.mjs",
     "test:dev-loop": "node --test --test-reporter ./test/failure-summary-reporter.mjs skills/dev-loop/scripts/dev-mode-context.test.mjs skills/dev-loop/scripts/render-template.test.mjs",
     "test:playwright:viewer": "playwright test -c playwright.inspect-run-viewer.config.mjs",

--- a/scripts/projects/ensure-queue-board.mjs
+++ b/scripts/projects/ensure-queue-board.mjs
@@ -70,8 +70,8 @@ function parseArgs(argv) {
 // no consecutive dashes); repo name similar but also allows dots/underscores.
 // no leading/trailing dash, no consecutive dashes.
 // Single-char owner/repo names are valid (e.g. a/b).
-const OWNER_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
-const REPO_NAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9_.-]*[a-zA-Z0-9])?$/;
+const OWNER_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
+const REPO_NAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9_.-]*[a-zA-Z0-9])?$/;
 
 function validateRepo(repo) {
   if (!repo || typeof repo !== "string") {

--- a/scripts/projects/ensure-queue-board.mjs
+++ b/scripts/projects/ensure-queue-board.mjs
@@ -57,9 +57,10 @@ function parseArgs(argv) {
 
 // ── Validation ───────────────────────────────────────────────────────────
 
-// Reject: empty segments, `.` / `..` segments, leading/trailing dots, segments
-// that start/end with dot-dash, and anything that isn't exactly owner/name.
-const REPO_SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9_.-]*[a-zA-Z0-9]\/[a-zA-Z0-9][a-zA-Z0-9_.-]*[a-zA-Z0-9]$/;
+// GitHub slug rules: 1-39 alnum/dash chars, no leading/trailing dash, no consecutive dashes.
+// Single-char owner/repo names are valid (e.g. a/b).
+const OWNER_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
+const REPO_NAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9_.-]*[a-zA-Z0-9])?$/;
 
 function validateRepo(repo) {
   if (!repo || typeof repo !== "string") {
@@ -72,14 +73,22 @@ function validateRepo(repo) {
       { code: "INVALID_REPO", usage: USAGE },
     );
   }
-  if (!REPO_SLUG_RE.test(repo)) {
+  const slashIdx = repo.indexOf("/");
+  if (slashIdx === -1) {
     throw Object.assign(
       new Error(`--repo must be exactly owner/name, got "${repo}"`),
       { code: "INVALID_REPO", usage: USAGE },
     );
   }
-  // Extra guard: reject path-traversal patterns that could pass regex
-  if (repo.includes("..")) {
+  const owner = repo.slice(0, slashIdx);
+  const name = repo.slice(slashIdx + 1);
+  if (!owner || !name) {
+    throw Object.assign(
+      new Error(`--repo must be exactly owner/name, got "${repo}"`),
+      { code: "INVALID_REPO", usage: USAGE },
+    );
+  }
+  if (!OWNER_RE.test(owner) || !REPO_NAME_RE.test(name)) {
     throw Object.assign(
       new Error(`--repo must be exactly owner/name, got "${repo}"`),
       { code: "INVALID_REPO", usage: USAGE },
@@ -184,10 +193,14 @@ const CREATE_PROJECT = [
 ].join("\n");
 
 const GET_PROJECT_FIELDS = [
-  "query($projectId:ID!) {",
+  "query($projectId:ID!, $after:String) {",
   "  node(id:$projectId) {",
   "    ... on ProjectV2 {",
-  "      fields(first:50) {",
+  "      fields(first:50, after:$after) {",
+  "        pageInfo {",
+  "          hasNextPage",
+  "          endCursor",
+  "        }",
   "        nodes {",
   "          ... on ProjectV2SingleSelectField {",
   "            id",
@@ -264,6 +277,31 @@ async function listAllProjects(login, kind, env, runChild) {
   return projects;
 }
 
+// ── Paginated field listing ──────────────────────────────────────────────
+
+async function listAllFields(projectId, env, runChild) {
+  const fields = [];
+  let after = null;
+  while (true) {
+    const vars = { projectId };
+    if (after) vars.after = after;
+    const payload = await ghGraphql(GET_PROJECT_FIELDS, vars, env, runChild);
+    const connection = payload?.data?.node?.fields;
+    const nodes = connection?.nodes ?? [];
+    fields.push(...nodes);
+    const pageInfo = connection?.pageInfo ?? {};
+    if (!pageInfo.hasNextPage) break;
+    if (!pageInfo.endCursor) {
+      throw Object.assign(
+        new Error("Invalid fields payload: hasNextPage is true but endCursor is missing"),
+        { code: "GH_API_ERROR" },
+      );
+    }
+    after = pageInfo.endCursor;
+  }
+  return fields;
+}
+
 // ── Exit code classification ────────────────────────────────────────────
 
 function classifyExitCode(err) {
@@ -288,9 +326,8 @@ async function main(args, { env = process.env, runChild } = {}) {
   let project = projects.find((p) => p.title === title);
 
   if (project) {
-    // Project exists — verify Status field
-    const fieldsPayload = await ghGraphql(GET_PROJECT_FIELDS, { projectId: project.id }, env, child);
-    const fieldNodes = fieldsPayload?.data?.node?.fields?.nodes ?? [];
+    // Project exists — verify Status field (paginated)
+    const fieldNodes = await listAllFields(project.id, env, child);
     const statusField = fieldNodes.find(
       (f) => f.name === "Status" && f.options,
     );

--- a/scripts/projects/ensure-queue-board.mjs
+++ b/scripts/projects/ensure-queue-board.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { runChild } from "../_cli-primitives.mjs";
+import { runChild as _runChild } from "../_cli-primitives.mjs";
 
 const USAGE = `Usage: node scripts/projects/ensure-queue-board.mjs --repo <owner/name> [--title <title>]
 
@@ -35,7 +35,7 @@ function parseArgs(argv) {
 
 // ── API helpers ──────────────────────────────────────────────────────────
 
-async function ghGraphql(query, vars, env) {
+async function ghGraphql(query, vars, env, runChild = _runChild) {
   const fieldArgs = [];
   for (const [key, value] of Object.entries(vars)) {
     fieldArgs.push("--field", `${key}=${value}`);
@@ -133,7 +133,8 @@ const CREATE_SINGLE_SELECT_FIELD = [
 
 // ── Main logic ──────────────────────────────────────────────────────────
 
-async function main(args, { env = process.env } = {}) {
+async function main(args, { env = process.env, runChild } = {}) {
+  const child = runChild ?? _runChild;
   const repo = args.repo;
   if (!repo || typeof repo !== "string" || !repo.includes("/")) {
     throw Object.assign(
@@ -145,7 +146,7 @@ async function main(args, { env = process.env } = {}) {
   const title = args.title || "Dev Loop Queue";
 
   // 1. Resolve owner ID
-  const userIdPayload = await ghGraphql(GET_USER_ID, { login: owner }, env);
+  const userIdPayload = await ghGraphql(GET_USER_ID, { login: owner }, env, child);
   const ownerId = userIdPayload?.data?.user?.id;
   if (!ownerId) {
     throw Object.assign(
@@ -155,13 +156,13 @@ async function main(args, { env = process.env } = {}) {
   }
 
   // 2. Look for existing project by title
-  const listPayload = await ghGraphql(LIST_PROJECTS, { login: owner }, env);
+  const listPayload = await ghGraphql(LIST_PROJECTS, { login: owner }, env, child);
   const projects = listPayload?.data?.user?.projectsV2?.nodes ?? [];
   let project = projects.find((p) => p.title === title);
 
   if (project) {
     // Project exists — verify Status field
-    const fieldsPayload = await ghGraphql(GET_PROJECT_FIELDS, { projectId: project.id }, env);
+    const fieldsPayload = await ghGraphql(GET_PROJECT_FIELDS, { projectId: project.id }, env, child);
     const fieldNodes = fieldsPayload?.data?.node?.fields?.nodes ?? [];
     const statusField = fieldNodes.find(
       (f) => f.name === "Status" && f.options,
@@ -207,7 +208,7 @@ async function main(args, { env = process.env } = {}) {
           { name: "Done", color: "GREEN" },
         ],
       }),
-    }, env);
+    }, env, child);
     const newField = createFieldPayload?.data?.createProjectV2Field?.projectV2Field;
     if (!newField) {
       throw Object.assign(new Error("Failed to create Status field"), { code: "CREATE_FIELD_FAILED" });
@@ -227,7 +228,7 @@ async function main(args, { env = process.env } = {}) {
   // 3. Create project
   const createPayload = await ghGraphql(CREATE_PROJECT, {
     input: JSON.stringify({ ownerId, title }),
-  }, env);
+  }, env, child);
   project = createPayload?.data?.createProjectV2?.projectV2;
   if (!project) {
     throw Object.assign(new Error("Failed to create project board"), { code: "CREATE_PROJECT_FAILED" });
@@ -246,7 +247,7 @@ async function main(args, { env = process.env } = {}) {
         { name: "Done", color: "GREEN" },
       ],
     }),
-  }, env);
+  }, env, child);
   const newField = createFieldPayload?.data?.createProjectV2Field?.projectV2Field;
   if (!newField) {
     throw Object.assign(new Error("Failed to create Status field on new project"), { code: "CREATE_FIELD_FAILED" });

--- a/scripts/projects/ensure-queue-board.mjs
+++ b/scripts/projects/ensure-queue-board.mjs
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { runChild } from "../_cli-primitives.mjs";
+
+const USAGE = `Usage: node scripts/projects/ensure-queue-board.mjs --repo <owner/name> [--title <title>]
+
+Idempotent bootstrap for a GitHub Projects V2 board used as the dev-loop queue.
+
+Creates the project board if it doesn't exist, ensures a Status field with
+standard columns (Backlog, Next Up, In Progress, Done). Exits clean if the
+board and Status field already exist.
+
+Output (stdout):
+  JSON: { ok: true, project: { id, number, title, url, statusFieldId } }
+
+Exit codes:
+  0 — board exists or was created successfully (idempotent)
+  1 — usage or argument error
+  2 — GitHub API error
+`;
+
+function parseArgs(argv) {
+  const args = { title: "Dev Loop Queue" };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--repo" && i + 1 < argv.length) {
+      args.repo = argv[++i];
+    } else if (argv[i] === "--title" && i + 1 < argv.length) {
+      args.title = argv[++i];
+    } else if (argv[i] === "--help" || argv[i] === "-h") {
+      args.help = true;
+    }
+  }
+  return args;
+}
+
+// ── API helpers ──────────────────────────────────────────────────────────
+
+async function ghGraphql(query, vars, env) {
+  const fieldArgs = [];
+  for (const [key, value] of Object.entries(vars)) {
+    fieldArgs.push("--field", `${key}=${value}`);
+  }
+  const result = await runChild(
+    "gh",
+    ["api", "graphql", "--field", `query=${query}`, ...fieldArgs],
+    env,
+  );
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw Object.assign(new Error(`gh api graphql failed: ${detail}`), { code: "GH_API_ERROR" });
+  }
+  const payload = parseJsonText(result.stdout);
+  if (payload.errors && payload.errors.length > 0) {
+    throw Object.assign(
+      new Error(`GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`),
+      { code: "GRAPHQL_ERROR" },
+    );
+  }
+  return payload;
+}
+
+// ── Query/mutation fragments ────────────────────────────────────────────
+
+const GET_USER_ID = [
+  "query($login:String!) {",
+  "  user(login:$login) {",
+  "    id",
+  "  }",
+  "}"
+].join("\n");
+
+const LIST_PROJECTS = [
+  "query($login:String!) {",
+  "  user(login:$login) {",
+  "    projectsV2(first:50) {",
+  "      nodes {",
+  "        id",
+  "        number",
+  "        title",
+  "        url",
+  "      }",
+  "    }",
+  "  }",
+  "}"
+].join("\n");
+
+const CREATE_PROJECT = [
+  "mutation($input:CreateProjectV2Input!) {",
+  "  createProjectV2(input:$input) {",
+  "    projectV2 {",
+  "      id",
+  "      number",
+  "      title",
+  "      url",
+  "    }",
+  "  }",
+  "}"
+].join("\n");
+
+const GET_PROJECT_FIELDS = [
+  "query($projectId:ID!) {",
+  "  node(id:$projectId) {",
+  "    ... on ProjectV2 {",
+  "      fields(first:50) {",
+  "        nodes {",
+  "          ... on ProjectV2SingleSelectField {",
+  "            id",
+  "            name",
+  "            options {",
+  "              id",
+  "              name",
+  "            }",
+  "          }",
+  "        }",
+  "      }",
+  "    }",
+  "  }",
+  "}"
+].join("\n");
+
+const CREATE_SINGLE_SELECT_FIELD = [
+  "mutation($input:CreateProjectV2FieldInput!) {",
+  "  createProjectV2Field(input:$input) {",
+  "    projectV2Field {",
+  "      ... on ProjectV2SingleSelectField {",
+  "        id",
+  "        name",
+  "      }",
+  "    }",
+  "  }",
+  "}"
+].join("\n");
+
+// ── Main logic ──────────────────────────────────────────────────────────
+
+async function main(args, { env = process.env } = {}) {
+  const repo = args.repo;
+  if (!repo || typeof repo !== "string" || !repo.includes("/")) {
+    throw Object.assign(
+      new Error(`--repo is required and must be owner/name, got "${repo}"`),
+      { code: "INVALID_REPO" },
+    );
+  }
+  const [owner] = repo.split("/");
+  const title = args.title || "Dev Loop Queue";
+
+  // 1. Resolve owner ID
+  const userIdPayload = await ghGraphql(GET_USER_ID, { login: owner }, env);
+  const ownerId = userIdPayload?.data?.user?.id;
+  if (!ownerId) {
+    throw Object.assign(
+      new Error(`Could not resolve user ID for "${owner}"`),
+      { code: "NO_USER_ID" },
+    );
+  }
+
+  // 2. Look for existing project by title
+  const listPayload = await ghGraphql(LIST_PROJECTS, { login: owner }, env);
+  const projects = listPayload?.data?.user?.projectsV2?.nodes ?? [];
+  let project = projects.find((p) => p.title === title);
+
+  if (project) {
+    // Project exists — verify Status field
+    const fieldsPayload = await ghGraphql(GET_PROJECT_FIELDS, { projectId: project.id }, env);
+    const fieldNodes = fieldsPayload?.data?.node?.fields?.nodes ?? [];
+    const statusField = fieldNodes.find(
+      (f) => f.name === "Status" && f.options,
+    );
+
+    const expectedColumns = ["Backlog", "Next Up", "In Progress", "Done"];
+    const existingColumns = statusField?.options?.map((o) => o.name) ?? [];
+    const missingColumns = expectedColumns.filter((c) => !existingColumns.includes(c));
+
+    if (statusField && missingColumns.length === 0) {
+      return {
+        ok: true,
+        project: {
+          id: project.id,
+          number: project.number,
+          title: project.title,
+          url: project.url,
+          statusFieldId: statusField.id,
+        },
+      };
+    }
+
+    if (statusField) {
+      throw Object.assign(
+        new Error(
+          `Project "${title}" (number ${project.number}) exists but Status field missing columns: ${missingColumns.join(", ")}. ` +
+          "Add missing columns via GitHub UI or reconcile manually.",
+        ),
+        { code: "MISSING_COLUMNS" },
+      );
+    }
+
+    // No Status field — create it
+    const createFieldPayload = await ghGraphql(CREATE_SINGLE_SELECT_FIELD, {
+      input: JSON.stringify({
+        projectId: project.id,
+        dataType: "SINGLE_SELECT",
+        name: "Status",
+        singleSelectOptions: [
+          { name: "Backlog", color: "GRAY" },
+          { name: "Next Up", color: "BLUE" },
+          { name: "In Progress", color: "YELLOW" },
+          { name: "Done", color: "GREEN" },
+        ],
+      }),
+    }, env);
+    const newField = createFieldPayload?.data?.createProjectV2Field?.projectV2Field;
+    if (!newField) {
+      throw Object.assign(new Error("Failed to create Status field"), { code: "CREATE_FIELD_FAILED" });
+    }
+    return {
+      ok: true,
+      project: {
+        id: project.id,
+        number: project.number,
+        title: project.title,
+        url: project.url,
+        statusFieldId: newField.id,
+      },
+    };
+  }
+
+  // 3. Create project
+  const createPayload = await ghGraphql(CREATE_PROJECT, {
+    input: JSON.stringify({ ownerId, title }),
+  }, env);
+  project = createPayload?.data?.createProjectV2?.projectV2;
+  if (!project) {
+    throw Object.assign(new Error("Failed to create project board"), { code: "CREATE_PROJECT_FAILED" });
+  }
+
+  // 4. Create Status field on new project
+  const createFieldPayload = await ghGraphql(CREATE_SINGLE_SELECT_FIELD, {
+    input: JSON.stringify({
+      projectId: project.id,
+      dataType: "SINGLE_SELECT",
+      name: "Status",
+      singleSelectOptions: [
+        { name: "Backlog", color: "GRAY" },
+        { name: "Next Up", color: "BLUE" },
+        { name: "In Progress", color: "YELLOW" },
+        { name: "Done", color: "GREEN" },
+      ],
+    }),
+  }, env);
+  const newField = createFieldPayload?.data?.createProjectV2Field?.projectV2Field;
+  if (!newField) {
+    throw Object.assign(new Error("Failed to create Status field on new project"), { code: "CREATE_FIELD_FAILED" });
+  }
+
+  return {
+    ok: true,
+    project: {
+      id: project.id,
+      number: project.number,
+      title: project.title,
+      url: project.url,
+      statusFieldId: newField.id,
+    },
+  };
+}
+
+// ── CLI entrypoint ──────────────────────────────────────────────────────
+
+async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, env = process.env } = {}) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    stdout.write(USAGE);
+    return;
+  }
+  try {
+    const result = await main(args, { env });
+    stdout.write(JSON.stringify(result) + "\n");
+  } catch (err) {
+    if (err.code === "INVALID_REPO") {
+      stderr.write(`${formatCliError(err)}\n`);
+      process.exitCode = 1;
+      return;
+    }
+    stderr.write(`${formatCliError(err)}\n`);
+    process.exitCode = 2;
+  }
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(`${formatCliError(error)}\n`);
+    process.exitCode = 2;
+  });
+}
+
+export { main };

--- a/scripts/projects/ensure-queue-board.mjs
+++ b/scripts/projects/ensure-queue-board.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
 
 const USAGE = `Usage: node scripts/projects/ensure-queue-board.mjs --repo <owner/name> [--title <title>]
@@ -57,23 +57,32 @@ function parseArgs(argv) {
 
 // ── Validation ───────────────────────────────────────────────────────────
 
-const REPO_SLUG_RE = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
+// Reject: empty segments, `.` / `..` segments, leading/trailing dots, segments
+// that start/end with dot-dash, and anything that isn't exactly owner/name.
+const REPO_SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9_.-]*[a-zA-Z0-9]\/[a-zA-Z0-9][a-zA-Z0-9_.-]*[a-zA-Z0-9]$/;
 
 function validateRepo(repo) {
   if (!repo || typeof repo !== "string") {
-    throw Object.assign(new Error("--repo is required"), { code: "INVALID_REPO" });
+    throw Object.assign(new Error("--repo is required"), { code: "INVALID_REPO", usage: USAGE });
   }
   const trimmed = repo.trim();
   if (trimmed !== repo) {
     throw Object.assign(
       new Error(`--repo must not have leading/trailing whitespace, got "${repo}"`),
-      { code: "INVALID_REPO" },
+      { code: "INVALID_REPO", usage: USAGE },
     );
   }
   if (!REPO_SLUG_RE.test(repo)) {
     throw Object.assign(
       new Error(`--repo must be exactly owner/name, got "${repo}"`),
-      { code: "INVALID_REPO" },
+      { code: "INVALID_REPO", usage: USAGE },
+    );
+  }
+  // Extra guard: reject path-traversal patterns that could pass regex
+  if (repo.includes("..")) {
+    throw Object.assign(
+      new Error(`--repo must be exactly owner/name, got "${repo}"`),
+      { code: "INVALID_REPO", usage: USAGE },
     );
   }
   return repo;
@@ -216,14 +225,10 @@ async function resolveOwner(login, env, runChild) {
   if (userPayload?.data?.user?.id) {
     return { id: userPayload.data.user.id, kind: "user" };
   }
-  // Try organization
-  try {
-    const orgPayload = await ghGraphql(GET_ORG_ID, { login }, env, runChild);
-    if (orgPayload?.data?.organization?.id) {
-      return { id: orgPayload.data.organization.id, kind: "org" };
-    }
-  } catch {
-    // If org query fails (e.g., not an org), fall through
+  // Try organization (only if user returned null — not for API errors)
+  const orgPayload = await ghGraphql(GET_ORG_ID, { login }, env, runChild);
+  if (orgPayload?.data?.organization?.id) {
+    return { id: orgPayload.data.organization.id, kind: "org" };
   }
   throw Object.assign(
     new Error(`Could not resolve owner ID for "${login}" (not a user or organization)`),
@@ -395,7 +400,6 @@ async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, 
     args = parseArgs(argv);
   } catch (err) {
     stderr.write(`${formatCliError(err)}\n`);
-    if (err.usage) stderr.write(err.usage);
     process.exitCode = 1;
     return;
   }

--- a/scripts/projects/ensure-queue-board.mjs
+++ b/scripts/projects/ensure-queue-board.mjs
@@ -24,7 +24,9 @@ const VALID_ARGS = new Set(["--repo", "--title", "--help", "-h"]);
 
 function parseArgs(argv) {
   const args = { title: "Dev Loop Queue" };
+  const consumed = new Set();
   for (let i = 0; i < argv.length; i++) {
+    if (consumed.has(i)) continue;
     const arg = argv[i];
     if (!VALID_ARGS.has(arg) && arg.startsWith("-")) {
       throw Object.assign(
@@ -40,6 +42,7 @@ function parseArgs(argv) {
         );
       }
       args.repo = argv[++i];
+      consumed.add(i);
     } else if (arg === "--title") {
       if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
         throw Object.assign(
@@ -48,8 +51,14 @@ function parseArgs(argv) {
         );
       }
       args.title = argv[++i];
+      consumed.add(i);
     } else if (arg === "--help" || arg === "-h") {
       args.help = true;
+    } else {
+      throw Object.assign(
+        new Error(`Unexpected argument: ${arg}`),
+        { code: "INVALID_REPO", usage: USAGE },
+      );
     }
   }
   return args;
@@ -57,7 +66,9 @@ function parseArgs(argv) {
 
 // ── Validation ───────────────────────────────────────────────────────────
 
-// GitHub slug rules: 1-39 alnum/dash chars, no leading/trailing dash, no consecutive dashes.
+// GitHub slug rules: owner 1-39 chars (alnum/dash, no leading/trailing dash,
+// no consecutive dashes); repo name similar but also allows dots/underscores.
+// no leading/trailing dash, no consecutive dashes.
 // Single-char owner/repo names are valid (e.g. a/b).
 const OWNER_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
 const REPO_NAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9_.-]*[a-zA-Z0-9])?$/;

--- a/scripts/projects/ensure-queue-board.mjs
+++ b/scripts/projects/ensure-queue-board.mjs
@@ -17,20 +17,66 @@ Exit codes:
   0 — board exists or was created successfully (idempotent)
   1 — usage or argument error
   2 — GitHub API error
+  3 — board schema/config mismatch (manual reconciliation needed)
 `;
+
+const VALID_ARGS = new Set(["--repo", "--title", "--help", "-h"]);
 
 function parseArgs(argv) {
   const args = { title: "Dev Loop Queue" };
   for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === "--repo" && i + 1 < argv.length) {
+    const arg = argv[i];
+    if (!VALID_ARGS.has(arg) && arg.startsWith("-")) {
+      throw Object.assign(
+        new Error(`Unknown flag: ${arg}`),
+        { code: "INVALID_REPO", usage: USAGE },
+      );
+    }
+    if (arg === "--repo") {
+      if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
+        throw Object.assign(
+          new Error("--repo requires a value (owner/name)"),
+          { code: "INVALID_REPO", usage: USAGE },
+        );
+      }
       args.repo = argv[++i];
-    } else if (argv[i] === "--title" && i + 1 < argv.length) {
+    } else if (arg === "--title") {
+      if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
+        throw Object.assign(
+          new Error("--title requires a value"),
+          { code: "INVALID_REPO", usage: USAGE },
+        );
+      }
       args.title = argv[++i];
-    } else if (argv[i] === "--help" || argv[i] === "-h") {
+    } else if (arg === "--help" || arg === "-h") {
       args.help = true;
     }
   }
   return args;
+}
+
+// ── Validation ───────────────────────────────────────────────────────────
+
+const REPO_SLUG_RE = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
+
+function validateRepo(repo) {
+  if (!repo || typeof repo !== "string") {
+    throw Object.assign(new Error("--repo is required"), { code: "INVALID_REPO" });
+  }
+  const trimmed = repo.trim();
+  if (trimmed !== repo) {
+    throw Object.assign(
+      new Error(`--repo must not have leading/trailing whitespace, got "${repo}"`),
+      { code: "INVALID_REPO" },
+    );
+  }
+  if (!REPO_SLUG_RE.test(repo)) {
+    throw Object.assign(
+      new Error(`--repo must be exactly owner/name, got "${repo}"`),
+      { code: "INVALID_REPO" },
+    );
+  }
+  return repo;
 }
 
 // ── API helpers ──────────────────────────────────────────────────────────
@@ -69,10 +115,41 @@ const GET_USER_ID = [
   "}"
 ].join("\n");
 
-const LIST_PROJECTS = [
+const GET_ORG_ID = [
   "query($login:String!) {",
+  "  organization(login:$login) {",
+  "    id",
+  "  }",
+  "}"
+].join("\n");
+
+const LIST_USER_PROJECTS = [
+  "query($login:String!, $after:String) {",
   "  user(login:$login) {",
-  "    projectsV2(first:50) {",
+  "    projectsV2(first:50, after:$after) {",
+  "      pageInfo {",
+  "        hasNextPage",
+  "        endCursor",
+  "      }",
+  "      nodes {",
+  "        id",
+  "        number",
+  "        title",
+  "        url",
+  "      }",
+  "    }",
+  "  }",
+  "}"
+].join("\n");
+
+const LIST_ORG_PROJECTS = [
+  "query($login:String!, $after:String) {",
+  "  organization(login:$login) {",
+  "    projectsV2(first:50, after:$after) {",
+  "      pageInfo {",
+  "        hasNextPage",
+  "        endCursor",
+  "      }",
   "      nodes {",
   "        id",
   "        number",
@@ -131,33 +208,78 @@ const CREATE_SINGLE_SELECT_FIELD = [
   "}"
 ].join("\n");
 
+// ── Owner resolution ────────────────────────────────────────────────────
+
+async function resolveOwner(login, env, runChild) {
+  // Try user first
+  const userPayload = await ghGraphql(GET_USER_ID, { login }, env, runChild);
+  if (userPayload?.data?.user?.id) {
+    return { id: userPayload.data.user.id, kind: "user" };
+  }
+  // Try organization
+  try {
+    const orgPayload = await ghGraphql(GET_ORG_ID, { login }, env, runChild);
+    if (orgPayload?.data?.organization?.id) {
+      return { id: orgPayload.data.organization.id, kind: "org" };
+    }
+  } catch {
+    // If org query fails (e.g., not an org), fall through
+  }
+  throw Object.assign(
+    new Error(`Could not resolve owner ID for "${login}" (not a user or organization)`),
+    { code: "NO_USER_ID" },
+  );
+}
+
+// ── Paginated project listing ────────────────────────────────────────────
+
+async function listAllProjects(login, kind, env, runChild) {
+  const query = kind === "org" ? LIST_ORG_PROJECTS : LIST_USER_PROJECTS;
+  const projects = [];
+  let after = null;
+  while (true) {
+    const vars = { login };
+    if (after) vars.after = after;
+    const payload = await ghGraphql(query, vars, env, runChild);
+    const connection = kind === "org"
+      ? payload?.data?.organization?.projectsV2
+      : payload?.data?.user?.projectsV2;
+    const nodes = connection?.nodes ?? [];
+    projects.push(...nodes);
+    const pageInfo = connection?.pageInfo ?? {};
+    if (!pageInfo.hasNextPage) break;
+    if (!pageInfo.endCursor) {
+      throw Object.assign(
+        new Error("Invalid projects list payload: hasNextPage is true but endCursor is missing"),
+        { code: "GH_API_ERROR" },
+      );
+    }
+    after = pageInfo.endCursor;
+  }
+  return projects;
+}
+
+// ── Exit code classification ────────────────────────────────────────────
+
+function classifyExitCode(err) {
+  if (err.code === "INVALID_REPO") return 1;
+  if (err.code === "MISSING_COLUMNS") return 3;
+  return 2;
+}
+
 // ── Main logic ──────────────────────────────────────────────────────────
 
 async function main(args, { env = process.env, runChild } = {}) {
   const child = runChild ?? _runChild;
-  const repo = args.repo;
-  if (!repo || typeof repo !== "string" || !repo.includes("/")) {
-    throw Object.assign(
-      new Error(`--repo is required and must be owner/name, got "${repo}"`),
-      { code: "INVALID_REPO" },
-    );
-  }
+  const repo = validateRepo(args.repo);
   const [owner] = repo.split("/");
   const title = args.title || "Dev Loop Queue";
 
-  // 1. Resolve owner ID
-  const userIdPayload = await ghGraphql(GET_USER_ID, { login: owner }, env, child);
-  const ownerId = userIdPayload?.data?.user?.id;
-  if (!ownerId) {
-    throw Object.assign(
-      new Error(`Could not resolve user ID for "${owner}"`),
-      { code: "NO_USER_ID" },
-    );
-  }
+  // 1. Resolve owner (user or org)
+  const { id: ownerId, kind: ownerKind } = await resolveOwner(owner, env, child);
 
-  // 2. Look for existing project by title
-  const listPayload = await ghGraphql(LIST_PROJECTS, { login: owner }, env, child);
-  const projects = listPayload?.data?.user?.projectsV2?.nodes ?? [];
+  // 2. Look for existing project by title (paginated)
+  const projects = await listAllProjects(owner, ownerKind, env, child);
   let project = projects.find((p) => p.title === title);
 
   if (project) {
@@ -268,7 +390,15 @@ async function main(args, { env = process.env, runChild } = {}) {
 // ── CLI entrypoint ──────────────────────────────────────────────────────
 
 async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, env = process.env } = {}) {
-  const args = parseArgs(argv);
+  let args;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    stderr.write(`${formatCliError(err)}\n`);
+    if (err.usage) stderr.write(err.usage);
+    process.exitCode = 1;
+    return;
+  }
   if (args.help) {
     stdout.write(USAGE);
     return;
@@ -277,13 +407,8 @@ async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, 
     const result = await main(args, { env });
     stdout.write(JSON.stringify(result) + "\n");
   } catch (err) {
-    if (err.code === "INVALID_REPO") {
-      stderr.write(`${formatCliError(err)}\n`);
-      process.exitCode = 1;
-      return;
-    }
     stderr.write(`${formatCliError(err)}\n`);
-    process.exitCode = 2;
+    process.exitCode = classifyExitCode(err);
   }
 }
 

--- a/test/projects/ensure-queue-board.test.mjs
+++ b/test/projects/ensure-queue-board.test.mjs
@@ -316,7 +316,7 @@ describe("ensure-queue-board", () => {
   });
 
   describe("exit code classification", () => {
-    it("MISSING_COLUMNS gets code 3 not 2", async () => {
+    it("MISSING_COLUMNS error has code MISSING_COLUMNS", async () => {
       const partialField = {
         id: "PVTSSF_partial", name: "Status",
         options: [{ id: "opt1", name: "Backlog" }],

--- a/test/projects/ensure-queue-board.test.mjs
+++ b/test/projects/ensure-queue-board.test.mjs
@@ -20,13 +20,45 @@ function mockRunChild(responses) {
 
 // ── Fixtures ────────────────────────────────────────────────────────────
 
-const USER_ID_RESPONSE = {
-  data: { user: { id: "U_kgDOABC123" } },
-};
+function userPayload() {
+  return { data: { user: { id: "U_kgDOABC123" } } };
+}
 
-function listProjectsResponse(projects) {
+function orgPayload() {
+  return { data: { organization: { id: "O_kgDOXYZ789" } } };
+}
+
+function noUserPayload() {
+  return { data: { user: null } };
+}
+
+function noOrgPayload() {
+  return { data: { organization: null } };
+}
+
+function listUserProjectsResponse(projects) {
   return {
-    data: { user: { projectsV2: { nodes: projects } } },
+    data: {
+      user: {
+        projectsV2: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: projects,
+        },
+      },
+    },
+  };
+}
+
+function listOrgProjectsResponse(projects) {
+  return {
+    data: {
+      organization: {
+        projectsV2: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: projects,
+        },
+      },
+    },
   };
 }
 
@@ -70,10 +102,10 @@ const EXISTING_PROJECT = {
 
 describe("ensure-queue-board", () => {
   describe("create path", () => {
-    it("creates project and Status field when board does not exist", async () => {
+    it("creates project and Status field when board does not exist (user)", async () => {
       const responses = [
-        { payload: USER_ID_RESPONSE },
-        { payload: listProjectsResponse([]) },
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([]) },
         {
           payload: createProjectResponse({
             id: "PVT_new",
@@ -83,10 +115,7 @@ describe("ensure-queue-board", () => {
           }),
         },
         {
-          payload: createFieldResponse({
-            id: "PVTSSF_new",
-            name: "Status",
-          }),
+          payload: createFieldResponse({ id: "PVTSSF_new", name: "Status" }),
         },
       ];
       const result = await main(
@@ -101,23 +130,43 @@ describe("ensure-queue-board", () => {
       assert.equal(result.project.statusFieldId, "PVTSSF_new");
     });
 
-    it("uses custom title", async () => {
+    it("creates project for org owner", async () => {
       const responses = [
-        { payload: USER_ID_RESPONSE },
-        { payload: listProjectsResponse([]) },
+        { payload: noUserPayload() },
+        { payload: orgPayload() },
+        { payload: listOrgProjectsResponse([]) },
         {
           payload: createProjectResponse({
-            id: "PVT_custom",
-            number: 3,
-            title: "My Queue",
+            id: "PVT_org",
+            number: 1,
+            title: "Dev Loop Queue",
+            url: "https://github.com/orgs/myorg/projects/1",
+          }),
+        },
+        {
+          payload: createFieldResponse({ id: "PVTSSF_org", name: "Status" }),
+        },
+      ];
+      const result = await main(
+        { repo: "myorg/repo" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.project.number, 1);
+    });
+
+    it("uses custom title", async () => {
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([]) },
+        {
+          payload: createProjectResponse({
+            id: "PVT_custom", number: 3, title: "My Queue",
             url: "https://github.com/users/mfittko/projects/3",
           }),
         },
         {
-          payload: createFieldResponse({
-            id: "PVTSSF_custom",
-            name: "Status",
-          }),
+          payload: createFieldResponse({ id: "PVTSSF_custom", name: "Status" }),
         },
       ];
       const result = await main(
@@ -132,8 +181,8 @@ describe("ensure-queue-board", () => {
   describe("already-exists path", () => {
     it("returns existing project when board and Status field exist", async () => {
       const responses = [
-        { payload: USER_ID_RESPONSE },
-        { payload: listProjectsResponse([EXISTING_PROJECT]) },
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
         { payload: getFieldsResponse([STATUS_FIELD]) },
       ];
       const result = await main(
@@ -149,14 +198,11 @@ describe("ensure-queue-board", () => {
 
     it("creates Status field when project exists but field is missing", async () => {
       const responses = [
-        { payload: USER_ID_RESPONSE },
-        { payload: listProjectsResponse([EXISTING_PROJECT]) },
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
         { payload: getFieldsResponse([]) },
         {
-          payload: createFieldResponse({
-            id: "PVTSSF_new",
-            name: "Status",
-          }),
+          payload: createFieldResponse({ id: "PVTSSF_new", name: "Status" }),
         },
       ];
       const result = await main(
@@ -168,42 +214,79 @@ describe("ensure-queue-board", () => {
     });
 
     it("throws on missing columns in existing Status field", async () => {
-      const partialStatusField = {
-        id: "PVTSSF_partial",
-        name: "Status",
-        options: [{ id: "opt1", name: "Backlog" }], // missing Next Up, In Progress, Done
+      const partialField = {
+        id: "PVTSSF_partial", name: "Status",
+        options: [{ id: "opt1", name: "Backlog" }],
       };
       const responses = [
-        { payload: USER_ID_RESPONSE },
-        { payload: listProjectsResponse([EXISTING_PROJECT]) },
-        { payload: getFieldsResponse([partialStatusField]) },
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([partialField]) },
       ];
       await assert.rejects(
         () => main({ repo: "mfittko/pi-dev-loops" }, { env: {}, runChild: mockRunChild(responses) }),
         /missing columns/,
       );
     });
+
+    it("handles paginated project listing (>50 projects)", async () => {
+      const page1 = {
+        data: {
+          user: {
+            projectsV2: {
+              pageInfo: { hasNextPage: true, endCursor: "cursor1" },
+              nodes: Array.from({ length: 50 }, (_, i) => ({
+                id: `PVT_${i}`, number: i, title: `Project ${i}`,
+                url: `https://github.com/users/mfittko/projects/${i}`,
+              })),
+            },
+          },
+        },
+      };
+      const page2 = {
+        data: {
+          user: {
+            projectsV2: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [EXISTING_PROJECT],
+            },
+          },
+        },
+      };
+      const responses = [
+        { payload: userPayload() },
+        { payload: page1 },
+        { payload: page2 },
+        { payload: getFieldsResponse([STATUS_FIELD]) },
+      ];
+      const result = await main(
+        { repo: "mfittko/pi-dev-loops" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.project.number, 1);
+    });
   });
 
   describe("error paths", () => {
-    it("throws on invalid repo", async () => {
-      await assert.rejects(
-        () => main({ repo: "not-a-repo" }),
-        /owner\/name/,
-      );
+    it("throws on invalid repo format", async () => {
+      await assert.rejects(() => main({ repo: "not-a-repo" }), /owner\/name/);
+    });
+
+    it("throws on repo with extra segments", async () => {
+      await assert.rejects(() => main({ repo: "a/b/c" }), /owner\/name/);
+    });
+
+    it("throws on whitespace-padded repo", async () => {
+      await assert.rejects(() => main({ repo: " owner/repo " }), /whitespace/);
     });
 
     it("throws on missing repo", async () => {
-      await assert.rejects(
-        () => main({}),
-        /owner\/name/,
-      );
+      await assert.rejects(() => main({}), /required/);
     });
 
     it("throws on GraphQL API error", async () => {
-      const responses = [
-        { error: "gh: authentication required" },
-      ];
+      const responses = [{ error: "gh: authentication required" }];
       await assert.rejects(
         () => main({ repo: "mfittko/pi-dev-loops" }, { env: {}, runChild: mockRunChild(responses) }),
         /gh api graphql failed/,
@@ -211,27 +294,44 @@ describe("ensure-queue-board", () => {
     });
 
     it("throws on GraphQL errors in payload", async () => {
-      const responses = [
-        {
-          payload: {
-            errors: [{ message: "Could not resolve to a User" }],
-          },
-        },
-      ];
+      const responses = [{
+        payload: { errors: [{ message: "Could not resolve to a User" }] },
+      }];
       await assert.rejects(
         () => main({ repo: "mfittko/pi-dev-loops" }, { env: {}, runChild: mockRunChild(responses) }),
         /GraphQL errors/,
       );
     });
 
-    it("throws when user ID cannot be resolved", async () => {
+    it("throws when neither user nor org resolves", async () => {
       const responses = [
-        { payload: { data: { user: null } } },
+        { payload: noUserPayload() },
+        { payload: noOrgPayload() },
       ];
       await assert.rejects(
         () => main({ repo: "mfittko/pi-dev-loops" }, { env: {}, runChild: mockRunChild(responses) }),
-        /Could not resolve user ID/,
+        /Could not resolve owner ID/,
       );
+    });
+  });
+
+  describe("exit code classification", () => {
+    it("MISSING_COLUMNS gets code 3 not 2", async () => {
+      const partialField = {
+        id: "PVTSSF_partial", name: "Status",
+        options: [{ id: "opt1", name: "Backlog" }],
+      };
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([partialField]) },
+      ];
+      try {
+        await main({ repo: "mfittko/pi-dev-loops" }, { env: {}, runChild: mockRunChild(responses) });
+        assert.fail("should have thrown");
+      } catch (err) {
+        assert.equal(err.code, "MISSING_COLUMNS");
+      }
     });
   });
 });

--- a/test/projects/ensure-queue-board.test.mjs
+++ b/test/projects/ensure-queue-board.test.mjs
@@ -1,0 +1,237 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { main } from "../../scripts/projects/ensure-queue-board.mjs";
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function mockRunChild(responses) {
+  let callIndex = 0;
+  return async (_cmd, args, _env) => {
+    if (callIndex >= responses.length) {
+      throw new Error(`Unexpected gh call #${callIndex + 1} (only ${responses.length} mocked)`);
+    }
+    const resp = responses[callIndex++];
+    if (resp.error) {
+      return { code: 1, stdout: "", stderr: resp.error };
+    }
+    return { code: 0, stdout: JSON.stringify(resp.payload), stderr: "" };
+  };
+}
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+
+const USER_ID_RESPONSE = {
+  data: { user: { id: "U_kgDOABC123" } },
+};
+
+function listProjectsResponse(projects) {
+  return {
+    data: { user: { projectsV2: { nodes: projects } } },
+  };
+}
+
+function getFieldsResponse(fields) {
+  return {
+    data: { node: { fields: { nodes: fields } } },
+  };
+}
+
+function createProjectResponse(project) {
+  return {
+    data: { createProjectV2: { projectV2: project } },
+  };
+}
+
+function createFieldResponse(field) {
+  return {
+    data: { createProjectV2Field: { projectV2Field: field } },
+  };
+}
+
+const STATUS_FIELD = {
+  id: "PVTSSF_lADO...",
+  name: "Status",
+  options: [
+    { id: "opt1", name: "Backlog" },
+    { id: "opt2", name: "Next Up" },
+    { id: "opt3", name: "In Progress" },
+    { id: "opt4", name: "Done" },
+  ],
+};
+
+const EXISTING_PROJECT = {
+  id: "PVT_kwDO...",
+  number: 1,
+  title: "Dev Loop Queue",
+  url: "https://github.com/users/mfittko/projects/1",
+};
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe("ensure-queue-board", () => {
+  describe("create path", () => {
+    it("creates project and Status field when board does not exist", async () => {
+      const responses = [
+        { payload: USER_ID_RESPONSE },
+        { payload: listProjectsResponse([]) },
+        {
+          payload: createProjectResponse({
+            id: "PVT_new",
+            number: 2,
+            title: "Dev Loop Queue",
+            url: "https://github.com/users/mfittko/projects/2",
+          }),
+        },
+        {
+          payload: createFieldResponse({
+            id: "PVTSSF_new",
+            name: "Status",
+          }),
+        },
+      ];
+      const result = await main(
+        { repo: "mfittko/pi-dev-loops" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.project.title, "Dev Loop Queue");
+      assert.equal(result.project.number, 2);
+      assert.ok(result.project.id);
+      assert.ok(result.project.url);
+      assert.equal(result.project.statusFieldId, "PVTSSF_new");
+    });
+
+    it("uses custom title", async () => {
+      const responses = [
+        { payload: USER_ID_RESPONSE },
+        { payload: listProjectsResponse([]) },
+        {
+          payload: createProjectResponse({
+            id: "PVT_custom",
+            number: 3,
+            title: "My Queue",
+            url: "https://github.com/users/mfittko/projects/3",
+          }),
+        },
+        {
+          payload: createFieldResponse({
+            id: "PVTSSF_custom",
+            name: "Status",
+          }),
+        },
+      ];
+      const result = await main(
+        { repo: "mfittko/pi-dev-loops", title: "My Queue" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.project.title, "My Queue");
+    });
+  });
+
+  describe("already-exists path", () => {
+    it("returns existing project when board and Status field exist", async () => {
+      const responses = [
+        { payload: USER_ID_RESPONSE },
+        { payload: listProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([STATUS_FIELD]) },
+      ];
+      const result = await main(
+        { repo: "mfittko/pi-dev-loops" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.project.id, "PVT_kwDO...");
+      assert.equal(result.project.number, 1);
+      assert.equal(result.project.title, "Dev Loop Queue");
+      assert.equal(result.project.statusFieldId, "PVTSSF_lADO...");
+    });
+
+    it("creates Status field when project exists but field is missing", async () => {
+      const responses = [
+        { payload: USER_ID_RESPONSE },
+        { payload: listProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([]) },
+        {
+          payload: createFieldResponse({
+            id: "PVTSSF_new",
+            name: "Status",
+          }),
+        },
+      ];
+      const result = await main(
+        { repo: "mfittko/pi-dev-loops" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.project.statusFieldId, "PVTSSF_new");
+    });
+
+    it("throws on missing columns in existing Status field", async () => {
+      const partialStatusField = {
+        id: "PVTSSF_partial",
+        name: "Status",
+        options: [{ id: "opt1", name: "Backlog" }], // missing Next Up, In Progress, Done
+      };
+      const responses = [
+        { payload: USER_ID_RESPONSE },
+        { payload: listProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([partialStatusField]) },
+      ];
+      await assert.rejects(
+        () => main({ repo: "mfittko/pi-dev-loops" }, { env: {}, runChild: mockRunChild(responses) }),
+        /missing columns/,
+      );
+    });
+  });
+
+  describe("error paths", () => {
+    it("throws on invalid repo", async () => {
+      await assert.rejects(
+        () => main({ repo: "not-a-repo" }),
+        /owner\/name/,
+      );
+    });
+
+    it("throws on missing repo", async () => {
+      await assert.rejects(
+        () => main({}),
+        /owner\/name/,
+      );
+    });
+
+    it("throws on GraphQL API error", async () => {
+      const responses = [
+        { error: "gh: authentication required" },
+      ];
+      await assert.rejects(
+        () => main({ repo: "mfittko/pi-dev-loops" }, { env: {}, runChild: mockRunChild(responses) }),
+        /gh api graphql failed/,
+      );
+    });
+
+    it("throws on GraphQL errors in payload", async () => {
+      const responses = [
+        {
+          payload: {
+            errors: [{ message: "Could not resolve to a User" }],
+          },
+        },
+      ];
+      await assert.rejects(
+        () => main({ repo: "mfittko/pi-dev-loops" }, { env: {}, runChild: mockRunChild(responses) }),
+        /GraphQL errors/,
+      );
+    });
+
+    it("throws when user ID cannot be resolved", async () => {
+      const responses = [
+        { payload: { data: { user: null } } },
+      ];
+      await assert.rejects(
+        () => main({ repo: "mfittko/pi-dev-loops" }, { env: {}, runChild: mockRunChild(responses) }),
+        /Could not resolve user ID/,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

One-time setup for the GitHub Projects V2 board used by `dev-loop queue` helpers.

Two pieces:
1. **Manual docs** (`docs/queue-board-setup.md`) — setup instructions for creating and configuring the board
2. **Thin wrapper** (`scripts/projects/ensure-queue-board.mjs`) — idempotent bootstrap using `gh api graphql`

## Changes

- `docs/queue-board-setup.md` — manual setup docs with copy-paste examples, column descriptions, and fail-closed behavior
- `scripts/projects/ensure-queue-board.mjs` — idempotent bootstrap: creates project board + Status field with standard columns (Backlog, Next Up, In Progress, Done); exits clean if already present; emits machine-readable JSON
- `docs/index.md` — add queue board setup link

## Acceptance criteria

- Manual docs exist alongside #631
- Wrapper is idempotent (safe to re-run)
- Wrapper emits machine-readable JSON with project id/number
- No local queue persistence introduced

## Validation

```sh
# Verify wrapper loads and parses args correctly
node scripts/projects/ensure-queue-board.mjs --help
node scripts/projects/ensure-queue-board.mjs  # exits 1 with usage error

# Full test suite (pre-existing flaky test in detect-checkpoint-evidence, unrelated)
npm run verify
```

Closes #632
