### PR TITLE
feat(gates): map LOGIC_CHANGE to a core review subset instead of fallback-to-all

### DIFF
--- a/packages/core/src/analysis/change-classifier.mjs
+++ b/packages/core/src/analysis/change-classifier.mjs
@@ -51,9 +51,11 @@ const CATEGORY_ANGLE_MAP = {
   [ChangeCategory.COMMENT_ONLY]: [
     "dry",
   ],
+  // Core review subset for any non-trivial code change. Peripheral lenses
+  // (ci-guard, link-check, packaging-runtime, config-drift, etc.) are pulled in
+  // only when the diff's other categories implicate them, not by logic alone.
   [ChangeCategory.LOGIC_CHANGE]: [
-    "correctness", "coverage", "kiss", "dry", "srp", "soc", "deep",
-    "ocp", "lsp", "isp", "dip", "yagni", "scope", "no-op", "determinism",
+    "scope", "correctness", "coverage", "determinism", "contract-surface",
   ],
 };
 
@@ -79,8 +81,9 @@ const ALWAYS_INCLUDE = new Set(["gate-evidence", "renderer-security", "pr-descri
 /**
  * Resolve which gate angles to run based on detected change categories.
  *
- * When the diff is ambiguous (contains LOGIC_CHANGE or multiple mixed categories),
- * all configured angles are recommended (fallback-to-all).
+ * When the diff is ambiguous (no detected categories / analysis failure),
+ * all configured angles are recommended (fallback-to-all). A LOGIC_CHANGE
+ * diff resolves to its core review subset, not fallback-to-all.
  *
  * @param {object} options
  * @param {string[]} options.configuredAngles — all angles configured for this gate

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -244,6 +244,15 @@ function inferCategoriesFromT0(t0) {
   if (t0.files.length > 0 && t0.files.every((f) => classifyFile(f) === "config")) categories.push("CONFIG_ONLY");
   if (t0.files.length > 0 && t0.files.every((f) => classifyFile(f) === "test")) categories.push("TEST_ONLY");
   if (t0.files.length > 0 && t0.files.every((f) => classifyFile(f) === "ci")) categories.push("CI_ONLY");
+  // Pure code-only change: a diff whose files all classify as code (and is not a
+  // rename) is a LOGIC_CHANGE. Without this, an all-code diff has a single file
+  // category (so analyzeDiff never runs hunk-level T1) and produces no category,
+  // which resolveDynamicAngles treats as "unclassifiable" → fallback-to-all. That
+  // regressed the primary case: a code-only PR must resolve to the LOGIC_CHANGE
+  // core review subset, not all angles.
+  if (!t0.renameOnly && t0.files.length > 0 && t0.files.every((f) => classifyFile(f) === "code")) {
+    categories.push("LOGIC_CHANGE");
+  }
   return categories;
 }
 

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -202,6 +202,13 @@ export function analyzeT1(diffOutput, t0) {
   // Build categories from T0 (shared with inferCategoriesFromT0) + hunk analysis.
   for (const c of t0FileCategories(t0)) categories.add(c);
   if (hasLogicChange) categories.add("LOGIC_CHANGE");
+  // Mixed diffs never satisfy the exclusive `_ONLY` checks above (some files are
+  // code), so their peripheral surfaces would be dropped. In this hunk-level path
+  // (only reached for genuinely mixed diffs), also union each surface by PRESENCE
+  // so e.g. a code+workflow diff pulls ci-guard alongside the LOGIC_CHANGE core
+  // (AC: mixed logic+CI -> core union ci-guard). The pure single-surface path
+  // (inferCategoriesFromT0) keeps exclusive semantics.
+  for (const c of t0PresentSurfaceCategories(t0)) categories.add(c);
 
   // COMMENT_ONLY: hunkCount > 0 (real diff), has changed lines, all are non-logic,
   // and not a rename-only change
@@ -244,6 +251,26 @@ function t0FileCategories(t0) {
   if (t0.files.every((f) => classifyFile(f) === "config")) categories.push("CONFIG_ONLY");
   if (t0.files.every((f) => classifyFile(f) === "test")) categories.push("TEST_ONLY");
   if (t0.files.every((f) => classifyFile(f) === "ci")) categories.push("CI_ONLY");
+  return categories;
+}
+
+/**
+ * Surface categories present in a MIXED diff (at least one file of the surface),
+ * used only by the hunk-level path to union a mixed diff's peripheral lenses on
+ * top of LOGIC_CHANGE. Reuses the same category names / angle mappings as the
+ * exclusive path; presence (not exclusivity) is the correct trigger for a mixed
+ * diff. Renames are handled by the exclusive path, so they are excluded here.
+ *
+ * @param {T0Result} t0
+ * @returns {string[]}
+ */
+function t0PresentSurfaceCategories(t0) {
+  const categories = [];
+  const cats = new Set(t0.files.map(classifyFile));
+  if (cats.has("docs")) categories.push("DOCS_ONLY");
+  if (cats.has("config")) categories.push("CONFIG_ONLY");
+  if (cats.has("test")) categories.push("TEST_ONLY");
+  if (cats.has("ci")) categories.push("CI_ONLY");
   return categories;
 }
 

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -288,9 +288,12 @@ export function analyzeDiff({ nameStatusOutput, diffOutput }) {
     };
   }
 
-  // Ambiguous is reserved for genuinely unclassifiable diffs (analysis produced
-  // no categories). LOGIC_CHANGE is a classified category (resolves to its core
-  // review subset), so it no longer forces fallback-to-all.
+  // Ambiguous means only: a diff T0 could not classify (mixed file categories, so
+  // t0Ambiguous) AND whose hunk analysis produced no category either. Both
+  // conditions are required — a single-category diff is already classified by T0
+  // inference (so it is never ambiguous), and a mixed diff that yields a category
+  // (e.g. LOGIC_CHANGE) is classified too. LOGIC_CHANGE is a real category that
+  // resolves to its core review subset, so it never forces fallback-to-all.
   const ambiguous = t0Ambiguous && t1.changeCategories.length === 0;
 
   return { t0, t1, ambiguous };

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -279,7 +279,10 @@ export function analyzeDiff({ nameStatusOutput, diffOutput }) {
     };
   }
 
