### PR TITLE
feat(projects): add --link-repo flag, column auto-repair, settings fallback to ensure-queue-board

### DIFF
--- a/docs/projects-queue-contract.md
+++ b/docs/projects-queue-contract.md
@@ -10,6 +10,11 @@ ordering from a project board and write status transitions back. This contract d
 expected board shape so tooling can rely on deterministic field/column names and fail safely
 when the board is absent or misconfigured.
 
+**The queue board MUST be linked to the target repository** via `linkProjectV2ToRepository`.
+Repo-linked boards travel with the repository, are visible to all collaborators, and appear
+in the repository's Projects tab. User-level (unlinked) projects are not supported for queue
+ordering and must be migrated.
+
 **Board state is an optional scheduling input; it does not replace GitHub issue/PR state as
 the source of truth.** This contract introduces no new local queue file; it complements the
 existing queue mode infrastructure (see Relationship to queue mode below).
@@ -196,6 +201,21 @@ The stderr payload follows the repo's standard CLI error format (`formatCliError
 such as `code` keys or suggested commands live in documentation, not in the structured
 stderr output.
 
+## Column auto-repair
+
+The bootstrap wrapper (`node scripts/projects/ensure-queue-board.mjs`) performs automatic column repair
+when the Status field exists but has non-standard columns. Instead of throwing, it calls
+`updateProjectV2Field` to add missing standard columns (`Backlog`, `Next Up`, `In Progress`,
+`Done`). Non-standard columns are left in place — only missing columns are added.
+
+Auto-repair covers:
+- Status field with a subset of standard columns (e.g. only `Backlog` and `Done`)
+- Status field with entirely non-standard columns (e.g. `Todo`/`Doing`/`Done`)
+- Status field with a mix of standard and non-standard columns
+
+Auto-repair does NOT remove or rename existing columns. Column removal/reordering remains
+a manual operation via the GitHub Projects UI.
+
 ## Configuration shape
 
 Queue board configuration lives under `.pi/dev-loop/settings.yaml`. All keys are optional;
@@ -205,6 +225,12 @@ the queue path works without a board.
 queue:
   # Maximum parallel entries the queue may process concurrently.
   maxParallel: 3
+
+  # GitHub Projects V2 project number for direct lookup (overrides title-based discovery).
+  projectNumber: 1
+
+  # Board title for Projects V2 lookup (used when projectNumber is not set).
+  boardTitle: "Dev Loop Queue"
 
   # Maximum bug issues the queue driver may auto-file in one run.
   maxAutoFiledIssues: 10
@@ -231,6 +257,11 @@ The `queue.boardTitle` key is the sole opt-in signal for Projects-based queue or
 If `boardTitle` is set but the project does not exist, queue operations that depend on board
 ordering fail closed — they do not treat the missing board as equivalent to "not opted in."
 
+### Project number key
+
+The `queue.projectNumber` key provides direct project lookup by number, bypassing title-based
+discovery. When both `projectNumber` and `boardTitle` are set, `projectNumber` takes precedence.
+
 ### Settings precedence
 
 1. `.pi/dev-loop/defaults.yaml` — shipped defaults (does not set `boardTitle`)
@@ -248,6 +279,8 @@ Helpers consume these minimal GraphQL operations:
 | `projectsV2` query (user/org) | List projects by owner, find by title | bootstrap, list, move, add, reorder |
 | `createProjectV2` mutation | Create project board | bootstrap only |
 | `createProjectV2Field` mutation | Create Status field with columns | bootstrap only |
+| `linkProjectV2ToRepository` mutation | Link a project board to a repository | bootstrap only |
+| `updateProjectV2Field` mutation | Add columns to an existing Status field | bootstrap auto-repair only |
 | `fields` query (with `ProjectV2SingleSelectField`) | Read Status field + options | bootstrap, list, move, add |
 | `items` query (with `orderBy` + `filterBy`) | List items in a column by POSITION | list, reorder |
 | `updateProjectV2ItemFieldValue` mutation | Set Status on an item (move between columns) | move |

--- a/docs/projects-queue-contract.md
+++ b/docs/projects-queue-contract.md
@@ -238,15 +238,11 @@ queue:
   # Maximum retry attempts per entry for recoverable failures.
   reDispatchMaxRetries: 1
 
