### PR TITLE
CI: compile + publish repo wiki to GitHub Wiki

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -98,7 +98,7 @@ jobs:
           LLMWIKI_PUBLISH_REMOTE: https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.wiki.git
         run: |
           npm run repo-wiki -- publish --target github-wiki || {
-            echo '::error::Wiki publish failed. Wiki feature not enabled — enable in Settings → Features → Wikis.'
-            echo "Wiki feature not enabled — enable in Settings → Features → Wikis" >> "$GITHUB_STEP_SUMMARY"
+            echo '::error::Wiki publish failed. If the Wiki feature is disabled, enable it in Settings → General → Features → Wikis.'
+            echo "Wiki publish failed — if the Wiki feature is disabled, enable it in Settings → General → Features → Wikis" >> "$GITHUB_STEP_SUMMARY"
             exit 1
           }

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -1,0 +1,126 @@
+name: Compile and publish repo wiki
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Wiki compile mode
+        required: true
+        default: bootstrap
+        type: choice
+        options:
+          - bootstrap
+          - incremental
+      publish_wiki:
+        description: Publish compiled wiki to GitHub Wiki
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+  push:
+    branches:
+      - main
+
+jobs:
+  compile-wiki:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Determine mode
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "MODE=${{ github.event.inputs.mode }}" >> "$GITHUB_ENV"
+          else
+            echo "MODE=incremental" >> "$GITHUB_ENV"
+          fi
+
+      - name: Scan
+        run: node scripts/repo-wiki.mjs scan --mode "$MODE" --repo . --out .llmwiki/run
+
+      - name: Plan
+        run: node scripts/repo-wiki.mjs plan --scan .llmwiki/run --out .llmwiki/plan.json
+
+      - name: Compile
+        env:
+          LLMWIKI_COMPILER_MODE: ${{ vars.LLMWIKI_COMPILER_MODE }}
+          LLMWIKI_LLM_PROVIDER: ${{ vars.LLMWIKI_LLM_PROVIDER }}
+          LLMWIKI_LLM_BASE_URL: ${{ vars.LLMWIKI_LLM_BASE_URL }}
+          LLMWIKI_LLM_MODEL: ${{ vars.LLMWIKI_LLM_MODEL }}
+          LLMWIKI_LLM_ARCHITECTURE_MODEL: ${{ vars.LLMWIKI_LLM_ARCHITECTURE_MODEL }}
+          LLMWIKI_LLM_TEMPERATURE: ${{ vars.LLMWIKI_LLM_TEMPERATURE }}
+          LLMWIKI_LLM_REASONING_EFFORT: ${{ vars.LLMWIKI_LLM_REASONING_EFFORT }}
+          LLMWIKI_LLM_MAX_OUTPUT_TOKENS: ${{ vars.LLMWIKI_LLM_MAX_OUTPUT_TOKENS }}
+          LLMWIKI_LLM_ARCHITECTURE_MAX_OUTPUT_TOKENS: ${{ vars.LLMWIKI_LLM_ARCHITECTURE_MAX_OUTPUT_TOKENS }}
+          LLMWIKI_LLM_TIMEOUT_MS: ${{ vars.LLMWIKI_LLM_TIMEOUT_MS }}
+          LLMWIKI_LLM_ARCHITECTURE_TIMEOUT_MS: ${{ vars.LLMWIKI_LLM_ARCHITECTURE_TIMEOUT_MS || vars.LLMWIKI_LLM_TIMEOUT_MS || '180000' }}
+          LLMWIKI_LLM_ARCHITECTURE_REASONING_EFFORT: ${{ vars.LLMWIKI_LLM_ARCHITECTURE_REASONING_EFFORT || 'low' }}
+          LLMWIKI_LLM_RETRIES: ${{ vars.LLMWIKI_LLM_RETRIES }}
+          LLMWIKI_LLM_API_KEY: ${{ secrets.LLMWIKI_LLM_API_KEY || '' }}
+          LLMWIKI_LLM_SYSTEM_PROMPT: ${{ vars.LLMWIKI_LLM_SYSTEM_PROMPT }}
+          LLMWIKI_LLM_SYSTEM_PROMPT_FILE: ${{ vars.LLMWIKI_LLM_SYSTEM_PROMPT_FILE }}
+        run: node scripts/repo-wiki.mjs compile --scan .llmwiki/run --plan .llmwiki/plan.json --wiki .llmwiki/wiki
+
+      - name: Lint
+        continue-on-error: true
+        run: node scripts/repo-wiki.mjs lint --wiki .llmwiki/wiki --scan .llmwiki/run
+
+      - name: Upload compiled wiki
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compiled-wiki
+          path: .llmwiki/wiki
+
+  publish-wiki:
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_wiki == 'true')
+    needs: compile-wiki
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download compiled wiki
+        uses: actions/download-artifact@v4
+        with:
+          name: compiled-wiki
+          path: .llmwiki/wiki
+
+      - name: Publish wiki
+        env:
+          LLMWIKI_PUBLISH_REMOTE: https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.wiki.git
+        run: |
+          node scripts/repo-wiki.mjs publish --target github-wiki --wiki .llmwiki/wiki || {
+            echo '::error::Wiki publish failed. Wiki feature not enabled — enable in Settings → Features → Wikis.'
+            echo "Wiki feature not enabled — enable in Settings → Features → Wikis" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          }

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -3,14 +3,6 @@ name: Compile and publish repo wiki
 on:
   workflow_dispatch:
     inputs:
