### PR TITLE
docs(agents): point developer/fixer at the tooling-internals anti-pattern (#863)

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -17,7 +17,7 @@ You are a focused implementation agent. You take a single clearly-scoped coding 
 - Do not re-plan the broader milestone unless a blocker forces it.
 - Stay within the requested scope and files unless a small adjacent fix is required to complete the task safely.
 - Preserve existing project conventions and package/runtime behavior.
-- Do not read installed-package internals or scan tooling source to understand a tool — use its CLI, `--help`, and `skills/docs/`. Read tool source only when the task is to inspect or change that tool, or when a concrete failure path is inside it with no public CLI/docs path. See [Anti-patterns](../skills/docs/anti-patterns.md#core-anti-patterns).
+- Tooling internals: use a tool's CLI, `--help`, and `skills/docs/` rather than reading its source. See [Anti-patterns](../skills/docs/anti-patterns.md#core-anti-patterns).
 
 ## Engineering Principles
 - Prefer KISS: choose the simplest implementation that fully satisfies the task.

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -17,6 +17,7 @@ You are a focused implementation agent. You take a single clearly-scoped coding 
 - Do not re-plan the broader milestone unless a blocker forces it.
 - Stay within the requested scope and files unless a small adjacent fix is required to complete the task safely.
 - Preserve existing project conventions and package/runtime behavior.
+- Do not read installed-package internals or scan tooling source to understand a tool — use its CLI, `--help`, and `skills/docs/`. Read tool source only when the task is to inspect or change that tool, or when a concrete failure path is inside it with no public CLI/docs path. See [Anti-patterns](../skills/docs/anti-patterns.md#core-anti-patterns).
 
 ## Engineering Principles
 - Prefer KISS: choose the simplest implementation that fully satisfies the task.

--- a/.claude/agents/fixer.md
+++ b/.claude/agents/fixer.md
@@ -22,6 +22,7 @@ You are a focused review-fix agent. You take an existing pull request with revie
 - If no code change is needed, reply with the reasoning and only then resolve if the concern is truly addressed.
 - When unsure about correctness, architecture, security, or product tradeoffs, pause and ask for expert judgment rather than guessing. Use the available project workflow for expert review when possible, or clearly report the decision needed.
 - Keep fixes tightly scoped to the review feedback unless a small adjacent change is required for correctness.
+- Do not read installed-package internals or scan tooling source to understand a tool — use its CLI, `--help`, and `skills/docs/`. Read tool source only when the task is to inspect or change that tool, or when a concrete failure path is inside it with no public CLI/docs path. See [Anti-patterns](../skills/docs/anti-patterns.md#core-anti-patterns).
 
 ## Review Workflow
 1. Read unresolved review threads and any general review comments.

--- a/.claude/agents/fixer.md
+++ b/.claude/agents/fixer.md
@@ -22,7 +22,7 @@ You are a focused review-fix agent. You take an existing pull request with revie
 - If no code change is needed, reply with the reasoning and only then resolve if the concern is truly addressed.
 - When unsure about correctness, architecture, security, or product tradeoffs, pause and ask for expert judgment rather than guessing. Use the available project workflow for expert review when possible, or clearly report the decision needed.
 - Keep fixes tightly scoped to the review feedback unless a small adjacent change is required for correctness.
-- Do not read installed-package internals or scan tooling source to understand a tool — use its CLI, `--help`, and `skills/docs/`. Read tool source only when the task is to inspect or change that tool, or when a concrete failure path is inside it with no public CLI/docs path. See [Anti-patterns](../skills/docs/anti-patterns.md#core-anti-patterns).
+- Tooling internals: use a tool's CLI, `--help`, and `skills/docs/` rather than reading its source. See [Anti-patterns](../skills/docs/anti-patterns.md#core-anti-patterns).
 
 ## Review Workflow
 1. Read unresolved review threads and any general review comments.

--- a/agents/developer.agent.md
+++ b/agents/developer.agent.md
@@ -19,7 +19,7 @@ You are a focused implementation agent. You take a single clearly-scoped coding 
 - Do not re-plan the broader milestone unless a blocker forces it.
 - Stay within the requested scope and files unless a small adjacent fix is required to complete the task safely.
 - Preserve existing project conventions and package/runtime behavior.
-- Do not read installed-package internals or scan tooling source to understand a tool — use its CLI, `--help`, and `skills/docs/`. Read tool source only when the task is to inspect or change that tool, or when a concrete failure path is inside it with no public CLI/docs path. See [Anti-patterns](../skills/docs/anti-patterns.md#core-anti-patterns).
+- Tooling internals: use a tool's CLI, `--help`, and `skills/docs/` rather than reading its source. See [Anti-patterns](../skills/docs/anti-patterns.md#core-anti-patterns).
 
 ## Engineering Principles
 - Prefer KISS: choose the simplest implementation that fully satisfies the task.

--- a/agents/developer.agent.md
+++ b/agents/developer.agent.md
@@ -19,6 +19,7 @@ You are a focused implementation agent. You take a single clearly-scoped coding 
 - Do not re-plan the broader milestone unless a blocker forces it.
 - Stay within the requested scope and files unless a small adjacent fix is required to complete the task safely.
 - Preserve existing project conventions and package/runtime behavior.
+- Do not read installed-package internals or scan tooling source to understand a tool — use its CLI, `--help`, and `skills/docs/`. Read tool source only when the task is to inspect or change that tool, or when a concrete failure path is inside it with no public CLI/docs path. See [Anti-patterns](../skills/docs/anti-patterns.md#core-anti-patterns).
 
 ## Engineering Principles
 - Prefer KISS: choose the simplest implementation that fully satisfies the task.

--- a/agents/fixer.agent.md
+++ b/agents/fixer.agent.md
@@ -24,6 +24,7 @@ You are a focused review-fix agent. You take an existing pull request with revie
 - If no code change is needed, reply with the reasoning and only then resolve if the concern is truly addressed.
 - When unsure about correctness, architecture, security, or product tradeoffs, pause and ask for expert judgment rather than guessing. Use the available project workflow for expert review when possible, or clearly report the decision needed.
 - Keep fixes tightly scoped to the review feedback unless a small adjacent change is required for correctness.
+- Do not read installed-package internals or scan tooling source to understand a tool — use its CLI, `--help`, and `skills/docs/`. Read tool source only when the task is to inspect or change that tool, or when a concrete failure path is inside it with no public CLI/docs path. See [Anti-patterns](../skills/docs/anti-patterns.md#core-anti-patterns).
 
 ## Review Workflow
 1. Read unresolved review threads and any general review comments.

--- a/agents/fixer.agent.md
+++ b/agents/fixer.agent.md
@@ -24,7 +24,7 @@ You are a focused review-fix agent. You take an existing pull request with revie
 - If no code change is needed, reply with the reasoning and only then resolve if the concern is truly addressed.
 - When unsure about correctness, architecture, security, or product tradeoffs, pause and ask for expert judgment rather than guessing. Use the available project workflow for expert review when possible, or clearly report the decision needed.
 - Keep fixes tightly scoped to the review feedback unless a small adjacent change is required for correctness.
-- Do not read installed-package internals or scan tooling source to understand a tool — use its CLI, `--help`, and `skills/docs/`. Read tool source only when the task is to inspect or change that tool, or when a concrete failure path is inside it with no public CLI/docs path. See [Anti-patterns](../skills/docs/anti-patterns.md#core-anti-patterns).
+- Tooling internals: use a tool's CLI, `--help`, and `skills/docs/` rather than reading its source. See [Anti-patterns](../skills/docs/anti-patterns.md#core-anti-patterns).
 
 ## Review Workflow
 1. Read unresolved review threads and any general review comments.

--- a/test/contracts/agent-tooling-anti-pattern-contract.test.mjs
+++ b/test/contracts/agent-tooling-anti-pattern-contract.test.mjs
@@ -1,0 +1,20 @@
+import {
+  assertMatchesAll,
+  readRepo,
+  test,
+} from "../imported-assets-helpers.mjs";
+
+// #863: the implementation agents must surface the tooling-internals
+// anti-pattern (anti-patterns.md #7), since they do not auto-load that doc.
+// The reference must be a pointer/cross-reference, not a duplicated rule.
+for (const agent of ["developer", "fixer"]) {
+  test(`${agent} agent references the tooling-internals anti-pattern`, async () => {
+    const content = await readRepo(`agents/${agent}.agent.md`);
+
+    assertMatchesAll(content, [
+      /Do not read installed-package internals or scan tooling source/i,
+      /use its CLI[\s\S]{0,40}`--help`[\s\S]{0,40}`skills\/docs\/?`/i,
+      /\[Anti-patterns\]\(\.\.\/skills\/docs\/anti-patterns\.md#core-anti-patterns\)/,
+    ], `agents/${agent}.agent.md`);
+  });
+}

--- a/test/contracts/agent-tooling-anti-pattern-contract.test.mjs
+++ b/test/contracts/agent-tooling-anti-pattern-contract.test.mjs
@@ -11,9 +11,10 @@ for (const agent of ["developer", "fixer"]) {
   test(`${agent} agent references the tooling-internals anti-pattern`, async () => {
     const content = await readRepo(`agents/${agent}.agent.md`);
 
+    // Assert the cross-reference link + a lightweight label only — the agent
+    // doc is a pointer, not a copy of the rule (anti-patterns.md stays canonical).
     assertMatchesAll(content, [
-      /Do not read installed-package internals or scan tooling source/i,
-      /use its CLI[\s\S]{0,40}`--help`[\s\S]{0,40}`skills\/docs\/?`/i,
+      /tooling internals/i,
       /\[Anti-patterns\]\(\.\.\/skills\/docs\/anti-patterns\.md#core-anti-patterns\)/,
     ], `agents/${agent}.agent.md`);
   });


### PR DESCRIPTION
## Summary

Surface the tooling-internals anti-pattern (`skills/docs/anti-patterns.md` #7, added in #862) to the two implementation agents — `developer` and `fixer` — which do not auto-load that doc, so the rule did not bind the agents most likely to spelunk tooling source.

## Approach (refined in #863)

Selected **Option 1**: add a one-line cross-reference under each agent's `## Expectations`, pointing to `../skills/docs/anti-patterns.md#core-anti-patterns`. A pointer, not a copied rule, so `validate-no-duplicate-rules` is not tripped. Rejected: editing `AGENTS.md` (conflicts with "keep procedure out of AGENTS") and changing the `requiredReads` derivation in `@dev-loops/core` (over-invasive for a small nudge).

## Changes

- `agents/developer.agent.md`, `agents/fixer.agent.md` — cross-reference bullet.
- `.claude/agents/developer.md`, `.claude/agents/fixer.md` — regenerated mirrors.
- `test/contracts/agent-tooling-anti-pattern-contract.test.mjs` — regression test asserting both agent docs reference the anti-pattern via the cross-reference link.

## Acceptance criteria

- [x] Both implementation agents reference the tooling-internals anti-pattern via a cross-reference to `skills/docs/anti-patterns.md`.
- [x] Reference is a pointer, not a duplicated rule (no `validate-no-duplicate-rules` failure).
- [x] Relative link resolves from `agents/`; `npm run test:docs` link validation passes.
- [x] `.claude` mirrors regenerated; `generate-claude-assets.mjs --check` passes.
- [x] Regression contract test added.
- [x] `npm run verify` passes.

## Non-goals

- Other agents (`review`, `quality`, `docs`, `refiner`) — not the implementation-spelunking surface.

Closes #863
