### PR TITLE
Gate checks: PR body completeness and AC/DoD/non-goals matrix verification (#753)

### DIFF
--- a/.devloops
+++ b/.devloops
@@ -28,6 +28,8 @@ gates:
       - pr-description
       - pr-comments
     requireCi: true
+    mandatoryAngles:
+      - pr-description
     blockCleanOnFindingSeverities:
       - must-fix
       - worth-fixing-now
@@ -45,6 +47,10 @@ gates:
       - isp
       - dip
       - renderer-security
+      - pr-checklist-matrix
+    mandatoryAngles:
+      - pr-checklist-matrix
+
     blockCleanOnFindingSeverities:
       - must-fix
       - worth-fixing-now

--- a/.pi/dev-loop/defaults.yaml
+++ b/.pi/dev-loop/defaults.yaml
@@ -45,6 +45,7 @@ gates:
       - renderer-security
       - determinism
       - pr-comments
+      - pr-description
     excludeAngles: []
     required: true
     # When true, draft gate waits for green CI before the gate may run.
@@ -65,6 +66,7 @@ gates:
       - isp
       - dip
       - docs
+      - pr-checklist-matrix
     excludeAngles: []
     required: true
 
@@ -357,15 +359,29 @@ personas:
   pr-description:
     persona: review
     prompt: >-
-      Review the PR description for completeness and contract fitness.
+      Review the PR description for completeness and contract fitness before this PR is marked ready for review.
       The PR body is the implementation contract — it must have:
       - A Summary section explaining what changed and why
-      - A Changes section listing files touched and modifications
-      - A Validation section describing how to verify
-      - Reference to the linked issue acceptance criteria
+      - A Scope and context section defining the boundary of the change
+      - A File-by-file changes section listing every touched file and its modification
+      - An Acceptance criteria section with the linked issue acceptance criteria
+      - A Definition of done section
+      - A Non-goals section
+      - A Validation command section describing exactly how to verify the change
       - The "Closes #N" line must match the linked issue; flag changes that alter or remove the operator-intended close target
-      Flag PRs where the body is a single sentence or lacks these sections.
+      Flag PRs where the body is a single sentence or lacks any of these sections.
       Do not block on formatting preferences — only on missing structure.
+    defaultModel: null
+
+  pr-checklist-matrix:
+    persona: review
+    prompt: >-
+      Verify before approval that the PR checklist and AC/DoD/non-goals matrix are complete.
+      - Every PR checkbox (`- [ ]`) must be checked. If any box is unchecked, flag it as a blocking finding.
+      - The PR body must contain an AC/DoD/non-goals matrix that maps each acceptance criterion
+        to its definition-of-done item(s) and lists explicit non-goals.
+      - The matrix must have a markdown table with at least a header row and one content row.
+      - Flag the matrix as incomplete if any acceptance criterion, definition-of-done item, or non-goal is missing.
     defaultModel: null
 
   pr-comments:

--- a/.pi/dev-loop/defaults.yaml
+++ b/.pi/dev-loop/defaults.yaml
@@ -50,6 +50,8 @@ gates:
     required: true
     # When true, draft gate waits for green CI before the gate may run.
     requireCi: true
+    mandatoryAngles:
+      - pr-description
   preApproval:
     # Pre-approval gate: runs before declaring merge-ready.
     # All angle families enabled by default.
@@ -69,6 +71,8 @@ gates:
       - pr-checklist-matrix
     excludeAngles: []
     required: true
+    mandatoryAngles:
+      - pr-checklist-matrix
 
 # Autonomy: which gates require operator confirmation (stop points)
 autonomy:
@@ -363,7 +367,7 @@ personas:
       The PR body is the implementation contract — it must have:
       - A Summary section explaining what changed and why
       - A Scope and context section defining the boundary of the change
-      - A File-by-file changes section listing every touched file and its modification
+      - A File-by-file changes section listing every touched file and what changed in it
       - An Acceptance criteria section with the linked issue acceptance criteria
       - A Definition of done section
       - A Non-goals section

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1997,7 +1997,6 @@ describe("shipped defaults docs and deep angle wiring", () => {
       assert.match(result.config.personas["pr-description"].prompt, /File-by-file changes section/i);
       assert.match(result.config.personas["pr-description"].prompt, /Definition of done section/i);
       assert.match(result.config.personas["pr-description"].prompt, /Non-goals section/i);
-      assert.match(result.config.personas["pr-description"].prompt, /Validation command section/i);
       assert.ok(draftAngles.includes("pr-description"), "pr-description must be in draft gate angles after settings opt-in");
       assert.equal(prDescRole.persona, "review");
       assert.equal(prDescRole.fallback, false);

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1988,15 +1988,51 @@ describe("shipped defaults docs and deep angle wiring", () => {
       assert.equal(result.config.personas["pr-description"].persona, "review");
       assert.match(result.config.personas["pr-description"].prompt, /Summary section/i);
       assert.match(result.config.personas["pr-description"].prompt, /Changes section/i);
-      assert.match(result.config.personas["pr-description"].prompt, /Validation section/i);
+      assert.match(result.config.personas["pr-description"].prompt, /Validation command section/i);
       assert.match(result.config.personas["pr-description"].prompt, /Do not block on formatting/i);
       assert.match(result.config.personas["pr-description"].prompt, /linked issue acceptance criteria/i);
       assert.match(result.config.personas["pr-description"].prompt, /single sentence/i);
       assert.match(result.config.personas["pr-description"].prompt, /Closes #N/i);
       assert.match(result.config.personas["pr-description"].prompt, /operator-intended close target/i);
+      assert.match(result.config.personas["pr-description"].prompt, /Scope and context section/i);
+      assert.match(result.config.personas["pr-description"].prompt, /File-by-file changes section/i);
+      assert.match(result.config.personas["pr-description"].prompt, /Definition of done section/i);
+      assert.match(result.config.personas["pr-description"].prompt, /Non-goals section/i);
+      assert.match(result.config.personas["pr-description"].prompt, /Validation command section/i);
       assert.ok(draftAngles.includes("pr-description"), "pr-description must be in draft gate angles after settings opt-in");
       assert.equal(prDescRole.persona, "review");
       assert.equal(prDescRole.fallback, false);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("D4: pr-checklist-matrix persona resolves and appears in pre-approval gate angles after settings opt-in", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-D4-"));
+    try {
+      const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+      const sourceDefaults = await readFile(path.join(repoRoot, ".pi", "dev-loop", "defaults.yaml"), "utf8");
+      const sourceSettings = await readFile(path.join(repoRoot, ".devloops"), "utf8");
+      const piDir = path.join(tmpDir, ".pi", "dev-loop");
+      await mkdir(piDir, { recursive: true });
+      await writeFile(path.join(piDir, "defaults.yaml"), sourceDefaults);
+      await writeFile(path.join(tmpDir, ".devloops"), sourceSettings);
+
+      const { loadDevLoopConfig, resolveReviewerRole, resolveGateAngles } = await import("../src/config/config.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+
+      const checklistRole = resolveReviewerRole(result.config, "pr-checklist-matrix");
+      const preApprovalAngles = resolveGateAngles(result.config, "preApproval");
+
+      assert.deepEqual(result.errors, []);
+      assert.equal(result.config.personas["pr-checklist-matrix"].persona, "review");
+      assert.match(result.config.personas["pr-checklist-matrix"].prompt, /checkbox/i);
+      assert.match(result.config.personas["pr-checklist-matrix"].prompt, /AC\/DoD\/non-goals matrix/i);
+      assert.match(result.config.personas["pr-checklist-matrix"].prompt, /markdown table/i);
+      assert.match(result.config.personas["pr-checklist-matrix"].prompt, /unchecked/i);
+      assert.ok(preApprovalAngles.includes("pr-checklist-matrix"), "pr-checklist-matrix must be in pre-approval gate angles after settings opt-in");
+      assert.equal(checklistRole.persona, "review");
+      assert.equal(checklistRole.fallback, false);
     } finally {
       await rm(tmpDir, { recursive: true, force: true });
     }

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1987,7 +1987,6 @@ describe("shipped defaults docs and deep angle wiring", () => {
       assert.deepEqual(result.errors, []);
       assert.equal(result.config.personas["pr-description"].persona, "review");
       assert.match(result.config.personas["pr-description"].prompt, /Summary section/i);
-      assert.match(result.config.personas["pr-description"].prompt, /Changes section/i);
       assert.match(result.config.personas["pr-description"].prompt, /Validation command section/i);
       assert.match(result.config.personas["pr-description"].prompt, /Do not block on formatting/i);
       assert.match(result.config.personas["pr-description"].prompt, /linked issue acceptance criteria/i);

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -288,7 +288,7 @@ This is the default pre-approval gate for this workflow boundary. The canonical 
 - **Gate name:** Pre-approval gate
 - **Trigger / boundary:** right before calling a PR/branch review-complete, approval-ready, merge-ready, or ready for final handoff
 - **Execution directive:** run the checkpoint review chain defined in [Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md) with the pre-approval gate inspection angles resolved from config. Retry rule: in subsequent cycles, only re-run reviewers that produced `findings_present` in the previous pass.
-- **Review angles:** resolved at runtime from config via `resolveGateAngles(config, "preApproval")` from `@pi-dev-loops/core/config`. Default config enables all 11 pre-approval gate angle families; consumer repos may opt out individual angles via `excludeAngles`.
+- **Review angles:** resolved at runtime from config via `resolveGateAngles(config, "preApproval")` from `@pi-dev-loops/core/config`. Default config enables all configured pre-approval gate angle families; consumer repos may opt out individual angles via `excludeAngles`.
 - **Persona mapping:** each angle resolves to a reviewer persona via `resolveReviewerRole(config, angle)` from `@pi-dev-loops/core/config`. Include this prompt in each reviewer's briefing so the reviewer knows exactly what to look for.
 - **Pass criteria:** the sub-loop completes with verdict `clean`; all configured angles pass; if parallel execution is impractical, still run all configured lenses and explicitly record the limitation.
 - **Acceptance criteria verification:** follow the canonical procedure in [Acceptance Criteria Verification](../docs/acceptance-criteria-verification.md) before posting the `pre_approval_gate` comment.


### PR DESCRIPTION
## Summary

Adds gate angles so the draft gate verifies PR body completeness and the approval (pre-approval) gate verifies checked checkboxes and the AC/DoD/non-goals matrix.

## Scope and context

Issue #753 noted that PR descriptions could stay thin past the draft gate and that AC/DoD/non-goals matrix plus PR checkboxes were not verified.

## File-by-file changes

- .pi/dev-loop/defaults.yaml: expanded pr-description persona, added pr-checklist-matrix persona, wired both into default gate angle lists.
- .devloops: added pr-description as mandatory draft angle and pr-checklist-matrix as a mandatory pre-approval angle.
- packages/core/test/config.test.mjs: updated D3 assertions for the expanded prompt and added D4 for pr-checklist-matrix.
- skills/copilot-pr-followup/SKILL.md: removed hard-coded pre-approval angle count so wording stays accurate.

## Acceptance criteria

- [x] Draft gate angle exists for PR body completeness and is enforced.
- [x] Approval gate angle exists for checkbox + AC/DoD/non-goals verification.
- [x] Existing gate configs/tests are updated.
- [x] Validation passes.

## Definition of done

- [x] Config changes landed in a feature branch worktree.
- [x] Unit tests updated and passing.
- [x] npm run verify passes.
- [x] Draft PR opened for review.

## Non-goals

- No new checker CLI scripts; gate review continues to use configured reviewer personas.
- No changes to the core angle registry/BUILTIN_PERSONAS.

## AC/DoD/Non-goals matrix

| AC | DoD | Non-goal |
|---|---|---|
| Draft gate angle for PR body completeness | pr-description mandatory in draft gate | No new checker CLI |
| Approval gate angle for checkbox + matrix | pr-checklist-matrix mandatory in pre-approval gate | No core registry change |
| Existing configs/tests updated | Tests D3/D4 pass | - |
| Validation passes | npm run verify passes | - |

## Validation

- npm run verify

Closes #753
