### PR TITLE
Rename package surface from pi-dev-loops to dev-loops

### DIFF
--- a/.devloops
+++ b/.devloops
@@ -68,7 +68,7 @@ localImplementation:
     maxLines: 100
 
 queue:
-  boardTitle: "pi-dev-loops Queue"
+  boardTitle: "dev-loops Queue"
   maxParallel: 3
   maxAutoFiledIssues: 10
   reDispatchMaxRetries: 1

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-# Copilot instructions — pi-dev-loops
+# Copilot instructions — dev-loops
 
 Single entrypoint: `dev-loop`. Prefer GitHub-first path. KISS, SRP, YAGNI.
 Work test-first, ≥90% coverage. `npm run verify` for full validation.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# pi-dev-loops containerized dev-loop runtime
+# dev-loops containerized dev-loop runtime
 # Single-stage deterministic build for local and CI use.
 
 FROM node:24-bookworm-slim@sha256:242549cd46785b480c832479a730f4f2a20865d61ea2e404fdb2a5c3d3b73ecf

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pi-dev-loops
+# dev-loops
 
 Turn GitHub issues into merged PRs with zero manual steps between issue and approval.
 
@@ -37,7 +37,7 @@ A deterministic container image with all required tooling for dev-loop operation
 ### Build
 
 ```bash
-docker build -t pi-dev-loops .
+docker build -t dev-loops .
 ```
 
 ### Environment variables
@@ -52,7 +52,7 @@ docker build -t pi-dev-loops .
 Verify the image works with a minimal dev-loop info call:
 
 ```bash
-docker run --rm -e GH_TOKEN="$GH_TOKEN" pi-dev-loops dev-loops loop info --repo mfittko/pi-dev-loops --issue 1
+docker run --rm -e GH_TOKEN="$GH_TOKEN" dev-loops dev-loops loop info --repo mfittko/pi-dev-loops --issue 1
 ```
 
 ### Toolchain verification
@@ -60,11 +60,11 @@ docker run --rm -e GH_TOKEN="$GH_TOKEN" pi-dev-loops dev-loops loop info --repo 
 Check that all required tools are reachable:
 
 ```bash
-docker run --rm pi-dev-loops node --version
-docker run --rm pi-dev-loops pi --version
-docker run --rm pi-dev-loops dev-loops --version
-docker run --rm pi-dev-loops gh --version
-docker run --rm pi-dev-loops git --version
+docker run --rm dev-loops node --version
+docker run --rm dev-loops pi --version
+docker run --rm dev-loops dev-loops --version
+docker run --rm dev-loops gh --version
+docker run --rm dev-loops git --version
 ```
 
 ### Repeatable builds
@@ -79,7 +79,7 @@ The Dockerfile pins exact versions for Node.js (via base image), pi CLI, pi exte
 docker run -it --rm \
   -e GH_TOKEN="$GH_TOKEN" \
   -v "$HOME/.pi:/home/node/.pi" \
-  pi-dev-loops pi
+  dev-loops pi
 ```
 
 Shares sessions, models, settings. Container writes session logs to host `~/.pi`.
@@ -90,7 +90,7 @@ Shares sessions, models, settings. Container writes session logs to host `~/.pi`
 docker run -it --rm \
   -e GH_TOKEN="$GH_TOKEN" \
   -e OPENAI_API_KEY="$OPENAI_API_KEY" \
-  pi-dev-loops pi
+  dev-loops pi
 ```
 
 Ephemeral `~/.pi` inside container. Provider auth via env vars.
@@ -105,7 +105,7 @@ docker run -it --rm \
   -e GH_TOKEN="$GH_TOKEN" \
   -v "$HOME/.pi:/home/node/.pi" \
   -v /tmp/run:/workspace \
