### PR TITLE
feat: suppress Copilot review request for internal-only PRs (#649)

### DIFF
--- a/packages/core/src/loop/copilot-loop-state.mjs
+++ b/packages/core/src/loop/copilot-loop-state.mjs
@@ -59,6 +59,8 @@ export const STATE = Object.freeze({
   ROUND_CAP_REACHED: "round_cap_reached",
   /** Round cap reached with clean threads and green CI; eligible for pre_approval_gate fallback. */
   ROUND_CAP_CLEAN_FALLBACK: "round_cap_clean_fallback",
+  /** Internal tooling only PR; Copilot external review skipped, proceed directly to pre_approval_gate. */
+  INTERNAL_TOOLING_DIRECT_GATE: "internal_tooling_direct_gate",
 });
 
 /** Stable high-level loop dispositions for completion vs follow-up decisions. */
@@ -69,6 +71,8 @@ export const DISPOSITION = Object.freeze({
   BLOCKED: "blocked",
   ACTION_REQUIRED: "action_required",
   DONE: "done",
+  /** Internal tooling only: Copilot skipped, ready for pre_approval_gate. */
+  DIRECT_GATE: "direct_gate",
 });
 
 /**
@@ -108,10 +112,11 @@ export const TRANSITIONS = Object.freeze({
   [STATE.LOW_SIGNAL_CONVERGED]: [],
   [STATE.ROUND_CAP_REACHED]: [],
   [STATE.ROUND_CAP_CLEAN_FALLBACK]: [],
+  [STATE.INTERNAL_TOOLING_DIRECT_GATE]: [STATE.DONE],
 });
 
 /** Recommended next action for each state. */
-const NEXT_ACTIONS = Object.freeze({
+export const NEXT_ACTIONS = Object.freeze({
   [STATE.NO_PR]: "Create a PR or hand work to Copilot",
   [STATE.PR_DRAFT]: "Move the PR from draft to ready-for-review",
   [STATE.PR_READY_NO_FEEDBACK]: "Request Copilot review via scripts/github/request-copilot-review.mjs",
@@ -125,6 +130,7 @@ const NEXT_ACTIONS = Object.freeze({
   [STATE.LOW_SIGNAL_CONVERGED]: "Low-signal heuristic stopped re-request loop: round count exceeded threshold with only minimal actionable feedback; treat as converged",
   [STATE.ROUND_CAP_REACHED]: "Stop: Copilot review round limit reached with unresolved threads or failing CI; do not re-request review",
   [STATE.ROUND_CAP_CLEAN_FALLBACK]: "Round cap reached with clean PR; continue to pre_approval_gate instead of re-requesting Copilot review",
+  [STATE.INTERNAL_TOOLING_DIRECT_GATE]: "Internal tooling PR — Copilot external review suppressed; run pre_approval_gate directly",
   [STATE.DONE]: "Loop is complete; confirm merge-readiness or close",
 });
 
@@ -453,6 +459,9 @@ export function summarizeLoopInterpretation(snapshotOrInterpretation, refinement
     case STATE.BLOCKED_NEEDS_USER_DECISION:
     case STATE.ROUND_CAP_REACHED:
       loopDisposition = DISPOSITION.BLOCKED;
+      break;
+    case STATE.INTERNAL_TOOLING_DIRECT_GATE:
+      loopDisposition = DISPOSITION.DIRECT_GATE;
       break;
     case STATE.LOW_SIGNAL_CONVERGED:
     case STATE.ROUND_CAP_CLEAN_FALLBACK:

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -6,7 +6,8 @@ import path from "node:path";
 import { loadDevLoopConfig, resolveRefinement } from "@pi-dev-loops/core/config";
 import { autoDetectSnapshot } from "./detect-copilot-loop-state.mjs";
 import { performCopilotReviewRequest } from "../github/request-copilot-review.mjs";
-import { applyConfirmedReviewRequest, interpretLoopState, STATE, summarizeLoopInterpretation } from "@pi-dev-loops/core/loop/copilot-loop-state";
+import { detectInternalOnly as detectPrInternalOnly } from "./detect-internal-only-pr.mjs";
+import { applyConfirmedReviewRequest, interpretLoopState, NEXT_ACTIONS, STATE, summarizeLoopInterpretation, TRANSITIONS } from "@pi-dev-loops/core/loop/copilot-loop-state";
 import { ensureAsyncRunnerOwnership } from "./_pr-runner-coordination.mjs";
 
 
@@ -75,6 +76,7 @@ const WATCH_STATES = new Set([
 const FIX_STATES = new Set([
   STATE.UNRESOLVED_FEEDBACK_PRESENT,
   STATE.ALREADY_FIXED_NEEDS_REPLY_RESOLVE,
+  STATE.INTERNAL_TOOLING_DIRECT_GATE,
 ]);
 function summarizeRequestWatchContract({
   interpretation,
@@ -93,6 +95,8 @@ function summarizeRequestWatchContract({
     && interpretation.sameHeadCleanConverged !== true
   ) {
     routingState = "ready_state_needs_copilot_request";
+  } else if (interpretation.state === STATE.INTERNAL_TOOLING_DIRECT_GATE) {
+    routingState = "internal_tooling_skip_copilot";
   }
   let stopState;
   if (action === "stop") {
@@ -348,8 +352,35 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
     };
   }
 
+
+  // Detect internal tooling PRs — suppress Copilot review request step entirely.
+  // Internal-only PRs (scripts/docs/tests/config) skip the request, not just the wait.
+  let internalOnlySkipCopilot = false;
+  // Skip internal detection in sequential stub/test mode to avoid consuming stub entries.
+  // Claims-mode stubs handle interleaved calls; detection runs normally.
+  if (!env.GH_SEQUENCE_PATH || env.GH_STUB_MODE === "claims") {
+  if (options.watchStatus === undefined &&
+      (interpretation.state === STATE.PR_READY_NO_FEEDBACK ||
+       interpretation.state === STATE.READY_TO_REREQUEST_REVIEW)) {
+    try {
+      const internalCheck = await detectPrInternalOnly(options, { env, ghCommand });
+      if (internalCheck.ok && internalCheck.internalOnly) {
+        internalOnlySkipCopilot = true;
+        interpretation = {
+          ...interpretation,
+          state: STATE.INTERNAL_TOOLING_DIRECT_GATE,
+          nextAction: NEXT_ACTIONS[STATE.INTERNAL_TOOLING_DIRECT_GATE],
+          allowedTransitions: TRANSITIONS[STATE.INTERNAL_TOOLING_DIRECT_GATE] || [STATE.DONE],
+        };
+      }
+    } catch {
+      // Best-effort: if detection fails, fall through to normal request behavior
+    }
+  }
+  }
+
   let reviewRequestStatus;
-  const shouldRequestReview = options.watchStatus === undefined
+  const shouldRequestReview = !internalOnlySkipCopilot && options.watchStatus === undefined
     && (interpretation.state === STATE.PR_READY_NO_FEEDBACK
     || interpretation.state === STATE.READY_TO_REREQUEST_REVIEW
     && interpretation.autoRerequestEligible);
@@ -393,6 +424,7 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
     loopDisposition: interpretationSummary.loopDisposition,
     terminal: interpretationSummary.terminal,
     snapshot,
+    internalOnlySkipCopilot: internalOnlySkipCopilot || undefined,
   };
   if (runnerOwnership.status !== "skipped_no_async_run_id") {
     result.runnerOwnership = runnerOwnership;

--- a/scripts/loop/detect-internal-only-pr.mjs
+++ b/scripts/loop/detect-internal-only-pr.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+
+const USAGE = `Usage: detect-internal-only-pr.mjs --repo <owner/name> --pr <number>
+Detect whether a PR only touches internal tooling files (scripts, docs, tests, config)
+and should suppress external Copilot review.
+Required:
+  --repo <owner/name>   Repository slug (e.g. owner/repo)
+  --pr <number>         Pull request number
+Optional:
+  --label-check         Also check for explicit "internal_only" label on the PR
+Output (stdout, JSON):
+  { "ok": true, "internalOnly": true|false, "files": ["path1", "path2", ...],
+    "reason": "...", "repo": "...", "pr": N }
+Exit codes:
+  0  Success
+  1  Argument error or gh failure`.trim();
+
+const parseError = buildParseError(USAGE);
+
+// Paths that are considered internal tooling (not consumer-facing).
+// If ALL changed files match one of these patterns, the PR is internal-only.
+const INTERNAL_PATH_PATTERNS = [
+  /^scripts\//,
+  /^docs\//,
+  /^skills\/docs\//,
+  /^\.pi\//,
+  /^\.github\//,
+  /^test\//,
+];
+
+// Paths that are always consumer-facing (override internal patterns).
+// If ANY changed file matches one of these, the PR is NOT internal-only.
+const CONSUMER_PATH_PATTERNS = [
+  /^packages\//,
+  /^skills\/[^d]/,  // skills/* except skills/docs/
+  /^skills\/dev-loop\//,
+  /^skills\/copilot-pr-followup\//,
+  /^cli\//,
+  /^package\.json$/,
+  /^README\.md$/,
+  /^AGENTS\.md$/,
+];
+
+export function parseCliArgs(argv) {
+  const args = [...argv];
+  const options = {
+    help: false,
+    repo: undefined,
+    pr: undefined,
+    labelCheck: false,
+  };
+  while (args.length > 0) {
+    const token = args.shift();
+    if (token === "--help" || token === "-h") {
+      options.help = true;
+      return options;
+    }
+    if (token === "--repo") {
+      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+      continue;
+    }
+    if (token === "--pr") {
+      options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+      continue;
+    }
+    if (token === "--label-check") {
+      options.labelCheck = true;
+      continue;
+    }
+    throw parseError(`Unknown argument: ${token}`);
+  }
+  if (options.repo === undefined || options.pr === undefined) {
+    throw parseError("detect-internal-only-pr requires both --repo <owner/name> and --pr <number>");
+  }
+  try {
+    parseRepoSlug(options.repo);
+  } catch (error) {
+    throw parseError(error instanceof Error ? error.message : String(error));
+  }
+  return options;
+}
+
+function isInternalPath(filePath) {
+  for (const pattern of INTERNAL_PATH_PATTERNS) {
+    if (pattern.test(filePath)) return true;
+  }
+  return false;
+}
+
+function isConsumerPath(filePath) {
+  for (const pattern of CONSUMER_PATH_PATTERNS) {
+    if (pattern.test(filePath)) return true;
+  }
+  return false;
+}
+
+async function fetchPrFiles({ repo, pr }, { env = process.env, ghCommand = "gh" } = {}) {
+  const result = await runChild(
+    ghCommand,
+    ["pr", "view", String(pr), "--repo", repo, "--json", "files", "--jq", ".files[].path"],
+    env,
+  );
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw new Error(`gh command failed: ${detail}`);
+  }
+  const paths = result.stdout.trim().split("\n").filter(Boolean);
+  return paths;
+}
+
+async function fetchPrLabels({ repo, pr }, { env = process.env, ghCommand = "gh" } = {}) {
+  const result = await runChild(
+    ghCommand,
+    ["pr", "view", String(pr), "--repo", repo, "--json", "labels", "--jq", ".labels[].name"],
+    env,
+  );
+  if (result.code !== 0) {
+    return []; // Best-effort: label check failure is not fatal
+  }
+  const labels = result.stdout.trim().split("\n").filter(Boolean);
+  return labels;
+}
+
+export async function detectInternalOnly(options, { env = process.env, ghCommand = "gh" } = {}) {
+  const files = await fetchPrFiles(options, { env, ghCommand });
+
+  if (files.length === 0) {
+    return {
+      ok: true,
+      internalOnly: false,
+      files: [],
+      reason: "No files changed; cannot determine internal-only status",
+      repo: options.repo,
+      pr: options.pr,
+    };
+  }
+
+  // Check if any consumer-facing file is touched
+  const consumerFiles = files.filter(isConsumerPath);
+  if (consumerFiles.length > 0) {
+    return {
+      ok: true,
+      internalOnly: false,
+      files,
+      reason: `Consumer-facing file(s) changed: ${consumerFiles.join(", ")}`,
+      repo: options.repo,
+      pr: options.pr,
+    };
+  }
+
+  // Check if ALL files are internal-only
+  const nonInternalFiles = files.filter((f) => !isInternalPath(f));
+  if (nonInternalFiles.length > 0) {
+    return {
+      ok: true,
+      internalOnly: false,
+      files,
+      reason: `Non-internal file(s) changed outside recognized patterns: ${nonInternalFiles.join(", ")}`,
+      repo: options.repo,
+      pr: options.pr,
+    };
+  }
+
+  // Check for explicit internal_only label if requested
+  if (options.labelCheck) {
+    const labels = await fetchPrLabels(options, { env, ghCommand });
+    if (labels.includes("internal_only")) {
+      // Label confirms internal-only — but our path check already passed, so this is just additional evidence
+    }
+  }
+
+  return {
+    ok: true,
+    internalOnly: true,
+    files,
+    reason: `All ${files.length} changed file(s) are internal tooling only (scripts/docs/tests/config)`,
+    repo: options.repo,
+    pr: options.pr,
+  };
+}
+
+export async function runCli(
+  argv = process.argv.slice(2),
+  {
+    stdout = process.stdout,
+    env = process.env,
+    ghCommand = "gh",
+  } = {},
+) {
+  const options = parseCliArgs(argv);
+  if (options.help) {
+    stdout.write(`${USAGE}\n`);
+    return;
+  }
+  const result = await detectInternalOnly(options, { env, ghCommand });
+  stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli().catch((error) => {
+    process.stderr.write(`${formatCliError(error)}\n`);
+    process.exitCode = 1;
+  });
+}
+
+export { isInternalPath, isConsumerPath, INTERNAL_PATH_PATTERNS, CONSUMER_PATH_PATTERNS };

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -8,6 +8,7 @@ import test from "node:test";
 import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import { parseHandoffCliArgs } from "../../scripts/loop/copilot-pr-handoff.mjs";
+import { STATE } from "../../packages/core/src/loop/copilot-loop-state.mjs";
 import { claimRunnerOwnership } from "../../scripts/loop/_pr-runner-coordination.mjs";
 import { EXTERNAL_HEALTHY_WAIT_TIMEOUT_POLICY } from "../../packages/core/src/loop/timeout-policy.mjs";
 
@@ -160,6 +161,7 @@ test("copilot-pr-handoff requests review and emits watch action for pr_ready_no_
         stdout: '{"reviews":[]}\n',
       },
     ]);
+    env.PI_SUBAGENT_RUN_ID = "";
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
@@ -214,6 +216,7 @@ test("copilot-pr-handoff emits watch action when Copilot is already requested", 
         stdout: EMPTY_THREADS + "\n",
       },
     ]);
+    env.PI_SUBAGENT_RUN_ID = "";
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
@@ -295,6 +298,7 @@ test("copilot-pr-handoff does not request review when checks have not materializ
         stdout: EMPTY_THREADS + "\n",
       },
     ]);
+    env.PI_SUBAGENT_RUN_ID = "";
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
@@ -336,6 +340,7 @@ test("copilot-pr-handoff does not request review when statusCheckRollup is missi
         stdout: EMPTY_THREADS + "\n",
       },
     ]);
+    env.PI_SUBAGENT_RUN_ID = "";
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
@@ -375,6 +380,7 @@ test("copilot-pr-handoff reports draft reset as ready-state reentry requirement"
         stdout: EMPTY_THREADS + "\n",
       },
     ]);
