### PR TITLE
feat(gates): record execution mode + opt-in fan-out evidence enforcement (#867 Phase 1)

### DIFF
--- a/.claude/skills/copilot-pr-followup/SKILL.md
+++ b/.claude/skills/copilot-pr-followup/SKILL.md
@@ -262,6 +262,8 @@ node <resolved-skill-scripts>/github/upsert-checkpoint-verdict.mjs \
   --next-action "<next action>" --findings-severity-counts '{"must-fix":0,"worth-fixing-now":0,"defer":0}'
 ```
 
+`--execution-mode <fanout_fanin|inline_single_agent>` records how the gate review ran (default `inline_single_agent`). When the gate did not run via the fan-out/fan-in sub-loop ([Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md)), you MUST pass `--execution-mode inline_single_agent --inline-reason "<why>"` — silent inline runs are no longer allowed, and inline mode emits a stderr warning. The recorded `executionMode` is surfaced by `detect-checkpoint-evidence.mjs` and gated by `gates.requireFanoutEvidence`.
+
 Do NOT use `gh pr comment`, `gh api`, or `gh pr review` for gate comments.
 
 `--force --force-reason` on `upsert-checkpoint-verdict.mjs` is a narrow operator-authorized CI override for the helper itself, not the default gate path. Use it only when the helper refuses gate entry solely because the current head is `blocked_needs_user_decision` with `ciStatus="failure"`, and only after the user explicitly authorizes ignoring that current-head CI failure for this one gate-comment upsert. It does **not** bypass stale-head checks, unresolved-thread / unsettled-review refusal, non-draft `draft_gate` refusal, merge conflicts, or other legality checks.

--- a/.claude/skills/copilot-pr-followup/SKILL.md
+++ b/.claude/skills/copilot-pr-followup/SKILL.md
@@ -251,6 +251,8 @@ Do not treat `fix applied locally` as the end of the loop when the workflow also
 
 For every `draft_gate` or `pre_approval_gate` comment, you MUST run:
 
+For a gate that ran via the fan-out/fan-in sub-loop:
+
 ```sh
 node <resolved-skill-scripts>/github/upsert-checkpoint-verdict.mjs \
   --repo <owner/name> \
@@ -259,10 +261,25 @@ node <resolved-skill-scripts>/github/upsert-checkpoint-verdict.mjs \
   --head-sha <current_head_sha> \
   --verdict <clean|findings_present|blocked> \
   --findings-summary "<summary>" \
-  --next-action "<next action>" --findings-severity-counts '{"must-fix":0,"worth-fixing-now":0,"defer":0}'
+  --next-action "<next action>" --findings-severity-counts '{"must-fix":0,"worth-fixing-now":0,"defer":0}' \
+  --execution-mode fanout_fanin
 ```
 
-`--execution-mode <fanout_fanin|inline_single_agent>` records how the gate review ran (default `inline_single_agent`). When the gate did not run via the fan-out/fan-in sub-loop ([Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md)), you MUST pass `--execution-mode inline_single_agent --inline-reason "<why>"` — silent inline runs are no longer allowed, and inline mode emits a stderr warning. The recorded `executionMode` is surfaced by `detect-checkpoint-evidence.mjs` and gated by `gates.requireFanoutEvidence`.
+For a gate that ran inline (single agent, not via the sub-loop):
+
+```sh
+node <resolved-skill-scripts>/github/upsert-checkpoint-verdict.mjs \
+  --repo <owner/name> \
+  --pr <number> \
+  --gate <draft_gate|pre_approval_gate> \
+  --head-sha <current_head_sha> \
+  --verdict <clean|findings_present|blocked> \
+  --findings-summary "<summary>" \
+  --next-action "<next action>" --findings-severity-counts '{"must-fix":0,"worth-fixing-now":0,"defer":0}' \
+  --execution-mode inline_single_agent --inline-reason "<why>"
+```
+
+`--execution-mode <fanout_fanin|inline_single_agent>` records how the gate review ran (default `inline_single_agent`). When the gate did not run via the fan-out/fan-in sub-loop ([Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md)), you MUST pass `--execution-mode inline_single_agent --inline-reason "<why>"` — silent inline runs are no longer allowed: inline mode requires a non-empty `--inline-reason` and emits a stderr warning. Because inline is the default mode, a bare call with neither flag now fails with an argument error, so always pass `--execution-mode` explicitly (and `--inline-reason` for inline). The recorded `executionMode` is surfaced by `detect-checkpoint-evidence.mjs` and gated by `gates.requireFanoutEvidence`.
 
 Do NOT use `gh pr comment`, `gh api`, or `gh pr review` for gate comments.
 

--- a/.devloops
+++ b/.devloops
@@ -10,6 +10,11 @@ refinement:
   maxCopilotRounds: 2
 
 gates:
+  # Opt-in fail-closed enforcement that gate verdicts were produced by the
+  # fan-out/fan-in review sub-loop (executionMode fanout_fanin + a findings-log
+  # ledger), not an inline single-agent run. Phases 2-3 (live fan-out + dynamic
+  # angle resolution) are the follow-up that makes fanout_fanin producible.
+  requireFanoutEvidence: false
   draft:
     angles:
       - scope

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -184,6 +184,11 @@ The log is written under `tmp/gate-findings/<repo-slug>/pr-<N>/<gate>-<headSha>.
 Each log entry records the full disposition: severity, angle, summary, affected files, and
 resolved-in SHA (for findings resolved in a later pass).
 
+## Execution mode and fan-out evidence enforcement
+
+Each gate verdict records an `executionMode` (`fanout_fanin` or `inline_single_agent`,
+default `inline_single_agent`) via the [Gate comment command](../skills/copilot-pr-followup/SKILL.md#mandatory-gate-comment-command-contract); inline runs must declare an `--inline-reason`. The opt-in `gates.requireFanoutEvidence` config (default `false`) makes the pre-merge evidence check fail closed for a required gate unless its recorded `executionMode` is `fanout_fanin` and a findings-log ledger exists for that gate + head SHA. Phases 2-3 — live context-builder/fan-out execution and dynamic angle resolution — are the follow-up that makes `fanout_fanin` producible.
+
 ## See also
 
 - [Checkpoint Verdict Comment Contract](./gate-review-comment-contract.md) — visible PR comment evidence format

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -53,6 +53,11 @@ const GatesConfig = z.strictObject({
   // `requireCi` is only behaviorally configurable for the draft gate.
   // preApproval always requires CI even if config repeats `requireCi`.
   preApproval: GateConfig.optional(),
+  // Opt-in fail-closed enforcement that a gate verdict was produced by the
+  // fan-out/fan-in review sub-loop (executionMode === "fanout_fanin" plus a
+  // durable findings-log ledger), not an inline single-agent run. Default
+  // false preserves current behavior. See docs/gate-review-sub-loop-contract.md.
+  requireFanoutEvidence: z.boolean().default(false),
 });
 
 const AutonomyConfig = z.strictObject({
@@ -107,6 +112,7 @@ const FileGateConfig = GateConfig.partial();
 const FileGatesConfig = z.strictObject({
   draft: FileGateConfig.optional(),
   preApproval: FileGateConfig.optional(),
+  requireFanoutEvidence: z.boolean().optional(),
 });
 
 // Partial persona entries for file-level config (allows omitting fields)
@@ -813,6 +819,21 @@ export function resolveGateConfig(config, gate) {
       ? [...gateConfig.blockCleanOnFindingSeverities]
       : ["must-fix"],
   };
+}
+
+/**
+ * Resolve whether fan-out/fan-in review evidence is required for a gate verdict.
+ *
+ * Opt-in, defaults to false. When true, the pre-merge evidence check fails
+ * closed unless a required gate's recorded executionMode is "fanout_fanin" and
+ * a durable findings-log ledger exists for that gate + head SHA. See
+ * docs/gate-review-sub-loop-contract.md.
+ *
+ * @param {DevLoopConfig} config
+ * @returns {boolean}
+ */
+export function resolveRequireFanoutEvidence(config) {
+  return config?.gates?.requireFanoutEvidence === true;
 }
 
 /**

--- a/packages/core/src/github/copilot-helpers.mjs
+++ b/packages/core/src/github/copilot-helpers.mjs
@@ -9,6 +9,7 @@
 const SUBMITTED_REVIEW_STATES = new Set(["APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED"]);
 const GATE_REVIEW_NAMES = new Set(["draft_gate", "pre_approval_gate"]);
 const GATE_REVIEW_VERDICTS = new Set(["clean", "findings_present", "blocked"]);
+const GATE_EXECUTION_MODES = new Set(["fanout_fanin", "inline_single_agent"]);
 
 export function isCopilotLogin(login) {
   return typeof login === "string" && /^copilot(?:[^a-z]|$)/i.test(login);
@@ -63,6 +64,11 @@ function normalizeGateReviewHeadSha(value) {
   return /^[0-9a-f]{7,64}$/i.test(normalized) ? normalized : null;
 }
 
+function normalizeGateExecutionMode(value) {
+  const normalized = stripOptionalCodeTicks(value).toLowerCase();
+  return GATE_EXECUTION_MODES.has(normalized) ? normalized : null;
+}
+
 function parseGateReviewCommentFields(body) {
   if (typeof body !== "string" || body.trim().length === 0) {
     return null;
@@ -74,6 +80,8 @@ function parseGateReviewCommentFields(body) {
     verdict: null,
     findingsSummary: null,
     nextAction: null,
+    executionMode: null,
+    inlineReason: null,
   };
 
   for (const rawLine of body.split(/\r?\n/u)) {
@@ -110,6 +118,21 @@ function parseGateReviewCommentFields(body) {
     match = line.match(/^(?:[-*]\s*)?next\s+action\s*:\s*(.+)$/iu);
     if (match) {
       fields.nextAction = match[1].trim();
+      continue;
+    }
+
+    match = line.match(/^(?:[-*]\s*)?execution\s+mode\s*:\s*(.+)$/iu);
+    if (match) {
+      const rest = match[1].trim();
+      // Split on the first em-dash / en-dash / " - " separator to recover an
+      // optional inline reason: "inline_single_agent — <reason>".
+      const sepMatch = rest.match(/^(.*?)\s*(?:[—–]|\s-\s)\s*(.*)$/u);
+      const modeToken = sepMatch ? sepMatch[1].trim() : rest;
+      const reasonToken = sepMatch ? sepMatch[2].trim() : "";
+      fields.executionMode = normalizeGateExecutionMode(modeToken);
+      if (reasonToken.length > 0) {
+        fields.inlineReason = reasonToken;
+      }
       continue;
     }
   }
@@ -178,6 +201,8 @@ export function parseGateReviewCommentMarkerBody(body) {
     verdict: fields.verdict,
     findingsSummary: fields.findingsSummary,
     nextAction: fields.nextAction,
+    executionMode: fields.executionMode,
+    inlineReason: fields.inlineReason,
     contractComplete: Boolean(fields.verdict && fields.findingsSummary && fields.nextAction),
   };
 }
@@ -253,6 +278,8 @@ export function summarizeGateReviewCommentMarkers(comments, { headSha } = {}) {
       verdict: parsed.verdict,
       findingsSummary: parsed.findingsSummary,
       nextAction: parsed.nextAction,
+      executionMode: parsed.executionMode ?? null,
+      inlineReason: parsed.inlineReason ?? null,
       contractComplete: parsed.contractComplete,
       commentId: Number.isInteger(comment?.id) ? comment.id : null,
       commentUrl: typeof comment?.html_url === "string" && comment.html_url.trim().length > 0 ? comment.html_url.trim() : null,

--- a/packages/core/src/github/copilot-helpers.mjs
+++ b/packages/core/src/github/copilot-helpers.mjs
@@ -230,6 +230,8 @@ export function summarizeGateReviewComments(comments) {
       verdict: parsed.verdict,
       findingsSummary: parsed.findingsSummary,
       nextAction: parsed.nextAction,
+      executionMode: parsed.executionMode ?? null,
+      inlineReason: parsed.inlineReason ?? null,
       commentId: Number.isInteger(comment?.id) ? comment.id : null,
       commentUrl: typeof comment?.html_url === "string" && comment.html_url.trim().length > 0 ? comment.html_url.trim() : null,
       updatedAt: typeof (comment?.updated_at ?? comment?.updatedAt) === "string"

--- a/packages/core/src/github/copilot-helpers.mjs
+++ b/packages/core/src/github/copilot-helpers.mjs
@@ -130,7 +130,10 @@ function parseGateReviewCommentFields(body) {
       const modeToken = sepMatch ? sepMatch[1].trim() : rest;
       const reasonToken = sepMatch ? sepMatch[2].trim() : "";
       fields.executionMode = normalizeGateExecutionMode(modeToken);
-      if (reasonToken.length > 0) {
+      // Only record an inline reason for inline_single_agent. A trailing
+      // "— text" on a fanout_fanin (or invalid) mode line must not surface an
+      // inconsistent mode/reason pair, so leave inlineReason null otherwise.
+      if (reasonToken.length > 0 && fields.executionMode === "inline_single_agent") {
         fields.inlineReason = reasonToken;
       }
       continue;

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -380,6 +380,30 @@ describe("loader — graceful degradation", () => {
     }
   });
 
+  test("L1-validation: invalid .devloops returns non-empty errors without throwing", async () => {
+    // FIX C: loadDevLoopConfig never throws on a validation failure. Callers that
+    // previously wrapped it in try/catch expecting a throw must instead treat a
+    // non-empty errors array as "config unavailable".
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-invalid-"));
+    try {
+      // gates.requireFanoutEvidence must be a boolean; a string value fails schema validation.
+      await writeFile(
+        path.join(tmpDir, ".devloops"),
+        "version: 1\ngates:\n  requireFanoutEvidence: \"yes\"\n",
+      );
+      const { loadDevLoopConfig } = await import("../src/config/config.mjs");
+      let result;
+      await assert.doesNotReject(async () => {
+        result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      });
+      assert.ok(Array.isArray(result.errors) && result.errors.length > 0, "validation failure should populate errors");
+      // config object is still returned (merged), so callers can inspect errors and decide.
+      assert.ok(result.config);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   test("L1b: a plain consumer (no .devloops) defaults the retrospective gate OFF (#841)", async () => {
     // The retrospective is a dev-loop-development artifact; shipped defaults must be permissive so
     // an ordinary consumer's product PRs do not carry the meta-process gate. extension-defaults

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -20,6 +20,7 @@ import {
   resolveGateAnglesDynamic,
   resolveWorkflowConfig,
   resolveLightMode,
+  resolveRequireFanoutEvidence,
 } from "../src/config/config.mjs";
 // ============================================================================
 // Schema validation tests (S1–S26)
@@ -2651,4 +2652,30 @@ describe("resolveGateAnglesDynamic", () => {
     assert.ok(result.recommendedAngles.includes("pr-description"));
   });
 
+});
+
+describe("gates.requireFanoutEvidence", () => {
+  test("defaults to false and resolveRequireFanoutEvidence reflects it", () => {
+    assert.equal(resolveRequireFanoutEvidence({}), false);
+    assert.equal(resolveRequireFanoutEvidence({ gates: {} }), false);
+    const parsed = DevLoopConfigSchema.safeParse({ version: 1, gates: { draft: {} } });
+    assert.equal(parsed.success, true);
+    assert.equal(parsed.data.gates.requireFanoutEvidence, false);
+  });
+
+  test("accepts requireFanoutEvidence: true in full and file schemas", () => {
+    const full = DevLoopConfigSchema.safeParse({ version: 1, gates: { requireFanoutEvidence: true } });
+    assert.equal(full.success, true);
+    assert.equal(full.data.gates.requireFanoutEvidence, true);
+    assert.equal(resolveRequireFanoutEvidence(full.data), true);
+
+    const file = FileConfigSchema.safeParse({ version: 1, gates: { requireFanoutEvidence: true } });
+    assert.equal(file.success, true);
+    assert.equal(file.data.gates.requireFanoutEvidence, true);
+  });
+
+  test("rejects non-boolean requireFanoutEvidence", () => {
+    const bad = DevLoopConfigSchema.safeParse({ version: 1, gates: { requireFanoutEvidence: "yes" } });
+    assert.equal(bad.success, false);
+  });
 });

--- a/packages/core/test/copilot-helpers.test.mjs
+++ b/packages/core/test/copilot-helpers.test.mjs
@@ -112,6 +112,54 @@ test("parseGateReviewCommentMarkerBody parses partial new-format markers", () =>
 });
 
 
+test("parseGateReviewCommentMarkerBody round-trips executionMode and inlineReason", () => {
+  const inlineBody = [
+    "### Gate review: `draft_gate`",
+    "",
+    "**Reviewed head SHA:** `abc1234`",
+    "**Verdict:** clean",
+    "**Execution mode:** inline_single_agent — small docs-only change",
+    "",
+    "**Findings summary:** no issues found",
+    "",
+    "**Next action:** mark ready for review",
+  ].join("\n");
+  const inline = parseGateReviewCommentMarkerBody(inlineBody);
+  assert.equal(inline.executionMode, "inline_single_agent");
+  assert.equal(inline.inlineReason, "small docs-only change");
+
+  const fanoutBody = inlineBody.replace("inline_single_agent — small docs-only change", "fanout_fanin");
+  const fanout = parseGateReviewCommentMarkerBody(fanoutBody);
+  assert.equal(fanout.executionMode, "fanout_fanin");
+  assert.equal(fanout.inlineReason, null);
+
+  // Markers without an execution-mode line surface null (back-compat).
+  const legacyBody = inlineBody.replace("**Execution mode:** inline_single_agent — small docs-only change\n", "");
+  const legacy = parseGateReviewCommentMarkerBody(legacyBody);
+  assert.equal(legacy.executionMode, null);
+  assert.equal(legacy.inlineReason, null);
+});
+
+test("summarizeGateReviewCommentMarkers surfaces executionMode and inlineReason per gate", () => {
+  const comments = [
+    {
+      id: 7,
+      updated_at: "2024-02-01T00:00:00Z",
+      body: [
+        "### Gate review: `draft_gate`",
+        "**Reviewed head SHA:** `abc1234`",
+        "**Verdict:** clean",
+        "**Execution mode:** inline_single_agent — quick fix",
+        "**Findings summary:** none",
+        "**Next action:** ready",
+      ].join("\n"),
+    },
+  ];
+  const summary = summarizeGateReviewCommentMarkers(comments, { headSha: "abc1234" });
+  assert.equal(summary.draft_gate.executionMode, "inline_single_agent");
+  assert.equal(summary.draft_gate.inlineReason, "quick fix");
+});
+
 test("summarizeGateReviewComments picks the most-recently-updated entry per gate", () => {
   const comments = [
     {

--- a/packages/core/test/copilot-helpers.test.mjs
+++ b/packages/core/test/copilot-helpers.test.mjs
@@ -180,6 +180,39 @@ test("summarizeGateReviewComments picks the most-recently-updated entry per gate
   assert.equal(summary.pre_approval_gate, null);
 });
 
+test("summarizeGateReviewComments surfaces executionMode and inlineReason on the strict summary", () => {
+  const comments = [
+    {
+      body: [
+        "### Gate review: `draft_gate`",
+        "**Reviewed head SHA:** `abc1234`",
+        "**Verdict:** clean",
+        "**Execution mode:** inline_single_agent — small docs-only change",
+        "**Findings summary:** no issues found",
+        "**Next action:** mark ready for review",
+      ].join("\n"),
+      id: 7,
+    },
+  ];
+
+  const summary = summarizeGateReviewComments(comments);
+  assert.equal(summary.draft_gate?.executionMode, "inline_single_agent");
+  assert.equal(summary.draft_gate?.inlineReason, "small docs-only change");
+});
+
+test("summarizeGateReviewComments defaults executionMode and inlineReason to null when absent", () => {
+  const comments = [
+    {
+      body: "gate: draft_gate\nhead sha reviewed: aaa1111\nverdict: clean\nfindings summary: ok\nnext action: mark ready for review",
+      id: 9,
+    },
+  ];
+
+  const summary = summarizeGateReviewComments(comments);
+  assert.equal(summary.draft_gate?.executionMode, null);
+  assert.equal(summary.draft_gate?.inlineReason, null);
+});
+
 test("summarizeGateReviewCommentMarkers filters by headSha when provided", () => {
   const comments = [
     {

--- a/packages/core/test/copilot-helpers.test.mjs
+++ b/packages/core/test/copilot-helpers.test.mjs
@@ -140,6 +140,32 @@ test("parseGateReviewCommentMarkerBody round-trips executionMode and inlineReaso
   assert.equal(legacy.inlineReason, null);
 });
 
+test("parseGateReviewCommentMarkerBody only records inlineReason for inline_single_agent", () => {
+  const baseBody = (modeLine) => [
+    "### Gate review: `draft_gate`",
+    "",
+    "**Reviewed head SHA:** `abc1234`",
+    "**Verdict:** clean",
+    `**Execution mode:** ${modeLine}`,
+    "",
+    "**Findings summary:** no issues found",
+    "",
+    "**Next action:** mark ready for review",
+  ].join("\n");
+
+  // A fanout_fanin line with a trailing "— text" must NOT yield an inlineReason:
+  // the mode/reason pair would otherwise be inconsistent.
+  const fanout = parseGateReviewCommentMarkerBody(baseBody("fanout_fanin — ran the full sub-loop"));
+  assert.equal(fanout.executionMode, "fanout_fanin");
+  assert.equal(fanout.inlineReason, null);
+
+  // An invalid mode token with a trailing dash + text must also leave both
+  // fields clean (executionMode null, no inline reason leaking through).
+  const invalid = parseGateReviewCommentMarkerBody(baseBody("bogus_mode — some note"));
+  assert.equal(invalid.executionMode, null);
+  assert.equal(invalid.inlineReason, null);
+});
+
 test("summarizeGateReviewCommentMarkers surfaces executionMode and inlineReason per gate", () => {
   const comments = [
     {

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -9,9 +9,13 @@ import {
   summarizeGateReviewCommentMarkers,
   summarizeGateReviewComments,
 } from "../_core-helpers.mjs";
+import { access } from "node:fs/promises";
+import path from "node:path";
 import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
+import { loadDevLoopConfig, resolveGateConfig, resolveRequireFanoutEvidence } from "@dev-loops/core/config";
+import { buildLogPath } from "./write-gate-findings-log.mjs";
 import { ensureAsyncRunnerOwnership } from "../loop/_pr-runner-coordination.mjs";
 import { detectStaleRunner } from "../loop/_stale-runner-detection.mjs";
 const USAGE = `Usage: detect-checkpoint-evidence.mjs --repo <owner/name> --pr <number>
@@ -200,6 +204,8 @@ function emptyGateMarkerSummary() {
     verdict: null,
     findingsSummary: null,
     nextAction: null,
+    executionMode: null,
+    inlineReason: null,
     contractComplete: false,
     commentId: null,
     commentUrl: null,
@@ -216,13 +222,15 @@ function normalizeGateMarkerSummary(summary) {
     verdict: summary.verdict,
     findingsSummary: summary.findingsSummary,
     nextAction: summary.nextAction,
+    executionMode: summary.executionMode ?? null,
+    inlineReason: summary.inlineReason ?? null,
     contractComplete: summary.contractComplete === true,
     commentId: summary.commentId,
     commentUrl: summary.commentUrl,
     updatedAt: summary.updatedAt,
   };
 }
-export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null, staleRunnerCheck = null) {
+export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null, staleRunnerCheck = null, fanoutEnforcement = null) {
   const failures = [];
   if (!(evidence.draftGate.visible && evidence.draftGate.verdict === "clean")) {
     failures.push("missing visible clean draft_gate comment");
@@ -235,6 +243,24 @@ export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null, s
     && preApproval.headSha === evidence.currentHeadSha
   )) {
     failures.push("missing visible clean current-head pre_approval_gate comment");
+  }
+  // Opt-in fail-closed fan-out evidence enforcement (gates.requireFanoutEvidence).
+  // When disabled (default), fanoutEnforcement is null and this block is skipped,
+  // preserving current behavior.
+  if (fanoutEnforcement && fanoutEnforcement.required) {
+    for (const gate of fanoutEnforcement.gates) {
+      if (gate.executionMode !== "fanout_fanin") {
+        failures.push(
+          `${gate.name}: requireFanoutEvidence is enabled but executionMode is "${gate.executionMode ?? "unset"}" (expected "fanout_fanin"); inline gate verdicts are not accepted`,
+        );
+        continue;
+      }
+      if (!gate.ledgerExists) {
+        failures.push(
+          `${gate.name}: requireFanoutEvidence is enabled but no findings-log ledger exists for the reviewed head (${gate.ledgerPath})`,
+        );
+      }
+    }
   }
   if (typeof unresolvedThreadCount === "number" && unresolvedThreadCount !== 0) {
     if (unresolvedThreadCount === -1) {
@@ -252,6 +278,46 @@ export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null, s
     ok: failures.length === 0,
     failures,
   };
+}
+async function ledgerExists(fullPath) {
+  try {
+    await access(fullPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+/**
+ * Build the opt-in fan-out evidence enforcement descriptor.
+ *
+ * Returns { required: false } when gates.requireFanoutEvidence is disabled
+ * (default). When enabled, records per-required-gate executionMode and whether
+ * the deterministic findings-log ledger exists for the reviewed head SHA so the
+ * pre-merge check can fail closed on inline verdicts or missing ledgers.
+ */
+async function buildFanoutEnforcement({ repo, pr, currentHeadSha, draftGateMarker, preApprovalGateMarker, config, cwd }) {
+  if (!resolveRequireFanoutEvidence(config)) {
+    return { required: false, gates: [] };
+  }
+  const draftRequired = resolveGateConfig(config, "draft").required;
+  const preApprovalRequired = resolveGateConfig(config, "preApproval").required;
+  const gateSpecs = [
+    { name: "draft_gate", marker: draftGateMarker, required: draftRequired },
+    { name: "pre_approval_gate", marker: preApprovalGateMarker, required: preApprovalRequired },
+  ].filter((spec) => spec.required && spec.marker.visible);
+  const gates = [];
+  for (const spec of gateSpecs) {
+    const headSha = spec.marker.headSha ?? currentHeadSha;
+    const ledgerPath = buildLogPath({ repo, pr, gate: spec.name, headSha, tmpRoot: "tmp" });
+    const fullPath = path.resolve(cwd, ledgerPath);
+    gates.push({
+      name: spec.name,
+      executionMode: spec.marker.executionMode ?? null,
+      ledgerPath,
+      ledgerExists: await ledgerExists(fullPath),
+    });
+  }
+  return { required: true, gates };
 }
 export async function detectCheckpointEvidence(options, { env = process.env, ghCommand = "gh", cwd = process.cwd() } = {}) {
   const runnerOwnership = await ensureAsyncRunnerOwnership({
@@ -299,6 +365,25 @@ export async function detectCheckpointEvidence(options, { env = process.env, ghC
   const allComments = [...commentsPayload, ...prReviews];
   const commentSummary = summarizeGateReviewComments(allComments);
   const markerSummary = summarizeGateReviewCommentMarkers(allComments, { headSha: currentHeadSha });
+  const draftGateMarker = normalizeGateMarkerSummary(markerSummary.draft_gate);
+  const preApprovalGateMarker = normalizeGateMarkerSummary(markerSummary.pre_approval_gate);
+  let config = null;
+  try {
+    ({ config } = await loadDevLoopConfig({ repoRoot: cwd }));
+  } catch {
+    // Non-fatal: config load failure leaves fan-out enforcement disabled
+    // (preserves default behavior). Other gate checks remain unaffected.
+    config = null;
+  }
+  const fanoutEnforcement = await buildFanoutEnforcement({
+    repo: options.repo,
+    pr: options.pr,
+    currentHeadSha,
+    draftGateMarker,
+    preApprovalGateMarker,
+    config,
+    cwd,
+  });
   return {
     ok: true,
     repo: options.repo,
@@ -306,9 +391,10 @@ export async function detectCheckpointEvidence(options, { env = process.env, ghC
     currentHeadSha,
     draftGate: normalizeGateSummary(commentSummary.draft_gate),
     preApprovalGate: normalizeGateSummary(commentSummary.pre_approval_gate),
-    draftGateMarker: normalizeGateMarkerSummary(markerSummary.draft_gate),
-    preApprovalGateMarker: normalizeGateMarkerSummary(markerSummary.pre_approval_gate),
+    draftGateMarker,
+    preApprovalGateMarker,
     draftGateSatisfied: commentSummary.draft_gate?.verdict === "clean" && typeof commentSummary.draft_gate?.headSha === "string",
+    fanoutEnforcement,
     ...(runnerOwnership.status !== "skipped_no_async_run_id" ? { runnerOwnership } : {}),
     staleRunner: {
       status: staleRunnerDetection.status,
@@ -351,7 +437,7 @@ async function main() {
         ? [`exit signal recorded for run ${result.staleRunner.activeRun?.runId}: refuse to merge`]
         : [],
     };
-    const preMergeGateCheck = buildPreMergeGateCheck(result, unresolvedThreadCount, staleRunnerCheck);
+    const preMergeGateCheck = buildPreMergeGateCheck(result, unresolvedThreadCount, staleRunnerCheck, result.fanoutEnforcement);
     const output = { ...result, preMergeGateCheck, staleRunnerCheck };
     if (!preMergeGateCheck.ok) {
       process.stderr.write(`${JSON.stringify({

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -245,8 +245,8 @@ export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null, s
     failures.push("missing visible clean current-head pre_approval_gate comment");
   }
   // Opt-in fail-closed fan-out evidence enforcement (gates.requireFanoutEvidence).
-  // When disabled (default), fanoutEnforcement is null and this block is skipped,
-  // preserving current behavior.
+  // When disabled (default), fanoutEnforcement is { required: false, gates: [] }
+  // so the `.required` guard skips this block, preserving current behavior.
   if (fanoutEnforcement && fanoutEnforcement.required) {
     for (const gate of fanoutEnforcement.gates) {
       if (gate.executionMode !== "fanout_fanin") {

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -367,14 +367,13 @@ export async function detectCheckpointEvidence(options, { env = process.env, ghC
   const markerSummary = summarizeGateReviewCommentMarkers(allComments, { headSha: currentHeadSha });
   const draftGateMarker = normalizeGateMarkerSummary(markerSummary.draft_gate);
   const preApprovalGateMarker = normalizeGateMarkerSummary(markerSummary.pre_approval_gate);
+  // loadDevLoopConfig never throws: it returns { config, warnings, errors }.
+  // A non-empty errors array means the config could not be loaded/validated, so
+  // treat it as config-unavailable and leave fan-out enforcement disabled
+  // (preserves default behavior). Other gate checks remain unaffected.
   let config = null;
-  try {
-    ({ config } = await loadDevLoopConfig({ repoRoot: cwd }));
-  } catch {
-    // Non-fatal: config load failure leaves fan-out enforcement disabled
-    // (preserves default behavior). Other gate checks remain unaffected.
-    config = null;
-  }
+  const { config: loadedConfig, errors: configErrors } = await loadDevLoopConfig({ repoRoot: cwd });
+  config = Array.isArray(configErrors) && configErrors.length > 0 ? null : loadedConfig;
   const fanoutEnforcement = await buildFanoutEnforcement({
     repo: options.repo,
     pr: options.pr,

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -364,6 +364,16 @@ export function parseUpsertCheckpointVerdictCliArgs(argv) {
   if (missing.length > 0) {
     throw parseError("upsert-checkpoint-verdict requires --repo, --pr, --head-sha, --verdict, --findings-summary (or --findings-file), and --next-action");
   }
+  // Contract (skills/copilot-pr-followup/SKILL.md): inline runs MUST pass
+  // --inline-reason. Inline is the default mode, so a complete call that resolves
+  // to inline without a reason errors here. fanout_fanin does not require a
+  // reason. Checked after required-field validation so an incomplete call still
+  // reports the missing-field error first.
+  if (options.executionMode === "inline_single_agent" && options.inlineReason === undefined) {
+    throw parseError(
+      "--inline-reason is required for executionMode inline_single_agent (the default). Pass --execution-mode fanout_fanin for fan-out/fan-in runs, or --inline-reason \"<why>\" to record why the gate ran inline.",
+    );
+  }
   try {
     parseRepoSlug(options.repo);
   } catch (error) {
@@ -456,6 +466,7 @@ function summarizeExistingComment({ strict, marker, headSha }) {
       findingsSummary: markerSameHead.findingsSummary ?? null,
       nextAction: markerSameHead.nextAction ?? null,
       executionMode: markerSameHead.executionMode ?? null,
+      inlineReason: markerSameHead.inlineReason ?? null,
       contractComplete: markerSameHead.contractComplete === true,
     };
   }
@@ -468,6 +479,7 @@ function summarizeExistingComment({ strict, marker, headSha }) {
       findingsSummary: strictSameHead.findingsSummary,
       nextAction: strictSameHead.nextAction,
       executionMode: strictSameHead.executionMode ?? markerSameHead?.executionMode ?? null,
+      inlineReason: strictSameHead.inlineReason ?? markerSameHead?.inlineReason ?? null,
       contractComplete: true,
     };
   }
@@ -480,6 +492,7 @@ function summarizeExistingComment({ strict, marker, headSha }) {
       findingsSummary: markerSameHead.findingsSummary ?? null,
       nextAction: markerSameHead.nextAction ?? null,
       executionMode: markerSameHead.executionMode ?? null,
+      inlineReason: markerSameHead.inlineReason ?? null,
       contractComplete: markerSameHead.contractComplete === true,
     };
   }
@@ -662,6 +675,17 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
   const existing = summarizeExistingComment({ ...gateEvidence, headSha: canonicalHeadSha });
   const warning = detectStaleGateCommentWarning({ strict: gateEvidence.strict, headSha: canonicalHeadSha, gate: options.gate });
   const desiredExecutionMode = options.executionMode ?? DEFAULT_EXECUTION_MODE;
+  // inlineReason is only meaningful for inline mode and is dropped for
+  // fanout_fanin at parse time, so normalize both sides to null when the
+  // resolved mode is not inline. This makes the noop short-circuit fire only
+  // when verdict/summary/nextAction/executionMode AND the inline reason all
+  // match, so a changed/added --inline-reason forces a comment update.
+  const desiredInlineReason = desiredExecutionMode === "inline_single_agent"
+    ? (options.inlineReason ?? null)
+    : null;
+  const existingInlineReason = (existing?.executionMode ?? DEFAULT_EXECUTION_MODE) === "inline_single_agent"
+    ? (existing?.inlineReason ?? null)
+    : null;
   if (
     existing
     && existing.contractComplete
@@ -669,6 +693,7 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
     && existing.findingsSummary === effectiveFindingsSummary
     && existing.nextAction === options.nextAction
     && (existing.executionMode ?? DEFAULT_EXECUTION_MODE) === desiredExecutionMode
+    && existingInlineReason === desiredInlineReason
   ) {
     return {
       ok: true,
@@ -682,7 +707,7 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
       commentUrl: existing.commentUrl,
       blockCleanOnFindingSeverities: activeGateConfig.blockCleanOnFindingSeverities,
       executionMode: options.executionMode ?? DEFAULT_EXECUTION_MODE,
-      ...(options.inlineReason ? { inlineReason: options.inlineReason } : {}),
+      ...(existingInlineReason ? { inlineReason: existingInlineReason } : {}),
       ...(warning ? { warning } : {}),
     };
   }

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -56,9 +56,14 @@ Optional:
                                             Defaults to inline_single_agent. Inline
                                             runs (default or explicit) emit a stderr
                                             warning that the fan-out/fan-in sub-loop
-                                            was not run; pass --inline-reason "<why>".
-  --inline-reason <text>                    Short reason recorded when the gate ran
-                                            inline (executionMode inline_single_agent).
+                                            was not run and REQUIRE --inline-reason.
+  --inline-reason <text>                    REQUIRED when executionMode resolves to
+                                            inline_single_agent (the default mode):
+                                            short reason recorded for why the gate
+                                            ran inline. A bare call with neither
+                                            --execution-mode nor --inline-reason
+                                            errors. Optional and ignored (dropped)
+                                            for --execution-mode fanout_fanin.
 Output (stdout, JSON):
   {
     "ok": true,

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -15,6 +15,8 @@ import { detectStaleRunner } from "../loop/_stale-runner-detection.mjs";
 import { detectInternalOnly } from "../loop/detect-internal-only-pr.mjs";
 const GATE_NAMES = new Set(["draft_gate", "pre_approval_gate"]);
 const GATE_VERDICTS = new Set(["clean", "findings_present", "blocked"]);
+const GATE_EXECUTION_MODES = new Set(["fanout_fanin", "inline_single_agent"]);
+const DEFAULT_EXECUTION_MODE = "inline_single_agent";
 const MAX_GATE_COMMENT_TEXT_LENGTH = 2000;
 const MAX_GATE_COMMENT_EXCERPT_LENGTH = 120;
 const REMOVED_FLAGS = new Set([
@@ -49,6 +51,14 @@ Optional:
                                              (e.g. '{"must-fix":0,"worth-fixing-now":0}').
                                              Required for --verdict clean when
                                              blockCleanOnFindingSeverities is configured.
+  --execution-mode <fanout_fanin|inline_single_agent>
+                                            How the gate review was executed.
+                                            Defaults to inline_single_agent. Inline
+                                            runs (default or explicit) emit a stderr
+                                            warning that the fan-out/fan-in sub-loop
+                                            was not run; pass --inline-reason "<why>".
+  --inline-reason <text>                    Short reason recorded when the gate ran
+                                            inline (executionMode inline_single_agent).
 Output (stdout, JSON):
   {
     "ok": true,
@@ -86,6 +96,10 @@ function normalizeVerdict(value) {
 function normalizeHeadSha(value) {
   const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
   return /^[0-9a-f]{7,64}$/i.test(normalized) ? normalized : null;
+}
+function normalizeExecutionMode(value) {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  return GATE_EXECUTION_MODES.has(normalized) ? normalized : null;
 }
 function normalizeRequiredText(value, flag) {
   const normalized = typeof value === "string" ? value.trim() : "";
@@ -212,6 +226,8 @@ export function parseUpsertCheckpointVerdictCliArgs(argv) {
       "findings-file": { type: "string" },
       "next-action": { type: "string" },
       "findings-severity-counts": { type: "string" },
+      "execution-mode": { type: "string" },
+      "inline-reason": { type: "string" },
     },
     allowPositionals: true,
     strict: false,
@@ -228,6 +244,8 @@ export function parseUpsertCheckpointVerdictCliArgs(argv) {
     findingsFile: undefined,
     nextAction: undefined,
     findingsSeverityCounts: undefined,
+    executionMode: undefined,
+    inlineReason: undefined,
   };
   for (const token of tokens) {
     if (token.kind === "positional") {
@@ -312,7 +330,30 @@ export function parseUpsertCheckpointVerdictCliArgs(argv) {
       options.findingsSeverityCounts = counts;
       continue;
     }
+    if (token.name === "execution-mode") {
+      const mode = normalizeExecutionMode(requireTokenValue(token, parseError));
+      if (!mode) {
+        throw parseError("--execution-mode must be one of: fanout_fanin, inline_single_agent");
+      }
+      options.executionMode = mode;
+      continue;
+    }
+    if (token.name === "inline-reason") {
+      const reason = collapseWhitespace(requireTokenValue(token, parseError));
+      if (reason.length === 0) {
+        throw parseError("--inline-reason must be a non-empty string");
+      }
+      options.inlineReason = smartTruncate(reason, MAX_GATE_COMMENT_EXCERPT_LENGTH);
+      continue;
+    }
     throw parseError(`Unknown argument: ${token.rawName}`);
+  }
+  // Default execution mode to inline_single_agent when omitted. inlineReason is
+  // only meaningful for inline mode; drop it for fanout_fanin to avoid recording
+  // a misleading reason.
+  options.executionMode = options.executionMode ?? DEFAULT_EXECUTION_MODE;
+  if (options.executionMode !== "inline_single_agent") {
+    options.inlineReason = undefined;
   }
   const missing = ["repo", "pr", "headSha", "verdict", "findingsSummary", "nextAction"]
     .filter((key) => options[key] === undefined);
@@ -344,12 +385,23 @@ function appendGateEvidenceNote(summary, note) {
   }
   return smartTruncate(`${normalizedSummary}; ${normalizedNote}`, MAX_GATE_COMMENT_TEXT_LENGTH);
 }
-export function renderGateReviewCommentBody({ gate, headSha, verdict, findingsSummary, nextAction, blockCleanOnFindingSeverities }) {
+function renderExecutionModeLine(executionMode, inlineReason) {
+  const mode = executionMode ?? DEFAULT_EXECUTION_MODE;
+  if (mode === "inline_single_agent") {
+    const reason = typeof inlineReason === "string" ? collapseWhitespace(inlineReason) : "";
+    return reason.length > 0
+      ? `**Execution mode:** inline_single_agent — ${reason}`
+      : "**Execution mode:** inline_single_agent";
+  }
+  return `**Execution mode:** ${mode}`;
+}
+export function renderGateReviewCommentBody({ gate, headSha, verdict, findingsSummary, nextAction, blockCleanOnFindingSeverities, executionMode, inlineReason }) {
   const lines = [
     `### Gate review: \`${gate}\``,
     "",
     `**Reviewed head SHA:** \`${headSha}\``,
     `**Verdict:** ${verdict}`,
+    renderExecutionModeLine(executionMode, inlineReason),
   ];
   if ((verdict === "findings_present" || verdict === "blocked") && blockCleanOnFindingSeverities && blockCleanOnFindingSeverities.length > 0) {
     const sevs = blockCleanOnFindingSeverities.join(", ");
@@ -403,6 +455,7 @@ function summarizeExistingComment({ strict, marker, headSha }) {
       verdict: markerSameHead.verdict,
       findingsSummary: markerSameHead.findingsSummary ?? null,
       nextAction: markerSameHead.nextAction ?? null,
+      executionMode: markerSameHead.executionMode ?? null,
       contractComplete: markerSameHead.contractComplete === true,
     };
   }
@@ -414,6 +467,7 @@ function summarizeExistingComment({ strict, marker, headSha }) {
       verdict: strictSameHead.verdict,
       findingsSummary: strictSameHead.findingsSummary,
       nextAction: strictSameHead.nextAction,
+      executionMode: strictSameHead.executionMode ?? markerSameHead?.executionMode ?? null,
       contractComplete: true,
     };
   }
@@ -425,6 +479,7 @@ function summarizeExistingComment({ strict, marker, headSha }) {
       verdict: markerSameHead.verdict,
       findingsSummary: markerSameHead.findingsSummary ?? null,
       nextAction: markerSameHead.nextAction ?? null,
+      executionMode: markerSameHead.executionMode ?? null,
       contractComplete: markerSameHead.contractComplete === true,
     };
   }
@@ -606,12 +661,14 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
   const gateEvidence = selectGateEvidence(evidence, options.gate);
   const existing = summarizeExistingComment({ ...gateEvidence, headSha: canonicalHeadSha });
   const warning = detectStaleGateCommentWarning({ strict: gateEvidence.strict, headSha: canonicalHeadSha, gate: options.gate });
+  const desiredExecutionMode = options.executionMode ?? DEFAULT_EXECUTION_MODE;
   if (
     existing
     && existing.contractComplete
     && existing.verdict === options.verdict
     && existing.findingsSummary === effectiveFindingsSummary
     && existing.nextAction === options.nextAction
+    && (existing.executionMode ?? DEFAULT_EXECUTION_MODE) === desiredExecutionMode
   ) {
     return {
       ok: true,
@@ -624,6 +681,8 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
       commentId: existing.commentId,
       commentUrl: existing.commentUrl,
       blockCleanOnFindingSeverities: activeGateConfig.blockCleanOnFindingSeverities,
+      executionMode: options.executionMode ?? DEFAULT_EXECUTION_MODE,
+      ...(options.inlineReason ? { inlineReason: options.inlineReason } : {}),
       ...(warning ? { warning } : {}),
     };
   }
@@ -653,6 +712,8 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
       commentId: updated.commentId,
       commentUrl: updated.commentUrl,
       blockCleanOnFindingSeverities: activeGateConfig.blockCleanOnFindingSeverities,
+      executionMode: options.executionMode ?? DEFAULT_EXECUTION_MODE,
+      ...(options.inlineReason ? { inlineReason: options.inlineReason } : {}),
       ...(warning ? { warning } : {}),
       ...(updateVerificationWarning ? { verificationWarning: updateVerificationWarning } : {}),
     };
@@ -688,9 +749,19 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
     commentId: created.commentId,
     commentUrl: created.commentUrl,
     blockCleanOnFindingSeverities: activeGateConfig.blockCleanOnFindingSeverities,
+    executionMode: options.executionMode ?? DEFAULT_EXECUTION_MODE,
+    ...(options.inlineReason ? { inlineReason: options.inlineReason } : {}),
     ...(warning ? { warning } : {}),
     ...(verificationWarning ? { verificationWarning } : {}),
   };
+}
+export function buildInlineExecutionWarning(executionMode, inlineReason) {
+  if ((executionMode ?? DEFAULT_EXECUTION_MODE) !== "inline_single_agent") {
+    return null;
+  }
+  const reason = typeof inlineReason === "string" ? inlineReason.trim() : "";
+  const base = "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).";
+  return reason.length > 0 ? `${base} Reason: ${reason}` : base;
 }
 async function main() {
   let options;
@@ -705,8 +776,14 @@ async function main() {
     process.stdout.write(`${USAGE}\n`);
     return;
   }
+  const inlineWarning = buildInlineExecutionWarning(options.executionMode, options.inlineReason);
   try {
     const result = await upsertCheckpointVerdict(options);
+    // Emit the inline-execution warning only on success so the JSON error
+    // envelope on stderr stays clean and machine-parseable on failures.
+    if (inlineWarning) {
+      process.stderr.write(`${inlineWarning}\n`);
+    }
     process.stdout.write(`${JSON.stringify(result)}\n`);
   } catch (error) {
     process.stderr.write(`${JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) })}\n`);

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -168,7 +168,7 @@ export function parseWriteGateFindingsLogCliArgs(argv) {
   }
   return options;
 }
-function buildLogPath({ repo, pr, gate, headSha, tmpRoot }) {
+export function buildLogPath({ repo, pr, gate, headSha, tmpRoot }) {
   const parts = repo.split("/");
   if (parts.length !== 2 || parts.some(p => p.length === 0)) {
     throw new Error(`--repo must be in owner/name format, got: ${JSON.stringify(repo)}`);

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -264,6 +264,8 @@ Do not treat `fix applied locally` as the end of the loop when the workflow also
 
 For every `draft_gate` or `pre_approval_gate` comment, you MUST run:
 
+For a gate that ran via the fan-out/fan-in sub-loop:
+
 ```sh
 node <resolved-skill-scripts>/github/upsert-checkpoint-verdict.mjs \
   --repo <owner/name> \
@@ -272,10 +274,25 @@ node <resolved-skill-scripts>/github/upsert-checkpoint-verdict.mjs \
   --head-sha <current_head_sha> \
   --verdict <clean|findings_present|blocked> \
   --findings-summary "<summary>" \
-  --next-action "<next action>" --findings-severity-counts '{"must-fix":0,"worth-fixing-now":0,"defer":0}'
+  --next-action "<next action>" --findings-severity-counts '{"must-fix":0,"worth-fixing-now":0,"defer":0}' \
+  --execution-mode fanout_fanin
 ```
 
-`--execution-mode <fanout_fanin|inline_single_agent>` records how the gate review ran (default `inline_single_agent`). When the gate did not run via the fan-out/fan-in sub-loop ([Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md)), you MUST pass `--execution-mode inline_single_agent --inline-reason "<why>"` — silent inline runs are no longer allowed, and inline mode emits a stderr warning. The recorded `executionMode` is surfaced by `detect-checkpoint-evidence.mjs` and gated by `gates.requireFanoutEvidence`.
+For a gate that ran inline (single agent, not via the sub-loop):
+
+```sh
+node <resolved-skill-scripts>/github/upsert-checkpoint-verdict.mjs \
+  --repo <owner/name> \
+  --pr <number> \
+  --gate <draft_gate|pre_approval_gate> \
+  --head-sha <current_head_sha> \
+  --verdict <clean|findings_present|blocked> \
+  --findings-summary "<summary>" \
+  --next-action "<next action>" --findings-severity-counts '{"must-fix":0,"worth-fixing-now":0,"defer":0}' \
+  --execution-mode inline_single_agent --inline-reason "<why>"
+```
+
+`--execution-mode <fanout_fanin|inline_single_agent>` records how the gate review ran (default `inline_single_agent`). When the gate did not run via the fan-out/fan-in sub-loop ([Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md)), you MUST pass `--execution-mode inline_single_agent --inline-reason "<why>"` — silent inline runs are no longer allowed: inline mode requires a non-empty `--inline-reason` and emits a stderr warning. Because inline is the default mode, a bare call with neither flag now fails with an argument error, so always pass `--execution-mode` explicitly (and `--inline-reason` for inline). The recorded `executionMode` is surfaced by `detect-checkpoint-evidence.mjs` and gated by `gates.requireFanoutEvidence`.
 
 Do NOT use `gh pr comment`, `gh api`, or `gh pr review` for gate comments.
 

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -275,6 +275,8 @@ node <resolved-skill-scripts>/github/upsert-checkpoint-verdict.mjs \
   --next-action "<next action>" --findings-severity-counts '{"must-fix":0,"worth-fixing-now":0,"defer":0}'
 ```
 
+`--execution-mode <fanout_fanin|inline_single_agent>` records how the gate review ran (default `inline_single_agent`). When the gate did not run via the fan-out/fan-in sub-loop ([Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md)), you MUST pass `--execution-mode inline_single_agent --inline-reason "<why>"` — silent inline runs are no longer allowed, and inline mode emits a stderr warning. The recorded `executionMode` is surfaced by `detect-checkpoint-evidence.mjs` and gated by `gates.requireFanoutEvidence`.
+
 Do NOT use `gh pr comment`, `gh api`, or `gh pr review` for gate comments.
 
 `--force --force-reason` on `upsert-checkpoint-verdict.mjs` is a narrow operator-authorized CI override for the helper itself, not the default gate path. Use it only when the helper refuses gate entry solely because the current head is `blocked_needs_user_decision` with `ciStatus="failure"`, and only after the user explicitly authorizes ignoring that current-head CI failure for this one gate-comment upsert. It does **not** bypass stale-head checks, unresolved-thread / unsettled-review refusal, non-draft `draft_gate` refusal, merge conflicts, or other legality checks.

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -49,6 +49,8 @@ test("parseGateReviewCommentBody parses the deterministic visible gate comment f
     verdict: "clean",
     findingsSummary: "no issues found",
     nextAction: "mark ready for review",
+    executionMode: null,
+    inlineReason: null,
   });
 });
 
@@ -74,6 +76,8 @@ test("parseGateReviewCommentMarkerBody accepts gate/head markers even when contr
     verdict: "clean",
     findingsSummary: null,
     nextAction: null,
+    executionMode: null,
+    inlineReason: null,
     contractComplete: false,
   });
 });
@@ -300,6 +304,8 @@ test("detect-checkpoint-evidence summarizes the newest valid live gate comments 
         verdict: "clean",
         findingsSummary: "no issues found",
         nextAction: "mark ready for review",
+        executionMode: null,
+        inlineReason: null,
         contractComplete: true,
         commentId: 42,
         commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-42",
@@ -311,12 +317,15 @@ test("detect-checkpoint-evidence summarizes the newest valid live gate comments 
         verdict: "clean",
         findingsSummary: "no issues found",
         nextAction: "await final human approval",
+        executionMode: null,
+        inlineReason: null,
         contractComplete: true,
         commentId: 43,
         commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-43",
         updatedAt: "2026-05-29T22:00:00Z",
       },
       draftGateSatisfied: true,
+      fanoutEnforcement: { required: false, gates: [] },
       preMergeGateCheck: {
         ok: true,
         failures: [],
@@ -815,6 +824,66 @@ test("buildPreMergeGateCheck passes with zero unresolved threads", () => {
   assert.deepEqual(result.failures, []);
 });
 
+function cleanEvidence() {
+  return {
+    currentHeadSha: "abc1234",
+    draftGate: { visible: true, verdict: "clean" },
+    preApprovalGateMarker: { visible: true, contractComplete: true, verdict: "clean", headSha: "abc1234" },
+  };
+}
+
+test("buildPreMergeGateCheck default (requireFanoutEvidence off) ignores executionMode", () => {
+  // No fanoutEnforcement argument => current behavior preserved.
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null);
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.failures, []);
+
+  // Explicit not-required descriptor also preserves behavior.
+  const result2 = buildPreMergeGateCheck(cleanEvidence(), 0, null, { required: false, gates: [] });
+  assert.equal(result2.ok, true);
+  assert.deepEqual(result2.failures, []);
+});
+
+test("buildPreMergeGateCheck fails closed when requireFanoutEvidence and executionMode is inline_single_agent", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    gates: [
+      { name: "pre_approval_gate", executionMode: "inline_single_agent", ledgerPath: "tmp/x.json", ledgerExists: true },
+    ],
+  });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.failures.some((f) => f.includes("pre_approval_gate") && f.includes("inline_single_agent")),
+    JSON.stringify(result.failures),
+  );
+});
+
+test("buildPreMergeGateCheck fails closed when requireFanoutEvidence and ledger is missing", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    gates: [
+      { name: "pre_approval_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/gate-findings/o-r/pr-17/pre_approval_gate-abc1234.json", ledgerExists: false },
+    ],
+  });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.failures.some((f) => f.includes("no findings-log ledger") && f.includes("pre_approval_gate-abc1234.json")),
+    JSON.stringify(result.failures),
+  );
+});
+
+test("buildPreMergeGateCheck passes when requireFanoutEvidence and executionMode is fanout_fanin with ledger present", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    gates: [
+      { name: "draft_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/a.json", ledgerExists: true },
+      { name: "pre_approval_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/b.json", ledgerExists: true },
+    ],
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.failures, []);
+});
+
 test("detect-checkpoint-evidence fails pre-merge with unresolved human review threads", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-gate-human-unresolved-"));
 
@@ -1089,6 +1158,128 @@ test("detect-checkpoint-evidence finds gate comment posted as PR review (root ca
     // The pre-approval gate evidence is visible with the correct head SHA
     assert.equal(payload.preApprovalGate.visible, true);
     assert.equal(payload.preApprovalGate.verdict, "clean");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+function gateMarkerComment({ gate, headSha, nextAction, executionMode, inlineReason, id, updatedAt }) {
+  const modeLine = inlineReason
+    ? `**Execution mode:** ${executionMode} — ${inlineReason}`
+    : `**Execution mode:** ${executionMode}`;
+  return {
+    id,
+    updated_at: updatedAt,
+    html_url: `https://github.com/owner/repo/pull/17#issuecomment-${id}`,
+    body: [
+      `### Gate review: \`${gate}\``,
+      "",
+      `**Reviewed head SHA:** \`${headSha}\``,
+      "**Verdict:** clean",
+      modeLine,
+      "",
+      "**Findings summary:** no issues found",
+      "",
+      `**Next action:** ${nextAction}`,
+    ].join("\n"),
+  };
+}
+
+function fanoutEvidenceGhEntries(executionMode, inlineReason = null) {
+  return [
+    {
+      assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
+      stdout: '{"headRefOid":"abc1234"}\n',
+    },
+    {
+      assertArgs: ["api", "repos/owner/repo/issues/17/comments?per_page=100"],
+      stdout: `${JSON.stringify([
+        gateMarkerComment({ gate: "draft_gate", headSha: "abc1234", nextAction: "mark ready for review", executionMode, inlineReason, id: 42, updatedAt: "2026-05-29T21:00:00Z" }),
+        gateMarkerComment({ gate: "pre_approval_gate", headSha: "abc1234", nextAction: "await final human approval", executionMode, inlineReason, id: 43, updatedAt: "2026-05-29T22:00:00Z" }),
+      ])}\n`,
+    },
+    {
+      assertArgs: ["api", "graphql"],
+      stdout: JSON.stringify({ data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } }) + "\n",
+    },
+  ];
+}
+
+async function writeLedger(tempDir, gate) {
+  const dir = path.join(tempDir, "tmp", "gate-findings", "owner-repo", "pr-17");
+  await import("node:fs/promises").then((fs) => fs.mkdir(dir, { recursive: true }));
+  await writeFile(path.join(dir, `${gate}-abc1234.json`), JSON.stringify({ gate, headSha: "abc1234", findings: [] }) + "\n", "utf8");
+}
+
+test("detect-checkpoint-evidence surfaces executionMode in gate markers", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-execmode-"));
+  try {
+    const env = await writeGhStub(tempDir, fanoutEvidenceGhEntries("inline_single_agent", "tiny change"));
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
+    assert.equal(result.code, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.draftGateMarker.executionMode, "inline_single_agent");
+    assert.equal(payload.draftGateMarker.inlineReason, "tiny change");
+    assert.equal(payload.preApprovalGateMarker.executionMode, "inline_single_agent");
+    // requireFanoutEvidence is not set in this tempDir => default false => enforcement off.
+    assert.equal(payload.fanoutEnforcement.required, false);
+    assert.deepEqual(payload.preMergeGateCheck.failures, []);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-checkpoint-evidence requireFanoutEvidence=true fails closed for inline_single_agent verdicts", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-fanout-inline-"));
+  try {
+    await writeFile(path.join(tempDir, ".devloops"), "version: 1\ngates:\n  requireFanoutEvidence: true\n", "utf8");
+    await writeLedger(tempDir, "draft_gate");
+    await writeLedger(tempDir, "pre_approval_gate");
+    const env = await writeGhStub(tempDir, fanoutEvidenceGhEntries("inline_single_agent"));
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.ok(
+      payload.preMergeGateCheck.failures.some((f) => f.includes("inline_single_agent") && f.includes("requireFanoutEvidence")),
+      JSON.stringify(payload.preMergeGateCheck.failures),
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-checkpoint-evidence requireFanoutEvidence=true fails closed when the ledger is missing", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-fanout-noledger-"));
+  try {
+    await writeFile(path.join(tempDir, ".devloops"), "version: 1\ngates:\n  requireFanoutEvidence: true\n", "utf8");
+    // No ledger written.
+    const env = await writeGhStub(tempDir, fanoutEvidenceGhEntries("fanout_fanin"));
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
+    assert.equal(result.code, 1);
+    const payload = JSON.parse(result.stderr);
+    assert.ok(
+      payload.preMergeGateCheck.failures.some((f) => f.includes("no findings-log ledger")),
+      JSON.stringify(payload.preMergeGateCheck.failures),
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-checkpoint-evidence requireFanoutEvidence=true passes for fanout_fanin with ledger present", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-fanout-pass-"));
+  try {
+    await writeFile(path.join(tempDir, ".devloops"), "version: 1\ngates:\n  requireFanoutEvidence: true\n", "utf8");
+    await writeLedger(tempDir, "draft_gate");
+    await writeLedger(tempDir, "pre_approval_gate");
+    const env = await writeGhStub(tempDir, fanoutEvidenceGhEntries("fanout_fanin"));
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
+    assert.equal(result.code, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.fanoutEnforcement.required, true);
+    assert.deepEqual(payload.preMergeGateCheck.failures, []);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -1268,6 +1268,26 @@ test("detect-checkpoint-evidence requireFanoutEvidence=true fails closed when th
   }
 });
 
+test("detect-checkpoint-evidence disables fan-out enforcement (non-fatal) when config fails to load", async () => {
+  // FIX C: loadDevLoopConfig never throws; it returns { config, warnings, errors }.
+  // A config that fails schema validation produces a non-empty errors array, which
+  // must be treated as config-unavailable => enforcement disabled, NOT a crash.
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-badconfig-"));
+  try {
+    // requireFanoutEvidence must be a boolean; a string value fails validation.
+    await writeFile(path.join(tempDir, ".devloops"), "version: 1\ngates:\n  requireFanoutEvidence: \"yes\"\n", "utf8");
+    const env = await writeGhStub(tempDir, fanoutEvidenceGhEntries("inline_single_agent"));
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
+    // Enforcement disabled => the gate evidence is otherwise clean => exit 0.
+    assert.equal(result.code, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.fanoutEnforcement.required, false);
+    assert.deepEqual(payload.preMergeGateCheck.failures, []);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("detect-checkpoint-evidence requireFanoutEvidence=true passes for fanout_fanin with ledger present", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-fanout-pass-"));
   try {

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -8,6 +8,7 @@ import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson a
 
 import {
   parseUpsertCheckpointVerdictCliArgs,
+  renderGateReviewCommentBody,
   summarizeCheckpointVerdictText,
   upsertCheckpointVerdict,
 } from "../../scripts/github/upsert-checkpoint-verdict.mjs";
@@ -453,7 +454,7 @@ test("upsert-checkpoint-verdict creates a new comment when no same-head marker e
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
     assert.deepEqual(JSON.parse(result.stdout), {
       ok: true,
       action: "created",
@@ -464,6 +465,7 @@ test("upsert-checkpoint-verdict creates a new comment when no same-head marker e
       currentHeadSha: "abc1234",
       commentId: 101,
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
+      executionMode: "inline_single_agent",
       blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
     });
   } finally {
@@ -526,7 +528,7 @@ test("upsert-checkpoint-verdict embeds --findings-file content with preserved ne
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
     const parsed = JSON.parse(result.stdout);
     assert.equal(parsed.action, "created");
     assert.equal(parsed.gate, "draft_gate");
@@ -587,7 +589,7 @@ test("upsert-checkpoint-verdict --findings-file takes precedence over --findings
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
     const parsed = JSON.parse(result.stdout);
     assert.equal(parsed.action, "created");
   } finally {
@@ -640,7 +642,7 @@ test("upsert-checkpoint-verdict omits Blocking severities line on clean verdict"
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
     const parsed = JSON.parse(result.stdout);
     assert.equal(parsed.action, "created");
   } finally {
@@ -834,7 +836,7 @@ test("upsert-checkpoint-verdict appends the round-cap fallback note to pre-appro
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
     assert.deepEqual(JSON.parse(result.stdout), {
       ok: true,
       action: "created",
@@ -845,6 +847,7 @@ test("upsert-checkpoint-verdict appends the round-cap fallback note to pre-appro
       currentHeadSha: "abc1234",
       commentId: 101,
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
+      executionMode: "inline_single_agent",
       blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
     });
   } finally {
@@ -921,7 +924,7 @@ test("upsert-checkpoint-verdict truncates verbose findings summary before commen
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
     assert.deepEqual(JSON.parse(result.stdout), {
       ok: true,
       action: "created",
@@ -932,6 +935,7 @@ test("upsert-checkpoint-verdict truncates verbose findings summary before commen
       currentHeadSha: "abc1234",
       commentId: 101,
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
+      executionMode: "inline_single_agent",
       blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
     });
   } finally {
@@ -1002,7 +1006,7 @@ test("upsert-checkpoint-verdict suppresses duplicate repost when the current sam
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
     assert.deepEqual(JSON.parse(result.stdout), {
       ok: true,
       action: "noop",
@@ -1013,6 +1017,7 @@ test("upsert-checkpoint-verdict suppresses duplicate repost when the current sam
       currentHeadSha: "abc1234",
       commentId: 101,
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
+      executionMode: "inline_single_agent",
       blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
     });
     // 7 gh calls: pr facts + requested_reviewers + review threads + headRefOid + issue comments + PR reviews + internal-only file check
@@ -1092,7 +1097,7 @@ test("upsert-checkpoint-verdict noop still warns when a stale comment exists on 
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
     const parsed = JSON.parse(result.stdout);
     assert.equal(parsed.action, "noop");
     assert.equal(parsed.headSha, "abc1234");
@@ -1161,7 +1166,7 @@ test("upsert-checkpoint-verdict updates an incomplete same-head marker in place"
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
     assert.deepEqual(JSON.parse(result.stdout), {
       ok: true,
       action: "updated",
@@ -1172,6 +1177,7 @@ test("upsert-checkpoint-verdict updates an incomplete same-head marker in place"
       currentHeadSha: "abc1234",
       commentId: 101,
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
+      executionMode: "inline_single_agent",
       blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
     });
   } finally {
@@ -1251,7 +1257,7 @@ test("upsert-checkpoint-verdict updates the current same-head marker even when a
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
     assert.deepEqual(JSON.parse(result.stdout), {
       ok: true,
       action: "updated",
@@ -1263,6 +1269,7 @@ test("upsert-checkpoint-verdict updates the current same-head marker even when a
       commentId: 101,
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
       warning: "A gate comment for \`draft_gate\` already exists on a different head SHA \`def5678\` (comment 202). The old comment is stale for the current head.",
+      executionMode: "inline_single_agent",
       blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
     });
   } finally {
@@ -1342,7 +1349,7 @@ test("upsert-checkpoint-verdict prefers the latest same-head marker when it diff
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
     assert.deepEqual(JSON.parse(result.stdout), {
       ok: true,
       action: "updated",
@@ -1353,6 +1360,7 @@ test("upsert-checkpoint-verdict prefers the latest same-head marker when it diff
       currentHeadSha: "abc1234",
       commentId: 202,
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-202",
+      executionMode: "inline_single_agent",
       blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
     });
   } finally {
@@ -1423,7 +1431,7 @@ test("upsert-checkpoint-verdict expands an abbreviated current-head SHA before m
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
     assert.deepEqual(JSON.parse(result.stdout), {
       ok: true,
       action: "noop",
@@ -1434,6 +1442,7 @@ test("upsert-checkpoint-verdict expands an abbreviated current-head SHA before m
       currentHeadSha: "abcdef1234567890abcdef1234567890abcdef12",
       commentId: 101,
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
+      executionMode: "inline_single_agent",
       blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
     });
     // 7 gh calls: pr facts + requested_reviewers + review threads + headRefOid + issue comments + PR reviews + internal-only file check
@@ -1547,7 +1556,7 @@ test("upsert-checkpoint-verdict warns when a gate comment exists on a different 
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
     const parsed = JSON.parse(result.stdout);
     assert.equal(parsed.action, "created");
     assert.equal(parsed.gate, "draft_gate");
@@ -1681,7 +1690,7 @@ test("upsert-checkpoint-verdict allows clean verdict when no blocking-severity f
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
     const parsed = JSON.parse(result.stdout);
     assert.equal(parsed.ok, true);
     assert.equal(parsed.action, "created");
@@ -1857,7 +1866,7 @@ test("upsert-checkpoint-verdict skips Copilot convergence requirement for intern
     ], { env });
 
     assert.equal(result.code, 0, result.stderr);
-    assert.equal(result.stderr, "");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
     const payload = JSON.parse(result.stdout);
     assert.equal(payload.ok, true);
     assert.equal(payload.action, "created");
@@ -1927,12 +1936,97 @@ test("upsert-checkpoint-verdict performs stale-runner takeover before gate coord
     // The command should succeed (not fail with ownership_lost) because the stale runner was taken over.
     // Without the fix, this would fail: "active run is old-run-id, current run is new-run-id".
     assert.equal(result.code, 0, result.stderr);
-    assert.equal(result.stderr, "");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
     const payload = JSON.parse(result.stdout);
     assert.equal(payload.ok, true);
     assert.equal(payload.action, "created");
     assert.equal(payload.gate, "draft_gate");
     assert.equal(payload.commentId, 300);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("parseUpsertCheckpointVerdictCliArgs defaults executionMode and validates the flag", () => {
+  const base = ["--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234", "--verdict", "clean", "--findings-summary", "ok", "--next-action", "go", "--findings-severity-counts", '{"must-fix":0}'];
+  const def = parseUpsertCheckpointVerdictCliArgs(base);
+  assert.equal(def.executionMode, "inline_single_agent");
+  assert.equal(def.inlineReason, undefined);
+
+  const inline = parseUpsertCheckpointVerdictCliArgs([...base, "--execution-mode", "inline_single_agent", "--inline-reason", "tiny docs change"]);
+  assert.equal(inline.executionMode, "inline_single_agent");
+  assert.equal(inline.inlineReason, "tiny docs change");
+
+  // fanout_fanin drops any inline reason.
+  const fanout = parseUpsertCheckpointVerdictCliArgs([...base, "--execution-mode", "fanout_fanin", "--inline-reason", "ignored"]);
+  assert.equal(fanout.executionMode, "fanout_fanin");
+  assert.equal(fanout.inlineReason, undefined);
+
+  assert.throws(
+    () => parseUpsertCheckpointVerdictCliArgs([...base, "--execution-mode", "bogus"]),
+    /--execution-mode must be one of: fanout_fanin, inline_single_agent/i,
+  );
+});
+
+test("renderGateReviewCommentBody renders the execution-mode line round-trippable by the marker parser", async () => {
+  const { parseGateReviewCommentMarkerBody } = await import("../../scripts/_core-helpers.mjs");
+  const inlineBody = renderGateReviewCommentBody({
+    gate: "draft_gate", headSha: "abc1234", verdict: "clean", findingsSummary: "none", nextAction: "go",
+    executionMode: "inline_single_agent", inlineReason: "quick fix",
+  });
+  assert.match(inlineBody, /\*\*Execution mode:\*\* inline_single_agent — quick fix/);
+  const parsedInline = parseGateReviewCommentMarkerBody(inlineBody);
+  assert.equal(parsedInline.executionMode, "inline_single_agent");
+  assert.equal(parsedInline.inlineReason, "quick fix");
+
+  const fanoutBody = renderGateReviewCommentBody({
+    gate: "draft_gate", headSha: "abc1234", verdict: "clean", findingsSummary: "none", nextAction: "go",
+    executionMode: "fanout_fanin",
+  });
+  assert.match(fanoutBody, /\*\*Execution mode:\*\* fanout_fanin/);
+  assert.equal(parseGateReviewCommentMarkerBody(fanoutBody).executionMode, "fanout_fanin");
+});
+
+test("upsert-checkpoint-verdict records executionMode and warns on inline, stays clean on fanout", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-execmode-"));
+  try {
+    const env = await writeGhStub(tempDir, [
+      ...buildGateCoordinationEntries({ isDraft: true, statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }] }),
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f"],
+        assertArgContains: ["body=### Gate review: `draft_gate`", "**Execution mode:** inline_single_agent — manual single-agent run"],
+        stdout: '{"id":101,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-101"}\n',
+      },
+    ]);
+    const inline = await runNode([
+      "--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234",
+      "--verdict", "clean", "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
+      "--findings-summary", "no issues found", "--next-action", "mark ready for review",
+      "--execution-mode", "inline_single_agent", "--inline-reason", "manual single-agent run",
+    ], { env });
+    assert.equal(inline.code, 0, inline.stderr);
+    assert.match(inline.stderr, /WARNING: gate ran inline_single_agent/);
+    const inlineOut = JSON.parse(inline.stdout);
+    assert.equal(inlineOut.executionMode, "inline_single_agent");
+    assert.equal(inlineOut.inlineReason, "manual single-agent run");
+
+    const env2 = await writeGhStub(tempDir, [
+      ...buildGateCoordinationEntries({ isDraft: true, statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }] }),
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f"],
+        assertArgContains: ["**Execution mode:** fanout_fanin"],
+        stdout: '{"id":102,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-102"}\n',
+      },
+    ]);
+    const fanout = await runNode([
+      "--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234",
+      "--verdict", "clean", "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
+      "--findings-summary", "no issues found", "--next-action", "mark ready for review",
+      "--execution-mode", "fanout_fanin",
+    ], { env: env2 });
+    assert.equal(fanout.code, 0, fanout.stderr);
+    assert.equal(fanout.stderr, "");
+    assert.equal(JSON.parse(fanout.stdout).executionMode, "fanout_fanin");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -16,7 +16,21 @@ import { claimRunnerOwnership } from "../../scripts/loop/_pr-runner-coordination
 
 const scriptPath = path.resolve("scripts/github/upsert-checkpoint-verdict.mjs");
 
-const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, {
+// Inline mode is the default execution mode and now requires a non-empty
+// --inline-reason (see FIX B). For tests that do not explicitly exercise the
+// execution-mode flags, auto-append a default inline reason so the existing
+// scenarios keep covering their original behavior. Tests that pass their own
+// --execution-mode / --inline-reason (or that expect an argument error before
+// the parser reaches the inline-reason check) are left untouched.
+const DEFAULT_TEST_INLINE_REASON = "single-agent inline review (test)";
+const augmentInlineReason = (args) => {
+  if (args.includes("--execution-mode") || args.includes("--inline-reason")) {
+    return args;
+  }
+  return [...args, "--inline-reason", DEFAULT_TEST_INLINE_REASON];
+};
+
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, augmentInlineReason(args), {
   ...options,
   env: {
     ...process.env,
@@ -113,6 +127,7 @@ test("parseUpsertCheckpointVerdictCliArgs rejects malformed arguments determinis
       "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
     "--findings-summary", "no issues found",
     "--next-action", "mark ready for review",
+    "--inline-reason", "tiny docs change",
   ]);
   assert.equal(parsed.headSha, "abc1234");
 
@@ -140,6 +155,7 @@ test("parseUpsertCheckpointVerdictCliArgs accepts --findings-file without --find
     "--verdict", "findings_present",
     "--findings-file", "/tmp/findings.md",
     "--next-action", "stay draft and fix",
+    "--inline-reason", "tiny docs change",
   ]);
   assert.equal(parsed.findingsFile, "/tmp/findings.md");
   assert.equal(parsed.findingsSummary, undefined);
@@ -156,6 +172,7 @@ test("parseUpsertCheckpointVerdictCliArgs accepts --findings-file with --finding
     "--findings-summary", "fallback text",
     "--findings-file", "/tmp/findings.md",
     "--next-action", "stay draft and fix",
+    "--inline-reason", "tiny docs change",
   ]);
   assert.equal(parsed.findingsFile, "/tmp/findings.md");
   assert.equal(parsed.findingsSummary, "fallback text");
@@ -454,7 +471,7 @@ test("upsert-checkpoint-verdict creates a new comment when no same-head marker e
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop). Reason: single-agent inline review (test)\n");
     assert.deepEqual(JSON.parse(result.stdout), {
       ok: true,
       action: "created",
@@ -466,6 +483,7 @@ test("upsert-checkpoint-verdict creates a new comment when no same-head marker e
       commentId: 101,
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
       executionMode: "inline_single_agent",
+      inlineReason: "single-agent inline review (test)",
       blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
     });
   } finally {
@@ -528,7 +546,7 @@ test("upsert-checkpoint-verdict embeds --findings-file content with preserved ne
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop). Reason: single-agent inline review (test)\n");
     const parsed = JSON.parse(result.stdout);
     assert.equal(parsed.action, "created");
     assert.equal(parsed.gate, "draft_gate");
@@ -589,7 +607,7 @@ test("upsert-checkpoint-verdict --findings-file takes precedence over --findings
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop). Reason: single-agent inline review (test)\n");
     const parsed = JSON.parse(result.stdout);
     assert.equal(parsed.action, "created");
   } finally {
@@ -642,7 +660,7 @@ test("upsert-checkpoint-verdict omits Blocking severities line on clean verdict"
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop). Reason: single-agent inline review (test)\n");
     const parsed = JSON.parse(result.stdout);
     assert.equal(parsed.action, "created");
   } finally {
@@ -836,7 +854,7 @@ test("upsert-checkpoint-verdict appends the round-cap fallback note to pre-appro
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop). Reason: single-agent inline review (test)\n");
     assert.deepEqual(JSON.parse(result.stdout), {
       ok: true,
       action: "created",
@@ -848,6 +866,7 @@ test("upsert-checkpoint-verdict appends the round-cap fallback note to pre-appro
       commentId: 101,
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
       executionMode: "inline_single_agent",
+      inlineReason: "single-agent inline review (test)",
       blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
     });
   } finally {
@@ -924,7 +943,7 @@ test("upsert-checkpoint-verdict truncates verbose findings summary before commen
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop). Reason: single-agent inline review (test)\n");
     assert.deepEqual(JSON.parse(result.stdout), {
       ok: true,
       action: "created",
@@ -936,6 +955,7 @@ test("upsert-checkpoint-verdict truncates verbose findings summary before commen
       commentId: 101,
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
       executionMode: "inline_single_agent",
+      inlineReason: "single-agent inline review (test)",
       blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
     });
   } finally {
@@ -974,6 +994,7 @@ test("upsert-checkpoint-verdict suppresses duplicate repost when the current sam
             "",
             "**Reviewed head SHA:** `abc1234`",
             "**Verdict:** clean",
+            "**Execution mode:** inline_single_agent — single-agent inline review (test)",
             "",
             "**Findings summary:** no issues found",
             "",
@@ -1006,7 +1027,7 @@ test("upsert-checkpoint-verdict suppresses duplicate repost when the current sam
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop). Reason: single-agent inline review (test)\n");
     assert.deepEqual(JSON.parse(result.stdout), {
       ok: true,
       action: "noop",
@@ -1018,10 +1039,91 @@ test("upsert-checkpoint-verdict suppresses duplicate repost when the current sam
       commentId: 101,
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
       executionMode: "inline_single_agent",
+      inlineReason: "single-agent inline review (test)",
       blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
     });
     // 7 gh calls: pr facts + requested_reviewers + review threads + headRefOid + issue comments + PR reviews + internal-only file check
     assert.equal(Number((await readFile(env.GH_COUNTER_PATH, "utf8")).trim()), 7);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("upsert-checkpoint-verdict updates (not noop) when only the inline reason changed on the same head", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-inline-reason-change-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"],
+        stdout: '{"number":17,"state":"OPEN","isDraft":true,"headRefOid":"abc1234","reviews":[],"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=17"],
+        stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n',
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
+        stdout: '{"headRefOid":"abc1234"}\n',
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/17/comments?per_page=100"],
+        stdout: `${JSON.stringify([
+          {
+            id: 101,
+            // Same verdict/summary/nextAction, but a DIFFERENT inline reason than
+            // the incoming request. FIX A: this must force an update, not a noop.
+            body: [
+            "### Gate review: `draft_gate`",
+            "",
+            "**Reviewed head SHA:** `abc1234`",
+            "**Verdict:** clean",
+            "**Execution mode:** inline_single_agent — stale prior reason",
+            "",
+            "**Findings summary:** no issues found",
+            "",
+            "**Next action:** mark ready for review",
+            ].join("\n"),
+            html_url: "https://github.com/owner/repo/pull/17#issuecomment-101",
+            updated_at: "2026-05-30T17:00:00Z",
+          },
+        ])}\n`,
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/pulls/17/reviews?per_page=100"],
+        stdout: "[]\n",
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files"],
+        stdout: '{"files":[{"path":"src/index.ts"}]}\n',
+      },
+      {
+        assertArgs: ["api", "-X", "PATCH", "repos/owner/repo/issues/comments/101", "-f"],
+        assertArgContains: ["body=### Gate review: `draft_gate`", "**Execution mode:** inline_single_agent — single-agent inline review (test)"],
+        stdout: '{"id":101,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-101"}\n',
+      },
+    ]);
+
+    const result = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "17",
+      "--gate", "draft_gate",
+      "--head-sha", "abc1234",
+      "--verdict", "clean",
+      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
+      "--findings-summary", "no issues found",
+      "--next-action", "mark ready for review",
+    ], { env });
+
+    assert.equal(result.code, 0);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.action, "updated");
+    assert.equal(parsed.executionMode, "inline_single_agent");
+    assert.equal(parsed.inlineReason, "single-agent inline review (test)");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -1058,6 +1160,7 @@ test("upsert-checkpoint-verdict noop still warns when a stale comment exists on 
             "",
             "**Reviewed head SHA:** `abc1234`",
             "**Verdict:** clean",
+            "**Execution mode:** inline_single_agent — single-agent inline review (test)",
             "",
             "**Findings summary:** no issues found",
             "",
@@ -1097,7 +1200,7 @@ test("upsert-checkpoint-verdict noop still warns when a stale comment exists on 
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop). Reason: single-agent inline review (test)\n");
     const parsed = JSON.parse(result.stdout);
     assert.equal(parsed.action, "noop");
     assert.equal(parsed.headSha, "abc1234");
@@ -1166,7 +1269,7 @@ test("upsert-checkpoint-verdict updates an incomplete same-head marker in place"
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop). Reason: single-agent inline review (test)\n");
     assert.deepEqual(JSON.parse(result.stdout), {
       ok: true,
       action: "updated",
@@ -1178,6 +1281,7 @@ test("upsert-checkpoint-verdict updates an incomplete same-head marker in place"
       commentId: 101,
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
       executionMode: "inline_single_agent",
+      inlineReason: "single-agent inline review (test)",
       blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
     });
   } finally {
@@ -1257,7 +1361,7 @@ test("upsert-checkpoint-verdict updates the current same-head marker even when a
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop). Reason: single-agent inline review (test)\n");
     assert.deepEqual(JSON.parse(result.stdout), {
       ok: true,
       action: "updated",
@@ -1270,6 +1374,7 @@ test("upsert-checkpoint-verdict updates the current same-head marker even when a
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
       warning: "A gate comment for \`draft_gate\` already exists on a different head SHA \`def5678\` (comment 202). The old comment is stale for the current head.",
       executionMode: "inline_single_agent",
+      inlineReason: "single-agent inline review (test)",
       blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
     });
   } finally {
@@ -1349,7 +1454,7 @@ test("upsert-checkpoint-verdict prefers the latest same-head marker when it diff
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop). Reason: single-agent inline review (test)\n");
     assert.deepEqual(JSON.parse(result.stdout), {
       ok: true,
       action: "updated",
@@ -1361,6 +1466,7 @@ test("upsert-checkpoint-verdict prefers the latest same-head marker when it diff
       commentId: 202,
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-202",
       executionMode: "inline_single_agent",
+      inlineReason: "single-agent inline review (test)",
       blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
     });
   } finally {
@@ -1399,6 +1505,7 @@ test("upsert-checkpoint-verdict expands an abbreviated current-head SHA before m
             "",
             "**Reviewed head SHA:** `abcdef1234567890abcdef1234567890abcdef12`",
             "**Verdict:** clean",
+            "**Execution mode:** inline_single_agent — single-agent inline review (test)",
             "",
             "**Findings summary:** no issues found",
             "",
@@ -1431,7 +1538,7 @@ test("upsert-checkpoint-verdict expands an abbreviated current-head SHA before m
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop). Reason: single-agent inline review (test)\n");
     assert.deepEqual(JSON.parse(result.stdout), {
       ok: true,
       action: "noop",
@@ -1443,6 +1550,7 @@ test("upsert-checkpoint-verdict expands an abbreviated current-head SHA before m
       commentId: 101,
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
       executionMode: "inline_single_agent",
+      inlineReason: "single-agent inline review (test)",
       blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
     });
     // 7 gh calls: pr facts + requested_reviewers + review threads + headRefOid + issue comments + PR reviews + internal-only file check
@@ -1556,7 +1664,7 @@ test("upsert-checkpoint-verdict warns when a gate comment exists on a different 
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop). Reason: single-agent inline review (test)\n");
     const parsed = JSON.parse(result.stdout);
     assert.equal(parsed.action, "created");
     assert.equal(parsed.gate, "draft_gate");
@@ -1690,7 +1798,7 @@ test("upsert-checkpoint-verdict allows clean verdict when no blocking-severity f
     ], { env });
 
     assert.equal(result.code, 0);
-    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop). Reason: single-agent inline review (test)\n");
     const parsed = JSON.parse(result.stdout);
     assert.equal(parsed.ok, true);
     assert.equal(parsed.action, "created");
@@ -1866,7 +1974,7 @@ test("upsert-checkpoint-verdict skips Copilot convergence requirement for intern
     ], { env });
 
     assert.equal(result.code, 0, result.stderr);
-    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop). Reason: single-agent inline review (test)\n");
     const payload = JSON.parse(result.stdout);
     assert.equal(payload.ok, true);
     assert.equal(payload.action, "created");
@@ -1936,7 +2044,7 @@ test("upsert-checkpoint-verdict performs stale-runner takeover before gate coord
     // The command should succeed (not fail with ownership_lost) because the stale runner was taken over.
     // Without the fix, this would fail: "active run is old-run-id, current run is new-run-id".
     assert.equal(result.code, 0, result.stderr);
-    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop).\n");
+    assert.equal(result.stderr, "WARNING: gate ran inline_single_agent (not via the fan-out/fan-in review sub-loop). Reason: single-agent inline review (test)\n");
     const payload = JSON.parse(result.stdout);
     assert.equal(payload.ok, true);
     assert.equal(payload.action, "created");
@@ -1949,13 +2057,32 @@ test("upsert-checkpoint-verdict performs stale-runner takeover before gate coord
 
 test("parseUpsertCheckpointVerdictCliArgs defaults executionMode and validates the flag", () => {
   const base = ["--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234", "--verdict", "clean", "--findings-summary", "ok", "--next-action", "go", "--findings-severity-counts", '{"must-fix":0}'];
-  const def = parseUpsertCheckpointVerdictCliArgs(base);
+
+  // Inline is the default mode and now REQUIRES --inline-reason: a bare call
+  // with neither --execution-mode nor --inline-reason errors (FIX B).
+  assert.throws(
+    () => parseUpsertCheckpointVerdictCliArgs(base),
+    /--inline-reason is required for executionMode inline_single_agent/i,
+  );
+
+  // Explicit inline_single_agent without a reason still errors.
+  assert.throws(
+    () => parseUpsertCheckpointVerdictCliArgs([...base, "--execution-mode", "inline_single_agent"]),
+    /--inline-reason is required for executionMode inline_single_agent/i,
+  );
+
+  const def = parseUpsertCheckpointVerdictCliArgs([...base, "--inline-reason", "tiny docs change"]);
   assert.equal(def.executionMode, "inline_single_agent");
-  assert.equal(def.inlineReason, undefined);
+  assert.equal(def.inlineReason, "tiny docs change");
 
   const inline = parseUpsertCheckpointVerdictCliArgs([...base, "--execution-mode", "inline_single_agent", "--inline-reason", "tiny docs change"]);
   assert.equal(inline.executionMode, "inline_single_agent");
   assert.equal(inline.inlineReason, "tiny docs change");
+
+  // fanout_fanin does NOT require a reason.
+  const fanoutNoReason = parseUpsertCheckpointVerdictCliArgs([...base, "--execution-mode", "fanout_fanin"]);
+  assert.equal(fanoutNoReason.executionMode, "fanout_fanin");
+  assert.equal(fanoutNoReason.inlineReason, undefined);
 
   // fanout_fanin drops any inline reason.
   const fanout = parseUpsertCheckpointVerdictCliArgs([...base, "--execution-mode", "fanout_fanin", "--inline-reason", "ignored"]);
@@ -2030,4 +2157,22 @@ test("upsert-checkpoint-verdict records executionMode and warns on inline, stays
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
+});
+
+test("upsert-checkpoint-verdict CLI fails closed for inline mode without --inline-reason", async () => {
+  // End-to-end argument-error path: a complete call that resolves to the default
+  // inline mode but omits --inline-reason exits 1 with a clear argument error
+  // (FIX B). runNodeHelper is used directly so no inline reason is auto-appended.
+  const args = [
+    "--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234",
+    "--verdict", "clean", "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
+    "--findings-summary", "no issues found", "--next-action", "mark ready for review",
+  ];
+  const result = await runNodeHelper(scriptPath, args, {
+    env: { ...process.env, PI_SUBAGENT_RUN_ID: "" },
+  });
+  assert.equal(result.code, 1);
+  const payload = JSON.parse(result.stderr);
+  assert.equal(payload.ok, false);
+  assert.match(payload.error, /--inline-reason is required for executionMode inline_single_agent/i);
 });


### PR DESCRIPTION
## Summary

**Phase 1 of #867.** Make gate execution mode explicit, auditable, and machine-readable, with opt-in fail-closed enforcement — closing the *silent* core of the gap where a clean verdict couldn't be distinguished between a real fan-out/fan-in review and an inline single-agent pass.

## Changes

- `upsert-checkpoint-verdict.mjs`: `--execution-mode <fanout_fanin|inline_single_agent>` (default `inline_single_agent`) + `--inline-reason`; persisted in the gate marker, rendered in the comment, stderr warning on inline runs.
- `detect-checkpoint-evidence.mjs`: surfaces `executionMode`/`inlineReason`; adds opt-in `gates.requireFanoutEvidence` (default **false**) that fails the pre-merge check closed unless each required gate is `fanout_fanin` **and** a findings-log ledger exists for the head SHA.
- `config.mjs`: `gates.requireFanoutEvidence` + `resolveRequireFanoutEvidence`; `copilot-helpers` parses the marker fields; `write-gate-findings-log` exports `buildLogPath`.
- Docs: gate-comment command contract + `gate-review-sub-loop-contract.md`.

## Scope / non-goals (reviewer note)

This is **Phase 1 only**. It does **not** build the live context-builder fan-out execution or dynamic angle resolution (Phases 2-3) — so `fanout_fanin` is currently only producible by a caller that explicitly runs the sub-loop and writes the ledger. Enforcement therefore defaults **off**; flipping `requireFanoutEvidence` on becomes meaningful once Phases 2-3 land. Clean seams left: typed `executionMode` marker field, isolated `resolveRequireFanoutEvidence`/`fanoutEnforcement`, shared `buildLogPath`.

> This PR's own gates are run inline and disclosed via the new `--execution-mode inline_single_agent` field — dogfooding the feature.

## Validation

- `npm run verify` — pass (scripts 1502, core 1556, docs/links/dup, dev-loop 32; 0 fail).
- New tests: marker round-trips executionMode/inlineReason; detector surfaces them; `requireFanoutEvidence=true` fails closed without fan-out evidence and passes with it; default false unchanged.

Part of #867 (epic) — Phase 1. The epic stays open until Phases 2-4 land.

