### PR TITLE
feat(pages): add a GitHub repo link (inline icon) to the site nav

### DIFF
--- a/scripts/pages/build-site.mjs
+++ b/scripts/pages/build-site.mjs
@@ -60,7 +60,14 @@ const NAV_CSS = `
   .site-nav-brand { font-weight: 700; letter-spacing: -0.01em; color: var(--heading); text-decoration: none; border: 0; margin-right: auto; }
   .site-nav-links { display: flex; flex-wrap: wrap; gap: 0.5rem 1.1rem; }
   .site-nav a { color: var(--kicker); text-decoration: none; font-size: 0.9rem; border: 0; }
-  .site-nav a:hover { color: var(--accent-soft); }`;
+  .site-nav a:hover { color: var(--accent-soft); }
+  .site-nav-gh { display: inline-flex; align-items: center; }
+  .site-nav-gh svg { width: 1.15rem; height: 1.15rem; fill: currentColor; display: block; }`;
+
+// The repository the site links to from its nav. Inline SVG (GitHub octicon mark)
+// so it renders under the page's strict CSP (img-src is data:-only; no external icon).
+const REPO_URL = 'https://github.com/mfittko/dev-loops';
+const GITHUB_ICON = '<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg>';
 
 function navMarkup() {
   const links = NAV_LINKS.map((l) => `        <a href="${l.file}">${l.label}</a>`).join('\n');
@@ -68,6 +75,7 @@ function navMarkup() {
       <a class="site-nav-brand" href="index.html">dev-loops</a>
       <div class="site-nav-links">
 ${links}
+        <a class="site-nav-gh" href="${REPO_URL}" aria-label="dev-loops on GitHub">${GITHUB_ICON}</a>
       </div>
     </nav>`;
 }

--- a/scripts/pages/build-site.mjs
+++ b/scripts/pages/build-site.mjs
@@ -62,26 +62,30 @@ const NAV_CSS = `
   .site-nav a { color: var(--kicker); text-decoration: none; font-size: 0.9rem; border: 0; }
   .site-nav a:hover { color: var(--accent-soft); }
   .site-nav-gh { display: inline-flex; align-items: center; }
-  .site-nav-gh svg { width: 1.15rem; height: 1.15rem; fill: currentColor; display: block; }`;
+  .site-nav-gh svg { width: 1.125rem; height: 1.125rem; fill: currentColor; display: block; }`;
 
-// The repository the site links to from its nav. Derived from package.json's
-// repository.url (single source of truth) so a repo rename/move updates the nav
-// link too, rather than drifting from a hardcoded copy. The '.git' suffix is
-// stripped to yield the browsable web URL.
-const REPO_URL = JSON.parse(
-  await readFile(join(REPO_ROOT_DEFAULT, 'package.json'), 'utf8'),
-).repository.url.replace(/\.git$/, '');
+// The repository the site links to from its nav. Derived from the effective
+// repoRoot's package.json repository.url (single source of truth) so a repo
+// rename/move updates the nav link too, rather than drifting from a hardcoded
+// copy. Resolved inside buildSite from its repoRoot param (not at module load)
+// so --repo-root / buildSite({ repoRoot }) reads the right package.json and no
+// I/O runs merely on import. The '.git' suffix is stripped for the web URL.
+async function resolveRepoUrl(repoRoot) {
+  return JSON.parse(
+    await readFile(join(repoRoot, 'package.json'), 'utf8'),
+  ).repository.url.replace(/\.git$/, '');
+}
 // Inline SVG (GitHub octicon mark) so it renders under the page's strict CSP
 // (img-src is data:-only; no external icon).
 const GITHUB_ICON = '<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg>';
 
-function navMarkup() {
+function navMarkup(repoUrl) {
   const links = NAV_LINKS.map((l) => `        <a href="${l.file}">${l.label}</a>`).join('\n');
   return `<nav class="site-nav" aria-label="dev-loops resources">
       <a class="site-nav-brand" href="index.html">dev-loops</a>
       <div class="site-nav-links">
 ${links}
