### PR TITLE
fix(loop): resolve repo root/ledger worktree-relative, not from cwd (#1052, #1019, #1050)

### DIFF
--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -18,7 +18,7 @@ import { loadDevLoopConfig, resolveGateConfig, resolveRequireFanoutEvidence } fr
 import { buildLogPath } from "./write-gate-findings-log.mjs";
 import { ensureAsyncRunnerOwnership } from "../loop/_pr-runner-coordination.mjs";
 import { detectStaleRunner } from "../loop/_stale-runner-detection.mjs";
-import { resolveLedgerCheckouts } from "../loop/_repo-root-resolver.mjs";
+import { resolveLedgerCheckouts, resolveRepoRoot } from "../loop/_repo-root-resolver.mjs";
 const USAGE = `Usage: detect-checkpoint-evidence.mjs --repo <owner/name> --pr <number>
 Fetch the live PR head SHA and visible PR issue comments, then summarize the
 latest valid draft-gate and pre-approval checkpoint verdict comments. Always fail
@@ -392,7 +392,7 @@ export async function detectCheckpointEvidence(options, { env = process.env, ghC
   // treat it as config-unavailable and leave fan-out enforcement disabled
   // (preserves default behavior). Other gate checks remain unaffected.
   let config = null;
-  const { config: loadedConfig, errors: configErrors } = await loadDevLoopConfig({ repoRoot: cwd });
+  const { config: loadedConfig, errors: configErrors } = await loadDevLoopConfig({ repoRoot: resolveRepoRoot(cwd) });
   config = Array.isArray(configErrors) && configErrors.length > 0 ? null : loadedConfig;
   const fanoutEnforcement = await buildFanoutEnforcement({
     repo: options.repo,

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -18,6 +18,7 @@ import { loadDevLoopConfig, resolveGateConfig, resolveRequireFanoutEvidence } fr
 import { buildLogPath } from "./write-gate-findings-log.mjs";
 import { ensureAsyncRunnerOwnership } from "../loop/_pr-runner-coordination.mjs";
 import { detectStaleRunner } from "../loop/_stale-runner-detection.mjs";
+import { resolveLedgerCheckouts } from "../loop/_repo-root-resolver.mjs";
 const USAGE = `Usage: detect-checkpoint-evidence.mjs --repo <owner/name> --pr <number>
 Fetch the live PR head SHA and visible PR issue comments, then summarize the
 latest valid draft-gate and pre-approval checkpoint verdict comments. Always fail
@@ -288,6 +289,19 @@ async function ledgerExists(fullPath) {
   }
 }
 /**
+ * True if the ledger (relative path) exists under ANY enumerated checkout
+ * (main + every worktree). Fixes #1050: a ledger written in the PR worktree is
+ * found even when the check runs from a different checkout's git-toplevel.
+ */
+async function ledgerExistsInAny(checkouts, ledgerPath) {
+  for (const root of checkouts) {
+    if (await ledgerExists(path.resolve(root, ledgerPath))) {
+      return true;
+    }
+  }
+  return false;
+}
+/**
  * Build the fan-out evidence enforcement descriptor.
  *
  * Enforcement is ON by default (opt-out via gates.requireFanoutEvidence: false).
@@ -298,7 +312,7 @@ async function ledgerExists(fullPath) {
  * reviewed head SHA so the pre-merge check can fail closed on inline verdicts or
  * missing ledgers.
  */
-async function buildFanoutEnforcement({ repo, pr, currentHeadSha, draftGateMarker, preApprovalGateMarker, config, cwd }) {
+export async function buildFanoutEnforcement({ repo, pr, currentHeadSha, draftGateMarker, preApprovalGateMarker, config, cwd }) {
   // Fail open when config could not be loaded/validated. `== null` covers both
   // null and undefined; the loader only ever yields null on failure, but the
   // loose check defensively treats an absent config as unavailable.
@@ -312,15 +326,15 @@ async function buildFanoutEnforcement({ repo, pr, currentHeadSha, draftGateMarke
     { name: "pre_approval_gate", marker: preApprovalGateMarker, required: preApprovalRequired },
   ].filter((spec) => spec.required && spec.marker.visible);
   const gates = [];
+  const checkouts = resolveLedgerCheckouts(cwd);
   for (const spec of gateSpecs) {
     const headSha = spec.marker.headSha ?? currentHeadSha;
     const ledgerPath = buildLogPath({ repo, pr, gate: spec.name, headSha, tmpRoot: "tmp" });
-    const fullPath = path.resolve(cwd, ledgerPath);
     gates.push({
       name: spec.name,
       executionMode: spec.marker.executionMode ?? null,
       ledgerPath,
-      ledgerExists: await ledgerExists(fullPath),
+      ledgerExists: await ledgerExistsInAny(checkouts, ledgerPath),
     });
   }
   return { required: true, gates };

--- a/scripts/loop/_repo-root-resolver.mjs
+++ b/scripts/loop/_repo-root-resolver.mjs
@@ -1,0 +1,46 @@
+/**
+ * Shared worktree-relative repo-root / ledger-checkout resolver (issue #1052,
+ * folds #1019 and #1050). ONE shared resolver: derive repo root from the
+ * checkout under operation (git-toplevel, not ambient cwd) for config reads,
+ * and enumerate ALL checkouts (main + every worktree) for ledger reads so a
+ * ledger written in any worktree is visible regardless of which checkout runs
+ * the check.
+ *
+ * #1050: the pre-PR-worktree flow means the session cwd is a DIFFERENT checkout
+ * than the PR worktree. Ledgers get written cwd-relative in the PR worktree but
+ * read cwd-relative from the session checkout, so they diverge and clean gates
+ * false-block on "missing pre-merge gate evidence". resolveLedgerCheckouts
+ * enumerates every checkout so a ledger written in one is found from any.
+ *
+ * #1019: .devloops is read at EXACTLY <repoRoot>/.devloops with no upward walk.
+ * Reading it from process.cwd() (a subdir or sibling checkout) silently falls
+ * back to defaults (maxCopilotRounds -> 5). resolveRepoRoot derives the root
+ * from the checkout's git-toplevel so config resolves correctly.
+ */
+import { execFileSync } from "node:child_process";
+import { parseAllWorktreePaths, parseMainWorktreePath } from "@dev-loops/core/loop/worktree-guard";
+
+export function resolveRepoRoot(cwd, { gitCommand = "git" } = {}) {
+  try {
+    return execFileSync(gitCommand, ["rev-parse", "--show-toplevel"], {
+      cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"],
+    }).trim() || cwd;
+  } catch {
+    return cwd;
+  }
+}
+
+export function resolveLedgerCheckouts(cwd, { gitCommand = "git" } = {}) {
+  const roots = [];
+  const add = (p) => { if (typeof p === "string" && p.length > 0 && !roots.includes(p)) roots.push(p); };
+  add(resolveRepoRoot(cwd, { gitCommand }));
+  try {
+    const listing = execFileSync(gitCommand, ["worktree", "list"], {
+      cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"],
+    });
+    add(parseMainWorktreePath(listing));
+    for (const p of parseAllWorktreePaths(listing)) add(p);
+  } catch { /* git unavailable: cwd-toplevel is all we have */ }
+  if (roots.length === 0) add(cwd);
+  return roots;
+}

--- a/scripts/loop/_repo-root-resolver.mjs
+++ b/scripts/loop/_repo-root-resolver.mjs
@@ -26,6 +26,7 @@ export function resolveRepoRoot(cwd, { gitCommand = "git" } = {}) {
       cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"],
     }).trim() || cwd;
   } catch {
+    // git failed or cwd is not inside a git repo (or git is unavailable) -> fall back to cwd.
     return cwd;
   }
 }
