### PR TITLE
fix(hooks): gate `gh pr merge` behind pre-merge evidence check

### DIFF
--- a/.claude/hooks/_bash-command-classify.mjs
+++ b/.claude/hooks/_bash-command-classify.mjs
@@ -117,16 +117,30 @@ function findGhPrVerbSegment(command, verb) {
   return null;
 }
 
-/** Generic `gh pr <verb>` detector that scans ALL shell segments. */
+/**
+ * Generic `gh pr <verb>` detector — checks the FIRST shell segment only.
+ *
+ * Used by the Pi extension's post-execute handler (`onUserBash`) to record that `gh pr ready`
+ * actually ran. First-segment-only is correct for that use: `false && gh pr ready 42` short-
+ * circuits so ready never executes, and the extension should not record a spurious invocation.
+ *
+ * For the Claude Code PreToolUse gate (block before execution), use
+ * `commandContainsGhPrReady`/`commandContainsGhPrMerge` instead — those scan ALL segments.
+ */
 function isGhPrVerbCommand(command, verb) {
-  return findGhPrVerbSegment(command, verb) !== null;
+  const re = ghPrVerbRegex(verb);
+  const segment = firstShellSegment(command);
+  if (!segment || !re.test(segment)) return false;
+  const remainder = segment.replace(re, "").trim();
+  if (!remainder) return true;
+  const args = remainder.split(/\s+/).map((a) => a.toLowerCase());
+  return !args.includes("--help") && !args.includes("-h");
 }
 
