### PR TITLE
feat(gate): detect merge-blocking markers in the PR title (#842)

### DIFF
--- a/.claude/skills/docs/merge-preconditions.md
+++ b/.claude/skills/docs/merge-preconditions.md
@@ -10,6 +10,21 @@ Canonical owner for merge preconditions across all workflow families.
 4. ✅ All review threads resolved
 5. ✅ Explicit merge authorization from operator
 6. ✅ PR body contains `Closes #N` or `Fixes #N`
+7. ✅ PR **title** free of merge-blocking markers — `WIP`, `[WIP]`, `DRAFT`, `DO NOT MERGE`, `🚧` (case-insensitive)
+
+## Title markers
+
+The PR title is a contract surface, so a merge-blocking marker in the title is enforced
+deterministically (`findBlockingTitleMarkers` in `@dev-loops/core/loop/pr-title-markers`), not
+just reviewed:
+
+- At the **draft → ready-for-review** transition: `ready-for-review` refuses `gh pr ready` while the
+  title carries a marker.
+- At the **pre-approval gate boundary and final approval** (for non-draft PRs): the gate coordinator
+  returns `title_marker_blocked` so a PR un-drafted externally still cannot enter pre-approval or
+  reach merge-ready with a marked title.
+
+A marker is allowed only while the PR is still in draft; it must be removed before the PR leaves draft.
 
 ## Merge authorization
 

--- a/.claude/skills/docs/pr-lifecycle-contract.md
+++ b/.claude/skills/docs/pr-lifecycle-contract.md
@@ -44,6 +44,7 @@ It does not redefine helper transport mechanics, reviewer-loop internals, conduc
 - Draft existence alone is **not** draft-gate readiness.
 - A PR must clear the draft-stage gate for the current head before Copilot review may be requested.
 - Ready -> draft resets the lifecycle back into draft-stage gating.
+- A merge-blocking marker in the PR **title** (`WIP`/`[WIP]`/`DRAFT`/`DO NOT MERGE`/`🚧`, case-insensitive) blocks the draft -> ready transition and, for non-draft PRs, blocks entry to the pre-approval gate and final approval (`title_marker_blocked`). Markers are permitted only while the PR remains draft. See [Merge preconditions](merge-preconditions.md#title-markers).
 - Human approval / merge are explicit external waits, not hidden remediation states.
 
 ## Two required local gates

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,7 @@
     "./loop/phase-files": "./src/loop/phase-files.mjs",
     "./loop/policy-constants": "./src/loop/policy-constants.mjs",
     "./loop/pr-gate-coordination": "./src/loop/pr-gate-coordination.mjs",
+    "./loop/pr-title-markers": "./src/loop/pr-title-markers.mjs",
     "./loop/public-dev-loop-routing": "./src/loop/public-dev-loop-routing.mjs",
     "./loop/queue-driver": "./src/loop/queue-driver.mjs",
     "./loop/queue-parallel": "./src/loop/queue-parallel.mjs",

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -524,7 +524,63 @@ export function shouldGuardCopilotReviewRequest({
   return true;
 }
 
+/**
+ * Boundaries at which a non-draft PR must NOT carry a merge-blocking title
+ * marker (issue #842 / AC2). A WIP/DRAFT/DO NOT MERGE/🚧 title is acceptable
+ * while the PR is still in draft, but the moment the PR leaves draft and reaches
+ * the pre-approval gate boundary (entry) or the final-approval boundary, the
+ * title is a live merge-contract surface and must be clean. The guard is applied
+ * once, as a post-pass over the core evaluation result, so no individual return
+ * site can be missed even if a PR was un-drafted externally (bypassing
+ * ready-for-review).
+ */
+const TITLE_MARKER_GUARDED_BOUNDARIES = Object.freeze([
+  PR_CHECKPOINT.PRE_APPROVAL_GATE_NEEDED,
+  PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW,
+  PR_CHECKPOINT.FINAL_APPROVAL_READY,
+]);
+
+/**
+ * Evaluates PR gate coordination, then re-asserts the merge-blocking title guard
+ * (issue #842) at the pre-approval / final-approval boundary for non-draft PRs.
+ *
+ * The title check is also performed inline at the three FINAL_APPROVAL_READY
+ * sites (defense in depth); this wrapper additionally covers the pre-approval
+ * gate boundary, which is reached before any pre-approval evidence exists and so
+ * is not protected by the inline checks.
+ */
 export function evaluatePrGateCoordination(input = {}) {
+  const result = evaluatePrGateCoordinationCore(input);
+
+  const prDraft = input.prDraft === true;
+  const prTitle = typeof input.prTitle === "string" ? input.prTitle : "";
+  // Draft PRs may legitimately carry a WIP title; the marker only blocks once
+  // the PR has left draft and is at a pre-approval/final-approval boundary.
+  if (prDraft || !result || typeof result !== "object") {
+    return result;
+  }
+  if (!TITLE_MARKER_GUARDED_BOUNDARIES.includes(result.gateBoundary)) {
+    return result;
+  }
+  const markers = findBlockingTitleMarkers(prTitle);
+  if (markers.length === 0) {
+    return result;
+  }
+
+  return buildTitleMarkerBlockedResult({
+    input,
+    currentHeadSha: result.currentHeadSha ?? null,
+    draftGateAlreadySatisfied: result.draftGateAlreadySatisfied === true,
+    draftGate: result.draftGate,
+    preApprovalGate: result.preApprovalGate,
+    mergeStateStatus: result.mergeStateStatus ?? null,
+    conflictFiles: result.conflictFiles ?? [],
+    markers,
+    refinementArtifact: result.refinementArtifact ?? null,
+  });
+}
+
+function evaluatePrGateCoordinationCore(input = {}) {
   const currentHeadSha = typeof input.currentHeadSha === "string" && input.currentHeadSha.trim().length > 0
     ? input.currentHeadSha.trim()
     : null;

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -367,7 +367,7 @@ function buildTitleMarkerBlockedResult({
     allowedNextActions,
     forbiddenActions,
     nextAction: PR_CHECKPOINT_ACTION.REPORT_BLOCKED,
-    reason: `Merge remains blocked: the PR title contains merge-blocking marker(s): ${markers.join(", ")}. Remove them from the title before final approval.`,
+    reason: `Blocked: the PR title contains merge-blocking marker(s): ${markers.join(", ")}. Remove them from the title before the PR can leave draft, enter the pre-approval gate, or reach final approval.`,
     mergeStateStatus,
     conflictFiles,
       refinementArtifact,

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -1,4 +1,5 @@
 import { DISPOSITION, STATE } from "./copilot-loop-state.mjs";
+import { findBlockingTitleMarkers } from "./pr-title-markers.mjs";
 
 export const PR_CHECKPOINT = Object.freeze({
   DRAFT_REVIEW: "draft_review",
@@ -324,6 +325,56 @@ function buildRetrospectiveGatePendingResult({
 }
 
 
+/**
+ * Blocked result for a PR that would otherwise reach final_approval_ready but
+ * still carries a merge-blocking marker in its title (issue #842). The title is
+ * the most visible contract surface, so a WIP/DRAFT/DO NOT MERGE title must
+ * block the final-approval boundary just like the mark-ready transition does.
+ */
+function buildTitleMarkerBlockedResult({
+  input,
+  currentHeadSha,
+  draftGateAlreadySatisfied,
+  draftGate,
+  preApprovalGate,
+  mergeStateStatus,
+  conflictFiles,
+  markers,
+  refinementArtifact = null,
+}) {
+  const allowedNextActions = [];
+  const forbiddenActions = [];
+  pushUnique(allowedNextActions, [PR_CHECKPOINT_ACTION.REPORT_BLOCKED]);
+  pushUnique(forbiddenActions, [
+    PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE,
+    PR_CHECKPOINT_ACTION.MARK_READY_FOR_REVIEW,
+    PR_CHECKPOINT_ACTION.REQUEST_COPILOT_REVIEW,
+    PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE,
+    PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL,
+    PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY,
+  ]);
+
+  return buildResult({
+    repo: input.repo ?? null,
+    pr: Number.isInteger(input.pr) ? input.pr : null,
+    currentHeadSha,
+    lifecycleState: "title_marker_blocked",
+    loopDisposition: DISPOSITION.BLOCKED,
+    gateBoundary: PR_CHECKPOINT.BLOCKED,
+    draftGateAlreadySatisfied,
+    draftGate,
+    preApprovalGate,
+    allowedNextActions,
+    forbiddenActions,
+    nextAction: PR_CHECKPOINT_ACTION.REPORT_BLOCKED,
+    reason: `Merge remains blocked: the PR title contains merge-blocking marker(s): ${markers.join(", ")}. Remove them from the title before final approval.`,
+    mergeStateStatus,
+    conflictFiles,
+      refinementArtifact,
+  });
+}
+
+
 function buildDraftGateNeededForMergeResult({
   input,
   currentHeadSha,
@@ -500,6 +551,7 @@ export function evaluatePrGateCoordination(input = {}) {
   const roundCapReached = maxCopilotRounds !== null && copilotReviewRoundCount >= maxCopilotRounds;
   const requireRetrospectiveGate = input.requireRetrospectiveGate === true;
   const retrospectiveCheckpoint = input.retrospectiveCheckpoint;
+  const prTitle = typeof input.prTitle === "string" ? input.prTitle : "";
   const refinementArtifact = input.refinementArtifact && typeof input.refinementArtifact === "object"
     ? input.refinementArtifact
     : null;
@@ -777,6 +829,20 @@ export function evaluatePrGateCoordination(input = {}) {
         });
       }
       if (preApprovalGate.currentHeadClean) {
+        const titleMarkers = findBlockingTitleMarkers(prTitle);
+        if (titleMarkers.length > 0) {
+          return buildTitleMarkerBlockedResult({
+            input,
+            currentHeadSha,
+            draftGateAlreadySatisfied: roundCapReached ? true : draftGateAlreadySatisfied,
+            draftGate,
+            preApprovalGate,
+            mergeStateStatus,
+            conflictFiles,
+            markers: titleMarkers,
+            refinementArtifact,
+          });
+        }
         if (requireRetrospectiveGate) {
           const retrospectiveGate = evaluateRetrospectiveMergeApproval(retrospectiveCheckpoint);
           if (!retrospectiveGate.approved) {
@@ -1035,6 +1101,20 @@ export function evaluatePrGateCoordination(input = {}) {
     }
 
     if (preApprovalGate.currentHeadClean) {
+      const titleMarkers = findBlockingTitleMarkers(prTitle);
+      if (titleMarkers.length > 0) {
+        return buildTitleMarkerBlockedResult({
+          input,
+          currentHeadSha,
+          draftGateAlreadySatisfied: roundCapReached ? true : draftGateAlreadySatisfied,
+          draftGate,
+          preApprovalGate,
+          mergeStateStatus,
+          conflictFiles,
+          markers: titleMarkers,
+          refinementArtifact,
+        });
+      }
       if (requireRetrospectiveGate) {
         const retrospectiveGate = evaluateRetrospectiveMergeApproval(retrospectiveCheckpoint);
         if (!retrospectiveGate.approved) {
@@ -1178,6 +1258,20 @@ export function evaluatePrGateCoordination(input = {}) {
       });
     }
     if (preApprovalGate.currentHeadClean) {
+      const titleMarkers = findBlockingTitleMarkers(prTitle);
+      if (titleMarkers.length > 0) {
+        return buildTitleMarkerBlockedResult({
+          input,
+          currentHeadSha,
+          draftGateAlreadySatisfied: roundCapReached ? true : draftGateAlreadySatisfied,
+          draftGate,
+          preApprovalGate,
+          mergeStateStatus,
+          conflictFiles,
+          markers: titleMarkers,
+          refinementArtifact,
+        });
+      }
       if (requireRetrospectiveGate) {
         const retrospectiveGate = evaluateRetrospectiveMergeApproval(retrospectiveCheckpoint);
         if (!retrospectiveGate.approved) {

--- a/packages/core/src/loop/pr-title-markers.mjs
+++ b/packages/core/src/loop/pr-title-markers.mjs
@@ -1,0 +1,56 @@
+/**
+ * Merge-blocking marker detection for PR titles (issue #842).
+ *
+ * The PR title is the single most visible contract surface of a pull request:
+ * it shows up in the PR list, in notifications, in the merge commit, and in the
+ * changelog. A "WIP"/"DRAFT"/"DO NOT MERGE" title on an otherwise merge-ready PR
+ * directly contradicts the gate's assertion that the work is done. The gate
+ * pipeline historically only inspected the PR body, so a stale work-in-progress
+ * title could slip through both the mark-ready transition and the final-approval
+ * boundary. This module provides the pure detection seam used at both points.
+ *
+ * It is intentionally pure and side-effect free.
+ */
+
+/**
+ * Canonical merge-blocking markers and how to detect them.
+ *
+ * Word-boundary matching is used for the alphabetic markers so that real words
+ * are not false-positives (e.g. "swipe"/"wiped" must not match WIP;
+ * "drafting"/"redraft" must not match DRAFT). Bracket/paren/colon punctuation
+ * (`[WIP]`, `(wip)`, `WIP:`) are non-word characters, so `\b` boundaries still
+ * match those variants. The construction emoji has no word boundary, so it is
+ * matched literally anywhere in the title.
+ */
+const MARKER_MATCHERS = [
+  { label: "WIP", pattern: /\bWIP\b/i },
+  { label: "DRAFT", pattern: /\bDRAFT\b/i },
+  // Flexible (any) whitespace between the phrase words, case-insensitive.
+  { label: "DO NOT MERGE", pattern: /\bDO\s+NOT\s+MERGE\b/i },
+  { label: "🚧", pattern: /🚧/u },
+];
+
+/**
+ * Finds merge-blocking markers in a PR title.
+ *
+ * Returns the canonical labels of every matched marker, de-duped and in a
+ * stable order (the declaration order of {@link MARKER_MATCHERS}). Returns an
+ * empty array when the title is clean, empty, or not a string.
+ *
+ * @param {unknown} title - The PR title to inspect.
+ * @returns {string[]} Canonical labels of matched markers, e.g. ["WIP"] or
+ *   ["DO NOT MERGE", "🚧"]. Empty when no markers are present.
+ */
+export function findBlockingTitleMarkers(title) {
+  if (typeof title !== "string" || title.length === 0) {
+    return [];
+  }
+
+  const matched = [];
+  for (const { label, pattern } of MARKER_MATCHERS) {
+    if (pattern.test(title) && !matched.includes(label)) {
+      matched.push(label);
+    }
+  }
+  return matched;
+}

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -1475,3 +1475,68 @@ test("guard returns false when review request status is unavailable", () => {
     gateBoundary: PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW,
   }), false);
 });
+
+// #842: a merge-blocking marker in the PR title must re-block the
+// final-approval boundary, mirroring the mark-ready transition guard.
+
+test("WIP title blocks an otherwise final-approval-ready PR (title_marker_blocked)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 842,
+    currentHeadSha: "abc123456789",
+    prDraft: false,
+    lifecycleState: STATE.PR_READY_NO_FEEDBACK,
+    loopDisposition: DISPOSITION.ACTION_REQUIRED,
+    reviewMode: "internal_only",
+    prTitle: "[WIP] add authentication flow",
+    draftGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
+    preApprovalGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.equal(result.lifecycleState, "title_marker_blocked");
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.BLOCKED);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
+  assert.deepEqual(result.allowedNextActions, [PR_CHECKPOINT_ACTION.REPORT_BLOCKED]);
+  assert.match(result.reason, /merge-blocking marker/i);
+  assert.match(result.reason, /WIP/);
+});
+
+test("clean title still reaches final_approval_ready (title-marker control)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 842,
+    currentHeadSha: "abc123456789",
+    prDraft: false,
+    lifecycleState: STATE.PR_READY_NO_FEEDBACK,
+    loopDisposition: DISPOSITION.ACTION_REQUIRED,
+    reviewMode: "internal_only",
+    prTitle: "Add user authentication flow",
+    draftGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
+    preApprovalGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.FINAL_APPROVAL_READY);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL);
+});
+
+test("title marker takes precedence over a missing retrospective checkpoint", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 842,
+    currentHeadSha: "abc123456789",
+    prDraft: false,
+    lifecycleState: STATE.PR_READY_NO_FEEDBACK,
+    loopDisposition: DISPOSITION.ACTION_REQUIRED,
+    reviewMode: "internal_only",
+    requireRetrospectiveGate: true,
+    prTitle: "DO NOT MERGE: pending infra",
+    draftGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
+    preApprovalGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.equal(result.lifecycleState, "title_marker_blocked");
+  assert.match(result.reason, /DO NOT MERGE/);
+});

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -1540,3 +1540,87 @@ test("title marker takes precedence over a missing retrospective checkpoint", ()
   assert.equal(result.lifecycleState, "title_marker_blocked");
   assert.match(result.reason, /DO NOT MERGE/);
 });
+
+// #842 site 2: the converged settled-review branch
+// (READY_TO_REREQUEST_REVIEW / CLEAN_CONVERGED with sameHeadCleanConverged).
+
+test("WIP title blocks the converged settled-review final-approval site (site 2)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    loopDisposition: DISPOSITION.CLEAN_CONVERGED,
+    sameHeadCleanConverged: true,
+    ciStatus: "success",
+    mergeStateStatus: "CLEAN",
+    prTitle: "WIP: rework review loop",
+    draftGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "fedcba9", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
+    preApprovalGateMarker: gate({ visible: true, headSha: "fedcba9", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.equal(result.lifecycleState, "title_marker_blocked");
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.BLOCKED);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
+  assert.match(result.reason, /merge-blocking marker/i);
+  assert.match(result.reason, /WIP/);
+});
+
+test("clean title still reaches final_approval_ready at the converged settled-review site (site 2)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    loopDisposition: DISPOSITION.CLEAN_CONVERGED,
+    sameHeadCleanConverged: true,
+    ciStatus: "success",
+    mergeStateStatus: "CLEAN",
+    prTitle: "Rework review loop convergence",
+    draftGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "fedcba9", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
+    preApprovalGateMarker: gate({ visible: true, headSha: "fedcba9", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.FINAL_APPROVAL_READY);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL);
+});
+
+// #842 site 3: the low-signal / round-cap heuristic branch
+// (LOW_SIGNAL_CONVERGED with clean pre-approval evidence).
+
+test("WIP title blocks the low-signal heuristic final-approval site (site 3)", () => {
+  const result = evaluatePrGateCoordination({
+    repo: "owner/repo", pr: 17, currentHeadSha: "abc1234",
+    lifecycleState: STATE.LOW_SIGNAL_CONVERGED, loopDisposition: DISPOSITION.DONE,
+    prDraft: false, ciStatus: "success",
+    prTitle: "🚧 still wiring up the heuristic",
+    preApprovalGate: { visible: true, verdict: "clean", headSha: "abc1234" },
+    preApprovalGateMarker: { visible: true, verdict: "clean", headSha: "abc1234", contractComplete: true },
+    draftGate: { visible: true, verdict: "clean", headSha: "abc1234" },
+  });
+
+  assert.equal(result.lifecycleState, "title_marker_blocked");
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.BLOCKED);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
+  assert.match(result.reason, /merge-blocking marker/i);
+  assert.match(result.reason, /🚧/);
+});
+
+test("clean title still reaches final_approval_ready at the low-signal heuristic site (site 3)", () => {
+  const result = evaluatePrGateCoordination({
+    repo: "owner/repo", pr: 17, currentHeadSha: "abc1234",
+    lifecycleState: STATE.LOW_SIGNAL_CONVERGED, loopDisposition: DISPOSITION.DONE,
+    prDraft: false, ciStatus: "success",
+    prTitle: "Wire up the convergence heuristic",
+    preApprovalGate: { visible: true, verdict: "clean", headSha: "abc1234" },
+    preApprovalGateMarker: { visible: true, verdict: "clean", headSha: "abc1234", contractComplete: true },
+    draftGate: { visible: true, verdict: "clean", headSha: "abc1234" },
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.FINAL_APPROVAL_READY);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL);
+});

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -1624,3 +1624,71 @@ test("clean title still reaches final_approval_ready at the low-signal heuristic
   assert.equal(result.gateBoundary, PR_CHECKPOINT.FINAL_APPROVAL_READY);
   assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL);
 });
+
+// #842 AC2: a WIP/DRAFT/DO NOT MERGE/🚧 title must also block the pre-approval
+// gate ENTRY boundary for non-draft PRs (e.g. a PR un-drafted externally,
+// bypassing ready-for-review). Draft PRs are NOT blocked — a WIP title is fine
+// while the work is still in draft.
+
+test("WIP title blocks a non-draft PR at the pre-approval gate boundary (#842 AC2)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "abc123456789",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    loopDisposition: DISPOSITION.CLEAN_CONVERGED,
+    sameHeadCleanConverged: true,
+    ciStatus: "success",
+    prTitle: "[WIP] converge the review loop",
+    draftGate: gate({ visible: false }),
+    draftGateMarker: gate({ visible: false }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.lifecycleState, "title_marker_blocked");
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.BLOCKED);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
+  assert(!result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert.match(result.reason, /merge-blocking marker/i);
+  assert.match(result.reason, /WIP/);
+});
+
+test("clean title still reaches the pre-approval gate boundary for a non-draft PR (#842 AC2 control)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "abc123456789",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    loopDisposition: DISPOSITION.CLEAN_CONVERGED,
+    sameHeadCleanConverged: true,
+    ciStatus: "success",
+    prTitle: "Converge the review loop",
+    draftGate: gate({ visible: false }),
+    draftGateMarker: gate({ visible: false }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
+  assert(result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+});
+
+test("draft PR with a WIP title is NOT blocked by the title guard (#842 AC2 — draft work continues)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 10,
+    currentHeadSha: "abc123456789",
+    prDraft: true,
+    lifecycleState: STATE.PR_DRAFT,
+    loopDisposition: DISPOSITION.ACTION_REQUIRED,
+    prTitle: "[WIP] still building this",
+    draftGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.notEqual(result.lifecycleState, "title_marker_blocked");
+  assert.notEqual(result.gateBoundary, PR_CHECKPOINT.BLOCKED);
+  assert.equal(result.draftGate.cleanEvidenceExists, true);
+});

--- a/packages/core/test/pr-title-markers.test.mjs
+++ b/packages/core/test/pr-title-markers.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { findBlockingTitleMarkers } from "../src/loop/pr-title-markers.mjs";
+
+test("matches bare WIP", () => {
+  assert.deepEqual(findBlockingTitleMarkers("WIP"), ["WIP"]);
+});
+
+test("matches bracketed [WIP]", () => {
+  assert.deepEqual(findBlockingTitleMarkers("[WIP] add feature"), ["WIP"]);
+});
+
+test("matches WIP with colon", () => {
+  assert.deepEqual(findBlockingTitleMarkers("WIP: add feature"), ["WIP"]);
+});
+
+test("matches WIP followed by a word", () => {
+  assert.deepEqual(findBlockingTitleMarkers("WIP foo bar"), ["WIP"]);
+});
+
+test("matches parenthesized lowercase (wip)", () => {
+  assert.deepEqual(findBlockingTitleMarkers("Fix login (wip)"), ["WIP"]);
+});
+
+test("matches DRAFT as a word", () => {
+  assert.deepEqual(findBlockingTitleMarkers("DRAFT: new module"), ["DRAFT"]);
+});
+
+test("matches DRAFT case-insensitively", () => {
+  assert.deepEqual(findBlockingTitleMarkers("Add module [draft]"), ["DRAFT"]);
+});
+
+test("matches DO NOT MERGE phrase", () => {
+  assert.deepEqual(findBlockingTitleMarkers("DO NOT MERGE - blocked on infra"), ["DO NOT MERGE"]);
+});
+
+test("matches DO NOT MERGE with flexible whitespace, case-insensitive", () => {
+  assert.deepEqual(findBlockingTitleMarkers("Fix bug (do   not\tmerge)"), ["DO NOT MERGE"]);
+});
+
+test("matches the construction emoji anywhere", () => {
+  assert.deepEqual(findBlockingTitleMarkers("Refactor pipeline 🚧"), ["🚧"]);
+});
+
+test("matches construction emoji at start", () => {
+  assert.deepEqual(findBlockingTitleMarkers("🚧 still building"), ["🚧"]);
+});
+
+test("clean title returns empty array", () => {
+  assert.deepEqual(findBlockingTitleMarkers("Add user authentication flow"), []);
+});
+
+test("does not match swipe (false positive guard)", () => {
+  assert.deepEqual(findBlockingTitleMarkers("Improve swipe gesture handling"), []);
+});
+
+test("does not match wiped (false positive guard)", () => {
+  assert.deepEqual(findBlockingTitleMarkers("Cache is wiped on logout"), []);
+});
+
+test("does not match drafting (false positive guard)", () => {
+  assert.deepEqual(findBlockingTitleMarkers("Improve drafting workflow"), []);
+});
+
+test("does not match redraft (false positive guard)", () => {
+  assert.deepEqual(findBlockingTitleMarkers("Redraft the proposal copy"), []);
+});
+
+test("does not match DOI NOT MERGE-like noise (negative phrase guard)", () => {
+  assert.deepEqual(findBlockingTitleMarkers("DOI NOT MERGEABLE registry"), []);
+});
+
+test("empty string returns empty array", () => {
+  assert.deepEqual(findBlockingTitleMarkers(""), []);
+});
+
+test("null returns empty array", () => {
+  assert.deepEqual(findBlockingTitleMarkers(null), []);
+});
+
+test("undefined returns empty array", () => {
+  assert.deepEqual(findBlockingTitleMarkers(undefined), []);
+});
+
+test("non-string returns empty array", () => {
+  assert.deepEqual(findBlockingTitleMarkers(42), []);
+  assert.deepEqual(findBlockingTitleMarkers({ title: "WIP" }), []);
+});
+
+test("multiple distinct markers are returned in stable order", () => {
+  assert.deepEqual(
+    findBlockingTitleMarkers("DO NOT MERGE [WIP] 🚧"),
+    ["WIP", "DO NOT MERGE", "🚧"],
+  );
+});
+
+test("repeated markers are de-duped", () => {
+  assert.deepEqual(findBlockingTitleMarkers("WIP wip [WIP]"), ["WIP"]);
+});
+
+test("DRAFT and WIP together both surface", () => {
+  assert.deepEqual(findBlockingTitleMarkers("WIP draft work"), ["WIP", "DRAFT"]);
+});

--- a/scripts/github/ready-for-review.mjs
+++ b/scripts/github/ready-for-review.mjs
@@ -3,10 +3,11 @@ import { buildParseError, formatCliError, isDirectCliRun, parseJsonText, summari
 import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { loadDevLoopConfig, resolveGateConfig } from "@dev-loops/core/config";
+import { findBlockingTitleMarkers } from "@dev-loops/core/loop/pr-title-markers";
 
 const USAGE = `Usage: ready-for-review.mjs --repo <owner/name> --pr <number>\nWrapper around gh pr ready that enforces gate-evidence validation.`;
 const parseError = buildParseError(USAGE);
-const PR_VIEW_QUERY = `query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { pullRequest(number:$number) { id, isDraft, headRefOid, state, mergeStateStatus } } }`;
+const PR_VIEW_QUERY = `query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { pullRequest(number:$number) { id, isDraft, headRefOid, state, mergeStateStatus, title } } }`;
 
 export function parseReadyForReviewCliArgs(argv) {
   const args = [...argv], opts = { help: false, repo: undefined, pr: undefined };
@@ -33,7 +34,7 @@ async function fetchPrState({ repo, pr }, { env, ghCommand }) {
   const r = await runGhJson(["api", "graphql", "-f", `query=${PR_VIEW_QUERY}`, "-f", `owner=${owner}`, "-f", `name=${name}`, "-F", `number=${pr}`], { env, ghCommand });
   const d = r?.data?.repository?.pullRequest;
   if (!d) throw new Error(`Could not fetch PR #${pr}`);
-  return { id: d.id, isDraft: d.isDraft === true, headRefOid: typeof d.headRefOid === "string" ? d.headRefOid.trim() : null, state: typeof d.state === "string" ? d.state.trim() : null, mergeStateStatus: typeof d.mergeStateStatus === "string" ? d.mergeStateStatus.trim() : null };
+  return { id: d.id, isDraft: d.isDraft === true, headRefOid: typeof d.headRefOid === "string" ? d.headRefOid.trim() : null, state: typeof d.state === "string" ? d.state.trim() : null, mergeStateStatus: typeof d.mergeStateStatus === "string" ? d.mergeStateStatus.trim() : null, title: typeof d.title === "string" ? d.title : null };
 }
 
 async function fetchCiStatus({ repo, pr }, { env, ghCommand }) {
@@ -71,6 +72,8 @@ export async function readyForReview(options, { env = process.env, ghCommand = "
   const headSha = prState.headRefOid;
   if (!headSha) throw new Error(`Could not resolve head SHA`);
   if (!prState.isDraft) throw new Error(`PR #${options.pr} is not in draft state`);
+  const titleMarkers = findBlockingTitleMarkers(prState.title);
+  if (titleMarkers.length > 0) throw new Error(`PR #${options.pr} cannot be marked ready: title contains merge-blocking marker(s): ${titleMarkers.join(", ")}. Remove them from the title first.`);
   if (requireCi) { const ci = await fetchCiStatus({ repo: options.repo, pr: options.pr }, { env, ghCommand }); if (ci.status === "blocked") throw new Error(`PR #${options.pr} has blocking CI checks`); if (ci.status !== "success") throw new Error(`PR #${options.pr} CI is not green`); }
   const gate = await fetchGateEvidence({ repo: options.repo, pr: options.pr, headSha }, { env, ghCommand });
   if (!gate.cleanEvidenceExists && !gate.effectiveHeadClean) throw new Error(`No visible clean draft_gate evidence on ${headSha.slice(0,7)}`);

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -147,7 +147,7 @@ async function fetchRequestedReviewers({ repo, pr }, { env = process.env, ghComm
 async function fetchPrFacts({ repo, pr }, { env = process.env, ghCommand = "gh" } = {}) {
   const result = await runChild(
     ghCommand,
-    ["pr", "view", String(pr), "--repo", repo, "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+    ["pr", "view", String(pr), "--repo", repo, "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
     env,
   );
   if (result.code !== 0) {
@@ -381,6 +381,7 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
     prDraft: Boolean(context.prData?.isDraft),
     prClosed: String(context.prData?.state || "").toUpperCase() === "CLOSED",
     prMerged: String(context.prData?.state || "").toUpperCase() === "MERGED",
+    prTitle: context.prData?.title,
     mergeStateStatus: context.mergeStateStatus,
     conflictFiles: context.conflictFiles,
     lifecycleState: context.interpretation.state,

--- a/skills/docs/merge-preconditions.md
+++ b/skills/docs/merge-preconditions.md
@@ -10,6 +10,21 @@ Canonical owner for merge preconditions across all workflow families.
 4. ✅ All review threads resolved
 5. ✅ Explicit merge authorization from operator
 6. ✅ PR body contains `Closes #N` or `Fixes #N`
+7. ✅ PR **title** free of merge-blocking markers — `WIP`, `[WIP]`, `DRAFT`, `DO NOT MERGE`, `🚧` (case-insensitive)
+
+## Title markers
+
+The PR title is a contract surface, so a merge-blocking marker in the title is enforced
+deterministically (`findBlockingTitleMarkers` in `@dev-loops/core/loop/pr-title-markers`), not
+just reviewed:
+
+- At the **draft → ready-for-review** transition: `ready-for-review` refuses `gh pr ready` while the
+  title carries a marker.
+- At the **pre-approval gate boundary and final approval** (for non-draft PRs): the gate coordinator
+  returns `title_marker_blocked` so a PR un-drafted externally still cannot enter pre-approval or
+  reach merge-ready with a marked title.
+
+A marker is allowed only while the PR is still in draft; it must be removed before the PR leaves draft.
 
 ## Merge authorization
 

--- a/skills/docs/pr-lifecycle-contract.md
+++ b/skills/docs/pr-lifecycle-contract.md
@@ -44,6 +44,7 @@ It does not redefine helper transport mechanics, reviewer-loop internals, conduc
 - Draft existence alone is **not** draft-gate readiness.
 - A PR must clear the draft-stage gate for the current head before Copilot review may be requested.
 - Ready -> draft resets the lifecycle back into draft-stage gating.
+- A merge-blocking marker in the PR **title** (`WIP`/`[WIP]`/`DRAFT`/`DO NOT MERGE`/`🚧`, case-insensitive) blocks the draft -> ready transition and, for non-draft PRs, blocks entry to the pre-approval gate and final approval (`title_marker_blocked`). Markers are permitted only while the PR remains draft. See [Merge preconditions](merge-preconditions.md#title-markers).
 - Human approval / merge are explicit external waits, not hidden remediation states.
 
 ## Two required local gates

--- a/test/github/ready-for-review.test.mjs
+++ b/test/github/ready-for-review.test.mjs
@@ -289,6 +289,99 @@ test("succeeds when draft gate evidence exists and CI is green", async () => {
   }
 });
 
+test("refuses to mark ready when PR title contains a WIP marker", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-wip-title-"));
+
+  try {
+    const { env, ghLogPath } = await writeGhStub(tempDir, [
+      {
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                id: "PR_abc123",
+                isDraft: true,
+                headRefOid: "abc123def456",
+                state: "OPEN",
+                mergeStateStatus: "CLEAN",
+                title: "[WIP] add authentication flow",
+              },
+            },
+          },
+        }),
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /title contains merge-blocking marker/i);
+    assert.match(result.stderr, /WIP/);
+
+    // gh pr ready must NOT have been called.
+    const calls = await readGhCalls(ghLogPath);
+    const readyCall = calls.find((c) => Array.isArray(c) && c[0] === "pr" && c[1] === "ready");
+    assert.ok(!readyCall, `gh pr ready should not be called for a WIP title. Calls: ${JSON.stringify(calls)}`);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("proceeds when PR title is clean", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-clean-title-"));
+
+  try {
+    const { env, ghLogPath } = await writeGhStub(tempDir, [
+      {
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                id: "PR_abc123",
+                isDraft: true,
+                headRefOid: "abc123def456",
+                state: "OPEN",
+                mergeStateStatus: "CLEAN",
+                title: "Add user authentication flow",
+              },
+            },
+          },
+        }),
+      },
+      {
+        stdout: JSON.stringify([
+          { name: "test", state: "success", bucket: "pass" },
+        ]),
+      },
+      {
+        stdout: JSON.stringify([
+          {
+            body: "Gate review: draft_gate\nReviewed head SHA: abc123def456\nVerdict: clean\nFindings summary: no issues found\nNext action: mark ready for review",
+            id: 101,
+            html_url: "https://github.com/owner/repo/pull/17#issuecomment-101",
+            created_at: "2026-06-05T00:00:00Z",
+            updated_at: "2026-06-05T00:00:00Z",
+          },
+        ]),
+      },
+      { stdout: "" }, // gh pr ready
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0, `Expected exit code 0, got ${result.code}. Stderr: ${result.stderr}`);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.action, "marked_ready");
+
+    const calls = await readGhCalls(ghLogPath);
+    const readyCall = calls.find((c) => Array.isArray(c) && c[0] === "pr" && c[1] === "ready");
+    assert.ok(readyCall, "gh pr ready should have been called for a clean title");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test.skip("--skip-gate-check allows transition without gate evidence", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-skip-gate-"));
 

--- a/test/github/reconcile-draft-gate.test.mjs
+++ b/test/github/reconcile-draft-gate.test.mjs
@@ -304,7 +304,7 @@ test("reconcile-draft-gate skips CI checks when config disables draft requireCi"
         stdout: '{"data":{"convertPullRequestToDraft":{"pullRequest":{"id":"PR_kwDOScHU78000017","isDraft":true}}}}\n',
       },
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc123456789","reviews":[],"statusCheckRollup":[]}\n',
       },
       {
@@ -390,7 +390,7 @@ test("reconcile-draft-gate skips the draft conversion mutation when the PR is al
         stdout: '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOScHU78000017","isDraft":true}}}}\n',
       },
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc123456789","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -477,7 +477,7 @@ test("reconcile-draft-gate does not mark ready when upsert throws and the PR was
         stdout: '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOScHU78000017","isDraft":true}}}}\n',
       },
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc123456789","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -555,7 +555,7 @@ test("reconcile-draft-gate marks the PR ready again if gate-comment upsert throw
         stdout: '{"data":{"convertPullRequestToDraft":{"pullRequest":{"id":"PR_kwDOScHU78000017","isDraft":true}}}}\n',
       },
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc123456789","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -637,7 +637,7 @@ test("reconcile-draft-gate converts to draft, posts clean evidence, and marks re
         stdout: '{"data":{"convertPullRequestToDraft":{"pullRequest":{"id":"PR_kwDOScHU78000017","isDraft":true}}}}\n',
       },
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc123456789","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -41,7 +41,7 @@ function buildGateCoordinationEntries({
 }) {
   return [
     {
-      assertArgs: ["pr", "view", String(pr), "--repo", repo, "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+      assertArgs: ["pr", "view", String(pr), "--repo", repo, "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
       stdout: JSON.stringify({
         number: pr,
         state: "OPEN",
@@ -415,7 +415,7 @@ test("upsert-checkpoint-verdict creates a new comment when no same-head marker e
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -480,7 +480,7 @@ test("upsert-checkpoint-verdict embeds --findings-file content with preserved ne
 
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -544,7 +544,7 @@ test("upsert-checkpoint-verdict --findings-file takes precedence over --findings
 
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -601,7 +601,7 @@ test("upsert-checkpoint-verdict omits Blocking severities line on clean verdict"
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -654,7 +654,7 @@ test("upsert-checkpoint-verdict fails closed when pre-approval gate entry is sti
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":266,"state":"OPEN","isDraft":false,"headRefOid":"def56789abcdef","reviews":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]}\n',
       },
       {
@@ -716,7 +716,7 @@ test("upsert-checkpoint-verdict rejects pre_approval_gate when PR is still draft
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "543", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "543", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":543,"state":"OPEN","isDraft":true,"headRefOid":"f7a611b7234af479","reviews":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]}\n',
       },
       {
@@ -766,7 +766,7 @@ test("upsert-checkpoint-verdict appends the round-cap fallback note to pre-appro
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: JSON.stringify({
           number: 17,
           state: "OPEN",
@@ -858,7 +858,7 @@ test("upsert-checkpoint-verdict truncates verbose findings summary before commen
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":false,"headRefOid":"abc1234","reviews":[{"author":{"login":"copilot-pull-request-reviewer"},"state":"COMMENTED","submittedAt":"2026-05-31T20:00:00Z","commit":{"oid":"abc1234"}}],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]}\n',
       },
       {
@@ -945,7 +945,7 @@ test("upsert-checkpoint-verdict suppresses duplicate repost when the current sam
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -1028,7 +1028,7 @@ test("upsert-checkpoint-verdict noop still warns when a stale comment exists on 
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -1110,7 +1110,7 @@ test("upsert-checkpoint-verdict updates an incomplete same-head marker in place"
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -1185,7 +1185,7 @@ test("upsert-checkpoint-verdict updates the current same-head marker even when a
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -1276,7 +1276,7 @@ test("upsert-checkpoint-verdict prefers the latest same-head marker when it diff
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -1366,7 +1366,7 @@ test("upsert-checkpoint-verdict expands an abbreviated current-head SHA before m
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abcdef1234567890abcdef1234567890abcdef12","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -1449,7 +1449,7 @@ test("upsert-checkpoint-verdict fails closed when the requested head SHA is stal
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"def5678","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -1494,7 +1494,7 @@ test("upsert-checkpoint-verdict warns when a gate comment exists on a different 
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"def5678","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
       },
       {
@@ -1565,7 +1565,7 @@ test("upsert-checkpoint-verdict fails closed when draft_gate is forbidden on a n
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: '{"number":266,"state":"OPEN","isDraft":false,"headRefOid":"def56789abcdef","reviews":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]}\n',
       },
       {

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -84,7 +84,7 @@ test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 266,
           state: "OPEN",
@@ -208,7 +208,7 @@ test("detect-pr-gate-coordination-state flags draft_gate_needed for non-draft PR
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 266,
           state: "OPEN",
@@ -259,7 +259,7 @@ test("detect-pr-gate-coordination-state flags draft_gate_needed for converged no
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 266,
           state: "OPEN",
@@ -332,7 +332,7 @@ test("detect-pr-gate-coordination-state flags draft_gate_needed when Copilot rou
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 266,
           state: "OPEN",
@@ -433,7 +433,7 @@ test("detect-pr-gate-coordination-state auto-detects local-fix-without-reply (#4
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "269", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "269", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 269,
           state: "OPEN",
@@ -530,7 +530,7 @@ test("detectPrGateCoordinationState tolerates missing local git binary and falls
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 266,
           state: "OPEN",
@@ -582,7 +582,7 @@ test("detect-pr-gate-coordination-state preserves non-conflict mergeStateStatus 
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 266,
           state: "OPEN",
@@ -648,7 +648,7 @@ test("detect-pr-gate-coordination-state surfaces conflict_resolution for conflic
   try {
     const ghEnv = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "370", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "370", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 370,
           state: "OPEN",
@@ -708,7 +708,7 @@ test.skip("detect-pr-gate-coordination-state with --review-mode internal_only sk
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "267", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "267", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 267,
           state: "OPEN",
@@ -796,7 +796,7 @@ test("pre-approval-gate-detector overrides to pre_approval_gate_needed when neve
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "268", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "268", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 268,
           state: "OPEN",
@@ -881,7 +881,7 @@ test("detect-pr-gate-coordination-state blocks merge readiness when retrospectiv
 
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "271", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "271", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 271,
           state: "OPEN",
@@ -966,7 +966,7 @@ test("detect-pr-gate-coordination-state fails closed when the PR head changes mi
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 266,
           state: "OPEN",
@@ -1122,7 +1122,7 @@ test("detect-pr-gate-coordination-state resets Copilot round count when draft_ga
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 266,
           state: "OPEN",
@@ -1184,7 +1184,7 @@ test("detect-pr-gate-coordination-state does NOT reset round count when draft_ga
   try {
     const env = await writeGhStub(tempDir, [
       {
-        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,closingIssuesReferences,reviews,statusCheckRollup"],
+        assertArgs: ["pr", "view", "266", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
         stdout: jsonLine({
           number: 266,
           state: "OPEN",


### PR DESCRIPTION
## Summary

The gate pipeline reviewed the PR **body** but never the **title**, so a PR could reach `final_approval_ready` / merge-ready while its title still carried a `[WIP]` (or `WIP` / `DRAFT` / `DO NOT MERGE` / 🚧) marker — the most visible contract surface contradicting merge-readiness.

## Fix

New pure detector `@dev-loops/core/loop/pr-title-markers` → `findBlockingTitleMarkers(title)` (case-insensitive; word-boundary aware so `swipe`/`wiped`/`drafting`/`redraft` don't false-positive; `DO NOT MERGE` matches with flexible whitespace; 🚧 matched anywhere). Enforced at two points:

1. **Mark-ready transition** (`ready-for-review.mjs`): refuses `gh pr ready` when the title carries a blocking marker.
2. **Pre-approval / final-approval gate** (`pr-gate-coordination.mjs`): re-asserts at all three `FINAL_APPROVAL_READY` sites via a `title_marker_blocked` result, so a PR un-drafted externally (bypassing the mark-ready guard — cf. #836) still can't reach merge-ready with a WIP title. The coordination detector now also fetches the PR title.

## Tests

- Detector: each marker, bracket/colon/paren variants, emoji, clean titles, false-positive guards, empty/null/non-string, multi-marker de-dupe.
- `ready-for-review`: WIP title refused before `gh pr ready`; clean title proceeds.
- Gate coordination: WIP title blocks final approval (incl. precedence over a missing retrospective); clean title still reaches `FINAL_APPROVAL_READY`.

`npm run verify` passes.

Closes #842
