### PR TITLE
feat(gates): context-builder handoff artifact + dynamic angle resolution (#877)

### DIFF
--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -50,8 +50,20 @@ on an isolated checkout:
 - fresh context (do not fork the parent session just to share chat history). **Mandatory:** every gate-review subagent must run `scripts/github/verify-fresh-review-context.mjs` at startup and refuse to proceed on contamination. Use `--scope <angle>` so each reviewer writes its own sentinel.
 - `worktree: true` recommended per reviewer/subagent for filesystem isolation; prescribe it but
   do not fail closed if worktrees are unavailable in the current environment
+- the preamble resolves the gate's review angle set: it starts from the configured
+  angle pool (`gates.<gate>.angles`) and, when `gates.<gate>.dynamicAngles` is enabled,
+  narrows it to the angles relevant to the change at hand (configured pool → resolved
+  set). Optional code-review lenses not triggered by the change (for example most code
+  lenses for a docs-only change) are dropped, and the reason each angle was dropped is
+  recorded as rationale. Angles in `gates.<gate>.mandatoryAngles` form a floor and are
+  always included after dynamic selection (filtered only by `excludeAngles`); they are
+  never dropped. When `dynamicAngles` is off (or no diff is available), the configured
+  static pool is used unchanged.
 - the preamble produces one or more review handoff artifacts (branch, head SHA, PR/issue
-  scope, acceptance criteria, touched files, validation posture)
+  scope, acceptance criteria, touched files, validation posture). The resolved angle set
+  and its rationale are written as a deterministic handoff artifact under
+  `tmp/gate-context/<repo-slug>/pr-<N>/<gate>-<headSha>.json` so the Phase 2 fan-out
+  consumes a stable, auditable briefing per head SHA.
 - reference the pi-subagents `parallel context-build` technique when applicable:
   run parallel `context-builder` agents from fresh context with distinct output paths
   (e.g. `context-build/request-and-scope.md`, `context-build/codebase-and-patterns.md`,

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -62,7 +62,7 @@ on an isolated checkout:
 - the preamble produces one or more review handoff artifacts (branch, head SHA, PR/issue
   scope, acceptance criteria, touched files, validation posture). The resolved angle set
   and its rationale are written as a deterministic handoff artifact under
-  `tmp/gate-context/<repo-slug>/pr-<N>/<gate>-<headSha>.json` so the Phase 2 fan-out
+  `tmp/gate-context/<repo-slug>/pr-<N>/<gate>-<headSha>.json` so the fork fan-out phase
   consumes a stable, auditable briefing per head SHA.
 - reference the pi-subagents `parallel context-build` technique when applicable:
   run parallel `context-builder` agents from fresh context with distinct output paths
@@ -199,7 +199,7 @@ resolved-in SHA (for findings resolved in a later pass).
 ## Execution mode and fan-out evidence enforcement
 
 Each gate verdict records an `executionMode` (`fanout_fanin` or `inline_single_agent`,
-default `inline_single_agent`) via the [Gate comment command](../skills/copilot-pr-followup/SKILL.md#mandatory-gate-comment-command-contract); inline runs must declare an `--inline-reason`. The opt-in `gates.requireFanoutEvidence` config (default `false`) makes the pre-merge evidence check fail closed for a required gate unless its recorded `executionMode` is `fanout_fanin` and a findings-log ledger exists for that gate + head SHA. Phases 2-3 — live context-builder/fan-out execution and dynamic angle resolution — are the follow-up that makes `fanout_fanin` producible.
+default `inline_single_agent`) via the [Gate comment command](../skills/copilot-pr-followup/SKILL.md#mandatory-gate-comment-command-contract); inline runs must declare an `--inline-reason`. The opt-in `gates.requireFanoutEvidence` config (default `false`) makes the pre-merge evidence check fail closed for a required gate unless its recorded `executionMode` is `fanout_fanin` and a findings-log ledger exists for that gate + head SHA. Live context-builder/fan-out execution (the follow-up work tracked in epic #867) is what makes `fanout_fanin` producible — distinct from this contract's own sub-loop phase numbering (preamble / fanout / fanin).
 
 ## See also
 

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -1,0 +1,449 @@
+#!/usr/bin/env node
+/**
+ * write-gate-context.mjs — context-builder handoff artifact writer.
+ *
+ * The gate-review context-builder (Phase 1 of the gate-review sub-loop) resolves
+ * the dynamic review-angle set and writes a deterministic JSON handoff artifact
+ * that downstream fan-out reviewers (Phase 3) consume. This module owns that
+ * artifact: a deterministic path builder, a writer, and a reader for round-trip
+ * use, plus a thin context-builder entrypoint (`buildGateContext`) that derives
+ * the angle set + rationale directly from the canonical resolver.
+ *
+ * Angle resolution is NOT re-implemented here. The single source of truth is
+ * `resolveGateAnglesDynamic(config, gate, { diff })` from @dev-loops/core/config:
+ * it honors the mandatory-angle floor (mandatory angles are always merged back
+ * after dynamic selection, filtered by excludeAngles) and falls back to the
+ * static configured pool when `dynamicAngles` is off or no diff is available.
+ * This module maps that resolver's output into the persisted artifact:
+ *   resolvedAngles  = resolver.recommendedAngles
+ *   rationale       = resolver.skippedAngles (action 'dropped', reason from
+ *                     resolver.reasons) + the rest as action 'kept'
+ *
+ * The artifact records the resolved angle set + rationale + change scope
+ * (branch, head SHA, touched files, acceptance-criteria pointer, validation
+ * posture) so reviewers receive a stable, auditable briefing per head SHA.
+ *
+ * Path scheme mirrors write-gate-findings-log.mjs `buildLogPath`:
+ *   <tmpRoot>/gate-context/<repo-slug>/pr-<N>/<gate>-<headSha>.json
+ */
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { parseArgs } from "node:util";
+
+import { resolveGateAnglesDynamic } from "@dev-loops/core/config";
+
+import { parsePrNumber, requireTokenValue } from "../_cli-primitives.mjs";
+import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+
+/**
+ * Map the artifact gate name (draft_gate | pre_approval_gate) to the config
+ * gate key understood by resolveGateAnglesDynamic (draft | preApproval).
+ * @param {string} gate
+ * @returns {"draft"|"preApproval"}
+ */
+export function mapGateToConfigKey(gate) {
+  if (gate === "draft_gate") return "draft";
+  if (gate === "pre_approval_gate") return "preApproval";
+  throw new Error(`Unknown gate: ${JSON.stringify(gate)} (expected draft_gate or pre_approval_gate)`);
+}
+
+/**
+ * Map a resolveGateAnglesDynamic result into the persisted artifact fields.
+ * Does NOT re-derive angles — it only reshapes the resolver's output.
+ *
+ * @param {{ recommendedAngles: string[]|null, skippedAngles?: string[], reasons?: Record<string,string> }} resolverResult
+ * @returns {{ resolvedAngles: string[], rationale: Array<{angle: string, action: "kept"|"dropped", reason: string}> }}
+ */
+export function rationaleFromResolver(resolverResult) {
+  const recommended = Array.isArray(resolverResult?.recommendedAngles)
+    ? resolverResult.recommendedAngles
+    : [];
+  const skipped = Array.isArray(resolverResult?.skippedAngles)
+    ? resolverResult.skippedAngles
+    : [];
+  const reasons = resolverResult?.reasons ?? {};
+
+  const rationale = [];
+  for (const angle of recommended) {
+    rationale.push({ angle, action: "kept", reason: "selected by dynamic angle resolver" });
+  }
+  for (const angle of skipped) {
+    rationale.push({
+      angle,
+      action: "dropped",
+      reason: typeof reasons[angle] === "string" && reasons[angle].length > 0
+        ? reasons[angle]
+        : "not relevant to the change set",
+    });
+  }
+  return { resolvedAngles: [...recommended], rationale };
+}
+
+const USAGE = `Usage: write-gate-context.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate> --head-sha <sha> --angles <json> [--rationale <json>] [--branch <name>] [--touched-files <json>] [--acceptance-criteria <pointer>] [--validation-posture <text>] [--tmp-root <path>]
+Write a deterministic gate-review context-builder handoff artifact under tmp/ paths.
+Required:
+  --repo <owner/name>
+  --pr <number>
+  --gate <draft_gate|pre_approval_gate>
+  --head-sha <sha>
+  --angles <json>                JSON array of resolved review-angle name strings
+Optional:
+  --rationale <json>             JSON array of {angle, action, reason} entries
+  --branch <name>                Source branch name
+  --touched-files <json>         JSON array of changed file path strings
+  --acceptance-criteria <ptr>    Pointer to acceptance criteria (issue ref, doc path, URL)
+  --validation-posture <text>    Short description of the validation posture
+  --tmp-root <path>              Root tmp directory (default: tmp/)
+`.trim();
+
+function parseError(message) {
+  return Object.assign(new Error(message), { usage: USAGE });
+}
+
+function normalizeGate(value) {
+  const gates = new Set(["draft_gate", "pre_approval_gate"]);
+  const normalized = String(value).trim().toLowerCase();
+  return gates.has(normalized) ? normalized : null;
+}
+
+function normalizeHeadSha(value) {
+  const normalized = String(value).trim().toLowerCase();
+  return /^[0-9a-f]{7,64}$/i.test(normalized) ? normalized : null;
+}
+
+const VALID_ACTIONS = new Set(["kept", "added", "dropped", "joined"]);
+
+function parseAnglesJson(raw) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw parseError("--angles must be valid JSON");
+  }
+  if (!Array.isArray(parsed)) {
+    throw parseError("--angles must be a JSON array");
+  }
+  return parsed.map((a, i) => {
+    if (typeof a !== "string" || a.trim().length === 0) {
+      throw parseError(`--angles[${i}] must be a non-empty string`);
+    }
+    return a.trim();
+  });
+}
+
+function parseRationaleJson(raw) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw parseError("--rationale must be valid JSON");
+  }
+  if (!Array.isArray(parsed)) {
+    throw parseError("--rationale must be a JSON array");
+  }
+  return parsed.map((r, i) => {
+    if (!r || typeof r !== "object" || Array.isArray(r)) {
+      throw parseError(`--rationale[${i}] must be an object`);
+    }
+    if (!r.angle || typeof r.angle !== "string" || r.angle.trim().length === 0) {
+      throw parseError(`--rationale[${i}].angle is required`);
+    }
+    if (!r.action || !VALID_ACTIONS.has(r.action)) {
+      throw parseError(`--rationale[${i}].action must be one of: kept, added, dropped, joined`);
+    }
+    if (!r.reason || typeof r.reason !== "string" || r.reason.trim().length === 0) {
+      throw parseError(`--rationale[${i}].reason is required`);
+    }
+    return { angle: r.angle.trim(), action: r.action, reason: r.reason.trim() };
+  });
+}
+
+function parseStringArrayJson(raw, label) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw parseError(`${label} must be valid JSON`);
+  }
+  if (!Array.isArray(parsed)) {
+    throw parseError(`${label} must be a JSON array`);
+  }
+  return parsed.filter((x) => typeof x === "string" && x.trim().length > 0).map((x) => x.trim());
+}
+
+export function parseWriteGateContextCliArgs(argv) {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+      gate: { type: "string" },
+      "head-sha": { type: "string" },
+      angles: { type: "string" },
+      rationale: { type: "string" },
+      branch: { type: "string" },
+      "touched-files": { type: "string" },
+      "acceptance-criteria": { type: "string" },
+      "validation-posture": { type: "string" },
+      "tmp-root": { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  const options = {
+    repo: undefined,
+    pr: undefined,
+    gate: undefined,
+    headSha: undefined,
+    angles: undefined,
+    rationale: [],
+    branch: null,
+    touchedFiles: [],
+    acceptanceCriteria: null,
+    validationPosture: null,
+    tmpRoot: "tmp",
+  };
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
+      return { help: true };
+    }
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
+      continue;
+    }
+    if (token.name === "pr") {
+      options.pr = parsePrNumber(requireTokenValue(token, parseError), parseError);
+      continue;
+    }
+    if (token.name === "gate") {
+      const gate = normalizeGate(requireTokenValue(token, parseError));
+      if (!gate) throw parseError("--gate must be draft_gate or pre_approval_gate");
+      options.gate = gate;
+      continue;
+    }
+    if (token.name === "head-sha") {
+      const sha = normalizeHeadSha(requireTokenValue(token, parseError));
+      if (!sha) throw parseError("--head-sha must be a 7-64 character hex SHA");
+      options.headSha = sha;
+      continue;
+    }
+    if (token.name === "angles") {
+      options.angles = parseAnglesJson(requireTokenValue(token, parseError));
+      continue;
+    }
+    if (token.name === "rationale") {
+      options.rationale = parseRationaleJson(requireTokenValue(token, parseError));
+      continue;
+    }
+    if (token.name === "branch") {
+      options.branch = requireTokenValue(token, parseError).trim();
+      continue;
+    }
+    if (token.name === "touched-files") {
+      options.touchedFiles = parseStringArrayJson(requireTokenValue(token, parseError), "--touched-files");
+      continue;
+    }
+    if (token.name === "acceptance-criteria") {
+      options.acceptanceCriteria = requireTokenValue(token, parseError).trim();
+      continue;
+    }
+    if (token.name === "validation-posture") {
+      options.validationPosture = requireTokenValue(token, parseError).trim();
+      continue;
+    }
+    if (token.name === "tmp-root") {
+      options.tmpRoot = requireTokenValue(token, parseError).trim();
+      continue;
+    }
+    throw parseError(`Unknown argument: ${token.rawName}`);
+  }
+  const missing = ["repo", "pr", "gate", "headSha", "angles"]
+    .filter((k) => options[k] === undefined);
+  if (missing.length > 0) {
+    throw parseError(`Missing required arguments: ${missing.join(", ")}`);
+  }
+  return options;
+}
+
+/**
+ * Build the deterministic artifact path for a gate-review context handoff.
+ * Mirrors write-gate-findings-log.mjs buildLogPath. Exported for reuse by the
+ * Phase 3 fan-out reviewers so producer and consumer agree on the path.
+ *
+ * @param {object} input
+ * @param {string} input.repo — owner/name
+ * @param {number|string} input.pr
+ * @param {string} input.gate — draft_gate | pre_approval_gate
+ * @param {string} input.headSha
+ * @param {string} [input.tmpRoot] — default "tmp"
+ * @returns {string} relative artifact path
+ */
+export function buildGateContextPath({ repo, pr, gate, headSha, tmpRoot = "tmp" }) {
+  const parts = String(repo).split("/");
+  if (parts.length !== 2 || parts.some((p) => p.length === 0)) {
+    throw new Error(`--repo must be in owner/name format, got: ${JSON.stringify(repo)}`);
+  }
+  for (const p of parts) {
+    if (p === "." || p === ".." || /[\s\\]/.test(p)) {
+      throw new Error(`--repo segment ${JSON.stringify(p)} contains unsafe characters (dots, whitespace, or backslashes)`);
+    }
+  }
+  const repoSlug = parts.join("-");
+  return path.join(tmpRoot, "gate-context", repoSlug, `pr-${pr}`, `${gate}-${headSha}.json`);
+}
+
+/**
+ * Build the deterministic artifact object (no I/O). Exported for callers that
+ * want the artifact shape without writing it.
+ *
+ * @param {object} options — parsed CLI options shape
+ * @returns {object}
+ */
+export function buildGateContextArtifact(options) {
+  return {
+    repo: options.repo,
+    pr: options.pr,
+    gate: options.gate,
+    headSha: options.headSha,
+    resolvedAngles: [...options.angles],
+    rationale: Array.isArray(options.rationale) ? options.rationale : [],
+    scope: {
+      branch: options.branch ?? null,
+      headSha: options.headSha,
+      touchedFiles: Array.isArray(options.touchedFiles) ? options.touchedFiles : [],
+      acceptanceCriteria: options.acceptanceCriteria ?? null,
+      validationPosture: options.validationPosture ?? null,
+    },
+  };
+}
+
+export async function writeGateContext(options, { repoRoot = process.cwd() } = {}) {
+  const contextPath = buildGateContextPath({
+    repo: options.repo,
+    pr: options.pr,
+    gate: options.gate,
+    headSha: options.headSha,
+    tmpRoot: options.tmpRoot || "tmp",
+  });
+  const fullPath = path.resolve(repoRoot, contextPath);
+  const artifact = {
+    ...buildGateContextArtifact(options),
+    loggedAt: new Date().toISOString(),
+  };
+  await mkdir(path.dirname(fullPath), { recursive: true });
+  await writeFile(fullPath, JSON.stringify(artifact, null, 2) + "\n", "utf8");
+  return { ok: true, path: contextPath, artifact };
+}
+
+/**
+ * Context-builder entrypoint: resolve the dynamic review-angle set via the
+ * canonical resolver and persist the handoff artifact.
+ *
+ * Angle selection is delegated entirely to `resolveGateAnglesDynamic` (the
+ * single source of truth, which honors the mandatory-angle floor and falls back
+ * to the static configured pool when `dynamicAngles` is off or no diff is
+ * given). This function only maps that result into the artifact and writes it.
+ *
+ * @param {object} input
+ * @param {import("@dev-loops/core/config").DevLoopConfig} input.config — merged dev-loop config
+ * @param {string} input.gate — draft_gate | pre_approval_gate
+ * @param {{ nameStatusOutput: string, diffOutput?: string }} [input.diff] — diff for dynamic resolution
+ * @param {string} input.repo — owner/name
+ * @param {number|string} input.pr
+ * @param {string} input.headSha
+ * @param {string|null} [input.branch]
+ * @param {string[]} [input.touchedFiles]
+ * @param {string|null} [input.acceptanceCriteria]
+ * @param {string|null} [input.validationPosture]
+ * @param {string} [input.tmpRoot]
+ * @param {{ repoRoot?: string }} [opts]
+ * @returns {Promise<{ ok: boolean, path: string, artifact: object, resolver: object }>}
+ */
+export async function buildGateContext(input, { repoRoot = process.cwd() } = {}) {
+  const configKey = mapGateToConfigKey(input.gate);
+  const resolverResult = await resolveGateAnglesDynamic(input.config, configKey, {
+    diff: input.diff,
+  });
+  const { resolvedAngles, rationale } = rationaleFromResolver(resolverResult);
+
+  const writeResult = await writeGateContext(
+    {
+      repo: input.repo,
+      pr: input.pr,
+      gate: input.gate,
+      headSha: input.headSha,
+      angles: resolvedAngles,
+      rationale,
+      branch: input.branch ?? null,
+      touchedFiles: input.touchedFiles ?? [],
+      acceptanceCriteria: input.acceptanceCriteria ?? null,
+      validationPosture: input.validationPosture ?? null,
+      tmpRoot: input.tmpRoot || "tmp",
+    },
+    { repoRoot },
+  );
+
+  return { ...writeResult, resolver: resolverResult };
+}
+
+/**
+ * Read a previously-written gate context artifact. Returns null when absent.
+ *
+ * @param {object} input — { repo, pr, gate, headSha, tmpRoot }
+ * @param {{ repoRoot?: string }} [options]
+ * @returns {Promise<object|null>}
+ */
+export async function readGateContext(input, { repoRoot = process.cwd() } = {}) {
+  const contextPath = buildGateContextPath({
+    repo: input.repo,
+    pr: input.pr,
+    gate: input.gate,
+    headSha: input.headSha,
+    tmpRoot: input.tmpRoot || "tmp",
+  });
+  const fullPath = path.resolve(repoRoot, contextPath);
+  try {
+    const raw = await readFile(fullPath, "utf8");
+    return JSON.parse(raw);
+  } catch (err) {
+    if (err && err.code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+async function main() {
+  let options;
+  try {
+    options = parseWriteGateContextCliArgs(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${formatCliError(error, { usage: USAGE })}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  if (options.help) {
+    process.stdout.write(`${USAGE}\n`);
+    return;
+  }
+  try {
+    const result = await writeGateContext(options);
+    process.stdout.write(JSON.stringify(result) + "\n");
+  } catch (error) {
+    process.stderr.write(JSON.stringify({
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    }) + "\n");
+    process.exitCode = 1;
+  }
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  await main();
+}

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -62,10 +62,14 @@ export function rationaleFromResolver(resolverResult) {
     ? resolverResult.skippedAngles
     : [];
   const reasons = resolverResult?.reasons ?? {};
+  const dynamicActive = resolverResult?.dynamicAnglesActive === true;
+  const keptReason = dynamicActive
+    ? "selected by dynamic angle resolver"
+    : "static pool (dynamic angle resolution inactive)";
 
   const rationale = [];
   for (const angle of recommended) {
-    rationale.push({ angle, action: "kept", reason: "selected by dynamic angle resolver" });
+    rationale.push({ angle, action: "kept", reason: keptReason });
   }
   for (const angle of skipped) {
     rationale.push({

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -4,7 +4,7 @@
  *
  * The gate-review context-builder (Phase 1 of the gate-review sub-loop) resolves
  * the dynamic review-angle set and writes a deterministic JSON handoff artifact
- * that downstream fan-out reviewers (Phase 3) consume. This module owns that
+ * that the downstream fork fan-out reviewers consume. This module owns that
  * artifact: a deterministic path builder, a writer, and a reader for round-trip
  * use, plus a thin context-builder entrypoint (`buildGateContext`) that derives
  * the angle set + rationale directly from the canonical resolver.
@@ -280,7 +280,7 @@ export function parseWriteGateContextCliArgs(argv) {
 /**
  * Build the deterministic artifact path for a gate-review context handoff.
  * Mirrors write-gate-findings-log.mjs buildLogPath. Exported for reuse by the
- * Phase 3 fan-out reviewers so producer and consumer agree on the path.
+ * fork fan-out reviewers so producer and consumer agree on the path.
  *
  * @param {object} input
  * @param {string} input.repo — owner/name

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -1,0 +1,376 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { resolveGateAnglesDynamic } from "@dev-loops/core/config";
+
+import {
+  buildGateContext,
+  buildGateContextArtifact,
+  buildGateContextPath,
+  mapGateToConfigKey,
+  parseWriteGateContextCliArgs,
+  rationaleFromResolver,
+  readGateContext,
+  writeGateContext,
+} from "../../scripts/github/write-gate-context.mjs";
+
+function draftConfig(overrides = {}) {
+  return {
+    version: 1,
+    gates: {
+      draft: {
+        angles: ["scope", "coverage", "correctness", "docs", "link-check", "config-drift"],
+        mandatoryAngles: ["gate-evidence"],
+        excludeAngles: [],
+        dynamicAngles: true,
+        ...overrides,
+      },
+    },
+  };
+}
+
+const DOCS_ONLY_DIFF = {
+  nameStatusOutput: "M\tdocs/foo.md\nM\tREADME.md\n",
+  diffOutput: "",
+};
+
+// ---------------------------------------------------------------------------
+// Path builder
+// ---------------------------------------------------------------------------
+
+test("buildGateContextPath produces a deterministic slugged path", () => {
+  const p = buildGateContextPath({
+    repo: "owner/repo",
+    pr: 42,
+    gate: "draft_gate",
+    headSha: "abc1234",
+    tmpRoot: "tmp",
+  });
+  assert.equal(p, path.join("tmp", "gate-context", "owner-repo", "pr-42", "draft_gate-abc1234.json"));
+});
+
+test("buildGateContextPath honors custom tmp-root", () => {
+  const p = buildGateContextPath({
+    repo: "a/b",
+    pr: 1,
+    gate: "pre_approval_gate",
+    headSha: "deadbeef",
+    tmpRoot: "custom",
+  });
+  assert.equal(p, path.join("custom", "gate-context", "a-b", "pr-1", "pre_approval_gate-deadbeef.json"));
+});
+
+test("buildGateContextPath rejects malformed repo", () => {
+  assert.throws(() => buildGateContextPath({ repo: "no-slash", pr: 1, gate: "draft_gate", headSha: "abc1234" }), /owner\/name/);
+  assert.throws(() => buildGateContextPath({ repo: "../x/y", pr: 1, gate: "draft_gate", headSha: "abc1234" }), /owner\/name|unsafe/);
+});
+
+// ---------------------------------------------------------------------------
+// CLI arg parsing
+// ---------------------------------------------------------------------------
+
+test("parseWriteGateContextCliArgs parses required args", () => {
+  const result = parseWriteGateContextCliArgs([
+    "--repo", "owner/repo",
+    "--pr", "42",
+    "--gate", "draft_gate",
+    "--head-sha", "abc1234567890abcdef",
+    "--angles", '["scope","correctness"]',
+  ]);
+  assert.equal(result.repo, "owner/repo");
+  assert.equal(result.pr, 42);
+  assert.equal(result.gate, "draft_gate");
+  assert.equal(result.headSha, "abc1234567890abcdef");
+  assert.deepEqual(result.angles, ["scope", "correctness"]);
+  assert.equal(result.tmpRoot, "tmp");
+});
+
+test("parseWriteGateContextCliArgs parses optional scope + rationale", () => {
+  const result = parseWriteGateContextCliArgs([
+    "--repo", "a/b", "--pr", "3", "--gate", "pre_approval_gate",
+    "--head-sha", "deadbeef1234567890",
+    "--angles", '["scope"]',
+    "--rationale", '[{"angle":"coverage","action":"dropped","reason":"docs-only"}]',
+    "--branch", "issue-877",
+    "--touched-files", '["docs/x.md"]',
+    "--acceptance-criteria", "#877",
+    "--validation-posture", "npm run verify",
+  ]);
+  assert.deepEqual(result.rationale, [{ angle: "coverage", action: "dropped", reason: "docs-only" }]);
+  assert.equal(result.branch, "issue-877");
+  assert.deepEqual(result.touchedFiles, ["docs/x.md"]);
+  assert.equal(result.acceptanceCriteria, "#877");
+  assert.equal(result.validationPosture, "npm run verify");
+});
+
+test("parseWriteGateContextCliArgs rejects invalid gate", () => {
+  assert.throws(() => parseWriteGateContextCliArgs([
+    "--repo", "a/b", "--pr", "1", "--gate", "bad", "--head-sha", "abc1234", "--angles", "[]",
+  ]), /gate/);
+});
+
+test("parseWriteGateContextCliArgs rejects invalid head-sha", () => {
+  assert.throws(() => parseWriteGateContextCliArgs([
+    "--repo", "a/b", "--pr", "1", "--gate", "draft_gate", "--head-sha", "zzz", "--angles", "[]",
+  ]), /head-sha/);
+});
+
+test("parseWriteGateContextCliArgs rejects non-array angles", () => {
+  assert.throws(() => parseWriteGateContextCliArgs([
+    "--repo", "a/b", "--pr", "1", "--gate", "draft_gate", "--head-sha", "abc1234", "--angles", "{}",
+  ]), /array/);
+});
+
+test("parseWriteGateContextCliArgs rejects bad rationale action", () => {
+  assert.throws(() => parseWriteGateContextCliArgs([
+    "--repo", "a/b", "--pr", "1", "--gate", "draft_gate", "--head-sha", "abc1234",
+    "--angles", '["scope"]',
+    "--rationale", '[{"angle":"scope","action":"bogus","reason":"x"}]',
+  ]), /action/);
+});
+
+test("parseWriteGateContextCliArgs reports missing required args", () => {
+  assert.throws(() => parseWriteGateContextCliArgs(["--repo", "a/b"]), /Missing required/);
+});
+
+// ---------------------------------------------------------------------------
+// Artifact shape
+// ---------------------------------------------------------------------------
+
+test("buildGateContextArtifact records angles + rationale + scope", () => {
+  const artifact = buildGateContextArtifact({
+    repo: "a/b", pr: 5, gate: "draft_gate", headSha: "abc1234",
+    angles: ["scope"],
+    rationale: [{ angle: "scope", action: "kept", reason: "relevant" }],
+    branch: "feat", touchedFiles: ["x.mjs"],
+    acceptanceCriteria: "#5", validationPosture: "npm test",
+  });
+  assert.deepEqual(artifact.resolvedAngles, ["scope"]);
+  assert.equal(artifact.rationale.length, 1);
+  assert.deepEqual(artifact.scope, {
+    branch: "feat",
+    headSha: "abc1234",
+    touchedFiles: ["x.mjs"],
+    acceptanceCriteria: "#5",
+    validationPosture: "npm test",
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Write / read round-trip
+// ---------------------------------------------------------------------------
+
+test("writeGateContext + readGateContext round-trip", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-"));
+  try {
+    const options = parseWriteGateContextCliArgs([
+      "--repo", "owner/repo", "--pr", "7", "--gate", "draft_gate",
+      "--head-sha", "abc1234567890",
+      "--angles", '["scope","docs"]',
+      "--rationale", '[{"angle":"scope","action":"kept","reason":"relevant"}]',
+      "--branch", "issue-877",
+      "--touched-files", '["docs/a.md"]',
+      "--acceptance-criteria", "#877",
+      "--validation-posture", "npm run verify",
+    ]);
+    const writeResult = await writeGateContext(options, { repoRoot });
+
+    assert.equal(writeResult.ok, true);
+    assert.equal(
+      writeResult.path,
+      path.join("tmp", "gate-context", "owner-repo", "pr-7", "draft_gate-abc1234567890.json"),
+    );
+
+    const onDisk = JSON.parse(await readFile(path.resolve(repoRoot, writeResult.path), "utf8"));
+    assert.deepEqual(onDisk.resolvedAngles, ["scope", "docs"]);
+    assert.equal(onDisk.scope.branch, "issue-877");
+    assert.equal(typeof onDisk.loggedAt, "string");
+
+    const reread = await readGateContext({
+      repo: "owner/repo", pr: 7, gate: "draft_gate", headSha: "abc1234567890",
+    }, { repoRoot });
+    assert.deepEqual(reread.resolvedAngles, ["scope", "docs"]);
+    assert.deepEqual(reread.scope.touchedFiles, ["docs/a.md"]);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("readGateContext returns null when artifact absent", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-"));
+  try {
+    const result = await readGateContext({
+      repo: "owner/repo", pr: 999, gate: "draft_gate", headSha: "abc1234",
+    }, { repoRoot });
+    assert.equal(result, null);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Gate-name mapping
+// ---------------------------------------------------------------------------
+
+test("mapGateToConfigKey maps artifact gate names to config keys", () => {
+  assert.equal(mapGateToConfigKey("draft_gate"), "draft");
+  assert.equal(mapGateToConfigKey("pre_approval_gate"), "preApproval");
+  assert.throws(() => mapGateToConfigKey("bogus"), /Unknown gate/);
+});
+
+// ---------------------------------------------------------------------------
+// rationaleFromResolver — maps resolver output, does not re-derive angles
+// ---------------------------------------------------------------------------
+
+test("rationaleFromResolver maps recommended→kept and skipped→dropped with reasons", () => {
+  const { resolvedAngles, rationale } = rationaleFromResolver({
+    recommendedAngles: ["gate-evidence", "docs"],
+    skippedAngles: ["coverage"],
+    reasons: { coverage: "DOCS_ONLY" },
+  });
+  assert.deepEqual(resolvedAngles, ["gate-evidence", "docs"]);
+  assert.deepEqual(rationale.find((r) => r.angle === "gate-evidence"), {
+    angle: "gate-evidence", action: "kept", reason: "selected by dynamic angle resolver",
+  });
+  assert.deepEqual(rationale.find((r) => r.angle === "coverage"), {
+    angle: "coverage", action: "dropped", reason: "DOCS_ONLY",
+  });
+});
+
+test("rationaleFromResolver tolerates null/empty resolver output", () => {
+  const { resolvedAngles, rationale } = rationaleFromResolver({ recommendedAngles: null });
+  assert.deepEqual(resolvedAngles, []);
+  assert.deepEqual(rationale, []);
+});
+
+// ---------------------------------------------------------------------------
+// buildGateContext — integration with the canonical resolver
+// ---------------------------------------------------------------------------
+
+test("buildGateContext persists resolveGateAnglesDynamic output (docs-only)", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-"));
+  try {
+    const config = draftConfig();
+
+    // Verify against the canonical resolver directly (single source of truth).
+    const resolver = await resolveGateAnglesDynamic(config, "draft", { diff: DOCS_ONLY_DIFF });
+    assert.equal(resolver.dynamicAnglesActive, true);
+
+    const result = await buildGateContext(
+      {
+        config,
+        gate: "draft_gate",
+        diff: DOCS_ONLY_DIFF,
+        repo: "owner/repo",
+        pr: 12,
+        headSha: "abc1234567890",
+        branch: "issue-877",
+        touchedFiles: ["docs/foo.md", "README.md"],
+        acceptanceCriteria: "#877",
+        validationPosture: "npm run verify",
+      },
+      { repoRoot },
+    );
+
+    // resolvedAngles mirror the resolver's recommendedAngles exactly.
+    assert.deepEqual(result.artifact.resolvedAngles, resolver.recommendedAngles);
+
+    // Mandatory floor present in resolvedAngles.
+    assert.ok(result.artifact.resolvedAngles.includes("gate-evidence"));
+
+    // Dropped angles (skipped by the resolver) appear in rationale as 'dropped'.
+    for (const dropped of resolver.skippedAngles) {
+      const entry = result.artifact.rationale.find((r) => r.angle === dropped);
+      assert.equal(entry.action, "dropped");
+      assert.equal(entry.reason, resolver.reasons[dropped]);
+    }
+    // docs-only drops code lenses.
+    assert.ok(!result.artifact.resolvedAngles.includes("coverage"));
+    assert.ok(result.artifact.rationale.some((r) => r.angle === "coverage" && r.action === "dropped"));
+
+    // Scope persisted.
+    assert.deepEqual(result.artifact.scope, {
+      branch: "issue-877",
+      headSha: "abc1234567890",
+      touchedFiles: ["docs/foo.md", "README.md"],
+      acceptanceCriteria: "#877",
+      validationPosture: "npm run verify",
+    });
+
+    // Round-trips on disk.
+    const onDisk = await readGateContext({
+      repo: "owner/repo", pr: 12, gate: "draft_gate", headSha: "abc1234567890",
+    }, { repoRoot });
+    assert.deepEqual(onDisk.resolvedAngles, resolver.recommendedAngles);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("buildGateContext with dynamicAngles=off persists the static pool, all kept", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-"));
+  try {
+    const config = draftConfig({ dynamicAngles: false });
+    const resolver = await resolveGateAnglesDynamic(config, "draft", { diff: DOCS_ONLY_DIFF });
+    assert.equal(resolver.dynamicAnglesActive, false);
+
+    const result = await buildGateContext(
+      {
+        config,
+        gate: "draft_gate",
+        diff: DOCS_ONLY_DIFF,
+        repo: "owner/repo",
+        pr: 13,
+        headSha: "deadbeef1234",
+      },
+      { repoRoot },
+    );
+
+    // Static pool preserved unchanged (no drops) — matches resolver output.
+    assert.deepEqual(result.artifact.resolvedAngles, resolver.recommendedAngles);
+    assert.ok(result.artifact.resolvedAngles.includes("coverage")); // not dropped
+    assert.ok(result.artifact.resolvedAngles.includes("gate-evidence")); // mandatory floor
+    // No 'dropped' rationale entries in static mode.
+    assert.ok(result.artifact.rationale.every((r) => r.action === "kept"));
+    assert.equal(result.artifact.rationale.length, resolver.recommendedAngles.length);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("buildGateContext maps pre_approval_gate to the preApproval config key", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-"));
+  try {
+    const config = {
+      version: 1,
+      gates: {
+        preApproval: {
+          angles: ["dry", "kiss", "docs"],
+          mandatoryAngles: ["renderer-security"],
+          excludeAngles: [],
+          dynamicAngles: true,
+        },
+      },
+    };
+    const result = await buildGateContext(
+      {
+        config,
+        gate: "pre_approval_gate",
+        diff: DOCS_ONLY_DIFF,
+        repo: "a/b",
+        pr: 14,
+        headSha: "feedface1234",
+      },
+      { repoRoot },
+    );
+    // Mandatory floor honored for the preApproval gate.
+    assert.ok(result.artifact.resolvedAngles.includes("renderer-security"));
+    assert.equal(result.artifact.gate, "pre_approval_gate");
+    assert.equal(result.path, path.join("tmp", "gate-context", "a-b", "pr-14", "pre_approval_gate-feedface1234.json"));
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -230,6 +230,7 @@ test("rationaleFromResolver maps recommended→kept and skipped→dropped with r
     recommendedAngles: ["gate-evidence", "docs"],
     skippedAngles: ["coverage"],
     reasons: { coverage: "DOCS_ONLY" },
+    dynamicAnglesActive: true,
   });
   assert.deepEqual(resolvedAngles, ["gate-evidence", "docs"]);
   assert.deepEqual(rationale.find((r) => r.angle === "gate-evidence"), {
@@ -238,6 +239,19 @@ test("rationaleFromResolver maps recommended→kept and skipped→dropped with r
   assert.deepEqual(rationale.find((r) => r.angle === "coverage"), {
     angle: "coverage", action: "dropped", reason: "DOCS_ONLY",
   });
+});
+
+test("rationaleFromResolver marks kept angles as static when dynamic resolution is inactive", () => {
+  const { rationale } = rationaleFromResolver({
+    recommendedAngles: ["gate-evidence", "coverage"],
+    skippedAngles: [],
+    reasons: {},
+    dynamicAnglesActive: false,
+  });
+  for (const r of rationale) {
+    assert.equal(r.action, "kept");
+    assert.equal(r.reason, "static pool (dynamic angle resolution inactive)");
+  }
 });
 
 test("rationaleFromResolver tolerates null/empty resolver output", () => {


### PR DESCRIPTION
## Summary

**Phase 2 of epic #867.** Add the gate-review **context-builder handoff artifact** — it persists the dynamically-resolved review-angle set + rationale + scope so Phase 3 (#878) can fan out one reviewer per resolved angle.

## Approach

Uses the **existing canonical resolver** `resolveGateAnglesDynamic` (config.mjs) — which already enforces the mandatory-angle floor (mandatory angles always merged back; only the candidate pool is dynamically selected) and falls back to the static pool when `dynamicAngles` is off. **No parallel resolver/classifier** — an earlier draft that duplicated this machinery was removed.

- `scripts/github/write-gate-context.mjs`: deterministic `tmp/gate-context/<repo>/pr-<N>/<gate>-<headSha>.json` path builder + writer/reader (mirrors `write-gate-findings-log.mjs`). `buildGateContext()` calls `resolveGateAnglesDynamic`, maps `recommendedAngles → resolvedAngles` and `skippedAngles`/`reasons → rationale (kept/dropped)`, persists scope.
- `docs/gate-review-sub-loop-contract.md`: Phase 1 note.

## Non-goals

- Live per-angle reviewer fan-out (#878, Phase 3); enforcement flip (#879, Phase 4).

## Validation

- `npm run verify` — pass (core 1560, scripts 1524, docs/links/dup, dev-loop 32; 0 fail).
- Tests cover: mandatory floor present in resolved set, dropped angles → rationale with resolver reasons, `dynamicAngles=off` → static pool all-kept, both gate mappings, deterministic path + round-trip.

Part of #867 (epic) — Phase 2.


Closes #877
