### PR TITLE
fix(packaging): import @dev-loops/core via package specifier in skill shims (closes #890)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ All notable changes to this project will be documented in this file.
 - **Gate fan-out evidence enforcement is now ON by default** (#882, #879, epic #867 final phase). A clean gate verdict requires the gate to have run via `--execution-mode fanout_fanin` with a findings-log ledger for the head SHA; the pre-merge evidence check fails closed otherwise. Repos can opt out with `gates.requireFanoutEvidence: false`.
 - **Board status auto-syncs on dev-loop transitions** (#883, #874). A linked issue's board Status column is synced on loop transitions (e.g. PR opened → `In Progress`, merged → `Done`) via local `gh` auth — best-effort and non-fatal. Repairs the `move-queue-item` lookup that passed numeric (not string) project/item refs.
 
+### Fixed
+
+- **Skill shims import `@dev-loops/core` via its package specifier** (#890). `skills/dev-loop/scripts/log-bash-exit-1.mjs` and `phase-files.mjs` previously reached into core through cross-package relative paths (`../../../packages/core/src/...`), which are broken on disk for npm consumers because the published `dev-loops` package ships `skills/` but not `packages/core/`. They now import via the `@dev-loops/core` `exports` map. A contract test guards against reintroducing relative cross-package imports under `skills/`.
+
 ## 0.2.8
 
 ### Added

--- a/skills/dev-loop/scripts/log-bash-exit-1.mjs
+++ b/skills/dev-loop/scripts/log-bash-exit-1.mjs
@@ -9,9 +9,9 @@ export {
   readRecordFromStdin,
   runCli,
   truncateText,
-} from "../../../packages/core/src/bash-exit-one.mjs";
+} from "@dev-loops/core/bash-exit-one";
 
-import { runCli } from "../../../packages/core/src/bash-exit-one.mjs";
+import { runCli } from "@dev-loops/core/bash-exit-one";
 
 const invokedAsScript = process.argv[1]
   ? import.meta.url === pathToFileURL(process.argv[1]).href

--- a/skills/dev-loop/scripts/phase-files.mjs
+++ b/skills/dev-loop/scripts/phase-files.mjs
@@ -13,9 +13,9 @@ export {
   uniqueSortedStrings,
   upsertPhaseIndex,
   writeJson,
-} from "../../../packages/core/src/loop/phase-files.mjs";
+} from "@dev-loops/core/loop/phase-files";
 
-import { runCli } from "../../../packages/core/src/loop/phase-files.mjs";
+import { runCli } from "@dev-loops/core/loop/phase-files";
 
 const invokedAsScript = process.argv[1]
   ? import.meta.url === pathToFileURL(process.argv[1]).href

--- a/test/contracts/skills-no-cross-package-relative-import.test.mjs
+++ b/test/contracts/skills-no-cross-package-relative-import.test.mjs
@@ -16,7 +16,7 @@ const SCAN_DIR = "skills";
 // Detect a real ESM import (static, side-effect, or dynamic) whose specifier is a relative
 // path reaching into `packages/core`. The leading relative segment and the `from`/`import`
 // keyword keep prose mentions of the path in comments/strings from being false positives.
-// The optional `(?:\.\/)+` prefix also catches `./..`-style equivalents (e.g.
+// The optional `(?:\.\/)*` prefix also catches `./..`-style equivalents (e.g.
 // `"./../../packages/core/..."`) that are still relative paths but would otherwise bypass a
 // detector anchored solely on a leading `..`.
 const RELATIVE_CORE_STATIC_OR_SIDE_EFFECT_RE =
@@ -50,7 +50,7 @@ async function collectSourceFiles(dir) {
   return out;
 }
 
-test("no file under skills/ imports @dev-loops/core via a cross-package relative path", async () => {
+test("no file under skills/ reaches into packages/core via a cross-package relative import path", async () => {
   const files = await collectSourceFiles(SCAN_DIR);
   assert.ok(files.length > 0, "expected to scan some source files under skills/");
 

--- a/test/contracts/skills-no-cross-package-relative-import.test.mjs
+++ b/test/contracts/skills-no-cross-package-relative-import.test.mjs
@@ -14,11 +14,14 @@ const repoRoot = path.resolve(fileURLToPath(new URL("../../", import.meta.url)))
 const SCAN_DIR = "skills";
 
 // Detect a real ESM import (static, side-effect, or dynamic) whose specifier is a relative
-// path reaching into `packages/core`. The leading `..` and `from`/`import` keyword keep
-// prose mentions of the path in comments/strings from being false positives.
+// path reaching into `packages/core`. The leading relative segment and the `from`/`import`
+// keyword keep prose mentions of the path in comments/strings from being false positives.
+// The optional `(?:\.\/)+` prefix also catches `./..`-style equivalents (e.g.
+// `"./../../packages/core/..."`) that are still relative paths but would otherwise bypass a
+// detector anchored solely on a leading `..`.
 const RELATIVE_CORE_STATIC_OR_SIDE_EFFECT_RE =
-  /\b(?:from|import)\s+['"]\.\.[^'"]*packages\/core[^'"]*['"]/;
-const RELATIVE_CORE_DYNAMIC_RE = /\bimport\(\s*['"]\.\.[^'"]*packages\/core/;
+  /\b(?:from|import)\s+['"](?:\.\/)*\.\.[^'"]*packages\/core[^'"]*['"]/;
+const RELATIVE_CORE_DYNAMIC_RE = /\bimport\(\s*['"](?:\.\/)*\.\.[^'"]*packages\/core/;
 
 function importsCoreViaRelativePath(content) {
   return (
@@ -85,7 +88,28 @@ test("importsCoreViaRelativePath detects static, side-effect, and dynamic relati
     true,
     "dynamic import must be caught",
   );
+  // A leading `./` (or repeated `./`) before `..` is still an equivalent relative path and
+  // must be caught so it cannot be used to bypass the guard.
+  assert.equal(
+    importsCoreViaRelativePath('import { x } from "./../../packages/core/src/x.mjs";'),
+    true,
+    "./..-prefixed static import must be caught",
+  );
+  assert.equal(
+    importsCoreViaRelativePath('import "././../../packages/core/src/x.mjs";'),
+    true,
+    "repeated ./ prefix before .. must be caught",
+  );
+  assert.equal(
+    importsCoreViaRelativePath("await import('./../../packages/core/src/x.mjs');"),
+    true,
+    "./..-prefixed dynamic import must be caught",
+  );
   // The package specifier is the sanctioned form and must NOT trip the detector.
+  assert.equal(
+    importsCoreViaRelativePath('import { x } from "@dev-loops/core/loop/phase-files";'),
+    false,
+  );
   assert.equal(
     importsCoreViaRelativePath('import { x } from "@dev-loops/core/bash-exit-one";'),
     false,

--- a/test/contracts/skills-no-cross-package-relative-import.test.mjs
+++ b/test/contracts/skills-no-cross-package-relative-import.test.mjs
@@ -1,0 +1,102 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// #890 packaging boundary. The root `dev-loops` npm package ships `skills/` but NOT
+// `packages/core/` in its `files` allowlist. Any file under `skills/` that imports core
+// via a cross-package RELATIVE path (e.g. `../../../packages/core/src/...`) is broken on
+// disk for npm consumers. Core must be reached through the `@dev-loops/core` package
+// specifier and its `exports` map instead.
+
+const repoRoot = path.resolve(fileURLToPath(new URL("../../", import.meta.url)));
+const SCAN_DIR = "skills";
+
+// Detect a real ESM import (static, side-effect, or dynamic) whose specifier is a relative
+// path reaching into `packages/core`. The leading `..` and `from`/`import` keyword keep
+// prose mentions of the path in comments/strings from being false positives.
+const RELATIVE_CORE_STATIC_OR_SIDE_EFFECT_RE =
+  /\b(?:from|import)\s+['"]\.\.[^'"]*packages\/core[^'"]*['"]/;
+const RELATIVE_CORE_DYNAMIC_RE = /\bimport\(\s*['"]\.\.[^'"]*packages\/core/;
+
+function importsCoreViaRelativePath(content) {
+  return (
+    RELATIVE_CORE_STATIC_OR_SIDE_EFFECT_RE.test(content) ||
+    RELATIVE_CORE_DYNAMIC_RE.test(content)
+  );
+}
+
+async function collectSourceFiles(dir) {
+  const abs = path.join(repoRoot, dir);
+  const out = [];
+  let entries;
+  try {
+    entries = await readdir(abs, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const rel = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...(await collectSourceFiles(rel)));
+    } else if (/\.(ts|mjs|js)$/.test(entry.name)) {
+      out.push(rel);
+    }
+  }
+  return out;
+}
+
+test("no file under skills/ imports @dev-loops/core via a cross-package relative path", async () => {
+  const files = await collectSourceFiles(SCAN_DIR);
+  assert.ok(files.length > 0, "expected to scan some source files under skills/");
+
+  const offenders = [];
+  for (const rel of files) {
+    const content = await readFile(path.join(repoRoot, rel), "utf8");
+    if (importsCoreViaRelativePath(content)) {
+      offenders.push(rel);
+    }
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `These skills files import packages/core via a relative path; use the "@dev-loops/core" specifier instead: ${offenders.join(", ")}`,
+  );
+});
+
+test("importsCoreViaRelativePath detects static, side-effect, and dynamic relative core imports without prose false positives", () => {
+  assert.equal(
+    importsCoreViaRelativePath('import { x } from "../../../packages/core/src/bash-exit-one.mjs";'),
+    true,
+  );
+  assert.equal(
+    importsCoreViaRelativePath("export { y } from '../../packages/core/src/loop/phase-files.mjs';"),
+    true,
+  );
+  assert.equal(
+    importsCoreViaRelativePath('import "../../../packages/core/src/foo.mjs";'),
+    true,
+    "side-effect import must be caught",
+  );
+  assert.equal(
+    importsCoreViaRelativePath("await import('../../../packages/core/src/foo.mjs');"),
+    true,
+    "dynamic import must be caught",
+  );
+  // The package specifier is the sanctioned form and must NOT trip the detector.
+  assert.equal(
+    importsCoreViaRelativePath('import { x } from "@dev-loops/core/bash-exit-one";'),
+    false,
+  );
+  // Prose mentions of the path must NOT trip the detector.
+  assert.equal(
+    importsCoreViaRelativePath("// see ../../../packages/core/src/loop/phase-files.mjs"),
+    false,
+  );
+  assert.equal(
+    importsCoreViaRelativePath("a doc string referencing packages/core/src in passing"),
+    false,
+  );
+});


### PR DESCRIPTION
Closes #890.

## Problem

`skills/dev-loop/scripts/log-bash-exit-1.mjs` and `skills/dev-loop/scripts/phase-files.mjs` imported `@dev-loops/core` internals via cross-package **relative** paths (`../../../packages/core/src/...`). The published `dev-loops` npm package ships `skills/` but **not** `packages/core/` in its `files` allowlist, so those imports are broken on disk for npm consumers.

## Fix

- Replaced the relative imports with the `@dev-loops/core` package specifier, using existing `exports` subpaths:
  - `../../../packages/core/src/bash-exit-one.mjs` → `@dev-loops/core/bash-exit-one`
  - `../../../packages/core/src/loop/phase-files.mjs` → `@dev-loops/core/loop/phase-files`
  - Updated both the `export { … } from` and the separate `import { runCli } from` lines in each shim.
- Grepped all of `skills/` for `packages/core` relative imports; only these two `.mjs` files had real imports (other hits are docs prose). No new `exports` entries were needed — both subpaths already existed.
- Added a guard contract test that fails if any file under `skills/` imports `packages/core` via a relative path.
- Added a `### Fixed` entry under the unpublished `## 0.3.0` CHANGELOG section.

## Checklist

- [x] Both shims import via `@dev-loops/core` exports map
- [x] Import-smoke confirmed both shims resolve and load
- [x] Guard test added under `test/contracts/` and passing
- [x] `npm run verify` green (exit 0)
- [x] `package-lock.json` unchanged (no lockfile churn)
- [x] CHANGELOG `### Fixed` entry referencing #890

🤖 Generated with [Claude Code](https://claude.com/claude-code)