### PR TITLE
feat(cli): make the public dev-loops CLI surface harness-neutral (#774)

### DIFF
--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -209,8 +209,8 @@ function buildCliHelpLines() {
     "Use `dev-loops <category> <subcommand> --help` for per-subcommand usage.",
     "",
     "`/dev-loops hide` remains an extension-only Pi command.",
-    "Install the CLI with `npm install dev-loops`; see the README for harness-specific setup",
-    "(Claude Code plugin or the Pi extension).",
+    "Install the CLI with `npm install dev-loops`; see the README for Pi-extension setup",
+    "(Claude Code plugin packaging is in progress).",
   ];
 }
 
@@ -232,7 +232,7 @@ function orderedCliSetupSteps(checks) {
   return [
     "1. Use `/dev-loop` (Claude Code) or `/skill:dev-loop` (Pi) to start or continue a dev loop — the single public entry.",
     "2. Run `dev-loops status` whenever you want a concise readiness snapshot.",
-    "3. Install the CLI with `npm install dev-loops`; see the README for harness setup (Claude Code plugin or Pi extension).",
+    "3. Install the CLI with `npm install dev-loops`; see the README for Pi-extension setup (Claude Code plugin packaging is in progress).",
   ];
 }
 

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -195,7 +195,7 @@ function buildCliHelpLines() {
     "dev-loops help",
     "",
     "Workflow entry:",
-    "- /skill:dev-loop (in Pi) or `subagent dev-loop` — single public entrypoint; routing handles the rest",
+    "- `/dev-loop` (Claude Code) or `/skill:dev-loop` (Pi) — single public entrypoint; routing handles the rest",
     "",
     "Commands:",
     "- dev-loops help                   Show this help",
@@ -209,8 +209,8 @@ function buildCliHelpLines() {
     "Use `dev-loops <category> <subcommand> --help` for per-subcommand usage.",
     "",
     "`/dev-loops hide` remains an extension-only Pi command.",
-    "Use `pi install git:github.com/mfittko/dev-loops` to install skills and agents, or",
-    "`pi update git:github.com/mfittko/dev-loops` to refresh the package.",
+    "Install the CLI with `npm install dev-loops`; see the README for harness-specific setup",
+    "(Claude Code plugin or the Pi extension).",
   ];
 }
 
@@ -230,9 +230,9 @@ function orderedCliSetupSteps(checks) {
   const steps = [...new Set(DEV_LOOP_CHECK_IDS.filter((id) => byId.get(id)?.ok === false).map((id) => CLI_SETUP_GUIDANCE[id]))];
   if (steps.length > 0) return steps.map((step, i) => `${i + 1}. ${step}`);
   return [
-    "1. Use `/skill:dev-loop` (in Pi) or `subagent dev-loop` to start or continue a dev loop — the single public entry.",
+    "1. Use `/dev-loop` (Claude Code) or `/skill:dev-loop` (Pi) to start or continue a dev loop — the single public entry.",
     "2. Run `dev-loops status` whenever you want a concise readiness snapshot.",
-    "3. Use `pi install git:github.com/mfittko/dev-loops` to install the package, or `pi update git:github.com/mfittko/dev-loops` to refresh it.",
+    "3. Install the CLI with `npm install dev-loops`; see the README for harness setup (Claude Code plugin or Pi extension).",
   ];
 }
 

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -209,8 +209,8 @@ function buildCliHelpLines() {
     "Use `dev-loops <category> <subcommand> --help` for per-subcommand usage.",
     "",
     "`/dev-loops hide` remains an extension-only Pi command.",
-    "Install the CLI with `npm install dev-loops`; see the README for Pi-extension setup",
-    "(Claude Code plugin packaging is in progress).",
+    "Run via `npx dev-loops` (or `npm install -g dev-loops` for the shell command); see the",
+    "README for Pi-extension setup (Claude Code plugin packaging is in progress).",
   ];
 }
 
@@ -232,7 +232,7 @@ function orderedCliSetupSteps(checks) {
   return [
     "1. Use `/dev-loop` (Claude Code) or `/skill:dev-loop` (Pi) to start or continue a dev loop — the single public entry.",
     "2. Run `dev-loops status` whenever you want a concise readiness snapshot.",
-    "3. Install the CLI with `npm install dev-loops`; see the README for Pi-extension setup (Claude Code plugin packaging is in progress).",
+    "3. Run via `npx dev-loops` (or `npm install -g dev-loops` for the shell command); see the README for Pi-extension setup (Claude Code plugin packaging is in progress).",
   ];
 }
 

