### PR TITLE
Phase C — Add npm publish metadata to dev-loops package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## 0.1.0 - 2026-06-15
+
+### Added
+
+- Initial publishable package metadata for `dev-loops`.
+  - `version`: `0.1.0`
+  - `files`: explicit allowlist so the published tarball includes only runtime assets (`cli/`, `lib/`, `scripts/`, and the subset of `packages/core/` used by the CLI entrypoint).
+  - `publishConfig`: `{ "access": "public", "provenance": true }`
+  - `repository`, `bugs`, `homepage`: point to `https://github.com/mfittko/dev-loops`
+- `CHANGELOG.md` with this initial release entry.
+
+### Changed
+
+- `cli/index.mjs` now imports the harness adapter and retry-wrapper from relative paths inside `packages/core/`, so the published tarball can resolve them without relying on the unpublished `@pi-dev-loops/core` workspace package.
+
+### Decisions
+
+- Package name: `dev-loops` (unscoped) is primary per #788 confirmed decisions. `@mfittko/dev-loops` remains the documented fallback if the unscoped name is blocked on npm.
+- `packages/core` is not published independently in this slice; the root package carries only the core runtime pieces the CLI entrypoint needs (#766 will decide on core publishing).
+
+### Notes
+
+- This release does **not** publish to npm or add the publish workflow; Phase D will add `.github/workflows/npm-publish.yml` and Phase E will cut the first release.

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -13,7 +13,7 @@ import {
   DEV_LOOP_CHECK_IDS,
 } from "../lib/dev-loops-core.mjs";
 import { isUsageError, buildCorrectedArgs } from "../packages/core/src/cli/retry-wrapper.mjs";
-import { createPiAdapter } from "@pi-dev-loops/core/harness";
+import { createPiAdapter } from "../packages/core/src/harness/index.mjs";
 
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 

--- a/package.json
+++ b/package.json
@@ -87,7 +87,13 @@
     "packages/core/src/cli/",
     "README.md",
     "CHANGELOG.md",
-    "LICENSE"
+    "LICENSE",
+    "packages/core/src/bash-exit-one.mjs",
+    "packages/core/src/config/",
+    "packages/core/src/github/",
+    "packages/core/src/loop/",
+    "packages/core/src/debt/",
+    "packages/core/src/refinement/"
   ],
   "publishConfig": {
     "access": "public",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
   },
   "dependencies": {
     "mermaid": "11.15.0",
-    "zod": "^4.4.3"
+    "zod": "^4.4.3",
+    "yaml": "^2.9.0"
   },
   "repository": {
     "type": "git",
@@ -93,7 +94,8 @@
     "packages/core/src/github/",
     "packages/core/src/loop/",
     "packages/core/src/debt/",
-    "packages/core/src/refinement/"
+    "packages/core/src/refinement/",
+    "packages/core/src/analysis/"
   ],
   "publishConfig": {
     "access": "public",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "dev-loops",
-  "private": true,
   "license": "MIT",
   "type": "module",
   "description": "Shared Pi workflow infrastructure for reusable local and remote development loops",
@@ -29,7 +28,6 @@
     "test:dev-loop": "node --test --test-reporter ./test/failure-summary-reporter.mjs skills/dev-loop/scripts/dev-mode-context.test.mjs skills/dev-loop/scripts/render-template.test.mjs skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs",
     "test:playwright:viewer": "playwright test -c playwright.inspect-run-viewer.config.mjs",
     "test:docs": "node scripts/docs/validate-links.mjs && node scripts/docs/validate-no-duplicate-rules.mjs",
-    "postinstall": "chmod +x cli/index.mjs && ln -sf ../../cli/index.mjs node_modules/.bin/dev-loops",
     "repo-wiki": "node scripts/repo-wiki.mjs",
     "repo-wiki:bootstrap": "node scripts/repo-wiki.mjs scan --repo . && node scripts/repo-wiki.mjs plan --repo . && node scripts/repo-wiki.mjs compile --repo .",
     "repo-wiki:scan": "node scripts/repo-wiki.mjs scan --repo .",
@@ -79,5 +77,20 @@
   "bugs": {
     "url": "https://github.com/mfittko/dev-loops/issues"
   },
-  "homepage": "https://github.com/mfittko/dev-loops#readme"
+  "homepage": "https://github.com/mfittko/dev-loops#readme",
+  "version": "0.1.0",
+  "files": [
+    "cli/",
+    "lib/",
+    "scripts/",
+    "packages/core/src/harness/",
+    "packages/core/src/cli/",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
 }

--- a/scripts/_cli-primitives.mjs
+++ b/scripts/_cli-primitives.mjs
@@ -7,4 +7,4 @@ export {
   parseIssueNumber,
   runChild,
   runCommand,
-} from "@pi-dev-loops/core/cli/primitives";
+} from "../packages/core/src/cli/primitives.mjs";

--- a/scripts/_core-helpers.mjs
+++ b/scripts/_core-helpers.mjs
@@ -6,12 +6,12 @@ export {
   classifyReviewThreadsSignal,
   parseReviewThreads,
   readInput,
-} from "@pi-dev-loops/core/github/review-threads";
+} from "../packages/core/src/github/review-threads.mjs";
 
 export {
   buildPhasePaths,
   readJsonIfExists,
-} from "@pi-dev-loops/core/loop/phase-files";
+} from "../packages/core/src/loop/phase-files.mjs";
 
 export {
   extractReviewCommitSha,
@@ -22,9 +22,9 @@ export {
   summarizeCopilotReviews,
   summarizeGateReviewCommentMarkers,
   summarizeGateReviewComments,
-} from "@pi-dev-loops/core/github/copilot-helpers";
+} from "../packages/core/src/github/copilot-helpers.mjs";
 
 export {
   buildParseError,
   isDirectCliRun,
-} from "@pi-dev-loops/core/cli/helpers";
+} from "../packages/core/src/cli/helpers.mjs";

