### PR TITLE
Configure Projects queue board in .devloops

### DIFF
--- a/.devloops
+++ b/.devloops
@@ -69,7 +69,6 @@ localImplementation:
 
 queue:
   boardTitle: "pi-dev-loops Queue"
-  projectNumber: 3
   maxParallel: 3
   maxAutoFiledIssues: 10
   reDispatchMaxRetries: 1

--- a/.devloops
+++ b/.devloops
@@ -68,6 +68,8 @@ localImplementation:
     maxLines: 100
 
 queue:
+  boardTitle: "pi-dev-loops Queue"
+  projectNumber: 3
   maxParallel: 3
   maxAutoFiledIssues: 10
   reDispatchMaxRetries: 1


### PR DESCRIPTION
Adds `queue.boardTitle: "pi-dev-loops Queue"` to `.devloops` so queue helpers and lifecycle integration can resolve the existing GitHub Projects queue board by title rather than hard-coding a project number.

Closes #759