### PR TITLE
feat: add GitHub Projects queue reorder helper (#630)

### DIFF
--- a/scripts/projects/reorder-queue-item.mjs
+++ b/scripts/projects/reorder-queue-item.mjs
@@ -1,0 +1,508 @@
+#!/usr/bin/env node
+import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { runChild as _runChild } from "../_cli-primitives.mjs";
+
+const USAGE = `Usage: node scripts/projects/reorder-queue-item.mjs --repo <owner/name> --project <number|id> --item <number|node-id> [--after <number|node-id>]
+
+Reorder a GitHub Projects V2 item by board position via updateProjectV2ItemPosition.
+Moves item to top when no --after is provided, or after the specified item.
+
+Options:
+  --repo <owner/name>         Required. Repository to scope the project search.
+  --project <number|id>       Required. Project number (integer) or node ID.
+  --item <number|node-id>     Required. Item to reorder: issue/PR number, or project item node ID.
+  --after <number|node-id>    Position after this item. When omitted, move to top.
+  --help, -h                  Show this help.
+
+Output (stdout):
+  JSON: { ok: true, item: { itemId, issueNumber, prNumber, position }, after: { itemId, issueNumber, prNumber } | null }
+
+Exit codes:
+  0 — success
+  1 — usage or argument error
+  2 — GitHub API error
+  3 — project, item, or after-item not found
+`.trim();
+
+const VALID_ARGS = new Set(["--repo", "--project", "--item", "--after", "--help", "-h"]);
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!VALID_ARGS.has(arg) && arg.startsWith("-")) {
+      throw Object.assign(
+        new Error(`Unknown flag: ${arg}`),
+        { code: "INVALID_ARGS", usage: USAGE },
+      );
+    }
+    if (arg === "--repo") {
+      if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
+        throw Object.assign(new Error("--repo requires a value (owner/name)"), { code: "INVALID_REPO" });
+      }
+      args.repo = argv[++i];
+    } else if (arg === "--project") {
+      if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
+        throw Object.assign(new Error("--project requires a value (number or node ID)"), { code: "INVALID_PROJECT" });
+      }
+      args.project = argv[++i];
+    } else if (arg === "--item") {
+      if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
+        throw Object.assign(new Error("--item requires a value (number or node ID)"), { code: "INVALID_ITEM" });
+      }
+      args.item = argv[++i];
+    } else if (arg === "--after") {
+      if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
+        throw Object.assign(new Error("--after requires a value (number or node ID)"), { code: "INVALID_AFTER" });
+      }
+      args.after = argv[++i];
+    } else if (arg === "--help" || arg === "-h") {
+      args.help = true;
+    } else {
+      throw Object.assign(new Error(`Unexpected argument: ${arg}`), { code: "INVALID_ARGS", usage: USAGE });
+    }
+  }
+  return args;
+}
+
+// ── Validation ───────────────────────────────────────────────────────────
+
+const OWNER_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
+const REPO_NAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9_.-]*[a-zA-Z0-9])?$/;
+const GLOBAL_NODE_ID_RE = /^[A-Za-z0-9_]+$/;
+
+function validateRepo(repo) {
+  if (!repo || typeof repo !== "string") {
+    throw Object.assign(new Error("--repo is required"), { code: "INVALID_REPO" });
+  }
+  const trimmed = repo.trim();
+  if (trimmed !== repo) {
+    throw Object.assign(
+      new Error(`--repo must not have leading/trailing whitespace, got "${repo}"`),
+      { code: "INVALID_REPO" },
+    );
+  }
+  const slashIdx = repo.indexOf("/");
+  if (slashIdx === -1) {
+    throw Object.assign(new Error(`--repo must be exactly owner/name, got "${repo}"`), { code: "INVALID_REPO" });
+  }
+  const owner = repo.slice(0, slashIdx);
+  const name = repo.slice(slashIdx + 1);
+  if (!owner || !name || !OWNER_RE.test(owner) || !REPO_NAME_RE.test(name)) {
+    throw Object.assign(new Error(`--repo must be exactly owner/name, got "${repo}"`), { code: "INVALID_REPO" });
+  }
+  return repo;
+}
+
+function parseProjectRef(raw) {
+  if (!raw || typeof raw !== "string" || raw.trim().length === 0) {
+    throw Object.assign(new Error("--project is required"), { code: "INVALID_PROJECT" });
+  }
+  const trimmed = raw.trim();
+  const asNum = Number(trimmed);
+  if (Number.isInteger(asNum) && asNum > 0 && String(asNum) === trimmed) {
+    return { kind: "number", value: asNum };
+  }
+  if (trimmed === "0") {
+    throw Object.assign(new Error(`--project must be a positive integer or a node ID, got "${raw}"`), { code: "INVALID_PROJECT" });
+  }
+  if (GLOBAL_NODE_ID_RE.test(trimmed)) {
+    return { kind: "id", value: trimmed };
+  }
+  throw Object.assign(new Error(`--project must be a positive integer or a node ID, got "${raw}"`), { code: "INVALID_PROJECT" });
+}
+
+function parseItemRef(raw) {
+  if (!raw || typeof raw !== "string" || raw.trim().length === 0) {
+    throw Object.assign(new Error("--item is required"), { code: "INVALID_ITEM" });
+  }
+  const trimmed = raw.trim();
+  const asNum = Number(trimmed);
+  if (Number.isInteger(asNum) && asNum > 0 && String(asNum) === trimmed) {
+    return { kind: "number", value: asNum };
+  }
+  if (trimmed === "0") {
+    throw Object.assign(new Error(`--item must be a positive integer or an item node ID, got "${raw}"`), { code: "INVALID_ITEM" });
+  }
+  if (GLOBAL_NODE_ID_RE.test(trimmed)) {
+    return { kind: "id", value: trimmed };
+  }
+  throw Object.assign(new Error(`--item must be a positive integer or an item node ID, got "${raw}"`), { code: "INVALID_ITEM" });
+}
+
+// ── API helpers ──────────────────────────────────────────────────────────
+
+async function ghGraphql(query, vars, env, runChild = _runChild) {
+  const fieldArgs = [];
+  for (const [key, value] of Object.entries(vars)) {
+    fieldArgs.push("--field", `${key}=${value}`);
+  }
+  const result = await runChild(
+    "gh",
+    ["api", "graphql", "--field", `query=${query}`, ...fieldArgs],
+    env,
+  );
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw Object.assign(new Error(`gh api graphql failed: ${detail}`), { code: "GH_API_ERROR" });
+  }
+  const payload = parseJsonText(result.stdout);
+  if (payload.errors && payload.errors.length > 0) {
+    throw Object.assign(
+      new Error(`GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`),
+      { code: "GRAPHQL_ERROR" },
+    );
+  }
+  return payload;
+}
+
+// ── GraphQL fragments ────────────────────────────────────────────────────
+
+const GET_USER_ID = [
+  "query($login:String!) {",
+  "  user(login:$login) { id }",
+  "}"
+].join("\n");
+
+const GET_ORG_ID = [
+  "query($login:String!) {",
+  "  organization(login:$login) { id }",
+  "}"
+].join("\n");
+
+const LIST_USER_PROJECTS = [
+  "query($login:String!, $after:String) {",
+  "  user(login:$login) {",
+  "    projectsV2(first:50, after:$after) {",
+  "      pageInfo { hasNextPage endCursor }",
+  "      nodes { id number title url }",
+  "    }",
+  "  }",
+  "}"
+].join("\n");
+
+const LIST_ORG_PROJECTS = [
+  "query($login:String!, $after:String) {",
+  "  organization(login:$login) {",
+  "    projectsV2(first:50, after:$after) {",
+  "      pageInfo { hasNextPage endCursor }",
+  "      nodes { id number title url }",
+  "    }",
+  "  }",
+  "}"
+].join("\n");
+
+const GET_PROJECT_ITEMS_BY_CONTENT = [
+  "query($projectId:ID!, $owner:String!, $repo:String!, $number:Int!, $after:String) {",
+  "  node(id:$projectId) {",
+  "    ... on ProjectV2 {",
+  "      items(first:10, after:$after, orderBy:{field:POSITION, direction:ASC}) {",
+  "        pageInfo { hasNextPage endCursor }",
+  "        nodes {",
+  "          id",
+  "          fieldValues(first:20) {",
+  "            nodes {",
+  "              ... on ProjectV2ItemFieldSingleSelectValue {",
+  "                field { ... on ProjectV2SingleSelectField { id name } }",
+  "                name",
+  "              }",
+  "            }",
+  "          }",
+  "          content {",
+  "            ... on Issue { number repository { nameWithOwner } }",
+  "            ... on PullRequest { number repository { nameWithOwner } }",
+  "          }",
+  "        }",
+  "      }",
+  "    }",
+  "  }",
+  "}"
+].join("\n");
+
+const GET_PROJECT_ITEM = [
+  "query($projectId:ID!, $itemId:ID!) {",
+  "  node(id:$projectId) {",
+  "    ... on ProjectV2 {",
+  "      item: item(id:$itemId) {",
+  "        id",
+  "        fieldValues(first:20) {",
+  "          nodes {",
+  "            ... on ProjectV2ItemFieldSingleSelectValue {",
+  "              field { ... on ProjectV2SingleSelectField { id name } }",
+  "              name",
+  "            }",
+  "          }",
+  "        }",
+  "        content {",
+  "          ... on Issue { number title url }",
+  "          ... on PullRequest { number title url }",
+  "        }",
+  "      }",
+  "    }",
+  "  }",
+  "}"
+].join("\n");
+
+const UPDATE_ITEM_POSITION = [
+  "mutation($input:UpdateProjectV2ItemPositionInput!) {",
+  "  updateProjectV2ItemPosition(input:$input) {",
+  "    clientMutationId",
+  "  }",
+  "}"
+].join("\n");
+
+// ── Owner resolution ────────────────────────────────────────────────────
+
+async function resolveOwner(login, env, runChild) {
+  const userPayload = await ghGraphql(GET_USER_ID, { login }, env, runChild);
+  if (userPayload?.data?.user?.id) {
+    return { id: userPayload.data.user.id, kind: "user" };
+  }
+  const orgPayload = await ghGraphql(GET_ORG_ID, { login }, env, runChild);
+  if (orgPayload?.data?.organization?.id) {
+    return { id: orgPayload.data.organization.id, kind: "org" };
+  }
+  throw Object.assign(
+    new Error(`Could not resolve owner ID for "${login}"`),
+    { code: "NO_USER_ID" },
+  );
+}
+
+// ── Paginated project listing ────────────────────────────────────────────
+
+async function listAllProjects(login, kind, env, runChild) {
+  const query = kind === "org" ? LIST_ORG_PROJECTS : LIST_USER_PROJECTS;
+  const projects = [];
+  let after = null;
+  while (true) {
+    const vars = { login };
+    if (after) vars.after = after;
+    const payload = await ghGraphql(query, vars, env, runChild);
+    const connection = kind === "org"
+      ? payload?.data?.organization?.projectsV2
+      : payload?.data?.user?.projectsV2;
+    const nodes = connection?.nodes ?? [];
+    projects.push(...nodes);
+    const pageInfo = connection?.pageInfo ?? {};
+    if (!pageInfo.hasNextPage) break;
+    if (!pageInfo.endCursor) {
+      throw Object.assign(
+        new Error("Invalid projects list payload: hasNextPage is true but endCursor is missing"),
+        { code: "GH_API_ERROR" },
+      );
+    }
+    after = pageInfo.endCursor;
+  }
+  return projects;
+}
+
+// ── Resolve an item in a project by reference (number or node ID) ──────
+
+async function resolveProjectItem(projectId, itemRef, owner, repoName, repo, env, runChild) {
+  let itemId;
+  let issueNumber = null;
+  let prNumber = null;
+  let status = null;
+
+  if (itemRef.kind === "id") {
+    // Direct item node ID lookup
+    const itemPayload = await ghGraphql(GET_PROJECT_ITEM, {
+      projectId,
+      itemId: itemRef.value,
+    }, env, runChild);
+    const item = itemPayload?.data?.node?.item;
+    if (!item) {
+      throw Object.assign(
+        new Error(`Item "${itemRef.value}" not found in project`),
+        { code: "ITEM_NOT_FOUND" },
+      );
+    }
+    itemId = item.id;
+    const fvs = item.fieldValues?.nodes ?? [];
+    for (const fv of fvs) {
+      if (fv && fv.field && fv.field.name === "Status") {
+        status = fv.name;
+        break;
+      }
+    }
+    if (item.content) {
+      if (item.content.__typename === "Issue") {
+        issueNumber = item.content.number;
+      } else {
+        prNumber = item.content.number;
+      }
+    }
+  } else {
+    // Look up by issue/PR number in the project
+    const itemsPayload = await ghGraphql(GET_PROJECT_ITEMS_BY_CONTENT, {
+      projectId,
+      owner,
+      repo: repoName,
+      number: itemRef.value,
+    }, env, runChild);
+    const items = itemsPayload?.data?.node?.items?.nodes ?? [];
+
+    // Filter by matching repo exactly
+    const matchingItems = items.filter((it) => {
+      if (!it.content) return false;
+      return it.content.repository?.nameWithOwner === repo;
+    });
+
+    if (matchingItems.length === 0) {
+      throw Object.assign(
+        new Error(`Item #${itemRef.value} not found in project for repo "${repo}"`),
+        { code: "ITEM_NOT_FOUND" },
+      );
+    }
+
+    // Use the first match (by position order)
+    const match = matchingItems[0];
+    itemId = match.id;
+    const fvs = match.fieldValues?.nodes ?? [];
+    for (const fv of fvs) {
+      if (fv && fv.field && fv.field.name === "Status") {
+        status = fv.name;
+        break;
+      }
+    }
+    if (match.content) {
+      if (match.content.__typename === "Issue") {
+        issueNumber = match.content.number;
+      } else {
+        prNumber = match.content.number;
+      }
+    }
+  }
+
+  return { itemId, issueNumber, prNumber, status };
+}
+
+// ── Exit code classification ────────────────────────────────────────────
+
+function classifyExitCode(err) {
+  if (err.code === "INVALID_REPO" || err.code === "INVALID_PROJECT" || err.code === "INVALID_ITEM" ||
+      err.code === "INVALID_AFTER" || err.code === "INVALID_ARGS") return 1;
+  if (err.code === "PROJECT_NOT_FOUND" || err.code === "ITEM_NOT_FOUND" || err.code === "AFTER_ITEM_NOT_FOUND") return 3;
+  return 2;
+}
+
+// ── Main logic ──────────────────────────────────────────────────────────
+
+async function main(args, { env = process.env, runChild } = {}) {
+  const child = runChild ?? _runChild;
+  const repo = validateRepo(args.repo);
+  const [owner, repoName] = repo.split("/");
+  const projectRef = parseProjectRef(args.project);
+  const itemRef = parseItemRef(args.item);
+
+  // --after is optional
+  let afterRef = null;
+  if (args.after !== undefined) {
+    afterRef = parseItemRef(args.after);
+  }
+
+  // 1. Resolve owner
+  const { id: ownerId, kind: ownerKind } = await resolveOwner(owner, env, child);
+
+  // 2. Resolve project
+  const projects = await listAllProjects(owner, ownerKind, env, child);
+  let project;
+  if (projectRef.kind === "id") {
+    project = projects.find((p) => p.id === projectRef.value);
+  } else {
+    project = projects.find((p) => p.number === projectRef.value);
+  }
+  if (!project) {
+    throw Object.assign(
+      new Error(`Project ${projectRef.kind === "id" ? `"${projectRef.value}"` : `number ${projectRef.value}`} not found under owner "${owner}"`),
+      { code: "PROJECT_NOT_FOUND" },
+    );
+  }
+
+  // 3. Resolve the item to move
+  const item = await resolveProjectItem(project.id, itemRef, owner, repoName, repo, env, child);
+
+  // 4. Resolve the after-item (if provided)
+  let afterItem = null;
+  if (afterRef) {
+    afterItem = await resolveProjectItem(project.id, afterRef, owner, repoName, repo, env, child);
+
+    // Fail closed: cannot reorder after itself
+    if (afterItem.itemId === item.itemId) {
+      throw Object.assign(
+        new Error("Cannot reorder an item after itself"),
+        { code: "INVALID_AFTER" },
+      );
+    }
+  }
+
+  // 5. Execute reorder mutation
+  const mutationInput = {
+    projectId: project.id,
+    itemId: item.itemId,
+  };
+  if (afterItem) {
+    mutationInput.afterId = afterItem.itemId;
+  }
+
+  const mutationPayload = await ghGraphql(UPDATE_ITEM_POSITION, {
+    input: JSON.stringify(mutationInput),
+  }, env, child);
+
+  if (!mutationPayload?.data?.updateProjectV2ItemPosition) {
+    throw Object.assign(new Error("Failed to reorder item"), { code: "MUTATION_FAILED" });
+  }
+
+  const result = {
+    ok: true,
+    item: {
+      itemId: item.itemId,
+      issueNumber: item.issueNumber,
+      prNumber: item.prNumber,
+      status: item.status,
+      position: afterItem ? "after" : "top",
+    },
+    after: afterItem
+      ? {
+          itemId: afterItem.itemId,
+          issueNumber: afterItem.issueNumber,
+          prNumber: afterItem.prNumber,
+        }
+      : null,
+  };
+
+  return result;
+}
+
+// ── CLI entrypoint ──────────────────────────────────────────────────────
+
+async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, env = process.env } = {}) {
+  let args;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    stderr.write(`${formatCliError(err)}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  if (args.help) {
+    stdout.write(USAGE);
+    return;
+  }
+  try {
+    const result = await main(args, { env });
+    stdout.write(JSON.stringify(result) + "\n");
+  } catch (err) {
+    stderr.write(JSON.stringify({ ok: false, error: err.message, code: err.code ?? "UNKNOWN" }) + "\n");
+    process.exitCode = classifyExitCode(err);
+  }
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(JSON.stringify({ ok: false, error: error.message, code: error.code ?? "UNKNOWN" }) + "\n");
+    process.exitCode = 2;
+  });
+}
+
+export { main };

--- a/scripts/projects/reorder-queue-item.mjs
+++ b/scripts/projects/reorder-queue-item.mjs
@@ -193,7 +193,7 @@ const LIST_ORG_PROJECTS = [
 ].join("\n");
 
 const GET_PROJECT_ITEMS_BY_CONTENT = [
-  "query($projectId:ID!, $owner:String!, $repo:String!, $number:Int!, $after:String) {",
+  "query($projectId:ID!, $after:String) {",
   "  node(id:$projectId) {",
   "    ... on ProjectV2 {",
   "      items(first:10, after:$after, orderBy:{field:POSITION, direction:ASC}) {",
@@ -209,8 +209,8 @@ const GET_PROJECT_ITEMS_BY_CONTENT = [
   "            }",
   "          }",
   "          content {",
-  "            ... on Issue { number repository { nameWithOwner } }",
-  "            ... on PullRequest { number repository { nameWithOwner } }",
+  "            ... on Issue { __typename number repository { nameWithOwner } }",
+  "            ... on PullRequest { __typename number repository { nameWithOwner } }",
   "          }",
   "        }",
   "      }",
@@ -234,8 +234,8 @@ const GET_PROJECT_ITEM = [
   "          }",
   "        }",
   "        content {",
-  "          ... on Issue { number title url }",
-  "          ... on PullRequest { number title url }",
+  "          ... on Issue { __typename number title url }",
+  "          ... on PullRequest { __typename number title url }",
   "        }",
   "      }",
   "    }",
@@ -338,7 +338,7 @@ async function resolveProjectItem(projectId, itemRef, owner, repoName, repo, env
     let allItems = [];
     let after = null;
     while (true) {
-      const vars = { projectId, owner, repo: repoName, number: targetNumber };
+      const vars = { projectId };
       if (after) vars.after = after;
       const itemsPayload = await ghGraphql(GET_PROJECT_ITEMS_BY_CONTENT, vars, env, runChild);
       const connection = itemsPayload?.data?.node?.items;

--- a/scripts/projects/reorder-queue-item.mjs
+++ b/scripts/projects/reorder-queue-item.mjs
@@ -15,7 +15,7 @@ Options:
   --help, -h                  Show this help.
 
 Output (stdout):
-  JSON: { ok: true, item: { itemId, issueNumber, prNumber, position }, after: { itemId, issueNumber, prNumber } | null }
+  JSON: { ok: true, item: { itemId, issueNumber, prNumber, status, position }, after: { itemId, issueNumber, prNumber } | null }
 
 Exit codes:
   0 — success
@@ -333,24 +333,38 @@ async function resolveProjectItem(projectId, itemRef, owner, repoName, repo, env
       }
     }
   } else {
-    // Look up by issue/PR number in the project
-    const itemsPayload = await ghGraphql(GET_PROJECT_ITEMS_BY_CONTENT, {
-      projectId,
-      owner,
-      repo: repoName,
-      number: itemRef.value,
-    }, env, runChild);
-    const items = itemsPayload?.data?.node?.items?.nodes ?? [];
+    // Look up by issue/PR number in the project (paginated)
+    const targetNumber = itemRef.value;
+    let allItems = [];
+    let after = null;
+    while (true) {
+      const vars = { projectId, owner, repo: repoName, number: targetNumber };
+      if (after) vars.after = after;
+      const itemsPayload = await ghGraphql(GET_PROJECT_ITEMS_BY_CONTENT, vars, env, runChild);
+      const connection = itemsPayload?.data?.node?.items;
+      const nodes = connection?.nodes ?? [];
+      allItems.push(...nodes);
+      const pageInfo = connection?.pageInfo ?? {};
+      if (!pageInfo.hasNextPage) break;
+      if (!pageInfo.endCursor) {
+        throw Object.assign(
+          new Error("Invalid items payload: hasNextPage is true but endCursor is missing"),
+          { code: "GH_API_ERROR" },
+        );
+      }
+      after = pageInfo.endCursor;
+    }
 
-    // Filter by matching repo exactly
-    const matchingItems = items.filter((it) => {
+    // Filter by matching repo AND number exactly
+    const matchingItems = allItems.filter((it) => {
       if (!it.content) return false;
-      return it.content.repository?.nameWithOwner === repo;
+      if (it.content.repository?.nameWithOwner !== repo) return false;
+      return it.content.number === targetNumber;
     });
 
     if (matchingItems.length === 0) {
       throw Object.assign(
-        new Error(`Item #${itemRef.value} not found in project for repo "${repo}"`),
+        new Error(`Item #${targetNumber} not found in project for repo "${repo}"`),
         { code: "ITEM_NOT_FOUND" },
       );
     }

