### PR TITLE
feat(queue): make a configured board the queue membership source (#864)

### DIFF
--- a/.claude/skills/docs/anti-patterns.md
+++ b/.claude/skills/docs/anti-patterns.md
@@ -11,6 +11,7 @@ Canonical owner for anti-pattern guidance across all workflow families.
 5. **Duplicate worktree paths**: Check `git worktree list` before creating new worktrees; reuse existing matching worktrees.
 6. **Main-checkout mutation**: Reserve main checkout for inspection/control; use `tmp/worktrees/` paths for mutation work.
 7. **Spelunking tooling internals instead of using the public surface**: Do not read installed package internals, scan tooling source, or run ad-hoc scripts to understand a tool's behavior. Use the CLI, its `--help` subcommands, and `skills/docs/`. Read tool source only when the task is to inspect or change that tool, or when a concrete failure path is inside it and no public CLI/docs path exists. Once a failure is concrete, search changed files for the exact pattern — don't run duplicate broad searches.
+8. **Hand-editing the queue file when a board is configured**: When a GitHub Projects board is configured (`queue.projectNumber`/`queue.boardTitle` in `.devloops`), the board is the authoritative queue MEMBERSHIP and ordering source — not just status. Add work via the board (`dev-loops project add ... --status "Next Up"`), not by hand-editing `.pi/dev-loop-queue.json`; the queue runner reconciles board `Next Up` items into queue entries before each run. See the operator guides under `docs/` (queue board usage/setup) for the workflow.
 
 ## Light mode exception
 

--- a/docs/projects-queue-usage.md
+++ b/docs/projects-queue-usage.md
@@ -12,8 +12,8 @@ hint — not as a database or transactional state store.
 
 - **Board state is durable** — survives CI restarts, local machine wipes, and session boundaries
 - **Board state is visible** — operators inspect and reorder the queue from the GitHub UI
-- **Board state is optional** — queue helpers treat it as an optional scheduling input, not mandatory authority
-- **No local queue file duplication** — the board complements `.pi/dev-loop-queue.json` for entry lifecycle tracking; it does not replace it and does not introduce a second local file
+- **Board state is authoritative when configured** — a configured board is the source of queue membership and ordering; the queue runner reconciles its `Next Up` items into `.pi/dev-loop-queue.json` before running. When no board is configured, the local queue file's entry order is used.
+- **No local queue file duplication** — the board drives membership/ordering while `.pi/dev-loop-queue.json` tracks entry lifecycle; the board does not introduce a second local file
 
 This means board position is a **good-enough** signal for ordering the outer queue. The board
 does not need to be transactionally consistent with local state for the queue to work correctly:
@@ -128,20 +128,26 @@ project structure. It safely re-runs: if the board and Status field already exis
 clean with the existing project details. Runtime helpers (list, move, add, reorder) never
 create or modify project/field structure.
 
-## How dev-loop should treat board state
+## How dev-loop treats board state
 
-Dev-loop queue drivers should treat board state as **optional scheduling input**, not as
-mandatory authority:
+When a board is **configured** (`queue.projectNumber` or `queue.boardTitle` in `.devloops`),
+it is the **authoritative source of queue membership and ordering** — not just status:
 
-- When the board is configured and reachable: queue ordering may be read from board position
-- When the board is configured but unreachable (API error): the queue continues with its
-  default entry ordering; no board mutations are attempted
-- When the board is not configured: the queue falls back to its default entry order
-  (e.g., `.pi/dev-loop-queue.json` entry order)
+- **Configured and reachable**: `dev-loop queue run` resolves the board's `Next Up` column and
+  reconciles those items into `.pi/dev-loop-queue.json` (appending a queued entry for any
+  `Next Up` issue not already present) before running. The board therefore drives **which**
+  issues are worked and their order. Enqueue work via `dev-loops project add ... --status "Next Up"`
+  rather than hand-editing the queue file.
+- **Configured but unreachable (API error)**: reconciliation fails open — the run continues
+  with the existing local queue entries; no board mutations are attempted.
+- **Configured but `Next Up` is empty**: the run reports "Board configured but Next Up is empty;
+  nothing to run", distinct from the unconfigured "Queue is empty".
+- **Not configured**: the queue falls back to its local entry order (`.pi/dev-loop-queue.json`),
+  and the legacy "Queue is empty" message applies when that file has no pending entries.
 
-This posture keeps the queue resilient: a transient GitHub API outage or misconfigured
-board does not block the entire queue run. Board state is read at dispatch time; the queue
-does not continuously sync local state to board state.
+This posture keeps the queue resilient: a transient GitHub API outage or misconfigured board
+does not block the run. Board state is read at dispatch time; the queue does not continuously
+sync local state to board state.
 
 ## See also
 

--- a/docs/projects-queue-usage.md
+++ b/docs/projects-queue-usage.md
@@ -133,7 +133,7 @@ create or modify project/field structure.
 When a board is **configured** (`queue.projectNumber` or `queue.boardTitle` in `.devloops`),
 it is the **authoritative source of queue membership and ordering** — not just status:
 
-- **Configured and reachable**: `dev-loop queue run` resolves the board's `Next Up` column and
+- **Configured and reachable**: `dev-loops queue run` resolves the board's `Next Up` column and
   reconciles those items into `.pi/dev-loop-queue.json` (appending a queued entry for any
   `Next Up` issue not already present) before running. The board therefore drives **which**
   issues are worked and their order. Enqueue work via `dev-loops project add ... --status "Next Up"`

--- a/docs/queue-board-setup.md
+++ b/docs/queue-board-setup.md
@@ -8,7 +8,9 @@ The board provides durable, visible, shared state for queue ordering and item st
 
 - **Durable** — survives CI restarts, local machine wipes, and session boundaries
 - **Visible** — operators can inspect and reorder the queue from the GitHub UI
-- **Optional** — queue helpers treat board state as an optional scheduling input, not mandatory authority. Without the board, `dev-loop queue` falls back to positional argument ordering.
+- **Authoritative for membership + ordering when configured** — when a board is configured (`queue.projectNumber` or `queue.boardTitle`), `dev-loop queue run` reconciles the board's `Next Up` items into `.pi/dev-loop-queue.json` before running, so the board (not hand edits) drives **which** issues are worked and their order. Without a configured board, `dev-loop queue` falls back to the local queue file's entry order.
+
+> Add work to the queue via the board (`dev-loops project add ... --status "Next Up"`), not by hand-editing `.pi/dev-loop-queue.json`. With a populated board and an empty local queue, the runner reconciles the board's `Next Up` items in rather than reporting an empty queue. If a board is configured but `Next Up` is empty, the runner reports "Board configured but Next Up is empty; nothing to run" — distinct from the unconfigured-and-empty "Queue is empty".
 
 ## Setup
 
@@ -75,10 +77,11 @@ After manual creation, the wrapper's idempotent re-run will detect the existing 
 Dev-loop queue wrappers will:
 
 - **List** items from the board ordered by position
-- **Add** new items to the `Backlog` column when issues are queued
+- **Add** new items to the `Backlog` column when issues are queued; promote to `Next Up` to enqueue them for the runner
+- **Drive membership + ordering** from the board's `Next Up` column: `dev-loop queue run` reconciles `Next Up` items into queue entries before running (configured board is authoritative)
 - **Move** items to `In Progress` when processing starts, `Done` when complete
 - **Reorder** items when the operator adjusts priority via `--after` dependencies or manual intervention
-- **Fall back** gracefully when the board is absent: positional argument order takes over, and no board mutations are attempted
+- **Fall back** gracefully when the board is absent or unreachable: the local queue file's entry order takes over, and no board mutations are attempted
 
 Use `dev-loops project --help` to inspect the queue helper surface and per-subcommand `--help` for details.
 

--- a/docs/queue-board-setup.md
+++ b/docs/queue-board-setup.md
@@ -1,6 +1,6 @@
 # GitHub Projects V2 queue board setup
 
-One-time manual setup for the GitHub Projects V2 board that `dev-loop queue` helpers will read and write.
+One-time manual setup for the GitHub Projects V2 board that `dev-loops queue` helpers will read and write.
 
 ## Why a Projects V2 board?
 
@@ -8,7 +8,7 @@ The board provides durable, visible, shared state for queue ordering and item st
 
 - **Durable** — survives CI restarts, local machine wipes, and session boundaries
 - **Visible** — operators can inspect and reorder the queue from the GitHub UI
-- **Authoritative for membership + ordering when configured** — when a board is configured (`queue.projectNumber` or `queue.boardTitle`), `dev-loop queue run` reconciles the board's `Next Up` items into `.pi/dev-loop-queue.json` before running, so the board (not hand edits) drives **which** issues are worked and their order. Without a configured board, `dev-loop queue` falls back to the local queue file's entry order.
+- **Authoritative for membership + ordering when configured** — when a board is configured (`queue.projectNumber` or `queue.boardTitle`), `dev-loops queue run` reconciles the board's `Next Up` items into `.pi/dev-loop-queue.json` before running, so the board (not hand edits) drives **which** issues are worked and their order. Without a configured board, `dev-loops queue` falls back to the local queue file's entry order.
 
 > Add work to the queue via the board (`dev-loops project add ... --status "Next Up"`), not by hand-editing `.pi/dev-loop-queue.json`. With a populated board and an empty local queue, the runner reconciles the board's `Next Up` items in rather than reporting an empty queue. If a board is configured but `Next Up` is empty, the runner reports "Board configured but Next Up is empty; nothing to run" — distinct from the unconfigured-and-empty "Queue is empty".
 
@@ -78,7 +78,7 @@ Dev-loop queue wrappers will:
 
 - **List** items from the board ordered by position
 - **Add** new items to the `Backlog` column when issues are queued; promote to `Next Up` to enqueue them for the runner
-- **Drive membership + ordering** from the board's `Next Up` column: `dev-loop queue run` reconciles `Next Up` items into queue entries before running (configured board is authoritative)
+- **Drive membership + ordering** from the board's `Next Up` column: `dev-loops queue run` reconciles `Next Up` items into queue entries before running (configured board is authoritative)
 - **Move** items to `In Progress` when processing starts, `Done` when complete
 - **Reorder** items when the operator adjusts priority via `--after` dependencies or manual intervention
 - **Fall back** gracefully when the board is absent or unreachable: the local queue file's entry order takes over, and no board mutations are attempted

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,6 +39,7 @@
     "./loop/public-dev-loop-routing": "./src/loop/public-dev-loop-routing.mjs",
     "./loop/queue-board-sync": "./src/loop/queue-board-sync.mjs",
     "./loop/queue-driver": "./src/loop/queue-driver.mjs",
+    "./loop/queue-membership": "./src/loop/queue-membership.mjs",
     "./loop/queue-parallel": "./src/loop/queue-parallel.mjs",
     "./loop/queue-state": "./src/loop/queue-state.mjs",
     "./loop/reviewer-loop-state": "./src/loop/reviewer-loop-state.mjs",

--- a/packages/core/src/loop/queue-membership.mjs
+++ b/packages/core/src/loop/queue-membership.mjs
@@ -49,16 +49,13 @@ import { reconcileEntriesFromBoard, writeQueue, pendingEntries } from "./queue-s
  * @param {(repoRoot:string)=>{enabled:boolean}} [deps.loadBoardConfig]
  * @param {(repo:string, repoRoot:string, env:object, d:object)=>Promise<{ok:boolean, order:number[], reason:?string}>} [deps.resolveNextUpOrder]
  * @param {(repoRoot:string, queue:object)=>Promise<void>} [deps.writeQueue]
- * @param {object} [deps.env]
  * @param {(msg:string)=>void} [deps.log]
- * @param {object} [deps.boardDependencies] - forwarded to resolveNextUpOrder.
  * @returns {Promise<{queue:object, added:number[], boardConfigured:boolean, emptiness:(null|"queue_empty"|"board_empty"|"board_unavailable"), reason:(string|null)}>}
  */
 export async function reconcileBoardMembership(repoRoot, repo, queue, deps = {}) {
   const loadConfig = deps.loadBoardConfig ?? loadBoardConfig;
   const resolveOrder = deps.resolveNextUpOrder ?? resolveNextUpOrder;
   const persist = deps.writeQueue ?? writeQueue;
-  const env = deps.env ?? process.env;
   const log = typeof deps.log === "function" ? deps.log : (msg) => console.error(msg);
 
   let boardConfigured = false;
@@ -90,7 +87,10 @@ export async function reconcileBoardMembership(repoRoot, repo, queue, deps = {})
   if (boardConfigured) {
     let nextUp = [];
     try {
-      const result = await resolveOrder(repo, repoRoot, env, deps.boardDependencies ?? {});
+      // env/board dependencies use resolveNextUpOrder's own defaults
+      // (process.env / {}); the production caller never overrides them, and
+      // tests inject a stubbed resolveNextUpOrder.
+      const result = await resolveOrder(repo, repoRoot, process.env, {});
       reason = result?.reason ?? null;
       nextUp = Array.isArray(result?.order) ? result.order : [];
       // Fail-open contract: an empty order paired with a non-null reason means

--- a/packages/core/src/loop/queue-membership.mjs
+++ b/packages/core/src/loop/queue-membership.mjs
@@ -29,12 +29,18 @@ import { reconcileEntriesFromBoard, writeQueue, pendingEntries } from "./queue-s
  *     via `writeQueue`.
  *
  * Emptiness verdict (`emptiness`):
- *   - `null`            — there is pending work; the caller should run the queue.
- *   - "queue_empty"      — board not configured and the local queue is empty
- *                          (legacy "Queue is empty" message).
- *   - "board_empty"      — board IS configured but, after reconcile, there is no
- *                          pending work (board Next Up empty / nothing to do).
- *                          Distinct from the misleading generic empty case.
+ *   - `null`              — there is pending work; the caller should run the queue.
+ *   - "queue_empty"       — board not configured and the local queue is empty
+ *                           (legacy "Queue is empty" message).
+ *   - "board_empty"       — board IS configured, Next Up resolved successfully
+ *                           (reason == null) but is genuinely empty, and there is
+ *                           no pending local work. Distinct from the misleading
+ *                           generic empty case.
+ *   - "board_unavailable" — board IS configured but Next Up resolution failed
+ *                           (fail-open: empty order WITH a non-null reason) and
+ *                           the local queue had no pending work to fall back to.
+ *                           This must NOT be reported as "board_empty" — the
+ *                           board may well have items we simply could not read.
  *
  * @param {string} repoRoot
  * @param {string} repo - "owner/name"
@@ -46,7 +52,7 @@ import { reconcileEntriesFromBoard, writeQueue, pendingEntries } from "./queue-s
  * @param {object} [deps.env]
  * @param {(msg:string)=>void} [deps.log]
  * @param {object} [deps.boardDependencies] - forwarded to resolveNextUpOrder.
- * @returns {Promise<{queue:object, added:number[], boardConfigured:boolean, emptiness:(null|"queue_empty"|"board_empty"), reason:(string|null)}>}
+ * @returns {Promise<{queue:object, added:number[], boardConfigured:boolean, emptiness:(null|"queue_empty"|"board_empty"|"board_unavailable"), reason:(string|null)}>}
  */
 export async function reconcileBoardMembership(repoRoot, repo, queue, deps = {}) {
   const loadConfig = deps.loadBoardConfig ?? loadBoardConfig;
@@ -66,6 +72,11 @@ export async function reconcileBoardMembership(repoRoot, repo, queue, deps = {})
 
   let added = [];
   let reason = null;
+  // True when the board is configured but Next Up could not be resolved: the
+  // resolver is fail-open, so this surfaces as an empty order WITH a non-null
+  // reason (or a thrown error caught below). We must not confuse this with a
+  // genuinely empty Next Up (empty order AND reason == null).
+  let resolutionFailed = false;
 
   if (boardConfigured) {
     let nextUp = [];
@@ -73,10 +84,18 @@ export async function reconcileBoardMembership(repoRoot, repo, queue, deps = {})
       const result = await resolveOrder(repo, repoRoot, env, deps.boardDependencies ?? {});
       reason = result?.reason ?? null;
       nextUp = Array.isArray(result?.order) ? result.order : [];
+      // Fail-open contract: an empty order paired with a non-null reason means
+      // resolution failed (API error, board lookup failure, etc.) — NOT that the
+      // board's Next Up is genuinely empty.
+      if (nextUp.length === 0 && reason != null) {
+        resolutionFailed = true;
+        log(`[queue-membership] Next Up resolution failed (fail-open), using local queue: ${reason}`);
+      }
     } catch (err) {
       // resolveNextUpOrder is itself fail-open, but guard anyway: a board
       // resolution error falls back to the local queue without crashing.
       reason = err?.message ?? "board resolution failed";
+      resolutionFailed = true;
       log(`[queue-membership] Next Up resolution failed (fail-open), using local queue: ${reason}`);
       nextUp = [];
     }
@@ -100,7 +119,17 @@ export async function reconcileBoardMembership(repoRoot, repo, queue, deps = {})
   const pending = pendingEntries(queue);
   let emptiness = null;
   if (pending.length === 0) {
-    emptiness = boardConfigured ? "board_empty" : "queue_empty";
+    if (!boardConfigured) {
+      emptiness = "queue_empty";
+    } else if (resolutionFailed) {
+      // Board configured but we could not read Next Up and the local queue is
+      // empty: the board may have items we simply failed to fetch. Report a
+      // distinct verdict instead of the misleading "board_empty".
+      emptiness = "board_unavailable";
+    } else {
+      // Board configured, Next Up resolved cleanly (reason == null) and empty.
+      emptiness = "board_empty";
+    }
   }
 
   return { queue, added, boardConfigured, emptiness, reason };

--- a/packages/core/src/loop/queue-membership.mjs
+++ b/packages/core/src/loop/queue-membership.mjs
@@ -63,7 +63,16 @@ export async function reconcileBoardMembership(repoRoot, repo, queue, deps = {})
 
   let boardConfigured = false;
   try {
-    boardConfigured = Boolean(loadConfig(repoRoot)?.enabled);
+    const config = loadConfig(repoRoot);
+    boardConfigured = Boolean(config?.enabled);
+    // loadBoardConfig does not throw on read/parse failures; it reports them
+    // via `{ enabled: false, reason: ... }`. Surface that reason so a genuine
+    // config read/parse error is visible instead of being silently treated as
+    // "board not configured". The ordinary "board not configured" case carries
+    // no reason and must stay quiet.
+    if (!boardConfigured && config?.reason) {
+      log(`[queue-membership] board config unavailable (fail-open): ${config.reason}`);
+    }
   } catch (err) {
     // Config read errors must not crash the queue; treat as unconfigured.
     log(`[queue-membership] board config read failed (fail-open): ${err?.message ?? err}`);

--- a/packages/core/src/loop/queue-membership.mjs
+++ b/packages/core/src/loop/queue-membership.mjs
@@ -1,0 +1,107 @@
+/**
+ * Queue membership reconciliation (issue #864).
+ *
+ * A configured GitHub Projects board is the authoritative source of queue
+ * MEMBERSHIP (which issues to work) and ordering — not just status. Before a
+ * queue run, this module folds the board's "Next Up" items into the local
+ * `.pi/dev-loop-queue.json` entries so the board drives membership, and reports
+ * a clear, non-misleading emptiness verdict.
+ *
+ * This is the testable orchestration seam used by `scripts/loop/run-queue.mjs`.
+ * Board config loading, Next Up resolution, and queue persistence are all
+ * injectable so the policy can be exercised without GitHub or the filesystem.
+ */
+
+import { loadBoardConfig } from "./queue-board-sync.mjs";
+import { resolveNextUpOrder } from "./queue-board-ordering.mjs";
+import { reconcileEntriesFromBoard, writeQueue, pendingEntries } from "./queue-state.mjs";
+
+/**
+ * Reconcile a configured board's Next Up membership into the queue, then
+ * classify emptiness.
+ *
+ * Behavior:
+ *   - Board NOT configured: no reconcile. Emptiness is judged purely on the
+ *     local queue (preserving the legacy "Queue is empty" behavior).
+ *   - Board configured: resolve Next Up targets and reconcile them in. If the
+ *     resolver fails-open (returns no targets) the board membership simply
+ *     contributes nothing; we never crash. Newly added targets are persisted
+ *     via `writeQueue`.
+ *
+ * Emptiness verdict (`emptiness`):
+ *   - `null`            — there is pending work; the caller should run the queue.
+ *   - "queue_empty"      — board not configured and the local queue is empty
+ *                          (legacy "Queue is empty" message).
+ *   - "board_empty"      — board IS configured but, after reconcile, there is no
+ *                          pending work (board Next Up empty / nothing to do).
+ *                          Distinct from the misleading generic empty case.
+ *
+ * @param {string} repoRoot
+ * @param {string} repo - "owner/name"
+ * @param {{version:number, entries:Array}} queue
+ * @param {object} [deps]
+ * @param {(repoRoot:string)=>{enabled:boolean}} [deps.loadBoardConfig]
+ * @param {(repo:string, repoRoot:string, env:object, d:object)=>Promise<{ok:boolean, order:number[], reason:?string}>} [deps.resolveNextUpOrder]
+ * @param {(repoRoot:string, queue:object)=>Promise<void>} [deps.writeQueue]
+ * @param {object} [deps.env]
+ * @param {(msg:string)=>void} [deps.log]
+ * @param {object} [deps.boardDependencies] - forwarded to resolveNextUpOrder.
+ * @returns {Promise<{queue:object, added:number[], boardConfigured:boolean, emptiness:(null|"queue_empty"|"board_empty"), reason:(string|null)}>}
+ */
+export async function reconcileBoardMembership(repoRoot, repo, queue, deps = {}) {
+  const loadConfig = deps.loadBoardConfig ?? loadBoardConfig;
+  const resolveOrder = deps.resolveNextUpOrder ?? resolveNextUpOrder;
+  const persist = deps.writeQueue ?? writeQueue;
+  const env = deps.env ?? process.env;
+  const log = typeof deps.log === "function" ? deps.log : (msg) => console.error(msg);
+
+  let boardConfigured = false;
+  try {
+    boardConfigured = Boolean(loadConfig(repoRoot)?.enabled);
+  } catch (err) {
+    // Config read errors must not crash the queue; treat as unconfigured.
+    log(`[queue-membership] board config read failed (fail-open): ${err?.message ?? err}`);
+    boardConfigured = false;
+  }
+
+  let added = [];
+  let reason = null;
+
+  if (boardConfigured) {
+    let nextUp = [];
+    try {
+      const result = await resolveOrder(repo, repoRoot, env, deps.boardDependencies ?? {});
+      reason = result?.reason ?? null;
+      nextUp = Array.isArray(result?.order) ? result.order : [];
+    } catch (err) {
+      // resolveNextUpOrder is itself fail-open, but guard anyway: a board
+      // resolution error falls back to the local queue without crashing.
+      reason = err?.message ?? "board resolution failed";
+      log(`[queue-membership] Next Up resolution failed (fail-open), using local queue: ${reason}`);
+      nextUp = [];
+    }
+
+    if (nextUp.length > 0) {
+      const outcome = reconcileEntriesFromBoard(queue, nextUp);
+      added = outcome.added;
+      if (added.length > 0) {
+        log(`[queue-membership] added ${added.length} entr${added.length === 1 ? "y" : "ies"} from board Next Up: ${added.join(", ")}`);
+        try {
+          await persist(repoRoot, queue);
+        } catch (err) {
+          // A write failure should not crash the run; entries still drive this
+          // in-memory run, they just are not persisted for the next invocation.
+          log(`[queue-membership] failed to persist reconciled queue (continuing in-memory): ${err?.message ?? err}`);
+        }
+      }
+    }
+  }
+
+  const pending = pendingEntries(queue);
+  let emptiness = null;
+  if (pending.length === 0) {
+    emptiness = boardConfigured ? "board_empty" : "queue_empty";
+  }
+
+  return { queue, added, boardConfigured, emptiness, reason };
+}

--- a/packages/core/src/loop/queue-state.mjs
+++ b/packages/core/src/loop/queue-state.mjs
@@ -81,7 +81,7 @@ export async function writeQueue(repoRoot, queue) {
 export function createEntry(target, kind, dependsOn = []) {
   return {
     target,
-    kind,           // "issue" | "pr"
+    kind,           // "issue" | "pr" | "board" (board = issue-or-PR, resolved by number at run time)
     status: "queued",
     dependsOn: Array.isArray(dependsOn) ? dependsOn : [],
     pr: null,
@@ -220,16 +220,24 @@ export function pendingEntries(queue) {
  * MEMBERSHIP (which issues should be worked), not just ordering/status. This
  * pure helper folds the board's "Next Up" targets into the queue: for each
  * target not already present (by `findEntry`), it appends a fresh queued
- * `createEntry(target, "issue")`. Existing entries — and their status, order,
+ * `createEntry(target, "board")`. Existing entries — and their status, order,
  * and metadata — are preserved untouched, and targets already present are
  * skipped (dedup).
+ *
+ * Entry kind is `"board"` rather than `"issue"`: the board's Next Up can hold
+ * issues OR PRs, and `resolveNextUpOrder` collapses each item to a bare number
+ * (`issueNumber ?? prNumber`), discarding the artifact kind. The queue driver
+ * never branches on `entry.kind`; it dispatches purely by `entry.target` and
+ * the per-entry startup resolver resolves the actual artifact (issue or PR) by
+ * number at run time. So a neutral `"board"` kind correctly records the
+ * provenance without falsely asserting "issue" for PR-backed board items.
  *
  * Pure: performs no I/O. Mutates and returns the passed `queue` object (its
  * `entries` array is appended to in place) plus the list of newly added
  * targets so the caller can log/report.
  *
  * @param {{version:number, entries:Array}} queue - the current queue.
- * @param {Array<number>} nextUpTargets - board "Next Up" issue numbers.
+ * @param {Array<number>} nextUpTargets - board "Next Up" issue/PR numbers.
  * @returns {{queue:{version:number, entries:Array}, added:number[]}}
  */
 export function reconcileEntriesFromBoard(queue, nextUpTargets) {
@@ -241,12 +249,18 @@ export function reconcileEntriesFromBoard(queue, nextUpTargets) {
     return { queue, added };
   }
   for (const target of nextUpTargets) {
-    // Guard against malformed/duplicate board input: only number targets,
-    // and never add the same target twice (even if it repeats in the board
-    // list and was not yet in the queue at the start of this loop).
-    if (typeof target !== "number") continue;
+    // Guard against malformed/duplicate board input: only positive-integer
+    // targets, and never add the same target twice (even if it repeats in the
+    // board list and was not yet in the queue at the start of this loop).
+    //
+    // The integer guard is critical for NaN: a NaN target never dedups via
+    // findEntry (NaN !== NaN), so accepting it would re-append a fresh NaN
+    // entry on every reconcile. Infinity, non-integers, negatives, and 0 are
+    // never valid issue/PR numbers either, so reject anything that is not a
+    // positive integer.
+    if (!Number.isInteger(target) || target <= 0) continue;
     if (findEntry(queue, target)) continue;
-    queue.entries.push(createEntry(target, "issue"));
+    queue.entries.push(createEntry(target, "board"));
     added.push(target);
   }
   return { queue, added };

--- a/packages/core/src/loop/queue-state.mjs
+++ b/packages/core/src/loop/queue-state.mjs
@@ -211,6 +211,47 @@ export function pendingEntries(queue) {
   );
 }
 
+// ── Board membership reconciliation ──────────────────────────────────
+
+/**
+ * Reconcile board-driven membership into the local queue (issue #864).
+ *
+ * A configured GitHub Projects board is the authoritative source of queue
+ * MEMBERSHIP (which issues should be worked), not just ordering/status. This
+ * pure helper folds the board's "Next Up" targets into the queue: for each
+ * target not already present (by `findEntry`), it appends a fresh queued
+ * `createEntry(target, "issue")`. Existing entries — and their status, order,
+ * and metadata — are preserved untouched, and targets already present are
+ * skipped (dedup).
+ *
+ * Pure: performs no I/O. Mutates and returns the passed `queue` object (its
+ * `entries` array is appended to in place) plus the list of newly added
+ * targets so the caller can log/report.
+ *
+ * @param {{version:number, entries:Array}} queue - the current queue.
+ * @param {Array<number>} nextUpTargets - board "Next Up" issue numbers.
+ * @returns {{queue:{version:number, entries:Array}, added:number[]}}
+ */
+export function reconcileEntriesFromBoard(queue, nextUpTargets) {
+  const added = [];
+  if (!queue || !Array.isArray(queue.entries)) {
+    return { queue, added };
+  }
+  if (!Array.isArray(nextUpTargets) || nextUpTargets.length === 0) {
+    return { queue, added };
+  }
+  for (const target of nextUpTargets) {
+    // Guard against malformed/duplicate board input: only number targets,
+    // and never add the same target twice (even if it repeats in the board
+    // list and was not yet in the queue at the start of this loop).
+    if (typeof target !== "number") continue;
+    if (findEntry(queue, target)) continue;
+    queue.entries.push(createEntry(target, "issue"));
+    added.push(target);
+  }
+  return { queue, added };
+}
+
 // ── Bug injection ────────────────────────────────────────────────────
 
 export function appendBugIssue(queue, issueNumber, dependsOn = null) {

--- a/packages/core/test/queue-membership.test.mjs
+++ b/packages/core/test/queue-membership.test.mjs
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { reconcileBoardMembership } from "../src/loop/queue-membership.mjs";
+import { createEntry } from "../src/loop/queue-state.mjs";
+
+function makeQueue(entries = []) {
+  return { version: 1, entries };
+}
+
+function captureLog() {
+  const lines = [];
+  return { log: (msg) => lines.push(msg), lines };
+}
+
+test("configured board + empty local queue reconciles Next Up into entries (no silent 'Queue is empty')", async () => {
+  const queue = makeQueue([]);
+  let written = null;
+  const { log, lines } = captureLog();
+
+  const result = await reconcileBoardMembership("/repo", "owner/name", queue, {
+    loadBoardConfig: () => ({ enabled: true, projectNumber: 7 }),
+    resolveNextUpOrder: async (repo, repoRoot) => {
+      assert.equal(repo, "owner/name");
+      assert.equal(repoRoot, "/repo");
+      return { ok: true, order: [10, 20], reason: null };
+    },
+    writeQueue: async (_root, q) => { written = q; },
+    log,
+  });
+
+  assert.equal(result.boardConfigured, true);
+  assert.deepEqual(result.added, [10, 20]);
+  // Not empty: the caller should run the queue (emptiness is null).
+  assert.equal(result.emptiness, null);
+  assert.deepEqual(queue.entries.map((e) => e.target), [10, 20]);
+  // Reconciled membership is persisted.
+  assert.equal(written, queue);
+  assert.ok(lines.some((l) => l.includes("added 2 entries from board Next Up")));
+});
+
+test("configured board + existing local entries: board adds only missing members, preserves existing", async () => {
+  const existing = createEntry(10, "issue");
+  existing.status = "running";
+  const queue = makeQueue([existing]);
+
+  const result = await reconcileBoardMembership("/repo", "owner/name", queue, {
+    loadBoardConfig: () => ({ enabled: true }),
+    resolveNextUpOrder: async () => ({ ok: true, order: [10, 30], reason: null }),
+    writeQueue: async () => {},
+  });
+
+  assert.deepEqual(result.added, [30]);
+  assert.equal(result.emptiness, null);
+  assert.deepEqual(queue.entries.map((e) => e.target), [10, 30]);
+  assert.equal(queue.entries[0].status, "running");
+});
+
+test("configured board with empty Next Up reports 'board_empty', not 'queue_empty'", async () => {
+  const queue = makeQueue([]);
+  let written = null;
+
+  const result = await reconcileBoardMembership("/repo", "owner/name", queue, {
+    loadBoardConfig: () => ({ enabled: true }),
+    resolveNextUpOrder: async () => ({ ok: true, order: [], reason: "Next Up empty" }),
+    writeQueue: async (_root, q) => { written = q; },
+  });
+
+  assert.equal(result.boardConfigured, true);
+  assert.deepEqual(result.added, []);
+  assert.equal(result.emptiness, "board_empty");
+  assert.equal(result.reason, "Next Up empty");
+  // Nothing added → no write.
+  assert.equal(written, null);
+});
+
+test("unconfigured board + empty local queue reports 'queue_empty' (legacy behavior)", async () => {
+  const queue = makeQueue([]);
+  let resolveCalled = false;
+
+  const result = await reconcileBoardMembership("/repo", "owner/name", queue, {
+    loadBoardConfig: () => ({ enabled: false }),
+    resolveNextUpOrder: async () => { resolveCalled = true; return { ok: true, order: [99] }; },
+    writeQueue: async () => {},
+  });
+
+  assert.equal(result.boardConfigured, false);
+  assert.deepEqual(result.added, []);
+  assert.equal(result.emptiness, "queue_empty");
+  // Board not configured: Next Up is never consulted.
+  assert.equal(resolveCalled, false);
+});
+
+test("unconfigured board + non-empty local queue runs (emptiness null), no board read", async () => {
+  const queue = makeQueue([createEntry(5, "issue")]);
+
+  const result = await reconcileBoardMembership("/repo", "owner/name", queue, {
+    loadBoardConfig: () => ({ enabled: false }),
+    resolveNextUpOrder: async () => { throw new Error("should not be called"); },
+    writeQueue: async () => {},
+  });
+
+  assert.equal(result.boardConfigured, false);
+  assert.equal(result.emptiness, null);
+});
+
+test("board resolution error fails open to local queue (no crash)", async () => {
+  const queue = makeQueue([createEntry(5, "issue")]);
+  const { log, lines } = captureLog();
+
+  const result = await reconcileBoardMembership("/repo", "owner/name", queue, {
+    loadBoardConfig: () => ({ enabled: true }),
+    resolveNextUpOrder: async () => { throw new Error("GraphQL boom"); },
+    writeQueue: async () => {},
+    log,
+  });
+
+  // Falls back to the local queue: existing pending entry means run it.
+  assert.deepEqual(result.added, []);
+  assert.equal(result.emptiness, null);
+  assert.equal(result.reason, "GraphQL boom");
+  assert.ok(lines.some((l) => l.includes("Next Up resolution failed")));
+});
+
+test("board config read error fails open to unconfigured (no crash)", async () => {
+  const queue = makeQueue([]);
+  const { log } = captureLog();
+
+  const result = await reconcileBoardMembership("/repo", "owner/name", queue, {
+    loadBoardConfig: () => { throw new Error("bad .devloops"); },
+    resolveNextUpOrder: async () => ({ ok: true, order: [1] }),
+    writeQueue: async () => {},
+    log,
+  });
+
+  assert.equal(result.boardConfigured, false);
+  assert.equal(result.emptiness, "queue_empty");
+});
+
+test("persist failure does not crash; entries still drive the in-memory run", async () => {
+  const queue = makeQueue([]);
+
+  const result = await reconcileBoardMembership("/repo", "owner/name", queue, {
+    loadBoardConfig: () => ({ enabled: true }),
+    resolveNextUpOrder: async () => ({ ok: true, order: [10] }),
+    writeQueue: async () => { throw new Error("disk full"); },
+    log: () => {},
+  });
+
+  assert.deepEqual(result.added, [10]);
+  assert.equal(result.emptiness, null);
+  assert.deepEqual(queue.entries.map((e) => e.target), [10]);
+});

--- a/packages/core/test/queue-membership.test.mjs
+++ b/packages/core/test/queue-membership.test.mjs
@@ -56,22 +56,66 @@ test("configured board + existing local entries: board adds only missing members
   assert.equal(queue.entries[0].status, "running");
 });
 
-test("configured board with empty Next Up reports 'board_empty', not 'queue_empty'", async () => {
+test("configured board with genuinely empty Next Up (reason null) reports 'board_empty', not 'queue_empty'", async () => {
   const queue = makeQueue([]);
   let written = null;
 
   const result = await reconcileBoardMembership("/repo", "owner/name", queue, {
     loadBoardConfig: () => ({ enabled: true }),
-    resolveNextUpOrder: async () => ({ ok: true, order: [], reason: "Next Up empty" }),
+    // Clean resolution that returns no items: reason is null, so this is a
+    // genuinely empty Next Up rather than a resolution failure.
+    resolveNextUpOrder: async () => ({ ok: true, order: [], reason: null }),
     writeQueue: async (_root, q) => { written = q; },
   });
 
   assert.equal(result.boardConfigured, true);
   assert.deepEqual(result.added, []);
   assert.equal(result.emptiness, "board_empty");
-  assert.equal(result.reason, "Next Up empty");
+  assert.equal(result.reason, null);
   // Nothing added → no write.
   assert.equal(written, null);
+});
+
+test("configured board + empty order WITH a reason (fail-open resolution failure) is NOT board_empty", async () => {
+  const queue = makeQueue([]);
+  let written = null;
+  const { log, lines } = captureLog();
+
+  const result = await reconcileBoardMembership("/repo", "owner/name", queue, {
+    loadBoardConfig: () => ({ enabled: true }),
+    // resolveNextUpOrder is fail-open: an API error yields ok:true, an empty
+    // order, AND a non-null reason. This must NOT be mistaken for an empty board.
+    resolveNextUpOrder: async () => ({ ok: true, order: [], reason: "GraphQL 502 Bad Gateway" }),
+    writeQueue: async (_root, q) => { written = q; },
+    log,
+  });
+
+  assert.equal(result.boardConfigured, true);
+  assert.deepEqual(result.added, []);
+  // Critical: a resolution failure must not be reported as board_empty.
+  assert.notEqual(result.emptiness, "board_empty");
+  assert.equal(result.emptiness, "board_unavailable");
+  assert.equal(result.reason, "GraphQL 502 Bad Gateway");
+  assert.equal(written, null);
+  // The real reason is logged so the failure is not silently swallowed.
+  assert.ok(lines.some((l) => l.includes("Next Up resolution failed") && l.includes("GraphQL 502 Bad Gateway")));
+});
+
+test("configured board + empty order WITH a reason but non-empty local queue falls through to running (emptiness null)", async () => {
+  const queue = makeQueue([createEntry(5, "issue")]);
+
+  const result = await reconcileBoardMembership("/repo", "owner/name", queue, {
+    loadBoardConfig: () => ({ enabled: true }),
+    resolveNextUpOrder: async () => ({ ok: true, order: [], reason: "board lookup failed" }),
+    writeQueue: async () => {},
+    log: () => {},
+  });
+
+  assert.equal(result.boardConfigured, true);
+  assert.deepEqual(result.added, []);
+  // Local queue has pending work: fail-open runs it rather than reporting empty.
+  assert.equal(result.emptiness, null);
+  assert.equal(result.reason, "board lookup failed");
 });
 
 test("unconfigured board + empty local queue reports 'queue_empty' (legacy behavior)", async () => {

--- a/packages/core/test/queue-membership.test.mjs
+++ b/packages/core/test/queue-membership.test.mjs
@@ -181,6 +181,43 @@ test("board config read error fails open to unconfigured (no crash)", async () =
   assert.equal(result.emptiness, "queue_empty");
 });
 
+test("loadBoardConfig read/parse failure reason (enabled:false + reason) is logged", async () => {
+  // loadBoardConfig does not throw on a read/parse error; it returns
+  // { enabled:false, reason }. That reason must be surfaced via the log seam so
+  // a real config failure is visible rather than silently swallowed.
+  const queue = makeQueue([]);
+  const { log, lines } = captureLog();
+
+  const result = await reconcileBoardMembership("/repo", "owner/name", queue, {
+    loadBoardConfig: () => ({ enabled: false, reason: "config read/parse error: bad yaml" }),
+    resolveNextUpOrder: async () => { throw new Error("should not be called"); },
+    writeQueue: async () => {},
+    log,
+  });
+
+  assert.equal(result.boardConfigured, false);
+  assert.equal(result.emptiness, "queue_empty");
+  assert.ok(
+    lines.some((l) => l.includes("config read/parse error: bad yaml")),
+    "the config failure reason should be logged",
+  );
+});
+
+test("ordinary 'board not configured' (enabled:false, no reason) is not logged", async () => {
+  const queue = makeQueue([]);
+  const { log, lines } = captureLog();
+
+  await reconcileBoardMembership("/repo", "owner/name", queue, {
+    loadBoardConfig: () => ({ enabled: false }),
+    resolveNextUpOrder: async () => { throw new Error("should not be called"); },
+    writeQueue: async () => {},
+    log,
+  });
+
+  // No reason => no config-unavailable log line (quiet legacy path).
+  assert.ok(!lines.some((l) => l.includes("board config unavailable")));
+});
+
 test("persist failure does not crash; entries still drive the in-memory run", async () => {
   const queue = makeQueue([]);
 

--- a/packages/core/test/queue-state.test.mjs
+++ b/packages/core/test/queue-state.test.mjs
@@ -354,13 +354,16 @@ test("appendBugIssue with dependency", () => {
 
 // ── reconcileEntriesFromBoard ───────────────────────────────────────
 
-test("reconcileEntriesFromBoard adds missing board targets as queued issue entries", () => {
+test("reconcileEntriesFromBoard adds missing board targets as queued board entries", () => {
   const queue = { version: 1, entries: [] };
   const { queue: out, added } = reconcileEntriesFromBoard(queue, [10, 20, 30]);
   assert.equal(out, queue, "mutates/returns the same queue object");
   assert.deepEqual(added, [10, 20, 30]);
   assert.deepEqual(out.entries.map((e) => e.target), [10, 20, 30]);
-  assert.ok(out.entries.every((e) => e.kind === "issue"));
+  // Board Next Up can hold issues OR PRs and resolveNextUpOrder discards the
+  // kind, so board-sourced entries use a neutral "board" kind rather than
+  // falsely asserting "issue". The driver resolves the artifact by number.
+  assert.ok(out.entries.every((e) => e.kind === "board"));
   assert.ok(out.entries.every((e) => e.status === "queued"));
 });
 
@@ -404,6 +407,36 @@ test("reconcileEntriesFromBoard ignores non-number targets", () => {
   const queue = { version: 1, entries: [] };
   const { added } = reconcileEntriesFromBoard(queue, [10, "PVTI_abc", null, 11]);
   assert.deepEqual(added, [10, 11]);
+});
+
+test("reconcileEntriesFromBoard filters NaN, Infinity, non-integer, negative, and 0 targets", () => {
+  const queue = { version: 1, entries: [] };
+  const { added } = reconcileEntriesFromBoard(queue, [
+    10,
+    NaN,
+    Infinity,
+    -Infinity,
+    3.5,
+    -7,
+    0,
+    11,
+  ]);
+  // Only positive integers survive the numeric guard.
+  assert.deepEqual(added, [10, 11]);
+  assert.deepEqual(queue.entries.map((e) => e.target), [10, 11]);
+});
+
+test("reconcileEntriesFromBoard never creates a NaN entry and does not accumulate across repeated reconciles", () => {
+  // NaN never dedups via findEntry (NaN !== NaN), so without the integer guard
+  // each reconcile would append a fresh NaN entry. Verify it is filtered and
+  // repeated reconciles stay a no-op.
+  const queue = { version: 1, entries: [] };
+  for (let i = 0; i < 3; i++) {
+    const { added } = reconcileEntriesFromBoard(queue, [NaN]);
+    assert.deepEqual(added, []);
+  }
+  assert.equal(queue.entries.length, 0);
+  assert.ok(!queue.entries.some((e) => Number.isNaN(e.target)));
 });
 
 test("reconcileEntriesFromBoard tolerates a malformed queue", () => {

--- a/packages/core/test/queue-state.test.mjs
+++ b/packages/core/test/queue-state.test.mjs
@@ -24,6 +24,7 @@ import {
   pendingEntries,
   appendBugIssue,
   queueFilePath,
+  reconcileEntriesFromBoard,
 } from "../src/loop/queue-state.mjs";
 
 // ── Constants ───────────────────────────────────────────────────────
@@ -349,4 +350,63 @@ test("appendBugIssue with dependency", () => {
   const queue = { version: 1, entries: [createEntry(1, "issue")] };
   appendBugIssue(queue, 999, 1);
   assert.deepEqual(queue.entries[1].dependsOn, [1]);
+});
+
+// ── reconcileEntriesFromBoard ───────────────────────────────────────
+
+test("reconcileEntriesFromBoard adds missing board targets as queued issue entries", () => {
+  const queue = { version: 1, entries: [] };
+  const { queue: out, added } = reconcileEntriesFromBoard(queue, [10, 20, 30]);
+  assert.equal(out, queue, "mutates/returns the same queue object");
+  assert.deepEqual(added, [10, 20, 30]);
+  assert.deepEqual(out.entries.map((e) => e.target), [10, 20, 30]);
+  assert.ok(out.entries.every((e) => e.kind === "issue"));
+  assert.ok(out.entries.every((e) => e.status === "queued"));
+});
+
+test("reconcileEntriesFromBoard preserves existing entries and their status/order", () => {
+  const done = createEntry(10, "issue"); done.status = "done";
+  const running = createEntry(20, "issue"); running.status = "running";
+  const queue = { version: 1, entries: [done, running] };
+  // Board reports 20 (already present) and 30 (new).
+  const { added } = reconcileEntriesFromBoard(queue, [20, 30]);
+  assert.deepEqual(added, [30]);
+  // Existing entries untouched and in original order; new one appended last.
+  assert.deepEqual(queue.entries.map((e) => e.target), [10, 20, 30]);
+  assert.equal(queue.entries[0].status, "done");
+  assert.equal(queue.entries[1].status, "running");
+  assert.equal(queue.entries[2].status, "queued");
+});
+
+test("reconcileEntriesFromBoard dedups targets already present", () => {
+  const queue = { version: 1, entries: [createEntry(10, "issue")] };
+  const { added } = reconcileEntriesFromBoard(queue, [10]);
+  assert.deepEqual(added, []);
+  assert.equal(queue.entries.length, 1);
+});
+
+test("reconcileEntriesFromBoard dedups repeated targets within the board list", () => {
+  const queue = { version: 1, entries: [] };
+  const { added } = reconcileEntriesFromBoard(queue, [10, 10, 11]);
+  assert.deepEqual(added, [10, 11]);
+  assert.deepEqual(queue.entries.map((e) => e.target), [10, 11]);
+});
+
+test("reconcileEntriesFromBoard is a no-op on empty board input", () => {
+  const queue = { version: 1, entries: [createEntry(1, "issue")] };
+  assert.deepEqual(reconcileEntriesFromBoard(queue, []).added, []);
+  assert.deepEqual(reconcileEntriesFromBoard(queue, null).added, []);
+  assert.deepEqual(reconcileEntriesFromBoard(queue, undefined).added, []);
+  assert.equal(queue.entries.length, 1);
+});
+
+test("reconcileEntriesFromBoard ignores non-number targets", () => {
+  const queue = { version: 1, entries: [] };
+  const { added } = reconcileEntriesFromBoard(queue, [10, "PVTI_abc", null, 11]);
+  assert.deepEqual(added, [10, 11]);
+});
+
+test("reconcileEntriesFromBoard tolerates a malformed queue", () => {
+  assert.deepEqual(reconcileEntriesFromBoard(null, [1]).added, []);
+  assert.deepEqual(reconcileEntriesFromBoard({}, [1]).added, []);
 });

--- a/scripts/loop/run-queue.mjs
+++ b/scripts/loop/run-queue.mjs
@@ -116,17 +116,34 @@ async function main() {
   // source (issue #864): fold its "Next Up" items into the queue before judging
   // emptiness so a populated board with an empty local queue is no longer a
   // silent no-op. Fail-open — a board hiccup falls back to the local queue.
+  // reconcileBoardMembership already logs an "added N ... from board Next Up"
+  // line to stderr (single source of truth); we deliberately do not duplicate
+  // it here to avoid noise for JSON consumers of stdout.
   const membership = await reconcileBoardMembership(REPO_ROOT, args.repo, queue);
-  if (membership.added.length > 0) {
-    console.error(`Board: reconciled ${membership.added.length} Next Up item(s) into the queue (${membership.added.join(", ")})`);
-  }
 
   if (membership.emptiness === "board_empty") {
     // Distinct from the legacy generic "Queue is empty": the board is the
-    // membership source and it currently has nothing in Next Up.
+    // membership source and it currently has nothing in Next Up. This branch is
+    // only reached for a genuinely empty Next Up (reason == null), never for a
+    // resolution failure (which falls through to the local queue below).
     console.log(JSON.stringify({
       ok: true,
       message: "Board configured but Next Up is empty; nothing to run",
+      boardConfigured: true,
+      reason: null,
+      results: [],
+    }));
+    return;
+  }
+
+  if (membership.emptiness === "board_unavailable") {
+    // The board IS configured but Next Up resolution failed (fail-open) and the
+    // local queue had nothing to fall back to. Do NOT claim "Next Up is empty";
+    // surface the real reason so consumers can distinguish an outage from an
+    // intentionally empty board.
+    console.log(JSON.stringify({
+      ok: true,
+      message: `Board configured but unavailable (${membership.reason}); nothing to run`,
       boardConfigured: true,
       reason: membership.reason ?? null,
       results: [],

--- a/scripts/loop/run-queue.mjs
+++ b/scripts/loop/run-queue.mjs
@@ -18,6 +18,7 @@ import { parseArgs } from "node:util";
 import { runQueue, DEFAULT_QUEUE_DRIVER_OPTIONS } from "@dev-loops/core/loop/queue-driver";
 import { computeParallelSchedule } from "@dev-loops/core/loop/queue-parallel";
 import { readQueue } from "@dev-loops/core/loop/queue-state";
+import { reconcileBoardMembership } from "@dev-loops/core/loop/queue-membership";
 import { parsePositiveInteger } from "@dev-loops/core/cli/primitives";
 
 const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
@@ -111,7 +112,29 @@ async function main() {
 
   const queue = await readQueue(REPO_ROOT);
 
-  if (queue.entries.length === 0) {
+  // A configured GitHub Projects board is the authoritative queue MEMBERSHIP
+  // source (issue #864): fold its "Next Up" items into the queue before judging
+  // emptiness so a populated board with an empty local queue is no longer a
+  // silent no-op. Fail-open — a board hiccup falls back to the local queue.
+  const membership = await reconcileBoardMembership(REPO_ROOT, args.repo, queue);
+  if (membership.added.length > 0) {
+    console.error(`Board: reconciled ${membership.added.length} Next Up item(s) into the queue (${membership.added.join(", ")})`);
+  }
+
+  if (membership.emptiness === "board_empty") {
+    // Distinct from the legacy generic "Queue is empty": the board is the
+    // membership source and it currently has nothing in Next Up.
+    console.log(JSON.stringify({
+      ok: true,
+      message: "Board configured but Next Up is empty; nothing to run",
+      boardConfigured: true,
+      reason: membership.reason ?? null,
+      results: [],
+    }));
+    return;
+  }
+
+  if (membership.emptiness === "queue_empty") {
     console.log(JSON.stringify({ ok: true, message: "Queue is empty", results: [] }));
     return;
   }

--- a/skills/docs/anti-patterns.md
+++ b/skills/docs/anti-patterns.md
@@ -11,6 +11,7 @@ Canonical owner for anti-pattern guidance across all workflow families.
 5. **Duplicate worktree paths**: Check `git worktree list` before creating new worktrees; reuse existing matching worktrees.
 6. **Main-checkout mutation**: Reserve main checkout for inspection/control; use `tmp/worktrees/` paths for mutation work.
 7. **Spelunking tooling internals instead of using the public surface**: Do not read installed package internals, scan tooling source, or run ad-hoc scripts to understand a tool's behavior. Use the CLI, its `--help` subcommands, and `skills/docs/`. Read tool source only when the task is to inspect or change that tool, or when a concrete failure path is inside it and no public CLI/docs path exists. Once a failure is concrete, search changed files for the exact pattern — don't run duplicate broad searches.
+8. **Hand-editing the queue file when a board is configured**: When a GitHub Projects board is configured (`queue.projectNumber`/`queue.boardTitle` in `.devloops`), the board is the authoritative queue MEMBERSHIP and ordering source — not just status. Add work via the board (`dev-loops project add ... --status "Next Up"`), not by hand-editing `.pi/dev-loop-queue.json`; the queue runner reconciles board `Next Up` items into queue entries before each run. See the operator guides under `docs/` (queue board usage/setup) for the workflow.
 
 ## Light mode exception
 


### PR DESCRIPTION
## Summary

Make a configured GitHub Projects board the authoritative **queue membership** source — not just ordering/status. Previously `dev-loops queue run` read membership only from `.pi/dev-loop-queue.json`, so a populated board with an empty local queue printed "Queue is empty" and silently no-op'd. Closes #864.

## Changes

- `queue-state`: pure `reconcileEntriesFromBoard(queue, nextUpTargets)` → appends `createEntry()` for board `Next Up` targets not already present; preserves existing entries/status/order; dedups; tolerates malformed/empty input.
- `queue-membership.mjs` (new): `reconcileBoardMembership()` — loads board config, fetches `Next Up` via `resolveNextUpOrder`, reconciles + persists, fail-open on errors. Returns an emptiness verdict: `null` (run) | `board_empty` (configured but Next Up empty) | `queue_empty` (unconfigured + empty local queue → legacy message).
- `run-queue.mjs`: wires the reconcile before the emptiness check and distinguishes "board configured but Next Up empty; nothing to run" from the legacy "Queue is empty".
- Docs: a configured board is the authoritative membership + ordering source; add items via `project add`, not by hand-editing the local queue file.

## Non-goals

- No change to ordering (`resolveNextUpOrder`), status-sync, or per-entry driver execution.

## Validation

- `npm run verify` — pass (core 1601; 0 fail). Tests: `reconcileEntriesFromBoard` (add/preserve/dedup/empty/malformed) + `reconcileBoardMembership` (configured→reconcile, board_empty, queue_empty, fail-open).

Closes #864