--- a/scripts/github/capture-review-threads.mjs
+++ b/scripts/github/capture-review-threads.mjs
@@ -9,7 +9,7 @@ import {
   readInput,
 } from "../_core-helpers.mjs";
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 export const REVIEW_THREADS_QUERY = [
   "query($owner: String!, $name: String!, $pr: Int!) {",
   "  repository(owner: $owner, name: $name) {",

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -10,7 +10,7 @@ import {
 } from "../_core-helpers.mjs";
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import { ensureAsyncRunnerOwnership } from "../loop/_pr-runner-coordination.mjs";
 import { detectStaleRunner } from "../loop/_stale-runner-detection.mjs";
 const USAGE = `Usage: detect-checkpoint-evidence.mjs --repo <owner/name> --pr <number>

--- a/scripts/github/detect-linked-issue-pr.mjs
+++ b/scripts/github/detect-linked-issue-pr.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { parseIssueNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 export const LINKED_ISSUE_PR_QUERY = [
   "query($owner:String!, $name:String!, $issue:Int!, $after:String) {",
   "  repository(owner:$owner, name:$name) {",

--- a/scripts/github/manage-sub-issues.mjs
+++ b/scripts/github/manage-sub-issues.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { parsePositiveInteger, requireOptionValue, runChild } from "../_cli-primitives.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 const USAGE = `Usage: manage-sub-issues.mjs <command> --repo <owner/name> --issue <number> [options]
 Deterministic helper for reading, linking, ordering, and verifying GitHub sub-issue trees.
 Commands:

--- a/scripts/github/probe-copilot-review.mjs
+++ b/scripts/github/probe-copilot-review.mjs
@@ -2,11 +2,11 @@
 import { setTimeout as delay } from "node:timers/promises";
 import { buildParseError, formatCliError, isCopilotLogin, isDirectCliRun, parseJsonText, parseReviewThreads } from "../_core-helpers.mjs";
 import { parsePositiveInteger, requireOptionValue, runChild } from "../_cli-primitives.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import {
   DEFAULT_POLL_INTERVAL_MS,
   COPILOT_REVIEW_WAIT_TIMEOUT_MS,
-} from "@pi-dev-loops/core/loop/policy-constants";
+} from "../../packages/core/src/loop/policy-constants.mjs";
 
 /** Maximum interval between heartbeat outputs during watch delays.
  *  Must be shorter than pi-subagents default needsAttentionAfterMs (60s). */

--- a/scripts/github/ready-for-review.mjs
+++ b/scripts/github/ready-for-review.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText, summarizeGateReviewComments, summarizeGateReviewCommentMarkers } from "../_core-helpers.mjs";
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
-import { loadDevLoopConfig, resolveGateConfig } from "@pi-dev-loops/core/config";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
+import { loadDevLoopConfig, resolveGateConfig } from "../../packages/core/src/config/config.mjs";
 
 const USAGE = `Usage: ready-for-review.mjs --repo <owner/name> --pr <number>\nWrapper around gh pr ready that enforces gate-evidence validation.`;
 const parseError = buildParseError(USAGE);

--- a/scripts/github/reconcile-draft-gate.mjs
+++ b/scripts/github/reconcile-draft-gate.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
-import { loadDevLoopConfig, resolveGateConfig } from "@pi-dev-loops/core/config";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { loadDevLoopConfig, resolveGateConfig } from "../../packages/core/src/config/config.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import { detectCheckpointEvidence } from "./detect-checkpoint-evidence.mjs";
 import { upsertCheckpointVerdict } from "./upsert-checkpoint-verdict.mjs";
 const USAGE = `Usage: reconcile-draft-gate.mjs --repo <owner/name> --pr <number>

--- a/scripts/github/reply-resolve-review-thread.mjs
+++ b/scripts/github/reply-resolve-review-thread.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { readFile } from "node:fs/promises";
-import { defineSubcommand, isDirectCliRun } from "@pi-dev-loops/core/cli/subcommand-runner";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { defineSubcommand, isDirectCliRun } from "../../packages/core/src/cli/subcommand-runner.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import {
   replyAndMaybeResolve,
   validateResolutionMessage,

--- a/scripts/github/reply-resolve-review-threads.mjs
+++ b/scripts/github/reply-resolve-review-threads.mjs
@@ -4,7 +4,7 @@ import {
   parsePrNumber,
   requireOptionValue,
 } from "../_cli-primitives.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import {
   authorMatchesFilter,
   captureParsedReviewThreads,

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -9,9 +9,9 @@ import {
 } from "../_core-helpers.mjs";
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
-import { buildSnapshotFromPrFacts, interpretLoopState } from "@pi-dev-loops/core/loop/copilot-loop-state";
-import { loadDevLoopConfig, resolveRefinement } from "@pi-dev-loops/core/config";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
+import { buildSnapshotFromPrFacts, interpretLoopState } from "../../packages/core/src/loop/copilot-loop-state.mjs";
+import { loadDevLoopConfig, resolveRefinement } from "../../packages/core/src/config/config.mjs";
 const BLOCKED_BY_COPILOT_COMMENT_STATUS = "blocked_by_copilot_comment";
 const SUPPRESSED_SAME_HEAD_CLEAN_STATUS = "suppressed_same_head_clean";
 const ROUND_CAP_REACHED_STATUS = "round_cap_reached";

--- a/scripts/github/resolve-tracker-local-spec.mjs
+++ b/scripts/github/resolve-tracker-local-spec.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { parseIssueNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 const ISSUE_JSON_FIELDS = "number,title,body,url,state";
 const USAGE = `Usage: resolve-tracker-local-spec.mjs (--repo <owner/name> --issue <number> | --issue-url <github-issue-url>)
 Resolve the canonical tracker-backed local spec bundle from one GitHub issue reference.