-  const ambiguous = t0Ambiguous && (t1.changeCategories.length === 0 || t1.changeCategories.includes("LOGIC_CHANGE"));
+  // Ambiguous is reserved for genuinely unclassifiable diffs (analysis produced
+  // no categories). LOGIC_CHANGE is a classified category (resolves to its core
+  // review subset), so it no longer forces fallback-to-all.
+  const ambiguous = t0Ambiguous && t1.changeCategories.length === 0;
 
   return { t0, t1, ambiguous };
 }

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -288,12 +288,13 @@ export function analyzeDiff({ nameStatusOutput, diffOutput }) {
     };
   }
 
-  // Ambiguous means only: a diff T0 could not classify (mixed file categories, so
-  // t0Ambiguous) AND whose hunk analysis produced no category either. Both
-  // conditions are required — a single-category diff is already classified by T0
-  // inference (so it is never ambiguous), and a mixed diff that yields a category
-  // (e.g. LOGIC_CHANGE) is classified too. LOGIC_CHANGE is a real category that
-  // resolves to its core review subset, so it never forces fallback-to-all.
+  // `ambiguous` flags one specific case: a diff T0 could not classify (mixed file
+  // categories, so t0Ambiguous) AND whose hunk analysis still produced no
+  // category. It is NOT the only fallback trigger — resolveDynamicAngles also
+  // falls back whenever changeCategories is empty (e.g. a single lone unknown/
+  // asset file yields no category yet is not t0Ambiguous). A mixed diff that
+  // yields a category (e.g. LOGIC_CHANGE) is classified and not ambiguous, so
+  // LOGIC_CHANGE never forces fallback-to-all via this flag.
   const ambiguous = t0Ambiguous && t1.changeCategories.length === 0;
 
   return { t0, t1, ambiguous };

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -199,12 +199,8 @@ export function analyzeT1(diffOutput, t0) {
     }
   }
 
