### PR TITLE
Abstract Pi-specific coupling for agent-harness-agnostic runtime

### DIFF
--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -13,6 +13,7 @@ import {
   DEV_LOOP_CHECK_IDS,
 } from "../lib/dev-loops-core.mjs";
 import { isUsageError, buildCorrectedArgs } from "../packages/core/src/cli/retry-wrapper.mjs";
+import { createPiAdapter } from "@pi-dev-loops/core/harness";
 
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 
@@ -238,17 +239,22 @@ function orderedCliSetupSteps(checks) {
 function writeLines(stream, lines) { stream.write(`${lines.join("\n")}\n`); }
 
 export function createCliRuntime({
-  cwd = process.cwd(), searchPath = process.env.PATH ?? "",
-  platform = process.platform, pathExt = process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD",
+  adapter = createPiAdapter(),
+  cwd, searchPath,
+  platform, pathExt,
 } = {}) {
+  const effectiveCwd = cwd ?? adapter.getCwd();
+  const effectiveSearchPath = searchPath ?? adapter.getEnv().PATH ?? "";
+  const effectivePlatform = platform ?? process.platform;
+  const effectivePathExt = pathExt ?? adapter.getEnv().PATHEXT ?? ".COM;.EXE;.BAT;.CMD";
   return {
     surface: "cli",
     cwd,
-    async commandExists(command) { return commandExists(command, { searchPath, platform, pathExt }); },
-    async ghAuthOk() { return spawnResult("gh", ["auth", "status"], { cwd }).ok; },
-    async insideGitRepo() { return spawnResult("git", ["rev-parse", "--is-inside-work-tree"], { cwd }).ok; },
+    async commandExists(command) { return commandExists(command, { searchPath: effectiveSearchPath, platform: effectivePlatform, pathExt: effectivePathExt }); },
+    async ghAuthOk() { return spawnResult("gh", ["auth", "status"], { cwd: effectiveCwd }).ok; },
+    async insideGitRepo() { return spawnResult("git", ["rev-parse", "--is-inside-work-tree"], { cwd: effectiveCwd }).ok; },
     async getSubagentAvailability() {
-      const ok = await commandExists("subagent", { searchPath, platform, pathExt });
+      const ok = await commandExists("subagent", { searchPath: effectiveSearchPath, platform: effectivePlatform, pathExt: effectivePathExt });
       return { ok, availableDetail: "`subagent` command is available.", unavailableDetail: "Install or enable subagent support so `subagent` is available." };
     },
   };
@@ -345,7 +351,7 @@ export async function runCli({
       return result.status ?? (result.signal ? 1 : result.error ? 1 : 0);
     }
     case "action": {
-      const activeRuntime = runtime ?? createCliRuntime({ cwd });
+      const activeRuntime = runtime ?? createCliRuntime({ adapter: createPiAdapter({ cwd }), cwd });
       const result = await executeDevLoopsCommand({ input: argv, surface: "cli", runtime: activeRuntime, stdout });
       switch (result.kind) {
         case "help": { writeLines(stdout, buildCliHelpLines()); return 0; }

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -249,7 +249,7 @@ export function createCliRuntime({
   const effectivePathExt = pathExt ?? adapter.getEnv().PATHEXT ?? ".COM;.EXE;.BAT;.CMD";
   return {
     surface: "cli",
-    cwd,
+    cwd: effectiveCwd,
     async commandExists(command) { return commandExists(command, { searchPath: effectiveSearchPath, platform: effectivePlatform, pathExt: effectivePathExt }); },
     async ghAuthOk() { return spawnResult("gh", ["auth", "status"], { cwd: effectiveCwd }).ok; },
     async insideGitRepo() { return spawnResult("git", ["rev-parse", "--is-inside-work-tree"], { cwd: effectiveCwd }).ok; },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,8 @@
     "./loop/steering": "./src/loop/steering.mjs",
     "./loop/timeout-policy": "./src/loop/timeout-policy.mjs",
     "./loop/tracker-pr-state": "./src/loop/tracker-pr-state.mjs",
-    "./refinement/ac-dod-matrix": "./src/refinement/ac-dod-matrix.mjs"
+    "./refinement/ac-dod-matrix": "./src/refinement/ac-dod-matrix.mjs",
+    "./harness": "./src/harness/index.mjs"
   },
   "bin": {
     "pi-dev-loops-log-bash-exit-1": "./bin/log-bash-exit-1.mjs",

--- a/packages/core/src/harness/adapter.mjs
+++ b/packages/core/src/harness/adapter.mjs
@@ -1,0 +1,57 @@
+/**
+ * Harness adapter interface.
+ *
+ * Abstracts runtime concerns that vary between agent harnesses (Pi, Claude,
+ * local CLI, test) so the dev-loop dispatch and handoff path stays harness-agnostic.
+ *
+ * This slice is intentionally minimal. Add methods only when the dispatch/handoff
+ * path needs them; do not turn the adapter into a generic process wrapper.
+ *
+ * @typedef {Object} HarnessAdapter
+ * @property {() => string} getCwd - Current working directory for the active session.
+ * @property {() => NodeJS.ProcessEnv} getEnv - Active environment variables.
+ * @property {() => boolean} isInteractive - Whether the session is interactive (vs batch/automated).
+ * @property {() => boolean} isInsidePi - Whether the session is running inside the Pi agent harness.
+ * @property {() => string} getRepoRoot - Best-effort repository root; falls back to cwd.
+ */
+
+const REQUIRED_METHODS = ["getCwd", "getEnv", "isInteractive", "isInsidePi", "getRepoRoot"];
+
+/**
+ * Validate and freeze a harness-adapter implementation.
+ *
+ * @param {Partial<HarnessAdapter>} impl
+ * @returns {HarnessAdapter}
+ */
+export function createHarnessAdapter(impl) {
+  if (!impl || typeof impl !== "object") {
+    throw new TypeError("createHarnessAdapter: impl must be an object");
+  }
+
+  for (const method of REQUIRED_METHODS) {
+    if (typeof impl[method] !== "function") {
+      throw new TypeError(`createHarnessAdapter: missing required method "${method}"`);
+    }
+  }
+
+  return Object.freeze({
+    getCwd: impl.getCwd,
+    getEnv: impl.getEnv,
+    isInteractive: impl.isInteractive,
+    isInsidePi: impl.isInsidePi,
+    getRepoRoot: impl.getRepoRoot,
+  });
+}
+
+/**
+ * Type guard for adapter values.
+ *
+ * @param {*} value
+ * @returns {value is HarnessAdapter}
+ */
+export function isHarnessAdapter(value) {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  return REQUIRED_METHODS.every((method) => typeof value[method] === "function");
+}

--- a/packages/core/src/harness/index.mjs
+++ b/packages/core/src/harness/index.mjs
@@ -1,0 +1,3 @@
+export { createHarnessAdapter, isHarnessAdapter } from "./adapter.mjs";
+export { createPiAdapter } from "./pi-adapter.mjs";
+export { createNoopAdapter } from "./noop-adapter.mjs";

--- a/packages/core/src/harness/noop-adapter.mjs
+++ b/packages/core/src/harness/noop-adapter.mjs
@@ -1,14 +1,17 @@
 import { createHarnessAdapter } from "./adapter.mjs";
 
 /**
- * Create a minimal no-op harness adapter for tests and fallback contexts.
+ * Create a minimal harness adapter for tests and fallback/CI/batch contexts.
+ *
+ * Defaults mirror the current process so swapping from the Pi adapter does not
+ * unexpectedly change behavior; callers can still pin cwd/env for determinism.
  *
  * @param {Object} [options]
  * @param {string} [options.cwd]
  * @param {NodeJS.ProcessEnv} [options.env]
  * @returns {import("./adapter.mjs").HarnessAdapter}
  */
-export function createNoopAdapter({ cwd = "/", env = {} } = {}) {
+export function createNoopAdapter({ cwd = process.cwd(), env = process.env } = {}) {
   return createHarnessAdapter({
     getCwd: () => cwd,
     getEnv: () => env,

--- a/packages/core/src/harness/noop-adapter.mjs
+++ b/packages/core/src/harness/noop-adapter.mjs
@@ -1,0 +1,19 @@
+import { createHarnessAdapter } from "./adapter.mjs";
+
+/**
+ * Create a minimal no-op harness adapter for tests and fallback contexts.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.cwd]
+ * @param {NodeJS.ProcessEnv} [options.env]
+ * @returns {import("./adapter.mjs").HarnessAdapter}
+ */
+export function createNoopAdapter({ cwd = "/", env = {} } = {}) {
+  return createHarnessAdapter({
+    getCwd: () => cwd,
+    getEnv: () => env,
+    isInteractive: () => false,
+    isInsidePi: () => false,
+    getRepoRoot: () => cwd,
+  });
+}

--- a/packages/core/src/harness/pi-adapter.mjs
+++ b/packages/core/src/harness/pi-adapter.mjs
@@ -1,0 +1,47 @@
+import { execFileSync } from "node:child_process";
+import { createHarnessAdapter } from "./adapter.mjs";
+
+/**
+ * Create the concrete Pi harness adapter.
+ *
+ * This is the only active adapter for #765. Future harnesses (Claude, etc.)
+ * can implement the same interface without changing call sites.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.cwd] - Override cwd (default: process.cwd()).
+ * @param {NodeJS.ProcessEnv} [options.env] - Override env (default: process.env).
+ * @returns {import("./adapter.mjs").HarnessAdapter}
+ */
+export function createPiAdapter({ cwd = process.cwd(), env = process.env } = {}) {
+  function getRepoRoot() {
+    try {
+      return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+        cwd,
+        env,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+    } catch {
+      return cwd;
+    }
+  }
+
+  function isInteractive() {
+    if (env.PI_INTERACTIVE === "0") return false;
+    if (env.PI_INTERACTIVE === "1") return true;
+    if (env.CI === "true" || env.CI === "1") return false;
+    return true;
+  }
+
+  function isInsidePi() {
+    return env.PI_SESSION === "1" || typeof globalThis.pi !== "undefined";
+  }
+
+  return createHarnessAdapter({
+    getCwd: () => cwd,
+    getEnv: () => env,
+    isInteractive,
+    isInsidePi,
+    getRepoRoot,
+  });
+}

--- a/packages/core/test/harness.test.mjs
+++ b/packages/core/test/harness.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import path from "node:path";
+
+import {
+  createHarnessAdapter,
+  isHarnessAdapter,
+  createPiAdapter,
+  createNoopAdapter,
+} from "../src/harness/index.mjs";
+
+test("createHarnessAdapter validates required methods", () => {
+  assert.throws(
+    () => createHarnessAdapter({ getCwd: () => "/", getEnv: () => ({}), isInteractive: () => false, isInsidePi: () => false }),
+    /missing required method "getRepoRoot"/,
+  );
+  assert.throws(() => createHarnessAdapter(null), /impl must be an object/);
+  assert.throws(() => createHarnessAdapter("nope"), /impl must be an object/);
+});
+
+test("isHarnessAdapter recognizes complete adapters", () => {
+  const adapter = createNoopAdapter();
+  assert.equal(isHarnessAdapter(adapter), true);
+  assert.equal(isHarnessAdapter({ getCwd: () => "/" }), false);
+  assert.equal(isHarnessAdapter(null), false);
+  assert.equal(isHarnessAdapter("adapter"), false);
+});
+
+test("noop adapter returns deterministic fallback values", () => {
+  const cwd = path.resolve("/tmp/noop-test");
+  const env = { FOO: "bar" };
+  const adapter = createNoopAdapter({ cwd, env });
+
+  assert.equal(adapter.getCwd(), cwd);
+  assert.deepEqual(adapter.getEnv(), env);
+  assert.equal(adapter.isInteractive(), false);
+  assert.equal(adapter.isInsidePi(), false);
+  assert.equal(adapter.getRepoRoot(), cwd);
+});
+
+test("noop adapter object is frozen", () => {
+  const adapter = createNoopAdapter();
+  assert.throws(() => { adapter.getCwd = () => "/hijack"; }, TypeError);
+});
+
+test("pi adapter exposes supplied cwd and env", () => {
+  const cwd = path.resolve("/tmp/pi-test");
+  const env = { PI_SESSION: "1", CI: "true" };
+  const adapter = createPiAdapter({ cwd, env });
+
+  assert.equal(adapter.getCwd(), cwd);
+  assert.deepEqual(adapter.getEnv(), env);
+});
+
+test("pi adapter resolves repo root via git", () => {
+  const adapter = createPiAdapter();
+  const repoRoot = adapter.getRepoRoot();
+  assert.ok(path.isAbsolute(repoRoot), "repo root should be absolute");
+  assert.ok(repoRoot.length > 0, "repo root should be non-empty");
+});
+
+test("pi adapter isInteractive respects env overrides", () => {
+  assert.equal(createPiAdapter({ env: { PI_INTERACTIVE: "0" } }).isInteractive(), false);
+  assert.equal(createPiAdapter({ env: { PI_INTERACTIVE: "1" } }).isInteractive(), true);
+  assert.equal(createPiAdapter({ env: { CI: "true" } }).isInteractive(), false);
+  assert.equal(createPiAdapter({ env: {} }).isInteractive(), true);
+});
+
+test("pi adapter isInsidePi is true when PI_SESSION=1", () => {
+  assert.equal(createPiAdapter({ env: { PI_SESSION: "1" } }).isInsidePi(), true);
+  assert.equal(createPiAdapter({ env: {} }).isInsidePi(), false);
+});

--- a/packages/core/test/package-surface.test.mjs
+++ b/packages/core/test/package-surface.test.mjs
@@ -31,6 +31,7 @@ test("packages/core exports the sanctioned runtime boundary and de-exports unuse
   assert.equal(packageJson.exports["./cli/primitives"], "./src/cli/primitives.mjs");
   assert.equal(packageJson.exports["./cli/helpers"], "./src/cli/helpers.mjs");
   assert.equal(packageJson.exports["./cli/subcommand-runner"], "./src/cli/subcommand-runner.mjs");
+  assert.equal(packageJson.exports["./harness"], "./src/harness/index.mjs");
 
   assert.equal(packageJson.exports["./loop/conductor-ownership"], undefined);
   assert.equal(packageJson.exports["./loop/conductor-pr-projection"], undefined);

--- a/scripts/loop/build-handoff-envelope.mjs
+++ b/scripts/loop/build-handoff-envelope.mjs
@@ -22,6 +22,7 @@ import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "
 import { requireOptionValue } from "../_cli-primitives.mjs";
 import { buildDevLoopHandoffEnvelope } from "@pi-dev-loops/core/loop/handoff-envelope";
 import { loadDevLoopConfig } from "@pi-dev-loops/core/config";
+import { createPiAdapter } from "@pi-dev-loops/core/harness";
 
 const USAGE = `Usage: build-handoff-envelope.mjs --input <path>
 Build a deterministic handoff envelope from startup resolver output and settings.
@@ -100,8 +101,9 @@ export function parseBuildHandoffEnvelopeCliArgs(argv) {
 
 export async function buildHandoffEnvelopeCli(
   options,
-  { cwd = process.cwd() } = {},
+  { adapter = createPiAdapter() } = {},
 ) {
+  const cwd = adapter.getCwd();
   // Resolve repo root for config loading (same approach as resolve-dev-loop-startup.mjs)
   let repoRoot = cwd;
   try {
@@ -156,7 +158,7 @@ export async function buildHandoffEnvelopeCli(
 
 export async function runCli(
   argv = process.argv.slice(2),
-  { stdout = process.stdout, stderr = process.stderr, cwd = process.cwd() } = {},
+  { stdout = process.stdout, stderr = process.stderr, adapter = createPiAdapter() } = {},
 ) {
   let options;
   try {
@@ -173,7 +175,7 @@ export async function runCli(
   }
 
   try {
-    const envelope = await buildHandoffEnvelopeCli(options, { cwd });
+    const envelope = await buildHandoffEnvelopeCli(options, { adapter });
     stdout.write(`${JSON.stringify(envelope)}\n`);
   } catch (err) {
     const msg = formatCliError(err);

--- a/scripts/loop/build-handoff-envelope.mjs
+++ b/scripts/loop/build-handoff-envelope.mjs
@@ -15,7 +15,6 @@
  *   npx dev-loops loop build-envelope --input resolver-output.json
  */
 import { readFile } from "node:fs/promises";
-import { execFileSync } from "node:child_process";
 import { detectRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import path from "node:path";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
@@ -103,16 +102,9 @@ export async function buildHandoffEnvelopeCli(
   options,
   { adapter = createPiAdapter() } = {},
 ) {
+  // Resolve repo root via the adapter so envelope construction stays harness-agnostic.
   const cwd = adapter.getCwd();
-  // Resolve repo root for config loading (same approach as resolve-dev-loop-startup.mjs)
-  let repoRoot = cwd;
-  try {
-    repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
-      cwd,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    }).trim();
-  } catch { /* keep cwd */ }
+  const repoRoot = adapter.getRepoRoot();
 
   // Load resolver output from file
   const inputPath = path.resolve(cwd, options.inputPath);

--- a/scripts/loop/pre-flight-gate.mjs
+++ b/scripts/loop/pre-flight-gate.mjs
@@ -2,6 +2,7 @@
 import { execFileSync } from "node:child_process";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { requireOptionValue } from "../_cli-primitives.mjs";
+import { createPiAdapter } from "@pi-dev-loops/core/harness";
 import {
   isUnderWorktreePath,
   parseMainWorktreePath,
@@ -150,17 +151,20 @@ export async function runCli(
   {
     stdout = process.stdout,
     stderr = process.stderr,
-    cwd = process.cwd(),
-    env = process.env,
+    adapter = createPiAdapter(),
+    cwd,
+    env,
     gitCommand = "git",
   } = {},
 ) {
+  const effectiveCwd = cwd ?? adapter.getCwd();
+  const effectiveEnv = env ?? adapter.getEnv();
   const options = parsePreFlightGateCliArgs(argv);
   if (options.help) {
     stdout.write(`${USAGE}\n`);
     return { ok: true, help: true };
   }
-  if ((env[PI_PREFLIGHT_BYPASS_VAR] ?? "").trim() === "1") {
+  if ((effectiveEnv[PI_PREFLIGHT_BYPASS_VAR] ?? "").trim() === "1") {
     const payload = {
       ok: true,
       checks: { worktree: true, branch: "skipped", subagents: "skipped" },
@@ -171,7 +175,7 @@ export async function runCli(
   }
   const checks = { worktree: false, branch: "skipped", subagents: "skipped" };
   const errors = [];
-  const worktreeResult = checkWorktreeIsolation({ cwd, env, gitCommand });
+  const worktreeResult = checkWorktreeIsolation({ cwd: effectiveCwd, env: effectiveEnv, gitCommand });
   checks.worktree = worktreeResult.ok;
   if (!worktreeResult.ok) {
     errors.push({
@@ -181,8 +185,8 @@ export async function runCli(
     });
   }
   const branchResult = checkBranchIdentity({
-    cwd,
-    env,
+    cwd: effectiveCwd,
+    env: effectiveEnv,
     expectedBranch: options.expectedBranch,
     gitCommand,
   });
@@ -195,7 +199,7 @@ export async function runCli(
     });
   }
   const subagentResult = checkSubagentAvailability({
-    env,
+    env: effectiveEnv,
     checkSubagents: options.checkSubagents,
   });
   checks.subagents = subagentResult.status;

--- a/scripts/loop/resolve-dev-loop-startup.mjs
+++ b/scripts/loop/resolve-dev-loop-startup.mjs
@@ -21,6 +21,7 @@ import {
 import { detectRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
 import { isCopilotLogin } from "@pi-dev-loops/core/github/copilot-helpers";
 import { loadDevLoopConfig, resolveWorkflowConfig } from "../../packages/core/src/config/config.mjs";
+import { createPiAdapter } from "@pi-dev-loops/core/harness";
 const USAGE = `Usage:
   resolve-dev-loop-startup.mjs --issue <number>
   resolve-dev-loop-startup.mjs --pr <number>
@@ -368,10 +369,12 @@ export function summarizeCanonicalState(bundle) {
       : false,
   };
 }
-export function buildResolveDevLoopStartupResult(input, { env = process.env, cwd = process.cwd(), asyncStartMode = "required" } = {}) {
+export function buildResolveDevLoopStartupResult(input, { adapter = createPiAdapter(), env, cwd, asyncStartMode = "required" } = {}) {
+  const effectiveEnv = env ?? adapter.getEnv();
+  const effectiveCwd = cwd ?? adapter.getCwd();
   try {
     const checkpointText = readFileSync(
-      path.join(cwd, ".pi", "dev-loop-retrospective-checkpoint.json"),
+      path.join(effectiveCwd, ".pi", "dev-loop-retrospective-checkpoint.json"),
       "utf8",
     );
     const checkpoint = JSON.parse(checkpointText);
@@ -408,7 +411,7 @@ export function buildResolveDevLoopStartupResult(input, { env = process.env, cwd
     ? (STRATEGY_ASYNC_DISPATCH[bundle.selectedStrategy] ?? false)
     : false;
   if (requiresAsyncDispatch) {
-    const validation = validateAsyncStartContext({ env, asyncStartMode });
+    const validation = validateAsyncStartContext({ env: effectiveEnv, asyncStartMode });
     if (validation.status === ASYNC_START_STATUS.REJECTED) {
       return buildAsyncStartRejection(validation);
     }
@@ -416,19 +419,19 @@ export function buildResolveDevLoopStartupResult(input, { env = process.env, cwd
   const PI_WORKTREE_BYPASS_VAR = "PI_WORKTREE_BYPASS";
   if (
     strategyKey === "local_implementation" &&
-    (env[PI_WORKTREE_BYPASS_VAR] ?? "").trim() !== "1"
+    (effectiveEnv[PI_WORKTREE_BYPASS_VAR] ?? "").trim() !== "1"
   ) {
     try {
       const worktreeOutput = execFileSync("git", ["worktree", "list"], {
-        cwd,
-        env,
+        cwd: effectiveCwd,
+        env: effectiveEnv,
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
       });
       const mainPath = parseMainWorktreePath(worktreeOutput);
       const allPaths = parseAllWorktreePaths(worktreeOutput);
-      if (!isUnderWorktreePath(cwd)) {
-        const reason = mainPath !== null && isMainCheckout(cwd, mainPath)
+      if (!isUnderWorktreePath(effectiveCwd)) {
+        const reason = mainPath !== null && isMainCheckout(effectiveCwd, mainPath)
           ? `Local implementation requires worktree isolation. Current directory is the main git checkout (${mainPath}). Create a worktree under tmp/worktrees/<slug>/ and re-run.`
           : "Local implementation requires worktree isolation. Current directory is not under tmp/worktrees/. Create a worktree and re-run.";
         return {
@@ -441,7 +444,7 @@ export function buildResolveDevLoopStartupResult(input, { env = process.env, cwd
           bundle,
         };
       }
-      if (!isListedWorktree(cwd, allPaths)) {
+      if (!isListedWorktree(effectiveCwd, allPaths)) {
         const reason = `Local implementation requires worktree isolation. Current directory is under tmp/worktrees/ but is not listed as a git worktree by \`git worktree list\`. Create a proper worktree with \`git worktree add\` and re-run.`;
         return {
           ok: true,
@@ -475,7 +478,8 @@ export function buildResolveDevLoopStartupResult(input, { env = process.env, cwd
     bundle,
   };
 }
-export async function runCli(argv = process.argv.slice(2), { stdout = process.stdout, stderr = process.stderr } = {}) {
+export async function runCli(argv = process.argv.slice(2), { stdout = process.stdout, stderr = process.stderr, adapter = createPiAdapter() } = {}) {
+  const sessionCwd = adapter.getCwd();
   const options = parseResolveDevLoopStartupCliArgs(argv);
   if (options.help) {
     stdout.write(`${USAGE}\n`);
@@ -484,10 +488,10 @@ export async function runCli(argv = process.argv.slice(2), { stdout = process.st
   // Resolve repo root to handle subdirectory invocations consistently.
   // buildAutoResolvedInput() also resolves via git rev-parse;
   // using the same root for config loading avoids mismatched roots.
-  let repoRoot = process.cwd();
+  let repoRoot = sessionCwd;
   try {
     repoRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
-      cwd: process.cwd(),
+      cwd: sessionCwd,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();
@@ -511,18 +515,18 @@ export async function runCli(argv = process.argv.slice(2), { stdout = process.st
   } else if (options.issue !== undefined) {
     input = buildAutoResolvedInput({
       issue: options.issue,
-      cwd: process.cwd(),
+      cwd: sessionCwd,
       targetPreference,
       inputSource,
     });
   } else {
     input = buildAutoResolvedInput({
       pr: options.pr,
-      cwd: process.cwd(),
+      cwd: sessionCwd,
       targetPreference,
     });
   }
-  const result = buildResolveDevLoopStartupResult(input, { asyncStartMode });
+  const result = buildResolveDevLoopStartupResult(input, { asyncStartMode, adapter });
   if (result.ok === false) {
     stderr.write(`${JSON.stringify(result)}\n`);
     process.exitCode = 1;

--- a/scripts/loop/resolve-dev-loop-startup.mjs
+++ b/scripts/loop/resolve-dev-loop-startup.mjs
@@ -485,17 +485,8 @@ export async function runCli(argv = process.argv.slice(2), { stdout = process.st
     stdout.write(`${USAGE}\n`);
     return;
   }
-  // Resolve repo root to handle subdirectory invocations consistently.
-  // buildAutoResolvedInput() also resolves via git rev-parse;
-  // using the same root for config loading avoids mismatched roots.
-  let repoRoot = sessionCwd;
-  try {
-    repoRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
-      cwd: sessionCwd,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
-  } catch { /* keep cwd */ }
+  // Resolve repo root via the adapter so the CLI stays harness-agnostic.
+  const repoRoot = adapter.getRepoRoot();
   const { config: devLoopConfig, errors: configErrors = [] } = await loadDevLoopConfig({ repoRoot });
   const asyncStartMode = configErrors.length === 0
     ? resolveWorkflowConfig(devLoopConfig, "asyncStartMode")


### PR DESCRIPTION
## Summary

Introduces a minimal `harness-adapter` seam in `@pi-dev-loops/core` so the dev-loop dispatch and handoff path can run against different agent harnesses without hardcoding Pi runtime assumptions. The concrete `pi-adapter` remains the only active adapter in this slice; a future issue (#770) will add a Claude/other harness adapter.

The adapter exposes a small, frozen interface (`getCwd`, `getEnv`, `isInteractive`, `isInsidePi`, `getRepoRoot`) and is consumed by the high-traffic dispatch scripts plus the CLI runtime. Existing behavior is preserved; call sites still flow through the Pi adapter by default.

## Closes

Closes #765

## Acceptance criteria / definition of done matrix

| Acceptance criteria (from #765) | Definition of done (from #765) | Status | Evidence |
|---|---|---|---|
| All Pi-only extension APIs are replaced by env vars, CLI flags, or neutral plugin interfaces. | PR with abstraction changes is open and green. | In progress — neutral `HarnessAdapter` interface is in place; Pi-specific extension surface (ExtensionAPI, UI widgets, Telegram, caveman) is intentionally deferred to #770. | `packages/core/src/harness/adapter.mjs`, `pi-adapter.mjs`, `noop-adapter.mjs` |
| The runtime can start and answer `--help` without a Pi session context. | Smoke test outside Pi passes. | Met | `node ./cli/index.mjs --help` succeeds; `npm run verify` green; `noop-adapter` works in CI/batch contexts. |
| Existing Pi consumers continue to work through a compatibility path. | Review confirms no breaking change for Pi consumers. | Met — `createPiAdapter()` is the default everywhere, so Pi behavior is unchanged. | Full test suite passes, including extension and CLI tests. |

## Non-goals

- Package rename (handled by #764)
- Folding or renaming `@pi-dev-loops/core` (handled by #766)
- Writing end-user migration docs (handled by #769)
- Adding a Claude adapter or replacing the Pi ExtensionAPI surface (handled by #770)

## Changed files

- `packages/core/package.json` — export `./harness` subpath.
- `packages/core/src/harness/adapter.mjs` — validated, frozen `HarnessAdapter` interface.
- `packages/core/src/harness/pi-adapter.mjs` — concrete Pi adapter (default, only active adapter).
- `packages/core/src/harness/noop-adapter.mjs` — test/fallback adapter.
- `packages/core/src/harness/index.mjs` — public harness exports.
- `packages/core/test/harness.test.mjs` — contract and behavior tests.
- `packages/core/test/package-surface.test.mjs` — assert `./harness` export.
- `scripts/loop/build-handoff-envelope.mjs` — use adapter for cwd.
- `scripts/loop/resolve-dev-loop-startup.mjs` — use adapter for cwd/env defaults.
- `scripts/loop/pre-flight-gate.mjs` — use adapter for cwd/env defaults.
- `cli/index.mjs` — `createCliRuntime`/`runCli` accept optional harness adapter.

## Migration note

Call sites still use the concrete `pi-adapter` by default, so this is a structural seam insertion, not a behavior change. Consumers that want to run outside Pi can pass a `noop-adapter` (or a future Claude adapter) instead of relying on `process.cwd()` / `process.env` defaults.

## Validation evidence

- `npm run verify` — all suites pass.
- `npm run repo-wiki:bootstrap` — wrapper completes successfully.
- `node ./cli/index.mjs --help` — prints help and exits 0 outside a Pi session.
- New adapter unit tests pass:
  - interface validation rejects incomplete adapters
  - `isHarnessAdapter` guard works
  - `noop-adapter` returns deterministic non-interactive/non-Pi values
  - `pi-adapter` respects `PI_INTERACTIVE`, `CI`, and `PI_SESSION` env vars, resolves repo root via git