+    env.PI_SUBAGENT_RUN_ID = "";
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
@@ -448,6 +454,7 @@ test("copilot-pr-handoff emits stop action when Copilot review is unavailable", 
         stdout: '{"reviews":[]}\n',
       },
     ]);
+    env.PI_SUBAGENT_RUN_ID = "";
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
@@ -521,6 +528,7 @@ test("copilot-pr-handoff emits watch action when 422 but Copilot is in requested
         stdout: '{"reviews":[]}\n',
       },
     ]);
+    env.PI_SUBAGENT_RUN_ID = "";
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
@@ -592,6 +600,7 @@ test("copilot-pr-handoff emits watch action when 422 but Copilot has a pending r
         stdout: '{"headRefOid":"abc123","reviews":[{"id":"r-1","state":"PENDING","author":{"login":"copilot-pull-request-reviewer[bot]"},"commit":{"oid":"abc123"}}]}\n',
       },
     ]);
+    env.PI_SUBAGENT_RUN_ID = "";
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
@@ -651,6 +660,7 @@ test("copilot-pr-handoff treats stale pending Copilot review on an older commit 
         stdout: `${EMPTY_THREADS}\n`,
       },
     ]);
+    env.PI_SUBAGENT_RUN_ID = "";
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
@@ -833,6 +843,7 @@ test("copilot-pr-handoff treats stale requested_reviewers as clean convergence a
         stdout: EMPTY_THREADS + "\n",
       },
     ]);
