### PR TITLE
fix(articles): target h2 not .section-h for desktop centering

### DIFF
--- a/docs/articles/dev-loops-deep-dive.html
+++ b/docs/articles/dev-loops-deep-dive.html
@@ -52,7 +52,7 @@
     .article p,
     .article ul,
     .article ol,
-    .article .section-h,
+    .article h2,
     .article .lede { margin-left: auto; margin-right: auto; }
   }
 
@@ -60,7 +60,7 @@
   .article p,
   .article ul,
   .article ol,
-  .article .section-h,
+  .article h2,
   .article .lede { max-width: 40rem; }
 
   .kicker {

--- a/docs/articles/introducing-dev-loops.html
+++ b/docs/articles/introducing-dev-loops.html
@@ -52,7 +52,7 @@
     .article p,
     .article ul,
     .article ol,
-    .article .section-h,
+    .article h2,
     .article .lede { margin-left: auto; margin-right: auto; }
   }
 
@@ -60,7 +60,7 @@
   .article p,
   .article ul,
   .article ol,
-  .article .section-h,
+  .article h2,
   .article .lede { max-width: 40rem; }
 
   .kicker {

--- a/test/playwright/harness/deck-fit-harness.mjs
+++ b/test/playwright/harness/deck-fit-harness.mjs
@@ -423,14 +423,14 @@ export function defineArticleSuite({ sliceId, articlePath }) {
 // Desktop (≥900px) layout constants for the alignment check.
 export const DESKTOP = { width: 1280, height: 900 };
 
-// On desktop (≥900px), `.article p`, `.article ul`, `.article .section-h`, and
+// On desktop (≥900px), `.article p`, `.article ul`, `.article h2`, and
 // `.article .lede` carry `margin-left: auto; margin-right: auto` so the prose
 // column is centred inside the widened `.wrap` (72rem). This check verifies the
 // rendered left-margin is non-zero (i.e. not flush-left) — the plain signal that
 // the auto-centering rule is active.
 export async function assertDesktopProseCentered(page) {
   const notCentered = await page.evaluate(() => {
-    const selectors = [".article p", ".article ul", ".article ol", ".article .section-h", ".article .lede"];
+    const selectors = [".article p", ".article ul", ".article ol", ".article h2", ".article .lede"];
     const offenders = [];
     for (const sel of selectors) {
       const els = document.querySelectorAll(sel);


### PR DESCRIPTION
## Summary

- `.article .section-h` matched nothing — article headings are plain `<h2>` elements with no class
- Replace with `.article h2` in both the `@media (min-width: 900px)` centering rule and the base `max-width: 40rem` rule in both article HTML files
- Fixes the zigzag layout (paragraphs centered, headings flush-left) visible after #1041 merged

## Root cause

#1041 added `margin-left: auto; margin-right: auto` to `.article .section-h` but no `<h2>` in the articles carries that class. The centering rule was a no-op for headings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)