### PR TITLE
fix(projects): repair move-queue-item lookup on both ref kinds (#865)

### DIFF
--- a/scripts/projects/move-queue-item.mjs
+++ b/scripts/projects/move-queue-item.mjs
@@ -227,7 +227,7 @@ const GET_PROJECT_ITEMS_BY_CONTENT = [
   "query($projectId:ID!, $after:String) {",
   "  node(id:$projectId) {",
   "    ... on ProjectV2 {",
-  "      items(first:10, after:$after, orderBy:{field:POSITION, direction:ASC}) {",
+  "      items(first:100, after:$after, orderBy:{field:POSITION, direction:ASC}) {",
   "        pageInfo { hasNextPage endCursor }",
   "        nodes {",
   "          id",
@@ -240,33 +240,9 @@ const GET_PROJECT_ITEMS_BY_CONTENT = [
   "            }",
   "          }",
   "          content {",
-  "            ... on Issue { number repository { nameWithOwner } }",
-  "            ... on PullRequest { number repository { nameWithOwner } }",
+  "            ... on Issue { __typename number repository { nameWithOwner } }",
+  "            ... on PullRequest { __typename number repository { nameWithOwner } }",
   "          }",
-  "        }",
-  "      }",
-  "    }",
-  "  }",
-  "}"
-].join("\n");
-
-const GET_PROJECT_ITEM = [
-  "query($projectId:ID!, $itemId:ID!) {",
-  "  node(id:$projectId) {",
-  "    ... on ProjectV2 {",
-  "      item: item(id:$itemId) {",
-  "        id",
-  "        fieldValues(first:20) {",
-  "          nodes {",
-  "            ... on ProjectV2ItemFieldSingleSelectValue {",
-  "              field { ... on ProjectV2SingleSelectField { id name } }",
-  "              name",
-  "            }",
-  "          }",
-  "        }",
-  "        content {",
-  "          ... on Issue { number title url }",
-  "          ... on PullRequest { number title url }",
   "        }",
   "      }",
   "    }",
@@ -354,6 +330,39 @@ async function listAllFields(projectId, env, runChild) {
   return fields;
 }
 
+// ── Paginated item listing (position order) ──────────────────────────────
+
+async function fetchAllItems(projectId, env, runChild) {
+  const items = [];
+  let after = null;
+  while (true) {
+    const vars = { projectId };
+    if (after) vars.after = after;
+    const payload = await ghGraphql(GET_PROJECT_ITEMS_BY_CONTENT, vars, env, runChild);
+    const connection = payload?.data?.node?.items;
+    const nodes = connection?.nodes ?? [];
+    items.push(...nodes);
+    const pageInfo = connection?.pageInfo ?? {};
+    if (!pageInfo.hasNextPage) break;
+    if (!pageInfo.endCursor) {
+      throw Object.assign(
+        new Error("Invalid items payload: hasNextPage is true but endCursor is missing"),
+        { code: "GH_API_ERROR" },
+      );
+    }
+    after = pageInfo.endCursor;
+  }
+  return items;
+}
+
+function statusOf(node) {
+  const fvs = node?.fieldValues?.nodes ?? [];
+  for (const fv of fvs) {
+    if (fv && fv.field && fv.field.name === "Status") return fv.name;
+  }
+  return null;
+}
+
 // ── Exit code classification ────────────────────────────────────────────
 
 function classifyExitCode(err) {
@@ -414,80 +423,53 @@ async function main(args, { env = process.env, runChild } = {}) {
     );
   }
 
-  // 4. Find the item
-  let itemId;
-  let previousColumn = null;
-  let issueNumber = null;
-  let prNumber = null;
+  // 4. Find the item.
+  //
+  // Fetch the full board item list ONCE (paginated, position order) and resolve
+  // BOTH ref kinds against it. This reuses the proven pattern from
+  // reorder-queue-item / list-queue-items: a node-id ref matches by item.id, a
+  // number ref matches by content.number. Both are scoped to the requested repo
+  // so a cross-project ref fails closed with ITEM_NOT_FOUND. (The previous code
+  // used `ProjectV2.item` — a field that does not exist — for the node-id path,
+  // and a single non-paginated `items(first:10)` page for the number path, so it
+  // could not find items beyond the first page.)
+  const allItems = await fetchAllItems(project.id, env, child);
 
+  let match;
   if (itemRef.kind === "id") {
-    // Direct item node ID lookup
-    const itemPayload = await ghGraphql(GET_PROJECT_ITEM, {
-      projectId: project.id,
-      itemId: itemRef.value,
-    }, env, child);
-    const item = itemPayload?.data?.node?.item;
-    if (!item) {
+    match = allItems.find(
+      (it) => it.id === itemRef.value && it.content?.repository?.nameWithOwner === repo,
+    );
+    if (!match) {
       throw Object.assign(
-        new Error(`Item "${itemRef.value}" not found in project "${project.title}"`),
+        new Error(`Item "${itemRef.value}" not found in project "${project.title}" for repo "${repo}"`),
         { code: "ITEM_NOT_FOUND" },
       );
     }
-    itemId = item.id;
-    const fvs = item.fieldValues?.nodes ?? [];
-    for (const fv of fvs) {
-      if (fv && fv.field && fv.field.name === "Status") {
-        previousColumn = fv.name;
-        break;
-      }
-    }
-    if (item.content) {
-      if (item.content.__typename === "Issue") {
-        issueNumber = item.content.number;
-      } else {
-        prNumber = item.content.number;
-      }
-    }
   } else {
-    // Look up by issue/PR number in the project
-    const itemsPayload = await ghGraphql(GET_PROJECT_ITEMS_BY_CONTENT, {
-      projectId: project.id,
-    }, env, child);
-    const items = itemsPayload?.data?.node?.items?.nodes ?? [];
-
-    // Filter by matching repo exactly and item number (when known)
-    const matchingItems = items.filter((it) => {
-      if (!it.content) return false;
-      const repoMatch = it.content.repository?.nameWithOwner === repo;
-      if (itemRef.kind === "number") {
-        return repoMatch && it.content.number === itemRef.value;
-      }
-      return repoMatch;
-    });
-
-    if (matchingItems.length === 0) {
+    match = allItems.find(
+      (it) =>
+        it.content &&
+        it.content.repository?.nameWithOwner === repo &&
+        it.content.number === itemRef.value,
+    );
+    if (!match) {
       throw Object.assign(
         new Error(`Item #${itemRef.value} not found in project "${project.title}" for repo "${repo}"`),
         { code: "ITEM_NOT_FOUND" },
       );
     }
+  }
 
-    // Use the first match (by position order)
-    const match = matchingItems[0];
-    itemId = match.id;
-    const fvs = match.fieldValues?.nodes ?? [];
-    for (const fv of fvs) {
-      if (fv && fv.field && fv.field.name === "Status") {
-        previousColumn = fv.name;
-        break;
-      }
-    }
-    if (match.content) {
-      if (match.content.__typename === "Issue") {
-        issueNumber = match.content.number;
-      } else {
-        prNumber = match.content.number;
-      }
+  const itemId = match.id;
+  const previousColumn = statusOf(match);
+  let issueNumber = null;
+  let prNumber = null;
+  if (match.content) {
+    if (match.content.__typename === "PullRequest") {
+      prNumber = match.content.number;
+    } else {
+      issueNumber = match.content.number;
     }
   }
 

--- a/test/projects/move-queue-item.test.mjs
+++ b/test/projects/move-queue-item.test.mjs
@@ -18,6 +18,31 @@ function mockRunChild(responses) {
   };
 }
 
+// Variant of mockRunChild that records every gh invocation so tests can assert
+// on the exact GraphQL query/variables sent to `gh api graphql`.
+function recordingRunChild(responses, calls) {
+  let callIndex = 0;
+  return async (cmd, args, _env) => {
+    // Reconstruct the query + variables from the `--field key=value` args.
+    const fields = {};
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] === "--field" && typeof args[i + 1] === "string") {
+        const eq = args[i + 1].indexOf("=");
+        if (eq !== -1) fields[args[i + 1].slice(0, eq)] = args[i + 1].slice(eq + 1);
+      }
+    }
+    calls.push({ cmd, args, query: fields.query, variables: fields });
+    if (callIndex >= responses.length) {
+      throw new Error(`Unexpected gh call #${callIndex + 1} (only ${responses.length} mocked)`);
+    }
+    const resp = responses[callIndex++];
+    if (resp.error) {
+      return { code: 1, stdout: "", stderr: resp.error };
+    }
+    return { code: 0, stdout: JSON.stringify(resp.payload), stderr: "" };
+  };
+}
+
 // ── Fixtures ────────────────────────────────────────────────────────────
 
 function userPayload() {
@@ -71,12 +96,6 @@ const EXISTING_PROJECT = {
 function getItemsByContentResponse(items) {
   return {
     data: { node: { items: { nodes: items, pageInfo: { hasNextPage: false, endCursor: null } } } },
-  };
-}
-
-function getItemResponse(item) {
-  return {
-    data: { node: { item } },
   };
 }
 
@@ -167,16 +186,15 @@ describe("move-queue-item", () => {
     });
 
     it("accepts item node ID", async () => {
-      const itemNode = {
-        id: "PVTI_42",
-        fieldValues: { nodes: [{ field: { id: "PVTSSF_status", name: "Status" }, name: "Backlog" }] },
-        content: { __typename: "Issue", number: 10, title: "Test", url: "https://github.com/mfittko/dev-loops/issues/10" },
-      };
       const responses = [
         { payload: userPayload() },
         { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
         { payload: getFieldsResponse([STATUS_FIELD]) },
-        { payload: getItemResponse(itemNode) },
+        {
+          payload: getItemsByContentResponse([
+            makeItemNode("PVTI_42", makeContent("Issue", 10), "Backlog"),
+          ]),
+        },
         { payload: updateItemFieldResponse() },
       ];
       const result = await main(
@@ -184,6 +202,7 @@ describe("move-queue-item", () => {
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
+      assert.equal(result.item.itemId, "PVTI_42");
       assert.equal(result.item.newColumn, "In Progress");
       assert.equal(result.item.issueNumber, 10);
     });
@@ -263,16 +282,15 @@ describe("move-queue-item", () => {
     });
 
     it("returns unchanged when already at target via item ID lookup", async () => {
-      const itemNode = {
-        id: "PVTI_42",
-        fieldValues: { nodes: [{ field: { id: "PVTSSF_status", name: "Status" }, name: "Done" }] },
-        content: { __typename: "Issue", number: 10, title: "Test", url: "https://github.com/mfittko/dev-loops/issues/10" },
-      };
       const responses = [
         { payload: userPayload() },
         { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
         { payload: getFieldsResponse([STATUS_FIELD]) },
-        { payload: getItemResponse(itemNode) },
+        {
+          payload: getItemsByContentResponse([
+            makeItemNode("PVTI_42", makeContent("Issue", 10), "Done"),
+          ]),
+        },
         // No mutation
       ];
       const result = await main(
@@ -393,7 +411,7 @@ describe("move-queue-item", () => {
         { payload: userPayload() },
         { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
         { payload: getFieldsResponse([STATUS_FIELD]) },
-        { payload: getItemResponse(null) },
+        { payload: getItemsByContentResponse([]) },
       ];
       try {
         await main(
@@ -460,6 +478,138 @@ describe("move-queue-item", () => {
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.ok, true);
+    });
+  });
+
+  describe("regression — well-formed GraphQL for both lookup paths", () => {
+    // The original bug: the by-number path issued a single non-paginated
+    // `items(first:10)` page, so an item beyond the first page (e.g. #857 on a
+    // busy board) reported ITEM_NOT_FOUND even though it was on the board.
+    it("paginates item lookup by number across pages", async () => {
+      const firstPage = {
+        data: {
+          node: {
+            items: {
+              nodes: Array.from({ length: 3 }, (_, i) =>
+                makeItemNode(`PVTI_p1_${i}`, makeContent("Issue", 100 + i), "Done")),
+              pageInfo: { hasNextPage: true, endCursor: "CURSOR_1" },
+            },
+          },
+        },
+      };
+      const secondPage = {
+        data: {
+          node: {
+            items: {
+              nodes: [makeItemNode("PVTI_target", makeContent("Issue", 857), "Done")],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        },
+      };
+      const calls = [];
+      const result = await main(
+        { repo: "mfittko/dev-loops", project: "1", item: "857", toColumn: "Next Up" },
+        {
+          env: {},
+          runChild: recordingRunChild(
+            [
+              { payload: userPayload() },
+              { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+              { payload: getFieldsResponse([STATUS_FIELD]) },
+              { payload: firstPage },
+              { payload: secondPage },
+              { payload: updateItemFieldResponse() },
+            ],
+            calls,
+          ),
+        },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.item.itemId, "PVTI_target");
+      assert.equal(result.item.issueNumber, 857);
+      assert.equal(result.item.previousColumn, "Done");
+      assert.equal(result.item.newColumn, "Next Up");
+
+      // The second item-list call must forward the endCursor — proves pagination.
+      const itemListCalls = calls.filter((c) => c.query && c.query.includes("orderBy:{field:POSITION"));
+      assert.equal(itemListCalls.length, 2, "expected two paginated item-list calls");
+      assert.equal(itemListCalls[1].variables.after, "CURSOR_1");
+    });
+
+    it("item-list query requests __typename and never references ProjectV2.item or an unused $itemId", async () => {
+      const calls = [];
+      await main(
+        { repo: "mfittko/dev-loops", project: "1", item: "10", toColumn: "Next Up" },
+        {
+          env: {},
+          runChild: recordingRunChild(
+            [
+              { payload: userPayload() },
+              { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+              { payload: getFieldsResponse([STATUS_FIELD]) },
+              {
+                payload: getItemsByContentResponse([
+                  makeItemNode("PVTI_1", makeContent("Issue", 10), "Backlog"),
+                ]),
+              },
+              { payload: updateItemFieldResponse() },
+            ],
+            calls,
+          ),
+        },
+      );
+
+      const queries = calls.map((c) => c.query).filter(Boolean);
+      // No query may reference the non-existent ProjectV2.item field.
+      for (const q of queries) {
+        assert.ok(!/item:\s*item\(/.test(q), `query must not alias ProjectV2.item: ${q}`);
+        assert.ok(!/\bitem\(id:/.test(q), `query must not select ProjectV2.item(id:): ${q}`);
+        // A query may only declare $itemId if it actually uses it.
+        if (q.includes("$itemId:ID!")) {
+          assert.ok(q.includes("itemId:$itemId"), `query declares $itemId but never uses it: ${q}`);
+        }
+      }
+
+      // The item-resolution query must request __typename so issue/PR is
+      // classified correctly (the original query omitted it, so issueNumber
+      // was always null).
+      const itemListQuery = queries.find((q) => q.includes("orderBy:{field:POSITION"));
+      assert.ok(itemListQuery, "expected an item-list query");
+      assert.ok(itemListQuery.includes("__typename"), "item-list query must request __typename");
+    });
+
+    it("item ID lookup resolves from the paginated list (no ProjectV2.item query)", async () => {
+      const calls = [];
+      const result = await main(
+        { repo: "mfittko/dev-loops", project: "1", item: "PVTI_target", toColumn: "Next Up" },
+        {
+          env: {},
+          runChild: recordingRunChild(
+            [
+              { payload: userPayload() },
+              { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+              { payload: getFieldsResponse([STATUS_FIELD]) },
+              {
+                payload: getItemsByContentResponse([
+                  makeItemNode("PVTI_target", makeContent("Issue", 42), "Backlog"),
+                ]),
+              },
+              { payload: updateItemFieldResponse() },
+            ],
+            calls,
+          ),
+        },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.item.itemId, "PVTI_target");
+      assert.equal(result.item.issueNumber, 42);
+      // The update mutation must target the resolved item id and field.
+      const mutationCall = calls.find((c) => c.query && c.query.includes("updateProjectV2ItemFieldValue"));
+      assert.ok(mutationCall, "expected an updateProjectV2ItemFieldValue mutation");
+      assert.equal(mutationCall.variables.itemId, "PVTI_target");
+      assert.equal(mutationCall.variables.fieldId, "PVTSSF_status");
+      assert.equal(mutationCall.variables.optionId, "opt2");
     });
   });
 


### PR DESCRIPTION
## Summary

Fix the `dev-loops project move` command (`scripts/projects/move-queue-item.mjs`), which was broken on **both** item-lookup paths.

## Root cause

1. **By issue/PR number** → `ITEM_NOT_FOUND` for on-board items: the lookup fetched only `items(first: 10)` with no pagination, so any item beyond board position 10 was never seen. Content fragments also omitted `__typename`, mis-classifying issue vs. PR.
2. **By item node id** → GraphQL error: the query used `node(id: $projectId) { ... on ProjectV2 { item(id: $itemId) } }`, but `ProjectV2` has no `item` field (`Field 'item' doesn't exist on type 'ProjectV2'`, `$itemId` unused).

## Fix

Resolve both ref kinds against a single **paginated** board-item list (mirroring the working `reorder-queue-item.mjs`), add `__typename` to content fragments, and delete the invalid query. The `updateProjectV2ItemFieldValue` Status-update mutation was already correct and is unchanged. CLI flag names, output JSON shape (`{ ok, item: { itemId, issueNumber, prNumber, previousColumn, newColumn } }`), error codes, and exit codes are preserved.

## Validation

- `npm run verify` — pass.
- `node --test test/projects/move-queue-item.test.mjs` — 30 pass. Added regression tests asserting well-formed GraphQL for both paths (paginated number lookup; no `ProjectV2.item`/unused `$itemId`; `__typename` requested).
- **Live-board smoke** (project #3): moved #804 by number (Done→Next Up) and by node-id (Next Up→Done), both `ok:true`; board restored.

Closes #865
