### PR TITLE
docs: remove 'private' from README, improve project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pi-dev-loops
 
-`pi-dev-loops` is a private, source-loaded workspace for reusable Pi development loops.
+`pi-dev-loops` is shared Pi workflow infrastructure for reusable local and remote development loops.
 
 ## Workflow posture
 
@@ -92,7 +92,7 @@ Notes:
 - `cli/` — shell-facing `dev-loops` entrypoint
 - `extension/` — `/dev-loops` extension implementation and docs
 - `lib/` — shared command helpers used by the extension and shell CLI
-- `packages/core/` — private deterministic support package
+- `packages/core/` — deterministic support package
 - `scripts/` — deterministic CLI helpers for GitHub/review/loop mechanics
 - `skills/` — packaged workflow skills
 - `test/` — root contract and regression tests

--- a/test/contracts/public-facade-doc-contracts.test.mjs
+++ b/test/contracts/public-facade-doc-contracts.test.mjs
@@ -94,7 +94,7 @@ test("README stays a landing page and lets docs/index own deeper doc navigation"
   assert.match(readme, /docs\/index\.md/i, "README should point readers to the docs index");
   assert.doesNotMatch(readme, /docs\/IMPLEMENTATION_STATE\.md/i, "README should not duplicate docs/index deep links for the implementation snapshot");
   assert.doesNotMatch(readme, /docs\/IMPLEMENTATION_WORKFLOW\.md/i, "README should not duplicate docs/index deep links for workflow docs");
-  assert.match(readme, /private, source-loaded workspace/i, "README should keep the repo posture concise without a separate status section");
+  assert.match(readme, /shared Pi workflow infrastructure/i, "README should describe the repo as shared Pi workflow infrastructure");
 });
 
 test("repo docs define dev-loop as the public façade and keep internal routed logic behind it", async () => {


### PR DESCRIPTION
## Summary

Remove inaccurate 'private' mentions from README.md and improve the project description. The repo is public and installable — calling it 'private' is misleading.

The contract test `test/contracts/public-facade-doc-contracts.test.mjs` is updated as a necessary companion: it asserted the old 'private, source-loaded workspace' text, so the assertion is updated to match the new 'shared Pi workflow infrastructure' description.

## Changes

- `README.md` line 3: Replace 'a private, source-loaded workspace' with 'shared Pi workflow infrastructure for reusable local and remote development loops' (matching the welcome message)
- `README.md` repository layout: Remove 'private' from `packages/core/` description
- `test/contracts/public-facade-doc-contracts.test.mjs`: Update contract assertion from old 'private, source-loaded workspace' regex to new 'shared Pi workflow infrastructure' regex

## Validation

- `grep -n private README.md` returns no matches
- `npm run verify` passes locally
- CI green on current head

Closes #663