-        <a class="site-nav-gh" href="${REPO_URL}" aria-label="dev-loops on GitHub">${GITHUB_ICON}</a>
+        <a class="site-nav-gh" href="${repoUrl}" aria-label="dev-loops on GitHub">${GITHUB_ICON}</a>
       </div>
     </nav>`;
 }
@@ -90,13 +94,13 @@ ${links}
 // markup right after <body>. Idempotent enough for assembly (each source file
 // is read once). Throws if the page lacks the expected anchors so a structural
 // drift fails the build rather than publishing an un-navigable page.
-export function injectNav(html) {
+export function injectNav(html, repoUrl) {
   if (!html.includes('</style>') || !/<body[^>]*>/.test(html)) {
     throw new Error('cannot inject nav: page is missing a <style> block or <body> tag');
   }
   return html
     .replace('</style>', `${NAV_CSS}\n</style>`)
-    .replace(/<body([^>]*)>/, `<body$1>\n    ${navMarkup()}`);
+    .replace(/<body([^>]*)>/, `<body$1>\n    ${navMarkup(repoUrl)}`);
 }
 
 export async function buildSite({ repoRoot = REPO_ROOT_DEFAULT, outDir } = {}) {
@@ -115,14 +119,16 @@ export async function buildSite({ repoRoot = REPO_ROOT_DEFAULT, outDir } = {}) {
   await rm(out, { recursive: true, force: true });
   await mkdir(out, { recursive: true });
 
+  const repoUrl = await resolveRepoUrl(repoRoot);
+
   // Landing page: the intro article, navigable, published as index.html.
   const landingHtml = await readFile(join(articlesDir, LANDING.file), 'utf8');
-  await writeFile(join(out, 'index.html'), injectNav(landingHtml), 'utf8');
+  await writeFile(join(out, 'index.html'), injectNav(landingHtml, repoUrl), 'utf8');
 
   // Deep-dive article: published with the same nav so the set is navigable.
   for (const article of ARTICLES) {
     const html = await readFile(join(articlesDir, article.file), 'utf8');
-    await writeFile(join(out, article.file), injectNav(html), 'utf8');
+    await writeFile(join(out, article.file), injectNav(html, repoUrl), 'utf8');
   }
 
   // Decks: self-contained slide renders, copied as-is (no nav injection).

--- a/scripts/pages/build-site.mjs
+++ b/scripts/pages/build-site.mjs
@@ -70,10 +70,18 @@ const NAV_CSS = `
 // copy. Resolved inside buildSite from its repoRoot param (not at module load)
 // so --repo-root / buildSite({ repoRoot }) reads the right package.json and no
 // I/O runs merely on import. The '.git' suffix is stripped for the web URL.