-      mode:
-        description: Wiki compile mode
-        required: true
-        default: bootstrap
-        type: choice
-        options:
-          - bootstrap
-          - incremental
       publish_wiki:
         description: Publish compiled wiki to GitHub Wiki
         required: true
@@ -44,21 +36,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Determine mode
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "MODE=${{ github.event.inputs.mode }}" >> "$GITHUB_ENV"
-          else
-            echo "MODE=incremental" >> "$GITHUB_ENV"
-          fi
-
-      - name: Scan
-        run: node scripts/repo-wiki.mjs scan --mode "$MODE" --repo . --out .llmwiki/run
-
-      - name: Plan
-        run: node scripts/repo-wiki.mjs plan --scan .llmwiki/run --out .llmwiki/plan.json
-
-      - name: Compile
+      - name: Bootstrap wiki (scan + plan + compile)
         env:
           LLMWIKI_COMPILER_MODE: ${{ vars.LLMWIKI_COMPILER_MODE }}
           LLMWIKI_LLM_PROVIDER: ${{ vars.LLMWIKI_LLM_PROVIDER }}
@@ -76,11 +54,11 @@ jobs:
           LLMWIKI_LLM_API_KEY: ${{ secrets.LLMWIKI_LLM_API_KEY || '' }}
           LLMWIKI_LLM_SYSTEM_PROMPT: ${{ vars.LLMWIKI_LLM_SYSTEM_PROMPT }}
           LLMWIKI_LLM_SYSTEM_PROMPT_FILE: ${{ vars.LLMWIKI_LLM_SYSTEM_PROMPT_FILE }}
-        run: node scripts/repo-wiki.mjs compile --scan .llmwiki/run --plan .llmwiki/plan.json --wiki .llmwiki/wiki
+        run: npm run repo-wiki:bootstrap
 
       - name: Lint
         continue-on-error: true
-        run: node scripts/repo-wiki.mjs lint --wiki .llmwiki/wiki --scan .llmwiki/run
+        run: npm run repo-wiki:lint
 
       - name: Upload compiled wiki
         if: always()
@@ -119,7 +97,7 @@ jobs:
         env:
           LLMWIKI_PUBLISH_REMOTE: https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.wiki.git
         run: |
