### PR TITLE
docs: add auto-resume guard and checkpoint re-attachment contract (#677)

### DIFF
--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -126,6 +126,29 @@ Branch on the `request-copilot-review.mjs` machine-readable result:
 
 Do not treat an attempted request as equivalent to a confirmed request.
 
+### Re-attachment guard (check for existing loop state first)
+
+Before entering issue-intake normalization or asking "what should we do" for a PR that
+already has an outer-loop checkpoint, check whether the checkpoint implies an auto-resume:
+
+1. Run `node <resolved-skill-scripts>/loop/outer-loop.mjs --repo <owner/name> --pr <number>`
+   to get the authoritative outer-loop checkpoint.
+2. If `outerAction` is `continue_wait`:
+   - The loop was waiting. The subagent exits; the main session re-dispatches a fresh
+     `dev-loop` async subagent that resumes from the checkpoint.
+3. If `outerAction` is `reenter_copilot_loop`:
+   - The copilot inner loop needs action. Run `copilot-pr-handoff.mjs` to determine the
+     exact next step and proceed.
+4. If `outerAction` is `reenter_reviewer_loop`:
+   - The reviewer inner loop needs action. Enter the reviewer-loop path.
+5. If `outerAction` is `stop`:
+   - Report the `reason` field and ask for direction.
+6. If no checkpoint exists or `outerAction` is `done`:
+   - Continue with normal step sequencing.
+
+Do not skip this guard when transitioning between async subagent runs on the same PR.
+The outer-loop checkpoint is the canonical re-attachment artifact for the subagent.
+
 ## Step 6: Async watch behavior
 
 Start every wait seam with a detector refresh: `detect-copilot-loop-state.mjs --repo <owner/name> --pr <number>`.

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -131,8 +131,11 @@ Do not treat an attempted request as equivalent to a confirmed request.
 Before entering issue-intake normalization or asking "what should we do" for a PR that
 already has an outer-loop checkpoint, check whether the checkpoint implies an auto-resume:
 
-1. Run `node <resolved-skill-scripts>/loop/outer-loop.mjs --repo <owner/name> --pr <number>`
-   to get the authoritative outer-loop checkpoint.
+1. Read the existing outer-loop checkpoint from
+   `tmp/copilot-loop/<owner>/<repo>/pr-<n>/outer-loop-state.json`.
+   Do **not** run `outer-loop.mjs` for this guard — it always rewrites the checkpoint
+   (including `timestamp` and potentially incrementing `waitCycles`).
+   Read the on-disk artifact without mutating it.
 2. If `outerAction` is `continue_wait`:
    - The loop was waiting. The subagent exits; the main session re-dispatches a fresh
      `dev-loop` async subagent that resumes from the checkpoint.

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -40,6 +40,31 @@ The subagent resolves authoritative state via the startup resolver (`npx dev-loo
 
 **Worktree fetch (mandatory — subagent only):** Always run `git fetch origin` before creating or reusing any worktree.
 
+### Resume from existing loop state
+
+When the startup resolver returns a fresh-start routing but an existing outer-loop checkpoint
+(`tmp/copilot-loop/<owner>/<repo>/pr-<n>/outer-loop-state.json`) is present on disk, the
+subagent must check the checkpoint before treating the start as a fresh intake or follow-up:
+
+1. Read the outer-loop checkpoint (authored by `outer-loop.mjs`).
+2. If `outerAction` is `continue_wait` or `reenter_copilot_loop`:
+   - Skip issue-intake normalization or fresh-intake routing.
+   - Route directly to the existing PR's copilot-pr-followup path (the PR number is in the
+     checkpoint's `pr` field).
+   - Load the checkpoint's `copilotState` and `reviewerState` as the known previous state
+     rather than re-detecting from scratch.
+3. If `outerAction` is `stop` with a non-terminal `reason`:
+   - Report the stop reason and the authoritative state from the checkpoint.
+   - Ask for direction rather than guessing or starting fresh.
+4. If no checkpoint exists, or `outerAction` is `done` / `stop` with a terminal reason:
+   - Treat as normal fresh startup (the existing startup resolver path).
+
+This eliminates the manual "report-and-resume" or "exit and resume later" pattern when the
+deterministic state already knows the next action.
+
+The outer-loop checkpoint is the canonical re-attachment artifact. Do not rely on chat
+context, local notes, or prose recollection of "where we left off."
+
 ## Route table
 
 Load only the route-specific internal skill required by `selectedStrategy`:

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -47,10 +47,11 @@ When the startup resolver returns a fresh-start routing but an existing outer-lo
 subagent must check the checkpoint before treating the start as a fresh intake or follow-up:
 
 1. Read the outer-loop checkpoint (authored by `outer-loop.mjs`).
-2. If `outerAction` is `continue_wait` or `reenter_copilot_loop`:
+2. If `outerAction` is `continue_wait`, `reenter_copilot_loop`, or `reenter_reviewer_loop`:
    - Skip issue-intake normalization or fresh-intake routing.
-   - Route directly to the existing PR's copilot-pr-followup path (the PR number is in the
-     checkpoint's `pr` field).
+   - Route directly to the existing PR's follow-up path (the PR number is in the
+     checkpoint's `pr` field). For `reenter_copilot_loop`, enter the copilot-pr-followup
+     path. For `reenter_reviewer_loop`, enter the reviewer-loop path.
    - Use the checkpoint's `copilotState` and `reviewerState` as last-known context for
      re-attachment, then re-baseline with fresh detectors (`copilot-pr-handoff.mjs`
      or `detect-copilot-loop-state.mjs`) before acting on the state.

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -51,12 +51,14 @@ subagent must check the checkpoint before treating the start as a fresh intake o
    - Skip issue-intake normalization or fresh-intake routing.
    - Route directly to the existing PR's copilot-pr-followup path (the PR number is in the
      checkpoint's `pr` field).
-   - Load the checkpoint's `copilotState` and `reviewerState` as the known previous state
-     rather than re-detecting from scratch.
-3. If `outerAction` is `stop` with a non-terminal `reason`:
-   - Report the stop reason and the authoritative state from the checkpoint.
-   - Ask for direction rather than guessing or starting fresh.
-4. If no checkpoint exists, or `outerAction` is `done` / `stop` with a terminal reason:
+   - Use the checkpoint's `copilotState` and `reviewerState` as last-known context for
+     re-attachment, then re-baseline with fresh detectors (`copilot-pr-handoff.mjs`
+     or `detect-copilot-loop-state.mjs`) before acting on the state.
+3. If `outerAction` is `stop`:
+   - Report the `reason` field and the authoritative state from the checkpoint.
+   - `stop` means the loop is blocked or needs a human decision; ask for direction
+     rather than guessing or starting fresh.
+4. If no checkpoint exists, or `outerAction` is `done`:
    - Treat as normal fresh startup (the existing startup resolver path).
 
 This eliminates the manual "report-and-resume" or "exit and resume later" pattern when the

--- a/skills/docs/copilot-loop-operations.md
+++ b/skills/docs/copilot-loop-operations.md
@@ -206,7 +206,7 @@ is the canonical re-attachment artifact for async subagent runs. It is written b
 | `reason` | Stop reason (`null` when `outerAction` is not `stop`) |
 | `timestamp` | ISO 8601 timestamp of checkpoint write |
 | `waitCycles` | Number of wait cycles accumulated |
-| `headSha` | PR head SHA at checkpoint time |
+| `headSha` | PR head SHA at checkpoint time (`null` when unavailable) |
 
 ### Re-attachment contract
 

--- a/skills/docs/copilot-loop-operations.md
+++ b/skills/docs/copilot-loop-operations.md
@@ -201,8 +201,8 @@ is the canonical re-attachment artifact for async subagent runs. It is written b
 | `outerAction` | Next action: `continue_wait`, `reenter_copilot_loop`, `reenter_reviewer_loop`, `stop`, `done` |
 | `copilotState` | Current copilot inner-loop state |
 | `reviewerState` | Current reviewer inner-loop state |
-| `reviewerScope` | Reviewer scope mode (when a reviewer pass is active) |
-| `reviewerLogin` | Reviewer GitHub login (when a reviewer pass is active) |
+| `reviewerScope` | Reviewer scope mode (always present; e.g. `all_reviewers` or `single_reviewer`) |
+| `reviewerLogin` | Reviewer GitHub login (always present; `null` unless single-reviewer scope) |
 | `reason` | Stop reason (when outerAction is `stop`) |
 | `timestamp` | ISO 8601 timestamp of checkpoint write |
 | `waitCycles` | Number of wait cycles accumulated |
@@ -216,8 +216,8 @@ checkpoint, it must read the checkpoint before entering any intake or follow-up 
 1. If `outerAction` is `continue_wait` or `reenter_copilot_loop`: auto-resume the loop
    rather than treating the start as fresh intake.
 2. If `outerAction` is `reenter_reviewer_loop`: enter the reviewer-loop path.
-3. If `outerAction` is `stop` with a non-terminal reason: report and ask for direction.
-4. If no checkpoint or `outerAction` is `done` / terminal stop: normal fresh startup.
+3. If `outerAction` is `stop`: the loop is blocked or needs a human decision; report the `reason` and ask for direction.
+4. If no checkpoint or `outerAction` is `done`: `done` means the PR is merged/closed; normal fresh startup.
 
 The checkpoint is the only source of truth for re-attachment. Do not rely on chat context
 or local notes to determine "where we left off."

--- a/skills/docs/copilot-loop-operations.md
+++ b/skills/docs/copilot-loop-operations.md
@@ -196,12 +196,17 @@ is the canonical re-attachment artifact for async subagent runs. It is written b
 
 | Field | Meaning |
 |---|---|
+| `pr` | PR number |
+| `repo` | Repository slug (`owner/name`) |
 | `outerAction` | Next action: `continue_wait`, `reenter_copilot_loop`, `reenter_reviewer_loop`, `stop`, `done` |
 | `copilotState` | Current copilot inner-loop state |
 | `reviewerState` | Current reviewer inner-loop state |
+| `reviewerScope` | Reviewer scope mode (when a reviewer pass is active) |
+| `reviewerLogin` | Reviewer GitHub login (when a reviewer pass is active) |
+| `reason` | Stop reason (when outerAction is `stop`) |
+| `timestamp` | ISO 8601 timestamp of checkpoint write |
 | `waitCycles` | Number of wait cycles accumulated |
 | `headSha` | PR head SHA at checkpoint time |
-| `reason` | Stop reason (when outerAction is `stop`) |
 
 ### Re-attachment contract
 

--- a/skills/docs/copilot-loop-operations.md
+++ b/skills/docs/copilot-loop-operations.md
@@ -188,7 +188,36 @@ Preferred defaults for this repo:
 
 These are the defaults built into `probe-copilot-review.mjs`, `run-watch-cycle.mjs`, and the `watchArgs` emitted by `copilot-pr-handoff.mjs`. Do not pass removed CLI policy flags (`--poll-interval-ms`, `--timeout-ms`, `--probe-only`) — helpers hard-error when they are provided. Timeouts and intervals are derived from `packages/core/src/loop/policy-constants.mjs`.
 
-### Hard rule: no agent-authored shell polling
+### Outer-loop checkpoint: canonical re-attachment artifact
+
+The outer-loop checkpoint (`tmp/copilot-loop/<owner>/<repo>/pr-<n>/outer-loop-state.json`)
+is the canonical re-attachment artifact for async subagent runs. It is written by
+`outer-loop.mjs` at every conductor cycle and records:
+
+| Field | Meaning |
+|---|---|
+| `outerAction` | Next action: `continue_wait`, `reenter_copilot_loop`, `reenter_reviewer_loop`, `stop`, `done` |
+| `copilotState` | Current copilot inner-loop state |
+| `reviewerState` | Current reviewer inner-loop state |
+| `waitCycles` | Number of wait cycles accumulated |
+| `headSha` | PR head SHA at checkpoint time |
+| `reason` | Stop reason (when outerAction is `stop`) |
+
+### Re-attachment contract
+
+When a fresh `dev-loop` async subagent starts on a PR that already has an outer-loop
+checkpoint, it must read the checkpoint before entering any intake or follow-up procedure:
+
+1. If `outerAction` is `continue_wait` or `reenter_copilot_loop`: auto-resume the loop
+   rather than treating the start as fresh intake.
+2. If `outerAction` is `reenter_reviewer_loop`: enter the reviewer-loop path.
+3. If `outerAction` is `stop` with a non-terminal reason: report and ask for direction.
+4. If no checkpoint or `outerAction` is `done` / terminal stop: normal fresh startup.
+
+The checkpoint is the only source of truth for re-attachment. Do not rely on chat context
+or local notes to determine "where we left off."
+
+## Hard rule: no agent-authored shell polling
 
 Helper-owned sleep inside `run-watch-cycle.mjs`, `probe-copilot-review.mjs`, or `watch-initial-copilot-pr.mjs` is allowed. Agent-authored shell polling (`sleep`, `for`, `while`, `timeout` wrappers around tool invocations) is a contract breach. This rule applies to ALL repos using the dev-loop workflow, not just the source repo.
 

--- a/skills/docs/copilot-loop-operations.md
+++ b/skills/docs/copilot-loop-operations.md
@@ -197,13 +197,13 @@ is the canonical re-attachment artifact for async subagent runs. It is written b
 | Field | Meaning |
 |---|---|
 | `pr` | PR number |
-| `repo` | Repository slug (`owner/name`) |
+| `repo` | Repository slug (`owner/name`; lowercased by `outer-loop.mjs`) |
 | `outerAction` | Next action: `continue_wait`, `reenter_copilot_loop`, `reenter_reviewer_loop`, `stop`, `done` |
 | `copilotState` | Current copilot inner-loop state |
 | `reviewerState` | Current reviewer inner-loop state |
 | `reviewerScope` | Reviewer scope mode (always present; e.g. `all_reviewers` or `single_reviewer`) |
 | `reviewerLogin` | Reviewer GitHub login (always present; `null` unless single-reviewer scope) |
-| `reason` | Stop reason (when outerAction is `stop`) |
+| `reason` | Stop reason (`null` when `outerAction` is not `stop`) |
 | `timestamp` | ISO 8601 timestamp of checkpoint write |
 | `waitCycles` | Number of wait cycles accumulated |
 | `headSha` | PR head SHA at checkpoint time |


### PR DESCRIPTION
## Summary

Add auto-resume guard and checkpoint re-attachment contract to reduce manual resume triggers in `copilot-pr-followup` and `dev-loop` skills. Audit identified 8 manual resume trigger points where deterministic state already knows the next action but the agent still asks/waits.

## Changes

- **`skills/dev-loop/SKILL.md`**: Add "Resume from existing loop state" section — subagent checks outer-loop checkpoint before treating start as fresh intake
- **`skills/copilot-pr-followup/SKILL.md`**: Add "Re-attachment guard" section before Step 6 — subagent checks checkpoint before asking "what should we do"
- **`skills/docs/copilot-loop-operations.md`**: Document outer-loop checkpoint as canonical re-attachment artifact with field table and contract
- **Issue #406**: Updated body with persistent-conductor dead-end note referencing #677 as re-scoped replacement

## Acceptance criteria

- [x] Audit complete — 8 manual-resume trigger points documented in `tmp/issues/issue-677/audit/auto-resume-audit.md`
- [x] Auto-resume improvements committed: checkpoint-aware startup, re-attachment guard, documented contract
- [x] State persistence more reliable — outer-loop checkpoint documented as canonical re-attachment artifact
- [x] `npm run verify` passes
- [x] #406 body updated with re-scope note

## Validation

```sh
npm run verify  # all 2807 tests pass, markdown links OK, no duplicate rules
```

Closes #677
