### PR TITLE
feat(#679): integrate lifecycle state model into inspect-run-viewer as 4th Mermaid lane

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "pi-dev-loops",
+      "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,7 @@
     "./loop/copilot-loop-iterations": "./src/loop/copilot-loop-iterations.mjs",
     "./loop/copilot-loop-state": "./src/loop/copilot-loop-state.mjs",
     "./loop/handoff-envelope": "./src/loop/handoff-envelope.mjs",
+    "./loop/lifecycle-state": "./src/loop/lifecycle-state.mjs",
     "./loop/issue-refinement-artifact": "./src/loop/issue-refinement-artifact.mjs",
     "./loop/phase-files": "./src/loop/phase-files.mjs",
     "./loop/policy-constants": "./src/loop/policy-constants.mjs",

--- a/packages/core/src/loop/lifecycle-state.mjs
+++ b/packages/core/src/loop/lifecycle-state.mjs
@@ -127,7 +127,7 @@ export const LIFECYCLE_NEXT_ACTIONS = Object.freeze({
   [LIFECYCLE_STATE.IMPLEMENTATION]:
     "Implement the accepted scope on a feature branch or via Copilot handoff.",
   [LIFECYCLE_STATE.DRAFT_GATE]:
-    "Run draft gate review at the draft→ready boundary; associated with pr_ready_no_feedback inner state.",
+    "Run draft gate review before marking the PR ready for review.",
   [LIFECYCLE_STATE.FEEDBACK_RESOLUTION]:
     "Address review feedback: fix, reply to, and resolve threads on GitHub.",
   [LIFECYCLE_STATE.PRE_APPROVAL_GATE]:
@@ -210,8 +210,8 @@ export function resolveLifecycleState(input = {}) {
     return buildResult(LIFECYCLE_STATE.MERGE);
   }
 
-  // 3. Merge authorized with pre-approval + PR exists → merge
-  if (mergeAuthorized && preApprovalGatePassed && hasLinkedPr) {
+  // 3. Merge authorized with pre-approval → merge
+  if (mergeAuthorized && preApprovalGatePassed) {
     return buildResult(LIFECYCLE_STATE.MERGE);
   }
 
@@ -225,17 +225,17 @@ export function resolveLifecycleState(input = {}) {
     return buildResult(LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
   }
 
-  // 6. Draft PR or ready PR → implementation
+  // 6. Draft PR → implementation
   if (prIsDraft && hasLinkedPr) {
     return buildResult(LIFECYCLE_STATE.IMPLEMENTATION);
   }
 
-  // 6b. PR exists (not draft) → implementation
+  // 7. PR exists (not draft) → implementation
   if (hasLinkedPr && !prIsDraft) {
     return buildResult(LIFECYCLE_STATE.IMPLEMENTATION);
   }
 
-  // 7. No linked PR → issue intake
+  // 8. No linked PR → issue intake
   return buildResult(LIFECYCLE_STATE.ISSUE_INTAKE);
 }
 
@@ -291,9 +291,7 @@ export function isKnownLifecycleState(value) {
  * inner-machine state (issue_intake, refinement, merge are outer-only).
  *
  * The inner machine is the authority for Copilot review/fix loop states;
- * this mapping is advisory for routing and status reporting. Phases
- * issue_intake and refinement are outer-only (no inner-machine states);
- * inner state "done" (PR merged/closed).
+ * this mapping is advisory for routing and status reporting.
  */
 export const COPILOT_INNER_STATE_MAP = Object.freeze({
   [LIFECYCLE_STATE.ISSUE_INTAKE]: Object.freeze([]),
@@ -310,19 +308,14 @@ export const COPILOT_INNER_STATE_MAP = Object.freeze({
     "unresolved_feedback_present",
     "already_fixed_needs_reply_resolve",
     "ready_to_rerequest_review",
-    "waiting_for_ci",
-    "review_request_unavailable",
-    "blocked_needs_user_decision",
-    "round_cap_reached",
   ]),
   [LIFECYCLE_STATE.PRE_APPROVAL_GATE]: Object.freeze([
     "low_signal_converged",
     "round_cap_clean_fallback",
     "internal_tooling_direct_gate",
-  ]),
-  [LIFECYCLE_STATE.MERGE]: Object.freeze([
     "done",
   ]),
+  [LIFECYCLE_STATE.MERGE]: Object.freeze([]),
 });
 
 /**

--- a/packages/core/src/loop/lifecycle-state.mjs
+++ b/packages/core/src/loop/lifecycle-state.mjs
@@ -179,7 +179,7 @@ function normalizeLifecycleState(value) {
  * Resolution order (first-match):
  * 1. Explicit phase → return canonical if recognized, fall through if not
  * 2. Merged → merge (terminal)
- * 3. Merge authorized + pre-approval passed → merge
+ * 3. Merge authorized + pre-approval passed + linked PR → merge
  * 4. Pre-approval passed + PR exists → pre_approval_gate
  * 5. Unresolved threads + PR exists → feedback_resolution
  * 6. Draft PR or ready PR → implementation
@@ -211,7 +211,7 @@ export function resolveLifecycleState(input = {}) {
   }
 
   // 3. Merge authorized with pre-approval → merge
-  if (mergeAuthorized && preApprovalGatePassed) {
+  if (mergeAuthorized && preApprovalGatePassed && hasLinkedPr) {
     return buildResult(LIFECYCLE_STATE.MERGE);
   }
 
@@ -288,7 +288,7 @@ export function isKnownLifecycleState(value) {
  *
  * Skills use this mapping to determine which inner-machine states are active
  * during a given lifecycle phase. Not all lifecycle phases have a corresponding
- * inner-machine state (issue_intake, refinement, merge are outer-only).
+ * inner-machine state (issue_intake and refinement are outer-only).
  *
  * The inner machine is the authority for Copilot review/fix loop states;
  * this mapping is advisory for routing and status reporting.
@@ -308,14 +308,19 @@ export const COPILOT_INNER_STATE_MAP = Object.freeze({
     "unresolved_feedback_present",
     "already_fixed_needs_reply_resolve",
     "ready_to_rerequest_review",
+    "waiting_for_ci",
+    "review_request_unavailable",
+    "blocked_needs_user_decision",
+    "round_cap_reached",
   ]),
   [LIFECYCLE_STATE.PRE_APPROVAL_GATE]: Object.freeze([
     "low_signal_converged",
     "round_cap_clean_fallback",
     "internal_tooling_direct_gate",
+  ]),
+  [LIFECYCLE_STATE.MERGE]: Object.freeze([
     "done",
   ]),
-  [LIFECYCLE_STATE.MERGE]: Object.freeze([]),
 });
 
 /**

--- a/packages/core/src/loop/lifecycle-state.mjs
+++ b/packages/core/src/loop/lifecycle-state.mjs
@@ -210,7 +210,7 @@ export function resolveLifecycleState(input = {}) {
     return buildResult(LIFECYCLE_STATE.MERGE);
   }
 
-  // 3. Merge authorized with pre-approval → merge
+  // 3. Merge authorized with pre-approval + linked PR → merge
   if (mergeAuthorized && preApprovalGatePassed && hasLinkedPr) {
     return buildResult(LIFECYCLE_STATE.MERGE);
   }

--- a/packages/core/src/loop/lifecycle-state.mjs
+++ b/packages/core/src/loop/lifecycle-state.mjs
@@ -182,8 +182,9 @@ function normalizeLifecycleState(value) {
  * 3. Merge authorized + pre-approval passed + linked PR → merge
  * 4. Pre-approval passed + PR exists → pre_approval_gate
  * 5. Unresolved threads + PR exists → feedback_resolution
- * 6. Draft PR or ready PR → implementation
- * 7. No linked PR → issue_intake
+ * 6. Draft PR → implementation
+ * 7. Ready PR (not draft) → implementation
+ * 8. No linked PR → issue_intake
  */
 export function resolveLifecycleState(input = {}) {
   const {

--- a/packages/core/src/loop/run-inspection.mjs
+++ b/packages/core/src/loop/run-inspection.mjs
@@ -25,6 +25,7 @@
 
 import { summarizeLoopInterpretation } from "./copilot-loop-state.mjs";
 import { isKnownOuterState } from "./conductor-routing.mjs";
+import { getAllowedTransitions, lifecyclePhaseForCopilotState, resolveLifecycleState } from "./lifecycle-state.mjs";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -536,6 +537,41 @@ export function composeRunInspectionSnapshot({
   }
 
   // -------------------------------------------------------------------------
+  // Lifecycle phase resolution (best-effort from available PR facts)
+  // -------------------------------------------------------------------------
+
+  let lifecyclePhase = null;
+  let lifecycleAllowedTransitions = null;
+
+  if (copilotLiveOk && copilotEvidence !== null) {
+    const copilotState = copilotEvidence.interpretation.state;
+    const mappedPhase = lifecyclePhaseForCopilotState(copilotState);
+    if (mappedPhase) {
+      lifecyclePhase = mappedPhase;
+      lifecycleAllowedTransitions = getAllowedTransitions(mappedPhase);
+    }
+  }
+
+  if (lifecyclePhase === null) {
+    // Fallback: derive from available PR facts
+    const loopIter = loopIterations ?? {};
+    const hasUnresolvedThreads = typeof loopIter.unresolvedReviewThreads === "number"
+      && loopIter.unresolvedReviewThreads > 0;
+    const copilotState = copilotLiveOk && copilotEvidence !== null
+      ? copilotEvidence.interpretation.state
+      : null;
+    const prIsDraft = copilotState === "pr_draft";
+
+    const resolved = resolveLifecycleState({
+      hasLinkedPr: true,
+      prIsDraft,
+      hasUnresolvedThreads,
+    });
+    lifecyclePhase = resolved.state;
+    lifecycleAllowedTransitions = resolved.allowedTransitions;
+  }
+
+  // -------------------------------------------------------------------------
   // Assemble final snapshot
   // -------------------------------------------------------------------------
 
@@ -562,5 +598,7 @@ export function composeRunInspectionSnapshot({
     markers,
     loopIterations,
     layers,
+    lifecyclePhase,
+    lifecycleAllowedTransitions,
   };
 }

--- a/packages/core/src/loop/run-inspection.mjs
+++ b/packages/core/src/loop/run-inspection.mjs
@@ -563,7 +563,7 @@ export function composeRunInspectionSnapshot({
     const prIsDraft = copilotState === "pr_draft";
 
     const resolved = resolveLifecycleState({
-      hasLinkedPr: true,
+      hasLinkedPr: !explicitTargetMissing,
       prIsDraft,
       hasUnresolvedThreads,
     });

--- a/packages/core/test/lifecycle-state.test.mjs
+++ b/packages/core/test/lifecycle-state.test.mjs
@@ -503,7 +503,7 @@ test("lifecyclePhaseForCopilotState returns correct phase for known inner states
   assert.equal(lifecyclePhaseForCopilotState("internal_tooling_direct_gate"), LIFECYCLE_STATE.PRE_APPROVAL_GATE);
 });
 
-test("lifecyclePhaseForCopilotState returns null for unknown inner states", () => {
+test("lifecyclePhaseForCopilotState handles known fallback and unknown inner states", () => {
   assert.equal(lifecyclePhaseForCopilotState("blocked_needs_user_decision"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
   assert.equal(lifecyclePhaseForCopilotState("review_request_unavailable"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
   assert.equal(lifecyclePhaseForCopilotState("round_cap_reached"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);

--- a/packages/core/test/lifecycle-state.test.mjs
+++ b/packages/core/test/lifecycle-state.test.mjs
@@ -418,13 +418,10 @@ test("copilot inner state map covers all lifecycle phases", () => {
   }
 });
 
-test("issue_intake and refinement map to empty inner states (outer-only)", () => {
+test("issue_intake and refinement and merge map to empty inner states (outer-only)", () => {
   assert.deepEqual(COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.ISSUE_INTAKE], []);
   assert.deepEqual(COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.REFINEMENT], []);
-});
-
-test("merge maps to done inner state", () => {
-  assert.deepEqual(COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.MERGE], ["done"]);
+  assert.deepEqual(COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.MERGE], []);
 });
 
 test("implementation maps to no_pr and pr_draft inner states", () => {
@@ -436,26 +433,23 @@ test("draft_gate maps to pr_ready_no_feedback", () => {
   assert.deepEqual(COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.DRAFT_GATE], ["pr_ready_no_feedback"]);
 });
 
-test("feedback_resolution maps to all review/fix/blocked inner states", () => {
+test("feedback_resolution maps to review/fix inner states", () => {
   const inner = COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.FEEDBACK_RESOLUTION];
   assert.deepEqual([...inner].sort(), [
     "waiting_for_copilot_review",
     "unresolved_feedback_present",
     "already_fixed_needs_reply_resolve",
     "ready_to_rerequest_review",
-    "waiting_for_ci",
-    "review_request_unavailable",
-    "blocked_needs_user_decision",
-    "round_cap_reached",
   ].sort());
 });
 
-test("pre_approval_gate maps to convergence inner states (no done)", () => {
+test("pre_approval_gate maps to convergence/terminal inner states", () => {
   const inner = COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.PRE_APPROVAL_GATE];
   assert.deepEqual([...inner].sort(), [
     "low_signal_converged",
     "round_cap_clean_fallback",
     "internal_tooling_direct_gate",
+    "done",
   ].sort());
 });
 
@@ -485,21 +479,19 @@ test("lifecyclePhaseForCopilotState returns correct phase for known inner states
   assert.equal(lifecyclePhaseForCopilotState("unresolved_feedback_present"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
   assert.equal(lifecyclePhaseForCopilotState("already_fixed_needs_reply_resolve"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
   assert.equal(lifecyclePhaseForCopilotState("ready_to_rerequest_review"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
-  assert.equal(lifecyclePhaseForCopilotState("waiting_for_ci"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
-  assert.equal(lifecyclePhaseForCopilotState("review_request_unavailable"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
-  assert.equal(lifecyclePhaseForCopilotState("blocked_needs_user_decision"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
-  assert.equal(lifecyclePhaseForCopilotState("round_cap_reached"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
-  assert.equal(lifecyclePhaseForCopilotState("done"), LIFECYCLE_STATE.MERGE);
+  assert.equal(lifecyclePhaseForCopilotState("done"), LIFECYCLE_STATE.PRE_APPROVAL_GATE);
   assert.equal(lifecyclePhaseForCopilotState("low_signal_converged"), LIFECYCLE_STATE.PRE_APPROVAL_GATE);
   assert.equal(lifecyclePhaseForCopilotState("round_cap_clean_fallback"), LIFECYCLE_STATE.PRE_APPROVAL_GATE);
   assert.equal(lifecyclePhaseForCopilotState("internal_tooling_direct_gate"), LIFECYCLE_STATE.PRE_APPROVAL_GATE);
 });
 
-test("lifecyclePhaseForCopilotState returns null for truly unknown inner states", () => {
+test("lifecyclePhaseForCopilotState returns null for unknown inner states", () => {
+  assert.equal(lifecyclePhaseForCopilotState("blocked_needs_user_decision"), null);
+  assert.equal(lifecyclePhaseForCopilotState("review_request_unavailable"), null);
+  assert.equal(lifecyclePhaseForCopilotState("round_cap_reached"), null);
   assert.equal(lifecyclePhaseForCopilotState("unknown_state"), null);
   assert.equal(lifecyclePhaseForCopilotState(""), null);
   assert.equal(lifecyclePhaseForCopilotState(null), null);
-  assert.equal(lifecyclePhaseForCopilotState(undefined), null);
 });
 
 // ---------------------------------------------------------------------------
@@ -517,13 +509,4 @@ test("resolveLifecycleState result is valid for all transition inputs", () => {
     assert.ok(Array.isArray(result.allowedTransitions));
     assert.equal(typeof result.nextAction, "string");
   }
-});
-
-test("resolveLifecycleState: merge authorized without linked PR → earlier phase", () => {
-  const result = resolveLifecycleState({
-    hasLinkedPr: false,
-    preApprovalGatePassed: true,
-    mergeAuthorized: true,
-  });
-  assert.equal(result.state, LIFECYCLE_STATE.ISSUE_INTAKE);
 });

--- a/packages/core/test/lifecycle-state.test.mjs
+++ b/packages/core/test/lifecycle-state.test.mjs
@@ -319,6 +319,17 @@ test("resolveLifecycleState: pre-approval + merge authorized → merge", () => {
   assert.deepEqual(result.allowedTransitions, []);
 });
 
+test("resolveLifecycleState: pre-approval + merge authorized without linked PR → not merge", () => {
+  const result = resolveLifecycleState({
+    hasLinkedPr: false,
+    hasUnresolvedThreads: false,
+    preApprovalGatePassed: true,
+    mergeAuthorized: true,
+  });
+  assert.notEqual(result.state, LIFECYCLE_STATE.MERGE);
+  assert.equal(result.state, LIFECYCLE_STATE.ISSUE_INTAKE);
+});
+
 test("resolveLifecycleState: merge authorized without pre-approval → earlier phase", () => {
   // merge authorization alone without pre-approval gate shouldn't jump to merge
   const result = resolveLifecycleState({
@@ -418,10 +429,13 @@ test("copilot inner state map covers all lifecycle phases", () => {
   }
 });
 
-test("issue_intake and refinement and merge map to empty inner states (outer-only)", () => {
+test("issue_intake and refinement map to empty inner states (outer-only)", () => {
   assert.deepEqual(COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.ISSUE_INTAKE], []);
   assert.deepEqual(COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.REFINEMENT], []);
-  assert.deepEqual(COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.MERGE], []);
+});
+
+test("merge maps to done inner state", () => {
+  assert.deepEqual(COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.MERGE], ["done"]);
 });
 
 test("implementation maps to no_pr and pr_draft inner states", () => {
@@ -440,16 +454,19 @@ test("feedback_resolution maps to review/fix inner states", () => {
     "unresolved_feedback_present",
     "already_fixed_needs_reply_resolve",
     "ready_to_rerequest_review",
+    "waiting_for_ci",
+    "review_request_unavailable",
+    "blocked_needs_user_decision",
+    "round_cap_reached",
   ].sort());
 });
 
-test("pre_approval_gate maps to convergence/terminal inner states", () => {
+test("pre_approval_gate maps to convergence inner states", () => {
   const inner = COPILOT_INNER_STATE_MAP[LIFECYCLE_STATE.PRE_APPROVAL_GATE];
   assert.deepEqual([...inner].sort(), [
     "low_signal_converged",
     "round_cap_clean_fallback",
     "internal_tooling_direct_gate",
-    "done",
   ].sort());
 });
 
@@ -479,16 +496,17 @@ test("lifecyclePhaseForCopilotState returns correct phase for known inner states
   assert.equal(lifecyclePhaseForCopilotState("unresolved_feedback_present"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
   assert.equal(lifecyclePhaseForCopilotState("already_fixed_needs_reply_resolve"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
   assert.equal(lifecyclePhaseForCopilotState("ready_to_rerequest_review"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
-  assert.equal(lifecyclePhaseForCopilotState("done"), LIFECYCLE_STATE.PRE_APPROVAL_GATE);
+  assert.equal(lifecyclePhaseForCopilotState("waiting_for_ci"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
+  assert.equal(lifecyclePhaseForCopilotState("done"), LIFECYCLE_STATE.MERGE);
   assert.equal(lifecyclePhaseForCopilotState("low_signal_converged"), LIFECYCLE_STATE.PRE_APPROVAL_GATE);
   assert.equal(lifecyclePhaseForCopilotState("round_cap_clean_fallback"), LIFECYCLE_STATE.PRE_APPROVAL_GATE);
   assert.equal(lifecyclePhaseForCopilotState("internal_tooling_direct_gate"), LIFECYCLE_STATE.PRE_APPROVAL_GATE);
 });
 
 test("lifecyclePhaseForCopilotState returns null for unknown inner states", () => {
-  assert.equal(lifecyclePhaseForCopilotState("blocked_needs_user_decision"), null);
-  assert.equal(lifecyclePhaseForCopilotState("review_request_unavailable"), null);
-  assert.equal(lifecyclePhaseForCopilotState("round_cap_reached"), null);
+  assert.equal(lifecyclePhaseForCopilotState("blocked_needs_user_decision"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
+  assert.equal(lifecyclePhaseForCopilotState("review_request_unavailable"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
+  assert.equal(lifecyclePhaseForCopilotState("round_cap_reached"), LIFECYCLE_STATE.FEEDBACK_RESOLUTION);
   assert.equal(lifecyclePhaseForCopilotState("unknown_state"), null);
   assert.equal(lifecyclePhaseForCopilotState(""), null);
   assert.equal(lifecyclePhaseForCopilotState(null), null);

--- a/scripts/loop/inspect-run-viewer/graph.mjs
+++ b/scripts/loop/inspect-run-viewer/graph.mjs
@@ -375,8 +375,8 @@ export function buildInspectionMermaidGraph(snapshot) {
     '  reviewer_layer_start ~~~ lifecycle_layer_start',
     '  outer_loop_family_start ~~~ lifecycle_layer_start',
     `  ${lanes[0].currentId} -. "layer view" .-> ${lanes[1].currentId}`,
-    `  ${lanes[1].currentId} -. "layer view" .-> ${lanes[2].currentId}`,
-    `  ${lanes[2].currentId} -. "layer view" .-> ${lanes[3].currentId}`,
+    `  ${lanes[0].currentId} -. "layer view" .-> ${lanes[2].currentId}`,
+    `  ${lanes[0].currentId} -. "layer view" .-> ${lanes[3].currentId}`,
   ];
 
   for (const [className, ids] of Object.entries(classIds)) {

--- a/scripts/loop/inspect-run-viewer/graph.mjs
+++ b/scripts/loop/inspect-run-viewer/graph.mjs
@@ -351,6 +351,13 @@ export function buildInspectionMermaidGraph(snapshot) {
     }
   }
 
+  const orderedLaneLines = [
+    '  subgraph lane_stack[" "]',
+    '    direction TB',
+    ...lanes.flatMap((lane) => lane.lines.map((line) => `    ${line.trimStart()}`)),
+    '  end',
+  ];
+
   const lines = [
     "flowchart TB",
     "  classDef cue fill:#f5f7f9,stroke:#78909c,stroke-width:1.5px,color:#355061,font-weight:bold;",
@@ -362,10 +369,13 @@ export function buildInspectionMermaidGraph(snapshot) {
     "  classDef inactive fill:#ffffff,stroke:#b0bec5,stroke-width:1.5px,color:#607d8b;",
     "  classDef unavailable fill:#f8fafc,stroke:#90a4ae,stroke-width:2px,color:#546e7a,stroke-dasharray: 6 4;",
     "  classDef note fill:#fff3e0,stroke:#ef6c00,stroke-width:2px,color:#7f4b00;",
-    ...lanes.flatMap((lane) => lane.lines),
+    ...orderedLaneLines,
+    '  outer_loop_family_start ~~~ copilot_layer_start',
+    '  copilot_layer_start ~~~ reviewer_layer_start',
+    '  reviewer_layer_start ~~~ lifecycle_layer_start',
     `  ${lanes[0].currentId} -. "layer view" .-> ${lanes[1].currentId}`,
-    `  ${lanes[0].currentId} -. "layer view" .-> ${lanes[2].currentId}`,
-    `  ${lanes[0].currentId} -. "layer view" .-> ${lanes[3].currentId}`,
+    `  ${lanes[1].currentId} -. "layer view" .-> ${lanes[2].currentId}`,
+    `  ${lanes[2].currentId} -. "layer view" .-> ${lanes[3].currentId}`,
   ];
 
   for (const [className, ids] of Object.entries(classIds)) {

--- a/scripts/loop/inspect-run-viewer/graph.mjs
+++ b/scripts/loop/inspect-run-viewer/graph.mjs
@@ -19,6 +19,12 @@ import {
   REVIEWER_TRANSITIONS,
 } from "@pi-dev-loops/core/loop/reviewer-loop-state";
 import {
+  LIFECYCLE_GRAPH,
+  LIFECYCLE_STATE,
+  LIFECYCLE_TERMINAL_STATES,
+  LIFECYCLE_TRANSITIONS,
+} from "@pi-dev-loops/core/loop/lifecycle-state";
+import {
   escapeHtml,
   formatStateToken,
   renderSnapshotStateLabel,
@@ -62,6 +68,8 @@ const REVIEWER_TERMINAL_STATES = new Set(
     .filter(([, nextStates]) => Array.isArray(nextStates) && nextStates.length === 0)
     .map(([state]) => state),
 );
+
+const LIFECYCLE_TERMINAL_STATE_SET = new Set(LIFECYCLE_TERMINAL_STATES);
 
 function normalizeCurrentStateInfo(currentState, { knownStates = null, terminalStates = null } = {}) {
   if (typeof currentState === "string" && currentState.length > 0) {
@@ -310,6 +318,19 @@ export function buildInspectionMermaidGraph(snapshot) {
       startStates: [REVIEWER_STATE.WAITING_FOR_REVIEW_REQUEST],
       terminalStates: REVIEWER_TERMINAL_STATES,
     }),
+    buildFullStateMachineLane({
+      laneKey: "lifecycle_layer",
+      title: "lifecycle",
+      states: Object.values(LIFECYCLE_STATE),
+      transitionTable: LIFECYCLE_TRANSITIONS,
+      currentState: snapshot.lifecyclePhase,
+      transitions: snapshot.lifecycleAllowedTransitions,
+      startStates: LIFECYCLE_GRAPH.entryStates,
+      startLabel: LIFECYCLE_GRAPH.start.label,
+      endLabel: LIFECYCLE_GRAPH.end.label,
+      terminalStates: LIFECYCLE_TERMINAL_STATE_SET,
+      displayLabelForState: humanizeGraphStateLabel,
+    }),
   ];
 
   const classIds = {
@@ -344,6 +365,7 @@ export function buildInspectionMermaidGraph(snapshot) {
     ...lanes.flatMap((lane) => lane.lines),
     `  ${lanes[0].currentId} -. "layer view" .-> ${lanes[1].currentId}`,
     `  ${lanes[0].currentId} -. "layer view" .-> ${lanes[2].currentId}`,
+    `  ${lanes[0].currentId} -. "layer view" .-> ${lanes[3].currentId}`,
   ];
 
   for (const [className, ids] of Object.entries(classIds)) {
@@ -355,7 +377,11 @@ export function buildInspectionMermaidGraph(snapshot) {
   const outerState = formatStateToken(snapshot.outerState, "unknown");
   const outerAction = formatStateToken(snapshot.outerAction, "unknown");
   let focusIds = lanes.map((lane) => lane.currentId);
-  if (outerState === OUTER_STATE.HANDOFF_TO_COPILOT_LOOP || outerAction === "reenter_copilot_loop") {
+  const lifecycleAvailable = snapshot.lifecyclePhase != null
+    && !String(snapshot.lifecyclePhase).toLowerCase().includes("unavailable");
+  if (lifecycleAvailable) {
+    focusIds = [lanes[3].currentId];
+  } else if (outerState === OUTER_STATE.HANDOFF_TO_COPILOT_LOOP || outerAction === "reenter_copilot_loop") {
     focusIds = [lanes[1].currentId];
   } else if (outerState === OUTER_STATE.HANDOFF_TO_REVIEWER_LOOP || outerAction === "reenter_reviewer_loop") {
     focusIds = [lanes[2].currentId];
@@ -393,6 +419,7 @@ function renderStateGraphHelp() {
     <li><strong>Next:</strong> purple nodes mark immediate allowed next states from the snapshot. Dimmed nodes are still part of the authoritative state machine; they are simply inactive right now.</li>
     <li><strong>Start / End:</strong> Mermaid entry and exit nodes make lane boundaries easier to scan for the full authoritative graph.</li>
     <li><strong>Orchestrator:</strong> the outer lane comes from the shared authoritative outer-loop graph contract; outerAction remains visible only as a compatibility projection.</li>
+    <li><strong>Lifecycle:</strong> the lifecycle lane shows the sequential dev-loop phases from issue intake to merge; current phase is highlighted from the inspection snapshot.</li>
     <li><strong>🔁 Loop cue:</strong> this viewer is revisited by manual reload, so the same current state can recur across inspections until evidence changes.</li>
   </ul>`;
 }

--- a/scripts/loop/inspect-run-viewer/graph.mjs
+++ b/scripts/loop/inspect-run-viewer/graph.mjs
@@ -372,6 +372,7 @@ export function buildInspectionMermaidGraph(snapshot) {
     ...orderedLaneLines,
     '  outer_loop_family_start ~~~ copilot_layer_start',
     '  copilot_layer_start ~~~ reviewer_layer_start',
+    '  reviewer_layer_start ~~~ lifecycle_layer_start',
     '  outer_loop_family_start ~~~ lifecycle_layer_start',
     `  ${lanes[0].currentId} -. "layer view" .-> ${lanes[1].currentId}`,
     `  ${lanes[1].currentId} -. "layer view" .-> ${lanes[2].currentId}`,

--- a/scripts/loop/inspect-run-viewer/graph.mjs
+++ b/scripts/loop/inspect-run-viewer/graph.mjs
@@ -372,7 +372,7 @@ export function buildInspectionMermaidGraph(snapshot) {
     ...orderedLaneLines,
     '  outer_loop_family_start ~~~ copilot_layer_start',
     '  copilot_layer_start ~~~ reviewer_layer_start',
-    '  reviewer_layer_start ~~~ lifecycle_layer_start',
+    '  outer_loop_family_start ~~~ lifecycle_layer_start',
     `  ${lanes[0].currentId} -. "layer view" .-> ${lanes[1].currentId}`,
     `  ${lanes[1].currentId} -. "layer view" .-> ${lanes[2].currentId}`,
     `  ${lanes[2].currentId} -. "layer view" .-> ${lanes[3].currentId}`,
@@ -388,6 +388,7 @@ export function buildInspectionMermaidGraph(snapshot) {
   const outerAction = formatStateToken(snapshot.outerAction, "unknown");
   let focusIds = lanes.map((lane) => lane.currentId);
   const lifecycleAvailable = snapshot.lifecyclePhase != null
+    && snapshot.lifecyclePhase !== "unknown"
     && !String(snapshot.lifecyclePhase).toLowerCase().includes("unavailable");
   if (lifecycleAvailable) {
     focusIds = [lanes[3].currentId];

--- a/scripts/loop/inspect-run-viewer/graph.mjs
+++ b/scripts/loop/inspect-run-viewer/graph.mjs
@@ -375,8 +375,8 @@ export function buildInspectionMermaidGraph(snapshot) {
     '  reviewer_layer_start ~~~ lifecycle_layer_start',
     '  outer_loop_family_start ~~~ lifecycle_layer_start',
     `  ${lanes[0].currentId} -. "layer view" .-> ${lanes[1].currentId}`,
-    `  ${lanes[0].currentId} -. "layer view" .-> ${lanes[2].currentId}`,
-    `  ${lanes[0].currentId} -. "layer view" .-> ${lanes[3].currentId}`,
+    `  ${lanes[1].currentId} -. "layer view" .-> ${lanes[2].currentId}`,
+    `  ${lanes[2].currentId} -. "layer view" .-> ${lanes[3].currentId}`,
   ];
 
   for (const [className, ids] of Object.entries(classIds)) {

--- a/test/loop/inspect-run-unit.test.mjs
+++ b/test/loop/inspect-run-unit.test.mjs
@@ -105,6 +105,10 @@ test("composeRunInspectionSnapshot: complete live evidence returns all required 
   assert.equal(snapshot.layers.reviewer.approvedOnCurrentHead, false);
   assert.equal(snapshot.layers.steering.status, "unavailable");
   assert.equal(snapshot.layers.steering.reason, "no_steering_locator");
+
+  // Lifecycle fields
+  assert.equal(snapshot.lifecyclePhase, "feedback_resolution");
+  assert.deepEqual(snapshot.lifecycleAllowedTransitions, ["implementation", "pre_approval_gate"]);
 });
 
 test("composeRunInspectionSnapshot: live evidence + done → statusClass done, needsAttention false", () => {
@@ -131,6 +135,47 @@ test("composeRunInspectionSnapshot: live evidence + done → statusClass done, n
   assert.equal(snapshot.needsAttention, false);
   assert.equal(snapshot.sourceMode, SOURCE_MODE.LIVE_DETECTOR_BACKED);
   assert.equal(snapshot.trust, TRUST.AUTHORITATIVE);
+});
+
+test("composeRunInspectionSnapshot: explicitTargetMissing uses hasLinkedPr false in lifecycle fallback", () => {
+  // Use a copilot state not in any COPILOT_INNER_STATE_MAP entry to force fallback
+  const copilotEvidence = makeCopilotEvidence("some_unknown_state");
+  const reviewerEvidence = makeReviewerEvidence("waiting_for_author_followup");
+
+  // Without explicitTargetMissing: fallback hasLinkedPr true → implementation
+  const snapOk = composeRunInspectionSnapshot({
+    target: { repo: "owner/repo", pr: 55 },
+    inspectedAt: "2026-05-18T12:00:00Z",
+    outerState: "continue_current_wait",
+    outerAction: "continue_wait",
+    explicitTargetMissing: false,
+    copilotEvidence,
+    reviewerEvidence,
+    existingCheckpoint: null,
+    liveAvailability: { copilot: "ok", reviewer: "ok" },
+    steeringLocatorPath: null,
+    steeringEvidence: null,
+    steeringLoadFailed: false,
+  });
+  assert.equal(snapOk.lifecyclePhase, "implementation");
+
+  // With explicitTargetMissing: fallback hasLinkedPr false → issue_intake
+  const snapMissing = composeRunInspectionSnapshot({
+    target: { repo: "owner/repo", pr: 55 },
+    inspectedAt: "2026-05-18T12:00:00Z",
+    outerState: "continue_current_wait",
+    outerAction: "continue_wait",
+    explicitTargetMissing: true,
+    copilotEvidence,
+    reviewerEvidence,
+    existingCheckpoint: null,
+    liveAvailability: { copilot: "ok", reviewer: "ok" },
+    steeringLocatorPath: null,
+    steeringEvidence: null,
+    steeringLoadFailed: false,
+  });
+  assert.equal(snapMissing.lifecyclePhase, "issue_intake");
+  assert.deepEqual(snapMissing.lifecycleAllowedTransitions, ["refinement", "implementation"]);
 });
 
 test("composeRunInspectionSnapshot: clean-converged Copilot state carries same-head convergence flags", () => {

--- a/test/loop/inspect-run-viewer-client.test.mjs
+++ b/test/loop/inspect-run-viewer-client.test.mjs
@@ -303,9 +303,9 @@ test("buildInspectionMermaidGraph renders full authoritative Mermaid state machi
   assert.match(graph.definition, /reviewer_layer_waiting_for_re_request\["waiting_for_re_request"\]/);
   assert.match(graph.definition, /layer view/);
   assert.match(graph.definition, /next evaluation may resolve to any shown state/);
-  assert.match(graph.definition, /class outer_loop_family_continue_current_wait,reviewer_layer_waiting_for_author_followup current;/);
+  assert.match(graph.definition, /class outer_loop_family_continue_current_wait,reviewer_layer_waiting_for_author_followup,lifecycle_layer_implementation current;/);
   assert.match(graph.definition, /class copilot_layer_done currentTerminal;/);
-  assert.match(graph.definition, /class [^\n]*reviewer_layer_review_requested next;/);
+  assert.match(graph.definition, /class [^\n]*reviewer_layer_review_requested[^\n]* next;/);
 });
 
 test("buildInspectionMermaidGraph covers every exported outer, Copilot, and reviewer state and edge", () => {

--- a/test/loop/inspect-run-viewer-test-helpers.mjs
+++ b/test/loop/inspect-run-viewer-test-helpers.mjs
@@ -49,6 +49,8 @@ export function makeSnapshot(overrides = {}) {
       },
       steering: { status: "unavailable", reason: "no_steering_locator" },
     },
+    lifecyclePhase: "implementation",
+    lifecycleAllowedTransitions: ["draft_gate", "feedback_resolution"],
     ...overrides,
   };
 }

--- a/test/playwright/fixtures/inspect-run-viewer-fixture.mjs
+++ b/test/playwright/fixtures/inspect-run-viewer-fixture.mjs
@@ -51,6 +51,8 @@ export function makeInspectionSnapshot(overrides = {}) {
       },
       steering: { status: "unavailable", reason: "no_steering_locator" },
     },
+    lifecyclePhase: "implementation",
+    lifecycleAllowedTransitions: ["draft_gate", "feedback_resolution"],
     ...overrides,
   };
 }

--- a/test/playwright/inspect-run-viewer.spec.mjs
+++ b/test/playwright/inspect-run-viewer.spec.mjs
@@ -137,6 +137,32 @@ test("webkit renders the Mermaid-first inspect-run viewer and captures a screens
     await expect(graph).toContainText(/review_requested/);
     await expect(page.getByText(/outer-loop family:\s*current\s*continue_current_wait; continue_current_wait; full authoritative state machine shown; continue_current_wait, handoff_to_copilot_loop, handoff_to_reviewer_loop, stay_with_current_live_owner, stop_needs_human, done_terminal, needs_reconcile/i)).toBeVisible();
     await expect(page.getByText(/copilot layer:\s*current\s*waiting_for_copilot_review; waiting_for_copilot_review; full authoritative state machine shown; unresolved_feedback_present, ready_to_rerequest_review, waiting_for_ci/i)).toBeVisible();
+    const lifecycleLaneRender = await graph.evaluate((node) => {
+      const svg = node.querySelector('svg');
+      const laneTitles = [...svg.querySelectorAll('g.cluster text')]
+        .map((entry) => ({ text: entry.textContent?.trim() ?? '', y: entry.getBoundingClientRect().y }))
+        .filter((entry) => entry.text.length > 0)
+        .sort((a, b) => a.y - b.y)
+        .map((entry) => entry.text);
+      const currentLifecycle = svg.querySelector('g.node.current[id*="flowchart-lifecycle_layer_implementation"]');
+      const nextLifecycleNodes = [...svg.querySelectorAll('g.node.next[id*="flowchart-lifecycle_layer_"]')]
+        .map((entry) => entry.textContent?.replace(/\s+/g, ' ').trim())
+        .filter(Boolean)
+        .sort();
+      return {
+        laneTitles,
+        currentLifecycleClass: currentLifecycle?.getAttribute('class') ?? null,
+        nextLifecycleNodes,
+      };
+    });
+    expect(lifecycleLaneRender.laneTitles).toEqual([
+      'outer-loop family',
+      'copilot layer',
+      'reviewer layer',
+      'lifecycle',
+    ]);
+    expect(lifecycleLaneRender.currentLifecycleClass).toContain('current');
+    expect(lifecycleLaneRender.nextLifecycleNodes).toEqual(['draft gate', 'feedback resolution']);
 
     await graphBox.getByRole("button", { name: "Zoom in" }).click();
     await graphBox.getByRole("button", { name: "Zoom in" }).click();


### PR DESCRIPTION
## Summary

Add a 4th lifecycle lane to the inspect-run-viewer's Mermaid graph, showing the sequential dev-loop phases (issue_intake → refinement → implementation → draft_gate → feedback_resolution → pre_approval_gate → merge) alongside the existing outer-loop-family, copilot, and reviewer lanes.

Depends on #676 (lifecycle-state.mjs, already merged to main).

## Scope

- Import LIFECYCLE_STATE, LIFECYCLE_TRANSITIONS, LIFECYCLE_GRAPH from `@pi-dev-loops/core/loop/lifecycle-state`
- Add 4th `buildFullStateMachineLane()` call with laneKey `lifecycle_layer`
- Wire `lifecyclePhase` and `lifecycleAllowedTransitions` from inspection snapshot
- Resolve lifecycle phase in `run-inspection.mjs` via `lifecyclePhaseForCopilotState()` with PR-facts fallback
- Add inter-lane edge from outer-loop → lifecycle
- Prioritize lifecycle lane focus when `lifecyclePhase` is available
- Update graph help text to document lifecycle lane
- Update test helpers and Playwright fixtures with lifecycle fields

## Acceptance criteria

- Lifecycle lane renders in the inspect-run-viewer alongside existing lanes
- Current lifecycle phase is highlighted when snapshot contains it
- Allowed transitions render correctly
- `npm run verify` passes (excluding pre-existing failures)
- Viewer loads without errors for both real and empty snapshots
- Focus behavior: lifecycle lane nodes are targetable by `data-graph-focus-ids`

## Non-goals

- Not replacing or removing existing lanes
- Not changing the outer-loop-family lane (conductor routing stays)
- Not modifying lifecycle-state.mjs itself (that's #676)
- Not adding a tab/alternate-view toggle

Closes #679