### PR TITLE
feat(gates): flip requireFanoutEvidence default-on + dynamic angles (#879)

### DIFF
--- a/.devloops
+++ b/.devloops
@@ -10,12 +10,13 @@ refinement:
   maxCopilotRounds: 2
 
 gates:
-  # Opt-in fail-closed enforcement that gate verdicts were produced by the
+  # Fail-closed enforcement that gate verdicts were produced by the
   # fan-out/fan-in review sub-loop (executionMode fanout_fanin + a findings-log
-  # ledger), not an inline single-agent run. Phases 2-3 (live fan-out + dynamic
-  # angle resolution) are the follow-up that makes fanout_fanin producible.
-  requireFanoutEvidence: false
+  # ledger), not an inline single-agent run. This repo runs enforcement on its
+  # own gates; dynamic angle resolution (below) scopes the fan-out per change.
+  requireFanoutEvidence: true
   draft:
+    dynamicAngles: true
     angles:
       - scope
       - coverage
@@ -39,6 +40,7 @@ gates:
       - must-fix
       - worth-fixing-now
   preApproval:
+    dynamicAngles: true
     angles:
       - dry
       - kiss

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Changed
+
+- **Gate fan-out evidence enforcement is now ON by default** (#879, epic #867 final phase). A clean gate verdict requires the gate to run via `--execution-mode fanout_fanin` with a findings-log ledger for the head SHA; the pre-merge evidence check fails closed otherwise. Repos can opt out with `gates.requireFanoutEvidence: false`. See [docs/gate-review-sub-loop-contract.md](docs/gate-review-sub-loop-contract.md).
+
 ## 0.2.8
 
 ### Added

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -203,7 +203,7 @@ resolved-in SHA (for findings resolved in a later pass).
 ## Execution mode and fan-out evidence enforcement
 
 Each gate verdict records an `executionMode` (`fanout_fanin` or `inline_single_agent`,
-default `inline_single_agent`) via the [Gate comment command](../skills/copilot-pr-followup/SKILL.md#mandatory-gate-comment-command-contract); inline runs must declare an `--inline-reason`. The opt-in `gates.requireFanoutEvidence` config (default `false`) makes the pre-merge evidence check fail closed for a required gate unless its recorded `executionMode` is `fanout_fanin` and a findings-log ledger exists for that gate + head SHA. Live context-builder/fan-out execution (the follow-up work tracked in epic #867) is what makes `fanout_fanin` producible — distinct from this contract's own sub-loop phase numbering (preamble / fanout / fanin).
+default `inline_single_agent`) via the [Gate comment command](../skills/copilot-pr-followup/SKILL.md#mandatory-gate-comment-command-contract); inline runs must declare an `--inline-reason`. Fan-out evidence enforcement is **ON by default** (`gates.requireFanoutEvidence`): a clean gate verdict requires the gate to run via `--execution-mode fanout_fanin` with a findings-log ledger for the head SHA, and the pre-merge evidence check fails closed for a required gate otherwise. Repos can opt out with `gates.requireFanoutEvidence: false`. Live context-builder/fan-out execution (epic #867) is what makes `fanout_fanin` producible — distinct from this contract's own sub-loop phase numbering (preamble / fanout / fanin).
 
 ## See also
 

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -53,11 +53,12 @@ const GatesConfig = z.strictObject({
   // `requireCi` is only behaviorally configurable for the draft gate.
   // preApproval always requires CI even if config repeats `requireCi`.
   preApproval: GateConfig.optional(),
-  // Opt-in fail-closed enforcement that a gate verdict was produced by the
+  // Fail-closed enforcement that a gate verdict was produced by the
   // fan-out/fan-in review sub-loop (executionMode === "fanout_fanin" plus a
   // durable findings-log ledger), not an inline single-agent run. Default
-  // false preserves current behavior. See docs/gate-review-sub-loop-contract.md.
-  requireFanoutEvidence: z.boolean().default(false),
+  // true (opt-out): a clean gate verdict requires fan-out/fan-in evidence
+  // unless explicitly disabled. See docs/gate-review-sub-loop-contract.md.
+  requireFanoutEvidence: z.boolean().default(true),
   // Cap on how many scoped `review` reviewers the gate fan-out spawns in
   // parallel. When the resolved angle set exceeds this cap, the overflow runs
   // in sequential batches and the degradation is recorded in the gate evidence.
@@ -831,16 +832,19 @@ export function resolveGateConfig(config, gate) {
 /**
  * Resolve whether fan-out/fan-in review evidence is required for a gate verdict.
  *
- * Opt-in, defaults to false. When true, the pre-merge evidence check fails
+ * Default-on (opt-out): enforcement is ON unless `gates.requireFanoutEvidence`
+ * is explicitly set to false. When ON, the pre-merge evidence check fails
  * closed unless a required gate's recorded executionMode is "fanout_fanin" and
- * a durable findings-log ledger exists for that gate + head SHA. See
+ * a durable findings-log ledger exists for that gate + head SHA. Using a
+ * `!== false` test (rather than `=== true`) keeps the opt-out semantics robust
+ * for programmatically-built config objects that bypass schema defaulting. See
  * docs/gate-review-sub-loop-contract.md.
  *
  * @param {DevLoopConfig} config
  * @returns {boolean}
  */
 export function resolveRequireFanoutEvidence(config) {
-  return config?.gates?.requireFanoutEvidence === true;
+  return config?.gates?.requireFanoutEvidence !== false;
 }
 
 /** Default parallel fan-out reviewer cap (mirrors GatesConfig.maxFanoutReviewers). */

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -2681,12 +2681,24 @@ describe("resolveGateAnglesDynamic", () => {
 });
 
 describe("gates.requireFanoutEvidence", () => {
-  test("defaults to false and resolveRequireFanoutEvidence reflects it", () => {
-    assert.equal(resolveRequireFanoutEvidence({}), false);
-    assert.equal(resolveRequireFanoutEvidence({ gates: {} }), false);
+  test("defaults to true (opt-out) and resolveRequireFanoutEvidence reflects it", () => {
+    // Default-on: enforcement is ON unless explicitly disabled. The `!== false`
+    // resolver semantics keep opt-out robust for programmatically-built config.
+    assert.equal(resolveRequireFanoutEvidence({}), true);
+    assert.equal(resolveRequireFanoutEvidence({ gates: {} }), true);
+    assert.equal(resolveRequireFanoutEvidence({ gates: { requireFanoutEvidence: true } }), true);
     const parsed = DevLoopConfigSchema.safeParse({ version: 1, gates: { draft: {} } });
     assert.equal(parsed.success, true);
+    assert.equal(parsed.data.gates.requireFanoutEvidence, true);
+    assert.equal(resolveRequireFanoutEvidence(parsed.data), true);
+  });
+
+  test("opt-out: explicit requireFanoutEvidence: false disables enforcement", () => {
+    assert.equal(resolveRequireFanoutEvidence({ gates: { requireFanoutEvidence: false } }), false);
+    const parsed = DevLoopConfigSchema.safeParse({ version: 1, gates: { requireFanoutEvidence: false } });
+    assert.equal(parsed.success, true);
     assert.equal(parsed.data.gates.requireFanoutEvidence, false);
+    assert.equal(resolveRequireFanoutEvidence(parsed.data), false);
   });
 
   test("accepts requireFanoutEvidence: true in full and file schemas", () => {

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -292,14 +292,16 @@ async function ledgerExists(fullPath) {
  *
  * Enforcement is ON by default (opt-out via gates.requireFanoutEvidence: false).
  * Returns { required: false } when enforcement is disabled OR when config is
- * unavailable (config === null after a failed load) — config-unavailable must
+ * unavailable (config == null — null or undefined — after a failed load) — config-unavailable must
  * fail open and never enable enforcement. When enabled, records per-required-gate
  * executionMode and whether the deterministic findings-log ledger exists for the
  * reviewed head SHA so the pre-merge check can fail closed on inline verdicts or
  * missing ledgers.
  */
 async function buildFanoutEnforcement({ repo, pr, currentHeadSha, draftGateMarker, preApprovalGateMarker, config, cwd }) {
-  // Fail open when config could not be loaded/validated (config === null).
+  // Fail open when config could not be loaded/validated. `== null` covers both
+  // null and undefined; the loader only ever yields null on failure, but the
+  // loose check defensively treats an absent config as unavailable.
   if (config == null || !resolveRequireFanoutEvidence(config)) {
     return { required: false, gates: [] };
   }

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -244,9 +244,9 @@ export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null, s
   )) {
     failures.push("missing visible clean current-head pre_approval_gate comment");
   }
-  // Opt-in fail-closed fan-out evidence enforcement (gates.requireFanoutEvidence).
-  // When disabled (default), fanoutEnforcement is { required: false, gates: [] }
-  // so the `.required` guard skips this block, preserving current behavior.
+  // Fail-closed fan-out evidence enforcement (gates.requireFanoutEvidence, ON by
+  // default / opt-out). When disabled or config-unavailable, fanoutEnforcement is
+  // { required: false, gates: [] } so the `.required` guard skips this block.
   if (fanoutEnforcement && fanoutEnforcement.required) {
     for (const gate of fanoutEnforcement.gates) {
       if (gate.executionMode !== "fanout_fanin") {
@@ -288,15 +288,19 @@ async function ledgerExists(fullPath) {
   }
 }
 /**
- * Build the opt-in fan-out evidence enforcement descriptor.
+ * Build the fan-out evidence enforcement descriptor.
  *
- * Returns { required: false } when gates.requireFanoutEvidence is disabled
- * (default). When enabled, records per-required-gate executionMode and whether
- * the deterministic findings-log ledger exists for the reviewed head SHA so the
- * pre-merge check can fail closed on inline verdicts or missing ledgers.
+ * Enforcement is ON by default (opt-out via gates.requireFanoutEvidence: false).
+ * Returns { required: false } when enforcement is disabled OR when config is
+ * unavailable (config === null after a failed load) — config-unavailable must
+ * fail open and never enable enforcement. When enabled, records per-required-gate
+ * executionMode and whether the deterministic findings-log ledger exists for the
+ * reviewed head SHA so the pre-merge check can fail closed on inline verdicts or
+ * missing ledgers.
  */
 async function buildFanoutEnforcement({ repo, pr, currentHeadSha, draftGateMarker, preApprovalGateMarker, config, cwd }) {
-  if (!resolveRequireFanoutEvidence(config)) {
+  // Fail open when config could not be loaded/validated (config === null).
+  if (config == null || !resolveRequireFanoutEvidence(config)) {
     return { required: false, gates: [] };
   }
   const draftRequired = resolveGateConfig(config, "draft").required;

--- a/test/github/detect-checkpoint-evidence-stale-runner.test.mjs
+++ b/test/github/detect-checkpoint-evidence-stale-runner.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -143,6 +143,10 @@ test("detect-checkpoint-evidence includes staleRunner and staleRunnerCheck in su
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-stale-runner-ckpt-"));
 
   try {
+    // This test exercises stale-runner/staleRunnerCheck output, not fan-out
+    // evidence enforcement (now ON by default). Opt out so the inline clean gate
+    // comments pass the pre-merge check.
+    await writeFile(path.join(tempDir, ".devloops"), "version: 1\ngates:\n  requireFanoutEvidence: false\n", "utf8");
     const env = await writeGhStub(tempDir);
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], {
       cwd: tempDir,

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -205,6 +205,9 @@ test("detect-checkpoint-evidence summarizes the newest valid live gate comments 
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-checkpoint-evidence-"));
 
   try {
+    // Enforcement-agnostic test: opt out of the (now default-on) fan-out evidence
+    // enforcement so inline clean gate comments pass the pre-merge check.
+    await writeFile(path.join(tempDir, ".devloops"), "version: 1\ngates:\n  requireFanoutEvidence: false\n", "utf8");
     const env = await writeGhStub(tempDir, [
       {
         assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
@@ -267,7 +270,7 @@ test("detect-checkpoint-evidence summarizes the newest valid live gate comments 
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 0);
     assert.equal(result.stderr, "");
@@ -352,6 +355,9 @@ test("detect-checkpoint-evidence fails pre-merge check when only draft gate exis
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-checkpoint-evidence-pages-"));
 
   try {
+    // Enforcement-agnostic test (asserts the missing-pre-approval failure). Opt
+    // out of the now default-on fan-out evidence enforcement.
+    await writeFile(path.join(tempDir, ".devloops"), "version: 1\ngates:\n  requireFanoutEvidence: false\n", "utf8");
     const env = await writeGhStub(tempDir, [
       {
         assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
@@ -394,7 +400,7 @@ test("detect-checkpoint-evidence fails pre-merge check when only draft gate exis
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 1);
     assert.equal(result.stdout, "");
@@ -505,6 +511,9 @@ test("detect-checkpoint-evidence always passes pre-merge check with clean draft 
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-gate-review-premerge-clean-"));
 
   try {
+    // Enforcement-agnostic test (clean inline gate comments). Opt out of the now
+    // default-on fan-out evidence enforcement.
+    await writeFile(path.join(tempDir, ".devloops"), "version: 1\ngates:\n  requireFanoutEvidence: false\n", "utf8");
     const env = await writeGhStub(tempDir, [
       {
         assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
@@ -550,7 +559,7 @@ test("detect-checkpoint-evidence always passes pre-merge check with clean draft 
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 0, result.stderr);
     const payload = JSON.parse(result.stdout);
@@ -832,8 +841,8 @@ function cleanEvidence() {
   };
 }
 
-test("buildPreMergeGateCheck default (requireFanoutEvidence off) ignores executionMode", () => {
-  // No fanoutEnforcement argument => current behavior preserved.
+test("buildPreMergeGateCheck with no/disabled enforcement descriptor ignores executionMode", () => {
+  // No fanoutEnforcement argument (or { required: false }) => enforcement skipped.
   const result = buildPreMergeGateCheck(cleanEvidence(), 0, null);
   assert.equal(result.ok, true);
   assert.deepEqual(result.failures, []);
@@ -960,6 +969,9 @@ test("detect-checkpoint-evidence passes pre-merge when all human review threads 
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-gate-human-resolved-"));
 
   try {
+    // Enforcement-agnostic test (resolved human threads). Opt out of the now
+    // default-on fan-out evidence enforcement.
+    await writeFile(path.join(tempDir, ".devloops"), "version: 1\ngates:\n  requireFanoutEvidence: false\n", "utf8");
     const env = await writeGhStub(tempDir, [
       {
         assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
@@ -1012,7 +1024,7 @@ test("detect-checkpoint-evidence passes pre-merge when all human review threads 
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 0);
     const payload = JSON.parse(result.stdout);
@@ -1092,6 +1104,9 @@ test("detect-checkpoint-evidence finds gate comment posted as PR review (root ca
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-gate-review-from-pr-review-"));
 
   try {
+    // Enforcement-agnostic test (PR-review gate-comment visibility). Opt out of
+    // the now default-on fan-out evidence enforcement.
+    await writeFile(path.join(tempDir, ".devloops"), "version: 1\ngates:\n  requireFanoutEvidence: false\n", "utf8");
     const prReviewGateComment = {
       id: 900,
       body: [
@@ -1148,7 +1163,7 @@ test("detect-checkpoint-evidence finds gate comment posted as PR review (root ca
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 0, result.stderr);
     const payload = JSON.parse(result.stdout);
@@ -1214,6 +1229,10 @@ async function writeLedger(tempDir, gate) {
 test("detect-checkpoint-evidence surfaces executionMode in gate markers", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-execmode-"));
   try {
+    // This test exercises executionMode surfacing, not enforcement. Opt out of
+    // the (now default-on) fan-out evidence enforcement so inline verdicts are
+    // accepted and the surfaced executionMode can be asserted.
+    await writeFile(path.join(tempDir, ".devloops"), "version: 1\ngates:\n  requireFanoutEvidence: false\n", "utf8");
     const env = await writeGhStub(tempDir, fanoutEvidenceGhEntries("inline_single_agent", "tiny change"));
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
     assert.equal(result.code, 0, result.stderr);
@@ -1221,7 +1240,7 @@ test("detect-checkpoint-evidence surfaces executionMode in gate markers", async 
     assert.equal(payload.draftGateMarker.executionMode, "inline_single_agent");
     assert.equal(payload.draftGateMarker.inlineReason, "tiny change");
     assert.equal(payload.preApprovalGateMarker.executionMode, "inline_single_agent");
-    // requireFanoutEvidence is not set in this tempDir => default false => enforcement off.
+    // requireFanoutEvidence is explicitly false => enforcement off (opt-out).
     assert.equal(payload.fanoutEnforcement.required, false);
     assert.deepEqual(payload.preMergeGateCheck.failures, []);
   } finally {

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -574,6 +574,9 @@ test("detect-checkpoint-evidence fails pre-merge check when pre-approval gate is
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-gate-review-stale-head-"));
 
   try {
+    // Hermetic: opt out of default-on fan-out enforcement so this test asserts
+    // only the stale-head failure, independent of the repo's .devloops.
+    await writeFile(path.join(tempDir, ".devloops"), "version: 1\ngates:\n  requireFanoutEvidence: false\n", "utf8");
     const env = await writeGhStub(tempDir, [
       {
         assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
@@ -619,7 +622,7 @@ test("detect-checkpoint-evidence fails pre-merge check when pre-approval gate is
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 1);
     const payload = JSON.parse(result.stderr);


### PR DESCRIPTION
## Summary

**Phase 4 (final) of epic #867.** Flip gate fan-out evidence enforcement to **default-on (opt-out)** and enable dynamic angle resolution for this repo's gates.

## Changes

- `config.mjs`: `requireFanoutEvidence` schema default `false → true`; `resolveRequireFanoutEvidence` returns ON unless explicitly `false` (opt-out semantics). `detect-checkpoint-evidence`: fail-open guard when config is unloadable (`null`) so a failed config load can't wrongly enable enforcement.
- `.devloops`: `requireFanoutEvidence: true` + `dynamicAngles: true` on both gates.
- Migration note (CHANGELOG + contract doc): clean gate verdicts now require `--execution-mode fanout_fanin` + a findings-log ledger; opt out via `gates.requireFanoutEvidence: false`.
- Updated the Phase-1 default-off tests to default-on + added opt-out coverage.

## Go-live / dogfood

This PR's own gates are run via a **real (representative-subset) fan-out** — scoped `review` agents over the mandatory + key angles → fan-in consolidation → disposition ledger → `fanout_fanin` verdict — proving the machinery end-to-end and satisfying the now-on enforcement. (Full-pool fan-out for a core change is ~29 reviewers; the dogfood runs a recorded representative subset.)

## Validation

- `npm run verify` — pass (core 1585; 0 fail); `generate-claude-assets --check` in sync.

Closes #879


## Non-goals

- No change to the angle-pool composition or the fan-in consolidation logic (Phase 3); this only flips the enforcement default and enables dynamic angle scoping.
