### PR TITLE
fix(core): pass stdout to executeDevLoopsCommand (#686)

### DIFF
--- a/lib/dev-loops-core.mjs
+++ b/lib/dev-loops-core.mjs
@@ -206,7 +206,7 @@ export function describeReadiness(checks) {
   };
 }
 
-export async function executeDevLoopsCommand({ input, surface = 'extension', runtime }) {
+export async function executeDevLoopsCommand({ input, surface = 'extension', runtime, stdout }) {
   const parsed = parseDevLoopsCommand(input, { surface });
 
   if (parsed.kind === 'inspect_action') {

--- a/test/dev-loops-core.test.mjs
+++ b/test/dev-loops-core.test.mjs
@@ -259,3 +259,27 @@ test('executor preserves repoRoot when the inspect-run lifecycle action throws a
     warning: null,
   });
 });
+
+test("gates action receives stdout and prints without ReferenceError", async () => {
+  const { Writable } = await import("node:stream");
+
+  const chunks = [];
+  const stdout = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(chunk);
+      callback();
+    },
+  });
+
+  const result = await executeDevLoopsCommand({
+    input: ["gates"],
+    surface: "cli",
+    runtime: createRuntime(),
+    stdout,
+  });
+
+  assert.equal(result.kind, "gates");
+  const output = Buffer.concat(chunks).toString("utf8");
+  assert.ok(output.includes("draft gate"), "should print draft gate section");
+  assert.ok(output.includes("pre-approval gate"), "should print pre-approval gate section");
+});


### PR DESCRIPTION
## Summary

`executeDevLoopsCommand` in `lib/dev-loops-core.mjs` did not accept `stdout` in its destructured parameters, even though the CLI caller (`cli/index.mjs`) already passes it. This caused a `ReferenceError` when running `dev-loops gates` because the `stdout` variable used inside the `gates` case was undefined.

## Changes

- `lib/dev-loops-core.mjs` line 209: added `stdout` to the destructured parameter list of `executeDevLoopsCommand`.

## Validation

- `node cli/index.mjs gates` now prints gate definitions without error (previously threw `ReferenceError: stdout is not defined`).

Closes #686