-          node scripts/repo-wiki.mjs publish --target github-wiki --wiki .llmwiki/wiki || {
+          npm run repo-wiki -- publish --target github-wiki || {
             echo '::error::Wiki publish failed. Wiki feature not enabled — enable in Settings → Features → Wikis.'
             echo "Wiki feature not enabled — enable in Settings → Features → Wikis" >> "$GITHUB_STEP_SUMMARY"
             exit 1

--- a/docs/repo-wiki-manual-first.md
+++ b/docs/repo-wiki-manual-first.md
@@ -165,6 +165,54 @@ node --test test/loop/repo-wiki.test.mjs test/loop/repo-wiki-local.test.mjs
 npm run verify
 ```
 
+## CI automation
+
+A GitHub Actions workflow at `.github/workflows/wiki.yml` compiles the repository wiki and, on pushes to `main` (or on demand via `workflow_dispatch`), publishes the compiled pages to the GitHub Wiki.
+
+### Triggers
+
+- `push` to `main` — compiles in `incremental` mode and publishes to the wiki.
+- `workflow_dispatch` — choose `bootstrap` or `incremental`, and opt in to `publish_wiki`.
+
+### Required operator setup
+
+1. **Secret** (Settings → Secrets and variables → Actions → Secrets):
+   - `LLMWIKI_LLM_API_KEY` — OpenAI-compatible API key. Required only when `LLMWIKI_COMPILER_MODE=llm`.
+2. **Variable** (Settings → Secrets and variables → Actions → Variables) — **only if LLM mode is desired**:
+   - `LLMWIKI_COMPILER_MODE=llm`
+   - Without this var, the workflow uses the deterministic baseline from `.llmwiki/config.json` and does not consume the API key.
+3. **Optional provider variables** (when LLM mode is enabled):
+   - `LLMWIKI_LLM_PROVIDER`
+   - `LLMWIKI_LLM_BASE_URL`
+   - `LLMWIKI_LLM_MODEL`
+   - `LLMWIKI_LLM_ARCHITECTURE_MODEL`
+   - `LLMWIKI_LLM_TEMPERATURE`
+   - `LLMWIKI_LLM_REASONING_EFFORT`
+   - `LLMWIKI_LLM_MAX_OUTPUT_TOKENS`
+   - `LLMWIKI_LLM_ARCHITECTURE_MAX_OUTPUT_TOKENS`
+   - `LLMWIKI_LLM_TIMEOUT_MS`
+   - `LLMWIKI_LLM_ARCHITECTURE_TIMEOUT_MS`
+   - `LLMWIKI_LLM_ARCHITECTURE_REASONING_EFFORT`
+   - `LLMWIKI_LLM_RETRIES`
+   - `LLMWIKI_LLM_SYSTEM_PROMPT`
+   - `LLMWIKI_LLM_SYSTEM_PROMPT_FILE`
+4. **Repo Wiki feature**:
+   - Confirm Wikis are enabled: Settings → General → Features → Wikis. If disabled, the `publish-wiki` job fails with a clear run summary message.
+
+### Workflow jobs
+
+- `compile-wiki` — checks out the repo, installs Node.js 24 dependencies, runs `scan`, `plan`, `compile`, and `lint`, then uploads `.llmwiki/wiki` as the `compiled-wiki` artifact.
+- `publish-wiki` — downloads the artifact and pushes it to `${{ github.repository }}.wiki.git` using `secrets.GITHUB_TOKEN`.
+
+### Local commands still work
+
+The CI workflow does not replace the local command surface. The existing npm scripts remain the recommended local path:
+
+```bash
+npm run repo-wiki:bootstrap
+npm run repo-wiki:lint
+```
+
 ## Deferred work
 
 Still deferred from this slice:

--- a/docs/repo-wiki-manual-first.md
+++ b/docs/repo-wiki-manual-first.md
@@ -23,7 +23,7 @@ This is the recommended path for normal local use. The npm wrapper at `scripts/r
 
 Pinned npm version used by the wrapper:
 
-- `@mfittko/repo-wiki@0.2.4`
+- `@mfittko/repo-wiki@0.2.6`
 
 ### Fallback path: pinned local helper
 

--- a/docs/repo-wiki-manual-first.md
+++ b/docs/repo-wiki-manual-first.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-This repository now has a **local runnable `repo-wiki` export path** that works from a clean checkout, using the published npm package as the primary install route and a pinned local-helper fallback for environments that cannot reach npm or that require a deterministic source pin.
+This repository now has a **local runnable `repo-wiki` export path** and a GitHub Actions CI workflow that compiles the wiki and publishes it to the repository's GitHub Wiki. The primary install route is the published npm package, with a pinned local-helper fallback for environments that cannot reach npm or require a deterministic source pin.
 
-This slice is intentionally limited to local export. It does **not** claim that `repo-wiki` is ready for GitHub Wiki publication, scheduled sync, or CI automation from this repository yet.
+Scheduled sync remains out of scope.
 
 Source files in this repository remain authoritative. Generated wiki output is a navigation aid, not the source of truth.
 
@@ -171,8 +171,8 @@ A GitHub Actions workflow at `.github/workflows/wiki.yml` compiles the repositor
 
 ### Triggers
 
-- `push` to `main` — compiles in `incremental` mode and publishes to the wiki.
-- `workflow_dispatch` — choose `bootstrap` or `incremental`, and opt in to `publish_wiki`.
+- `push` to `main` — runs the `compile-wiki` job and, because it is on `main`, the `publish-wiki` job.
+- `workflow_dispatch` — optionally opt in to `publish_wiki` after `compile-wiki` succeeds. The compile job always runs `npm run repo-wiki:bootstrap` (scan + plan + compile).
 
 ### Required operator setup
 
@@ -201,8 +201,8 @@ A GitHub Actions workflow at `.github/workflows/wiki.yml` compiles the repositor
 
 ### Workflow jobs
 
-- `compile-wiki` — checks out the repo, installs Node.js 24 dependencies, runs `scan`, `plan`, `compile`, and `lint`, then uploads `.llmwiki/wiki` as the `compiled-wiki` artifact.
-- `publish-wiki` — downloads the artifact and pushes it to `${{ github.repository }}.wiki.git` using `secrets.GITHUB_TOKEN`.
+- `compile-wiki` — checks out the repo, installs Node.js 24 dependencies, runs `npm run repo-wiki:bootstrap` (chained scan + plan + compile) and `npm run repo-wiki:lint`, then uploads `.llmwiki/wiki` as the `compiled-wiki` artifact.
+- `publish-wiki` — downloads the artifact and pushes it to `${{ github.repository }}.wiki.git` using `secrets.GITHUB_TOKEN` via `npm run repo-wiki -- publish --target github-wiki`.
 
 ### Local commands still work
 
@@ -217,8 +217,6 @@ npm run repo-wiki:lint
 
 Still deferred from this slice:
 
-- GitHub Wiki publish from this repository
-- CI automation for wiki export/publish
 - scheduled sync
 
-Those should come back as separate follow-up work once the local manual-first path is stable enough and the publish target/packaging story is intentionally chosen. The `repo-wiki publish` subcommand exists upstream but is intentionally not wired into a script by this slice.
+GitHub Wiki publishing and CI automation are now wired via `.github/workflows/wiki.yml`. Further enhancements (scheduled sync, additional modes, Pages publishing) should come back as separate follow-up work.

--- a/scripts/repo-wiki.mjs
+++ b/scripts/repo-wiki.mjs
@@ -12,7 +12,7 @@ import { isDirectCliRun } from "@pi-dev-loops/core/cli/helpers";
 // Pinned to the latest published release at the time this slice was opened.
 // Bump deliberately when the consumer repo wants to adopt a newer release.
 export const REPO_WIKI_NPM_PACKAGE = "@mfittko/repo-wiki";
-export const REPO_WIKI_NPM_VERSION = "0.2.4";
+export const REPO_WIKI_NPM_VERSION = "0.2.6";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = path.resolve(__dirname, "..");


### PR DESCRIPTION
## Summary

Adds a `.github/workflows/wiki.yml` CI workflow that compiles the repository wiki and publishes the compiled output to the GitHub Wiki on pushes to `main` (with optional `workflow_dispatch` for on-demand runs). The workflow defaults to deterministic mode via `.llmwiki/config.json`; LLM mode is opt-in through the `LLMWIKI_COMPILER_MODE` repository variable.

Closes #778

## AC / DoD matrix

| #778 item | Status | Notes |
|---|---|---|
| **AC1** — `.github/workflows/wiki.yml` with `compile-wiki` and `publish-wiki` jobs | ✅ | `publish-pages` intentionally skipped per non-goals |
| **AC2** — `compile-wiki` runs on `push` to `main` and `workflow_dispatch`; checkout@v5, setup-node@v5 (node 24), npm ci; `npm run repo-wiki:bootstrap` (chained scan/plan/compile) against `.llmwiki/`; lint via `npm run repo-wiki:lint`; uploads `compiled-wiki` artifact | ✅ | Lint step uses `continue-on-error: true` to avoid the known pre-existing finding blocking the build |
| **AC3** — Honors `LLMWIKI_COMPILER_MODE` and passes `LLMWIKI_LLM_API_KEY` only when present | ✅ | Defaults to deterministic when var unset |
| **AC4** — `publish-wiki` gated to `push` on `main` (or `workflow_dispatch` with `publish_wiki=true`); uses `${{ github.repository }}.wiki.git` with `github.token` | ✅ | Publish command `npm run repo-wiki -- publish --target github-wiki`; `contents: write` permission set |
| **AC5** — Clear failure mode when Wiki feature disabled | ✅ | Publish step catches failure and writes `Wiki feature not enabled — enable in Settings → Features → Wikis` to run summary |
| **AC6** — Respects `.llmwiki/config.json` deterministic baseline without forcing mode flip | ✅ | No env override of config mode unless operator sets the var |
| **AC7** — `npm run verify` passes; workflow YAML valid | ✅ | See validation evidence below |
| **AC8** — `npm run repo-wiki:bootstrap` still works | ✅ | Ran locally; deterministic compile succeeded |
| **AC9** — CI automation section added to `docs/repo-wiki-manual-first.md` | ✅ | Secret/vars/checklist documented |
| **DoD** — Ready for review; `draft_gate` and `pre_approval_gate` clean at current head; all review threads resolved | ✅ | Stopping at human approval per #778 |

## Non-goals (unchanged from #778)

- Migrating `repo-wiki:bootstrap` into a CI-only path — local scripts remain intact.
- LLM-by-default — deterministic remains the default.
- Replacing deterministic mode anywhere.
- GitHub Pages publishing — `publish-pages` not added.
- Cron scheduling.
- Treating generated wiki as source of truth.
- New top-level npm dependencies.

## Validation evidence

- `npm run verify`: **pass** (all suites green)
  - test:assets 86 pass
  - test:extension 63 pass
  - test:scripts 1428 pass / 36 skipped
  - test:core 1401 pass
  - test:docs links + duplicate-rule checks pass
  - test:dev-loop 32 pass
- `npx --yes js-yaml .github/workflows/wiki.yml`: **valid YAML**
- `npm run repo-wiki:bootstrap`: **pass** — deterministic compile produced 22 pages, 0 LLM pages
- `git diff --check`: **no whitespace errors**

## Operator checklist

See #778 **Operator setup (post-merge)**. After merge, confirm:

1. Secret `LLMWIKI_LLM_API_KEY` is set (only needed for LLM mode).
2. Variable `LLMWIKI_COMPILER_MODE=llm` is set **only if** LLM mode is desired.
3. Optional provider vars are set if using a non-OpenAI endpoint.
4. Repo Wiki feature is enabled at Settings → General → Features → Wikis.


