### PR TITLE
test(loop): make local conflict-files detection hermetic (#1006)

### DIFF
--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -22,7 +22,14 @@ const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, {
 
 async function writeGhStub(tempDir, entries) {
   const { env } = await writeGhStubHelper(tempDir, entries);
-  return { ...env, DEVLOOPS_RUN_ID: "" };
+  // Hermetic guard (#1006): seed a clean local git stub on the same PATH dir so
+  // the subprocess CLI's fetchLocalConflictFiles never shells out to the real
+  // working tree. Without this, concurrent git activity under parallel
+  // `npm run verify` transiently reports unmerged entries and flips these
+  // gh-driven suites to conflict_resolution. Tests needing a specific git
+  // response (e.g. the conflict-resolution case) overwrite this stub afterward.
+  const gitEnv = await writeGitStub(tempDir, { stdout: "" });
+  return { ...env, ...gitEnv, DEVLOOPS_RUN_ID: "" };
 }
 
 async function writeGitStub(tempDir, { stdout = "", stderr = "", exitCode = 0, assertArgs = [] } = {}) {


### PR DESCRIPTION
Closes #1006

## Summary
`fetchLocalConflictFiles` in `scripts/loop/detect-pr-gate-coordination-state.mjs` shells out to the real `git status --porcelain` when a test does not inject a git stub. Under parallel `npm run verify`, concurrent git activity in the working tree transiently reports unmerged entries, flipping the gh-driven `detect-pr-gate-coordination-state` and `pre-approval-gate-detector` suites from `draft_review`/`pre_approval` to `conflict_resolution`.

This makes the conflict-files detection path test-hermetic by seeding a clean local `git` stub in the shared `writeGhStub` test wrapper, so the subprocess CLI resolves the stubbed `git` on `PATH` instead of the real working tree. No production behavior change.

## Scope
Test-only change. One file: `test/loop/detect-pr-gate-coordination-state.test.mjs`.

## File-by-file
- `test/loop/detect-pr-gate-coordination-state.test.mjs`: the shared `writeGhStub` wrapper now also writes a clean git stub (empty porcelain output) into the same temp dir that is already prepended to `PATH`, and merges its `GIT_*` env. Every subprocess (`runNode`) test in this file therefore resolves `git` to the stub. The existing conflict-resolution test still overwrites the stub afterward to inject its own unmerged output, so its behavior is unchanged. Mirrors the pre-existing `writeGitStub` real-git stub pattern already used in this file.

## Acceptance criteria (from #1006)
- The conflict-files detection path is stubbed/guarded in the affected suites.
- Repeated and parallel local `npm run verify` is deterministic, with no transient `conflict_resolution` flips.
- No production behavior change.

## Definition of done
- Both affected suites are hermetic against the real working tree.
- Full `npm run verify` is green.
- No production files modified.

## Non-goals
- No change to `fetchLocalConflictFiles` or any production behavior.
- No new test framework, fixtures, or per-function suites.
- No change to how real conflicts are detected in production runs.

## Validation
- `node --test test/loop/detect-pr-gate-coordination-state.test.mjs` passes (21 pass, 0 fail), run 8x back-to-back deterministically.
- Ran the suite 3x while concurrently churning the real working tree (`git status` + touch/rm in a background loop) with no `conflict_resolution` flips.
- `npm run verify` is green (1934 + 1755 + 32 tests, 0 fail).
- `git diff --stat origin/main..HEAD` shows only the one test file changed (no production change).