-  # Board title for Projects V2 lookup.
-  # Recommended default title (set explicitly to opt in): "Dev Loop Queue".
-  # Omit or leave unset to not use Projects-based queue ordering.
-  boardTitle: "Dev Loop Queue"
 ```
 
 ### Board title key
 
-The `queue.boardTitle` key is the sole opt-in signal for Projects-based queue ordering:
+The `queue.boardTitle` key is the primary opt-in signal for Projects-based queue ordering (`projectNumber` is also available — see Project number key below):
 
 | Value | Meaning |
 |---|---|

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -78,6 +78,8 @@ const QueueConfig = z.strictObject({
   maxParallel: z.number().int().min(1).max(10).default(3),
   maxAutoFiledIssues: z.number().int().min(0).max(100).default(10),
   reDispatchMaxRetries: z.number().int().min(0).max(10).default(1),
+  projectNumber: z.number().int().positive().optional(),
+  boardTitle: z.string().trim().min(1).optional(),
 });
 
 /** Internal path whitelist for internal-only PR detection — flat array of regex strings */
@@ -151,6 +153,9 @@ export const BUILT_IN_DEFAULTS = Object.freeze({
     maxParallel: 3,
     maxAutoFiledIssues: 10,
     reDispatchMaxRetries: 1,
+    // projectNumber and boardTitle are intentionally absent from defaults
+    // — setting either is an explicit operator opt-in for Projects-based
+    // queue ordering.
   }),
   personas: Object.freeze({}),
   internalPathPatterns: Object.freeze([

--- a/scripts/projects/ensure-queue-board.mjs
+++ b/scripts/projects/ensure-queue-board.mjs
@@ -31,7 +31,7 @@ Exit codes:
 const VALID_ARGS = new Set(["--repo", "--project", "--title", "--link-repo", "--help", "-h"]);
 
 function parseArgs(argv) {
-  const args = { title: "Dev Loop Queue" };
+  const args = {}; // title default applied in runCli after settings fallback
   const consumed = new Set();
   for (let i = 0; i < argv.length; i++) {
     if (consumed.has(i)) continue;
@@ -55,14 +55,14 @@ function parseArgs(argv) {
       if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
         throw Object.assign(
           new Error("--project requires a numeric value"),
-          { code: "INVALID_REPO", usage: USAGE },
+          { code: "INVALID_PROJECT", usage: USAGE },
         );
       }
       const num = Number(argv[++i]);
       if (!Number.isInteger(num) || num <= 0) {
         throw Object.assign(
           new Error(`--project must be a positive integer, got "${argv[i]}"`),
-          { code: "INVALID_REPO", usage: USAGE },
+          { code: "INVALID_PROJECT", usage: USAGE },
         );
       }
       args.project = num;
@@ -477,8 +477,7 @@ async function autoRepairColumns(
 // ── Exit code classification ────────────────────────────────────────────
 
 function classifyExitCode(err) {
-  if (err.code === "INVALID_REPO") return 1;
-  if (err.code === "MISSING_COLUMNS") return 3;
+  if (err.code === "INVALID_REPO" || err.code === "INVALID_PROJECT") return 1;
   return 2;
 }
 
@@ -488,16 +487,27 @@ async function main(args, { env = process.env, runChild } = {}) {
   const child = runChild ?? _runChild;
   const repo = validateRepo(args.repo);
   const [owner] = repo.split("/");
-  const title = args.title || "Dev Loop Queue";
+  const title = args.title || "Dev Loop Queue"; // explicit default after settings fallback in runCli
   const linkRepo = args.linkRepo || null;
   if (linkRepo) validateRepo(linkRepo); // validate format early
 
   // 1. Resolve owner (user or org)
   const { id: ownerId, kind: ownerKind } = await resolveOwner(owner, env, child);
 
-  // 2. Look for existing project by title (paginated)
+  // 2. Look for existing project
   const projects = await listAllProjects(owner, ownerKind, env, child);
-  let project = projects.find((p) => p.title === title);
+  let project;
+  if (args.project) {
+    project = projects.find((p) => p.number === args.project);
+    if (!project) {
+      throw Object.assign(
+        new Error(`Project #${args.project} not found under "${owner}". Use --title to create a new board.`),
+        { code: "PROJECT_NOT_FOUND" },
+      );
+    }
+  } else {
+    project = projects.find((p) => p.title === title);
+  }
 
   if (project) {
     // Project exists — verify Status field (paginated)
@@ -649,14 +659,13 @@ async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, 
     return;
   }
 
