### PR TITLE
fix(gates): self-heal draft_gate posting on ready PRs (#891)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ All notable changes to this project will be documented in this file.
 - **Gate fan-out evidence enforcement is now ON by default** (#882, #879, epic #867 final phase). A clean gate verdict requires the gate to have run via `--execution-mode fanout_fanin` with a findings-log ledger for the head SHA; the pre-merge evidence check fails closed otherwise. Repos can opt out with `gates.requireFanoutEvidence: false`.
 - **Board status auto-syncs on dev-loop transitions** (#883, #874). A linked issue's board Status column is synced on loop transitions (e.g. PR opened → `In Progress`, merged → `Done`) via local `gh` auth — best-effort and non-fatal. Repairs the `move-queue-item` lookup that passed numeric (not string) project/item refs.
 
+### Fixed
+
+- **Draft-gate deadlock on ready PRs resolved** (#891). Posting a `draft_gate` verdict on a PR that is already ready-for-review (e.g. opened directly as ready) no longer dead-ends. `upsert-checkpoint-verdict` now (a) treats an already-satisfied draft gate as an idempotent no-op instead of a hard error, and (b) when a ready PR still needs clean draft-gate evidence, performs the draft→post→ready transition automatically — preserving the caller's execution mode (`fanout_fanin`), findings, and ledger. This is the fanout-aware analogue of `reconcile-draft-gate` (which only posts inline and so cannot satisfy `requireFanoutEvidence` on the draft gate).
+
 ## 0.2.8
 
 ### Added

--- a/scripts/github/reconcile-draft-gate.mjs
+++ b/scripts/github/reconcile-draft-gate.mjs
@@ -124,7 +124,7 @@ async function resolvePrNodeId({ repo, pr }, { env, ghCommand }) {
   }
   return { id: prData.id, isDraft: prData.isDraft };
 }
-async function convertPrToDraft({ repo, pr }, { env, ghCommand }) {
+export async function convertPrToDraft({ repo, pr }, { env, ghCommand }) {
   const resolvedPr = await resolvePrNodeId({ repo, pr }, { env, ghCommand });
   if (resolvedPr.isDraft === true) {
     return {
@@ -154,7 +154,7 @@ async function convertPrToDraft({ repo, pr }, { env, ghCommand }) {
     alreadyDraft: false,
   };
 }
-async function markPrReady({ repo, pr }, { env, ghCommand }) {
+export async function markPrReady({ repo, pr }, { env, ghCommand }) {
   const result = await runChild(ghCommand, [
     "pr", "ready", String(pr),
     "--repo", repo,

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -557,12 +557,14 @@ async function verifyComment({ repo, commentId }, { env, ghCommand }) {
 //
 // Durability note: there is a bounded window between convertPrToDraft and
 // markPrReady (the recursive verdict post does network I/O) in which a process
-// crash would leave the PR in draft. This is self-healing — the next run re-enters
-// as a draft, posts normally, and a subsequent transition/ready restores it — but
-// the transition is logged (below) so a stuck-draft PR leaves a breadcrumb. There
-// is no mutual exclusion around the GitHub draft toggle itself; the convert and
-// markPrReady mutations are individually idempotent, so cooperating runners cannot
-// produce a permanent draft (only a transient flicker).
+// crash would leave the PR in draft INDEFINITELY — until a later dev-loop run (or a
+// manual `gh pr ready`) restores it. Recovery is automatic but NOT instantaneous:
+// the next run re-enters as a draft, posts normally, and restores ready. The
+// transition is logged (below) so a stuck-draft PR leaves a breadcrumb. There is no
+// mutual exclusion around the GitHub draft toggle itself; the convert and
+// markPrReady mutations are individually idempotent, so concurrent cooperating
+// runners cause at most a transient draft flicker (not a stuck draft) — only a hard
+// crash mid-transition can leave the PR drafted until a subsequent run.
 async function postDraftGateViaDraftTransition(options, { env, ghCommand, repoRoot }) {
   const { convertPrToDraft, markPrReady } = await import("./reconcile-draft-gate.mjs");
   process.stderr.write(
@@ -693,9 +695,15 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
       repo: options.repo,
       pr: options.pr,
       gate: "draft_gate",
-      headSha: canonicalHeadSha,
+      // Report the head the existing clean evidence was recorded on (which may be a
+      // stale head — the draft gate is a one-time boundary accepted on any head),
+      // not the request's canonical head, so the field is not misleading.
+      headSha: satisfied.headSha ?? canonicalHeadSha,
       currentHeadSha: evidence.currentHeadSha,
       draftGateAlreadySatisfied: true,
+      // Mirror the field shape of the other success paths for consistent consumers.
+      blockCleanOnFindingSeverities: draftGateConfig.blockCleanOnFindingSeverities,
+      executionMode: satisfied.executionMode ?? DEFAULT_EXECUTION_MODE,
       ...(satisfied.commentId != null ? { commentId: satisfied.commentId } : {}),
       ...(satisfied.commentUrl ? { commentUrl: satisfied.commentUrl } : {}),
     };

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -554,8 +554,21 @@ async function verifyComment({ repo, commentId }, { env, ghCommand }) {
 // cannot satisfy requireFanoutEvidence on draft_gate), this preserves fanout
 // evidence. On any failure mid-transition the PR is best-effort restored to
 // ready before rethrowing. (#891)
+//
+// Durability note: there is a bounded window between convertPrToDraft and
+// markPrReady (the recursive verdict post does network I/O) in which a process
+// crash would leave the PR in draft. This is self-healing — the next run re-enters
+// as a draft, posts normally, and a subsequent transition/ready restores it — but
+// the transition is logged (below) so a stuck-draft PR leaves a breadcrumb. There
+// is no mutual exclusion around the GitHub draft toggle itself; the convert and
+// markPrReady mutations are individually idempotent, so cooperating runners cannot
+// produce a permanent draft (only a transient flicker).
 async function postDraftGateViaDraftTransition(options, { env, ghCommand, repoRoot }) {
   const { convertPrToDraft, markPrReady } = await import("./reconcile-draft-gate.mjs");
+  process.stderr.write(
+    `[draft_gate] ${options.repo}#${options.pr} is ready but needs clean draft_gate evidence; ` +
+    `temporarily converting to draft to post the verdict, then restoring ready.\n`,
+  );
   const conversion = await convertPrToDraft({ repo: options.repo, pr: options.pr }, { env, ghCommand });
   let result;
   try {
@@ -566,14 +579,21 @@ async function postDraftGateViaDraftTransition(options, { env, ghCommand, repoRo
     if (conversion.alreadyDraft !== true) {
       try {
         await markPrReady({ repo: options.repo, pr: options.pr }, { env, ghCommand });
-      } catch {
-        // Best-effort restore; surface the original error.
+        process.stderr.write(`[draft_gate] restored ${options.repo}#${options.pr} to ready after a failed verdict post.\n`);
+      } catch (restoreError) {
+        // Best-effort restore; surface the original error but log the restore failure
+        // so the transient draft state is not silent.
+        process.stderr.write(
+          `[draft_gate] WARNING: failed to restore ${options.repo}#${options.pr} to ready after a failed verdict post; ` +
+          `it may be left in draft: ${restoreError instanceof Error ? restoreError.message : String(restoreError)}\n`,
+        );
       }
     }
     throw error;
   }
   if (conversion.alreadyDraft !== true) {
     await markPrReady({ repo: options.repo, pr: options.pr }, { env, ghCommand });
+    process.stderr.write(`[draft_gate] restored ${options.repo}#${options.pr} to ready after posting draft_gate evidence.\n`);
   }
   return { ...result, draftTransition: true };
 }

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -688,6 +688,16 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
     // return idempotent success so scripted/automated callers are not dead-ended
     // by a hard throw. (#891)
     const satisfied = coordinationContext.gateEvidence?.draftGate ?? {};
+    // executionMode lives on the gate MARKER summary, not the COMMENT (strict)
+    // summary: the strict `draftGate` summary is parsed from the visible comment
+    // body via normalizeGateSummary, which carries no executionMode field, so it
+    // would always collapse to inline_single_agent — misleading when the satisfied
+    // gate actually ran fanout_fanin. Prefer the marker's executionMode; if the
+    // marker is unavailable, OMIT the field rather than report a misleading default.
+    const satisfiedExecutionMode =
+      coordinationContext.gateEvidence?.draftGateMarker?.executionMode
+      ?? satisfied.executionMode
+      ?? null;
     return {
       ok: true,
       action: "noop",
@@ -703,7 +713,7 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
       draftGateAlreadySatisfied: true,
       // Mirror the field shape of the other success paths for consistent consumers.
       blockCleanOnFindingSeverities: draftGateConfig.blockCleanOnFindingSeverities,
-      executionMode: satisfied.executionMode ?? DEFAULT_EXECUTION_MODE,
+      ...(satisfiedExecutionMode != null ? { executionMode: satisfiedExecutionMode } : {}),
       ...(satisfied.commentId != null ? { commentId: satisfied.commentId } : {}),
       ...(satisfied.commentUrl ? { commentUrl: satisfied.commentUrl } : {}),
     };

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -545,6 +545,39 @@ async function verifyComment({ repo, commentId }, { env, ghCommand }) {
   }
 }
 
+// Post a draft_gate verdict on a PR that is currently READY (non-draft) by
+// briefly transitioning it back to draft, posting the verdict (which is only
+// legal while the PR is a draft), then restoring the ready state. The caller's
+// options — verdict, execution mode (e.g. fanout_fanin), findings, ledger — are
+// preserved verbatim by re-entering upsertCheckpointVerdict once the PR is a
+// draft. Unlike `reconcile-draft-gate` (which posts an inline verdict and so
+// cannot satisfy requireFanoutEvidence on draft_gate), this preserves fanout
+// evidence. On any failure mid-transition the PR is best-effort restored to
+// ready before rethrowing. (#891)
+async function postDraftGateViaDraftTransition(options, { env, ghCommand, repoRoot }) {
+  const { convertPrToDraft, markPrReady } = await import("./reconcile-draft-gate.mjs");
+  const conversion = await convertPrToDraft({ repo: options.repo, pr: options.pr }, { env, ghCommand });
+  let result;
+  try {
+    // The PR is now a draft, so RUN_DRAFT_GATE is the legal action. Re-enter with
+    // the caller's full options; prIsDraft is now true so this branch is skipped.
+    result = await upsertCheckpointVerdict(options, { env, ghCommand, repoRoot });
+  } catch (error) {
+    if (conversion.alreadyDraft !== true) {
+      try {
+        await markPrReady({ repo: options.repo, pr: options.pr }, { env, ghCommand });
+      } catch {
+        // Best-effort restore; surface the original error.
+      }
+    }
+    throw error;
+  }
+  if (conversion.alreadyDraft !== true) {
+    await markPrReady({ repo: options.repo, pr: options.pr }, { env, ghCommand });
+  }
+  return { ...result, draftTransition: true };
+}
+
 export async function upsertCheckpointVerdict(options, { env = process.env, ghCommand = "gh", repoRoot = process.cwd() } = {}) {
   // Root cause 1: allow resurrected sessions to claim ownership when the previous
   // run's coordination record is stale. Without this, a new run ID is rejected even
@@ -613,14 +646,47 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
     }
   }
   const requestedGateAction = resolveGateAction(options.gate);
+  const prIsDraft = Boolean(coordinationContext.prData?.isDraft);
   if (options.gate === "draft_gate" && coordination.draftGateAlreadySatisfied) {
-    throw new Error(
-      `Cannot enter draft_gate on ${options.repo}#${options.pr}: draft gate was already satisfied ` +
-      `(clean evidence exists, PR is no longer draft). ` +
-      `Do not re-post draft_gate. The draft→ready transition was already recorded.`,
-    );
+    // The draft gate is a one-time boundary: a non-draft PR with clean draft_gate
+    // evidence (on any head) has already passed it, and the pre-merge gate check
+    // accepts that evidence. Re-posting is therefore a no-op, not an error —
+    // return idempotent success so scripted/automated callers are not dead-ended
+    // by a hard throw. (#891)
+    const satisfied = coordinationContext.gateEvidence?.draftGate ?? {};
+    return {
+      ok: true,
+      action: "noop",
+      reason: "draft_gate already satisfied (clean evidence exists; draft→ready boundary recorded)",
+      repo: options.repo,
+      pr: options.pr,
+      gate: "draft_gate",
+      headSha: canonicalHeadSha,
+      currentHeadSha: evidence.currentHeadSha,
+      draftGateAlreadySatisfied: true,
+      ...(satisfied.commentId != null ? { commentId: satisfied.commentId } : {}),
+      ...(satisfied.commentUrl ? { commentUrl: satisfied.commentUrl } : {}),
+    };
   }
   const gateActionForbidden = coordination.forbiddenActions.includes(requestedGateAction);
+  // Draft gate can only be posted while the PR is a draft (RUN_DRAFT_GATE is
+  // forbidden once the PR is ready). A PR opened directly as ready — or any ready
+  // PR that still needs clean draft_gate evidence for the pre-merge check — would
+  // otherwise dead-end: the poster refuses, yet the pre-merge gate check fails
+  // closed on "missing visible clean draft_gate comment". Rather than force the
+  // operator to manually toggle the PR back to draft, perform the
+  // draft→post→ready transition here, preserving the caller's verdict, execution
+  // mode (e.g. fanout_fanin), findings, and ledger. This is the fanout-aware
+  // analogue of `reconcile-draft-gate` (which only posts inline and so cannot
+  // satisfy requireFanoutEvidence on draft_gate). (#891)
+  if (
+    options.gate === "draft_gate"
+    && gateActionForbidden
+    && !prIsDraft
+    && !coordination.draftGateAlreadySatisfied
+  ) {
+    return await postDraftGateViaDraftTransition(options, { env, ghCommand, repoRoot });
+  }
   if (gateActionForbidden) {
     throw new Error(buildGateEntryRefusalError({ options, coordination }));
   }

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -592,7 +592,19 @@ async function postDraftGateViaDraftTransition(options, { env, ghCommand, repoRo
     throw error;
   }
   if (conversion.alreadyDraft !== true) {
-    await markPrReady({ repo: options.repo, pr: options.pr }, { env, ghCommand });
+    try {
+      await markPrReady({ repo: options.repo, pr: options.pr }, { env, ghCommand });
+    } catch (restoreError) {
+      // The verdict WAS posted successfully; only the ready-restore failed. Make that
+      // explicit so the caller does not re-post the gate (the comment already exists)
+      // and knows the PR may be left in draft until restored. (#891, Copilot review)
+      throw new Error(
+        `draft_gate verdict was posted to ${options.repo}#${options.pr} (comment ${result.commentId ?? "?"}), ` +
+        `but restoring the PR to ready failed; it may be left in draft. Do not re-post the gate — re-run ` +
+        `\`gh pr ready ${options.pr}\` (or the dev-loop) to restore ready. Cause: ` +
+        `${restoreError instanceof Error ? restoreError.message : String(restoreError)}`,
+      );
+    }
     process.stderr.write(`[draft_gate] restored ${options.repo}#${options.pr} to ready after posting draft_gate evidence.\n`);
   }
   return { ...result, draftTransition: true };
@@ -699,11 +711,18 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
   // mode (e.g. fanout_fanin), findings, and ledger. This is the fanout-aware
   // analogue of `reconcile-draft-gate` (which only posts inline and so cannot
   // satisfy requireFanoutEvidence on draft_gate). (#891)
+  //
+  // Trigger ONLY when coordination explicitly allows RECONCILE_DRAFT_GATE — i.e. the
+  // state machine determined this ready PR genuinely needs draft-gate evidence
+  // reconciled (a converged/merge-progression state with no clean draft evidence).
+  // RUN_DRAFT_GATE is forbidden on a ready PR in many OTHER states too (merge
+  // conflicts, waiting-for-CI, unresolved feedback, blocked); converting those to
+  // draft would be wrong, so we must NOT key off `gateActionForbidden` alone. (#891)
   if (
     options.gate === "draft_gate"
-    && gateActionForbidden
     && !prIsDraft
     && !coordination.draftGateAlreadySatisfied
+    && coordination.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RECONCILE_DRAFT_GATE)
   ) {
     return await postDraftGateViaDraftTransition(options, { env, ghCommand, repoRoot });
   }

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -1676,7 +1676,7 @@ test("upsert-checkpoint-verdict warns when a gate comment exists on a different 
   }
 });
 
-test("upsert-checkpoint-verdict fails closed when draft_gate is forbidden on a non-draft PR", async () => {
+test("upsert-checkpoint-verdict treats stale clean draft_gate evidence on a non-draft PR as an idempotent no-op (#891)", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-draft-forbidden-"));
 
   try {
@@ -1728,11 +1728,15 @@ test("upsert-checkpoint-verdict fails closed when draft_gate is forbidden on a n
       "--next-action", "mark ready for review",
     ], { env });
 
-    assert.equal(result.code, 1);
-    assert.equal(result.stdout, "");
-    const payload = JSON.parse(result.stderr);
-    assert.equal(payload.ok, false);
-    assert.match(payload.error, /Cannot enter/);
+    // The PR already carries clean draft_gate evidence (on an earlier head). The
+    // draft gate is a one-time boundary and the pre-merge check accepts any-head
+    // clean draft evidence, so re-posting is an idempotent no-op rather than a
+    // hard failure. (#891)
+    assert.equal(result.code, 0);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.action, "noop");
+    assert.equal(payload.draftGateAlreadySatisfied, true);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -1872,11 +1876,14 @@ test("upsert-checkpoint-verdict rejects clean verdict when --findings-severity-c
   }
 });
 
-test("upsert-checkpoint-verdict rejects draft_gate when draftGateAlreadySatisfied is true", async () => {
+test("upsert-checkpoint-verdict treats draft_gate as an idempotent no-op when already satisfied (#891)", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-already-satisfied-"));
 
   try {
-    // Simulate a non-draft PR with an existing clean draft_gate comment
+    // Simulate a non-draft PR with an existing clean draft_gate comment. The draft
+    // gate is a one-time boundary already passed; the pre-merge check accepts this
+    // evidence, so re-posting must be an idempotent no-op (not a hard error that
+    // dead-ends scripted callers). (#891)
     const cleanDraftGateComment = {
       id: 101,
       body: [
@@ -1910,13 +1917,85 @@ test("upsert-checkpoint-verdict rejects draft_gate when draftGateAlreadySatisfie
       "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
     ], { env });
 
-    assert.equal(result.code, 1);
-    assert.equal(result.stdout, "");
-    const payload = JSON.parse(result.stderr);
-    assert.equal(payload.ok, false);
-    assert.match(payload.error, /Cannot enter draft_gate on owner\/repo#17/);
-    assert.match(payload.error, /draft gate was already satisfied/);
-    assert.match(payload.error, /Do not re-post draft_gate/);
+    assert.equal(result.code, 0);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.action, "noop");
+    assert.equal(payload.draftGateAlreadySatisfied, true);
+    assert.equal(payload.gate, "draft_gate");
+    assert.match(payload.reason, /already satisfied/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("upsert-checkpoint-verdict posts draft_gate on a ready PR via a draft transition, preserving execution mode (#891)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-draft-transition-"));
+
+  try {
+    // A non-draft PR with NO draft_gate evidence and green CI. RUN_DRAFT_GATE is
+    // forbidden on a ready PR, so the poster transitions the PR back to draft,
+    // posts the verdict (preserving --execution-mode fanout_fanin), then restores
+    // ready — instead of dead-ending the operator. (#891)
+    // Claims (order-independent) matching: the two coordination passes share
+    // identical `pr view` args and are claimed in listed order (isDraft:false
+    // before isDraft:true).
+    const { env: claimsEnvRaw } = await writeGhStubHelper(tempDir, [
+      // 1) first coordination pass: ready PR, green CI, no draft evidence
+      ...buildGateCoordinationEntries({
+        isDraft: false,
+        statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+        issueComments: [],
+      }),
+      // 2) convertPrToDraft: resolve PR node id, then convert mutation
+      {
+        assertArgs: ["api", "graphql", "-f", "-F"],
+        assertArgContains: ["number=17", "pullRequest(number: $number)"],
+        stdout: '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOScHU78000017","isDraft":false}}}}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "-f", "-F"],
+        assertArgContains: ["pullRequestId=PR_kwDOScHU78000017", "convertPullRequestToDraft"],
+        stdout: '{"data":{"convertPullRequestToDraft":{"pullRequest":{"id":"PR_kwDOScHU78000017","isDraft":true}}}}\n',
+      },
+      // 3) recursive upsert: second coordination pass, now a draft PR
+      ...buildGateCoordinationEntries({
+        isDraft: true,
+        statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+        issueComments: [],
+      }),
+      // 4) post the draft_gate comment
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f"],
+        assertArgContains: ["body=### Gate review: `draft_gate`"],
+        stdout: '{"id":501,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-501"}\n',
+      },
+      // 5) restore ready state
+      {
+        assertArgs: ["pr", "ready", "17", "--repo", "owner/repo"],
+        stdout: "",
+      },
+    ], { matchMode: "claims" });
+    const env = { ...claimsEnvRaw, PI_SUBAGENT_RUN_ID: "" };
+
+    const result = await upsertCheckpointVerdict({
+      repo: "owner/repo",
+      pr: 17,
+      gate: "draft_gate",
+      headSha: "abc1234",
+      verdict: "clean",
+      findingsSeverityCounts: { "must-fix": 0, "worth-fixing-now": 0, "defer": 0 },
+      findingsSummary: "no issues found",
+      nextAction: "mark ready for review",
+      executionMode: "fanout_fanin",
+    }, { env, repoRoot: tempDir });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.action, "created");
+    assert.equal(result.gate, "draft_gate");
+    assert.equal(result.draftTransition, true);
+    assert.equal(result.executionMode, "fanout_fanin");
+    assert.equal(result.commentId, 501);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -1929,73 +1929,45 @@ test("upsert-checkpoint-verdict treats draft_gate as an idempotent no-op when al
   }
 });
 
-test("upsert-checkpoint-verdict posts draft_gate on a ready PR via a draft transition, preserving execution mode (#891)", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-draft-transition-"));
+test("upsert-checkpoint-verdict does NOT convert a ready PR to draft when reconcile is not the allowed action (#891 narrowing)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-no-self-heal-"));
 
   try {
-    // A non-draft PR with NO draft_gate evidence and green CI. RUN_DRAFT_GATE is
-    // forbidden on a ready PR, so the poster transitions the PR back to draft,
-    // posts the verdict (preserving --execution-mode fanout_fanin), then restores
-    // ready — instead of dead-ending the operator. (#891)
-    // Claims (order-independent) matching: the two coordination passes share
-    // identical `pr view` args and are claimed in listed order (isDraft:false
-    // before isDraft:true).
-    const { env: claimsEnvRaw } = await writeGhStubHelper(tempDir, [
-      // 1) first coordination pass: ready PR, green CI, no draft evidence
+    // The self-heal draft→post→ready transition must fire ONLY when coordination
+    // allows RECONCILE_DRAFT_GATE — NOT for every ready PR where RUN_DRAFT_GATE is
+    // forbidden. Here the PR is ready and the post-draft external review cycle has
+    // not started (REQUEST_COPILOT_REVIEW), so the poster must refuse WITHOUT
+    // converting the PR to draft. Guards against wrongly drafting blocked /
+    // waiting-for-CI / unresolved-feedback / review-pending PRs. (#891, Copilot review)
+    const { env: logEnvRaw } = await writeGhStubHelper(tempDir, [
       ...buildGateCoordinationEntries({
         isDraft: false,
         statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
         issueComments: [],
       }),
-      // 2) convertPrToDraft: resolve PR node id, then convert mutation
-      {
-        assertArgs: ["api", "graphql", "-f", "-F"],
-        assertArgContains: ["number=17", "pullRequest(number: $number)"],
-        stdout: '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOScHU78000017","isDraft":false}}}}\n',
-      },
-      {
-        assertArgs: ["api", "graphql", "-f", "-F"],
-        assertArgContains: ["pullRequestId=PR_kwDOScHU78000017", "convertPullRequestToDraft"],
-        stdout: '{"data":{"convertPullRequestToDraft":{"pullRequest":{"id":"PR_kwDOScHU78000017","isDraft":true}}}}\n',
-      },
-      // 3) recursive upsert: second coordination pass, now a draft PR
-      ...buildGateCoordinationEntries({
-        isDraft: true,
-        statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
-        issueComments: [],
-      }),
-      // 4) post the draft_gate comment
-      {
-        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f"],
-        assertArgContains: ["body=### Gate review: `draft_gate`"],
-        stdout: '{"id":501,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-501"}\n',
-      },
-      // 5) restore ready state
-      {
-        assertArgs: ["pr", "ready", "17", "--repo", "owner/repo"],
-        stdout: "",
-      },
-    ], { matchMode: "claims" });
-    const env = { ...claimsEnvRaw, PI_SUBAGENT_RUN_ID: "" };
+    ], { repeatLastOnOverflow: true, logCalls: true });
+    const env = { ...logEnvRaw, PI_SUBAGENT_RUN_ID: "" };
 
-    const result = await upsertCheckpointVerdict({
-      repo: "owner/repo",
-      pr: 17,
-      gate: "draft_gate",
-      headSha: "abc1234",
-      verdict: "clean",
-      findingsSeverityCounts: { "must-fix": 0, "worth-fixing-now": 0, "defer": 0 },
-      findingsSummary: "no issues found",
-      nextAction: "mark ready for review",
-      executionMode: "fanout_fanin",
-    }, { env, repoRoot: tempDir });
+    await assert.rejects(
+      () => upsertCheckpointVerdict({
+        repo: "owner/repo",
+        pr: 17,
+        gate: "draft_gate",
+        headSha: "abc1234",
+        verdict: "clean",
+        findingsSeverityCounts: { "must-fix": 0, "worth-fixing-now": 0, "defer": 0 },
+        findingsSummary: "no issues found",
+        nextAction: "mark ready for review",
+        executionMode: "fanout_fanin",
+      }, { env, repoRoot: tempDir }),
+      /Cannot enter|post-draft external review|request Copilot review/i,
+    );
 
-    assert.equal(result.ok, true);
-    assert.equal(result.action, "created");
-    assert.equal(result.gate, "draft_gate");
-    assert.equal(result.draftTransition, true);
-    assert.equal(result.executionMode, "fanout_fanin");
-    assert.equal(result.commentId, 501);
+    // Critical: the PR must NOT have been converted to draft, and must NOT have been
+    // re-marked ready — no draft-state toggle may happen in a non-reconcile state.
+    const ghLog = await readFile(path.join(tempDir, "gh-log.jsonl"), "utf8");
+    assert.ok(!/convertPullRequestToDraft/.test(ghLog), "must not convert the PR to draft");
+    assert.ok(!/\["pr","ready"/.test(ghLog.replace(/\s/g, "")), "must not mark the PR ready");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -1973,6 +1973,221 @@ test("upsert-checkpoint-verdict does NOT convert a ready PR to draft when reconc
   }
 });
 
+test("upsert-checkpoint-verdict self-heals a ready PR via draft transition, preserving fanout_fanin (#891)", async () => {
+  // POSITIVE regression for the self-heal `postDraftGateViaDraftTransition` path: a
+  // converged READY (non-draft) PR with clean current-head pre_approval_gate evidence
+  // but NO clean draft_gate evidence yields coordination state RECONCILE_DRAFT_GATE.
+  // The poster must convert the PR back to draft, post the draft_gate verdict
+  // (preserving executionMode fanout_fanin, NOT collapsing to inline), then re-mark
+  // the PR ready, and report draftTransition: true. (#891)
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-self-heal-transition-"));
+
+  try {
+    const headSha = "abc1234";
+    // A clean pre_approval_gate comment on the current head — combined with a
+    // submitted Copilot review on the current head and zero unresolved threads,
+    // this drives interpretation to ready_to_rerequest_review +
+    // sameHeadCleanConverged, which evaluatePrGateCoordination resolves to
+    // RECONCILE_DRAFT_GATE because no clean draft_gate evidence exists.
+    const cleanPreApprovalComment = {
+      id: 501,
+      body: [
+        "### Gate review: `pre_approval_gate`",
+        "",
+        "**Reviewed head SHA:** `abc1234`",
+        "**Verdict:** clean",
+        "**Execution mode:** fanout_fanin",
+        "",
+        "**Findings summary:** no issues found",
+        "",
+        "**Next action:** await final human approval",
+      ].join("\n"),
+      html_url: "https://github.com/owner/repo/pull/17#issuecomment-501",
+      updated_at: "2026-05-30T17:00:00Z",
+    };
+    const copilotReviewOnHead = {
+      id: 1,
+      author: { login: "copilot-pull-request-reviewer" },
+      state: "COMMENTED",
+      submittedAt: "2026-05-30T16:00:00Z",
+      commit: { oid: headSha },
+    };
+    const prFacts = (isDraft) => JSON.stringify({
+      number: 17,
+      state: "OPEN",
+      isDraft,
+      headRefOid: headSha,
+      statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+      reviews: [copilotReviewOnHead],
+    }) + "\n";
+
+    // Claims-mode (order-independent) matching across the TWO coordination passes:
+    // pass 1 sees isDraft:false (yields reconcile); after convertPullRequestToDraft
+    // the recursive post re-enters and pass 2 sees isDraft:true (posts normally).
+    // Each entry has specific assertArgs so claims selection is unambiguous, and the
+    // duplicated coordination calls supply isDraft:false first, then isDraft:true.
+    const { env: logEnvRaw, ghLogPath } = await writeGhStubHelper(tempDir, [
+      // --- coordination pass 1 (isDraft: false → reconcile) ---
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"], stdout: prFacts(false) },
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[],"teams":[]}\n' },
+      { assertArgs: ["api", "graphql", "pr=17"], stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n' },
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"], stdout: '{"headRefOid":"abc1234"}\n' },
+      { assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/17/comments?per_page=100"], stdout: JSON.stringify([[cleanPreApprovalComment]]) + "\n" },
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files"], stdout: "src/index.ts\n" },
+      // --- resolve PR node id + convert to draft ---
+      { assertArgs: ["api", "graphql", "name=repo", "number=17"], stdout: '{"data":{"repository":{"pullRequest":{"id":"PR_node","isDraft":false}}}}\n' },
+      { assertArgs: ["api", "graphql", "pullRequestId=PR_node"], stdout: '{"data":{"convertPullRequestToDraft":{"pullRequest":{"id":"PR_node","isDraft":true}}}}\n' },
+      // --- coordination pass 2 (isDraft: true → posts normally) ---
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup"], stdout: prFacts(true) },
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[],"teams":[]}\n' },
+      { assertArgs: ["api", "graphql", "pr=17"], stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n' },
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"], stdout: '{"headRefOid":"abc1234"}\n' },
+      { assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/17/comments?per_page=100"], stdout: JSON.stringify([[cleanPreApprovalComment]]) + "\n" },
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files"], stdout: "src/index.ts\n" },
+      // --- post the draft_gate verdict + restore ready ---
+      { assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f"], stdout: '{"id":900,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-900"}\n' },
+      { assertArgs: ["pr", "ready", "17", "--repo", "owner/repo"], stdout: "{}\n" },
+    ], { matchMode: "claims", logCalls: true });
+    const env = { ...logEnvRaw, PI_SUBAGENT_RUN_ID: "" };
+
+    const result = await upsertCheckpointVerdict({
+      repo: "owner/repo",
+      pr: 17,
+      gate: "draft_gate",
+      headSha,
+      verdict: "clean",
+      findingsSeverityCounts: { "must-fix": 0, "worth-fixing-now": 0, "defer": 0 },
+      findingsSummary: "no issues found",
+      nextAction: "mark ready for review",
+      executionMode: "fanout_fanin",
+    }, { env, repoRoot: tempDir });
+
+    // The verdict was posted via the transition, with fanout_fanin preserved.
+    assert.equal(result.ok, true);
+    assert.equal(result.action, "created");
+    assert.equal(result.gate, "draft_gate");
+    assert.equal(result.executionMode, "fanout_fanin");
+    assert.equal(result.draftTransition, true);
+    assert.equal(result.commentId, 900);
+
+    const ghLog = await readFile(ghLogPath, "utf8");
+    // The PR was converted to draft, then re-marked ready (the full transition).
+    assert.ok(/convertPullRequestToDraft/.test(ghLog), "expected a convertPullRequestToDraft mutation");
+    assert.ok(/\["pr","ready","17"/.test(ghLog.replace(/\s/g, "")), "expected a `pr ready` call to restore the ready state");
+    // The posted draft_gate comment must carry the fanout_fanin execution mode,
+    // proving the caller's mode is preserved across the recursive re-entry.
+    assert.ok(/Gate review: `draft_gate`/.test(ghLog), "expected a draft_gate verdict to be posted");
+    assert.ok(/\*\*Execution mode:\*\* fanout_fanin/.test(ghLog), "expected fanout_fanin in the posted verdict body");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("upsert-checkpoint-verdict already-satisfied no-op sources executionMode from the gate marker (#891 review)", async () => {
+  // The already-satisfied no-op must source executionMode from the gate MARKER
+  // summary (which carries executionMode), not the strict COMMENT summary (which
+  // has none and would always collapse to inline_single_agent). Here the existing
+  // clean draft_gate evidence is on the current head and was recorded fanout_fanin,
+  // so the no-op must report fanout_fanin — not a misleading inline default.
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-satisfied-marker-execmode-"));
+
+  try {
+    const fanoutDraftGateComment = {
+      id: 101,
+      body: renderGateReviewCommentBody({
+        gate: "draft_gate",
+        headSha: "abc1234",
+        verdict: "clean",
+        findingsSummary: "no issues found",
+        nextAction: "mark ready for review",
+        executionMode: "fanout_fanin",
+      }),
+      html_url: "https://github.com/owner/repo/pull/17#issuecomment-101",
+      updated_at: "2026-05-30T17:00:00Z",
+    };
+
+    const env = await writeGhStub(tempDir, buildGateCoordinationEntries({
+      isDraft: false,
+      statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+      issueComments: [fanoutDraftGateComment],
+    }));
+
+    const result = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "17",
+      "--gate", "draft_gate",
+      "--head-sha", "abc1234",
+      "--verdict", "clean",
+      "--findings-summary", "no issues found",
+      "--next-action", "mark ready for review",
+      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
+      "--execution-mode", "fanout_fanin",
+    ], { env });
+
+    assert.equal(result.code, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.action, "noop");
+    assert.equal(payload.draftGateAlreadySatisfied, true);
+    // Marker-sourced: fanout_fanin preserved, NOT the misleading inline default.
+    assert.equal(payload.executionMode, "fanout_fanin");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("upsert-checkpoint-verdict already-satisfied no-op OMITS executionMode when no current-head marker exists (#891 review)", async () => {
+  // When the satisfied clean draft_gate evidence is on a STALE head (the draft gate
+  // is a one-time boundary accepted on any head), no current-head marker exists, so
+  // the marker summary carries no executionMode. Rather than report a misleading
+  // inline_single_agent default, the no-op must OMIT the executionMode field.
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-satisfied-no-marker-"));
+
+  try {
+    // Clean draft_gate evidence on a DIFFERENT (stale) head than the request's head.
+    const staleHeadDraftGateComment = {
+      id: 101,
+      body: renderGateReviewCommentBody({
+        gate: "draft_gate",
+        headSha: "0000aaa",
+        verdict: "clean",
+        findingsSummary: "no issues found",
+        nextAction: "mark ready for review",
+        executionMode: "fanout_fanin",
+      }),
+      html_url: "https://github.com/owner/repo/pull/17#issuecomment-101",
+      updated_at: "2026-05-30T17:00:00Z",
+    };
+
+    const env = await writeGhStub(tempDir, buildGateCoordinationEntries({
+      isDraft: false,
+      headSha: "abc1234",
+      statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+      issueComments: [staleHeadDraftGateComment],
+    }));
+
+    const result = await runNode([
+      "--repo", "owner/repo",
+      "--pr", "17",
+      "--gate", "draft_gate",
+      "--head-sha", "abc1234",
+      "--verdict", "clean",
+      "--findings-summary", "no issues found",
+      "--next-action", "mark ready for review",
+      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
+      "--execution-mode", "fanout_fanin",
+    ], { env });
+
+    assert.equal(result.code, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.action, "noop");
+    assert.equal(payload.draftGateAlreadySatisfied, true);
+    // No current-head marker → executionMode omitted (not a misleading default).
+    assert.equal("executionMode" in payload, false);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("upsert-checkpoint-verdict skips Copilot convergence requirement for internal-only PRs", async () => {
   // Root cause 2 fix: when all changed files are internal tooling (scripts/docs/tests/config),
   // the Copilot review cycle is suppressed and pre_approval_gate may be posted directly.


### PR DESCRIPTION
Closes #891.

## Problem
Posting a `draft_gate` verdict on a PR that is already ready-for-review (e.g. opened directly as ready, as release PRs were) dead-ends: `upsert-checkpoint-verdict` refuses (hard "already satisfied" throw, or `RUN_DRAFT_GATE` forbidden once ready), while `detect-checkpoint-evidence`'s pre-merge check fails closed on "missing visible clean draft_gate comment". Recovery required manually toggling the PR back to draft. Because this repo sets `requireFanoutEvidence: true` + `draft.required: true`, the existing `reconcile-draft-gate` (which posts an **inline** verdict) cannot produce mergeable draft evidence either.

## Root cause
Investigated against the pure `evaluatePrGateCoordination` + `buildPreMergeGateCheck` surfaces (state matrix). The draft gate is an intentional **one-time boundary** (enforced at the draft→ready transition; `PR_READY_NO_FEEDBACK` deliberately routes to Copilot review per existing tests). The defect is in the **poster**: its two failure modes on a ready PR (hard "already satisfied" throw; forbidden `RUN_DRAFT_GATE`) leave no path to produce/refresh draft evidence without a manual draft toggle.

## Fix (`upsert-checkpoint-verdict.mjs`, no state-machine change)
1. **Idempotent no-op** when the draft gate is already satisfied (clean evidence on any head; the pre-merge check accepts it) — instead of a hard error that dead-ends scripted callers. The no-op surfaces `executionMode` from the gate **marker** summary (which carries it) and omits the field when no current-head marker exists, rather than reporting a misleading `inline_single_agent` default.
2. **Automatic draft→post→ready transition** when a ready PR still needs clean draft-gate evidence, **preserving the caller's execution mode (`fanout_fanin`), findings, and ledger** — the fanout-aware analogue of `reconcile-draft-gate`. Triggers ONLY when coordination explicitly allows `RECONCILE_DRAFT_GATE` (not for every ready PR where `RUN_DRAFT_GATE` is forbidden). On mid-transition failure the PR is best-effort restored to ready.
3. `convertPrToDraft`/`markPrReady` exported from `reconcile-draft-gate.mjs` and reused via dynamic import (avoids a circular dependency).

## Tests
- Updated the two tests that asserted the old hard-reject behavior → now assert idempotent no-op (current-head and stale-head clean evidence).
- **Positive** transition regression (full pipeline): a converged ready PR with clean current-head `pre_approval_gate` and no clean draft_gate evidence yields `RECONCILE_DRAFT_GATE`; the poster converts to draft, posts `draft_gate` (preserving `fanout_fanin`), re-marks ready, and returns `draftTransition: true` (asserted via the gh call log: `convertPullRequestToDraft` mutation + `pr ready` + a `fanout_fanin` verdict body).
- **Negative** narrowing guard: a ready PR in a non-reconcile state (e.g. `REQUEST_COPILOT_REVIEW`) must NOT be converted to draft or re-marked ready.
- No-op `executionMode` coverage: sourced from the marker when present (fanout_fanin), omitted when no current-head marker exists.
- `npm run verify` green.

## Checklist
- [x] Root-caused against the pure coordination + pre-merge surfaces (state matrix)
- [x] Fix isolated to the poster; no change to the gate state machine (existing `PR_READY_NO_FEEDBACK`/one-time-boundary tests untouched and passing)
- [x] Regression tests for no-op (×2), the positive draft-transition path (`draftTransition: true`, `fanout_fanin` preserved), and the negative narrowing guard (no draft toggle in non-reconcile states)
- [x] `npm run verify` green
- [x] CHANGELOG `### Fixed` under `## 0.3.0`
- [x] No new cross-package relative imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)
