### PR TITLE
fix: Projects helpers match by repo AND number, not repo-only (#650)

### DIFF
--- a/scripts/projects/add-queue-item.mjs
+++ b/scripts/projects/add-queue-item.mjs
@@ -408,7 +408,7 @@ async function main(args, { env = process.env, runChild } = {}) {
 
   const alreadyPresent = existingItems.filter((it) => {
     if (!it.content) return false;
-    return it.content.repository?.nameWithOwner === repo;
+    return it.content.repository?.nameWithOwner === repo && it.content.number === itemNumber;
   });
 
   if (alreadyPresent.length > 0) {

--- a/scripts/projects/move-queue-item.mjs
+++ b/scripts/projects/move-queue-item.mjs
@@ -438,10 +438,14 @@ async function main(args, { env = process.env, runChild } = {}) {
     }, env, child);
     const items = itemsPayload?.data?.node?.items?.nodes ?? [];
 
-    // Filter by matching repo exactly
+    // Filter by matching repo exactly and item number (when known)
     const matchingItems = items.filter((it) => {
       if (!it.content) return false;
-      return it.content.repository?.nameWithOwner === repo;
+      const repoMatch = it.content.repository?.nameWithOwner === repo;
+      if (itemRef.kind === "number") {
+        return repoMatch && it.content.number === itemRef.value;
+      }
+      return repoMatch;
     });
 
     if (matchingItems.length === 0) {


### PR DESCRIPTION
Fixes pre-existing bug where alreadyPresent check and item lookup matched any item from the same repo, ignoring the actual issue/PR number.

Closes #650