### PR TITLE
ci(pages): auto-deploy decks on push to main (closes #940)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,11 +1,10 @@
 name: Deploy presentation decks to GitHub Pages
 
-# build (assemble site/ + upload artifact) runs on push to main and validates
-# the assembly. It makes no Pages API call, so a push never turns red while
-# Pages is disabled. configure-pages + deploy live in the deploy job, which is
-# workflow_dispatch-only (private-repo plan caveat — see
-# docs/presentations/README.md). After enabling Pages (Settings -> Pages ->
-# Source: GitHub Actions), an operator runs this workflow via "Run workflow".
+# Pages is enabled (Settings -> Pages -> Source: GitHub Actions). build
+# (assemble site/ + upload artifact) and deploy (configure-pages + deploy-pages)
+# both run on every push to main, so a merge auto-publishes. workflow_dispatch
+# also triggers a manual deploy. The deploy job is scoped to the main ref. See
+# docs/presentations/README.md.
 
 on:
   push:
@@ -43,10 +42,10 @@ jobs:
           path: site
 
   deploy:
-    # Gated to workflow_dispatch: deploying before Pages is enabled fails, so
-    # only an operator triggers it (after enabling Pages). Pushes to main stop
-    # at build, which still validates the assembly.
-    if: github.event_name == 'workflow_dispatch'
+    # Pages is enabled (Source: GitHub Actions), so deploy runs on every push to
+    # main (auto-publish) and on manual workflow_dispatch. The job is scoped to
+    # main so a deploy never fires from another ref.
+    if: github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,9 +2,10 @@ name: Deploy presentation decks to GitHub Pages
 
 # Pages is enabled (Settings -> Pages -> Source: GitHub Actions). build
 # (assemble site/ + upload artifact) and deploy (configure-pages + deploy-pages)
-# both run on every push to main, so a merge auto-publishes. workflow_dispatch
-# also triggers a manual deploy. The deploy job is scoped to the main ref. See
-# docs/presentations/README.md.
+# both run on every push to main, so a merge auto-publishes. The deploy job is
+# scoped to the main ref (if: github.ref == 'refs/heads/main'), so a manual
+# workflow_dispatch deploys only when run against main; dispatching any other
+# branch/tag still builds but skips deploy. See docs/presentations/README.md.
 
 on:
   push:
@@ -43,8 +44,9 @@ jobs:
 
   deploy:
     # Pages is enabled (Source: GitHub Actions), so deploy runs on every push to
-    # main (auto-publish) and on manual workflow_dispatch. The job is scoped to
-    # main so a deploy never fires from another ref.
+    # main (auto-publish). Scoped to the main ref, so a manual workflow_dispatch
+    # deploys only when run against main; a dispatch on any other ref skips this
+    # job (build still runs).
     if: github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest

--- a/docs/presentations/README.md
+++ b/docs/presentations/README.md
@@ -38,25 +38,18 @@ and is gitignored — only the script and workflow are committed.
 (`configure-pages` + `upload-pages-artifact` + `deploy-pages`):
 
 - The **build** job assembles `site/` via the build script and uploads the
-  artifact (`upload-pages-artifact`). It makes no Pages API call, so every push
-  to `main` validates the assembly without turning the workflow red while Pages
-  is disabled.
-- The **deploy** job is gated to `workflow_dispatch` (`if: github.event_name == 'workflow_dispatch'`).
-  It runs `configure-pages` + `deploy-pages`, which require Pages to be enabled,
-  so an operator triggers it manually rather than letting a push to `main` turn
-  the workflow red.
+  artifact (`upload-pages-artifact`).
+- The **deploy** job runs `configure-pages` + `deploy-pages` on every push to
+  `main` (scoped via `if: github.ref == 'refs/heads/main'`), so a merge
+  **auto-publishes**. `workflow_dispatch` also triggers a manual deploy. The
+  published URL appears on the deploy job and the Pages settings page.
 
-### One-time operator step
-
-Enable Pages once: repo **Settings → Pages → Source: GitHub Actions**. Then run
-the workflow from the **Actions** tab → "Deploy presentation decks to GitHub
-Pages" → **Run workflow**. After that the published URL appears on the deploy
-job and the Pages settings page. The audience is public.
+Pages is enabled (repo **Settings → Pages → Source: GitHub Actions**), so no
+manual step is needed — merging to `main` deploys. The audience is public.
 
 ### Private-repo caveat
 
 This repo is private. A **public** Pages site from a private repo requires a
-plan that permits it (GitHub Pro/Team/Enterprise). If the plan does not allow
-it, leave Pages disabled — the workflow's deploy job is `workflow_dispatch`-only
-and is never auto-triggered, so it stays a no-op until an operator enables Pages
-and runs it. Pushes to `main` still build and validate the artifact regardless.
+plan that permits it (GitHub Pro/Team/Enterprise). Pages is currently enabled;
+if it is ever disabled, the deploy job will fail until it is re-enabled (the
+build job, which makes no Pages API call, still succeeds).

--- a/docs/presentations/README.md
+++ b/docs/presentations/README.md
@@ -41,7 +41,8 @@ and is gitignored — only the script and workflow are committed.
   artifact (`upload-pages-artifact`).
 - The **deploy** job runs `configure-pages` + `deploy-pages` on every push to
   `main` (scoped via `if: github.ref == 'refs/heads/main'`), so a merge
-  **auto-publishes**. `workflow_dispatch` also triggers a manual deploy. The
+  **auto-publishes**. A manual `workflow_dispatch` deploys only when run against
+  `main`; dispatching any other branch/tag still builds but skips deploy. The
   published URL appears on the deploy job and the Pages settings page.
 
 Pages is enabled (repo **Settings → Pages → Source: GitHub Actions**), so no


### PR DESCRIPTION
## Summary

Pages is enabled on this repo (Settings → Pages → Source: GitHub Actions), so the deploy job no longer needs to be gated behind `workflow_dispatch`. This change makes a merge to `main` auto-publish the presentation decks.

- `pages.yml` deploy job: `if: github.event_name == 'workflow_dispatch'` → `if: github.ref == 'refs/heads/main'`. The deploy now runs on every push to `main` (auto-publish) and still on manual `workflow_dispatch`. Scoping to the `main` ref keeps a deploy from firing off any other ref.
- Updated the workflow header comment and `docs/presentations/README.md` to describe auto-deploy on merge instead of the operator "Run workflow" step.

## Why

The operator-triggered model was a placeholder while Pages was disabled. Pages is enabled now, so merges should publish automatically.

## Acceptance

- deploy runs on push to `main` (no longer dispatch-gated) and still on `workflow_dispatch`.
- A merge to `main` runs build → deploy without reddening (Pages enabled).
- README + workflow header comment describe "auto-deploys on merge to main".

Closes #940
