### PR TITLE
fix(site): align nav/wrap/prose widths on desktop

### DIFF
--- a/docs/articles/dev-loops-deep-dive.html
+++ b/docs/articles/dev-loops-deep-dive.html
@@ -51,6 +51,7 @@
     .wrap { max-width: 72rem; }
     .article p,
     .article ul,
+    .article ol,
     .article .section-h,
     .article .lede { margin-left: auto; margin-right: auto; }
   }
@@ -58,6 +59,7 @@
   /* readable article measure (~65ch) inside the wrapper */
   .article p,
   .article ul,
+  .article ol,
   .article .section-h,
   .article .lede { max-width: 40rem; }
 

--- a/docs/articles/dev-loops-deep-dive.html
+++ b/docs/articles/dev-loops-deep-dive.html
@@ -49,6 +49,10 @@
 
   @media (min-width: 900px) {
     .wrap { max-width: 72rem; }
+    .article p,
+    .article ul,
+    .article .section-h,
+    .article .lede { margin-left: auto; margin-right: auto; }
   }
 
   /* readable article measure (~65ch) inside the wrapper */

--- a/docs/articles/introducing-dev-loops.html
+++ b/docs/articles/introducing-dev-loops.html
@@ -60,6 +60,7 @@
   .article p,
   .article ul,
   .article ol,
+  .article .section-h,
   .article .lede { max-width: 40rem; }
 
   .kicker {

--- a/docs/articles/introducing-dev-loops.html
+++ b/docs/articles/introducing-dev-loops.html
@@ -49,6 +49,10 @@
 
   @media (min-width: 900px) {
     .wrap { max-width: 72rem; }
+    .article p,
+    .article ul,
+    .article .section-h,
+    .article .lede { margin-left: auto; margin-right: auto; }
   }
 
   /* readable article measure (~65ch) inside the wrapper */

--- a/docs/articles/introducing-dev-loops.html
+++ b/docs/articles/introducing-dev-loops.html
@@ -51,6 +51,7 @@
     .wrap { max-width: 72rem; }
     .article p,
     .article ul,
+    .article ol,
     .article .section-h,
     .article .lede { margin-left: auto; margin-right: auto; }
   }