@@ -40,7 +41,7 @@ export function resolveLedgerCheckouts(cwd, { gitCommand = "git" } = {}) {
     });
     add(parseMainWorktreePath(listing));
     for (const p of parseAllWorktreePaths(listing)) add(p);
-  } catch { /* git unavailable: cwd-toplevel is all we have */ }
+  } catch { /* git failed, not inside a git repo, or git unavailable: cwd-toplevel is all we have */ }
   if (roots.length === 0) add(cwd);
   return roots;
 }

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -3,13 +3,13 @@ import { buildParseError, formatCliError, isCopilotLogin, isDirectCliRun, normal
 import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { detectRepoSlug, parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { resolveRunId } from "@dev-loops/core/loop/run-context";
-import path from "node:path";
 import { loadDevLoopConfig, resolveRefinement } from "@dev-loops/core/config";
 import { autoDetectSnapshot } from "./detect-copilot-loop-state.mjs";
 import { performCopilotReviewRequest } from "../github/request-copilot-review.mjs";
 import { detectInternalOnly as detectPrInternalOnly } from "./detect-internal-only-pr.mjs";
 import { applyConfirmedReviewRequest, interpretLoopState, NEXT_ACTIONS, STATE, summarizeLoopInterpretation, TRANSITIONS } from "@dev-loops/core/loop/copilot-loop-state";
 import { ensureAsyncRunnerOwnership } from "./_pr-runner-coordination.mjs";
+import { resolveRepoRoot } from "./_repo-root-resolver.mjs";
 
 
 import {
@@ -305,7 +305,7 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
     repo: options.repo,
     pr: options.pr,
     env,
-    cwd: path.resolve(process.cwd()),
+    cwd: resolveRepoRoot(process.cwd()),
     claimIfMissing: true,
   });
   if (!runnerOwnership.ok) {
@@ -337,7 +337,7 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
     { repo: options.repo, pr: options.pr },
     { env, ghCommand },
   );
-  const config = await loadDevLoopConfig({ repoRoot: path.resolve(process.cwd()) });
+  const config = await loadDevLoopConfig({ repoRoot: resolveRepoRoot(process.cwd()) });
   if (config.errors?.length > 0) {
     console.error("[copilot-pr-handoff] config warnings:", JSON.stringify(config.errors));
   }

--- a/scripts/loop/detect-copilot-loop-state.mjs
+++ b/scripts/loop/detect-copilot-loop-state.mjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 import { readFile } from "node:fs/promises";
-import path from "node:path";
 import { parseArgs } from "node:util";
 import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import {
@@ -28,6 +27,7 @@ import {
   normalizeHeadScopedCommitStatus,
   normalizeHeadScopedCiContract,
 } from "@dev-loops/core/loop/copilot-ci-status";
+import { resolveRepoRoot } from "./_repo-root-resolver.mjs";
 const USAGE = `Usage:
   detect-copilot-loop-state.mjs --repo <owner/name> --pr <number>
   detect-copilot-loop-state.mjs --input <path>
@@ -445,7 +445,7 @@ export async function runCli(
     interpretationInput = snapshot;
   }
   let interpretation;
-  const config = await loadDevLoopConfig({ repoRoot: path.resolve(process.cwd()) });
+  const config = await loadDevLoopConfig({ repoRoot: resolveRepoRoot(process.cwd()) });
   const refinementConfig = config.errors.length > 0
     ? resolveRefinement({ version: 1 })
     : resolveRefinement(config.config);

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -20,6 +20,7 @@ import { shouldGuardCopilotReviewRequest } from "@dev-loops/core/loop/pr-gate-co
 import { UI_E2E_CHECK_NAMES } from "@dev-loops/core/loop/ui-e2e-scoping";
 import { fetchGithubReviewThreadsPayload } from "../github/capture-review-threads.mjs";
 import { detectCheckpointEvidence } from "../github/detect-checkpoint-evidence.mjs";
+import { resolveRepoRoot } from "./_repo-root-resolver.mjs";
 import { parseArgs } from "node:util";
 const UNMERGED_GIT_STATUS_CODES = new Set(["DD", "AU", "UD", "UA", "DU", "AA", "UU"]);
 const USAGE = `Usage: detect-pr-gate-coordination-state.mjs --repo <owner/name> --pr <number>
@@ -346,7 +347,6 @@ export async function loadRefinementArtifact({ repo, prData, prDraft, prClosed, 
   // Note: `finding`/`missing` here is only enforced by the gate when the PR is
   // draft (`_onlyEnforcedWhenDraft`); closed/merged PRs surface it informationally.
   const firstEvaluated = evaluated[0];
-  const first = firstEvaluated.artifact;
   const allFailed = evaluated.every((e) => e.artifact === null);
   if (allFailed) {
     // Preserve prior single-issue semantics: draft → missing, else unknown.
@@ -368,9 +368,14 @@ export async function loadRefinementArtifact({ repo, prData, prDraft, prClosed, 
       reason: `Failed to fetch body for linked issue(s) ${scopeLabel}; refinement status is unknown.`,
     };
   }
+  // Mixed branch: not allFailed, so at least one body fetched but none is
+  // refined. Report against the first successfully-fetched (non-null) issue —
+  // `evaluated[0]` may be a failed fetch (null artifact) and has no fields.
+  const firstFetched = evaluated.find((e) => e.artifact !== null);
+  const first = firstFetched.artifact;
   return {
     status: "missing",
-    linkedIssue: firstEvaluated.issue,
+    linkedIssue: firstFetched.issue,
     linkedIssues,
     refinedIssues,
     source: first.source,
@@ -461,7 +466,7 @@ export async function loadPrGateCoordinationContext(options, runtime = {}) {
   // READY_TO_REREQUEST_REVIEW, dead-ending the loop at the round cap (#896). This
   // keeps the gate-coordination interpretation consistent with the standalone
   // detect-copilot-loop-state path and with request-copilot-review's cap logic.
-  const interpreterRepoRoot = runtime.repoRoot ?? process.cwd();
+  const interpreterRepoRoot = runtime.repoRoot ?? resolveRepoRoot(process.cwd());
   const interpreterConfigResult = await loadDevLoopConfig({ repoRoot: interpreterRepoRoot });
   const interpreterRefinementConfig = (Array.isArray(interpreterConfigResult.errors) && interpreterConfigResult.errors.length > 0)
     ? resolveRefinement({ version: 1 })
@@ -515,7 +520,7 @@ async function fetchCopilotEverFormallyRequested({ repo, pr }, { env = process.e
 
 export async function detectPrGateCoordinationState(options, runtime = {}) {
   const context = await loadPrGateCoordinationContext(options, runtime);
-  const repoRoot = runtime.repoRoot ?? process.cwd();
+  const repoRoot = runtime.repoRoot ?? resolveRepoRoot(process.cwd());
   const configLoadResult = await loadDevLoopConfig({ repoRoot });
   const hasConfigErrors = Array.isArray(configLoadResult.errors) && configLoadResult.errors.length > 0;
   const config = hasConfigErrors ? {} : (configLoadResult.config ?? {});

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -226,25 +226,38 @@ export function deriveUiE2ePassed(prData, checkNames = UI_E2E_CHECK_NAMES) {
   });
 }
 
-export function resolveLinkedIssueFromPr(prData) {
-  if (!prData || typeof prData !== "object") return null;
+// Ordered, de-duplicated list of ALL closing-referenced issue numbers for a PR.
+// Umbrella PRs legitimately close multiple issues (#1052), so the refinement
+// guard resolves against every one of them, not just a unique single ref.
+export function resolveLinkedIssuesFromPr(prData) {
+  if (!prData || typeof prData !== "object") return [];
+  const dedupe = (nums) => {
+    const seen = new Set();
+    const out = [];
+    for (const n of nums) {
+      if (Number.isInteger(n) && n > 0 && !seen.has(n)) {
+        seen.add(n);
+        out.push(n);
+      }
+    }
+    return out;
+  };
   const closing = Array.isArray(prData.closingIssuesReferences) ? prData.closingIssuesReferences : [];
-  const closingNumbers = closing
-    .map((entry) => Number(entry?.number))
-    .filter((n) => Number.isInteger(n) && n > 0);
-  if (closingNumbers.length === 1) {
-    return closingNumbers[0];
+  const closingNumbers = dedupe(closing.map((entry) => Number(entry?.number)));
+  if (closingNumbers.length > 0) {
+    return closingNumbers;
   }
   const body = typeof prData.body === "string" ? prData.body : "";
-  if (body.length === 0) return null;
+  if (body.length === 0) return [];
   const matches = body.match(/(?:closes|fixes|resolves)\s+#(\d+)/gi) || [];
-  const bodyNumbers = matches
-    .map((m) => Number((/(\d+)/.exec(m) || [])[1]))
-    .filter((n) => Number.isInteger(n) && n > 0);
-  if (bodyNumbers.length === 1) {
-    return bodyNumbers[0];
-  }
-  return null;
+  return dedupe(matches.map((m) => Number((/(\d+)/.exec(m) || [])[1])));
+}
+
+// Backward-compatible single-value resolver: preserves the "exactly one linked
+// issue" contract for external consumers.
+export function resolveLinkedIssueFromPr(prData) {
+  const arr = resolveLinkedIssuesFromPr(prData);
+  return arr.length === 1 ? arr[0] : null;
 }
 async function fetchIssueBody({ repo, issue }, { env = process.env, ghCommand = "gh" } = {}) {
   const result = await runChild(
@@ -262,13 +275,14 @@ async function fetchIssueBody({ repo, issue }, { env = process.env, ghCommand = 
     return null;
   }
 }
-async function loadRefinementArtifact({ repo, prData, prDraft, prClosed, prMerged }, { env = process.env, ghCommand = "gh" } = {}) {
-  const linkedIssue = resolveLinkedIssueFromPr(prData);
-  if (linkedIssue === null) {
+export async function loadRefinementArtifact({ repo, prData, prDraft, prClosed, prMerged }, { env = process.env, ghCommand = "gh" } = {}) {
+  const linkedIssues = resolveLinkedIssuesFromPr(prData);
+  if (linkedIssues.length === 0) {
     if (prDraft) {
       return {
         status: "missing",
         linkedIssue: null,
+        linkedIssues: [],
         reason: "Draft PR has no deterministically resolvable linked issue (no closingIssuesReferences, no unique Closes/Fixes/Resolves pattern in body); draft gate cannot verify a refinement artifact.",
         finding: "missing_refinement_artifact",
       };
@@ -276,44 +290,98 @@ async function loadRefinementArtifact({ repo, prData, prDraft, prClosed, prMerge
     return {
       status: "unknown",
       linkedIssue: null,
+      linkedIssues: [],
       reason: "No deterministically resolvable linked issue (no closingIssuesReferences, no unique Closes/Fixes/Resolves pattern in body).",
     };
   }
+  const scopeLabel = linkedIssues.map((n) => `#${n}`).join(", ");
   if (!prDraft && !prClosed && !prMerged) {
     return {
       status: "unknown",
-      linkedIssue,
-      reason: `Linked issue #${linkedIssue} detected; refinement check is a draft-gate boundary and the PR is not draft, so the check is informational only and does not fetch the issue body.`,
+      linkedIssue: linkedIssues.length === 1 ? linkedIssues[0] : null,
+      linkedIssues,
+      reason: `Linked issue(s) ${scopeLabel} detected (${linkedIssues.length}); refinement check is a draft-gate boundary and the PR is not draft, so the check is informational only and does not fetch issue bodies.`,
     };
   }
-  const body = await fetchIssueBody({ repo, issue: linkedIssue }, { env, ghCommand });
-  if (body === null) {
+  const { detectIssueRefinementArtifact } = await import("@dev-loops/core/loop/issue-refinement-artifact");
+  // Fetch and evaluate every closing-referenced issue. An umbrella PR's scope
+  // is refined if AT LEAST ONE linked issue carries a refinement artifact.
+  const evaluated = [];
+  for (const issue of linkedIssues) {
+    const body = await fetchIssueBody({ repo, issue }, { env, ghCommand });
+    if (body === null) {
+      evaluated.push({ issue, artifact: null });
+      continue;
+    }
+    evaluated.push({ issue, artifact: detectIssueRefinementArtifact({ body, issueNumber: issue }) });
+  }
+  const refinedIssues = evaluated
+    .filter((e) => e.artifact && e.artifact.hasACs === true)
+    .map((e) => e.issue);
+  const firstPresent = evaluated.find((e) => e.artifact && e.artifact.hasACs === true);
+  const isUmbrella = linkedIssues.length > 1;
+
+  if (firstPresent) {
+    const a = firstPresent.artifact;
+    return {
+      status: "present",
+      linkedIssue: firstPresent.issue,
+      linkedIssues,
+      refinedIssues,
+      source: a.source,
+      acItems: a.acItems,
+      dodItems: a.dodItems,
+      sections: a.sections,
+      linkedDoc: a.linkedDoc,
+      reason: isUmbrella
+        ? `Refinement artifact present via linked issue #${firstPresent.issue} (umbrella PR closes ${scopeLabel}).`
+        : a.reason,
+      finding: a.finding,
+      _onlyEnforcedWhenDraft: prDraft === true,
+    };
+  }
+
+  // None of the linked issues carry a refinement artifact (or all bodies failed
+  // to fetch). Report against the first linked issue for single-value consumers.
+  // Note: `finding`/`missing` here is only enforced by the gate when the PR is
+  // draft (`_onlyEnforcedWhenDraft`); closed/merged PRs surface it informationally.
+  const firstEvaluated = evaluated[0];
+  const first = firstEvaluated.artifact;
+  const allFailed = evaluated.every((e) => e.artifact === null);
+  if (allFailed) {
+    // Preserve prior single-issue semantics: draft → missing, else unknown.
     if (prDraft) {
       return {
         status: "missing",
-        linkedIssue,
-        reason: `Failed to fetch body for linked issue #${linkedIssue}; draft gate cannot verify a refinement artifact, treating as missing.`,
+        linkedIssue: firstEvaluated.issue,
+        linkedIssues,
+        refinedIssues,
+        reason: `Failed to fetch body for linked issue(s) ${scopeLabel}; draft gate cannot verify a refinement artifact, treating as missing.`,
         finding: "missing_refinement_artifact",
       };
     }
     return {
       status: "unknown",
-      linkedIssue,
-      reason: `Failed to fetch body for linked issue #${linkedIssue}; refinement status is unknown.`,
+      linkedIssue: linkedIssues.length === 1 ? linkedIssues[0] : firstEvaluated.issue,
+      linkedIssues,
+      refinedIssues,
+      reason: `Failed to fetch body for linked issue(s) ${scopeLabel}; refinement status is unknown.`,
     };
   }
-  const { detectIssueRefinementArtifact } = await import("@dev-loops/core/loop/issue-refinement-artifact");
-  const artifact = detectIssueRefinementArtifact({ body, issueNumber: linkedIssue });
   return {
-    status: artifact.hasACs ? "present" : "missing",
-    linkedIssue,
-    source: artifact.source,
-    acItems: artifact.acItems,
-    dodItems: artifact.dodItems,
-    sections: artifact.sections,
-    linkedDoc: artifact.linkedDoc,
-    reason: artifact.reason,
-    finding: artifact.finding,
+    status: "missing",
+    linkedIssue: firstEvaluated.issue,
+    linkedIssues,
+    refinedIssues,
+    source: first.source,
+    acItems: first.acItems,
+    dodItems: first.dodItems,
+    sections: first.sections,
+    linkedDoc: first.linkedDoc,
+    reason: isUmbrella
+      ? `No linked issue (${scopeLabel}) carries a refinement artifact (ACs/DoD); draft gate cannot verify a refinement artifact.`
+      : first.reason,
+    finding: "missing_refinement_artifact",
     _onlyEnforcedWhenDraft: prDraft === true,
   };
 }

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -254,12 +254,6 @@ export function resolveLinkedIssuesFromPr(prData) {
   return dedupe(matches.map((m) => Number((/(\d+)/.exec(m) || [])[1])));
 }
 
-// Backward-compatible single-value resolver: preserves the "exactly one linked
-// issue" contract for external consumers.
-export function resolveLinkedIssueFromPr(prData) {
-  const arr = resolveLinkedIssuesFromPr(prData);
-  return arr.length === 1 ? arr[0] : null;
-}
 async function fetchIssueBody({ repo, issue }, { env = process.env, ghCommand = "gh" } = {}) {
   const result = await runChild(
     ghCommand,

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -284,7 +284,7 @@ export async function loadRefinementArtifact({ repo, prData, prDraft, prClosed, 
         status: "missing",
         linkedIssue: null,
         linkedIssues: [],
-        reason: "Draft PR has no deterministically resolvable linked issue (no closingIssuesReferences, no unique Closes/Fixes/Resolves pattern in body); draft gate cannot verify a refinement artifact.",
+        reason: "Draft PR has no deterministically resolvable linked issue (no closingIssuesReferences and no Closes/Fixes/Resolves #n reference in body); draft gate cannot verify a refinement artifact.",
         finding: "missing_refinement_artifact",
       };
     }
@@ -292,7 +292,7 @@ export async function loadRefinementArtifact({ repo, prData, prDraft, prClosed, 
       status: "unknown",
       linkedIssue: null,
       linkedIssues: [],
-      reason: "No deterministically resolvable linked issue (no closingIssuesReferences, no unique Closes/Fixes/Resolves pattern in body).",
+      reason: "No deterministically resolvable linked issue (no closingIssuesReferences and no Closes/Fixes/Resolves #n reference in body).",
     };
   }
   const scopeLabel = linkedIssues.map((n) => `#${n}`).join(", ");

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -370,7 +370,8 @@ export async function loadRefinementArtifact({ repo, prData, prDraft, prClosed, 
   }
   // Mixed branch: not allFailed, so at least one body fetched but none is
   // refined. Report against the first successfully-fetched (non-null) issue —
-  // `evaluated[0]` may be a failed fetch (null artifact) and has no fields.
+  // `evaluated[0]` may be a failed fetch: it still retains its `issue` field but
+  // has `artifact: null` (body fetch / artifact detection failed for that issue).
   const firstFetched = evaluated.find((e) => e.artifact !== null);
   const first = firstFetched.artifact;
   return {

--- a/test/github/detect-checkpoint-evidence-cross-worktree.test.mjs
+++ b/test/github/detect-checkpoint-evidence-cross-worktree.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, realpath } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { buildFanoutEnforcement } from "../../scripts/github/detect-checkpoint-evidence.mjs";
+import { writeGateFindingsLog } from "../../scripts/github/write-gate-findings-log.mjs";
+
+function git(cwd, args) {
+  execFileSync("git", args, { cwd, stdio: ["ignore", "pipe", "ignore"] });
+}
+
+async function makeRepoWithWorktrees() {
+  const base = await realpath(await mkdtemp(path.join(os.tmpdir(), "dev-loops-xwt-")));
+  const repoA = path.join(base, "a");
+  git(base, ["init", "-q", repoA]);
+  git(repoA, ["config", "user.email", "test@example.com"]);
+  git(repoA, ["config", "user.name", "Test"]);
+  git(repoA, ["commit", "--allow-empty", "-q", "-m", "init"]);
+  const repoB = path.join(base, "b");
+  git(repoA, ["worktree", "add", "-q", "-b", "feature", repoB]);
+  return { base, repoA, repoB: await realpath(repoB) };
+}
+
+// Config with requireFanoutEvidence + both gates required, mirroring the enforced posture.
+const CONFIG = {
+  gates: {
+    requireFanoutEvidence: true,
+    draft: { required: true },
+    preApproval: { required: true },
+  },
+};
+
+const HEAD = "abc1234def5678";
+const MARKER = { visible: true, headSha: HEAD, executionMode: "fanout_fanin" };
+
+test("cross-worktree: ledger written in worktree A is found when checked from worktree B (#1050)", async () => {
+  const { base, repoA, repoB } = await makeRepoWithWorktrees();
+  try {
+    // Write the fan-out ledger in worktree A.
+    await writeGateFindingsLog(
+      { repo: "owner/repo", pr: "42", gate: "draft_gate", headSha: HEAD, verdict: "clean", findings: "[]" },
+      { repoRoot: repoA },
+    );
+
+    // Check from worktree B — the ledger lives in A, not B.
+    const result = await buildFanoutEnforcement({
+      repo: "owner/repo",
+      pr: "42",
+      currentHeadSha: HEAD,
+      draftGateMarker: MARKER,
+      preApprovalGateMarker: MARKER,
+      config: CONFIG,
+      cwd: repoB,
+    });
+
+    assert.equal(result.required, true);
+    const draft = result.gates.find((g) => g.name === "draft_gate");
+    assert.ok(draft, "draft gate present");
+    assert.equal(draft.ledgerExists, true, "ledger written in A must be visible from B");
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("negative: ledger absent in all checkouts reports ledgerExists false", async () => {
+  const { base, repoB } = await makeRepoWithWorktrees();
+  try {
+    const result = await buildFanoutEnforcement({
+      repo: "owner/repo",
+      pr: "42",
+      currentHeadSha: HEAD,
+      draftGateMarker: MARKER,
+      preApprovalGateMarker: MARKER,
+      config: CONFIG,
+      cwd: repoB,
+    });
+
+    assert.equal(result.required, true);
+    for (const gate of result.gates) {
+      assert.equal(gate.ledgerExists, false, `${gate.name} ledger must be absent`);
+    }
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});

--- a/test/loop/detect-copilot-loop-state-repo-root.test.mjs
+++ b/test/loop/detect-copilot-loop-state-repo-root.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, rm, writeFile, realpath } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { resolveRepoRoot } from "../../scripts/loop/_repo-root-resolver.mjs";
+import { loadDevLoopConfig, resolveRefinementConfig } from "@dev-loops/core/config";
+
+function git(cwd, args) {
+  execFileSync("git", args, { cwd, stdio: ["ignore", "pipe", "ignore"] });
+}
+
+// #1019: .devloops (and thus maxCopilotRounds) must resolve from the checkout's
+// git-toplevel, not the ambient cwd. A non-default value at the repo root must
+// be picked up even when the process cwd is a subdirectory.
+test("maxCopilotRounds resolves from worktree root via resolveRepoRoot, not cwd (#1019)", async () => {
+  const repo = await realpath(await mkdtemp(path.join(os.tmpdir(), "dev-loops-1019-")));
+  try {
+    git(repo, ["init", "-q"]);
+    git(repo, ["config", "user.email", "test@example.com"]);
+    git(repo, ["config", "user.name", "Test"]);
+    // Non-default maxCopilotRounds (built-in default is 5).
+    await writeFile(path.join(repo, ".devloops"), "version: 1\nrefinement:\n  maxCopilotRounds: 2\n", "utf8");
+    git(repo, ["add", "-A"]);
+    git(repo, ["commit", "-q", "-m", "init"]);
+
+    const sub = path.join(repo, "packages", "x");
+    await mkdir(sub, { recursive: true });
+
+    // Reading cwd-relative from a subdir misses .devloops -> defaults to 5.
+    const cwdRelative = await loadDevLoopConfig({ repoRoot: sub });
+    assert.equal(resolveRefinementConfig(cwdRelative.config, "maxCopilotRounds"), 5, "cwd-relative misses .devloops");
+
+    // Worktree-relative via resolveRepoRoot finds .devloops -> 2.
+    const worktreeRelative = await loadDevLoopConfig({ repoRoot: resolveRepoRoot(sub) });
+    assert.equal(resolveRefinementConfig(worktreeRelative.config, "maxCopilotRounds"), 2, "resolveRepoRoot finds .devloops");
+  } finally {
+    await rm(repo, { recursive: true, force: true });
+  }
+});

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -230,7 +230,7 @@ test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs
         status: "unknown",
         linkedIssue: null,
         linkedIssues: [],
-        reason: "No deterministically resolvable linked issue (no closingIssuesReferences, no unique Closes/Fixes/Resolves pattern in body).",
+        reason: "No deterministically resolvable linked issue (no closingIssuesReferences and no Closes/Fixes/Resolves #n reference in body).",
       },
     });
   } finally {

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -229,6 +229,7 @@ test("detect-pr-gate-coordination-state allows post-draft flow for non-draft PRs
       refinementArtifact: {
         status: "unknown",
         linkedIssue: null,
+        linkedIssues: [],
         reason: "No deterministically resolvable linked issue (no closingIssuesReferences, no unique Closes/Fixes/Resolves pattern in body).",
       },
     });

--- a/test/loop/detect-pr-gate-coordination-umbrella.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-umbrella.test.mjs
@@ -123,6 +123,28 @@ test("loadRefinementArtifact: umbrella draft PR where NONE have ACs → missing"
   assert.equal(result._onlyEnforcedWhenDraft, true);
 });
 
+test("loadRefinementArtifact: umbrella draft PR where some fetches fail and no fetched issue is refined → missing", async (t) => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "umbrella-"));
+  t.after(() => rm(tempDir, { recursive: true, force: true }));
+  // 1052 omitted → fetch fails (body null); 1019/1050 fetch but are unrefined.
+  // allFailed is false (not every fetch failed), so this exercises the mixed
+  // partial-failure branch, not the allFailed branch.
+  const { ghCommand, env } = await writeIssueBodyGhStub(tempDir, {
+    1019: UNREFINED_BODY,
+    1050: UNREFINED_BODY,
+  });
+  const prData = { closingIssuesReferences: [{ number: 1052 }, { number: 1019 }, { number: 1050 }] };
+  const result = await loadRefinementArtifact(
+    { repo: "owner/repo", prData, prDraft: true, prClosed: false, prMerged: false },
+    { env, ghCommand },
+  );
+  assert.equal(result.status, "missing");
+  assert.equal(result.finding, "missing_refinement_artifact");
+  assert.deepEqual(result.refinedIssues, []);
+  assert.match(result.reason, /No linked issue \(#1052, #1019, #1050\) carries a refinement artifact/);
+  assert.equal(result._onlyEnforcedWhenDraft, true);
+});
+
 test("loadRefinementArtifact: single-issue draft PR unchanged — present when refined", async (t) => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "single-"));
   t.after(() => rm(tempDir, { recursive: true, force: true }));

--- a/test/loop/detect-pr-gate-coordination-umbrella.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-umbrella.test.mjs
@@ -6,7 +6,6 @@ import test from "node:test";
 
 import {
   resolveLinkedIssuesFromPr,
-  resolveLinkedIssueFromPr,
   loadRefinementArtifact,
 } from "../../scripts/loop/detect-pr-gate-coordination-state.mjs";
 
@@ -74,12 +73,6 @@ test("resolveLinkedIssuesFromPr: duplicates collapsed, first-appearance order pr
     resolveLinkedIssuesFromPr({ body: "Closes #5\nFixes #5\nResolves #7" }),
     [5, 7],
   );
-});
-
-test("resolveLinkedIssueFromPr: preserves exactly-one contract", () => {
-  assert.equal(resolveLinkedIssueFromPr({ closingIssuesReferences: [{ number: 42 }] }), 42);
-  assert.equal(resolveLinkedIssueFromPr({ closingIssuesReferences: [{ number: 1 }, { number: 2 }] }), null);
-  assert.equal(resolveLinkedIssueFromPr({ body: "no refs" }), null);
 });
 
 test("loadRefinementArtifact: umbrella draft PR where 2 of 3 issues have ACs → present", async (t) => {

--- a/test/loop/detect-pr-gate-coordination-umbrella.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-umbrella.test.mjs
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  resolveLinkedIssuesFromPr,
+  resolveLinkedIssueFromPr,
+  loadRefinementArtifact,
+} from "../../scripts/loop/detect-pr-gate-coordination-state.mjs";
+
+// AC/DoD body that detectIssueRefinementArtifact recognises as refined.
+const REFINED_BODY = [
+  "## Acceptance criteria",
+  "- [ ] first",
+  "- [ ] second",
+  "- [ ] third",
+].join("\n");
+
+// Umbrella-style body: numbered "Required work" list, no ACs/DoD heading → not refined.
+const UNREFINED_BODY = [
+  "## Required work",
+  "1. do #1019",
+  "2. do #1050",
+].join("\n");
+
+// Write a fake `gh` on PATH that answers `gh issue view <n> --json body` from a
+// number→body map. Missing entries exit non-zero (simulates a fetch failure).
+async function writeIssueBodyGhStub(tempDir, bodiesByIssue) {
+  const mapPath = path.join(tempDir, "issue-bodies.json");
+  await writeFile(mapPath, JSON.stringify(bodiesByIssue), "utf8");
+  const ghPath = path.join(tempDir, "gh");
+  const script = `#!/usr/bin/env node
+const { readFileSync } = require("node:fs");
+const map = JSON.parse(readFileSync(process.env.GH_BODIES_PATH, "utf8"));
+const args = process.argv.slice(2);
+const issue = args[args.indexOf("view") + 1];
+if (!(issue in map)) { process.exit(1); }
+process.stdout.write(JSON.stringify({ body: map[issue] }) + "\\n");
+`;
+  await writeFile(ghPath, script, "utf8");
+  await chmod(ghPath, 0o755);
+  return { ghCommand: ghPath, env: { ...process.env, GH_BODIES_PATH: mapPath } };
+}
+
+test("resolveLinkedIssuesFromPr: closingIssuesReferences with 3 entries returns all in order", () => {
+  const prData = { closingIssuesReferences: [{ number: 1052 }, { number: 1019 }, { number: 1050 }] };
+  assert.deepEqual(resolveLinkedIssuesFromPr(prData), [1052, 1019, 1050]);
+});
+
+test("resolveLinkedIssuesFromPr: body-only with 3 Closes lines returns 3 numbers in order", () => {
+  const prData = { body: "Closes #1052\nFixes #1019\nResolves #1050" };
+  assert.deepEqual(resolveLinkedIssuesFromPr(prData), [1052, 1019, 1050]);
+});
+
+test("resolveLinkedIssuesFromPr: single ref returns single-element array", () => {
+  assert.deepEqual(resolveLinkedIssuesFromPr({ closingIssuesReferences: [{ number: 42 }] }), [42]);
+  assert.deepEqual(resolveLinkedIssuesFromPr({ body: "Closes #42" }), [42]);
+});
+
+test("resolveLinkedIssuesFromPr: no refs returns empty array", () => {
+  assert.deepEqual(resolveLinkedIssuesFromPr({ body: "no refs here" }), []);
+  assert.deepEqual(resolveLinkedIssuesFromPr({}), []);
+  assert.deepEqual(resolveLinkedIssuesFromPr(null), []);
+});
+
+test("resolveLinkedIssuesFromPr: duplicates collapsed, first-appearance order preserved", () => {
+  assert.deepEqual(
+    resolveLinkedIssuesFromPr({ closingIssuesReferences: [{ number: 5 }, { number: 5 }, { number: 7 }] }),
+    [5, 7],
+  );
+  assert.deepEqual(
+    resolveLinkedIssuesFromPr({ body: "Closes #5\nFixes #5\nResolves #7" }),
+    [5, 7],
+  );
+});
+
+test("resolveLinkedIssueFromPr: preserves exactly-one contract", () => {
+  assert.equal(resolveLinkedIssueFromPr({ closingIssuesReferences: [{ number: 42 }] }), 42);
+  assert.equal(resolveLinkedIssueFromPr({ closingIssuesReferences: [{ number: 1 }, { number: 2 }] }), null);
+  assert.equal(resolveLinkedIssueFromPr({ body: "no refs" }), null);
+});
+
+test("loadRefinementArtifact: umbrella draft PR where 2 of 3 issues have ACs → present", async (t) => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "umbrella-"));
+  t.after(() => rm(tempDir, { recursive: true, force: true }));
+  const { ghCommand, env } = await writeIssueBodyGhStub(tempDir, {
+    1052: UNREFINED_BODY,
+    1019: REFINED_BODY,
+    1050: REFINED_BODY,
+  });
+  const prData = { closingIssuesReferences: [{ number: 1052 }, { number: 1019 }, { number: 1050 }] };
+  const result = await loadRefinementArtifact(
+    { repo: "owner/repo", prData, prDraft: true, prClosed: false, prMerged: false },
+    { env, ghCommand },
+  );
+  assert.equal(result.status, "present");
+  assert.equal(result.finding, null);
+  assert.deepEqual(result.linkedIssues, [1052, 1019, 1050]);
+  assert.deepEqual(result.refinedIssues, [1019, 1050]);
+  assert.equal(result.linkedIssue, 1019);
+  assert.match(result.reason, /umbrella PR closes #1052, #1019, #1050/);
+  assert.equal(result._onlyEnforcedWhenDraft, true);
+});
+
+test("loadRefinementArtifact: umbrella draft PR where NONE have ACs → missing", async (t) => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "umbrella-"));
+  t.after(() => rm(tempDir, { recursive: true, force: true }));
+  const { ghCommand, env } = await writeIssueBodyGhStub(tempDir, {
+    1052: UNREFINED_BODY,
+    1019: UNREFINED_BODY,
+    1050: UNREFINED_BODY,
+  });
+  const prData = { closingIssuesReferences: [{ number: 1052 }, { number: 1019 }, { number: 1050 }] };
+  const result = await loadRefinementArtifact(
+    { repo: "owner/repo", prData, prDraft: true, prClosed: false, prMerged: false },
+    { env, ghCommand },
+  );
+  assert.equal(result.status, "missing");
+  assert.equal(result.finding, "missing_refinement_artifact");
+  assert.deepEqual(result.refinedIssues, []);
+  assert.equal(result._onlyEnforcedWhenDraft, true);
+});
+
+test("loadRefinementArtifact: single-issue draft PR unchanged — present when refined", async (t) => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "single-"));
+  t.after(() => rm(tempDir, { recursive: true, force: true }));
+  const { ghCommand, env } = await writeIssueBodyGhStub(tempDir, { 42: REFINED_BODY });
+  const prData = { closingIssuesReferences: [{ number: 42 }] };
+  const result = await loadRefinementArtifact(
+    { repo: "owner/repo", prData, prDraft: true, prClosed: false, prMerged: false },
+    { env, ghCommand },
+  );
+  assert.equal(result.status, "present");
+  assert.equal(result.linkedIssue, 42);
+  assert.deepEqual(result.linkedIssues, [42]);
+  // Single-issue reason is the raw artifact reason (no umbrella framing).
+  assert.match(result.reason, /Acceptance criteria checklist item/);
+});
+
+test("loadRefinementArtifact: single-issue draft PR unchanged — missing when unrefined", async (t) => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "single-"));
+  t.after(() => rm(tempDir, { recursive: true, force: true }));
+  const { ghCommand, env } = await writeIssueBodyGhStub(tempDir, { 42: UNREFINED_BODY });
+  const prData = { closingIssuesReferences: [{ number: 42 }] };
+  const result = await loadRefinementArtifact(
+    { repo: "owner/repo", prData, prDraft: true, prClosed: false, prMerged: false },
+    { env, ghCommand },
+  );
+  assert.equal(result.status, "missing");
+  assert.equal(result.finding, "missing_refinement_artifact");
+});
+
+test("loadRefinementArtifact: no linked issue on draft PR → missing (unchanged)", async () => {
+  const result = await loadRefinementArtifact(
+    { repo: "owner/repo", prData: { body: "no refs" }, prDraft: true, prClosed: false, prMerged: false },
+    { env: process.env, ghCommand: "gh" },
+  );
+  assert.equal(result.status, "missing");
+  assert.equal(result.finding, "missing_refinement_artifact");
+  assert.equal(result.linkedIssue, null);
+});
+
+test("loadRefinementArtifact: non-draft open PR is informational only (does not fetch)", async () => {
+  const result = await loadRefinementArtifact(
+    {
+      repo: "owner/repo",
+      prData: { closingIssuesReferences: [{ number: 1052 }, { number: 1019 }, { number: 1050 }] },
+      prDraft: false,
+      prClosed: false,
+      prMerged: false,
+    },
+    // ghCommand deliberately invalid: informational branch must not shell out.
+    { env: process.env, ghCommand: "/nonexistent/gh" },
+  );
+  assert.equal(result.status, "unknown");
+  assert.equal(result.linkedIssue, null);
+  assert.deepEqual(result.linkedIssues, [1052, 1019, 1050]);
+});

--- a/test/loop/repo-root-resolver.test.mjs
+++ b/test/loop/repo-root-resolver.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, rm, realpath } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { resolveRepoRoot, resolveLedgerCheckouts } from "../../scripts/loop/_repo-root-resolver.mjs";
+
+function git(cwd, args) {
+  execFileSync("git", args, { cwd, stdio: ["ignore", "pipe", "ignore"] });
+}
+
+async function makeRepo() {
+  const dir = await realpath(await mkdtemp(path.join(os.tmpdir(), "dev-loops-repo-root-")));
+  git(dir, ["init", "-q"]);
+  git(dir, ["config", "user.email", "test@example.com"]);
+  git(dir, ["config", "user.name", "Test"]);
+  git(dir, ["commit", "--allow-empty", "-q", "-m", "init"]);
+  return dir;
+}
+
+test("resolveRepoRoot returns git-toplevel when cwd is a subdir of a repo", async () => {
+  const repo = await makeRepo();
+  try {
+    const sub = path.join(repo, "a", "b");
+    await mkdir(sub, { recursive: true });
+    assert.equal(resolveRepoRoot(sub), repo);
+    assert.equal(resolveRepoRoot(repo), repo);
+  } finally {
+    await rm(repo, { recursive: true, force: true });
+  }
+});
+
+test("resolveRepoRoot falls back to cwd when not a git repo", async () => {
+  const dir = await realpath(await mkdtemp(path.join(os.tmpdir(), "dev-loops-nogit-")));
+  try {
+    assert.equal(resolveRepoRoot(dir), dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveLedgerCheckouts includes main checkout and worktree, de-duped, cwd-toplevel first", async () => {
+  const repo = await makeRepo();
+  const wt = await realpath(await mkdtemp(path.join(os.tmpdir(), "dev-loops-wt-")));
+  const wtPath = path.join(wt, "worktree");
+  try {
+    git(repo, ["worktree", "add", "-q", "-b", "feature", wtPath]);
+    const wtReal = await realpath(wtPath);
+
+    // From the worktree: cwd-toplevel (worktree) must be first, main must be present.
+    const fromWt = resolveLedgerCheckouts(wtReal);
+    assert.equal(fromWt[0], wtReal, "cwd-toplevel first");
+    assert.ok(fromWt.includes(repo), "main checkout present");
+    assert.ok(fromWt.includes(wtReal), "worktree present");
+    assert.equal(new Set(fromWt).size, fromWt.length, "de-duplicated");
+
+    // From main: main first, worktree present.
+    const fromMain = resolveLedgerCheckouts(repo);
+    assert.equal(fromMain[0], repo, "cwd-toplevel first");
+    assert.ok(fromMain.includes(wtReal), "worktree present");
+    assert.equal(new Set(fromMain).size, fromMain.length, "de-duplicated");
+  } finally {
+    await rm(wt, { recursive: true, force: true });
+    await rm(repo, { recursive: true, force: true });
+  }
+});
+
+test("resolveLedgerCheckouts falls back to cwd when git is unavailable", async () => {
+  const dir = await realpath(await mkdtemp(path.join(os.tmpdir(), "dev-loops-nogit-ledger-")));
+  try {
+    const roots = resolveLedgerCheckouts(dir);
+    assert.deepEqual(roots, [dir]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/test/loop/repo-root-resolver.test.mjs
+++ b/test/loop/repo-root-resolver.test.mjs
@@ -32,10 +32,19 @@ test("resolveRepoRoot returns git-toplevel when cwd is a subdir of a repo", asyn
   }
 });
 
-test("resolveRepoRoot falls back to cwd when not a git repo", async () => {
-  const dir = await realpath(await mkdtemp(path.join(os.tmpdir(), "dev-loops-nogit-")));
+test("resolveRepoRoot falls back to cwd when cwd is not inside a git repo", async () => {
+  const dir = await realpath(await mkdtemp(path.join(os.tmpdir(), "dev-loops-notrepo-")));
   try {
     assert.equal(resolveRepoRoot(dir), dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveRepoRoot falls back to cwd when git is unavailable (exec failure)", async () => {
+  const dir = await realpath(await mkdtemp(path.join(os.tmpdir(), "dev-loops-nogit-")));
+  try {
+    assert.equal(resolveRepoRoot(dir, { gitCommand: `definitely-not-git-${Date.now()}` }), dir);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -67,10 +76,20 @@ test("resolveLedgerCheckouts includes main checkout and worktree, de-duped, cwd-
   }
 });
 
-test("resolveLedgerCheckouts falls back to cwd when git is unavailable", async () => {
-  const dir = await realpath(await mkdtemp(path.join(os.tmpdir(), "dev-loops-nogit-ledger-")));
+test("resolveLedgerCheckouts falls back to cwd when cwd is not inside a git repo", async () => {
+  const dir = await realpath(await mkdtemp(path.join(os.tmpdir(), "dev-loops-notrepo-ledger-")));
   try {
     const roots = resolveLedgerCheckouts(dir);
+    assert.deepEqual(roots, [dir]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveLedgerCheckouts returns [dir] when git is unavailable (exec failure)", async () => {
+  const dir = await realpath(await mkdtemp(path.join(os.tmpdir(), "dev-loops-nogit-ledger-")));
+  try {
+    const roots = resolveLedgerCheckouts(dir, { gitCommand: `definitely-not-git-${Date.now()}` });
     assert.deepEqual(roots, [dir]);
   } finally {
     await rm(dir, { recursive: true, force: true });


### PR DESCRIPTION
Closes #1052
Closes #1019
Closes #1050

## Summary

Multiple loop scripts resolved the repo root / `.devloops` / `tmp/` ledger location from `process.cwd()`. Under the per-PR-worktree flow the session cwd (and its git-toplevel) is a *different* checkout than the PR worktree, so cwd-bound reads silently diverged from cwd-bound writes. This umbrella establishes one shared worktree-relative resolver and fixes the confirmed symptoms. The resolution-location correctness is the theme; the one intentional gate-resolution refinement (umbrella multi-close) is called out explicitly below.

## Scope

- New shared resolver `scripts/loop/_repo-root-resolver.mjs`: `resolveRepoRoot(cwd)` (git-toplevel of the checkout under operation, not ambient cwd) and `resolveLedgerCheckouts(cwd)` (main checkout + every worktree, so a ledger written in any checkout is visible from any other).
- **#1050**: the pre-merge fan-out ledger check now looks for the ledger across all checkouts of the repo, so a ledger written in a PR worktree is visible to the merge check even when the bash-gate hook runs from a different session checkout. No more false "missing pre-merge gate evidence" block on clean gates.
- **#1019**: repo root is resolved worktree-relative before loading config, so `.devloops` (and `maxCopilotRounds`) resolve from the PR worktree instead of silently falling back to the default 5. Fixed in `detect-copilot-loop-state` and its clone in `copilot-pr-handoff`.

## File-by-file

- `scripts/loop/_repo-root-resolver.mjs` — new shared resolver (reuses `parseAllWorktreePaths` / `parseMainWorktreePath` from `@dev-loops/core/loop/worktree-guard`).
- `scripts/github/detect-checkpoint-evidence.mjs` — `buildFanoutEnforcement` checks the ledger across `resolveLedgerCheckouts(cwd)` instead of the single `path.resolve(cwd, ledgerPath)`.
- `scripts/loop/detect-copilot-loop-state.mjs` — load config from `resolveRepoRoot(process.cwd())` instead of raw `process.cwd()`.
- `scripts/loop/copilot-pr-handoff.mjs` — route config load and runner-ownership `cwd` through `resolveRepoRoot(process.cwd())` (same #1019 root-cause class).
- `scripts/loop/detect-pr-gate-coordination-state.mjs` — the two `runtime.repoRoot ?? process.cwd()` fallbacks now fall back to `resolveRepoRoot(process.cwd())`; the umbrella multi-close refinement resolution (see below); the mixed partial-fetch-failure branch now reports against the first successfully-fetched issue rather than `evaluated[0]` (which may be a failed fetch).
- Tests: cross-worktree ledger regression + resolver unit tests + worktree-relative `maxCopilotRounds`/`.devloops` resolution + umbrella refinement cases (present / all-missing / mixed partial-failure).

## Audit — process.cwd()-based repo-root/ledger resolution

Per #1052 AC #1, every `process.cwd()`-based repo-root/ledger resolution in `scripts/loop/**`, `scripts/github/**`, `.claude/hooks/**` is either fixed or justified:

**FIXED**

- `scripts/loop/detect-copilot-loop-state.mjs` — config `repoRoot` → `resolveRepoRoot`.
- `scripts/loop/copilot-pr-handoff.mjs` — config load + runner-ownership `cwd` → `resolveRepoRoot`.
- `scripts/loop/detect-pr-gate-coordination-state.mjs:464,518` — `runtime.repoRoot` fallbacks → `resolveRepoRoot(process.cwd())` (explicit `runtime.repoRoot` path was already correct; only the cwd fallback was the hazard).
- `scripts/github/detect-checkpoint-evidence.mjs` `buildFanoutEnforcement` — ledger lookup → `resolveLedgerCheckouts` across all checkouts.
- `scripts/github/detect-checkpoint-evidence.mjs:395` — config load `repoRoot` → `resolveRepoRoot(cwd)` (same #1019 divergence class as the ledger read in the same function; a raw cwd there would fail open and silently disable the fan-out evidence check).
- `.claude/hooks/pre-tool-use-bash-gate.mjs` + `write-gate-findings-log.mjs` — the cross-worktree ledger divergence, fixed on the read side via `resolveLedgerCheckouts` so the writer's worktree ledger is always visible to the reader.

**JUSTIFIED / OUT OF SCOPE**

- `scripts/loop/detect-change-scope.mjs:100` — runs in the local-implementation worktree by contract; cwd IS the worktree root, so no divergence.
- `scripts/loop/inspect-run-viewer/server.mjs` cwd reads (resolver target + config load) — operator-launched local inspect-run viewer; cwd = the launch dir the operator ran it from, not the per-PR-worktree hook/gate flow, so there is no cwd/worktree divergence to resolve here.
- `cwd = process.cwd()` DEFAULT PARAMETERS in `_pr-runner-coordination.mjs`, `_stale-runner-detection.mjs`, `steer-loop.mjs`, `conductor*.mjs`, `info.mjs`, `inspect-run-viewer/server.mjs`, etc. — injectable defaults whose callers pass an explicit `cwd`/`repoRoot`; not the divergence bug.
- The shared resolver is now available for future consolidation of the inline `git rev-parse --show-toplevel` sites (`run-refinement-audit`, `resolve-dev-loop-startup`, `ensure-worktree`, the bash-gate hook). That broad consolidation is explicitly a non-goal of this PR.

## Intentional gate-resolution change

The draft-gate refinement guard now resolves umbrella PRs that close multiple issues. Previously it required EXACTLY one closing reference, which false-blocked umbrella PRs. A PR's scope is refinement-`present` if ANY closing-referenced issue carries the refinement artifact (ACs/DoD) — the any-of contract; `refinedIssues` records which linked issues satisfied it. This is linked-issue *resolution* correctness (the theme of this PR), not a change to what the gate requires of a refined issue: the ledger format and pre-merge failure strings are unchanged.

## Acceptance

- [x] One shared resolver derives repo root from the checkout under operation, not ambient cwd
- [x] #1050: pre-merge ledger written in worktree A is found when the check runs from checkout B
- [x] #1019: `maxCopilotRounds` resolves from the worktree `.devloops`, not the cwd fallback default (both `detect-copilot-loop-state` and `copilot-pr-handoff`)
- [x] Regression test covers the cross-worktree write-A/check-B case
- [x] Audit list of remaining `process.cwd()`-based resolutions, each fixed or justified (above)
- [x] Umbrella any-of refinement resolution covered by tests (present / all-missing / mixed partial-failure)

## Definition of done

- [x] Shared resolver module added and reused by the fixed sites
- [x] Confirmed #1019/#1050 sites fixed plus the audited clones
- [x] Regression + umbrella refinement tests green
- [x] `npm run verify` green
- [x] Draft gate + pre-approval gate posted; Copilot review addressed

## Non-goals

- Wiring every `process.cwd()` caller across the codebase through the resolver (only the confirmed symptoms + the shared resolver are in scope; the rest are audited as justified/out-of-scope above).
- Broad consolidation of the inline `git rev-parse --show-toplevel` sites onto the shared resolver.
- PR→branch→worktree network lookup: the resolver enumerates local checkouts, which covers the divergence deterministically without a network call.

## Validation

- `npm run verify`
- Cross-worktree regression test (write ledger in worktree A, run pre-merge check from checkout B → found).
- Umbrella refinement cases: any-of present, all-missing, and mixed partial-fetch-failure.