--- a/test/projects/reorder-queue-item.test.mjs
+++ b/test/projects/reorder-queue-item.test.mjs
@@ -1,0 +1,377 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { main } from "../../scripts/projects/reorder-queue-item.mjs";
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function mockRunChild(responses) {
+  let callIndex = 0;
+  return async (_cmd, args, _env) => {
+    if (callIndex >= responses.length) {
+      throw new Error("Unexpected gh call #" + (callIndex + 1) + " (only " + responses.length + " mocked)");
+    }
+    const resp = responses[callIndex++];
+    if (resp.error) {
+      return { code: 1, stdout: "", stderr: resp.error };
+    }
+    return { code: 0, stdout: JSON.stringify(resp.payload), stderr: "" };
+  };
+}
+
+function extractGraphqlInput(args) {
+  // gh sends: ["api", "graphql", "--field", "query=...", "--field", "input=..."]
+  for (const arg of args) {
+    if (typeof arg === "string" && arg.startsWith("input=")) {
+      return JSON.parse(arg.slice("input=".length));
+    }
+  }
+  return null;
+}
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+
+function userPayload() {
+  return { data: { user: { id: "U_kgDOABC123" } } };
+}
+
+function listUserProjectsResponse(projects) {
+  return {
+    data: {
+      user: {
+        projectsV2: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: projects,
+        },
+      },
+    },
+  };
+}
+
+const EXISTING_PROJECT = {
+  id: "PVT_proj1",
+  number: 1,
+  title: "Dev Loop Queue",
+  url: "https://github.com/users/mfittko/projects/1",
+};
+
+function getItemsByContentResponse(items) {
+  return {
+    data: {
+      node: {
+        items: {
+          nodes: items,
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+    },
+  };
+}
+
+function emptyItemsResponse() {
+  return getItemsByContentResponse([]);
+}
+
+function getProjectItemResponse(itemId, itemContent) {
+  return {
+    data: {
+      node: {
+        item: {
+          id: itemId,
+          fieldValues: {
+            nodes: [
+              {
+                field: { id: "PVTSSF_status", name: "Status" },
+                name: "Backlog",
+              },
+            ],
+          },
+          content: itemContent ?? {
+            __typename: "Issue",
+            number: 630,
+            title: "Test Issue",
+            url: "https://github.com/mfittko/pi-dev-loops/issues/630",
+          },
+        },
+      },
+    },
+  };
+}
+
+function updatePositionResponse() {
+  return {
+    data: {
+      updateProjectV2ItemPosition: {
+        clientMutationId: null,
+      },
+    },
+  };
+}
+
+function makeItemContent(ref, typename, repo) {
+  return {
+    __typename: typename || "Issue",
+    number: ref,
+    repository: { nameWithOwner: repo || "mfittko/pi-dev-loops" },
+  };
+}
+
+function makeItemNode(itemId, ref, typename) {
+  return {
+    id: itemId,
+    fieldValues: {
+      nodes: [
+        {
+          field: { id: "PVTSSF_status", name: "Status" },
+          name: "Backlog",
+        },
+      ],
+    },
+    content: makeItemContent(ref, typename),
+  };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe("reorder-queue-item — move to top (no --after)", () => {
+  it("moves an item to top by issue number", async () => {
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      { payload: getItemsByContentResponse([makeItemNode("PVTI_item_1", 630)]) },
+      { payload: updatePositionResponse() },
+    ];
+    const runChild = mockRunChild(responses);
+
+    // Intercept the mutation call to check input
+    const orig = runChild;
+    let capturedInput = null;
+    const wrapped = async (cmd, args, env) => {
+      const result = await orig(cmd, args, env);
+      // The mutation is the 4th call (index 3 in responses)
+      // extract input from gh args
+      const input = extractGraphqlInput(args);
+      if (input !== null) capturedInput = input;
+      return result;
+    };
+
+    const result = await main(
+      { repo: "mfittko/pi-dev-loops", project: "1", item: "630" },
+      { runChild: wrapped },
+    );
+
+    assert.ok(result.ok);
+    assert.strictEqual(result.item.itemId, "PVTI_item_1");
+    assert.strictEqual(result.item.issueNumber, 630);
+    assert.strictEqual(result.item.position, "top");
+    assert.strictEqual(result.after, null);
+    assert.ok(capturedInput !== null, "Should have captured mutation input");
+    assert.strictEqual(capturedInput.projectId, "PVT_proj1");
+    assert.strictEqual(capturedInput.itemId, "PVTI_item_1");
+    assert.strictEqual("afterId" in capturedInput, false);
+  });
+
+  it("moves an item to top by item node ID", async () => {
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      {
+        payload: getProjectItemResponse("PVTI_item_x", {
+          __typename: "PullRequest",
+          number: 88,
+          title: "PR",
+          url: "...",
+        }),
+      },
+      { payload: updatePositionResponse() },
+    ];
+    const runChild = mockRunChild(responses);
+
+    let capturedInput = null;
+    const wrapped = async (cmd, args, env) => {
+      const result = await runChild(cmd, args, env);
+      const input = extractGraphqlInput(args);
+      if (input !== null) capturedInput = input;
+      return result;
+    };
+
+    const result = await main(
+      { repo: "mfittko/pi-dev-loops", project: "1", item: "PVTI_item_x" },
+      { runChild: wrapped },
+    );
+
+    assert.ok(result.ok);
+    assert.strictEqual(result.item.itemId, "PVTI_item_x");
+    assert.strictEqual(result.item.prNumber, 88);
+    assert.strictEqual(result.item.position, "top");
+    assert.strictEqual(result.after, null);
+    assert.ok(capturedInput !== null);
+    assert.strictEqual(capturedInput.afterId, undefined);
+  });
+});
+
+describe("reorder-queue-item — move after another item", () => {
+  it("moves an item after another by issue numbers", async () => {
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      { payload: getItemsByContentResponse([makeItemNode("PVTI_item_630", 630)]) },
+      { payload: getItemsByContentResponse([makeItemNode("PVTI_item_625", 625)]) },
+      { payload: updatePositionResponse() },
+    ];
+    const runChild = mockRunChild(responses);
+
+    let capturedInput = null;
+    const wrapped = async (cmd, args, env) => {
+      const result = await runChild(cmd, args, env);
+      const input = extractGraphqlInput(args);
+      if (input !== null) capturedInput = input;
+      return result;
+    };
+
+    const result = await main(
+      { repo: "mfittko/pi-dev-loops", project: "1", item: "630", after: "625" },
+      { runChild: wrapped },
+    );
+
+    assert.ok(result.ok);
+    assert.strictEqual(result.item.position, "after");
+    assert.strictEqual(result.after.itemId, "PVTI_item_625");
+    assert.strictEqual(result.after.issueNumber, 625);
+    assert.ok(capturedInput !== null);
+    assert.strictEqual(capturedInput.projectId, "PVT_proj1");
+    assert.strictEqual(capturedInput.itemId, "PVTI_item_630");
+    assert.strictEqual(capturedInput.afterId, "PVTI_item_625");
+  });
+
+  it("fails closed when after item is not found", async () => {
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      { payload: getItemsByContentResponse([makeItemNode("PVTI_item_630", 630)]) },
+      { payload: emptyItemsResponse() },
+    ];
+    const runChild = mockRunChild(responses);
+
+    await assert.rejects(
+      () => main(
+        { repo: "mfittko/pi-dev-loops", project: "1", item: "630", after: "999" },
+        { runChild },
+      ),
+      (err) => err.code === "ITEM_NOT_FOUND",
+    );
+  });
+
+  it("fails closed when item is same as after item", async () => {
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      { payload: getItemsByContentResponse([makeItemNode("PVTI_item_630", 630)]) },
+      { payload: getItemsByContentResponse([makeItemNode("PVTI_item_630", 630)]) },
+    ];
+    const runChild = mockRunChild(responses);
+
+    await assert.rejects(
+      () => main(
+        { repo: "mfittko/pi-dev-loops", project: "1", item: "630", after: "630" },
+        { runChild },
+      ),
+      (err) => err.message.includes("itself"),
+    );
+  });
+});
+
+describe("reorder-queue-item — error handling", () => {
+  it("fails closed when item is not found", async () => {
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      { payload: emptyItemsResponse() },
+    ];
+    const runChild = mockRunChild(responses);
+
+    await assert.rejects(
+      () => main(
+        { repo: "mfittko/pi-dev-loops", project: "1", item: "999" },
+        { runChild },
+      ),
+      (err) => err.code === "ITEM_NOT_FOUND",
+    );
+  });
+
+  it("fails closed when project is not found", async () => {
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([]) },
+    ];
+    const runChild = mockRunChild(responses);
+
+    await assert.rejects(
+      () => main(
+        { repo: "mfittko/pi-dev-loops", project: "99", item: "630" },
+        { runChild },
+      ),
+      (err) => err.code === "PROJECT_NOT_FOUND",
+    );
+  });
+});
+
+describe("reorder-queue-item — mutation input construction", () => {
+  it("constructs top-position mutation input correctly", async () => {
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      { payload: getItemsByContentResponse([makeItemNode("PVTI_item_1", 630)]) },
+      { payload: updatePositionResponse() },
+    ];
+    const runChild = mockRunChild(responses);
+
+    let capturedInput = null;
+    const wrapped = async (cmd, args, env) => {
+      const result = await runChild(cmd, args, env);
+      const input = extractGraphqlInput(args);
+      if (input !== null) capturedInput = input;
+      return result;
+    };
+
+    await main(
+      { repo: "mfittko/pi-dev-loops", project: "1", item: "630" },
+      { runChild: wrapped },
+    );
+
+    assert.deepStrictEqual(capturedInput, {
+      projectId: "PVT_proj1",
+      itemId: "PVTI_item_1",
+    });
+    assert.strictEqual("afterId" in capturedInput, false);
+  });
+
+  it("constructs after-item mutation input correctly", async () => {
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      { payload: getItemsByContentResponse([makeItemNode("PVTI_item_630", 630)]) },
+      { payload: getProjectItemResponse("PVTI_item_625", makeItemContent(625)) },
+      { payload: updatePositionResponse() },
+    ];
+    const runChild = mockRunChild(responses);
+
+    let capturedInput = null;
+    const wrapped = async (cmd, args, env) => {
+      const result = await runChild(cmd, args, env);
+      const input = extractGraphqlInput(args);
+      if (input !== null) capturedInput = input;
+      return result;
+    };
+
+    await main(
+      { repo: "mfittko/pi-dev-loops", project: "1", item: "630", after: "PVTI_item_625" },
+      { runChild: wrapped },
+    );
+
+    assert.deepStrictEqual(capturedInput, {
+      projectId: "PVT_proj1",
+      itemId: "PVTI_item_630",
+      afterId: "PVTI_item_625",
+    });
+  });
+});


### PR DESCRIPTION
Closes #630

Implements `scripts/projects/reorder-queue-item.mjs` using `updateProjectV2ItemPosition` GraphQL mutation.

- Move items to top when no `--after` is provided
- Move items after another item via `--after` (issue/PR number or node ID)
- Emit structured JSON result
- Fail closed when either item cannot be resolved
- Includes `--help` and machine-readable JSON output
- Tests cover top and after-item mutation input construction