--- a/scripts/pages/build-site.mjs
+++ b/scripts/pages/build-site.mjs
@@ -55,7 +55,7 @@ export const NAV_LINKS = [
 // Nav styling, appended to each article page's own <style> block so it reuses
 // the article design-system variables (--heading/--kicker/--accent-soft).
 const NAV_CSS = `
-  .site-nav { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem 1.1rem; max-width: 64rem; margin: 0 auto; padding: 0.9rem clamp(1.1rem, 5vw, 2rem); border-bottom: 1px solid rgba(148, 163, 184, 0.16); }
+  .site-nav { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem 1.1rem; max-width: 72rem; margin: 0 auto; padding: 0.9rem clamp(1.1rem, 5vw, 2rem); border-bottom: 1px solid rgba(148, 163, 184, 0.16); }
   .site-nav-brand { font-weight: 700; letter-spacing: -0.01em; color: var(--heading); text-decoration: none; border: 0; margin-right: auto; }
   .site-nav-links { display: flex; flex-wrap: wrap; gap: 0.5rem 1.1rem; }
   .site-nav a { color: var(--kicker); text-decoration: none; font-size: 0.9rem; border: 0; }

--- a/test/pages/build-site.test.mjs
+++ b/test/pages/build-site.test.mjs
@@ -40,8 +40,10 @@ test('build-site: index is the intro article, all resources published, nav links
 
     // Nav max-width must match the .wrap desktop width (72rem) so they align on desktop.
     // Regression guard for the issue-1040 fix: was incorrectly 64rem before.
-    assert.ok(index.includes('max-width: 72rem'), 'site-nav uses max-width 72rem (aligned with .wrap)');
-    assert.ok(!index.includes('max-width: 64rem'), 'site-nav must not use the old 64rem max-width');
+    // Check the .site-nav rule specifically — the page also has .wrap { max-width: 72rem }
+    // so a bare 72rem substring match would pass even if .site-nav regressed.
+    assert.ok(index.includes('.site-nav {') && index.match(/\.site-nav\s*\{[^}]*max-width:\s*72rem/), 'site-nav rule uses max-width 72rem (aligned with .wrap)');
+    assert.ok(!index.match(/\.site-nav\s*\{[^}]*max-width:\s*64rem/), 'site-nav must not use the old 64rem max-width');
 
     assert.deepEqual(
       result.files.sort(),

--- a/test/pages/build-site.test.mjs
+++ b/test/pages/build-site.test.mjs
@@ -38,6 +38,11 @@ test('build-site: index is the intro article, all resources published, nav links
     const deep = await readFile(join(out, ARTICLES[0].file), 'utf8');
     assert.ok(deep.includes('class="site-nav"'), 'deep-dive article carries the nav bar');
 
+    // Nav max-width must match the .wrap desktop width (72rem) so they align on desktop.
+    // Regression guard for the issue-1040 fix: was incorrectly 64rem before.
+    assert.ok(index.includes('max-width: 72rem'), 'site-nav uses max-width 72rem (aligned with .wrap)');
+    assert.ok(!index.includes('max-width: 64rem'), 'site-nav must not use the old 64rem max-width');
+
     assert.deepEqual(
       result.files.sort(),
       ['index.html', ...ARTICLES.map((a) => a.file), ...DECKS.map((d) => deckOut(d))].sort(),

--- a/test/pages/build-site.test.mjs
+++ b/test/pages/build-site.test.mjs
@@ -42,7 +42,7 @@ test('build-site: index is the intro article, all resources published, nav links
     // Regression guard for the issue-1040 fix: was incorrectly 64rem before.
     // Check the .site-nav rule specifically — the page also has .wrap { max-width: 72rem }
     // so a bare 72rem substring match would pass even if .site-nav regressed.
-    assert.ok(index.includes('.site-nav {') && index.match(/\.site-nav\s*\{[^}]*max-width:\s*72rem/), 'site-nav rule uses max-width 72rem (aligned with .wrap)');
+    assert.ok(index.match(/\.site-nav\s*\{[^}]*max-width:\s*72rem/), 'site-nav rule uses max-width 72rem (aligned with .wrap)');
     assert.ok(!index.match(/\.site-nav\s*\{[^}]*max-width:\s*64rem/), 'site-nav must not use the old 64rem max-width');
 
     assert.deepEqual(

--- a/test/playwright/harness/deck-fit-harness.mjs
+++ b/test/playwright/harness/deck-fit-harness.mjs
@@ -394,4 +394,58 @@ export function defineArticleSuite({ sliceId, articlePath }) {
       await stopFixtureServer(server);
     }
   });
+
+  test(`webkit ${sliceId} prose is centred on desktop (≥900px nav/wrap/prose alignment)`, async ({ page }, testInfo) => {
+    const { server, url } = await startServer();
+    try {
+      await page.setViewportSize(DESKTOP);
+      await page.goto(url, { waitUntil: "domcontentloaded" });
+      await page.waitForLoadState("networkidle");
+      await assertDesktopProseCentered(page);
+      await captureNamedUiState({
+        page,
+        testInfo,
+        sliceId,
+        stateName: `${sliceId} (desktop 1280)`,
+        fullPage: false,
+        metadata: {
+          fixture: articleName,
+          route: "/",
+          reviewHint: `Desktop (1280px) layout for ${articleName} — nav, wrap, and prose column aligned.`,
+        },
+      });
+    } finally {
+      await stopFixtureServer(server);
+    }
+  });
+}
+
+// Desktop (≥900px) layout constants for the alignment check.
+export const DESKTOP = { width: 1280, height: 900 };
+
+// On desktop (≥900px), `.article p`, `.article ul`, `.article .section-h`, and
+// `.article .lede` carry `margin-left: auto; margin-right: auto` so the prose
+// column is centred inside the widened `.wrap` (72rem). This check verifies the
+// rendered left-margin is non-zero (i.e. not flush-left) — the plain signal that
+// the auto-centering rule is active.
+export async function assertDesktopProseCentered(page) {
+  const notCentered = await page.evaluate(() => {
+    const selectors = [".article p", ".article ul", ".article .section-h", ".article .lede"];
+    const offenders = [];
+    for (const sel of selectors) {
+      const el = document.querySelector(sel);
+      if (!el) continue; // selector may be absent in some articles
+      const ml = parseFloat(getComputedStyle(el).marginLeft);
+      // margin-left must be > 0 to be centered — flush-left (≤1px) means the
+      // auto rule is missing or was overridden.
+      if (ml <= 1) {
+        offenders.push(`${sel}: margin-left=${ml}px (expected > 1px — auto centering)`);
+      }
+    }
+    return offenders;
+  });
+  expect(
+    notCentered,
+    `desktop prose is not centred — margin-left:auto rule missing:\n${notCentered.join("\n")}`,
+  ).toEqual([]);
 }

--- a/test/playwright/harness/deck-fit-harness.mjs
+++ b/test/playwright/harness/deck-fit-harness.mjs
@@ -430,7 +430,7 @@ export const DESKTOP = { width: 1280, height: 900 };
 // the auto-centering rule is active.
 export async function assertDesktopProseCentered(page) {
   const notCentered = await page.evaluate(() => {
-    const selectors = [".article p", ".article ul", ".article .section-h", ".article .lede"];
+    const selectors = [".article p", ".article ul", ".article ol", ".article .section-h", ".article .lede"];
     const offenders = [];
     for (const sel of selectors) {
       const els = document.querySelectorAll(sel);

--- a/test/playwright/harness/deck-fit-harness.mjs
+++ b/test/playwright/harness/deck-fit-harness.mjs
@@ -433,13 +433,19 @@ export async function assertDesktopProseCentered(page) {
     const selectors = [".article p", ".article ul", ".article .section-h", ".article .lede"];
     const offenders = [];
     for (const sel of selectors) {
-      const el = document.querySelector(sel);
-      if (!el) continue; // selector may be absent in some articles
-      const ml = parseFloat(getComputedStyle(el).marginLeft);
-      // margin-left must be > 0 to be centered — flush-left (≤1px) means the
-      // auto rule is missing or was overridden.
-      if (ml <= 1) {
-        offenders.push(`${sel}: margin-left=${ml}px (expected > 1px — auto centering)`);
+      const els = document.querySelectorAll(sel);
+      if (els.length === 0) continue; // selector may be absent in some articles
+      // Check all matching elements — a partial override on a subset would be missed
+      // by querySelector which only checks the first.
+      for (const el of els) {
+        const ml = parseFloat(getComputedStyle(el).marginLeft);
+        // margin-left must be > 0 to be centered — flush-left (≤1px) means the
+        // auto rule is missing or was overridden.
+        if (ml <= 1) {
+          const text = (el.textContent || "").trim().slice(0, 32);
+          offenders.push(`${sel}: margin-left=${ml}px (expected > 1px — auto centering) "${text}"`);
+          break; // one offender per selector is enough to flag the issue
+        }
       }
     }
     return offenders;


### PR DESCRIPTION
## Summary

- Widen `.site-nav` `max-width` from `64rem` → `72rem` in `scripts/pages/build-site.mjs` so the nav aligns with the widened `.wrap` on desktop
- Add `margin-left: auto; margin-right: auto` to `.article p`, `.article ul`, `.article .section-h`, `.article .lede` inside the `@media (min-width: 900px)` block in both article HTML files so the prose column is centred within the 72rem wrapper
- Add a regression test locking the nav max-width at 72rem
- Add a Playwright desktop alignment check (1280px viewport) verifying the prose is not flush-left when the desktop media query fires

## Test plan

- [x] `node --test test/pages/*.test.mjs` — 4 tests pass including new nav max-width regression assertion
- [x] `npx playwright test -c playwright.deep-dive-article.config.mjs` — 4 tests pass including new desktop centering check
- [x] `npx playwright test -c playwright.intro-article.config.mjs` — 4 tests pass including new desktop centering check
- [x] `npm run verify` — full suite (4058 tests, 0 failures)
- [x] Visual Playwright screenshot captured at 1280px: prose column is centred, nav and wrap are aligned

Closes #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)
