### PR TITLE
feat(core): add Zod AC/DoD matrix schema for refinement-to-implementation contract

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,8 @@
     "./loop/run-inspection": "./src/loop/run-inspection.mjs",
     "./loop/steering": "./src/loop/steering.mjs",
     "./loop/timeout-policy": "./src/loop/timeout-policy.mjs",
-    "./loop/tracker-pr-state": "./src/loop/tracker-pr-state.mjs"
+    "./loop/tracker-pr-state": "./src/loop/tracker-pr-state.mjs",
+    "./refinement/ac-dod-matrix": "./src/refinement/ac-dod-matrix.mjs"
   },
   "bin": {
     "pi-dev-loops-log-bash-exit-1": "./bin/log-bash-exit-1.mjs",

--- a/packages/core/src/loop/handoff-envelope.mjs
+++ b/packages/core/src/loop/handoff-envelope.mjs
@@ -474,7 +474,7 @@ export function buildDevLoopHandoffEnvelope(resolverOutput, settings, gateState 
   }
 
   // Optional refinement contract (AC/DoD matrix) from the refiner.
-  // Set via options.refinementContract or resolverOutput.refinementContract.
+  // Set via options.refinementContract, bundle.refinementContract, or resolverOutput.refinementContract.
   const refinementContract = options.refinementContract ?? bundle.refinementContract ?? resolverOutput.refinementContract ?? null;
   if (refinementContract != null) {
     envelope.refinementContract = refinementContract;
@@ -737,22 +737,22 @@ export function validateHandoffEnvelope(envelope) {
         if (bad.length > 0) {
           errors.push({
             field: "refinementContract.items",
-            reason: `entries at indices [${bad.join(',')}] must have valid item, type, status, evidence, and notes fields`,
+            reason: `entries at indices [${bad.join(",")}] must have valid item, type, status, evidence, and notes fields`,
             got: envelope.refinementContract.items,
           });
         }
       }
       if (typeof envelope.refinementContract.generatedAt !== "string" || !envelope.refinementContract.generatedAt.trim()) {
-        warnings.push({
+        errors.push({
           field: "refinementContract.generatedAt",
-          reason: "should be an ISO 8601 timestamp",
+          reason: "must be a valid ISO 8601 timestamp",
           got: envelope.refinementContract.generatedAt,
         });
       }
       if (typeof envelope.refinementContract.isComplete !== "boolean") {
-        warnings.push({
+        errors.push({
           field: "refinementContract.isComplete",
-          reason: "should be a boolean",
+          reason: "must be a boolean",
           got: envelope.refinementContract.isComplete,
         });
       }

--- a/packages/core/src/loop/handoff-envelope.mjs
+++ b/packages/core/src/loop/handoff-envelope.mjs
@@ -476,7 +476,7 @@ export function buildDevLoopHandoffEnvelope(resolverOutput, settings, gateState 
   // Optional refinement contract (AC/DoD matrix) from the refiner.
   // Set via options.refinementContract or resolverOutput.refinementContract.
   const refinementContract = options.refinementContract ?? resolverOutput.refinementContract ?? null;
-  if (refinementContract) {
+  if (refinementContract != null) {
     envelope.refinementContract = refinementContract;
   }
 
@@ -719,6 +719,28 @@ export function validateHandoffEnvelope(envelope) {
           reason: "must be a non-empty array of AC/DoD matrix items",
           got: envelope.refinementContract.items,
         });
+      } else {
+        const bad = [];
+        for (let i = 0; i < envelope.refinementContract.items.length; i++) {
+          const item = envelope.refinementContract.items[i];
+          if (
+            !item || typeof item !== 'object' ||
+            typeof item.item !== 'string' || !item.item.trim() ||
+            !['AC', 'DoD', 'Non-goal'].includes(item.type) ||
+            !['Met', 'Partial', 'Unmet', 'Unverified'].includes(item.status) ||
+            typeof item.evidence !== 'string' ||
+            typeof item.notes !== 'string'
+          ) {
+            bad.push(i);
+          }
+        }
+        if (bad.length > 0) {
+          errors.push({
+            field: 'refinementContract.items',
+            reason: `entries at indices [${bad.join(',')}] must have valid item, type, status, evidence, and notes fields`,
+            got: envelope.refinementContract.items,
+          });
+        }
       }
       if (typeof envelope.refinementContract.generatedAt !== 'string' || !envelope.refinementContract.generatedAt.trim()) {
         warnings.push({
@@ -737,7 +759,7 @@ export function validateHandoffEnvelope(envelope) {
     }
   }
 
-    // ----- derivedAt (informational, warn on missing) -----
+  // ----- derivedAt (informational, warn on missing) -----
   if (typeof envelope.derivedAt !== "string" || !envelope.derivedAt.trim()) {
     warnings.push({ field: "derivedAt", reason: "should be an ISO 8601 timestamp" });
   }

--- a/packages/core/src/loop/handoff-envelope.mjs
+++ b/packages/core/src/loop/handoff-envelope.mjs
@@ -473,6 +473,13 @@ export function buildDevLoopHandoffEnvelope(resolverOutput, settings, gateState 
     envelope.overrides = overrides;
   }
 
+  // Optional refinement contract (AC/DoD matrix) from the refiner.
+  // Set via options.refinementContract or resolverOutput.refinementContract.
+  const refinementContract = options.refinementContract ?? resolverOutput.refinementContract ?? null;
+  if (refinementContract) {
+    envelope.refinementContract = refinementContract;
+  }
+
   return deepFreeze(envelope);
 }
 
@@ -690,7 +697,47 @@ export function validateHandoffEnvelope(envelope) {
     });
   }
 
-  // ----- derivedAt (informational, warn on missing) -----
+  // ----- refinementContract (optional) -----
+  if (envelope.refinementContract !== undefined && envelope.refinementContract !== null) {
+    if (typeof envelope.refinementContract !== 'object' || Array.isArray(envelope.refinementContract)) {
+      errors.push({
+        field: "refinementContract",
+        reason: "if present, must be a non-array object with schema, items, generatedAt, and isComplete",
+        got: envelope.refinementContract,
+      });
+    } else {
+      if (envelope.refinementContract.schema !== 'ac-dod-matrix/v1') {
+        warnings.push({
+          field: "refinementContract.schema",
+          reason: "expected 'ac-dod-matrix/v1'",
+          got: envelope.refinementContract.schema,
+        });
+      }
+      if (!Array.isArray(envelope.refinementContract.items) || envelope.refinementContract.items.length === 0) {
+        errors.push({
+          field: "refinementContract.items",
+          reason: "must be a non-empty array of AC/DoD matrix items",
+          got: envelope.refinementContract.items,
+        });
+      }
+      if (typeof envelope.refinementContract.generatedAt !== 'string' || !envelope.refinementContract.generatedAt.trim()) {
+        warnings.push({
+          field: "refinementContract.generatedAt",
+          reason: "should be an ISO 8601 timestamp",
+          got: envelope.refinementContract.generatedAt,
+        });
+      }
+      if (typeof envelope.refinementContract.isComplete !== 'boolean') {
+        warnings.push({
+          field: "refinementContract.isComplete",
+          reason: "should be a boolean",
+          got: envelope.refinementContract.isComplete,
+        });
+      }
+    }
+  }
+
+    // ----- derivedAt (informational, warn on missing) -----
   if (typeof envelope.derivedAt !== "string" || !envelope.derivedAt.trim()) {
     warnings.push({ field: "derivedAt", reason: "should be an ISO 8601 timestamp" });
   }

--- a/packages/core/src/loop/handoff-envelope.mjs
+++ b/packages/core/src/loop/handoff-envelope.mjs
@@ -742,7 +742,7 @@ export function validateHandoffEnvelope(envelope) {
           });
         }
       }
-      if (typeof envelope.refinementContract.generatedAt !== "string" || !envelope.refinementContract.generatedAt.trim()) {
+      if (typeof envelope.refinementContract.generatedAt !== "string" || isNaN(Date.parse(envelope.refinementContract.generatedAt))) {
         errors.push({
           field: "refinementContract.generatedAt",
           reason: "must be a valid ISO 8601 timestamp",
@@ -755,6 +755,17 @@ export function validateHandoffEnvelope(envelope) {
           reason: "must be a boolean",
           got: envelope.refinementContract.isComplete,
         });
+      } else if (envelope.refinementContract.items && Array.isArray(envelope.refinementContract.items)) {
+        const allMet = envelope.refinementContract.items.every(
+          (item) => item && typeof item === "object" && item.status === "Met"
+        );
+        if (envelope.refinementContract.isComplete !== allMet) {
+          errors.push({
+            field: "refinementContract.isComplete",
+            reason: "must match items status (true iff every item has status 'Met')",
+            got: { isComplete: envelope.refinementContract.isComplete, allItemsMet: allMet },
+          });
+        }
       }
     }
   }

--- a/packages/core/src/loop/handoff-envelope.mjs
+++ b/packages/core/src/loop/handoff-envelope.mjs
@@ -475,7 +475,7 @@ export function buildDevLoopHandoffEnvelope(resolverOutput, settings, gateState 
 
   // Optional refinement contract (AC/DoD matrix) from the refiner.
   // Set via options.refinementContract or resolverOutput.refinementContract.
-  const refinementContract = options.refinementContract ?? resolverOutput.refinementContract ?? null;
+  const refinementContract = options.refinementContract ?? bundle.refinementContract ?? resolverOutput.refinementContract ?? null;
   if (refinementContract != null) {
     envelope.refinementContract = refinementContract;
   }
@@ -699,14 +699,14 @@ export function validateHandoffEnvelope(envelope) {
 
   // ----- refinementContract (optional) -----
   if (envelope.refinementContract !== undefined && envelope.refinementContract !== null) {
-    if (typeof envelope.refinementContract !== 'object' || Array.isArray(envelope.refinementContract)) {
+    if (typeof envelope.refinementContract !== "object" || Array.isArray(envelope.refinementContract)) {
       errors.push({
         field: "refinementContract",
         reason: "if present, must be a non-array object with schema, items, generatedAt, and isComplete",
         got: envelope.refinementContract,
       });
     } else {
-      if (envelope.refinementContract.schema !== 'ac-dod-matrix/v1') {
+      if (envelope.refinementContract.schema !== "ac-dod-matrix/v1") {
         warnings.push({
           field: "refinementContract.schema",
           reason: "expected 'ac-dod-matrix/v1'",
@@ -724,32 +724,32 @@ export function validateHandoffEnvelope(envelope) {
         for (let i = 0; i < envelope.refinementContract.items.length; i++) {
           const item = envelope.refinementContract.items[i];
           if (
-            !item || typeof item !== 'object' ||
-            typeof item.item !== 'string' || !item.item.trim() ||
-            !['AC', 'DoD', 'Non-goal'].includes(item.type) ||
-            !['Met', 'Partial', 'Unmet', 'Unverified'].includes(item.status) ||
-            typeof item.evidence !== 'string' ||
-            typeof item.notes !== 'string'
+            !item || typeof item !== "object" ||
+            typeof item.item !== "string" || !item.item.trim() ||
+            !["AC", "DoD", "Non-goal"].includes(item.type) ||
+            !["Met", "Partial", "Unmet", "Unverified"].includes(item.status) ||
+            typeof item.evidence !== "string" ||
+            typeof item.notes !== "string"
           ) {
             bad.push(i);
           }
         }
         if (bad.length > 0) {
           errors.push({
-            field: 'refinementContract.items',
+            field: "refinementContract.items",
             reason: `entries at indices [${bad.join(',')}] must have valid item, type, status, evidence, and notes fields`,
             got: envelope.refinementContract.items,
           });
         }
       }
-      if (typeof envelope.refinementContract.generatedAt !== 'string' || !envelope.refinementContract.generatedAt.trim()) {
+      if (typeof envelope.refinementContract.generatedAt !== "string" || !envelope.refinementContract.generatedAt.trim()) {
         warnings.push({
           field: "refinementContract.generatedAt",
           reason: "should be an ISO 8601 timestamp",
           got: envelope.refinementContract.generatedAt,
         });
       }
-      if (typeof envelope.refinementContract.isComplete !== 'boolean') {
+      if (typeof envelope.refinementContract.isComplete !== "boolean") {
         warnings.push({
           field: "refinementContract.isComplete",
           reason: "should be a boolean",

--- a/packages/core/src/refinement/ac-dod-matrix.mjs
+++ b/packages/core/src/refinement/ac-dod-matrix.mjs
@@ -23,7 +23,7 @@ export const AC_DOD_ITEM_STATUS = Object.freeze({
  */
 export const AcDodMatrixItemSchema = z.strictObject({
   /** Exact item text from the source issue/plan/spec */
-  item: z.string().min(1),
+  item: z.string().trim().min(1),
   /** Type classification */
   type: z.enum(["AC", "DoD", "Non-goal"]),
   /** Verification status */

--- a/packages/core/src/refinement/ac-dod-matrix.mjs
+++ b/packages/core/src/refinement/ac-dod-matrix.mjs
@@ -53,7 +53,13 @@ export const AcDodMatrixSchema = z.strictObject({
    * Implementation agents use this to gate merge-readiness.
    */
   isComplete: z.boolean(),
-});
+}).refine(
+  (data) => isMatrixComplete(data) === data.isComplete,
+  {
+    message: "isComplete must be true when (and only when) every item has status 'Met'",
+    path: ["isComplete"],
+  }
+);
 
 // ---------------------------------------------------------------------------
 // Convenience helpers

--- a/packages/core/src/refinement/ac-dod-matrix.mjs
+++ b/packages/core/src/refinement/ac-dod-matrix.mjs
@@ -25,9 +25,9 @@ export const AcDodMatrixItemSchema = z.strictObject({
   /** Exact item text from the source issue/plan/spec */
   item: z.string().trim().min(1),
   /** Type classification */
-  type: z.enum(["AC", "DoD", "Non-goal"]),
+  type: z.enum(Object.values(AC_DOD_ITEM_TYPE)),
   /** Verification status */
-  status: z.enum(["Met", "Partial", "Unmet", "Unverified"]),
+  status: z.enum(Object.values(AC_DOD_ITEM_STATUS)),
   /** Reference to supporting evidence (file, test, doc path, or URL) */
   evidence: z.string(),
   /** Additional context or caveats */
@@ -45,7 +45,7 @@ export const AcDodMatrixSchema = z.strictObject({
   /** Ordered list of matrix items */
   items: z.array(AcDodMatrixItemSchema).min(1),
   /** Source reference (issue URL, plan-doc path, etc.) */
-  source: z.string().min(1).optional(),
+  source: z.string().trim().min(1).optional(),
   /** ISO 8601 timestamp of matrix generation */
   generatedAt: z.string().datetime(),
   /**

--- a/packages/core/src/refinement/ac-dod-matrix.mjs
+++ b/packages/core/src/refinement/ac-dod-matrix.mjs
@@ -1,0 +1,89 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// AC/DoD matrix item — one row in the refinement coverage matrix
+// ---------------------------------------------------------------------------
+
+export const AC_DOD_ITEM_TYPE = Object.freeze({
+  AC: "AC",
+  DOD: "DoD",
+  NON_GOAL: "Non-goal",
+});
+
+export const AC_DOD_ITEM_STATUS = Object.freeze({
+  MET: "Met",
+  PARTIAL: "Partial",
+  UNMET: "Unmet",
+  UNVERIFIED: "Unverified",
+});
+
+/**
+ * A single row in the AC/DoD coverage matrix.
+ * Matches the refiner persona's required table output shape.
+ */
+export const AcDodMatrixItemSchema = z.strictObject({
+  /** Exact item text from the source issue/plan/spec */
+  item: z.string().min(1),
+  /** Type classification */
+  type: z.enum(["AC", "DoD", "Non-goal"]),
+  /** Verification status */
+  status: z.enum(["Met", "Partial", "Unmet", "Unverified"]),
+  /** Reference to supporting evidence (file, test, doc path, or URL) */
+  evidence: z.string(),
+  /** Additional context or caveats */
+  notes: z.string(),
+});
+
+/**
+ * The full AC/DoD/Non-goal coverage matrix.
+ * Emitted by the refiner during issue refinement, consumed by implementation
+ * agents via the handoff envelope as a structured contract.
+ */
+export const AcDodMatrixSchema = z.strictObject({
+  /** Schema identifier for dispatch and validation */
+  schema: z.literal("ac-dod-matrix/v1"),
+  /** Ordered list of matrix items */
+  items: z.array(AcDodMatrixItemSchema).min(1),
+  /** Source reference (issue URL, plan-doc path, etc.) */
+  source: z.string().min(1).optional(),
+  /** ISO 8601 timestamp of matrix generation */
+  generatedAt: z.string().datetime(),
+  /**
+   * True when every item has status "Met" — the contract is fully satisfied.
+   * Implementation agents use this to gate merge-readiness.
+   */
+  isComplete: z.boolean(),
+});
+
+// ---------------------------------------------------------------------------
+// Convenience helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a matrix is fully satisfied (all items Met).
+ * Pure function — does not require a parsed Zod result.
+ */
+export function isMatrixComplete(matrix) {
+  if (!matrix || !Array.isArray(matrix.items) || matrix.items.length === 0) {
+    return false;
+  }
+  return matrix.items.every((item) => item.status === AC_DOD_ITEM_STATUS.MET);
+}
+
+/**
+ * Collect all items that are not "Met" — the outstanding work contract.
+ */
+export function outstandingItems(matrix) {
+  if (!matrix || !Array.isArray(matrix.items)) {
+    return [];
+  }
+  return matrix.items.filter((item) => item.status !== AC_DOD_ITEM_STATUS.MET);
+}
+
+/**
+ * Validate raw data against the AC/DoD matrix schema.
+ * Returns a Zod safeParse result.
+ */
+export function validateAcDodMatrix(data) {
+  return AcDodMatrixSchema.safeParse(data);
+}

--- a/packages/core/test/ac-dod-matrix.test.mjs
+++ b/packages/core/test/ac-dod-matrix.test.mjs
@@ -336,3 +336,67 @@ test("handoff envelope warns on malformed refinementContract", async () => {
   // but items being empty IS an error
   assert.equal(validation.ok, false);
 });
+
+test("AcDodMatrixSchema rejects isComplete mismatch (true with non-Met items)", () => {
+  const mismatch = {
+    schema: "ac-dod-matrix/v1",
+    items: [
+      { ...validItem, status: AC_DOD_ITEM_STATUS.UNVERIFIED },
+    ],
+    generatedAt: "2026-06-08T12:00:00.000Z",
+    isComplete: true,
+  };
+  const result = validateAcDodMatrix(mismatch);
+  assert.equal(result.success, false);
+  const isCompleteIssue = result.error?.issues?.find((i) => i.path?.includes?.("isComplete"));
+  assert.ok(isCompleteIssue, "should have an issue on isComplete");
+});
+
+test("AcDodMatrixSchema rejects isComplete mismatch (false with all Met items)", () => {
+  const mismatch = {
+    schema: "ac-dod-matrix/v1",
+    items: [
+      { ...validItem, status: AC_DOD_ITEM_STATUS.MET },
+    ],
+    generatedAt: "2026-06-08T12:00:00.000Z",
+    isComplete: false,
+  };
+  const result = validateAcDodMatrix(mismatch);
+  assert.equal(result.success, false);
+  const isCompleteIssue = result.error?.issues?.find((i) => i.path?.includes?.("isComplete"));
+  assert.ok(isCompleteIssue, "should have an issue on isComplete");
+});
+
+test("handoff envelope refinementContract validation rejects per-item shape errors", async () => {
+  const { buildDevLoopHandoffEnvelope, validateHandoffEnvelope } = await import("../src/loop/handoff-envelope.mjs");
+
+  const resolverOutput = {
+    bundle: {
+      selectedStrategy: "copilot_pr_followup",
+      executionMode: "bounded_handoff",
+      nextAction: "Follow up on PR.",
+      requiredReads: ["skills/copilot-pr-followup/SKILL.md"],
+      activeArtifact: { kind: "issue", issue: 675, pr: 676, branch: null, phase: null },
+    },
+  };
+
+  const options = {
+    repoSlug: "mdfittko/pi-dev-loops",
+    refinementContract: {
+      schema: "ac-dod-matrix/v1",
+      items: [
+        { item: "ok", type: "AC", status: "Met", evidence: "x", notes: "" },
+        { item: "", type: "AC", status: "Met", evidence: "x", notes: "" }, // bad: empty item
+      ],
+      generatedAt: "2026-06-08T12:00:00.000Z",
+      isComplete: false,
+    },
+  };
+
+  const envelope = buildDevLoopHandoffEnvelope(resolverOutput, {}, {}, options);
+  const validation = validateHandoffEnvelope(envelope);
+
+  assert.equal(validation.ok, false);
+  const itemError = validation.errors.find((e) => e.field === "refinementContract.items" && e.reason.includes("entries at indices"));
+  assert.ok(itemError, "should have per-item validation error for bad item shape");
+});

--- a/packages/core/test/ac-dod-matrix.test.mjs
+++ b/packages/core/test/ac-dod-matrix.test.mjs
@@ -332,7 +332,7 @@ test("handoff envelope warns on malformed refinementContract", async () => {
   const envelope = buildDevLoopHandoffEnvelope(resolverOutput, {}, {}, options);
   const validation = validateHandoffEnvelope(envelope);
 
-  // Should still be ok (warnings, not errors) for the refinement contract shape
+  // Should fail (errors, not warnings) for the refinement contract shape
   // but items being empty IS an error
   assert.equal(validation.ok, false);
 });

--- a/packages/core/test/ac-dod-matrix.test.mjs
+++ b/packages/core/test/ac-dod-matrix.test.mjs
@@ -311,7 +311,7 @@ test("handoff envelope without refinementContract is still valid", async () => {
   assert.equal(envelope.refinementContract, undefined);
 });
 
-test("handoff envelope warns on malformed refinementContract", async () => {
+test("handoff envelope fails on malformed refinementContract", async () => {
   const { buildDevLoopHandoffEnvelope, validateHandoffEnvelope } = await import("../src/loop/handoff-envelope.mjs");
 
   const resolverOutput = {

--- a/packages/core/test/ac-dod-matrix.test.mjs
+++ b/packages/core/test/ac-dod-matrix.test.mjs
@@ -1,0 +1,338 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  AcDodMatrixItemSchema,
+  AcDodMatrixSchema,
+  validateAcDodMatrix,
+  isMatrixComplete,
+  outstandingItems,
+  AC_DOD_ITEM_TYPE,
+  AC_DOD_ITEM_STATUS,
+} from "../src/refinement/ac-dod-matrix.mjs";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const validItem = Object.freeze({
+  item: "Zod schema committed for the AC/DoD matrix output",
+  type: AC_DOD_ITEM_TYPE.AC,
+  status: AC_DOD_ITEM_STATUS.MET,
+  evidence: "packages/core/src/refinement/ac-dod-matrix.mjs",
+  notes: "Exported as ./refinement/ac-dod-matrix",
+});
+
+const validMatrix = Object.freeze({
+  schema: "ac-dod-matrix/v1",
+  items: [
+    validItem,
+    {
+      item: "Refiner produces a valid structured JSON contract",
+      type: AC_DOD_ITEM_TYPE.AC,
+      status: AC_DOD_ITEM_STATUS.UNVERIFIED,
+      evidence: "refiner output",
+      notes: "Pending refiner integration",
+    },
+  ],
+  source: "https://github.com/mfittko/pi-dev-loops/issues/675",
+  generatedAt: "2026-06-08T12:00:00.000Z",
+  isComplete: false,
+});
+
+// ---------------------------------------------------------------------------
+// AcDodMatrixItemSchema
+// ---------------------------------------------------------------------------
+
+test("AcDodMatrixItemSchema accepts valid item", () => {
+  const result = AcDodMatrixItemSchema.safeParse(validItem);
+  assert.equal(result.success, true);
+});
+
+test("AcDodMatrixItemSchema rejects missing item", () => {
+  const { item, ...rest } = validItem;
+  const result = AcDodMatrixItemSchema.safeParse(rest);
+  assert.equal(result.success, false);
+});
+
+test("AcDodMatrixItemSchema rejects empty item string", () => {
+  const result = AcDodMatrixItemSchema.safeParse({ ...validItem, item: "" });
+  assert.equal(result.success, false);
+});
+
+test("AcDodMatrixItemSchema rejects invalid type", () => {
+  const result = AcDodMatrixItemSchema.safeParse({ ...validItem, type: "invalid" });
+  assert.equal(result.success, false);
+});
+
+test("AcDodMatrixItemSchema rejects invalid status", () => {
+  const result = AcDodMatrixItemSchema.safeParse({ ...validItem, status: "done" });
+  assert.equal(result.success, false);
+});
+
+test("AcDodMatrixItemSchema accepts all valid types", () => {
+  for (const type of Object.values(AC_DOD_ITEM_TYPE)) {
+    const result = AcDodMatrixItemSchema.safeParse({ ...validItem, type });
+    assert.equal(result.success, true, `type ${type} should be valid`);
+  }
+});
+
+test("AcDodMatrixItemSchema accepts all valid statuses", () => {
+  for (const status of Object.values(AC_DOD_ITEM_STATUS)) {
+    const result = AcDodMatrixItemSchema.safeParse({ ...validItem, status });
+    assert.equal(result.success, true, `status ${status} should be valid`);
+  }
+});
+
+test("AcDodMatrixItemSchema rejects extra fields", () => {
+  const result = AcDodMatrixItemSchema.safeParse({ ...validItem, extra: "nope" });
+  assert.equal(result.success, false);
+});
+
+// ---------------------------------------------------------------------------
+// AcDodMatrixSchema
+// ---------------------------------------------------------------------------
+
+test("AcDodMatrixSchema accepts valid matrix", () => {
+  const result = validateAcDodMatrix(validMatrix);
+  assert.equal(result.success, true);
+});
+
+test("AcDodMatrixSchema rejects missing schema field", () => {
+  const { schema, ...rest } = validMatrix;
+  const result = validateAcDodMatrix(rest);
+  assert.equal(result.success, false);
+});
+
+test("AcDodMatrixSchema rejects wrong schema value", () => {
+  const result = validateAcDodMatrix({ ...validMatrix, schema: "wrong/v1" });
+  assert.equal(result.success, false);
+});
+
+test("AcDodMatrixSchema rejects empty items array", () => {
+  const result = validateAcDodMatrix({ ...validMatrix, items: [] });
+  assert.equal(result.success, false);
+});
+
+test("AcDodMatrixSchema rejects missing items", () => {
+  const { items, ...rest } = validMatrix;
+  const result = validateAcDodMatrix(rest);
+  assert.equal(result.success, false);
+});
+
+test("AcDodMatrixSchema rejects invalid item in array", () => {
+  const result = validateAcDodMatrix({
+    ...validMatrix,
+    items: [{ item: "bad", type: "nope", status: "Met", evidence: "", notes: "" }],
+  });
+  assert.equal(result.success, false);
+});
+
+test("AcDodMatrixSchema rejects invalid generatedAt", () => {
+  const result = validateAcDodMatrix({ ...validMatrix, generatedAt: "not-a-date" });
+  assert.equal(result.success, false);
+});
+
+test("AcDodMatrixSchema rejects non-boolean isComplete", () => {
+  const result = validateAcDodMatrix({ ...validMatrix, isComplete: "yes" });
+  assert.equal(result.success, false);
+});
+
+test("AcDodMatrixSchema accepts optional source", () => {
+  const { source, ...rest } = validMatrix;
+  const result = validateAcDodMatrix(rest);
+  assert.equal(result.success, true);
+});
+
+test("AcDodMatrixSchema rejects extra fields", () => {
+  const result = validateAcDodMatrix({ ...validMatrix, extra: "nope" });
+  assert.equal(result.success, false);
+});
+
+test("AcDodMatrixSchema complete matrix parses correctly", () => {
+  const complete = {
+    schema: "ac-dod-matrix/v1",
+    items: [
+      { ...validItem, status: AC_DOD_ITEM_STATUS.MET },
+      {
+        item: "All tests pass",
+        type: AC_DOD_ITEM_TYPE.DOD,
+        status: AC_DOD_ITEM_STATUS.MET,
+        evidence: "npm run verify",
+        notes: "",
+      },
+    ],
+    generatedAt: "2026-06-08T12:00:00.000Z",
+    isComplete: true,
+  };
+  const result = validateAcDodMatrix(complete);
+  assert.equal(result.success, true);
+  assert.equal(result.data.isComplete, true);
+  assert.equal(result.data.items.length, 2);
+});
+
+// ---------------------------------------------------------------------------
+// isMatrixComplete
+// ---------------------------------------------------------------------------
+
+test("isMatrixComplete returns true when all items Met", () => {
+  const matrix = {
+    items: [
+      { ...validItem, status: AC_DOD_ITEM_STATUS.MET },
+      { ...validItem, status: AC_DOD_ITEM_STATUS.MET },
+    ],
+  };
+  assert.equal(isMatrixComplete(matrix), true);
+});
+
+test("isMatrixComplete returns false when any item is Partial", () => {
+  const matrix = {
+    items: [
+      { ...validItem, status: AC_DOD_ITEM_STATUS.MET },
+      { ...validItem, status: AC_DOD_ITEM_STATUS.PARTIAL },
+    ],
+  };
+  assert.equal(isMatrixComplete(matrix), false);
+});
+
+test("isMatrixComplete returns false when any item is Unverified", () => {
+  const matrix = {
+    items: [
+      { ...validItem, status: AC_DOD_ITEM_STATUS.UNVERIFIED },
+    ],
+  };
+  assert.equal(isMatrixComplete(matrix), false);
+});
+
+test("isMatrixComplete returns false for null/empty input", () => {
+  assert.equal(isMatrixComplete(null), false);
+  assert.equal(isMatrixComplete({}), false);
+  assert.equal(isMatrixComplete({ items: [] }), false);
+});
+
+// ---------------------------------------------------------------------------
+// outstandingItems
+// ---------------------------------------------------------------------------
+
+test("outstandingItems returns non-Met items", () => {
+  const matrix = {
+    items: [
+      { ...validItem, item: "Done", status: AC_DOD_ITEM_STATUS.MET },
+      { ...validItem, item: "Pending", status: AC_DOD_ITEM_STATUS.UNVERIFIED },
+      { ...validItem, item: "Partial", status: AC_DOD_ITEM_STATUS.PARTIAL },
+    ],
+  };
+  const outstanding = outstandingItems(matrix);
+  assert.equal(outstanding.length, 2);
+  assert.equal(outstanding[0].item, "Pending");
+  assert.equal(outstanding[1].item, "Partial");
+});
+
+test("outstandingItems returns empty when all Met", () => {
+  const matrix = {
+    items: [
+      { ...validItem, status: AC_DOD_ITEM_STATUS.MET },
+      { ...validItem, status: AC_DOD_ITEM_STATUS.MET },
+    ],
+  };
+  assert.equal(outstandingItems(matrix).length, 0);
+});
+
+test("outstandingItems returns empty for null input", () => {
+  assert.deepEqual(outstandingItems(null), []);
+  assert.deepEqual(outstandingItems({}), []);
+});
+
+// ---------------------------------------------------------------------------
+// validateAcDodMatrix
+// ---------------------------------------------------------------------------
+
+test("validateAcDodMatrix returns safeParse result with error details", () => {
+  const result = validateAcDodMatrix({ schema: "wrong", items: [], generatedAt: "bad", isComplete: "nope" });
+  assert.equal(result.success, false);
+  assert.ok(result.error);
+  assert.ok(result.error.issues.length > 0);
+});
+
+// ---------------------------------------------------------------------------
+// Envelope refinementContract integration
+// ---------------------------------------------------------------------------
+
+test("handoff envelope accepts optional refinementContract field", async () => {
+  const { buildDevLoopHandoffEnvelope, validateHandoffEnvelope } = await import("../src/loop/handoff-envelope.mjs");
+
+  const resolverOutput = {
+    bundle: {
+      selectedStrategy: "copilot_pr_followup",
+      executionMode: "bounded_handoff",
+      nextAction: "Follow up on PR.",
+      requiredReads: ["skills/copilot-pr-followup/SKILL.md"],
+      activeArtifact: { kind: "issue", issue: 675, pr: 676, branch: null, phase: null },
+    },
+  };
+
+  const options = {
+    repoSlug: "mdfittko/pi-dev-loops",
+    refinementContract: {
+      schema: "ac-dod-matrix/v1",
+      items: [validItem],
+      generatedAt: "2026-06-08T12:00:00.000Z",
+      isComplete: true,
+    },
+  };
+
+  const envelope = buildDevLoopHandoffEnvelope(resolverOutput, {}, {}, options);
+  const validation = validateHandoffEnvelope(envelope);
+
+  assert.equal(validation.ok, true);
+  assert.ok(envelope.refinementContract);
+  assert.equal(envelope.refinementContract.schema, "ac-dod-matrix/v1");
+  assert.equal(envelope.refinementContract.items.length, 1);
+});
+
+test("handoff envelope without refinementContract is still valid", async () => {
+  const { buildDevLoopHandoffEnvelope, validateHandoffEnvelope } = await import("../src/loop/handoff-envelope.mjs");
+
+  const resolverOutput = {
+    bundle: {
+      selectedStrategy: "copilot_pr_followup",
+      executionMode: "bounded_handoff",
+      nextAction: "Follow up on PR.",
+      requiredReads: ["skills/copilot-pr-followup/SKILL.md"],
+      activeArtifact: { kind: "issue", issue: 675, pr: 676, branch: null, phase: null },
+    },
+  };
+
+  const options = { repoSlug: "mdfittko/pi-dev-loops" };
+  const envelope = buildDevLoopHandoffEnvelope(resolverOutput, {}, {}, options);
+  const validation = validateHandoffEnvelope(envelope);
+
+  assert.equal(validation.ok, true);
+  assert.equal(envelope.refinementContract, undefined);
+});
+
+test("handoff envelope warns on malformed refinementContract", async () => {
+  const { buildDevLoopHandoffEnvelope, validateHandoffEnvelope } = await import("../src/loop/handoff-envelope.mjs");
+
+  const resolverOutput = {
+    bundle: {
+      selectedStrategy: "copilot_pr_followup",
+      executionMode: "bounded_handoff",
+      nextAction: "Follow up on PR.",
+      requiredReads: ["skills/copilot-pr-followup/SKILL.md"],
+      activeArtifact: { kind: "issue", issue: 675, pr: 676, branch: null, phase: null },
+    },
+  };
+
+  const options = {
+    repoSlug: "mdfittko/pi-dev-loops",
+    refinementContract: { schema: "wrong/v1", items: [], generatedAt: "bad", isComplete: "nope" },
+  };
+
+  const envelope = buildDevLoopHandoffEnvelope(resolverOutput, {}, {}, options);
+  const validation = validateHandoffEnvelope(envelope);
+
+  // Should still be ok (warnings, not errors) for the refinement contract shape
+  // but items being empty IS an error
+  assert.equal(validation.ok, false);
+});

--- a/packages/core/test/ac-dod-matrix.test.mjs
+++ b/packages/core/test/ac-dod-matrix.test.mjs
@@ -272,7 +272,7 @@ test("handoff envelope accepts optional refinementContract field", async () => {
   };
 
   const options = {
-    repoSlug: "mdfittko/pi-dev-loops",
+    repoSlug: "mfittko/pi-dev-loops",
     refinementContract: {
       schema: "ac-dod-matrix/v1",
       items: [validItem],
@@ -303,7 +303,7 @@ test("handoff envelope without refinementContract is still valid", async () => {
     },
   };
 
-  const options = { repoSlug: "mdfittko/pi-dev-loops" };
+  const options = { repoSlug: "mfittko/pi-dev-loops" };
   const envelope = buildDevLoopHandoffEnvelope(resolverOutput, {}, {}, options);
   const validation = validateHandoffEnvelope(envelope);
 
@@ -325,7 +325,7 @@ test("handoff envelope warns on malformed refinementContract", async () => {
   };
 
   const options = {
-    repoSlug: "mdfittko/pi-dev-loops",
+    repoSlug: "mfittko/pi-dev-loops",
     refinementContract: { schema: "wrong/v1", items: [], generatedAt: "bad", isComplete: "nope" },
   };
 
@@ -381,7 +381,7 @@ test("handoff envelope refinementContract validation rejects per-item shape erro
   };
 
   const options = {
-    repoSlug: "mdfittko/pi-dev-loops",
+    repoSlug: "mfittko/pi-dev-loops",
     refinementContract: {
       schema: "ac-dod-matrix/v1",
       items: [


### PR DESCRIPTION
## Summary

Define a Zod schema for the AC/DoD matrix that the refiner persona already produces, making it machine-readable so implementation agents can consume it as a structured contract via the handoff envelope.

## Changes

- **`packages/core/src/refinement/ac-dod-matrix.mjs`** — New Zod schema for AC/DoD matrix items (`AcDodMatrixItemSchema`) and full matrix (`AcDodMatrixSchema`), plus convenience helpers (`isMatrixComplete`, `outstandingItems`, `validateAcDodMatrix`)
- **`packages/core/src/loop/handoff-envelope.mjs`** — Optional `refinementContract` field in envelope builder and validator
- **`packages/core/package.json`** — New export `./refinement/ac-dod-matrix`
- **`packages/core/test/ac-dod-matrix.test.mjs`** — 30 contract tests

## Validation

```sh
npm run verify  # all 2837 tests pass, 0 failures
node --test packages/core/test/ac-dod-matrix.test.mjs  # 30/30 pass
```

## Acceptance Criteria

- [x] Zod schema committed for the AC/DoD matrix output
- [x] Schema ready for refiner consumption
- [x] Implementation agent receives the contract via handoff envelope
- [x] `npm run verify` passes
- [x] Contract tests cover valid/invalid matrix shapes

## Non-goals

- Not changing the refiner persona prompt structure
- Not building a generic task-tracking system
- Not removing the markdown version (JSON supplements, doesn't replace)

Closes #675
