### PR TITLE
chore(config): disable requireRetrospectiveInternalTooling until #993

### DIFF
--- a/.devloops
+++ b/.devloops
@@ -76,7 +76,8 @@ workflow:
   # 0.5.0 CHANGELOG describe. Consumers default OFF.
   # TEMPORARY DIVERGENCE: set false here until #993 wraps the remaining agent-level gh
   # reads (CI-log, issue list/filter, issue comment). Until those wrappers exist,
-  # zero-raw-gh compliance isn't achievable, so enforcing would block every session.
+  # a fully clean tooling record (no agent-level raw gh / python / node -e — the full
+  # #982 discipline, not gh alone) isn't achievable, so enforcing would block every session.
   # The discipline is NOT enforced on this repo while this is false. Re-enable to true
   # as part of #993's DoD (which restores the documented posture).
   requireRetrospectiveInternalTooling: false

--- a/.devloops
+++ b/.devloops
@@ -70,12 +70,15 @@ gates:
 workflow:
   requireRetrospective: true
   requireRetrospectiveGate: true
-  # Developer mode: this repo dogfoods the dev-loops tooling, so it enforces the
-  # internal-tooling-only retro discipline on itself (#982). Consumers default OFF.
-  # Temporarily OFF until #993 wraps the remaining agent-level gh reads (CI-log,
-  # issue list/filter, issue comment) — until those wrappers exist, zero-raw-gh
-  # compliance isn't achievable, so enforcing would block every session. Re-enable
-  # to true as part of #993's DoD.
+  # Developer mode: this repo dogfoods the dev-loops tooling and its INTENDED posture
+  # is to enforce the internal-tooling-only retro discipline on itself (#982) — that
+  # intended-on state is what skills/docs/retrospective-checkpoint-contract.md and the
+  # 0.5.0 CHANGELOG describe. Consumers default OFF.
+  # TEMPORARY DIVERGENCE: set false here until #993 wraps the remaining agent-level gh
+  # reads (CI-log, issue list/filter, issue comment). Until those wrappers exist,
+  # zero-raw-gh compliance isn't achievable, so enforcing would block every session.
+  # The discipline is NOT enforced on this repo while this is false. Re-enable to true
+  # as part of #993's DoD (which restores the documented posture).
   requireRetrospectiveInternalTooling: false
   requireDraftFirst: true
   devModeDefault: true

--- a/.devloops
+++ b/.devloops
@@ -72,7 +72,11 @@ workflow:
   requireRetrospectiveGate: true
   # Developer mode: this repo dogfoods the dev-loops tooling, so it enforces the
   # internal-tooling-only retro discipline on itself (#982). Consumers default OFF.
-  requireRetrospectiveInternalTooling: true
+  # Temporarily OFF until #993 wraps the remaining agent-level gh reads (CI-log,
+  # issue list/filter, issue comment) — until those wrappers exist, zero-raw-gh
+  # compliance isn't achievable, so enforcing would block every session. Re-enable
+  # to true as part of #993's DoD.
+  requireRetrospectiveInternalTooling: false
   requireDraftFirst: true
   devModeDefault: true
 


### PR DESCRIPTION
## What

Sets `workflow.requireRetrospectiveInternalTooling: false` in the repo-root `.devloops` until #993 lands.

## Why

The hard developer-mode internal-tooling-only retro check (#982) shipped in v0.5.0 and is live on this repo. But the agent-level `gh` reads it flags — CI-run logs, issue list/filter, issue comment — have **no dev-loops wrapper yet** (filed as #993). Until those wrappers exist, zero-raw-`gh` compliance isn't achievable, so enforcing the check blocks every session on operations that have no internal-tooling alternative (it flagged the v0.5.0 release session itself).

The check itself is unchanged and consumer-safe (default OFF); this only flips this repo's own opt-in off temporarily. Re-enabling to `true` is part of #993's DoD.

## Verification
- [x] One-line config flip + explanatory comment; no code/behavior change
- [x] `npm run verify` (config schema accepts the boolean)

Related: #982 (the check), #993 (the wrappers that make compliance achievable)
