### PR TITLE
chore(config): pin queue.projectNumber to skip board-title lookup

### DIFF
--- a/.devloops
+++ b/.devloops
@@ -90,6 +90,10 @@ localImplementation:
     maxLines: 100
 
 queue:
+  # projectNumber pins the GitHub Projects V2 board by number so queue commands
+  # skip the boardTitle -> number lookup (a gh project list call). boardTitle is
+  # kept as a human-readable fallback / for board bootstrap.
+  projectNumber: 3
   boardTitle: "dev-loops Queue"
   maxParallel: 3
   maxAutoFiledIssues: 10


### PR DESCRIPTION
## Summary

Pins `queue.projectNumber: 3` in `.devloops` so queue commands resolve the GitHub Projects V2 board by number instead of by title.

## Why

`queue add` / `sync-status` / `archive-done` resolve the board from `.devloops`. With only `boardTitle` set, they must map the title to a project number via a `gh project list` lookup. `queue.projectNumber` is a first-class, schema-validated config key that the resolvers prefer over `boardTitle`, skipping that lookup. Surfaced during PR #1055's session when enqueueing a follow-up required resolving the board number by hand.

## Change

- `.devloops`: add `queue.projectNumber: 3` (board "dev-loops Queue"). `boardTitle` stays as the human-readable fallback / bootstrap title.

## Validation

Config loads with zero validation errors; `queue.projectNumber` resolves to 3 and `boardTitle` unchanged (`loadDevLoopConfig()`).

## Non-goals

No behavior change to queue commands beyond the resolution shortcut; no other config keys touched.
