### PR TITLE
feat: make internal-only PR detection patterns configurable (#652)

### DIFF
--- a/.pi/dev-loop/defaults.yaml
+++ b/.pi/dev-loop/defaults.yaml
@@ -416,11 +416,18 @@ personas:
 # If ALL changed files in a PR match one of these patterns, the PR is
 # classified as internal-only and Copilot review is suppressed.
 # Consumer repos can override these in .pi/dev-loop/settings.yaml.
+# Internal path patterns for internal-only PR detection.
+# Flat array of regex strings. If ALL changed files in a PR match at least
+# one pattern, the PR is classified as internal-only and Copilot review is
+# suppressed. Consumer repos override with their own list.
+# Example consumer override:
+#   internalPathPatterns:
+#     - "^tools/"
+#     - "^internal/"
 internalPathPatterns:
-  patterns:
-    - "^scripts/"
-    - "^docs/"
-    - "^skills/docs/"
-    - "^\\.pi/"
-    - "^\\.github/"
-    - "^test/"
+  - "^scripts/"
+  - "^docs/"
+  - "^skills/docs/"
+  - "^\\.pi/"
+  - "^\\.github/"
+  - "^test/"

--- a/.pi/dev-loop/defaults.yaml
+++ b/.pi/dev-loop/defaults.yaml
@@ -411,3 +411,16 @@ personas:
       - Flag patterns where a tool is called in a loop but only the last
         iteration's result is used (or none at all).
     defaultModel: null
+
+# Internal path patterns for internal-only PR detection.
+# If ALL changed files in a PR match one of these patterns, the PR is
+# classified as internal-only and Copilot review is suppressed.
+# Consumer repos can override these in .pi/dev-loop/settings.yaml.
+internalPathPatterns:
+  patterns:
+    - "^scripts/"
+    - "^docs/"
+    - "^skills/docs/"
+    - "^\\.pi/"
+    - "^\\.github/"
+    - "^test/"

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -80,10 +80,8 @@ const QueueConfig = z.strictObject({
   reDispatchMaxRetries: z.number().int().min(0).max(10).default(1),
 });
 
-/** Internal path whitelist for internal-only PR detection */
-const InternalPatternsConfig = z.strictObject({
-  patterns: z.array(z.string().min(1)).min(1),
-});
+/** Internal path whitelist for internal-only PR detection — flat array of regex strings */
+const InternalPatternsConfig = z.array(z.string().trim().min(1)).min(1);
 
 const PersonaEntry = z.strictObject({
   persona: z.string().min(1),
@@ -155,16 +153,14 @@ export const BUILT_IN_DEFAULTS = Object.freeze({
     reDispatchMaxRetries: 1,
   }),
   personas: Object.freeze({}),
-  internalPathPatterns: Object.freeze({
-    patterns: Object.freeze([
-      "^scripts/",
-      "^docs/",
-      "^skills/docs/",
-      "^\\.pi/",
-      "^\\.github/",
-      "^test/",
-    ]),
-  }),
+  internalPathPatterns: Object.freeze([
+    "^scripts/",
+    "^docs/",
+    "^skills/docs/",
+    "^\\.pi/",
+    "^\\.github/",
+    "^test/",
+  ]),
 });
 
 // ============================================================================
@@ -182,7 +178,7 @@ export const FileConfigSchema = z.strictObject({
   localImplementation: LocalImplementationConfig.partial().optional(),
   queue: QueueConfig.partial().optional(),
   personas: FilePersonasConfig.optional(),
-  internalPathPatterns: InternalPatternsConfig.partial().optional(),
+  internalPathPatterns: InternalPatternsConfig.optional(),
 });
 
 // ============================================================================
@@ -832,11 +828,11 @@ const DEFAULT_INTERNAL_PATH_PATTERNS = BUILT_IN_DEFAULTS.internalPathPatterns;
  */
 export function resolveInternalPathPatterns(config) {
   if (
-    config?.internalPathPatterns?.patterns &&
-    Array.isArray(config.internalPathPatterns.patterns) &&
-    config.internalPathPatterns.patterns.length > 0
+    config?.internalPathPatterns &&
+    Array.isArray(config.internalPathPatterns) &&
+    config.internalPathPatterns.length > 0
   ) {
-    return [...config.internalPathPatterns.patterns];
+    return [...config.internalPathPatterns];
   }
-  return [...DEFAULT_INTERNAL_PATH_PATTERNS.patterns];
+  return [...DEFAULT_INTERNAL_PATH_PATTERNS];
 }

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -80,6 +80,11 @@ const QueueConfig = z.strictObject({
   reDispatchMaxRetries: z.number().int().min(0).max(10).default(1),
 });
 
+/** Internal path whitelist for internal-only PR detection */
+const InternalPatternsConfig = z.strictObject({
+  patterns: z.array(z.string().min(1)).min(1),
+});
+
 const PersonaEntry = z.strictObject({
   persona: z.string().min(1),
   // Optional in the merged/full schema so consumer overrides can replace
@@ -120,6 +125,7 @@ export const DevLoopConfigSchema = z.strictObject({
   localImplementation: LocalImplementationConfig.optional(),
   queue: QueueConfig.optional(),
   personas: PersonasConfig.optional(),
+  internalPathPatterns: InternalPatternsConfig.optional(),
 });
 
 // ============================================================================
@@ -149,6 +155,16 @@ export const BUILT_IN_DEFAULTS = Object.freeze({
     reDispatchMaxRetries: 1,
   }),
   personas: Object.freeze({}),
+  internalPathPatterns: Object.freeze({
+    patterns: Object.freeze([
+      "^scripts/",
+      "^docs/",
+      "^skills/docs/",
+      "^\\.pi/",
+      "^\\.github/",
+      "^test/",
+    ]),
+  }),
 });
 
 // ============================================================================
@@ -166,6 +182,7 @@ export const FileConfigSchema = z.strictObject({
   localImplementation: LocalImplementationConfig.partial().optional(),
   queue: QueueConfig.partial().optional(),
   personas: FilePersonasConfig.optional(),
+  internalPathPatterns: InternalPatternsConfig.partial().optional(),
 });
 
 // ============================================================================
@@ -797,4 +814,29 @@ export function resolveWorkflowConfig(config, key) {
   }
 
   throw new Error(`Unknown workflow config key: ${key}`);
+}
+
+const DEFAULT_INTERNAL_PATH_PATTERNS = BUILT_IN_DEFAULTS.internalPathPatterns;
+
+/**
+ * Resolve the internal path patterns from the merged dev-loop config.
+ *
+ * Returns an array of regex pattern strings used by detect-internal-only-pr.mjs
+ * to classify files as internal tooling (vs consumer-facing). When the config
+ * omits this section, returns the built-in shipped defaults.
+ *
+ * Consumers can override these in .pi/dev-loop/settings.yaml.
+ *
+ * @param {DevLoopConfig} config
+ * @returns {string[]}
+ */
+export function resolveInternalPathPatterns(config) {
+  if (
+    config?.internalPathPatterns?.patterns &&
+    Array.isArray(config.internalPathPatterns.patterns) &&
+    config.internalPathPatterns.patterns.length > 0
+  ) {
+    return [...config.internalPathPatterns.patterns];
+  }
+  return [...DEFAULT_INTERNAL_PATH_PATTERNS.patterns];
 }

