### PR TITLE
fix(loop): resolve round-cap Copilot-gate deadlock at the cap (#848)

### DIFF
--- a/packages/core/src/loop/copilot-loop-state.mjs
+++ b/packages/core/src/loop/copilot-loop-state.mjs
@@ -229,12 +229,6 @@ function isAutoRerequestEligible(snapshot, state) {
  */
 const VALID_SIGNAL_LEVELS = new Set(["high", "mid", "low"]);
 
-function hasExplicitCurrentHeadReviewSignal(raw) {
-  return Boolean(raw)
-    && typeof raw === "object"
-    && Object.prototype.hasOwnProperty.call(raw, "copilotReviewOnCurrentHead");
-}
-
 export function normalizeSnapshot(raw) {
   if (!raw || typeof raw !== "object") {
     throw new Error("Snapshot must be a non-null object");
@@ -353,32 +347,48 @@ export function interpretLoopState(snapshot, refinementConfig) {
   // count has been exhausted, stop re-requests before entering fix/reply-resolve routing.
   // Gating here (before unresolved-thread checks) ensures round cap takes priority over
   // the normal fix loop, including unresolved threads, pending CI, and CI failures.
-  // Clean PRs are usually eligible for pre_approval_gate fallback; the only automatic
-  // exception is when the head has advanced since the last submitted Copilot review,
-  // all prior feedback is resolved, and CI is green/credibly green again. In that case
-  // the state re-opens to READY_TO_REREQUEST_REVIEW instead of terminating as clean fallback.
-  // Does NOT interrupt an in-flight review request (requested/already-requested).
+  //
+  // Precedence at the cap: copilotReviewRoundCount counts COMPLETED rounds, so at
+  // `>= maxRounds` every permitted Copilot round is already done and any lingering
+  // in-flight request (requested/already-requested) is for a forbidden over-cap round.
+  // A stale Copilot reviewer assignment must therefore NOT block the clean fallback:
+  // when threads are clean and CI is green, route to ROUND_CAP_CLEAN_FALLBACK even if
+  // copilotReviewRequestStatus is requested/already-requested. Otherwise a lingering
+  // assignment would dead-end the loop at WAITING_FOR_COPILOT_REVIEW waiting for a
+  // review that can never come (no further round is permitted past the cap). The
+  // pre_approval_gate (current-head clean evidence, enforced elsewhere) reviews any
+  // post-cap head change, so this proceeds without skipping review of new code.
+  //
+  // An in-flight request only still blocks the cap block when the PR is NOT clean
+  // (unresolved threads or non-green CI) — that legitimately stays in the fix/wait
+  // routing below rather than terminating as a clean fallback.
+  //
+  // Head-advanced handling: even when the head has advanced past the last submitted
+  // Copilot review with clean threads and green CI, re-requesting another Copilot pass
+  // is forbidden at the cap, so this routes to ROUND_CAP_CLEAN_FALLBACK (not
+  // READY_TO_REREQUEST_REVIEW, which would trigger an illegal auto re-request). The
+  // pre_approval_gate handles the current head.
   const maxRounds = refinementConfig?.maxCopilotRounds;
   const reviewInFlight = s.copilotReviewRequestStatus === "requested"
     || s.copilotReviewRequestStatus === "already-requested";
   if (typeof maxRounds === "number" && maxRounds > 0
       && s.copilotReviewRoundCount >= maxRounds
-      && !reviewInFlight
       && state !== STATE.NO_PR && state !== STATE.DONE
       && state !== STATE.PR_DRAFT && state !== STATE.REVIEW_REQUEST_UNAVAILABLE
       && state !== STATE.BLOCKED_NEEDS_USER_DECISION) {
     const ciClean = s.ciStatus === "success" || s.ciStatus === "crediblyGreen";
     const cleanThreads = s.unresolvedThreadCount === 0;
-    const headAdvancedSinceLastSubmittedCopilotReview = s.copilotReviewPresent
-      && hasExplicitCurrentHeadReviewSignal(snapshot)
-      && !s.copilotReviewOnCurrentHead;
-    if (cleanThreads && ciClean && headAdvancedSinceLastSubmittedCopilotReview) {
-      state = STATE.READY_TO_REREQUEST_REVIEW;
-    } else if (cleanThreads && ciClean) {
+    if (cleanThreads && ciClean) {
+      // Clean PR at the cap: proceed to the pre_approval_gate fallback regardless of a
+      // lingering Copilot reviewer assignment or an advanced head — no further Copilot
+      // round is permitted, so never re-open for re-request or wait on Copilot here.
       state = STATE.ROUND_CAP_CLEAN_FALLBACK;
-    } else {
+    } else if (!reviewInFlight) {
+      // Not clean and no in-flight request: hard stop at the cap.
       state = STATE.ROUND_CAP_REACHED;
     }
+    // Not clean WITH an in-flight request: leave state undecided so the normal
+    // fix/reply-resolve/wait routing below handles it (do not force a clean fallback).
   }
 
   if (state === undefined) {

--- a/packages/core/src/loop/copilot-loop-state.mjs
+++ b/packages/core/src/loop/copilot-loop-state.mjs
@@ -345,8 +345,12 @@ export function interpretLoopState(snapshot, refinementConfig) {
 
   // Round-cap enforcement: when maxCopilotRounds is configured and the review-round
   // count has been exhausted, stop re-requests before entering fix/reply-resolve routing.
-  // Gating here (before unresolved-thread checks) ensures round cap takes priority over
-  // the normal fix loop, including unresolved threads, pending CI, and CI failures.
+  // Gating here (before unresolved-thread checks) lets a CLEAN PR at the cap terminate as
+  // ROUND_CAP_CLEAN_FALLBACK ahead of the normal fix/wait routing. It does NOT blanket-
+  // override that routing: a NOT-clean PR (unresolved threads or non-green CI) with an
+  // in-flight request deliberately falls through to the normal fix/wait routing below
+  // (see the `!reviewInFlight` branch), and only a not-clean PR with no in-flight request
+  // hard-stops at ROUND_CAP_REACHED.
   //
   // Precedence at the cap: copilotReviewRoundCount counts COMPLETED rounds, so at
   // `>= maxRounds` every permitted Copilot round is already done and any lingering

--- a/packages/core/test/copilot-loop-state.test.mjs
+++ b/packages/core/test/copilot-loop-state.test.mjs
@@ -904,7 +904,7 @@ test("interpretLoopState routes to ROUND_CAP_REACHED when round cap reached with
   assert.equal(result.roundCapCleanEligible, false);
 });
 
-test("interpretLoopState re-opens to READY_TO_REREQUEST_REVIEW when round cap reached after new commits with clean PR and green CI", () => {
+test("interpretLoopState routes to ROUND_CAP_CLEAN_FALLBACK (no illegal re-request) when round cap reached after new commits with clean PR and green CI", () => {
   const snapshot = {
     prExists: true,
     prNumber: 17,
@@ -920,15 +920,17 @@ test("interpretLoopState re-opens to READY_TO_REREQUEST_REVIEW when round cap re
   const refinementConfig = { maxCopilotRounds: 5 };
 
   const result = interpretLoopState(snapshot, refinementConfig);
-  assert.equal(result.state, STATE.READY_TO_REREQUEST_REVIEW);
-  assert.deepEqual(result.allowedTransitions, [STATE.WAITING_FOR_COPILOT_REVIEW, STATE.REVIEW_REQUEST_UNAVAILABLE, STATE.DONE]);
-  assert.equal(result.autoRerequestEligible, true);
+  // Head advanced past last submitted review, but the cap forbids another Copilot
+  // round, so we must NOT re-open for re-request; pre_approval_gate handles the head.
+  assert.equal(result.state, STATE.ROUND_CAP_CLEAN_FALLBACK);
+  assert.deepEqual(result.allowedTransitions, []);
+  assert.equal(result.autoRerequestEligible, false);
   assert.equal(result.sameHeadCleanConverged, false);
-  assert.equal(result.roundCapCleanEligible, false);
-  assert.match(result.nextAction, /Re-request Copilot review/i);
+  assert.equal(result.roundCapCleanEligible, true);
+  assert.match(result.nextAction, /pre_approval_gate/i);
 });
 
-test("interpretLoopState re-opens to READY_TO_REREQUEST_REVIEW when round cap reached after new commits with crediblyGreen CI", () => {
+test("interpretLoopState routes to ROUND_CAP_CLEAN_FALLBACK (no illegal re-request) when round cap reached after new commits with crediblyGreen CI", () => {
   const snapshot = {
     prExists: true,
     prNumber: 17,
@@ -944,9 +946,9 @@ test("interpretLoopState re-opens to READY_TO_REREQUEST_REVIEW when round cap re
   const refinementConfig = { maxCopilotRounds: 5 };
 
   const result = interpretLoopState(snapshot, refinementConfig);
-  assert.equal(result.state, STATE.READY_TO_REREQUEST_REVIEW);
-  assert.equal(result.autoRerequestEligible, true);
-  assert.equal(result.roundCapCleanEligible, false);
+  assert.equal(result.state, STATE.ROUND_CAP_CLEAN_FALLBACK);
+  assert.equal(result.autoRerequestEligible, false);
+  assert.equal(result.roundCapCleanEligible, true);
 });
 
 test("interpretLoopState fails closed to ROUND_CAP_CLEAN_FALLBACK when round-cap snapshot omits current-head review signal", () => {
@@ -1115,6 +1117,116 @@ test("round cap overrides unresolved-thread routing when maxCopilotRounds is exc
   assert.equal(result.roundCapCleanEligible, false);
 });
 
+// Round-cap deadlock guard (#848): a lingering Copilot reviewer assignment
+// (already-requested) must not dead-end the loop at WAITING_FOR_COPILOT_REVIEW once
+// the cap is reached with a clean PR. The clean fallback takes priority over the
+// stale assignment because no further Copilot round is permitted past the cap.
+test("interpretLoopState routes to ROUND_CAP_CLEAN_FALLBACK when cap reached with clean PR despite lingering already-requested assignment", () => {
+  const snapshot = {
+    prExists: true,
+    prNumber: 847,
+    copilotReviewRequestStatus: "already-requested",
+    copilotReviewPresent: true,
+    copilotReviewOnCurrentHead: false,
+    unresolvedThreadCount: 0,
+    actionableThreadCount: 0,
+    copilotReviewRoundCount: 5,
+    ciStatus: "success",
+  };
+
+  const refinementConfig = { maxCopilotRounds: 5 };
+
+  const result = interpretLoopState(snapshot, refinementConfig);
+  assert.notEqual(result.state, STATE.WAITING_FOR_COPILOT_REVIEW);
+  assert.equal(result.state, STATE.ROUND_CAP_CLEAN_FALLBACK);
+  assert.equal(result.roundCapCleanEligible, true);
+  assert.equal(result.autoRerequestEligible, false);
+});
+
+test("interpretLoopState routes to ROUND_CAP_CLEAN_FALLBACK (no illegal re-request) when cap reached with clean PR, head advanced, and lingering requested assignment", () => {
+  const snapshot = {
+    prExists: true,
+    prNumber: 847,
+    copilotReviewRequestStatus: "requested",
+    copilotReviewPresent: true,
+    copilotReviewOnCurrentHead: false,
+    unresolvedThreadCount: 0,
+    actionableThreadCount: 0,
+    copilotReviewRoundCount: 5,
+    ciStatus: "crediblyGreen",
+  };
+
+  const refinementConfig = { maxCopilotRounds: 5 };
+
+  const result = interpretLoopState(snapshot, refinementConfig);
+  assert.equal(result.state, STATE.ROUND_CAP_CLEAN_FALLBACK);
+  assert.equal(result.roundCapCleanEligible, true);
+  // No illegal over-cap re-request is implied by the proceeding disposition.
+  assert.equal(result.autoRerequestEligible, false);
+});
+
+test("interpretLoopState keeps WAITING_FOR_COPILOT_REVIEW when cap NOT reached with already-requested assignment (regression guard)", () => {
+  const snapshot = {
+    prExists: true,
+    prNumber: 847,
+    copilotReviewRequestStatus: "already-requested",
+    copilotReviewPresent: false,
+    copilotReviewOnCurrentHead: false,
+    unresolvedThreadCount: 0,
+    actionableThreadCount: 0,
+    copilotReviewRoundCount: 2,
+    ciStatus: "success",
+  };
+
+  const refinementConfig = { maxCopilotRounds: 5 };
+
+  const result = interpretLoopState(snapshot, refinementConfig);
+  assert.equal(result.state, STATE.WAITING_FOR_COPILOT_REVIEW);
+  assert.equal(result.roundCapCleanEligible, false);
+});
+
+test("interpretLoopState routes to ROUND_CAP_REACHED when cap reached with unresolved threads and already-requested assignment", () => {
+  const snapshot = {
+    prExists: true,
+    prNumber: 847,
+    copilotReviewRequestStatus: "already-requested",
+    copilotReviewPresent: true,
+    copilotReviewOnCurrentHead: false,
+    unresolvedThreadCount: 2,
+    actionableThreadCount: 2,
+    copilotReviewRoundCount: 5,
+    ciStatus: "success",
+  };
+
+  const refinementConfig = { maxCopilotRounds: 5 };
+
+  const result = interpretLoopState(snapshot, refinementConfig);
+  // Not clean + in-flight request: stays in the fix/wait routing rather than a clean
+  // fallback. Unresolved threads take precedence over the lingering assignment.
+  assert.equal(result.state, STATE.UNRESOLVED_FEEDBACK_PRESENT);
+  assert.equal(result.roundCapCleanEligible, false);
+});
+
+test("interpretLoopState does not produce a clean fallback when cap reached with failing CI and already-requested assignment", () => {
+  const snapshot = {
+    prExists: true,
+    prNumber: 847,
+    copilotReviewRequestStatus: "already-requested",
+    copilotReviewPresent: true,
+    copilotReviewOnCurrentHead: false,
+    unresolvedThreadCount: 0,
+    actionableThreadCount: 0,
+    copilotReviewRoundCount: 5,
+    ciStatus: "failure",
+  };
+
+  const refinementConfig = { maxCopilotRounds: 5 };
+
+  const result = interpretLoopState(snapshot, refinementConfig);
+  assert.notEqual(result.state, STATE.ROUND_CAP_CLEAN_FALLBACK);
+  assert.equal(result.roundCapCleanEligible, false);
+});
+
 test("summarizeLoopInterpretation marks ROUND_CAP_REACHED as blocked and terminal", () => {
   // ROUND_CAP_REACHED is now reachable through normal routing when round cap gates
   // before unresolved-thread/CI checks. We simulate directly for summary test.
@@ -1165,7 +1277,7 @@ test("interpretLoopState returns false for roundCapCleanEligible in normal READY
   assert.equal(result.roundCapCleanEligible, false);
 });
 
-test("round cap does not interrupt an in-flight Copilot review request", () => {
+test("round cap clean fallback takes priority over a lingering in-flight Copilot review request (no waiting dead-end)", () => {
   const snapshot = {
     prExists: true,
     prNumber: 17,
@@ -1180,7 +1292,32 @@ test("round cap does not interrupt an in-flight Copilot review request", () => {
 
   const refinementConfig = { maxCopilotRounds: 5 };
 
-  // In-flight review request must not be interrupted by round cap
+  // At the cap, copilotReviewRoundCount counts COMPLETED rounds, so any in-flight
+  // request is for a forbidden over-cap round. With a clean PR, the loop must proceed
+  // to the pre_approval_gate fallback rather than dead-end at WAITING_FOR_COPILOT_REVIEW.
+  const result = interpretLoopState(snapshot, refinementConfig);
+  assert.notEqual(result.state, STATE.WAITING_FOR_COPILOT_REVIEW);
+  assert.equal(result.state, STATE.ROUND_CAP_CLEAN_FALLBACK);
+  assert.equal(result.roundCapCleanEligible, true);
+});
+
+test("round cap with in-flight request but NOT clean stays in fix/wait routing (no premature clean fallback)", () => {
+  const snapshot = {
+    prExists: true,
+    prNumber: 17,
+    copilotReviewRequestStatus: "requested",
+    copilotReviewPresent: true,
+    copilotReviewOnCurrentHead: false,
+    unresolvedThreadCount: 0,
+    actionableThreadCount: 0,
+    copilotReviewRoundCount: 5,
+    ciStatus: "pending",
+  };
+
+  const refinementConfig = { maxCopilotRounds: 5 };
+
+  // Pending CI + in-flight request: not clean, so no clean fallback; the in-flight
+  // request keeps the loop waiting for Copilot rather than forcing a hard stop.
   const result = interpretLoopState(snapshot, refinementConfig);
   assert.equal(result.state, STATE.WAITING_FOR_COPILOT_REVIEW);
   assert.equal(result.roundCapCleanEligible, false);
@@ -1207,7 +1344,7 @@ test("round cap does not override BLOCKED_NEEDS_USER_DECISION from failed review
   assert.equal(result.roundCapCleanEligible, false);
 });
 
-test("low-signal heuristic can still suppress a round-cap re-opened re-request when both apply", () => {
+test("round-cap clean fallback takes priority over the low-signal heuristic at the cap", () => {
   const snapshot = {
     prExists: true,
     prNumber: 17,
@@ -1228,7 +1365,10 @@ test("low-signal heuristic can still suppress a round-cap re-opened re-request w
     lowSignalMaxComments: 2,
   };
 
+  // At the cap with a clean PR the loop proceeds to the pre_approval_gate fallback.
+  // The low-signal heuristic only suppresses a permitted re-request (READY_TO_REREQUEST_REVIEW),
+  // which is forbidden at the cap, so it never applies here.
   const result = interpretLoopState(snapshot, refinementConfig);
-  assert.equal(result.state, STATE.LOW_SIGNAL_CONVERGED);
-  assert.equal(result.roundCapCleanEligible, false);
+  assert.equal(result.state, STATE.ROUND_CAP_CLEAN_FALLBACK);
+  assert.equal(result.roundCapCleanEligible, true);
 });

--- a/packages/core/test/copilot-loop-state.test.mjs
+++ b/packages/core/test/copilot-loop-state.test.mjs
@@ -1185,7 +1185,7 @@ test("interpretLoopState keeps WAITING_FOR_COPILOT_REVIEW when cap NOT reached w
   assert.equal(result.roundCapCleanEligible, false);
 });
 
-test("interpretLoopState routes to ROUND_CAP_REACHED when cap reached with unresolved threads and already-requested assignment", () => {
+test("interpretLoopState keeps UNRESOLVED_FEEDBACK_PRESENT (not a clean fallback) when cap reached with unresolved threads and an in-flight request", () => {
   const snapshot = {
     prExists: true,
     prNumber: 847,
@@ -1223,7 +1223,10 @@ test("interpretLoopState does not produce a clean fallback when cap reached with
   const refinementConfig = { maxCopilotRounds: 5 };
 
   const result = interpretLoopState(snapshot, refinementConfig);
-  assert.notEqual(result.state, STATE.ROUND_CAP_CLEAN_FALLBACK);
+  // Not clean (failing CI) + in-flight request at the cap: falls through to the normal
+  // wait routing (threads are 0 and a request is in flight) → WAITING_FOR_COPILOT_REVIEW,
+  // never a clean fallback.
+  assert.equal(result.state, STATE.WAITING_FOR_COPILOT_REVIEW);
   assert.equal(result.roundCapCleanEligible, false);
 });
 

--- a/test/github/request-copilot-review.test.mjs
+++ b/test/github/request-copilot-review.test.mjs
@@ -895,8 +895,8 @@ test("request-copilot-review respects low-signal refinement config before auto r
   }
 });
 
-test("request-copilot-review automatically re-requests at round cap when new commits land after resolved comments", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-roundcap-auto-rerequest-"));
+test("request-copilot-review does NOT auto re-request at round cap when new commits land after resolved comments (no illegal over-cap re-request)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-roundcap-no-auto-rerequest-"));
 
   try {
     const env = await writeGhStub(tempDir, [
@@ -912,31 +912,18 @@ test("request-copilot-review automatically re-requests at round cap when new com
         assertArgs: ["api", "graphql"],
         stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n',
       },
-      {
-        assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
-        stdout: "https://github.com/owner/repo/pull/17\n",
-      },
-      {
-        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
-        stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n',
-      },
-      {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
-        stdout: '{"headRefOid":"newsha","isDraft":false,"state":"OPEN","number":17,"reviews":[{"id":"r-1","state":"COMMENTED","author":{"login":"copilot-pull-request-reviewer[bot]"},"commit":{"oid":"sha1"}},{"id":"r-2","state":"COMMENTED","author":{"login":"copilot-pull-request-reviewer[bot]"},"commit":{"oid":"sha2"}}],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
-      },
     ]);
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
     assert.equal(result.code, 0);
     assert.equal(result.stderr, "");
-    assert.deepEqual(JSON.parse(result.stdout), {
-      ok: true,
-      status: "requested",
-      repo: "owner/repo",
-      pr: 17,
-      reviewer: "Copilot",
-    });
+    // At the cap, a head advance no longer re-opens an automatic Copilot re-request.
+    // The round cap is respected; the pre_approval_gate reviews the current head.
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.status, "round_cap_reached");
+    assert.equal(output.reviewer, "Copilot");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -1252,7 +1252,7 @@ test("copilot-pr-handoff keeps same-head suppression (no force flag)", async () 
   }
 });
 
-test("copilot-pr-handoff re-requests at round cap when new commits land after resolved comments", async () => {
+test("copilot-pr-handoff stops at round_cap_clean_fallback (no re-request) when new commits land after resolved comments", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-round-cap-rerequest-"));
 
   try {
@@ -1384,11 +1384,14 @@ test("copilot-pr-handoff re-requests at round cap when new commits land after re
 
     const output = JSON.parse(result.stdout);
     assert.equal(output.ok, true);
-    assert.equal(output.action, "watch");
-    assert.equal(output.state, "waiting_for_copilot_review");
-    assert.equal(output.reviewRequestStatus, "requested");
-    assert.equal(output.loopDisposition, "pending");
-    assert.equal(output.terminal, false);
+    // Head advanced past the last review at the cap: no Copilot re-request is permitted.
+    // The loop proceeds to the pre_approval_gate fallback (terminal/proceeding) rather
+    // than re-requesting and waiting for a review that would be an over-cap round.
+    assert.equal(output.action, "stop");
+    assert.equal(output.state, "round_cap_clean_fallback");
+    assert.equal(output.roundCapCleanEligible, true);
+    assert.equal(output.loopDisposition, "done");
+    assert.equal(output.terminal, true);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/detect-copilot-loop-state-auto-detect.test.mjs
+++ b/test/loop/detect-copilot-loop-state-auto-detect.test.mjs
@@ -533,7 +533,7 @@ test("detect-copilot-loop-state keeps zero-suite current-head CI at none under r
 });
 
 
-test("detect-copilot-loop-state re-opens round-cap clean PRs when new commits land after resolved comments", async () => {
+test("detect-copilot-loop-state routes round-cap clean PRs to round_cap_clean_fallback when new commits land after resolved comments", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-round-cap-rerequest-"));
 
   try {
@@ -616,9 +616,11 @@ test("detect-copilot-loop-state re-opens round-cap clean PRs when new commits la
     const output = JSON.parse(result.stdout);
     assert.equal(output.snapshot.ciStatus, "success");
     assert.equal(output.snapshot.copilotReviewOnCurrentHead, false);
-    assert.equal(output.state, "ready_to_rerequest_review");
-    assert.equal(output.autoRerequestEligible, true);
-    assert.equal(output.terminal, false);
+    // Head advanced past last review, but the cap forbids another Copilot round, so
+    // proceed to the pre_approval_gate fallback instead of an illegal re-request.
+    assert.equal(output.state, "round_cap_clean_fallback");
+    assert.equal(output.autoRerequestEligible, false);
+    assert.equal(output.terminal, true);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/detect-copilot-loop-state-input-modes.test.mjs
+++ b/test/loop/detect-copilot-loop-state-input-modes.test.mjs
@@ -118,7 +118,7 @@ test("detect-copilot-loop-state --input routes already-fixed threads to already_
   }
 });
 
-test("detect-copilot-loop-state --input re-opens clean exhausted rounds to ready_to_rerequest_review when head changed", async () => {
+test("detect-copilot-loop-state --input routes clean exhausted rounds to round_cap_clean_fallback when head changed (no illegal re-request)", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-round-cap-clean-"));
 
   try {
@@ -139,10 +139,12 @@ test("detect-copilot-loop-state --input re-opens clean exhausted rounds to ready
 
     assert.equal(result.code, 0);
     const output = JSON.parse(result.stdout);
-    assert.equal(output.state, "ready_to_rerequest_review");
-    assert.equal(output.autoRerequestEligible, true);
-    assert.equal(output.terminal, false);
-    assert.match(output.nextAction, /Re-request Copilot review/i);
+    // Head advanced past the last review, but the cap forbids another Copilot round,
+    // so proceed to the pre_approval_gate fallback instead of re-requesting.
+    assert.equal(output.state, "round_cap_clean_fallback");
+    assert.equal(output.autoRerequestEligible, false);
+    assert.equal(output.terminal, true);
+    assert.match(output.nextAction, /pre_approval_gate/i);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

When the Copilot round cap was reached and a commit was pushed afterward (even docs-only), GitHub kept the reviewer assigned (`copilotReviewRequestStatus: "already-requested"`), making `reviewInFlight` true. That **skipped the entire round-cap block**, so state fell through to `WAITING_FOR_COPILOT_REVIEW` with `autoRerequestEligible: false` — an unsatisfiable wait (no re-request is permitted past the cap). Hit live on #842/#847; required an operator override to merge.

## Fix

In `interpretLoopState`: `copilotReviewRoundCount` counts **completed** rounds, so at `>= maxRounds` every permitted round is done and any in-flight request is for a forbidden over-cap round. So:

- **At the cap + clean threads + green CI → `ROUND_CAP_CLEAN_FALLBACK`**, regardless of a lingering reviewer assignment or an advanced head. The `pre_approval_gate` (enforced on current-head clean evidence in `pr-gate-coordination.mjs`) re-reviews any post-cap head change, so **no new code skips review** — it just stops waiting on Copilot specifically.
- A lingering/in-flight request only still blocks the cap block when the PR is **not** clean (unresolved threads or non-green CI) — that stays in normal fix/wait routing.
- Removed the head-advanced `READY_TO_REREQUEST_REVIEW` re-open branch, which contradicted the never-re-request-past-cap contract by implying an illegal auto re-request.

## Tests

Clean-at-cap with lingering assignment / advanced head → clean fallback (no illegal re-request); below-cap `already-requested` still `WAITING_FOR_COPILOT_REVIEW` (regression guard); not-clean-at-cap paths unchanged (unresolved → reached; failing CI → not clean fallback; not-clean + in-flight → fix/wait). Updated knock-on expectations in the detector, request-copilot-review, and handoff tests. `npm run verify` passes.

Closes #848
