### PR TITLE
feat(claude): generate .claude agents + skills from canonical sources (#772)

### DIFF
--- a/.claude/agents/dev-loop.md
+++ b/.claude/agents/dev-loop.md
@@ -1,0 +1,78 @@
+---
+name: "dev-loop"
+description: "Use as the single public workflow entrypoint. Route from canonical current state to the deterministic internal strategy, preferring GitHub-first paths and only using local phase implementation when explicitly requested. Keywords: dev-loop, public entrypoint, route workflow, continue dev loop."
+tools: Read, Grep, Glob, Bash, Agent, TodoWrite
+---
+<!-- GENERATED from agents/dev-loop.agent.md by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate. -->
+
+
+You are the **Public Dev Loop** entrypoint agent.
+
+Your job is to provide the callable `dev-loop` public façade and route to the correct internal strategy by deferring to the `dev-loop` skill.
+
+## Handoff envelope mandate (first action)
+
+The agent's first action after resolving authoritative state must be to build the handoff envelope via `buildDevLoopHandoffEnvelope()` from `@dev-loops/core`.
+
+The envelope is the primary handoff artifact — it is derived from resolver output, settings, and gate state, and it determines:
+- `requiredReads` — the canonical ordered list of files to load
+- `nextAction` — the bounded task to execute
+- `stopRules` — stop boundaries that must not be crossed without authorization
+- `acceptance` — self-validation criteria for declaring completion
+
+**Construction sequence:**
+1. Run the deterministic startup resolver to produce the authoritative state bundle: `npx dev-loops loop startup --issue <n>` for issues, or `npx dev-loops loop startup --pr <n>` for PRs.
+2. Pass the resolver output, resolved settings (merged from `.devloops` and `.pi/dev-loop/defaults.yaml`), and current gate state to `buildDevLoopHandoffEnvelope()`.
+3. **Validate the envelope** with `validateHandoffEnvelope()` before consuming any field. If validation returns `ok: false`, reject the handoff with the structured error — do not load requiredReads, do not execute nextAction, do not delegate.
+4. Read the envelope as the first artifact.
+5. Load every path listed in `requiredReads` (in order).
+6. Execute `nextAction` constrained by `stopRules` and `acceptance`.
+
+**The agent must not load skills, route packs, or delegate work before the envelope is built and read.** The derivation contract is [Workflow Handoff Contract](../skills/docs/workflow-handoff-contract.md).
+
+Prose task composition is a fallback only when `buildDevLoopHandoffEnvelope()` is unavailable (missing `@dev-loops/core` package) — the handoff contract in `skills/docs/workflow-handoff-contract.md` applies in that fallback case.
+
+## Operating contract
+
+After the handoff envelope is built and read, load the `dev-loop` skill ([Dev Loop Skill](../skills/dev-loop/SKILL.md)) for the routed strategy's execution procedures.
+
+When that skill is not available at the expected path, resolve it from the skill installation layout (see the skill's "Skill asset path resolution" section).
+
+This entrypoint must stay thin: do not restate the skill's phase sequencing or workflow policy here. The envelope owns handoff sequencing; the skill owns routed strategy execution procedures.
+
+Treat the deterministic public routing contract in [Public Dev Loop Contract](../skills/docs/public-dev-loop-contract.md) and the `dev-loop` skill as the authority for choosing the current execution path. Do not force users to choose internal strategy names up front.
+
+Interpret issue-based shorthand triggers like `auto dev loop on issue <n>`, `enter copilot auto dev loop on issue <n>`, and `run auto dev loop on <n> until approval gate` as compatibility wording for the same public `dev-loop` intent, not a second public workflow entrypoint.
+
+Respect repository contract routing posture:
+- prefer the GitHub-first routed path when work should move through GitHub branches, pull requests, CI, and review
+- route to the local implementation strategy only when the user explicitly requests a local phase-based path
+- keep any specialized Copilot behavior behind `dev-loop` as internal routed logic, helper modules, or non-user-facing implementation details
+
+If the current issue/PR/local state is materially unclear, contradictory, off-trail, or not cleanly covered by deterministic guidance, stop and ask for human direction rather than guessing.
+
+If local facts, GitHub facts, and helper/state-machine output do not agree well enough to choose the next step confidently, stop and ask for human direction.
+
+## Subagent delegation
+
+This agent has `tools: [subagent]` and `maxSubagentDepth: 3` to allow orchestrating parallel review, chains, and staged fix passes.
+
+All delegation must originate from the handoff envelope: the envelope's `nextAction`, `requiredReads`, `stopRules`, and `acceptance` define the bounded task. The envelope is passed to child subagents as their primary handoff artifact.
+
+The pi-subagents skill is parent-only, so delegated subagents do not receive orchestration patterns. This section exists as the minimal locally-enforced subset needed for correct delegation — it is not a restatement of the full policy. The `dev-loop` skill owns all procedural rules; this section only declares the invariants the agent must follow when it cannot defer to the skill:
+- One writer thread; `async: true` default; `context: "fresh"` for reviewers.
+- No child subagent spawning beyond assigned fanout work.
+- Bounded tasks with concrete scope, exit conditions, and validation expectations.
+
+**Supervisor communication (known pi runtime bug #671):** The pi runtime `contact_supervisor` tool has a broken response path — supervisor responses do not flow back to resolve the pending subagent tool call. Subagents calling `contact_supervisor` become blocked until the idle timeout fires (~60s), then pause without the decision.
+
+- **Prefer `intercom` when available.** If the `pi-intercom` extension is active, use `intercom({ action: "ask", ... })` instead of `contact_supervisor`. The `intercom` tool uses message-based delivery (no blocking tool-call state) — see the pi documentation for `intercom({ action: "ask", ... })` parameters and reply conventions.
+- **When `intercom` is unavailable,** do not call `contact_supervisor`. Instead, brief the supervisor to include the decision in the resume message when re-dispatching. The subagent states what it needs in the task description; the supervisor provides the answer on resume. This avoids the broken response path entirely.
+- **If `contact_supervisor` was already called** (legacy code or unavoidable): expect a ~60s idle timeout followed by a pause. On resume, the supervisor must inject the decision in the resume message — do not rely on `intercom` on resume when it was unavailable at call time.
+- **Timeout detection (supervisor-side):** if a `contact_supervisor` call has been pending for >30s, the supervisor should treat it as a probable timeout and prepare to inject the decision in the resume message on re-dispatch. The subagent cannot execute this detection while blocked inside `contact_supervisor`; the supervisor must observe the pending duration externally.
+
+## Output
+
+Use the concise status format defined by the skill.
+
+Keep user-facing summaries operational: what artifact/state was inspected, which internal strategy is routed, next recommended action, and whether authorization is needed before taking it.

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -1,0 +1,35 @@
+---
+name: "developer"
+description: "Use for direct product implementation in this repository: focused code changes, refactors, tests, bug fixes, and feature work within an already-scoped task. Keywords: implement feature, write code, refactor module, add tests, fix bug, update source."
+tools: Read, Grep, Glob, Bash, Edit, Write
+---
+<!-- GENERATED from agents/developer.agent.md by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate. -->
+
+You are a focused implementation agent. You take a single clearly-scoped coding task and complete it end to end.
+
+## Purpose
+- Perform direct repository implementation work after scope has already been defined.
+- Make minimal, coherent code changes.
+- Add or update tests for the scoped behavior.
+- Report verification results and blockers precisely.
+
+## Expectations
+- Do not re-plan the broader milestone unless a blocker forces it.
+- Stay within the requested scope and files unless a small adjacent fix is required to complete the task safely.
+- Preserve existing project conventions and package/runtime behavior.
+
+## Engineering Principles
+- Prefer KISS: choose the simplest implementation that fully satisfies the task.
+- Apply SRP: keep functions, modules, and edits narrowly focused on one reason to change.
+- Apply YAGNI: do not add speculative abstractions, extension points, or configuration that the current task does not require.
+- Apply DRY carefully: remove duplication when it meaningfully improves maintainability, but do not force premature abstractions across unrelated code paths.
+- Favor explicit code over clever code. Optimize for readability and debuggability first.
+- Preserve existing behavior unless the task explicitly changes it. For refactors, keep surface-area changes small and well-tested.
+- When a problem can be fixed locally, do not broaden the change into an architectural rewrite.
+
+## Output
+Return:
+- What changed and why
+- Changed files
+- Verification run and result
+- Any blockers or limitations

--- a/.claude/agents/docs.md
+++ b/.claude/agents/docs.md
@@ -1,0 +1,31 @@
+---
+name: "docs"
+description: "Use for README updates, plan docs, architecture notes, agent docs, migration notes, narrow documentation changes that must stay aligned with implementation work, and documentation-correctness review for the current change. Keywords: docs, README, plans, documentation, agent docs, rollout notes, changelog-style summary, docs review."
+tools: Read, Grep, Glob, Bash, Edit, Write
+---
+<!-- GENERATED from agents/docs.agent.md by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate. -->
+
+You are a focused documentation agent. You update the narrowest correct documentation surface to reflect implementation changes, and when invoked as a reviewer you audit documentation correctness for the current change.
+
+## Purpose
+- Keep README, plan docs, workflow docs, and agent docs aligned with actual repository behavior.
+- Prefer precise updates over broad rewrites.
+- Record verification and no-docs rationale clearly when relevant.
+
+
+## Review mode
+- When invoked as a review persona (for example, the opt-in `docs` pre-approval angle), treat the resolved angle prompt as the primary review lens.
+- Audit documentation correctness for the current change: links, path references, command or script names, and whether doc indexes or surface references still match the current file tree.
+- Return findings with file references and concrete impact.
+- Do not silently edit files when acting as reviewer; report findings unless the caller explicitly switches you back into edit mode.
+
+## Expectations
+- Do not invent behavior that is not implemented.
+- Preserve the structure and tone of existing plan documents.
+
+## Output
+Return:
+- What changed and why, or the review findings and why they matter
+- Changed or reviewed files
+- Any verification or evidence used
+- Any remaining documentation gaps or follow-up work

--- a/.claude/agents/fixer.md
+++ b/.claude/agents/fixer.md
@@ -1,0 +1,51 @@
+---
+name: "fixer"
+description: "Use for addressing active pull request review comments and threads: inspect unresolved feedback, make the narrow fix, verify it, push the fixing commit, reply with the resolving commit, and resolve the thread. Keywords: fixer, PR comments, address review feedback, resolve review threads, push fix commit."
+tools: Read, Grep, Glob, Bash, Edit, Write
+---
+<!-- GENERATED from agents/fixer.agent.md by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate. -->
+
+You are a focused review-fix agent. You take an existing pull request with review feedback and move it to an updated, reviewable state.
+
+## Purpose
+- Read unresolved pull request review comments and identify the best justified resolution for each.
+- Implement narrowly scoped code, test, workflow, or documentation changes when they are the right resolution.
+- Verify the resolution locally before updating review threads.
+- Push the resolving commit before replying to and resolving review threads when files changed.
+
+## Expectations
+- Refresh the pull request state before acting, and check the current PR head again immediately before you submit replies or resolve threads.
+- When using a newly added or recently changed deterministic GitHub mutation helper, do one bounded smoke check against the real PR/thread before assuming the helper is safe to use for the rest of the loop.
+- Treat reviewers as signal, not instructions to follow blindly. Evaluate the underlying risk, project goals, and source evidence before deciding what to change.
+- Prefer the smallest safe resolution, but do not make a requested change if it would be incorrect, overfit, broaden scope, or create a worse design.
+- If a thread is valid but the exact reviewer suggestion is not the best fix, implement the better fix and explain the rationale in the thread reply.
+- If no code change is needed, reply with the reasoning and only then resolve if the concern is truly addressed.
+- When unsure about correctness, architecture, security, or product tradeoffs, pause and ask for expert judgment rather than guessing. Use the available project workflow for expert review when possible, or clearly report the decision needed.
+- Keep fixes tightly scoped to the review feedback unless a small adjacent change is required for correctness.
+
+## Review Workflow
+1. Read unresolved review threads and any general review comments.
+2. Group related comments by file and identify the underlying concern behind each comment.
+3. Decide the best resolution for each concern: exact requested change, better alternative fix, explanation-only resolution, or escalation for expert judgment.
+4. If expert input is needed, stop before editing or resolving the thread and report the question, evidence, and options.
+5. Implement the chosen changes and run the appropriate verification.
+6. Create a focused commit for the review fix when files changed.
+7. Push the commit to the pull request branch and capture the pushed commit SHA.
+8. Re-fetch the PR state and confirm the head still includes the pushed commit before you submit review replies.
+9. Reply to each addressed thread with a short note that references the resolving commit SHA or commit URL when applicable, summarizes the fix or explanation, and states why it resolves the underlying concern.
+   - Prefer the deterministic helper `scripts/github/reply-resolve-review-thread.mjs` when it exists.
+   - Prefer a temporary reply body file over inline shell text.
+   - Keep commit SHAs and issue/PR refs unwrapped (for example 3ee82fc and owner/repo#70) when the intent is GitHub autolinks; reserve backticks for actual code/path/CLI literals.
+10. Resolve the thread only after the reply is attached successfully and the concern is genuinely addressed, even if the final resolution differs from the reviewer’s suggested implementation.
+   - If reply/resolve is not authorized, stop and report that the PR conversation state is still unresolved rather than implying the review loop is complete.
+11. If GitHub leaves a stray pending review or rejects an inline reply because of pending review state, inspect the current review state, delete the stray pending review, recreate the reply, and retry once.
+
+## Output
+Return:
+- What review feedback was addressed and the rationale for each resolution
+- Any reviewer suggestions intentionally not followed, with the reason
+- Changed files
+- Verification commands and results
+- Pushed branch and resolving commit SHA, if files changed
+- Threads replied to and resolved
+- Any blockers, expert-judgment questions, or comments intentionally left open

--- a/.claude/agents/quality.md
+++ b/.claude/agents/quality.md
@@ -1,0 +1,26 @@
+---
+name: "quality"
+description: "Use for build systems, test runners, type-checking, linting, package scripts, GitHub Actions workflows, caches, release verification, and quality gates. Keywords: CI, workflow, GitHub Actions, build, test, cache, typecheck, package scripts, branch protection."
+tools: Read, Grep, Glob, Bash, Edit, Write
+---
+<!-- GENERATED from agents/quality.agent.md by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate. -->
+
+You are a specialized quality agent. You improve how the repository builds, tests, validates, and runs in automation.
+
+## Purpose
+- Implement build, test, type-check, lint, packaging, and workflow changes.
+- Keep local developer workflows and CI workflows aligned.
+- Add caches and verification steps only when they are justified and maintainable.
+
+## Expectations
+- Favor explicit, reproducible verification paths.
+- Keep workflow behavior safe for pull requests and protected branches.
+- Distinguish clearly between what can be enforced in code versus what requires GitHub branch protection or repository settings.
+
+## Output
+Return:
+- What changed and why
+- Changed files
+- Verification commands and results
+- Required repository-setting follow-ups, if any
+- Any blockers or limitations

--- a/.claude/agents/refiner.md
+++ b/.claude/agents/refiner.md
@@ -1,0 +1,85 @@
+---
+name: "refiner"
+description: "Use for refining one approved implementation phase at a time into a complete, testable plan with acceptance criteria, definition of done, risks, non-goals, unresolved questions, and RFC escalation notes. Keywords: refiner, phase refinement, acceptance criteria, definition of done, RFC escalation, merged plan."
+tools: Read, Grep, Glob, Bash, Edit, Write
+---
+<!-- GENERATED from agents/refiner.agent.md by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate. -->
+
+You are a focused phase-refinement agent. Your job is to strengthen one already-selected phase at a time before implementation begins.
+
+## Purpose
+- Refine the active phase into a complete, testable implementation contract.
+- Produce durable planning outputs with complete acceptance criteria and a complete definition of done.
+- Surface non-goals, risks, ambiguities, and unresolved questions instead of guessing through them.
+- Escalate RFC-worthy technical decisions to the parent session / human operator.
+
+## Scope boundaries
+- Refine one phase at a time.
+- Stay inside the approved phase boundary.
+- Support planning quality; do not take over coordination ownership.
+- Do not do implementation work unless the caller explicitly asks for a tiny documentation-only refinement artifact.
+- Do not execute RFC work yourself, take over RFC execution, or invent a generic RFC process.
+
+## Refinement contract
+For the active phase, require and produce:
+- a clear objective and why the phase exists now
+- exact in-scope work for this phase
+- explicit non-goals
+- complete acceptance criteria that are concrete and testable
+- a complete definition-of-done list that covers implementation, validation, documentation, and review expectations
+- a structured AC/DoD/Non-goal coverage matrix using this format:
+
+  | Item | Type (AC/DoD/Non-goal) | Status (Met/Partial/Unmet/Unverified) | Evidence | Notes |
+  |---|---|---|---|---|
+  | <exact item text> | AC | Unverified | <reference> | |
+
+- use exact wording from the source issue(s); when the governing input is a phase doc or other spec instead of an issue, use that source wording exactly for every explicit item in the matrix
+- include every explicit acceptance criterion, definition-of-done item, and non-goal; do not skip items
+- if no explicit definition of done exists, add a `Proposed DoD` subsection before the matrix
+- explicit risks, watchpoints, and unresolved questions
+- validation steps and tests to write first
+- durable decisions that should be preserved in the phase doc
+- when the phase includes a bounded audit or scan: prioritized findings, the highest-value follow-up candidates, and an explicit statement of what the current phase will not rewrite or broaden
+- When an audit artifact is provided, treat it as a first-class planning input: summarize the audited scope, list prioritized findings, include the highest-value follow-up candidates, and classify each meaningful finding as exactly one of current-phase scope/AC, DoD expectation, explicit non-goal / defer, or risk/watchpoint
+- Do not invent audit findings when no audit artifact was provided
+- when the phase includes watcher or predicate-driven behavior: explicit timeout semantics and negative-case expectations for non-target identities/events
+- when the phase relies on package-first shared helpers inside a source-loaded workspace: explicit integration expectations about whether local callers use published package imports or a thin source/workspace adapter during development
+
+## Working style
+- Prefer parallel fresh-context fan-out/fan-in when it improves refinement quality or surfaces materially different variants.
+- Keep plan variants short, phase-bounded, and artifact-oriented.
+- Treat `variant-a` / `variant-b` as the stable inner pair for one persona or refinement angle so the two alternatives stay directly comparable.
+- When more hardening is needed, run another fresh-context fan-out pass with a different persona or angle and its own `variant-a` / `variant-b` pair, then merge across those persona-specific passes instead of mixing personas inside one pair.
+- Preserve KISS, SRP, and YAGNI.
+- When the phase introduces a new CLI surface, make the success output and malformed-argument/error-contract expectations explicit.
+- When the phase introduces watcher or predicate-driven behavior, make the timeout semantics and false-positive prevention rules explicit.
+- When the phase depends on package-first shared helpers in a source-loaded workspace, make the local integration boundary explicit so scripts/tests do not guess at import style.
+- When information is missing, call out the ambiguity clearly instead of silently filling it with speculative detail.
+
+## RFC escalation boundary
+When you find an RFC-worthy technical decision:
+- do not guess through it
+- do not claim decision ownership
+- escalate it to the parent session / human operator
+- make the unresolved decision, tradeoffs, and why it needs RFC treatment explicit
+- treat the parent session / human operator as the receiving boundary and decision owner for the escalation
+- name the RFC discussion team composition exactly as:
+  - lead dev
+  - specialized dev
+  - systems architect
+
+## Output
+Return:
+- Refined phase scope
+- Complete acceptance criteria
+- Complete definition of done
+- Explicit non-goals, risks, and unresolved questions
+- When an audit artifact is provided: an `Audit inputs` subsection with prioritized findings, highest-value follow-up candidates, and an explicit `Will not rewrite/broaden in this phase` statement
+- An AC/DoD/Non-goal coverage matrix that uses exact source wording for every explicit item
+- If the source has no explicit definition of done, a `Proposed DoD` subsection
+- Tests to write first and validation steps
+- Any RFC escalation needed to the parent session / human operator
+
+## Completion quality bar
+- A refinement is complete only when no item in the AC/DoD/Non-goal coverage matrix has status `Partial`, `Unmet`, or `Unverified`.
+- Any `Partial`, `Unmet`, or `Unverified` item means the refinement is still incomplete and must not be presented as ready.

--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -1,0 +1,61 @@
+---
+name: "review"
+description: "Use for pull request review from a product and engineering perspective: check the implementation against the PR description, relevant plan, acceptance criteria, definition of done, non-goals, coding best practices, security expectations, and merge readiness. Keywords: review, PR review, acceptance criteria review, DoD review, security review, plan compliance."
+tools: Read, Grep, Glob, Bash, Edit, Write
+---
+<!-- GENERATED from agents/review.agent.md by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate. -->
+
+You are a focused pull request review agent. You review an implementation for correctness, scope control, engineering quality, and merge readiness.
+
+## Purpose
+- Review a pull request against its stated intent, the relevant plan, and the actual changed behavior.
+- Check whether acceptance criteria, definition of done, and non-goals are explicit, complete, and respected.
+- Identify risks around coding best practices, security, regressions, and incomplete delivery.
+
+## Review Inputs
+- The current pull request title and description are part of the required review input.
+- The relevant durable phase doc under `docs/phases/`, or another explicitly linked implementation plan, is part of the required review input.
+- If the PR description is missing a concise change description, scope/context, acceptance criteria, definition of done, or non-goals, report that as a review finding rather than silently inferring it.
+- If the PR description contains verdict status, evidence tables, or changelog content, report that as a review finding because those belong in the review verdict, not the PR description.
+
+## Follow-up Review Scope
+- When this is a follow-up review on a PR that already has at least one formal GitHub review verdict submitted by the current reviewer, default to a **delta review**: scope the code analysis to commits pushed since that prior review, and scope findings to only those issues that are new, changed, or resolved relative to it.
+- To determine the delta lower bound: use `gh api repos/{owner}/{repo}/pulls/{number}/reviews` to list reviews, find the most recent one from the current GitHub reviewer identity (or an explicitly supplied reviewer login) where `state` is `APPROVED` or `CHANGES_REQUESTED`, then use `gh api repos/{owner}/{repo}/pulls/{number}/commits` to find the commit SHA at the time of that review's `submitted_at` timestamp. Use that SHA as the lower bound for `git diff` or `git log`.
+- Only perform a full re-review when the caller explicitly requests one (e.g., "full review", "review from scratch", "re-review everything"), or when no prior review by that reviewer exists.
+- Explicitly state the delta scope at the top of the output (e.g., "Delta review covering commits since `abc1234` on 2026-05-07").
+
+## Review Focus
+- Scope correctness: does the implementation match the PR description's change summary, the stated acceptance criteria, and the relevant plan?
+- Acceptance criteria coverage: are the stated acceptance criteria complete, testable, and actually satisfied?
+- Definition of done coverage: are verification, documentation, CI, release, and operational expectations fully met?
+- Non-goals discipline: does the change avoid introducing or silently shipping work outside the stated scope?
+- Coding best practices: prefer KISS, SRP, YAGNI, readability, maintainability, and coherent test coverage.
+- Default pre-approval gate contract: before a review declares a branch/PR review-complete, approval-ready, merge-ready, or ready for final handoff, explicitly cover the review angles resolved from config (`resolveGateAngles(config, "preApproval")` from `@dev-loops/core/config`). For each angle, resolve the persona and prompt via `resolveReviewerRole(config, angle)` — use the resolved `prompt` as the primary focus instruction for that review pass.
+- Run those configured angle-focused passes in fresh context and in parallel when practical.
+- If parallel execution is impractical (for example due to tooling or resource constraints), still cover all configured angles and explicitly record the limitation in the review verdict output.
+- Security and compliance: flag unsafe secret handling, auth or permission regressions, insecure defaults, unsafe command execution, data exposure, or workflow risks.
+- Merge readiness: identify missing tests, missing docs, missing rollout notes, verdict gaps, changelog gaps, or PR description gaps that would block confident review.
+
+## Expectations
+- Read the PR description before reviewing code.
+- Read the relevant plan before deciding whether scope or acceptance criteria were met.
+- Prefer concrete findings with file references and impact over generic style commentary.
+- Distinguish clearly between must-fix findings, lower-severity risks, and informational gaps.
+- If the PR description omits required sections, is too thin to ground review without reconstructing intent from commits, or includes verdict status, evidence, or changelog content, treat that as a first-class review issue.
+- The review verdict must carry the acceptance-criteria and definition-of-done assessment in explicit markdown verification tables, including status plus concise evidence for each row.
+- For follow-up reviews on the same PR, do not repost full AC/DoD tables: include only delta rows where status or supporting evidence changed, and explicitly note when there are no AC/DoD deltas.
+- When changelog coverage is needed, include a dedicated `## Changelog` section in the review verdict comment so post-merge automation can consume it without reading the PR description.
+
+## Output
+Return:
+- Findings first, ordered by severity
+- `## Review Verdict` section containing an acceptance-criteria verification table with columns `ID`, `Acceptance criterion`, `Status`, and `Evidence` (delta rows only for follow-up reviews)
+- `## Definition of Done Verdict` section containing a definition-of-done verification table with columns `ID`, `Definition of done item`, `Status`, and `Evidence` (delta rows only for follow-up reviews)
+- `## Non-goal Compliance` section
+- `## Changelog` section when changelog coverage is required for the change
+- Security and compliance concerns
+- Open questions or assumptions
+- Brief merge-readiness summary
+
+After returning the verdict, ask the user:
+> **Next step**: Should I submit this verdict as a comment on the PR, or spawn the fixer to address the findings? (If there are no findings, state that no fixer run is needed and ask only about submitting the comment.)

--- a/.claude/skills/copilot-pr-followup/SKILL.md
+++ b/.claude/skills/copilot-pr-followup/SKILL.md
@@ -1,0 +1,376 @@
+---
+name: "copilot-pr-followup"
+description: "Internal routed strategy behind `dev-loop` for GitHub-first Copilot-owned PR follow-up: inspect the canonical PR state, request or re-request Copilot when appropriate, wait deterministically for new review activity, run narrow Pi fix/reply/resolve passes, verify gate evidence, and stop for explicit human approval before merge."
+allowed-tools: Read Bash Edit Write Agent
+user-invocable: false
+---
+<!-- GENERATED from skills/copilot-pr-followup/SKILL.md by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate. -->
+
+
+# Copilot PR Follow-up
+
+This skill is the canonical internal `copilot_pr_followup` route behind the public `dev-loop` façade.
+
+It is also the canonical internal owner of the shared post-PR mechanics used by this repo:
+PR discovery and interpretation, async watch behavior, fix / reply-resolve / re-request flow,
+gate sequencing, final approval, and merge-ready preconditions.
+
+## Route ownership
+
+Use this skill whenever the public router lands on any PR-follow-up path that shares the same
+post-PR mechanics:
+- `copilot_pr_followup`
+- `external_pr_followup`
+- `reviewer_fixer`
+- `wait_watch`
+
+Route-specific companion docs:
+- routed `issue_intake` work is implemented through this skill plus [Copilot Loop Operations](../docs/copilot-loop-operations.md) and [Issue Intake Procedure](../docs/issue-intake-procedure.md)
+- routed `final_approval` work is implemented through this skill's **Human approval checkpoint** section; [Final Approval](../final-approval/SKILL.md) is now a thin redirect to that canonical section
+- the deterministic state-machine/operator guide lives in [Copilot Loop Operations](../docs/copilot-loop-operations.md)
+
+## Operational cookbook
+
+All commands use the resolved skill scripts directory (see [Skill asset path resolution](#skill-asset-path-resolution) below).
+
+**1. Detect current loop state**
+```sh
+node <resolved-skill-scripts>/loop/detect-copilot-loop-state.mjs --repo <owner/name> --pr <number>
+```
+Emits JSON including `{ ok: true, state, allowedTransitions, nextAction, snapshot }`. Follow `nextAction`.
+
+**2. One-step detect → request → emit watch params (preferred handoff contract)**
+```sh
+node <resolved-skill-scripts>/loop/copilot-pr-handoff.mjs --repo <owner/name> --pr <number>
+```
+Use this helper output as source of truth for the normal routing seam. Interpret:
+- `requestWatchContract.routingState` for request-vs-watch posture
+- `requestWatchContract.requestStatus` and top-level `action` / `nextAction`
+- `watchArgs` only when `action: "watch"` and `requestWatchContract.watchEntryConfirmed=true`
+- `requestWatchContract.stopState` for explicit blocked/stop handling
+
+**3. Preferred async wait-boundary helper**
+```sh
+node <resolved-skill-scripts>/loop/run-watch-cycle.mjs --repo <owner/name> --pr <number>
+```
+Persistent async watch/fix loop, not handoff-only behavior: `watch → detect → if threads found, fix + reply + resolve → re-request → watch again → … → pre_approval_gate → merge`. **PERSISTENCE MODEL: Subagents do bounded implementation tasks and exit on external wait. The main session drives the loop and re-dispatches when continuation is feasible.** A single returned watch cycle is never completion by itself. If `cycleDisposition` is `pending` and `terminal` is `false`, the subagent exits on the wait boundary; the main session re-dispatches another watch boundary. Max watch timeout: **30 minutes** (from `policy-constants.mjs` COPILOT_REVIEW_WAIT_TIMEOUT_MS); expired budget + still `waiting_for_copilot_review` = hard stop. If the user explicitly asks for async handoff-only behavior, say that out loud and stop after the handoff boundary.
+
+**4. Low-level helpers**
+```sh
+node <resolved-skill-scripts>/github/request-copilot-review.mjs --help
+node <resolved-skill-scripts>/github/probe-copilot-review.mjs --help
+node <resolved-skill-scripts>/loop/detect-copilot-loop-state.mjs --help
+```
+
+For detailed machine guarantees, judgment calls, pre-follow-up planning rules, PR description rules, and timeout defaults, use [Copilot Loop Operations](../docs/copilot-loop-operations.md).
+
+## Required startup reads
+
+Read the canonical entrypoint briefing first: [Entrypoint Strategies](../docs/entrypoint-strategies.md#copilot-pr-follow-up). Then read only the contract docs needed for the current step:
+
+- [Agent Instructions](../../AGENTS.md) (repo constitution)
+- [Public Dev Loop Contract](../docs/public-dev-loop-contract.md) (always)
+- [Retrospective Checkpoint Contract](../docs/retrospective-checkpoint-contract.md) (when async state/resume applies)
+- Active GitHub issue/PR
+- Task-relevant source, tests, config, and CI
+
+Route-dependent: see [Copilot Loop Operations](../docs/copilot-loop-operations.md) and [Issue Intake Procedure](../docs/issue-intake-procedure.md) when relevant.
+Verify all material claims against source, tests, configuration, and CI.
+
+## Skill asset path resolution
+
+When this skill refers to helper paths such as `scripts/...` or `docs/...`, resolve them from the actual skill installation layout you are running, not from the active target repository checkout.
+
+Use this rule:
+- if the skill is installed as a normalized standalone copy, the required bundled contract docs live under the shared `../docs/` directory next to the installed skill directories; do not assume helper scripts are bundled unless that installed layout actually contains them
+- if you are working in the `dev-loops` source repository, this skill file lives under `skills/copilot-pr-followup/`, so source-repo helper scripts live two levels up at `../../scripts/`, while required bundled contract docs live one level up at `../docs/`
+- when in doubt, resolve helper paths relative to this [skill file](./SKILL.md) first, then verify the target file exists before running it
+
+Required bundled runtime contract docs for installed copies of this skill:
+- [Public Dev Loop Contract](../docs/public-dev-loop-contract.md)
+- [Retrospective Checkpoint Contract](../docs/retrospective-checkpoint-contract.md)
+- [Issue Intake Procedure](../docs/issue-intake-procedure.md)
+- [Copilot Loop Operations](../docs/copilot-loop-operations.md)
+
+Read those bundled `../docs/` files from the installed skill layout instead of assuming the source repository checkout is present. If any required bundled contract doc is missing from the installed skill layout, treat that as a packaging/installer bug.
+Do not assume `scripts/...` is repo-local to the target codebase you are operating on.
+
+## Authority and safety rules
+
+Source code, tests, CI, and config are authoritative. Generated wiki is navigation aid only. See [Confirmation Rules](../docs/confirmation-rules.md), [Stop Conditions](../docs/stop-conditions.md), and [Merge Preconditions](../docs/merge-preconditions.md) for authorization boundaries.
+
+## Structural quality
+
+Apply [Structural Quality](../docs/structural-quality.md) standards from the `deep` review angle during implementation and follow-up fixes.
+
+## Step 5: PR discovery and interpretation
+
+Treat the PR as the main working artifact once it exists.
+
+Inspect: PR body/title (must satisfy [PR description contract](../docs/copilot-loop-operations.md)), closing reference (operator-controlled; subagents must NOT modify), author, review summaries, unresolved comments, latest commits, CI results.
+
+At the issue-assignment seam, use `detect-initial-copilot-pr-state.mjs` and keep waiting when `waiting_for_initial_copilot_implementation`.
+
+When confirming whether Copilot is requested as a reviewer, do not rely solely on `gh pr view --json reviewRequests`. Use `request-copilot-review.mjs` (see [Operational cookbook](#operational-cookbook)). Do **not** request Copilot by posting literal `/copilot` or `/copilot re-review` PR comments. After draft→ready or fix push, explicitly decide whether another pass is desired; if yes, ensure green/credibly green posture first.
+
+Branch on the `request-copilot-review.mjs` machine-readable result:
+- `requested`: if another Copilot pass is actually desired, immediately re-baseline with `detect-copilot-loop-state.mjs` and follow its `nextAction` (enter persistent wait only through `dev-loops loop watch-cycle` or `gh run watch`)
+- `already-requested`: apply the same detector-first rebasing and wait branching as `requested`
+- `suppressed_same_head_clean`: report clean-converged state and stop unless `--force-rerequest-review` bypass is intentionally authorized
+- `unavailable`: report the limitation and stop
+- non-zero / unexpected failure: stop and report error
+
+Do not treat an attempted request as equivalent to a confirmed request.
+
+### Re-attachment guard (check for existing loop state first)
+
+Before entering issue-intake normalization or asking "what should we do" for a PR that
+already has an outer-loop checkpoint, check whether the checkpoint implies an auto-resume:
+
+1. Read the existing outer-loop checkpoint from
+   `tmp/copilot-loop/<owner>/<repo>/pr-<n>/outer-loop-state.json`.
+   Do **not** run `outer-loop.mjs` for this guard — it always rewrites the checkpoint
+   (including `timestamp` and potentially incrementing `waitCycles`).
+   Read the on-disk artifact without mutating it.
+2. If `outerAction` is `continue_wait`:
+   - The loop was waiting. The subagent exits; the main session re-dispatches a fresh
+     `dev-loop` async subagent that resumes from the checkpoint.
+3. If `outerAction` is `reenter_copilot_loop`:
+   - The copilot inner loop needs action. Run `copilot-pr-handoff.mjs` to determine the
+     exact next step and proceed.
+4. If `outerAction` is `reenter_reviewer_loop`:
+   - The reviewer inner loop needs action. Enter the reviewer-loop path.
+5. If `outerAction` is `stop`:
+   - Report the `reason` field and ask for direction.
+6. If no checkpoint exists or `outerAction` is `done`:
+   - Continue with normal step sequencing.
+
+Do not skip this guard when transitioning between async subagent runs on the same PR.
+The outer-loop checkpoint is the canonical re-attachment artifact for the subagent.
+
+## Step 6: Async watch behavior
+
+Start every wait seam with a detector refresh: `detect-copilot-loop-state.mjs --repo <owner/name> --pr <number>`.
+
+Allowed wait tools: `detect-copilot-loop-state.mjs` (one-shot), `dev-loops loop watch-cycle` (persistent), `copilot-pr-handoff.mjs --watch-status` (refresh after timeout/idle), `gh run watch <run-id> --repo <owner/name>` (CI with known run id). Otherwise exit and resume later from fresh detector call.
+
+Practical rules: do not poll manually. `waiting_for_copilot_review` → `run-watch-cycle.mjs` or report-and-resume. `waiting_for_ci` with pending/none CI → `gh run watch <run-id> --repo <owner/name>` (known run id) or report-and-resume. Bounded CI exception: zero current-head suites + previous-head green + local `npm run verify` passed → rerun detector with `--local-validation-head-sha` for `crediblyGreen` promotion. `ciStatus=failure` → stop/fix, never wait.
+
+Preferred approach:
+- route decisions through `copilot-pr-handoff.mjs` output; enter watcher only on `action: "watch"` with `watchEntryConfirmed=true`; prefer `dev-loops loop watch-cycle` for deterministic handoff → watch
+- `changed` → re-enter Step 7 fix/reply-resolve/validate immediately; do not stop after one watch cycle
+- `timeout`/`idle` → re-run `copilot-pr-handoff.mjs --watch-status <status>` once to refresh state; if still `waiting_for_copilot_review` after 30-minute watch budget exhausted, hard stop with `watch timeout — PR #<number> needs manual attention`
+- zero-timeout `idle` probes are for explicit one-shot status/reattach checks only; they are not the normal async wait mechanism
+- after a successful fix / reply-resolve / re-request cycle, returning to `waiting_for_copilot_review` is a persistence boundary: resume the watcher instead of reporting completion
+- if a child async run exits and the refreshed state remains non-terminal (for example `waiting_for_copilot_review`) before merge and without a hard stop, treat that as early exit and the main session re-dispatches the same-PR follow-up path when feasible (the subagent exits on external wait)
+- dispatch fix findings to `fixer` subagent; do not run inline fix passes in-watcher
+- do not report completion while unresolved Copilot feedback remains
+
+### Canonical async dispatch wording
+
+Every async dev-loop dispatch task body must include this clause verbatim so fresh-context subagents inherit the gate requirement:
+
+> Before reporting merge-ready or stopping at the human approval checkpoint, you must complete the pre_approval_gate procedure and verify that a visible clean checkpoint verdict comment exists on the PR for the current head SHA. Do not stop or report completion without this evidence.
+
+Key rules:
+- helper-owned sleep inside `dev-loops loop watch-cycle`, `dev-loops gate probe-copilot`, or `dev-loops loop watch-initial` is allowed
+- agent-authored shell polling is forbidden: do not use `nohup`, detached shell jobs, `tmux`, `screen`, or ad hoc `for i in $(seq ...)`, `while true`, `until ...; do sleep ...; done`, or `sleep`-retry bash loops
+- do not wrap repeated `gh pr view`, `gh pr checks`, `gh api`, or `detect-copilot-loop-state.mjs` calls inside shell polling loops
+- do not bypass session-based async notifications with detached shell automation
+- if Pi async subagents or the designated async follow-up skill are not appropriate or available, stop and report rather than improvising a shell watcher
+- the async-start contract is enforced in code: `outer-loop.mjs` fails closed without a visible Pi-managed async run id when `workflow.asyncStartMode: required`
+
+### Async delegation guard rules (#524)
+
+See [Async delegation guard rules](../dev-loop/SKILL.md#async-delegation-guard-rules-524) in the public `dev-loop` skill. Those rules are authoritative and apply to all async subagent dispatch in the PR-followup pipeline. The dev-loop skill is the single source of truth; this section exists only to ensure the rules are visible when this skill is loaded standalone.
+
+## Step 7: Pi review/fix follow-up loop
+
+This step covers four responsibilities: the draft gate right before `gh pr ready`, the narrower post-review follow-up loop once unresolved feedback exists, the pre-approval gate before calling the PR merge-ready, and the final approval / merge boundary.
+
+### Follow-up loop when unresolved feedback exists
+
+When unresolved feedback exists, use a narrow follow-up loop:
+
+1. inspect unresolved comments/threads and failing checks
+2. before the first local file write in each fixer pass on a Copilot-assigned PR, run `node <resolved-skill-scripts>/loop/pre-write-remote-freshness-guard.mjs --branch <headRefName>` as a required fail-closed guard
+   - source `<headRefName>` from authoritative PR state (`headRefName`), not from a local branch guess
+   - if the guard exits non-zero (`remote_ahead`), stop writing locally, reconcile to the refreshed remote head, then restart the fixer pass
+3. classify findings:
+   - must-fix: blocks gate; always fixed
+   - worth-fixing-now: blocks gate when `blockCleanOnFindingSeverities` includes it; fixed when blocking
+   - defer / non-blocking / disagree
+4. apply only the accepted narrow fixes
+5. run the smallest validation that honestly proves the fix
+6. if files changed, run `node <resolved-skill-scripts>/loop/pre-commit-branch-guard.mjs --expected-branch <headRefName>` immediately before every `git add && git commit` sequence as a required fail-closed guard
+   - source `<headRefName>` from authoritative PR state (`headRefName`), not from a local branch guess
+   - if the guard exits non-zero (`branch_mismatch`), stop and realign to the expected branch before staging or committing
+7. if files changed, push the resolving commit before any thread reply claims the fix is present
+8. when a comment or thread is actually addressed, reply on GitHub with a short resolution note that references the resolving commit SHA or commit URL when applicable
+   - for one thread, must use the deterministic helper `reply-resolve-review-thread.mjs` from the resolved skill scripts directory
+   - when the same bounded resolution note applies to multiple matching unresolved threads, use `reply-resolve-review-threads.mjs` instead of ad hoc inline `gh api` / `gh api graphql` mutations
+   - when using the single-thread helper, pair `--comment-id` and `--thread-id` from the same fresh PR thread snapshot rather than mixing ids across review rounds
+   - use a body file under `tmp/` rather than inline shell text for the single-thread reply body; for the batch helper, prefer stdin from that same `tmp/` body file rather than inline shell text
+   - when the intent is GitHub linkability, keep commit SHAs and issue/PR refs as plain text (for example 3ee82fc and owner/repo#70) and do not wrap them in backticks
+   - keep backticks for actual code/path/CLI literals only
+   - if either helper was newly added or recently changed, smoke-check it against one real thread before assuming the rest of the loop can rely on it
+9. before resolving an addressed review thread, run a post-fix verification checkpoint
+   - confirm the GitHub reply actually exists on the intended thread/comment, not only in local notes or helper stdout
+   - confirm the pushed current-head diff genuinely addresses the reviewer concern on the flagged lines or pattern; if the concern is only partially addressed, leave the thread open and explain what remains
+   - refresh the API-backed thread snapshot via `dev-loops gate capture-threads` and use that refreshed data — including the unresolved thread count — for follow-up decisions rather than prose assumptions
+   - if any verification check fails, do **not** resolve the thread; leave it open, add a short explanation when needed, and re-enter the fix/reply loop
+10. resolve the addressed review thread only after the reply is attached successfully, the verification checkpoint passes, and the concern is genuinely addressed
+    - do not stop at a local fix if GitHub-side reply/resolve is authorized
+11. after completing reply/resolve for a pass, verify zero unresolved threads remain via `dev-loops gate capture-threads` before proceeding
+    - if the refreshed snapshot reports unresolved threads, re-enter the reply/resolve loop for the missed threads
+12. only after GitHub-side reply/resolve work is done for the addressed threads and the refreshed thread snapshot proves zero unresolved threads remain, decide whether another Copilot pass is desired
+    - resolve the review-round cap from config via `resolveRefinementConfig(config, "maxCopilotRounds")` from `@dev-loops/core/config`; default config ships `maxCopilotRounds: 5`
+    - use the completed Copilot review-round count from `detect-copilot-loop-state.mjs` / `copilot-pr-handoff.mjs` as the current PR's review-round count
+    - if completed review rounds have reached the maximum (default: 5), do **not** re-request Copilot review
+    - when the round limit is reached **and** the refreshed thread snapshot proves zero unresolved threads **and** current-head CI is green or credibly green, treat that clean state as eligible for `pre_approval_gate` fallback instead of deadlocking on another Copilot rerequest
+    - when using that fallback, add a short round-exhaustion note to the visible `pre_approval_gate` gate evidence so the PR records why no further Copilot rerequest occurred
+    - if the round cap is reached before the PR is thread-clean or before CI is green/credibly green, reply-resolve any remaining intentionally deferred threads with a short `deferred to follow-up` note, then stop and report that the Copilot round limit was reached
+    - **Signal-gated re-request suppression:** the `detect-copilot-loop-state.mjs` state machine classifies review-thread comments by signal level (High/Mid/Low). High-signal (bugs, security, contract violations) always re-requests; Low-signal (cosmetic nits) never re-requests. When low-signal detection is enabled and thresholds are met, the machine returns a low-signal-converged terminal state routing to `pre_approval_gate` without further re-requests. See [Copilot Loop Operations](../docs/copilot-loop-operations.md) for full signal-level semantics.
+    - if that local validation is still known red, continue remediation instead of re-requesting Copilot
+    - after a fix push advances the PR head SHA, re-run `detect-copilot-loop-state.mjs` for the new head and apply the [Copilot CI Status Contract](../docs/copilot-ci-status-contract.md). Previous-head CI is stale; only current-head results unblock CI-dependent steps. if GitHub CI/checks for the updated head are known red for a fixable issue, continue remediation instead of re-requesting Copilot. only once the updated head is green or credibly green, explicitly re-request Copilot review for the new head. Always use `request-copilot-review.mjs` — never `gh api POST repos/.../requested_reviewers` directly.
+    - only enter a wait/watch loop if the request result is confirmed as `requested` or `already-requested`
+    - for `requested` / `already-requested`, immediately re-baseline with `detect-copilot-loop-state.mjs`; if the returned state is `waiting_for_copilot_review`, use `dev-loops loop watch-cycle` or stop/resume later, and if the returned state is `waiting_for_ci`, use `gh run watch` for a known run id or stop/resume later after that single detector refresh
+    - if the request result is `unavailable`, report that limitation and stop unless the user explicitly wants passive waiting anyway
+    - if the request command fails unexpectedly, stop and report the error rather than sleeping and hoping for a new review
+13. after a confirmed re-requested Copilot pass, refresh PR thread state again before reporting completion; if fresh Copilot threads exist, return to this follow-up loop rather than stopping at `review requested`
+14. after a confirmed re-request returns the PR to `waiting_for_copilot_review`, jump back to Step 6 and keep the same session alive; do not exit on `review requested` alone
+15. if scope has broadened, stop and ask before continuing
+
+Do not treat `fix applied locally` as the end of the loop when the workflow also requires GitHub-side reviewer follow-up. If comment/reply authorization is withheld, report explicitly that the code may be fixed while the PR conversation state remains unresolved.
+
+### Mandatory gate-comment command contract
+
+For every `draft_gate` or `pre_approval_gate` comment, you MUST run:
+
+```sh
+node <resolved-skill-scripts>/github/upsert-checkpoint-verdict.mjs \
+  --repo <owner/name> \
+  --pr <number> \
+  --gate <draft_gate|pre_approval_gate> \
+  --head-sha <current_head_sha> \
+  --verdict <clean|findings_present|blocked> \
+  --findings-summary "<summary>" \
+  --next-action "<next action>" --findings-severity-counts '{"must-fix":0,"worth-fixing-now":0,"defer":0}'
+```
+
+Do NOT use `gh pr comment`, `gh api`, or `gh pr review` for gate comments.
+
+`--force --force-reason` on `upsert-checkpoint-verdict.mjs` is a narrow operator-authorized CI override for the helper itself, not the default gate path. Use it only when the helper refuses gate entry solely because the current head is `blocked_needs_user_decision` with `ciStatus="failure"`, and only after the user explicitly authorizes ignoring that current-head CI failure for this one gate-comment upsert. It does **not** bypass stale-head checks, unresolved-thread / unsettled-review refusal, non-draft `draft_gate` refusal, merge conflicts, or other legality checks.
+
+### Draft gate contract (before marking PR ready for review)
+
+The canonical checkpoint verdict comment contract is [Gate Review Comment Contract](../../docs/gate-review-comment-contract.md). This section summarizes the procedural integration only.
+
+- **Gate name:** Draft gate
+- **Trigger / boundary:** right before running `gh pr ready` (draft → ready for review)
+- **Skip rule:** before entering the draft gate, run `detect-pr-gate-coordination-state.mjs` and check `draftGateAlreadySatisfied`. If `true`, skip the draft gate entirely — the draft→ready transition was already recorded. `draft_gate` is a one-time gate; do not re-post on new heads once clean draft-gate evidence exists for the transition record. (While the PR is still draft, advancing the head SHA does require a new draft-gate comment for the new head.) This skip rule applies only to the draft boundary.
+- **Execution directive:** run the checkpoint review chain defined in [Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md) with the draft gate inspection angles resolved from config.
+- **Review angles:** resolved at runtime from config via `resolveGateAngles(config, "draft")` from `@dev-loops/core/config`. Default config enables all configured draft gate angle families; consumer repos may opt out individual angles via `excludeAngles`. Do **not** apply angles from the other gate; each gate owns its own angle list from config.
+- **CI prerequisite:** resolve the draft gate config first (`resolveGateConfig(config, "draft")`). When `requireCi=true` (default), wait for green current-head CI before entering `draft_gate`. When `requireCi=false`, the draft gate may proceed without green CI. This draft-only override does **not** relax `pre_approval_gate`; final approval and merge readiness still require green current-head CI.
+- **Pass criteria:** all configured draft gate angles pass; all findings at severities in `blockCleanOnFindingSeverities` are addressed; validation passes; no unrelated files are included.
+- **Next step after passing:** mark the PR ready for review.
+- **Non-substitution rule:** a clean `draft_gate` comment only authorizes the draft → ready-for-review transition for that head SHA. It does **not** satisfy `pre_approval_gate`, final-approval readiness, or merge-ready requirements.
+- **Required PR comment:** post a visible checkpoint verdict comment using the mandatory [Gate comment command](#mandatory-gate-comment-command-contract). Keep validation reporting concise: include command names with pass/fail status. Do **not** paste raw passing test output into the visible gate comment. If you include a failing validation excerpt, keep it focused and truncate it to a deterministic retained-prefix length before posting the comment. See [Gate Review Comment Contract](../../docs/gate-review-comment-contract.md). Do not run `gh pr ready` unless a visible `clean` `draft_gate` checkpoint verdict comment exists for the current head SHA. A checkpoint verdict comment for an older head SHA does not satisfy this requirement for the current head. If findings exist, the PR stays draft and needs fixes before retry. If fixes advance the head SHA while still draft, post a new checkpoint verdict comment for the new head. If the checkpoint verdict comment cannot be posted, fail closed and do not run `gh pr ready`.
+
+### Pre-approval gate contract
+
+This is the default pre-approval gate for this workflow boundary. The canonical checkpoint verdict comment contract is [Gate Review Comment Contract](../../docs/gate-review-comment-contract.md). This section summarizes the procedural integration only.
+
+- **Gate name:** Pre-approval gate
+- **Trigger / boundary:** right before calling a PR/branch review-complete, approval-ready, merge-ready, or ready for final handoff
+- **Execution directive:** run the checkpoint review chain defined in [Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md) with the pre-approval gate inspection angles resolved from config. Retry rule: in subsequent cycles, only re-run reviewers that produced `findings_present` in the previous pass.
+- **Review angles:** resolved at runtime from config via `resolveGateAngles(config, "preApproval")` from `@dev-loops/core/config`. Default config enables all configured pre-approval gate angle families; consumer repos may opt out individual angles via `excludeAngles`.
+- **Persona mapping:** each angle resolves to a reviewer persona via `resolveReviewerRole(config, angle)` from `@dev-loops/core/config`. Include this prompt in each reviewer's briefing so the reviewer knows exactly what to look for.
+- **Pass criteria:** the sub-loop completes with verdict `clean`; all configured angles pass; if parallel execution is impractical, still run all configured lenses and explicitly record the limitation.
+- **Acceptance criteria verification:** follow the canonical procedure in [Acceptance Criteria Verification](../docs/acceptance-criteria-verification.md) before posting the `pre_approval_gate` comment.
+- **Next step after passing:** continue the Step 7 flow and then proceed to the human approval checkpoint below.
+- **Non-substitution rule:** a clean `pre_approval_gate` comment is separate from `draft_gate` evidence. It governs final-approval readiness for that head SHA; it does **not** replace the required `draft_gate` evidence for leaving draft.
+- **Required PR comment:** post a visible checkpoint verdict comment using the mandatory [Gate comment command](#mandatory-gate-comment-command-contract). Keep validation reporting concise: include command names with pass/fail status. Do **not** paste raw passing test output into the visible gate comment. If you include a failing validation excerpt, keep it focused and truncate it to a deterministic retained-prefix length before posting the comment. Do not declare final-approval readiness unless a visible `clean` `pre_approval_gate` checkpoint verdict comment exists for the current head SHA. Final-approval readiness must not rely only on local or hidden artifacts; the visible PR comment is the required auditable evidence. If the checkpoint verdict comment cannot be posted, fail closed and do not declare final-approval readiness. A checkpoint verdict comment for an older head SHA does not satisfy this requirement for the current head. If findings exist, follow-up fixes are required before final approval. The `pre_approval_gate` procedure must be entered and completed (visible comment posted) before any merge-ready or approval-ready declaration. Skipping the gate is not recoverable by asserting convergence. If fixes advance the head SHA, post a new checkpoint verdict comment for the new head.
+
+### Conflict-resolution gate
+
+Before any merge-ready or final-approval claim, run `detect-pr-gate-coordination-state.mjs` for the current PR. If it reports `gateBoundary=conflict_resolution` or `mergeStateStatus` is conflicted, stop the normal gate path immediately and use this recovery flow:
+
+1. fetch fresh `origin/main`, confirm the current PR head SHA, and summarize the conflict scope from `mergeStateStatus` plus any reported `conflictFiles`
+2. ask for explicit authorization before any rebase or other branch-state-changing reconciliation command
+3. after authorization, reconcile locally on the PR branch; default to rebase onto latest `origin/main`, unless the operator explicitly chooses another conflict-resolution command
+4. auto-resolve simple conflicts when the correct fix is mechanical and clearly in scope; report complex conflicts explicitly and fix them manually only for in-scope files
+5. rerun the smallest honest local validation for the touched conflict slice
+6. rerun `detect-pr-gate-coordination-state.mjs` for the new head
+7. because the head changed, rerun `pre_approval_gate` for the new head before any approval-ready or merge-ready claim
+8. wait for current-head CI again before retrying merge evaluation
+9. if the chosen reconciliation rewrote branch history (for example rebase), ask for explicit authorization before `git push --force-with-lease`, then continue the loop on the updated head
+
+`mergeStateStatus: CLEAN` alone is not enough to resume approval or merge claims. The existing merge-ready preconditions still apply: zero unresolved review threads, a clean current-head `pre_approval_gate`, and green current-head CI.
+
+### Merge-ready preconditions
+
+See [Merge Preconditions](../docs/merge-preconditions.md). Verify: zero unresolved threads (via `dev-loops gate capture-threads`), visible clean `draft_gate` + current-head `pre_approval_gate`, green CI. Fresh-context review follows [Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md).
+
+### Human approval checkpoint
+
+After merge-ready preconditions pass, verify [Merge Preconditions](../docs/merge-preconditions.md) authoritatively before reporting merge-ready. Stop at the human approval checkpoint by default. Cross-check via `dev-loops gate capture-threads` (not prose assertion).
+Follow [Merge Preconditions](../docs/merge-preconditions.md): stop at `waiting_for_merge_authorization` after approval unless merge explicitly authorized. Run pre-merge gate evidence check before any `gh pr merge`.
+
+### Mechanical pre-merge gate evidence check
+
+Immediately before any `gh pr merge`, run:
+
+```sh
+node <resolved-skill-scripts>/github/detect-checkpoint-evidence.mjs \
+  --repo <owner/name> \
+  --pr <number>
+```
+
+This helper is always-on: it uses `gh api` to fetch visible PR issue comments and fails closed unless both required gate comments exist: a clean `draft_gate` comment for the one-time draft boundary and a clean current-head `pre_approval_gate` comment. Do not run `gh pr merge` if this command exits non-zero. There is no opt-out flag. Resolved threads, green CI, clean Copilot rereview, or local notes do not substitute for this successful helper output. If a final approval or merge boundary sees `gh pr merge` without a same-boundary successful check, treat that as a workflow violation and stop.
+
+### Mandatory post-merge retrospective checkpoint write
+
+After a merge succeeds (or an explicit retrospective skip is authorized), write the durable retrospective checkpoint before exiting the subagent session:
+
+```sh
+node <resolved-skill-scripts>/loop/checkpoint-contract.mjs --state complete --notes "<one-line retrospective summary>"
+```
+
+For an explicit skip:
+
+```sh
+node <resolved-skill-scripts>/loop/checkpoint-contract.mjs --state skipped --reason "<why retrospective is skipped>"
+```
+
+Do not report completion or advance to the next PR queue item until `.pi/dev-loop-retrospective-checkpoint.json` is updated to `complete` or `skipped`.
+
+## Validation policy
+
+Follow [Validation Policy](../docs/validation-policy.md). Default: `npm run verify` before PR creation, gate entry, and merge. For repo-local examples: `npm run test:dev-loop` for skill scripts, contract tests for templates, `git diff --check` for docs. When CI runs exist, use `gh run watch` or `detect-copilot-loop-state.mjs` instead of `sleep`-based polling. Distinguish: locally validated, full PR-equivalent checks, awaiting CI.
+
+## Confirmation checkpoints
+
+See [Confirmation Rules](../docs/confirmation-rules.md). Stop and ask before GitHub mutations (edits, assignments, labels, comments, reviews, thread resolution, commits, pushes, merges, workflows) unless explicitly authorized.
+
+## Stop conditions
+
+Follow [Stop Conditions](../docs/stop-conditions.md). Genuine stops: `blocked` state, `done`, `approval_ready` without merge auth, ambiguous state, scope drift. Non-stops: `waiting` watcher states, quiet observations.
+
+## Anti-patterns
+
+See [Anti-patterns](../docs/anti-patterns.md). Key repo-specific additions:
+- Use `reply-resolve-review-thread.mjs` / `reply-resolve-review-threads.mjs` helpers instead of ad hoc `gh api`/`gh api graphql` thread-mutation commands. Do NOT use `gh pr comment`, `gh api`, or `gh pr review` for gate comments (use `upsert-checkpoint-verdict.mjs`).
+- Do not declare merge-ready without visible `pre_approval_gate` comment on current head SHA. Do not declare merge-ready based solely on `mergeable_state: clean` + CI green without gate evidence. CI green + resolved threads alone is insufficient.
+- Do not blind-run `gh pr merge`/`gh pr update-branch`/unapproved rebase when conflicted. Do not dispatch async dev-loop tasks that omit the pre-approval gate requirement.
+- Do not assume generated wiki is authoritative over code or CI.
+
+## Output expectations
+
+When using this skill, keep user-facing summaries concise and operational.
+
+A good status update should say:
+- what issue or PR you inspected
+- current state
+- what the next recommended action is
+- whether authorization is needed before taking it

--- a/.claude/skills/dev-loop/SKILL.md
+++ b/.claude/skills/dev-loop/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: "dev-loop"
+description: "Single public dev-loop entrypoint. Resolve canonical current state first, then load only route-specific internal skills."
+allowed-tools: Read Bash Edit Write Agent
+user-invocable: true
+---
+<!-- GENERATED from skills/dev-loop/SKILL.md by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate. -->
+
+
+**No-implicit-start rule:** Never start implementation without explicit instruction.
+
+**Work-origin rule:** All work must originate from a tracked artifact: a GitHub issue (tracker-first) or a persisted markdown plan file (local-planning). See [Artifact Authority Contract](../docs/artifact-authority-contract.md) for canonical mode definitions and settings. No work may originate from a PR or direct local change unless explicitly requested.
+
+# Unified Dev Loop
+
+This is the public `dev-loop` façade — a summary of the authoritative routing contract. The authoritative contract is [Public Dev Loop Contract](../docs/public-dev-loop-contract.md). Runtime evaluator: `@dev-loops/core/loop/public-dev-loop-routing`. For status/progress/readiness/merge-state/next-step queries, resolve authoritative artifact identity first; for issue targets, identity resolution is handled by the startup resolver. Fail closed to reconcile/unknown when unresolved. When an open linked PR exists, treat it as the single canonical artifact for the issue and reuse it instead of opening another PR.
+
+## Installed skill layout
+
+Required installed runtime contract docs are shared bundled copies under `../docs/` from this skill directory. Read those bundled `../docs/` files from the installed skill layout — do not assume a source checkout. If a required bundled contract doc is missing, treat it as a packaging/installer bug.
+
+## Startup procedure
+
+### Main agent (read-only)
+
+The main agent must **always** dispatch the `dev-loop` async subagent for any dev-loop work.
+Do not run `dev-loops loop startup` or any startup resolver in the main agent.
+The resolver requires `PI_SUBAGENT_RUN_ID` for async-required routes (the default `required` mode); the startup resolver can also run without it for non-async routes. Regardless, only the `dev-loop` async subagent runs it — never the main agent.
+
+### Dev-loop subagent (post-dispatch)
+
+The subagent resolves authoritative state via the startup resolver (`npx dev-loops loop startup --issue <n>` for issues, `npx dev-loops loop startup --pr <n>` for PRs), then immediately builds the handoff envelope via `npx dev-loops loop build-envelope --input <resolver-output.json>`. The envelope determines `requiredReads`, `nextAction`, `stopRules`, and `acceptance` — load only those files, execute only that bounded task. It is the first handoff artifact consumed before loading any route pack. See [Workflow Handoff Contract](../docs/workflow-handoff-contract.md) for the derivation contract.
+
+**Retrospective checkpoint gate:** the resolver reads `.pi/dev-loop-retrospective-checkpoint.json` and injects the state. When the checkpoint is `missing` and the repo config `workflow.requireRetrospective` (set via `.devloops` at repo root) is `true`, the resolver returns `needs_reconcile`. Complete or explicitly skip the retrospective before starting.
+
+**Pre-delegation gate (mandatory — subagent only):** Before delegating async work targeting an existing PR, the dev-loop subagent must run `node scripts/loop/copilot-pr-handoff.mjs --repo <owner/name> --pr <number>` and abort if `action: "stop"`. When `terminal: true`, proceed inline. When `terminal: false`, resolve the blocking condition first.
+
+**Worktree cwd (mandatory — subagent only):** Always use a worktree checkout for git operations, file reads/writes, and validation commands — never use the `main` checkout.
+
+**Worktree fetch (mandatory — subagent only):** Always run `git fetch origin` before creating or reusing any worktree.
+
+### Resume from existing loop state
+
+When the startup resolver returns a fresh-start routing but an existing outer-loop checkpoint
+(`tmp/copilot-loop/<owner>/<repo>/pr-<n>/outer-loop-state.json`) is present on disk, the
+subagent must check the checkpoint before treating the start as a fresh intake or follow-up:
+
+1. Read the outer-loop checkpoint (authored by `outer-loop.mjs`).
+2. If `outerAction` is `continue_wait`, `reenter_copilot_loop`, or `reenter_reviewer_loop`:
+   - Skip issue-intake normalization or fresh-intake routing.
+   - Route directly to the existing PR's follow-up path (the PR number is in the
+     checkpoint's `pr` field). For `reenter_copilot_loop`, enter the copilot-pr-followup
+     path. For `reenter_reviewer_loop`, enter the reviewer-loop path.
+   - Use the checkpoint's `copilotState` and `reviewerState` as last-known context for
+     re-attachment, then re-baseline with fresh detectors (`copilot-pr-handoff.mjs`
+     or `detect-copilot-loop-state.mjs`) before acting on the state.
+3. If `outerAction` is `stop`:
+   - Report the `reason` field and the authoritative state from the checkpoint.
+   - `stop` means the loop is blocked or needs a human decision; ask for direction
+     rather than guessing or starting fresh.
+4. If no checkpoint exists, or `outerAction` is `done`:
+   - Treat as normal fresh startup (the existing startup resolver path).
+
+This eliminates the manual "report-and-resume" or "exit and resume later" pattern when the
+deterministic state already knows the next action.
+
+The outer-loop checkpoint is the canonical re-attachment artifact. Do not rely on chat
+context, local notes, or prose recollection of "where we left off."
+
+## Route table
+
+Load only the route-specific internal skill required by `selectedStrategy`:
+
+| Strategy | Route pack to load |
+| --- | --- |
+| `local_implementation` | [Local Implementation Skill](../local-implementation/SKILL.md) |
+| `issue_intake` | [Copilot PR Follow-up Skill](../copilot-pr-followup/SKILL.md) + [Copilot Loop Operations](../docs/copilot-loop-operations.md) + [Issue Intake Procedure](../docs/issue-intake-procedure.md) |
+| `copilot_pr_followup` | [Copilot PR Follow-up Skill](../copilot-pr-followup/SKILL.md) + [Copilot Loop Operations](../docs/copilot-loop-operations.md) |
+| `external_pr_followup` | same as `copilot_pr_followup` |
+| `reviewer_fixer` | same as `copilot_pr_followup` |
+| `wait_watch` | same as `copilot_pr_followup` |
+| `final_approval` | same as `copilot_pr_followup` + [Final Approval Skill](../final-approval/SKILL.md) |
+
+Do not preload route packs before the resolver selects the strategy.
+
+## Async dispatch
+
+**Async dispatch rule (enforced):** the resolver enforces fail-closed for GitHub-first strategies when `canonicalStateSummary.requiresAsyncDispatch` is `true` (default `required` mode). Inline invocation without `PI_SUBAGENT_RUN_ID` is rejected only for those routes. See [Startup procedure](#startup-procedure).
+
+
+## Fallback gate-comment poster
+
+When the `@dev-loops/core` package is not installed in the consumer repo, the full `scripts/github/upsert-checkpoint-verdict.mjs` helper (referenced from the copilot-pr-followup skill procedure) is unavailable. To keep the PR audit trail intact in that mode, the dev-loop skill ships a small gh-only fallback poster at `scripts/post-gate-verdict-fallback.mjs` (relative to the dev-loop skill root) that renders the same visible comment format and fails closed if posting cannot succeed.
+
+Use the fallback poster only when the full helper cannot be reached:
+
+1. Detect the missing helper: try `node scripts/github/upsert-checkpoint-verdict.mjs --help` from the consumer repo. If the script is absent or imports fail, switch to the fallback path.
+2. Invoke the fallback from the installed dev-loop skill directory: `node <resolved-skill-scripts>/post-gate-verdict-fallback.mjs --repo <owner/name> --pr <number> --head-sha <sha> --verdict <clean|findings_present|blocked> (--findings-summary <text> | --findings-file <path>) --next-action <text> [--gate <draft_gate|pre_approval_gate>]`.
+3. Treat every successful fallback-posted gate comment as a one-shot create with no idempotent same-head update: if the agent reruns the gate on the same head, a duplicate comment will be created. Detect duplicates manually and update manually if needed.
+4. Treat every fallback-posted gate comment as a degraded audit-trail artifact: the visible body uses the same parser-stable shape as the full helper (gate name, head SHA, verdict, blocking severities when applicable, findings summary, next action), but the helper skips stale-head detection, gate-coordination validation, blocking-severity count enforcement, and the internal-only PR short-circuit.
+5. If the fallback helper exits non-zero, stop the gate and report the posting failure: do not mark the PR ready for review and do not proceed to merge readiness until the comment is posted.
+
+When `@dev-loops/core` is available again, switch back to the full helper. The fallback poster is a degraded path, not a permanent replacement.
+
+## Read-only info shortcut
+
+The main agent may handle info/handoff requests directly via `npx dev-loops loop info` without dispatching the async `dev-loop` subagent:
+- `npx dev-loops loop info --issue <n>` — human-readable issue state summary (strategy, route, linked PR, next action)
+- `npx dev-loops loop info --pr <n>` — human-readable PR state summary (branch, CI, threads, rounds, action)
+- `npx dev-loops loop info --issue <n> --json` — machine-readable JSON output
+
+## Guard rules (subagent reference)
+
+**Handoff envelope precedence:** The subagent builds the envelope immediately after authoritative-state resolution and treats it as the first handoff artifact. Read it first, load only `requiredReads`, execute `nextAction`. See [Dev-loop subagent](#dev-loop-subagent-post-dispatch). Derivation contract: [Workflow Handoff Contract](../docs/workflow-handoff-contract.md).
+
+**Handoff contract rule:** When no envelope is present, use the `workflow-handoff-contract.md` contract. Never delegate with abbreviated task summaries. Include deterministic routing inputs, explicit `cwd`, bounded task scope, exit conditions.
+
+**Inline-first rule:** Prefer inline commands over nested async delegation when managing a single PR. Use nested delegation only for parallel fan-out or when the parent needs to continue other work.
+
+**Bounded async task contract:** Break work into discrete tasks with clear inputs, explicit outputs, bounded scope. No shell polling — use `run-watch-cycle.mjs` or `gh run watch`.
+
+**Round-cap budget check (enforced):** After every watch cycle, fix pass, or reply-resolve, check whether completed Copilot review rounds have reached the maximum (default: 5). Stop re-requesting Copilot review when the limit is reached — never re-request after the cap.
+
+## Shorthand issue-based auto trigger contract
+
+- `auto dev loop on issue <n>` → public `dev-loop` intent `auto_continue_current` after authoritative current-state resolution
+- Continue through GitHub/Copilot loop until stop condition or human approval checkpoint
+- Stop at the human approval checkpoint by default unless merge explicitly authorized
+
+## No gate exemptions
+
+All PRs must pass the full gate pipeline before merge. No scope is exempt: docs-only, tooling, meta, configuration, internal-process — all require `draft_gate`, current-head `pre_approval_gate` evidence, and Copilot review (except internal-only PRs detected by path pattern, which skip the Copilot convergence requirement).
+
+## Authority boundary
+
+- Source code, tests, config, CI, and shared contract docs are authoritative.
+- Main-agent delegation contract: [Main Agent Contract](../docs/main-agent-contract.md) — absolute read-only boundary; all mutations flow through `dev-loop` async subagent.
+- Before any state-changing action, get explicit confirmation unless already authorized.
+- A question requires an answer, not an action.
+- Stop and ask rather than guessing when facts don't agree.

--- a/.claude/skills/final-approval/SKILL.md
+++ b/.claude/skills/final-approval/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: "final-approval"
+description: "Internal routed strategy behind `dev-loop` for the final human approval and merge gate. The canonical procedure now lives in copilot-pr-followup."
+allowed-tools: Read Bash Edit Write Agent
+user-invocable: false
+---
+<!-- GENERATED from skills/final-approval/SKILL.md by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate. -->
+
+
+# Final Approval (redirect)
+
+This route now uses [Copilot PR Follow-up Skill](../copilot-pr-followup/SKILL.md) as the canonical procedure owner.
+
+When the public router selects `final_approval`, load [Copilot PR Follow-up Skill](../copilot-pr-followup/SKILL.md)
+and follow its **Human approval checkpoint** section inside Step 7.
+
+Use this redirect only as a narrowed read-set pointer for the routed `final_approval` strategy.
+Do not restate merge-ready preconditions, gate evidence rules, or merge authorization policy here.

--- a/.claude/skills/local-implementation/SKILL.md
+++ b/.claude/skills/local-implementation/SKILL.md
@@ -1,0 +1,636 @@
+---
+name: "local-implementation"
+description: "Internal routed strategy behind `dev-loop` for local phase-bounded implementation. Use it when authoritative startup/resume routing selects the `local_implementation` strategy so the child agent can own phase planning, artifact discipline, test-first implementation, and local validation in fresh context."
+allowed-tools: Read Bash Edit Write Agent
+user-invocable: false
+---
+<!-- GENERATED from skills/local-implementation/SKILL.md by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate. -->
+
+
+# Local Implementation
+
+This skill is the canonical internal `local_implementation` route behind the public `dev-loop` façade.
+
+Use it only after the public dispatcher has already resolved `selectedStrategy: local_implementation`. This skill owns the local phase procedure and artifact discipline for that route; it does not redefine the shipped runtime semantics of helper CLIs, shared loop logic, or extension commands.
+
+Read the authoritative public routing contract at [Public Dev Loop Contract](../docs/public-dev-loop-contract.md) and keep any repository-specific decisions grounded in [Project Plan](../../PLAN.md), durable phase docs, source, tests, config, and actual validation commands.
+For UI validation under `dev-loop`, see [UI Validation Contract](../../docs/ui-validation-contract.md), [UI Smoke Harness](../../docs/ui-smoke-harness.md), [UI Artifact Contract](../../docs/ui-artifact-contract.md), and [UI Designer Review Loop](../../docs/ui-designer-review-loop.md) (designer + `uiReviewMode: vision`) (these are repo-level docs present in the source checkout; they are not part of the bundled `../docs/` runtime contract surface for installed skill copies).
+
+## Minimal required project inputs
+
+For a new project, the only required inputs are:
+
+1. [Project Plan](../../PLAN.md)
+2. [this skill file](./SKILL.md)
+
+Everything else is optional and may be bootstrapped by this skill.
+
+## Required startup reads
+
+Read the canonical entrypoint briefing first: [Entrypoint Strategies](../docs/entrypoint-strategies.md#local-implementation). Then read only what the current step needs:
+
+- [Agent Instructions](../../AGENTS.md) (repo constitution)
+- [Public Dev Loop Contract](../docs/public-dev-loop-contract.md)
+- [Retrospective Checkpoint Contract](../docs/retrospective-checkpoint-contract.md) (when async state applies)
+- [Project Plan](../../PLAN.md) and phase/tracker docs when relevant
+- Relevant issue/PR, validation surface, and task files
+
+Treat missing optional files as normal bootstrap conditions, not errors.
+
+### Tracker-backed local implementation
+
+Local implementation supports two durable spec inputs:
+
+- phase-doc-backed local sessions ([Phase Plan](../../docs/phases/phase-x.md) is canonical)
+- tracker-backed local sessions (the tracker issue is canonical)
+
+Tracker-backed local implementation stays inside the existing `local_implementation` path. For sub-issue tree decomposition, see [Sub-Issue Tree Contract](../../docs/sub-issue-tree-contract.md) (this is a source-repo reference; it is not part of the bundled `../docs/` runtime contract surface for installed skill copies). It does not introduce a new routing mode.
+
+When the local spec already lives in a tracker issue:
+
+- resolve the tracker reference deterministically from a GitHub issue URL or explicit `<owner/name>` + issue number
+- use the bounded GitHub helper `scripts/github/resolve-tracker-local-spec.mjs` when you need a machine-readable spec bundle
+- treat the tracker issue title/body/url/state as the durable local spec bundle
+- do not create or read [Phase Plan](../../docs/phases/phase-x.md) for that same tracker-backed session
+- sync durable scope / acceptance / status changes back to the tracker issue rather than maintaining a duplicate local phase doc
+- keep `tmp/` as temporary local execution state only; it does not become a second durable spec surface
+- for tracker-backed sessions, the handoff path is always: push the working branch → open a PR → merge via GitHub
+- for tracker-backed sessions, PR creation must always include `--assignee @me` so the new PR is self-assigned, and the PR body must contain `Closes #N` (or `Fixes #N`) for the linked issue so GitHub auto-closes it on merge. When `.devloops` sets `workflow.requireDraftFirst` to true, use `dev-loops pr create-draft --assignee @me ...`. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate inspection is a real workflow boundary.
+- do not suggest a direct local-main merge for tracker-backed sessions; do not merge the working branch into local `main` at phase completion
+
+## Primary execution rules
+
+### Step 0: Pre-flight gate (mandatory for local_implementation)
+
+For the `local_implementation` strategy, before any planning or implementation mutation, run the pre-flight gate:
+
+```sh
+node scripts/loop/pre-flight-gate.mjs --expected-branch <working-branch> --check-subagents
+```
+
+Before creating or reusing a worktree for local implementation, always run `git fetch origin` first. Always create worktrees from a freshly fetched `origin/main`. The fetched `origin/main` is the authoritative base for all worktree creation.
+
+This validates:
+- Worktree isolation (current directory is under `tmp/worktrees/`)
+- Branch identity (current branch matches the working branch)
+- Subagent availability (subagents should be used for fan-out when available)
+
+If the gate fails, **stop and fix the violation** before proceeding. Do not bypass the gate in normal workflow execution.
+
+Note: `--check-subagents` is advisory — it reports availability but does not block the gate. The worktree and branch checks are the mandatory gates.
+
+This gate does **not** apply to other routed strategies (`copilot_pr_followup`, `external_pr_followup`, `reviewer_fixer`, `wait_watch`, `final_approval`, `issue_intake`). Those strategies have their own execution rules and may edit code from any checkout as needed.
+
+Development-only bypass (`PI_PREFLIGHT_BYPASS=1`) exists for testing the gate itself but must not be used in production workflow runs. The bypass variable is a testing convenience, not an operational escape hatch.
+
+### Step 1
+
+- Implement **one phase at a time**.
+- Do not refine later phases in detail before the current phase is complete.
+- Use the `refiner` agent for phase-refinement work when subagents are available; escalate RFC-worthy technical decisions to the parent session / human operator.
+- Work **test-first** for all non-trivial logic.
+- Maintain **90% coverage** thresholds.
+- Log detailed iteration artifacts under `tmp/` using the required structure below.
+- For phase-doc-backed local sessions, keep durable phase intent and acceptance criteria in [Phase Plan](../../docs/phases/phase-x.md); for tracker-backed local sessions, keep that durable intent in the tracker issue and do not duplicate it into [Phase Plan](../../docs/phases/phase-x.md). Keep detailed execution artifacts in `tmp/`.
+- Treat `tmp/` as temporary local execution state. Do not rely on it as durable repo history and do not force-add it to git unless the user explicitly wants checked-in examples or fixtures.
+- When a phase changes durable product truth in ways `PLAN.md` should express (for example command surface, accepted product decisions, resolved open questions, or scope changes), update [Project Plan](../../PLAN.md) before closing the phase.
+- Do implementation work on a dedicated local branch, not directly on `main`.
+- If the repo has no commits yet, still create the working branch first so the first commits land off `main`; only move `main` forward after review and validation.
+- Use small atomic local commits as progress checkpoints whenever a coherent slice is green and reviewable.
+- Before a branch is considered review-complete, approval-ready, merge-ready, or ready for final handoff, run the default pre-approval gate as a full review / fix loop with the review angles resolved from config (`resolveGateAngles(config, "preApproval")`), then apply accepted fixes and rerun validation. Shipped defaults include the `deep` angle.
+- A phase is only fully complete when its scoped work, required support files, artifacts, validation, review/fix pass, commit(s), and finalization (merge into local `main` for phase-doc-backed sessions; PR merge for tracker-backed sessions) are done, or when the only remaining step is an explicitly noted authorization-gated finalization action.
+- When subagents are used, log what each subagent was asked to do and what it concluded.
+- If [Project Plan](../../PLAN.md) is too rough or ambiguous to safely start the current phase, do not guess: run a clarification/interview step with the user first.
+
+## Structural quality
+
+Apply [Structural Quality](../docs/structural-quality.md) from the `deep` review angle.
+
+## Light mode (small changes) — config-only
+
+Light mode is currently **config-only**: the schema, resolver, and scope detector are implemented, but no functional wiring exists yet in the local-implementation flow. When scope is small enough, the intent is to skip fan-out/fan-in and use a single review pass instead. Light mode will still require validation and pre-approval gate once wired.
+
+**Eligibility:** ≤3 files AND ≤200 lines changed (configurable via `.devloops` field `localImplementation.lightMode`).
+
+Use `scripts/loop/detect-change-scope.mjs` to determine eligibility:
+```sh
+node scripts/loop/detect-change-scope.mjs
+```
+
+**Planned light mode path (not yet wired):**
+1. Validation (`npm run verify`)
+2. Single review pass (not multi-angle fan-out)
+3. Pre-approval gate
+4. Finalization
+
+**Override threshold:**
+```yaml
+localImplementation:
+  lightMode:
+    enabled: true
+    maxFiles: 5
+    maxLines: 300
+```
+
+Disabled by default (opt-in). Scope above threshold falls back to full fan-out/fan-in path.
+
+## Deterministic logging structure
+
+Treat the workflow as three layers:
+- [Project Plan](../../PLAN.md) = strategic product and architecture truth
+- [Phase Plan](../../docs/phases/phase-x.md) or the canonical tracker issue = durable per-phase plan and acceptance criteria for the active local session
+- `tmp/` = temporary local execution audit trail and machine-friendly continuation state
+
+Maintain the core paths below while the phase is active locally, and create optional artifacts only when they are actually used:
+
+Core paths:
+- for phase-doc-backed local sessions: [Phase Plan](../../docs/phases/phase-x.md)
+- `tmp/phases/index.json`
+- `tmp/phases/phase-x/manifest.json`
+- `Variant A` (`tmp/phases/phase-x/variant-a.md`)
+- `Variant B` (`tmp/phases/phase-x/variant-b.md`)
+- `Merged Plan` (`tmp/phases/phase-x/merged-plan.md`)
+- `Phase Review` (`tmp/phases/phase-x/review.md`)
+- `Phase Summary` (`tmp/phases/phase-x/summary.md`)
+- `Retrospective` (`tmp/phases/phase-x/retrospective.md`)
+
+Optional when used:
+- `Variant C` (`tmp/phases/phase-x/variant-c.md`)
+- `tmp/phases/phase-x/subagents/`
+- `tmp/phases/phase-x/subagents/raw/`
+- `tmp/phases/phase-x/bash-exit-1.jsonl`
+- `Clarification Log` (`tmp/phases/phase-x/clarification.md`)
+- in dev mode: `tmp/phases/phase-x/dev-mode-context.json`
+- in dev mode: `Dev Mode Review` (`tmp/phases/phase-x/dev-mode-review.md`) as optional analytical notes when they help shape the retrospective
+- in dev mode: `Dev Mode Retrospective` (`tmp/phases/phase-x/dev-mode-retrospective.md`)
+- in dev mode: `Dev Mode Skill Changes` (`tmp/phases/phase-x/dev-mode-skill-changes.md`)
+
+Use the templates in `../dev-loop/templates/` (the sibling `skills/dev-loop/templates/` directory in this repo).
+
+Use deterministic helper scripts from `../dev-loop/scripts/` (the sibling `skills/dev-loop/scripts/` directory in this repo; in installed-skill layouts these live at `../dev-loop/scripts/` relative to this skill file, not inside this skill's own directory) for repeatable support tasks such as phase initialization, phase-file updates, template materialization, bash-exit logging, and dev-mode context collection.
+
+## Bootstrap missing support files
+
+If these files are missing, create them from the `../dev-loop/templates/` directory before continuing:
+
+- missing [Agent Instructions](../../AGENTS.md) -> create from [Bootstrap Agents Template](../dev-loop/templates/bootstrap-agents.md)
+- missing [Implementation State](../../docs/IMPLEMENTATION_STATE.md) -> create from [Bootstrap Implementation State Template](../dev-loop/templates/bootstrap-implementation-state.md)
+- missing [Implementation Workflow](../../docs/IMPLEMENTATION_WORKFLOW.md) -> create from [Bootstrap Implementation Workflow Template](../dev-loop/templates/bootstrap-implementation-workflow.md)
+- missing [Phase Plan](../../docs/phases/phase-x.md) for the active phase -> create from [Phase Doc Template](../dev-loop/templates/phase-doc.md)
+- missing `tmp/phases/index.json` -> create or reinitialize it
+
+The bootstrap files are support infrastructure. [Project Plan](../../PLAN.md) remains the product source of truth. For phase-doc-backed local sessions, [Phase Plan](../../docs/phases/phase-x.md) is the durable source of truth for the current phase's plan and acceptance boundary. For tracker-backed local sessions, the tracker issue is that durable source of truth, and no duplicate local phase doc should be bootstrapped.
+
+For bootstrap/setup phases, do not mark the phase `completed` or `awaiting-finalization` until the expected durable support files for the chosen workflow contract actually exist in the repository. Temporary `tmp/` execution artifacts do not need to be committed.
+## Plan sufficiency check
+
+Before phase planning, check whether [Project Plan](../../PLAN.md) contains enough information to proceed safely.
+
+At minimum, the current phase needs enough information to infer:
+- the goal of the phase
+- the main constraints
+- the intended scope or boundaries
+- at least rough acceptance criteria or success shape
+
+If that information is missing or too ambiguous, pause implementation and run a clarification/interview step.
+
+## Clarification / interview step
+
+When the plan is insufficient, use one of these modes:
+
+### Mode A — interactive clarification
+- ask only the missing high-value questions needed to safely refine the current phase
+- prefer a short interview or wizard-style sequence over one giant question dump
+- record the answers in `Clarification Log` (`tmp/phases/phase-x/clarification.md`)
+- update [Phase Plan](../../docs/phases/phase-x.md) with clarified durable phase intent, scope, or acceptance criteria
+- update [Project Plan](../../PLAN.md) only if the clarified information is durable product/project truth beyond the current phase
+- update [Implementation State](../../docs/IMPLEMENTATION_STATE.md) if the clarification changes the next phase boundary
+
+### Mode B — auto clarification
+Use this when the user explicitly asks for an auto option, says to just proceed, or is clearly optimizing for speed over discussion.
+
+In auto mode:
+- infer the smallest safe defaults for the current phase only
+- prefer conservative assumptions over ambitious ones
+- never auto-resolve product, security, or architecture decisions that could materially change scope
+- write all assumptions to `Clarification Log` (`tmp/phases/phase-x/clarification.md`)
+- mark them clearly as `auto-assumptions`
+- surface the assumptions in the phase plan audit so they can be challenged later
+- if an assumption is too risky to make safely, stop and ask the user anyway
+
+Do not begin fan-out planning until the current phase is sufficiently specified, either by user clarification or safe auto-assumptions.
+
+## Determine where to resume
+
+Read [Implementation State](../../docs/IMPLEMENTATION_STATE.md) and identify the next unfinished phase.
+Read [Phase Plan](../../docs/phases/phase-x.md) for that phase if it exists.
+
+If `tmp/phases/index.json` exists locally, use it as a fast index for prior artifacts.
+If the durable phase doc, the state file, and the tmp index disagree, trust docs first and note the mismatch in the phase plan audit log.
+
+If the state file is ambiguous, resolve ambiguity conservatively:
+- prefer the earliest clearly unfinished phase
+- do not skip ahead
+- note the ambiguity in the phase plan audit log under `tmp/`
+- if this is a first-run bootstrap, start from the earliest phase implied by [Project Plan](../../PLAN.md)
+
+## Phase planning loop
+
+For the **current phase only**, run this loop before implementation.
+
+### 1. Create or update the durable phase doc and tmp scaffold
+
+Use paths like:
+- `docs/phases/phase-0.md`
+- `tmp/phases/phase-0/`
+- `docs/phases/phase-1.md`
+- `tmp/phases/phase-1/`
+
+Create or update:
+- [Phase Plan](../../docs/phases/phase-x.md)
+- `tmp/phases/phase-x/manifest.json`
+- `tmp/phases/index.json`
+
+Prefer the deterministic helper:
+- `../dev-loop/scripts/init-phase.mjs`
+
+Use `../dev-loop/scripts/phase-files.mjs` only when you need a narrower manifest/index update without regenerating the standard phase-planning scaffold.
+
+### 2. Read the previous phase's learning before planning the next one
+
+If a previous phase exists, read:
+- its `summary.md`
+- its `retrospective.md`
+- any relevant subagent summaries
+
+Use those lessons to improve the current phase plan.
+
+### 2b. Optional bounded refinement audit
+
+Before variant fan-out, optionally run one bounded audit when the active phase would benefit from slop-risk discovery, structural drift discovery, or adjacent cleanup discovery.
+
+When used:
+- run one bounded audit before variant fan-out
+- write the audit artifact to `tmp/phases/phase-x/audit/refinement-audit-summary.json`
+- use `node scripts/loop/run-refinement-audit.mjs --paths ... --output tmp/phases/phase-x/audit/refinement-audit-summary.json`
+- pass a concise audit summary into every refiner briefing
+- keep the audit opt-in; do not turn it into a mandatory precondition
+- preserve prioritized findings, the highest-value follow-up candidates, and an explicit statement of what this phase will not rewrite or broaden in the merged plan and review artifacts
+
+### 3. Fan out short plan variants
+
+Write 2-3 short variants:
+- `Variant A` (`tmp/phases/phase-x/variant-a.md`) = smallest safe implementation
+- `Variant B` (`tmp/phases/phase-x/variant-b.md`) = best practical UX/developer-experience option within phase scope
+- `Variant C` (`tmp/phases/phase-x/variant-c.md`) = safest boundary/risk-reduction option when useful
+
+When subagents are available, the default refinement path should use the `refiner` role and **parallel fresh-context subagents** so the variants are independently generated rather than serially contaminated by one another. Pass each refiner a concise written briefing summary instead of relying on forked parent-session context.
+
+For future refinement hardening, treat the `variant-a` / `variant-b` pattern as the stable inner fan-out shape for a given persona or review angle. Do not switch personas halfway through one `a/b` pair. Instead, when more hardening is needed, run multiple fresh-context fan-out passes with different personas or angles, each with its own consistent `a/b` pair, and then merge across those persona-specific passes.
+
+Each refiner variant should make room for:
+- explicit non-goals
+- complete acceptance criteria
+- a complete definition of done
+- risks and unresolved questions
+- when a bounded audit artifact exists: prioritized findings, highest-value follow-up candidates, and what the phase will not rewrite or broaden
+- RFC escalation notes when technical decisions should go to the parent session / human operator
+- for watcher/predicate-heavy phases: explicit negative-case tests and timeout semantics, including any zero-timeout or single-check contract
+
+Use the template in [Phase Variant Template](../dev-loop/templates/phase-variant.md).
+
+Each variant should cover only:
+- scope for this phase
+- files/modules touched
+- tests to add first
+- implementation order
+- acceptance criteria
+- risks/non-goals
+
+When a phase includes a bounded audit, inventory, or scan:
+- treat the scan as a first-class deliverable rather than an implicit side note
+- require prioritized findings, not an unbounded dump
+- state explicitly what the scan does **not** authorize or rewrite in the current phase
+
+If subagents generate the variants:
+- run them in parallel with clean context when practical
+- give each variant generator a concise briefing summary that includes phase objective, in-scope work, constraints, known risks, and required outputs
+- keep each `variant-a` / `variant-b` pair anchored to one persona or refinement angle so the alternatives are directly comparable
+- when you want broader hardening, add another fan-out pass with a different persona or angle and its own `variant-a` / `variant-b` pair instead of blending multiple personas into one pair
+- do not fork the parent session just to share planning context; summarize it instead
+- save raw subagent outputs under `tmp/phases/phase-x/subagents/raw/` only when keeping the raw capture is actually useful
+- then write the human-oriented `Variant A` (`tmp/phases/phase-x/variant-a.md`) / `Variant B` (`tmp/phases/phase-x/variant-b.md`) / `Variant C` (`tmp/phases/phase-x/variant-c.md`) files from those raw outputs when applicable
+
+Update `manifest.json` with the planned artifact list and current status.
+
+### 4. Fan in to a merged phase plan
+
+Write:
+- `Merged Plan` (`tmp/phases/phase-x/merged-plan.md`)
+- update [Phase Plan](../../docs/phases/phase-x.md) with the selected durable phase plan
+
+Use the templates in [Merged Phase Plan Template](../dev-loop/templates/merged-phase-plan.md) and [Phase Doc Template](../dev-loop/templates/phase-doc.md).
+
+The merged plan must include:
+- exact scope for this phase
+- explicit non-goals
+- tests to write first
+- implementation order
+- validation steps
+- acceptance criteria
+- definition of done
+- when a bounded audit artifact exists: prioritized findings, highest-value follow-up candidates, and an explicit statement of what this phase will not rewrite or broaden
+- RFC escalation notes for any RFC-worthy technical decisions that must go to the parent session / human operator instead of being silently resolved during refinement
+- for any new CLI surface: explicit success-output and malformed-argument/error-contract expectations
+- for any watcher/predicate-driven behavior: explicit timeout semantics plus negative-case detection rules for non-target identities or events
+- for package-first phases in a source-loaded workspace: explicit expectations about whether callers consume shared logic through workspace/source adapters or published package import paths during local development
+
+The durable phase doc should capture the subset that a fresh human or agent should read first: objective, why now, scope, non-goals, acceptance criteria, definition of done, validation approach, durable decisions, and open questions.
+
+### 5. Review the merged phase plan adversarially
+
+Write:
+- `Phase Review` (`tmp/phases/phase-x/review.md`)
+
+Use the template in [Review Template](../dev-loop/templates/review.md).
+Ensure the durable phase doc still matches the reviewed plan; update [Phase Plan](../../docs/phases/phase-x.md) if the review changes accepted scope or criteria.
+
+The review must check for:
+- overreach beyond phase scope
+- KISS/SRP/YAGNI violations
+- missing tests
+- weak validation
+- unclear module boundaries
+- hidden coupling to Pi runtime internals
+- ambiguous acceptance criteria
+- unclear or incomplete definition-of-done output
+- missing review-surface completeness
+- weak RFC-escalation sanity when the plan surfaces an unresolved technical decision
+- for bounded audits/scans: missing prioritization or quiet expansion into a broad rewrite
+- for new CLI surfaces: weak malformed-argument or error-contract coverage
+- for watcher/predicate-heavy behavior: weak timeout semantics or missing negative-case tests for non-target activity
+- for package-first phases: ambiguous source-loaded workspace integration boundaries that leave local scripts/tests guessing how shared helpers are consumed
+
+If the review finds real issues, revise the merged plan and briefly update the review.
+
+### 6. Only then start implementation
+
+Do not begin coding before the merged phase plan has passed review.
+Update `manifest.json` to show that phase implementation has started.
+
+## Task breakdown & delegation
+
+After the merged phase plan passes review and before implementation starts, break the phase
+into parallel executable tasks and dispatch them to the right specialist subagents.
+
+### Task decomposition
+
+1. Read the merged phase plan and identify independent work slices.
+2. Break each slice into a discrete task with explicit acceptance criteria, required files,
+   and expected verification.
+3. Prefer parallel dispatch of non-overlapping tasks.
+4. Treat task ordering as: parallel-independent work first, then dependent work that requires
+   a prior task's output.
+
+### Delegation contract
+
+Dispatch implementation tasks to dedicated specialist agents:
+
+| Task type | Delegate to |
+|---|---|
+| Code changes, refactors, tests, bug fixes, feature work | `developer` |
+| Build systems, CI, test runners, type-checking, linting | `quality` |
+| README, plan docs, agent docs, migration notes | `docs` |
+| Review-comment follow-up, PR fix commits | `fixer` |
+
+For each delegated task:
+- give the subagent one focused task with exact success criteria
+- include only the minimum relevant files, plans, and repo context
+- tell the subagent whether it should implement, verify, or review
+- require the subagent to report blockers, verification results, and changed files
+- avoid circular delegation and overlapping scopes
+
+### Status monitoring
+
+Track each dispatched task:
+- at minimum record agent name, task summary, status (`queued`, `running`, `done`, `failed`),
+  and output artifacts
+- when tasks are dispatched asynchronously, check status periodically
+- if a subagent exits while the task is still non-terminal, resume or re-dispatch
+
+### Consolidation
+
+After all dispatched tasks complete:
+1. Collect results and verification output from each task.
+2. Review that each task's acceptance criteria are genuinely satisfied.
+3. Resolve any coordination gaps or overlapping changes.
+4. Proceed to the implementation loop for the phase once all tasks are green.
+
+## Subagent summary logging
+
+If subagents are used for planning, review, research, or implementation support:
+
+Create one summary file per subagent run under:
+- `tmp/phases/phase-x/subagents/`
+
+Recommended naming:
+- `001-planner.md`
+- `002-reviewer-correctness.md`
+- `003-reviewer-maintainability.md`
+- `004-worker-followup.md`
+
+Each summary must include a machine-readable header block using bullet-key format so
+`conductor-monitor.mjs` can detect and parse local phase subagent state:
+
+```
+- agent name: <developer|quality|docs|review|refiner|fixer>
+- status: <queued|running|completed|failed|paused>
+- run id: <subagent-run-id>
+- task: <one-line task summary>
+- cwd: <working directory>
+```
+
+Only `agent name` and `status` are required for conductor-monitor detection; the
+other fields improve resume-plan quality. The header block must start at the
+beginning of a line (no leading whitespace before the bullet).
+
+Below the header, include human-readable context:
+- whether it was sync or async
+- why it was used
+- main findings or output
+- files or artifacts it influenced
+- whether its advice was accepted, partially accepted, or rejected
+- raw output path if output was saved separately
+
+If the subagent ran asynchronously, update its summary when results arrive so fresh sessions can understand what happened without replaying the whole conversation.
+
+## Workflow-run subagent hand-off contract
+
+When handing off a full workflow run to a subagent (draft PR → gates → Copilot → merge),
+use the canonical hand-off contract. Do not rely on abbreviated task summaries or operator
+memory.
+
+The canonical contract is [Workflow Handoff Contract](../docs/workflow-handoff-contract.md) (source-tree path: `skills/docs/workflow-handoff-contract.md`). It includes:
+- direct contract-doc references the subagent must read before executing
+- a mandatory 8-step checklist (draft PR → draft_gate → ready → Copilot → resolve → pre_approval_gate → merge)
+- non-negotiable invariants (Copilot review loop between gates, `unresolvedThreadCount === 0`, visible gate comments)
+
+For all GitHub-first routed follow-up (`copilot_pr_followup`, `issue_intake`), the
+ `local-implementation` skill uses this template when delegating the full run to a subagent.
+Reference it by path, not by memory.
+
+## Implementation loop for the phase
+
+After the phase plan passes review:
+
+1. Write or update tests first.
+2. Implement only enough code for the current phase.
+3. Run local validation:
+   - `npm run verify`
+   - when a narrower local check is more honest for the touched slice, say so explicitly and run the narrowest justified subset instead of pretending the full verify path was unnecessary
+   - for user-facing HTML/UI/component slices when the user opts in, add a bounded deterministic browser smoke harness (prefer fixture-backed Playwright WebKit plus screenshot capture); use `npm run test:playwright:viewer` when that viewer/browser surface is part of the slice, and wire it into CI once it becomes required validation for that slice
+   - **Commit immediately after validation passes.** Once `npm run verify` (or the narrowest justified validation subset) is green, stage and commit the current slice of work with an atomic commit message. For tracker-backed sessions, also push the commit. In non-interactive subagent sessions, commit authorization is implicit — the subagent was dispatched to implement and must commit before exiting. In interactive sessions, wait for coordination agent authorization. Do not defer commits — uncommitted changes when the session terminates are a workflow defect.
+4. Review the implementation against the merged phase plan.
+5. Run the default pre-approval gate as a full review / fix loop on the branch before calling it review-complete, approval-ready, merge-ready, or ready for final handoff:
+   - resolve review angles from config: `resolveGateAngles(config, "preApproval")` from `@dev-loops/core/config` (shipped defaults enable all 11 pre-approval gate angle families; consumer repos may opt out individual angles via `excludeAngles`); run via the chain prescription below
+   - run the resolved angle-focused passes in parallel with fresh context when practical
+   - if parallel execution is impractical (for example due to tooling or resource constraints), run all angles sequentially and explicitly record why parallel execution was impractical in `Phase Review` (`tmp/phases/phase-x/review.md`) (or the equivalent merged review artifact)
+   - for each angle, resolve its persona and prompt via `resolveReviewerRole(config, angle)` — start each reviewer in fresh context with a concise briefing including the angle-specific prompt, the branch/phase, intended behavior, acceptance criteria, relevant files or artifacts, and current validation status
+   - run the mandatory chain defined in [Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md). Retry rule: in subsequent cycles, only re-run reviewers that produced findings in the previous pass. Do not fork the parent session for parallel reviewers; write a compact handoff artifact under `tmp/` and point the reviewer at it.
+   - when reviewer subagents stumble on raw source-tree reads (for example unresolved build artifacts or import assumptions), generate a deterministic diff/review artifact under `tmp/` and have reviewers inspect that artifact instead of the raw file set
+   - synthesize actionable findings
+   - apply accepted fixes on the same branch
+   - rerun validation after fixes
+   - log review artifacts and subagent summaries under `tmp/`
+6. Update [Phase Plan](../../docs/phases/phase-x.md) so it reflects the phase as actually implemented, including any accepted scope or validation changes.
+7. Update [Project Plan](../../PLAN.md) when the phase changed durable product truth, resolved an open question, or made the shipped command/behavior surface more concrete.
+8. Write `Phase Summary` (`tmp/phases/phase-x/summary.md`) using [Phase Summary Template](../dev-loop/templates/phase-summary.md).
+9. Write `Retrospective` (`tmp/phases/phase-x/retrospective.md`) using [Retrospective Template](../dev-loop/templates/retrospective.md).
+10. Update `tmp/phases/phase-x/manifest.json` and `tmp/phases/index.json`.
+11. Update [Implementation State](../../docs/IMPLEMENTATION_STATE.md).
+12. **Exit validation gate — no uncommitted changes.** Before the subagent session terminates, run `git status --porcelain` and verify the output is empty. If uncommitted changes exist, first determine whether they are intended implementation changes or unintended/post-validation deltas. Revert any unintended or speculative changes. For intended changes, rerun the narrowest justified validation (`npm run verify` or equivalent) before staging and committing with an appropriate message; for tracker-backed sessions, also push the branch. A subagent session that exits with uncommitted changes in the worktree is a workflow defect and must not be treated as a clean completion. After committing, verify `git status --porcelain` is empty before declaring phase completion.
+13. For tracker-backed sessions, create a draft PR from the working branch using `dev-loops pr create-draft --assignee @me --repo <owner/name> --base main --head <branch> --title "..." --body-file <body-file>`. When the `dev-loops` CLI helper is unavailable, use the equivalent `create-draft-pr.mjs` script directly: `node <resolved-skill-scripts>/github/create-draft-pr.mjs --repo <owner/name> --assignee @me --base main --head <branch> --title "..." --body-file <body-file>`. The PR body must contain `Closes #N` (or `Fixes #N`) for the linked issue. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy.
+14. If authorized, merge the fully reviewed, locally validated phase branch back into local `main` (phase-doc-backed sessions) or proceed through the PR gate pipeline (tracker-backed sessions).
+15. If authorization for PR creation or merge is still pending (commit authorization is already enforced by the exit validation gate in step 12), mark the phase as `awaiting-finalization` rather than `completed`, and record exactly which finalization step is pending.
+
+## Retrospective requirements
+
+The retrospective must capture:
+- what worked well in the local dev loop
+- what caused friction or waste
+- whether the fan-out/fan-in/review loop improved the phase
+- what should change in the skill or workflow next time
+- what a fresh session should know before the next phase
+
+This is the infrastructure for self-improvement. Do not skip it.
+
+## Dev mode
+
+Dev mode is for improving the local implementation loop itself while using it.
+
+A repository may also declare a formal-dev-mode default through `.devloops` field `workflow.devModeDefault`. Treat that config as the policy source of truth when present, but explicit user opt-in or opt-out for the current run still wins. Runtime consumption of that config may be staged separately from this documentation update.
+
+Trigger it when the user explicitly asks for dev mode, self-improvement mode, or says they want the skill to refine itself as it goes.
+
+In dev mode, after the normal phase summary and retrospective are written, run one extra bounded self-improvement pass before moving on:
+
+1. collect a deterministic context bundle for the phase using:
+   - `../dev-loop/scripts/dev-mode-context.mjs`
+   - output to `tmp/phases/phase-x/dev-mode-context.json`
+2. review the phase artifacts and logs with emphasis on the workflow itself:
+   - planning quality
+   - review quality
+   - validation friction
+   - bash exit-code-1 patterns
+   - places where skill or agent prompts should be tightened
+   - places where deterministic tooling should replace ad hoc work
+3. write `Dev Mode Retrospective` (`tmp/phases/phase-x/dev-mode-retrospective.md`)
+   - this is the required dev-mode retrospective artifact
+   - it should name the highest-value prompt/workflow follow-ups revealed by the phase
+4. optionally write `Dev Mode Review` (`tmp/phases/phase-x/dev-mode-review.md`) when separate analytical notes help support the retrospective
+5. apply at least one bounded follow-up update to a relevant skill and/or agent prompt
+   - deterministic tooling, docs, templates, or tests may accompany that change
+   - but they do not replace the required prompt update
+   - keep the change phase-bounded and tied directly to the retrospective findings
+6. write `Dev Mode Skill Changes` (`tmp/phases/phase-x/dev-mode-skill-changes.md`)
+   - record which skill and/or agent prompts changed
+   - record any supporting tooling/docs/template changes that accompanied them
+   - if no prompt update can be justified safely, stop and report that dev-mode exit criteria were not met
+7. if skill scripts or deterministic tooling changed, rerun the skill-local tests
+8. stop after this bounded self-improvement pass; do not recurse into endless self-editing loops
+
+Dev mode is still phase-bounded. It improves the loop around the completed phase; it does not authorize work on the next product phase.
+
+## tmp/ logging requirements
+
+At minimum, each phase should leave behind:
+- a durable phase doc at [Phase Plan](../../docs/phases/phase-x.md)
+- local `tmp/` execution artifacts needed to resume and audit the phase, including:
+  - `manifest.json`
+  - `Variant A` (`tmp/phases/phase-x/variant-a.md`)
+  - `Variant B` (`tmp/phases/phase-x/variant-b.md`)
+  - `merged-plan.md`
+  - `review.md`
+  - `summary.md`
+  - `retrospective.md`
+  - optional `Variant C` (`tmp/phases/phase-x/variant-c.md`) when a third variant was actually useful
+  - `bash-exit-1.jsonl` when any bash call during the phase exited with code `1`
+  - `clarification.md` when a plan-sufficiency interview or auto-clarification step was needed
+  - subagent summaries when subagents were used
+  - raw subagent outputs only when they were saved separately on purpose
+  - in dev mode: `dev-mode-context.json`, `dev-mode-retrospective.md`, and `dev-mode-skill-changes.md`
+  - optional in dev mode: `dev-mode-review.md` when separate analytical notes were useful
+
+These `tmp/` artifacts are normally temporary and do not need to be checked into git.
+
+Also log validation output summaries and notable decisions if they help evaluate the local dev loop later.
+
+Additionally, append every bash call that exits with code `1` to:
+- `tmp/phases/phase-x/bash-exit-1.jsonl`
+
+Use the deterministic helper:
+- `../dev-loop/scripts/log-bash-exit-1.mjs`
+
+Each line should be one JSON object with at least:
+- `timestamp`
+- `phase`
+- `cwd`
+- `command`
+- `exitCode`
+- `purpose`
+- `summary`
+
+If useful, also include truncated `stdout` and `stderr` fields or a path to a larger saved artifact. This log is for improving the local dev loop itself, so do not skip it just because the command was exploratory.
+
+## Stop conditions
+
+See [Stop Conditions](../docs/stop-conditions.md). Local-specific stops: phase completed & finalized, next-phase refinement needed, user/main-agent approval required, validation failure needing direction change.
+
+## Branch / review / merge policy
+
+- Do not implement directly on `main`.
+- Start or switch to a dedicated local working branch before the first mutating step.
+- If the repository is unborn (no commits yet), still create the working branch first and make the initial atomic commits there.
+- Use atomic local commits to log progress, but only for coherent reviewable slices.
+- Before merging, run a full parallel review / fix loop and resolve accepted findings on the same branch.
+- Rerun validation after review-driven fixes.
+- A phase is not operationally closed until its branch state is captured in commit history and the reviewed branch has been finalized according to session type (merged into local `main` for phase-doc-backed sessions; merged via GitHub PR for tracker-backed sessions), unless authorization for that finalization is still pending.
+- For tracker-backed sessions, the handoff path is always: push the working branch → open a PR → merge via GitHub; never merge the working branch into local `main`.
+- PR creation must always include `--assignee @me` so the new PR is self-assigned, and the PR body must contain `Closes #N` (or `Fixes #N`) for the linked issue so GitHub auto-closes it on merge. When `.devloops` sets `workflow.requireDraftFirst` to true, use `dev-loops pr create-draft --assignee @me ...`. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate inspection is a real workflow boundary, so a new PR must exist in draft before `gh pr ready` is eligible.
+- When authorization is pending, record the phase as `awaiting-finalization` and describe the exact missing step.
+- For phase-doc-backed sessions, merge the fully reviewed, locally validated branch back into local `main` when authorized.
+
+## Commit policy
+
+- Do not commit speculative work.
+- Do not commit before the relevant validation for that slice passes.
+- Immediately before every `git add && git commit` sequence, assert branch identity with `git branch --show-current` and stop if it does not match the intended local working branch.
+- Keep commits small and phase-bounded.
+- Do not leave completed phase work stranded off `main`; once the reviewed branch is ready and authorized, finalize it according to session type (merge into local `main` for phase-doc-backed sessions; complete via PR merge for tracker-backed sessions).
+- Commit only when the coordination/main agent has decided the slice or phase is ready. **Exception:** in non-interactive subagent sessions, commit authorization is implicit — the subagent was dispatched to implement and must commit before exiting (see the commit sub-bullet under implementation loop step 3 and the exit validation gate in step 12).
+- If commit/merge authorization has not yet been given, do not call the phase `completed`; call it `awaiting-finalization` instead.
+- **Subagent exit contract:** before a subagent session terminates, the exit validation gate (implementation loop step 12) must pass — `git status --porcelain` must be empty. A subagent that exits with uncommitted changes in the worktree has not completed its task, regardless of what was implemented.
+
+## Anti-patterns
+
+See [Anti-patterns](../docs/anti-patterns.md). Local-specific: don't assume optional plan docs exist, don't guess through missing plan details, don't skip fan-out/fan-in, don't skip `tmp/` artifacts, don't use subagents without readable summaries.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,7 @@
     "./cli/primitives": "./src/cli/primitives.mjs",
     "./cli/retry-wrapper": "./src/cli/retry-wrapper.mjs",
     "./cli/subcommand-runner": "./src/cli/subcommand-runner.mjs",
+    "./claude/asset-generation": "./src/claude/asset-generation.mjs",
     "./config": "./src/config/config.mjs",
     "./debt/cluster": "./src/debt/cluster.mjs",
     "./debt/finding": "./src/debt/debt-finding.mjs",

--- a/packages/core/src/claude/asset-generation.mjs
+++ b/packages/core/src/claude/asset-generation.mjs
@@ -37,17 +37,6 @@ export const TOOL_NAME_MAP = Object.freeze({
   review_loop: ["Agent"],
 });
 
-/** Pi-only agent frontmatter fields with no faithful Claude agent equivalent (dropped). */
-export const DROPPED_AGENT_FIELDS = Object.freeze([
-  "argument-hint",
-  "systemPromptMode",
-  "inheritProjectContext",
-  "inheritSkills",
-  "maxSubagentDepth",
-  "user-invocable",
-  "tools",
-]);
-
 const GENERATED_NOTE = (source) =>
   `<!-- GENERATED from ${source} by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate. -->`;
 
@@ -82,12 +71,18 @@ export function mapTools(tools) {
  * @param {string} raw
  * @returns {{ frontmatter: Record<string, unknown>, body: string }}
  */
-export function splitFrontmatter(raw) {
+export function splitFrontmatter(raw, source) {
+  const where = source ? ` (${source})` : "";
   const match = String(raw).match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
   if (!match) {
-    throw new Error("source file is missing a leading YAML frontmatter block");
+    throw new Error(`source file is missing a leading YAML frontmatter block${where}`);
   }
-  const frontmatter = parseYaml(match[1]) ?? {};
+  let frontmatter;
+  try {
+    frontmatter = parseYaml(match[1]) ?? {};
+  } catch (error) {
+    throw new Error(`failed to parse YAML frontmatter${where}: ${error instanceof Error ? error.message : String(error)}`);
+  }
   return { frontmatter, body: match[2] };
 }
 
@@ -108,7 +103,7 @@ function normalizeToolList(value) {
  * @returns {string} Full generated file content.
  */
 export function transformAgent({ source, raw }) {
-  const { frontmatter, body } = splitFrontmatter(raw);
+  const { frontmatter, body } = splitFrontmatter(raw, source);
   const tools = mapTools(normalizeToolList(frontmatter.tools));
 
   const lines = ["---"];
@@ -131,7 +126,7 @@ export function transformAgent({ source, raw }) {
  * @returns {string} Full generated file content.
  */
 export function transformSkill({ source, raw }) {
-  const { frontmatter, body } = splitFrontmatter(raw);
+  const { frontmatter, body } = splitFrontmatter(raw, source);
   const tools = mapTools(normalizeToolList(frontmatter["allowed-tools"]));
 
   const lines = ["---"];

--- a/packages/core/src/claude/asset-generation.mjs
+++ b/packages/core/src/claude/asset-generation.mjs
@@ -7,8 +7,9 @@
  * Pi→Claude tool-name mapping (confirmed against Claude Code docs):
  *   read→Read, search→Grep+Glob, execute→Bash, bash→Bash, edit→Edit, write→Write,
  *   agent→Agent, subagent→Agent, todo→TodoWrite, review_loop→Agent (the review subagent).
- * `subagent`/`review_loop` appear only in frontmatter (never invoked by name in bodies),
- * so no body rewriting is required.
+ * Only the frontmatter *tool lists* are rewritten; bodies are copied verbatim. Any prose
+ * mentions of Pi tool names (e.g. a sentence like "tools: [subagent]") are preserved as-is —
+ * neutralizing Pi-specific body prose is harness-neutrality work owned by #774, not this slice.
  *
  * Frontmatter handling:
  * - Agents keep name/description/tools (comma-separated, per Claude's agent format) and drop

--- a/packages/core/src/claude/asset-generation.mjs
+++ b/packages/core/src/claude/asset-generation.mjs
@@ -1,0 +1,153 @@
+/**
+ * Generate Claude Code assets (.claude/agents/*.md, .claude/skills/<name>/SKILL.md) from the
+ * canonical Pi sources (agents/*.agent.md, skills/**\/SKILL.md), which remain the single
+ * source of truth. These are pure transforms (no file IO) so they are deterministic and
+ * unit-testable; the orchestration/IO lives in scripts/claude/generate-claude-assets.mjs.
+ *
+ * Pi→Claude tool-name mapping (confirmed against Claude Code docs):
+ *   read→Read, search→Grep+Glob, execute→Bash, bash→Bash, edit→Edit, write→Write,
+ *   agent→Agent, subagent→Agent, todo→TodoWrite, review_loop→Agent (the review subagent).
+ * `subagent`/`review_loop` appear only in frontmatter (never invoked by name in bodies),
+ * so no body rewriting is required.
+ *
+ * Frontmatter handling:
+ * - Agents keep name/description/tools (comma-separated, per Claude's agent format) and drop
+ *   Pi-only fields that have no faithful Claude agent equivalent: argument-hint,
+ *   systemPromptMode, inheritProjectContext, inheritSkills, maxSubagentDepth, user-invocable.
+ *   (Subagents are never user-invocable in Claude; maxSubagentDepth/inherit* are Pi
+ *   async-dispatch concerns. The user entrypoint under Claude is the dev-loop *skill*.)
+ * - Skills keep name/description/allowed-tools (space-separated) and preserve `user-invocable`
+ *   (Claude honors it 1:1 — `user-invocable: false` hides the skill from the `/` menu). The
+ *   Pi-specific `compatibility` text is dropped (no Claude field).
+ */
+
+import { parse as parseYaml } from "yaml";
+
+/** Pi→Claude tool-name map. A Pi name may expand to multiple Claude tools (search→Grep,Glob). */
+export const TOOL_NAME_MAP = Object.freeze({
+  read: ["Read"],
+  search: ["Grep", "Glob"],
+  execute: ["Bash"],
+  bash: ["Bash"],
+  edit: ["Edit"],
+  write: ["Write"],
+  agent: ["Agent"],
+  subagent: ["Agent"],
+  todo: ["TodoWrite"],
+  review_loop: ["Agent"],
+});
+
+/** Pi-only agent frontmatter fields with no faithful Claude agent equivalent (dropped). */
+export const DROPPED_AGENT_FIELDS = Object.freeze([
+  "argument-hint",
+  "systemPromptMode",
+  "inheritProjectContext",
+  "inheritSkills",
+  "maxSubagentDepth",
+  "user-invocable",
+  "tools",
+]);
+
+const GENERATED_NOTE = (source) =>
+  `<!-- GENERATED from ${source} by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate. -->`;
+
+/**
+ * Map a single Pi tool name to its Claude tool name(s).
+ * @param {string} name
+ * @returns {string[]} Claude tool names (empty if unknown).
+ */
+export function mapTool(name) {
+  return TOOL_NAME_MAP[String(name).trim()] ?? [];
+}
+
+/**
+ * Map a list of Pi tool names to deduped Claude tool names, preserving first-seen order.
+ * @param {string[]} tools
+ * @returns {string[]}
+ */
+export function mapTools(tools) {
+  const out = [];
+  for (const tool of tools ?? []) {
+    for (const mapped of mapTool(tool)) {
+      if (!out.includes(mapped)) {
+        out.push(mapped);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Split a source markdown file into its parsed frontmatter and verbatim body.
+ * @param {string} raw
+ * @returns {{ frontmatter: Record<string, unknown>, body: string }}
+ */
+export function splitFrontmatter(raw) {
+  const match = String(raw).match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!match) {
+    throw new Error("source file is missing a leading YAML frontmatter block");
+  }
+  const frontmatter = parseYaml(match[1]) ?? {};
+  return { frontmatter, body: match[2] };
+}
+
+/** Normalize a Pi `tools` value (YAML list) into a string[] of names. */
+function normalizeToolList(value) {
+  if (Array.isArray(value)) {
+    return value.map((v) => String(v).trim()).filter(Boolean);
+  }
+  if (typeof value === "string") {
+    return value.split(/[\s,]+/).map((v) => v.trim()).filter(Boolean);
+  }
+  return [];
+}
+
+/**
+ * Transform a canonical `agents/*.agent.md` into a Claude `.claude/agents/*.md` document.
+ * @param {{ source: string, raw: string }} input
+ * @returns {string} Full generated file content.
+ */
+export function transformAgent({ source, raw }) {
+  const { frontmatter, body } = splitFrontmatter(raw);
+  const tools = mapTools(normalizeToolList(frontmatter.tools));
+
+  const lines = ["---"];
+  lines.push(`name: ${JSON.stringify(String(frontmatter.name ?? ""))}`);
+  if (frontmatter.description != null) {
+    lines.push(`description: ${JSON.stringify(String(frontmatter.description))}`);
+  }
+  if (tools.length > 0) {
+    lines.push(`tools: ${tools.join(", ")}`);
+  }
+  lines.push("---");
+  lines.push(GENERATED_NOTE(source));
+  lines.push("");
+  return `${lines.join("\n")}\n${body}`;
+}
+
+/**
+ * Transform a canonical `skills/<name>/SKILL.md` into a Claude `.claude/skills/<name>/SKILL.md`.
+ * @param {{ source: string, raw: string }} input
+ * @returns {string} Full generated file content.
+ */
+export function transformSkill({ source, raw }) {
+  const { frontmatter, body } = splitFrontmatter(raw);
+  const tools = mapTools(normalizeToolList(frontmatter["allowed-tools"]));
+
+  const lines = ["---"];
+  lines.push(`name: ${JSON.stringify(String(frontmatter.name ?? ""))}`);
+  if (frontmatter.description != null) {
+    lines.push(`description: ${JSON.stringify(String(frontmatter.description))}`);
+  }
+  if (tools.length > 0) {
+    lines.push(`allowed-tools: ${tools.join(" ")}`);
+  }
+  // user-invocable maps 1:1 — Claude honors `user-invocable: false` (hides from the / menu).
+  if (typeof frontmatter["user-invocable"] === "boolean") {
+    lines.push(`user-invocable: ${frontmatter["user-invocable"]}`);
+  }
+  lines.push("---");
+  lines.push(GENERATED_NOTE(source));
+  lines.push("");
+  return `${lines.join("\n")}\n${body}`;
+}

--- a/packages/core/test/claude-asset-generation.test.mjs
+++ b/packages/core/test/claude-asset-generation.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  TOOL_NAME_MAP,
+  mapTool,
+  mapTools,
+  splitFrontmatter,
+  transformAgent,
+  transformSkill,
+} from "../src/claude/asset-generation.mjs";
+
+test("mapTool expands search to Grep+Glob and maps subagent/review_loop to Agent", () => {
+  assert.deepEqual(mapTool("read"), ["Read"]);
+  assert.deepEqual(mapTool("search"), ["Grep", "Glob"]);
+  assert.deepEqual(mapTool("subagent"), ["Agent"]);
+  assert.deepEqual(mapTool("review_loop"), ["Agent"]);
+  assert.deepEqual(mapTool("todo"), ["TodoWrite"]);
+  assert.deepEqual(mapTool("unknown-tool"), []);
+});
+
+test("mapTools dedupes and preserves first-seen order", () => {
+  // execute+bash both → Bash; subagent+review_loop both → Agent.
+  assert.deepEqual(
+    mapTools(["read", "search", "execute", "bash", "edit", "write"]),
+    ["Read", "Grep", "Glob", "Bash", "Edit", "Write"],
+  );
+  assert.deepEqual(
+    mapTools(["read", "bash", "edit", "write", "subagent", "review_loop"]),
+    ["Read", "Bash", "Edit", "Write", "Agent"],
+  );
+  assert.deepEqual(mapTools(["agent", "subagent"]), ["Agent"]);
+});
+
+test("TOOL_NAME_MAP is frozen and complete for the Pi tool vocabulary", () => {
+  assert.throws(() => { TOOL_NAME_MAP.read = ["x"]; }, TypeError);
+  for (const pi of ["read", "search", "execute", "bash", "edit", "write", "agent", "subagent", "todo", "review_loop"]) {
+    assert.ok(Array.isArray(TOOL_NAME_MAP[pi]), `expected mapping for ${pi}`);
+  }
+});
+
+test("splitFrontmatter throws on a file without frontmatter", () => {
+  assert.throws(() => splitFrontmatter("no frontmatter here"), /missing a leading YAML frontmatter/);
+});
+
+const AGENT_SRC = `---
+name: "developer"
+description: "Implements code."
+tools: [read, search, execute, bash, edit, write]
+argument-hint: "task"
+systemPromptMode: append
+inheritProjectContext: true
+user-invocable: false
+maxSubagentDepth: 3
+---
+You are a focused implementation agent.
+- bullet one
+`;
+
+test("transformAgent maps tools (comma), drops Pi-only fields, keeps the body + generated note", () => {
+  const out = transformAgent({ source: "agents/developer.agent.md", raw: AGENT_SRC });
+  assert.match(out, /^---\nname: "developer"\ndescription: "Implements code\."\ntools: Read, Grep, Glob, Bash, Edit, Write\n---\n/);
+  // Pi-only fields must be gone.
+  for (const dropped of ["argument-hint", "systemPromptMode", "inheritProjectContext", "user-invocable", "maxSubagentDepth"]) {
+    assert.equal(out.includes(`${dropped}:`), false, `${dropped} should be dropped`);
+  }
+  assert.match(out, /<!-- GENERATED from agents\/developer\.agent\.md by/);
+  assert.match(out, /You are a focused implementation agent\.\n- bullet one/);
+});
+
+const SKILL_SRC = `---
+name: local-implementation
+description: "Internal routed strategy."
+compatibility: Pi skill for git-based repositories.
+allowed-tools: read bash edit write subagent review_loop
+user-invocable: false
+---
+# Local Implementation
+body text
+`;
+
+test("transformSkill maps allowed-tools (space), preserves user-invocable, drops compatibility", () => {
+  const out = transformSkill({ source: "skills/local-implementation/SKILL.md", raw: SKILL_SRC });
+  assert.match(out, /^---\nname: "local-implementation"\ndescription: "Internal routed strategy\."\nallowed-tools: Read Bash Edit Write Agent\nuser-invocable: false\n---\n/);
+  assert.equal(out.includes("compatibility:"), false, "Pi-specific compatibility should be dropped");
+  assert.match(out, /<!-- GENERATED from skills\/local-implementation\/SKILL\.md by/);
+  assert.match(out, /# Local Implementation\nbody text/);
+});
+
+test("transformSkill preserves user-invocable: true for the public entry skill", () => {
+  const out = transformSkill({
+    source: "skills/dev-loop/SKILL.md",
+    raw: SKILL_SRC.replace("user-invocable: false", "user-invocable: true"),
+  });
+  assert.match(out, /\nuser-invocable: true\n/);
+});

--- a/scripts/claude/generate-claude-assets.mjs
+++ b/scripts/claude/generate-claude-assets.mjs
@@ -60,14 +60,44 @@ export function writeAssets(assets, { repoRoot = process.cwd() } = {}) {
   return assets.map((a) => a.target);
 }
 
-/** Compare generated assets against the committed tree. Returns drifted targets. */
+/** List committed generated-asset files currently on disk (repo-relative, posix separators). */
+function listExistingAssetFiles(repoRoot) {
+  const found = [];
+  const agentsDir = path.join(repoRoot, ".claude", "agents");
+  if (fs.existsSync(agentsDir)) {
+    for (const entry of fs.readdirSync(agentsDir)) {
+      if (entry.endsWith(".md")) found.push(`.claude/agents/${entry}`);
+    }
+  }
+  const skillsDir = path.join(repoRoot, ".claude", "skills");
+  if (fs.existsSync(skillsDir)) {
+    for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const skillFile = path.join(skillsDir, entry.name, "SKILL.md");
+      if (fs.existsSync(skillFile)) found.push(`.claude/skills/${entry.name}/SKILL.md`);
+    }
+  }
+  return found;
+}
+
+/**
+ * Compare generated assets against the committed tree. Returns drifted targets, covering both
+ * missing/out-of-date generated files AND orphaned committed files no longer produced by a
+ * source (e.g. after a source agent/skill is renamed or removed).
+ */
 export function checkAssets(assets, { repoRoot = process.cwd() } = {}) {
   const drifted = [];
+  const expected = new Set(assets.map((a) => a.target));
   for (const { target, content } of assets) {
     const abs = path.join(repoRoot, target);
     const current = fs.existsSync(abs) ? fs.readFileSync(abs, "utf8") : null;
     if (current !== content) {
       drifted.push({ target, reason: current === null ? "missing" : "out-of-date" });
+    }
+  }
+  for (const existing of listExistingAssetFiles(repoRoot)) {
+    if (!expected.has(existing)) {
+      drifted.push({ target: existing, reason: "orphaned" });
     }
   }
   return drifted;
@@ -76,7 +106,15 @@ export function checkAssets(assets, { repoRoot = process.cwd() } = {}) {
 function main(argv) {
   const check = argv.includes("--check");
   const rootIdx = argv.indexOf("--repo-root");
-  const repoRoot = rootIdx !== -1 ? argv[rootIdx + 1] : process.cwd();
+  let repoRoot = process.cwd();
+  if (rootIdx !== -1) {
+    const value = argv[rootIdx + 1];
+    if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
+      process.stderr.write(JSON.stringify({ ok: false, error: "--repo-root requires a path value" }) + "\n");
+      process.exit(1);
+    }
+    repoRoot = value;
+  }
 
   const assets = collectGeneratedAssets({ repoRoot });
 

--- a/scripts/claude/generate-claude-assets.mjs
+++ b/scripts/claude/generate-claude-assets.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * Generate the Claude Code asset tree (.claude/agents, .claude/skills) from the canonical
+ * Pi sources (agents/*.agent.md, skills/<name>/SKILL.md). The sources remain the single
+ * source of truth; the generated tree is committed and kept in sync by `--check` (CI/test).
+ *
+ * Usage:
+ *   node scripts/claude/generate-claude-assets.mjs            Write the .claude tree.
+ *   node scripts/claude/generate-claude-assets.mjs --check    Exit non-zero if the committed
+ *                                                             tree drifts from the sources.
+ *   --repo-root <path>   Override the repo root (default: cwd).
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { transformAgent, transformSkill } from "@dev-loops/core/claude/asset-generation";
+
+/**
+ * Collect the generated assets as { target, content } pairs (target is repo-relative).
+ * @param {{ repoRoot?: string }} [options]
+ * @returns {{ target: string, content: string }[]}
+ */
+export function collectGeneratedAssets({ repoRoot = process.cwd() } = {}) {
+  const assets = [];
+
+  const agentsDir = path.join(repoRoot, "agents");
+  if (fs.existsSync(agentsDir)) {
+    for (const entry of fs.readdirSync(agentsDir).sort()) {
+      if (!entry.endsWith(".agent.md")) continue;
+      const source = `agents/${entry}`;
+      const raw = fs.readFileSync(path.join(repoRoot, source), "utf8");
+      const base = entry.slice(0, -".agent.md".length);
+      assets.push({ target: `.claude/agents/${base}.md`, content: transformAgent({ source, raw }) });
+    }
+  }
+
+  const skillsDir = path.join(repoRoot, "skills");
+  if (fs.existsSync(skillsDir)) {
+    for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      if (!entry.isDirectory()) continue;
+      const source = `skills/${entry.name}/SKILL.md`;
+      const abs = path.join(repoRoot, source);
+      if (!fs.existsSync(abs)) continue; // e.g. skills/docs/ holds shared docs, not a SKILL.md
+      const raw = fs.readFileSync(abs, "utf8");
+      assets.push({ target: `.claude/skills/${entry.name}/SKILL.md`, content: transformSkill({ source, raw }) });
+    }
+  }
+
+  return assets;
+}
+
+/** Write the generated assets to disk. Returns the list of written targets. */
+export function writeAssets(assets, { repoRoot = process.cwd() } = {}) {
+  for (const { target, content } of assets) {
+    const abs = path.join(repoRoot, target);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content, "utf8");
+  }
+  return assets.map((a) => a.target);
+}
+
+/** Compare generated assets against the committed tree. Returns drifted targets. */
+export function checkAssets(assets, { repoRoot = process.cwd() } = {}) {
+  const drifted = [];
+  for (const { target, content } of assets) {
+    const abs = path.join(repoRoot, target);
+    const current = fs.existsSync(abs) ? fs.readFileSync(abs, "utf8") : null;
+    if (current !== content) {
+      drifted.push({ target, reason: current === null ? "missing" : "out-of-date" });
+    }
+  }
+  return drifted;
+}
+
+function main(argv) {
+  const check = argv.includes("--check");
+  const rootIdx = argv.indexOf("--repo-root");
+  const repoRoot = rootIdx !== -1 ? argv[rootIdx + 1] : process.cwd();
+
+  const assets = collectGeneratedAssets({ repoRoot });
+
+  if (check) {
+    const drifted = checkAssets(assets, { repoRoot });
+    if (drifted.length > 0) {
+      process.stderr.write(
+        JSON.stringify({ ok: false, error: "generated .claude assets are out of date", drifted }, null, 2) + "\n",
+      );
+      process.stderr.write("Run `node scripts/claude/generate-claude-assets.mjs` and commit the result.\n");
+      process.exit(1);
+    }
+    process.stdout.write(JSON.stringify({ ok: true, checked: assets.length }) + "\n");
+    return;
+  }
+
+  const written = writeAssets(assets, { repoRoot });
+  process.stdout.write(JSON.stringify({ ok: true, written }, null, 2) + "\n");
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main(process.argv.slice(2));
+}

--- a/scripts/claude/generate-claude-assets.mjs
+++ b/scripts/claude/generate-claude-assets.mjs
@@ -63,15 +63,18 @@ export function writeAssets(assets, { repoRoot = process.cwd() } = {}) {
 /** List committed generated-asset files currently on disk (repo-relative, posix separators). */
 function listExistingAssetFiles(repoRoot) {
   const found = [];
+  // Sort directory entries so orphan detection (and --check output) is deterministic
+  // across filesystems/OSes — this backs a byte-stable no-drift contract.
   const agentsDir = path.join(repoRoot, ".claude", "agents");
   if (fs.existsSync(agentsDir)) {
-    for (const entry of fs.readdirSync(agentsDir)) {
+    for (const entry of fs.readdirSync(agentsDir).sort()) {
       if (entry.endsWith(".md")) found.push(`.claude/agents/${entry}`);
     }
   }
   const skillsDir = path.join(repoRoot, ".claude", "skills");
   if (fs.existsSync(skillsDir)) {
-    for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+    const dirs = fs.readdirSync(skillsDir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of dirs) {
       if (!entry.isDirectory()) continue;
       const skillFile = path.join(skillsDir, entry.name, "SKILL.md");
       if (fs.existsSync(skillFile)) found.push(`.claude/skills/${entry.name}/SKILL.md`);

--- a/test/contracts/claude-assets-reproducible.test.mjs
+++ b/test/contracts/claude-assets-reproducible.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { collectGeneratedAssets, checkAssets } from "../../scripts/claude/generate-claude-assets.mjs";
+
+// #772: the committed .claude tree must be byte-reproducible from the canonical sources.
+// If a source agent/skill changes, the generator must be re-run and the result committed.
+
+const repoRoot = path.resolve(fileURLToPath(new URL("../../", import.meta.url)));
+
+test("the committed .claude tree is byte-reproducible from the canonical sources (no drift)", () => {
+  const assets = collectGeneratedAssets({ repoRoot });
+  assert.ok(assets.length > 0, "expected to generate at least one asset");
+  const drifted = checkAssets(assets, { repoRoot });
+  assert.deepEqual(
+    drifted,
+    [],
+    `Generated .claude assets drifted from sources. Run \`node scripts/claude/generate-claude-assets.mjs\` and commit:\n${JSON.stringify(drifted, null, 2)}`,
+  );
+});
+
+test("every canonical agent and non-doc skill has a generated counterpart", () => {
+  const assets = collectGeneratedAssets({ repoRoot });
+  const targets = assets.map((a) => a.target);
+  // Spot-check the known surfaces so an accidentally-skipped source is caught.
+  for (const expected of [
+    ".claude/agents/dev-loop.md",
+    ".claude/agents/review.md",
+    ".claude/skills/dev-loop/SKILL.md",
+    ".claude/skills/local-implementation/SKILL.md",
+  ]) {
+    assert.ok(targets.includes(expected), `expected generated asset ${expected}`);
+  }
+});

--- a/test/contracts/claude-assets-reproducible.test.mjs
+++ b/test/contracts/claude-assets-reproducible.test.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import os from "node:os";
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { collectGeneratedAssets, checkAssets } from "../../scripts/claude/generate-claude-assets.mjs";
+import { collectGeneratedAssets, checkAssets, writeAssets } from "../../scripts/claude/generate-claude-assets.mjs";
 
 // #772: the committed .claude tree must be byte-reproducible from the canonical sources.
 // If a source agent/skill changes, the generator must be re-run and the result committed.
@@ -19,6 +21,28 @@ test("the committed .claude tree is byte-reproducible from the canonical sources
     [],
     `Generated .claude assets drifted from sources. Run \`node scripts/claude/generate-claude-assets.mjs\` and commit:\n${JSON.stringify(drifted, null, 2)}`,
   );
+});
+
+test("checkAssets flags an orphaned committed asset with no generating source", () => {
+  // Simulate a consumer tree: write the real generated assets, then plant a stale file
+  // that no source produces. checkAssets must report it as `orphaned`.
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "claude-assets-orphan-"));
+  try {
+    // Mirror the canonical sources into the temp root so collectGeneratedAssets has inputs.
+    for (const dir of ["agents", "skills"]) {
+      fs.cpSync(path.join(repoRoot, dir), path.join(tmpRoot, dir), { recursive: true });
+    }
+    const assets = collectGeneratedAssets({ repoRoot: tmpRoot });
+    writeAssets(assets, { repoRoot: tmpRoot });
+    assert.deepEqual(checkAssets(assets, { repoRoot: tmpRoot }), [], "freshly written tree must be clean");
+
+    const orphan = path.join(tmpRoot, ".claude", "agents", "stale-removed.md");
+    fs.writeFileSync(orphan, "stale\n", "utf8");
+    const drifted = checkAssets(assets, { repoRoot: tmpRoot });
+    assert.deepEqual(drifted, [{ target: ".claude/agents/stale-removed.md", reason: "orphaned" }]);
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
 });
 
 test("every canonical agent and non-doc skill has a generated counterpart", () => {


### PR DESCRIPTION
## Summary

A deterministic generator (CA3) that emits `.claude/agents/*.md` and
`.claude/skills/<name>/SKILL.md` from the canonical `agents/*.agent.md` and
`skills/<name>/SKILL.md` sources, which remain the single source of truth. The generated
tree is committed and kept in sync by a byte-reproducibility (no-drift) contract test.

## What changed

- `packages/core/src/claude/asset-generation.mjs` (`@dev-loops/core/claude/asset-generation`):
  pure, unit-tested transforms — `mapTool`/`mapTools`, `transformAgent`, `transformSkill`,
  `splitFrontmatter`.
- `scripts/claude/generate-claude-assets.mjs`: orchestration; `--check` mode exits non-zero
  on drift.
- Generated tree (committed): 7 agents + 4 skills.

## Tool-name mapping (Pi → Claude)

`read→Read`, `search→Grep,Glob`, `execute|bash→Bash`, `edit→Edit`, `write→Write`,
`agent|subagent→Agent`, `todo→TodoWrite`, `review_loop→Agent`. Deduped, order-stable.

## Frontmatter (confirmed against Claude Code docs)

- **Agents** keep `name`/`description`/`tools` (comma-separated); Pi-only fields
  (`argument-hint`, `systemPromptMode`, `inherit*`, `maxSubagentDepth`, `user-invocable`) are
  dropped — none have a faithful Claude agent field (subagents are never user-invocable;
  `maxSubagentDepth`/`inherit*` are Pi async-dispatch concerns). Documented in the module JSDoc.
- **Skills** keep `name`/`description`/`allowed-tools` (space-separated) and **preserve
  `user-invocable`** — Claude honors `user-invocable: false` (hides from the `/` menu), so the
  three internal routed skills stay internal and only `dev-loop` is user-invocable. Pi-specific
  `compatibility` text is dropped.
- `review_loop`/`subagent` appear only in frontmatter (never invoked by name in bodies), so no
  body rewriting is needed; the generated review subagent (`.claude/agents/review.md`) replaces
  `review_loop` and its `.devloops` gate-angle behavior is preserved unchanged.

## Acceptance criteria (#772)

- [x] Deterministic generator emits `.claude/agents` + `.claude/skills`; reproducible; no-drift test.
- [x] Tool names mapped per the table.
- [x] `review_loop` → review subagent (Agent); `.devloops` gate angles honored unchanged.
- [x] Internal (`user-invocable: false`) skills not surfaced as user-invocable (1:1 field);
      agent `maxSubagentDepth`/`inherit*`/`user-invocable` documented as no-Claude-field.

## Validation

`npm run verify` green: assets 92, extension 72, scripts 1435, core 1447, dev-loop 32. New
unit tests for the tool map + frontmatter transforms, and a byte-reproducibility contract test.

## Scope boundaries

- Hook wiring + read-only enforcement → #773. Plugin packaging (bundling `.claude` + manifest) → #774.
- Headless SDK entry → #775. `.pi/` path neutralization → #774.

Closes #772
