### PR TITLE
docs: drop 'preview' from Claude Code plugin section

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ Or run directly without installing:
 npx dev-loops --help
 ```
 
-### Claude Code plugin (preview)
+### Claude Code plugin
 
 The repo ships a Claude Code plugin rooted at `.claude/` (manifest at
-`.claude/.claude-plugin/plugin.json`) exposing the dev-loop agents and skills. Load it for a
-session with:
+`.claude/.claude-plugin/plugin.json`) exposing the dev-loop **agents, skills, and hooks**. Load it
+for a session with:
 
 ```bash
 claude --plugin-dir .claude                              # load it for a session
@@ -58,8 +58,11 @@ claude --plugin-dir .claude plugin details dev-loops     # inspect the discovere
 
 When installed from npm, point at the bundled copy: `claude --plugin-dir node_modules/dev-loops/.claude`.
 
-Preview: hook bundling and shared-doc/Pi-prose neutralization in the generated skills are
-tracked follow-ups (the skills load but some in-body links resolve only inside this repo for now).
+The plugin is self-contained: it bundles the shared contract docs and templates the skills
+reference, and strips Pi-runtime-only prose from the generated assets. The hooks provide the
+`gh pr ready` draft-gate guard and the main-agent read-only boundary (the read-only enforcement
+is opt-in via `DEVLOOPS_MAIN_AGENT_READONLY=1`). Skill references to a project's own `PLAN.md` /
+`AGENTS.md` resolve against the consumer repo, by design.
 
 ### Pi extension
 

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -232,7 +232,7 @@ function orderedCliSetupSteps(checks) {
   return [
     "1. Use `/dev-loop` (Claude Code) or `/skill:dev-loop` (Pi) to start or continue a dev loop — the single public entry.",
     "2. Run `dev-loops status` whenever you want a concise readiness snapshot.",
-    "3. Run via `npx dev-loops` (or `npm install -g dev-loops` for the shell command); see the README for Pi-extension setup (Claude Code plugin packaging is in progress).",
+    "3. Run via `npx dev-loops` (or `npm install -g dev-loops` for the shell command); see the README for Pi-extension and Claude Code plugin setup.",
   ];
 }
 

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -210,7 +210,7 @@ function buildCliHelpLines() {
     "",
     "`/dev-loops hide` remains an extension-only Pi command.",
     "Run via `npx dev-loops` (or `npm install -g dev-loops` for the shell command); see the",
-    "README for Pi-extension setup (Claude Code plugin packaging is in progress).",
+    "README for Pi-extension and Claude Code plugin setup.",
   ];
 }
 


### PR DESCRIPTION
Now that the Claude Code plugin is fully shipped in v0.2.0 — hooks bundled (#824), shared docs/templates bundled (#816), Pi-only prose stripped (#817) — the README's `(preview)` label and "hook bundling … tracked follow-ups" caveat are stale.

## Changes
- README `### Claude Code plugin` section: drop `(preview)`; state the plugin exposes **agents, skills, and hooks** and is self-contained (docs/templates bundled, Pi prose stripped); document the hooks (draft-gate guard + opt-in `DEVLOOPS_MAIN_AGENT_READONLY` read-only boundary); note that `PLAN.md`/`AGENTS.md` refs resolve against the consumer repo by design.
- `cli/index.mjs`: update the two help lines that still said "Claude Code plugin packaging is in progress".

Docs-only + CLI help text. `npm run verify` green (361 links checked; 32 dev-loop tests pass).

This is part of the Claude harness effort and closes out the last stale framing post-v0.2.0.