### PR TITLE
feat(queue): post-merge board archive as a local dev-loop step (#869)

### DIFF
--- a/.claude/skills/copilot-pr-followup/SKILL.md
+++ b/.claude/skills/copilot-pr-followup/SKILL.md
@@ -349,6 +349,16 @@ node <resolved-skill-scripts>/loop/checkpoint-contract.mjs --state skipped --rea
 
 Do not report completion or advance to the next PR queue item until `.pi/dev-loop-retrospective-checkpoint.json` is updated to `complete` or `skipped`.
 
+### Post-merge board archive (best-effort)
+
+After the retrospective checkpoint write, optionally tidy the queue board locally:
+
+```sh
+node <resolved-skill-scripts>/projects/archive-done-items.mjs --repo <owner/name>
+```
+
+Board and threshold resolve from `.devloops` (`queue.projectNumber`/`queue.boardTitle`, `queue.archiveOlderThanDays`, default 7d), using local `gh` auth — no CI, cron, or PAT. This step is best-effort and NON-FATAL: ignore any failure and never let it block the merge or the retrospective.
+
 ## Validation policy
 
 Follow [Validation Policy](../docs/validation-policy.md). Default: `npm run verify` before PR creation, gate entry, and merge. For repo-local examples: `npm run test:dev-loop` for skill scripts, contract tests for templates, `git diff --check` for docs. When CI runs exist, use `gh run watch` or `detect-copilot-loop-state.mjs` instead of `sleep`-based polling. Distinguish: locally validated, full PR-equivalent checks, awaiting CI.

--- a/.devloops
+++ b/.devloops
@@ -72,3 +72,4 @@ queue:
   maxParallel: 3
   maxAutoFiledIssues: 10
   reDispatchMaxRetries: 1
+  archiveOlderThanDays: 7

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -85,6 +85,7 @@ const QueueConfig = z.strictObject({
   reDispatchMaxRetries: z.number().int().min(0).max(10).default(1),
   projectNumber: z.number().int().positive().optional(),
   boardTitle: z.string().trim().min(1).optional(),
+  archiveOlderThanDays: z.number().int().positive().optional(),
 });
 
 /** Internal path whitelist for internal-only PR detection — flat array of regex strings */

--- a/scripts/projects/archive-done-items.mjs
+++ b/scripts/projects/archive-done-items.mjs
@@ -1,18 +1,24 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { parse as parseYaml } from "yaml";
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
 import { parseArgs } from "node:util";
 
-const USAGE = `Usage: dev-loops project archive-done --repo <owner/name> --project <number|id> [--older-than <duration>] [--dry-run]
+const USAGE = `Usage: dev-loops project archive-done --repo <owner/name> [--project <number|id>] [--older-than <duration>] [--dry-run]
 
 Archive GitHub Projects V2 items whose issue/PR has been closed for at least the
 given duration. Operator-triggered (no webhooks). Uses archiveProjectV2Item.
 
 Options:
   --repo <owner/name>     Required. Repository to scope the project search.
-  --project <number|id>   Required. Project number (integer) or node ID.
+  --project <number|id>   Project number (integer) or node ID. When omitted,
+                          resolved from .devloops queue.projectNumber /
+                          queue.boardTitle.
   --older-than <duration> Closed-for threshold. Format: <n><unit> where unit is
-                          h (hours), d (days), or w (weeks). Default: 30d.
+                          h (hours), d (days), or w (weeks). Default resolves
+                          from .devloops queue.archiveOlderThanDays, else 7d.
   --dry-run               Print the intended archive mutation(s) without executing.
   --help, -h              Show this help.
 
@@ -145,6 +151,37 @@ function parseDuration(raw) {
     throw Object.assign(new Error(`--older-than must be a positive amount, got "${raw}"`), { code: "INVALID_DURATION" });
   }
   return n * UNIT_MS[m[2]];
+}
+
+// ── Settings fallback ──────────────────────────────────────────────────────
+
+// Read .devloops (and extension variants) queue settings, mirroring the
+// resolution used by ensure-queue-board.mjs. Returns { project }, { title },
+// and/or { olderThanDays } when configured; never throws on a missing/bad file.
+function resolveSettings(cwd) {
+  const basePath = path.join(cwd, ".devloops");
+  const extensions = ["", ".yaml", ".yml", ".json"];
+  for (const ext of extensions) {
+    try {
+      const raw = readFileSync(basePath + ext, "utf-8");
+      const settings = ext === ".json" ? JSON.parse(raw) : parseYaml(raw);
+      const queue = settings?.queue;
+      if (!queue) return null;
+      const out = {};
+      if (typeof queue.projectNumber === "number" && Number.isInteger(queue.projectNumber) && queue.projectNumber > 0) {
+        out.project = queue.projectNumber;
+      } else if (typeof queue.boardTitle === "string" && queue.boardTitle.trim().length > 0) {
+        out.title = queue.boardTitle.trim();
+      }
+      if (typeof queue.archiveOlderThanDays === "number" && Number.isInteger(queue.archiveOlderThanDays) && queue.archiveOlderThanDays > 0) {
+        out.olderThanDays = queue.archiveOlderThanDays;
+      }
+      return out;
+    } catch {
+      // extension not present or unparseable — try next
+    }
+  }
+  return null;
 }
 
 // ── API helpers ──────────────────────────────────────────────────────────
