### PR TITLE
Redesign inspect-run-viewer: card layout, 4 tabs, compact banner, auto-reload, spacing polish

### DIFF
--- a/scripts/loop/inspect-run-viewer/graph.mjs
+++ b/scripts/loop/inspect-run-viewer/graph.mjs
@@ -429,7 +429,7 @@ function renderStateGraphHelp() {
   return `<ul class="state-graph-help">
     <li><strong>Current:</strong> emphasized nodes show the snapshot-derived current state for each lane when that state is actually known.</li>
     <li><strong>Next:</strong> purple nodes mark immediate allowed next states from the snapshot. Dimmed nodes are still part of the authoritative state machine; they are simply inactive right now.</li>
-    <li><strong>Start / End:</strong> Mermaid entry and exit nodes make lane boundaries easier to scan for the full authoritative graph.</li>
+    <li><strong>Start / End:</strong> entry and exit nodes make lane boundaries easier to scan for the full authoritative graph.</li>
     <li><strong>Orchestrator:</strong> the outer lane comes from the shared authoritative outer-loop graph contract; outerAction remains visible only as a compatibility projection.</li>
     <li><strong>Lifecycle:</strong> the lifecycle lane shows the sequential dev-loop phases from issue intake to merge; current phase is highlighted from the inspection snapshot.</li>
     <li><strong>🔁 Loop cue:</strong> this viewer is revisited by manual reload, so the same current state can recur across inspections until evidence changes.</li>
@@ -690,7 +690,7 @@ export function renderMermaidBootScript() {
           return;
         }
         if (typeof window.mermaid === "undefined") {
-          renderFallback("Mermaid browser asset unavailable. Use the details below or open /snapshot.json.");
+          renderFallback("Graph renderer unavailable. Use the details below or open /snapshot.json.");
           return;
         }
 
@@ -715,7 +715,7 @@ export function renderMermaidBootScript() {
             await window.mermaid.run({ nodes: visibleGraphs });
             await Promise.all(visibleGraphs.map((graph) => finalizeRenderedGraph(graph)));
           }).catch(() => {
-            renderFallback("Mermaid could not render this snapshot safely. Use the details below or open /snapshot.json.");
+            renderFallback("Could not render graph for this snapshot. Use the details below or open /snapshot.json.");
           });
           return pendingRender;
         };

--- a/scripts/loop/inspect-run-viewer/graph.mjs
+++ b/scripts/loop/inspect-run-viewer/graph.mjs
@@ -456,6 +456,7 @@ export function renderMermaidBootScript() {
       (() => {
         const frames = Array.from(document.querySelectorAll(".state-graph-frame"));
         const graphs = Array.from(document.querySelectorAll(".mermaid-state-graph"));
+        const renderedGraphs = new WeakSet();
         const clampScale = (value) => Math.max(0.5, Math.min(5, value));
         const updateFrameScale = (frame, requestedScale) => {
           const scale = clampScale(requestedScale);
@@ -580,6 +581,38 @@ export function renderMermaidBootScript() {
             graph.replaceWith(fallback);
           });
         };
+        const isGraphVisible = (graph) => {
+          if (!(graph instanceof HTMLElement)) {
+            return false;
+          }
+          const panel = graph.closest(".tab-content");
+          if (panel && !panel.classList.contains("active")) {
+            return false;
+          }
+          const rect = graph.getBoundingClientRect();
+          return rect.width > 0 && rect.height > 0;
+        };
+        const finalizeRenderedGraph = async (graph) => {
+          graph.dataset.rendered = "settling";
+          const frame = graph.closest(".state-graph-frame");
+          if (!frame) {
+            graph.dataset.rendered = "true";
+            renderedGraphs.add(graph);
+            return;
+          }
+          updateFrameScale(frame, Number(frame.dataset.graphScale || 1));
+          const graphViewport = frame.querySelector(".mermaid-state-graph");
+          if (graphViewport) {
+            const focused = await fitGraphToCurrentState(frame, graphViewport);
+            if (!focused) {
+              await settleGraphViewport();
+            }
+          } else {
+            await settleGraphViewport();
+          }
+          graph.dataset.rendered = "true";
+          renderedGraphs.add(graph);
+        };
 
         frames.forEach((frame) => {
           updateFrameScale(frame, Number(frame.dataset.graphScale || 1));
@@ -672,29 +705,30 @@ export function renderMermaidBootScript() {
           },
         });
 
-        window.mermaid.run({ nodes: graphs }).then(async () => {
-          await Promise.all(graphs.map(async (graph) => {
-            graph.dataset.rendered = "settling";
-            const frame = graph.closest(".state-graph-frame");
-            if (!frame) {
-              graph.dataset.rendered = "true";
+        let pendingRender = Promise.resolve();
+        const queueVisibleGraphRender = () => {
+          pendingRender = pendingRender.then(async () => {
+            const visibleGraphs = graphs.filter((graph) => !renderedGraphs.has(graph) && isGraphVisible(graph));
+            if (visibleGraphs.length === 0) {
               return;
             }
-            updateFrameScale(frame, Number(frame.dataset.graphScale || 1));
-            const graphViewport = frame.querySelector(".mermaid-state-graph");
-            if (graphViewport) {
-              const focused = await fitGraphToCurrentState(frame, graphViewport);
-              if (!focused) {
-                await settleGraphViewport();
-              }
-            } else {
-              await settleGraphViewport();
-            }
-            graph.dataset.rendered = "true";
-          }));
-        }).catch(() => {
-          renderFallback("Mermaid could not render this snapshot safely. Use the details below or open /snapshot.json.");
+            await window.mermaid.run({ nodes: visibleGraphs });
+            await Promise.all(visibleGraphs.map((graph) => finalizeRenderedGraph(graph)));
+          }).catch(() => {
+            renderFallback("Mermaid could not render this snapshot safely. Use the details below or open /snapshot.json.");
+          });
+          return pendingRender;
+        };
+
+        document.addEventListener("inspect-run-viewer:tabchange", () => {
+          window.requestAnimationFrame(() => {
+            void queueVisibleGraphRender();
+          });
         });
+        window.addEventListener("load", () => {
+          void queueVisibleGraphRender();
+        });
+        void queueVisibleGraphRender();
       })();
     </script>`;
 }

--- a/scripts/loop/inspect-run-viewer/handoff-envelope-renderer.mjs
+++ b/scripts/loop/inspect-run-viewer/handoff-envelope-renderer.mjs
@@ -3,125 +3,396 @@
  *
  * Depends on the handoff envelope module from @pi-dev-loops/core.
  */
-import { escapeHtml, renderList } from "./shared.mjs";
+import { escapeHtml } from "./shared.mjs";
 
