### PR TITLE
feat: define main-agent delegation contract (#660)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Canonical workflow docs live under `skills/docs/`.
 
 ## Working rules
+- Main agent: read-only for all repo files. All mutations flow through `dev-loop` async subagent. Load `skills/docs/main-agent-contract.md`.
 - No direct commits to `main`; use feature branches, worktrees, and PRs.
 - Use `tmp/worktrees/<issue-or-branch-slug>/` for mutating local work; keep the main checkout for inspection.
 - Always run `git fetch origin` before creating or reusing a worktree — never create from a stale `origin/main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - Canonical workflow docs live under `skills/docs/`.
 
 ## Working rules
-- Main agent: read-only for all files tracked by the repository. All mutations flow through `dev-loop` async subagent. Load `skills/docs/main-agent-contract.md`.
+- Main agent: read-only for all files tracked by the repository. All mutations flow through `dev-loop` async subagent. `skills/docs/main-agent-contract.md` is a mandatory baseline read alongside AGENTS.md (intentional exception to requiredReads-only loading for routed work; it defines the absolute delegation boundary that applies in all sessions).
 - No direct commits to `main`; use feature branches, worktrees, and PRs.
 - Use `tmp/worktrees/<issue-or-branch-slug>/` for mutating local work; keep the main checkout for inspection.
 - Always run `git fetch origin` before creating or reusing a worktree — never create from a stale `origin/main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - Canonical workflow docs live under `skills/docs/`.
 
 ## Working rules
-- Main agent: read-only for all repo files. All mutations flow through `dev-loop` async subagent. Load `skills/docs/main-agent-contract.md`.
+- Main agent: read-only for all files tracked by the repository. All mutations flow through `dev-loop` async subagent. Load `skills/docs/main-agent-contract.md`.
 - No direct commits to `main`; use feature branches, worktrees, and PRs.
 - Use `tmp/worktrees/<issue-or-branch-slug>/` for mutating local work; keep the main checkout for inspection.
 - Always run `git fetch origin` before creating or reusing a worktree — never create from a stale `origin/main`.

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -140,6 +140,7 @@ PR #578 (docs-only, 2 files) was merged without gate checks and serves as the br
 ## Authority boundary and stop rules
 
 - Source code, tests, config, CI, and shared contract docs are authoritative.
+- Main-agent delegation contract: [Main Agent Contract](../docs/main-agent-contract.md) — absolute read-only boundary; all mutations flow through `dev-loop` async subagent.
 - This dispatcher summarizes the public routing contract; it does not redefine the shipped runtime semantics of helper CLIs, shared loop logic, or extension commands.
 - Keep specialized Copilot behavior internal behind `dev-loop`; do not expose internal route packs as peer public workflow entrypoints.
 - Before any state-changing action, get explicit confirmation unless the latest user message already clearly authorizes that exact action.

--- a/skills/docs/main-agent-contract.md
+++ b/skills/docs/main-agent-contract.md
@@ -28,7 +28,7 @@ because "the user said yes," not because it is running from a worktree.
 
 - `write`, `edit`, or delete any file tracked by the repo
 - `git commit`, `git push`, create branches, create worktrees
-- Run state-changing dev-loop subcommands (`gate`, `loop outer`, `pr` commands — those belong inside `dev-loop`). Read-only `loop startup` resolver runs are allowed.
+- Run state-changing dev-loops CLI subcommands (`gate`, `loop outer`, `pr` commands — those belong inside `dev-loop`). Read-only `loop startup` resolver runs are allowed.
 - Delegate implementation to any agent other than `dev-loop`
 
 ## Dev-loop agent (async) owns

--- a/skills/docs/main-agent-contract.md
+++ b/skills/docs/main-agent-contract.md
@@ -28,7 +28,7 @@ because "the user said yes," not because it is running from a worktree.
 
 - `write`, `edit`, or delete any file tracked by the repo
 - `git commit`, `git push`, create branches, create worktrees
-- Run state-changing dev-loops CLI subcommands (`gate`, `loop outer`, `pr` commands — those belong inside `dev-loop`). Read-only `loop startup` resolver runs are allowed.
+- Run state-changing dev-loops CLI subcommands (`gate`, any state-changing `loop` subcommand, `pr` commands — those belong inside `dev-loop`). Read-only `loop startup` resolver runs are allowed.
 - Delegate implementation to any agent other than `dev-loop`
 
 ## Dev-loop agent (async) owns
@@ -42,7 +42,7 @@ because "the user said yes," not because it is running from a worktree.
 
 | Operation | Verdict |
 |---|---|
-| `gh issue create --title "..." --body "..."` | Allowed — mutates GitHub, not repo files |
+| `gh issue create --title "..." --body "..."` | Allowed — mutates GitHub, not files tracked by the repository |
 | Write to `/tmp/issue-body.md` | Allowed — outside the repo |
 | Write to `packages/core/src/foo.mjs` | **BREACH** — must delegate to `dev-loop` |
 | `git status` | Allowed — read-only |

--- a/skills/docs/main-agent-contract.md
+++ b/skills/docs/main-agent-contract.md
@@ -1,6 +1,6 @@
 # Main-agent delegation contract
 
-> **Absolute read-only boundary.** The main agent must never mutate repo files.
+> **Absolute read-only boundary.** The main agent must never mutate files tracked by the repository.
 > All mutations flow through the `dev-loop` async subagent.
 
 ## Contract
@@ -28,7 +28,7 @@ because "the user said yes," not because it is running from a worktree.
 
 - `write`, `edit`, or delete any file tracked by the repo
 - `git commit`, `git push`, create branches, create worktrees
-- Run dev-loop subcommands (`gate`, `loop`, `pr` commands — those belong inside `dev-loop`)
+- Run state-changing dev-loop subcommands (`gate`, `loop outer`, `pr` commands — those belong inside `dev-loop`). Read-only `loop startup` resolver runs are allowed.
 - Delegate implementation to any agent other than `dev-loop`
 
 ## Dev-loop agent (async) owns
@@ -47,7 +47,7 @@ because "the user said yes," not because it is running from a worktree.
 | Write to `packages/core/src/foo.mjs` | **BREACH** — must delegate to `dev-loop` |
 | `git status` | Allowed — read-only |
 | `git commit -m "..."` | **BREACH** — must delegate to `dev-loop` |
-| `subagent dev-loop --task "implement issue 42"` | Allowed — correct delegation |
+| `subagent dev-loop` | Allowed — correct delegation |
 | `subagent fixer --task "fix the bug"` | Allowed only when called from within `dev-loop` |
 
 ## Enforcement posture

--- a/skills/docs/main-agent-contract.md
+++ b/skills/docs/main-agent-contract.md
@@ -1,0 +1,65 @@
+# Main-agent delegation contract
+
+> **Absolute read-only boundary.** The main agent must never mutate repo files.
+> All mutations flow through the `dev-loop` async subagent.
+
+## Contract
+
+The main agent is **read-only** for every file tracked by the repository. Every
+write, edit, delete, commit, branch, push, and PR lifecycle operation must flow
+through the `dev-loop` async subagent.
+
+This contract is a hard rule, not a default or guideline. The main agent must
+never rationalize a direct mutation — not because the work is small, not
+because "the user said yes," not because it is running from a worktree.
+
+## Main agent owns (allowed)
+
+- Read, inspect, search any repo file
+- `git fetch`, `git worktree list`, `git status`, `git log` (read-only git)
+- `gh issue view / create / edit / comment / close` (GitHub API, not file mutations)
+- `gh pr view / list` (read-only GitHub API)
+- Write to `/tmp` or other non-repo paths (e.g., issue body drafts)
+- Delegate to the `dev-loop` agent (async, with worktree cwd)
+- Report findings, ask questions, get confirmation
+- `npm test`, `npm run verify` (read-only validation)
+
+## Main agent must NEVER
+
+- `write`, `edit`, or delete any file tracked by the repo
+- `git commit`, `git push`, create branches, create worktrees
+- Run dev-loop subcommands (`gate`, `loop`, `pr` commands — those belong inside `dev-loop`)
+- Delegate implementation to any agent other than `dev-loop`
+
+## Dev-loop agent (async) owns
+
+- ALL file mutations in the repo (write, edit, delete)
+- ALL git operations (branch, commit, push)
+- ALL PR lifecycle (create, draft, review, merge)
+- Sub-delegation to developer, fixer, review, quality agents
+
+## Boundary examples
+
+| Operation | Verdict |
+|---|---|
+| `gh issue create --title "..." --body "..."` | Allowed — mutates GitHub, not repo files |
+| Write to `/tmp/issue-body.md` | Allowed — outside the repo |
+| Write to `packages/core/src/foo.mjs` | **BREACH** — must delegate to `dev-loop` |
+| `git status` | Allowed — read-only |
+| `git commit -m "..."` | **BREACH** — must delegate to `dev-loop` |
+| `subagent dev-loop --task "implement issue 42"` | Allowed — correct delegation |
+| `subagent fixer --task "fix the bug"` | Allowed only when called from within `dev-loop` |
+
+## Enforcement posture
+
+- This contract is enforced by convention and review, not by tool-level guards.
+- Mechanical enforcement (pre-commit hooks, tool-level write guards) is a
+  non-goal for this document and may be addressed in follow-up work.
+- A `dev-loop` async subagent should reject delegation attempts that bypass
+  the contract (e.g., direct mutation requests from the main agent).
+
+## Non-goals
+
+- Tool-level enforcement (file-write guards, pre-commit hooks)
+- Changing dev-loop resolver behavior
+- Modifying the subagent API itself

--- a/skills/docs/main-agent-contract.md
+++ b/skills/docs/main-agent-contract.md
@@ -16,7 +16,7 @@ because "the user said yes," not because it is running from a worktree.
 ## Main agent owns (allowed)
 
 - Read, inspect, search any repo file
-- `git fetch`, `git worktree list`, `git status`, `git log` (read-only git)
+- `git worktree list`, `git status`, `git log` (read-only git). `git fetch` is also allowed (updates local refs but does not touch tracked working-tree files).
 - `gh issue view / create / edit / comment / close` (GitHub API, not file mutations)
 - `gh pr view / list` (read-only GitHub API)
 - Write to `/tmp` or other non-repo paths (e.g., issue body drafts)
@@ -48,7 +48,7 @@ because "the user said yes," not because it is running from a worktree.
 | `git status` | Allowed — read-only |
 | `git commit -m "..."` | **BREACH** — must delegate to `dev-loop` |
 | `subagent dev-loop` | Allowed — correct delegation |
-| `subagent fixer --task "fix the bug"` | Allowed only when called from within `dev-loop` |
+| `subagent fixer` | Allowed only when called from within `dev-loop`; describe the task as part of the message |
 
 ## Enforcement posture
 


### PR DESCRIPTION
## Summary

Define main-agent delegation contract establishing absolute read-only boundary. Main agent must never mutate repo files; all mutations flow through dev-loop async subagent.

## Changes

- **New:** `skills/docs/main-agent-contract.md` — self-contained contract doc
- **Edit:** `AGENTS.md` — add mandatory one-line pointer as first working rule
- **Edit:** `skills/dev-loop/SKILL.md` — add contract reference in Authority boundary section

## Validation

- `npm run verify` — 2752 tests pass, 0 fail
- `scripts/docs/validate-links.mjs` — 71 files, 353 links OK
- No duplicate rules detected

Closes #660