### PR TITLE
docs(deck): port intro deck desktop UX

### DIFF
--- a/docs/presentations/introducing-dev-loops.html
+++ b/docs/presentations/introducing-dev-loops.html
@@ -104,19 +104,6 @@
     font-weight: 600;
   }
 
-  .part-tag {
-    display: inline-block;
-    text-transform: uppercase;
-    letter-spacing: 0.16em;
-    font-size: clamp(0.66rem, 0.75vw, 0.88rem);
-    font-weight: 700;
-    color: var(--accent-soft);
-    border: 1px solid rgba(167, 139, 250, 0.4);
-    border-radius: 9999px;
-    padding: clamp(0.2rem, 0.25vw, 0.32rem) clamp(0.7rem, 0.8vw, 1rem);
-    margin: 0 0 clamp(0.75rem, 0.9vw, 1.2rem);
-  }
-
   .glass-card, .hero-card, .metric-card {
     background: linear-gradient(180deg, rgba(15, 23, 42, 0.8), rgba(15, 23, 42, 0.62));
     border: 1px solid var(--card-border);
@@ -185,7 +172,6 @@
   .flow-card { justify-content: center; }
 
   .soft-note { color: var(--copy); margin-top: clamp(0.75rem, 0.9vw, 1.25rem); font-size: clamp(0.95rem, 1vw, 1.15rem); }
-  .section-lead { color: var(--copy); font-size: clamp(1rem, 1.1vw, 1.2rem); margin: 0 0 clamp(0.35rem, 0.45vw, 0.6rem); }
   .note-top-md { margin-top: clamp(0.65rem, 0.8vw, 1rem); }
   .note-top-sm { margin-top: clamp(0.4rem, 0.5vw, 0.65rem); }
   .card-label { color: var(--accent-soft); font-weight: 650; margin: 0 0 clamp(0.6rem, 0.7vw, 1rem); font-size: clamp(0.95rem, 1vw, 1.15rem); }

--- a/docs/presentations/introducing-dev-loops.html
+++ b/docs/presentations/introducing-dev-loops.html
@@ -485,6 +485,19 @@
   let cur = 0;
   const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
 
+  const currentSlideIndex = () => {
+    let best = cur;
+    let bestDistance = Infinity;
+    slides.forEach((slide, i) => {
+      const distance = Math.abs(slide.getBoundingClientRect().top);
+      if (distance < bestDistance) {
+        best = i;
+        bestDistance = distance;
+      }
+    });
+    return best;
+  };
+
   const observer = new IntersectionObserver(entries => {
     entries.forEach(e => {
       if (e.isIntersecting && e.intersectionRatio >= 0.5)
@@ -497,6 +510,7 @@
     if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return;
     const tag = document.activeElement ? document.activeElement.tagName : '';
     if (['INPUT', 'TEXTAREA', 'SELECT'].includes(tag) || document.activeElement.isContentEditable) return;
+    cur = currentSlideIndex();
     const behavior = reducedMotion.matches ? 'auto' : 'smooth';
     if (['ArrowDown', 'ArrowRight', 'PageDown', ' '].includes(e.key)) {
       e.preventDefault();

--- a/docs/presentations/introducing-dev-loops.html
+++ b/docs/presentations/introducing-dev-loops.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'" />
 <title>dev-loops: Introducing dev-loops</title>
 <style>
   :root {
@@ -23,12 +23,6 @@
   * { box-sizing: border-box; }
 
   html { scroll-behavior: smooth; }
-  @media (prefers-reduced-motion: reduce) {
-    html { scroll-behavior: auto; }
-    body { scroll-snap-type: none; }
-    .slide { scroll-snap-align: none; }
-  }
-
   body {
     margin: 0;
     font-family: var(--font);
@@ -36,7 +30,7 @@
     background: var(--ground-3);
     overflow-x: hidden;
     -webkit-text-size-adjust: 100%;
-    scroll-snap-type: y proximity;
+    scroll-snap-type: y mandatory;
     height: 100vh;
     overflow-y: auto;
   }
@@ -44,12 +38,10 @@
   .slide {
     position: relative;
     min-height: 100vh;
-    padding: clamp(2rem, 5vh, 3.5rem) clamp(1.25rem, 5vw, 3rem);
+    padding: clamp(2rem, 4vh, 4rem) clamp(1.25rem, 4vw, 4rem);
     display: flex;
     flex-direction: column;
     justify-content: center;
-    /* visible (not hidden): a slide taller than the viewport must grow and let
-       the page scroll, never clip its content at the bottom. */
     overflow: visible;
     scroll-snap-align: start;
     background:
@@ -57,6 +49,12 @@
       radial-gradient(circle at 15% 8%, rgba(59, 130, 246, 0.18), transparent 20%),
       linear-gradient(180deg, var(--ground-1) 0%, var(--ground-2) 42%, var(--ground-3) 100%);
     border-top: 1px solid rgba(148, 163, 184, 0.08);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    html { scroll-behavior: auto; }
+    body { scroll-snap-type: none; }
+    .slide { scroll-snap-align: none; }
   }
 
   .slide::before {
@@ -74,24 +72,14 @@
 
   .slide > * { position: relative; z-index: 1; }
 
-  .slide-inner {
-    width: 100%;
-    max-width: 72rem;
-    margin: 0 auto;
-  }
+  .slide-inner { width: 100%; max-width: 88rem; margin: 0 auto; }
 
-  h1, h2, h3 {
-    color: var(--heading);
-    letter-spacing: -0.02em;
-    line-height: 1.05;
-    margin-top: 0;
-  }
-
+  h1, h2, h3 { color: var(--heading); letter-spacing: -0.02em; line-height: 1.05; margin-top: 0; }
   h1 { font-weight: 760; margin-bottom: 0.6rem; }
-  h2 { margin-bottom: 1rem; font-size: clamp(1.5rem, 3.2vw, 2.2rem); font-weight: 720; }
+  h2 { margin-bottom: clamp(0.75rem, 1vw, 1.25rem); font-size: clamp(1.5rem, 3.2vw, 3rem); font-weight: 720; text-wrap: balance; }
   h3 { margin-bottom: 0.6rem; }
 
-  p, li { line-height: 1.5; overflow-wrap: anywhere; }
+  p, li { font-size: clamp(1rem, 1.1vw, 1.2rem); line-height: 1.55; overflow-wrap: anywhere; }
   strong { color: var(--accent-soft); }
   em { color: #e2e8f0; font-style: italic; }
 
@@ -110,22 +98,33 @@
   .kicker {
     text-transform: uppercase;
     letter-spacing: 0.14em;
-    font-size: 0.72rem;
+    font-size: clamp(0.72rem, 0.85vw, 1.05rem);
     color: var(--kicker);
-    margin: 0 0 0.45rem;
+    margin: 0 0 clamp(0.45rem, 0.5vw, 0.7rem);
     font-weight: 600;
   }
 
-  .glass-card,
-  .hero-card,
-  .metric-card {
+  .part-tag {
+    display: inline-block;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    font-size: clamp(0.66rem, 0.75vw, 0.88rem);
+    font-weight: 700;
+    color: var(--accent-soft);
+    border: 1px solid rgba(167, 139, 250, 0.4);
+    border-radius: 9999px;
+    padding: clamp(0.2rem, 0.25vw, 0.32rem) clamp(0.7rem, 0.8vw, 1rem);
+    margin: 0 0 clamp(0.75rem, 0.9vw, 1.2rem);
+  }
+
+  .glass-card, .hero-card, .metric-card {
     background: linear-gradient(180deg, rgba(15, 23, 42, 0.8), rgba(15, 23, 42, 0.62));
     border: 1px solid var(--card-border);
     box-shadow: 0 22px 60px rgba(0, 0, 0, 0.28);
     -webkit-backdrop-filter: blur(12px);
     backdrop-filter: blur(12px);
     border-radius: 24px;
-    padding: 1.25rem 1.35rem;
+    padding: clamp(1.25rem, 1.5vw, 2rem) clamp(1.35rem, 1.8vw, 2.5rem);
   }
 
   .metric-card {
@@ -133,106 +132,80 @@
     border-color: rgba(129, 140, 248, 0.35);
     box-shadow: 0 18px 44px rgba(0, 0, 0, 0.24);
   }
+  .metric-figure { font-size: clamp(2rem, 6vw, 2.8rem); font-weight: 740; color: var(--accent-soft); line-height: 1; margin: 0 0 0.35rem; letter-spacing: -0.02em; }
+  .metric-label { color: var(--copy); font-size: 0.92rem; margin: 0; }
 
-  .hero-card h1 { font-size: clamp(2rem, 5.2vw, 3rem); margin-bottom: 1.2rem; }
+  .hero-card h1 { font-size: clamp(2rem, 5.2vw, 4.5rem); margin-bottom: clamp(1rem, 1.2vw, 1.6rem); }
   .hero-copy {
-    max-width: 44rem;
+    max-width: 56rem;
     color: var(--copy);
-    font-size: clamp(1.05rem, 2.4vw, 1.25rem);
+    font-size: clamp(1.05rem, 2.4vw, 1.6rem);
     margin: 0;
   }
 
-  /* stretch cards to equal height per row so card bottoms align (designer-review fix) */
-  .grid { display: grid; gap: 1.25rem; align-items: stretch; }
-  /* min-width:0 keeps a wide child from forcing its grid track past the viewport */
+  .grid { display: grid; gap: clamp(1rem, 1.5vw, 2rem); align-items: stretch; }
   .grid > * { min-width: 0; }
-  .grid > .glass-card,
-  .grid > .metric-card { display: flex; flex-direction: column; min-width: 0; }
+  .grid > .glass-card, .grid > .metric-card { display: flex; flex-direction: column; min-width: 0; }
   .grid-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
 
-  @media (max-width: 760px) {
+  @media (max-width: 860px) {
     .grid-2, .grid-3 { grid-template-columns: 1fr; }
   }
 
-  .tight-list, .mini-list {
-    margin: 0;
-    padding-left: 1.1rem;
-    color: #e2e8f0;
-  }
-  .tight-list li + li { margin-top: 0.4rem; }
-  .mini-list li + li { margin-top: 0.45rem; }
+  .tight-list, .mini-list { margin: 0; padding-left: 1.1rem; color: #e2e8f0; }
+  .tight-list li + li { margin-top: clamp(0.4rem, 0.5vw, 0.65rem); }
+  .mini-list li + li { margin-top: clamp(0.45rem, 0.55vw, 0.7rem); }
 
-  .chip-row { display: flex; gap: 0.65rem; flex-wrap: wrap; }
+  .chip-row { display: flex; gap: clamp(0.5rem, 0.65vw, 0.85rem); flex-wrap: wrap; margin-top: clamp(0.85rem, 1vw, 1.3rem); }
 
   .pill {
     display: inline-flex;
     align-items: center;
-    padding: 0.4rem 0.85rem;
+    padding: clamp(0.4rem, 0.4vw, 0.55rem) clamp(0.85rem, 0.9vw, 1.15rem);
     border-radius: 9999px;
     background: rgba(15, 23, 42, 0.72);
     border: 1px solid rgba(167, 139, 250, 0.35);
     color: var(--accent-soft);
-    font-size: 0.86rem;
+    font-size: clamp(0.86rem, 0.9vw, 1.05rem);
     font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   }
 
-  /* single full-width card: cap measure so lines stay readable; anchor left under the title */
   .card-narrow { max-width: 58rem; }
 
-  /* closing line: center it in its card and give it punchline weight */
   .closer { justify-content: center; }
   .closer .hero-copy {
     text-align: center;
     font-weight: 620;
-    font-size: clamp(1.15rem, 2.6vw, 1.5rem);
+    font-size: clamp(1.15rem, 2.6vw, 2.2rem);
     line-height: 1.35;
     color: var(--accent-soft);
   }
 
-  /* flow card: keep diagram visually centered when copy is short */
   .flow-card { justify-content: center; }
 
-  .soft-note { color: var(--copy); margin-top: 0.85rem; font-size: 0.95rem; }
-  .note-top-md { margin-top: 0.75rem; }
-  .note-top-sm { margin-top: 0.5rem; }
-  .card-label { color: var(--accent-soft); font-weight: 650; margin: 0 0 0.7rem; }
+  .soft-note { color: var(--copy); margin-top: clamp(0.75rem, 0.9vw, 1.25rem); font-size: clamp(0.95rem, 1vw, 1.15rem); }
+  .section-lead { color: var(--copy); font-size: clamp(1rem, 1.1vw, 1.2rem); margin: 0 0 clamp(0.35rem, 0.45vw, 0.6rem); }
+  .note-top-md { margin-top: clamp(0.65rem, 0.8vw, 1rem); }
+  .note-top-sm { margin-top: clamp(0.4rem, 0.5vw, 0.65rem); }
+  .card-label { color: var(--accent-soft); font-weight: 650; margin: 0 0 clamp(0.6rem, 0.7vw, 1rem); font-size: clamp(0.95rem, 1vw, 1.15rem); }
 
-  /* big metric figure for the proof slide */
-  .metric-figure { font-size: clamp(2rem, 6vw, 2.8rem); font-weight: 740; color: var(--accent-soft); line-height: 1; margin: 0 0 0.35rem; letter-spacing: -0.02em; }
-  .metric-label { color: var(--copy); font-size: 0.92rem; margin: 0; }
-
-  /* inline flow diagrams */
   .flow-scroll {
-    margin-top: 1.4rem;
+    margin-top: clamp(1.2rem, 1.4vw, 1.8rem);
     padding-bottom: 0.5rem;
     min-width: 0;
     max-width: 100%;
-    /* Fallback safety net only — the layout FITS without scrolling
-       (desktop: nodes are short; mobile: .flow stacks vertically below). */
     overflow-x: auto;
   }
-  .flow {
-    display: flex;
-    align-items: center;
-    gap: 0;
-    /* fit the container width, don't force it wider; nodes are short enough */
-    flex-wrap: wrap;
-    justify-content: center;
-  }
-  .flow-col {
-    display: flex;
-    flex-direction: column;
-    gap: 0.6rem;
-    justify-content: center;
-  }
+  .flow { display: flex; align-items: center; gap: 0; flex-wrap: wrap; justify-content: center; }
+  .flow-col { display: flex; flex-direction: column; gap: 0.6rem; justify-content: center; }
   .node {
     background: linear-gradient(180deg, rgba(24, 36, 61, 0.92), rgba(17, 24, 39, 0.82));
     border: 1px solid rgba(129, 140, 248, 0.4);
     border-radius: 14px;
-    padding: 0.55rem 0.85rem;
+    padding: clamp(0.55rem, 0.6vw, 0.8rem) clamp(0.85rem, 1vw, 1.2rem);
     font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-    font-size: 0.82rem;
+    font-size: clamp(0.82rem, 0.9vw, 1.05rem);
     color: #e2e8f0;
     white-space: nowrap;
     text-align: center;
@@ -244,12 +217,12 @@
     flex-direction: column;
     align-items: center;
     color: rgba(148, 163, 184, 0.8);
-    padding: 0 0.65rem;
-    min-width: 3.2rem;
+    padding: 0 clamp(0.5rem, 0.65vw, 0.9rem);
+    min-width: 3rem;
   }
-  .edge .arrow { font-size: 1.1rem; line-height: 1; }
+  .edge .arrow { font-size: clamp(1rem, 1.2vw, 1.4rem); line-height: 1; }
   .edge .edge-label {
-    font-size: 0.66rem;
+    font-size: clamp(0.66rem, 0.7vw, 0.85rem);
     color: var(--kicker);
     text-align: center;
     margin-top: 0.2rem;
@@ -257,18 +230,13 @@
     line-height: 1.2;
   }
 
-  /* Mobile: fit the phone width — the flow stacks vertically (arrows point
-     down) so nothing scrolls sideways or clips, and the type/spacing scale
-     down so a slide's content fits comfortably. */
   @media (max-width: 600px) {
     .slide { padding: 2rem 1.1rem; justify-content: flex-start; }
     .glass-card, .hero-card, .metric-card { padding: 1rem 1.05rem; border-radius: 18px; }
     h2 { font-size: clamp(1.3rem, 6vw, 1.6rem); }
     .hero-card h1 { font-size: clamp(1.6rem, 7.5vw, 2.1rem); }
-    .hero-copy { font-size: 1rem; }
+    .hero-copy { font-size: 1rem; max-width: 100%; }
     p, li { font-size: 0.95rem; }
-    .metric-figure { font-size: clamp(1.8rem, 9vw, 2.2rem); }
-
     .flow-scroll { margin-top: 1rem; }
     .flow { flex-direction: column; align-items: stretch; gap: 0.5rem; }
     .flow-col { gap: 0.5rem; }
@@ -276,6 +244,7 @@
     .edge { flex-direction: row; padding: 0; min-width: 0; }
     .edge .arrow { transform: rotate(90deg); }
     .edge .edge-label { max-width: none; margin-top: 0; margin-left: 0.4rem; }
+    .metric-figure { font-size: clamp(1.8rem, 9vw, 2.2rem); }
   }
 </style>
 </head>
@@ -523,5 +492,35 @@
   </div>
 </section>
 
+<script>
+(function () {
+  const slides = Array.from(document.querySelectorAll('.slide'));
+  const indexMap = new Map(slides.map((s, i) => [s, i]));
+  let cur = 0;
+  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(e => {
+      if (e.isIntersecting && e.intersectionRatio >= 0.5)
+        cur = indexMap.get(e.target) ?? cur;
+    });
+  }, { threshold: 0.5 });
+  slides.forEach(s => observer.observe(s));
+
+  document.addEventListener('keydown', e => {
+    if (e.altKey || e.ctrlKey || e.metaKey) return;
+    const tag = document.activeElement ? document.activeElement.tagName : '';
+    if (['INPUT', 'TEXTAREA', 'SELECT'].includes(tag) || document.activeElement.isContentEditable) return;
+    const behavior = reducedMotion.matches ? 'auto' : 'smooth';
+    if (['ArrowDown', 'ArrowRight', 'PageDown', ' '].includes(e.key)) {
+      e.preventDefault();
+      if (cur < slides.length - 1) slides[++cur].scrollIntoView({ behavior });
+    } else if (['ArrowUp', 'ArrowLeft', 'PageUp'].includes(e.key)) {
+      e.preventDefault();
+      if (cur > 0) slides[--cur].scrollIntoView({ behavior });
+    }
+  });
+})();
+</script>
 </body>
 </html>

--- a/docs/presentations/introducing-dev-loops.html
+++ b/docs/presentations/introducing-dev-loops.html
@@ -508,7 +508,7 @@
   slides.forEach(s => observer.observe(s));
 
   document.addEventListener('keydown', e => {
-    if (e.altKey || e.ctrlKey || e.metaKey) return;
+    if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return;
     const tag = document.activeElement ? document.activeElement.tagName : '';
     if (['INPUT', 'TEXTAREA', 'SELECT'].includes(tag) || document.activeElement.isContentEditable) return;
     const behavior = reducedMotion.matches ? 'auto' : 'smooth';

--- a/test/playwright/intro-deck.spec.mjs
+++ b/test/playwright/intro-deck.spec.mjs
@@ -35,6 +35,11 @@ test("webkit intro deck keyboard navigation advances, backs up, and ignores guar
     expect(await scrollTop(page)).toBeLessThan(height * 0.9);
     await resetScroll(page);
 
+    await page.keyboard.press("Shift+ArrowDown");
+    await page.waitForTimeout(50);
+    expect(await scrollTop(page)).toBeLessThan(height * 0.9);
+    await resetScroll(page);
+
     await page.evaluate(() => {
       const input = document.createElement("input");
       input.id = "keyboard-test-input";

--- a/test/playwright/intro-deck.spec.mjs
+++ b/test/playwright/intro-deck.spec.mjs
@@ -55,18 +55,29 @@ test("webkit intro deck keyboard navigation advances, backs up, and ignores guar
     expect(await scrollTop(page)).toBeLessThan(height * 0.5);
     await resetScroll(page);
 
-    await page.evaluate(() => {
+    const focusBody = () => page.evaluate(() => {
       document.getElementById("keyboard-test-input")?.remove();
       document.body.tabIndex = -1;
       document.body.focus();
     });
-    await page.keyboard.press("ArrowDown");
-    await page.waitForFunction(() => Math.max(document.documentElement.scrollTop, document.body.scrollTop) > window.innerHeight * 0.5);
-    await expect(page.locator("#coordination-cost")).toBeVisible();
 
-    await page.keyboard.press("ArrowUp");
-    await page.waitForFunction(() => Math.max(document.documentElement.scrollTop, document.body.scrollTop) < window.innerHeight * 0.5);
-    await expect(page.locator("#hero")).toBeVisible();
+    for (const key of ["ArrowDown", "ArrowRight", "PageDown", "Space"]) {
+      await resetScroll(page);
+      await focusBody();
+      await page.keyboard.press(key);
+      await page.waitForFunction(() => Math.max(document.documentElement.scrollTop, document.body.scrollTop) > window.innerHeight * 0.5);
+      await expect(page.locator("#coordination-cost")).toBeVisible();
+    }
+
+    for (const key of ["ArrowUp", "ArrowLeft", "PageUp"]) {
+      await resetScroll(page);
+      await focusBody();
+      await page.keyboard.press("ArrowDown");
+      await page.waitForFunction(() => Math.max(document.documentElement.scrollTop, document.body.scrollTop) > window.innerHeight * 0.5);
+      await page.keyboard.press(key);
+      await page.waitForFunction(() => Math.max(document.documentElement.scrollTop, document.body.scrollTop) < window.innerHeight * 0.5);
+      await expect(page.locator("#hero")).toBeVisible();
+    }
   } finally {
     await stopFixtureServer(server);
   }

--- a/test/playwright/intro-deck.spec.mjs
+++ b/test/playwright/intro-deck.spec.mjs
@@ -19,6 +19,9 @@ const resetScroll = (page) => page.evaluate(() => {
   document.body.scrollTop = 0;
 });
 const viewportHeight = (page) => page.evaluate(() => window.innerHeight);
+const waitForAnimationFrames = (page, count = 2) => page.evaluate(async (frames) => {
+  for (let i = 0; i < frames; i += 1) await new Promise(requestAnimationFrame);
+}, count);
 
 test("webkit intro deck keyboard navigation advances, backs up, and ignores guarded keys", async ({ page }) => {
   const { server, url } = await startFixtureServer(() => makeDeckServer(deckPath));
@@ -31,12 +34,12 @@ test("webkit intro deck keyboard navigation advances, backs up, and ignores guar
 
     const height = await viewportHeight(page);
     await page.keyboard.press("Control+ArrowDown");
-    await page.waitForTimeout(50);
+    await waitForAnimationFrames(page);
     expect(await scrollTop(page)).toBeLessThan(height * 0.9);
     await resetScroll(page);
 
     await page.keyboard.press("Shift+ArrowDown");
-    await page.waitForTimeout(50);
+    await waitForAnimationFrames(page);
     expect(await scrollTop(page)).toBeLessThan(height * 0.9);
     await resetScroll(page);
 
@@ -48,7 +51,7 @@ test("webkit intro deck keyboard navigation advances, backs up, and ignores guar
       input.focus();
     });
     await page.keyboard.press("ArrowDown");
-    await page.waitForTimeout(50);
+    await waitForAnimationFrames(page);
     expect(await scrollTop(page)).toBeLessThan(height * 0.5);
     await resetScroll(page);
 

--- a/test/playwright/intro-deck.spec.mjs
+++ b/test/playwright/intro-deck.spec.mjs
@@ -1,10 +1,65 @@
 import { fileURLToPath } from "node:url";
 
-import { deckRegistryEntry, defineDeckSuite } from "./harness/deck-fit-harness.mjs";
+import { expect, test } from "@playwright/test";
+
+import { deckRegistryEntry, defineDeckSuite, makeDeckServer } from "./harness/deck-fit-harness.mjs";
+import { startFixtureServer, stopFixtureServer } from "./harness/webkit-smoke-harness.mjs";
 
 const entry = deckRegistryEntry("intro-deck");
+const deckPath = fileURLToPath(new URL(`../../docs/presentations/${entry.deck}`, import.meta.url));
 
 defineDeckSuite({
   ...entry,
-  deckPath: fileURLToPath(new URL(`../../docs/presentations/${entry.deck}`, import.meta.url)),
+  deckPath,
+});
+
+const scrollTop = (page) => page.evaluate(() => Math.max(document.documentElement.scrollTop, document.body.scrollTop));
+const resetScroll = (page) => page.evaluate(() => {
+  document.documentElement.scrollTop = 0;
+  document.body.scrollTop = 0;
+});
+const viewportHeight = (page) => page.evaluate(() => window.innerHeight);
+
+test("webkit intro deck keyboard navigation advances, backs up, and ignores guarded keys", async ({ page }) => {
+  const { server, url } = await startFixtureServer(() => makeDeckServer(deckPath));
+  try {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto(url, { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle");
+    await expect(page.locator("#hero")).toBeVisible();
+
+    const height = await viewportHeight(page);
+    await page.keyboard.press("Control+ArrowDown");
+    await page.waitForTimeout(50);
+    expect(await scrollTop(page)).toBeLessThan(height * 0.9);
+    await resetScroll(page);
+
+    await page.evaluate(() => {
+      const input = document.createElement("input");
+      input.id = "keyboard-test-input";
+      input.style.cssText = "position:fixed;left:0;top:0;width:1px;height:1px;opacity:0";
+      document.body.appendChild(input);
+      input.focus();
+    });
+    await page.keyboard.press("ArrowDown");
+    await page.waitForTimeout(50);
+    expect(await scrollTop(page)).toBeLessThan(height * 0.5);
+    await resetScroll(page);
+
+    await page.evaluate(() => {
+      document.getElementById("keyboard-test-input")?.remove();
+      document.body.tabIndex = -1;
+      document.body.focus();
+    });
+    await page.keyboard.press("ArrowDown");
+    await page.waitForFunction(() => Math.max(document.documentElement.scrollTop, document.body.scrollTop) > window.innerHeight * 0.5);
+    await expect(page.locator("#coordination-cost")).toBeVisible();
+
+    await page.keyboard.press("ArrowUp");
+    await page.waitForFunction(() => Math.max(document.documentElement.scrollTop, document.body.scrollTop) < window.innerHeight * 0.5);
+    await expect(page.locator("#hero")).toBeVisible();
+  } finally {
+    await stopFixtureServer(server);
+  }
 });


### PR DESCRIPTION
## Summary
- Ported the deep-dive deck desktop UX treatment to the intro deck: wider responsive slide layout, mandatory vertical scroll snap, reduced-motion opt-out, and keyboard navigation.
- Added CSP `script-src 'unsafe-inline'` required for the inline deck navigation script.
- Added an intro-deck Playwright check for keyboard navigation advance/back behavior plus modified-key/editable-control guards.

Closes #1027

## Validation
- `npm run test:playwright:intro-deck` — 4 passed
- `node tmp/ui-review/issue-1027/run-ui-review.mjs` — passed; 36 screenshots captured across mobile 390×844 and desktop 1280×800, 1440×900, 1920×1080; no horizontal overflow or vertical clipping; mandatory snap and reduced-motion opt-out verified; keyboard keys/guards verified.
- `env -u PI_SUBAGENT_RUN_ID -u DEVLOOPS_RUN_ID npm run verify` — passed

## Notes
- Plain `npm run verify` under this Pi subagent inherited `PI_SUBAGENT_RUN_ID=5834a9f5`, which contaminated hermetic Claude contract tests. Re-running with the run-id markers unset passed fully.