-  pi-dev-loops pi
+  dev-loops pi
 ```
 
 Mounts live repo worktree over baked-in `/workspace`. One isolated Pi session per container.

--- a/extension/index.ts
+++ b/extension/index.ts
@@ -70,7 +70,7 @@ export default function (pi: ExtensionAPI, runtimeOverrides: ExtensionRuntimeOve
   });
 
   pi.registerCommand('dev-loops', {
-    description: 'Manage pi-dev-loops readiness and inspect-run local UI lifecycle: /dev-loops [help|status|doctor|gates|hide|inspect ...]',
+    description: 'Manage dev-loops readiness and inspect-run local UI lifecycle: /dev-loops [help|status|doctor|gates|hide|inspect ...]',
     handler: async (args, ctx) => {
       const result = await executeDevLoopsCommand({
         input: args,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "pi-dev-loops",
+  "name": "dev-loops",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pi-dev-loops",
+      "name": "dev-loops",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pi-dev-loops",
+  "name": "dev-loops",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/schemas/dev-loop-config.schema.json
+++ b/schemas/dev-loop-config.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/mfittko/pi-dev-loops/schemas/dev-loop-config.schema.json",
-  "title": "pi-dev-loops config",
+  "title": "dev-loops config",
   "description": "Schema for .pi/dev-loop/defaults.yaml, settings.yaml, or overrides.yaml.",
   "type": "object",
   "additionalProperties": false,


### PR DESCRIPTION
## Summary

This PR renames the root package surface from `pi-dev-loops` to `dev-loops` as the first slice of the #763 rebrand epic. It touches only root-level package identity, CLI/branding strings, and internal root config/docs. The `@pi-dev-loops/core` runtime package and its imports are intentionally left untouched and remain the authoritative helper layer until #766.

## Scope / context

- Target issue: #764
- Base: `origin/main` at `86d4b3c`
- Branch: `issue-764-root-rename`

## Linked issue

Closes #764

## Changes

| File | Change |
|------|--------|
| `package.json` | Root `name` changed from `pi-dev-loops` to `dev-loops`; `bin` already exposed `dev-loops`. |
| `package-lock.json` | Regenerated root package name to `dev-loops`; `@pi-dev-loops/core` workspace entry and its bin names preserved. |
| `README.md` | Header and Docker image tag/branding examples updated to `dev-loops`; install Git URLs kept because the repo slug has not changed. |
| `.github/copilot-instructions.md` | Header product string updated to `dev-loops`. |
| `.devloops` | `queue.boardTitle` updated to `"dev-loops Queue"`. |
| `schemas/dev-loop-config.schema.json` | `title` updated to `"dev-loops config"`; `$id` kept because it encodes the repo slug. |
| `Dockerfile` | Top comment updated to `dev-loops`. |
| `extension/index.ts` | `/dev-loops` command description updated to `dev-loops`; status/widget keys left unchanged to avoid breaking persisted Pi UI state (not a root rename requirement). |

## Acceptance criteria

- [x] Root `package.json` name, version entrypoint, and binary fields use `dev-loops`.
- [x] CLI help text and command banners reference `dev-loops` instead of `pi-dev-loops`.
- [x] Internal references in root scripts and CI that assume the old package name are updated.
- [x] `npm run verify` still passes after rename.

## Definition of done

- [x] A PR exists with the rename changes and passes CI.
- [ ] The PR is approved and merged, or explicitly held pending sibling issues. *(held at human approval checkpoint per #764 instructions)*

## Non-goals

- Pi-specific runtime abstraction — handled by #765.
- Core package rearchitecture — handled by #766.
- npm publish mechanics — handled by #767.
- Consumer migration documentation — handled by #769.

## AC/DoD/Non-goals matrix

| Item | Type | Status | Evidence | Notes |
|---|---|---|---|---|
| Root package fields renamed | AC | Met | `package.json` and `package-lock.json` show `"name": "dev-loops"`; `bin` already `dev-loops` | CLI binary surface unchanged because it was already `dev-loops`. |
| CLI help/banners updated | AC | Met | `cli/index.mjs` help lines already use `dev-loops`; output of `dev-loops --help` shows `dev-loops` everywhere | No `pi-dev-loops` remains in command banners. |
| Internal references updated | AC | Met | Root `.devloops`, `.github/copilot-instructions.md`, `README.md`, `Dockerfile`, `schemas/dev-loop-config.schema.json`, and `extension/index.ts` description updated | `@pi-dev-loops/core` imports and repo slug references intentionally preserved. |
| `npm run verify` passes | AC | Met | `npm run verify` all green (3046 tests, 0 failures) | See validation section. |
| PR exists and green | DoD | Met | This PR opened as draft | Stops at approval checkpoint per task. |
| Human approval / merge | DoD | Unmet | — | Waiting for explicit review/approval; do not merge without authorization. |
| Pi-specific runtime abstraction | Non-goal | N/A | #765 | Not touched. |
| Core package rearchitecture | Non-goal | N/A | #766 | `@pi-dev-loops/core` package surface untouched. |
| npm publish mechanics | Non-goal | N/A | #767 | Not touched. |
| Consumer migration docs | Non-goal | N/A | #769 | Not touched. |

## Validation

### `npm run verify` (green)

```text
> verify
> npm test && npm run test:dev-loop

> test:assets     pass 86
> test:extension  pass 63
> test:scripts    pass 1428 / skipped 36
> test:core       pass 1401
> test:docs       Markdown links OK; no duplicate rules
> test:dev-loop   pass 32
```

Total: **3046 tests, 0 failures, 0 cancellations**.

### `npm run repo-wiki:bootstrap` (green)

```text
> repo-wiki:bootstrap
scan  -> 413 files, commit 86d4b3c...
plan  -> 22 pages
compile -> 22 deterministic pages, 0 skipped
```

The wrapper still proxies through `@mfittko/repo-wiki` and its `@pi-dev-loops/core` import path is unchanged.

### `rg` audit of remaining `pi-dev-loops` strings

| Category | Count after rename | Disposition |
|---|---|---|
| `@pi-dev-loops/core` runtime imports | ~144 | **Keep** — separate package owned by #766. |
| GitHub repo slug `mfittko/pi-dev-loops` | ~230 | **Keep** — repository name is not part of this slice. |
| Test temp-dir prefixes (`pi-dev-loops-*`) | ~418 | **Keep** — ephemeral test fixtures, not public package surface. |
| Core package source/tests (`packages/core/...`) | ~25 | **Keep** — internal to `@pi-dev-loops/core`, owned by #766. |
| Core package bin names (`pi-dev-loops-*`) | ~12 | **Keep** — inside `@pi-dev-loops/core`, owned by #766. |
| Skill docs describing runtime contract | ~9 | **Keep** — docs rebrand owned by #768. |
| **Total tracked occurrences** | **835** | Down from ~853 on `origin/main` (18 removed root-level occurrences). |

The post-rename inventory was produced with `git grep -n 'pi-dev-loops'`; every hit can be traced to one of the keep categories above.

## Note on `@pi-dev-loops/core`

`scripts/repo-wiki.mjs` still imports `isDirectCliRun` from `@pi-dev-loops/core/cli/helpers`, and every other root script continues to import helpers from `@pi-dev-loops/core`. These imports are deliberately **not** renamed in this slice because the core package rearchitecture is owned by #766. The rename PR therefore preserves the runtime helper dependency boundary while changing only the root package's own name field and branding strings.
