### PR TITLE
feat(config): opt out of Copilot review gate via maxCopilotRounds: 0

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-loops",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Agent-harness-agnostic dev-loop: agents, skills, and hooks for GitHub/Copilot-driven development loops.",
   "author": {
     "name": "Manuel Fittko",

--- a/.claude/skills/copilot-pr-followup/SKILL.md
+++ b/.claude/skills/copilot-pr-followup/SKILL.md
@@ -225,6 +225,7 @@ When unresolved feedback exists, use a narrow follow-up loop:
     - if the refreshed snapshot reports unresolved threads, re-enter the reply/resolve loop for the missed threads
 12. only after GitHub-side reply/resolve work is done for the addressed threads and the refreshed thread snapshot proves zero unresolved threads remain, decide whether another Copilot pass is desired
     - resolve the review-round cap from config via `resolveRefinementConfig(config, "maxCopilotRounds")` from `@dev-loops/core/config`; default config ships `maxCopilotRounds: 5`
+    - **Opt out entirely:** `maxCopilotRounds: 0` disables the external Copilot review gate for the repo — the loop runs `draft_gate → pre_approval_gate` with the local harness only, never requesting or waiting on Copilot. Use this when the repo has no Copilot reviewer configured or prefers local-harness-only review.
     - use the completed Copilot review-round count from `detect-copilot-loop-state.mjs` / `copilot-pr-handoff.mjs` as the current PR's review-round count
     - if completed review rounds have reached the maximum (default: 5), do **not** re-request Copilot review
     - when the round limit is reached **and** the refreshed thread snapshot proves zero unresolved threads **and** current-head CI is green or credibly green, treat that clean state as eligible for `pre_approval_gate` fallback instead of deadlocking on another Copilot rerequest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.3
+
+### Added
+
+- **Opt out of the Copilot review gate via `refinement.maxCopilotRounds: 0`** (#832). For repos
+  without a Copilot reviewer configured (or that prefer local-harness-only review), setting
+  `maxCopilotRounds: 0` disables the external Copilot review cycle entirely — the loop runs
+  `draft_gate → pre_approval_gate` with no Copilot request or wait. The config schema now accepts
+  `0` (`nonnegative`; negative still rejected); `evaluatePrGateCoordination` routes `0` through the
+  existing `internal_only` path, `shouldGuardCopilotReviewRequest` never forces a request at `0`,
+  and the watch-cycle handoff (`copilot-pr-handoff`) skips the request too. Default (`5`) unchanged.
+  Documented in the README, extension config docs, and the `copilot-pr-followup` skill.
+
 ## 0.2.2
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ npx dev-loops gates   # see what reviewers will check
 Key surfaces:
 - **Gate angles** — which review lenses run at draft and pre-approval gates
 - **Persona prompts** — focused instructions per angle (DRY, KISS, YAGNI, SRP, SoC, and more)
-- **Refinement** — fan-out count and mode for parallel review variants
+- **Refinement** — fan-out count and mode for parallel review variants; `refinement.maxCopilotRounds` caps Copilot re-review rounds (default `5`), and **`maxCopilotRounds: 0` disables the Copilot review gate entirely** for local-harness-only review (`draft_gate → pre_approval_gate`, no Copilot) — useful when the repo has no Copilot reviewer configured
 - **Autonomy** — which gates require operator confirmation
 - **Workflow defaults** — retrospective enforcement, draft-first posture, dev-mode policy
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -133,7 +133,9 @@ personas:
 
 # Override gate requirements
 refinement:
-  fanOut: 5      # run 5 parallel review variants instead of 3
+  fanOut: 5            # run 5 parallel review variants instead of 3
+  maxCopilotRounds: 0  # 0 disables the Copilot review gate entirely (local-harness-only
+                       # review: draft_gate → pre_approval_gate, no Copilot). Default: 5.
 
 autonomy:
   stopAt:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "dev-loops",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dev-loops",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"
       ],
       "dependencies": {
-        "@dev-loops/core": "^0.2.2",
+        "@dev-loops/core": "^0.2.3",
         "mermaid": "11.15.0"
       },
       "bin": {
@@ -3725,7 +3725,7 @@
     },
     "packages/core": {
       "name": "@dev-loops/core",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "mermaid": "11.15.0",
-    "@dev-loops/core": "^0.2.2"
+    "@dev-loops/core": "^0.2.3"
   },
   "repository": {
     "type": "git",
@@ -78,7 +78,7 @@
     "url": "https://github.com/mfittko/dev-loops/issues"
   },
   "homepage": "https://github.com/mfittko/dev-loops#readme",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "files": [
     "cli/",
     "lib/",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev-loops/core",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "description": "Shared deterministic support package for dev-loop skills, repo-local scripts, and GitHub automation.",
   "exports": {

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -28,7 +28,7 @@ const ModelsConfig = z.strictObject({
 const RefinementConfig = z.strictObject({
   fanOut: z.number().int().min(1).max(10),
   mode: z.enum(["parallel", "sequential"]),
-  maxCopilotRounds: z.number().int().positive().default(5),
+  maxCopilotRounds: z.number().int().nonnegative().default(5),
   stopOnLowSignal: z.boolean().default(false),
   lowSignalRoundThreshold: z.number().int().nonnegative().default(3),
   lowSignalMaxComments: z.number().int().nonnegative().default(2),

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -447,6 +447,12 @@ export function shouldGuardCopilotReviewRequest({
   if (!gateBoundariesRequiringCopilotFormalRequest.has(gateBoundary)) {
     return false;
   }
+  // Copilot review disabled for the repo (maxCopilotRounds: 0): never force a
+  // formal request — the loop runs draft_gate → pre_approval with the local
+  // harness only. See evaluatePrGateCoordination (internal_only routing).
+  if (maxCopilotRounds === 0) {
+    return false;
+  }
   if (copilotReviewRequestStatus !== "none") {
     return false;
   }
@@ -477,9 +483,14 @@ export function evaluatePrGateCoordination(input = {}) {
   const prClosed = input.prClosed === true;
   const prMerged = input.prMerged === true;
   const sameHeadCleanConverged = input.sameHeadCleanConverged === true;
-  const reviewMode = typeof input.reviewMode === "string"
-    ? input.reviewMode.trim().toLowerCase()
-    : null;
+  // maxCopilotRounds: 0 disables the external Copilot review gate entirely
+  // (for repos without Copilot / local-harness-only review). It reuses the
+  // existing internal_only routing — skip the Copilot cycle, go straight to
+  // pre_approval — so no separate skip path is needed.
+  const copilotReviewDisabled = input.maxCopilotRounds === 0;
+  const reviewMode = copilotReviewDisabled
+    ? "internal_only"
+    : (typeof input.reviewMode === "string" ? input.reviewMode.trim().toLowerCase() : null);
   const mergeStateStatus = normalizeMergeStateStatus(input.mergeStateStatus);
   const conflictFiles = normalizeConflictFiles(input.conflictFiles);
   const ciStatus = normalizeCiStatus(input.ciStatus);
@@ -813,7 +824,9 @@ export function evaluatePrGateCoordination(input = {}) {
           allowedNextActions,
           forbiddenActions,
           nextAction: PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL,
-          reason: "This is an explicitly internal-only PR with clean draft_gate evidence and current-head clean pre_approval_gate, so it is ready for final human approval.",
+          reason: copilotReviewDisabled
+            ? "Copilot review is disabled for this repo (maxCopilotRounds: 0); with clean draft_gate evidence and current-head clean pre_approval_gate, the PR is ready for final human approval."
+            : "This is an explicitly internal-only PR with clean draft_gate evidence and current-head clean pre_approval_gate, so it is ready for final human approval.",
           mergeStateStatus,
           conflictFiles,
             refinementArtifact,
@@ -835,7 +848,9 @@ export function evaluatePrGateCoordination(input = {}) {
         allowedNextActions,
         forbiddenActions,
         nextAction: PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE,
-        reason: "This is an explicitly internal-only PR, so `pre_approval_gate` is the next legal boundary instead of an external Copilot review cycle.",
+        reason: copilotReviewDisabled
+          ? "Copilot review is disabled for this repo (maxCopilotRounds: 0), so `pre_approval_gate` is the next legal boundary instead of an external Copilot review cycle."
+          : "This is an explicitly internal-only PR, so `pre_approval_gate` is the next legal boundary instead of an external Copilot review cycle.",
         mergeStateStatus,
         conflictFiles,
           refinementArtifact,

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -212,12 +212,20 @@ describe("schema validation", () => {
     assert.ok(!result.success);
   });
 
-  test("S17b: refinement.maxCopilotRounds must be a positive integer", () => {
-    const result = DevLoopConfigSchema.safeParse({
+  test("S17b: refinement.maxCopilotRounds must be a non-negative integer (0 = Copilot gate disabled)", () => {
+    // 0 is valid and disables the external Copilot review gate (#832).
+    const zero = DevLoopConfigSchema.safeParse({
       version: 1,
       refinement: { fanOut: 3, mode: "parallel", maxCopilotRounds: 0 },
     });
-    assert.ok(!result.success);
+    assert.ok(zero.success, "maxCopilotRounds: 0 must be accepted (Copilot opt-out)");
+    assert.equal(zero.data.refinement.maxCopilotRounds, 0);
+    // Negative is still rejected.
+    const negative = DevLoopConfigSchema.safeParse({
+      version: 1,
+      refinement: { fanOut: 3, mode: "parallel", maxCopilotRounds: -1 },
+    });
+    assert.ok(!negative.success);
   });
 
   test("S18: autonomy.stopAt contains unknown gate name", () => {

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -684,6 +684,74 @@ test("PR without explicit reviewMode uses standard Copilot review path (default)
   assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
 });
 
+// #832: maxCopilotRounds: 0 disables the external Copilot review gate entirely
+// (reusing the internal_only routing — skip Copilot, go to pre-approval).
+
+test("maxCopilotRounds: 0 disables Copilot — ready PR skips to pre-approval gate", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 298,
+    currentHeadSha: "abc123456789",
+    prDraft: false,
+    lifecycleState: STATE.PR_READY_NO_FEEDBACK,
+    loopDisposition: DISPOSITION.ACTION_REQUIRED,
+    maxCopilotRounds: 0,
+    draftGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.REQUEST_COPILOT_REVIEW));
+  assert.match(result.reason, /disabled.*maxCopilotRounds: 0/i);
+});
+
+test("maxCopilotRounds: 0 with both gates clean goes straight to final approval (no Copilot)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 298,
+    currentHeadSha: "abc123456789",
+    prDraft: false,
+    lifecycleState: STATE.PR_READY_NO_FEEDBACK,
+    loopDisposition: DISPOSITION.ACTION_REQUIRED,
+    maxCopilotRounds: 0,
+    draftGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
+    preApprovalGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.FINAL_APPROVAL_READY);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL);
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.REQUEST_COPILOT_REVIEW));
+  assert.match(result.reason, /disabled.*maxCopilotRounds: 0/i);
+});
+
+test("shouldGuardCopilotReviewRequest: never forces a request when maxCopilotRounds is 0", () => {
+  // At a pre-approval boundary, status none, never requested, not converged —
+  // normally this would force a request; with the gate disabled it must not.
+  const guarded = shouldGuardCopilotReviewRequest({
+    copilotReviewRequestStatus: "none",
+    copilotReviewRoundCount: 0,
+    copilotReviewEverFormallyRequested: false,
+    maxCopilotRounds: 0,
+    sameHeadCleanConverged: false,
+    gateBoundary: PR_CHECKPOINT.PRE_APPROVAL_GATE_NEEDED,
+  });
+  assert.equal(guarded, false);
+
+  // Sanity: with the default cap it WOULD guard in the same situation.
+  const guardedDefault = shouldGuardCopilotReviewRequest({
+    copilotReviewRequestStatus: "none",
+    copilotReviewRoundCount: 0,
+    copilotReviewEverFormallyRequested: false,
+    maxCopilotRounds: 5,
+    sameHeadCleanConverged: false,
+    gateBoundary: PR_CHECKPOINT.PRE_APPROVAL_GATE_NEEDED,
+  });
+  assert.equal(guardedDefault, true);
+});
+
 test("internal-only PR without clean draft gate still enters pre-approval gate window", () => {
   const result = evaluatePrGateCoordination({
     pr: 298,

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -366,9 +366,25 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
   // Detect internal tooling PRs — suppress Copilot review request step entirely.
   // Internal-only PRs (scripts/docs/tests/config) skip the request, not just the wait.
   let internalOnlySkipCopilot = false;
+  // Config opt-out (#832): maxCopilotRounds: 0 disables the external Copilot review
+  // gate for the repo (local-harness-only review). Treat it like an internal-only PR
+  // — skip the request, not just the wait — regardless of stub/sequence mode. This
+  // mirrors the gate-coordination side, which routes maxCopilotRounds: 0 to internal_only.
+  if (refinementConfig?.maxCopilotRounds === 0 &&
+      options.watchStatus === undefined &&
+      (interpretation.state === STATE.PR_READY_NO_FEEDBACK ||
+       interpretation.state === STATE.READY_TO_REREQUEST_REVIEW)) {
+    internalOnlySkipCopilot = true;
+    interpretation = {
+      ...interpretation,
+      state: STATE.INTERNAL_TOOLING_DIRECT_GATE,
+      nextAction: NEXT_ACTIONS[STATE.INTERNAL_TOOLING_DIRECT_GATE],
+      allowedTransitions: TRANSITIONS[STATE.INTERNAL_TOOLING_DIRECT_GATE] || [STATE.DONE],
+    };
+  }
   // Skip internal detection in sequential stub/test mode to avoid consuming stub entries.
   // Claims-mode stubs handle interleaved calls; detection runs normally.
-  if (!env.GH_SEQUENCE_PATH || env.GH_STUB_MODE === "claims") {
+  if (!internalOnlySkipCopilot && (!env.GH_SEQUENCE_PATH || env.GH_STUB_MODE === "claims")) {
   if (options.watchStatus === undefined &&
       (interpretation.state === STATE.PR_READY_NO_FEEDBACK ||
        interpretation.state === STATE.READY_TO_REREQUEST_REVIEW)) {

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -384,10 +384,13 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
   }
   // Skip internal detection in sequential stub/test mode to avoid consuming stub entries.
   // Claims-mode stubs handle interleaved calls; detection runs normally.
-  if (!internalOnlySkipCopilot && (!env.GH_SEQUENCE_PATH || env.GH_STUB_MODE === "claims")) {
-  if (options.watchStatus === undefined &&
-      (interpretation.state === STATE.PR_READY_NO_FEEDBACK ||
-       interpretation.state === STATE.READY_TO_REREQUEST_REVIEW)) {
+  if (
+    !internalOnlySkipCopilot &&
+    (!env.GH_SEQUENCE_PATH || env.GH_STUB_MODE === "claims") &&
+    options.watchStatus === undefined &&
+    (interpretation.state === STATE.PR_READY_NO_FEEDBACK ||
+      interpretation.state === STATE.READY_TO_REREQUEST_REVIEW)
+  ) {
     try {
       const internalCheck = await detectPrInternalOnly(options, { env, ghCommand });
       if (internalCheck.ok && internalCheck.internalOnly) {
@@ -402,7 +405,6 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
     } catch {
       // Best-effort: if detection fails, fall through to normal request behavior
     }
-  }
   }
 
   let reviewRequestStatus;

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -229,6 +229,7 @@ When unresolved feedback exists, use a narrow follow-up loop:
     - if the refreshed snapshot reports unresolved threads, re-enter the reply/resolve loop for the missed threads
 12. only after GitHub-side reply/resolve work is done for the addressed threads and the refreshed thread snapshot proves zero unresolved threads remain, decide whether another Copilot pass is desired
     - resolve the review-round cap from config via `resolveRefinementConfig(config, "maxCopilotRounds")` from `@dev-loops/core/config`; default config ships `maxCopilotRounds: 5`
+    - **Opt out entirely:** `maxCopilotRounds: 0` disables the external Copilot review gate for the repo — the loop runs `draft_gate → pre_approval_gate` with the local harness only, never requesting or waiting on Copilot. Use this when the repo has no Copilot reviewer configured or prefers local-harness-only review.
     - use the completed Copilot review-round count from `detect-copilot-loop-state.mjs` / `copilot-pr-handoff.mjs` as the current PR's review-round count
     - if completed review rounds have reached the maximum (default: 5), do **not** re-request Copilot review
     - when the round limit is reached **and** the refreshed thread snapshot proves zero unresolved threads **and** current-head CI is green or credibly green, treat that clean state as eligible for `pre_approval_gate` fallback instead of deadlocking on another Copilot rerequest

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -2252,6 +2252,31 @@ test("copilot-pr-handoff skips Copilot request for internal-only PR and emits fi
   }
 });
 
+test("copilot-pr-handoff skips Copilot request when maxCopilotRounds: 0 disables the gate (#832)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-copilot-disabled-"));
+  try {
+    // Repo config disables the Copilot review gate entirely.
+    await writeFile(path.join(tempDir, ".devloops"), "version: 1\nrefinement:\n  maxCopilotRounds: 0\n", "utf8");
+    // Only the autoDetect snapshot calls are consumed — the config opt-out short-circuits
+    // before the file-path internal detection and before any review request.
+    const env = await writeGhStub(tempDir, [
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json"], stdout: JSON.stringify({isDraft:false,state:"OPEN",number:17,headRefOid:"abc123",reviews:[],statusCheckRollup:[{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }]}) + "\n" },
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[],"teams":[]}\n' },
+      { assertArgs: ["api", "graphql"], stdout: EMPTY_THREADS + "\n" },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { cwd: tempDir, env });
+    assert.equal(result.code, 0);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.state, STATE.INTERNAL_TOOLING_DIRECT_GATE);
+    assert.equal(output.internalOnlySkipCopilot, true);
+    assert.equal(output.reviewRequestStatus, undefined, "must not request Copilot when the gate is disabled");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("copilot-pr-handoff does not skip Copilot for consumer-facing PR", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-not-internal-"));
   try {


### PR DESCRIPTION
Closes #832.

## Problem
Repos without Copilot configured (or preferring local-harness-only review) had no easy, documented way to skip the Copilot review round. The schema rejected `0` (`positive()`), and the gate coordination *forces* a Copilot request before `pre_approval_gate`.

## Change
`maxCopilotRounds: 0` now disables the external Copilot review gate entirely. Implemented as a **contained** change that reuses the existing, tested `internal_only` routing (skip the Copilot cycle → `pre_approval_gate`):

- **schema** (`config.mjs`): `positive()` → `nonnegative()` — `0` valid; negative still rejected.
- **`evaluatePrGateCoordination`**: `maxCopilotRounds === 0` maps to `internal_only` routing, with accurate `Copilot disabled (maxCopilotRounds: 0)` reasons.
- **`shouldGuardCopilotReviewRequest`**: never forces a formal request when `maxCopilotRounds === 0`.
- No `interpretLoopState` surgery — the detect script already passes `maxCopilotRounds` to the evaluator, and the `internal_only` branch handles `PR_READY_NO_FEEDBACK` → pre-approval.

Default behavior (`5`) is unchanged.

## Docs
- `copilot-pr-followup` skill (Step 7) + regenerated `.claude`; `extension/README.md`; `README.md` Configuration.

## Verification
- Unit tests: schema (`0` valid, negative rejected) + 3 gate-coordination tests (ready→pre-approval, both-gates→final-approval, guard returns false at 0).
- End-to-end: `CLAUDECODE=1` + `maxCopilotRounds: 0` ready PR → routes to `pre_approval_gate`, `REQUEST_COPILOT_REVIEW` forbidden.
- `npm run verify` green (0 fail; 355 links; no asset drift).