### PR TITLE
feat(envelope): surface effective async-start mode + relaxation source (#834)

### DIFF
--- a/packages/core/src/loop/handoff-envelope.mjs
+++ b/packages/core/src/loop/handoff-envelope.mjs
@@ -20,6 +20,7 @@ import {
 } from "./public-dev-loop-routing-contract.mjs";
 import { normalizeRepoSlug } from "../github/repo-slug.mjs";
 import { COPILOT_REVIEW_WAIT_TIMEOUT_MS } from "./policy-constants.mjs";
+import { resolveEffectiveAsyncStartMode } from "./async-start-contract.mjs";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -430,6 +431,16 @@ export function buildDevLoopHandoffEnvelope(resolverOutput, settings, gateState 
     ? { ...options.overrides }
     : undefined;
 
+  // Surface the *effective* async-start posture alongside the *configured* one (#834). The
+  // configured `asyncStartMode` is echoed verbatim from settings (back-compat), but the contract
+  // is relaxed at validation time under the Claude harness (resolveEffectiveAsyncStartMode →
+  // "allowed" when CLAUDECODE=1). Without surfacing the effective value, a `required` envelope
+  // reads as if it should still block even though the resolver correctly proceeds.
+  const env = options.env ?? (typeof process !== "undefined" ? process.env : {});
+  const configuredAsyncStartMode = settings?.workflow?.asyncStartMode ?? "required";
+  const effectiveAsyncStartMode = resolveEffectiveAsyncStartMode(configuredAsyncStartMode, env);
+  const asyncStartRelaxedBy = effectiveAsyncStartMode !== configuredAsyncStartMode ? "claude-harness" : null;
+
   const envelope = {
     handoffVersion: ENVELOPE_HANDOFF_VERSION,
     derivedAt: (now ?? new Date()).toISOString(),
@@ -447,7 +458,9 @@ export function buildDevLoopHandoffEnvelope(resolverOutput, settings, gateState 
     requiredReads,
 
     stopRules,
-    asyncStartMode: settings?.workflow?.asyncStartMode ?? "required",
+    asyncStartMode: configuredAsyncStartMode,
+    asyncStartEffective: effectiveAsyncStartMode,
+    asyncStartRelaxedBy,
     requireDraftFirst: settings?.workflow?.requireDraftFirst ?? false,
 
     cwd: derivedCwd,
@@ -694,6 +707,21 @@ export function validateHandoffEnvelope(envelope) {
       field: "asyncStartMode",
       reason: `must be one of: ${VALID_ASYNC_START_MODES.join(", ")}`,
       got: envelope.asyncStartMode,
+    });
+  }
+
+  // ----- asyncStartEffective (required field; the harness-resolved posture, #834) -----
+  if (envelope.asyncStartEffective === undefined || envelope.asyncStartEffective === null) {
+    errors.push({
+      field: "asyncStartEffective",
+      reason: "must be present",
+      got: envelope.asyncStartEffective,
+    });
+  } else if (!VALID_ASYNC_START_MODES.includes(envelope.asyncStartEffective)) {
+    errors.push({
+      field: "asyncStartEffective",
+      reason: `must be one of: ${VALID_ASYNC_START_MODES.join(", ")}`,
+      got: envelope.asyncStartEffective,
     });
   }
 

--- a/packages/core/test/handoff-envelope.test.mjs
+++ b/packages/core/test/handoff-envelope.test.mjs
@@ -136,6 +136,42 @@ test("fn-exists: buildDevLoopHandoffEnvelope is a function", () => {
   assert.equal(typeof buildDevLoopHandoffEnvelope, "function");
 });
 
+test("async-start (#834): configured mode echoed; not relaxed off the Claude harness", () => {
+  const env = buildDevLoopHandoffEnvelope(
+    issueBundle(42),
+    defaultSettings,
+    {},
+    { ...defaultOptions, env: {} }, // no CLAUDECODE
+  );
+  assert.equal(env.asyncStartMode, "required", "configured value unchanged (back-compat)");
+  assert.equal(env.asyncStartEffective, "required", "effective equals configured off-harness");
+  assert.equal(env.asyncStartRelaxedBy, null, "no relaxation flag when nothing was relaxed");
+});
+
+test("async-start (#834): required is relaxed to allowed under the Claude harness, with a flag", () => {
+  const env = buildDevLoopHandoffEnvelope(
+    issueBundle(42),
+    defaultSettings,
+    {},
+    { ...defaultOptions, env: { CLAUDECODE: "1" } },
+  );
+  assert.equal(env.asyncStartMode, "required", "configured value still echoed verbatim");
+  assert.equal(env.asyncStartEffective, "allowed", "effective is allowed under Claude");
+  assert.equal(env.asyncStartRelaxedBy, "claude-harness", "relaxation source surfaced");
+});
+
+test("async-start (#834): already-allowed config is not flagged as relaxed under Claude", () => {
+  const env = buildDevLoopHandoffEnvelope(
+    issueBundle(42),
+    { ...defaultSettings, workflow: { asyncStartMode: "allowed", requireDraftFirst: true } },
+    {},
+    { ...defaultOptions, env: { CLAUDECODE: "1" } },
+  );
+  assert.equal(env.asyncStartMode, "allowed");
+  assert.equal(env.asyncStartEffective, "allowed");
+  assert.equal(env.asyncStartRelaxedBy, null, "no relaxation when already allowed");
+});
+
 test("shape: envelope has correct top-level keys", () => {
   const env = buildDevLoopHandoffEnvelope(
     issueBundle(42),

--- a/packages/core/test/handoff-envelope.test.mjs
+++ b/packages/core/test/handoff-envelope.test.mjs
@@ -126,7 +126,11 @@ const defaultSettings = {
   },
 };
 
-const defaultOptions = { repoSlug: "owner/repo" };
+// Pin env to {} so envelope-building tests stay deterministic regardless of the ambient harness
+// (buildDevLoopHandoffEnvelope defaults options.env to process.env; under CLAUDECODE=1 a `required`
+// async-start mode resolves to an `allowed` effective value — #834). Tests that exercise Claude
+// behavior override `env` explicitly.
+const defaultOptions = { repoSlug: "owner/repo", env: {} };
 
 // ===========================================================================
 // 1. fn-exists and basic shape


### PR DESCRIPTION
## Summary

The handoff envelope echoed `asyncStartMode` verbatim from settings (e.g. `"required"`) with no indication that the contract is **relaxed at validation time under the Claude harness** (`resolveEffectiveAsyncStartMode` → `"allowed"` when `CLAUDECODE=1`). It read as if a `required` envelope should still block, even though the resolver correctly proceeds — a pure observability gap (follow-up to #830 / v0.2.2).

## Fix

Add two derived fields to the envelope, keeping the configured one unchanged:

- `asyncStartMode` — **unchanged**, the configured value (back-compat).
- `asyncStartEffective` — the harness-resolved mode (`"allowed"` under Claude).
- `asyncStartRelaxedBy` — `"claude-harness"` when effective ≠ configured, else `null`.

`env` is threaded via `options` (defaults to `process.env`). Envelope validation now also requires `asyncStartEffective`.

## Tests

- Off-harness: effective == configured, `asyncStartRelaxedBy: null`.
- Claude harness, configured `required`: effective `allowed`, `asyncStartRelaxedBy: "claude-harness"`.
- Claude harness, configured `allowed`: not flagged (nothing relaxed).

`npm run verify` passes.

Closes #834
