### PR TITLE
chore(release): bump to v0.2.0 — Claude Code dual-harness support

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-loops",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Agent-harness-agnostic dev-loop: agents, skills, and hooks for GitHub/Copilot-driven development loops.",
   "license": "MIT",
   "homepage": "https://github.com/mfittko/dev-loops#readme",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.0
+
+### Added — Claude Code harness (agent-harness-agnostic dev-loop)
+
+dev-loops is now dual-harness: it runs under both Pi and Claude Code. Pi behavior is unchanged.
+
+- **Harness adapter seam** (#770): a neutral `ExtensionHarnessAdapter` (exec + lifecycle +
+  command registration + ui) with Pi and Claude adapters; `@dev-loops/core/harness`.
+- **Neutral run-id contract** (#771): `DEVLOOPS_RUN_ID` (with `PI_SUBAGENT_RUN_ID` as a
+  backward-compatible alias) via `@dev-loops/core/loop/run-context`; all runner-coordination /
+  async-start readers route through it.
+- **Generated `.claude` assets** (#772, #816, #817): a deterministic generator emits
+  `.claude/agents` + `.claude/skills` from the canonical Pi sources (`@dev-loops/core/claude/
+  asset-generation`), with the Pi→Claude tool-name mapping, bundled shared contract docs +
+  templates, and Pi-runtime-only prose stripped via `<!-- pi-only -->` markers.
+- **Claude hooks + read-only enforcement** (#773): PreToolUse Bash draft-gate guard + Write/Edit
+  main-agent read-only guard (`@dev-loops/core/claude/hook-decisions`), opt-in via
+  `DEVLOOPS_MAIN_AGENT_READONLY`.
+- **CLI Pi-neutrality** (#774): `npx dev-loops --help`/`status` run with no `@earendil-works/pi-*`
+  present; Pi-only install strings no longer shown unconditionally.
+- **Headless entry** (#775): a `claude -p` headless dev-loop entry (`@dev-loops/core/claude/
+  headless-entry`) that mints + propagates the run id, plus an offline read-only CI/Docker smoke
+  (`npm run smoke:headless`); the Pi Docker smoke is preserved (dual-harness).
+- **Claude Code plugin** (#818, #824): `.claude/.claude-plugin/plugin.json` (plugin root
+  `.claude/`) bundling the dev-loop agents, skills, and hooks —
+  `claude --plugin-dir .claude` loads 4 skills, 7 agents, 2 hooks.
+
+### Changed
+
+- `@dev-loops/core` bumped to `^0.2.0` (new `claude/*`, `loop/run-context`, and
+  `loop/bash-command-classify` exports).
+
 ## 0.1.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,25 @@ dev-loops is now dual-harness: it runs under both Pi and Claude Code. Pi behavio
 - `@dev-loops/core` bumped to `^0.2.0` (new `claude/*`, `loop/run-context`, and
   `loop/bash-command-classify` exports).
 
+## 0.1.3
+
+### Fixed
+
+- Removed a stale `defaults.yaml` from the `files` allowlist and regenerated the lockfile (#806).
+
+## 0.1.2
+
+### Changed
+
+- Ship the extension-packaged dev-loop defaults only; removed the duplicated
+  `.pi/dev-loop/defaults.yaml` (#805).
+
+## 0.1.1
+
+### Changed
+
+- Renamed the Pi peer dependencies to the `@earendil-works/pi-*` scope (#799).
+
 ## 0.1.0
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "dev-loops",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dev-loops",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
       ],
       "dependencies": {
-        "@dev-loops/core": "^0.1.3",
+        "@dev-loops/core": "^0.2.0",
         "mermaid": "11.15.0",
         "zod": "^4.4.3"
       },
@@ -603,7 +603,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -4473,7 +4473,7 @@
     },
     "packages/core": {
       "name": "@dev-loops/core",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -2,15 +2,17 @@
   "name": "dev-loops",
   "license": "MIT",
   "type": "module",
-  "description": "Shared Pi workflow infrastructure for reusable local and remote development loops",
+  "description": "Agent-harness-agnostic dev-loop infrastructure (Pi and Claude Code) for reusable local and remote development loops",
   "keywords": [
-    "pi-package",
+    "dev-loop",
+    "workflow",
+    "github",
+    "copilot",
+    "claude-code",
+    "claude",
     "pi",
     "pi-coding-agent",
-    "workflow",
-    "dev-loop",
-    "github",
-    "copilot"
+    "pi-package"
   ],
   "engines": {
     "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "mermaid": "11.15.0",
     "zod": "^4.4.3",
-    "@dev-loops/core": "^0.1.3"
+    "@dev-loops/core": "^0.2.0"
   },
   "repository": {
     "type": "git",
@@ -83,7 +83,7 @@
     "url": "https://github.com/mfittko/dev-loops/issues"
   },
   "homepage": "https://github.com/mfittko/dev-loops#readme",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "files": [
     "cli/",
     "lib/",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev-loops/core",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "type": "module",
   "description": "Shared deterministic support package for dev-loop skills, repo-local scripts, and GitHub automation.",
   "exports": {


### PR DESCRIPTION
## Summary

Release **v0.2.0** — Claude Code dual-harness support. Bumps `dev-loops` + `@dev-loops/core` +
the Claude plugin manifest to 0.2.0, and the root→core dependency to `^0.2.0`.

**Why the dep bump matters:** the root package now imports new `@dev-loops/core` exports added
during the harness work (`claude/asset-generation`, `claude/hook-decisions`,
`claude/headless-entry`, `loop/run-context`, `loop/bash-command-classify`). The published core
0.1.3 doesn't have these, so the root must require core `^0.2.0` — otherwise a consumer installing
`dev-loops@0.2.0` would resolve the stale 0.1.x core and break.

## What 0.2.0 ships (see CHANGELOG)

The agent-harness-agnostic dev-loop (#770–#775, #816–#818, #824): Pi + Claude adapter seam, neutral
`DEVLOOPS_RUN_ID`, generated `.claude` agents/skills (tool-mapped, docs/templates bundled, Pi
prose stripped), Claude hooks + read-only enforcement, CLI Pi-neutrality, a headless `claude -p`
entry, and a Claude Code plugin. **Pi behavior is unchanged** (dual-harness).

## Validation

`npm run verify` green: assets 120, extension 72, scripts 1435, core 1476, dev-loop 32. Core + root
`npm pack --dry-run` clean (root ships `.claude/.claude-plugin/`, `.claude/hooks/`, bundled docs).
Plugin manifest version stays in sync with `package.json` (contract test). Pi verified: extension
suite + pi-packaging contract green; the Pi extension entry still registers all four lifecycle
handlers + the `dev-loops` command.

## Release mechanics

On merge, publishing a GitHub release `v0.2.0` triggers `.github/workflows/npm-publish.yml`, which
verifies the commit is on main, runs `npm run verify`, then publishes `@dev-loops/core` and
`dev-loops` (provenance, public).
