### PR TITLE
fix(config): default the retrospective gate OFF for consumers (#841)

### DIFF
--- a/packages/core/src/config/extension-defaults.yaml
+++ b/packages/core/src/config/extension-defaults.yaml
@@ -76,8 +76,12 @@ autonomy:
 # Workflow enforcement defaults.
 workflow:
   asyncStartMode: required
-  requireRetrospective: true
-  requireRetrospectiveGate: true
+  # The retrospective is a dev-loop-development artifact; shipped defaults stay permissive so an
+  # ordinary consumer's product PRs do not carry the meta-process gate (#841). Matches the code
+  # default (DEFAULT_WORKFLOW_CONFIG) and the contract. The dev-loops repo opts in via its own
+  # repo-root .devloops, which takes precedence over these extension defaults.
+  requireRetrospective: false
+  requireRetrospectiveGate: false
   requireDraftFirst: true
   devModeDefault: true
 

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -379,6 +379,37 @@ describe("loader — graceful degradation", () => {
     }
   });
 
+  test("L1b: a plain consumer (no .devloops) defaults the retrospective gate OFF (#841)", async () => {
+    // The retrospective is a dev-loop-development artifact; shipped defaults must be permissive so
+    // an ordinary consumer's product PRs do not carry the meta-process gate. extension-defaults
+    // must not force it on (this asserts the resolved/merged value, not just the code default).
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-retro-off-"));
+    try {
+      const { loadDevLoopConfig } = await import("../src/config/config.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.equal(result.config.workflow.requireRetrospective, false);
+      assert.equal(result.config.workflow.requireRetrospectiveGate, false);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("L1c: a consumer can opt INTO the retrospective gate via .devloops (#841)", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-retro-on-"));
+    try {
+      await writeFile(
+        path.join(tmpDir, ".devloops"),
+        "version: 1\nworkflow:\n  requireRetrospective: true\n  requireRetrospectiveGate: true\n",
+      );
+      const { loadDevLoopConfig } = await import("../src/config/config.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.equal(result.config.workflow.requireRetrospective, true);
+      assert.equal(result.config.workflow.requireRetrospectiveGate, true);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   test("L2: only defaults.json present, valid", async () => {
     const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-L2-"));
     try {


### PR DESCRIPTION
## Summary

`extension-defaults.yaml` shipped `requireRetrospective: true` and `requireRetrospectiveGate: true`, overriding both the code default (`DEFAULT_WORKFLOW_CONFIG` — both `false`) and the contract doc ("shipped defaults remain permissive and this repo opts in") for **every consumer**. A plain consumer repo that set nothing was forced into the retrospective merge gate on ordinary product PRs that have nothing to do with improving the loop.

## Fix

Set both keys to `false` in `extension-defaults.yaml` so the shipped default matches the code default and the contract. The dev-loops repo keeps opting in via its own repo-root `.devloops` — config precedence is `.devloops > extension-defaults > built-in`, so behavioral retrospectives still run here (where they're genuinely valuable) while consumers are unaffected by default.

Code default (false), shipped default (now false), and the contract doc (opt-in) now all agree.

## Tests

- A plain consumer (no `.devloops`) resolves `requireRetrospective` and `requireRetrospectiveGate` to `false`.
- A consumer that opts in via `.devloops` resolves both to `true`.

Closes #841