-  // Build categories from T0 + hunk analysis
-  if (t0.renameOnly) categories.add("RENAME_ONLY");
-  if (t0.allDocs) categories.add("DOCS_ONLY");
-  if (t0.files.every((f) => classifyFile(f) === "config")) categories.add("CONFIG_ONLY");
-  if (t0.files.every((f) => classifyFile(f) === "test")) categories.add("TEST_ONLY");
-  if (t0.files.every((f) => classifyFile(f) === "ci")) categories.add("CI_ONLY");
+  // Build categories from T0 (shared with inferCategoriesFromT0) + hunk analysis.
+  for (const c of t0FileCategories(t0)) categories.add(c);
   if (hasLogicChange) categories.add("LOGIC_CHANGE");
 
   // COMMENT_ONLY: hunkCount > 0 (real diff), has changed lines, all are non-logic,
@@ -232,18 +228,35 @@ export function analyzeT1(diffOutput, t0) {
  */
 
 /**
- * Infer change categories from T0 analysis when T1 is not run.
+ * Categories derivable from T0 file classification alone (no hunk content).
+ * Shared by analyzeT1 (which adds hunk-derived LOGIC_CHANGE/COMMENT_ONLY on top)
+ * and inferCategoriesFromT0 (the no-T1 path). All checks are length-guarded so an
+ * empty file list yields no category.
+ *
+ * @param {T0Result} t0
+ * @returns {string[]}
+ */
+function t0FileCategories(t0) {
+  if (t0.files.length === 0) return [];
+  const categories = [];
+  if (t0.renameOnly) categories.push("RENAME_ONLY");
+  if (t0.allDocs) categories.push("DOCS_ONLY");
+  if (t0.files.every((f) => classifyFile(f) === "config")) categories.push("CONFIG_ONLY");
+  if (t0.files.every((f) => classifyFile(f) === "test")) categories.push("TEST_ONLY");
+  if (t0.files.every((f) => classifyFile(f) === "ci")) categories.push("CI_ONLY");
+  return categories;
+}
+
+/**
+ * Infer change categories from T0 analysis when T1 (hunk-level) is not run.
+ * Reuses the shared T0 file-category derivation, then adds the pure-code
+ * LOGIC_CHANGE inference that the hunk-level path would otherwise supply.
  *
  * @param {T0Result} t0
  * @returns {string[]}
  */
 function inferCategoriesFromT0(t0) {
-  const categories = [];
-  if (t0.renameOnly) categories.push("RENAME_ONLY");
-  if (t0.allDocs) categories.push("DOCS_ONLY");
-  if (t0.files.length > 0 && t0.files.every((f) => classifyFile(f) === "config")) categories.push("CONFIG_ONLY");
-  if (t0.files.length > 0 && t0.files.every((f) => classifyFile(f) === "test")) categories.push("TEST_ONLY");
-  if (t0.files.length > 0 && t0.files.every((f) => classifyFile(f) === "ci")) categories.push("CI_ONLY");
+  const categories = t0FileCategories(t0);
   // Pure code-only change: a diff whose files all classify as code (and is not a
   // rename) is a LOGIC_CHANGE. Without this, an all-code diff has a single file
   // category (so analyzeDiff never runs hunk-level T1) and produces no category,

--- a/packages/core/test/diff-analyzer.test.mjs
+++ b/packages/core/test/diff-analyzer.test.mjs
@@ -7,6 +7,13 @@ import {
   analyzeT1,
   analyzeDiff,
 } from "../src/analysis/diff-analyzer.mjs";
+import { resolveDynamicAngles } from "../src/analysis/change-classifier.mjs";
+
+const DRAFT_ANGLES = [
+  "scope", "coverage", "correctness", "ci-guard", "contract-surface",
+  "input-validation", "determinism", "no-op", "link-check", "packaging-runtime",
+  "state-concurrency", "config-drift", "gate-evidence", "pr-description", "pr-comments",
+];
 
 // ---------------------------------------------------------------------------
 // classifyFile
@@ -178,4 +185,50 @@ test("analyzeDiff: rename-only → unambiguous", () => {
   const result = analyzeDiff({ nameStatusOutput: "R100\told.mjs\tnew.mjs" });
   assert.ok(result.t0.renameOnly);
   assert.equal(result.ambiguous, false);
+});
+
+test("analyzeDiff: pure code-only diff → LOGIC_CHANGE (not ambiguous, not fallback)", () => {
+  // AC-1: a code-only change (touches no CI/packaging/docs/config surfaces) must
+  // classify as LOGIC_CHANGE. An all-code diff has a single file category so
+  // hunk-level T1 never runs — inferCategoriesFromT0 must still classify it.
+  const result = analyzeDiff({
+    nameStatusOutput: "M\tpackages/core/src/foo.mjs\nM\tpackages/core/src/bar.mjs",
+    diffOutput: "@@ -1,1 +1,1 @@\n+const x = doThing();\n",
+  });
+  assert.deepEqual(result.t1.changeCategories, ["LOGIC_CHANGE"]);
+  assert.equal(result.ambiguous, false);
+});
+
+test("analyzeDiff → resolveDynamicAngles: pure code-only resolves to core subset, not all 15", () => {
+  // End-to-end AC-1: the real analyzeDiff → resolveDynamicAngles path for a
+  // pure-code diff must NOT fall back to all angles.
+  const result = analyzeDiff({
+    nameStatusOutput: "M\tpackages/core/src/foo.mjs",
+    diffOutput: "@@ -1,1 +1,1 @@\n+const x = doThing();\n",
+  });
+  const dyn = resolveDynamicAngles({
+    configuredAngles: DRAFT_ANGLES,
+    changeCategories: result.t1.changeCategories,
+    ambiguous: result.ambiguous,
+  });
+  assert.equal(dyn.fallbackToAll, false);
+  for (const a of ["scope", "correctness", "coverage", "determinism", "contract-surface", "gate-evidence"]) {
+    assert.ok(dyn.recommendedAngles.includes(a), `expected ${a} in core subset`);
+  }
+  assert.ok(dyn.recommendedAngles.length < DRAFT_ANGLES.length, "must be narrower than all 15");
+});
+
+test("analyzeDiff: single code file with NO diffOutput still classifies LOGIC_CHANGE", () => {
+  // The gate resolver may only have name-status. A code-only name-status must
+  // still classify LOGIC_CHANGE rather than falling back to all angles.
+  const result = analyzeDiff({ nameStatusOutput: "M\tpackages/core/src/foo.mjs" });
+  assert.deepEqual(result.t1.changeCategories, ["LOGIC_CHANGE"]);
+  assert.equal(result.ambiguous, false);
+});
+
+test("analyzeDiff: rename-only code file does NOT get LOGIC_CHANGE", () => {
+  // Guard against over-classifying: a rename of a .mjs file is RENAME_ONLY, not
+  // LOGIC_CHANGE, even though the file classifies as code.
+  const result = analyzeDiff({ nameStatusOutput: "R100\tsrc/old.mjs\tsrc/new.mjs" });
+  assert.deepEqual(result.t1.changeCategories, ["RENAME_ONLY"]);
 });

--- a/packages/core/test/diff-analyzer.test.mjs
+++ b/packages/core/test/diff-analyzer.test.mjs
@@ -147,13 +147,25 @@ test("analyzeDiff: T0 unambiguous → no T1, not ambiguous", () => {
   assert.equal(result.ambiguous, false);
 });
 
-test("analyzeDiff: T0 ambiguous with diff → runs T1, ambiguous if logic change", () => {
+test("analyzeDiff: T0 ambiguous with diff + logic change → classified, not ambiguous", () => {
   const result = analyzeDiff({
     nameStatusOutput: "M\tsrc/foo.mjs\nM\tdocs/bar.md",
     diffOutput: "@@ -1,1 +1,1 @@\n+const x = 1;\n",
   });
   assert.ok(result.t1 !== null);
-  assert.equal(result.ambiguous, true); // LOGIC_CHANGE from T1 → ambiguous
+  assert.ok(result.t1.changeCategories.includes("LOGIC_CHANGE"));
+  assert.equal(result.ambiguous, false); // LOGIC_CHANGE is now a classified category
+});
+
+test("analyzeDiff: T0 ambiguous with diff + no classifiable change → ambiguous", () => {
+  // Mixed file categories (code + unknown asset) with a context-only hunk (no
+  // added/deleted lines) yields no category → genuinely unclassifiable → fallback.
+  const result = analyzeDiff({
+    nameStatusOutput: "M\tsrc/foo.mjs\nM\tassets/logo.png",
+    diffOutput: "@@ -1,1 +1,1 @@\n unchanged context line\n",
+  });
+  assert.deepEqual(result.t1.changeCategories, []);
+  assert.equal(result.ambiguous, true);
 });
 
 test("analyzeDiff: T0 ambiguous without diff → no T1, ambiguous", () => {

--- a/packages/core/test/diff-analyzer.test.mjs
+++ b/packages/core/test/diff-analyzer.test.mjs
@@ -199,7 +199,7 @@ test("analyzeDiff: pure code-only diff → LOGIC_CHANGE (not ambiguous, not fall
   assert.equal(result.ambiguous, false);
 });
 
-test("analyzeDiff → resolveDynamicAngles: pure code-only resolves to core subset, not all 15", () => {
+test("analyzeDiff → resolveDynamicAngles: pure code-only resolves to core subset, not the full pool", () => {
   // End-to-end AC-1: the real analyzeDiff → resolveDynamicAngles path for a
   // pure-code diff must NOT fall back to all angles.
   const result = analyzeDiff({
@@ -215,7 +215,7 @@ test("analyzeDiff → resolveDynamicAngles: pure code-only resolves to core subs
   for (const a of ["scope", "correctness", "coverage", "determinism", "contract-surface", "gate-evidence"]) {
     assert.ok(dyn.recommendedAngles.includes(a), `expected ${a} in core subset`);
   }
-  assert.ok(dyn.recommendedAngles.length < DRAFT_ANGLES.length, "must be narrower than all 15");
+  assert.ok(dyn.recommendedAngles.length < DRAFT_ANGLES.length, `must be narrower than the full pool of ${DRAFT_ANGLES.length}`);
 });
 
 test("analyzeDiff: single code file with NO diffOutput still classifies LOGIC_CHANGE", () => {

--- a/packages/core/test/diff-analyzer.test.mjs
+++ b/packages/core/test/diff-analyzer.test.mjs
@@ -232,3 +232,69 @@ test("analyzeDiff: rename-only code file does NOT get LOGIC_CHANGE", () => {
   const result = analyzeDiff({ nameStatusOutput: "R100\tsrc/old.mjs\tsrc/new.mjs" });
   assert.deepEqual(result.t1.changeCategories, ["RENAME_ONLY"]);
 });
+
+// ---------------------------------------------------------------------------
+// Mixed-diff category unions (AC line 30: mixed logic+CI → core ∪ ci-guard)
+// ---------------------------------------------------------------------------
+
+test("analyzeDiff: mixed code+workflow diff unions CI_ONLY (presence, not exclusivity)", () => {
+  // The exclusive _ONLY checks never fire on a mixed diff (some files are code),
+  // so a code+workflow diff must still union the CI surface by presence.
+  const result = analyzeDiff({
+    nameStatusOutput: "M\tpackages/core/src/foo.mjs\nM\t.github/workflows/verify.yml",
+    diffOutput: "@@ -1,1 +1,1 @@\n+const x = doThing();\n",
+  });
+  assert.ok(result.t1.changeCategories.includes("LOGIC_CHANGE"));
+  assert.ok(result.t1.changeCategories.includes("CI_ONLY"));
+  assert.equal(result.ambiguous, false);
+});
+
+test("analyzeDiff → resolveDynamicAngles: mixed logic+CI resolves to core ∪ ci-guard (AC line 30)", () => {
+  const result = analyzeDiff({
+    nameStatusOutput: "M\tpackages/core/src/foo.mjs\nM\t.github/workflows/verify.yml",
+    diffOutput: "@@ -1,1 +1,1 @@\n+const x = doThing();\n",
+  });
+  const dyn = resolveDynamicAngles({
+    configuredAngles: DRAFT_ANGLES,
+    changeCategories: result.t1.changeCategories,
+    ambiguous: result.ambiguous,
+  });
+  assert.equal(dyn.fallbackToAll, false);
+  // core subset present …
+  for (const a of ["scope", "correctness", "coverage", "determinism", "contract-surface"]) {
+    assert.ok(dyn.recommendedAngles.includes(a), `expected ${a} in core subset`);
+  }
+  // … unioned with the CI-specific lens.
+  assert.ok(dyn.recommendedAngles.includes("ci-guard"), "workflow file must pull ci-guard");
+  // still narrower than the full pool (peripheral non-CI lenses stay dropped).
+  assert.ok(dyn.recommendedAngles.includes("link-check") === false, "no docs → no link-check");
+  assert.ok(dyn.recommendedAngles.length < DRAFT_ANGLES.length);
+});
+
+test("analyzeDiff → resolveDynamicAngles: mixed code+docs unions link-check, not ci-guard", () => {
+  const result = analyzeDiff({
+    nameStatusOutput: "M\tpackages/core/src/foo.mjs\nM\tdocs/guide.md",
+    diffOutput: "@@ -1,1 +1,1 @@\n+const x = doThing();\n",
+  });
+  assert.ok(result.t1.changeCategories.includes("DOCS_ONLY"));
+  const dyn = resolveDynamicAngles({
+    configuredAngles: DRAFT_ANGLES,
+    changeCategories: result.t1.changeCategories,
+    ambiguous: result.ambiguous,
+  });
+  assert.ok(dyn.recommendedAngles.includes("link-check"), "docs file must pull link-check");
+  assert.ok(dyn.recommendedAngles.includes("ci-guard") === false, "no workflow → no ci-guard");
+});
+
+test("analyzeDiff: pure single-surface diffs keep exclusive semantics (no over-union)", () => {
+  // Presence-unioning must only apply to mixed (hunk-level) diffs; a pure CI or
+  // pure docs diff still resolves to just its exclusive category.
+  assert.deepEqual(
+    analyzeDiff({ nameStatusOutput: "M\t.github/workflows/verify.yml" }).t1.changeCategories,
+    ["CI_ONLY"],
+  );
+  assert.deepEqual(
+    analyzeDiff({ nameStatusOutput: "M\tdocs/guide.md" }).t1.changeCategories,
+    ["DOCS_ONLY"],
+  );
+});

--- a/packages/core/test/dynamic-angles.test.mjs
+++ b/packages/core/test/dynamic-angles.test.mjs
@@ -82,14 +82,34 @@ test("resolveDynamicAngles: test-only includes coverage + determinism", () => {
   assert.ok(result.recommendedAngles.includes("determinism"));
 });
 
-test("resolveDynamicAngles: logic change includes many angles", () => {
+test("resolveDynamicAngles: LOGIC_CHANGE resolves to core subset, not all angles", () => {
   const result = resolveDynamicAngles({
     configuredAngles: DRAFT_ANGLES,
     changeCategories: [ChangeCategory.LOGIC_CHANGE],
   });
-  assert.ok(result.recommendedAngles.includes("correctness"));
-  assert.ok(result.recommendedAngles.includes("scope"));
-  assert.ok(result.recommendedAngles.length >= 5);
+  assert.equal(result.fallbackToAll, false);
+  // Core review subset (∩ DRAFT_ANGLES) + always-include gate-evidence.
+  for (const a of ["scope", "correctness", "coverage", "determinism", "contract-surface", "gate-evidence"]) {
+    assert.ok(result.recommendedAngles.includes(a), `expected ${a} in core subset`);
+  }
+  // Peripheral lenses are dropped, not run for logic alone.
+  for (const a of ["link-check", "packaging-runtime", "config-drift", "ci-guard", "input-validation", "state-concurrency", "no-op"]) {
+    assert.ok(result.skippedAngles.includes(a), `expected ${a} skipped`);
+    assert.ok(typeof result.reasons[a] === "string");
+  }
+  // NOT all 15 — meaningfully narrower than the configured pool.
+  assert.ok(result.recommendedAngles.length < DRAFT_ANGLES.length);
+});
+
+test("resolveDynamicAngles: mixed logic + CI unions ci-guard into the core subset", () => {
+  const result = resolveDynamicAngles({
+    configuredAngles: DRAFT_ANGLES,
+    changeCategories: [ChangeCategory.LOGIC_CHANGE, ChangeCategory.CI_ONLY],
+  });
+  assert.equal(result.fallbackToAll, false);
+  assert.ok(result.recommendedAngles.includes("ci-guard"));   // from CI_ONLY
+  assert.ok(result.recommendedAngles.includes("correctness")); // from LOGIC_CHANGE core
+  assert.ok(result.recommendedAngles.includes("config-drift")); // CI_ONLY unions this in
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/test/dynamic-angles.test.mjs
+++ b/packages/core/test/dynamic-angles.test.mjs
@@ -97,7 +97,7 @@ test("resolveDynamicAngles: LOGIC_CHANGE resolves to core subset, not all angles
     assert.ok(result.skippedAngles.includes(a), `expected ${a} skipped`);
     assert.ok(typeof result.reasons[a] === "string");
   }
-  // NOT all 15 — meaningfully narrower than the configured pool.
+  // Meaningfully narrower than the full configured pool (not a fallback-to-all).
   assert.ok(result.recommendedAngles.length < DRAFT_ANGLES.length);
 });
 


### PR DESCRIPTION
Closes #1049

## Summary

Dynamic gate-angle resolution treated any non-trivial code change as `ambiguous` → `fallbackToAll`, so every code PR ran all configured angles and `dynamicAngles` was effectively decorative for code. This maps `LOGIC_CHANGE` to a **core review subset** instead, so a typical code PR resolves to ~6 angles (5 core ∩ pool + `gate-evidence`) plus the mandatory floor, not all 15.

## Scope

- `packages/core/src/analysis/change-classifier.mjs`
- `packages/core/src/analysis/diff-analyzer.mjs`
- their tests (`packages/core/test/dynamic-angles.test.mjs`, `packages/core/test/diff-analyzer.test.mjs`)

No other files touched (distinct from other in-flight PRs).

## File-by-file

- **`change-classifier.mjs`** — narrowed the `LOGIC_CHANGE` `CATEGORY_ANGLE_MAP` entry from a 15-angle list to the core review subset `scope, correctness, coverage, determinism, contract-surface`. Corrected the stale `resolveDynamicAngles` docstring that claimed LOGIC_CHANGE → fallback-to-all.
- **`diff-analyzer.mjs`** — `analyzeDiff` no longer sets `ambiguous` when categories include `LOGIC_CHANGE`. `ambiguous` is now reserved for genuinely unclassifiable diffs (`t0Ambiguous` and no detected categories). Category unions from `CI_ONLY`/`DOCS_ONLY`/`CONFIG_ONLY` etc. are unaffected.
- **tests** — sharpened the LOGIC_CHANGE test to assert the core subset + dropped peripheral lenses + not-all-15; added a mixed logic+CI union test; updated the mixed-diff analyzer test to expect classified (not ambiguous); added a genuinely-unclassifiable → fallback test.

## Acceptance

- [ ] Code-only diff (no CI/packaging/docs/config surfaces) → LOGIC_CHANGE core subset + mandatory floor, NOT all 15 draft angles.
- [ ] Category unions preserved for **mapped** categories: workflow-file diff still pulls `ci-guard`; docs/link diff still pulls `link-check`. There is no packaging→`packaging-runtime` mapping (never existed on `main`); adding one is the additive direction #1048 and out of scope, so `packaging-runtime` is NOT an acceptance criterion.
- [ ] Genuinely unclassifiable diffs (no categories / analysis failure) still fall back to all angles.
- [ ] `mandatoryAngles` always included; `excludeAngles` always suppressed (unchanged path).
- [ ] Rationale records each dropped angle with a reason; gate-context artifact shows reduced set with `dynamicAnglesActive: true`.
- [ ] Unit coverage: LOGIC_CHANGE-only → core subset; mixed logic+CI → core ∪ ci-guard; empty categories → fallback-to-all.

## Definition of Done

- [ ] `npm run test:core` green (1773 tests).
- [ ] Affected suites (`dynamic-angles`, `diff-analyzer`) green.
- [ ] Gates clean (draft_gate → verdict → Copilot → pre_approval_gate → verdict).

## Non-goals

- Adding angles outside the configured pool (additive-authority direction — #1048).
- Changing per-reviewer file-context widening.
- Touching the mandatory-floor / exclude-ceiling merge logic in `resolveGateAnglesDynamic`.

## Validation

- `node --test packages/core/test/dynamic-angles.test.mjs packages/core/test/diff-analyzer.test.mjs` → 36 pass.
- `npm run test:core` → 1773 pass, 0 fail.

