### PR TITLE
chore: add npm publish metadata for dev-loops v0.1.0 (#785)

### DIFF
--- a/.pi/dev-loop/defaults.yaml
+++ b/.pi/dev-loop/defaults.yaml
@@ -92,7 +92,7 @@ workflow:
 # as `refiner` may also live here so consuming repos can customize prompt text.
 # Consumers can add custom angles or reusable persona prompts.
 # Each entry:
-#   persona      — agent persona name (must exist in .pi/agents/)
+#   persona      — agent persona name (must exist in agents/)
 #   prompt       — focused instruction for the agent
 #   defaultModel — optional model override (null = use persona default)
 personas:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Initial publishable `dev-loops` v0.1.0 package metadata.
+- Primary npm package name is the unscoped `dev-loops` (`@mfittko/dev-loops` kept only as a documented fallback).
 - Public npm provenance and access configuration.
-- `@dev-loops/core` `^0.1.0` dependency for the scoped runtime package.
+- `@dev-loops/core` `^0.1.0` dependency for the extracted scoped runtime package.
 - CLI entrypoint `dev-loops` via `./cli/index.mjs`.
 - Repository, bugs, and homepage URLs pointing to `mfittko/dev-loops`.
+
+### Removed
+
+- Broken `postinstall` lifecycle script that failed on consumer installs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## 0.1.0
+
+### Added
+
+- Initial publishable `dev-loops` v0.1.0 package metadata.
+- Public npm provenance and access configuration.
+- `@dev-loops/core` `^0.1.0` dependency for the scoped runtime package.
+- CLI entrypoint `dev-loops` via `./cli/index.mjs`.
+- Repository, bugs, and homepage URLs pointing to `mfittko/dev-loops`.

--- a/extension/README.md
+++ b/extension/README.md
@@ -7,7 +7,7 @@ Installing the package exposes two thin wrappers over one shared deterministic c
 - the shell CLI entrypoint `dev-loops`
 - a bounded post-merge helper that queues one `pi update git:github.com/mfittko/dev-loops` after a successful in-session `gh pr merge ...` or `git merge ...` inside this repo and flushes it on `agent_end`
 
-Installing the package with `pi install git:github.com/mfittko/dev-loops` exposes the packaged skills through `package.json` `pi.skills`, and the extension syncs packaged agent files (`.pi/agents/*.agent.md`) into `~/.agents/` on `session_start`.
+Installing the package with `pi install git:github.com/mfittko/dev-loops` exposes the packaged skills through `package.json` `pi.skills`, and the extension syncs packaged agent files (`agents/*.agent.md`) into `~/.agents/` on `session_start`.
 
 ## Command surface
 
@@ -196,7 +196,7 @@ workflow:
 
 1. Add the angle name to `gates.draft.angles` or `gates.preApproval.angles`
 2. Add a `personas.<angle>` entry with a `persona` agent name and a `prompt` instruction
-3. Create the corresponding `Agent file` (`.pi/agents/<persona>.agent.md`) if using a new persona
+3. Create the corresponding `Agent file` (`agents/<persona>.agent.md`) if using a new persona
 4. Optionally set a per-angle model override via `models.roles.<angle>`
 
 ### Config format
@@ -211,9 +211,9 @@ Current Phase 3+ contract:
 - Node runtime floor: `>=20` (from `package.json`)
 - Pi host expectations are documented from current peer dependencies rather than a tested pinned Pi version range
 - the extension is source-loaded from `./extension/index.ts` through `package.json` `pi.extensions`
-- the package exposes `.pi/skills` through `package.json` `pi.skills` for install-based global skill loading
+- the package exposes `skills` through `package.json` `pi.skills` for install-based global skill loading
 - the shell CLI is exposed through `package.json` `bin.dev-loops`
-- the extension syncs packaged agent files (`.pi/agents/*.agent.md`) into `~/.agents/` on `session_start` so user-level agents are available outside this repo
+- the extension syncs packaged agent files (`agents/*.agent.md`) into `~/.agents/` on `session_start` so user-level agents are available outside this repo
 - package install/update happens through `pi install` / `pi update`
 - this phase does not yet claim a specific supported `gh` version; it only checks `gh` presence and authentication state
 - this phase does not require a separate compiled build or `dist/` pipeline

--- a/extension/index.ts
+++ b/extension/index.ts
@@ -23,7 +23,7 @@ type ExtensionRuntimeOverrides = NonNullable<Parameters<typeof createExtensionCo
 
 const STATUS_KEY = 'dev-loops';
 const WIDGET_KEY = 'dev-loops.setup';
-const PACKAGED_AGENTS_ROOT = new URL('../.pi/agents/', import.meta.url);
+const PACKAGED_AGENTS_ROOT = new URL('../agents/', import.meta.url);
 
 export function syncPackagedAgents({
   sourceRoot = fileURLToPath(PACKAGED_AGENTS_ROOT),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "dev-loops",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dev-loops",
-      "hasInstallScript": true,
+      "version": "0.1.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -5726,6 +5727,7 @@
     "packages/core": {
       "name": "@dev-loops/core",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "yaml": "^2.9.0",
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     ".pi/dev-loop/defaults.yaml",
     "README.md",
     "CHANGELOG.md",
-    "LICENSE"
+    "LICENSE",
+    "AGENTS.md"
   ],
   "publishConfig": {
     "access": "public",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "dev-loops",
-  "private": true,
   "license": "MIT",
   "type": "module",
   "description": "Shared Pi workflow infrastructure for reusable local and remote development loops",
@@ -29,7 +28,6 @@
     "test:dev-loop": "node --test --test-reporter ./test/failure-summary-reporter.mjs skills/dev-loop/scripts/dev-mode-context.test.mjs skills/dev-loop/scripts/render-template.test.mjs skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs",
     "test:playwright:viewer": "playwright test -c playwright.inspect-run-viewer.config.mjs",
     "test:docs": "node scripts/docs/validate-links.mjs && node scripts/docs/validate-no-duplicate-rules.mjs",
-    "postinstall": "chmod +x cli/index.mjs && ln -sf ../../cli/index.mjs node_modules/.bin/dev-loops",
     "repo-wiki": "node scripts/repo-wiki.mjs",
     "repo-wiki:bootstrap": "node scripts/repo-wiki.mjs scan --repo . && node scripts/repo-wiki.mjs plan --repo . && node scripts/repo-wiki.mjs compile --repo .",
     "repo-wiki:scan": "node scripts/repo-wiki.mjs scan --repo .",
@@ -81,5 +79,17 @@
     "url": "https://github.com/mfittko/dev-loops/issues"
   },
   "homepage": "https://github.com/mfittko/dev-loops#readme",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "files": [
+    "cli/",
+    "lib/",
+    "scripts/",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,10 @@
       "./extension/index.ts"
     ],
     "skills": [
-      ".pi/skills"
+      "skills"
+    ],
+    "agents": [
+      "agents"
     ]
   },
   "dependencies": {
@@ -84,6 +87,10 @@
     "cli/",
     "lib/",
     "scripts/",
+    "extension/",
+    "skills/",
+    "agents/",
+    ".pi/dev-loop/defaults.yaml",
     "README.md",
     "CHANGELOG.md",
     "LICENSE"

--- a/test/contracts/public-facade-doc-contracts.test.mjs
+++ b/test/contracts/public-facade-doc-contracts.test.mjs
@@ -20,8 +20,8 @@ async function readCopilotFollowupSurface() {
 
 test("installed skill guidance owns packaging guarantees and contract docs stay contract-focused", async () => {
   const [devLoopSkill, copilotFollowupSkill, publicContract, retrospectiveContract] = await Promise.all([
-    readRepo(".pi/skills/dev-loop/SKILL.md"),
-    readRepo(".pi/skills/copilot-pr-followup/SKILL.md"),
+    readRepo("skills/dev-loop/SKILL.md"),
+    readRepo("skills/copilot-pr-followup/SKILL.md"),
     readRepo("skills/docs/public-dev-loop-contract.md"),
     readRepo("skills/docs/retrospective-checkpoint-contract.md"),
   ]);

--- a/test/extension-command-contract.test.mjs
+++ b/test/extension-command-contract.test.mjs
@@ -97,7 +97,7 @@ test("extension clears stale footer status and syncs packaged agents on session 
     assert.deepEqual(calls.statuses, [{ key: "dev-loops", text: undefined }]);
     assert.equal(
       await readFile(path.join(tempHome, ".agents", "dev-loop.agent.md"), "utf8"),
-      await readFile(new URL("../.pi/agents/dev-loop.agent.md", import.meta.url), "utf8"),
+      await readFile(new URL("../agents/dev-loop.agent.md", import.meta.url), "utf8"),
     );
     assert.equal(await readFile(path.join(tempHome, ".agents", "keep.txt"), "utf8"), "keep me\n");
     await access(path.join(tempHome, ".agents", "developer.agent.md"));

--- a/test/extension-package-contract.test.mjs
+++ b/test/extension-package-contract.test.mjs
@@ -20,7 +20,8 @@ test("package metadata exposes the extension entrypoint and root extension test 
   assert.match(packageJson.scripts["test:extension"], /extension-command-contract/);
   assert.match(packageJson.scripts["test:extension"], /extension-package-contract/);
   assert.equal(packageJson.dependencies.mermaid, "11.15.0");
-  assert.deepEqual(packageJson.pi.skills, [".pi/skills"]);
+  assert.deepEqual(packageJson.pi.skills, ["skills"]);
+  assert.deepEqual(packageJson.pi.agents, ["agents"]);
 });
 
 test("extension README documents the supported command, install, and verification surfaces without exposing internal workflow seams", async () => {
@@ -46,7 +47,7 @@ test("extension README documents the supported command, install, and verificatio
     /Node[^\n]*>=20/i,
     /source-loaded/i,
     /package\.json` `pi\.skills`/i,
-    /\.pi\/agents\/\*\.agent\.md/i,
+    /agents\/\*\.agent\.md/i,
     /~\/\.agents/i,
     /single public workflow entry/i,
     /npm run verify/i,
@@ -77,12 +78,12 @@ test("required installed runtime contract docs are bundled once in the shared in
   for (const doc of requiredDocs) {
     const [sourceBundledCopy, installedBundledCopy] = await Promise.all([
       readRepo(`skills/docs/${doc}`),
-      readRepo(`.pi/skills/docs/${doc}`),
+      readRepo(`skills/docs/${doc}`),
     ]);
     assert.equal(
       installedBundledCopy,
       sourceBundledCopy,
-      `installed shared docs copy (.pi dev alias: .pi/skills/docs/${doc}) should stay byte-for-byte aligned with skills/docs/${doc}`,
+      `installed shared docs copy (skills/docs/${doc}) should stay byte-for-byte aligned with skills/docs/${doc}`,
     );
     await assert.rejects(stat(fromRepoRoot(`docs/${doc}`)), /ENOENT/);
   }

--- a/test/extension-package-contract.test.mjs
+++ b/test/extension-package-contract.test.mjs
@@ -76,15 +76,9 @@ test("required installed runtime contract docs are bundled once in the shared in
   ];
 
   for (const doc of requiredDocs) {
-    const [sourceBundledCopy, installedBundledCopy] = await Promise.all([
-      readRepo(`skills/docs/${doc}`),
-      readRepo(`skills/docs/${doc}`),
-    ]);
-    assert.equal(
-      installedBundledCopy,
-      sourceBundledCopy,
-      `installed shared docs copy (skills/docs/${doc}) should stay byte-for-byte aligned with skills/docs/${doc}`,
-    );
+    const bundledCopy = await readRepo(`skills/docs/${doc}`);
+    assert.ok(bundledCopy.length > 0, `bundled contract doc skills/docs/${doc} must be present in the installed skills subtree`);
+    assert.doesNotMatch(bundledCopy, /Packaged \/ installed skill use|Packaged \/ installed agent use/i, `skills/docs/${doc} should not restate the shared install contract block`);
     await assert.rejects(stat(fromRepoRoot(`docs/${doc}`)), /ENOENT/);
   }
 


### PR DESCRIPTION
## Summary

Add npm publish metadata to the root `dev-loops` package and wire it to the scoped runtime dependency `@dev-loops/core`.

Closes #785

## AC / DoD matrix

| AC | Requirement | Evidence |
|---|---|---|
| AC1 | `package.json`: version `0.1.0`, name `dev-loops` unscoped, `files` allowlist, `publishConfig` public + provenance, repository/bugs/homepage URLs, `@dev-loops/core: ^0.1.0` dependency | `package.json` |
| AC2 | Primary name `dev-loops` unscoped documented | `README.md` and `extension/README.md` use `dev-loops`; package name stays unscoped |
| AC3 | `CHANGELOG.md` v0.1.0 entry | `CHANGELOG.md` |
| AC4 | `LICENSE` present | `LICENSE` (MIT) |
| AC5 | `npm pack --dry-run` sensible: includes `cli/`, `lib/`, `scripts/`, `extension/`, `skills/`, `agents/`, `.pi/dev-loop/defaults.yaml`, `CHANGELOG`, `README`, `LICENSE`; excludes `node_modules`, `.git`, `.pi/runner-coordination`, `packages/core/src`, tests, source maps | `npm pack --dry-run` output: 155 files / 367.7 kB |
| AC6 | `npx dev-loops --help` from packed tarball exits 0 | Verified with local `@dev-loops/core` tarball (environmental; see notes) |
| AC7 | `cli/index.mjs` uses `@dev-loops/core/*` imports, no relative `packages/core/src` imports | `cli/index.mjs` imports `@dev-loops/core/harness` and `@dev-loops/core/cli/retry-wrapper` |
| AC8 | Postinstall/broken lifecycle scripts removed/verified safe | `postinstall` script removed from `package.json` |

## Validation evidence

- `npm run verify`: pass (all test suites green, run with fresh `PI_SUBAGENT_RUN_ID` to avoid stale-runner false positives)
- `npm pack --dry-run`: passes, tarball includes intended runtime and Pi assets
- Smoke test: `npx dev-loops --help` exits 0 when installed from packed tarballs
- `npm run repo-wiki:bootstrap`: pass

## Notes

- `@dev-loops/core` v0.1.0 is not yet published to the npm registry in this environment. AC6 smoke test was performed by installing both the root tarball and a locally packed `@dev-loops/core` tarball. Once `@dev-loops/core` is published, `npm install <root-tarball>` alone will satisfy AC6.
- npm does not dereference symlinks, so the shipped Pi skill/agent contract was moved from `.pi/skills` and `.pi/agents` symlinks to the real root `skills/` and `agents/` directories. The local `.pi/skills` and `.pi/agents` symlinks are kept for backward compatibility but are no longer referenced by `package.json` `pi` metadata.
- No Phase D publish workflow added in this PR.
