### PR TITLE
feat(project): board reorder subcommands + archive-done CLI (#789)

### DIFF
--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -52,6 +52,7 @@ const SUBCOMMAND_ROUTES = {
     add:     "scripts/projects/add-queue-item.mjs",
     move:    "scripts/projects/move-queue-item.mjs",
     reorder: "scripts/projects/reorder-queue-item.mjs",
+    "archive-done": "scripts/projects/archive-done-items.mjs",
     ensure:  "scripts/projects/ensure-queue-board.mjs",
   },
   queue: {
@@ -113,7 +114,8 @@ const SUBCOMMAND_DESCRIPTIONS = {
     list: "List queue board items",
     add: "Add issue/PR to queue board",
     move: "Move queue item between Status columns",
-    reorder: "Reorder queue board items",
+    reorder: "Reorder items (move-to-top/move-after/order, --dry-run)",
+    "archive-done": "Archive closed Done items older than a duration",
     ensure: "Create/repair queue board bootstrap surface",
   },
   queue: {

--- a/docs/queue-board-setup.md
+++ b/docs/queue-board-setup.md
@@ -82,6 +82,96 @@ Dev-loop queue wrappers will:
 
 Use `dev-loops project --help` to inspect the queue helper surface and per-subcommand `--help` for details.
 
+## Reordering board items
+
+`dev-loops project reorder` wraps the `updateProjectV2ItemPosition` mutation. In
+addition to the flag form (`--item [--after]`), it exposes three ergonomic
+subcommands. A `<ref>` is an issue/PR **number** or a project **item node ID**,
+and every form works for both issues and PRs.
+
+```sh
+# Move issue/PR #630 to the top of its current Status column
+dev-loops project reorder move-to-top 630 --repo mfittko/dev-loops --project 1
+
+# Move #630 immediately after #625
+dev-loops project reorder move-after 630 625 --repo mfittko/dev-loops --project 1
+
+# Set an explicit order: 103 first, then 101, then 102
+dev-loops project reorder order 103 101 102 --repo mfittko/dev-loops --project 1
+```
+
+The subcommand forms emit diff-friendly JSON with the column order **before** and
+**after** the change, plus the resolved item IDs:
+
+```json
+{
+  "ok": true,
+  "item": { "itemId": "PVTI_b", "issueNumber": 630, "status": "Next Up", "position": "top" },
+  "after_ref": null,
+  "before": [{ "itemId": "PVTI_a", "issueNumber": 625 }, { "itemId": "PVTI_b", "issueNumber": 630 }],
+  "after":  [{ "itemId": "PVTI_b", "issueNumber": 630 }, { "itemId": "PVTI_a", "issueNumber": 625 }]
+}
+```
+
+`order` returns a `moves` array (one entry per chained position mutation) plus the
+same `before`/`after` snapshots.
+
+### Dry run
+
+Add `--dry-run` to any form to print the intended GraphQL mutation(s) — including
+the chained mutations for `order` — without executing them:
+
+```sh
+dev-loops project reorder order 103 101 102 --repo mfittko/dev-loops --project 1 --dry-run
+```
+
+```json
+{
+  "ok": true,
+  "dryRun": true,
+  "mutations": [
+    { "query": "mutation(...) { updateProjectV2ItemPosition(...) }", "variables": { "projectId": "PVT_proj1", "itemId": "PVTI_3" } },
+    { "query": "...", "variables": { "projectId": "PVT_proj1", "itemId": "PVTI_1", "afterId": "PVTI_3" } }
+  ]
+}
+```
+
+A ref that does not resolve to an item in the target Project fails closed with a
+clear `ITEM_NOT_FOUND` error (exit code 3) — only items in the target Project can
+be reordered.
+
+## Archiving completed items
+
+`dev-loops project archive-done` removes finished work from the board. It archives
+items (via `archiveProjectV2Item`) whose issue or PR has been **closed** for at
+least the given duration. It is operator-triggered (no webhooks) and scoped to the
+single repo passed via `--repo`.
+
+```sh
+# Archive items whose issue/PR closed more than 30 days ago (default)
+dev-loops project archive-done --repo mfittko/dev-loops --project 1
+
+# Custom threshold (units: h = hours, d = days, w = weeks)
+dev-loops project archive-done --repo mfittko/dev-loops --project 1 --older-than 7d
+
+# Preview without mutating
+dev-loops project archive-done --repo mfittko/dev-loops --project 1 --dry-run
+```
+
+Output reports how many items were considered and which were archived:
+
+```json
+{
+  "ok": true,
+  "olderThan": "30d",
+  "considered": 12,
+  "archived": [{ "itemId": "PVTI_a", "issueNumber": 1, "prNumber": null, "closedAt": "2026-01-01T00:00:00Z" }]
+}
+```
+
+Open items (even if parked in the `Done` column) and already-archived items are
+never touched.
+
 
 ### Repairing drifted Status columns
 

--- a/docs/queue-board-setup.md
+++ b/docs/queue-board-setup.md
@@ -116,6 +116,13 @@ The subcommand forms emit diff-friendly JSON with the column order **before** an
 `order` returns a `moves` array (one entry per chained position mutation) plus the
 same `before`/`after` snapshots.
 
+> **`order` is not atomic.** It applies N sequential `updateProjectV2ItemPosition`
+> mutations with no rollback. If it fails partway, the board is left partially
+> reordered and the thrown error reports how many moves completed (for example
+> `order partially applied: 1 of 3 moves completed`). Re-running the **same**
+> `order <ref1> <ref2> ...` command is idempotent and is the supported recovery
+> path — it re-applies the full target sequence.
+
 ### Dry run
 
 Add `--dry-run` to any form to print the intended GraphQL mutation(s) — including
@@ -158,16 +165,21 @@ dev-loops project archive-done --repo mfittko/dev-loops --project 1 --older-than
 dev-loops project archive-done --repo mfittko/dev-loops --project 1 --dry-run
 ```
 
-Output reports how many items were considered and which were archived:
+Output distinguishes the items scanned from the actual archive candidates:
 
 ```json
 {
   "ok": true,
   "olderThan": "30d",
-  "considered": 12,
+  "scanned": 12,
+  "archivable": 1,
   "archived": [{ "itemId": "PVTI_a", "issueNumber": 1, "prNumber": null, "closedAt": "2026-01-01T00:00:00Z" }]
 }
 ```
+
+- `scanned` — all board items belonging to the repo (open, closed, and archived).
+- `archivable` — the subset selected for archival by the closed-duration filter.
+- `archived` — the items actually archived (equals `archivable`, or empty under `--dry-run`).
 
 Open items (even if parked in the `Done` column) and already-archived items are
 never touched.

--- a/docs/queue-board-setup.md
+++ b/docs/queue-board-setup.md
@@ -166,8 +166,10 @@ be reordered.
 
 `dev-loops project archive-done` removes finished work from the board. It archives
 items (via `archiveProjectV2Item`) whose issue or PR has been **closed** for at
-least the given duration. It is operator-triggered (no webhooks) and scoped to the
-single repo passed via `--repo`.
+least the given duration. The closed state — not the board Status column — is the
+criterion (a closed issue/PR is "done" for cleanup purposes), so a closed item is
+archived regardless of which column it still sits in. It is operator-triggered (no
+webhooks) and scoped to the single repo passed via `--repo`.
 
 ```sh
 # Archive items whose issue/PR closed more than 30 days ago (default)

--- a/docs/queue-board-setup.md
+++ b/docs/queue-board-setup.md
@@ -106,15 +106,22 @@ The subcommand forms emit diff-friendly JSON with the column order **before** an
 ```json
 {
   "ok": true,
-  "item": { "itemId": "PVTI_b", "issueNumber": 630, "status": "Next Up", "position": "top" },
+  "item": { "itemId": "PVTI_b", "issueNumber": 630, "prNumber": null, "status": "Next Up", "position": "top" },
   "after_ref": null,
-  "before": [{ "itemId": "PVTI_a", "issueNumber": 625 }, { "itemId": "PVTI_b", "issueNumber": 630 }],
-  "after":  [{ "itemId": "PVTI_b", "issueNumber": 630 }, { "itemId": "PVTI_a", "issueNumber": 625 }]
+  "before": [
+    { "itemId": "PVTI_a", "issueNumber": 625, "prNumber": null, "status": "Next Up" },
+    { "itemId": "PVTI_b", "issueNumber": 630, "prNumber": null, "status": "Next Up" }
+  ],
+  "after": [
+    { "itemId": "PVTI_b", "issueNumber": 630, "prNumber": null, "status": "Next Up" },
+    { "itemId": "PVTI_a", "issueNumber": 625, "prNumber": null, "status": "Next Up" }
+  ]
 }
 ```
 
-`order` returns a `moves` array (one entry per chained position mutation) plus the
-same `before`/`after` snapshots.
+Each snapshot entry carries `itemId`, `issueNumber`, `prNumber` (one of the latter
+two is `null`), and `status`. `order` returns a `moves` array (one entry per chained
+position mutation) plus the same `before`/`after` snapshots.
 
 > **`order` is not atomic.** It applies N sequential `updateProjectV2ItemPosition`
 > mutations with no rollback. If it fails partway, the board is left partially
@@ -139,9 +146,17 @@ dev-loops project reorder order 103 101 102 --repo mfittko/dev-loops --project 1
   "mutations": [
     { "query": "mutation(...) { updateProjectV2ItemPosition(...) }", "variables": { "projectId": "PVT_proj1", "itemId": "PVTI_3" } },
     { "query": "...", "variables": { "projectId": "PVT_proj1", "itemId": "PVTI_1", "afterId": "PVTI_3" } }
+  ],
+  "before": [
+    { "itemId": "PVTI_1", "issueNumber": 101, "prNumber": null, "status": "Next Up" },
+    { "itemId": "PVTI_2", "issueNumber": 102, "prNumber": null, "status": "Next Up" },
+    { "itemId": "PVTI_3", "issueNumber": 103, "prNumber": null, "status": "Next Up" }
   ]
 }
 ```
+
+The flag form (`--item [--after] --dry-run`) returns the same `{ mutations, before }`
+shape with a single mutation.
 
 A ref that does not resolve to an item in the target Project fails closed with a
 clear `ITEM_NOT_FOUND` error (exit code 3) — only items in the target Project can

--- a/scripts/projects/archive-done-items.mjs
+++ b/scripts/projects/archive-done-items.mjs
@@ -16,8 +16,9 @@ Options:
   --help, -h              Show this help.
 
 Output (stdout):
-  JSON: { ok: true, olderThan, considered, archived: [{ itemId, issueNumber, prNumber, closedAt }] }
-  dry-run: { ok: true, dryRun: true, olderThan, mutations: [{ query, variables }] }
+  JSON: { ok: true, olderThan, scanned, archivable, archived: [{ itemId, issueNumber, prNumber, closedAt }] }
+  dry-run: { ok: true, dryRun: true, olderThan, scanned, archivable, mutations: [{ query, variables }] }
+  (scanned = all repo board items; archivable = items selected for archival)
 
 Exit codes:
   0 — success
@@ -346,7 +347,8 @@ async function main(args, { env = process.env, runChild } = {}) {
       ok: true,
       dryRun: true,
       olderThan: olderThanRaw,
-      considered: repoItems.length,
+      scanned: repoItems.length,
+      archivable: archivable.length,
       mutations,
     };
   }
@@ -368,7 +370,8 @@ async function main(args, { env = process.env, runChild } = {}) {
   return {
     ok: true,
     olderThan: olderThanRaw,
-    considered: repoItems.length,
+    scanned: repoItems.length,
+    archivable: archivable.length,
     archived,
   };
 }

--- a/scripts/projects/archive-done-items.mjs
+++ b/scripts/projects/archive-done-items.mjs
@@ -1,0 +1,407 @@
+#!/usr/bin/env node
+import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { runChild as _runChild } from "../_cli-primitives.mjs";
+
+const USAGE = `Usage: dev-loops project archive-done --repo <owner/name> --project <number|id> [--older-than <duration>] [--dry-run]
+
+Archive GitHub Projects V2 items whose issue/PR has been closed for at least the
+given duration. Operator-triggered (no webhooks). Uses archiveProjectV2Item.
+
+Options:
+  --repo <owner/name>     Required. Repository to scope the project search.
+  --project <number|id>   Required. Project number (integer) or node ID.
+  --older-than <duration> Closed-for threshold. Format: <n><unit> where unit is
+                          h (hours), d (days), or w (weeks). Default: 30d.
+  --dry-run               Print the intended archive mutation(s) without executing.
+  --help, -h              Show this help.
+
+Output (stdout):
+  JSON: { ok: true, olderThan, considered, archived: [{ itemId, issueNumber, prNumber, closedAt }] }
+  dry-run: { ok: true, dryRun: true, olderThan, mutations: [{ query, variables }] }
+
+Exit codes:
+  0 — success
+  1 — usage or argument error
+  2 — GitHub API error
+  3 — project not found
+`.trim();
+
+const VALID_ARGS = new Set(["--repo", "--project", "--older-than", "--dry-run", "--help", "-h"]);
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!VALID_ARGS.has(arg) && arg.startsWith("-")) {
+      throw Object.assign(new Error(`Unknown flag: ${arg}`), { code: "INVALID_ARGS", usage: USAGE });
+    }
+    if (arg === "--repo") {
+      if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
+        throw Object.assign(new Error("--repo requires a value (owner/name)"), { code: "INVALID_REPO" });
+      }
+      args.repo = argv[++i];
+    } else if (arg === "--project") {
+      if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
+        throw Object.assign(new Error("--project requires a value (number or node ID)"), { code: "INVALID_PROJECT" });
+      }
+      args.project = argv[++i];
+    } else if (arg === "--older-than") {
+      if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
+        throw Object.assign(new Error("--older-than requires a value (e.g. 30d)"), { code: "INVALID_DURATION" });
+      }
+      args.olderThan = argv[++i];
+    } else if (arg === "--dry-run") {
+      args.dryRun = true;
+    } else if (arg === "--help" || arg === "-h") {
+      args.help = true;
+    } else {
+      throw Object.assign(new Error(`Unexpected argument: ${arg}`), { code: "INVALID_ARGS", usage: USAGE });
+    }
+  }
+  return args;
+}
+
+// ── Validation ───────────────────────────────────────────────────────────
+
+const OWNER_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
+const REPO_NAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9_.-]*[a-zA-Z0-9])?$/;
+const GLOBAL_NODE_ID_RE = /^[A-Za-z0-9_]+$/;
+
+function validateRepo(repo) {
+  if (!repo || typeof repo !== "string") {
+    throw Object.assign(new Error("--repo is required"), { code: "INVALID_REPO" });
+  }
+  const slashIdx = repo.indexOf("/");
+  if (slashIdx === -1) {
+    throw Object.assign(new Error(`--repo must be exactly owner/name, got "${repo}"`), { code: "INVALID_REPO" });
+  }
+  const owner = repo.slice(0, slashIdx);
+  const name = repo.slice(slashIdx + 1);
+  if (!owner || !name || !OWNER_RE.test(owner) || !REPO_NAME_RE.test(name)) {
+    throw Object.assign(new Error(`--repo must be exactly owner/name, got "${repo}"`), { code: "INVALID_REPO" });
+  }
+  return repo;
+}
+
+function parseProjectRef(raw) {
+  if (!raw || typeof raw !== "string" || raw.trim().length === 0) {
+    throw Object.assign(new Error("--project is required"), { code: "INVALID_PROJECT" });
+  }
+  const trimmed = raw.trim();
+  const asNum = Number(trimmed);
+  if (Number.isInteger(asNum) && asNum > 0 && String(asNum) === trimmed) {
+    return { kind: "number", value: asNum };
+  }
+  if (GLOBAL_NODE_ID_RE.test(trimmed) && trimmed !== "0") {
+    return { kind: "id", value: trimmed };
+  }
+  throw Object.assign(new Error(`--project must be a positive integer or a node ID, got "${raw}"`), { code: "INVALID_PROJECT" });
+}
+
+const DURATION_RE = /^(\d+)(h|d|w)$/;
+const UNIT_MS = {
+  h: 60 * 60 * 1000,
+  d: 24 * 60 * 60 * 1000,
+  w: 7 * 24 * 60 * 60 * 1000,
+};
+
+function parseDuration(raw) {
+  if (!raw || typeof raw !== "string") {
+    throw Object.assign(new Error(`--older-than must be <n>(h|d|w), got "${raw}"`), { code: "INVALID_DURATION" });
+  }
+  const m = DURATION_RE.exec(raw.trim());
+  if (!m) {
+    throw Object.assign(new Error(`--older-than must be <n>(h|d|w), got "${raw}"`), { code: "INVALID_DURATION" });
+  }
+  const n = Number(m[1]);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw Object.assign(new Error(`--older-than must be a positive amount, got "${raw}"`), { code: "INVALID_DURATION" });
+  }
+  return n * UNIT_MS[m[2]];
+}
+
+// ── API helpers ──────────────────────────────────────────────────────────
+
+async function ghGraphql(query, vars, env, runChild = _runChild) {
+  const fieldArgs = [];
+  for (const [key, value] of Object.entries(vars)) {
+    fieldArgs.push("--field", `${key}=${value}`);
+  }
+  const result = await runChild("gh", ["api", "graphql", "--field", `query=${query}`, ...fieldArgs], env);
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw Object.assign(new Error(`gh api graphql failed: ${detail}`), { code: "GH_API_ERROR" });
+  }
+  const payload = parseJsonText(result.stdout);
+  if (payload.errors && payload.errors.length > 0) {
+    throw Object.assign(
+      new Error(`GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`),
+      { code: "GRAPHQL_ERROR" },
+    );
+  }
+  return payload;
+}
+
+// ── GraphQL fragments ────────────────────────────────────────────────────
+
+const GET_USER_ID = ["query($login:String!) {", "  user(login:$login) { id }", "}"].join("\n");
+const GET_ORG_ID = ["query($login:String!) {", "  organization(login:$login) { id }", "}"].join("\n");
+
+const LIST_USER_PROJECTS = [
+  "query($login:String!, $after:String) {",
+  "  user(login:$login) {",
+  "    projectsV2(first:50, after:$after) {",
+  "      pageInfo { hasNextPage endCursor }",
+  "      nodes { id number title url }",
+  "    }",
+  "  }",
+  "}",
+].join("\n");
+
+const LIST_ORG_PROJECTS = [
+  "query($login:String!, $after:String) {",
+  "  organization(login:$login) {",
+  "    projectsV2(first:50, after:$after) {",
+  "      pageInfo { hasNextPage endCursor }",
+  "      nodes { id number title url }",
+  "    }",
+  "  }",
+  "}",
+].join("\n");
+
+const GET_PROJECT_ITEMS = [
+  "query($projectId:ID!, $after:String) {",
+  "  node(id:$projectId) {",
+  "    ... on ProjectV2 {",
+  "      items(first:50, after:$after, orderBy:{field:POSITION, direction:ASC}) {",
+  "        pageInfo { hasNextPage endCursor }",
+  "        nodes {",
+  "          id",
+  "          isArchived",
+  "          fieldValues(first:20) {",
+  "            nodes {",
+  "              ... on ProjectV2ItemFieldSingleSelectValue {",
+  "                field { ... on ProjectV2SingleSelectField { id name } }",
+  "                name",
+  "              }",
+  "            }",
+  "          }",
+  "          content {",
+  "            ... on Issue { __typename number closed closedAt repository { nameWithOwner } }",
+  "            ... on PullRequest { __typename number closed closedAt repository { nameWithOwner } }",
+  "          }",
+  "        }",
+  "      }",
+  "    }",
+  "  }",
+  "}",
+].join("\n");
+
+const ARCHIVE_ITEM = [
+  "mutation($projectId:ID!, $itemId:ID!) {",
+  "  archiveProjectV2Item(input:{projectId:$projectId, itemId:$itemId}) {",
+  "    item { id }",
+  "  }",
+  "}",
+].join("\n");
+
+// ── Owner / project resolution ─────────────────────────────────────────────
+
+async function resolveOwner(login, env, runChild) {
+  const userPayload = await ghGraphql(GET_USER_ID, { login }, env, runChild);
+  if (userPayload?.data?.user?.id) return { id: userPayload.data.user.id, kind: "user" };
+  const orgPayload = await ghGraphql(GET_ORG_ID, { login }, env, runChild);
+  if (orgPayload?.data?.organization?.id) return { id: orgPayload.data.organization.id, kind: "org" };
+  throw Object.assign(new Error(`Could not resolve owner ID for "${login}"`), { code: "NO_USER_ID" });
+}
+
+async function listAllProjects(login, kind, env, runChild) {
+  const query = kind === "org" ? LIST_ORG_PROJECTS : LIST_USER_PROJECTS;
+  const projects = [];
+  let after = null;
+  while (true) {
+    const vars = { login };
+    if (after) vars.after = after;
+    const payload = await ghGraphql(query, vars, env, runChild);
+    const connection = kind === "org" ? payload?.data?.organization?.projectsV2 : payload?.data?.user?.projectsV2;
+    const nodes = connection?.nodes ?? [];
+    projects.push(...nodes);
+    const pageInfo = connection?.pageInfo ?? {};
+    if (!pageInfo.hasNextPage) break;
+    if (!pageInfo.endCursor) {
+      throw Object.assign(new Error("Invalid projects list payload: hasNextPage true but endCursor missing"), { code: "GH_API_ERROR" });
+    }
+    after = pageInfo.endCursor;
+  }
+  return projects;
+}
+
+async function fetchAllItems(projectId, env, runChild) {
+  const all = [];
+  let after = null;
+  while (true) {
+    const vars = { projectId };
+    if (after) vars.after = after;
+    const payload = await ghGraphql(GET_PROJECT_ITEMS, vars, env, runChild);
+    const connection = payload?.data?.node?.items;
+    const nodes = connection?.nodes ?? [];
+    all.push(...nodes);
+    const pageInfo = connection?.pageInfo ?? {};
+    if (!pageInfo.hasNextPage) break;
+    if (!pageInfo.endCursor) {
+      throw Object.assign(new Error("Invalid items payload: hasNextPage true but endCursor missing"), { code: "GH_API_ERROR" });
+    }
+    after = pageInfo.endCursor;
+  }
+  return all;
+}
+
+function statusOf(node) {
+  const fvs = node?.fieldValues?.nodes ?? [];
+  for (const fv of fvs) {
+    if (fv && fv.field && fv.field.name === "Status") return fv.name;
+  }
+  return null;
+}
+
+// Normalize a raw GraphQL item node into the shape selectArchivable expects.
+function normalizeItem(node) {
+  return {
+    id: node.id,
+    isArchived: Boolean(node.isArchived),
+    status: statusOf(node),
+    content: node.content
+      ? {
+          __typename: node.content.__typename,
+          number: node.content.number,
+          closed: Boolean(node.content.closed),
+          closedAt: node.content.closedAt ?? null,
+          repository: node.content.repository,
+        }
+      : null,
+  };
+}
+
+// ── Selection logic (pure) ────────────────────────────────────────────────
+
+// Select items whose issue/PR is closed and has been closed for >= olderThanMs.
+function selectArchivable(items, { now, olderThanMs }) {
+  return items.filter((it) => {
+    if (it.isArchived) return false;
+    const c = it.content;
+    if (!c || !c.closed || !c.closedAt) return false;
+    const closedAtMs = Date.parse(c.closedAt);
+    if (Number.isNaN(closedAtMs)) return false;
+    return now - closedAtMs >= olderThanMs;
+  });
+}
+
+// ── Exit code classification ────────────────────────────────────────────
+
+function classifyExitCode(err) {
+  if (err.code === "INVALID_REPO" || err.code === "INVALID_PROJECT" ||
+      err.code === "INVALID_DURATION" || err.code === "INVALID_ARGS") return 1;
+  if (err.code === "PROJECT_NOT_FOUND") return 3;
+  return 2;
+}
+
+// ── Main logic ──────────────────────────────────────────────────────────
+
+async function main(args, { env = process.env, runChild } = {}) {
+  const child = runChild ?? _runChild;
+  const repo = validateRepo(args.repo);
+  const [owner] = repo.split("/");
+  const projectRef = parseProjectRef(args.project);
+  const olderThanRaw = args.olderThan ?? "30d";
+  const olderThanMs = parseDuration(olderThanRaw);
+  const now = args.now ?? Date.now();
+
+  const { kind: ownerKind } = await resolveOwner(owner, env, child);
+  const projects = await listAllProjects(owner, ownerKind, env, child);
+  const project = projectRef.kind === "id"
+    ? projects.find((p) => p.id === projectRef.value)
+    : projects.find((p) => p.number === projectRef.value);
+  if (!project) {
+    throw Object.assign(
+      new Error(`Project ${projectRef.kind === "id" ? `"${projectRef.value}"` : `number ${projectRef.value}`} not found under owner "${owner}"`),
+      { code: "PROJECT_NOT_FOUND" },
+    );
+  }
+
+  const rawItems = await fetchAllItems(project.id, env, child);
+  // Only consider items whose content belongs to the target repo (single-repo scope).
+  const repoItems = rawItems
+    .filter((n) => n.content && n.content.repository?.nameWithOwner === repo)
+    .map(normalizeItem);
+
+  const archivable = selectArchivable(repoItems, { now, olderThanMs });
+
+  const mutations = archivable.map((it) => ({
+    query: ARCHIVE_ITEM,
+    variables: { projectId: project.id, itemId: it.id },
+  }));
+
+  if (args.dryRun) {
+    return {
+      ok: true,
+      dryRun: true,
+      olderThan: olderThanRaw,
+      considered: repoItems.length,
+      mutations,
+    };
+  }
+
+  const archived = [];
+  for (const it of archivable) {
+    const payload = await ghGraphql(ARCHIVE_ITEM, { projectId: project.id, itemId: it.id }, env, child);
+    if (!payload?.data?.archiveProjectV2Item?.item) {
+      throw Object.assign(new Error(`Failed to archive item ${it.id}`), { code: "MUTATION_FAILED" });
+    }
+    archived.push({
+      itemId: it.id,
+      issueNumber: it.content.__typename === "Issue" ? it.content.number : null,
+      prNumber: it.content.__typename === "PullRequest" ? it.content.number : null,
+      closedAt: it.content.closedAt,
+    });
+  }
+
+  return {
+    ok: true,
+    olderThan: olderThanRaw,
+    considered: repoItems.length,
+    archived,
+  };
+}
+
+// ── CLI entrypoint ──────────────────────────────────────────────────────
+
+async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, env = process.env } = {}) {
+  let args;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    stderr.write(`${formatCliError(err)}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  if (args.help) {
+    stdout.write(USAGE);
+    return;
+  }
+  try {
+    const result = await main(args, { env });
+    stdout.write(JSON.stringify(result) + "\n");
+  } catch (err) {
+    stderr.write(JSON.stringify({ ok: false, error: err.message, code: err.code ?? "UNKNOWN" }) + "\n");
+    process.exitCode = classifyExitCode(err);
+  }
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(JSON.stringify({ ok: false, error: error.message, code: error.code ?? "UNKNOWN" }) + "\n");
+    process.exitCode = 2;
+  });
+}
+
+export { main, parseDuration, selectArchivable };

