### PR TITLE
feat(claude): strip Pi-runtime-only prose from generated assets (#817)

### DIFF
--- a/.claude/agents/dev-loop.md
+++ b/.claude/agents/dev-loop.md
@@ -55,21 +55,12 @@ If local facts, GitHub facts, and helper/state-machine output do not agree well 
 
 ## Subagent delegation
 
-This agent has `tools: [subagent]` and `maxSubagentDepth: 3` to allow orchestrating parallel review, chains, and staged fix passes.
-
 All delegation must originate from the handoff envelope: the envelope's `nextAction`, `requiredReads`, `stopRules`, and `acceptance` define the bounded task. The envelope is passed to child subagents as their primary handoff artifact.
 
 The pi-subagents skill is parent-only, so delegated subagents do not receive orchestration patterns. This section exists as the minimal locally-enforced subset needed for correct delegation — it is not a restatement of the full policy. The `dev-loop` skill owns all procedural rules; this section only declares the invariants the agent must follow when it cannot defer to the skill:
 - One writer thread; `async: true` default; `context: "fresh"` for reviewers.
 - No child subagent spawning beyond assigned fanout work.
 - Bounded tasks with concrete scope, exit conditions, and validation expectations.
-
-**Supervisor communication (known pi runtime bug #671):** The pi runtime `contact_supervisor` tool has a broken response path — supervisor responses do not flow back to resolve the pending subagent tool call. Subagents calling `contact_supervisor` become blocked until the idle timeout fires (~60s), then pause without the decision.
-
-- **Prefer `intercom` when available.** If the `pi-intercom` extension is active, use `intercom({ action: "ask", ... })` instead of `contact_supervisor`. The `intercom` tool uses message-based delivery (no blocking tool-call state) — see the pi documentation for `intercom({ action: "ask", ... })` parameters and reply conventions.
-- **When `intercom` is unavailable,** do not call `contact_supervisor`. Instead, brief the supervisor to include the decision in the resume message when re-dispatching. The subagent states what it needs in the task description; the supervisor provides the answer on resume. This avoids the broken response path entirely.
-- **If `contact_supervisor` was already called** (legacy code or unavoidable): expect a ~60s idle timeout followed by a pause. On resume, the supervisor must inject the decision in the resume message — do not rely on `intercom` on resume when it was unavailable at call time.
-- **Timeout detection (supervisor-side):** if a `contact_supervisor` call has been pending for >30s, the supervisor should treat it as a probable timeout and prepare to inject the decision in the resume message on re-dispatch. The subagent cannot execute this detection while blocked inside `contact_supervisor`; the supervisor must observe the pending duration externally.
 
 ## Output
 

--- a/agents/dev-loop.agent.md
+++ b/agents/dev-loop.agent.md
@@ -59,7 +59,9 @@ If local facts, GitHub facts, and helper/state-machine output do not agree well 
 
 ## Subagent delegation
 
+<!-- pi-only -->
 This agent has `tools: [subagent]` and `maxSubagentDepth: 3` to allow orchestrating parallel review, chains, and staged fix passes.
+<!-- /pi-only -->
 
 All delegation must originate from the handoff envelope: the envelope's `nextAction`, `requiredReads`, `stopRules`, and `acceptance` define the bounded task. The envelope is passed to child subagents as their primary handoff artifact.
 
@@ -68,12 +70,14 @@ The pi-subagents skill is parent-only, so delegated subagents do not receive orc
 - No child subagent spawning beyond assigned fanout work.
 - Bounded tasks with concrete scope, exit conditions, and validation expectations.
 
+<!-- pi-only -->
 **Supervisor communication (known pi runtime bug #671):** The pi runtime `contact_supervisor` tool has a broken response path — supervisor responses do not flow back to resolve the pending subagent tool call. Subagents calling `contact_supervisor` become blocked until the idle timeout fires (~60s), then pause without the decision.
 
 - **Prefer `intercom` when available.** If the `pi-intercom` extension is active, use `intercom({ action: "ask", ... })` instead of `contact_supervisor`. The `intercom` tool uses message-based delivery (no blocking tool-call state) — see the pi documentation for `intercom({ action: "ask", ... })` parameters and reply conventions.
 - **When `intercom` is unavailable,** do not call `contact_supervisor`. Instead, brief the supervisor to include the decision in the resume message when re-dispatching. The subagent states what it needs in the task description; the supervisor provides the answer on resume. This avoids the broken response path entirely.
 - **If `contact_supervisor` was already called** (legacy code or unavoidable): expect a ~60s idle timeout followed by a pause. On resume, the supervisor must inject the decision in the resume message — do not rely on `intercom` on resume when it was unavailable at call time.
 - **Timeout detection (supervisor-side):** if a `contact_supervisor` call has been pending for >30s, the supervisor should treat it as a probable timeout and prepare to inject the decision in the resume message on re-dispatch. The subagent cannot execute this detection while blocked inside `contact_supervisor`; the supervisor must observe the pending duration externally.
+<!-- /pi-only -->
 
 ## Output
 

--- a/packages/core/src/claude/asset-generation.mjs
+++ b/packages/core/src/claude/asset-generation.mjs
@@ -55,7 +55,15 @@ const GENERATED_NOTE = (source) =>
  * @returns {string}
  */
 export function stripPiOnlyBlocks(body) {
-  return String(body)
+  const s = String(body);
+  // True no-op when there are no markers — must NOT touch blank-line runs in marker-free
+  // bodies (they may carry intentional spacing; collapsing them would drift the committed tree).
+  if (!s.includes("<!-- pi-only -->")) {
+    return s;
+  }
+  // Markers must not nest; pairs are matched non-greedily. The trailing `\n{3,}` collapse only
+  // tidies the gap left where a block was removed.
+  return s
     .replace(/[ \t]*<!-- pi-only -->[\s\S]*?<!-- \/pi-only -->[ \t]*\n?/g, "")
     .replace(/\n{3,}/g, "\n\n");
 }

--- a/packages/core/src/claude/asset-generation.mjs
+++ b/packages/core/src/claude/asset-generation.mjs
@@ -7,9 +7,11 @@
  * Pi→Claude tool-name mapping (confirmed against Claude Code docs):
  *   read→Read, search→Grep+Glob, execute→Bash, bash→Bash, edit→Edit, write→Write,
  *   agent→Agent, subagent→Agent, todo→TodoWrite, review_loop→Agent (the review subagent).
- * Only the frontmatter *tool lists* are rewritten; bodies are copied verbatim. Any prose
- * mentions of Pi tool names (e.g. a sentence like "tools: [subagent]") are preserved as-is —
- * neutralizing Pi-specific body prose is harness-neutrality work owned by #774, not this slice.
+ * Frontmatter *tool lists* are rewritten, and bodies are copied through `stripPiOnlyBlocks`
+ * (#817): `<!-- pi-only -->`…`<!-- /pi-only -->` sections are removed for the Claude output so
+ * Pi-runtime-specific prose (e.g. `tools: [subagent]`/`maxSubagentDepth` assertions, the
+ * `contact_supervisor`/`pi-intercom` bug guidance) doesn't contradict the Claude assets. The
+ * source stays Pi-complete; general `subagent` prose is preserved (Claude has subagents too).
  *
  * Frontmatter handling:
  * - Agents keep name/description/tools (comma-separated, per Claude's agent format) and drop
@@ -61,8 +63,10 @@ export function stripPiOnlyBlocks(body) {
   if (!s.includes("<!-- pi-only -->")) {
     return s;
   }
-  // Markers must not nest; pairs are matched non-greedily. The trailing `\n{3,}` collapse only
-  // tidies the gap left where a block was removed.
+  // Markers must not nest; pairs are matched non-greedily. After removing the block(s), collapse
+  // any run of 3+ newlines in this (marker-bearing) body to a single blank line — this tidies the
+  // gaps left by removal; marker-free bodies are returned untouched above, so their intentional
+  // blank runs are never affected.
   return s
     .replace(/[ \t]*<!-- pi-only -->[\s\S]*?<!-- \/pi-only -->[ \t]*\n?/g, "")
     .replace(/\n{3,}/g, "\n\n");

--- a/packages/core/src/claude/asset-generation.mjs
+++ b/packages/core/src/claude/asset-generation.mjs
@@ -42,6 +42,25 @@ const GENERATED_NOTE = (source) =>
   `<!-- GENERATED from ${source} by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate. -->`;
 
 /**
+ * Strip Pi-runtime-only prose blocks from a body for the Claude output (#817).
+ *
+ * The canonical sources stay Pi-complete; sections that are Pi-runtime-specific and misleading
+ * under Claude (e.g. `tools: [subagent]`/`maxSubagentDepth` assertions that contradict the
+ * mapped Claude frontmatter, or the `contact_supervisor`/`pi-intercom` Pi-bug guidance) are
+ * wrapped in the source with `<!-- pi-only -->` … `<!-- /pi-only -->` and removed here. Resulting
+ * blank-line runs are collapsed so the stripped body stays clean. `subagent` prose in general is
+ * NOT stripped — Claude has subagents too.
+ *
+ * @param {string} body
+ * @returns {string}
+ */
+export function stripPiOnlyBlocks(body) {
+  return String(body)
+    .replace(/[ \t]*<!-- pi-only -->[\s\S]*?<!-- \/pi-only -->[ \t]*\n?/g, "")
+    .replace(/\n{3,}/g, "\n\n");
+}
+
+/**
  * Map a single Pi tool name to its Claude tool name(s).
  * @param {string} name
  * @returns {string[]} Claude tool names (empty if unknown).
@@ -104,7 +123,8 @@ function normalizeToolList(value) {
  * @returns {string} Full generated file content.
  */
 export function transformAgent({ source, raw }) {
-  const { frontmatter, body } = splitFrontmatter(raw, source);
+  const { frontmatter, body: rawBody } = splitFrontmatter(raw, source);
+  const body = stripPiOnlyBlocks(rawBody);
   const tools = mapTools(normalizeToolList(frontmatter.tools));
 
   const lines = ["---"];
@@ -127,7 +147,8 @@ export function transformAgent({ source, raw }) {
  * @returns {string} Full generated file content.
  */
 export function transformSkill({ source, raw }) {
-  const { frontmatter, body } = splitFrontmatter(raw, source);
+  const { frontmatter, body: rawBody } = splitFrontmatter(raw, source);
+  const body = stripPiOnlyBlocks(rawBody);
   const tools = mapTools(normalizeToolList(frontmatter["allowed-tools"]));
 
   const lines = ["---"];

--- a/packages/core/test/claude-asset-generation.test.mjs
+++ b/packages/core/test/claude-asset-generation.test.mjs
@@ -45,6 +45,14 @@ test("transformAgent strips pi-only blocks from the body", () => {
   assert.match(out, /Outro\./);
 });
 
+test("transformSkill strips pi-only blocks from the body too", () => {
+  const raw = `---\nname: s\ndescription: d\nallowed-tools: read bash\n---\nKeep this.\n<!-- pi-only -->\ncontact_supervisor guidance here.\n<!-- /pi-only -->\nAnd keep this.\n`;
+  const out = transformSkill({ source: "skills/s/SKILL.md", raw });
+  assert.equal(out.includes("contact_supervisor"), false);
+  assert.match(out, /Keep this\./);
+  assert.match(out, /And keep this\./);
+});
+
 test("mapTool expands search to Grep+Glob and maps subagent/review_loop to Agent", () => {
   assert.deepEqual(mapTool("read"), ["Read"]);
   assert.deepEqual(mapTool("search"), ["Grep", "Glob"]);

--- a/packages/core/test/claude-asset-generation.test.mjs
+++ b/packages/core/test/claude-asset-generation.test.mjs
@@ -6,9 +6,33 @@ import {
   mapTool,
   mapTools,
   splitFrontmatter,
+  stripPiOnlyBlocks,
   transformAgent,
   transformSkill,
 } from "../src/claude/asset-generation.mjs";
+
+test("stripPiOnlyBlocks removes <!-- pi-only --> blocks and collapses blank runs; keeps other prose", () => {
+  const body = "Keep A.\n\n<!-- pi-only -->\nPi-only line about contact_supervisor.\n<!-- /pi-only -->\n\nKeep B.\n";
+  const out = stripPiOnlyBlocks(body);
+  assert.equal(out.includes("contact_supervisor"), false);
+  assert.equal(out.includes("pi-only"), false);
+  assert.match(out, /Keep A\./);
+  assert.match(out, /Keep B\./);
+  assert.equal(out.includes("\n\n\n"), false, "blank-line runs collapsed");
+});
+
+test("stripPiOnlyBlocks is a no-op when there are no markers", () => {
+  const body = "Subagents are fine to mention.\n\nNo markers here.\n";
+  assert.equal(stripPiOnlyBlocks(body), body);
+});
+
+test("transformAgent strips pi-only blocks from the body", () => {
+  const raw = `---\nname: x\ndescription: d\ntools: [read]\n---\nIntro.\n<!-- pi-only -->\nmaxSubagentDepth: 3 lives here.\n<!-- /pi-only -->\nOutro.\n`;
+  const out = transformAgent({ source: "agents/x.agent.md", raw });
+  assert.equal(out.includes("maxSubagentDepth"), false);
+  assert.match(out, /Intro\./);
+  assert.match(out, /Outro\./);
+});
 
 test("mapTool expands search to Grep+Glob and maps subagent/review_loop to Agent", () => {
   assert.deepEqual(mapTool("read"), ["Read"]);

--- a/packages/core/test/claude-asset-generation.test.mjs
+++ b/packages/core/test/claude-asset-generation.test.mjs
@@ -21,9 +21,20 @@ test("stripPiOnlyBlocks removes <!-- pi-only --> blocks and collapses blank runs
   assert.equal(out.includes("\n\n\n"), false, "blank-line runs collapsed");
 });
 
-test("stripPiOnlyBlocks is a no-op when there are no markers", () => {
-  const body = "Subagents are fine to mention.\n\nNo markers here.\n";
+test("stripPiOnlyBlocks is a byte-exact no-op without markers, even with pre-existing blank runs", () => {
+  // Must NOT collapse intentional double-blank runs in marker-free bodies (drift guard).
+  const body = "Para one.\n\n\nPara two (after a double blank).\n\nPara three.\n";
   assert.equal(stripPiOnlyBlocks(body), body);
+});
+
+test("stripPiOnlyBlocks removes multiple blocks non-greedily (no over-strip between them)", () => {
+  const body = "A\n\n<!-- pi-only -->\nfirst\n<!-- /pi-only -->\n\nKEEP MIDDLE\n\n<!-- pi-only -->\nsecond\n<!-- /pi-only -->\n\nB\n";
+  const out = stripPiOnlyBlocks(body);
+  assert.equal(out.includes("first"), false);
+  assert.equal(out.includes("second"), false);
+  assert.match(out, /KEEP MIDDLE/);
+  assert.match(out, /A\n/);
+  assert.match(out, /B\n/);
 });
 
 test("transformAgent strips pi-only blocks from the body", () => {

--- a/test/contracts/claude-assets-reproducible.test.mjs
+++ b/test/contracts/claude-assets-reproducible.test.mjs
@@ -37,6 +37,15 @@ test("shared docs + dev-loop templates are bundled so generated skill links reso
   }
 });
 
+test("Pi-runtime-only prose is stripped from generated assets but retained in source (#817)", () => {
+  const generated = fs.readFileSync(path.join(repoRoot, ".claude/agents/dev-loop.md"), "utf8");
+  const source = fs.readFileSync(path.join(repoRoot, "agents/dev-loop.agent.md"), "utf8");
+  for (const term of ["maxSubagentDepth", "contact_supervisor", "pi-intercom", "<!-- pi-only -->"]) {
+    assert.equal(generated.includes(term), false, `generated dev-loop.md must not contain Pi-runtime prose: ${term}`);
+    assert.ok(source.includes(term), `source dev-loop.agent.md must retain Pi-complete prose: ${term}`);
+  }
+});
+
 test("the committed .claude tree is byte-reproducible from the canonical sources (no drift)", () => {
   const assets = collectGeneratedAssets({ repoRoot });
   assert.ok(assets.length > 0, "expected to generate at least one asset");


### PR DESCRIPTION
## Summary

The generated Claude agent/skill bodies were copied verbatim (#772), so Pi-runtime-specific
prose leaked into the Claude output and **contradicted** it — e.g. `agents/dev-loop.agent.md`
asserted `tools: [subagent]` and `maxSubagentDepth: 3` (the generated Claude frontmatter has
neither) and documented the Pi `contact_supervisor`/`pi-intercom` runtime-bug workaround
(Pi-only, misleading under Claude). This strips those blocks from the Claude output while keeping
the source Pi-complete.

## What changed

- `@dev-loops/core/claude/asset-generation` — new `stripPiOnlyBlocks()` removes
  `<!-- pi-only -->` … `<!-- /pi-only -->` blocks from the body and collapses blank-line runs;
  applied in `transformAgent` + `transformSkill`. General `subagent` prose is **not** stripped —
  Claude has subagents too; only the genuinely Pi-runtime-specific, self-contradictory sections.
- `agents/dev-loop.agent.md` — wrap the `tools`/`maxSubagentDepth` assertion and the
  `contact_supervisor`/`pi-intercom` block in `pi-only` markers. The **source stays Pi-complete**
  (markers are HTML comments invisible to Pi); only the generated Claude copy omits them.
- Regenerated `.claude/agents/dev-loop.md` (Pi-runtime prose removed; the "Subagent delegation"
  section still reads coherently).

## Acceptance criteria (#817)

- [x] Generated `.claude` assets contain no Pi-specific runtime assertions that contradict the
      Claude tool vocabulary (verified: generated `dev-loop.md` has no `maxSubagentDepth` /
      `contact_supervisor` / `pi-intercom` / `tools: [subagent]` / markers; source retains them).

## Validation

`npm run verify` green: assets 118, extension 72, scripts 1435, core 1475, dev-loop 32. Tests:
`stripPiOnlyBlocks` units + `transformAgent` strip; a contract test asserting the generated
agent lacks the Pi-runtime terms while the source retains them. `claude --plugin-dir .claude
plugin details dev-loops` still loads 4 skills + 7 agents.

## Notes

- Approach (b): a generator strip-step (not source neutralization) so the canonical source stays
  Pi-correct — Pi is a first-class harness. Only the two self-contradictory Pi-runtime sections
  in the dev-loop agent are marked; pervasive `subagent` workflow prose is intentionally kept.

Closes #817
