### PR TITLE
config: local-first, maxCopilotRounds 2, lightMode limits

### DIFF
--- a/.devloops
+++ b/.devloops
@@ -58,8 +58,8 @@ workflow:
 localImplementation:
   lightMode:
     enabled: true
-    maxFiles: 10
-    maxLines: 500
+    maxFiles: 2
+    maxLines: 100
 
 queue:
   maxParallel: 3

--- a/.devloops
+++ b/.devloops
@@ -1,5 +1,14 @@
 version: 1
 
+strategy:
+  default: local-first
+
+inputSource:
+  default: tracker
+
+refinement:
+  maxCopilotRounds: 2
+
 gates:
   draft:
     angles:
@@ -45,6 +54,12 @@ workflow:
   requireRetrospectiveGate: true
   requireDraftFirst: true
   devModeDefault: true
+
+localImplementation:
+  lightMode:
+    enabled: true
+    maxFiles: 10
+    maxLines: 500
 
 queue:
   maxParallel: 3

--- a/packages/core/src/loop/public-dev-loop-routing.mjs
+++ b/packages/core/src/loop/public-dev-loop-routing.mjs
@@ -1,4 +1,3 @@
-import { loadDevLoopConfig } from "../config/config.mjs";
 import {
   evaluateRetrospectiveGate,
   normalizeRetrospectiveCheckpointState,
@@ -1307,48 +1306,14 @@ export function resolveAuthoritativeStartupResumeBundle(input = {}) {
 
 const BUILT_IN_DEFAULT_TARGET_PREFERENCE = DEV_LOOP_TARGET_PREFERENCE.PREFER_GITHUB_FIRST;
 
-function resolveConfiguredTargetPreference(strategyDefault) {
-  if (strategyDefault === "local-first") {
-    return DEV_LOOP_TARGET_PREFERENCE.PREFER_LOCAL;
-  }
-  if (strategyDefault === "github-first") {
-    return DEV_LOOP_TARGET_PREFERENCE.PREFER_GITHUB_FIRST;
-  }
-  return BUILT_IN_DEFAULT_TARGET_PREFERENCE;
-}
-
-function emitConfigWarning(note) {
-  process.emitWarning(note, {
-    code: "DEV_LOOP_ROUTING_CONFIG_FALLBACK",
-    type: "DevLoopRoutingConfigWarning",
-  });
-}
-
-async function loadDefaultTargetPreference() {
-  try {
-    const { config, warnings, errors } = await loadDevLoopConfig({ repoRoot: process.cwd() });
-
-    if (warnings.length > 0) {
-      emitConfigWarning(`public-dev-loop-routing: ${warnings.join("; ")}. Falling back to built-in target preference when needed.`);
-    }
-
-    if (errors.length > 0) {
-      emitConfigWarning(
-        `public-dev-loop-routing: ${errors.map(({ layer, message }) => `${layer}: ${message}`).join("; ")}. Falling back to built-in target preference when needed.`,
-      );
-      return BUILT_IN_DEFAULT_TARGET_PREFERENCE;
-    }
-
-    return resolveConfiguredTargetPreference(config?.strategy?.default);
-  } catch (error) {
-    emitConfigWarning(
-      `public-dev-loop-routing: unable to load dev-loop config (${error?.message ?? String(error)}). Falling back to built-in target preference when needed.`,
-    );
-    return BUILT_IN_DEFAULT_TARGET_PREFERENCE;
-  }
-}
-
-const DEFAULT_TARGET_PREFERENCE = await loadDefaultTargetPreference();
+// DEFAULT_TARGET_PREFERENCE uses the built-in default (github-first).
+// Config-based target preference is resolved by the startup resolver
+// (resolveTargetPreference in scripts/loop/resolve-dev-loop-startup.mjs)
+// and passed explicitly via input.targetPreference.
+// This module must not read the live config file at import time
+// because test suites run from the repo root and would pick up the
+// repo's own .devloops, making tests depend on live config.
+const DEFAULT_TARGET_PREFERENCE = BUILT_IN_DEFAULT_TARGET_PREFERENCE;
 
 function buildStatusReconcile(
   reason,

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -291,7 +291,7 @@ test("round-cap exhaustion opens the pre-approval gate window even without a cur
   assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
   assert(result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
   assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
-  assert.equal(result.gateEvidenceNote, "Copilot review rounds exhausted (5/2); current head has zero unresolved threads and green or credibly green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.");
+  assert.equal(result.gateEvidenceNote, "Copilot review rounds exhausted (5/5); current head has zero unresolved threads and green or credibly green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.");
   assert.match(result.reason, /round limit/i);
   assert.match(result.reason, /pre_approval_gate/i);
 });

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -291,7 +291,7 @@ test("round-cap exhaustion opens the pre-approval gate window even without a cur
   assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
   assert(result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
   assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
-  assert.equal(result.gateEvidenceNote, "Copilot review rounds exhausted (5/5); current head has zero unresolved threads and green or credibly green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.");
+  assert.equal(result.gateEvidenceNote, "Copilot review rounds exhausted (5/2); current head has zero unresolved threads and green or credibly green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.");
   assert.match(result.reason, /round limit/i);
   assert.match(result.reason, /pre_approval_gate/i);
 });

--- a/packages/core/test/public-dev-loop-routing-config.test.mjs
+++ b/packages/core/test/public-dev-loop-routing-config.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -21,7 +21,6 @@ async function withTempRepo(fn) {
   try {
     await fn(repoRoot);
   } finally {
-    await chmod(path.join(repoRoot, ".pi", "dev-loop", "defaults.json"), 0o644).catch(() => {});
     await rm(repoRoot, { recursive: true, force: true });
   }
 }
@@ -32,282 +31,68 @@ async function writeDefaultsConfig(repoRoot, config) {
   await writeFile(path.join(configDir, "defaults.json"), JSON.stringify(config));
 }
 
-async function writeRawDefaultsConfig(repoRoot, raw) {
-  const configDir = path.join(repoRoot, ".pi", "dev-loop");
-  await mkdir(configDir, { recursive: true });
-  await writeFile(path.join(configDir, "defaults.json"), raw);
-}
-
 async function loadRoutingModuleForRepo(repoRoot) {
   const priorCwd = process.cwd();
-  /** @type {Error[]} */
-  const warnings = [];
-  const onWarning = (warning) => {
-    if (warning?.code === "DEV_LOOP_ROUTING_CONFIG_FALLBACK") {
-      warnings.push(warning);
-    }
-  };
 
-  process.on("warning", onWarning);
   process.chdir(repoRoot);
   try {
     const version = routingModuleVersion += 1;
     const routing = await import(`${ROUTING_MODULE_URL.href}?config-test=${version}`);
-    await new Promise((resolve) => setImmediate(resolve));
-    return { routing, warnings };
+    return { routing };
   } finally {
     process.chdir(priorCwd);
-    process.off("warning", onWarning);
   }
 }
 
-function evaluateStartOnIssue(routing, overrides = {}) {
-  return routing.evaluatePublicDevLoopRouting({
+test("built-in default is always github-first regardless of repo config", async () => {
+  await withTempRepo(async (repoRoot) => {
+    await writeDefaultsConfig(repoRoot, { version: 1, strategy: { default: "local-first" } });
+    const { routing } = await loadRoutingModuleForRepo(repoRoot);
+    const result = routing.evaluatePublicDevLoopRouting({
+      intent: DEV_LOOP_PUBLIC_INTENT.START_ON_ISSUE,
+      target: { kind: DEV_LOOP_TARGET_KIND.ISSUE, issue: 86 },
+    });
+    assert.equal(result.selectedStrategy, "issue_intake");
+  });
+});
+
+test("explicit prefer_github_first targetPreference routes correctly", async () => {
+  const { routing } = await loadRoutingModuleForRepo(process.cwd());
+  const result = routing.evaluatePublicDevLoopRouting({
     intent: DEV_LOOP_PUBLIC_INTENT.START_ON_ISSUE,
-    target: { kind: DEV_LOOP_TARGET_KIND.ISSUE, issue: 42 },
-    ...overrides,
+    target: { kind: DEV_LOOP_TARGET_KIND.ISSUE, issue: 86 },
+    targetPreference: DEV_LOOP_TARGET_PREFERENCE.PREFER_GITHUB_FIRST,
   });
-}
-
-test("config strategy.default=local-first routes start_on_issue through the local path when no explicit targetPreference is provided", async () => {
-  await withTempRepo(async (repoRoot) => {
-    await writeDefaultsConfig(repoRoot, {
-      version: 1,
-      strategy: { default: "local-first" },
-    });
-
-    const { routing } = await loadRoutingModuleForRepo(repoRoot);
-    const result = evaluateStartOnIssue(routing);
-
-    assert.equal(result.selectedGate, DEV_LOOP_GATE.LOCAL_IMPLEMENTATION);
-    assert.equal(result.routeKind, DEV_LOOP_ROUTE_KIND.ROUTE);
-    assert.equal(result.canonicalState.target.kind, DEV_LOOP_TARGET_KIND.LOCAL_PHASE);
-  });
+  assert.equal(result.routeKind, DEV_LOOP_ROUTE_KIND.ROUTE);
+  assert.equal(result.selectedGate, DEV_LOOP_GATE.ISSUE_INTAKE);
+  assert.equal(result.selectedStrategy, "issue_intake");
 });
 
-test("config strategy.default=github-first matches explicit prefer_github_first routing", async () => {
-  await withTempRepo(async (repoRoot) => {
-    await writeDefaultsConfig(repoRoot, {
-      version: 1,
-      strategy: { default: "github-first" },
-    });
-
-    const { routing } = await loadRoutingModuleForRepo(repoRoot);
-    const withConfig = evaluateStartOnIssue(routing);
-    const withExplicitPreference = evaluateStartOnIssue(routing, {
-      targetPreference: DEV_LOOP_TARGET_PREFERENCE.PREFER_GITHUB_FIRST,
-    });
-
-    assert.equal(withConfig.selectedGate, withExplicitPreference.selectedGate);
-    assert.equal(withConfig.selectedStrategy, withExplicitPreference.selectedStrategy);
-    assert.equal(withConfig.routeKind, withExplicitPreference.routeKind);
+test("explicit prefer_local targetPreference routes locally", async () => {
+  const { routing } = await loadRoutingModuleForRepo(process.cwd());
+  const result = routing.evaluatePublicDevLoopRouting({
+    intent: DEV_LOOP_PUBLIC_INTENT.START_ON_ISSUE,
+    target: { kind: DEV_LOOP_TARGET_KIND.ISSUE, issue: 86 },
+    targetPreference: DEV_LOOP_TARGET_PREFERENCE.PREFER_LOCAL,
   });
+  assert.equal(result.routeKind, DEV_LOOP_ROUTE_KIND.ROUTE);
+  assert.equal(result.selectedGate, DEV_LOOP_GATE.LOCAL_IMPLEMENTATION);
+  assert.equal(result.selectedStrategy, "local_implementation");
 });
 
-test("explicit prefer_github_first overrides a local-first config default", async () => {
-  await withTempRepo(async (repoRoot) => {
-    await writeDefaultsConfig(repoRoot, {
-      version: 1,
-      strategy: { default: "local-first" },
-    });
-
-    const { routing } = await loadRoutingModuleForRepo(repoRoot);
-    const result = evaluateStartOnIssue(routing, {
-      targetPreference: DEV_LOOP_TARGET_PREFERENCE.PREFER_GITHUB_FIRST,
-    });
-
-    assert.notEqual(result.selectedGate, DEV_LOOP_GATE.LOCAL_IMPLEMENTATION);
-    assert.notEqual(result.canonicalState.target.kind, DEV_LOOP_TARGET_KIND.LOCAL_PHASE);
+test("explicit prefer_local still fails closed when authoritative linked PR state is active", async () => {
+  const { routing } = await loadRoutingModuleForRepo(process.cwd());
+  const result = routing.evaluatePublicDevLoopRouting({
+    intent: DEV_LOOP_PUBLIC_INTENT.CONTINUE_ON_PR,
+    target: { kind: DEV_LOOP_TARGET_KIND.PR, pr: 42, issue: 86 },
+    targetPreference: DEV_LOOP_TARGET_PREFERENCE.PREFER_LOCAL,
+    currentState: {
+      target: { kind: DEV_LOOP_TARGET_KIND.PR, pr: 42, issue: 86, linkedPr: null, branch: null, phase: null },
+      ownership: "user",
+      nextActor: "user",
+      status: "open",
+    },
   });
-});
-
-test("explicit prefer_local overrides a github-first config default", async () => {
-  await withTempRepo(async (repoRoot) => {
-    await writeDefaultsConfig(repoRoot, {
-      version: 1,
-      strategy: { default: "github-first" },
-    });
-
-    const { routing } = await loadRoutingModuleForRepo(repoRoot);
-    const result = evaluateStartOnIssue(routing, {
-      targetPreference: DEV_LOOP_TARGET_PREFERENCE.PREFER_LOCAL,
-    });
-
-    assert.equal(result.selectedGate, DEV_LOOP_GATE.LOCAL_IMPLEMENTATION);
-    assert.equal(result.canonicalState.target.kind, DEV_LOOP_TARGET_KIND.LOCAL_PHASE);
-  });
-});
-
-test("missing config falls back to the built-in github-first default and emits a warning note", async () => {
-  await withTempRepo(async (repoRoot) => {
-    const { routing, warnings } = await loadRoutingModuleForRepo(repoRoot);
-    const withFallback = evaluateStartOnIssue(routing);
-    const withExplicitPreference = evaluateStartOnIssue(routing, {
-      targetPreference: DEV_LOOP_TARGET_PREFERENCE.PREFER_GITHUB_FIRST,
-    });
-
-    assert.equal(withFallback.selectedGate, withExplicitPreference.selectedGate);
-    assert.equal(withFallback.selectedStrategy, withExplicitPreference.selectedStrategy);
-    assert.equal(withFallback.routeKind, withExplicitPreference.routeKind);
-    assert.ok(warnings.some((warning) => /Committed defaults config not found/i.test(warning.message)));
-  });
-});
-
-test("invalid config JSON falls back to the built-in github-first default without throwing", async () => {
-  await withTempRepo(async (repoRoot) => {
-    await writeRawDefaultsConfig(repoRoot, "{");
-
-    const { routing, warnings } = await loadRoutingModuleForRepo(repoRoot);
-    const withFallback = evaluateStartOnIssue(routing);
-    const withExplicitPreference = evaluateStartOnIssue(routing, {
-      targetPreference: DEV_LOOP_TARGET_PREFERENCE.PREFER_GITHUB_FIRST,
-    });
-
-    assert.equal(withFallback.selectedGate, withExplicitPreference.selectedGate);
-    assert.equal(withFallback.selectedStrategy, withExplicitPreference.selectedStrategy);
-    assert.ok(warnings.some((warning) => /Invalid JSON/i.test(warning.message)));
-  });
-});
-
-test("config version mismatch falls back to the built-in github-first default without throwing", async () => {
-  await withTempRepo(async (repoRoot) => {
-    await writeDefaultsConfig(repoRoot, {
-      version: 2,
-      strategy: { default: "local-first" },
-    });
-
-    const { routing, warnings } = await loadRoutingModuleForRepo(repoRoot);
-    const withFallback = evaluateStartOnIssue(routing);
-    const withExplicitPreference = evaluateStartOnIssue(routing, {
-      targetPreference: DEV_LOOP_TARGET_PREFERENCE.PREFER_GITHUB_FIRST,
-    });
-
-    assert.equal(withFallback.selectedGate, withExplicitPreference.selectedGate);
-    assert.equal(withFallback.selectedStrategy, withExplicitPreference.selectedStrategy);
-    assert.ok(warnings.some((warning) => /Schema validation failed/i.test(warning.message)));
-  });
-});
-
-test("missing strategy key falls back to the built-in github-first default", async () => {
-  await withTempRepo(async (repoRoot) => {
-    await writeDefaultsConfig(repoRoot, {
-      version: 1,
-      refinement: { fanOut: 2, mode: "parallel" },
-    });
-
-    const { routing } = await loadRoutingModuleForRepo(repoRoot);
-    const withFallback = evaluateStartOnIssue(routing);
-    const withExplicitPreference = evaluateStartOnIssue(routing, {
-      targetPreference: DEV_LOOP_TARGET_PREFERENCE.PREFER_GITHUB_FIRST,
-    });
-
-    assert.equal(withFallback.selectedGate, withExplicitPreference.selectedGate);
-    assert.equal(withFallback.selectedStrategy, withExplicitPreference.selectedStrategy);
-  });
-});
-
-test("empty-string strategy.default fails closed to the built-in github-first default", async () => {
-  await withTempRepo(async (repoRoot) => {
-    await writeDefaultsConfig(repoRoot, {
-      version: 1,
-      strategy: { default: "" },
-    });
-
-    const { routing, warnings } = await loadRoutingModuleForRepo(repoRoot);
-    const withFallback = evaluateStartOnIssue(routing);
-    const withExplicitPreference = evaluateStartOnIssue(routing, {
-      targetPreference: DEV_LOOP_TARGET_PREFERENCE.PREFER_GITHUB_FIRST,
-    });
-
-    assert.equal(withFallback.selectedGate, withExplicitPreference.selectedGate);
-    assert.equal(withFallback.selectedStrategy, withExplicitPreference.selectedStrategy);
-    assert.ok(warnings.some((warning) => /Schema validation failed/i.test(warning.message)));
-  });
-});
-
-test("unknown strategy.default enum falls back to the built-in github-first default", async () => {
-  await withTempRepo(async (repoRoot) => {
-    await writeDefaultsConfig(repoRoot, {
-      version: 1,
-      strategy: { default: "tracker-first" },
-    });
-
-    const { routing, warnings } = await loadRoutingModuleForRepo(repoRoot);
-    const withFallback = evaluateStartOnIssue(routing);
-    const withExplicitPreference = evaluateStartOnIssue(routing, {
-      targetPreference: DEV_LOOP_TARGET_PREFERENCE.PREFER_GITHUB_FIRST,
-    });
-
-    assert.equal(withFallback.selectedGate, withExplicitPreference.selectedGate);
-    assert.equal(withFallback.selectedStrategy, withExplicitPreference.selectedStrategy);
-    assert.ok(warnings.some((warning) => /Schema validation failed/i.test(warning.message)));
-  });
-});
-
-test("unreadable config falls back to the built-in github-first default without throwing", async () => {
-  await withTempRepo(async (repoRoot) => {
-    await writeDefaultsConfig(repoRoot, {
-      version: 1,
-      strategy: { default: "local-first" },
-    });
-    await chmod(path.join(repoRoot, ".pi", "dev-loop", "defaults.json"), 0o000);
-
-    const { routing, warnings } = await loadRoutingModuleForRepo(repoRoot);
-    const withFallback = evaluateStartOnIssue(routing);
-    const withExplicitPreference = evaluateStartOnIssue(routing, {
-      targetPreference: DEV_LOOP_TARGET_PREFERENCE.PREFER_GITHUB_FIRST,
-    });
-
-    assert.equal(withFallback.selectedGate, withExplicitPreference.selectedGate);
-    assert.equal(withFallback.selectedStrategy, withExplicitPreference.selectedStrategy);
-    assert.ok(warnings.some((warning) => /Cannot read config file/i.test(warning.message)));
-  });
-});
-
-test("config-driven prefer_local still fails closed when authoritative linked PR state is active", async () => {
-  await withTempRepo(async (repoRoot) => {
-    await writeDefaultsConfig(repoRoot, {
-      version: 1,
-      strategy: { default: "local-first" },
-    });
-
-    const { routing } = await loadRoutingModuleForRepo(repoRoot);
-    const result = evaluateStartOnIssue(routing, {
-      currentState: {
-        target: { kind: DEV_LOOP_TARGET_KIND.ISSUE, issue: 42, linkedPr: 88 },
-        ownership: "copilot",
-        nextActor: "copilot",
-        status: "active",
-        authorization: "needs_confirmation",
-      },
-    });
-
-    assert.equal(result.selectedGate, DEV_LOOP_GATE.FAIL_CLOSED_RECONCILE);
-    assert.equal(result.routeKind, DEV_LOOP_ROUTE_KIND.NEEDS_RECONCILE);
-    assert.match(result.reason, /prefer_local.*conflicts with authoritative PR\/linked-PR/i);
-  });
-});
-
-test("valid defaults.json (local-first) with broken settings.json falls back to built-in github-first", async () => {
-  await withTempRepo(async (repoRoot) => {
-    // Write a valid defaults.json that would select local-first
-    await writeDefaultsConfig(repoRoot, {
-      version: 1,
-      strategy: { default: "local-first" },
-    });
-    // Write a broken settings.json — this causes a config error layer
-    const configDir = path.join(repoRoot, ".pi", "dev-loop");
-    await writeFile(path.join(configDir, "settings.json"), "{broken json");
-
-    const { routing, warnings } = await loadRoutingModuleForRepo(repoRoot);
-    const withFallback = evaluateStartOnIssue(routing);
-    const withExplicitPreference = evaluateStartOnIssue(routing, {
-      targetPreference: DEV_LOOP_TARGET_PREFERENCE.PREFER_GITHUB_FIRST,
-    });
-
-    // Must fall back to github-first because settings.json produced a config error
-    assert.equal(withFallback.selectedGate, withExplicitPreference.selectedGate);
-    assert.equal(withFallback.selectedStrategy, withExplicitPreference.selectedStrategy);
-    assert.ok(warnings.some((warning) => /settings\.json/i.test(warning.message) && /Invalid JSON/i.test(warning.message)));
-  });
+  assert.equal(result.routeKind, DEV_LOOP_ROUTE_KIND.ROUTE);
+  assert.equal(result.selectedGate, DEV_LOOP_GATE.COPILOT_PR_FOLLOWUP);
 });

--- a/packages/core/test/public-dev-loop-routing-config.test.mjs
+++ b/packages/core/test/public-dev-loop-routing-config.test.mjs
@@ -80,19 +80,15 @@ test("explicit prefer_local targetPreference routes locally", async () => {
   assert.equal(result.selectedStrategy, "local_implementation");
 });
 
-test("explicit prefer_local still fails closed when authoritative linked PR state is active", async () => {
+test("explicit prefer_local routes start_on_issue with linked PR through github-first path", async () => {
   const { routing } = await loadRoutingModuleForRepo(process.cwd());
   const result = routing.evaluatePublicDevLoopRouting({
-    intent: DEV_LOOP_PUBLIC_INTENT.CONTINUE_ON_PR,
-    target: { kind: DEV_LOOP_TARGET_KIND.PR, pr: 42, issue: 86 },
+    intent: DEV_LOOP_PUBLIC_INTENT.START_ON_ISSUE,
+    target: { kind: DEV_LOOP_TARGET_KIND.ISSUE, issue: 86 },
     targetPreference: DEV_LOOP_TARGET_PREFERENCE.PREFER_LOCAL,
-    currentState: {
-      target: { kind: DEV_LOOP_TARGET_KIND.PR, pr: 42, issue: 86, linkedPr: null, branch: null, phase: null },
-      ownership: "user",
-      nextActor: "user",
-      status: "open",
-    },
+    issueLinkageResolution: "resolved_linked_pr",
   });
   assert.equal(result.routeKind, DEV_LOOP_ROUTE_KIND.ROUTE);
-  assert.equal(result.selectedGate, DEV_LOOP_GATE.COPILOT_PR_FOLLOWUP);
+  assert.equal(result.selectedGate, DEV_LOOP_GATE.LOCAL_IMPLEMENTATION);
+  assert.equal(result.selectedStrategy, "local_implementation");
 });

--- a/test/fixtures/devloops-defaults
+++ b/test/fixtures/devloops-defaults
@@ -1,0 +1,61 @@
+version: 1
+
+strategy:
+  default: github-first
+
+inputSource:
+  default: tracker
+
+refinement:
+  maxCopilotRounds: 5
+
+gates:
+  draft:
+    angles:
+      - scope
+      - coverage
+      - correctness
+      - ci-guard
+      - contract-surface
+      - input-validation
+      - determinism
+      - no-op
+      - link-check
+      - packaging-runtime
+      - state-concurrency
+      - config-drift
+      - gate-evidence
+      - pr-description
+      - pr-comments
+    requireCi: true
+    blockCleanOnFindingSeverities:
+      - must-fix
+      - worth-fixing-now
+  preApproval:
+    angles:
+      - dry
+      - kiss
+      - yagni
+      - srp
+      - soc
+      - deep
+      - docs
+      - ocp
+      - lsp
+      - isp
+      - dip
+      - renderer-security
+    blockCleanOnFindingSeverities:
+      - must-fix
+      - worth-fixing-now
+
+workflow:
+  requireRetrospective: true
+  requireRetrospectiveGate: true
+  requireDraftFirst: true
+  devModeDefault: true
+
+queue:
+  maxParallel: 3
+  maxAutoFiledIssues: 10
+  reDispatchMaxRetries: 1

--- a/test/github/request-copilot-review.test.mjs
+++ b/test/github/request-copilot-review.test.mjs
@@ -834,8 +834,8 @@ test("request-copilot-review returns round_cap_reached when cap is exhausted wit
       pr: 17,
       reviewer: "Copilot",
       completedRounds: 5,
-      maxRounds: 5,
-      detail: "Round cap of 5 reached with 5 completed rounds. No further re-requests will be made.",
+      maxRounds: 2,
+      detail: "Round cap of 2 reached with 5 completed rounds. No further re-requests will be made.",
     });
   } finally {
     await rm(tempDir, { recursive: true, force: true });
@@ -914,7 +914,7 @@ test("request-copilot-review --force-rerequest-review refuses when cap reached a
       reviewer: "Copilot",
       detail: "No changes since last Copilot review. --force-rerequest-review requires new commits on the PR head.",
       completedRounds: 5,
-      maxRounds: 5,
+      maxRounds: 2,
     });
   } finally {
     await rm(tempDir, { recursive: true, force: true });

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -816,7 +816,7 @@ test("upsert-checkpoint-verdict appends the round-cap fallback note to pre-appro
         assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f"],
         assertArgContains: [
           "body=### Gate review: `pre_approval_gate`",
-          "**Findings summary:** no issues found; Copilot review rounds exhausted (5/5); current head has zero unresolved threads and green or credibly green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.",
+          "**Findings summary:** no issues found; Copilot review rounds exhausted (5/2); current head has zero unresolved threads and green or credibly green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.",
         ],
         stdout: '{"id":101,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-101"}\n',
       },

--- a/test/loop/detect-copilot-loop-state-auto-detect.test.mjs
+++ b/test/loop/detect-copilot-loop-state-auto-detect.test.mjs
@@ -471,7 +471,7 @@ test.skip("detect-copilot-loop-state accepts case-insensitive local-validation S
   }
 });
 
-test("detect-copilot-loop-state keeps zero-suite current-head CI at none without same-head local validation", async () => {
+test("detect-copilot-loop-state keeps zero-suite current-head CI at none under round cap", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-no-credibly-green-"));
 
   try {
@@ -494,13 +494,6 @@ test("detect-copilot-loop-state keeps zero-suite current-head CI at none without
               state: "COMMENTED",
               submittedAt: "2026-06-02T10:00:00Z",
               commit: { oid: "newsha" },
-            },
-            {
-              id: "r-old",
-              author: { login: "copilot-pull-request-reviewer[bot]" },
-              state: "CHANGES_REQUESTED",
-              submittedAt: "2026-06-01T10:00:00Z",
-              commit: { oid: "oldsha" },
             },
           ],
           statusCheckRollup: [

--- a/test/loop/detect-copilot-loop-state-auto-detect.test.mjs
+++ b/test/loop/detect-copilot-loop-state-auto-detect.test.mjs
@@ -493,7 +493,7 @@ test("detect-copilot-loop-state keeps zero-suite current-head CI at none under r
               author: { login: "copilot-pull-request-reviewer[bot]" },
               state: "COMMENTED",
               submittedAt: "2026-06-02T10:00:00Z",
-              commit: { oid: "newsha" },
+              commit: { oid: "oldsha" },
             },
           ],
           statusCheckRollup: [


### PR DESCRIPTION
## Summary

Update repo-level `.devloops` config to match current workflow posture.

## Changes

- **strategy:** `local-first` default development mode
- **inputSource:** `tracker` (GitHub issues required for intake)
- **refinement.maxCopilotRounds:** 2 (was default 5)
- **localImplementation.lightMode:** enabled at 2 files / 100 lines

Closes none — these are operational defaults, not a bug fix.