--- a/scripts/github/stage-reviewer-draft.mjs
+++ b/scripts/github/stage-reviewer-draft.mjs
@@ -4,8 +4,8 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { parsePositiveInteger, requireOptionValue } from "../_cli-primitives.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
-import { buildDraftReviewPayload } from "@pi-dev-loops/core/loop/reviewer-loop-state";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
+import { buildDraftReviewPayload } from "../../packages/core/src/loop/reviewer-loop-state.mjs";
 const HELP = `Usage: stage-reviewer-draft.mjs --repo <owner/name> --pr <number> --review-file <path> [--local-state-output <path>]
 Stage a pending draft review on a GitHub pull request.
 Options:

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 import { readFile } from "node:fs/promises";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { loadDevLoopConfig, resolveGateConfig, resolveRefinementConfig } from "@pi-dev-loops/core/config";
+import { loadDevLoopConfig, resolveGateConfig, resolveRefinementConfig } from "../../packages/core/src/config/config.mjs";
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
-import { truncateText } from "@pi-dev-loops/core/bash-exit-one";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { truncateText } from "../../packages/core/src/bash-exit-one.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import { loadPrGateCoordinationContext } from "../loop/detect-pr-gate-coordination-state.mjs";
-import { evaluatePrGateCoordination, PR_CHECKPOINT_ACTION } from "@pi-dev-loops/core/loop/pr-gate-coordination";
-import { STATE } from "@pi-dev-loops/core/loop/copilot-loop-state";
+import { evaluatePrGateCoordination, PR_CHECKPOINT_ACTION } from "../../packages/core/src/loop/pr-gate-coordination.mjs";
+import { STATE } from "../../packages/core/src/loop/copilot-loop-state.mjs";
 import { claimRunnerOwnership } from "../loop/_pr-runner-coordination.mjs";
 import { detectStaleRunner } from "../loop/_stale-runner-detection.mjs";
 import { detectInternalOnly } from "../loop/detect-internal-only-pr.mjs";

--- a/scripts/loop/_handoff-contract.mjs
+++ b/scripts/loop/_handoff-contract.mjs
@@ -1,4 +1,4 @@
-import { PR_CHECKPOINT } from "@pi-dev-loops/core/loop/pr-gate-coordination";
+import { PR_CHECKPOINT } from "../../packages/core/src/loop/pr-gate-coordination.mjs";
 const HANDOFF_OWNERSHIP = Object.freeze({
   SUBAGENT: "subagent",
   PARENT: "parent",

--- a/scripts/loop/_inspect-run-viewer-adapter.mjs
+++ b/scripts/loop/_inspect-run-viewer-adapter.mjs
@@ -1,4 +1,4 @@
-import { parseRepoSlugParts } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlugParts } from "../../packages/core/src/github/repo-slug.mjs";
 import { inspectRun } from "./inspect-run.mjs";
 import { runChild } from "../_cli-primitives.mjs";
 const ASSIGNED_PR_LIST_CACHE_TTL_MS = 15_000;

--- a/scripts/loop/_loop-evidence.mjs
+++ b/scripts/loop/_loop-evidence.mjs
@@ -5,11 +5,11 @@ import { autoDetectReviewerSnapshot } from "./detect-reviewer-loop-state.mjs";
 import {
   interpretLoopState,
   normalizeSnapshot as normalizeCopilotSnapshot,
-} from "@pi-dev-loops/core/loop/copilot-loop-state";
+} from "../../packages/core/src/loop/copilot-loop-state.mjs";
 import {
   interpretReviewerLoopState,
   normalizeReviewerSnapshot,
-} from "@pi-dev-loops/core/loop/reviewer-loop-state";
+} from "../../packages/core/src/loop/reviewer-loop-state.mjs";
 export async function loadCopilotEvidence({ repo, pr, copilotInputPath }, { env = process.env, ghCommand = "gh" } = {}) {
   let snapshot;
   if (copilotInputPath !== undefined) {

--- a/scripts/loop/_pr-runner-coordination.mjs
+++ b/scripts/loop/_pr-runner-coordination.mjs
@@ -1,6 +1,6 @@
 import path from "node:path";
 import process from "node:process";
-import { parseRepoSlugParts } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlugParts } from "../../packages/core/src/github/repo-slug.mjs";
 import {
   loadStateFile as loadSharedStateFile,
   saveStateFile as saveSharedStateFile,

--- a/scripts/loop/_steering-state-file.mjs
+++ b/scripts/loop/_steering-state-file.mjs
@@ -1,7 +1,7 @@
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
-import { parseRepoSlugParts } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlugParts } from "../../packages/core/src/github/repo-slug.mjs";
 const STATE_FILE_LOCK_TIMEOUT_MS = 5000;
 const STATE_FILE_LOCK_RETRY_MS = 50;
 function normalizeRepoSlug(repo) {

--- a/scripts/loop/build-handoff-envelope.mjs
+++ b/scripts/loop/build-handoff-envelope.mjs
@@ -15,13 +15,13 @@
  *   npx dev-loops loop build-envelope --input resolver-output.json
  */
 import { readFile } from "node:fs/promises";
-import { detectRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { detectRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import path from "node:path";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { requireOptionValue } from "../_cli-primitives.mjs";
-import { buildDevLoopHandoffEnvelope } from "@pi-dev-loops/core/loop/handoff-envelope";
-import { loadDevLoopConfig } from "@pi-dev-loops/core/config";
-import { createPiAdapter } from "@pi-dev-loops/core/harness";
+import { buildDevLoopHandoffEnvelope } from "../../packages/core/src/loop/handoff-envelope.mjs";
+import { loadDevLoopConfig } from "../../packages/core/src/config/config.mjs";
+import { createPiAdapter } from "../../packages/core/src/harness/index.mjs";
 
 const USAGE = `Usage: build-handoff-envelope.mjs --input <path>
 Build a deterministic handoff envelope from startup resolver output and settings.

--- a/scripts/loop/checkpoint-contract.mjs
+++ b/scripts/loop/checkpoint-contract.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { defineSubcommand, isDirectCliRun } from "@pi-dev-loops/core/cli/subcommand-runner";
+import { defineSubcommand, isDirectCliRun } from "../../packages/core/src/cli/subcommand-runner.mjs";
 
 const CHECKPOINT_FILE = ".pi/dev-loop-retrospective-checkpoint.json";
 const ALLOWED_STATES = new Set(["required", "complete", "skipped", "none", "missing"]);

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -5,14 +5,14 @@ import os from "node:os";
 import path from "node:path";
 import { runChild, requireOptionValue } from "../_cli-primitives.mjs";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import { autoDetectSnapshot } from "./detect-copilot-loop-state.mjs";
 import {
   buildHandoffContractForResumeAction,
   compareHandoffContracts,
   parseRecordedHandoffContract,
 } from "./_handoff-contract.mjs";
