### PR TITLE
fix: ensure-queue-board reads .devloops instead of .pi/dev-loop/settings.yaml

### DIFF
--- a/.devloops
+++ b/.devloops
@@ -58,8 +58,8 @@ workflow:
 localImplementation:
   lightMode:
     enabled: true
-    maxFiles: 10
-    maxLines: 500
+    maxFiles: 2
+    maxLines: 100
 
 queue:
   maxParallel: 3

--- a/.devloops
+++ b/.devloops
@@ -58,8 +58,8 @@ workflow:
 localImplementation:
   lightMode:
     enabled: true
-    maxFiles: 2
-    maxLines: 100
+    maxFiles: 10
+    maxLines: 500
 
 queue:
   maxParallel: 3

--- a/scripts/projects/ensure-queue-board.mjs
+++ b/scripts/projects/ensure-queue-board.mjs
@@ -143,13 +143,14 @@ function validateRepo(repo) {
 function resolveSettings(cwd) {
   // Try bare .devloops and extension variants (.yaml, .yml, .json)
   // to match the config loader's consumer override detection.
+  // .json uses strict JSON.parse; all others use the YAML parser.
   const basePath = path.join(cwd, ".devloops");
   const extensions = ["", ".yaml", ".yml", ".json"];
   for (const ext of extensions) {
     try {
       const settingsPath = basePath + ext;
       const raw = readFileSync(settingsPath, "utf-8");
-      const settings = parseYaml(raw);
+      const settings = ext === ".json" ? JSON.parse(raw) : parseYaml(raw);
       const queue = settings?.queue;
       if (queue) {
         if (typeof queue.projectNumber === "number" && Number.isInteger(queue.projectNumber) && queue.projectNumber > 0) {

--- a/scripts/projects/ensure-queue-board.mjs
+++ b/scripts/projects/ensure-queue-board.mjs
@@ -142,7 +142,7 @@ function validateRepo(repo) {
 
 function resolveSettings(cwd) {
   try {
-    const settingsPath = path.join(cwd, ".pi", "dev-loop", "settings.yaml");
+    const settingsPath = path.join(cwd, ".devloops");
     const raw = readFileSync(settingsPath, "utf-8");
     const settings = parseYaml(raw);
     const queue = settings?.queue;

--- a/scripts/projects/ensure-queue-board.mjs
+++ b/scripts/projects/ensure-queue-board.mjs
@@ -141,21 +141,28 @@ function validateRepo(repo) {
 // ── Settings fallback ────────────────────────────────────────────────────
 
 function resolveSettings(cwd) {
-  try {
-    const settingsPath = path.join(cwd, ".devloops");
-    const raw = readFileSync(settingsPath, "utf-8");
-    const settings = parseYaml(raw);
-    const queue = settings?.queue;
-    if (queue) {
-      if (typeof queue.projectNumber === "number" && Number.isInteger(queue.projectNumber) && queue.projectNumber > 0) {
-        return { project: queue.projectNumber };
+  // Try bare .devloops and extension variants (.yaml, .yml, .json)
+  // to match the config loader's consumer override detection.
+  const basePath = path.join(cwd, ".devloops");
+  const extensions = ["", ".yaml", ".yml", ".json"];
+  for (const ext of extensions) {
+    try {
+      const settingsPath = basePath + ext;
+      const raw = readFileSync(settingsPath, "utf-8");
+      const settings = parseYaml(raw);
+      const queue = settings?.queue;
+      if (queue) {
+        if (typeof queue.projectNumber === "number" && Number.isInteger(queue.projectNumber) && queue.projectNumber > 0) {
+          return { project: queue.projectNumber };
+        }
+        if (typeof queue.boardTitle === "string" && queue.boardTitle.trim().length > 0) {
+          return { title: queue.boardTitle.trim() };
+        }
       }
-      if (typeof queue.boardTitle === "string" && queue.boardTitle.trim().length > 0) {
-        return { title: queue.boardTitle.trim() };
-      }
+      return null;
+    } catch {
+      // extension not present or unparseable — try next
     }
-  } catch {
-    // settings file missing or unparseable — no fallback
   }
   return null;
 }

--- a/test/projects/ensure-queue-board.test.mjs
+++ b/test/projects/ensure-queue-board.test.mjs
@@ -580,11 +580,10 @@ describe("ensure-queue-board", () => {
 
 
   describe("resolveSettings integration", () => {
-    it("returns project number from settings.yaml", () => {
+    it("returns project number from .devloops", () => {
       const tmp = mkdtempSync(path.join(import.meta.dirname || "/tmp", "settings-test-"));
       try {
-        mkdirSync(path.join(tmp, ".pi", "dev-loop"), { recursive: true });
-        writeFileSync(path.join(tmp, ".pi", "dev-loop", "settings.yaml"), [
+        writeFileSync(path.join(tmp, ".devloops"), [
           "version: 1",
           "queue:",
           "  projectNumber: 42",
@@ -599,8 +598,7 @@ describe("ensure-queue-board", () => {
     it("returns title from settings when projectNumber is absent", () => {
       const tmp = mkdtempSync(path.join(import.meta.dirname || "/tmp", "settings-test-"));
       try {
-        mkdirSync(path.join(tmp, ".pi", "dev-loop"), { recursive: true });
-        writeFileSync(path.join(tmp, ".pi", "dev-loop", "settings.yaml"), [
+        writeFileSync(path.join(tmp, ".devloops"), [
           "version: 1",
           "queue:",
           "  boardTitle: My Board",

--- a/test/projects/ensure-queue-board.test.mjs
+++ b/test/projects/ensure-queue-board.test.mjs
@@ -610,6 +610,37 @@ describe("ensure-queue-board", () => {
       }
     });
 
+    it("reads .devloops.json extension variant", () => {
+      const tmp = mkdtempSync(path.join(import.meta.dirname || "/tmp", "settings-test-"));
+      try {
+        writeFileSync(path.join(tmp, ".devloops.json"), JSON.stringify({
+          version: 1,
+          queue: {
+            projectNumber: 99,
+          },
+        }));
+        const result = resolveSettings(tmp);
+        assert.deepEqual(result, { project: 99 });
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it("reads .devloops.yml extension variant", () => {
+      const tmp = mkdtempSync(path.join(import.meta.dirname || "/tmp", "settings-test-"));
+      try {
+        writeFileSync(path.join(tmp, ".devloops.yml"), [
+          "version: 1",
+          "queue:",
+          "  boardTitle: From Yml",
+        ].join("\n"));
+        const result = resolveSettings(tmp);
+        assert.deepEqual(result, { title: "From Yml" });
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
     it("returns title from settings when projectNumber is absent", () => {
       const tmp = mkdtempSync(path.join(import.meta.dirname || "/tmp", "settings-test-"));
       try {

--- a/test/projects/ensure-queue-board.test.mjs
+++ b/test/projects/ensure-queue-board.test.mjs
@@ -595,6 +595,21 @@ describe("ensure-queue-board", () => {
       }
     });
 
+    it("reads .devloops.yaml extension variant", () => {
+      const tmp = mkdtempSync(path.join(import.meta.dirname || "/tmp", "settings-test-"));
+      try {
+        writeFileSync(path.join(tmp, ".devloops.yaml"), [
+          "version: 1",
+          "queue:",
+          "  boardTitle: From Yaml",
+        ].join("\n"));
+        const result = resolveSettings(tmp);
+        assert.deepEqual(result, { title: "From Yaml" });
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
     it("returns title from settings when projectNumber is absent", () => {
       const tmp = mkdtempSync(path.join(import.meta.dirname || "/tmp", "settings-test-"));
       try {


### PR DESCRIPTION
## Summary

Fix `scripts/projects/ensure-queue-board.mjs` to read queue configuration from `.devloops` at repo root instead of the deprecated `.pi/dev-loop/settings.yaml` path. This matches the contract in `docs/projects-queue-contract.md` which states queue board configuration lives under `.devloops`.

## Changes

- `scripts/projects/ensure-queue-board.mjs` line 145: change `path.join(cwd, ".pi", "dev-loop", "settings.yaml")` to `path.join(cwd, ".devloops")`
- `test/projects/ensure-queue-board.test.mjs`: update test fixtures to write to `.devloops` instead of `.pi/dev-loop/settings.yaml`, and remove `mkdirSync` calls for the old directory

## Validation

- `npm run verify` — all 115 projects tests pass
- 4 pre-existing failures in `request-copilot-review`/`upsert-checkpoint-verdict`/`detect-copilot-loop-state` tests (caused by `.devloops` setting `maxCopilotRounds: 2`, unrelated to this change)
- Pre-approval gate: all 12 angles clean

Closes #742
