### PR TITLE
feat: add GitHub Projects queue move helper (#628)

### DIFF
--- a/scripts/projects/move-queue-item.mjs
+++ b/scripts/projects/move-queue-item.mjs
@@ -1,0 +1,550 @@
+#!/usr/bin/env node
+import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { runChild as _runChild } from "../_cli-primitives.mjs";
+
+const USAGE = `Usage: node scripts/projects/move-queue-item.mjs --repo <owner/name> --project <number|id> --item <number|node-id> --to-column <name>
+
+Move a GitHub Projects V2 item between Status columns.
+
+Options:
+  --repo <owner/name>         Required. Repository to scope the project search.
+  --project <number|id>       Required. Project number (integer) or node ID.
+  --item <number|node-id>     Required. Item to move: issue/PR number, or project item node ID.
+  --to-column <name>          Required. Target Status column (e.g. "Next Up", "In Progress").
+  --help, -h                  Show this help.
+
+Output (stdout):
+  JSON: { ok: true, item: { itemId, issueNumber, prNumber, previousColumn, newColumn } }
+
+Exit codes:
+  0 — success
+  1 — usage or argument error
+  2 — GitHub API error
+  3 — project, field, column, or item not found
+`.trim();
+
+const VALID_ARGS = new Set(["--repo", "--project", "--item", "--to-column", "--help", "-h"]);
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!VALID_ARGS.has(arg) && arg.startsWith("-")) {
+      throw Object.assign(
+        new Error(`Unknown flag: ${arg}`),
+        { code: "INVALID_ARGS", usage: USAGE },
+      );
+    }
+    if (arg === "--repo") {
+      if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
+        throw Object.assign(new Error("--repo requires a value (owner/name)"), { code: "INVALID_REPO" });
+      }
+      args.repo = argv[++i];
+    } else if (arg === "--project") {
+      if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
+        throw Object.assign(new Error("--project requires a value (number or node ID)"), { code: "INVALID_PROJECT" });
+      }
+      args.project = argv[++i];
+    } else if (arg === "--item") {
+      if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
+        throw Object.assign(new Error("--item requires a value (number or node ID)"), { code: "INVALID_ITEM" });
+      }
+      args.item = argv[++i];
+    } else if (arg === "--to-column") {
+      if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
+        throw Object.assign(new Error("--to-column requires a value"), { code: "INVALID_COLUMN" });
+      }
+      args.toColumn = argv[++i];
+    } else if (arg === "--help" || arg === "-h") {
+      args.help = true;
+    } else {
+      throw Object.assign(new Error(`Unexpected argument: ${arg}`), { code: "INVALID_ARGS", usage: USAGE });
+    }
+  }
+  return args;
+}
+
+// ── Validation ───────────────────────────────────────────────────────────
+
+const OWNER_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
+const REPO_NAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9_.-]*[a-zA-Z0-9])?$/;
+const GLOBAL_NODE_ID_RE = /^[A-Za-z0-9_]+$/;
+
+function validateRepo(repo) {
+  if (!repo || typeof repo !== "string") {
+    throw Object.assign(new Error("--repo is required"), { code: "INVALID_REPO" });
+  }
+  const trimmed = repo.trim();
+  if (trimmed !== repo) {
+    throw Object.assign(new Error(`--repo must not have leading/trailing whitespace, got "${repo}"`), { code: "INVALID_REPO" });
+  }
+  const slashIdx = repo.indexOf("/");
+  if (slashIdx === -1) {
+    throw Object.assign(new Error(`--repo must be exactly owner/name, got "${repo}"`), { code: "INVALID_REPO" });
+  }
+  const owner = repo.slice(0, slashIdx);
+  const name = repo.slice(slashIdx + 1);
+  if (!owner || !name || !OWNER_RE.test(owner) || !REPO_NAME_RE.test(name)) {
+    throw Object.assign(new Error(`--repo must be exactly owner/name, got "${repo}"`), { code: "INVALID_REPO" });
+  }
+  return repo;
+}
+
+function parseProjectRef(raw) {
+  if (!raw || typeof raw !== "string" || raw.trim().length === 0) {
+    throw Object.assign(new Error("--project is required"), { code: "INVALID_PROJECT" });
+  }
+  const trimmed = raw.trim();
+  const asNum = Number(trimmed);
+  if (Number.isInteger(asNum) && asNum > 0 && String(asNum) === trimmed) {
+    return { kind: "number", value: asNum };
+  }
+  if (trimmed === "0") {
+    throw Object.assign(new Error(`--project must be a positive integer or a node ID, got "${raw}"`), { code: "INVALID_PROJECT" });
+  }
+  if (GLOBAL_NODE_ID_RE.test(trimmed)) {
+    return { kind: "id", value: trimmed };
+  }
+  throw Object.assign(new Error(`--project must be a positive integer or a node ID, got "${raw}"`), { code: "INVALID_PROJECT" });
+}
+
+function parseItemRef(raw) {
+  if (!raw || typeof raw !== "string" || raw.trim().length === 0) {
+    throw Object.assign(new Error("--item is required"), { code: "INVALID_ITEM" });
+  }
+  const trimmed = raw.trim();
+  const asNum = Number(trimmed);
+  if (Number.isInteger(asNum) && asNum > 0 && String(asNum) === trimmed) {
+    return { kind: "number", value: asNum };
+  }
+  if (trimmed === "0") {
+    throw Object.assign(new Error(`--item must be a positive integer or an item node ID, got "${raw}"`), { code: "INVALID_ITEM" });
+  }
+  if (GLOBAL_NODE_ID_RE.test(trimmed)) {
+    return { kind: "id", value: trimmed };
+  }
+  throw Object.assign(new Error(`--item must be a positive integer or an item node ID, got "${raw}"`), { code: "INVALID_ITEM" });
+}
+
+// ── API helpers ──────────────────────────────────────────────────────────
+
+async function ghGraphql(query, vars, env, runChild = _runChild) {
+  const fieldArgs = [];
+  for (const [key, value] of Object.entries(vars)) {
+    fieldArgs.push("--field", `${key}=${value}`);
+  }
+  const result = await runChild(
+    "gh",
+    ["api", "graphql", "--field", `query=${query}`, ...fieldArgs],
+    env,
+  );
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw Object.assign(new Error(`gh api graphql failed: ${detail}`), { code: "GH_API_ERROR" });
+  }
+  const payload = parseJsonText(result.stdout);
+  if (payload.errors && payload.errors.length > 0) {
+    throw Object.assign(
+      new Error(`GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`),
+      { code: "GRAPHQL_ERROR" },
+    );
+  }
+  return payload;
+}
+
+// ── GraphQL fragments ────────────────────────────────────────────────────
+
+const GET_USER_ID = [
+  "query($login:String!) {",
+  "  user(login:$login) { id }",
+  "}"
+].join("\n");
+
+const GET_ORG_ID = [
+  "query($login:String!) {",
+  "  organization(login:$login) { id }",
+  "}"
+].join("\n");
+
+const LIST_USER_PROJECTS = [
+  "query($login:String!, $after:String) {",
+  "  user(login:$login) {",
+  "    projectsV2(first:50, after:$after) {",
+  "      pageInfo { hasNextPage endCursor }",
+  "      nodes { id number title url }",
+  "    }",
+  "  }",
+  "}"
+].join("\n");
+
+const LIST_ORG_PROJECTS = [
+  "query($login:String!, $after:String) {",
+  "  organization(login:$login) {",
+  "    projectsV2(first:50, after:$after) {",
+  "      pageInfo { hasNextPage endCursor }",
+  "      nodes { id number title url }",
+  "    }",
+  "  }",
+  "}"
+].join("\n");
+
+const GET_PROJECT_FIELDS = [
+  "query($projectId:ID!, $after:String) {",
+  "  node(id:$projectId) {",
+  "    ... on ProjectV2 {",
+  "      fields(first:50, after:$after) {",
+  "        pageInfo { hasNextPage endCursor }",
+  "        nodes {",
+  "          ... on ProjectV2SingleSelectField {",
+  "            id name",
+  "            options { id name }",
+  "          }",
+  "        }",
+  "      }",
+  "    }",
+  "  }",
+  "}"
+].join("\n");
+
+const GET_PROJECT_ITEMS_BY_CONTENT = [
+  "query($projectId:ID!, $owner:String!, $repo:String!, $number:Int!, $after:String) {",
+  "  node(id:$projectId) {",
+  "    ... on ProjectV2 {",
+  "      items(first:10, after:$after, orderBy:{field:POSITION, direction:ASC}) {",
+  "        pageInfo { hasNextPage endCursor }",
+  "        nodes {",
+  "          id",
+  "          fieldValues(first:20) {",
+  "            nodes {",
+  "              ... on ProjectV2ItemFieldSingleSelectValue {",
+  "                field { ... on ProjectV2SingleSelectField { id name } }",
+  "                name",
+  "              }",
+  "            }",
+  "          }",
+  "          content {",
+  "            ... on Issue { number repository { nameWithOwner } }",
+  "            ... on PullRequest { number repository { nameWithOwner } }",
+  "          }",
+  "        }",
+  "      }",
+  "    }",
+  "  }",
+  "}"
+].join("\n");
+
+const GET_PROJECT_ITEM = [
+  "query($projectId:ID!, $itemId:ID!) {",
+  "  node(id:$projectId) {",
+  "    ... on ProjectV2 {",
+  "      item: item(id:$itemId) {",
+  "        id",
+  "        fieldValues(first:20) {",
+  "          nodes {",
+  "            ... on ProjectV2ItemFieldSingleSelectValue {",
+  "              field { ... on ProjectV2SingleSelectField { id name } }",
+  "              name",
+  "            }",
+  "          }",
+  "        }",
+  "        content {",
+  "          ... on Issue { number title url }",
+  "          ... on PullRequest { number title url }",
+  "        }",
+  "      }",
+  "    }",
+  "  }",
+  "}"
+].join("\n");
+
+const UPDATE_ITEM_FIELD = [
+  "mutation($input:UpdateProjectV2ItemFieldValueInput!) {",
+  "  updateProjectV2ItemFieldValue(input:$input) {",
+  "    projectV2Item {",
+  "      id",
+  "    }",
+  "  }",
+  "}"
+].join("\n");
+
+// ── Owner resolution ────────────────────────────────────────────────────
+
+async function resolveOwner(login, env, runChild) {
+  const userPayload = await ghGraphql(GET_USER_ID, { login }, env, runChild);
+  if (userPayload?.data?.user?.id) {
+    return { id: userPayload.data.user.id, kind: "user" };
+  }
+  const orgPayload = await ghGraphql(GET_ORG_ID, { login }, env, runChild);
+  if (orgPayload?.data?.organization?.id) {
+    return { id: orgPayload.data.organization.id, kind: "org" };
+  }
+  throw Object.assign(
+    new Error(`Could not resolve owner ID for "${login}"`),
+    { code: "NO_USER_ID" },
+  );
+}
+
+// ── Paginated project listing ────────────────────────────────────────────
+
+async function listAllProjects(login, kind, env, runChild) {
+  const query = kind === "org" ? LIST_ORG_PROJECTS : LIST_USER_PROJECTS;
+  const projects = [];
+  let after = null;
+  while (true) {
+    const vars = { login };
+    if (after) vars.after = after;
+    const payload = await ghGraphql(query, vars, env, runChild);
+    const connection = kind === "org"
+      ? payload?.data?.organization?.projectsV2
+      : payload?.data?.user?.projectsV2;
+    const nodes = connection?.nodes ?? [];
+    projects.push(...nodes);
+    const pageInfo = connection?.pageInfo ?? {};
+    if (!pageInfo.hasNextPage) break;
+    if (!pageInfo.endCursor) {
+      throw Object.assign(
+        new Error("Invalid projects list payload: hasNextPage is true but endCursor is missing"),
+        { code: "GH_API_ERROR" },
+      );
+    }
+    after = pageInfo.endCursor;
+  }
+  return projects;
+}
+
+// ── Paginated field listing ──────────────────────────────────────────────
+
+async function listAllFields(projectId, env, runChild) {
+  const fields = [];
+  let after = null;
+  while (true) {
+    const vars = { projectId };
+    if (after) vars.after = after;
+    const payload = await ghGraphql(GET_PROJECT_FIELDS, vars, env, runChild);
+    const connection = payload?.data?.node?.fields;
+    const nodes = connection?.nodes ?? [];
+    fields.push(...nodes);
+    const pageInfo = connection?.pageInfo ?? {};
+    if (!pageInfo.hasNextPage) break;
+    if (!pageInfo.endCursor) {
+      throw Object.assign(
+        new Error("Invalid fields payload: hasNextPage is true but endCursor is missing"),
+        { code: "GH_API_ERROR" },
+      );
+    }
+    after = pageInfo.endCursor;
+  }
+  return fields;
+}
+
+// ── Exit code classification ────────────────────────────────────────────
+
+function classifyExitCode(err) {
+  if (err.code === "INVALID_REPO" || err.code === "INVALID_PROJECT" || err.code === "INVALID_ITEM" ||
+      err.code === "INVALID_COLUMN" || err.code === "INVALID_ARGS") return 1;
+  if (err.code === "PROJECT_NOT_FOUND" || err.code === "FIELD_NOT_FOUND" || err.code === "COLUMN_NOT_FOUND" ||
+      err.code === "ITEM_NOT_FOUND") return 3;
+  return 2;
+}
+
+// ── Main logic ──────────────────────────────────────────────────────────
+
+async function main(args, { env = process.env, runChild } = {}) {
+  const child = runChild ?? _runChild;
+  const repo = validateRepo(args.repo);
+  const [owner, repoName] = repo.split("/");
+  const projectRef = parseProjectRef(args.project);
+  const itemRef = parseItemRef(args.item);
+  const toColumn = (args.toColumn ?? "").trim();
+  if (!toColumn) {
+    throw Object.assign(new Error("--to-column is required"), { code: "INVALID_COLUMN" });
+  }
+
+  // 1. Resolve owner
+  const { id: ownerId, kind: ownerKind } = await resolveOwner(owner, env, child);
+
+  // 2. Resolve project
+  const projects = await listAllProjects(owner, ownerKind, env, child);
+  let project;
+  if (projectRef.kind === "id") {
+    project = projects.find((p) => p.id === projectRef.value);
+  } else {
+    project = projects.find((p) => p.number === projectRef.value);
+  }
+  if (!project) {
+    throw Object.assign(
+      new Error(`Project ${projectRef.kind === "id" ? `"${projectRef.value}"` : `number ${projectRef.value}`} not found under owner "${owner}"`),
+      { code: "PROJECT_NOT_FOUND" },
+    );
+  }
+
+  // 3. Resolve Status field and target column
+  const fieldNodes = await listAllFields(project.id, env, child);
+  const statusField = fieldNodes.find((f) => f.name === "Status" && f.options);
+  if (!statusField) {
+    throw Object.assign(
+      new Error(`Status field not found in project "${project.title}" (number ${project.number})`),
+      { code: "FIELD_NOT_FOUND" },
+    );
+  }
+
+  const targetOption = statusField.options.find((o) => o.name === toColumn);
+  if (!targetOption) {
+    const available = statusField.options.map((o) => o.name).join(", ");
+    throw Object.assign(
+      new Error(`Column "${toColumn}" not found in Status field. Available: ${available}`),
+      { code: "COLUMN_NOT_FOUND" },
+    );
+  }
+
+  // 4. Find the item
+  let itemId;
+  let previousColumn = null;
+  let issueNumber = null;
+  let prNumber = null;
+
+  if (itemRef.kind === "id") {
+    // Direct item node ID lookup
+    const itemPayload = await ghGraphql(GET_PROJECT_ITEM, {
+      projectId: project.id,
+      itemId: itemRef.value,
+    }, env, child);
+    const item = itemPayload?.data?.node?.item;
+    if (!item) {
+      throw Object.assign(
+        new Error(`Item "${itemRef.value}" not found in project "${project.title}"`),
+        { code: "ITEM_NOT_FOUND" },
+      );
+    }
+    itemId = item.id;
+    const fvs = item.fieldValues?.nodes ?? [];
+    for (const fv of fvs) {
+      if (fv && fv.field && fv.field.name === "Status") {
+        previousColumn = fv.name;
+        break;
+      }
+    }
+    if (item.content) {
+      if (item.content.__typename === "Issue") {
+        issueNumber = item.content.number;
+      } else {
+        prNumber = item.content.number;
+      }
+    }
+  } else {
+    // Look up by issue/PR number in the project
+    const itemsPayload = await ghGraphql(GET_PROJECT_ITEMS_BY_CONTENT, {
+      projectId: project.id,
+      owner,
+      repo: repoName,
+      number: itemRef.value,
+    }, env, child);
+    const items = itemsPayload?.data?.node?.items?.nodes ?? [];
+
+    // Filter by matching repo exactly
+    const matchingItems = items.filter((it) => {
+      if (!it.content) return false;
+      return it.content.repository?.nameWithOwner === repo;
+    });
+
+    if (matchingItems.length === 0) {
+      throw Object.assign(
+        new Error(`Item #${itemRef.value} not found in project "${project.title}" for repo "${repo}"`),
+        { code: "ITEM_NOT_FOUND" },
+      );
+    }
+
+    // Use the first match (by position order)
+    const match = matchingItems[0];
+    itemId = match.id;
+    const fvs = match.fieldValues?.nodes ?? [];
+    for (const fv of fvs) {
+      if (fv && fv.field && fv.field.name === "Status") {
+        previousColumn = fv.name;
+        break;
+      }
+    }
+    if (match.content) {
+      if (match.content.__typename === "Issue") {
+        issueNumber = match.content.number;
+      } else {
+        prNumber = match.content.number;
+      }
+    }
+  }
+
+  // 5. No-op if already at target column
+  if (previousColumn === toColumn) {
+    return {
+      ok: true,
+      item: {
+        itemId,
+        issueNumber,
+        prNumber,
+        previousColumn,
+        newColumn: toColumn,
+        unchanged: true,
+      },
+    };
+  }
+
+  // 6. Update Status via mutation
+  const updatePayload = await ghGraphql(UPDATE_ITEM_FIELD, {
+    input: JSON.stringify({
+      projectId: project.id,
+      itemId,
+      fieldId: statusField.id,
+      value: { singleSelectOptionId: targetOption.id },
+    }),
+  }, env, child);
+
+  const updated = updatePayload?.data?.updateProjectV2ItemFieldValue?.projectV2Item;
+  if (!updated) {
+    throw Object.assign(new Error("Failed to update item field value"), { code: "MUTATION_FAILED" });
+  }
+
+  return {
+    ok: true,
+    item: {
+      itemId,
+      issueNumber,
+      prNumber,
+      previousColumn,
+      newColumn: toColumn,
+      unchanged: false,
+    },
+  };
+}
+
+// ── CLI entrypoint ──────────────────────────────────────────────────────
+
+async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, env = process.env } = {}) {
+  let args;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    stderr.write(`${formatCliError(err)}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  if (args.help) {
+    stdout.write(USAGE);
+    return;
+  }
+  try {
+    const result = await main(args, { env });
+    stdout.write(JSON.stringify(result) + "\n");
+  } catch (err) {
+    stderr.write(JSON.stringify({ ok: false, error: err.message, code: err.code ?? "UNKNOWN" }) + "\n");
+    process.exitCode = classifyExitCode(err);
+  }
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(JSON.stringify({ ok: false, error: error.message, code: error.code ?? "UNKNOWN" }) + "\n");
+    process.exitCode = 2;
+  });
+}
+
+export { main };

--- a/test/projects/move-queue-item.test.mjs
+++ b/test/projects/move-queue-item.test.mjs
@@ -1,0 +1,487 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { main } from "../../scripts/projects/move-queue-item.mjs";
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function mockRunChild(responses) {
+  let callIndex = 0;
+  return async (_cmd, args, _env) => {
+    if (callIndex >= responses.length) {
+      throw new Error(`Unexpected gh call #${callIndex + 1} (only ${responses.length} mocked)`);
+    }
+    const resp = responses[callIndex++];
+    if (resp.error) {
+      return { code: 1, stdout: "", stderr: resp.error };
+    }
+    return { code: 0, stdout: JSON.stringify(resp.payload), stderr: "" };
+  };
+}
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+
+function userPayload() {
+  return { data: { user: { id: "U_kgDOABC123" } } };
+}
+
+function noUserPayload() {
+  return { data: { user: null } };
+}
+
+function orgPayload() {
+  return { data: { organization: { id: "O_kgDOXYZ789" } } };
+}
+
+function noOrgPayload() {
+  return { data: { organization: null } };
+}
+
+function listUserProjectsResponse(projects) {
+  return {
+    data: {
+      user: {
+        projectsV2: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: projects },
+      },
+    },
+  };
+}
+
+function getFieldsResponse(fields) {
+  return { data: { node: { fields: { nodes: fields, pageInfo: { hasNextPage: false } } } } };
+}
+
+const STATUS_FIELD = {
+  id: "PVTSSF_status",
+  name: "Status",
+  options: [
+    { id: "opt1", name: "Backlog" },
+    { id: "opt2", name: "Next Up" },
+    { id: "opt3", name: "In Progress" },
+    { id: "opt4", name: "Done" },
+  ],
+};
+
+const EXISTING_PROJECT = {
+  id: "PVT_proj1",
+  number: 1,
+  title: "Dev Loop Queue",
+  url: "https://github.com/users/mfittko/projects/1",
+};
+
+function getItemsByContentResponse(items) {
+  return {
+    data: { node: { items: { nodes: items, pageInfo: { hasNextPage: false, endCursor: null } } } },
+  };
+}
+
+function getItemResponse(item) {
+  return {
+    data: { node: { item } },
+  };
+}
+
+function updateItemFieldResponse() {
+  return {
+    data: {
+      updateProjectV2ItemFieldValue: { projectV2Item: { id: "PVTI_1" } },
+    },
+  };
+}
+
+function makeItemNode(itemId, content, status) {
+  const fieldValues = status != null
+    ? { nodes: [{ field: { id: "PVTSSF_status", name: "Status" }, name: status }] }
+    : { nodes: [] };
+  return { id: itemId, fieldValues, content };
+}
+
+function makeContent(type, number, repo = "mfittko/pi-dev-loops") {
+  const __typename = type === "PR" ? "PullRequest" : "Issue";
+  return { __typename, number, repository: { nameWithOwner: repo } };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe("move-queue-item", () => {
+  describe("argument parsing", () => {
+    it("requires --repo", async () => {
+      await assert.rejects(
+        () => main({ project: "1", item: "10", toColumn: "Next Up" }),
+        /--repo is required/,
+      );
+    });
+
+    it("requires --project", async () => {
+      await assert.rejects(
+        () => main({ repo: "mfittko/pi-dev-loops", item: "10", toColumn: "Next Up" }),
+        /--project is required/,
+      );
+    });
+
+    it("requires --item", async () => {
+      await assert.rejects(
+        () => main({ repo: "mfittko/pi-dev-loops", project: "1", toColumn: "Next Up" }),
+        /--item is required/,
+      );
+    });
+
+    it("requires --to-column", async () => {
+      await assert.rejects(
+        () => main({ repo: "mfittko/pi-dev-loops", project: "1", item: "10" }),
+        /--to-column is required/,
+      );
+    });
+
+    it("rejects invalid project format", async () => {
+      await assert.rejects(
+        () => main({ repo: "mfittko/pi-dev-loops", project: "not-a-number", item: "10", toColumn: "Next Up" }),
+        /--project must be a positive integer or a node ID/,
+      );
+    });
+
+    it("rejects invalid item format", async () => {
+      await assert.rejects(
+        () => main({ repo: "mfittko/pi-dev-loops", project: "1", item: "not-a-number", toColumn: "Next Up" }),
+        /--item must be a positive integer or an item node ID/,
+      );
+    });
+
+    it("accepts project node ID", async () => {
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([STATUS_FIELD]) },
+        {
+          payload: getItemsByContentResponse([
+            makeItemNode("PVTI_1", makeContent("Issue", 10), "Backlog"),
+          ]),
+        },
+        { payload: updateItemFieldResponse() },
+      ];
+      const result = await main(
+        { repo: "mfittko/pi-dev-loops", project: "PVT_proj1", item: "10", toColumn: "Next Up" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.item.newColumn, "Next Up");
+    });
+
+    it("accepts item node ID", async () => {
+      const itemNode = {
+        id: "PVTI_42",
+        fieldValues: { nodes: [{ field: { id: "PVTSSF_status", name: "Status" }, name: "Backlog" }] },
+        content: { __typename: "Issue", number: 10, title: "Test", url: "https://github.com/mfittko/pi-dev-loops/issues/10" },
+      };
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([STATUS_FIELD]) },
+        { payload: getItemResponse(itemNode) },
+        { payload: updateItemFieldResponse() },
+      ];
+      const result = await main(
+        { repo: "mfittko/pi-dev-loops", project: "1", item: "PVTI_42", toColumn: "In Progress" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.item.newColumn, "In Progress");
+      assert.equal(result.item.issueNumber, 10);
+    });
+  });
+
+  describe("success path — move by number", () => {
+    it("moves an issue from Backlog to Next Up", async () => {
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([STATUS_FIELD]) },
+        {
+          payload: getItemsByContentResponse([
+            makeItemNode("PVTI_1", makeContent("Issue", 10), "Backlog"),
+          ]),
+        },
+        { payload: updateItemFieldResponse() },
+      ];
+      const result = await main(
+        { repo: "mfittko/pi-dev-loops", project: "1", item: "10", toColumn: "Next Up" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.item.itemId, "PVTI_1");
+      assert.equal(result.item.issueNumber, 10);
+      assert.equal(result.item.prNumber, null);
+      assert.equal(result.item.previousColumn, "Backlog");
+      assert.equal(result.item.newColumn, "Next Up");
+      assert.equal(result.item.unchanged, false);
+    });
+
+    it("moves a PR between columns", async () => {
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([STATUS_FIELD]) },
+        {
+          payload: getItemsByContentResponse([
+            makeItemNode("PVTI_2", makeContent("PR", 20), "In Progress"),
+          ]),
+        },
+        { payload: updateItemFieldResponse() },
+      ];
+      const result = await main(
+        { repo: "mfittko/pi-dev-loops", project: "1", item: "20", toColumn: "Done" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.item.prNumber, 20);
+      assert.equal(result.item.previousColumn, "In Progress");
+      assert.equal(result.item.newColumn, "Done");
+      assert.equal(result.item.unchanged, false);
+    });
+  });
+
+  describe("no-op when already at target column", () => {
+    it("returns unchanged when already at target", async () => {
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([STATUS_FIELD]) },
+        {
+          payload: getItemsByContentResponse([
+            makeItemNode("PVTI_1", makeContent("Issue", 10), "Next Up"),
+          ]),
+        },
+        // No mutation call expected — unchanged
+      ];
+      const result = await main(
+        { repo: "mfittko/pi-dev-loops", project: "1", item: "10", toColumn: "Next Up" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.item.previousColumn, "Next Up");
+      assert.equal(result.item.newColumn, "Next Up");
+      assert.equal(result.item.unchanged, true);
+    });
+
+    it("returns unchanged when already at target via item ID lookup", async () => {
+      const itemNode = {
+        id: "PVTI_42",
+        fieldValues: { nodes: [{ field: { id: "PVTSSF_status", name: "Status" }, name: "Done" }] },
+        content: { __typename: "Issue", number: 10, title: "Test", url: "https://github.com/mfittko/pi-dev-loops/issues/10" },
+      };
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([STATUS_FIELD]) },
+        { payload: getItemResponse(itemNode) },
+        // No mutation
+      ];
+      const result = await main(
+        { repo: "mfittko/pi-dev-loops", project: "1", item: "PVTI_42", toColumn: "Done" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.item.unchanged, true);
+    });
+  });
+
+  describe("supports all standard transitions", () => {
+    const transitions = [
+      ["Backlog", "Next Up"],
+      ["Next Up", "In Progress"],
+      ["In Progress", "Done"],
+      ["Done", "Backlog"],
+      ["Backlog", "In Progress"],
+      ["Next Up", "Done"],
+    ];
+    for (const [from, to] of transitions) {
+      it(`moves from "${from}" to "${to}"`, async () => {
+        const responses = [
+          { payload: userPayload() },
+          { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+          { payload: getFieldsResponse([STATUS_FIELD]) },
+          {
+            payload: getItemsByContentResponse([
+              makeItemNode("PVTI_1", makeContent("Issue", 10), from),
+            ]),
+          },
+          { payload: updateItemFieldResponse() },
+        ];
+        const result = await main(
+          { repo: "mfittko/pi-dev-loops", project: "1", item: "10", toColumn: to },
+          { env: {}, runChild: mockRunChild(responses) },
+        );
+        assert.equal(result.ok, true);
+        assert.equal(result.item.previousColumn, from);
+        assert.equal(result.item.newColumn, to);
+        assert.equal(result.item.unchanged, false);
+      });
+    }
+  });
+
+  describe("error paths — not found", () => {
+    it("throws PROJECT_NOT_FOUND for missing project number", async () => {
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([]) },
+      ];
+      try {
+        await main(
+          { repo: "mfittko/pi-dev-loops", project: "999", item: "10", toColumn: "Next Up" },
+          { env: {}, runChild: mockRunChild(responses) },
+        );
+        assert.fail("should have thrown");
+      } catch (err) {
+        assert.equal(err.code, "PROJECT_NOT_FOUND");
+      }
+    });
+
+    it("throws FIELD_NOT_FOUND when Status field missing", async () => {
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([]) },
+      ];
+      try {
+        await main(
+          { repo: "mfittko/pi-dev-loops", project: "1", item: "10", toColumn: "Next Up" },
+          { env: {}, runChild: mockRunChild(responses) },
+        );
+        assert.fail("should have thrown");
+      } catch (err) {
+        assert.equal(err.code, "FIELD_NOT_FOUND");
+      }
+    });
+
+    it("throws COLUMN_NOT_FOUND for unknown target column", async () => {
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([STATUS_FIELD]) },
+      ];
+      try {
+        await main(
+          { repo: "mfittko/pi-dev-loops", project: "1", item: "10", toColumn: "Icebox" },
+          { env: {}, runChild: mockRunChild(responses) },
+        );
+        assert.fail("should have thrown");
+      } catch (err) {
+        assert.equal(err.code, "COLUMN_NOT_FOUND");
+        assert.match(err.message, /"Icebox" not found/);
+      }
+    });
+
+    it("throws ITEM_NOT_FOUND when item not in project (by number)", async () => {
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([STATUS_FIELD]) },
+        { payload: getItemsByContentResponse([]) },
+      ];
+      try {
+        await main(
+          { repo: "mfittko/pi-dev-loops", project: "1", item: "42", toColumn: "Next Up" },
+          { env: {}, runChild: mockRunChild(responses) },
+        );
+        assert.fail("should have thrown");
+      } catch (err) {
+        assert.equal(err.code, "ITEM_NOT_FOUND");
+      }
+    });
+
+    it("throws ITEM_NOT_FOUND when item ID not found", async () => {
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([STATUS_FIELD]) },
+        { payload: getItemResponse(null) },
+      ];
+      try {
+        await main(
+          { repo: "mfittko/pi-dev-loops", project: "1", item: "PVTI_nonexistent", toColumn: "Next Up" },
+          { env: {}, runChild: mockRunChild(responses) },
+        );
+        assert.fail("should have thrown");
+      } catch (err) {
+        assert.equal(err.code, "ITEM_NOT_FOUND");
+      }
+    });
+  });
+
+  describe("error paths — API errors", () => {
+    it("throws on gh CLI failure", async () => {
+      const responses = [{ error: "gh: authentication required" }];
+      try {
+        await main(
+          { repo: "mfittko/pi-dev-loops", project: "1", item: "10", toColumn: "Next Up" },
+          { env: {}, runChild: mockRunChild(responses) },
+        );
+        assert.fail("should have thrown");
+      } catch (err) {
+        assert.equal(err.code, "GH_API_ERROR");
+      }
+    });
+
+    it("throws on GraphQL errors", async () => {
+      const responses = [{ payload: { errors: [{ message: "Could not resolve" }] } }];
+      try {
+        await main(
+          { repo: "mfittko/pi-dev-loops", project: "1", item: "10", toColumn: "Next Up" },
+          { env: {}, runChild: mockRunChild(responses) },
+        );
+        assert.fail("should have thrown");
+      } catch (err) {
+        assert.equal(err.code, "GRAPHQL_ERROR");
+      }
+    });
+  });
+
+  describe("owner resolution", () => {
+    it("resolves org owner", async () => {
+      const orgProject = { id: "PVT_org", number: 1, title: "Org Queue", url: "https://github.com/orgs/myorg/projects/1" };
+      const orgStatusField = { ...STATUS_FIELD };
+      const responses = [
+        { payload: noUserPayload() },
+        { payload: orgPayload() },
+        {
+          payload: {
+            data: { organization: { projectsV2: { pageInfo: { hasNextPage: false }, nodes: [orgProject] } } },
+          },
+        },
+        { payload: getFieldsResponse([orgStatusField]) },
+        {
+          payload: getItemsByContentResponse([
+            makeItemNode("PVTI_org", makeContent("Issue", 10, "myorg/repo"), "Backlog"),
+          ]),
+        },
+        { payload: updateItemFieldResponse() },
+      ];
+      const result = await main(
+        { repo: "myorg/repo", project: "1", item: "10", toColumn: "Next Up" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+    });
+  });
+
+  describe("structured error output", () => {
+    it("produces JSON error shape for CLI consumers", async () => {
+      try {
+        await main(
+          { repo: "mfittko/pi-dev-loops", project: "1", item: "42", toColumn: "Next Up" },
+          { env: {}, runChild: mockRunChild([
+            { payload: userPayload() },
+            { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+            { payload: getFieldsResponse([STATUS_FIELD]) },
+            { payload: getItemsByContentResponse([]) },
+          ]) },
+        );
+        assert.fail("should have thrown");
+      } catch (err) {
+        assert.equal(err.code, "ITEM_NOT_FOUND");
+        const json = { ok: false, error: err.message, code: err.code };
+        assert.equal(json.ok, false);
+        assert.equal(json.code, "ITEM_NOT_FOUND");
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes #628

## Summary

Add `scripts/projects/move-queue-item.mjs` — a CLI helper for moving GitHub Projects V2 items between Status columns via `updateProjectV2ItemFieldValue`.

## Changes

- **`scripts/projects/move-queue-item.mjs`**: Full implementation
  - Identify item by issue/PR number or project item node ID
  - Resolve Status field and target column option ID
  - Support all standard transitions
  - No-op when already at target column
  - Fail closed on missing project/field/column/item
  - Machine-readable JSON output
- **`test/projects/move-queue-item.test.mjs`**: 27 tests covering argument parsing, success paths, no-op, all standard transitions, error paths, API errors, and org owner resolution