### PR TITLE
fix(claude): relax async-start contract under Claude harness; bump v0.2.2

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-loops",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Agent-harness-agnostic dev-loop: agents, skills, and hooks for GitHub/Copilot-driven development loops.",
   "author": {
     "name": "Manuel Fittko",

--- a/.claude/skills/dev-loop/SKILL.md
+++ b/.claude/skills/dev-loop/SKILL.md
@@ -25,7 +25,7 @@ Required installed runtime contract docs are shared bundled copies under `../doc
 
 The main agent must **always** dispatch the `dev-loop` async subagent for any dev-loop work.
 Do not run `dev-loops loop startup` or any startup resolver in the main agent.
-The resolver requires `PI_SUBAGENT_RUN_ID` for async-required routes (the default `required` mode); the startup resolver can also run without it for non-async routes. Regardless, only the `dev-loop` async subagent runs it — never the main agent.
+For async-required routes (config `workflow.asyncStartMode`, default `required`) the resolver needs an async run-id marker (`DEVLOOPS_RUN_ID`, or the `PI_SUBAGENT_RUN_ID` alias) that the Pi harness injects when it dispatches the async subagent; under the Claude Code harness the requirement is relaxed automatically (no marker needed). The startup resolver also runs without a marker for non-async routes. Regardless, only the `dev-loop` subagent runs it — never the main agent.
 
 ### Dev-loop subagent (post-dispatch)
 
@@ -85,7 +85,7 @@ Do not preload route packs before the resolver selects the strategy.
 
 ## Async dispatch
 
-**Async dispatch rule (enforced):** the resolver enforces fail-closed for GitHub-first strategies when `canonicalStateSummary.requiresAsyncDispatch` is `true` (default `required` mode). Inline invocation without `PI_SUBAGENT_RUN_ID` is rejected only for those routes. See [Startup procedure](#startup-procedure).
+**Async dispatch rule (enforced):** the resolver fails closed for GitHub-first strategies when `canonicalStateSummary.requiresAsyncDispatch` is `true` (default `required` mode) — inline invocation without an async run-id marker (`DEVLOOPS_RUN_ID`, or the `PI_SUBAGENT_RUN_ID` alias) is rejected for those routes. Under the Claude Code harness this requirement is relaxed automatically. See [Startup procedure](#startup-procedure).
 
 
 ## Fallback gate-comment poster

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.2
+
+### Fixed
+
+- **Claude Code: dev-loop no longer dead-ends on the async-start contract** (#830). Running
+  `/dev-loop` from the installed plugin failed immediately because `dev-loops loop startup`
+  enforces an async-start contract — it requires a run-id env marker (`DEVLOOPS_RUN_ID` /
+  `PI_SUBAGENT_RUN_ID`) that Pi injects when dispatching an async subagent but Claude Code's
+  Agent tool does not. That contract guards against detached, uninspectable background
+  processes, a risk that does not exist under Claude's Agent model (each subagent run is
+  visible and inspectable). The async requirement remains configurable via
+  `workflow.asyncStartMode` (`required` | `allowed`); under the Claude harness it is now
+  **relaxed to `allowed` at runtime** via `resolveEffectiveAsyncStartMode`, which consults the
+  new `isClaudeHarness` helper (`CLAUDECODE=1`) in `@dev-loops/core/loop/run-context`. An
+  explicit `DEVLOOPS_RUN_ID` still resolves as `valid`, and Pi behavior is unchanged (outside
+  Claude the configured mode is honored verbatim).
+- The async-start CLI contract test is now hermetic — it clears `CLAUDECODE` (and the run-id
+  markers) so the rejection path is exercised regardless of the harness the suite runs under.
+
 ## 0.2.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ All notable changes to this project will be documented in this file.
   Claude the configured mode is honored verbatim).
 - The async-start CLI contract test is now hermetic — it clears `CLAUDECODE` (and the run-id
   markers) so the rejection path is exercised regardless of the harness the suite runs under.
+- The generated `dev-loop` skill prose no longer claims `PI_SUBAGENT_RUN_ID` is *required* — it
+  now describes the async run-id marker (`DEVLOOPS_RUN_ID` / `PI_SUBAGENT_RUN_ID` alias) and notes
+  the Claude-harness relaxation, so the plugin's docs match the runtime behavior. Subagent
+  spawning via the `dev-loop` agent is confirmed correctly wired: it grants the `Agent` tool
+  (the current subagent-spawning tool, renamed from `Task` in Claude Code v2.1.63) and the
+  strategy skills delegate to the worker agents (`developer`/`quality`/`refiner`/`fixer`/`review`/`docs`).
 
 ## 0.2.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "dev-loops",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dev-loops",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"
       ],
       "dependencies": {
-        "@dev-loops/core": "^0.2.1",
+        "@dev-loops/core": "^0.2.2",
         "mermaid": "11.15.0"
       },
       "bin": {
@@ -3725,7 +3725,7 @@
     },
     "packages/core": {
       "name": "@dev-loops/core",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "mermaid": "11.15.0",
-    "@dev-loops/core": "^0.2.1"
+    "@dev-loops/core": "^0.2.2"
   },
   "repository": {
     "type": "git",
@@ -78,7 +78,7 @@
     "url": "https://github.com/mfittko/dev-loops/issues"
   },
   "homepage": "https://github.com/mfittko/dev-loops#readme",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "files": [
     "cli/",
     "lib/",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev-loops/core",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "description": "Shared deterministic support package for dev-loop skills, repo-local scripts, and GitHub automation.",
   "exports": {

--- a/packages/core/src/loop/async-start-contract.mjs
+++ b/packages/core/src/loop/async-start-contract.mjs
@@ -71,7 +71,12 @@ export const ASYNC_START_STATUS = Object.freeze({
  * @returns {"required"|"allowed"}
  */
 export function resolveEffectiveAsyncStartMode(configuredMode, env = process.env) {
-  if (isClaudeHarness(env)) {
+  // Only relax a recognized mode. An unrecognized configuredMode must pass through
+  // verbatim so validateAsyncStartContext still rejects it (surfacing the config
+  // error) rather than having the Claude relaxation silently mask a typo'd value.
+  const isRecognizedMode =
+    configuredMode === ASYNC_START_MODE.REQUIRED || configuredMode === ASYNC_START_MODE.ALLOWED;
+  if (isRecognizedMode && isClaudeHarness(env)) {
     return ASYNC_START_MODE.ALLOWED;
   }
   return configuredMode;

--- a/packages/core/src/loop/async-start-contract.mjs
+++ b/packages/core/src/loop/async-start-contract.mjs
@@ -23,7 +23,7 @@
  * This module is intentionally pure and side-effect free.
  */
 
-import { RUN_ID_MARKERS } from "./run-context.mjs";
+import { RUN_ID_MARKERS, isClaudeHarness } from "./run-context.mjs";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -53,6 +53,29 @@ export const ASYNC_START_STATUS = Object.freeze({
   /** No harness-managed async context was detected; fail closed. */
   REJECTED: "rejected",
 });
+
+/**
+ * Resolve the effective async-start mode for the current harness.
+ *
+ * The async-start contract is configurable via `workflow.asyncStartMode`
+ * (`required` | `allowed`) — see defaults.yaml. It exists to stop the Pi
+ * harness from running the loop as a detached, uninspectable background
+ * process. Claude Code's Agent tool has no detached-process variant (each
+ * subagent run is visible and inspectable), so under the Claude harness the
+ * requirement is relaxed to `allowed` at runtime, regardless of the
+ * configured value. Pi behavior is unchanged: outside Claude the configured
+ * mode is returned verbatim.
+ *
+ * @param {"required"|"allowed"} configuredMode - Mode from workflow config.
+ * @param {Record<string, string|undefined>} [env]
+ * @returns {"required"|"allowed"}
+ */
+export function resolveEffectiveAsyncStartMode(configuredMode, env = process.env) {
+  if (isClaudeHarness(env)) {
+    return ASYNC_START_MODE.ALLOWED;
+  }
+  return configuredMode;
+}
 
 // ---------------------------------------------------------------------------
 // Validation

--- a/packages/core/src/loop/async-start-contract.mjs
+++ b/packages/core/src/loop/async-start-contract.mjs
@@ -61,14 +61,19 @@ export const ASYNC_START_STATUS = Object.freeze({
  * (`required` | `allowed`) — see defaults.yaml. It exists to stop the Pi
  * harness from running the loop as a detached, uninspectable background
  * process. Claude Code's Agent tool has no detached-process variant (each
- * subagent run is visible and inspectable), so under the Claude harness the
- * requirement is relaxed to `allowed` at runtime, regardless of the
- * configured value. Pi behavior is unchanged: outside Claude the configured
- * mode is returned verbatim.
+ * subagent run is visible and inspectable), so under the Claude harness a
+ * *recognized* mode is relaxed to `allowed` at runtime. An unrecognized
+ * (e.g. typo'd) `configuredMode` is returned verbatim — not relaxed — so
+ * `validateAsyncStartContext` still rejects it and the config error surfaces
+ * even under Claude. Pi behavior is unchanged: outside Claude the configured
+ * mode is always returned verbatim.
  *
- * @param {"required"|"allowed"} configuredMode - Mode from workflow config.
+ * @param {string} configuredMode - Mode from workflow config; normally
+ *   `"required"` | `"allowed"`, but any value is accepted and an unrecognized
+ *   one is passed through unchanged for downstream validation.
  * @param {Record<string, string|undefined>} [env]
- * @returns {"required"|"allowed"}
+ * @returns {string} The effective mode (`"allowed"` when a recognized mode is
+ *   relaxed under Claude; otherwise `configuredMode` verbatim).
  */
 export function resolveEffectiveAsyncStartMode(configuredMode, env = process.env) {
   // Only relax a recognized mode. An unrecognized configuredMode must pass through

--- a/packages/core/src/loop/run-context.mjs
+++ b/packages/core/src/loop/run-context.mjs
@@ -35,6 +35,27 @@ export const PI_RUN_ID_ALIAS_VAR = "PI_SUBAGENT_RUN_ID";
 export const RUN_CONTEXT_FILENAME = "dev-loop-run-context.json";
 
 /**
+ * Env var Claude Code sets in every tool/subagent shell it spawns.
+ * Used as the harness signal — see `isClaudeHarness`.
+ */
+export const CLAUDE_HARNESS_MARKER = "CLAUDECODE";
+
+/**
+ * True when running under the Claude Code harness.
+ *
+ * Claude Code sets `CLAUDECODE=1` in the environment of every Bash tool and
+ * subagent it spawns. This is the harness-detection seam used to relax
+ * Pi-specific runtime contracts (e.g. the async-start contract) that do not
+ * apply to Claude's execution model.
+ *
+ * @param {Record<string, string|undefined>} [env]
+ * @returns {boolean}
+ */
+export function isClaudeHarness(env = process.env) {
+  return env?.[CLAUDE_HARNESS_MARKER] === "1";
+}
+
+/**
  * Resolve the active run id from the environment, neutral marker first.
  *
  * @param {Record<string, string|undefined>} [env]

--- a/packages/core/test/async-start-contract.test.mjs
+++ b/packages/core/test/async-start-contract.test.mjs
@@ -192,6 +192,15 @@ test("resolveEffectiveAsyncStartMode: relaxes to allowed under the Claude harnes
   );
 });
 
+test("resolveEffectiveAsyncStartMode: does NOT relax an unrecognized mode under Claude (config error must still surface)", () => {
+  // A typo'd asyncStartMode must pass through so validateAsyncStartContext rejects it,
+  // rather than the Claude relaxation silently masking the misconfiguration.
+  const bogus = "requried";
+  assert.equal(resolveEffectiveAsyncStartMode(bogus, { CLAUDECODE: "1" }), bogus);
+  const result = validateAsyncStartContext({ env: { CLAUDECODE: "1" }, asyncStartMode: bogus });
+  assert.equal(result.status, ASYNC_START_STATUS.REJECTED);
+});
+
 test("resolveEffectiveAsyncStartMode: returns the configured mode verbatim outside Claude (Pi unchanged)", () => {
   assert.equal(resolveEffectiveAsyncStartMode(ASYNC_START_MODE.REQUIRED, {}), ASYNC_START_MODE.REQUIRED);
   assert.equal(resolveEffectiveAsyncStartMode(ASYNC_START_MODE.ALLOWED, {}), ASYNC_START_MODE.ALLOWED);

--- a/packages/core/test/async-start-contract.test.mjs
+++ b/packages/core/test/async-start-contract.test.mjs
@@ -7,6 +7,7 @@ import {
   PI_ASYNC_CONTEXT_MARKERS,
   buildAsyncStartRejection,
   validateAsyncStartContext,
+  resolveEffectiveAsyncStartMode,
 } from "../src/loop/async-start-contract.mjs";
 
 // ---------------------------------------------------------------------------
@@ -173,4 +174,48 @@ test("ASYNC_START_STATUS has all expected values", () => {
   assert.equal(ASYNC_START_STATUS.ALLOWED, "allowed");
   assert.equal(ASYNC_START_STATUS.SNAPSHOT_MODE, "snapshot_mode");
   assert.equal(ASYNC_START_STATUS.REJECTED, "rejected");
+});
+
+// ---------------------------------------------------------------------------
+// resolveEffectiveAsyncStartMode: Claude Code harness relaxation (#830)
+// ---------------------------------------------------------------------------
+
+test("resolveEffectiveAsyncStartMode: relaxes to allowed under the Claude harness", () => {
+  assert.equal(
+    resolveEffectiveAsyncStartMode(ASYNC_START_MODE.REQUIRED, { CLAUDECODE: "1" }),
+    ASYNC_START_MODE.ALLOWED,
+  );
+  // Even an explicitly-allowed config stays allowed under Claude.
+  assert.equal(
+    resolveEffectiveAsyncStartMode(ASYNC_START_MODE.ALLOWED, { CLAUDECODE: "1" }),
+    ASYNC_START_MODE.ALLOWED,
+  );
+});
+
+test("resolveEffectiveAsyncStartMode: returns the configured mode verbatim outside Claude (Pi unchanged)", () => {
+  assert.equal(resolveEffectiveAsyncStartMode(ASYNC_START_MODE.REQUIRED, {}), ASYNC_START_MODE.REQUIRED);
+  assert.equal(resolveEffectiveAsyncStartMode(ASYNC_START_MODE.ALLOWED, {}), ASYNC_START_MODE.ALLOWED);
+  // CLAUDECODE present but not exactly "1" → no relaxation.
+  for (const value of ["0", "", "true", "yes"]) {
+    assert.equal(
+      resolveEffectiveAsyncStartMode(ASYNC_START_MODE.REQUIRED, { CLAUDECODE: value }),
+      ASYNC_START_MODE.REQUIRED,
+      `CLAUDECODE=${JSON.stringify(value)} must not relax`,
+    );
+  }
+});
+
+test("resolveEffectiveAsyncStartMode + validateAsyncStartContext: Claude harness passes without a run-id marker", () => {
+  // End-to-end of the runtime override: required config + Claude harness + no marker → not rejected.
+  const effective = resolveEffectiveAsyncStartMode(ASYNC_START_MODE.REQUIRED, { CLAUDECODE: "1" });
+  const result = validateAsyncStartContext({ env: { CLAUDECODE: "1" }, asyncStartMode: effective });
+  assert.equal(result.status, ASYNC_START_STATUS.ALLOWED);
+  assert.notEqual(result.status, ASYNC_START_STATUS.REJECTED);
+});
+
+test("Claude harness override still honors an explicit run-id marker as VALID", () => {
+  const effective = resolveEffectiveAsyncStartMode(ASYNC_START_MODE.REQUIRED, { CLAUDECODE: "1", DEVLOOPS_RUN_ID: "devloops-abc" });
+  const result = validateAsyncStartContext({ env: { CLAUDECODE: "1", DEVLOOPS_RUN_ID: "devloops-abc" }, asyncStartMode: effective });
+  assert.equal(result.status, ASYNC_START_STATUS.VALID);
+  assert.equal(result.detectedMarker, "DEVLOOPS_RUN_ID");
 });

--- a/packages/core/test/run-context.test.mjs
+++ b/packages/core/test/run-context.test.mjs
@@ -15,6 +15,8 @@ import {
   writeRunContext,
   readRunContext,
   ensureRunId,
+  isClaudeHarness,
+  CLAUDE_HARNESS_MARKER,
 } from "../src/loop/run-context.mjs";
 
 // Track temp dirs and clean them up after the suite so CI does not accumulate /tmp entries.
@@ -116,4 +118,15 @@ test("ensureRunId mints in-memory when no root is given (no file write)", () => 
   assert.equal(result.minted, true);
   assert.equal(result.statePath, null);
   assert.match(result.runId, /^devloops-/);
+});
+
+test("isClaudeHarness is true only when CLAUDECODE is exactly \"1\"", () => {
+  // Assert against explicit env objects only — the default arg reads process.env,
+  // whose CLAUDECODE is ambient (set under the Claude Code harness, unset in CI).
+  assert.equal(CLAUDE_HARNESS_MARKER, "CLAUDECODE");
+  assert.equal(isClaudeHarness({ CLAUDECODE: "1" }), true);
+  assert.equal(isClaudeHarness({ CLAUDECODE: "0" }), false);
+  assert.equal(isClaudeHarness({ CLAUDECODE: "true" }), false);
+  assert.equal(isClaudeHarness({ CLAUDECODE: "" }), false);
+  assert.equal(isClaudeHarness({}), false);
 });

--- a/scripts/loop/outer-loop.mjs
+++ b/scripts/loop/outer-loop.mjs
@@ -22,6 +22,7 @@ import {
   ASYNC_START_STATUS,
   buildAsyncStartRejection,
   validateAsyncStartContext,
+  resolveEffectiveAsyncStartMode,
 } from "@dev-loops/core/loop/async-start-contract";
 import { loadDevLoopConfig, resolveConductorModel, resolveAutonomyStopAt, resolveWorkflowConfig } from "@dev-loops/core/config";
 const USAGE = `Usage: outer-loop.mjs --repo <owner/name> --pr <number>
@@ -286,9 +287,11 @@ export async function runOuterLoop(options, { env = process.env, ghCommand = "gh
       devLoopConfig = loaded.config;
     }
   }
-  const asyncStartMode = devLoopConfig === null
+  const configuredAsyncStartMode = devLoopConfig === null
     ? "required"
     : resolveWorkflowConfig(devLoopConfig, "asyncStartMode");
+  // Relaxed to "allowed" under the Claude harness (Pi async-start contract does not apply).
+  const asyncStartMode = resolveEffectiveAsyncStartMode(configuredAsyncStartMode, env);
   const asyncStartValidation = validateAsyncStartContext({ env, isSnapshotMode, asyncStartMode });
   if (asyncStartValidation.status === ASYNC_START_STATUS.REJECTED) {
     return buildAsyncStartRejection(asyncStartValidation);

--- a/scripts/loop/resolve-dev-loop-startup.mjs
+++ b/scripts/loop/resolve-dev-loop-startup.mjs
@@ -16,6 +16,7 @@ import {
 import {
   validateAsyncStartContext,
   buildAsyncStartRejection,
+  resolveEffectiveAsyncStartMode,
   ASYNC_START_STATUS,
 } from "@dev-loops/core/loop/async-start-contract";
 import { detectRepoSlug } from "@dev-loops/core/github/repo-slug";
@@ -411,7 +412,10 @@ export function buildResolveDevLoopStartupResult(input, { adapter = createPiAdap
     ? (STRATEGY_ASYNC_DISPATCH[bundle.selectedStrategy] ?? false)
     : false;
   if (requiresAsyncDispatch) {
-    const validation = validateAsyncStartContext({ env: effectiveEnv, asyncStartMode });
+    // The configured async-start mode is relaxed to "allowed" under the Claude
+    // harness, where the Pi async-subagent start contract does not apply.
+    const effectiveAsyncStartMode = resolveEffectiveAsyncStartMode(asyncStartMode, effectiveEnv);
+    const validation = validateAsyncStartContext({ env: effectiveEnv, asyncStartMode: effectiveAsyncStartMode });
     if (validation.status === ASYNC_START_STATUS.REJECTED) {
       return buildAsyncStartRejection(validation);
     }

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -26,7 +26,7 @@ Required installed runtime contract docs are shared bundled copies under `../doc
 
 The main agent must **always** dispatch the `dev-loop` async subagent for any dev-loop work.
 Do not run `dev-loops loop startup` or any startup resolver in the main agent.
-The resolver requires `PI_SUBAGENT_RUN_ID` for async-required routes (the default `required` mode); the startup resolver can also run without it for non-async routes. Regardless, only the `dev-loop` async subagent runs it — never the main agent.
+For async-required routes (config `workflow.asyncStartMode`, default `required`) the resolver needs an async run-id marker (`DEVLOOPS_RUN_ID`, or the `PI_SUBAGENT_RUN_ID` alias) that the Pi harness injects when it dispatches the async subagent; under the Claude Code harness the requirement is relaxed automatically (no marker needed). The startup resolver also runs without a marker for non-async routes. Regardless, only the `dev-loop` subagent runs it — never the main agent.
 
 ### Dev-loop subagent (post-dispatch)
 
@@ -86,7 +86,7 @@ Do not preload route packs before the resolver selects the strategy.
 
 ## Async dispatch
 
-**Async dispatch rule (enforced):** the resolver enforces fail-closed for GitHub-first strategies when `canonicalStateSummary.requiresAsyncDispatch` is `true` (default `required` mode). Inline invocation without `PI_SUBAGENT_RUN_ID` is rejected only for those routes. See [Startup procedure](#startup-procedure).
+**Async dispatch rule (enforced):** the resolver fails closed for GitHub-first strategies when `canonicalStateSummary.requiresAsyncDispatch` is `true` (default `required` mode) — inline invocation without an async run-id marker (`DEVLOOPS_RUN_ID`, or the `PI_SUBAGENT_RUN_ID` alias) is rejected for those routes. Under the Claude Code harness this requirement is relaxed automatically. See [Startup procedure](#startup-procedure).
 
 
 ## Fallback gate-comment poster

--- a/test/loop/resolve-dev-loop-startup-cli-contract.test.mjs
+++ b/test/loop/resolve-dev-loop-startup-cli-contract.test.mjs
@@ -124,12 +124,20 @@ test("resolve-dev-loop-startup rejects async-required strategy via stderr contra
     const result = spawnSync(process.execPath, [cliPath, "--input", inputPath], {
       cwd: repoRoot,
       encoding: "utf8",
-      // Deliberately omit every async-context signal so the rejection path is
-      // exercised hermetically — including CLAUDECODE, which would otherwise
-      // relax the contract when this suite runs under the Claude Code harness (#830).
+      // Deliberately omit every async-context signal so both the rejection
+      // path AND its exact reason are exercised hermetically — independent of
+      // the ambient harness. CLAUDECODE would relax the contract (#830);
+      // PI_SESSION_ID / PI_ASYNC_CONTEXT / PI_DEV_LOOP_DETACHED would switch
+      // validateAsyncStartContext to a different rejection-reason branch.
       env: Object.fromEntries(
         Object.entries(process.env).filter(
-          ([k]) => k !== "PI_SUBAGENT_RUN_ID" && k !== "DEVLOOPS_RUN_ID" && k !== "CLAUDECODE",
+          ([k]) =>
+            k !== "PI_SUBAGENT_RUN_ID" &&
+            k !== "DEVLOOPS_RUN_ID" &&
+            k !== "CLAUDECODE" &&
+            k !== "PI_SESSION_ID" &&
+            k !== "PI_ASYNC_CONTEXT" &&
+            k !== "PI_DEV_LOOP_DETACHED",
         ),
       ),
     });

--- a/test/loop/resolve-dev-loop-startup-cli-contract.test.mjs
+++ b/test/loop/resolve-dev-loop-startup-cli-contract.test.mjs
@@ -124,10 +124,12 @@ test("resolve-dev-loop-startup rejects async-required strategy via stderr contra
     const result = spawnSync(process.execPath, [cliPath, "--input", inputPath], {
       cwd: repoRoot,
       encoding: "utf8",
-      // Deliberately omit PI_SUBAGENT_RUN_ID.
+      // Deliberately omit every async-context signal so the rejection path is
+      // exercised hermetically — including CLAUDECODE, which would otherwise
+      // relax the contract when this suite runs under the Claude Code harness (#830).
       env: Object.fromEntries(
         Object.entries(process.env).filter(
-          ([k]) => k !== "PI_SUBAGENT_RUN_ID",
+          ([k]) => k !== "PI_SUBAGENT_RUN_ID" && k !== "DEVLOOPS_RUN_ID" && k !== "CLAUDECODE",
         ),
       ),
     });


### PR DESCRIPTION
Closes #830.

## Problem
`/dev-loop` from the installed Claude Code plugin dead-ends immediately: `dev-loops loop startup` rejects with *"No async context detected… Set DEVLOOPS_RUN_ID…"*. The **async-start contract** requires a run-id env marker that **Pi** injects when dispatching an async subagent, but Claude Code's `Agent` tool does not — so the resolver fails closed at step 1 and never produces authoritative state.

## Design (config-driven, override at runtime)
The contract guards against *detached, uninspectable background processes* — a risk that doesn't exist under Claude's Agent model (each subagent run is visible/inspectable). The requirement was **already configurable** via `workflow.asyncStartMode` (`required` | `allowed`); this PR keeps the contract pure/config-driven and **overrides the mode to `allowed` at runtime under the Claude harness** (per maintainer direction):

- `@dev-loops/core/loop/run-context`: add `isClaudeHarness(env)` (`CLAUDECODE === "1"`) + `CLAUDE_HARNESS_MARKER`.
- `async-start-contract`: add `resolveEffectiveAsyncStartMode(configuredMode, env)` → returns `allowed` under Claude, else the configured mode verbatim. `validateAsyncStartContext` stays pure.
- Apply the override in `resolve-dev-loop-startup.mjs` and `outer-loop.mjs`.
- Make the async-start CLI contract test **hermetic** (clear `CLAUDECODE` + run-id markers) so the rejection path holds regardless of the harness the suite runs under.

## Verified end-to-end (copilot-followup async route)
- Bare shell (no harness, no run-id): **rejects, exit 1** — Pi behavior preserved.
- `CLAUDECODE=1` (no run-id): **resolves `copilot_pr_followup`, exit 0** — and the routing `DURABLE_AUTO` gate does not separately block.
- An explicit `DEVLOOPS_RUN_ID` still resolves as `valid` under Claude.

`npm run verify` green (1475+1436+125+72+32, 0 fail; lockfile diff is only the 0.2.2 bump). Release **0.2.2** (root + @dev-loops/core + plugin.json; root→core dep `^0.2.2`).