### PR TITLE
refactor(cli): migrate while/shift arg parsers to node:util.parseArgs (#808)

### DIFF
--- a/packages/core/src/bash-exit-one.mjs
+++ b/packages/core/src/bash-exit-one.mjs
@@ -1,5 +1,6 @@
 import { appendFile, mkdir } from "node:fs/promises";
 import path from "node:path";
+import { parseArgs } from "node:util";
 
 export const DEFAULT_OUTPUT_LIMIT = 4000;
 
@@ -79,23 +80,40 @@ export async function appendBashExitOneRecord(logPath, record) {
 }
 
 export function parseCliArgs(argv) {
-  const args = [...argv];
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      log: { type: "string" },
+      record: { type: "string" },
+    },
+    allowPositionals: false,
+    strict: false,
+    tokens: true,
+  });
+
   let logPath;
   let recordJson;
 
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--log") {
-      logPath = args.shift();
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw new Error(`Unknown argument: ${token.value}`);
+    }
+
+    if (token.kind !== "option") {
       continue;
     }
 
-    if (token === "--record") {
-      recordJson = args.shift();
+    if (token.name === "log") {
+      logPath = token.value;
       continue;
     }
 
-    throw new Error(`Unknown argument: ${token}`);
+    if (token.name === "record") {
+      recordJson = token.value;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${token.rawName}`);
   }
 
   if (!logPath) {

--- a/packages/core/src/bash-exit-one.mjs
+++ b/packages/core/src/bash-exit-one.mjs
@@ -86,7 +86,7 @@ export function parseCliArgs(argv) {
       log: { type: "string" },
       record: { type: "string" },
     },
-    allowPositionals: false,
+    allowPositionals: true,
     strict: false,
     tokens: true,
   });

--- a/packages/core/src/cli/primitives.mjs
+++ b/packages/core/src/cli/primitives.mjs
@@ -54,7 +54,9 @@ export function parseCliTokens(argv, options, parseError = null, { allowPosition
     }
 
     if (spec.type === "boolean") {
-      values.set(token.name, true);
+      // A bare boolean flag carries no value (parseArgs → undefined) and means true;
+      // an explicit inline value (e.g. --flag=false) is honored rather than forced true.
+      values.set(token.name, token.value === undefined ? true : token.value !== "false");
       continue;
     }
 

--- a/packages/core/src/cli/primitives.mjs
+++ b/packages/core/src/cli/primitives.mjs
@@ -1,9 +1,72 @@
 import { spawn } from "node:child_process";
+import { parseArgs } from "node:util";
 
 /**
  * Shared CLI primitives for arg parsing, validation, and child process execution.
  * Extracted from scripts/_cli-primitives.mjs per issue #548 Phase 2.
  */
+
+/**
+ * Parse argv with node:util parseArgs while preserving the legacy hand-rolled
+ * parser semantics that several callers depend on:
+ *
+ * - Unknown options/positionals throw `Unknown argument: <raw>`.
+ * - A string option whose value is missing or looks like another flag throws
+ *   `Missing value for <--flag>` (matching {@link requireOptionValue}).
+ *
+ * Returns a Map of canonical option name -> value (last-wins for repeats, which
+ * matches the legacy while/shift loops that simply reassigned on each match).
+ *
+ * @param {string[]} argv
+ * @param {Record<string, { type: "string" | "boolean", short?: string }>} options
+ * @param {(message: string) => Error} [parseError]
+ * @param {{ allowPositionals?: boolean, flagPattern?: RegExp }} [config]
+ * @returns {{ values: Map<string, string | boolean>, positionals: string[] }}
+ */
+export function parseCliTokens(argv, options, parseError = null, { allowPositionals = false, flagPattern = /^--/u } = {}) {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options,
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+
+  const values = new Map();
+  const positionals = [];
+
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      if (allowPositionals) {
+        positionals.push(token.value);
+        continue;
+      }
+      throw toCliError(`Unknown argument: ${token.value}`, parseError);
+    }
+
+    if (token.kind !== "option") {
+      continue;
+    }
+
+    const spec = options[token.name];
+    if (!spec) {
+      throw toCliError(`Unknown argument: ${token.rawName}`, parseError);
+    }
+
+    if (spec.type === "boolean") {
+      values.set(token.name, true);
+      continue;
+    }
+
+    const value = token.value;
+    if (typeof value !== "string" || value.length === 0 || flagPattern.test(value)) {
+      throw toCliError(`Missing value for ${token.rawName}`, parseError);
+    }
+    values.set(token.name, value);
+  }
+
+  return { values, positionals };
+}
 
 function toCliError(message, parseError) {
   if (typeof parseError === "function") {
@@ -16,6 +79,25 @@ export function requireOptionValue(args, flag, parseError = null, { flagPattern 
   const value = args.shift();
   if (typeof value !== "string" || value.length === 0 || flagPattern.test(value)) {
     throw toCliError(`Missing value for ${flag}`, parseError);
+  }
+  return value;
+}
+
+/**
+ * Token-based equivalent of {@link requireOptionValue} for callers that have
+ * migrated to node:util parseArgs with `tokens: true`. Validates the value
+ * attached to a parsed option token, rejecting missing or flag-like values with
+ * the same `Missing value for <--flag>` message the legacy parsers emitted.
+ *
+ * @param {{ value?: string, rawName?: string }} token - a parseArgs option token
+ * @param {(message: string) => Error} [parseError]
+ * @param {{ flagPattern?: RegExp }} [config]
+ * @returns {string}
+ */
+export function requireTokenValue(token, parseError = null, { flagPattern = /^--/u } = {}) {
+  const value = token?.value;
+  if (typeof value !== "string" || value.length === 0 || flagPattern.test(value)) {
+    throw toCliError(`Missing value for ${token?.rawName}`, parseError);
   }
   return value;
 }

--- a/packages/core/src/github/review-threads.mjs
+++ b/packages/core/src/github/review-threads.mjs
@@ -1,5 +1,7 @@
 import { readFile } from "node:fs/promises";
 
+import { parseCliTokens } from "../cli/primitives.mjs";
+
 function normalizeId(value, fallback) {
   if (typeof value === "string" && value.trim().length > 0) {
     return value.trim();
@@ -266,34 +268,14 @@ export function classifyReviewThreadsSignal(parsedResult, isCopilotLoginFn) {
 }
 
 
-function requireOptionValue(args, flag) {
-  const value = args.shift();
-
-  if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
-    throw new Error(`Missing value for ${flag}`);
-  }
-
-  return value;
-}
-
 export function parseCliArgs(argv) {
-  const args = [...argv];
-  const options = {
-    inputPath: undefined,
+  const { values } = parseCliTokens(argv, {
+    input: { type: "string" },
+  });
+
+  return {
+    inputPath: values.get("input"),
   };
-
-  while (args.length > 0) {
-    const token = args.shift();
-
-    if (token === "--input") {
-      options.inputPath = requireOptionValue(args, "--input");
-      continue;
-    }
-
-    throw new Error(`Unknown argument: ${token}`);
-  }
-
-  return options;
 }
 
 export async function readInput({ inputPath, stdin = process.stdin } = {}) {

--- a/packages/core/src/loop/phase-files.mjs
+++ b/packages/core/src/loop/phase-files.mjs
@@ -1,6 +1,8 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
+import { parseCliTokens } from "../cli/primitives.mjs";
+
 export function createDefaultPhaseManifest(phase) {
   return {
     phase,
@@ -134,44 +136,18 @@ export async function ensurePhaseFiles(projectRoot, phase, patch = {}) {
   };
 }
 
-function requireOptionValue(args, flag) {
-  const value = args.shift();
-
-  if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
-    throw new Error(`Missing value for ${flag}`);
-  }
-
-  return value;
-}
-
 export function parseCliArgs(argv) {
-  const args = [...argv];
+  const { values } = parseCliTokens(argv, {
+    "project-root": { type: "string" },
+    phase: { type: "string" },
+    patch: { type: "string" },
+  });
+
   const options = {
-    projectRoot: process.cwd(),
-    phase: undefined,
-    patch: {},
+    projectRoot: values.has("project-root") ? values.get("project-root") : process.cwd(),
+    phase: values.get("phase"),
+    patch: values.has("patch") ? JSON.parse(values.get("patch")) : {},
   };
-
-  while (args.length > 0) {
-    const token = args.shift();
-
-    if (token === "--project-root") {
-      options.projectRoot = requireOptionValue(args, "--project-root");
-      continue;
-    }
-
-    if (token === "--phase") {
-      options.phase = requireOptionValue(args, "--phase");
-      continue;
-    }
-
-    if (token === "--patch") {
-      options.patch = JSON.parse(requireOptionValue(args, "--patch"));
-      continue;
-    }
-
-    throw new Error(`Unknown argument: ${token}`);
-  }
 
   if (!options.phase) {
     throw new Error("Missing required --phase <phase-name> argument");

--- a/scripts/_cli-primitives.mjs
+++ b/scripts/_cli-primitives.mjs
@@ -1,6 +1,8 @@
 // Re-export from shared library (Phase 2, issue #548)
 export {
+  parseCliTokens,
   requireOptionValue,
+  requireTokenValue,
   parsePositiveInteger,
   parseNonNegativeInteger,
   parsePrNumber,

--- a/scripts/docs/validate-links.mjs
+++ b/scripts/docs/validate-links.mjs
@@ -2,9 +2,10 @@
 import { lstat, readdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
 
 import { isDirectCliRun } from "../_core-helpers.mjs";
-import { requireOptionValue } from "../_cli-primitives.mjs";
+import { requireTokenValue } from "../_cli-primitives.mjs";
 
 const DEFAULT_SCAN_PATHS = Object.freeze([
   "README.md",
@@ -52,26 +53,34 @@ function parseError(message) {
 }
 
 export function parseValidateLinksCliArgs(argv) {
-  const args = [...argv];
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: { help: { type: "boolean", short: "h" }, root: { type: "string" } },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
   const options = {
     help: false,
     repoRoot: resolveDefaultRepoRoot(),
   };
 
-  while (args.length > 0) {
-    const token = args.shift();
-
-    if (token === "--help" || token === "-h") {
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-
-    if (token === "--root") {
-      options.repoRoot = path.resolve(requireOptionValue(args, "--root"));
+    if (token.name === "root") {
+      options.repoRoot = path.resolve(requireTokenValue(token));
       continue;
     }
-
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
 
   return options;

--- a/scripts/github/capture-review-threads.mjs
+++ b/scripts/github/capture-review-threads.mjs
@@ -8,7 +8,8 @@ import {
   parseReviewThreads,
   readInput,
 } from "../_core-helpers.mjs";
-import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parseArgs } from "node:util";
+import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 export const REVIEW_THREADS_QUERY = [
   "query($owner: String!, $name: String!, $pr: Int!) {",
@@ -49,7 +50,19 @@ Exit codes:
   1   Error
 `;
 export function parseCaptureCliArgs(argv) {
-  const args = [...argv];
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      input: { type: "string" },
+      output: { type: "string" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
   const options = {
     inputPath: undefined,
     outputPath: undefined,
@@ -57,29 +70,34 @@ export function parseCaptureCliArgs(argv) {
     pr: undefined,
     help: false,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw new Error(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--input") {
-      options.inputPath = requireOptionValue(args, "--input");
+    if (token.name === "input") {
+      options.inputPath = requireTokenValue(token);
       continue;
     }
-    if (token === "--output") {
-      options.outputPath = requireOptionValue(args, "--output");
+    if (token.name === "output") {
+      options.outputPath = requireTokenValue(token);
       continue;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo");
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token);
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePrNumber(requireOptionValue(args, "--pr"));
+    if (token.name === "pr") {
+      options.pr = parsePrNumber(requireTokenValue(token));
       continue;
     }
-    throw new Error(`Unknown argument: ${token}`);
+    throw new Error(`Unknown argument: ${token.rawName}`);
   }
   const hasLiveArgs = options.repo !== undefined || options.pr !== undefined;
   const hasCompleteLiveArgs = options.repo !== undefined && options.pr !== undefined;

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { parseArgs } from "node:util";
 import {
   buildParseError,
   formatCliError,
@@ -8,7 +9,7 @@ import {
   summarizeGateReviewCommentMarkers,
   summarizeGateReviewComments,
 } from "../_core-helpers.mjs";
-import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { ensureAsyncRunnerOwnership } from "../loop/_pr-runner-coordination.mjs";
@@ -84,30 +85,46 @@ Exit codes:
   1  Argument error, gh failure, malformed gh JSON, or missing required pre-merge gate evidence.`.trim();
 const parseError = buildParseError(USAGE);
 export function parseDetectCheckpointEvidenceCliArgs(argv) {
-  const args = [...argv];
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+      "require-before-merge": { type: "boolean" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
   const options = {
     help: false,
     repo: undefined,
     pr: undefined,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+    if (token.name === "pr") {
+      options.pr = parsePrNumber(requireTokenValue(token, parseError), parseError);
       continue;
     }
-    if (token === "--require-before-merge") {
+    if (token.name === "require-before-merge") {
       throw parseError(`--require-before-merge has been removed: gate evidence enforcement is now always-on by default. Omit the flag.`);
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.repo === undefined || options.pr === undefined) {
     throw parseError("detect-checkpoint-evidence requires both --repo <owner/name> and --pr <number>");

--- a/scripts/github/detect-linked-issue-pr.mjs
+++ b/scripts/github/detect-linked-issue-pr.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
+import { parseArgs } from "node:util";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { parseIssueNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parseIssueNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 export const LINKED_ISSUE_PR_QUERY = [
   "query($owner:String!, $name:String!, $issue:Int!, $after:String) {",
@@ -75,27 +76,38 @@ Error output (stderr, JSON):
     { "ok": false, "error": "..." }`.trim();
 const parseError = buildParseError(USAGE);
 export function parseDetectLinkedIssuePrCliArgs(argv) {
-  const args = [...argv];
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: { help: { type: "boolean", short: "h" }, repo: { type: "string" }, issue: { type: "string" } },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
   const options = {
     help: false,
     repo: undefined,
     issue: undefined,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--issue") {
-      options.issue = parseIssueNumber(requireOptionValue(args, "--issue", parseError), parseError);
+    if (token.name === "issue") {
+      options.issue = parseIssueNumber(requireTokenValue(token, parseError), parseError);
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.repo === undefined || options.issue === undefined) {
     throw parseError("Linked PR detection requires both --repo <owner/name> and --issue <number>");

--- a/scripts/github/manage-sub-issues.mjs
+++ b/scripts/github/manage-sub-issues.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
+import { parseArgs } from "node:util";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { parsePositiveInteger, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parsePositiveInteger, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 const USAGE = `Usage: manage-sub-issues.mjs <command> --repo <owner/name> --issue <number> [options]
 Deterministic helper for reading, linking, ordering, and verifying GitHub sub-issue trees.
@@ -76,37 +77,57 @@ export function parseManageSubIssuesCliArgs(argv) {
     expected: undefined,
     ordered: false,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args,
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      issue: { type: "string" },
+      child: { type: "string" },
+      order: { type: "string" },
+      expected: { type: "string" },
+      ordered: { type: "boolean" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--issue") {
-      options.issue = parsePositiveInteger(requireOptionValue(args, "--issue", parseError), "Issue number", parseError);
+    if (token.name === "issue") {
+      options.issue = parsePositiveInteger(requireTokenValue(token, parseError), "Issue number", parseError);
       continue;
     }
-    if (token === "--child") {
-      options.child = parsePositiveInteger(requireOptionValue(args, "--child", parseError), "Issue number", parseError);
+    if (token.name === "child") {
+      options.child = parsePositiveInteger(requireTokenValue(token, parseError), "Issue number", parseError);
       continue;
     }
-    if (token === "--order") {
-      options.order = parseIssueList(requireOptionValue(args, "--order", parseError));
+    if (token.name === "order") {
+      options.order = parseIssueList(requireTokenValue(token, parseError));
       continue;
     }
-    if (token === "--expected") {
-      options.expected = parseIssueList(requireOptionValue(args, "--expected", parseError));
+    if (token.name === "expected") {
+      options.expected = parseIssueList(requireTokenValue(token, parseError));
       continue;
     }
-    if (token === "--ordered") {
+    if (token.name === "ordered") {
       options.ordered = true;
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.repo === undefined || options.issue === undefined) {
     throw parseError("Both --repo <owner/name> and --issue <number> are required");

--- a/scripts/github/probe-copilot-review.mjs
+++ b/scripts/github/probe-copilot-review.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import { setTimeout as delay } from "node:timers/promises";
 import { buildParseError, formatCliError, isCopilotLogin, isDirectCliRun, parseJsonText, parseReviewThreads } from "../_core-helpers.mjs";
-import { parsePositiveInteger, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parseArgs } from "node:util";
+import { parsePositiveInteger, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import {
   DEFAULT_POLL_INTERVAL_MS,
@@ -88,7 +89,13 @@ function rejectRemovedFlag(token) {
   );
 }
 export function parseWatchCliArgs(argv) {
-  const args = [...argv];
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: { help: { type: "boolean", short: "h" }, repo: { type: "string" }, pr: { type: "string" } },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
   const options = {
     help: false,
     repo: undefined,
@@ -96,24 +103,29 @@ export function parseWatchCliArgs(argv) {
     pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
     timeoutMs: COPILOT_REVIEW_WAIT_TIMEOUT_MS,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (REMOVED_FLAGS.has(token)) {
-      rejectRemovedFlag(token);
+    if (REMOVED_FLAGS.has(token.rawName)) {
+      rejectRemovedFlag(token.rawName);
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePositiveInteger(requireOptionValue(args, "--pr", parseError), "--pr", parseError);
+    if (token.name === "pr") {
+      options.pr = parsePositiveInteger(requireTokenValue(token, parseError), "--pr", parseError);
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.repo === undefined || options.pr === undefined) {
     throw parseError("Watching Copilot review requires both --repo <owner/name> and --pr <number>");

--- a/scripts/github/ready-for-review.mjs
+++ b/scripts/github/ready-for-review.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
+import { parseArgs } from "node:util";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText, summarizeGateReviewComments, summarizeGateReviewCommentMarkers } from "../_core-helpers.mjs";
-import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { loadDevLoopConfig, resolveGateConfig } from "@dev-loops/core/config";
 import { findBlockingTitleMarkers } from "@dev-loops/core/loop/pr-title-markers";
@@ -10,13 +11,21 @@ const parseError = buildParseError(USAGE);
 const PR_VIEW_QUERY = `query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { pullRequest(number:$number) { id, isDraft, headRefOid, state, mergeStateStatus, title } } }`;
 
 export function parseReadyForReviewCliArgs(argv) {
-  const args = [...argv], opts = { help: false, repo: undefined, pr: undefined };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") { opts.help = true; return opts; }
-    if (token === "--repo") { opts.repo = requireOptionValue(args, "--repo", parseError).trim(); continue; }
-    if (token === "--pr") { opts.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError); continue; }
-    throw parseError(`Unknown argument: ${token}`);
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: { help: { type: "boolean", short: "h" }, repo: { type: "string" }, pr: { type: "string" } },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  const opts = { help: false, repo: undefined, pr: undefined };
+  for (const token of tokens) {
+    if (token.kind === "positional") throw parseError(`Unknown argument: ${token.value}`);
+    if (token.kind !== "option") continue;
+    if (token.name === "help") { opts.help = true; return opts; }
+    if (token.name === "repo") { opts.repo = requireTokenValue(token, parseError).trim(); continue; }
+    if (token.name === "pr") { opts.pr = parsePrNumber(requireTokenValue(token, parseError), parseError); continue; }
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (!opts.repo || opts.pr === undefined) throw parseError("ready-for-review requires --repo and --pr");
   parseRepoSlug(opts.repo);

--- a/scripts/github/reconcile-draft-gate.mjs
+++ b/scripts/github/reconcile-draft-gate.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
+import { parseArgs } from "node:util";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { loadDevLoopConfig, resolveGateConfig } from "@dev-loops/core/config";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { detectCheckpointEvidence } from "./detect-checkpoint-evidence.mjs";
@@ -36,27 +37,38 @@ Exit codes:
   1  Argument error, gh failure, or unrecoverable state`.trim();
 const parseError = buildParseError(USAGE);
 export function parseReconcileDraftGateCliArgs(argv) {
-  const args = [...argv];
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: { help: { type: "boolean", short: "h" }, repo: { type: "string" }, pr: { type: "string" } },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
   const options = {
     help: false,
     repo: undefined,
     pr: undefined,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+    if (token.name === "pr") {
+      options.pr = parsePrNumber(requireTokenValue(token, parseError), parseError);
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   const missing = ["repo", "pr"].filter((key) => options[key] === undefined);
   if (missing.length > 0) {

--- a/scripts/github/reply-resolve-review-threads.mjs
+++ b/scripts/github/reply-resolve-review-threads.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
+import { parseArgs } from "node:util";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import {
   parsePrNumber,
-  requireOptionValue,
+  requireTokenValue,
 } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import {
@@ -34,7 +35,20 @@ Exit codes:
   1  Argument error or gh/runtime failure`.trim();
 const parseError = buildParseError(USAGE);
 export function parseReplyResolveThreadsCliArgs(argv) {
-  const args = [...argv];
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+      author: { type: "string" },
+      message: { type: "string" },
+      resolve: { type: "boolean" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
   const options = {
     help: false,
     repo: undefined,
@@ -43,33 +57,38 @@ export function parseReplyResolveThreadsCliArgs(argv) {
     message: undefined,
     resolve: false,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+    if (token.name === "pr") {
+      options.pr = parsePrNumber(requireTokenValue(token, parseError), parseError);
       continue;
     }
-    if (token === "--author") {
-      options.author = requireOptionValue(args, "--author", parseError).trim();
+    if (token.name === "author") {
+      options.author = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--message") {
-      options.message = requireOptionValue(args, "--message", parseError);
+    if (token.name === "message") {
+      options.message = requireTokenValue(token, parseError);
       continue;
     }
-    if (token === "--resolve") {
+    if (token.name === "resolve") {
       options.resolve = true;
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.repo === undefined || options.pr === undefined) {
     throw parseError("Replying and resolving review threads requires both --repo <owner/name> and --pr <number>");

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { parseArgs } from "node:util";
 import {
   buildParseError,
   formatCliError,
@@ -7,7 +8,7 @@ import {
   parseReviewThreads,
   summarizeCopilotReviews,
 } from "../_core-helpers.mjs";
-import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { buildSnapshotFromPrFacts, interpretLoopState } from "@dev-loops/core/loop/copilot-loop-state";
@@ -52,32 +53,48 @@ Exit codes:
   1  Argument error or gh failure`.trim();
 const parseError = buildParseError(USAGE);
 export function parseRequestCliArgs(argv) {
-  const args = [...argv];
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      "force-rerequest-review": { type: "boolean" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
   const options = {
     help: false,
     repo: undefined,
     pr: undefined,
     forceRerequestReview: false,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--force-rerequest-review") {
+    if (token.name === "force-rerequest-review") {
       options.forceRerequestReview = true;
       continue;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+    if (token.name === "pr") {
+      options.pr = parsePrNumber(requireTokenValue(token, parseError), parseError);
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.repo === undefined || options.pr === undefined) {
     throw parseError("Requesting Copilot review requires both --repo <owner/name> and --pr <number>");

--- a/scripts/github/resolve-tracker-local-spec.mjs
+++ b/scripts/github/resolve-tracker-local-spec.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
+import { parseArgs } from "node:util";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { parseIssueNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parseIssueNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 const ISSUE_JSON_FIELDS = "number,title,body,url,state";
 const USAGE = `Usage: resolve-tracker-local-spec.mjs (--repo <owner/name> --issue <number> | --issue-url <github-issue-url>)
@@ -60,32 +61,48 @@ export function parseGitHubIssueUrl(value) {
   };
 }
 export function parseResolveTrackerLocalSpecCliArgs(argv) {
-  const args = [...argv];
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      issue: { type: "string" },
+      "issue-url": { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
   const options = {
     help: false,
     repo: undefined,
     issue: undefined,
     issueUrl: undefined,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--issue") {
-      options.issue = parseIssueNumber(requireOptionValue(args, "--issue", parseError), parseError);
+    if (token.name === "issue") {
+      options.issue = parseIssueNumber(requireTokenValue(token, parseError), parseError);
       continue;
     }
-    if (token === "--issue-url") {
-      options.issueUrl = requireOptionValue(args, "--issue-url", parseError).trim();
+    if (token.name === "issue-url") {
+      options.issueUrl = requireTokenValue(token, parseError).trim();
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   const usingIssueUrl = typeof options.issueUrl === "string";
   const usingRepoIssue = options.repo !== undefined || options.issue !== undefined;

--- a/scripts/github/stage-reviewer-draft.mjs
+++ b/scripts/github/stage-reviewer-draft.mjs
@@ -3,7 +3,8 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { parsePositiveInteger, requireOptionValue } from "../_cli-primitives.mjs";
+import { parseArgs } from "node:util";
+import { parsePositiveInteger, requireTokenValue } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { buildDraftReviewPayload } from "@dev-loops/core/loop/reviewer-loop-state";
 const HELP = `Usage: stage-reviewer-draft.mjs --repo <owner/name> --pr <number> --review-file <path> [--local-state-output <path>]
@@ -19,7 +20,19 @@ Exit codes:
   1   Error
 `;
 export function parseStageDraftCliArgs(argv) {
-  const args = [...argv];
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+      "review-file": { type: "string" },
+      "local-state-output": { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
   const options = {
     repo: undefined,
     pr: undefined,
@@ -27,29 +40,34 @@ export function parseStageDraftCliArgs(argv) {
     localStateOutput: undefined,
     help: false,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw new Error(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo").trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token).trim();
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePositiveInteger(requireOptionValue(args, "--pr"), "--pr");
+    if (token.name === "pr") {
+      options.pr = parsePositiveInteger(requireTokenValue(token), "--pr");
       continue;
     }
-    if (token === "--review-file") {
-      options.reviewFile = requireOptionValue(args, "--review-file");
+    if (token.name === "review-file") {
+      options.reviewFile = requireTokenValue(token);
       continue;
     }
-    if (token === "--local-state-output") {
-      options.localStateOutput = requireOptionValue(args, "--local-state-output");
+    if (token.name === "local-state-output") {
+      options.localStateOutput = requireTokenValue(token);
       continue;
     }
-    throw new Error(`Unknown argument: ${token}`);
+    throw new Error(`Unknown argument: ${token.rawName}`);
   }
   if (!options.repo || !options.pr || !options.reviewFile) {
     throw new Error(

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -2,7 +2,8 @@
 import { readFile } from "node:fs/promises";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { loadDevLoopConfig, resolveGateConfig, resolveRefinementConfig } from "@dev-loops/core/config";
-import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parseArgs } from "node:util";
+import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { truncateText } from "@dev-loops/core/bash-exit-one";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { loadPrGateCoordinationContext } from "../loop/detect-pr-gate-coordination-state.mjs";
@@ -198,7 +199,24 @@ export function summarizeCheckpointVerdictText(value, limit = MAX_GATE_COMMENT_T
   return smartTruncate(verboseSummary ?? flat, limit);
 }
 export function parseUpsertCheckpointVerdictCliArgs(argv) {
-  const args = [...argv];
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+      gate: { type: "string" },
+      "head-sha": { type: "string" },
+      verdict: { type: "string" },
+      "findings-summary": { type: "string" },
+      "findings-file": { type: "string" },
+      "next-action": { type: "string" },
+      "findings-severity-counts": { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
   const options = {
     help: false,
     repo: undefined,
@@ -211,65 +229,70 @@ export function parseUpsertCheckpointVerdictCliArgs(argv) {
     nextAction: undefined,
     findingsSeverityCounts: undefined,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (REMOVED_FLAGS.has(token)) {
-      rejectRemovedFlag(token);
+    if (REMOVED_FLAGS.has(token.rawName)) {
+      rejectRemovedFlag(token.rawName);
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+    if (token.name === "pr") {
+      options.pr = parsePrNumber(requireTokenValue(token, parseError), parseError);
       continue;
     }
-    if (token === "--gate") {
-      const gate = normalizeGateName(requireOptionValue(args, "--gate", parseError));
+    if (token.name === "gate") {
+      const gate = normalizeGateName(requireTokenValue(token, parseError));
       if (!gate) {
         throw parseError("--gate must be one of: draft_gate, pre_approval_gate");
       }
       options.gate = gate;
       continue;
     }
-    if (token === "--head-sha") {
-      const headSha = normalizeHeadSha(requireOptionValue(args, "--head-sha", parseError));
+    if (token.name === "head-sha") {
+      const headSha = normalizeHeadSha(requireTokenValue(token, parseError));
       if (!headSha) {
         throw parseError("--head-sha must be a 7-64 character hexadecimal SHA");
       }
       options.headSha = headSha;
       continue;
     }
-    if (token === "--verdict") {
-      const verdict = normalizeVerdict(requireOptionValue(args, "--verdict", parseError));
+    if (token.name === "verdict") {
+      const verdict = normalizeVerdict(requireTokenValue(token, parseError));
       if (!verdict) {
         throw parseError("--verdict must be one of: clean, findings_present, blocked");
       }
       options.verdict = verdict;
       continue;
     }
-    if (token === "--findings-summary") {
-      options.findingsSummary = normalizeRequiredText(requireOptionValue(args, "--findings-summary", parseError), "--findings-summary");
+    if (token.name === "findings-summary") {
+      options.findingsSummary = normalizeRequiredText(requireTokenValue(token, parseError), "--findings-summary");
       continue;
     }
-    if (token === "--findings-file") {
-      const rawPath = requireOptionValue(args, "--findings-file", parseError).trim();
+    if (token.name === "findings-file") {
+      const rawPath = requireTokenValue(token, parseError).trim();
       if (rawPath.length === 0) {
         throw parseError("--findings-file must be a non-empty path");
       }
       options.findingsFile = rawPath;
       continue;
     }
-    if (token === "--next-action") {
-      options.nextAction = normalizeRequiredText(requireOptionValue(args, "--next-action", parseError), "--next-action");
+    if (token.name === "next-action") {
+      options.nextAction = normalizeRequiredText(requireTokenValue(token, parseError), "--next-action");
       continue;
     }
-    if (token === "--findings-severity-counts") {
-      const raw = requireOptionValue(args, "--findings-severity-counts", parseError);
+    if (token.name === "findings-severity-counts") {
+      const raw = requireTokenValue(token, parseError);
       let parsed;
       try {
         parsed = JSON.parse(raw);
@@ -289,7 +312,7 @@ export function parseUpsertCheckpointVerdictCliArgs(argv) {
       options.findingsSeverityCounts = counts;
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   const missing = ["repo", "pr", "headSha", "verdict", "findingsSummary", "nextAction"]
     .filter((key) => options[key] === undefined);

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { parsePrNumber, requireOptionValue } from "../_cli-primitives.mjs";
+import { parseArgs } from "node:util";
+import { parsePrNumber, requireTokenValue } from "../_cli-primitives.mjs";
 import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 const USAGE = `Usage: write-gate-findings-log.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate> --head-sha <sha> --verdict <clean|findings_present|blocked> --findings <json> [--tmp-root <path>]
 Write a durable <gate>-<headSha>.json log under deterministic tmp/ paths.
@@ -89,7 +90,22 @@ function parseFindingsJson(raw) {
   });
 }
 export function parseWriteGateFindingsLogCliArgs(argv) {
-  const args = [...argv];
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+      gate: { type: "string" },
+      "head-sha": { type: "string" },
+      verdict: { type: "string" },
+      findings: { type: "string" },
+      "tmp-root": { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
   const options = {
     repo: undefined,
     pr: undefined,
@@ -99,46 +115,51 @@ export function parseWriteGateFindingsLogCliArgs(argv) {
     findings: undefined,
     tmpRoot: "tmp",
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       return { help: true };
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+    if (token.name === "pr") {
+      options.pr = parsePrNumber(requireTokenValue(token, parseError), parseError);
       continue;
     }
-    if (token === "--gate") {
-      const gate = normalizeGate(requireOptionValue(args, "--gate", parseError));
+    if (token.name === "gate") {
+      const gate = normalizeGate(requireTokenValue(token, parseError));
       if (!gate) throw parseError("--gate must be draft_gate or pre_approval_gate");
       options.gate = gate;
       continue;
     }
-    if (token === "--head-sha") {
-      const sha = normalizeHeadSha(requireOptionValue(args, "--head-sha", parseError));
+    if (token.name === "head-sha") {
+      const sha = normalizeHeadSha(requireTokenValue(token, parseError));
       if (!sha) throw parseError("--head-sha must be a 7-64 character hex SHA");
       options.headSha = sha;
       continue;
     }
-    if (token === "--verdict") {
-      const verdict = normalizeVerdict(requireOptionValue(args, "--verdict", parseError));
+    if (token.name === "verdict") {
+      const verdict = normalizeVerdict(requireTokenValue(token, parseError));
       if (!verdict) throw parseError("--verdict must be clean, findings_present, or blocked");
       options.verdict = verdict;
       continue;
     }
-    if (token === "--findings") {
-      options.findings = requireOptionValue(args, "--findings", parseError);
+    if (token.name === "findings") {
+      options.findings = requireTokenValue(token, parseError);
       continue;
     }
-    if (token === "--tmp-root") {
-      options.tmpRoot = requireOptionValue(args, "--tmp-root", parseError).trim();
+    if (token.name === "tmp-root") {
+      options.tmpRoot = requireTokenValue(token, parseError).trim();
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   const missing = ["repo", "pr", "gate", "headSha", "verdict", "findings"]
     .filter(k => options[k] === undefined);

--- a/scripts/loop/build-handoff-envelope.mjs
+++ b/scripts/loop/build-handoff-envelope.mjs
@@ -18,10 +18,11 @@ import { readFile } from "node:fs/promises";
 import { detectRepoSlug } from "@dev-loops/core/github/repo-slug";
 import path from "node:path";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { requireOptionValue } from "../_cli-primitives.mjs";
+import { requireTokenValue } from "../_cli-primitives.mjs";
 import { buildDevLoopHandoffEnvelope } from "@dev-loops/core/loop/handoff-envelope";
 import { loadDevLoopConfig } from "@dev-loops/core/config";
 import { createPiAdapter } from "@dev-loops/core/harness";
+import { parseArgs } from "node:util";
 
 const USAGE = `Usage: build-handoff-envelope.mjs --input <path>
 Build a deterministic handoff envelope from startup resolver output and settings.
@@ -56,7 +57,6 @@ function parseFlagJson(raw, flagName, parseErrorFn) {
 }
 
 export function parseBuildHandoffEnvelopeCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     inputPath: undefined,
@@ -65,29 +65,47 @@ export function parseBuildHandoffEnvelopeCliArgs(argv) {
     repo: undefined,
   };
 
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      input: { type: "string" },
+      "gate-state": { type: "string" },
+      overrides: { type: "string" },
+      repo: { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--input") {
-      options.inputPath = requireOptionValue(args, "--input", parseError);
+    if (token.name === "input") {
+      options.inputPath = requireTokenValue(token, parseError);
       continue;
     }
-    if (token === "--gate-state") {
-      options.gateState = requireOptionValue(args, "--gate-state", parseError);
+    if (token.name === "gate-state") {
+      options.gateState = requireTokenValue(token, parseError);
       continue;
     }
-    if (token === "--overrides") {
-      options.overrides = requireOptionValue(args, "--overrides", parseError);
+    if (token.name === "overrides") {
+      options.overrides = requireTokenValue(token, parseError);
       continue;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError);
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError);
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
 
   if (!options.inputPath) {

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs";
 import { access, open, readFile, readdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { requireOptionValue } from "../_cli-primitives.mjs";
+import { requireTokenValue } from "../_cli-primitives.mjs";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { autoDetectSnapshot } from "./detect-copilot-loop-state.mjs";
@@ -14,6 +14,7 @@ import {
 } from "./_handoff-contract.mjs";
 import { interpretLoopState, summarizeLoopInterpretation } from "@dev-loops/core/loop/copilot-loop-state";
 import { listOpenPrs } from "./_loop-pr-aggregation.mjs";
+import { parseArgs } from "node:util";
 const USAGE = `Usage: conductor-monitor.mjs --repo <owner/name> [--auto-resume]
 Aggregate Copilot-loop status across all open PRs in one repo.
 Required:
@@ -113,27 +114,42 @@ const MANUAL_REASON = {
   HANDOFF_CONTRACT_MISMATCH: "handoff_contract_mismatch",
 };
 function parseCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     repo: undefined,
     autoResume: false,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      "auto-resume": { type: "boolean" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--auto-resume") {
+    if (token.name === "auto-resume") {
       options.autoResume = true;
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.repo === undefined) {
     throw parseError("conductor-monitor requires --repo <owner/name>");

--- a/scripts/loop/conductor.mjs
+++ b/scripts/loop/conductor.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { runConductorCycle } from "./run-conductor-cycle.mjs";
 import { runConductorMonitor } from "./conductor-monitor.mjs";
-import { requireOptionValue } from "../_cli-primitives.mjs";
+import { requireTokenValue } from "../_cli-primitives.mjs";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import {
@@ -12,6 +12,7 @@ import {
 } from "@dev-loops/core/config";
 import { readFileSync } from "node:fs";
 import path from "node:path";
+import { parseArgs } from "node:util";
 const USAGE = `Usage: conductor.mjs --repo <owner/name> [--auto-resume] [--cycle-only] [--monitor-only] [--require-retrospective]
 Unified conductor entrypoint for dev-loop lifecycle orchestration.`.trim();
 const parseError = buildParseError(USAGE);
@@ -43,7 +44,6 @@ function checkRetrospectiveGate(cwd, requireRetrospective) {
   }
 }
 function parseCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     repo: undefined,
@@ -52,33 +52,52 @@ function parseCliArgs(argv) {
     monitorOnly: false,
     requireRetrospective: false,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      "auto-resume": { type: "boolean" },
+      "cycle-only": { type: "boolean" },
+      "monitor-only": { type: "boolean" },
+      "require-retrospective": { type: "boolean" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--auto-resume") {
+    if (token.name === "auto-resume") {
       options.autoResume = true;
       continue;
     }
-    if (token === "--cycle-only") {
+    if (token.name === "cycle-only") {
       options.cycleOnly = true;
       continue;
     }
-    if (token === "--monitor-only") {
+    if (token.name === "monitor-only") {
       options.monitorOnly = true;
       continue;
     }
-    if (token === "--require-retrospective") {
+    if (token.name === "require-retrospective") {
       options.requireRetrospective = true;
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.repo === undefined) {
     throw parseError("conductor requires --repo <owner/name>");

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { buildParseError, formatCliError, isCopilotLogin, isDirectCliRun, normalizeTimestamp } from "../_core-helpers.mjs";
-import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { detectRepoSlug, parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { resolveRunId } from "@dev-loops/core/loop/run-context";
 import path from "node:path";
@@ -16,6 +16,7 @@ import {
   EXTERNAL_HEALTHY_WAIT_TIMEOUT_POLICY,
   enforceExternalHealthyWaitTimeout,
 } from "@dev-loops/core/loop/timeout-policy";
+import { parseArgs } from "node:util";
 import {
   DEFAULT_POLL_INTERVAL_MS,
   COPILOT_REVIEW_WAIT_TIMEOUT_MS,
@@ -128,39 +129,55 @@ function rejectRemovedFlag(token) {
   );
 }
 export function parseHandoffCliArgs(argv, { cwd = process.cwd() } = {}) {
-  const args = [...argv];
   const options = {
     help: false,
     repo: undefined,
     pr: undefined,
     watchStatus: undefined,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+      "watch-status": { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (REMOVED_FLAGS.has(token)) {
-      rejectRemovedFlag(token);
+    if (REMOVED_FLAGS.has(token.rawName)) {
+      rejectRemovedFlag(token.rawName);
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+    if (token.name === "pr") {
+      options.pr = parsePrNumber(requireTokenValue(token, parseError), parseError);
       continue;
     }
-    if (token === "--watch-status") {
-      const watchStatus = requireOptionValue(args, "--watch-status", parseError).trim().toLowerCase();
+    if (token.name === "watch-status") {
+      const watchStatus = requireTokenValue(token, parseError).trim().toLowerCase();
       if (!VALID_WATCH_STATUSES.has(watchStatus)) {
         throw parseError(`--watch-status must be one of: ${[...VALID_WATCH_STATUSES].join(", ")}`);
       }
       options.watchStatus = watchStatus;
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.pr === undefined) {
     throw parseError("copilot-pr-handoff requires --pr <number>");

--- a/scripts/loop/debt-remediate.mjs
+++ b/scripts/loop/debt-remediate.mjs
@@ -15,9 +15,10 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
+import { parseArgs } from "node:util";
 
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { requireOptionValue } from "../_cli-primitives.mjs";
+import { requireTokenValue } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { DebtSignalSchema } from "@dev-loops/core/debt/signal";
 import { clusterSignalsEnriched } from "@dev-loops/core/debt/cluster";
@@ -150,28 +151,44 @@ function buildReport(signalsCount, findingsCount, results) {
 // ============================================================================
 
 export async function runCli(argv) {
-  const args = [...argv];
   const options = { input: undefined, repo: undefined, dryRun: false, help: false };
 
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      input: { type: "string" },
+      repo: { type: "string" },
+      "dry-run": { type: "boolean" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown flag: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       break;
     }
-    if (token === "--input") {
-      options.input = requireOptionValue(args, "--input", parseError);
+    if (token.name === "input") {
+      options.input = requireTokenValue(token, parseError);
       continue;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError);
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError);
       continue;
     }
-    if (token === "--dry-run") {
+    if (token.name === "dry-run") {
       options.dryRun = true;
       continue;
     }
-    throw parseError(`Unknown flag: ${token}`);
+    throw parseError(`Unknown flag: ${token.rawName}`);
   }
 
   if (options.help) {

--- a/scripts/loop/detect-copilot-loop-state.mjs
+++ b/scripts/loop/detect-copilot-loop-state.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parseArgs } from "node:util";
+import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import {
   buildParseError,
   formatCliError,
@@ -58,32 +59,48 @@ Exit codes:
 const VALID_OVERRIDE_STATUSES = new Set(["requested", "already-requested", "unavailable", "none", "failed"]);
 const parseError = buildParseError(USAGE);
 export function parseDetectCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     inputPath: undefined,
     repo: undefined,
     pr: undefined,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      input: { type: "string" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--input") {
-      options.inputPath = requireOptionValue(args, "--input", parseError);
+    if (token.name === "input") {
+      options.inputPath = requireTokenValue(token, parseError);
       continue;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+    if (token.name === "pr") {
+      options.pr = parsePrNumber(requireTokenValue(token, parseError), parseError);
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.inputPath !== undefined) {
     if (options.repo !== undefined || options.pr !== undefined) {

--- a/scripts/loop/detect-copilot-session-activity.mjs
+++ b/scripts/loop/detect-copilot-session-activity.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { parsePositiveInteger, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parsePositiveInteger, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
+import { parseArgs } from "node:util";
 const USAGE = `Usage: detect-copilot-session-activity.mjs --repo <owner/name> --branch <name> [--limit <number>]
 Detect Copilot GitHub Actions session activity on a branch.
 Required:
@@ -41,32 +42,48 @@ const COPILOT_RUN_NAME_PATTERNS = Object.freeze([
 ]);
 const parseError = buildParseError(USAGE);
 export function parseDetectCopilotSessionActivityCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     repo: undefined,
     branch: undefined,
     limit: DEFAULT_LIMIT,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      branch: { type: "string" },
+      limit: { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--branch") {
-      options.branch = requireOptionValue(args, "--branch", parseError).trim();
+    if (token.name === "branch") {
+      options.branch = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--limit") {
-      options.limit = parsePositiveInteger(requireOptionValue(args, "--limit", parseError), "--limit", parseError);
+    if (token.name === "limit") {
+      options.limit = parsePositiveInteger(requireTokenValue(token, parseError), "--limit", parseError);
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.repo === undefined || options.branch === undefined || options.branch.length === 0) {
     throw parseError("detect-copilot-session-activity requires both --repo <owner/name> and --branch <name>");

--- a/scripts/loop/detect-initial-copilot-pr-state.mjs
+++ b/scripts/loop/detect-initial-copilot-pr-state.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { parseIssueNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parseIssueNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { detectLinkedIssuePr } from "../github/detect-linked-issue-pr.mjs";
 import { detectCopilotSessionActivity } from "./detect-copilot-session-activity.mjs";
+import { parseArgs } from "node:util";
 const USAGE = `Usage: detect-initial-copilot-pr-state.mjs --repo <owner/name> --issue <number>
 Detect whether an assigned issue is still on the bootstrap-only Copilot draft PR
 or has moved into normal linked-PR follow-up.
@@ -79,27 +80,42 @@ const INITIAL_COPILOT_PR_FACTS_QUERY = [
 ].join("\n");
 const parseError = buildParseError(USAGE);
 export function parseDetectInitialCopilotPrStateCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     repo: undefined,
     issue: undefined,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      issue: { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--issue") {
-      options.issue = parseIssueNumber(requireOptionValue(args, "--issue", parseError), parseError);
+    if (token.name === "issue") {
+      options.issue = parseIssueNumber(requireTokenValue(token, parseError), parseError);
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.repo === undefined || options.issue === undefined) {
     throw parseError("detect-initial-copilot-pr-state requires both --repo <owner/name> and --issue <number>");

--- a/scripts/loop/detect-internal-only-pr.mjs
+++ b/scripts/loop/detect-internal-only-pr.mjs
@@ -3,8 +3,9 @@ import { statSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { parse as parseYaml } from "yaml";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
+import { parseArgs } from "node:util";
 
 const USAGE = `Usage: detect-internal-only-pr.mjs --repo <owner/name> --pr <number> [--config <path>]
 Detect whether a PR only touches internal tooling files (scripts, docs, tests, config)
@@ -118,7 +119,6 @@ function buildPatternMatchers(patterns) {
 }
 
 export function parseCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     repo: undefined,
@@ -126,29 +126,47 @@ export function parseCliArgs(argv) {
     config: undefined,
     labelCheck: false,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+      config: { type: "string" },
+      "label-check": { type: "boolean" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+    if (token.name === "pr") {
+      options.pr = parsePrNumber(requireTokenValue(token, parseError), parseError);
       continue;
     }
-    if (token === "--config") {
-      options.config = requireOptionValue(args, "--config", parseError).trim();
+    if (token.name === "config") {
+      options.config = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--label-check") {
+    if (token.name === "label-check") {
       options.labelCheck = true;
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.repo === undefined || options.pr === undefined) {
     throw parseError("detect-internal-only-pr requires both --repo <owner/name> and --pr <number>");

--- a/scripts/loop/detect-issue-refinement-artifact.mjs
+++ b/scripts/loop/detect-issue-refinement-artifact.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import { readFile } from "node:fs/promises";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
+import { parseArgs } from "node:util";
 import {
   detectIssueRefinementArtifact,
   REFINEMENT_SOURCE,
@@ -33,36 +34,52 @@ Error output (stderr, JSON):
   { "ok": false, "error": "...", "usage": "..." }`.trim();
 const parseError = buildParseError(USAGE);
 export function parseDetectIssueRefinementArtifactCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     repo: undefined,
     issue: undefined,
     input: undefined,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      issue: { type: "string" },
+      input: { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--issue") {
-      const value = requireOptionValue(args, "--issue", parseError);
+    if (token.name === "issue") {
+      const value = requireTokenValue(token, parseError);
       if (!/^\d+$/.test(value) || Number(value) === 0) {
         throw parseError("--issue must be a positive integer");
       }
       options.issue = Number(value);
       continue;
     }
-    if (token === "--input") {
-      options.input = requireOptionValue(args, "--input", parseError).trim();
+    if (token.name === "input") {
+      options.input = requireTokenValue(token, parseError).trim();
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   const hasInput = typeof options.input === "string" && options.input.length > 0;
   const hasRemote = typeof options.repo === "string" && options.repo.length > 0 && Number.isInteger(options.issue);

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -11,7 +11,7 @@ import {
   parseReviewThreads,
   summarizeCopilotReviews,
 } from "../_core-helpers.mjs";
-import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { loadDevLoopConfig, resolveGateConfig, resolveRefinementConfig, resolveWorkflowConfig } from "@dev-loops/core/config";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { buildSnapshotFromPrFacts, interpretLoopState, summarizeLoopInterpretation } from "@dev-loops/core/loop/copilot-loop-state";
@@ -19,6 +19,7 @@ import { evaluatePrGateCoordination, PR_CHECKPOINT, PR_CHECKPOINT_ACTION } from 
 import { shouldGuardCopilotReviewRequest } from "@dev-loops/core/loop/pr-gate-coordination";
 import { fetchGithubReviewThreadsPayload } from "../github/capture-review-threads.mjs";
 import { detectCheckpointEvidence } from "../github/detect-checkpoint-evidence.mjs";
+import { parseArgs } from "node:util";
 const UNMERGED_GIT_STATUS_CODES = new Set(["DD", "AU", "UD", "UA", "DU", "AA", "UU"]);
 const USAGE = `Usage: detect-pr-gate-coordination-state.mjs --repo <owner/name> --pr <number>
 Determine which PR gate/transition is legal next for a pull request.
@@ -70,27 +71,42 @@ Exit codes:
   1  Argument error or gh/runtime failure`.trim();
 const parseError = buildParseError(USAGE);
 export function parseDetectPrGateCoordinationCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     repo: undefined,
     pr: undefined,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+    if (token.name === "pr") {
+      options.pr = parsePrNumber(requireTokenValue(token, parseError), parseError);
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.repo === undefined || options.pr === undefined) {
     throw parseError("detect-pr-gate-coordination-state requires both --repo <owner/name> and --pr <number>");

--- a/scripts/loop/detect-reviewer-loop-state.mjs
+++ b/scripts/loop/detect-reviewer-loop-state.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { readFile } from "node:fs/promises";
-import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parseArgs } from "node:util";
+import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import {
@@ -27,6 +28,20 @@ function parseBool(value, flag) {
 }
 export function parseDetectReviewerCliArgs(argv) {
   const args = [...argv];
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      input: { type: "string" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+      "review-requested": { type: "string" },
+      "local-state": { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
   const options = {
     inputPath: undefined,
     repo: undefined,
@@ -35,36 +50,41 @@ export function parseDetectReviewerCliArgs(argv) {
     localStatePath: undefined,
     help: false,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw new Error(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--input") {
-      options.inputPath = requireOptionValue(args, "--input");
+    if (token.name === "input") {
+      options.inputPath = requireTokenValue(token);
       continue;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo").trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token).trim();
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePrNumber(requireOptionValue(args, "--pr"));
+    if (token.name === "pr") {
+      options.pr = parsePrNumber(requireTokenValue(token));
       continue;
     }
-    if (token === "--review-requested") {
+    if (token.name === "review-requested") {
       options.reviewRequestedOverride = parseBool(
-        requireOptionValue(args, "--review-requested"),
+        requireTokenValue(token),
         "--review-requested",
       );
       continue;
     }
-    if (token === "--local-state") {
-      options.localStatePath = requireOptionValue(args, "--local-state");
+    if (token.name === "local-state") {
+      options.localStatePath = requireTokenValue(token);
       continue;
     }
-    throw new Error(`Unknown argument: ${token}`);
+    throw new Error(`Unknown argument: ${token.rawName}`);
   }
   if (options.inputPath !== undefined) {
     if (options.repo !== undefined || options.pr !== undefined) {

--- a/scripts/loop/detect-reviewer-loop-state.mjs
+++ b/scripts/loop/detect-reviewer-loop-state.mjs
@@ -27,7 +27,6 @@ function parseBool(value, flag) {
   throw new Error(`${flag} must be true or false`);
 }
 export function parseDetectReviewerCliArgs(argv) {
-  const args = [...argv];
   const { tokens } = parseArgs({
     args: [...argv],
     options: {

--- a/scripts/loop/detect-stale-runner.mjs
+++ b/scripts/loop/detect-stale-runner.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import process from "node:process";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { parsePrNumber, requireOptionValue } from "../_cli-primitives.mjs";
+import { parsePrNumber, requireTokenValue } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { resolveRunId as resolveEnvRunId } from "@dev-loops/core/loop/run-context";
+import { parseArgs } from "node:util";
 import {
   detectStaleRunner,
   STALE_RUNNER_ERROR,
@@ -50,7 +51,6 @@ Exit codes:
   1  Argument error or stale/exit-signal condition detected`.trim();
 const parseError = buildParseError(USAGE);
 function parseCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     repo: undefined,
@@ -58,22 +58,40 @@ function parseCliArgs(argv) {
     staleRunnerMaxAgeMs: undefined,
     runId: undefined,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+      "stale-runner-max-age-ms": { type: "string" },
+      "run-id": { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+    if (token.name === "pr") {
+      options.pr = parsePrNumber(requireTokenValue(token, parseError), parseError);
       continue;
     }
-    if (token === "--stale-runner-max-age-ms") {
-      const raw = requireOptionValue(args, "--stale-runner-max-age-ms", parseError).trim();
+    if (token.name === "stale-runner-max-age-ms") {
+      const raw = requireTokenValue(token, parseError).trim();
       const parsed = Number(raw);
       if (!Number.isFinite(parsed) || parsed <= 0) {
         throw parseError(`--stale-runner-max-age-ms must be a positive integer (ms), got: ${raw}`);
@@ -81,11 +99,11 @@ function parseCliArgs(argv) {
       options.staleRunnerMaxAgeMs = Math.floor(parsed);
       continue;
     }
-    if (token === "--run-id") {
-      options.runId = requireOptionValue(args, "--run-id", parseError).trim();
+    if (token.name === "run-id") {
+      options.runId = requireTokenValue(token, parseError).trim();
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.repo === undefined || options.pr === undefined) {
     throw parseError("detect-stale-runner requires both --repo <owner/name> and --pr <number>");

--- a/scripts/loop/detect-tracker-pr-state.mjs
+++ b/scripts/loop/detect-tracker-pr-state.mjs
@@ -3,7 +3,8 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildParseError, formatCliError, parseJsonText } from "../_core-helpers.mjs";
-import { requireOptionValue } from "../_cli-primitives.mjs";
+import { requireTokenValue } from "../_cli-primitives.mjs";
+import { parseArgs } from "node:util";
 import {
   interpretTrackerPrState,
   normalizeTrackerPrSnapshot,
@@ -51,22 +52,36 @@ Exit codes:
   1  Argument error or runtime failure`.trim();
 const parseError = buildParseError(USAGE);
 export function parseDetectTrackerPrCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     inputPath: undefined,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      input: { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--input") {
-      options.inputPath = requireOptionValue(args, "--input", parseError);
+    if (token.name === "input") {
+      options.inputPath = requireTokenValue(token, parseError);
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.inputPath === undefined) {
     throw parseError("--input <path> is required");

--- a/scripts/loop/info.mjs
+++ b/scripts/loop/info.mjs
@@ -3,9 +3,10 @@ import { execFileSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { requireOptionValue, parsePositiveInteger } from "../_cli-primitives.mjs";
+import { requireTokenValue, parsePositiveInteger } from "../_cli-primitives.mjs";
 import { detectRepoSlug, normalizeRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { runContextEnv } from "@dev-loops/core/loop/run-context";
+import { parseArgs } from "node:util";
 
 // REPO_ROOT resolves to the git repo root (scripts/loop/info.mjs → scripts/ → repo/)
 const REPO_ROOT = path.resolve(fileURLToPath(new URL("..", import.meta.url)), "..");
@@ -27,16 +28,33 @@ Exit codes:
 const parseError = buildParseError(USAGE);
 
 function parseCliArgs(argv) {
-  const args = [...argv];
   const opts = { help: false, issue: undefined, pr: undefined, json: false, repo: undefined };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") { opts.help = true; return opts; }
-    if (token === "--json") { opts.json = true; continue; }
-    if (token === "--issue") { opts.issue = parsePositiveInteger(requireOptionValue(args, "--issue", parseError), "--issue", parseError); continue; }
-    if (token === "--pr") { opts.pr = parsePositiveInteger(requireOptionValue(args, "--pr", parseError), "--pr", parseError); continue; }
-    if (token === "--repo") { opts.repo = requireOptionValue(args, "--repo", parseError); continue; }
-    throw parseError(`Unknown argument: ${token}`);
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      json: { type: "boolean" },
+      issue: { type: "string" },
+      pr: { type: "string" },
+      repo: { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") { opts.help = true; return opts; }
+    if (token.name === "json") { opts.json = true; continue; }
+    if (token.name === "issue") { opts.issue = parsePositiveInteger(requireTokenValue(token, parseError), "--issue", parseError); continue; }
+    if (token.name === "pr") { opts.pr = parsePositiveInteger(requireTokenValue(token, parseError), "--pr", parseError); continue; }
+    if (token.name === "repo") { opts.repo = requireTokenValue(token, parseError); continue; }
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   const modes = [opts.issue, opts.pr].filter(v => v !== undefined).length;
   if (modes > 1) throw parseError("--issue and --pr are mutually exclusive");

--- a/scripts/loop/inspect-run-viewer/cli.mjs
+++ b/scripts/loop/inspect-run-viewer/cli.mjs
@@ -3,7 +3,8 @@ import {
   DEFAULT_PORT,
   USAGE,
 } from "./constants.mjs";
-import { requireOptionValue } from "../../_cli-primitives.mjs";
+import { parseArgs } from "node:util";
+import { requireTokenValue } from "../../_cli-primitives.mjs";
 import { normalizeInspectionTarget } from "../_inspect-run-viewer-adapter.mjs";
 
 export function parseInspectRunViewerCliError(message) {
@@ -47,7 +48,6 @@ export function normalizeCliRepoOption(rawRepo) {
 }
 
 export function parseInspectRunViewerCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     repo: undefined,
@@ -60,48 +60,71 @@ export function parseInspectRunViewerCliArgs(argv) {
     restart: false,
   };
 
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      pr: { type: "boolean" },
+      host: { type: "string" },
+      port: { type: "string" },
+      "allow-non-localhost": { type: "boolean" },
+      restart: { type: "boolean" },
+      "steering-state-file": { type: "string" },
+      "copilot-input": { type: "string" },
+      "reviewer-input": { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseInspectRunViewerCliError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseInspectRunViewerCliError);
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseInspectRunViewerCliError);
       continue;
     }
-    if (token === "--pr") {
+    if (token.name === "pr") {
       throw parseInspectRunViewerCliError("--pr is no longer supported on the CLI; choose a PR with ?pr=<number> in the viewer URL");
     }
-    if (token === "--host") {
-      options.host = parseHost(requireOptionValue(args, "--host", parseInspectRunViewerCliError));
+    if (token.name === "host") {
+      options.host = parseHost(requireTokenValue(token, parseInspectRunViewerCliError));
       continue;
     }
-    if (token === "--port") {
-      options.port = parsePort(requireOptionValue(args, "--port", parseInspectRunViewerCliError));
+    if (token.name === "port") {
+      options.port = parsePort(requireTokenValue(token, parseInspectRunViewerCliError));
       continue;
     }
-    if (token === "--allow-non-localhost") {
+    if (token.name === "allow-non-localhost") {
       options.allowNonLocalhost = true;
       continue;
     }
-    if (token === "--restart") {
+    if (token.name === "restart") {
       options.restart = true;
       continue;
     }
-    if (token === "--steering-state-file") {
-      options.steeringStateFile = requireOptionValue(args, "--steering-state-file", parseInspectRunViewerCliError);
+    if (token.name === "steering-state-file") {
+      options.steeringStateFile = requireTokenValue(token, parseInspectRunViewerCliError);
       continue;
     }
-    if (token === "--copilot-input") {
-      options.copilotInputPath = requireOptionValue(args, "--copilot-input", parseInspectRunViewerCliError);
+    if (token.name === "copilot-input") {
+      options.copilotInputPath = requireTokenValue(token, parseInspectRunViewerCliError);
       continue;
     }
-    if (token === "--reviewer-input") {
-      options.reviewerInputPath = requireOptionValue(args, "--reviewer-input", parseInspectRunViewerCliError);
+    if (token.name === "reviewer-input") {
+      options.reviewerInputPath = requireTokenValue(token, parseInspectRunViewerCliError);
       continue;
     }
-    throw parseInspectRunViewerCliError(`Unknown argument: ${token}`);
+    throw parseInspectRunViewerCliError(`Unknown argument: ${token.rawName}`);
   }
 
   if (!options.help) {

--- a/scripts/loop/inspect-run.mjs
+++ b/scripts/loop/inspect-run.mjs
@@ -2,7 +2,7 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { buildParseError, formatCliError, parseJsonText, parseReviewThreads } from "../_core-helpers.mjs";
 import { fetchGithubReviewThreadsPayload } from "../github/capture-review-threads.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
@@ -22,6 +22,7 @@ import {
   STEERING_KIND,
 } from "@dev-loops/core/loop/steering";
 import { validateSteeringStateTarget } from "./_steering-state-file.mjs";
+import { parseArgs } from "node:util";
 const USAGE = `Usage: inspect-run.mjs --repo <owner/name> --pr <number>
 Read-only run inspection for the Copilot PR outer-loop family.
 Produces a single JSON snapshot describing the current state of one
@@ -72,7 +73,6 @@ Exit codes:
   1  Argument error or unexpected runtime failure`.trim();
 const parseError = buildParseError(USAGE);
 export function parseInspectRunCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     repo: undefined,
@@ -81,33 +81,52 @@ export function parseInspectRunCliArgs(argv) {
     copilotInputPath: undefined,
     reviewerInputPath: undefined,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+      "steering-state-file": { type: "string" },
+      "copilot-input": { type: "string" },
+      "reviewer-input": { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+    if (token.name === "pr") {
+      options.pr = parsePrNumber(requireTokenValue(token, parseError), parseError);
       continue;
     }
-    if (token === "--steering-state-file") {
-      options.steeringStateFile = requireOptionValue(args, "--steering-state-file", parseError);
+    if (token.name === "steering-state-file") {
+      options.steeringStateFile = requireTokenValue(token, parseError);
       continue;
     }
-    if (token === "--copilot-input") {
-      options.copilotInputPath = requireOptionValue(args, "--copilot-input", parseError);
+    if (token.name === "copilot-input") {
+      options.copilotInputPath = requireTokenValue(token, parseError);
       continue;
     }
-    if (token === "--reviewer-input") {
-      options.reviewerInputPath = requireOptionValue(args, "--reviewer-input", parseError);
+    if (token.name === "reviewer-input") {
+      options.reviewerInputPath = requireTokenValue(token, parseError);
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (!options.help) {
     if (options.repo === undefined || options.pr === undefined) {

--- a/scripts/loop/outer-loop.mjs
+++ b/scripts/loop/outer-loop.mjs
@@ -2,7 +2,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { buildParseError, formatCliError, parseJsonText } from "../_core-helpers.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import {
@@ -25,6 +25,7 @@ import {
   resolveEffectiveAsyncStartMode,
 } from "@dev-loops/core/loop/async-start-contract";
 import { loadDevLoopConfig, resolveConductorModel, resolveAutonomyStopAt, resolveWorkflowConfig } from "@dev-loops/core/config";
+import { parseArgs } from "node:util";
 const USAGE = `Usage: outer-loop.mjs --repo <owner/name> --pr <number>
 Thin outer-loop wrapper for the Copilot PR remediation loop.
 Detects current PR state from both the Copilot inner loop and the reviewer
@@ -88,7 +89,6 @@ Exit codes:
   1  Argument error, gh/git failure, or indeterminate state`.trim();
 const parseError = buildParseError(USAGE);
 export function parseOuterLoopCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     repo: undefined,
@@ -97,33 +97,52 @@ export function parseOuterLoopCliArgs(argv) {
     copilotInputPath: undefined,
     reviewerInputPath: undefined,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+      "checkpoint-dir": { type: "string" },
+      "copilot-input": { type: "string" },
+      "reviewer-input": { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+    if (token.name === "pr") {
+      options.pr = parsePrNumber(requireTokenValue(token, parseError), parseError);
       continue;
     }
-    if (token === "--checkpoint-dir") {
-      options.checkpointDir = requireOptionValue(args, "--checkpoint-dir", parseError);
+    if (token.name === "checkpoint-dir") {
+      options.checkpointDir = requireTokenValue(token, parseError);
       continue;
     }
-    if (token === "--copilot-input") {
-      options.copilotInputPath = requireOptionValue(args, "--copilot-input", parseError);
+    if (token.name === "copilot-input") {
+      options.copilotInputPath = requireTokenValue(token, parseError);
       continue;
     }
-    if (token === "--reviewer-input") {
-      options.reviewerInputPath = requireOptionValue(args, "--reviewer-input", parseError);
+    if (token.name === "reviewer-input") {
+      options.reviewerInputPath = requireTokenValue(token, parseError);
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (!options.help) {
     if (options.repo === undefined || options.pr === undefined) {

--- a/scripts/loop/pr-runner-coordination.mjs
+++ b/scripts/loop/pr-runner-coordination.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import process from "node:process";
+import { parseArgs } from "node:util";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { parsePrNumber, requireOptionValue } from "../_cli-primitives.mjs";
+import { parsePrNumber, requireTokenValue } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { resolveRunId as resolveEnvRunId } from "@dev-loops/core/loop/run-context";
 import {
@@ -42,29 +43,47 @@ function parseCliArgs(argv) {
     return options;
   }
   options.command = command;
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args,
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+      "run-id": { type: "string" },
+      "require-existing": { type: "boolean" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+    if (token.name === "pr") {
+      options.pr = parsePrNumber(requireTokenValue(token, parseError), parseError);
       continue;
     }
-    if (token === "--run-id") {
-      options.runId = requireOptionValue(args, "--run-id", parseError).trim();
+    if (token.name === "run-id") {
+      options.runId = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--require-existing") {
+    if (token.name === "require-existing") {
       options.requireExisting = true;
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   const validCommands = new Set(["status", "claim", "takeover", "assert", "release"]);
   if (!validCommands.has(options.command)) {

--- a/scripts/loop/pre-commit-branch-guard.mjs
+++ b/scripts/loop/pre-commit-branch-guard.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { requireOptionValue, runCommand } from "../_cli-primitives.mjs";
+import { requireTokenValue, runCommand } from "../_cli-primitives.mjs";
+import { parseArgs } from "node:util";
 import {
   isUnderWorktreePath, parseMainWorktreePath, isMainCheckout,
 } from "@dev-loops/core/loop/worktree-guard";
@@ -13,15 +14,31 @@ Verify the current git branch identity and/or worktree isolation before local co
 const parseError = buildParseError(USAGE);
 
 export function parseBranchGuardCliArgs(argv) {
-  const args = [...argv];
   const options = { help: false, expectedBranch: undefined, requireWorktree: false, blockMainCheckout: false };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") { options.help = true; return options; }
-    if (token === "--expected-branch") { options.expectedBranch = requireOptionValue(args, "--expected-branch", parseError, { flagPattern: /^-/u }); continue; }
-    if (token === "--require-worktree") { options.requireWorktree = true; continue; }
-    if (token === "--block-main-checkout") { options.blockMainCheckout = true; continue; }
-    throw parseError(`Unknown argument: ${token}`);
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      "expected-branch": { type: "string" },
+      "require-worktree": { type: "boolean" },
+      "block-main-checkout": { type: "boolean" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") { options.help = true; return options; }
+    if (token.name === "expected-branch") { options.expectedBranch = requireTokenValue(token, parseError, { flagPattern: /^-/u }); continue; }
+    if (token.name === "require-worktree") { options.requireWorktree = true; continue; }
+    if (token.name === "block-main-checkout") { options.blockMainCheckout = true; continue; }
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.expectedBranch === undefined) { throw parseError("--expected-branch <name> is required"); }
   return options;

--- a/scripts/loop/pre-flight-gate.mjs
+++ b/scripts/loop/pre-flight-gate.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { requireOptionValue } from "../_cli-primitives.mjs";
+import { requireTokenValue } from "../_cli-primitives.mjs";
 import { createPiAdapter } from "@dev-loops/core/harness";
+import { parseArgs } from "node:util";
 import {
   isUnderWorktreePath,
   parseMainWorktreePath,
@@ -30,27 +31,42 @@ Bypass:
   PI_PREFLIGHT_BYPASS=1   Skip all checks (for development/testing only).`.trim();
 const parseError = buildParseError(USAGE);
 export function parsePreFlightGateCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     expectedBranch: undefined,
     checkSubagents: false,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      "expected-branch": { type: "string" },
+      "check-subagents": { type: "boolean" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--expected-branch") {
-      options.expectedBranch = requireOptionValue(args, "--expected-branch", parseError, { flagPattern: /^-/u });
+    if (token.name === "expected-branch") {
+      options.expectedBranch = requireTokenValue(token, parseError, { flagPattern: /^-/u });
       continue;
     }
-    if (token === "--check-subagents") {
+    if (token.name === "check-subagents") {
       options.checkSubagents = true;
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   return options;
 }

--- a/scripts/loop/pre-pr-ready-gate.mjs
+++ b/scripts/loop/pre-pr-ready-gate.mjs
@@ -7,8 +7,9 @@ import {
   summarizeGateReviewComments,
   summarizeGateReviewCommentMarkers,
 } from "../_core-helpers.mjs";
-import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
+import { parseArgs } from "node:util";
 
 const USAGE = `Usage:
   pre-pr-ready-gate.mjs --repo <owner/name> --pr <number>
@@ -38,14 +39,29 @@ const parseError = buildParseError(USAGE);
 const PR_VIEW_QUERY = `query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { pullRequest(number:$number) { id, isDraft, headRefOid, state } } }`;
 
 export function parsePrePrReadyGateCliArgs(argv) {
-  const args = [...argv];
   const options = { help: false, repo: undefined, pr: undefined };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") { options.help = true; return options; }
-    if (token === "--repo") { options.repo = requireOptionValue(args, "--repo", parseError).trim(); continue; }
-    if (token === "--pr") { options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError); continue; }
-    throw parseError(`Unknown argument: ${token}`);
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") { options.help = true; return options; }
+    if (token.name === "repo") { options.repo = requireTokenValue(token, parseError).trim(); continue; }
+    if (token.name === "pr") { options.pr = parsePrNumber(requireTokenValue(token, parseError), parseError); continue; }
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.repo === undefined || options.pr === undefined) {
     throw parseError("pre-pr-ready-gate requires both --repo <owner/name> and --pr <number>");

--- a/scripts/loop/pre-push-main-guard.mjs
+++ b/scripts/loop/pre-push-main-guard.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { createInterface } from "node:readline";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { parseArgs } from "node:util";
 
 const PI_PREPUSH_BYPASS_VAR = "PI_PREPUSH_BYPASS";
 const BLOCKED_REFS = ["refs/heads/main"];
@@ -61,11 +62,24 @@ function findBlockedRef(refs) {
 }
 
 export function parsePrePushGuardCliArgs(argv) {
-  const args = [...argv];
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") return { help: true };
-    throw parseError(`Unknown argument: ${token}`);
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") return { help: true };
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   return { help: false };
 }

--- a/scripts/loop/pre-write-remote-freshness-guard.mjs
+++ b/scripts/loop/pre-write-remote-freshness-guard.mjs
@@ -1,17 +1,33 @@
 #!/usr/bin/env node
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { requireOptionValue, runCommand } from "../_cli-primitives.mjs";
+import { requireTokenValue, runCommand } from "../_cli-primitives.mjs";
+import { parseArgs } from "node:util";
 
 const USAGE = `Usage: pre-write-remote-freshness-guard.mjs --branch <name>\nRefresh remote branch state before starting local file writes.`;
 const parseError = buildParseError(USAGE);
 
 export function parseRemoteFreshnessGuardCliArgs(argv) {
-  const args = [...argv], options = { help: false, branch: undefined };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") { options.help = true; return options; }
-    if (token === "--branch") { options.branch = requireOptionValue(args, "--branch", parseError, { flagPattern: /^-/u }); continue; }
-    throw parseError(`Unknown argument: ${token}`);
+  const options = { help: false, branch: undefined };
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      branch: { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") { options.help = true; return options; }
+    if (token.name === "branch") { options.branch = requireTokenValue(token, parseError, { flagPattern: /^-/u }); continue; }
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.branch === undefined) throw parseError("--branch <name> is required");
   return options;

--- a/scripts/loop/resolve-dev-loop-startup.mjs
+++ b/scripts/loop/resolve-dev-loop-startup.mjs
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { resolveAuthoritativeStartupResumeBundle } from "@dev-loops/core/loop/public-dev-loop-routing";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { requireOptionValue, parsePositiveInteger } from "../_cli-primitives.mjs";
+import { requireTokenValue, parsePositiveInteger } from "../_cli-primitives.mjs";
 import { execFileSync } from "node:child_process";
 import {
   isUnderWorktreePath,
@@ -23,6 +23,7 @@ import { detectRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { isCopilotLogin } from "@dev-loops/core/github/copilot-helpers";
 import { loadDevLoopConfig, resolveWorkflowConfig } from "@dev-loops/core/config";
 import { createPiAdapter } from "@dev-loops/core/harness";
+import { parseArgs } from "node:util";
 const USAGE = `Usage:
   resolve-dev-loop-startup.mjs --issue <number>
   resolve-dev-loop-startup.mjs --pr <number>
@@ -96,32 +97,48 @@ const STRATEGY_ASYNC_DISPATCH = {
 };
 const parseError = buildParseError(USAGE);
 export function parseResolveDevLoopStartupCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     inputPath: undefined,
     issue: undefined,
     pr: undefined,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      input: { type: "string" },
+      issue: { type: "string" },
+      pr: { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--input") {
-      options.inputPath = requireOptionValue(args, "--input", parseError);
+    if (token.name === "input") {
+      options.inputPath = requireTokenValue(token, parseError);
       continue;
     }
-    if (token === "--issue") {
-      options.issue = parsePositiveInteger(requireOptionValue(args, "--issue", parseError), "--issue", parseError);
+    if (token.name === "issue") {
+      options.issue = parsePositiveInteger(requireTokenValue(token, parseError), "--issue", parseError);
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePositiveInteger(requireOptionValue(args, "--pr", parseError), "--pr", parseError);
+    if (token.name === "pr") {
+      options.pr = parsePositiveInteger(requireTokenValue(token, parseError), "--pr", parseError);
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   const modeCount = [options.inputPath, options.issue, options.pr].filter(v => v !== undefined).length;
   if (modeCount > 1) {

--- a/scripts/loop/run-conductor-cycle.mjs
+++ b/scripts/loop/run-conductor-cycle.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { requireOptionValue } from "../_cli-primitives.mjs";
+import { requireTokenValue } from "../_cli-primitives.mjs";
 import {
   buildParseError,
   formatCliError,
@@ -14,6 +14,7 @@ import {
   buildHandoffContractForConductorAction,
 } from "./_handoff-contract.mjs";
 import { listOpenPrs } from "./_loop-pr-aggregation.mjs";
+import { parseArgs } from "node:util";
 export { listOpenPrs };
 const USAGE = `Usage: run-conductor-cycle.mjs --repo <owner/name>
 Poll all open PRs, detect state, and output an ordered action queue.`.trim();
@@ -63,22 +64,36 @@ export function actionRequiresApproval(action, autonomyStopAt = ["merge"]) {
 }
 const parseError = buildParseError(USAGE);
 export function parseCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     repo: undefined,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.repo === undefined) {
     throw parseError("run-conductor-cycle requires --repo <owner/name>");

--- a/scripts/loop/run-refinement-audit.mjs
+++ b/scripts/loop/run-refinement-audit.mjs
@@ -2,7 +2,8 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { parsePositiveInteger, requireOptionValue, runCommand } from "../_cli-primitives.mjs";
+import { parsePositiveInteger, requireTokenValue, runCommand } from "../_cli-primitives.mjs";
+import { parseArgs } from "node:util";
 const DEFAULT_MAX_LINES = 1000;
 const DEFAULT_DUPLICATE_WINDOW_LINES = 4;
 const DEFAULT_BRANCH_THRESHOLD = 25;
@@ -43,7 +44,6 @@ const PRIORITY_ORDER = new Map([
   ["low", 2],
 ]);
 export function parseRefinementAuditCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     paths: undefined,
@@ -55,57 +55,79 @@ export function parseRefinementAuditCliArgs(argv) {
     thinWrapperMaxLines: DEFAULT_THIN_WRAPPER_MAX_LINES,
     output: undefined,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      paths: { type: "string" },
+      "paths-file": { type: "string" },
+      root: { type: "string" },
+      "max-lines": { type: "string" },
+      "duplicate-window-lines": { type: "string" },
+      "branch-threshold": { type: "string" },
+      "thin-wrapper-max-lines": { type: "string" },
+      output: { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--paths") {
-      options.paths = requireOptionValue(args, "--paths", parseError, { flagPattern: /^-/u });
+    if (token.name === "paths") {
+      options.paths = requireTokenValue(token, parseError, { flagPattern: /^-/u });
       continue;
     }
-    if (token === "--paths-file") {
-      options.pathsFile = requireOptionValue(args, "--paths-file", parseError, { flagPattern: /^-/u });
+    if (token.name === "paths-file") {
+      options.pathsFile = requireTokenValue(token, parseError, { flagPattern: /^-/u });
       continue;
     }
-    if (token === "--root") {
-      options.root = requireOptionValue(args, "--root", parseError, { flagPattern: /^-/u });
+    if (token.name === "root") {
+      options.root = requireTokenValue(token, parseError, { flagPattern: /^-/u });
       continue;
     }
-    if (token === "--max-lines") {
-      options.maxLines = parsePositiveInteger(requireOptionValue(args, "--max-lines", parseError), "--max-lines", parseError);
+    if (token.name === "max-lines") {
+      options.maxLines = parsePositiveInteger(requireTokenValue(token, parseError), "--max-lines", parseError);
       continue;
     }
-    if (token === "--duplicate-window-lines") {
+    if (token.name === "duplicate-window-lines") {
       options.duplicateWindowLines = parsePositiveInteger(
-        requireOptionValue(args, "--duplicate-window-lines", parseError),
+        requireTokenValue(token, parseError),
         "--duplicate-window-lines",
         parseError,
       );
       continue;
     }
-    if (token === "--branch-threshold") {
+    if (token.name === "branch-threshold") {
       options.branchThreshold = parsePositiveInteger(
-        requireOptionValue(args, "--branch-threshold", parseError),
+        requireTokenValue(token, parseError),
         "--branch-threshold",
         parseError,
       );
       continue;
     }
-    if (token === "--thin-wrapper-max-lines") {
+    if (token.name === "thin-wrapper-max-lines") {
       options.thinWrapperMaxLines = parsePositiveInteger(
-        requireOptionValue(args, "--thin-wrapper-max-lines", parseError),
+        requireTokenValue(token, parseError),
         "--thin-wrapper-max-lines",
         parseError,
       );
       continue;
     }
-    if (token === "--output") {
-      options.output = requireOptionValue(args, "--output", parseError, { flagPattern: /^-/u });
+    if (token.name === "output") {
+      options.output = requireTokenValue(token, parseError, { flagPattern: /^-/u });
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.paths !== undefined && options.pathsFile !== undefined) {
     throw parseError("Specify exactly one of --paths or --paths-file");

--- a/scripts/loop/run-watch-cycle.mjs
+++ b/scripts/loop/run-watch-cycle.mjs
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
-import { parsePrNumber, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { DEV_LOOP_CONTRACT_TRACE_CLASSIFICATION } from "@dev-loops/core/loop/public-dev-loop-routing";
 import { watchCopilotReview } from "../github/probe-copilot-review.mjs";
 import { runHandoff } from "./copilot-pr-handoff.mjs";
 import { detectCopilotSessionActivity } from "./detect-copilot-session-activity.mjs";
+import { parseArgs } from "node:util";
 import {
   EXTERNAL_HEALTHY_WAIT_TIMEOUT_POLICY,
   enforceExternalHealthyWaitTimeout,
@@ -178,30 +179,45 @@ function buildWatchCycleContractTrace({
   };
 }
 export function parseWatchCycleCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     repo: undefined,
     pr: undefined,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (REMOVED_FLAGS.has(token)) {
-      rejectRemovedFlag(token);
+    if (REMOVED_FLAGS.has(token.rawName)) {
+      rejectRemovedFlag(token.rawName);
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePrNumber(requireOptionValue(args, "--pr", parseError), parseError);
+    if (token.name === "pr") {
+      options.pr = parsePrNumber(requireTokenValue(token, parseError), parseError);
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.repo === undefined || options.pr === undefined) {
     throw parseError("run-watch-cycle requires both --repo <owner/name> and --pr <number>");

--- a/scripts/loop/steer-loop.mjs
+++ b/scripts/loop/steer-loop.mjs
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import process from "node:process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
 import {
   STEERING_KIND,
   STEERING_RESULT,
@@ -31,7 +32,7 @@ import {
   withStateFileLock,
 } from "./_steering-state-file.mjs";
 import { formatCliError } from "../_core-helpers.mjs";
-import { requireOptionValue as readSharedOptionValue } from "../_cli-primitives.mjs";
+import { requireTokenValue as readSharedTokenValue } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 const SUBMIT_USAGE = `Usage:
   steer-loop.mjs submit --repo <owner/name> --pr <number>
@@ -112,10 +113,9 @@ function runIdMismatchError(persistedRunId, requestedRunId) {
     `run-id mismatch: --state-file contains run ${JSON.stringify(persistedRunId)} but --run-id is ${JSON.stringify(requestedRunId)}. Use the correct --run-id or point --state-file at the right file.`
   );
 }
-function readRequiredOptionValue(args, flag, usage, { allowFlagLike = false } = {}) {
-  return readSharedOptionValue(
-    args,
-    flag,
+function readRequiredOptionValue(token, usage, { allowFlagLike = false } = {}) {
+  return readSharedTokenValue(
+    token,
     (message) => usageError(message, usage),
     { flagPattern: allowFlagLike ? /$^/u : /^--/u },
   );
@@ -139,7 +139,6 @@ function parsePositiveIntegerOption(raw, flag, usage) {
   return Number(raw);
 }
 export function parseSubmitCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     repo: undefined,
@@ -156,48 +155,74 @@ export function parseSubmitCliArgs(argv) {
     copilotInputPath: undefined,
     reviewerInputPath: undefined,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      "run-id": { type: "string" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+      kind: { type: "string" },
+      directive: { type: "string" },
+      seq: { type: "string" },
+      "state-file": { type: "string" },
+      "loop-state": { type: "string" },
+      "apply-mode": { type: "string" },
+      "event-id": { type: "string" },
+      "copilot-input": { type: "string" },
+      "reviewer-input": { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw usageError(`Unknown argument: ${token.value}`, SUBMIT_USAGE);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--run-id") {
-      options.runId = readRequiredOptionValue(args, "--run-id", SUBMIT_USAGE).trim();
+    if (token.name === "run-id") {
+      options.runId = readRequiredOptionValue(token, SUBMIT_USAGE).trim();
       validateSafeRunId(options.runId, SUBMIT_USAGE);
       continue;
     }
-    if (token === "--repo") {
-      options.repo = readRequiredOptionValue(args, "--repo", SUBMIT_USAGE).trim();
+    if (token.name === "repo") {
+      options.repo = readRequiredOptionValue(token, SUBMIT_USAGE).trim();
       parseRepoSlugOption(options.repo, SUBMIT_USAGE);
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePositiveIntegerOption(readRequiredOptionValue(args, "--pr", SUBMIT_USAGE), "--pr", SUBMIT_USAGE);
+    if (token.name === "pr") {
+      options.pr = parsePositiveIntegerOption(readRequiredOptionValue(token, SUBMIT_USAGE), "--pr", SUBMIT_USAGE);
       continue;
     }
-    if (token === "--kind") {
-      const val = readRequiredOptionValue(args, "--kind", SUBMIT_USAGE);
+    if (token.name === "kind") {
+      const val = readRequiredOptionValue(token, SUBMIT_USAGE);
       if (!VALID_KINDS.has(val)) {
         throw usageError(`--kind must be one of: ${[...VALID_KINDS].join(", ")}`, SUBMIT_USAGE);
       }
       options.kind = val;
       continue;
     }
-    if (token === "--directive") {
-      options.directive = readRequiredOptionValue(args, "--directive", SUBMIT_USAGE, { allowFlagLike: true }).trim();
+    if (token.name === "directive") {
+      options.directive = readRequiredOptionValue(token, SUBMIT_USAGE, { allowFlagLike: true }).trim();
       continue;
     }
-    if (token === "--seq") {
-      options.seq = parsePositiveIntegerOption(readRequiredOptionValue(args, "--seq", SUBMIT_USAGE), "--seq", SUBMIT_USAGE);
+    if (token.name === "seq") {
+      options.seq = parsePositiveIntegerOption(readRequiredOptionValue(token, SUBMIT_USAGE), "--seq", SUBMIT_USAGE);
       continue;
     }
-    if (token === "--state-file") {
-      options.stateFile = readRequiredOptionValue(args, "--state-file", SUBMIT_USAGE);
+    if (token.name === "state-file") {
+      options.stateFile = readRequiredOptionValue(token, SUBMIT_USAGE);
       continue;
     }
-    if (token === "--loop-state") {
-      const val = readRequiredOptionValue(args, "--loop-state", SUBMIT_USAGE);
+    if (token.name === "loop-state") {
+      const val = readRequiredOptionValue(token, SUBMIT_USAGE);
       if (!VALID_LOOP_STATES.has(val)) {
         throw usageError(`--loop-state must be one of: ${[...VALID_LOOP_STATES].join(", ")}`, SUBMIT_USAGE);
       }
@@ -205,27 +230,27 @@ export function parseSubmitCliArgs(argv) {
       options.loopStateExplicit = true;
       continue;
     }
-    if (token === "--apply-mode") {
-      const val = readRequiredOptionValue(args, "--apply-mode", SUBMIT_USAGE);
+    if (token.name === "apply-mode") {
+      const val = readRequiredOptionValue(token, SUBMIT_USAGE);
       if (!VALID_APPLY_MODES.has(val)) {
         throw usageError(`--apply-mode must be one of: ${[...VALID_APPLY_MODES].join(", ")}`, SUBMIT_USAGE);
       }
       options.applyMode = val;
       continue;
     }
-    if (token === "--event-id") {
-      options.eventId = readRequiredOptionValue(args, "--event-id", SUBMIT_USAGE);
+    if (token.name === "event-id") {
+      options.eventId = readRequiredOptionValue(token, SUBMIT_USAGE);
       continue;
     }
-    if (token === "--copilot-input") {
-      options.copilotInputPath = readRequiredOptionValue(args, "--copilot-input", SUBMIT_USAGE);
+    if (token.name === "copilot-input") {
+      options.copilotInputPath = readRequiredOptionValue(token, SUBMIT_USAGE);
       continue;
     }
-    if (token === "--reviewer-input") {
-      options.reviewerInputPath = readRequiredOptionValue(args, "--reviewer-input", SUBMIT_USAGE);
+    if (token.name === "reviewer-input") {
+      options.reviewerInputPath = readRequiredOptionValue(token, SUBMIT_USAGE);
       continue;
     }
-    throw usageError(`Unknown argument: ${token}`, SUBMIT_USAGE);
+    throw usageError(`Unknown argument: ${token.rawName}`, SUBMIT_USAGE);
   }
   if (!options.help) {
     if ((options.repo === undefined) !== (options.pr === undefined)) {
@@ -250,7 +275,6 @@ export function parseSubmitCliArgs(argv) {
   return options;
 }
 export function parseStatusCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     repo: undefined,
@@ -258,31 +282,49 @@ export function parseStatusCliArgs(argv) {
     runId: undefined,
     stateFile: undefined,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      "run-id": { type: "string" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+      "state-file": { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw usageError(`Unknown argument: ${token.value}`, STATUS_USAGE);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--run-id") {
-      options.runId = readRequiredOptionValue(args, "--run-id", STATUS_USAGE).trim();
+    if (token.name === "run-id") {
+      options.runId = readRequiredOptionValue(token, STATUS_USAGE).trim();
       validateSafeRunId(options.runId, STATUS_USAGE);
       continue;
     }
-    if (token === "--repo") {
-      options.repo = readRequiredOptionValue(args, "--repo", STATUS_USAGE).trim();
+    if (token.name === "repo") {
+      options.repo = readRequiredOptionValue(token, STATUS_USAGE).trim();
       parseRepoSlugOption(options.repo, STATUS_USAGE);
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePositiveIntegerOption(readRequiredOptionValue(args, "--pr", STATUS_USAGE), "--pr", STATUS_USAGE);
+    if (token.name === "pr") {
+      options.pr = parsePositiveIntegerOption(readRequiredOptionValue(token, STATUS_USAGE), "--pr", STATUS_USAGE);
       continue;
     }
-    if (token === "--state-file") {
-      options.stateFile = readRequiredOptionValue(args, "--state-file", STATUS_USAGE);
+    if (token.name === "state-file") {
+      options.stateFile = readRequiredOptionValue(token, STATUS_USAGE);
       continue;
     }
-    throw usageError(`Unknown argument: ${token}`, STATUS_USAGE);
+    throw usageError(`Unknown argument: ${token.rawName}`, STATUS_USAGE);
   }
   if (!options.help) {
     if ((options.repo === undefined) !== (options.pr === undefined)) {
@@ -298,7 +340,6 @@ export function parseStatusCliArgs(argv) {
   return options;
 }
 export function parsePromoteCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     repo: undefined,
@@ -307,39 +348,58 @@ export function parsePromoteCliArgs(argv) {
     stateFile: undefined,
     loopState: undefined,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      "run-id": { type: "string" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+      "state-file": { type: "string" },
+      "loop-state": { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw usageError(`Unknown argument: ${token.value}`, PROMOTE_USAGE);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--run-id") {
-      options.runId = readRequiredOptionValue(args, "--run-id", PROMOTE_USAGE).trim();
+    if (token.name === "run-id") {
+      options.runId = readRequiredOptionValue(token, PROMOTE_USAGE).trim();
       validateSafeRunId(options.runId, PROMOTE_USAGE);
       continue;
     }
-    if (token === "--repo") {
-      options.repo = readRequiredOptionValue(args, "--repo", PROMOTE_USAGE).trim();
+    if (token.name === "repo") {
+      options.repo = readRequiredOptionValue(token, PROMOTE_USAGE).trim();
       parseRepoSlugOption(options.repo, PROMOTE_USAGE);
       continue;
     }
-    if (token === "--pr") {
-      options.pr = parsePositiveIntegerOption(readRequiredOptionValue(args, "--pr", PROMOTE_USAGE), "--pr", PROMOTE_USAGE);
+    if (token.name === "pr") {
+      options.pr = parsePositiveIntegerOption(readRequiredOptionValue(token, PROMOTE_USAGE), "--pr", PROMOTE_USAGE);
       continue;
     }
-    if (token === "--state-file") {
-      options.stateFile = readRequiredOptionValue(args, "--state-file", PROMOTE_USAGE);
+    if (token.name === "state-file") {
+      options.stateFile = readRequiredOptionValue(token, PROMOTE_USAGE);
       continue;
     }
-    if (token === "--loop-state") {
-      const val = readRequiredOptionValue(args, "--loop-state", PROMOTE_USAGE);
+    if (token.name === "loop-state") {
+      const val = readRequiredOptionValue(token, PROMOTE_USAGE);
       if (!VALID_LOOP_STATES.has(val)) {
         throw usageError(`--loop-state must be one of: ${[...VALID_LOOP_STATES].join(", ")}`, PROMOTE_USAGE);
       }
       options.loopState = val;
       continue;
     }
-    throw usageError(`Unknown argument: ${token}`, PROMOTE_USAGE);
+    throw usageError(`Unknown argument: ${token.rawName}`, PROMOTE_USAGE);
   }
   if (!options.help) {
     if ((options.repo === undefined) !== (options.pr === undefined)) {

--- a/scripts/loop/watch-initial-copilot-pr.mjs
+++ b/scripts/loop/watch-initial-copilot-pr.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import { setTimeout as delay } from "node:timers/promises";
 import { spawn } from "node:child_process";
+import { parseArgs } from "node:util";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { parseIssueNumber, requireOptionValue } from "../_cli-primitives.mjs";
+import { parseIssueNumber, requireTokenValue } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { detectInitialCopilotPrState, LINKED_PR_STATE } from "./detect-initial-copilot-pr-state.mjs";
 import { enforcePersistentInternalWaitTimeout } from "@dev-loops/core/loop/timeout-policy";
@@ -94,7 +95,6 @@ export async function watchCopilotRunUntilComplete(
   });
 }
 export function parseWatchInitialCopilotPrCliArgs(argv) {
-  const args = [...argv];
   const options = {
     help: false,
     repo: undefined,
@@ -102,24 +102,40 @@ export function parseWatchInitialCopilotPrCliArgs(argv) {
     pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
     timeoutMs: COPILOT_FIRST_DURABLE_WAIT_TIMEOUT_MS,
   };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      issue: { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (REMOVED_FLAGS.has(token)) {
-      rejectRemovedFlag(token);
+    if (REMOVED_FLAGS.has(token.rawName)) {
+      rejectRemovedFlag(token.rawName);
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError).trim();
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
       continue;
     }
-    if (token === "--issue") {
-      options.issue = parseIssueNumber(requireOptionValue(args, "--issue", parseError), parseError);
+    if (token.name === "issue") {
+      options.issue = parseIssueNumber(requireTokenValue(token, parseError), parseError);
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (options.repo === undefined || options.issue === undefined) {
     throw parseError("watch-initial-copilot-pr requires both --repo <owner/name> and --issue <number>");

--- a/scripts/refine/_refine-helpers.mjs
+++ b/scripts/refine/_refine-helpers.mjs
@@ -2,7 +2,8 @@
 import { readFile } from "node:fs/promises";
 
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { parsePositiveInteger, requireOptionValue, runChild } from "../_cli-primitives.mjs";
+import { parseArgs } from "node:util";
+import { parsePositiveInteger, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { detectRepoSlug, parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 
 export const FORBIDDEN_PROSE_PATTERNS = [
@@ -23,23 +24,34 @@ export function normalizeIssueNumber(value, label, parseError) {
 
 export function parseCheckerCliArgs(argv, usage, checkerName) {
   const parseError = buildParseError(usage);
-  const args = [...argv];
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: { help: { type: "boolean", short: "h" }, input: { type: "string" }, json: { type: "boolean" } },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
   const options = { help: false, input: undefined, json: false };
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--input") {
-      options.input = requireOptionValue(args, "--input", parseError, { flagPattern: /^-/u });
+    if (token.name === "input") {
+      options.input = requireTokenValue(token, parseError, { flagPattern: /^-/u });
       continue;
     }
-    if (token === "--json") {
+    if (token.name === "json") {
       options.json = true;
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (typeof options.input !== "string" || options.input.trim().length === 0) {
     throw parseError(`${checkerName} requires --input <path>`);

--- a/scripts/refine/verify.mjs
+++ b/scripts/refine/verify.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { buildParseError, formatCliError } from "../_core-helpers.mjs";
-import { parsePositiveInteger, requireOptionValue } from "../_cli-primitives.mjs";
+import { parseArgs } from "node:util";
+import { parsePositiveInteger, requireTokenValue } from "../_cli-primitives.mjs";
 import { detectRepoSlug, parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 
 import { isDirectCliRun, loadTreeFromInput, loadTreeOnline } from "./_refine-helpers.mjs";
@@ -30,7 +31,19 @@ Optional:
 const parseError = buildParseError(USAGE);
 
 export function parseRefineVerifyCliArgs(argv) {
-  const args = [...argv];
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      issue: { type: "string" },
+      repo: { type: "string" },
+      input: { type: "string" },
+      json: { type: "boolean" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
   const options = {
     help: false,
     issue: undefined,
@@ -39,29 +52,34 @@ export function parseRefineVerifyCliArgs(argv) {
     json: false,
   };
 
-  while (args.length > 0) {
-    const token = args.shift();
-    if (token === "--help" || token === "-h") {
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
       options.help = true;
       return options;
     }
-    if (token === "--issue") {
-      options.issue = parsePositiveInteger(requireOptionValue(args, "--issue", parseError), "Issue number", parseError);
+    if (token.name === "issue") {
+      options.issue = parsePositiveInteger(requireTokenValue(token, parseError), "Issue number", parseError);
       continue;
     }
-    if (token === "--repo") {
-      options.repo = requireOptionValue(args, "--repo", parseError, { flagPattern: /^-/u });
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError, { flagPattern: /^-/u });
       continue;
     }
-    if (token === "--input") {
-      options.input = requireOptionValue(args, "--input", parseError, { flagPattern: /^-/u });
+    if (token.name === "input") {
+      options.input = requireTokenValue(token, parseError, { flagPattern: /^-/u });
       continue;
     }
-    if (token === "--json") {
+    if (token.name === "json") {
       options.json = true;
       continue;
     }
-    throw parseError(`Unknown argument: ${token}`);
+    throw parseError(`Unknown argument: ${token.rawName}`);
   }
 
   const hasIssueMode = options.issue !== undefined;

--- a/test/loop/cli-primitives.test.mjs
+++ b/test/loop/cli-primitives.test.mjs
@@ -3,11 +3,13 @@ import test from "node:test";
 
 import { buildParseError } from "../../scripts/_core-helpers.mjs";
 import {
+  parseCliTokens,
   parseIssueNumber,
   parseNonNegativeInteger,
   parsePositiveInteger,
   parsePrNumber,
   requireOptionValue,
+  requireTokenValue,
   runChild,
   runCommand,
 } from "../../scripts/_cli-primitives.mjs";
@@ -29,6 +31,64 @@ test("requireOptionValue uses provided parseError", () => {
   assert.throws(
     () => requireOptionValue([], "--repo", (message) => Object.assign(new Error(message), { usage: "usage" })),
     (error) => error.message === "Missing value for --repo" && error.usage === "usage",
+  );
+});
+
+// ── requireTokenValue / parseCliTokens (node:util.parseArgs adapters, #808) ──
+
+test("requireTokenValue returns the token value", () => {
+  assert.equal(requireTokenValue({ rawName: "--repo", value: "owner/name" }), "owner/name");
+});
+
+test("requireTokenValue rejects a missing value with the legacy message", () => {
+  assert.throws(
+    () => requireTokenValue({ rawName: "--repo", value: undefined }, (m) => Object.assign(new Error(m), { usage: "u" })),
+    (error) => error.message === "Missing value for --repo" && error.usage === "u",
+  );
+});
+
+test("requireTokenValue rejects an empty value", () => {
+  assert.throws(
+    () => requireTokenValue({ rawName: "--repo", value: "" }),
+    (error) => error.message === "Missing value for --repo",
+  );
+});
+
+test("requireTokenValue rejects a flag-like value (default --flagPattern)", () => {
+  assert.throws(
+    () => requireTokenValue({ rawName: "--repo", value: "--pr" }),
+    (error) => error.message === "Missing value for --repo",
+  );
+});
+
+test("requireTokenValue accepts a single-dash value under the default pattern but rejects it under /^-/", () => {
+  // Default /^--/ only rejects double-dash values, so a single-dash value passes.
+  assert.equal(requireTokenValue({ rawName: "--branch", value: "-x" }), "-x");
+  // A stricter /^-/ pattern rejects it (the short-flag-like case).
+  assert.throws(
+    () => requireTokenValue({ rawName: "--branch", value: "-x" }, null, { flagPattern: /^-/u }),
+    (error) => error.message === "Missing value for --branch",
+  );
+});
+
+test("parseCliTokens collects option values and rejects unknown flags / positionals", () => {
+  const options = { repo: { type: "string" }, json: { type: "boolean" } };
+  const { values, positionals } = parseCliTokens(["--repo", "owner/name", "--json"], options);
+  assert.equal(values.get("repo"), "owner/name");
+  assert.equal(values.get("json"), true);
+  assert.deepEqual(positionals, []);
+
+  assert.throws(() => parseCliTokens(["--bogus"], options), (e) => e.message === "Unknown argument: --bogus");
+  assert.throws(() => parseCliTokens(["extra"], options), (e) => e.message === "Unknown argument: extra");
+});
+
+test("parseCliTokens keeps positionals when allowed and rejects flag-like option values", () => {
+  const options = { repo: { type: "string" } };
+  const { positionals } = parseCliTokens(["cmd"], options, null, { allowPositionals: true });
+  assert.deepEqual(positionals, ["cmd"]);
+  assert.throws(
+    () => parseCliTokens(["--repo", "--json"], options),
+    (e) => e.message === "Missing value for --repo",
   );
 });
 

--- a/test/loop/cli-primitives.test.mjs
+++ b/test/loop/cli-primitives.test.mjs
@@ -82,6 +82,13 @@ test("parseCliTokens collects option values and rejects unknown flags / position
   assert.throws(() => parseCliTokens(["extra"], options), (e) => e.message === "Unknown argument: extra");
 });
 
+test("parseCliTokens sets a bare boolean flag true but honors an explicit =false", () => {
+  const options = { json: { type: "boolean" } };
+  assert.equal(parseCliTokens(["--json"], options).values.get("json"), true);
+  assert.equal(parseCliTokens(["--json=false"], options).values.get("json"), false);
+  assert.equal(parseCliTokens(["--json=true"], options).values.get("json"), true);
+});
+
 test("parseCliTokens keeps positionals when allowed and rejects flag-like option values", () => {
   const options = { repo: { type: "string" } };
   const { positionals } = parseCliTokens(["cmd"], options, null, { allowPositionals: true });


### PR DESCRIPTION
## Summary

Child of #792. Replaces hand-rolled `while (args)`/`args.shift()` argument parsers with `node:util.parseArgs` across **49 scripts/modules** (12 `scripts/github`, 30+ `scripts/loop`, `scripts/docs`, `scripts/refine`) plus the 3 core files named in #792 AC1 (`bash-exit-one`, `loop/phase-files`, `github/review-threads`).

**No behavior change.** Every flag name/alias, required/optional semantic, error JSON shape, USAGE string, and exit code is preserved — verified by the existing per-script test suites (`npm run verify` green). Exported `parse*CliArgs` functions keep their signatures (tests import them).

## Approach

Standardized on `parseArgs({ strict:false, tokens:true, allowPositionals:true })` + a thin shared `requireTokenValue` primitive (in `@dev-loops/core/cli/primitives`) that re-derives the legacy flag-like-value rejection (e.g. `Missing value for --phase`). Preserved exactly: removed-flag policies, `--help`/`-h` early return, and leading-subcommand dispatch (`manage-sub-issues`, `pr-runner-coordination`).

**Zero hand-rolled `while/shift` arg loops remain (#808 AC2).**

## Deferred (correctness over completeness)

Index-based (`for`-loop, `argv[++i]`) parsers in `scripts/projects/*`, a few `scripts/loop/*` (`detect-change-scope`, `detect-tracker-first-loop-state`, `run-queue`), and `scripts/claude/*` use a distinct idiom with bespoke error contracts. Converting them risks subtle message/positional drift, so they're deferred to a follow-up. This PR covers the `while/shift` scope (the issue's named inventory).

Refs #808

## Note (review)
`--flag=value` (equals form) is now additionally accepted by parseArgs, whereas the old space-only parsers rejected it as `Unknown argument`. This is strictly additive — no previously-valid invocation changes — and is an improvement, but noted for accuracy of the no-behavior-change claim.