### PR TITLE
fix(claude): make plugin hooks self-contained so they load from the plugin cache (#843)

### DIFF
--- a/.claude/hooks/_bash-command-classify.mjs
+++ b/.claude/hooks/_bash-command-classify.mjs
@@ -1,0 +1,164 @@
+// GENERATED from packages/core/src/loop/bash-command-classify.mjs by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate.
+/**
+ * Pure classification of shell command strings for the dev-loop gate boundary.
+ *
+ * Shared by the Pi extension (`extension/post-merge-update.ts`, which re-exports these so its
+ * behavior is unchanged) and the Claude Code PreToolUse Bash hook. Keeping one source of truth
+ * means the `gh pr ready` / merge detection is identical across harnesses.
+ *
+ * Pure and side-effect free.
+ */
+
+/** The repository these gate guards apply to. */
+export const TARGET_REPO_SLUG = "mfittko/dev-loops";
+
+/** Flags known to take a value argument for `gh pr ready` (not boolean flags). */
+export const FLAGS_THAT_TAKE_VALUE = new Set(["-r", "--repo"]);
+
+/** @param {string|null|undefined} value @returns {string|null} */
+export function trimToNull(value) {
+  const trimmed = `${value ?? ""}`.trim();
+  return trimmed ? trimmed : null;
+}
+
+/**
+ * Normalize a git remote URL into an `owner/name` slug (lowercased), or null.
+ * @param {string} remoteUrl
+ * @returns {string|null}
+ */
+export function normalizeGitHubRepoSlug(remoteUrl) {
+  const normalized = trimToNull(remoteUrl);
+  if (!normalized) {
+    return null;
+  }
+
+  const patterns = [
+    /^git@github\.com:([^\s]+?)(?:\.git)?$/i,
+    /^https?:\/\/github\.com\/([^\s]+?)(?:\.git)?$/i,
+    /^ssh:\/\/git@github\.com\/([^\s]+?)(?:\.git)?$/i,
+    /^git:\/\/github\.com\/([^\s]+?)(?:\.git)?$/i,
+    /^git:github\.com\/([^\s]+?)(?:\.git)?$/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = normalized.match(pattern);
+    if (!match) {
+      continue;
+    }
+    return trimToNull(match[1])?.toLowerCase() ?? null;
+  }
+
+  return null;
+}
+
+function isGhPrMergeCommand(segment) {
+  if (!/^gh\s+pr\s+merge(?:\s|$)/i.test(segment)) {
+    return false;
+  }
+  const remainder = segment.replace(/^gh\s+pr\s+merge(?:\s|$)/i, "").trim();
+  if (!remainder) {
+    return true;
+  }
+  const firstArg = remainder.match(/^(\S+)/)?.[1]?.toLowerCase() ?? "";
+  return !["--help", "-h"].includes(firstArg);
+}
+
+function isGitMergeCompletionCommand(segment) {
+  if (!/^git\s+merge(?:\s|$)/i.test(segment)) {
+    return false;
+  }
+  const remainder = segment.replace(/^git\s+merge(?:\s|$)/i, "").trim();
+  if (!remainder) {
+    return true;
+  }
+  const firstArg = remainder.match(/^(\S+)/)?.[1]?.toLowerCase() ?? "";
+  return !["--abort", "--continue", "--quit", "--help", "-h"].includes(firstArg);
+}
+
+/** @param {string} command @returns {boolean} */
+export function isMergeCapableCommand(command) {
+  const normalized = command.trim();
+  if (!normalized) {
+    return false;
+  }
+  return normalized
+    .split(/\s*(?:&&|\|\||;|\|)\s*/)
+    .some((segment) => isGhPrMergeCommand(segment) || isGitMergeCompletionCommand(segment));
+}
+
+/** @param {string} command @returns {string} */
+export function firstShellSegment(command) {
+  return command.trim().split(/\s*(?:&&|\|\||;|\|)\s*/)[0]?.trim() ?? "";
+}
+
+/** @param {string} command @returns {boolean} */
+export function isGhPrReadyCommand(command) {
+  const segment = firstShellSegment(command);
+  if (!segment || !/^gh\s+pr\s+ready(?:\s|$)/i.test(segment)) {
+    return false;
+  }
+  const remainder = segment.replace(/^gh\s+pr\s+ready(?:\s|$)/i, "").trim();
+  if (!remainder) {
+    return true;
+  }
+  const args = remainder.split(/\s+/).map((a) => a.toLowerCase());
+  return !args.includes("--help") && !args.includes("-h");
+}
+
+/** @param {string} command @returns {number|null} */
+export function extractPrNumberFromGhPrReady(command) {
+  const segment = firstShellSegment(command);
+  if (!/^gh\s+pr\s+ready(?:\s|$)/i.test(segment)) {
+    return null;
+  }
+  const remainder = segment.replace(/^gh\s+pr\s+ready(?:\s|$)/i, "").trim();
+  if (!remainder) {
+    return null;
+  }
+  const tokens = remainder.split(/\s+/);
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (token.startsWith("-")) {
+      const flagName = token.replace(/=.*$/, "").toLowerCase();
+      if (!token.includes("=") && FLAGS_THAT_TAKE_VALUE.has(flagName)) {
+        i++;
+      }
+      continue;
+    }
+    if (/^\d+$/.test(token)) {
+      const num = Number(token);
+      if (num > 0) {
+        return num;
+      }
+    }
+    return null;
+  }
+  return null;
+}
+
+/** @param {string} command @returns {string|null} */
+export function extractRepoFlagFromGhPrReady(command) {
+  const segment = firstShellSegment(command);
+  if (!/^gh\s+pr\s+ready(?:\s|$)/i.test(segment)) {
+    return null;
+  }
+  const remainder = segment.replace(/^gh\s+pr\s+ready(?:\s|$)/i, "").trim();
+  if (!remainder) {
+    return null;
+  }
+  const tokens = remainder.split(/\s+/);
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    const lower = token.toLowerCase();
+    if (lower === "-r" || lower === "--repo") {
+      if (i + 1 < tokens.length && !tokens[i + 1].startsWith("-")) {
+        return tokens[i + 1];
+      }
+    }
+    const repoEqMatch = token.match(/^(?:--repo|-R)=(.+)$/i);
+    if (repoEqMatch) {
+      return repoEqMatch[1];
+    }
+  }
+  return null;
+}