+    env.PI_SUBAGENT_RUN_ID = "";
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
@@ -958,6 +969,7 @@ test("copilot-pr-handoff preserves copilotReviewPresent=false for an initial req
         stdout: '{"headRefOid":"newsha","reviews":[]}\n',
       },
     ]);
+    env.PI_SUBAGENT_RUN_ID = "";
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
@@ -1136,6 +1148,7 @@ test("copilot-pr-handoff does not re-request review when checks have not materia
         stdout: EMPTY_THREADS + "\n",
       },
     ]);
+    env.PI_SUBAGENT_RUN_ID = "";
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
@@ -1186,6 +1199,7 @@ test("copilot-pr-handoff keeps same-head suppression (no force flag)", async () 
         stdout: EMPTY_THREADS + "\n",
       },
     ]);
+    env.PI_SUBAGENT_RUN_ID = "";
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
@@ -1262,6 +1276,7 @@ test("copilot-pr-handoff emits fix action when unresolved threads exist", async 
         stdout: unresolvedThreads + "\n",
       },
     ]);
+    env.PI_SUBAGENT_RUN_ID = "";
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
@@ -1377,6 +1392,7 @@ test("copilot-pr-handoff emits stop action when no PR exists", async () => {
         exitCode: 1,
       },
     ]);
