### PR TITLE
Fix Pi /dev-loops direct entrypoints

### DIFF
--- a/extension/harness-types.ts
+++ b/extension/harness-types.ts
@@ -29,6 +29,7 @@ export type HarnessContext = {
   cwd: string;
   hasUI: boolean;
   ui: HarnessUi;
+  sendUserMessage?: (message: string, options?: Record<string, unknown>) => unknown;
 };
 
 export type HarnessLifecycleEvent = 'session_start' | 'tool_result' | 'user_bash' | 'agent_end';

--- a/extension/index.ts
+++ b/extension/index.ts
@@ -26,6 +26,10 @@ const STATUS_KEY = 'dev-loops';
 const WIDGET_KEY = 'dev-loops.setup';
 const PACKAGED_AGENTS_ROOT = new URL('../agents/', import.meta.url);
 
+async function dispatchDevLoopIntent(ctx: { sendUserMessage?: (message: string) => unknown }, intent: string) {
+  await ctx.sendUserMessage?.(`/skill:dev-loop ${intent}`);
+}
+
 export function syncPackagedAgents({
   sourceRoot = fileURLToPath(PACKAGED_AGENTS_ROOT),
   targetRoot = path.join(os.homedir(), '.agents'),
@@ -92,10 +96,12 @@ export default function (pi: ExtensionAPI, runtimeOverrides: ExtensionRuntimeOve
           return;
         case 'entrypoint':
           ctx.ui.setWidget(WIDGET_KEY, buildEntrypointLines(result.action, result.intent), { placement: 'belowEditor' });
+          await dispatchDevLoopIntent(ctx, result.intent);
           ctx.ui.notify(`dev-loops ${result.action}: ${result.intent}`, 'info');
           return;
         case 'start_spike':
           ctx.ui.setWidget(WIDGET_KEY, buildEntrypointLines('start-spike', result.intent), { placement: 'belowEditor' });
+          await dispatchDevLoopIntent(ctx, result.intent);
           ctx.ui.notify(`dev-loops start-spike: ${result.intent}`, 'info');
           return;
         case 'checks':

--- a/extension/pi-extension-adapter.ts
+++ b/extension/pi-extension-adapter.ts
@@ -26,6 +26,7 @@ import type {
 
 export function toHarnessContext(ctx: Partial<ExtensionContext> | undefined): HarnessContext {
   const ui = ctx?.ui;
+  const sender = (ctx as { sendUserMessage?: (message: string, options?: Record<string, unknown>) => unknown } | undefined)?.sendUserMessage;
   return {
     cwd: (ctx?.cwd as string) ?? process.cwd(),
     hasUI: Boolean(ctx?.hasUI),
@@ -34,6 +35,7 @@ export function toHarnessContext(ctx: Partial<ExtensionContext> | undefined): Ha
       setWidget: (key, lines, options) => ui?.setWidget?.(key, lines as never, options as never),
       setStatus: (key, text) => ui?.setStatus?.(key, text as never),
     },
+    sendUserMessage: sender ? (message, options) => sender.call(ctx, message, options) : undefined,
   };
 }
 

--- a/extension/presentation.ts
+++ b/extension/presentation.ts
@@ -47,24 +47,13 @@ export function buildEntrypointLines(action: string, intent: string): string[] {
 export function buildHelpLines(): string[] {
   return [
     'dev-loops help',
-    'Workflow entry:',
-    '- /skill:dev-loop — single public entrypoint; routing handles the rest',
-    'Direct entrypoints:',
-    '- /dev-loops start <issue>',
-    '- /dev-loops auto <issue>',
-    '- /dev-loops continue [issue|pr]',
-    '- /dev-loops start-spike <question>',
-    '- /dev-loops info <issue|pr>',
-    'Commands:',
-    '- /dev-loops status',
-    '- /dev-loops doctor',
-    '- /dev-loops hide',
-    '- /dev-loops inspect open [--repo <owner/name>]',
-    '- /dev-loops inspect resume [--repo <owner/name>]',
-    '- /dev-loops inspect status [--repo <owner/name>]',
-    '- /dev-loops inspect stop [--repo <owner/name>]',
-    '- /dev-loops inspect restart [--repo <owner/name>]',
-    'Use `pi install git:github.com/mfittko/dev-loops` to install skills and agents; packaged agents sync into `~/.agents/` on session start.',
+    '/skill:dev-loop <intent> starts the public loop',
+    'Direct: /dev-loops start <issue> | auto <issue>',
+    'Continue/info: /dev-loops continue [issue|pr] | info <issue|pr>',
+    'Spike: /dev-loops start-spike <question>',
+    'Inspect viewer: /dev-loops inspect open|resume|status|stop|restart',
+    'Checks: /dev-loops status | doctor',
+    'Clear this widget: /dev-loops hide',
   ];
 }
 

--- a/extension/presentation.ts
+++ b/extension/presentation.ts
@@ -48,12 +48,11 @@ export function buildHelpLines(): string[] {
   return [
     'dev-loops help',
     '/skill:dev-loop <intent> starts the public loop',
-    'Direct: /dev-loops start <issue> | auto <issue>',
-    'Continue/info: /dev-loops continue [issue|pr] | info <issue|pr>',
-    'Spike: /dev-loops start-spike <question>',
-    'Inspect viewer: /dev-loops inspect open|resume|status|stop|restart',
-    'Checks: /dev-loops status | doctor',
-    'Clear this widget: /dev-loops hide',
+    '/dev-loops start <issue> | /dev-loops auto <issue>',
+    '/dev-loops continue [issue|pr] | /dev-loops info <issue|pr>',
+    '/dev-loops start-spike <question>',
+    '/dev-loops inspect open|resume|status|stop|restart',
+    '/dev-loops status | /dev-loops doctor | /dev-loops hide',
   ];
 }
 

--- a/packages/core/src/harness/extension-adapter.mjs
+++ b/packages/core/src/harness/extension-adapter.mjs
@@ -30,6 +30,7 @@
  * @property {string} cwd - Working directory for the current invocation.
  * @property {boolean} hasUI - Whether an interactive UI surface is attached.
  * @property {HarnessUi} ui - UI operations for this invocation.
+ * @property {((message: string, options?: Record<string, unknown>) => unknown) | undefined} sendUserMessage - Optional: send a user-turn message into the harness (Pi extension only; absent in other harnesses).
  *
  * @typedef {'session_start'|'tool_result'|'user_bash'|'agent_end'} HarnessLifecycleEvent
  *

--- a/test/extension-command-contract.test.mjs
+++ b/test/extension-command-contract.test.mjs
@@ -43,6 +43,7 @@ function createCommandContext() {
     widgets: [],
     notifications: [],
     statuses: [],
+    userMessages: [],
   };
 
   return {
@@ -57,6 +58,9 @@ function createCommandContext() {
         setStatus(key, text) {
           calls.statuses.push({ key, text });
         },
+      },
+      sendUserMessage(message, options) {
+        calls.userMessages.push({ message, options });
       },
     },
     calls,
@@ -173,14 +177,24 @@ test("direct entrypoints surface the public intent for dispatch (#972)", async (
   const pi = readyPi();
   registerExtension(pi);
 
-  const { ctx, calls } = createCommandContext();
-  await pi.registeredCommands.get("dev-loops").handler("continue 88", ctx);
+  for (const { input, action, intent } of [
+    { input: "start 88", action: "start", intent: "start dev loop on issue 88" },
+    { input: "auto 88", action: "auto", intent: "auto dev loop on issue 88" },
+    { input: "continue 88", action: "continue", intent: "continue dev loop on 88" },
+    { input: "info 88", action: "info", intent: "inspect dev loop state on 88" },
+  ]) {
+    const { ctx, calls } = createCommandContext();
+    await pi.registeredCommands.get("dev-loops").handler(input, ctx);
 
-  const widget = calls.widgets.at(-1);
-  assert.equal(widget.key, "dev-loops.setup");
-  assert(widget.lines.some((line) => /\/skill:dev-loop continue dev loop on 88/.test(line)));
-  assert.equal(calls.notifications.at(-1).message, "dev-loops continue: continue dev loop on 88");
-  assert.equal(calls.notifications.at(-1).level, "info");
+    const widget = calls.widgets.at(-1);
+    assert.equal(widget.key, "dev-loops.setup");
+    assert(widget.lines.some((line) => line === `/skill:dev-loop ${intent}`));
+    assert.deepEqual(calls.userMessages, [
+      { message: `/skill:dev-loop ${intent}`, options: undefined },
+    ]);
+    assert.equal(calls.notifications.at(-1).message, `dev-loops ${action}: ${intent}`);
+    assert.equal(calls.notifications.at(-1).level, "info");
+  }
 
   // Help lists the direct entrypoints so they are discoverable.
   const helpContext = createCommandContext();
@@ -201,6 +215,9 @@ test("start-spike surfaces the spike intent through the Pi handler (#988 P2)", a
   const widget = calls.widgets.at(-1);
   assert.equal(widget.key, "dev-loops.setup");
   assert(widget.lines.some((line) => /dev-loops start-spike/.test(line)));
+  assert.deepEqual(calls.userMessages, [
+    { message: "/skill:dev-loop start a dev-loop spike on the question: Would an LRU cache help?", options: undefined },
+  ]);
   assert.match(calls.notifications.at(-1).message, /start a dev-loop spike on the question: Would an LRU cache help\?/);
   assert.equal(calls.notifications.at(-1).level, "info");
 });

--- a/test/extension-command-contract.test.mjs
+++ b/test/extension-command-contract.test.mjs
@@ -201,7 +201,7 @@ test("direct entrypoints surface the public intent for dispatch (#972)", async (
   const helpContext = createCommandContext();
   await pi.registeredCommands.get("dev-loops").handler("", helpContext.ctx);
   const helpLines = helpContext.calls.widgets.at(-1).lines;
-  for (const re of [/\/dev-loops start <issue>/, /auto <issue>/, /\/dev-loops continue \[issue\|pr\]/, /\/dev-loops start-spike <question>/, /info <issue\|pr>/, /\/dev-loops inspect open\|resume\|status\|stop\|restart/]) {
+  for (const re of [/\/dev-loops start <issue>/, /\/dev-loops auto <issue>/, /\/dev-loops continue \[issue\|pr\]/, /\/dev-loops start-spike <question>/, /\/dev-loops info <issue\|pr>/, /\/dev-loops inspect open\|resume\|status\|stop\|restart/]) {
     assert(helpLines.some((line) => re.test(line)), `help should list ${re}`);
   }
 });

--- a/test/extension-command-contract.test.mjs
+++ b/test/extension-command-contract.test.mjs
@@ -139,10 +139,11 @@ test("help is the default action and removed install/update commands fall back t
   const widget = calls.widgets.at(-1);
   assert.equal(widget.key, "dev-loops.setup");
   assert.match(widget.lines[0], /dev-loops help/);
+  assert(widget.lines.length <= 8, "help should stay compact enough for the Pi widget");
   assert(widget.lines.some((line) => /\/dev-loops status/i.test(line)));
-  assert(widget.lines.some((line) => /pi install git:github.com\/mfittko\/dev-loops/i.test(line)));
+  assert(widget.lines.some((line) => /\/dev-loops hide/i.test(line)), "help should make the clear action visible");
   assert(widget.lines.some((line) => /\/skill:dev-loop/i.test(line)), "help should mention /skill:dev-loop as workflow entry");
-  assert(widget.lines.some((line) => /single public entry/i.test(line)), "help should describe dev-loop as single public entry");
+  assert(widget.lines.some((line) => /public loop/i.test(line)), "help should describe dev-loop as the public loop entry");
   assert.equal(widget.lines.some((line) => /copilot-dev-loop|copilot-autopilot/i.test(line)), false, "help should not surface internal seam names");
   assert.doesNotMatch(widget.lines.join("\n"), /\/dev-loops (?:install|update)/i);
   assert.equal(calls.notifications.at(-1).message, "dev-loops help");
@@ -200,7 +201,7 @@ test("direct entrypoints surface the public intent for dispatch (#972)", async (
   const helpContext = createCommandContext();
   await pi.registeredCommands.get("dev-loops").handler("", helpContext.ctx);
   const helpLines = helpContext.calls.widgets.at(-1).lines;
-  for (const re of [/\/dev-loops start <issue>/, /\/dev-loops auto <issue>/, /\/dev-loops continue \[issue\|pr\]/, /\/dev-loops start-spike <question>/, /\/dev-loops info <issue\|pr>/]) {
+  for (const re of [/\/dev-loops start <issue>/, /auto <issue>/, /\/dev-loops continue \[issue\|pr\]/, /\/dev-loops start-spike <question>/, /info <issue\|pr>/, /\/dev-loops inspect open\|resume\|status\|stop\|restart/]) {
     assert(helpLines.some((line) => re.test(line)), `help should list ${re}`);
   }
 });


### PR DESCRIPTION
Closes #1029

## Summary
- dispatch Pi `/dev-loops` direct workflow entrypoints through the public `dev-loop` skill intent
- preserve existing status/help/doctor/hide/inspect widget behavior
- compact direct-entrypoint widget presentation

## Validation
- `npm run verify` currently fails in unrelated contract tests:
  - `test/contracts/claude-headless-smoke.test.mjs` expects `DEVLOOPS_RUN_ID` prefix `devloops-`, got UUID
  - `test/contracts/claude-hooks-settings.test.mjs` expected structured decision, got null
