### PR TITLE
fix(docs): desktop-optimize article pages — widen .wrap to 72rem on desktop

### DIFF
--- a/docs/articles/dev-loops-deep-dive.html
+++ b/docs/articles/dev-loops-deep-dive.html
@@ -47,6 +47,10 @@
     padding: clamp(2rem, 6vw, 4rem) clamp(1.1rem, 5vw, 2rem) 5rem;
   }
 
+  @media (min-width: 900px) {
+    .wrap { max-width: 72rem; }
+  }
+
   /* readable article measure (~65ch) inside the wrapper */
   .article p,
   .article ul,
@@ -544,12 +548,14 @@
 
   <p class="closer">The next agent will write your code in seconds. The lever you control is the coordination around it: keep the next step known so the next actor pulls it, and measure how long the work waits.</p>
 
+<!--
   <hr class="rule" />
 
   <div class="render-note">
     <h2>Rendering the diagrams on Medium</h2>
     <p>Medium does not natively render Mermaid. In the Markdown version of this article each diagram is a fenced <code>mermaid</code> block so it stays editable, and each carries a caption so the article reads cleanly with each diagram shown as a static image. To publish on Medium, either paste each block into a Mermaid-enabled editor and embed the rendered image, or export each diagram as SVG/PNG and drop it in where the block sits. Because every diagram is captioned, the prose carries the argument on its own.</p>
   </div>
+-->
 
 </article>
 </div>

--- a/docs/articles/dev-loops-deep-dive.md
+++ b/docs/articles/dev-loops-deep-dive.md
@@ -231,6 +231,7 @@ So make the next step always known, and measure the waits. Compute the next acti
 
 The next agent will write your code in seconds. The lever you control is the coordination around it: keep the next step known so the next actor pulls it, and measure how long the work waits.
 
+<!--
 ---
 
 ## Rendering the diagrams on Medium
@@ -238,3 +239,4 @@ The next agent will write your code in seconds. The lever you control is the coo
 Before pasting into Medium, remove the YAML front-matter block (the `---` fenced `title` / `subtitle` / `tags` at the top) — Medium shows it as literal text; use the title and subtitle as the Medium headline and subtitle, and the tags as Medium tags.
 
 Medium does not natively render Mermaid. Each diagram above is written as a fenced `mermaid` block so it stays editable, and each carries a caption so the article reads cleanly with each diagram shown as a static image. To publish on Medium, either paste each block into a Mermaid-enabled editor (for example, the Mermaid Live Editor or any Markdown tool with Mermaid support) and embed the rendered image, or export each diagram as SVG/PNG and drop it in where the block sits. Because every diagram is captioned, the prose carries the argument on its own and the diagrams support it.
+-->

--- a/docs/articles/introducing-dev-loops.html
+++ b/docs/articles/introducing-dev-loops.html
@@ -47,6 +47,10 @@
     padding: clamp(2rem, 6vw, 4rem) clamp(1.1rem, 5vw, 2rem) 5rem;
   }
 
+  @media (min-width: 900px) {
+    .wrap { max-width: 72rem; }
+  }
+
   /* readable article measure (~65ch) inside the wrapper */
   .article p,
   .article ul,

--- a/docs/presentations/introducing-dev-loops.html
+++ b/docs/presentations/introducing-dev-loops.html
@@ -458,26 +458,6 @@
   </div>
 </section>
 
-<section class="slide" id="close">
-  <div class="slide-inner">
-    <p class="kicker">Where to go deeper</p>
-    <h2>Two Companion Pieces</h2>
-    <div class="grid grid-2">
-      <div class="glass-card">
-        <p class="card-label">Eliminating Coordination Delay</p>
-        <p class="soft-note note-top-sm">Why the next step is always known so the next actor pulls it, and why the loop runs on a state graph.</p>
-      </div>
-      <div class="glass-card">
-        <p class="card-label">Make the Waiting Visible</p>
-        <p class="soft-note note-top-sm">Measuring the waiting between actions, which is where the lead time goes once the code is fast to write.</p>
-      </div>
-    </div>
-    <div class="metric-card closer note-top-md">
-      <p class="hero-copy">Carry every change along the same recorded path, with a person merging by default.</p>
-    </div>
-  </div>
-</section>
-
 <script>
 (function () {
   const slides = Array.from(document.querySelectorAll('.slide'));

--- a/test/playwright/harness/deck-fit-harness.mjs
+++ b/test/playwright/harness/deck-fit-harness.mjs
@@ -255,7 +255,6 @@ export const DECK_REGISTRY = {
       { id: "model-agnostic", stateName: "Model agnostic" },
       { id: "proof", stateName: "Proof (data)" },
       { id: "setup", stateName: "Setup" },
-      { id: "close", stateName: "Close" },
     ],
   },
   "deep-dive-deck": {


### PR DESCRIPTION
## Summary

Desktop-optimize article pages by widening the \`.wrap\` container on large viewports, and clean up Medium-specific content from the standalone published articles.

- Add \`@media (min-width: 900px) { .wrap { max-width: 72rem } }\` desktop breakpoint to both article HTML files so the page layout uses available screen width on desktop while mobile/tablet behaviour is unchanged
- Comment out the \`<div class="render-note">\` Medium hints block in \`dev-loops-deep-dive.html\` (not relevant to the standalone article)
- Wrap the "Rendering the diagrams on Medium" section in \`dev-loops-deep-dive.md\` in HTML comments
- Remove the closing "Two Companion Pieces" slide (\`id="close"\`) from the introducing-dev-loops presentation

## Test plan

- [x] Page build tests pass (4/4)
- [x] \`.wrap\` max-width is 72rem at ≥900px viewport
- [x] Mobile behaviour unchanged (375px, 768px)
- [x] No prose-width regressions (\`.article p\` etc. stay ≤ 65ch)

Closes #1037