### PR TITLE
fix(queue): resolve board Next Up membership from a title-only config (#901)

### DIFF
--- a/packages/core/src/loop/queue-board-ordering.mjs
+++ b/packages/core/src/loop/queue-board-ordering.mjs
@@ -25,7 +25,11 @@ export async function resolveNextUpOrder(
   const listItems = dependencies.listQueueItems ?? listQueueItemsMain;
   try {
     const result = await listItems(
-      { repo, project: projectNumber, column: "Next Up" },
+      // list-queue-items validates `project` as a string ref (CLI contract);
+      // resolveProjectNumber yields a number, so stringify it. Passing the raw
+      // number trips parseProjectRef's `typeof raw !== "string"` guard, which
+      // surfaces as a misleading "--project is required" (#901).
+      { repo, project: String(projectNumber), column: "Next Up" },
       { env, runChild: dependencies.runChild },
     );
     const order = (result?.items ?? [])

--- a/packages/core/test/queue-board-ordering.test.mjs
+++ b/packages/core/test/queue-board-ordering.test.mjs
@@ -35,7 +35,9 @@ test("resolveNextUpOrder returns order from mocked list helper", async () => {
       { GH_TOKEN: "mock" },
       {
         listQueueItems: async (args) => {
-          assert.deepEqual(args, { repo: "owner/repo", project: 3, column: "Next Up" });
+          // list-queue-items' CLI contract requires `project` as a string ref;
+          // resolveNextUpOrder must stringify the resolved number (#901).
+          assert.deepEqual(args, { repo: "owner/repo", project: "3", column: "Next Up" });
           return {
             ok: true,
             items: [
@@ -49,6 +51,127 @@ test("resolveNextUpOrder returns order from mocked list helper", async () => {
     );
     assert.equal(result.ok, true);
     assert.deepEqual(result.order, [10, 20, 30]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ── Real integration: title-only config → real list-queue-items path ──────
+//
+// Regression guard for #901. The earlier tests stub `listQueueItems`, so the
+// real `resolveProjectNumber` (title→number) + `listQueueItemsMain` integration
+// was never exercised — which hid the number-vs-string `--project` mismatch.
+// This test stubs ONLY the `gh`/`runChild` layer with realistic Projects-v2
+// payloads, routing each GraphQL query by its shape.
+
+/**
+ * Build a runChild stub that answers the gh GraphQL queries issued by the real
+ * resolveProjectNumber → listQueueItemsMain path for a title-only board config.
+ */
+function makeGhStub({ projects, statusOptions, items }) {
+  return async (_cmd, args) => {
+    const queryIdx = args.indexOf("query=") === -1
+      ? args.findIndex((a) => typeof a === "string" && a.startsWith("query="))
+      : args.indexOf("query=");
+    const query = queryIdx >= 0 ? args[queryIdx].slice("query=".length) : "";
+
+    const respond = (data) => ({ code: 0, stdout: JSON.stringify({ data }), stderr: "" });
+
+    // Owner resolution: GET_USER_ID
+    if (query.includes("user(login:$login) { id }")) {
+      return respond({ user: { id: "U_owner" } });
+    }
+    // Project listing: LIST_USER_PROJECTS (title → number / id)
+    if (query.includes("projectsV2(first:50")) {
+      return respond({
+        user: {
+          projectsV2: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: projects,
+          },
+        },
+      });
+    }
+    // Fields: GET_PROJECT_FIELDS (Status single-select)
+    if (query.includes("fields(first:50")) {
+      return respond({
+        node: {
+          fields: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [{ id: "F_status", name: "Status", options: statusOptions }],
+          },
+        },
+      });
+    }
+    // Items: GET_PROJECT_ITEMS
+    if (query.includes("items(first:100")) {
+      return respond({
+        node: {
+          items: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: items,
+          },
+        },
+      });
+    }
+    throw new Error(`unexpected gh query: ${query.slice(0, 60)}`);
+  };
+}
+
+test("resolveNextUpOrder resolves Next Up from a title-only config (real list-queue-items path)", async () => {
+  const dir = await makeRepo('queue:\n  boardTitle: "dev-loops Queue"\n');
+  try {
+    const statusOptions = [
+      { id: "opt_next", name: "Next Up" },
+      { id: "opt_prog", name: "In Progress" },
+    ];
+    const mkItem = (id, number, status) => ({
+      id,
+      fieldValues: {
+        nodes: [{ field: { id: "F_status", name: "Status" }, name: status }],
+      },
+      content: { number, title: `Issue ${number}`, url: `https://x/${number}`, id: `I_${number}` },
+    });
+    const runChild = makeGhStub({
+      projects: [
+        { id: "PVT_other", number: 1, title: "Other board", url: "u1" },
+        { id: "PVT_queue", number: 3, title: "dev-loops Queue", url: "u3" },
+      ],
+      statusOptions,
+      items: [
+        mkItem("it1", 101, "Next Up"),
+        mkItem("it2", 102, "In Progress"),
+        mkItem("it3", 103, "Next Up"),
+      ],
+    });
+
+    const result = await resolveNextUpOrder("owner/repo", dir, { GH_TOKEN: "mock" }, { runChild });
+    assert.equal(result.ok, true);
+    assert.equal(result.reason, null);
+    // Only the Next Up items, in position order.
+    assert.deepEqual(result.order, [101, 103]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveNextUpOrder yields a clean reason (not '--project is required') when the board title is unresolvable", async () => {
+  // Distinct repo + title so the module-level resolveProjectNumber cache from
+  // the prior test does not satisfy this lookup.
+  const dir = await makeRepo('queue:\n  boardTitle: "Missing Board"\n');
+  try {
+    const runChild = makeGhStub({
+      // No project matching the configured title → resolveProjectNumber throws
+      // BOARD_NOT_FOUND, surfaced as a clear reason.
+      projects: [{ id: "PVT_other", number: 1, title: "Other board", url: "u1" }],
+      statusOptions: [],
+      items: [],
+    });
+    const result = await resolveNextUpOrder("owner/missingrepo", dir, { GH_TOKEN: "mock" }, { runChild });
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.order, []);
+    assert.notEqual(result.reason, "--project is required");
+    assert.match(result.reason, /not found under/);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/core/test/queue-board-ordering.test.mjs
+++ b/packages/core/test/queue-board-ordering.test.mjs
@@ -70,9 +70,7 @@ test("resolveNextUpOrder returns order from mocked list helper", async () => {
  */
 function makeGhStub({ projects, statusOptions, items }) {
   return async (_cmd, args) => {
-    const queryIdx = args.indexOf("query=") === -1
-      ? args.findIndex((a) => typeof a === "string" && a.startsWith("query="))
-      : args.indexOf("query=");
+    const queryIdx = args.findIndex((a) => typeof a === "string" && a.startsWith("query="));
     const query = queryIdx >= 0 ? args[queryIdx].slice("query=".length) : "";
 
     const respond = (data) => ({ code: 0, stdout: JSON.stringify({ data }), stderr: "" });


### PR DESCRIPTION
## Root cause (confirmed by repro)

`resolveNextUpOrder` (`packages/core/src/loop/queue-board-ordering.mjs`) passed the
resolved project number to `list-queue-items` as a **raw number**:

```js
const result = await listItems({ repo, project: projectNumber, column: "Next Up" }, ...);
```

`list-queue-items`' `parseProjectRef` rejects any non-string up front:

```js
if (!raw || typeof raw !== "string" || raw.trim().length === 0) {
  throw Object.assign(new Error("--project is required"), { code: "INVALID_PROJECT" });
}
```

So a perfectly valid project number (3) was rejected with the misleading
`--project is required`, which `resolveNextUpOrder` caught and surfaced as its
`reason`. The queue then reported *"Board configured but unavailable (--project
is required); nothing to run"* and never read `Next Up`.

The title→number resolution itself was fine — `resolveProjectNumber` correctly
returns `3` for `boardTitle: "dev-loops Queue"`. The defect was purely the
number-vs-string type mismatch at the `list-queue-items` boundary. `syncBoardStatus`
already does `String(projectNumber)`; `resolveNextUpOrder` did not.

Repro evidence (this repo's title-only `.devloops`):
- `parseProjectRef` with `project: 3` (number) → `--project is required` / `INVALID_PROJECT`.
- After fix, `resolveNextUpOrder("mfittko/dev-loops", cwd)` → `{"ok":true,"order":[],"reason":null}` (Next Up currently empty; clean, no error).
- Live `resolveProjectNumber` → `3`; real `list-queue-items` for `In Progress` → `[792, 901]`.

## Fix

Stringify the resolved project number before handing it to `list-queue-items`,
matching `syncBoardStatus`. A genuinely unresolvable title still fails cleanly
via the existing `BOARD_NOT_FOUND` path (`reason: ... not found under ...`),
and fail-open behavior for an unconfigured/unavailable board is preserved.

## Test (the gap that hid this)

Added a **real-integration** test in `packages/core/test/queue-board-ordering.test.mjs`
that exercises `resolveProjectNumber` (title→number) + the real `listQueueItemsMain`,
stubbing **only** the `gh`/`runChild` layer with realistic Projects-v2 payloads
(owner resolution → projects list with a matching title → Status field → items).
It asserts the ordered Next Up issue numbers are returned. A second test asserts an
unresolvable title yields a clean reason (not `--project is required`). The prior
stubbed test that asserted the number form of `project` (which hid the bug) was
corrected to assert the string form.

## Validation

- `npm run verify` → exit 0 (1657 + 1623 core tests pass; docs/dev-loop suites green).
- package-lock churn reverted.
- Live check against `mfittko/dev-loops`: queue no longer reports `--project is required`;
  the board (project 3) resolves from the title-only config and the real `list-queue-items`
  path returns items.

## Checklist

- [x] Title-only board config resolves `Next Up` (or fails cleanly when unresolvable)
- [x] Real `resolveNextUpOrder` → `list-queue-items` integration test (not a stubbed `listQueueItems`)
- [x] Existing #864 membership/state tests green
- [x] Fail-open behavior preserved
- [x] `npm run verify` exit 0; lockfile unchanged

Closes #901

🤖 Generated with [Claude Code](https://claude.com/claude-code)