-  // Settings-based fallback for --project
-  if (args.project === undefined) {
-    const settings = resolveSettings(cwd);
-    if (settings?.project) {
-      args.project = settings.project;
-    } else if (settings?.title) {
-      args.title = args.title || settings.title;
-    }
+  // Settings-based fallback for --project and --title
+  const settings = resolveSettings(cwd);
+  if (args.project === undefined && settings?.project) {
+    args.project = settings.project;
+  }
+  if (args.title === undefined && settings?.title) {
+    args.title = settings.title;
   }
 
   try {

--- a/scripts/projects/ensure-queue-board.mjs
+++ b/scripts/projects/ensure-queue-board.mjs
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { parse as parseYaml } from "yaml";
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
 
-const USAGE = `Usage: node scripts/projects/ensure-queue-board.mjs --repo <owner/name> [--title <title>]
+const USAGE = `Usage: node scripts/projects/ensure-queue-board.mjs --repo <owner/name> [--project <number>] [--title <title>] [--link-repo <owner/name>]
 
 Idempotent bootstrap for a GitHub Projects V2 board used as the dev-loop queue.
 
@@ -10,8 +13,13 @@ Creates the project board if it doesn't exist, ensures a Status field with
 standard columns (Backlog, Next Up, In Progress, Done). Exits clean if the
 board and Status field already exist.
 
+When --link-repo is provided, links the project to the given repository after creation.
+
+When --project is not provided, resolves from .pi/dev-loop/settings.yaml
+queue.projectNumber or queue.boardTitle.
+
 Output (stdout):
-  JSON: { ok: true, project: { id, number, title, url, statusFieldId } }
+  JSON: { ok: true, project: { id, number, title, url, statusFieldId, linkedRepo } }
 
 Exit codes:
   0 — board exists or was created successfully (idempotent)
@@ -20,7 +28,7 @@ Exit codes:
   3 — board schema/config mismatch (manual reconciliation needed)
 `;
 
-const VALID_ARGS = new Set(["--repo", "--title", "--help", "-h"]);
+const VALID_ARGS = new Set(["--repo", "--project", "--title", "--link-repo", "--help", "-h"]);
 
 function parseArgs(argv) {
   const args = { title: "Dev Loop Queue" };
@@ -43,6 +51,21 @@ function parseArgs(argv) {
       }
       args.repo = argv[++i];
       consumed.add(i);
+    } else if (arg === "--project") {
+      if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
+        throw Object.assign(
+          new Error("--project requires a numeric value"),
+          { code: "INVALID_REPO", usage: USAGE },
+        );
+      }
+      const num = Number(argv[++i]);
+      if (!Number.isInteger(num) || num <= 0) {
+        throw Object.assign(
+          new Error(`--project must be a positive integer, got "${argv[i]}"`),
+          { code: "INVALID_REPO", usage: USAGE },
+        );
+      }
+      args.project = num;
     } else if (arg === "--title") {
       if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
         throw Object.assign(
@@ -51,6 +74,15 @@ function parseArgs(argv) {
         );
       }
       args.title = argv[++i];
+      consumed.add(i);
+    } else if (arg === "--link-repo") {
+      if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
+        throw Object.assign(
+          new Error("--link-repo requires a value (owner/name)"),
+          { code: "INVALID_REPO", usage: USAGE },
+        );
+      }
+      args.linkRepo = argv[++i];
       consumed.add(i);
     } else if (arg === "--help" || arg === "-h") {
       args.help = true;
@@ -68,8 +100,6 @@ function parseArgs(argv) {
 
 // GitHub slug rules: owner 1-39 chars (alnum/dash, no leading/trailing dash,
 // no consecutive dashes); repo name similar but also allows dots/underscores.
-// no leading/trailing dash, no consecutive dashes.
-// Single-char owner/repo names are valid (e.g. a/b).
 const OWNER_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
 const REPO_NAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9_.-]*[a-zA-Z0-9])?$/;
 
@@ -106,6 +136,28 @@ function validateRepo(repo) {
     );
   }
   return repo;
+}
+
+// ── Settings fallback ────────────────────────────────────────────────────
+
+function resolveSettings(cwd) {
+  try {
+    const settingsPath = path.join(cwd, ".pi", "dev-loop", "settings.yaml");
+    const raw = readFileSync(settingsPath, "utf-8");
+    const settings = parseYaml(raw);
+    const queue = settings?.queue;
+    if (queue) {
+      if (typeof queue.projectNumber === "number" && Number.isInteger(queue.projectNumber) && queue.projectNumber > 0) {
+        return { project: queue.projectNumber };
+      }
+      if (typeof queue.boardTitle === "string" && queue.boardTitle.trim().length > 0) {
+        return { title: queue.boardTitle.trim() };
+      }
+    }
+  } catch {
+    // settings file missing or unparseable — no fallback
+  }
+  return null;
 }
 
 // ── API helpers ──────────────────────────────────────────────────────────
@@ -246,6 +298,39 @@ const CREATE_SINGLE_SELECT_FIELD = [
   "}"
 ].join("\n");
 
+const LINK_PROJECT_TO_REPO = [
+  "mutation($projectId:ID!, $repositoryId:ID!) {",
+  "  linkProjectV2ToRepository(input:{projectId:$projectId, repositoryId:$repositoryId}) {",
+  "    clientMutationId",
+  "  }",
+  "}"
+].join("\n");
+
+const UPDATE_PROJECT_FIELD = [
+  "mutation($fieldId:ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]!) {",
+  "  updateProjectV2Field(input:{fieldId:$fieldId, singleSelectOptions:$options}) {",
+  "    projectV2Field {",
+  "      ... on ProjectV2SingleSelectField {",
+  "        id",
+  "        name",
+  "        options {",
+  "          id",
+  "          name",
+  "        }",
+  "      }",
+  "    }",
+  "  }",
+  "}"
+].join("\n");
+
+const GET_REPO_ID = [
+  "query($owner:String!, $name:String!) {",
+  "  repository(owner:$owner, name:$name) {",
+  "    id",
+  "  }",
+  "}"
+].join("\n");
+
 // ── Owner resolution ────────────────────────────────────────────────────
 
 async function resolveOwner(login, env, runChild) {
@@ -263,6 +348,20 @@ async function resolveOwner(login, env, runChild) {
     new Error(`Could not resolve owner ID for "${login}" (not a user or organization)`),
     { code: "NO_USER_ID" },
   );
+}
+
+// ── Repository ID resolution ─────────────────────────────────────────────
+
+async function resolveRepoId(slug, env, runChild) {
+  const [owner, name] = slug.split("/");
+  const payload = await ghGraphql(GET_REPO_ID, { owner, name }, env, runChild);
+  if (!payload?.data?.repository?.id) {
+    throw Object.assign(
+      new Error(`Could not resolve repository ID for "${slug}"`),
+      { code: "NO_REPO_ID" },
+    );
+  }
+  return payload.data.repository.id;
 }
 
 // ── Paginated project listing ────────────────────────────────────────────
@@ -318,6 +417,63 @@ async function listAllFields(projectId, env, runChild) {
   return fields;
 }
 
+// ── Column auto-repair ───────────────────────────────────────────────────
+
+const STANDARD_COLUMNS = [
+  { name: "Backlog", color: "GRAY", description: "" },
+  { name: "Next Up", color: "BLUE", description: "" },
+  { name: "In Progress", color: "YELLOW", description: "" },
+  { name: "Done", color: "GREEN", description: "" },
+];
+
+const STANDARD_COLUMN_NAMES = STANDARD_COLUMNS.map((c) => c.name);
+
+/**
+ * Auto-repair a Status field that is missing standard columns.
+ *
+ * Calls updateProjectV2Field to add missing columns while preserving
+ * any existing (non-standard) columns in their current order.
+ *
+ * Returns the updated field options (with IDs from the mutation response).
+ */
+async function autoRepairColumns(
+  fieldId,
+  existingOptions,
+  env,
+  runChild,
+) {
+  const existingNames = new Set(existingOptions.map((o) => o.name));
+  const missingColumns = STANDARD_COLUMNS.filter(
+    (c) => !existingNames.has(c.name),
+  );
+
+  if (missingColumns.length === 0) {
+    // Nothing to repair — should not be called in this case
+    return existingOptions;
+  }
+
+  // Build full option list: existing options + missing standard columns appended
+  const fullOptions = [
+    ...existingOptions.map((o) => ({ name: o.name, color: o.color ?? "GRAY", description: o.description ?? "" })),
+    ...missingColumns,
+  ];
+
+  const payload = await ghGraphql(UPDATE_PROJECT_FIELD, {
+    fieldId,
+    options: JSON.stringify(fullOptions),
+  }, env, runChild);
+
+  const updatedField = payload?.data?.updateProjectV2Field?.projectV2Field;
+  if (!updatedField) {
+    throw Object.assign(
+      new Error("Failed to update Status field with missing columns"),
+      { code: "UPDATE_FIELD_FAILED" },
+    );
+  }
+
+  return updatedField.options ?? fullOptions;
+}
+
 // ── Exit code classification ────────────────────────────────────────────
 
 function classifyExitCode(err) {
@@ -333,6 +489,8 @@ async function main(args, { env = process.env, runChild } = {}) {
   const repo = validateRepo(args.repo);
   const [owner] = repo.split("/");
   const title = args.title || "Dev Loop Queue";
+  const linkRepo = args.linkRepo || null;
+  if (linkRepo) validateRepo(linkRepo); // validate format early
 
   // 1. Resolve owner (user or org)
   const { id: ownerId, kind: ownerKind } = await resolveOwner(owner, env, child);
@@ -348,11 +506,20 @@ async function main(args, { env = process.env, runChild } = {}) {
       (f) => f.name === "Status" && f.options,
     );
 
-    const expectedColumns = ["Backlog", "Next Up", "In Progress", "Done"];
     const existingColumns = statusField?.options?.map((o) => o.name) ?? [];
-    const missingColumns = expectedColumns.filter((c) => !existingColumns.includes(c));
+    const missingColumns = STANDARD_COLUMN_NAMES.filter((c) => !existingColumns.includes(c));
 
     if (statusField && missingColumns.length === 0) {
+      // All columns present — check repo link if requested
+      let linkedRepo = null;
+      if (linkRepo) {
+        const repoId = await resolveRepoId(linkRepo, env, child);
+        await ghGraphql(LINK_PROJECT_TO_REPO, {
+          projectId: project.id,
+          repositoryId: repoId,
+        }, env, child);
+        linkedRepo = linkRepo;
+      }
       return {
         ok: true,
         project: {
@@ -361,18 +528,35 @@ async function main(args, { env = process.env, runChild } = {}) {
           title: project.title,
           url: project.url,
           statusFieldId: statusField.id,
+          ...(linkedRepo ? { linkedRepo } : {}),
         },
       };
     }
 
     if (statusField) {
-      throw Object.assign(
-        new Error(
-          `Project "${title}" (number ${project.number}) exists but Status field missing columns: ${missingColumns.join(", ")}. ` +
-          "Add missing columns via GitHub UI or reconcile manually.",
-        ),
-        { code: "MISSING_COLUMNS" },
-      );
+      // Auto-repair: add missing columns instead of throwing
+      await autoRepairColumns(statusField.id, statusField.options, env, child);
+
+      let linkedRepo = null;
+      if (linkRepo) {
+        const repoId = await resolveRepoId(linkRepo, env, child);
+        await ghGraphql(LINK_PROJECT_TO_REPO, {
+          projectId: project.id,
+          repositoryId: repoId,
+        }, env, child);
+        linkedRepo = linkRepo;
+      }
+      return {
+        ok: true,
+        project: {
+          id: project.id,
+          number: project.number,
+          title: project.title,
+          url: project.url,
+          statusFieldId: statusField.id,
+          ...(linkedRepo ? { linkedRepo } : {}),
+        },
+      };
     }
 
     // No Status field — create it
@@ -383,6 +567,16 @@ async function main(args, { env = process.env, runChild } = {}) {
     if (!newField) {
       throw Object.assign(new Error("Failed to create Status field"), { code: "CREATE_FIELD_FAILED" });
     }
+
+    let linkedRepo = null;
+    if (linkRepo) {
+      const repoId = await resolveRepoId(linkRepo, env, child);
+      await ghGraphql(LINK_PROJECT_TO_REPO, {
+        projectId: project.id,
+        repositoryId: repoId,
+      }, env, child);
+      linkedRepo = linkRepo;
+    }
     return {
       ok: true,
       project: {
@@ -391,6 +585,7 @@ async function main(args, { env = process.env, runChild } = {}) {
         title: project.title,
         url: project.url,
         statusFieldId: newField.id,
+        ...(linkedRepo ? { linkedRepo } : {}),
       },
     };
   }
@@ -405,7 +600,18 @@ async function main(args, { env = process.env, runChild } = {}) {
     throw Object.assign(new Error("Failed to create project board"), { code: "CREATE_PROJECT_FAILED" });
   }
 
-  // 4. Create Status field on new project
+  // 4. Link to repo if --link-repo provided
+  let linkedRepo = null;
+  if (linkRepo) {
+    const repoId = await resolveRepoId(linkRepo, env, child);
+    await ghGraphql(LINK_PROJECT_TO_REPO, {
+      projectId: project.id,
+      repositoryId: repoId,
+    }, env, child);
+    linkedRepo = linkRepo;
+  }
+
+  // 5. Create Status field on new project
   const createFieldPayload = await ghGraphql(CREATE_SINGLE_SELECT_FIELD, {
     projectId: project.id,
   }, env, child);
@@ -422,13 +628,14 @@ async function main(args, { env = process.env, runChild } = {}) {
       title: project.title,
       url: project.url,
       statusFieldId: newField.id,
+      ...(linkedRepo ? { linkedRepo } : {}),
     },
   };
 }
 
 // ── CLI entrypoint ──────────────────────────────────────────────────────
 
-async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, env = process.env } = {}) {
+async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, env = process.env, cwd = process.cwd() } = {}) {
   let args;
   try {
     args = parseArgs(argv);
@@ -441,6 +648,17 @@ async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, 
     stdout.write(USAGE);
     return;
   }
+
+  // Settings-based fallback for --project
+  if (args.project === undefined) {
+    const settings = resolveSettings(cwd);
+    if (settings?.project) {
+      args.project = settings.project;
+    } else if (settings?.title) {
+      args.title = args.title || settings.title;
+    }
+  }
+
   try {
     const result = await main(args, { env });
     stdout.write(JSON.stringify(result) + "\n");
@@ -457,4 +675,4 @@ if (isDirectCliRun(import.meta.url)) {
   });
 }
 
-export { main };
+export { main, autoRepairColumns, resolveSettings, STANDARD_COLUMNS, STANDARD_COLUMN_NAMES };

--- a/test/projects/ensure-queue-board.test.mjs
+++ b/test/projects/ensure-queue-board.test.mjs
@@ -1,5 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
 import { main, autoRepairColumns, resolveSettings, STANDARD_COLUMNS, STANDARD_COLUMN_NAMES } from "../../scripts/projects/ensure-queue-board.mjs";
 
 // ── Helpers ─────────────────────────────────────────────────────────────
@@ -204,6 +206,39 @@ describe("ensure-queue-board", () => {
       );
       assert.equal(result.ok, true);
       assert.equal(result.project.title, "My Queue");
+    });
+  });
+
+
+  describe("--project lookup", () => {
+    it("finds project by number when --project is provided", async () => {
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([STATUS_FIELD]) },
+      ];
+      const result = await main(
+        { repo: "mfittko/pi-dev-loops", project: 1 },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.project.number, 1);
+    });
+
+    it("throws PROJECT_NOT_FOUND when --project number does not match any project", async () => {
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      ];
+      try {
+        await main(
+          { repo: "mfittko/pi-dev-loops", project: 999 },
+          { env: {}, runChild: mockRunChild(responses) },
+        );
+        assert.fail("should have thrown");
+      } catch (err) {
+        assert.equal(err.code, "PROJECT_NOT_FOUND");
+      }
     });
   });
 
@@ -543,13 +578,46 @@ describe("ensure-queue-board", () => {
     });
   });
 
-  describe("resolveSettings", () => {
-    it("returns project number when queue.projectNumber is set", () => {
-      // resolveSettings reads from cwd, so we test the function shape only
-      // Integration test would need temp directory with settings.yaml
-      assert.equal(typeof resolveSettings, "function");
+
+  describe("resolveSettings integration", () => {
+    it("returns project number from settings.yaml", () => {
+      const tmp = mkdtempSync(path.join(import.meta.dirname || "/tmp", "settings-test-"));
+      try {
+        mkdirSync(path.join(tmp, ".pi", "dev-loop"), { recursive: true });
+        writeFileSync(path.join(tmp, ".pi", "dev-loop", "settings.yaml"), [
+          "version: 1",
+          "queue:",
+          "  projectNumber: 42",
+        ].join("\n"));
+        const result = resolveSettings(tmp);
+        assert.deepEqual(result, { project: 42 });
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it("returns title from settings when projectNumber is absent", () => {
+      const tmp = mkdtempSync(path.join(import.meta.dirname || "/tmp", "settings-test-"));
+      try {
+        mkdirSync(path.join(tmp, ".pi", "dev-loop"), { recursive: true });
+        writeFileSync(path.join(tmp, ".pi", "dev-loop", "settings.yaml"), [
+          "version: 1",
+          "queue:",
+          "  boardTitle: My Board",
+        ].join("\n"));
+        const result = resolveSettings(tmp);
+        assert.deepEqual(result, { title: "My Board" });
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it("returns null when settings file is missing", () => {
+      const result = resolveSettings("/nonexistent/path/xyz");
+      assert.equal(result, null);
     });
   });
+
 
   describe("STANDARD_COLUMNS", () => {
     it("has exactly 4 standard columns in correct order", () => {

--- a/test/projects/ensure-queue-board.test.mjs
+++ b/test/projects/ensure-queue-board.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { main } from "../../scripts/projects/ensure-queue-board.mjs";
+import { main, autoRepairColumns, resolveSettings, STANDARD_COLUMNS, STANDARD_COLUMN_NAMES } from "../../scripts/projects/ensure-queue-board.mjs";
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
@@ -34,6 +34,10 @@ function noUserPayload() {
 
 function noOrgPayload() {
   return { data: { organization: null } };
+}
+
+function repoIdPayload() {
+  return { data: { repository: { id: "R_kgDOABC456" } } };
 }
 
 function listUserProjectsResponse(projects) {
@@ -77,6 +81,31 @@ function createProjectResponse(project) {
 function createFieldResponse(field) {
   return {
     data: { createProjectV2Field: { projectV2Field: field } },
+  };
+}
+
+function linkRepoResponse() {
+  return {
+    data: { linkProjectV2ToRepository: { clientMutationId: null } },
+  };
+}
+
+function updateFieldResponse(options) {
+  return {
+    data: {
+      updateProjectV2Field: {
+        projectV2Field: {
+          id: "PVTSSF_updated",
+          name: "Status",
+          options: options ?? [
+            { id: "opt1", name: "Backlog", color: "GRAY" },
+            { id: "opt2", name: "Next Up", color: "BLUE" },
+            { id: "opt3", name: "In Progress", color: "YELLOW" },
+            { id: "opt4", name: "Done", color: "GREEN" },
+          ],
+        },
+      },
+    },
   };
 }
 
@@ -178,6 +207,196 @@ describe("ensure-queue-board", () => {
     });
   });
 
+  describe("--link-repo", () => {
+    it("links new project to repo after creation", async () => {
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([]) },
+        {
+          payload: createProjectResponse({
+            id: "PVT_new",
+            number: 2,
+            title: "Dev Loop Queue",
+            url: "https://github.com/users/mfittko/projects/2",
+          }),
+        },
+        { payload: repoIdPayload() },
+        { payload: linkRepoResponse() },
+        {
+          payload: createFieldResponse({ id: "PVTSSF_new", name: "Status" }),
+        },
+      ];
+      const result = await main(
+        { repo: "mfittko/pi-dev-loops", linkRepo: "mfittko/pi-dev-loops" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.project.linkedRepo, "mfittko/pi-dev-loops");
+      assert.equal(result.project.statusFieldId, "PVTSSF_new");
+    });
+
+    it("links existing project to repo", async () => {
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([STATUS_FIELD]) },
+        { payload: repoIdPayload() },
+        { payload: linkRepoResponse() },
+      ];
+      const result = await main(
+        { repo: "mfittko/pi-dev-loops", linkRepo: "mfittko/pi-dev-loops" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.project.linkedRepo, "mfittko/pi-dev-loops");
+    });
+
+    it("validates link-repo format", async () => {
+      await assert.rejects(
+        () => main({
+          repo: "mfittko/pi-dev-loops",
+          linkRepo: "not-a-repo",
+        }),
+        /owner\/name/,
+      );
+    });
+  });
+
+  describe("column auto-repair", () => {
+    it("auto-repairs missing columns instead of throwing", async () => {
+      const partialField = {
+        id: "PVTSSF_partial", name: "Status",
+        options: [
+          { id: "opt1", name: "Backlog", color: "GRAY" },
+        ],
+      };
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([partialField]) },
+        { payload: updateFieldResponse() },
+      ];
+      const result = await main(
+        { repo: "mfittko/pi-dev-loops" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.project.statusFieldId, "PVTSSF_partial");
+    });
+
+    it("auto-repairs completely non-standard columns", async () => {
+      const nonStandardField = {
+        id: "PVTSSF_nonstd", name: "Status",
+        options: [
+          { id: "opt1", name: "Todo", color: "RED" },
+          { id: "opt2", name: "Doing", color: "YELLOW" },
+          { id: "opt3", name: "Done", color: "GREEN" },
+        ],
+      };
+      const expectedOptions = [
+        { id: "opt1", name: "Todo", color: "RED" },
+        { id: "opt2", name: "Doing", color: "YELLOW" },
+        { id: "opt3", name: "Done", color: "GREEN" },
+        { id: "new1", name: "Backlog", color: "GRAY" },
+        { id: "new2", name: "Next Up", color: "BLUE" },
+        { id: "new3", name: "In Progress", color: "YELLOW" },
+      ];
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([nonStandardField]) },
+        { payload: updateFieldResponse(expectedOptions) },
+      ];
+      const result = await main(
+        { repo: "mfittko/pi-dev-loops" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.project.statusFieldId, "PVTSSF_nonstd");
+    });
+
+    it("auto-repairs existing status field and links repo together", async () => {
+      const partialField = {
+        id: "PVTSSF_partial", name: "Status",
+        options: [
+          { id: "opt1", name: "In Progress", color: "YELLOW" },
+          { id: "opt2", name: "Done", color: "GREEN" },
+        ],
+      };
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([partialField]) },
+        { payload: updateFieldResponse() },
+        { payload: repoIdPayload() },
+        { payload: linkRepoResponse() },
+      ];
+      const result = await main(
+        { repo: "mfittko/pi-dev-loops", linkRepo: "mfittko/pi-dev-loops" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.project.statusFieldId, "PVTSSF_partial");
+      assert.equal(result.project.linkedRepo, "mfittko/pi-dev-loops");
+    });
+  });
+
+  describe("autoRepairColumns unit", () => {
+    it("appends missing standard columns to existing options", async () => {
+      const existing = [
+        { id: "a", name: "Backlog", color: "GRAY" },
+      ];
+      const updatedOpts = [
+        { id: "a", name: "Backlog", color: "GRAY" },
+        { id: "n1", name: "Next Up", color: "BLUE" },
+        { id: "n2", name: "In Progress", color: "YELLOW" },
+        { id: "n3", name: "Done", color: "GREEN" },
+      ];
+      const responses = [
+        { payload: updateFieldResponse(updatedOpts) },
+      ];
+      const result = await autoRepairColumns(
+        "fieldId", existing, {}, mockRunChild(responses),
+      );
+      assert.equal(result.length, 4);
+      assert.deepEqual(result.map((o) => o.name), STANDARD_COLUMN_NAMES);
+    });
+
+    it("preserves non-standard columns when adding missing ones", async () => {
+      const existing = [
+        { id: "a", name: "Custom Column", color: "RED" },
+      ];
+      const updatedOpts = [
+        { id: "a", name: "Custom Column", color: "RED" },
+        { id: "n1", name: "Backlog", color: "GRAY" },
+        { id: "n2", name: "Next Up", color: "BLUE" },
+        { id: "n3", name: "In Progress", color: "YELLOW" },
+        { id: "n4", name: "Done", color: "GREEN" },
+      ];
+      const responses = [
+        { payload: updateFieldResponse(updatedOpts) },
+      ];
+      const result = await autoRepairColumns(
+        "fieldId", existing, {}, mockRunChild(responses),
+      );
+      assert.equal(result.length, 5);
+      assert.equal(result[0].name, "Custom Column");
+    });
+
+    it("no-ops when all standard columns are present", async () => {
+      const existing = STANDARD_COLUMNS.map((c, i) => ({
+        id: `opt${i}`, name: c.name, color: c.color,
+      }));
+      // Should not call gh at all — returns existing options directly
+      const result = await autoRepairColumns(
+        "fieldId", existing, {}, () => {
+          throw new Error("should not be called");
+        },
+      );
+      assert.equal(result, existing);
+    });
+  });
+
   describe("already-exists path", () => {
     it("returns existing project when board and Status field exist", async () => {
       const responses = [
@@ -211,22 +430,6 @@ describe("ensure-queue-board", () => {
       );
       assert.equal(result.ok, true);
       assert.equal(result.project.statusFieldId, "PVTSSF_new");
-    });
-
-    it("throws on missing columns in existing Status field", async () => {
-      const partialField = {
-        id: "PVTSSF_partial", name: "Status",
-        options: [{ id: "opt1", name: "Backlog" }],
-      };
-      const responses = [
-        { payload: userPayload() },
-        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
-        { payload: getFieldsResponse([partialField]) },
-      ];
-      await assert.rejects(
-        () => main({ repo: "mfittko/pi-dev-loops" }, { env: {}, runChild: mockRunChild(responses) }),
-        /missing columns/,
-      );
     });
 
     it("handles paginated project listing (>50 projects)", async () => {
@@ -313,25 +516,45 @@ describe("ensure-queue-board", () => {
         /Could not resolve owner ID/,
       );
     });
-  });
 
-  describe("exit code classification", () => {
-    it("MISSING_COLUMNS error has code MISSING_COLUMNS", async () => {
-      const partialField = {
-        id: "PVTSSF_partial", name: "Status",
-        options: [{ id: "opt1", name: "Backlog" }],
-      };
+    it("throws when --link-repo has unresolvable repository", async () => {
       const responses = [
         { payload: userPayload() },
-        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
-        { payload: getFieldsResponse([partialField]) },
+        { payload: listUserProjectsResponse([]) },
+        {
+          payload: createProjectResponse({
+            id: "PVT_new",
+            number: 2,
+            title: "Dev Loop Queue",
+            url: "https://github.com/users/mfittko/projects/2",
+          }),
+        },
+        {
+          payload: { data: { repository: null } },
+        },
       ];
-      try {
-        await main({ repo: "mfittko/pi-dev-loops" }, { env: {}, runChild: mockRunChild(responses) });
-        assert.fail("should have thrown");
-      } catch (err) {
-        assert.equal(err.code, "MISSING_COLUMNS");
-      }
+      await assert.rejects(
+        () => main(
+          { repo: "mfittko/pi-dev-loops", linkRepo: "nonexistent/repo" },
+          { env: {}, runChild: mockRunChild(responses) },
+        ),
+        /Could not resolve repository ID/,
+      );
+    });
+  });
+
+  describe("resolveSettings", () => {
+    it("returns project number when queue.projectNumber is set", () => {
+      // resolveSettings reads from cwd, so we test the function shape only
+      // Integration test would need temp directory with settings.yaml
+      assert.equal(typeof resolveSettings, "function");
+    });
+  });
+
+  describe("STANDARD_COLUMNS", () => {
+    it("has exactly 4 standard columns in correct order", () => {
+      assert.equal(STANDARD_COLUMNS.length, 4);
+      assert.deepEqual(STANDARD_COLUMN_NAMES, ["Backlog", "Next Up", "In Progress", "Done"]);
     });
   });
 });


### PR DESCRIPTION
## Summary

Implements #653: adds `--link-repo` flag, column auto-repair, and settings-based project detection to `ensure-queue-board.mjs`.

## Changes

### 1. `--link-repo` flag
- New `--link-repo <owner/name>` flag calls `linkProjectV2ToRepository` mutation after project creation or when operating on an existing project
- Added `resolveRepoId()` helper and `LINK_PROJECT_TO_REPO` GraphQL mutation
- Output includes `linkedRepo` field when linking is performed

### 2. Column auto-repair
- Replaced `MISSING_COLUMNS` throw with automatic `updateProjectV2Field` repair
- `autoRepairColumns()` appends missing standard columns (Backlog/Next Up/In Progress/Done) while preserving non-standard columns in-place
- No-op when all standard columns are already present

### 3. Settings-based project detection
- Added `--project <number>` flag for direct project lookup by number
- Added `resolveSettings()` function that reads `.pi/dev-loop/settings.yaml` and falls back to `queue.projectNumber` or `queue.boardTitle`
- Added `projectNumber` and `boardTitle` optional fields to `QueueConfig` schema

### 4. Contract doc updates
- Requires repo-linked boards (not user-level) for queue ordering
- Documents column auto-repair behavior
- Adds `projectNumber` key documentation
- Adds `linkProjectV2ToRepository` and `updateProjectV2Field` to GraphQL operations table

### Files touched
- `docs/projects-queue-contract.md`: repo-link requirement, auto-repair section, projectNumber, new ops
- `packages/core/src/config/config.mjs`: QueueConfig extended with projectNumber/boardTitle
- `scripts/projects/ensure-queue-board.mjs`: main implementation
- `test/projects/ensure-queue-board.test.mjs`: 25 tests covering new and existing behavior

## Validation
- `npm run verify`: all tests pass (1 pre-existing flaky test in detect-checkpoint-evidence unrelated)
- `npm run test:scripts`: 1306 pass / 0 fail (36 skipped)
- `npm run test:core`: 1286 pass
- `npm run test:docs`: 70 files / 352 links OK

Closes #653