### PR TITLE
fix(inspect-run-viewer): tear down long-lived viewer server

### DIFF
--- a/scripts/loop/inspect-run-viewer.mjs
+++ b/scripts/loop/inspect-run-viewer.mjs
@@ -38,6 +38,63 @@ export {
   resetMermaidBrowserScriptCache,
   restartExistingPortListener,
 };
+// ponytail: lifetime timeout defaults to 8h; long-running viewer sessions can raise it via --lifetime-ms.
+export const DEFAULT_SERVER_LIFETIME_MS = 8 * 60 * 60 * 1000;
+
+// Wires signal handlers + a lifetime timeout so a directly-run viewer server is
+// always torn down instead of leaking across sessions. Returns an idempotent
+// teardown() that closes the server and detaches every handler it installed.
+export function installServerTeardown(
+  server,
+  {
+    signals = ["SIGINT", "SIGTERM"],
+    lifetimeMs = DEFAULT_SERVER_LIFETIME_MS,
+    onTeardown = () => {},
+    processImpl = process,
+    setTimeoutImpl = setTimeout,
+    clearTimeoutImpl = clearTimeout,
+  } = {},
+) {
+  let closed = false;
+  let lifetimeTimer = null;
+
+  const teardown = (reason = "teardown") => {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    if (lifetimeTimer !== null) {
+      clearTimeoutImpl(lifetimeTimer);
+      lifetimeTimer = null;
+    }
+    for (const signal of signals) {
+      processImpl.removeListener(signal, signalHandler);
+    }
+    try {
+      onTeardown(reason);
+    } finally {
+      server.close();
+    }
+  };
+
+  function signalHandler(signal) {
+    teardown(signal);
+  }
+
+  for (const signal of signals) {
+    processImpl.on(signal, signalHandler);
+  }
+
+  if (Number.isFinite(lifetimeMs) && lifetimeMs > 0) {
+    lifetimeTimer = setTimeoutImpl(() => teardown("lifetime-timeout"), lifetimeMs);
+    // Do not let the teardown timer itself keep the event loop alive.
+    if (typeof lifetimeTimer?.unref === "function") {
+      lifetimeTimer.unref();
+    }
+  }
+
+  return teardown;
+}
 export async function runCli(
   argv = process.argv.slice(2),
   {
@@ -75,8 +132,14 @@ export async function runCli(
 }
 const isDirectRun = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 if (isDirectRun) {
-  runCli().catch((error) => {
-    process.stderr.write(`${formatCliError(error)}\n`);
-    process.exitCode = 1;
-  });
+  runCli()
+    .then((server) => {
+      if (server) {
+        installServerTeardown(server);
+      }
+    })
+    .catch((error) => {
+      process.stderr.write(`${formatCliError(error)}\n`);
+      process.exitCode = 1;
+    });
 }

--- a/scripts/loop/inspect-run-viewer.mjs
+++ b/scripts/loop/inspect-run-viewer.mjs
@@ -38,7 +38,7 @@ export {
   resetMermaidBrowserScriptCache,
   restartExistingPortListener,
 };
-// ponytail: lifetime timeout defaults to 8h; long-running viewer sessions can raise it via --lifetime-ms.
+// ponytail: lifetime timeout defaults to 8h so a forgotten direct-run viewer cannot leak indefinitely; callers pass lifetimeMs to override.
 export const DEFAULT_SERVER_LIFETIME_MS = 8 * 60 * 60 * 1000;
 
 // Wires signal handlers + a lifetime timeout so a directly-run viewer server is

--- a/test/loop/inspect-run-viewer-teardown.test.mjs
+++ b/test/loop/inspect-run-viewer-teardown.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+
+import { installServerTeardown } from "../../scripts/loop/inspect-run-viewer.mjs";
+
+function makeServerStub() {
+  let closeCount = 0;
+  return {
+    get closeCount() {
+      return closeCount;
+    },
+    close() {
+      closeCount += 1;
+    },
+  };
+}
+
+function makeProcessStub() {
+  const emitter = new EventEmitter();
+  return {
+    emitter,
+    on: (signal, handler) => emitter.on(signal, handler),
+    removeListener: (signal, handler) => emitter.removeListener(signal, handler),
+    listenerCount: (signal) => emitter.listenerCount(signal),
+  };
+}
+
+test("teardown() closes the server and is idempotent", () => {
+  const server = makeServerStub();
+  const processImpl = makeProcessStub();
+  const teardown = installServerTeardown(server, { lifetimeMs: 0, processImpl });
+
+  teardown();
+  teardown();
+
+  assert.equal(server.closeCount, 1, "server should be closed exactly once");
+});
+
+test("SIGINT and SIGTERM each close the server via the installed handler", () => {
+  for (const signal of ["SIGINT", "SIGTERM"]) {
+    const server = makeServerStub();
+    const processImpl = makeProcessStub();
+    installServerTeardown(server, { lifetimeMs: 0, processImpl });
+
+    assert.equal(processImpl.listenerCount(signal), 1, `${signal} handler installed`);
+    processImpl.emitter.emit(signal, signal);
+
+    assert.equal(server.closeCount, 1, `${signal} should close the server`);
+    assert.equal(processImpl.listenerCount(signal), 0, `${signal} handler detached after teardown`);
+  }
+});
+
+test("lifetime timeout closes the server and the timer is unref'd", () => {
+  const server = makeServerStub();
+  const processImpl = makeProcessStub();
+  let scheduled = null;
+  let unrefCalled = false;
+  const setTimeoutImpl = (fn, ms) => {
+    scheduled = { fn, ms };
+    return { unref: () => { unrefCalled = true; } };
+  };
+  const clearTimeoutImpl = () => {};
+
+  installServerTeardown(server, {
+    lifetimeMs: 1000,
+    processImpl,
+    setTimeoutImpl,
+    clearTimeoutImpl,
+  });
+
+  assert.equal(scheduled.ms, 1000, "lifetime timer scheduled with configured ms");
+  assert.equal(unrefCalled, true, "lifetime timer is unref'd so it never keeps the loop alive");
+
+  scheduled.fn();
+  assert.equal(server.closeCount, 1, "lifetime timeout should close the server");
+});
+
+test("explicit teardown detaches all signal handlers and clears the timer", () => {
+  const server = makeServerStub();
+  const processImpl = makeProcessStub();
+  let cleared = false;
+  const teardown = installServerTeardown(server, {
+    lifetimeMs: 1000,
+    processImpl,
+    setTimeoutImpl: () => ({ unref() {} }),
+    clearTimeoutImpl: () => { cleared = true; },
+  });
+
+  teardown();
+
+  assert.equal(processImpl.listenerCount("SIGINT"), 0);
+  assert.equal(processImpl.listenerCount("SIGTERM"), 0);
+  assert.equal(cleared, true, "pending lifetime timer is cleared on teardown");
+});


### PR DESCRIPTION
Closes #1013

## Summary
The directly-run inspect-run viewer (`scripts/loop/inspect-run-viewer.mjs`) started a long-lived HTTP server that was never torn down. Orphaned instances accumulated across sessions (found running 19–27 days, reparented to PID 1), leaking ports and memory. This adds a lifecycle teardown so a directly-run server is always closed.

## Scope
- `scripts/loop/inspect-run-viewer.mjs` — the leaking script
- `test/loop/inspect-run-viewer-teardown.test.mjs` — regression test

No other files are touched. Distinct from other in-flight PRs.

## File-by-file
- `scripts/loop/inspect-run-viewer.mjs`
  - New exported `installServerTeardown(server, opts)` helper: installs SIGINT/SIGTERM handlers, an unref'd lifetime timeout (`DEFAULT_SERVER_LIFETIME_MS`, 8h), and returns an idempotent `teardown()` that closes the server and detaches every handler it installed. Signal/timer/process seams are injectable for testing.
  - Wired into the direct-run path only (`isDirectRun` block), so importing the module for tests/reuse does not attach process-global signal handlers.
- `test/loop/inspect-run-viewer-teardown.test.mjs`
  - Covers: teardown closes the server and is idempotent; SIGINT and SIGTERM each close via the installed handler; lifetime timeout closes the server and the timer is unref'd; explicit teardown detaches all signal handlers and clears the pending timer.

## Acceptance
- [ ] Directly-run viewer server is torn down (not leaked) via SIGINT/SIGTERM.
- [ ] A lifetime timeout provides a backstop teardown for idle/forgotten instances.
- [ ] An explicit `teardown()` path exists and is idempotent.
- [ ] The lifetime timer does not itself keep the process alive (unref'd).
- [ ] Regression test asserts the server closes on the teardown path.

## Definition of Done
- [ ] New and existing inspect-run-viewer tests pass.
- [ ] No behavioral change to the HTTP request handling surface.
- [ ] Change confined to the one script and its test.

## Non-goals
- No change to `createInspectRunViewerServer` request handling or routes.
- No change to the managed-instance lifecycle seam or CLI arguments.
- Not touching sibling in-flight PRs or unrelated scripts.

## Validation
- `node --test test/loop/inspect-run-viewer-teardown.test.mjs` → 4/4 pass
- `node --test test/loop/inspect-run-viewer-server.test.mjs` → 21/21 pass