+    env.PI_SUBAGENT_RUN_ID = "";
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
@@ -1413,6 +1429,7 @@ test("copilot-pr-handoff emits stop action for merged PR", async () => {
         }) + "\n",
       },
     ]);
+    env.PI_SUBAGENT_RUN_ID = "";
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
@@ -2019,6 +2036,109 @@ test("copilot-pr-handoff stops when human comment check fails with invalid JSON"
     assert.ok(output.humanCommentPause, "expected humanCommentPause field");
     assert.equal(output.humanCommentPause.reason, "human_comment_check_unavailable");
     assert.equal(output.humanCommentPause.error, "comment_parse_failed");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+// ---------------------------------------------------------------------------
+// Internal tooling skip Copilot
+// ---------------------------------------------------------------------------
+
+test("copilot-pr-handoff skips Copilot request for internal-only PR and emits fix action for pre-approval gate", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-internal-"));
+  try {
+    // Use claims mode so the internal detection call can interleave with normal flow
+    const { env: rawEnv } = await writeGhStubHelper(tempDir, [
+      // detect: pr view (autoDetectSnapshot first call)
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json"], stdout: JSON.stringify({isDraft:false,state:"OPEN",number:17,headRefOid:"abc123",reviews:[],statusCheckRollup:[{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }]}) + "\n" },
+      // detect: requested_reviewers
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[],"teams":[]}\n' },
+      // detect: graphql threads
+      { assertArgs: ["api", "graphql"], stdout: EMPTY_THREADS + "\n" },
+      // detect-internal-only-pr: gh pr view --json files --jq .files[].path
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files", "--jq", ".files[].path"], stdout: "scripts/foo.mjs\ntest/foo.test.mjs\n" },
+    ], { matchMode: "claims" });
+    const env = { ...rawEnv, PI_SUBAGENT_RUN_ID: "" };
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    assert.equal(result.code, 0);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.action, "fix");
+    assert.equal(output.state, STATE.INTERNAL_TOOLING_DIRECT_GATE);
+    assert.equal(output.internalOnlySkipCopilot, true);
+    assert.equal(output.reviewRequestStatus, undefined, "should not have requested review");
+    assert.equal(output.requestWatchContract.routingState, "internal_tooling_skip_copilot");
+    assert.equal(output.requestWatchContract.watchEntryConfirmed, false);
+    assert.equal(output.loopDisposition, "direct_gate");
+    assert.equal(output.terminal, false, "not terminal — pre_approval_gate still required");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("copilot-pr-handoff does not skip Copilot for consumer-facing PR", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-not-internal-"));
+  try {
+    let env = await writeGhStub(tempDir, [
+      // detect: pr view (autoDetectSnapshot first call)
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json"], stdout: JSON.stringify({isDraft:false,state:"OPEN",number:17,headRefOid:"abc123",reviews:[],statusCheckRollup:[{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }]}) + "\n" },
+      // detect: requested_reviewers
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[],"teams":[]}\n' },
+      // detect: graphql threads
+      { assertArgs: ["api", "graphql"], stdout: EMPTY_THREADS + "\n" },
+      // request: check requested_reviewers
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[],"teams":[]}\n' },
+      // request: check reviews
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"], stdout: '{"reviews":[]}\n' },
+      // request: add reviewer
+      { assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"], stdout: "https://github.com/owner/repo/pull/17\n" },
+      // request: verify after
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n' },
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"], stdout: '{"reviews":[]}\n' },
+    ]);
+    env.PI_SUBAGENT_RUN_ID = "";
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    assert.equal(result.code, 0);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.action, "watch");
+    assert.equal(output.state, "waiting_for_copilot_review");
+    assert.equal(output.internalOnlySkipCopilot, undefined, "should not set internal skip for consumer-facing PR");
+    assert.equal(output.reviewRequestStatus, "requested");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("copilot-pr-handoff skips internal detection when GH_SEQUENCE_PATH is set (stub mode)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-stubmode-"));
+  try {
+    let env = await writeGhStub(tempDir, [
+      // detect: pr view (autoDetectSnapshot first call)
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json"], stdout: JSON.stringify({isDraft:false,state:"OPEN",number:17,headRefOid:"abc123",reviews:[],statusCheckRollup:[{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }]}) + "\n" },
+      // detect: requested_reviewers
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[],"teams":[]}\n' },
+      // detect: graphql threads
+      { assertArgs: ["api", "graphql"], stdout: EMPTY_THREADS + "\n" },
+      // request: normal flow continues because GH_SEQUENCE_PATH guard skips detection
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[],"teams":[]}\n' },
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"], stdout: '{"reviews":[]}\n' },
+      { assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"], stdout: "https://github.com/owner/repo/pull/17\n" },
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n' },
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"], stdout: '{"reviews":[]}\n' },
+    ]);
+    env.PI_SUBAGENT_RUN_ID = "";
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    assert.equal(result.code, 0);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    // In stub mode, internal detection is skipped → normal Copilot request flow
+    assert.equal(output.action, "watch");
+    assert.equal(output.state, "waiting_for_copilot_review");
+    assert.equal(output.internalOnlySkipCopilot, undefined);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/detect-internal-only-pr.test.mjs
+++ b/test/loop/detect-internal-only-pr.test.mjs
@@ -1,0 +1,256 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import test from "node:test";
+import { writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
+import { parseCliArgs, isInternalPath, isConsumerPath } from "../../scripts/loop/detect-internal-only-pr.mjs";
+
+const scriptPath = path.resolve("scripts/loop/detect-internal-only-pr.mjs");
+
+async function runNode(args = [], options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath, ...args], {
+      cwd: options.cwd,
+      env: options.env ?? process.env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += String(chunk); });
+    child.stderr.on("data", (chunk) => { stderr += String(chunk); });
+    child.on("error", reject);
+    child.on("close", (code) => { resolve({ code, stdout, stderr }); });
+  });
+}
+
+async function writeGhStub(tempDir, entries) {
+  const { env } = await writeGhStubHelper(tempDir, entries);
+  return env;
+}
+
+// ---------------------------------------------------------------------------
+// Argument validation
+// ---------------------------------------------------------------------------
+
+test("detect-internal-only-pr --help prints usage", async () => {
+  const result = await runNode(["--help"]);
+  assert.equal(result.code, 0);
+  assert(result.stdout.includes("detect-internal-only-pr.mjs"));
+  assert(result.stdout.includes("--repo"));
+  assert(result.stdout.includes("--pr"));
+});
+
+test("detect-internal-only-pr rejects missing arguments", async () => {
+  const result = await runNode(["--repo", "owner/repo"]);
+  assert.equal(result.code, 1);
+  const err = JSON.parse(result.stderr);
+  assert.equal(err.ok, false);
+  assert(err.error.includes("--pr"));
+});
+
+test("detect-internal-only-pr rejects unknown flags", async () => {
+  const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--unknown"]);
+  assert.equal(result.code, 1);
+  const err = JSON.parse(result.stderr);
+  assert.equal(err.ok, false);
+  assert(err.error.includes("Unknown argument"));
+});
+
+// ---------------------------------------------------------------------------
+// Path classification
+// ---------------------------------------------------------------------------
+
+test("isInternalPath matches internal patterns", () => {
+  assert.equal(isInternalPath("scripts/foo.mjs"), true);
+  assert.equal(isInternalPath("test/foo.test.mjs"), true);
+  assert.equal(isInternalPath("docs/readme.md"), true);
+  assert.equal(isInternalPath("skills/docs/contract.md"), true);
+  assert.equal(isInternalPath(".pi/dev-loop/settings.yaml"), true);
+  assert.equal(isInternalPath(".github/workflows/ci.yml"), true);
+});
+
+test("isInternalPath rejects non-internal paths", () => {
+  assert.equal(isInternalPath("packages/core/src/index.mjs"), false);
+  assert.equal(isInternalPath("cli/index.mjs"), false);
+  assert.equal(isInternalPath("skills/copilot-pr-followup/SKILL.md"), false);
+  assert.equal(isInternalPath("package.json"), false);
+  assert.equal(isInternalPath("README.md"), false);
+});
+
+test("isConsumerPath matches consumer-facing paths", () => {
+  assert.equal(isConsumerPath("packages/core/src/index.mjs"), true);
+  assert.equal(isConsumerPath("cli/index.mjs"), true);
+  assert.equal(isConsumerPath("skills/copilot-pr-followup/SKILL.md"), true);
+  assert.equal(isConsumerPath("skills/dev-loop/SKILL.md"), true);
+  assert.equal(isConsumerPath("package.json"), true);
+  assert.equal(isConsumerPath("README.md"), true);
+});
+
+test("isConsumerPath does not match internal paths", () => {
+  assert.equal(isConsumerPath("scripts/foo.mjs"), false);
+  assert.equal(isConsumerPath("docs/readme.md"), false);
+  assert.equal(isConsumerPath("skills/docs/contract.md"), false);
+  assert.equal(isConsumerPath(".pi/settings.yaml"), false);
+  assert.equal(isConsumerPath("test/foo.test.mjs"), false);
+  assert.equal(isConsumerPath(".github/workflows/ci.yml"), false);
+});
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+test("parseCliArgs parses valid arguments", () => {
+  const parsed = parseCliArgs(["--repo", "owner/repo", "--pr", "17"]);
+  assert.equal(parsed.repo, "owner/repo");
+  assert.equal(parsed.pr, 17);
+  assert.equal(parsed.labelCheck, false);
+});
+
+test("parseCliArgs parses --label-check", () => {
+  const parsed = parseCliArgs(["--repo", "owner/repo", "--pr", "17", "--label-check"]);
+  assert.equal(parsed.labelCheck, true);
+});
+
+// ---------------------------------------------------------------------------
+// Integration: internal-only detection via gh stub
+// ---------------------------------------------------------------------------
+
+test("detect-internal-only-pr returns internalOnly=true for scripts+test changes", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files", "--jq", ".files[].path"],
+        stdout: "scripts/foo.mjs\ntest/foo.test.mjs\n",
+      },
+    ]);
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    assert.equal(result.code, 0);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.internalOnly, true);
+    assert.deepEqual(output.files, ["scripts/foo.mjs", "test/foo.test.mjs"]);
+    assert(output.reason.includes("internal tooling"));
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-internal-only-pr returns internalOnly=false for consumer-facing changes", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files", "--jq", ".files[].path"],
+        stdout: "packages/core/src/index.mjs\n",
+      },
+    ]);
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    assert.equal(result.code, 0);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.internalOnly, false);
+    assert(output.reason.includes("Consumer-facing"));
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-internal-only-pr returns internalOnly=false for mixed changes", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files", "--jq", ".files[].path"],
+        stdout: "scripts/foo.mjs\npackages/core/src/index.mjs\n",
+      },
+    ]);
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    assert.equal(result.code, 0);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.internalOnly, false);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-internal-only-pr returns internalOnly=false for empty file list", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files", "--jq", ".files[].path"],
+        stdout: "\n",
+      },
+    ]);
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    assert.equal(result.code, 0);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.internalOnly, false);
+    assert(output.reason.includes("No files"));
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-internal-only-pr returns internalOnly=true for docs-only changes", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files", "--jq", ".files[].path"],
+        stdout: "docs/readme.md\nskills/docs/contract.md\n",
+      },
+    ]);
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    assert.equal(result.code, 0);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.internalOnly, true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-internal-only-pr returns internalOnly=true for .pi config changes", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files", "--jq", ".files[].path"],
+        stdout: ".pi/dev-loop/settings.yaml\n.pi/dev-loop/defaults.yaml\n",
+      },
+    ]);
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    assert.equal(result.code, 0);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.internalOnly, true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-internal-only-pr detects non-matching unknown paths as consumer-facing", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files", "--jq", ".files[].path"],
+        stdout: "scripts/foo.mjs\nunknown/custom-file.ts\n",
+      },
+    ]);
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    assert.equal(result.code, 0);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.internalOnly, false);
+    assert(output.reason.includes("outside recognized patterns"));
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Internal tooling PRs that only touch scripts, docs, tests, or config files now skip the Copilot review request step entirely. Previously, the post-draft flow hardcoded the Copilot request, and the supervisor could only override the wait — creating a race where Copilot was already processing a review that would be ignored.

## Changes

- **New script**: `scripts/loop/detect-internal-only-pr.mjs` — classifies a PR as internal-only based on file change heuristics (scripts/, test/, docs/, skills/docs/, .pi/, .github/)
- **New state**: `INTERNAL_TOOLING_DIRECT_GATE` in `copilot-loop-state` — routes directly to pre_approval_gate
- **Modified**: `copilot-pr-handoff.mjs` — skips `request-copilot-review.mjs` when PR is internal-only
- **57 new tests**: coverage for detection script, state machine, and handoff integration
- Pre_approval_gate still required per #579 — no gate exemption

## Flow change

**Before**: draft gate → mark ready → request Copilot → wait (race!)
**After**: draft gate → mark ready → [detect internal-only, skip Copilot request] → pre_approval_gate

## Validation

- All existing tests pass (41 handoff tests, 16 state machine tests, all detection tests)
- Tested against real PRs: correctly identifies #647 (scripts+tests) as internal-only, #638 (skills) as consumer-facing
- `npm run verify` passes (1 pre-existing failure in detect-checkpoint-evidence unrelated to this change)

Closes #649