--- a/.claude/hooks/_hook-decisions.mjs
+++ b/.claude/hooks/_hook-decisions.mjs
@@ -1,0 +1,130 @@
+// GENERATED from packages/core/src/claude/hook-decisions.mjs by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate.
+/**
+ * Pure decision logic for the Claude Code dev-loop hooks (#773).
+ *
+ * The hook *scripts* are thin: they read the PreToolUse/PostToolUse stdin payload, gather facts
+ * (git tracked/ignored status, gate-evidence result), and call these pure deciders. Keeping the
+ * decisions here makes the deny/allow boundary fully unit-testable without spawning hooks, and
+ * keeps the Claude-specific stdin/stdout IO at the edge.
+ *
+ * Pure and side-effect free.
+ */
+
+import { resolveRunId } from "./_run-context.mjs";
+import {
+  isGhPrReadyCommand,
+  extractPrNumberFromGhPrReady,
+  extractRepoFlagFromGhPrReady,
+  TARGET_REPO_SLUG,
+} from "./_bash-command-classify.mjs";
+
+/**
+ * @typedef {Object} HookDecision
+ * @property {"allow"|"deny"} decision
+ * @property {string} [reason] - Human-readable reason (shown to Claude on deny).
+ */
+
+const ALLOW = Object.freeze({ decision: "allow" });
+
+/**
+ * The agent type (Claude `agent_type` / the canonical agent name) that owns repo mutations.
+ * Only this subagent — not arbitrary subagents (Explore, Plan, generic Task agents) — may
+ * bypass the main-agent read-only boundary.
+ */
+export const DEV_LOOP_AGENT_TYPE = "dev-loop";
+
+/**
+ * Decide whether a PreToolUse Bash command must be blocked by the draft-gate boundary.
+ *
+ * Mirrors the Pi extension's `onUserBash`: the only blocked case is `gh pr ready` for the
+ * target repo without clean draft_gate evidence. Everything else (including merges, which
+ * trigger the post-merge step, not a block) is allowed through.
+ *
+ * @param {Object} params
+ * @param {string} params.command - The Bash command string.
+ * @param {string|null} [params.repoSlug] - Resolved owner/name of the cwd repo (null if unknown).
+ * @param {boolean} [params.gatePassed] - Whether `pre-pr-ready-gate` evidence exists for the PR.
+ * @param {string|null} [params.gateError] - Error detail when the gate guard could not run.
+ * @returns {HookDecision}
+ */
+export function decideBashGate({ command, repoSlug = null, gatePassed = false, gateError = null }) {
+  if (typeof command !== "string" || !isGhPrReadyCommand(command)) {
+    return ALLOW;
+  }
+
+  // An explicit `--repo other/repo` that is not the target → not our concern, pass through.
+  const explicitRepo = extractRepoFlagFromGhPrReady(command);
+  if (explicitRepo && explicitRepo.toLowerCase() !== TARGET_REPO_SLUG.toLowerCase()) {
+    return ALLOW;
+  }
+  // Only gate within the target repo (case-insensitive — callers may pass an un-lowercased slug).
+  if ((repoSlug ?? "").toLowerCase() !== TARGET_REPO_SLUG.toLowerCase()) {
+    return ALLOW;
+  }
+
+  const prNumber = extractPrNumberFromGhPrReady(command);
+  if (prNumber === null) {
+    return {
+      decision: "deny",
+      reason:
+        "gh pr ready blocked: could not determine the PR number from the command. Include the PR number explicitly.",
+    };
+  }
+
+  if (gateError) {
+    return {
+      decision: "deny",
+      reason: `gh pr ready blocked: draft-gate evidence check failed (${gateError}).`,
+    };
+  }
+
+  if (!gatePassed) {
+    return {
+      decision: "deny",
+      reason: `gh pr ready blocked: no visible clean draft_gate checkpoint verdict comment found for PR #${prNumber}.`,
+    };
+  }
+
+  return ALLOW;
+}
+
+/**
+ * Decide whether a PreToolUse Write/Edit must be blocked by the main-agent read-only boundary.
+ *
+ * Denies a mutation whose target is inside the repo working tree AND not gitignored, when the
+ * call originates from the MAIN agent. Allows it only inside the *dev-loop* subagent context:
+ * the CA2 run id (`DEVLOOPS_RUN_ID`) is present, or the Claude `agent_type` is the dev-loop
+ * agent. A generic subagent (Explore, Plan, an arbitrary Task agent) is NOT authorized — the
+ * contract requires mutations to flow through the dev-loop subagent specifically. Non-repo /
+ * gitignored paths are always allowed. Strict enforcement is opt-in via `enforce` (the hook
+ * derives it from `DEVLOOPS_MAIN_AGENT_READONLY=1`) so adopting the harness does not
+ * retroactively break a repo's own interactive dev; default is fail-open.
+ *
+ * @param {Object} params
+ * @param {string} params.filePath - Target file path.
+ * @param {boolean} params.isRepoMutation - True if inside the repo working tree AND not gitignored.
+ * @param {boolean} [params.enforce] - Strict mode (DEVLOOPS_MAIN_AGENT_READONLY=1).
+ * @param {Record<string,string|undefined>} [params.env] - Environment (for the CA2 run id).
+ * @param {string|null} [params.agentType] - Claude `agent_type` from the hook payload, if any.
+ * @returns {HookDecision}
+ */
+export function decideWriteGuard({ filePath, isRepoMutation, enforce = false, env = {}, agentType = null }) {
+  if (!enforce) {
+    return ALLOW; // strict enforcement not enabled — fail open
+  }
+  if (!isRepoMutation) {
+    return ALLOW; // non-repo or gitignored path (e.g. /tmp, tmp/) — allowed by the contract
+  }
+  // Authorized only inside the dev-loop subagent context: CA2 run id, or the dev-loop agent
+  // type. Any other subagent type is treated like the main agent and denied.
+  if (resolveRunId(env) || agentType === DEV_LOOP_AGENT_TYPE) {
+    return ALLOW;
+  }
+  return {
+    decision: "deny",
+    reason:
+      `Main-agent read-only boundary: refusing to mutate repository path "${filePath}". ` +
+      "All repository mutations must flow through the dev-loop subagent. " +
+      "See skills/docs/main-agent-contract.md.",
+  };
+}

