### PR TITLE
feat(claude): collapse the Pi dev-loop umbrella to a single agent on Claude

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-loops",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Agent-harness-agnostic dev-loop: agents, skills, and hooks for GitHub/Copilot-driven development loops.",
   "author": {
     "name": "Manuel Fittko",

--- a/.claude/skills/dev-loop/SKILL.md
+++ b/.claude/skills/dev-loop/SKILL.md
@@ -39,7 +39,7 @@ Resolve authoritative state via the startup resolver (`npx dev-loops loop startu
 
 When the startup resolver returns a fresh-start routing but an existing outer-loop checkpoint
 (`tmp/copilot-loop/<owner>/<repo>/pr-<n>/outer-loop-state.json`) is present on disk, the
-subagent must check the checkpoint before treating the start as a fresh intake or follow-up:
+dev-loop must check the checkpoint before treating the start as a fresh intake or follow-up:
 
 1. Read the outer-loop checkpoint (authored by `outer-loop.mjs`).
 2. If `outerAction` is `continue_wait`, `reenter_copilot_loop`, or `reenter_reviewer_loop`:
@@ -99,14 +99,14 @@ When `@dev-loops/core` is available again, switch back to the full helper. The f
 
 ## Read-only info shortcut
 
-The main agent may handle info/handoff requests directly via `npx dev-loops loop info` without dispatching the async `dev-loop` subagent:
+Info/handoff requests can be served directly via `npx dev-loops loop info` (read-only; no full dev-loop run required):
 - `npx dev-loops loop info --issue <n>` — human-readable issue state summary (strategy, route, linked PR, next action)
 - `npx dev-loops loop info --pr <n>` — human-readable PR state summary (branch, CI, threads, rounds, action)
 - `npx dev-loops loop info --issue <n> --json` — machine-readable JSON output
 
-## Guard rules (subagent reference)
+## Guard rules
 
-**Handoff envelope precedence:** The subagent builds the envelope immediately after authoritative-state resolution and treats it as the first handoff artifact. Read it first, load only `requiredReads`, execute `nextAction`. See [Dev-loop subagent](#dev-loop-subagent-post-dispatch). Derivation contract: [Workflow Handoff Contract](../docs/workflow-handoff-contract.md).
+**Handoff envelope precedence:** The dev-loop builds the envelope immediately after authoritative-state resolution and treats it as the first handoff artifact. Read it first, load only `requiredReads`, execute `nextAction`. See [Resolve authoritative state](#resolve-authoritative-state). Derivation contract: [Workflow Handoff Contract](../docs/workflow-handoff-contract.md).
 
 **Handoff contract rule:** When no envelope is present, use the `workflow-handoff-contract.md` contract. Never delegate with abbreviated task summaries. Include deterministic routing inputs, explicit `cwd`, bounded task scope, exit conditions.
 

--- a/.claude/skills/dev-loop/SKILL.md
+++ b/.claude/skills/dev-loop/SKILL.md
@@ -21,23 +21,19 @@ Required installed runtime contract docs are shared bundled copies under `../doc
 
 ## Startup procedure
 
-### Main agent (read-only)
+### Resolve authoritative state
 
-The main agent must **always** dispatch the `dev-loop` async subagent for any dev-loop work.
-Do not run `dev-loops loop startup` or any startup resolver in the main agent.
-For async-required routes (config `workflow.asyncStartMode`, default `required`) the resolver needs an async run-id marker (`DEVLOOPS_RUN_ID`, or the `PI_SUBAGENT_RUN_ID` alias) that the Pi harness injects when it dispatches the async subagent; under the Claude Code harness the requirement is relaxed automatically (no marker needed). The startup resolver also runs without a marker for non-async routes. Regardless, only the `dev-loop` subagent runs it — never the main agent.
+> Under the Claude Code harness the dev-loop runs as a single agent: run these steps directly — no read-only boundary and no separate async-subagent dispatch. See [Main Agent Contract](../docs/main-agent-contract.md).
 
-### Dev-loop subagent (post-dispatch)
-
-The subagent resolves authoritative state via the startup resolver (`npx dev-loops loop startup --issue <n>` for issues, `npx dev-loops loop startup --pr <n>` for PRs), then immediately builds the handoff envelope via `npx dev-loops loop build-envelope --input <resolver-output.json>`. The envelope determines `requiredReads`, `nextAction`, `stopRules`, and `acceptance` — load only those files, execute only that bounded task. It is the first handoff artifact consumed before loading any route pack. See [Workflow Handoff Contract](../docs/workflow-handoff-contract.md) for the derivation contract.
+Resolve authoritative state via the startup resolver (`npx dev-loops loop startup --issue <n>` for issues, `npx dev-loops loop startup --pr <n>` for PRs), then immediately build the handoff envelope via `npx dev-loops loop build-envelope --input <resolver-output.json>`. The envelope determines `requiredReads`, `nextAction`, `stopRules`, and `acceptance` — load only those files, execute only that bounded task. It is the first handoff artifact consumed before loading any route pack. See [Workflow Handoff Contract](../docs/workflow-handoff-contract.md) for the derivation contract.
 
 **Retrospective checkpoint gate:** the resolver reads `.pi/dev-loop-retrospective-checkpoint.json` and injects the state. When the checkpoint is `missing` and the repo config `workflow.requireRetrospective` (set via `.devloops` at repo root) is `true`, the resolver returns `needs_reconcile`. Complete or explicitly skip the retrospective before starting.
 
-**Pre-delegation gate (mandatory — subagent only):** Before delegating async work targeting an existing PR, the dev-loop subagent must run `node scripts/loop/copilot-pr-handoff.mjs --repo <owner/name> --pr <number>` and abort if `action: "stop"`. When `terminal: true`, proceed inline. When `terminal: false`, resolve the blocking condition first.
+**Pre-flight PR gate (mandatory):** Before working an existing PR, the dev-loop must run `node scripts/loop/copilot-pr-handoff.mjs --repo <owner/name> --pr <number>` and abort if `action: "stop"`. When `terminal: true`, proceed inline. When `terminal: false`, resolve the blocking condition first.
 
-**Worktree cwd (mandatory — subagent only):** Always use a worktree checkout for git operations, file reads/writes, and validation commands — never use the `main` checkout.
+**Worktree cwd (mandatory):** Always use a worktree checkout for git operations, file reads/writes, and validation commands — never use the `main` checkout.
 
-**Worktree fetch (mandatory — subagent only):** Always run `git fetch origin` before creating or reusing any worktree.
+**Worktree fetch (mandatory):** Always run `git fetch origin` before creating or reusing any worktree.
 
 ### Resume from existing loop state
 
@@ -87,7 +83,6 @@ Do not preload route packs before the resolver selects the strategy.
 
 **Async dispatch rule (enforced):** the resolver fails closed for GitHub-first strategies when `canonicalStateSummary.requiresAsyncDispatch` is `true` (default `required` mode) — inline invocation without an async run-id marker (`DEVLOOPS_RUN_ID`, or the `PI_SUBAGENT_RUN_ID` alias) is rejected for those routes. Under the Claude Code harness this requirement is relaxed automatically. See [Startup procedure](#startup-procedure).
 
-
 ## Fallback gate-comment poster
 
 When the `@dev-loops/core` package is not installed in the consumer repo, the full `scripts/github/upsert-checkpoint-verdict.mjs` helper (referenced from the copilot-pr-followup skill procedure) is unavailable. To keep the PR audit trail intact in that mode, the dev-loop skill ships a small gh-only fallback poster at `scripts/post-gate-verdict-fallback.mjs` (relative to the dev-loop skill root) that renders the same visible comment format and fails closed if posting cannot succeed.
@@ -134,7 +129,7 @@ All PRs must pass the full gate pipeline before merge. No scope is exempt: docs-
 ## Authority boundary
 
 - Source code, tests, config, CI, and shared contract docs are authoritative.
-- Main-agent delegation contract: [Main Agent Contract](../docs/main-agent-contract.md) — absolute read-only boundary; all mutations flow through `dev-loop` async subagent.
+- Main-agent delegation contract: [Main Agent Contract](../docs/main-agent-contract.md) — how dev-loop work is structured per harness (Pi: read-only main agent + async-subagent dispatch; Claude: a single agent runs the steps directly).
 - Before any state-changing action, get explicit confirmation unless already authorized.
 - A question requires an answer, not an action.
 - Stop and ask rather than guessing when facts don't agree.

--- a/.claude/skills/docs/main-agent-contract.md
+++ b/.claude/skills/docs/main-agent-contract.md
@@ -1,85 +1,13 @@
 # Main-agent delegation contract
 
-> **Absolute read-only boundary.** The main agent must never mutate files tracked by the repository.
-> All mutations flow through the `dev-loop` async subagent.
+How dev-loop work is structured depends on the harness.
 
-## Contract
+**Under the Claude Code harness, the dev-loop runs as a single agent.** The agent invoked for
+dev-loop work performs the steps directly — it reads and writes repository files, runs git and PR
+lifecycle operations, runs the `dev-loops` CLI (including state-changing `gate` / `pr` / `loop`
+subcommands), and posts gate verdicts under the operating session's identity. There is no separate
+read-only "main agent" and no mandatory async-subagent dispatch: the dev-loop agent owns the work
+end to end. The draft-gate `gh pr ready` guard still applies (harness-agnostic). A read-only
+boundary can be re-imposed optionally via the Write/Edit guard hook — opt-in with
+`DEVLOOPS_MAIN_AGENT_READONLY=1` (default fail-open) — for repos that want it.
 
-The main agent is **read-only** for every file tracked by the repository. Every
-write, edit, delete, commit, branch, push, and PR lifecycle operation must flow
-through the `dev-loop` async subagent.
-
-This contract is a hard rule, not a default or guideline. The main agent must
-never rationalize a direct mutation — not because the work is small, not
-because "the user said yes," not because it is running from a worktree.
-
-## Main agent owns (allowed)
-
-- Read, inspect, search any repo file
-- `git worktree list`, `git status`, `git log` (read-only git). `git fetch` is also allowed (updates local refs but does not touch tracked working-tree files).
-- `gh issue view / create / edit / comment / close` (GitHub API, not file mutations)
-- `gh pr view / list` (read-only GitHub API)
-- Write to `/tmp` or other non-repo paths (e.g., issue body drafts)
-- Delegate to the `dev-loop` agent (async, with worktree cwd)
-- Report findings, ask questions, get confirmation
-- `npm test`, `npm run verify` (read-only validation)
-
-## Main agent must NEVER
-
-- `write`, `edit`, or delete any file tracked by the repo
-- `git commit`, `git push`, create branches, create worktrees
-- Run state-changing dev-loops CLI subcommands (`gate`, any state-changing `loop` subcommand, `pr` commands — those belong inside `dev-loop`).
-- Delegate implementation to any agent other than `dev-loop`
-
-## Dev-loop agent (async) owns
-
-- ALL file mutations in the repo (write, edit, delete)
-- ALL git operations (branch, commit, push)
-- ALL PR lifecycle (create, draft, review, merge)
-- Sub-delegation to developer, fixer, review, quality agents
-
-## Boundary examples
-
-| Operation | Verdict |
-|---|---|
-| `gh issue create --title "..." --body "..."` | Allowed — mutates GitHub, not files tracked by the repository |
-| Write to `/tmp/issue-body.md` | Allowed — outside the repo |
-| Write to `packages/core/src/foo.mjs` | **BREACH** — must delegate to `dev-loop` |
-| `git status` | Allowed — read-only |
-| `git commit -m "..."` | **BREACH** — must delegate to `dev-loop` |
-| `subagent dev-loop` | Allowed — correct delegation |
-| `subagent fixer` | Allowed only when called from within `dev-loop`; describe the task as part of the message |
-
-## Dev-loop startup
-
-When a user triggers the dev loop, the main agent must immediately dispatch the
-`dev-loop` async subagent. The subagent owns the startup resolver, route selection,
-and all subsequent implementation steps. The main agent never runs `dev-loops loop startup`
-directly.
-
-## Enforcement posture
-
-- Under **Pi**, this contract is enforced by convention and review.
-- Under **Claude Code**, the **Edit/Write tool** path is enforced **mechanically** by a
-  `PreToolUse` Write/Edit hook (`.claude/hooks/pre-tool-use-write-guard.mjs`, wired via
-  `.claude/settings.json` for this repo's own sessions and via `.claude/hooks/hooks.json` for the
-  Claude plugin): a Write/Edit whose target is inside the repo working tree and not
-  gitignored is **denied** when it originates from the main agent, and allowed only inside the
-  `dev-loop` subagent context (detected via the neutral `DEVLOOPS_RUN_ID` run-id contract, or
-  the dev-loop `agent_type` — a generic subagent is not authorized).
-  Strict enforcement is opt-in via `DEVLOOPS_MAIN_AGENT_READONLY=1` (default fail-open) so
-  adopting the harness does not retroactively break a repo's own interactive dev; full run-id
-  propagation into the Claude subagent context completes with the headless/agent wiring.
-- **Scope of mechanical enforcement:** the hook covers the Edit and Write tools. Bash-driven
-  repo mutations the contract also forbids (`git commit`/`git push`/branch creation, in-place
-  edits like `sed -i`, shell redirection `> file` / `tee`) run through the Bash tool and remain
-  **convention-enforced** for now; the only Bash command the gate hook blocks is the ungated
-  `gh pr ready`. Tightening Bash-mutation coverage is possible follow-up.
-- A companion `PreToolUse` Bash hook reproduces the `gh pr ready` draft-gate guard.
-- A `dev-loop` async subagent should still reject delegation attempts that bypass the contract.
-
-## Non-goals
-
-- Pre-commit hooks (out of scope; the boundary is enforced at the Claude tool layer).
-- Changing dev-loop resolver behavior
-- Modifying the subagent API itself

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.4
+
+### Changed
+
+- **Claude Code: the dev-loop runs as a single agent** (#837). The Pi "umbrella" execution model —
+  a strictly read-only main agent that must dispatch an async `dev-loop` subagent, with all
+  mutations and state-changing CLI (`gate`/`pr`/`loop`) confined to that subagent — is now scoped
+  to Pi only. Under the Claude harness the dev-loop agent performs the steps directly: it reads and
+  writes repo files, runs git/PR operations, runs the `dev-loops` CLI, and **posts gate verdicts
+  under the operating session's identity** (fixing clean gates that previously stalled, unable to
+  record their verdict without separate "coordinator authority"). The `gh pr ready` draft-gate
+  guard still applies, and the read-only boundary remains available opt-in via
+  `DEVLOOPS_MAIN_AGENT_READONLY=1`. Implemented by scoping the Pi read-only/dispatch contract in
+  `main-agent-contract.md` and the dev-loop skill's startup procedure behind `<!-- pi-only -->`
+  markers; the asset generator now applies that stripping to bundled contract docs too, so the
+  Claude plugin ships the single-agent model while Pi keeps the full contract. Pi behavior is
+  unchanged. (Follow-up #838 tracks the copilot-pr-followup/conductor async-execution model.)
+
 ## 0.2.3
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "dev-loops",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dev-loops",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "workspaces": [
         "packages/*"
       ],
       "dependencies": {
-        "@dev-loops/core": "^0.2.3",
+        "@dev-loops/core": "^0.2.4",
         "mermaid": "11.15.0"
       },
       "bin": {
@@ -3725,7 +3725,7 @@
     },
     "packages/core": {
       "name": "@dev-loops/core",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "mermaid": "11.15.0",
-    "@dev-loops/core": "^0.2.3"
+    "@dev-loops/core": "^0.2.4"
   },
   "repository": {
     "type": "git",
@@ -78,7 +78,7 @@
     "url": "https://github.com/mfittko/dev-loops/issues"
   },
   "homepage": "https://github.com/mfittko/dev-loops#readme",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "files": [
     "cli/",
     "lib/",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev-loops/core",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "description": "Shared deterministic support package for dev-loop skills, repo-local scripts, and GitHub automation.",
   "exports": {

--- a/scripts/claude/generate-claude-assets.mjs
+++ b/scripts/claude/generate-claude-assets.mjs
@@ -14,7 +14,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { transformAgent, transformSkill } from "@dev-loops/core/claude/asset-generation";
+import { transformAgent, transformSkill, stripPiOnlyBlocks } from "@dev-loops/core/claude/asset-generation";
 
 /**
  * Collect the generated assets as { target, content } pairs (target is repo-relative).
@@ -63,7 +63,12 @@ export function collectGeneratedAssets({ repoRoot = process.cwd() } = {}) {
   return assets;
 }
 
-/** Recursively collect `*.md` files under a source dir as verbatim {target, content} bundle assets. */
+/**
+ * Recursively collect `*.md` files under a source dir as {target, content} bundle assets.
+ * Bodies are passed through `stripPiOnlyBlocks` so bundled contract docs can scope Pi-runtime
+ * prose out of the Claude copies via `<!-- pi-only -->` markers (a no-op for marker-free docs,
+ * so the existing verbatim bundle is unchanged).
+ */
 function collectBundle(repoRoot, srcRel, targetRel) {
   const out = [];
   const absDir = path.join(repoRoot, srcRel);
@@ -74,7 +79,7 @@ function collectBundle(repoRoot, srcRel, targetRel) {
     } else if (entry.name.endsWith(".md")) {
       out.push({
         target: `${targetRel}/${entry.name}`,
-        content: fs.readFileSync(path.join(absDir, entry.name), "utf8"),
+        content: stripPiOnlyBlocks(fs.readFileSync(path.join(absDir, entry.name), "utf8")),
       });
     }
   }

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -48,7 +48,7 @@ Resolve authoritative state via the startup resolver (`npx dev-loops loop startu
 
 When the startup resolver returns a fresh-start routing but an existing outer-loop checkpoint
 (`tmp/copilot-loop/<owner>/<repo>/pr-<n>/outer-loop-state.json`) is present on disk, the
-subagent must check the checkpoint before treating the start as a fresh intake or follow-up:
+dev-loop must check the checkpoint before treating the start as a fresh intake or follow-up:
 
 1. Read the outer-loop checkpoint (authored by `outer-loop.mjs`).
 2. If `outerAction` is `continue_wait`, `reenter_copilot_loop`, or `reenter_reviewer_loop`:
@@ -109,14 +109,14 @@ When `@dev-loops/core` is available again, switch back to the full helper. The f
 
 ## Read-only info shortcut
 
-The main agent may handle info/handoff requests directly via `npx dev-loops loop info` without dispatching the async `dev-loop` subagent:
+Info/handoff requests can be served directly via `npx dev-loops loop info` (read-only; no full dev-loop run required):
 - `npx dev-loops loop info --issue <n>` — human-readable issue state summary (strategy, route, linked PR, next action)
 - `npx dev-loops loop info --pr <n>` — human-readable PR state summary (branch, CI, threads, rounds, action)
 - `npx dev-loops loop info --issue <n> --json` — machine-readable JSON output
 
-## Guard rules (subagent reference)
+## Guard rules
 
-**Handoff envelope precedence:** The subagent builds the envelope immediately after authoritative-state resolution and treats it as the first handoff artifact. Read it first, load only `requiredReads`, execute `nextAction`. See [Dev-loop subagent](#dev-loop-subagent-post-dispatch). Derivation contract: [Workflow Handoff Contract](../docs/workflow-handoff-contract.md).
+**Handoff envelope precedence:** The dev-loop builds the envelope immediately after authoritative-state resolution and treats it as the first handoff artifact. Read it first, load only `requiredReads`, execute `nextAction`. See [Resolve authoritative state](#resolve-authoritative-state). Derivation contract: [Workflow Handoff Contract](../docs/workflow-handoff-contract.md).
 
 **Handoff contract rule:** When no envelope is present, use the `workflow-handoff-contract.md` contract. Never delegate with abbreviated task summaries. Include deterministic routing inputs, explicit `cwd`, bounded task scope, exit conditions.
 

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -22,23 +22,27 @@ Required installed runtime contract docs are shared bundled copies under `../doc
 
 ## Startup procedure
 
+<!-- pi-only -->
 ### Main agent (read-only)
 
 The main agent must **always** dispatch the `dev-loop` async subagent for any dev-loop work.
 Do not run `dev-loops loop startup` or any startup resolver in the main agent.
 For async-required routes (config `workflow.asyncStartMode`, default `required`) the resolver needs an async run-id marker (`DEVLOOPS_RUN_ID`, or the `PI_SUBAGENT_RUN_ID` alias) that the Pi harness injects when it dispatches the async subagent; under the Claude Code harness the requirement is relaxed automatically (no marker needed). The startup resolver also runs without a marker for non-async routes. Regardless, only the `dev-loop` subagent runs it — never the main agent.
+<!-- /pi-only -->
 
-### Dev-loop subagent (post-dispatch)
+### Resolve authoritative state
 
-The subagent resolves authoritative state via the startup resolver (`npx dev-loops loop startup --issue <n>` for issues, `npx dev-loops loop startup --pr <n>` for PRs), then immediately builds the handoff envelope via `npx dev-loops loop build-envelope --input <resolver-output.json>`. The envelope determines `requiredReads`, `nextAction`, `stopRules`, and `acceptance` — load only those files, execute only that bounded task. It is the first handoff artifact consumed before loading any route pack. See [Workflow Handoff Contract](../docs/workflow-handoff-contract.md) for the derivation contract.
+> Under the Claude Code harness the dev-loop runs as a single agent: run these steps directly — no read-only boundary and no separate async-subagent dispatch. See [Main Agent Contract](../docs/main-agent-contract.md).
+
+Resolve authoritative state via the startup resolver (`npx dev-loops loop startup --issue <n>` for issues, `npx dev-loops loop startup --pr <n>` for PRs), then immediately build the handoff envelope via `npx dev-loops loop build-envelope --input <resolver-output.json>`. The envelope determines `requiredReads`, `nextAction`, `stopRules`, and `acceptance` — load only those files, execute only that bounded task. It is the first handoff artifact consumed before loading any route pack. See [Workflow Handoff Contract](../docs/workflow-handoff-contract.md) for the derivation contract.
 
 **Retrospective checkpoint gate:** the resolver reads `.pi/dev-loop-retrospective-checkpoint.json` and injects the state. When the checkpoint is `missing` and the repo config `workflow.requireRetrospective` (set via `.devloops` at repo root) is `true`, the resolver returns `needs_reconcile`. Complete or explicitly skip the retrospective before starting.
 
-**Pre-delegation gate (mandatory — subagent only):** Before delegating async work targeting an existing PR, the dev-loop subagent must run `node scripts/loop/copilot-pr-handoff.mjs --repo <owner/name> --pr <number>` and abort if `action: "stop"`. When `terminal: true`, proceed inline. When `terminal: false`, resolve the blocking condition first.
+**Pre-flight PR gate (mandatory):** Before working an existing PR, the dev-loop must run `node scripts/loop/copilot-pr-handoff.mjs --repo <owner/name> --pr <number>` and abort if `action: "stop"`. When `terminal: true`, proceed inline. When `terminal: false`, resolve the blocking condition first.
 
-**Worktree cwd (mandatory — subagent only):** Always use a worktree checkout for git operations, file reads/writes, and validation commands — never use the `main` checkout.
+**Worktree cwd (mandatory):** Always use a worktree checkout for git operations, file reads/writes, and validation commands — never use the `main` checkout.
 
-**Worktree fetch (mandatory — subagent only):** Always run `git fetch origin` before creating or reusing any worktree.
+**Worktree fetch (mandatory):** Always run `git fetch origin` before creating or reusing any worktree.
 
 ### Resume from existing loop state
 
@@ -135,7 +139,7 @@ All PRs must pass the full gate pipeline before merge. No scope is exempt: docs-
 ## Authority boundary
 
 - Source code, tests, config, CI, and shared contract docs are authoritative.
-- Main-agent delegation contract: [Main Agent Contract](../docs/main-agent-contract.md) — absolute read-only boundary; all mutations flow through `dev-loop` async subagent.
+- Main-agent delegation contract: [Main Agent Contract](../docs/main-agent-contract.md) — how dev-loop work is structured per harness (Pi: read-only main agent + async-subagent dispatch; Claude: a single agent runs the steps directly).
 - Before any state-changing action, get explicit confirmation unless already authorized.
 - A question requires an answer, not an action.
 - Stop and ask rather than guessing when facts don't agree.

--- a/skills/docs/main-agent-contract.md
+++ b/skills/docs/main-agent-contract.md
@@ -1,6 +1,18 @@
 # Main-agent delegation contract
 
-> **Absolute read-only boundary.** The main agent must never mutate files tracked by the repository.
+How dev-loop work is structured depends on the harness.
+
+**Under the Claude Code harness, the dev-loop runs as a single agent.** The agent invoked for
+dev-loop work performs the steps directly — it reads and writes repository files, runs git and PR
+lifecycle operations, runs the `dev-loops` CLI (including state-changing `gate` / `pr` / `loop`
+subcommands), and posts gate verdicts under the operating session's identity. There is no separate
+read-only "main agent" and no mandatory async-subagent dispatch: the dev-loop agent owns the work
+end to end. The draft-gate `gh pr ready` guard still applies (harness-agnostic). A read-only
+boundary can be re-imposed optionally via the Write/Edit guard hook — opt-in with
+`DEVLOOPS_MAIN_AGENT_READONLY=1` (default fail-open) — for repos that want it.
+
+<!-- pi-only -->
+> **Absolute read-only boundary (Pi).** The main agent must never mutate files tracked by the repository.
 > All mutations flow through the `dev-loop` async subagent.
 
 ## Contract
@@ -83,3 +95,4 @@ directly.
 - Pre-commit hooks (out of scope; the boundary is enforced at the Claude tool layer).
 - Changing dev-loop resolver behavior
 - Modifying the subagent API itself
+<!-- /pi-only -->

--- a/test/contracts/claude-assets-reproducible.test.mjs
+++ b/test/contracts/claude-assets-reproducible.test.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { collectGeneratedAssets, checkAssets, writeAssets } from "../../scripts/claude/generate-claude-assets.mjs";
+import { stripPiOnlyBlocks } from "../../packages/core/src/claude/asset-generation.mjs";
 
 // #772: the committed .claude tree must be byte-reproducible from the canonical sources.
 // If a source agent/skill changes, the generator must be re-run and the result committed.
@@ -22,8 +23,10 @@ test("shared docs + dev-loop templates are bundled so generated skill links reso
   // A representative `../dev-loop/templates/` link target.
   assert.ok(targets.has(".claude/skills/dev-loop/templates/phase-doc.md"), "dev-loop template must be bundled");
 
-  // EVERY bundled file must be byte-identical to its source (verbatim copy). Bundled targets map
-  // back to source by dropping the `.claude/skills/` prefix → `skills/<...>`.
+  // EVERY bundled file must equal its source with `<!-- pi-only -->` blocks stripped (#837).
+  // For marker-free docs this is a verbatim copy (stripPiOnlyBlocks is a no-op); docs that scope
+  // Pi-runtime prose (e.g. main-agent-contract.md) bundle their Claude-applicable subset. Bundled
+  // targets map back to source by dropping the `.claude/skills/` prefix → `skills/<...>`.
   const bundlePrefixes = [".claude/skills/docs/", ".claude/skills/dev-loop/templates/"];
   const bundled = assets.filter((a) => bundlePrefixes.some((p) => a.target.startsWith(p)));
   assert.ok(bundled.length >= 30, `expected the full bundled set, got ${bundled.length}`);
@@ -31,10 +34,21 @@ test("shared docs + dev-loop templates are bundled so generated skill links reso
     const source = asset.target.replace(/^\.claude\/skills\//, "skills/");
     assert.equal(
       asset.content,
-      fs.readFileSync(path.join(repoRoot, source), "utf8"),
-      `${asset.target} must be a verbatim copy of ${source}`,
+      stripPiOnlyBlocks(fs.readFileSync(path.join(repoRoot, source), "utf8")),
+      `${asset.target} must be its source with pi-only blocks stripped (${source})`,
     );
   }
+
+  // The Claude bundle of main-agent-contract.md must drop the Pi read-only/dispatch contract
+  // (collapsed umbrella, #837) while the source retains it.
+  const contract = bundled.find((a) => a.target.endsWith("docs/main-agent-contract.md"));
+  assert.ok(contract, "main-agent-contract.md must be bundled");
+  assert.equal(contract.content.includes("Main agent must NEVER"), false, "Claude bundle must drop the Pi read-only contract");
+  assert.match(contract.content, /the dev-loop runs as a single agent/i, "Claude bundle must state the single-agent model");
+  assert.ok(
+    fs.readFileSync(path.join(repoRoot, "skills/docs/main-agent-contract.md"), "utf8").includes("Main agent must NEVER"),
+    "source must retain the Pi read-only contract",
+  );
 });
 
 test("Pi-runtime-only prose is stripped from generated assets but retained in source (#817)", () => {


### PR DESCRIPTION
Closes #837.

## Problem
On Claude Code the dev-loop self-blocked on the Pi execution model: a **clean draft gate could not record its verdict** because posting it 'under the user's identity' violated the Pi *coordinator-authority / read-only-main / async-subagent-dispatch* contract. The Pi umbrella (read-only main agent → dispatch async `dev-loop` subagent → all mutations & state-changing CLI inside it) doesn't fit Claude's single-identity, direct-tool model.

## Change — collapse the umbrella on Claude
Scope the Pi umbrella behind `<!-- pi-only -->` so it applies to **Pi only**. Under Claude the dev-loop agent runs the steps directly and posts gate verdicts under the operating session's identity:
- **`main-agent-contract.md`**: prepend a Claude single-agent section; wrap the strict Pi read-only/dispatch contract in `pi-only` (source retains it; Claude bundle drops it).
- **dev-loop SKILL startup procedure**: `pi-only` the 'Main agent (read-only)' dispatch mandate; neutralize the `subagent-only` qualifiers and the contract-reference clause.
- **Generator**: `collectBundle` now runs `stripPiOnlyBlocks` on bundled contract docs (no-op for marker-free docs → existing bundle unchanged), so docs can scope Pi prose out of the Claude copies.
- Read-only boundary stays **opt-in** (`DEVLOOPS_MAIN_AGENT_READONLY=1`); the `gh pr ready` draft-gate guard is unchanged; **Pi behavior unchanged** (Pi reads the source verbatim, including the pi-only contract).

## Scope
This collapses the **core** umbrella (the part causing the blocker). The deeper copilot-pr-followup/conductor async-execution model is tracked in **#838**.

## Verification
- Generated Claude `main-agent-contract.md` is single-agent (no "Main agent must NEVER"); source retains the full Pi contract. Locked by an updated #816 bundle test (asserts stripped-not-verbatim + the collapsed contract).
- `npm run verify` green (0 fail; no asset drift; 356 links). `npm ci` validates the lockfile (version-only 0.2.4 bump).

Release **0.2.4**.