--- a/scripts/projects/reorder-queue-item.mjs
+++ b/scripts/projects/reorder-queue-item.mjs
@@ -592,10 +592,31 @@ async function mainSubcommand(args, { env, child, repo, owner, repoName, project
     return { ok: true, dryRun: true, mutations, before };
   }
 
-  for (const mutation of mutations) {
-    const payload = await ghGraphql(mutation.query, mutation.variables, env, child);
+  // NOTE: `order` applies N sequential position mutations and is NOT atomic. A
+  // mid-sequence failure leaves the board partially reordered; re-running the
+  // same `order` command is idempotent and is the supported recovery path. The
+  // thrown error reports how many moves were applied before failing.
+  for (let i = 0; i < mutations.length; i++) {
+    const mutation = mutations[i];
+    let payload;
+    try {
+      payload = await ghGraphql(mutation.query, mutation.variables, env, child);
+    } catch (err) {
+      if (subcommand === "order") {
+        err.message = `${err.message} (order partially applied: ${i} of ${mutations.length} moves completed; re-run the same order command to recover)`;
+        err.appliedMoves = i;
+        err.totalMoves = mutations.length;
+      }
+      throw err;
+    }
     if (!payload?.data?.updateProjectV2ItemPosition) {
-      throw Object.assign(new Error("Failed to reorder item"), { code: "MUTATION_FAILED" });
+      const detail = subcommand === "order"
+        ? ` (order partially applied: ${i} of ${mutations.length} moves completed; re-run the same order command to recover)`
+        : "";
+      throw Object.assign(new Error(`Failed to reorder item${detail}`), {
+        code: "MUTATION_FAILED",
+        ...(subcommand === "order" ? { appliedMoves: i, totalMoves: mutations.length } : {}),
+      });
     }
   }
 

--- a/scripts/projects/reorder-queue-item.mjs
+++ b/scripts/projects/reorder-queue-item.mjs
@@ -609,6 +609,23 @@ async function mainSubcommand(args, { env, child, repo, project }) {
   const refs = positional.map((p) => parseItemRef(p));
   const resolved = refs.map((ref) => resolveFromItems(items, ref, repo));
 
+  // Reordering positions within a single Status column. The before/after snapshot is scoped
+  // to one column, and a cross-column move plan is misleading/invalid — so fail closed unless
+  // every resolved ref shares the first ref's Status (multi-ref subcommands only).
+  if (resolved.length > 1) {
+    const primaryStatus = resolved[0].status ?? null;
+    const offender = resolved.find((it) => (it.status ?? null) !== primaryStatus);
+    if (offender) {
+      throw Object.assign(
+        new Error(
+          `All reordered items must be in the same Status column as the first item (${primaryStatus ?? "(none)"}); ` +
+            `${offender.itemId} is in ${offender.status ?? "(none)"}.`,
+        ),
+        { code: "MIXED_STATUS" },
+      );
+    }
+  }
+
   // Build the ordered list of position moves, each { item, afterItem|null }.
   let plan;
   if (subcommand === "move-to-top") {

--- a/scripts/projects/reorder-queue-item.mjs
+++ b/scripts/projects/reorder-queue-item.mjs
@@ -2,20 +2,35 @@
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
 
-const USAGE = `Usage: dev-loops project reorder --repo <owner/name> --project <number|id> --item <number|node-id> [--after <number|node-id>]
+const USAGE = `Usage:
+  dev-loops project reorder --repo <owner/name> --project <number|id> --item <number|node-id> [--after <number|node-id>]
+  dev-loops project reorder move-to-top <ref> --repo <owner/name> --project <number|id>
+  dev-loops project reorder move-after <ref> <after-ref> --repo <owner/name> --project <number|id>
+  dev-loops project reorder order <ref1> <ref2> ... --repo <owner/name> --project <number|id>
 
-Reorder a GitHub Projects V2 item by board position via updateProjectV2ItemPosition.
-Moves item to top when no --after is provided, or after the specified item.
+Reorder GitHub Projects V2 items by board position via updateProjectV2ItemPosition.
+
+Forms:
+  (no subcommand)   Flag form. Moves --item to top, or after --after when provided.
+  move-to-top <ref> Move <ref> to the first position in its current Status column.
+  move-after <ref> <after-ref>
+                    Move <ref> immediately after <after-ref>.
+  order <ref1> ...  Set explicit ordering: ref1 first, ref2 after ref1, and so on.
+
+A <ref> is an issue/PR number OR a project item node ID. Works for both issues and PRs.
 
 Options:
   --repo <owner/name>         Required. Repository to scope the project search.
   --project <number|id>       Required. Project number (integer) or node ID.
-  --item <number|node-id>     Required. Item to reorder: issue/PR number, or project item node ID.
-  --after <number|node-id>    Position after this item. When omitted, move to top.
+  --item <number|node-id>     Flag form: item to reorder.
+  --after <number|node-id>    Flag form: position after this item. When omitted, move to top.
+  --dry-run                   Print the intended GraphQL mutation(s) without executing.
   --help, -h                  Show this help.
 
 Output (stdout):
-  JSON: { ok: true, item: { itemId, issueNumber, prNumber, status, position }, after: { itemId, issueNumber, prNumber } | null }
+  JSON. Move/move-to-top: { ok, item, after_ref|null, before, after }.
+        order: { ok, moves: [...], before, after }.
+        dry-run: { ok, dryRun: true, mutations: [{ query, variables }], before }.
 
 Exit codes:
   0 — success
@@ -24,13 +39,27 @@ Exit codes:
   3 — project, item, or after-item not found
 `.trim();
 
-const VALID_ARGS = new Set(["--repo", "--project", "--item", "--after", "--help", "-h"]);
+const SUBCOMMANDS = new Set(["move-to-top", "move-after", "order"]);
+const VALID_ARGS = new Set(["--repo", "--project", "--item", "--after", "--dry-run", "--help", "-h"]);
 
 function parseArgs(argv) {
-  const args = {};
-  for (let i = 0; i < argv.length; i++) {
+  const args = { _positional: [] };
+  let i = 0;
+
+  // Optional leading positional subcommand.
+  if (argv.length > 0 && SUBCOMMANDS.has(argv[0])) {
+    args._subcommand = argv[0];
+    i = 1;
+  }
+
+  for (; i < argv.length; i++) {
     const arg = argv[i];
-    if (!VALID_ARGS.has(arg) && arg.startsWith("-")) {
+    if (!arg.startsWith("-")) {
+      // Positional ref (only meaningful with a subcommand).
+      args._positional.push(arg);
+      continue;
+    }
+    if (!VALID_ARGS.has(arg)) {
       throw Object.assign(
         new Error(`Unknown flag: ${arg}`),
         { code: "INVALID_ARGS", usage: USAGE },
@@ -56,6 +85,8 @@ function parseArgs(argv) {
         throw Object.assign(new Error("--after requires a value (number or node ID)"), { code: "INVALID_AFTER" });
       }
       args.after = argv[++i];
+    } else if (arg === "--dry-run") {
+      args.dryRun = true;
     } else if (arg === "--help" || arg === "-h") {
       args.help = true;
     } else {
@@ -296,6 +327,54 @@ async function listAllProjects(login, kind, env, runChild) {
   return projects;
 }
 
+// ── Fetch all project items (paginated, position order) ────────────────
+
+async function fetchAllItems(projectId, env, runChild) {
+  const allItems = [];
+  let after = null;
+  while (true) {
+    const vars = { projectId };
+    if (after) vars.after = after;
+    const itemsPayload = await ghGraphql(GET_PROJECT_ITEMS_BY_CONTENT, vars, env, runChild);
+    const connection = itemsPayload?.data?.node?.items;
+    const nodes = connection?.nodes ?? [];
+    allItems.push(...nodes);
+    const pageInfo = connection?.pageInfo ?? {};
+    if (!pageInfo.hasNextPage) break;
+    if (!pageInfo.endCursor) {
+      throw Object.assign(
+        new Error("Invalid items payload: hasNextPage is true but endCursor is missing"),
+        { code: "GH_API_ERROR" },
+      );
+    }
+    after = pageInfo.endCursor;
+  }
+  return allItems;
+}
+
+function statusOf(node) {
+  const fvs = node?.fieldValues?.nodes ?? [];
+  for (const fv of fvs) {
+    if (fv && fv.field && fv.field.name === "Status") return fv.name;
+  }
+  return null;
+}
+
+// Build a diff-friendly snapshot of items in `repo` (optionally a single Status
+// column), in board position order.
+async function snapshotOrder(projectId, repo, statusFilter, env, runChild) {
+  const items = await fetchAllItems(projectId, env, runChild);
+  return items
+    .filter((it) => it.content && it.content.repository?.nameWithOwner === repo)
+    .filter((it) => (statusFilter == null ? true : statusOf(it) === statusFilter))
+    .map((it) => ({
+      itemId: it.id,
+      issueNumber: it.content.__typename === "Issue" ? it.content.number : null,
+      prNumber: it.content.__typename === "PullRequest" ? it.content.number : null,
+      status: statusOf(it),
+    }));
+}
+
 // ── Resolve an item in a project by reference (number or node ID) ──────
 
 async function resolveProjectItem(projectId, itemRef, owner, repoName, repo, env, runChild) {
@@ -335,25 +414,7 @@ async function resolveProjectItem(projectId, itemRef, owner, repoName, repo, env
   } else {
     // Look up by issue/PR number in the project (paginated)
     const targetNumber = itemRef.value;
-    let allItems = [];
-    let after = null;
-    while (true) {
-      const vars = { projectId };
-      if (after) vars.after = after;
-      const itemsPayload = await ghGraphql(GET_PROJECT_ITEMS_BY_CONTENT, vars, env, runChild);
-      const connection = itemsPayload?.data?.node?.items;
-      const nodes = connection?.nodes ?? [];
-      allItems.push(...nodes);
-      const pageInfo = connection?.pageInfo ?? {};
-      if (!pageInfo.hasNextPage) break;
-      if (!pageInfo.endCursor) {
-        throw Object.assign(
-          new Error("Invalid items payload: hasNextPage is true but endCursor is missing"),
-          { code: "GH_API_ERROR" },
-        );
-      }
-      after = pageInfo.endCursor;
-    }
+    const allItems = await fetchAllItems(projectId, env, runChild);
 
     // Filter by matching repo AND number exactly
     const matchingItems = allItems.filter((it) => {
@@ -400,70 +461,65 @@ function classifyExitCode(err) {
   return 2;
 }
 
-// ── Main logic ──────────────────────────────────────────────────────────
+// ── Resolve owner + project (shared) ──────────────────────────────────────
 
-async function main(args, { env = process.env, runChild } = {}) {
-  const child = runChild ?? _runChild;
-  const repo = validateRepo(args.repo);
-  const [owner, repoName] = repo.split("/");
-  const projectRef = parseProjectRef(args.project);
-  const itemRef = parseItemRef(args.item);
-
-  // --after is optional
-  let afterRef = null;
-  if (args.after !== undefined) {
-    afterRef = parseItemRef(args.after);
-  }
-
-  // 1. Resolve owner
-  const { id: ownerId, kind: ownerKind } = await resolveOwner(owner, env, child);
-
-  // 2. Resolve project
+async function resolveProject(owner, projectRef, env, child) {
+  const { kind: ownerKind } = await resolveOwner(owner, env, child);
   const projects = await listAllProjects(owner, ownerKind, env, child);
-  let project;
-  if (projectRef.kind === "id") {
-    project = projects.find((p) => p.id === projectRef.value);
-  } else {
-    project = projects.find((p) => p.number === projectRef.value);
-  }
+  const project = projectRef.kind === "id"
+    ? projects.find((p) => p.id === projectRef.value)
+    : projects.find((p) => p.number === projectRef.value);
   if (!project) {
     throw Object.assign(
       new Error(`Project ${projectRef.kind === "id" ? `"${projectRef.value}"` : `number ${projectRef.value}`} not found under owner "${owner}"`),
       { code: "PROJECT_NOT_FOUND" },
     );
   }
+  return project;
+}
 
-  // 3. Resolve the item to move
+function executePosition(projectId, itemId, afterId) {
+  return {
+    query: UPDATE_ITEM_POSITION,
+    variables: afterId
+      ? { projectId, itemId, afterId }
+      : { projectId, itemId },
+  };
+}
+
+// ── Legacy flag form: --item [--after] ────────────────────────────────────
+
+async function mainFlagForm(args, { env, child, repo, owner, repoName, project }) {
+  const itemRef = parseItemRef(args.item);
+  let afterRef = null;
+  if (args.after !== undefined) afterRef = parseItemRef(args.after);
+
   const item = await resolveProjectItem(project.id, itemRef, owner, repoName, repo, env, child);
 
-  // 4. Resolve the after-item (if provided)
   let afterItem = null;
   if (afterRef) {
     afterItem = await resolveProjectItem(project.id, afterRef, owner, repoName, repo, env, child);
-
-    // Fail closed: cannot reorder after itself
     if (afterItem.itemId === item.itemId) {
-      throw Object.assign(
-        new Error("Cannot reorder an item after itself"),
-        { code: "INVALID_AFTER" },
-      );
+      throw Object.assign(new Error("Cannot reorder an item after itself"), { code: "INVALID_AFTER" });
     }
   }
 
-  // 5. Execute reorder mutation
-  const mutationVars = {
-    projectId: project.id,
-    itemId: item.itemId,
-    afterId: afterItem ? afterItem.itemId : null,
-  };
+  const mutation = executePosition(project.id, item.itemId, afterItem ? afterItem.itemId : null);
 
-  const mutationPayload = await ghGraphql(UPDATE_ITEM_POSITION, mutationVars, env, child);
+  if (args.dryRun) {
+    return {
+      ok: true,
+      dryRun: true,
+      mutations: [mutation],
+    };
+  }
 
+  const mutationPayload = await ghGraphql(mutation.query, mutation.variables, env, child);
   if (!mutationPayload?.data?.updateProjectV2ItemPosition) {
     throw Object.assign(new Error("Failed to reorder item"), { code: "MUTATION_FAILED" });
   }
 
-  const result = {
+  return {
     ok: true,
     item: {
       itemId: item.itemId,
@@ -473,15 +529,124 @@ async function main(args, { env = process.env, runChild } = {}) {
       position: afterItem ? "after" : "top",
     },
     after: afterItem
-      ? {
-          itemId: afterItem.itemId,
-          issueNumber: afterItem.issueNumber,
-          prNumber: afterItem.prNumber,
-        }
+      ? { itemId: afterItem.itemId, issueNumber: afterItem.issueNumber, prNumber: afterItem.prNumber }
       : null,
   };
+}
 
-  return result;
+// ── Subcommand forms: move-to-top / move-after / order ────────────────────
+
+function requirePositionals(subcommand, positional) {
+  if (subcommand === "move-to-top") {
+    if (positional.length !== 1) {
+      throw Object.assign(new Error("move-to-top requires exactly one <ref>"), { code: "INVALID_ARGS", usage: USAGE });
+    }
+  } else if (subcommand === "move-after") {
+    if (positional.length !== 2) {
+      throw Object.assign(new Error("move-after requires <ref> <after-ref>"), { code: "INVALID_ARGS", usage: USAGE });
+    }
+  } else if (subcommand === "order") {
+    if (positional.length < 2) {
+      throw Object.assign(new Error("order requires at least two <ref> values"), { code: "INVALID_ARGS", usage: USAGE });
+    }
+  }
+}
+
+async function mainSubcommand(args, { env, child, repo, owner, repoName, project }) {
+  const subcommand = args._subcommand;
+  const positional = args._positional ?? [];
+  requirePositionals(subcommand, positional);
+
+  // Resolve all referenced items up-front (fail closed before any mutation).
+  const refs = positional.map((p) => parseItemRef(p));
+  const resolved = [];
+  for (const ref of refs) {
+    resolved.push(await resolveProjectItem(project.id, ref, owner, repoName, repo, env, child));
+  }
+
+  // Build the ordered list of position moves, each { item, afterItem|null }.
+  let plan;
+  if (subcommand === "move-to-top") {
+    plan = [{ item: resolved[0], afterItem: null }];
+  } else if (subcommand === "move-after") {
+    const [item, afterItem] = resolved;
+    if (item.itemId === afterItem.itemId) {
+      throw Object.assign(new Error("Cannot reorder an item after itself"), { code: "INVALID_AFTER" });
+    }
+    plan = [{ item, afterItem }];
+  } else {
+    // order: ref1 to top, then each subsequent ref after its predecessor.
+    plan = resolved.map((item, idx) => ({
+      item,
+      afterItem: idx === 0 ? null : resolved[idx - 1],
+    }));
+  }
+
+  const mutations = plan.map((m) => executePosition(project.id, m.item.itemId, m.afterItem ? m.afterItem.itemId : null));
+
+  // Status column for the diff snapshot: use the primary moved item's status.
+  const statusFilter = resolved[0].status ?? null;
+  const before = await snapshotOrder(project.id, repo, statusFilter, env, child);
+
+  if (args.dryRun) {
+    return { ok: true, dryRun: true, mutations, before };
+  }
+
+  for (const mutation of mutations) {
+    const payload = await ghGraphql(mutation.query, mutation.variables, env, child);
+    if (!payload?.data?.updateProjectV2ItemPosition) {
+      throw Object.assign(new Error("Failed to reorder item"), { code: "MUTATION_FAILED" });
+    }
+  }
+
+  const after = await snapshotOrder(project.id, repo, statusFilter, env, child);
+
+  const moves = plan.map((m) => ({
+    itemId: m.item.itemId,
+    issueNumber: m.item.issueNumber,
+    prNumber: m.item.prNumber,
+    status: m.item.status,
+    position: m.afterItem ? "after" : "top",
+    afterId: m.afterItem ? m.afterItem.itemId : null,
+  }));
+
+  if (subcommand === "order") {
+    return { ok: true, moves, before, after };
+  }
+
+  // move-to-top / move-after: single move, richer shape.
+  const m = plan[0];
+  return {
+    ok: true,
+    item: {
+      itemId: m.item.itemId,
+      issueNumber: m.item.issueNumber,
+      prNumber: m.item.prNumber,
+      status: m.item.status,
+      position: m.afterItem ? "after" : "top",
+    },
+    after_ref: m.afterItem
+      ? { itemId: m.afterItem.itemId, issueNumber: m.afterItem.issueNumber, prNumber: m.afterItem.prNumber }
+      : null,
+    before,
+    after,
+  };
+}
+
+// ── Main logic ──────────────────────────────────────────────────────────
+
+async function main(args, { env = process.env, runChild } = {}) {
+  const child = runChild ?? _runChild;
+  const repo = validateRepo(args.repo);
+  const [owner, repoName] = repo.split("/");
+  const projectRef = parseProjectRef(args.project);
+
+  const project = await resolveProject(owner, projectRef, env, child);
+
+  if (args._subcommand) {
+    return mainSubcommand(args, { env, child, repo, owner, repoName, project });
+  }
+  return mainFlagForm(args, { env, child, repo, owner, repoName, project });
 }
 
 // ── CLI entrypoint ──────────────────────────────────────────────────────

--- a/scripts/projects/reorder-queue-item.mjs
+++ b/scripts/projects/reorder-queue-item.mjs
@@ -360,19 +360,59 @@ function statusOf(node) {
   return null;
 }
 
+function describeItem(node) {
+  return {
+    itemId: node.id,
+    issueNumber: node.content?.__typename === "Issue" ? node.content.number : null,
+    prNumber: node.content?.__typename === "PullRequest" ? node.content.number : null,
+    status: statusOf(node),
+  };
+}
+
 // Build a diff-friendly snapshot of items in `repo` (optionally a single Status
-// column), in board position order.
-async function snapshotOrder(projectId, repo, statusFilter, env, runChild) {
-  const items = await fetchAllItems(projectId, env, runChild);
+// column), in board position order, from a pre-fetched item list.
+function snapshotFromItems(items, repo, statusFilter) {
   return items
     .filter((it) => it.content && it.content.repository?.nameWithOwner === repo)
     .filter((it) => (statusFilter == null ? true : statusOf(it) === statusFilter))
-    .map((it) => ({
-      itemId: it.id,
-      issueNumber: it.content.__typename === "Issue" ? it.content.number : null,
-      prNumber: it.content.__typename === "PullRequest" ? it.content.number : null,
-      status: statusOf(it),
-    }));
+    .map(describeItem);
+}
+
+async function snapshotOrder(projectId, repo, statusFilter, env, runChild) {
+  const items = await fetchAllItems(projectId, env, runChild);
+  return snapshotFromItems(items, repo, statusFilter);
+}
+
+// Resolve a ref (number or item node ID) against a pre-fetched item list,
+// enforcing the same repo scope for BOTH number and id refs so a cross-project
+// ref fails closed with ITEM_NOT_FOUND.
+function resolveFromItems(items, itemRef, repo) {
+  let match;
+  if (itemRef.kind === "id") {
+    match = items.find(
+      (it) => it.id === itemRef.value && it.content?.repository?.nameWithOwner === repo,
+    );
+    if (!match) {
+      throw Object.assign(
+        new Error(`Item "${itemRef.value}" not found in project for repo "${repo}"`),
+        { code: "ITEM_NOT_FOUND" },
+      );
+    }
+  } else {
+    match = items.find(
+      (it) =>
+        it.content &&
+        it.content.repository?.nameWithOwner === repo &&
+        it.content.number === itemRef.value,
+    );
+    if (!match) {
+      throw Object.assign(
+        new Error(`Item #${itemRef.value} not found in project for repo "${repo}"`),
+        { code: "ITEM_NOT_FOUND" },
+      );
+    }
+  }
+  return describeItem(match);
 }
 
 // ── Resolve an item in a project by reference (number or node ID) ──────
