### PR TITLE
fix(github): guard draft_gate self-heal against unbounded recursion on lagged draft-state read (#1020)

### DIFF
--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -1088,8 +1088,9 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
       `draft_gate self-heal for ${options.repo}#${options.pr} failed: the PR was converted to draft ` +
       `to post the verdict, but GitHub still reports it as non-draft on re-entry (draft-state read lagged ` +
       `the conversion mutation, or the conversion did not take). Not recursing. Re-run the draft_gate post ` +
-      `once the PR reflects the draft state, or reconcile manually with \`gh pr ready ${options.pr}\` / ` +
-      `\`node scripts/github/reconcile-draft-gate.mjs\`.`,
+      `once the PR reflects the draft state, or reconcile manually with ` +
+      `\`gh pr ready ${options.pr} --repo ${options.repo}\` / ` +
+      `\`node scripts/github/reconcile-draft-gate.mjs --repo ${options.repo} --pr ${options.pr}\`.`,
     );
   }
   if (gateActionForbidden) {

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -897,7 +897,14 @@ async function postDraftGateViaDraftTransition(options, { env, ghCommand, repoRo
   try {
     // The PR is now a draft, so RUN_DRAFT_GATE is the legal action. Re-enter with
     // the caller's full options; prIsDraft is now true so this branch is skipped.
-    result = await upsertCheckpointVerdict(options, { env, ghCommand, repoRoot });
+    // `_draftTransitionInProgress` guards against unbounded recursion: if GitHub's
+    // draft-state read still lags the conversion mutation on re-entry (isDraft reads
+    // false again), the reconcile branch must NOT fire a second time — it fails closed
+    // with a clear error instead of recursing indefinitely (exit 13). (#1020)
+    result = await upsertCheckpointVerdict(
+      { ...options, _draftTransitionInProgress: true },
+      { env, ghCommand, repoRoot },
+    );
   } catch (error) {
     if (conversion.alreadyDraft !== true) {
       try {
@@ -1060,10 +1067,30 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
   if (
     options.gate === "draft_gate"
     && !prIsDraft
+    && !options._draftTransitionInProgress
     && !coordination.draftGateAlreadySatisfied
     && coordination.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RECONCILE_DRAFT_GATE)
   ) {
     return await postDraftGateViaDraftTransition(options, { env, ghCommand, repoRoot });
+  }
+  // Fail closed on a lagged draft-state read: we are re-entering FROM
+  // postDraftGateViaDraftTransition (which just converted the PR to draft) yet the
+  // coordination context still reports the PR as non-draft. Recursing would loop
+  // indefinitely (the original #1020 hang → exit 13, error swallowed). Surface a
+  // clear, actionable error instead so the operator knows the draft conversion did
+  // not take (or GitHub's read lags the mutation) and can retry. (#1020)
+  if (
+    options.gate === "draft_gate"
+    && !prIsDraft
+    && options._draftTransitionInProgress
+  ) {
+    throw new Error(
+      `draft_gate self-heal for ${options.repo}#${options.pr} failed: the PR was converted to draft ` +
+      `to post the verdict, but GitHub still reports it as non-draft on re-entry (draft-state read lagged ` +
+      `the conversion mutation, or the conversion did not take). Not recursing. Re-run the draft_gate post ` +
+      `once the PR reflects the draft state, or reconcile manually with \`gh pr ready ${options.pr}\` / ` +
+      `\`node scripts/github/reconcile-draft-gate.mjs\`.`,
+    );
   }
   if (gateActionForbidden) {
     throw new Error(buildGateEntryRefusalError({ options, coordination }));

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -2083,6 +2083,109 @@ test("upsert-checkpoint-verdict self-heals a ready PR via draft transition, pres
   }
 });
 
+test("upsert-checkpoint-verdict fails closed (no unbounded recursion) when the draft-state read lags the conversion mutation (#1020)", async () => {
+  // REGRESSION for the #1020 hang: `postDraftGateViaDraftTransition` converts a ready
+  // PR to draft, then re-enters upsertCheckpointVerdict to post the draft_gate verdict.
+  // If GitHub's draft-state read lags the conversion (isDraft still reads FALSE on
+  // re-entry — a race / eventual-consistency), the reconcile branch previously fired
+  // AGAIN, re-converting and re-entering without bound → indefinite recursion, eventual
+  // Node exit 13 with the error swallowed. The recursion guard must short-circuit the
+  // re-entry and surface a CLEAR error instead of recursing. (#1020)
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-draft-race-"));
+
+  try {
+    const headSha = "abc1234";
+    const cleanPreApprovalComment = {
+      id: 501,
+      body: [
+        "### Gate review: `pre_approval_gate`",
+        "",
+        "**Reviewed head SHA:** `abc1234`",
+        "**Verdict:** clean",
+        "**Execution mode:** fanout_fanin",
+        "",
+        "**Findings summary:** no issues found",
+        "",
+        "**Next action:** await final human approval",
+      ].join("\n"),
+      html_url: "https://github.com/owner/repo/pull/17#issuecomment-501",
+      updated_at: "2026-05-30T17:00:00Z",
+    };
+    const copilotReviewOnHead = {
+      id: 1,
+      author: { login: "copilot-pull-request-reviewer" },
+      state: "COMMENTED",
+      submittedAt: "2026-05-30T16:00:00Z",
+      commit: { oid: headSha },
+    };
+    const prFacts = (isDraft) => JSON.stringify({
+      number: 17,
+      state: "OPEN",
+      isDraft,
+      headRefOid: headSha,
+      statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+      reviews: [copilotReviewOnHead],
+    }) + "\n";
+
+    // Both coordination passes report isDraft:false — pass 2 (the re-entry) simulates
+    // the lagged draft-state read. If the guard were absent, the poster would try to
+    // convert to draft again and re-enter a THIRD time; providing only ONE convert
+    // entry means a recursing implementation would exhaust the stub and fail loudly on
+    // the WRONG error. The guard must instead throw the clear #1020 self-heal error
+    // BEFORE any second conversion. `pr ready` is provided so a best-effort restore in
+    // the catch path (conversion.alreadyDraft !== true) is satisfied.
+    const { env: logEnvRaw, ghLogPath } = await writeGhStubHelper(tempDir, [
+      // --- coordination pass 1 (isDraft: false → reconcile) ---
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeable,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup,files"], stdout: prFacts(false) },
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[],"teams":[]}\n' },
+      { assertArgs: ["api", "graphql", "pr=17"], stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n' },
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"], stdout: '{"headRefOid":"abc1234"}\n' },
+      { assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/17/comments?per_page=100"], stdout: JSON.stringify([[cleanPreApprovalComment]]) + "\n" },
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files"], stdout: "src/index.ts\n" },
+      // --- resolve PR node id + convert to draft (ONLY ONCE) ---
+      { assertArgs: ["api", "graphql", "name=repo", "number=17"], stdout: '{"data":{"repository":{"pullRequest":{"id":"PR_node","isDraft":false}}}}\n' },
+      { assertArgs: ["api", "graphql", "pullRequestId=PR_node"], stdout: '{"data":{"convertPullRequestToDraft":{"pullRequest":{"id":"PR_node","isDraft":true}}}}\n' },
+      // --- coordination pass 2 (LAGGED read: isDraft STILL false → must NOT recurse) ---
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeable,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup,files"], stdout: prFacts(false) },
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[],"teams":[]}\n' },
+      { assertArgs: ["api", "graphql", "pr=17"], stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n' },
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"], stdout: '{"headRefOid":"abc1234"}\n' },
+      { assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/17/comments?per_page=100"], stdout: JSON.stringify([[cleanPreApprovalComment]]) + "\n" },
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files"], stdout: "src/index.ts\n" },
+      // --- best-effort restore to ready after the guarded failure ---
+      { assertArgs: ["pr", "ready", "17", "--repo", "owner/repo"], stdout: "{}\n" },
+    ], { matchMode: "claims", logCalls: true });
+    const env = { ...logEnvRaw, DEVLOOPS_RUN_ID: "" };
+
+    await assert.rejects(
+      () => upsertCheckpointVerdict({
+        repo: "owner/repo",
+        pr: 17,
+        gate: "draft_gate",
+        headSha,
+        verdict: "clean",
+        findingsSeverityCounts: { "must-fix": 0, "worth-fixing-now": 0, "defer": 0 },
+        findingsSummary: "no issues found",
+        nextAction: "mark ready for review",
+        executionMode: "fanout_fanin",
+      }, { env, repoRoot: tempDir }),
+      (error) => {
+        // Clear, actionable message — not a swallowed hang.
+        assert.match(error.message, /still reports it as non-draft on re-entry/);
+        assert.match(error.message, /Not recursing/);
+        return true;
+      },
+    );
+
+    // Exactly ONE conversion to draft — proving no unbounded re-conversion loop.
+    const ghLog = await readFile(ghLogPath, "utf8");
+    const conversions = (ghLog.match(/convertPullRequestToDraft/g) || []).length;
+    assert.equal(conversions, 1, "expected exactly one convertPullRequestToDraft (no recursion loop)");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("upsert-checkpoint-verdict already-satisfied no-op sources executionMode from the gate marker (#891 review)", async () => {
   // The already-satisfied no-op must source executionMode from the gate MARKER
   // summary (which carries executionMode), not the strict COMMENT summary (which


### PR DESCRIPTION
Closes #1020

## Summary

`postDraftGateViaDraftTransition` in `scripts/github/upsert-checkpoint-verdict.mjs` could recurse indefinitely (hang, eventual Node exit 13, error swallowed) when posting a `draft_gate` verdict on a PR that is already `ready` (non-draft) and lacks prior `draft_gate` evidence.

The helper converts the ready PR to draft, then re-enters `upsertCheckpointVerdict` to post the verdict (legal only while draft). If GitHub's draft-state read lagged the conversion mutation (a race / eventual-consistency), `prIsDraft` read `false` again on re-entry, the reconcile branch fired again, re-converted, and re-entered without bound. The `try/catch` intended to restore ready never ran (the re-entry never threw — it hung), so the error was swallowed.

Fix: a recursion guard (`_draftTransitionInProgress`) set on the re-entry. The reconcile branch no longer fires a second time; a still-non-draft re-entry now fails closed with a clear, actionable error instead of hanging. The normal post path is unchanged.

## Scope

- `scripts/github/upsert-checkpoint-verdict.mjs` — the fix (this is the same script the gate pipeline uses to post verdicts; the normal post path is untouched).
- `test/github/upsert-checkpoint-verdict.test.mjs` — regression test.

No other files touched; distinct from other in-flight PRs.

## File-by-file

- `scripts/github/upsert-checkpoint-verdict.mjs`
  - `postDraftGateViaDraftTransition`: sets `_draftTransitionInProgress: true` on the recursive `upsertCheckpointVerdict` re-entry.
  - reconcile branch (`options.gate === "draft_gate" && !prIsDraft && ...`): added `&& !options._draftTransitionInProgress` so it cannot fire a second time from within the transition.
  - added a guarded fail-closed branch: when `_draftTransitionInProgress` is set and the PR still reads non-draft, throw a clear error naming the lagged draft-state read and the manual reconcile path — instead of recursing.
- `test/github/upsert-checkpoint-verdict.test.mjs`
  - added a regression test: coordination pass 2 (the re-entry) reports `isDraft:false` (the lagged read); asserts the call rejects with the clear `still reports it as non-draft on re-entry` / `Not recursing` message and that exactly one `convertPullRequestToDraft` mutation occurred.

## Acceptance

- [ ] `upsert-checkpoint-verdict --gate draft_gate` on a ready PR with no draft_gate evidence posts the verdict and restores ready without hanging when the draft read lags conversion (existing self-heal positive test still green).
- [ ] No unbounded recursion in `postDraftGateViaDraftTransition` — a stuck/lagged draft-state read surfaces a clear error instead of hanging.
- [ ] Regression test asserts the helper errors clearly (not recurses) on the race path and performs exactly one draft conversion.

## Definition of Done

- [ ] Root-cause fix applied in the shared function (all callers routing through it are covered).
- [ ] Normal `draft_gate` post path unchanged (all 69 tests in the file pass).
- [ ] Regression test added and green; runs in <1s (proving no hang).
- [ ] `node --check` passes on both files.

## Non-goals

- No changes to `reconcile-draft-gate.mjs`, the gate state machine, or any other caller.
- No timeout/watchdog machinery added — the recursion guard alone converts the hang into a deterministic clear error (YAGNI on a timeout when the loop can no longer occur).

## Validation

- `node --test test/github/upsert-checkpoint-verdict.test.mjs` → 69 pass, 0 fail. New regression test completes in ~0.9s (previously hung).
- `node --check` clean on both changed files.
