### PR TITLE
feat: expose Projects queue CLI wrappers

### DIFF
--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -46,8 +46,14 @@ const SUBCOMMAND_ROUTES = {
     "ready-for-review": "scripts/github/ready-for-review.mjs",
     "reconcile-draft":  "scripts/github/reconcile-draft-gate.mjs",
   },
+  project: {
+    list:    "scripts/projects/list-queue-items.mjs",
+    add:     "scripts/projects/add-queue-item.mjs",
+    move:    "scripts/projects/move-queue-item.mjs",
+    reorder: "scripts/projects/reorder-queue-item.mjs",
+    ensure:  "scripts/projects/ensure-queue-board.mjs",
+  },
   queue: {
-    
     run:            "scripts/loop/run-queue.mjs",
   },
   inspect: {
@@ -60,6 +66,55 @@ const SUBCOMMAND_ROUTES = {
 };
 
 const TOP_LEVEL_COMMANDS = new Set(["help", "status", "doctor", "gates", "hide"]);
+
+const SUBCOMMAND_DESCRIPTIONS = {
+  gate: {
+    "upsert-verdict": "Post/update gate review comment",
+    "detect-evidence": "Check merge preconditions",
+    "write-findings-log": "Write disposition ledger",
+    "request-copilot": "Request Copilot review",
+    "probe-copilot": "Poll for Copilot review activity",
+    "capture-threads": "Capture review threads",
+    "reply-resolve": "Reply and resolve review threads",
+  },
+  loop: {
+    startup: "Resolve dev-loop startup bundle",
+    "build-envelope": "Build handoff envelope from startup output",
+    outer: "Run outer-loop detection",
+    "watch-cycle": "Run Copilot wait cycle",
+    handoff: "Copilot PR handoff",
+    "watch-initial": "Watch initial Copilot PR",
+    "loop-state": "Detect Copilot loop state",
+    "reviewer-state": "Detect reviewer loop state",
+    "gate-coordination": "Detect PR gate coordination state",
+    "linked-issue-pr": "Detect linked issue ↔ PR",
+    "issue-refinement": "Detect issue refinement artifact",
+    info: "Show read-only issue/PR state summary",
+    "debt-remediate": "File debt remediation issues",
+  },
+  pr: {
+    "create-draft": "Create draft PR",
+    "ready-for-review": "Mark PR ready for review",
+    "reconcile-draft": "Reconcile non-draft PR",
+  },
+  project: {
+    list: "List queue board items",
+    add: "Add issue/PR to queue board",
+    move: "Move queue item between Status columns",
+    reorder: "Reorder queue board items",
+    ensure: "Create/repair queue board bootstrap surface",
+  },
+  queue: {
+    run: "Run queue driver",
+  },
+  inspect: {
+    run: "Inspect run state",
+    viewer: "Start inspection viewer",
+  },
+  refine: {
+    verify: "Verify epic tree refinement integrity",
+  },
+};
 
 const CLI_SETUP_GUIDANCE = {
   "gh-installed": "Install GitHub CLI to enable remote GitHub/Copilot workflows.",
@@ -102,7 +157,16 @@ async function commandExists(
 function buildCategoryHelp(category) {
   const routes = SUBCOMMAND_ROUTES[category];
   if (!routes) return [`Unknown category: ${category}`];
-  return [`dev-loops ${category} <subcommand> [...]`, "", "Available subcommands:", ...Object.keys(routes).map((s) => `  ${s}`)];
+  const descriptions = SUBCOMMAND_DESCRIPTIONS[category] ?? {};
+  return [
+    `dev-loops ${category} <subcommand> [...]`,
+    "",
+    "Available subcommands:",
+    ...Object.keys(routes).map((s) => {
+      const description = descriptions[s];
+      return description ? `  ${s.padEnd(16)} ${description}` : `  ${s}`;
+    }),
+  ];
 }
 
 function buildCliHelpLines() {
@@ -144,6 +208,12 @@ function buildCliHelpLines() {
     "    create-draft      Create draft PR",
     "    ready-for-review  Mark PR ready for review",
     "    reconcile-draft   Reconcile non-draft PR",
+    "- dev-loops project <sub> [...]    GitHub Projects queue helpers",
+    "    list              List queue board items",
+    "    add               Add issue/PR to queue board",
+    "    move              Move queue item between Status columns",
+    "    reorder           Reorder queue board items",
+    "    ensure            Create/repair queue board bootstrap surface",
     "- dev-loops inspect <sub> [...]    Inspection (Pi extension only)",
     "    run               Inspect run state",
     "    viewer            Start inspection viewer",

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -67,6 +67,17 @@ const SUBCOMMAND_ROUTES = {
 
 const TOP_LEVEL_COMMANDS = new Set(["help", "status", "doctor", "gates", "hide"]);
 
+const HELP_CATEGORY_LABELS = {
+  gate: "Gate verdicts, evidence, and review operations",
+  loop: "Loop lifecycle",
+  pr: "PR helpers",
+  project: "GitHub Projects queue helpers",
+  inspect: "Inspection (Pi extension only)",
+  refine: "Epic tree refinement verification",
+};
+
+const TOP_LEVEL_HELP_CATEGORY_ORDER = ["gate", "loop", "pr", "project", "inspect", "refine"];
+
 const SUBCOMMAND_DESCRIPTIONS = {
   gate: {
     "upsert-verdict": "Post/update gate review comment",
@@ -154,18 +165,27 @@ async function commandExists(
   return false;
 }
 
+function buildSubcommandLines(category, { includeHeader = false } = {}) {
+  const routes = SUBCOMMAND_ROUTES[category];
+  if (!routes) return [];
+  const descriptions = SUBCOMMAND_DESCRIPTIONS[category] ?? {};
+  const lines = Object.keys(routes).map((subcommand) => {
+    const description = descriptions[subcommand];
+    return description ? `    ${subcommand.padEnd(16)} ${description}` : `    ${subcommand}`;
+  });
+  if (!includeHeader) return lines;
+  const label = HELP_CATEGORY_LABELS[category] ?? `${category} helpers`;
+  return [`- dev-loops ${category} <sub> [...]    ${label}`, ...lines];
+}
+
 function buildCategoryHelp(category) {
   const routes = SUBCOMMAND_ROUTES[category];
   if (!routes) return [`Unknown category: ${category}`];
-  const descriptions = SUBCOMMAND_DESCRIPTIONS[category] ?? {};
   return [
     `dev-loops ${category} <subcommand> [...]`,
     "",
     "Available subcommands:",
-    ...Object.keys(routes).map((s) => {
-      const description = descriptions[s];
-      return description ? `  ${s.padEnd(16)} ${description}` : `  ${s}`;
-    }),
+    ...buildSubcommandLines(category),
   ];
 }
 
@@ -183,42 +203,7 @@ function buildCliHelpLines() {
     "- dev-loops gates                  Print gate state",
     "",
     "Subcommands:",
-    "- dev-loops gate <sub> [...]       Gate verdicts, evidence, and review operations",
-    "    upsert-verdict    Post/update gate review comment",
-    "    detect-evidence   Check merge preconditions",
-    "    write-findings-log Write disposition ledger",
-    "    request-copilot   Request Copilot review",
-    "    probe-copilot     Poll for Copilot review activity",
-    "    capture-threads   Capture review threads",
-    "    reply-resolve     Reply and resolve review threads",
-    "- dev-loops loop <sub> [...]       Loop lifecycle",
-    "    startup           Resolve dev-loop startup bundle",
-    "    build-envelope    Build handoff envelope from startup output",
-    "    outer             Run outer-loop detection",
-    "    watch-cycle       Run Copilot wait cycle",
-    "    handoff           Copilot PR handoff",
-    "    watch-initial     Watch initial Copilot PR",
-    "    loop-state        Detect Copilot loop state",
-    "    reviewer-state    Detect reviewer loop state",
-    "    gate-coordination Detect PR gate coordination state",
-    "    linked-issue-pr   Detect linked issue ↔ PR",
-    "    issue-refinement  Detect issue refinement artifact",
-    "    info              Show read-only issue/PR state summary",
-    "- dev-loops pr <sub> [...]         PR helpers",
-    "    create-draft      Create draft PR",
-    "    ready-for-review  Mark PR ready for review",
-    "    reconcile-draft   Reconcile non-draft PR",
-    "- dev-loops project <sub> [...]    GitHub Projects queue helpers",
-    "    list              List queue board items",
-    "    add               Add issue/PR to queue board",
-    "    move              Move queue item between Status columns",
-    "    reorder           Reorder queue board items",
-    "    ensure            Create/repair queue board bootstrap surface",
-    "- dev-loops inspect <sub> [...]    Inspection (Pi extension only)",
-    "    run               Inspect run state",
-    "    viewer            Start inspection viewer",
-    "- dev-loops refine <sub> [...]     Epic tree refinement verification",
-    "    verify            Verify tree linkage, scope boundaries, completeness, and integrity",
+    ...TOP_LEVEL_HELP_CATEGORY_ORDER.flatMap((category) => buildSubcommandLines(category, { includeHeader: true })),
     "",
     "Use `dev-loops <category> <subcommand> --help` for per-subcommand usage.",
     "",

--- a/docs/projects-queue-contract.md
+++ b/docs/projects-queue-contract.md
@@ -26,7 +26,7 @@ fall back to positional argument ordering when no board is configured. Setting u
 a one-time operator action, not a startup requirement.
 
 Tooling never mutates project/field structure without explicit operator invocation of the
-bootstrap wrapper (`node scripts/projects/ensure-queue-board.mjs`). Runtime queue operations only read/write item
+bootstrap wrapper (`dev-loops project ensure`). Runtime queue operations only read/write item
 position and Status field values.
 
 ## Board identification
@@ -180,7 +180,7 @@ board validates preconditions first:
 
 ### Idempotent bootstrap exception
 
-The `node scripts/projects/ensure-queue-board.mjs` bootstrap wrapper has relaxed fail-closed behavior: it
+The `dev-loops project ensure` bootstrap wrapper has relaxed fail-closed behavior: it
 **creates** a missing project and/or Status field with conventional columns. This is the only
 tool allowed to mutate project structure. Runtime queue helpers (list, move, add, reorder)
 never create or modify project/field structure.
@@ -203,7 +203,7 @@ stderr output.
 
 ## Column auto-repair
 
-The bootstrap wrapper (`node scripts/projects/ensure-queue-board.mjs`) performs automatic column repair
+The bootstrap wrapper (`dev-loops project ensure`) performs automatic column repair
 when the Status field exists but has non-standard columns. Instead of throwing, it calls
 `updateProjectV2Field` to add missing standard columns (`Backlog`, `Next Up`, `In Progress`,
 `Done`). Non-standard columns are left in place — only missing columns are added.

--- a/docs/projects-queue-usage.md
+++ b/docs/projects-queue-usage.md
@@ -28,7 +28,7 @@ No configuration file entry is required — helpers use explicit CLI arguments.
 First, bootstrap the board (one-time):
 
 ```sh
-node scripts/projects/ensure-queue-board.mjs --repo <owner/name>
+dev-loops project ensure --repo <owner/name>
 ```
 
 The wrapper emits the project number and URL. Use the project number in subsequent
@@ -43,56 +43,56 @@ stdout and structured errors on stderr. All accept `--help` for usage.
 
 ```sh
 # List all items in a project
-node scripts/projects/list-queue-items.mjs --repo mfittko/pi-dev-loops --project 1
+dev-loops project list --repo mfittko/pi-dev-loops --project 1
 
 # List only items in "Next Up" column
-node scripts/projects/list-queue-items.mjs --repo mfittko/pi-dev-loops --project 1 --column "Next Up"
+dev-loops project list --repo mfittko/pi-dev-loops --project 1 --column "Next Up"
 
 # Limit to top 5 items
-node scripts/projects/list-queue-items.mjs --repo mfittko/pi-dev-loops --project 1 --limit 5
+dev-loops project list --repo mfittko/pi-dev-loops --project 1 --limit 5
 ```
 
 ### Add an item to the queue
 
 ```sh
 # Add issue #42 to the Backlog column (default)
-node scripts/projects/add-queue-item.mjs --repo mfittko/pi-dev-loops --project 1 --item 42
+dev-loops project add --repo mfittko/pi-dev-loops --project 1 --item 42
 
 # Add issue #42 to a specific column
-node scripts/projects/add-queue-item.mjs --repo mfittko/pi-dev-loops --project 1 --item 42 --status "Next Up"
+dev-loops project add --repo mfittko/pi-dev-loops --project 1 --item 42 --status "Next Up"
 ```
 
 ### Move an item between columns
 
 ```sh
 # Move issue #42 from its current column to In Progress
-node scripts/projects/move-queue-item.mjs --repo mfittko/pi-dev-loops --project 1 --item 42 --to-column "In Progress"
+dev-loops project move --repo mfittko/pi-dev-loops --project 1 --item 42 --to-column "In Progress"
 
 # Move a project item by its node ID
-node scripts/projects/move-queue-item.mjs --repo mfittko/pi-dev-loops --project 1 --item "PVTI_..." --to-column "Done"
+dev-loops project move --repo mfittko/pi-dev-loops --project 1 --item "PVTI_..." --to-column "Done"
 ```
 
 ### Reorder items
 
 ```sh
 # Move issue #42 to the top of the column
-node scripts/projects/reorder-queue-item.mjs --repo mfittko/pi-dev-loops --project 1 --item 42
+dev-loops project reorder --repo mfittko/pi-dev-loops --project 1 --item 42
 
 # Move issue #42 after issue #17
-node scripts/projects/reorder-queue-item.mjs --repo mfittko/pi-dev-loops --project 1 --item 42 --after 17
+dev-loops project reorder --repo mfittko/pi-dev-loops --project 1 --item 42 --after 17
 
 # Reorder by project item node IDs
-node scripts/projects/reorder-queue-item.mjs --repo mfittko/pi-dev-loops --project 1 --item "PVTI_abc" --after "PVTI_xyz"
+dev-loops project reorder --repo mfittko/pi-dev-loops --project 1 --item "PVTI_abc" --after "PVTI_xyz"
 ```
 
 ### Typical workflow
 
-1. Bootstrap the board once: `node scripts/projects/ensure-queue-board.mjs --repo <owner/name>`
-2. Add items as they are queued: `node scripts/projects/add-queue-item.mjs --repo ... --project <n> --item <issue>`
-3. Reorder by priority: drag in the GitHub UI, or use `reorder-queue-item.mjs`
-4. When a worker picks up an item: `node scripts/projects/move-queue-item.mjs ... --to-column "In Progress"`
-5. When done: `node scripts/projects/move-queue-item.mjs ... --to-column "Done"`
-6. Inspect the queue at any time: `node scripts/projects/list-queue-items.mjs ...`
+1. Bootstrap the board once: `dev-loops project ensure --repo <owner/name>`
+2. Add items as they are queued: `dev-loops project add --repo ... --project <n> --item <issue>`
+3. Reorder by priority: drag in the GitHub UI, or use `dev-loops project reorder`
+4. When a worker picks up an item: `dev-loops project move ... --to-column "In Progress"`
+5. When done: `dev-loops project move ... --to-column "Done"`
+6. Inspect the queue at any time: `dev-loops project list ...`
 
 ## Fail-closed behavior
 
@@ -123,7 +123,7 @@ Exit codes:
 
 ### Idempotent bootstrap exception
 
-The `ensure-queue-board.mjs` bootstrap wrapper is the only helper allowed to **create**
+The `dev-loops project ensure` bootstrap wrapper is the only helper allowed to **create**
 project structure. It safely re-runs: if the board and Status field already exist, it exits
 clean with the existing project details. Runtime helpers (list, move, add, reorder) never
 create or modify project/field structure.

--- a/docs/queue-board-setup.md
+++ b/docs/queue-board-setup.md
@@ -17,7 +17,7 @@ The board provides durable, visible, shared state for queue ordering and item st
 Run the idempotent bootstrap wrapper:
 
 ```sh
-node scripts/projects/ensure-queue-board.mjs --repo mfittko/pi-dev-loops
+dev-loops project ensure --repo mfittko/pi-dev-loops
 ```
 
 This creates a project named "Dev Loop Queue" (default) under the `mfittko` user:
@@ -40,7 +40,7 @@ Safe to re-run — exits clean if the board already exists.
 #### Custom title
 
 ```sh
-node scripts/projects/ensure-queue-board.mjs --repo mfittko/pi-dev-loops --title "My Queue"
+dev-loops project ensure --repo mfittko/pi-dev-loops --title "My Queue"
 ```
 
 ### 2. Verify the Status field
@@ -80,7 +80,7 @@ Dev-loop queue wrappers will:
 - **Reorder** items when the operator adjusts priority via `--after` dependencies or manual intervention
 - **Fall back** gracefully when the board is absent: positional argument order takes over, and no board mutations are attempted
 
-Helper commands for these operations will be added in future PRs alongside the bootstrap wrapper.
+Use `dev-loops project --help` to inspect the queue helper surface and per-subcommand `--help` for details.
 
 ### Fail-closed behavior
 

--- a/scripts/projects/add-queue-item.mjs
+++ b/scripts/projects/add-queue-item.mjs
@@ -2,7 +2,7 @@
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
 
-const USAGE = `Usage: node scripts/projects/add-queue-item.mjs --repo <owner/name> --project <number|id> --item <number>
+const USAGE = `Usage: dev-loops project add --repo <owner/name> --project <number|id> --item <number>
 
 Add an existing issue or PR to a GitHub Projects V2 board.
 

--- a/scripts/projects/ensure-queue-board.mjs
+++ b/scripts/projects/ensure-queue-board.mjs
@@ -5,7 +5,7 @@ import { parse as parseYaml } from "yaml";
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
 
-const USAGE = `Usage: node scripts/projects/ensure-queue-board.mjs --repo <owner/name> [--project <number>] [--title <title>] [--link-repo <owner/name>]
+const USAGE = `Usage: dev-loops project ensure --repo <owner/name> [--project <number>] [--title <title>] [--link-repo <owner/name>]
 
 Idempotent bootstrap for a GitHub Projects V2 board used as the dev-loop queue.
 

--- a/scripts/projects/list-queue-items.mjs
+++ b/scripts/projects/list-queue-items.mjs
@@ -2,7 +2,7 @@
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
 
-const USAGE = `Usage: node scripts/projects/list-queue-items.mjs --repo <owner/name> --project <number|id> [--column <name>] [--limit <n>]
+const USAGE = `Usage: dev-loops project list --repo <owner/name> --project <number|id> [--column <name>] [--limit <n>]
 
 List GitHub Projects V2 items filtered by Status column, ordered by position
 ascending. Returns machine-readable JSON.

--- a/scripts/projects/move-queue-item.mjs
+++ b/scripts/projects/move-queue-item.mjs
@@ -2,7 +2,7 @@
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
 
-const USAGE = `Usage: node scripts/projects/move-queue-item.mjs --repo <owner/name> --project <number|id> --item <number|node-id> --to-column <name>
+const USAGE = `Usage: dev-loops project move --repo <owner/name> --project <number|id> --item <number|node-id> --to-column <name>
 
 Move a GitHub Projects V2 item between Status columns.
 

--- a/scripts/projects/reorder-queue-item.mjs
+++ b/scripts/projects/reorder-queue-item.mjs
@@ -2,7 +2,7 @@
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
 
-const USAGE = `Usage: node scripts/projects/reorder-queue-item.mjs --repo <owner/name> --project <number|id> --item <number|node-id> [--after <number|node-id>]
+const USAGE = `Usage: dev-loops project reorder --repo <owner/name> --project <number|id> --item <number|node-id> [--after <number|node-id>]
 
 Reorder a GitHub Projects V2 item by board position via updateProjectV2ItemPosition.
 Moves item to top when no --after is provided, or after the specified item.

--- a/test/dev-loops-cli.test.mjs
+++ b/test/dev-loops-cli.test.mjs
@@ -130,6 +130,39 @@ test("CLI help leads with dev-loop as the primary workflow entry", async () => {
   assert.equal(helpStderr.read(), "");
 });
 
+
+test("CLI help exposes project queue wrapper surface", async () => {
+  const helpStdout = createBufferStream();
+  const helpStderr = createBufferStream();
+  const categoryStdout = createBufferStream();
+  const categoryStderr = createBufferStream();
+
+  const helpExitCode = await runCli({
+    argv: ["help"],
+    runtime: createRuntime(),
+    stdout: helpStdout.stream,
+    stderr: helpStderr.stream,
+  });
+  const categoryExitCode = await runCli({
+    argv: ["project", "--help"],
+    runtime: createRuntime(),
+    stdout: categoryStdout.stream,
+    stderr: categoryStderr.stream,
+  });
+
+  assert.equal(helpExitCode, 0);
+  assert.equal(categoryExitCode, 0);
+  assert.match(helpStdout.read(), /dev-loops project <sub>/);
+  assert.match(helpStdout.read(), /GitHub Projects queue helpers/);
+  const categoryHelp = categoryStdout.read();
+  assert.match(categoryHelp, /dev-loops project <subcommand>/);
+  assert.match(categoryHelp, /list\s+List queue board items/);
+  assert.match(categoryHelp, /ensure\s+Create\/repair queue board bootstrap surface/);
+  assert.equal(helpStderr.read(), "");
+  assert.equal(categoryStderr.read(), "");
+});
+
+
 test("CLI status next steps lead with dev-loop when all checks pass", async () => {
   const statusStdout = createBufferStream();
   const statusStderr = createBufferStream();
@@ -254,6 +287,63 @@ test("CLI rejects removed update command", async () => {
     assert.equal(stdout.read(), "");
     assert.match(stderr.read(), /Unrecognized command: update\./);
     assert.match(stderr.read(), /dev-loops help/);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+
+test("project wrappers pass through helper stdout and exit codes", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-project-cli-"));
+  const binDir = path.join(tempRoot, "bin");
+  await mkdir(binDir, { recursive: true });
+  const ghPath = path.join(binDir, process.platform === "win32" ? "gh.cmd" : "gh");
+  const ghScript = `#!/usr/bin/env node
+const queryArg = process.argv.find((arg) => arg.startsWith("query=")) ?? "";
+const query = queryArg.slice("query=".length);
+function write(payload) {
+  process.stdout.write(JSON.stringify(payload));
+}
+if (query.includes("user(login:$login) { id }")) {
+  write({ data: { user: { id: "U_1" } } });
+} else if (query.includes("projectsV2(first:50, after:$after)")) {
+  write({ data: { user: { projectsV2: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [{ id: "PVT_proj1", number: 1, title: "Dev Loop Queue", url: "https://github.com/users/mfittko/projects/1" }] } } } });
+} else if (query.includes("fields(first:50, after:$after)")) {
+  write({ data: { node: { fields: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [{ id: "PVTSSF_1", name: "Status", options: [{ id: "opt1", name: "Backlog" }, { id: "opt2", name: "Next Up" }] }] } } } });
+} else if (query.includes("items(first:100, after:$after)")) {
+  write({ data: { node: { items: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [{ id: "PVTI_1", fieldValues: { nodes: [{ field: { id: "PVTSSF_1", name: "Status" }, name: "Next Up" }] }, content: { number: 748, title: "Public CLI surface", url: "https://github.com/mfittko/pi-dev-loops/issues/748", id: "I_748" } }] } } } });
+} else {
+  process.stderr.write(JSON.stringify({ ok: false, error: "Unhandled query: " + query }));
+  process.exit(1);
+}
+`;
+  await writeFile(ghPath, ghScript);
+  await chmod(ghPath, 0o755);
+
+  try {
+    const env = { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` };
+    const success = spawnSync("node", ["./cli/index.mjs", "project", "list", "--repo", "mfittko/pi-dev-loops", "--project", "1", "--column", "Next Up"], {
+      cwd: repoRoot,
+      env,
+      encoding: "utf8",
+    });
+    assert.equal(success.status, 0, success.stderr);
+    assert.equal(success.stderr, "");
+    const payload = JSON.parse(success.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.items.length, 1);
+    assert.equal(payload.items[0].issueNumber, 748);
+    assert.equal(payload.items[0].status, "Next Up");
+
+    const failure = spawnSync("node", ["./cli/index.mjs", "project", "list"], {
+      cwd: repoRoot,
+      env,
+      encoding: "utf8",
+    });
+    assert.equal(failure.status, 1);
+    assert.equal(failure.stdout, "");
+    assert.match(failure.stderr, /--repo is required/);
+    assert.match(failure.stderr, /"code":"INVALID_REPO"/);
   } finally {
     await rm(tempRoot, { recursive: true, force: true });
   }

--- a/test/dev-loops-cli.test.mjs
+++ b/test/dev-loops-cli.test.mjs
@@ -297,9 +297,9 @@ test("project wrappers pass through helper stdout and exit codes", async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-project-cli-"));
   const binDir = path.join(tempRoot, "bin");
   await mkdir(binDir, { recursive: true });
+  const ghImplPath = path.join(binDir, "gh-impl.mjs");
   const ghPath = path.join(binDir, process.platform === "win32" ? "gh.cmd" : "gh");
-  const ghScript = `#!/usr/bin/env node
-const queryArg = process.argv.find((arg) => arg.startsWith("query=")) ?? "";
+  const ghImpl = `const queryArg = process.argv.find((arg) => arg.startsWith("query=")) ?? "";
 const query = queryArg.slice("query=".length);
 function write(payload) {
   process.stdout.write(JSON.stringify(payload));
@@ -317,7 +317,15 @@ if (query.includes("user(login:$login) { id }")) {
   process.exit(1);
 }
 `;
-  await writeFile(ghPath, ghScript);
+  const ghLauncher = process.platform === "win32"
+    ? `@echo off
+node "%~dp0\gh-impl.mjs" %*
+`
+    : `#!/bin/sh
+node "$(dirname "$0")/gh-impl.mjs" "$@"
+`;
+  await writeFile(ghImplPath, ghImpl);
+  await writeFile(ghPath, ghLauncher);
   await chmod(ghPath, 0o755);
 
   try {


### PR DESCRIPTION
## Summary

This PR exposes the existing GitHub Projects queue helper scripts through a public, documented `dev-loops project` CLI surface so operators no longer need to invoke `node scripts/projects/*.mjs` directly.

What changed:
- Added `project` as a first-class CLI category with five subcommands: `list`, `add`, `move`, `reorder`, `ensure`.
- Reworked the CLI help renderer to derive categories, order, and per-subcommand descriptions from data structures, so new categories get consistent top-level and category-specific help automatically.
- Updated all queue-related documentation and script usage strings to use the public `dev-loops project <sub>` spelling instead of the internal script path.
- Added test coverage verifying the new category appears in help and that the wrappers correctly pass through helper stdout/stderr and exit codes.

No helper logic, GraphQL queries, or repository mutation semantics were changed; only CLI routing, help text, docs, and usage banners are affected.

## Scope / Context

- Issue #748 requested public CLI wrappers for the Projects queue helpers (`list-queue-items`, `add-queue-item`, `move-queue-item`, `reorder-queue-item`, `ensure-queue-board`).
- The helper scripts already existed and were fully functional; the gap was discoverability and ease of invocation.
- Exposing them as `dev-loops project <sub>` keeps the CLI the single public workflow entrypoint and removes the need to remember long `node scripts/projects/*` paths.

## File-by-File Changes

| File | Change |
|------|--------|
| `cli/index.mjs` | Added `SUBCOMMAND_ROUTES.project` mapping to the five queue helpers. Introduced `HELP_CATEGORY_LABELS`, `TOP_LEVEL_HELP_CATEGORY_ORDER`, `SUBCOMMAND_DESCRIPTIONS`, and `buildSubcommandLines` to render categorized help with descriptions. Refactored `buildCategoryHelp` and `buildCliHelpLines` to use the new helpers. |
| `scripts/projects/add-queue-item.mjs` | Updated `USAGE` string to `dev-loops project add ...`. |
| `scripts/projects/ensure-queue-board.mjs` | Updated `USAGE` string to `dev-loops project ensure ...`. |
| `scripts/projects/list-queue-items.mjs` | Updated `USAGE` string to `dev-loops project list ...`. |
| `scripts/projects/move-queue-item.mjs` | Updated `USAGE` string to `dev-loops project move ...`. |
| `scripts/projects/reorder-queue-item.mjs` | Updated `USAGE` string to `dev-loops project reorder ...`. |
| `docs/projects-queue-contract.md` | Replaced direct script-path references with `dev-loops project ensure`. |
| `docs/projects-queue-usage.md` | Rewrote command examples and workflow steps to use the public `dev-loops project` spelling. |
| `docs/queue-board-setup.md` | Replaced `node scripts/projects/ensure-queue-board.mjs` with `dev-loops project ensure`; updated future-helper note to reference `dev-loops project --help`. |
| `test/dev-loops-cli.test.mjs` | Added `CLI help exposes project queue wrapper surface` test and `project wrappers pass through helper stdout and exit codes` test. |

## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `dev-loops project` is a top-level CLI category with `list`, `add`, `move`, `reorder`, `ensure` subcommands | ✅ |
| 2 | `dev-loops help` shows the `project` category, its label, and each subcommand with a short description | ✅ |
| 3 | `dev-loops project --help` lists all subcommands with descriptions | ✅ |
| 4 | Queue helper scripts’ `USAGE` strings advertise the public CLI spelling | ✅ |
| 5 | Queue docs and setup guide refer to the public CLI spelling | ✅ |
| 6 | Tests cover help exposure and wrapper pass-through behavior | ✅ |
| 7 | Internal helper behavior remains unchanged | ✅ |

## Definition of Done

- [x] Public `dev-loops project` surface wired through `cli/index.mjs`.
- [x] `USAGE` strings, docs, and setup guide updated to the public spelling.
- [x] Help renderer refactored with descriptions and deterministic category order.
- [x] Automated tests added for the new CLI surface.
- [x] Validation command passes: `npm run verify`.
- [x] Scope restricted to CLI/docs; no helper logic modified.

## Non-Goals

- This PR does **not** change the underlying queue helper implementation, GraphQL queries, or business rules.
- It does **not** add new queue operations or new configuration keys.
- It does **not** remove or deprecate the `scripts/projects/*.mjs` scripts; they remain callable directly for development/debugging.
- It does **not** alter CI, merge gates, branching policy, or issue/PR automation.

## Validation Command

```sh
npm run verify
```

Closes #748
