### PR TITLE
fix: detect Copilot PR authorship in startup resolver ownership (#735)

### DIFF
--- a/scripts/loop/resolve-dev-loop-startup.mjs
+++ b/scripts/loop/resolve-dev-loop-startup.mjs
@@ -19,6 +19,7 @@ import {
   ASYNC_START_STATUS,
 } from "../../packages/core/src/loop/async-start-contract.mjs";
 import { detectRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { isCopilotLogin } from "@pi-dev-loops/core/github/copilot-helpers";
 import { loadDevLoopConfig, resolveWorkflowConfig } from "../../packages/core/src/config/config.mjs";
 const USAGE = `Usage:
   resolve-dev-loop-startup.mjs --issue <number>
@@ -219,10 +220,11 @@ export function buildAutoResolvedInput({ issue, pr, cwd, targetPreference, input
         },
       };
     }
-    const artifactState = "not_applicable";
+    let artifactState = "not_applicable";
     const warnings = [];
     let issueLinkageResolution = "resolved_no_open_pr";
     let linkedPr = null;
+    let ownership = "local";
     try {
       const linkageJson = execFileSync(process.execPath, [
         path.join(repoRoot, "scripts/github/detect-linked-issue-pr.mjs"),
@@ -232,6 +234,15 @@ export function buildAutoResolvedInput({ issue, pr, cwd, targetPreference, input
       if (linkage.hasOpenLinkedPr) {
         issueLinkageResolution = "resolved_linked_pr";
         linkedPr = linkage.prNumber;
+        try {
+          const prJson = ghJson(["pr", "view", String(linkedPr), "--repo", repo, "--json", "author,state"], repoRoot);
+          ownership = isCopilotLogin(prJson?.author?.login) ? "copilot" : "external_human";
+          artifactState = mapGhState(prJson?.state ?? "OPEN");
+        } catch {
+          warnings.push(
+            `linkedPr authorship: using default ownership "${ownership}" for PR #${linkedPr} — gh pr view failed`,
+          );
+        }
       }
     } catch {
       warnings.push(`issueLinkageResolution: using default "${issueLinkageResolution}" — linked-PR detection unavailable`);
@@ -267,8 +278,11 @@ export function buildAutoResolvedInput({ issue, pr, cwd, targetPreference, input
       warnings: warnings.length > 0 ? warnings : undefined,
       currentState: {
         target: { kind: "issue", issue, pr: null, linkedPr, branch: null, phase: null },
-        ownership: "local",
-        nextActor: "local",
+        ownership: ownership,
+        nextActor: ownership === "copilot"
+          ? "copilot"
+          : ownership === "external_human"
+            ? "external_human" : "local",
         status: "active",
         authorization: "authorized",
       },

--- a/test/loop/resolve-dev-loop-startup.test.mjs
+++ b/test/loop/resolve-dev-loop-startup.test.mjs
@@ -866,6 +866,7 @@ test("buildAutoResolvedInput detects Copilot authorship from linked PR author", 
       env: {
         ...ghStub.env,
         PI_WORKTREE_BYPASS: "1",
+        PI_SUBAGENT_RUN_ID: "test-run-copilot-author",
       },
     });
     assert.equal(result.code, 0, result.stderr);
@@ -901,6 +902,7 @@ test("buildAutoResolvedInput detects external_human authorship from linked PR au
       env: {
         ...ghStub.env,
         PI_WORKTREE_BYPASS: "1",
+        PI_SUBAGENT_RUN_ID: "test-run-external-author",
       },
     });
     assert.equal(result.code, 0, result.stderr);

--- a/test/loop/resolve-dev-loop-startup.test.mjs
+++ b/test/loop/resolve-dev-loop-startup.test.mjs
@@ -844,3 +844,73 @@ test("runCli --issue uses config inputSource=phase-docs to choose phase-doc loca
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+test("buildAutoResolvedInput detects Copilot authorship from linked PR author", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "resolve-dev-loop-copilot-author-"));
+  try {
+    execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/pi-dev-loops.git"], { cwd: tempDir, stdio: "ignore" });
+    // Create the detect-linked-issue-pr script path so the subprocess can resolve
+    await mkdir(path.join(tempDir, "scripts", "github"), { recursive: true });
+    await writeFile(
+      path.join(tempDir, "scripts/github/detect-linked-issue-pr.mjs"),
+      'process.stdout.write(JSON.stringify({ ok: true, repo: "mfittko/pi-dev-loops", issue: 735, hasOpenLinkedPr: true, prNumber: 740 }));',
+      "utf8",
+    );
+    // Stub gh pr view to return Copilot author
+    const ghStub = await writeGhStubHelper(tempDir, [
+      { assertArgs: ["pr", "view", "740"], stdout: JSON.stringify({ author: { login: "copilot-swe-agent" }, state: "OPEN" }) },
+    ]);
+    const result = await runNode(["--issue", "735"], {
+      cwd: tempDir,
+      env: {
+        ...ghStub.env,
+        PI_WORKTREE_BYPASS: "1",
+      },
+    });
+    assert.equal(result.code, 0, result.stderr);
+    const parsed = JSON.parse(result.stdout);
+    // Ownership should be copilot since the PR author is copilot-swe-agent
+    assert.equal(parsed.bundleKind, "resolved");
+    assert.equal(parsed.selectedStrategy, "copilot_pr_followup");
+    assert.equal(parsed.canonicalStateSummary.ownership, "copilot");
+    assert.equal(parsed.canonicalStateSummary.nextActor, "copilot");
+    // PR target should be the linked PR number (transformed from issue+linkedPr)
+    assert.equal(parsed.canonicalStateSummary.target.pr, 740);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("buildAutoResolvedInput detects external_human authorship from linked PR author", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "resolve-dev-loop-external-author-"));
+  try {
+    execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/pi-dev-loops.git"], { cwd: tempDir, stdio: "ignore" });
+    await mkdir(path.join(tempDir, "scripts", "github"), { recursive: true });
+    await writeFile(
+      path.join(tempDir, "scripts/github/detect-linked-issue-pr.mjs"),
+      'process.stdout.write(JSON.stringify({ ok: true, repo: "mfittko/pi-dev-loops", issue: 735, hasOpenLinkedPr: true, prNumber: 740 }));',
+      "utf8",
+    );
+    const ghStub = await writeGhStubHelper(tempDir, [
+      { assertArgs: ["pr", "view", "740"], stdout: JSON.stringify({ author: { login: "some-human-dev" }, state: "OPEN" }) },
+    ]);
+    const result = await runNode(["--issue", "735"], {
+      cwd: tempDir,
+      env: {
+        ...ghStub.env,
+        PI_WORKTREE_BYPASS: "1",
+      },
+    });
+    assert.equal(result.code, 0, result.stderr);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.bundleKind, "resolved");
+    assert.equal(parsed.selectedStrategy, "external_pr_followup");
+    assert.equal(parsed.canonicalStateSummary.ownership, "external_human");
+    assert.equal(parsed.canonicalStateSummary.nextActor, "external_human");
+    assert.equal(parsed.canonicalStateSummary.target.pr, 740);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Fix #735: Copilot-authored PRs now correctly route to `copilot_pr_followup` instead of `needs_reconcile`.

The startup resolver's `buildAutoResolvedInput` always set `ownership: "local"` for issue targets, even when a linked Copilot-authored PR existed. This forced every Copilot PR through the reconcile path, requiring manual re-dispatch.

## Changes

### `scripts/loop/resolve-dev-loop-startup.mjs`
- Import `isCopilotLogin` from `@pi-dev-loops/core/github/copilot-helpers`
- After detecting a linked PR, query `gh pr view` for `author` and `state`
- Set ownership to `"copilot"` when `isCopilotLogin(pr.author.login)` is true, `"external_human"` otherwise
- Set `artifactState` to the PR's state (`"open"`) so `isArtifactStateCompatible` passes for the routed PR target
- Derive `nextActor` from ownership

### `test/loop/resolve-dev-loop-startup.test.mjs`
- Added `buildAutoResolvedInput detects Copilot authorship from linked PR author` — verifies ownership=*copilot*, route=`copilot_pr_followup`
- Added `buildAutoResolvedInput detects external_human authorship from linked PR author` — verifies ownership=*external_human*, route=`external_pr_followup`

## Validation

- `npm run verify` — all 2974+ tests pass (0 failures)
- Startup resolver tests: 37 pass, including 2 new authorship tests
- Core routing tests: 68 pass

## Scope

Only `--issue` auto-resolution path in `buildAutoResolvedInput`. The `--pr` path already hardcoded `ownership: "copilot"` and is unchanged.

Closes #735