@@ -507,10 +547,13 @@ async function mainFlagForm(args, { env, child, repo, owner, repoName, project }
   const mutation = executePosition(project.id, item.itemId, afterItem ? afterItem.itemId : null);
 
   if (args.dryRun) {
+    // Include the before snapshot for parity with the subcommand dry-run form.
+    const before = await snapshotOrder(project.id, repo, item.status ?? null, env, child);
     return {
       ok: true,
       dryRun: true,
       mutations: [mutation],
+      before,
     };
   }
 
@@ -552,17 +595,19 @@ function requirePositionals(subcommand, positional) {
   }
 }
 
-async function mainSubcommand(args, { env, child, repo, owner, repoName, project }) {
+async function mainSubcommand(args, { env, child, repo, project }) {
   const subcommand = args._subcommand;
   const positional = args._positional ?? [];
   requirePositionals(subcommand, positional);
 
+  // Fetch the board item list ONCE, then resolve every ref (number or id) from
+  // that single list — avoids N full-board scans for N refs and enforces the
+  // same repo scope for both ref kinds (cross-project refs fail closed).
+  const items = await fetchAllItems(project.id, env, child);
+
   // Resolve all referenced items up-front (fail closed before any mutation).
   const refs = positional.map((p) => parseItemRef(p));
-  const resolved = [];
-  for (const ref of refs) {
-    resolved.push(await resolveProjectItem(project.id, ref, owner, repoName, repo, env, child));
-  }
+  const resolved = refs.map((ref) => resolveFromItems(items, ref, repo));
 
   // Build the ordered list of position moves, each { item, afterItem|null }.
   let plan;
@@ -585,8 +630,9 @@ async function mainSubcommand(args, { env, child, repo, owner, repoName, project
   const mutations = plan.map((m) => executePosition(project.id, m.item.itemId, m.afterItem ? m.afterItem.itemId : null));
 
   // Status column for the diff snapshot: use the primary moved item's status.
+  // Reuse the already-fetched list for the before-snapshot (no extra fetch).
   const statusFilter = resolved[0].status ?? null;
-  const before = await snapshotOrder(project.id, repo, statusFilter, env, child);
+  const before = snapshotFromItems(items, repo, statusFilter);
 
   if (args.dryRun) {
     return { ok: true, dryRun: true, mutations, before };
@@ -662,10 +708,19 @@ async function main(args, { env = process.env, runChild } = {}) {
   const [owner, repoName] = repo.split("/");
   const projectRef = parseProjectRef(args.project);
 
+  // Fail closed: the legacy flag form takes no positional arguments. A stray
+  // token (e.g. `reorder 630 --item ...`) must not be silently ignored.
+  if (!args._subcommand && (args._positional?.length ?? 0) > 0) {
+    throw Object.assign(
+      new Error(`Unexpected argument: ${args._positional[0]}`),
+      { code: "INVALID_ARGS", usage: USAGE },
+    );
+  }
+
   const project = await resolveProject(owner, projectRef, env, child);
 
   if (args._subcommand) {
-    return mainSubcommand(args, { env, child, repo, owner, repoName, project });
+    return mainSubcommand(args, { env, child, repo, project });
   }
   return mainFlagForm(args, { env, child, repo, owner, repoName, project });
 }

--- a/test/projects/archive-done-items.test.mjs
+++ b/test/projects/archive-done-items.test.mjs
@@ -148,6 +148,10 @@ describe("archive-done — integration", () => {
     assert.strictEqual(result.archived[0].itemId, "A");
     assert.strictEqual(result.archived[0].issueNumber, 1);
     assert.strictEqual(countMutations(runChild.calls), 1);
+    // Output distinguishes all scanned board items from archive candidates.
+    assert.strictEqual(result.scanned, 2);
+    assert.strictEqual(result.archivable, 1);
+    assert.strictEqual("considered" in result, false);
   });
 
   it("--dry-run lists intended archive mutations without executing", async () => {
@@ -169,6 +173,8 @@ describe("archive-done — integration", () => {
     assert.ok(result.mutations[0].query.includes("archiveProjectV2Item"));
     assert.strictEqual(result.mutations[0].variables.itemId, "A");
     assert.strictEqual(countMutations(runChild.calls), 0);
+    assert.strictEqual(result.scanned, 1);
+    assert.strictEqual(result.archivable, 1);
   });
 
   it("defaults to 30d when --older-than is omitted", async () => {

--- a/test/projects/archive-done-items.test.mjs
+++ b/test/projects/archive-done-items.test.mjs
@@ -1,0 +1,192 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  main,
+  parseDuration,
+  selectArchivable,
+} from "../../scripts/projects/archive-done-items.mjs";
+
+// ── Pure unit: parseDuration ──────────────────────────────────────────────
+
+describe("archive-done — parseDuration", () => {
+  it("parses days", () => {
+    assert.strictEqual(parseDuration("30d"), 30 * 24 * 60 * 60 * 1000);
+  });
+  it("parses hours and weeks", () => {
+    assert.strictEqual(parseDuration("12h"), 12 * 60 * 60 * 1000);
+    assert.strictEqual(parseDuration("2w"), 2 * 7 * 24 * 60 * 60 * 1000);
+  });
+  it("rejects invalid duration", () => {
+    assert.throws(() => parseDuration("abc"), (e) => e.code === "INVALID_DURATION");
+    assert.throws(() => parseDuration("0d"), (e) => e.code === "INVALID_DURATION");
+  });
+});
+
+// ── Pure unit: selectArchivable ──────────────────────────────────────────
+
+function item(id, { number, typename = "Issue", closed = false, closedAt = null, status = "Done" }) {
+  return {
+    id,
+    isArchived: false,
+    status,
+    content: {
+      __typename: typename,
+      number,
+      closed,
+      closedAt,
+      repository: { nameWithOwner: "mfittko/dev-loops" },
+    },
+  };
+}
+
+describe("archive-done — selectArchivable", () => {
+  const now = Date.parse("2026-06-24T00:00:00Z");
+  const olderThanMs = 30 * 24 * 60 * 60 * 1000;
+
+  it("selects items closed longer than the threshold", () => {
+    const items = [
+      item("A", { number: 1, closed: true, closedAt: "2026-05-01T00:00:00Z" }), // 54d ago
+      item("B", { number: 2, closed: true, closedAt: "2026-06-20T00:00:00Z" }), // 4d ago
+    ];
+    const selected = selectArchivable(items, { now, olderThanMs });
+    assert.deepStrictEqual(selected.map((x) => x.id), ["A"]);
+  });
+
+  it("excludes open items even if in Done column", () => {
+    const items = [
+      item("C", { number: 3, closed: false, closedAt: null, status: "Done" }),
+    ];
+    const selected = selectArchivable(items, { now, olderThanMs });
+    assert.strictEqual(selected.length, 0);
+  });
+
+  it("excludes already-archived items", () => {
+    const items = [
+      { ...item("D", { number: 4, closed: true, closedAt: "2026-01-01T00:00:00Z" }), isArchived: true },
+    ];
+    const selected = selectArchivable(items, { now, olderThanMs });
+    assert.strictEqual(selected.length, 0);
+  });
+
+  it("selects closed PRs as well as issues", () => {
+    const items = [
+      item("E", { number: 5, typename: "PullRequest", closed: true, closedAt: "2026-01-01T00:00:00Z" }),
+    ];
+    const selected = selectArchivable(items, { now, olderThanMs });
+    assert.deepStrictEqual(selected.map((x) => x.id), ["E"]);
+  });
+});
+
+// ── Integration via mocked gh ─────────────────────────────────────────────
+
+function mockRunChild(responses) {
+  let callIndex = 0;
+  const calls = [];
+  const fn = async (_cmd, args) => {
+    calls.push(args);
+    if (callIndex >= responses.length) {
+      throw new Error("Unexpected gh call #" + (callIndex + 1));
+    }
+    const resp = responses[callIndex++];
+    if (resp.error) return { code: 1, stdout: "", stderr: resp.error };
+    return { code: 0, stdout: JSON.stringify(resp.payload), stderr: "" };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function userPayload() {
+  return { data: { user: { id: "U_1" } } };
+}
+function listUserProjectsResponse(projects) {
+  return { data: { user: { projectsV2: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: projects } } } };
+}
+const PROJECT = { id: "PVT_proj1", number: 1, title: "Dev Loop Queue", url: "u" };
+
+function itemsResponse(nodes) {
+  return { data: { node: { items: { pageInfo: { hasNextPage: false, endCursor: null }, nodes } } } };
+}
+function rawItemNode(id, number, { closed, closedAt, status = "Done", typename = "Issue", repo = "mfittko/dev-loops" }) {
+  return {
+    id,
+    isArchived: false,
+    fieldValues: { nodes: [{ field: { id: "f", name: "Status" }, name: status }] },
+    content: { __typename: typename, number, closed, closedAt, repository: { nameWithOwner: repo } },
+  };
+}
+function archiveResponse(id) {
+  return { data: { archiveProjectV2Item: { item: { id } } } };
+}
+
+function countMutations(calls) {
+  return calls.filter((args) =>
+    args.some((a) => typeof a === "string" && a.startsWith("query=") && a.includes("mutation")),
+  ).length;
+}
+
+describe("archive-done — integration", () => {
+  it("archives items closed longer than the threshold and reports them", async () => {
+    const nodes = [
+      rawItemNode("A", 1, { closed: true, closedAt: "2026-01-01T00:00:00Z" }),
+      rawItemNode("B", 2, { closed: true, closedAt: "2026-06-23T00:00:00Z" }), // recent
+    ];
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([PROJECT]) },
+      { payload: itemsResponse(nodes) },
+      { payload: archiveResponse("A") },
+    ];
+    const runChild = mockRunChild(responses);
+
+    const result = await main(
+      { repo: "mfittko/dev-loops", project: "1", olderThan: "30d", now: Date.parse("2026-06-24T00:00:00Z") },
+      { runChild },
+    );
+
+    assert.ok(result.ok);
+    assert.strictEqual(result.archived.length, 1);
+    assert.strictEqual(result.archived[0].itemId, "A");
+    assert.strictEqual(result.archived[0].issueNumber, 1);
+    assert.strictEqual(countMutations(runChild.calls), 1);
+  });
+
+  it("--dry-run lists intended archive mutations without executing", async () => {
+    const nodes = [rawItemNode("A", 1, { closed: true, closedAt: "2026-01-01T00:00:00Z" })];
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([PROJECT]) },
+      { payload: itemsResponse(nodes) },
+    ];
+    const runChild = mockRunChild(responses);
+
+    const result = await main(
+      { repo: "mfittko/dev-loops", project: "1", olderThan: "30d", dryRun: true, now: Date.parse("2026-06-24T00:00:00Z") },
+      { runChild },
+    );
+
+    assert.strictEqual(result.dryRun, true);
+    assert.strictEqual(result.mutations.length, 1);
+    assert.ok(result.mutations[0].query.includes("archiveProjectV2Item"));
+    assert.strictEqual(result.mutations[0].variables.itemId, "A");
+    assert.strictEqual(countMutations(runChild.calls), 0);
+  });
+
+  it("defaults to 30d when --older-than is omitted", async () => {
+    const nodes = [rawItemNode("A", 1, { closed: true, closedAt: "2026-06-23T00:00:00Z" })]; // 1d ago
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([PROJECT]) },
+      { payload: itemsResponse(nodes) },
+    ];
+    const runChild = mockRunChild(responses);
+
+    const result = await main(
+      { repo: "mfittko/dev-loops", project: "1", now: Date.parse("2026-06-24T00:00:00Z") },
+      { runChild },
+    );
+
+    assert.ok(result.ok);
+    assert.strictEqual(result.archived.length, 0);
+    assert.strictEqual(result.olderThan, "30d");
+  });
+});

--- a/test/projects/reorder-subcommands.test.mjs
+++ b/test/projects/reorder-subcommands.test.mjs
@@ -1,0 +1,332 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { main } from "../../scripts/projects/reorder-queue-item.mjs";
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function mockRunChild(responses) {
+  let callIndex = 0;
+  const calls = [];
+  const fn = async (_cmd, args, _env) => {
+    calls.push(args);
+    if (callIndex >= responses.length) {
+      throw new Error("Unexpected gh call #" + (callIndex + 1) + " (only " + responses.length + " mocked)");
+    }
+    const resp = responses[callIndex++];
+    if (resp.error) {
+      return { code: 1, stdout: "", stderr: resp.error };
+    }
+    return { code: 0, stdout: JSON.stringify(resp.payload), stderr: "" };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function extractGraphqlInput(args) {
+  const vars = {};
+  for (const arg of args) {
+    if (typeof arg === "string") {
+      const eq = arg.indexOf("=");
+      if (eq > 0 && !arg.startsWith("query=")) {
+        const key = arg.slice(0, eq);
+        const value = arg.slice(eq + 1);
+        vars[key] = value;
+      }
+    }
+  }
+  return Object.keys(vars).length > 0 ? vars : null;
+}
+
+function countMutations(calls) {
+  return calls.filter((args) =>
+    args.some((a) => typeof a === "string" && a.startsWith("query=") && a.includes("mutation")),
+  ).length;
+}
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+
+function userPayload() {
+  return { data: { user: { id: "U_kgDOABC123" } } };
+}
+
+function listUserProjectsResponse(projects) {
+  return {
+    data: {
+      user: {
+        projectsV2: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: projects,
+        },
+      },
+    },
+  };
+}
+
+const EXISTING_PROJECT = {
+  id: "PVT_proj1",
+  number: 1,
+  title: "Dev Loop Queue",
+  url: "https://github.com/users/mfittko/projects/1",
+};
+
+function makeItemContent(ref, typename, repo) {
+  return {
+    __typename: typename || "Issue",
+    number: ref,
+    repository: { nameWithOwner: repo || "mfittko/dev-loops" },
+  };
+}
+
+function makeItemNode(itemId, ref, typename, status) {
+  return {
+    id: itemId,
+    fieldValues: {
+      nodes: [
+        {
+          field: { id: "PVTSSF_status", name: "Status" },
+          name: status || "Backlog",
+        },
+      ],
+    },
+    content: makeItemContent(ref, typename),
+  };
+}
+
+function getItemsByContentResponse(items) {
+  return {
+    data: {
+      node: {
+        items: {
+          nodes: items,
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+    },
+  };
+}
+
+function updatePositionResponse() {
+  return {
+    data: { updateProjectV2ItemPosition: { clientMutationId: null } },
+  };
+}
+
+// ── move-to-top subcommand ────────────────────────────────────────────────
+
+describe("reorder — move-to-top subcommand", () => {
+  it("moves an item to top via positional ref and reports diff", async () => {
+    const items = [
+      makeItemNode("PVTI_a", 625, "Issue", "Next Up"),
+      makeItemNode("PVTI_b", 630, "Issue", "Next Up"),
+    ];
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      { payload: getItemsByContentResponse(items) }, // resolve target item
+      { payload: getItemsByContentResponse(items) }, // before-order snapshot
+      { payload: updatePositionResponse() },
+      { payload: getItemsByContentResponse([items[1], items[0]]) }, // after-order snapshot
+    ];
+    const runChild = mockRunChild(responses);
+
+    const result = await main(
+      { _subcommand: "move-to-top", _positional: ["630"], repo: "mfittko/dev-loops", project: "1" },
+      { runChild },
+    );
+
+    assert.ok(result.ok);
+    assert.strictEqual(result.item.itemId, "PVTI_b");
+    assert.strictEqual(result.item.issueNumber, 630);
+    assert.strictEqual(result.item.position, "top");
+    assert.ok(Array.isArray(result.before), "before order present");
+    assert.ok(Array.isArray(result.after), "after order present");
+    assert.deepStrictEqual(result.before.map((x) => x.itemId), ["PVTI_a", "PVTI_b"]);
+    assert.deepStrictEqual(result.after.map((x) => x.itemId), ["PVTI_b", "PVTI_a"]);
+  });
+});
+
+// ── move-after subcommand ─────────────────────────────────────────────────
+
+describe("reorder — move-after subcommand", () => {
+  it("moves item after another via two positional refs", async () => {
+    const items = [
+      makeItemNode("PVTI_630", 630, "Issue", "Next Up"),
+      makeItemNode("PVTI_625", 625, "Issue", "Next Up"),
+    ];
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      { payload: getItemsByContentResponse(items) }, // target
+      { payload: getItemsByContentResponse(items) }, // after-ref
+      { payload: getItemsByContentResponse(items) }, // before snapshot
+      { payload: updatePositionResponse() },
+      { payload: getItemsByContentResponse([items[1], items[0]]) }, // after snapshot
+    ];
+    const runChild = mockRunChild(responses);
+
+    let capturedInput = null;
+    const wrapped = async (cmd, args, env) => {
+      const r = await runChild(cmd, args, env);
+      if (args.some((a) => typeof a === "string" && a.includes("mutation"))) {
+        capturedInput = extractGraphqlInput(args);
+      }
+      return r;
+    };
+    wrapped.calls = runChild.calls;
+
+    const result = await main(
+      { _subcommand: "move-after", _positional: ["630", "625"], repo: "mfittko/dev-loops", project: "1" },
+      { runChild: wrapped },
+    );
+
+    assert.ok(result.ok);
+    assert.strictEqual(result.item.position, "after");
+    assert.strictEqual(result.after_ref.itemId, "PVTI_625");
+    assert.strictEqual(capturedInput.itemId, "PVTI_630");
+    assert.strictEqual(capturedInput.afterId, "PVTI_625");
+  });
+});
+
+// ── order subcommand ──────────────────────────────────────────────────────
+
+describe("reorder — order subcommand", () => {
+  it("sets explicit ordering for a sequence with chained mutations", async () => {
+    const items = [
+      makeItemNode("PVTI_1", 101, "Issue", "Next Up"),
+      makeItemNode("PVTI_2", 102, "Issue", "Next Up"),
+      makeItemNode("PVTI_3", 103, "Issue", "Next Up"),
+    ];
+    // order 103 101 102: resolve each (3), before snapshot (1), 3 mutations, after snapshot (1)
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      { payload: getItemsByContentResponse(items) }, // resolve 103
+      { payload: getItemsByContentResponse(items) }, // resolve 101
+      { payload: getItemsByContentResponse(items) }, // resolve 102
+      { payload: getItemsByContentResponse(items) }, // before snapshot
+      { payload: updatePositionResponse() }, // 103 -> top
+      { payload: updatePositionResponse() }, // 101 -> after 103
+      { payload: updatePositionResponse() }, // 102 -> after 101
+      { payload: getItemsByContentResponse([items[2], items[0], items[1]]) }, // after snapshot
+    ];
+    const runChild = mockRunChild(responses);
+
+    const result = await main(
+      { _subcommand: "order", _positional: ["103", "101", "102"], repo: "mfittko/dev-loops", project: "1" },
+      { runChild },
+    );
+
+    assert.ok(result.ok);
+    assert.strictEqual(result.moves.length, 3);
+    assert.strictEqual(result.moves[0].position, "top");
+    assert.strictEqual(result.moves[1].position, "after");
+    assert.strictEqual(result.moves[2].position, "after");
+    assert.strictEqual(countMutations(runChild.calls), 3);
+    assert.deepStrictEqual(result.after.map((x) => x.itemId), ["PVTI_3", "PVTI_1", "PVTI_2"]);
+  });
+});
+
+// ── --dry-run ─────────────────────────────────────────────────────────────
+
+describe("reorder — --dry-run", () => {
+  it("prints intended mutations without executing them (move-to-top)", async () => {
+    const items = [makeItemNode("PVTI_b", 630, "Issue", "Next Up")];
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      { payload: getItemsByContentResponse(items) }, // resolve
+      { payload: getItemsByContentResponse(items) }, // before snapshot
+    ];
+    const runChild = mockRunChild(responses);
+
+    const result = await main(
+      { _subcommand: "move-to-top", _positional: ["630"], repo: "mfittko/dev-loops", project: "1", dryRun: true },
+      { runChild },
+    );
+
+    assert.ok(result.ok);
+    assert.strictEqual(result.dryRun, true);
+    assert.ok(Array.isArray(result.mutations));
+    assert.strictEqual(result.mutations.length, 1);
+    assert.ok(result.mutations[0].query.includes("updateProjectV2ItemPosition"));
+    assert.strictEqual(result.mutations[0].variables.itemId, "PVTI_b");
+    // No mutation gh calls were made
+    assert.strictEqual(countMutations(runChild.calls), 0);
+  });
+
+  it("prints all chained mutations for order without executing", async () => {
+    const items = [
+      makeItemNode("PVTI_1", 101, "Issue", "Next Up"),
+      makeItemNode("PVTI_2", 102, "Issue", "Next Up"),
+    ];
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      { payload: getItemsByContentResponse(items) }, // resolve 102
+      { payload: getItemsByContentResponse(items) }, // resolve 101
+      { payload: getItemsByContentResponse(items) }, // before snapshot
+    ];
+    const runChild = mockRunChild(responses);
+
+    const result = await main(
+      { _subcommand: "order", _positional: ["102", "101"], repo: "mfittko/dev-loops", project: "1", dryRun: true },
+      { runChild },
+    );
+
+    assert.strictEqual(result.dryRun, true);
+    assert.strictEqual(result.mutations.length, 2);
+    assert.strictEqual(result.mutations[0].variables.afterId ?? null, null);
+    assert.strictEqual(result.mutations[1].variables.afterId, "PVTI_2");
+    assert.strictEqual(countMutations(runChild.calls), 0);
+  });
+});
+
+// ── issue vs PR ref ───────────────────────────────────────────────────────
+
+describe("reorder — issue and PR refs", () => {
+  it("resolves a PR item ref for move-to-top", async () => {
+    const items = [makeItemNode("PVTI_pr", 88, "PullRequest", "Next Up")];
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      { payload: getItemsByContentResponse(items) },
+      { payload: getItemsByContentResponse(items) },
+      { payload: updatePositionResponse() },
+      { payload: getItemsByContentResponse(items) },
+    ];
+    const runChild = mockRunChild(responses);
+
+    const result = await main(
+      { _subcommand: "move-to-top", _positional: ["88"], repo: "mfittko/dev-loops", project: "1" },
+      { runChild },
+    );
+
+    assert.ok(result.ok);
+    assert.strictEqual(result.item.prNumber, 88);
+    assert.strictEqual(result.item.issueNumber, null);
+  });
+});
+
+// ── cross-project / not found error ───────────────────────────────────────
+
+describe("reorder — cross-project error", () => {
+  it("returns clear ITEM_NOT_FOUND when ref is not in the target project", async () => {
+    const items = [makeItemNode("PVTI_other", 630, "Issue", "Next Up", "Next Up")];
+    // item belongs to a different repo -> filtered out
+    items[0].content.repository.nameWithOwner = "other/repo";
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      { payload: getItemsByContentResponse(items) },
+    ];
+    const runChild = mockRunChild(responses);
+
+    await assert.rejects(
+      () => main(
+        { _subcommand: "move-to-top", _positional: ["630"], repo: "mfittko/dev-loops", project: "1" },
+        { runChild },
+      ),
+      (err) => err.code === "ITEM_NOT_FOUND" && /not found in project/.test(err.message),
+    );
+  });
+});

