### PR TITLE
fix(github): make reply-resolve-review-threads always terminate

### DIFF
--- a/scripts/github/reply-resolve-review-threads.mjs
+++ b/scripts/github/reply-resolve-review-threads.mjs
@@ -114,10 +114,12 @@ async function readStdinText(stdin) {
 // When --message is set, stdin is read only to detect a conflicting second
 // message source. A detached/idle pipe never sends EOF, so an unbounded read
 // hangs forever and the process never exits (issue #1012). Resolve as soon as
-// ANY data chunk arrives (a conflicting body is detected the instant bytes
-// appear — no need to wait for EOF), resolve on natural EOF, and time out on a
-// silent/idle pipe. Either way the stdin handle is released so the event loop
-// can drain and the tool always terminates.
+// any NON-WHITESPACE byte arrives (a conflicting body is detected the instant
+// real content appears — no need to wait for EOF); keep buffering while only
+// whitespace has arrived (a leading newline is not yet a conflict and more may
+// follow); resolve on natural EOF; and time out on a silent/idle pipe. Either
+// way the stdin handle is released so the event loop can drain and the tool
+// always terminates.
 const CONFLICT_STDIN_TIMEOUT_MS = 500;
 function readStdinConflictProbe(stdin, timeoutMs) {
   return new Promise((resolve) => {
@@ -145,12 +147,15 @@ function readStdinConflictProbe(stdin, timeoutMs) {
       cleanup();
       resolve(value);
     };
-    // 'text' seen on any data chunk (a conflict); '' on clean EOF with no data;
-    // undefined only on timeout (idle pipe) so the caller proceeds with --message.
+    // Resolve early only once non-whitespace content is seen (a real conflict);
+    // '' or whitespace-only on clean EOF is not a conflict; undefined only on
+    // timeout (idle pipe) so the caller proceeds with --message.
     let text = "";
     const onData = (chunk) => {
       text += String(chunk);
-      finish(text);
+      if (text.trim().length > 0) {
+        finish(text);
+      }
     };
     const onEnd = () => finish(text);
     timer = setTimeout(() => finish(undefined), timeoutMs);

--- a/scripts/github/reply-resolve-review-threads.mjs
+++ b/scripts/github/reply-resolve-review-threads.mjs
@@ -111,38 +111,57 @@ async function readStdinText(stdin) {
   }
   return text;
 }
-// ponytail: when --message is set, stdin is read only to detect a conflicting
-// second message source. A detached/idle pipe never sends EOF, so the unbounded
-// read hangs forever (issue #1012). Termination is the hard requirement, so the
-// read is bounded: on timeout we treat --message as the authoritative source and
-// proceed. Conflict detection is therefore best-effort — a body piped and closed
-// promptly (the normal case, and how the CLI is scripted) is seen and rejected;
-// a slow/never-closed producer may be missed in favor of always terminating.
-// Raise CONFLICT_STDIN_TIMEOUT_MS to widen the conflict-detection window if needed.
+// When --message is set, stdin is read only to detect a conflicting second
+// message source. A detached/idle pipe never sends EOF, so an unbounded read
+// hangs forever and the process never exits (issue #1012). Resolve as soon as
+// ANY data chunk arrives (a conflicting body is detected the instant bytes
+// appear — no need to wait for EOF), resolve on natural EOF, and time out on a
+// silent/idle pipe. Either way the stdin handle is released so the event loop
+// can drain and the tool always terminates.
 const CONFLICT_STDIN_TIMEOUT_MS = 500;
-async function readStdinTextBounded(stdin, timeoutMs) {
-  let timer;
-  const timeout = new Promise((resolve) => {
-    timer = setTimeout(() => resolve(undefined), timeoutMs);
+function readStdinConflictProbe(stdin, timeoutMs) {
+  return new Promise((resolve) => {
+    let settled = false;
+    let timer;
+    const cleanup = () => {
+      clearTimeout(timer);
+      stdin.off?.("data", onData);
+      stdin.off?.("end", onEnd);
+      stdin.off?.("error", onEnd);
+      // Release the handle: an abandoned reader on a still-open pipe would
+      // otherwise keep the event loop alive and re-introduce the hang.
+      stdin.pause?.();
+      if (typeof stdin.unref === "function") {
+        stdin.unref();
+      } else {
+        stdin.destroy?.();
+      }
+    };
+    const finish = (value) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+    // 'text' seen on any data chunk (a conflict); '' on clean EOF with no data;
+    // undefined only on timeout (idle pipe) so the caller proceeds with --message.
+    let text = "";
+    const onData = (chunk) => {
+      text += String(chunk);
+      finish(text);
+    };
+    const onEnd = () => finish(text);
+    timer = setTimeout(() => finish(undefined), timeoutMs);
     timer.unref?.();
+    stdin.setEncoding?.("utf8");
+    stdin.on?.("data", onData);
+    stdin.on?.("end", onEnd);
+    stdin.on?.("error", onEnd);
   });
-  try {
-    return await Promise.race([readStdinText(stdin), timeout]);
-  } finally {
-    clearTimeout(timer);
-    // Abandoning the for-await iterator leaves stdin referenced and flowing,
-    // which keeps the event loop alive and prevents the process from ever
-    // exiting (issue #1012). Release the handle so the tool can terminate.
-    // process.stdin always has unref(); destroy() is a hard fallback so a
-    // non-tty Readable without unref() cannot silently revert to the hang.
-    stdin.pause?.();
-    if (typeof stdin.unref === "function") {
-      stdin.unref();
-    } else {
-      stdin.destroy?.();
-    }
-  }
 }
+
 async function resolveMessageInput(options, { stdin = process.stdin } = {}) {
   if (typeof options.message === "string") {
     if (stdin.isTTY) {
@@ -151,7 +170,7 @@ async function resolveMessageInput(options, { stdin = process.stdin } = {}) {
       }
       return options.message;
     }
-    const stdinText = await readStdinTextBounded(stdin, CONFLICT_STDIN_TIMEOUT_MS);
+    const stdinText = await readStdinConflictProbe(stdin, CONFLICT_STDIN_TIMEOUT_MS);
     if (typeof stdinText === "string" && stdinText.trim().length > 0) {
       throw parseError("Choose exactly one message source: --message <text> or stdin");
     }

--- a/scripts/github/reply-resolve-review-threads.mjs
+++ b/scripts/github/reply-resolve-review-threads.mjs
@@ -111,6 +111,38 @@ async function readStdinText(stdin) {
   }
   return text;
 }
+// ponytail: when --message is set, stdin is read only to detect a conflicting
+// second message source. A detached/idle pipe never sends EOF, so the unbounded
+// read hangs forever (issue #1012). Termination is the hard requirement, so the
+// read is bounded: on timeout we treat --message as the authoritative source and
+// proceed. Conflict detection is therefore best-effort — a body piped and closed
+// promptly (the normal case, and how the CLI is scripted) is seen and rejected;
+// a slow/never-closed producer may be missed in favor of always terminating.
+// Raise CONFLICT_STDIN_TIMEOUT_MS to widen the conflict-detection window if needed.
+const CONFLICT_STDIN_TIMEOUT_MS = 500;
+async function readStdinTextBounded(stdin, timeoutMs) {
+  let timer;
+  const timeout = new Promise((resolve) => {
+    timer = setTimeout(() => resolve(undefined), timeoutMs);
+    timer.unref?.();
+  });
+  try {
+    return await Promise.race([readStdinText(stdin), timeout]);
+  } finally {
+    clearTimeout(timer);
+    // Abandoning the for-await iterator leaves stdin referenced and flowing,
+    // which keeps the event loop alive and prevents the process from ever
+    // exiting (issue #1012). Release the handle so the tool can terminate.
+    // process.stdin always has unref(); destroy() is a hard fallback so a
+    // non-tty Readable without unref() cannot silently revert to the hang.
+    stdin.pause?.();
+    if (typeof stdin.unref === "function") {
+      stdin.unref();
+    } else {
+      stdin.destroy?.();
+    }
+  }
+}
 async function resolveMessageInput(options, { stdin = process.stdin } = {}) {
   if (typeof options.message === "string") {
     if (stdin.isTTY) {
@@ -119,8 +151,8 @@ async function resolveMessageInput(options, { stdin = process.stdin } = {}) {
       }
       return options.message;
     }
-    const stdinText = await readStdinText(stdin);
-    if (stdinText.trim().length > 0) {
+    const stdinText = await readStdinTextBounded(stdin, CONFLICT_STDIN_TIMEOUT_MS);
+    if (typeof stdinText === "string" && stdinText.trim().length > 0) {
       throw parseError("Choose exactly one message source: --message <text> or stdin");
     }
     if (options.message.trim().length === 0) {

--- a/test/github/reply-resolve-review-threads.test.mjs
+++ b/test/github/reply-resolve-review-threads.test.mjs
@@ -746,38 +746,25 @@ test("reply-resolve-review-threads skips resolved human threads by default", asy
   }
 });
 
-test("reply-resolve-review-threads terminates on multi-thread input even when stdin stays open (no hang)", async () => {
+test("reply-resolve-review-threads terminates on an idle open stdin pipe with no data (no hang)", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-threads-no-hang-"));
 
   try {
     const gh = await writeGhStub(tempDir, [
       {
         stdout: createReviewThreadsPayload([
-          {
-            id: "THREAD_1",
-            isResolved: false,
-            comments: { nodes: [{ id: "PRRC_node_101", databaseId: 101, body: "note", author: { login: "Copilot", __typename: "Bot" } }] },
-          },
-          {
-            id: "THREAD_2",
-            isResolved: false,
-            comments: { nodes: [{ id: "PRRC_node_201", databaseId: 201, body: "note", author: { login: "Copilot", __typename: "Bot" } }] },
-          },
+          { id: "THREAD_1", isResolved: false, comments: { nodes: [{ id: "PRRC_node_101", databaseId: 101, body: "note", author: { login: "Copilot", __typename: "Bot" } }] } },
+          { id: "THREAD_2", isResolved: false, comments: { nodes: [{ id: "PRRC_node_201", databaseId: 201, body: "note", author: { login: "Copilot", __typename: "Bot" } }] } },
         ]),
       },
-      {
-        assertArgs: ["repos/owner/repo/pulls/17/comments/101/replies"],
-        stdout: '{"id":1401,"html_url":"https://github.com/owner/repo/pull/17#discussion_r1401"}\n',
-      },
-      {
-        assertArgs: ["repos/owner/repo/pulls/17/comments/201/replies"],
-        stdout: '{"id":1402,"html_url":"https://github.com/owner/repo/pull/17#discussion_r1402"}\n',
-      },
+      { assertArgs: ["repos/owner/repo/pulls/17/comments/101/replies"], stdout: '{"id":1401,"html_url":"https://github.com/owner/repo/pull/17#discussion_r1401"}\n' },
+      { assertArgs: ["repos/owner/repo/pulls/17/comments/201/replies"], stdout: '{"id":1402,"html_url":"https://github.com/owner/repo/pull/17#discussion_r1402"}\n' },
     ]);
 
-    // Regression for #1012: with --message set, stdin was read to detect a
-    // conflicting source. A detached/idle pipe never sends EOF, so the tool
-    // hung forever. It must terminate on its own; leave stdin open (no .end()).
+    // Regression for #1012: with --message set, stdin was probed to detect a
+    // conflicting source. A detached/idle pipe never sends EOF nor any data, so
+    // the old unbounded read hung forever. With no data, the probe times out,
+    // the tool proceeds with --message, and it must terminate cleanly.
     const result = await new Promise((resolve, reject) => {
       const child = spawn(process.execPath, [
         scriptPath,
@@ -794,10 +781,11 @@ test("reply-resolve-review-threads terminates on multi-thread input even when st
       }, 5000);
       child.on("error", reject);
       child.on("close", (code) => { clearTimeout(timer); resolve({ code, stdout, stderr }); });
-      // Intentionally do NOT end stdin, simulating a detached/idle pipe.
+      // Intentionally do NOT write or end stdin: an idle, never-EOF pipe.
     });
 
     assert.equal(result.code, 0, result.stderr);
+    assert.equal(result.stderr, "");
     const parsed = JSON.parse(result.stdout);
     assert.equal(parsed.matchedThreadCount, 2);
     assert.equal(parsed.repliedThreadCount, 2);
@@ -806,30 +794,17 @@ test("reply-resolve-review-threads terminates on multi-thread input even when st
   }
 });
 
-test("reply-resolve-review-threads terminates even when a producer holds stdin open without EOF", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-threads-open-pipe-terminates-"));
+test("reply-resolve-review-threads detects a conflicting stdin source promptly over an open (never-EOF) pipe and terminates", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-threads-open-pipe-conflict-"));
 
   try {
-    const gh = await writeGhStub(tempDir, [
-      {
-        stdout: createReviewThreadsPayload([
-          {
-            id: "THREAD_1",
-            isResolved: false,
-            comments: { nodes: [{ id: "PRRC_node_101", databaseId: 101, body: "note", author: { login: "Copilot", __typename: "Bot" } }] },
-          },
-        ]),
-      },
-      {
-        assertArgs: ["repos/owner/repo/pulls/17/comments/101/replies"],
-        stdout: '{"id":1501,"html_url":"https://github.com/owner/repo/pull/17#discussion_r1501"}\n',
-      },
-    ]);
+    // No gh calls expected: the conflict is detected before any capture.
+    const gh = await writeGhStub(tempDir, []);
 
-    // Regression for #1012: termination is the hard guarantee. Even when a
-    // producer holds stdin open (writes without ever calling .end(), so no EOF),
-    // the bounded read must fall back to --message and let the tool finish.
-    // Conflict detection is best-effort in this open-pipe case; termination is not.
+    // Regression for #1012: with --message set AND real data on stdin, the
+    // conflict must be detected as soon as bytes arrive — without waiting for
+    // EOF — and the tool must terminate (fail closed) rather than hang. Here the
+    // pipe is never ended, so only prompt (chunk-triggered) detection can pass.
     const result = await new Promise((resolve, reject) => {
       const child = spawn(process.execPath, [
         scriptPath,
@@ -842,18 +817,20 @@ test("reply-resolve-review-threads terminates even when a producer holds stdin o
       child.stderr.on("data", (chunk) => { stderr += String(chunk); });
       const timer = setTimeout(() => {
         child.kill("SIGKILL");
-        reject(new Error("reply-resolve-review-threads did not terminate on an open stdin pipe (regression #1012)"));
+        reject(new Error("reply-resolve-review-threads did not terminate on open-pipe conflict (regression #1012)"));
       }, 5000);
       child.on("error", reject);
       child.on("close", (code) => { clearTimeout(timer); resolve({ code, stdout, stderr }); });
-      // Hold the pipe open: write without ever ending it (no EOF).
-      child.stdin.write("partial body with no newline and no end");
+      // Write conflicting body but never end the pipe; the conflict must be
+      // detected on the first data chunk, before any EOF.
+      child.stdin.write("Also from stdin\n");
     });
 
-    assert.equal(result.code, 0, result.stderr);
-    const parsed = JSON.parse(result.stdout);
-    assert.equal(parsed.matchedThreadCount, 1);
-    assert.equal(parsed.repliedThreadCount, 1);
+    assert.equal(result.code, 1, result.stdout);
+    assert.equal(result.stdout, "");
+    const parsed = JSON.parse(result.stderr);
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.error, "Choose exactly one message source: --message <text> or stdin");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/github/reply-resolve-review-threads.test.mjs
+++ b/test/github/reply-resolve-review-threads.test.mjs
@@ -745,3 +745,116 @@ test("reply-resolve-review-threads skips resolved human threads by default", asy
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+test("reply-resolve-review-threads terminates on multi-thread input even when stdin stays open (no hang)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-threads-no-hang-"));
+
+  try {
+    const gh = await writeGhStub(tempDir, [
+      {
+        stdout: createReviewThreadsPayload([
+          {
+            id: "THREAD_1",
+            isResolved: false,
+            comments: { nodes: [{ id: "PRRC_node_101", databaseId: 101, body: "note", author: { login: "Copilot", __typename: "Bot" } }] },
+          },
+          {
+            id: "THREAD_2",
+            isResolved: false,
+            comments: { nodes: [{ id: "PRRC_node_201", databaseId: 201, body: "note", author: { login: "Copilot", __typename: "Bot" } }] },
+          },
+        ]),
+      },
+      {
+        assertArgs: ["repos/owner/repo/pulls/17/comments/101/replies"],
+        stdout: '{"id":1401,"html_url":"https://github.com/owner/repo/pull/17#discussion_r1401"}\n',
+      },
+      {
+        assertArgs: ["repos/owner/repo/pulls/17/comments/201/replies"],
+        stdout: '{"id":1402,"html_url":"https://github.com/owner/repo/pull/17#discussion_r1402"}\n',
+      },
+    ]);
+
+    // Regression for #1012: with --message set, stdin was read to detect a
+    // conflicting source. A detached/idle pipe never sends EOF, so the tool
+    // hung forever. It must terminate on its own; leave stdin open (no .end()).
+    const result = await new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [
+        scriptPath,
+        "--repo", "owner/repo", "--pr", "17",
+        "--message", "Fixed in 93cd7f8 with enough detail to satisfy the resolution contract.",
+      ], { env: gh.env, stdio: ["pipe", "pipe", "pipe"] });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (chunk) => { stdout += String(chunk); });
+      child.stderr.on("data", (chunk) => { stderr += String(chunk); });
+      const timer = setTimeout(() => {
+        child.kill("SIGKILL");
+        reject(new Error("reply-resolve-review-threads did not terminate (hang regression #1012)"));
+      }, 5000);
+      child.on("error", reject);
+      child.on("close", (code) => { clearTimeout(timer); resolve({ code, stdout, stderr }); });
+      // Intentionally do NOT end stdin, simulating a detached/idle pipe.
+    });
+
+    assert.equal(result.code, 0, result.stderr);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.matchedThreadCount, 2);
+    assert.equal(parsed.repliedThreadCount, 2);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("reply-resolve-review-threads terminates even when a producer holds stdin open without EOF", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-threads-open-pipe-terminates-"));
+
+  try {
+    const gh = await writeGhStub(tempDir, [
+      {
+        stdout: createReviewThreadsPayload([
+          {
+            id: "THREAD_1",
+            isResolved: false,
+            comments: { nodes: [{ id: "PRRC_node_101", databaseId: 101, body: "note", author: { login: "Copilot", __typename: "Bot" } }] },
+          },
+        ]),
+      },
+      {
+        assertArgs: ["repos/owner/repo/pulls/17/comments/101/replies"],
+        stdout: '{"id":1501,"html_url":"https://github.com/owner/repo/pull/17#discussion_r1501"}\n',
+      },
+    ]);
+
+    // Regression for #1012: termination is the hard guarantee. Even when a
+    // producer holds stdin open (writes without ever calling .end(), so no EOF),
+    // the bounded read must fall back to --message and let the tool finish.
+    // Conflict detection is best-effort in this open-pipe case; termination is not.
+    const result = await new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [
+        scriptPath,
+        "--repo", "owner/repo", "--pr", "17",
+        "--message", "Fixed in 93cd7f8 with enough detail to satisfy the resolution contract.",
+      ], { env: gh.env, stdio: ["pipe", "pipe", "pipe"] });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (chunk) => { stdout += String(chunk); });
+      child.stderr.on("data", (chunk) => { stderr += String(chunk); });
+      const timer = setTimeout(() => {
+        child.kill("SIGKILL");
+        reject(new Error("reply-resolve-review-threads did not terminate on an open stdin pipe (regression #1012)"));
+      }, 5000);
+      child.on("error", reject);
+      child.on("close", (code) => { clearTimeout(timer); resolve({ code, stdout, stderr }); });
+      // Hold the pipe open: write without ever ending it (no EOF).
+      child.stdin.write("partial body with no newline and no end");
+    });
+
+    assert.equal(result.code, 0, result.stderr);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.matchedThreadCount, 1);
+    assert.equal(parsed.repliedThreadCount, 1);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/github/reply-resolve-review-threads.test.mjs
+++ b/test/github/reply-resolve-review-threads.test.mjs
@@ -835,3 +835,45 @@ test("reply-resolve-review-threads detects a conflicting stdin source promptly o
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+test("reply-resolve-review-threads detects a conflict when a whitespace-only chunk precedes real stdin content over an open pipe", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-threads-ws-then-data-"));
+
+  try {
+    // No gh calls expected: the conflict must be detected before any capture.
+    const gh = await writeGhStub(tempDir, []);
+
+    // Regression for Copilot round 2: the conflict probe must not settle on a
+    // leading whitespace-only chunk (which would falsely proceed with --message).
+    // It must keep buffering until non-whitespace arrives, detect the conflict,
+    // and terminate — all without waiting for EOF (pipe never ends).
+    const result = await new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [
+        scriptPath,
+        "--repo", "owner/repo", "--pr", "17",
+        "--message", "Fixed in 93cd7f8 with enough detail to satisfy the resolution contract.",
+      ], { env: gh.env, stdio: ["pipe", "pipe", "pipe"] });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (chunk) => { stdout += String(chunk); });
+      child.stderr.on("data", (chunk) => { stderr += String(chunk); });
+      const timer = setTimeout(() => {
+        child.kill("SIGKILL");
+        reject(new Error("reply-resolve-review-threads did not terminate on whitespace-then-data conflict"));
+      }, 5000);
+      child.on("error", reject);
+      child.on("close", (code) => { clearTimeout(timer); resolve({ code, stdout, stderr }); });
+      // First a whitespace-only chunk, then real content — never end the pipe.
+      child.stdin.write("   \n");
+      setTimeout(() => child.stdin.write("real conflicting body\n"), 50);
+    });
+
+    assert.equal(result.code, 1, result.stdout);
+    assert.equal(result.stdout, "");
+    const parsed = JSON.parse(result.stderr);
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.error, "Choose exactly one message source: --message <text> or stdin");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #1012

## Summary
`scripts/github/reply-resolve-review-threads.mjs` (plural) hung indefinitely instead of exiting, leaving orphaned node processes accumulating as permanent background tasks (observed 1+ day old on prior PRs). Root cause: when `--message` is provided, the tool read `process.stdin` to detect a conflicting second message source via an unbounded `for await`. A detached/idle stdin pipe never sends EOF, so that read never resolved, and the abandoned async iterator left stdin referenced and flowing, keeping the event loop alive so the process never exited. The singular sibling `reply-resolve-review-thread.mjs` never touches stdin (it reads `--body-file`), which is why only the plural tool hung.

Fix: replace the stdin read with a chunk-aware conflict probe that settles as soon as any non-whitespace byte arrives (so a conflicting body is detected the instant real content appears — no EOF wait), settles on natural EOF, and times out on a silent/idle pipe. Either way the stdin handle is released (`pause()` then `unref()`, with `destroy()` fallback), so the tool always terminates while fully preserving the "exactly one message source" contract.

## Scope
One script plus its test. No other files touched. Distinct from other in-flight PRs.

## File-by-file
- `scripts/github/reply-resolve-review-threads.mjs` — replace the unbounded `--message`-path stdin read with `readStdinConflictProbe()`: settles early only on non-whitespace content, on EOF, or on a 500ms timeout; releases the stdin handle in all cases. The no-`--message` stdin-as-body path is unchanged.
- `test/github/reply-resolve-review-threads.test.mjs` — add regression tests: (a) terminates on an idle open pipe with no data (asserts `stderr === ""`), (b) detects a conflict promptly over an open never-EOF pipe (fail-closed), (c) detects a conflict when a whitespace-only chunk precedes real content over an open pipe. All verified non-vacuous (fail against the pre-fix / intermediate-bug code).

## Acceptance criteria
- [x] The plural tool either completes promptly or fails closed within a bounded time; it never produces a process that outlives the call.
- [x] The conflict-detection stdin read is bounded (times out on an idle pipe).
- [x] Existing conflict-detection behavior is preserved (both `--message` and piped stdin still errors "Choose exactly one message source"), and is detected promptly even over an open pipe.
- [x] A regression test proves the tool terminates on multi-thread / open-pipe input; repeated invocations leave no lingering `node …reply-resolve-review-threads` processes.

## Definition of done
- [x] Root-cause fix landed in `scripts/github/reply-resolve-review-threads.mjs` only.
- [x] Non-vacuous regression tests added and passing (fail against the pre-fix code).
- [x] Full `test/github/*.test.mjs` group green.
- [x] No unrelated files touched; per-thread sibling and shared modules unchanged.

## Non-goals
- No changes to the per-thread `reply-resolve-review-thread.mjs`.
- No changes to shared mutation/capture modules or GraphQL pagination.
- The separate `scripts/loop/inspect-run-viewer.mjs` HTTP-server leak is out of scope.

## AC / DoD / Non-goals matrix

| Acceptance criterion | Definition-of-done item(s) | Non-goal boundary |
|---|---|---|
| Tool completes or fails closed within bounded time (never outlives the call) | Root-cause fix landed in the plural script only; full test group green | Per-thread sibling unchanged |
| Conflict-detection stdin read is bounded (times out on idle pipe) | Non-vacuous regression test (a) idle open pipe terminates | Shared capture/mutation modules unchanged |
| Conflict detection preserved and prompt even over an open pipe | Non-vacuous regression tests (b) prompt conflict, (c) whitespace-then-content conflict | GraphQL pagination unchanged |
| Regression proves termination; no lingering node processes | All regression tests passing; verified fail against pre-fix code | inspect-run-viewer.mjs leak out of scope |

## Validation
- `node --test test/github/reply-resolve-review-threads.test.mjs` → 17 pass / 0 fail.
- `node --test test/github/*.test.mjs` → 505 pass / 0 fail.
- `npm run verify` green; GitHub CI green on the current head.
- Each regression test verified to fail against the corresponding buggy version (unbounded read; first-chunk-resolve), confirming they guard the fix.
