### PR TITLE
feat(env)!: raise Node floor >=20 → >=24 (#911)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- **BREAKING: Node floor raised `>=20` → `>=24`** (#911). `engines.node` is now `>=24` in both `dev-loops` and `@dev-loops/core` (the latter previously declared no floor). CI already runs Node 24; this makes the supported floor explicit and unlocks Node 24 stdlib (e.g. native `fsp.glob`/`path.matchesGlob`). Consumers on Node < 24 must upgrade.
+
 ### Added
 
 - **Consumer migration guide** (#769): [`docs/migrating-to-dev-loops.md`](docs/migrating-to-dev-loops.md) walks existing `pi-dev-loops` consumers through every breaking change — package name (`pi-dev-loops`→`dev-loops`, `@pi-dev-loops/core`→`@dev-loops/core`), repo slug, the full `PI_*`→`DEVLOOPS_*` env-var mapping (a deliberate clean break with no aliases), and the `.devloops` config location. Linked from the README. The env vars are not shimmed by design (`0.x`, YAGNI); the legacy `.pi/dev-loop/settings.yaml` config path still loads with a deprecation warning.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ pi install git:github.com/mfittko/dev-loops    # global
 pi install -l git:github.com/mfittko/dev-loops # project-local
 ```
 
-The CLI requires Node `>=20` and a GitHub-authenticated `gh` CLI for repository workflows. See [Requirements](#requirements).
+The CLI requires Node `>=24` and a GitHub-authenticated `gh` CLI for repository workflows. See [Requirements](#requirements).
 
 ## Docker
 
@@ -253,7 +253,7 @@ See [Extension Documentation](./extension/README.md) for the full command and pa
 
 ## Requirements
 
-- Node `>=20`
+- Node `>=24`
 - `gh` installed and authenticated for GitHub/Copilot workflows
 - `pi-subagents` for async workflow assumptions
 - A Pi host that satisfies peer dependencies on `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui`

--- a/docs/migrating-to-dev-loops.md
+++ b/docs/migrating-to-dev-loops.md
@@ -81,6 +81,12 @@ overrides to `.devloops` (`.yml`/`.json` extensions are also accepted). Packaged
 ship with the extension (`.pi/dev-loop/defaults.yaml`); you only need to override the keys
 you want to change.
 
+## 5. Node version floor
+
+The minimum supported Node version was raised **`>=20` → `>=24`** (both `dev-loops` and
+`@dev-loops/core`). Consumers running Node < 24 must upgrade — `npm install` will warn (or
+fail under `engine-strict`) otherwise.
+
 ## See also
 
 - [`CHANGELOG.md`](../CHANGELOG.md) — the `PI_*`→`DEVLOOPS_*` env-var rename entry records the full mapping.

--- a/docs/repo-wiki-manual-first.md
+++ b/docs/repo-wiki-manual-first.md
@@ -47,7 +47,7 @@ Helper entrypoint:
 
 For both paths:
 
-- Node.js 20+ for the npm wrapper (matches the repository engine requirement)
+- Node.js 24+ for the npm wrapper (matches the repository engine requirement)
 - Node.js 24+ if you use the local-helper fallback (the pinned commit requires it)
 - git and npm available locally
 - network access to `https://github.com/mfittko/repo-wiki.git` (fallback path) and the public npm registry (primary path)

--- a/extension/README.md
+++ b/extension/README.md
@@ -210,7 +210,7 @@ Config is validated at runtime by Zod schemas (`packages/core/src/config/config.
 ## Runtime / build / test contract
 
 Current Phase 3+ contract:
-- Node runtime floor: `>=20` (from `package.json`)
+- Node runtime floor: `>=24` (from `package.json`)
 - Pi host expectations are documented from current peer dependencies rather than a tested pinned Pi version range
 - the extension is source-loaded from `./extension/index.ts` through `package.json` `pi.extensions`
 - the package exposes `skills` through `package.json` `pi.skills` for install-based global skill loading

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "tsx": "^4.22.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=24"
       },
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": "*",
@@ -591,7 +591,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -3736,6 +3736,9 @@
         "dev-loops-ensure-phase-files": "bin/ensure-phase-files.mjs",
         "dev-loops-log-bash-exit-1": "bin/log-bash-exit-1.mjs",
         "dev-loops-parse-review-threads": "bin/parse-review-threads.mjs"
+      },
+      "engines": {
+        "node": ">=24"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pi-package"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "workspaces": [
     "packages/*"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,9 @@
   "name": "@dev-loops/core",
   "version": "0.3.0",
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "description": "Shared deterministic support package for dev-loop skills, repo-local scripts, and GitHub automation.",
   "exports": {
     "./bash-exit-one": "./src/bash-exit-one.mjs",

--- a/test/extension-package-contract.test.mjs
+++ b/test/extension-package-contract.test.mjs
@@ -10,7 +10,7 @@ test("package metadata exposes the extension entrypoint and root extension test 
 
   assert.deepEqual(packageJson.pi.extensions, ["./extension/index.ts"]);
   assert.equal(packageJson.bin["dev-loops"], "./cli/index.mjs");
-  assert.match(packageJson.engines.node, />=20/);
+  assert.match(packageJson.engines.node, />=24/);
   assert.equal(typeof packageJson.peerDependencies["@earendil-works/pi-coding-agent"], "string");
   assert.equal(typeof packageJson.peerDependencies["@earendil-works/pi-tui"], "string");
   assert.equal(typeof packageJson.scripts["test:extension"], "string");
@@ -44,7 +44,7 @@ test("extension README documents the supported command, install, and verificatio
   }
 
   for (const runtimePattern of [
-    /Node[^\n]*>=20/i,
+    /Node[^\n]*>=24/i,
     /source-loaded/i,
     /package\.json` `pi\.skills`/i,
     /agents\/\*\.agent\.md/i,


### PR DESCRIPTION
Raises the Node engine floor `>=20` → `>=24` (closes #911). `feat(env)!` breaking.

- `engines.node` → `>=24` in **`package.json`** and **`packages/core/package.json`** (core previously declared no `engines` at all — now explicit for the published `@dev-loops/core`).
- Updated the user-facing Node-version statements: `README.md` (2 spots) and `extension/README.md`, plus the `extension-package-contract` test assertions (`>=20` → `>=24`).
- Lockfile regenerated.

## Why
CI already runs Node 24; the declared `>=20` floor was stale. Making it explicit unlocks Node 24 stdlib (native `fsp.glob`/`path.matchesGlob`) needed by #909's glob-pattern worktree provisioning, which lists this bump as a prerequisite.

## Checklist
- [x] `engines.node` is `>=24` in root + `packages/core`
- [x] All user-facing Node-floor references updated (README, extension README, contract test)
- [x] `npm run verify` green
- [x] CHANGELOG notes the breaking floor bump
- [x] `Closes #911`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