-import { interpretLoopState, summarizeLoopInterpretation } from "@pi-dev-loops/core/loop/copilot-loop-state";
+import { interpretLoopState, summarizeLoopInterpretation } from "../../packages/core/src/loop/copilot-loop-state.mjs";
 const USAGE = `Usage: conductor-monitor.mjs --repo <owner/name> [--auto-resume]
 Aggregate Copilot-loop status across all open PRs in one repo.
 Required:

--- a/scripts/loop/conductor.mjs
+++ b/scripts/loop/conductor.mjs
@@ -3,13 +3,13 @@ import { runConductorCycle } from "./run-conductor-cycle.mjs";
 import { runConductorMonitor } from "./conductor-monitor.mjs";
 import { requireOptionValue } from "../_cli-primitives.mjs";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import {
   loadDevLoopConfig,
   resolveWorkflowConfig,
   resolveAutonomyStopAt,
   resolveGateConfig,
-} from "@pi-dev-loops/core/config";
+} from "../../packages/core/src/config/config.mjs";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 const USAGE = `Usage: conductor.mjs --repo <owner/name> [--auto-resume] [--cycle-only] [--monitor-only] [--require-retrospective]

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -1,24 +1,24 @@
 #!/usr/bin/env node
 import { buildParseError, formatCliError, isCopilotLogin, isDirectCliRun, normalizeTimestamp } from "../_core-helpers.mjs";
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
-import { detectRepoSlug, parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { detectRepoSlug, parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import path from "node:path";
-import { loadDevLoopConfig, resolveRefinement } from "@pi-dev-loops/core/config";
+import { loadDevLoopConfig, resolveRefinement } from "../../packages/core/src/config/config.mjs";
 import { autoDetectSnapshot } from "./detect-copilot-loop-state.mjs";
 import { performCopilotReviewRequest } from "../github/request-copilot-review.mjs";
 import { detectInternalOnly as detectPrInternalOnly } from "./detect-internal-only-pr.mjs";
-import { applyConfirmedReviewRequest, interpretLoopState, NEXT_ACTIONS, STATE, summarizeLoopInterpretation, TRANSITIONS } from "@pi-dev-loops/core/loop/copilot-loop-state";
+import { applyConfirmedReviewRequest, interpretLoopState, NEXT_ACTIONS, STATE, summarizeLoopInterpretation, TRANSITIONS } from "../../packages/core/src/loop/copilot-loop-state.mjs";
 import { ensureAsyncRunnerOwnership } from "./_pr-runner-coordination.mjs";
 
 
 import {
   EXTERNAL_HEALTHY_WAIT_TIMEOUT_POLICY,
   enforceExternalHealthyWaitTimeout,
-} from "@pi-dev-loops/core/loop/timeout-policy";
+} from "../../packages/core/src/loop/timeout-policy.mjs";
 import {
   DEFAULT_POLL_INTERVAL_MS,
   COPILOT_REVIEW_WAIT_TIMEOUT_MS,
-} from "@pi-dev-loops/core/loop/policy-constants";
+} from "../../packages/core/src/loop/policy-constants.mjs";
 const VALID_WATCH_STATUSES = new Set(["changed", "timeout", "idle"]);
 const REMOVED_FLAGS = new Set([
   "--force-rerequest-review",

--- a/scripts/loop/debt-remediate.mjs
+++ b/scripts/loop/debt-remediate.mjs
@@ -18,11 +18,11 @@ import { execFileSync } from "node:child_process";
 
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { requireOptionValue } from "../_cli-primitives.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
-import { DebtSignalSchema } from "@pi-dev-loops/core/debt/signal";
-import { clusterSignalsEnriched } from "@pi-dev-loops/core/debt/cluster";
-import { shapeFindings } from "@pi-dev-loops/core/debt/shape";
-import { createRemediationIssue } from "@pi-dev-loops/core/debt/remediation-to-issue";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
+import { DebtSignalSchema } from "../../packages/core/src/debt/debt-signal.mjs";
+import { clusterSignalsEnriched } from "../../packages/core/src/debt/cluster.mjs";
+import { shapeFindings } from "../../packages/core/src/debt/shape.mjs";
+import { createRemediationIssue } from "../../packages/core/src/debt/remediation-to-issue.mjs";
 
 const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
 

--- a/scripts/loop/detect-copilot-loop-state.mjs
+++ b/scripts/loop/detect-copilot-loop-state.mjs
@@ -13,20 +13,20 @@ import {
   summarizeCopilotReviews,
 } from "../_core-helpers.mjs";
 import { fetchGithubReviewThreadsPayload } from "../github/capture-review-threads.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
-import { loadDevLoopConfig, resolveRefinement } from "@pi-dev-loops/core/config";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
+import { loadDevLoopConfig, resolveRefinement } from "../../packages/core/src/config/config.mjs";
 import {
   buildSnapshotFromPrFacts,
   interpretLoopState,
   normalizeSnapshot,
   summarizeLoopInterpretation,
-} from "@pi-dev-loops/core/loop/copilot-loop-state";
+} from "../../packages/core/src/loop/copilot-loop-state.mjs";
 import {
   normalizeStatusCheckRollupContract,
   summarizeHeadScopedCheckRunsSignal,
   normalizeHeadScopedCommitStatus,
   normalizeHeadScopedCiContract,
-} from "@pi-dev-loops/core/loop/copilot-ci-status";
+} from "../../packages/core/src/loop/copilot-ci-status.mjs";
 const USAGE = `Usage:
   detect-copilot-loop-state.mjs --repo <owner/name> --pr <number>
   detect-copilot-loop-state.mjs --input <path>

--- a/scripts/loop/detect-copilot-session-activity.mjs
+++ b/scripts/loop/detect-copilot-session-activity.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { parsePositiveInteger, requireOptionValue, runChild } from "../_cli-primitives.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 const USAGE = `Usage: detect-copilot-session-activity.mjs --repo <owner/name> --branch <name> [--limit <number>]
 Detect Copilot GitHub Actions session activity on a branch.
 Required:

