### PR TITLE
fix(queue): adapter must not fabricate 'done' without a terminal signal (#913)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- **`queue run` no longer fabricates `done` for undispatched items** (#913, data-integrity). The queue driver is a deterministic adapter over the board, not the orchestration harness — but its missing-orchestrator path fell back to a per-entry `{ ok: true, pr: null }`, which silently marked every `Next Up` item `done` and moved it to **Done** with `pr: null`/`runId: null` in ~1s without any work happening (a single resolve pass would "complete" an entire backlog untouched). The driver now requires a verifiable terminal signal (an orchestrator-supplied result, e.g. a merged PR) before reflecting an item to Done; with no orchestrator wired (`runEntry`) in the current harness, `dev-loops queue run` is a no-op that leaves every board column unchanged and reports `reason: "no-orchestrator"`. The legit reflect path (real merged PR → Done) is preserved.
+
 ### Changed
 
 - **Queue management surfaced under `dev-loops queue`** (#912). The queue board management commands (`add`, `list`, `reorder`, `move`, `sync-status`, `archive-done`, `ensure`) are now discoverable and runnable under `dev-loops queue <sub>` alongside the existing `queue run` — `dev-loops queue --help` lists them all with one-line descriptions. They delegate to the same `scripts/projects/*.mjs` implementations; `dev-loops project <sub>` is retained as a back-compat alias group (lowest-churn: the routing table is data-driven, so `queue` reuses the existing script mappings). Flag consistency: `queue add` now accepts `--column <name>` for the Status column (matching `queue list`), with `--status <name>` kept as a back-compat alias. `move`/`sync-status` keep their distinct `--to-column`. Removes the only reason to hand-write `gh api graphql` for queue work.

--- a/docs/projects-queue-usage.md
+++ b/docs/projects-queue-usage.md
@@ -151,6 +151,15 @@ This posture keeps the queue resilient: a transient GitHub API outage or misconf
 does not block the run. Board state is read at dispatch time; the queue does not continuously
 sync local state to board state.
 
+### Completion is reflected, never fabricated
+
+The queue runner is a **deterministic adapter** over the board — it is **not** the orchestration
+harness. It moves an item to **Done** (and marks the entry `done`) only as a reflection of a
+**real terminal signal** supplied by an orchestrator (e.g. the item's linked PR merged), never as
+a side effect of a resolve/run pass. When no orchestrator is wired into the current harness,
+`dev-loops queue run` is a **no-op**: it leaves every board column unchanged and reports
+`reason: "no-orchestrator"` rather than fabricating completion for unperformed work (#913).
+
 ## See also
 
 - [Projects Queue Contract](./projects-queue-contract.md) — formal board contract

--- a/packages/core/src/loop/queue-driver.mjs
+++ b/packages/core/src/loop/queue-driver.mjs
@@ -57,6 +57,28 @@ export async function runQueue(repoRoot, repo, options = {}) {
   const opts = { ...DEFAULT_QUEUE_DRIVER_OPTIONS, ...options };
   const queue = await readQueue(repoRoot);
 
+  // Data-integrity guard (#913): this driver is a deterministic ADAPTER over the
+  // board, not the orchestration harness. Completion (`done` / move to Done) may
+  // only ever REFLECT a real terminal signal supplied by an orchestrator via
+  // `runEntry` (e.g. a merged PR). With no `runEntry` wired in the current
+  // harness there is nothing that can produce a verifiable terminal state, so
+  // the run MUST be a no-op: leave every entry and board column untouched and
+  // report the reason. Previously the missing-orchestrator path fell back to a
+  // fabricated `{ ok: true, pr: null }` per entry, which silently marked an
+  // entire Next Up `done` and moved it to Done without any work happening.
+  if (typeof opts.runEntry !== "function") {
+    return {
+      ok: true,
+      noop: true,
+      reason: "no-orchestrator",
+      message:
+        "queue run is a deterministic adapter with no orchestrator wired (no runEntry); " +
+        "leaving board columns unchanged. Items move to Done only on a real terminal signal.",
+      results: [],
+      queue,
+    };
+  }
+
   // Config-driven loop-state → board-column mapping (#793, AC1/AC3). Loaded
   // once per run; resolves logical columns to configured display names, with
   // the AC1 defaults when no `queue.statusColumns`/`queue.stateColumnMap` is set.
@@ -135,9 +157,9 @@ export async function runQueue(repoRoot, repo, options = {}) {
     await syncColumn(entry.target, columnFor("implementation"));
 
     try {
-      const entryResult = opts.runEntry
-        ? await opts.runEntry(entry, repo, opts)
-        : { ok: true, pr: null };
+      // runEntry is guaranteed a function here (guarded at function entry):
+      // the adapter never fabricates a terminal result for an undispatched item.
+      const entryResult = await opts.runEntry(entry, repo, opts);
 
       if (entryResult.ok) {
         if (entryResult.pr) {

--- a/packages/core/test/queue-driver.test.mjs
+++ b/packages/core/test/queue-driver.test.mjs
@@ -458,6 +458,75 @@ test("runQueue records fallback board transition on failure", async () => {
   }
 });
 
+// ── #913: adapter must not fabricate `done` without an orchestrator ──
+
+test("runQueue with no orchestrator is a no-op: no entry marked done, board unchanged (#913)", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "queue-driver-noorch-"));
+  try {
+    await writeFile(path.join(dir, ".devloops"), "queue:\n  projectNumber: 7\n");
+    const queue = {
+      version: 1,
+      entries: [createEntry(911, "issue"), createEntry(909, "issue"), createEntry(912, "issue")],
+    };
+    await writeQueue(dir, queue);
+
+    const moves = [];
+    // No `runEntry` supplied — exactly the CLI default path that fabricated done.
+    const result = await runQueue(dir, "test/repo", {
+      mergeAuthorized: false,
+      queueBoardSyncDependencies: {
+        moveQueueItem: async (args) => {
+          moves.push({ ...args });
+          return { ok: true, item: { newColumn: args.toColumn } };
+        },
+      },
+    });
+
+    assert.equal(result.noop, true);
+    assert.equal(result.reason, "no-orchestrator");
+    assert.deepEqual(result.results, []);
+    // Board columns untouched — not a single move was issued.
+    assert.equal(moves.length, 0);
+    // Every entry left exactly where it was; none fabricated to done.
+    for (const e of result.queue.entries) {
+      assert.equal(e.status, "queued");
+      assert.equal(e.pr, null);
+      assert.equal(e.runId, null);
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("runQueue reflects a real merged-PR terminal signal to Done (#913 legit path)", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "queue-driver-merged-"));
+  try {
+    await writeFile(path.join(dir, ".devloops"), "queue:\n  projectNumber: 7\n");
+    const queue = { version: 1, entries: [createEntry(101, "issue")] };
+    await writeQueue(dir, queue);
+
+    const moves = [];
+    // An orchestrator supplies a verifiable terminal signal (PR) and merge is
+    // authorized — the adapter correctly reflects that to Done.
+    const result = await runQueue(dir, "test/repo", {
+      mergeAuthorized: true,
+      runEntry: async () => ({ ok: true, pr: 555 }),
+      queueBoardSyncDependencies: {
+        moveQueueItem: async (args) => {
+          moves.push({ ...args });
+          return { ok: true, item: { newColumn: args.toColumn } };
+        },
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.queue.entries[0].status, "done");
+    assert.equal(moves[moves.length - 1].toColumn, "Done");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("runQueue reorders ready entries by board Next Up order", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "queue-driver-order-"));
   try {


### PR DESCRIPTION
Fixes the queue-run false-completion data-integrity bug (closes #913): the queue adapter no longer fabricates a terminal `done` state.

## Root cause
`packages/core/src/loop/queue-driver.mjs` `runQueue` per-entry loop fell back to `{ ok: true, pr: null }` when no `runEntry` orchestrator was supplied. The only production caller (`scripts/loop/run-queue.mjs`) wires **no** `runEntry`, so every Next Up item hit `ok && !pr` → marked `done` + moved to the Done column in ~1s with no PR/run/orchestration. A whole Next Up backlog got "completed" untouched.

## Fix (adapter reflects, never fabricates)
Per the architecture: the queue tooling is a deterministic gh-Projects **adapter**, not the orchestration harness. So:
- `runQueue` now guards at entry: if no `runEntry` function is supplied, it returns a **no-op** (`reason: "no-orchestrator"`) leaving every entry and board column **unchanged** — it never marks `done`.
- Removed the `{ ok: true, pr: null }` fabrication fallback; completion is only ever **reflected** from an orchestrator-supplied terminal result (a real merged PR via `{ ok: true, pr: N }` + `mergeAuthorized`). That legit reflect path is unchanged.
- No new PR-polling (YAGNI — the terminal signal arrives through `runEntry`).

## Tests
- Regression (the exact live repro): 3 Next Up items, no orchestrator → no-op, zero board moves, all entries stay `queued` (pr/runId null).
- Legit path: an orchestrator-supplied merged-PR result still reflects to Done.
- 22 pre-existing queue-driver tests still pass.

## Checklist
- [x] Item marked `done`/moved to Done ONLY on a verifiable terminal signal
- [x] No-orchestrator case leaves board unchanged + reports the reason
- [x] No change to queue ordering / board schema
- [x] Regression test for the reproduction; legit reflect path test
- [x] `npm run verify` green; docs/CHANGELOG updated; `generate-claude --check` clean
- [x] `Closes #913`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
