### PR TITLE
refactor(cli): migrate archive-done-items.mjs arg parser to node:util.parseArgs (#870)

### DIFF
--- a/scripts/projects/archive-done-items.mjs
+++ b/scripts/projects/archive-done-items.mjs
@@ -433,4 +433,4 @@ if (isDirectCliRun(import.meta.url)) {
   });
 }
 
-export { main, parseDuration, selectArchivable };
+export { main, parseCliArgs, parseDuration, selectArchivable };

--- a/scripts/projects/archive-done-items.mjs
+++ b/scripts/projects/archive-done-items.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
+import { parseArgs } from "node:util";
 
 const USAGE = `Usage: dev-loops project archive-done --repo <owner/name> --project <number|id> [--older-than <duration>] [--dry-run]
 
@@ -27,36 +28,61 @@ Exit codes:
   3 — project not found
 `.trim();
 
-const VALID_ARGS = new Set(["--repo", "--project", "--older-than", "--dry-run", "--help", "-h"]);
-
-function parseArgs(argv) {
-  const args = {};
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    if (!VALID_ARGS.has(arg) && arg.startsWith("-")) {
-      throw Object.assign(new Error(`Unknown flag: ${arg}`), { code: "INVALID_ARGS", usage: USAGE });
+function parseCliArgs(argv) {
+  const requireValue = (token, message, code) => {
+    const v = token.value;
+    if (typeof v !== "string" || v.length === 0 || v.startsWith("-")) {
+      throw Object.assign(new Error(message), { code });
     }
-    if (arg === "--repo") {
-      if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
-        throw Object.assign(new Error("--repo requires a value (owner/name)"), { code: "INVALID_REPO" });
-      }
-      args.repo = argv[++i];
-    } else if (arg === "--project") {
-      if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
-        throw Object.assign(new Error("--project requires a value (number or node ID)"), { code: "INVALID_PROJECT" });
-      }
-      args.project = argv[++i];
-    } else if (arg === "--older-than") {
-      if (i + 1 >= argv.length || argv[i + 1].startsWith("-")) {
-        throw Object.assign(new Error("--older-than requires a value (e.g. 30d)"), { code: "INVALID_DURATION" });
-      }
-      args.olderThan = argv[++i];
-    } else if (arg === "--dry-run") {
-      args.dryRun = true;
-    } else if (arg === "--help" || arg === "-h") {
-      args.help = true;
-    } else {
-      throw Object.assign(new Error(`Unexpected argument: ${arg}`), { code: "INVALID_ARGS", usage: USAGE });
+    return v;
+  };
+
+  const args = {};
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      repo: { type: "string" },
+      project: { type: "string" },
+      "older-than": { type: "string" },
+      "dry-run": { type: "boolean" },
+      help: { type: "boolean", short: "h" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw Object.assign(new Error(`Unexpected argument: ${token.value}`), { code: "INVALID_ARGS", usage: USAGE });
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    switch (token.name) {
+      case "help":
+        if (token.value !== undefined) {
+          throw Object.assign(new Error(`Unknown flag: ${token.rawName}=${token.value}`), { code: "INVALID_ARGS", usage: USAGE });
+        }
+        args.help = true;
+        break;
+      case "repo":
+        args.repo = requireValue(token, "--repo requires a value (owner/name)", "INVALID_REPO");
+        break;
+      case "project":
+        args.project = requireValue(token, "--project requires a value (number or node ID)", "INVALID_PROJECT");
+        break;
+      case "older-than":
+        args.olderThan = requireValue(token, "--older-than requires a value (e.g. 30d)", "INVALID_DURATION");
+        break;
+      case "dry-run":
+        if (token.value !== undefined) {
+          throw Object.assign(new Error(`Unknown flag: ${token.rawName}=${token.value}`), { code: "INVALID_ARGS", usage: USAGE });
+        }
+        args.dryRun = true;
+        break;
+      default:
+        throw Object.assign(new Error(`Unknown flag: ${token.rawName}`), { code: "INVALID_ARGS", usage: USAGE });
     }
   }
   return args;
@@ -381,7 +407,7 @@ async function main(args, { env = process.env, runChild } = {}) {
 async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, env = process.env } = {}) {
   let args;
   try {
-    args = parseArgs(argv);
+    args = parseCliArgs(argv);
   } catch (err) {
     stderr.write(`${formatCliError(err)}\n`);
     process.exitCode = 1;

--- a/test/projects/archive-done-items.test.mjs
+++ b/test/projects/archive-done-items.test.mjs
@@ -2,9 +2,37 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   main,
+  parseCliArgs,
   parseDuration,
   selectArchivable,
 } from "../../scripts/projects/archive-done-items.mjs";
+
+// ── Pure unit: parseCliArgs ───────────────────────────────────────────────
+
+describe("archive-done — parseCliArgs", () => {
+  it("parses repo, project, older-than, and dry-run", () => {
+    const args = parseCliArgs(["--repo", "o/r", "--project", "3", "--older-than", "7d", "--dry-run"]);
+    assert.deepStrictEqual(args, { repo: "o/r", project: "3", olderThan: "7d", dryRun: true });
+  });
+  it("supports --help / -h", () => {
+    assert.strictEqual(parseCliArgs(["--help"]).help, true);
+    assert.strictEqual(parseCliArgs(["-h"]).help, true);
+  });
+  it("rejects an unknown flag", () => {
+    assert.throws(() => parseCliArgs(["--bogus"]), (e) => e.code === "INVALID_ARGS");
+  });
+  it("rejects an unexpected positional", () => {
+    assert.throws(() => parseCliArgs(["stray"]), (e) => e.code === "INVALID_ARGS");
+  });
+  it("requires a value for --repo / --project / --older-than", () => {
+    assert.throws(() => parseCliArgs(["--repo"]), (e) => e.code === "INVALID_REPO");
+    assert.throws(() => parseCliArgs(["--project"]), (e) => e.code === "INVALID_PROJECT");
+    assert.throws(() => parseCliArgs(["--older-than"]), (e) => e.code === "INVALID_DURATION");
+  });
+  it("rejects an explicit inline value on boolean --dry-run", () => {
+    assert.throws(() => parseCliArgs(["--dry-run=false"]), (e) => e.code === "INVALID_ARGS");
+  });
+});
 
 // ── Pure unit: parseDuration ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Complete the index-based arg-parser migration from #857/#866 by migrating the one remaining file, `scripts/projects/archive-done-items.mjs`, to `node:util.parseArgs`. This file was added after #857 (via #858) and was an explicit non-goal of #866.

## Approach

Same uniform pattern as #866: `parseArgs({ options, allowPositionals: true, strict: false, tokens: true })`, iterate `tokens`, `switch (token.name)`. Flag names (`--repo`, `--project`, `--older-than`, `--dry-run`, `--help/-h`), error JSON shapes + `code` values, exit codes, and positional handling preserved exactly. The boolean `--dry-run` (and `--help`) reject an explicit inline `=value` (the #866 round-2 lesson) so `--dry-run=false` errors rather than silently inverting.

## Acceptance criteria

- [x] `archive-done-items.mjs` parses args via `node:util.parseArgs`.
- [x] No hand-rolled `for`-index `argv[++i]` arg loop remains.
- [x] CLI contract preserved: flag names, error JSON shapes/messages, exit codes, positional handling.
- [x] Boolean options reject an explicit inline `=value`.
- [x] Existing `test/projects/archive-done-items.test.mjs` passes; `npm run verify` green.

## Non-goals

- No change to archive-done behavior/semantics; parser migration only.

Closes #870
