### PR TITLE
feat(plugin): ship Claude Code marketplace catalog; bump v0.2.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "dev-loops",
+  "owner": {
+    "name": "Manuel Fittko",
+    "email": "manuel.fittko@sofatutor.com"
+  },
+  "description": "Turn GitHub issues into merged PRs: agent-harness-agnostic dev-loop agents, skills, and hooks for Claude Code.",
+  "plugins": [
+    {
+      "name": "dev-loops",
+      "source": "./.claude",
+      "description": "Agent-harness-agnostic dev-loop: agents, skills, and hooks for GitHub/Copilot-driven development loops.",
+      "homepage": "https://github.com/mfittko/dev-loops#readme",
+      "repository": "https://github.com/mfittko/dev-loops.git",
+      "license": "MIT",
+      "keywords": ["dev-loop", "workflow", "github", "copilot", "claude-code", "plugin"]
+    }
+  ]
+}

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,11 @@
 {
   "name": "dev-loops",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Agent-harness-agnostic dev-loop: agents, skills, and hooks for GitHub/Copilot-driven development loops.",
+  "author": {
+    "name": "Manuel Fittko",
+    "email": "manuel.fittko@sofatutor.com"
+  },
   "license": "MIT",
   "homepage": "https://github.com/mfittko/dev-loops#readme",
   "repository": "https://github.com/mfittko/dev-loops.git",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.1
+
+### Added
+
+- **Claude Code marketplace catalog** (#828): ship `.claude-plugin/marketplace.json` at the repo
+  root so the repo can be added as a plugin marketplace (`/plugin marketplace add mfittko/dev-loops`,
+  or the *Manage Plugins → Marketplaces → Add* UI) and the plugin installed with
+  `/plugin install dev-loops@dev-loops`. The catalog's single plugin entry sources the existing
+  in-repo plugin at `./.claude`; the plugin version stays authoritative in `plugin.json`. A
+  contract test locks the catalog shape, and `.claude-plugin/` is added to the npm `files`
+  allowlist. Verified end-to-end with `claude plugin validate` + `marketplace add`/`install`
+  (4 skills, 7 agents, 2 hooks).
+
+### Changed
+
+- `plugin.json` now declares an `author` (clears the marketplace-validation warning).
+- README "Claude Code plugin" section drops the `(preview)` framing and documents marketplace
+  install; the two CLI help lines that said plugin packaging was "in progress" are updated.
+
 ## 0.2.0
 
 ### Added — Claude Code harness (agent-harness-agnostic dev-loop)

--- a/README.md
+++ b/README.md
@@ -45,11 +45,19 @@ Or run directly without installing:
 npx dev-loops --help
 ```
 
-### Claude Code plugin (preview)
+### Claude Code plugin
 
 The repo ships a Claude Code plugin rooted at `.claude/` (manifest at
-`.claude/.claude-plugin/plugin.json`) exposing the dev-loop agents and skills. Load it for a
-session with:
+`.claude/.claude-plugin/plugin.json`) exposing the dev-loop **agents, skills, and hooks**.
+
+Install it from the bundled marketplace catalog (`.claude-plugin/marketplace.json`):
+
+```bash
+/plugin marketplace add mfittko/dev-loops    # register the marketplace
+/plugin install dev-loops@dev-loops          # install the plugin
+```
+
+Or load it directly for a single session without installing:
 
 ```bash
 claude --plugin-dir .claude                              # load it for a session
@@ -58,8 +66,11 @@ claude --plugin-dir .claude plugin details dev-loops     # inspect the discovere
 
 When installed from npm, point at the bundled copy: `claude --plugin-dir node_modules/dev-loops/.claude`.
 
-Preview: hook bundling and shared-doc/Pi-prose neutralization in the generated skills are
-tracked follow-ups (the skills load but some in-body links resolve only inside this repo for now).
+The plugin is self-contained: it bundles the shared contract docs and templates the skills
+reference, and strips Pi-runtime-only prose from the generated assets. The hooks provide the
+`gh pr ready` draft-gate guard and the main-agent read-only boundary (the read-only enforcement
+is opt-in via `DEVLOOPS_MAIN_AGENT_READONLY=1`). Skill references to a project's own `PLAN.md` /
+`AGENTS.md` resolve against the consumer repo, by design.
 
 ### Pi extension
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ npx dev-loops --help
 The repo ships a Claude Code plugin rooted at `.claude/` (manifest at
 `.claude/.claude-plugin/plugin.json`) exposing the dev-loop **agents, skills, and hooks**.
 
-Install it from the bundled marketplace catalog (`.claude-plugin/marketplace.json`):
+Install it from the bundled marketplace catalog (`.claude-plugin/marketplace.json`) by running
+these slash commands inside Claude Code:
 
-```bash
+```text
 /plugin marketplace add mfittko/dev-loops    # register the marketplace
 /plugin install dev-loops@dev-loops          # install the plugin
 ```

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -210,7 +210,7 @@ function buildCliHelpLines() {
     "",
     "`/dev-loops hide` remains an extension-only Pi command.",
     "Run via `npx dev-loops` (or `npm install -g dev-loops` for the shell command); see the",
-    "README for Pi-extension setup (Claude Code plugin packaging is in progress).",
+    "README for Pi-extension and Claude Code plugin setup.",
   ];
 }
 
@@ -232,7 +232,7 @@ function orderedCliSetupSteps(checks) {
   return [
     "1. Use `/dev-loop` (Claude Code) or `/skill:dev-loop` (Pi) to start or continue a dev loop — the single public entry.",
     "2. Run `dev-loops status` whenever you want a concise readiness snapshot.",
-    "3. Run via `npx dev-loops` (or `npm install -g dev-loops` for the shell command); see the README for Pi-extension setup (Claude Code plugin packaging is in progress).",
+    "3. Run via `npx dev-loops` (or `npm install -g dev-loops` for the shell command); see the README for Pi-extension and Claude Code plugin setup.",
   ];
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "dev-loops",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dev-loops",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"
       ],
       "dependencies": {
-        "@dev-loops/core": "^0.2.0",
+        "@dev-loops/core": "^0.2.1",
         "mermaid": "11.15.0",
         "zod": "^4.4.3"
       },
@@ -4473,7 +4473,7 @@
     },
     "packages/core": {
       "name": "@dev-loops/core",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "dependencies": {
     "mermaid": "11.15.0",
     "zod": "^4.4.3",
-    "@dev-loops/core": "^0.2.0"
+    "@dev-loops/core": "^0.2.1"
   },
   "repository": {
     "type": "git",
@@ -85,7 +85,7 @@
     "url": "https://github.com/mfittko/dev-loops/issues"
   },
   "homepage": "https://github.com/mfittko/dev-loops#readme",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "files": [
     "cli/",
     "lib/",
@@ -93,6 +93,7 @@
     "extension/",
     "skills/",
     "agents/",
+    ".claude-plugin/",
     ".claude/.claude-plugin/",
     ".claude/agents/",
     ".claude/skills/",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev-loops/core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "Shared deterministic support package for dev-loop skills, repo-local scripts, and GitHub automation.",
   "exports": {

--- a/test/contracts/claude-plugin-marketplace.test.mjs
+++ b/test/contracts/claude-plugin-marketplace.test.mjs
@@ -38,12 +38,20 @@ test("the plugin entry sources the in-repo plugin at ./.claude", async () => {
 
 test("every relative plugin source is a safe in-repo path (no traversal)", async () => {
   // A real invariant over ALL entries (not coupled to the exact-match above): any
-  // string `source` must be a repo-relative path that does not escape the marketplace root.
+  // string `source` must be a repo-relative path that, once resolved, stays inside the
+  // marketplace root. Resolving (rather than substring-checking for "..") catches traversal
+  // via backslashes, encoded segments, or normalization quirks — not just literal "../".
   const catalog = JSON.parse(await readFile(marketplacePath, "utf8"));
   for (const entry of catalog.plugins) {
     if (typeof entry.source !== "string") continue; // object sources (git/npm) are out of scope here
     assert.ok(entry.source.startsWith("./"), `relative source must start with "./": ${entry.source}`);
-    assert.equal(entry.source.split("/").includes(".."), false, `source must not contain "..": ${entry.source}`);
+    assert.equal(entry.source.includes("\\"), false, `source must not contain backslashes: ${entry.source}`);
+    const resolved = path.resolve(repoRoot, entry.source);
+    const rel = path.relative(repoRoot, resolved);
+    assert.ok(
+      rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel)),
+      `source must resolve to a path inside the repo root: ${entry.source} -> ${resolved}`,
+    );
   }
 });
 

--- a/test/contracts/claude-plugin-marketplace.test.mjs
+++ b/test/contracts/claude-plugin-marketplace.test.mjs
@@ -26,6 +26,7 @@ test("marketplace catalog exists and names the dev-loops marketplace", async () 
 
 test("the plugin entry sources the in-repo plugin at ./.claude", async () => {
   const catalog = JSON.parse(await readFile(marketplacePath, "utf8"));
+  assert.ok(Array.isArray(catalog.plugins) && catalog.plugins.length >= 1, "catalog must list at least one plugin");
   const entry = catalog.plugins[0];
   assert.equal(entry.name, "dev-loops");
   assert.equal(entry.source, "./.claude", "source must point at the plugin dir (the one holding .claude-plugin/)");
@@ -57,6 +58,7 @@ test("every relative plugin source is a safe in-repo path (no traversal)", async
 
 test("the catalog defers versioning to plugin.json (no entry-level version to drift)", async () => {
   const catalog = JSON.parse(await readFile(marketplacePath, "utf8"));
+  assert.ok(Array.isArray(catalog.plugins) && catalog.plugins.length >= 1, "catalog must list at least one plugin");
   const entry = catalog.plugins[0];
   assert.equal(
     "version" in entry,

--- a/test/contracts/claude-plugin-marketplace.test.mjs
+++ b/test/contracts/claude-plugin-marketplace.test.mjs
@@ -29,12 +29,22 @@ test("the plugin entry sources the in-repo plugin at ./.claude", async () => {
   const entry = catalog.plugins[0];
   assert.equal(entry.name, "dev-loops");
   assert.equal(entry.source, "./.claude", "source must point at the plugin dir (the one holding .claude-plugin/)");
-  assert.equal(entry.source.includes(".."), false, "source must not contain path traversal");
   // The source dir must actually contain a plugin manifest.
   assert.ok(
     existsSync(path.join(repoRoot, ".claude", ".claude-plugin", "plugin.json")),
     "source ./.claude must contain .claude-plugin/plugin.json",
   );
+});
+
+test("every relative plugin source is a safe in-repo path (no traversal)", async () => {
+  // A real invariant over ALL entries (not coupled to the exact-match above): any
+  // string `source` must be a repo-relative path that does not escape the marketplace root.
+  const catalog = JSON.parse(await readFile(marketplacePath, "utf8"));
+  for (const entry of catalog.plugins) {
+    if (typeof entry.source !== "string") continue; // object sources (git/npm) are out of scope here
+    assert.ok(entry.source.startsWith("./"), `relative source must start with "./": ${entry.source}`);
+    assert.equal(entry.source.split("/").includes(".."), false, `source must not contain "..": ${entry.source}`);
+  }
 });
 
 test("the catalog defers versioning to plugin.json (no entry-level version to drift)", async () => {

--- a/test/contracts/claude-plugin-marketplace.test.mjs
+++ b/test/contracts/claude-plugin-marketplace.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// #828: the repo ships a Claude Code marketplace CATALOG at the repo root
+// (`.claude-plugin/marketplace.json`) — distinct from the plugin MANIFEST at
+// `.claude/.claude-plugin/plugin.json`. The catalog is what `/plugin marketplace add
+// mfittko/dev-loops` reads; its single plugin entry sources the in-repo plugin at `./.claude`.
+// Verified end-to-end with `claude plugin validate` + `marketplace add`/`install`.
+
+const repoRoot = path.resolve(fileURLToPath(new URL("../../", import.meta.url)));
+const marketplacePath = path.join(repoRoot, ".claude-plugin", "marketplace.json");
+
+test("marketplace catalog exists and names the dev-loops marketplace", async () => {
+  const catalog = JSON.parse(await readFile(marketplacePath, "utf8"));
+  assert.equal(catalog.name, "dev-loops");
+  assert.ok(
+    catalog.owner && typeof catalog.owner === "object" && typeof catalog.owner.name === "string",
+    "owner must be an object with a name (not a string) per the marketplace schema",
+  );
+  assert.ok(Array.isArray(catalog.plugins) && catalog.plugins.length === 1, "exactly one plugin entry");
+});
+
+test("the plugin entry sources the in-repo plugin at ./.claude", async () => {
+  const catalog = JSON.parse(await readFile(marketplacePath, "utf8"));
+  const entry = catalog.plugins[0];
+  assert.equal(entry.name, "dev-loops");
+  assert.equal(entry.source, "./.claude", "source must point at the plugin dir (the one holding .claude-plugin/)");
+  assert.equal(entry.source.includes(".."), false, "source must not contain path traversal");
+  // The source dir must actually contain a plugin manifest.
+  assert.ok(
+    existsSync(path.join(repoRoot, ".claude", ".claude-plugin", "plugin.json")),
+    "source ./.claude must contain .claude-plugin/plugin.json",
+  );
+});
+
+test("the catalog defers versioning to plugin.json (no entry-level version to drift)", async () => {
+  const catalog = JSON.parse(await readFile(marketplacePath, "utf8"));
+  const entry = catalog.plugins[0];
+  assert.equal(
+    "version" in entry,
+    false,
+    "do not pin a version in the catalog entry — plugin.json is the single authoritative source",
+  );
+  // Catalog plugin name and manifest plugin name must agree.
+  const manifest = JSON.parse(await readFile(path.join(repoRoot, ".claude", ".claude-plugin", "plugin.json"), "utf8"));
+  assert.equal(entry.name, manifest.name, "catalog entry name must match plugin.json name");
+});
+
+test("the publish files allowlist ships the marketplace catalog", async () => {
+  const pkg = JSON.parse(await readFile(path.join(repoRoot, "package.json"), "utf8"));
+  assert.ok(pkg.files.includes(".claude-plugin/"), "files allowlist must include .claude-plugin/");
+});


### PR DESCRIPTION
Closes #828.

## Problem
Adding the repo as a Claude Code **plugin marketplace** failed — `Marketplace file not found at .../.claude-plugin/marketplace.json`. We shipped the plugin **manifest** (`.claude/.claude-plugin/plugin.json`) but not a marketplace **catalog**. They're two different files: the catalog (repo-root `.claude-plugin/marketplace.json`) is what `/plugin marketplace add` reads.

## Fix
- **`.claude-plugin/marketplace.json`** — catalog with one plugin entry sourcing the in-repo plugin at `./.claude`. No entry-level `version`: `plugin.json` stays the single authoritative, version-synced source.
- **`plugin.json`** — declare `author` (clears the `claude plugin validate` warning).
- **Contract test** `test/contracts/claude-plugin-marketplace.test.mjs` (4 tests) — locks name, owner-is-object, `source → ./.claude`, no traversal, no drifting version, files-allowlist entry.
- **`files` allowlist** — add `.claude-plugin/`.
- **Folds PR #827**: README plugin section drops `(preview)`, documents marketplace install, and the two stale "plugin packaging in progress" CLI help lines are fixed.

## Release
Bump `dev-loops` + `@dev-loops/core` + `plugin.json` to **0.2.1**; root→core dep `^0.2.1` (lockstep — the release publishes both packages).

## Verification
- `claude plugin validate .` → **Validation passed** (no warnings).
- `claude plugin marketplace add <path>` → `/plugin install dev-loops@dev-loops` → `plugin details` shows **4 skills, 7 agents, 2 hooks**. Test registration cleaned up.
- `npm run verify` green (1476 + 124 + 72 + 32 tests, 0 fail; 361 links OK). Lockfile diff is only the dep bump.