### PR TITLE
test(gate): regression-guard #836 out-of-order draft-gate transition (+ verify defects resolved)

### DIFF
--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -985,6 +985,35 @@ test("non-round-cap PR without draft_gate evidence is still blocked from final a
   assert.match(result.reason, /no gate exemptions, #579/i);
 });
 
+test("#836: a PR un-drafted externally before draft_gate ran is caught at the merge boundary (reconcile_draft_gate, #579) — the out-of-order transition is no longer silent", () => {
+  // #836 defect 2: a PR was marked ready-for-review outside the loop, so draft_gate never ran
+  // and no draft_gate comment exists. The original report was that "no detector caught the
+  // out-of-order transition." It is caught now: a non-draft PR with no clean draft_gate evidence
+  // (and not in the round-cap clean-fallback equivalence of #587) cannot reach final approval —
+  // it routes to reconcile_draft_gate and merge is forbidden.
+  const result = evaluatePrGateCoordination({
+    pr: 20326,
+    currentHeadSha: "abc123456789",
+    prDraft: false, // un-drafted externally
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    loopDisposition: DISPOSITION.CLEAN_CONVERGED,
+    sameHeadCleanConverged: true,
+    ciStatus: "success",
+    copilotReviewRoundCount: 2,
+    maxCopilotRounds: 5, // NOT at the cap → the #587 round-cap draft-gate equivalence does not apply
+    draftGate: gate({ visible: false }), // draft_gate never ran
+    draftGateMarker: gate({ visible: false }),
+    preApprovalGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
+    preApprovalGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.notEqual(result.gateBoundary, PR_CHECKPOINT.FINAL_APPROVAL_READY);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RECONCILE_DRAFT_GATE);
+  assert.equal(result.draftGateAlreadySatisfied, false);
+  assert.ok(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY));
+  assert.match(result.reason, /no gate exemptions, #579/i);
+});
+
 
 // ── LOW_SIGNAL_CONVERGED gate routing tests ─────────────────────────────
 

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -1007,7 +1007,7 @@ test("#836: a PR un-drafted externally before draft_gate ran is caught at the me
     preApprovalGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
   });
 
-  assert.notEqual(result.gateBoundary, PR_CHECKPOINT.FINAL_APPROVAL_READY);
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.DRAFT_GATE_NEEDED);
   assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RECONCILE_DRAFT_GATE);
   assert.equal(result.draftGateAlreadySatisfied, false);
   assert.ok(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY));

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -1010,6 +1010,10 @@ test("#836: a PR un-drafted externally before draft_gate ran is caught at the me
   assert.equal(result.gateBoundary, PR_CHECKPOINT.DRAFT_GATE_NEEDED);
   assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RECONCILE_DRAFT_GATE);
   assert.equal(result.draftGateAlreadySatisfied, false);
+  // Lock the "draft_gate never ran" precondition: no clean evidence, and no visible
+  // draft_gate comment at all (matches the surrounding #579/#587 tests).
+  assert.equal(result.draftGate.cleanEvidenceExists, false);
+  assert.equal(result.draftGate.anyVisible, false);
   assert.ok(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY));
   assert.match(result.reason, /no gate exemptions, #579/i);
 });


### PR DESCRIPTION
## Summary

#836 reported two defects against the **Pi main-agent/async-subagent** topology. Both are addressed by changes that landed after it was filed; this PR adds a regression guard for the enforced path and closes the issue.

### Defect 1 — relayed-authorization deadlock (`blocked_needs_user_decision`)
**Moot under the Claude harness.** The Pi "umbrella" (read-only main agent that must relay authorization to an async subagent) was collapsed to a single agent in #837/#839 — the dev-loop agent accepts the user's authorization directly, with no relay boundary. Verified: the generated Claude `main-agent-contract` bundle carries **zero** Pi read-only/relay prose and states "the dev-loop runs as a single agent."

### Defect 2 — draft-gate ordering not enforced after external un-draft
**Now enforced.** A non-draft PR with no clean `draft_gate` evidence is routed to `reconcile_draft_gate` and merge is forbidden (`#579`, "no gate exemptions"). The original "no detector caught the out-of-order transition" report predates that enforcement. This PR adds an explicitly #836-named regression test for that path. (7 existing tests already cover the `reconcile_draft_gate` enforcement at the pre-approval/final-approval boundaries.)

## Noted residual (deliberate, not changed here)

The round-cap clean fallback still auto-satisfies the draft gate (`#587` — "round-cap clean fallback accepted as draft gate equivalent"), an explicit and auditable equivalence shown in the gate reason. This technically contradicts `#579`'s "no exemptions"; reversing it would force the disruptive `reconcile-draft-gate` flow (flip the converged PR back to draft and re-ready it). That's a genuine #579-vs-#587 tradeoff worth a separate decision rather than a silent reversal — flagged for follow-up.

No behavior change. `npm run verify` passes.

Closes #836
