### PR TITLE
fix(cli): harness-aware deterministic dev-loops CLI invocation (#801, #833)

### DIFF
--- a/.claude/agents/dev-loop.md
+++ b/.claude/agents/dev-loop.md
@@ -21,7 +21,8 @@ The envelope is the primary handoff artifact — it is derived from resolver out
 - `acceptance` — self-validation criteria for declaring completion
 
 **Construction sequence:**
-1. Run the deterministic startup resolver to produce the authoritative state bundle: `npx dev-loops loop startup --issue <n>` for issues, or `npx dev-loops loop startup --pr <n>` for PRs.
+
+1. Run the deterministic startup resolver to produce the authoritative state bundle: `npx dev-loops@0.2.6 loop startup --issue <n>` for issues, or `npx dev-loops@0.2.6 loop startup --pr <n>` for PRs.
 2. Pass the resolver output, resolved settings (merged from `.devloops` and `.pi/dev-loop/defaults.yaml`), and current gate state to `buildDevLoopHandoffEnvelope()`.
 3. **Validate the envelope** with `validateHandoffEnvelope()` before consuming any field. If validation returns `ok: false`, reject the handoff with the structured error — do not load requiredReads, do not execute nextAction, do not delegate.
 4. Read the envelope as the first artifact.

--- a/.claude/skills/dev-loop/SKILL.md
+++ b/.claude/skills/dev-loop/SKILL.md
@@ -25,7 +25,7 @@ Required installed runtime contract docs are shared bundled copies under `../doc
 
 > Under the Claude Code harness the dev-loop runs as a single agent: run these steps directly — no read-only boundary and no separate async-subagent dispatch. See [Main Agent Contract](../docs/main-agent-contract.md).
 
-Resolve authoritative state via the startup resolver (`npx dev-loops loop startup --issue <n>` for issues, `npx dev-loops loop startup --pr <n>` for PRs), then immediately build the handoff envelope via `npx dev-loops loop build-envelope --input <resolver-output.json>`. The envelope determines `requiredReads`, `nextAction`, `stopRules`, and `acceptance` — load only those files, execute only that bounded task. It is the first handoff artifact consumed before loading any route pack. See [Workflow Handoff Contract](../docs/workflow-handoff-contract.md) for the derivation contract.
+Resolve authoritative state via the startup resolver (`npx dev-loops@0.2.6 loop startup --issue <n>` for issues, `npx dev-loops@0.2.6 loop startup --pr <n>` for PRs), then immediately build the handoff envelope via `npx dev-loops@0.2.6 loop build-envelope --input <resolver-output.json>`. The envelope determines `requiredReads`, `nextAction`, `stopRules`, and `acceptance` — load only those files, execute only that bounded task. It is the first handoff artifact consumed before loading any route pack. See [Workflow Handoff Contract](../docs/workflow-handoff-contract.md) for the derivation contract.
 
 **Retrospective checkpoint gate:** the resolver reads `.pi/dev-loop-retrospective-checkpoint.json` and injects the state. When the checkpoint is `missing` and the repo config `workflow.requireRetrospective` (set via `.devloops` at repo root) is `true`, the resolver returns `needs_reconcile`. Complete or explicitly skip the retrospective before starting.
 
@@ -99,10 +99,10 @@ When `@dev-loops/core` is available again, switch back to the full helper. The f
 
 ## Read-only info shortcut
 
-Info/handoff requests can be served directly via `npx dev-loops loop info` (read-only; no full dev-loop run required):
-- `npx dev-loops loop info --issue <n>` — human-readable issue state summary (strategy, route, linked PR, next action)
-- `npx dev-loops loop info --pr <n>` — human-readable PR state summary (branch, CI, threads, rounds, action)
-- `npx dev-loops loop info --issue <n> --json` — machine-readable JSON output
+Info/handoff requests can be served directly via `npx dev-loops@0.2.6 loop info` (read-only; no full dev-loop run required):
+- `npx dev-loops@0.2.6 loop info --issue <n>` — human-readable issue state summary (strategy, route, linked PR, next action)
+- `npx dev-loops@0.2.6 loop info --pr <n>` — human-readable PR state summary (branch, CI, threads, rounds, action)
+- `npx dev-loops@0.2.6 loop info --issue <n> --json` — machine-readable JSON output
 
 ## Guard rules
 

--- a/agents/dev-loop.agent.md
+++ b/agents/dev-loop.agent.md
@@ -26,7 +26,7 @@ The envelope is the primary handoff artifact — it is derived from resolver out
 
 **Construction sequence:**
 <!-- pi-only -->
-**CLI invocation (`<dev-loops-package-root>`):** dev-loop CLI commands are invoked as `node <dev-loops-package-root>/cli/index.mjs <verb...>` using the package-local CLI rather than `npx`, so they resolve unambiguously from the installed package without a global install. Resolve `<dev-loops-package-root>` from this agent's own installed path: this agent is installed at `<package-root>/.pi/agents/dev-loop.agent.md`, so the package root is `../../..` from this agent's directory. (The `dev-loop` skill resolves it analogously from its own installed path.)
+**CLI invocation (`<dev-loops-package-root>`):** dev-loop CLI commands are invoked as `node <dev-loops-package-root>/cli/index.mjs <verb...>` using the package-local CLI rather than `npx`, so they resolve unambiguously from the installed package without a global install. Resolve `<dev-loops-package-root>` from this agent's own installed path: this agent is installed at `<package-root>/.pi/agents/dev-loop.agent.md`, so the package root is `../..` from this agent's directory (`agents` → `.pi` → package root). (The `dev-loop` skill resolves it analogously from its own installed path.)
 <!-- /pi-only -->
 
 1. Run the deterministic startup resolver to produce the authoritative state bundle: `node <dev-loops-package-root>/cli/index.mjs loop startup --issue <n>` for issues, or `node <dev-loops-package-root>/cli/index.mjs loop startup --pr <n>` for PRs.

--- a/agents/dev-loop.agent.md
+++ b/agents/dev-loop.agent.md
@@ -25,7 +25,11 @@ The envelope is the primary handoff artifact — it is derived from resolver out
 - `acceptance` — self-validation criteria for declaring completion
 
 **Construction sequence:**
-1. Run the deterministic startup resolver to produce the authoritative state bundle: `npx dev-loops loop startup --issue <n>` for issues, or `npx dev-loops loop startup --pr <n>` for PRs.
+<!-- pi-only -->
+**CLI invocation (`<dev-loops-package-root>`):** dev-loop CLI commands are invoked as `node <dev-loops-package-root>/cli/index.mjs <verb...>` using the package-local CLI rather than `npx`, so they resolve unambiguously from the installed package without a global install. Resolve `<dev-loops-package-root>` from this agent's own installed path: this agent is installed at `<package-root>/.pi/agents/dev-loop.agent.md`, so the package root is `../../..` from this agent's directory. (The `dev-loop` skill resolves it analogously from its own installed path.)
+<!-- /pi-only -->
+
+1. Run the deterministic startup resolver to produce the authoritative state bundle: `node <dev-loops-package-root>/cli/index.mjs loop startup --issue <n>` for issues, or `node <dev-loops-package-root>/cli/index.mjs loop startup --pr <n>` for PRs.
 2. Pass the resolver output, resolved settings (merged from `.devloops` and `.pi/dev-loop/defaults.yaml`), and current gate state to `buildDevLoopHandoffEnvelope()`.
 3. **Validate the envelope** with `validateHandoffEnvelope()` before consuming any field. If validation returns `ok: false`, reject the handoff with the structured error — do not load requiredReads, do not execute nextAction, do not delegate.
 4. Read the envelope as the first artifact.

--- a/packages/core/src/claude/asset-generation.mjs
+++ b/packages/core/src/claude/asset-generation.mjs
@@ -73,6 +73,22 @@ export function stripPiOnlyBlocks(body) {
 }
 
 /**
+ * Rewrite the Pi package-local CLI invocation into the Claude version-pinned `npx` form (#801,
+ * #833). The Pi runtime sources invoke the CLI as `node <dev-loops-package-root>/cli/index.mjs`
+ * (resolves unambiguously from the installed package). The Claude plugin does NOT bundle `cli/`,
+ * so for the generated tree those tokens become `npx dev-loops@<version>` — pinning the version
+ * keeps the CLI from drifting against the published plugin version (#833). The Pi-only
+ * package-root resolution note is removed separately by `stripPiOnlyBlocks`.
+ *
+ * @param {string} body
+ * @param {string} version dev-loops package version to pin (e.g. "0.2.6").
+ * @returns {string}
+ */
+export function rewriteCliInvocation(body, version) {
+  return String(body).split("node <dev-loops-package-root>/cli/index.mjs").join(`npx dev-loops@${version}`);
+}
+
+/**
  * Map a single Pi tool name to its Claude tool name(s).
  * @param {string} name
  * @returns {string[]} Claude tool names (empty if unknown).
@@ -131,12 +147,12 @@ function normalizeToolList(value) {
 
 /**
  * Transform a canonical `agents/*.agent.md` into a Claude `.claude/agents/*.md` document.
- * @param {{ source: string, raw: string }} input
+ * @param {{ source: string, raw: string, version?: string }} input
  * @returns {string} Full generated file content.
  */
-export function transformAgent({ source, raw }) {
+export function transformAgent({ source, raw, version = "latest" }) {
   const { frontmatter, body: rawBody } = splitFrontmatter(raw, source);
-  const body = stripPiOnlyBlocks(rawBody);
+  const body = rewriteCliInvocation(stripPiOnlyBlocks(rawBody), version);
   const tools = mapTools(normalizeToolList(frontmatter.tools));
 
   const lines = ["---"];
@@ -155,12 +171,12 @@ export function transformAgent({ source, raw }) {
 
 /**
  * Transform a canonical `skills/<name>/SKILL.md` into a Claude `.claude/skills/<name>/SKILL.md`.
- * @param {{ source: string, raw: string }} input
+ * @param {{ source: string, raw: string, version?: string }} input
  * @returns {string} Full generated file content.
  */
-export function transformSkill({ source, raw }) {
+export function transformSkill({ source, raw, version = "latest" }) {
   const { frontmatter, body: rawBody } = splitFrontmatter(raw, source);
-  const body = stripPiOnlyBlocks(rawBody);
+  const body = rewriteCliInvocation(stripPiOnlyBlocks(rawBody), version);
   const tools = mapTools(normalizeToolList(frontmatter["allowed-tools"]));
 
   const lines = ["---"];

--- a/packages/core/test/claude-asset-generation.test.mjs
+++ b/packages/core/test/claude-asset-generation.test.mjs
@@ -7,9 +7,29 @@ import {
   mapTools,
   splitFrontmatter,
   stripPiOnlyBlocks,
+  rewriteCliInvocation,
   transformAgent,
   transformSkill,
 } from "../src/claude/asset-generation.mjs";
+
+test("rewriteCliInvocation pins the package-local CLI to npx dev-loops@<version> (#801, #833)", () => {
+  const body = "Run `node <dev-loops-package-root>/cli/index.mjs loop info` and `node <dev-loops-package-root>/cli/index.mjs loop startup`.";
+  const out = rewriteCliInvocation(body, "0.2.6");
+  assert.equal(out.includes("node <dev-loops-package-root>/cli/index.mjs"), false);
+  assert.equal((out.match(/npx dev-loops@0\.2\.6/g) ?? []).length, 2, "every token is rewritten");
+});
+
+test("transformAgent and transformSkill rewrite the package-local CLI form to the pinned npx form", () => {
+  const agentRaw = `---\nname: a\ndescription: d\ntools: [read]\n---\nRun \`node <dev-loops-package-root>/cli/index.mjs loop startup\`.\n`;
+  const agent = transformAgent({ source: "agents/a.agent.md", raw: agentRaw, version: "1.2.3" });
+  assert.ok(agent.includes("npx dev-loops@1.2.3 loop startup"));
+  assert.equal(agent.includes("<dev-loops-package-root>"), false);
+
+  const skillRaw = `---\nname: s\ndescription: d\nallowed-tools: read\n---\nRun \`node <dev-loops-package-root>/cli/index.mjs loop info\`.\n`;
+  const skill = transformSkill({ source: "skills/s/SKILL.md", raw: skillRaw, version: "1.2.3" });
+  assert.ok(skill.includes("npx dev-loops@1.2.3 loop info"));
+  assert.equal(skill.includes("<dev-loops-package-root>"), false);
+});
 
 test("stripPiOnlyBlocks removes <!-- pi-only --> blocks and collapses blank runs; keeps other prose", () => {
   const body = "Keep A.\n\n<!-- pi-only -->\nPi-only line about contact_supervisor.\n<!-- /pi-only -->\n\nKeep B.\n";

--- a/scripts/claude/generate-claude-assets.mjs
+++ b/scripts/claude/generate-claude-assets.mjs
@@ -24,6 +24,16 @@ import { transformAgent, transformSkill, stripPiOnlyBlocks } from "@dev-loops/co
 export function collectGeneratedAssets({ repoRoot = process.cwd() } = {}) {
   const assets = [];
 
+  // The dev-loops package version pins the Claude `npx dev-loops@<version>` CLI invocation so the
+  // generated plugin tree cannot drift against the published version (#833). Read it once here.
+  // Falls back to `latest` when no repo-root package.json is present (e.g. a consumer/fixture tree
+  // that mirrors only agents/skills).
+  let version = "latest";
+  const pkgPath = path.join(repoRoot, "package.json");
+  if (fs.existsSync(pkgPath)) {
+    version = JSON.parse(fs.readFileSync(pkgPath, "utf8")).version ?? "latest";
+  }
+
   const agentsDir = path.join(repoRoot, "agents");
   if (fs.existsSync(agentsDir)) {
     for (const entry of fs.readdirSync(agentsDir).sort()) {
@@ -31,7 +41,7 @@ export function collectGeneratedAssets({ repoRoot = process.cwd() } = {}) {
       const source = `agents/${entry}`;
       const raw = fs.readFileSync(path.join(repoRoot, source), "utf8");
       const base = entry.slice(0, -".agent.md".length);
-      assets.push({ target: `.claude/agents/${base}.md`, content: transformAgent({ source, raw }) });
+      assets.push({ target: `.claude/agents/${base}.md`, content: transformAgent({ source, raw, version }) });
     }
   }
 
@@ -43,7 +53,7 @@ export function collectGeneratedAssets({ repoRoot = process.cwd() } = {}) {
       const abs = path.join(repoRoot, source);
       if (!fs.existsSync(abs)) continue; // e.g. skills/docs/ holds shared docs, not a SKILL.md
       const raw = fs.readFileSync(abs, "utf8");
-      assets.push({ target: `.claude/skills/${entry.name}/SKILL.md`, content: transformSkill({ source, raw }) });
+      assets.push({ target: `.claude/skills/${entry.name}/SKILL.md`, content: transformSkill({ source, raw, version }) });
     }
   }
 

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -34,7 +34,11 @@ For async-required routes (config `workflow.asyncStartMode`, default `required`)
 
 > Under the Claude Code harness the dev-loop runs as a single agent: run these steps directly — no read-only boundary and no separate async-subagent dispatch. See [Main Agent Contract](../docs/main-agent-contract.md).
 
-Resolve authoritative state via the startup resolver (`npx dev-loops loop startup --issue <n>` for issues, `npx dev-loops loop startup --pr <n>` for PRs), then immediately build the handoff envelope via `npx dev-loops loop build-envelope --input <resolver-output.json>`. The envelope determines `requiredReads`, `nextAction`, `stopRules`, and `acceptance` — load only those files, execute only that bounded task. It is the first handoff artifact consumed before loading any route pack. See [Workflow Handoff Contract](../docs/workflow-handoff-contract.md) for the derivation contract.
+<!-- pi-only -->
+**CLI invocation (`<dev-loops-package-root>`):** dev-loop CLI commands below are invoked as `node <dev-loops-package-root>/cli/index.mjs <verb...>` using the package-local CLI rather than `npx`, so they resolve unambiguously from the installed package without a global install. Resolve `<dev-loops-package-root>` from this skill's own installed path: this skill is installed at `<package-root>/.pi/skills/dev-loop/SKILL.md`, so the package root is `../../..` from this skill's directory. (The `dev-loop` agent resolves it analogously from its own installed path.)
+<!-- /pi-only -->
+
+Resolve authoritative state via the startup resolver (`node <dev-loops-package-root>/cli/index.mjs loop startup --issue <n>` for issues, `node <dev-loops-package-root>/cli/index.mjs loop startup --pr <n>` for PRs), then immediately build the handoff envelope via `node <dev-loops-package-root>/cli/index.mjs loop build-envelope --input <resolver-output.json>`. The envelope determines `requiredReads`, `nextAction`, `stopRules`, and `acceptance` — load only those files, execute only that bounded task. It is the first handoff artifact consumed before loading any route pack. See [Workflow Handoff Contract](../docs/workflow-handoff-contract.md) for the derivation contract.
 
 **Retrospective checkpoint gate:** the resolver reads `.pi/dev-loop-retrospective-checkpoint.json` and injects the state. When the checkpoint is `missing` and the repo config `workflow.requireRetrospective` (set via `.devloops` at repo root) is `true`, the resolver returns `needs_reconcile`. Complete or explicitly skip the retrospective before starting.
 
@@ -109,10 +113,10 @@ When `@dev-loops/core` is available again, switch back to the full helper. The f
 
 ## Read-only info shortcut
 
-Info/handoff requests can be served directly via `npx dev-loops loop info` (read-only; no full dev-loop run required):
-- `npx dev-loops loop info --issue <n>` — human-readable issue state summary (strategy, route, linked PR, next action)
-- `npx dev-loops loop info --pr <n>` — human-readable PR state summary (branch, CI, threads, rounds, action)
-- `npx dev-loops loop info --issue <n> --json` — machine-readable JSON output
+Info/handoff requests can be served directly via `node <dev-loops-package-root>/cli/index.mjs loop info` (read-only; no full dev-loop run required):
+- `node <dev-loops-package-root>/cli/index.mjs loop info --issue <n>` — human-readable issue state summary (strategy, route, linked PR, next action)
+- `node <dev-loops-package-root>/cli/index.mjs loop info --pr <n>` — human-readable PR state summary (branch, CI, threads, rounds, action)
+- `node <dev-loops-package-root>/cli/index.mjs loop info --issue <n> --json` — machine-readable JSON output
 
 ## Guard rules
 

--- a/test/contracts/cli-invocation-contract.test.mjs
+++ b/test/contracts/cli-invocation-contract.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { collectGeneratedAssets } from "../../scripts/claude/generate-claude-assets.mjs";
+
+// #801 + #833: the Pi runtime sources invoke the CLI as the package-local
+// `node <dev-loops-package-root>/cli/index.mjs` form (resolves unambiguously from the installed
+// package, no global install). The generated Claude tree rewrites that to the version-pinned
+// `npx dev-loops@<version>` form, because the Claude plugin does not bundle `cli/` and pinning
+// the version eliminates CLI-vs-plugin version skew.
+
+const repoRoot = path.resolve(fileURLToPath(new URL("../../", import.meta.url)));
+const currentVersion = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8")).version;
+
+const PI_TOKEN = "node <dev-loops-package-root>/cli/index.mjs";
+
+/** Every runtime source skill/agent file (the files Pi consumes directly). */
+function runtimeSourceFiles() {
+  const files = [];
+  const skillsDir = path.join(repoRoot, "skills");
+  for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const abs = path.join(skillsDir, entry.name, "SKILL.md");
+    if (fs.existsSync(abs)) files.push(path.relative(repoRoot, abs));
+  }
+  const agentsDir = path.join(repoRoot, "agents");
+  for (const entry of fs.readdirSync(agentsDir)) {
+    if (entry.endsWith(".agent.md")) files.push(path.relative(repoRoot, path.join(agentsDir, entry)));
+  }
+  return files;
+}
+
+test("no unversioned `npx dev-loops` remains in the runtime source skills/agents (#801, #833)", () => {
+  for (const rel of runtimeSourceFiles()) {
+    const raw = fs.readFileSync(path.join(repoRoot, rel), "utf8");
+    // `npx dev-loops` not immediately followed by `@` is the unversioned, ambiguous form we ban.
+    const unversioned = raw.match(/npx dev-loops(?!@)/g) ?? [];
+    assert.deepEqual(unversioned, [], `${rel} must not contain unversioned \`npx dev-loops\``);
+  }
+});
+
+test("the dev-loop runtime source uses the package-local `node .../cli/index.mjs` form (#801)", () => {
+  const skill = fs.readFileSync(path.join(repoRoot, "skills/dev-loop/SKILL.md"), "utf8");
+  const agent = fs.readFileSync(path.join(repoRoot, "agents/dev-loop.agent.md"), "utf8");
+  assert.ok(skill.includes(PI_TOKEN), "dev-loop SKILL.md must invoke the package-local CLI form");
+  assert.ok(agent.includes(PI_TOKEN), "dev-loop agent must invoke the package-local CLI form");
+});
+
+test("generated Claude skill/agent pin `npx dev-loops@<version>` and drop the package-local form (#833)", () => {
+  const assets = collectGeneratedAssets({ repoRoot });
+  const byTarget = new Map(assets.map((a) => [a.target, a.content]));
+  for (const target of [".claude/skills/dev-loop/SKILL.md", ".claude/agents/dev-loop.md"]) {
+    const content = byTarget.get(target);
+    assert.ok(content, `expected generated ${target}`);
+    assert.ok(
+      content.includes(`npx dev-loops@${currentVersion}`),
+      `${target} must pin npx dev-loops@${currentVersion}`,
+    );
+    assert.equal(
+      content.includes(PI_TOKEN),
+      false,
+      `${target} must not contain the package-local CLI form (Claude bundles no cli/)`,
+    );
+    assert.equal(
+      content.includes("<dev-loops-package-root>"),
+      false,
+      `${target} must not contain the Pi-only package-root note`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Runtime skill/agent docs invoked `npx dev-loops <verb>` — ambiguous resolution (cwd/cache/global/registry), requires a global install (#801), and unversioned so the CLI drifts from the plugin version (#833; e.g. global `0.2.5` vs published `0.2.6`).

## Harness-aware fix

- **Pi runtime** (`skills/dev-loop/SKILL.md`, `agents/dev-loop.agent.md`): package-local `node <dev-loops-package-root>/cli/index.mjs <verb>` + a one-time `<!-- pi-only -->` package-root resolution note. No npx, no global install — the CLI ships in the Pi package. **(#801)**
- **Claude runtime** (generated `.claude/`): the asset generator rewrites that token to the version-pinned **`npx dev-loops@<version>`** (version read from `package.json`, threaded via a new `rewriteCliInvocation` helper). The Claude plugin bundles no `cli/` (cf. #843), and pinning eliminates the skew. Regenerating at release keeps the pin current. **(#833)**

README human-facing docs are intentionally left as `npx` (#801 non-goal).

## Tests

`test/contracts/cli-invocation-contract.test.mjs`: no unversioned `npx dev-loops` in runtime sources; sources use the `node` form; generated Claude tree pins `npx dev-loops@<version>` and drops the package-local form. Plus `rewriteCliInvocation` unit tests. `npm run verify` passes; no-drift check green.

Closes #801
Closes #833
