### PR TITLE
fix: do not false-block on hidden failed head check-run (#740)

### DIFF
--- a/packages/core/src/loop/copilot-ci-status.mjs
+++ b/packages/core/src/loop/copilot-ci-status.mjs
@@ -93,7 +93,7 @@ export function normalizeStatusCheckRollupStatus(rollup) {
  * Summarize the GitHub check-runs API payload for one head SHA.
  *
  * @param {object} payload
- * @returns {{ status: "success"|"failure"|"pending"|"none", unsupportedCompleted: boolean }}
+ * @returns {{ status: "success"|"failure"|"pending"|"none", unsupportedCompleted: boolean, failureDetails?: Array<string> }}
  */
 export function summarizeHeadScopedCheckRunsSignal(payload) {
   const runs = Array.isArray(payload?.check_runs) ? payload.check_runs : [];
@@ -105,6 +105,7 @@ export function summarizeHeadScopedCheckRunsSignal(payload) {
   let hasFailure = false;
   let hasSuccess = false;
   let hasUnsupportedCompleted = false;
+  const failureDetails = [];
 
   for (const run of runs) {
     const status = typeof run?.status === "string" ? run.status.toUpperCase() : "";
@@ -117,6 +118,8 @@ export function summarizeHeadScopedCheckRunsSignal(payload) {
 
     if (FAILURE_CONCLUSIONS.has(conclusion)) {
       hasFailure = true;
+      const name = typeof run?.name === "string" ? run.name : "";
+      if (name) failureDetails.push(name);
       continue;
     }
 
@@ -128,11 +131,11 @@ export function summarizeHeadScopedCheckRunsSignal(payload) {
     hasUnsupportedCompleted = true;
   }
 
-  if (hasFailure) return { status: "failure", unsupportedCompleted: hasUnsupportedCompleted };
-  if (hasPending) return { status: "pending", unsupportedCompleted: hasUnsupportedCompleted };
-  if (hasUnsupportedCompleted) return { status: "none", unsupportedCompleted: true };
-  if (hasSuccess) return { status: "success", unsupportedCompleted: false };
-  return { status: "none", unsupportedCompleted: false };
+  if (hasFailure) return { status: "failure", unsupportedCompleted: hasUnsupportedCompleted, failureDetails };
+  if (hasPending) return { status: "pending", unsupportedCompleted: hasUnsupportedCompleted, failureDetails: failureDetails.length > 0 ? failureDetails : undefined };
+  if (hasUnsupportedCompleted) return { status: "none", unsupportedCompleted: true, failureDetails: failureDetails.length > 0 ? failureDetails : undefined };
+  if (hasSuccess) return { status: "success", unsupportedCompleted: false, failureDetails: failureDetails.length > 0 ? failureDetails : undefined };
+  return { status: "none", unsupportedCompleted: false, failureDetails: failureDetails.length > 0 ? failureDetails : undefined };
 }
 
 /**

--- a/packages/core/src/loop/copilot-loop-state.mjs
+++ b/packages/core/src/loop/copilot-loop-state.mjs
@@ -163,6 +163,8 @@ export function buildSnapshotFromPrFacts({
   copilotReviewRoundCount = 0,
   ciStatus,
   lastCopilotRoundMaxSignal = null,
+  failureDetails = [],
+  excludedFailureDetails = [],
 }) {
   const prState = typeof prData?.state === "string" ? prData.state.toUpperCase() : "OPEN";
   const prMerged = prState === "MERGED";
@@ -182,6 +184,8 @@ export function buildSnapshotFromPrFacts({
     copilotReviewRoundCount,
     lastCopilotRoundMaxSignal,
     ciStatus: ciStatus ?? normalizeCiStatus(prData?.statusCheckRollup),
+    failureDetails,
+    excludedFailureDetails,
   });
 }
 
@@ -257,6 +261,8 @@ export function normalizeSnapshot(raw) {
     ciStatus: VALID_CI_STATUSES.has(raw.ciStatus) ? raw.ciStatus : "none",
     lastCopilotRoundMaxSignal: VALID_SIGNAL_LEVELS.has(raw.lastCopilotRoundMaxSignal) ? raw.lastCopilotRoundMaxSignal : null,
     agentFixStatus: raw.agentFixStatus === "applied" ? "applied" : null,
+    failureDetails: Array.isArray(raw.failureDetails) ? raw.failureDetails : [],
+    excludedFailureDetails: Array.isArray(raw.excludedFailureDetails) ? raw.excludedFailureDetails : [],
   };
 }
 

--- a/packages/core/src/loop/copilot-loop-state.mjs
+++ b/packages/core/src/loop/copilot-loop-state.mjs
@@ -221,6 +221,8 @@ function isAutoRerequestEligible(snapshot, state) {
  * - ciStatus {"success"|"failure"|"pending"|"none"|"crediblyGreen"} — current CI check rollup status
  * - lastCopilotRoundMaxSignal {"high"|"mid"|"low"|null} — highest signal level across Copilot-authored threads
  * - agentFixStatus {"applied"|null} — agent-provided input: "applied" when code has been fixed
+ * - failureDetails {Array<string>} — names of failing visible check-runs from refreshed head-scoped CI evidence
+ * - excludedFailureDetails {Array<string>} — names of failing check-runs filtered out by PR-visibility intersection
  *
  * @param {object} raw - raw snapshot input
  * @returns {object} normalized snapshot

--- a/packages/core/test/copilot-ci-status.test.mjs
+++ b/packages/core/test/copilot-ci-status.test.mjs
@@ -162,3 +162,40 @@ test("normalizeHeadScopedCiContract emits blocked semantics for failure", () => 
   assert.equal(blocked.semantics.blocked, true);
   assert.equal(blocked.semantics.timeoutDisposition, "not_applicable");
 });
+
+test("summarizeHeadScopedCheckRunsSignal returns failureDetails for failed runs", () => {
+  const summary = summarizeHeadScopedCheckRunsSignal({
+    check_runs: [
+      { status: "COMPLETED", conclusion: "SUCCESS", name: "ci" },
+      { status: "COMPLETED", conclusion: "FAILURE", name: "copilot" },
+      { status: "COMPLETED", conclusion: "FAILURE", name: "lint" },
+    ],
+  });
+
+  assert.equal(summary.status, "failure");
+  assert.deepEqual(summary.failureDetails, ["copilot", "lint"]);
+});
+
+test("summarizeHeadScopedCheckRunsSignal omits empty names from failureDetails", () => {
+  const summary = summarizeHeadScopedCheckRunsSignal({
+    check_runs: [
+      { status: "COMPLETED", conclusion: "FAILURE" },
+      { status: "COMPLETED", conclusion: "FAILURE", name: "" },
+      { status: "COMPLETED", conclusion: "FAILURE", name: "lint" },
+    ],
+  });
+
+  assert.equal(summary.status, "failure");
+  assert.deepEqual(summary.failureDetails, ["lint"]);
+});
+
+test("summarizeHeadScopedCheckRunsSignal returns failureDetails undefined when no failures", () => {
+  const summary = summarizeHeadScopedCheckRunsSignal({
+    check_runs: [
+      { status: "COMPLETED", conclusion: "SUCCESS", name: "ci" },
+    ],
+  });
+
+  assert.equal(summary.status, "success");
+  assert.equal(summary.failureDetails, undefined);
+});

--- a/packages/core/test/copilot-loop-state.test.mjs
+++ b/packages/core/test/copilot-loop-state.test.mjs
@@ -39,6 +39,8 @@ test("normalizeSnapshot returns safe defaults for an empty object", () => {
     ciStatus: "none",
     lastCopilotRoundMaxSignal: null,
     agentFixStatus: null,
+    failureDetails: [],
+    excludedFailureDetails: [],
   });
 });
 

--- a/scripts/loop/detect-copilot-loop-state.mjs
+++ b/scripts/loop/detect-copilot-loop-state.mjs
@@ -207,7 +207,11 @@ async function fetchCurrentHeadCiEvidence({ repo, headSha, prVisibleCheckNames }
         // the cautious none override (#740).
         const visibleSignal = summarizeHeadScopedCheckRunsSignal({ check_runs: visibleRuns });
         const fullSignal = summarizeHeadScopedCheckRunsSignal(payload);
-        checkRunsSignal = { ...visibleSignal, unsupportedCompleted: fullSignal.unsupportedCompleted };
+        const excludedRuns = visibleSet
+          ? payload.check_runs.filter((run) => run.name && !visibleSet.has(run.name))
+          : [];
+        const excludedSignal = summarizeHeadScopedCheckRunsSignal({ check_runs: excludedRuns });
+        checkRunsSignal = { ...visibleSignal, unsupportedCompleted: fullSignal.unsupportedCompleted, excludedFailureDetails: excludedSignal.failureDetails ?? [] };
         checkRunsCount = payload.check_runs.length;
       }
     } catch {
@@ -240,6 +244,7 @@ async function fetchCurrentHeadCiEvidence({ repo, headSha, prVisibleCheckNames }
     }).overallStatus,
     observedZeroSuitesAndStatuses: checkRunsCount === 0 && statusesCount === 0,
     failureDetails: checkRunsSignal?.failureDetails ?? [],
+    excludedFailureDetails: checkRunsSignal?.excludedFailureDetails ?? [],
   };
 }
 function hasLocalValidationForCurrentHead(localValidationHeadSha, currentHeadSha) {
@@ -359,9 +364,13 @@ export async function autoDetectSnapshot({ repo, pr, reviewRequestStatusOverride
     );
   const prVisibleCheckNames = extractPrVisibleCheckNames(prData.statusCheckRollup);
   let currentHeadCiStatus = fallbackCiStatus;
+  let failureDetails = [];
+  let excludedFailureDetails = [];
   if (shouldRefreshCurrentHeadCi) {
     const refreshed = await fetchCurrentHeadCiEvidence({ repo, headSha: prHeadSha, prVisibleCheckNames }, { env, ghCommand });
     currentHeadCiStatus = refreshed?.status ?? "none";
+    failureDetails = refreshed?.failureDetails ?? [];
+    excludedFailureDetails = refreshed?.excludedFailureDetails ?? [];
     if (shouldPromoteCrediblyGreen({
       refreshedCurrentHeadCi: refreshed,
       fallbackCiStatus,
@@ -385,6 +394,8 @@ export async function autoDetectSnapshot({ repo, pr, reviewRequestStatusOverride
     copilotReviewRoundCount: reviewSummary.completedCopilotReviewRounds,
     lastCopilotRoundMaxSignal,
     ciStatus: currentHeadCiStatus,
+    failureDetails,
+    excludedFailureDetails,
   });
 }
 export async function runCli(

--- a/scripts/loop/detect-copilot-loop-state.mjs
+++ b/scripts/loop/detect-copilot-loop-state.mjs
@@ -172,7 +172,14 @@ async function fetchLatestCopilotReviewRequestAt({ repo, pr }, { env, ghCommand 
   }
   return latestAt;
 }
-async function fetchCurrentHeadCiEvidence({ repo, headSha }, { env, ghCommand }) {
+function extractPrVisibleCheckNames(statusCheckRollup) {
+  if (!Array.isArray(statusCheckRollup)) return [];
+  return statusCheckRollup
+    .map((entry) => entry?.name || entry?.context)
+    .filter((name) => typeof name === "string" && name.length > 0);
+}
+
+async function fetchCurrentHeadCiEvidence({ repo, headSha, prVisibleCheckNames }, { env, ghCommand }) {
   const [checkRunsResult, statusesResult] = await Promise.all([
     runChild(
       ghCommand,
@@ -191,7 +198,16 @@ async function fetchCurrentHeadCiEvidence({ repo, headSha }, { env, ghCommand })
     try {
       const payload = JSON.parse(checkRunsResult.stdout);
       if (Array.isArray(payload?.check_runs)) {
-        checkRunsSignal = summarizeHeadScopedCheckRunsSignal(payload);
+        const visibleSet = prVisibleCheckNames?.length > 0 ? new Set(prVisibleCheckNames) : null;
+        const visibleRuns = visibleSet
+          ? payload.check_runs.filter((run) => !run.name || visibleSet.has(run.name))
+          : payload.check_runs;
+        // Use visible runs for the status signal, but preserve the full-set
+        // unsupportedCompleted flag so hidden check-runs still contribute to
+        // the cautious none override (#740).
+        const visibleSignal = summarizeHeadScopedCheckRunsSignal({ check_runs: visibleRuns });
+        const fullSignal = summarizeHeadScopedCheckRunsSignal(payload);
+        checkRunsSignal = { ...visibleSignal, unsupportedCompleted: fullSignal.unsupportedCompleted };
         checkRunsCount = payload.check_runs.length;
       }
     } catch {
@@ -223,6 +239,7 @@ async function fetchCurrentHeadCiEvidence({ repo, headSha }, { env, ghCommand })
       checkRunsUnsupportedCompleted: checkRunsSignal?.unsupportedCompleted ?? false,
     }).overallStatus,
     observedZeroSuitesAndStatuses: checkRunsCount === 0 && statusesCount === 0,
+    failureDetails: checkRunsSignal?.failureDetails ?? [],
   };
 }
 function hasLocalValidationForCurrentHead(localValidationHeadSha, currentHeadSha) {
@@ -340,9 +357,10 @@ export async function autoDetectSnapshot({ repo, pr, reviewRequestStatusOverride
         && hasLocalValidationForCurrentHead(localValidationHeadSha, prHeadSha)
       )
     );
+  const prVisibleCheckNames = extractPrVisibleCheckNames(prData.statusCheckRollup);
   let currentHeadCiStatus = fallbackCiStatus;
   if (shouldRefreshCurrentHeadCi) {
-    const refreshed = await fetchCurrentHeadCiEvidence({ repo, headSha: prHeadSha }, { env, ghCommand });
+    const refreshed = await fetchCurrentHeadCiEvidence({ repo, headSha: prHeadSha, prVisibleCheckNames }, { env, ghCommand });
     currentHeadCiStatus = refreshed?.status ?? "none";
     if (shouldPromoteCrediblyGreen({
       refreshedCurrentHeadCi: refreshed,

--- a/test/loop/detect-copilot-loop-state-auto-detect.test.mjs
+++ b/test/loop/detect-copilot-loop-state-auto-detect.test.mjs
@@ -614,7 +614,7 @@ test.skip("detect-copilot-loop-state keeps pending and failure current-head CI a
     },
     {
       name: "failure",
-      checkRuns: '{"check_runs":[{"status":"COMPLETED","conclusion":"FAILURE"}]}\n',
+      checkRuns: '{"check_runs":[{"status":"COMPLETED","conclusion":"FAILURE","name":"ci-old-head"}]}\n',
       statuses: '{"statuses":[]}\n',
       expectedCiStatus: "failure",
       expectedState: "blocked_needs_user_decision",
@@ -906,7 +906,7 @@ test("detect-copilot-loop-state fails closed from old-head green to new-head fai
       },
       {
         assertArgs: ["api", "repos/owner/repo/commits/newsha/check-runs?per_page=100"],
-        stdout: '{"check_runs":[{"status":"COMPLETED","conclusion":"FAILURE"}]}\n',
+        stdout: '{"check_runs":[{"status":"COMPLETED","conclusion":"FAILURE","name":"ci-old-head"}]}\n',
       },
       {
         assertArgs: ["api", "repos/owner/repo/commits/newsha/status?per_page=100"],
@@ -969,7 +969,7 @@ test("detect-copilot-loop-state uses head-scoped check-runs when commit status r
       },
       {
         assertArgs: ["api", "repos/owner/repo/commits/newsha/check-runs?per_page=100"],
-        stdout: '{"check_runs":[{"status":"COMPLETED","conclusion":"FAILURE"}]}\n',
+        stdout: '{"check_runs":[{"status":"COMPLETED","conclusion":"FAILURE","name":"ci-old-head"}]}\n',
       },
       {
         assertArgs: ["api", "repos/owner/repo/commits/newsha/status?per_page=100"],
@@ -1243,7 +1243,7 @@ test("detect-copilot-loop-state treats mixed head-scoped failure-plus-pending ch
       },
       {
         assertArgs: ["api", "repos/owner/repo/commits/newsha/check-runs?per_page=100"],
-        stdout: '{"check_runs":[{"status":"IN_PROGRESS","conclusion":null},{"status":"COMPLETED","conclusion":"FAILURE"}]}\n',
+        stdout: '{"check_runs":[{"status":"IN_PROGRESS","conclusion":null},{"status":"COMPLETED","conclusion":"FAILURE","name":"ci-old-head"}]}\n',
       },
       {
         assertArgs: ["api", "repos/owner/repo/commits/newsha/status?per_page=100"],
@@ -1441,6 +1441,74 @@ test.skip("detect-copilot-loop-state allows clean convergence once current-head 
     assert.equal(output.sameHeadCleanConverged, true);
     assert.equal(output.loopDisposition, "clean_converged");
     assert.equal(output.terminal, true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-copilot-loop-state does not false-block on hidden failed head check-run (#740)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-740-"));
+
+  try {
+    const emptyThreads = JSON.stringify({
+      data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } },
+    });
+
+    const { env } = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: JSON.stringify({
+          isDraft: false,
+          state: "OPEN",
+          number: 17,
+          headRefOid: "newsha",
+          reviews: [
+            {
+              id: "r-old-submitted",
+              author: { login: "copilot-pull-request-reviewer[bot]" },
+              state: "CHANGES_REQUESTED",
+              commit: { oid: "oldsha" },
+            },
+          ],
+          statusCheckRollup: [
+            { status: "COMPLETED", conclusion: "SUCCESS", name: "ci" },
+          ],
+        }) + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: emptyThreads + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/commits/newsha/check-runs?per_page=100"],
+        stdout: JSON.stringify({
+          check_runs: [
+            { status: "COMPLETED", conclusion: "SUCCESS", name: "ci" },
+            { status: "COMPLETED", conclusion: "FAILURE", name: "copilot" },
+          ],
+        }) + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/commits/newsha/status?per_page=100"],
+        stdout: '{"statuses":[]}\n',
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0, `stderr: ${result.stderr}`);
+
+    const output = JSON.parse(result.stdout);
+    // PR-visible rollup is success, so hidden head-scoped failure must not downgrade.
+    assert.notEqual(output.snapshot.ciStatus, "failure");
+    assert.notEqual(output.state, "blocked_needs_user_decision");
+    // Should stay waiting for CI since the hidden failure is ignored and actual visible CI is success
+    assert.equal(output.snapshot.ciStatus, "success");
+    assert.equal(output.snapshot.copilotReviewOnCurrentHead, false);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/detect-copilot-loop-state-auto-detect.test.mjs
+++ b/test/loop/detect-copilot-loop-state-auto-detect.test.mjs
@@ -263,6 +263,7 @@ test("detect-copilot-loop-state fails closed from old-head green to new-head pen
     assert.equal(output.state, "waiting_for_ci");
     assert.equal(output.snapshot.ciStatus, "pending");
     assert.equal(output.snapshot.copilotReviewOnCurrentHead, false);
+    assert.deepEqual(output.snapshot.excludedFailureDetails, ["copilot"]);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -1506,7 +1507,7 @@ test("detect-copilot-loop-state does not false-block on hidden failed head check
     // PR-visible rollup is success, so hidden head-scoped failure must not downgrade.
     assert.notEqual(output.snapshot.ciStatus, "failure");
     assert.notEqual(output.state, "blocked_needs_user_decision");
-    // Should stay waiting for CI since the hidden failure is ignored and actual visible CI is success
+    // Hidden failure correctly ignored; visible CI is success so no false block
     assert.equal(output.snapshot.ciStatus, "success");
     assert.equal(output.snapshot.copilotReviewOnCurrentHead, false);
   } finally {

--- a/test/loop/detect-copilot-loop-state-auto-detect.test.mjs
+++ b/test/loop/detect-copilot-loop-state-auto-detect.test.mjs
@@ -922,6 +922,7 @@ test("detect-copilot-loop-state fails closed from old-head green to new-head fai
     assert.equal(output.state, "blocked_needs_user_decision");
     assert.equal(output.snapshot.ciStatus, "failure");
     assert.equal(output.snapshot.copilotReviewOnCurrentHead, false);
+    assert.deepEqual(output.snapshot.failureDetails, ["ci-old-head"]);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -1510,6 +1511,141 @@ test("detect-copilot-loop-state does not false-block on hidden failed head check
     assert.equal(output.snapshot.ciStatus, "success");
     assert.equal(output.snapshot.copilotReviewOnCurrentHead, false);
     assert.deepEqual(output.snapshot.excludedFailureDetails, ["copilot"]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-copilot-loop-state downgrades visible success to none when hidden check-run is unsupported completed (#740)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-740-unsupported-completed-"));
+
+  try {
+    const emptyThreads = JSON.stringify({
+      data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } },
+    });
+
+    const { env } = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: JSON.stringify({
+          isDraft: false,
+          state: "OPEN",
+          number: 17,
+          headRefOid: "newsha",
+          reviews: [
+            {
+              id: "r-old-submitted",
+              author: { login: "copilot-pull-request-reviewer[bot]" },
+              state: "CHANGES_REQUESTED",
+              commit: { oid: "oldsha" },
+            },
+          ],
+          statusCheckRollup: [
+            { status: "COMPLETED", conclusion: "SUCCESS", name: "ci" },
+          ],
+        }) + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: emptyThreads + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/commits/newsha/check-runs?per_page=100"],
+        stdout: JSON.stringify({
+          check_runs: [
+            { status: "COMPLETED", conclusion: "SUCCESS", name: "ci" },
+            { status: "COMPLETED", conclusion: "CANCELLED", name: "ops" },
+          ],
+        }) + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/commits/newsha/status?per_page=100"],
+        stdout: '{"statuses":[]}\n',
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0, `stderr: ${result.stderr}`);
+
+    const output = JSON.parse(result.stdout);
+    // Hidden unsupported-completed check forces downgrade from success to none.
+    assert.equal(output.snapshot.ciStatus, "none");
+    assert.equal(output.state, "waiting_for_ci");
+    assert.equal(output.snapshot.copilotReviewOnCurrentHead, false);
+    assert.deepEqual(output.snapshot.excludedFailureDetails, []);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-copilot-loop-state preserves success when multiple hidden checks fail (#740)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-740-multi-hidden-failures-"));
+
+  try {
+    const emptyThreads = JSON.stringify({
+      data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } },
+    });
+
+    const { env } = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: JSON.stringify({
+          isDraft: false,
+          state: "OPEN",
+          number: 17,
+          headRefOid: "newsha",
+          reviews: [
+            {
+              id: "r-old-submitted",
+              author: { login: "copilot-pull-request-reviewer[bot]" },
+              state: "CHANGES_REQUESTED",
+              commit: { oid: "oldsha" },
+            },
+          ],
+          statusCheckRollup: [
+            { status: "COMPLETED", conclusion: "SUCCESS", name: "ci" },
+          ],
+        }) + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: emptyThreads + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/commits/newsha/check-runs?per_page=100"],
+        stdout: JSON.stringify({
+          check_runs: [
+            { status: "COMPLETED", conclusion: "SUCCESS", name: "ci" },
+            { status: "COMPLETED", conclusion: "FAILURE", name: "copilot" },
+            { status: "COMPLETED", conclusion: "FAILURE", name: "lint" },
+          ],
+        }) + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/commits/newsha/status?per_page=100"],
+        stdout: '{"statuses":[]}\n',
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0, `stderr: ${result.stderr}`);
+
+    const output = JSON.parse(result.stdout);
+    // PR-visible rollup is success, so multiple hidden head-scoped failures must not downgrade.
+    assert.equal(output.snapshot.ciStatus, "success");
+    assert.equal(output.state, "ready_to_rerequest_review");
+    assert.equal(output.snapshot.copilotReviewOnCurrentHead, false);
+    assert.deepEqual(output.snapshot.excludedFailureDetails, ["copilot", "lint"]);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/detect-copilot-loop-state-auto-detect.test.mjs
+++ b/test/loop/detect-copilot-loop-state-auto-detect.test.mjs
@@ -263,7 +263,6 @@ test("detect-copilot-loop-state fails closed from old-head green to new-head pen
     assert.equal(output.state, "waiting_for_ci");
     assert.equal(output.snapshot.ciStatus, "pending");
     assert.equal(output.snapshot.copilotReviewOnCurrentHead, false);
-    assert.deepEqual(output.snapshot.excludedFailureDetails, ["copilot"]);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -1510,6 +1509,7 @@ test("detect-copilot-loop-state does not false-block on hidden failed head check
     // Hidden failure correctly ignored; visible CI is success so no false block
     assert.equal(output.snapshot.ciStatus, "success");
     assert.equal(output.snapshot.copilotReviewOnCurrentHead, false);
+    assert.deepEqual(output.snapshot.excludedFailureDetails, ["copilot"]);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
fix: do not false-block on hidden failed head check-run (#740)

## Summary
Fixes a bug where `detect-copilot-loop-state` reports `ciStatus: "failure"` even when the PR-visible checks surface (`gh pr checks` / `statusCheckRollup`) is green. The false-blocker was a failed non-PR-visible check-run (in the reported case, a `copilot` automation run from GitHub Actions) present on the head SHA via the commit-scoped check-runs API.

## Changes
- `packages/core/src/loop/copilot-ci-status.mjs`: `summarizeHeadScopedCheckRunsSignal` now returns `failureDetails` with names of failed check-runs.
- `scripts/loop/detect-copilot-loop-state.mjs`: 
  - `fetchCurrentHeadCiEvidence` intersects head-scoped check-runs with PR-visible check names extracted from `statusCheckRollup`.
  - Named check-runs not in the PR-visible set are filtered out.
  - Nameless check-runs are preserved for backward compatibility.
  - The full-set `unsupportedCompleted` flag is still preserved for the cautious `none` override.
  - `failureDetails` propagated for debug/logging.
- `packages/core/test/copilot-ci-status.test.mjs`: unit tests for `failureDetails`.
- `test/loop/detect-copilot-loop-state-auto-detect.test.mjs`: regression test for the hidden-failure scenario.

## Validation
- `npm run verify` passes (1433 tests).

## Associated issue
Closes #740