--- a/scripts/loop/detect-initial-copilot-pr-state.mjs
+++ b/scripts/loop/detect-initial-copilot-pr-state.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { parseIssueNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import { detectLinkedIssuePr } from "../github/detect-linked-issue-pr.mjs";
 import { detectCopilotSessionActivity } from "./detect-copilot-session-activity.mjs";
 const USAGE = `Usage: detect-initial-copilot-pr-state.mjs --repo <owner/name> --issue <number>

--- a/scripts/loop/detect-internal-only-pr.mjs
+++ b/scripts/loop/detect-internal-only-pr.mjs
@@ -4,7 +4,7 @@ import path from "node:path";
 import { parse as parseYaml } from "yaml";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 
 const USAGE = `Usage: detect-internal-only-pr.mjs --repo <owner/name> --pr <number> [--config <path>]
 Detect whether a PR only touches internal tooling files (scripts, docs, tests, config)

--- a/scripts/loop/detect-issue-refinement-artifact.mjs
+++ b/scripts/loop/detect-issue-refinement-artifact.mjs
@@ -2,11 +2,11 @@
 import { readFile } from "node:fs/promises";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { requireOptionValue, runChild } from "../_cli-primitives.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import {
   detectIssueRefinementArtifact,
   REFINEMENT_SOURCE,
-} from "@pi-dev-loops/core/loop/issue-refinement-artifact";
+} from "../../packages/core/src/loop/issue-refinement-artifact.mjs";
 const USAGE = `Usage:
   detect-issue-refinement-artifact.mjs --repo <owner/name> --issue <number>
   detect-issue-refinement-artifact.mjs --input <path>

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -12,10 +12,10 @@ import {
   summarizeCopilotReviews,
 } from "../_core-helpers.mjs";
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
-import { loadDevLoopConfig, resolveGateConfig, resolveRefinementConfig, resolveWorkflowConfig } from "@pi-dev-loops/core/config";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
-import { buildSnapshotFromPrFacts, interpretLoopState, summarizeLoopInterpretation } from "@pi-dev-loops/core/loop/copilot-loop-state";
-import { evaluatePrGateCoordination, PR_CHECKPOINT, PR_CHECKPOINT_ACTION } from "@pi-dev-loops/core/loop/pr-gate-coordination";
+import { loadDevLoopConfig, resolveGateConfig, resolveRefinementConfig, resolveWorkflowConfig } from "../../packages/core/src/config/config.mjs";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
+import { buildSnapshotFromPrFacts, interpretLoopState, summarizeLoopInterpretation } from "../../packages/core/src/loop/copilot-loop-state.mjs";
+import { evaluatePrGateCoordination, PR_CHECKPOINT, PR_CHECKPOINT_ACTION } from "../../packages/core/src/loop/pr-gate-coordination.mjs";
 import { shouldGuardCopilotReviewRequest } from "../../packages/core/src/loop/pr-gate-coordination.mjs";
 import { fetchGithubReviewThreadsPayload } from "../github/capture-review-threads.mjs";
 import { detectCheckpointEvidence } from "../github/detect-checkpoint-evidence.mjs";
@@ -232,7 +232,7 @@ async function loadRefinementArtifact({ repo, prData, prDraft, prClosed, prMerge
       reason: `Failed to fetch body for linked issue #${linkedIssue}; refinement status is unknown.`,
     };
   }
-  const { detectIssueRefinementArtifact } = await import("@pi-dev-loops/core/loop/issue-refinement-artifact");
+  const { detectIssueRefinementArtifact } = await import("../../packages/core/src/loop/issue-refinement-artifact.mjs");
   const artifact = detectIssueRefinementArtifact({ body, issueNumber: linkedIssue });
   return {
     status: artifact.hasACs ? "present" : "missing",

--- a/scripts/loop/detect-reviewer-loop-state.mjs
+++ b/scripts/loop/detect-reviewer-loop-state.mjs
@@ -2,11 +2,11 @@
 import { readFile } from "node:fs/promises";
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import {
   interpretReviewerLoopState,
   normalizeReviewerSnapshot,
-} from "@pi-dev-loops/core/loop/reviewer-loop-state";
+} from "../../packages/core/src/loop/reviewer-loop-state.mjs";
 const HELP = `Usage: detect-reviewer-loop-state.mjs [--input <path> | --repo <owner/name> --pr <number>] [--review-requested <true|false>] [--local-state <path>]
 Detect reviewer loop state for a pull request.
 Modes:

--- a/scripts/loop/detect-stale-runner.mjs
+++ b/scripts/loop/detect-stale-runner.mjs
@@ -2,7 +2,7 @@
 import process from "node:process";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { parsePrNumber, requireOptionValue } from "../_cli-primitives.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import {
   detectStaleRunner,
   STALE_RUNNER_ERROR,

--- a/scripts/loop/detect-tracker-pr-state.mjs
+++ b/scripts/loop/detect-tracker-pr-state.mjs
@@ -7,7 +7,7 @@ import { requireOptionValue } from "../_cli-primitives.mjs";
 import {
   interpretTrackerPrState,
   normalizeTrackerPrSnapshot,
-} from "@pi-dev-loops/core/loop/tracker-pr-state";
+} from "../../packages/core/src/loop/tracker-pr-state.mjs";
 const USAGE = `Usage:
   detect-tracker-pr-state.mjs --input <path>
 Interpret a pre-built tracker-PR snapshot JSON and emit the current lifecycle

