### PR TITLE
fix: restructure Projects GraphQL queries to use scalar variables

### DIFF
--- a/scripts/projects/add-queue-item.mjs
+++ b/scripts/projects/add-queue-item.mjs
@@ -129,7 +129,7 @@ function parseProjectRef(raw) {
 
 // ── API helpers ──────────────────────────────────────────────────────────
 
-async function ghGraphql(query, vars, env, runChild = _runChild) {
+async function ghGraphql(query, vars, env, runChild = _runChild, { allowErrors = false } = {}) {
   const fieldArgs = [];
   for (const [key, value] of Object.entries(vars)) {
     fieldArgs.push("--field", `${key}=${value}`);
@@ -144,7 +144,7 @@ async function ghGraphql(query, vars, env, runChild = _runChild) {
     throw Object.assign(new Error(`gh api graphql failed: ${detail}`), { code: "GH_API_ERROR" });
   }
   const payload = parseJsonText(result.stdout);
-  if (payload.errors && payload.errors.length > 0) {
+  if (!allowErrors && payload.errors && payload.errors.length > 0) {
     throw Object.assign(
       new Error(`GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`),
       { code: "GRAPHQL_ERROR" },
@@ -208,30 +208,20 @@ const GET_PROJECT_FIELDS = [
 ].join("\n");
 
 // Resolve an issue or PR's GraphQL node ID by number
-const RESOLVE_ISSUE_NODE_ID = [
+const RESOLVE_CONTENT_NODE_ID = [
   "query($owner:String!, $repo:String!, $number:Int!) {",
   "  repository(owner:$owner, name:$repo) {",
-  "    issue: issue(number:$number) {",
-  "      id",
-  "      number",
-  "      title",
-  "      url",
-  "      __typename",
-  "    }",
-  "    pr: pullRequest(number:$number) {",
-  "      id",
-  "      number",
-  "      title",
-  "      url",
-  "      __typename",
+  "    issueOrPullRequest(number:$number) {",
+  "      ... on Issue { id __typename }",
+  "      ... on PullRequest { id __typename }",
   "    }",
   "  }",
   "}"
 ].join("\n");
 
 const ADD_PROJECT_ITEM = [
-  "mutation($input:AddProjectV2ItemByIdInput!) {",
-  "  addProjectV2ItemById(input:$input) {",
+  "mutation($projectId:ID!, $contentId:ID!) {",
+  "  addProjectV2ItemById(input:{projectId:$projectId, contentId:$contentId}) {",
   "    item {",
   "      id",
   "    }",
@@ -240,8 +230,8 @@ const ADD_PROJECT_ITEM = [
 ].join("\n");
 
 const UPDATE_ITEM_FIELD = [
-  "mutation($input:UpdateProjectV2ItemFieldValueInput!) {",
-  "  updateProjectV2ItemFieldValue(input:$input) {",
+  "mutation($projectId:ID!, $itemId:ID!, $fieldId:ID!, $optionId:String!) {",
+  "  updateProjectV2ItemFieldValue(input:{projectId:$projectId, itemId:$itemId, fieldId:$fieldId, value:{singleSelectOptionId:$optionId}}) {",
   "    projectV2Item {",
   "      id",
   "    }",
@@ -251,7 +241,7 @@ const UPDATE_ITEM_FIELD = [
 
 // Check if an item already exists in the project by content ID
 const GET_PROJECT_ITEMS_BY_CONTENT = [
-  "query($projectId:ID!, $owner:String!, $repo:String!, $number:Int!, $after:String) {",
+  "query($projectId:ID!, $after:String) {",
   "  node(id:$projectId) {",
   "    ... on ProjectV2 {",
   "      items(first:10, after:$after, orderBy:{field:POSITION, direction:ASC}) {",
@@ -413,9 +403,6 @@ async function main(args, { env = process.env, runChild } = {}) {
   // 4. Check if item already exists in the project
   const existingItemsPayload = await ghGraphql(GET_PROJECT_ITEMS_BY_CONTENT, {
     projectId: project.id,
-    owner,
-    repo: repoName,
-    number: itemNumber,
   }, env, child);
   const existingItems = existingItemsPayload?.data?.node?.items?.nodes ?? [];
 
@@ -453,44 +440,28 @@ async function main(args, { env = process.env, runChild } = {}) {
   }
 
   // 5. Resolve content node ID (issue or PR)
-  const contentPayload = await ghGraphql(RESOLVE_ISSUE_NODE_ID, {
+  const contentPayload = await ghGraphql(RESOLVE_CONTENT_NODE_ID, {
     owner,
     repo: repoName,
     number: itemNumber,
-  }, env, child);
+  }, env, child, { allowErrors: true });
   const repoData = contentPayload?.data?.repository;
-  if (!repoData) {
+  const fullResult = repoData?.issueOrPullRequest;
+  if (!fullResult) {
     throw Object.assign(
-      new Error(`Repository "${repo}" not found`),
+      new Error(`Issue or PR #${itemNumber} not found in "${repo}"`),
       { code: "CONTENT_NOT_FOUND" },
     );
   }
 
-  const issue = repoData.issue;
-  const pr = repoData.pr;
-  let contentId;
-  let issueNumber = null;
-  let prNumber = null;
-
-  if (issue) {
-    contentId = issue.id;
-    issueNumber = issue.number;
-  } else if (pr) {
-    contentId = pr.id;
-    prNumber = pr.number;
-  } else {
-    throw Object.assign(
-      new Error(`Issue or PR #${itemNumber} not found in repository "${repo}"`),
-      { code: "CONTENT_NOT_FOUND" },
-    );
-  }
+  let contentId = fullResult.id;
+  let issueNumber = fullResult.__typename === "Issue" ? itemNumber : null;
+  let prNumber = fullResult.__typename === "PullRequest" ? itemNumber : null;
 
   // 6. Add item to project
   const addPayload = await ghGraphql(ADD_PROJECT_ITEM, {
-    input: JSON.stringify({
-      projectId: project.id,
-      contentId,
-    }),
+    projectId: project.id,
+    contentId,
   }, env, child);
 
   const newItem = addPayload?.data?.addProjectV2ItemById?.item;
@@ -500,12 +471,10 @@ async function main(args, { env = process.env, runChild } = {}) {
 
   // 7. Set initial Status
   const updatePayload = await ghGraphql(UPDATE_ITEM_FIELD, {
-    input: JSON.stringify({
-      projectId: project.id,
-      itemId: newItem.id,
-      fieldId: statusField.id,
-      value: { singleSelectOptionId: targetOption.id },
-    }),
+    projectId: project.id,
+    itemId: newItem.id,
+    fieldId: statusField.id,
+    optionId: targetOption.id,
   }, env, child);
 
   const updated = updatePayload?.data?.updateProjectV2ItemFieldValue?.projectV2Item;

--- a/scripts/projects/ensure-queue-board.mjs
+++ b/scripts/projects/ensure-queue-board.mjs
@@ -191,8 +191,8 @@ const LIST_ORG_PROJECTS = [
 ].join("\n");
 
 const CREATE_PROJECT = [
-  "mutation($input:CreateProjectV2Input!) {",
-  "  createProjectV2(input:$input) {",
+  "mutation($ownerId:ID!, $title:String!) {",
+  "  createProjectV2(input:{ownerId:$ownerId, title:$title}) {",
   "    projectV2 {",
   "      id",
   "      number",
@@ -229,8 +229,13 @@ const GET_PROJECT_FIELDS = [
 ].join("\n");
 
 const CREATE_SINGLE_SELECT_FIELD = [
-  "mutation($input:CreateProjectV2FieldInput!) {",
-  "  createProjectV2Field(input:$input) {",
+  "mutation($projectId:ID!) {",
+  "  createProjectV2Field(input:{projectId:$projectId, dataType:SINGLE_SELECT, name:\"Status\", singleSelectOptions:[",
+  "    {name:\"Backlog\",color:GRAY,description:\"\"},",
+  "    {name:\"Next Up\",color:BLUE,description:\"\"},",
+  "    {name:\"In Progress\",color:YELLOW,description:\"\"},",
+  "    {name:\"Done\",color:GREEN,description:\"\"}",
+  "  ]}) {",
   "    projectV2Field {",
   "      ... on ProjectV2SingleSelectField {",
   "        id",
@@ -372,17 +377,7 @@ async function main(args, { env = process.env, runChild } = {}) {
 
     // No Status field — create it
     const createFieldPayload = await ghGraphql(CREATE_SINGLE_SELECT_FIELD, {
-      input: JSON.stringify({
-        projectId: project.id,
-        dataType: "SINGLE_SELECT",
-        name: "Status",
-        singleSelectOptions: [
-          { name: "Backlog", color: "GRAY" },
-          { name: "Next Up", color: "BLUE" },
-          { name: "In Progress", color: "YELLOW" },
-          { name: "Done", color: "GREEN" },
-        ],
-      }),
+      projectId: project.id,
     }, env, child);
     const newField = createFieldPayload?.data?.createProjectV2Field?.projectV2Field;
     if (!newField) {
@@ -402,7 +397,8 @@ async function main(args, { env = process.env, runChild } = {}) {
 
   // 3. Create project
   const createPayload = await ghGraphql(CREATE_PROJECT, {
-    input: JSON.stringify({ ownerId, title }),
+    ownerId,
+    title,
   }, env, child);
   project = createPayload?.data?.createProjectV2?.projectV2;
   if (!project) {
@@ -411,17 +407,7 @@ async function main(args, { env = process.env, runChild } = {}) {
 
   // 4. Create Status field on new project
   const createFieldPayload = await ghGraphql(CREATE_SINGLE_SELECT_FIELD, {
-    input: JSON.stringify({
-      projectId: project.id,
-      dataType: "SINGLE_SELECT",
-      name: "Status",
-      singleSelectOptions: [
-        { name: "Backlog", color: "GRAY" },
-        { name: "Next Up", color: "BLUE" },
-        { name: "In Progress", color: "YELLOW" },
-        { name: "Done", color: "GREEN" },
-      ],
-    }),
+    projectId: project.id,
   }, env, child);
   const newField = createFieldPayload?.data?.createProjectV2Field?.projectV2Field;
   if (!newField) {

--- a/scripts/projects/move-queue-item.mjs
+++ b/scripts/projects/move-queue-item.mjs
@@ -207,7 +207,7 @@ const GET_PROJECT_FIELDS = [
 ].join("\n");
 
 const GET_PROJECT_ITEMS_BY_CONTENT = [
-  "query($projectId:ID!, $owner:String!, $repo:String!, $number:Int!, $after:String) {",
+  "query($projectId:ID!, $after:String) {",
   "  node(id:$projectId) {",
   "    ... on ProjectV2 {",
   "      items(first:10, after:$after, orderBy:{field:POSITION, direction:ASC}) {",
@@ -258,8 +258,8 @@ const GET_PROJECT_ITEM = [
 ].join("\n");
 
 const UPDATE_ITEM_FIELD = [
-  "mutation($input:UpdateProjectV2ItemFieldValueInput!) {",
-  "  updateProjectV2ItemFieldValue(input:$input) {",
+  "mutation($projectId:ID!, $itemId:ID!, $fieldId:ID!, $optionId:String!) {",
+  "  updateProjectV2ItemFieldValue(input:{projectId:$projectId, itemId:$itemId, fieldId:$fieldId, value:{singleSelectOptionId:$optionId}}) {",
   "    projectV2Item {",
   "      id",
   "    }",
@@ -435,9 +435,6 @@ async function main(args, { env = process.env, runChild } = {}) {
     // Look up by issue/PR number in the project
     const itemsPayload = await ghGraphql(GET_PROJECT_ITEMS_BY_CONTENT, {
       projectId: project.id,
-      owner,
-      repo: repoName,
-      number: itemRef.value,
     }, env, child);
     const items = itemsPayload?.data?.node?.items?.nodes ?? [];
 
@@ -490,12 +487,10 @@ async function main(args, { env = process.env, runChild } = {}) {
 
   // 6. Update Status via mutation
   const updatePayload = await ghGraphql(UPDATE_ITEM_FIELD, {
-    input: JSON.stringify({
-      projectId: project.id,
-      itemId,
-      fieldId: statusField.id,
-      value: { singleSelectOptionId: targetOption.id },
-    }),
+    projectId: project.id,
+    itemId,
+    fieldId: statusField.id,
+    optionId: targetOption.id,
   }, env, child);
 
   const updated = updatePayload?.data?.updateProjectV2ItemFieldValue?.projectV2Item;

--- a/scripts/projects/reorder-queue-item.mjs
+++ b/scripts/projects/reorder-queue-item.mjs
@@ -244,8 +244,8 @@ const GET_PROJECT_ITEM = [
 ].join("\n");
 
 const UPDATE_ITEM_POSITION = [
-  "mutation($input:UpdateProjectV2ItemPositionInput!) {",
-  "  updateProjectV2ItemPosition(input:$input) {",
+  "mutation($projectId:ID!, $itemId:ID!, $afterId:ID) {",
+  "  updateProjectV2ItemPosition(input:{projectId:$projectId, itemId:$itemId, afterId:$afterId}) {",
   "    clientMutationId",
   "  }",
   "}"
@@ -451,17 +451,13 @@ async function main(args, { env = process.env, runChild } = {}) {
   }
 
   // 5. Execute reorder mutation
-  const mutationInput = {
+  const mutationVars = {
     projectId: project.id,
     itemId: item.itemId,
+    afterId: afterItem ? afterItem.itemId : null,
   };
-  if (afterItem) {
-    mutationInput.afterId = afterItem.itemId;
-  }
 
-  const mutationPayload = await ghGraphql(UPDATE_ITEM_POSITION, {
-    input: JSON.stringify(mutationInput),
-  }, env, child);
+  const mutationPayload = await ghGraphql(UPDATE_ITEM_POSITION, mutationVars, env, child);
 
   if (!mutationPayload?.data?.updateProjectV2ItemPosition) {
     throw Object.assign(new Error("Failed to reorder item"), { code: "MUTATION_FAILED" });

--- a/test/projects/add-queue-item.test.mjs
+++ b/test/projects/add-queue-item.test.mjs
@@ -78,14 +78,10 @@ function resolveIssueResponse(issueId) {
   return {
     data: {
       repository: {
-        issue: {
+        issueOrPullRequest: {
           id: issueId,
-          number: 10,
-          title: "Test Issue",
-          url: "https://github.com/mfittko/pi-dev-loops/issues/10",
           __typename: "Issue",
         },
-        pr: null,
       },
     },
   };
@@ -95,12 +91,8 @@ function resolvePrResponse(prId) {
   return {
     data: {
       repository: {
-        issue: null,
-        pr: {
+        issueOrPullRequest: {
           id: prId,
-          number: 20,
-          title: "Test PR",
-          url: "https://github.com/mfittko/pi-dev-loops/pull/20",
           __typename: "PullRequest",
         },
       },
@@ -112,19 +104,9 @@ function resolveBothResponse() {
   return {
     data: {
       repository: {
-        issue: {
+        issueOrPullRequest: {
           id: "I_kwDO_10",
-          number: 10,
-          title: "Test Issue",
-          url: "https://github.com/mfittko/pi-dev-loops/issues/10",
           __typename: "Issue",
-        },
-        pr: {
-          id: "PR_kwDO_10",
-          number: 10,
-          title: "Test PR",
-          url: "https://github.com/mfittko/pi-dev-loops/pull/10",
-          __typename: "PullRequest",
         },
       },
     },

--- a/test/projects/reorder-queue-item.test.mjs
+++ b/test/projects/reorder-queue-item.test.mjs
@@ -19,13 +19,21 @@ function mockRunChild(responses) {
 }
 
 function extractGraphqlInput(args) {
-  // gh sends: ["api", "graphql", "--field", "query=...", "--field", "input=..."]
+  // gh sends: ["api", "graphql", "--raw-field", "query=...", "--raw-field", "projectId=...", ...]
+  const vars = {};
   for (const arg of args) {
-    if (typeof arg === "string" && arg.startsWith("input=")) {
-      return JSON.parse(arg.slice("input=".length));
+    if (typeof arg === "string") {
+      const eq = arg.indexOf("=");
+      if (eq > 0 && !arg.startsWith("query=")) {
+        const key = arg.slice(0, eq);
+        const value = arg.slice(eq + 1);
+        if (value !== "null" && value !== "undefined") {
+          vars[key] = value;
+        }
+      }
     }
   }
-  return null;
+  return Object.keys(vars).length > 0 ? vars : null;
 }
 
 // ── Fixtures ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes `gh api graphql` complex input object limitation across all Projects queue helpers.

`gh api graphql --field` cannot pass complex input objects (`CreateProjectV2Input`, `UpdateProjectV2ItemFieldValueInput`, etc.) — `gh` treats them as strings instead of typed objects. All mutation queries restructured to use individual scalar variables.

**Changes (5 files):**
- `ensure-queue-board.mjs`: CREATE_PROJECT uses ``/``; field creation hardcodes standard columns
- `add-queue-item.mjs`: mutations use scalar vars; `issueOrPullRequest` unified resolver avoids null-field errors; removed unused vars from items query
- `move-queue-item.mjs`: mutation uses ``/``/``/``; removed unused vars
- `reorder-queue-item.mjs`: mutation uses ``/``/``
- `test/projects/add-queue-item.test.mjs`: fixtures updated for new response shapes
- `test/projects/reorder-queue-item.test.mjs`: extractGraphqlInput handles individual vars

**Test results:** 101/101 pass. Smoke-tested with live board #2 (add, move, list).
Closes #648