### PR TITLE
feat(harness): extension-surface HarnessAdapter seam with Pi + Claude adapters (#770)

### DIFF
--- a/extension/checks.ts
+++ b/extension/checks.ts
@@ -41,7 +41,7 @@ async function insideGitRepo(adapter: ExtensionHarnessAdapter): Promise<boolean>
 async function getRepoRoot(adapter: ExtensionHarnessAdapter): Promise<string> {
   const result = await adapter.exec('git rev-parse --show-toplevel', { timeout: 10_000 });
   if (result.code !== 0) {
-    throw new Error('Open Pi inside a git repository before using `/dev-loops inspect`.');
+    throw new Error('Open this session inside a git repository before using `/dev-loops inspect`.');
   }
   const repoRoot = `${result.stdout ?? ''}`.trim();
   if (!repoRoot) {

--- a/extension/checks.ts
+++ b/extension/checks.ts
@@ -1,7 +1,6 @@
-import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
-
 import { collectDevLoopChecks as collectSharedDevLoopChecks, DEV_LOOP_CHECK_IDS } from '../lib/dev-loops-core.mjs';
 import { createInspectRunViewerLifecycleManager } from '../scripts/loop/inspect-run-viewer/managed-instance.mjs';
+import type { ExtensionHarnessAdapter } from './harness-types.ts';
 
 export type DevLoopCheckId = (typeof DEV_LOOP_CHECK_IDS)[number];
 
@@ -12,45 +11,35 @@ export type DevLoopCheck = {
   detail: string;
 };
 
-async function commandExists(pi: ExtensionAPI, command: string): Promise<boolean> {
+async function commandExists(adapter: ExtensionHarnessAdapter, command: string): Promise<boolean> {
   try {
-    const result = await pi.exec('bash', ['-lc', `command -v ${command} >/dev/null 2>&1`], {
-      timeout: 5_000,
-    });
+    const result = await adapter.exec(`command -v ${command} >/dev/null 2>&1`, { timeout: 5_000 });
     return result.code === 0;
   } catch {
     return false;
   }
 }
 
-async function ghAuthOk(pi: ExtensionAPI): Promise<boolean> {
+async function ghAuthOk(adapter: ExtensionHarnessAdapter): Promise<boolean> {
   try {
-    const result = await pi.exec('bash', ['-lc', 'gh auth status >/dev/null 2>&1'], {
-      timeout: 10_000,
-    });
+    const result = await adapter.exec('gh auth status >/dev/null 2>&1', { timeout: 10_000 });
     return result.code === 0;
   } catch {
     return false;
   }
 }
 
-async function insideGitRepo(pi: ExtensionAPI): Promise<boolean> {
+async function insideGitRepo(adapter: ExtensionHarnessAdapter): Promise<boolean> {
   try {
-    const result = await pi.exec(
-      'bash',
-      ['-lc', 'git rev-parse --is-inside-work-tree >/dev/null 2>&1'],
-      { timeout: 5_000 },
-    );
+    const result = await adapter.exec('git rev-parse --is-inside-work-tree >/dev/null 2>&1', { timeout: 5_000 });
     return result.code === 0;
   } catch {
     return false;
   }
 }
 
-async function getRepoRoot(pi: ExtensionAPI): Promise<string> {
-  const result = await pi.exec('bash', ['-lc', 'git rev-parse --show-toplevel'], {
-    timeout: 10_000,
-  });
+async function getRepoRoot(adapter: ExtensionHarnessAdapter): Promise<string> {
+  const result = await adapter.exec('git rev-parse --show-toplevel', { timeout: 10_000 });
   if (result.code !== 0) {
     throw new Error('Open Pi inside a git repository before using `/dev-loops inspect`.');
   }
@@ -62,7 +51,7 @@ async function getRepoRoot(pi: ExtensionAPI): Promise<string> {
 }
 
 export function createExtensionCoreRuntime(
-  pi: ExtensionAPI,
+  adapter: ExtensionHarnessAdapter,
   {
     uiLifecycle = createInspectRunViewerLifecycleManager(),
     getRepoRoot: getRepoRootOverride,
@@ -73,13 +62,13 @@ export function createExtensionCoreRuntime(
 ) {
   return {
     surface: 'extension' as const,
-    commandExists: (command: string) => commandExists(pi, command),
-    ghAuthOk: () => ghAuthOk(pi),
-    insideGitRepo: () => insideGitRepo(pi),
-    getRepoRoot: () => (getRepoRootOverride ? getRepoRootOverride() : getRepoRoot(pi)),
+    commandExists: (command: string) => commandExists(adapter, command),
+    ghAuthOk: () => ghAuthOk(adapter),
+    insideGitRepo: () => insideGitRepo(adapter),
+    getRepoRoot: () => (getRepoRootOverride ? getRepoRootOverride() : getRepoRoot(adapter)),
     uiLifecycle,
     async getSubagentAvailability() {
-      const ok = await commandExists(pi, 'subagent');
+      const ok = await commandExists(adapter, 'subagent');
       return {
         ok,
         availableDetail: '`subagent` command is available.',
@@ -89,6 +78,6 @@ export function createExtensionCoreRuntime(
   };
 }
 
-export async function collectDevLoopChecks(pi: ExtensionAPI): Promise<DevLoopCheck[]> {
-  return collectSharedDevLoopChecks(createExtensionCoreRuntime(pi));
+export async function collectDevLoopChecks(adapter: ExtensionHarnessAdapter): Promise<DevLoopCheck[]> {
+  return collectSharedDevLoopChecks(createExtensionCoreRuntime(adapter));
 }

--- a/extension/harness-types.ts
+++ b/extension/harness-types.ts
@@ -1,0 +1,47 @@
+/**
+ * Neutral, harness-agnostic types for the extension surface.
+ *
+ * These mirror the JSDoc typedefs in
+ * `packages/core/src/harness/extension-adapter.mjs` so the `.ts` extension modules
+ * can share a single import-free type vocabulary. No `@earendil-works/pi-*` import
+ * lives here — that boundary is owned solely by `./pi-extension-adapter.ts`.
+ */
+
+export type HarnessExecResult = {
+  code?: number;
+  stdout?: string;
+  stderr?: string;
+  killed?: boolean;
+};
+
+export type HarnessExecOptions = {
+  cwd?: string;
+  timeout?: number;
+};
+
+export type HarnessUi = {
+  notify(message: string, level?: 'info' | 'warning' | 'error'): void;
+  setWidget(key: string, lines: string[] | undefined, options?: Record<string, unknown>): void;
+  setStatus(key: string, text: string | undefined): void;
+};
+
+export type HarnessContext = {
+  cwd: string;
+  hasUI: boolean;
+  ui: HarnessUi;
+};
+
+export type HarnessLifecycleEvent = 'session_start' | 'tool_result' | 'user_bash' | 'agent_end';
+
+export type HarnessCommandConfig = {
+  description: string;
+  handler: (args: string | string[], ctx: HarnessContext) => unknown;
+};
+
+export type HarnessLifecycleHandler = (event: unknown, ctx: HarnessContext) => unknown;
+
+export type ExtensionHarnessAdapter = {
+  exec(command: string, options?: HarnessExecOptions): Promise<HarnessExecResult>;
+  on(event: HarnessLifecycleEvent, handler: HarnessLifecycleHandler): void;
+  registerCommand(name: string, config: HarnessCommandConfig): void;
+};

--- a/extension/index.ts
+++ b/extension/index.ts
@@ -2,11 +2,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 
 import { executeDevLoopsCommand } from '../lib/dev-loops-core.mjs';
 import { createExtensionCoreRuntime } from './checks.ts';
 import { createPostMergeUpdateHook } from './post-merge-update.ts';
+import { createPiExtensionAdapter, type ExtensionAPI } from './pi-extension-adapter.ts';
 import {
   buildHelpLines,
   buildInspectLines,
@@ -45,9 +45,11 @@ export function syncPackagedAgents({
 }
 
 export default function (pi: ExtensionAPI, runtimeOverrides: ExtensionRuntimeOverrides = {}) {
-  const postMergeUpdateHook = runtimeOverrides.postMergeUpdateHook ?? createPostMergeUpdateHook(pi);
+  // Wrap the Pi harness at the entry boundary; everything below talks to the neutral seam.
+  const adapter = createPiExtensionAdapter(pi);
+  const postMergeUpdateHook = runtimeOverrides.postMergeUpdateHook ?? createPostMergeUpdateHook({ exec: adapter.exec });
 
-  pi.on('session_start', async (_event, ctx) => {
+  adapter.on('session_start', async (_event, ctx) => {
     postMergeUpdateHook.onSessionStart();
     try {
       syncPackagedAgents();
@@ -57,25 +59,25 @@ export default function (pi: ExtensionAPI, runtimeOverrides: ExtensionRuntimeOve
     ctx.ui.setStatus(STATUS_KEY, undefined);
   });
 
-  pi.on('tool_result', async (event, ctx) => {
-    await postMergeUpdateHook.onToolResult(event, ctx);
+  adapter.on('tool_result', async (event, ctx) => {
+    await postMergeUpdateHook.onToolResult(event as Parameters<typeof postMergeUpdateHook.onToolResult>[0], ctx);
   });
 
-  pi.on('user_bash', async (event, ctx) => {
-    return postMergeUpdateHook.onUserBash(event, ctx);
+  adapter.on('user_bash', async (event, ctx) => {
+    return postMergeUpdateHook.onUserBash(event as Parameters<typeof postMergeUpdateHook.onUserBash>[0], ctx);
   });
 
-  pi.on('agent_end', async (event, ctx) => {
+  adapter.on('agent_end', async (event, ctx) => {
     await postMergeUpdateHook.onAgentEnd(event, ctx);
   });
 
-  pi.registerCommand('dev-loops', {
+  adapter.registerCommand('dev-loops', {
     description: 'Manage dev-loops readiness and inspect-run local UI lifecycle: /dev-loops [help|status|doctor|gates|hide|inspect ...]',
     handler: async (args, ctx) => {
       const result = await executeDevLoopsCommand({
         input: args,
         surface: 'extension',
-        runtime: createExtensionCoreRuntime(pi, runtimeOverrides),
+        runtime: createExtensionCoreRuntime(adapter, runtimeOverrides),
       });
 
       switch (result.kind) {

--- a/extension/index.ts
+++ b/extension/index.ts
@@ -60,11 +60,11 @@ export default function (pi: ExtensionAPI, runtimeOverrides: ExtensionRuntimeOve
   });
 
   adapter.on('tool_result', async (event, ctx) => {
-    await postMergeUpdateHook.onToolResult(event as Parameters<typeof postMergeUpdateHook.onToolResult>[0], ctx);
+    await postMergeUpdateHook.onToolResult(event, ctx);
   });
 
   adapter.on('user_bash', async (event, ctx) => {
-    return postMergeUpdateHook.onUserBash(event as Parameters<typeof postMergeUpdateHook.onUserBash>[0], ctx);
+    return postMergeUpdateHook.onUserBash(event, ctx);
   });
 
   adapter.on('agent_end', async (event, ctx) => {

--- a/extension/pi-extension-adapter.ts
+++ b/extension/pi-extension-adapter.ts
@@ -1,0 +1,60 @@
+import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
+
+// Re-exported so the rest of the extension can name the Pi entry type without importing
+// `@earendil-works/pi-*` directly — this module owns that import boundary.
+export type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+
+import type {
+  ExtensionHarnessAdapter,
+  HarnessContext,
+  HarnessCommandConfig,
+  HarnessExecOptions,
+  HarnessLifecycleEvent,
+  HarnessLifecycleHandler,
+} from './harness-types.ts';
+
+/**
+ * The single module allowed to import `@earendil-works/pi-*`.
+ *
+ * Wraps a Pi `ExtensionAPI` into the neutral `ExtensionHarnessAdapter` so the rest of
+ * the extension talks only to the neutral seam. Pi's per-invocation `ExtensionContext`
+ * is converted to a neutral `HarnessContext` at call time, so UI/cwd flow through
+ * unchanged — preserving today's behavior exactly.
+ */
+
+export function toHarnessContext(ctx: Partial<ExtensionContext> | undefined): HarnessContext {
+  const ui = ctx?.ui;
+  return {
+    cwd: (ctx?.cwd as string) ?? process.cwd(),
+    hasUI: Boolean(ctx?.hasUI),
+    ui: {
+      notify: (message, level = 'info') => ui?.notify?.(message, level),
+      setWidget: (key, lines, options) => ui?.setWidget?.(key, lines as never, options as never),
+      setStatus: (key, text) => ui?.setStatus?.(key, text as never),
+    },
+  };
+}
+
+export function createPiExtensionAdapter(pi: ExtensionAPI): ExtensionHarnessAdapter {
+  return {
+    async exec(command: string, options: HarnessExecOptions = {}) {
+      return pi.exec('bash', ['-lc', command], {
+        cwd: options.cwd,
+        timeout: options.timeout,
+      });
+    },
+
+    on(event: HarnessLifecycleEvent, handler: HarnessLifecycleHandler) {
+      pi.on(event as never, (async (piEvent: unknown, piCtx: ExtensionContext) =>
+        handler(piEvent, toHarnessContext(piCtx))) as never);
+    },
+
+    registerCommand(name: string, config: HarnessCommandConfig) {
+      pi.registerCommand(name, {
+        description: config.description,
+        handler: (async (args: string | string[], piCtx: ExtensionContext) =>
+          config.handler(args, toHarnessContext(piCtx))) as never,
+      });
+    },
+  };
+}

--- a/extension/pi-extension-adapter.ts
+++ b/extension/pi-extension-adapter.ts
@@ -1,5 +1,7 @@
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
 
+import { createExtensionHarnessAdapter } from '@dev-loops/core/harness';
+
 // Re-exported so the rest of the extension can name the Pi entry type without importing
 // `@earendil-works/pi-*` directly — this module owns that import boundary.
 export type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
@@ -36,7 +38,9 @@ export function toHarnessContext(ctx: Partial<ExtensionContext> | undefined): Ha
 }
 
 export function createPiExtensionAdapter(pi: ExtensionAPI): ExtensionHarnessAdapter {
-  return {
+  // Route through the shared factory so the Pi adapter gets the same validation + freeze
+  // guarantee as the Claude adapter (symmetric construction across harnesses).
+  return createExtensionHarnessAdapter({
     async exec(command: string, options: HarnessExecOptions = {}) {
       return pi.exec('bash', ['-lc', command], {
         cwd: options.cwd,
@@ -56,5 +60,5 @@ export function createPiExtensionAdapter(pi: ExtensionAPI): ExtensionHarnessAdap
           config.handler(args, toHarnessContext(piCtx))) as never,
       });
     },
-  };
+  }) as ExtensionHarnessAdapter;
 }

--- a/extension/post-merge-update.ts
+++ b/extension/post-merge-update.ts
@@ -1,12 +1,17 @@
-import type {
-  AgentEndEvent,
-  ExecResult,
-  ExtensionAPI,
-  ExtensionContext,
-  ToolResultEvent,
-  UserBashEvent,
-  UserBashEventResult,
-} from '@earendil-works/pi-coding-agent';
+import type { ExtensionHarnessAdapter, HarnessContext, HarnessExecResult } from './harness-types.ts';
+
+// Neutral event shapes the post-merge hook reads. The harness adapter forwards the
+// harness-native event object through unchanged; these capture only the fields used here.
+type ToolResultLike = { toolName?: string; input?: { command?: unknown } | null; isError?: boolean };
+type UserBashLike = { command: string; cwd: string };
+type UserBashResultLike = {
+  result: {
+    output: string;
+    exitCode: number | undefined;
+    cancelled: boolean;
+    truncated: boolean;
+  };
+};
 
 export const TARGET_REPO_SLUG = 'mfittko/dev-loops';
 export const POST_MERGE_UPDATE_COMMAND = 'pi update git:github.com/mfittko/dev-loops';
@@ -31,7 +36,7 @@ type RunCommandArgs = {
   timeout?: number;
 };
 
-type RunCommandResult = ExecResult;
+type RunCommandResult = HarnessExecResult;
 
 type PostMergeUpdateHookState = {
   pendingPostMergeUpdate: boolean;
@@ -40,6 +45,7 @@ type PostMergeUpdateHookState = {
 };
 
 type CreatePostMergeUpdateHookOptions = {
+  exec?: ExtensionHarnessAdapter['exec'];
   resolveRepoContext?: (cwd: string) => Promise<RepoContext>;
   runCommand?: (args: RunCommandArgs) => Promise<RunCommandResult>;
 };
@@ -66,7 +72,7 @@ function buildFailureSummary(result: Pick<RunCommandResult, 'stdout' | 'stderr' 
       : (typeof result.code === 'number' ? `exit code ${result.code}` : 'exit code unavailable'));
 }
 
-function getBashCommandFromToolResult(event: ToolResultEvent): string | null {
+function getBashCommandFromToolResult(event: ToolResultLike): string | null {
   if (event.toolName !== 'bash') {
     return null;
   }
@@ -74,14 +80,14 @@ function getBashCommandFromToolResult(event: ToolResultEvent): string | null {
   return typeof command === 'string' ? command : null;
 }
 
-function notify(ctx: ExtensionContext, message: string, level: 'info' | 'warning' | 'error' = 'info'): void {
+function notify(ctx: Pick<HarnessContext, 'hasUI' | 'ui'>, message: string, level: 'info' | 'warning' | 'error' = 'info'): void {
   if (ctx.hasUI) {
     ctx.ui.notify(message, level);
   }
 }
 
-async function defaultResolveRepoContext(pi: ExtensionAPI, cwd: string): Promise<RepoContext> {
-  const rootResult = await pi.exec('bash', ['-lc', 'git rev-parse --show-toplevel'], {
+async function defaultResolveRepoContext(exec: ExtensionHarnessAdapter['exec'], cwd: string): Promise<RepoContext> {
+  const rootResult = await exec('git rev-parse --show-toplevel', {
     cwd,
     timeout: REPO_RESOLUTION_TIMEOUT_MS,
   });
@@ -94,7 +100,7 @@ async function defaultResolveRepoContext(pi: ExtensionAPI, cwd: string): Promise
     return { repoRoot: null, repoSlug: null };
   }
 
-  const remoteResult = await pi.exec('bash', ['-lc', 'git config --get remote.origin.url'], {
+  const remoteResult = await exec('git config --get remote.origin.url', {
     cwd: repoRoot,
     timeout: REPO_RESOLUTION_TIMEOUT_MS,
   });
@@ -104,12 +110,12 @@ async function defaultResolveRepoContext(pi: ExtensionAPI, cwd: string): Promise
 
   return {
     repoRoot,
-    repoSlug: normalizeGitHubRepoSlug(remoteResult.stdout),
+    repoSlug: normalizeGitHubRepoSlug(remoteResult.stdout ?? ''),
   };
 }
 
-async function defaultRunCommand(pi: ExtensionAPI, args: RunCommandArgs): Promise<RunCommandResult> {
-  return pi.exec('bash', ['-lc', args.command], {
+async function defaultRunCommand(exec: ExtensionHarnessAdapter['exec'], args: RunCommandArgs): Promise<RunCommandResult> {
+  return exec(args.command, {
     cwd: args.cwd,
     timeout: args.timeout,
   });
@@ -303,21 +309,16 @@ export function extractRepoFlagFromGhPrReady(command: string): string | null {
   return null;
 }
 
-export function createPostMergeUpdateHook(
-  piOrOptions: ExtensionAPI | CreatePostMergeUpdateHookOptions,
-  maybeOptions: CreatePostMergeUpdateHookOptions = {},
-) {
-  const hasPiExec = typeof (piOrOptions as ExtensionAPI)?.exec === 'function';
-  const pi = hasPiExec ? piOrOptions as ExtensionAPI : null;
-  const options = hasPiExec ? maybeOptions : (piOrOptions as CreatePostMergeUpdateHookOptions);
+export function createPostMergeUpdateHook(options: CreatePostMergeUpdateHookOptions = {}) {
+  const exec = options.exec ?? null;
 
   const resolveRepoContext = options.resolveRepoContext
-    ?? (pi ? ((cwd: string) => defaultResolveRepoContext(pi, cwd)) : null);
+    ?? (exec ? ((cwd: string) => defaultResolveRepoContext(exec, cwd)) : null);
   const runCommand = options.runCommand
-    ?? (pi ? ((args: RunCommandArgs) => defaultRunCommand(pi, args)) : null);
+    ?? (exec ? ((args: RunCommandArgs) => defaultRunCommand(exec, args)) : null);
 
   if (!resolveRepoContext || !runCommand) {
-    throw new Error('createPostMergeUpdateHook requires an ExtensionAPI or explicit resolveRepoContext/runCommand overrides.');
+    throw new Error('createPostMergeUpdateHook requires an `exec` function or explicit resolveRepoContext/runCommand overrides.');
   }
 
   const state: PostMergeUpdateHookState = {
@@ -341,15 +342,15 @@ export function createPostMergeUpdateHook(
       reset();
     },
 
-    async onToolResult(event: Pick<ToolResultEvent, 'toolName' | 'input' | 'isError'>, ctx: Pick<ExtensionContext, 'cwd'>): Promise<void> {
-      const command = getBashCommandFromToolResult(event as ToolResultEvent);
+    async onToolResult(event: ToolResultLike, ctx: Pick<HarnessContext, 'cwd'>): Promise<void> {
+      const command = getBashCommandFromToolResult(event);
       if (!command || event.isError) {
         return;
       }
       await queueIfEligible(state, resolveRepoContext, command, ctx.cwd);
     },
 
-    async onUserBash(event: Pick<UserBashEvent, 'command' | 'cwd'>, _ctx?: ExtensionContext): Promise<UserBashEventResult | undefined> {
+    async onUserBash(event: UserBashLike, _ctx?: HarnessContext): Promise<UserBashResultLike | undefined> {
       // Intercept gh pr ready before any other checks
       if (isGhPrReadyCommand(event.command)) {
         // Check if the command explicitly targets a different repo via -R/--repo
@@ -477,13 +478,13 @@ export function createPostMergeUpdateHook(
       }
     },
 
-    async onAgentEnd(_event: AgentEndEvent, ctx: Pick<ExtensionContext, 'cwd' | 'hasUI' | 'ui'>): Promise<void> {
+    async onAgentEnd(_event: unknown, ctx: Pick<HarnessContext, 'cwd' | 'hasUI' | 'ui'>): Promise<void> {
       if (!state.pendingPostMergeUpdate || state.updateInFlight) {
         return;
       }
 
       state.updateInFlight = true;
-      notify(ctx as ExtensionContext, `Post-merge update running: ${POST_MERGE_UPDATE_COMMAND}`, 'info');
+      notify(ctx, `Post-merge update running: ${POST_MERGE_UPDATE_COMMAND}`, 'info');
 
       try {
         const result = await runCommand({
@@ -493,17 +494,17 @@ export function createPostMergeUpdateHook(
         });
 
         if (result.code === 0 && !result.killed) {
-          notify(ctx as ExtensionContext, `Post-merge update completed: ${POST_MERGE_UPDATE_COMMAND}`, 'info');
+          notify(ctx, `Post-merge update completed: ${POST_MERGE_UPDATE_COMMAND}`, 'info');
         } else {
           notify(
-            ctx as ExtensionContext,
+            ctx,
             `Post-merge update failed (warning only): ${buildFailureSummary(result)}`,
             'warning',
           );
         }
       } catch (error) {
         const detail = error instanceof Error ? error.message : String(error);
-        notify(ctx as ExtensionContext, `Post-merge update failed (warning only): ${detail}`, 'warning');
+        notify(ctx, `Post-merge update failed (warning only): ${detail}`, 'warning');
       } finally {
         reset();
       }

--- a/extension/post-merge-update.ts
+++ b/extension/post-merge-update.ts
@@ -72,8 +72,8 @@ function buildFailureSummary(result: Pick<RunCommandResult, 'stdout' | 'stderr' 
       : (typeof result.code === 'number' ? `exit code ${result.code}` : 'exit code unavailable'));
 }
 
-function getBashCommandFromToolResult(event: ToolResultLike): string | null {
-  if (event.toolName !== 'bash') {
+function getBashCommandFromToolResult(event: ToolResultLike | null | undefined): string | null {
+  if (!event || event.toolName !== 'bash') {
     return null;
   }
   const command = event.input?.command;
@@ -355,6 +355,11 @@ export function createPostMergeUpdateHook(options: CreatePostMergeUpdateHookOpti
 
     async onUserBash(rawEvent: unknown, _ctx?: HarnessContext): Promise<UserBashResultLike | undefined> {
       const event = rawEvent as UserBashLike;
+      // The seam forwards events as `unknown`; a malformed/foreign-harness event must pass
+      // through untouched rather than crash the handler (downstream calls .trim() on command).
+      if (!event || typeof event.command !== 'string') {
+        return undefined;
+      }
       // Intercept gh pr ready before any other checks
       if (isGhPrReadyCommand(event.command)) {
         // Check if the command explicitly targets a different repo via -R/--repo

--- a/extension/post-merge-update.ts
+++ b/extension/post-merge-update.ts
@@ -342,7 +342,10 @@ export function createPostMergeUpdateHook(options: CreatePostMergeUpdateHookOpti
       reset();
     },
 
-    async onToolResult(event: ToolResultLike, ctx: Pick<HarnessContext, 'cwd'>): Promise<void> {
+    async onToolResult(rawEvent: unknown, ctx: Pick<HarnessContext, 'cwd'>): Promise<void> {
+      // Harness events arrive as `unknown` across the neutral seam; narrow here, at the
+      // single place that knows which fields this hook reads.
+      const event = rawEvent as ToolResultLike;
       const command = getBashCommandFromToolResult(event);
       if (!command || event.isError) {
         return;
@@ -350,7 +353,8 @@ export function createPostMergeUpdateHook(options: CreatePostMergeUpdateHookOpti
       await queueIfEligible(state, resolveRepoContext, command, ctx.cwd);
     },
 
-    async onUserBash(event: UserBashLike, _ctx?: HarnessContext): Promise<UserBashResultLike | undefined> {
+    async onUserBash(rawEvent: unknown, _ctx?: HarnessContext): Promise<UserBashResultLike | undefined> {
+      const event = rawEvent as UserBashLike;
       // Intercept gh pr ready before any other checks
       if (isGhPrReadyCommand(event.command)) {
         // Check if the command explicitly targets a different repo via -R/--repo

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "verify": "npm test && npm run test:dev-loop",
     "test": "npm run test:assets && npm run test:extension && npm run test:scripts && npm run test:core && npm run test:docs",
     "test:assets": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/dev-loop-init-phase-smoke.test.mjs test/contracts/*.test.mjs test/workflow-handoff-contract.test.mjs",
-    "test:extension": "node --import tsx --test --test-reporter ./test/failure-summary-reporter.mjs test/extension-checks.test.mjs test/extension-post-merge-update.test.mjs test/extension-command-contract.test.mjs test/extension-package-contract.test.mjs test/dev-loops-core.test.mjs test/dev-loops-cli.test.mjs",
+    "test:extension": "node --import tsx --test --test-reporter ./test/failure-summary-reporter.mjs test/extension-checks.test.mjs test/extension-post-merge-update.test.mjs test/extension-command-contract.test.mjs test/extension-package-contract.test.mjs test/extension-pi-adapter.test.mjs test/extension-claude-adapter.test.mjs test/dev-loops-core.test.mjs test/dev-loops-cli.test.mjs",
     "test:scripts": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/github/*.test.mjs test/loop/*.test.mjs test/docs/*.test.mjs test/projects/*.test.mjs",
     "test:core": "node --test --test-reporter ./test/failure-summary-reporter.mjs packages/core/test/*.test.mjs",
     "test:dev-loop": "node --test --test-reporter ./test/failure-summary-reporter.mjs skills/dev-loop/scripts/dev-mode-context.test.mjs skills/dev-loop/scripts/render-template.test.mjs skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs",

--- a/packages/core/src/harness/claude-extension-adapter.mjs
+++ b/packages/core/src/harness/claude-extension-adapter.mjs
@@ -48,11 +48,14 @@ export function createClaudeExtensionAdapter({
         },
         (error, stdout, stderr) => {
           if (error) {
+            // Match the documented HarnessExecResult contract: `code` is undefined when
+            // the process was killed (e.g. timeout), mirroring the Pi adapter's shape.
+            const killed = Boolean(error.killed);
             resolve({
-              code: typeof error.code === "number" ? error.code : 1,
+              code: killed ? undefined : (typeof error.code === "number" ? error.code : 1),
               stdout: stdout ?? "",
               stderr: stderr ?? "",
-              killed: Boolean(error.killed),
+              killed,
             });
             return;
           }

--- a/packages/core/src/harness/claude-extension-adapter.mjs
+++ b/packages/core/src/harness/claude-extension-adapter.mjs
@@ -49,7 +49,7 @@ export function createClaudeExtensionAdapter({
         (error, stdout, stderr) => {
           if (error) {
             // Match the documented HarnessExecResult contract: `code` is undefined when
-            // the process was killed (e.g. timeout), mirroring the Pi adapter's shape.
+            // the process was killed (e.g. timeout). Consumers branch on `killed` first.
             const killed = Boolean(error.killed);
             resolve({
               code: killed ? undefined : (typeof error.code === "number" ? error.code : 1),
@@ -89,12 +89,14 @@ export function createClaudeExtensionAdapter({
     },
   });
 
-  return {
+  // Freeze the composite so the validated interface guarantee from the factory carries
+  // through to the returned object (which also exposes the #773 dispatch registries).
+  return Object.freeze({
     exec: adapter.exec,
     on: adapter.on,
     registerCommand: adapter.registerCommand,
     listeners,
     commands,
     makeContext,
-  };
+  });
 }

--- a/packages/core/src/harness/claude-extension-adapter.mjs
+++ b/packages/core/src/harness/claude-extension-adapter.mjs
@@ -1,0 +1,97 @@
+import { execFile } from "node:child_process";
+
+import { createExtensionHarnessAdapter } from "./extension-adapter.mjs";
+
+/**
+ * Create the Claude Code extension-surface adapter.
+ *
+ * Implements the same `ExtensionHarnessAdapter` interface as the Pi adapter so
+ * `executeDevLoopsCommand` and the extension wiring run unchanged under Claude.
+ *
+ * - `exec` shells out via `bash -lc` (Claude has no native exec API in core).
+ * - lifecycle `on(...)` registrations are stored in `listeners` for hook-driven
+ *   dispatch (wired in CA4 / #773); they are not auto-fired here.
+ * - `registerCommand(...)` registrations are stored in `commands`.
+ * - Claude core has no interactive widget/status surface, so the default
+ *   `HarnessContext` reports `hasUI: false` and routes `ui` calls to a sink.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.cwd] - Default cwd for exec and contexts (default: process.cwd()).
+ * @param {NodeJS.ProcessEnv} [options.env] - Env for exec (default: process.env).
+ * @param {(message: string, level: string) => void} [options.onNotify] - Optional sink for
+ *   `ui.notify` (e.g. console). Defaults to a no-op.
+ * @returns {import("./extension-adapter.mjs").ExtensionHarnessAdapter & {
+ *   listeners: Map<string, Function>,
+ *   commands: Map<string, import("./extension-adapter.mjs").HarnessCommandConfig>,
+ *   makeContext: (overrides?: {cwd?: string}) => import("./extension-adapter.mjs").HarnessContext,
+ * }}
+ */
+export function createClaudeExtensionAdapter({
+  cwd = process.cwd(),
+  env = process.env,
+  onNotify = () => {},
+} = {}) {
+  const listeners = new Map();
+  const commands = new Map();
+
+  function exec(command, options = {}) {
+    return new Promise((resolve) => {
+      execFile(
+        "bash",
+        ["-lc", command],
+        {
+          cwd: options.cwd ?? cwd,
+          env,
+          timeout: options.timeout ?? 0,
+          encoding: "utf8",
+          maxBuffer: 64 * 1024 * 1024,
+        },
+        (error, stdout, stderr) => {
+          if (error) {
+            resolve({
+              code: typeof error.code === "number" ? error.code : 1,
+              stdout: stdout ?? "",
+              stderr: stderr ?? "",
+              killed: Boolean(error.killed),
+            });
+            return;
+          }
+          resolve({ code: 0, stdout: stdout ?? "", stderr: stderr ?? "", killed: false });
+        },
+      );
+    });
+  }
+
+  function makeContext({ cwd: ctxCwd } = {}) {
+    return {
+      cwd: ctxCwd ?? cwd,
+      hasUI: false,
+      ui: {
+        notify(message, level = "info") {
+          onNotify(message, level);
+        },
+        setWidget() {},
+        setStatus() {},
+      },
+    };
+  }
+
+  const adapter = createExtensionHarnessAdapter({
+    exec,
+    on(event, handler) {
+      listeners.set(event, handler);
+    },
+    registerCommand(name, config) {
+      commands.set(name, config);
+    },
+  });
+
+  return {
+    exec: adapter.exec,
+    on: adapter.on,
+    registerCommand: adapter.registerCommand,
+    listeners,
+    commands,
+    makeContext,
+  };
+}

--- a/packages/core/src/harness/extension-adapter.mjs
+++ b/packages/core/src/harness/extension-adapter.mjs
@@ -1,0 +1,83 @@
+/**
+ * Extension-surface harness adapter interface.
+ *
+ * Abstracts the *extension surface* that the dev-loops runtime uses today — process
+ * execution, session lifecycle events, slash-command registration, and a UI surface —
+ * so the extension is no longer bound directly to Pi's `ExtensionAPI`/`ExtensionContext`.
+ *
+ * This is distinct from the context seam in `./adapter.mjs` (cwd/env/repo-root): that one
+ * answers "where/how am I running"; this one answers "how do I talk to the harness".
+ *
+ * Concrete adapters (Pi, Claude, test) implement this so call sites stay harness-agnostic.
+ * Keep it minimal — add a method only when a real call site needs it.
+ *
+ * @typedef {Object} HarnessExecResult
+ * @property {number} [code] - Process exit code (undefined when killed).
+ * @property {string} [stdout]
+ * @property {string} [stderr]
+ * @property {boolean} [killed] - Whether the process was killed (e.g. timeout).
+ *
+ * @typedef {Object} HarnessExecOptions
+ * @property {string} [cwd]
+ * @property {number} [timeout] - Timeout in milliseconds.
+ *
+ * @typedef {Object} HarnessUi
+ * @property {(message: string, level?: 'info'|'warning'|'error') => void} notify
+ * @property {(key: string, lines: string[]|undefined, options?: object) => void} setWidget
+ * @property {(key: string, text: string|undefined) => void} setStatus
+ *
+ * @typedef {Object} HarnessContext
+ * @property {string} cwd - Working directory for the current invocation.
+ * @property {boolean} hasUI - Whether an interactive UI surface is attached.
+ * @property {HarnessUi} ui - UI operations for this invocation.
+ *
+ * @typedef {'session_start'|'tool_result'|'user_bash'|'agent_end'} HarnessLifecycleEvent
+ *
+ * @typedef {Object} HarnessCommandConfig
+ * @property {string} description
+ * @property {(args: string|string[], ctx: HarnessContext) => unknown} handler
+ *
+ * @typedef {Object} ExtensionHarnessAdapter
+ * @property {(command: string, options?: HarnessExecOptions) => Promise<HarnessExecResult>} exec
+ * @property {(event: HarnessLifecycleEvent, handler: (event: any, ctx: HarnessContext) => unknown) => void} on
+ * @property {(name: string, config: HarnessCommandConfig) => void} registerCommand
+ */
+
+const REQUIRED_METHODS = ["exec", "on", "registerCommand"];
+
+/**
+ * Validate and freeze an extension-surface harness-adapter implementation.
+ *
+ * @param {Partial<ExtensionHarnessAdapter>} impl
+ * @returns {ExtensionHarnessAdapter}
+ */
+export function createExtensionHarnessAdapter(impl) {
+  if (!impl || typeof impl !== "object") {
+    throw new TypeError("createExtensionHarnessAdapter: impl must be an object");
+  }
+
+  for (const method of REQUIRED_METHODS) {
+    if (typeof impl[method] !== "function") {
+      throw new TypeError(`createExtensionHarnessAdapter: missing required method "${method}"`);
+    }
+  }
+
+  return Object.freeze({
+    exec: impl.exec,
+    on: impl.on,
+    registerCommand: impl.registerCommand,
+  });
+}
+
+/**
+ * Type guard for extension-surface adapter values.
+ *
+ * @param {*} value
+ * @returns {value is ExtensionHarnessAdapter}
+ */
+export function isExtensionHarnessAdapter(value) {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  return REQUIRED_METHODS.every((method) => typeof value[method] === "function");
+}

--- a/packages/core/src/harness/extension-adapter.mjs
+++ b/packages/core/src/harness/extension-adapter.mjs
@@ -39,7 +39,7 @@
  *
  * @typedef {Object} ExtensionHarnessAdapter
  * @property {(command: string, options?: HarnessExecOptions) => Promise<HarnessExecResult>} exec
- * @property {(event: HarnessLifecycleEvent, handler: (event: any, ctx: HarnessContext) => unknown) => void} on
+ * @property {(event: HarnessLifecycleEvent, handler: (event: unknown, ctx: HarnessContext) => unknown) => void} on
  * @property {(name: string, config: HarnessCommandConfig) => void} registerCommand
  */
 
@@ -67,17 +67,4 @@ export function createExtensionHarnessAdapter(impl) {
     on: impl.on,
     registerCommand: impl.registerCommand,
   });
-}
-
-/**
- * Type guard for extension-surface adapter values.
- *
- * @param {*} value
- * @returns {value is ExtensionHarnessAdapter}
- */
-export function isExtensionHarnessAdapter(value) {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  return REQUIRED_METHODS.every((method) => typeof value[method] === "function");
 }

--- a/packages/core/src/harness/index.mjs
+++ b/packages/core/src/harness/index.mjs
@@ -1,8 +1,5 @@
 export { createHarnessAdapter, isHarnessAdapter } from "./adapter.mjs";
 export { createPiAdapter } from "./pi-adapter.mjs";
 export { createNoopAdapter } from "./noop-adapter.mjs";
-export {
-  createExtensionHarnessAdapter,
-  isExtensionHarnessAdapter,
-} from "./extension-adapter.mjs";
+export { createExtensionHarnessAdapter } from "./extension-adapter.mjs";
 export { createClaudeExtensionAdapter } from "./claude-extension-adapter.mjs";

--- a/packages/core/src/harness/index.mjs
+++ b/packages/core/src/harness/index.mjs
@@ -1,3 +1,8 @@
 export { createHarnessAdapter, isHarnessAdapter } from "./adapter.mjs";
 export { createPiAdapter } from "./pi-adapter.mjs";
 export { createNoopAdapter } from "./noop-adapter.mjs";
+export {
+  createExtensionHarnessAdapter,
+  isExtensionHarnessAdapter,
+} from "./extension-adapter.mjs";
+export { createClaudeExtensionAdapter } from "./claude-extension-adapter.mjs";

--- a/packages/core/test/extension-adapter.test.mjs
+++ b/packages/core/test/extension-adapter.test.mjs
@@ -44,6 +44,13 @@ test("claude adapter exec normalizes a non-zero exit without throwing", async ()
   assert.equal(result.killed, false);
 });
 
+test("claude adapter exec reports killed with undefined code on timeout", async () => {
+  const adapter = createClaudeExtensionAdapter();
+  const result = await adapter.exec("sleep 5", { timeout: 50 });
+  assert.equal(result.killed, true);
+  assert.equal(result.code, undefined);
+});
+
 test("claude adapter exec honors cwd", async () => {
   const adapter = createClaudeExtensionAdapter();
   const result = await adapter.exec("pwd", { cwd: "/tmp" });

--- a/packages/core/test/extension-adapter.test.mjs
+++ b/packages/core/test/extension-adapter.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createExtensionHarnessAdapter,
+  isExtensionHarnessAdapter,
+  createClaudeExtensionAdapter,
+} from "../src/harness/index.mjs";
+
+test("createExtensionHarnessAdapter validates required methods", () => {
+  assert.throws(
+    () => createExtensionHarnessAdapter({ exec: () => {}, on: () => {} }),
+    /missing required method "registerCommand"/,
+  );
+  assert.throws(() => createExtensionHarnessAdapter(null), /impl must be an object/);
+  assert.throws(() => createExtensionHarnessAdapter("nope"), /impl must be an object/);
+});
+
+test("createExtensionHarnessAdapter freezes the returned adapter", () => {
+  const adapter = createExtensionHarnessAdapter({ exec: async () => ({ code: 0 }), on: () => {}, registerCommand: () => {} });
+  assert.throws(() => { adapter.exec = () => {}; }, TypeError);
+});
+
+test("isExtensionHarnessAdapter recognizes complete adapters", () => {
+  const adapter = createClaudeExtensionAdapter();
+  assert.equal(isExtensionHarnessAdapter(adapter), true);
+  assert.equal(isExtensionHarnessAdapter({ exec: () => {} }), false);
+  assert.equal(isExtensionHarnessAdapter(null), false);
+  assert.equal(isExtensionHarnessAdapter("adapter"), false);
+});
+
+test("claude adapter exec runs a real command and normalizes success", async () => {
+  const adapter = createClaudeExtensionAdapter();
+  const result = await adapter.exec("printf hello");
+  assert.equal(result.code, 0);
+  assert.equal(result.stdout, "hello");
+  assert.equal(result.killed, false);
+});
+
+test("claude adapter exec normalizes a non-zero exit without throwing", async () => {
+  const adapter = createClaudeExtensionAdapter();
+  const result = await adapter.exec("exit 3");
+  assert.equal(result.code, 3);
+  assert.equal(result.killed, false);
+});
+
+test("claude adapter exec honors cwd", async () => {
+  const adapter = createClaudeExtensionAdapter();
+  const result = await adapter.exec("pwd", { cwd: "/tmp" });
+  assert.equal(result.code, 0);
+  // macOS reports /tmp as /private/tmp via pwd -P; accept either.
+  assert.match(result.stdout.trim(), /\/tmp$/);
+});
+
+test("claude adapter stores lifecycle and command registrations", () => {
+  const adapter = createClaudeExtensionAdapter();
+  const handler = () => {};
+  adapter.on("session_start", handler);
+  adapter.registerCommand("dev-loops", { description: "d", handler });
+
+  assert.equal(adapter.listeners.get("session_start"), handler);
+  assert.equal(adapter.commands.get("dev-loops").handler, handler);
+});
+
+test("claude adapter context reports no UI and routes notify to a sink", () => {
+  const notes = [];
+  const adapter = createClaudeExtensionAdapter({ cwd: "/work", onNotify: (m, l) => notes.push([m, l]) });
+  const ctx = adapter.makeContext();
+
+  assert.equal(ctx.cwd, "/work");
+  assert.equal(ctx.hasUI, false);
+  ctx.ui.notify("hi", "warning");
+  ctx.ui.setWidget("k", ["line"]); // no-op, should not throw
+  ctx.ui.setStatus("k", "t"); // no-op, should not throw
+  assert.deepEqual(notes, [["hi", "warning"]]);
+
+  assert.equal(adapter.makeContext({ cwd: "/other" }).cwd, "/other");
+});

--- a/packages/core/test/extension-adapter.test.mjs
+++ b/packages/core/test/extension-adapter.test.mjs
@@ -3,7 +3,6 @@ import test from "node:test";
 
 import {
   createExtensionHarnessAdapter,
-  isExtensionHarnessAdapter,
   createClaudeExtensionAdapter,
 } from "../src/harness/index.mjs";
 
@@ -21,12 +20,12 @@ test("createExtensionHarnessAdapter freezes the returned adapter", () => {
   assert.throws(() => { adapter.exec = () => {}; }, TypeError);
 });
 
-test("isExtensionHarnessAdapter recognizes complete adapters", () => {
+test("claude adapter exposes the interface methods and is frozen", () => {
   const adapter = createClaudeExtensionAdapter();
-  assert.equal(isExtensionHarnessAdapter(adapter), true);
-  assert.equal(isExtensionHarnessAdapter({ exec: () => {} }), false);
-  assert.equal(isExtensionHarnessAdapter(null), false);
-  assert.equal(isExtensionHarnessAdapter("adapter"), false);
+  assert.equal(typeof adapter.exec, "function");
+  assert.equal(typeof adapter.on, "function");
+  assert.equal(typeof adapter.registerCommand, "function");
+  assert.throws(() => { adapter.exec = () => {}; }, TypeError);
 });
 
 test("claude adapter exec runs a real command and normalizes success", async () => {

--- a/test/contracts/harness-pi-import-boundary.test.mjs
+++ b/test/contracts/harness-pi-import-boundary.test.mjs
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// CA1 (#770) import boundary: only the dedicated Pi adapter module may import
+// `@earendil-works/pi-*`. Every other extension / core-harness source must talk to the
+// neutral seam. peerDependencies in package.json are not source imports and are exempt.
+
+const repoRoot = path.resolve(fileURLToPath(new URL("../../", import.meta.url)));
+
+const SCAN_DIRS = ["extension", "packages/core/src/harness"];
+const ALLOWED = new Set([path.join("extension", "pi-extension-adapter.ts")]);
+const PI_IMPORT_RE = /from\s+['"]@earendil-works\/pi-[^'"]+['"]|import\(['"]@earendil-works\/pi-/;
+
+async function collectSourceFiles(dir) {
+  const abs = path.join(repoRoot, dir);
+  const out = [];
+  let entries;
+  try {
+    entries = await readdir(abs, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const rel = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...(await collectSourceFiles(rel)));
+    } else if (/\.(ts|mjs|js)$/.test(entry.name)) {
+      out.push(rel);
+    }
+  }
+  return out;
+}
+
+test("only pi-extension-adapter.ts imports @earendil-works/pi-*", async () => {
+  const files = (await Promise.all(SCAN_DIRS.map(collectSourceFiles))).flat();
+  assert.ok(files.length > 0, "expected to scan some source files");
+
+  const offenders = [];
+  for (const rel of files) {
+    if (ALLOWED.has(rel)) continue;
+    const content = await readFile(path.join(repoRoot, rel), "utf8");
+    if (PI_IMPORT_RE.test(content)) {
+      offenders.push(rel);
+    }
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `These modules import @earendil-works/pi-* outside the dedicated Pi adapter: ${offenders.join(", ")}`,
+  );
+});
+
+test("the dedicated Pi adapter module still owns the Pi import", async () => {
+  const content = await readFile(path.join(repoRoot, "extension/pi-extension-adapter.ts"), "utf8");
+  assert.match(content, /@earendil-works\/pi-coding-agent/);
+});

--- a/test/contracts/harness-pi-import-boundary.test.mjs
+++ b/test/contracts/harness-pi-import-boundary.test.mjs
@@ -18,7 +18,19 @@ const repoRoot = path.resolve(fileURLToPath(new URL("../../", import.meta.url)))
 
 const SCAN_DIRS = ["extension", "packages/core/src/harness"];
 const ALLOWED = new Set([path.join("extension", "pi-extension-adapter.ts")]);
-const PI_IMPORT_RE = /from\s+['"]@earendil-works\/pi-[^'"]+['"]|import\(['"]@earendil-works\/pi-/;
+
+// Detect a real ESM import of `@earendil-works/pi-*`, covering all three forms:
+//   static:       import ... from '@earendil-works/pi-x'
+//   side-effect:  import '@earendil-works/pi-x'
+//   dynamic:      import('@earendil-works/pi-x')
+// Requires the `import`/`from` keyword immediately before the specifier so prose mentions
+// of the module name in comments/strings are not false positives.
+const PI_STATIC_OR_SIDE_EFFECT_RE = /\b(?:from|import)\s+['"]@earendil-works\/pi-[^'"]+['"]/;
+const PI_DYNAMIC_RE = /\bimport\(\s*['"]@earendil-works\/pi-/;
+
+function importsPiHarness(content) {
+  return PI_STATIC_OR_SIDE_EFFECT_RE.test(content) || PI_DYNAMIC_RE.test(content);
+}
 
 async function collectSourceFiles(dir) {
   const abs = path.join(repoRoot, dir);
@@ -48,7 +60,7 @@ test("within the neutral extension runtime + core harness, only pi-extension-ada
   for (const rel of files) {
     if (ALLOWED.has(rel)) continue;
     const content = await readFile(path.join(repoRoot, rel), "utf8");
-    if (PI_IMPORT_RE.test(content)) {
+    if (importsPiHarness(content)) {
       offenders.push(rel);
     }
   }
@@ -58,6 +70,17 @@ test("within the neutral extension runtime + core harness, only pi-extension-ada
     [],
     `These modules import @earendil-works/pi-* outside the dedicated Pi adapter: ${offenders.join(", ")}`,
   );
+});
+
+test("importsPiHarness detects static, side-effect, and dynamic Pi imports without prose false positives", () => {
+  assert.equal(importsPiHarness("import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';"), true);
+  assert.equal(importsPiHarness('import { x } from "@earendil-works/pi-tui";'), true);
+  assert.equal(importsPiHarness("import '@earendil-works/pi-coding-agent';"), true, "side-effect import must be caught");
+  assert.equal(importsPiHarness('import "@earendil-works/pi-coding-agent";'), true);
+  assert.equal(importsPiHarness("await import('@earendil-works/pi-coding-agent');"), true, "dynamic import must be caught");
+  // Prose mentions must NOT trip the detector.
+  assert.equal(importsPiHarness("// No `@earendil-works/pi-*` import lives here."), false);
+  assert.equal(importsPiHarness("a string with @earendil-works/pi-coding-agent in it"), false);
 });
 
 test("the dedicated Pi adapter module still owns the Pi import", async () => {

--- a/test/contracts/harness-pi-import-boundary.test.mjs
+++ b/test/contracts/harness-pi-import-boundary.test.mjs
@@ -4,9 +4,15 @@ import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-// CA1 (#770) import boundary: only the dedicated Pi adapter module may import
-// `@earendil-works/pi-*`. Every other extension / core-harness source must talk to the
-// neutral seam. peerDependencies in package.json are not source imports and are exempt.
+// CA1 (#770) import boundary. The seam this slice introduces covers the *neutral extension
+// runtime* (`extension/`) and the *core harness* (`packages/core/src/harness`): within those
+// trees only the dedicated Pi adapter module (`extension/pi-extension-adapter.ts`) may import
+// `@earendil-works/pi-*`. Everything else there must talk to the neutral seam.
+//
+// Out of scope by design: `.pi/extensions/` holds standalone Pi-native extensions (e.g.
+// `dev-loop-behavioral-review.ts`) that are inherently coupled to the Pi harness and are not
+// part of the neutral runtime — they are intentionally NOT covered by this boundary.
+// peerDependencies in package.json are not source imports and are exempt.
 
 const repoRoot = path.resolve(fileURLToPath(new URL("../../", import.meta.url)));
 
@@ -34,7 +40,7 @@ async function collectSourceFiles(dir) {
   return out;
 }
 
-test("only pi-extension-adapter.ts imports @earendil-works/pi-*", async () => {
+test("within the neutral extension runtime + core harness, only pi-extension-adapter.ts imports @earendil-works/pi-*", async () => {
   const files = (await Promise.all(SCAN_DIRS.map(collectSourceFiles))).flat();
   assert.ok(files.length > 0, "expected to scan some source files");
 
@@ -57,4 +63,17 @@ test("only pi-extension-adapter.ts imports @earendil-works/pi-*", async () => {
 test("the dedicated Pi adapter module still owns the Pi import", async () => {
   const content = await readFile(path.join(repoRoot, "extension/pi-extension-adapter.ts"), "utf8");
   assert.match(content, /@earendil-works\/pi-coding-agent/);
+});
+
+test("`.pi/extensions/` is a Pi-native surface intentionally outside this boundary", async () => {
+  // Documents the known exemption so a reader does not mistake the scoped boundary above
+  // for a repo-wide one. This standalone Pi extension legitimately imports the Pi harness.
+  const piNativeExtension = path.join(repoRoot, ".pi/extensions/dev-loop-behavioral-review.ts");
+  const content = await readFile(piNativeExtension, "utf8").catch(() => null);
+  if (content === null) return; // tolerate absence in trimmed/published trees
+  assert.match(content, /@earendil-works\/pi-coding-agent/, "expected the documented Pi-native extension to import Pi");
+  assert.ok(
+    !SCAN_DIRS.some((dir) => path.join(repoRoot, ".pi/extensions/dev-loop-behavioral-review.ts").startsWith(path.join(repoRoot, dir) + path.sep)),
+    ".pi/extensions/ must remain outside the scanned trees",
+  );
 });

--- a/test/extension-checks.test.mjs
+++ b/test/extension-checks.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { collectDevLoopChecks } from "../extension/checks.ts";
+import { createPiExtensionAdapter } from "../extension/pi-extension-adapter.ts";
 import { renderCheckLines, summarizeChecks } from "../lib/dev-loops-core.mjs";
 
 function createFakePi({ commandResults = new Map(), tools = [], commands = [] } = {}) {
@@ -25,9 +26,15 @@ function createFakePi({ commandResults = new Map(), tools = [], commands = [] } 
   };
 }
 
+// collectDevLoopChecks now consumes the neutral extension adapter; wrap the Pi double
+// through the Pi adapter so the de-facto command->result mapping is exercised end to end.
+function createFakeAdapter(options) {
+  return createPiExtensionAdapter(createFakePi(options));
+}
+
 test("collectDevLoopChecks returns stable ordering and pass/fail detail", async () => {
   const checks = await collectDevLoopChecks(
-    createFakePi({
+    createFakeAdapter({
       commandResults: new Map([
         ["command -v gh >/dev/null 2>&1", 0],
         ["gh auth status >/dev/null 2>&1", 0],
@@ -51,14 +58,15 @@ test("collectDevLoopChecks returns stable ordering and pass/fail detail", async 
 });
 
 test("collectDevLoopChecks distinguishes missing gh from missing gh auth", async () => {
-  const missingGhChecks = await collectDevLoopChecks(createFakePi());
+  const missingGhChecks = await collectDevLoopChecks(
+    createFakeAdapter());
   assert.equal(missingGhChecks[0].ok, false);
   assert.match(missingGhChecks[0].detail, /Install GitHub CLI/);
   assert.equal(missingGhChecks[1].ok, false);
   assert.equal(missingGhChecks[1].detail, "GitHub CLI is not installed yet.");
 
   const missingAuthChecks = await collectDevLoopChecks(
-    createFakePi({
+    createFakeAdapter({
       commandResults: new Map([
         ["command -v gh >/dev/null 2>&1", 0],
         ["gh auth status >/dev/null 2>&1", 1],
@@ -72,7 +80,7 @@ test("collectDevLoopChecks distinguishes missing gh from missing gh auth", async
 
 test("collectDevLoopChecks uses subagent command availability for discoverability checks", async () => {
   const checks = await collectDevLoopChecks(
-    createFakePi({
+    createFakeAdapter({
       commandResults: new Map([["command -v subagent >/dev/null 2>&1", 0]]),
     }),
   );

--- a/test/extension-claude-adapter.test.mjs
+++ b/test/extension-claude-adapter.test.mjs
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createClaudeExtensionAdapter } from "@dev-loops/core/harness";
+
+import { createExtensionCoreRuntime } from "../extension/checks.ts";
+import { executeDevLoopsCommand } from "../lib/dev-loops-core.mjs";
+
+// CA1 acceptance: executeDevLoopsCommand runs unchanged against a runtime built from the
+// Claude adapter (same interface as the Pi adapter), proving the seam is harness-neutral.
+
+test("executeDevLoopsCommand resolves help against the Claude adapter runtime", async () => {
+  const adapter = createClaudeExtensionAdapter();
+  const result = await executeDevLoopsCommand({
+    input: "help",
+    surface: "extension",
+    runtime: createExtensionCoreRuntime(adapter),
+  });
+  assert.equal(result.kind, "help");
+});
+
+test("executeDevLoopsCommand resolves status checks against the Claude adapter runtime", async () => {
+  const adapter = createClaudeExtensionAdapter();
+  const result = await executeDevLoopsCommand({
+    input: "status",
+    surface: "extension",
+    runtime: createExtensionCoreRuntime(adapter),
+  });
+
+  assert.equal(result.kind, "checks");
+  assert.equal(result.action, "status");
+  assert.deepEqual(
+    result.checks.map((c) => c.id),
+    ["gh-installed", "gh-auth", "subagent-command", "git-repo"],
+  );
+  // Every check has a boolean ok + non-empty detail regardless of host environment.
+  for (const check of result.checks) {
+    assert.equal(typeof check.ok, "boolean");
+    assert.ok(check.detail.length > 0);
+  }
+});

--- a/test/extension-pi-adapter.test.mjs
+++ b/test/extension-pi-adapter.test.mjs
@@ -24,6 +24,14 @@ function createPiDouble() {
   };
 }
 
+test("pi adapter is validated and frozen via the shared factory", () => {
+  const adapter = createPiExtensionAdapter(createPiDouble());
+  assert.equal(typeof adapter.exec, "function");
+  assert.equal(typeof adapter.on, "function");
+  assert.equal(typeof adapter.registerCommand, "function");
+  assert.throws(() => { adapter.exec = () => {}; }, TypeError);
+});
+
 test("pi adapter exec maps a command string to pi.exec('bash', ['-lc', cmd], opts)", async () => {
   const pi = createPiDouble();
   const adapter = createPiExtensionAdapter(pi);

--- a/test/extension-pi-adapter.test.mjs
+++ b/test/extension-pi-adapter.test.mjs
@@ -1,0 +1,101 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createPiExtensionAdapter, toHarnessContext } from "../extension/pi-extension-adapter.ts";
+
+function createPiDouble() {
+  const events = new Map();
+  const commands = new Map();
+  const execCalls = [];
+  return {
+    async exec(tool, args, opts) {
+      execCalls.push({ tool, args, opts });
+      return { code: 0, stdout: "out", stderr: "", killed: false };
+    },
+    on(event, handler) {
+      events.set(event, handler);
+    },
+    registerCommand(name, config) {
+      commands.set(name, config);
+    },
+    events,
+    commands,
+    execCalls,
+  };
+}
+
+test("pi adapter exec maps a command string to pi.exec('bash', ['-lc', cmd], opts)", async () => {
+  const pi = createPiDouble();
+  const adapter = createPiExtensionAdapter(pi);
+  const result = await adapter.exec("echo hi", { cwd: "/w", timeout: 1234 });
+
+  assert.deepEqual(result, { code: 0, stdout: "out", stderr: "", killed: false });
+  assert.deepEqual(pi.execCalls[0], {
+    tool: "bash",
+    args: ["-lc", "echo hi"],
+    opts: { cwd: "/w", timeout: 1234 },
+  });
+});
+
+test("pi adapter on(...) forwards to pi.on and maps ctx to a HarnessContext", async () => {
+  const pi = createPiDouble();
+  const adapter = createPiExtensionAdapter(pi);
+
+  let seen = null;
+  adapter.on("session_start", (event, ctx) => {
+    seen = { event, ctx };
+    ctx.ui.setStatus("dev-loops", undefined);
+  });
+
+  const statuses = [];
+  const piCtx = { cwd: "/repo", hasUI: true, ui: { setStatus: (k, t) => statuses.push({ k, t }) } };
+  await pi.events.get("session_start")({ kind: "session_start" }, piCtx);
+
+  assert.deepEqual(seen.event, { kind: "session_start" });
+  assert.equal(seen.ctx.cwd, "/repo");
+  assert.equal(seen.ctx.hasUI, true);
+  assert.deepEqual(statuses, [{ k: "dev-loops", t: undefined }]);
+});
+
+test("pi adapter user_bash handler return value propagates back through pi.on", async () => {
+  const pi = createPiDouble();
+  const adapter = createPiExtensionAdapter(pi);
+
+  adapter.on("user_bash", async () => ({ result: { output: "blocked", exitCode: 1 } }));
+
+  const piCtx = { cwd: "/repo", hasUI: false, ui: {} };
+  const returned = await pi.events.get("user_bash")({ command: "gh pr ready", cwd: "/repo" }, piCtx);
+  assert.deepEqual(returned, { result: { output: "blocked", exitCode: 1 } });
+});
+
+test("pi adapter registerCommand forwards name/description and wraps the handler", async () => {
+  const pi = createPiDouble();
+  const adapter = createPiExtensionAdapter(pi);
+
+  let received = null;
+  adapter.registerCommand("dev-loops", {
+    description: "desc",
+    handler: (args, ctx) => {
+      received = { args, hasUI: ctx.hasUI };
+      ctx.ui.notify("hello", "info");
+    },
+  });
+
+  const registered = pi.commands.get("dev-loops");
+  assert.equal(registered.description, "desc");
+
+  const notes = [];
+  await registered.handler("status", { cwd: "/r", hasUI: true, ui: { notify: (m, l) => notes.push({ m, l }) } });
+  assert.deepEqual(received, { args: "status", hasUI: true });
+  assert.deepEqual(notes, [{ m: "hello", l: "info" }]);
+});
+
+test("toHarnessContext tolerates a missing ui/cwd and never throws", () => {
+  const ctx = toHarnessContext(undefined);
+  assert.equal(typeof ctx.cwd, "string");
+  assert.equal(ctx.hasUI, false);
+  // No UI present — calls must be safe no-ops.
+  ctx.ui.notify("x");
+  ctx.ui.setWidget("k", ["l"]);
+  ctx.ui.setStatus("k", "t");
+});

--- a/test/extension-post-merge-update.test.mjs
+++ b/test/extension-post-merge-update.test.mjs
@@ -207,6 +207,30 @@ test("repo-resolution failures are swallowed so the hook stays best-effort", asy
   assert.equal(hook.getState().pendingPostMergeUpdate, false);
 });
 
+test("malformed or foreign-harness events pass through safely without throwing", async () => {
+  let resolveCalls = 0;
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => {
+      resolveCalls += 1;
+      return { repoRoot: cwd, repoSlug: TARGET_REPO_SLUG };
+    },
+    runCommand: async () => ({ code: 0, stdout: "", stderr: "", killed: false }),
+  });
+  const { ctx } = createUiCalls();
+
+  // onUserBash: missing/typed-wrong command and null event must return undefined (pass through).
+  assert.equal(await hook.onUserBash({}, ctx), undefined);
+  assert.equal(await hook.onUserBash({ command: 123 }, ctx), undefined);
+  assert.equal(await hook.onUserBash(null, ctx), undefined);
+
+  // onToolResult: null/empty events must not throw and must not queue an update.
+  await hook.onToolResult(null, ctx);
+  await hook.onToolResult({}, ctx);
+
+  assert.equal(resolveCalls, 0, "malformed events must not even reach repo resolution");
+  assert.equal(hook.getState().pendingPostMergeUpdate, false);
+});
+
 test("multiple merge signals in one turn still run only one update", async () => {
   const calls = [];
   const hook = createPostMergeUpdateHook({


### PR DESCRIPTION
## Summary

Formalizes the **extension-surface** harness seam (CA1) so the dev-loops extension is no
longer bound directly to Pi's `ExtensionAPI`/`ExtensionContext`. This is distinct from the
*context* seam shipped in #765/#783 — it covers `exec`, session lifecycle events, slash-command
registration, and the per-invocation UI surface — and provides both a Pi adapter (wrapping
today's behavior, no functional change) and a Claude Code adapter behind one interface.

## What changed

**New**
- `packages/core/src/harness/extension-adapter.mjs` — neutral `ExtensionHarnessAdapter`
  interface factory + type guard.
- `packages/core/src/harness/claude-extension-adapter.mjs` — Claude adapter: real `exec` via
  `node:child_process`, no-UI `HarnessContext`, and command/lifecycle registries for the
  hook-driven dispatch wired later in #773.
- `extension/pi-extension-adapter.ts` — the **only** module importing `@earendil-works/pi-*`;
  wraps a `pi` `ExtensionAPI` into the neutral adapter and maps pi's per-invocation `ctx` to a
  neutral `HarnessContext`.
- `extension/harness-types.ts` — neutral, import-free TS types shared by the `.ts` modules.

**Changed (no external behavior change)**
- `extension/index.ts` — wraps `pi`→adapter at the entry boundary, then wires lifecycle +
  command registration via the neutral adapter; builds the post-merge hook from `adapter.exec`.
- `extension/checks.ts` — `createExtensionCoreRuntime`/`collectDevLoopChecks` consume the
  neutral adapter.
- `extension/post-merge-update.ts` — drops the Pi type import in favor of an `{exec}` option
  and neutral event/context types; logic unchanged.

## Acceptance criteria (#770)

- [x] Neutral adapter interface covering exec + lifecycle + command registration + ui surface.
- [x] Pi extension refactored to implement it with no behavior change; `npm run verify` passes.
- [x] Claude adapter implements the same interface; `executeDevLoopsCommand` runs unchanged
      against a runtime built from it.
- [x] No `@earendil-works/pi-*` import outside the dedicated Pi adapter module (enforced by a
      guard test).

## Validation

`npm run verify` green: assets 88, extension 70, scripts 1433, core 1421, docs OK, dev-loop 32.
New tests: adapter factory/guard + Claude adapter (8), Pi adapter forwarding + ctx mapping (5),
`executeDevLoopsCommand` on the Claude adapter runtime (2), import-boundary guard (2).

## Scope boundaries (deferred to sibling slices)

- Run-id / async-context contract → #771
- `.claude` agents/skills generation → #772
- Hooks + read-only enforcement (consumes the Claude adapter registries) → #773
- Plugin packaging + Pi-only string neutrality → #774

Closes #770
