### PR TITLE
Add narrow local failure triage path

### DIFF
--- a/.claude/skills/docs/anti-patterns.md
+++ b/.claude/skills/docs/anti-patterns.md
@@ -10,6 +10,7 @@ Canonical owner for anti-pattern guidance across all workflow families.
 4. **Merging directly to main without PR**: Use PR-based remote loop when practical.
 5. **Duplicate worktree paths**: Check `git worktree list` before creating new worktrees; reuse existing matching worktrees.
 6. **Main-checkout mutation**: Reserve main checkout for inspection/control; use `tmp/worktrees/` paths for mutation work.
+7. **Spelunking tooling internals instead of using the public surface**: Do not read installed package internals, scan tooling source, or run ad-hoc scripts to understand a tool's behavior. Use the CLI, its `--help` subcommands, and `skills/docs/`. Read tool source only when the task is to inspect or change that tool, or when a concrete failure path is inside it and no public CLI/docs path exists. Once a failure is concrete, search changed files for the exact pattern — don't run duplicate broad searches.
 
 ## Light mode exception
 

--- a/.claude/skills/local-implementation/SKILL.md
+++ b/.claude/skills/local-implementation/SKILL.md
@@ -95,7 +95,7 @@ When resuming local implementation with dirty work or an observed failing comman
 6. run focused smoke checks for that failure
 7. run default verification
 
-Do not read installed package internals unless the failing path is inside that installed package or no public CLI/docs path exists. Do not run duplicate broad searches (for example `grep` and `rg` over the same pattern) once the exact suspect pattern is known.
+Follow [Anti-patterns](../docs/anti-patterns.md) for the general tooling-internals and duplicate-broad-search prohibition; this local fast path owns only the ordered failure-triage procedure above.
 
 ### Step 1
 

