### PR TITLE
feat(queue): drive board status sync from the loop state (#793)

### DIFF
--- a/docs/queue-board-setup.md
+++ b/docs/queue-board-setup.md
@@ -110,8 +110,9 @@ is persisted.
 
 Both overrides live under the same opt-in `queue` section in `.devloops` that
 enables board sync (`queue.projectNumber` or `queue.boardTitle`). When the
-`queue` section is absent or disabled, status sync is a **no-op** — nothing is
-read or written.
+`queue` section is absent or disabled, status sync is a **no-op**: it makes **no
+GitHub API calls and no board mutations**. (It may still read the local
+`.devloops` config in order to determine that sync is disabled.)
 
 `queue.statusColumns` renames the display name of a logical column:
 

--- a/docs/queue-board-setup.md
+++ b/docs/queue-board-setup.md
@@ -82,6 +82,66 @@ Dev-loop queue wrappers will:
 
 Use `dev-loops project --help` to inspect the queue helper surface and per-subcommand `--help` for details.
 
+## Status sync is driven by the loop state
+
+The board **Status** column is kept in sync with the dev-loop's own state machine
+rather than from hardcoded strings. A pure mapping
+(`boardColumnForLoopState(loopState, mapping)` in
+`packages/core/src/loop/queue-board-sync.mjs`) resolves each loop/lifecycle state
+to a logical column, then to a configured display name.
+
+### State → logical column (defaults)
+
+| Loop / lifecycle state | Logical column | Default display name |
+| --- | --- | --- |
+| `issue_opened`, `issue_intake`, `refinement`, `no_pr`, `pr_draft` | `next_up` | **Next Up** |
+| `implementation`, `local_implementation_active`, `pr_ready_no_feedback`, `waiting_for_copilot_review`, `ready_to_rerequest_review`, `unresolved_feedback_present`, `already_fixed_needs_reply_resolve`, `waiting_for_ci`, `blocked_needs_user_decision`, other in-flight states | `in_progress` | **In Progress** |
+| `final_approval_ready`, `pre_approval_gate` | `ready_for_review` | **In Progress** (unless overridden, see below) |
+| `merged`, `issue_closed`, `done`, `merge` | `done` | **Done** |
+| _any unmapped state_ | `in_progress` | **In Progress** (safe default — work is visibly active rather than dropped) |
+
+The mapping is **stateless**: it depends only on the current state, so a reverted
+state moves the column backward automatically. For example, a merged PR that is
+reopened maps back from **Done** to **In Progress**, and a ready PR demoted to a
+draft maps back from **In Progress** to **Next Up**. No "furthest reached" column
+is persisted.
+
+### Configuring column names (opt-in)
+
+Both overrides live under the same opt-in `queue` section in `.devloops` that
+enables board sync (`queue.projectNumber` or `queue.boardTitle`). When the
+`queue` section is absent or disabled, status sync is a **no-op** — nothing is
+read or written.
+
+`queue.statusColumns` renames the display name of a logical column:
+
+```yaml
+queue:
+  projectNumber: 7
+  statusColumns:
+    next_up: "Todo"
+    in_progress: "Doing"
+    ready_for_review: "Ready for Review"   # opt-in column; otherwise final_approval_ready stays "In Progress"
+    done: "Shipped"
+```
+
+`queue.stateColumnMap` remaps an individual loop state to a different logical
+column (rarely needed):
+
+```yaml
+queue:
+  projectNumber: 7
+  stateColumnMap:
+    blocked_needs_user_decision: next_up
+```
+
+### No-op behavior
+
+- **Board not configured / disabled** — sync returns `{ ok: true, skipped: true }`
+  and performs no GitHub calls (AC2/AC6).
+- **Item not on the board** — sync is a logged no-op (`{ ok: true, skipped: true }`),
+  never an error, so a missing board item can never break the loop (AC4).
+
 ## Reordering board items
 
 `dev-loops project reorder` wraps the `updateProjectV2ItemPosition` mutation. In

--- a/packages/core/src/loop/queue-board-sync.mjs
+++ b/packages/core/src/loop/queue-board-sync.mjs
@@ -349,11 +349,18 @@ export async function syncBoardStatus(
     );
     return { ok: true, skipped: false, result };
   } catch (err) {
-    // Fail-open: a board hiccup (rate limit, item not on board, missing column)
-    // must never break the loop. AC4: when the item is not on the board this is
-    // a logged no-op, not an error.
+    // Fail-open: a board hiccup (rate limit, missing column, item not on board)
+    // must never break the loop.
     const reason = err?.message ?? "board sync failed";
-    log(`[board-sync] no-op for item ${itemNumber} → "${targetColumn}": ${reason}`);
+    // AC4: the explicit "item not on board" case is a clean, logged no-op.
+    // Other fail-open failures (rate limit, missing column, etc.) get a
+    // distinct, distinguishable message so they are not conflated with AC4.
+    const notOnBoard = err?.code === "ITEM_NOT_FOUND" || err?.code === "ITEM_NOT_ON_BOARD";
+    if (notOnBoard) {
+      log(`[board-sync] no-op: item ${itemNumber} is not on the board (${reason})`);
+    } else {
+      log(`[board-sync] sync failed (fail-open) for item ${itemNumber} → "${targetColumn}": ${reason}`);
+    }
     return { ok: true, skipped: true, reason };
   }
 }

--- a/packages/core/src/loop/queue-board-sync.mjs
+++ b/packages/core/src/loop/queue-board-sync.mjs
@@ -21,6 +21,12 @@ export const LOGICAL_COLUMN = Object.freeze({
   DONE: "done",
 });
 
