### PR TITLE
feat(claude): bundle shared docs + dev-loop templates into generated .claude tree (#816)

### DIFF
--- a/.claude/skills/dev-loop/templates/bootstrap-agents.md
+++ b/.claude/skills/dev-loop/templates/bootstrap-agents.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+## Project contract
+
+This repository uses the `dev-loop` skill as the primary implementation workflow.
+
+The skill may be provided repo-locally or globally; this contract does not assume a local skill path.
+
+## Working agreement
+
+- Work test-first for all non-trivial logic.
+- Maintain at least 90% coverage for lines, statements, functions, and branches.
+- Implement one phase at a time.
+- Use fan-out / fan-in / review / merge before implementing each phase.
+- Keep logs under `tmp/` in deterministic phase-scoped paths.
+- Use local branches and small commits only after local verification.
+- Do not assume GitHub PR or issue workflows.
+
+## Core guard rails
+
+- KISS
+- SRP
+- YAGNI
+- strict TypeScript
+- thin runtime glue
+- no production reliance on Pi private internals

--- a/.claude/skills/dev-loop/templates/bootstrap-implementation-state.md
+++ b/.claude/skills/dev-loop/templates/bootstrap-implementation-state.md
@@ -1,0 +1,31 @@
+# Implementation state
+
+## Status
+
+Preparation is in place. Implementation has not started.
+
+## Current source of truth
+
+- Product plan: [Project Plan](../../../PLAN.md)
+- Durable phase plans: [Phase Plan](../../../docs/phases/)
+- Execution skill: `dev-loop`
+- Repo contract: [Agent Instructions](../../../AGENTS.md)
+- Workflow explainer: [Implementation Workflow](../../../docs/IMPLEMENTATION_WORKFLOW.md)
+- tmp index for fresh-context inspection if present locally: `tmp/phases/index.json`
+
+## Next action for a fresh session
+
+If the user says **"start implementation"**:
+
+1. read [Project Plan](../../../PLAN.md)
+2. load the `dev-loop` skill
+3. read [Agent Instructions](../../../AGENTS.md) if it exists
+4. read [Implementation Workflow](../../../docs/IMPLEMENTATION_WORKFLOW.md)
+5. read the current durable phase plan under `docs/phases/` if it exists
+6. inspect `tmp/phases/` only if it exists locally and is relevant
+7. read this file
+8. start with the next unfinished phase only
+
+## Next unfinished phase
+
+Phase 0 — define the workflow convention, durable phase-plan format, and initial package boundary.

--- a/.claude/skills/dev-loop/templates/bootstrap-implementation-workflow.md
+++ b/.claude/skills/dev-loop/templates/bootstrap-implementation-workflow.md
@@ -1,0 +1,17 @@
+# Implementation workflow
+
+This file is optional. The primary execution entrypoint is the `dev-loop` skill.
+
+Use this file for repo-specific workflow notes that complement the skill.
+
+## Defaults
+
+- one phase at a time
+- [Project Plan](../../../PLAN.md) holds roadmap/product truth
+- `docs/phases/phase-<n>.md` holds the durable plan for the active phase
+- `tmp/phases/phase-<n>/` holds temporary local execution artifacts, reviews, and logs
+- fan-out / fan-in / review / merge before coding
+- test-first
+- deterministic tmp logging
+- local validation before phase completion
+- local branches and small commits only after verification

--- a/.claude/skills/dev-loop/templates/dev-mode-retrospective.md
+++ b/.claude/skills/dev-loop/templates/dev-mode-retrospective.md
@@ -1,0 +1,15 @@
+# Phase {{phase}} dev-mode retrospective
+
+## Iteration reviewed
+
+## What the loop did well
+
+## What created friction or waste
+
+## Prompt follow-ups required
+
+## Prompt and workflow changes applied
+
+## Validation of the follow-up changes
+
+## Next dev-mode watchpoints

--- a/.claude/skills/dev-loop/templates/dev-mode-review.md
+++ b/.claude/skills/dev-loop/templates/dev-mode-review.md
@@ -1,0 +1,17 @@
+# Phase {{phase}} dev-mode review
+
+Optional analytical notes that support the required [Dev Mode Retrospective](./dev-mode-retrospective.md).
+
+## Iteration reviewed
+
+## Artifact inputs reviewed
+
+## What the skill did well
+
+## Friction and failure patterns
+
+## Deterministic tooling gaps
+
+## Recommended skill or workflow changes
+
+## Decision

--- a/.claude/skills/dev-loop/templates/dev-mode-skill-changes.md
+++ b/.claude/skills/dev-loop/templates/dev-mode-skill-changes.md
@@ -1,0 +1,11 @@
+# Phase {{phase}} dev-mode skill changes
+
+## Trigger
+
+## Changes made
+
+## Why these changes were chosen
+
+## Validation
+
+## Remaining gaps

--- a/.claude/skills/dev-loop/templates/merged-phase-plan.md
+++ b/.claude/skills/dev-loop/templates/merged-phase-plan.md
@@ -1,0 +1,19 @@
+# Phase {{phase}} merged plan
+
+## Selected direction
+
+## Exact scope
+
+## Explicit non-goals
+
+## Tests to write first
+
+## Implementation order
+
+## Validation steps
+
+## Acceptance criteria
+
+## Definition of done
+
+## Risks / watchpoints

--- a/.claude/skills/dev-loop/templates/phase-doc.md
+++ b/.claude/skills/dev-loop/templates/phase-doc.md
@@ -1,0 +1,27 @@
+# {{phase}} durable plan
+
+## Status
+
+Planning
+
+## Objective
+
+## Why this phase exists now
+
+## In scope
+
+## Explicit non-goals
+
+## Acceptance criteria
+
+## Definition of done
+
+## Validation approach
+
+## Durable decisions
+
+## Open questions
+
+## Links to execution artifacts
+
+- local execution artifacts may exist under `tmp/phases/{{phase}}/`

--- a/.claude/skills/dev-loop/templates/phase-summary.md
+++ b/.claude/skills/dev-loop/templates/phase-summary.md
@@ -1,0 +1,13 @@
+# Phase {{phase}} summary
+
+## What was planned
+
+## What was implemented
+
+## Tests added or updated
+
+## Validation results
+
+## Decisions recorded
+
+## Follow-ups for next phase

--- a/.claude/skills/dev-loop/templates/phase-variant.md
+++ b/.claude/skills/dev-loop/templates/phase-variant.md
@@ -1,0 +1,15 @@
+# Phase {{phase}} variant {{variant}}
+
+## Intent
+
+## Phase scope
+
+## Files/modules touched
+
+## Tests to add first
+
+## Implementation order
+
+## Acceptance criteria
+
+## Risks / non-goals

--- a/.claude/skills/dev-loop/templates/retrospective.md
+++ b/.claude/skills/dev-loop/templates/retrospective.md
@@ -1,0 +1,11 @@
+# Phase {{phase}} retrospective
+
+## What worked well
+
+## What caused friction or waste
+
+## Fan-out / fan-in / review loop effectiveness
+
+## What to change in the skill or workflow next time
+
+## What a fresh session should know before the next phase

--- a/.claude/skills/dev-loop/templates/review.md
+++ b/.claude/skills/dev-loop/templates/review.md
@@ -1,0 +1,32 @@
+# Phase {{phase}} merged-plan review
+
+## Review verdict
+
+## Scope overreach check
+
+## Default pre-approval gate
+<!-- Resolve angles from config: resolveGateAngles(config, "preApproval") -->
+- configured angle checks: add one bullet per configured pre-approval angle (for example `dry`, `kiss`, `yagni`, `srp`, `soc` when defaults apply)
+- fallback note: if parallel execution of the configured review angles is impractical, record why and confirm all configured angles were still covered
+
+## Additional design-principle check (SRP, etc.)
+
+## Test and validation check
+
+## Module boundary check
+
+## Pi API / runtime coupling check
+
+## Acceptance criteria clarity check
+
+## Definition-of-done clarity check
+
+## Review-surface completeness check
+- review-surface completeness: confirm the merged plan and durable phase doc both carry stable definition-of-done output
+- confirm the review surface checks the planned definition of done instead of only acceptance criteria
+
+## RFC-escalation sanity check
+- confirm RFC-worthy technical decisions are escalated to the parent session / human operator
+- confirm the parent-session receiving boundary and decision ownership remain explicit
+
+## Required revisions

--- a/.claude/skills/dev-loop/templates/ui-vision-review.md
+++ b/.claude/skills/dev-loop/templates/ui-vision-review.md
@@ -1,0 +1,55 @@
+# Vision-model UI review prompt template
+
+Use this template when `uiReviewMode` is `vision`.
+
+You are a vision-capable UI reviewer (model: `gpt-5.4`) reviewing deterministic named-state artifacts produced by `captureNamedUiState()`.
+
+## Inputs
+
+- `acceptanceCriteria`: required list of UI acceptance criteria
+- `reviewBrief`: required short focus brief
+- `artifactBundle.sliceId`: required UI slice id
+- `artifactBundle.namedStates[]`: required list of named states
+  - `stateName`
+  - `screenshotPath` (must point to `screenshot.png`)
+  - `statePath` (must point to `state.json`)
+
+## Review policy
+
+1. Fail closed when required inputs are missing, ambiguous, or unreadable.
+2. Ground every finding in one or more `screenshotPath` and `statePath` references.
+3. Evaluate layout, hierarchy, spacing, clipping, overlap, contrast, callouts/highlighting, and state-transition clarity against the acceptance criteria and review brief.
+4. Return only deterministic findings; do not invent evidence that is not visible in artifacts.
+
+## Required output format
+
+Allowed enum values:
+- `outcome`: `"continue_ui_fix_loop"` | `"ui_review_satisfied"` | `"blocked_needs_human_decision"`
+- `severity`: `"high"` | `"medium"` | `"low"`
+
+`blockedReason` must always be present in the output. Set it to `null` unless `outcome` is `"blocked_needs_human_decision"`, in which case provide a non-empty string explaining the block reason.
+
+Return strict JSON with this shape (example uses concrete values):
+
+```json
+{
+  "outcome": "ui_review_satisfied",
+  "summary": "short overall verdict",
+  "findings": [
+    {
+      "severity": "medium",
+      "stateName": "named state label",
+      "evidence": {
+        "screenshotPath": "test-results/ui-smoke/<sliceId>/named-states/<state-slug>/screenshot.png",
+        "statePath": "test-results/ui-smoke/<sliceId>/named-states/<state-slug>/state.json"
+      },
+      "problem": "what is visually wrong or unclear",
+      "suggestedFix": "specific corrective action"
+    }
+  ],
+  "nextIterationFocus": [
+    "small, actionable UI fix target"
+  ],
+  "blockedReason": null
+}
+```

--- a/.claude/skills/docs/acceptance-criteria-verification.md
+++ b/.claude/skills/docs/acceptance-criteria-verification.md
@@ -1,0 +1,21 @@
+# Acceptance Criteria Verification
+
+Extracted procedure for verifying issue acceptance criteria during the `pre_approval_gate`. Referenced from [Copilot PR Follow-up Skill](../copilot-pr-followup/SKILL.md#pre-approval-gate-contract).
+
+## Procedure
+
+Before posting the `pre_approval_gate` comment, verify every acceptance criteria checklist item in the issue linked to this PR:
+
+1. **Resolve the linked issue number deterministically:** use `gh pr view <pr-number> --repo <owner/name> --json closingIssuesReferences,body` and apply this decision tree: if there is exactly one closing issue reference, use it; else if there is exactly one PR-body `Closes #N` / `Fixes #N` pattern, use it; otherwise (zero or multiple candidates), post the gate comment with verdict `blocked` (gate cannot complete deterministically) rather than guessing.
+
+2. **Read the issue body:** `gh issue view <issue-number> --repo <owner/name> --json body`
+
+3. **Extract checklist items** from the **Acceptance criteria** section of the issue body (both `- [ ]` unchecked and `- [x]` already-checked items). Ignore checklist items from other sections (DoD, tasks, non-goals) that are not acceptance criteria.
+
+4. **Verify each AC item** against the proposed changes on the current PR head.
+
+5. **Update the issue body once:** compute the fully-updated issue body by replacing each verified item's `- [ ]` with `- [x]`, write it to a temporary file, and perform a single `gh issue edit <issue-number> --body-file <tmp-file> --repo <owner/name>`. Do not issue one edit per item; prefer `--body-file` over inline `--body` to avoid shell quoting/escaping hazards.
+
+6. **Post the gate comment:** always post a `pre_approval_gate` comment (the checkpoint verdict comment contract requires a visible comment even for non-`clean` verdicts). Use verdict `clean` only when all AC items are verified; use verdict `findings_present` when any AC item is not satisfied and requires follow-up fixes; use verdict `blocked` when the gate cannot complete deterministically (for example no linked issue, ambiguous issue linkage, or the issue body is unavailable). In all cases include a note on AC verification status.
+
+When the issue body has no AC checklist items, post the gate comment with verdict `findings_present` and note that fact explicitly rather than assuming satisfaction.

--- a/.claude/skills/docs/anti-patterns.md
+++ b/.claude/skills/docs/anti-patterns.md
@@ -1,0 +1,21 @@
+# Anti-patterns
+
+Canonical owner for anti-pattern guidance across all workflow families.
+
+## Core anti-patterns
+
+1. **Skipping fan-out/fan-in for non-trivial changes**: Do not implement directly without refinement when scope exceeds light-mode thresholds.
+2. **Routing review-only work through local_implementation**: Review-only comparison, synthesis, or consolidation must use `refiner` agent, not `dev-loop` + `local_implementation`.
+3. **Thin placeholder PR descriptions**: Always include change summary, scope/context, acceptance criteria, definition of done, non-goals, and `Closes #N`.
+4. **Merging directly to main without PR**: Use PR-based remote loop when practical.
+5. **Duplicate worktree paths**: Check `git worktree list` before creating new worktrees; reuse existing matching worktrees.
+6. **Main-checkout mutation**: Reserve main checkout for inspection/control; use `tmp/worktrees/` paths for mutation work.
+
+## Light mode exception
+
+Small scoped changes (≤3 files, ≤200 lines) may skip fan-out/fan-in but must still run validation and a single review pass. See [Local Implementation](../local-implementation/SKILL.md) for details.
+
+## Cross-references
+
+- [Structural quality](structural-quality.md)
+- [Validation policy](validation-policy.md)

--- a/.claude/skills/docs/artifact-authority-contract.md
+++ b/.claude/skills/docs/artifact-authority-contract.md
@@ -1,0 +1,119 @@
+# Artifact authority contract
+
+This document is the canonical authority for the artifact-selection model: when work originates from a GitHub issue (tracker-first) vs a persisted markdown plan file (local-planning).
+
+This canonical owner lives in the shipped `skills/docs/` surface because installed skill/runtime consumers reliably own the skills subtree. In installed layouts, read the same contract via [Artifact Authority Contract](../docs/artifact-authority-contract.md) from the installed skill directory.
+
+Other repo docs may summarize or link this contract, but they should not redefine it.
+
+## Two-tier model
+
+dev-loops supports two mutually exclusive artifact authority modes. Every work item must originate from exactly one authoritative artifact — a GitHub issue or a persisted markdown plan file. No work may originate from a PR or direct local change unless explicitly requested.
+
+### Tracker-first (default)
+
+**GitHub issues are the authoritative artifact store.** Work originates from a GitHub issue. A linked PR is the execution artifact. GitHub is the canonical source of truth for issue identity, acceptance criteria, scope, and lifecycle state.
+
+Artifacts:
+- **Planning artifact:** GitHub issue (title, body, labels, assignees, acceptance criteria)
+- **Execution artifact:** GitHub PR (linked to issue; created during implementation)
+- **No local duplicate:** Do not create `docs/phases/phase-<n>.md` for the same session when a GitHub issue is the canonical spec
+
+Key contract:
+- GitHub issue state is authoritative — not local notes or chat context
+- A linked PR is the single canonical follow-up artifact for the issue
+- When an open linked PR exists, reuse it rather than opening another
+- Implementation may proceed through either the GitHub-first routed path or the local implementation strategy (see [Public Dev Loop Contract](public-dev-loop-contract.md) `targetPreference`)
+
+### Local-planning (opt-out)
+
+**Persisted markdown plan files are the authoritative artifact store.** Work originates from a markdown plan file committed to the repository. No GitHub issue is required. GitHub PRs are still used for review and merge, but the plan file is the canonical spec.
+
+Artifacts:
+- **Planning artifact:** Persisted markdown plan file (e.g., `docs/phases/phase-<n>.md`)
+- **Execution artifact:** Local branch and associated GitHub PR (created during implementation)
+- **No GitHub issue:** The plan file replaces the issue as the canonical spec
+
+Key contract:
+- The markdown plan file is the canonical spec — not a duplicate of a tracker issue
+- GitHub issues may still be used for tracking or linking, but the plan file is authoritative for scope and acceptance criteria
+- A tracker-backed local implementation session (GitHub issue as canonical spec) must not also maintain a duplicate `docs/phases/phase-<n>.md` — see [Public Dev Loop Contract](public-dev-loop-contract.md) "Tracker-backed local implementation input-source contract"
+
+### Mode selection table
+
+| Mode | Canonical artifact | GitHub issue required | Settings values |
+|---|---|---|---|
+| Tracker-first (default) | GitHub issue | Yes | `strategy.default: github-first` |
+| Local-planning (opt-out) | Markdown plan file | No | `strategy.default: local-first` |
+
+`inputSource.default` further disambiguates local-first startup:
+| inputSource | Meaning |
+|---|---|
+| `tracker` (default) | Local agent implements from the GitHub issue body; no phase doc created |
+| `phase-docs` | Local agent implements from persisted phase docs (e.g., `docs/phases/phase-<n>.md`) |
+
+## Settings mechanism
+
+Artifact authority mode is controlled by `.devloops` at repo root:
+
+```yaml
+# .devloops
+strategy:
+  default: github-first   # tracker-first (GitHub issue required)
+  # default: local-first  # local-planning (markdown plan file)
+inputSource:
+  default: tracker        # spec source for local-first: tracker (issue body) or phase-docs
+```
+
+The `strategy.default` key serves dual purpose:
+1. It selects the artifact authority mode (tracker-first vs local-planning)
+2. It sets the default routing preference for `targetPreference` in dev-loop startup
+
+The `inputSource.default` key disambiguates local-first startup:
+- `tracker` (default): local agent implements from the GitHub issue body; the issue is canonical spec
+- `phase-docs`: local agent implements from persisted phase docs; no tracker issue required
+
+These keys are already defined in `.pi/dev-loop/defaults.yaml` (shipped with dev-loops) and may be overridden in `.devloops` (per-repo).
+
+### Defaults resolution
+
+1. `.pi/dev-loop/defaults.yaml` — shipped default (`github-first`)
+2. `.devloops` — per-repo override (takes precedence)
+
+### Explicit non-knobs
+
+These are not valid artifact authority mode selectors:
+- `strategy.default: copilot` — not a valid mode; must be `github-first` or `local-first`
+- Free-form string values — fail closed
+- Omitting `strategy.default` entirely — defaults to `github-first` from the shipped defaults
+
+## dev-loops own mode
+
+dev-loops is **tracker-first (opted in, GitHub backend).**
+
+- **Mode:** Tracker-first
+- **Settings:** `.pi/dev-loop/defaults.yaml` sets `strategy.default: github-first`
+- **Artifact authority:** GitHub issues are the canonical spec for all work in this repository
+- **No local-planning override:** This repo does not opt out to local-planning mode
+- **Why tracker-first:** All work in this repo originates from GitHub issues. The public dev-loop contract, Copilot follow-up state machines, and gate pipeline all assume issues are the primary artifact. Self-improvement work on dev-loops itself follows the same tracker-first contract.
+
+## Relationship to other docs
+
+| Doc | Relationship |
+|---|---|
+| [Public Dev Loop Contract](public-dev-loop-contract.md) | This contract is the canonical entrypoint; artifact authority contract defines the artifact model it assumes |
+| [Tracker-First Loop State](tracker-first-loop-state.md) | That doc defines the PR-level state machine for tracker-first PR workflows — it is about execution state, not artifact authority |
+| [Main Agent Contract](main-agent-contract.md) | Defines the delegation boundary; artifact authority defines which artifacts govern work |
+| AGENTS.md | Repo constitution; cites the work-origin rule and points to this contract |
+| [Dev Loop Skill](../dev-loop/SKILL.md) | Public entrypoint skill; cites the work-origin rule and points to this contract |
+
+### Distinction: artifact authority vs tracker-first PR workflow
+
+`tracker-first-loop-state.md` defines a state machine for PR lifecycle management when a tracker item (e.g., Shortcut story) drives a GitHub PR. That is a **PR-level workflow contract**, not the artifact authority model. The term "tracker-first" in that doc refers to tracker-driven PR state transitions — it does not redefine the artifact authority contract defined here.
+
+## Non-goals
+
+- Defining tracker adapters or multi-tracker support
+- Specifying how PRs map to issues in detail (that is the [Public Dev Loop Contract](public-dev-loop-contract.md))
+- Changing the dev-loop startup resolver behavior
+- Adding tracker-specific settings beyond `inputSource` — further tracker adapters or multi-tracker support remain out of scope

--- a/.claude/skills/docs/confirmation-rules.md
+++ b/.claude/skills/docs/confirmation-rules.md
@@ -1,0 +1,28 @@
+# Confirmation rules
+
+Canonical owner for agent confirmation / authorization rules across all workflow families.
+
+## Core rule
+
+Before any state-changing action, get explicit confirmation unless the latest user message already clearly authorizes that exact action.
+
+## What counts as confirmation
+
+- ✅ Explicit authorization in the current conversation
+- ✅ Pre-authorized merge or mutation scope (e.g. "Merge authorized if gates green")
+- ❌ Questions, preferences, future-tense statements
+- ❌ Implied approval from prior turns
+- ❌ Bare response `ok`
+
+## Where this rule applies
+
+- All routed strategies (`local_implementation`, `copilot_pr_followup`, `issue_intake`, `reviewer_fixer`, `final_approval`)
+- All gate entries (`draft_gate`, `pre_approval_gate`)
+- All merge operations
+- All force-push / history-rewriting operations
+
+## Cross-references
+
+- [Stop conditions](stop-conditions.md)
+- [Merge preconditions](merge-preconditions.md)
+- [Public Dev Loop Contract](public-dev-loop-contract.md)

--- a/.claude/skills/docs/copilot-ci-status-contract.md
+++ b/.claude/skills/docs/copilot-ci-status-contract.md
@@ -1,0 +1,52 @@
+# Copilot PR CI/check normalization contract
+
+This document is the canonical bundled contract for deterministic interpretation of PR CI/check inputs used by Copilot PR follow-up flows.
+
+Installed skill/runtime consumers should read this bundled `skills/docs/` copy via [Copilot CI Status Contract](../docs/copilot-ci-status-contract.md) from the relevant skill directory. Repository-local docs may summarize or link this contract, but they should not redefine it.
+
+Implementation surface:
+- `@dev-loops/core/loop/copilot-ci-status`
+- source file: `packages/core/src/loop/copilot-ci-status.mjs`
+
+## Entry points
+
+- `normalizeStatusCheckRollupContract(statusCheckRollup)` — normalizes the PR `statusCheckRollup` snapshot from `gh pr view`
+- `normalizeHeadScopedCiContract({ checkRunsStatus, commitStatus })` — normalizes current-head refresh inputs after explicit `check-runs` / commit-status probes
+
+Both entry points return the same machine-readable contract shape.
+
+## Inputs
+
+### `normalizeStatusCheckRollupContract(statusCheckRollup)`
+
+- `statusCheckRollup` — the raw PR `statusCheckRollup` array from `gh pr view`; entries may be CheckRun-like (`status` + `conclusion`) or legacy StatusContext-like (`state`)
+
+### `normalizeHeadScopedCiContract({ checkRunsStatus, commitStatus })`
+
+- `checkRunsStatus` — normalized head-scoped check-runs status (`success` | `failure` | `pending` | `none`)
+- `commitStatus` — normalized head-scoped commit-status status (`success` | `failure` | `pending` | `none`)
+- optional `checkRunsUnsupportedCompleted` — `true` when the current-head check-runs probe observed an unsupported/non-success completed conclusion (for example `CANCELLED`) that must keep the merged result non-green even if commit status separately reports success
+
+## Output
+
+The returned object always includes:
+
+- `overallStatus` (`success` | `failure` | `pending` | `none`)
+- `rollup` (`success`/`failure`/`pending`/`none` booleans; exactly one true)
+- `semantics.wait` (`true` when `overallStatus` is `pending` or `none`)
+- `semantics.blocked` (`true` when `overallStatus` is `failure`)
+- `semantics.timeoutDisposition` (`remain_waiting` for `pending`/`none`; otherwise `not_applicable`)
+
+## Deterministic precedence
+
+The rollup precedence is fixed and policy-agnostic for ordinary normalized status values:
+1. `failure`
+2. `pending`
+3. `success`
+4. `none`
+
+Completed `SKIPPED` and `NEUTRAL` check-run conclusions count as non-blocking success-like signals. A completed `CANCELLED` check does not count as a successful readiness signal by itself; cancelled-only snapshots normalize to `none` so CI-dependent gates do not advance on cancelled work. Legacy successful `StatusContext` rollup entries also normalize to `success` instead of being mistaken for pending work.
+
+Merged current-head exception:
+- when `checkRunsUnsupportedCompleted=true`, a `checkRunsStatus: "none"` result caused by unsupported/non-success completed check-runs must remain non-green even if `commitStatus` is `success`
+- in that specific case, the merged `overallStatus` stays `none` rather than letting `success` mask the unsupported completed check-run signal

--- a/.claude/skills/docs/copilot-loop-operations.md
+++ b/.claude/skills/docs/copilot-loop-operations.md
@@ -1,0 +1,233 @@
+# Copilot loop operations
+
+This document is the canonical operational reference for the deterministic Copilot PR follow-up state machine used by the routed `copilot_pr_followup`, `wait_watch`, `reviewer_fixer`, and `final_approval` paths behind `dev-loop`.
+
+Use it together with:
+- [Copilot PR Follow-up Skill](../copilot-pr-followup/SKILL.md)
+- [Public Dev Loop Contract](./public-dev-loop-contract.md)
+- [Retrospective Checkpoint Contract](./retrospective-checkpoint-contract.md) when the current step depends on async start/resume/status or retrospective enforcement
+
+## Deterministic orchestration authority
+
+When operating in PR follow-up or async watch mode, use the deterministic state machines
+as the authoritative source for:
+
+- Copilot follow-up loop: `detect-copilot-loop-state.mjs` from the resolved skill scripts directory
+- reviewer-side PR review loop: `detect-reviewer-loop-state.mjs` from the resolved skill scripts directory
+
+Resolve those helper paths from the skill asset layout described by the main skill. In the `dev-loops`
+source repository the skill scripts directory is `../../scripts/` relative to `skills/copilot-pr-followup/SKILL.md`; in normalized
+installed copies it may instead be `scripts/` inside the installed skill directory when that layout bundles the helper scripts.
+
+Use the machines to answer:
+- what state the PR/loop is in right now
+- what transitions are currently allowed
+- what the next required action is
+- when to stop instead of guessing
+
+Each machine captures an observable snapshot from GitHub facts (plus explicit bounded local loop
+metadata when required) and interprets it into exactly one current state plus allowed next
+transitions. In the `dev-loops` source repository, the supporting source-authority references are [Copilot Loop State Graph](../../docs/copilot-loop-state-graph.md) and [Reviewer Loop State Graph](../../docs/reviewer-loop-state-graph.md) under `../../docs/` relative to `skills/copilot-pr-followup/SKILL.md`. Treat those links as source-repo references, not bundled installed-skill docs.
+
+For tracker-first MVP `story -> PR -> tracker sync` work, the source-repo reference is [Tracker-First Story-to-PR Contract](../../docs/tracker-story-pr-contract.md). That source doc inherits source-of-truth ownership, the required work item <-> PR link, and reverse-sync semantics from `#21`; it only adds the mutually exclusive workflow-family states and post-merge sync-verification states for this narrower MVP slice.
+
+## Key guarantees from the state machine
+
+- `unresolvedThreadCount > 0` always routes to fix/reply-resolve — never to a wait/watch state
+- `snapshot.copilotReviewRequestStatus === "unavailable"` or `snapshot.copilotReviewRequestStatus === "failed"` routes to a terminal stop state — never to sleep or watch
+- `agentFixStatus === "applied"` with unresolved threads routes to `already_fixed_needs_reply_resolve` — reply/resolve on GitHub is required before re-requesting review
+- Copilot being in `requested_reviewers` (`"requested"` or `"already-requested"`) routes to `waiting_for_copilot_review`
+
+## How to use the state machine in practice
+
+1. Run `node <resolved-skill-scripts>/loop/detect-copilot-loop-state.mjs --repo <owner/name> --pr <number>`
+   to get the current Copilot-loop state, decisive snapshot fields, and recommended next action.
+
+2. If you already ran `<resolved-skill-scripts>/github/request-copilot-review.mjs` and got a known status,
+   inject it without re-probing: add `--review-request-status <status>`.
+
+3. When the agent has applied a fix and wants to signal reply/resolve is next, build a snapshot
+   with `agentFixStatus: "applied"` and use `--input <snapshot.json>` for interpretation.
+
+4. Branch on the detector output instead of inventing a polling loop:
+   - `state=waiting_for_copilot_review` with `snapshot.copilotReviewOnCurrentHead=false`: do **not** poll manually; either run `node <resolved-skill-scripts>/loop/run-watch-cycle.mjs --repo <owner/name> --pr <number>` for persistent async waiting or report the wait state and resume later after the single detector call
+   - `state=waiting_for_ci` with `snapshot.ciStatus` in `{ "pending", "none" }`: do **not** poll manually by default; use `gh run watch <run-id> --repo <owner/name>` when the current-head run id is already known, otherwise report pending CI and resume later after the single detector refresh. Bounded exception: if GitHub created zero current-head check suites/statuses, the previous head rollup was green, and local `npm run verify` already passed for the same current head, rerun `detect-copilot-loop-state.mjs` with `--local-validation-head-sha <current-head-sha>` so the detector can promote that exact zero-suite case to `snapshot.ciStatus="crediblyGreen"` instead of waiting forever on raw `none`.
+   - `snapshot.ciStatus="failure"` remains a stop/fix state, never a wait loop
+
+5. For reviewer-side draft-review work, run `node <resolved-skill-scripts>/loop/detect-reviewer-loop-state.mjs --repo <owner/name> --pr <number> [--reviewer-login <login>] [--local-state <path>]`.
+   If the state reaches `draft_review_ready`, stage the pending review with
+   `node <resolved-skill-scripts>/github/stage-reviewer-draft.mjs --repo <owner/name> --pr <number> --review-file <merged-review.json> --local-state-output <state.json>`,
+   then re-run the detector with `--local-state <state.json>`.
+
+6. Follow the `nextAction` from the machine output. For stop states (`review_request_unavailable`,
+   `blocked_needs_user_decision`), report to the user and do not proceed.
+
+## Judgment calls that remain in the agent layer
+
+- Whether a comment should be accepted, deferred, or disagreed with
+- Whether the code change is already sufficient (→ sets `agentFixStatus: "applied"`)
+- What the narrowest valid fix is
+- Whether another Copilot pass is desired (→ triggers re-request or selects `done`)
+
+## Workflow overview
+
+```text
+ready issue -> confirm scope -> Copilot branch/PR -> async review/watch -> Pi follow-up fixes -> validation -> confirm verdict/action -> merge when authorized
+```
+
+Use the resolved `detect-copilot-loop-state.mjs` helper from the skill scripts directory at each
+decision point in this flow to determine the current state and route to the correct next step
+deterministically.
+
+## Pre-follow-up working rules
+
+> **Phase boundary:** Steps 1-4 apply when no PR exists yet (issue intake).
+> If a PR already exists, skip to [Deterministic orchestration authority](#deterministic-orchestration-authority) —
+> the state machine owns all post-PR routing.
+
+### Step 1: Choose the work item
+
+Prefer a GitHub issue over an ad hoc local TODO.
+
+When selecting the next item:
+- prefer `type:task` issues under the relevant epic
+- prefer `status:ready`
+- inspect milestone, labels, and acceptance criteria
+- confirm whether a PR already exists for the issue before proposing new execution
+
+Useful checks:
+- `gh issue list --state open`
+- `gh issue view <number>`
+- `gh pr list --state open`
+
+If the user asks for status/progress/readiness/merge-state/next-step (including “what is next”):
+- resolve authoritative active artifact identity first (issue/PR, plus branch/head SHA when useful)
+- for issue targets, do not assert "no open PR" until authoritative issue↔PR linkage is resolved via the startup resolver (`dev-loops loop startup --issue <number>`, run inside the `dev-loop` async subagent) — do not run `detect-linked-issue-pr.mjs` manually
+- resolve artifact state (`open`/`closed`/`merged`/`not_applicable`)
+- resolve current loop state and next action from deterministic helper/state output
+- include explicit resolved artifact identity in the answer
+- if identity/state cannot be resolved confidently, stop with reconcile/unknown instead of guessing from chat context
+
+### Step 2: Confirm issue scope before execution
+
+Before handing work to Copilot or doing follow-up fixes, summarize:
+- issue number and title
+- parent epic if present
+- milestone
+- labels
+- exact acceptance criteria
+- intended narrow scope
+- non-goals inferred from the issue and plan
+
+If the work item is phase-like, ambiguous, or likely to shape more than one downstream step, default to a short fan-out / fan-in refinement pass before implementation:
+- generate 2-3 plan variants in parallel when practical
+- compare the variants explicitly
+- merge them into one bounded execution plan
+- only then proceed with GitHub execution
+
+If the issue text is too vague, stop and ask a short clarification question rather than guessing.
+
+### Step 3: Decide whether Copilot or Pi should act next
+
+Use this heuristic:
+
+#### Prefer Copilot when
+- there is a ready implementation issue with clear acceptance criteria
+- no PR exists yet for that issue
+- the user wants the repository's normal GitHub/Copilot path
+- the next step is “start work” rather than “finish this already-open PR right now”
+
+#### Prefer Pi follow-up when
+- a PR already exists
+- Copilot has already pushed work and now needs review/fix follow-up
+- there are unresolved comments or failing checks
+- the user wants async in-session watching and response
+
+#### Prefer plain analysis only when
+- the user is asking what should happen next
+- authorization for GitHub state changes has not been given yet
+- the issue/PR state is unclear and needs inspection first
+
+### Step 4: Copilot handoff rules
+
+When preparing work for Copilot:
+- use the GitHub issue as the source of truth
+- preserve the issue's acceptance criteria
+- keep the requested scope narrow
+- do not broaden into adjacent backlog items
+- prefer one issue per PR unless the user explicitly wants bundling
+
+Before any GitHub mutation such as assigning the issue, posting instructions, or changing labels, confirm first unless explicitly authorized.
+
+When you do hand work to Copilot:
+- assign `copilot-swe-agent`
+- reference the issue number and acceptance criteria clearly
+- keep instructions implementation-focused and test-aware
+
+## PR description contract
+
+Follow the PR description contract (see [Agent Instructions](../../AGENTS.md) if present; otherwise use the structure below): detailed structured descriptions, not thin placeholders. At minimum include change summary, scope/context, explicit acceptance criteria, explicit definition of done, and explicit non-goals, and `Closes #N` (or `Fixes #N`) for the linked issue so GitHub auto-closes it on merge.
+
+Checkbox rule: acceptance criteria, definition-of-done items, and any task list must be rendered as real GitHub markdown checkboxes inside list items (`- [ ]` / `- [x]`, also `* [ ]` / `* [x]`). Do not wrap checkbox markers (e.g. `[x]`) in backticks. Do not place checkbox markers inside table cells — task lists are not interactive there even with a leading `- `.
+
+New PRs in this workflow must be opened as **draft** PRs first when the repository enables `.devloops` at repo root `workflow.requireDraftFirst`. The built-in shipped default remains permissive; this repo opts in. Do not create a fresh PR directly in ready-for-review state unless the user explicitly overrides that policy for the current PR scope. The draft gate inspection is a real workflow boundary, so a new PR must exist in draft before `gh pr ready` is even eligible.
+
+Only use `node <resolved-skill-scripts>/github/create-draft-pr.mjs` when authoritative issue↔PR resolution says there is no already-open linked PR. If a PR already exists, reuse/update that canonical PR instead of opening another one. This wrapper preserves the underlying `gh pr create` output contract while enforcing draft-first mechanically.
+
+MUST use `node <resolved-skill-scripts>/github/create-draft-pr.mjs --repo <owner/name> --assignee @me --base <base> --head <head> --title "..." --body-file <body-file>`.
+
+## Timeout and watch policy
+
+This workflow is intentionally long-lived, but one Copilot review watch boundary must still be capped.
+
+Preferred defaults for this repo:
+- poll interval for review/activity watchers: **1 minute** (derived from `packages/core/src/loop/policy-constants.mjs` DEFAULT_POLL_INTERVAL_MS)
+- max watch timeout per Copilot review boundary: **30 minutes** (derived from `packages/core/src/loop/policy-constants.mjs` COPILOT_REVIEW_WAIT_TIMEOUT_MS)
+- if that 30-minute watch budget expires, refresh authoritative state once; if the refreshed state still resolves `waiting_for_copilot_review`, stop with `watch timeout — PR #<number> needs manual attention`
+- do not silently extend that 30-minute cap unless the user or conductor explicitly authorizes a longer watch budget for the active PR
+- parent/subagent no-activity threshold for watcher-style runs: at least **15 minutes**
+- active-long-running notice threshold for watcher-style runs: about **30 minutes**
+
+These are the defaults built into `probe-copilot-review.mjs`, `run-watch-cycle.mjs`, and the `watchArgs` emitted by `copilot-pr-handoff.mjs`. Do not pass removed CLI policy flags (`--poll-interval-ms`, `--timeout-ms`, `--probe-only`) — helpers hard-error when they are provided. Timeouts and intervals are derived from `packages/core/src/loop/policy-constants.mjs`.
+
+### Outer-loop checkpoint: canonical re-attachment artifact
+
+The outer-loop checkpoint (`tmp/copilot-loop/<owner>/<repo>/pr-<n>/outer-loop-state.json`)
+is the canonical re-attachment artifact for async subagent runs. It is written by
+`outer-loop.mjs` at every conductor cycle and records:
+
+| Field | Meaning |
+|---|---|
+| `pr` | PR number |
+| `repo` | Repository slug (`owner/name`; lowercased by `outer-loop.mjs`) |
+| `outerAction` | Next action: `continue_wait`, `reenter_copilot_loop`, `reenter_reviewer_loop`, `stop`, `done` |
+| `copilotState` | Current copilot inner-loop state |
+| `reviewerState` | Current reviewer inner-loop state |
+| `reviewerScope` | Reviewer scope mode (always present; e.g. `all_reviewers` or `single_reviewer`) |
+| `reviewerLogin` | Reviewer GitHub login (always present; `null` unless single-reviewer scope) |
+| `reason` | Stop reason (`null` when `outerAction` is not `stop`) |
+| `timestamp` | ISO 8601 timestamp of checkpoint write |
+| `waitCycles` | Number of wait cycles accumulated |
+| `headSha` | PR head SHA at checkpoint time (`null` when unavailable) |
+
+### Re-attachment contract
+
+When a fresh `dev-loop` async subagent starts on a PR that already has an outer-loop
+checkpoint, it must read the checkpoint before entering any intake or follow-up procedure:
+
+1. If `outerAction` is `continue_wait` or `reenter_copilot_loop`: auto-resume the loop
+   rather than treating the start as fresh intake.
+2. If `outerAction` is `reenter_reviewer_loop`: enter the reviewer-loop path.
+3. If `outerAction` is `stop`: the loop is blocked or needs a human decision; report the `reason` and ask for direction.
+4. If no checkpoint or `outerAction` is `done`: `done` means the PR is merged/closed; normal fresh startup.
+
+The checkpoint is the only source of truth for re-attachment. Do not rely on chat context
+or local notes to determine "where we left off."
+
+## Hard rule: no agent-authored shell polling
+
+Helper-owned sleep inside `run-watch-cycle.mjs`, `probe-copilot-review.mjs`, or `watch-initial-copilot-pr.mjs` is allowed. Agent-authored shell polling (`sleep`, `for`, `while`, `timeout` wrappers around tool invocations) is a contract breach. This rule applies to ALL repos using the dev-loop workflow, not just the source repo.
+
+A watcher sleeping between polls is expected behavior, not a blocker.
+
+If the polling interval is 1 minute, do not treat silence shorter than one full poll interval as suspicious, and do not configure needs-attention thresholds close to a few seconds for this loop.

--- a/.claude/skills/docs/debt-remediation-contract.md
+++ b/.claude/skills/docs/debt-remediation-contract.md
@@ -1,0 +1,107 @@
+# Debt remediation contract
+
+Canonical authority for the debt remediation pipeline and its integration with the `dev-loop` execution path.
+
+## Pipeline
+
+```
+debt_signals → cluster → score → shape → remediation_item → GitHub issue → dev-loop
+```
+
+Core pipeline stages under `packages/core/src/debt/`:
+
+| Module | Role | Side effects |
+|---|---|---|
+| `debt-signal.mjs` | Signal schema and validation | None |
+| `cluster.mjs` | Group signals into findings by file, module, theme | None |
+| `score.mjs` | 0-100 score from frequency, severity, impact | None |
+| `shape.mjs` | Classify findings: remediation_item, debt_epic, defer, watch, dismiss | None |
+| `remediation-to-issue.mjs` | Convert remediation_item to GitHub issue payload; create via `gh issue create` | `gh issue create` call |
+
+The cluster, score, and shape stages are deterministic pure functions.
+`remediation-to-issue.mjs` performs a side effect (`gh issue create`) and requires GitHub auth.
+
+## CLI entrypoint
+
+`scripts/loop/debt-remediate.mjs` is the single CLI entrypoint routed under `dev-loops loop debt-remediate`.
+
+```
+dev-loops loop debt-remediate --input <signals.json> [--repo <owner/name>] [--dry-run]
+```
+
+### Contract
+
+- **Input**: JSON array of `debt_signal` objects (validated against `DebtSignalSchema`)
+- **Pipeline**: cluster → score → shape → issue creation
+- **Issue creation**: calls `gh issue create --assignee @me` for each `remediation_item`
+- **Output**: JSON report with counts, issue URLs, and summary
+- **Exit codes**: 0 (success — all remediation issue creations succeeded), 1 (argument error, input validation failure, or any issue creation failure)
+- **Dry run**: `--dry-run` runs the full pipeline and validates but skips issue creation
+
+### Output shape
+
+```json
+{
+  "ok": true,
+  "dryRun": false,
+  "repo": "owner/name",
+  "signals": 5,
+  "findings": 2,
+  "remediationItems": 1,
+  "debtEpics": 0,
+  "deferred": 1,
+  "watching": 0,
+  "dismissed": 0,
+  "issues": [
+    {
+      "findingId": "uuid",
+      "title": "...",
+      "created": true,
+      "issueNumber": 123,
+      "issueUrl": "https://github.com/owner/name/issues/123",
+      "error": null
+    }
+  ],
+  "summary": "5 signals → 2 findings; 1 remediation items (1 issues created, 0 failed); ..."
+}
+```
+
+## Integration with dev-loop
+
+Once a remediation issue is created, it is a standard GitHub issue that feeds into the existing `dev-loop` execution path:
+
+1. `dev-loops loop startup --issue <n>` resolves the issue
+2. Standard `copilot-pr-followup` or `issue_intake` strategy takes over
+3. PR → review → merge as normal
+
+This closes the remediation execution loop: `remediation_item → issue → dev-loop → PR → merge`.
+
+## Shape thresholds
+
+Thresholds are hardcoded constants in `shape.mjs`. The outcome for a finding is determined by the combined thresholds:
+
+| Threshold | Value | Outcome |
+|---|---|---|
+| `EPIC_SIGNAL_COUNT_THRESHOLD` | 3 | When `signalCount > 3` and score ≥ `ITEM_THRESHOLD`, the finding becomes a `debt_epic` instead of `remediation_item` |
+| `ITEM_THRESHOLD` | 65 | `remediation_item` (unless signal count pushes to `debt_epic`) |
+| `DEFER_THRESHOLD` | 50 | `defer` |
+| `WATCH_THRESHOLD` | 30 | `watch` |
+| (below) | <30 | `dismiss` |
+
+The `EPIC_SIGNAL_COUNT_THRESHOLD` takes precedence: a finding with score ≥ `ITEM_THRESHOLD` and `signalCount > 3` becomes a `debt_epic`, not a `remediation_item`.
+
+## Scoring model
+
+Three dimensions, weighted:
+
+| Dimension | Weight | Description |
+|---|---|---|
+| Frequency | 0.35 | Signal count, logarithmic cap |
+| Severity | 0.40 | Average severity hint (info=1..critical=5) |
+| Impact | 0.25 | File presence, confidence, category diversity |
+
+Clamped to 0-100.
+
+## Labels
+
+Created issues receive the `workflow` label by default. This keeps them discoverable in the standard dev-loop issue tracking surface.

--- a/.claude/skills/docs/entrypoint-strategies.md
+++ b/.claude/skills/docs/entrypoint-strategies.md
@@ -1,0 +1,115 @@
+# Entrypoint strategies
+
+This document replaces the seven individual `entrypoint-briefing-*.md` files with a single per-strategy-section reference. Each section preserves the state vocabulary and key operational content for that strategy.
+
+## Copilot PR follow-up
+
+State vocabulary: `waiting_for_initial_copilot_implementation`, `waiting_for_copilot_review`, `review_feedback_received`, `linked_pr_ready_for_followup`, `blocked_needs_user_decision`
+
+Next-action sentence: "Load PR state from `detect-copilot-loop-state.mjs`, resolve gate coordination, then execute the appropriate follow-up action (fix, review, wait, or escalate)."
+
+Helpers to run first:
+1. `dev-loops loop loop-state --repo <owner/name> --pr <N>` — resolve loop state
+2. `dev-loops loop gate-coordination --repo <owner/name> --pr <N>` — resolve gate state
+3. `dev-loops gate upsert-verdict` — post/update gate comments
+
+Required reading:
+- [Public Dev Loop Contract](public-dev-loop-contract.md)
+- [Copilot Loop Operations](copilot-loop-operations.md)
+- [Confirmation rules](confirmation-rules.md)
+- [Stop conditions](stop-conditions.md)
+- [Validation policy](validation-policy.md)
+
+## External PR follow-up
+
+State vocabulary: Same as Copilot PR follow-up but with external-human ownership.
+
+Next-action sentence: "Load PR state, check for external review cycles, then route to reviewer/fixer or maintenance workflow."
+
+Helpers to run first: Same as [Copilot PR follow-up](#copilot-pr-follow-up).
+
+Required reading: Same as [Copilot PR follow-up](#copilot-pr-follow-up).
+
+## Final approval
+
+State vocabulary: `approval_ready`, `merge_ready`, `waiting_for_merge_authorization`
+
+Next-action sentence: "Verify pre_approval_gate evidence, confirm CI green + resolved threads, then request explicit merge authorization."
+
+Helpers to run first:
+1. `dev-loops gate detect-evidence --repo <owner/name> --pr <N>` — verify gate evidence
+2. `dev-loops gate upsert-verdict` — post pre_approval_gate
+
+Required reading:
+- [Public Dev Loop Contract](public-dev-loop-contract.md)
+- [Final Approval SKILL](../final-approval/SKILL.md)
+- [Merge preconditions](merge-preconditions.md)
+- [Confirmation rules](confirmation-rules.md)
+
+## Issue intake
+
+State vocabulary: `waiting_for_initial_copilot_implementation`, `needs_refinement`, `ready_needs_assignment_confirmation`, `ready_assign_now`, `assigned_to_copilot`
+
+Next-action sentence: "Resolve issue readiness, handle assignment seam, then bootstrap PR creation or wait for Copilot implementation."
+
+Helpers to run first:
+1. `dev-loops loop linked-issue-pr --repo <owner/name> --issue <N>` — resolve issue↔PR linkage
+2. `dev-loops loop startup` — resolve routing
+
+Required reading:
+- [Public Dev Loop Contract](public-dev-loop-contract.md)
+- [Issue Intake Procedure](issue-intake-procedure.md)
+- [Confirmation rules](confirmation-rules.md)
+- [Stop conditions](stop-conditions.md)
+
+## Local implementation
+
+State vocabulary: `local_branch`, `local_phase`, `in_progress`, `review`, `merge_ready`
+
+Next-action sentence: "Fan-out refinement (unless light-mode), implement phase, validate, then create PR or continue to next phase."
+
+Helpers to run first:
+1. `dev-loops loop startup` — resolve routing
+2. `node scripts/loop/pre-commit-branch-guard.mjs --expected-branch <name> [--require-worktree] [--block-main-checkout]` — verify isolation (no CLI route; use script path)
+
+Required reading:
+- [Public Dev Loop Contract](public-dev-loop-contract.md)
+- [Local Implementation SKILL](../local-implementation/SKILL.md)
+- [Anti-patterns](anti-patterns.md)
+- [Structural quality](structural-quality.md)
+- [Validation policy](validation-policy.md)
+
+## Tracker-first
+
+**Strategy:** `tracker_first` (reserved for future `dev-loop` routing when tracker context detected)
+
+**Purpose:** Tracker-first workflow for story/epic tracker items that follow a PR-based GitHub execution path.
+
+**Routing status:** Routing integration in `resolve-dev-loop-startup.mjs` is deferred (no `tracker_first` route exists yet). This briefing documents the intended contract surface; the state machine and detector are implemented and tested.
+
+**Key artifacts:**
+- Tracker issue (canonical spec)
+- [Tracker-First Loop State](tracker-first-loop-state.md) — state machine doc
+- `detect-tracker-first-loop-state.mjs` — loop state detector
+- `detect-tracker-pr-state.mjs` — PR-level state detector
+
+**Routing:** `dev-loop` will resolve to tracker-first when a tracker context is detected (issue has tracker labels, is a tracker-backed issue). Fail-closed: unknown tracker state → `needs_triage`.
+
+**State vocabulary:** `drafting`, `needs_triage`, `in_progress`, `in_review`, `merge_ready`, `blocked`, `completed`, `unknown`
+
+**Interface contract:** Same as Copilot loop: `{ ok, state, snapshot, allowedTransitions, nextAction }`
+
+## Wait / watch
+
+State vocabulary: `waiting`, `waiting_for_initial_copilot_implementation`, `waiting_for_copilot_review`
+
+Next-action sentence: "Enter healthy-watch mode with configured timeout; escalate only on genuine blocked/authorization/reconcile states."
+
+Helpers to run first:
+1. `dev-loops loop watch-initial --repo <owner/name> --issue <N>` — bootstrap watcher
+2. `dev-loops loop watch-cycle --repo <owner/name> --pr <N>` — cycle watcher
+
+Required reading:
+- [Public Dev Loop Contract](public-dev-loop-contract.md)
+- [Copilot Loop Operations](copilot-loop-operations.md)
+- [Stop conditions](stop-conditions.md)

--- a/.claude/skills/docs/epic-tree-refinement-procedure.md
+++ b/.claude/skills/docs/epic-tree-refinement-procedure.md
@@ -1,0 +1,234 @@
+# Epic tree refinement procedure
+
+This document is the canonical procedure for depth-first, top-down-then-bottom-up refinement of
+an existing GitHub sub-issue tree (parent → children → grandchildren).
+
+Use it together with:
+- [Issue Intake Procedure](./issue-intake-procedure.md) — Phase 3b calls this procedure for epic decomposition
+- [Sub-Issue Tree Contract](../../docs/sub-issue-tree-contract.md) — authoritative sub-issue tooling (source-repo reference)
+
+When you have a tree of GitHub issues that already exists and you need to align AC, DoD, scope
+boundaries, and delegation contracts across all levels, follow this procedure. It is deterministic
+enough that a fresh agent can run it without prior context about the tree.
+
+---
+
+## Definitions
+
+| Term | Meaning |
+|---|---|
+| **Root** | The umbrella/epic issue at the top of the tree |
+| **Parent** | Any issue that has at least one sub-issue child |
+| **Child** | A direct sub-issue of a parent |
+| **Leaf** | An issue with no sub-issue children |
+| **Phase table** | A section of the root/parent body that names each child and what it owns vs excludes |
+| **Scope boundary** | Explicit text in an issue body: `"This issue owns X. It does NOT own Y (#NNN)."` |
+| **AC/DoD matrix** | A two-column table mapping each acceptance criterion to its corresponding DoD checklist item(s) |
+
+---
+
+## Prerequisites
+
+Before starting, verify:
+
+1. The root issue and all intended children/grandchildren exist as GitHub issues in the repo.
+2. The sub-issue tree is attached (run `node <resolved-skill-scripts>/github/manage-sub-issues.mjs list --repo <repo> --issue <root>` to inspect it).
+3. You have the resolved repo slug (`owner/name`).
+
+Optional but recommended before and after edits:
+
+```sh
+dev-loops refine verify --issue <root> --repo <repo>
+```
+
+This verification command checks linkage policy, sibling scope boundaries, refinement completeness,
+and tree integrity in one deterministic pass.
+
+If the sub-issue tree does not yet exist, use [Issue Intake Procedure](./issue-intake-procedure.md) Phase 3b to decompose and attach it first.
+
+---
+
+## Phases
+
+### Phase A — Root refinement (serial)
+
+Refine the root issue **first** before touching any child.
+
+For the root issue:
+1. Read the current body: `gh issue view <root> --repo <repo> --json number,title,body`
+2. Confirm the problem statement is clear and scoped
+3. Confirm a **phase scope table** exists — one row per immediate child naming what each child
+   owns and what it excludes; add or update this table if missing
+4. Confirm **AC checklist** covers the end-to-end goal (not the implementation details owned by children)
+5. Confirm **DoD checklist** — merge-ready condition for the root issue as a whole
+6. Confirm **AC/DoD matrix** — each AC maps to at least one DoD item
+7. Confirm **non-goals** section — prevents scope creep into adjacent areas
+8. Write the updated body to a tmp file: `tmp/issues/<root>/refinement/root-body.md`
+9. Show the diff and obtain confirmation before mutating GitHub
+10. Apply: `gh issue edit <root> --repo <repo> --body-file tmp/issues/<root>/refinement/root-body.md`
+
+**Gate:** Phase B must not start until Phase A is complete and the root body is updated on GitHub.
+
+---
+
+### Phase B — Descend: refine children against parent (parallel fan-out per level)
+
+For **each level** of the tree (breadth-first traversal of levels, depth-first traversal within
+a single branch), refine all siblings in parallel — siblings are independent and only need the
+parent's updated body, not each other's output.
+
+**For each issue at this level:**
+
+1. Read the parent's updated body: `gh issue view <parent> --repo <repo> --json number,title,body`
+2. Read the current child body: `gh issue view <child> --repo <repo> --json number,title,body`
+3. Verify the child's scope matches what the parent's phase table delegates to it
+4. Identify any overlap with sibling issues (read sibling titles/bodies if needed)
+5. Refine the child body with:
+   - **Scope boundary** (explicit): `"This issue owns X. It does NOT own Y (#NNN) or Z (#MMM)."`
+   - **AC checklist** specific to this child's bounded scope
+   - **DoD checklist** — when is this child independently closable?
+   - **AC/DoD matrix**
+   - **Non-goals** — what this child intentionally excludes
+6. Write refined body to `tmp/issues/<child>/refinement/child-body.md`
+7. Show the diff and obtain confirmation before mutating (unless running unattended with explicit authorization)
+8. Apply: `gh issue edit <child> --repo <repo> --body-file tmp/issues/<child>/refinement/child-body.md`
+
+**Parallelism rule:** All siblings at the same level can be refined concurrently. No child needs
+another child's output; each child only reads the parent's contract and its own current body.
+
+**Serial gate between levels:** All children at level N must complete before descending to level N+1.
+
+Repeat Phase B until all leaves are refined.
+
+---
+
+### Phase C — Ascend: reconcile parents with children (parallel fan-out per level)
+
+After all children under a given parent are refined, reconcile that parent. Work bottom-up.
+
+All parents at the same depth can be reconciled in parallel (they only need their own children's
+updated bodies, not sibling parents).
+
+**For each parent (bottom-up):**
+
+1. Re-read the parent body: `gh issue view <parent> --repo <repo> --json number,title,body`
+2. Re-read all direct children bodies
+3. Verify:
+   - The parent's phase scope table still matches what the children now claim to own
+   - No orphaned responsibilities (parent promised something no child owns)
+   - No duplicate ownership (two children claiming the same thing)
+4. Update the parent's phase scope table and AC/DoD as needed to reflect what children now explicitly own
+5. Write refined body to `tmp/issues/<parent>/refinement/parent-reconciled-body.md`
+6. Show the diff and obtain confirmation before mutating
+7. Apply: `gh issue edit <parent> --repo <repo> --body-file tmp/issues/<parent>/refinement/parent-reconciled-body.md`
+
+**Serial gate between levels:** All parents at depth N must complete reconciliation before ascending to depth N-1.
+
+---
+
+### Phase D — Root final reconcile (serial)
+
+After all immediate children of the root have been reconciled:
+
+1. Re-read the root body: `gh issue view <root> --repo <repo> --json number,title,body`
+2. Re-read all immediate children bodies
+3. Verify:
+   - Phase scope table matches actual child scope
+   - Dependency chain is correct (does execution order in the sub-issue tree match dependencies?)
+   - No orphaned responsibilities; no duplicate ownership
+4. Update the root body with the final reconciled phase scope table and AC/DoD
+5. Write to `tmp/issues/<root>/refinement/root-final-body.md`
+6. Show the diff and obtain confirmation before mutating
+7. Apply: `gh issue edit <root> --repo <repo> --body-file tmp/issues/<root>/refinement/root-final-body.md`
+8. Verify the sub-issue tree still reflects the correct execution order:
+   ```sh
+   node <resolved-skill-scripts>/github/manage-sub-issues.mjs verify \
+     --repo <repo> --issue <root> --expected <n1,n2,...> --ordered
+   ```
+
+**Gate:** Root final reconcile completes the procedure. All issues in the tree must now have:
+- AC checklist, DoD checklist, AC/DoD matrix, non-goals, explicit scope boundary
+
+---
+
+## Rules
+
+- **No implementation, no PRs, no Copilot assignment** — this procedure is refinement-only
+- **Use `gh issue edit`** to apply changes directly — do not create new issues or PRs
+- **No prose parent/child links in bodies** — GitHub sub-issues API handles hierarchy
+- **Each issue must have:** AC checklist, DoD checklist, non-goals, AC/DoD matrix, scope boundary
+- **Scope boundary format:** `"This issue owns X. It does NOT own Y (#NNN) or Z (#MMM)."`
+- **Show the diff** and get confirmation before each `gh issue edit` mutation (unless unattended with explicit authorization)
+- **Write tmp artifacts** under `tmp/issues/<number>/refinement/` before applying
+- **Do not duplicate** the child list in parent bodies — the sub-issue tree API owns hierarchy
+
+---
+
+## Parallelism model
+
+Sibling refinements are independent: siblings only need the parent's contract, not each other's
+output. The wall-clock complexity is O(depth), not O(nodes).
+
+```text
+Phase A:  [root]                            serial (1 step)
+Phase B:  [child1 || child2 || child3]      parallel per level (1 step per level)
+          [gc1a || gc1b || gc2a || gc3a]    parallel per level (1 step per level)
+Phase C:  [child1 || child2 || child3]      parallel per level (1 step per level)
+Phase D:  [root]                            serial (1 step)
+```
+
+Total serial steps for a tree with depth D: `1 + (D-1) + (D-1) + 1 = 2D`
+
+**Fan-out rule:** At any level, when a parent is refined, ALL its children can be refined in parallel.
+
+**Serial gates:**
+- Root refinement must complete before any child starts
+- A parent's reconciliation must wait for ALL its children to finish
+- Root reconciliation must wait for all immediate children to reconcile
+
+---
+
+## Completion criteria
+
+The procedure is complete when all issues in the tree satisfy:
+
+| Check | How to verify |
+|---|---|
+| AC checklist present | Issue body contains `## Acceptance Criteria` with at least one `- [ ]` item |
+| DoD checklist present | Issue body contains `## Definition of Done` with at least one `- [ ]` item |
+| AC/DoD matrix present | Issue body contains a two-column table mapping AC items to DoD items |
+| Non-goals present | Issue body contains `## Non-goals` section |
+| Scope boundary present | Issue body contains explicit `"This issue owns ... It does NOT own ..."` text |
+| No orphaned responsibilities | Each thing the parent delegates maps to exactly one child |
+| No duplicate ownership | No two siblings claim the same responsibility |
+| Sub-issue tree order valid | `manage-sub-issues.mjs verify --ordered` exits 0 |
+
+---
+
+## Example traversal for a 3-level tree
+
+For root #715 with children #716, #717, #718 and grandchildren #720–#729:
+
+```
+Phase A: #715 refine
+Phase B level 2 (parallel): #716 refine  ‖  #717 refine  ‖  #718 refine
+Phase B level 3 (parallel): #720 ‖ #721 ‖ #722  (under #716)
+                             #723 ‖ #724         (under #717)
+                             #726 ‖ #729 ‖ #727 ‖ #728  (under #718)
+Phase C level 2 (parallel): #716 reconcile  ‖  #717 reconcile  ‖  #718 reconcile
+Phase D: #715 root reconcile
+```
+
+Wall-clock serial steps: 5 (not 17).
+
+---
+
+## Relationship to other procedures
+
+| Procedure | When to use it |
+|---|---|
+| [Issue Intake Procedure](./issue-intake-procedure.md) Phase 3b | *Creating* a new sub-issue tree from an umbrella issue |
+| **This procedure** | *Refining* an existing sub-issue tree to align scope, AC, DoD, and delegation contracts |
+| [Sub-Issue Tree Contract](../../docs/sub-issue-tree-contract.md) | Tooling for listing, attaching, ordering, and verifying sub-issue trees |
+
+These are complementary. Phase 3b creates the structure; this procedure aligns the contracts.

--- a/.claude/skills/docs/issue-intake-procedure.md
+++ b/.claude/skills/docs/issue-intake-procedure.md
@@ -1,0 +1,235 @@
+# Issue intake procedure
+
+This document is the canonical owner of the routed `issue_intake` procedure behind the public `dev-loop` façade.
+
+Use it together with:
+- [Copilot PR Follow-up Skill](../copilot-pr-followup/SKILL.md)
+- [Public Dev Loop Contract](./public-dev-loop-contract.md)
+- [Retrospective Checkpoint Contract](./retrospective-checkpoint-contract.md) when the current step depends on async start/resume/status or retrospective enforcement
+
+When routed work is issue-first rather than already in active PR follow-up, use the procedure below before entering the shared post-PR loop. Treat this document as the issue-refinement specialist procedure for the routed `issue_intake` seam.
+
+## New-idea safety layer (default contract in this repo)
+
+For **all new ideas** that are not already anchored to an existing issue (including abstract ideas such as plain-language requests without an issue number or plan-doc path), apply this procedure-owned intake contract before any GitHub mutation:
+
+- procedure owns classification; human operator gates all mutations
+- run classification in fresh context by default
+- run classification asynchronously when practical
+- run async fan-out / fan-in proposal generation by default when practical
+- emit a proposal artifact before any GitHub state-changing mutation, including create/edit/retitle/collapse/link operations
+- default to create-new over overwrite/update when a new tracked artifact is justified
+- do not repurpose/retitle/collapse/overwrite an existing issue unless that exact mutation is explicitly proposed and explicitly approved
+- after approval, run a second async mutation pass (dispatched via the procedure) instead of mutating directly from inherited context
+- verify post-mutation artifact state and record what actually changed
+
+Deterministic intake + mutation-gate state machine:
+
+```text
+idea_received
+  -> fresh_context_started
+  -> fanout_started
+  -> fanin_complete
+  -> artifact_scan_complete
+  -> classified
+  -> proposal_emitted
+  -> awaiting_user_approval
+  -> ready_for_mutation
+  -> mutation_executed
+  -> mutation_verified
+  -> done
+
+stop states:
+- stopped_overlap_needs_decision
+- stopped_low_confidence
+- stopped_explicit_reject
+```
+
+Proposal artifact contract:
+- human-readable Markdown proposal
+- machine-readable JSON snapshot
+- write temporary artifacts under `Proposal` (`tmp/new-idea-intake/<run-id>/proposal.md`) and `tmp/new-idea-intake/<run-id>/proposal.json`
+
+If the Phase 1 preflight verdict is `pause_for_clarification`, stop and ask.
+If the intake state machine stops at `stopped_overlap_needs_decision` or `stopped_low_confidence`, stop and ask.
+If the intake state machine stops at `stopped_explicit_reject`, stop and record that the proposal was rejected; do not mutate GitHub.
+After approval, start a separate async mutation pass (dispatched via the procedure) that consumes the approved proposal and emits a post-mutation verification artifact. Emit a concise post-mutation verification artifact and record what the mutation pass actually changed and verify the resulting issue/artifact state.
+
+## Unattended issue-first execution and automatic re-entry
+
+When the user explicitly authorizes unattended execution for a specific issue/PR scope, continue through the normal loop mutations for that scope without stopping at every intermediate phase boundary.
+
+Under that unattended execution contract:
+- automatically detect the current lifecycle entrypoint from existing GitHub state
+- use the deterministic helper/state-machine surface as the authority for current-state routing and next-step selection
+- if local facts, GitHub facts, and helper/state-machine output do not agree, or the state is materially unclear, contradictory, off-trail, or not cleanly covered, stop and ask for human direction rather than guessing
+- a pre-existing PR is not a stop-by-default condition
+- If a PR already exists, classify the post-assignment seam before follow-up
+- `waiting_for_initial_copilot_implementation`: keep waiting
+- `linked_pr_ready_for_followup`: route to the existing PR follow-up path immediately; resume from that PR
+- when routing leaves bootstrap wait for `linked_pr_ready_for_followup`, do not stop only because local isolation is required; re-enter the same PR follow-up from a safe isolated checkout/worktree
+- When the draft PR appears, classify whether it is still the bootstrap-only Copilot draft before entering normal follow-up
+- if a child async run exits while the deterministic state is still non-terminal (for example `waiting_for_copilot_review`), automatically resume/restart follow-up when continuation is feasible instead of requiring manual operator restart
+- continue unattended until the human approval checkpoint unless a genuine stop condition is reached
+- stop for a human approval decision by default
+- after approval, report `waiting_for_merge_authorization` and stop again unless merge has been explicitly authorized
+- this does **not** imply unattended merge by default
+
+Issue-first shorthand such as `auto dev loop on issue <n>` should preserve this same stop boundary and human approval checkpoint default.
+
+## Phase 1 — Preflight intake
+
+Before any automation, answer these questions:
+1. smallest executable work item
+2. existing issue check
+3. scope clarity
+4. acceptance criteria
+5. verification path
+6. active PR check
+
+Accepted input types:
+- GitHub issue number or URL
+- plan-doc path
+- abstract roadmap idea
+
+Preflight verdicts:
+- `proceed`
+- `proceed_with_assumptions`
+- `pause_for_clarification`
+
+## Phase 2 — Input normalization
+
+### From a GitHub issue number or URL
+
+- if the input is a full GitHub issue URL, parse `<owner/name>` and `<number>`
+- fetch with `gh issue view <number> --repo <owner/name> --json number,title,body,state,labels,assignees,milestone`
+- If the issue is closed, stop for a user decision before proceeding
+- detect an existing linked PR with the deterministic linked-PR helper:
+  `node <resolved-skill-scripts>/github/detect-linked-issue-pr.mjs --repo <resolved-repo> --issue <number>`
+- treat the helper output as authoritative for linked-PR detection/selection
+- do not re-implement linked-event query behavior, pagination, repo filtering, or tie-break logic
+- do not rely only on PR title/body containing a literal issue number
+- treat an open linked PR as the active implementation for this issue
+- once an open linked PR exists, that PR is the only canonical follow-up artifact for the issue; attach follow-up work to it and do not open another PR unless the prior PR was explicitly superseded and reconciled first
+- if a PR already exists, classify bootstrap-wait versus follow-up:
+  `node <resolved-skill-scripts>/loop/detect-initial-copilot-pr-state.mjs --repo <resolved-repo> --issue <number>`
+- `waiting_for_initial_copilot_implementation`: keep waiting; in durable-auto mode use:
+  ```sh
+  node <resolved-skill-scripts>/loop/watch-initial-copilot-pr.mjs --repo <resolved-repo> --issue <number>
+  ```
+  - must use the dedicated `watch-initial-copilot-pr.mjs` watcher and its default 1-hour watch budget
+  - quiet/no-activity watch observations alone are non-terminal
+  - `ready_for_followup`: linked PR has become substantive; resume from that PR
+  - `timed_out`: observational first; refresh authoritative state
+  - if refreshed state is still `waiting_for_initial_copilot_implementation`, remain attached to the same durable wait seam and continue waiting
+  - if the refreshed state exits this seam, route based on that refreshed state instead of surfacing timeout attention
+  - when the refreshed state is `linked_pr_ready_for_followup`, re-enter normal PR follow-up; if the follow-up handoff carries `conductorRouting.handoffEnvelope.requiresLocalIsolation=true`, perform the expected isolated-checkout/worktree handoff and continue
+  - only surface timeout attention when the seam's durable watch budget is actually exhausted
+  - for explicit inspect/status requests, report the still-waiting state and exit normally
+- carry that resolved repo slug through every later GitHub issue/PR command
+
+### From a plan-doc path
+
+- Resolve the target repository slug for this work item before any GitHub search or mutation
+- default to the current repository slug
+- if the plan-doc reference explicitly points at another GitHub repository, resolve `<resolved-repo>` first
+- search existing issues with:
+  ```sh
+  gh issue list --repo <resolved-repo> --state all --search "<title keywords>"
+  ```
+- If a matching issue exists:
+  - if the matching issue is closed, stop for a user decision before proceeding
+  - if that matching issue turns out to be closed, stop for a user decision
+  - if a PR already exists, classify bootstrap-wait versus follow-up
+- if a governing plan doc or roadmap section actually applies, follow the plan-doc normalization path above
+
+### From an abstract idea
+
+- otherwise search existing issues directly
+- if a matching issue exists, follow the issue-number/URL normalization path
+- resolve `<resolved-repo>` for this work item using the same rule as the plan-doc path
+
+## Phase 3 — Async issue refinement
+
+Before updating or assigning the issue, refine it asynchronously when practical. Keep issue refinement separate from the phase-scoped refiner used by the local implementation workflow. Use the `refiner` agent for this review-only issue-refinement chain, including the consolidation/fan-in step; do not route those comparison/synthesis steps through `dev-loop` + `local_implementation` (the strategy loaded by `skills/local-implementation`).
+
+When issue refinement would benefit from structural/slop discovery and the likely code/doc surface is knowable, run the bounded audit first.
+- write the issue-refinement audit artifact to `tmp/issues/issue-<number>/audit/refinement-audit-summary.json`
+- use the same audit artifact shape as local phase refinement
+- keep the audit bounded to the named files/areas for this issue; do not widen into a full-repo scan
+- pass a concise audit summary into refiner fan-out and fan-in
+- require the issue-refinement write-up to translate audit findings into scope, AC/DoD, risks, and explicit non-goals without silently broadening the issue
+
+## Phase 3b — Epic decomposition with GitHub sub-issue trees
+
+When the work item is an umbrella/epic issue that must be decomposed into bounded child slices,
+use **real GitHub sub-issue trees** as the default durable output — not body checklists, not
+a manual follow-up linking step.
+
+Prefer real sub-issue linkage over parent-body checklists when a work tree is intended.
+A parent issue body should stay lean once the tree exists: keep scope, acceptance criteria, and
+non-goals there, but do **not** duplicate the ordered child list in the body.
+
+Full decomposition flow:
+
+1. refine umbrella issue framing (scope, acceptance criteria, non-goals)
+2. define bounded child slices — each slice must be independently closable
+3. create child issues with `gh issue create --repo <resolved-repo> --assignee @me`
+4. attach each child as a real sub-issue:
+   ```sh
+   node <resolved-skill-scripts>/github/manage-sub-issues.mjs add \
+     --repo <resolved-repo> --issue <parent-number> --child <child-number>
+   ```
+5. set execution order (highest priority first):
+   ```sh
+   node <resolved-skill-scripts>/github/manage-sub-issues.mjs reorder \
+     --repo <resolved-repo> --issue <parent-number> --order <n1,n2,...>
+   ```
+6. verify the resulting tree:
+   ```sh
+   node <resolved-skill-scripts>/github/manage-sub-issues.mjs verify \
+     --repo <resolved-repo> --issue <parent-number> --expected <n1,n2,...> [--ordered]
+   ```
+7. keep the parent issue body lean — sequencing and progress now live in the sub-issue tree
+
+To inspect the current tree at any time:
+```sh
+node <resolved-skill-scripts>/github/manage-sub-issues.mjs list \
+  --repo <resolved-repo> --issue <parent-number>
+```
+
+Do **not** re-implement sub-issue management ad hoc or bypass `manage-sub-issues.mjs`.
+Do **not** maintain a body checklist that duplicates the sub-issue tree.
+
+For the full `manage-sub-issues.mjs` contract, use [Sub-Issue Tree Contract](../../docs/sub-issue-tree-contract.md) when working in the `dev-loops` source repository. That contract is a source-repo reference, not part of the bundled installed skill-doc surface. For installed or normalized skill copies, inspect the target repository docs/source directly instead of assuming a bundled shared-doc copy exists.
+
+When an existing sub-issue tree needs **scope alignment, AC/DoD contracts, and delegation boundary refinement** across all levels (parent → children → grandchildren), use the [Epic Tree Refinement Procedure](./epic-tree-refinement-procedure.md) — it owns the deterministic depth-first, top-down-then-bottom-up refinement protocol.
+
+## Phase 4 — Copilot handoff and bootstrap wait
+
+Before updating the GitHub issue body, show the diff and get explicit confirmation. Then use:
+```sh
+gh issue edit <number> --repo <resolved-repo> --body-file <updated-body-file>
+gh issue edit <number> --repo <resolved-repo> --add-assignee copilot-swe-agent
+```
+Verify assignment with:
+```sh
+gh issue view <number> --repo <resolved-repo> --json assignees
+```
+
+When the linked PR becomes substantive, keep the shared loop scoped to the resolved repo, for example:
+```sh
+node <resolved-skill-scripts>/loop/copilot-pr-handoff.mjs --repo <resolved-repo> --pr <number>
+gh pr edit <pr-number> --repo <resolved-repo> --title "..." --body-file <body-file>
+gh pr ready <pr-number> --repo <resolved-repo>
+gh pr review <pr-number> --repo <resolved-repo> --approve --body "..."
+node <resolved-skill-scripts>/github/detect-checkpoint-evidence.mjs --repo <resolved-repo> --pr <pr-number>
+gh pr merge <pr-number> --repo <resolved-repo> --squash --delete-branch
+```
+
+Bootstrap-wait interpretation remains fail-closed and observational-first:
+- `ready_for_followup`: linked PR has become substantive; resume from that PR
+- `timed_out`: observational first; refresh authoritative state
+- if refreshed state is still `waiting_for_initial_copilot_implementation`, remain attached to the same durable wait seam and continue waiting
+- if refreshed state exits that seam, route based on refreshed state instead of surfacing timeout attention
+

--- a/.claude/skills/docs/main-agent-contract.md
+++ b/.claude/skills/docs/main-agent-contract.md
@@ -1,0 +1,84 @@
+# Main-agent delegation contract
+
+> **Absolute read-only boundary.** The main agent must never mutate files tracked by the repository.
+> All mutations flow through the `dev-loop` async subagent.
+
+## Contract
+
+The main agent is **read-only** for every file tracked by the repository. Every
+write, edit, delete, commit, branch, push, and PR lifecycle operation must flow
+through the `dev-loop` async subagent.
+
+This contract is a hard rule, not a default or guideline. The main agent must
+never rationalize a direct mutation — not because the work is small, not
+because "the user said yes," not because it is running from a worktree.
+
+## Main agent owns (allowed)
+
+- Read, inspect, search any repo file
+- `git worktree list`, `git status`, `git log` (read-only git). `git fetch` is also allowed (updates local refs but does not touch tracked working-tree files).
+- `gh issue view / create / edit / comment / close` (GitHub API, not file mutations)
+- `gh pr view / list` (read-only GitHub API)
+- Write to `/tmp` or other non-repo paths (e.g., issue body drafts)
+- Delegate to the `dev-loop` agent (async, with worktree cwd)
+- Report findings, ask questions, get confirmation
+- `npm test`, `npm run verify` (read-only validation)
+
+## Main agent must NEVER
+
+- `write`, `edit`, or delete any file tracked by the repo
+- `git commit`, `git push`, create branches, create worktrees
+- Run state-changing dev-loops CLI subcommands (`gate`, any state-changing `loop` subcommand, `pr` commands — those belong inside `dev-loop`).
+- Delegate implementation to any agent other than `dev-loop`
+
+## Dev-loop agent (async) owns
+
+- ALL file mutations in the repo (write, edit, delete)
+- ALL git operations (branch, commit, push)
+- ALL PR lifecycle (create, draft, review, merge)
+- Sub-delegation to developer, fixer, review, quality agents
+
+## Boundary examples
+
+| Operation | Verdict |
+|---|---|
+| `gh issue create --title "..." --body "..."` | Allowed — mutates GitHub, not files tracked by the repository |
+| Write to `/tmp/issue-body.md` | Allowed — outside the repo |
+| Write to `packages/core/src/foo.mjs` | **BREACH** — must delegate to `dev-loop` |
+| `git status` | Allowed — read-only |
+| `git commit -m "..."` | **BREACH** — must delegate to `dev-loop` |
+| `subagent dev-loop` | Allowed — correct delegation |
+| `subagent fixer` | Allowed only when called from within `dev-loop`; describe the task as part of the message |
+
+## Dev-loop startup
+
+When a user triggers the dev loop, the main agent must immediately dispatch the
+`dev-loop` async subagent. The subagent owns the startup resolver, route selection,
+and all subsequent implementation steps. The main agent never runs `dev-loops loop startup`
+directly.
+
+## Enforcement posture
+
+- Under **Pi**, this contract is enforced by convention and review.
+- Under **Claude Code**, the **Edit/Write tool** path is enforced **mechanically** by a
+  `PreToolUse` Write/Edit hook (`scripts/claude/hooks/pre-tool-use-write-guard.mjs`, wired in
+  `.claude/settings.json`): a Write/Edit whose target is inside the repo working tree and not
+  gitignored is **denied** when it originates from the main agent, and allowed only inside the
+  `dev-loop` subagent context (detected via the neutral `DEVLOOPS_RUN_ID` run-id contract, or
+  the dev-loop `agent_type` — a generic subagent is not authorized).
+  Strict enforcement is opt-in via `DEVLOOPS_MAIN_AGENT_READONLY=1` (default fail-open) so
+  adopting the harness does not retroactively break a repo's own interactive dev; full run-id
+  propagation into the Claude subagent context completes with the headless/agent wiring.
+- **Scope of mechanical enforcement:** the hook covers the Edit and Write tools. Bash-driven
+  repo mutations the contract also forbids (`git commit`/`git push`/branch creation, in-place
+  edits like `sed -i`, shell redirection `> file` / `tee`) run through the Bash tool and remain
+  **convention-enforced** for now; the only Bash command the gate hook blocks is the ungated
+  `gh pr ready`. Tightening Bash-mutation coverage is possible follow-up.
+- A companion `PreToolUse` Bash hook reproduces the `gh pr ready` draft-gate guard.
+- A `dev-loop` async subagent should still reject delegation attempts that bypass the contract.
+
+## Non-goals
+
+- Pre-commit hooks (out of scope; the boundary is enforced at the Claude tool layer).
+- Changing dev-loop resolver behavior
+- Modifying the subagent API itself

--- a/.claude/skills/docs/merge-preconditions.md
+++ b/.claude/skills/docs/merge-preconditions.md
@@ -1,0 +1,29 @@
+# Merge preconditions
+
+Canonical owner for merge preconditions across all workflow families.
+
+## Required before merge
+
+1. ✅ CI green on current head (or crediblyGreen via `--local-validation-head-sha`)
+2. ✅ Draft gate satisfied (clean verdict)
+3. ✅ Pre-approval gate satisfied (clean verdict, current head)
+4. ✅ All review threads resolved
+5. ✅ Explicit merge authorization from operator
+6. ✅ PR body contains `Closes #N` or `Fixes #N`
+
+## Merge authorization
+
+- Must be explicit for the active issue/PR scope
+- `"Merge authorized if gates green"` is valid explicit authorization
+- Implied approval from prior turns is not sufficient
+
+## Post-merge
+
+- Remove merged worktree: `git worktree remove --force <path> && git worktree prune`
+- Clean up stale branches
+
+## Cross-references
+
+- [Confirmation rules](confirmation-rules.md)
+- [Validation policy](validation-policy.md)
+- [Stop conditions](stop-conditions.md)

--- a/.claude/skills/docs/pr-lifecycle-contract.md
+++ b/.claude/skills/docs/pr-lifecycle-contract.md
@@ -1,0 +1,209 @@
+# PR lifecycle contract
+
+This document defines the deterministic **family-local PR lifecycle contract** for the GitHub/Copilot workflow family in `dev-loops`.
+
+The canonical contract lives in the shipped `skills/docs/` surface because installed skill/runtime consumers reliably own the skills subtree.
+
+It consolidates the lifecycle boundary currently split across:
+- [Copilot Loop State Graph](../../docs/copilot-loop-state-graph.md)
+- [Reviewer Loop State Graph](../../docs/reviewer-loop-state-graph.md)
+- [Gate Review Comment Contract](../../docs/gate-review-comment-contract.md)
+
+## Purpose
+
+This contract freezes the end-to-end lifecycle semantics for one PR as it moves through:
+
+```text
+draft-stage local gate -> draft remediation -> ready-for-review
+-> explicit Copilot request/wait -> Copilot remediation / reply-resolve / re-review
+-> final local pre-approval gate -> human approval / merge waits
+```
+
+This document owns the **family-local lifecycle semantics** only.
+It does not redefine helper transport mechanics, reviewer-loop internals, conductor routing, or merge policy.
+
+## Relationship to adjacent contracts
+
+| Surface | Relationship |
+|---|---|
+| [Copilot Loop State Graph](../../docs/copilot-loop-state-graph.md) | Copilot-family inner-loop state machine consumed by this lifecycle |
+| [Reviewer Loop State Graph](../../docs/reviewer-loop-state-graph.md) | Reviewer-side review production / submission boundary consumed by this lifecycle |
+| [Gate Review Comment Contract](../../docs/gate-review-comment-contract.md) | Visible evidence contract for `draft_gate` and `pre_approval_gate` |
+| [Conductor Routing Contract](../../docs/conductor-routing-contract.md) | Downstream consumer of family-local lifecycle outcomes |
+| issue #29 | Reviewer-loop boundary semantics |
+| issue #34 | Copilot request / re-request / watch helper mechanics |
+| issue #43 | Review-angle policy for the final local pre-approval gate (now config-driven via `gates.preApproval.angles` and `resolveGateAngles`) |
+| issue #61 | Conductor routing and loop-family handoff above this family-local lifecycle |
+| issue #32 | Ownership/idempotency truth for active runs |
+
+## Core rules
+
+- Exactly **one current lifecycle state** must apply at a time.
+- The lifecycle must fail closed when required evidence is missing, stale, ambiguous, or unparsable.
+- Every gate-crossing decision is for the **current PR head SHA**.
+- Draft existence alone is **not** draft-gate readiness.
+- A PR must clear the draft-stage gate for the current head before Copilot review may be requested.
+- Ready -> draft resets the lifecycle back into draft-stage gating.
+- Human approval / merge are explicit external waits, not hidden remediation states.
+
+## Two required local gates
+
+Each gate runs an independent review chain with its own disposition ledger, review angles,
+and exit conditions. The chains are not interchangeable; see [Checkpoint Review Chain Contract](../../docs/gate-review-sub-loop-contract.md).
+
+### 1. `draft_gate`
+
+Applies while the PR is draft.
+
+Purpose:
+- decide whether the current draft head is materially reviewable
+- decide whether the PR stays draft for more remediation or may leave draft
+- when `gates.draft.requireCi=true` (default), require green current-head CI before the draft gate may be entered; when `false`, this draft-only CI prerequisite may be skipped
+
+Boundary note:
+- `draft_gate` governs only the draft -> ready-for-review boundary for the reviewed head
+- a clean verdict requires no findings at any severity in the gate's `blockCleanOnFindingSeverities` (resolved from config via `resolveGateConfig(config, "draft").blockCleanOnFindingSeverities`)
+- every gate pass writes a durable disposition ledger via `write-gate-findings-log.mjs` under `tmp/gate-findings/`
+- visible comment schema/evidence rules stay in [Gate Review Comment Contract](../../docs/gate-review-comment-contract.md)
+- `gates.draft.requireCi=false` does **not** relax `pre_approval_gate`; final approval and merge readiness still require green current-head CI
+
+### 2. `pre_approval_gate`
+
+Applies after Copilot convergence and before final approval / merge claims.
+
+This gate uses review angles resolved from config (`resolveGateAngles(config, "preApproval")`). Originally defined by #43; now config-driven.
+
+Boundary note:
+- `pre_approval_gate` governs only final approval readiness for the reviewed head
+- a clean verdict requires no findings at any severity in the gate's `blockCleanOnFindingSeverities` (resolved from config via `resolveGateConfig(config, "preApproval").blockCleanOnFindingSeverities`)
+- every gate pass writes a durable disposition ledger via `write-gate-findings-log.mjs` under `tmp/gate-findings/`
+- non-draft PRs do not need visible `draft_gate` evidence to enter the post-draft review / `pre_approval_gate` lifecycle; only the draft -> ready transition depends on `draft_gate`
+- visible comment schema/evidence rules stay in [Gate Review Comment Contract](../../docs/gate-review-comment-contract.md)
+
+## Lifecycle states
+
+The family-local lifecycle should be modeled in this vocabulary. These state identifiers are part of the stable contract surface for this lifecycle, even if adjacent helper implementations evolve around them:
+
+| State | Meaning |
+|---|---|
+| `draft_local_review_gate` | draft PR is at the local draft-stage gate boundary |
+| `draft_local_remediation` | draft-stage findings require more local remediation while the PR remains draft |
+| `ready_state_needs_copilot_request` | draft gate is clear for the current head; Copilot request is the next legal step |
+| `waiting_for_copilot_review` | Copilot request/re-review is observably in progress for the current head |
+| `copilot_feedback_remediation` | unresolved Copilot feedback exists; fixes are the next active step |
+| `copilot_reply_resolve_pending` | fixes were applied, but GitHub thread reply/resolve work still remains |
+| `merge_conflict_resolution` | current PR head conflicts with base or local reconcile is in progress; resolve conflicts before any further gate progression |
+| `final_local_preapproval_gate` | current-head post-Copilot convergence is ready for the final local gate |
+| `final_gate_remediation` | Pre-approval gate findings require more remediation after the final gate |
+| `waiting_for_human_pr_approval` | local gates are satisfied; waiting for explicit human approval |
+| `waiting_for_merge` | approval exists; waiting for merge / merge-triggering external action |
+| `terminal_slice_complete` | merged/closed and no further owned step remains |
+| `stopped_needs_user_decision` | blocked/ambiguous state requiring explicit human decision |
+
+## Required transitions
+
+At minimum, the lifecycle must enforce these transitions:
+
+- `draft_local_review_gate` -> `draft_local_remediation`
+  - blocking `draft_gate` findings
+- `draft_local_review_gate` -> `ready_state_needs_copilot_request`
+  - clean current-head `draft_gate` evidence exists
+- `draft_local_review_gate` -> `stopped_needs_user_decision`
+  - human decision required
+- `draft_local_remediation` -> `draft_local_review_gate`
+  - fixes pushed on the draft head
+- `ready_state_needs_copilot_request` -> `waiting_for_copilot_review`
+  - explicit request/confirm succeeded
+- `ready_state_needs_copilot_request` -> `stopped_needs_user_decision`
+  - request unavailable or blocked
+- `waiting_for_copilot_review` -> `copilot_feedback_remediation`
+  - unresolved Copilot feedback exists
+- `copilot_feedback_remediation` -> `copilot_reply_resolve_pending`
+  - fixes applied but reply/resolve still remains
+- `copilot_reply_resolve_pending` -> `ready_state_needs_copilot_request`
+  - reply/resolve complete and another Copilot pass is required
+- any open non-terminal lifecycle slice -> `merge_conflict_resolution`
+  - current-head merge state is conflicted (`DIRTY` / `CONFLICTING`) or local conflict reconciliation is already in progress
+- `merge_conflict_resolution` -> normal lifecycle re-entry state
+  - only after local conflict resolution produces a new head, validation is rerun for the touched conflict slice, and gate state is re-detected for that new head
+- `waiting_for_copilot_review` -> `final_local_preapproval_gate`
+  - the current-head request/re-review cycle has settled cleanly with no unresolved feedback and no further Copilot pass is needed
+- `final_local_preapproval_gate` -> `final_gate_remediation`
+  - pre-approval gate findings require changes
+- `final_local_preapproval_gate` -> `waiting_for_human_pr_approval`
+  - clean current-head `pre_approval_gate` evidence exists
+- `waiting_for_human_pr_approval` -> `waiting_for_merge`
+  - approval arrives
+- `waiting_for_human_pr_approval` -> `draft_local_review_gate`
+  - PR reset to draft
+- `waiting_for_merge` -> `terminal_slice_complete`
+  - merged/closed and the PR lifecycle is complete
+
+### Required negative boundaries
+
+- no Copilot request before clean current-head `draft_gate` evidence
+- no direct skip from fix-applied to Copilot re-request while reply/resolve remains incomplete
+- no reuse of ready-side or gate evidence after ready -> draft
+- a conflicted PR must not be treated as `waiting_for_human_pr_approval`, `waiting_for_merge`, or merge-ready, even if older gate comments and CI were previously green
+- no implicit fallthrough from approval/merge waits into remediation without a triggering event
+
+## Remediation ownership boundary
+
+The lifecycle must keep the next action class explicit:
+- draft-stage local findings route to `draft_local_remediation`
+- unresolved Copilot feedback routes to `copilot_feedback_remediation`
+- fixes applied but unresolved GitHub reply/resolve work remains route to `copilot_reply_resolve_pending`
+- pre-approval gate findings route to `final_gate_remediation`
+- merge conflicts route to `merge_conflict_resolution` and must be reconciled locally on the PR branch before lifecycle re-entry
+- human approval / merge remain explicit external waits
+
+Reviewer-loop reminder:
+- reviewer-loop semantics end at a review result / submission boundary
+- this lifecycle defines what happens after that boundary without absorbing reviewer-loop planning/submission behavior
+
+## Required evidence classes
+
+The lifecycle distinguishes two evidence classes:
+
+1. **observable GitHub state**
+   - PR draft/non-draft/merged/closed state
+   - current head SHA
+   - reviews, review threads, requested reviewers
+   - any current-head validation/check freshness only where an adjacent gate/helper already makes a boundary CI-dependent
+
+2. **visible gate evidence on the PR**
+   - current-head `draft_gate` evidence when draft-gate clearance is required
+   - current-head `pre_approval_gate` evidence when final approval readiness is required
+
+3. **durable disposition ledger**
+   - every gate pass logs findings and dispositions under `tmp/gate-findings/<repo-slug>/pr-<N>/`
+   - the ledger is the durable record of what each gate found and what was decided
+   - the visible PR comment is a summary; the disposition ledger is the complete record
+
+### Precedence rules
+
+- current observable PR/head state beats stale local memory
+- required visible gate evidence beats local-only gate records for crossing a gate boundary
+- incomplete or conflicting evidence yields fail-closed blocked/reconcile behavior, not optimistic progression
+
+## Fail-closed rules
+
+The lifecycle must stop or reconcile rather than advance when:
+- current head SHA cannot be determined
+- required current-head `draft_gate` evidence is missing
+- required current-head `pre_approval_gate` evidence is missing
+- gate evidence exists but gate name, verdict, or reviewed SHA is missing or unparsable
+- evidence exists only for an older head SHA
+- review-thread capture failed or is incomplete, so unresolved feedback cannot safely be treated as zero
+- Copilot request status is failed, unavailable without in-progress evidence, or otherwise ambiguous for the current head
+- a required current-head wait cannot be confirmed settled
+- the current head reports conflicted merge state (`DIRTY` / `CONFLICTING`) or local git conflict markers are present; enter `merge_conflict_resolution` instead of progressing
+- a boundary that is already CI/validation-dependent cannot confirm current-head freshness because the relevant status is pending, none, unknown, or stale
+- a required visible gate comment could not be confirmed posted
+
+In those cases the workflow must not:
+- leave draft
+- request or re-request Copilot review
+- declare final approval readiness
+- silently fall through to a more permissive state
+

--- a/.claude/skills/docs/public-dev-loop-contract.md
+++ b/.claude/skills/docs/public-dev-loop-contract.md
@@ -1,0 +1,497 @@
+# Public dev-loop contract
+
+This document is the canonical authority for the public `dev-loop` entrypoint, its routed semantics, accepted shorthand, and the rule that internal strategy names stay behind that public façade.
+
+This canonical owner lives in the shipped `skills/docs/` surface because installed skill/runtime consumers reliably own the skills subtree. In installed layouts, read the same contract via [Public Dev Loop Contract](../docs/public-dev-loop-contract.md) from the installed skill directory.
+
+Other repo docs may summarize or link this contract, but they should not redefine it.
+
+## Public surface
+
+The single public entrypoint is:
+
+- `dev-loop`
+
+It should be callable from the user-facing workflow surfaces, including:
+
+- `subagent dev-loop`
+- `/skill:dev-loop`
+
+Day-one user-intent forms:
+
+- start dev loop on issue `<n>`
+- continue dev loop on PR `<n>`
+- start issue `<n>` locally
+- start issue `<n>` locally, then continue the loop
+- continue the current dev loop
+- auto dev loop (durable auto ownership over the detected routed loop)
+- auto dev loop on issue `<n>`
+- what state is the dev loop in?
+
+Users should not have to choose `dev-loop` vs internal seam names up front.
+
+## Issue-based shorthand auto trigger contract
+
+This shorthand form is explicitly accepted and resolves to the same bounded public `dev-loop` intent:
+
+- `auto dev loop on issue 112`
+
+Canonical mapping:
+
+| Shorthand phrase | Canonical public intent |
+|---|---|
+| `auto dev loop on issue 112` | `dev-loop --intent auto_continue_current` with authoritative current state targeting issue 112 |
+
+Stop-boundary contract for this shorthand:
+
+1. continue through the normal GitHub/Copilot loop (assignment, PR watch, draft review/fix, Copilot review/fix, and final pre-approval work) unless a genuine stop condition is reached
+2. stop at the final human approval decision by default
+3. after formal approval, stop again in `waiting_for_merge_authorization` unless merge authorization is explicitly granted for the active issue/PR scope
+4. merge only after explicit merge authorization for the active issue/PR scope
+
+## Surfaced-UX deprecation readiness bar
+
+Do not remove surfaced internal loop names until all of the following are true:
+
+1. authoritative routing is explicit and test-backed
+2. fresh-session startup/resume/status can route from the bounded authoritative startup bundle
+3. former name-shaped variation pressure has a bounded `dev-loop` parameter/settings home
+4. surfaced help/discovery/readiness paths already point users to `dev-loop` and supported routed/parameterized forms
+
+Once that bar is met:
+
+- `dev-loop` remains the only intended visible workflow entrypoint in surfaced UX
+- internal seam names are removed from surfaced workflow-choice phrasing
+- any remaining seam use stays explicitly internal/runtime-only
+
+## Workflow-surface taxonomy and guardrails
+
+Use this taxonomy consistently across docs, discovery surfaces, and tests:
+
+| Surface class | Entrypoints | Guardrail |
+|---|---|---|
+| Public workflow entrypoint | `dev-loop` | treat as the default and converging public workflow surface |
+| Internal routed strategy modules | `issue-intake`, `copilot-pr-followup`, `local-implementation`, `final-approval` | keep internal-only behind `dev-loop`; do not expose as executable peer workflow entrypoints |
+| Reusable role agents | `developer`, `docs`, `review`, `fixer`, `quality`, `refiner` | keep framed as reusable building blocks, not peer public workflow entrypoints |
+
+Any remaining specialized Copilot behavior stays internal-only behind `dev-loop`.
+
+Regression tests must fail if this taxonomy drifts in wording or surfaced entrypoint assets.
+
+## Canonical current state
+
+The public router consumes one canonical current state with these top-level dimensions:
+
+| Field | Meaning |
+|---|---|
+| `target` | active artifact: `issue` \| `pr` \| `local_branch` \| `local_phase`; issue targets may include `linkedPr` when an existing PR is authoritative |
+| `ownership` | durable owner or strategy family currently responsible for the artifact: `local` \| `copilot` \| `external_human` \| `reviewer` \| `maintainer` \| `user` |
+| `nextActor` | immediate actor expected to take the next step; it may differ from `ownership` during review, approval, or handoff states |
+| `status` | `active` \| `waiting` \| `blocked` \| `approval_ready` \| `merge_ready` \| `done` |
+| `authorization` | `authorized` \| `needs_confirmation` \| `not_authorized` |
+
+The authoritative first-slice evaluator is:
+
+- `packages/core/src/loop/public-dev-loop-routing.mjs`
+
+Authoritative status-report helper:
+
+- `resolveAuthoritativeDevLoopStatus()` in `packages/core/src/loop/public-dev-loop-routing.mjs`
+
+Authoritative startup/resume bundle helper:
+
+- `resolveAuthoritativeStartupResumeBundle()` in `packages/core/src/loop/public-dev-loop-routing.mjs`
+
+Its tests are:
+
+- `packages/core/test/public-dev-loop-routing.test.mjs`
+
+## Authoritative-state-first status reporting contract
+
+Before answering status/progress/readiness/merge-state/next-step questions, consumers must:
+
+1. resolve the authoritative active artifact identity (issue/PR/branch/phase as applicable)
+   - for issue targets, this includes authoritative issue↔PR linkage resolution (for example via timeline linkage detection such as `scripts/github/detect-linked-issue-pr.mjs`)
+2. resolve artifact state (`open` \| `closed` \| `merged` \| `not_applicable`)
+3. resolve current loop state
+4. resolve the next action from routed canonical state
+
+Prior chat context is only a hint, never state authority.
+
+If authoritative identity/state (including issue↔PR linkage when relevant) cannot be resolved confidently, fail closed to reconcile/unknown instead of guessing.
+For async/durable-auto flows, do not claim that `dev-loop` has started or is running unless a visible Pi-managed async run id has also been resolved.
+
+When the routed next step requires confirmation for a mutation, the status/startup next action should name that concrete pending mutation (for example issue assignment to `copilot-swe-agent`) instead of generic "approval gate" wording.
+
+## Authoritative startup/resume bundle contract
+
+Fresh-session `continue`, `inspect`, and status-style paths should compose one bounded authoritative startup/resume bundle from the existing routing/status contract fields.
+
+An optional public `intent` may be supplied when the caller needs the bundle to preserve `inspect_state` semantics without re-deriving them in a separate layer.
+
+Required authoritative inputs:
+
+- `currentState` (`target`, `ownership`, `nextActor`, `status`, `authorization`)
+- optional `intent`
+  - when present, it must be a valid public `dev-loop` intent
+  - `inspect_state` preserves the bundle's `inspect` route kind and inspect-style next action
+- optional `mode` (`bounded_handoff` \| `durable_auto`)
+  - same bounded variation-mode semantics as `evaluatePublicDevLoopRouting`
+  - `auto_continue_current` always resolves to `durable_auto`
+- `issueLinkageResolution` (`resolved_linked_pr` \| `resolved_no_open_pr` \| `not_applicable`)
+  - required when `currentState.target.kind === issue`
+- `issueReadiness` (`ready` \| `needs_clarification` \| `not_applicable`)
+  - required for Copilot-first issue targets with `issueLinkageResolution=resolved_no_open_pr`
+- `issueAssignmentState` (`unassigned` \| `assigned_to_copilot` \| `not_applicable`)
+  - required for Copilot-first issue targets with `issueLinkageResolution=resolved_no_open_pr`
+- `artifactState` (`open` \| `closed` \| `merged` \| `not_applicable`)
+- explicit resolved `loopState` (`unknown` is not authoritative input)
+- required for async/durable-auto startup or status paths: `asyncRun`
+  - shape: `{ "kind": "pi_managed_run" | "detached_process", "runId": "<visible-run-id>" | null, "processId": 12345 | null, "visible": true|false, "inspectionState"?: "visible" | "hidden" | "stale" | "uninspectable" | "missing" }`
+  - durable-auto success requires `kind=pi_managed_run`, a non-empty visible `runId`, and `visible=true`
+  - when `inspectionState` is provided as `hidden`, `stale`, or `uninspectable`, durable-auto must fail closed with that state surfaced in diagnostics
+  - detached local processes are diagnostic-only evidence and must fail closed instead of being treated as a successful async start
+- when refreshed loop state is `linked_pr_ready_for_followup` for an issue target with a resolved linked PR, startup/resume and status resolution must promote stale bootstrap waiting to the linked PR follow-up path (or fail closed if the linked-PR facts are incomplete/contradictory) instead of preserving the old bootstrap wait route
+- when refreshed loop state is `prior_linked_pr_closed_unmerged` for a Copilot-owned issue target with `issueLinkageResolution=resolved_no_open_pr`, startup/resume and status resolution must fail closed to reconcile instead of treating the issue as a healthy bootstrap wait or fresh issue-intake path
+
+Resolved bundle output shape:
+
+```json
+{
+  "bundleKind": "resolved | needs_reconcile",
+  "activeArtifact": {
+    "kind": "issue | pr | local_branch | local_phase",
+    "issue": 111,
+    "pr": null,
+    "branch": null,
+    "phase": null
+  },
+  "artifactState": "open | closed | merged | not_applicable",
+  "issueLinkageResolution": "resolved_linked_pr | resolved_no_open_pr | not_applicable",
+  "issueAssignmentSeam": "needs_refinement | ready_needs_assignment_confirmation | ready_assign_now | assigned_to_copilot | not_applicable",
+  "canonicalState": {
+    "target": { "kind": "..." },
+    "ownership": "...",
+    "nextActor": "...",
+    "status": "...",
+    "authorization": "..."
+  },
+  "loopState": "...",
+  "routeKind": "route | wait | stop | inspect | needs_reconcile",
+  "selectedGate": "...",
+  "selectedStrategy": "...",
+  "executionMode": "bounded_handoff | durable_auto",
+  "waitSemantics": "default | auto_healthy_wait",
+  "asyncRun": {
+    "kind": "pi_managed_run",
+    "runId": "run-186",
+    "processId": null,
+    "visible": true
+  },
+  "nextAction": "...",
+  "reason": "...",
+  "contractTrace": {
+    "decision": {
+      "selectedGate": "...",
+      "routeKind": "...",
+      "selectedStrategy": "...",
+      "executionMode": "...",
+      "watchRequested": true,
+      "contractClassification": "routed_followup | healthy_wait | terminal | blocked | authorization_gated | reconcile | inspect",
+      "contractJustification": "..."
+    },
+    "waitStrategy": {
+      "waitMode": "persistent_watch | not_applicable",
+      "timeoutPolicyClassification": "... | null",
+      "effectiveTimeoutMs": 3600000,
+      "effectivePollIntervalMs": null
+    },
+    "stopReason": {
+      "classification": "routed_followup | healthy_wait | terminal | blocked | authorization_gated | reconcile | inspect",
+      "terminal": false,
+      "reason": "..."
+    },
+    "stateRefresh": {
+      "boundaryKind": "post_watch_or_probe | startup_resume_refresh | authoritative_status_refresh",
+      "refreshRequired": true,
+      "refreshReason": "..."
+    }
+  }
+}
+```
+
+Dev-mode observability requirement:
+
+- saved artifacts must preserve the `contractTrace` decision, wait strategy, state-refresh boundary, and stop classification so a fresh session can explain why a healthy wait re-attached, stopped, or failed closed without replaying the whole run
+- wait/watch artifacts must record the effective timeout budget in force and whether the seam ran as `persistent_watch` or `one_shot_probe`; when a surface does not own a poll interval directly it may record `effectivePollIntervalMs=null` rather than inventing a value
+
+Fail-closed semantics:
+
+- incomplete/invalid/conflicting startup inputs return:
+  - `bundleKind = needs_reconcile`
+  - `routeKind = needs_reconcile`
+  - `selectedStrategy = none`
+  - `loopState = unknown`
+  - `nextAction` must instruct reconciliation before routing/status answers
+- `executionMode=durable_auto` must fail closed unless a visible Pi-managed async run is already registered
+- a detached watcher/background pid is never acceptable evidence of async `dev-loop` startup success
+- invalid explicit `intent` also fails closed
+- do not introduce additional public degraded states for this slice
+
+Expected answer shape (field names may vary by surface, but semantics must match):
+
+```text
+Active issue: <owner/repo>#<n> (when applicable)
+Active PR: <owner/repo>#<n> (when applicable)
+Artifact state: open|closed|merged|not_applicable
+Loop state: <resolved loop state>
+Async run: <visible Pi-managed run id>|unknown
+Next action: <resolved next action>
+```
+
+## Internal strategy families
+
+The public router currently maps to these deterministic internal strategies:
+
+| Strategy | Used for | Public workflow entrypoint exposure |
+|---|---|---|
+| `local_implementation` | local branch/phase work and explicit local starts | `dev-loop` |
+| `issue_intake` | issue-first normalization/intake before PR follow-up | none (internal-only via `dev-loop` routing; implemented by [Copilot PR Follow-up](../copilot-pr-followup/SKILL.md) + [Copilot Loop Operations](./copilot-loop-operations.md) + [Issue Intake Procedure](./issue-intake-procedure.md)) |
+| `copilot_pr_followup` | Copilot-owned PR follow-up | none (internal-only via `dev-loop` routing) |
+| `external_pr_followup` | external-human contributor PR follow-up | none |
+| `reviewer_fixer` | reviewer/fixer passes on the current PR | none |
+| `wait_watch` | waiting/watch states | `dev-loop` |
+| `final_approval` | approval-ready gate, or merge-ready with explicit merge authorization | none (canonical procedure lives in [Copilot PR Follow-up](../copilot-pr-followup/SKILL.md) + [Copilot Loop Operations](./copilot-loop-operations.md) Human approval checkpoint; [Final Approval](../final-approval/SKILL.md) is a thin redirect) |
+
+`waiting_for_merge_authorization` is part of the gate contract below as a stop gate rather than an internal strategy.
+
+Internal strategy naming is implementation detail; normal orchestration always starts from `dev-loop`.
+
+## Tracker-backed local implementation input-source contract
+
+Tracker-backed local implementation is an input-source addition to the existing `local_implementation` strategy. It does **not** create a new routing mode, strategy family, or public workflow entrypoint.
+
+For tracker-backed local sessions, the tracker issue is canonical. `docs/phases/phase-<n>.md` must not exist for that same session, and local execution must not maintain a second durable phase-doc copy of the same spec.
+
+Deterministic GitHub-backed spec resolution:
+
+1. accept either a full GitHub issue URL or an explicit `<owner/name>` + `<number>` tracker reference
+2. parse that reference into one deterministic repo slug + issue number pair
+3. resolve the issue through the bounded GitHub helper path (`scripts/github/resolve-tracker-local-spec.mjs`) or the equivalent `gh issue view <number> --repo <owner/name> --json number,title,body,url,state` call
+4. treat the returned issue `title`, `body`, `url`, and `state` as the usable local spec bundle
+5. if the tracker reference cannot be resolved into one valid issue payload, fail closed instead of guessing or falling back to a duplicate phase doc
+
+State-sync expectations for this slice:
+
+- local branch state and `tmp/` artifacts remain local execution state
+- durable scope / acceptance / status changes discovered during local execution should sync back to the tracker issue, because the tracker issue remains the canonical spec source for tracker-backed sessions
+- this slice does **not** introduce full bidirectional tracker sync or tracker-provider adapters beyond the bounded GitHub-backed helper path above
+
+Non-duplication rule:
+
+- do not create, read, or update `docs/phases/phase-<n>.md` for the same tracker-backed session
+- if a duplicate local phase doc already exists for the same tracker-backed session, reconcile that conflict explicitly before continuing; do not silently keep two durable spec surfaces alive
+
+## Copilot-first issue-assignment seam (unassigned issues)
+
+For Copilot-first issue flows (`currentState.target.kind=issue`, `ownership=copilot`, and no linked PR), orchestration must resolve this seam from authoritative issue facts before follow-up routing:
+
+1. `issueReadiness=needs_clarification` → ask clarification questions and stop before assignment (`issueAssignmentSeam=needs_refinement`)
+2. `issueReadiness=ready` + `issueAssignmentState=unassigned` + `authorization=needs_confirmation` → ask for explicit assignment confirmation (`issueAssignmentSeam=ready_needs_assignment_confirmation`)
+3. `issueReadiness=ready` + `issueAssignmentState=unassigned` + `authorization=authorized` → assign `copilot-swe-agent` now before PR/bootstrap/watch follow-up (`issueAssignmentSeam=ready_assign_now`)
+4. `issueReadiness=ready` + `issueAssignmentState=assigned_to_copilot` → assignment seam satisfied; proceed to follow-up (`issueAssignmentSeam=assigned_to_copilot`)
+
+Fail closed if those readiness/assignment facts are missing or invalid.
+
+## Authoritative gate contract
+
+Authoritative route selection is a two-step boundary for this slice:
+
+1. resolve one authoritative canonical current state
+2. map that state to one explicit gate, then to the corresponding route/strategy outcome
+
+The shared machine-checkable gate contract is exported from `packages/core/src/loop/public-dev-loop-routing.mjs` as `DEV_LOOP_GATE` and `PUBLIC_DEV_LOOP_GATE_CONTRACT`.
+
+| Gate | Route kind | Strategy | Meaning |
+|---|---|---|---|
+| `stop_blocked_or_not_authorized` | `stop` | none | blocked or not-authorized canonical state stops for a human decision |
+| `stop_done_terminal` | `stop` | none | done canonical state stops as terminal work |
+| `final_approval` | `route` | `final_approval` | approval-ready canonical state routes to the human approval checkpoint; merge-ready routes here only when merge authorization is explicit; requires explicit current-head `pre_approval_gate` checkpoint verdict evidence — CI green + resolved threads + clean rereview are not sufficient substitutes |
+| `waiting_for_merge_authorization` | `stop` | none | merge-ready canonical state without explicit merge authorization stops and waits for explicit merge authorization |
+| `wait_watch` | `wait` | `wait_watch` | waiting canonical state routes to the shared wait/watch strategy |
+| `local_implementation` | `route` | `local_implementation` | local branch or local phase canonical state stays on local implementation |
+| `issue_intake` | `route` | `issue_intake` | issue canonical state without a linked PR routes to issue intake |
+| `external_pr_followup` | `route` | `external_pr_followup` | external-human PR ownership routes to external PR follow-up |
+| `reviewer_fixer` | `route` | `reviewer_fixer` | reviewer-owned or reviewer-next PR state routes to reviewer/fixer |
+| `copilot_pr_followup` | `route` | `copilot_pr_followup` | Copilot-owned PR state routes to Copilot PR follow-up |
+| `fail_closed_reconcile` | `needs_reconcile` | none | ambiguous, conflicting, or unsupported canonical state fails closed to reconcile |
+
+For issue targets, authoritative issue↔PR linkage resolution remains part of state resolution before claiming there is no open linked PR:
+
+- when canonical issue state includes `linkedPr`, route selection first uses that linked PR as the authoritative routable artifact
+- when canonical issue state does **not** include `linkedPr`, status/reporting consumers must still require explicit authoritative linkage resolution before asserting there is no open linked PR
+- when authoritative linkage resolves an already-open linked PR, that PR is the only canonical active artifact for the issue during follow-up; startup/status/follow-up must reuse it and fail closed against opening another PR until the prior state is explicitly reconciled
+
+## Deterministic routing order
+
+First-match-wins routing posture:
+
+1. blocked or not-authorized state -> stop and ask for a human decision
+2. done -> terminal stop
+3. merge-ready + `authorization=needs_confirmation` -> `waiting_for_merge_authorization`
+4. approval-ready with explicit current-head `pre_approval_gate` evidence, or merge-ready + `authorization=authorized` with the same evidence -> `final_approval`
+5. waiting -> `wait_watch`
+6. local branch / local phase -> `local_implementation`
+7. issue target with `linkedPr` -> route as the linked PR with the same ownership/actor state
+8. issue target without `linkedPr` -> `issue_intake`
+9. PR owned by external human -> `external_pr_followup`
+10. PR owned by reviewer or next actor reviewer -> `reviewer_fixer`
+11. PR owned by Copilot -> `copilot_pr_followup`
+12. anything else -> fail closed to `needs_reconcile`
+
+## Conflict reconciliation path (`CONFLICTING` / `DIRTY`)
+
+When an open linked PR reports merge conflict against `main`, treat this as an explicit bounded local-agent reconciliation path, not as a blind merge/update step:
+
+1. keep the route at `needs_reconcile` / `fail_closed_reconcile` until reconciliation is complete
+2. before any conflict edit, retrieve authoritative context at minimum:
+   - latest `origin/main`
+   - current PR head SHA and effective PR diff
+   - issue/PR scope and acceptance criteria
+   - current-head gate evidence and relevant unresolved review feedback
+   - local validation surface for the touched conflict slice
+3. if required authoritative context is missing, stale for the current head, or contradictory, fail closed to reconcile
+4. only when that context is complete for one current head, resolve the conflict locally on the PR branch
+5. after conflict resolution, rerun required local validation, gate checks, and required CI checks for the new head before approval/merge evaluation
+
+## `auto dev loop` durable auto contract
+
+When the public intent is `auto dev loop`, the router must:
+
+1. require canonical current state resolution first
+2. route to the same detected internal strategy as normal state-based routing
+3. mark execution mode as durable auto ownership (`durable_auto`)
+4. keep waiting/watch states in healthy-wait semantics (`auto_healthy_wait`)
+
+In healthy waiting states, quiet watcher observations (for example `timeout` or `idle`) are observational only and must not be surfaced as attention by themselves. Escalation is still expected for true blocked/authorization/reconcile states.
+
+For the Copilot-first bootstrap seam (`waiting_for_initial_copilot_implementation`), durable-auto ownership must route to the dedicated `watch-initial-copilot-pr.mjs` watcher with its default 1-hour watch budget. Quiet/no-activity observations alone do not eject durable ownership while refreshed authoritative state still resolves `waiting_for_initial_copilot_implementation`; inspect/status intents may still summarize that state and exit normally. This seam has a bootstrap-only exception to the general blocked escalation rule: when the linked PR is still bootstrap-only, approval-gated Actions/Copilot runs in `action_required` (GitHub Actions run conclusion, not a lifecycle state term) are treated as non-blocking observational signals (surfacing as concluded session activity) and do not by themselves force stop/escalation.
+When refreshed authoritative bootstrap state instead resolves `prior_linked_pr_closed_unmerged`, that is not a healthy wait seam: the routed outcome must fail closed to reconcile so status/startup answers surface the prior closed-unmerged PR decision rather than implying normal watch continuity.
+
+When that refreshed seam state advances to `linked_pr_ready_for_followup`, durable-auto continuation must re-enter the same linked PR follow-up path. If the follow-up handoff carries `conductorRouting.handoffEnvelope.requiresLocalIsolation=true`, orchestration should continue through an isolated checkout/worktree transition instead of treating that boundary as final completion.
+
+Main conductor orchestration must treat non-terminal follow-up/wait states (for example `waiting_for_copilot_review`) as continuation boundaries rather than clean completion. If an async child exits before the requested stop boundary and continuation is feasible, re-dispatch via the main session driver (the subagent exits on external wait; the main session re-dispatches); otherwise surface the concrete blocker.
+
+## Internal / external model
+
+```mermaid
+flowchart TD
+    U[User intent / public dev-loop entrypoint] --> C[Unified dev-loop conductor]
+    C --> S[Canonical current state]
+    S --> R[Deterministic router]
+
+    R --> L[Local implementation]
+    R --> I[Issue intake / normalization]
+    R --> CP[Copilot PR follow-up]
+    R --> HP[External-human PR follow-up]
+    R --> RF[Reviewer / fixer]
+    R --> W[Wait / watch]
+    R --> A[Human approval checkpoint]
+    R --> M[Wait for merge authorization]
+
+    L --> S
+    I --> S
+    CP --> S
+    HP --> S
+    RF --> S
+    W --> S
+    A --> S
+    M --> S
+```
+
+## Single-entrypoint convergence posture
+
+- `dev-loop` is the only intended public workflow entrypoint.
+- any remaining specialized Copilot behavior is internal-only and non-user-invocable behind the canonical internal route-pack surface (`issue-intake`, `copilot-pr-followup`, `local-implementation`, `final-approval`).
+- Documentation and examples should lead with `dev-loop` and explain routed behavior.
+- Almost all workflow branching should converge into deterministic state-machine/tooling surfaces behind `dev-loop`.
+- User-visible variation should be expressed through the external `dev-loop` API / bounded parameters or settings, not by preserving multiple public workflow names or legacy compatibility seams.
+
+## Bounded variation parameter contract
+
+Supported workflow variations are expressed as `dev-loop` API parameters or settings rather than as new public workflow names.
+Parameters may **steer** `dev-loop`, but must not replace authoritative routing.
+
+### Precedence order (highest → lowest)
+
+1. **Authoritative current state** — primary source of truth for what artifact/state the loop is actually in
+2. **Explicit user intent / API parameters** — may choose among supported variation modes for the same public entrypoint
+3. **Settings / preferences** — provide defaults only when explicit intent/parameters have not decided
+
+Any conflict that would materially change artifact identity, ownership truth, or gate classification **fails closed** rather than being silently resolved by a parameter or preference.
+
+### First-slice allowed parameters
+
+| Parameter | Allowed values | Behavior |
+|---|---|---|
+| `mode` | `bounded_handoff` (default) \| `durable_auto` | Steers execution mode; `durable_auto` uses the same durable-auto execution-mode semantics as `auto_continue_current`, without replacing the selected intent |
+| `watch` | boolean | Explicitly request wait/watch semantics; fails closed for otherwise-successful non-wait routed results, while preserving authoritative `stop` and `needs_reconcile` outcomes |
+| `intent` | any existing public `dev-loop` intent | Disambiguates the supported public intent; maps to existing contract values |
+| `targetPreference` | `prefer_github_first` (default) \| `prefer_local` | Steers routing preference; must not override authoritative linked-PR or active-artifact truth |
+
+The bounded allow-list is exported from `packages/core/src/loop/public-dev-loop-routing.mjs` as `DEV_LOOP_VARIATION_PARAMETER_CONTRACT`.
+
+`issueReadiness` and `issueAssignmentState` are **not** part of that bounded variation-parameter allow-list. They are authoritative issue-state facts used only for the Copilot-first unassigned-issue seam during startup/status/routing resolution.
+
+### Explicit non-parameters for this slice
+
+These must **not** become public variation knobs:
+- arbitrary ownership override for an already-resolved canonical state
+- arbitrary strategy override (e.g. "force copilot-pr-followup")
+- arbitrary gate override (e.g. "skip approval gate")
+- issue↔PR linkage bypass
+- free-form "expert mode" flags that bypass deterministic routing
+
+### Fail-closed rules
+
+The following parameter/state combinations fail closed to `needs_reconcile` instead of silently coercing:
+
+| Conflict | Reason |
+|---|---|
+| `mode=bounded_handoff` + `intent=auto_continue_current` | `auto_continue_current` always requires durable auto execution mode |
+| Unrecognized `mode` value | Value not on the bounded allow-list |
+| Unrecognized `targetPreference` value | Value not on the bounded allow-list |
+| `watch=true` when an otherwise-successful routed result is not wait/watch-eligible | Watch semantics require a routed wait result (`routeKind=wait`), not just `selectedGate=wait_watch`; existing `stop` and `needs_reconcile` outcomes stay authoritative |
+| Non-boolean `watch` value | Value is outside the bounded boolean allow-list and must fail closed |
+| `targetPreference=prefer_local` when authoritative state has a linked PR or active PR artifact | Preference must not override authoritative PR/linked-PR active artifact truth |
+| `mode=durable_auto` without authoritative current state | Durable auto requires authoritative current state to route from |
+
+### Representative translations: name-shaped intent → parameterized `dev-loop` form
+
+| Formerly name-shaped or prose-shaped | Parameterized single-entrypoint form |
+|---|---|
+| "auto dev loop" | `dev-loop --intent continue_current --mode durable_auto` |
+| "run dev loop on PR 88 and stay on it" | `dev-loop --intent continue_on_pr --target pr:88 --watch` |
+| "prefer the local path for issue 42" | `dev-loop --intent start_on_issue --target issue:42 --target-preference prefer_local` |
+| "just inspect current state" | `dev-loop --intent inspect_state` |
+
+These are parameterized uses of `dev-loop`, not new workflow-facing entrypoints.
+
+## Non-goals for this slice
+
+- broad deletion of lower-level helper logic that `dev-loop` still routes to internally
+- flattening actor/ownership differences between local, Copilot, reviewer, maintainer, and external-human paths
+- replacing existing lower-level state machines with prompt-only branching
+- wiring every runtime helper through this façade in one change
+- broad UI work outside the public workflow/API unification
+
+## Example mappings
+
+| User intent | Canonical state / route |
+|---|---|
+| start dev loop on issue `86` with no linked PR | synthesize issue target -> `issue_intake` internal strategy (routed behind `dev-loop`) |
+| start dev loop on issue `86` with linked PR `88` and Copilot ownership | issue target + `linkedPr=88` -> route as PR `88` -> `copilot_pr_followup` internal strategy (routed behind `dev-loop`) |
+| continue dev loop on PR `88` with Copilot ownership | PR target + `ownership=copilot` -> `copilot_pr_followup` internal strategy (routed behind `dev-loop`) |
+| start issue `86` locally, then continue the loop | local phase slice for issue `86` -> `local_implementation`, then resume via public `dev-loop` against the updated state |
+| continue the current dev loop while waiting | same target + `status=waiting` -> `wait_watch` |
+| what state is the dev loop in? | inspect the canonical state and report the routed internal strategy without switching public entrypoints |

--- a/.claude/skills/docs/retrospective-checkpoint-contract.md
+++ b/.claude/skills/docs/retrospective-checkpoint-contract.md
@@ -1,0 +1,159 @@
+# Retrospective checkpoint contract
+
+This document defines the enforcement seam for the post-run behavioral retrospective checkpoint after qualifying async `dev-loop` completions in this repository. Whether a missing checkpoint blocks the next qualifying start/resume is controlled by `.devloops` at repo root `workflow.requireRetrospective`; shipped defaults remain permissive and this repo opts in.
+
+## Relationship to formal dev mode
+
+Formal local dev mode and the required post-run behavioral retrospective are related but distinct:
+
+| Requirement | Scope |
+|---|---|
+| **Formal local dev mode** | Local implementation/self-improvement work; explicitly scoped in [Dev Loop Skill](../dev-loop/SKILL.md) |
+| **Required post-run behavioral retrospective** | Every qualifying async GitHub-first `dev-loop` completion in this repo |
+
+Routed GitHub-first async `dev-loop` runs do **not** need to be in full formal local dev mode. When `workflow.requireRetrospective` is enabled, they **do** require the retrospective checkpoint before the next qualifying start/resume.
+
+## Qualifying completions
+
+A qualifying async `dev-loop` completion is one that:
+- routes through a GitHub-first Copilot-owned strategy gate, and
+- has `routeKind === "route"` (inspect/status-only results do not qualify).
+
+Qualifying gates:
+
+| Gate | Strategy | Description |
+|---|---|---|
+| `copilot_pr_followup` | Copilot PR follow-up | Primary routed GitHub-first async path |
+| `issue_intake` | Issue intake | Copilot-first issue assignment path |
+
+The authoritative classification function is `isQualifyingAsyncCompletion(routingResult)` in `packages/core/src/loop/retrospective-checkpoint.mjs`.
+
+## Checkpoint states
+
+A fresh session can determine the status of the required retrospective by reading `.pi/dev-loop-retrospective-checkpoint.json`:
+
+| File state | Mapped checkpoint state | Meaning |
+|---|---|---|
+| File absent | `RETROSPECTIVE_CHECKPOINT_STATE.NONE` | No qualifying completion has occurred; no requirement |
+| `{ "state": "required" }` | `RETROSPECTIVE_CHECKPOINT_STATE.MISSING` | Qualifying completion detected; retrospective pending |
+| `{ "state": "complete" }` | `RETROSPECTIVE_CHECKPOINT_STATE.COMPLETE` | Retrospective recorded; requirement satisfied |
+| `{ "state": "skipped" }` | `RETROSPECTIVE_CHECKPOINT_STATE.SKIPPED` | Explicitly skipped with reason; requirement satisfied |
+
+## Enforcement gate
+
+The enforcement seam is the pure function `evaluateRetrospectiveGate` in `packages/core/src/loop/retrospective-checkpoint.mjs`. The checkpoint artifact may still exist even when enforcement is disabled; callers must first consult `workflow.requireRetrospective` to decide whether the checkpoint should block the next qualifying routed start/resume or remain advisory-only.
+
+For convenience, the public routing helpers in `packages/core/src/loop/public-dev-loop-routing.mjs` also accept an optional `retrospectiveCheckpointState` input and apply the same gate internally before returning routed start/resume/status results. Callers should only pass that input when `workflow.requireRetrospective` is enabled for the active repo/workflow posture.
+
+### Inputs
+
+```js
+evaluateRetrospectiveGate({
+  checkpointState,  // one of RETROSPECTIVE_CHECKPOINT_STATE
+  proposedRouting,  // result from evaluatePublicDevLoopRouting()
+})
+```
+
+### Outputs
+
+- **Pass-through** (proposed routing returned unchanged) when:
+  - `checkpointState` is `none`, `complete`, or `skipped`
+  - `proposedRouting` is already `stop`, `needs_reconcile`, or `inspect`
+- **Fail-closed** (`needs_reconcile` result) when:
+  - `checkpointState` is `missing`
+  - `checkpointState` is unrecognized
+
+### Caller contract
+
+Callers have two supported integration options:
+
+#### Option A — direct public-routing helper integration (preferred)
+
+1. Read `.pi/dev-loop-retrospective-checkpoint.json` (if it exists).
+2. Map the file contents to a `RETROSPECTIVE_CHECKPOINT_STATE` value.
+3. Pass that value as `retrospectiveCheckpointState` to one of:
+   - `evaluatePublicDevLoopRouting(...)`
+   - `resolveAuthoritativeStartupResumeBundle(...)`
+   - `resolveAuthoritativeDevLoopStatus(...)`
+4. Use the returned result directly. When enforcement is enabled and the checkpoint is missing, these helpers fail closed to `needs_reconcile`.
+
+#### Option B — explicit manual gate composition
+
+1. Read `.pi/dev-loop-retrospective-checkpoint.json` (if it exists).
+2. Map the file contents to a `RETROSPECTIVE_CHECKPOINT_STATE` value.
+3. Call `evaluatePublicDevLoopRouting(...)` to get the proposed routing.
+4. Call `evaluateRetrospectiveGate({ checkpointState, proposedRouting })`.
+5. Use the gate result (not the raw routing result) as the effective routing decision when enforcement is enabled; otherwise keep the raw routing result and treat the checkpoint artifact as advisory context only.
+
+If the gate result is `needs_reconcile`, the caller must not proceed with the proposed routing. The `nextAction` field instructs the operator to complete or explicitly skip the retrospective.
+
+## Merge gate (`requireRetrospectiveGate`)
+
+When `workflow.requireRetrospectiveGate` is enabled in `.devloops` at repo root, merge-ready progression is blocked after `pre_approval_gate` unless the retrospective checkpoint:
+- has `state: "complete"`
+- includes a `behavioralReview` with `mergeApproved: true`, `followedWorkingAgreement` (boolean), `gateQualityAcceptable` (boolean), and `drifts` (array)
+- includes `mergeRecommendation` (non-empty string)
+
+The enforcement function is `evaluateRetrospectiveMergeApproval(checkpoint)` in `packages/core/src/loop/pr-gate-coordination.mjs`, called from `evaluatePrGateCoordination` at each merge-ready boundary.
+
+### Merge gate states
+
+| Retrospective state | Merge gate result |
+|---|---|
+| No checkpoint file | Blocked: `retrospective_gate_pending` |
+| `state: "complete"` with `mergeApproved: true` and valid fields | Allowed: proceeds to `FINAL_APPROVAL_READY` |
+| `state: "complete"` without `mergeApproved: true` | Blocked |
+| Missing required fields (`followedWorkingAgreement`, `gateQualityAcceptable`, `drifts`, `mergeRecommendation`) | Blocked |
+| `state: "skipped"` or `state: "required"` | Blocked |
+
+### Configuration
+
+```yaml
+# .devloops at repo root
+workflow:
+  requireRetrospective: true        # startup/resume gate
+  requireRetrospectiveGate: true    # merge gate after pre_approval_gate
+```
+
+## Durable artifact format
+
+The checkpoint file is written by `.pi/extensions/dev-loop-behavioral-review.ts` when it observes the standard async `dev-loop` completion message. The extension trigger is message-based; qualifying-path policy is enforced by the checkpoint gate and repo contract, not by deep route inspection in the extension itself:
+
+### On observed async dev-loop completion message (written automatically by extension)
+
+```json
+{
+  "state": "required",
+  "triggeredAt": "2026-05-29T16:00:00.000Z"
+}
+```
+
+### After retrospective is done (written by operator or skill)
+
+```json
+{
+  "state": "complete",
+  "completedAt": "2026-05-29T16:30:00.000Z",
+  "notes": "Loop followed working agreement; minor drift on thread resolution."
+}
+```
+
+### Explicit skip with reason
+
+```json
+{
+  "state": "skipped",
+  "skippedAt": "2026-05-29T16:30:00.000Z",
+  "reason": "Trivial documentation-only change; no post-run audit needed."
+}
+```
+
+## Authoritative source locations
+
+| Artifact | Location |
+|---|---|
+| Checkpoint state machine | `packages/core/src/loop/retrospective-checkpoint.mjs` (internal core module; not part of the public package exports surface) |
+| Tests | `packages/core/test/retrospective-checkpoint.test.mjs` |
+| Extension (writes required marker, fires review prompt) | `.pi/extensions/dev-loop-behavioral-review.ts` |
+| Checkpoint file | `.pi/dev-loop-retrospective-checkpoint.json` |
+| AGENTS.md repo contract | [Agent Instructions](../../AGENTS.md) — concise repo contract and working rules |

--- a/.claude/skills/docs/stop-conditions.md
+++ b/.claude/skills/docs/stop-conditions.md
@@ -1,0 +1,29 @@
+# Stop conditions
+
+Canonical owner for agent stop / wait / block conditions across all workflow families.
+
+## Genuine stop conditions
+
+| Condition | Strategy | Behavior |
+|---|---|---|
+| `blocked` lifecycle state | all | Stop for human decision |
+| `done` lifecycle state | all | Terminal stop |
+| `approval_ready` without explicit merge auth | `final_approval` | Stop at approval gate |
+| `merge_ready` without explicit merge auth | all | Stop at `waiting_for_merge_authorization` |
+| Ambiguous / contradictory state | all | Fail closed to `needs_reconcile` |
+| Missing authoritative startup inputs | `dev-loop` | Fail closed |
+
+## Non-stop conditions
+
+| Condition | Strategy | Behavior |
+|---|---|---|
+| `waiting` lifecycle state | `wait_watch` | Healthy wait; re-dispatch from main session |
+| `waiting_for_initial_copilot_implementation` | `issue_intake` | Bootstrap wait with 1h watch budget |
+| `waiting_for_copilot_review` | `copilot_pr_followup` | Continuation boundary, not completion |
+| Quiet watcher observations | `wait_watch` | Observational only, do not surface |
+
+## Cross-references
+
+- [Confirmation rules](confirmation-rules.md)
+- [Merge preconditions](merge-preconditions.md)
+- [Public Dev Loop Contract](public-dev-loop-contract.md)

--- a/.claude/skills/docs/structural-quality.md
+++ b/.claude/skills/docs/structural-quality.md
@@ -1,0 +1,42 @@
+# Structural quality
+
+Canonical owner for structural quality standards across all workflow families.
+
+## Core principles
+
+- **KISS**: Keep implementations simple; prefer thin glue over thick abstraction
+- **SRP**: Single Responsibility Principle — one reason to change per module
+- **YAGNI**: Don't add speculative features, compatibility shims, or unused abstractions
+- **Strict TypeScript**: No `any`, no implicit coercion, explicit return types
+
+## Deep review standards
+
+Apply these during implementation (not just review):
+
+1. **Cohesion**: Related functionality lives together; unrelated functionality is separated
+2. **Coupling**: Minimize dependencies between modules; prefer explicit injection over globals
+3. **Error handling**: All error paths are explicit and tested; no silent failures
+4. **Testability**: Every public function is independently testable; no hidden state
+5. **Naming**: Names describe what, not how; consistent vocabulary across codebase
+
+## Implementation self-check rules
+
+Apply these during implementation (not just at review time):
+
+- **Prefer deletion over addition**: Question every new file, export, layer, and moving part. If it does not earn its keep, remove it.
+- **File size ceiling**: Files over ~1k lines need extraction or an explicit justification kept in a code comment or doc reference.
+- **Logic placement**: Do not bolt conditionals onto unrelated paths; push logic into its own dedicated boundary.
+- **Avoid thin abstractions**: No thin wrappers, re-export-only files, or identity abstractions that add indirection without clarity.
+- **No leaky abstractions**: Do not leak feature-specific logic into shared or general-purpose modules.
+
+## Anti-patterns to avoid
+
+- Over-engineering: adding abstraction layers "just in case"
+- Copy-paste duplication: extracting shared logic too late
+- Magic values: undocumented constants or configuration
+- God modules: single file doing too many unrelated things
+
+## Cross-references
+
+- [Anti-patterns](anti-patterns.md)
+- [Validation policy](validation-policy.md)

--- a/.claude/skills/docs/tracker-first-loop-state.md
+++ b/.claude/skills/docs/tracker-first-loop-state.md
@@ -1,0 +1,281 @@
+# Tracker-First Story-to-PR Contract
+
+This document defines the adapter-agnostic MVP contract for the tracker-first
+story-to-PR workflow in `pi-dev-loops`.
+
+**MVP invariant: one tracker work item → one GitHub PR.**
+
+This document serves dual purpose:
+1. **Story-to-PR contract** — canonical for the PR-level tracker state machine
+2. **Loop state machine doc** — canonical for the tracker-first loop state machine (#449)
+
+Implementation for each:
+
+| Component | File |
+|---|---|
+| PR-level state machine (story-to-PR) | `packages/core/src/loop/tracker-pr-state.mjs` |
+| PR-level CLI detector | `scripts/loop/detect-tracker-pr-state.mjs` |
+| Loop state machine (tracker-first) | `packages/core/src/loop/tracker-first-loop-state.mjs` |
+| Loop state CLI detector | `scripts/loop/detect-tracker-first-loop-state.mjs` |
+| Loop state contract doc | this file |
+| Entrypoint briefing | `skills/docs/entrypoint-strategies.md#tracker-first` |
+
+## 1. Artifact Subset and MVP Invariant
+
+| Artifact | Role in this slice |
+|---|---|
+| One tracker work item (story, task, or bug) | Planning artifact; source of truth for work identity and planning state |
+| One GitHub PR | Execution artifact; source of truth for lifecycle, review, CI, and merge facts |
+| PR review / CI / merge facts | Observable from GitHub; feed reverse-sync decisions |
+| Epic / PRD reference | Optional linked metadata only; no roll-up or automation in this slice |
+| ADR / RFC reference | Optional linked metadata only; no decision-sync in this slice |
+
+**Invariant:** For any single tracker work item in scope, there is at most
+one active GitHub PR at a time. Multi-PR workflows and roll-up automation
+are out of scope for this slice.
+
+## 2. Source-of-Truth Ownership
+
+| Domain | Owner | Examples |
+|---|---|---|
+| Work-item identity and planning hierarchy | Tracker | Item ID, title, description, priority, assignee, epic link |
+| Tracker-native workflow state | Tracker | In-progress, blocked, done/completed, and any tracker-specific sub-states |
+| PR lifecycle facts | GitHub | Draft / ready-for-review, open / merged / closed, branch, head SHA |
+| PR review and CI facts | GitHub | Reviewer assignments, review states, check-run results, merge status |
+| Decision content | ADR / RFC artifacts (when linked) | Architecture decisions and RFCs referenced from PR body |
+| PR projection and reverse-sync logic | `pi-dev-loops` | Title/body/label generation rules, state mapping, sync triggers |
+
+`pi-dev-loops` **does not** become the canonical owner of any business fields.
+It provides projection and sync logic only.
+
+## 3. PR Projection Contract
+
+The following rules define how a tracker work item projects into GitHub PR
+metadata. All rules are deterministic and idempotent: applying them to the
+same inputs always produces the same output, and re-applying them to an
+already-correct PR leaves it unchanged.
+
+### 3.1 Required PR Metadata
+
+| Field | Rule |
+|---|---|
+| PR title | `[{TRACKER_ID}] {tracker item title}` — bracketed tracker identifier followed by the item title verbatim |
+| PR body — Tracker section | Required. Must include the tracker item ID and a direct link to the item. |
+| PR body — Summary section | Required. Brief description of the change implemented in this PR. |
+| PR body — Acceptance Criteria section | Required. Copied or linked from the tracker item's acceptance criteria. |
+| Labels | Required: `tracker:{TRACKER_ID}`. Optional reference labels: `epic:{EPIC_ID}`, `prd:{PRD_ID}` when references are present. |
+| Draft state | PR must start as a draft. It must not be marked ready-for-review until development work is complete. |
+
+### 3.2 Optional Reference Metadata
+
+Optional parent / decision references may appear in the PR body as links only.
+They are read-only metadata in this slice and do not trigger any automation:
+
+| Reference type | Placement | Effect |
+|---|---|---|
+| Epic | PR body — References section | Link only; no roll-up automation |
+| PRD | PR body — References section | Link only; no roll-up automation |
+| ADR | PR body — References section | Link only; no decision sync |
+| RFC | PR body — References section | Link only; no decision sync |
+
+### 3.3 Deterministic Update Rules
+
+1. **On PR create**: Generate title, body, and labels from tracker item fields.
+   Apply draft state.
+2. **On tracker item field change**: Re-apply projection rules to PR title,
+   body, and labels. Leave any sections not covered by projection rules
+   (e.g. reviewer-added review comments) intact.
+3. **Idempotent regeneration**: If the PR already has the correct title, body
+   sections, and labels, no mutation is performed. Projection is a no-op
+   when the current state already matches the target.
+
+### 3.4 PR Body Template
+
+```
+## Summary
+{brief description of the change}
+
+## Acceptance Criteria
+{copied or linked from tracker item}
+
+## Tracker
+- Item: [{TRACKER_ID}]({TRACKER_ITEM_URL})
+
+## References
+<!-- optional; add epic/PRD/ADR/RFC links here as plain links only -->
+```
+
+## 4. Reverse-Sync Contract
+
+The following table defines the canonical reverse-sync contract. Adapter
+implementations map canonical action names to tracker-native field updates.
+
+### 4.1 Canonical State Table
+
+| Lifecycle state | `reverseSyncAction` | Tracker effect |
+|---|---|---|
+| `ready_no_pr` — tracker item exists, no PR exists yet | `none` | No automatic mutation. Tracker-native readiness remains tracker-owned and is outside this snapshot-only helper. |
+| `draft_pr_open` — draft PR created or open | `set_in_progress` | Tracker moves to in-progress (or nearest equivalent) |
+| `pr_reviewable` — PR marked ready for review | `set_reviewable` | Tracker moves to reviewable / in-review (or nearest equivalent) |
+| `pr_merged` — PR merged | `set_done` | Tracker moves to done/completed terminal state |
+| `pr_closed_unmerged` — PR closed without merge | `none` | No automatic terminal transition; human decision required |
+| `no_tracker_item` | `none` | No tracker item to update |
+| `blocked_needs_user_decision` | `none` | Stop and report; no automatic tracker update |
+
+### 4.2 Event Triggers
+
+| PR lifecycle event | Maps to canonical state | Sync trigger |
+|---|---|---|
+| No PR created yet | `ready_no_pr` | No trigger |
+| Draft PR creation succeeds | `draft_pr_open` | Apply `set_in_progress` to tracker |
+| PR converted from draft to ready-for-review | `pr_reviewable` | Apply `set_reviewable` to tracker |
+| PR merged | `pr_merged` | Apply `set_done` to tracker |
+| PR closed without merge | `pr_closed_unmerged` | No automatic sync; report to user |
+
+### 4.3 Adapter Mapping Guidance
+
+Each tracker adapter maps the four canonical action names to its native API:
+
+| Canonical action | Adapter responsibility |
+|---|---|
+| `set_in_progress` | Move item to the adapter's in-progress equivalent (e.g. "In Progress" column, status field, or state transition) |
+| `set_reviewable` | Move item to the adapter's in-review / reviewable equivalent |
+| `set_done` | Move item to the adapter's done/completed terminal state |
+| `none` | No tracker mutation |
+
+## 5. State Machine
+
+The full lifecycle path for this MVP slice is:
+
+```text
+selected/ready (tracker-owned precondition; not encoded directly in this snapshot)
+  -> tracker item exists, no PR   [ready_no_pr]
+  -> draft PR created             [draft_pr_open]   -> tracker: set_in_progress
+  -> PR marked ready for review   [pr_reviewable]   -> tracker: set_reviewable
+  -> PR merged                    [pr_merged]       -> tracker: set_done
+```
+
+Alternate paths:
+
+```text
+PR closed without merge   [pr_closed_unmerged]          -> tracker: no automatic action
+No tracker item, no PR    [no_tracker_item]             -> blocked; report and stop
+Contradictory snapshot    [blocked_needs_user_decision] -> stop and report
+```
+
+### 5.1 State Definitions
+
+| State | Meaning |
+|---|---|
+| `no_tracker_item` | No tracker work item was found; lifecycle cannot proceed |
+| `ready_no_pr` | Tracker item exists and no PR has been created yet. This helper does not infer tracker-native readiness beyond that no-PR fact. |
+| `draft_pr_open` | Draft PR exists; tracker should reflect in-progress |
+| `pr_reviewable` | PR is open and not draft; tracker should reflect reviewable / in-review |
+| `pr_merged` | PR has been merged; tracker should be moved to done/completed |
+| `pr_closed_unmerged` | PR was closed without merge; no automatic tracker transition |
+| `blocked_needs_user_decision` | Unexpected or contradictory state; requires explicit user decision |
+
+### 5.2 Transition Graph
+
+```
+no_tracker_item
+  (no transitions — obtain a valid tracker item first)
+
+ready_no_pr
+  -> draft_pr_open         (create a draft PR with required tracker metadata)
+
+draft_pr_open
+  -> pr_reviewable         (mark the PR as ready for review)
+
+pr_reviewable
+  -> pr_merged             (PR is merged)
+  -> pr_closed_unmerged    (PR is closed without merge)
+  -> draft_pr_open         (convert back to draft if rework is needed)
+
+pr_merged
+  (no transitions — terminal success state)
+
+pr_closed_unmerged
+  -> ready_no_pr           (reopen work; create a new PR)
+  -> blocked_needs_user_decision  (escalate if context is unclear)
+
+blocked_needs_user_decision
+  (no transitions — stop and report; await explicit user authorization)
+```
+
+### 5.3 Snapshot Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `trackerItemExists` | `boolean` | Whether a tracker work item was found |
+| `trackerItemId` | `string \| null` | Opaque tracker item identifier (e.g. `"PROJ-123"`) |
+| `prExists` | `boolean` | Whether a GitHub PR exists for this tracker item |
+| `prNumber` | `number \| null` | PR number if known. Canonical no-PR snapshots should set this to `null`; `prNumber` with `prExists=false` is treated as contradictory and blocked. |
+| `prDraft` | `boolean` | Whether the PR is in draft state |
+| `prMerged` | `boolean` | Whether the PR has been merged |
+| `prClosed` | `boolean` | Whether the PR is closed on GitHub. Merged PRs are also closed, so `pr_closed_unmerged` is derived from `prClosed && !prMerged`. |
+
+Unlike the Copilot/reviewer loop snapshots, this tracker contract uses `prClosed` for the raw GitHub closed state. Merged PRs therefore set both `prMerged=true` and `prClosed=true`, while `pr_closed_unmerged` remains the derived terminal state for `prClosed && !prMerged`.
+
+This snapshot intentionally omits tracker-native workflow fields such as selected/ready, blocked, or done. Higher-level callers must combine tracker-owned readiness/state separately when deciding whether opening a PR is appropriate.
+
+## 6. Scope Boundaries
+
+This contract is intentionally narrower than the parent epics:
+
+| Boundary | In scope (this slice) | Out of scope (deferred) |
+|---|---|---|
+| Tracker adapters | Adapter-agnostic contract only | Jira adapter, Shortcut adapter, any specific adapter |
+| Artifact model | One tracker item + one PR | Multi-PR, roll-up, cross-artifact sync |
+| Epic / PRD | Metadata reference links only | Automated roll-up or field sync |
+| ADR / RFC | Metadata reference links only | Decision synchronization |
+| Reverse sync | Four canonical states above | Tracker comment mirroring, full bidirectional field sync |
+| Parent epics | Consistent with #17 and #19 | Does not re-own the umbrella artifact model |
+
+## 7. Related
+
+- Parent workflow-family epic: [mfittko/pi-dev-loops#17](https://github.com/mfittko/pi-dev-loops/issues/17)
+- Umbrella artifact model epic: [mfittko/pi-dev-loops#19](https://github.com/mfittko/pi-dev-loops/issues/19)
+- This contract (first implementable slice): [mfittko/pi-dev-loops#21](https://github.com/mfittko/pi-dev-loops/issues/21)
+- Copilot loop state graph: [Copilot Loop State Graph](../../docs/copilot-loop-state-graph.md)
+- Reviewer loop state graph: [Reviewer Loop State Graph](../../docs/reviewer-loop-state-graph.md)
+
+---
+
+## State machine integration
+
+This document is also the canonical state-graph doc for the tracker-first loop state machine.
+
+### Loop state machine (distinct from PR-level machine above)
+
+Implementation:
+- `packages/core/src/loop/tracker-first-loop-state.mjs` — pure logic layer (`interpretTrackerLoopState`)
+- `scripts/loop/detect-tracker-first-loop-state.mjs` — CLI wrapper (same interface as `detect-copilot-loop-state.mjs`)
+
+**Loop state vocabulary:** `drafting`, `needs_triage`, `in_progress`, `in_review`, `merge_ready`, `blocked`, `completed`, `unknown`
+
+**Loop interface contract:** `{ ok, state, snapshot, allowedTransitions, nextAction }`
+
+**Loop snapshot fields:**
+| Field | Type | Description |
+|---|---|---|
+| `trackerState` | `string` | Canonical loop state |
+| `rawTrackerState` | `string` | Raw input state string |
+| `prLinked` | `boolean` | Whether a linked PR was found |
+| `prContext` | `object \| null` | Linked PR context (number, state, headRefName) |
+
+**Loop nextAction mapping:**
+| State | nextAction |
+|---|---|
+| `drafting` | `triage_or_block` |
+| `needs_triage` | `start_work` |
+| `in_progress` | `review` |
+| `in_review` | `merge_or_fix` |
+| `merge_ready` | `merge` |
+| `blocked` | `resolve_blocker` |
+| `completed` | `done` |
+| `unknown` | `reconcile` |
+
+**Fail-closed contract:** Unrecognized/empty/garbage tracker state → `needs_triage`. Only explicit `"unknown"` → canonical `unknown` state.
+
+**PR-level state machine** (sections 1-5 above) uses a separate vocabulary (`ready_no_pr`, `draft_pr_open`, `pr_reviewable`, `pr_merged`, `pr_closed_unmerged`, `no_tracker_item`, `blocked_needs_user_decision`) with its own snapshot schema and reverse-sync actions.

--- a/.claude/skills/docs/validation-policy.md
+++ b/.claude/skills/docs/validation-policy.md
@@ -1,0 +1,27 @@
+# Validation policy
+
+Canonical owner for validation requirements across all workflow families.
+
+## Default validation
+
+- `npm run verify` is the default repo-level local validation path
+- Must pass before: PR creation, gate entry, merge
+- At minimum: `npm test && npm run test:dev-loop`
+
+## Gate-specific requirements
+
+| Gate | Validation required |
+|---|---|
+| `draft_gate` | CI green on current head (or `--local-validation-head-sha` if CI absent) |
+| `pre_approval_gate` | CI green on current head + resolved review threads + clean re-review |
+
+## Coverage requirements
+
+- ≥90% coverage for lines, statements, functions, and branches on changed files
+- Test-first for all non-trivial logic
+
+## Cross-references
+
+- [Merge preconditions](merge-preconditions.md)
+- [Stop conditions](stop-conditions.md)
+- [Public Dev Loop Contract](public-dev-loop-contract.md)

--- a/.claude/skills/docs/workflow-handoff-contract.md
+++ b/.claude/skills/docs/workflow-handoff-contract.md
@@ -1,0 +1,135 @@
+# Workflow Handoff — Derivation Contract
+
+> **Status:** This document defines the **contract** for the
+> `buildDevLoopHandoffEnvelope()` function in `@dev-loops/core`.
+> Agents should read the envelope as their first artifact and then load
+> only the listed `requiredReads` before executing `nextAction`.
+
+## Authoritative sources
+
+Every field in the handoff envelope is derived from authoritative sources as shown below. No field uses a hard-coded magic string or prose
+template.
+
+| Source | Fields derived |
+|---|---|
+| Resolver output (`resolve-dev-loop-startup.mjs` bundle) | `target`, `nextAction`, `requiredReads`, `executionMode` |
+| Caller options (`repoRoot`, `worktreeCwd`) | `cwd` |
+| Gate state (detectors) + strategy defaults | `currentGate`, `worktreeRequired` |
+| Settings (`.devloops` at repo root + `defaults.yaml`) | `gateConfig`, `stopRules`, `asyncStartMode`, `requireDraftFirst`, `maxCopilotRounds` |
+| Gate state (detectors) | `currentHeadSha`, `ciStatus`, `unresolvedThreadCount`, `copilotRoundCount` |
+
+## Acceptance templates
+
+`acceptance.criteria`, `acceptance.evidence`, `acceptance.maxFinalizationTurns`,
+and `control.*` are derived from a static strategy+gate mapping table:
+
+| Strategy | Gate | criteria | evidence | maxFinalizationTurns | needsAttentionAfterMs |
+|---|---|---|---|---|---|
+| `copilot_pr_followup` | `draft` | AC check, scope, coverage, DoD alignment | commands-run, validation-output, review-findings | 4 | 300000 |
+| `copilot_pr_followup` | `watch` | Copilot activity detection, no stuck watch | commands-run | 2 | 1800000 |
+| `copilot_pr_followup` | `pre-approval` | Full pre-approval gate chain, clean verdict, unresolved threads, CI green | commands-run, validation-output, review-findings, residual-risks | 6 | 300000 |
+| `final_approval` | `default` | Gate evidence, human confirmation, CI green | validation-output, manual-notes | 2 | 300000 |
+| `local_implementation` | `default` | Phase-acceptance criteria, verify green | commands-run, validation-output, changed-files | 6 | 300000 |
+| `issue_intake` | `default` | Contract compliance | commands-run, validation-output | 4 | 300000 |
+| `external_pr_followup` | `default` | Contract compliance | commands-run, validation-output | 4 | 300000 |
+| `reviewer_fixer` | `default` | Contract compliance | commands-run, validation-output | 4 | 300000 |
+| `wait_watch` | `default` | Contract compliance | commands-run, validation-output | 4 | 1800000 |
+
+Unknown strategy+gate combinations throw an explicit error listing known combos.
+
+## Stop rules
+
+Stop rules are derived from `settings.autonomy.stopAt` when present.
+When absent, strategy defaults apply:
+
+| Strategy | Default stop rules |
+|---|---|
+| `copilot_pr_followup` | `["draft-pr", "merge"]` |
+| `issue_intake` | `["merge"]` |
+| `external_pr_followup` | `["merge"]` |
+| `reviewer_fixer` | `["merge"]` |
+| `wait_watch` | `["merge"]` |
+| `final_approval` | `["merge"]` |
+| `local_implementation` | `[]` (auto-continue) |
+
+## Envelope schema
+
+```typescript
+interface HandoffEnvelope {
+  handoffVersion: 1;
+  derivedAt: string; // ISO timestamp
+
+  target: {
+    kind: "issue" | "pr" | "local_branch" | "local_phase";
+    repo: string;
+    issue?: number;
+    pr?: number;
+    linkedPr?: number;
+    branch?: string;
+    phase?: string;
+  };
+
+  currentGate: string;
+  currentHeadSha: string | null;
+  ciStatus: string | null;
+  unresolvedThreadCount: number;
+  copilotRoundCount: number;
+  maxCopilotRounds: number;
+  executionMode: "bounded_handoff" | "durable_auto";
+
+  nextAction: string;
+  requiredReads: string[];
+
+  gateConfig?: {
+    angles: string[];
+    excludeAngles?: string[];
+    blockCleanOnFindingSeverities: string[];
+    requireCi: boolean;
+  };
+
+  stopRules: string[];
+  asyncStartMode: "required" | "allowed";
+  requireDraftFirst: boolean;
+
+  cwd: string | null;
+  worktreeRequired: boolean;
+
+  acceptance: {
+    criteria: Array<{ id: string; must: string; severity: "required" | "recommended" }>;
+    evidence: string[];
+    maxFinalizationTurns: number;
+  };
+
+  control: {
+    needsAttentionAfterMs: number;
+    activeNoticeAfterMs: number;
+  };
+
+  overrides?: {
+    mergeAuthorized?: boolean;
+    preferLocal?: boolean;
+    scopeConstraint?: string;
+    customStopAt?: string;
+  };
+}
+```
+
+## Agent consumption pattern
+
+1. Read the handoff envelope as the first artifact.
+2. Read every path listed in `requiredReads` (in order).
+3. Execute `nextAction`.
+4. Respect `stopRules` — do not proceed past a gated stop point without authorization.
+5. Use `acceptance` to self-validate before declaring completion.
+
+## Backward compatibility
+
+The `acceptance` block maps 1:1 into the existing `subagent()` acceptance
+contract shape. When the envelope is present, no separate prose task
+parameter is required.
+
+## Non-goals
+
+- This contract does not define dispatch mechanics.
+- This contract does not define UI/UX for envelope display.
+- This contract does not modify the `subagent()` API itself.

--- a/scripts/claude/generate-claude-assets.mjs
+++ b/scripts/claude/generate-claude-assets.mjs
@@ -47,7 +47,38 @@ export function collectGeneratedAssets({ repoRoot = process.cwd() } = {}) {
     }
   }
 
+  // Bundle the shared markdown the generated skills reference via relative links so they resolve
+  // inside the .claude/ tree (#816). The skills live at .claude/skills/<name>/, so:
+  //   `../docs/<contract>.md`        → .claude/skills/docs/<contract>.md      (skills/docs/*.md)
+  //   `../dev-loop/templates/<t>.md` → .claude/skills/dev-loop/templates/<t>.md (skills/dev-loop/templates/*.md)
+  // Copied verbatim; the no-drift test keeps them in sync with source. (Repo-root `../../` refs —
+  // PLAN.md/AGENTS.md/docs/phases — point at the *consumer project's* files and are out of scope.)
+  for (const [srcRel, targetRel] of [
+    ["skills/docs", ".claude/skills/docs"],
+    ["skills/dev-loop/templates", ".claude/skills/dev-loop/templates"],
+  ]) {
+    assets.push(...collectBundle(repoRoot, srcRel, targetRel));
+  }
+
   return assets;
+}
+
+/** Recursively collect `*.md` files under a source dir as verbatim {target, content} bundle assets. */
+function collectBundle(repoRoot, srcRel, targetRel) {
+  const out = [];
+  const absDir = path.join(repoRoot, srcRel);
+  if (!fs.existsSync(absDir)) return out;
+  for (const entry of fs.readdirSync(absDir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    if (entry.isDirectory()) {
+      out.push(...collectBundle(repoRoot, `${srcRel}/${entry.name}`, `${targetRel}/${entry.name}`));
+    } else if (entry.name.endsWith(".md")) {
+      out.push({
+        target: `${targetRel}/${entry.name}`,
+        content: fs.readFileSync(path.join(absDir, entry.name), "utf8"),
+      });
+    }
+  }
+  return out;
 }
 
 /** Write the generated assets to disk. Returns the list of written targets. */
@@ -60,27 +91,28 @@ export function writeAssets(assets, { repoRoot = process.cwd() } = {}) {
   return assets.map((a) => a.target);
 }
 
-/** List committed generated-asset files currently on disk (repo-relative, posix separators). */
+/** Recursively list committed files under a `.claude/` subtree (repo-relative, sorted). */
+function listFilesRecursive(repoRoot, rel) {
+  const out = [];
+  const abs = path.join(repoRoot, rel);
+  if (!fs.existsSync(abs)) return out;
+  for (const entry of fs.readdirSync(abs, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    if (entry.isDirectory()) out.push(...listFilesRecursive(repoRoot, `${rel}/${entry.name}`));
+    else out.push(`${rel}/${entry.name}`);
+  }
+  return out;
+}
+
+/**
+ * List committed generated-asset files currently on disk (repo-relative, posix separators).
+ * Recurses the whole `.claude/agents` + `.claude/skills` trees so stale orphans — including
+ * bundled docs/templates whose source was removed — are detected, not just SKILL.md files.
+ */
 function listExistingAssetFiles(repoRoot) {
-  const found = [];
-  // Sort directory entries so orphan detection (and --check output) is deterministic
-  // across filesystems/OSes — this backs a byte-stable no-drift contract.
-  const agentsDir = path.join(repoRoot, ".claude", "agents");
-  if (fs.existsSync(agentsDir)) {
-    for (const entry of fs.readdirSync(agentsDir).sort()) {
-      if (entry.endsWith(".md")) found.push(`.claude/agents/${entry}`);
-    }
-  }
-  const skillsDir = path.join(repoRoot, ".claude", "skills");
-  if (fs.existsSync(skillsDir)) {
-    const dirs = fs.readdirSync(skillsDir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
-    for (const entry of dirs) {
-      if (!entry.isDirectory()) continue;
-      const skillFile = path.join(skillsDir, entry.name, "SKILL.md");
-      if (fs.existsSync(skillFile)) found.push(`.claude/skills/${entry.name}/SKILL.md`);
-    }
-  }
-  return found;
+  return [
+    ...listFilesRecursive(repoRoot, ".claude/agents"),
+    ...listFilesRecursive(repoRoot, ".claude/skills"),
+  ];
 }
 
 /**

--- a/test/contracts/claude-assets-reproducible.test.mjs
+++ b/test/contracts/claude-assets-reproducible.test.mjs
@@ -21,9 +21,20 @@ test("shared docs + dev-loop templates are bundled so generated skill links reso
   assert.ok(targets.has(".claude/skills/docs/public-dev-loop-contract.md"), "shared contract doc must be bundled");
   // A representative `../dev-loop/templates/` link target.
   assert.ok(targets.has(".claude/skills/dev-loop/templates/phase-doc.md"), "dev-loop template must be bundled");
-  // Every bundled doc must be byte-identical to its source (verbatim copy).
-  const bundled = assets.find((a) => a.target === ".claude/skills/docs/public-dev-loop-contract.md");
-  assert.equal(bundled.content, fs.readFileSync(path.join(repoRoot, "skills/docs/public-dev-loop-contract.md"), "utf8"));
+
+  // EVERY bundled file must be byte-identical to its source (verbatim copy). Bundled targets map
+  // back to source by dropping the `.claude/skills/` prefix → `skills/<...>`.
+  const bundlePrefixes = [".claude/skills/docs/", ".claude/skills/dev-loop/templates/"];
+  const bundled = assets.filter((a) => bundlePrefixes.some((p) => a.target.startsWith(p)));
+  assert.ok(bundled.length >= 30, `expected the full bundled set, got ${bundled.length}`);
+  for (const asset of bundled) {
+    const source = asset.target.replace(/^\.claude\/skills\//, "skills/");
+    assert.equal(
+      asset.content,
+      fs.readFileSync(path.join(repoRoot, source), "utf8"),
+      `${asset.target} must be a verbatim copy of ${source}`,
+    );
+  }
 });
 
 test("the committed .claude tree is byte-reproducible from the canonical sources (no drift)", () => {

--- a/test/contracts/claude-assets-reproducible.test.mjs
+++ b/test/contracts/claude-assets-reproducible.test.mjs
@@ -12,6 +12,20 @@ import { collectGeneratedAssets, checkAssets, writeAssets } from "../../scripts/
 
 const repoRoot = path.resolve(fileURLToPath(new URL("../../", import.meta.url)));
 
+test("shared docs + dev-loop templates are bundled so generated skill links resolve (#816)", () => {
+  // The generated skills reference `../docs/<contract>.md` and `../dev-loop/templates/<t>.md`;
+  // these resolve only if the shared content is bundled under .claude/skills/.
+  const assets = collectGeneratedAssets({ repoRoot });
+  const targets = new Set(assets.map((a) => a.target));
+  // A representative `../docs/` link target (from .claude/skills/dev-loop/SKILL.md).
+  assert.ok(targets.has(".claude/skills/docs/public-dev-loop-contract.md"), "shared contract doc must be bundled");
+  // A representative `../dev-loop/templates/` link target.
+  assert.ok(targets.has(".claude/skills/dev-loop/templates/phase-doc.md"), "dev-loop template must be bundled");
+  // Every bundled doc must be byte-identical to its source (verbatim copy).
+  const bundled = assets.find((a) => a.target === ".claude/skills/docs/public-dev-loop-contract.md");
+  assert.equal(bundled.content, fs.readFileSync(path.join(repoRoot, "skills/docs/public-dev-loop-contract.md"), "utf8"));
+});
+
 test("the committed .claude tree is byte-reproducible from the canonical sources (no drift)", () => {
   const assets = collectGeneratedAssets({ repoRoot });
   assert.ok(assets.length > 0, "expected to generate at least one asset");

--- a/test/contracts/claude-plugin-manifest.test.mjs
+++ b/test/contracts/claude-plugin-manifest.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { readFile, readdir, access } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -38,14 +39,15 @@ test("the plugin exposes exactly the expected agents + skills (locks the surface
     .sort();
   assert.deepEqual(agents, ["dev-loop", "developer", "docs", "fixer", "quality", "refiner", "review"]);
 
-  const skills = (await readdir(path.join(repoRoot, ".claude", "skills"), { withFileTypes: true }))
-    .filter((d) => d.isDirectory())
-    .map((d) => d.name)
-    .sort();
-  assert.deepEqual(skills, ["copilot-pr-followup", "dev-loop", "final-approval", "local-implementation"]);
-  for (const name of skills) {
-    await access(path.join(repoRoot, ".claude", "skills", name, "SKILL.md"));
+  // A skill is a dir containing SKILL.md. `.claude/skills/` also holds bundled shared content
+  // (e.g. `docs/` from #816) which is NOT a skill — assert the exact set of SKILL-bearing dirs.
+  const skillDirs = (await readdir(path.join(repoRoot, ".claude", "skills"), { withFileTypes: true })).filter((d) => d.isDirectory());
+  const skills = [];
+  for (const d of skillDirs) {
+    if (existsSync(path.join(repoRoot, ".claude", "skills", d.name, "SKILL.md"))) skills.push(d.name);
   }
+  skills.sort();
+  assert.deepEqual(skills, ["copilot-pr-followup", "dev-loop", "final-approval", "local-implementation"]);
 });
 
 test("the publish files allowlist ships the plugin (not the project settings.json) and preserves Pi packaging", async () => {


### PR DESCRIPTION
## Summary

The generated `.claude` skills (#772) reference `../docs/<contract>.md` and
`../dev-loop/templates/<t>.md`; those links only resolve if the shared markdown travels with the
skills. This extends the generator to **bundle** that content into the `.claude/skills/` tree, so
the dev-loop skills are self-contained when loaded as the Claude plugin (#818).

## What changed

- `scripts/claude/generate-claude-assets.mjs` — bundle (verbatim) the shared markdown the skills
  reference:
  - `skills/docs/*.md` → `.claude/skills/docs/*.md` (20 contract docs)
  - `skills/dev-loop/templates/*` → `.claude/skills/dev-loop/templates/*` (13 templates)
  - orphan detection now recurses the whole `.claude/agents` + `.claude/skills` trees, so stale
    bundled files (source removed) are caught by the no-drift contract test.
- Generated tree: 33 new bundled files committed.
- `test/contracts/claude-assets-reproducible.test.mjs` — assert the bundled docs/templates are
  present and byte-identical to source.
- `test/contracts/claude-plugin-manifest.test.mjs` (#818) — the exact-skill-set assertion now
  filters to SKILL-bearing dirs (the bundled `docs/` dir is not a skill); `claude plugin details`
  still reports exactly 4 skills.

## Validation

`npm run verify` green: assets 117, extension 72, scripts 1435, core 1471, dev-loop 32. Verified
`claude --plugin-dir .claude plugin details dev-loops` still loads 4 skills + 7 agents, and the
`../docs/` + `../dev-loop/templates/` link targets now exist in-tree. The no-drift `--check`
returns clean (44 assets).

## Scope boundaries (deliberately out of scope)

- `../../PLAN.md`, `../../AGENTS.md`, `../../docs/phases/*` and similar repo-root refs point at
  the **consumer project's** files (a deliberate "read the project plan" reference) and carry a
  plugin-install-depth caveat — not bundled (they shouldn't be this repo's copies).
- `../dev-loop/scripts/*.mjs` refs need the `@dev-loops/core` package (shipped via npm), not
  duplicated code under `.claude/`.
- Pi-specific body prose in the generated assets → #817.

Closes #816