-async function resolveRepoUrl(repoRoot) {
-  return JSON.parse(
-    await readFile(join(repoRoot, 'package.json'), 'utf8'),
-  ).repository.url.replace(/\.git$/, '');
+// npm's `repository` field may be a string ("github:owner/repo" or a full URL)
+// or an object { type, url }. Accept both; fail with an explicit, actionable
+// message when neither yields a URL, rather than an implicit TypeError.
+export async function resolveRepoUrl(repoRoot) {
+  const { repository } = JSON.parse(await readFile(join(repoRoot, 'package.json'), 'utf8'));
+  const raw = typeof repository === 'string' ? repository : repository?.url;
+  if (!raw) {
+    throw new Error(`cannot resolve repo URL: package.json at ${repoRoot} has no repository.url`);
+  }
+  return raw
+    .replace(/^github:/, 'https://github.com/')
+    .replace(/\.git$/, '');
 }
 // Inline SVG (GitHub octicon mark) so it renders under the page's strict CSP
 // (img-src is data:-only; no external icon).

--- a/scripts/pages/build-site.mjs
+++ b/scripts/pages/build-site.mjs
@@ -64,9 +64,15 @@ const NAV_CSS = `
   .site-nav-gh { display: inline-flex; align-items: center; }
   .site-nav-gh svg { width: 1.15rem; height: 1.15rem; fill: currentColor; display: block; }`;
 
-// The repository the site links to from its nav. Inline SVG (GitHub octicon mark)
-// so it renders under the page's strict CSP (img-src is data:-only; no external icon).
-const REPO_URL = 'https://github.com/mfittko/dev-loops';
+// The repository the site links to from its nav. Derived from package.json's
+// repository.url (single source of truth) so a repo rename/move updates the nav
+// link too, rather than drifting from a hardcoded copy. The '.git' suffix is
+// stripped to yield the browsable web URL.
+const REPO_URL = JSON.parse(
+  await readFile(join(REPO_ROOT_DEFAULT, 'package.json'), 'utf8'),
+).repository.url.replace(/\.git$/, '');
+// Inline SVG (GitHub octicon mark) so it renders under the page's strict CSP
+// (img-src is data:-only; no external icon).
 const GITHUB_ICON = '<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg>';
 
 function navMarkup() {

--- a/test/pages/build-site.test.mjs
+++ b/test/pages/build-site.test.mjs
@@ -10,6 +10,16 @@ import { buildSite, injectNav, ARTICLES, DECKS, NAV_LINKS } from '../../scripts/
 // share the source basename), else its source file name.
 const deckOut = (d) => d.outFile ?? d.file;
 
+const REPO_URL = 'https://github.com/mfittko/dev-loops';
+
+// Extract the .site-nav-gh anchor's href and inner HTML so assertions bind to
+// that specific anchor (not any <svg> that may appear in page content).
+function ghAnchor(html) {
+  const m = html.match(/<a class="site-nav-gh"[^>]*href="([^"]+)"[^>]*>(.*?)<\/a>/s);
+  assert.ok(m, 'page has a .site-nav-gh anchor');
+  return { href: m[1], inner: m[2] };
+}
+
 test('build-site: index is the intro article, all resources published, nav links the others', async () => {
   const out = await mkdtemp(join(tmpdir(), 'pages-site-'));
   try {
@@ -33,14 +43,17 @@ test('build-site: index is the intro article, all resources published, nav links
       assert.ok(index.includes(`>${l.label}</a>`), `nav shows ${l.label}`);
     }
     assert.ok(index.includes('class="site-nav"'), 'index carries the nav bar');
-    // Nav carries a GitHub repo link with an inline (CSP-safe) icon.
-    assert.ok(index.includes('href="https://github.com/mfittko/dev-loops"'), 'nav links the GitHub repo');
-    assert.ok(index.includes('class="site-nav-gh"') && index.includes('<svg'), 'nav GitHub link uses an inline SVG icon');
+    // Nav's GitHub anchor links the repo with an inline (CSP-safe) icon.
+    const indexGh = ghAnchor(index);
+    assert.equal(indexGh.href, REPO_URL, 'index GitHub nav anchor links the repo');
+    assert.ok(indexGh.inner.includes('<svg'), 'index GitHub nav anchor uses an inline SVG icon');
 
     // Deep-dive articles also carry the nav so the set is navigable.
     const deep = await readFile(join(out, ARTICLES[0].file), 'utf8');
     assert.ok(deep.includes('class="site-nav"'), 'deep-dive article carries the nav bar');
-    assert.ok(deep.includes('class="site-nav-gh"'), 'deep-dive article carries the GitHub nav link');
+    const deepGh = ghAnchor(deep);
+    assert.equal(deepGh.href, REPO_URL, 'deep-dive GitHub nav anchor links the repo');
+    assert.ok(deepGh.inner.includes('<svg'), 'deep-dive GitHub nav anchor uses an inline SVG icon');
 
     assert.deepEqual(
       result.files.sort(),
@@ -52,8 +65,8 @@ test('build-site: index is the intro article, all resources published, nav links
 });
 
 test('injectNav fails closed when a page lacks the expected structure', () => {
-  assert.throws(() => injectNav('<html><body>no style block</body></html>'), /missing a <style> block or <body>/);
-  assert.throws(() => injectNav('<style>x</style> no body'), /missing a <style> block or <body>/);
+  assert.throws(() => injectNav('<html><body>no style block</body></html>', REPO_URL), /missing a <style> block or <body>/);
+  assert.throws(() => injectNav('<style>x</style> no body', REPO_URL), /missing a <style> block or <body>/);
 });
 
 test('build-site refuses to wipe filesystem root', async () => {

--- a/test/pages/build-site.test.mjs
+++ b/test/pages/build-site.test.mjs
@@ -1,10 +1,10 @@
-import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { buildSite, injectNav, ARTICLES, DECKS, NAV_LINKS } from '../../scripts/pages/build-site.mjs';
+import { buildSite, injectNav, resolveRepoUrl, ARTICLES, DECKS, NAV_LINKS } from '../../scripts/pages/build-site.mjs';
 
 // A deck publishes under its outFile when set (the deep-dive article and deck
 // share the source basename), else its source file name.
@@ -71,6 +71,24 @@ test('injectNav fails closed when a page lacks the expected structure', () => {
 
 test('build-site refuses to wipe filesystem root', async () => {
   await assert.rejects(() => buildSite({ outDir: '/' }), /refusing to wipe unsafe output dir/);
+});
+
+test('resolveRepoUrl accepts string/object forms and throws a clear error when missing', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'pages-repo-url-'));
+  const write = (repository) =>
+    writeFile(join(dir, 'package.json'), JSON.stringify(repository === undefined ? {} : { repository }), 'utf8');
+  try {
+    await write({ type: 'git', url: 'https://github.com/mfittko/dev-loops.git' });
+    assert.equal(await resolveRepoUrl(dir), REPO_URL, 'object form: strips .git');
+
+    await write('github:mfittko/dev-loops');
+    assert.equal(await resolveRepoUrl(dir), REPO_URL, 'string shorthand normalizes to https URL');
+
+    await write(undefined);
+    await assert.rejects(() => resolveRepoUrl(dir), /has no repository\.url/, 'missing repository throws explicit error');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
 test('build-site refuses to wipe repoRoot itself', async () => {

--- a/test/pages/build-site.test.mjs
+++ b/test/pages/build-site.test.mjs
@@ -33,10 +33,14 @@ test('build-site: index is the intro article, all resources published, nav links
       assert.ok(index.includes(`>${l.label}</a>`), `nav shows ${l.label}`);
     }
     assert.ok(index.includes('class="site-nav"'), 'index carries the nav bar');
+    // Nav carries a GitHub repo link with an inline (CSP-safe) icon.
+    assert.ok(index.includes('href="https://github.com/mfittko/dev-loops"'), 'nav links the GitHub repo');
+    assert.ok(index.includes('class="site-nav-gh"') && index.includes('<svg'), 'nav GitHub link uses an inline SVG icon');
 
     // Deep-dive articles also carry the nav so the set is navigable.
     const deep = await readFile(join(out, ARTICLES[0].file), 'utf8');
     assert.ok(deep.includes('class="site-nav"'), 'deep-dive article carries the nav bar');
+    assert.ok(deep.includes('class="site-nav-gh"'), 'deep-dive article carries the GitHub nav link');
 
     assert.deepEqual(
       result.files.sort(),


### PR DESCRIPTION
## Summary

Adds a GitHub repo link to the shared header nav on the published pages, using an inline SVG octicon.

## Scope and context

Touches only the shared nav injected by `scripts/pages/build-site.mjs` (and its unit test). No article content or other nav items change.

## File-by-file changes

- `scripts/pages/build-site.mjs` — new `.site-nav-gh` CSS (inline-flex, 1.125rem = 18px `currentColor` SVG) and an inline `GITHUB_ICON` octicon const. The repo URL is not hardcoded: an exported async helper `resolveRepoUrl(repoRoot)` reads the effective repoRoot's package.json `repository.url` (single source of truth), accepts both npm string and `{type,url}` object forms plus the `github:` shorthand, strips a trailing `.git`, and throws an explicit error when no URL is present. `buildSite` resolves it once from its `repoRoot` and threads it through `injectNav(html, repoUrl)` → `navMarkup(repoUrl)`, which renders a `.site-nav-gh` anchor with a dynamic `href="${repoUrl}"` at the end of the nav links row (no module-load I/O side effect).
- `test/pages/build-site.test.mjs` — asserts (via a shared anchor-extraction helper) that the `.site-nav-gh` anchor carries the expected repo href and an inline `<svg>` on both the index and deep-dive pages, and unit-tests `resolveRepoUrl` for the object form, the `github:` shorthand, and the explicit missing-`repository.url` error.

## Acceptance criteria (from #1054)

- Nav links `https://github.com/mfittko/dev-loops`.
- Inline SVG icon (no external image) — required by the strict CSP (`img-src data:`).
- Reuses nav link color/hover, vertically aligned, layout unbroken (desktop + mobile).
- Present on index and deep-dive pages.

## Definition of done

Build-site unit test green; article-smoke CI green; visually verified via Playwright (icon found, `href` = repo, 18×18 SVG, icon mid-Y = nav mid-Y).

## Non-goals

Other social/edit links; other nav changes.

## Validation

`node --test test/pages/build-site.test.mjs` ; `node scripts/pages/build-site.mjs` then inspect the nav.

Closes #1054