--- a/scripts/loop/info.mjs
+++ b/scripts/loop/info.mjs
@@ -4,7 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { requireOptionValue, parsePositiveInteger } from "../_cli-primitives.mjs";
-import { detectRepoSlug, normalizeRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { detectRepoSlug, normalizeRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 
 // REPO_ROOT resolves to the git repo root (scripts/loop/info.mjs → scripts/ → repo/)
 const REPO_ROOT = path.resolve(fileURLToPath(new URL("..", import.meta.url)), "..");

--- a/scripts/loop/inspect-run-viewer/graph.mjs
+++ b/scripts/loop/inspect-run-viewer/graph.mjs
@@ -7,23 +7,23 @@ import {
 import {
   STATE as COPILOT_STATE,
   TRANSITIONS as COPILOT_TRANSITIONS,
-} from "@pi-dev-loops/core/loop/copilot-loop-state";
+} from "../../../packages/core/src/loop/copilot-loop-state.mjs";
 import {
   OUTER_GRAPH,
   OUTER_STATE,
   OUTER_TERMINAL_STATES,
   OUTER_TRANSITIONS,
-} from "@pi-dev-loops/core/loop/conductor-routing";
+} from "../../../packages/core/src/loop/conductor-routing.mjs";
 import {
   REVIEWER_STATE,
   REVIEWER_TRANSITIONS,
-} from "@pi-dev-loops/core/loop/reviewer-loop-state";
+} from "../../../packages/core/src/loop/reviewer-loop-state.mjs";
 import {
   LIFECYCLE_GRAPH,
   LIFECYCLE_STATE,
   LIFECYCLE_TERMINAL_STATES,
   LIFECYCLE_TRANSITIONS,
-} from "@pi-dev-loops/core/loop/lifecycle-state";
+} from "../../../packages/core/src/loop/lifecycle-state.mjs";
 import {
   escapeHtml,
   formatStateToken,

--- a/scripts/loop/inspect-run-viewer/inbox.mjs
+++ b/scripts/loop/inspect-run-viewer/inbox.mjs
@@ -7,7 +7,7 @@ import {
   INBOX_STATE_FILTER_PRESETS,
   INBOX_UPDATED_FILTER_PRESETS,
 } from "./constants.mjs";
-import { dedupeRepoSlugOptions, repoSlugEquals } from "@pi-dev-loops/core/github/repo-slug";
+import { dedupeRepoSlugOptions, repoSlugEquals } from "../../../packages/core/src/github/repo-slug.mjs";
 import {
   escapeHtml,
   formatStateToken,

--- a/scripts/loop/inspect-run-viewer/server.mjs
+++ b/scripts/loop/inspect-run-viewer/server.mjs
@@ -25,9 +25,9 @@ import {
   createInspectionViewerAdapter,
   normalizeInspectionTarget,
 } from "../_inspect-run-viewer-adapter.mjs";
-import { dedupeRepoSlugOptions, repoSlugEquals } from "@pi-dev-loops/core/github/repo-slug";
-import { buildDevLoopHandoffEnvelope } from "@pi-dev-loops/core/loop/handoff-envelope";
-import { loadDevLoopConfig } from "@pi-dev-loops/core/config";
+import { dedupeRepoSlugOptions, repoSlugEquals } from "../../../packages/core/src/github/repo-slug.mjs";
+import { buildDevLoopHandoffEnvelope } from "../../../packages/core/src/loop/handoff-envelope.mjs";
+import { loadDevLoopConfig } from "../../../packages/core/src/config/config.mjs";
 
 const execFile = promisify(execFileCallback);
 

--- a/scripts/loop/inspect-run-viewer/shared.mjs
+++ b/scripts/loop/inspect-run-viewer/shared.mjs
@@ -1,4 +1,4 @@
-import { tryNormalizeRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { tryNormalizeRepoSlug } from "../../../packages/core/src/github/repo-slug.mjs";
 
 export function escapeHtml(value) {
   return String(value)

--- a/scripts/loop/inspect-run-viewer/status.mjs
+++ b/scripts/loop/inspect-run-viewer/status.mjs
@@ -1,4 +1,4 @@
-import { OUTER_STATE } from "@pi-dev-loops/core/loop/conductor-routing";
+import { OUTER_STATE } from "../../../packages/core/src/loop/conductor-routing.mjs";
 
 import {
   escapeHtml,

--- a/scripts/loop/inspect-run.mjs
+++ b/scripts/loop/inspect-run.mjs
@@ -5,22 +5,22 @@ import { fileURLToPath } from "node:url";
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { buildParseError, formatCliError, parseJsonText, parseReviewThreads } from "../_core-helpers.mjs";
 import { fetchGithubReviewThreadsPayload } from "../github/capture-review-threads.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import { readExistingCheckpoint } from "./_checkpoint-io.mjs";
 import { loadCopilotEvidence, loadReviewerEvidence } from "./_loop-evidence.mjs";
-import { interpretOuterLoopState } from "@pi-dev-loops/core/loop/conductor-routing";
+import { interpretOuterLoopState } from "../../packages/core/src/loop/conductor-routing.mjs";
 import {
   composeRunInspectionSnapshot,
   deriveRunIdForInspectionTarget,
-} from "@pi-dev-loops/core/loop/run-inspection";
-import { summarizeCopilotLoopIterations } from "@pi-dev-loops/core/loop/copilot-loop-iterations";
+} from "../../packages/core/src/loop/run-inspection.mjs";
+import { summarizeCopilotLoopIterations } from "../../packages/core/src/loop/copilot-loop-iterations.mjs";
 import {
   classifySafePoint,
   getSteeringStatus,
   normalizeSteeringState,
   resolveEffectiveLoopState,
   STEERING_KIND,
-} from "@pi-dev-loops/core/loop/steering";
+} from "../../packages/core/src/loop/steering.mjs";
 import { validateSteeringStateTarget } from "./_steering-state-file.mjs";
 const USAGE = `Usage: inspect-run.mjs --repo <owner/name> --pr <number>
 Read-only run inspection for the Copilot PR outer-loop family.

--- a/scripts/loop/outer-loop.mjs
+++ b/scripts/loop/outer-loop.mjs
@@ -4,7 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { buildParseError, formatCliError, parseJsonText } from "../_core-helpers.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import {
   buildCheckpointFilePath,
   buildDefaultCheckpointDir,
@@ -17,7 +17,7 @@ import {
   LOOP_FAMILY,
   ROUTING_OUTCOME,
   SOURCE_MODE,
-} from "@pi-dev-loops/core/loop/conductor-routing";
+} from "../../packages/core/src/loop/conductor-routing.mjs";
 import {
   ASYNC_START_STATUS,
   buildAsyncStartRejection,

--- a/scripts/loop/pr-runner-coordination.mjs
+++ b/scripts/loop/pr-runner-coordination.mjs
@@ -2,7 +2,7 @@
 import process from "node:process";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { parsePrNumber, requireOptionValue } from "../_cli-primitives.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import {
   assertRunnerOwnership,
   claimRunnerOwnership,

--- a/scripts/loop/pre-flight-gate.mjs
+++ b/scripts/loop/pre-flight-gate.mjs
@@ -2,7 +2,7 @@
 import { execFileSync } from "node:child_process";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { requireOptionValue } from "../_cli-primitives.mjs";
-import { createPiAdapter } from "@pi-dev-loops/core/harness";
+import { createPiAdapter } from "../../packages/core/src/harness/index.mjs";
 import {
   isUnderWorktreePath,
   parseMainWorktreePath,

--- a/scripts/loop/pre-pr-ready-gate.mjs
+++ b/scripts/loop/pre-pr-ready-gate.mjs
@@ -8,7 +8,7 @@ import {
   summarizeGateReviewCommentMarkers,
 } from "../_core-helpers.mjs";
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 
 const USAGE = `Usage:
   pre-pr-ready-gate.mjs --repo <owner/name> --pr <number>

--- a/scripts/loop/resolve-dev-loop-startup.mjs
+++ b/scripts/loop/resolve-dev-loop-startup.mjs
@@ -18,10 +18,10 @@ import {
   buildAsyncStartRejection,
   ASYNC_START_STATUS,
 } from "../../packages/core/src/loop/async-start-contract.mjs";
-import { detectRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
-import { isCopilotLogin } from "@pi-dev-loops/core/github/copilot-helpers";
+import { detectRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
+import { isCopilotLogin } from "../../packages/core/src/github/copilot-helpers.mjs";
 import { loadDevLoopConfig, resolveWorkflowConfig } from "../../packages/core/src/config/config.mjs";
-import { createPiAdapter } from "@pi-dev-loops/core/harness";
+import { createPiAdapter } from "../../packages/core/src/harness/index.mjs";
 const USAGE = `Usage:
   resolve-dev-loop-startup.mjs --issue <number>
   resolve-dev-loop-startup.mjs --pr <number>

--- a/scripts/loop/run-conductor-cycle.mjs
+++ b/scripts/loop/run-conductor-cycle.mjs
@@ -6,10 +6,10 @@ import {
   isDirectCliRun,
   parseJsonText,
 } from "../_core-helpers.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import { detectPrGateCoordinationState } from "./detect-pr-gate-coordination-state.mjs";
 import { autoDetectSnapshot } from "./detect-copilot-loop-state.mjs";
-import { PR_CHECKPOINT_ACTION } from "@pi-dev-loops/core/loop/pr-gate-coordination";
+import { PR_CHECKPOINT_ACTION } from "../../packages/core/src/loop/pr-gate-coordination.mjs";
 import {
   SUBAGENT_ACTIONS as SHARED_SUBAGENT_ACTIONS,
   buildHandoffContractForConductorAction,

--- a/scripts/loop/run-watch-cycle.mjs
+++ b/scripts/loop/run-watch-cycle.mjs
@@ -2,15 +2,15 @@
 import { spawn } from "node:child_process";
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
-import { DEV_LOOP_CONTRACT_TRACE_CLASSIFICATION } from "@pi-dev-loops/core/loop/public-dev-loop-routing";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
+import { DEV_LOOP_CONTRACT_TRACE_CLASSIFICATION } from "../../packages/core/src/loop/public-dev-loop-routing.mjs";
 import { watchCopilotReview } from "../github/probe-copilot-review.mjs";
 import { runHandoff } from "./copilot-pr-handoff.mjs";
 import { detectCopilotSessionActivity } from "./detect-copilot-session-activity.mjs";
 import {
   EXTERNAL_HEALTHY_WAIT_TIMEOUT_POLICY,
   enforceExternalHealthyWaitTimeout,
-} from "@pi-dev-loops/core/loop/timeout-policy";
+} from "../../packages/core/src/loop/timeout-policy.mjs";
 const REMOVED_FLAGS = new Set([
   "--force-rerequest-review",
   "--probe-only",

--- a/scripts/loop/steer-loop.mjs
+++ b/scripts/loop/steer-loop.mjs
@@ -13,14 +13,14 @@ import {
   promoteQueuedSteering,
   submitSteering,
   getSteeringStatus,
-} from "@pi-dev-loops/core/loop/steering";
-import { STATE } from "@pi-dev-loops/core/loop/copilot-loop-state";
+} from "../../packages/core/src/loop/steering.mjs";
+import { STATE } from "../../packages/core/src/loop/copilot-loop-state.mjs";
 import {
   ACTIVE_STATE_FAMILY,
   deriveRunIdForInspectionTarget,
   SOURCE_MODE,
   TRUST,
-} from "@pi-dev-loops/core/loop/run-inspection";
+} from "../../packages/core/src/loop/run-inspection.mjs";
 import { inspectRun } from "./inspect-run.mjs";
 import {
   defaultStateFilePath,
@@ -32,7 +32,7 @@ import {
 } from "./_steering-state-file.mjs";
 import { formatCliError } from "../_core-helpers.mjs";
 import { requireOptionValue as readSharedOptionValue } from "../_cli-primitives.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 const SUBMIT_USAGE = `Usage:
   steer-loop.mjs submit --repo <owner/name> --pr <number>
     --kind stop_at_next_safe_gate --directive <text> --seq <n>

--- a/scripts/loop/watch-initial-copilot-pr.mjs
+++ b/scripts/loop/watch-initial-copilot-pr.mjs
@@ -3,13 +3,13 @@ import { setTimeout as delay } from "node:timers/promises";
 import { spawn } from "node:child_process";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { parseIssueNumber, requireOptionValue } from "../_cli-primitives.mjs";
-import { parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 import { detectInitialCopilotPrState, LINKED_PR_STATE } from "./detect-initial-copilot-pr-state.mjs";
-import { enforcePersistentInternalWaitTimeout } from "@pi-dev-loops/core/loop/timeout-policy";
+import { enforcePersistentInternalWaitTimeout } from "../../packages/core/src/loop/timeout-policy.mjs";
 import {
   DEFAULT_POLL_INTERVAL_MS,
   COPILOT_FIRST_DURABLE_WAIT_TIMEOUT_MS,
-} from "@pi-dev-loops/core/loop/policy-constants";
+} from "../../packages/core/src/loop/policy-constants.mjs";
 const REMOVED_FLAGS = new Set([
   "--poll-interval-ms",
   "--timeout-ms",

--- a/scripts/refine/_refine-helpers.mjs
+++ b/scripts/refine/_refine-helpers.mjs
@@ -3,7 +3,7 @@ import { readFile } from "node:fs/promises";
 
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { parsePositiveInteger, requireOptionValue, runChild } from "../_cli-primitives.mjs";
-import { detectRepoSlug, parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { detectRepoSlug, parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 
 export const FORBIDDEN_PROSE_PATTERNS = [
   /Child of #/iu,

--- a/scripts/refine/verify.mjs
+++ b/scripts/refine/verify.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { buildParseError, formatCliError } from "../_core-helpers.mjs";
 import { parsePositiveInteger, requireOptionValue } from "../_cli-primitives.mjs";
-import { detectRepoSlug, parseRepoSlug } from "@pi-dev-loops/core/github/repo-slug";
+import { detectRepoSlug, parseRepoSlug } from "../../packages/core/src/github/repo-slug.mjs";
 
 import { isDirectCliRun, loadTreeFromInput, loadTreeOnline } from "./_refine-helpers.mjs";
 import { runProseLinkageDetector } from "./prose-linkage-detector.mjs";

--- a/scripts/repo-wiki-local.mjs
+++ b/scripts/repo-wiki-local.mjs
@@ -16,7 +16,7 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
-import { isDirectCliRun } from "@pi-dev-loops/core/cli/helpers";
+import { isDirectCliRun } from "../packages/core/src/cli/helpers.mjs";
 
 export const REPO_WIKI_GIT_URL = "https://github.com/mfittko/repo-wiki.git";
 export const REPO_WIKI_REF = "d7e772e3d702a75896a6f4eec574a4e4e5bfa6dd";

--- a/scripts/repo-wiki.mjs
+++ b/scripts/repo-wiki.mjs
@@ -7,7 +7,7 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
-import { isDirectCliRun } from "@pi-dev-loops/core/cli/helpers";
+import { isDirectCliRun } from "../packages/core/src/cli/helpers.mjs";
 
 // Pinned to the latest published release at the time this slice was opened.
 // Bump deliberately when the consumer repo wants to adopt a newer release.


### PR DESCRIPTION
## Summary

Adds the npm publish metadata needed to make `dev-loops` publishable, and verifies the packaged tarball can install and run `dev-loops --help` successfully. The actual npm publish and the release workflow will follow in Phase D/E.

Closes #785

## Scope

- `package.json`:
  - `version`: `0.1.0`
  - `files`: explicit allowlist (`cli/`, `lib/`, `scripts/`, `packages/core/src/harness/`, `packages/core/src/cli/`, `README.md`, `CHANGELOG.md`, `LICENSE`)
  - `publishConfig`: `{ "access": "public", "provenance": true }`
  - `repository` / `bugs` / `homepage`: already point to `mfittko/dev-loops` after the Phase A/B rename
  - Removed `private` flag
  - Removed `postinstall` (it assumed a workspace root and failed on consumer installs)
- `cli/index.mjs`: switched `@pi-dev-loops/core/harness` and `../packages/core/src/cli/retry-wrapper.mjs` imports to relative paths so the published tarball resolves them without relying on the unpublished `@pi-dev-loops/core` workspace package.
- Created `CHANGELOG.md` with the initial v0.1.0 entry and the scoped/unscoped name decision.

## AC/DoD matrix

| Item | Type | Status | Evidence |
|---|---|---|---|
| package.json has version 0.1.0 | AC1 | Met | package.json |
| package.json has explicit `files` allowlist | AC1 | Met | package.json |
| package.json has `publishConfig` { access: public, provenance: true } | AC1 | Met | package.json |
| repository/bugs/homepage URLs point to mfittko/dev-loops | AC1 | Met | package.json |
| Scoped vs unscoped decision documented | AC2 | Met | CHANGELOG.md + PR body |
| CHANGELOG.md created with v0.1.0 entry | AC3 | Met | CHANGELOG.md |
| LICENSE present | AC4 | Met | LICENSE |
| `npm pack --dry-run` produces sensible tarball | AC5 | Met | see Validation |
| `npx dev-loops --help` exits 0 after installing packed tarball | AC6 | Met | see Validation |
| Root files do not include packages/core source/tests broadly | AC7 | Met | only CLI-needed harness/cli subdirs included |
| PR merged with metadata + CHANGELOG | DoD | Pending | this PR |
| `npm pack --dry-run` output reviewed and accepted | DoD | Met | see Validation |
| Local tarball install smoke test passes | DoD | Met | see Validation |
| Both gates clean | DoD | Pending | draft → ready → gate review |
| CI green at merge head | DoD | Pending |

## Name decision

- **Primary:** `dev-loops` (unscoped), per confirmed decisions in #788.
- **Fallback:** `@mfittko/dev-loops` if the unscoped name is blocked on npm.

## Non-goals

- Publishing `packages/core` independently (#766).
- Renaming the GitHub repo (Phase A/B).
- Creating the publish workflow (Phase D).
- Cutting the first release (Phase E).
- Adding new external runtime dependencies.

## Validation

```text
$ npm run verify
# all test suites passed (test:assets, test:extension, test:scripts, test:core, test:docs, test:dev-loop)

$ npm pack --dry-run
# package: dev-loops@0.1.0
# package size: 252.6 kB
# unpacked size: 1.1 MB
# total files: 104

$ npm install /path/to/dev-loops-0.1.0.tgz && npx dev-loops --help
# exit 0; help output printed
```

Also ran `npm run repo-wiki:bootstrap` with no regression.
