### PR TITLE
chore(release): v0.2.6

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-loops",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Agent-harness-agnostic dev-loop: agents, skills, and hooks for GitHub/Copilot-driven development loops.",
   "author": {
     "name": "Manuel Fittko",
@@ -9,5 +9,12 @@
   "license": "MIT",
   "homepage": "https://github.com/mfittko/dev-loops#readme",
   "repository": "https://github.com/mfittko/dev-loops.git",
-  "keywords": ["dev-loop", "workflow", "github", "copilot", "claude-code", "plugin"]
+  "keywords": [
+    "dev-loop",
+    "workflow",
+    "github",
+    "copilot",
+    "claude-code",
+    "plugin"
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.6
+
+### Fixed
+
+- **Claude plugin hooks are self-contained** (#843). The bundled PreToolUse/PostToolUse hooks
+  imported a bare `@dev-loops/core`, which is unresolvable from the marketplace plugin cache (no
+  `node_modules` there), so every hook crashed on load — the two PreToolUse gates were silently
+  failing open. The asset generator now emits a vendored, relative-import hook bundle
+  (`.claude/hooks/_*.mjs`) from the canonical core modules, drift-guarded by the no-drift check.
+- **Retrospective gate is opt-in for consumers** (#841). `extension-defaults.yaml` shipped
+  `requireRetrospective`/`requireRetrospectiveGate: true`, forcing the retrospective merge gate on
+  every consumer's product PRs against the code default and the contract. Both now default `false`;
+  the dev-loops repo opts in via its own `.devloops`.
+- **Dev mode is opt-in for consumers** (#846). `extension-defaults.yaml` shipped
+  `devModeDefault: true`, pushing every consumer's product phases into the loop's self-improvement
+  mode (which edits the loop's own skill/agent prompts). Now defaults `false`; the dev-loops repo
+  opts in via `.devloops`.
+
+### Added
+
+- **Merge-blocking PR-title gate** (#842). The gate pipeline now flags `WIP`/`[WIP]`/`DRAFT`/
+  `DO NOT MERGE`/`🚧` (case-insensitive) in the PR **title**, blocking the draft→ready transition
+  and — for non-draft PRs — entry to the pre-approval gate and final approval. Documented in the
+  merge-preconditions and PR-lifecycle contracts.
+- **Effective async-start mode is surfaced** (#834). The handoff envelope now reports
+  `asyncStartEffective` and `asyncStartRelaxedBy` alongside the unchanged configured
+  `asyncStartMode`, so the Claude harness relaxation (`required`→`allowed`) is visible instead of
+  reading as a contradiction.
+
+### Changed
+
+- **Deduplicated PR aggregation** (#809). The duplicated `listOpenPrs` helper is extracted into a
+  shared `scripts/loop/_loop-pr-aggregation.mjs` and reused by `conductor-monitor.mjs` and
+  `run-conductor-cycle.mjs`. No behavior change.
+
 ## 0.2.5
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "dev-loops",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dev-loops",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "MIT",
       "workspaces": [
         "packages/*"
       ],
       "dependencies": {
-        "@dev-loops/core": "^0.2.5",
+        "@dev-loops/core": "^0.2.6",
         "mermaid": "11.15.0"
       },
       "bin": {
@@ -591,7 +591,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -3725,7 +3725,7 @@
     },
     "packages/core": {
       "name": "@dev-loops/core",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "mermaid": "11.15.0",
-    "@dev-loops/core": "^0.2.5"
+    "@dev-loops/core": "^0.2.6"
   },
   "repository": {
     "type": "git",
@@ -78,7 +78,7 @@
     "url": "https://github.com/mfittko/dev-loops/issues"
   },
   "homepage": "https://github.com/mfittko/dev-loops#readme",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "files": [
     "cli/",
     "lib/",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev-loops/core",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "description": "Shared deterministic support package for dev-loop skills, repo-local scripts, and GitHub automation.",
   "exports": {


### PR DESCRIPTION
## Release v0.2.6

Re-aligns all version surfaces onto **0.2.6** (npm `package.json`, `@dev-loops/core`, and the Claude plugin manifest `.claude/.claude-plugin/plugin.json` were all `0.2.5`), bumps the root→core dependency to `^0.2.6`, syncs the lockfile, and adds the CHANGELOG entry.

### Included since v0.2.5
- **fix** self-contained Claude plugin hooks (#843)
- **fix** retrospective gate opt-in for consumers (#841)
- **fix** devModeDefault opt-in for consumers (#846)
- **feat** merge-blocking PR-title gate (#842)
- **feat** surface effective async-start mode (#834)
- **refactor** dedup `listOpenPrs` aggregation (#809)

After merge, I'll create the GitHub release with tag `v0.2.6` on the merge commit, which triggers the npm publish workflow (`packages/core` + root, with provenance).

`npm run verify` passes.