@@ -338,19 +375,36 @@ async function main(args, { env = process.env, runChild } = {}) {
   const child = runChild ?? _runChild;
   const repo = validateRepo(args.repo);
   const [owner] = repo.split("/");
-  const projectRef = parseProjectRef(args.project);
-  const olderThanRaw = args.olderThan ?? "30d";
+  // Board: explicit --project ref wins; otherwise resolve by board title from
+  // .devloops (passed in as args.projectTitle by runCli). Fail closed if neither.
+  const hasProjectRef = typeof args.project === "string" && args.project.trim().length > 0;
+  const projectRef = hasProjectRef ? parseProjectRef(args.project) : null;
+  const projectTitle = !hasProjectRef && typeof args.projectTitle === "string" && args.projectTitle.trim().length > 0
+    ? args.projectTitle.trim()
+    : null;
+  if (!projectRef && !projectTitle) {
+    throw Object.assign(
+      new Error("--project is required (or configure queue.projectNumber / queue.boardTitle in .devloops)"),
+      { code: "INVALID_PROJECT" },
+    );
+  }
+  const olderThanRaw = args.olderThan ?? args.olderThanDefault ?? "7d";
   const olderThanMs = parseDuration(olderThanRaw);
   const now = args.now ?? Date.now();
 
   const { kind: ownerKind } = await resolveOwner(owner, env, child);
   const projects = await listAllProjects(owner, ownerKind, env, child);
-  const project = projectRef.kind === "id"
-    ? projects.find((p) => p.id === projectRef.value)
-    : projects.find((p) => p.number === projectRef.value);
+  const project = projectRef
+    ? (projectRef.kind === "id"
+        ? projects.find((p) => p.id === projectRef.value)
+        : projects.find((p) => p.number === projectRef.value))
+    : projects.find((p) => p.title === projectTitle);
   if (!project) {
+    const desc = projectRef
+      ? (projectRef.kind === "id" ? `"${projectRef.value}"` : `number ${projectRef.value}`)
+      : `title "${projectTitle}"`;
     throw Object.assign(
-      new Error(`Project ${projectRef.kind === "id" ? `"${projectRef.value}"` : `number ${projectRef.value}`} not found under owner "${owner}"`),
+      new Error(`Project ${desc} not found under owner "${owner}"`),
       { code: "PROJECT_NOT_FOUND" },
     );
   }
@@ -404,7 +458,7 @@ async function main(args, { env = process.env, runChild } = {}) {
 
 // ── CLI entrypoint ──────────────────────────────────────────────────────
 
-async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, env = process.env } = {}) {
+async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, env = process.env, cwd = process.cwd() } = {}) {
   let args;
   try {
     args = parseCliArgs(argv);
@@ -417,6 +471,19 @@ async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, 
     stdout.write(USAGE);
     return;
   }
+
+  // Resolve board + threshold defaults from .devloops when the flags are absent.
+  // Precedence: explicit --project flag > queue.projectNumber/boardTitle.
+  //             explicit --older-than flag > queue.archiveOlderThanDays > 7d.
+  const settings = resolveSettings(cwd);
+  if (args.project === undefined && settings) {
+    if (settings.project) args.project = String(settings.project);
+    else if (settings.title) args.projectTitle = settings.title;
+  }
+  if (args.olderThan === undefined && settings?.olderThanDays) {
+    args.olderThanDefault = `${settings.olderThanDays}d`;
+  }
+
   try {
     const result = await main(args, { env });
     stdout.write(JSON.stringify(result) + "\n");
@@ -433,4 +500,4 @@ if (isDirectCliRun(import.meta.url)) {
   });
 }
 
