### PR TITLE
feat(claude): headless dev-loop entry + read-only CI/Docker smoke (#775)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ test-results/
 .DS_Store
 *.log
 .pi/dev-loop-retrospective-checkpoint.json
+.pi/dev-loop-run-context.json
 
 .pi/ui-servers/
 worktrees/

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,8 +62,9 @@ USER node
 
 # Dual-harness smoke (#775):
 # - Pi: the default `dev-loops` CMD below (Pi CLI installed above).
-# - Claude (Pi-free, read-only, no interactive session / API key):
-#     npm run smoke:headless            # exercises `dev-loops loop info`
+# - Claude (Pi-free, read-only, offline — no interactive session, API key, or GitHub token):
+#     npm run smoke:headless            # exercises the offline `dev-loops status` info path
+#   Add `-- --loop-info --issue <n>` to also exercise `dev-loops loop info` (needs GitHub read access).
 #   The headless Claude Agent SDK run is `node scripts/claude/headless-dev-loop.mjs --issue <n>`
 #   (needs `claude` on PATH + an API key; use `--dry-run` to inspect the invocation).
 CMD ["dev-loops"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,4 +59,11 @@ ENV PATH="${PATH}:/workspace/node_modules/.bin"
 
 # Run as non-root node user (base image provides this user)
 USER node
+
+# Dual-harness smoke (#775):
+# - Pi: the default `dev-loops` CMD below (Pi CLI installed above).
+# - Claude (Pi-free, read-only, no interactive session / API key):
+#     npm run smoke:headless            # exercises `dev-loops loop info`
+#   The headless Claude Agent SDK run is `node scripts/claude/headless-dev-loop.mjs --issue <n>`
+#   (needs `claude` on PATH + an API key; use `--dry-run` to inspect the invocation).
 CMD ["dev-loops"]

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:core": "node --test --test-reporter ./test/failure-summary-reporter.mjs packages/core/test/*.test.mjs",
     "test:dev-loop": "node --test --test-reporter ./test/failure-summary-reporter.mjs skills/dev-loop/scripts/dev-mode-context.test.mjs skills/dev-loop/scripts/render-template.test.mjs skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs",
     "test:playwright:viewer": "playwright test -c playwright.inspect-run-viewer.config.mjs",
+    "smoke:headless": "node scripts/claude/headless-info-smoke.mjs",
     "test:docs": "node scripts/docs/validate-links.mjs && node scripts/docs/validate-no-duplicate-rules.mjs",
     "repo-wiki": "node scripts/repo-wiki.mjs",
     "repo-wiki:bootstrap": "node scripts/repo-wiki.mjs scan --repo . && node scripts/repo-wiki.mjs plan --repo . && node scripts/repo-wiki.mjs compile --repo .",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
     "./cli/retry-wrapper": "./src/cli/retry-wrapper.mjs",
     "./cli/subcommand-runner": "./src/cli/subcommand-runner.mjs",
     "./claude/asset-generation": "./src/claude/asset-generation.mjs",
+    "./claude/headless-entry": "./src/claude/headless-entry.mjs",
     "./claude/hook-decisions": "./src/claude/hook-decisions.mjs",
     "./config": "./src/config/config.mjs",
     "./debt/cluster": "./src/debt/cluster.mjs",

--- a/packages/core/src/claude/headless-entry.mjs
+++ b/packages/core/src/claude/headless-entry.mjs
@@ -52,6 +52,12 @@ export function buildHeadlessClaudeInvocation({ prompt, runId, claudeBin = DEFAU
   if (typeof runId !== "string" || runId.trim().length === 0) {
     throw new TypeError("buildHeadlessClaudeInvocation: runId must be a non-empty string");
   }
+  if (typeof claudeBin !== "string" || claudeBin.trim().length === 0) {
+    throw new TypeError("buildHeadlessClaudeInvocation: claudeBin must be a non-empty string");
+  }
+  if (!Array.isArray(extraArgs)) {
+    throw new TypeError("buildHeadlessClaudeInvocation: extraArgs must be an array");
+  }
   return {
     command: claudeBin,
     args: ["-p", prompt, ...extraArgs],

--- a/packages/core/src/claude/headless-entry.mjs
+++ b/packages/core/src/claude/headless-entry.mjs
@@ -1,0 +1,60 @@
+/**
+ * Headless dev-loop entry helpers for Claude Code (#775).
+ *
+ * Builds a non-interactive `claude -p` invocation that runs the dev-loop, with the CA2 run id
+ * propagated into the spawned process's environment via `runContextEnv`. That propagation is
+ * what lets the #773 PreToolUse write-guard recognize the headless session as the dev-loop
+ * subagent context (completing the CA2→CA4 wiring for the headless path). The repo's
+ * `.claude/settings.json` hooks apply automatically to the spawned session.
+ *
+ * Pure: builds the command/args/env; the actual spawn lives in the entry script
+ * (scripts/claude/headless-dev-loop.mjs), which is the only part that needs `claude` on PATH.
+ */
+
+import { runContextEnv } from "../loop/run-context.mjs";
+
+/** Default Claude CLI binary name. */
+export const DEFAULT_CLAUDE_BIN = "claude";
+
+/**
+ * Build the headless dev-loop prompt for a target.
+ *
+ * @param {Object} [params]
+ * @param {number|string} [params.issue]
+ * @param {number|string} [params.pr]
+ * @returns {string}
+ */
+export function buildDevLoopPrompt({ issue, pr } = {}) {
+  if (issue != null && `${issue}`.trim()) {
+    return `Run the dev-loop for issue #${issue}. Use the /dev-loop skill; routing resolves the rest.`;
+  }
+  if (pr != null && `${pr}`.trim()) {
+    return `Run the dev-loop for PR #${pr}. Use the /dev-loop skill; routing resolves the rest.`;
+  }
+  return "Run the dev-loop. Use the /dev-loop skill; routing resolves the current state.";
+}
+
+/**
+ * Build a non-interactive `claude -p` invocation for the dev-loop.
+ *
+ * @param {Object} params
+ * @param {string} params.prompt - The headless prompt (see buildDevLoopPrompt).
+ * @param {string} params.runId - The dev-loop run id to propagate (see ensureRunId).
+ * @param {string} [params.claudeBin] - Claude CLI binary (default "claude").
+ * @param {string[]} [params.extraArgs] - Extra args appended after `-p <prompt>`.
+ * @param {Record<string,string|undefined>} [params.baseEnv] - Base env (default process.env).
+ * @returns {{ command: string, args: string[], env: Record<string,string|undefined> }}
+ */
+export function buildHeadlessClaudeInvocation({ prompt, runId, claudeBin = DEFAULT_CLAUDE_BIN, extraArgs = [], baseEnv = process.env }) {
+  if (typeof prompt !== "string" || prompt.trim().length === 0) {
+    throw new TypeError("buildHeadlessClaudeInvocation: prompt must be a non-empty string");
+  }
+  if (typeof runId !== "string" || runId.trim().length === 0) {
+    throw new TypeError("buildHeadlessClaudeInvocation: runId must be a non-empty string");
+  }
+  return {
+    command: claudeBin,
+    args: ["-p", prompt, ...extraArgs],
+    env: { ...baseEnv, ...runContextEnv(runId) },
+  };
+}

--- a/packages/core/src/claude/headless-entry.mjs
+++ b/packages/core/src/claude/headless-entry.mjs
@@ -25,6 +25,9 @@ export const DEFAULT_CLAUDE_BIN = "claude";
  * @returns {string}
  */
 export function buildDevLoopPrompt({ issue, pr } = {}) {
+  if (issue != null && `${issue}`.trim() && pr != null && `${pr}`.trim()) {
+    throw new TypeError("buildDevLoopPrompt: provide at most one target (issue or pr), not both");
+  }
   if (issue != null && `${issue}`.trim()) {
     return `Run the dev-loop for issue #${issue}. Use the /dev-loop skill; routing resolves the rest.`;
   }

--- a/packages/core/test/claude-headless-entry.test.mjs
+++ b/packages/core/test/claude-headless-entry.test.mjs
@@ -37,7 +37,9 @@ test("buildHeadlessClaudeInvocation honors claudeBin and extraArgs", () => {
   assert.deepEqual(args, ["-p", "p", "--output-format", "json"]);
 });
 
-test("buildHeadlessClaudeInvocation rejects empty prompt or runId", () => {
+test("buildHeadlessClaudeInvocation rejects empty prompt/runId/claudeBin and non-array extraArgs", () => {
   assert.throws(() => buildHeadlessClaudeInvocation({ prompt: "", runId: "r" }), /prompt/);
   assert.throws(() => buildHeadlessClaudeInvocation({ prompt: "p", runId: "" }), /runId/);
+  assert.throws(() => buildHeadlessClaudeInvocation({ prompt: "p", runId: "r", claudeBin: "" }), /claudeBin/);
+  assert.throws(() => buildHeadlessClaudeInvocation({ prompt: "p", runId: "r", extraArgs: "--nope" }), /extraArgs/);
 });

--- a/packages/core/test/claude-headless-entry.test.mjs
+++ b/packages/core/test/claude-headless-entry.test.mjs
@@ -14,6 +14,10 @@ test("buildDevLoopPrompt targets issue, pr, or current state", () => {
   assert.match(buildDevLoopPrompt({ issue: 1 }), /\/dev-loop skill/);
 });
 
+test("buildDevLoopPrompt rejects both issue and pr (single target)", () => {
+  assert.throws(() => buildDevLoopPrompt({ issue: 1, pr: 2 }), /at most one target/);
+});
+
 test("buildHeadlessClaudeInvocation builds `claude -p <prompt>` and propagates DEVLOOPS_RUN_ID", () => {
   const { command, args, env } = buildHeadlessClaudeInvocation({
     prompt: "do the loop",

--- a/packages/core/test/claude-headless-entry.test.mjs
+++ b/packages/core/test/claude-headless-entry.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_CLAUDE_BIN,
+  buildDevLoopPrompt,
+  buildHeadlessClaudeInvocation,
+} from "../src/claude/headless-entry.mjs";
+
+test("buildDevLoopPrompt targets issue, pr, or current state", () => {
+  assert.match(buildDevLoopPrompt({ issue: 775 }), /issue #775/);
+  assert.match(buildDevLoopPrompt({ pr: 42 }), /PR #42/);
+  assert.match(buildDevLoopPrompt({}), /current state/);
+  assert.match(buildDevLoopPrompt({ issue: 1 }), /\/dev-loop skill/);
+});
+
+test("buildHeadlessClaudeInvocation builds `claude -p <prompt>` and propagates DEVLOOPS_RUN_ID", () => {
+  const { command, args, env } = buildHeadlessClaudeInvocation({
+    prompt: "do the loop",
+    runId: "devloops-abc",
+    baseEnv: { EXISTING: "1" },
+  });
+  assert.equal(command, DEFAULT_CLAUDE_BIN);
+  assert.deepEqual(args, ["-p", "do the loop"]);
+  assert.equal(env.DEVLOOPS_RUN_ID, "devloops-abc");
+  assert.equal(env.EXISTING, "1", "base env is preserved");
+});
+
+test("buildHeadlessClaudeInvocation honors claudeBin and extraArgs", () => {
+  const { command, args } = buildHeadlessClaudeInvocation({
+    prompt: "p",
+    runId: "r",
+    claudeBin: "/opt/claude",
+    extraArgs: ["--output-format", "json"],
+  });
+  assert.equal(command, "/opt/claude");
+  assert.deepEqual(args, ["-p", "p", "--output-format", "json"]);
+});
+
+test("buildHeadlessClaudeInvocation rejects empty prompt or runId", () => {
+  assert.throws(() => buildHeadlessClaudeInvocation({ prompt: "", runId: "r" }), /prompt/);
+  assert.throws(() => buildHeadlessClaudeInvocation({ prompt: "p", runId: "" }), /runId/);
+});

--- a/scripts/claude/headless-dev-loop.mjs
+++ b/scripts/claude/headless-dev-loop.mjs
@@ -60,7 +60,8 @@ function main(argv) {
   }
   const repoRoot = path.resolve(fileURLToPath(new URL("../../", import.meta.url)));
 
-  const { runId } = ensureRunId({ env: process.env, root: repoRoot });
+  // --dry-run is side-effect-free: mint a run id in-memory without persisting the state file.
+  const { runId } = ensureRunId({ env: process.env, root: opts.dryRun ? undefined : repoRoot });
   const prompt = opts.prompt ?? buildDevLoopPrompt({ issue: opts.issue, pr: opts.pr });
   const { command, args, env } = buildHeadlessClaudeInvocation({
     prompt,

--- a/scripts/claude/headless-dev-loop.mjs
+++ b/scripts/claude/headless-dev-loop.mjs
@@ -8,8 +8,12 @@
  * session is recognized as the dev-loop subagent context by the write-guard.
  *
  * Usage:
- *   node scripts/claude/headless-dev-loop.mjs --issue <n> [--pr <n>] [--claude-bin <path>] [--dry-run]
+ *   node scripts/claude/headless-dev-loop.mjs [--issue <n> | --pr <n>] [--prompt <text>]
+ *                                             [--claude-bin <path>] [--dry-run]
  *
+ * --issue/--pr select the target; with neither, the prompt targets the current state.
+ * --prompt overrides the generated dev-loop prompt entirely.
+ * --claude-bin overrides the `claude` binary path.
  * --dry-run prints the resolved command + the DEVLOOPS_RUN_ID without spawning `claude`
  *   (CI-safe; no API key / `claude` binary required).
  */

--- a/scripts/claude/headless-dev-loop.mjs
+++ b/scripts/claude/headless-dev-loop.mjs
@@ -30,19 +30,34 @@ import {
 
 function parseArgs(argv) {
   const opts = { dryRun: false, claudeBin: DEFAULT_CLAUDE_BIN };
+  const requireValue = (name, i) => {
+    const v = argv[i + 1];
+    if (v === undefined || v.startsWith("--")) throw new Error(`${name} requires a value`);
+    return v;
+  };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--dry-run") opts.dryRun = true;
-    else if (a === "--issue") opts.issue = argv[++i];
-    else if (a === "--pr") opts.pr = argv[++i];
-    else if (a === "--claude-bin") opts.claudeBin = argv[++i];
-    else if (a === "--prompt") opts.prompt = argv[++i];
+    else if (a === "--issue") { opts.issue = requireValue(a, i); i++; }
+    else if (a === "--pr") { opts.pr = requireValue(a, i); i++; }
+    else if (a === "--claude-bin") { opts.claudeBin = requireValue(a, i); i++; }
+    else if (a === "--prompt") { opts.prompt = requireValue(a, i); i++; }
+    else throw new Error(`unknown argument: ${a}`);
+  }
+  if (opts.issue != null && opts.pr != null) {
+    throw new Error("--issue and --pr are mutually exclusive");
   }
   return opts;
 }
 
 function main(argv) {
-  const opts = parseArgs(argv);
+  let opts;
+  try {
+    opts = parseArgs(argv);
+  } catch (error) {
+    process.stderr.write(JSON.stringify({ ok: false, error: error.message }) + "\n");
+    return 1;
+  }
   const repoRoot = path.resolve(fileURLToPath(new URL("../../", import.meta.url)));
 
   const { runId } = ensureRunId({ env: process.env, root: repoRoot });

--- a/scripts/claude/headless-dev-loop.mjs
+++ b/scripts/claude/headless-dev-loop.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Headless dev-loop entry for Claude Code (#775).
+ *
+ * Runs the dev-loop non-interactively via `claude -p` (the Claude Agent SDK headless path),
+ * with the repo's `.claude/settings.json` hooks (gate + read-only guard, #773) active. It mints
+ * a neutral DEVLOOPS_RUN_ID (CA2) and propagates it into the spawned `claude` env so the headless
+ * session is recognized as the dev-loop subagent context by the write-guard.
+ *
+ * Usage:
+ *   node scripts/claude/headless-dev-loop.mjs --issue <n> [--pr <n>] [--claude-bin <path>] [--dry-run]
+ *
+ * --dry-run prints the resolved command + the DEVLOOPS_RUN_ID without spawning `claude`
+ *   (CI-safe; no API key / `claude` binary required).
+ */
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ensureRunId } from "@dev-loops/core/loop/run-context";
+import {
+  buildDevLoopPrompt,
+  buildHeadlessClaudeInvocation,
+  DEFAULT_CLAUDE_BIN,
+} from "@dev-loops/core/claude/headless-entry";
+
+function parseArgs(argv) {
+  const opts = { dryRun: false, claudeBin: DEFAULT_CLAUDE_BIN };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dry-run") opts.dryRun = true;
+    else if (a === "--issue") opts.issue = argv[++i];
+    else if (a === "--pr") opts.pr = argv[++i];
+    else if (a === "--claude-bin") opts.claudeBin = argv[++i];
+    else if (a === "--prompt") opts.prompt = argv[++i];
+  }
+  return opts;
+}
+
+function main(argv) {
+  const opts = parseArgs(argv);
+  const repoRoot = path.resolve(fileURLToPath(new URL("../../", import.meta.url)));
+
+  const { runId } = ensureRunId({ env: process.env, root: repoRoot });
+  const prompt = opts.prompt ?? buildDevLoopPrompt({ issue: opts.issue, pr: opts.pr });
+  const { command, args, env } = buildHeadlessClaudeInvocation({
+    prompt,
+    runId,
+    claudeBin: opts.claudeBin,
+  });
+
+  if (opts.dryRun) {
+    process.stdout.write(
+      JSON.stringify({ ok: true, dryRun: true, command, args, runId, DEVLOOPS_RUN_ID: env.DEVLOOPS_RUN_ID }, null, 2) + "\n",
+    );
+    return 0;
+  }
+
+  const res = spawnSync(command, args, { cwd: repoRoot, env, stdio: "inherit" });
+  if (res.error) {
+    process.stderr.write(
+      JSON.stringify({ ok: false, error: `failed to spawn ${command}: ${res.error.message}` }) + "\n",
+    );
+    return 127;
+  }
+  return res.status ?? 1;
+}
+
+process.exit(main(process.argv.slice(2)));

--- a/scripts/claude/headless-info-smoke.mjs
+++ b/scripts/claude/headless-info-smoke.mjs
@@ -21,10 +21,20 @@ import { fileURLToPath } from "node:url";
 
 function parseArgs(argv) {
   const opts = { loopInfo: false };
+  const requireValue = (name, i) => {
+    const v = argv[i + 1];
+    if (v === undefined || v.startsWith("--")) throw new Error(`${name} requires a value`);
+    return v;
+  };
   for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === "--loop-info") opts.loopInfo = true;
-    else if (argv[i] === "--issue") opts.issue = argv[++i];
-    else if (argv[i] === "--pr") opts.pr = argv[++i];
+    const a = argv[i];
+    if (a === "--loop-info") opts.loopInfo = true;
+    else if (a === "--issue") { opts.issue = requireValue(a, i); i++; }
+    else if (a === "--pr") { opts.pr = requireValue(a, i); i++; }
+    else throw new Error(`unknown argument: ${a}`);
+  }
+  if (opts.issue != null && opts.pr != null) {
+    throw new Error("--issue and --pr are mutually exclusive");
   }
   return opts;
 }
@@ -34,7 +44,13 @@ function runCli(cliEntry, repoRoot, args) {
 }
 
 function main(argv) {
-  const opts = parseArgs(argv);
+  let opts;
+  try {
+    opts = parseArgs(argv);
+  } catch (error) {
+    process.stderr.write(JSON.stringify({ ok: false, error: error.message }) + "\n");
+    return 1;
+  }
   const repoRoot = path.resolve(fileURLToPath(new URL("../../", import.meta.url)));
   const cliEntry = path.join(repoRoot, "cli", "index.mjs");
 

--- a/scripts/claude/headless-info-smoke.mjs
+++ b/scripts/claude/headless-info-smoke.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Headless read-only dev-loop info smoke (#775).
+ *
+ * Exercises the read-only `dev-loops loop info` path non-interactively (no LLM, no interactive
+ * session, no `@earendil-works/pi-*` required) so CI / the Docker image can verify the headless
+ * info surface works. Parallel to the Pi Docker smoke (dual-harness). Exits 0 on success.
+ *
+ * Usage: node scripts/claude/headless-info-smoke.mjs [--issue <n>] [--pr <n>]
+ */
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+function parseArgs(argv) {
+  const opts = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--issue") opts.issue = argv[++i];
+    else if (argv[i] === "--pr") opts.pr = argv[++i];
+  }
+  return opts;
+}
+
+function main(argv) {
+  const opts = parseArgs(argv);
+  const repoRoot = path.resolve(fileURLToPath(new URL("../../", import.meta.url)));
+  const cliEntry = path.join(repoRoot, "cli", "index.mjs");
+
+  const target = opts.pr ? ["--pr", String(opts.pr)] : ["--issue", String(opts.issue ?? "775")];
+  const res = spawnSync(process.execPath, [cliEntry, "loop", "info", ...target], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+
+  if (res.status !== 0) {
+    process.stderr.write(
+      JSON.stringify({ ok: false, error: "headless `dev-loops loop info` smoke failed", status: res.status, stderr: res.stderr }) + "\n",
+    );
+    return res.status ?? 1;
+  }
+  process.stdout.write(res.stdout);
+  process.stdout.write(JSON.stringify({ ok: true, smoke: "headless-info", target }) + "\n");
+  return 0;
+}
+
+process.exit(main(process.argv.slice(2)));

--- a/scripts/claude/headless-info-smoke.mjs
+++ b/scripts/claude/headless-info-smoke.mjs
@@ -50,7 +50,13 @@ function main(argv) {
 
   // Opt-in GitHub-backed info path (needs read access; not run by the hermetic CI smoke).
   if (opts.loopInfo) {
-    const target = opts.pr ? ["--pr", String(opts.pr)] : ["--issue", String(opts.issue ?? "775")];
+    if (opts.issue == null && opts.pr == null) {
+      process.stderr.write(
+        JSON.stringify({ ok: false, error: "--loop-info requires an explicit --issue <n> or --pr <n> target" }) + "\n",
+      );
+      return 1;
+    }
+    const target = opts.pr ? ["--pr", String(opts.pr)] : ["--issue", String(opts.issue)];
     const infoRes = runCli(cliEntry, repoRoot, ["loop", "info", ...target]);
     if (infoRes.status !== 0) {
       process.stderr.write(

--- a/scripts/claude/headless-info-smoke.mjs
+++ b/scripts/claude/headless-info-smoke.mjs
@@ -2,23 +2,35 @@
 /**
  * Headless read-only dev-loop info smoke (#775).
  *
- * Exercises the read-only `dev-loops loop info` path non-interactively (no LLM, no interactive
- * session, no `@earendil-works/pi-*` required) so CI / the Docker image can verify the headless
- * info surface works. Parallel to the Pi Docker smoke (dual-harness). Exits 0 on success.
+ * Exercises a read-only dev-loop info path non-interactively (no LLM, no interactive session,
+ * no `@earendil-works/pi-*`), so CI / the Docker image can verify the headless info surface.
+ * Parallel to the Pi Docker smoke (dual-harness). Exits 0 on success.
  *
- * Usage: node scripts/claude/headless-info-smoke.mjs [--issue <n>] [--pr <n>]
+ * Default: `dev-loops status` — a fully offline readiness snapshot that needs no GitHub auth
+ * (it reports "needs setup" rather than failing), so it is safe in a hermetic CI verify job.
+ *
+ * `--loop-info --issue <n>` (or `--pr <n>`) additionally runs `dev-loops loop info`, which
+ * queries GitHub and therefore needs read access (a token / `gh` auth). Opt-in: skipped by
+ * default so the smoke stays secret-free.
+ *
+ * Usage: node scripts/claude/headless-info-smoke.mjs [--loop-info --issue <n> | --pr <n>]
  */
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 function parseArgs(argv) {
-  const opts = {};
+  const opts = { loopInfo: false };
   for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === "--issue") opts.issue = argv[++i];
+    if (argv[i] === "--loop-info") opts.loopInfo = true;
+    else if (argv[i] === "--issue") opts.issue = argv[++i];
     else if (argv[i] === "--pr") opts.pr = argv[++i];
   }
   return opts;
+}
+
+function runCli(cliEntry, repoRoot, args) {
+  return spawnSync(process.execPath, [cliEntry, ...args], { cwd: repoRoot, encoding: "utf8" });
 }
 
 function main(argv) {
@@ -26,20 +38,30 @@ function main(argv) {
   const repoRoot = path.resolve(fileURLToPath(new URL("../../", import.meta.url)));
   const cliEntry = path.join(repoRoot, "cli", "index.mjs");
 
-  const target = opts.pr ? ["--pr", String(opts.pr)] : ["--issue", String(opts.issue ?? "775")];
-  const res = spawnSync(process.execPath, [cliEntry, "loop", "info", ...target], {
-    cwd: repoRoot,
-    encoding: "utf8",
-  });
-
-  if (res.status !== 0) {
+  // Offline, secret-free read-only info path — the CI/Docker smoke.
+  const statusRes = runCli(cliEntry, repoRoot, ["status"]);
+  if (statusRes.status !== 0) {
     process.stderr.write(
-      JSON.stringify({ ok: false, error: "headless `dev-loops loop info` smoke failed", status: res.status, stderr: res.stderr }) + "\n",
+      JSON.stringify({ ok: false, error: "headless `dev-loops status` smoke failed", status: statusRes.status, stderr: statusRes.stderr }) + "\n",
     );
-    return res.status ?? 1;
+    return statusRes.status ?? 1;
   }
-  process.stdout.write(res.stdout);
-  process.stdout.write(JSON.stringify({ ok: true, smoke: "headless-info", target }) + "\n");
+  process.stdout.write(statusRes.stdout);
+
+  // Opt-in GitHub-backed info path (needs read access; not run by the hermetic CI smoke).
+  if (opts.loopInfo) {
+    const target = opts.pr ? ["--pr", String(opts.pr)] : ["--issue", String(opts.issue ?? "775")];
+    const infoRes = runCli(cliEntry, repoRoot, ["loop", "info", ...target]);
+    if (infoRes.status !== 0) {
+      process.stderr.write(
+        JSON.stringify({ ok: false, error: "headless `dev-loops loop info` smoke failed (needs GitHub read access)", status: infoRes.status, stderr: infoRes.stderr }) + "\n",
+      );
+      return infoRes.status ?? 1;
+    }
+    process.stdout.write(infoRes.stdout);
+  }
+
+  process.stdout.write(JSON.stringify({ ok: true, smoke: "headless-info", loopInfo: opts.loopInfo }) + "\n");
   return 0;
 }
 

--- a/test/contracts/claude-headless-smoke.test.mjs
+++ b/test/contracts/claude-headless-smoke.test.mjs
@@ -15,10 +15,19 @@ function runNode(scriptRel, args) {
   return spawnSync(process.execPath, [path.join(repoRoot, scriptRel), ...args], { cwd: repoRoot, encoding: "utf8" });
 }
 
-test("headless-info-smoke runs the read-only loop info path and exits 0 (Pi-free)", () => {
-  const res = runNode("scripts/claude/headless-info-smoke.mjs", ["--issue", "775"]);
+test("headless-info-smoke runs the offline read-only status path and exits 0 (no GitHub auth, Pi-free)", () => {
+  // Run with GitHub auth env explicitly removed to prove the default smoke is secret-free
+  // (hermetic CI verify job has no token); the default path is `dev-loops status` (offline).
+  const env = { ...process.env };
+  delete env.GH_TOKEN;
+  delete env.GITHUB_TOKEN;
+  const res = spawnSync(process.execPath, [path.join(repoRoot, "scripts/claude/headless-info-smoke.mjs")], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env,
+  });
   assert.equal(res.status, 0, res.stderr);
-  assert.match(res.stdout, /Issue #775/);
+  assert.match(res.stdout, /dev-loops status:/);
   assert.match(res.stdout, /"ok":true,"smoke":"headless-info"/);
 });
 

--- a/test/contracts/claude-headless-smoke.test.mjs
+++ b/test/contracts/claude-headless-smoke.test.mjs
@@ -49,6 +49,20 @@ test("headless-info-smoke --loop-info without a target fails fast (no hidden iss
   assert.match(res.stderr, /--loop-info requires an explicit --issue/);
 });
 
+test("headless-dev-loop arg parsing fails fast on bad invocations", () => {
+  const both = runNode("scripts/claude/headless-dev-loop.mjs", ["--dry-run", "--issue", "1", "--pr", "2"]);
+  assert.notEqual(both.status, 0);
+  assert.match(both.stderr, /mutually exclusive/);
+
+  const missing = runNode("scripts/claude/headless-dev-loop.mjs", ["--issue", "--dry-run"]);
+  assert.notEqual(missing.status, 0);
+  assert.match(missing.stderr, /--issue requires a value/);
+
+  const unknown = runNode("scripts/claude/headless-dev-loop.mjs", ["--dry-run", "--bogus"]);
+  assert.notEqual(unknown.status, 0);
+  assert.match(unknown.stderr, /unknown argument: --bogus/);
+});
+
 test("headless entry + smoke scripts do not import the Pi SDK", async () => {
   for (const rel of ["scripts/claude/headless-dev-loop.mjs", "scripts/claude/headless-info-smoke.mjs"]) {
     const content = await readFile(path.join(repoRoot, rel), "utf8");

--- a/test/contracts/claude-headless-smoke.test.mjs
+++ b/test/contracts/claude-headless-smoke.test.mjs
@@ -41,6 +41,8 @@ test("headless-dev-loop --dry-run prints a claude -p invocation carrying DEVLOOP
   assert.equal(out.args[0], "-p");
   assert.match(out.args[1], /issue #775/);
   assert.match(out.DEVLOOPS_RUN_ID, /^devloops-/);
+  // --dry-run must be side-effect-free: no run-context state file written.
+  assert.equal(res.stderr, "", "dry-run should not warn/persist");
 });
 
 test("headless-info-smoke --loop-info without a target fails fast (no hidden issue default)", () => {

--- a/test/contracts/claude-headless-smoke.test.mjs
+++ b/test/contracts/claude-headless-smoke.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+// #775: headless entry + read-only info smoke. CI exercises the read-only path and the entry's
+// --dry-run (the live `claude -p` agent run needs an API key and is out of CI scope).
+
+const repoRoot = path.resolve(fileURLToPath(new URL("../../", import.meta.url)));
+const PI_IMPORT_RE = /\b(?:from|import)\s+['"]@earendil-works\/pi-[^'"]+['"]|\bimport\(\s*['"]@earendil-works\/pi-/;
+
+function runNode(scriptRel, args) {
+  return spawnSync(process.execPath, [path.join(repoRoot, scriptRel), ...args], { cwd: repoRoot, encoding: "utf8" });
+}
+
+test("headless-info-smoke runs the read-only loop info path and exits 0 (Pi-free)", () => {
+  const res = runNode("scripts/claude/headless-info-smoke.mjs", ["--issue", "775"]);
+  assert.equal(res.status, 0, res.stderr);
+  assert.match(res.stdout, /Issue #775/);
+  assert.match(res.stdout, /"ok":true,"smoke":"headless-info"/);
+});
+
+test("headless-dev-loop --dry-run prints a claude -p invocation carrying DEVLOOPS_RUN_ID, without spawning claude", () => {
+  // PATH cleared of a real `claude` is unnecessary: --dry-run never spawns. Assert the shape.
+  const res = runNode("scripts/claude/headless-dev-loop.mjs", ["--issue", "775", "--dry-run"]);
+  assert.equal(res.status, 0, res.stderr);
+  const out = JSON.parse(res.stdout);
+  assert.equal(out.dryRun, true);
+  assert.equal(out.command, "claude");
+  assert.equal(out.args[0], "-p");
+  assert.match(out.args[1], /issue #775/);
+  assert.match(out.DEVLOOPS_RUN_ID, /^devloops-/);
+});
+
+test("headless entry + smoke scripts do not import the Pi SDK", async () => {
+  for (const rel of ["scripts/claude/headless-dev-loop.mjs", "scripts/claude/headless-info-smoke.mjs"]) {
+    const content = await readFile(path.join(repoRoot, rel), "utf8");
+    assert.equal(PI_IMPORT_RE.test(content), false, `${rel} must not import @earendil-works/pi-*`);
+  }
+});
+
+test("Dockerfile keeps the Pi install (dual-harness smoke preserved)", async () => {
+  const dockerfile = await readFile(path.join(repoRoot, "Dockerfile"), "utf8");
+  assert.match(dockerfile, /@earendil-works\/pi-coding-agent/, "Pi CLI install must remain for the Pi Docker smoke");
+});

--- a/test/contracts/claude-headless-smoke.test.mjs
+++ b/test/contracts/claude-headless-smoke.test.mjs
@@ -43,6 +43,12 @@ test("headless-dev-loop --dry-run prints a claude -p invocation carrying DEVLOOP
   assert.match(out.DEVLOOPS_RUN_ID, /^devloops-/);
 });
 
+test("headless-info-smoke --loop-info without a target fails fast (no hidden issue default)", () => {
+  const res = runNode("scripts/claude/headless-info-smoke.mjs", ["--loop-info"]);
+  assert.notEqual(res.status, 0);
+  assert.match(res.stderr, /--loop-info requires an explicit --issue/);
+});
+
 test("headless entry + smoke scripts do not import the Pi SDK", async () => {
   for (const rel of ["scripts/claude/headless-dev-loop.mjs", "scripts/claude/headless-info-smoke.mjs"]) {
     const content = await readFile(path.join(repoRoot, rel), "utf8");


### PR DESCRIPTION
## Summary

Adds a non-interactive **headless dev-loop path** for Claude Code (the Claude Agent SDK /
`claude -p` entry) plus a **read-only CI/Docker smoke**, parallel to the existing Pi Docker
smoke (dual-harness). Completes the original Claude-harness chain (#770–#775).

## What changed

- `@dev-loops/core/claude/headless-entry` — pure builder: `buildHeadlessClaudeInvocation()`
  emits a `claude -p <prompt>` command and **propagates the CA2 `DEVLOOPS_RUN_ID`** into the
  spawned env, so the headless session is recognized as the dev-loop subagent context by the
  #773 write-guard (this completes the CA2→CA4 propagation for the headless path).
  `buildDevLoopPrompt()` builds the issue/PR/current-state prompt.
- `scripts/claude/headless-dev-loop.mjs` — the entry: `ensureRunId()` mints + persists the run
  id, then spawns `claude -p` with the repo's `.claude/settings.json` hooks active.
  **`--dry-run`** prints the resolved invocation + run id without spawning `claude` (CI-safe;
  no API key required).
- `scripts/claude/headless-info-smoke.mjs` (+ `npm run smoke:headless`) — exercises the
  **offline** read-only `dev-loops status` info path: no LLM, no interactive session, no
  `@earendil-works/pi-*`, and **no GitHub token** (status reports "needs setup" rather than
  failing), so it's safe in a hermetic CI job. `--loop-info --issue <n>` additionally runs
  `dev-loops loop info` (queries GitHub → needs read access; opt-in, not run by the CI smoke).
- `Dockerfile` — documents the dual-harness smoke (Pi `CMD` + the Claude read-only smoke); the
  Pi install is unchanged.

## Acceptance criteria (#775)

- [x] A headless entry runs the dev-loop via `claude -p` (Agent SDK) with hooks active — entry
      script + pure builder; `--dry-run` proves the invocation shape and run-id propagation;
      hooks apply via `.claude/settings.json` (#773).
- [x] A CI/Docker smoke exercises a read-only dev-loop info path without an interactive session
      — `headless-info-smoke.mjs` / `npm run smoke:headless`, using the **offline** `dev-loops
      status` path (Pi-free, no GitHub token; tested with auth env removed). The GitHub-backed
      `loop info` is an opt-in `--loop-info` extra (needs read access), not part of the hermetic smoke.
- [x] The existing Pi Docker smoke remains (Dockerfile Pi install + `CMD ["dev-loops"]`
      unchanged; asserted by a contract test).

## Validation

`npm run verify` green: assets 110, extension 72, scripts 1435, core 1470, dev-loop 32. Tests:
builder units (command/args/env + `DEVLOOPS_RUN_ID` propagation + validation) and a contract
test that runs the read-only smoke (exit 0, Pi-free) and the entry `--dry-run` (claude -p shape
carrying the run id, no spawn).

## Scope boundaries

- A live, API-key-backed end-to-end agent run in CI needs secrets and is out of scope — `--dry-run`
  + the read-only smoke cover what CI can verify deterministically.
- Standing up a CI docker-build job is #720. Plugin packaging is #818.

Closes #775
