### PR TITLE
Phase B — Repo rename execution (file edits + remote URL update) (#786)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,6 @@
-# pi-dev-loops Plan
+# dev-loops Plan
 
-`pi-dev-loops` is a shared home for Pi-centered development workflow infrastructure.
+`dev-loops` is a shared home for Pi-centered development workflow infrastructure.
 
 The durable goal is to ship a reusable toolkit for Pi-based local and GitHub-first development loops without letting workflow mechanics drift back into ad hoc markdown or repo-specific shell glue.
 
@@ -24,7 +24,7 @@ Do **not** use `PLAN.md` for one-off issue execution plans, PR-specific checklis
 - For active implementation and release work in this repo, the default routed path should still prefer the GitHub-first internal strategies when practical.
 - The local implementation strategy remains supported when the user explicitly wants local phase-bounded work.
 - GitHub issues are the backlog and GitHub PRs are the main execution trail for remote-loop work.
-- Installing the package with `pi install git:github.com/mfittko/pi-dev-loops` exposes packaged skills through `package.json` `pi.skills`; `/dev-loops install` and `/dev-loops update` are removed — use `pi install` / `pi update` directly.
+- Installing the package with `pi install git:github.com/mfittko/dev-loops` exposes packaged skills through `package.json` `pi.skills`; `/dev-loops install` and `/dev-loops update` are removed — use `pi install` / `pi update` directly.
 
 ## Product intent
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ docker build -t dev-loops .
 Verify the image works with a minimal dev-loop info call:
 
 ```bash
-docker run --rm -e GH_TOKEN="$GH_TOKEN" dev-loops dev-loops loop info --repo mfittko/pi-dev-loops --issue 1
+docker run --rm -e GH_TOKEN="$GH_TOKEN" dev-loops dev-loops loop info --repo mfittko/dev-loops --issue 1
 ```
 
 ### Toolchain verification
@@ -143,8 +143,8 @@ Full details: [Extension Documentation](./extension/README.md) and `.pi/dev-loop
 Install with:
 
 ```bash
-pi install git:github.com/mfittko/pi-dev-loops          # global
-pi install -l git:github.com/mfittko/pi-dev-loops       # project-local
+pi install git:github.com/mfittko/dev-loops          # global
+pi install -l git:github.com/mfittko/dev-loops       # project-local
 ```
 
 Use `npx dev-loops` to run the CLI without installing. After a global `pi install`, the `dev-loops` command is available directly in your shell.

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -209,8 +209,8 @@ function buildCliHelpLines() {
     "Use `dev-loops <category> <subcommand> --help` for per-subcommand usage.",
     "",
     "`/dev-loops hide` remains an extension-only Pi command.",
-    "Use `pi install git:github.com/mfittko/pi-dev-loops` to install skills and agents, or",
-    "`pi update git:github.com/mfittko/pi-dev-loops` to refresh the package.",
+    "Use `pi install git:github.com/mfittko/dev-loops` to install skills and agents, or",
+    "`pi update git:github.com/mfittko/dev-loops` to refresh the package.",
   ];
 }
 
@@ -232,7 +232,7 @@ function orderedCliSetupSteps(checks) {
   return [
     "1. Use `/skill:dev-loop` (in Pi) or `subagent dev-loop` to start or continue a dev loop — the single public entry.",
     "2. Run `dev-loops status` whenever you want a concise readiness snapshot.",
-    "3. Use `pi install git:github.com/mfittko/pi-dev-loops` to install the package, or `pi update git:github.com/mfittko/pi-dev-loops` to refresh it.",
+    "3. Use `pi install git:github.com/mfittko/dev-loops` to install the package, or `pi update git:github.com/mfittko/dev-loops` to refresh it.",
   ];
 }
 

--- a/docs/conductor-routing-contract.md
+++ b/docs/conductor-routing-contract.md
@@ -23,12 +23,12 @@ pre-computed outer-loop action. It is the routing authority, not a remapper.
 
 | Contract / Issue | Relationship |
 |---|---|
-| [#28 — conductor umbrella](https://github.com/mfittko/pi-dev-loops/issues/28) | Parent umbrella |
-| [#32 — ownership/idempotency](https://github.com/mfittko/pi-dev-loops/issues/32) | **Historical**: designed the ownership model; the `conductor-ownership.mjs` module was retired during deslop cleanup (issue #319). `ownershipState` remains as an optional external input. |
-| [#26 — family-local PR lifecycle contract](https://github.com/mfittko/pi-dev-loops/issues/26) / [PR Lifecycle Contract](../skills/docs/pr-lifecycle-contract.md) | **Upstream**: provides family-local PR lifecycle semantics; the concrete `copilotState` and `reviewerState` inputs still come from the existing copilot/reviewer state machines, and this contract consumes them without redefining their semantics |
-| [#34 — request/watch helper contract](https://github.com/mfittko/pi-dev-loops/issues/34) | **Adjacent**: defines Copilot request/watch semantics inside the copilot loop family; this contract decides _which family_ gets control |
-| [#48 — visible PR projection](https://github.com/mfittko/pi-dev-loops/issues/48) | **Downstream**: routing decisions may drive PR projection artifacts |
-| [#57/#58/#59 — inspection/viewer/steering](https://github.com/mfittko/pi-dev-loops/issues/57) | **Adjacent**: read-only inspection surfaces; this contract defines routing policy, not operator UX |
+| [#28 — conductor umbrella](https://github.com/mfittko/dev-loops/issues/28) | Parent umbrella |
+| [#32 — ownership/idempotency](https://github.com/mfittko/dev-loops/issues/32) | **Historical**: designed the ownership model; the `conductor-ownership.mjs` module was retired during deslop cleanup (issue #319). `ownershipState` remains as an optional external input. |
+| [#26 — family-local PR lifecycle contract](https://github.com/mfittko/dev-loops/issues/26) / [PR Lifecycle Contract](../skills/docs/pr-lifecycle-contract.md) | **Upstream**: provides family-local PR lifecycle semantics; the concrete `copilotState` and `reviewerState` inputs still come from the existing copilot/reviewer state machines, and this contract consumes them without redefining their semantics |
+| [#34 — request/watch helper contract](https://github.com/mfittko/dev-loops/issues/34) | **Adjacent**: defines Copilot request/watch semantics inside the copilot loop family; this contract decides _which family_ gets control |
+| [#48 — visible PR projection](https://github.com/mfittko/dev-loops/issues/48) | **Downstream**: routing decisions may drive PR projection artifacts |
+| [#57/#58/#59 — inspection/viewer/steering](https://github.com/mfittko/dev-loops/issues/57) | **Adjacent**: read-only inspection surfaces; this contract defines routing policy, not operator UX |
 
 ## Boundary
 

--- a/docs/phases/phase-7.md
+++ b/docs/phases/phase-7.md
@@ -10,7 +10,7 @@ Phase 7 remains a valid planned second-repo pilot, but it is not the active phas
 
 ## Objective
 
-Prove that `pi-dev-loops` works outside this bootstrap repository in one real second repository through the preferred GitHub-first workflow, using source-loaded consumption only, and capture only the minimum portability fixes and durable decisions needed before broader agent generalization or package-strategy work.
+Prove that `dev-loops` works outside this bootstrap repository in one real second repository through the preferred GitHub-first workflow, using source-loaded consumption only, and capture only the minimum portability fixes and durable decisions needed before broader agent generalization or package-strategy work.
 
 ## Why this phase exists now
 
@@ -120,7 +120,7 @@ This phase exists to answer, in one real non-bootstrap repo:
 - success requires discovery/readiness proof, one bounded non-mutating skill path, and one thin local override
 - success does not require publishing, multi-repo proof, watcher validation, overlay-system design, or broad agent cleanup
 - any downstream customization in this phase should stay thin, local, and explicitly documented rather than generalized prematurely
-- for the Phase 7 portability path, `pi install git:github.com/mfittko/pi-dev-loops` exposes the extension command surface and packaged skills through `package.json` `pi.skills`
+- for the Phase 7 portability path, `pi install git:github.com/mfittko/dev-loops` exposes the extension command surface and packaged skills through `package.json` `pi.skills`
 - `/dev-loops install` and `/dev-loops update` are removed; use `pi install` / `pi update` directly
 - phase refinement for this repo should default to fan-out / fan-in planning with multiple variants before converging on one merged plan
 

--- a/docs/phases/phase-8.md
+++ b/docs/phases/phase-8.md
@@ -165,5 +165,5 @@ This means angles are lenses first, optionally backed by dedicated agent persona
 
 ## Links
 
-- GitHub issue: [#286](https://github.com/mfittko/pi-dev-loops/issues/286)
+- GitHub issue: [#286](https://github.com/mfittko/dev-loops/issues/286)
 - Local execution artifacts will live under `tmp/phases/phase-8/`

--- a/docs/presentations/applied-dev-loops-presentation.md
+++ b/docs/presentations/applied-dev-loops-presentation.md
@@ -1,8 +1,8 @@
 ---
 theme: default
 colorSchema: dark
-title: "pi-dev-loops: Applied Process Observability"
-info: How pi-dev-loops eliminates coordination delay in AI-assisted dev workflows
+title: "dev-loops: Applied Process Observability"
+info: How dev-loops eliminates coordination delay in AI-assisted dev workflows
 class: text-left
 transition: slide-left
 mdc: true
@@ -10,7 +10,7 @@ css: ./style.css
 ---
 
 <div class="hero-card">
-  <p class="kicker">pi-dev-loops</p>
+  <p class="kicker">dev-loops</p>
   <h1>Eliminating Coordination Delay in AI-Assisted Dev Workflows</h1>
   <p class="hero-copy">A coordination runtime built on nested state machines. Every handoff is explicit, routed, and observable.</p>
 </div>

--- a/docs/projects-queue-contract.md
+++ b/docs/projects-queue-contract.md
@@ -400,5 +400,5 @@ back to positional arguments as described in the queue mode specification.
 
 - [Queue Board Setup](./queue-board-setup.md) — one-time setup guide
 - [Queue Mode SPEC](./specs/queue-mode/SPEC.md) — full queue mode specification
-- Issue [#625](https://github.com/mfittko/pi-dev-loops/issues/625) — parent epic
-- Issue [#626](https://github.com/mfittko/pi-dev-loops/issues/626) — this contract refinement
+- Issue [#625](https://github.com/mfittko/dev-loops/issues/625) — parent epic
+- Issue [#626](https://github.com/mfittko/dev-loops/issues/626) — this contract refinement

--- a/docs/projects-queue-usage.md
+++ b/docs/projects-queue-usage.md
@@ -43,46 +43,46 @@ stdout and structured errors on stderr. All accept `--help` for usage.
 
 ```sh
 # List all items in a project
-dev-loops project list --repo mfittko/pi-dev-loops --project 1
+dev-loops project list --repo mfittko/dev-loops --project 1
 
 # List only items in "Next Up" column
-dev-loops project list --repo mfittko/pi-dev-loops --project 1 --column "Next Up"
+dev-loops project list --repo mfittko/dev-loops --project 1 --column "Next Up"
 
 # Limit to top 5 items
-dev-loops project list --repo mfittko/pi-dev-loops --project 1 --limit 5
+dev-loops project list --repo mfittko/dev-loops --project 1 --limit 5
 ```
 
 ### Add an item to the queue
 
 ```sh
 # Add issue #42 to the Backlog column (default)
-dev-loops project add --repo mfittko/pi-dev-loops --project 1 --item 42
+dev-loops project add --repo mfittko/dev-loops --project 1 --item 42
 
 # Add issue #42 to a specific column
-dev-loops project add --repo mfittko/pi-dev-loops --project 1 --item 42 --status "Next Up"
+dev-loops project add --repo mfittko/dev-loops --project 1 --item 42 --status "Next Up"
 ```
 
 ### Move an item between columns
 
 ```sh
 # Move issue #42 from its current column to In Progress
-dev-loops project move --repo mfittko/pi-dev-loops --project 1 --item 42 --to-column "In Progress"
+dev-loops project move --repo mfittko/dev-loops --project 1 --item 42 --to-column "In Progress"
 
 # Move a project item by its node ID
-dev-loops project move --repo mfittko/pi-dev-loops --project 1 --item "PVTI_..." --to-column "Done"
+dev-loops project move --repo mfittko/dev-loops --project 1 --item "PVTI_..." --to-column "Done"
 ```
 
 ### Reorder items
 
 ```sh
 # Move issue #42 to the top of the column
-dev-loops project reorder --repo mfittko/pi-dev-loops --project 1 --item 42
+dev-loops project reorder --repo mfittko/dev-loops --project 1 --item 42
 
 # Move issue #42 after issue #17
-dev-loops project reorder --repo mfittko/pi-dev-loops --project 1 --item 42 --after 17
+dev-loops project reorder --repo mfittko/dev-loops --project 1 --item 42 --after 17
 
 # Reorder by project item node IDs
-dev-loops project reorder --repo mfittko/pi-dev-loops --project 1 --item "PVTI_abc" --after "PVTI_xyz"
+dev-loops project reorder --repo mfittko/dev-loops --project 1 --item "PVTI_abc" --after "PVTI_xyz"
 ```
 
 ### Typical workflow
@@ -147,11 +147,11 @@ does not continuously sync local state to board state.
 
 - [Projects Queue Contract](./projects-queue-contract.md) — formal board contract
 - [Queue Board Setup](./queue-board-setup.md) — one-time setup guide
-- Issue [#625](https://github.com/mfittko/pi-dev-loops/issues/625) — parent epic
-- Issue [#626](https://github.com/mfittko/pi-dev-loops/issues/626) — queue contract
-- Issue [#627](https://github.com/mfittko/pi-dev-loops/issues/627) — list helper
-- Issue [#628](https://github.com/mfittko/pi-dev-loops/issues/628) — move helper
-- Issue [#629](https://github.com/mfittko/pi-dev-loops/issues/629) — add helper
-- Issue [#630](https://github.com/mfittko/pi-dev-loops/issues/630) — reorder helper
-- Issue [#631](https://github.com/mfittko/pi-dev-loops/issues/631) — this doc
-- Issue [#632](https://github.com/mfittko/pi-dev-loops/issues/632) — board bootstrap
+- Issue [#625](https://github.com/mfittko/dev-loops/issues/625) — parent epic
+- Issue [#626](https://github.com/mfittko/dev-loops/issues/626) — queue contract
+- Issue [#627](https://github.com/mfittko/dev-loops/issues/627) — list helper
+- Issue [#628](https://github.com/mfittko/dev-loops/issues/628) — move helper
+- Issue [#629](https://github.com/mfittko/dev-loops/issues/629) — add helper
+- Issue [#630](https://github.com/mfittko/dev-loops/issues/630) — reorder helper
+- Issue [#631](https://github.com/mfittko/dev-loops/issues/631) — this doc
+- Issue [#632](https://github.com/mfittko/dev-loops/issues/632) — board bootstrap

--- a/docs/queue-board-setup.md
+++ b/docs/queue-board-setup.md
@@ -17,7 +17,7 @@ The board provides durable, visible, shared state for queue ordering and item st
 Run the idempotent bootstrap wrapper:
 
 ```sh
-dev-loops project ensure --repo mfittko/pi-dev-loops
+dev-loops project ensure --repo mfittko/dev-loops
 ```
 
 This creates a project named "Dev Loop Queue" (default) under the `mfittko` user:
@@ -40,7 +40,7 @@ Safe to re-run — exits clean if the board already exists.
 #### Custom title
 
 ```sh
-dev-loops project ensure --repo mfittko/pi-dev-loops --title "My Queue"
+dev-loops project ensure --repo mfittko/dev-loops --title "My Queue"
 ```
 
 ### 2. Verify the Status field
@@ -90,7 +90,7 @@ Real boards drift over time. An operator may rename `Next Up` to `Ready`, or `In
 Report drift without mutating (safe default):
 
 ```sh
-dev-loops project ensure --repo mfittko/pi-dev-loops
+dev-loops project ensure --repo mfittko/dev-loops
 ```
 
 When drift is detected, the JSON output includes `repairs.renameCandidates` but leaves existing columns untouched.
@@ -98,7 +98,7 @@ When drift is detected, the JSON output includes `repairs.renameCandidates` but 
 Rename equivalent columns after review:
 
 ```sh
-dev-loops project ensure --repo mfittko/pi-dev-loops --repair-rename
+dev-loops project ensure --repo mfittko/dev-loops --repair-rename
 ```
 
 This renames recognized equivalents (for example `Ready` -> `Next Up`) and adds any still-missing standard columns. It never removes existing columns. Irreconcilable conflicts (for example both `Ready` and `Next` mapping to `Next Up`) are reported in `repairs.conflicts` and no mutation is performed (no renames and no additive column creation).
@@ -130,6 +130,6 @@ The queue board URL and number are discoverable at runtime — no explicit confi
 ## See also
 
 - [Queue mode SPEC](./specs/queue-mode/SPEC.md) — full queue mode specification
-- Issue [#632](https://github.com/mfittko/pi-dev-loops/issues/632) — this setup task
-- Issue [#625](https://github.com/mfittko/pi-dev-loops/issues/625) — parent epic
-- Issue [#631](https://github.com/mfittko/pi-dev-loops/issues/631) — queue workflow documentation
+- Issue [#632](https://github.com/mfittko/dev-loops/issues/632) — this setup task
+- Issue [#625](https://github.com/mfittko/dev-loops/issues/625) — parent epic
+- Issue [#631](https://github.com/mfittko/dev-loops/issues/631) — queue workflow documentation

--- a/docs/reviewer-loop-state-graph.md
+++ b/docs/reviewer-loop-state-graph.md
@@ -58,7 +58,7 @@ The contract separates observable current state (`submittedReviewPresent`, `subm
 - default fan-out is 3
 - output is deterministic (`runId` sequence + angle ordering)
 
-For `pi-dev-loops`, the default pre-approval gate before calling a branch/PR
+For `dev-loops`, the default pre-approval gate before calling a branch/PR
 review-complete, approval-ready, merge-ready, or ready for final handoff uses
 review angles resolved from config (`resolveGateAngles(config, "preApproval")`
 from `@pi-dev-loops/core/config`). Default config ships `dry`, `kiss`, `yagni`.

--- a/docs/specs/queue-mode/SPEC.md
+++ b/docs/specs/queue-mode/SPEC.md
@@ -1,6 +1,6 @@
 # SPEC: Outer dev-loop queue mode
 
-**Issue:** [#556](https://github.com/mfittko/pi-dev-loops/issues/556)
+**Issue:** [#556](https://github.com/mfittko/dev-loops/issues/556)
 **Status:** Draft — intake refinement
 **Branch:** `issue/556-queue-mode`
 
@@ -101,7 +101,7 @@ When `--parallel` is set:
 
 During any gate review (draft_gate, pre_approval_gate):
 - Detect workflow bugs, contract violations, or tool failures
-- Auto-file issue via `gh issue create --repo mfittko/pi-dev-loops --assignee @me`
+- Auto-file issue via `gh issue create --repo mfittko/dev-loops --assignee @me`
 - Append new issue to end of queue
 - Update `.pi/dev-loop-queue.json`
 

--- a/docs/steerable-subagents-design.md
+++ b/docs/steerable-subagents-design.md
@@ -176,9 +176,9 @@ The only new responsibility is to expose the session’s steerability through th
 
 ---
 
-## Operation-class gating in `pi-dev-loops`
+## Operation-class gating in `dev-loops`
 
-If `pi-subagents` / `pi-intercom` add the runtime hooks, `pi-dev-loops` would map
+If `pi-subagents` / `pi-intercom` add the runtime hooks, `dev-loops` would map
 its routed gates to operation classes.
 
 | Route / phase | Operation class | Notes |
@@ -189,7 +189,7 @@ its routed gates to operation classes.
 | `copilot_pr_followup` round iteration | `edit` | Per-Copilot-review round, before the next gate post. |
 
 This mapping belongs in the route-specific dispatch code that calls `subagent()`,
-so upstream does not need to know about `pi-dev-loops` gates.
+so upstream does not need to know about `dev-loops` gates.
 
 ---
 
@@ -217,7 +217,7 @@ provides.
 ### Other open questions
 
 1. **Who owns the dispatch-side flag?** Should `pi-subagents` declare the
-   `steerable` / `operationClass` API, or should `pi-dev-loops` wrap the call and
+   `steerable` / `operationClass` API, or should `dev-loops` wrap the call and
    re-export a narrower, opinionated surface?
 2. **Implicit vs. declared checkpoints.** Should the runtime insert checkpoints
    automatically around operation-class transitions, or should the subagent code
@@ -233,7 +233,7 @@ provides.
 
 - Opt-in via `steerable: true`.
 - Default behavior of `subagent()` is unchanged.
-- Existing dispatchers in `pi-dev-loops` and other consumers keep atomic
+- Existing dispatchers in `dev-loops` and other consumers keep atomic
   behavior unless they explicitly classify their work as steerable.
 
 ---

--- a/docs/sub-issue-tree-contract.md
+++ b/docs/sub-issue-tree-contract.md
@@ -1,7 +1,7 @@
 # Sub-Issue Tree Contract
 
 This document defines the deterministic pattern for epic/umbrella issue decomposition using
-GitHub sub-issues in `pi-dev-loops`.
+GitHub sub-issues in `dev-loops`.
 
 ## Purpose
 
@@ -61,7 +61,7 @@ node <resolved-skill-scripts>/github/manage-sub-issues.mjs <command> \
   --repo <owner/name> --issue <parent-number> [options]
 ```
 
-In the `pi-dev-loops` source repository the scripts directory is `scripts/` from the repo root.
+In the `dev-loops` source repository the scripts directory is `scripts/` from the repo root.
 In normalized installed skill copies it may be `scripts/` inside the installed skill directory.
 
 ### List sub-issues

--- a/docs/worktree-guidance.md
+++ b/docs/worktree-guidance.md
@@ -3,7 +3,7 @@
 ## Purpose and scope
 
 This document is the canonical repo-level owner for local worktree usage guidance in
-`pi-dev-loops`.
+`dev-loops`.
 
 Use it to keep local mutation work isolated, predictable, and easy to clean up.
 This guidance covers where worktrees live, when to create or reuse them, how to

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,13 +1,13 @@
 # Extension scaffold
 
-`pi-dev-loops` ships a lightweight package extension for readiness UX plus one bounded local UI lifecycle seam.
+`dev-loops` ships a lightweight package extension for readiness UX plus one bounded local UI lifecycle seam.
 
 Installing the package exposes two thin wrappers over one shared deterministic core:
 - the Pi extension command family rooted at `/dev-loops`
 - the shell CLI entrypoint `dev-loops`
-- a bounded post-merge helper that queues one `pi update git:github.com/mfittko/pi-dev-loops` after a successful in-session `gh pr merge ...` or `git merge ...` inside this repo and flushes it on `agent_end`
+- a bounded post-merge helper that queues one `pi update git:github.com/mfittko/dev-loops` after a successful in-session `gh pr merge ...` or `git merge ...` inside this repo and flushes it on `agent_end`
 
-Installing the package with `pi install git:github.com/mfittko/pi-dev-loops` exposes the packaged skills through `package.json` `pi.skills`, and the extension syncs packaged agent files (`.pi/agents/*.agent.md`) into `~/.agents/` on `session_start`.
+Installing the package with `pi install git:github.com/mfittko/dev-loops` exposes the packaged skills through `package.json` `pi.skills`, and the extension syncs packaged agent files (`.pi/agents/*.agent.md`) into `~/.agents/` on `session_start`.
 
 ## Command surface
 
@@ -89,9 +89,9 @@ The messaging distinguishes between local loop readiness and remote GitHub/Copil
 
 ## Package install contract for this phase
 
-- `pi install git:github.com/mfittko/pi-dev-loops` is the distribution mechanism for the extension, skills, scripts, packaged agents, and required installed runtime contract docs
-- `pi install -l git:github.com/mfittko/pi-dev-loops` is the project-local replacement for the old `install repo` flow
-- `pi update git:github.com/mfittko/pi-dev-loops` refreshes an installed package
+- `pi install git:github.com/mfittko/dev-loops` is the distribution mechanism for the extension, skills, scripts, packaged agents, and required installed runtime contract docs
+- `pi install -l git:github.com/mfittko/dev-loops` is the project-local replacement for the old `install repo` flow
+- `pi update git:github.com/mfittko/dev-loops` refreshes an installed package
 - source-tree canonical contract docs live under `skills/docs/`; installer/package output must ship this shared docs bundle with the installed skills subtree: [Public Dev Loop Contract](../skills/docs/public-dev-loop-contract.md) and [Retrospective Checkpoint Contract](../skills/docs/retrospective-checkpoint-contract.md)
 - installed skill/runtime guidance must read those bundled shared docs (from installed `skills/<skill>/`, resolve via `../docs/`) instead of assuming a source checkout is present; a missing bundled contract doc is a packaging/installer bug
 - packaged agents are refreshed into `~/.agents/` on each `session_start`

--- a/extension/index.ts
+++ b/extension/index.ts
@@ -21,8 +21,8 @@ type ExtensionRuntimeOverrides = NonNullable<Parameters<typeof createExtensionCo
   postMergeUpdateHook?: ReturnType<typeof createPostMergeUpdateHook>;
 };
 
-const STATUS_KEY = 'pi-dev-loops';
-const WIDGET_KEY = 'pi-dev-loops.setup';
+const STATUS_KEY = 'dev-loops';
+const WIDGET_KEY = 'dev-loops.setup';
 const PACKAGED_AGENTS_ROOT = new URL('../.pi/agents/', import.meta.url);
 
 export function syncPackagedAgents({

--- a/extension/post-merge-update.ts
+++ b/extension/post-merge-update.ts
@@ -8,8 +8,8 @@ import type {
   UserBashEventResult,
 } from '@mariozechner/pi-coding-agent';
 
-export const TARGET_REPO_SLUG = 'mfittko/pi-dev-loops';
-export const POST_MERGE_UPDATE_COMMAND = 'pi update git:github.com/mfittko/pi-dev-loops';
+export const TARGET_REPO_SLUG = 'mfittko/dev-loops';
+export const POST_MERGE_UPDATE_COMMAND = 'pi update git:github.com/mfittko/dev-loops';
 export const PRE_PR_READY_GATE_SCRIPT = 'node scripts/loop/pre-pr-ready-gate.mjs';
 
 const MERGE_COMMAND_TIMEOUT_MS = 15 * 60 * 1000;

--- a/extension/presentation.ts
+++ b/extension/presentation.ts
@@ -31,7 +31,7 @@ export function orderedSetupSteps(checks: DevLoopCheck[]): string[] {
   return [
     '1. Use `/skill:dev-loop` to start or continue a dev loop — the single public entry; routing handles the rest.',
     '2. Run `/dev-loops status` whenever you want a concise readiness snapshot.',
-    '3. Use `pi install git:github.com/mfittko/pi-dev-loops` to install the package, or `pi update git:github.com/mfittko/pi-dev-loops` to refresh it.',
+    '3. Use `pi install git:github.com/mfittko/dev-loops` to install the package, or `pi update git:github.com/mfittko/dev-loops` to refresh it.',
   ];
 }
 
@@ -49,7 +49,7 @@ export function buildHelpLines(): string[] {
     '- /dev-loops inspect status [--repo <owner/name>]',
     '- /dev-loops inspect stop [--repo <owner/name>]',
     '- /dev-loops inspect restart [--repo <owner/name>]',
-    'Use `pi install git:github.com/mfittko/pi-dev-loops` to install skills and agents; packaged agents sync into `~/.agents/` on session start.',
+    'Use `pi install git:github.com/mfittko/dev-loops` to install skills and agents; packaged agents sync into `~/.agents/` on session start.',
   ];
 }
 
@@ -73,7 +73,7 @@ export function buildWidgetLines(action: Extract<DevLoopsAction, 'doctor' | 'sta
   return [
     ...lines,
     ...renderCheckLines(checks),
-    'Skills load via `pi install git:github.com/mfittko/pi-dev-loops`; packaged agents sync into `~/.agents/` on session start.',
+    'Skills load via `pi install git:github.com/mfittko/dev-loops`; packaged agents sync into `~/.agents/` on session start.',
   ];
 }
 

--- a/package.json
+++ b/package.json
@@ -71,5 +71,13 @@
   "dependencies": {
     "mermaid": "11.15.0",
     "zod": "^4.4.3"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mfittko/dev-loops.git"
+  },
+  "bugs": {
+    "url": "https://github.com/mfittko/dev-loops/issues"
+  },
+  "homepage": "https://github.com/mfittko/dev-loops#readme"
 }

--- a/packages/core/src/loop/tracker-pr-state.mjs
+++ b/packages/core/src/loop/tracker-pr-state.mjs
@@ -25,7 +25,7 @@
  * Source-of-truth ownership:
  * - Tracker:        work-item identity, planning hierarchy, and tracker-native state
  * - GitHub:         PR lifecycle, review state, CI/check results, and merge facts
- * - pi-dev-loops:   projection and sync logic only; never the canonical owner of
+ * - dev-loops:   projection and sync logic only; never the canonical owner of
  *                   business fields
  */
 

--- a/packages/core/test/ac-dod-matrix.test.mjs
+++ b/packages/core/test/ac-dod-matrix.test.mjs
@@ -35,7 +35,7 @@ const validMatrix = Object.freeze({
       notes: "Pending refiner integration",
     },
   ],
-  source: "https://github.com/mfittko/pi-dev-loops/issues/675",
+  source: "https://github.com/mfittko/dev-loops/issues/675",
   generatedAt: "2026-06-08T12:00:00.000Z",
   isComplete: false,
 });
@@ -272,7 +272,7 @@ test("handoff envelope accepts optional refinementContract field", async () => {
   };
 
   const options = {
-    repoSlug: "mfittko/pi-dev-loops",
+    repoSlug: "mfittko/dev-loops",
     refinementContract: {
       schema: "ac-dod-matrix/v1",
       items: [validItem],
@@ -303,7 +303,7 @@ test("handoff envelope without refinementContract is still valid", async () => {
     },
   };
 
-  const options = { repoSlug: "mfittko/pi-dev-loops" };
+  const options = { repoSlug: "mfittko/dev-loops" };
   const envelope = buildDevLoopHandoffEnvelope(resolverOutput, {}, {}, options);
   const validation = validateHandoffEnvelope(envelope);
 
@@ -325,7 +325,7 @@ test("handoff envelope fails on malformed refinementContract", async () => {
   };
 
   const options = {
-    repoSlug: "mfittko/pi-dev-loops",
+    repoSlug: "mfittko/dev-loops",
     refinementContract: { schema: "wrong/v1", items: [], generatedAt: "bad", isComplete: "nope" },
   };
 
@@ -381,7 +381,7 @@ test("handoff envelope refinementContract validation rejects per-item shape erro
   };
 
   const options = {
-    repoSlug: "mfittko/pi-dev-loops",
+    repoSlug: "mfittko/dev-loops",
     refinementContract: {
       schema: "ac-dod-matrix/v1",
       items: [

--- a/packages/core/test/bash-exit-one.test.mjs
+++ b/packages/core/test/bash-exit-one.test.mjs
@@ -83,7 +83,7 @@ test("formatBashExitOneRecord formats one jsonl line", () => {
 });
 
 test("appendBashExitOneRecord appends a normalized record to jsonl", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-core-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-core-"));
   const logPath = path.join(tempDir, "bash-exit-1.jsonl");
 
   try {

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1920,7 +1920,7 @@ describe("shipped defaults docs and deep angle wiring", () => {
         assert.equal(role.persona, "review", `${angle} should use review persona`);
         assert.equal(role.fallback, false, `${angle} should resolve from persona registry`);
         assert.equal(role.prompt, result.config.personas[angle].prompt, `${angle} prompt should come from config`);
-        assert.doesNotMatch(role.prompt, /mfittko\/pi-dev-loops|issue #?\d+|tmp\/investigation|uncategorized-clusters/i, `${angle} prompt should stay repo-agnostic`);
+        assert.doesNotMatch(role.prompt, /mfittko\/dev-loops|issue #?\d+|tmp\/investigation|uncategorized-clusters/i, `${angle} prompt should stay repo-agnostic`);
       }
 
       assert.match(result.config.personas["contract-surface"].prompt, /schema fields, state\/sentinel names, runtime values, tests, and CLI output agree/i);

--- a/packages/core/test/copilot-helpers.test.mjs
+++ b/packages/core/test/copilot-helpers.test.mjs
@@ -288,7 +288,7 @@ test("summarizeGateReviewCommentMarkers prefers structured over lenient when bot
 test("parseGateReviewCommentMarkerBody lenient SHA ignores github comment URLs", () => {
   // "head e284c2e341" matched by context-based parser; URL #issuecomment-4615274563 ignored
   const body = "pre_approval_gate for head e284c2e341: all clear!\n\n" +
-    "See https://github.com/mfittko/pi-dev-loops/pull/450#issuecomment-4615274563 for details.";
+    "See https://github.com/mfittko/dev-loops/pull/450#issuecomment-4615274563 for details.";
   const result = parseGateReviewCommentMarkerBody(body);
   assert.notEqual(result, null);
   assert.equal(result.gate, "pre_approval_gate");

--- a/packages/core/test/debt-e2e-synthetic.test.mjs
+++ b/packages/core/test/debt-e2e-synthetic.test.mjs
@@ -18,7 +18,7 @@ function syntheticSignal(id, opts = {}) {
       description: opts.description || "Auto-generated synthetic signal",
       metadata: {
         prNumber: "88",
-        prUrl: "https://github.com/mfittko/pi-dev-loops/pull/88",
+        prUrl: "https://github.com/mfittko/dev-loops/pull/88",
         commentId: `comment-${id}`,
         category: opts.signalKind || "file_size",
       },

--- a/packages/core/test/debt-signal.test.mjs
+++ b/packages/core/test/debt-signal.test.mjs
@@ -17,12 +17,12 @@ describe("debt-signal schema", () => {
         lineStart: 10,
         lineEnd: 20,
         commitSha: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b",
-        url: "https://github.com/mfittko/pi-dev-loops/blob/main/src/index.mjs",
+        url: "https://github.com/mfittko/dev-loops/blob/main/src/index.mjs",
       },
       severityHint: "high",
       timestamp: validTimestamp,
       rawPayload: { key: "value" },
-      repository: { owner: "mfittko", name: "pi-dev-loops" },
+      repository: { owner: "mfittko", name: "dev-loops" },
       confidence: 0.85,
     };
     const result = DebtSignalSchema.safeParse(input);
@@ -31,7 +31,7 @@ describe("debt-signal schema", () => {
       assert.equal(result.data.id, validUUID);
       assert.equal(result.data.confidence, 0.85);
       assert.deepEqual(result.data.rawPayload, { key: "value" });
-      assert.deepEqual(result.data.repository, { owner: "mfittko", name: "pi-dev-loops" });
+      assert.deepEqual(result.data.repository, { owner: "mfittko", name: "dev-loops" });
     }
   });
 

--- a/packages/core/test/deep-persona-signals.test.mjs
+++ b/packages/core/test/deep-persona-signals.test.mjs
@@ -19,7 +19,7 @@ import {
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_PATH = join(__dirname, "fixtures", "github", "review-threads", "deep-persona-threads.json");
 
-const PR_META = { prNumber: "412", prUrl: "https://github.com/mfittko/pi-dev-loops/pull/412" };
+const PR_META = { prNumber: "412", prUrl: "https://github.com/mfittko/dev-loops/pull/412" };
 
 // ============================================================================
 // Helpers
@@ -211,7 +211,7 @@ describe("deep-persona signal extraction", () => {
       const meta = firstSignal.rawPayload?.metadata;
       assert.ok(meta, "metadata should exist in rawPayload");
       assert.equal(meta.prNumber, "412");
-      assert.equal(meta.prUrl, "https://github.com/mfittko/pi-dev-loops/pull/412");
+      assert.equal(meta.prUrl, "https://github.com/mfittko/dev-loops/pull/412");
       assert.ok(typeof meta.commentId === "string");
       assert.ok(typeof meta.threadId === "string");
       assert.ok(typeof meta.isResolved === "boolean");

--- a/packages/core/test/phase-files.test.mjs
+++ b/packages/core/test/phase-files.test.mjs
@@ -156,7 +156,7 @@ test("buildPhasePaths returns deterministic project-relative paths", () => {
 });
 
 test("ensurePhaseFiles writes manifest and index files with merged patch data", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-phase-files-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-phase-files-"));
 
   try {
     const first = await ensurePhaseFiles(tempDir, "phase-0", {
@@ -210,7 +210,7 @@ test("parseCliArgs rejects missing phase, missing option values, and unknown arg
 });
 
 test("ensure-phase-files CLI emits stable machine-readable success output", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-phase-files-cli-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-phase-files-cli-"));
   const cliPath = path.resolve("packages/core/bin/ensure-phase-files.mjs");
 
   try {

--- a/packages/core/test/review-threads-cli.test.mjs
+++ b/packages/core/test/review-threads-cli.test.mjs
@@ -59,7 +59,7 @@ test("parse-review-threads CLI emits stable machine-readable success output", as
 });
 
 test("parse-review-threads CLI reports invalid JSON deterministically", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-review-cli-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-review-cli-"));
   const invalidPath = path.join(tempDir, "invalid.json");
 
   try {

--- a/schemas/dev-loop-config.schema.json
+++ b/schemas/dev-loop-config.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/mfittko/pi-dev-loops/schemas/dev-loop-config.schema.json",
+  "$id": "https://github.com/mfittko/dev-loops/schemas/dev-loop-config.schema.json",
   "title": "dev-loops config",
   "description": "Schema for .pi/dev-loop/defaults.yaml, settings.yaml, or overrides.yaml.",
   "type": "object",

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -87,7 +87,7 @@ When this skill refers to helper paths such as `scripts/...` or `docs/...`, reso
 
 Use this rule:
 - if the skill is installed as a normalized standalone copy, the required bundled contract docs live under the shared `../docs/` directory next to the installed skill directories; do not assume helper scripts are bundled unless that installed layout actually contains them
-- if you are working in the `pi-dev-loops` source repository, this skill file lives under `skills/copilot-pr-followup/`, so source-repo helper scripts live two levels up at `../../scripts/`, while required bundled contract docs live one level up at `../docs/`
+- if you are working in the `dev-loops` source repository, this skill file lives under `skills/copilot-pr-followup/`, so source-repo helper scripts live two levels up at `../../scripts/`, while required bundled contract docs live one level up at `../docs/`
 - when in doubt, resolve helper paths relative to this [skill file](./SKILL.md) first, then verify the target file exists before running it
 
 Required bundled runtime contract docs for installed copies of this skill:

--- a/skills/docs/artifact-authority-contract.md
+++ b/skills/docs/artifact-authority-contract.md
@@ -8,7 +8,7 @@ Other repo docs may summarize or link this contract, but they should not redefin
 
 ## Two-tier model
 
-pi-dev-loops supports two mutually exclusive artifact authority modes. Every work item must originate from exactly one authoritative artifact — a GitHub issue or a persisted markdown plan file. No work may originate from a PR or direct local change unless explicitly requested.
+dev-loops supports two mutually exclusive artifact authority modes. Every work item must originate from exactly one authoritative artifact — a GitHub issue or a persisted markdown plan file. No work may originate from a PR or direct local change unless explicitly requested.
 
 ### Tracker-first (default)
 
@@ -73,7 +73,7 @@ The `inputSource.default` key disambiguates local-first startup:
 - `tracker` (default): local agent implements from the GitHub issue body; the issue is canonical spec
 - `phase-docs`: local agent implements from persisted phase docs; no tracker issue required
 
-These keys are already defined in `.pi/dev-loop/defaults.yaml` (shipped with pi-dev-loops) and may be overridden in `.devloops` (per-repo).
+These keys are already defined in `.pi/dev-loop/defaults.yaml` (shipped with dev-loops) and may be overridden in `.devloops` (per-repo).
 
 ### Defaults resolution
 
@@ -87,15 +87,15 @@ These are not valid artifact authority mode selectors:
 - Free-form string values — fail closed
 - Omitting `strategy.default` entirely — defaults to `github-first` from the shipped defaults
 
-## pi-dev-loops own mode
+## dev-loops own mode
 
-pi-dev-loops is **tracker-first (opted in, GitHub backend).**
+dev-loops is **tracker-first (opted in, GitHub backend).**
 
 - **Mode:** Tracker-first
 - **Settings:** `.pi/dev-loop/defaults.yaml` sets `strategy.default: github-first`
 - **Artifact authority:** GitHub issues are the canonical spec for all work in this repository
 - **No local-planning override:** This repo does not opt out to local-planning mode
-- **Why tracker-first:** All work in this repo originates from GitHub issues. The public dev-loop contract, Copilot follow-up state machines, and gate pipeline all assume issues are the primary artifact. Self-improvement work on pi-dev-loops itself follows the same tracker-first contract.
+- **Why tracker-first:** All work in this repo originates from GitHub issues. The public dev-loop contract, Copilot follow-up state machines, and gate pipeline all assume issues are the primary artifact. Self-improvement work on dev-loops itself follows the same tracker-first contract.
 
 ## Relationship to other docs
 

--- a/skills/docs/copilot-loop-operations.md
+++ b/skills/docs/copilot-loop-operations.md
@@ -15,7 +15,7 @@ as the authoritative source for:
 - Copilot follow-up loop: `detect-copilot-loop-state.mjs` from the resolved skill scripts directory
 - reviewer-side PR review loop: `detect-reviewer-loop-state.mjs` from the resolved skill scripts directory
 
-Resolve those helper paths from the skill asset layout described by the main skill. In the `pi-dev-loops`
+Resolve those helper paths from the skill asset layout described by the main skill. In the `dev-loops`
 source repository the skill scripts directory is `../../scripts/` relative to `skills/copilot-pr-followup/SKILL.md`; in normalized
 installed copies it may instead be `scripts/` inside the installed skill directory when that layout bundles the helper scripts.
 
@@ -27,7 +27,7 @@ Use the machines to answer:
 
 Each machine captures an observable snapshot from GitHub facts (plus explicit bounded local loop
 metadata when required) and interprets it into exactly one current state plus allowed next
-transitions. In the `pi-dev-loops` source repository, the supporting source-authority references are [Copilot Loop State Graph](../../docs/copilot-loop-state-graph.md) and [Reviewer Loop State Graph](../../docs/reviewer-loop-state-graph.md) under `../../docs/` relative to `skills/copilot-pr-followup/SKILL.md`. Treat those links as source-repo references, not bundled installed-skill docs.
+transitions. In the `dev-loops` source repository, the supporting source-authority references are [Copilot Loop State Graph](../../docs/copilot-loop-state-graph.md) and [Reviewer Loop State Graph](../../docs/reviewer-loop-state-graph.md) under `../../docs/` relative to `skills/copilot-pr-followup/SKILL.md`. Treat those links as source-repo references, not bundled installed-skill docs.
 
 For tracker-first MVP `story -> PR -> tracker sync` work, the source-repo reference is [Tracker-First Story-to-PR Contract](../../docs/tracker-story-pr-contract.md). That source doc inherits source-of-truth ownership, the required work item <-> PR link, and reverse-sync semantics from `#21`; it only adds the mutually exclusive workflow-family states and post-merge sync-verification states for this narrower MVP slice.
 

--- a/skills/docs/issue-intake-procedure.md
+++ b/skills/docs/issue-intake-procedure.md
@@ -201,7 +201,7 @@ node <resolved-skill-scripts>/github/manage-sub-issues.mjs list \
 Do **not** re-implement sub-issue management ad hoc or bypass `manage-sub-issues.mjs`.
 Do **not** maintain a body checklist that duplicates the sub-issue tree.
 
-For the full `manage-sub-issues.mjs` contract, use [Sub-Issue Tree Contract](../../docs/sub-issue-tree-contract.md) when working in the `pi-dev-loops` source repository. That contract is a source-repo reference, not part of the bundled installed skill-doc surface. For installed or normalized skill copies, inspect the target repository docs/source directly instead of assuming a bundled shared-doc copy exists.
+For the full `manage-sub-issues.mjs` contract, use [Sub-Issue Tree Contract](../../docs/sub-issue-tree-contract.md) when working in the `dev-loops` source repository. That contract is a source-repo reference, not part of the bundled installed skill-doc surface. For installed or normalized skill copies, inspect the target repository docs/source directly instead of assuming a bundled shared-doc copy exists.
 
 When an existing sub-issue tree needs **scope alignment, AC/DoD contracts, and delegation boundary refinement** across all levels (parent → children → grandchildren), use the [Epic Tree Refinement Procedure](./epic-tree-refinement-procedure.md) — it owns the deterministic depth-first, top-down-then-bottom-up refinement protocol.
 

--- a/skills/docs/pr-lifecycle-contract.md
+++ b/skills/docs/pr-lifecycle-contract.md
@@ -1,6 +1,6 @@
 # PR lifecycle contract
 
-This document defines the deterministic **family-local PR lifecycle contract** for the GitHub/Copilot workflow family in `pi-dev-loops`.
+This document defines the deterministic **family-local PR lifecycle contract** for the GitHub/Copilot workflow family in `dev-loops`.
 
 The canonical contract lives in the shipped `skills/docs/` surface because installed skill/runtime consumers reliably own the skills subtree.
 

--- a/test/dev-loops-cli.test.mjs
+++ b/test/dev-loops-cli.test.mjs
@@ -125,7 +125,7 @@ test("CLI help leads with dev-loop as the primary workflow entry", async () => {
   assert.equal(helpExitCode, 0);
   assert.match(helpStdout.read(), /\/skill:dev-loop/, "CLI help should mention /skill:dev-loop as workflow entry");
   assert.match(helpStdout.read(), /single public entry/, "CLI help should describe dev-loop as single public entry");
-  assert.doesNotMatch(helpStdout.read(), /pi-dev-loops (?:install|update)/);
+  assert.doesNotMatch(helpStdout.read(), /dev-loops (?:install|update)/);
   assert.doesNotMatch(helpStdout.read(), /copilot-dev-loop|copilot-autopilot/i, "CLI help should not surface internal seam names");
   assert.equal(helpStderr.read(), "");
 });
@@ -182,7 +182,7 @@ test("CLI status next steps lead with dev-loop when all checks pass", async () =
 
 
 test("createCliRuntime rejects path-like command probes", async () => {
-  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-cli-path-guard-"));
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "dev-loops-cli-path-guard-"));
   const binDir = path.join(tempRoot, "bin");
   const nestedDir = path.join(binDir, "foo");
   await mkdir(nestedDir, { recursive: true });
@@ -205,7 +205,7 @@ exit 0
 
 
 test("createCliRuntime probes PATH commands and git repositories without a login shell", async () => {
-  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-cli-runtime-"));
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "dev-loops-cli-runtime-"));
   const binDir = path.join(tempRoot, "bin");
   const repoDir = path.join(tempRoot, "repo");
   await mkdir(binDir, { recursive: true });
@@ -247,7 +247,7 @@ exit 0
 
 
 test("createCliRuntime honors PATHEXT lookups when simulating Windows PATH resolution", async () => {
-  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-cli-win-runtime-"));
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "dev-loops-cli-win-runtime-"));
   const binDir = path.join(tempRoot, "bin");
   await mkdir(binDir, { recursive: true });
   await writeFile(path.join(binDir, "gh.EXE"), "");
@@ -271,7 +271,7 @@ test("createCliRuntime honors PATHEXT lookups when simulating Windows PATH resol
 });
 
 test("CLI rejects removed update command", async () => {
-  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-cli-update-"));
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "dev-loops-cli-update-"));
   const stdout = createBufferStream();
   const stderr = createBufferStream();
 
@@ -294,7 +294,7 @@ test("CLI rejects removed update command", async () => {
 
 
 test("project wrappers pass through helper stdout and exit codes", async () => {
-  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-project-cli-"));
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "dev-loops-project-cli-"));
   const binDir = path.join(tempRoot, "bin");
   await mkdir(binDir, { recursive: true });
   const ghImplPath = path.join(binDir, "gh-impl.mjs");
@@ -311,7 +311,7 @@ if (query.includes("user(login:$login) { id }")) {
 } else if (query.includes("fields(first:50, after:$after)")) {
   write({ data: { node: { fields: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [{ id: "PVTSSF_1", name: "Status", options: [{ id: "opt1", name: "Backlog" }, { id: "opt2", name: "Next Up" }] }] } } } });
 } else if (query.includes("items(first:100, after:$after)")) {
-  write({ data: { node: { items: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [{ id: "PVTI_1", fieldValues: { nodes: [{ field: { id: "PVTSSF_1", name: "Status" }, name: "Next Up" }] }, content: { number: 748, title: "Public CLI surface", url: "https://github.com/mfittko/pi-dev-loops/issues/748", id: "I_748" } }] } } } });
+  write({ data: { node: { items: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [{ id: "PVTI_1", fieldValues: { nodes: [{ field: { id: "PVTSSF_1", name: "Status" }, name: "Next Up" }] }, content: { number: 748, title: "Public CLI surface", url: "https://github.com/mfittko/dev-loops/issues/748", id: "I_748" } }] } } } });
 } else {
   process.stderr.write(JSON.stringify({ ok: false, error: "Unhandled query: " + query }));
   process.exit(1);
@@ -330,7 +330,7 @@ node "$(dirname "$0")/gh-impl.mjs" "$@"
 
   try {
     const env = { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` };
-    const success = spawnSync("node", ["./cli/index.mjs", "project", "list", "--repo", "mfittko/pi-dev-loops", "--project", "1", "--column", "Next Up"], {
+    const success = spawnSync("node", ["./cli/index.mjs", "project", "list", "--repo", "mfittko/dev-loops", "--project", "1", "--column", "Next Up"], {
       cwd: repoRoot,
       env,
       encoding: "utf8",

--- a/test/dev-loops-core.test.mjs
+++ b/test/dev-loops-core.test.mjs
@@ -151,10 +151,10 @@ test("collectDevLoopChecks no longer reports a dev-loop skill readiness check", 
 
 test("parser accepts the bounded inspect lifecycle command family only on the extension surface", () => {
   for (const action of ["open", "resume", "status", "stop", "restart"]) {
-    const parsed = parseDevLoopsCommand(["inspect", action, "--repo", "mfittko/pi-dev-loops"], { surface: "extension" });
+    const parsed = parseDevLoopsCommand(["inspect", action, "--repo", "mfittko/dev-loops"], { surface: "extension" });
     assert.equal(parsed.kind, "inspect_action");
     assert.equal(parsed.action, action);
-    assert.equal(parsed.repo, "mfittko/pi-dev-loops");
+    assert.equal(parsed.repo, "mfittko/dev-loops");
   }
 
   assert.deepEqual(parseDevLoopsCommand(["inspect", "launch"], { surface: "extension" }), {
@@ -203,33 +203,33 @@ test('executor returns a structured inspect-run UI result when repo-root lookup 
 test('normalizeInput handles non-breaking spaces and other unusual whitespace', () => {
   // parseDevLoopsCommand routes through normalizeInput internally
   const parsed = parseDevLoopsCommand(
-    ['inspect', '\u00A0open\u00A0', '--repo', '\u00A0mfittko/pi-dev-loops\u00A0'],
+    ['inspect', '\u00A0open\u00A0', '--repo', '\u00A0mfittko/dev-loops\u00A0'],
     { surface: 'extension' }
   );
   assert.equal(parsed.kind, 'inspect_action');
   assert.equal(parsed.action, 'open');
-  assert.equal(parsed.repo, 'mfittko/pi-dev-loops');
+  assert.equal(parsed.repo, 'mfittko/dev-loops');
 });
 
 test('normalizeInput filters non-primitive array elements', () => {
   const parsed = parseDevLoopsCommand(
-    ['inspect', 'open', { _meta: 'should-be-ignored' }, '--repo', 'mfittko/pi-dev-loops'],
+    ['inspect', 'open', { _meta: 'should-be-ignored' }, '--repo', 'mfittko/dev-loops'],
     { surface: 'extension' }
   );
   assert.equal(parsed.kind, 'inspect_action');
   assert.equal(parsed.action, 'open');
-  assert.equal(parsed.repo, 'mfittko/pi-dev-loops');
+  assert.equal(parsed.repo, 'mfittko/dev-loops');
 });
 
 test('normalizeInput handles mixed whitespace characters', () => {
   // em-space, en-space, thin space, NBSP
   const parsed = parseDevLoopsCommand(
-    ['inspect\u2003open\u2002--repo\u2009mfittko/pi-dev-loops'],
+    ['inspect\u2003open\u2002--repo\u2009mfittko/dev-loops'],
     { surface: 'extension' }
   );
   assert.equal(parsed.kind, 'inspect_action');
   assert.equal(parsed.action, 'open');
-  assert.equal(parsed.repo, 'mfittko/pi-dev-loops');
+  assert.equal(parsed.repo, 'mfittko/dev-loops');
 });
 
 test('executor preserves repoRoot when the inspect-run lifecycle action throws after repo-root lookup succeeds', async () => {

--- a/test/docs/validate-links.test.mjs
+++ b/test/docs/validate-links.test.mjs
@@ -10,7 +10,7 @@ import { formatBrokenLinkReport, validateMarkdownLinks } from "../../scripts/doc
 const scriptPath = path.resolve("scripts/docs/validate-links.mjs");
 
 async function createRepo(files) {
-  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-validate-links-"));
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "dev-loops-validate-links-"));
 
   for (const [relativePath, content] of Object.entries(files)) {
     const absolutePath = path.join(repoRoot, relativePath);

--- a/test/docs/validate-no-duplicate-rules.test.mjs
+++ b/test/docs/validate-no-duplicate-rules.test.mjs
@@ -129,7 +129,7 @@ test("extractSentences handles ~~~ fenced blocks", () => {
 });
 
 test("scanSkills detects cross-file duplicates", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-validate-rules-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-validate-rules-"));
   try {
     const skillsDir = await writeSkillsDir(tempDir, {
       "doc-a/SKILL.md": "You must always run tests before pushing changes to main.",
@@ -152,7 +152,7 @@ test("scanSkills detects cross-file duplicates", async () => {
 });
 
 test("scanSkills reports no duplicates when clean", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-validate-rules-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-validate-rules-"));
   try {
     const skillsDir = await writeSkillsDir(tempDir, {
       "doc-a/SKILL.md": "You must run tests before pushing changes to the branch.",
@@ -168,7 +168,7 @@ test("scanSkills reports no duplicates when clean", async () => {
 });
 
 test("scanSkills detects duplicate across three files", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-validate-rules-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-validate-rules-"));
   try {
     const skillsDir = await writeSkillsDir(tempDir, {
       "doc-a/SKILL.md": "You must always run tests before pushing to main.",
@@ -187,7 +187,7 @@ test("scanSkills detects duplicate across three files", async () => {
 });
 
 test("scanSkills ignores same-file duplicates", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-validate-rules-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-validate-rules-"));
   try {
     const skillsDir = await writeSkillsDir(tempDir, {
       "doc-a/SKILL.md": "You must run tests before pushing. You must run tests before pushing.",
@@ -203,7 +203,7 @@ test("scanSkills ignores same-file duplicates", async () => {
 });
 
 test("scanSkills handles empty skills tree", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-validate-rules-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-validate-rules-"));
   try {
     const skillsDir = path.join(tempDir, "skills");
     await mkdir(skillsDir, { recursive: true });
@@ -218,7 +218,7 @@ test("scanSkills handles empty skills tree", async () => {
 });
 
 test("scanSkills detects duplicate when non-canonical file restates canonical rule", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-validate-rules-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-validate-rules-"));
   try {
     const skillsDir = await writeSkillsDir(tempDir, {
       "docs/copilot-loop-operations.md": "You must run tests before every push to main and also verify the build output is correct.",
@@ -235,7 +235,7 @@ test("scanSkills detects duplicate when non-canonical file restates canonical ru
 });
 
 test("scanSkills suppresses duplicates when all occurrences are canonical", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-validate-rules-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-validate-rules-"));
   try {
     const skillsDir = await writeSkillsDir(tempDir, {
       "docs/copilot-loop-operations.md": "You must run tests before every push to main and also verify the build output is correct.",
@@ -253,7 +253,7 @@ test("scanSkills suppresses duplicates when all occurrences are canonical", asyn
 
 
 test("scanSkills excludes known intentional duplicates", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-validate-rules-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-validate-rules-"));
   try {
     // This sentence is in the KNOWN_INTENTIONAL_DUPLICATES set,
     // so cross-file duplication should be suppressed.
@@ -271,7 +271,7 @@ test("scanSkills excludes known intentional duplicates", async () => {
 });
 
 test("collectMarkdownFiles finds markdown files recursively", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-validate-rules-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-validate-rules-"));
   try {
     const skillsDir = await writeSkillsDir(tempDir, {
       "SKILL.md": "root",

--- a/test/extension-command-contract.test.mjs
+++ b/test/extension-command-contract.test.mjs
@@ -77,7 +77,7 @@ function readyPi() {
 
 test("extension clears stale footer status and syncs packaged agents on session start", async () => {
   const previousHome = process.env.HOME;
-  const tempHome = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-session-home-"));
+  const tempHome = await mkdtemp(path.join(os.tmpdir(), "dev-loops-session-home-"));
   process.env.HOME = tempHome;
 
   try {
@@ -94,7 +94,7 @@ test("extension clears stale footer status and syncs packaged agents on session 
     const { ctx, calls } = createCommandContext();
     await pi.events.get("session_start")({}, ctx);
 
-    assert.deepEqual(calls.statuses, [{ key: "pi-dev-loops", text: undefined }]);
+    assert.deepEqual(calls.statuses, [{ key: "dev-loops", text: undefined }]);
     assert.equal(
       await readFile(path.join(tempHome, ".agents", "dev-loop.agent.md"), "utf8"),
       await readFile(new URL("../.pi/agents/dev-loop.agent.md", import.meta.url), "utf8"),
@@ -111,7 +111,7 @@ test("extension clears stale footer status and syncs packaged agents on session 
 });
 
 test("syncPackagedAgents creates the target directory and only copies .agent.md files", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-agent-sync-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-agent-sync-"));
   const sourceRoot = path.join(tempDir, "source");
   const targetRoot = path.join(tempDir, "target");
 
@@ -133,10 +133,10 @@ test("help is the default action and removed install/update commands fall back t
   await pi.registeredCommands.get("dev-loops").handler("", ctx);
 
   const widget = calls.widgets.at(-1);
-  assert.equal(widget.key, "pi-dev-loops.setup");
+  assert.equal(widget.key, "dev-loops.setup");
   assert.match(widget.lines[0], /dev-loops help/);
   assert(widget.lines.some((line) => /\/dev-loops status/i.test(line)));
-  assert(widget.lines.some((line) => /pi install git:github.com\/mfittko\/pi-dev-loops/i.test(line)));
+  assert(widget.lines.some((line) => /pi install git:github.com\/mfittko\/dev-loops/i.test(line)));
   assert(widget.lines.some((line) => /\/skill:dev-loop/i.test(line)), "help should mention /skill:dev-loop as workflow entry");
   assert(widget.lines.some((line) => /single public entry/i.test(line)), "help should describe dev-loop as single public entry");
   assert.equal(widget.lines.some((line) => /copilot-dev-loop|copilot-autopilot/i.test(line)), false, "help should not surface internal seam names");
@@ -188,7 +188,7 @@ test("status and doctor use the reduced readiness surface", async () => {
   assert(doctorLines.some((line) => /^⚠️ GitHub CLI authenticated/.test(line)));
   assert.equal(doctorLines.some((line) => /Local dev-loop skill discoverable/i.test(line)), false);
   assert.equal(doctorLines.some((line) => /copilot-dev-loop|copilot-autopilot/i.test(line)), false);
-  assert(doctorLines.some((line) => /Skills load via `pi install git:github.com\/mfittko\/pi-dev-loops`/i.test(line)));
+  assert(doctorLines.some((line) => /Skills load via `pi install git:github.com\/mfittko\/dev-loops`/i.test(line)));
 
   const statusContext = createCommandContext();
   await pi.registeredCommands.get("dev-loops").handler("status", statusContext.ctx);
@@ -205,7 +205,7 @@ test("hide still clears the widget and unknown commands fall back to help", asyn
   const hideContext = createCommandContext();
   await pi.registeredCommands.get("dev-loops").handler("hide", hideContext.ctx);
   assert.deepEqual(hideContext.calls.widgets.at(-1), {
-    key: "pi-dev-loops.setup",
+    key: "dev-loops.setup",
     lines: undefined,
     options: undefined,
   });
@@ -223,10 +223,10 @@ test("extension dispatches inspect-run open and surfaces browser warnings withou
     uiLifecycle: {
       async open({ repoRoot, repo }) {
         assert.equal(repoRoot, '/repo/root');
-        assert.equal(repo, 'mfittko/pi-dev-loops');
+        assert.equal(repo, 'mfittko/dev-loops');
         return {
           state: 'running',
-          url: 'http://127.0.0.1:4311/?scope=mfittko%2Fpi-dev-loops',
+          url: 'http://127.0.0.1:4311/?scope=mfittko%2Fdev-loops',
           detail: 'Reused the managed inspect-run viewer.',
           warning: 'browser unavailable',
         };
@@ -236,10 +236,10 @@ test("extension dispatches inspect-run open and surfaces browser warnings withou
   });
 
   const { ctx, calls } = createCommandContext();
-  await pi.registeredCommands.get('dev-loops').handler('inspect open --repo mfittko/pi-dev-loops', ctx);
+  await pi.registeredCommands.get('dev-loops').handler('inspect open --repo mfittko/dev-loops', ctx);
 
   const widget = calls.widgets.at(-1);
-  assert.equal(widget.key, 'pi-dev-loops.setup');
+  assert.equal(widget.key, 'dev-loops.setup');
   assert(widget.lines.some((line) => /inspect open/i.test(line)));
   assert(widget.lines.some((line) => /running/i.test(line)));
   assert(widget.lines.some((line) => /http:\/\/127\.0\.0\.1:4311/i.test(line)));

--- a/test/extension-package-contract.test.mjs
+++ b/test/extension-package-contract.test.mjs
@@ -35,9 +35,9 @@ test("extension README documents the supported command, install, and verificatio
   }
 
   for (const installPattern of [
-    /pi install git:github.com\/mfittko\/pi-dev-loops/i,
-    /pi install -l git:github.com\/mfittko\/pi-dev-loops/i,
-    /pi update git:github.com\/mfittko\/pi-dev-loops/i,
+    /pi install git:github.com\/mfittko\/dev-loops/i,
+    /pi install -l git:github.com\/mfittko\/dev-loops/i,
+    /pi update git:github.com\/mfittko\/dev-loops/i,
   ]) {
     assert.match(readme, installPattern);
   }

--- a/test/extension-post-merge-update.test.mjs
+++ b/test/extension-post-merge-update.test.mjs
@@ -50,12 +50,12 @@ function createPiDouble() {
 }
 
 test("normalizeGitHubRepoSlug recognizes GitHub remote variants", () => {
-  assert.equal(normalizeGitHubRepoSlug("git@github.com:mfittko/pi-dev-loops.git"), TARGET_REPO_SLUG);
-  assert.equal(normalizeGitHubRepoSlug("https://github.com/mfittko/pi-dev-loops.git"), TARGET_REPO_SLUG);
-  assert.equal(normalizeGitHubRepoSlug("git@github.com:Mfittko/Pi-Dev-Loops.git"), TARGET_REPO_SLUG);
-  assert.equal(normalizeGitHubRepoSlug("ssh://git@github.com/mfittko/pi-dev-loops.git"), TARGET_REPO_SLUG);
-  assert.equal(normalizeGitHubRepoSlug("git:github.com/mfittko/pi-dev-loops"), TARGET_REPO_SLUG);
-  assert.equal(normalizeGitHubRepoSlug("https://gitlab.com/mfittko/pi-dev-loops.git"), null);
+  assert.equal(normalizeGitHubRepoSlug("git@github.com:mfittko/dev-loops.git"), TARGET_REPO_SLUG);
+  assert.equal(normalizeGitHubRepoSlug("https://github.com/mfittko/dev-loops.git"), TARGET_REPO_SLUG);
+  assert.equal(normalizeGitHubRepoSlug("git@github.com:Mfittko/Dev-Loops.git"), TARGET_REPO_SLUG);
+  assert.equal(normalizeGitHubRepoSlug("ssh://git@github.com/mfittko/dev-loops.git"), TARGET_REPO_SLUG);
+  assert.equal(normalizeGitHubRepoSlug("git:github.com/mfittko/dev-loops"), TARGET_REPO_SLUG);
+  assert.equal(normalizeGitHubRepoSlug("https://gitlab.com/mfittko/dev-loops.git"), null);
 });
 
 test("isMergeCapableCommand only matches bounded merge commands", () => {
@@ -263,7 +263,7 @@ test("killed post-merge updates surface a clear warning message", async () => {
 
 test("session_start resets post-merge hook state and extension registers lifecycle listeners", async () => {
   const previousHome = process.env.HOME;
-  const tempHome = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-post-merge-home-"));
+  const tempHome = await mkdtemp(path.join(os.tmpdir(), "dev-loops-post-merge-home-"));
   process.env.HOME = tempHome;
 
   try {
@@ -300,7 +300,7 @@ test("session_start resets post-merge hook state and extension registers lifecyc
 test("isGhPrReadyCommand matches gh pr ready variants", () => {
   assert.equal(isGhPrReadyCommand("gh pr ready"), true);
   assert.equal(isGhPrReadyCommand("gh pr ready 42"), true);
-  assert.equal(isGhPrReadyCommand("gh pr ready 42 --repo mfittko/pi-dev-loops"), true);
+  assert.equal(isGhPrReadyCommand("gh pr ready 42 --repo mfittko/dev-loops"), true);
   assert.equal(isGhPrReadyCommand("gh pr ready --help"), false);
   assert.equal(isGhPrReadyCommand("gh pr ready -h"), false);
   assert.equal(isGhPrReadyCommand("gh pr ready 42 --help"), false);
@@ -317,8 +317,8 @@ test("isGhPrReadyCommand matches gh pr ready variants", () => {
 test("extractPrNumberFromGhPrReady extracts the PR number", () => {
   assert.equal(extractPrNumberFromGhPrReady("gh pr ready 42"), 42);
   assert.equal(extractPrNumberFromGhPrReady("gh pr ready 123"), 123);
-  assert.equal(extractPrNumberFromGhPrReady("gh pr ready 42 --repo mfittko/pi-dev-loops"), 42);
-  assert.equal(extractPrNumberFromGhPrReady("gh pr ready --repo mfittko/pi-dev-loops 42"), 42);
+  assert.equal(extractPrNumberFromGhPrReady("gh pr ready 42 --repo mfittko/dev-loops"), 42);
+  assert.equal(extractPrNumberFromGhPrReady("gh pr ready --repo mfittko/dev-loops 42"), 42);
   assert.equal(extractPrNumberFromGhPrReady("gh pr ready -r other/repo 42"), 42);
   assert.equal(extractPrNumberFromGhPrReady("gh pr ready --REPO other/repo 42"), 42);
   assert.equal(extractPrNumberFromGhPrReady("gh pr ready 42abc"), null);

--- a/test/github/capture-review-threads.test.mjs
+++ b/test/github/capture-review-threads.test.mjs
@@ -55,7 +55,7 @@ test("capture-review-threads reads review-thread JSON from stdin", async () => {
 });
 
 test("capture-review-threads writes identical JSON to --output", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-capture-review-threads-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-capture-review-threads-"));
   const outputPath = path.join(tempDir, "review-threads.json");
 
   try {
@@ -75,7 +75,7 @@ test("capture-review-threads writes identical JSON to --output", async () => {
 });
 
 test("capture-review-threads supports live gh capture only with explicit --repo and --pr", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-capture-review-live-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-capture-review-live-"));
 
   try {
     const fixtureText = await readFile(fixturePath, "utf8");
@@ -105,7 +105,7 @@ test("capture-review-threads supports live gh capture only with explicit --repo 
 });
 
 test("capture-review-threads exposes numeric comment database ids in normalized live output", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-capture-review-database-id-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-capture-review-database-id-"));
 
   try {
     const gh = await writeGhStub(tempDir, [
@@ -211,7 +211,7 @@ test("capture-review-threads rejects malformed live-argument combinations determ
 });
 
 test("capture-review-threads reports gh failures deterministically", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-capture-review-gh-failure-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-capture-review-gh-failure-"));
 
   try {
     const gh = await writeGhStub(tempDir, [

--- a/test/github/create-draft-pr.test.mjs
+++ b/test/github/create-draft-pr.test.mjs
@@ -60,7 +60,7 @@ test("detectClosingKeyword scans only first MAX_BODY_SCAN_BYTES", () => {
 // --- integration tests for closing-keyword warning ---
 
 test("create-draft-pr --body with closing keyword emits no stderr warning", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-create-draft-pr-body-keyword-ok-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-create-draft-pr-body-keyword-ok-"));
 
   try {
     const { env, ghLogPath } = await writeGhStub(tempDir, [
@@ -86,7 +86,7 @@ test("create-draft-pr --body with closing keyword emits no stderr warning", asyn
 });
 
 test("create-draft-pr --body without closing keyword emits stderr warning but exits 0", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-create-draft-pr-body-no-keyword-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-create-draft-pr-body-no-keyword-"));
 
   try {
     const { env, ghLogPath } = await writeGhStub(tempDir, [
@@ -112,7 +112,7 @@ test("create-draft-pr --body without closing keyword emits stderr warning but ex
 });
 
 test("create-draft-pr --body-file with closing keyword emits no stderr warning", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-create-draft-pr-bodyfile-keyword-ok-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-create-draft-pr-bodyfile-keyword-ok-"));
 
   try {
     const bodyPath = path.join(tempDir, "pr-body.md");
@@ -141,7 +141,7 @@ test("create-draft-pr --body-file with closing keyword emits no stderr warning",
 });
 
 test("create-draft-pr --body-file without closing keyword emits stderr warning but exits 0", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-create-draft-pr-bodyfile-no-keyword-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-create-draft-pr-bodyfile-no-keyword-"));
 
   try {
     const bodyPath = path.join(tempDir, "pr-body.md");
@@ -170,7 +170,7 @@ test("create-draft-pr --body-file without closing keyword emits stderr warning b
 });
 
 test("create-draft-pr --body-file with missing file emits stderr warning (non-fatal)", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-create-draft-pr-bodyfile-missing-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-create-draft-pr-bodyfile-missing-"));
 
   try {
     const { env, ghLogPath } = await writeGhStub(tempDir, [
@@ -266,7 +266,7 @@ test("create-draft-pr --help documents draft-only behavior and --ready rejection
 });
 
 test("create-draft-pr forwards args in order and preserves gh stdout on success", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-create-draft-pr-success-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-create-draft-pr-success-"));
 
   try {
     const { env, ghLogPath } = await writeGhStub(tempDir, [
@@ -308,7 +308,7 @@ test("create-draft-pr forwards args in order and preserves gh stdout on success"
 });
 
 test("create-draft-pr preserves an existing --draft without adding another copy", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-create-draft-pr-existing-draft-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-create-draft-pr-existing-draft-"));
 
   try {
     const { env, ghLogPath } = await writeGhStub(tempDir, [
@@ -335,7 +335,7 @@ test("create-draft-pr preserves an existing --draft without adding another copy"
 });
 
 test("create-draft-pr appends --draft after --draft=false so draft-first still wins", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-create-draft-pr-false-draft-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-create-draft-pr-false-draft-"));
 
   try {
     const { env, ghLogPath } = await writeGhStub(tempDir, [
@@ -358,7 +358,7 @@ test("create-draft-pr appends --draft after --draft=false so draft-first still w
 });
 
 test("create-draft-pr re-appends --draft when a later token disables it", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-create-draft-pr-reappend-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-create-draft-pr-reappend-"));
 
   try {
     const { env, ghLogPath } = await writeGhStub(tempDir, [
@@ -381,7 +381,7 @@ test("create-draft-pr re-appends --draft when a later token disables it", async 
 });
 
 test("create-draft-pr treats --draft=true as already supplied and avoids a duplicate", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-create-draft-pr-true-draft-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-create-draft-pr-true-draft-"));
 
   try {
     const { env, ghLogPath } = await writeGhStub(tempDir, [
@@ -404,7 +404,7 @@ test("create-draft-pr treats --draft=true as already supplied and avoids a dupli
 });
 
 test("create-draft-pr rejects --ready without invoking gh", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-create-draft-pr-ready-reject-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-create-draft-pr-ready-reject-"));
 
   try {
     const { env, counterPath, ghLogPath } = await writeGhStub(tempDir, []);
@@ -423,7 +423,7 @@ test("create-draft-pr rejects --ready without invoking gh", async () => {
 });
 
 test("create-draft-pr preserves gh stdout, stderr, and exit code on failure", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-create-draft-pr-gh-failure-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-create-draft-pr-gh-failure-"));
 
   try {
     const { env, ghLogPath } = await writeGhStub(tempDir, [

--- a/test/github/detect-checkpoint-evidence-stale-runner.test.mjs
+++ b/test/github/detect-checkpoint-evidence-stale-runner.test.mjs
@@ -69,7 +69,7 @@ async function writeGhStub(tempDir) {
 }
 
 test("detect-checkpoint-evidence fails closed when active runner is stale", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-ckpt-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-stale-runner-ckpt-"));
 
   try {
     await claimRunnerOwnership({
@@ -102,7 +102,7 @@ test("detect-checkpoint-evidence fails closed when active runner is stale", asyn
 });
 
 test("detect-checkpoint-evidence fails closed when active runner has an exit signal", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-ckpt-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-stale-runner-ckpt-"));
 
   try {
     await claimRunnerOwnership({
@@ -140,7 +140,7 @@ test("detect-checkpoint-evidence fails closed when active runner has an exit sig
 });
 
 test("detect-checkpoint-evidence includes staleRunner and staleRunnerCheck in successful output", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-ckpt-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-stale-runner-ckpt-"));
 
   try {
     const env = await writeGhStub(tempDir);

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -198,7 +198,7 @@ test("parseDetectCheckpointEvidenceCliArgs rejects malformed arguments determini
 });
 
 test("detect-checkpoint-evidence summarizes the newest valid live gate comments and passes pre-merge check", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-checkpoint-evidence-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-checkpoint-evidence-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -340,7 +340,7 @@ test("detect-checkpoint-evidence summarizes the newest valid live gate comments 
 });
 
 test("detect-checkpoint-evidence fails pre-merge check when only draft gate exists (no pre-approval)", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-checkpoint-evidence-pages-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-checkpoint-evidence-pages-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -401,7 +401,7 @@ test("detect-checkpoint-evidence fails pre-merge check when only draft gate exis
 });
 
 test("detect-checkpoint-evidence fails pre-merge check when only partial draft gate marker exists (no pre-approval)", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-checkpoint-evidence-marker-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-checkpoint-evidence-marker-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -453,7 +453,7 @@ test("detect-checkpoint-evidence fails pre-merge check when only partial draft g
 
 
 test("detect-checkpoint-evidence always fails before merge when gate comments are missing", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-gate-review-premerge-missing-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-gate-review-premerge-missing-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -493,7 +493,7 @@ test("detect-checkpoint-evidence always fails before merge when gate comments ar
 });
 
 test("detect-checkpoint-evidence always passes pre-merge check with clean draft and current-head pre-approval gate comments", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-gate-review-premerge-clean-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-gate-review-premerge-clean-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -553,7 +553,7 @@ test("detect-checkpoint-evidence always passes pre-merge check with clean draft 
 });
 
 test("detect-checkpoint-evidence fails pre-merge check when pre-approval gate is for a stale head SHA", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-gate-review-stale-head-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-gate-review-stale-head-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -617,7 +617,7 @@ test("detect-checkpoint-evidence fails pre-merge check when pre-approval gate is
 
 
 test("detect-checkpoint-evidence reports gh failures deterministically", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-checkpoint-evidence-fail-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-checkpoint-evidence-fail-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -649,7 +649,7 @@ test("detect-checkpoint-evidence reports gh failures deterministically", async (
 
 
 test("detect-checkpoint-evidence fails pre-merge with unresolved review threads via CLI", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-gate-review-unresolved-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-gate-review-unresolved-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -714,7 +714,7 @@ test("detect-checkpoint-evidence fails pre-merge with unresolved review threads 
 });
 
 test("detect-checkpoint-evidence fails pre-merge when graphql review-thread fetch fails via CLI", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-gate-review-graphql-fail-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-gate-review-graphql-fail-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -817,7 +817,7 @@ test("buildPreMergeGateCheck passes with zero unresolved threads", () => {
 
 
 test("detect-checkpoint-evidence fails closed when async run no longer owns the PR", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-checkpoint-evidence-ownership-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-checkpoint-evidence-ownership-"));
 
   try {
     await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-active", cwd: tempDir });
@@ -839,7 +839,7 @@ test("detect-checkpoint-evidence fails closed when async run no longer owns the 
 });
 
 test("detect-checkpoint-evidence does not fail closed when async run has no ownership record", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-checkpoint-evidence-ownership-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-checkpoint-evidence-ownership-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -881,7 +881,7 @@ test("detect-checkpoint-evidence does not fail closed when async run has no owne
 test("detect-checkpoint-evidence finds gate comment posted as PR review (root cause 3 fix)", async () => {
   // Root cause 3 fix: gate comments posted via the PR review API (escape-hatch path) must be
   // visible to the evidence checker to prevent duplicate reposts.
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-gate-review-from-pr-review-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-gate-review-from-pr-review-"));
 
   try {
     const prReviewGateComment = {

--- a/test/github/detect-linked-issue-pr.test.mjs
+++ b/test/github/detect-linked-issue-pr.test.mjs
@@ -61,7 +61,7 @@ function crossNode({ createdAt, number, state = "OPEN", repo = "owner/repo", url
 }
 
 test("detect-linked-issue-pr paginates and applies deterministic event-type priority", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-linked-pr-page-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-linked-pr-page-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -109,7 +109,7 @@ test("detect-linked-issue-pr paginates and applies deterministic event-type prio
 });
 
 test("detect-linked-issue-pr matches same-repo linked PRs case-insensitively", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-linked-pr-case-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-linked-pr-case-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -147,7 +147,7 @@ test("detect-linked-issue-pr matches same-repo linked PRs case-insensitively", a
 });
 
 test("detect-linked-issue-pr tests fail fast on unexpected extra gh calls", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-linked-pr-overcall-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-linked-pr-overcall-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -174,7 +174,7 @@ test("detect-linked-issue-pr tests fail fast on unexpected extra gh calls", asyn
 });
 
 test("detect-linked-issue-pr filters cross-repo/closed candidates and picks newest createdAt within event type", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-linked-pr-filter-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-linked-pr-filter-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -216,7 +216,7 @@ test("detect-linked-issue-pr filters cross-repo/closed candidates and picks newe
 });
 
 test("detect-linked-issue-pr returns no match when no open same-repo linked PR exists", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-linked-pr-none-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-linked-pr-none-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -254,7 +254,7 @@ test("detect-linked-issue-pr returns no match when no open same-repo linked PR e
 });
 
 test("detect-linked-issue-pr detects prior closed-unmerged same-repo PR when no open PR exists", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-linked-pr-closed-unmerged-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-linked-pr-closed-unmerged-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -291,7 +291,7 @@ test("detect-linked-issue-pr detects prior closed-unmerged same-repo PR when no 
 });
 
 test("detect-linked-issue-pr does not surface merged same-repo PR as prior closed-unmerged", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-linked-pr-merged-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-linked-pr-merged-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -328,7 +328,7 @@ test("detect-linked-issue-pr does not surface merged same-repo PR as prior close
 });
 
 test("detect-linked-issue-pr selects most recent closed-unmerged PR when multiple exist", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-linked-pr-multi-closed-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-linked-pr-multi-closed-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -358,7 +358,7 @@ test("detect-linked-issue-pr selects most recent closed-unmerged PR when multipl
 });
 
 test("detect-linked-issue-pr open PR takes precedence and closed-unmerged fields are absent", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-linked-pr-open-wins-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-linked-pr-open-wins-"));
 
   try {
     const env = await writeGhStub(tempDir, [

--- a/test/github/manage-sub-issues.test.mjs
+++ b/test/github/manage-sub-issues.test.mjs
@@ -302,7 +302,7 @@ test("computeVerifyResult with --ordered: verified:true when sets match and orde
 // ─── CLI integration tests ────────────────────────────────────────────────────
 
 test("manage-sub-issues list returns sub-issues from API", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-manage-sub-issues-list-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-manage-sub-issues-list-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -334,7 +334,7 @@ test("manage-sub-issues list returns sub-issues from API", async () => {
 });
 
 test("manage-sub-issues list drops entries with unsupported states", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-manage-sub-issues-bad-state-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-manage-sub-issues-bad-state-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -361,7 +361,7 @@ test("manage-sub-issues list drops entries with unsupported states", async () =>
 });
 
 test("manage-sub-issues list returns empty array when no sub-issues", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-manage-sub-issues-empty-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-manage-sub-issues-empty-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -383,7 +383,7 @@ test("manage-sub-issues list returns empty array when no sub-issues", async () =
 });
 
 test("manage-sub-issues add resolves child id and posts to sub_issues endpoint", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-manage-sub-issues-add-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-manage-sub-issues-add-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -422,7 +422,7 @@ test("manage-sub-issues add resolves child id and posts to sub_issues endpoint",
 });
 
 test("manage-sub-issues reorder sets execution order via sequential PATCH calls", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-manage-sub-issues-reorder-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-manage-sub-issues-reorder-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -493,7 +493,7 @@ test("manage-sub-issues reorder sets execution order via sequential PATCH calls"
 
 test("manage-sub-issues reorder fails when a specified issue is not a sub-issue", async () => {
   const tempDir = await mkdtemp(
-    path.join(os.tmpdir(), "pi-dev-loops-manage-sub-issues-reorder-fail-"),
+    path.join(os.tmpdir(), "dev-loops-manage-sub-issues-reorder-fail-"),
   );
 
   try {
@@ -523,7 +523,7 @@ test("manage-sub-issues reorder fails when a specified issue is not a sub-issue"
 
 test("manage-sub-issues verify returns verified:true when sub-issues match", async () => {
   const tempDir = await mkdtemp(
-    path.join(os.tmpdir(), "pi-dev-loops-manage-sub-issues-verify-ok-"),
+    path.join(os.tmpdir(), "dev-loops-manage-sub-issues-verify-ok-"),
   );
 
   try {
@@ -556,7 +556,7 @@ test("manage-sub-issues verify returns verified:true when sub-issues match", asy
 
 test("manage-sub-issues verify returns verified:false with missing and unexpected", async () => {
   const tempDir = await mkdtemp(
-    path.join(os.tmpdir(), "pi-dev-loops-manage-sub-issues-verify-fail-"),
+    path.join(os.tmpdir(), "dev-loops-manage-sub-issues-verify-fail-"),
   );
 
   try {
@@ -588,7 +588,7 @@ test("manage-sub-issues verify returns verified:false with missing and unexpecte
 
 test("manage-sub-issues verify --ordered detects order mismatch", async () => {
   const tempDir = await mkdtemp(
-    path.join(os.tmpdir(), "pi-dev-loops-manage-sub-issues-verify-order-"),
+    path.join(os.tmpdir(), "dev-loops-manage-sub-issues-verify-order-"),
   );
 
   try {
@@ -641,7 +641,7 @@ test("manage-sub-issues prints usage to stdout and exits 0 for --help", async ()
 
 test("manage-sub-issues add fails when gh returns an error", async () => {
   const tempDir = await mkdtemp(
-    path.join(os.tmpdir(), "pi-dev-loops-manage-sub-issues-add-fail-"),
+    path.join(os.tmpdir(), "dev-loops-manage-sub-issues-add-fail-"),
   );
 
   try {

--- a/test/github/probe-copilot-review.test.mjs
+++ b/test/github/probe-copilot-review.test.mjs
@@ -102,7 +102,7 @@ test("buildPollDelayMs schedules polls on the requested watch timeline", () => {
 });
 
 test("probe-copilot-review returns idle for a zero-timeout no-change check", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-idle-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-watch-copilot-idle-"));
   const baseline = createActivityPayload();
   try {
     const env = await writeGhStub(tempDir, [{ stdout: JSON.stringify(baseline) + "\n" }]);
@@ -114,7 +114,7 @@ test("probe-copilot-review returns idle for a zero-timeout no-change check", asy
 });
 
 test("probe-copilot-review returns timeout after bounded polling with no fresh Copilot activity", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-timeout-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-watch-copilot-timeout-"));
   try {
     const payload = createActivityPayload();
     const env = await writeGhStub(tempDir, [
@@ -130,7 +130,7 @@ test("probe-copilot-review returns timeout after bounded polling with no fresh C
 });
 
 test("probe-copilot-review rounds up attempt budget so non-divisible timeout still covers full window", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-round-up-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-watch-copilot-round-up-"));
   try {
     const payload = createActivityPayload();
     const env = await writeGhStub(tempDir, [
@@ -146,7 +146,7 @@ test("probe-copilot-review rounds up attempt budget so non-divisible timeout sti
 });
 
 test("probe-copilot-review returns changed for fresh Copilot review-thread comments", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-thread-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-watch-copilot-thread-"));
   const baseline = createActivityPayload({ threads: [createThread("c-1", "reviewer", "Please add a test.")] });
   const changed = createActivityPayload({
     threads: [
@@ -169,7 +169,7 @@ test("probe-copilot-review returns changed for fresh Copilot review-thread comme
 });
 
 test("probe-copilot-review returns changed for fresh Copilot review summaries", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-probe-copilot-review-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-probe-copilot-review-"));
   const baseline = createActivityPayload();
   const changed = createActivityPayload({
     reviews: [createReview("r-1", "copilot-pull-request-reviewer[bot]", "Automated Copilot summary.", "Bot")],
@@ -189,7 +189,7 @@ test("probe-copilot-review returns changed for fresh Copilot review summaries", 
 });
 
 test("probe-copilot-review returns changed for fresh Copilot issue comments", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-issue-comment-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-watch-copilot-issue-comment-"));
   const baseline = createActivityPayload();
   const changed = createActivityPayload({
     issueComments: [createIssueComment("i-1", "Copilot", "Fresh Copilot issue comment.", "Bot")],
@@ -209,7 +209,7 @@ test("probe-copilot-review returns changed for fresh Copilot issue comments", as
 });
 
 test("probe-copilot-review ignores fresh non-Copilot activity", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-ignore-non-copilot-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-watch-copilot-ignore-non-copilot-"));
   const baseline = createActivityPayload();
   const changed = createActivityPayload({
     threads: [createThread("c-1", "reviewer", "Please add a test."), createThread("c-2", "maintainer", "I will handle this comment.")],
@@ -230,7 +230,7 @@ test("probe-copilot-review ignores fresh non-Copilot activity", async () => {
 });
 
 test("probe-copilot-review ignores lookalike non-Copilot logins", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-copilot-lookalike-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-watch-copilot-lookalike-"));
   const baseline = createActivityPayload();
   const changed = createActivityPayload({
     threads: [createThread("c-1", "reviewer", "Please add a test."), createThread("c-2", "my-copilot-helper", "This should not count as Copilot.")],

--- a/test/github/ready-for-review.test.mjs
+++ b/test/github/ready-for-review.test.mjs
@@ -116,7 +116,7 @@ test("rejects --pr without value", async () => {
 });
 
 test("fails when PR is not in draft state", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-ready-not-draft-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-not-draft-"));
 
   try {
     const { env, ghLogPath } = await writeGhStub(tempDir, [
@@ -150,7 +150,7 @@ test("fails when PR is not in draft state", async () => {
 });
 
 test("fails when draft_gate evidence is missing (fail-closed)", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-ready-no-gate-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-no-gate-"));
 
   try {
     const { env, ghLogPath } = await writeGhStub(tempDir, [
@@ -185,7 +185,7 @@ test("fails when draft_gate evidence is missing (fail-closed)", async () => {
 });
 
 test("fails when CI is blocked", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-ready-ci-blocked-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-ci-blocked-"));
 
   try {
     const { env, ghLogPath } = await writeGhStub(tempDir, [
@@ -224,7 +224,7 @@ test("fails when CI is blocked", async () => {
 });
 
 test("succeeds when draft gate evidence exists and CI is green", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-ready-success-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-success-"));
 
   try {
     const { env, ghLogPath } = await writeGhStub(tempDir, [
@@ -290,7 +290,7 @@ test("succeeds when draft gate evidence exists and CI is green", async () => {
 });
 
 test.skip("--skip-gate-check allows transition without gate evidence", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-ready-skip-gate-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-skip-gate-"));
 
   try {
     const { env, ghLogPath } = await writeGhStub(tempDir, [
@@ -333,7 +333,7 @@ test.skip("--skip-gate-check allows transition without gate evidence", async () 
 });
 
 test("fails when draft_gate marker does not match current head SHA", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-ready-mismatch-head-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-mismatch-head-"));
 
   try {
     // PR head is a NEW commit pushed after the gate was run
@@ -391,7 +391,7 @@ test("fails when draft_gate marker does not match current head SHA", async () =>
 });
 
 test("succeeds when gate comment has abbreviated SHA matching full PR head SHA", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-ready-abbrev-sha-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-abbrev-sha-"));
 
   try {
     // GitHub reports full 40-char SHA; gate comment may record abbreviated 7+ char SHA

--- a/test/github/reconcile-draft-gate.test.mjs
+++ b/test/github/reconcile-draft-gate.test.mjs
@@ -85,7 +85,7 @@ test("reconcile-draft-gate --help describes the script as optional manual recove
 });
 
 test("reconcile-draft-gate fails closed when visible draft_gate evidence already exists", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reconcile-draft-gate-visible-evidence-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reconcile-draft-gate-visible-evidence-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -124,7 +124,7 @@ test("reconcile-draft-gate fails closed when visible draft_gate evidence already
 });
 
 test("reconcile-draft-gate blocks while CI is still pending", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reconcile-draft-gate-pending-ci-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reconcile-draft-gate-pending-ci-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -161,7 +161,7 @@ test("reconcile-draft-gate blocks while CI is still pending", async () => {
 });
 
 test("reconcile-draft-gate treats failing gh pr checks JSON output as blocked even on exit code 1", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reconcile-draft-gate-failing-ci-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reconcile-draft-gate-failing-ci-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -198,7 +198,7 @@ test("reconcile-draft-gate treats failing gh pr checks JSON output as blocked ev
 });
 
 test("reconcile-draft-gate surfaces gh pr checks stderr when exit code 1 has no JSON payload", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reconcile-draft-gate-failing-ci-no-json-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reconcile-draft-gate-failing-ci-no-json-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -233,7 +233,7 @@ test("reconcile-draft-gate surfaces gh pr checks stderr when exit code 1 has no 
 });
 
 test("reconcile-draft-gate blocks when no CI checks are reported", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reconcile-draft-gate-no-ci-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reconcile-draft-gate-no-ci-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -267,7 +267,7 @@ test("reconcile-draft-gate blocks when no CI checks are reported", async () => {
 });
 
 test("reconcile-draft-gate skips CI checks when config disables draft requireCi", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reconcile-draft-gate-config-skip-ci-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reconcile-draft-gate-config-skip-ci-"));
 
   try {
     await mkdir(path.join(tempDir, ".pi", "dev-loop"), { recursive: true });
@@ -364,7 +364,7 @@ test("reconcile-draft-gate skips CI checks when config disables draft requireCi"
 });
 
 test("reconcile-draft-gate skips the draft conversion mutation when the PR is already draft", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reconcile-draft-gate-already-draft-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reconcile-draft-gate-already-draft-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -451,7 +451,7 @@ test("reconcile-draft-gate skips the draft conversion mutation when the PR is al
 });
 
 test("reconcile-draft-gate does not mark ready when upsert throws and the PR was already draft", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reconcile-draft-gate-already-draft-upsert-failure-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reconcile-draft-gate-already-draft-upsert-failure-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -524,7 +524,7 @@ test("reconcile-draft-gate does not mark ready when upsert throws and the PR was
 });
 
 test("reconcile-draft-gate marks the PR ready again if gate-comment upsert throws after converting to draft", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reconcile-draft-gate-upsert-failure-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reconcile-draft-gate-upsert-failure-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -606,7 +606,7 @@ test("reconcile-draft-gate marks the PR ready again if gate-comment upsert throw
 });
 
 test("reconcile-draft-gate converts to draft, posts clean evidence, and marks ready when CI is green", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reconcile-draft-gate-success-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reconcile-draft-gate-success-"));
 
   try {
     const env = await writeGhStub(tempDir, [

--- a/test/github/reply-resolve-review-thread.test.mjs
+++ b/test/github/reply-resolve-review-thread.test.mjs
@@ -28,7 +28,7 @@ function createReviewThreadsPayload(threads) {
 const writeGhStub = (tempDir, entries) => writeGhStubHelper(tempDir, entries, { repeatLastOnOverflow: true, logCalls: true });
 
 test("reply-resolve-review-thread posts a reply then resolves the thread", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-thread-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-thread-"));
   const bodyFile = path.join(tempDir, "reply.md");
   await writeFile(bodyFile, "Fixed in 93cd7f8. Added the missing symlinked-ancestor guard and coverage.\n", "utf8");
 
@@ -86,7 +86,7 @@ test("reply-resolve-review-thread posts a reply then resolves the thread", async
 });
 
 test("reply-resolve-review-thread rejects thin replies without commit SHA or dismissal reason", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-thin-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-thin-"));
   const bodyFile = path.join(tempDir, "reply.md");
   await writeFile(bodyFile, "Acknowledged.\n", "utf8");
 
@@ -107,7 +107,7 @@ test("reply-resolve-review-thread rejects thin replies without commit SHA or dis
 });
 
 test("reply-resolve-review-thread rejects pure-numeric tokens that are not commit SHAs", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-numeric-sha-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-numeric-sha-"));
   const bodyFile = path.join(tempDir, "reply.md");
   // "1234567" matches the 7-40 hex-char regex but contains no hex letters; must not bypass the check
   await writeFile(bodyFile, "1234567\n", "utf8");
@@ -169,7 +169,7 @@ test("reply-resolve-review-thread rejects malformed arguments and empty body fil
   assert.equal(badRepoParsed.ok, false);
   assert.match(badRepoParsed.error, /repo|slug|owner/i);
 
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-empty-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-empty-"));
   const emptyBody = path.join(tempDir, "empty.md");
   await writeFile(emptyBody, "   \n", "utf8");
 
@@ -198,7 +198,7 @@ test("reply-resolve-review-thread rejects malformed arguments and empty body fil
 });
 
 test("reply-resolve-review-thread preserves leading whitespace in the reply body payload", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-whitespace-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-whitespace-"));
   const bodyFile = path.join(tempDir, "reply.md");
   await writeFile(bodyFile, "  indented line with enough text to pass resolution contract\n", "utf8");
 
@@ -241,7 +241,7 @@ test("reply-resolve-review-thread preserves leading whitespace in the reply body
 });
 
 test("reply-resolve-review-thread reports reply and resolve failures deterministically", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-failure-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-failure-"));
   const bodyFile = path.join(tempDir, "reply.md");
   await writeFile(bodyFile, "Resolved in 93cd7f8.\n", "utf8");
 
@@ -342,7 +342,7 @@ test("reply-resolve-review-thread reports reply and resolve failures determinist
 });
 
 test("reply-resolve-review-thread fails closed before mutating when comment and thread do not match", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-mismatch-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-mismatch-"));
   const bodyFile = path.join(tempDir, "reply.md");
   await writeFile(bodyFile, "Fixed in 93cd7f8.\n", "utf8");
 
@@ -391,7 +391,7 @@ test("reply-resolve-review-thread fails closed before mutating when comment and 
 });
 
 test("reply-resolve-review-thread fails closed before mutating when the target thread is missing", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-missing-thread-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-missing-thread-"));
   const bodyFile = path.join(tempDir, "reply.md");
   await writeFile(bodyFile, "Fixed in 93cd7f8.\n", "utf8");
 
@@ -431,7 +431,7 @@ test("reply-resolve-review-thread fails closed before mutating when the target t
 });
 
 test("reply-resolve-review-thread fails closed before mutating when the target comment is missing", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-missing-comment-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-missing-comment-"));
   const bodyFile = path.join(tempDir, "reply.md");
   await writeFile(bodyFile, "Fixed in 93cd7f8.\n", "utf8");
 
@@ -471,7 +471,7 @@ test("reply-resolve-review-thread fails closed before mutating when the target c
 });
 
 test("reply-resolve-review-thread fails closed before mutating when the validation snapshot is malformed", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-malformed-snapshot-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-malformed-snapshot-"));
   const bodyFile = path.join(tempDir, "reply.md");
   await writeFile(bodyFile, "Fixed in 93cd7f8.\n", "utf8");
 

--- a/test/github/reply-resolve-review-threads.test.mjs
+++ b/test/github/reply-resolve-review-threads.test.mjs
@@ -87,7 +87,7 @@ test("reply-resolve-review-threads rejects malformed arguments and conflicting o
 });
 
 test("reply-resolve-review-threads replies to matching unresolved threads without resolving by default", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-threads-reply-only-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-threads-reply-only-"));
 
   try {
     const gh = await writeGhStub(tempDir, [
@@ -188,7 +188,7 @@ test("reply-resolve-review-threads replies to matching unresolved threads withou
 });
 
 test("reply-resolve-review-threads resolves matched threads and verifies they stay resolved", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-threads-resolve-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-threads-resolve-"));
 
   try {
     const gh = await writeGhStub(tempDir, [
@@ -286,7 +286,7 @@ test("reply-resolve-review-threads resolves matched threads and verifies they st
 });
 
 test("reply-resolve-review-threads chooses the newest matching author-authored comment as the reply target", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-threads-newest-comment-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-threads-newest-comment-"));
 
   try {
     const gh = await writeGhStub(tempDir, [
@@ -325,7 +325,7 @@ test("reply-resolve-review-threads chooses the newest matching author-authored c
 });
 
 test("reply-resolve-review-threads returns deterministic success when nothing matches", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-threads-noop-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-threads-noop-"));
 
   try {
     const gh = await writeGhStub(tempDir, [
@@ -369,7 +369,7 @@ test("reply-resolve-review-threads returns deterministic success when nothing ma
 });
 
 test("reply-resolve-review-threads fails closed on malformed capture payloads", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-threads-bad-payload-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-threads-bad-payload-"));
 
   try {
     const gh = await writeGhStub(tempDir, [
@@ -395,7 +395,7 @@ test("reply-resolve-review-threads fails closed on malformed capture payloads", 
 });
 
 test("reply-resolve-review-threads stops on reply failure and reports partial progress", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-threads-partial-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-threads-partial-"));
 
   try {
     const gh = await writeGhStub(tempDir, [
@@ -459,7 +459,7 @@ test("reply-resolve-review-threads stops on reply failure and reports partial pr
 });
 
 test("reply-resolve-review-threads fails closed when post-resolve verification still finds targeted unresolved threads", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-threads-verify-fail-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-threads-verify-fail-"));
 
   try {
     const gh = await writeGhStub(tempDir, [
@@ -527,7 +527,7 @@ test("reply-resolve-review-threads fails closed when post-resolve verification s
 });
 
 test("reply-resolve-review-threads preserves leading whitespace and newlines from stdin", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-threads-stdin-whitespace-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-threads-stdin-whitespace-"));
 
   try {
     const gh = await writeGhStub(tempDir, [
@@ -560,7 +560,7 @@ test("reply-resolve-review-threads preserves leading whitespace and newlines fro
 });
 
 test("reply-resolve-review-threads preserves leading whitespace from --message", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reply-resolve-threads-message-whitespace-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-threads-message-whitespace-"));
 
   try {
     const gh = await writeGhStub(tempDir, [

--- a/test/github/request-copilot-review.test.mjs
+++ b/test/github/request-copilot-review.test.mjs
@@ -16,7 +16,7 @@ async function writeGhStub(tempDir, entries) {
 }
 
 test("request-copilot-review requests Copilot deterministically and verifies via requested_reviewers", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-review-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-review-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -59,7 +59,7 @@ test("request-copilot-review requests Copilot deterministically and verifies via
 });
 
 test("request-copilot-review recognizes Copilot under the requested reviewer login returned by GitHub", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-login-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-login-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -90,7 +90,7 @@ test("request-copilot-review recognizes Copilot under the requested reviewer log
 });
 
 test("request-copilot-review reports already-requested without mutating PR state again", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-already-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-already-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -121,7 +121,7 @@ test("request-copilot-review reports already-requested without mutating PR state
 });
 
 test("request-copilot-review suppresses same-head clean re-request by default", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-suppressed-same-head-clean-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-suppressed-same-head-clean-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -161,7 +161,7 @@ test("request-copilot-review suppresses same-head clean re-request by default", 
 
 
 test("request-copilot-review treats pending review as already-requested even when a submitted current-head review exists", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-pending-with-submitted-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-pending-with-submitted-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -193,7 +193,7 @@ test("request-copilot-review treats pending review as already-requested even whe
 });
 
 test("request-copilot-review treats a pending Copilot review as already-requested before mutating", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-pending-before-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-pending-before-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -225,7 +225,7 @@ test("request-copilot-review treats a pending Copilot review as already-requeste
 
 test("request-copilot-review accepts --force-rerequest-review as a valid flag", async () => {
   // With cap not reached (0 reviews, default cap 5): flag is a no-op; normal flow applies.
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-force-noop-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-force-noop-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -262,7 +262,7 @@ test("request-copilot-review accepts --force-rerequest-review as a valid flag", 
 });
 
 test("request-copilot-review accepts an immediate Copilot review as proof the request succeeded", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-immediate-review-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-immediate-review-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -305,7 +305,7 @@ test("request-copilot-review accepts an immediate Copilot review as proof the re
 });
 
 test("request-copilot-review normalizes known unrequestable/unavailable failures", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-unavailable-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-unavailable-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -357,7 +357,7 @@ test("request-copilot-review normalizes known unrequestable/unavailable failures
 });
 
 test("request-copilot-review returns already-requested when 422 but Copilot is in requested_reviewers", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-422-in-progress-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-422-in-progress-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -409,7 +409,7 @@ test("request-copilot-review returns already-requested when 422 but Copilot is i
 });
 
 test("request-copilot-review returns already-requested when 422 but Copilot has a pending review", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-422-pending-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-422-pending-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -452,7 +452,7 @@ test("request-copilot-review returns already-requested when 422 but Copilot has 
 });
 
 test("request-copilot-review does not treat a stale pending Copilot review as already-requested before mutating", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-stale-pending-before-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-stale-pending-before-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -495,7 +495,7 @@ test("request-copilot-review does not treat a stale pending Copilot review as al
 });
 
 test("request-copilot-review ignores a stale pending Copilot review after 422 and stays unavailable", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-stale-pending-422-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-stale-pending-422-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -545,7 +545,7 @@ test("request-copilot-review ignores a stale pending Copilot review after 422 an
 });
 
 test("request-copilot-review wraps invalid gh JSON deterministically", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-json-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-json-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -630,7 +630,7 @@ test("request-copilot-review --help prints usage and exits 0", async () => {
 });
 
 test("checkForCopilotComments blocks when @copilot comment found from non-Copilot author", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-blocked-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-blocked-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -651,7 +651,7 @@ test("checkForCopilotComments blocks when @copilot comment found from non-Copilo
 });
 
 test("checkForCopilotComments passes when no @copilot comments found", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-noblock-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-noblock-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -672,7 +672,7 @@ test("checkForCopilotComments passes when no @copilot comments found", async () 
 });
 
 test("checkForCopilotComments ignores @copilot in Copilot-authored comments", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-copilot-author-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-copilot-author-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -693,7 +693,7 @@ test("checkForCopilotComments ignores @copilot in Copilot-authored comments", as
 });
 
 test("checkForCopilotComments reports all violation comments when multiple found", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-multiviolation-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-multiviolation-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -714,7 +714,7 @@ test("checkForCopilotComments reports all violation comments when multiple found
 });
 
 test("request-copilot-review blocks request when PR is in draft state", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-draft-block-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-draft-block-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -746,7 +746,7 @@ test("request-copilot-review blocks request when PR is in draft state", async ()
 });
 
 test("request-copilot-review does not block request when PR is not draft", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-draft-ok-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-draft-ok-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -783,7 +783,7 @@ test("request-copilot-review does not block request when PR is not draft", async
 });
 
 test("request-copilot-review draft check takes precedence over round cap", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-draft-roundcap-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-draft-roundcap-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -809,7 +809,7 @@ test("request-copilot-review draft check takes precedence over round cap", async
 });
 
 test("request-copilot-review returns round_cap_reached when cap is exhausted without force flag", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-roundcap-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-roundcap-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -847,7 +847,7 @@ test("request-copilot-review returns round_cap_reached when cap is exhausted wit
 });
 
 test("request-copilot-review respects low-signal refinement config before auto re-requesting at round cap", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-roundcap-low-signal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-roundcap-low-signal-"));
 
   try {
     await writeFile(path.join(tempDir, ".devloops"), [
@@ -896,7 +896,7 @@ test("request-copilot-review respects low-signal refinement config before auto r
 });
 
 test("request-copilot-review automatically re-requests at round cap when new commits land after resolved comments", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-roundcap-auto-rerequest-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-roundcap-auto-rerequest-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -943,7 +943,7 @@ test("request-copilot-review automatically re-requests at round cap when new com
 });
 
 test("request-copilot-review --force-rerequest-review allows re-request when cap reached and new commits exist", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-force-newcommits-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-force-newcommits-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -987,7 +987,7 @@ test("request-copilot-review --force-rerequest-review allows re-request when cap
 });
 
 test("request-copilot-review --force-rerequest-review refuses when cap reached and no new commits", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-request-copilot-force-nochange-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-force-nochange-"));
 
   try {
     const env = await writeGhStub(tempDir, [

--- a/test/github/resolve-tracker-local-spec.test.mjs
+++ b/test/github/resolve-tracker-local-spec.test.mjs
@@ -54,7 +54,7 @@ test("parseResolveTrackerLocalSpecCliArgs rejects mixed issue-url and repo/issue
 });
 
 test("resolve-tracker-local-spec resolves repo and issue inputs through gh issue view", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-resolve-tracker-local-spec-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-resolve-tracker-local-spec-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -93,7 +93,7 @@ test("resolve-tracker-local-spec resolves repo and issue inputs through gh issue
 });
 
 test("resolve-tracker-local-spec accepts GitHub issue URLs as input", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-resolve-tracker-local-spec-url-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-resolve-tracker-local-spec-url-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -144,7 +144,7 @@ test("resolve-tracker-local-spec reports usage errors with usage payload", async
 
 
 test("resolve-tracker-local-spec normalizes repo slug in gh call and output", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-resolve-tracker-local-spec-normalize-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-resolve-tracker-local-spec-normalize-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -174,7 +174,7 @@ test("resolve-tracker-local-spec normalizes repo slug in gh call and output", as
   }
 });
 test("resolve-tracker-local-spec reports gh failures without usage for runtime errors", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-resolve-tracker-local-spec-ghfail-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-resolve-tracker-local-spec-ghfail-"));
 
   try {
     const env = await writeGhStub(tempDir, [

--- a/test/github/stage-reviewer-draft.test.mjs
+++ b/test/github/stage-reviewer-draft.test.mjs
@@ -15,7 +15,7 @@ const writeJson = writeJsonHelper;
 const writeGhStub = (tempDir, entries) => writeGhStubHelper(tempDir, entries, { logCalls: true });
 
 test("stage-reviewer-draft posts a deterministic pending review and writes local state", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stage-reviewer-draft-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-stage-reviewer-draft-"));
 
   try {
     const reviewFile = path.join(tempDir, "merged-review.json");
@@ -88,7 +88,7 @@ test("stage-reviewer-draft posts a deterministic pending review and writes local
 });
 
 test("stage-reviewer-draft merges into an existing local state file", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stage-reviewer-state-merge-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-stage-reviewer-state-merge-"));
 
   try {
     const reviewFile = path.join(tempDir, "merged-review.json");
@@ -140,7 +140,7 @@ test("stage-reviewer-draft merges into an existing local state file", async () =
 
 
 test("stage-reviewer-draft reports localStatePath as null when no output path is requested", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stage-reviewer-null-local-state-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-stage-reviewer-null-local-state-"));
 
   try {
     const reviewFile = path.join(tempDir, "merged-review.json");
@@ -183,7 +183,7 @@ test("stage-reviewer-draft rejects malformed arguments and missing headSha deter
     error: "Staging a reviewer draft requires --repo <owner/name>, --pr <number>, and --review-file <path>",
   });
 
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stage-reviewer-bad-review-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-stage-reviewer-bad-review-"));
   try {
     const reviewFile = path.join(tempDir, "merged-review.json");
     await writeJson(reviewFile, {
@@ -212,7 +212,7 @@ test("stage-reviewer-draft rejects malformed arguments and missing headSha deter
 });
 
 test("stage-reviewer-draft reports gh failures deterministically", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stage-reviewer-gh-fail-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-stage-reviewer-gh-fail-"));
 
   try {
     const reviewFile = path.join(tempDir, "merged-review.json");
@@ -253,7 +253,7 @@ test("stage-reviewer-draft reports gh failures deterministically", async () => {
 
 
 test("stage-reviewer-draft rejects malformed success payloads from gh deterministically", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stage-reviewer-bad-success-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-stage-reviewer-bad-success-"));
 
   try {
     const reviewFile = path.join(tempDir, "merged-review.json");

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -182,7 +182,7 @@ test("parseUpsertCheckpointVerdictCliArgs rejects --force-reason without --force
 });
 
 test("upsertCheckpointVerdict ignores force/forceReason in programmatic API", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-force-programmatic-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-force-programmatic-"));
   try {
     const env = await writeGhStub(tempDir, [
       ...buildGateCoordinationEntries({ isDraft: true, statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }] }),
@@ -243,7 +243,7 @@ test("summarizeCheckpointVerdictText keeps failing validation to a concise excer
       "ℹ fail 1",
       "✖ test/github/upsert-checkpoint-verdict.test.mjs",
       "AssertionError: Expected values to be strictly equal: 1 !== 2",
-      "at TestContext.<anonymous> (/tmp/workspace/mfittko/pi-dev-loops/test/github/upsert-checkpoint-verdict.test.mjs:42:10)",
+      "at TestContext.<anonymous> (/tmp/workspace/mfittko/dev-loops/test/github/upsert-checkpoint-verdict.test.mjs:42:10)",
     ].join("\n")),
     "commands: npm test; tests: 46, pass: 45, fail: 1; failure excerpt: test/github/upsert-checkpoint-verdict.test.mjs",
   );
@@ -301,7 +301,7 @@ test("summarizeCheckpointVerdictText does not treat markdown headings as shell c
 });
 
 test("upsert-checkpoint-verdict rejects --force on draft_gate create", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-force-draft-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-force-draft-"));
   try {
     const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234", "--verdict", "clean", "--findings-summary", "Tests pass", "--next-action", "Mark ready for review", "--force", "--force-reason", "CI cancelled due to infrastructure"]);
     assert.equal(result.code, 1);
@@ -313,7 +313,7 @@ test("upsert-checkpoint-verdict rejects --force on draft_gate create", async () 
 });
 
 test("upsert-checkpoint-verdict rejects --force on pre_approval_gate create", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-force-preapproval-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-force-preapproval-"));
   try {
     const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--gate", "pre_approval_gate", "--head-sha", "abc1234", "--verdict", "clean", "--findings-summary", "Tests pass.", "--findings-severity-counts", JSON.stringify({"must-fix":0,"worth-fixing-now":0}), "--next-action", "Approve and merge", "--force", "--force-reason", "CI cancelled due to infrastructure"]);
     assert.equal(result.code, 1);
@@ -330,7 +330,7 @@ test("upsert-checkpoint-verdict keeps CI-blocked gate upserts fail-closed", asyn
     { gate: "pre_approval_gate", isDraft: false, headSha: "abc1234", verdict: "findings_present", findingsSummary: "CI failed", nextAction: "Fix CI and re-run", findingsSeverityCounts: { "must-fix": 0, "worth-fixing-now": 1 } },
   ];
   for (const scenario of scenarios) {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), `pi-dev-loops-upsert-gate-review-fail-closed-${scenario.gate}-`));
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), `dev-loops-upsert-gate-review-fail-closed-${scenario.gate}-`));
     try {
       const env = await writeGhStub(tempDir, buildGateCoordinationEntries({
         isDraft: scenario.isDraft,
@@ -350,7 +350,7 @@ test("upsert-checkpoint-verdict keeps CI-blocked gate upserts fail-closed", asyn
   }
 });
 test("upsert-checkpoint-verdict --force rejected before update", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-force-update-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-force-update-"));
   try {
     const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234", "--verdict", "clean", "--findings-summary", "CI green", "--next-action", "merge", "--force", "--force-reason", "CI cancelled"]);
     assert.equal(result.code, 1);
@@ -362,7 +362,7 @@ test("upsert-checkpoint-verdict --force rejected before update", async () => {
 });
 
 test("upsert-checkpoint-verdict --force rejected before noop", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-force-noop-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-force-noop-"));
   try {
     const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234", "--verdict", "clean", "--findings-summary", "Tests pass", "--next-action", "merge", "--force", "--force-reason", "CI cancelled"]);
     assert.equal(result.code, 1);
@@ -374,7 +374,7 @@ test("upsert-checkpoint-verdict --force rejected before noop", async () => {
 });
 
 test("upsert-checkpoint-verdict rejects --force for non-CI pre_approval_gate refusal", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-force-non-ci-preapproval-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-force-non-ci-preapproval-"));
   try {
     const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--gate", "pre_approval_gate", "--head-sha", "abc1234", "--verdict", "findings_present", "--findings-summary", "Some issues", "--next-action", "Fix issues", "--force", "--force-reason", "forced"]);
     assert.equal(result.code, 1);
@@ -386,7 +386,7 @@ test("upsert-checkpoint-verdict rejects --force for non-CI pre_approval_gate ref
 });
 
 test("upsert-checkpoint-verdict rejects --force for draft_gate on non-draft PR", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-force-non-draft-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-force-non-draft-"));
   try {
     const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234", "--verdict", "findings_present", "--findings-summary", "Some issues", "--next-action", "Fix issues", "--force", "--force-reason", "forced"]);
     assert.equal(result.code, 1);
@@ -398,7 +398,7 @@ test("upsert-checkpoint-verdict rejects --force for draft_gate on non-draft PR",
 });
 
 test("upsert-checkpoint-verdict --force rejected before stale-head check", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-force-stale-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-force-stale-"));
   try {
     const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234", "--verdict", "clean", "--findings-summary", "n/a", "--next-action", "merge", "--force", "--force-reason", "forced"]);
     assert.equal(result.code, 1);
@@ -410,7 +410,7 @@ test("upsert-checkpoint-verdict --force rejected before stale-head check", async
 });
 
 test("upsert-checkpoint-verdict creates a new comment when no same-head marker exists", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-create-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-create-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -472,7 +472,7 @@ test("upsert-checkpoint-verdict creates a new comment when no same-head marker e
 });
 
 test("upsert-checkpoint-verdict embeds --findings-file content with preserved newlines", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-findings-file-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-findings-file-"));
 
   try {
     const findingsPath = path.join(tempDir, "findings.md");
@@ -536,7 +536,7 @@ test("upsert-checkpoint-verdict embeds --findings-file content with preserved ne
 });
 
 test("upsert-checkpoint-verdict --findings-file takes precedence over --findings-summary", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-findings-precedence-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-findings-precedence-"));
 
   try {
     const findingsPath = path.join(tempDir, "findings.md");
@@ -596,7 +596,7 @@ test("upsert-checkpoint-verdict --findings-file takes precedence over --findings
 });
 
 test("upsert-checkpoint-verdict omits Blocking severities line on clean verdict", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-clean-no-blocking-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-clean-no-blocking-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -649,7 +649,7 @@ test("upsert-checkpoint-verdict omits Blocking severities line on clean verdict"
 });
 
 test("upsert-checkpoint-verdict fails closed when pre-approval gate entry is still illegal", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-illegal-preapproval-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-illegal-preapproval-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -711,7 +711,7 @@ test("upsert-checkpoint-verdict fails closed when pre-approval gate entry is sti
   }
 
 test("upsert-checkpoint-verdict rejects pre_approval_gate when PR is still draft", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-draft-preapproval-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-draft-preapproval-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -761,7 +761,7 @@ test("upsert-checkpoint-verdict rejects pre_approval_gate when PR is still draft
 });
 
 test("upsert-checkpoint-verdict appends the round-cap fallback note to pre-approval evidence", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-round-cap-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-round-cap-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -853,7 +853,7 @@ test("upsert-checkpoint-verdict appends the round-cap fallback note to pre-appro
 });
 
 test("upsert-checkpoint-verdict truncates verbose findings summary before comment creation", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-verbose-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-verbose-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -940,7 +940,7 @@ test("upsert-checkpoint-verdict truncates verbose findings summary before commen
 });
 
 test("upsert-checkpoint-verdict suppresses duplicate repost when the current same-head comment already matches", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-noop-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-noop-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -1023,7 +1023,7 @@ test("upsert-checkpoint-verdict suppresses duplicate repost when the current sam
 });
 
 test("upsert-checkpoint-verdict noop still warns when a stale comment exists on a different head", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-noop-warn-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-noop-warn-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -1105,7 +1105,7 @@ test("upsert-checkpoint-verdict noop still warns when a stale comment exists on 
 });
 
 test("upsert-checkpoint-verdict updates an incomplete same-head marker in place", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-update-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-update-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -1180,7 +1180,7 @@ test("upsert-checkpoint-verdict updates an incomplete same-head marker in place"
 });
 
 test("upsert-checkpoint-verdict updates the current same-head marker even when another head has a newer marker", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-current-head-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-current-head-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -1271,7 +1271,7 @@ test("upsert-checkpoint-verdict updates the current same-head marker even when a
 });
 
 test("upsert-checkpoint-verdict prefers the latest same-head marker when it differs from the older strict summary", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-latest-marker-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-latest-marker-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -1361,7 +1361,7 @@ test("upsert-checkpoint-verdict prefers the latest same-head marker when it diff
 });
 
 test("upsert-checkpoint-verdict expands an abbreviated current-head SHA before matching same-head markers", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-short-head-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-short-head-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -1444,7 +1444,7 @@ test("upsert-checkpoint-verdict expands an abbreviated current-head SHA before m
 });
 
 test("upsert-checkpoint-verdict fails closed when the requested head SHA is stale", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-stale-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-stale-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -1489,7 +1489,7 @@ test("upsert-checkpoint-verdict fails closed when the requested head SHA is stal
 });
 
 test("upsert-checkpoint-verdict warns when a gate comment exists on a different head SHA", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-warn-stale-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-warn-stale-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -1560,7 +1560,7 @@ test("upsert-checkpoint-verdict warns when a gate comment exists on a different 
 });
 
 test("upsert-checkpoint-verdict fails closed when draft_gate is forbidden on a non-draft PR", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-draft-forbidden-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-draft-forbidden-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -1622,7 +1622,7 @@ test("upsert-checkpoint-verdict fails closed when draft_gate is forbidden on a n
 });
 
 test("upsert-checkpoint-verdict rejects clean verdict when unresolved blocking-severity findings remain", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-blocking-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-blocking-"));
 
   try {
     const env = await writeGhStub(tempDir, buildGateCoordinationEntries({
@@ -1654,7 +1654,7 @@ test("upsert-checkpoint-verdict rejects clean verdict when unresolved blocking-s
 });
 
 test("upsert-checkpoint-verdict allows clean verdict when no blocking-severity findings remain", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-clean-ok-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-clean-ok-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -1693,7 +1693,7 @@ test("upsert-checkpoint-verdict allows clean verdict when no blocking-severity f
 
 
 test("upsert-checkpoint-verdict rejects clean verdict when --findings-severity-counts is missing and blocking severities are configured", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-missing-counts-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-missing-counts-"));
 
   try {
     const env = await writeGhStub(tempDir, buildGateCoordinationEntries({
@@ -1725,7 +1725,7 @@ test("upsert-checkpoint-verdict rejects clean verdict when --findings-severity-c
 });
 
 test("upsert-checkpoint-verdict rejects clean verdict when --findings-severity-counts omits a blocking severity", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-missing-key-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-missing-key-"));
 
   try {
     const env = await writeGhStub(tempDir, buildGateCoordinationEntries({
@@ -1756,7 +1756,7 @@ test("upsert-checkpoint-verdict rejects clean verdict when --findings-severity-c
 });
 
 test("upsert-checkpoint-verdict rejects draft_gate when draftGateAlreadySatisfied is true", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-gate-review-already-satisfied-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-already-satisfied-"));
 
   try {
     // Simulate a non-draft PR with an existing clean draft_gate comment
@@ -1808,7 +1808,7 @@ test("upsert-checkpoint-verdict rejects draft_gate when draftGateAlreadySatisfie
 test("upsert-checkpoint-verdict skips Copilot convergence requirement for internal-only PRs", async () => {
   // Root cause 2 fix: when all changed files are internal tooling (scripts/docs/tests/config),
   // the Copilot review cycle is suppressed and pre_approval_gate may be posted directly.
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-internal-only-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-internal-only-"));
 
   try {
     const cleanDraftGateComment = buildGateComment({
@@ -1872,7 +1872,7 @@ test("upsert-checkpoint-verdict skips Copilot convergence requirement for intern
 test("upsert-checkpoint-verdict performs stale-runner takeover before gate coordination", async () => {
   // Root cause 1 fix: when a previous run owns the coordination file but is stale,
   // the new run takes over ownership rather than being rejected.
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-upsert-stale-takeover-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-stale-takeover-"));
 
   try {
     // Pre-claim ownership with an old timestamp so the runner is considered stale

--- a/test/github/verify-fresh-review-context.test.mjs
+++ b/test/github/verify-fresh-review-context.test.mjs
@@ -15,7 +15,7 @@ function runScript(args = [], opts = {}) {
 }
 
 test("verify-fresh-review-context exits 0 on first run (fresh context)", async () => {
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-verify-fresh-"));
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
   try {
     await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
     const result = runScript([], { cwd: tmpDir });
@@ -30,7 +30,7 @@ test("verify-fresh-review-context exits 0 on first run (fresh context)", async (
 });
 
 test("verify-fresh-review-context exits 1 when sentinel already exists", async () => {
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-verify-fresh-"));
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
   try {
     await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
     await writeFile(
@@ -56,7 +56,7 @@ test("verify-fresh-review-context --help prints usage and exits 0", async () => 
 });
 
 test("verify-fresh-review-context creates tmp dir if needed", async () => {
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-verify-fresh-"));
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
   try {
     const result = runScript([], { cwd: tmpDir });
     assert.equal(result.status, 0, result.stderr);
@@ -68,7 +68,7 @@ test("verify-fresh-review-context creates tmp dir if needed", async () => {
 });
 
 test("verify-fresh-review-context second run in same dir detects contamination", async () => {
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-verify-fresh-"));
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
   try {
     await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
     const r1 = runScript([], { cwd: tmpDir });
@@ -84,7 +84,7 @@ test("verify-fresh-review-context second run in same dir detects contamination",
 });
 
 test("verify-fresh-review-context --scope isolates parallel reviewers in same CWD", async () => {
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-verify-fresh-"));
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
   try {
     await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
 
@@ -101,7 +101,7 @@ test("verify-fresh-review-context --scope isolates parallel reviewers in same CW
 });
 
 test("verify-fresh-review-context --scope re-run with same scope detects contamination", async () => {
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-verify-fresh-"));
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
   try {
     await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
 
@@ -134,7 +134,7 @@ test("verify-fresh-review-context --scope rejects values with slashes", async ()
 
 test("verify-fresh-review-context --scope with missing value fails closed", async () => {
   // --scope followed by another flag or nothing
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-verify-fresh-"));
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
   try {
     await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
     const result = runScript(["--scope"], { cwd: tmpDir });

--- a/test/loop/conductor-integration.test.mjs
+++ b/test/loop/conductor-integration.test.mjs
@@ -18,7 +18,7 @@ const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, opt
  * Write a minimal .pi/dev-loop/settings.yaml and return cleanup helper.
  */
 async function setupConfigDir(requireRetrospective = false, extraSettings = {}) {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-config-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-config-"));
   const configDir = path.join(tempDir, ".pi", "dev-loop");
   await mkdir(configDir, { recursive: true });
 
@@ -282,7 +282,7 @@ test("runConductor degrades gracefully with monitor-only", async () => {
 // ---------------------------------------------------------------------------
 
 test("conductor --cycle-only CLI reports empty queue when no open PRs exist", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-cycle-only-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-cycle-only-"));
 
   try {
     const { env } = await writeGhStubHelper(tempDir, [{
@@ -307,7 +307,7 @@ test("conductor --cycle-only CLI reports empty queue when no open PRs exist", as
 });
 
 test("conductor --monitor-only CLI reports queue_complete when no open PRs exist", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-only-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-only-"));
 
   try {
     const { env } = await writeGhStubHelper(tempDir, [{
@@ -331,7 +331,7 @@ test("conductor --monitor-only CLI reports queue_complete when no open PRs exist
 
 test("conductor --require-retrospective CLI blocks when checkpoint is pending", async () => {
   const { repoRoot, cleanup } = await setupConfigDir(false);
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-require-retro-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-require-retro-"));
 
   try {
     const piDir = path.join(repoRoot, ".pi");
@@ -364,7 +364,7 @@ test("conductor --require-retrospective CLI blocks when checkpoint is pending", 
 });
 
 test("conductor CLI with both cycle and monitor uses repeat-last for sequential gh calls", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-both-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-both-"));
 
   try {
     const { env } = await writeGhStubHelper(tempDir, [{

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -192,7 +192,7 @@ async function runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asy
 }
 
 test("conductor-monitor reports queue_complete when no open PRs exist", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-empty-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-empty-"));
 
   try {
     const env = await writeGhStub(tempDir, [{
@@ -218,7 +218,7 @@ test("conductor-monitor reports queue_complete when no open PRs exist", async ()
 });
 
 test("conductor-monitor --auto-resume keeps queue_complete semantics when no open PRs exist", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-auto-resume-empty-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-auto-resume-empty-"));
 
   try {
     const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
@@ -248,7 +248,7 @@ test("conductor-monitor --auto-resume keeps queue_complete semantics when no ope
 });
 
 test("conductor-monitor reports gh runtime failures without a usage payload", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-gh-failure-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-gh-failure-"));
 
   try {
     const env = await writeGhStub(tempDir, [{
@@ -271,7 +271,7 @@ test("conductor-monitor reports gh runtime failures without a usage payload", as
 });
 
 test("conductor-monitor fails closed when gh pr list returns non-array JSON", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-invalid-list-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-invalid-list-"));
 
   try {
     const env = await writeGhStub(tempDir, [{
@@ -292,7 +292,7 @@ test("conductor-monitor fails closed when gh pr list returns non-array JSON", as
 });
 
 test("conductor-monitor reports monitoring when open PRs are still in healthy wait states", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-waiting-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-waiting-"));
 
   try {
     const env = await writeGhStub(tempDir, buildGhEntries({
@@ -326,7 +326,7 @@ test("conductor-monitor reports monitoring when open PRs are still in healthy wa
 });
 
 test("conductor-monitor --auto-resume ignores invalid async JSON side artifacts instead of crashing the scan", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-invalid-async-json-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-invalid-async-json-"));
 
   try {
     const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
@@ -350,7 +350,7 @@ test("conductor-monitor --auto-resume ignores invalid async JSON side artifacts 
 });
 
 test("conductor-monitor flags unresolved-feedback PRs as needing attention while preserving pending waits", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-attention-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-attention-"));
   const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");
 
   try {
@@ -401,7 +401,7 @@ test("conductor-monitor flags unresolved-feedback PRs as needing attention while
 });
 
 test("conductor-monitor --auto-resume ignores malformed session headers instead of crashing the scan", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-invalid-session-json-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-invalid-session-json-"));
 
   try {
     const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
@@ -432,7 +432,7 @@ test("conductor-monitor --auto-resume ignores malformed session headers instead 
 });
 
 test("conductor-monitor --auto-resume ignores parse-failed artifacts that do not match the live open PR set", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-nonopen-manual-ignore-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-nonopen-manual-ignore-"));
 
   try {
     const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
@@ -468,7 +468,7 @@ test("conductor-monitor --auto-resume ignores parse-failed artifacts that do not
 });
 
 test("conductor-monitor --auto-resume fails closed when an active matching run cannot be proven newer by timestamp", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-indeterminate-active-run-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-indeterminate-active-run-"));
 
   try {
     const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
@@ -509,7 +509,7 @@ test("conductor-monitor --auto-resume fails closed when an active matching run c
 });
 
 test("conductor-monitor --auto-resume preserves artifact run ids that contain underscores", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-underscore-run-id-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-underscore-run-id-"));
   const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");
 
   try {
@@ -540,7 +540,7 @@ test("conductor-monitor --auto-resume preserves artifact run ids that contain un
 });
 
 test("conductor-monitor --auto-resume fails closed when run exit state cannot be proven", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-unknown-run-state-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-unknown-run-state-"));
 
   try {
     const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
@@ -567,7 +567,7 @@ test("conductor-monitor --auto-resume fails closed when run exit state cannot be
 });
 
 test("conductor-monitor --auto-resume preserves the stronger failed run state when evidence conflicts", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-run-state-priority-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-run-state-priority-"));
   const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");
 
   try {
@@ -608,7 +608,7 @@ test("conductor-monitor --auto-resume preserves the stronger failed run state wh
 });
 
 test("conductor-monitor --auto-resume uses grouped result summaries as the artifactPath when no output artifact exists", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-grouped-summary-path-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-grouped-summary-path-"));
 
   try {
     const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
@@ -653,7 +653,7 @@ test("conductor-monitor --auto-resume uses grouped result summaries as the artif
 });
 
 test("conductor-monitor --auto-resume reuses grouped result summaries when acceptance reporting drops the output artifact", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-reporting-fallback-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-reporting-fallback-"));
 
   try {
     const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
@@ -721,7 +721,7 @@ test("conductor-monitor --auto-resume reuses grouped result summaries when accep
 });
 
 test("conductor-monitor --auto-resume falls back to deterministic output logs when grouped summaries are absent", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-output-log-fallback-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-output-log-fallback-"));
 
   try {
     const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
@@ -785,7 +785,7 @@ test("conductor-monitor --auto-resume falls back to deterministic output logs wh
 });
 
 test("conductor-monitor --auto-resume fails closed when an active matching run has the same timestamp as the exited candidate", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-same-timestamp-active-run-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-same-timestamp-active-run-"));
 
   try {
     const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
@@ -821,7 +821,7 @@ test("conductor-monitor --auto-resume fails closed when an active matching run h
 });
 
 test("conductor-monitor --auto-resume does not invent a failed run state from meta without an integer exitCode", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-invalid-meta-exitcode-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-invalid-meta-exitcode-"));
 
   try {
     const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
@@ -858,7 +858,7 @@ test("conductor-monitor --auto-resume does not invent a failed run state from me
 });
 
 test("conductor-monitor --auto-resume keeps stale-worktree runs resumable when JSON result evidence is the only surviving artifact", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-stale-worktree-result-json-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-stale-worktree-result-json-"));
 
   try {
     const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
@@ -906,7 +906,7 @@ test("conductor-monitor --auto-resume keeps stale-worktree runs resumable when J
 });
 
 test("conductor-monitor --auto-resume includes a non-zero child index in the resume preview even when only one child matches", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-nonzero-child-index-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-nonzero-child-index-"));
   const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");
 
   try {
@@ -938,7 +938,7 @@ test("conductor-monitor --auto-resume includes a non-zero child index in the res
 });
 
 test("conductor-monitor --auto-resume emits a feedback-fix resume plan for an orphaned unresolved-feedback PR", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-fix-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-orphan-fix-"));
   const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");
 
   try {
@@ -1009,7 +1009,7 @@ test("conductor-monitor --auto-resume emits a feedback-fix resume plan for an or
 });
 
 test("conductor-monitor --auto-resume fails closed when recorded handoff contract conflicts with resume action", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-handoff-mismatch-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-handoff-mismatch-"));
   const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");
 
   try {
@@ -1056,7 +1056,7 @@ test("conductor-monitor --auto-resume fails closed when recorded handoff contrac
 });
 
 test("conductor-monitor --auto-resume emits a final-approval resume plan for an orphaned approval-boundary PR", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-final-approval-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-orphan-final-approval-"));
 
   try {
     const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
@@ -1097,7 +1097,7 @@ test("conductor-monitor --auto-resume emits a final-approval resume plan for an 
 });
 
 test("conductor-monitor --auto-resume emits a merge-authorization resume plan for an orphaned merge-ready PR", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-merge-auth-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-orphan-merge-auth-"));
 
   try {
     const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
@@ -1137,7 +1137,7 @@ test("conductor-monitor --auto-resume emits a merge-authorization resume plan fo
 });
 
 test("conductor-monitor --auto-resume ignores an older completed run when a newer running run matches the same PR", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-suppressed-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-orphan-suppressed-"));
 
   try {
     const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
@@ -1177,7 +1177,7 @@ test("conductor-monitor --auto-resume ignores an older completed run when a newe
 });
 
 test("conductor-monitor --auto-resume fails closed when the output artifact is missing", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-missing-artifact-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-orphan-missing-artifact-"));
 
   try {
     const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
@@ -1219,7 +1219,7 @@ test("conductor-monitor --auto-resume fails closed when the output artifact is m
 });
 
 test("conductor-monitor --auto-resume fails closed on ambiguous PR identity inside one artifact", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-ambiguous-pr-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-orphan-ambiguous-pr-"));
 
   try {
     const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
@@ -1248,7 +1248,7 @@ test("conductor-monitor --auto-resume fails closed on ambiguous PR identity insi
 });
 
 test("conductor-monitor --auto-resume keeps a stale-worktree run resumable when artifact and session evidence are still present", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-stale-worktree-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-orphan-stale-worktree-"));
   const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");
 
   try {
@@ -1286,7 +1286,7 @@ test("conductor-monitor --auto-resume keeps a stale-worktree run resumable when 
 });
 
 test("conductor-monitor --auto-resume ignores non-dev-loop runs and runs from other repos", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-ignore-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-orphan-ignore-"));
 
   try {
     const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
@@ -1321,7 +1321,7 @@ test("conductor-monitor --auto-resume ignores non-dev-loop runs and runs from ot
 });
 
 test("conductor-monitor --auto-resume suppresses orphan alert for healthy PR (no unresolved threads, CI green) with fix/feedback artifact", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-healthy-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-orphan-healthy-"));
 
   try {
     const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
@@ -1362,7 +1362,7 @@ test("conductor-monitor --auto-resume suppresses orphan alert for healthy PR (no
 });
 
 test("conductor-monitor --auto-resume still flags orphan for unhealthy PR (unresolved threads present) with fix/feedback artifact", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-conductor-monitor-orphan-unhealthy-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-orphan-unhealthy-"));
   const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");
 
   try {

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -149,7 +149,7 @@ test("copilot-pr-handoff --repo auto-detected from git remote when omitted", asy
 });
 
 test("copilot-pr-handoff requests review and emits watch action for pr_ready_no_feedback", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-watch-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-watch-"));
 
   try {
     const { env } = await writeGhStubHelper(tempDir, [
@@ -229,7 +229,7 @@ test("copilot-pr-handoff requests review and emits watch action for pr_ready_no_
 // ---------------------------------------------------------------------------
 
 test("copilot-pr-handoff emits watch action when Copilot is already requested", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-already-requested-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-already-requested-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -270,7 +270,7 @@ test("copilot-pr-handoff emits watch action when Copilot is already requested", 
 });
 
 test("copilot-pr-handoff treats watch timeout with pending requested review as non-terminal", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-timeout-pending-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-timeout-pending-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -308,7 +308,7 @@ test("copilot-pr-handoff treats watch timeout with pending requested review as n
 });
 
 test("copilot-pr-handoff does not request review when checks have not materialized on the first-request path", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-no-checks-first-request-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-no-checks-first-request-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -351,7 +351,7 @@ test("copilot-pr-handoff does not request review when checks have not materializ
 });
 
 test("copilot-pr-handoff does not request review when statusCheckRollup is missing on the first-request path", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-missing-rollup-first-request-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-missing-rollup-first-request-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -393,7 +393,7 @@ test("copilot-pr-handoff does not request review when statusCheckRollup is missi
 });
 
 test("copilot-pr-handoff reports draft reset as ready-state reentry requirement", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-draft-reentry-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-draft-reentry-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -437,7 +437,7 @@ test("copilot-pr-handoff reports draft reset as ready-state reentry requirement"
 // ---------------------------------------------------------------------------
 
 test("copilot-pr-handoff emits stop action when Copilot review is unavailable", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-unavailable-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-unavailable-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -512,7 +512,7 @@ test("copilot-pr-handoff emits stop action when Copilot review is unavailable", 
 // ---------------------------------------------------------------------------
 
 test("copilot-pr-handoff emits watch action when 422 but Copilot is in requested_reviewers", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-422-in-progress-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-422-in-progress-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -584,7 +584,7 @@ test("copilot-pr-handoff emits watch action when 422 but Copilot is in requested
 });
 
 test("copilot-pr-handoff emits watch action when 422 but Copilot has a pending review in progress", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-422-pending-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-422-pending-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -656,7 +656,7 @@ test("copilot-pr-handoff emits watch action when 422 but Copilot has a pending r
 });
 
 test("copilot-pr-handoff treats stale pending Copilot review on an older commit plus no checks as waiting_for_ci", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-422-stale-pending-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-422-stale-pending-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -712,7 +712,7 @@ test("copilot-pr-handoff treats stale pending Copilot review on an older commit 
 });
 
 test("copilot-pr-handoff still re-requests review when a stale pending Copilot review exists on an older commit and CI is green", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-stale-pending-success-rerequest-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-stale-pending-success-rerequest-"));
 
   try {
     const ghPath = path.join(tempDir, "gh");
@@ -838,7 +838,7 @@ process.exit(97);
 });
 
 test("copilot-pr-handoff treats stale requested_reviewers as clean convergence after current-head review", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-current-head-review-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-current-head-review-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -899,7 +899,7 @@ test("copilot-pr-handoff treats stale requested_reviewers as clean convergence a
 });
 
 test("copilot-pr-handoff classifies watch timeout plus stale requested_reviewers as clean-converged", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-timeout-clean-converged-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-timeout-clean-converged-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -958,7 +958,7 @@ test("copilot-pr-handoff classifies watch timeout plus stale requested_reviewers
 });
 
 test("copilot-pr-handoff preserves copilotReviewPresent=false for an initial request with no prior review", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-initial-request-preserves-review-presence-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-initial-request-preserves-review-presence-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -1024,7 +1024,7 @@ test("copilot-pr-handoff preserves copilotReviewPresent=false for an initial req
 });
 
 test("copilot-pr-handoff auto re-requests when a newer head has no submitted Copilot review yet", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-reenabled-after-head-change-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-reenabled-after-head-change-"));
 
   try {
     const ghPath = path.join(tempDir, "gh");
@@ -1138,7 +1138,7 @@ process.exit(97);
 });
 
 test("copilot-pr-handoff rejects --force-rerequest-review as a removed policy flag (standalone)", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-force-rerequest-rejected-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-force-rerequest-rejected-"));
   try {
     const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--force-rerequest-review"]);
     assert.equal(result.code, 1);
@@ -1150,7 +1150,7 @@ test("copilot-pr-handoff rejects --force-rerequest-review as a removed policy fl
 });
 
 test("copilot-pr-handoff does not re-request review when checks have not materialized on the re-request path", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-no-checks-rerequest-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-no-checks-rerequest-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -1201,7 +1201,7 @@ test("copilot-pr-handoff does not re-request review when checks have not materia
 });
 
 test("copilot-pr-handoff keeps same-head suppression (no force flag)", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-no-force-rerequest-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-no-force-rerequest-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -1253,7 +1253,7 @@ test("copilot-pr-handoff keeps same-head suppression (no force flag)", async () 
 });
 
 test("copilot-pr-handoff re-requests at round cap when new commits land after resolved comments", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-round-cap-rerequest-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-round-cap-rerequest-"));
 
   try {
     const { env } = await writeGhStubHelper(tempDir, [
@@ -1399,7 +1399,7 @@ test("copilot-pr-handoff re-requests at round cap when new commits land after re
 // ---------------------------------------------------------------------------
 
 test("copilot-pr-handoff emits fix action when unresolved threads exist", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-fix-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-fix-"));
 
   const unresolvedThreads = JSON.stringify({
     data: {
@@ -1469,7 +1469,7 @@ test("copilot-pr-handoff emits fix action when unresolved threads exist", async 
 });
 
 test("copilot-pr-handoff classifies watch timeout with refreshed unresolved thread as unresolved feedback", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-timeout-unresolved-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-timeout-unresolved-"));
 
   const unresolvedThreads = JSON.stringify({
     data: {
@@ -1557,7 +1557,7 @@ test("copilot-pr-handoff classifies watch timeout with refreshed unresolved thre
 // ---------------------------------------------------------------------------
 
 test("copilot-pr-handoff emits stop action when no PR exists", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-no-pr-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-no-pr-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -1589,7 +1589,7 @@ test("copilot-pr-handoff emits stop action when no PR exists", async () => {
 // ---------------------------------------------------------------------------
 
 test("copilot-pr-handoff emits stop action for merged PR", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-merged-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-merged-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -1621,7 +1621,7 @@ test("copilot-pr-handoff emits stop action for merged PR", async () => {
 });
 
 test("copilot-pr-handoff classifies watch timeout with CI still pending as non-terminal pending", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-timeout-ci-pending-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-timeout-ci-pending-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -1681,7 +1681,7 @@ test("copilot-pr-handoff classifies watch timeout with CI still pending as non-t
 
 
 test("copilot-pr-handoff stops cleanly when another run already owns the PR", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-ownership-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-ownership-"));
 
   try {
     await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-active", cwd: tempDir });
@@ -1713,7 +1713,7 @@ test("copilot-pr-handoff stops cleanly when another run already owns the PR", as
 // ---------------------------------------------------------------------------
 
 test("detectRecentHumanComments detects human comment after last bot comment", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-detect-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-human-detect-"));
 
   try {
     const { detectRecentHumanComments } = await import("../../scripts/loop/copilot-pr-handoff.mjs");
@@ -1754,7 +1754,7 @@ test("detectRecentHumanComments detects human comment after last bot comment", a
 });
 
 test("detectRecentHumanComments does not pause when human comment is before bot", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-before-bot-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-human-before-bot-"));
 
   try {
     const { detectRecentHumanComments } = await import("../../scripts/loop/copilot-pr-handoff.mjs");
@@ -1791,7 +1791,7 @@ test("detectRecentHumanComments does not pause when human comment is before bot"
 });
 
 test("detectRecentHumanComments skips gate-pattern human comments", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-gate-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-human-gate-"));
 
   try {
     const { detectRecentHumanComments } = await import("../../scripts/loop/copilot-pr-handoff.mjs");
@@ -1828,7 +1828,7 @@ test("detectRecentHumanComments skips gate-pattern human comments", async () => 
 });
 
 test("detectRecentHumanComments skips Gate review: format gate comments", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-gate-format-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-human-gate-format-"));
 
   try {
     const { detectRecentHumanComments } = await import("../../scripts/loop/copilot-pr-handoff.mjs");
@@ -1865,7 +1865,7 @@ test("detectRecentHumanComments skips Gate review: format gate comments", async 
 });
 
 test("detectRecentHumanComments returns false when only bots commented", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-bots-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-human-bots-"));
 
   try {
     const { detectRecentHumanComments } = await import("../../scripts/loop/copilot-pr-handoff.mjs");
@@ -1902,7 +1902,7 @@ test("detectRecentHumanComments returns false when only bots commented", async (
 });
 
 test("detectRecentHumanComments returns false when no bot baseline exists", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-no-baseline-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-human-no-baseline-"));
 
   try {
     const { detectRecentHumanComments } = await import("../../scripts/loop/copilot-pr-handoff.mjs");
@@ -1933,7 +1933,7 @@ test("detectRecentHumanComments returns false when no bot baseline exists", asyn
 });
 
 test("detectRecentHumanComments detects multiple human comments after last bot", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-multi-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-human-multi-"));
 
   try {
     const { detectRecentHumanComments } = await import("../../scripts/loop/copilot-pr-handoff.mjs");
@@ -1979,7 +1979,7 @@ test("detectRecentHumanComments detects multiple human comments after last bot",
 });
 
 test("copilot-pr-handoff skips human comment check when PI_SUBAGENT_RUN_ID not set", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-skip-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-human-skip-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -2016,7 +2016,7 @@ test("copilot-pr-handoff skips human comment check when PI_SUBAGENT_RUN_ID not s
 
 
 test("copilot-pr-handoff runs human comment check when PI_SUBAGENT_RUN_ID is set", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-active-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-human-active-"));
 
   try {
     const HUMAN_COMMENT = JSON.stringify({
@@ -2076,7 +2076,7 @@ test("copilot-pr-handoff runs human comment check when PI_SUBAGENT_RUN_ID is set
 });
 
 test("copilot-pr-handoff stops when human comment check fails with non-zero exit", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-fetch-fail-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-human-fetch-fail-"));
 
   try {
     const BOT_COMMENT = JSON.stringify({
@@ -2151,7 +2151,7 @@ test("copilot-pr-handoff stops when human comment check fails with non-zero exit
 });
 
 test("copilot-pr-handoff stops when human comment check fails with invalid JSON", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-human-parse-fail-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-human-parse-fail-"));
 
   try {
     const { env } = await writeGhStubHelper(tempDir, [
@@ -2220,7 +2220,7 @@ test("copilot-pr-handoff stops when human comment check fails with invalid JSON"
 // ---------------------------------------------------------------------------
 
 test("copilot-pr-handoff skips Copilot request for internal-only PR and emits fix action for pre-approval gate", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-internal-"));
   try {
     // Use claims mode so the internal detection call can interleave with normal flow
     const { env: rawEnv } = await writeGhStubHelper(tempDir, [
@@ -2253,7 +2253,7 @@ test("copilot-pr-handoff skips Copilot request for internal-only PR and emits fi
 });
 
 test("copilot-pr-handoff does not skip Copilot for consumer-facing PR", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-not-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-not-internal-"));
   try {
     let env = await writeGhStub(tempDir, [
       // detect: pr view (autoDetectSnapshot first call)
@@ -2288,7 +2288,7 @@ test("copilot-pr-handoff does not skip Copilot for consumer-facing PR", async ()
 });
 
 test("copilot-pr-handoff skips internal detection when GH_SEQUENCE_PATH is set (stub mode)", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-handoff-stubmode-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-stubmode-"));
   try {
     let env = await writeGhStub(tempDir, [
       // detect: pr view (autoDetectSnapshot first call)

--- a/test/loop/detect-copilot-loop-state-auto-detect.test.mjs
+++ b/test/loop/detect-copilot-loop-state-auto-detect.test.mjs
@@ -16,7 +16,7 @@ import {
   writeJson,
 } from "./detect-copilot-loop-state-test-helpers.mjs";
 test("detect-copilot-loop-state auto-detect returns waiting_for_ci for open PR with no review when checks have not materialized", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-ready-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-ready-"));
 
   try {
     // Fixture has unresolved threads, but we use a clean threads response here
@@ -75,7 +75,7 @@ test("detect-copilot-loop-state auto-detect returns waiting_for_ci for open PR w
 
 
 test("detect-copilot-loop-state auto-detect returns unresolved_feedback_present when threads exist", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-unresolved-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-unresolved-"));
   const fixtureText = await readFile(fixturePath, "utf8");
 
   try {
@@ -118,7 +118,7 @@ test("detect-copilot-loop-state auto-detect returns unresolved_feedback_present 
 
 
 test("detect-copilot-loop-state auto-detect returns waiting_for_copilot_review when Copilot is requested", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-waiting-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-waiting-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -162,7 +162,7 @@ test("detect-copilot-loop-state auto-detect returns waiting_for_copilot_review w
 
 
 test("detect-copilot-loop-state auto-detect treats a pending Copilot review as in-progress evidence", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-pending-copilot-review-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-pending-copilot-review-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -209,7 +209,7 @@ test("detect-copilot-loop-state auto-detect treats a pending Copilot review as i
 });
 
 test("detect-copilot-loop-state fails closed from old-head green to new-head pending", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-old-green-new-pending-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-old-green-new-pending-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -269,7 +269,7 @@ test("detect-copilot-loop-state fails closed from old-head green to new-head pen
 });
 
 test("detect-copilot-loop-state fails closed from old-head green to new-head none", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-old-green-new-none-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-old-green-new-none-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -329,7 +329,7 @@ test("detect-copilot-loop-state fails closed from old-head green to new-head non
 });
 
 test.skip("detect-copilot-loop-state promotes zero-suite current-head CI to crediblyGreen when same-head local validation is supplied", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-credibly-green-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-credibly-green-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -401,7 +401,7 @@ test.skip("detect-copilot-loop-state promotes zero-suite current-head CI to cred
 });
 
 test.skip("detect-copilot-loop-state accepts case-insensitive local-validation SHA prefixes for crediblyGreen promotion", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-credibly-green-prefix-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-credibly-green-prefix-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -472,7 +472,7 @@ test.skip("detect-copilot-loop-state accepts case-insensitive local-validation S
 });
 
 test("detect-copilot-loop-state keeps zero-suite current-head CI at none under round cap", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-no-credibly-green-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-no-credibly-green-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -534,7 +534,7 @@ test("detect-copilot-loop-state keeps zero-suite current-head CI at none under r
 
 
 test("detect-copilot-loop-state re-opens round-cap clean PRs when new commits land after resolved comments", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-round-cap-rerequest-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-round-cap-rerequest-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -625,7 +625,7 @@ test("detect-copilot-loop-state re-opens round-cap clean PRs when new commits la
 });
 
 test.skip("detect-copilot-loop-state does not treat malformed zero-suite payloads as explicit empty arrays", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-malformed-zero-suite-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-malformed-zero-suite-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -712,7 +712,7 @@ test.skip("detect-copilot-loop-state keeps pending and failure current-head CI a
       expectedState: "blocked_needs_user_decision",
     },
   ]) {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), `pi-dev-loops-detect-credibly-green-${scenario.name}-`));
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), `dev-loops-detect-credibly-green-${scenario.name}-`));
 
     try {
       const emptyThreads = JSON.stringify({
@@ -784,7 +784,7 @@ test.skip("detect-copilot-loop-state keeps pending and failure current-head CI a
 });
 
 test("detect-copilot-loop-state auto-detect ignores stale pending Copilot reviews from older commits", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-stale-pending-copilot-review-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-stale-pending-copilot-review-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -843,7 +843,7 @@ test("detect-copilot-loop-state auto-detect ignores stale pending Copilot review
 });
 
 test("detect-copilot-loop-state refreshes current-head CI for a commented old-head review", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-commented-old-head-new-pending-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-commented-old-head-new-pending-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -902,7 +902,7 @@ test("detect-copilot-loop-state refreshes current-head CI for a commented old-he
 });
 
 test("detect-copilot-loop-state fails closed from old-head green to new-head success", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-old-green-new-success-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-old-green-new-success-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -961,7 +961,7 @@ test("detect-copilot-loop-state fails closed from old-head green to new-head suc
 });
 
 test("detect-copilot-loop-state fails closed from old-head green to new-head failure", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-old-green-new-failure-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-old-green-new-failure-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -1025,7 +1025,7 @@ test("detect-copilot-loop-state fails closed from old-head green to new-head fai
 // ---------------------------------------------------------------------------
 
 test("detect-copilot-loop-state uses head-scoped check-runs when commit status refresh is unavailable", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-head-check-runs-only-failure-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-head-check-runs-only-failure-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -1085,7 +1085,7 @@ test("detect-copilot-loop-state uses head-scoped check-runs when commit status r
 });
 
 test("detect-copilot-loop-state refreshes head-scoped CI probes in parallel for stale-success cases", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-head-refresh-parallel-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-head-refresh-parallel-"));
 
   try {
     const ghPath = path.join(tempDir, "gh");
@@ -1182,7 +1182,7 @@ process.exit(97);
 });
 
 test("detect-copilot-loop-state keeps cancelled check-runs from being masked by commit-status success", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-cancelled-plus-status-success-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-cancelled-plus-status-success-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -1240,7 +1240,7 @@ test("detect-copilot-loop-state keeps cancelled check-runs from being masked by 
 });
 
 test("detect-copilot-loop-state treats cancelled head-scoped check runs as none", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-head-cancelled-none-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-head-cancelled-none-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -1299,7 +1299,7 @@ test("detect-copilot-loop-state treats cancelled head-scoped check runs as none"
 });
 
 test("detect-copilot-loop-state treats mixed head-scoped failure-plus-pending checks as failure", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-old-green-new-failure-over-pending-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-old-green-new-failure-over-pending-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -1361,7 +1361,7 @@ test("detect-copilot-loop-state allows clean convergence when only stale request
   // requested_reviewers can briefly still list Copilot after a submitted
   // current-head review. With no pending current-head review, auto-detect should
   // treat that as settled rather than over-blocking forever.
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-review-on-head-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-review-on-head-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -1427,7 +1427,7 @@ test("detect-copilot-loop-state allows clean convergence when only stale request
 test("detect-copilot-loop-state keeps request active when timeline re-request is newer than submitted review", async () => {
   // A deliberate same-head re-request was made AFTER the existing submitted review.
   // The detector must keep the request active (not demote to stale).
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-fresh-rerequest-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-fresh-rerequest-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -1486,7 +1486,7 @@ test("detect-copilot-loop-state keeps request active when timeline re-request is
 });
 
 test.skip("detect-copilot-loop-state allows clean convergence once current-head request status is settled", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-review-on-head-settled-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-review-on-head-settled-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -1540,7 +1540,7 @@ test.skip("detect-copilot-loop-state allows clean convergence once current-head 
 });
 
 test("detect-copilot-loop-state does not false-block on hidden failed head check-run (#740)", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-740-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-740-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -1609,7 +1609,7 @@ test("detect-copilot-loop-state does not false-block on hidden failed head check
 });
 
 test("detect-copilot-loop-state downgrades visible success to none when hidden check-run is unsupported completed (#740)", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-740-unsupported-completed-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-740-unsupported-completed-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -1676,7 +1676,7 @@ test("detect-copilot-loop-state downgrades visible success to none when hidden c
 });
 
 test("detect-copilot-loop-state preserves success when multiple hidden checks fail (#740)", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-740-multi-hidden-failures-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-740-multi-hidden-failures-"));
 
   try {
     const emptyThreads = JSON.stringify({

--- a/test/loop/detect-copilot-loop-state-input-modes.test.mjs
+++ b/test/loop/detect-copilot-loop-state-input-modes.test.mjs
@@ -18,7 +18,7 @@ import {
   writeJson,
 } from "./detect-copilot-loop-state-test-helpers.mjs";
 test("detect-copilot-loop-state --input interprets a snapshot file and emits state JSON", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-input-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-input-"));
 
   try {
     const snapshotPath = path.join(tempDir, "snapshot.json");
@@ -48,7 +48,7 @@ test("detect-copilot-loop-state --input interprets a snapshot file and emits sta
 });
 
 test("detect-copilot-loop-state --input routes unresolved threads to unresolved_feedback_present", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-unresolved-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-unresolved-"));
 
   try {
     const snapshotPath = path.join(tempDir, "snapshot.json");
@@ -71,7 +71,7 @@ test("detect-copilot-loop-state --input routes unresolved threads to unresolved_
 });
 
 test("detect-copilot-loop-state --input routes unavailable status to review_request_unavailable", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-unavailable-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-unavailable-"));
 
   try {
     const snapshotPath = path.join(tempDir, "snapshot.json");
@@ -94,7 +94,7 @@ test("detect-copilot-loop-state --input routes unavailable status to review_requ
 });
 
 test("detect-copilot-loop-state --input routes already-fixed threads to already_fixed_needs_reply_resolve", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-fixed-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-fixed-"));
 
   try {
     const snapshotPath = path.join(tempDir, "snapshot.json");
@@ -119,7 +119,7 @@ test("detect-copilot-loop-state --input routes already-fixed threads to already_
 });
 
 test("detect-copilot-loop-state --input re-opens clean exhausted rounds to ready_to_rerequest_review when head changed", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-round-cap-clean-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-round-cap-clean-"));
 
   try {
     const snapshotPath = path.join(tempDir, "snapshot.json");
@@ -149,7 +149,7 @@ test("detect-copilot-loop-state --input re-opens clean exhausted rounds to ready
 });
 
 test("detect-copilot-loop-state --input fails closed to round_cap_clean_fallback when current-head review signal is omitted", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-round-cap-clean-missing-head-signal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-round-cap-clean-missing-head-signal-"));
 
   try {
     const snapshotPath = path.join(tempDir, "snapshot.json");
@@ -177,7 +177,7 @@ test("detect-copilot-loop-state --input fails closed to round_cap_clean_fallback
 });
 
 test("detect-copilot-loop-state --input keeps clean exhausted rounds on current head at round_cap_clean_fallback", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-round-cap-clean-current-head-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-round-cap-clean-current-head-"));
 
   try {
     const snapshotPath = path.join(tempDir, "snapshot.json");
@@ -206,7 +206,7 @@ test("detect-copilot-loop-state --input keeps clean exhausted rounds on current 
 });
 
 test("detect-copilot-loop-state --input routes blocked exhausted rounds to round_cap_reached", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-round-cap-blocked-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-round-cap-blocked-"));
 
   try {
     const snapshotPath = path.join(tempDir, "snapshot.json");
@@ -234,7 +234,7 @@ test("detect-copilot-loop-state --input routes blocked exhausted rounds to round
 });
 
 test("detect-copilot-loop-state --input routes failed review request to blocked_needs_user_decision", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-failed-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-failed-"));
 
   try {
     const snapshotPath = path.join(tempDir, "snapshot.json");
@@ -256,7 +256,7 @@ test("detect-copilot-loop-state --input routes failed review request to blocked_
 });
 
 test("detect-copilot-loop-state --input returns done for merged PR snapshot", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-done-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-done-"));
 
   try {
     const snapshotPath = path.join(tempDir, "snapshot.json");
@@ -281,7 +281,7 @@ test("detect-copilot-loop-state --input returns done for merged PR snapshot", as
 // ---------------------------------------------------------------------------
 
 test("detect-copilot-loop-state auto-detect accepts successful status-context rollup entries", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-status-context-success-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-status-context-success-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -325,7 +325,7 @@ test("detect-copilot-loop-state auto-detect accepts successful status-context ro
 });
 
 test("detect-copilot-loop-state auto-detect returns waiting_for_ci when statusCheckRollup is missing", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-missing-rollup-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-missing-rollup-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -368,7 +368,7 @@ test("detect-copilot-loop-state auto-detect returns waiting_for_ci when statusCh
 
 
 test("detect-copilot-loop-state auto-detect tracks completed Copilot review rounds in the snapshot", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-round-count-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-round-count-"));
 
   try {
     const { env } = await writeAutoDetectGhStub(tempDir, {
@@ -419,7 +419,7 @@ test("detect-copilot-loop-state auto-detect tracks completed Copilot review roun
 });
 
 test("autoDetectSnapshot uses the default ghCommand when deps omit it", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-auto-detect-default-deps-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-auto-detect-default-deps-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -463,7 +463,7 @@ test("autoDetectSnapshot uses the default ghCommand when deps omit it", async ()
 
 
 test("detect-copilot-loop-state auto-detect returns done for merged PR", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-merged-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-merged-"));
 
   try {
     const { env } = await writeGhStub(tempDir, [
@@ -491,7 +491,7 @@ test("detect-copilot-loop-state auto-detect returns done for merged PR", async (
 });
 
 test("detect-copilot-loop-state auto-detect returns no_pr when gh reports PR not found", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-auto-no-pr-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-auto-no-pr-"));
 
   try {
     const { env } = await writeGhStub(tempDir, [
@@ -515,7 +515,7 @@ test("detect-copilot-loop-state auto-detect returns no_pr when gh reports PR not
 });
 
 test.skip("detect-copilot-loop-state --review-request-status override injects status without re-probing", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-override-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-override-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -557,7 +557,7 @@ test.skip("detect-copilot-loop-state --review-request-status override injects st
 });
 
 test("detect-copilot-loop-state auto-detect detects CI pending status", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-ci-pending-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-ci-pending-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -601,7 +601,7 @@ test("detect-copilot-loop-state auto-detect detects CI pending status", async ()
 });
 
 test("detect-copilot-loop-state auto-detect prioritizes CI failure over pending checks", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-ci-failure-priority-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-ci-failure-priority-"));
 
   try {
     const emptyThreads = JSON.stringify({
@@ -645,7 +645,7 @@ test("detect-copilot-loop-state auto-detect prioritizes CI failure over pending 
 });
 
 test("detect-copilot-loop-state auto-detect fails when the gh stub is missing a scripted invocation", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-gh-budget-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-gh-budget-"));
 
   try {
     const { env } = await writeGhStub(tempDir, [
@@ -747,7 +747,7 @@ test("detect-copilot-loop-state --help prints usage and exits 0", async () => {
 });
 
 test("detect-copilot-loop-state reports gh failures deterministically", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-gh-failure-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-gh-failure-"));
 
   try {
     const { env } = await writeGhStub(tempDir, [
@@ -772,7 +772,7 @@ test("detect-copilot-loop-state reports gh failures deterministically", async ()
 });
 
 test("detect-copilot-loop-state fails closed when review threads cannot be fetched", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-thread-failure-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-thread-failure-"));
 
   try {
     const { env } = await writeGhStub(tempDir, [

--- a/test/loop/detect-copilot-session-activity.test.mjs
+++ b/test/loop/detect-copilot-session-activity.test.mjs
@@ -16,7 +16,7 @@ async function writeGhStub(tempDir, entries) {
 }
 
 test("detect-copilot-session-activity reports active when matching run is in progress", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-session-active-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-session-active-"));
 
   try {
     const env = await writeGhStub(tempDir, [{
@@ -45,7 +45,7 @@ test("detect-copilot-session-activity reports active when matching run is in pro
 });
 
 test("detect-copilot-session-activity prefers the newest matching run over older active runs", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-session-newest-wins-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-session-newest-wins-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -84,7 +84,7 @@ test("detect-copilot-session-activity prefers the newest matching run over older
 });
 
 test("detect-copilot-session-activity reports concluded when latest matching run completed", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-session-concluded-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-session-concluded-"));
 
   try {
     const env = await writeGhStub(tempDir, [{
@@ -119,7 +119,7 @@ test("detect-copilot-session-activity reports concluded when latest matching run
 });
 
 test("detect-copilot-session-activity treats approval-gated action_required runs as concluded", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-session-action-required-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-session-action-required-"));
 
   try {
     const env = await writeGhStub(tempDir, [{
@@ -148,7 +148,7 @@ test("detect-copilot-session-activity treats approval-gated action_required runs
 });
 
 test("detect-copilot-session-activity treats status=action_required as concluded even without a conclusion", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-session-status-action-required-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-session-status-action-required-"));
 
   try {
     const env = await writeGhStub(tempDir, [{
@@ -179,7 +179,7 @@ test("detect-copilot-session-activity treats status=action_required as concluded
 });
 
 test("detect-copilot-session-activity reports idle when no matching run names exist", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-session-idle-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-session-idle-"));
 
   try {
     const env = await writeGhStub(tempDir, [{
@@ -206,7 +206,7 @@ test("detect-copilot-session-activity reports idle when no matching run names ex
 });
 
 test("detect-copilot-session-activity reports idle when branch has no runs", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-session-empty-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-session-empty-"));
 
   try {
     const env = await writeGhStub(tempDir, [{

--- a/test/loop/detect-initial-copilot-pr-state.test.mjs
+++ b/test/loop/detect-initial-copilot-pr-state.test.mjs
@@ -118,7 +118,7 @@ function linkedPrClosedPayload({ closedPrNumber = 149, closedPrUrl = "https://gi
 }
 
 test("detect-initial-copilot-pr-state returns no_linked_pr when no linked PR exists", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-initial-pr-none-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-initial-pr-none-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -159,7 +159,7 @@ test("detect-initial-copilot-pr-state returns no_linked_pr when no linked PR exi
 });
 
 test("detect-initial-copilot-pr-state returns waiting_for_initial_copilot_implementation for bootstrap-only Copilot draft", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-initial-pr-bootstrap-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-initial-pr-bootstrap-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -188,7 +188,7 @@ test("detect-initial-copilot-pr-state returns waiting_for_initial_copilot_implem
 });
 
 test("detect-initial-copilot-pr-state returns waiting_for_initial_copilot_implementation for bootstrap-only copilot-swe-agent draft", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-initial-pr-bootstrap-swe-agent-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-initial-pr-bootstrap-swe-agent-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -217,7 +217,7 @@ test("detect-initial-copilot-pr-state returns waiting_for_initial_copilot_implem
 });
 
 test("detect-initial-copilot-pr-state returns linked_pr_ready_for_followup for substantive linked draft PR", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-initial-pr-substantive-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-initial-pr-substantive-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -234,7 +234,7 @@ test("detect-initial-copilot-pr-state returns linked_pr_ready_for_followup for s
         stdout: workflowRunsPayload([
           {
             databaseId: 91,
-            name: "Copilot coding for issue mfittko/pi-dev-loops#59",
+            name: "Copilot coding for issue mfittko/dev-loops#59",
             status: "completed",
             conclusion: "success",
             createdAt: "2026-05-21T12:00:00Z",
@@ -254,7 +254,7 @@ test("detect-initial-copilot-pr-state returns linked_pr_ready_for_followup for s
 });
 
 test("detect-initial-copilot-pr-state returns linked_pr_ready_for_followup when the linked PR has more than one commit", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-initial-pr-multi-commit-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-initial-pr-multi-commit-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -271,7 +271,7 @@ test("detect-initial-copilot-pr-state returns linked_pr_ready_for_followup when 
         stdout: workflowRunsPayload([
           {
             databaseId: 91,
-            name: "Copilot coding for issue mfittko/pi-dev-loops#59",
+            name: "Copilot coding for issue mfittko/dev-loops#59",
             status: "completed",
             conclusion: "success",
             createdAt: "2026-05-21T12:00:00Z",
@@ -291,7 +291,7 @@ test("detect-initial-copilot-pr-state returns linked_pr_ready_for_followup when 
 });
 
 test("detect-initial-copilot-pr-state returns linked_pr_ready_for_followup for a ready-for-review PR", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-initial-pr-ready-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-initial-pr-ready-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -316,7 +316,7 @@ test("detect-initial-copilot-pr-state returns linked_pr_ready_for_followup for a
 });
 
 test("detect-initial-copilot-pr-state returns linked_pr_ready_for_followup for non-Copilot draft PR", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-initial-pr-non-copilot-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-initial-pr-non-copilot-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -341,8 +341,8 @@ test("detect-initial-copilot-pr-state returns linked_pr_ready_for_followup for n
 });
 
 test("detect-initial-copilot-pr-state exits bootstrap wait state when implementation commits land", async () => {
-  const firstDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-initial-pr-transition-a-"));
-  const secondDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-initial-pr-transition-b-"));
+  const firstDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-initial-pr-transition-a-"));
+  const secondDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-initial-pr-transition-b-"));
 
   try {
     const firstEnv = await writeGhStub(firstDir, [
@@ -373,7 +373,7 @@ test("detect-initial-copilot-pr-state exits bootstrap wait state when implementa
         stdout: workflowRunsPayload([
           {
             databaseId: 91,
-            name: "Copilot coding for issue mfittko/pi-dev-loops#59",
+            name: "Copilot coding for issue mfittko/dev-loops#59",
             status: "completed",
             conclusion: "success",
             createdAt: "2026-05-21T12:00:00Z",
@@ -397,7 +397,7 @@ test("detect-initial-copilot-pr-state exits bootstrap wait state when implementa
 });
 
 test("detect-initial-copilot-pr-state falls back to substantive PR heuristics when session activity is idle", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-initial-pr-idle-substantive-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-initial-pr-idle-substantive-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -428,7 +428,7 @@ test("detect-initial-copilot-pr-state falls back to substantive PR heuristics wh
 });
 
 test("detect-initial-copilot-pr-state fails closed when the session-activity probe fails", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-initial-pr-session-failure-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-initial-pr-session-failure-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -460,7 +460,7 @@ test("detect-initial-copilot-pr-state fails closed when the session-activity pro
 });
 
 test("detect-initial-copilot-pr-state returns copilot_session_active while Copilot run is in progress", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-initial-pr-active-session-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-initial-pr-active-session-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -477,7 +477,7 @@ test("detect-initial-copilot-pr-state returns copilot_session_active while Copil
         stdout: workflowRunsPayload([
           {
             databaseId: 123,
-            name: "Addressing comment on PR mfittko/pi-dev-loops#79",
+            name: "Addressing comment on PR mfittko/dev-loops#79",
             status: "in_progress",
             conclusion: "",
             createdAt: "2026-05-21T12:00:00Z",
@@ -502,7 +502,7 @@ test("detect-initial-copilot-pr-state returns copilot_session_active while Copil
 });
 
 test("detect-initial-copilot-pr-state keeps bootstrap wait for approval-gated action_required runs", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-initial-pr-action-required-bootstrap-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-initial-pr-action-required-bootstrap-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -519,7 +519,7 @@ test("detect-initial-copilot-pr-state keeps bootstrap wait for approval-gated ac
         stdout: workflowRunsPayload([
           {
             databaseId: 555,
-            name: "Addressing comment on PR mfittko/pi-dev-loops#79",
+            name: "Addressing comment on PR mfittko/dev-loops#79",
             status: "in_progress",
             conclusion: "action_required",
             createdAt: "2026-05-21T12:00:00Z",
@@ -543,7 +543,7 @@ test("detect-initial-copilot-pr-state keeps bootstrap wait for approval-gated ac
 });
 
 test("detect-initial-copilot-pr-state returns prior_linked_pr_closed_unmerged when prior closed PR exists (regression: issue#130/PR#149 shape)", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-initial-pr-prior-closed-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-initial-pr-prior-closed-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -584,7 +584,7 @@ test("detect-initial-copilot-pr-state returns prior_linked_pr_closed_unmerged wh
 });
 
 test("detect-initial-copilot-pr-state returns no_linked_pr (not prior_linked_pr_closed_unmerged) when only merged PRs exist", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-initial-pr-merged-only-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-initial-pr-merged-only-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -607,7 +607,7 @@ test("detect-initial-copilot-pr-state returns no_linked_pr (not prior_linked_pr_
 test("detect-initial-copilot-pr-state returns prior_linked_pr_closed_unmerged state not a healthy wait seam", async () => {
   // Verifies the prior_linked_pr_closed_unmerged state is distinct from no_linked_pr
   // and carries the closed PR's number/url for caller reference.
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-initial-pr-prior-closed-distinct-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-initial-pr-prior-closed-distinct-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -650,7 +650,7 @@ test("detect-initial-copilot-pr-state rejects malformed arguments deterministica
 });
 
 test("detect-initial-copilot-pr-state fails closed when required PR facts are missing", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-initial-pr-missing-facts-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-initial-pr-missing-facts-"));
 
   try {
     const env = await writeGhStub(tempDir, [

--- a/test/loop/detect-internal-only-pr.test.mjs
+++ b/test/loop/detect-internal-only-pr.test.mjs
@@ -99,7 +99,7 @@ test("loadInternalPathPatterns returns shipped defaults when no config found", (
 });
 
 test("loadInternalPathPatterns loads flat array from --config path (settings.yaml)", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-internal-"));
   try {
     const configPath = path.join(tempDir, "settings.yaml");
     await writeFile(configPath, "internalPathPatterns:\n  - \"^src/\"\n  - \"^lib/\"\n");
@@ -111,7 +111,7 @@ test("loadInternalPathPatterns loads flat array from --config path (settings.yam
 });
 
 test("loadInternalPathPatterns falls back to defaults on invalid config", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-internal-"));
   try {
     const configPath = path.join(tempDir, "settings.yaml");
     await writeFile(configPath, "garbage: [[[");
@@ -123,7 +123,7 @@ test("loadInternalPathPatterns falls back to defaults on invalid config", async 
 });
 
 test("loadInternalPathPatterns falls back to defaults on empty patterns array", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-internal-"));
   try {
     const configPath = path.join(tempDir, "settings.yaml");
     await writeFile(configPath, "internalPathPatterns: []\n");
@@ -135,7 +135,7 @@ test("loadInternalPathPatterns falls back to defaults on empty patterns array", 
 });
 
 test("loadInternalPathPatterns falls back to defaults on whitespace-only patterns", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-internal-"));
   try {
     const configPath = path.join(tempDir, "settings.yaml");
     await writeFile(configPath, "internalPathPatterns:\n  - \"   \"\n  - \"\"\n");
@@ -147,7 +147,7 @@ test("loadInternalPathPatterns falls back to defaults on whitespace-only pattern
 });
 
 test("loadInternalPathPatterns skips missing internalPathPatterns key", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-internal-"));
   try {
     const configPath = path.join(tempDir, "settings.yaml");
     await writeFile(configPath, "gates:\n  draft:\n    requireCi: false\n");
@@ -163,7 +163,7 @@ test("loadInternalPathPatterns skips missing internalPathPatterns key", async ()
 // ---------------------------------------------------------------------------
 
 test("loadInternalPathPatterns auto-detects overrides.yaml via spawned process", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-internal-"));
   try {
     await mkdir(path.join(tempDir, ".git"));
     const piDir = path.join(tempDir, ".pi", "dev-loop");
@@ -186,7 +186,7 @@ test("loadInternalPathPatterns auto-detects overrides.yaml via spawned process",
 });
 
 test("loadInternalPathPatterns prefers settings.yaml over overrides.yaml via spawned process", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-internal-"));
   try {
     await mkdir(path.join(tempDir, ".git"));
     const piDir = path.join(tempDir, ".pi", "dev-loop");
@@ -214,7 +214,7 @@ test("loadInternalPathPatterns prefers settings.yaml over overrides.yaml via spa
 // ---------------------------------------------------------------------------
 
 test("tryLoadFromFile returns patterns from valid config", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-internal-"));
   try {
     const configPath = path.join(tempDir, "settings.yaml");
     await writeFile(configPath, "internalPathPatterns:\n  - \"^a/\"\n  - \"^b/\"\n");
@@ -226,7 +226,7 @@ test("tryLoadFromFile returns patterns from valid config", async () => {
 });
 
 test("tryLoadFromFile returns null for invalid YAML", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-internal-"));
   try {
     const configPath = path.join(tempDir, "invalid.yaml");
     await writeFile(configPath, "::: bad yaml");
@@ -237,7 +237,7 @@ test("tryLoadFromFile returns null for invalid YAML", async () => {
 });
 
 test("tryLoadFromFile returns null for empty patterns array", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-internal-"));
   try {
     const configPath = path.join(tempDir, "settings.yaml");
     await writeFile(configPath, "internalPathPatterns: []\n");
@@ -248,7 +248,7 @@ test("tryLoadFromFile returns null for empty patterns array", async () => {
 });
 
 test("tryLoadFromFile trims whitespace from patterns", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-internal-"));
   try {
     const configPath = path.join(tempDir, "settings.yaml");
     await writeFile(configPath, "internalPathPatterns:\n  - \"  ^src/  \"\n  - \"^lib/\"\n");
@@ -281,7 +281,7 @@ test("buildPatternMatchers skips invalid regex", () => {
 // ---------------------------------------------------------------------------
 
 test("detect-internal-only-pr returns internalOnly=true for scripts+test changes", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-internal-"));
   try {
     const env = await writeGhStub(tempDir, [
       {
@@ -302,7 +302,7 @@ test("detect-internal-only-pr returns internalOnly=true for scripts+test changes
 });
 
 test("detect-internal-only-pr returns internalOnly=false for consumer-facing changes", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-internal-"));
   try {
     const env = await writeGhStub(tempDir, [
       {
@@ -322,7 +322,7 @@ test("detect-internal-only-pr returns internalOnly=false for consumer-facing cha
 });
 
 test("detect-internal-only-pr returns internalOnly=false for mixed changes", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-internal-"));
   try {
     const env = await writeGhStub(tempDir, [
       {
@@ -341,7 +341,7 @@ test("detect-internal-only-pr returns internalOnly=false for mixed changes", asy
 });
 
 test("detect-internal-only-pr returns internalOnly=false for empty file list", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-internal-"));
   try {
     const env = await writeGhStub(tempDir, [
       {
@@ -361,7 +361,7 @@ test("detect-internal-only-pr returns internalOnly=false for empty file list", a
 });
 
 test("detect-internal-only-pr returns internalOnly=true for docs-only changes", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-internal-"));
   try {
     const env = await writeGhStub(tempDir, [
       {
@@ -380,7 +380,7 @@ test("detect-internal-only-pr returns internalOnly=true for docs-only changes", 
 });
 
 test("detect-internal-only-pr returns internalOnly=true for .pi config changes", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-internal-"));
   try {
     const env = await writeGhStub(tempDir, [
       {
@@ -399,7 +399,7 @@ test("detect-internal-only-pr returns internalOnly=true for .pi config changes",
 });
 
 test("detect-internal-only-pr detects non-matching unknown paths as consumer-facing", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-internal-"));
   try {
     const env = await writeGhStub(tempDir, [
       {
@@ -419,7 +419,7 @@ test("detect-internal-only-pr detects non-matching unknown paths as consumer-fac
 });
 
 test("detect-internal-only-pr respects --config with custom patterns (flat array)", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-internal-"));
   try {
     const configPath = path.join(tempDir, "settings.yaml");
     await writeFile(configPath, "internalPathPatterns:\n  - \"^custom/\"\n  - \"^tools/\"\n");
@@ -440,7 +440,7 @@ test("detect-internal-only-pr respects --config with custom patterns (flat array
 });
 
 test("detect-internal-only-pr with --config detects non-matching file as consumer-facing", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-detect-internal-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-internal-"));
   try {
     const configPath = path.join(tempDir, "settings.yaml");
     await writeFile(configPath, "internalPathPatterns:\n  - \"^custom/\"\n");

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -79,7 +79,7 @@ test("parseGitStatusConflictFiles parses NUL-delimited porcelain output with det
 });
 
 test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs with clean draft_gate on a different head (one-time boundary)", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-state-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pr-gate-state-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -203,7 +203,7 @@ test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs
 });
 
 test("detect-pr-gate-coordination-state flags draft_gate_needed for non-draft PRs with no draft_gate evidence", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-no-draft-evidence-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pr-gate-no-draft-evidence-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -254,7 +254,7 @@ test("detect-pr-gate-coordination-state flags draft_gate_needed for non-draft PR
 });
 
 test("detect-pr-gate-coordination-state flags draft_gate_needed for converged non-draft PRs with no draft_gate evidence", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-no-draft-evidence-converged-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pr-gate-no-draft-evidence-converged-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -327,7 +327,7 @@ test("detect-pr-gate-coordination-state flags draft_gate_needed for converged no
 
 
 test("detect-pr-gate-coordination-state flags draft_gate_needed when Copilot round cap is exhausted without draft_gate", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-round-cap-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pr-gate-round-cap-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -428,7 +428,7 @@ test("detect-pr-gate-coordination-state flags draft_gate_needed when Copilot rou
 });
 
 test("detect-pr-gate-coordination-state auto-detects local-fix-without-reply (#464) when unresolved threads exist on older review commit", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-464-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pr-gate-464-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -525,7 +525,7 @@ test("detect-pr-gate-coordination-state auto-detects local-fix-without-reply (#4
 });
 
 test("detectPrGateCoordinationState tolerates missing local git binary and falls back to GitHub-only facts", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-missing-git-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pr-gate-missing-git-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -577,7 +577,7 @@ test("detectPrGateCoordinationState tolerates missing local git binary and falls
 });
 
 test("detect-pr-gate-coordination-state preserves non-conflict mergeStateStatus values in helper output", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-merge-state-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pr-gate-merge-state-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -643,7 +643,7 @@ test("detect-pr-gate-coordination-state preserves non-conflict mergeStateStatus 
 });
 
 test("detect-pr-gate-coordination-state surfaces conflict_resolution for conflicted PRs and reports conflict files", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-conflict-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pr-gate-conflict-"));
 
   try {
     const ghEnv = await writeGhStub(tempDir, [
@@ -703,7 +703,7 @@ test("detect-pr-gate-coordination-state surfaces conflict_resolution for conflic
 });
 
 test.skip("detect-pr-gate-coordination-state with --review-mode internal_only skips Copilot review", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-local-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pr-gate-local-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -791,7 +791,7 @@ test.skip("detect-pr-gate-coordination-state with --review-mode internal_only sk
 
 
 test("pre-approval-gate-detector overrides to pre_approval_gate_needed when never entered", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-never-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pr-gate-never-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -865,7 +865,7 @@ test("pre-approval-gate-detector overrides to pre_approval_gate_needed when neve
 });
 
 test("detect-pr-gate-coordination-state blocks merge readiness when retrospective gate is enabled without approved retrospective", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-retro-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pr-gate-retro-"));
 
   try {
     await mkdir(path.join(tempDir, ".pi", "dev-loop"), { recursive: true });
@@ -961,7 +961,7 @@ test("detect-pr-gate-coordination-state blocks merge readiness when retrospectiv
 });
 
 test("detect-pr-gate-coordination-state fails closed when the PR head changes mid-read", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-head-drift-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pr-gate-head-drift-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -1117,7 +1117,7 @@ test("detect-pr-gate-coordination-state leaves refinement=present when linked is
 // ── draft gate round-count reset (#560) ──────────────────────────────────
 
 test("detect-pr-gate-coordination-state resets Copilot round count when draft_gate re-passed on different head", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-round-reset-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pr-gate-round-reset-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -1179,7 +1179,7 @@ test("detect-pr-gate-coordination-state resets Copilot round count when draft_ga
 });
 
 test("detect-pr-gate-coordination-state does NOT reset round count when draft_gate is on same head", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-pr-gate-same-head-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pr-gate-same-head-"));
 
   try {
     const env = await writeGhStub(tempDir, [

--- a/test/loop/detect-reviewer-loop-state.test.mjs
+++ b/test/loop/detect-reviewer-loop-state.test.mjs
@@ -15,7 +15,7 @@ const writeJson = writeJsonHelper;
 const writeGhStub = (tempDir, entries) => writeGhStubHelper(tempDir, entries, { overflowMessageMode: "generic" });
 
 test("detect-reviewer-loop-state --input returns correct states for planning/running/merge snapshots", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reviewer-state-detect-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reviewer-state-detect-"));
 
   try {
     const snapshotPath = path.join(tempDir, "snapshot.json");
@@ -53,7 +53,7 @@ test("detect-reviewer-loop-state --input returns correct states for planning/run
 });
 
 test("detect-reviewer-loop-state --input distinguishes draft lifecycle and invalidation", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reviewer-draft-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reviewer-draft-"));
 
   try {
     const snapshotPath = path.join(tempDir, "snapshot.json");
@@ -92,7 +92,7 @@ test("detect-reviewer-loop-state --input distinguishes draft lifecycle and inval
 });
 
 test("detect-reviewer-loop-state --input treats submitted review as handoff and re-request as new pass", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reviewer-rerequest-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reviewer-rerequest-"));
 
   try {
     const snapshotPath = path.join(tempDir, "snapshot.json");
@@ -134,7 +134,7 @@ test("detect-reviewer-loop-state --input treats submitted review as handoff and 
 });
 
 test.skip("detect-reviewer-loop-state auto-detect returns review_requested when reviewer is requested", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reviewer-auto-requested-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reviewer-auto-requested-"));
 
   try {
     const { env } = await writeGhStub(tempDir, [
@@ -178,7 +178,7 @@ test.skip("detect-reviewer-loop-state auto-detect returns review_requested when 
 });
 
 test.skip("detect-reviewer-loop-state auto-detect returns waiting_for_user_submit for current-head draft review", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reviewer-auto-draft-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reviewer-auto-draft-"));
 
   try {
     const localStatePath = path.join(tempDir, "local-state.json");
@@ -230,7 +230,7 @@ test.skip("detect-reviewer-loop-state auto-detect returns waiting_for_user_submi
 
 
 test.skip("detect-reviewer-loop-state auto-detect treats missing local state as empty metadata", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reviewer-auto-missing-local-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reviewer-auto-missing-local-"));
 
   try {
     const missingLocalStatePath = path.join(tempDir, "missing-state.json");
@@ -272,7 +272,7 @@ test.skip("detect-reviewer-loop-state auto-detect treats missing local state as 
 
 
 test.skip("detect-reviewer-loop-state auto-detect keeps fresh pending review ahead of historical submitted review", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reviewer-auto-rereview-draft-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reviewer-auto-rereview-draft-"));
 
   try {
     const localStatePath = path.join(tempDir, "local-state.json");
@@ -332,7 +332,7 @@ test.skip("detect-reviewer-loop-state auto-detect keeps fresh pending review ahe
 });
 
 test.skip("detect-reviewer-loop-state auto-detect marks stale draft as review_invalidated", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reviewer-auto-invalidated-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reviewer-auto-invalidated-"));
 
   try {
     const { env } = await writeGhStub(tempDir, [
@@ -364,7 +364,7 @@ test.skip("detect-reviewer-loop-state auto-detect marks stale draft as review_in
 });
 
 test("detect-reviewer-loop-state auto-detect fails when gh stub call budget is exceeded", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-reviewer-auto-budget-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reviewer-auto-budget-"));
 
   try {
     const { env } = await writeGhStub(tempDir, [

--- a/test/loop/detect-stale-runner.test.mjs
+++ b/test/loop/detect-stale-runner.test.mjs
@@ -29,7 +29,7 @@ test("resolveStaleRunnerMaxAgeMs prefers explicit option, then env, then default
 });
 
 test("detectStaleRunner returns no_owner_record when no coordination file exists", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-stale-runner-"));
 
   try {
     const result = await detectStaleRunner({ repo: "owner/repo", pr: 17, cwd: tempDir });
@@ -44,7 +44,7 @@ test("detectStaleRunner returns no_owner_record when no coordination file exists
 });
 
 test("detectStaleRunner returns fresh_runner when active run is recent", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-stale-runner-"));
 
   try {
     const claimed = await claimRunnerOwnership({
@@ -71,7 +71,7 @@ test("detectStaleRunner returns fresh_runner when active run is recent", async (
 });
 
 test("detectStaleRunner returns stale_runner when active run is older than max age", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-stale-runner-"));
 
   try {
     const claimed = await claimRunnerOwnership({
@@ -102,7 +102,7 @@ test("detectStaleRunner returns stale_runner when active run is older than max a
 });
 
 test("detectStaleRunner returns exit_signal_recorded when an exit signal exists for the active run", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-stale-runner-"));
 
   try {
     const claimed = await claimRunnerOwnership({
@@ -142,7 +142,7 @@ test("detectStaleRunner returns exit_signal_recorded when an exit signal exists 
 });
 
 test("detectStaleRunner ignores exit signals for non-active runs", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-stale-runner-"));
 
   try {
     // claim a non-owner exit signal that should be ignored (requireActiveOwner=false bypasses the
@@ -180,7 +180,7 @@ test("detectStaleRunner ignores exit signals for non-active runs", async () => {
 });
 
 test("recordExitSignalForRunner rejects when current run is not the active owner", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-stale-runner-"));
 
   try {
     await claimRunnerOwnership({
@@ -206,7 +206,7 @@ test("recordExitSignalForRunner rejects when current run is not the active owner
 });
 
 test("recordExitSignalForRunner allows non-owner recording when requireActiveOwner is false", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-stale-runner-"));
 
   try {
     await claimRunnerOwnership({
@@ -232,7 +232,7 @@ test("recordExitSignalForRunner allows non-owner recording when requireActiveOwn
 });
 
 test("recordExitSignalForRunner rejects when no coordination file exists", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-stale-runner-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-stale-runner-"));
 
   try {
     const result = await recordExitSignalForRunner({

--- a/test/loop/inspect-run-viewer-managed-instance.test.mjs
+++ b/test/loop/inspect-run-viewer-managed-instance.test.mjs
@@ -122,7 +122,7 @@ test('managed seam writes and reads the repo-local record on open/status', async
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-managed-'));
   const { manager, browserOpens, launches } = createManager();
 
-  const opened = await manager.open({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  const opened = await manager.open({ repoRoot, repo: 'mfittko/dev-loops' });
   assert.equal(opened.state, 'running');
   assert.equal(opened.startedFresh, true);
   assert.equal(opened.reusedExisting, false);
@@ -133,11 +133,11 @@ test('managed seam writes and reads the repo-local record on open/status', async
   const recordPath = path.join(repoRoot, INSPECT_RUN_VIEWER_MANAGED_RECORD_PATH);
   const record = JSON.parse(await readFile(recordPath, 'utf8'));
   assert.equal(record.surfaceId, 'inspect-run-viewer');
-  assert.equal(record.launchArgs.repo, 'mfittko/pi-dev-loops');
+  assert.equal(record.launchArgs.repo, 'mfittko/dev-loops');
   assert.equal(record.pid, launches[0].pid);
   assert.equal(record.cwd, repoRoot);
 
-  const status = await manager.status({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  const status = await manager.status({ repoRoot, repo: 'mfittko/dev-loops' });
   assert.equal(status.state, 'running');
   assert.equal(status.url, 'http://127.0.0.1:4311');
   assert.match(status.detail, /managed/i);
@@ -174,7 +174,7 @@ test('restart reclaims unmanaged listeners when no managed record exists', async
   listenersByPort.set(4311, [9001]);
   processes.set(9001, { alive: true, healthy: true, port: 4311, url: 'http://127.0.0.1:4311' });
 
-  const restarted = await manager.restart({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  const restarted = await manager.restart({ repoRoot, repo: 'mfittko/dev-loops' });
   assert.equal(restarted.state, 'running');
   assert.match(restarted.detail, /restarted the managed inspect-run viewer/i);
   assert.deepEqual(stopped, [9001]);
@@ -185,8 +185,8 @@ test('open reuses a matching live managed instance instead of relaunching', asyn
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-reuse-'));
   const { manager, launches, browserOpens } = createManager();
 
-  await manager.open({ repoRoot, repo: 'mfittko/pi-dev-loops' });
-  const reopened = await manager.open({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  await manager.open({ repoRoot, repo: 'mfittko/dev-loops' });
+  const reopened = await manager.open({ repoRoot, repo: 'mfittko/dev-loops' });
 
   assert.equal(reopened.state, 'running');
   assert.equal(reopened.reusedExisting, true);
@@ -199,7 +199,7 @@ test('open keeps the managed record when a running viewer ignores SIGTERM during
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-open-running-stubborn-'));
   const { manager, launches, stopCalls, currentPid } = createStubbornManagedProcessManager();
 
-  await manager.open({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  await manager.open({ repoRoot, repo: 'mfittko/dev-loops' });
   const result = await manager.open({ repoRoot, repo: 'other/repo' });
 
   assert.equal(result.state, 'stale_record');
@@ -215,7 +215,7 @@ test('resume fails closed and does not auto-start when nothing live is managed',
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-resume-'));
   const { manager, launches, browserOpens } = createManager();
 
-  const resumed = await manager.resume({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  const resumed = await manager.resume({ repoRoot, repo: 'mfittko/dev-loops' });
   assert.equal(resumed.state, 'stopped');
   assert.equal(resumed.resumedExisting, false);
   assert.equal(resumed.url, null);
@@ -242,8 +242,8 @@ test('restart keeps the managed record when a running viewer ignores SIGTERM', a
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-restart-running-stubborn-'));
   const { manager, launches, stopCalls, currentPid } = createStubbornManagedProcessManager();
 
-  await manager.open({ repoRoot, repo: 'mfittko/pi-dev-loops' });
-  const result = await manager.restart({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  await manager.open({ repoRoot, repo: 'mfittko/dev-loops' });
+  const result = await manager.restart({ repoRoot, repo: 'mfittko/dev-loops' });
 
   assert.equal(result.state, 'stale_record');
   assert.match(result.detail, /keeping the managed record instead of restarting it/i);
@@ -258,14 +258,14 @@ test('restart reclaims an unmanaged listener conflict before relaunching', async
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-restart-'));
   const { manager, listenersByPort, processes, stopped, launches } = createManager();
 
-  await manager.open({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  await manager.open({ repoRoot, repo: 'mfittko/dev-loops' });
   const managedPid = launches[0].pid;
   processes.get(managedPid).alive = false;
   processes.get(managedPid).healthy = false;
   listenersByPort.set(4311, [9111]);
   processes.set(9111, { alive: true, healthy: true, port: 4311, url: 'http://127.0.0.1:4311' });
 
-  const restarted = await manager.restart({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  const restarted = await manager.restart({ repoRoot, repo: 'mfittko/dev-loops' });
   assert.equal(restarted.state, 'running');
   assert.match(restarted.detail, /restarted the managed inspect-run viewer/i);
   assert.deepEqual(stopped, [9111]);
@@ -345,7 +345,7 @@ test('stop fails closed with explicit guidance when --repo does not match the ma
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'inspect-run-viewer-stop-mismatch-'));
   const { manager, launches, stopped } = createManager();
 
-  await manager.open({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  await manager.open({ repoRoot, repo: 'mfittko/dev-loops' });
   const result = await manager.stop({ repoRoot, repo: 'other/repo' });
 
   assert.equal(result.state, 'stopped');
@@ -483,7 +483,7 @@ test('open tolerates ESRCH while replacing a managed instance', async () => {
     async openBrowserImpl() {},
   });
 
-  await manager.open({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  await manager.open({ repoRoot, repo: 'mfittko/dev-loops' });
   const reopened = await manager.open({ repoRoot, repo: 'other/repo' });
   assert.equal(reopened.state, 'running');
   assert.deepEqual(stopCalls, [5000]);
@@ -528,12 +528,12 @@ test('stop and restart treat ESRCH as already-stopped', async () => {
     async openBrowserImpl() {},
   });
 
-  await manager.open({ repoRoot, repo: 'mfittko/pi-dev-loops' });
-  const stopped = await manager.stop({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  await manager.open({ repoRoot, repo: 'mfittko/dev-loops' });
+  const stopped = await manager.stop({ repoRoot, repo: 'mfittko/dev-loops' });
   assert.equal(stopped.state, 'stopped');
 
-  await manager.open({ repoRoot, repo: 'mfittko/pi-dev-loops' });
-  const restarted = await manager.restart({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  await manager.open({ repoRoot, repo: 'mfittko/dev-loops' });
+  const restarted = await manager.restart({ repoRoot, repo: 'mfittko/dev-loops' });
   assert.equal(restarted.state, 'running');
   assert.equal(stopCalls, 2);
 });
@@ -544,7 +544,7 @@ test('status returns the raw conflict URL instead of appending a scoped query to
   listenersByPort.set(4311, [9444]);
   processes.set(9444, { alive: true, healthy: true, port: 4311, url: 'http://127.0.0.1:4311' });
 
-  const status = await manager.status({ repoRoot, repo: 'mfittko/pi-dev-loops' });
+  const status = await manager.status({ repoRoot, repo: 'mfittko/dev-loops' });
   assert.equal(status.state, 'conflict_unmanaged_listener');
   assert.equal(status.url, 'http://127.0.0.1:4311');
 });

--- a/test/loop/pr-runner-coordination.test.mjs
+++ b/test/loop/pr-runner-coordination.test.mjs
@@ -15,7 +15,7 @@ import {
 import { runPrRunnerCoordination } from "../../scripts/loop/pr-runner-coordination.mjs";
 
 test("runner coordination claims empty PR ownership and refreshes same run", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-runner-coordination-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-"));
 
   try {
     const claimed = await claimRunnerOwnership({
@@ -49,7 +49,7 @@ test("runner coordination claims empty PR ownership and refreshes same run", asy
 });
 
 test("runner coordination fails closed for second claim and allows explicit takeover", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-runner-coordination-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-"));
 
   try {
     await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-1", cwd: tempDir, now: "2026-06-05T08:00:00.000Z" });
@@ -82,7 +82,7 @@ test("runner coordination fails closed for second claim and allows explicit take
 });
 
 test("runner coordination pre-merge assert requires existing owner record for async runs", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-runner-coordination-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-"));
 
   try {
     const missing = await assertRunnerOwnership({
@@ -111,7 +111,7 @@ test("runner coordination pre-merge assert requires existing owner record for as
 });
 
 test("runner coordination release clears active owner", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-runner-coordination-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-"));
 
   try {
     await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-1", cwd: tempDir });
@@ -127,7 +127,7 @@ test("runner coordination release clears active owner", async () => {
 });
 
 test("pr-runner-coordination CLI facade returns machine-readable conflicts", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-runner-coordination-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-"));
 
   try {
     const filePath = defaultRunnerCoordinationFilePathForTarget({ repo: "owner/repo", pr: 17 }, tempDir);
@@ -148,7 +148,7 @@ test("pr-runner-coordination CLI facade returns machine-readable conflicts", asy
 
 
 test("ensureAsyncRunnerOwnership auto-claims when no file exists", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-runner-coordination-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-"));
 
   try {
     const result = await ensureAsyncRunnerOwnership({
@@ -167,7 +167,7 @@ test("ensureAsyncRunnerOwnership auto-claims when no file exists", async () => {
 });
 
 test("ensureAsyncRunnerOwnership auto-claims after release when no active owner remains", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-runner-coordination-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-"));
 
   try {
     await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-1", cwd: tempDir });

--- a/test/loop/refine-verify.test.mjs
+++ b/test/loop/refine-verify.test.mjs
@@ -168,7 +168,7 @@ test("runTreeIntegrityValidator detects orphans, cycles, and depth violations", 
 });
 
 test("verify script returns exit 0 and checker payload in offline JSON mode", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-refine-verify-pass-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-refine-verify-pass-"));
   try {
     const inputPath = await writeFixture(tempDir, "tree.json", buildPassingTreePayload());
     const result = await runVerify(["--input", inputPath, "--json"]);
@@ -185,7 +185,7 @@ test("verify script returns exit 0 and checker payload in offline JSON mode", as
 });
 
 test("verify script returns human-readable failures and exit 1", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-refine-verify-fail-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-refine-verify-fail-"));
   try {
     const failingTree = buildPassingTreePayload();
     failingTree.issues[2].body = `${failingTree.issues[2].body}\nParent: #1`;
@@ -202,7 +202,7 @@ test("verify script returns human-readable failures and exit 1", async () => {
 });
 
 test("dev-loops refine verify routes through CLI", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-cli-refine-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-cli-refine-"));
   try {
     const inputPath = await writeFixture(tempDir, "tree.json", buildPassingTreePayload());
     const result = await runCli(["refine", "verify", "--input", inputPath, "--json"]);
@@ -215,7 +215,7 @@ test("dev-loops refine verify routes through CLI", async () => {
 });
 
 test("verify script online mode fetches tree via GitHub API", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-refine-verify-online-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-refine-verify-online-"));
   try {
     const { env } = await writeGhStub(tempDir, [
       {

--- a/test/loop/resolve-dev-loop-startup.test.mjs
+++ b/test/loop/resolve-dev-loop-startup.test.mjs
@@ -718,7 +718,7 @@ test("buildAutoResolvedInput returns warnings array for failed detection", () =>
   const tmp = mkdtempSync(path.join(os.tmpdir(), "dev-loop-511-"));
   try {
     execFileSync("git", ["init"], { cwd: tmp, stdio: "ignore" });
-    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/pi-dev-loops.git"], { cwd: tmp, stdio: "ignore" });
+    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/dev-loops.git"], { cwd: tmp, stdio: "ignore" });
     const result = buildAutoResolvedInput({ issue: 999999, cwd: tmp });
     assert.equal(result.intent, "start_issue_locally");
     assert.equal(result.artifactState, "not_applicable");
@@ -737,7 +737,7 @@ test("buildAutoResolvedInput sets linkedPr null when detection fails", () => {
   const tmp = mkdtempSync(path.join(os.tmpdir(), "dev-loop-511-"));
   try {
     execFileSync("git", ["init"], { cwd: tmp, stdio: "ignore" });
-    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/pi-dev-loops.git"], { cwd: tmp, stdio: "ignore" });
+    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/dev-loops.git"], { cwd: tmp, stdio: "ignore" });
     const result = buildAutoResolvedInput({ issue: 999999, cwd: tmp });
     assert.equal(result.currentState.target.linkedPr, null);
     assert.equal(result.issueLinkageResolution, "resolved_no_open_pr");
@@ -750,7 +750,7 @@ test("buildAutoResolvedInput for PR returns pr_followup_start", () => {
   const tmp = mkdtempSync(path.join(os.tmpdir(), "dev-loop-511-"));
   try {
     execFileSync("git", ["init"], { cwd: tmp, stdio: "ignore" });
-    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/pi-dev-loops.git"], { cwd: tmp, stdio: "ignore" });
+    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/dev-loops.git"], { cwd: tmp, stdio: "ignore" });
     const result = buildAutoResolvedInput({ pr: 999999, cwd: tmp });
     assert.equal(result.intent, "continue_on_pr");
     assert.equal(result.loopState, "pr_followup_start");
@@ -765,7 +765,7 @@ test("buildAutoResolvedInput returns valid targetPreference", () => {
   const tmp = mkdtempSync(path.join(os.tmpdir(), "dev-loop-511-"));
   try {
     execFileSync("git", ["init"], { cwd: tmp, stdio: "ignore" });
-    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/pi-dev-loops.git"], { cwd: tmp, stdio: "ignore" });
+    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/dev-loops.git"], { cwd: tmp, stdio: "ignore" });
     const result = buildAutoResolvedInput({ issue: 999999, cwd: tmp });
     assert.ok(
       result.targetPreference === "prefer_local" || result.targetPreference === "prefer_github_first",
@@ -779,7 +779,7 @@ test("buildAutoResolvedInput with local-first tracker source keeps issue-backed 
   const tmp = mkdtempSync(path.join(os.tmpdir(), "dev-loop-511-"));
   try {
     execFileSync("git", ["init"], { cwd: tmp, stdio: "ignore" });
-    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/pi-dev-loops.git"], { cwd: tmp, stdio: "ignore" });
+    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/dev-loops.git"], { cwd: tmp, stdio: "ignore" });
     const result = buildAutoResolvedInput({
       issue: 999999,
       cwd: tmp,
@@ -798,7 +798,7 @@ test("buildAutoResolvedInput with local-first phase-doc source uses local_phase 
   const tmp = mkdtempSync(path.join(os.tmpdir(), "dev-loop-511-"));
   try {
     execFileSync("git", ["init"], { cwd: tmp, stdio: "ignore" });
-    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/pi-dev-loops.git"], { cwd: tmp, stdio: "ignore" });
+    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/dev-loops.git"], { cwd: tmp, stdio: "ignore" });
     const result = buildAutoResolvedInput({
       issue: 999999,
       cwd: tmp,
@@ -818,7 +818,7 @@ test("runCli --issue uses config inputSource=phase-docs to choose phase-doc loca
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "resolve-dev-loop-phase-doc-input-source-"));
   try {
     execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
-    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/pi-dev-loops.git"], { cwd: tempDir, stdio: "ignore" });
+    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/dev-loops.git"], { cwd: tempDir, stdio: "ignore" });
     await mkdir(path.join(tempDir, ".pi", "dev-loop"), { recursive: true });
     await writeFile(
       path.join(tempDir, ".pi", "dev-loop", "settings.yaml"),
@@ -849,12 +849,12 @@ test("buildAutoResolvedInput detects Copilot authorship from linked PR author", 
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "resolve-dev-loop-copilot-author-"));
   try {
     execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
-    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/pi-dev-loops.git"], { cwd: tempDir, stdio: "ignore" });
+    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/dev-loops.git"], { cwd: tempDir, stdio: "ignore" });
     // Create the detect-linked-issue-pr script path so the subprocess can resolve
     await mkdir(path.join(tempDir, "scripts", "github"), { recursive: true });
     await writeFile(
       path.join(tempDir, "scripts/github/detect-linked-issue-pr.mjs"),
-      'process.stdout.write(JSON.stringify({ ok: true, repo: "mfittko/pi-dev-loops", issue: 735, hasOpenLinkedPr: true, prNumber: 740 }));',
+      'process.stdout.write(JSON.stringify({ ok: true, repo: "mfittko/dev-loops", issue: 735, hasOpenLinkedPr: true, prNumber: 740 }));',
       "utf8",
     );
     // Stub gh pr view to return Copilot author
@@ -887,11 +887,11 @@ test("buildAutoResolvedInput detects external_human authorship from linked PR au
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "resolve-dev-loop-external-author-"));
   try {
     execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
-    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/pi-dev-loops.git"], { cwd: tempDir, stdio: "ignore" });
+    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/dev-loops.git"], { cwd: tempDir, stdio: "ignore" });
     await mkdir(path.join(tempDir, "scripts", "github"), { recursive: true });
     await writeFile(
       path.join(tempDir, "scripts/github/detect-linked-issue-pr.mjs"),
-      'process.stdout.write(JSON.stringify({ ok: true, repo: "mfittko/pi-dev-loops", issue: 735, hasOpenLinkedPr: true, prNumber: 740 }));',
+      'process.stdout.write(JSON.stringify({ ok: true, repo: "mfittko/dev-loops", issue: 735, hasOpenLinkedPr: true, prNumber: 740 }));',
       "utf8",
     );
     const ghStub = await writeGhStubHelper(tempDir, [

--- a/test/loop/run-conductor-cycle.test.mjs
+++ b/test/loop/run-conductor-cycle.test.mjs
@@ -505,7 +505,7 @@ test("parseCliArgs handles --help", () => {
 // ---------------------------------------------------------------------------
 
 test("run-conductor-cycle CLI reports empty queue when no open PRs exist", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-rc-cycle-empty-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-rc-cycle-empty-"));
 
   try {
     const { env } = await writeGhStubHelper(tempDir, [{
@@ -529,7 +529,7 @@ test("run-conductor-cycle CLI reports empty queue when no open PRs exist", async
 });
 
 test("run-conductor-cycle CLI fails gracefully on gh pr list failure", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-rc-cycle-gh-fail-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-rc-cycle-gh-fail-"));
 
   try {
     const { env } = await writeGhStubHelper(tempDir, [{
@@ -551,7 +551,7 @@ test("run-conductor-cycle CLI fails gracefully on gh pr list failure", async () 
 });
 
 test("run-conductor-cycle CLI fails closed on non-array pr list response", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-rc-cycle-bad-list-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-rc-cycle-bad-list-"));
 
   try {
     const { env } = await writeGhStubHelper(tempDir, [{

--- a/test/loop/run-watch-cycle.test.mjs
+++ b/test/loop/run-watch-cycle.test.mjs
@@ -317,7 +317,7 @@ test("runWatchCycle preserves blocked classification for stop states without inv
 });
 
 test("runWatchCycle integration keeps initial request-review -> waiting_for_copilot_review non-terminal", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-cycle-initial-request-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-watch-cycle-initial-request-"));
   let watcherOptions;
 
   try {
@@ -410,7 +410,7 @@ test("runWatchCycle integration keeps initial request-review -> waiting_for_copi
 });
 
 test("runWatchCycle integration keeps re-requested newer-head wait state non-terminal", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-cycle-rerequest-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-watch-cycle-rerequest-"));
   let watcherOptions;
 
   try {
@@ -552,7 +552,7 @@ process.exit(97);
 });
 
 test("runWatchCycle integration keeps checks non-blocking with active Copilot workflow run", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-cycle-session-active-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-watch-cycle-session-active-"));
   let watcherOptions;
 
   try {
@@ -697,7 +697,7 @@ test("runWatchCycle integration bounds active Copilot workflow waits by the emit
 });
 
 test("runWatchCycle integration keeps the full persistent watch timeout after active Copilot workflow waits", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-cycle-session-active-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-watch-cycle-session-active-"));
   let watcherOptions;
 
   try {

--- a/test/loop/watch-initial-copilot-pr.test.mjs
+++ b/test/loop/watch-initial-copilot-pr.test.mjs
@@ -626,7 +626,7 @@ test("watchInitialCopilotPr prior_linked_pr_closed_unmerged exits even when time
 
 
 test("watch-initial-copilot-pr returns ready_for_followup via CLI when PR is immediately substantive", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pi-dev-loops-watch-initial-pr-ready-"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-watch-initial-pr-ready-"));
 
   try {
     const env = await writeGhStub(tempDir, [

--- a/test/projects/add-queue-item.test.mjs
+++ b/test/projects/add-queue-item.test.mjs
@@ -138,7 +138,7 @@ function makeItemNode(itemId, content, status) {
 
 function makeContent(type, number) {
   const __typename = type === "PR" ? "PullRequest" : "Issue";
-  return { __typename, number, repository: { nameWithOwner: "mfittko/pi-dev-loops" } };
+  return { __typename, number, repository: { nameWithOwner: "mfittko/dev-loops" } };
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────
@@ -154,28 +154,28 @@ describe("add-queue-item", () => {
 
     it("requires --project", async () => {
       await assert.rejects(
-        () => main({ repo: "mfittko/pi-dev-loops", item: 10 }),
+        () => main({ repo: "mfittko/dev-loops", item: 10 }),
         /--project is required/,
       );
     });
 
     it("requires --item", async () => {
       await assert.rejects(
-        () => main({ repo: "mfittko/pi-dev-loops", project: "1" }),
+        () => main({ repo: "mfittko/dev-loops", project: "1" }),
         /--item is required/,
       );
     });
 
     it("rejects non-integer item", async () => {
       await assert.rejects(
-        () => main({ repo: "mfittko/pi-dev-loops", project: "1", item: "not-a-number" }),
+        () => main({ repo: "mfittko/dev-loops", project: "1", item: "not-a-number" }),
         /--item is required/,
       );
     });
 
     it("rejects invalid project format", async () => {
       await assert.rejects(
-        () => main({ repo: "mfittko/pi-dev-loops", project: "not-a-number", item: 10 }),
+        () => main({ repo: "mfittko/dev-loops", project: "not-a-number", item: 10 }),
         /--project must be a positive integer or a node ID/,
       );
     });
@@ -191,7 +191,7 @@ describe("add-queue-item", () => {
         { payload: updateFieldResponse() },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "PVT_proj1", item: 10 },
+        { repo: "mfittko/dev-loops", project: "PVT_proj1", item: 10 },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -210,7 +210,7 @@ describe("add-queue-item", () => {
         { payload: updateFieldResponse() },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "1", item: 10 },
+        { repo: "mfittko/dev-loops", project: "1", item: 10 },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -232,7 +232,7 @@ describe("add-queue-item", () => {
         { payload: updateFieldResponse() },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "1", item: 20 },
+        { repo: "mfittko/dev-loops", project: "1", item: 20 },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -253,7 +253,7 @@ describe("add-queue-item", () => {
         { payload: updateFieldResponse() },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "1", item: 10, status: "In Progress" },
+        { repo: "mfittko/dev-loops", project: "1", item: 10, status: "In Progress" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -272,7 +272,7 @@ describe("add-queue-item", () => {
         { payload: updateFieldResponse() },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "1", item: 10 },
+        { repo: "mfittko/dev-loops", project: "1", item: 10 },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -292,7 +292,7 @@ describe("add-queue-item", () => {
         // No resolve, add, or update calls expected
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "1", item: 10 },
+        { repo: "mfittko/dev-loops", project: "1", item: 10 },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -311,7 +311,7 @@ describe("add-queue-item", () => {
         { payload: getItemsByContentResponse([existingItem]) },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "1", item: 20 },
+        { repo: "mfittko/dev-loops", project: "1", item: 20 },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -333,7 +333,7 @@ describe("add-queue-item", () => {
         { payload: updateFieldResponse() },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "1", item: 10 },
+        { repo: "mfittko/dev-loops", project: "1", item: 10 },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -349,7 +349,7 @@ describe("add-queue-item", () => {
       ];
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "999", item: 10 },
+          { repo: "mfittko/dev-loops", project: "999", item: 10 },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.fail("should have thrown");
@@ -366,7 +366,7 @@ describe("add-queue-item", () => {
       ];
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "1", item: 10 },
+          { repo: "mfittko/dev-loops", project: "1", item: 10 },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.fail("should have thrown");
@@ -383,7 +383,7 @@ describe("add-queue-item", () => {
       ];
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "1", item: 10, status: "Icebox" },
+          { repo: "mfittko/dev-loops", project: "1", item: 10, status: "Icebox" },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.fail("should have thrown");
@@ -404,7 +404,7 @@ describe("add-queue-item", () => {
       ];
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "1", item: 999 },
+          { repo: "mfittko/dev-loops", project: "1", item: 999 },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.fail("should have thrown");
@@ -426,7 +426,7 @@ describe("add-queue-item", () => {
       ];
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "1", item: 10 },
+          { repo: "mfittko/dev-loops", project: "1", item: 10 },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.fail("should have thrown");
@@ -441,7 +441,7 @@ describe("add-queue-item", () => {
       const responses = [{ error: "gh: authentication required" }];
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "1", item: 10 },
+          { repo: "mfittko/dev-loops", project: "1", item: 10 },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.fail("should have thrown");
@@ -454,7 +454,7 @@ describe("add-queue-item", () => {
       const responses = [{ payload: { errors: [{ message: "Could not resolve" }] } }];
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "1", item: 10 },
+          { repo: "mfittko/dev-loops", project: "1", item: 10 },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.fail("should have thrown");
@@ -493,7 +493,7 @@ describe("add-queue-item", () => {
     it("produces JSON error shape for CLI consumers", async () => {
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "1", item: 999 },
+          { repo: "mfittko/dev-loops", project: "1", item: 999 },
           { env: {}, runChild: mockRunChild([
             { payload: userPayload() },
             { payload: listUserProjectsResponse([EXISTING_PROJECT]) },

--- a/test/projects/ensure-queue-board.test.mjs
+++ b/test/projects/ensure-queue-board.test.mjs
@@ -150,7 +150,7 @@ describe("ensure-queue-board", () => {
         },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops" },
+        { repo: "mfittko/dev-loops" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -201,7 +201,7 @@ describe("ensure-queue-board", () => {
         },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", title: "My Queue" },
+        { repo: "mfittko/dev-loops", title: "My Queue" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -218,7 +218,7 @@ describe("ensure-queue-board", () => {
         { payload: getFieldsResponse([STATUS_FIELD]) },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: 1 },
+        { repo: "mfittko/dev-loops", project: 1 },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -232,7 +232,7 @@ describe("ensure-queue-board", () => {
       ];
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: 999 },
+          { repo: "mfittko/dev-loops", project: 999 },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.fail("should have thrown");
@@ -262,11 +262,11 @@ describe("ensure-queue-board", () => {
         },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", linkRepo: "mfittko/pi-dev-loops" },
+        { repo: "mfittko/dev-loops", linkRepo: "mfittko/dev-loops" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
-      assert.equal(result.project.linkedRepo, "mfittko/pi-dev-loops");
+      assert.equal(result.project.linkedRepo, "mfittko/dev-loops");
       assert.equal(result.project.statusFieldId, "PVTSSF_new");
     });
 
@@ -279,17 +279,17 @@ describe("ensure-queue-board", () => {
         { payload: linkRepoResponse() },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", linkRepo: "mfittko/pi-dev-loops" },
+        { repo: "mfittko/dev-loops", linkRepo: "mfittko/dev-loops" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
-      assert.equal(result.project.linkedRepo, "mfittko/pi-dev-loops");
+      assert.equal(result.project.linkedRepo, "mfittko/dev-loops");
     });
 
     it("validates link-repo format", async () => {
       await assert.rejects(
         () => main({
-          repo: "mfittko/pi-dev-loops",
+          repo: "mfittko/dev-loops",
           linkRepo: "not-a-repo",
         }),
         /owner\/name/,
@@ -312,7 +312,7 @@ describe("ensure-queue-board", () => {
         { payload: updateFieldResponse() },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops" },
+        { repo: "mfittko/dev-loops" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -343,7 +343,7 @@ describe("ensure-queue-board", () => {
         { payload: updateFieldResponse(expectedOptions) },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops" },
+        { repo: "mfittko/dev-loops" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -367,12 +367,12 @@ describe("ensure-queue-board", () => {
         { payload: linkRepoResponse() },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", linkRepo: "mfittko/pi-dev-loops" },
+        { repo: "mfittko/dev-loops", linkRepo: "mfittko/dev-loops" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
       assert.equal(result.project.statusFieldId, "PVTSSF_partial");
-      assert.equal(result.project.linkedRepo, "mfittko/pi-dev-loops");
+      assert.equal(result.project.linkedRepo, "mfittko/dev-loops");
     });
   });
 
@@ -440,7 +440,7 @@ describe("ensure-queue-board", () => {
         { payload: getFieldsResponse([STATUS_FIELD]) },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops" },
+        { repo: "mfittko/dev-loops" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -460,7 +460,7 @@ describe("ensure-queue-board", () => {
         },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops" },
+        { repo: "mfittko/dev-loops" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -498,7 +498,7 @@ describe("ensure-queue-board", () => {
         { payload: getFieldsResponse([STATUS_FIELD]) },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops" },
+        { repo: "mfittko/dev-loops" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -526,7 +526,7 @@ describe("ensure-queue-board", () => {
     it("throws on GraphQL API error", async () => {
       const responses = [{ error: "gh: authentication required" }];
       await assert.rejects(
-        () => main({ repo: "mfittko/pi-dev-loops" }, { env: {}, runChild: mockRunChild(responses) }),
+        () => main({ repo: "mfittko/dev-loops" }, { env: {}, runChild: mockRunChild(responses) }),
         /gh api graphql failed/,
       );
     });
@@ -536,7 +536,7 @@ describe("ensure-queue-board", () => {
         payload: { errors: [{ message: "Could not resolve to a User" }] },
       }];
       await assert.rejects(
-        () => main({ repo: "mfittko/pi-dev-loops" }, { env: {}, runChild: mockRunChild(responses) }),
+        () => main({ repo: "mfittko/dev-loops" }, { env: {}, runChild: mockRunChild(responses) }),
         /GraphQL errors/,
       );
     });
@@ -547,7 +547,7 @@ describe("ensure-queue-board", () => {
         { payload: noOrgPayload() },
       ];
       await assert.rejects(
-        () => main({ repo: "mfittko/pi-dev-loops" }, { env: {}, runChild: mockRunChild(responses) }),
+        () => main({ repo: "mfittko/dev-loops" }, { env: {}, runChild: mockRunChild(responses) }),
         /Could not resolve owner ID/,
       );
     });
@@ -570,7 +570,7 @@ describe("ensure-queue-board", () => {
       ];
       await assert.rejects(
         () => main(
-          { repo: "mfittko/pi-dev-loops", linkRepo: "nonexistent/repo" },
+          { repo: "mfittko/dev-loops", linkRepo: "nonexistent/repo" },
           { env: {}, runChild: mockRunChild(responses) },
         ),
         /Could not resolve repository ID/,
@@ -691,7 +691,7 @@ describe("rename/reconcile drift", () => {
 
   it("reports empty repairs when all standard columns are present", async () => {
     const result = await main(
-      { repo: "mfittko/pi-dev-loops" },
+      { repo: "mfittko/dev-loops" },
       { env: {}, runChild: mockRunChild(NO_DRIFT_RESPONSES()) },
     );
     assert.equal(result.ok, true);
@@ -712,7 +712,7 @@ describe("rename/reconcile drift", () => {
       { payload: getFieldsResponse([RENAMED_FIELD]) },
     ];
     const result = await main(
-      { repo: "mfittko/pi-dev-loops" },
+      { repo: "mfittko/dev-loops" },
       { env: {}, runChild: mockRunChild(responses) },
     );
     assert.equal(result.ok, true);
@@ -736,7 +736,7 @@ describe("rename/reconcile drift", () => {
       { payload: updateFieldResponse(expectedOptions) },
     ];
     const result = await main(
-      { repo: "mfittko/pi-dev-loops", repairRename: true },
+      { repo: "mfittko/dev-loops", repairRename: true },
       { env: {}, runChild: mockRunChild(responses) },
     );
     assert.equal(result.ok, true);
@@ -763,7 +763,7 @@ describe("rename/reconcile drift", () => {
       { payload: getFieldsResponse([conflictField]) },
     ];
     const result = await main(
-      { repo: "mfittko/pi-dev-loops", repairRename: true },
+      { repo: "mfittko/dev-loops", repairRename: true },
       { env: {}, runChild: mockRunChild(responses) },
     );
     assert.equal(result.ok, true);
@@ -794,7 +794,7 @@ describe("rename/reconcile drift", () => {
       { payload: updateFieldResponse(expectedOptions) },
     ];
     const result = await main(
-      { repo: "mfittko/pi-dev-loops", repairRename: true },
+      { repo: "mfittko/dev-loops", repairRename: true },
       { env: {}, runChild: mockRunChild(responses) },
     );
     assert.equal(result.ok, true);
@@ -822,7 +822,7 @@ describe("rename conflict when standard already exists", () => {
       { payload: getFieldsResponse([duplicateStandardField]) },
     ];
     const result = await main(
-      { repo: "mfittko/pi-dev-loops", repairRename: true },
+      { repo: "mfittko/dev-loops", repairRename: true },
       { env: {}, runChild: mockRunChild(responses) },
     );
     assert.equal(result.ok, true);
@@ -849,7 +849,7 @@ describe("rename conflict when standard already exists", () => {
       },
     ];
     const result = await main(
-      { repo: "mfittko/pi-dev-loops" },
+      { repo: "mfittko/dev-loops" },
       { env: {}, runChild: mockRunChild(responses) },
     );
     assert.equal(result.ok, true);

--- a/test/projects/list-queue-items.test.mjs
+++ b/test/projects/list-queue-items.test.mjs
@@ -114,28 +114,28 @@ describe("list-queue-items", () => {
 
     it("requires --project", async () => {
       await assert.rejects(
-        () => main({ repo: "mfittko/pi-dev-loops" }),
+        () => main({ repo: "mfittko/dev-loops" }),
         /--project is required/,
       );
     });
 
     it("rejects invalid project format", async () => {
       await assert.rejects(
-        () => main({ repo: "mfittko/pi-dev-loops", project: "not-a-number" }),
+        () => main({ repo: "mfittko/dev-loops", project: "not-a-number" }),
         /--project must be a positive integer or a node ID/,
       );
     });
 
     it("rejects negative project number", async () => {
       await assert.rejects(
-        () => main({ repo: "mfittko/pi-dev-loops", project: "-1" }),
+        () => main({ repo: "mfittko/dev-loops", project: "-1" }),
         /--project must be a positive integer or a node ID/,
       );
     });
 
     it("rejects zero project number", async () => {
       await assert.rejects(
-        () => main({ repo: "mfittko/pi-dev-loops", project: "0" }),
+        () => main({ repo: "mfittko/dev-loops", project: "0" }),
         /--project must be a positive integer or a node ID/,
       );
     });
@@ -162,7 +162,7 @@ describe("list-queue-items", () => {
         { payload: getItemsResponse([]) },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "PVT_proj1" },
+        { repo: "mfittko/dev-loops", project: "PVT_proj1" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -177,7 +177,7 @@ describe("list-queue-items", () => {
       ];
       // Whitespace-padded number should still parse as integer and find project
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: " 1 " },
+        { repo: "mfittko/dev-loops", project: " 1 " },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -198,7 +198,7 @@ describe("list-queue-items", () => {
         { payload: getItemsResponse(items) },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "1" },
+        { repo: "mfittko/dev-loops", project: "1" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -224,7 +224,7 @@ describe("list-queue-items", () => {
         { payload: getItemsResponse(items) },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "1", column: "Next Up" },
+        { repo: "mfittko/dev-loops", project: "1", column: "Next Up" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -249,7 +249,7 @@ describe("list-queue-items", () => {
         { payload: getItemsResponse(items) },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "1", column: "Next Up", limit: 1 },
+        { repo: "mfittko/dev-loops", project: "1", column: "Next Up", limit: 1 },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -268,7 +268,7 @@ describe("list-queue-items", () => {
         { payload: getItemsResponse(items) },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "1" },
+        { repo: "mfittko/dev-loops", project: "1" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -294,7 +294,7 @@ describe("list-queue-items", () => {
         { payload: getItemsResponse(items) },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "1" },
+        { repo: "mfittko/dev-loops", project: "1" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -317,7 +317,7 @@ describe("list-queue-items", () => {
         { payload: getItemsResponse([]) },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "1" },
+        { repo: "mfittko/dev-loops", project: "1" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -332,7 +332,7 @@ describe("list-queue-items", () => {
         { payload: getItemsResponse([]) },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "PVT_proj1" },
+        { repo: "mfittko/dev-loops", project: "PVT_proj1" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -391,7 +391,7 @@ describe("list-queue-items", () => {
         { payload: getItemsResponse([]) },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "1" },
+        { repo: "mfittko/dev-loops", project: "1" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -406,7 +406,7 @@ describe("list-queue-items", () => {
       ];
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "42" },
+          { repo: "mfittko/dev-loops", project: "42" },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.fail("should have thrown");
@@ -423,7 +423,7 @@ describe("list-queue-items", () => {
       ];
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "PVT_nonexistent" },
+          { repo: "mfittko/dev-loops", project: "PVT_nonexistent" },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.fail("should have thrown");
@@ -440,7 +440,7 @@ describe("list-queue-items", () => {
       ];
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "1" },
+          { repo: "mfittko/dev-loops", project: "1" },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.fail("should have thrown");
@@ -458,7 +458,7 @@ describe("list-queue-items", () => {
       ];
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "1", column: "Icebox" },
+          { repo: "mfittko/dev-loops", project: "1", column: "Icebox" },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.fail("should have thrown");
@@ -491,7 +491,7 @@ describe("list-queue-items", () => {
       const responses = [{ error: "gh: authentication required" }];
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "1" },
+          { repo: "mfittko/dev-loops", project: "1" },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.fail("should have thrown");
@@ -507,7 +507,7 @@ describe("list-queue-items", () => {
       }];
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "1" },
+          { repo: "mfittko/dev-loops", project: "1" },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.fail("should have thrown");
@@ -530,7 +530,7 @@ describe("list-queue-items", () => {
         { payload: getItemsResponse(items) },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "1" },
+        { repo: "mfittko/dev-loops", project: "1" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -550,7 +550,7 @@ describe("list-queue-items", () => {
         { payload: getItemsResponse(items) },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "1", column: "Next Up" },
+        { repo: "mfittko/dev-loops", project: "1", column: "Next Up" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -564,7 +564,7 @@ describe("list-queue-items", () => {
       // We can test the error object shape by catching from main()
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "999" },
+          { repo: "mfittko/dev-loops", project: "999" },
           { env: {}, runChild: mockRunChild([
             { payload: userPayload() },
             { payload: listUserProjectsResponse([]) },

--- a/test/projects/move-queue-item.test.mjs
+++ b/test/projects/move-queue-item.test.mjs
@@ -95,7 +95,7 @@ function makeItemNode(itemId, content, status) {
   return { id: itemId, fieldValues, content };
 }
 
-function makeContent(type, number, repo = "mfittko/pi-dev-loops") {
+function makeContent(type, number, repo = "mfittko/dev-loops") {
   const __typename = type === "PR" ? "PullRequest" : "Issue";
   return { __typename, number, repository: { nameWithOwner: repo } };
 }
@@ -113,35 +113,35 @@ describe("move-queue-item", () => {
 
     it("requires --project", async () => {
       await assert.rejects(
-        () => main({ repo: "mfittko/pi-dev-loops", item: "10", toColumn: "Next Up" }),
+        () => main({ repo: "mfittko/dev-loops", item: "10", toColumn: "Next Up" }),
         /--project is required/,
       );
     });
 
     it("requires --item", async () => {
       await assert.rejects(
-        () => main({ repo: "mfittko/pi-dev-loops", project: "1", toColumn: "Next Up" }),
+        () => main({ repo: "mfittko/dev-loops", project: "1", toColumn: "Next Up" }),
         /--item is required/,
       );
     });
 
     it("requires --to-column", async () => {
       await assert.rejects(
-        () => main({ repo: "mfittko/pi-dev-loops", project: "1", item: "10" }),
+        () => main({ repo: "mfittko/dev-loops", project: "1", item: "10" }),
         /--to-column is required/,
       );
     });
 
     it("rejects invalid project format", async () => {
       await assert.rejects(
-        () => main({ repo: "mfittko/pi-dev-loops", project: "not-a-number", item: "10", toColumn: "Next Up" }),
+        () => main({ repo: "mfittko/dev-loops", project: "not-a-number", item: "10", toColumn: "Next Up" }),
         /--project must be a positive integer or a node ID/,
       );
     });
 
     it("rejects invalid item format", async () => {
       await assert.rejects(
-        () => main({ repo: "mfittko/pi-dev-loops", project: "1", item: "not-a-number", toColumn: "Next Up" }),
+        () => main({ repo: "mfittko/dev-loops", project: "1", item: "not-a-number", toColumn: "Next Up" }),
         /--item must be a positive integer or an item node ID/,
       );
     });
@@ -159,7 +159,7 @@ describe("move-queue-item", () => {
         { payload: updateItemFieldResponse() },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "PVT_proj1", item: "10", toColumn: "Next Up" },
+        { repo: "mfittko/dev-loops", project: "PVT_proj1", item: "10", toColumn: "Next Up" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -170,7 +170,7 @@ describe("move-queue-item", () => {
       const itemNode = {
         id: "PVTI_42",
         fieldValues: { nodes: [{ field: { id: "PVTSSF_status", name: "Status" }, name: "Backlog" }] },
-        content: { __typename: "Issue", number: 10, title: "Test", url: "https://github.com/mfittko/pi-dev-loops/issues/10" },
+        content: { __typename: "Issue", number: 10, title: "Test", url: "https://github.com/mfittko/dev-loops/issues/10" },
       };
       const responses = [
         { payload: userPayload() },
@@ -180,7 +180,7 @@ describe("move-queue-item", () => {
         { payload: updateItemFieldResponse() },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "1", item: "PVTI_42", toColumn: "In Progress" },
+        { repo: "mfittko/dev-loops", project: "1", item: "PVTI_42", toColumn: "In Progress" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -203,7 +203,7 @@ describe("move-queue-item", () => {
         { payload: updateItemFieldResponse() },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "1", item: "10", toColumn: "Next Up" },
+        { repo: "mfittko/dev-loops", project: "1", item: "10", toColumn: "Next Up" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -228,7 +228,7 @@ describe("move-queue-item", () => {
         { payload: updateItemFieldResponse() },
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "1", item: "20", toColumn: "Done" },
+        { repo: "mfittko/dev-loops", project: "1", item: "20", toColumn: "Done" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -253,7 +253,7 @@ describe("move-queue-item", () => {
         // No mutation call expected — unchanged
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "1", item: "10", toColumn: "Next Up" },
+        { repo: "mfittko/dev-loops", project: "1", item: "10", toColumn: "Next Up" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -266,7 +266,7 @@ describe("move-queue-item", () => {
       const itemNode = {
         id: "PVTI_42",
         fieldValues: { nodes: [{ field: { id: "PVTSSF_status", name: "Status" }, name: "Done" }] },
-        content: { __typename: "Issue", number: 10, title: "Test", url: "https://github.com/mfittko/pi-dev-loops/issues/10" },
+        content: { __typename: "Issue", number: 10, title: "Test", url: "https://github.com/mfittko/dev-loops/issues/10" },
       };
       const responses = [
         { payload: userPayload() },
@@ -276,7 +276,7 @@ describe("move-queue-item", () => {
         // No mutation
       ];
       const result = await main(
-        { repo: "mfittko/pi-dev-loops", project: "1", item: "PVTI_42", toColumn: "Done" },
+        { repo: "mfittko/dev-loops", project: "1", item: "PVTI_42", toColumn: "Done" },
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
@@ -307,7 +307,7 @@ describe("move-queue-item", () => {
           { payload: updateItemFieldResponse() },
         ];
         const result = await main(
-          { repo: "mfittko/pi-dev-loops", project: "1", item: "10", toColumn: to },
+          { repo: "mfittko/dev-loops", project: "1", item: "10", toColumn: to },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.equal(result.ok, true);
@@ -326,7 +326,7 @@ describe("move-queue-item", () => {
       ];
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "999", item: "10", toColumn: "Next Up" },
+          { repo: "mfittko/dev-loops", project: "999", item: "10", toColumn: "Next Up" },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.fail("should have thrown");
@@ -343,7 +343,7 @@ describe("move-queue-item", () => {
       ];
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "1", item: "10", toColumn: "Next Up" },
+          { repo: "mfittko/dev-loops", project: "1", item: "10", toColumn: "Next Up" },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.fail("should have thrown");
@@ -360,7 +360,7 @@ describe("move-queue-item", () => {
       ];
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "1", item: "10", toColumn: "Icebox" },
+          { repo: "mfittko/dev-loops", project: "1", item: "10", toColumn: "Icebox" },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.fail("should have thrown");
@@ -379,7 +379,7 @@ describe("move-queue-item", () => {
       ];
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "1", item: "42", toColumn: "Next Up" },
+          { repo: "mfittko/dev-loops", project: "1", item: "42", toColumn: "Next Up" },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.fail("should have thrown");
@@ -397,7 +397,7 @@ describe("move-queue-item", () => {
       ];
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "1", item: "PVTI_nonexistent", toColumn: "Next Up" },
+          { repo: "mfittko/dev-loops", project: "1", item: "PVTI_nonexistent", toColumn: "Next Up" },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.fail("should have thrown");
@@ -412,7 +412,7 @@ describe("move-queue-item", () => {
       const responses = [{ error: "gh: authentication required" }];
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "1", item: "10", toColumn: "Next Up" },
+          { repo: "mfittko/dev-loops", project: "1", item: "10", toColumn: "Next Up" },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.fail("should have thrown");
@@ -425,7 +425,7 @@ describe("move-queue-item", () => {
       const responses = [{ payload: { errors: [{ message: "Could not resolve" }] } }];
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "1", item: "10", toColumn: "Next Up" },
+          { repo: "mfittko/dev-loops", project: "1", item: "10", toColumn: "Next Up" },
           { env: {}, runChild: mockRunChild(responses) },
         );
         assert.fail("should have thrown");
@@ -467,7 +467,7 @@ describe("move-queue-item", () => {
     it("produces JSON error shape for CLI consumers", async () => {
       try {
         await main(
-          { repo: "mfittko/pi-dev-loops", project: "1", item: "42", toColumn: "Next Up" },
+          { repo: "mfittko/dev-loops", project: "1", item: "42", toColumn: "Next Up" },
           { env: {}, runChild: mockRunChild([
             { payload: userPayload() },
             { payload: listUserProjectsResponse([EXISTING_PROJECT]) },

--- a/test/projects/reorder-queue-item.test.mjs
+++ b/test/projects/reorder-queue-item.test.mjs
@@ -97,7 +97,7 @@ function getProjectItemResponse(itemId, itemContent) {
             __typename: "Issue",
             number: 630,
             title: "Test Issue",
-            url: "https://github.com/mfittko/pi-dev-loops/issues/630",
+            url: "https://github.com/mfittko/dev-loops/issues/630",
           },
         },
       },
@@ -119,7 +119,7 @@ function makeItemContent(ref, typename, repo) {
   return {
     __typename: typename || "Issue",
     number: ref,
-    repository: { nameWithOwner: repo || "mfittko/pi-dev-loops" },
+    repository: { nameWithOwner: repo || "mfittko/dev-loops" },
   };
 }
 
@@ -163,7 +163,7 @@ describe("reorder-queue-item — move to top (no --after)", () => {
     };
 
     const result = await main(
-      { repo: "mfittko/pi-dev-loops", project: "1", item: "630" },
+      { repo: "mfittko/dev-loops", project: "1", item: "630" },
       { runChild: wrapped },
     );
 
@@ -203,7 +203,7 @@ describe("reorder-queue-item — move to top (no --after)", () => {
     };
 
     const result = await main(
-      { repo: "mfittko/pi-dev-loops", project: "1", item: "PVTI_item_x" },
+      { repo: "mfittko/dev-loops", project: "1", item: "PVTI_item_x" },
       { runChild: wrapped },
     );
 
@@ -237,7 +237,7 @@ describe("reorder-queue-item — move after another item", () => {
     };
 
     const result = await main(
-      { repo: "mfittko/pi-dev-loops", project: "1", item: "630", after: "625" },
+      { repo: "mfittko/dev-loops", project: "1", item: "630", after: "625" },
       { runChild: wrapped },
     );
 
@@ -262,7 +262,7 @@ describe("reorder-queue-item — move after another item", () => {
 
     await assert.rejects(
       () => main(
-        { repo: "mfittko/pi-dev-loops", project: "1", item: "630", after: "999" },
+        { repo: "mfittko/dev-loops", project: "1", item: "630", after: "999" },
         { runChild },
       ),
       (err) => err.code === "ITEM_NOT_FOUND",
@@ -280,7 +280,7 @@ describe("reorder-queue-item — move after another item", () => {
 
     await assert.rejects(
       () => main(
-        { repo: "mfittko/pi-dev-loops", project: "1", item: "630", after: "630" },
+        { repo: "mfittko/dev-loops", project: "1", item: "630", after: "630" },
         { runChild },
       ),
       (err) => err.message.includes("itself"),
@@ -299,7 +299,7 @@ describe("reorder-queue-item — error handling", () => {
 
     await assert.rejects(
       () => main(
-        { repo: "mfittko/pi-dev-loops", project: "1", item: "999" },
+        { repo: "mfittko/dev-loops", project: "1", item: "999" },
         { runChild },
       ),
       (err) => err.code === "ITEM_NOT_FOUND",
@@ -315,7 +315,7 @@ describe("reorder-queue-item — error handling", () => {
 
     await assert.rejects(
       () => main(
-        { repo: "mfittko/pi-dev-loops", project: "99", item: "630" },
+        { repo: "mfittko/dev-loops", project: "99", item: "630" },
         { runChild },
       ),
       (err) => err.code === "PROJECT_NOT_FOUND",
@@ -342,7 +342,7 @@ describe("reorder-queue-item — mutation input construction", () => {
     };
 
     await main(
-      { repo: "mfittko/pi-dev-loops", project: "1", item: "630" },
+      { repo: "mfittko/dev-loops", project: "1", item: "630" },
       { runChild: wrapped },
     );
 
@@ -372,7 +372,7 @@ describe("reorder-queue-item — mutation input construction", () => {
     };
 
     await main(
-      { repo: "mfittko/pi-dev-loops", project: "1", item: "630", after: "PVTI_item_625" },
+      { repo: "mfittko/dev-loops", project: "1", item: "630", after: "PVTI_item_625" },
       { runChild: wrapped },
     );
 


### PR DESCRIPTION
## Summary

Execute the repository rename from `mfittko/pi-dev-loops` to `mfittko/dev-loops` across tracked files, as planned in `docs/phase-a-repo-slug-survey.md` (Phase A, #790). The GitHub Settings rename was already completed by the operator; this PR updates local file references, the `origin` remote URL (already `https://github.com/mfittko/dev-loops.git`), `package.json` repository/bugs/homepage URLs, and test fixtures that hard-coded the old slug.

Closes #786

## AC / DoD matrix (from #786)

### Acceptance criteria

| ID | Criterion | Status | Evidence |
|---|---|---|---|
| AC1 | All ~30 tracked files categorized in Phase A's survey have been edited. | Met | 82 files changed; survey action-list items applied. |
| AC2 | `rg 'pi-dev-loops' .` (excluding `node_modules/`, `.git/`, build artifacts) returns ZERO hits outside `@pi-dev-loops/core` package refs. | Met with documented exceptions | Residual hits are only `@pi-dev-loops/core` imports/bin names (#766), the deferred skill content in `skills/docs/tracker-first-loop-state.md` (#768), the deferred archive `docs/archive/phases/phase-6.md`, and the Phase A survey doc `docs/phase-a-repo-slug-survey.md` (historical artifact). |
| AC3 | `npm run verify` passes locally. | Met | All test suites green (see validation below). |
| AC4 | `npm run repo-wiki:bootstrap` regenerates the wiki successfully. | Met | Bootstrap completed 22 pages, 0 skips. |
| AC5 | `git remote -v` updated to new URL. | Met | `origin https://github.com/mfittko/dev-loops.git`. |
| AC6 | Any URL in README.md, extension/, CI workflows, `.github/` updated to the new slug. | Met | README, extension README/TS/presentation, CLI help, docs, schema `$id`, and `.github/` checked; no hardcoded old-slug URLs remain in those surfaces. |
| AC7 | Wikis auto-publish to the new `.wiki.git` on next push. | Expected | Wiki workflow uses `${{ github.repository }}`; repo slug change is active on GitHub. |

### Definition of done

| ID | Item | Status | Evidence |
|---|---|---|---|
| DoD1 | PR opened with all renames. | Met | This draft PR. |
| DoD2 | CI green at merge head. | Pending | Will be verified before merge. |
| DoD3 | Both gates (`draft_gate`, `pre_approval_gate`) clean. | Pending | Following repository gate process. |
| DoD4 | No remaining `pi-dev-loops` slug references in tracked files outside `@pi-dev-loops/core` package refs. | Met with documented exceptions | Same residual set as AC2 (see below). |

## Non-goals (from #786)

- Renaming the `@pi-dev-loops/core` package or its imports — tracked in #766.
- Renaming deferred skill content references — tracked in #768.
- Phase C (npm metadata), Phase D (publish workflow), Phase E (first release) — separate issues.

## Files touched

- `package.json` — added `repository`, `bugs`, `homepage` pointing to `mfittko/dev-loops`.
- `README.md`, `PLAN.md`, `docs/worktree-guidance.md`, `docs/sub-issue-tree-contract.md`, `docs/steerable-subagents-design.md`, `docs/reviewer-loop-state-graph.md`, `docs/conductor-routing-contract.md`, `docs/projects-queue-contract.md`, `docs/projects-queue-usage.md`, `docs/queue-board-setup.md`, `docs/specs/queue-mode/SPEC.md`, `docs/phases/phase-7.md`, `docs/phases/phase-8.md`, `docs/presentations/applied-dev-loops-presentation.md`.
- `cli/index.mjs`, `extension/README.md`, `extension/index.ts`, `extension/post-merge-update.ts`, `extension/presentation.ts`.
- `schemas/dev-loop-config.schema.json`.
- Test fixtures across `test/**` and `packages/core/test/**` (repo slugs, temp-directory prefixes, status/widget keys).
- `packages/core/src/loop/tracker-pr-state.mjs` comment.
- Selected skill docs (`skills/copilot-pr-followup/SKILL.md`, `skills/docs/artifact-authority-contract.md`, `skills/docs/issue-intake-procedure.md`, `skills/docs/pr-lifecycle-contract.md`, `skills/docs/copilot-loop-operations.md`) where only project-name references appeared.

## Validation

```text
$ npm run verify
✅ test:assets      86 pass / 0 fail
✅ test:extension   63 pass / 0 fail
✅ test:scripts   1428 pass / 0 fail / 36 skipped
✅ test:core      1409 pass / 0 fail
✅ test:docs        links OK, no duplicate rules
✅ test:dev-loop    32 pass / 0 fail

$ npm run repo-wiki:bootstrap
✅ scan/plan/compile green (22 pages, 0 skipped)

$ rg 'mfittko/pi-dev-loops' . --hidden -g '!node_modules' -g '!.git' -g '!package-lock.json' -g '!tmp' -g '!.wiki'
Only allowed residuals:
- skills/docs/tracker-first-loop-state.md  (#768 deferred)
- docs/archive/phases/phase-6.md            (archive deferred)
- docs/phase-a-repo-slug-survey.md          (Phase A historical artifact)
```

## Notes

- `@pi-dev-loops/core` imports, `packages/core/package.json` name, and the `pi-dev-loops-*` bin entries are intentionally untouched per #766.
- `docs/phase-a-repo-slug-survey.md` intentionally preserves the old slug because it is the Phase A historical record; it is not part of the rename surface.