--- a/test/projects/reorder-subcommands.test.mjs
+++ b/test/projects/reorder-subcommands.test.mjs
@@ -226,6 +226,42 @@ describe("reorder — order subcommand", () => {
   });
 });
 
+describe("reorder — order partial-failure recovery", () => {
+  it("reports how many moves were applied when a mid-sequence mutation fails", async () => {
+    const items = [
+      makeItemNode("PVTI_1", 101, "Issue", "Next Up"),
+      makeItemNode("PVTI_2", 102, "Issue", "Next Up"),
+      makeItemNode("PVTI_3", 103, "Issue", "Next Up"),
+    ];
+    // order 103 101 102: resolve each (3), before snapshot (1), mutation 1 ok, mutation 2 fails
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      { payload: getItemsByContentResponse(items) }, // resolve 103
+      { payload: getItemsByContentResponse(items) }, // resolve 101
+      { payload: getItemsByContentResponse(items) }, // resolve 102
+      { payload: getItemsByContentResponse(items) }, // before snapshot
+      { payload: updatePositionResponse() }, // move 1 ok
+      { error: "boom" }, // move 2 fails
+    ];
+    const runChild = mockRunChild(responses);
+
+    await assert.rejects(
+      () => main(
+        { _subcommand: "order", _positional: ["103", "101", "102"], repo: "mfittko/dev-loops", project: "1" },
+        { runChild },
+      ),
+      (err) => {
+        assert.strictEqual(err.appliedMoves, 1);
+        assert.strictEqual(err.totalMoves, 3);
+        assert.match(err.message, /order partially applied: 1 of 3/);
+        assert.match(err.message, /re-run the same order command/);
+        return true;
+      },
+    );
+  });
+});
+
 // ── --dry-run ─────────────────────────────────────────────────────────────
 
 describe("reorder — --dry-run", () => {

--- a/test/projects/reorder-subcommands.test.mjs
+++ b/test/projects/reorder-subcommands.test.mjs
@@ -218,6 +218,25 @@ describe("reorder — order subcommand", () => {
     assert.strictEqual(countMutations(runChild.calls), 3);
     assert.deepStrictEqual(result.after.map((x) => x.itemId), ["PVTI_3", "PVTI_1", "PVTI_2"]);
   });
+
+  it("fails closed when refs span different Status columns (no mutation)", async () => {
+    const items = [
+      makeItemNode("PVTI_1", 101, "Issue", "Next Up"),
+      makeItemNode("PVTI_2", 102, "Issue", "In Progress"), // different column
+    ];
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      { payload: getItemsByContentResponse(items) }, // single resolve fetch
+    ];
+    const runChild = mockRunChild(responses);
+
+    await assert.rejects(
+      () => main({ _subcommand: "order", _positional: ["101", "102"], repo: "mfittko/dev-loops", project: "1" }, { runChild }),
+      (err) => err.code === "MIXED_STATUS" && /same Status column/.test(err.message),
+    );
+    assert.strictEqual(countMutations(runChild.calls), 0, "no mutation on a mixed-status plan");
+  });
 });
 
 describe("reorder — order partial-failure recovery", () => {

--- a/test/projects/reorder-subcommands.test.mjs
+++ b/test/projects/reorder-subcommands.test.mjs
@@ -122,8 +122,7 @@ describe("reorder — move-to-top subcommand", () => {
     const responses = [
       { payload: userPayload() },
       { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
-      { payload: getItemsByContentResponse(items) }, // resolve target item
-      { payload: getItemsByContentResponse(items) }, // before-order snapshot
+      { payload: getItemsByContentResponse(items) }, // single fetch: resolve + before snapshot
       { payload: updatePositionResponse() },
       { payload: getItemsByContentResponse([items[1], items[0]]) }, // after-order snapshot
     ];
@@ -156,9 +155,7 @@ describe("reorder — move-after subcommand", () => {
     const responses = [
       { payload: userPayload() },
       { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
-      { payload: getItemsByContentResponse(items) }, // target
-      { payload: getItemsByContentResponse(items) }, // after-ref
-      { payload: getItemsByContentResponse(items) }, // before snapshot
+      { payload: getItemsByContentResponse(items) }, // single fetch: resolve both refs + before
       { payload: updatePositionResponse() },
       { payload: getItemsByContentResponse([items[1], items[0]]) }, // after snapshot
     ];
@@ -196,14 +193,11 @@ describe("reorder — order subcommand", () => {
       makeItemNode("PVTI_2", 102, "Issue", "Next Up"),
       makeItemNode("PVTI_3", 103, "Issue", "Next Up"),
     ];
-    // order 103 101 102: resolve each (3), before snapshot (1), 3 mutations, after snapshot (1)
+    // order 103 101 102: single fetch (resolve all + before), 3 mutations, after snapshot (1)
     const responses = [
       { payload: userPayload() },
       { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
-      { payload: getItemsByContentResponse(items) }, // resolve 103
-      { payload: getItemsByContentResponse(items) }, // resolve 101
-      { payload: getItemsByContentResponse(items) }, // resolve 102
-      { payload: getItemsByContentResponse(items) }, // before snapshot
+      { payload: getItemsByContentResponse(items) }, // single fetch: resolve all refs + before
       { payload: updatePositionResponse() }, // 103 -> top
       { payload: updatePositionResponse() }, // 101 -> after 103
       { payload: updatePositionResponse() }, // 102 -> after 101
@@ -233,14 +227,11 @@ describe("reorder — order partial-failure recovery", () => {
       makeItemNode("PVTI_2", 102, "Issue", "Next Up"),
       makeItemNode("PVTI_3", 103, "Issue", "Next Up"),
     ];
-    // order 103 101 102: resolve each (3), before snapshot (1), mutation 1 ok, mutation 2 fails
+    // order 103 101 102: single fetch (resolve all + before), mutation 1 ok, mutation 2 fails
     const responses = [
       { payload: userPayload() },
       { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
-      { payload: getItemsByContentResponse(items) }, // resolve 103
-      { payload: getItemsByContentResponse(items) }, // resolve 101
-      { payload: getItemsByContentResponse(items) }, // resolve 102
-      { payload: getItemsByContentResponse(items) }, // before snapshot
+      { payload: getItemsByContentResponse(items) }, // single fetch: resolve all refs + before
       { payload: updatePositionResponse() }, // move 1 ok
       { error: "boom" }, // move 2 fails
     ];
@@ -270,8 +261,7 @@ describe("reorder — --dry-run", () => {
     const responses = [
       { payload: userPayload() },
       { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
-      { payload: getItemsByContentResponse(items) }, // resolve
-      { payload: getItemsByContentResponse(items) }, // before snapshot
+      { payload: getItemsByContentResponse(items) }, // single fetch: resolve + before snapshot
     ];
     const runChild = mockRunChild(responses);
 
@@ -286,6 +276,7 @@ describe("reorder — --dry-run", () => {
     assert.strictEqual(result.mutations.length, 1);
     assert.ok(result.mutations[0].query.includes("updateProjectV2ItemPosition"));
     assert.strictEqual(result.mutations[0].variables.itemId, "PVTI_b");
+    assert.ok(Array.isArray(result.before), "before snapshot present in dry-run");
     // No mutation gh calls were made
     assert.strictEqual(countMutations(runChild.calls), 0);
   });
@@ -298,9 +289,7 @@ describe("reorder — --dry-run", () => {
     const responses = [
       { payload: userPayload() },
       { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
-      { payload: getItemsByContentResponse(items) }, // resolve 102
-      { payload: getItemsByContentResponse(items) }, // resolve 101
-      { payload: getItemsByContentResponse(items) }, // before snapshot
+      { payload: getItemsByContentResponse(items) }, // single fetch: resolve all refs + before
     ];
     const runChild = mockRunChild(responses);
 
@@ -317,6 +306,43 @@ describe("reorder — --dry-run", () => {
   });
 });
 
+// ── legacy flag form ──────────────────────────────────────────────────────
+
+describe("reorder — legacy flag form", () => {
+  it("rejects a stray positional argument (fail closed)", async () => {
+    const runChild = mockRunChild([]); // should never reach a gh call
+    await assert.rejects(
+      () => main(
+        { _positional: ["630"], repo: "mfittko/dev-loops", project: "1", item: "630" },
+        { runChild },
+      ),
+      (err) => err.code === "INVALID_ARGS" && /Unexpected argument: 630/.test(err.message),
+    );
+  });
+
+  it("includes a before snapshot in --dry-run output (parity with subcommands)", async () => {
+    const items = [makeItemNode("PVTI_b", 630, "Issue", "Next Up")];
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      { payload: getItemsByContentResponse(items) }, // resolveProjectItem (number)
+      { payload: getItemsByContentResponse(items) }, // before snapshot
+    ];
+    const runChild = mockRunChild(responses);
+
+    const result = await main(
+      { _positional: [], repo: "mfittko/dev-loops", project: "1", item: "630", dryRun: true },
+      { runChild },
+    );
+
+    assert.ok(result.ok);
+    assert.strictEqual(result.dryRun, true);
+    assert.strictEqual(result.mutations.length, 1);
+    assert.ok(Array.isArray(result.before), "before snapshot present in legacy dry-run");
+    assert.strictEqual(countMutations(runChild.calls), 0);
+  });
+});
+
 // ── issue vs PR ref ───────────────────────────────────────────────────────
 
 describe("reorder — issue and PR refs", () => {
@@ -325,10 +351,9 @@ describe("reorder — issue and PR refs", () => {
     const responses = [
       { payload: userPayload() },
       { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
-      { payload: getItemsByContentResponse(items) },
-      { payload: getItemsByContentResponse(items) },
+      { payload: getItemsByContentResponse(items) }, // single fetch: resolve + before
       { payload: updatePositionResponse() },
-      { payload: getItemsByContentResponse(items) },
+      { payload: getItemsByContentResponse(items) }, // after snapshot
     ];
     const runChild = mockRunChild(responses);
 
@@ -363,6 +388,26 @@ describe("reorder — cross-project error", () => {
         { runChild },
       ),
       (err) => err.code === "ITEM_NOT_FOUND" && /not found in project/.test(err.message),
+    );
+  });
+
+  it("fails closed when an item NODE ID ref belongs to another repo", async () => {
+    // The item id exists on the board but its content is in a different repo.
+    const items = [makeItemNode("PVTI_other", 630, "Issue", "Next Up", "Next Up")];
+    items[0].content.repository.nameWithOwner = "other/repo";
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      { payload: getItemsByContentResponse(items) }, // single fetch
+    ];
+    const runChild = mockRunChild(responses);
+
+    await assert.rejects(
+      () => main(
+        { _subcommand: "move-to-top", _positional: ["PVTI_other"], repo: "mfittko/dev-loops", project: "1" },
+        { runChild },
+      ),
+      (err) => err.code === "ITEM_NOT_FOUND" && /not found in project for repo/.test(err.message),
     );
   });
 });


### PR DESCRIPTION
## Summary

Extends the GitHub Projects queue tooling so (re-)ordering and Done-cleanup no longer need hand-crafted GraphQL.

### `project reorder` (extended)
- `move-to-top <ref>` · `move-after <ref> <after-ref>` · `order <ref1> <ref2> ...` (chained `updateProjectV2ItemPosition`). The legacy `--item`/`--after` form is preserved (backward compatible). **(AC1)**
- `--dry-run` prints the intended mutation(s) without executing. **(AC4)**
- Diff-friendly `before`/`after` column-order + resolved item IDs (`order` adds a `moves` array). **(AC2)**
- Resolves issue **or** PR refs **(AC3)**; a ref not in the target Project fails closed (`ITEM_NOT_FOUND`, exit 3). **(AC6)**

### `project archive-done` (new)
- `archive-done [--older-than <dur>]` (default `30d`; `h`/`d`/`w`) archives items whose issue/PR has been closed at least that long (`archiveProjectV2Item`); open / already-archived / cross-repo items excluded; `--dry-run` supported. **(AC7)**

CLI registers `project archive-done` + updates help. `docs/queue-board-setup.md` gains Reordering + Archiving sections **(AC5)**.

## Tests
18 new under `test/projects/` (reorder subcommands incl. dry-run/PR-ref/cross-project; archive-done duration parsing + selection + dry-run). `npm run verify` passes. Stays on the existing index-based arg parser per the #857 migration split.

Closes #789