-/**
- * Render a single handoff envelope field key-value pair.
- * Handles arrays and objects gracefully.
- */
-function renderEnvelopeValue(value) {
+const LABELS = {
+  kind: "Kind",
+  repo: "Repository",
+  pr: "PR",
+  issue: "Issue",
+  branch: "Branch",
+  phase: "Phase",
+  currentGate: "Current gate",
+  currentHeadSha: "Head SHA",
+  ciStatus: "CI status",
+  unresolvedThreadCount: "Unresolved threads",
+  copilotRoundCount: "Completed rounds",
+  maxCopilotRounds: "Round limit",
+  executionMode: "Execution mode",
+  nextAction: "Next action",
+  asyncStartMode: "Async start mode",
+  requireDraftFirst: "Require draft first",
+  cwd: "Working directory",
+  worktreeRequired: "Worktree required",
+  angles: "Review angles",
+  excludeAngles: "Excluded angles",
+  blockCleanOnFindingSeverities: "Block on severities",
+  requireCi: "Require CI",
+  evidence: "Evidence",
+  maxFinalizationTurns: "Max finalization turns",
+  needsAttentionAfterMs: "Needs attention after",
+  activeNoticeAfterMs: "Active notice after",
+};
+
+function humanizeKey(key) {
+  if (LABELS[key]) {
+    return LABELS[key];
+  }
+  return String(key)
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replaceAll("_", " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function normalizeToken(value) {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function formatDurationMs(value) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return renderPlainValue(value);
+  }
+  const seconds = value / 1000;
+  if (seconds < 60) {
+    return `${escapeHtml(String(seconds))} sec · ${escapeHtml(String(value))} ms`;
+  }
+  const minutes = seconds / 60;
+  if (minutes < 60) {
+    return `${escapeHtml(String(minutes))} min · ${escapeHtml(String(value))} ms`;
+  }
+  const hours = minutes / 60;
+  return `${escapeHtml(String(hours))} hr · ${escapeHtml(String(value))} ms`;
+}
+
+function renderBadge(label, tone = "neutral", extraClass = "") {
+  return `<span class="handoff-badge handoff-badge-${escapeHtml(tone)}${extraClass ? ` ${escapeHtml(extraClass)}` : ""}">${escapeHtml(String(label))}</span>`;
+}
+
+function renderBooleanBadge(value, { trueLabel = "Yes", falseLabel = "No" } = {}) {
   if (value === null || value === undefined) {
-    return `<em>not set</em>`;
+    return `<span class="handoff-empty-value">not set</span>`;
   }
-  if (Array.isArray(value)) {
-    if (value.length === 0) return `<em>empty</em>`;
-    return renderList(value.map((v) => (typeof v === "object" ? JSON.stringify(v) : String(v))));
-  }
-  if (typeof value === "object") {
-    return renderEnvelopeDefinitionList(Object.entries(value).map(([k, v]) => [k, typeof v === "string" ? escapeHtml(v) : escapeHtml(JSON.stringify(v))]));
+  return value ? renderBadge(trueLabel, "success") : renderBadge(falseLabel, "muted");
+}
+
+function toneForGate(value) {
+  const token = normalizeToken(value);
+  if (["clean", "ready", "pass", "passed", "approved"].includes(token)) return "success";
+  if (["draft", "pending", "queued", "review"].includes(token)) return "warning";
+  if (["fail", "failed", "blocked", "rejected"].includes(token)) return "danger";
+  return "info";
+}
+
+function toneForCi(value) {
+  const token = normalizeToken(value);
+  if (["success", "passed", "green"].includes(token)) return "success";
+  if (["failure", "failed", "error", "red"].includes(token)) return "danger";
+  if (["pending", "running", "queued", "in_progress"].includes(token)) return "warning";
+  if (["skipped", "cancelled", "canceled"].includes(token)) return "muted";
+  return "neutral";
+}
+
+function toneForSeverity(value) {
+  const token = normalizeToken(value);
+  if (["required", "must-fix", "blocker", "high"].includes(token)) return "danger";
+  if (["worth-fixing-now", "warning", "medium"].includes(token)) return "warning";
+  return "info";
+}
+
+function renderPlainValue(value) {
+  if (value === null || value === undefined) {
+    return `<span class="handoff-empty-value">not set</span>`;
   }
   return escapeHtml(String(value));
 }
 
-/**
- * Render the handoff envelope as structured HTML.
- *
- * @param {object|null} envelope - The handoff envelope object, or null when unavailable.
- * @returns {string} HTML
- */
+function renderInlineValue(value, key = "") {
+  if (value === null || value === undefined) {
+    return `<span class="handoff-empty-value">not set</span>`;
+  }
+  if (key === "currentGate") {
+    return renderBadge(value, toneForGate(value));
+  }
+  if (key === "ciStatus") {
+    return renderBadge(value, toneForCi(value));
+  }
+  if (["executionMode", "asyncStartMode", "kind"].includes(key)) {
+    return renderBadge(value, "info");
+  }
+  if (["requireDraftFirst", "worktreeRequired", "requireCi"].includes(key)) {
+    return renderBooleanBadge(value);
+  }
+  if (["needsAttentionAfterMs", "activeNoticeAfterMs"].includes(key)) {
+    return formatDurationMs(value);
+  }
+  if (key === "currentHeadSha" && typeof value === "string") {
+    const shortSha = value.length > 12 ? value.slice(0, 12) : value;
+    return `<code title="${escapeHtml(value)}">${escapeHtml(shortSha)}</code>`;
+  }
+  return renderPlainValue(value);
+}
 
-/**
- * Render a definition list where values are already HTML-safe (pre-escaped by renderEnvelopeValue).
- * Unlike renderDefinitionList, this does NOT escape values, only keys.
- */
-function renderEnvelopeDefinitionList(entries) {
-  return `<dl>${entries.map(([label, value]) => `<dt>${escapeHtml(label)}</dt><dd>${value}</dd>`).join("")}</dl>`;
+function renderChipList(items, tone = "neutral", { code = false } = {}) {
+  if (!Array.isArray(items) || items.length === 0) {
+    return `<ul class="handoff-chip-list"><li>${renderBadge("none", "muted")}</li></ul>`;
+  }
+  return `<ul class="handoff-chip-list">${items.map((item) => `<li>${code ? `<code>${escapeHtml(String(item))}</code>` : renderBadge(item, tone)}</li>`).join("")}</ul>`;
+}
+
+function renderReadList(items) {
+  if (!Array.isArray(items) || items.length === 0) {
+    return `<p class="handoff-empty-copy">none</p>`;
+  }
+  return `<ol class="handoff-read-list">${items.map((item) => `<li><code>${escapeHtml(String(item))}</code></li>`).join("")}</ol>`;
+}
+
+function renderCriteria(criteria) {
+  if (!Array.isArray(criteria) || criteria.length === 0) {
+    return `<p class="handoff-empty-copy">none</p>`;
+  }
+  return `<ol class="handoff-criteria-list">${criteria.map((criterion) => `
+    <li class="handoff-criteria-item">
+      <div class="handoff-criteria-header">
+        ${renderBadge(criterion.severity ?? "not set", toneForSeverity(criterion.severity), "handoff-criteria-severity")}
+        <code>${escapeHtml(String(criterion.id ?? "unknown"))}</code>
+      </div>
+      <p>${escapeHtml(String(criterion.must ?? "not set"))}</p>
+    </li>
+  `).join("")}</ol>`;
+}
+
+function renderKeyValueList(entries, { compact = false } = {}) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return `<p class="handoff-empty-copy">none</p>`;
+  }
+  return `<dl class="handoff-kv${compact ? " handoff-kv-compact" : ""}">${entries.map(({ key, label, valueHtml }) => `
+    <div class="handoff-kv-row"${key ? ` data-field="${escapeHtml(String(key))}"` : ""}>
+      <dt>${escapeHtml(label)}</dt>
+      <dd>${valueHtml}</dd>
+    </div>
+  `).join("")}</dl>`;
+}
+
+function renderObjectAsKeyValue(value) {
+  if (value === null || value === undefined) {
+    return `<span class="handoff-empty-value">not set</span>`;
+  }
+  const entries = Object.entries(value)
+    .filter(([, entryValue]) => entryValue !== undefined)
+    .map(([key, entryValue]) => ({
+      key,
+      label: humanizeKey(key),
+      valueHtml: renderEnvelopeValue(entryValue, key),
+    }));
+  return renderKeyValueList(entries, { compact: true });
+}
+
+function renderEnvelopeValue(value, key = "") {
+  if (value === null || value === undefined) {
+    return `<span class="handoff-empty-value">not set</span>`;
+  }
+  if (Array.isArray(value)) {
+    return renderReadList(value.map((item) => (typeof item === "object" ? JSON.stringify(item) : String(item))));
+  }
+  if (typeof value === "object") {
+    return renderObjectAsKeyValue(value);
+  }
+  return renderInlineValue(value, key);
+}
+
+function renderCard({ title, kicker = null, content, className = "" }) {
+  return `<article class="handoff-card${className ? ` ${escapeHtml(className)}` : ""}">
+    ${kicker ? `<p class="handoff-card-kicker">${escapeHtml(kicker)}</p>` : ""}
+    <h3>${escapeHtml(title)}</h3>
+    ${content}
+  </article>`;
+}
+
+function renderStatGrid(items) {
+  const normalizedItems = Array.isArray(items) ? items.filter(Boolean) : [];
+  if (normalizedItems.length === 0) {
+    return `<p class="handoff-empty-copy">none</p>`;
+  }
+  return `<div class="handoff-stat-grid">${normalizedItems.map(({ label, valueHtml }) => `
+    <div class="handoff-stat">
+      <span class="handoff-stat-label">${escapeHtml(String(label))}</span>
+      <span class="handoff-stat-value">${valueHtml}</span>
+    </div>
+  `).join("")}</div>`;
+}
+
+function buildIdentity(envelope) {
+  if (!envelope?.target) {
+    return "unknown";
+  }
+  const t = envelope.target;
+  if (t.kind === "pr" || t.kind === "issue") {
+    return `${t.repo || "?"}#${t.pr ?? t.issue ?? "?"}`;
+  }
+  if (t.kind === "local_branch") {
+    return t.branch ? `branch:${t.branch}` : "branch:?";
+  }
+  if (t.kind === "local_phase") {
+    return t.phase ? `phase:${t.phase}` : "phase:?";
+  }
+  return `${t.repo || "?"}#${t.pr ?? t.issue ?? "?"}`;
 }
 
 export function renderHandoffEnvelopeSection(envelope) {
   if (!envelope) {
-    return `<section id="handoff-envelope-section">
-      <h2>Agent handoff</h2>
-      <p><em>Envelope unavailable. Ensure buildDevLoopHandoffEnvelope() is callable and all inputs (resolver output, settings, gate state) are resolvable for the current PR.</em></p>
+    return `<section id="handoff-envelope-section" class="handoff-envelope-section">
+      <div class="handoff-empty-state">
+        <p class="handoff-card-kicker">Agent handoff</p>
+        <h2>Envelope unavailable</h2>
+        <p><em>Ensure buildDevLoopHandoffEnvelope() is callable and all inputs (resolver output, settings, gate state) are resolvable for the current PR.</em></p>
+      </div>
     </section>`;
   }
 
-  let identity = "unknown";
-  if (envelope.target) {
-    const t = envelope.target;
-    if (t.kind === "pr" || t.kind === "issue") {
-      identity = `${t.repo || "?"}#${t.pr ?? t.issue ?? "?"}`;
-    } else if (t.kind === "local_branch") {
-      identity = t.branch ? `branch:${t.branch}` : "branch:?";
-    } else if (t.kind === "local_phase") {
-      identity = t.phase ? `phase:${t.phase}` : "phase:?";
-    } else {
-      identity = `${t.repo || "?"}#${t.pr ?? t.issue ?? "?"}`;
-    }
-  }
+  const identity = buildIdentity(envelope);
+  const targetEntries = envelope.target
+    ? Object.entries(envelope.target)
+      .filter(([, value]) => value !== undefined && value !== null)
+      .map(([key, value]) => ({ key, label: humanizeKey(key), valueHtml: renderInlineValue(value, key) }))
+    : [{ key: "target", label: "Target", valueHtml: `<span class="handoff-empty-value">missing</span>` }];
+  const currentStateEntries = [
+    { key: "currentGate", label: humanizeKey("currentGate"), valueHtml: renderInlineValue(envelope.currentGate, "currentGate") },
+    { key: "currentHeadSha", label: humanizeKey("currentHeadSha"), valueHtml: renderInlineValue(envelope.currentHeadSha, "currentHeadSha") },
+    { key: "ciStatus", label: humanizeKey("ciStatus"), valueHtml: renderInlineValue(envelope.ciStatus, "ciStatus") },
+    { key: "unresolvedThreadCount", label: humanizeKey("unresolvedThreadCount"), valueHtml: renderInlineValue(envelope.unresolvedThreadCount, "unresolvedThreadCount") },
+    { key: "copilotRoundCount", label: humanizeKey("copilotRoundCount"), valueHtml: renderInlineValue(envelope.copilotRoundCount, "copilotRoundCount") },
+    { key: "maxCopilotRounds", label: humanizeKey("maxCopilotRounds"), valueHtml: renderInlineValue(envelope.maxCopilotRounds, "maxCopilotRounds") },
+    { key: "executionMode", label: humanizeKey("executionMode"), valueHtml: renderInlineValue(envelope.executionMode, "executionMode") },
+  ];
+  const policyEntries = [
+    { key: "asyncStartMode", label: humanizeKey("asyncStartMode"), valueHtml: renderInlineValue(envelope.asyncStartMode, "asyncStartMode") },
+    { key: "requireDraftFirst", label: humanizeKey("requireDraftFirst"), valueHtml: renderInlineValue(envelope.requireDraftFirst, "requireDraftFirst") },
+  ];
+  const isolationEntries = [
+    { key: "cwd", label: humanizeKey("cwd"), valueHtml: renderInlineValue(envelope.cwd, "cwd") },
+    { key: "worktreeRequired", label: humanizeKey("worktreeRequired"), valueHtml: renderInlineValue(envelope.worktreeRequired, "worktreeRequired") },
+  ];
+  const controlEntries = envelope.control ? [
+    { key: "needsAttentionAfterMs", label: humanizeKey("needsAttentionAfterMs"), valueHtml: renderInlineValue(envelope.control.needsAttentionAfterMs, "needsAttentionAfterMs") },
+    { key: "activeNoticeAfterMs", label: humanizeKey("activeNoticeAfterMs"), valueHtml: renderInlineValue(envelope.control.activeNoticeAfterMs, "activeNoticeAfterMs") },
+  ] : [];
 
-  return `<section id="handoff-envelope-section">
-    <h2>Agent handoff — ${escapeHtml(identity)}</h2>
-    <p><em>Derived${envelope.derivedAt ? ` at ${escapeHtml(envelope.derivedAt)}` : ""}. Version ${escapeHtml(String(envelope.handoffVersion ?? "unknown"))}.</em></p>
+  return `<section id="handoff-envelope-section" class="handoff-envelope-section">
+    <div class="handoff-hero">
+      <div class="handoff-hero-copy">
+        <p class="handoff-card-kicker">Agent handoff</p>
+        <h2>${escapeHtml(identity)}</h2>
+        <p class="handoff-hero-meta">Derived${envelope.derivedAt ? ` at ${escapeHtml(envelope.derivedAt)}` : ""} · Version ${escapeHtml(String(envelope.handoffVersion ?? "unknown"))}</p>
+        <div class="handoff-hero-badges">
+          ${renderBadge(`gate: ${envelope.currentGate ?? "not set"}`, toneForGate(envelope.currentGate))}
+          ${renderBadge(`ci: ${envelope.ciStatus ?? "not set"}`, toneForCi(envelope.ciStatus))}
+          ${renderBadge(`mode: ${envelope.executionMode ?? "not set"}`, "info")}
+        </div>
+      </div>
+      <div class="handoff-hero-side">
+        ${renderCard({
+          title: "At a glance",
+          kicker: "Summary",
+          className: "handoff-card-tight",
+          content: renderStatGrid([
+            { label: "Artifact", valueHtml: renderInlineValue(envelope.target?.kind, "kind") },
+            { label: "Target", valueHtml: renderInlineValue(envelope.target?.pr ?? envelope.target?.issue ?? envelope.target?.branch ?? envelope.target?.phase, "target") },
+            { label: "Rounds", valueHtml: `<strong>${renderPlainValue(envelope.copilotRoundCount)}</strong> / ${renderPlainValue(envelope.maxCopilotRounds)}` },
+            { label: "Isolation", valueHtml: renderInlineValue(envelope.worktreeRequired, "worktreeRequired") },
+            { label: "Threads", valueHtml: renderPlainValue(envelope.unresolvedThreadCount) },
+            { label: "Stop rules", valueHtml: renderPlainValue(Array.isArray(envelope.stopRules) ? envelope.stopRules.length : 0) },
+          ]),
+        })}
+      </div>
+    </div>
 
-    <h3>Target</h3>
-    ${renderEnvelopeDefinitionList(envelope.target ? Object.entries(envelope.target).filter(([, v]) => v !== undefined && v !== null).map(([k, v]) => [k, renderEnvelopeValue(v)]) : [["target", "<em>missing</em>"]])}
+    <div class="handoff-layout">
+      <div class="handoff-column handoff-column-side">
+        ${renderCard({ title: "Target", kicker: "Identity", content: renderKeyValueList(targetEntries) })}
+        ${renderCard({ title: "Current state", kicker: "Live status", content: renderKeyValueList(currentStateEntries) })}
+        ${renderCard({ title: "Worktree / isolation", kicker: "Execution boundary", content: renderKeyValueList(isolationEntries) })}
+        ${controlEntries.length > 0 ? renderCard({ title: "Runtime control", kicker: "Watch timers", content: renderKeyValueList(controlEntries) }) : ""}
+      </div>
 
-    <h3>Current state</h3>
-    ${renderEnvelopeDefinitionList([
-      ["currentGate", renderEnvelopeValue(envelope.currentGate)],
-      ["currentHeadSha", renderEnvelopeValue(envelope.currentHeadSha)],
-      ["ciStatus", renderEnvelopeValue(envelope.ciStatus)],
-      ["unresolvedThreadCount", renderEnvelopeValue(envelope.unresolvedThreadCount)],
-      ["copilotRoundCount", renderEnvelopeValue(envelope.copilotRoundCount)],
-      ["maxCopilotRounds", renderEnvelopeValue(envelope.maxCopilotRounds)],
-      ["executionMode", renderEnvelopeValue(envelope.executionMode)],
-    ])}
+      <div class="handoff-column">
+        ${renderCard({
+          title: "Work directive",
+          kicker: "Next step",
+          className: "handoff-card-emphasis",
+          content: `
+            <div class="handoff-next-action"><p>${renderInlineValue(envelope.nextAction, "nextAction")}</p></div>
+            <div class="handoff-subsection">
+              <h4>Required reads</h4>
+              ${renderReadList(envelope.requiredReads)}
+            </div>
+          `,
+        })}
 
-    <h3>Work directive</h3>
-    ${renderEnvelopeDefinitionList([
-      ["nextAction", renderEnvelopeValue(envelope.nextAction)],
-    ])}
-    <h4>Required reads</h4>
-    ${renderEnvelopeValue(envelope.requiredReads)}
+        ${envelope.gateConfig ? renderCard({
+          title: "Gate configuration",
+          kicker: "Review policy",
+          content: `
+            ${renderStatGrid([
+              { label: "Angles", valueHtml: renderPlainValue(Array.isArray(envelope.gateConfig.angles) ? envelope.gateConfig.angles.length : 0) },
+              { label: "Excluded", valueHtml: renderPlainValue(Array.isArray(envelope.gateConfig.excludeAngles) ? envelope.gateConfig.excludeAngles.length : 0) },
+              { label: "Blockers", valueHtml: renderPlainValue(Array.isArray(envelope.gateConfig.blockCleanOnFindingSeverities) ? envelope.gateConfig.blockCleanOnFindingSeverities.length : 0) },
+              { label: "Require CI", valueHtml: renderInlineValue(envelope.gateConfig.requireCi, "requireCi") },
+            ])}
+            <div class="handoff-subgrid">
+              <div class="handoff-subsection">
+                <h4>Review angles</h4>
+                ${renderChipList(envelope.gateConfig.angles, "info")}
+              </div>
+              <div class="handoff-subsection">
+                <h4>Excluded angles</h4>
+                ${renderChipList(envelope.gateConfig.excludeAngles, "muted")}
+                <h4>Block on severities</h4>
+                ${Array.isArray(envelope.gateConfig.blockCleanOnFindingSeverities) && envelope.gateConfig.blockCleanOnFindingSeverities.length > 0
+                  ? `<ul class="handoff-chip-list">${envelope.gateConfig.blockCleanOnFindingSeverities.map((severity) => `<li>${renderBadge(severity, toneForSeverity(severity))}</li>`).join("")}</ul>`
+                  : renderChipList([], "muted")}
+              </div>
+            </div>
+          `,
+        }) : ""}
 
-    ${envelope.gateConfig ? `<h3>Gate configuration</h3>
-    ${renderEnvelopeDefinitionList([
-      ["angles", renderEnvelopeValue(envelope.gateConfig.angles)],
-      ["excludeAngles", renderEnvelopeValue(envelope.gateConfig.excludeAngles)],
-      ["blockCleanOnFindingSeverities", renderEnvelopeValue(envelope.gateConfig.blockCleanOnFindingSeverities)],
-      ["requireCi", renderEnvelopeValue(envelope.gateConfig.requireCi)],
-    ])}` : ""}
+        ${renderCard({
+          title: "Policy",
+          kicker: "Operating rules",
+          content: `
+            ${renderKeyValueList(policyEntries)}
+            <div class="handoff-subsection">
+              <h4>Stop rules</h4>
+              ${renderChipList(envelope.stopRules, "warning")}
+            </div>
+          `,
+        })}
 
-    <h3>Policy</h3>
-    ${renderEnvelopeDefinitionList([
-      ["asyncStartMode", renderEnvelopeValue(envelope.asyncStartMode)],
-      ["requireDraftFirst", renderEnvelopeValue(envelope.requireDraftFirst)],
-    ])}
-    <h4>Stop rules</h4>
-    ${renderEnvelopeValue(envelope.stopRules)}
+        ${envelope.acceptance ? renderCard({
+          title: "Acceptance contract",
+          kicker: "Done means",
+          content: `
+            ${renderStatGrid([
+              { label: "Criteria", valueHtml: renderPlainValue(Array.isArray(envelope.acceptance.criteria) ? envelope.acceptance.criteria.length : 0) },
+              { label: "Evidence", valueHtml: renderPlainValue(Array.isArray(envelope.acceptance.evidence) ? envelope.acceptance.evidence.length : 0) },
+              { label: "Max finalization", valueHtml: renderInlineValue(envelope.acceptance.maxFinalizationTurns, "maxFinalizationTurns") },
+            ])}
+            <div class="handoff-subsection">
+              <h4>Criteria</h4>
+              ${renderCriteria(envelope.acceptance.criteria)}
+            </div>
+            <div class="handoff-subsection">
+              <h4>Evidence</h4>
+              ${renderChipList(envelope.acceptance.evidence, "neutral")}
+            </div>
+          `,
+        }) : ""}
 
-    <h3>Worktree / isolation</h3>
-    ${renderEnvelopeDefinitionList([
-      ["cwd", renderEnvelopeValue(envelope.cwd)],
-      ["worktreeRequired", renderEnvelopeValue(envelope.worktreeRequired)],
-    ])}
-
-    ${envelope.acceptance ? `<h3>Acceptance contract</h3>
-    <h4>Criteria</h4>
-    ${renderEnvelopeValue(envelope.acceptance.criteria?.map((c) => `[${c.severity}] ${c.id}: ${c.must}`))}
-    ${renderEnvelopeDefinitionList([
-      ["evidence", renderEnvelopeValue(envelope.acceptance.evidence)],
-      ["maxFinalizationTurns", renderEnvelopeValue(envelope.acceptance.maxFinalizationTurns)],
-    ])}` : ""}
-
-    ${envelope.control ? `<h3>Runtime control</h3>
-    ${renderEnvelopeDefinitionList([
-      ["needsAttentionAfterMs", renderEnvelopeValue(envelope.control.needsAttentionAfterMs)],
-      ["activeNoticeAfterMs", renderEnvelopeValue(envelope.control.activeNoticeAfterMs)],
-    ])}` : ""}
-
-    ${envelope.overrides ? `<h3>Explicit overrides</h3>
-    ${renderEnvelopeValue(envelope.overrides)}` : ""}
+        ${envelope.overrides ? renderCard({
+          title: "Explicit overrides",
+          kicker: "Manual exceptions",
+          content: renderObjectAsKeyValue(envelope.overrides),
+        }) : ""}
+      </div>
+    </div>
   </section>`;
 }

--- a/scripts/loop/inspect-run-viewer/handoff-envelope-renderer.mjs
+++ b/scripts/loop/inspect-run-viewer/handoff-envelope-renderer.mjs
@@ -204,7 +204,7 @@ function renderCard({ title, kicker = null, content, className = "" }) {
   return `<article class="handoff-card${className ? ` ${escapeHtml(className)}` : ""}">
     ${kicker ? `<p class="handoff-card-kicker">${escapeHtml(kicker)}</p>` : ""}
     <h3>${escapeHtml(title)}</h3>
-    ${content}
+    <div class="handoff-card-body">${content}</div>
   </article>`;
 }
 

--- a/scripts/loop/inspect-run-viewer/inbox.mjs
+++ b/scripts/loop/inspect-run-viewer/inbox.mjs
@@ -62,8 +62,8 @@ function describeInboxSignal(signal) {
 
 function summarizeInboxRow(snapshot, fallbackSignal = "unknown") {
   const normalizedFallbackSignal = normalizeInboxSignal(fallbackSignal);
-  const signal = normalizedFallbackSignal === "closed"
-    ? "closed"
+  const signal = normalizedFallbackSignal !== "unknown"
+    ? normalizedFallbackSignal
     : snapshot
       ? deriveInboxSignalFromSnapshot(snapshot)
       : normalizedFallbackSignal;

--- a/scripts/loop/inspect-run-viewer/rendering.mjs
+++ b/scripts/loop/inspect-run-viewer/rendering.mjs
@@ -354,7 +354,7 @@ export function renderInspectRunViewerHtml({
               </div>
             </div>
             <div class="tab-content active" id="tab-overview" role="tabpanel" aria-labelledby="tab-btn-overview">
-              ${renderOverviewSection(normalizedSnapshot, stateLabel)}
+              ${renderOverviewSection(normalizedSnapshot)}
             </div>
             <div class="tab-content" id="tab-graph" role="tabpanel" aria-labelledby="tab-btn-graph">
               <section class="viewer-tab-section" aria-label="Graph">

--- a/scripts/loop/inspect-run-viewer/rendering.mjs
+++ b/scripts/loop/inspect-run-viewer/rendering.mjs
@@ -8,24 +8,22 @@ import {
   buildInspectionMermaidGraph,
   loadMermaidBrowserScript,
   renderMermaidBootScript,
+  renderStateVisualizationSection,
   resetMermaidBrowserScriptCache,
 } from "./graph.mjs";
 import { buildSnapshotHref, renderInboxShellScript, renderInboxSidebar } from "./inbox.mjs";
 import {
   deriveInboxSignalFromSnapshot,
   renderCopilotLayerSection,
-  renderCopilotLoopIterationsSection,
   renderCurrentStateBanner,
   renderOuterLoopSummarySection,
+  renderOverviewSection,
   renderReviewerLayerSection,
   renderSteeringSummarySection,
 } from "./status.mjs";
 import {
   escapeHtml,
   normalizeInboxSignal,
-  renderCollapsedDetailsPanel,
-  renderDefinitionList,
-  renderList,
   renderSnapshotStateLabel,
   renderTargetKey,
 } from "./shared.mjs";
@@ -67,36 +65,7 @@ export function renderInspectRunViewerHtml({
   const title = target
     ? `${target.repo}#${target.pr} inspection snapshot`
     : `${scopeLabel} PR inspection dashboard`;
-  const runId = normalizedSnapshot?.runId ?? "not present";
   const rawSnapshotHref = buildSnapshotHref(target, scopeFilter);
-  const topSummary = target === null
-    ? `<section>
-      <h2>No PR selected</h2>
-      <p>No assigned PR in ${escapeHtml(scopeLabel)} matched the current view yet.</p>
-      <p>Pick a PR from the sidebar, widen the state or updated filters, or move to another inbox page.</p>
-    </section>`
-    : normalizedSnapshot === null
-      ? `<section>
-        <h2>Snapshot unavailable</h2>
-        <p>${escapeHtml(error?.message ?? "Unable to load inspect-run snapshot.")}</p>
-        <p>Manual reload only: use the reload button or browser refresh.</p>
-      </section>`
-      : `<section>
-        <h2>Top summary</h2>
-        ${renderDefinitionList([
-          ["target.repo", normalizedSnapshot.target?.repo ?? target.repo],
-          ["target.pr", normalizedSnapshot.target?.pr ?? target.pr],
-          ["runId", runId],
-          ["inspectedAt", normalizedSnapshot.inspectedAt ?? "not present"],
-        ])}
-        <h3>Markers</h3>
-        <h4>markers.missing</h4>
-        ${renderList(normalizedSnapshot.markers?.missing)}
-        <h4>markers.stale</h4>
-        ${renderList(normalizedSnapshot.markers?.stale)}
-        <h4>markers.conflicts</h4>
-        ${renderList(normalizedSnapshot.markers?.conflicts)}
-      </section>`;
 
   return `<!doctype html>
 <html lang="en">
@@ -158,27 +127,55 @@ export function renderInspectRunViewerHtml({
       .assigned-pr-page-link.is-disabled { color: #9aa9b8; pointer-events: none; }
       .assigned-pr-page-status { font-weight: 700; color: #253b53; }
       .inspection-main { min-width: 0; }
-      .badge { display: inline-block; padding: 0.25rem 0.5rem; border: 1px solid #666; border-radius: 0.25rem; font-weight: 600; }
-      .current-pr-state-banner { border: none; background: none; box-shadow: none; padding: 0; margin-top: 0; }
+      .current-pr-state-banner { border: 1px solid #d7e3f4; border-radius: 1rem; background: linear-gradient(180deg, #ffffff 0%, #f6fbff 100%); box-shadow: 0 1px 2px rgba(35, 69, 102, 0.06); padding: 1rem 1.1rem; margin-top: 0; }
       .current-pr-state-heading-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.75rem; }
       .current-pr-state-heading-copy { min-width: 0; }
-      .current-pr-state-kicker { margin: 0 0 0.28rem 0; font-size: 0.96rem; font-weight: 700; }
+      .current-pr-state-kicker { margin: 0 0 0.25rem 0; font-size: 0.86rem; font-weight: 800; letter-spacing: 0.06em; text-transform: uppercase; color: #486174; }
       .current-pr-state-kicker a { color: #355061; text-decoration: none; }
       .current-pr-state-kicker a:hover { text-decoration: underline; }
-      .current-pr-state-mode-indicator { flex: 0 0 auto; font-size: 1.55rem; line-height: 1; margin-top: 0.08rem; }
-      .current-pr-state-banner h1 { margin: 0 0 0.5rem 0; font-size: 2.2rem; line-height: 1.15; }
-      .current-pr-state-summary-headline { margin: 0 0 0.4rem 0; color: #1565c0; font-weight: 700; font-size: 1.1rem; }
-      .current-pr-state-detail { margin: 0.25rem 0 0.8rem 0; color: #274766; font-size: 0.98rem; }
-      .current-pr-state-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); background: none; padding: 0; border-radius: 0; margin-bottom: 1rem; }
-      .current-pr-state-grid dt { font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.03em; color: #4c6478; }
-      .current-pr-state-grid dd { margin: 0 0 0.75rem 0; }
+      .current-pr-state-mode-indicator { flex: 0 0 auto; font-size: 1.65rem; line-height: 1; margin-top: 0.08rem; }
+      .current-pr-state-banner h1 { margin: 0; font-size: 2rem; line-height: 1.15; color: #18324a; }
+      .current-pr-state-summary-headline { margin: 0.75rem 0 0.3rem 0; color: #1565c0; font-size: 1.06rem; }
+      .current-pr-state-detail { margin: 0; color: #274766; font-size: 0.98rem; }
+      .current-pr-state-note { margin: 0.55rem 0 0 0; color: #4b6579; font-size: 0.92rem; }
+      .current-pr-state-badge-row { margin-top: 0.75rem; }
+      .viewer-badge-row { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+      .viewer-card-grid { display: grid; gap: 1rem; align-items: start; }
+      .viewer-card-grid-overview { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+      .viewer-card-grid-layers { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .viewer-tab-section { border: none; background: none; padding: 0; margin-top: 1rem; }
+      .viewer-tab-shell { position: sticky; top: 0.65rem; z-index: 4; border: 1px solid #d7e3f4; border-radius: 0.85rem; background: rgba(251, 253, 255, 0.96); backdrop-filter: blur(6px); padding: 0.3rem; margin-top: 0.85rem; }
+      .viewer-tabs { display: flex; flex-wrap: wrap; gap: 0.4rem; margin: 0; }
+      .viewer-tab { padding: 0.58rem 0.9rem; cursor: pointer; border: 1px solid transparent; border-radius: 0.7rem; background: transparent; font: inherit; font-weight: 700; color: #486174; transition: color 0.15s, border-color 0.15s, background 0.15s, box-shadow 0.15s; }
+      .viewer-tab:hover { color: #1565c0; background: #f4f9ff; }
+      .viewer-tab.active { color: #1565c0; background: #fff; border-color: #c8d9ec; box-shadow: 0 1px 2px rgba(35, 69, 102, 0.08); }
+      .tab-content { display: none; }
+      .tab-content.active { display: block; }
+      .viewer-card { min-width: 0; }
+      .viewer-card-list-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.75rem; margin-top: 0.9rem; }
+      .viewer-card-list-block h4,
+      .viewer-card-subsection h4,
+      .viewer-graph-header h3 { margin: 0 0 0.5rem 0; font-size: 0.88rem; font-weight: 700; color: #486174; }
+      .viewer-card-subsection { margin-top: 0.95rem; }
+      .viewer-card-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.45rem; }
+      .viewer-card-list li { border: 1px solid #dbe6f3; border-radius: 0.65rem; background: #fbfdff; padding: 0.5rem 0.65rem; color: #23384d; }
+      .viewer-card-actions { display: flex; flex-wrap: wrap; gap: 0.65rem; align-items: center; margin-top: 0.95rem; }
+      .viewer-action-button { border: 1px solid #bfd0e2; border-radius: 0.55rem; background: #fff; color: #355061; padding: 0.45rem 0.7rem; font: inherit; font-weight: 700; cursor: pointer; }
+      .viewer-action-button:hover { background: #f4f9ff; }
+      .viewer-inline-link { color: #2456a6; font-weight: 600; text-decoration: none; }
+      .viewer-inline-link:hover { text-decoration: underline; }
+      .viewer-stat-grid-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .viewer-stat-grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+      .viewer-next-action { margin-bottom: 0.9rem; }
+      .viewer-graph-header { margin-bottom: 0.75rem; }
+      .viewer-graph-header p { margin: 0.35rem 0 0 0; color: #486174; }
       .state-graph-block { margin-top: 0.4rem; }
       .state-graph-frame { margin-top: 0.5rem; border: 1px solid #d7e3f4; border-radius: 0.75rem; background: linear-gradient(180deg, #fbfdff 0%, #f4f8fc 100%); }
       .state-graph-toolbar { display: flex; align-items: center; gap: 0.4rem; padding: 0.55rem 0.65rem; border-bottom: 1px solid #d7e3f4; background: rgba(255,255,255,0.85); }
       .state-graph-toolbar button { border: 1px solid #9fb6cb; background: #fff; border-radius: 0.45rem; padding: 0.3rem 0.6rem; font: inherit; cursor: pointer; }
       .state-graph-toolbar button:hover { background: #f3f8fd; }
       .state-graph-zoom-value { margin-left: auto; font-size: 0.88rem; color: #486174; }
-      .mermaid-state-graph { min-height: 16rem; padding: 0.75rem; overflow: auto; cursor: grab; user-select: none; touch-action: none; }
+      .mermaid-state-graph { min-height: 20rem; padding: 0.75rem; overflow: auto; cursor: grab; user-select: none; touch-action: none; }
       .mermaid-state-graph[data-dragging="true"] { cursor: grabbing; }
       .mermaid-state-graph[data-rendered="pending"] { color: #5a7184; opacity: 0; pointer-events: none; }
       .mermaid-state-graph[data-rendered="settling"] { opacity: 0; pointer-events: none; }
@@ -198,33 +195,94 @@ export function renderInspectRunViewerHtml({
       .state-graph-render-error { margin: 0; padding: 0.9rem; color: #7f4b00; }
       .state-graph-summaries { margin: 0.85rem 0 0 0; padding-left: 1.1rem; }
       .state-graph-summary + .state-graph-summary { margin-top: 0.3rem; }
-      .inspection-details { margin-top: 1rem; }
-      .inspection-details summary { cursor: pointer; font-weight: 700; }
       dl { display: grid; grid-template-columns: 14rem 1fr; gap: 0.35rem 0.75rem; }
       dt { font-weight: 600; }
       section { border: 1px solid #ddd; border-radius: 0.5rem; padding: 0.75rem; margin-top: 1rem; }
-      .viewer-tabs { display: flex; gap: 0; margin: 1rem 0 0 0; border-bottom: 2px solid #ddd; }
-      .viewer-tab { padding: 0.5rem 1rem; cursor: pointer; border: none; background: none; font: inherit; font-weight: 600; color: #666; border-bottom: 2px solid transparent; margin-bottom: -2px; transition: color 0.15s, border-color 0.15s; }
-      .viewer-tab:hover { color: #1565c0; }
-      .viewer-tab.active { color: #1565c0; border-bottom-color: #1565c0; }
-      .tab-content { display: none; }
-      .tab-content.active { display: block; }
+      .handoff-envelope-section { border-color: #d7e3f4; background: linear-gradient(180deg, #fbfdff 0%, #f7fbff 100%); }
+      .handoff-hero { display: grid; grid-template-columns: minmax(0, 1.6fr) minmax(18rem, 0.9fr); gap: 1rem; align-items: start; }
+      .handoff-hero h2 { margin: 0; font-size: 1.9rem; line-height: 1.12; }
+      .handoff-card-kicker { margin: 0 0 0.35rem 0; font-size: 0.76rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; color: #486174; }
+      .handoff-hero-meta { margin: 0.5rem 0 0 0; color: #486174; }
+      .handoff-hero-badges { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.7rem; }
+      .handoff-layout { display: grid; grid-template-columns: minmax(17rem, 24rem) minmax(0, 1fr); gap: 1rem; margin-top: 1rem; align-items: start; }
+      .handoff-column { display: grid; gap: 1rem; align-content: start; }
+      .handoff-card { border: 1px solid #d7e3f4; border-radius: 0.85rem; background: #fff; box-shadow: 0 1px 2px rgba(35, 69, 102, 0.06); padding: 0.95rem 1rem; }
+      .handoff-card h3 { margin: 0 0 0.75rem 0; font-size: 1.03rem; color: #23384d; }
+      .handoff-card-tight { height: 100%; }
+      .handoff-card-emphasis { background: linear-gradient(180deg, #ffffff 0%, #f6faff 100%); }
+      .handoff-stat-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.65rem; }
+      .handoff-stat { border: 1px solid #dbe6f3; border-radius: 0.7rem; background: #fbfdff; padding: 0.65rem 0.75rem; }
+      .handoff-stat-label { display: block; font-size: 0.74rem; font-weight: 700; color: #567086; margin-bottom: 0.28rem; }
+      .handoff-stat-value { display: block; color: #20384f; font-weight: 700; }
+      .handoff-empty-state { border: 1px dashed #b8c9db; border-radius: 0.85rem; background: #fff; padding: 1.25rem; }
+      .handoff-empty-state h2 { margin: 0 0 0.5rem 0; }
+      .handoff-kv { display: grid; grid-template-columns: minmax(9rem, 12rem) minmax(0, 1fr); gap: 0.65rem 0.9rem; margin: 0; }
+      .handoff-kv-compact { grid-template-columns: minmax(7rem, 9rem) minmax(0, 1fr); }
+      .handoff-kv-row { display: contents; }
+      .handoff-kv dt { font-size: 0.78rem; font-weight: 700; color: #4c6478; }
+      .handoff-kv dd { margin: 0; min-width: 0; color: #23384d; }
+      .handoff-badge { display: inline-flex; align-items: center; justify-content: center; padding: 0.2rem 0.58rem; border-radius: 999px; border: 1px solid #b8c9db; background: #f6f9fc; color: #355061; font-size: 0.82rem; font-weight: 700; line-height: 1.2; }
+      .handoff-badge-success { border-color: #9dd4a2; background: #edf8ee; color: #25632a; }
+      .handoff-badge-warning { border-color: #f2c37b; background: #fff4de; color: #915800; }
+      .handoff-badge-danger { border-color: #efb0b0; background: #fff0f0; color: #9f2c2c; }
+      .handoff-badge-info { border-color: #b5cdef; background: #edf4ff; color: #2456a6; }
+      .handoff-badge-muted { border-color: #d5dde7; background: #f5f7fa; color: #5e7283; }
+      .handoff-next-action { font-size: 1rem; line-height: 1.55; color: #1f354b; padding: 0.85rem 0.95rem; border: 1px solid #dce8f5; border-radius: 0.8rem; background: linear-gradient(180deg, #fbfdff 0%, #f4f9ff 100%); }
+      .handoff-next-action p { margin: 0; }
+      .handoff-subsection + .handoff-subsection { margin-top: 0.95rem; }
+      .handoff-subgrid { display: grid; grid-template-columns: 1.6fr minmax(12rem, 0.9fr); gap: 1rem; align-items: start; }
+      .handoff-subsection h4 { margin: 0.95rem 0 0.45rem 0; font-size: 0.84rem; font-weight: 700; color: #486174; }
+      .handoff-chip-list,
+      .handoff-read-list,
+      .handoff-criteria-list { margin: 0; padding: 0; list-style: none; }
+      .handoff-chip-list { display: flex; flex-wrap: wrap; gap: 0.42rem; }
+      .handoff-read-list { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.42rem; }
+      .handoff-read-list li { padding: 0.48rem 0.65rem; border: 1px solid #dbe6f3; border-radius: 0.65rem; background: #fbfdff; }
+      .handoff-read-list code { color: #20496f; }
+      .handoff-criteria-list { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.7rem; }
+      .handoff-criteria-item { border: 1px solid #dbe6f3; border-left: 0.32rem solid #6d90c6; border-radius: 0.75rem; padding: 0.75rem; background: #fbfdff; }
+      .handoff-criteria-header { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 0.45rem; }
+      .handoff-criteria-item p { margin: 0; color: #304a62; }
+      .handoff-empty-copy,
+      .handoff-empty-value { color: #708497; }
       .current-pr-state-banner section,
       .current-pr-state-banner .state-graph-block,
       .current-pr-state-banner .current-pr-state-visualization { border: none; padding: 0; margin-top: 0; }
+      @media (max-width: 1100px) {
+        .viewer-card-grid-overview,
+        .viewer-card-grid-layers,
+        .viewer-card-list-grid,
+        .viewer-stat-grid-3 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      }
       @media (max-width: 900px) {
         .inspection-shell { grid-template-columns: minmax(0, 1fr); }
         .assigned-pr-inbox { position: static; max-height: none; }
-        .current-pr-state-grid { grid-template-columns: 1fr 1fr; }
+        .handoff-hero,
+        .handoff-layout,
+        .handoff-subgrid,
+        .handoff-criteria-list,
+        .handoff-read-list,
+        .viewer-card-grid-overview,
+        .viewer-card-grid-layers,
+        .viewer-card-list-grid { grid-template-columns: 1fr; }
+        .handoff-stat-grid,
+        .viewer-stat-grid-2,
+        .viewer-stat-grid-3 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
       }
       @media (max-width: 640px) {
-        .current-pr-state-grid { grid-template-columns: 1fr; }
         .state-graph-toolbar { flex-wrap: wrap; }
         .state-graph-zoom-value { margin-left: 0; }
         .assigned-pr-secondary-controls { flex-wrap: wrap; }
         .assigned-pr-select-mid,
         .assigned-pr-select-sm,
         .assigned-pr-select-updated { width: 100%; max-width: none; margin-left: 0; flex: 1 1 6rem; }
+        .handoff-kv,
+        .handoff-kv-compact,
+        .handoff-stat-grid,
+        .viewer-stat-grid-2,
+        .viewer-stat-grid-3 { grid-template-columns: 1fr; }
+        .viewer-action-button,
+        .viewer-inline-link { width: 100%; }
       }
     </style>
   </head>
@@ -234,33 +292,61 @@ export function renderInspectRunViewerHtml({
       <main class="inspection-main">
         ${target === null
           ? `<section class="current-pr-state-banner" aria-label="${escapeHtml(scopeLabel)} PR inspection dashboard">
-              <h1>${escapeHtml(scopeLabel)} PR inspection dashboard</h1>
-              <p class="current-pr-state-summary-headline">Choose a PR from the sidebar</p>
+              <div class="current-pr-state-heading-row">
+                <div class="current-pr-state-heading-copy">
+                  <p class="current-pr-state-kicker">Inspection dashboard</p>
+                  <h1>${escapeHtml(scopeLabel)} PR inspection dashboard</h1>
+                </div>
+              </div>
+              <p class="current-pr-state-summary-headline"><strong>No PR selected</strong></p>
               <p class="current-pr-state-detail">This local/operator dashboard is read-only. inspect-run remains authoritative for inspection/status state while this UI owns inbox discovery plus read-only presentation/prioritization.</p>
-              <p class="current-pr-state-detail">The dashboard can span all assigned repos or be narrowed to one repo. The sidebar defaults to open PRs from the last 7 days and paginates through the result set.</p>
+              <p class="current-pr-state-note">No assigned PR in ${escapeHtml(scopeLabel)} matched the current view yet. Pick a PR from the sidebar, widen the state or updated filters, or move to another inbox page.</p>
+            </section>
+            <section class="viewer-tab-section" aria-label="Dashboard empty state">
+              <div class="handoff-empty-state">
+                <h2>Choose a PR from sidebar</h2>
+                <p>The dashboard can span all assigned repos or be narrowed to one repo. Sidebar defaults to open PRs from last 7 days and paginates through result set.</p>
+              </div>
             </section>`
-          : renderCurrentStateBanner(normalizedSnapshot, target, stateLabel, graph, effectiveSelectedTitle)}
-        ${renderCollapsedDetailsPanel(`
-      <p><strong>Snapshot state:</strong> <span class="badge">${escapeHtml(stateLabel)}</span> <button type="button" onclick="window.location.reload()" title="Reload snapshot" aria-label="Reload snapshot">🔄</button></p>
-      <p><strong>Refresh:</strong> manual reload only.${rawSnapshotHref ? ` <strong>Raw snapshot:</strong> <a href="${escapeHtml(rawSnapshotHref)}"><code>${escapeHtml(rawSnapshotHref)}</code></a>` : ""}</p>
-      ${topSummary}
-    `)}
-      <div class="viewer-tabs">
-        <button class="viewer-tab active" data-tab="live" onclick="switchTab('live')">Live view</button>
-        <button class="viewer-tab" data-tab="handoff" onclick="switchTab('handoff')">Agent handoff</button>
-      </div>
-      <div class="tab-content active" id="tab-live">
-        ${renderCollapsedDetailsPanel(`
-      ${renderOuterLoopSummarySection(normalizedSnapshot)}
-      ${renderCopilotLoopIterationsSection(normalizedSnapshot)}
-      ${renderCopilotLayerSection(normalizedSnapshot?.layers?.copilot)}
-      ${renderReviewerLayerSection(normalizedSnapshot?.layers?.reviewer)}
-      ${renderSteeringSummarySection(normalizedSnapshot?.layers?.steering)}
-        `)}
-      </div>
-      <div class="tab-content" id="tab-handoff">
-        ${renderHandoffEnvelopeSection(handoffEnvelope)}
-      </div>
+          : `${renderCurrentStateBanner(normalizedSnapshot, target, stateLabel, graph, effectiveSelectedTitle)}
+            <div class="viewer-tab-shell" role="tablist" aria-label="Inspect run viewer tabs">
+              <div class="viewer-tabs">
+                <button class="viewer-tab active" data-tab="graph" onclick="switchTab('graph')">Graph</button>
+                <button class="viewer-tab" data-tab="overview" onclick="switchTab('overview')">Overview</button>
+                <button class="viewer-tab" data-tab="layers" onclick="switchTab('layers')">Layers</button>
+                <button class="viewer-tab" data-tab="handoff" onclick="switchTab('handoff')">Agent handoff</button>
+              </div>
+            </div>
+            <div class="tab-content active" id="tab-graph">
+              <section class="viewer-tab-section" aria-label="Graph">
+                <article class="handoff-card handoff-card-emphasis viewer-card">
+                  <p class="handoff-card-kicker">Graph</p>
+                  <div class="viewer-graph-header">
+                    <h3>Full state machine</h3>
+                    <p>Authoritative Mermaid lane graph. Use zoom controls, drag, and graph guide to inspect current and next-state cues.</p>
+                  </div>
+                  ${graph === null
+                    ? `<p>${escapeHtml(error?.message ?? "Unable to load inspect-run snapshot.")}</p><p>Snapshot unavailable, so no state graph can be rendered yet. Manual reload only.</p>`
+                    : `<div class="viewer-graph-body">${renderStateVisualizationSection(normalizedSnapshot, graph)}</div>`}
+                </article>
+              </section>
+            </div>
+            <div class="tab-content" id="tab-overview">
+              ${renderOverviewSection(normalizedSnapshot, target, stateLabel, rawSnapshotHref)}
+            </div>
+            <div class="tab-content" id="tab-layers">
+              <section class="viewer-tab-section" aria-label="Layers">
+                <div class="viewer-card-grid viewer-card-grid-layers">
+                  ${renderOuterLoopSummarySection(normalizedSnapshot)}
+                  ${renderCopilotLayerSection(normalizedSnapshot?.layers?.copilot, normalizedSnapshot)}
+                  ${renderReviewerLayerSection(normalizedSnapshot?.layers?.reviewer)}
+                  ${renderSteeringSummarySection(normalizedSnapshot?.layers?.steering)}
+                </div>
+              </section>
+            </div>
+            <div class="tab-content" id="tab-handoff">
+              ${renderHandoffEnvelopeSection(handoffEnvelope)}
+            </div>`}
       </main>
     </div>
     ${renderInboxShellScript()}

--- a/scripts/loop/inspect-run-viewer/rendering.mjs
+++ b/scripts/loop/inspect-run-viewer/rendering.mjs
@@ -236,10 +236,10 @@ export function renderInspectRunViewerHtml({
       .handoff-empty-state h2 { margin: 0; line-height: 1.2; }
       .handoff-empty-state p { margin: 0; line-height: 1.6; }
       .handoff-kv { display: grid; grid-template-columns: minmax(9rem, 12rem) minmax(0, 1fr); gap: 0.8rem 1rem; margin: 0; }
-      .handoff-kv-compact { grid-template-columns: minmax(7rem, 9rem) minmax(0, 1fr); }
+      .handoff-kv-compact { grid-template-columns: minmax(9rem, 15rem) minmax(0, 1fr); }
       .handoff-kv-row { display: contents; }
-      .handoff-kv dt { font-size: 0.79rem; font-weight: 700; line-height: 1.4; color: #4c6478; }
-      .handoff-kv dd { margin: 0; min-width: 0; line-height: 1.55; color: #23384d; }
+      .handoff-kv dt { font-size: 0.79rem; font-weight: 700; line-height: 1.4; color: #4c6478; word-break: break-word; }
+      .handoff-kv dd { margin: 0; min-width: 0; line-height: 1.55; color: #23384d; word-break: break-word; }
       .handoff-badge { display: inline-flex; align-items: center; justify-content: center; padding: 0.28rem 0.7rem; border-radius: 999px; border: 1px solid #b8c9db; background: #f6f9fc; color: #355061; font-size: 0.84rem; font-weight: 700; line-height: 1.25; }
       .handoff-badge-success { border-color: #9dd4a2; background: #edf8ee; color: #25632a; }
       .handoff-badge-warning { border-color: #f2c37b; background: #fff4de; color: #915800; }
@@ -347,13 +347,16 @@ export function renderInspectRunViewerHtml({
           : `${renderCurrentStateBanner(normalizedSnapshot, target, stateLabel, graph, effectiveSelectedTitle)}
             <div class="viewer-tab-shell" role="tablist" aria-label="Inspect run viewer tabs">
               <div class="viewer-tabs">
-                <button id="tab-btn-graph" class="viewer-tab active" role="tab" aria-selected="true" aria-controls="tab-graph" data-tab="graph" onclick="switchTab('graph')">Graph</button>
-                <button id="tab-btn-overview" class="viewer-tab" role="tab" aria-selected="false" aria-controls="tab-overview" data-tab="overview" onclick="switchTab('overview')">Overview</button>
+                <button id="tab-btn-overview" class="viewer-tab active" role="tab" aria-selected="true" aria-controls="tab-overview" data-tab="overview" onclick="switchTab('overview')">Overview</button>
+                <button id="tab-btn-graph" class="viewer-tab" role="tab" aria-selected="false" aria-controls="tab-graph" data-tab="graph" onclick="switchTab('graph')">Graph</button>
                 <button id="tab-btn-layers" class="viewer-tab" role="tab" aria-selected="false" aria-controls="tab-layers" data-tab="layers" onclick="switchTab('layers')">Layers</button>
                 <button id="tab-btn-handoff" class="viewer-tab" role="tab" aria-selected="false" aria-controls="tab-handoff" data-tab="handoff" onclick="switchTab('handoff')">Agent handoff</button>
               </div>
             </div>
-            <div class="tab-content active" id="tab-graph" role="tabpanel" aria-labelledby="tab-btn-graph">
+            <div class="tab-content active" id="tab-overview" role="tabpanel" aria-labelledby="tab-btn-overview">
+              ${renderOverviewSection(normalizedSnapshot, target, stateLabel)}
+            </div>
+            <div class="tab-content" id="tab-graph" role="tabpanel" aria-labelledby="tab-btn-graph">
               <section class="viewer-tab-section" aria-label="Graph">
                 <article class="handoff-card handoff-card-emphasis viewer-card">
                   <p class="handoff-card-kicker">Graph</p>
@@ -366,9 +369,6 @@ export function renderInspectRunViewerHtml({
                     : `<div class="viewer-graph-body">${renderStateVisualizationSection(normalizedSnapshot, graph)}</div>`}
                 </article>
               </section>
-            </div>
-            <div class="tab-content" id="tab-overview" role="tabpanel" aria-labelledby="tab-btn-overview">
-              ${renderOverviewSection(normalizedSnapshot, target, stateLabel)}
             </div>
             <div class="tab-content" id="tab-layers" role="tabpanel" aria-labelledby="tab-btn-layers">
               <section class="viewer-tab-section" aria-label="Layers">
@@ -392,14 +392,17 @@ export function renderInspectRunViewerHtml({
           t.classList.remove('active');
           t.setAttribute('aria-selected', 'false');
         });
-        
+
         document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
         const activeTab = document.querySelector('.viewer-tab[data-tab="' + tabName + '"]');
         if (!activeTab) { return; }
         activeTab.classList.add('active');
         activeTab.setAttribute('aria-selected', 'true');
-        const panel = document.getElementById('tab-' + tabName); if (panel) { panel.classList.add('active');
+        const panel = document.getElementById('tab-' + tabName);
+        if (panel) {
+          panel.classList.add('active');
         }
+        document.dispatchEvent(new CustomEvent('inspect-run-viewer:tabchange', { detail: { tabName } }));
       }
     </script>
     ${graph === null ? "" : renderMermaidBootScript()}

--- a/scripts/loop/inspect-run-viewer/rendering.mjs
+++ b/scripts/loop/inspect-run-viewer/rendering.mjs
@@ -73,11 +73,15 @@ export function renderInspectRunViewerHtml({
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>${escapeHtml(title)}</title>
     <style>
-      body { font-family: sans-serif; margin: 1rem; max-width: none; line-height: 1.4; }
+      *, *::before, *::after { box-sizing: border-box; }
+      body { font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 1.25rem; max-width: none; line-height: 1.55; color: #20384f; background: #fff; }
       code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre-wrap; }
-      .inspection-shell { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 1rem; align-items: start; }
-      .assigned-pr-inbox { position: sticky; top: 1rem; width: 22rem; max-width: 100%; border: 1px solid #d9e5f2; border-radius: 0.65rem; padding: 0.65rem; background: #fbfdff; max-height: calc(100vh - 2rem); overflow: auto; box-sizing: border-box; }
-      .assigned-pr-inbox[data-sidebar-collapsed="true"] { width: 2.15rem; overflow: hidden; padding: 0.22rem; border-color: transparent; background: transparent; box-shadow: none; }
+      code { padding: 0.12rem 0.38rem; border-radius: 0.42rem; background: #f4f8fd; color: #20496f; font-size: 0.94em; line-height: 1.45; overflow-wrap: anywhere; }
+      pre { margin: 0; padding: 0.95rem 1rem; border: 1px solid #dbe6f3; border-radius: 0.85rem; background: #f8fbff; overflow: auto; line-height: 1.6; }
+      pre code { padding: 0; border-radius: 0; background: transparent; color: inherit; }
+      .inspection-shell { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 1.35rem; align-items: start; }
+      .assigned-pr-inbox { position: sticky; top: 1.25rem; width: 22rem; max-width: 100%; border: 1px solid #d9e5f2; border-radius: 0.8rem; padding: 0.9rem; background: #fbfdff; max-height: calc(100vh - 2.5rem); overflow: auto; box-sizing: border-box; box-shadow: 0 1px 2px rgba(35, 69, 102, 0.05); }
+      .assigned-pr-inbox[data-sidebar-collapsed="true"] { width: 2.35rem; overflow: hidden; padding: 0.28rem; border-color: transparent; background: transparent; box-shadow: none; }
       .assigned-pr-inbox[data-sidebar-collapsed="true"] h2,
       .assigned-pr-inbox[data-sidebar-collapsed="true"] .assigned-pr-controls,
       .assigned-pr-inbox[data-sidebar-collapsed="true"] .assigned-pr-filter-note,
@@ -86,22 +90,22 @@ export function renderInspectRunViewerHtml({
       .assigned-pr-inbox[data-sidebar-collapsed="true"] .assigned-pr-list,
       .assigned-pr-inbox[data-sidebar-collapsed="true"] .assigned-pr-empty,
       .assigned-pr-inbox[data-sidebar-collapsed="true"] .assigned-pr-pagination { display: none; }
-      .assigned-pr-inbox-header { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.45rem; }
-      .assigned-pr-inbox-header h2 { margin: 0; font-size: 0.98rem; flex: 1; }
-      .assigned-pr-controls { display: flex; flex-wrap: wrap; gap: 0.32rem 0.45rem; margin-bottom: 0.35rem; align-items: center; }
-      .assigned-pr-control-row { display: flex; align-items: center; gap: 0.45rem; flex-wrap: wrap; }
+      .assigned-pr-inbox-header { display: flex; align-items: center; gap: 0.7rem; margin-bottom: 0.7rem; }
+      .assigned-pr-inbox-header h2 { margin: 0; font-size: 1rem; line-height: 1.3; flex: 1; }
+      .assigned-pr-controls { display: flex; flex-wrap: wrap; gap: 0.55rem 0.6rem; margin-bottom: 0.55rem; align-items: center; }
+      .assigned-pr-control-row { display: flex; align-items: center; gap: 0.55rem; flex-wrap: wrap; }
       .assigned-pr-scope-row { align-items: center; }
       .assigned-pr-secondary-controls { flex: 999 1 18rem; flex-wrap: nowrap; }
       .assigned-pr-filter-label { display: inline-block; min-width: 3.6rem; margin: 0; font-size: 0.74rem; font-weight: 700; color: #355061; text-transform: uppercase; letter-spacing: 0.03em; }
-      .assigned-pr-select { flex: 1; min-width: 0; max-width: 100%; border: 1px solid #bfd0e2; border-radius: 0.42rem; padding: 0.22rem 0.4rem; font: inherit; font-size: 0.8rem; color: #355061; background: #fff; }
+      .assigned-pr-select { flex: 1; min-width: 0; max-width: 100%; border: 1px solid #bfd0e2; border-radius: 0.5rem; padding: 0.4rem 0.55rem; font: inherit; font-size: 0.83rem; line-height: 1.35; color: #355061; background: #fff; }
       .assigned-pr-select-mid { flex: 0 1 auto; width: min(7.25rem, 100%); max-width: 7.25rem; min-width: 5.2rem; }
       .assigned-pr-select-sm { flex: 0 1 auto; width: min(4.8rem, 100%); max-width: 4.8rem; min-width: 3.6rem; }
       .assigned-pr-select-updated { margin-left: auto; }
-      .inbox-collapse-toggle { border: none; outline: none; box-shadow: none; appearance: none; -webkit-appearance: none; background: #355061; color: #fff; border-radius: 0.4rem; padding: 0.12rem 0.22rem; cursor: pointer; font-size: 1rem; line-height: 1; }
-      .inbox-search-label { display: block; font-size: 0.82rem; font-weight: 600; color: #355061; margin-bottom: 0.18rem; margin-top: 0.1rem; }
-      .inbox-search-input { width: 100%; border: 1px solid #bfd0e2; border-radius: 0.4rem; padding: 0.28rem 0.42rem; margin-bottom: 0.45rem; }
-      .assigned-pr-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.36rem; }
-      .assigned-pr-row { border: 1px solid #d6e0ea; border-left: 0.32rem solid #8ca3b8; border-radius: 0.5rem; background: #fff; }
+      .inbox-collapse-toggle { border: none; outline: none; box-shadow: none; appearance: none; -webkit-appearance: none; background: #355061; color: #fff; border-radius: 0.4rem; padding: 0.2rem 0.32rem; cursor: pointer; font-size: 1rem; line-height: 1; }
+      .inbox-search-label { display: block; font-size: 0.82rem; font-weight: 600; color: #355061; margin-bottom: 0.3rem; margin-top: 0.2rem; }
+      .inbox-search-input { width: 100%; border: 1px solid #bfd0e2; border-radius: 0.5rem; padding: 0.42rem 0.55rem; margin-bottom: 0.7rem; }
+      .assigned-pr-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.55rem; }
+      .assigned-pr-row { border: 1px solid #d6e0ea; border-left: 0.32rem solid #8ca3b8; border-radius: 0.6rem; background: #fff; }
       .assigned-pr-row.assigned-pr-row-attention { border-left-color: #c87400; }
       .assigned-pr-row.assigned-pr-row-pending { border-left-color: #b88900; }
       .assigned-pr-row.assigned-pr-row-gate { border-left-color: #6f42c1; }
@@ -109,140 +113,160 @@ export function renderInspectRunViewerHtml({
       .assigned-pr-row.assigned-pr-row-closed { border-left-color: #7a8694; }
       .assigned-pr-row.assigned-pr-row-unknown { border-left-color: #8ca3b8; }
       .assigned-pr-row.assigned-pr-row-waiting { border-left-color: #1565c0; }
-      .assigned-pr-link { display: block; padding: 0.38rem 0.45rem; color: inherit; text-decoration: none; }
+      .assigned-pr-link { display: block; padding: 0.56rem 0.65rem; color: inherit; text-decoration: none; }
       .assigned-pr-row.is-selected .assigned-pr-link { box-shadow: inset 0 0 0 1px #1565c0; border-radius: 0.3rem; }
-      .assigned-pr-title-line { display: flex; align-items: flex-start; gap: 0.35rem; }
+      .assigned-pr-title-line { display: flex; align-items: flex-start; gap: 0.5rem; }
       .assigned-pr-id-col { display: flex; flex-direction: column; align-items: center; flex-shrink: 0; min-width: 2.4rem; margin-right: 0.15rem; }
-      .assigned-pr-id { font-weight: 700; }
+      .assigned-pr-id { font-weight: 700; line-height: 1.2; }
       .assigned-pr-signal-emoji { font-size: 0.65rem; line-height: 1.2; }
-      .assigned-pr-title { font-weight: 600; min-width: 0; flex: 1 1 auto; }
-      .assigned-pr-line + .assigned-pr-line { margin-top: 0.18rem; }
-      .assigned-pr-meta { display: flex; flex-wrap: wrap; gap: 0.22rem 0.36rem; font-size: 0.76rem; color: #486174; }
+      .assigned-pr-title { font-weight: 600; min-width: 0; flex: 1 1 auto; line-height: 1.45; }
+      .assigned-pr-line + .assigned-pr-line { margin-top: 0.28rem; }
+      .assigned-pr-meta { display: flex; flex-wrap: wrap; gap: 0.3rem 0.45rem; font-size: 0.78rem; line-height: 1.45; color: #486174; }
       .assigned-pr-meta-primary { justify-content: space-between; align-items: baseline; gap: 0.5rem; }
       .assigned-pr-meta-primary .assigned-pr-repo { text-align: left; min-width: 0; }
       .assigned-pr-meta-primary .assigned-pr-updated { margin-left: auto; text-align: right; white-space: nowrap; }
-      .assigned-pr-pagination { display: flex; align-items: center; justify-content: center; gap: 0.6rem; margin-top: 0.45rem; }
+      .assigned-pr-pagination { display: flex; align-items: center; justify-content: center; gap: 0.6rem; margin-top: 0.75rem; }
       .assigned-pr-page-link { color: #5b2ca0; text-decoration: none; font-weight: 700; }
       .assigned-pr-page-link.is-disabled { color: #9aa9b8; pointer-events: none; }
       .assigned-pr-page-status { font-weight: 700; color: #253b53; }
       .inspection-main { min-width: 0; }
-      .current-pr-state-banner { border: 1px solid #d7e3f4; border-radius: 1rem; background: linear-gradient(180deg, #ffffff 0%, #f6fbff 100%); box-shadow: 0 1px 2px rgba(35, 69, 102, 0.06); padding: 1rem 1.1rem; margin-top: 0; }
-      .current-pr-state-heading-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.75rem; }
-      .current-pr-state-heading-copy { min-width: 0; }
-      .current-pr-state-kicker { margin: 0 0 0.25rem 0; font-size: 0.86rem; font-weight: 800; letter-spacing: 0.06em; text-transform: uppercase; color: #486174; }
+      .current-pr-state-banner { border: 1px solid #d7e3f4; border-radius: 1rem; background: linear-gradient(180deg, #ffffff 0%, #f6fbff 100%); box-shadow: 0 1px 2px rgba(35, 69, 102, 0.06); padding: 1.2rem 1.3rem; margin-top: 0; display: grid; gap: 0.9rem; }
+      .current-pr-state-heading-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.9rem; }
+      .current-pr-state-heading-copy { min-width: 0; display: grid; gap: 0.35rem; }
+      .current-pr-state-kicker { margin: 0; font-size: 0.82rem; font-weight: 800; letter-spacing: 0.06em; text-transform: uppercase; color: #486174; }
       .current-pr-state-kicker a { color: #355061; text-decoration: none; }
       .current-pr-state-kicker a:hover { text-decoration: underline; }
-      .current-pr-state-mode-indicator { flex: 0 0 auto; font-size: 1.65rem; line-height: 1; margin-top: 0.08rem; }
-      .current-pr-state-banner h1 { margin: 0; font-size: 2rem; line-height: 1.15; color: #18324a; }
-      .current-pr-state-summary-headline { margin: 0.75rem 0 0.3rem 0; color: #1565c0; font-size: 1.06rem; }
-      .current-pr-state-detail { margin: 0; color: #274766; font-size: 0.98rem; }
-      .current-pr-state-meta { margin: 0.55rem 0 0 0; color: #5a758b; font-size: 0.82rem; }
-      .current-pr-state-badge-row { margin-top: 0.75rem; }
-      .viewer-badge-row { display: flex; flex-wrap: wrap; gap: 0.4rem; }
-      .viewer-card-grid { display: grid; gap: 1rem; align-items: start; }
+      .current-pr-state-mode-indicator { flex: 0 0 auto; font-size: 1.75rem; line-height: 1; margin-top: 0.08rem; }
+      .current-pr-state-banner h1 { margin: 0; font-size: 2rem; line-height: 1.12; color: #18324a; overflow-wrap: anywhere; }
+      .current-pr-state-copy-flow { display: grid; gap: 0.7rem; min-width: 0; }
+      .current-pr-state-summary-headline { margin: 0; color: #1565c0; font-size: 1.08rem; line-height: 1.35; }
+      .current-pr-state-detail { margin: 0; color: #274766; font-size: 1rem; line-height: 1.6; max-width: 78ch; }
+      .current-pr-state-meta { margin: 0; color: #5a758b; font-size: 0.84rem; line-height: 1.5; }
+      .current-pr-state-note { margin: 0; color: #5a758b; font-size: 0.92rem; line-height: 1.55; max-width: 78ch; }
+      .current-pr-state-badge-row { margin-top: 0; }
+      .current-pr-state-reload { flex: 0 0 auto; }
+      .viewer-badge-row { display: flex; flex-wrap: wrap; gap: 0.5rem 0.6rem; align-items: flex-start; }
+      .viewer-card-grid { display: grid; gap: 1.15rem; align-items: start; }
       .viewer-card-grid-overview { grid-template-columns: repeat(2, minmax(0, 1fr)); }
       .viewer-card-grid-layers { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-      .viewer-tab-section { border: none; background: none; padding: 0; margin-top: 1rem; }
-      .viewer-tab-shell { position: sticky; top: 0.65rem; z-index: 4; border: 1px solid #d7e3f4; border-radius: 0.85rem; background: rgba(251, 253, 255, 0.96); backdrop-filter: blur(6px); padding: 0.3rem; margin-top: 0.85rem; }
-      .viewer-tabs { display: flex; flex-wrap: wrap; gap: 0.4rem; margin: 0; }
-      .viewer-tab { padding: 0.58rem 0.9rem; cursor: pointer; border: 1px solid transparent; border-radius: 0.7rem; background: transparent; font: inherit; font-weight: 700; color: #486174; transition: color 0.15s, border-color 0.15s, background 0.15s, box-shadow 0.15s; }
+      .viewer-tab-section { border: none; background: none; padding: 0; margin-top: 1.15rem; }
+      .viewer-tab-shell { position: sticky; top: 0.8rem; z-index: 4; border: 1px solid #d7e3f4; border-radius: 0.95rem; background: rgba(251, 253, 255, 0.96); backdrop-filter: blur(6px); padding: 0.4rem; margin-top: 1rem; box-shadow: 0 1px 2px rgba(35, 69, 102, 0.06); }
+      .viewer-tabs { display: flex; flex-wrap: wrap; gap: 0.45rem; margin: 0; }
+      .viewer-tab { padding: 0.68rem 1rem; cursor: pointer; border: 1px solid transparent; border-radius: 0.7rem; background: transparent; font: inherit; font-weight: 700; line-height: 1.25; color: #486174; transition: color 0.15s, border-color 0.15s, background 0.15s, box-shadow 0.15s; }
       .viewer-tab:hover { color: #1565c0; background: #f4f9ff; }
       .viewer-tab.active { color: #1565c0; background: #fff; border-color: #c8d9ec; box-shadow: 0 1px 2px rgba(35, 69, 102, 0.08); }
       .tab-content { display: none; }
       .tab-content.active { display: block; }
       .viewer-card { min-width: 0; }
-      .viewer-card-list-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.75rem; margin-top: 0.9rem; }
+      .viewer-card-body,
+      .handoff-card-body,
+      .viewer-card-list-block,
+      .viewer-graph-header,
+      .handoff-hero-copy { display: grid; gap: 0.7rem; min-width: 0; }
+      .viewer-card-list-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.9rem; margin-top: 1rem; }
       .viewer-card-list-block h4,
       .viewer-card-subsection h4,
-      .viewer-graph-header h3 { margin: 0 0 0.5rem 0; font-size: 0.88rem; font-weight: 700; color: #486174; }
-      .viewer-card-subsection { margin-top: 0.95rem; }
-      .viewer-card-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.45rem; }
-      .viewer-card-list li { border: 1px solid #dbe6f3; border-radius: 0.65rem; background: #fbfdff; padding: 0.5rem 0.65rem; color: #23384d; }
-      .viewer-card-actions { display: flex; flex-wrap: wrap; gap: 0.65rem; align-items: center; margin-top: 0.95rem; }
-      .viewer-action-button { border: 1px solid #bfd0e2; border-radius: 0.55rem; background: #fff; color: #355061; padding: 0.45rem 0.7rem; font: inherit; font-weight: 700; cursor: pointer; }
+      .viewer-graph-header h3 { margin: 0; font-size: 0.9rem; font-weight: 700; line-height: 1.35; color: #486174; }
+      .viewer-card-subsection { margin-top: 1.1rem; display: grid; gap: 0.55rem; }
+      .viewer-card-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.55rem; }
+      .viewer-card-list li { border: 1px solid #dbe6f3; border-radius: 0.65rem; background: #fbfdff; padding: 0.65rem 0.8rem; color: #23384d; line-height: 1.5; }
+      .viewer-card-actions { display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center; margin-top: 1.1rem; }
+      .viewer-action-button { border: 1px solid #bfd0e2; border-radius: 0.55rem; background: #fff; color: #355061; padding: 0.5rem 0.78rem; font: inherit; font-weight: 700; line-height: 1.35; cursor: pointer; }
       .viewer-action-button:hover { background: #f4f9ff; }
-      .viewer-inline-link { color: #2456a6; font-weight: 600; text-decoration: none; }
+      .viewer-inline-link { color: #2456a6; font-weight: 600; line-height: 1.4; text-decoration: none; }
       .viewer-inline-link:hover { text-decoration: underline; }
       .viewer-stat-grid-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
       .viewer-stat-grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-      .viewer-next-action { margin-bottom: 0.9rem; }
-      .viewer-graph-header { margin-bottom: 0.75rem; }
-      .viewer-graph-header p { margin: 0.35rem 0 0 0; color: #486174; }
-      .state-graph-block { margin-top: 0.4rem; }
-      .state-graph-frame { margin-top: 0.5rem; border: 1px solid #d7e3f4; border-radius: 0.75rem; background: linear-gradient(180deg, #fbfdff 0%, #f4f8fc 100%); }
-      .state-graph-toolbar { display: flex; align-items: center; gap: 0.4rem; padding: 0.55rem 0.65rem; border-bottom: 1px solid #d7e3f4; background: rgba(255,255,255,0.85); }
-      .state-graph-toolbar button { border: 1px solid #9fb6cb; background: #fff; border-radius: 0.45rem; padding: 0.3rem 0.6rem; font: inherit; cursor: pointer; }
+      .viewer-next-action { margin-bottom: 0; }
+      .viewer-graph-header { margin-bottom: 0; }
+      .viewer-graph-header p { margin: 0; color: #486174; line-height: 1.6; max-width: 72ch; }
+      .state-graph-block { margin-top: 0.25rem; }
+      .state-graph-frame { margin-top: 0.75rem; min-width: 0; border: 1px solid #d7e3f4; border-radius: 0.85rem; background: linear-gradient(180deg, #fbfdff 0%, #f4f8fc 100%); overflow: hidden; }
+      .state-graph-toolbar { display: flex; align-items: center; gap: 0.55rem; padding: 0.75rem 0.85rem; border-bottom: 1px solid #d7e3f4; background: rgba(255,255,255,0.85); }
+      .state-graph-toolbar button { border: 1px solid #9fb6cb; background: #fff; border-radius: 0.45rem; padding: 0.38rem 0.72rem; font: inherit; font-weight: 600; line-height: 1.25; cursor: pointer; }
       .state-graph-toolbar button:hover { background: #f3f8fd; }
-      .state-graph-zoom-value { margin-left: auto; font-size: 0.88rem; color: #486174; }
-      .mermaid-state-graph { min-height: 20rem; padding: 0.75rem; overflow: auto; cursor: grab; user-select: none; touch-action: none; }
+      .state-graph-zoom-value { margin-left: auto; font-size: 0.92rem; line-height: 1.4; color: #486174; }
+      .viewer-graph-body,
+      .state-graph-block { min-width: 0; }
+      .mermaid-state-graph { min-height: 21rem; min-width: 0; max-width: 100%; padding: 1rem; overflow: auto; cursor: grab; user-select: none; touch-action: none; }
       .mermaid-state-graph[data-dragging="true"] { cursor: grabbing; }
       .mermaid-state-graph[data-rendered="pending"] { color: #5a7184; opacity: 0; pointer-events: none; }
       .mermaid-state-graph[data-rendered="settling"] { opacity: 0; pointer-events: none; }
       .mermaid-state-graph svg { display: block; width: 100%; height: auto; transition: width 120ms ease; }
-      .state-graph-cues { display: flex; flex-wrap: wrap; gap: 0.45rem 0.75rem; margin: 0.75rem 0 0.35rem 0; }
-      .state-graph-cue { display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.88rem; color: #355061; }
-      .state-graph-cue-chip { display: inline-flex; align-items: center; justify-content: center; min-width: 2.5rem; padding: 0.14rem 0.5rem; border-radius: 999px; border: 1px solid #90a4ae; background: #fff; font-weight: 700; }
+      .state-graph-cues { display: flex; flex-wrap: wrap; gap: 0.55rem 0.85rem; margin: 1rem 0 0.2rem 0; }
+      .state-graph-cue { display: inline-flex; align-items: center; gap: 0.45rem; font-size: 0.9rem; line-height: 1.45; color: #355061; }
+      .state-graph-cue-chip { display: inline-flex; align-items: center; justify-content: center; min-width: 2.5rem; padding: 0.22rem 0.58rem; border-radius: 999px; border: 1px solid #90a4ae; background: #fff; font-weight: 700; line-height: 1.2; }
       .state-graph-cue-chip-start { border-color: #78909c; background: #f5f7f9; }
       .state-graph-cue-chip-current { border-color: #1565c0; background: #e3f2fd; }
       .state-graph-cue-chip-next { border-color: #5c6bc0; background: #f3f4ff; }
       .state-graph-cue-chip-end { border-color: #2e7d32; background: #e8f5e9; }
       .state-graph-cue-chip-loop { border-color: #ef6c00; background: #fff3e0; }
-      .state-graph-details { margin-top: 0.7rem; }
-      .state-graph-details summary { cursor: pointer; font-weight: 600; color: #355061; }
-      .state-graph-help { margin: 0.75rem 0 0.85rem 1.1rem; padding: 0; color: #425d70; }
-      .state-graph-help li + li { margin-top: 0.35rem; }
-      .state-graph-render-error { margin: 0; padding: 0.9rem; color: #7f4b00; }
-      .state-graph-summaries { margin: 0.85rem 0 0 0; padding-left: 1.1rem; }
-      .state-graph-summary + .state-graph-summary { margin-top: 0.3rem; }
-      dl { display: grid; grid-template-columns: 14rem 1fr; gap: 0.35rem 0.75rem; }
-      dt { font-weight: 600; }
-      section { border: 1px solid #ddd; border-radius: 0.5rem; padding: 0.75rem; margin-top: 1rem; }
-      .handoff-envelope-section { border-color: #d7e3f4; background: linear-gradient(180deg, #fbfdff 0%, #f7fbff 100%); }
-      .handoff-hero { display: grid; grid-template-columns: minmax(0, 1.6fr) minmax(18rem, 0.9fr); gap: 1rem; align-items: start; }
-      .handoff-hero h2 { margin: 0; font-size: 1.9rem; line-height: 1.12; }
-      .handoff-card-kicker { margin: 0 0 0.35rem 0; font-size: 0.76rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; color: #486174; }
-      .handoff-hero-meta { margin: 0.5rem 0 0 0; color: #486174; }
-      .handoff-hero-badges { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.7rem; }
-      .handoff-layout { display: grid; grid-template-columns: minmax(17rem, 24rem) minmax(0, 1fr); gap: 1rem; margin-top: 1rem; align-items: start; }
-      .handoff-column { display: grid; gap: 1rem; align-content: start; }
-      .handoff-card { border: 1px solid #d7e3f4; border-radius: 0.85rem; background: #fff; box-shadow: 0 1px 2px rgba(35, 69, 102, 0.06); padding: 0.95rem 1rem; }
-      .handoff-card h3 { margin: 0 0 0.75rem 0; font-size: 1.03rem; color: #23384d; }
+      .state-graph-details { margin-top: 0.9rem; }
+      .state-graph-details summary { cursor: pointer; font-weight: 600; line-height: 1.4; color: #355061; }
+      .state-graph-help { margin: 0.85rem 0 1rem 1.2rem; padding: 0; line-height: 1.55; color: #425d70; }
+      .state-graph-help li + li { margin-top: 0.4rem; }
+      .state-graph-render-error { margin: 0; padding: 1rem; line-height: 1.55; color: #7f4b00; }
+      .state-graph-summaries { margin: 1rem 0 0 0; padding-left: 1.2rem; line-height: 1.55; }
+      .state-graph-summary + .state-graph-summary { margin-top: 0.45rem; }
+      dl { display: grid; grid-template-columns: 14rem 1fr; gap: 0.5rem 0.95rem; }
+      dt { font-weight: 600; line-height: 1.4; }
+      dd { margin: 0; line-height: 1.55; overflow-wrap: anywhere; }
+      section { border: 1px solid #ddd; border-radius: 0.5rem; padding: 0.9rem; margin-top: 1.1rem; }
+      .handoff-envelope-section { border-color: #d7e3f4; background: linear-gradient(180deg, #fbfdff 0%, #f7fbff 100%); padding: 1.05rem 1.15rem; }
+      .handoff-hero { display: grid; grid-template-columns: minmax(0, 1.6fr) minmax(18rem, 0.9fr); gap: 1.15rem; align-items: start; }
+      .handoff-hero h2 { margin: 0; font-size: 1.9rem; line-height: 1.14; overflow-wrap: anywhere; }
+      .handoff-card-kicker { margin: 0; font-size: 0.76rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; color: #486174; }
+      .handoff-hero-meta { margin: 0; line-height: 1.55; color: #486174; }
+      .handoff-hero-badges { display: flex; flex-wrap: wrap; gap: 0.5rem 0.6rem; margin-top: 0; }
+      .handoff-layout { display: grid; grid-template-columns: minmax(17rem, 24rem) minmax(0, 1fr); gap: 1.15rem; margin-top: 1.15rem; align-items: start; }
+      .handoff-column { display: grid; gap: 1.15rem; align-content: start; }
+      .handoff-card { border: 1px solid #d7e3f4; border-radius: 0.85rem; background: #fff; box-shadow: 0 1px 2px rgba(35, 69, 102, 0.06); padding: 1.1rem 1.15rem; display: grid; gap: 0.75rem; align-content: start; }
+      .handoff-card h3 { margin: 0; font-size: 1.05rem; line-height: 1.3; color: #23384d; }
       .handoff-card-tight { height: 100%; }
       .handoff-card-emphasis { background: linear-gradient(180deg, #ffffff 0%, #f6faff 100%); }
-      .handoff-stat-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.65rem; }
-      .handoff-stat { border: 1px solid #dbe6f3; border-radius: 0.7rem; background: #fbfdff; padding: 0.65rem 0.75rem; }
-      .handoff-stat-label { display: block; font-size: 0.74rem; font-weight: 700; color: #567086; margin-bottom: 0.28rem; }
-      .handoff-stat-value { display: block; color: #20384f; font-weight: 700; }
-      .handoff-empty-state { border: 1px dashed #b8c9db; border-radius: 0.85rem; background: #fff; padding: 1.25rem; }
-      .handoff-empty-state h2 { margin: 0 0 0.5rem 0; }
-      .handoff-kv { display: grid; grid-template-columns: minmax(9rem, 12rem) minmax(0, 1fr); gap: 0.65rem 0.9rem; margin: 0; }
+      .handoff-stat-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.8rem; }
+      .handoff-stat { border: 1px solid #dbe6f3; border-radius: 0.7rem; background: #fbfdff; padding: 0.8rem 0.9rem; }
+      .handoff-stat-label { display: block; font-size: 0.76rem; font-weight: 700; line-height: 1.35; color: #567086; margin-bottom: 0.35rem; }
+      .handoff-stat-value { display: block; color: #20384f; font-weight: 700; line-height: 1.35; overflow-wrap: anywhere; }
+      .handoff-empty-state { border: 1px dashed #b8c9db; border-radius: 0.85rem; background: #fff; padding: 1.35rem; display: grid; gap: 0.6rem; }
+      .handoff-empty-state h2 { margin: 0; line-height: 1.2; }
+      .handoff-empty-state p { margin: 0; line-height: 1.6; }
+      .handoff-kv { display: grid; grid-template-columns: minmax(9rem, 12rem) minmax(0, 1fr); gap: 0.8rem 1rem; margin: 0; }
       .handoff-kv-compact { grid-template-columns: minmax(7rem, 9rem) minmax(0, 1fr); }
       .handoff-kv-row { display: contents; }
-      .handoff-kv dt { font-size: 0.78rem; font-weight: 700; color: #4c6478; }
-      .handoff-kv dd { margin: 0; min-width: 0; color: #23384d; }
-      .handoff-badge { display: inline-flex; align-items: center; justify-content: center; padding: 0.2rem 0.58rem; border-radius: 999px; border: 1px solid #b8c9db; background: #f6f9fc; color: #355061; font-size: 0.82rem; font-weight: 700; line-height: 1.2; }
+      .handoff-kv dt { font-size: 0.79rem; font-weight: 700; line-height: 1.4; color: #4c6478; }
+      .handoff-kv dd { margin: 0; min-width: 0; line-height: 1.55; color: #23384d; }
+      .handoff-badge { display: inline-flex; align-items: center; justify-content: center; padding: 0.28rem 0.7rem; border-radius: 999px; border: 1px solid #b8c9db; background: #f6f9fc; color: #355061; font-size: 0.84rem; font-weight: 700; line-height: 1.25; }
       .handoff-badge-success { border-color: #9dd4a2; background: #edf8ee; color: #25632a; }
       .handoff-badge-warning { border-color: #f2c37b; background: #fff4de; color: #915800; }
       .handoff-badge-danger { border-color: #efb0b0; background: #fff0f0; color: #9f2c2c; }
       .handoff-badge-info { border-color: #b5cdef; background: #edf4ff; color: #2456a6; }
       .handoff-badge-muted { border-color: #d5dde7; background: #f5f7fa; color: #5e7283; }
       .handoff-badge-neutral { border-color: #d5dde7; background: #f5f7fa; color: #5e7283; }
-      .handoff-next-action { font-size: 1rem; line-height: 1.55; color: #1f354b; padding: 0.85rem 0.95rem; border: 1px solid #dce8f5; border-radius: 0.8rem; background: linear-gradient(180deg, #fbfdff 0%, #f4f9ff 100%); }
+      .handoff-next-action { font-size: 1rem; line-height: 1.6; color: #1f354b; padding: 1rem 1.05rem; border: 1px solid #dce8f5; border-radius: 0.8rem; background: linear-gradient(180deg, #fbfdff 0%, #f4f9ff 100%); }
       .handoff-next-action p { margin: 0; }
-      .handoff-subsection + .handoff-subsection { margin-top: 0.95rem; }
-      .handoff-subgrid { display: grid; grid-template-columns: 1.6fr minmax(12rem, 0.9fr); gap: 1rem; align-items: start; }
-      .handoff-subsection h4 { margin: 0.95rem 0 0.45rem 0; font-size: 0.84rem; font-weight: 700; color: #486174; }
+      .handoff-subsection + .handoff-subsection { margin-top: 1.1rem; }
+      .handoff-subgrid { display: grid; grid-template-columns: 1.6fr minmax(12rem, 0.9fr); gap: 1.05rem; align-items: start; }
+      .handoff-subsection { display: grid; gap: 0.55rem; }
+      .handoff-subsection h4 { margin: 0; font-size: 0.85rem; font-weight: 700; line-height: 1.35; color: #486174; }
       .handoff-chip-list,
       .handoff-read-list,
       .handoff-criteria-list { margin: 0; padding: 0; list-style: none; }
-      .handoff-chip-list { display: flex; flex-wrap: wrap; gap: 0.42rem; }
-      .handoff-read-list { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.42rem; }
-      .handoff-read-list li { padding: 0.48rem 0.65rem; border: 1px solid #dbe6f3; border-radius: 0.65rem; background: #fbfdff; }
+      .handoff-chip-list { display: flex; flex-wrap: wrap; gap: 0.55rem 0.6rem; align-items: flex-start; }
+      .handoff-chip-list li,
+      .handoff-read-list li { min-width: 0; }
+      .handoff-chip-list code,
+      .handoff-read-list code,
+      .handoff-kv code,
+      .viewer-card code,
+      .current-pr-state-banner code { overflow-wrap: anywhere; }
+      .handoff-read-list { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.55rem; }
+      .handoff-read-list li { padding: 0.62rem 0.78rem; border: 1px solid #dbe6f3; border-radius: 0.65rem; background: #fbfdff; line-height: 1.5; }
       .handoff-read-list code { color: #20496f; }
-      .handoff-criteria-list { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.7rem; }
-      .handoff-criteria-item { border: 1px solid #dbe6f3; border-left: 0.32rem solid #6d90c6; border-radius: 0.75rem; padding: 0.75rem; background: #fbfdff; }
-      .handoff-criteria-header { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 0.45rem; }
-      .handoff-criteria-item p { margin: 0; color: #304a62; }
+      .handoff-criteria-list { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.8rem; }
+      .handoff-criteria-item { border: 1px solid #dbe6f3; border-left: 0.32rem solid #6d90c6; border-radius: 0.75rem; padding: 0.85rem; background: #fbfdff; }
+      .handoff-criteria-header { display: flex; align-items: center; gap: 0.55rem; flex-wrap: wrap; margin-bottom: 0.55rem; }
+      .handoff-criteria-item p { margin: 0; line-height: 1.55; color: #304a62; }
       .handoff-empty-copy,
       .handoff-empty-value { color: #708497; }
       .current-pr-state-banner section,
@@ -255,6 +279,7 @@ export function renderInspectRunViewerHtml({
         .viewer-stat-grid-3 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
       }
       @media (max-width: 900px) {
+        body { margin: 1rem; }
         .inspection-shell { grid-template-columns: minmax(0, 1fr); }
         .assigned-pr-inbox { position: static; max-height: none; }
         .handoff-hero,
@@ -270,6 +295,10 @@ export function renderInspectRunViewerHtml({
         .viewer-stat-grid-3 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
       }
       @media (max-width: 640px) {
+        body { margin: 0.75rem; }
+        section,
+        .handoff-envelope-section { padding: 0.9rem; }
+        .viewer-tab-shell { top: 0.5rem; }
         .state-graph-toolbar { flex-wrap: wrap; }
         .state-graph-zoom-value { margin-left: 0; }
         .assigned-pr-secondary-controls { flex-wrap: wrap; }

--- a/scripts/loop/inspect-run-viewer/rendering.mjs
+++ b/scripts/loop/inspect-run-viewer/rendering.mjs
@@ -340,10 +340,10 @@ export function renderInspectRunViewerHtml({
           : `${renderCurrentStateBanner(normalizedSnapshot, target, stateLabel, graph, effectiveSelectedTitle)}
             <div class="viewer-tab-shell" role="tablist" aria-label="Inspect run viewer tabs">
               <div class="viewer-tabs">
-                <button id="tab-btn-graph" class="viewer-tab active" role="tab" aria-selected="true" aria-controls="tab-graph" tabindex="0" data-tab="graph" onclick="switchTab('graph')">Graph</button>
-                <button id="tab-btn-overview" class="viewer-tab" role="tab" aria-selected="false" aria-controls="tab-overview" tabindex="-1" data-tab="overview" onclick="switchTab('overview')">Overview</button>
-                <button id="tab-btn-layers" class="viewer-tab" role="tab" aria-selected="false" aria-controls="tab-layers" tabindex="-1" data-tab="layers" onclick="switchTab('layers')">Layers</button>
-                <button id="tab-btn-handoff" class="viewer-tab" role="tab" aria-selected="false" aria-controls="tab-handoff" tabindex="-1" data-tab="handoff" onclick="switchTab('handoff')">Agent handoff</button>
+                <button id="tab-btn-graph" class="viewer-tab active" role="tab" aria-selected="true" aria-controls="tab-graph" data-tab="graph" onclick="switchTab('graph')">Graph</button>
+                <button id="tab-btn-overview" class="viewer-tab" role="tab" aria-selected="false" aria-controls="tab-overview" data-tab="overview" onclick="switchTab('overview')">Overview</button>
+                <button id="tab-btn-layers" class="viewer-tab" role="tab" aria-selected="false" aria-controls="tab-layers" data-tab="layers" onclick="switchTab('layers')">Layers</button>
+                <button id="tab-btn-handoff" class="viewer-tab" role="tab" aria-selected="false" aria-controls="tab-handoff" data-tab="handoff" onclick="switchTab('handoff')">Agent handoff</button>
               </div>
             </div>
             <div class="tab-content active" id="tab-graph" role="tabpanel" aria-labelledby="tab-btn-graph">
@@ -384,14 +384,12 @@ export function renderInspectRunViewerHtml({
         document.querySelectorAll('.viewer-tab').forEach(t => {
           t.classList.remove('active');
           t.setAttribute('aria-selected', 'false');
-          t.setAttribute('tabindex', '-1');
         });
         
         document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
         const activeTab = document.querySelector('.viewer-tab[data-tab="' + tabName + '"]');
         activeTab.classList.add('active');
         activeTab.setAttribute('aria-selected', 'true');
-        activeTab.setAttribute('tabindex', '0');
         document.getElementById('tab-' + tabName).classList.add('active');
       }
     </script>

--- a/scripts/loop/inspect-run-viewer/rendering.mjs
+++ b/scripts/loop/inspect-run-viewer/rendering.mjs
@@ -137,11 +137,11 @@ export function renderInspectRunViewerHtml({
       .current-pr-state-banner h1 { margin: 0; font-size: 2rem; line-height: 1.15; color: #18324a; }
       .current-pr-state-summary-headline { margin: 0.75rem 0 0.3rem 0; color: #1565c0; font-size: 1.06rem; }
       .current-pr-state-detail { margin: 0; color: #274766; font-size: 0.98rem; }
-      .current-pr-state-note { margin: 0.55rem 0 0 0; color: #4b6579; font-size: 0.92rem; }
+      .current-pr-state-meta { margin: 0.55rem 0 0 0; color: #5a758b; font-size: 0.82rem; }
       .current-pr-state-badge-row { margin-top: 0.75rem; }
       .viewer-badge-row { display: flex; flex-wrap: wrap; gap: 0.4rem; }
       .viewer-card-grid { display: grid; gap: 1rem; align-items: start; }
-      .viewer-card-grid-overview { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+      .viewer-card-grid-overview { grid-template-columns: repeat(2, minmax(0, 1fr)); }
       .viewer-card-grid-layers { grid-template-columns: repeat(2, minmax(0, 1fr)); }
       .viewer-tab-section { border: none; background: none; padding: 0; margin-top: 1rem; }
       .viewer-tab-shell { position: sticky; top: 0.65rem; z-index: 4; border: 1px solid #d7e3f4; border-radius: 0.85rem; background: rgba(251, 253, 255, 0.96); backdrop-filter: blur(6px); padding: 0.3rem; margin-top: 0.85rem; }
@@ -332,7 +332,7 @@ export function renderInspectRunViewerHtml({
               </section>
             </div>
             <div class="tab-content" id="tab-overview">
-              ${renderOverviewSection(normalizedSnapshot, target, stateLabel, rawSnapshotHref)}
+              ${renderOverviewSection(normalizedSnapshot, target, stateLabel)}
             </div>
             <div class="tab-content" id="tab-layers">
               <section class="viewer-tab-section" aria-label="Layers">

--- a/scripts/loop/inspect-run-viewer/rendering.mjs
+++ b/scripts/loop/inspect-run-viewer/rendering.mjs
@@ -183,7 +183,7 @@ export function renderInspectRunViewerHtml({
       .viewer-stat-grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
       .viewer-next-action { margin-bottom: 0; }
       .viewer-graph-header { margin-bottom: 0; }
-      .viewer-graph-header p { margin: 0; color: #486174; line-height: 1.6; max-width: 72ch; }
+      .viewer-graph-description { margin: 0.7rem 0 0 0; color: #6b8296; font-size: 0.82rem; line-height: 1.5; }
       .state-graph-block { margin-top: 0.25rem; }
       .state-graph-frame { margin-top: 0.75rem; min-width: 0; border: 1px solid #d7e3f4; border-radius: 0.85rem; background: linear-gradient(180deg, #fbfdff 0%, #f4f8fc 100%); overflow: hidden; }
       .state-graph-toolbar { display: flex; align-items: center; gap: 0.55rem; padding: 0.75rem 0.85rem; border-bottom: 1px solid #d7e3f4; background: rgba(255,255,255,0.85); }
@@ -361,12 +361,12 @@ export function renderInspectRunViewerHtml({
                 <article class="handoff-card handoff-card-emphasis viewer-card">
                   <p class="handoff-card-kicker">Graph</p>
                   <div class="viewer-graph-header">
-                    <h3>Full state machine</h3>
-                    <p>Authoritative Mermaid lane graph. Use zoom controls, drag, and graph guide to inspect current and next-state cues.</p>
+                    <h3>Full state machine graph</h3>
                   </div>
                   ${graph === null
                     ? `<p>${escapeHtml(error?.message ?? "Unable to load inspect-run snapshot.")}</p><p>Snapshot unavailable, so no state graph can be rendered yet. Use the Reload snapshot control to refresh.</p>`
                     : `<div class="viewer-graph-body">${renderStateVisualizationSection(normalizedSnapshot, graph)}</div>`}
+                  <p class="viewer-graph-description">Use zoom controls, drag, and the graph guide below to inspect current and next-state cues.</p>
                 </article>
               </section>
             </div>

--- a/scripts/loop/inspect-run-viewer/rendering.mjs
+++ b/scripts/loop/inspect-run-viewer/rendering.mjs
@@ -344,7 +344,7 @@ export function renderInspectRunViewerHtml({
                 <p>The dashboard can span all assigned repos or be narrowed to one repo. Sidebar defaults to open PRs from last 7 days and paginates through result set.</p>
               </div>
             </section>`
-          : `${renderCurrentStateBanner(normalizedSnapshot, target, stateLabel, graph, effectiveSelectedTitle)}
+          : `${renderCurrentStateBanner(normalizedSnapshot, target, stateLabel, effectiveSelectedTitle)}
             <div class="viewer-tab-shell" role="tablist" aria-label="Inspect run viewer tabs">
               <div class="viewer-tabs">
                 <button id="tab-btn-overview" class="viewer-tab active" role="tab" aria-selected="true" aria-controls="tab-overview" data-tab="overview" onclick="switchTab('overview')">Overview</button>
@@ -354,7 +354,7 @@ export function renderInspectRunViewerHtml({
               </div>
             </div>
             <div class="tab-content active" id="tab-overview" role="tabpanel" aria-labelledby="tab-btn-overview">
-              ${renderOverviewSection(normalizedSnapshot, target, stateLabel)}
+              ${renderOverviewSection(normalizedSnapshot, stateLabel)}
             </div>
             <div class="tab-content" id="tab-graph" role="tabpanel" aria-labelledby="tab-btn-graph">
               <section class="viewer-tab-section" aria-label="Graph">

--- a/scripts/loop/inspect-run-viewer/rendering.mjs
+++ b/scripts/loop/inspect-run-viewer/rendering.mjs
@@ -11,7 +11,7 @@ import {
   renderStateVisualizationSection,
   resetMermaidBrowserScriptCache,
 } from "./graph.mjs";
-import { buildSnapshotHref, renderInboxShellScript, renderInboxSidebar } from "./inbox.mjs";
+import { renderInboxShellScript, renderInboxSidebar } from "./inbox.mjs";
 import {
   deriveInboxSignalFromSnapshot,
   renderCopilotLayerSection,
@@ -65,7 +65,6 @@ export function renderInspectRunViewerHtml({
   const title = target
     ? `${target.repo}#${target.pr} inspection snapshot`
     : `${scopeLabel} PR inspection dashboard`;
-  const rawSnapshotHref = buildSnapshotHref(target, scopeFilter);
 
   return `<!doctype html>
 <html lang="en">
@@ -312,13 +311,13 @@ export function renderInspectRunViewerHtml({
           : `${renderCurrentStateBanner(normalizedSnapshot, target, stateLabel, graph, effectiveSelectedTitle)}
             <div class="viewer-tab-shell" role="tablist" aria-label="Inspect run viewer tabs">
               <div class="viewer-tabs">
-                <button id="tab-btn-graph" class="viewer-tab active" role="tab" aria-selected="true" aria-controls="tab-graph" data-tab="graph" onclick="switchTab('graph')">Graph</button>
-                <button id="tab-btn-overview" class="viewer-tab" role="tab" aria-selected="false" aria-controls="tab-overview" data-tab="overview" onclick="switchTab('overview')">Overview</button>
-                <button id="tab-btn-layers" class="viewer-tab" role="tab" aria-selected="false" aria-controls="tab-layers" data-tab="layers" onclick="switchTab('layers')">Layers</button>
-                <button id="tab-btn-handoff" class="viewer-tab" role="tab" aria-selected="false" aria-controls="tab-handoff" data-tab="handoff" onclick="switchTab('handoff')">Agent handoff</button>
+                <button id="tab-btn-graph" class="viewer-tab active" role="tab" aria-selected="true" aria-controls="tab-graph" tabindex="0" data-tab="graph" onclick="switchTab('graph')">Graph</button>
+                <button id="tab-btn-overview" class="viewer-tab" role="tab" aria-selected="false" aria-controls="tab-overview" tabindex="-1" data-tab="overview" onclick="switchTab('overview')">Overview</button>
+                <button id="tab-btn-layers" class="viewer-tab" role="tab" aria-selected="false" aria-controls="tab-layers" tabindex="-1" data-tab="layers" onclick="switchTab('layers')">Layers</button>
+                <button id="tab-btn-handoff" class="viewer-tab" role="tab" aria-selected="false" aria-controls="tab-handoff" tabindex="-1" data-tab="handoff" onclick="switchTab('handoff')">Agent handoff</button>
               </div>
             </div>
-            <div class="tab-content active" id="tab-graph">
+            <div class="tab-content active" id="tab-graph" role="tabpanel" aria-labelledby="tab-btn-graph">
               <section class="viewer-tab-section" aria-label="Graph">
                 <article class="handoff-card handoff-card-emphasis viewer-card">
                   <p class="handoff-card-kicker">Graph</p>
@@ -332,10 +331,10 @@ export function renderInspectRunViewerHtml({
                 </article>
               </section>
             </div>
-            <div class="tab-content" id="tab-overview">
+            <div class="tab-content" id="tab-overview" role="tabpanel" aria-labelledby="tab-btn-overview">
               ${renderOverviewSection(normalizedSnapshot, target, stateLabel)}
             </div>
-            <div class="tab-content" id="tab-layers">
+            <div class="tab-content" id="tab-layers" role="tabpanel" aria-labelledby="tab-btn-layers">
               <section class="viewer-tab-section" aria-label="Layers">
                 <div class="viewer-card-grid viewer-card-grid-layers">
                   ${renderOuterLoopSummarySection(normalizedSnapshot)}
@@ -345,7 +344,7 @@ export function renderInspectRunViewerHtml({
                 </div>
               </section>
             </div>
-            <div class="tab-content" id="tab-handoff">
+            <div class="tab-content" id="tab-handoff" role="tabpanel" aria-labelledby="tab-btn-handoff">
               ${renderHandoffEnvelopeSection(handoffEnvelope)}
             </div>`}
       </main>

--- a/scripts/loop/inspect-run-viewer/rendering.mjs
+++ b/scripts/loop/inspect-run-viewer/rendering.mjs
@@ -227,6 +227,7 @@ export function renderInspectRunViewerHtml({
       .handoff-badge-danger { border-color: #efb0b0; background: #fff0f0; color: #9f2c2c; }
       .handoff-badge-info { border-color: #b5cdef; background: #edf4ff; color: #2456a6; }
       .handoff-badge-muted { border-color: #d5dde7; background: #f5f7fa; color: #5e7283; }
+      .handoff-badge-neutral { border-color: #d5dde7; background: #f5f7fa; color: #5e7283; }
       .handoff-next-action { font-size: 1rem; line-height: 1.55; color: #1f354b; padding: 0.85rem 0.95rem; border: 1px solid #dce8f5; border-radius: 0.8rem; background: linear-gradient(180deg, #fbfdff 0%, #f4f9ff 100%); }
       .handoff-next-action p { margin: 0; }
       .handoff-subsection + .handoff-subsection { margin-top: 0.95rem; }
@@ -311,10 +312,10 @@ export function renderInspectRunViewerHtml({
           : `${renderCurrentStateBanner(normalizedSnapshot, target, stateLabel, graph, effectiveSelectedTitle)}
             <div class="viewer-tab-shell" role="tablist" aria-label="Inspect run viewer tabs">
               <div class="viewer-tabs">
-                <button class="viewer-tab active" data-tab="graph" onclick="switchTab('graph')">Graph</button>
-                <button class="viewer-tab" data-tab="overview" onclick="switchTab('overview')">Overview</button>
-                <button class="viewer-tab" data-tab="layers" onclick="switchTab('layers')">Layers</button>
-                <button class="viewer-tab" data-tab="handoff" onclick="switchTab('handoff')">Agent handoff</button>
+                <button id="tab-btn-graph" class="viewer-tab active" role="tab" aria-selected="true" aria-controls="tab-graph" data-tab="graph" onclick="switchTab('graph')">Graph</button>
+                <button id="tab-btn-overview" class="viewer-tab" role="tab" aria-selected="false" aria-controls="tab-overview" data-tab="overview" onclick="switchTab('overview')">Overview</button>
+                <button id="tab-btn-layers" class="viewer-tab" role="tab" aria-selected="false" aria-controls="tab-layers" data-tab="layers" onclick="switchTab('layers')">Layers</button>
+                <button id="tab-btn-handoff" class="viewer-tab" role="tab" aria-selected="false" aria-controls="tab-handoff" data-tab="handoff" onclick="switchTab('handoff')">Agent handoff</button>
               </div>
             </div>
             <div class="tab-content active" id="tab-graph">
@@ -326,7 +327,7 @@ export function renderInspectRunViewerHtml({
                     <p>Authoritative Mermaid lane graph. Use zoom controls, drag, and graph guide to inspect current and next-state cues.</p>
                   </div>
                   ${graph === null
-                    ? `<p>${escapeHtml(error?.message ?? "Unable to load inspect-run snapshot.")}</p><p>Snapshot unavailable, so no state graph can be rendered yet. Manual reload only.</p>`
+                    ? `<p>${escapeHtml(error?.message ?? "Unable to load inspect-run snapshot.")}</p><p>Snapshot unavailable, so no state graph can be rendered yet. Use the Reload snapshot control to refresh.</p>`
                     : `<div class="viewer-graph-body">${renderStateVisualizationSection(normalizedSnapshot, graph)}</div>`}
                 </article>
               </section>
@@ -352,9 +353,17 @@ export function renderInspectRunViewerHtml({
     ${renderInboxShellScript()}
     <script>
       function switchTab(tabName) {
-        document.querySelectorAll('.viewer-tab').forEach(t => t.classList.remove('active'));
+        document.querySelectorAll('.viewer-tab').forEach(t => {
+          t.classList.remove('active');
+          t.setAttribute('aria-selected', 'false');
+          t.setAttribute('tabindex', '-1');
+        });
+        
         document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
-        document.querySelector('.viewer-tab[data-tab="' + tabName + '"]').classList.add('active');
+        const activeTab = document.querySelector('.viewer-tab[data-tab="' + tabName + '"]');
+        activeTab.classList.add('active');
+        activeTab.setAttribute('aria-selected', 'true');
+        activeTab.setAttribute('tabindex', '0');
         document.getElementById('tab-' + tabName).classList.add('active');
       }
     </script>

--- a/scripts/loop/inspect-run-viewer/rendering.mjs
+++ b/scripts/loop/inspect-run-viewer/rendering.mjs
@@ -395,9 +395,11 @@ export function renderInspectRunViewerHtml({
         
         document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
         const activeTab = document.querySelector('.viewer-tab[data-tab="' + tabName + '"]');
+        if (!activeTab) { return; }
         activeTab.classList.add('active');
         activeTab.setAttribute('aria-selected', 'true');
-        document.getElementById('tab-' + tabName).classList.add('active');
+        const panel = document.getElementById('tab-' + tabName); if (panel) { panel.classList.add('active');
+        }
       }
     </script>
     ${graph === null ? "" : renderMermaidBootScript()}

--- a/scripts/loop/inspect-run-viewer/rendering.mjs
+++ b/scripts/loop/inspect-run-viewer/rendering.mjs
@@ -130,7 +130,7 @@ export function renderInspectRunViewerHtml({
       .assigned-pr-page-link.is-disabled { color: #9aa9b8; pointer-events: none; }
       .assigned-pr-page-status { font-weight: 700; color: #253b53; }
       .inspection-main { min-width: 0; }
-      .current-pr-state-banner { border: 1px solid #d7e3f4; border-radius: 1rem; background: linear-gradient(180deg, #ffffff 0%, #f6fbff 100%); box-shadow: 0 1px 2px rgba(35, 69, 102, 0.06); padding: 1.2rem 1.3rem; margin-top: 0; display: grid; gap: 0.9rem; }
+      .current-pr-state-banner { position: relative; border: 1px solid #d7e3f4; border-radius: 1rem; background: linear-gradient(180deg, #ffffff 0%, #f6fbff 100%); box-shadow: 0 1px 2px rgba(35, 69, 102, 0.06); padding: 1.2rem 1.3rem 4.65rem; margin-top: 0; display: grid; gap: 0.9rem; }
       .current-pr-state-heading-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.9rem; }
       .current-pr-state-heading-copy { min-width: 0; display: grid; gap: 0.35rem; }
       .current-pr-state-kicker { margin: 0; font-size: 0.82rem; font-weight: 800; letter-spacing: 0.06em; text-transform: uppercase; color: #486174; }
@@ -144,7 +144,11 @@ export function renderInspectRunViewerHtml({
       .current-pr-state-meta { margin: 0; color: #5a758b; font-size: 0.84rem; line-height: 1.5; }
       .current-pr-state-note { margin: 0; color: #5a758b; font-size: 0.92rem; line-height: 1.55; max-width: 78ch; }
       .current-pr-state-badge-row { margin-top: 0; }
+      .current-pr-state-controls { position: absolute; right: 1.3rem; bottom: 1.2rem; display: flex; flex-wrap: wrap; align-items: center; justify-content: flex-end; gap: 0.5rem 0.6rem; max-width: calc(100% - 2.6rem); }
+      .current-pr-state-auto-reload-label { display: inline-flex; align-items: center; gap: 0.32rem; margin: 0; font-size: 0.78rem; font-weight: 700; color: #486174; }
+      .current-pr-state-auto-reload-select { min-width: 7.4rem; border: 1px solid #bfd0e2; border-radius: 0.5rem; padding: 0.4rem 0.55rem; font: inherit; font-size: 0.83rem; line-height: 1.35; color: #355061; background: #fff; }
       .current-pr-state-reload { flex: 0 0 auto; }
+      .current-pr-state-reload[hidden] { display: none; }
       .viewer-badge-row { display: flex; flex-wrap: wrap; gap: 0.5rem 0.6rem; align-items: flex-start; }
       .viewer-card-grid { display: grid; gap: 1.15rem; align-items: start; }
       .viewer-card-grid-overview { grid-template-columns: repeat(2, minmax(0, 1fr)); }
@@ -305,6 +309,9 @@ export function renderInspectRunViewerHtml({
         .assigned-pr-select-mid,
         .assigned-pr-select-sm,
         .assigned-pr-select-updated { width: 100%; max-width: none; margin-left: 0; flex: 1 1 6rem; }
+        .current-pr-state-banner { padding-bottom: 0.9rem; }
+        .current-pr-state-controls { position: static; justify-content: flex-start; max-width: none; }
+        .current-pr-state-auto-reload-select { min-width: 0; flex: 1 1 8rem; }
         .handoff-kv,
         .handoff-kv-compact,
         .handoff-stat-grid,

--- a/scripts/loop/inspect-run-viewer/status.mjs
+++ b/scripts/loop/inspect-run-viewer/status.mjs
@@ -133,18 +133,9 @@ function buildCopilotLoopIterationEntries(snapshot) {
   ];
 }
 
-export function renderOverviewSection(snapshot, target, stateLabel, rawSnapshotHref = null) {
+export function renderOverviewSection(snapshot, target, stateLabel) {
   const summary = summarizeCurrentPrStatus(snapshot);
   const loopIterations = snapshot?.loopIterations;
-  const metadataBody = renderKeyValueRows([
-    ["target.repo", `<code>${escapeHtml(target?.repo ?? "not present")}</code>`],
-    ["target.pr", `<code>${escapeHtml(String(target?.pr ?? "not present"))}</code>`],
-    ["runId", `<code>${escapeHtml(snapshot?.runId ?? "not present")}</code>`],
-    ["inspectedAt", escapeHtml(snapshot?.inspectedAt ?? "not present")],
-  ]) + `<div class="viewer-card-actions">
-    <button type="button" class="viewer-action-button" onclick="window.location.reload()" title="Reload snapshot" aria-label="Reload snapshot">🔄 Reload snapshot</button>
-    ${rawSnapshotHref ? `<a class="viewer-inline-link" href="${escapeHtml(rawSnapshotHref)}">Open raw snapshot JSON</a>` : ""}
-  </div>`;
 
   const stateBody = `<div class="viewer-badge-row">
     ${renderCurrentStateBadge(stateLabel)}
@@ -154,15 +145,13 @@ export function renderOverviewSection(snapshot, target, stateLabel, rawSnapshotH
   ${renderStatGrid([
     { label: "status class", value: renderCodeValue(snapshot?.statusClass) },
     { label: "outer state", value: renderCodeValue(snapshot?.outerState) },
-    { label: "outerAction (compatibility)", value: renderCodeValue(snapshot?.outerAction) },
-    { label: "current Copilot state", value: renderCodeValue(snapshot?.layers?.copilot?.currentState) },
-    { label: "current reviewer state", value: renderCodeValue(snapshot?.layers?.reviewer?.currentState) },
+    { label: "outerAction", value: renderCodeValue(snapshot?.outerAction) },
+    { label: "Copilot state", value: renderCodeValue(snapshot?.layers?.copilot?.currentState) },
+    { label: "reviewer state", value: renderCodeValue(snapshot?.layers?.reviewer?.currentState) },
     { label: "reviewer verdict", value: escapeHtml(renderReviewerVerdict(snapshot)) },
     { label: "needs attention", value: renderBooleanBadge(snapshot?.needsAttention) },
     { label: "sourceMode", value: escapeHtml(formatStateToken(snapshot?.sourceMode)) },
-    { label: "trust", value: escapeHtml(snapshot?.trust ?? "not present") },
-    { label: "evidence.summary", value: escapeHtml(snapshot?.evidence?.summary ?? "not present") },
-  ], { columns: "viewer-stat-grid-3" })}`;
+  ], { columns: "viewer-stat-grid-2" })}`;
 
   const metricsBody = `<div class="handoff-next-action viewer-next-action">
     <p><strong>${escapeHtml(summary.headline)}.</strong> ${escapeHtml(summary.nextAction)}</p>
@@ -185,7 +174,6 @@ export function renderOverviewSection(snapshot, target, stateLabel, rawSnapshotH
 
   return `<section class="viewer-tab-section" aria-label="Overview">
     <div class="viewer-card-grid viewer-card-grid-overview">
-      ${renderCard({ kicker: "Overview", title: "Target metadata", body: metadataBody, className: "handoff-card-tight", dataField: "overview-metadata" })}
       ${renderCard({ kicker: "Overview", title: "Current state", body: stateBody, className: "handoff-card-tight handoff-card-emphasis", dataField: "overview-state" })}
       ${renderCard({ kicker: "Overview", title: "Next action and key metrics", body: metricsBody, className: "handoff-card-tight", dataField: "overview-metrics" })}
     </div>
@@ -496,30 +484,6 @@ export function summarizeCurrentPrStatus(snapshot) {
   };
 }
 
-function renderCurrentStateNote(snapshot) {
-  if (!snapshot) {
-    return "Unable to determine the current PR state yet.";
-  }
-
-  if (snapshot.sourceMode === "unavailable") {
-    return "Snapshot unavailable. Open /snapshot.json or reload once the inspection surface is available again.";
-  }
-
-  if ((snapshot.markers?.conflicts?.length ?? 0) > 0) {
-    return "Conflicting evidence is present. Treat the current-state fields below as advisory until the snapshot is reconciled.";
-  }
-
-  if (snapshot.sourceMode === "checkpoint-only") {
-    return "This is a checkpoint-only snapshot. The current-state fields below are advisory, not live-confirmed.";
-  }
-
-  if (snapshot.sourceMode === "partial" || snapshot.trust === "degraded") {
-    return "This snapshot is degraded. The current-state fields below may be incomplete and should be cross-checked against the graph and raw snapshot.";
-  }
-
-  return "These fields are shown directly from the loaded inspection snapshot so the current state stays visible without inventing a second viewer-only status model.";
-}
-
 function buildPullRequestHref(target) {
   if (!target?.repo || target?.pr === null || target?.pr === undefined) {
     return null;
@@ -582,6 +546,12 @@ export function renderCurrentStateBanner(snapshot, target, stateLabel, graph, se
     : `PR #${target?.pr ?? "unknown"}`;
   void graph;
 
+  const metaLine = [
+    snapshot?.runId ? `run ${escapeHtml(snapshot.runId)}` : null,
+    snapshot?.inspectedAt ? escapeHtml(snapshot.inspectedAt) : null,
+    snapshot?.sourceMode ? escapeHtml(`source: ${snapshot.sourceMode}`) : null,
+  ].filter(Boolean).join(" · ");
+
   return `<section class="current-pr-state-banner" aria-label="PR #${escapeHtml(target.pr)}">
     <div class="current-pr-state-heading-row">
       <div class="current-pr-state-heading-copy">
@@ -591,7 +561,9 @@ export function renderCurrentStateBanner(snapshot, target, stateLabel, graph, se
         <h1>${escapeHtml(heading)}</h1>
       </div>
       ${mode ? `<span class="current-pr-state-mode-indicator" title="${escapeHtml(mode.label)}" aria-label="${escapeHtml(mode.label)}">${escapeHtml(mode.emoji)}</span>` : ""}
+      <button type="button" class="viewer-action-button current-pr-state-reload" onclick="window.location.reload()" title="Reload snapshot" aria-label="Reload snapshot">🔄</button>
     </div>
+    ${metaLine ? `<p class="current-pr-state-meta">${metaLine}</p>` : ""}
     <div class="viewer-badge-row current-pr-state-badge-row">
       ${renderCurrentStateBadge(stateLabel)}
       ${renderInboxSignalBadge(snapshot)}
@@ -599,7 +571,6 @@ export function renderCurrentStateBanner(snapshot, target, stateLabel, graph, se
     </div>
     <p class="current-pr-state-summary-headline"><strong>${escapeHtml(summary.headline)}</strong></p>
     <p class="current-pr-state-detail">${escapeHtml(summary.detail)}</p>
-    <p class="current-pr-state-note">${escapeHtml(renderCurrentStateNote(snapshot))}</p>
   </section>`;
 }
 

--- a/scripts/loop/inspect-run-viewer/status.mjs
+++ b/scripts/loop/inspect-run-viewer/status.mjs
@@ -534,7 +534,7 @@ function summarizeCurrentPrMode(snapshot) {
   return null;
 }
 
-export function renderCurrentStateBanner(snapshot, target, stateLabel, graph, selectedTitle = null) {
+export function renderCurrentStateBanner(snapshot, target, stateLabel, _graph, selectedTitle = null) {
   const summary = summarizeCurrentPrStatus(snapshot);
   const pullRequestHref = buildPullRequestHref(target);
   const mode = summarizeCurrentPrMode(snapshot);
@@ -544,7 +544,6 @@ export function renderCurrentStateBanner(snapshot, target, stateLabel, graph, se
   const targetLabel = target?.repo && target?.pr !== null && target?.pr !== undefined
     ? `${target.repo}#${target.pr}`
     : `PR #${target?.pr ?? "unknown"}`;
-  void graph;
 
   const metaLine = [
     snapshot?.runId ? `run ${escapeHtml(snapshot.runId)}` : null,

--- a/scripts/loop/inspect-run-viewer/status.mjs
+++ b/scripts/loop/inspect-run-viewer/status.mjs
@@ -133,7 +133,7 @@ function buildCopilotLoopIterationEntries(snapshot) {
   ];
 }
 
-export function renderOverviewSection(snapshot, target, stateLabel) {
+export function renderOverviewSection(snapshot, _target, stateLabel) {
   const summary = summarizeCurrentPrStatus(snapshot);
   const loopIterations = snapshot?.loopIterations;
 

--- a/scripts/loop/inspect-run-viewer/status.mjs
+++ b/scripts/loop/inspect-run-viewer/status.mjs
@@ -534,6 +534,12 @@ export function renderCurrentStateBanner(snapshot, target, stateLabel, _graph, s
   const targetLabel = target?.repo && target?.pr !== null && target?.pr !== undefined
     ? `${target.repo}#${target.pr}`
     : `PR #${target?.pr ?? "unknown"}`;
+  const autoReloadOptions = [
+    { value: "off", label: "Off" },
+    { value: "60000", label: "1 minute" },
+    { value: "300000", label: "5 minutes" },
+    { value: "900000", label: "15 minutes" },
+  ];
 
   const metaLine = [
     snapshot?.runId ? `run ${escapeHtml(snapshot.runId)}` : null,
@@ -550,7 +556,6 @@ export function renderCurrentStateBanner(snapshot, target, stateLabel, _graph, s
         <h1>${escapeHtml(heading)}</h1>
       </div>
       ${mode ? `<span class="current-pr-state-mode-indicator" title="${escapeHtml(mode.label)}" aria-label="${escapeHtml(mode.label)}">${escapeHtml(mode.emoji)}</span>` : ""}
-      <button type="button" class="viewer-action-button current-pr-state-reload" onclick="window.location.reload()" title="Reload snapshot" aria-label="Reload snapshot">🔄</button>
     </div>
     <div class="current-pr-state-copy-flow">
       ${metaLine ? `<p class="current-pr-state-meta">${metaLine}</p>` : ""}
@@ -562,7 +567,77 @@ export function renderCurrentStateBanner(snapshot, target, stateLabel, _graph, s
       <p class="current-pr-state-summary-headline"><strong>${escapeHtml(summary.headline)}</strong></p>
       <p class="current-pr-state-detail">${escapeHtml(summary.detail)}</p>
     </div>
-  </section>`;
+    <div class="current-pr-state-controls" data-auto-reload-controls>
+      <label class="current-pr-state-auto-reload-label" for="current-pr-state-auto-reload">
+        <span aria-hidden="true">⏱</span>
+        <span>Auto-reload:</span>
+      </label>
+      <select id="current-pr-state-auto-reload" class="current-pr-state-auto-reload-select" data-auto-reload-select aria-label="Auto-reload period">
+        ${autoReloadOptions.map((option) => `<option value="${escapeHtml(option.value)}">${escapeHtml(option.label)}</option>`).join("")}
+      </select>
+      <button type="button" class="viewer-action-button current-pr-state-reload" data-auto-reload-manual onclick="window.location.reload()" title="Reload snapshot" aria-label="Reload snapshot">🔄 Reload</button>
+    </div>
+  </section>
+  <script>
+    (() => {
+      const AUTO_RELOAD_STORAGE_KEY = "inspect-run-viewer:auto-reload-ms";
+      const select = document.querySelector("[data-auto-reload-select]");
+      const manualButton = document.querySelector("[data-auto-reload-manual]");
+      if (!select || !manualButton) {
+        return;
+      }
+
+      let autoReloadTimer = null;
+      const clearAutoReloadTimer = () => {
+        if (autoReloadTimer !== null) {
+          window.clearInterval(autoReloadTimer);
+          autoReloadTimer = null;
+        }
+      };
+      const applyAutoReloadValue = (rawValue) => {
+        const nextValue = Array.from(select.options).some((option) => option.value === rawValue)
+          ? rawValue
+          : "off";
+        select.value = nextValue;
+        const autoReloadEnabled = nextValue !== "off";
+        manualButton.hidden = autoReloadEnabled;
+        clearAutoReloadTimer();
+        if (!autoReloadEnabled) {
+          return;
+        }
+        const intervalMs = Number.parseInt(nextValue, 10);
+        if (Number.isFinite(intervalMs) && intervalMs > 0) {
+          autoReloadTimer = window.setInterval(() => {
+            window.location.reload();
+          }, intervalMs);
+        }
+      };
+
+      let storedValue = "off";
+      try {
+        storedValue = window.localStorage.getItem(AUTO_RELOAD_STORAGE_KEY) ?? "off";
+      } catch {
+        storedValue = "off";
+      }
+      applyAutoReloadValue(storedValue);
+
+      select.addEventListener("change", () => {
+        const nextValue = select.value;
+        try {
+          if (nextValue === "off") {
+            window.localStorage.removeItem(AUTO_RELOAD_STORAGE_KEY);
+          } else {
+            window.localStorage.setItem(AUTO_RELOAD_STORAGE_KEY, nextValue);
+          }
+        } catch {
+          // Ignore localStorage write failures.
+        }
+        applyAutoReloadValue(nextValue);
+      });
+
+      window.addEventListener("beforeunload", clearAutoReloadTimer);
+    })();
+  </script>`;
 }
 
 export function deriveInboxSignalFromSnapshot(snapshot) {

--- a/scripts/loop/inspect-run-viewer/status.mjs
+++ b/scripts/loop/inspect-run-viewer/status.mjs
@@ -137,12 +137,7 @@ export function renderOverviewSection(snapshot, _target, stateLabel) {
   const summary = summarizeCurrentPrStatus(snapshot);
   const loopIterations = snapshot?.loopIterations;
 
-  const stateBody = `<div class="viewer-badge-row">
-    ${renderCurrentStateBadge(stateLabel)}
-    ${renderInboxSignalBadge(snapshot)}
-    ${renderBadge(formatStateToken(snapshot?.statusClass), "info")}
-  </div>
-  ${renderStatGrid([
+  const stateBody = `${renderStatGrid([
     { label: "status class", value: renderCodeValue(snapshot?.statusClass) },
     { label: "outer state", value: renderCodeValue(snapshot?.outerState) },
     { label: "outerAction", value: renderCodeValue(snapshot?.outerAction) },

--- a/scripts/loop/inspect-run-viewer/status.mjs
+++ b/scripts/loop/inspect-run-viewer/status.mjs
@@ -133,7 +133,7 @@ function buildCopilotLoopIterationEntries(snapshot) {
   ];
 }
 
-export function renderOverviewSection(snapshot, stateLabel) {
+export function renderOverviewSection(snapshot) {
   const summary = summarizeCurrentPrStatus(snapshot);
   const loopIterations = snapshot?.loopIterations;
 

--- a/scripts/loop/inspect-run-viewer/status.mjs
+++ b/scripts/loop/inspect-run-viewer/status.mjs
@@ -93,12 +93,12 @@ function renderInboxSignalBadge(snapshot) {
   return renderBadge(signal.replaceAll("_", " "), INBOX_SIGNAL_BADGE_VARIANTS[signal] ?? "muted");
 }
 
-function renderBooleanBadge(value) {
+function renderBooleanBadge(value, { positive = false } = {}) {
   if (value === true) {
-    return renderBadge("true", "danger");
+    return renderBadge("true", positive ? "success" : "danger");
   }
   if (value === false) {
-    return renderBadge("false", "success");
+    return renderBadge("false", positive ? "muted" : "success");
   }
   return renderBadge("not present", "muted");
 }
@@ -234,8 +234,8 @@ export function renderCopilotLayerSection(layer, snapshot = null) {
     body: `${renderStatGrid([
       { label: "currentState", value: renderCodeValue(layer.currentState) },
       { label: "loopDisposition", value: renderCodeValue(layer.loopDisposition) },
-      { label: "sameHeadCleanConverged", value: renderBooleanBadge(layer.sameHeadCleanConverged) },
-      { label: "terminal", value: renderBooleanBadge(layer.terminal) },
+      { label: "sameHeadCleanConverged", value: renderBooleanBadge(layer.sameHeadCleanConverged, { positive: true }) },
+      { label: "terminal", value: renderBooleanBadge(layer.terminal, { positive: true }) },
     ], { columns: "viewer-stat-grid-2" })}
     ${renderCardListBlock("allowedTransitions", layer.allowedTransitions)}
     <div class="viewer-card-subsection">
@@ -245,16 +245,6 @@ export function renderCopilotLayerSection(layer, snapshot = null) {
   });
 }
 
-export function renderCopilotLoopIterationsSection(snapshot) {
-  const entries = buildCopilotLoopIterationEntries(snapshot);
-  return renderCard({
-    kicker: "Layers",
-    title: "Copilot loop iterations",
-    className: "handoff-card-tight",
-    dataField: "copilot-loop-iterations",
-    body: entries ? renderKeyValueRows(entries, { compact: true }) : renderCardEmptyState(),
-  });
-}
 
 export function renderReviewerLayerSection(layer) {
   if (layer === null || layer === undefined) {
@@ -271,7 +261,7 @@ export function renderReviewerLayerSection(layer) {
       { label: "scope.mode", value: escapeHtml(layer.scope?.mode ?? "not present") },
       { label: "scope.reviewerLogin", value: escapeHtml(layer.scope?.reviewerLogin ?? "not present") },
       { label: "submittedReviewState", value: renderCodeValue(layer.submittedReviewState) },
-      { label: "approvedOnCurrentHead", value: renderBooleanBadge(layer.approvedOnCurrentHead) },
+      { label: "approvedOnCurrentHead", value: renderBooleanBadge(layer.approvedOnCurrentHead, { positive: true }) },
     ], { columns: "viewer-stat-grid-2" })}
     ${renderCardListBlock("allowedTransitions", layer.allowedTransitions)}`,
   });

--- a/scripts/loop/inspect-run-viewer/status.mjs
+++ b/scripts/loop/inspect-run-viewer/status.mjs
@@ -208,8 +208,8 @@ export function renderOuterLoopSummarySection(snapshot) {
   });
 }
 
-export function renderCopilotLayerSection(layer) {
-  const snapshot = arguments[1] ?? null;
+export function renderCopilotLayerSection(layer, snapshot = null) {
+  
   const loopIterationEntries = buildCopilotLoopIterationEntries(snapshot);
 
   if (layer === null || layer === undefined) {

--- a/scripts/loop/inspect-run-viewer/status.mjs
+++ b/scripts/loop/inspect-run-viewer/status.mjs
@@ -1,56 +1,112 @@
 import { OUTER_STATE } from "@pi-dev-loops/core/loop/conductor-routing";
 
-import { renderStateVisualizationSection } from "./graph.mjs";
 import {
   escapeHtml,
   formatStateToken,
   humanizeStateToken,
-  renderCompactSection,
   titleCaseWords,
 } from "./shared.mjs";
 
-export function renderOuterLoopSummarySection(snapshot) {
-  if (snapshot === null || snapshot === undefined) {
-    return renderCompactSection({ title: "outer-loop summary" });
-  }
+const SNAPSHOT_BADGE_VARIANTS = {
+  authoritative: "success",
+  conflicting: "danger",
+  degraded: "warning",
+  "checkpoint-only": "warning",
+  unavailable: "muted",
+};
 
-  return renderCompactSection({
-    title: "outer-loop summary",
-    entries: [
-      ["activeStateFamily", snapshot.activeStateFamily ?? "not present"],
-      ["outerState", snapshot.outerState ?? "not present"],
-      ["outerAction (compatibility)", snapshot.outerAction ?? "not present"],
-      ["activeFamilyState", snapshot.activeFamilyState ?? "not present"],
-      ["statusClass", snapshot.statusClass ?? "not present"],
-      ["needsAttention", String(snapshot.needsAttention ?? "not present")],
-      ["sourceMode", snapshot.sourceMode ?? "not present"],
-      ["trust", snapshot.trust ?? "not present"],
-      ["evidence.summary", snapshot.evidence?.summary ?? "not present"],
-    ],
-    lists: [
-      { title: "evidence.authoritative", items: snapshot.evidence?.authoritative },
-      { title: "evidence.checkpoint", items: snapshot.evidence?.checkpoint },
-    ],
-  });
+const INBOX_SIGNAL_BADGE_VARIANTS = {
+  attention: "danger",
+  pending: "warning",
+  gate: "info",
+  ready: "success",
+  closed: "muted",
+  unknown: "muted",
+  waiting: "info",
+};
+
+function renderBadge(label, variant = "muted") {
+  return `<span class="handoff-badge handoff-badge-${escapeHtml(variant)}">${escapeHtml(label)}</span>`;
 }
 
-export function renderCopilotLayerSection(layer) {
-  if (layer === null || layer === undefined) {
-    return renderCompactSection({ title: "copilot layer" });
-  }
-
-  return renderCompactSection({
-    title: "copilot layer",
-    entries: [["currentState", layer.currentState ?? "not present"]],
-    lists: [{ title: "allowedTransitions", items: layer.allowedTransitions }],
-  });
+function renderCodeValue(value, fallback = "not present") {
+  return `<code>${escapeHtml(formatStateToken(value, fallback))}</code>`;
 }
 
-export function renderCopilotLoopIterationsSection(snapshot) {
+function renderCard({ kicker, title, body, className = "", dataField = null }) {
+  return `<article class="handoff-card viewer-card${className ? ` ${escapeHtml(className)}` : ""}"${dataField ? ` data-field="${escapeHtml(dataField)}"` : ""}>
+    ${kicker ? `<p class="handoff-card-kicker">${escapeHtml(kicker)}</p>` : ""}
+    ${title ? `<h3>${escapeHtml(title)}</h3>` : ""}
+    ${body}
+  </article>`;
+}
+
+function renderCardEmptyState() {
+  return '<p class="handoff-empty-copy">not present / unavailable</p>';
+}
+
+function renderKeyValueRows(entries, { compact = false } = {}) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return renderCardEmptyState();
+  }
+
+  return `<dl class="handoff-kv${compact ? " handoff-kv-compact" : ""}">
+    ${entries.map(([label, value]) => `<div class="handoff-kv-row"><dt>${escapeHtml(label)}</dt><dd>${value}</dd></div>`).join("")}
+  </dl>`;
+}
+
+function renderStatGrid(stats, { columns = "" } = {}) {
+  const normalizedStats = Array.isArray(stats) ? stats.filter(Boolean) : [];
+  if (normalizedStats.length === 0) {
+    return renderCardEmptyState();
+  }
+
+  return `<div class="handoff-stat-grid viewer-stat-grid${columns ? ` ${escapeHtml(columns)}` : ""}">
+    ${normalizedStats.map(({ label, value }) => `<div class="handoff-stat"><span class="handoff-stat-label">${escapeHtml(label)}</span><span class="handoff-stat-value">${value}</span></div>`).join("")}
+  </div>`;
+}
+
+function renderCardList(items, { emptyText = "none" } = {}) {
+  if (!Array.isArray(items)) {
+    return `<p class="handoff-empty-copy">not present / unavailable</p>`;
+  }
+  if (items.length === 0) {
+    return `<p class="handoff-empty-copy">${escapeHtml(emptyText)}</p>`;
+  }
+
+  return `<ul class="viewer-card-list">${items.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>`;
+}
+
+function renderCardListBlock(title, items, options = {}) {
+  return `<div class="viewer-card-list-block">
+    <h4>${escapeHtml(title)}</h4>
+    ${renderCardList(items, options)}
+  </div>`;
+}
+
+function renderCurrentStateBadge(stateLabel) {
+  return renderBadge(stateLabel, SNAPSHOT_BADGE_VARIANTS[stateLabel] ?? "muted");
+}
+
+function renderInboxSignalBadge(snapshot) {
+  const signal = deriveInboxSignalFromSnapshot(snapshot);
+  return renderBadge(signal.replaceAll("_", " "), INBOX_SIGNAL_BADGE_VARIANTS[signal] ?? "muted");
+}
+
+function renderBooleanBadge(value) {
+  if (value === true) {
+    return renderBadge("true", "danger");
+  }
+  if (value === false) {
+    return renderBadge("false", "success");
+  }
+  return renderBadge("not present", "muted");
+}
+
+function buildCopilotLoopIterationEntries(snapshot) {
   const loopIterations = snapshot?.loopIterations;
-
   if (loopIterations === null || loopIterations === undefined) {
-    return renderCompactSection({ title: "Copilot loop iterations" });
+    return null;
   }
 
   const humanSummary = loopIterations.available
@@ -62,51 +118,191 @@ export function renderCopilotLoopIterationsSection(snapshot) {
     ].join("; ")
     : "not present / unavailable";
 
-  return renderCompactSection({
+  return [
+    ["available", escapeHtml(String(loopIterations.available))],
+    ["source", escapeHtml(loopIterations.source ?? "not present")],
+    ["reason", escapeHtml(loopIterations.reason ?? "not present")],
+    ["completedCopilotReviewRounds", escapeHtml(String(loopIterations.completedCopilotReviewRounds ?? "not present"))],
+    ["pendingCopilotReviewRounds", escapeHtml(String(loopIterations.pendingCopilotReviewRounds ?? "not present"))],
+    ["copilotReviewRequests", escapeHtml(String(loopIterations.copilotReviewRequests ?? "not present"))],
+    ["copilotReviewComments", escapeHtml(String(loopIterations.copilotReviewComments ?? "not present"))],
+    ["resolvedReviewThreads", escapeHtml(String(loopIterations.resolvedReviewThreads ?? "not present"))],
+    ["unresolvedReviewThreads", escapeHtml(String(loopIterations.unresolvedReviewThreads ?? "not present"))],
+    ["fixCommitsAfterFeedback", escapeHtml(String(loopIterations.fixCommitsAfterFeedback ?? "not present"))],
+    ["humanSummary", escapeHtml(humanSummary)],
+  ];
+}
+
+export function renderOverviewSection(snapshot, target, stateLabel, rawSnapshotHref = null) {
+  const summary = summarizeCurrentPrStatus(snapshot);
+  const loopIterations = snapshot?.loopIterations;
+  const metadataBody = renderKeyValueRows([
+    ["target.repo", `<code>${escapeHtml(target?.repo ?? "not present")}</code>`],
+    ["target.pr", `<code>${escapeHtml(String(target?.pr ?? "not present"))}</code>`],
+    ["runId", `<code>${escapeHtml(snapshot?.runId ?? "not present")}</code>`],
+    ["inspectedAt", escapeHtml(snapshot?.inspectedAt ?? "not present")],
+  ]) + `<div class="viewer-card-actions">
+    <button type="button" class="viewer-action-button" onclick="window.location.reload()" title="Reload snapshot" aria-label="Reload snapshot">🔄 Reload snapshot</button>
+    ${rawSnapshotHref ? `<a class="viewer-inline-link" href="${escapeHtml(rawSnapshotHref)}">Open raw snapshot JSON</a>` : ""}
+  </div>`;
+
+  const stateBody = `<div class="viewer-badge-row">
+    ${renderCurrentStateBadge(stateLabel)}
+    ${renderInboxSignalBadge(snapshot)}
+    ${renderBadge(formatStateToken(snapshot?.statusClass), "info")}
+  </div>
+  ${renderStatGrid([
+    { label: "status class", value: renderCodeValue(snapshot?.statusClass) },
+    { label: "outer state", value: renderCodeValue(snapshot?.outerState) },
+    { label: "outerAction (compatibility)", value: renderCodeValue(snapshot?.outerAction) },
+    { label: "current Copilot state", value: renderCodeValue(snapshot?.layers?.copilot?.currentState) },
+    { label: "current reviewer state", value: renderCodeValue(snapshot?.layers?.reviewer?.currentState) },
+    { label: "reviewer verdict", value: escapeHtml(renderReviewerVerdict(snapshot)) },
+    { label: "needs attention", value: renderBooleanBadge(snapshot?.needsAttention) },
+    { label: "sourceMode", value: escapeHtml(formatStateToken(snapshot?.sourceMode)) },
+    { label: "trust", value: escapeHtml(snapshot?.trust ?? "not present") },
+    { label: "evidence.summary", value: escapeHtml(snapshot?.evidence?.summary ?? "not present") },
+  ], { columns: "viewer-stat-grid-3" })}`;
+
+  const metricsBody = `<div class="handoff-next-action viewer-next-action">
+    <p><strong>${escapeHtml(summary.headline)}.</strong> ${escapeHtml(summary.nextAction)}</p>
+  </div>
+  ${loopIterations
+    ? renderStatGrid([
+      { label: "completed rounds", value: escapeHtml(String(loopIterations.completedCopilotReviewRounds ?? "not present")) },
+      { label: "pending rounds", value: escapeHtml(String(loopIterations.pendingCopilotReviewRounds ?? "not present")) },
+      { label: "Copilot comments", value: escapeHtml(String(loopIterations.copilotReviewComments ?? "not present")) },
+      { label: "unresolved threads", value: escapeHtml(String(loopIterations.unresolvedReviewThreads ?? "not present")) },
+      { label: "resolved threads", value: escapeHtml(String(loopIterations.resolvedReviewThreads ?? "not present")) },
+      { label: "fix commits", value: escapeHtml(String(loopIterations.fixCommitsAfterFeedback ?? "not present")) },
+    ], { columns: "viewer-stat-grid-3" })
+    : renderCardEmptyState()}
+  <div class="viewer-card-list-grid">
+    ${renderCardListBlock("markers.missing", snapshot?.markers?.missing)}
+    ${renderCardListBlock("markers.stale", snapshot?.markers?.stale)}
+    ${renderCardListBlock("markers.conflicts", snapshot?.markers?.conflicts)}
+  </div>`;
+
+  return `<section class="viewer-tab-section" aria-label="Overview">
+    <div class="viewer-card-grid viewer-card-grid-overview">
+      ${renderCard({ kicker: "Overview", title: "Target metadata", body: metadataBody, className: "handoff-card-tight", dataField: "overview-metadata" })}
+      ${renderCard({ kicker: "Overview", title: "Current state", body: stateBody, className: "handoff-card-tight handoff-card-emphasis", dataField: "overview-state" })}
+      ${renderCard({ kicker: "Overview", title: "Next action and key metrics", body: metricsBody, className: "handoff-card-tight", dataField: "overview-metrics" })}
+    </div>
+  </section>`;
+}
+
+export function renderOuterLoopSummarySection(snapshot) {
+  if (snapshot === null || snapshot === undefined) {
+    return renderCard({ kicker: "Layers", title: "Outer-loop", body: renderCardEmptyState(), className: "handoff-card-tight", dataField: "outer-loop-summary" });
+  }
+
+  return renderCard({
+    kicker: "Layers",
+    title: "Outer-loop",
+    className: "handoff-card-tight",
+    dataField: "outer-loop-summary",
+    body: `${renderStatGrid([
+      { label: "activeStateFamily", value: escapeHtml(snapshot.activeStateFamily ?? "not present") },
+      { label: "outerState", value: renderCodeValue(snapshot.outerState) },
+      { label: "outerAction (compatibility)", value: renderCodeValue(snapshot.outerAction) },
+      { label: "activeFamilyState", value: escapeHtml(snapshot.activeFamilyState ?? "not present") },
+      { label: "statusClass", value: escapeHtml(snapshot.statusClass ?? "not present") },
+      { label: "needsAttention", value: renderBooleanBadge(snapshot.needsAttention) },
+      { label: "sourceMode", value: escapeHtml(snapshot.sourceMode ?? "not present") },
+      { label: "trust", value: escapeHtml(snapshot.trust ?? "not present") },
+      { label: "evidence.summary", value: escapeHtml(snapshot.evidence?.summary ?? "not present") },
+    ], { columns: "viewer-stat-grid-3" })}
+    <div class="viewer-card-list-grid">
+      ${renderCardListBlock("evidence.authoritative", snapshot.evidence?.authoritative)}
+      ${renderCardListBlock("evidence.checkpoint", snapshot.evidence?.checkpoint)}
+    </div>`,
+  });
+}
+
+export function renderCopilotLayerSection(layer) {
+  const snapshot = arguments[1] ?? null;
+  const loopIterationEntries = buildCopilotLoopIterationEntries(snapshot);
+
+  if (layer === null || layer === undefined) {
+    return renderCard({
+      kicker: "Layers",
+      title: "Copilot",
+      className: "handoff-card-tight",
+      dataField: "copilot-layer",
+      body: `${renderCardEmptyState()}
+    <div class="viewer-card-subsection">
+      <h4>Copilot loop iterations</h4>
+      ${loopIterationEntries ? renderKeyValueRows(loopIterationEntries, { compact: true }) : renderCardEmptyState()}
+    </div>`,
+    });
+  }
+
+  return renderCard({
+    kicker: "Layers",
+    title: "Copilot",
+    className: "handoff-card-tight",
+    dataField: "copilot-layer",
+    body: `${renderStatGrid([
+      { label: "currentState", value: renderCodeValue(layer.currentState) },
+      { label: "loopDisposition", value: renderCodeValue(layer.loopDisposition) },
+      { label: "sameHeadCleanConverged", value: renderBooleanBadge(layer.sameHeadCleanConverged) },
+      { label: "terminal", value: renderBooleanBadge(layer.terminal) },
+    ], { columns: "viewer-stat-grid-2" })}
+    ${renderCardListBlock("allowedTransitions", layer.allowedTransitions)}
+    <div class="viewer-card-subsection">
+      <h4>Copilot loop iterations</h4>
+      ${loopIterationEntries ? renderKeyValueRows(loopIterationEntries, { compact: true }) : renderCardEmptyState()}
+    </div>`,
+  });
+}
+
+export function renderCopilotLoopIterationsSection(snapshot) {
+  const entries = buildCopilotLoopIterationEntries(snapshot);
+  return renderCard({
+    kicker: "Layers",
     title: "Copilot loop iterations",
-    entries: [
-      ["available", String(loopIterations.available)],
-      ["source", loopIterations.source ?? "not present"],
-      ["reason", loopIterations.reason ?? "not present"],
-      ["completedCopilotReviewRounds", loopIterations.completedCopilotReviewRounds ?? "not present"],
-      ["pendingCopilotReviewRounds", loopIterations.pendingCopilotReviewRounds ?? "not present"],
-      ["copilotReviewRequests", loopIterations.copilotReviewRequests ?? "not present"],
-      ["copilotReviewComments", loopIterations.copilotReviewComments ?? "not present"],
-      ["resolvedReviewThreads", loopIterations.resolvedReviewThreads ?? "not present"],
-      ["unresolvedReviewThreads", loopIterations.unresolvedReviewThreads ?? "not present"],
-      ["fixCommitsAfterFeedback", loopIterations.fixCommitsAfterFeedback ?? "not present"],
-      ["humanSummary", humanSummary],
-    ],
+    className: "handoff-card-tight",
+    dataField: "copilot-loop-iterations",
+    body: entries ? renderKeyValueRows(entries, { compact: true }) : renderCardEmptyState(),
   });
 }
 
 export function renderReviewerLayerSection(layer) {
   if (layer === null || layer === undefined) {
-    return renderCompactSection({ title: "reviewer layer" });
+    return renderCard({ kicker: "Layers", title: "Reviewer", body: renderCardEmptyState(), className: "handoff-card-tight", dataField: "reviewer-layer" });
   }
 
-  return renderCompactSection({
-    title: "reviewer layer",
-    entries: [
-      ["currentState", layer.currentState ?? "not present"],
-      ["scope.mode", layer.scope?.mode ?? "not present"],
-      ["scope.reviewerLogin", layer.scope?.reviewerLogin ?? "not present"],
-    ],
-    lists: [{ title: "allowedTransitions", items: layer.allowedTransitions }],
+  return renderCard({
+    kicker: "Layers",
+    title: "Reviewer",
+    className: "handoff-card-tight",
+    dataField: "reviewer-layer",
+    body: `${renderStatGrid([
+      { label: "currentState", value: renderCodeValue(layer.currentState) },
+      { label: "scope.mode", value: escapeHtml(layer.scope?.mode ?? "not present") },
+      { label: "scope.reviewerLogin", value: escapeHtml(layer.scope?.reviewerLogin ?? "not present") },
+      { label: "submittedReviewState", value: renderCodeValue(layer.submittedReviewState) },
+      { label: "approvedOnCurrentHead", value: renderBooleanBadge(layer.approvedOnCurrentHead) },
+    ], { columns: "viewer-stat-grid-2" })}
+    ${renderCardListBlock("allowedTransitions", layer.allowedTransitions)}`,
   });
 }
 
 export function renderSteeringSummarySection(layer) {
   if (layer === null || layer === undefined) {
-    return renderCompactSection({ title: "steering summary" });
+    return renderCard({ kicker: "Layers", title: "Steering", body: renderCardEmptyState(), className: "handoff-card-tight", dataField: "steering-summary" });
   }
 
-  return renderCompactSection({
-    title: "steering summary",
-    entries: [
-      ["status", layer.status ?? "not present"],
-      ["reason", layer.reason ?? "not present"],
-    ],
+  return renderCard({
+    kicker: "Layers",
+    title: "Steering",
+    className: "handoff-card-tight",
+    dataField: "steering-summary",
+    body: renderStatGrid([
+      { label: "status", value: escapeHtml(layer.status ?? "not present") },
+      { label: "reason", value: escapeHtml(layer.reason ?? "not present") },
+    ], { columns: "viewer-stat-grid-2" }),
   });
 }
 
@@ -381,35 +577,29 @@ export function renderCurrentStateBanner(snapshot, target, stateLabel, graph, se
   const heading = typeof selectedTitle === "string" && selectedTitle.trim().length > 0
     ? selectedTitle.trim()
     : `PR #${target.pr}`;
+  const targetLabel = target?.repo && target?.pr !== null && target?.pr !== undefined
+    ? `${target.repo}#${target.pr}`
+    : `PR #${target?.pr ?? "unknown"}`;
+  void graph;
+
   return `<section class="current-pr-state-banner" aria-label="PR #${escapeHtml(target.pr)}">
     <div class="current-pr-state-heading-row">
       <div class="current-pr-state-heading-copy">
         <p class="current-pr-state-kicker">${pullRequestHref
-          ? `<a href="${escapeHtml(pullRequestHref)}">PR #${escapeHtml(target.pr)}</a>`
-          : `PR #${escapeHtml(target.pr)}`}</p>
+          ? `<a href="${escapeHtml(pullRequestHref)}">${escapeHtml(targetLabel)}</a>`
+          : escapeHtml(targetLabel)}</p>
         <h1>${escapeHtml(heading)}</h1>
       </div>
       ${mode ? `<span class="current-pr-state-mode-indicator" title="${escapeHtml(mode.label)}" aria-label="${escapeHtml(mode.label)}">${escapeHtml(mode.emoji)}</span>` : ""}
     </div>
-    <p class="current-pr-state-summary-headline">${escapeHtml(summary.headline)}</p>
-    <p class="current-pr-state-detail">${escapeHtml(summary.detail)}</p>
-    <p class="current-pr-state-detail">${escapeHtml(renderCurrentStateNote(snapshot))}</p>
-    <dl class="current-pr-state-grid">
-      <dt>target</dt><dd><code>${escapeHtml(target.repo)}#${escapeHtml(target.pr)}</code></dd>
-      <dt>snapshot trust</dt><dd><span class="badge">${escapeHtml(stateLabel)}</span></dd>
-      <dt>status class</dt><dd><code>${escapeHtml(formatStateToken(snapshot?.statusClass))}</code></dd>
-      <dt>outer state</dt><dd><code>${escapeHtml(formatStateToken(snapshot?.outerState))}</code></dd>
-      <dt>outerAction (compatibility)</dt><dd><code>${escapeHtml(formatStateToken(snapshot?.outerAction))}</code></dd>
-      <dt>current Copilot state</dt><dd><code>${escapeHtml(formatStateToken(snapshot?.layers?.copilot?.currentState))}</code></dd>
-      <dt>current reviewer state</dt><dd><code>${escapeHtml(formatStateToken(snapshot?.layers?.reviewer?.currentState))}</code></dd>
-      <dt>reviewer verdict</dt><dd>${escapeHtml(renderReviewerVerdict(snapshot))}</dd>
-      <dt>needs attention</dt><dd>${escapeHtml(String(snapshot?.needsAttention ?? "not present"))}</dd>
-      <dt>next action</dt><dd>${escapeHtml(summary.nextAction)}</dd>
-      <dt>trust</dt><dd>${escapeHtml(snapshot?.evidence?.summary ?? "not present")}</dd>
-    </dl>
-    <div class="current-pr-state-visualization">
-      ${renderStateVisualizationSection(snapshot, graph)}
+    <div class="viewer-badge-row current-pr-state-badge-row">
+      ${renderCurrentStateBadge(stateLabel)}
+      ${renderInboxSignalBadge(snapshot)}
+      ${mode ? renderBadge(mode.label, "info") : ""}
     </div>
+    <p class="current-pr-state-summary-headline"><strong>${escapeHtml(summary.headline)}</strong></p>
+    <p class="current-pr-state-detail">${escapeHtml(summary.detail)}</p>
+    <p class="current-pr-state-note">${escapeHtml(renderCurrentStateNote(snapshot))}</p>
   </section>`;
 }
 

--- a/scripts/loop/inspect-run-viewer/status.mjs
+++ b/scripts/loop/inspect-run-viewer/status.mjs
@@ -133,7 +133,7 @@ function buildCopilotLoopIterationEntries(snapshot) {
   ];
 }
 
-export function renderOverviewSection(snapshot, _target, stateLabel) {
+export function renderOverviewSection(snapshot, stateLabel) {
   const summary = summarizeCurrentPrStatus(snapshot);
   const loopIterations = snapshot?.loopIterations;
 
@@ -519,7 +519,7 @@ function summarizeCurrentPrMode(snapshot) {
   return null;
 }
 
-export function renderCurrentStateBanner(snapshot, target, stateLabel, _graph, selectedTitle = null) {
+export function renderCurrentStateBanner(snapshot, target, stateLabel, selectedTitle = null) {
   const summary = summarizeCurrentPrStatus(snapshot);
   const pullRequestHref = buildPullRequestHref(target);
   const mode = summarizeCurrentPrMode(snapshot);

--- a/scripts/loop/inspect-run-viewer/status.mjs
+++ b/scripts/loop/inspect-run-viewer/status.mjs
@@ -37,7 +37,7 @@ function renderCard({ kicker, title, body, className = "", dataField = null }) {
   return `<article class="handoff-card viewer-card${className ? ` ${escapeHtml(className)}` : ""}"${dataField ? ` data-field="${escapeHtml(dataField)}"` : ""}>
     ${kicker ? `<p class="handoff-card-kicker">${escapeHtml(kicker)}</p>` : ""}
     ${title ? `<h3>${escapeHtml(title)}</h3>` : ""}
-    ${body}
+    <div class="viewer-card-body">${body}</div>
   </article>`;
 }
 
@@ -552,14 +552,16 @@ export function renderCurrentStateBanner(snapshot, target, stateLabel, _graph, s
       ${mode ? `<span class="current-pr-state-mode-indicator" title="${escapeHtml(mode.label)}" aria-label="${escapeHtml(mode.label)}">${escapeHtml(mode.emoji)}</span>` : ""}
       <button type="button" class="viewer-action-button current-pr-state-reload" onclick="window.location.reload()" title="Reload snapshot" aria-label="Reload snapshot">🔄</button>
     </div>
-    ${metaLine ? `<p class="current-pr-state-meta">${metaLine}</p>` : ""}
-    <div class="viewer-badge-row current-pr-state-badge-row">
-      ${renderCurrentStateBadge(stateLabel)}
-      ${renderInboxSignalBadge(snapshot)}
-      ${mode ? renderBadge(mode.label, "info") : ""}
+    <div class="current-pr-state-copy-flow">
+      ${metaLine ? `<p class="current-pr-state-meta">${metaLine}</p>` : ""}
+      <div class="viewer-badge-row current-pr-state-badge-row">
+        ${renderCurrentStateBadge(stateLabel)}
+        ${renderInboxSignalBadge(snapshot)}
+        ${mode ? renderBadge(mode.label, "info") : ""}
+      </div>
+      <p class="current-pr-state-summary-headline"><strong>${escapeHtml(summary.headline)}</strong></p>
+      <p class="current-pr-state-detail">${escapeHtml(summary.detail)}</p>
     </div>
-    <p class="current-pr-state-summary-headline"><strong>${escapeHtml(summary.headline)}</strong></p>
-    <p class="current-pr-state-detail">${escapeHtml(summary.detail)}</p>
   </section>`;
 }
 

--- a/test/loop/inspect-run-viewer-handoff-envelope-renderer.test.mjs
+++ b/test/loop/inspect-run-viewer-handoff-envelope-renderer.test.mjs
@@ -24,6 +24,7 @@ describe("renderHandoffEnvelopeSection", () => {
     const html = renderHandoffEnvelopeSection(envelope);
     assert.ok(html.includes("owner/name#42"), "should show repo#pr identity");
     assert.ok(html.includes("Agent handoff"), "should include section heading");
+    assert.ok(html.includes("handoff-card-body"), "should wrap card content for spacing control");
     assert.ok(!html.includes("Envelope unavailable"), "should not show unavailable");
   });
 

--- a/test/loop/inspect-run-viewer-rendering.test.mjs
+++ b/test/loop/inspect-run-viewer-rendering.test.mjs
@@ -819,7 +819,6 @@ test("renderInspectRunViewerHtml renders unavailable snapshot and malformed targ
   assert.match(html, /target\.pr must be a positive integer/);
   assert.match(html, /no state graph can be rendered yet/i);
   assert.match(html, /Use the Reload snapshot control to refresh/i);
-  assert.match(html, /href="\/snapshot\.json\?repo=bad(?:\+|%20)target&amp;pr=x"/);
 });
 
 

--- a/test/loop/inspect-run-viewer-rendering.test.mjs
+++ b/test/loop/inspect-run-viewer-rendering.test.mjs
@@ -880,7 +880,7 @@ test("renderInspectRunViewerHtml includes deterministic Mermaid asset fallback m
     snapshot: makeSnapshot(),
   });
 
-  assert.match(html, /Mermaid browser asset unavailable\. Use the details below or open \/snapshot\.json\./);
+  assert.match(html, /Graph renderer unavailable\. Use the details below or open \/snapshot\.json\./);
 });
 test("renderInspectRunViewerHtml fail-closes the graph for unavailable snapshots", () => {
   const html = renderInspectRunViewerHtml({

--- a/test/loop/inspect-run-viewer-rendering.test.mjs
+++ b/test/loop/inspect-run-viewer-rendering.test.mjs
@@ -165,7 +165,7 @@ test("renderInspectRunViewerHtml renders required top-level fields for authorita
   assert.match(html, /aria-label="Next page"/);
   assert.doesNotMatch(html, /assigned-pr-title-indicator/);
   assert.match(html, /pr=77/);
-  assert.match(html, /<a href="https:\/\/github\.com\/owner\/repo\/pull\/55">PR #55<\/a>/);
+  assert.match(html, /<a href="https:\/\/github\.com\/owner\/repo\/pull\/55">owner\/repo#55<\/a>/);
   assert.match(html, /<h1>Selected PR<\/h1>/);
   assert.match(html, /aria-label="PR #55"/);
   assert.match(html, /title="Waiting state"/);
@@ -179,9 +179,16 @@ test("renderInspectRunViewerHtml renders required top-level fields for authorita
   assert.match(html, /current Copilot state/);
   assert.match(html, /current reviewer state/);
   assert.match(html, /reviewer verdict/);
-  assert.match(html, /next action/);
+  assert.match(html, /Next action and key metrics/);
   assert.match(html, /Graph guide and lane details/);
-  assert.match(html, /Details/);
+  assert.match(html, /data-tab="graph"/);
+  assert.match(html, /data-tab="overview"/);
+  assert.match(html, /data-tab="layers"/);
+  assert.match(html, /data-tab="handoff"/);
+  assert.match(html, /Graph<\/button>/);
+  assert.match(html, /Overview<\/button>/);
+  assert.match(html, /Layers<\/button>/);
+  assert.doesNotMatch(html, /Live view/);
   assert.match(html, /target\.repo/);
   assert.match(html, /owner\/repo/);
   assert.match(html, /target\.pr/);
@@ -223,15 +230,15 @@ test("renderInspectRunViewerHtml renders required top-level fields for authorita
   assert.match(html, /Dimmed nodes are still part of the authoritative state machine/);
   assert.ok(html.indexOf('class="mermaid-state-graph mermaid"') < html.indexOf('class="state-graph-cues"'));
   assert.match(html, /outer lane comes from the shared authoritative outer-loop graph contract/);
-  assert.match(html, /outer-loop summary/);
+  assert.match(html, /Outer-loop/);
   assert.match(html, /Copilot loop iterations/);
   assert.match(html, /4 completed, 1 pending/);
   assert.match(html, /fix commits: 3/);
-  assert.match(html, /copilot layer/);
-  assert.match(html, /reviewer layer/);
-  assert.match(html, /steering summary/);
+  assert.match(html, /Copilot/);
+  assert.match(html, /Reviewer/);
+  assert.match(html, /Steering/);
   assert.match(html, /href="\/snapshot\.json\?repo=owner%2Frepo&amp;pr=55"/);
-  assert.match(html, /manual reload only/i);
+  assert.match(html, /Reload snapshot/);
   assert.doesNotMatch(html, /Connected state map/);
   assert.doesNotMatch(html, /"schemaVersion": 1/);
   assert.doesNotMatch(html, /"ok": true/);
@@ -353,9 +360,9 @@ test("renderInspectRunViewerHtml does not headline waiting_for_ci when reviewer 
     ],
   });
 
-  assert.match(html, /<p class="current-pr-state-summary-headline">Reviewer loop active<\/p>/);
+  assert.match(html, /<p class="current-pr-state-summary-headline"><strong>Reviewer loop active<\/strong><\/p>/);
   assert.match(html, /<span class="assigned-pr-headline">Reviewer loop active<\/span>/);
-  assert.doesNotMatch(html, /<p class="current-pr-state-summary-headline">Waiting for CI<\/p>/);
+  assert.doesNotMatch(html, /<p class="current-pr-state-summary-headline"><strong>Waiting for CI<\/strong><\/p>/);
   assert.doesNotMatch(html, /<span class="assigned-pr-headline">Waiting for CI<\/span>/);
 });
 
@@ -558,7 +565,7 @@ test("renderInspectRunViewerHtml highlights terminal merged states", () => {
     }),
   });
 
-  assert.match(html, /<a href="https:\/\/github\.com\/owner\/repo\/pull\/55">PR #55<\/a>/);
+  assert.match(html, /<a href="https:\/\/github\.com\/owner\/repo\/pull\/55">owner\/repo#55<\/a>/);
   assert.match(html, /PR complete/);
   assert.match(html, /The current inspection says this PR is in a terminal done state/);
   assert.match(html, /status class[\s\S]*<code>done<\/code>/);
@@ -806,7 +813,7 @@ test("renderInspectRunViewerHtml renders conflicting snapshot cues", () => {
     }),
   });
 
-  assert.match(html, /Snapshot state:[\s\S]*conflicting/);
+  assert.match(html, /handoff-badge-danger">conflicting<\/span>/);
   assert.doesNotMatch(html, /Conflicting graph view[\s\S]*resolve the evidence conflict before trusting the highlights\./i);
   assert.match(html, /Conflicting evidence is present\. Treat the current-state fields below as advisory until the snapshot is reconciled\./i);
   assert.match(html, /checkpoint outerAction/);

--- a/test/loop/inspect-run-viewer-rendering.test.mjs
+++ b/test/loop/inspect-run-viewer-rendering.test.mjs
@@ -818,7 +818,8 @@ test("renderInspectRunViewerHtml renders unavailable snapshot and malformed targ
   assert.match(html, /Snapshot unavailable/);
   assert.match(html, /target\.pr must be a positive integer/);
   assert.match(html, /no state graph can be rendered yet/i);
-  assert.match(html, /manual reload only/i);
+  assert.match(html, /Use the Reload snapshot control to refresh/i);
+  assert.match(html, /href="\/snapshot\.json\?repo=bad(?:\+|%20)target&amp;pr=x"/);
 });
 
 

--- a/test/loop/inspect-run-viewer-rendering.test.mjs
+++ b/test/loop/inspect-run-viewer-rendering.test.mjs
@@ -106,6 +106,27 @@ test("renderInspectRunViewerHtml hides pagination controls in the collapsed side
   assert.match(html, /\.assigned-pr-inbox\[data-sidebar-collapsed="true"\] \.assigned-pr-pagination \{ display: none; \}/);
 });
 
+test("renderInspectRunViewerHtml keeps overview first and tab buttons aligned with tab panels", () => {
+  const html = renderInspectRunViewerHtml({
+    repo: "owner/repo",
+    target: { repo: "owner/repo", pr: 55 },
+    snapshot: makeSnapshot(),
+    inboxItems: [
+      {
+        target: { repo: "owner/repo", pr: 55 },
+        title: "Selected PR",
+        snapshot: makeSnapshot(),
+      },
+    ],
+  });
+
+  assert.match(html, /<button id="tab-btn-overview" class="viewer-tab active"[^>]*aria-controls="tab-overview"[^>]*>Overview<\/button>\s*<button id="tab-btn-graph" class="viewer-tab"[^>]*aria-controls="tab-graph"[^>]*>Graph<\/button>\s*<button id="tab-btn-layers" class="viewer-tab"[^>]*aria-controls="tab-layers"[^>]*>Layers<\/button>\s*<button id="tab-btn-handoff" class="viewer-tab"[^>]*aria-controls="tab-handoff"[^>]*>Agent handoff<\/button>/);
+  assert.match(html, /<div class="tab-content active" id="tab-overview" role="tabpanel" aria-labelledby="tab-btn-overview">/);
+  assert.match(html, /<div class="tab-content" id="tab-graph" role="tabpanel" aria-labelledby="tab-btn-graph">/);
+  assert.match(html, /document\.dispatchEvent\(new CustomEvent\('inspect-run-viewer:tabchange', \{ detail: \{ tabName \} \}\)\);/);
+  assert.match(html, /document\.addEventListener\("inspect-run-viewer:tabchange", \(\) => \{/);
+});
+
 test("renderInspectRunViewerHtml renders required top-level fields for authoritative snapshot and links to raw JSON", () => {
   const html = renderInspectRunViewerHtml({
     repo: "owner/repo",

--- a/test/loop/inspect-run-viewer-rendering.test.mjs
+++ b/test/loop/inspect-run-viewer-rendering.test.mjs
@@ -168,6 +168,8 @@ test("renderInspectRunViewerHtml renders required top-level fields for authorita
   assert.match(html, /<a href="https:\/\/github\.com\/owner\/repo\/pull\/55">owner\/repo#55<\/a>/);
   assert.match(html, /<h1>Selected PR<\/h1>/);
   assert.match(html, /aria-label="PR #55"/);
+  assert.match(html, /<div class="current-pr-state-copy-flow">/);
+  assert.match(html, /class="viewer-card-body"/);
   assert.match(html, /title="Waiting state"/);
   assert.match(html, /⏳/);
   assert.match(html, /Waiting for Copilot review/);
@@ -211,6 +213,9 @@ test("renderInspectRunViewerHtml renders required top-level fields for authorita
   assert.match(html, /const \[firstRect, \.\.\.remainingRects\] = targetRects;/);
   assert.match(html, /cursor: grab/);
   assert.match(html, /data-dragging="true"/);
+  assert.match(html, /\.viewer-card-body,/);
+  assert.match(html, /\.current-pr-state-copy-flow \{ display: grid; gap: 0\.7rem; min-width: 0; \}/);
+  assert.match(html, /pre \{ margin: 0; padding: 0\.95rem 1rem;/);
   assert.match(html, /assets\/mermaid\.min\.js/);
   assert.match(html, /Start/);
   assert.match(html, /End/);

--- a/test/loop/inspect-run-viewer-rendering.test.mjs
+++ b/test/loop/inspect-run-viewer-rendering.test.mjs
@@ -172,12 +172,11 @@ test("renderInspectRunViewerHtml renders required top-level fields for authorita
   assert.match(html, /⏳/);
   assert.match(html, /Waiting for Copilot review/);
   assert.match(html, /Copilot review has been requested and the PR is waiting for new review activity/);
-  assert.match(html, /These fields are shown directly from the loaded inspection snapshot/i);
   assert.match(html, /status class/);
   assert.match(html, /outer state/);
-  assert.match(html, /outerAction \(compatibility\)/);
-  assert.match(html, /current Copilot state/);
-  assert.match(html, /current reviewer state/);
+  assert.match(html, /outerAction/);
+  assert.match(html, /Copilot state/);
+  assert.match(html, /reviewer state/);
   assert.match(html, /reviewer verdict/);
   assert.match(html, /Next action and key metrics/);
   assert.match(html, /Graph guide and lane details/);
@@ -189,21 +188,14 @@ test("renderInspectRunViewerHtml renders required top-level fields for authorita
   assert.match(html, /Overview<\/button>/);
   assert.match(html, /Layers<\/button>/);
   assert.doesNotMatch(html, /Live view/);
-  assert.match(html, /target\.repo/);
-  assert.match(html, /owner\/repo/);
-  assert.match(html, /target\.pr/);
-  assert.match(html, /55/);
-  assert.match(html, /runId/);
+  assert.match(html, /owner\/repo#55/);
   assert.match(html, /pr-55/);
-  assert.match(html, /inspectedAt/);
   assert.match(html, /activeStateFamily/);
   assert.match(html, /outerAction/);
   assert.match(html, /activeFamilyState/);
   assert.match(html, /statusClass/);
   assert.match(html, /needsAttention/);
   assert.match(html, /sourceMode/);
-  assert.match(html, /trust/);
-  assert.match(html, /evidence\.summary/);
   assert.match(html, /markers\.missing/);
   assert.match(html, /markers\.stale/);
   assert.match(html, /markers\.conflicts/);
@@ -237,8 +229,6 @@ test("renderInspectRunViewerHtml renders required top-level fields for authorita
   assert.match(html, /Copilot/);
   assert.match(html, /Reviewer/);
   assert.match(html, /Steering/);
-  assert.match(html, /href="\/snapshot\.json\?repo=owner%2Frepo&amp;pr=55"/);
-  assert.match(html, /Reload snapshot/);
   assert.doesNotMatch(html, /Connected state map/);
   assert.doesNotMatch(html, /"schemaVersion": 1/);
   assert.doesNotMatch(html, /"ok": true/);
@@ -507,7 +497,6 @@ test("renderInspectRunViewerHtml renders checkpoint-only \/ degraded cues and ab
   assert.doesNotMatch(html, /checkpoint-only graph view[\s\S]*current and next highlights are advisory until live inspection is available\./i);
   assert.match(html, /Needs attention/);
   assert.match(html, /The current snapshot is not authoritative enough to collapse to one trusted outer state/);
-  assert.match(html, /This is a checkpoint-only snapshot\. The current-state fields below are advisory, not live-confirmed\./i);
   assert.match(html, /class="mermaid-state-graph mermaid"/);
   assert.match(html, /current state unavailable/);
   assert.match(html, /not present \/ unavailable/);
@@ -815,7 +804,6 @@ test("renderInspectRunViewerHtml renders conflicting snapshot cues", () => {
 
   assert.match(html, /handoff-badge-danger">conflicting<\/span>/);
   assert.doesNotMatch(html, /Conflicting graph view[\s\S]*resolve the evidence conflict before trusting the highlights\./i);
-  assert.match(html, /Conflicting evidence is present\. Treat the current-state fields below as advisory until the snapshot is reconciled\./i);
   assert.match(html, /checkpoint outerAction/);
 });
 
@@ -831,7 +819,6 @@ test("renderInspectRunViewerHtml renders unavailable snapshot and malformed targ
   assert.match(html, /target\.pr must be a positive integer/);
   assert.match(html, /no state graph can be rendered yet/i);
   assert.match(html, /manual reload only/i);
-  assert.match(html, /href="\/snapshot\.json\?repo=bad(?:\+|%20)target&amp;pr=x"/);
 });
 
 

--- a/test/loop/inspect-run-viewer-server.test.mjs
+++ b/test/loop/inspect-run-viewer-server.test.mjs
@@ -28,10 +28,10 @@ test("createInspectRunViewerServer serves browser html from adapter snapshot wit
     assert.equal(response.statusCode, 200);
     assert.equal(response.headers["content-type"], "text/html; charset=utf-8");
     assert.equal(response.headers["cache-control"], "no-store");
-    assert.match(response.body, /<a href="https:\/\/github\.com\/owner\/repo\/pull\/55">PR #55<\/a>/);
+    assert.match(response.body, /<a href="https:\/\/github\.com\/owner\/repo\/pull\/55">owner\/repo#55<\/a>/);
     assert.match(response.body, /owner\/repo/);
     assert.match(response.body, /degraded/);
-    assert.match(response.body, /manual reload only/i);
+    assert.doesNotMatch(response.body, /manual reload only/i);
     assert.match(response.body, /href="\/snapshot\.json\?repo=owner%2Frepo&amp;pr=55"/);
     assert.doesNotMatch(response.body, /"schemaVersion": 1/);
     assert.equal(loadCount, 1);

--- a/test/loop/inspect-run-viewer-server.test.mjs
+++ b/test/loop/inspect-run-viewer-server.test.mjs
@@ -32,7 +32,7 @@ test("createInspectRunViewerServer serves browser html from adapter snapshot wit
     assert.match(response.body, /owner\/repo/);
     assert.match(response.body, /degraded/);
     assert.doesNotMatch(response.body, /manual reload only/i);
-    assert.match(response.body, /href="\/snapshot\.json\?repo=owner%2Frepo&amp;pr=55"/);
+    assert.doesNotMatch(response.body, /href="\/snapshot\.json\?repo=owner%2Frepo&amp;pr=55"/);
     assert.doesNotMatch(response.body, /"schemaVersion": 1/);
     assert.equal(loadCount, 1);
   } finally {
@@ -144,7 +144,7 @@ test("createInspectRunViewerServer supports selecting another PR from query para
     assert.match(response.body, /aria-label="PR #77"/);
     assert.match(response.body, /<h1>Selected from inbox<\/h1>/);
     assert.match(response.body, /Selected from inbox/);
-    assert.match(response.body, /href="\/snapshot\.json\?repo=owner%2Frepo&amp;pr=77"/);
+    assert.doesNotMatch(response.body, /href="\/snapshot\.json\?repo=owner%2Frepo&amp;pr=77"/);
     assert.ok(seenTargets.some((target) => target.repo === "owner/repo" && target.pr === 77));
   } finally {
     await new Promise((resolve) => server.close(resolve));
@@ -373,7 +373,7 @@ test("createInspectRunViewerServer keeps explicit query targets even when they a
     assert.equal(htmlResponse.statusCode, 200);
     assert.match(htmlResponse.body, /aria-label="PR #77"/);
     assert.match(htmlResponse.body, /<h1>PR #77<\/h1>/);
-    assert.match(htmlResponse.body, /href="\/snapshot\.json\?repo=owner%2Frepo&amp;pr=77"/);
+    assert.doesNotMatch(htmlResponse.body, /href="\/snapshot\.json\?repo=owner%2Frepo&amp;pr=77"/);
     assert.doesNotMatch(htmlResponse.body, /aria-current="page"/);
     assert.doesNotMatch(htmlResponse.body, /#77<\/span>/);
 
@@ -786,7 +786,7 @@ test("createInspectRunViewerServer guards malformed request URLs and undefined s
 
     assert.equal(response.statusCode, 200);
     assert.match(response.body, /Snapshot unavailable/);
-    assert.match(response.body, /href="\/snapshot\.json\?repo=owner%2Frepo&amp;pr=55"/);
+    assert.doesNotMatch(response.body, /href="\/snapshot\.json\?repo=owner%2Frepo&amp;pr=55"/);
     assert.equal(loadCount, 1);
 
     const malformedResponse = await new Promise((resolve) => {

--- a/test/playwright/inspect-run-viewer.spec.mjs
+++ b/test/playwright/inspect-run-viewer.spec.mjs
@@ -48,14 +48,20 @@ async function startViewer(snapshot = makeInspectionSnapshot(), assignedPullRequ
   ));
 }
 
+async function openTab(page, tabName) {
+  await page.locator(`.viewer-tab[data-tab="${tabName}"]`).click();
+}
+
 async function waitForMermaidGraph(page) {
-  const graph = page.locator(".mermaid-state-graph");
+  const graphPanel = page.locator("#tab-graph");
+  await expect(graphPanel).toHaveClass(/active/);
+  const graph = graphPanel.locator(".mermaid-state-graph");
   await expect(graph).toHaveAttribute("data-rendered", "true");
   await expect(graph.locator("svg")).toBeVisible();
   return graph;
 }
 
-test("webkit renders the Mermaid-first inspect-run viewer and captures a screenshot", async ({ page }, testInfo) => {
+test("webkit renders overview-first tabs, matches tab panels, and captures a screenshot", async ({ page }, testInfo) => {
   const { server, url } = await startViewer(makeInspectionSnapshot(), [
     { target: { repo: "other/repo", pr: 77 }, title: "Waiting PR", signal: "attention" },
     ...Array.from({ length: 26 }, (_, index) => ({
@@ -75,11 +81,33 @@ test("webkit renders the Mermaid-first inspect-run viewer and captures a screens
     await expect(currentStateBanner.getByTitle("Waiting state")).toBeVisible();
     await expect(currentStateBanner.getByText("Waiting for Copilot review")).toBeVisible();
     await expect(page.locator(".state-graph-intro")).toHaveCount(0);
-    await expect(page.locator(".state-graph-cues")).toContainText(/Start/);
-    await expect(page.locator(".state-graph-cues")).toContainText(/Current/);
-    await expect(page.locator(".state-graph-cues")).toContainText(/Next/);
-    await expect(page.locator(".state-graph-cues")).toContainText(/End/);
-    await expect(page.locator(".state-graph-cues")).toContainText(/🔁/);
+    const tabs = await page.locator('.viewer-tab').evaluateAll((nodes) => nodes.map((node) => ({
+      text: node.textContent?.trim() ?? '',
+      id: node.id,
+      controls: node.getAttribute('aria-controls'),
+      active: node.classList.contains('active'),
+    })));
+    expect(tabs).toEqual([
+      { text: 'Overview', id: 'tab-btn-overview', controls: 'tab-overview', active: true },
+      { text: 'Graph', id: 'tab-btn-graph', controls: 'tab-graph', active: false },
+      { text: 'Layers', id: 'tab-btn-layers', controls: 'tab-layers', active: false },
+      { text: 'Agent handoff', id: 'tab-btn-handoff', controls: 'tab-handoff', active: false },
+    ]);
+    const panels = await page.locator('.tab-content').evaluateAll((nodes) => nodes.map((node) => ({
+      id: node.id,
+      labelledBy: node.getAttribute('aria-labelledby'),
+    })));
+    expect(panels).toEqual([
+      { id: 'tab-overview', labelledBy: 'tab-btn-overview' },
+      { id: 'tab-graph', labelledBy: 'tab-btn-graph' },
+      { id: 'tab-layers', labelledBy: 'tab-btn-layers' },
+      { id: 'tab-handoff', labelledBy: 'tab-btn-handoff' },
+    ]);
+    const overviewPanel = page.locator('#tab-overview');
+    await expect(overviewPanel).toHaveClass(/active/);
+    await expect(overviewPanel.locator('.viewer-card-grid-overview')).toBeVisible();
+    await expect(overviewPanel.getByText('Current state')).toBeVisible();
+    await expect(overviewPanel.getByText('Next action and key metrics')).toBeVisible();
     const sidebar = page.locator(".assigned-pr-inbox");
     await expect(page.getByRole("heading", { name: "PR inspection dashboard" })).toBeVisible();
     await expect(page.getByLabel("Assignment mode")).toBeVisible();
@@ -119,6 +147,7 @@ test("webkit renders the Mermaid-first inspect-run viewer and captures a screens
     await expect(page.locator("[data-inbox-empty]")).toBeHidden();
     await expect(inboxList.getByRole("link", { name: /Current PR/ })).toBeVisible();
 
+    await openTab(page, 'graph');
     const graphGuide = page.getByText(/Graph guide and lane details/);
     await expect(graphGuide).toBeVisible();
     await graphGuide.click();
@@ -210,8 +239,19 @@ test("webkit renders the Mermaid-first inspect-run viewer and captures a screens
     });
     await expect(graphBox.locator("[data-graph-zoom-value]")).toHaveText("125%");
 
-    await page.locator('.viewer-tab[data-tab="overview"]').click();
-    await expect(page.getByRole("button", { name: /Reload snapshot/ })).toBeVisible();
+    await openTab(page, 'layers');
+    await expect(page.locator('#tab-layers')).toHaveClass(/active/);
+    await expect(page.locator('#tab-layers')).toContainText(/Outer-loop/);
+    await expect(page.locator('#tab-layers')).toContainText(/Copilot/);
+
+    await openTab(page, 'handoff');
+    await expect(page.locator('#tab-handoff')).toHaveClass(/active/);
+    await expect(page.locator('#handoff-envelope-section')).toBeVisible();
+    await expect(page.locator('#handoff-envelope-section')).toContainText(/Agent handoff/);
+
+    await openTab(page, 'overview');
+    await expect(page.locator('#tab-overview')).toHaveClass(/active/);
+    await expect(page.locator('#tab-overview .viewer-card-grid-overview')).toBeVisible();
 
     await captureNamedUiState({
       page,
@@ -249,6 +289,7 @@ test("webkit shows checkpoint-only graph uncertainty without guessing missing tr
     await expect(page.getByRole("heading", { name: "Current PR" })).toBeVisible();
     await expect(page.locator(".current-pr-state-summary-headline")).toContainText(/Needs attention/);
     await expect(page.locator(".state-graph-intro")).toHaveCount(0);
+    await openTab(page, 'graph');
     await page.getByText(/Graph guide and lane details/).click();
     const graph = await waitForMermaidGraph(page);
     await expect(graph).toContainText(/current state unavailable/);
@@ -281,6 +322,7 @@ test("webkit shows degraded graph messaging when snapshot trust is partial", asy
     await page.goto(url, { waitUntil: "domcontentloaded" });
 
     await expect(page.locator(".state-graph-intro")).toHaveCount(0);
+    await openTab(page, 'graph');
     await waitForMermaidGraph(page);
 
     await captureNamedUiState({
@@ -325,10 +367,10 @@ test("webkit shows terminal merged states clearly in the Mermaid graph", async (
     const currentStateBanner = page.locator('section[aria-label="PR #55"]');
     await expect(currentStateBanner.getByRole("heading", { name: "Current PR" })).toBeVisible();
     await expect(currentStateBanner.getByText("PR complete")).toBeVisible();
-    await page.locator('.viewer-tab[data-tab="overview"]').click();
+    await openTab(page, 'overview');
     await expect(page.locator('#tab-overview')).toContainText(/status class/);
     await expect(page.locator('#tab-overview')).toContainText(/done/);
-    await page.locator('.viewer-tab[data-tab="graph"]').click();
+    await openTab(page, 'graph');
     await page.getByText(/Graph guide and lane details/).click();
     const graph = await waitForMermaidGraph(page);
     await expect(graph).toContainText(/End/);
@@ -364,8 +406,9 @@ test("webkit shows the unavailable-state fallback for unavailable snapshots", as
   try {
     await page.goto(url, { waitUntil: "domcontentloaded" });
 
+    await openTab(page, 'graph');
     await expect(page.locator(".mermaid-state-graph")).toHaveCount(0);
-    await expect(page.getByText(/Snapshot unavailable, so no state graph can be rendered yet/i)).toBeVisible();
+    await expect(page.locator('#tab-graph')).toContainText(/Snapshot unavailable, so no state graph can be rendered yet/i);
 
     await captureNamedUiState({
       page,
@@ -394,19 +437,20 @@ test("webkit renders the Agent handoff tab and validates structured envelope ren
     await expect(handoffTab).toBeVisible();
     await expect(handoffTab).toHaveText("Agent handoff");
 
-    // Graph tab is visible and active by default
+    // Overview tab is visible and active by default
     const graphTab = page.locator('.viewer-tab[data-tab="graph"]');
     const overviewTab = page.locator('.viewer-tab[data-tab="overview"]');
     const layersTab = page.locator('.viewer-tab[data-tab="layers"]');
     await expect(graphTab).toBeVisible();
     await expect(overviewTab).toBeVisible();
     await expect(layersTab).toBeVisible();
-    await expect(graphTab).toHaveClass(/active/);
+    await expect(overviewTab).toHaveClass(/active/);
+    await expect(graphTab).not.toHaveClass(/active/);
 
     // Handoff tab content is present (may show "Envelope unavailable" if resolver unavailable)
-    await handoffTab.click();
+    await openTab(page, 'handoff');
     await expect(handoffTab).toHaveClass(/active/);
-    await expect(graphTab).not.toHaveClass(/active/);
+    await expect(overviewTab).not.toHaveClass(/active/);
 
     // Handoff content section is visible
     const handoffSection = page.locator("#handoff-envelope-section");
@@ -423,7 +467,7 @@ test("webkit renders the Agent handoff tab and validates structured envelope ren
     await expect(handoffSection).toContainText(/Acceptance/);
 
     // Switch back to graph view
-    await graphTab.click();
+    await openTab(page, 'graph');
     await expect(graphTab).toHaveClass(/active/);
   } finally {
     await stopFixtureServer(server);

--- a/test/playwright/inspect-run-viewer.spec.mjs
+++ b/test/playwright/inspect-run-viewer.spec.mjs
@@ -74,7 +74,6 @@ test("webkit renders the Mermaid-first inspect-run viewer and captures a screens
     await expect(currentStateBanner).toBeVisible();
     await expect(currentStateBanner.getByTitle("Waiting state")).toBeVisible();
     await expect(currentStateBanner.getByText("Waiting for Copilot review")).toBeVisible();
-    await expect(page.locator("body")).toContainText(/These fields are shown directly from the loaded inspection snapshot/i);
     await expect(page.locator(".state-graph-intro")).toHaveCount(0);
     await expect(page.locator(".state-graph-cues")).toContainText(/Start/);
     await expect(page.locator(".state-graph-cues")).toContainText(/Current/);
@@ -212,7 +211,7 @@ test("webkit renders the Mermaid-first inspect-run viewer and captures a screens
     await expect(graphBox.locator("[data-graph-zoom-value]")).toHaveText("125%");
 
     await page.locator('.viewer-tab[data-tab="overview"]').click();
-    await expect(page.getByRole("link", { name: /Open raw snapshot JSON/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Reload snapshot/ })).toBeVisible();
 
     await captureNamedUiState({
       page,
@@ -249,7 +248,6 @@ test("webkit shows checkpoint-only graph uncertainty without guessing missing tr
 
     await expect(page.getByRole("heading", { name: "Current PR" })).toBeVisible();
     await expect(page.locator(".current-pr-state-summary-headline")).toContainText(/Needs attention/);
-    await expect(page.locator(".current-pr-state-note")).toContainText(/checkpoint-only snapshot/i);
     await expect(page.locator(".state-graph-intro")).toHaveCount(0);
     await page.getByText(/Graph guide and lane details/).click();
     const graph = await waitForMermaidGraph(page);

--- a/test/playwright/inspect-run-viewer.spec.mjs
+++ b/test/playwright/inspect-run-viewer.spec.mjs
@@ -68,7 +68,7 @@ test("webkit renders the Mermaid-first inspect-run viewer and captures a screens
   try {
     await page.goto(url, { waitUntil: "domcontentloaded" });
 
-    await expect(page.getByRole("link", { name: "PR #55" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "owner/repo#55" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Current PR" })).toBeVisible();
     const currentStateBanner = page.locator('section[aria-label="PR #55"]');
     await expect(currentStateBanner).toBeVisible();
@@ -123,7 +123,7 @@ test("webkit renders the Mermaid-first inspect-run viewer and captures a screens
     const graphGuide = page.getByText(/Graph guide and lane details/);
     await expect(graphGuide).toBeVisible();
     await graphGuide.click();
-    const graphBox = page.locator(".current-pr-state-visualization");
+    const graphBox = page.locator("#tab-graph .viewer-graph-body");
     await expect(graphBox.getByRole("button", { name: "Zoom in" })).toBeVisible();
     await expect(graphBox.getByRole("button", { name: "Zoom out" })).toBeVisible();
     await expect(graphBox.getByRole("button", { name: "Reset zoom" })).toBeVisible();
@@ -211,8 +211,8 @@ test("webkit renders the Mermaid-first inspect-run viewer and captures a screens
     });
     await expect(graphBox.locator("[data-graph-zoom-value]")).toHaveText("125%");
 
-    await page.locator(".inspection-details").first().locator("summary").click();
-    await expect(page.getByRole("link", { name: /\/snapshot\.json\?repo=owner%2Frepo&pr=55/ })).toBeVisible();
+    await page.locator('.viewer-tab[data-tab="overview"]').click();
+    await expect(page.getByRole("link", { name: /Open raw snapshot JSON/ })).toBeVisible();
 
     await captureNamedUiState({
       page,
@@ -249,7 +249,7 @@ test("webkit shows checkpoint-only graph uncertainty without guessing missing tr
 
     await expect(page.getByRole("heading", { name: "Current PR" })).toBeVisible();
     await expect(page.locator(".current-pr-state-summary-headline")).toContainText(/Needs attention/);
-    await expect(page.locator(".current-pr-state-detail").last()).toContainText(/checkpoint-only snapshot/i);
+    await expect(page.locator(".current-pr-state-note")).toContainText(/checkpoint-only snapshot/i);
     await expect(page.locator(".state-graph-intro")).toHaveCount(0);
     await page.getByText(/Graph guide and lane details/).click();
     const graph = await waitForMermaidGraph(page);
@@ -327,8 +327,10 @@ test("webkit shows terminal merged states clearly in the Mermaid graph", async (
     const currentStateBanner = page.locator('section[aria-label="PR #55"]');
     await expect(currentStateBanner.getByRole("heading", { name: "Current PR" })).toBeVisible();
     await expect(currentStateBanner.getByText("PR complete")).toBeVisible();
-    await expect(page.locator(".current-pr-state-grid")).toContainText(/status class/);
-    await expect(page.locator(".current-pr-state-grid")).toContainText(/done/);
+    await page.locator('.viewer-tab[data-tab="overview"]').click();
+    await expect(page.locator('#tab-overview')).toContainText(/status class/);
+    await expect(page.locator('#tab-overview')).toContainText(/done/);
+    await page.locator('.viewer-tab[data-tab="graph"]').click();
     await page.getByText(/Graph guide and lane details/).click();
     const graph = await waitForMermaidGraph(page);
     await expect(graph).toContainText(/End/);
@@ -394,15 +396,19 @@ test("webkit renders the Agent handoff tab and validates structured envelope ren
     await expect(handoffTab).toBeVisible();
     await expect(handoffTab).toHaveText("Agent handoff");
 
-    // Live view tab is visible and active by default
-    const liveTab = page.locator('.viewer-tab[data-tab="live"]');
-    await expect(liveTab).toBeVisible();
-    await expect(liveTab).toHaveClass(/active/);
+    // Graph tab is visible and active by default
+    const graphTab = page.locator('.viewer-tab[data-tab="graph"]');
+    const overviewTab = page.locator('.viewer-tab[data-tab="overview"]');
+    const layersTab = page.locator('.viewer-tab[data-tab="layers"]');
+    await expect(graphTab).toBeVisible();
+    await expect(overviewTab).toBeVisible();
+    await expect(layersTab).toBeVisible();
+    await expect(graphTab).toHaveClass(/active/);
 
     // Handoff tab content is present (may show "Envelope unavailable" if resolver unavailable)
     await handoffTab.click();
     await expect(handoffTab).toHaveClass(/active/);
-    await expect(liveTab).not.toHaveClass(/active/);
+    await expect(graphTab).not.toHaveClass(/active/);
 
     // Handoff content section is visible
     const handoffSection = page.locator("#handoff-envelope-section");
@@ -413,13 +419,14 @@ test("webkit renders the Agent handoff tab and validates structured envelope ren
     await expect(handoffSection).not.toContainText(/Envelope unavailable/);
     await expect(handoffSection).toContainText(/Target/);
     await expect(handoffSection).toContainText(/Current state/);
-    await expect(page.locator("#handoff-envelope-section dt:has-text('currentGate') + dd")).toHaveText("draft");
+    await expect(page.locator('#handoff-envelope-section .handoff-card')).toHaveCount(9);
+    await expect(page.locator('#handoff-envelope-section [data-field="currentGate"] dd')).toHaveText(/draft/i);
     await expect(handoffSection).toContainText(/Policy/);
     await expect(handoffSection).toContainText(/Acceptance/);
 
-    // Switch back to live view
-    await liveTab.click();
-    await expect(liveTab).toHaveClass(/active/);
+    // Switch back to graph view
+    await graphTab.click();
+    await expect(graphTab).toHaveClass(/active/);
   } finally {
     await stopFixtureServer(server);
   }


### PR DESCRIPTION
Closes #706

## What

Full redesign of the inspect-run-viewer UI across three phases:

### Agent handoff tab
- Card/panel layout with hero, stat tiles, color-coded status badges
- Two-column body: metadata left, directive/policy/acceptance right
- Criteria cards, chip lists, human-readable labels

### Main viewer — 4 tabs
- **Overview** (default) | Graph | Layers | Agent handoff
- Compact banner: PR identity + headline, meta line, auto-reload combo (off/1m/5m/15m)
- Moved 11-row state grid from banner into Overview cards (banner ~2200px → ~240px)
- Graph tab: full-width state machine with deferred render for correct sizing
- Layers tab: outer-loop, copilot, reviewer, steering in card layout

### Polish passes
- Spacing/typography consistency across all cards
- Sidebar selection preserves signal-based border color and emoji
- Tab keyboard navigation restored
- Removed Mermaid branding from user-facing text

## Testing
- Unit: 28/28 pass
- Playwright: 7/7 pass (WebKit)
- 5 Copilot review rounds, 21 threads resolved
- Pre-approval gate: clean