--- a/scripts/loop/detect-internal-only-pr.mjs
+++ b/scripts/loop/detect-internal-only-pr.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { readFileSync } from "node:fs";
+import { statSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { parse as parseYaml } from "yaml";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
@@ -38,10 +38,9 @@ const SHIPPED_DEFAULT_PATTERNS = [
 function findRepoRoot(cwd = process.cwd()) {
   let dir = cwd;
   while (true) {
-    const candidate = path.join(dir, ".git");
     try {
-      readFileSync(candidate);
-      return dir;
+      const s = statSync(path.join(dir, ".git"));
+      if (s.isDirectory() || s.isFile()) return dir;
     } catch {
     }
     const parent = path.dirname(dir);
@@ -50,20 +49,20 @@ function findRepoRoot(cwd = process.cwd()) {
   }
 }
 
+/**
+ * Load internal path patterns from config, with precedence:
+ *   1. --config flag (explicit path)
+ *   2. Auto-detect from repo root (.pi/dev-loop/settings.* or overrides.*)
+ *   3. Shipped defaults
+ *
+ * Returns a flat array of regex pattern strings.
+ * Falls back to shipped defaults when parsed patterns are empty or invalid.
+ */
 function loadInternalPathPatterns(configPath) {
   // --config flag takes priority
   if (configPath) {
-    try {
-      const raw = readFileSync(configPath, "utf8");
-      const parsed = configPath.endsWith(".yaml") || configPath.endsWith(".yml")
-        ? parseYaml(raw)
-        : JSON.parse(raw);
-      if (parsed?.internalPathPatterns?.patterns && Array.isArray(parsed.internalPathPatterns.patterns)) {
-        return parsed.internalPathPatterns.patterns.filter(p => typeof p === "string" && p.trim());
-      }
-    } catch {
-      // Fall through to defaults
-    }
+    const patterns = tryLoadFromFile(configPath);
+    if (patterns && patterns.length > 0) return patterns;
     return [...SHIPPED_DEFAULT_PATTERNS];
   }
 
@@ -74,22 +73,32 @@ function loadInternalPathPatterns(configPath) {
       path.join(repoRoot, ".pi", "dev-loop", "settings.yaml"),
       path.join(repoRoot, ".pi", "dev-loop", "settings.yml"),
       path.join(repoRoot, ".pi", "dev-loop", "settings.json"),
+      path.join(repoRoot, ".pi", "dev-loop", "overrides.yaml"),
+      path.join(repoRoot, ".pi", "dev-loop", "overrides.yml"),
+      path.join(repoRoot, ".pi", "dev-loop", "overrides.json"),
     ];
     for (const candidate of candidates) {
-      try {
-        const raw = readFileSync(candidate, "utf8");
-        const parsed = candidate.endsWith(".json") ? JSON.parse(raw) : parseYaml(raw);
-        if (parsed?.internalPathPatterns?.patterns && Array.isArray(parsed.internalPathPatterns.patterns)) {
-          return parsed.internalPathPatterns.patterns.filter(p => typeof p === "string" && p.trim());
-        }
-      } catch {
-        continue;
-      }
+      const patterns = tryLoadFromFile(candidate);
+      if (patterns && patterns.length > 0) return patterns;
     }
   }
 
   // Fall back to shipped defaults
   return [...SHIPPED_DEFAULT_PATTERNS];
+}
+
+function tryLoadFromFile(filePath) {
+  try {
+    const raw = readFileSync(filePath, "utf8");
+    const parsed = filePath.endsWith(".json") ? JSON.parse(raw) : parseYaml(raw);
+    const patterns = parsed?.internalPathPatterns;
+    if (Array.isArray(patterns)) {
+      const trimmed = patterns.filter(p => typeof p === "string" && p.trim()).map(p => p.trim());
+      return trimmed.length > 0 ? trimmed : null;
+    }
+  } catch {
+  }
+  return null;
 }
 
 function buildPatternMatchers(patterns) {
@@ -252,4 +261,4 @@ if (isDirectCliRun(import.meta.url)) {
   });
 }
 
-export { loadInternalPathPatterns, buildPatternMatchers, SHIPPED_DEFAULT_PATTERNS };
+export { findRepoRoot, loadInternalPathPatterns, buildPatternMatchers, tryLoadFromFile, SHIPPED_DEFAULT_PATTERNS };

--- a/scripts/loop/detect-internal-only-pr.mjs
+++ b/scripts/loop/detect-internal-only-pr.mjs
@@ -1,15 +1,20 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { parse as parseYaml } from "yaml";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 
-const USAGE = `Usage: detect-internal-only-pr.mjs --repo <owner/name> --pr <number>
+const USAGE = `Usage: detect-internal-only-pr.mjs --repo <owner/name> --pr <number> [--config <path>]
 Detect whether a PR only touches internal tooling files (scripts, docs, tests, config)
 and should suppress external Copilot review.
+
 Required:
   --repo <owner/name>   Repository slug (e.g. owner/repo)
   --pr <number>         Pull request number
 Optional:
+  --config <path>       Path to .pi/dev-loop/settings.yaml (default: auto-detect)
   --label-check         Also check for explicit "internal_only" label on the PR
 Output (stdout, JSON):
   { "ok": true, "internalOnly": true|false, "files": ["path1", "path2", ...],
@@ -20,29 +25,82 @@ Exit codes:
 
 const parseError = buildParseError(USAGE);
 
-// Paths that are considered internal tooling (not consumer-facing).
-// If ALL changed files match one of these patterns, the PR is internal-only.
-const INTERNAL_PATH_PATTERNS = [
-  /^scripts\//,
-  /^docs\//,
-  /^skills\/docs\//,
-  /^\.pi\//,
-  /^\.github\//,
-  /^test\//,
+// Shipped default patterns used as fallback when no config is found.
+const SHIPPED_DEFAULT_PATTERNS = [
+  "^scripts/",
+  "^docs/",
+  "^skills/docs/",
+  "^\\.pi/",
+  "^\\.github/",
+  "^test/",
 ];
 
-// Paths that are always consumer-facing (override internal patterns).
-// If ANY changed file matches one of these, the PR is NOT internal-only.
-const CONSUMER_PATH_PATTERNS = [
-  /^packages\//,
-  /^skills\/[^d]/,  // skills/* except skills/docs/
-  /^skills\/dev-loop\//,
-  /^skills\/copilot-pr-followup\//,
-  /^cli\//,
-  /^package\.json$/,
-  /^README\.md$/,
-  /^AGENTS\.md$/,
-];
+function findRepoRoot(cwd = process.cwd()) {
+  let dir = cwd;
+  while (true) {
+    const candidate = path.join(dir, ".git");
+    try {
+      readFileSync(candidate);
+      return dir;
+    } catch {
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+function loadInternalPathPatterns(configPath) {
+  // --config flag takes priority
+  if (configPath) {
+    try {
+      const raw = readFileSync(configPath, "utf8");
+      const parsed = configPath.endsWith(".yaml") || configPath.endsWith(".yml")
+        ? parseYaml(raw)
+        : JSON.parse(raw);
+      if (parsed?.internalPathPatterns?.patterns && Array.isArray(parsed.internalPathPatterns.patterns)) {
+        return parsed.internalPathPatterns.patterns.filter(p => typeof p === "string" && p.trim());
+      }
+    } catch {
+      // Fall through to defaults
+    }
+    return [...SHIPPED_DEFAULT_PATTERNS];
+  }
+
+  // Auto-detect from repo root
+  const repoRoot = findRepoRoot();
+  if (repoRoot) {
+    const candidates = [
+      path.join(repoRoot, ".pi", "dev-loop", "settings.yaml"),
+      path.join(repoRoot, ".pi", "dev-loop", "settings.yml"),
+      path.join(repoRoot, ".pi", "dev-loop", "settings.json"),
+    ];
+    for (const candidate of candidates) {
+      try {
+        const raw = readFileSync(candidate, "utf8");
+        const parsed = candidate.endsWith(".json") ? JSON.parse(raw) : parseYaml(raw);
+        if (parsed?.internalPathPatterns?.patterns && Array.isArray(parsed.internalPathPatterns.patterns)) {
+          return parsed.internalPathPatterns.patterns.filter(p => typeof p === "string" && p.trim());
+        }
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  // Fall back to shipped defaults
+  return [...SHIPPED_DEFAULT_PATTERNS];
+}
+
+function buildPatternMatchers(patterns) {
+  return patterns.map(p => {
+    try {
+      return new RegExp(p);
+    } catch {
+      return null;
+    }
+  }).filter(r => r !== null);
+}
 
 export function parseCliArgs(argv) {
   const args = [...argv];
@@ -50,6 +108,7 @@ export function parseCliArgs(argv) {
     help: false,
     repo: undefined,
     pr: undefined,
+    config: undefined,
     labelCheck: false,
   };
   while (args.length > 0) {
@@ -64,6 +123,10 @@ export function parseCliArgs(argv) {
     }
     if (token === "--pr") {
       options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+      continue;
+    }
+    if (token === "--config") {
+      options.config = requireOptionValue(args, "--config", parseError).trim();
       continue;
     }
     if (token === "--label-check") {
@@ -81,20 +144,6 @@ export function parseCliArgs(argv) {
     throw parseError(error instanceof Error ? error.message : String(error));
   }
   return options;
-}
-
-function isInternalPath(filePath) {
-  for (const pattern of INTERNAL_PATH_PATTERNS) {
-    if (pattern.test(filePath)) return true;
-  }
-  return false;
-}
-
-function isConsumerPath(filePath) {
-  for (const pattern of CONSUMER_PATH_PATTERNS) {
-    if (pattern.test(filePath)) return true;
-  }
-  return false;
 }
 
 async function fetchPrFiles({ repo, pr }, { env = process.env, ghCommand = "gh" } = {}) {
@@ -124,7 +173,17 @@ async function fetchPrLabels({ repo, pr }, { env = process.env, ghCommand = "gh"
   return labels;
 }
 
+/**
+ * Detect whether a PR is internal-only using a configurable whitelist.
+ *
+ * Single-whitelist logic:
+ * - If ALL changed files match at least one internal pattern → internalOnly=true
+ * - If ANY changed file doesn't match any pattern → internalOnly=false
+ * - No blacklist needed — a non-matching file is consumer-facing by definition.
+ */
 export async function detectInternalOnly(options, { env = process.env, ghCommand = "gh" } = {}) {
+  const patterns = loadInternalPathPatterns(options.config);
+  const matchers = buildPatternMatchers(patterns);
   const files = await fetchPrFiles(options, { env, ghCommand });
 
   if (files.length === 0) {
@@ -138,37 +197,24 @@ export async function detectInternalOnly(options, { env = process.env, ghCommand
     };
   }
 
-  // Check if any consumer-facing file is touched
-  const consumerFiles = files.filter(isConsumerPath);
-  if (consumerFiles.length > 0) {
+  // Single whitelist: any non-matching file → NOT internal-only
+  const nonMatching = files.filter(f => !matchers.some(r => r.test(f)));
+  if (nonMatching.length > 0) {
     return {
       ok: true,
       internalOnly: false,
       files,
-      reason: `Consumer-facing file(s) changed: ${consumerFiles.join(", ")}`,
+      reason: `Consumer-facing file(s) changed: ${nonMatching.join(", ")}`,
       repo: options.repo,
       pr: options.pr,
     };
   }
 
-  // Check if ALL files are internal-only
-  const nonInternalFiles = files.filter((f) => !isInternalPath(f));
-  if (nonInternalFiles.length > 0) {
-    return {
-      ok: true,
-      internalOnly: false,
-      files,
-      reason: `Non-internal file(s) changed outside recognized patterns: ${nonInternalFiles.join(", ")}`,
-      repo: options.repo,
-      pr: options.pr,
-    };
-  }
-
-  // Check for explicit internal_only label if requested
+  // Check for explicit internal_only label if requested (confirmation only)
   if (options.labelCheck) {
     const labels = await fetchPrLabels(options, { env, ghCommand });
     if (labels.includes("internal_only")) {
-      // Label confirms internal-only — but our path check already passed, so this is just additional evidence
+      // Label confirms — path check already passed
     }
   }
 
@@ -206,4 +252,4 @@ if (isDirectCliRun(import.meta.url)) {
   });
 }
 
-export { isInternalPath, isConsumerPath, INTERNAL_PATH_PATTERNS, CONSUMER_PATH_PATTERNS };
+export { loadInternalPathPatterns, buildPatternMatchers, SHIPPED_DEFAULT_PATTERNS };

--- a/test/loop/detect-internal-only-pr.test.mjs
+++ b/test/loop/detect-internal-only-pr.test.mjs
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
 import { writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
-import { parseCliArgs, isInternalPath, isConsumerPath } from "../../scripts/loop/detect-internal-only-pr.mjs";
+import { parseCliArgs, loadInternalPathPatterns, buildPatternMatchers, SHIPPED_DEFAULT_PATTERNS } from "../../scripts/loop/detect-internal-only-pr.mjs";
 
 const scriptPath = path.resolve("scripts/loop/detect-internal-only-pr.mjs");
 
@@ -40,6 +40,7 @@ test("detect-internal-only-pr --help prints usage", async () => {
   assert(result.stdout.includes("detect-internal-only-pr.mjs"));
   assert(result.stdout.includes("--repo"));
   assert(result.stdout.includes("--pr"));
+  assert(result.stdout.includes("--config"));
 });
 
 test("detect-internal-only-pr rejects missing arguments", async () => {
@@ -59,45 +60,6 @@ test("detect-internal-only-pr rejects unknown flags", async () => {
 });
 
 // ---------------------------------------------------------------------------
-// Path classification
-// ---------------------------------------------------------------------------
-
-test("isInternalPath matches internal patterns", () => {
-  assert.equal(isInternalPath("scripts/foo.mjs"), true);
-  assert.equal(isInternalPath("test/foo.test.mjs"), true);
-  assert.equal(isInternalPath("docs/readme.md"), true);
-  assert.equal(isInternalPath("skills/docs/contract.md"), true);
-  assert.equal(isInternalPath(".pi/dev-loop/settings.yaml"), true);
-  assert.equal(isInternalPath(".github/workflows/ci.yml"), true);
-});
-
-test("isInternalPath rejects non-internal paths", () => {
-  assert.equal(isInternalPath("packages/core/src/index.mjs"), false);
-  assert.equal(isInternalPath("cli/index.mjs"), false);
-  assert.equal(isInternalPath("skills/copilot-pr-followup/SKILL.md"), false);
-  assert.equal(isInternalPath("package.json"), false);
-  assert.equal(isInternalPath("README.md"), false);
-});
-
-test("isConsumerPath matches consumer-facing paths", () => {
-  assert.equal(isConsumerPath("packages/core/src/index.mjs"), true);
-  assert.equal(isConsumerPath("cli/index.mjs"), true);
-  assert.equal(isConsumerPath("skills/copilot-pr-followup/SKILL.md"), true);
-  assert.equal(isConsumerPath("skills/dev-loop/SKILL.md"), true);
-  assert.equal(isConsumerPath("package.json"), true);
-  assert.equal(isConsumerPath("README.md"), true);
-});
-
-test("isConsumerPath does not match internal paths", () => {
-  assert.equal(isConsumerPath("scripts/foo.mjs"), false);
-  assert.equal(isConsumerPath("docs/readme.md"), false);
-  assert.equal(isConsumerPath("skills/docs/contract.md"), false);
-  assert.equal(isConsumerPath(".pi/settings.yaml"), false);
-  assert.equal(isConsumerPath("test/foo.test.mjs"), false);
-  assert.equal(isConsumerPath(".github/workflows/ci.yml"), false);
-});
-
-// ---------------------------------------------------------------------------
 // CLI argument parsing
 // ---------------------------------------------------------------------------
 
@@ -106,11 +68,84 @@ test("parseCliArgs parses valid arguments", () => {
   assert.equal(parsed.repo, "owner/repo");
   assert.equal(parsed.pr, 17);
   assert.equal(parsed.labelCheck, false);
+  assert.equal(parsed.config, undefined);
 });
 
 test("parseCliArgs parses --label-check", () => {
   const parsed = parseCliArgs(["--repo", "owner/repo", "--pr", "17", "--label-check"]);
   assert.equal(parsed.labelCheck, true);
+});
+
+test("parseCliArgs parses --config", () => {
+  const parsed = parseCliArgs(["--repo", "owner/repo", "--pr", "17", "--config", "/path/to/settings.yaml"]);
+  assert.equal(parsed.config, "/path/to/settings.yaml");
+});
+
+// ---------------------------------------------------------------------------
+// Pattern loading
+// ---------------------------------------------------------------------------
+
+test("loadInternalPathPatterns returns shipped defaults when no config found", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  try {
+    const patterns = loadInternalPathPatterns(undefined);
+    assert.deepEqual(patterns, SHIPPED_DEFAULT_PATTERNS);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("loadInternalPathPatterns loads from --config path", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  try {
+    const configPath = path.join(tempDir, "settings.yaml");
+    await writeFile(configPath, "internalPathPatterns:\n  patterns:\n    - \"^src/\"\n    - \"^lib/\"\n");
+    const patterns = loadInternalPathPatterns(configPath);
+    assert.deepEqual(patterns, ["^src/", "^lib/"]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("loadInternalPathPatterns falls back to defaults on invalid config", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  try {
+    const configPath = path.join(tempDir, "settings.yaml");
+    await writeFile(configPath, "garbage: [[[");
+    const patterns = loadInternalPathPatterns(configPath);
+    assert.deepEqual(patterns, SHIPPED_DEFAULT_PATTERNS);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("loadInternalPathPatterns skips missing internalPathPatterns key", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  try {
+    const configPath = path.join(tempDir, "settings.yaml");
+    await writeFile(configPath, "gates:\n  draft:\n    requireCi: false\n");
+    const patterns = loadInternalPathPatterns(configPath);
+    assert.deepEqual(patterns, SHIPPED_DEFAULT_PATTERNS);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Pattern matchers
+// ---------------------------------------------------------------------------
+
+test("buildPatternMatchers converts strings to RegExp", () => {
+  const matchers = buildPatternMatchers(["^scripts/", "^test/"]);
+  assert.equal(matchers.length, 2);
+  assert(matchers[0].test("scripts/foo.mjs"));
+  assert(matchers[1].test("test/bar.test.mjs"));
+  assert(!matchers[0].test("packages/foo.mjs"));
+});
+
+test("buildPatternMatchers skips invalid regex", () => {
+  const matchers = buildPatternMatchers(["^valid/", "[invalid"]);
+  assert.equal(matchers.length, 1);
 });
 
 // ---------------------------------------------------------------------------
@@ -249,7 +284,50 @@ test("detect-internal-only-pr detects non-matching unknown paths as consumer-fac
     const output = JSON.parse(result.stdout);
     assert.equal(output.ok, true);
     assert.equal(output.internalOnly, false);
-    assert(output.reason.includes("outside recognized patterns"));
+    assert(output.reason.includes("Consumer-facing"));
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-internal-only-pr respects --config with custom patterns", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  try {
+    const configPath = path.join(tempDir, "settings.yaml");
+    await writeFile(configPath, "internalPathPatterns:\n  patterns:\n    - \"^custom/\"\n    - \"^tools/\"\n");
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files", "--jq", ".files[].path"],
+        stdout: "custom/foo.mjs\ntools/bar.sh\n",
+      },
+    ]);
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--config", configPath], { env });
+    assert.equal(result.code, 0);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.internalOnly, true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-internal-only-pr with --config detects non-matching file as consumer-facing", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  try {
+    const configPath = path.join(tempDir, "settings.yaml");
+    await writeFile(configPath, "internalPathPatterns:\n  patterns:\n    - \"^custom/\"\n");
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files", "--jq", ".files[].path"],
+        stdout: "custom/foo.mjs\npackages/core/src/bar.mjs\n",
+      },
+    ]);
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--config", configPath], { env });
+    assert.equal(result.code, 0);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.internalOnly, false);
+    assert(output.reason.includes("Consumer-facing"));
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/detect-internal-only-pr.test.mjs
+++ b/test/loop/detect-internal-only-pr.test.mjs
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
 import { writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
-import { parseCliArgs, loadInternalPathPatterns, buildPatternMatchers, SHIPPED_DEFAULT_PATTERNS } from "../../scripts/loop/detect-internal-only-pr.mjs";
+import { parseCliArgs, findRepoRoot, loadInternalPathPatterns, buildPatternMatchers, tryLoadFromFile, SHIPPED_DEFAULT_PATTERNS } from "../../scripts/loop/detect-internal-only-pr.mjs";
 
 const scriptPath = path.resolve("scripts/loop/detect-internal-only-pr.mjs");
 
@@ -82,24 +82,27 @@ test("parseCliArgs parses --config", () => {
 });
 
 // ---------------------------------------------------------------------------
+// findRepoRoot
+// ---------------------------------------------------------------------------
+
+test("findRepoRoot returns null when no .git found", () => {
+  assert.equal(findRepoRoot("/tmp/nonexistent-repo-xyz"), null);
+});
+
+// ---------------------------------------------------------------------------
 // Pattern loading
 // ---------------------------------------------------------------------------
 
-test("loadInternalPathPatterns returns shipped defaults when no config found", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
-  try {
-    const patterns = loadInternalPathPatterns(undefined);
-    assert.deepEqual(patterns, SHIPPED_DEFAULT_PATTERNS);
-  } finally {
-    await rm(tempDir, { recursive: true, force: true });
-  }
+test("loadInternalPathPatterns returns shipped defaults when no config found", () => {
+  const patterns = loadInternalPathPatterns(undefined);
+  assert.deepEqual(patterns, SHIPPED_DEFAULT_PATTERNS);
 });
 
-test("loadInternalPathPatterns loads from --config path", async () => {
+test("loadInternalPathPatterns loads flat array from --config path (settings.yaml)", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
   try {
     const configPath = path.join(tempDir, "settings.yaml");
-    await writeFile(configPath, "internalPathPatterns:\n  patterns:\n    - \"^src/\"\n    - \"^lib/\"\n");
+    await writeFile(configPath, "internalPathPatterns:\n  - \"^src/\"\n  - \"^lib/\"\n");
     const patterns = loadInternalPathPatterns(configPath);
     assert.deepEqual(patterns, ["^src/", "^lib/"]);
   } finally {
@@ -119,6 +122,30 @@ test("loadInternalPathPatterns falls back to defaults on invalid config", async 
   }
 });
 
+test("loadInternalPathPatterns falls back to defaults on empty patterns array", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  try {
+    const configPath = path.join(tempDir, "settings.yaml");
+    await writeFile(configPath, "internalPathPatterns: []\n");
+    const patterns = loadInternalPathPatterns(configPath);
+    assert.deepEqual(patterns, SHIPPED_DEFAULT_PATTERNS);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("loadInternalPathPatterns falls back to defaults on whitespace-only patterns", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  try {
+    const configPath = path.join(tempDir, "settings.yaml");
+    await writeFile(configPath, "internalPathPatterns:\n  - \"   \"\n  - \"\"\n");
+    const patterns = loadInternalPathPatterns(configPath);
+    assert.deepEqual(patterns, SHIPPED_DEFAULT_PATTERNS);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("loadInternalPathPatterns skips missing internalPathPatterns key", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
   try {
@@ -126,6 +153,107 @@ test("loadInternalPathPatterns skips missing internalPathPatterns key", async ()
     await writeFile(configPath, "gates:\n  draft:\n    requireCi: false\n");
     const patterns = loadInternalPathPatterns(configPath);
     assert.deepEqual(patterns, SHIPPED_DEFAULT_PATTERNS);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Auto-detect via spawned process (cwd = temp repo)
+// ---------------------------------------------------------------------------
+
+test("loadInternalPathPatterns auto-detects overrides.yaml via spawned process", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  try {
+    await mkdir(path.join(tempDir, ".git"));
+    const piDir = path.join(tempDir, ".pi", "dev-loop");
+    await mkdir(piDir, { recursive: true });
+    await writeFile(path.join(piDir, "overrides.yaml"), "internalPathPatterns:\n  - \"^custom/\"\n  - \"^internal/\"\n");
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files", "--jq", ".files[].path"],
+        stdout: "custom/foo.mjs\ninternal/bar.sh\n",
+      },
+    ]);
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
+    assert.equal(result.code, 0);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.internalOnly, true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("loadInternalPathPatterns prefers settings.yaml over overrides.yaml via spawned process", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  try {
+    await mkdir(path.join(tempDir, ".git"));
+    const piDir = path.join(tempDir, ".pi", "dev-loop");
+    await mkdir(piDir, { recursive: true });
+    await writeFile(path.join(piDir, "overrides.yaml"), "internalPathPatterns:\n  - \"^bad/\"\n");
+    await writeFile(path.join(piDir, "settings.yaml"), "internalPathPatterns:\n  - \"^good/\"\n");
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files", "--jq", ".files[].path"],
+        stdout: "good/foo.mjs\n",
+      },
+    ]);
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
+    assert.equal(result.code, 0);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.internalOnly, true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// tryLoadFromFile unit
+// ---------------------------------------------------------------------------
+
+test("tryLoadFromFile returns patterns from valid config", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  try {
+    const configPath = path.join(tempDir, "settings.yaml");
+    await writeFile(configPath, "internalPathPatterns:\n  - \"^a/\"\n  - \"^b/\"\n");
+    const patterns = tryLoadFromFile(configPath);
+    assert.deepEqual(patterns, ["^a/", "^b/"]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("tryLoadFromFile returns null for invalid YAML", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  try {
+    const configPath = path.join(tempDir, "invalid.yaml");
+    await writeFile(configPath, "::: bad yaml");
+    assert.equal(tryLoadFromFile(configPath), null);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("tryLoadFromFile returns null for empty patterns array", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  try {
+    const configPath = path.join(tempDir, "settings.yaml");
+    await writeFile(configPath, "internalPathPatterns: []\n");
+    assert.equal(tryLoadFromFile(configPath), null);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("tryLoadFromFile trims whitespace from patterns", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  try {
+    const configPath = path.join(tempDir, "settings.yaml");
+    await writeFile(configPath, "internalPathPatterns:\n  - \"  ^src/  \"\n  - \"^lib/\"\n");
+    const patterns = tryLoadFromFile(configPath);
+    assert.deepEqual(patterns, ["^src/", "^lib/"]);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -290,11 +418,11 @@ test("detect-internal-only-pr detects non-matching unknown paths as consumer-fac
   }
 });
 
-test("detect-internal-only-pr respects --config with custom patterns", async () => {
+test("detect-internal-only-pr respects --config with custom patterns (flat array)", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
   try {
     const configPath = path.join(tempDir, "settings.yaml");
-    await writeFile(configPath, "internalPathPatterns:\n  patterns:\n    - \"^custom/\"\n    - \"^tools/\"\n");
+    await writeFile(configPath, "internalPathPatterns:\n  - \"^custom/\"\n  - \"^tools/\"\n");
     const env = await writeGhStub(tempDir, [
       {
         assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files", "--jq", ".files[].path"],
@@ -315,7 +443,7 @@ test("detect-internal-only-pr with --config detects non-matching file as consume
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
   try {
     const configPath = path.join(tempDir, "settings.yaml");
-    await writeFile(configPath, "internalPathPatterns:\n  patterns:\n    - \"^custom/\"\n");
+    await writeFile(configPath, "internalPathPatterns:\n  - \"^custom/\"\n");
     const env = await writeGhStub(tempDir, [
       {
         assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files", "--jq", ".files[].path"],


### PR DESCRIPTION
## Summary

Replace the hardcoded dual-list (`INTERNAL_PATH_PATTERNS` + `CONSUMER_PATH_PATTERNS`) in `detect-internal-only-pr.mjs` with a single configurable whitelist.

**Before:** Two hardcoded lists — an allowlist and a blacklist — coupled to `pi-dev-loops`'s directory structure.

**After:** Single whitelist. If ALL changed files match at least one internal pattern → internal-only → suppress Copilot review. If ANY file doesn't match → NOT internal-only → full Copilot flow. No blacklist needed — a non-matching file is consumer-facing by definition.

## Changes

| File | Change |
|---|---|
| `scripts/loop/detect-internal-only-pr.mjs` | Replace `INTERNAL_PATH_PATTERNS` + `CONSUMER_PATH_PATTERNS` with `loadInternalPathPatterns()` that reads from `.pi/dev-loop/settings.yaml` (with shipped defaults). Add `--config` flag. Remove `isInternalPath`, `isConsumerPath` functions. |
| `packages/core/src/config/config.mjs` | Add `InternalPatternsConfig` schema, built-in defaults, `resolveInternalPathPatterns()` resolver. |
| `.pi/dev-loop/defaults.yaml` | Add `internalPathPatterns` section with shipped defaults for `pi-dev-loops`. |
| `test/loop/detect-internal-only-pr.test.mjs` | Remove `isConsumerPath`/`isInternalPath` unit tests. Add `loadInternalPathPatterns`, `buildPatternMatchers`, `--config` integration tests. |

## Validation

- `npm run verify`: 1286 pass, 1 pre-existing failure (unrelated detect-checkpoint-evidence)
- All 12 detect-internal-only-pr tests pass
- Manual verification of config loading with custom patterns
- Consumer repos override in their `.pi/dev-loop/settings.yaml`:
  ```yaml
  internalPathPatterns:
    patterns:
      - "^tools/"
      - "^internal/"
  ```

Closes #652