--- a/.claude/hooks/_hook-io.mjs
+++ b/.claude/hooks/_hook-io.mjs
@@ -4,7 +4,7 @@
  * Hooks receive the event payload as JSON on stdin and signal a PreToolUse decision either via
  * exit code 2 (stderr → Claude) or exit 0 with a `hookSpecificOutput` JSON object. We use the
  * structured JSON form so the deny reason is explicit. The decision logic itself lives in the
- * pure `@dev-loops/core/claude/hook-decisions` deciders — these helpers are only the edge IO.
+ * pure deciders in the vendored `./_hook-decisions.mjs` bundle — these helpers are only edge IO.
  */
 import { readFileSync } from "node:fs";
 

--- a/.claude/hooks/_run-context.mjs
+++ b/.claude/hooks/_run-context.mjs
@@ -1,0 +1,179 @@
+// GENERATED from packages/core/src/loop/run-context.mjs by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate.
+/**
+ * Neutral run-id / async-context contract.
+ *
+ * The dev-loop async path historically keyed off Pi's `PI_SUBAGENT_RUN_ID` env var to
+ * identify an inspectable per-subagent run (runner ownership, async-start enforcement,
+ * human-comment gating). This module generalizes that into a harness-neutral
+ * `DEVLOOPS_RUN_ID`, keeping `PI_SUBAGENT_RUN_ID` as a backward-compatible alias, and
+ * provides a mint-and-propagate path for harnesses (e.g. Claude Code) that inject no
+ * native per-subagent run id.
+ *
+ * Marker precedence is neutral-first: a present `DEVLOOPS_RUN_ID` wins; otherwise the Pi
+ * alias is honored. Existing Pi runs that set only `PI_SUBAGENT_RUN_ID` behave identically.
+ *
+ * This module is pure except for the explicit file/IO helpers (writeRunContext/readRunContext),
+ * which take an injectable `fs` and `root` for testability.
+ */
+
+import crypto from "node:crypto";
+import fsDefault from "node:fs";
+import path from "node:path";
+
+/**
+ * Env var names that carry the async-context run id, in resolution precedence order.
+ * Neutral `DEVLOOPS_RUN_ID` first; Pi `PI_SUBAGENT_RUN_ID` retained as a compatibility alias.
+ */
+export const RUN_ID_MARKERS = Object.freeze(["DEVLOOPS_RUN_ID", "PI_SUBAGENT_RUN_ID"]);
+
+/** Neutral env var name used when minting/propagating a run id. */
+export const NEUTRAL_RUN_ID_VAR = "DEVLOOPS_RUN_ID";
+
+/** Pi-compatibility alias env var name. */
+export const PI_RUN_ID_ALIAS_VAR = "PI_SUBAGENT_RUN_ID";
+
+/** State-file name (under `.pi/`, consistent with existing dev-loop checkpoint files). */
+export const RUN_CONTEXT_FILENAME = "dev-loop-run-context.json";
+
+/**
+ * Env var Claude Code sets in every tool/subagent shell it spawns.
+ * Used as the harness signal — see `isClaudeHarness`.
+ */
+export const CLAUDE_HARNESS_MARKER = "CLAUDECODE";
+
+/**
+ * True when running under the Claude Code harness.
+ *
+ * Claude Code sets `CLAUDECODE=1` in the environment of every Bash tool and
+ * subagent it spawns. This is the harness-detection seam used to relax
+ * Pi-specific runtime contracts (e.g. the async-start contract) that do not
+ * apply to Claude's execution model.
+ *
+ * @param {Record<string, string|undefined>} [env]
+ * @returns {boolean}
+ */
+export function isClaudeHarness(env = process.env) {
+  return env?.[CLAUDE_HARNESS_MARKER] === "1";
+}
+
+/**
+ * Resolve the active run id from the environment, neutral marker first.
+ *
+ * @param {Record<string, string|undefined>} [env]
+ * @returns {string|null} The trimmed run id, or null when none is set.
+ */
+export function resolveRunId(env = process.env) {
+  for (const marker of RUN_ID_MARKERS) {
+    const value = env?.[marker];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+/**
+ * Mint a fresh neutral run id.
+ *
+ * @returns {string} `devloops-<uuid>` (e.g. "devloops-3f2c1e84-...-9a0b")
+ */
+export function mintRunId() {
+  return `devloops-${crypto.randomUUID()}`;
+}
+
+/**
+ * Build the env fragment that propagates a run id to child processes.
+ *
+ * Sets the neutral var; child Bash scripts observe it via `resolveRunId`. Callers merge
+ * this into the child env (e.g. `{ ...process.env, ...runContextEnv(runId) }`).
+ *
+ * @param {string} runId
+ * @returns {{ DEVLOOPS_RUN_ID: string }}
+ */
+export function runContextEnv(runId) {
+  return { [NEUTRAL_RUN_ID_VAR]: runId };
+}
+
+/**
+ * Absolute path to the run-context state file for a repo root.
+ *
+ * @param {string} root - Repository root (or any base dir).
+ * @returns {string}
+ */
+export function runContextPath(root) {
+  return path.join(root, ".pi", RUN_CONTEXT_FILENAME);
+}
+
+/**
+ * Persist the run-context state file (for inspection/recovery).
+ *
+ * @param {object} params
+ * @param {string} params.runId
+ * @param {string} params.root
+ * @param {string} [params.mintedAt] - ISO timestamp; defaults to now. Tests pass a fixed
+ *   value for determinism; real runs get a useful inspection/recovery timestamp.
+ * @param {typeof import("node:fs")} [params.fs]
+ * @returns {string} The path written.
+ */
+export function writeRunContext({ runId, root, mintedAt, fs = fsDefault }) {
+  if (typeof runId !== "string" || runId.trim().length === 0) {
+    throw new TypeError("writeRunContext: runId must be a non-empty string");
+  }
+  const file = runContextPath(root);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const payload = {
+    runId: runId.trim(),
+    mintedAt: mintedAt ?? new Date().toISOString(),
+  };
+  fs.writeFileSync(file, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  return file;
+}
+
+/**
+ * Read the run-context state file, or null when absent/unparseable.
+ *
+ * @param {object} params
+ * @param {string} params.root
+ * @param {typeof import("node:fs")} [params.fs]
+ * @returns {{ runId: string, mintedAt: string|null }|null}
+ */
+export function readRunContext({ root, fs = fsDefault }) {
+  const file = runContextPath(root);
+  try {
+    const raw = fs.readFileSync(file, "utf8");
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed.runId === "string" && parsed.runId.trim().length > 0) {
+      return { runId: parsed.runId.trim(), mintedAt: parsed.mintedAt ?? null };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the active run id, or mint one and persist a run-context state file.
+ *
+ * This is the "mint at startup and propagate" primitive a Claude dev-loop agent (or a
+ * headless entry) calls before dispatching child work. When the env already carries a run
+ * id (Pi alias or neutral), it is reused and no new id is minted.
+ *
+ * @param {object} [params]
+ * @param {Record<string, string|undefined>} [params.env]
+ * @param {string} [params.root]
+ * @param {string} [params.mintedAt] - ISO timestamp for the state file (determinism).
+ * @param {typeof import("node:fs")} [params.fs]
+ * @returns {{ runId: string, minted: boolean, statePath: string|null }}
+ */
+export function ensureRunId({ env = process.env, root, mintedAt, fs = fsDefault } = {}) {
+  const existing = resolveRunId(env);
+  if (existing) {
+    return { runId: existing, minted: false, statePath: null };
+  }
+  const runId = mintRunId();
+  let statePath = null;
+  if (typeof root === "string" && root.length > 0) {
+    statePath = writeRunContext({ runId, root, mintedAt, fs });
+  }
+  return { runId, minted: true, statePath };
+}

--- a/.claude/hooks/post-tool-use-merge.mjs
+++ b/.claude/hooks/post-tool-use-merge.mjs
@@ -9,7 +9,7 @@
  * action is a no-op. There is therefore nothing to run on Stop/SubagentStop; the merge is simply
  * detected here on PostToolUse and an informational, non-blocking note is surfaced. Never blocks.
  */
-import { isMergeCapableCommand } from "@dev-loops/core/loop/bash-command-classify";
+import { isMergeCapableCommand } from "./_bash-command-classify.mjs";
 
 import { readHookInput } from "./_hook-io.mjs";
 

--- a/.claude/hooks/pre-tool-use-bash-gate.mjs
+++ b/.claude/hooks/pre-tool-use-bash-gate.mjs
@@ -10,13 +10,13 @@
 import { execFileSync } from "node:child_process";
 import path from "node:path";
 
-import { decideBashGate } from "@dev-loops/core/claude/hook-decisions";
+import { decideBashGate } from "./_hook-decisions.mjs";
 import {
   isGhPrReadyCommand,
   extractPrNumberFromGhPrReady,
   normalizeGitHubRepoSlug,
   TARGET_REPO_SLUG,
-} from "@dev-loops/core/loop/bash-command-classify";
+} from "./_bash-command-classify.mjs";
 
 import { readHookInput, emitDeny, emitAllow } from "./_hook-io.mjs";
 

--- a/.claude/hooks/pre-tool-use-write-guard.mjs
+++ b/.claude/hooks/pre-tool-use-write-guard.mjs
@@ -12,7 +12,7 @@
 import { execFileSync } from "node:child_process";
 import path from "node:path";
 
-import { decideWriteGuard } from "@dev-loops/core/claude/hook-decisions";
+import { decideWriteGuard } from "./_hook-decisions.mjs";
 
 import { readHookInput, emitDeny, emitAllow } from "./_hook-io.mjs";
 

--- a/scripts/claude/generate-claude-assets.mjs
+++ b/scripts/claude/generate-claude-assets.mjs
@@ -89,6 +89,11 @@ const HOOK_BUNDLE = [
   },
 ];
 
+/** Marker that identifies a generated hook-bundle module (a JS comment, distinct from the
+ * markdown `<!-- GENERATED -->` banner used by generated skills/agents/docs). Used both to
+ * stamp generated bundle modules and to scope orphan detection to them within `.claude/hooks/`. */
+const HOOK_BUNDLE_BANNER_PREFIX = "// GENERATED from ";
+
 /** Collect the vendored self-contained hook bundle modules (#843). */
 function collectHookBundle(repoRoot) {
   const out = [];
@@ -97,7 +102,7 @@ function collectHookBundle(repoRoot) {
     if (!fs.existsSync(abs)) continue; // no-op when core sources are absent (e.g. consumer tree)
     let body = fs.readFileSync(abs, "utf8");
     for (const [from, to] of rewrites) body = body.split(from).join(to);
-    const banner = `// GENERATED from ${source} by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate.\n`;
+    const banner = `${HOOK_BUNDLE_BANNER_PREFIX}${source} by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate.\n`;
     out.push({ target, content: banner + body });
   }
   return out;
@@ -154,10 +159,23 @@ function listFilesRecursive(repoRoot, rel) {
  * bundled docs/templates whose source was removed — are detected, not just SKILL.md files.
  */
 function listExistingAssetFiles(repoRoot) {
-  return [
+  const files = [
     ...listFilesRecursive(repoRoot, ".claude/agents"),
     ...listFilesRecursive(repoRoot, ".claude/skills"),
   ];
+  // `.claude/hooks/` mixes hand-authored scripts (hooks.json, _hook-io.mjs, the three hook
+  // scripts) with generated bundle modules (#843). Only the generated ones — identified by the
+  // generator banner — participate in orphan detection, so a dropped/renamed HOOK_BUNDLE entry
+  // is caught without false-flagging the hand-authored files.
+  for (const rel of listFilesRecursive(repoRoot, ".claude/hooks")) {
+    const abs = path.join(repoRoot, rel);
+    try {
+      if (fs.readFileSync(abs, "utf8").startsWith(HOOK_BUNDLE_BANNER_PREFIX)) files.push(rel);
+    } catch {
+      // unreadable — skip
+    }
+  }
+  return files;
 }
 
 /**

--- a/scripts/claude/generate-claude-assets.mjs
+++ b/scripts/claude/generate-claude-assets.mjs
@@ -60,7 +60,47 @@ export function collectGeneratedAssets({ repoRoot = process.cwd() } = {}) {
     assets.push(...collectBundle(repoRoot, srcRel, targetRel));
   }
 
+  // Self-contained hook bundle (#843). The PreToolUse/PostToolUse hook scripts under
+  // .claude/hooks/ ship inside the Claude plugin, which has no node_modules — so they cannot
+  // import `@dev-loops/core` (it is unresolvable from the plugin cache and crashes the hook on
+  // load). Vendor the pure deciders/classifiers they need as self-contained relative `_*.mjs`
+  // modules generated from the canonical core sources, with cross-module imports rewritten to
+  // local paths. The no-drift check keeps them in sync with packages/core/src.
+  assets.push(...collectHookBundle(repoRoot));
+
   return assets;
+}
+
+/**
+ * The core modules vendored into `.claude/hooks/` for the self-contained hook bundle (#843).
+ * `rewrites` rewrites cross-module import specifiers to the sibling vendored copies; node:
+ * builtins are left untouched.
+ */
+const HOOK_BUNDLE = [
+  { source: "packages/core/src/loop/bash-command-classify.mjs", target: ".claude/hooks/_bash-command-classify.mjs", rewrites: [] },
+  { source: "packages/core/src/loop/run-context.mjs", target: ".claude/hooks/_run-context.mjs", rewrites: [] },
+  {
+    source: "packages/core/src/claude/hook-decisions.mjs",
+    target: ".claude/hooks/_hook-decisions.mjs",
+    rewrites: [
+      ['"../loop/run-context.mjs"', '"./_run-context.mjs"'],
+      ['"../loop/bash-command-classify.mjs"', '"./_bash-command-classify.mjs"'],
+    ],
+  },
+];
+
+/** Collect the vendored self-contained hook bundle modules (#843). */
+function collectHookBundle(repoRoot) {
+  const out = [];
+  for (const { source, target, rewrites } of HOOK_BUNDLE) {
+    const abs = path.join(repoRoot, source);
+    if (!fs.existsSync(abs)) continue; // no-op when core sources are absent (e.g. consumer tree)
+    let body = fs.readFileSync(abs, "utf8");
+    for (const [from, to] of rewrites) body = body.split(from).join(to);
+    const banner = `// GENERATED from ${source} by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate.\n`;
+    out.push({ target, content: banner + body });
+  }
+  return out;
 }
 
 /**

--- a/test/contracts/claude-assets-reproducible.test.mjs
+++ b/test/contracts/claude-assets-reproducible.test.mjs
@@ -110,6 +110,33 @@ test("checkAssets flags an orphaned committed asset with no generating source", 
   }
 });
 
+test("checkAssets flags a stale generated hook-bundle module but not hand-authored hooks (#843)", () => {
+  // The hooks dir mixes generated bundle modules (banner-stamped) with hand-authored scripts.
+  // Orphan detection must catch a generated module no longer produced (e.g. a dropped HOOK_BUNDLE
+  // entry) while leaving hand-authored hooks (no banner) alone.
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "claude-hooks-orphan-"));
+  try {
+    const hooksDir = path.join(tmpRoot, ".claude", "hooks");
+    fs.mkdirSync(hooksDir, { recursive: true });
+    // A stale generated module: carries the generator banner, but no source produces it.
+    fs.writeFileSync(
+      path.join(hooksDir, "_stale-removed.mjs"),
+      "// GENERATED from packages/core/src/loop/gone.mjs by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate.\nexport const x = 1;\n",
+      "utf8",
+    );
+    // Hand-authored files (no banner) must never be flagged.
+    fs.writeFileSync(path.join(hooksDir, "_hook-io.mjs"), "export function readHookInput() {}\n", "utf8");
+    fs.writeFileSync(path.join(hooksDir, "hooks.json"), "{}\n", "utf8");
+
+    // No sources present in tmpRoot → collectGeneratedAssets yields nothing; the only orphan is
+    // the banner-stamped stale module.
+    const drifted = checkAssets([], { repoRoot: tmpRoot });
+    assert.deepEqual(drifted, [{ target: ".claude/hooks/_stale-removed.mjs", reason: "orphaned" }]);
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
 test("every canonical agent and non-doc skill has a generated counterpart", () => {
   const assets = collectGeneratedAssets({ repoRoot });
   const targets = assets.map((a) => a.target);

--- a/test/contracts/claude-hooks-settings.test.mjs
+++ b/test/contracts/claude-hooks-settings.test.mjs
@@ -63,6 +63,35 @@ test("the three hook scripts (+ _hook-io) exist under the plugin root", () => {
   }
 });
 
+test("the self-contained hook bundle modules exist under the plugin root (#843)", () => {
+  for (const module of ["_bash-command-classify.mjs", "_run-context.mjs", "_hook-decisions.mjs"]) {
+    assert.ok(fs.existsSync(path.join(hooksDir, module)), `missing bundled module ${module}`);
+  }
+});
+
+test("no .claude/hooks script imports an unresolvable bare package (#843)", () => {
+  // The marketplace plugin bundle has no node_modules, so a bare specifier like
+  // `@dev-loops/core/...` is unresolvable from the plugin cache and crashes the hook on load.
+  // Hooks (and their vendored bundle modules) may only import `node:` builtins or relative paths.
+  const importRe = /^\s*(?:import|export)\b[^"';]*?\bfrom\s+["']([^"']+)["']|^\s*import\s+["']([^"']+)["']/gm;
+  const offenders = [];
+  for (const file of fs.readdirSync(hooksDir).filter((f) => f.endsWith(".mjs"))) {
+    const body = fs.readFileSync(path.join(hooksDir, file), "utf8");
+    let match;
+    while ((match = importRe.exec(body)) !== null) {
+      const spec = match[1] ?? match[2];
+      if (!spec) continue;
+      const resolvable = spec.startsWith("node:") || spec.startsWith("./") || spec.startsWith("../");
+      if (!resolvable) offenders.push(`${file} → ${spec}`);
+    }
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    `Bundled hooks must only import node: builtins or relative paths (no node_modules in the plugin):\n${offenders.join("\n")}`,
+  );
+});
+
 test("package.json files allowlist ships the plugin hooks", () => {
   const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
   assert.ok(pkg.files.includes(".claude/hooks/"), "files allowlist must ship .claude/hooks/");

--- a/test/contracts/claude-hooks-settings.test.mjs
+++ b/test/contracts/claude-hooks-settings.test.mjs
@@ -73,12 +73,13 @@ test("no .claude/hooks script imports an unresolvable bare package (#843)", () =
   // The marketplace plugin bundle has no node_modules, so a bare specifier like
   // `@dev-loops/core/...` is unresolvable from the plugin cache and crashes the hook on load.
   // Hooks (and their vendored bundle modules) may only import `node:` builtins or relative paths.
-  const importRe = /^\s*(?:import|export)\b[^"';]*?\bfrom\s+["']([^"']+)["']|^\s*import\s+["']([^"']+)["']/gm;
+  const importPattern = /^\s*(?:import|export)\b[^"';]*?\bfrom\s+["']([^"']+)["']|^\s*import\s+["']([^"']+)["']/gm;
   const offenders = [];
   for (const file of fs.readdirSync(hooksDir).filter((f) => f.endsWith(".mjs"))) {
     const body = fs.readFileSync(path.join(hooksDir, file), "utf8");
-    let match;
-    while ((match = importRe.exec(body)) !== null) {
+    // Fresh regex per file: a shared /g regex would carry `lastIndex` across files and skip
+    // imports at the top of later files (Copilot review, PR #844).
+    for (const match of body.matchAll(new RegExp(importPattern))) {
       const spec = match[1] ?? match[2];
       if (!spec) continue;
       const resolvable = spec.startsWith("node:") || spec.startsWith("./") || spec.startsWith("../");


### PR DESCRIPTION
## Summary

The Claude plugin hooks imported bare `@dev-loops/core/...`. The marketplace plugin bundle has **no `node_modules`**, so the import is unresolvable from the plugin cache and every hook crashes on load with `ERR_MODULE_NOT_FOUND`. The visible symptom was a noisy `PostToolUse:Bash` error, but the more important consequence was that the two `PreToolUse` gates (ungated `gh pr ready` deny; main-agent read-only write guard) were **silently failing open**. CI masked it: the e2e hook tests run from the repo root, where the workspace symlink resolves `@dev-loops/core`.

## Fix

Generate a **self-contained hook bundle**. `scripts/claude/generate-claude-assets.mjs` now vendors the three pure core modules into `.claude/hooks/_*.mjs` with cross-module imports rewritten to relative paths, and the hook scripts import the relative bundle instead of `@dev-loops/core`:

- `packages/core/src/loop/bash-command-classify.mjs` → `.claude/hooks/_bash-command-classify.mjs`
- `packages/core/src/loop/run-context.mjs` → `.claude/hooks/_run-context.mjs`
- `packages/core/src/claude/hook-decisions.mjs` → `.claude/hooks/_hook-decisions.mjs`

`packages/core/src` stays the single source of truth; the existing `claude-assets-reproducible` no-drift check now also covers the bundle.

## Tests

- New static guard: no `.claude/hooks/*.mjs` import may be a bare specifier (only `node:` builtins or relative paths) — the regression guard CI was missing.
- New bundle-presence check.
- Verified the three hooks load and run correctly from a directory with **no** `@dev-loops/core` on the resolution path.
- Existing e2e hook tests and full `npm run verify` pass.

Closes #843
