### PR TITLE
feat(queue): auto-sync linked issue board status on dev-loop transitions (#874)

### DIFF
--- a/.claude/skills/copilot-pr-followup/SKILL.md
+++ b/.claude/skills/copilot-pr-followup/SKILL.md
@@ -307,6 +307,11 @@ The canonical checkpoint verdict comment contract is [Gate Review Comment Contra
 - **CI prerequisite:** resolve the draft gate config first (`resolveGateConfig(config, "draft")`). When `requireCi=true` (default), wait for green current-head CI before entering `draft_gate`. When `requireCi=false`, the draft gate may proceed without green CI. This draft-only override does **not** relax `pre_approval_gate`; final approval and merge readiness still require green current-head CI.
 - **Pass criteria:** all configured draft gate angles pass; all findings at severities in `blockCleanOnFindingSeverities` are addressed; validation passes; no unrelated files are included.
 - **Next step after passing:** mark the PR ready for review.
+- **Board status sync (best-effort, after ready-for-review):** once the PR is created/marked ready for review, sync the linked issue's board item to "In Progress" so the queue board reflects active work without a manual `add-queue-item --status`:
+  ```sh
+  node <resolved-skill-scripts>/projects/sync-item-status.mjs --repo <owner/name> --item <linked-issue> --to-column "In Progress"
+  ```
+  Best-effort and NON-FATAL: it uses local `gh` auth (no CI/PAT), exits 0 when the board is not configured / the item is not on the board / the API fails, and never blocks marking the PR ready.
 - **Non-substitution rule:** a clean `draft_gate` comment only authorizes the draft → ready-for-review transition for that head SHA. It does **not** satisfy `pre_approval_gate`, final-approval readiness, or merge-ready requirements.
 - **Required PR comment:** post a visible checkpoint verdict comment using the mandatory [Gate comment command](#mandatory-gate-comment-command-contract). Keep validation reporting concise: include command names with pass/fail status. Do **not** paste raw passing test output into the visible gate comment. If you include a failing validation excerpt, keep it focused and truncate it to a deterministic retained-prefix length before posting the comment. See [Gate Review Comment Contract](../../docs/gate-review-comment-contract.md). Do not run `gh pr ready` unless a visible `clean` `draft_gate` checkpoint verdict comment exists for the current head SHA. A checkpoint verdict comment for an older head SHA does not satisfy this requirement for the current head. If findings exist, the PR stays draft and needs fixes before retry. If fixes advance the head SHA while still draft, post a new checkpoint verdict comment for the new head. If the checkpoint verdict comment cannot be posted, fail closed and do not run `gh pr ready`.
 
@@ -387,6 +392,14 @@ node <resolved-skill-scripts>/projects/archive-done-items.mjs --repo <owner/name
 ```
 
 Board and threshold resolve from `.devloops` (`queue.projectNumber`/`queue.boardTitle`, `queue.archiveOlderThanDays`, default 7d), using local `gh` auth — no CI, cron, or PAT. This step is best-effort and NON-FATAL: ignore any failure and never let it block the merge or the retrospective.
+
+Alongside the archive step, sync the linked issue's board item to "Done" so the queue board reflects the merge without a manual `add-queue-item --status`:
+
+```sh
+node <resolved-skill-scripts>/projects/sync-item-status.mjs --repo <owner/name> --item <linked-issue> --to-column "Done"
+```
+
+Same best-effort/NON-FATAL contract as the archive step: local `gh` auth (no CI/PAT), exits 0 when the board is not configured / the item is not on the board / the API fails, and never blocks the merge or the retrospective.
 
 ## Validation policy
 

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -53,6 +53,7 @@ const SUBCOMMAND_ROUTES = {
     move:    "scripts/projects/move-queue-item.mjs",
     reorder: "scripts/projects/reorder-queue-item.mjs",
     "archive-done": "scripts/projects/archive-done-items.mjs",
+    "sync-status": "scripts/projects/sync-item-status.mjs",
     ensure:  "scripts/projects/ensure-queue-board.mjs",
   },
   queue: {
@@ -116,6 +117,7 @@ const SUBCOMMAND_DESCRIPTIONS = {
     move: "Move queue item between Status columns",
     reorder: "Reorder items (move-to-top/move-after/order, --dry-run)",
     "archive-done": "Archive closed Done items older than a duration",
+    "sync-status": "Sync a queued issue/PR's board Status column (best-effort)",
     ensure: "Create/repair queue board bootstrap surface",
   },
   queue: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
     "./loop/pr-gate-coordination": "./src/loop/pr-gate-coordination.mjs",
     "./loop/pr-title-markers": "./src/loop/pr-title-markers.mjs",
     "./loop/public-dev-loop-routing": "./src/loop/public-dev-loop-routing.mjs",
+    "./loop/queue-board-sync": "./src/loop/queue-board-sync.mjs",
     "./loop/queue-driver": "./src/loop/queue-driver.mjs",
     "./loop/queue-parallel": "./src/loop/queue-parallel.mjs",
     "./loop/queue-state": "./src/loop/queue-state.mjs",

--- a/packages/core/src/loop/queue-board-sync.mjs
+++ b/packages/core/src/loop/queue-board-sync.mjs
@@ -370,7 +370,10 @@ export async function syncBoardStatus(
   const moveItem = dependencies.moveQueueItem ?? moveQueueItemMain;
   try {
     const result = await moveItem(
-      { repo, project: projectNumber, item: itemNumber, toColumn: targetColumn },
+      // move-queue-item validates project + item as string refs (CLI contract);
+      // resolveProjectNumber yields a number and itemNumber is numeric, so
+      // stringify both.
+      { repo, project: String(projectNumber), item: String(itemNumber), toColumn: targetColumn },
       { env, runChild: dependencies.runChild },
     );
     return { ok: true, skipped: false, result };

--- a/packages/core/test/queue-board-sync.test.mjs
+++ b/packages/core/test/queue-board-sync.test.mjs
@@ -94,6 +94,40 @@ test("syncBoardStatus moves item when configured", async () => {
   }
 });
 
+// AC #5 (#874): both dev-loop transitions move the item. "In Progress" is
+// covered above (PR-ready); this covers the merge → "Done" transition with the
+// same stringified-ref contract.
+test("syncBoardStatus moves item to Done (merge transition)", async () => {
+  const dir = await makeRepo("queue:\n  projectNumber: 5\n");
+  try {
+    const moved = [];
+    const result = await syncBoardStatus(
+      "owner/repo",
+      dir,
+      42,
+      "Done",
+      { GH_TOKEN: "mock" },
+      {
+        moveQueueItem: async (args, _ctx) => {
+          moved.push(args);
+          return { ok: true, item: { newColumn: args.toColumn } };
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.skipped, false);
+    assert.equal(moved.length, 1);
+    assert.deepEqual(moved[0], {
+      repo: "owner/repo",
+      project: "5",
+      item: "42",
+      toColumn: "Done",
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("syncBoardStatus fail-open when move fails", async () => {
   const dir = await makeRepo("queue:\n  projectNumber: 5\n");
   try {

--- a/packages/core/test/queue-board-sync.test.mjs
+++ b/packages/core/test/queue-board-sync.test.mjs
@@ -83,8 +83,10 @@ test("syncBoardStatus moves item when configured", async () => {
     assert.equal(moved.length, 1);
     assert.deepEqual(moved[0], {
       repo: "owner/repo",
-      project: 5,
-      item: 42,
+      // move-queue-item validates project + item as string refs; syncBoardStatus
+      // stringifies the resolved number/item before delegating.
+      project: "5",
+      item: "42",
       toColumn: "In Progress",
     });
   } finally {
@@ -464,8 +466,8 @@ test("syncBoardStatus resolves boardTitle to project number and moves item", asy
     assert.equal(moved.length, 1);
     assert.deepEqual(moved[0], {
       repo: "owner/repo",
-      project: 9,
-      item: 42,
+      project: "9",
+      item: "42",
       toColumn: "In Progress",
     });
   } finally {

--- a/scripts/projects/sync-item-status.mjs
+++ b/scripts/projects/sync-item-status.mjs
@@ -153,6 +153,9 @@ async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, 
   }
   if (args.help) {
     stdout.write(USAGE);
+    // Help is a success path: clear any pre-existing non-zero process.exitCode
+    // so help output can't inherit a leaked failure code.
+    process.exitCode = 0;
     return;
   }
 
@@ -187,6 +190,8 @@ if (isDirectCliRun(import.meta.url)) {
   runCli(process.argv.slice(2)).catch((error) => {
     // Best-effort: even an unexpected failure must not fail the caller.
     process.stdout.write(JSON.stringify({ ok: true, skipped: true, reason: error.message ?? "board sync failed" }) + "\n");
+    // Force the documented exit-0 contract even on this last-resort path.
+    process.exitCode = 0;
   });
 }
 

--- a/scripts/projects/sync-item-status.mjs
+++ b/scripts/projects/sync-item-status.mjs
@@ -34,7 +34,7 @@ function parseCliArgs(argv) {
   const requireValue = (token, message, code) => {
     const v = token.value;
     if (typeof v !== "string" || v.length === 0 || v.startsWith("-")) {
-      throw Object.assign(new Error(message), { code });
+      throw Object.assign(new Error(message), { code, usage: USAGE });
     }
     return v;
   };
@@ -91,6 +91,13 @@ const REPO_NAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9_.-]*[a-zA-Z0-9])?$/;
 function validateRepo(repo) {
   if (!repo || typeof repo !== "string") {
     throw Object.assign(new Error("--repo is required"), { code: "INVALID_REPO" });
+  }
+  const trimmed = repo.trim();
+  if (trimmed !== repo) {
+    throw Object.assign(
+      new Error(`--repo must not have leading/trailing whitespace, got "${repo}"`),
+      { code: "INVALID_REPO" },
+    );
   }
   const slashIdx = repo.indexOf("/");
   if (slashIdx === -1) {
@@ -165,9 +172,15 @@ async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, 
     // Defensive: any unexpected error stays best-effort/non-fatal — report it
     // as a skip and keep exit 0 so it never blocks the PR/merge caller.
     stdout.write(JSON.stringify({ ok: true, skipped: true, reason: err.message ?? "board sync failed" }) + "\n");
+    // Explicitly assert success: a pre-existing non-zero process.exitCode from a
+    // long-lived caller must not leak through this best-effort path.
+    process.exitCode = 0;
     return;
   }
   stdout.write(JSON.stringify(result) + "\n");
+  // Best-effort contract: a parsed command always reports success. Explicitly
+  // clear any pre-existing non-zero process.exitCode so it cannot leak.
+  process.exitCode = 0;
 }
 
 if (isDirectCliRun(import.meta.url)) {

--- a/scripts/projects/sync-item-status.mjs
+++ b/scripts/projects/sync-item-status.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { runChild as _runChild } from "../_cli-primitives.mjs";
+import { syncBoardStatus } from "@dev-loops/core/loop/queue-board-sync";
+import { parseArgs } from "node:util";
+
+const USAGE = `Usage: dev-loops project sync-status --repo <owner/name> --item <number> --to-column <name>
+
+Sync a queued issue/PR's board Status column on a dev-loop transition (e.g.
+PR opened → "In Progress", merged → "Done"). Resolves the board from .devloops
+and uses local gh auth.
+
+This command is BEST-EFFORT and NON-FATAL: a board that is not configured, an
+item that is not on the board, or any GitHub API failure exits 0 with a JSON
+result describing the skip/failure. It never fails the caller.
+
+Options:
+  --repo <owner/name>     Required. Repository to scope the project search.
+  --item <number>         Required. Linked issue/PR number (positive integer).
+  --to-column <name>      Required. Target Status column (e.g. "In Progress", "Done").
+  --help, -h              Show this help.
+
+Output (stdout):
+  JSON: the syncBoardStatus result, e.g.
+    { ok: true, skipped: false, result: { item: { newColumn } } }
+    { ok: true, skipped: true, reason: "board not configured" }
+
+Exit codes:
+  0 — always on a parsed command (best-effort sync; skips/failures are reported in JSON)
+  1 — usage or argument error
+`.trim();
+
+function parseCliArgs(argv) {
+  const requireValue = (token, message, code) => {
+    const v = token.value;
+    if (typeof v !== "string" || v.length === 0 || v.startsWith("-")) {
+      throw Object.assign(new Error(message), { code });
+    }
+    return v;
+  };
+
+  const args = {};
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      repo: { type: "string" },
+      item: { type: "string" },
+      "to-column": { type: "string" },
+      help: { type: "boolean", short: "h" },
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw Object.assign(new Error(`Unexpected argument: ${token.value}`), { code: "INVALID_ARGS", usage: USAGE });
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    switch (token.name) {
+      case "help":
+        if (token.value !== undefined) {
+          throw Object.assign(new Error(`Unknown flag: ${token.rawName}=${token.value}`), { code: "INVALID_ARGS", usage: USAGE });
+        }
+        args.help = true;
+        break;
+      case "repo":
+        args.repo = requireValue(token, "--repo requires a value (owner/name)", "INVALID_REPO");
+        break;
+      case "item":
+        args.item = requireValue(token, "--item requires a value (positive integer)", "INVALID_ITEM");
+        break;
+      case "to-column":
+        args.toColumn = requireValue(token, "--to-column requires a value", "INVALID_COLUMN");
+        break;
+      default:
+        throw Object.assign(new Error(`Unknown flag: ${token.rawName}`), { code: "INVALID_ARGS", usage: USAGE });
+    }
+  }
+  return args;
+}
+
+// ── Validation ───────────────────────────────────────────────────────────
+
+const OWNER_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
+const REPO_NAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9_.-]*[a-zA-Z0-9])?$/;
+
+function validateRepo(repo) {
+  if (!repo || typeof repo !== "string") {
+    throw Object.assign(new Error("--repo is required"), { code: "INVALID_REPO" });
+  }
+  const slashIdx = repo.indexOf("/");
+  if (slashIdx === -1) {
+    throw Object.assign(new Error(`--repo must be exactly owner/name, got "${repo}"`), { code: "INVALID_REPO" });
+  }
+  const owner = repo.slice(0, slashIdx);
+  const name = repo.slice(slashIdx + 1);
+  if (!owner || !name || !OWNER_RE.test(owner) || !REPO_NAME_RE.test(name)) {
+    throw Object.assign(new Error(`--repo must be exactly owner/name, got "${repo}"`), { code: "INVALID_REPO" });
+  }
+  return repo;
+}
+
+function parseItemNumber(raw) {
+  if (!raw || typeof raw !== "string" || raw.trim().length === 0) {
+    throw Object.assign(new Error("--item is required"), { code: "INVALID_ITEM" });
+  }
+  const trimmed = raw.trim();
+  const asNum = Number(trimmed);
+  if (Number.isInteger(asNum) && asNum > 0 && String(asNum) === trimmed) {
+    return asNum;
+  }
+  throw Object.assign(new Error(`--item must be a positive integer, got "${raw}"`), { code: "INVALID_ITEM" });
+}
+
+// ── Main logic ──────────────────────────────────────────────────────────
+
+async function main(args, { env = process.env, runChild, cwd = process.cwd() } = {}) {
+  const child = runChild ?? _runChild;
+  const repo = validateRepo(args.repo);
+  const item = parseItemNumber(args.item);
+  const toColumn = (args.toColumn ?? "").trim();
+  if (!toColumn) {
+    throw Object.assign(new Error("--to-column is required"), { code: "INVALID_COLUMN" });
+  }
+
+  // syncBoardStatus owns the fail-open contract: a not-configured board, an
+  // item not on the board, or any gh/API failure resolves to a skipped/failure
+  // result rather than throwing. We surface that result verbatim and exit 0.
+  return syncBoardStatus(repo, cwd, item, toColumn, env, { runChild: child });
+}
+
+// ── CLI entrypoint ──────────────────────────────────────────────────────
+
+async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, env = process.env, cwd = process.cwd() } = {}) {
+  let args;
+  try {
+    args = parseCliArgs(argv);
+  } catch (err) {
+    stderr.write(`${formatCliError(err)}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  if (args.help) {
+    stdout.write(USAGE);
+    return;
+  }
+
+  // Argument validation errors (bad --repo / --item / missing --to-column) are
+  // genuine usage errors → exit 1. Everything past validation is best-effort:
+  // syncBoardStatus never throws for board/API conditions, so a parsed command
+  // always reports its result on stdout and exits 0.
+  let result;
+  try {
+    result = await main(args, { env, cwd });
+  } catch (err) {
+    if (err.code === "INVALID_REPO" || err.code === "INVALID_ITEM" || err.code === "INVALID_COLUMN" || err.code === "INVALID_ARGS") {
+      stderr.write(`${formatCliError(err)}\n`);
+      process.exitCode = 1;
+      return;
+    }
+    // Defensive: any unexpected error stays best-effort/non-fatal — report it
+    // as a skip and keep exit 0 so it never blocks the PR/merge caller.
+    stdout.write(JSON.stringify({ ok: true, skipped: true, reason: err.message ?? "board sync failed" }) + "\n");
+    return;
+  }
+  stdout.write(JSON.stringify(result) + "\n");
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli(process.argv.slice(2)).catch((error) => {
+    // Best-effort: even an unexpected failure must not fail the caller.
+    process.stdout.write(JSON.stringify({ ok: true, skipped: true, reason: error.message ?? "board sync failed" }) + "\n");
+  });
+}
+
+export { main, parseCliArgs, parseItemNumber, runCli };

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -320,6 +320,11 @@ The canonical checkpoint verdict comment contract is [Gate Review Comment Contra
 - **CI prerequisite:** resolve the draft gate config first (`resolveGateConfig(config, "draft")`). When `requireCi=true` (default), wait for green current-head CI before entering `draft_gate`. When `requireCi=false`, the draft gate may proceed without green CI. This draft-only override does **not** relax `pre_approval_gate`; final approval and merge readiness still require green current-head CI.
 - **Pass criteria:** all configured draft gate angles pass; all findings at severities in `blockCleanOnFindingSeverities` are addressed; validation passes; no unrelated files are included.
 - **Next step after passing:** mark the PR ready for review.
+- **Board status sync (best-effort, after ready-for-review):** once the PR is created/marked ready for review, sync the linked issue's board item to "In Progress" so the queue board reflects active work without a manual `add-queue-item --status`:
+  ```sh
+  node <resolved-skill-scripts>/projects/sync-item-status.mjs --repo <owner/name> --item <linked-issue> --to-column "In Progress"
+  ```
+  Best-effort and NON-FATAL: it uses local `gh` auth (no CI/PAT), exits 0 when the board is not configured / the item is not on the board / the API fails, and never blocks marking the PR ready.
 - **Non-substitution rule:** a clean `draft_gate` comment only authorizes the draft → ready-for-review transition for that head SHA. It does **not** satisfy `pre_approval_gate`, final-approval readiness, or merge-ready requirements.
 - **Required PR comment:** post a visible checkpoint verdict comment using the mandatory [Gate comment command](#mandatory-gate-comment-command-contract). Keep validation reporting concise: include command names with pass/fail status. Do **not** paste raw passing test output into the visible gate comment. If you include a failing validation excerpt, keep it focused and truncate it to a deterministic retained-prefix length before posting the comment. See [Gate Review Comment Contract](../../docs/gate-review-comment-contract.md). Do not run `gh pr ready` unless a visible `clean` `draft_gate` checkpoint verdict comment exists for the current head SHA. A checkpoint verdict comment for an older head SHA does not satisfy this requirement for the current head. If findings exist, the PR stays draft and needs fixes before retry. If fixes advance the head SHA while still draft, post a new checkpoint verdict comment for the new head. If the checkpoint verdict comment cannot be posted, fail closed and do not run `gh pr ready`.
 
@@ -400,6 +405,14 @@ node <resolved-skill-scripts>/projects/archive-done-items.mjs --repo <owner/name
 ```
 
 Board and threshold resolve from `.devloops` (`queue.projectNumber`/`queue.boardTitle`, `queue.archiveOlderThanDays`, default 7d), using local `gh` auth — no CI, cron, or PAT. This step is best-effort and NON-FATAL: ignore any failure and never let it block the merge or the retrospective.
+
+Alongside the archive step, sync the linked issue's board item to "Done" so the queue board reflects the merge without a manual `add-queue-item --status`:
+
+```sh
+node <resolved-skill-scripts>/projects/sync-item-status.mjs --repo <owner/name> --item <linked-issue> --to-column "Done"
+```
+
+Same best-effort/NON-FATAL contract as the archive step: local `gh` auth (no CI/PAT), exits 0 when the board is not configured / the item is not on the board / the API fails, and never blocks the merge or the retrospective.
 
 ## Validation policy
 

--- a/test/projects/sync-item-status.test.mjs
+++ b/test/projects/sync-item-status.test.mjs
@@ -1,6 +1,9 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { Writable } from "node:stream";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { main, parseCliArgs, parseItemNumber, runCli } from "../../scripts/projects/sync-item-status.mjs";
 
 // ── Helpers ─────────────────────────────────────────────────────────────
@@ -101,22 +104,30 @@ describe("sync-item-status", () => {
       assert.equal(result.reason, "board not configured");
     });
 
-    it("stays best-effort when syncBoardStatus reports a failure (injected stub)", async () => {
-      // Inject a syncBoardStatus stub via the dependency seam is not exposed on
-      // main(); instead drive the real fail-open path through a board-configured
-      // root + failing gh. Here we assert via runCli that stdout carries the
-      // skipped result and exit code stays 0.
-      const stdout = collectingStream();
-      const stderr = collectingStream();
-      await runCli(
-        ["--repo", "mfittko/dev-loops", "--item", "10", "--to-column", "Done"],
-        { stdout, stderr, env: {}, cwd: "/nonexistent-repo-root-for-sync-test" },
-      );
-      assert.equal(process.exitCode ?? 0, 0);
-      const out = JSON.parse(stdout.text());
-      assert.equal(out.ok, true);
-      assert.equal(out.skipped, true);
-      assert.equal(stderr.text(), "");
+    it("stays best-effort when a configured board's gh call fails (fail-open)", async () => {
+      // Drive the REAL gh-failure → fail-open path: configure a board in
+      // .devloops so syncBoardStatus proceeds past the "board not configured"
+      // early-return, then stub gh to fail. The result must be a skipped
+      // fail-open (NOT the "board not configured" skip), and exit code stays 0.
+      const tempDir = mkdtempSync(path.join(tmpdir(), "sync-item-status-"));
+      try {
+        writeFileSync(
+          path.join(tempDir, ".devloops"),
+          "version: 1\nqueue:\n  projectNumber: 3\n",
+          "utf8",
+        );
+        const result = await main(
+          { repo: "mfittko/dev-loops", item: "10", toColumn: "Done" },
+          { runChild: failingRunChild(), cwd: tempDir, env: {} },
+        );
+        assert.equal(result.ok, true);
+        assert.equal(result.skipped, true);
+        // Must NOT be the not-configured skip — the gh failure was reached.
+        assert.notEqual(result.reason, "board not configured");
+        assert.match(result.reason, /gh api graphql failed|authentication required/);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
     });
 
     it("runCli exits 1 with stderr usage on an argument error", async () => {

--- a/test/projects/sync-item-status.test.mjs
+++ b/test/projects/sync-item-status.test.mjs
@@ -1,0 +1,145 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Writable } from "node:stream";
+import { main, parseCliArgs, parseItemNumber, runCli } from "../../scripts/projects/sync-item-status.mjs";
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+// Collect everything written to a stream into a string buffer.
+function collectingStream() {
+  const chunks = [];
+  const stream = new Writable({
+    write(chunk, _enc, cb) {
+      chunks.push(chunk.toString());
+      cb();
+    },
+  });
+  stream.text = () => chunks.join("");
+  return stream;
+}
+
+// gh runChild stub that always reports the gh CLI failing. syncBoardStatus
+// wraps such failures in its fail-open contract (skipped + reason), so the
+// command must still exit 0.
+function failingRunChild() {
+  return async () => ({ code: 1, stdout: "", stderr: "gh: authentication required" });
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe("sync-item-status", () => {
+  describe("argument parsing", () => {
+    it("requires --repo", async () => {
+      await assert.rejects(
+        () => main({ item: "10", toColumn: "In Progress" }, { runChild: failingRunChild() }),
+        /--repo is required/,
+      );
+    });
+
+    it("requires --item", async () => {
+      await assert.rejects(
+        () => main({ repo: "mfittko/dev-loops", toColumn: "In Progress" }, { runChild: failingRunChild() }),
+        /--item is required/,
+      );
+    });
+
+    it("requires --to-column", async () => {
+      await assert.rejects(
+        () => main({ repo: "mfittko/dev-loops", item: "10" }, { runChild: failingRunChild() }),
+        /--to-column is required/,
+      );
+    });
+
+    it("rejects a non-numeric item", async () => {
+      await assert.rejects(
+        () => main({ repo: "mfittko/dev-loops", item: "not-a-number", toColumn: "In Progress" }, { runChild: failingRunChild() }),
+        /--item must be a positive integer/,
+      );
+    });
+
+    it("rejects a node-id item (numbers only)", () => {
+      assert.throws(() => parseItemNumber("PVTI_42"), /--item must be a positive integer/);
+    });
+
+    it("rejects zero / negative item", () => {
+      assert.throws(() => parseItemNumber("0"), /--item must be a positive integer/);
+      assert.throws(() => parseItemNumber("-3"), /--item must be a positive integer/);
+    });
+
+    it("rejects an invalid repo slug", async () => {
+      await assert.rejects(
+        () => main({ repo: "no-slash", item: "10", toColumn: "Done" }, { runChild: failingRunChild() }),
+        /--repo must be exactly owner\/name/,
+      );
+    });
+
+    it("rejects a boolean flag given an inline value (--help=foo)", () => {
+      assert.throws(() => parseCliArgs(["--help=foo"]), /Unknown flag: --help=foo/);
+    });
+
+    it("rejects an unexpected positional argument", () => {
+      assert.throws(() => parseCliArgs(["stray", "--repo", "o/n"]), /Unexpected argument: stray/);
+    });
+
+    it("parses required flags into the canonical shape", () => {
+      const args = parseCliArgs(["--repo", "mfittko/dev-loops", "--item", "10", "--to-column", "In Progress"]);
+      assert.equal(args.repo, "mfittko/dev-loops");
+      assert.equal(args.item, "10");
+      assert.equal(args.toColumn, "In Progress");
+    });
+  });
+
+  describe("best-effort / exit-0 contract", () => {
+    it("returns a skipped result when the board is not configured (no .devloops)", async () => {
+      // cwd has no .devloops → syncBoardStatus skips without any gh call.
+      const result = await main(
+        { repo: "mfittko/dev-loops", item: "10", toColumn: "In Progress" },
+        { runChild: failingRunChild(), cwd: "/nonexistent-repo-root-for-sync-test", env: {} },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.skipped, true);
+      assert.equal(result.reason, "board not configured");
+    });
+
+    it("stays best-effort when syncBoardStatus reports a failure (injected stub)", async () => {
+      // Inject a syncBoardStatus stub via the dependency seam is not exposed on
+      // main(); instead drive the real fail-open path through a board-configured
+      // root + failing gh. Here we assert via runCli that stdout carries the
+      // skipped result and exit code stays 0.
+      const stdout = collectingStream();
+      const stderr = collectingStream();
+      await runCli(
+        ["--repo", "mfittko/dev-loops", "--item", "10", "--to-column", "Done"],
+        { stdout, stderr, env: {}, cwd: "/nonexistent-repo-root-for-sync-test" },
+      );
+      assert.equal(process.exitCode ?? 0, 0);
+      const out = JSON.parse(stdout.text());
+      assert.equal(out.ok, true);
+      assert.equal(out.skipped, true);
+      assert.equal(stderr.text(), "");
+    });
+
+    it("runCli exits 1 with stderr usage on an argument error", async () => {
+      const prevExitCode = process.exitCode;
+      const stdout = collectingStream();
+      const stderr = collectingStream();
+      await runCli(
+        ["--repo", "mfittko/dev-loops", "--item", "not-a-number", "--to-column", "Done"],
+        { stdout, stderr, env: {}, cwd: "/nonexistent-repo-root-for-sync-test" },
+      );
+      assert.equal(process.exitCode, 1);
+      assert.match(stderr.text(), /--item must be a positive integer/);
+      assert.equal(stdout.text(), "");
+      process.exitCode = prevExitCode;
+    });
+
+    it("--help prints usage to stdout without exiting non-zero", async () => {
+      const prevExitCode = process.exitCode;
+      const stdout = collectingStream();
+      const stderr = collectingStream();
+      await runCli(["--help"], { stdout, stderr, env: {} });
+      assert.match(stdout.text(), /dev-loops project sync-status/);
+      assert.equal(process.exitCode ?? 0, prevExitCode ?? 0);
+    });
+  });
+});

--- a/test/projects/sync-item-status.test.mjs
+++ b/test/projects/sync-item-status.test.mjs
@@ -144,13 +144,17 @@ describe("sync-item-status", () => {
       process.exitCode = prevExitCode;
     });
 
-    it("--help prints usage to stdout without exiting non-zero", async () => {
+    it("--help prints usage to stdout and forces exit 0 (clears a leaked non-zero code)", async () => {
       const prevExitCode = process.exitCode;
+      // Seed a non-zero code to prove the --help path clears it rather than
+      // inheriting a pre-existing failure code from a prior test/runner.
+      process.exitCode = 7;
       const stdout = collectingStream();
       const stderr = collectingStream();
       await runCli(["--help"], { stdout, stderr, env: {} });
       assert.match(stdout.text(), /dev-loops project sync-status/);
-      assert.equal(process.exitCode ?? 0, prevExitCode ?? 0);
+      assert.equal(process.exitCode, 0);
+      process.exitCode = prevExitCode;
     });
   });
 });


### PR DESCRIPTION
## Summary

Auto-sync a queued issue's board status on dev-loop transitions — **PR ready → "In Progress", merge → "Done"** — using local `gh` auth, best-effort/non-fatal, so it no longer relies on manual `add-queue-item --status`. Closes #874.

## Changes

- **New CLI** `dev-loops project sync-status` (`scripts/projects/sync-item-status.mjs`): `--repo --item --to-column`; delegates to `syncBoardStatus`; fail-open (exits 0 when board not configured / item not on board / API fails).
- **Skill wiring** (`copilot-pr-followup`): sync linked issue → "In Progress" after the PR is ready; → "Done" in the post-merge step. Best-effort, non-fatal.
- **Latent bug fix:** `syncBoardStatus` passed `project`/`item` to `move-queue-item` as **numbers**, but its `parseProjectRef`/item validation require **string** refs — so the sync silently failed with "--project is required". Stringify both. This **also repairs the queue-driver's board status sync**, which hit the same broken path. Verified live (item moved end-to-end). `queue-board-sync` tests updated to expect string refs.

## Non-goals

- Board *membership* reconciliation from the configured board (#864, separately queued).

## Validation

- `npm run verify` — pass (core 1585; 0 fail). New `sync-item-status` tests (best-effort/arg-parsing); live end-to-end sync confirmed.

Closes #874


- Adds a `./loop/queue-board-sync` subpath export to `@dev-loops/core` so the new CLI can import `syncBoardStatus`.


### AC#5 test mapping
Both transitions are covered by automated tests at the syncBoardStatus boundary (`packages/core/test/queue-board-sync.test.mjs`): "moves item when configured" asserts the **In Progress** (PR-ready) move with stringified refs, and "moves item to Done (merge transition)" asserts the **Done** (merge) move. The `sync-item-status` CLI wrapper (delegation + best-effort fail-open + exit-0) is covered by `test/projects/sync-item-status.test.mjs`. The live end-to-end check is supplementary, not the sole evidence.