-export { main, parseCliArgs, parseDuration, selectArchivable };
+export { main, parseCliArgs, parseDuration, selectArchivable, resolveSettings, runCli };

--- a/scripts/projects/archive-done-items.mjs
+++ b/scripts/projects/archive-done-items.mjs
@@ -352,6 +352,9 @@ function normalizeItem(node) {
 function selectArchivable(items, { now, olderThanMs }) {
   return items.filter((it) => {
     if (it.isArchived) return false;
+    // Only archive items in the Done column — a closed issue/PR parked in
+    // another column (Backlog/Next Up/In Progress) must be left untouched.
+    if (it.status !== "Done") return false;
     const c = it.content;
     if (!c || !c.closed || !c.closedAt) return false;
     const closedAtMs = Date.parse(c.closedAt);

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -362,6 +362,16 @@ node <resolved-skill-scripts>/loop/checkpoint-contract.mjs --state skipped --rea
 
 Do not report completion or advance to the next PR queue item until `.pi/dev-loop-retrospective-checkpoint.json` is updated to `complete` or `skipped`.
 
+### Post-merge board archive (best-effort)
+
+After the retrospective checkpoint write, optionally tidy the queue board locally:
+
+```sh
+node <resolved-skill-scripts>/projects/archive-done-items.mjs --repo <owner/name>
+```
+
+Board and threshold resolve from `.devloops` (`queue.projectNumber`/`queue.boardTitle`, `queue.archiveOlderThanDays`, default 7d), using local `gh` auth — no CI, cron, or PAT. This step is best-effort and NON-FATAL: ignore any failure and never let it block the merge or the retrospective.
+
 ## Validation policy
 
 Follow [Validation Policy](../docs/validation-policy.md). Default: `npm run verify` before PR creation, gate entry, and merge. For repo-local examples: `npm run test:dev-loop` for skill scripts, contract tests for templates, `git diff --check` for docs. When CI runs exist, use `gh run watch` or `detect-copilot-loop-state.mjs` instead of `sleep`-based polling. Distinguish: locally validated, full PR-equivalent checks, awaiting CI.

--- a/test/projects/archive-done-items.test.mjs
+++ b/test/projects/archive-done-items.test.mjs
@@ -89,6 +89,14 @@ describe("archive-done — selectArchivable", () => {
     assert.strictEqual(selected.length, 0);
   });
 
+  it("excludes closed items that are not in the Done column", () => {
+    const items = [
+      item("D", { number: 4, closed: true, closedAt: new Date(now - 40 * 86400000).toISOString(), status: "Backlog" }),
+      item("E", { number: 5, closed: true, closedAt: new Date(now - 40 * 86400000).toISOString(), status: "In Progress" }),
+    ];
+    const selected = selectArchivable(items, { now, olderThanMs });
+    assert.strictEqual(selected.length, 0);
+  });
   it("excludes already-archived items", () => {
     const items = [
       { ...item("D", { number: 4, closed: true, closedAt: "2026-01-01T00:00:00Z" }), isArchived: true },

--- a/test/projects/archive-done-items.test.mjs
+++ b/test/projects/archive-done-items.test.mjs
@@ -5,6 +5,7 @@ import {
   parseCliArgs,
   parseDuration,
   selectArchivable,
+  resolveSettings,
 } from "../../scripts/projects/archive-done-items.mjs";
 
 // ── Pure unit: parseCliArgs ───────────────────────────────────────────────
@@ -205,7 +206,7 @@ describe("archive-done — integration", () => {
     assert.strictEqual(result.archivable, 1);
   });
 
-  it("defaults to 30d when --older-than is omitted", async () => {
+  it("defaults to 7d when --older-than is omitted and no config default applies", async () => {
     const nodes = [rawItemNode("A", 1, { closed: true, closedAt: "2026-06-23T00:00:00Z" })]; // 1d ago
     const responses = [
       { payload: userPayload() },
@@ -221,6 +222,131 @@ describe("archive-done — integration", () => {
 
     assert.ok(result.ok);
     assert.strictEqual(result.archived.length, 0);
-    assert.strictEqual(result.olderThan, "30d");
+    assert.strictEqual(result.olderThan, "7d");
+  });
+
+  it("uses olderThanDefault (from .devloops) when --older-than is omitted", async () => {
+    // closedAt 5d ago: archived under a 3d config default, kept under default 7d.
+    const nodes = [rawItemNode("A", 1, { closed: true, closedAt: "2026-06-19T00:00:00Z" })];
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([PROJECT]) },
+      { payload: itemsResponse(nodes) },
+      { payload: archiveResponse("A") },
+    ];
+    const runChild = mockRunChild(responses);
+
+    const result = await main(
+      { repo: "mfittko/dev-loops", project: "1", olderThanDefault: "3d", now: Date.parse("2026-06-24T00:00:00Z") },
+      { runChild },
+    );
+
+    assert.ok(result.ok);
+    assert.strictEqual(result.olderThan, "3d");
+    assert.strictEqual(result.archived.length, 1);
+  });
+
+  it("explicit --older-than overrides the config default", async () => {
+    const nodes = [rawItemNode("A", 1, { closed: true, closedAt: "2026-06-19T00:00:00Z" })]; // 5d ago
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([PROJECT]) },
+      { payload: itemsResponse(nodes) },
+    ];
+    const runChild = mockRunChild(responses);
+
+    const result = await main(
+      // explicit 7d wins over config default 3d → 5d-old item is kept
+      { repo: "mfittko/dev-loops", project: "1", olderThan: "7d", olderThanDefault: "3d", now: Date.parse("2026-06-24T00:00:00Z") },
+      { runChild },
+    );
+
+    assert.ok(result.ok);
+    assert.strictEqual(result.olderThan, "7d");
+    assert.strictEqual(result.archived.length, 0);
+  });
+
+  it("resolves the board by title when --project is omitted (projectTitle)", async () => {
+    const nodes = [rawItemNode("A", 1, { closed: true, closedAt: "2026-01-01T00:00:00Z" })];
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([PROJECT]) },
+      { payload: itemsResponse(nodes) },
+      { payload: archiveResponse("A") },
+    ];
+    const runChild = mockRunChild(responses);
+
+    const result = await main(
+      { repo: "mfittko/dev-loops", projectTitle: "Dev Loop Queue", olderThan: "30d", now: Date.parse("2026-06-24T00:00:00Z") },
+      { runChild },
+    );
+
+    assert.ok(result.ok);
+    assert.strictEqual(result.archived.length, 1);
+    assert.strictEqual(result.archived[0].itemId, "A");
+  });
+
+  it("fails closed when neither --project nor a configured board resolves", async () => {
+    const runChild = mockRunChild([]);
+    await assert.rejects(
+      () => main({ repo: "mfittko/dev-loops", now: Date.parse("2026-06-24T00:00:00Z") }, { runChild }),
+      (e) => e.code === "INVALID_PROJECT",
+    );
+  });
+});
+
+// ── resolveSettings (config-driven defaults) ──────────────────────────────
+
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import nodePath from "node:path";
+
+function withTempDevloops(contents, fn) {
+  const dir = mkdtempSync(nodePath.join(tmpdir(), "archive-done-cfg-"));
+  try {
+    if (contents !== null) writeFileSync(nodePath.join(dir, ".devloops"), contents, "utf-8");
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("archive-done — resolveSettings", () => {
+  it("returns null when no .devloops is present (default threshold/board apply)", () => {
+    withTempDevloops(null, (dir) => {
+      assert.strictEqual(resolveSettings(dir), null);
+    });
+  });
+
+  it("reads archiveOlderThanDays and boardTitle from queue", () => {
+    withTempDevloops(
+      "queue:\n  boardTitle: \"dev-loops Queue\"\n  archiveOlderThanDays: 14\n",
+      (dir) => {
+        const s = resolveSettings(dir);
+        assert.strictEqual(s.title, "dev-loops Queue");
+        assert.strictEqual(s.olderThanDays, 14);
+      },
+    );
+  });
+
+  it("prefers projectNumber over boardTitle for board resolution", () => {
+    withTempDevloops(
+      "queue:\n  projectNumber: 5\n  boardTitle: \"ignored\"\n",
+      (dir) => {
+        const s = resolveSettings(dir);
+        assert.strictEqual(s.project, 5);
+        assert.strictEqual(s.title, undefined);
+      },
+    );
+  });
+
+  it("ignores a non-positive archiveOlderThanDays", () => {
+    withTempDevloops(
+      "queue:\n  boardTitle: \"b\"\n  archiveOlderThanDays: 0\n",
+      (dir) => {
+        const s = resolveSettings(dir);
+        assert.strictEqual(s.olderThanDays, undefined);
+      },
+    );
   });
 });


### PR DESCRIPTION
## Summary

Make the dev-loop queue board self-clean as a **local after-merge step** — not CI/cron, no PAT. After a PR merges, the dev-loop post-merge step archives `Done` board items older than a configurable threshold (default 7 days) using the operator's existing local `gh` auth. The manual `dev-loops project archive-done` CLI stays available on-demand.

> Corrected from an earlier CI-cron framing: GitHub Actions can't write user-owned Projects V2 with `GITHUB_TOKEN` and can't do interactive `gh auth login`, so this runs locally off the existing login.

## Changes

- `scripts/projects/archive-done-items.mjs`: threshold default resolves `--older-than` > `.devloops queue.archiveOlderThanDays` > `7d`; board resolves from `.devloops` (`queue.projectNumber`/`boardTitle`) when `--project` is omitted. `archiveProjectV2Item` semantics, output JSON, error codes, exit codes unchanged.
- `.devloops`: `queue.archiveOlderThanDays: 7`; config schema (`QueueConfig`) accepts the key.
- `skills/copilot-pr-followup/SKILL.md`: best-effort, **non-fatal** post-merge archive step (a failure never blocks merge/retrospective); `.claude` mirror regenerated.

## Acceptance criteria

- [x] Dev-loop post-merge step archives Done items older than the configured threshold via local `gh` auth, after the retrospective checkpoint, best-effort/non-fatal.
- [x] Threshold defaults to 7d, configurable via `.devloops queue.archiveOlderThanDays`; board resolved from `.devloops`.
- [x] Only `Done` items archived (recoverable), never deleted.
- [x] On-demand `dev-loops project archive-done` still works.
- [x] No GitHub Actions / cron / PAT introduced.
- [x] `.claude` regenerated; `npm run verify` green (archive-done tests: 24 pass).

Closes #869
