### PR TITLE
feat: gate machinery treats human and Copilot review threads equally (#804)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -45,7 +45,7 @@ Failure behavior:
 
 ### `scripts/github/capture-review-threads.mjs`
 
-Capture and normalize PR review-thread JSON.
+Capture and normalize PR review-thread JSON from all reviewers.
 
 Supported inputs:
 - `--input <path>`
@@ -54,6 +54,9 @@ Supported inputs:
 
 Optional:
 - `--output <path>` writes the same success JSON emitted on stdout
+
+Contract:
+- live capture loads review threads from all reviewers; no author filter is applied
 
 Success output shape:
 - `{ "ok": true, "source": { ... }, "summary": { ... }, "threads": [...], "comments": [...] }`
@@ -280,7 +283,7 @@ Required:
 - `--pr <number>`
 
 Optional:
-- `--author <login>` (default `Copilot`)
+- `--author <login>` (default `all`)
 - exactly one message source: `--message <text>` or stdin
 - `--resolve`
 
@@ -294,7 +297,7 @@ Contract:
 - zero-match runs are deterministic no-ops with success JSON
 
 Success output shape:
-- `{ "ok": true, "repo": "owner/name", "pr": 17, "author": "Copilot", "resolve": true|false, "matchedThreadCount": 2, "repliedThreadCount": 2, "resolvedThreadCount": 2, "skippedThreadCount": 1, "results": [{ "threadId": "...", "commentId": 123, "replyId": 456, "replyUrl": "...", "resolved": true }] }`
+- `{ "ok": true, "repo": "owner/name", "pr": 17, "author": "all", "resolve": true|false, "matchedThreadCount": 2, "repliedThreadCount": 2, "resolvedThreadCount": 2, "skippedThreadCount": 1, "results": [{ "threadId": "...", "commentId": 123, "replyId": 456, "replyUrl": "...", "resolved": true }] }`
 
 Failure behavior:
 - malformed arguments, empty/conflicting message input, malformed thread snapshots, unexpected `gh` failures, reply failures, resolve failures, and failed post-resolve verification emit `{ "ok": false, "error": "..." }` on stderr and exit non-zero

--- a/scripts/github/_review-thread-mutations.mjs
+++ b/scripts/github/_review-thread-mutations.mjs
@@ -207,6 +207,9 @@ export function authorMatchesFilter(commentAuthorLogin, authorFilter) {
   if (normalizedLogin.length === 0 || normalizedFilter.length === 0) {
     return false;
   }
+  if (normalizedFilter.toLowerCase() === "all") {
+    return true;
+  }
   if (normalizedFilter.toLowerCase() === "copilot") {
     return isCopilotLogin(normalizedLogin) || normalizedLogin.toLowerCase() === "copilot";
   }

--- a/scripts/github/reply-resolve-review-threads.mjs
+++ b/scripts/github/reply-resolve-review-threads.mjs
@@ -17,11 +17,11 @@ Required:
   --repo <owner/name>   Repository slug (e.g. owner/repo)
   --pr <number>         Pull request number
 Optional:
-  --author <login>      Match threads containing a comment from this author (default: Copilot)
+  --author <login>      Match threads containing a comment from this author (default: all)
   --message <text>      Reply body text; provide exactly one message source via --message or stdin
   --resolve             Resolve each matched thread after the reply succeeds
 Output (stdout, JSON):
-  { "ok": true, "repo": "owner/name", "pr": 17, "author": "Copilot", "resolve": true,
+  { "ok": true, "repo": "owner/name", "pr": 17, "author": "all", "resolve": true,
     "matchedThreadCount": 2, "repliedThreadCount": 2, "resolvedThreadCount": 2,
     "skippedThreadCount": 1, "results": [{ ... }] }
 Error output (stderr, JSON):
@@ -39,7 +39,7 @@ export function parseReplyResolveThreadsCliArgs(argv) {
     help: false,
     repo: undefined,
     pr: undefined,
-    author: "Copilot",
+    author: "all",
     message: undefined,
     resolve: false,
   };

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -815,6 +815,145 @@ test("buildPreMergeGateCheck passes with zero unresolved threads", () => {
   assert.deepEqual(result.failures, []);
 });
 
+test("detect-checkpoint-evidence fails pre-merge with unresolved human review threads", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-gate-human-unresolved-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
+        stdout: '{"headRefOid":"abc1234"}\n',
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/17/comments?per_page=100"],
+        stdout: JSON.stringify([
+          {
+            id: 90,
+            body: [
+              "Gate review: draft_gate",
+              "Reviewed head SHA: bcd5678",
+              "Verdict: clean",
+              "Findings summary: no issues found",
+              "Next action: mark ready for review",
+            ].join("\n"),
+            updated_at: "2026-05-29T21:00:00Z",
+            html_url: "https://github.com/owner/repo/pull/17#issuecomment-90",
+          },
+          {
+            id: 91,
+            body: [
+              "Gate review: pre_approval_gate",
+              "Reviewed head SHA: abc1234",
+              "Verdict: clean",
+              "Findings summary: no issues found",
+              "Next action: await final human approval",
+            ].join("\n"),
+            updated_at: "2026-05-29T22:00:00Z",
+            html_url: "https://github.com/owner/repo/pull/17#issuecomment-91",
+          },
+        ]) + "\n",
+      },
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: JSON.stringify({
+          data: { repository: { pullRequest: { reviewThreads: { nodes: [
+            {
+              id: "t-human",
+              isResolved: false,
+              comments: {
+                nodes: [
+                  { id: "c-human", databaseId: 5001, body: "human reviewer concern", author: { login: "reviewer", __typename: "User" } },
+                ],
+              },
+            },
+          ] } } } }
+        }) + "\n",
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /Pre-merge gate evidence check failed/i);
+    assert.ok(
+      payload.preMergeGateCheck.failures.some((f) => f.includes("unresolved review threads present")),
+      "expected unresolved thread failure for human-authored thread in " + JSON.stringify(payload.preMergeGateCheck.failures)
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-checkpoint-evidence passes pre-merge when all human review threads are resolved", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-gate-human-resolved-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
+        stdout: '{"headRefOid":"abc1234"}\n',
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/17/comments?per_page=100"],
+        stdout: JSON.stringify([
+          {
+            id: 90,
+            body: [
+              "Gate review: draft_gate",
+              "Reviewed head SHA: bcd5678",
+              "Verdict: clean",
+              "Findings summary: no issues found",
+              "Next action: mark ready for review",
+            ].join("\n"),
+            updated_at: "2026-05-29T21:00:00Z",
+            html_url: "https://github.com/owner/repo/pull/17#issuecomment-90",
+          },
+          {
+            id: 91,
+            body: [
+              "Gate review: pre_approval_gate",
+              "Reviewed head SHA: abc1234",
+              "Verdict: clean",
+              "Findings summary: no issues found",
+              "Next action: await final human approval",
+            ].join("\n"),
+            updated_at: "2026-05-29T22:00:00Z",
+            html_url: "https://github.com/owner/repo/pull/17#issuecomment-91",
+          },
+        ]) + "\n",
+      },
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: JSON.stringify({
+          data: { repository: { pullRequest: { reviewThreads: { nodes: [
+            {
+              id: "t-human",
+              isResolved: true,
+              comments: {
+                nodes: [
+                  { id: "c-human", databaseId: 5001, body: "human reviewer concern", author: { login: "reviewer", __typename: "User" } },
+                ],
+              },
+            },
+          ] } } } }
+        }) + "\n",
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.preMergeGateCheck.ok, true);
+    assert.deepEqual(payload.preMergeGateCheck.failures, []);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 
 test("detect-checkpoint-evidence fails closed when async run no longer owns the PR", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-checkpoint-evidence-ownership-"));

--- a/test/github/reply-resolve-review-threads.test.mjs
+++ b/test/github/reply-resolve-review-threads.test.mjs
@@ -35,7 +35,7 @@ test("parseReplyResolveThreadsCliArgs sets defaults and parses optional flags", 
       help: false,
       repo: "owner/repo",
       pr: 17,
-      author: "Copilot",
+      author: "all",
       message: undefined,
       resolve: false,
     },
@@ -146,7 +146,7 @@ test("reply-resolve-review-threads replies to matching unresolved threads withou
     ]);
 
     const result = await runNode(
-      ["--repo", "owner/repo", "--pr", "17", "--message", "Fixed in 93cd7f8 with enough detail to satisfy the resolution contract."],
+      ["--repo", "owner/repo", "--pr", "17", "--author", "Copilot", "--message", "Fixed in 93cd7f8 with enough detail to satisfy the resolution contract."],
       { env: gh.env },
     );
 
@@ -257,7 +257,7 @@ test("reply-resolve-review-threads resolves matched threads and verifies they st
       ok: true,
       repo: "owner/repo",
       pr: 17,
-      author: "Copilot",
+      author: "all",
       resolve: true,
       matchedThreadCount: 2,
       repliedThreadCount: 2,
@@ -355,7 +355,7 @@ test("reply-resolve-review-threads returns deterministic success when nothing ma
       ok: true,
       repo: "owner/repo",
       pr: 17,
-      author: "Copilot",
+      author: "all",
       resolve: false,
       matchedThreadCount: 0,
       repliedThreadCount: 0,
@@ -437,7 +437,7 @@ test("reply-resolve-review-threads stops on reply failure and reports partial pr
     assert.deepEqual(parsed.partialProgress, {
       repo: "owner/repo",
       pr: 17,
-      author: "Copilot",
+      author: "all",
       resolve: false,
       matchedThreadCount: 2,
       repliedThreadCount: 1,
@@ -504,7 +504,7 @@ test("reply-resolve-review-threads fails closed when post-resolve verification s
     assert.deepEqual(parsed.partialProgress, {
       repo: "owner/repo",
       pr: 17,
-      author: "Copilot",
+      author: "all",
       resolve: true,
       matchedThreadCount: 1,
       repliedThreadCount: 1,
@@ -587,6 +587,160 @@ test("reply-resolve-review-threads preserves leading whitespace from --message",
 
     assert.equal(result.code, 0);
     assert.equal(result.stderr, "");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("reply-resolve-review-threads defaults to all reviewers and processes mixed human + Copilot threads", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-threads-mixed-all-"));
+
+  try {
+    const gh = await writeGhStub(tempDir, [
+      {
+        stdout: createReviewThreadsPayload([
+          {
+            id: "THREAD_1",
+            isResolved: false,
+            comments: {
+              nodes: [
+                { id: "PRRC_node_101", databaseId: 101, body: "copilot note", author: { login: "Copilot", __typename: "Bot" } },
+              ],
+            },
+          },
+          {
+            id: "THREAD_2",
+            isResolved: false,
+            comments: {
+              nodes: [
+                { id: "PRRC_node_201", databaseId: 201, body: "human review note", author: { login: "reviewer", __typename: "User" } },
+              ],
+            },
+          },
+        ]),
+      },
+      {
+        assertArgs: ["api", "-X", "POST", "repos/owner/repo/pulls/17/comments/101/replies", "--input", "-"],
+        stdout: '{"id":1101,"html_url":"https://github.com/owner/repo/pull/17#discussion_r1101"}\n',
+      },
+      {
+        assertArgs: ["api", "-X", "POST", "repos/owner/repo/pulls/17/comments/201/replies", "--input", "-"],
+        stdout: '{"id":1102,"html_url":"https://github.com/owner/repo/pull/17#discussion_r1102"}\n',
+      },
+    ]);
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--message", "Fixed in 93cd7f8 with enough detail to satisfy the resolution contract."],
+      { env: gh.env },
+    );
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.author, "all");
+    assert.equal(parsed.matchedThreadCount, 2);
+    assert.equal(parsed.skippedThreadCount, 0);
+    assert.deepEqual(parsed.results.map((r) => r.commentId).sort(), [101, 201]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("reply-resolve-review-threads filters to human-only unresolved threads with explicit --author", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-threads-human-only-"));
+
+  try {
+    const gh = await writeGhStub(tempDir, [
+      {
+        stdout: createReviewThreadsPayload([
+          {
+            id: "THREAD_1",
+            isResolved: false,
+            comments: {
+              nodes: [
+                { id: "PRRC_node_201", databaseId: 201, body: "human note", author: { login: "reviewer", __typename: "User" } },
+              ],
+            },
+          },
+          {
+            id: "THREAD_2",
+            isResolved: false,
+            comments: {
+              nodes: [
+                { id: "PRRC_node_101", databaseId: 101, body: "copilot note", author: { login: "Copilot", __typename: "Bot" } },
+              ],
+            },
+          },
+        ]),
+      },
+      {
+        assertArgs: ["api", "-X", "POST", "repos/owner/repo/pulls/17/comments/201/replies", "--input", "-"],
+        stdout: '{"id":1201,"html_url":"https://github.com/owner/repo/pull/17#discussion_r1201"}\n',
+      },
+    ]);
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--author", "reviewer", "--message", "Fixed in 93cd7f8 with enough detail to satisfy the resolution contract."],
+      { env: gh.env },
+    );
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.author, "reviewer");
+    assert.equal(parsed.matchedThreadCount, 1);
+    assert.equal(parsed.skippedThreadCount, 1);
+    assert.deepEqual(parsed.results.map((r) => r.commentId), [201]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("reply-resolve-review-threads skips resolved human threads by default", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-threads-human-resolved-"));
+
+  try {
+    const gh = await writeGhStub(tempDir, [
+      {
+        stdout: createReviewThreadsPayload([
+          {
+            id: "THREAD_1",
+            isResolved: true,
+            comments: {
+              nodes: [
+                { id: "PRRC_node_201", databaseId: 201, body: "human resolved note", author: { login: "reviewer", __typename: "User" } },
+              ],
+            },
+          },
+          {
+            id: "THREAD_2",
+            isResolved: false,
+            comments: {
+              nodes: [
+                { id: "PRRC_node_101", databaseId: 101, body: "copilot note", author: { login: "Copilot", __typename: "Bot" } },
+              ],
+            },
+          },
+        ]),
+      },
+      {
+        assertArgs: ["api", "-X", "POST", "repos/owner/repo/pulls/17/comments/101/replies", "--input", "-"],
+        stdout: '{"id":1301,"html_url":"https://github.com/owner/repo/pull/17#discussion_r1301"}\n',
+      },
+    ]);
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--message", "Fixed in 93cd7f8 with enough detail to satisfy the resolution contract."],
+      { env: gh.env },
+    );
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.author, "all");
+    assert.equal(parsed.matchedThreadCount, 1);
+    assert.equal(parsed.skippedThreadCount, 0);
+    assert.deepEqual(parsed.results.map((r) => r.commentId), [101]);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #804

## Summary
The gate machinery now treats unresolved review threads from human reviewers the same as threads from Copilot.

## Changes
- `scripts/github/reply-resolve-review-threads.mjs` defaults to `--author all`, so a single bounded reply/resolve pass covers unresolved threads from any reviewer. Explicit `--author <login>` filtering still works.
- `scripts/github/_review-thread-mutations.mjs` `authorMatchesFilter()` recognizes the `all` sentinel.
- `scripts/README.md` updated to document the new default and the capture contract.
- Tests added for mixed human + Copilot threads, human-only unresolved threads, resolved human threads, and pre-merge gate behavior with human-authored threads.

## AC / DoD matrix
| AC | Status | Evidence |
|---|---|---|
| AC1 — capture loads threads from all reviewers | ✅ | `capture-review-threads.mjs` GraphQL query already fetches `reviewThreads` without author filter; docs now state this explicitly. |
| AC2 — `unresolvedThreadCount` includes human threads | ✅ | `parseReviewThreads()` counts every unresolved thread; tests assert human thread counts block merge. |
| AC3 — feedback resolution handles human threads | ✅ | `reply-resolve-review-threads.mjs` default `all` replies/resolves any unresolved thread. |
| AC4 — `pre_approval_gate` blocks on any unresolved thread | ✅ | `buildPreMergeGateCheck()` and `detect-checkpoint-evidence.mjs` already block on any non-zero unresolved count; tests added. |
| AC5 — tests cover mixed human + Copilot threads | ✅ | New tests in `test/github/reply-resolve-review-threads.test.mjs` and `test/github/detect-checkpoint-evidence.test.mjs`. |
| AC6 — documentation updated | ✅ | `scripts/README.md` updated. |

## Verification
- `npm run verify` passes (all 3,063 tests).
