### PR TITLE
refactor(loop): extract duplicated listOpenPrs into a shared module (#809)

### DIFF
--- a/scripts/loop/_loop-pr-aggregation.mjs
+++ b/scripts/loop/_loop-pr-aggregation.mjs
@@ -1,0 +1,45 @@
+// Shared loop PR-aggregation helpers used by both conductor-monitor.mjs and
+// run-conductor-cycle.mjs. Spawns `gh`, so this lives at the scripts level
+// rather than in @dev-loops/core.
+import { runChild } from "../_cli-primitives.mjs";
+import { parseJsonText } from "../_core-helpers.mjs";
+
+export const OPEN_PR_LIST_LIMIT = 1000;
+
+export async function listOpenPrs({ repo }, { env, ghCommand }) {
+  const result = await runChild(
+    ghCommand,
+    [
+      "pr",
+      "list",
+      "--repo",
+      repo,
+      "--state",
+      "open",
+      "--limit",
+      String(OPEN_PR_LIST_LIMIT),
+      "--json",
+      "number,title,url,isDraft,headRefName,author",
+    ],
+    env,
+  );
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw new Error(`gh command failed: ${detail}`);
+  }
+  const payload = parseJsonText(result.stdout);
+  if (!Array.isArray(payload)) {
+    throw new Error("Invalid gh pr list payload: expected an array");
+  }
+  return payload
+    .map((pr) => ({
+      number: Number.isInteger(pr?.number) ? pr.number : null,
+      title: typeof pr?.title === "string" ? pr.title : "",
+      url: typeof pr?.url === "string" ? pr.url : null,
+      isDraft: Boolean(pr?.isDraft),
+      headRefName: typeof pr?.headRefName === "string" ? pr.headRefName : null,
+      authorLogin: typeof pr?.author?.login === "string" ? pr.author.login : null,
+    }))
+    .filter((pr) => pr.number !== null)
+    .sort((left, right) => left.number - right.number);
+}

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs";
 import { access, open, readFile, readdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { runChild, requireOptionValue } from "../_cli-primitives.mjs";
+import { requireOptionValue } from "../_cli-primitives.mjs";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { autoDetectSnapshot } from "./detect-copilot-loop-state.mjs";
@@ -13,6 +13,7 @@ import {
   parseRecordedHandoffContract,
 } from "./_handoff-contract.mjs";
 import { interpretLoopState, summarizeLoopInterpretation } from "@dev-loops/core/loop/copilot-loop-state";
+import { listOpenPrs } from "./_loop-pr-aggregation.mjs";
 const USAGE = `Usage: conductor-monitor.mjs --repo <owner/name> [--auto-resume]
 Aggregate Copilot-loop status across all open PRs in one repo.
 Required:
@@ -80,7 +81,6 @@ Exit codes:
   0  Success
   1  Argument error, gh failure, or indeterminate PR status`.trim();
 const parseError = buildParseError(USAGE);
-const OPEN_PR_LIST_LIMIT = 1000;
 const DEFAULT_SESSION_ROOT = path.join(os.homedir(), ".pi", "agent", "sessions");
 const RUN_STATE = {
   COMPLETED: "completed",
@@ -144,43 +144,6 @@ function parseCliArgs(argv) {
     throw parseError(error instanceof Error ? error.message : String(error));
   }
   return options;
-}
-async function listOpenPrs({ repo }, { env, ghCommand }) {
-  const result = await runChild(
-    ghCommand,
-    [
-      "pr",
-      "list",
-      "--repo",
-      repo,
-      "--state",
-      "open",
-      "--limit",
-      String(OPEN_PR_LIST_LIMIT),
-      "--json",
-      "number,title,url,isDraft,headRefName,author",
-    ],
-    env,
-  );
-  if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw new Error(`gh command failed: ${detail}`);
-  }
-  const payload = parseJsonText(result.stdout);
-  if (!Array.isArray(payload)) {
-    throw new Error("Invalid gh pr list payload: expected an array");
-  }
-  return payload
-    .map((pr) => ({
-      number: Number.isInteger(pr?.number) ? pr.number : null,
-      title: typeof pr?.title === "string" ? pr.title : "",
-      url: typeof pr?.url === "string" ? pr.url : null,
-      isDraft: Boolean(pr?.isDraft),
-      headRefName: typeof pr?.headRefName === "string" ? pr.headRefName : null,
-      authorLogin: typeof pr?.author?.login === "string" ? pr.author.login : null,
-    }))
-    .filter((pr) => pr.number !== null)
-    .sort((left, right) => left.number - right.number);
 }
 function summarizePrDisposition(loopDisposition) {
   switch (loopDisposition) {

--- a/scripts/loop/run-conductor-cycle.mjs
+++ b/scripts/loop/run-conductor-cycle.mjs
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
-import { runChild, requireOptionValue } from "../_cli-primitives.mjs";
+import { requireOptionValue } from "../_cli-primitives.mjs";
 import {
   buildParseError,
   formatCliError,
   isDirectCliRun,
-  parseJsonText,
 } from "../_core-helpers.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { detectPrGateCoordinationState } from "./detect-pr-gate-coordination-state.mjs";
@@ -14,9 +13,10 @@ import {
   SUBAGENT_ACTIONS as SHARED_SUBAGENT_ACTIONS,
   buildHandoffContractForConductorAction,
 } from "./_handoff-contract.mjs";
+import { listOpenPrs } from "./_loop-pr-aggregation.mjs";
+export { listOpenPrs };
 const USAGE = `Usage: run-conductor-cycle.mjs --repo <owner/name>
 Poll all open PRs, detect state, and output an ordered action queue.`.trim();
-const OPEN_PR_LIST_LIMIT = 1000;
 export const CHECKPOINT_ACTION_TO_CONDUCTOR_ACTION = Object.freeze({
   [PR_CHECKPOINT_ACTION.ADDRESS_REVIEW_FEEDBACK]: "fix_threads",
   [PR_CHECKPOINT_ACTION.REPLY_RESOLVE_REVIEW_THREADS]: "fix_threads",
@@ -89,43 +89,6 @@ export function parseCliArgs(argv) {
     throw parseError(error instanceof Error ? error.message : String(error));
   }
   return options;
-}
-export async function listOpenPrs({ repo }, { env, ghCommand }) {
-  const result = await runChild(
-    ghCommand,
-    [
-      "pr",
-      "list",
-      "--repo",
-      repo,
-      "--state",
-      "open",
-      "--limit",
-      String(OPEN_PR_LIST_LIMIT),
-      "--json",
-      "number,title,url,isDraft,headRefName,author",
-    ],
-    env,
-  );
-  if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw new Error(`gh command failed: ${detail}`);
-  }
-  const payload = parseJsonText(result.stdout);
-  if (!Array.isArray(payload)) {
-    throw new Error("Invalid gh pr list payload: expected an array");
-  }
-  return payload
-    .map((pr) => ({
-      number: Number.isInteger(pr?.number) ? pr.number : null,
-      title: typeof pr?.title === "string" ? pr.title : "",
-      url: typeof pr?.url === "string" ? pr.url : null,
-      isDraft: Boolean(pr?.isDraft),
-      headRefName: typeof pr?.headRefName === "string" ? pr.headRefName : null,
-      authorLogin: typeof pr?.author?.login === "string" ? pr.author.login : null,
-    }))
-    .filter((pr) => pr.number !== null)
-    .sort((left, right) => left.number - right.number);
 }
 export async function detectPrState(
   pr,

--- a/test/loop/loop-pr-aggregation.test.mjs
+++ b/test/loop/loop-pr-aggregation.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile, chmod } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  OPEN_PR_LIST_LIMIT,
+  listOpenPrs,
+} from "../../scripts/loop/_loop-pr-aggregation.mjs";
+
+async function withFakeGh(stdout, { code = 0, stderr = "" } = {}, run) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "loop-pr-agg-"));
+  const ghPath = path.join(dir, "gh");
+  const script = `#!/usr/bin/env node
+process.stdout.write(${JSON.stringify(stdout)});
+process.stderr.write(${JSON.stringify(stderr)});
+process.exit(${code});
+`;
+  await writeFile(ghPath, script, "utf8");
+  await chmod(ghPath, 0o755);
+  try {
+    return await run(ghPath);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("listOpenPrs normalizes, filters, and sorts the gh payload", async () => {
+  const payload = JSON.stringify([
+    { number: 7, title: "Seven", url: "u7", isDraft: true, headRefName: "f7", author: { login: "alice" } },
+    { number: 3, title: "Three", url: "u3", isDraft: false, headRefName: "f3", author: { login: "bob" } },
+    { number: null, title: "skip-no-number" },
+    { number: 5 },
+  ]);
+  const prs = await withFakeGh(payload, {}, (ghPath) =>
+    listOpenPrs({ repo: "owner/repo" }, { env: process.env, ghCommand: ghPath }),
+  );
+  assert.deepEqual(prs, [
+    { number: 3, title: "Three", url: "u3", isDraft: false, headRefName: "f3", authorLogin: "bob" },
+    { number: 5, title: "", url: null, isDraft: false, headRefName: null, authorLogin: null },
+    { number: 7, title: "Seven", url: "u7", isDraft: true, headRefName: "f7", authorLogin: "alice" },
+  ]);
+});
+
+test("listOpenPrs throws on gh failure", async () => {
+  await withFakeGh("", { code: 1, stderr: "boom" }, async (ghPath) => {
+    await assert.rejects(
+      listOpenPrs({ repo: "owner/repo" }, { env: process.env, ghCommand: ghPath }),
+      /gh command failed: boom/,
+    );
+  });
+});
+
+test("listOpenPrs throws when payload is not an array", async () => {
+  await withFakeGh(JSON.stringify({ not: "array" }), {}, async (ghPath) => {
+    await assert.rejects(
+      listOpenPrs({ repo: "owner/repo" }, { env: process.env, ghCommand: ghPath }),
+      /expected an array/,
+    );
+  });
+});
+
+test("OPEN_PR_LIST_LIMIT is the shared constant", () => {
+  assert.equal(OPEN_PR_LIST_LIMIT, 1000);
+});


### PR DESCRIPTION
## Summary

Child of #792 (ponytail audit). `listOpenPrs` (and `OPEN_PR_LIST_LIMIT`) was **byte-for-byte duplicated** in `conductor-monitor.mjs` and `run-conductor-cycle.mjs`. Extract it into a single shared scripts-level module and delete the copies.

## What changed

- New `scripts/loop/_loop-pr-aggregation.mjs` exporting `listOpenPrs` + `OPEN_PR_LIST_LIMIT`. Kept at the scripts level (not `@dev-loops/core`) because it spawns `gh`.
- Both callers import it; duplicated definitions removed. `run-conductor-cycle.mjs` re-exports `listOpenPrs` so its public export and the `listPrsImpl = listOpenPrs` injection seam are unchanged.
- The other candidate helpers (`buildPrReport`, `buildQueueSummary`, `normalizeRunState`/`normalizeRunStateForPlan`/`runStatePriority`) are **conductor-monitor-only** — not duplicated — so they're deliberately left in place to avoid churn.

**No behavior change.** CLI contracts, JSON shapes, and exit codes untouched.

Line counts: `conductor-monitor.mjs` 1850→1813; `run-conductor-cycle.mjs` 322→285.

## Tests

New `test/loop/loop-pr-aggregation.test.mjs` exercises `listOpenPrs` via a fake-gh executable (normalize/filter/sort, gh-failure error, non-array payload error, shared constant). `npm run verify` passes.

Closes #809
