### PR TITLE
fix(release): make extract-changelog-section dependency-free (closes #1016)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- **`release.yml` auto-Release never ran — the CHANGELOG extractor pulled in `@dev-loops/core` (#1016, regression in #996's first run).** `scripts/release/extract-changelog-section.mjs` imported `isDirectCliRun` from `scripts/_core-helpers.mjs`, which re-exports from the `@dev-loops/core` workspace package. `release.yml` runs the extractor with **no `npm ci`** (a text parser needs no install), so on a `v*` tag push the import `ERR_MODULE_NOT_FOUND`ed before any notes were extracted and the GitHub Release was never created (the same hands-off-publish gap #996 set out to close). The extractor now imports **only `node:` builtins** — `isDirectCliRun` is inlined (`node:fs` `realpathSync` + `node:url` `fileURLToPath`), all behavior unchanged (`--version`/`--changelog`, leading-`v` strip, heading lookahead so `0.5.1` ≠ `0.5.10`, stop-at-next-`## `, no Unreleased bleed, exit 1 absent/empty, exit 2 arg/file error, the `extractChangelogSection()` export). A new guard test parses the script's `import` statements and asserts every specifier is `node:`-prefixed, so a future workspace import can't silently reintroduce the deps-free break. `release.yml` is unchanged — the standalone script is the fix.
+
 ## 0.6.0 - 2026-06-29
 
 ### Added

--- a/scripts/release/extract-changelog-section.mjs
+++ b/scripts/release/extract-changelog-section.mjs
@@ -1,6 +1,20 @@
+import { realpathSync } from "node:fs";
 import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 
-import { isDirectCliRun } from "../_core-helpers.mjs";
+// Inlined (was scripts/_core-helpers.mjs -> @dev-loops/core): this script runs
+// in release.yml with no `npm ci`, so it must import only node: builtins.
+// A workspace import here ERR_MODULE_NOT_FOUNDs and the Release never gets made.
+function isDirectCliRun(importMetaUrl, argv1 = process.argv[1]) {
+  if (typeof argv1 !== "string" || argv1.length === 0) {
+    return false;
+  }
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(importMetaUrl));
+  } catch {
+    return false;
+  }
+}
 
 const USAGE = `Usage: extract-changelog-section.mjs --version <v> [--changelog <path>]
 

--- a/test/docs/extract-changelog-section.test.mjs
+++ b/test/docs/extract-changelog-section.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -119,4 +120,20 @@ test("CLI exits 2 when a flag is missing its value", () => {
   );
   assert.equal(result.status, 2);
   assert.match(result.stderr, /--changelog requires a value/);
+});
+
+test("imports only node: builtins (must run dependency-free in release.yml — #1016)", async () => {
+  // release.yml runs this script with no `npm ci`, so any workspace/3rd-party
+  // import (e.g. @dev-loops/core via _core-helpers.mjs) ERR_MODULE_NOT_FOUNDs
+  // and the GitHub Release is never created. Guard against reintroduction.
+  const source = await readFile(scriptPath, "utf8");
+  const importRe = /^\s*import\b[^"']*["']([^"']+)["']/gm;
+  const specifiers = [...source.matchAll(importRe)].map((m) => m[1]);
+  assert.notEqual(specifiers.length, 0, "expected at least one import");
+  for (const spec of specifiers) {
+    assert.ok(
+      spec.startsWith("node:"),
+      `non-node: import "${spec}" would break the deps-free release.yml runner`,
+    );
+  }
 });

--- a/test/docs/extract-changelog-section.test.mjs
+++ b/test/docs/extract-changelog-section.test.mjs
@@ -127,8 +127,17 @@ test("imports only node: builtins (must run dependency-free in release.yml — #
   // import (e.g. @dev-loops/core via _core-helpers.mjs) ERR_MODULE_NOT_FOUNDs
   // and the GitHub Release is never created. Guard against reintroduction.
   const source = await readFile(scriptPath, "utf8");
-  const importRe = /^\s*import\b[^"']*["']([^"']+)["']/gm;
-  const specifiers = [...source.matchAll(importRe)].map((m) => m[1]);
+  // Match every module-specifier form a dependency could sneak in through:
+  // `import ... from "x"`, bare `import "x"`, `export ... from "x"`, and
+  // dynamic `import("x")` — not just the static `import ... from` Copilot noted.
+  const importRe = /^\s*import\b[^"'\n;]*["']([^"']+)["']/gm;
+  const exportFromRe = /^\s*export\b[^"'\n;]*\bfrom\s*["']([^"']+)["']/gm;
+  const dynamicRe = /\bimport\s*\(\s*["']([^"']+)["']/g;
+  const specifiers = [
+    ...[...source.matchAll(importRe)].map((m) => m[1]),
+    ...[...source.matchAll(exportFromRe)].map((m) => m[1]),
+    ...[...source.matchAll(dynamicRe)].map((m) => m[1]),
+  ];
   assert.notEqual(specifiers.length, 0, "expected at least one import");
   for (const spec of specifiers) {
     assert.ok(

--- a/test/docs/extract-changelog-section.test.mjs
+++ b/test/docs/extract-changelog-section.test.mjs
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";


### PR DESCRIPTION
## Why
`release.yml` (#996) fired on the `v0.6.0` tag but **failed** — the "Extract release notes" step hit `ERR_MODULE_NOT_FOUND: @dev-loops/core` because `extract-changelog-section.mjs` imported `isDirectCliRun` from `scripts/_core-helpers.mjs` (which re-exports `@dev-loops/core` at module top level), and `release.yml` runs no `npm ci`. The auto-Release was never created; 0.6.0 was published via a manual `gh release create` workaround.

## What
- Removed the `_core-helpers.mjs` import; inlined `isDirectCliRun` verbatim (uses only `node:fs` `realpathSync` + `node:url` `fileURLToPath`).
- The script now imports **only** `node:` builtins — a standalone text parser needs no install.
- All existing behavior preserved (`--version`/`--changelog`, leading-`v` strip, `0.5.1`≠`0.5.10` lookahead, stop-at-next-`## `, no Unreleased bleed, exit 1 absent/empty, exit 2 arg/file error, `extractChangelogSection()` export).

## Proof
- Ran the script in a scratchpad dir with **no `node_modules`** via bare `node`: `--version 0.6.0` → exit 0 + body; absent version → exit 1 fail-closed.
- Added a guard test (`test/docs/extract-changelog-section.test.mjs`): parses every `import` specifier in the source and asserts each is `node:`-prefixed (fails if a workspace/3rd-party import is reintroduced).
- `npm run verify` → green.

## Non-goals
`release.yml` unchanged — adding `npm ci` would be a redundant, slower belt for a text parser. Add only if the extract step later grows a real runtime dep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
