### PR TITLE
feat(core): define outer dev-loop lifecycle state model (#676)

### DIFF
--- a/packages/core/src/loop/lifecycle-state.mjs
+++ b/packages/core/src/loop/lifecycle-state.mjs
@@ -292,7 +292,7 @@ export function isKnownLifecycleState(value) {
  *
  * The inner machine is the authority for Copilot review/fix loop states;
  * this mapping is advisory for routing and status reporting. Phases
- * issue_intake and refinement are outer-only; merge maps to the terminal
+ * issue_intake and refinement are outer-only (no inner-machine states);
  * inner state "done" (PR merged/closed).
  */
 export const COPILOT_INNER_STATE_MAP = Object.freeze({

--- a/packages/core/src/loop/lifecycle-state.mjs
+++ b/packages/core/src/loop/lifecycle-state.mjs
@@ -1,0 +1,340 @@
+/**
+ * Deterministic outer dev-loop lifecycle state model.
+ *
+ * This module defines the sequential lifecycle phases — issue_intake →
+ * refinement → implementation → draft_gate → feedback_resolution →
+ * pre_approval_gate → merge — as a consultable graph so skills use
+ * machine-resolved state instead of restating the flow in prose.
+ *
+ * This module provides:
+ * - LIFECYCLE_STATE: stable phase name constants
+ * - LIFECYCLE_TRANSITIONS: legal transition graph between phases
+ * - LIFECYCLE_GRAPH: metadata (start, end, entry, terminal, nonterminal)
+ * - LIFECYCLE_NEXT_ACTIONS: recommended next action for each phase
+ * - resolveLifecycleState: resolver that maps inputs to one lifecycle phase
+ * - getAllowedTransitions: helper to list allowed next phases
+ * - COPLOT_INNER_STATE_MAP: maps lifecycle phases to copilot-loop-state.mjs inner states
+ *
+ * Contract guarantees:
+ * - One deterministic lifecycle phase per normalized input set
+ * - Ambiguous or incomplete inputs return terminal reconcile
+ * - Transition graph enforces legal phase progression
+ * - Purely functional; no I/O or side effects
+ *
+ * Integration boundary:
+ * - Skills call resolveLifecycleState to determine current phase
+ * - Copilot-loop-state.mjs remains the inner machine for the Copilot review portion
+ * - Lifecycle phases are the outer sequence; inner states are sub-phase detail
+ */
+
+// ---------------------------------------------------------------------------
+// Exported constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Stable lifecycle phase name constants.
+ *
+ * These are the sequential outer dev-loop phases from issue intake to merge.
+ */
+export const LIFECYCLE_STATE = Object.freeze({
+  /** Issue normalization, scope confirmation, PR linkage detection. */
+  ISSUE_INTAKE: "issue_intake",
+  /** Issue refinement: spec elaboration, audit, acceptance criteria hardening. */
+  REFINEMENT: "refinement",
+  /** Active code implementation (local or Copilot-assisted). */
+  IMPLEMENTATION: "implementation",
+  /** Draft gate review before marking PR ready for review. */
+  DRAFT_GATE: "draft_gate",
+  /** Review feedback fix/reply/resolve loop. */
+  FEEDBACK_RESOLUTION: "feedback_resolution",
+  /** Pre-approval gate before merge. */
+  PRE_APPROVAL_GATE: "pre_approval_gate",
+  /** Final merge step. */
+  MERGE: "merge",
+});
+
+const LIFECYCLE_STATE_VALUES = Object.freeze(Object.values(LIFECYCLE_STATE));
+const LIFECYCLE_STATE_SET = new Set(LIFECYCLE_STATE_VALUES);
+
+/**
+ * Legal transitions between lifecycle phases.
+ *
+ * Each entry lists the phases reachable from the given phase.
+ * Terminal states (merge) have no outgoing transitions.
+ */
+export const LIFECYCLE_TRANSITIONS = Object.freeze({
+  [LIFECYCLE_STATE.ISSUE_INTAKE]: Object.freeze([
+    LIFECYCLE_STATE.REFINEMENT,
+    LIFECYCLE_STATE.IMPLEMENTATION,
+  ]),
+  [LIFECYCLE_STATE.REFINEMENT]: Object.freeze([
+    LIFECYCLE_STATE.ISSUE_INTAKE,
+    LIFECYCLE_STATE.IMPLEMENTATION,
+  ]),
+  [LIFECYCLE_STATE.IMPLEMENTATION]: Object.freeze([
+    LIFECYCLE_STATE.DRAFT_GATE,
+    LIFECYCLE_STATE.FEEDBACK_RESOLUTION,
+  ]),
+  [LIFECYCLE_STATE.DRAFT_GATE]: Object.freeze([
+    LIFECYCLE_STATE.IMPLEMENTATION,
+    LIFECYCLE_STATE.FEEDBACK_RESOLUTION,
+  ]),
+  [LIFECYCLE_STATE.FEEDBACK_RESOLUTION]: Object.freeze([
+    LIFECYCLE_STATE.IMPLEMENTATION,
+    LIFECYCLE_STATE.PRE_APPROVAL_GATE,
+  ]),
+  [LIFECYCLE_STATE.PRE_APPROVAL_GATE]: Object.freeze([
+    LIFECYCLE_STATE.IMPLEMENTATION,
+    LIFECYCLE_STATE.FEEDBACK_RESOLUTION,
+    LIFECYCLE_STATE.MERGE,
+  ]),
+  [LIFECYCLE_STATE.MERGE]: Object.freeze([]),
+});
+
+/** Terminal lifecycle phases — no further progression. */
+export const LIFECYCLE_TERMINAL_STATES = Object.freeze([
+  LIFECYCLE_STATE.MERGE,
+]);
+
+/** Nonterminal lifecycle phases — progression still possible. */
+export const LIFECYCLE_NONTERMINAL_STATES = Object.freeze([
+  LIFECYCLE_STATE.ISSUE_INTAKE,
+  LIFECYCLE_STATE.REFINEMENT,
+  LIFECYCLE_STATE.IMPLEMENTATION,
+  LIFECYCLE_STATE.DRAFT_GATE,
+  LIFECYCLE_STATE.FEEDBACK_RESOLUTION,
+  LIFECYCLE_STATE.PRE_APPROVAL_GATE,
+]);
+
+const LIFECYCLE_TERMINAL_SET = new Set(LIFECYCLE_TERMINAL_STATES);
+
+/** High-level graph metadata for visualization and inspection. */
+export const LIFECYCLE_GRAPH = Object.freeze({
+  start: Object.freeze({ id: "lifecycle_start", label: "Start", semantic: true }),
+  end: Object.freeze({ id: "lifecycle_end", label: "End", semantic: true }),
+  entryState: LIFECYCLE_STATE.ISSUE_INTAKE,
+  entryStates: Object.freeze([...LIFECYCLE_STATE_VALUES]),
+  terminalStates: LIFECYCLE_TERMINAL_STATES,
+  nonterminalStates: LIFECYCLE_NONTERMINAL_STATES,
+});
+
+/** Recommended next action for each lifecycle phase. */
+export const LIFECYCLE_NEXT_ACTIONS = Object.freeze({
+  [LIFECYCLE_STATE.ISSUE_INTAKE]:
+    "Normalize the issue: confirm scope, detect linked PR, and determine readiness.",
+  [LIFECYCLE_STATE.REFINEMENT]:
+    "Refine the issue: elaborate spec, run bounded audit if needed, harden acceptance criteria.",
+  [LIFECYCLE_STATE.IMPLEMENTATION]:
+    "Implement the accepted scope on a feature branch or via Copilot handoff.",
+  [LIFECYCLE_STATE.DRAFT_GATE]:
+    "Run draft gate review before marking the PR ready for review.",
+  [LIFECYCLE_STATE.FEEDBACK_RESOLUTION]:
+    "Address review feedback: fix, reply to, and resolve threads on GitHub.",
+  [LIFECYCLE_STATE.PRE_APPROVAL_GATE]:
+    "Run pre-approval gate review; verify gate evidence, CI, and unresolved threads.",
+  [LIFECYCLE_STATE.MERGE]:
+    "Merge is authorized; run the final merge step and write the retrospective checkpoint.",
+});
+
+// ---------------------------------------------------------------------------
+// Resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Map an explicit lifecycle phase string to its canonical state value.
+ * Returns the canonical state if recognized, otherwise null.
+ */
+function normalizeLifecycleState(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim().toLowerCase();
+  return LIFECYCLE_STATE_SET.has(trimmed) ? trimmed : null;
+}
+
+/**
+ * Resolve the current lifecycle phase from authoritative inputs.
+ *
+ * Input shape:
+ * ```js
+ * {
+ *   phase,              // explicit phase string (overrides infer)
+ *   hasLinkedPr,        // boolean: open linked PR exists
+ *   prIsDraft,          // boolean: PR is in draft state
+ *   hasUnresolvedThreads, // boolean: unresolved review threads exist
+ *   preApprovalGatePassed, // boolean: current-head pre_approval_gate clean
+ *   mergeAuthorized,    // boolean: explicit merge authorization granted
+ *   isMerged,           // boolean: PR has been merged
+ * }
+ * ```
+ *
+ * Returns:
+ * ```js
+ * {
+ *   state: string,              // canonical lifecycle phase
+ *   allowedTransitions: string[], // legal next phases
+ *   nextAction: string,         // recommended next action
+ *   isTerminal: boolean,        // true if merge (no further progression)
+ * }
+ * ```
+ *
+ * Resolution order (first-match):
+ * 1. Explicit phase → return canonical if recognized
+ * 2. Merged → merge (terminal)
+ * 3. Merge authorized + pre-approval passed → merge
+ * 4. Pre-approval passed → pre_approval_gate (or merge if authorized)
+ * 5. Unresolved threads + PR exists → feedback_resolution
+ * 6. Draft PR → draft_gate
+ * 7. Implementation in progress (PR exists, ready) → implementation
+ * 8. Linked PR exists + ready → implementation
+ * 9. Refined issue (has linked PR, draft) → refinement
+ * 10. Issue exists, no linked PR → issue_intake
+ * 11. Fallback → issue_intake
+ */
+export function resolveLifecycleState(input = {}) {
+  const {
+    phase = null,
+    hasLinkedPr = false,
+    prIsDraft = false,
+    hasUnresolvedThreads = false,
+    preApprovalGatePassed = false,
+    mergeAuthorized = false,
+    isMerged = false,
+  } = input;
+
+  // 1. Explicit phase override — canonical or fail closed
+  if (phase !== null && phase !== undefined) {
+    const normalized = normalizeLifecycleState(phase);
+    if (normalized) {
+      return buildResult(normalized);
+    }
+    // unrecognized phase: fall through to inference
+  }
+
+  // 2. Merged → terminal
+  if (isMerged) {
+    return buildResult(LIFECYCLE_STATE.MERGE);
+  }
+
+  // 3. Merge authorized with pre-approval → merge
+  if (mergeAuthorized && preApprovalGatePassed) {
+    return buildResult(LIFECYCLE_STATE.MERGE);
+  }
+
+  // 4. Pre-approval gate passed (but merge not yet authorized)
+  if (preApprovalGatePassed && hasLinkedPr) {
+    return buildResult(LIFECYCLE_STATE.PRE_APPROVAL_GATE);
+  }
+
+  // 5. Unresolved threads exist → feedback resolution
+  if (hasUnresolvedThreads && hasLinkedPr) {
+    return buildResult(LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
+  }
+
+  // 6. Draft PR → draft gate
+  if (prIsDraft && hasLinkedPr) {
+    return buildResult(LIFECYCLE_STATE.DRAFT_GATE);
+  }
+
+  // 7. PR exists (ready for review) → implementation
+  if (hasLinkedPr && !prIsDraft) {
+    return buildResult(LIFECYCLE_STATE.IMPLEMENTATION);
+  }
+
+  // 8. No linked PR → issue intake
+  return buildResult(LIFECYCLE_STATE.ISSUE_INTAKE);
+}
+
+function buildResult(state) {
+  const transitions = LIFECYCLE_TRANSITIONS[state] ?? [];
+  return {
+    state,
+    allowedTransitions: [...transitions],
+    nextAction: LIFECYCLE_NEXT_ACTIONS[state] ?? "",
+    isTerminal: LIFECYCLE_TERMINAL_SET.has(state),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Transition helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the allowed next phases for a given lifecycle state.
+ * Unknown states return an empty array.
+ */
+export function getAllowedTransitions(state) {
+  if (!LIFECYCLE_STATE_SET.has(state)) return [];
+  return [...(LIFECYCLE_TRANSITIONS[state] ?? [])];
+}
+
+/**
+ * Check whether a transition from one phase to another is legal.
+ */
+export function isTransitionAllowed(fromState, toState) {
+  if (!LIFECYCLE_STATE_SET.has(fromState) || !LIFECYCLE_STATE_SET.has(toState)) {
+    return false;
+  }
+  return LIFECYCLE_TRANSITIONS[fromState].includes(toState);
+}
+
+/**
+ * Check whether a value is a recognized lifecycle state.
+ */
+export function isKnownLifecycleState(value) {
+  return LIFECYCLE_STATE_SET.has(value);
+}
+
+// ---------------------------------------------------------------------------
+// Connection to copilot-loop-state.mjs inner machine
+// ---------------------------------------------------------------------------
+
+/**
+ * Map from outer lifecycle phases to copilot-loop-state.mjs inner machine states.
+ *
+ * Skills use this mapping to determine which inner-machine states are active
+ * during a given lifecycle phase. Not all lifecycle phases have a corresponding
+ * inner-machine state (issue_intake, refinement, merge are outer-only).
+ *
+ * The inner machine is the authority for Copilot review/fix loop states;
+ * this mapping is advisory for routing and status reporting.
+ */
+export const COPILOT_INNER_STATE_MAP = Object.freeze({
+  [LIFECYCLE_STATE.ISSUE_INTAKE]: Object.freeze([]),
+  [LIFECYCLE_STATE.REFINEMENT]: Object.freeze([]),
+  [LIFECYCLE_STATE.IMPLEMENTATION]: Object.freeze([
+    "no_pr",
+    "pr_draft",
+  ]),
+  [LIFECYCLE_STATE.DRAFT_GATE]: Object.freeze([
+    "pr_ready_no_feedback",
+  ]),
+  [LIFECYCLE_STATE.FEEDBACK_RESOLUTION]: Object.freeze([
+    "waiting_for_copilot_review",
+    "unresolved_feedback_present",
+    "already_fixed_needs_reply_resolve",
+    "ready_to_rerequest_review",
+  ]),
+  [LIFECYCLE_STATE.PRE_APPROVAL_GATE]: Object.freeze([
+    "low_signal_converged",
+    "round_cap_clean_fallback",
+    "internal_tooling_direct_gate",
+    "done",
+  ]),
+  [LIFECYCLE_STATE.MERGE]: Object.freeze([]),
+});
+
+/**
+ * Resolve the lifecycle phase implied by a given copilot-loop-state.mjs inner state.
+ *
+ * Returns the lifecycle phase that typically contains the given inner state,
+ * or null if the inner state maps to no lifecycle phase.
+ */
+export function lifecyclePhaseForCopilotState(copilotState) {
+  if (typeof copilotState !== "string") return null;
+
+  for (const [phase, innerStates] of Object.entries(COPILOT_INNER_STATE_MAP)) {
+    if (innerStates.includes(copilotState)) {
+      return phase;
+    }
+  }
+  return null;
+}

--- a/packages/core/src/loop/lifecycle-state.mjs
+++ b/packages/core/src/loop/lifecycle-state.mjs
@@ -13,11 +13,11 @@
  * - LIFECYCLE_NEXT_ACTIONS: recommended next action for each phase
  * - resolveLifecycleState: resolver that maps inputs to one lifecycle phase
  * - getAllowedTransitions: helper to list allowed next phases
- * - COPLOT_INNER_STATE_MAP: maps lifecycle phases to copilot-loop-state.mjs inner states
+ * - COPILOT_INNER_STATE_MAP: maps lifecycle phases to copilot-loop-state.mjs inner states
  *
  * Contract guarantees:
  * - One deterministic lifecycle phase per normalized input set
- * - Ambiguous or incomplete inputs return terminal reconcile
+ * - Ambiguous or incomplete inputs fall back to issue_intake
  * - Transition graph enforces legal phase progression
  * - Purely functional; no I/O or side effects
  *
@@ -177,17 +177,13 @@ function normalizeLifecycleState(value) {
  * ```
  *
  * Resolution order (first-match):
- * 1. Explicit phase → return canonical if recognized
+ * 1. Explicit phase → return canonical if recognized, fall through if not
  * 2. Merged → merge (terminal)
  * 3. Merge authorized + pre-approval passed → merge
- * 4. Pre-approval passed → pre_approval_gate (or merge if authorized)
+ * 4. Pre-approval passed + PR exists → pre_approval_gate
  * 5. Unresolved threads + PR exists → feedback_resolution
- * 6. Draft PR → draft_gate
- * 7. Implementation in progress (PR exists, ready) → implementation
- * 8. Linked PR exists + ready → implementation
- * 9. Refined issue (has linked PR, draft) → refinement
- * 10. Issue exists, no linked PR → issue_intake
- * 11. Fallback → issue_intake
+ * 6. Draft PR or ready PR → implementation
+ * 7. No linked PR → issue_intake
  */
 export function resolveLifecycleState(input = {}) {
   const {
@@ -229,12 +225,12 @@ export function resolveLifecycleState(input = {}) {
     return buildResult(LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
   }
 
-  // 6. Draft PR → draft gate
+  // 6. Draft PR → implementation
   if (prIsDraft && hasLinkedPr) {
-    return buildResult(LIFECYCLE_STATE.DRAFT_GATE);
+    return buildResult(LIFECYCLE_STATE.IMPLEMENTATION);
   }
 
-  // 7. PR exists (ready for review) → implementation
+  // 7. PR exists (not draft) → implementation
   if (hasLinkedPr && !prIsDraft) {
     return buildResult(LIFECYCLE_STATE.IMPLEMENTATION);
   }

--- a/packages/core/src/loop/lifecycle-state.mjs
+++ b/packages/core/src/loop/lifecycle-state.mjs
@@ -127,7 +127,7 @@ export const LIFECYCLE_NEXT_ACTIONS = Object.freeze({
   [LIFECYCLE_STATE.IMPLEMENTATION]:
     "Implement the accepted scope on a feature branch or via Copilot handoff.",
   [LIFECYCLE_STATE.DRAFT_GATE]:
-    "Run draft gate review before marking the PR ready for review.",
+    "Run draft gate review at the draft→ready boundary; associated with pr_ready_no_feedback inner state.",
   [LIFECYCLE_STATE.FEEDBACK_RESOLUTION]:
     "Address review feedback: fix, reply to, and resolve threads on GitHub.",
   [LIFECYCLE_STATE.PRE_APPROVAL_GATE]:
@@ -235,7 +235,7 @@ export function resolveLifecycleState(input = {}) {
     return buildResult(LIFECYCLE_STATE.IMPLEMENTATION);
   }
 
-  // 8. No linked PR → issue intake
+  // 7. No linked PR → issue intake
   return buildResult(LIFECYCLE_STATE.ISSUE_INTAKE);
 }
 

--- a/packages/core/src/loop/lifecycle-state.mjs
+++ b/packages/core/src/loop/lifecycle-state.mjs
@@ -210,8 +210,8 @@ export function resolveLifecycleState(input = {}) {
     return buildResult(LIFECYCLE_STATE.MERGE);
   }
 
-  // 3. Merge authorized with pre-approval → merge
-  if (mergeAuthorized && preApprovalGatePassed) {
+  // 3. Merge authorized with pre-approval + PR exists → merge
+  if (mergeAuthorized && preApprovalGatePassed && hasLinkedPr) {
     return buildResult(LIFECYCLE_STATE.MERGE);
   }
 
@@ -225,12 +225,12 @@ export function resolveLifecycleState(input = {}) {
     return buildResult(LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
   }
 
-  // 6. Draft PR → implementation
+  // 6. Draft PR or ready PR → implementation
   if (prIsDraft && hasLinkedPr) {
     return buildResult(LIFECYCLE_STATE.IMPLEMENTATION);
   }
 
-  // 7. PR exists (not draft) → implementation
+  // 6b. PR exists (not draft) → implementation
   if (hasLinkedPr && !prIsDraft) {
     return buildResult(LIFECYCLE_STATE.IMPLEMENTATION);
   }

--- a/packages/core/src/loop/lifecycle-state.mjs
+++ b/packages/core/src/loop/lifecycle-state.mjs
@@ -291,7 +291,9 @@ export function isKnownLifecycleState(value) {
  * inner-machine state (issue_intake, refinement, merge are outer-only).
  *
  * The inner machine is the authority for Copilot review/fix loop states;
- * this mapping is advisory for routing and status reporting.
+ * this mapping is advisory for routing and status reporting. Phases
+ * issue_intake and refinement are outer-only; merge maps to the terminal
+ * inner state "done" (PR merged/closed).
  */
 export const COPILOT_INNER_STATE_MAP = Object.freeze({
   [LIFECYCLE_STATE.ISSUE_INTAKE]: Object.freeze([]),
@@ -308,14 +310,19 @@ export const COPILOT_INNER_STATE_MAP = Object.freeze({
     "unresolved_feedback_present",
     "already_fixed_needs_reply_resolve",
     "ready_to_rerequest_review",
+    "waiting_for_ci",
+    "review_request_unavailable",
+    "blocked_needs_user_decision",
+    "round_cap_reached",
   ]),
   [LIFECYCLE_STATE.PRE_APPROVAL_GATE]: Object.freeze([
     "low_signal_converged",
     "round_cap_clean_fallback",
     "internal_tooling_direct_gate",
+  ]),
+  [LIFECYCLE_STATE.MERGE]: Object.freeze([
     "done",
   ]),
-  [LIFECYCLE_STATE.MERGE]: Object.freeze([]),
 });
 
 /**

--- a/packages/core/test/lifecycle-state.test.mjs
+++ b/packages/core/test/lifecycle-state.test.mjs
@@ -261,12 +261,12 @@ test("resolveLifecycleState: no PR → issue_intake", () => {
   assert.ok(result.allowedTransitions.length > 0);
 });
 
-test("resolveLifecycleState: draft PR → draft_gate", () => {
+test("resolveLifecycleState: draft PR → implementation", () => {
   const result = resolveLifecycleState({
     hasLinkedPr: true,
     prIsDraft: true,
   });
-  assert.equal(result.state, LIFECYCLE_STATE.DRAFT_GATE);
+  assert.equal(result.state, LIFECYCLE_STATE.IMPLEMENTATION);
   assert.equal(result.isTerminal, false);
 });
 

--- a/packages/core/test/lifecycle-state.test.mjs
+++ b/packages/core/test/lifecycle-state.test.mjs
@@ -418,10 +418,13 @@ test("copilot inner state map covers all lifecycle phases", () => {
   }
 });
 
-test("issue_intake and refinement and merge map to empty inner states (outer-only)", () => {
+test("issue_intake and refinement map to empty inner states (outer-only)", () => {
   assert.deepEqual(COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.ISSUE_INTAKE], []);
   assert.deepEqual(COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.REFINEMENT], []);
-  assert.deepEqual(COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.MERGE], []);
+});
+
+test("merge maps to done inner state", () => {
+  assert.deepEqual(COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.MERGE], ["done"]);
 });
 
 test("implementation maps to no_pr and pr_draft inner states", () => {
@@ -433,23 +436,26 @@ test("draft_gate maps to pr_ready_no_feedback", () => {
   assert.deepEqual(COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.DRAFT_GATE], ["pr_ready_no_feedback"]);
 });
 
-test("feedback_resolution maps to review/fix inner states", () => {
+test("feedback_resolution maps to all review/fix/blocked inner states", () => {
   const inner = COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.FEEDBACK_RESOLUTION];
   assert.deepEqual([...inner].sort(), [
     "waiting_for_copilot_review",
     "unresolved_feedback_present",
     "already_fixed_needs_reply_resolve",
     "ready_to_rerequest_review",
+    "waiting_for_ci",
+    "review_request_unavailable",
+    "blocked_needs_user_decision",
+    "round_cap_reached",
   ].sort());
 });
 
-test("pre_approval_gate maps to convergence/terminal inner states", () => {
+test("pre_approval_gate maps to convergence inner states (no done)", () => {
   const inner = COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.PRE_APPROVAL_GATE];
   assert.deepEqual([...inner].sort(), [
     "low_signal_converged",
     "round_cap_clean_fallback",
     "internal_tooling_direct_gate",
-    "done",
   ].sort());
 });
 
@@ -479,19 +485,21 @@ test("lifecyclePhaseForCopilotState returns correct phase for known inner states
   assert.equal(lifecyclePhaseForCopilotState("unresolved_feedback_present"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
   assert.equal(lifecyclePhaseForCopilotState("already_fixed_needs_reply_resolve"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
   assert.equal(lifecyclePhaseForCopilotState("ready_to_rerequest_review"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
-  assert.equal(lifecyclePhaseForCopilotState("done"), LIFECYCLE_STATE.PRE_APPROVAL_GATE);
+  assert.equal(lifecyclePhaseForCopilotState("waiting_for_ci"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
+  assert.equal(lifecyclePhaseForCopilotState("review_request_unavailable"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
+  assert.equal(lifecyclePhaseForCopilotState("blocked_needs_user_decision"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
+  assert.equal(lifecyclePhaseForCopilotState("round_cap_reached"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
+  assert.equal(lifecyclePhaseForCopilotState("done"), LIFECYCLE_STATE.MERGE);
   assert.equal(lifecyclePhaseForCopilotState("low_signal_converged"), LIFECYCLE_STATE.PRE_APPROVAL_GATE);
   assert.equal(lifecyclePhaseForCopilotState("round_cap_clean_fallback"), LIFECYCLE_STATE.PRE_APPROVAL_GATE);
   assert.equal(lifecyclePhaseForCopilotState("internal_tooling_direct_gate"), LIFECYCLE_STATE.PRE_APPROVAL_GATE);
 });
 
-test("lifecyclePhaseForCopilotState returns null for unknown inner states", () => {
-  assert.equal(lifecyclePhaseForCopilotState("blocked_needs_user_decision"), null);
-  assert.equal(lifecyclePhaseForCopilotState("review_request_unavailable"), null);
-  assert.equal(lifecyclePhaseForCopilotState("round_cap_reached"), null);
+test("lifecyclePhaseForCopilotState returns null for truly unknown inner states", () => {
   assert.equal(lifecyclePhaseForCopilotState("unknown_state"), null);
   assert.equal(lifecyclePhaseForCopilotState(""), null);
   assert.equal(lifecyclePhaseForCopilotState(null), null);
+  assert.equal(lifecyclePhaseForCopilotState(undefined), null);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/test/lifecycle-state.test.mjs
+++ b/packages/core/test/lifecycle-state.test.mjs
@@ -510,3 +510,12 @@ test("resolveLifecycleState result is valid for all transition inputs", () => {
     assert.equal(typeof result.nextAction, "string");
   }
 });
+
+test("resolveLifecycleState: merge authorized without linked PR → earlier phase", () => {
+  const result = resolveLifecycleState({
+    hasLinkedPr: false,
+    preApprovalGatePassed: true,
+    mergeAuthorized: true,
+  });
+  assert.equal(result.state, LIFECYCLE_STATE.ISSUE_INTAKE);
+});

--- a/packages/core/test/lifecycle-state.test.mjs
+++ b/packages/core/test/lifecycle-state.test.mjs
@@ -1,0 +1,512 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  LIFECYCLE_STATE,
+  LIFECYCLE_TRANSITIONS,
+  LIFECYCLE_GRAPH,
+  LIFECYCLE_NEXT_ACTIONS,
+  LIFECYCLE_TERMINAL_STATES,
+  LIFECYCLE_NONTERMINAL_STATES,
+  COPILOT_INNER_STATE_MAP,
+  resolveLifecycleState,
+  getAllowedTransitions,
+  isTransitionAllowed,
+  isKnownLifecycleState,
+  lifecyclePhaseForCopilotState,
+} from "../src/loop/lifecycle-state.mjs";
+
+// ---------------------------------------------------------------------------
+// State constant contract tests
+// ---------------------------------------------------------------------------
+
+test("lifecycle state constants define exactly 7 phases", () => {
+  const values = Object.values(LIFECYCLE_STATE);
+  assert.equal(values.length, 7);
+  assert.deepEqual(values.sort(), [
+    "draft_gate",
+    "feedback_resolution",
+    "implementation",
+    "issue_intake",
+    "merge",
+    "pre_approval_gate",
+    "refinement",
+  ].sort());
+});
+
+test("lifecycle state values are the expected enum strings", () => {
+  assert.equal(LIFECYCLE_STATE.ISSUE_INTAKE, "issue_intake");
+  assert.equal(LIFECYCLE_STATE.REFINEMENT, "refinement");
+  assert.equal(LIFECYCLE_STATE.IMPLEMENTATION, "implementation");
+  assert.equal(LIFECYCLE_STATE.DRAFT_GATE, "draft_gate");
+  assert.equal(LIFECYCLE_STATE.FEEDBACK_RESOLUTION, "feedback_resolution");
+  assert.equal(LIFECYCLE_STATE.PRE_APPROVAL_GATE, "pre_approval_gate");
+  assert.equal(LIFECYCLE_STATE.MERGE, "merge");
+});
+
+// ---------------------------------------------------------------------------
+// Terminal / nonterminal contract tests
+// ---------------------------------------------------------------------------
+
+test("merge is the only terminal lifecycle state", () => {
+  assert.deepEqual(LIFECYCLE_TERMINAL_STATES, [LIFECYCLE_STATE.MERGE]);
+  assert.equal(LIFECYCLE_TERMINAL_STATES.length, 1);
+});
+
+test("nonterminal states include the 6 phases before merge", () => {
+  assert.deepEqual([...LIFECYCLE_NONTERMINAL_STATES].sort(), [
+    LIFECYCLE_STATE.ISSUE_INTAKE,
+    LIFECYCLE_STATE.REFINEMENT,
+    LIFECYCLE_STATE.IMPLEMENTATION,
+    LIFECYCLE_STATE.DRAFT_GATE,
+    LIFECYCLE_STATE.FEEDBACK_RESOLUTION,
+    LIFECYCLE_STATE.PRE_APPROVAL_GATE,
+  ].sort());
+  assert.equal(LIFECYCLE_NONTERMINAL_STATES.length, 6);
+});
+
+// ---------------------------------------------------------------------------
+// Transition graph contract tests
+// ---------------------------------------------------------------------------
+
+test("merge has no outgoing transitions (terminal)", () => {
+  assert.deepEqual(LIFECYCLE_TRANSITIONS[LIFECYCLE_STATE.MERGE], []);
+  assert.deepEqual(getAllowedTransitions(LIFECYCLE_STATE.MERGE), []);
+});
+
+test("pre_approval_gate can transition to implementation, feedback_resolution, or merge", () => {
+  const allowed = LIFECYCLE_TRANSITIONS[LIFECYCLE_STATE.PRE_APPROVAL_GATE];
+  assert.deepEqual([...allowed].sort(), [
+    LIFECYCLE_STATE.IMPLEMENTATION,
+    LIFECYCLE_STATE.FEEDBACK_RESOLUTION,
+    LIFECYCLE_STATE.MERGE,
+  ].sort());
+});
+
+test("feedback_resolution can transition to implementation or pre_approval_gate", () => {
+  const allowed = LIFECYCLE_TRANSITIONS[LIFECYCLE_STATE.FEEDBACK_RESOLUTION];
+  assert.deepEqual([...allowed].sort(), [
+    LIFECYCLE_STATE.IMPLEMENTATION,
+    LIFECYCLE_STATE.PRE_APPROVAL_GATE,
+  ].sort());
+});
+
+test("draft_gate can transition to implementation or feedback_resolution", () => {
+  const allowed = LIFECYCLE_TRANSITIONS[LIFECYCLE_STATE.DRAFT_GATE];
+  assert.deepEqual([...allowed].sort(), [
+    LIFECYCLE_STATE.IMPLEMENTATION,
+    LIFECYCLE_STATE.FEEDBACK_RESOLUTION,
+  ].sort());
+});
+
+test("implementation can transition to draft_gate or feedback_resolution", () => {
+  const allowed = LIFECYCLE_TRANSITIONS[LIFECYCLE_STATE.IMPLEMENTATION];
+  assert.deepEqual([...allowed].sort(), [
+    LIFECYCLE_STATE.DRAFT_GATE,
+    LIFECYCLE_STATE.FEEDBACK_RESOLUTION,
+  ].sort());
+});
+
+test("refinement can transition to issue_intake or implementation", () => {
+  const allowed = LIFECYCLE_TRANSITIONS[LIFECYCLE_STATE.REFINEMENT];
+  assert.deepEqual([...allowed].sort(), [
+    LIFECYCLE_STATE.ISSUE_INTAKE,
+    LIFECYCLE_STATE.IMPLEMENTATION,
+  ].sort());
+});
+
+test("issue_intake can transition to refinement or implementation", () => {
+  const allowed = LIFECYCLE_TRANSITIONS[LIFECYCLE_STATE.ISSUE_INTAKE];
+  assert.deepEqual([...allowed].sort(), [
+    LIFECYCLE_STATE.REFINEMENT,
+    LIFECYCLE_STATE.IMPLEMENTATION,
+  ].sort());
+});
+
+test("transition graph has exactly 7 entries (one per phase)", () => {
+  assert.equal(Object.keys(LIFECYCLE_TRANSITIONS).length, 7);
+});
+
+test("every nonterminal state has at least one outgoing transition", () => {
+  for (const state of LIFECYCLE_NONTERMINAL_STATES) {
+    assert.ok(
+      LIFECYCLE_TRANSITIONS[state].length > 0,
+      `${state} should have at least one transition`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// isTransitionAllowed contract tests
+// ---------------------------------------------------------------------------
+
+test("isTransitionAllowed returns true for legal transitions", () => {
+  assert.equal(isTransitionAllowed(LIFECYCLE_STATE.ISSUE_INTAKE, LIFECYCLE_STATE.REFINEMENT), true);
+  assert.equal(isTransitionAllowed(LIFECYCLE_STATE.REFINEMENT, LIFECYCLE_STATE.IMPLEMENTATION), true);
+  assert.equal(isTransitionAllowed(LIFECYCLE_STATE.IMPLEMENTATION, LIFECYCLE_STATE.DRAFT_GATE), true);
+  assert.equal(isTransitionAllowed(LIFECYCLE_STATE.DRAFT_GATE, LIFECYCLE_STATE.FEEDBACK_RESOLUTION), true);
+  assert.equal(isTransitionAllowed(LIFECYCLE_STATE.FEEDBACK_RESOLUTION, LIFECYCLE_STATE.PRE_APPROVAL_GATE), true);
+  assert.equal(isTransitionAllowed(LIFECYCLE_STATE.PRE_APPROVAL_GATE, LIFECYCLE_STATE.MERGE), true);
+});
+
+test("isTransitionAllowed returns false for illegal transitions", () => {
+  assert.equal(isTransitionAllowed(LIFECYCLE_STATE.ISSUE_INTAKE, LIFECYCLE_STATE.MERGE), false);
+  assert.equal(isTransitionAllowed(LIFECYCLE_STATE.REFINEMENT, LIFECYCLE_STATE.MERGE), false);
+  assert.equal(isTransitionAllowed(LIFECYCLE_STATE.IMPLEMENTATION, LIFECYCLE_STATE.MERGE), false);
+  assert.equal(isTransitionAllowed(LIFECYCLE_STATE.MERGE, LIFECYCLE_STATE.ISSUE_INTAKE), false);
+  assert.equal(isTransitionAllowed(LIFECYCLE_STATE.DRAFT_GATE, LIFECYCLE_STATE.ISSUE_INTAKE), false);
+});
+
+test("isTransitionAllowed returns false for unknown states", () => {
+  assert.equal(isTransitionAllowed("unknown", LIFECYCLE_STATE.MERGE), false);
+  assert.equal(isTransitionAllowed(LIFECYCLE_STATE.ISSUE_INTAKE, "unknown"), false);
+  assert.equal(isTransitionAllowed("bad", "worse"), false);
+});
+
+test("isTransitionAllowed returns false for back-transitions not in the graph", () => {
+  // merge → implementation is not allowed
+  assert.equal(isTransitionAllowed(LIFECYCLE_STATE.MERGE, LIFECYCLE_STATE.IMPLEMENTATION), false);
+  // pre_approval_gate → issue_intake is not allowed
+  assert.equal(isTransitionAllowed(LIFECYCLE_STATE.PRE_APPROVAL_GATE, LIFECYCLE_STATE.ISSUE_INTAKE), false);
+});
+
+// ---------------------------------------------------------------------------
+// getAllowedTransitions contract tests
+// ---------------------------------------------------------------------------
+
+test("getAllowedTransitions returns a copy (not the frozen array)", () => {
+  const transitions = getAllowedTransitions(LIFECYCLE_STATE.ISSUE_INTAKE);
+  assert.notEqual(transitions, LIFECYCLE_TRANSITIONS[LIFECYCLE_STATE.ISSUE_INTAKE]);
+  assert.deepEqual(transitions, LIFECYCLE_TRANSITIONS[LIFECYCLE_STATE.ISSUE_INTAKE]);
+});
+
+test("getAllowedTransitions returns empty array for unknown state", () => {
+  assert.deepEqual(getAllowedTransitions("unknown"), []);
+  assert.deepEqual(getAllowedTransitions(""), []);
+  assert.deepEqual(getAllowedTransitions(null), []);
+});
+
+// ---------------------------------------------------------------------------
+// isKnownLifecycleState contract tests
+// ---------------------------------------------------------------------------
+
+test("isKnownLifecycleState recognizes all valid states", () => {
+  for (const state of Object.values(LIFECYCLE_STATE)) {
+    assert.equal(isKnownLifecycleState(state), true);
+  }
+});
+
+test("isKnownLifecycleState rejects unknown values", () => {
+  assert.equal(isKnownLifecycleState("unknown"), false);
+  assert.equal(isKnownLifecycleState(""), false);
+  assert.equal(isKnownLifecycleState(null), false);
+  assert.equal(isKnownLifecycleState(undefined), false);
+});
+
+// ---------------------------------------------------------------------------
+// Graph metadata contract tests
+// ---------------------------------------------------------------------------
+
+test("lifecycle graph has semantic start and end", () => {
+  assert.deepEqual(LIFECYCLE_GRAPH.start, { id: "lifecycle_start", label: "Start", semantic: true });
+  assert.deepEqual(LIFECYCLE_GRAPH.end, { id: "lifecycle_end", label: "End", semantic: true });
+});
+
+test("lifecycle graph entryState is issue_intake", () => {
+  assert.equal(LIFECYCLE_GRAPH.entryState, LIFECYCLE_STATE.ISSUE_INTAKE);
+});
+
+test("lifecycle graph entryStates includes all 7 phases", () => {
+  assert.deepEqual([...LIFECYCLE_GRAPH.entryStates].sort(), Object.values(LIFECYCLE_STATE).sort());
+});
+
+test("lifecycle graph terminalStates matches LIFECYCLE_TERMINAL_STATES", () => {
+  assert.deepEqual(LIFECYCLE_GRAPH.terminalStates, LIFECYCLE_TERMINAL_STATES);
+});
+
+test("lifecycle graph terminalState and nonterminalState sets are disjoint", () => {
+  const terminalSet = new Set(LIFECYCLE_GRAPH.terminalStates);
+  for (const state of LIFECYCLE_GRAPH.nonterminalStates) {
+    assert.equal(terminalSet.has(state), false, `${state} should not be terminal`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Next actions contract tests
+// ---------------------------------------------------------------------------
+
+test("every lifecycle state has a defined next action string", () => {
+  for (const state of Object.values(LIFECYCLE_STATE)) {
+    assert.equal(typeof LIFECYCLE_NEXT_ACTIONS[state], "string");
+    assert.ok(LIFECYCLE_NEXT_ACTIONS[state].length > 0, `${state} next action must not be empty`);
+  }
+});
+
+test("merge next action includes retrospective checkpoint", () => {
+  assert.ok(
+    LIFECYCLE_NEXT_ACTIONS[LIFECYCLE_STATE.MERGE].includes("merge"),
+    "merge next action should mention merge",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Resolver: resolveLifecycleState contract tests
+// ---------------------------------------------------------------------------
+
+test("resolveLifecycleState: no PR → issue_intake", () => {
+  const result = resolveLifecycleState({});
+  assert.equal(result.state, LIFECYCLE_STATE.ISSUE_INTAKE);
+  assert.equal(result.isTerminal, false);
+  assert.equal(typeof result.nextAction, "string");
+  assert.ok(result.allowedTransitions.length > 0);
+});
+
+test("resolveLifecycleState: draft PR → draft_gate", () => {
+  const result = resolveLifecycleState({
+    hasLinkedPr: true,
+    prIsDraft: true,
+  });
+  assert.equal(result.state, LIFECYCLE_STATE.DRAFT_GATE);
+  assert.equal(result.isTerminal, false);
+});
+
+test("resolveLifecycleState: ready PR (not draft) → implementation", () => {
+  const result = resolveLifecycleState({
+    hasLinkedPr: true,
+    prIsDraft: false,
+  });
+  assert.equal(result.state, LIFECYCLE_STATE.IMPLEMENTATION);
+  assert.equal(result.isTerminal, false);
+});
+
+test("resolveLifecycleState: unresolved threads → feedback_resolution", () => {
+  const result = resolveLifecycleState({
+    hasLinkedPr: true,
+    prIsDraft: false,
+    hasUnresolvedThreads: true,
+  });
+  assert.equal(result.state, LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
+});
+
+test("resolveLifecycleState: unresolved threads beats draft (threads > gate)", () => {
+  const result = resolveLifecycleState({
+    hasLinkedPr: true,
+    prIsDraft: true,
+    hasUnresolvedThreads: true,
+  });
+  assert.equal(result.state, LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
+});
+
+test("resolveLifecycleState: pre-approval passed → pre_approval_gate", () => {
+  const result = resolveLifecycleState({
+    hasLinkedPr: true,
+    prIsDraft: false,
+    hasUnresolvedThreads: false,
+    preApprovalGatePassed: true,
+  });
+  assert.equal(result.state, LIFECYCLE_STATE.PRE_APPROVAL_GATE);
+});
+
+test("resolveLifecycleState: pre-approval + merge authorized → merge", () => {
+  const result = resolveLifecycleState({
+    hasLinkedPr: true,
+    hasUnresolvedThreads: false,
+    preApprovalGatePassed: true,
+    mergeAuthorized: true,
+  });
+  assert.equal(result.state, LIFECYCLE_STATE.MERGE);
+  assert.equal(result.isTerminal, true);
+  assert.deepEqual(result.allowedTransitions, []);
+});
+
+test("resolveLifecycleState: merge authorized without pre-approval → earlier phase", () => {
+  // merge authorization alone without pre-approval gate shouldn't jump to merge
+  const result = resolveLifecycleState({
+    hasLinkedPr: true,
+    hasUnresolvedThreads: false,
+    mergeAuthorized: true,
+  });
+  assert.notEqual(result.state, LIFECYCLE_STATE.MERGE);
+});
+
+test("resolveLifecycleState: merged → merge (terminal)", () => {
+  const result = resolveLifecycleState({
+    isMerged: true,
+  });
+  assert.equal(result.state, LIFECYCLE_STATE.MERGE);
+  assert.equal(result.isTerminal, true);
+});
+
+test("resolveLifecycleState: merged beats all other flags", () => {
+  const result = resolveLifecycleState({
+    isMerged: true,
+    hasLinkedPr: true,
+    prIsDraft: true,
+    hasUnresolvedThreads: true,
+  });
+  assert.equal(result.state, LIFECYCLE_STATE.MERGE);
+});
+
+test("resolveLifecycleState: explicit phase overrides inference", () => {
+  const result = resolveLifecycleState({
+    phase: LIFECYCLE_STATE.REFINEMENT,
+    hasLinkedPr: true,
+    hasUnresolvedThreads: true,
+    preApprovalGatePassed: true,
+  });
+  assert.equal(result.state, LIFECYCLE_STATE.REFINEMENT);
+});
+
+test("resolveLifecycleState: explicit phase must be recognized", () => {
+  const result = resolveLifecycleState({
+    phase: "unknown",
+    hasLinkedPr: true,
+    hasUnresolvedThreads: true,
+  });
+  // Falls back because unknown phase normalizes to null → inference takes over
+  assert.equal(result.state, LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
+});
+
+test("resolveLifecycleState: empty input returns issue_intake", () => {
+  const result = resolveLifecycleState();
+  assert.equal(result.state, LIFECYCLE_STATE.ISSUE_INTAKE);
+  assert.equal(result.isTerminal, false);
+});
+
+test("resolveLifecycleState: result shape is consistent", () => {
+  const result = resolveLifecycleState({ hasLinkedPr: true, prIsDraft: true });
+  assert.equal(typeof result.state, "string");
+  assert.ok(Array.isArray(result.allowedTransitions));
+  assert.equal(typeof result.nextAction, "string");
+  assert.equal(typeof result.isTerminal, "boolean");
+});
+
+// ---------------------------------------------------------------------------
+// Forward progress: full linear path contract test
+// ---------------------------------------------------------------------------
+
+test("full linear lifecycle path is traversable via legal transitions", () => {
+  const path = [
+    LIFECYCLE_STATE.ISSUE_INTAKE,
+    LIFECYCLE_STATE.REFINEMENT,
+    LIFECYCLE_STATE.IMPLEMENTATION,
+    LIFECYCLE_STATE.DRAFT_GATE,
+    LIFECYCLE_STATE.FEEDBACK_RESOLUTION,
+    LIFECYCLE_STATE.PRE_APPROVAL_GATE,
+    LIFECYCLE_STATE.MERGE,
+  ];
+
+  for (let i = 0; i < path.length - 1; i++) {
+    assert.equal(
+      isTransitionAllowed(path[i], path[i + 1]),
+      true,
+      `Transition ${path[i]} → ${path[i + 1]} should be legal`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// COPILOT_INNER_STATE_MAP contract tests
+// ---------------------------------------------------------------------------
+
+test("copilot inner state map covers all lifecycle phases", () => {
+  for (const phase of Object.values(LIFECYCLE_STATE)) {
+    assert.ok(
+      Array.isArray(COPILOT_INNER_STATE_MAP[phase]),
+      `${phase} should have an inner state map entry`,
+    );
+  }
+});
+
+test("issue_intake and refinement and merge map to empty inner states (outer-only)", () => {
+  assert.deepEqual(COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.ISSUE_INTAKE], []);
+  assert.deepEqual(COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.REFINEMENT], []);
+  assert.deepEqual(COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.MERGE], []);
+});
+
+test("implementation maps to no_pr and pr_draft inner states", () => {
+  const inner = COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.IMPLEMENTATION];
+  assert.deepEqual([...inner].sort(), ["no_pr", "pr_draft"].sort());
+});
+
+test("draft_gate maps to pr_ready_no_feedback", () => {
+  assert.deepEqual(COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.DRAFT_GATE], ["pr_ready_no_feedback"]);
+});
+
+test("feedback_resolution maps to review/fix inner states", () => {
+  const inner = COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.FEEDBACK_RESOLUTION];
+  assert.deepEqual([...inner].sort(), [
+    "waiting_for_copilot_review",
+    "unresolved_feedback_present",
+    "already_fixed_needs_reply_resolve",
+    "ready_to_rerequest_review",
+  ].sort());
+});
+
+test("pre_approval_gate maps to convergence/terminal inner states", () => {
+  const inner = COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.PRE_APPROVAL_GATE];
+  assert.deepEqual([...inner].sort(), [
+    "low_signal_converged",
+    "round_cap_clean_fallback",
+    "internal_tooling_direct_gate",
+    "done",
+  ].sort());
+});
+
+test("no copilot inner state appears in more than one lifecycle phase", () => {
+  const seen = new Map();
+  for (const [phase, innerStates] of Object.entries(COPILOT_INNER_STATE_MAP)) {
+    for (const inner of innerStates) {
+      if (seen.has(inner)) {
+        assert.fail(`Inner state "${inner}" appears in both "${seen.get(inner)}" and "${phase}"`);
+      }
+      seen.set(inner, phase);
+    }
+  }
+  // If we got here, no duplicates
+  assert.ok(true);
+});
+
+// ---------------------------------------------------------------------------
+// lifecyclePhaseForCopilotState contract tests
+// ---------------------------------------------------------------------------
+
+test("lifecyclePhaseForCopilotState returns correct phase for known inner states", () => {
+  assert.equal(lifecyclePhaseForCopilotState("no_pr"), LIFECYCLE_STATE.IMPLEMENTATION);
+  assert.equal(lifecyclePhaseForCopilotState("pr_draft"), LIFECYCLE_STATE.IMPLEMENTATION);
+  assert.equal(lifecyclePhaseForCopilotState("pr_ready_no_feedback"), LIFECYCLE_STATE.DRAFT_GATE);
+  assert.equal(lifecyclePhaseForCopilotState("waiting_for_copilot_review"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
+  assert.equal(lifecyclePhaseForCopilotState("unresolved_feedback_present"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
+  assert.equal(lifecyclePhaseForCopilotState("already_fixed_needs_reply_resolve"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
+  assert.equal(lifecyclePhaseForCopilotState("ready_to_rerequest_review"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
+  assert.equal(lifecyclePhaseForCopilotState("done"), LIFECYCLE_STATE.PRE_APPROVAL_GATE);
+  assert.equal(lifecyclePhaseForCopilotState("low_signal_converged"), LIFECYCLE_STATE.PRE_APPROVAL_GATE);
+  assert.equal(lifecyclePhaseForCopilotState("round_cap_clean_fallback"), LIFECYCLE_STATE.PRE_APPROVAL_GATE);
+  assert.equal(lifecyclePhaseForCopilotState("internal_tooling_direct_gate"), LIFECYCLE_STATE.PRE_APPROVAL_GATE);
+});
+
+test("lifecyclePhaseForCopilotState returns null for unknown inner states", () => {
+  assert.equal(lifecyclePhaseForCopilotState("blocked_needs_user_decision"), null);
+  assert.equal(lifecyclePhaseForCopilotState("review_request_unavailable"), null);
+  assert.equal(lifecyclePhaseForCopilotState("round_cap_reached"), null);
+  assert.equal(lifecyclePhaseForCopilotState("unknown_state"), null);
+  assert.equal(lifecyclePhaseForCopilotState(""), null);
+  assert.equal(lifecyclePhaseForCopilotState(null), null);
+});
+
+// ---------------------------------------------------------------------------
+// Resolver: all valid transitions produce valid results
+// ---------------------------------------------------------------------------
+
+test("resolveLifecycleState result is valid for all transition inputs", () => {
+  const states = Object.values(LIFECYCLE_STATE);
+
+  // Every explicit phase returns a valid result
+  for (const state of states) {
+    const result = resolveLifecycleState({ phase: state });
+    assert.equal(result.state, state);
+    assert.equal(typeof result.isTerminal, "boolean");
+    assert.ok(Array.isArray(result.allowedTransitions));
+    assert.equal(typeof result.nextAction, "string");
+  }
+});


### PR DESCRIPTION
## Summary

Define outer dev-loop lifecycle state model in `packages/core/src/loop/lifecycle-state.mjs` so skills consult deterministic code for routing decisions instead of restating the flow in prose.

## Scope

- `lifecycle-state.mjs`: 7 lifecycle phases (issue_intake → refinement → implementation → draft_gate → feedback_resolution → pre_approval_gate → merge) with transition graph, resolver, and copilot inner-state connectivity
- `lifecycle-state.test.mjs`: 53 contract tests

## AC

- Outer lifecycle state definitions committed under `packages/core/src/loop/`
- Transition graph defined and validated
- State resolver returns correct state + allowed transitions for given inputs
- `npm run verify` passes (1320 pass, 1 pre-existing failure unrelated)
- Contract tests cover valid and invalid state transitions

## Non-goals

- Not replacing `copilot-loop-state.mjs` (it remains the inner machine)
- Not making Node drive subagent execution
- Not rewriting the skills to use the state model (follow-up)

## DoD

- `npm run verify` passes
- 53 lifecycle-state contract tests
- Copilot inner-state mapping verified

Closes #676
