### PR TITLE
fix(dev-loop): post gate-verdict comments in fallback (no @pi-dev-loops/core) — #761

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:extension": "node --import tsx --test --test-reporter ./test/failure-summary-reporter.mjs test/extension-checks.test.mjs test/extension-post-merge-update.test.mjs test/extension-command-contract.test.mjs test/extension-package-contract.test.mjs test/dev-loops-core.test.mjs test/dev-loops-cli.test.mjs",
     "test:scripts": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/github/*.test.mjs test/loop/*.test.mjs test/docs/*.test.mjs test/projects/*.test.mjs",
     "test:core": "node --test --test-reporter ./test/failure-summary-reporter.mjs packages/core/test/*.test.mjs",
-    "test:dev-loop": "node --test --test-reporter ./test/failure-summary-reporter.mjs skills/dev-loop/scripts/dev-mode-context.test.mjs skills/dev-loop/scripts/render-template.test.mjs",
+    "test:dev-loop": "node --test --test-reporter ./test/failure-summary-reporter.mjs skills/dev-loop/scripts/dev-mode-context.test.mjs skills/dev-loop/scripts/render-template.test.mjs skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs",
     "test:playwright:viewer": "playwright test -c playwright.inspect-run-viewer.config.mjs",
     "test:docs": "node scripts/docs/validate-links.mjs && node scripts/docs/validate-no-duplicate-rules.mjs",
     "postinstall": "chmod +x cli/index.mjs && ln -sf ../../cli/index.mjs node_modules/.bin/dev-loops",

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -91,7 +91,7 @@ Do not preload route packs before the resolver selects the strategy.
 
 ## Fallback gate-comment poster
 
-When the `@pi-dev-loops/core` package is not installed in the consumer repo, the full `scripts/github/upsert-checkpoint-verdict.mjs` helper (referenced from the copilot-pr-followup skill procedure) is unavailable. To keep the PR audit trail intact in that mode, the dev-loop skill ships a small gh-only fallback poster at `scripts/dev-loop/scripts/post-gate-verdict-fallback.mjs` that renders the same visible comment format and fails closed if posting cannot succeed.
+When the `@pi-dev-loops/core` package is not installed in the consumer repo, the full `scripts/github/upsert-checkpoint-verdict.mjs` helper (referenced from the copilot-pr-followup skill procedure) is unavailable. To keep the PR audit trail intact in that mode, the dev-loop skill ships a small gh-only fallback poster at `scripts/post-gate-verdict-fallback.mjs` (relative to the dev-loop skill root) that renders the same visible comment format and fails closed if posting cannot succeed.
 
 Use the fallback poster only when the full helper cannot be reached:
 

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -89,6 +89,20 @@ Do not preload route packs before the resolver selects the strategy.
 **Async dispatch rule (enforced):** the resolver enforces fail-closed for GitHub-first strategies when `canonicalStateSummary.requiresAsyncDispatch` is `true` (default `required` mode). Inline invocation without `PI_SUBAGENT_RUN_ID` is rejected only for those routes. See [Startup procedure](#startup-procedure).
 
 
+## Fallback gate-comment poster
+
+When the `@pi-dev-loops/core` package is not installed in the consumer repo, the full `scripts/github/upsert-checkpoint-verdict.mjs` helper (referenced from the copilot-pr-followup skill procedure) is unavailable. To keep the PR audit trail intact in that mode, the dev-loop skill ships a small gh-only fallback poster at `scripts/dev-loop/scripts/post-gate-verdict-fallback.mjs` that renders the same visible comment format and fails closed if posting cannot succeed.
+
+Use the fallback poster only when the full helper cannot be reached:
+
+1. Detect the missing helper: try `node scripts/github/upsert-checkpoint-verdict.mjs --help` from the consumer repo. If the script is absent or imports fail, switch to the fallback path.
+2. Invoke the fallback from the installed dev-loop skill directory: `node <resolved-skill-scripts>/post-gate-verdict-fallback.mjs --repo <owner/name> --pr <number> --head-sha <sha> --verdict <clean|findings_present|blocked> (--findings-summary <text> | --findings-file <path>) --next-action <text> [--gate <draft_gate|pre_approval_gate>]`.
+3. Treat every successful fallback-posted gate comment as a one-shot create with no idempotent same-head update: if the agent reruns the gate on the same head, a duplicate comment will be created. Detect duplicates manually and update manually if needed.
+4. Treat every fallback-posted gate comment as a degraded audit-trail artifact: the visible body uses the same parser-stable shape as the full helper (gate name, head SHA, verdict, blocking severities when applicable, findings summary, next action), but the helper skips stale-head detection, gate-coordination validation, blocking-severity count enforcement, and the internal-only PR short-circuit.
+5. If the fallback helper exits non-zero, stop the gate and report the posting failure: do not mark the PR ready for review and do not proceed to merge readiness until the comment is posted.
+
+When `@pi-dev-loops/core` is available again, switch back to the full helper. The fallback poster is a degraded path, not a permanent replacement.
+
 ## Read-only info shortcut
 
 The main agent may handle info/handoff requests directly via `npx dev-loops loop info` without dispatching the async `dev-loop` subagent:

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
@@ -1,0 +1,451 @@
+#!/usr/bin/env node
+// post-gate-verdict-fallback.mjs
+//
+// Minimal gate-verdict-comment poster for the fallback path used when the
+// `@pi-dev-loops/core` package is not installed in the consumer repo and the
+// full `scripts/github/upsert-checkpoint-verdict.mjs` helper is therefore
+// unavailable. Posts the same visible comment format as the full helper, but
+// without the full helper's idempotent same-head update, stale-head detection,
+// gate-coordination validation, or internal-only PR short-circuit.
+//
+// Contract reference: docs/gate-review-comment-contract.md and
+// skills/docs/gate-review-comment-contract.md (rendered body must remain
+// parser-stable for gate name and head SHA).
+//
+// Degraded semantics (vs. the full helper):
+//   - one-shot create only; no idempotent same-head update
+//   - no stale-head detection against existing comments
+//   - no gate-coordination state validation
+//   - no blocking-severity count enforcement (caller is responsible)
+//   - no internal-only PR short-circuit
+//
+// The script always emits a stderr warning explaining that fallback mode is
+// active and the audit trail is degraded. On posting failure it fails closed
+// with a non-zero exit so the calling agent does not silently proceed past
+// the gate-comment requirement.
+
+import { readFile } from "node:fs/promises";
+import { spawn as defaultSpawn } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const GATE_NAMES = new Set(["draft_gate", "pre_approval_gate"]);
+const VERDICTS = new Set(["clean", "findings_present", "blocked"]);
+const REPO_SLUG_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const SHA_PATTERN = /^[0-9a-f]{7,64}$/i;
+const MAX_BODY_LENGTH = 6000;
+
+const USAGE = `Usage: post-gate-verdict-fallback.mjs --repo <owner/name> --pr <number> --head-sha <sha> --verdict <clean|findings_present|blocked> (--findings-summary <text> | --findings-file <path>) --next-action <text> [--gate <draft_gate|pre_approval_gate>] [--gh-command <path>]
+Minimal fallback poster for draft_gate / pre_approval_gate checkpoint verdict comments.
+Use only when @pi-dev-loops/core is not installed; otherwise prefer scripts/github/upsert-checkpoint-verdict.mjs.
+Required:
+  --repo <owner/name>
+  --pr <number>
+  --head-sha <sha>                            Full or 7+ char hex prefix
+  --verdict <clean|findings_present|blocked>
+  --findings-summary <text>                 Single-line summary
+  --findings-file <path>                    Read summary from file (preserves
+                                            newlines; takes precedence when
+                                            both are provided)
+  --next-action <text>
+Optional:
+  --gate <draft_gate|pre_approval_gate>     Defaults to draft_gate
+  --gh-command <path>                       Defaults to "gh"
+Output (stdout, JSON):
+  {
+    "ok": true,
+    "action": "created",
+    "repo": "owner/repo",
+    "pr": 17,
+    "gate": "draft_gate",
+    "headSha": "abc1234",
+    "commentId": 101,
+    "commentUrl": "https://github.com/owner/repo/pull/17#issuecomment-101",
+    "fallback": true,
+    "warning": "..."
+  }
+Exit codes:
+  0  Success
+  1  Argument error or gh failure`.trim();
+
+export function buildParseError(usage) {
+  return (message) => {
+    const error = new Error(message);
+    error.usage = usage;
+    return error;
+  };
+}
+
+function requireOptionValue(args, flag, parseError) {
+  const next = args.shift();
+  if (typeof next !== "string" || next.length === 0) {
+    throw parseError(`${flag} requires a non-empty value`);
+  }
+  return next;
+}
+
+function normalizeRepoSlug(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return REPO_SLUG_PATTERN.test(trimmed) ? trimmed : null;
+}
+
+function normalizePrNumber(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const num = Number.parseInt(trimmed, 10);
+  return Number.isInteger(num) && num > 0 ? num : null;
+}
+
+function normalizeHeadSha(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim().toLowerCase();
+  return SHA_PATTERN.test(trimmed) ? trimmed : null;
+}
+
+function normalizeGate(value) {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return GATE_NAMES.has(normalized) ? normalized : null;
+}
+
+function normalizeVerdict(value) {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return VERDICTS.has(normalized) ? normalized : null;
+}
+
+function normalizeRequiredText(value, flag, parseError) {
+  if (typeof value !== "string") {
+    throw parseError(`${flag} must be a non-empty string`);
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw parseError(`${flag} must be a non-empty string`);
+  }
+  return trimmed;
+}
+
+function collapseWhitespace(value) {
+  return String(value).replace(/\s+/gu, " ").trim();
+}
+
+function smartTruncate(value, limit) {
+  const text = String(value);
+  if (text.length <= limit) {
+    return text;
+  }
+  const truncated = text.slice(0, limit);
+  const lastSpace = truncated.lastIndexOf(" ");
+  const breakPoint = lastSpace > Math.floor(limit * 0.7) ? lastSpace : limit;
+  const retained = truncated.slice(0, breakPoint);
+  const omitted = text.length - retained.length;
+  return `${retained}…[truncated ${omitted} chars]`;
+}
+
+export function parsePostGateVerdictFallbackCliArgs(argv, { parseError } = {}) {
+  const parseErr = parseError ?? buildParseError(USAGE);
+  const args = [...argv];
+  const options = {
+    repo: undefined,
+    pr: undefined,
+    gate: undefined,
+    headSha: undefined,
+    verdict: undefined,
+    findingsSummary: undefined,
+    findingsFile: undefined,
+    nextAction: undefined,
+    ghCommand: undefined,
+  };
+
+  while (args.length > 0) {
+    const token = args.shift();
+    if (token === "--repo") {
+      const repo = normalizeRepoSlug(requireOptionValue(args, "--repo", parseErr));
+      if (!repo) {
+        throw parseErr("--repo must be of the form owner/name (alphanumeric, dot, dash, underscore)");
+      }
+      options.repo = repo;
+      continue;
+    }
+    if (token === "--pr") {
+      const pr = normalizePrNumber(requireOptionValue(args, "--pr", parseErr));
+      if (!pr) {
+        throw parseErr("--pr must be a positive integer");
+      }
+      options.pr = pr;
+      continue;
+    }
+    if (token === "--head-sha") {
+      const headSha = normalizeHeadSha(requireOptionValue(args, "--head-sha", parseErr));
+      if (!headSha) {
+        throw parseErr("--head-sha must be a 7-64 character hexadecimal SHA");
+      }
+      options.headSha = headSha;
+      continue;
+    }
+    if (token === "--gate") {
+      const gate = normalizeGate(requireOptionValue(args, "--gate", parseErr));
+      if (!gate) {
+        throw parseErr("--gate must be one of: draft_gate, pre_approval_gate");
+      }
+      options.gate = gate;
+      continue;
+    }
+    if (token === "--verdict") {
+      const verdict = normalizeVerdict(requireOptionValue(args, "--verdict", parseErr));
+      if (!verdict) {
+        throw parseErr("--verdict must be one of: clean, findings_present, blocked");
+      }
+      options.verdict = verdict;
+      continue;
+    }
+    if (token === "--findings-summary") {
+      options.findingsSummary = normalizeRequiredText(
+        requireOptionValue(args, "--findings-summary", parseErr),
+        "--findings-summary",
+        parseErr,
+      );
+      continue;
+    }
+    if (token === "--findings-file") {
+      const rawPath = requireOptionValue(args, "--findings-file", parseErr).trim();
+      if (rawPath.length === 0) {
+        throw parseErr("--findings-file must be a non-empty path");
+      }
+      options.findingsFile = rawPath;
+      continue;
+    }
+    if (token === "--next-action") {
+      options.nextAction = normalizeRequiredText(
+        requireOptionValue(args, "--next-action", parseErr),
+        "--next-action",
+        parseErr,
+      );
+      continue;
+    }
+    if (token === "--gh-command") {
+      const cmd = requireOptionValue(args, "--gh-command", parseErr).trim();
+      if (cmd.length === 0) {
+        throw parseErr("--gh-command must be a non-empty path or executable name");
+      }
+      options.ghCommand = cmd;
+      continue;
+    }
+    throw parseErr(`Unknown argument: ${token}`);
+  }
+
+  const required = ["repo", "pr", "headSha", "verdict", "nextAction"];
+  const missing = required.filter((key) => options[key] === undefined);
+  if (options.findingsSummary === undefined && options.findingsFile === undefined) {
+    missing.push("findingsSummary|findingsFile");
+  }
+  if (missing.length > 0) {
+    throw parseErr(
+      `post-gate-verdict-fallback requires --repo, --pr, --head-sha, --verdict, --next-action, and either --findings-summary or --findings-file (missing: ${missing.join(", ")})`,
+    );
+  }
+
+  if (options.gate === undefined) {
+    options.gate = "draft_gate";
+  }
+
+  return options;
+}
+
+/**
+ * Render the visible gate-review comment body in the same parser-stable
+ * format used by `scripts/github/upsert-checkpoint-verdict.mjs`'s
+ * `renderGateReviewCommentBody`. Mirrors that helper's shape so the existing
+ * detectors can still parse gate name and head SHA out of fallback comments.
+ */
+export function renderFallbackGateReviewCommentBody({
+  gate,
+  headSha,
+  verdict,
+  findingsSummary,
+  nextAction,
+  blockCleanOnFindingSeverities,
+}) {
+  const lines = [
+    `### Gate review: \`${gate}\``,
+    "",
+    `**Reviewed head SHA:** \`${headSha}\``,
+    `**Verdict:** ${verdict}`,
+  ];
+  if (
+    (verdict === "findings_present" || verdict === "blocked")
+    && Array.isArray(blockCleanOnFindingSeverities)
+    && blockCleanOnFindingSeverities.length > 0
+  ) {
+    const sevs = blockCleanOnFindingSeverities.join(", ");
+    lines.push(`**Blocking severities:** ${sevs} (clean requires no findings matching these severities)`);
+  }
+  lines.push(
+    "",
+    `**Findings summary:** ${findingsSummary}`,
+    "",
+    `**Next action:** ${nextAction}`,
+  );
+  return smartTruncate(lines.join("\n"), MAX_BODY_LENGTH);
+}
+
+async function resolveFindingsSummary(options, { parseError }) {
+  if (typeof options.findingsFile === "string" && options.findingsFile.length > 0) {
+    let content;
+    try {
+      content = await readFile(options.findingsFile, "utf8");
+    } catch (err) {
+      throw parseError(`Cannot read --findings-file "${options.findingsFile}": ${err instanceof Error ? err.message : String(err)}`);
+    }
+    const trimmed = content.replace(/\n+$/, "");
+    if (trimmed.length === 0) {
+      throw parseError(`--findings-file "${options.findingsFile}" is empty or contains only whitespace`);
+    }
+    return trimmed;
+  }
+  if (typeof options.findingsSummary === "string" && options.findingsSummary.length > 0) {
+    // Single-line summaries only; multi-line must use --findings-file.
+    return collapseWhitespace(options.findingsSummary);
+  }
+  throw parseError("post-gate-verdict-fallback requires either --findings-summary or --findings-file");
+}
+
+export async function postGateVerdictViaGh({
+  repo,
+  pr,
+  body,
+  env = process.env,
+  ghCommand = "gh",
+  spawnImpl = defaultSpawn,
+}) {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify({ body });
+    const child = spawnImpl(
+      ghCommand,
+      ["api", "--method", "POST", "-H", "Content-Type: application/json", "--input", "-", `repos/${repo}/issues/${pr}/comments`],
+      { env, stdio: ["pipe", "pipe", "pipe"] },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", (err) => {
+      reject(new Error(`gh api failed to spawn: ${err instanceof Error ? err.message : String(err)}`));
+    });
+    child.on("close", (code) => {
+      if (code !== 0) {
+        const detail = stderr.trim() || `exit code ${code}`;
+        reject(new Error(`gh api failed to post gate verdict comment for ${repo}#${pr}: ${detail}`));
+        return;
+      }
+      let responsePayload;
+      try {
+        responsePayload = JSON.parse(stdout);
+      } catch (err) {
+        reject(new Error(`gh api returned non-JSON response for ${repo}#${pr}: ${err instanceof Error ? err.message : String(err)}`));
+        return;
+      }
+      const commentId = Number.isInteger(responsePayload?.id) ? responsePayload.id : null;
+      const commentUrl = typeof responsePayload?.html_url === "string" && responsePayload.html_url.length > 0
+        ? responsePayload.html_url
+        : null;
+      if (commentId === null || commentUrl === null) {
+        reject(new Error(`gh api response missing comment id/html_url for ${repo}#${pr}: ${stdout.trim().slice(0, 200)}`));
+        return;
+      }
+      resolve({ commentId, commentUrl });
+    });
+    child.stdin.end(payload);
+  });
+}
+
+export function buildFallbackWarning() {
+  return [
+    "[post-gate-verdict-fallback] WARNING: fallback mode active.",
+    "The full @pi-dev-loops/core helper (scripts/github/upsert-checkpoint-verdict.mjs) was not available,",
+    "so this comment was posted via the degraded gh-only fallback poster.",
+    "Audit trail is degraded: no idempotent same-head update, no stale-head detection,",
+    "no gate-coordination validation, no internal-only PR short-circuit, no blocking-severity count enforcement.",
+    "Install @pi-dev-loops/core to restore full gate-comment semantics.",
+  ].join(" ");
+}
+
+/**
+ * Programmatic entry point. Resolves CLI args, renders the visible body,
+ * posts via gh, and emits a stderr warning explaining the degraded audit
+ * trail. Throws on argument errors or gh failures (fail-closed).
+ */
+export async function runCli(
+  argv = process.argv.slice(2),
+  {
+    env = process.env,
+    spawn = defaultSpawn,
+    ghCommand,
+    stdoutSink,
+    stderrSink,
+    parseErrorFactory,
+  } = {},
+) {
+  const parseError = parseErrorFactory ?? buildParseError(USAGE);
+  const options = parsePostGateVerdictFallbackCliArgs(argv, { parseError });
+  const findingsSummary = await resolveFindingsSummary(options, { parseError });
+  const body = renderFallbackGateReviewCommentBody({
+    gate: options.gate,
+    headSha: options.headSha,
+    verdict: options.verdict,
+    findingsSummary,
+    nextAction: options.nextAction,
+  });
+  const warning = buildFallbackWarning();
+  if (stderrSink && Array.isArray(stderrSink)) {
+    stderrSink.push(`${warning}\n`);
+  } else {
+    process.stderr.write(`${warning}\n`);
+  }
+  const { commentId, commentUrl } = await postGateVerdictViaGh({
+    repo: options.repo,
+    pr: options.pr,
+    body,
+    env,
+    ghCommand: ghCommand ?? options.ghCommand ?? "gh",
+    spawnImpl: spawn,
+  });
+  const result = {
+    ok: true,
+    action: "created",
+    repo: options.repo,
+    pr: options.pr,
+    gate: options.gate,
+    headSha: options.headSha,
+    commentId,
+    commentUrl,
+    fallback: true,
+    warning,
+  };
+  if (stdoutSink && Array.isArray(stdoutSink)) {
+    stdoutSink.push(`${JSON.stringify(result)}\n`);
+  } else {
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  }
+  return 0;
+}
+
+const invokedAsScript = process.argv[1]
+  ? import.meta.url === pathToFileURL(process.argv[1]).href
+  : false;
+
+if (invokedAsScript) {
+  runCli().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    if (error?.usage) {
+      process.stderr.write(`${error.usage}\n`);
+    }
+    process.exitCode = 1;
+  });
+}

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
@@ -90,11 +90,16 @@ export function buildParseError(usage) {
 }
 
 function requireOptionValue(args, flag, parseError) {
-  const next = args.shift();
-  if (typeof next !== "string" || next.length === 0) {
+  // Peek at the next token without consuming it so we can detect a flag-like next value
+  // and fail with a clearer error rather than treating it as the current flag's value.
+  if (args.length === 0) {
     throw parseError(`${flag} requires a non-empty value`);
   }
-  return next;
+  const next = args[0];
+  if (typeof next !== "string" || next.length === 0 || /^-/u.test(next)) {
+    throw parseError(`${flag} requires a non-empty value (got ${JSON.stringify(next)})`);
+  }
+  return args.shift();
 }
 
 function normalizeRepoSlug(value) {

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
@@ -26,11 +26,26 @@
 
 import { readFile } from "node:fs/promises";
 import { spawn as defaultSpawn } from "node:child_process";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { pathToFileURL } from "node:url";
 
 const GATE_NAMES = new Set(["draft_gate", "pre_approval_gate"]);
 const VERDICTS = new Set(["clean", "findings_present", "blocked"]);
-const REPO_SLUG_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+function isSafeRepoSegment(segment) {
+  return typeof segment === "string"
+    && segment.length > 0
+    && segment !== "."
+    && segment !== ".."
+    && !/[\\/]/.test(segment)
+    && !/\s/.test(segment);
+}
+
+function isValidRepoSlug(repo) {
+  if (typeof repo !== "string") return false;
+  const trimmed = repo.trim();
+  const parts = trimmed.split("/");
+  if (parts.length !== 2) return false;
+  return isSafeRepoSegment(parts[0]) && isSafeRepoSegment(parts[1]);
+}
 const SHA_PATTERN = /^[0-9a-f]{7,64}$/i;
 const MAX_BODY_LENGTH = 6000;
 
@@ -86,7 +101,7 @@ function requireOptionValue(args, flag, parseError) {
 function normalizeRepoSlug(value) {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
-  return REPO_SLUG_PATTERN.test(trimmed) ? trimmed : null;
+  return isValidRepoSlug(trimmed) ? trimmed : null;
 }
 
 function normalizePrNumber(value) {
@@ -298,7 +313,7 @@ async function resolveFindingsSummary(options, { parseError }) {
     } catch (err) {
       throw parseError(`Cannot read --findings-file "${options.findingsFile}": ${err instanceof Error ? err.message : String(err)}`);
     }
-    const trimmed = content.replace(/\n+$/, "");
+    const trimmed = content.replace(/\n+$/, "").trim();
     if (trimmed.length === 0) {
       throw parseError(`--findings-file "${options.findingsFile}" is empty or contains only whitespace`);
     }

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
@@ -48,8 +48,6 @@ function isValidRepoSlug(repo) {
   return isSafeRepoSegment(parts[0]) && isSafeRepoSegment(parts[1]);
 }
 const SHA_PATTERN = /^[0-9a-f]{7,64}$/i;
-const MAX_BODY_LENGTH = 6000;
-
 const USAGE = `Usage: post-gate-verdict-fallback.mjs --repo <owner/name> --pr <number> --head-sha <sha> --verdict <clean|findings_present|blocked> (--findings-summary <text> | --findings-file <path>) --next-action <text> [--gate <draft_gate|pre_approval_gate>] [--gh-command <path>]
 Minimal fallback poster for draft_gate / pre_approval_gate checkpoint verdict comments.
 Use only when @pi-dev-loops/core is not installed; otherwise prefer scripts/github/upsert-checkpoint-verdict.mjs.
@@ -269,6 +267,12 @@ export function parsePostGateVerdictFallbackCliArgs(argv, { parseError } = {}) {
   return options;
 }
 
+// Per-field cap for findingsSummary when read from --findings-file or supplied inline.
+// Mirrors the full helper's MAX_GATE_COMMENT_TEXT_LENGTH behavior so a large file cannot
+// blow out the rendered comment; the full template structure (gate name, head SHA, verdict,
+// next action) is always preserved so parseGateReviewCommentBody() stays deterministic.
+const MAX_FINDINGS_SUMMARY_LENGTH = 2000;
+
 /**
  * Render the visible gate-review comment body in the same parser-stable
  * format used by `scripts/github/upsert-checkpoint-verdict.mjs`'s
@@ -283,6 +287,7 @@ export function renderFallbackGateReviewCommentBody({
   nextAction,
   blockCleanOnFindingSeverities,
 }) {
+  const summary = smartTruncate(String(findingsSummary ?? ""), MAX_FINDINGS_SUMMARY_LENGTH);
   const lines = [
     `### Gate review: \`${gate}\``,
     "",
@@ -299,11 +304,11 @@ export function renderFallbackGateReviewCommentBody({
   }
   lines.push(
     "",
-    `**Findings summary:** ${findingsSummary}`,
+    `**Findings summary:** ${summary}`,
     "",
     `**Next action:** ${nextAction}`,
   );
-  return smartTruncate(lines.join("\n"), MAX_BODY_LENGTH);
+  return lines.join("\n");
 }
 
 async function resolveFindingsSummary(options, { parseError }) {
@@ -314,11 +319,14 @@ async function resolveFindingsSummary(options, { parseError }) {
     } catch (err) {
       throw parseError(`Cannot read --findings-file "${options.findingsFile}": ${err instanceof Error ? err.message : String(err)}`);
     }
-    const trimmed = content.replace(/\n+$/, "").trim();
-    if (trimmed.length === 0) {
+    // Match the full helper's --findings-file semantics: trim only trailing newlines so the
+    // summary preserves its internal newlines and any intentional leading content. Reject
+    // whitespace-only files via a separate .trim()-based emptiness check.
+    const trimmedTrailing = content.replace(/\n+$/, "");
+    if (trimmedTrailing.trim().length === 0) {
       throw parseError(`--findings-file "${options.findingsFile}" is empty or contains only whitespace`);
     }
-    return trimmed;
+    return trimmedTrailing;
   }
   if (typeof options.findingsSummary === "string" && options.findingsSummary.length > 0) {
     // Single-line summaries only; multi-line must use --findings-file.

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
@@ -8,9 +8,10 @@
 // without the full helper's idempotent same-head update, stale-head detection,
 // gate-coordination validation, or internal-only PR short-circuit.
 //
-// Contract reference: docs/gate-review-comment-contract.md and
-// skills/docs/gate-review-comment-contract.md (rendered body must remain
-// parser-stable for gate name and head SHA).
+// Contract reference: docs/gate-review-comment-contract.md (rendered body must
+// remain parser-stable for gate name and head SHA). The skill-bundled copy at
+// skills/docs/gate-review-comment-contract.md inherits from the source-repo doc
+// and is not a separate contract surface.
 //
 // Degraded semantics (vs. the full helper):
 //   - one-shot create only; no idempotent same-head update
@@ -178,7 +179,7 @@ export function parsePostGateVerdictFallbackCliArgs(argv, { parseError } = {}) {
     if (token === "--repo") {
       const repo = normalizeRepoSlug(requireOptionValue(args, "--repo", parseErr));
       if (!repo) {
-        throw parseErr("--repo must be of the form owner/name (alphanumeric, dot, dash, underscore)");
+        throw parseErr("--repo must be of the form owner/name: each segment must be non-empty, must not be \".\" or \"..\", and must not contain whitespace, slashes, or backslashes");
       }
       options.repo = repo;
       continue;

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
@@ -1,0 +1,515 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import test from "node:test";
+
+import {
+  buildParseError,
+  parsePostGateVerdictFallbackCliArgs,
+  renderFallbackGateReviewCommentBody,
+  runCli,
+} from "./post-gate-verdict-fallback.mjs";
+
+const scriptPath = path.resolve("skills/dev-loop/scripts/post-gate-verdict-fallback.mjs");
+
+function runNode(args, env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath, ...args], {
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+function buildGhStubScript() {
+  return [
+    "#!/usr/bin/env node",
+    'const { readFileSync } = require("node:fs");',
+    'const sequencePath = process.env.GH_SEQUENCE_PATH;',
+    'const counterPath = process.env.GH_COUNTER_PATH;',
+    'const defaultStdout = process.env.GH_DEFAULT_STDOUT ?? "{\\"id\\":1,\\"html_url\\":\\"https://example/comment\\"}\\n";',
+    'const exitCode = Number(process.env.GH_EXIT_CODE ?? 0);',
+    'const entries = sequencePath ? JSON.parse(readFileSync(sequencePath, "utf8")) : [];',
+    'const actual = process.argv.slice(2);',
+    'const current = counterPath ? Number(readFileSync(counterPath, "utf8").trim() || "0") : 0;',
+    'const entry = entries.length === 0 ? null : (entries[Math.min(current, entries.length - 1)] ?? null);',
+    'if (counterPath) require("node:fs").writeFileSync(counterPath, String(current + 1));',
+    'let stdin = "";',
+    'process.stdin.setEncoding("utf8");',
+    'process.stdin.on("data", (chunk) => { stdin += chunk; });',
+    'process.stdin.on("end", () => {',
+    '  if (entry && entry.assertArgIncludes) {',
+    '    for (const expected of entry.assertArgIncludes) {',
+    '      if (!actual.some((a) => String(a).includes(expected))) {',
+    '        process.stderr.write(`missing expected arg substring: ${expected}\\nactual: ${actual.join(" ")}\\n`);',
+    '        process.exit(94);',
+    '      }',
+    '    }',
+    '  }',
+    '  if (entry && entry.assertStdinIncludes) {',
+    '    for (const expected of entry.assertStdinIncludes) {',
+    '      if (!stdin.includes(expected)) {',
+    '        process.stderr.write(`missing expected stdin text: ${expected}\\n`);',
+    '        process.exit(96);',
+    '      }',
+    '    }',
+    '  }',
+    '  if (entry && entry.stderr) process.stderr.write(entry.stderr);',
+    '  if (entry && entry.stdout) {',
+    '    process.stdout.write(entry.stdout);',
+    '  } else {',
+    '    process.stdout.write(defaultStdout);',
+    '  }',
+    '  process.exit(entry && Number.isInteger(entry.exitCode) ? entry.exitCode : exitCode);',
+    '});',
+    "",
+  ].join("\n");
+}
+
+async function writeGhStub(tempDir, entries = [], { defaultStdout, exitCode = 0 } = {}) {
+  const sequencePath = path.join(tempDir, "gh-sequence.json");
+  const counterPath = path.join(tempDir, "gh-counter.txt");
+  const ghPath = path.join(tempDir, "gh");
+  await writeFile(sequencePath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
+  await writeFile(counterPath, "0\n", "utf8");
+  await writeFile(ghPath, buildGhStubScript(), "utf8");
+  await chmod(ghPath, 0o755);
+  return {
+    env: {
+      ...process.env,
+      PATH: [tempDir, process.env.PATH ?? ""].filter(Boolean).join(path.delimiter),
+      GH_SEQUENCE_PATH: sequencePath,
+      GH_COUNTER_PATH: counterPath,
+      GH_DEFAULT_STDOUT: defaultStdout ?? "",
+      GH_EXIT_CODE: String(exitCode),
+    },
+    ghPath,
+    counterPath,
+  };
+}
+
+test("renderFallbackGateReviewCommentBody matches the full helper's visible format", () => {
+  const body = renderFallbackGateReviewCommentBody({
+    gate: "draft_gate",
+    headSha: "abc1234",
+    verdict: "clean",
+    findingsSummary: "no issues found",
+    nextAction: "mark ready for review",
+  });
+  assert.match(body, /### Gate review: `draft_gate`/);
+  assert.match(body, /\*\*Reviewed head SHA:\*\* `abc1234`/);
+  assert.match(body, /\*\*Verdict:\*\* clean/);
+  assert.match(body, /\*\*Findings summary:\*\* no issues found/);
+  assert.match(body, /\*\*Next action:\*\* mark ready for review/);
+});
+
+test("renderFallbackGateReviewCommentBody includes blocking severities for findings_present", () => {
+  const body = renderFallbackGateReviewCommentBody({
+    gate: "pre_approval_gate",
+    headSha: "deadbeef",
+    verdict: "findings_present",
+    findingsSummary: "two must-fix items",
+    nextAction: "stay draft and fix",
+    blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
+  });
+  assert.match(body, /\*\*Blocking severities:\*\* must-fix, worth-fixing-now/);
+  assert.match(body, /\*\*Next action:\*\* stay draft and fix/);
+});
+
+test("renderFallbackGateReviewCommentBody omits blocking severities line when verdict is clean and no blocking list provided", () => {
+  const body = renderFallbackGateReviewCommentBody({
+    gate: "draft_gate",
+    headSha: "abc1234",
+    verdict: "clean",
+    findingsSummary: "no issues found",
+    nextAction: "mark ready for review",
+  });
+  assert.doesNotMatch(body, /\*\*Blocking severities:\*\*/);
+});
+
+test("parsePostGateVerdictFallbackCliArgs rejects missing required flags", () => {
+  const parseError = buildParseError("Usage: ...");
+  assert.throws(
+    () => parsePostGateVerdictFallbackCliArgs([], { parseError }),
+    /requires --repo, --pr, --head-sha, --verdict, --next-action, and either --findings-summary/,
+  );
+});
+
+test("parsePostGateVerdictFallbackCliArgs rejects malformed gate", () => {
+  const parseError = buildParseError("Usage: ...");
+  assert.throws(
+    () =>
+      parsePostGateVerdictFallbackCliArgs(
+        [
+          "--repo",
+          "owner/repo",
+          "--pr",
+          "17",
+          "--head-sha",
+          "abc1234",
+          "--verdict",
+          "clean",
+          "--findings-summary",
+          "ok",
+          "--next-action",
+          "go",
+          "--gate",
+          "wrong",
+        ],
+        { parseError },
+      ),
+    /--gate must be one of: draft_gate, pre_approval_gate/,
+  );
+});
+
+test("parsePostGateVerdictFallbackCliArgs rejects malformed verdict", () => {
+  const parseError = buildParseError("Usage: ...");
+  assert.throws(
+    () =>
+      parsePostGateVerdictFallbackCliArgs(
+        [
+          "--repo",
+          "owner/repo",
+          "--pr",
+          "17",
+          "--head-sha",
+          "abc1234",
+          "--verdict",
+          "maybe",
+          "--findings-summary",
+          "ok",
+          "--next-action",
+          "go",
+        ],
+        { parseError },
+      ),
+    /--verdict must be one of: clean, findings_present, blocked/,
+  );
+});
+
+test("parsePostGateVerdictFallbackCliArgs rejects malformed head SHA", () => {
+  const parseError = buildParseError("Usage: ...");
+  assert.throws(
+    () =>
+      parsePostGateVerdictFallbackCliArgs(
+        [
+          "--repo",
+          "owner/repo",
+          "--pr",
+          "17",
+          "--head-sha",
+          "XYZ",
+          "--verdict",
+          "clean",
+          "--findings-summary",
+          "ok",
+          "--next-action",
+          "go",
+        ],
+        { parseError },
+      ),
+    /--head-sha must be a 7-64 character hexadecimal SHA/,
+  );
+});
+
+test("parsePostGateVerdictFallbackCliArgs rejects malformed repo slug", () => {
+  const parseError = buildParseError("Usage: ...");
+  assert.throws(
+    () =>
+      parsePostGateVerdictFallbackCliArgs(
+        [
+          "--repo",
+          "no-slash",
+          "--pr",
+          "17",
+          "--head-sha",
+          "abc1234",
+          "--verdict",
+          "clean",
+          "--findings-summary",
+          "ok",
+          "--next-action",
+          "go",
+        ],
+        { parseError },
+      ),
+    /--repo must be of the form owner\/name/,
+  );
+});
+
+test("parsePostGateVerdictFallbackCliArgs accepts well-formed arguments", () => {
+  const parseError = buildParseError("Usage: ...");
+  const parsed = parsePostGateVerdictFallbackCliArgs(
+    [
+      "--repo",
+      "owner/repo",
+      "--pr",
+      "17",
+      "--head-sha",
+      "abc1234",
+      "--verdict",
+      "clean",
+      "--findings-summary",
+      "ok",
+      "--next-action",
+      "go",
+    ],
+    { parseError },
+  );
+  assert.equal(parsed.repo, "owner/repo");
+  assert.equal(parsed.pr, 17);
+  assert.equal(parsed.headSha, "abc1234");
+  assert.equal(parsed.verdict, "clean");
+  assert.equal(parsed.findingsSummary, "ok");
+  assert.equal(parsed.nextAction, "go");
+});
+
+test("runCli posts via gh and emits a degraded-mode warning", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loop-gate-fallback-"));
+  try {
+    const stub = await writeGhStub(
+      tempDir,
+      [
+        {
+          assertArgIncludes: ["api", "repos/owner/repo/issues/17/comments"],
+          assertStdinIncludes: ["### Gate review: `draft_gate`"],
+          stdout: '{"id":101,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-101"}\n',
+        },
+      ],
+      {},
+    );
+    const stdout = [];
+    const stderr = [];
+    const exitCode = await runCli(
+      [
+        "--repo",
+        "owner/repo",
+        "--pr",
+        "17",
+        "--head-sha",
+        "abc1234",
+        "--verdict",
+        "clean",
+        "--findings-summary",
+        "no issues found",
+        "--next-action",
+        "mark ready for review",
+      ],
+      {
+        env: stub.env,
+        spawn: spawn,
+        ghCommand: "gh",
+        stdoutSink: stdout,
+        stderrSink: stderr,
+      },
+    );
+    assert.equal(exitCode, 0);
+    const result = JSON.parse(stdout.join(""));
+    assert.equal(result.ok, true);
+    assert.equal(result.action, "created");
+    assert.equal(result.commentId, 101);
+    assert.equal(result.commentUrl, "https://github.com/owner/repo/pull/17#issuecomment-101");
+    assert.equal(result.gate, "draft_gate");
+    assert.equal(result.fallback, true);
+    assert.match(stderr.join(""), /fallback mode active/i);
+    assert.match(stderr.join(""), /audit trail is degraded/i);
+    const counterText = await readFile(stub.counterPath, "utf8");
+    assert.equal(counterText.trim(), "1");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("runCli fails closed (non-zero exit) when gh posting fails", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loop-gate-fallback-"));
+  try {
+    const stub = await writeGhStub(
+      tempDir,
+      [
+        {
+          assertArgIncludes: ["api", "repos/owner/repo/issues/17/comments"],
+          stderr: "gh: POST failed: 403 (Resource not accessible by integration)\n",
+          exitCode: 1,
+        },
+      ],
+      {},
+    );
+    let caught = null;
+    try {
+      await runCli(
+        [
+          "--repo",
+          "owner/repo",
+          "--pr",
+          "17",
+          "--head-sha",
+          "abc1234",
+          "--verdict",
+          "clean",
+          "--findings-summary",
+          "no issues found",
+          "--next-action",
+          "mark ready for review",
+        ],
+        {
+          env: stub.env,
+          spawn: spawn,
+          ghCommand: "gh",
+          stdoutSink: [],
+          stderrSink: [],
+        },
+      );
+    } catch (err) {
+      caught = err;
+    }
+    assert.ok(caught instanceof Error, "expected runCli to throw on posting failure");
+    assert.match(String(caught.message), /gh api failed to post gate verdict comment/i);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("runCli reads --findings-file when provided instead of inline summary", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loop-gate-fallback-"));
+  try {
+    const findingsPath = path.join(tempDir, "findings.md");
+    await writeFile(findingsPath, "no issues found\n", "utf8");
+    const stub = await writeGhStub(
+      tempDir,
+      [
+        {
+          assertArgIncludes: ["api", "repos/owner/repo/issues/17/comments"],
+          assertStdinIncludes: ["**Findings summary:** no issues found"],
+          stdout: '{"id":102,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-102"}\n',
+        },
+      ],
+      {},
+    );
+    const stdout = [];
+    await runCli(
+      [
+        "--repo",
+        "owner/repo",
+        "--pr",
+        "17",
+        "--head-sha",
+        "abc1234",
+        "--verdict",
+        "clean",
+        "--findings-file",
+        findingsPath,
+        "--next-action",
+        "mark ready for review",
+      ],
+      {
+        env: stub.env,
+        spawn: spawn,
+        ghCommand: "gh",
+        stdoutSink: stdout,
+        stderrSink: [],
+      },
+    );
+    const result = JSON.parse(stdout.join(""));
+    assert.equal(result.ok, true);
+    assert.equal(result.commentId, 102);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("CLI integration: posts via the real node CLI when gh is stubbed", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loop-gate-fallback-cli-"));
+  try {
+    const stub = await writeGhStub(
+      tempDir,
+      [
+        {
+          assertArgIncludes: ["api", "repos/owner/repo/issues/17/comments"],
+          assertStdinIncludes: ["### Gate review: `pre_approval_gate`"],
+          stdout: '{"id":303,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-303"}\n',
+        },
+      ],
+      {},
+    );
+    const result = await runNode(
+      [
+        "--repo",
+        "owner/repo",
+        "--pr",
+        "17",
+        "--head-sha",
+        "abc1234",
+        "--verdict",
+        "clean",
+        "--findings-summary",
+        "ok",
+        "--next-action",
+        "await final human approval",
+        "--gate",
+        "pre_approval_gate",
+      ],
+      stub.env,
+    );
+    assert.equal(result.code, 0);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.action, "created");
+    assert.equal(parsed.gate, "pre_approval_gate");
+    assert.equal(parsed.fallback, true);
+    assert.match(result.stderr, /fallback mode active/i);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("CLI integration: fails closed with non-zero exit when gh posting fails", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loop-gate-fallback-cli-"));
+  try {
+    const stub = await writeGhStub(
+      tempDir,
+      [
+        {
+          assertArgIncludes: ["api", "repos/owner/repo/issues/17/comments"],
+          stderr: "gh: POST failed: 500 (internal)\n",
+          exitCode: 1,
+        },
+      ],
+      {},
+    );
+    const result = await runNode(
+      [
+        "--repo",
+        "owner/repo",
+        "--pr",
+        "17",
+        "--head-sha",
+        "abc1234",
+        "--verdict",
+        "clean",
+        "--findings-summary",
+        "ok",
+        "--next-action",
+        "go",
+      ],
+      stub.env,
+    );
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr, /gh api failed to post gate verdict comment/i);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
@@ -497,6 +497,13 @@ test("runCli reads --findings-file when provided instead of inline summary", asy
         stderrSink: [],
       },
     );
+    const result = JSON.parse(stdout.join(""));
+    assert.equal(result.ok, true);
+    assert.equal(result.commentId, 102);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
 
 test("runCli rejects --findings-file that contains only whitespace", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loop-gate-fallback-wn-1"));
@@ -532,12 +539,6 @@ test("runCli rejects --findings-file that contains only whitespace", async () =>
       ),
       /empty or contains only whitespace/,
     );
-  } finally {
-    await rm(tempDir, { recursive: true, force: true });
-  }
-});    const result = JSON.parse(stdout.join(""));
-    assert.equal(result.ok, true);
-    assert.equal(result.commentId, 102);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
@@ -584,7 +584,9 @@ test("runCli preserves internal newlines and leading content from --findings-fil
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
-});test("runCli rejects --findings-file that contains only whitespace", async () => {
+});
+
+test("runCli rejects --findings-file that contains only whitespace", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loop-gate-fallback-wn-1"));
   try {
     const findingsPath = path.join(tempDir, "findings.md");

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
@@ -173,7 +173,30 @@ test("renderFallbackGateReviewCommentBody preserves leading content in findingsS
   assert.match(body, /\*\*Findings summary:\*\*   leading-space summary/);
 });
 
-test("parsePostGateVerdictFallbackCliArgs rejects missing required flags", () => {
+
+test("parsePostGateVerdictFallbackCliArgs reports a clear error when a flag is followed by another flag", () => {
+  const parseError = buildParseError("Usage: ...");
+  assert.throws(
+    () =>
+      parsePostGateVerdictFallbackCliArgs(
+        [
+          "--repo",
+          "--pr",
+          "17",
+          "--head-sha",
+          "abc1234",
+          "--verdict",
+          "clean",
+          "--findings-summary",
+          "ok",
+          "--next-action",
+          "go",
+        ],
+        { parseError },
+      ),
+    /--repo requires a non-empty value \(got "--pr"\)/,
+  );
+});test("parsePostGateVerdictFallbackCliArgs rejects missing required flags", () => {
   const parseError = buildParseError("Usage: ...");
   assert.throws(
     () => parsePostGateVerdictFallbackCliArgs([], { parseError }),

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
@@ -250,6 +250,80 @@ test("parsePostGateVerdictFallbackCliArgs rejects malformed repo slug", () => {
     /--repo must be of the form owner\/name/,
   );
 });
+test("parsePostGateVerdictFallbackCliArgs rejects repo slug with whitespace segments", () => {
+  const parseError = buildParseError("Usage: ...");
+  assert.throws(
+    () =>
+      parsePostGateVerdictFallbackCliArgs(
+        [
+          "--repo",
+          "own er/repo",
+          "--pr",
+          "17",
+          "--head-sha",
+          "abc1234",
+          "--verdict",
+          "clean",
+          "--findings-summary",
+          "ok",
+          "--next-action",
+          "go",
+        ],
+        { parseError },
+      ),
+    /--repo must be of the form owner\/name/,
+  );
+});
+
+test("parsePostGateVerdictFallbackCliArgs rejects repo slug with dot-dot segments", () => {
+  const parseError = buildParseError("Usage: ...");
+  assert.throws(
+    () =>
+      parsePostGateVerdictFallbackCliArgs(
+        [
+          "--repo",
+          "..\//repo",
+          "--pr",
+          "17",
+          "--head-sha",
+          "abc1234",
+          "--verdict",
+          "clean",
+          "--findings-summary",
+          "ok",
+          "--next-action",
+          "go",
+        ],
+        { parseError },
+      ),
+    /--repo must be of the form owner\/name/,
+  );
+});
+
+test("parsePostGateVerdictFallbackCliArgs rejects repo slug with more than one slash", () => {
+  const parseError = buildParseError("Usage: ...");
+  assert.throws(
+    () =>
+      parsePostGateVerdictFallbackCliArgs(
+        [
+          "--repo",
+          "owner/repo/extra",
+          "--pr",
+          "17",
+          "--head-sha",
+          "abc1234",
+          "--verdict",
+          "clean",
+          "--findings-summary",
+          "ok",
+          "--next-action",
+          "go",
+        ],
+        { parseError },
+      ),
+    /--repo must be of the form owner\/name/,
+  );
+});
 
 test("parsePostGateVerdictFallbackCliArgs accepts well-formed arguments", () => {
   const parseError = buildParseError("Usage: ...");
@@ -423,7 +497,45 @@ test("runCli reads --findings-file when provided instead of inline summary", asy
         stderrSink: [],
       },
     );
-    const result = JSON.parse(stdout.join(""));
+
+test("runCli rejects --findings-file that contains only whitespace", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loop-gate-fallback-wn-1"));
+  try {
+    const findingsPath = path.join(tempDir, "findings.md");
+    await writeFile(findingsPath, "   \n\t\n  \n", "utf8");
+    const stub = await writeGhStub(tempDir, [], {});
+    const stdout = [];
+    const stderr = [];
+    await assert.rejects(
+      runCli(
+        [
+          "--repo",
+          "owner/repo",
+          "--pr",
+          "17",
+          "--head-sha",
+          "abc1234",
+          "--verdict",
+          "clean",
+          "--findings-file",
+          findingsPath,
+          "--next-action",
+          "mark ready for review",
+        ],
+        {
+          env: stub.env,
+          spawn: spawn,
+          ghCommand: "gh",
+          stdoutSink: stdout,
+          stderrSink: stderr,
+        },
+      ),
+      /empty or contains only whitespace/,
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});    const result = JSON.parse(stdout.join(""));
     assert.equal(result.ok, true);
     assert.equal(result.commentId, 102);
   } finally {

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
@@ -94,7 +94,7 @@ async function writeGhStub(tempDir, entries = [], { defaultStdout, exitCode = 0 
       PATH: [tempDir, process.env.PATH ?? ""].filter(Boolean).join(path.delimiter),
       GH_SEQUENCE_PATH: sequencePath,
       GH_COUNTER_PATH: counterPath,
-      GH_DEFAULT_STDOUT: defaultStdout ?? "",
+      ...(defaultStdout === undefined ? {} : { GH_DEFAULT_STDOUT: defaultStdout }),
       GH_EXIT_CODE: String(exitCode),
     },
     ghPath,
@@ -139,6 +139,38 @@ test("renderFallbackGateReviewCommentBody omits blocking severities line when ve
     nextAction: "mark ready for review",
   });
   assert.doesNotMatch(body, /\*\*Blocking severities:\*\*/);
+});
+test("renderFallbackGateReviewCommentBody preserves full template structure when findingsSummary is large", () => {
+  const huge = "x".repeat(5000);
+  const body = renderFallbackGateReviewCommentBody({
+    gate: "draft_gate",
+    headSha: "abc1234",
+    verdict: "clean",
+    findingsSummary: huge,
+    nextAction: "mark ready for review",
+  });
+  // Template structure stays intact so parseGateReviewCommentBody() never loses required fields.
+  assert.match(body, /### Gate review: `draft_gate`/);
+  assert.match(body, /\*\*Reviewed head SHA:\*\* `abc1234`/);
+  assert.match(body, /\*\*Verdict:\*\* clean/);
+  assert.match(body, /\*\*Next action:\*\* mark ready for review/);
+  // Findings summary is truncated per-field, not the whole body.
+  const summaryLine = body.split("\n").find((line) => line.startsWith("**Findings summary:**"));
+  assert.ok(summaryLine, "findings summary line present");
+  assert.ok(summaryLine.length < huge.length + 200, "summary line is truncated per-field");
+  assert.match(summaryLine, /\[truncated \d+ chars\]/);
+});
+
+test("renderFallbackGateReviewCommentBody preserves leading content in findingsSummary", () => {
+  // Caller-controlled summaries should not have leading whitespace stripped.
+  const body = renderFallbackGateReviewCommentBody({
+    gate: "draft_gate",
+    headSha: "abc1234",
+    verdict: "clean",
+    findingsSummary: "  leading-space summary\n  second line",
+    nextAction: "mark ready for review",
+  });
+  assert.match(body, /\*\*Findings summary:\*\*   leading-space summary/);
 });
 
 test("parsePostGateVerdictFallbackCliArgs rejects missing required flags", () => {
@@ -505,7 +537,54 @@ test("runCli reads --findings-file when provided instead of inline summary", asy
   }
 });
 
-test("runCli rejects --findings-file that contains only whitespace", async () => {
+
+test("runCli preserves internal newlines and leading content from --findings-file", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loop-gate-fallback-wn-2-"));
+  try {
+    const findingsPath = path.join(tempDir, "findings.md");
+    await writeFile(findingsPath, "  first line\n  second line\n", "utf8");
+    const stub = await writeGhStub(
+      tempDir,
+      [
+        {
+          assertArgIncludes: ["api", "repos/owner/repo/issues/17/comments"],
+          assertStdinIncludes: ["**Findings summary:**   first line\\n  second line"],
+          stdout: '{"id":104,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-104"}\n',
+        },
+      ],
+      {},
+    );
+    const stdout = [];
+    await runCli(
+      [
+        "--repo",
+        "owner/repo",
+        "--pr",
+        "17",
+        "--head-sha",
+        "abc1234",
+        "--verdict",
+        "clean",
+        "--findings-file",
+        findingsPath,
+        "--next-action",
+        "mark ready for review",
+      ],
+      {
+        env: stub.env,
+        spawn: spawn,
+        ghCommand: "gh",
+        stdoutSink: stdout,
+        stderrSink: [],
+      },
+    );
+    const result = JSON.parse(stdout.join(""));
+    assert.equal(result.ok, true);
+    assert.equal(result.commentId, 104);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});test("runCli rejects --findings-file that contains only whitespace", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loop-gate-fallback-wn-1"));
   try {
     const findingsPath = path.join(tempDir, "findings.md");


### PR DESCRIPTION
## Summary

Fixes #761. When a consumer repo runs `auto dev loop` (or `dev-loop`) with the `dev-loop` skill installed but `@pi-dev-loops/core` not available, the fallback prose pipeline runs validation but skips the visible draft-gate and pre-approval-gate verdict comments. The PR can reach merge-ready state with no gate evidence on the conversation.

This PR adds a small gh-only fallback poster (`skills/dev-loop/scripts/post-gate-verdict-fallback.mjs`) shipped inside the dev-loop skill bundle so the same visible comment format is posted from the fallback path, with an explicit stderr warning that the audit trail is degraded and a fail-closed exit when posting cannot succeed.

## Acceptance Criteria / Definition of Done

| AC | DoD gate | Status |
|----|----------|--------|
| AC1 — Fallback mode posts the same visible comment format as the full helper when posting succeeds | New `post-gate-verdict-fallback.mjs` renders the same parser-stable body; tests `renderFallbackGateReviewCommentBody matches the full helper's visible format` and `runCli posts via gh and emits a degraded-mode warning` pass | Done |
| AC2 — Fallback mode fails closed when posting fails (non-zero exit, clear stderr error) | `postGateVerdictViaGh` rejects on non-zero gh exit and missing comment id/html_url; tests `runCli fails closed (non-zero exit) when gh posting fails` and `CLI integration: fails closed with non-zero exit when gh posting fails` pass | Done |
| AC3 — Fallback mode emits an explicit stderr warning that fallback mode is active and the audit trail is degraded | `buildFallbackWarning()` is emitted before posting; tests assert the warning text; `result.warning` is also returned on stdout JSON for downstream consumers | Done |
| AC4 — `npm run verify` passes with no regressions | Full verify run is green (24 dev-loop tests including 14 new, 86 assets, 63 extension, 1464 scripts, 1401 core, docs lint clean) | Done |
| AC5 — Draft PR opened with `Closes #761`, self-assigned, draft-first | This PR uses `dev-loops pr create-draft --assignee @me ...`; body contains `Closes #761` | Done |

## Non-goals

- No refactor or replacement of the full `scripts/github/upsert-checkpoint-verdict.mjs` helper.
- No new top-level npm dependencies. The fallback uses only `node:fs/promises`, `node:child_process`, and `node:url`.
- No rewrite of the dev-loop agent prose fallback path itself. The fix is additive: a small helper plus a focused SKILL.md section that points the agent at it when the full helper is unreachable.
- No inline copy of `@pi-dev-loops/core/loop/validate-summary` or other validation-summary parser. The fallback accepts pre-formatted `--findings-summary` / `--findings-file` from the caller.

## Degraded semantics (vs. the full helper)

The fallback is explicitly a degraded path. Each successful post is documented to the operator via stderr and on stdout JSON `warning`. Skipped behaviors:

- one-shot create only (no idempotent same-head update)
- no stale-head detection against existing comments
- no gate-coordination state validation
- no blocking-severity count enforcement
- no internal-only PR short-circuit

When `@pi-dev-loops/core` is available again, operators should switch back to the full helper. The fallback is not a permanent replacement.

## Test coverage

`skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs` (14 tests, all passing):

- body rendering matches the full helper's visible format
- body rendering includes blocking severities for `findings_present` verdicts
- body rendering omits the blocking-severities line for `clean` verdicts without a blocking list
- CLI argument validation: missing required flags, malformed gate, malformed verdict, malformed head SHA, malformed repo slug
- CLI argument validation accepts well-formed arguments
- `runCli` posts via gh and emits a degraded-mode warning (counter advances)
- `runCli` fails closed when gh posting fails
- `runCli` reads `--findings-file` instead of inline summary
- CLI integration: full `node` invocation with stubbed `gh` posts and returns the comment URL
- CLI integration: full `node` invocation with failing `gh` exits non-zero with a clear error

## Files

- `skills/dev-loop/scripts/post-gate-verdict-fallback.mjs` — new
- `skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs` — new
- `skills/dev-loop/SKILL.md` — adds the "Fallback gate-comment poster" section
- `package.json` — wires the new test into `test:dev-loop`

`Closes #761`