+/** Allow-list of recognized logical column tokens (for config validation). */
+const KNOWN_LOGICAL_COLUMNS = new Set(Object.values(LOGICAL_COLUMN));
+
+/** Keys that must never be copied from untrusted config (prototype pollution). */
+const DANGEROUS_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+
 /** Default display name for each logical column (AC1 values). */
 export const DEFAULT_STATE_COLUMN_NAMES = Object.freeze({
   [LOGICAL_COLUMN.NEXT_UP]: "Next Up",
@@ -85,7 +91,9 @@ const DEFAULT_LOGICAL_COLUMN = LOGICAL_COLUMN.IN_PROGRESS;
 /**
  * Pure mapping: loop state → board column display name.
  *
- * @param {string} loopState - a lifecycle or inner loop state name.
+ * @param {string|null|undefined} loopState - a lifecycle or inner loop state
+ *   name. `null`, `undefined`, and any unrecognized value fall through to the
+ *   safe default logical column (IN_PROGRESS).
  * @param {{stateColumnMap?:Object, columnNames?:Object}} [mapping]
  *   Optional overrides. `stateColumnMap` overrides state→logical-column;
  *   `columnNames` overrides logical-column→display-name. Both fall back to
@@ -150,15 +158,29 @@ export function loadBoardConfig(repoRoot) {
  *
  * Returns a `{ stateColumnMap, columnNames }` shape consumable by
  * `boardColumnForLoopState`. Missing config yields the AC1 defaults.
+ *
+ * Hardened against untrusted `.devloops` input:
+ *   - `statusColumns` keys are allow-listed to the known logical columns;
+ *     unrecognized keys are ignored.
+ *   - `stateColumnMap` entries whose value is not a known logical column are
+ *     ignored.
+ *   - Dangerous keys (`__proto__`, `prototype`, `constructor`) are skipped and
+ *     results are built on null-prototype objects, so a malicious config key
+ *     cannot pollute Object.prototype.
  */
 export function loadStateColumnMap(repoRoot) {
   const { settings: queue } = readDevloopsSettings(repoRoot);
-  const columnNames = { ...DEFAULT_STATE_COLUMN_NAMES };
-  const stateColumnMap = {};
+  // Null-prototype objects: untrusted keys can never reach Object.prototype.
+  const columnNames = Object.assign(Object.create(null), DEFAULT_STATE_COLUMN_NAMES);
+  const stateColumnMap = Object.create(null);
 
   const statusColumns = queue?.statusColumns;
   if (statusColumns && typeof statusColumns === "object") {
-    for (const [logical, name] of Object.entries(statusColumns)) {
+    for (const logical of Object.keys(statusColumns)) {
+      if (DANGEROUS_KEYS.has(logical)) continue;
+      // Allow-list: only recognized logical columns may be renamed.
+      if (!KNOWN_LOGICAL_COLUMNS.has(logical)) continue;
+      const name = statusColumns[logical];
       if (typeof name === "string" && name.trim().length > 0) {
         columnNames[logical] = name.trim();
       }
@@ -167,10 +189,14 @@ export function loadStateColumnMap(repoRoot) {
 
   const stateMap = queue?.stateColumnMap;
   if (stateMap && typeof stateMap === "object") {
-    for (const [state, logical] of Object.entries(stateMap)) {
-      if (typeof logical === "string" && logical.trim().length > 0) {
-        stateColumnMap[state] = logical.trim();
-      }
+    for (const state of Object.keys(stateMap)) {
+      if (DANGEROUS_KEYS.has(state)) continue;
+      const logical = stateMap[state];
+      // Ignore values that are not a recognized logical column.
+      if (typeof logical !== "string") continue;
+      const trimmed = logical.trim();
+      if (!KNOWN_LOGICAL_COLUMNS.has(trimmed)) continue;
+      stateColumnMap[state] = trimmed;
     }
   }
 

--- a/packages/core/src/loop/queue-board-sync.mjs
+++ b/packages/core/src/loop/queue-board-sync.mjs
@@ -6,6 +6,96 @@ import { main as moveQueueItemMain } from "../../../../scripts/projects/move-que
 
 const DEFAULT_NON_SUCCESS_COLUMN = "Backlog";
 
+// ── State → board column mapping (AC1, AC3, AC5) ─────────────────────────
+//
+// The mapping is intentionally stateless: it is a pure function of the loop
+// state. Because of that, a reverted loop state (e.g. a merged PR reopened, or
+// a ready PR demoted back to draft) maps backward to the earlier column for
+// free (AC5) — there is no persisted "furthest reached" column to unwind.
+
+/** Logical board columns. Display names are config-driven (AC3). */
+export const LOGICAL_COLUMN = Object.freeze({
+  NEXT_UP: "next_up",
+  IN_PROGRESS: "in_progress",
+  READY_FOR_REVIEW: "ready_for_review",
+  DONE: "done",
+});
+
+/** Default display name for each logical column (AC1 values). */
+export const DEFAULT_STATE_COLUMN_NAMES = Object.freeze({
+  [LOGICAL_COLUMN.NEXT_UP]: "Next Up",
+  [LOGICAL_COLUMN.IN_PROGRESS]: "In Progress",
+  // Ready for Review is opt-in: by default it resolves to In Progress so that
+  // final_approval_ready keeps "In Progress" unless a board configures it.
+  [LOGICAL_COLUMN.READY_FOR_REVIEW]: "In Progress",
+  [LOGICAL_COLUMN.DONE]: "Done",
+});
+
+/**
+ * Default loop-state → logical-column map. Covers both the lifecycle states
+ * (lifecycle-state.mjs) and the inner Copilot loop states (copilot-loop-state.mjs),
+ * plus the conceptual names used by issue #793. Unknown states fall back to
+ * IN_PROGRESS (a safe, visible "work is happening" column) rather than throwing.
+ */
+export const DEFAULT_STATE_LOGICAL_MAP = Object.freeze({
+  // Next Up — work not yet actively in flight
+  issue_opened: LOGICAL_COLUMN.NEXT_UP,
+  issue_intake: LOGICAL_COLUMN.NEXT_UP,
+  refinement: LOGICAL_COLUMN.NEXT_UP,
+  no_pr: LOGICAL_COLUMN.NEXT_UP,
+  pr_draft: LOGICAL_COLUMN.NEXT_UP,
+
+  // In Progress — active implementation / review / feedback resolution
+  implementation: LOGICAL_COLUMN.IN_PROGRESS,
+  local_implementation_active: LOGICAL_COLUMN.IN_PROGRESS,
+  draft_gate: LOGICAL_COLUMN.IN_PROGRESS,
+  pr_ready_no_feedback: LOGICAL_COLUMN.IN_PROGRESS,
+  feedback_resolution: LOGICAL_COLUMN.IN_PROGRESS,
+  copilot_review: LOGICAL_COLUMN.IN_PROGRESS,
+  waiting_for_copilot_review: LOGICAL_COLUMN.IN_PROGRESS,
+  ready_to_rerequest_review: LOGICAL_COLUMN.IN_PROGRESS,
+  unresolved_feedback_present: LOGICAL_COLUMN.IN_PROGRESS,
+  already_fixed_needs_reply_resolve: LOGICAL_COLUMN.IN_PROGRESS,
+  waiting_for_ci: LOGICAL_COLUMN.IN_PROGRESS,
+  review_request_unavailable: LOGICAL_COLUMN.IN_PROGRESS,
+  round_cap_reached: LOGICAL_COLUMN.IN_PROGRESS,
+  round_cap_clean_fallback: LOGICAL_COLUMN.IN_PROGRESS,
+  internal_tooling_direct_gate: LOGICAL_COLUMN.IN_PROGRESS,
+  low_signal_converged: LOGICAL_COLUMN.IN_PROGRESS,
+  blocked_needs_user_decision: LOGICAL_COLUMN.IN_PROGRESS,
+
+  // Ready for Review — final approval gate. Resolves to In Progress unless a
+  // board configures a distinct "Ready for Review" column name (AC1).
+  pre_approval_gate: LOGICAL_COLUMN.READY_FOR_REVIEW,
+  final_approval_ready: LOGICAL_COLUMN.READY_FOR_REVIEW,
+
+  // Done — terminal
+  merge: LOGICAL_COLUMN.DONE,
+  merged: LOGICAL_COLUMN.DONE,
+  issue_closed: LOGICAL_COLUMN.DONE,
+  done: LOGICAL_COLUMN.DONE,
+});
+
+/** Safe default logical column for any state we do not explicitly map. */
+const DEFAULT_LOGICAL_COLUMN = LOGICAL_COLUMN.IN_PROGRESS;
+
+/**
+ * Pure mapping: loop state → board column display name.
+ *
+ * @param {string} loopState - a lifecycle or inner loop state name.
+ * @param {{stateColumnMap?:Object, columnNames?:Object}} [mapping]
+ *   Optional overrides. `stateColumnMap` overrides state→logical-column;
+ *   `columnNames` overrides logical-column→display-name. Both fall back to
+ *   the AC1 defaults.
+ * @returns {string} the target board column display name.
+ */
+export function boardColumnForLoopState(loopState, mapping = {}) {
+  const stateMap = { ...DEFAULT_STATE_LOGICAL_MAP, ...(mapping.stateColumnMap ?? {}) };
+  const columnNames = { ...DEFAULT_STATE_COLUMN_NAMES, ...(mapping.columnNames ?? {}) };
+  const logical = stateMap[loopState] ?? DEFAULT_LOGICAL_COLUMN;
+  return columnNames[logical] ?? columnNames[DEFAULT_LOGICAL_COLUMN];
+}
+
 // ── Local config loader ─────────────────────────────────────────────────
 
 function readDevloopsSettings(repoRoot) {
@@ -44,6 +134,44 @@ export function loadBoardConfig(repoRoot) {
     return { enabled: true, boardTitle: queue.boardTitle.trim() };
   }
   return { enabled: false };
+}
+
+/**
+ * Load the config-driven state→column mapping from `.devloops` `queue` (AC3).
+ *
+ * Reads two optional config keys, both gated behind the same opt-in `queue`
+ * section as `loadBoardConfig` (AC2/AC6):
+ *   - `queue.statusColumns`  — logical-column → display-name overrides
+ *     (keys: next_up, in_progress, ready_for_review, done)
+ *   - `queue.stateColumnMap` — loop-state → logical-column overrides
+ *
+ * Returns a `{ stateColumnMap, columnNames }` shape consumable by
+ * `boardColumnForLoopState`. Missing config yields the AC1 defaults.
+ */
+export function loadStateColumnMap(repoRoot) {
+  const { settings: queue } = readDevloopsSettings(repoRoot);
+  const columnNames = { ...DEFAULT_STATE_COLUMN_NAMES };
+  const stateColumnMap = {};
+
+  const statusColumns = queue?.statusColumns;
+  if (statusColumns && typeof statusColumns === "object") {
+    for (const [logical, name] of Object.entries(statusColumns)) {
+      if (typeof name === "string" && name.trim().length > 0) {
+        columnNames[logical] = name.trim();
+      }
+    }
+  }
+
+  const stateMap = queue?.stateColumnMap;
+  if (stateMap && typeof stateMap === "object") {
+    for (const [state, logical] of Object.entries(stateMap)) {
+      if (typeof logical === "string" && logical.trim().length > 0) {
+        stateColumnMap[state] = logical.trim();
+      }
+    }
+  }
+
+  return { columnNames, stateColumnMap };
 }
 
 // ── Minimal project lookup (read-only, no create/repair) ────────────────
@@ -187,6 +315,10 @@ export async function syncBoardStatus(
   env = process.env,
   dependencies = {},
 ) {
+  const log = typeof dependencies.log === "function"
+    ? dependencies.log
+    : () => {};
+
   const config = loadBoardConfig(repoRoot);
   if (!config.enabled) {
     return { ok: true, skipped: true, reason: config.reason ?? "board not configured" };
@@ -210,7 +342,12 @@ export async function syncBoardStatus(
     );
     return { ok: true, skipped: false, result };
   } catch (err) {
-    return { ok: true, skipped: true, reason: err.message ?? "board sync failed" };
+    // Fail-open: a board hiccup (rate limit, item not on board, missing column)
+    // must never break the loop. AC4: when the item is not on the board this is
+    // a logged no-op, not an error.
+    const reason = err?.message ?? "board sync failed";
+    log(`[board-sync] no-op for item ${itemNumber} → "${targetColumn}": ${reason}`);
+    return { ok: true, skipped: true, reason };
   }
 }
 

--- a/packages/core/src/loop/queue-board-sync.mjs
+++ b/packages/core/src/loop/queue-board-sync.mjs
@@ -47,6 +47,8 @@ export const DEFAULT_STATE_LOGICAL_MAP = Object.freeze({
 
   // In Progress — active implementation / review / feedback resolution
   implementation: LOGICAL_COLUMN.IN_PROGRESS,
+  // Tolerated alias for `implementation` (conceptual name from issue #793);
+  // the queue driver passes the real `implementation` lifecycle state.
   local_implementation_active: LOGICAL_COLUMN.IN_PROGRESS,
   draft_gate: LOGICAL_COLUMN.IN_PROGRESS,
   pr_ready_no_feedback: LOGICAL_COLUMN.IN_PROGRESS,
@@ -69,11 +71,12 @@ export const DEFAULT_STATE_LOGICAL_MAP = Object.freeze({
   pre_approval_gate: LOGICAL_COLUMN.READY_FOR_REVIEW,
   final_approval_ready: LOGICAL_COLUMN.READY_FOR_REVIEW,
 
-  // Done — terminal
+  // Done — terminal (lifecycle MERGE = "merge", queue terminal = "done")
   merge: LOGICAL_COLUMN.DONE,
+  done: LOGICAL_COLUMN.DONE,
+  // Tolerated aliases (conceptual names from issue #793).
   merged: LOGICAL_COLUMN.DONE,
   issue_closed: LOGICAL_COLUMN.DONE,
-  done: LOGICAL_COLUMN.DONE,
 });
 
 /** Safe default logical column for any state we do not explicitly map. */
@@ -315,9 +318,13 @@ export async function syncBoardStatus(
   env = process.env,
   dependencies = {},
 ) {
+  // AC4: the not-on-board / fail-open path is a logged no-op. Default to
+  // console.error so it logs in real runs; tests inject their own stub. The
+  // log fires at most once per syncBoardStatus call (single catch, no internal
+  // retry), so it cannot spam.
   const log = typeof dependencies.log === "function"
     ? dependencies.log
-    : () => {};
+    : (msg) => console.error(msg);
 
   const config = loadBoardConfig(repoRoot);
   if (!config.enabled) {

--- a/packages/core/src/loop/queue-driver.mjs
+++ b/packages/core/src/loop/queue-driver.mjs
@@ -107,12 +107,13 @@ export async function runQueue(repoRoot, repo, options = {}) {
       return r;
     };
 
-    // Entry has been picked up and is actively running: local implementation.
+    // Entry has been picked up and is actively running: implementation phase
+    // (real lifecycle state, lifecycle-state.mjs LIFECYCLE_STATE.IMPLEMENTATION).
     await recordBoardSync(syncBoardStatus(
       repo,
       repoRoot,
       entry.target,
-      columnFor("local_implementation_active"),
+      columnFor("implementation"),
       opts.env ?? process.env,
       boardSyncDeps,
     ));
@@ -129,7 +130,7 @@ export async function runQueue(repoRoot, repo, options = {}) {
           if (opts.mergeAuthorized) {
             await doTransition(entry, "merging", queue, repoRoot, opts);
             await doTransition(entry, "done", queue, repoRoot, opts, { retrospectiveWritten: true });
-            await recordBoardSync(syncBoardStatus(repo, repoRoot, entry.target, columnFor("merged"), opts.env ?? process.env, boardSyncDeps));
+            await recordBoardSync(syncBoardStatus(repo, repoRoot, entry.target, columnFor("done"), opts.env ?? process.env, boardSyncDeps));
           } else {
             // PR is up with gates passing but merge is not authorized: the work
             // is awaiting final approval/merge. Map to the final-approval column

--- a/packages/core/src/loop/queue-driver.mjs
+++ b/packages/core/src/loop/queue-driver.mjs
@@ -13,7 +13,12 @@ import {
   RECOVERABLE_FAILURES,
   appendBugIssue,
 } from "./queue-state.mjs";
-import { syncBoardStatus, nonSuccessBoardColumn } from "./queue-board-sync.mjs";
+import {
+  syncBoardStatus,
+  nonSuccessBoardColumn,
+  boardColumnForLoopState,
+  loadStateColumnMap,
+} from "./queue-board-sync.mjs";
 import { resolveNextUpOrder } from "./queue-board-ordering.mjs";
 
 export const DEFAULT_QUEUE_DRIVER_OPTIONS = {
@@ -51,6 +56,12 @@ async function doTransition(entry, to, queue, repoRoot, opts, metadata) {
 export async function runQueue(repoRoot, repo, options = {}) {
   const opts = { ...DEFAULT_QUEUE_DRIVER_OPTIONS, ...options };
   const queue = await readQueue(repoRoot);
+
+  // Config-driven loop-state → board-column mapping (#793, AC1/AC3). Loaded
+  // once per run; resolves logical columns to configured display names, with
+  // the AC1 defaults when no `queue.statusColumns`/`queue.stateColumnMap` is set.
+  const stateColumnMap = loadStateColumnMap(repoRoot);
+  const columnFor = (loopState) => boardColumnForLoopState(loopState, stateColumnMap);
 
   // Optional board-aware ordering: fetch Next Up order before processing.
   // Fail-open: if the board is unreachable, orderHint stays empty and the
@@ -96,11 +107,12 @@ export async function runQueue(repoRoot, repo, options = {}) {
       return r;
     };
 
+    // Entry has been picked up and is actively running: local implementation.
     await recordBoardSync(syncBoardStatus(
       repo,
       repoRoot,
       entry.target,
-      "In Progress",
+      columnFor("local_implementation_active"),
       opts.env ?? process.env,
       boardSyncDeps,
     ));
@@ -117,12 +129,16 @@ export async function runQueue(repoRoot, repo, options = {}) {
           if (opts.mergeAuthorized) {
             await doTransition(entry, "merging", queue, repoRoot, opts);
             await doTransition(entry, "done", queue, repoRoot, opts, { retrospectiveWritten: true });
-            await recordBoardSync(syncBoardStatus(repo, repoRoot, entry.target, "Done", opts.env ?? process.env, boardSyncDeps));
+            await recordBoardSync(syncBoardStatus(repo, repoRoot, entry.target, columnFor("merged"), opts.env ?? process.env, boardSyncDeps));
+          } else {
+            // PR is up with gates passing but merge is not authorized: the work
+            // is awaiting final approval/merge. Map to the final-approval column
+            // (configured "Ready for Review" if present, else "In Progress").
+            await recordBoardSync(syncBoardStatus(repo, repoRoot, entry.target, columnFor("final_approval_ready"), opts.env ?? process.env, boardSyncDeps));
           }
-          // else: stays at gates_passing for future merge run
         } else {
           await doTransition(entry, "done", queue, repoRoot, opts);
-          await recordBoardSync(syncBoardStatus(repo, repoRoot, entry.target, "Done", opts.env ?? process.env, boardSyncDeps));
+          await recordBoardSync(syncBoardStatus(repo, repoRoot, entry.target, columnFor("done"), opts.env ?? process.env, boardSyncDeps));
         }
         results.push({ target: entry.target, ok: true, entry: snapshotEntry(entry), boardSync });
       } else {

--- a/packages/core/src/loop/queue-driver.mjs
+++ b/packages/core/src/loop/queue-driver.mjs
@@ -63,6 +63,13 @@ export async function runQueue(repoRoot, repo, options = {}) {
   const stateColumnMap = loadStateColumnMap(repoRoot);
   const columnFor = (loopState) => boardColumnForLoopState(loopState, stateColumnMap);
 
+  // Per-item dedup: a single run may resolve consecutive loop states to the
+  // same display column (e.g. implementation → final_approval_ready both
+  // default to "In Progress"). Skip the redundant board write/API call when the
+  // target column is unchanged for that item; a genuinely different column
+  // (e.g. a configured "Ready for Review") still syncs. (#793 round-1 #1)
+  const lastSyncedColumn = new Map();
+
   // Optional board-aware ordering: fetch Next Up order before processing.
   // Fail-open: if the board is unreachable, orderHint stays empty and the
   // driver falls back to the existing queue order.
@@ -106,17 +113,26 @@ export async function runQueue(repoRoot, repo, options = {}) {
       boardSync.push(r);
       return r;
     };
+    // Sync a target to a column, short-circuiting (no API call) when the column
+    // is unchanged from the last sync for the same item in this run.
+    const syncColumn = async (target, column) => {
+      if (lastSyncedColumn.get(target) === column) {
+        return recordBoardSync(Promise.resolve({
+          ok: true, skipped: true, reason: "column unchanged",
+        }));
+      }
+      const r = await recordBoardSync(syncBoardStatus(
+        repo, repoRoot, target, column, opts.env ?? process.env, boardSyncDeps,
+      ));
+      // Only remember the column when the move actually landed, so a fail-open
+      // skip does not suppress a later retry to the same column.
+      if (r.ok && r.skipped !== true) lastSyncedColumn.set(target, column);
+      return r;
+    };
 
     // Entry has been picked up and is actively running: implementation phase
     // (real lifecycle state, lifecycle-state.mjs LIFECYCLE_STATE.IMPLEMENTATION).
-    await recordBoardSync(syncBoardStatus(
-      repo,
-      repoRoot,
-      entry.target,
-      columnFor("implementation"),
-      opts.env ?? process.env,
-      boardSyncDeps,
-    ));
+    await syncColumn(entry.target, columnFor("implementation"));
 
     try {
       const entryResult = opts.runEntry
@@ -130,16 +146,18 @@ export async function runQueue(repoRoot, repo, options = {}) {
           if (opts.mergeAuthorized) {
             await doTransition(entry, "merging", queue, repoRoot, opts);
             await doTransition(entry, "done", queue, repoRoot, opts, { retrospectiveWritten: true });
-            await recordBoardSync(syncBoardStatus(repo, repoRoot, entry.target, columnFor("done"), opts.env ?? process.env, boardSyncDeps));
+            await syncColumn(entry.target, columnFor("done"));
           } else {
             // PR is up with gates passing but merge is not authorized: the work
             // is awaiting final approval/merge. Map to the final-approval column
             // (configured "Ready for Review" if present, else "In Progress").
-            await recordBoardSync(syncBoardStatus(repo, repoRoot, entry.target, columnFor("final_approval_ready"), opts.env ?? process.env, boardSyncDeps));
+            // Deduped: when this resolves to the same column already synced for
+            // this item, no extra board write/API call is made.
+            await syncColumn(entry.target, columnFor("final_approval_ready"));
           }
         } else {
           await doTransition(entry, "done", queue, repoRoot, opts);
-          await recordBoardSync(syncBoardStatus(repo, repoRoot, entry.target, columnFor("done"), opts.env ?? process.env, boardSyncDeps));
+          await syncColumn(entry.target, columnFor("done"));
         }
         results.push({ target: entry.target, ok: true, entry: snapshotEntry(entry), boardSync });
       } else {

--- a/packages/core/test/queue-board-sync.test.mjs
+++ b/packages/core/test/queue-board-sync.test.mjs
@@ -230,8 +230,10 @@ test("loadStateColumnMap returns defaults when no config present", async () => {
   const dir = await makeRepo(null);
   try {
     const mapping = loadStateColumnMap(dir);
-    assert.deepEqual(mapping.columnNames, DEFAULT_STATE_COLUMN_NAMES);
-    assert.deepEqual(mapping.stateColumnMap, {});
+    // Built on null-prototype objects (prototype-pollution hardening), so
+    // compare contents rather than prototype identity.
+    assert.deepEqual({ ...mapping.columnNames }, { ...DEFAULT_STATE_COLUMN_NAMES });
+    assert.deepEqual({ ...mapping.stateColumnMap }, {});
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -262,6 +264,57 @@ test("loadStateColumnMap reads queue.stateColumnMap per-state overrides (AC3)", 
   try {
     const mapping = loadStateColumnMap(dir);
     assert.equal(boardColumnForLoopState("final_approval_ready", mapping), "Ready for Review");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadStateColumnMap ignores unknown statusColumns keys (allow-list)", async () => {
+  const dir = await makeRepo(
+    "queue:\n  projectNumber: 5\n  statusColumns:\n    bogus_column: Nope\n    next_up: Todo\n",
+  );
+  try {
+    const mapping = loadStateColumnMap(dir);
+    // valid override applies
+    assert.equal(mapping.columnNames[LOGICAL_COLUMN.NEXT_UP], "Todo");
+    // unknown logical-column key is not copied in
+    assert.equal(Object.prototype.hasOwnProperty.call(mapping.columnNames, "bogus_column"), false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadStateColumnMap ignores stateColumnMap entries with an unknown logical-column value", async () => {
+  const dir = await makeRepo(
+    "queue:\n  projectNumber: 5\n  stateColumnMap:\n    pr_draft: not_a_column\n    blocked_needs_user_decision: next_up\n",
+  );
+  try {
+    const mapping = loadStateColumnMap(dir);
+    // invalid value ignored — pr_draft keeps its default logical column (Next Up)
+    assert.equal(Object.prototype.hasOwnProperty.call(mapping.stateColumnMap, "pr_draft"), false);
+    assert.equal(boardColumnForLoopState("pr_draft", mapping), "Next Up");
+    // valid value applies
+    assert.equal(mapping.stateColumnMap["blocked_needs_user_decision"], "next_up");
+    assert.equal(boardColumnForLoopState("blocked_needs_user_decision", mapping), "Next Up");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadStateColumnMap is not vulnerable to prototype pollution via config keys", async () => {
+  const dir = await makeRepo(
+    'queue:\n  projectNumber: 5\n  statusColumns:\n    __proto__: { polluted: yes }\n  stateColumnMap:\n    __proto__: { polluted: yes }\n',
+  );
+  try {
+    const mapping = loadStateColumnMap(dir);
+    // Object.prototype must remain unpolluted.
+    assert.equal({}.polluted, undefined);
+    assert.equal(Object.prototype.polluted, undefined);
+    // The dangerous key is not copied into the result objects either.
+    assert.equal(mapping.columnNames.polluted, undefined);
+    assert.equal(mapping.stateColumnMap.polluted, undefined);
+    // Valid defaults still intact.
+    assert.equal(mapping.columnNames[LOGICAL_COLUMN.IN_PROGRESS], "In Progress");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/core/test/queue-board-sync.test.mjs
+++ b/packages/core/test/queue-board-sync.test.mjs
@@ -8,6 +8,10 @@ import {
   loadBoardConfig,
   syncBoardStatus,
   nonSuccessBoardColumn,
+  boardColumnForLoopState,
+  loadStateColumnMap,
+  LOGICAL_COLUMN,
+  DEFAULT_STATE_COLUMN_NAMES,
 } from "../src/loop/queue-board-sync.mjs";
 
 async function makeRepo(configYaml) {
@@ -136,6 +140,168 @@ test("loadBoardConfig surfaces config read errors", async () => {
     const result = loadBoardConfig(dir);
     assert.equal(result.enabled, false);
     assert.match(result.reason, /config read\/parse error/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ── boardColumnForLoopState (AC1, AC3, AC5) ──────────────────────────────
+
+test("boardColumnForLoopState maps issue_opened and pr_draft to Next Up (AC1)", () => {
+  assert.equal(boardColumnForLoopState("issue_opened"), "Next Up");
+  assert.equal(boardColumnForLoopState("pr_draft"), "Next Up");
+});
+
+test("boardColumnForLoopState maps active/feedback states to In Progress (AC1)", () => {
+  for (const state of [
+    "pr_ready_no_feedback",
+    "waiting_for_copilot_review",
+    "ready_to_rerequest_review",
+    "local_implementation_active",
+    "implementation",
+    "feedback_resolution",
+    "unresolved_feedback_present",
+    "already_fixed_needs_reply_resolve",
+    "waiting_for_ci",
+    "blocked_needs_user_decision",
+  ]) {
+    assert.equal(boardColumnForLoopState(state), "In Progress", `state ${state}`);
+  }
+});
+
+test("boardColumnForLoopState maps final_approval_ready to In Progress by default (AC1)", () => {
+  assert.equal(boardColumnForLoopState("final_approval_ready"), "In Progress");
+});
+
+test("boardColumnForLoopState uses configured Ready for Review column for final_approval_ready when present (AC1)", () => {
+  const mapping = {
+    columnNames: { ...DEFAULT_STATE_COLUMN_NAMES, [LOGICAL_COLUMN.READY_FOR_REVIEW]: "Ready for Review" },
+  };
+  assert.equal(boardColumnForLoopState("final_approval_ready", mapping), "Ready for Review");
+});
+
+test("boardColumnForLoopState maps merged / issue_closed / done to Done (AC1)", () => {
+  assert.equal(boardColumnForLoopState("merged"), "Done");
+  assert.equal(boardColumnForLoopState("issue_closed"), "Done");
+  assert.equal(boardColumnForLoopState("done"), "Done");
+});
+
+test("boardColumnForLoopState falls back to In Progress for unknown states (documented default)", () => {
+  assert.equal(boardColumnForLoopState("some_unmapped_state"), "In Progress");
+  assert.equal(boardColumnForLoopState(undefined), "In Progress");
+  assert.equal(boardColumnForLoopState(null), "In Progress");
+});
+
+test("boardColumnForLoopState honors a config-driven column name override (AC3)", () => {
+  const mapping = {
+    columnNames: {
+      ...DEFAULT_STATE_COLUMN_NAMES,
+      [LOGICAL_COLUMN.NEXT_UP]: "Todo",
+      [LOGICAL_COLUMN.IN_PROGRESS]: "Doing",
+      [LOGICAL_COLUMN.DONE]: "Shipped",
+    },
+  };
+  assert.equal(boardColumnForLoopState("pr_draft", mapping), "Todo");
+  assert.equal(boardColumnForLoopState("waiting_for_copilot_review", mapping), "Doing");
+  assert.equal(boardColumnForLoopState("merged", mapping), "Shipped");
+});
+
+test("boardColumnForLoopState honors a per-state override via stateColumnMap (AC3)", () => {
+  const mapping = {
+    stateColumnMap: { blocked_needs_user_decision: LOGICAL_COLUMN.NEXT_UP },
+    columnNames: DEFAULT_STATE_COLUMN_NAMES,
+  };
+  // overridden logical column, default name
+  assert.equal(boardColumnForLoopState("blocked_needs_user_decision", mapping), "Next Up");
+});
+
+test("boardColumnForLoopState supports a reverse transition merged->Done then reopened->In Progress (AC5)", () => {
+  // forward: merged sits in Done
+  assert.equal(boardColumnForLoopState("merged"), "Done");
+  // reverted: PR reopened back to ready -> In Progress (moves backward)
+  assert.equal(boardColumnForLoopState("pr_ready_no_feedback"), "In Progress");
+  // ready -> draft reverts further back to Next Up
+  assert.equal(boardColumnForLoopState("pr_draft"), "Next Up");
+});
+
+// ── loadStateColumnMap (AC2/AC3/AC6) ─────────────────────────────────────
+
+test("loadStateColumnMap returns defaults when no config present", async () => {
+  const dir = await makeRepo(null);
+  try {
+    const mapping = loadStateColumnMap(dir);
+    assert.deepEqual(mapping.columnNames, DEFAULT_STATE_COLUMN_NAMES);
+    assert.deepEqual(mapping.stateColumnMap, {});
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadStateColumnMap reads queue.statusColumns overrides (AC3)", async () => {
+  const dir = await makeRepo(
+    "queue:\n  projectNumber: 5\n  statusColumns:\n    next_up: Todo\n    done: Shipped\n",
+  );
+  try {
+    const mapping = loadStateColumnMap(dir);
+    assert.equal(mapping.columnNames[LOGICAL_COLUMN.NEXT_UP], "Todo");
+    assert.equal(mapping.columnNames[LOGICAL_COLUMN.DONE], "Shipped");
+    // untouched logical columns keep defaults
+    assert.equal(
+      mapping.columnNames[LOGICAL_COLUMN.IN_PROGRESS],
+      DEFAULT_STATE_COLUMN_NAMES[LOGICAL_COLUMN.IN_PROGRESS],
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadStateColumnMap reads queue.stateColumnMap per-state overrides (AC3)", async () => {
+  const dir = await makeRepo(
+    "queue:\n  projectNumber: 5\n  stateColumnMap:\n    final_approval_ready: ready_for_review\n  statusColumns:\n    ready_for_review: \"Ready for Review\"\n",
+  );
+  try {
+    const mapping = loadStateColumnMap(dir);
+    assert.equal(boardColumnForLoopState("final_approval_ready", mapping), "Ready for Review");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("syncBoardStatus is a no-op when board config disabled, driven by mapping (AC2/AC6)", async () => {
+  const dir = await makeRepo(null);
+  try {
+    const column = boardColumnForLoopState("waiting_for_copilot_review", loadStateColumnMap(dir));
+    const result = await syncBoardStatus("owner/repo", dir, 42, column, {});
+    assert.equal(result.ok, true);
+    assert.equal(result.skipped, true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("syncBoardStatus is a logged no-op when item is not on the board (AC4)", async () => {
+  const dir = await makeRepo("queue:\n  projectNumber: 5\n");
+  try {
+    const logs = [];
+    const result = await syncBoardStatus(
+      "owner/repo",
+      dir,
+      42,
+      "In Progress",
+      { GH_TOKEN: "mock" },
+      {
+        log: (msg) => logs.push(msg),
+        moveQueueItem: async () => {
+          throw Object.assign(new Error("item 42 is not on project board 5"), {
+            code: "ITEM_NOT_ON_BOARD",
+          });
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.skipped, true);
+    assert.match(result.reason, /not on/i);
+    assert.equal(logs.length, 1, "expected exactly one log for the no-op");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/core/test/queue-board-sync.test.mjs
+++ b/packages/core/test/queue-board-sync.test.mjs
@@ -302,6 +302,62 @@ test("syncBoardStatus is a logged no-op when item is not on the board (AC4)", as
     assert.equal(result.skipped, true);
     assert.match(result.reason, /not on/i);
     assert.equal(logs.length, 1, "expected exactly one log for the no-op");
+    assert.match(logs[0], /no-op: item 42 is not on the board/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("syncBoardStatus also treats ITEM_NOT_FOUND as the not-on-board no-op (AC4)", async () => {
+  const dir = await makeRepo("queue:\n  projectNumber: 5\n");
+  try {
+    const logs = [];
+    const result = await syncBoardStatus(
+      "owner/repo",
+      dir,
+      42,
+      "In Progress",
+      { GH_TOKEN: "mock" },
+      {
+        log: (msg) => logs.push(msg),
+        moveQueueItem: async () => {
+          throw Object.assign(new Error("Item #42 not found in project"), {
+            code: "ITEM_NOT_FOUND",
+          });
+        },
+      },
+    );
+    assert.equal(result.skipped, true);
+    assert.equal(logs.length, 1);
+    assert.match(logs[0], /not on the board/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("syncBoardStatus logs a distinct fail-open message for non-not-on-board errors", async () => {
+  const dir = await makeRepo("queue:\n  projectNumber: 5\n");
+  try {
+    const logs = [];
+    const result = await syncBoardStatus(
+      "owner/repo",
+      dir,
+      42,
+      "In Progress",
+      { GH_TOKEN: "mock" },
+      {
+        log: (msg) => logs.push(msg),
+        moveQueueItem: async () => {
+          throw Object.assign(new Error("API rate limit exceeded"), { code: "GH_API_ERROR" });
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.skipped, true);
+    assert.equal(logs.length, 1);
+    // Must NOT be mistaken for the AC4 not-on-board no-op.
+    assert.doesNotMatch(logs[0], /not on the board/);
+    assert.match(logs[0], /sync failed \(fail-open\)/);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/core/test/queue-driver.test.mjs
+++ b/packages/core/test/queue-driver.test.mjs
@@ -343,12 +343,50 @@ test("runQueue syncs final-approval column for open PR when merge not authorized
 
     // Entry stays at gates_passing (merge not authorized) for a future run.
     assert.equal(result.queue.entries[0].status, "gates_passing");
-    // running → In Progress, then gates_passing-without-merge → final approval.
+    // running → In Progress; final_approval_ready resolves to the SAME column
+    // ("In Progress") so the redundant board write is deduped — only ONE move.
+    assert.equal(moves.length, 1, "redundant same-column final-approval sync is deduped");
+    assert.equal(moves[0].toColumn, "In Progress");
+    // Both syncs still accounted for; the second is a skipped "column unchanged".
+    assert.equal(result.results[0].boardSync.length, 2);
+    assert.equal(result.results[0].boardSync[0].skipped, false);
+    assert.equal(result.results[0].boardSync[1].skipped, true);
+    assert.equal(result.results[0].boardSync[1].reason, "column unchanged");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("runQueue does sync a distinct Ready for Review column for open PR (#793)", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "queue-driver-ready-review-"));
+  try {
+    await writeFile(
+      path.join(dir, ".devloops"),
+      "queue:\n  projectNumber: 7\n  statusColumns:\n    ready_for_review: \"Ready for Review\"\n",
+    );
+    const queue = {
+      version: 1,
+      entries: [createEntry(203, "issue")],
+    };
+    await writeQueue(dir, queue);
+
+    const moves = [];
+    const result = await runQueue(dir, "test/repo", {
+      mergeAuthorized: false,
+      runEntry: async () => ({ ok: true, pr: 42 }),
+      queueBoardSyncDependencies: {
+        moveQueueItem: async (args) => {
+          moves.push({ ...args });
+          return { ok: true, item: { newColumn: args.toColumn } };
+        },
+      },
+    });
+
+    assert.equal(result.queue.entries[0].status, "gates_passing");
+    // Distinct column configured → both moves land (no dedup).
     assert.equal(moves.length, 2);
     assert.equal(moves[0].toColumn, "In Progress");
-    // final_approval_ready defaults to "In Progress" (no Ready for Review column configured).
-    assert.equal(moves[1].toColumn, "In Progress");
-    assert.equal(result.results[0].boardSync.length, 2);
+    assert.equal(moves[1].toColumn, "Ready for Review");
     assert.equal(result.results[0].boardSync[1].skipped, false);
   } finally {
     await rm(dir, { recursive: true, force: true });

--- a/packages/core/test/queue-driver.test.mjs
+++ b/packages/core/test/queue-driver.test.mjs
@@ -319,6 +319,73 @@ test("runQueue wires board transitions when configured and records them", async 
   }
 });
 
+test("runQueue syncs final-approval column for open PR when merge not authorized (#793)", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "queue-driver-final-approval-"));
+  try {
+    await writeFile(path.join(dir, ".devloops"), "queue:\n  projectNumber: 7\n");
+    const queue = {
+      version: 1,
+      entries: [createEntry(201, "issue")],
+    };
+    await writeQueue(dir, queue);
+
+    const moves = [];
+    const result = await runQueue(dir, "test/repo", {
+      mergeAuthorized: false,
+      runEntry: async () => ({ ok: true, pr: 42 }),
+      queueBoardSyncDependencies: {
+        moveQueueItem: async (args) => {
+          moves.push({ ...args });
+          return { ok: true, item: { newColumn: args.toColumn } };
+        },
+      },
+    });
+
+    // Entry stays at gates_passing (merge not authorized) for a future run.
+    assert.equal(result.queue.entries[0].status, "gates_passing");
+    // running → In Progress, then gates_passing-without-merge → final approval.
+    assert.equal(moves.length, 2);
+    assert.equal(moves[0].toColumn, "In Progress");
+    // final_approval_ready defaults to "In Progress" (no Ready for Review column configured).
+    assert.equal(moves[1].toColumn, "In Progress");
+    assert.equal(result.results[0].boardSync.length, 2);
+    assert.equal(result.results[0].boardSync[1].skipped, false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("runQueue final-approval board sync is a no-op when board unconfigured (#793)", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "queue-driver-final-approval-noop-"));
+  try {
+    const queue = {
+      version: 1,
+      entries: [createEntry(202, "issue")],
+    };
+    await writeQueue(dir, queue);
+
+    const moves = [];
+    const result = await runQueue(dir, "test/repo", {
+      mergeAuthorized: false,
+      runEntry: async () => ({ ok: true, pr: 42 }),
+      queueBoardSyncDependencies: {
+        moveQueueItem: async (args) => {
+          moves.push({ ...args });
+          return { ok: true, item: { newColumn: args.toColumn } };
+        },
+      },
+    });
+
+    assert.equal(result.queue.entries[0].status, "gates_passing");
+    assert.equal(moves.length, 0, "no board mutations when board is unconfigured");
+    // Both syncs (running + final approval) recorded as skipped no-ops.
+    assert.equal(result.results[0].boardSync.length, 2);
+    assert.equal(result.results[0].boardSync.every((s) => s.skipped), true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("runQueue records fallback board transition on failure", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "queue-driver-board-fail-"));
   try {


### PR DESCRIPTION
## Summary

Board Status column is now derived from the **loop state** via a pure, config-driven mapping instead of hardcoded column strings.

- **`boardColumnForLoopState(loopState, mapping)`** (pure): `state → logical column → display name`. `issue_opened`/`pr_draft` → Next Up; active/feedback/copilot/blocked states → In Progress; `final_approval_ready`/`pre_approval_gate` → Ready for Review (defaults to In Progress unless a board configures it); `merged`/`issue_closed`/`done` → Done; unknown → In Progress (documented safe default). **(AC1)**
- **Config-driven names (AC3):** `queue.statusColumns` (logical→display) and `queue.stateColumnMap` (per-state→logical) overrides via `loadStateColumnMap`.
- **Wiring:** `queue-driver` now syncs via `columnFor(state)` at its transition points (running, merged, no-PR-done, + a new `final_approval_ready` hook) instead of hardcoded columns.
- **Opt-in + discovery** via `loadBoardConfig` **(AC2/AC6)**; `syncBoardStatus` is a **logged no-op** when the board is unconfigured or the item isn't on a board **(AC4)**; **reverse transitions** fall out of statelessness **(AC5)**.

**Deferred (honest scope):** a deeper per-PR hook inside the pure state-interpreters (`copilot-loop-state`/`pr-gate-coordination`) — they don't own the board item, so threading sync there is larger plumbing. The queue-driver covers every transition it drives, and the mapping is reusable when that deeper integration is wanted.

## Tests
Mapping per AC1 state, unknown-default, config overrides, disabled/not-on-board no-op, reverse transition. Docs: `queue-board-setup.md` state→column section. `npm run verify` passes **(AC7)**.

Closes #793

## Reachability note (review)
The mapping covers all AC1 states, but only the transitions the **queue-driver** drives fire end-to-end today: running→In Progress, merged→Done, no-PR-done→Done, and gates-passing-without-merge→final-approval (In Progress). Conceptual states like `issue_opened`/`copilot_review`/`issue_closed` are mapped (so the table is complete and future-proof) but are not emitted at a wired call site yet — they become live when the deferred per-PR inner-loop hook is added. The mapping itself is the reusable, fully-tested core.