--- a/test/contracts/cli-pi-neutrality.test.mjs
+++ b/test/contracts/cli-pi-neutrality.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+// #774 (rescoped): the public `npx dev-loops` CLI must be harness-neutral — it must run with
+// no `@earendil-works/pi-*` present, and must not show Pi-only install strings unconditionally.
+
+const repoRoot = path.resolve(fileURLToPath(new URL("../../", import.meta.url)));
+const PI_IMPORT_RE = /\b(?:from|import)\s+['"]@earendil-works\/pi-[^'"]+['"]|import\(\s*['"]@earendil-works\/pi-/;
+
+async function collectSourceFiles(dir) {
+  const abs = path.join(repoRoot, dir);
+  const out = [];
+  let entries;
+  try {
+    entries = await readdir(abs, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const rel = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await collectSourceFiles(rel)));
+    else if (/\.(mjs|js|cjs)$/.test(entry.name)) out.push(rel);
+  }
+  return out;
+}
+
+test("the CLI/lib source imports no @earendil-works/pi-* (Pi SDK not required)", async () => {
+  const files = (await Promise.all(["cli", "lib"].map(collectSourceFiles))).flat();
+  assert.ok(files.length > 0, "expected to scan CLI/lib sources");
+  const offenders = [];
+  for (const rel of files) {
+    if (PI_IMPORT_RE.test(await readFile(path.join(repoRoot, rel), "utf8"))) offenders.push(rel);
+  }
+  assert.deepEqual(offenders, [], `CLI/lib must not import the Pi SDK: ${offenders.join(", ")}`);
+});
+
+function runCli(args) {
+  return spawnSync("node", [path.join(repoRoot, "cli", "index.mjs"), ...args], {
+    encoding: "utf8",
+    cwd: repoRoot,
+  });
+}
+
+test("`dev-loops --help` runs standalone and is harness-neutral", () => {
+  const res = runCli(["--help"]);
+  assert.equal(res.status, 0, res.stderr);
+  const out = res.stdout;
+  // Names both harness entrypoints (neutral), not Pi-only.
+  assert.match(out, /\/dev-loop` \(Claude Code\)/);
+  assert.match(out, /\/skill:dev-loop` \(Pi\)/);
+  // No unconditional Pi install/update push on the neutral CLI surface.
+  assert.doesNotMatch(out, /pi install git:/);
+  assert.doesNotMatch(out, /pi update git:/);
+});
+
+test("`dev-loops status` runs standalone and exits 0", () => {
+  const res = runCli(["status"]);
+  assert.equal(res.status, 0, res.stderr);
+  assert.match(res.stdout, /dev-loops status:/);
+});
+
+test("Pi packaging is preserved in package.json (dual-harness)", async () => {
+  const pkg = JSON.parse(await readFile(path.join(repoRoot, "package.json"), "utf8"));
+  assert.deepEqual(pkg.pi.extensions, ["./extension/index.ts"]);
+  assert.deepEqual(pkg.pi.skills, ["skills"]);
+  assert.deepEqual(pkg.pi.agents, ["agents"]);
+});

--- a/test/contracts/cli-pi-neutrality.test.mjs
+++ b/test/contracts/cli-pi-neutrality.test.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from "node:url";
 // no `@earendil-works/pi-*` present, and must not show Pi-only install strings unconditionally.
 
 const repoRoot = path.resolve(fileURLToPath(new URL("../../", import.meta.url)));
-const PI_IMPORT_RE = /\b(?:from|import)\s+['"]@earendil-works\/pi-[^'"]+['"]|import\(\s*['"]@earendil-works\/pi-/;
+const PI_IMPORT_RE = /\b(?:from|import)\s+['"]@earendil-works\/pi-[^'"]+['"]|\bimport\(\s*['"]@earendil-works\/pi-/;
 
 async function collectSourceFiles(dir) {
   const abs = path.join(repoRoot, dir);


### PR DESCRIPTION
## Summary

Makes the public `npx dev-loops` CLI surface **harness-neutral** (CA5, CLI half). The
**plugin-manifest** half of #774 is split to #818 (a real plugin-root vs Pi-sources
discovery-collision design — see the #774 scope-split comment).

## What changed

- `cli/index.mjs` — the workflow-entry line in `--help` and the `status` setup steps now name
  **both** harness entrypoints (`/dev-loop` for Claude Code, `/skill:dev-loop` for Pi) instead
  of Pi-only, and the two unconditional `pi install`/`pi update` lines are replaced with neutral
  install guidance (`npm install dev-loops` + a README pointer for harness-specific setup). No
  unconditional Pi push on the neutral CLI surface.
- `test/contracts/cli-pi-neutrality.test.mjs` (new) — locks the neutrality: `cli/` + `lib/`
  import no `@earendil-works/pi-*`; `dev-loops --help`/`status` run standalone (spawned, exit 0);
  help is neutral (names both harnesses, no `pi install/update git:`); `package.json` `pi.*`
  packaging preserved.

The CLI already imported only `@dev-loops/core/*` (no Pi SDK) thanks to #770, so this slice
*proves and locks* Pi-neutrality and removes the Pi-only help strings, rather than fixing a break.

## Acceptance criteria (#774, rescoped to CLI Pi-neutrality)

- [x] `npx dev-loops --help` and `dev-loops status` run with no `@earendil-works/pi-*` present
      (import-boundary guard + standalone spawn test).
- [x] Pi-only install/update strings are not shown unconditionally on the CLI surface.
- [x] Pi packaging (`pi.extensions`/`pi.skills`/`pi.agents`) continues to work (unchanged + asserted).

## Validation

`npm run verify` green: assets 106, extension 72, scripts 1435, core 1466, dev-loop 32.

## Scope boundaries (split out)

- `.claude-plugin/plugin.json` manifest + plugin layout → **#818** (resolves the plugin-root vs
  Pi-sources collision; pairs with #816 doc bundling + #817 prose neutralization).
- `extension/presentation.ts` / `extension/README.md` are the Pi-harness UI surface (only
  rendered under Pi) — intentionally untouched.

Closes #774
