### PR TITLE
docs: align remaining identity references to dev-loops (#768)

### DIFF
--- a/.claude/skills/docs/tracker-first-loop-state.md
+++ b/.claude/skills/docs/tracker-first-loop-state.md
@@ -1,7 +1,7 @@
 # Tracker-First Story-to-PR Contract
 
 This document defines the adapter-agnostic MVP contract for the tracker-first
-story-to-PR workflow in `pi-dev-loops`.
+story-to-PR workflow in `dev-loops`.
 
 **MVP invariant: one tracker work item → one GitHub PR.**
 
@@ -43,9 +43,9 @@ are out of scope for this slice.
 | PR lifecycle facts | GitHub | Draft / ready-for-review, open / merged / closed, branch, head SHA |
 | PR review and CI facts | GitHub | Reviewer assignments, review states, check-run results, merge status |
 | Decision content | ADR / RFC artifacts (when linked) | Architecture decisions and RFCs referenced from PR body |
-| PR projection and reverse-sync logic | `pi-dev-loops` | Title/body/label generation rules, state mapping, sync triggers |
+| PR projection and reverse-sync logic | `dev-loops` | Title/body/label generation rules, state mapping, sync triggers |
 
-`pi-dev-loops` **does not** become the canonical owner of any business fields.
+`dev-loops` **does not** become the canonical owner of any business fields.
 It provides projection and sync logic only.
 
 ## 3. PR Projection Contract
@@ -234,9 +234,9 @@ This contract is intentionally narrower than the parent epics:
 
 ## 7. Related
 
-- Parent workflow-family epic: [mfittko/pi-dev-loops#17](https://github.com/mfittko/pi-dev-loops/issues/17)
-- Umbrella artifact model epic: [mfittko/pi-dev-loops#19](https://github.com/mfittko/pi-dev-loops/issues/19)
-- This contract (first implementable slice): [mfittko/pi-dev-loops#21](https://github.com/mfittko/pi-dev-loops/issues/21)
+- Parent workflow-family epic: [mfittko/dev-loops#17](https://github.com/mfittko/dev-loops/issues/17)
+- Umbrella artifact model epic: [mfittko/dev-loops#19](https://github.com/mfittko/dev-loops/issues/19)
+- This contract (first implementable slice): [mfittko/dev-loops#21](https://github.com/mfittko/dev-loops/issues/21)
 - Copilot loop state graph: [Copilot Loop State Graph](../../docs/copilot-loop-state-graph.md)
 - Reviewer loop state graph: [Reviewer Loop State Graph](../../docs/reviewer-loop-state-graph.md)
 

--- a/skills/docs/tracker-first-loop-state.md
+++ b/skills/docs/tracker-first-loop-state.md
@@ -1,7 +1,7 @@
 # Tracker-First Story-to-PR Contract
 
 This document defines the adapter-agnostic MVP contract for the tracker-first
-story-to-PR workflow in `pi-dev-loops`.
+story-to-PR workflow in `dev-loops`.
 
 **MVP invariant: one tracker work item → one GitHub PR.**
 
@@ -43,9 +43,9 @@ are out of scope for this slice.
 | PR lifecycle facts | GitHub | Draft / ready-for-review, open / merged / closed, branch, head SHA |
 | PR review and CI facts | GitHub | Reviewer assignments, review states, check-run results, merge status |
 | Decision content | ADR / RFC artifacts (when linked) | Architecture decisions and RFCs referenced from PR body |
-| PR projection and reverse-sync logic | `pi-dev-loops` | Title/body/label generation rules, state mapping, sync triggers |
+| PR projection and reverse-sync logic | `dev-loops` | Title/body/label generation rules, state mapping, sync triggers |
 
-`pi-dev-loops` **does not** become the canonical owner of any business fields.
+`dev-loops` **does not** become the canonical owner of any business fields.
 It provides projection and sync logic only.
 
 ## 3. PR Projection Contract
@@ -234,9 +234,9 @@ This contract is intentionally narrower than the parent epics:
 
 ## 7. Related
 
-- Parent workflow-family epic: [mfittko/pi-dev-loops#17](https://github.com/mfittko/pi-dev-loops/issues/17)
-- Umbrella artifact model epic: [mfittko/pi-dev-loops#19](https://github.com/mfittko/pi-dev-loops/issues/19)
-- This contract (first implementable slice): [mfittko/pi-dev-loops#21](https://github.com/mfittko/pi-dev-loops/issues/21)
+- Parent workflow-family epic: [mfittko/dev-loops#17](https://github.com/mfittko/dev-loops/issues/17)
+- Umbrella artifact model epic: [mfittko/dev-loops#19](https://github.com/mfittko/dev-loops/issues/19)
+- This contract (first implementable slice): [mfittko/dev-loops#21](https://github.com/mfittko/dev-loops/issues/21)
 - Copilot loop state graph: [Copilot Loop State Graph](../../docs/copilot-loop-state-graph.md)
 - Reviewer loop state graph: [Reviewer Loop State Graph](../../docs/reviewer-loop-state-graph.md)
 

--- a/test/contracts/docs-identity-contract.test.mjs
+++ b/test/contracts/docs-identity-contract.test.mjs
@@ -24,16 +24,18 @@ const HISTORICAL_ARTIFACT_ALLOWLIST = new Set([
   "docs/phase-a-repo-slug-survey.md",
 ]);
 
-// Recursively collect files under `dir` whose extension is in `extensions`. Missing directories
-// are skipped gracefully (the readdir error is swallowed and an empty list returned).
+// Recursively collect files under `dir` whose extension is in `extensions`. A MISSING directory
+// is skipped gracefully (ENOENT → empty list); any other readdir error (permissions, I/O) is
+// rethrown so the guard fails loudly rather than silently under-scanning the identity surface.
 async function collectFiles(dir, extensions) {
   const abs = path.join(repoRoot, dir);
   const out = [];
   let entries;
   try {
     entries = await fsReaddir(abs, { withFileTypes: true });
-  } catch {
-    return out;
+  } catch (err) {
+    if (err && err.code === "ENOENT") return out;
+    throw err;
   }
   for (const entry of entries) {
     const rel = path.posix.join(dir, entry.name);

--- a/test/contracts/docs-identity-contract.test.mjs
+++ b/test/contracts/docs-identity-contract.test.mjs
@@ -48,6 +48,18 @@ async function collectFiles(dir, extensions) {
   return out;
 }
 
+// Existence check that fails loudly: true if the path exists, false ONLY on ENOENT,
+// rethrow any other stat error (permissions/I/O) so the guard never silently skips.
+async function pathExists(rel) {
+  try {
+    await stat(path.join(repoRoot, rel));
+    return true;
+  } catch (err) {
+    if (err && err.code === "ENOENT") return false;
+    throw err;
+  }
+}
+
 test("user-facing identity surface carries no stale pi-dev-loops identity reference", async () => {
   // Each surface declares the extensions it owns: docs dirs scan Markdown, `.github/` also scans
   // workflow/config YAML. `collectFiles` already skips missing directories, so no pre-filtering is
@@ -63,7 +75,7 @@ test("user-facing identity surface carries no stale pi-dev-loops identity refere
   ).flat();
   const rootDocs = ["README.md", "AGENTS.md", "extension/README.md"];
   for (const rel of rootDocs) {
-    if (await stat(path.join(repoRoot, rel)).then(() => true).catch(() => false)) {
+    if (await pathExists(rel)) {
       docFiles.push(rel);
     }
   }
@@ -87,7 +99,7 @@ test("user-facing identity surface carries no stale pi-dev-loops identity refere
   // Guard the guard: the allow-listed historical artifact must still exist, so the exclusion
   // stays meaningful and does not silently mask a moved/renamed doc.
   for (const rel of HISTORICAL_ARTIFACT_ALLOWLIST) {
-    const exists = await stat(path.join(repoRoot, rel)).then(() => true).catch(() => false);
+    const exists = await pathExists(rel);
     assert.ok(exists, `historical-artifact allowlist entry should exist: ${rel}`);
   }
 });

--- a/test/contracts/docs-identity-contract.test.mjs
+++ b/test/contracts/docs-identity-contract.test.mjs
@@ -1,0 +1,113 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { readdir as fsReaddir, readFile, stat } from "node:fs/promises";
+
+import { assert, fromRepoRoot, readRepo, test } from "../imported-assets-helpers.mjs";
+
+// #768: docs-identity guard. v0.3.0 shipped `dev-loops` / `@dev-loops/core` to npm, so the
+// user-facing identity surface must consistently say `dev-loops` and must not carry stale
+// `pi-dev-loops` / `@pi-dev-loops` install/identity references. Historical rename-survey
+// artifacts (which intentionally record the old slug) are explicitly allow-listed.
+
+const repoRoot = path.resolve(fileURLToPath(new URL("../../", import.meta.url)));
+const STALE_IDENTITY_RE = /(?:@)?pi-dev-loops/;
+
+// Historical rename artifacts intentionally record the old slug. They must NOT be rewritten
+// and must NOT trip the guard. Any genuine rename-history doc belongs here.
+const HISTORICAL_ARTIFACT_ALLOWLIST = new Set([
+  "docs/phase-a-repo-slug-survey.md",
+]);
+
+async function collectMarkdownFiles(dir) {
+  const abs = path.join(repoRoot, dir);
+  const out = [];
+  let entries;
+  try {
+    entries = await fsReaddir(abs, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const rel = path.posix.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...(await collectMarkdownFiles(rel)));
+    } else if (entry.name.endsWith(".md")) {
+      out.push(rel);
+    }
+  }
+  return out;
+}
+
+async function existingDir(dir) {
+  return stat(path.join(repoRoot, dir)).then((s) => s.isDirectory()).catch(() => false);
+}
+
+test("user-facing identity surface carries no stale pi-dev-loops identity reference", async () => {
+  const docDirs = ["skills", ".github", "docs"];
+  const docFiles = (await Promise.all(docDirs.filter(existingDir).map(collectMarkdownFiles))).flat();
+  const rootDocs = ["README.md", "AGENTS.md", "extension/README.md"];
+  for (const rel of rootDocs) {
+    if (await stat(path.join(repoRoot, rel)).then(() => true).catch(() => false)) {
+      docFiles.push(rel);
+    }
+  }
+
+  const surface = [...new Set(docFiles)]
+    .filter((rel) => !HISTORICAL_ARTIFACT_ALLOWLIST.has(rel))
+    .sort();
+  assert.ok(surface.length > 0, "expected to scan the user-facing doc surface");
+
+  const offenders = [];
+  for (const rel of surface) {
+    const content = await readFile(path.join(repoRoot, rel), "utf8");
+    if (STALE_IDENTITY_RE.test(content)) offenders.push(rel);
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    `stale pi-dev-loops identity references must be migrated to dev-loops: ${offenders.join(", ")}`,
+  );
+
+  // Guard the guard: the allow-listed historical artifact must still exist, so the exclusion
+  // stays meaningful and does not silently mask a moved/renamed doc.
+  for (const rel of HISTORICAL_ARTIFACT_ALLOWLIST) {
+    const exists = await stat(path.join(repoRoot, rel)).then(() => true).catch(() => false);
+    assert.ok(exists, `historical-artifact allowlist entry should exist: ${rel}`);
+  }
+});
+
+test("CLI --help text carries no stale pi-dev-loops identity reference", () => {
+  const res = spawnSync("node", [path.join(repoRoot, "cli", "index.mjs"), "--help"], {
+    encoding: "utf8",
+    cwd: repoRoot,
+  });
+  assert.equal(res.status, 0, res.stderr);
+  assert.doesNotMatch(res.stdout, STALE_IDENTITY_RE, "CLI --help must reference dev-loops, not pi-dev-loops");
+});
+
+test("README references installing dev-loops from npm and stays consistent with the published major", async () => {
+  const readme = await readRepo("README.md");
+
+  // Accept both the global and non-global install form.
+  assert.match(readme, /npm install (-g )?dev-loops/, "README should reference `npm install dev-loops`");
+  assert.match(readme, /npx dev-loops/, "README should reference `npx dev-loops`");
+
+  // Derive the published identity/major from package.json so the guard does not rot on the
+  // next bump (do NOT hard-code a major here).
+  const pkg = JSON.parse(await readFile(fromRepoRoot("package.json"), "utf8"));
+  assert.equal(pkg.name, "dev-loops", "package should be published as dev-loops");
+  const major = pkg.version.split(".")[0];
+
+  // If the README pins any concrete dev-loops major (e.g. `dev-loops@0`), it must agree with
+  // the currently published major. Placeholder forms (`dev-loops@<version>`) are allowed and
+  // do not pin a major.
+  const pinnedMajors = [...readme.matchAll(/dev-loops@(\d+)/g)].map((m) => m[1]);
+  for (const pinned of pinnedMajors) {
+    assert.equal(
+      pinned,
+      major,
+      `README pins dev-loops@${pinned} but the published major is ${major}`,
+    );
+  }
+});

--- a/test/contracts/docs-identity-contract.test.mjs
+++ b/test/contracts/docs-identity-contract.test.mjs
@@ -3,6 +3,11 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { readdir as fsReaddir, readFile, stat } from "node:fs/promises";
 
+const MARKDOWN_EXTENSIONS = new Set([".md"]);
+// `.github/` carries identity-bearing config (workflow YAML), not just docs. Scan it for the
+// same stale-slug references so the guard's "covers `.github/**`" claim is actually true.
+const GITHUB_EXTENSIONS = new Set([".md", ".yml", ".yaml"]);
+
 import { assert, fromRepoRoot, readRepo, test } from "../imported-assets-helpers.mjs";
 
 // #768: docs-identity guard. v0.3.0 shipped `dev-loops` / `@dev-loops/core` to npm, so the
@@ -19,7 +24,9 @@ const HISTORICAL_ARTIFACT_ALLOWLIST = new Set([
   "docs/phase-a-repo-slug-survey.md",
 ]);
 
-async function collectMarkdownFiles(dir) {
+// Recursively collect files under `dir` whose extension is in `extensions`. Missing directories
+// are skipped gracefully (the readdir error is swallowed and an empty list returned).
+async function collectFiles(dir, extensions) {
   const abs = path.join(repoRoot, dir);
   const out = [];
   let entries;
@@ -31,21 +38,27 @@ async function collectMarkdownFiles(dir) {
   for (const entry of entries) {
     const rel = path.posix.join(dir, entry.name);
     if (entry.isDirectory()) {
-      out.push(...(await collectMarkdownFiles(rel)));
-    } else if (entry.name.endsWith(".md")) {
+      out.push(...(await collectFiles(rel, extensions)));
+    } else if (extensions.has(path.extname(entry.name))) {
       out.push(rel);
     }
   }
   return out;
 }
 
-async function existingDir(dir) {
-  return stat(path.join(repoRoot, dir)).then((s) => s.isDirectory()).catch(() => false);
-}
-
 test("user-facing identity surface carries no stale pi-dev-loops identity reference", async () => {
-  const docDirs = ["skills", ".github", "docs"];
-  const docFiles = (await Promise.all(docDirs.filter(existingDir).map(collectMarkdownFiles))).flat();
+  // Each surface declares the extensions it owns: docs dirs scan Markdown, `.github/` also scans
+  // workflow/config YAML. `collectFiles` already skips missing directories, so no pre-filtering is
+  // needed (the previous `docDirs.filter(existingDir)` was a dead async predicate that filtered
+  // nothing because it returned a Promise).
+  const docDirs = [
+    { dir: "skills", extensions: MARKDOWN_EXTENSIONS },
+    { dir: ".github", extensions: GITHUB_EXTENSIONS },
+    { dir: "docs", extensions: MARKDOWN_EXTENSIONS },
+  ];
+  const docFiles = (
+    await Promise.all(docDirs.map(({ dir, extensions }) => collectFiles(dir, extensions)))
+  ).flat();
   const rootDocs = ["README.md", "AGENTS.md", "extension/README.md"];
   for (const rel of rootDocs) {
     if (await stat(path.join(repoRoot, rel)).then(() => true).catch(() => false)) {


### PR DESCRIPTION
## What

The repo was already ~95% rebranded to `dev-loops` / `@dev-loops/core` (README install, CLI `--help`, plugin/marketplace docs, `.github/`, `docs/` nav all truthful post-`0.3.0`). This closes the residual identity gap.

### Stale references fixed
All 6 live `pi-dev-loops` identity references lived in one contract doc, `skills/docs/tracker-first-loop-state.md`:
- project name `pi-dev-loops` -> `dev-loops` (intro line, capability-ownership table row, ownership disclaimer)
- related-epic links `mfittko/pi-dev-loops#17/#19/#21` -> `mfittko/dev-loops#17/#19/#21`

Its generated mirror `.claude/skills/docs/tracker-first-loop-state.md` was regenerated via `node scripts/claude/generate-claude-assets.mjs` (enforced by `claude-assets-reproducible.test.mjs --check`), not hand-edited.

`docs/phase-a-repo-slug-survey.md` (historical rename-survey artifact) intentionally records the old slug and was deliberately left untouched.

### Guard added
New `test/contracts/docs-identity-contract.test.mjs`:
- asserts the user-facing doc surface (`README.md`, `AGENTS.md`, `extension/README.md`, `skills/**`, `.github/**`, `docs/**`) carries no stale `pi-dev-loops`/`@pi-dev-loops` identity reference, with an explicit ALLOWLIST for the historical rename artifact (`docs/phase-a-repo-slug-survey.md`) -- plus a guard-the-guard check that the allow-listed file still exists;
- asserts CLI `--help` text carries no stale reference;
- asserts the README references installing `dev-loops` from npm, accepting both `npm install dev-loops` and `npm install -g dev-loops` (regex `/npm install (-g )?dev-loops/`) plus `npx dev-loops`;
- DERIVES the published major from `package.json` (no hard-coded `0.3`) and verifies any concrete `dev-loops@<major>` pin in the README agrees with it -- placeholder forms (`dev-loops@<version>`) are allowed.

## Verification
`npm run verify` -> exit 0 (full suite green; no package-lock churn).

Closes #768

### Checklist
- [x] Source doc + regenerated `.claude/` mirror updated in the same commit; `generate-claude-assets.mjs --check` clean
- [x] Docs-identity guard added and passing
- [x] `npm run verify` green
- [x] No version/CHANGELOG bump (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
