### PR TITLE
fix(config): default devModeDefault OFF for consumers (#846)

### DIFF
--- a/packages/core/src/config/extension-defaults.yaml
+++ b/packages/core/src/config/extension-defaults.yaml
@@ -83,7 +83,11 @@ workflow:
   requireRetrospective: false
   requireRetrospectiveGate: false
   requireDraftFirst: true
-  devModeDefault: true
+  # Dev mode is the dev-loop self-improvement mode — it edits the loop's own skill/agent prompts
+  # after a phase, which is only meaningful in the dev-loops repo. Shipped defaults must not force
+  # it on consumers' product phases (#846). Matches the code default; the dev-loops repo opts in
+  # via its own repo-root .devloops (which takes precedence over these extension defaults).
+  devModeDefault: false
 
 # Light-mode threshold for small local changes.
 localImplementation:

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -426,7 +426,10 @@ describe("loader — graceful degradation", () => {
   test("L1e: a consumer can opt INTO dev mode via .devloops (#846)", async () => {
     const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-devmode-on-"));
     try {
-      await writeFile(path.join(tmpDir, ".devloops"), "version: 1\nworkflow:\n  devModeDefault: true\n");
+      await writeFile(
+        path.join(tmpDir, ".devloops"),
+        "version: 1\nworkflow:\n  devModeDefault: true\n",
+      );
       const { loadDevLoopConfig } = await import("../src/config/config.mjs");
       const result = await loadDevLoopConfig({ repoRoot: tmpDir });
       assert.equal(result.config.workflow.devModeDefault, true);

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -410,6 +410,31 @@ describe("loader — graceful degradation", () => {
     }
   });
 
+  test("L1d: a plain consumer (no .devloops) defaults devModeDefault OFF (#846)", async () => {
+    // Dev mode is the dev-loop self-improvement mode (it edits the loop's own skill/agent prompts
+    // after a phase); shipped defaults must not force it on consumers' ordinary product phases.
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-devmode-off-"));
+    try {
+      const { loadDevLoopConfig } = await import("../src/config/config.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.equal(result.config.workflow.devModeDefault, false);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("L1e: a consumer can opt INTO dev mode via .devloops (#846)", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-devmode-on-"));
+    try {
+      await writeFile(path.join(tmpDir, ".devloops"), "version: 1\nworkflow:\n  devModeDefault: true\n");
+      const { loadDevLoopConfig } = await import("../src/config/config.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.equal(result.config.workflow.devModeDefault, true);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   test("L2: only defaults.json present, valid", async () => {
     const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-L2-"));
     try {


### PR DESCRIPTION
## Summary

`extension-defaults.yaml` shipped `workflow.devModeDefault: true`, forcing **dev mode** — the dev-loop self-improvement mode that edits the loop's own skill/agent prompts after a phase — onto every consumer's ordinary product phases. Dev mode is only meaningful in the dev-loops repo. Same class of defect as #841.

## Fix

Set `devModeDefault: false` in `extension-defaults.yaml` so the shipped default matches the code default (`DEFAULT_WORKFLOW_CONFIG.devModeDefault = false`). The dev-loops repo keeps opting in via its own repo-root `.devloops` (precedence `.devloops > extension-defaults > built-in`), so dev mode still runs here.

## Tests

- A plain consumer (no `.devloops`) resolves `devModeDefault: false`.
- A consumer that opts in via `.devloops` resolves `true`.

`npm run verify` passes.

Closes #846
