### PR TITLE
docs: clarify dev-loops CLI invocation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Phase 8 is the active durable phase; Phase 7 second-repo pilot is deferred. See 
 
 ## Configuration
 
-Gate review angles, refinement settings, persona mappings, and workflow defaults are config-driven via `.pi/dev-loop/defaults.yaml`. Consumer repos override values in `.pi/dev-loop/settings.yaml`.
+Gate review angles, refinement settings, persona mappings, and workflow defaults are config-driven via `.pi/dev-loop/defaults.yaml`. Consumer repos override values in `.pi/dev-loop/settings.yaml`. The loader also accepts `.yml` and `.json` extensions and legacy `overrides.*` files as fallback formats. See [Extension Documentation](./extension/README.md) for details.
 
 ```bash
 npx dev-loops gates   # see what reviewers will check
@@ -67,7 +67,7 @@ pi install git:github.com/mfittko/pi-dev-loops          # global
 pi install -l git:github.com/mfittko/pi-dev-loops       # project-local
 ```
 
-Use `npx dev-loops` to run the CLI without a global install, or `npm install -g` for bare `dev-loops`.
+Use `npx dev-loops` to run the CLI without installing. After a global `pi install`, the `dev-loops` command is available directly in your shell.
 
 The package exposes the `/dev-loops` extension command surface, the `dev-loops` shell CLI, and packaged skills from `package.json` `pi.skills`.
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Phase 8 is the active durable phase; Phase 7 second-repo pilot is deferred. See 
 
 ## Configuration
 
-Gate review angles, refinement settings, persona mappings, and workflow defaults are config-driven via `.pi/dev-loop/defaults.yaml`. Consumer repos override values in `.pi/dev-loop/settings.yaml` (also supports `.yml` and `.json`; legacy `overrides.*` still load as fallback).
+Gate review angles, refinement settings, persona mappings, and workflow defaults are config-driven via `.pi/dev-loop/defaults.yaml`. Consumer repos override values in `.pi/dev-loop/settings.yaml`.
 
 ```bash
-dev-loops gates   # see what reviewers will check
+npx dev-loops gates   # see what reviewers will check
 ```
 
 Key surfaces:
@@ -66,6 +66,8 @@ Install with:
 pi install git:github.com/mfittko/pi-dev-loops          # global
 pi install -l git:github.com/mfittko/pi-dev-loops       # project-local
 ```
+
+Use `npx dev-loops` to run the CLI without a global install, or `npm install -g` for bare `dev-loops`.
 
 The package exposes the `/dev-loops` extension command surface, the `dev-loops` shell CLI, and packaged skills from `package.json` `pi.skills`.
 


### PR DESCRIPTION
## Summary

Clarify how to invoke the `dev-loops` shell CLI in README.md. Users need `npx dev-loops` without a global install; bare `dev-loops` only works after `npm install -g` or when `node_modules/.bin` is in PATH.

## Changes

- **Configuration section:** Change `dev-loops gates` to `npx dev-loops gates`
- **Configuration section:** Remove legacy config fallback parenthetical (`.yml`/`.json`/`overrides.*`)
- **Package surface section:** Add `npx` vs global install clarification note after install commands

Closes #689