-/** Generic positional PR-number extractor for `gh pr <verb>` — finds the verb segment first. */
-function extractPrNumberFromGhPrVerb(command, verb) {
-  const segment = findGhPrVerbSegment(command, verb);
-  if (!segment) return null;
+/** Extract PR number from a single already-isolated segment (shared by both first- and all-segment paths). */
+function extractPrNumberFromSegment(segment, verb) {
   const re = ghPrVerbRegex(verb);
+  if (!segment || !re.test(segment)) return null;
   const remainder = segment.replace(re, "").trim();
   if (!remainder) {
     return null;
@@ -152,11 +166,10 @@ function extractPrNumberFromGhPrVerb(command, verb) {
   return null;
 }
 
-/** Generic `--repo`/`-R` extractor for `gh pr <verb>` — finds the verb segment first. */
-function extractRepoFlagFromGhPrVerb(command, verb) {
-  const segment = findGhPrVerbSegment(command, verb);
-  if (!segment) return null;
+/** Extract repo flag from a single already-isolated segment. */
+function extractRepoFlagFromSegment(segment, verb) {
   const re = ghPrVerbRegex(verb);
+  if (!segment || !re.test(segment)) return null;
   const remainder = segment.replace(re, "").trim();
   if (!remainder) {
     return null;
@@ -178,6 +191,16 @@ function extractRepoFlagFromGhPrVerb(command, verb) {
   return null;
 }
 
+/** First-segment extractor for `gh pr <verb>` PR number — Pi extension public API. */
+function extractPrNumberFromGhPrVerb(command, verb) {
+  return extractPrNumberFromSegment(firstShellSegment(command), verb);
+}
+
+/** First-segment extractor for `gh pr <verb>` --repo flag — Pi extension public API. */
+function extractRepoFlagFromGhPrVerb(command, verb) {
+  return extractRepoFlagFromSegment(firstShellSegment(command), verb);
+}
+
 /** @param {string} command @returns {boolean} */
 export function isGhPrReadyCommand(command) {
   return isGhPrVerbCommand(command, "ready");
@@ -194,14 +217,52 @@ export function extractRepoFlagFromGhPrReady(command) {
 }
 
 /**
- * Whether `command` contains a `gh pr merge` invocation in any shell segment, ignoring `--help`/`-h`.
- * Used by the PreToolUse gate to block a direct merge that bypasses the dev-loop's pre-merge
- * gate-evidence check — the loop normally runs `detect-checkpoint-evidence` before merging, but
- * a hand-run `gh pr merge` would otherwise skip it.
+ * Whether `command` contains a `gh pr merge` invocation in the FIRST shell segment,
+ * ignoring `--help`/`-h`. Used by the Pi extension's post-execute handler.
+ * For the Claude Code PreToolUse gate, use `commandContainsGhPrMerge` instead.
  * @param {string} command @returns {boolean}
  */
 export function isGhPrMergeCommand(command) {
   return isGhPrVerbCommand(command, "merge");
+}
+
+/**
+ * Whether `command` contains a `gh pr ready` invocation in ANY shell segment.
+ * For use in the Claude Code PreToolUse gate only — blocks the whole command pre-emptively
+ * regardless of shell short-circuit semantics (`false && gh pr ready 42` is still blocked).
+ * @param {string} command @returns {boolean}
+ */
+export function commandContainsGhPrReady(command) {
+  return findGhPrVerbSegment(command, "ready") !== null;
+}
+
+/**
+ * Whether `command` contains a `gh pr merge` invocation in ANY shell segment.
+ * For use in the Claude Code PreToolUse gate only — blocks the whole command pre-emptively.
+ * @param {string} command @returns {boolean}
+ */
+export function commandContainsGhPrMerge(command) {
+  return findGhPrVerbSegment(command, "merge") !== null;
+}
+
+/** Extract PR number from `gh pr ready` in any shell segment — PreToolUse gate use only. */
+export function extractPrNumberFromGhPrReadyAnywhere(command) {
+  return extractPrNumberFromSegment(findGhPrVerbSegment(command, "ready"), "ready");
+}
+
+/** @param {string} command @returns {string|null} */
+export function extractRepoFlagFromGhPrReadyAnywhere(command) {
+  return extractRepoFlagFromSegment(findGhPrVerbSegment(command, "ready"), "ready");
+}
+
+/** Extract PR number from `gh pr merge` in any shell segment — PreToolUse gate use only. */
+export function extractPrNumberFromGhPrMergeAnywhere(command) {
+  return extractPrNumberFromSegment(findGhPrVerbSegment(command, "merge"), "merge");
+}
+
+/** @param {string} command @returns {string|null} */
+export function extractRepoFlagFromGhPrMergeAnywhere(command) {
+  return extractRepoFlagFromSegment(findGhPrVerbSegment(command, "merge"), "merge");
 }
 
 /** @param {string} command @returns {number|null} */

--- a/.claude/hooks/_bash-command-classify.mjs
+++ b/.claude/hooks/_bash-command-classify.mjs
@@ -51,7 +51,7 @@ export function normalizeGitHubRepoSlug(remoteUrl) {
   return null;
 }
 
-function isGhPrMergeCommand(segment) {
+function segmentIsGhPrMerge(segment) {
   if (!/^gh\s+pr\s+merge(?:\s|$)/i.test(segment)) {
     return false;
   }
@@ -83,7 +83,7 @@ export function isMergeCapableCommand(command) {
   }
   return normalized
     .split(/\s*(?:&&|\|\||;|\|)\s*/)
-    .some((segment) => isGhPrMergeCommand(segment) || isGitMergeCompletionCommand(segment));
+    .some((segment) => segmentIsGhPrMerge(segment) || isGitMergeCompletionCommand(segment));
 }
 
 /** @param {string} command @returns {string} */
@@ -91,13 +91,19 @@ export function firstShellSegment(command) {
   return command.trim().split(/\s*(?:&&|\|\||;|\|)\s*/)[0]?.trim() ?? "";
 }
 
-/** @param {string} command @returns {boolean} */
-export function isGhPrReadyCommand(command) {
+/** Build the `^gh pr <verb>` prefix matcher for a `gh pr <verb>` subcommand. */
+function ghPrVerbRegex(verb) {
+  return new RegExp(`^gh\\s+pr\\s+${verb}(?:\\s|$)`, "i");
+}
+
+/** Generic `gh pr <verb>` (first-segment) detector, ignoring `--help`/`-h`. */
+function isGhPrVerbCommand(command, verb) {
   const segment = firstShellSegment(command);
-  if (!segment || !/^gh\s+pr\s+ready(?:\s|$)/i.test(segment)) {
+  const re = ghPrVerbRegex(verb);
+  if (!segment || !re.test(segment)) {
     return false;
   }
-  const remainder = segment.replace(/^gh\s+pr\s+ready(?:\s|$)/i, "").trim();
+  const remainder = segment.replace(re, "").trim();
   if (!remainder) {
     return true;
   }
@@ -105,13 +111,14 @@ export function isGhPrReadyCommand(command) {
   return !args.includes("--help") && !args.includes("-h");
 }
 
-/** @param {string} command @returns {number|null} */
-export function extractPrNumberFromGhPrReady(command) {
+/** Generic positional PR-number extractor for `gh pr <verb>`. */
+function extractPrNumberFromGhPrVerb(command, verb) {
   const segment = firstShellSegment(command);
-  if (!/^gh\s+pr\s+ready(?:\s|$)/i.test(segment)) {
+  const re = ghPrVerbRegex(verb);
+  if (!re.test(segment)) {
     return null;
   }
-  const remainder = segment.replace(/^gh\s+pr\s+ready(?:\s|$)/i, "").trim();
+  const remainder = segment.replace(re, "").trim();
   if (!remainder) {
     return null;
   }
@@ -136,13 +143,14 @@ export function extractPrNumberFromGhPrReady(command) {
   return null;
 }
 
-/** @param {string} command @returns {string|null} */
-export function extractRepoFlagFromGhPrReady(command) {
+/** Generic `--repo`/`-R` extractor for `gh pr <verb>`. */
+function extractRepoFlagFromGhPrVerb(command, verb) {
   const segment = firstShellSegment(command);
-  if (!/^gh\s+pr\s+ready(?:\s|$)/i.test(segment)) {
+  const re = ghPrVerbRegex(verb);
+  if (!re.test(segment)) {
     return null;
   }
-  const remainder = segment.replace(/^gh\s+pr\s+ready(?:\s|$)/i, "").trim();
+  const remainder = segment.replace(re, "").trim();
   if (!remainder) {
     return null;
   }
@@ -161,4 +169,40 @@ export function extractRepoFlagFromGhPrReady(command) {
     }
   }
   return null;
+}
+
+/** @param {string} command @returns {boolean} */
+export function isGhPrReadyCommand(command) {
+  return isGhPrVerbCommand(command, "ready");
+}
+
+/** @param {string} command @returns {number|null} */
+export function extractPrNumberFromGhPrReady(command) {
+  return extractPrNumberFromGhPrVerb(command, "ready");
+}
+
+/** @param {string} command @returns {string|null} */
+export function extractRepoFlagFromGhPrReady(command) {
+  return extractRepoFlagFromGhPrVerb(command, "ready");
+}
+
+/**
+ * Whether `command` is a `gh pr merge` invocation (first segment), ignoring `--help`/`-h`.
+ * Used by the PreToolUse gate to block a direct merge that bypasses the dev-loop's pre-merge
+ * gate-evidence check — the loop normally runs `detect-checkpoint-evidence` before merging, but
+ * a hand-run `gh pr merge` would otherwise skip it.
+ * @param {string} command @returns {boolean}
+ */
+export function isGhPrMergeCommand(command) {
+  return isGhPrVerbCommand(command, "merge");
+}
+
+/** @param {string} command @returns {number|null} */
+export function extractPrNumberFromGhPrMerge(command) {
+  return extractPrNumberFromGhPrVerb(command, "merge");
+}
+
+/** @param {string} command @returns {string|null} */
+export function extractRepoFlagFromGhPrMerge(command) {
+  return extractRepoFlagFromGhPrVerb(command, "merge");
 }

--- a/.claude/hooks/_bash-command-classify.mjs
+++ b/.claude/hooks/_bash-command-classify.mjs
@@ -91,33 +91,42 @@ export function firstShellSegment(command) {
   return command.trim().split(/\s*(?:&&|\|\||;|\|)\s*/)[0]?.trim() ?? "";
 }
 
+/** Split a compound shell command into its individual segments. */
+function shellSegments(command) {
+  return command.trim().split(/\s*(?:&&|\|\||;|\|)\s*/).map((s) => s.trim()).filter(Boolean);
+}
+
 /** Build the `^gh pr <verb>` prefix matcher for a `gh pr <verb>` subcommand. */
 function ghPrVerbRegex(verb) {
   return new RegExp(`^gh\\s+pr\\s+${verb}(?:\\s|$)`, "i");
 }
 
-/** Generic `gh pr <verb>` (first-segment) detector, ignoring `--help`/`-h`. */
-function isGhPrVerbCommand(command, verb) {
-  const segment = firstShellSegment(command);
+/**
+ * Return the first segment in the command that is a `gh pr <verb>` call (ignoring --help/-h),
+ * or null. Scans ALL segments so compound commands (`echo ok && gh pr merge 1`) are caught.
+ */
+function findGhPrVerbSegment(command, verb) {
   const re = ghPrVerbRegex(verb);
-  if (!segment || !re.test(segment)) {
-    return false;
+  for (const segment of shellSegments(command)) {
+    if (!re.test(segment)) continue;
+    const remainder = segment.replace(re, "").trim();
+    if (!remainder) return segment;
+    const args = remainder.split(/\s+/).map((a) => a.toLowerCase());
+    if (!args.includes("--help") && !args.includes("-h")) return segment;
   }
-  const remainder = segment.replace(re, "").trim();
-  if (!remainder) {
-    return true;
-  }
-  const args = remainder.split(/\s+/).map((a) => a.toLowerCase());
-  return !args.includes("--help") && !args.includes("-h");
+  return null;
 }
 
-/** Generic positional PR-number extractor for `gh pr <verb>`. */
+/** Generic `gh pr <verb>` detector that scans ALL shell segments. */
+function isGhPrVerbCommand(command, verb) {
+  return findGhPrVerbSegment(command, verb) !== null;
+}
+
+/** Generic positional PR-number extractor for `gh pr <verb>` — finds the verb segment first. */
 function extractPrNumberFromGhPrVerb(command, verb) {
-  const segment = firstShellSegment(command);
+  const segment = findGhPrVerbSegment(command, verb);
+  if (!segment) return null;
   const re = ghPrVerbRegex(verb);
-  if (!re.test(segment)) {
-    return null;
-  }
   const remainder = segment.replace(re, "").trim();
   if (!remainder) {
     return null;
@@ -143,13 +152,11 @@ function extractPrNumberFromGhPrVerb(command, verb) {
   return null;
 }
 
-/** Generic `--repo`/`-R` extractor for `gh pr <verb>`. */
+/** Generic `--repo`/`-R` extractor for `gh pr <verb>` — finds the verb segment first. */
 function extractRepoFlagFromGhPrVerb(command, verb) {
-  const segment = firstShellSegment(command);
+  const segment = findGhPrVerbSegment(command, verb);
+  if (!segment) return null;
   const re = ghPrVerbRegex(verb);
-  if (!re.test(segment)) {
-    return null;
-  }
   const remainder = segment.replace(re, "").trim();
   if (!remainder) {
     return null;

--- a/.claude/hooks/_bash-command-classify.mjs
+++ b/.claude/hooks/_bash-command-classify.mjs
@@ -194,7 +194,7 @@ export function extractRepoFlagFromGhPrReady(command) {
 }
 
 /**
- * Whether `command` is a `gh pr merge` invocation (first segment), ignoring `--help`/`-h`.
+ * Whether `command` contains a `gh pr merge` invocation in any shell segment, ignoring `--help`/`-h`.
  * Used by the PreToolUse gate to block a direct merge that bypasses the dev-loop's pre-merge
  * gate-evidence check — the loop normally runs `detect-checkpoint-evidence` before merging, but
  * a hand-run `gh pr merge` would otherwise skip it.

--- a/.claude/hooks/_hook-decisions.mjs
+++ b/.claude/hooks/_hook-decisions.mjs
@@ -12,12 +12,12 @@
 
 import { resolveRunId } from "./_run-context.mjs";
 import {
-  isGhPrReadyCommand,
-  extractPrNumberFromGhPrReady,
-  extractRepoFlagFromGhPrReady,
-  isGhPrMergeCommand,
-  extractPrNumberFromGhPrMerge,
-  extractRepoFlagFromGhPrMerge,
+  commandContainsGhPrReady,
+  commandContainsGhPrMerge,
+  extractPrNumberFromGhPrReadyAnywhere,
+  extractRepoFlagFromGhPrReadyAnywhere,
+  extractPrNumberFromGhPrMergeAnywhere,
+  extractRepoFlagFromGhPrMergeAnywhere,
   TARGET_REPO_SLUG,
 } from "./_bash-command-classify.mjs";
 
@@ -59,8 +59,12 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
   if (typeof command !== "string") {
     return ALLOW;
   }
-  const isReady = isGhPrReadyCommand(command);
-  const isMerge = isGhPrMergeCommand(command);
+  // Scan ALL shell segments — the PreToolUse gate blocks pre-emptively, so a gated verb in any
+  // segment (even after `&&` or `;`) must be caught. This differs from the Pi extension's
+  // post-execute `isGhPrReadyCommand`/`isGhPrMergeCommand` which scan only the first segment
+  // (correct there: `false && gh pr ready 42` short-circuits so ready never ran).
+  const isReady = commandContainsGhPrReady(command);
+  const isMerge = commandContainsGhPrMerge(command);
   if (!isReady && !isMerge) {
     return ALLOW;
   }
@@ -68,7 +72,9 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
   // the draft_gate (a subset of the pre-merge evidence check) is also satisfied.
   const verb = isMerge ? "gh pr merge" : "gh pr ready";
   // An explicit `--repo other/repo` that is not the target → not our concern, pass through.
-  const explicitRepo = isMerge ? extractRepoFlagFromGhPrMerge(command) : extractRepoFlagFromGhPrReady(command);
+  const explicitRepo = isMerge
+    ? extractRepoFlagFromGhPrMergeAnywhere(command)
+    : extractRepoFlagFromGhPrReadyAnywhere(command);
   if (explicitRepo && explicitRepo.toLowerCase() !== TARGET_REPO_SLUG.toLowerCase()) {
     return ALLOW;
   }
@@ -77,7 +83,9 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
     return ALLOW;
   }
 
-  const prNumber = isMerge ? extractPrNumberFromGhPrMerge(command) : extractPrNumberFromGhPrReady(command);
+  const prNumber = isMerge
+    ? extractPrNumberFromGhPrMergeAnywhere(command)
+    : extractPrNumberFromGhPrReadyAnywhere(command);
   if (prNumber === null) {
     return {
       decision: "deny",

--- a/.claude/hooks/_hook-decisions.mjs
+++ b/.claude/hooks/_hook-decisions.mjs
@@ -15,6 +15,9 @@ import {
   isGhPrReadyCommand,
   extractPrNumberFromGhPrReady,
   extractRepoFlagFromGhPrReady,
+  isGhPrMergeCommand,
+  extractPrNumberFromGhPrMerge,
+  extractRepoFlagFromGhPrMerge,
   TARGET_REPO_SLUG,
 } from "./_bash-command-classify.mjs";
 
@@ -34,26 +37,37 @@ const ALLOW = Object.freeze({ decision: "allow" });
 export const DEV_LOOP_AGENT_TYPE = "dev-loop";
 
 /**
- * Decide whether a PreToolUse Bash command must be blocked by the draft-gate boundary.
+ * Decide whether a PreToolUse Bash command must be blocked by a dev-loop gate boundary.
  *
- * Mirrors the Pi extension's `onUserBash`: the only blocked case is `gh pr ready` for the
- * target repo without clean draft_gate evidence. Everything else (including merges, which
- * trigger the post-merge step, not a block) is allowed through.
+ * Two gated commands on the target repo:
+ *   - `gh pr ready` — blocked without clean draft_gate evidence (`pre-pr-ready-gate`).
+ *   - `gh pr merge` — blocked without the full pre-merge gate evidence (`detect-checkpoint-evidence`:
+ *     clean current-head draft_gate + pre_approval_gate). The loop runs this check before merging;
+ *     gating it here closes the hole where a hand-run `gh pr merge` skips the pre-approval gate
+ *     entirely. Everything else passes through.
+ *
+ * The hook computes `gatePassed`/`gateError` from the gate script appropriate to the command kind.
  *
  * @param {Object} params
  * @param {string} params.command - The Bash command string.
  * @param {string|null} [params.repoSlug] - Resolved owner/name of the cwd repo (null if unknown).
- * @param {boolean} [params.gatePassed] - Whether `pre-pr-ready-gate` evidence exists for the PR.
+ * @param {boolean} [params.gatePassed] - Whether the relevant gate evidence exists for the PR.
  * @param {string|null} [params.gateError] - Error detail when the gate guard could not run.
  * @returns {HookDecision}
  */
 export function decideBashGate({ command, repoSlug = null, gatePassed = false, gateError = null }) {
-  if (typeof command !== "string" || !isGhPrReadyCommand(command)) {
+  if (typeof command !== "string") {
+    return ALLOW;
+  }
+  const isReady = isGhPrReadyCommand(command);
+  const isMerge = !isReady && isGhPrMergeCommand(command);
+  if (!isReady && !isMerge) {
     return ALLOW;
   }
 
+  const verb = isReady ? "gh pr ready" : "gh pr merge";
   // An explicit `--repo other/repo` that is not the target → not our concern, pass through.
-  const explicitRepo = extractRepoFlagFromGhPrReady(command);
+  const explicitRepo = isReady ? extractRepoFlagFromGhPrReady(command) : extractRepoFlagFromGhPrMerge(command);
   if (explicitRepo && explicitRepo.toLowerCase() !== TARGET_REPO_SLUG.toLowerCase()) {
     return ALLOW;
   }
@@ -62,26 +76,28 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
     return ALLOW;
   }
 
-  const prNumber = extractPrNumberFromGhPrReady(command);
+  const prNumber = isReady ? extractPrNumberFromGhPrReady(command) : extractPrNumberFromGhPrMerge(command);
   if (prNumber === null) {
     return {
       decision: "deny",
-      reason:
-        "gh pr ready blocked: could not determine the PR number from the command. Include the PR number explicitly.",
+      reason: `${verb} blocked: could not determine the PR number from the command. Include the PR number explicitly.`,
     };
   }
 
   if (gateError) {
+    const which = isReady ? "draft-gate" : "pre-merge gate";
     return {
       decision: "deny",
-      reason: `gh pr ready blocked: draft-gate evidence check failed (${gateError}).`,
+      reason: `${verb} blocked: ${which} evidence check failed (${gateError}).`,
     };
   }
 
   if (!gatePassed) {
     return {
       decision: "deny",
-      reason: `gh pr ready blocked: no visible clean draft_gate checkpoint verdict comment found for PR #${prNumber}.`,
+      reason: isReady
+        ? `gh pr ready blocked: no visible clean draft_gate checkpoint verdict comment found for PR #${prNumber}.`
+        : `gh pr merge blocked: missing pre-merge gate evidence for PR #${prNumber} (need clean current-head draft_gate + pre_approval_gate; inline verdicts are not accepted). Run the dev-loop gates instead of merging directly.`,
     };
   }
 

--- a/.claude/hooks/_hook-decisions.mjs
+++ b/.claude/hooks/_hook-decisions.mjs
@@ -60,14 +60,15 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
     return ALLOW;
   }
   const isReady = isGhPrReadyCommand(command);
-  const isMerge = !isReady && isGhPrMergeCommand(command);
+  const isMerge = isGhPrMergeCommand(command);
   if (!isReady && !isMerge) {
     return ALLOW;
   }
-
-  const verb = isReady ? "gh pr ready" : "gh pr merge";
+  // When both verbs appear in a compound command, apply the stricter merge gate — if it passes,
+  // the draft_gate (a subset of the pre-merge evidence check) is also satisfied.
+  const verb = isMerge ? "gh pr merge" : "gh pr ready";
   // An explicit `--repo other/repo` that is not the target → not our concern, pass through.
-  const explicitRepo = isReady ? extractRepoFlagFromGhPrReady(command) : extractRepoFlagFromGhPrMerge(command);
+  const explicitRepo = isMerge ? extractRepoFlagFromGhPrMerge(command) : extractRepoFlagFromGhPrReady(command);
   if (explicitRepo && explicitRepo.toLowerCase() !== TARGET_REPO_SLUG.toLowerCase()) {
     return ALLOW;
   }
@@ -76,7 +77,7 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
     return ALLOW;
   }
 
-  const prNumber = isReady ? extractPrNumberFromGhPrReady(command) : extractPrNumberFromGhPrMerge(command);
+  const prNumber = isMerge ? extractPrNumberFromGhPrMerge(command) : extractPrNumberFromGhPrReady(command);
   if (prNumber === null) {
     return {
       decision: "deny",
@@ -85,7 +86,7 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
   }
 
   if (gateError) {
-    const which = isReady ? "draft-gate" : "pre-merge gate";
+    const which = isMerge ? "pre-merge gate" : "draft-gate";
     return {
       decision: "deny",
       reason: `${verb} blocked: ${which} evidence check failed (${gateError}).`,
@@ -95,9 +96,9 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
   if (!gatePassed) {
     return {
       decision: "deny",
-      reason: isReady
-        ? `gh pr ready blocked: no visible clean draft_gate checkpoint verdict comment found for PR #${prNumber}.`
-        : `gh pr merge blocked: missing pre-merge gate evidence for PR #${prNumber} (need clean current-head draft_gate + pre_approval_gate; inline verdicts are not accepted). Run the dev-loop gates instead of merging directly.`,
+      reason: isMerge
+        ? `gh pr merge blocked: missing pre-merge gate evidence for PR #${prNumber} (need clean current-head draft_gate + pre_approval_gate; inline verdicts are not accepted). Run the dev-loop gates instead of merging directly.`
+        : `gh pr ready blocked: no visible clean draft_gate checkpoint verdict comment found for PR #${prNumber}.`,
     };
   }
 

--- a/.claude/hooks/pre-tool-use-bash-gate.mjs
+++ b/.claude/hooks/pre-tool-use-bash-gate.mjs
@@ -2,10 +2,12 @@
 /**
  * PreToolUse Bash gate hook (#773).
  *
- * Reproduces the Pi extension's `onUserBash` draft-gate guard for Claude Code: blocks
- * `gh pr ready` for the target repo unless a clean draft_gate checkpoint verdict exists for the
- * PR (via scripts/loop/pre-pr-ready-gate.mjs). Merges are NOT blocked here (they trigger the
- * post-merge hook). All other commands pass through.
+ * Blocks two commands on the target repo unless their gate evidence exists; everything else
+ * passes through:
+ *   - `gh pr ready` — needs a clean draft_gate verdict (via scripts/loop/pre-pr-ready-gate.mjs).
+ *   - `gh pr merge` — needs full pre-merge evidence (clean current-head draft_gate +
+ *     pre_approval_gate, via scripts/github/detect-checkpoint-evidence.mjs). This closes the hole
+ *     where a hand-run merge skips the loop's pre-merge gate check (and thus the pre-approval gate).
  */
 import { execFileSync } from "node:child_process";
 import path from "node:path";
@@ -13,7 +15,9 @@ import path from "node:path";
 import { decideBashGate } from "./_hook-decisions.mjs";
 import {
   isGhPrReadyCommand,
+  isGhPrMergeCommand,
   extractPrNumberFromGhPrReady,
+  extractPrNumberFromGhPrMerge,
   normalizeGitHubRepoSlug,
   TARGET_REPO_SLUG,
 } from "./_bash-command-classify.mjs";
@@ -22,7 +26,9 @@ import { readHookInput, emitDeny, emitAllow } from "./_hook-io.mjs";
 
 const input = readHookInput();
 const command = input?.tool_input?.command;
-if (typeof command !== "string" || !isGhPrReadyCommand(command)) {
+const isReady = typeof command === "string" && isGhPrReadyCommand(command);
+const isMerge = typeof command === "string" && !isReady && isGhPrMergeCommand(command);
+if (!isReady && !isMerge) {
   emitAllow();
 }
 
@@ -44,12 +50,15 @@ try {
 let gatePassed = false;
 let gateError = null;
 if (repoSlug === TARGET_REPO_SLUG) {
-  const pr = extractPrNumberFromGhPrReady(command);
+  const pr = isReady ? extractPrNumberFromGhPrReady(command) : extractPrNumberFromGhPrMerge(command);
   if (pr !== null && repoRoot) {
-    // The gate guard script is overridable for deterministic testing (stub instead of the
-    // network-touching real guard); defaults to the bundled pre-pr-ready-gate.
-    const gateScript =
-      process.env.DEVLOOPS_PRE_PR_READY_GATE_SCRIPT || path.join(repoRoot, "scripts/loop/pre-pr-ready-gate.mjs");
+    // Each gate script is overridable for deterministic testing (stub instead of the
+    // network-touching real guard). `gh pr ready` → draft-gate only; `gh pr merge` → the full
+    // pre-merge evidence check (draft_gate + pre_approval_gate).
+    const gateScript = isReady
+      ? process.env.DEVLOOPS_PRE_PR_READY_GATE_SCRIPT || path.join(repoRoot, "scripts/loop/pre-pr-ready-gate.mjs")
+      : process.env.DEVLOOPS_PRE_MERGE_GATE_SCRIPT ||
+        path.join(repoRoot, "scripts/github/detect-checkpoint-evidence.mjs");
     try {
       execFileSync("node", [gateScript, "--repo", repoSlug, "--pr", String(pr)], {
         cwd: repoRoot,
@@ -57,10 +66,10 @@ if (repoSlug === TARGET_REPO_SLUG) {
       });
       gatePassed = true;
     } catch (error) {
-      // Exit 1 from the guard = no clean draft_gate evidence (gatePassed stays false).
+      // Exit 1 from the guard = gate evidence missing/insufficient (gatePassed stays false).
       // A missing/unspawnable guard (no numeric status) = could-not-run → gateError.
       if (typeof error?.status !== "number") {
-        gateError = "could not run the draft-gate guard script";
+        gateError = "could not run the gate guard script";
       }
     }
   }

--- a/.claude/hooks/pre-tool-use-bash-gate.mjs
+++ b/.claude/hooks/pre-tool-use-bash-gate.mjs
@@ -27,7 +27,7 @@ import { readHookInput, emitDeny, emitAllow } from "./_hook-io.mjs";
 const input = readHookInput();
 const command = input?.tool_input?.command;
 const isReady = typeof command === "string" && isGhPrReadyCommand(command);
-const isMerge = typeof command === "string" && !isReady && isGhPrMergeCommand(command);
+const isMerge = typeof command === "string" && isGhPrMergeCommand(command);
 if (!isReady && !isMerge) {
   emitAllow();
 }
@@ -50,15 +50,16 @@ try {
 let gatePassed = false;
 let gateError = null;
 if (repoSlug === TARGET_REPO_SLUG) {
-  const pr = isReady ? extractPrNumberFromGhPrReady(command) : extractPrNumberFromGhPrMerge(command);
+  // When both verbs appear (compound command), apply the stricter merge gate.
+  const pr = isMerge ? extractPrNumberFromGhPrMerge(command) : extractPrNumberFromGhPrReady(command);
   if (pr !== null && repoRoot) {
     // Each gate script is overridable for deterministic testing (stub instead of the
     // network-touching real guard). `gh pr ready` → draft-gate only; `gh pr merge` → the full
     // pre-merge evidence check (draft_gate + pre_approval_gate).
-    const gateScript = isReady
-      ? process.env.DEVLOOPS_PRE_PR_READY_GATE_SCRIPT || path.join(repoRoot, "scripts/loop/pre-pr-ready-gate.mjs")
-      : process.env.DEVLOOPS_PRE_MERGE_GATE_SCRIPT ||
-        path.join(repoRoot, "scripts/github/detect-checkpoint-evidence.mjs");
+    const gateScript = isMerge
+      ? process.env.DEVLOOPS_PRE_MERGE_GATE_SCRIPT ||
+        path.join(repoRoot, "scripts/github/detect-checkpoint-evidence.mjs")
+      : process.env.DEVLOOPS_PRE_PR_READY_GATE_SCRIPT || path.join(repoRoot, "scripts/loop/pre-pr-ready-gate.mjs");
     try {
       execFileSync("node", [gateScript, "--repo", repoSlug, "--pr", String(pr)], {
         cwd: repoRoot,

--- a/.claude/hooks/pre-tool-use-bash-gate.mjs
+++ b/.claude/hooks/pre-tool-use-bash-gate.mjs
@@ -14,10 +14,10 @@ import path from "node:path";
 
 import { decideBashGate } from "./_hook-decisions.mjs";
 import {
-  isGhPrReadyCommand,
-  isGhPrMergeCommand,
-  extractPrNumberFromGhPrReady,
-  extractPrNumberFromGhPrMerge,
+  commandContainsGhPrReady,
+  commandContainsGhPrMerge,
+  extractPrNumberFromGhPrReadyAnywhere,
+  extractPrNumberFromGhPrMergeAnywhere,
   normalizeGitHubRepoSlug,
   TARGET_REPO_SLUG,
 } from "./_bash-command-classify.mjs";
@@ -26,8 +26,8 @@ import { readHookInput, emitDeny, emitAllow } from "./_hook-io.mjs";
 
 const input = readHookInput();
 const command = input?.tool_input?.command;
-const isReady = typeof command === "string" && isGhPrReadyCommand(command);
-const isMerge = typeof command === "string" && isGhPrMergeCommand(command);
+const isReady = typeof command === "string" && commandContainsGhPrReady(command);
+const isMerge = typeof command === "string" && commandContainsGhPrMerge(command);
 if (!isReady && !isMerge) {
   emitAllow();
 }
@@ -51,7 +51,7 @@ let gatePassed = false;
 let gateError = null;
 if (repoSlug === TARGET_REPO_SLUG) {
   // When both verbs appear (compound command), apply the stricter merge gate.
-  const pr = isMerge ? extractPrNumberFromGhPrMerge(command) : extractPrNumberFromGhPrReady(command);
+  const pr = isMerge ? extractPrNumberFromGhPrMergeAnywhere(command) : extractPrNumberFromGhPrReadyAnywhere(command);
   if (pr !== null && repoRoot) {
     // Each gate script is overridable for deterministic testing (stub instead of the
     // network-touching real guard). `gh pr ready` → draft-gate only; `gh pr merge` → the full

--- a/packages/core/src/claude/hook-decisions.mjs
+++ b/packages/core/src/claude/hook-decisions.mjs
@@ -59,14 +59,15 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
     return ALLOW;
   }
   const isReady = isGhPrReadyCommand(command);
-  const isMerge = !isReady && isGhPrMergeCommand(command);
+  const isMerge = isGhPrMergeCommand(command);
   if (!isReady && !isMerge) {
     return ALLOW;
   }
-
-  const verb = isReady ? "gh pr ready" : "gh pr merge";
+  // When both verbs appear in a compound command, apply the stricter merge gate — if it passes,
+  // the draft_gate (a subset of the pre-merge evidence check) is also satisfied.
+  const verb = isMerge ? "gh pr merge" : "gh pr ready";
   // An explicit `--repo other/repo` that is not the target → not our concern, pass through.
-  const explicitRepo = isReady ? extractRepoFlagFromGhPrReady(command) : extractRepoFlagFromGhPrMerge(command);
+  const explicitRepo = isMerge ? extractRepoFlagFromGhPrMerge(command) : extractRepoFlagFromGhPrReady(command);
   if (explicitRepo && explicitRepo.toLowerCase() !== TARGET_REPO_SLUG.toLowerCase()) {
     return ALLOW;
   }
@@ -75,7 +76,7 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
     return ALLOW;
   }
 
-  const prNumber = isReady ? extractPrNumberFromGhPrReady(command) : extractPrNumberFromGhPrMerge(command);
+  const prNumber = isMerge ? extractPrNumberFromGhPrMerge(command) : extractPrNumberFromGhPrReady(command);
   if (prNumber === null) {
     return {
       decision: "deny",
@@ -84,7 +85,7 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
   }
 
   if (gateError) {
-    const which = isReady ? "draft-gate" : "pre-merge gate";
+    const which = isMerge ? "pre-merge gate" : "draft-gate";
     return {
       decision: "deny",
       reason: `${verb} blocked: ${which} evidence check failed (${gateError}).`,
@@ -94,9 +95,9 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
   if (!gatePassed) {
     return {
       decision: "deny",
-      reason: isReady
-        ? `gh pr ready blocked: no visible clean draft_gate checkpoint verdict comment found for PR #${prNumber}.`
-        : `gh pr merge blocked: missing pre-merge gate evidence for PR #${prNumber} (need clean current-head draft_gate + pre_approval_gate; inline verdicts are not accepted). Run the dev-loop gates instead of merging directly.`,
+      reason: isMerge
+        ? `gh pr merge blocked: missing pre-merge gate evidence for PR #${prNumber} (need clean current-head draft_gate + pre_approval_gate; inline verdicts are not accepted). Run the dev-loop gates instead of merging directly.`
+        : `gh pr ready blocked: no visible clean draft_gate checkpoint verdict comment found for PR #${prNumber}.`,
     };
   }
 

--- a/packages/core/src/claude/hook-decisions.mjs
+++ b/packages/core/src/claude/hook-decisions.mjs
@@ -14,6 +14,9 @@ import {
   isGhPrReadyCommand,
   extractPrNumberFromGhPrReady,
   extractRepoFlagFromGhPrReady,
+  isGhPrMergeCommand,
+  extractPrNumberFromGhPrMerge,
+  extractRepoFlagFromGhPrMerge,
   TARGET_REPO_SLUG,
 } from "../loop/bash-command-classify.mjs";
 
@@ -33,26 +36,37 @@ const ALLOW = Object.freeze({ decision: "allow" });
 export const DEV_LOOP_AGENT_TYPE = "dev-loop";
 
 /**
- * Decide whether a PreToolUse Bash command must be blocked by the draft-gate boundary.
+ * Decide whether a PreToolUse Bash command must be blocked by a dev-loop gate boundary.
  *
- * Mirrors the Pi extension's `onUserBash`: the only blocked case is `gh pr ready` for the
- * target repo without clean draft_gate evidence. Everything else (including merges, which
- * trigger the post-merge step, not a block) is allowed through.
+ * Two gated commands on the target repo:
+ *   - `gh pr ready` — blocked without clean draft_gate evidence (`pre-pr-ready-gate`).
+ *   - `gh pr merge` — blocked without the full pre-merge gate evidence (`detect-checkpoint-evidence`:
+ *     clean current-head draft_gate + pre_approval_gate). The loop runs this check before merging;
+ *     gating it here closes the hole where a hand-run `gh pr merge` skips the pre-approval gate
+ *     entirely. Everything else passes through.
+ *
+ * The hook computes `gatePassed`/`gateError` from the gate script appropriate to the command kind.
  *
  * @param {Object} params
  * @param {string} params.command - The Bash command string.
  * @param {string|null} [params.repoSlug] - Resolved owner/name of the cwd repo (null if unknown).
- * @param {boolean} [params.gatePassed] - Whether `pre-pr-ready-gate` evidence exists for the PR.
+ * @param {boolean} [params.gatePassed] - Whether the relevant gate evidence exists for the PR.
  * @param {string|null} [params.gateError] - Error detail when the gate guard could not run.
  * @returns {HookDecision}
  */
 export function decideBashGate({ command, repoSlug = null, gatePassed = false, gateError = null }) {
-  if (typeof command !== "string" || !isGhPrReadyCommand(command)) {
+  if (typeof command !== "string") {
+    return ALLOW;
+  }
+  const isReady = isGhPrReadyCommand(command);
+  const isMerge = !isReady && isGhPrMergeCommand(command);
+  if (!isReady && !isMerge) {
     return ALLOW;
   }
 
+  const verb = isReady ? "gh pr ready" : "gh pr merge";
   // An explicit `--repo other/repo` that is not the target → not our concern, pass through.
-  const explicitRepo = extractRepoFlagFromGhPrReady(command);
+  const explicitRepo = isReady ? extractRepoFlagFromGhPrReady(command) : extractRepoFlagFromGhPrMerge(command);
   if (explicitRepo && explicitRepo.toLowerCase() !== TARGET_REPO_SLUG.toLowerCase()) {
     return ALLOW;
   }
@@ -61,26 +75,28 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
     return ALLOW;
   }
 
-  const prNumber = extractPrNumberFromGhPrReady(command);
+  const prNumber = isReady ? extractPrNumberFromGhPrReady(command) : extractPrNumberFromGhPrMerge(command);
   if (prNumber === null) {
     return {
       decision: "deny",
-      reason:
-        "gh pr ready blocked: could not determine the PR number from the command. Include the PR number explicitly.",
+      reason: `${verb} blocked: could not determine the PR number from the command. Include the PR number explicitly.`,
     };
   }
 
   if (gateError) {
+    const which = isReady ? "draft-gate" : "pre-merge gate";
     return {
       decision: "deny",
-      reason: `gh pr ready blocked: draft-gate evidence check failed (${gateError}).`,
+      reason: `${verb} blocked: ${which} evidence check failed (${gateError}).`,
     };
   }
 
   if (!gatePassed) {
     return {
       decision: "deny",
-      reason: `gh pr ready blocked: no visible clean draft_gate checkpoint verdict comment found for PR #${prNumber}.`,
+      reason: isReady
+        ? `gh pr ready blocked: no visible clean draft_gate checkpoint verdict comment found for PR #${prNumber}.`
+        : `gh pr merge blocked: missing pre-merge gate evidence for PR #${prNumber} (need clean current-head draft_gate + pre_approval_gate; inline verdicts are not accepted). Run the dev-loop gates instead of merging directly.`,
     };
   }
 

--- a/packages/core/src/claude/hook-decisions.mjs
+++ b/packages/core/src/claude/hook-decisions.mjs
@@ -11,12 +11,12 @@
 
 import { resolveRunId } from "../loop/run-context.mjs";
 import {
-  isGhPrReadyCommand,
-  extractPrNumberFromGhPrReady,
-  extractRepoFlagFromGhPrReady,
-  isGhPrMergeCommand,
-  extractPrNumberFromGhPrMerge,
-  extractRepoFlagFromGhPrMerge,
+  commandContainsGhPrReady,
+  commandContainsGhPrMerge,
+  extractPrNumberFromGhPrReadyAnywhere,
+  extractRepoFlagFromGhPrReadyAnywhere,
+  extractPrNumberFromGhPrMergeAnywhere,
+  extractRepoFlagFromGhPrMergeAnywhere,
   TARGET_REPO_SLUG,
 } from "../loop/bash-command-classify.mjs";
 
@@ -58,8 +58,12 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
   if (typeof command !== "string") {
     return ALLOW;
   }
-  const isReady = isGhPrReadyCommand(command);
-  const isMerge = isGhPrMergeCommand(command);
+  // Scan ALL shell segments — the PreToolUse gate blocks pre-emptively, so a gated verb in any
+  // segment (even after `&&` or `;`) must be caught. This differs from the Pi extension's
+  // post-execute `isGhPrReadyCommand`/`isGhPrMergeCommand` which scan only the first segment
+  // (correct there: `false && gh pr ready 42` short-circuits so ready never ran).
+  const isReady = commandContainsGhPrReady(command);
+  const isMerge = commandContainsGhPrMerge(command);
   if (!isReady && !isMerge) {
     return ALLOW;
   }
@@ -67,7 +71,9 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
   // the draft_gate (a subset of the pre-merge evidence check) is also satisfied.
   const verb = isMerge ? "gh pr merge" : "gh pr ready";
   // An explicit `--repo other/repo` that is not the target → not our concern, pass through.
-  const explicitRepo = isMerge ? extractRepoFlagFromGhPrMerge(command) : extractRepoFlagFromGhPrReady(command);
+  const explicitRepo = isMerge
+    ? extractRepoFlagFromGhPrMergeAnywhere(command)
+    : extractRepoFlagFromGhPrReadyAnywhere(command);
   if (explicitRepo && explicitRepo.toLowerCase() !== TARGET_REPO_SLUG.toLowerCase()) {
     return ALLOW;
   }
@@ -76,7 +82,9 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
     return ALLOW;
   }
 
-  const prNumber = isMerge ? extractPrNumberFromGhPrMerge(command) : extractPrNumberFromGhPrReady(command);
+  const prNumber = isMerge
+    ? extractPrNumberFromGhPrMergeAnywhere(command)
+    : extractPrNumberFromGhPrReadyAnywhere(command);
   if (prNumber === null) {
     return {
       decision: "deny",

--- a/packages/core/src/loop/bash-command-classify.mjs
+++ b/packages/core/src/loop/bash-command-classify.mjs
@@ -50,7 +50,7 @@ export function normalizeGitHubRepoSlug(remoteUrl) {
   return null;
 }
 
-function isGhPrMergeCommand(segment) {
+function segmentIsGhPrMerge(segment) {
   if (!/^gh\s+pr\s+merge(?:\s|$)/i.test(segment)) {
     return false;
   }
@@ -82,7 +82,7 @@ export function isMergeCapableCommand(command) {
   }
   return normalized
     .split(/\s*(?:&&|\|\||;|\|)\s*/)
-    .some((segment) => isGhPrMergeCommand(segment) || isGitMergeCompletionCommand(segment));
+    .some((segment) => segmentIsGhPrMerge(segment) || isGitMergeCompletionCommand(segment));
 }
 
 /** @param {string} command @returns {string} */
@@ -90,13 +90,19 @@ export function firstShellSegment(command) {
   return command.trim().split(/\s*(?:&&|\|\||;|\|)\s*/)[0]?.trim() ?? "";
 }
 
-/** @param {string} command @returns {boolean} */
-export function isGhPrReadyCommand(command) {
+/** Build the `^gh pr <verb>` prefix matcher for a `gh pr <verb>` subcommand. */
+function ghPrVerbRegex(verb) {
+  return new RegExp(`^gh\\s+pr\\s+${verb}(?:\\s|$)`, "i");
+}
+
+/** Generic `gh pr <verb>` (first-segment) detector, ignoring `--help`/`-h`. */
+function isGhPrVerbCommand(command, verb) {
   const segment = firstShellSegment(command);
-  if (!segment || !/^gh\s+pr\s+ready(?:\s|$)/i.test(segment)) {
+  const re = ghPrVerbRegex(verb);
+  if (!segment || !re.test(segment)) {
     return false;
   }
-  const remainder = segment.replace(/^gh\s+pr\s+ready(?:\s|$)/i, "").trim();
+  const remainder = segment.replace(re, "").trim();
   if (!remainder) {
     return true;
   }
@@ -104,13 +110,14 @@ export function isGhPrReadyCommand(command) {
   return !args.includes("--help") && !args.includes("-h");
 }
 
-/** @param {string} command @returns {number|null} */
-export function extractPrNumberFromGhPrReady(command) {
+/** Generic positional PR-number extractor for `gh pr <verb>`. */
+function extractPrNumberFromGhPrVerb(command, verb) {
   const segment = firstShellSegment(command);
-  if (!/^gh\s+pr\s+ready(?:\s|$)/i.test(segment)) {
+  const re = ghPrVerbRegex(verb);
+  if (!re.test(segment)) {
     return null;
   }
-  const remainder = segment.replace(/^gh\s+pr\s+ready(?:\s|$)/i, "").trim();
+  const remainder = segment.replace(re, "").trim();
   if (!remainder) {
     return null;
   }
@@ -135,13 +142,14 @@ export function extractPrNumberFromGhPrReady(command) {
   return null;
 }
 
-/** @param {string} command @returns {string|null} */
-export function extractRepoFlagFromGhPrReady(command) {
+/** Generic `--repo`/`-R` extractor for `gh pr <verb>`. */
+function extractRepoFlagFromGhPrVerb(command, verb) {
   const segment = firstShellSegment(command);
-  if (!/^gh\s+pr\s+ready(?:\s|$)/i.test(segment)) {
+  const re = ghPrVerbRegex(verb);
+  if (!re.test(segment)) {
     return null;
   }
-  const remainder = segment.replace(/^gh\s+pr\s+ready(?:\s|$)/i, "").trim();
+  const remainder = segment.replace(re, "").trim();
   if (!remainder) {
     return null;
   }
@@ -160,4 +168,40 @@ export function extractRepoFlagFromGhPrReady(command) {
     }
   }
   return null;
+}
+
+/** @param {string} command @returns {boolean} */
+export function isGhPrReadyCommand(command) {
+  return isGhPrVerbCommand(command, "ready");
+}
+
+/** @param {string} command @returns {number|null} */
+export function extractPrNumberFromGhPrReady(command) {
+  return extractPrNumberFromGhPrVerb(command, "ready");
+}
+
+/** @param {string} command @returns {string|null} */
+export function extractRepoFlagFromGhPrReady(command) {
+  return extractRepoFlagFromGhPrVerb(command, "ready");
+}
+
+/**
+ * Whether `command` is a `gh pr merge` invocation (first segment), ignoring `--help`/`-h`.
+ * Used by the PreToolUse gate to block a direct merge that bypasses the dev-loop's pre-merge
+ * gate-evidence check — the loop normally runs `detect-checkpoint-evidence` before merging, but
+ * a hand-run `gh pr merge` would otherwise skip it.
+ * @param {string} command @returns {boolean}
+ */
+export function isGhPrMergeCommand(command) {
+  return isGhPrVerbCommand(command, "merge");
+}
+
+/** @param {string} command @returns {number|null} */
+export function extractPrNumberFromGhPrMerge(command) {
+  return extractPrNumberFromGhPrVerb(command, "merge");
+}
+
+/** @param {string} command @returns {string|null} */
+export function extractRepoFlagFromGhPrMerge(command) {
+  return extractRepoFlagFromGhPrVerb(command, "merge");
 }

--- a/packages/core/src/loop/bash-command-classify.mjs
+++ b/packages/core/src/loop/bash-command-classify.mjs
@@ -116,16 +116,30 @@ function findGhPrVerbSegment(command, verb) {
   return null;
 }
 
-/** Generic `gh pr <verb>` detector that scans ALL shell segments. */
+/**
+ * Generic `gh pr <verb>` detector — checks the FIRST shell segment only.
+ *
+ * Used by the Pi extension's post-execute handler (`onUserBash`) to record that `gh pr ready`
+ * actually ran. First-segment-only is correct for that use: `false && gh pr ready 42` short-
+ * circuits so ready never executes, and the extension should not record a spurious invocation.
+ *
+ * For the Claude Code PreToolUse gate (block before execution), use
+ * `commandContainsGhPrReady`/`commandContainsGhPrMerge` instead — those scan ALL segments.
+ */
 function isGhPrVerbCommand(command, verb) {
-  return findGhPrVerbSegment(command, verb) !== null;
+  const re = ghPrVerbRegex(verb);
+  const segment = firstShellSegment(command);
+  if (!segment || !re.test(segment)) return false;
+  const remainder = segment.replace(re, "").trim();
+  if (!remainder) return true;
+  const args = remainder.split(/\s+/).map((a) => a.toLowerCase());
+  return !args.includes("--help") && !args.includes("-h");
 }
 
-/** Generic positional PR-number extractor for `gh pr <verb>` — finds the verb segment first. */
-function extractPrNumberFromGhPrVerb(command, verb) {
-  const segment = findGhPrVerbSegment(command, verb);
-  if (!segment) return null;
+/** Extract PR number from a single already-isolated segment (shared by both first- and all-segment paths). */
+function extractPrNumberFromSegment(segment, verb) {
   const re = ghPrVerbRegex(verb);
+  if (!segment || !re.test(segment)) return null;
   const remainder = segment.replace(re, "").trim();
   if (!remainder) {
     return null;
@@ -151,11 +165,10 @@ function extractPrNumberFromGhPrVerb(command, verb) {
   return null;
 }
 
-/** Generic `--repo`/`-R` extractor for `gh pr <verb>` — finds the verb segment first. */
-function extractRepoFlagFromGhPrVerb(command, verb) {
-  const segment = findGhPrVerbSegment(command, verb);
-  if (!segment) return null;
+/** Extract repo flag from a single already-isolated segment. */
+function extractRepoFlagFromSegment(segment, verb) {
   const re = ghPrVerbRegex(verb);
+  if (!segment || !re.test(segment)) return null;
   const remainder = segment.replace(re, "").trim();
   if (!remainder) {
     return null;
@@ -177,6 +190,16 @@ function extractRepoFlagFromGhPrVerb(command, verb) {
   return null;
 }
 
+/** First-segment extractor for `gh pr <verb>` PR number — Pi extension public API. */
+function extractPrNumberFromGhPrVerb(command, verb) {
+  return extractPrNumberFromSegment(firstShellSegment(command), verb);
+}
+
+/** First-segment extractor for `gh pr <verb>` --repo flag — Pi extension public API. */
+function extractRepoFlagFromGhPrVerb(command, verb) {
+  return extractRepoFlagFromSegment(firstShellSegment(command), verb);
+}
+
 /** @param {string} command @returns {boolean} */
 export function isGhPrReadyCommand(command) {
   return isGhPrVerbCommand(command, "ready");
@@ -193,14 +216,52 @@ export function extractRepoFlagFromGhPrReady(command) {
 }
 
 /**
- * Whether `command` contains a `gh pr merge` invocation in any shell segment, ignoring `--help`/`-h`.
- * Used by the PreToolUse gate to block a direct merge that bypasses the dev-loop's pre-merge
- * gate-evidence check — the loop normally runs `detect-checkpoint-evidence` before merging, but
- * a hand-run `gh pr merge` would otherwise skip it.
+ * Whether `command` contains a `gh pr merge` invocation in the FIRST shell segment,
+ * ignoring `--help`/`-h`. Used by the Pi extension's post-execute handler.
+ * For the Claude Code PreToolUse gate, use `commandContainsGhPrMerge` instead.
  * @param {string} command @returns {boolean}
  */
 export function isGhPrMergeCommand(command) {
   return isGhPrVerbCommand(command, "merge");
+}
+
+/**
+ * Whether `command` contains a `gh pr ready` invocation in ANY shell segment.
+ * For use in the Claude Code PreToolUse gate only — blocks the whole command pre-emptively
+ * regardless of shell short-circuit semantics (`false && gh pr ready 42` is still blocked).
+ * @param {string} command @returns {boolean}
+ */
+export function commandContainsGhPrReady(command) {
+  return findGhPrVerbSegment(command, "ready") !== null;
+}
+
+/**
+ * Whether `command` contains a `gh pr merge` invocation in ANY shell segment.
+ * For use in the Claude Code PreToolUse gate only — blocks the whole command pre-emptively.
+ * @param {string} command @returns {boolean}
+ */
+export function commandContainsGhPrMerge(command) {
+  return findGhPrVerbSegment(command, "merge") !== null;
+}
+
+/** Extract PR number from `gh pr ready` in any shell segment — PreToolUse gate use only. */
+export function extractPrNumberFromGhPrReadyAnywhere(command) {
+  return extractPrNumberFromSegment(findGhPrVerbSegment(command, "ready"), "ready");
+}
+
+/** @param {string} command @returns {string|null} */
+export function extractRepoFlagFromGhPrReadyAnywhere(command) {
+  return extractRepoFlagFromSegment(findGhPrVerbSegment(command, "ready"), "ready");
+}
+
+/** Extract PR number from `gh pr merge` in any shell segment — PreToolUse gate use only. */
+export function extractPrNumberFromGhPrMergeAnywhere(command) {
+  return extractPrNumberFromSegment(findGhPrVerbSegment(command, "merge"), "merge");
+}
+
+/** @param {string} command @returns {string|null} */
+export function extractRepoFlagFromGhPrMergeAnywhere(command) {
+  return extractRepoFlagFromSegment(findGhPrVerbSegment(command, "merge"), "merge");
 }
 
 /** @param {string} command @returns {number|null} */

--- a/packages/core/src/loop/bash-command-classify.mjs
+++ b/packages/core/src/loop/bash-command-classify.mjs
@@ -193,7 +193,7 @@ export function extractRepoFlagFromGhPrReady(command) {
 }
 
 /**
- * Whether `command` is a `gh pr merge` invocation (first segment), ignoring `--help`/`-h`.
+ * Whether `command` contains a `gh pr merge` invocation in any shell segment, ignoring `--help`/`-h`.
  * Used by the PreToolUse gate to block a direct merge that bypasses the dev-loop's pre-merge
  * gate-evidence check — the loop normally runs `detect-checkpoint-evidence` before merging, but
  * a hand-run `gh pr merge` would otherwise skip it.

--- a/packages/core/src/loop/bash-command-classify.mjs
+++ b/packages/core/src/loop/bash-command-classify.mjs
@@ -90,33 +90,42 @@ export function firstShellSegment(command) {
   return command.trim().split(/\s*(?:&&|\|\||;|\|)\s*/)[0]?.trim() ?? "";
 }
 
+/** Split a compound shell command into its individual segments. */
+function shellSegments(command) {
+  return command.trim().split(/\s*(?:&&|\|\||;|\|)\s*/).map((s) => s.trim()).filter(Boolean);
+}
+
 /** Build the `^gh pr <verb>` prefix matcher for a `gh pr <verb>` subcommand. */
 function ghPrVerbRegex(verb) {
   return new RegExp(`^gh\\s+pr\\s+${verb}(?:\\s|$)`, "i");
 }
 
-/** Generic `gh pr <verb>` (first-segment) detector, ignoring `--help`/`-h`. */
-function isGhPrVerbCommand(command, verb) {
-  const segment = firstShellSegment(command);
+/**
+ * Return the first segment in the command that is a `gh pr <verb>` call (ignoring --help/-h),
+ * or null. Scans ALL segments so compound commands (`echo ok && gh pr merge 1`) are caught.
+ */
+function findGhPrVerbSegment(command, verb) {
   const re = ghPrVerbRegex(verb);
-  if (!segment || !re.test(segment)) {
-    return false;
+  for (const segment of shellSegments(command)) {
+    if (!re.test(segment)) continue;
+    const remainder = segment.replace(re, "").trim();
+    if (!remainder) return segment;
+    const args = remainder.split(/\s+/).map((a) => a.toLowerCase());
+    if (!args.includes("--help") && !args.includes("-h")) return segment;
   }
-  const remainder = segment.replace(re, "").trim();
-  if (!remainder) {
-    return true;
-  }
-  const args = remainder.split(/\s+/).map((a) => a.toLowerCase());
-  return !args.includes("--help") && !args.includes("-h");
+  return null;
 }
 
-/** Generic positional PR-number extractor for `gh pr <verb>`. */
+/** Generic `gh pr <verb>` detector that scans ALL shell segments. */
+function isGhPrVerbCommand(command, verb) {
+  return findGhPrVerbSegment(command, verb) !== null;
+}
+
+/** Generic positional PR-number extractor for `gh pr <verb>` — finds the verb segment first. */
 function extractPrNumberFromGhPrVerb(command, verb) {
-  const segment = firstShellSegment(command);
+  const segment = findGhPrVerbSegment(command, verb);
+  if (!segment) return null;
   const re = ghPrVerbRegex(verb);
-  if (!re.test(segment)) {
-    return null;
-  }
   const remainder = segment.replace(re, "").trim();
   if (!remainder) {
     return null;
@@ -142,13 +151,11 @@ function extractPrNumberFromGhPrVerb(command, verb) {
   return null;
 }
 
-/** Generic `--repo`/`-R` extractor for `gh pr <verb>`. */
+/** Generic `--repo`/`-R` extractor for `gh pr <verb>` — finds the verb segment first. */
 function extractRepoFlagFromGhPrVerb(command, verb) {
-  const segment = firstShellSegment(command);
+  const segment = findGhPrVerbSegment(command, verb);
+  if (!segment) return null;
   const re = ghPrVerbRegex(verb);
-  if (!re.test(segment)) {
-    return null;
-  }
   const remainder = segment.replace(re, "").trim();
   if (!remainder) {
     return null;

--- a/packages/core/test/bash-command-classify.test.mjs
+++ b/packages/core/test/bash-command-classify.test.mjs
@@ -11,6 +11,10 @@ import {
   isGhPrMergeCommand,
   extractPrNumberFromGhPrMerge,
   extractRepoFlagFromGhPrMerge,
+  commandContainsGhPrReady,
+  commandContainsGhPrMerge,
+  extractPrNumberFromGhPrMergeAnywhere,
+  extractRepoFlagFromGhPrMergeAnywhere,
 } from "../src/loop/bash-command-classify.mjs";
 
 test("TARGET_REPO_SLUG is the dev-loops repo", () => {
@@ -46,19 +50,32 @@ test("extractRepoFlagFromGhPrReady reads -r/--repo and --repo=value", () => {
   assert.equal(extractRepoFlagFromGhPrReady("gh pr ready 1"), null);
 });
 
-test("isGhPrMergeCommand recognizes gh pr merge in any segment and ignores --help", () => {
+test("isGhPrMergeCommand (first-segment, Pi extension) recognizes gh pr merge and ignores --help", () => {
   assert.equal(isGhPrMergeCommand("gh pr merge 1023 --squash"), true);
   assert.equal(isGhPrMergeCommand("gh pr merge"), true);
   assert.equal(isGhPrMergeCommand("gh pr merge --help"), false);
   assert.equal(isGhPrMergeCommand("gh pr ready 17"), false);
-  // Compound command — merge in later segment must be detected.
-  assert.equal(isGhPrMergeCommand("echo ok && gh pr merge 1 --squash"), true);
-  assert.equal(isGhPrMergeCommand("gh pr ready 1 && gh pr merge 1"), true);
+  // First-segment-only: merge in later segment is NOT detected (correct for post-execute use).
+  assert.equal(isGhPrMergeCommand("echo ok && gh pr merge 1 --squash"), false);
 });
 
-test("isGhPrReadyCommand recognizes gh pr ready in any segment", () => {
-  assert.equal(isGhPrReadyCommand("echo ok && gh pr ready 17"), true);
-  assert.equal(isGhPrReadyCommand("gh pr ready 17 && echo done"), true);
+test("commandContainsGhPrReady (all-segments, PreToolUse gate) detects ready in any segment", () => {
+  assert.equal(commandContainsGhPrReady("gh pr ready 17"), true);
+  assert.equal(commandContainsGhPrReady("echo ok && gh pr ready 17"), true);
+  assert.equal(commandContainsGhPrReady("false && gh pr ready 42"), true);
+  assert.equal(commandContainsGhPrReady("gh pr merge 1"), false);
+});
+
+test("commandContainsGhPrMerge (all-segments, PreToolUse gate) detects merge in any segment", () => {
+  assert.equal(commandContainsGhPrMerge("gh pr merge 1 --squash"), true);
+  assert.equal(commandContainsGhPrMerge("echo ok && gh pr merge 1 --squash"), true);
+  assert.equal(commandContainsGhPrMerge("gh pr ready 1 && gh pr merge 1"), true);
+  assert.equal(commandContainsGhPrMerge("gh pr ready 17"), false);
+});
+
+test("extractPrNumberFromGhPrMergeAnywhere finds merge PR number in any segment", () => {
+  assert.equal(extractPrNumberFromGhPrMergeAnywhere("echo ok && gh pr merge 42 --squash"), 42);
+  assert.equal(extractRepoFlagFromGhPrMergeAnywhere("echo ok && gh pr merge --repo other/repo 1"), "other/repo");
 });
 
 test("extractPrNumber/RepoFlag FromGhPrMerge mirror the ready extractors", () => {

--- a/packages/core/test/bash-command-classify.test.mjs
+++ b/packages/core/test/bash-command-classify.test.mjs
@@ -8,6 +8,9 @@ import {
   isGhPrReadyCommand,
   extractPrNumberFromGhPrReady,
   extractRepoFlagFromGhPrReady,
+  isGhPrMergeCommand,
+  extractPrNumberFromGhPrMerge,
+  extractRepoFlagFromGhPrMerge,
 } from "../src/loop/bash-command-classify.mjs";
 
 test("TARGET_REPO_SLUG is the dev-loops repo", () => {
@@ -41,6 +44,22 @@ test("extractRepoFlagFromGhPrReady reads -r/--repo and --repo=value", () => {
   assert.equal(extractRepoFlagFromGhPrReady("gh pr ready --repo other/repo 1"), "other/repo");
   assert.equal(extractRepoFlagFromGhPrReady("gh pr ready --repo=other/repo 1"), "other/repo");
   assert.equal(extractRepoFlagFromGhPrReady("gh pr ready 1"), null);
+});
+
+test("isGhPrMergeCommand recognizes gh pr merge (first segment) and ignores --help", () => {
+  assert.equal(isGhPrMergeCommand("gh pr merge 1023 --squash"), true);
+  assert.equal(isGhPrMergeCommand("gh pr merge"), true);
+  assert.equal(isGhPrMergeCommand("gh pr merge --help"), false);
+  assert.equal(isGhPrMergeCommand("gh pr ready 17"), false);
+});
+
+test("extractPrNumber/RepoFlag FromGhPrMerge mirror the ready extractors", () => {
+  assert.equal(extractPrNumberFromGhPrMerge("gh pr merge 1023 --squash"), 1023);
+  assert.equal(extractPrNumberFromGhPrMerge("gh pr merge --repo mfittko/dev-loops 42"), 42);
+  assert.equal(extractPrNumberFromGhPrMerge("gh pr merge --squash"), null);
+  assert.equal(extractRepoFlagFromGhPrMerge("gh pr merge --repo other/repo 1"), "other/repo");
+  assert.equal(extractRepoFlagFromGhPrMerge("gh pr merge --repo=other/repo 1"), "other/repo");
+  assert.equal(extractRepoFlagFromGhPrMerge("gh pr merge 1"), null);
 });
 
 test("isMergeCapableCommand detects gh pr merge / git merge, ignores aborts and help", () => {

--- a/packages/core/test/bash-command-classify.test.mjs
+++ b/packages/core/test/bash-command-classify.test.mjs
@@ -46,11 +46,19 @@ test("extractRepoFlagFromGhPrReady reads -r/--repo and --repo=value", () => {
   assert.equal(extractRepoFlagFromGhPrReady("gh pr ready 1"), null);
 });
 
-test("isGhPrMergeCommand recognizes gh pr merge (first segment) and ignores --help", () => {
+test("isGhPrMergeCommand recognizes gh pr merge in any segment and ignores --help", () => {
   assert.equal(isGhPrMergeCommand("gh pr merge 1023 --squash"), true);
   assert.equal(isGhPrMergeCommand("gh pr merge"), true);
   assert.equal(isGhPrMergeCommand("gh pr merge --help"), false);
   assert.equal(isGhPrMergeCommand("gh pr ready 17"), false);
+  // Compound command — merge in later segment must be detected.
+  assert.equal(isGhPrMergeCommand("echo ok && gh pr merge 1 --squash"), true);
+  assert.equal(isGhPrMergeCommand("gh pr ready 1 && gh pr merge 1"), true);
+});
+
+test("isGhPrReadyCommand recognizes gh pr ready in any segment", () => {
+  assert.equal(isGhPrReadyCommand("echo ok && gh pr ready 17"), true);
+  assert.equal(isGhPrReadyCommand("gh pr ready 17 && echo done"), true);
 });
 
 test("extractPrNumber/RepoFlag FromGhPrMerge mirror the ready extractors", () => {

--- a/packages/core/test/claude-hook-decisions.test.mjs
+++ b/packages/core/test/claude-hook-decisions.test.mjs
@@ -9,9 +9,9 @@ const TARGET = "mfittko/dev-loops";
 // decideBashGate
 // ---------------------------------------------------------------------------
 
-test("decideBashGate allows non-gh-pr-ready commands", () => {
+test("decideBashGate allows non-gated commands", () => {
   assert.equal(decideBashGate({ command: "npm test", repoSlug: TARGET }).decision, "allow");
-  assert.equal(decideBashGate({ command: "gh pr merge 1 --squash", repoSlug: TARGET }).decision, "allow");
+  assert.equal(decideBashGate({ command: "gh pr view 1", repoSlug: TARGET }).decision, "allow");
 });
 
 test("decideBashGate denies ungated gh pr ready in the target repo", () => {
@@ -19,6 +19,37 @@ test("decideBashGate denies ungated gh pr ready in the target repo", () => {
   assert.equal(d.decision, "deny");
   assert.match(d.reason, /no visible clean draft_gate/);
   assert.match(d.reason, /#17/);
+});
+
+// gh pr merge is gated on the full pre-merge evidence (draft_gate + pre_approval_gate); a direct
+// merge must not bypass the pre-approval gate the way a hand-run `gh pr merge` previously could.
+test("decideBashGate denies ungated gh pr merge in the target repo", () => {
+  const d = decideBashGate({ command: "gh pr merge 1 --squash", repoSlug: TARGET, gatePassed: false });
+  assert.equal(d.decision, "deny");
+  assert.match(d.reason, /gh pr merge blocked/);
+  assert.match(d.reason, /pre_approval_gate/);
+  assert.match(d.reason, /#1/);
+});
+
+test("decideBashGate allows gh pr merge when pre-merge evidence passed", () => {
+  assert.equal(
+    decideBashGate({ command: "gh pr merge 1 --squash", repoSlug: TARGET, gatePassed: true }).decision,
+    "allow",
+  );
+});
+
+test("decideBashGate passes through gh pr merge for a non-target --repo", () => {
+  assert.equal(
+    decideBashGate({ command: "gh pr merge --repo other/repo 1", repoSlug: TARGET, gatePassed: false }).decision,
+    "allow",
+  );
+});
+
+test("decideBashGate passes through gh pr merge outside the target repo", () => {
+  assert.equal(
+    decideBashGate({ command: "gh pr merge 1 --squash", repoSlug: "someone/else", gatePassed: false }).decision,
+    "allow",
+  );
 });
 
 test("decideBashGate allows gh pr ready when the draft gate passed", () => {

--- a/packages/core/test/claude-hook-decisions.test.mjs
+++ b/packages/core/test/claude-hook-decisions.test.mjs
@@ -52,6 +52,18 @@ test("decideBashGate passes through gh pr merge outside the target repo", () => 
   );
 });
 
+test("decideBashGate denies gh pr merge when PR number cannot be determined", () => {
+  const d = decideBashGate({ command: "gh pr merge --squash", repoSlug: TARGET, gatePassed: false });
+  assert.equal(d.decision, "deny");
+  assert.match(d.reason, /could not determine the PR number/);
+});
+
+test("decideBashGate denies with a pre-merge gate error reason for gh pr merge", () => {
+  const d = decideBashGate({ command: "gh pr merge 42", repoSlug: TARGET, gateError: "could not run the gate guard script" });
+  assert.equal(d.decision, "deny");
+  assert.match(d.reason, /pre-merge gate evidence check failed/);
+});
+
 test("decideBashGate allows gh pr ready when the draft gate passed", () => {
   assert.equal(decideBashGate({ command: "gh pr ready 17", repoSlug: TARGET, gatePassed: true }).decision, "allow");
 });

--- a/packages/core/test/claude-hook-decisions.test.mjs
+++ b/packages/core/test/claude-hook-decisions.test.mjs
@@ -52,6 +52,21 @@ test("decideBashGate passes through gh pr merge outside the target repo", () => 
   );
 });
 
+// Copilot review findings: compound command bypasses must be blocked.
+test("decideBashGate denies gh pr merge in a later compound segment", () => {
+  const d = decideBashGate({ command: "echo ok && gh pr merge 1 --squash", repoSlug: TARGET, gatePassed: false });
+  assert.equal(d.decision, "deny");
+  assert.match(d.reason, /gh pr merge blocked/);
+});
+
+test("decideBashGate applies the stricter merge gate when both ready and merge appear", () => {
+  // gh pr ready && gh pr merge — merge gate (stricter) must be applied, not just draft_gate.
+  const d = decideBashGate({ command: "gh pr ready 1 && gh pr merge 1", repoSlug: TARGET, gatePassed: false });
+  assert.equal(d.decision, "deny");
+  assert.match(d.reason, /gh pr merge blocked/);
+  assert.match(d.reason, /pre_approval_gate/);
+});
+
 test("decideBashGate denies gh pr merge when PR number cannot be determined", () => {
   const d = decideBashGate({ command: "gh pr merge --squash", repoSlug: TARGET, gatePassed: false });
   assert.equal(d.decision, "deny");

--- a/test/extension-post-merge-update.test.mjs
+++ b/test/extension-post-merge-update.test.mjs
@@ -333,6 +333,9 @@ test("isGhPrReadyCommand matches gh pr ready variants", () => {
   assert.equal(isGhPrReadyCommand("gh pr merge 42"), false);
   assert.equal(isGhPrReadyCommand("git merge origin/main"), false);
   assert.equal(isGhPrReadyCommand("echo gh pr ready"), false);
+  // Pi extension: first-segment-only (correct for post-execute detection — if false short-
+  // circuits &&, gh pr ready never ran). The Claude Code PreToolUse gate uses
+  // commandContainsGhPrReady which scans all segments for pre-emptive blocking.
   assert.equal(isGhPrReadyCommand("false && gh pr ready 42"), false);
   assert.equal(isGhPrReadyCommand("echo ok; gh pr ready 42"), false);
   assert.equal(isGhPrReadyCommand("gh pr ready 42 && echo ok"), true);
@@ -350,7 +353,7 @@ test("extractPrNumberFromGhPrReady extracts the PR number", () => {
   assert.equal(extractPrNumberFromGhPrReady("gh pr ready"), null);
   assert.equal(extractPrNumberFromGhPrReady("gh pr ready --help"), null);
   assert.equal(extractPrNumberFromGhPrReady("gh pr merge 42"), null);
-  assert.equal(extractPrNumberFromGhPrReady("false && gh pr ready 42"), null);
+  assert.equal(extractPrNumberFromGhPrReady("false && gh pr ready 42"), null); // first-segment only
 });
 
 test("extractRepoFlagFromGhPrReady extracts -R/--repo", () => {


### PR DESCRIPTION
## Summary

Closes the gate bypass discovered when PR #1023 was merged without running the pre-approval gate sub-loop. A hand-run `gh pr merge` was not blocked by the PreToolUse hook — only `gh pr ready` was. This meant the loop's pre-merge `detect-checkpoint-evidence` check (which requires both a clean current-head `draft_gate` + `pre_approval_gate` in `fanout_fanin` mode) could be skipped entirely.

**Root cause:** `decideBashGate` only matched `isGhPrReadyCommand`; merge fell through to `ALLOW`.

**Fix:** Gate `gh pr merge` on the target repo behind `detect-checkpoint-evidence.mjs` (exits 1 unless both gates present, inline verdicts rejected). Mirrors the existing `gh pr ready` → `pre-pr-ready-gate` pattern.

## Changes

- `bash-command-classify`: exported `isGhPrMergeCommand`, `extractPrNumberFromGhPrMerge`, `extractRepoFlagFromGhPrMerge` (via shared private verb helpers; `isMergeCapableCommand` unchanged)
- `hook-decisions`: `decideBashGate` now gates both `gh pr ready` and `gh pr merge`; clear deny message for merge cites the missing `pre_approval_gate`
- `pre-tool-use-bash-gate.mjs`: detects merge commands, runs `detect-checkpoint-evidence.mjs`; gate script overridable via `DEVLOOPS_PRE_MERGE_GATE_SCRIPT` for deterministic testing
- Regenerated `.claude/hooks/_bash-command-classify.mjs` + `_hook-decisions.mjs`
- +5 classifier tests, +4 decider tests; fix old test asserting `gh pr merge` was always allowed

## Test plan

- `node --test packages/core/test/bash-command-classify.test.mjs packages/core/test/claude-hook-decisions.test.mjs` — 38 pass
- End-to-end: hook emits `permissionDecision: deny` for `gh pr merge 1023 --squash` when stub gate exits 1; emits allow when gate exits 0; `git merge` and `gh pr view` pass through
- Drift check: `node scripts/claude/generate-claude-assets.mjs --check` → `{"ok":true,"checked":60}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)