--- a/.claude/skills/local-implementation/SKILL.md
+++ b/.claude/skills/local-implementation/SKILL.md
@@ -83,6 +83,20 @@ This gate does **not** apply to other routed strategies (`copilot_pr_followup`, 
 
 Development-only bypass (`PI_PREFLIGHT_BYPASS=1`) exists for testing the gate itself but must not be used in production workflow runs. The bypass variable is a testing convenience, not an operational escape hatch.
 
+## Narrow failure-triage fast path
+
+When resuming local implementation with dirty work or an observed failing command, use this path before broad discovery:
+
+1. run startup once from the relevant worktree/context
+2. inspect current state with `git status` and the changed files
+3. reproduce or identify the failing command
+4. run an exact-pattern search in changed files for the suspect call/site
+5. patch the minimum call sites
+6. run focused smoke checks for that failure
+7. run default verification
+
+Do not read installed package internals unless the failing path is inside that installed package or no public CLI/docs path exists. Do not run duplicate broad searches (for example `grep` and `rg` over the same pattern) once the exact suspect pattern is known.
+
 ### Step 1
 
 - Implement **one phase at a time**.

--- a/.claude/skills/local-implementation/SKILL.md
+++ b/.claude/skills/local-implementation/SKILL.md
@@ -90,7 +90,7 @@ When resuming local implementation with dirty work or an observed failing comman
 1. run startup once from the relevant worktree/context
 2. inspect current state with `git status` and the changed files
 3. reproduce or identify the failing command
-4. run an exact-pattern search in changed files for the suspect call/site
+4. run an exact-pattern search in changed files for the suspect call site
 5. patch the minimum call sites
 6. run focused smoke checks for that failure
 7. run default verification

--- a/skills/docs/anti-patterns.md
+++ b/skills/docs/anti-patterns.md
@@ -10,6 +10,7 @@ Canonical owner for anti-pattern guidance across all workflow families.
 4. **Merging directly to main without PR**: Use PR-based remote loop when practical.
 5. **Duplicate worktree paths**: Check `git worktree list` before creating new worktrees; reuse existing matching worktrees.
 6. **Main-checkout mutation**: Reserve main checkout for inspection/control; use `tmp/worktrees/` paths for mutation work.
+7. **Spelunking tooling internals instead of using the public surface**: Do not read installed package internals, scan tooling source, or run ad-hoc scripts to understand a tool's behavior. Use the CLI, its `--help` subcommands, and `skills/docs/`. Read tool source only when the task is to inspect or change that tool, or when a concrete failure path is inside it and no public CLI/docs path exists. Once a failure is concrete, search changed files for the exact pattern — don't run duplicate broad searches.
 
 ## Light mode exception
 

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -94,7 +94,7 @@ When resuming local implementation with dirty work or an observed failing comman
 1. run startup once from the relevant worktree/context
 2. inspect current state with `git status` and the changed files
 3. reproduce or identify the failing command
-4. run an exact-pattern search in changed files for the suspect call/site
+4. run an exact-pattern search in changed files for the suspect call site
 5. patch the minimum call sites
 6. run focused smoke checks for that failure
 7. run default verification

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -99,7 +99,7 @@ When resuming local implementation with dirty work or an observed failing comman
 6. run focused smoke checks for that failure
 7. run default verification
 
-Do not read installed package internals unless the failing path is inside that installed package or no public CLI/docs path exists. Do not run duplicate broad searches (for example `grep` and `rg` over the same pattern) once the exact suspect pattern is known.
+Follow [Anti-patterns](../docs/anti-patterns.md) for the general tooling-internals and duplicate-broad-search prohibition; this local fast path owns only the ordered failure-triage procedure above.
 
 ### Step 1
 

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -87,6 +87,20 @@ This gate does **not** apply to other routed strategies (`copilot_pr_followup`, 
 
 Development-only bypass (`PI_PREFLIGHT_BYPASS=1`) exists for testing the gate itself but must not be used in production workflow runs. The bypass variable is a testing convenience, not an operational escape hatch.
 
+## Narrow failure-triage fast path
+
+When resuming local implementation with dirty work or an observed failing command, use this path before broad discovery:
+
+1. run startup once from the relevant worktree/context
+2. inspect current state with `git status` and the changed files
+3. reproduce or identify the failing command
+4. run an exact-pattern search in changed files for the suspect call/site
+5. patch the minimum call sites
+6. run focused smoke checks for that failure
+7. run default verification
+
+Do not read installed package internals unless the failing path is inside that installed package or no public CLI/docs path exists. Do not run duplicate broad searches (for example `grep` and `rg` over the same pattern) once the exact suspect pattern is known.
+
 ### Step 1
 
 - Implement **one phase at a time**.

--- a/test/contracts/local-implementation-failure-triage-contract.test.mjs
+++ b/test/contracts/local-implementation-failure-triage-contract.test.mjs
@@ -1,4 +1,5 @@
 import {
+  assert,
   assertMatchesAll,
   readRepo,
   test,
@@ -7,7 +8,7 @@ import {
 test("local-implementation skill keeps narrow failure-triage ordering", async () => {
   const content = await readRepo("skills/local-implementation/SKILL.md");
 
-  assertMatchesAll(content, [
+  const orderedPatterns = [
     /## Narrow failure-triage fast path/i,
     /run startup once from the relevant worktree/i,
     /inspect current state[\s\S]{0,120}`git status`[\s\S]{0,120}changed files/i,
@@ -17,7 +18,20 @@ test("local-implementation skill keeps narrow failure-triage ordering", async ()
     /focused smoke checks/i,
     /default verification/i,
     /general tooling-internals and duplicate-broad-search prohibition/i,
-  ], "skills/local-implementation/SKILL.md");
+  ];
+
+  // Verify all patterns are present
+  assertMatchesAll(content, orderedPatterns, "skills/local-implementation/SKILL.md");
+
+  // Verify patterns appear in the declared order
+  let lastPos = -1;
+  for (const pattern of orderedPatterns) {
+    const match = content.match(pattern);
+    assert.ok(match, `skills/local-implementation/SKILL.md should match ${pattern}`);
+    const pos = match.index;
+    assert.ok(pos > lastPos, `skills/local-implementation/SKILL.md pattern "${pattern}" (at ${pos}) should appear after previous match (last at ${lastPos})`);
+    lastPos = pos;
+  }
 });
 
 test("anti-patterns doc owns the general tooling-internals guidance", async () => {

--- a/test/contracts/local-implementation-failure-triage-contract.test.mjs
+++ b/test/contracts/local-implementation-failure-triage-contract.test.mjs
@@ -4,7 +4,7 @@ import {
   test,
 } from "../imported-assets-helpers.mjs";
 
-test("local-implementation skill keeps narrow failure-triage guidance", async () => {
+test("local-implementation skill keeps narrow failure-triage ordering", async () => {
   const content = await readRepo("skills/local-implementation/SKILL.md");
 
   assertMatchesAll(content, [
@@ -16,7 +16,21 @@ test("local-implementation skill keeps narrow failure-triage guidance", async ()
     /patch the minimum call sites/i,
     /focused smoke checks/i,
     /default verification/i,
-    /Do not read installed package internals unless the failing path is inside that installed package or no public CLI\/docs path exists/i,
-    /Do not run duplicate broad searches/i,
+    /general tooling-internals and duplicate-broad-search prohibition/i,
   ], "skills/local-implementation/SKILL.md");
+});
+
+test("anti-patterns doc owns the general tooling-internals guidance", async () => {
+  const content = await readRepo("skills/docs/anti-patterns.md");
+
+  assertMatchesAll(content, [
+    /Spelunking tooling internals instead of using the public surface/i,
+    /Do not read installed package internals/i,
+    /scan tooling source/i,
+    /run ad-hoc scripts to understand a tool's behavior/i,
+    /Use the CLI[\s\S]{0,120}`--help` subcommands[\s\S]{0,120}`skills\/docs\/?`/i,
+    /concrete failure path is inside it and no public CLI\/docs path exists/i,
+    /search changed files for the exact pattern/i,
+    /don't run duplicate broad searches/i,
+  ], "skills/docs/anti-patterns.md");
 });

--- a/test/contracts/local-implementation-failure-triage-contract.test.mjs
+++ b/test/contracts/local-implementation-failure-triage-contract.test.mjs
@@ -1,0 +1,22 @@
+import {
+  assertMatchesAll,
+  readRepo,
+  test,
+} from "../imported-assets-helpers.mjs";
+
+test("local-implementation skill keeps narrow failure-triage guidance", async () => {
+  const content = await readRepo("skills/local-implementation/SKILL.md");
+
+  assertMatchesAll(content, [
+    /## Narrow failure-triage fast path/i,
+    /run startup once from the relevant worktree/i,
+    /inspect current state[\s\S]{0,120}`git status`[\s\S]{0,120}changed files/i,
+    /reproduce[^\n]*failing command/i,
+    /exact-pattern search in changed files/i,
+    /patch the minimum call sites/i,
+    /focused smoke checks/i,
+    /default verification/i,
+    /Do not read installed package internals unless the failing path is inside that installed package or no public CLI\/docs path exists/i,
+    /Do not run duplicate broad searches/i,
+  ], "skills/local-implementation/SKILL.md");
+});


### PR DESCRIPTION
## Summary
- promote the general "don't spelunk tooling internals — use the CLI / `--help` / `skills/docs/`" rule to `skills/docs/anti-patterns.md` (the declared canonical owner across all workflow families)
- add a narrow failure-triage fast path to the local-implementation skill that cross-references the anti-pattern and owns only the ordered triage procedure
- require exact-pattern search in changed files once a concrete failing command is known
- add split contract regression tests (anti-patterns ownership + ordered triage with sequential-order enforcement) and regenerate Claude skill assets

## Validation
- `node --test test/contracts/local-implementation-failure-triage-contract.test.mjs`
- `node scripts/claude/generate-claude-assets.mjs --check`
- `env -u PI_SUBAGENT_RUN_ID npm run verify`

Closes #861
