### PR TITLE
feat(queue): add grouped board-summary mode to 'queue list' (#1061)

### DIFF
--- a/scripts/projects/list-queue-items.mjs
+++ b/scripts/projects/list-queue-items.mjs
@@ -422,7 +422,7 @@ async function main(args, { env = process.env, runChild } = {}) {
   }
   if (args.summary && args.limit) {
     throw Object.assign(
-      new Error("--summary and --limit are mutually exclusive; use --done-limit to cap the Done group"),
+      new Error("--summary and --limit are mutually exclusive; use --done-limit to cap the Done group (or terminal column if no Done column exists)"),
       { code: "INVALID_ARGS" },
     );
   }
@@ -529,7 +529,7 @@ async function main(args, { env = process.env, runChild } = {}) {
       groups[option.name] = { count: 0, items: [] };
     }
     for (const r of results) {
-      // ponytail: status===null items get no board column — skipped, matches --column behavior.
+      // Items with null status belong to no Status option, so they are excluded here — matches --column filtering behavior.
       if (r.status === null) continue;
       const group = groups[r.status];
       if (!group) continue; // status value not among current board options

--- a/scripts/projects/list-queue-items.mjs
+++ b/scripts/projects/list-queue-items.mjs
@@ -5,6 +5,7 @@ import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult } from "../lib/jq-output.mjs";
 
 const USAGE = `Usage: dev-loops queue list --repo <owner/name> --project <number|id> [--column <name>] [--limit <n>]
+       dev-loops queue list --repo <owner/name> --project <number|id> --summary [--done-limit <n>]
        (dev-loops project list … is a back-compat alias)
 
 List GitHub Projects V2 items filtered by Status column, ordered by position
@@ -14,11 +15,23 @@ Options:
   --repo <owner/name>     Required. Repository to scope the project search.
   --project <number|id>   Required. Project number (integer) or node ID.
   --column <name>         Filter items by Status column value (e.g. "Next Up").
-  --limit <n>             Return at most <n> items.
+  --limit <n>             Return at most <n> items (flat mode only).
+  --summary               Whole-board digest grouped by Status column, in board
+                          column order. Emits { ok, groups: { <status>: { count, items } } }.
+  --group-by status       Alias for --summary. Only "status" is supported.
+  --done-limit <n>        With --summary: cap the "Done" group's items array to
+                          <n> (count stays the true total). Use 0 for counts only.
   --help, -h              Show this help.
 
+Grouping / aggregation is done via --summary (this mode). Do NOT pipe flat
+output through inline parsers (e.g. \`| python3\`) or reduce/group_by jq filters
+to build a per-status digest — the summary mode is the sanctioned one-call path.
+
+--summary is mutually exclusive with --column and --limit (both exit 1).
+
 Output (stdout):
-  JSON: { ok: true, items: [{ issueNumber, prNumber, title, url, itemId, contentId, status }, ...] }
+  flat:    { ok: true, items: [{ issueNumber, prNumber, title, url, itemId, contentId, status }, ...] }
+  summary: { ok: true, groups: { "<Status>": { count, items: [ <item>, ... ] }, ... } }
 
 ${JQ_OUTPUT_USAGE}
 
@@ -47,6 +60,9 @@ function parseCliArgs(argv) {
       project: { type: "string" },
       column: { type: "string" },
       limit: { type: "string" },
+      summary: { type: "boolean" },
+      "group-by": { type: "string" },
+      "done-limit": { type: "string" },
       help: { type: "boolean", short: "h" },
       ...JQ_OUTPUT_PARSE_OPTIONS,
     },
@@ -85,6 +101,29 @@ function parseCliArgs(argv) {
           throw parseError(`--limit must be a positive integer, got "${raw}"`);
         }
         args.limit = val;
+        break;
+      }
+      case "summary":
+        if (token.value !== undefined) {
+          throw parseError(`Unknown flag: ${token.rawName}=${token.value}`);
+        }
+        args.summary = true;
+        break;
+      case "group-by": {
+        const val = requireValue(token, "--group-by requires a value (only \"status\" is supported)");
+        if (val !== "status") {
+          throw parseError(`--group-by only supports "status", got "${val}"`);
+        }
+        args.summary = true;
+        break;
+      }
+      case "done-limit": {
+        const raw = requireValue(token, "--done-limit requires a non-negative integer");
+        const val = Number(raw);
+        if (!Number.isInteger(val) || val < 0) {
+          throw parseError(`--done-limit must be a non-negative integer, got "${raw}"`);
+        }
+        args.doneLimit = val;
         break;
       }
       case "jq":
@@ -371,6 +410,27 @@ async function main(args, { env = process.env, runChild } = {}) {
   const [owner] = repo.split("/");
   const projectRef = parseProjectRef(args.project);
 
+  // Mutual exclusion: --summary is the whole-board grouped view; --column/--limit
+  // are flat-mode knobs. Combining them is ambiguous.
+  if (args.summary && args.column) {
+    throw Object.assign(
+      new Error("--summary and --column are mutually exclusive (--column filters to one status; --summary groups the whole board)"),
+      { code: "INVALID_ARGS" },
+    );
+  }
+  if (args.summary && args.limit) {
+    throw Object.assign(
+      new Error("--summary and --limit are mutually exclusive; use --done-limit to cap the Done group"),
+      { code: "INVALID_ARGS" },
+    );
+  }
+  if (args.doneLimit !== undefined && !args.summary) {
+    throw Object.assign(
+      new Error("--done-limit only applies with --summary"),
+      { code: "INVALID_ARGS" },
+    );
+  }
+
   // 1. Resolve owner (user or org)
   const { id: ownerId, kind: ownerKind } = await resolveOwner(owner, env, child);
 
@@ -458,7 +518,27 @@ async function main(args, { env = process.env, runChild } = {}) {
     });
   }
 
-  // 5. Items are returned in position order from GraphQL. Apply limit.
+  // 5a. Summary mode: group by Status column in board option order.
+  if (args.summary) {
+    const groups = {};
+    for (const option of statusField.options) {
+      groups[option.name] = { count: 0, items: [] };
+    }
+    for (const r of results) {
+      // ponytail: status===null items get no board column — skipped, matches --column behavior.
+      if (r.status === null) continue;
+      const group = groups[r.status];
+      if (!group) continue; // status value not among current board options
+      group.count += 1;
+      group.items.push(r);
+    }
+    if (args.doneLimit !== undefined && groups.Done) {
+      groups.Done.items = groups.Done.items.slice(0, args.doneLimit);
+    }
+    return { ok: true, groups };
+  }
+
+  // 5b. Flat mode: items are returned in position order from GraphQL. Apply limit.
   const limited = args.limit ? results.slice(0, args.limit) : results;
 
   return {
@@ -498,4 +578,4 @@ if (isDirectCliRun(import.meta.url)) {
   });
 }
 
-export { main };
+export { main, parseCliArgs };

--- a/scripts/projects/list-queue-items.mjs
+++ b/scripts/projects/list-queue-items.mjs
@@ -20,7 +20,9 @@ Options:
                           column order. Emits { ok, groups: { <status>: { count, items } } }.
   --group-by status       Alias for --summary. Only "status" is supported.
   --done-limit <n>        With --summary: cap the "Done" group's items array to
-                          <n> (count stays the true total). Use 0 for counts only.
+                          <n> (or the last/terminal board column if no column is
+                          named "Done"). Count stays the true total; use 0 for
+                          counts only.
   --help, -h              Show this help.
 
 Grouping / aggregation is done via --summary (this mode). Do NOT pipe flat
@@ -520,7 +522,9 @@ async function main(args, { env = process.env, runChild } = {}) {
 
   // 5a. Summary mode: group by Status column in board option order.
   if (args.summary) {
-    const groups = {};
+    // Object.create(null): board option names are free text, so a column named
+    // "__proto__"/"constructor" must be an own key, not touch Object.prototype.
+    const groups = Object.create(null);
     for (const option of statusField.options) {
       groups[option.name] = { count: 0, items: [] };
     }
@@ -532,8 +536,14 @@ async function main(args, { env = process.env, runChild } = {}) {
       group.count += 1;
       group.items.push(r);
     }
-    if (args.doneLimit !== undefined && groups.Done) {
-      groups.Done.items = groups.Done.items.slice(0, args.doneLimit);
+    if (args.doneLimit !== undefined) {
+      // Cap "Done" per the issue AC; if no column is literally named "Done",
+      // fall back to the last board option (conventionally the terminal column)
+      // so --done-limit is honest instead of a silent no-op.
+      const doneGroup = groups.Done ?? groups[statusField.options.at(-1)?.name];
+      if (doneGroup) {
+        doneGroup.items = doneGroup.items.slice(0, args.doneLimit);
+      }
     }
     return { ok: true, groups };
   }

--- a/test/projects/list-queue-items.test.mjs
+++ b/test/projects/list-queue-items.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { main } from "../../scripts/projects/list-queue-items.mjs";
+import { main, parseCliArgs } from "../../scripts/projects/list-queue-items.mjs";
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
@@ -556,6 +556,138 @@ describe("list-queue-items", () => {
       assert.equal(result.ok, true);
       assert.equal(result.items.length, 1);
       assert.equal(result.items[0].issueNumber, 20);
+    });
+  });
+
+  describe("summary mode — grouped by status", () => {
+    function summaryResponses(items) {
+      return [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([STATUS_FIELD]) },
+        { payload: getItemsResponse(items) },
+      ];
+    }
+
+    const SAMPLE_ITEMS = [
+      makeItem("PVTI_1", "I_1", "Issue", 10, "A", "https://github.com/mfittko/repo/issues/10", "Backlog"),
+      makeItem("PVTI_2", "I_2", "Issue", 20, "B", "https://github.com/mfittko/repo/issues/20", "Backlog"),
+      makeItem("PVTI_3", "PR_3", "PullRequest", 30, "C", "https://github.com/mfittko/repo/pull/30", "In Progress"),
+      makeItem("PVTI_4", "I_4", "Issue", 40, "D", "https://github.com/mfittko/repo/issues/40", "Done"),
+      makeItem("PVTI_5", "I_5", "Issue", 50, "E", "https://github.com/mfittko/repo/issues/50", "Done"),
+      makeItem("PVTI_6", "I_6", "Issue", 60, "F", "https://github.com/mfittko/repo/issues/60", "Done"),
+      makeItem("PVTI_7", "I_7", "Issue", 70, "G", "https://github.com/mfittko/repo/issues/70", null),
+    ];
+
+    it("groups items by status with counts; empty column present with count 0", async () => {
+      const result = await main(
+        { repo: "mfittko/dev-loops", project: "1", summary: true },
+        { env: {}, runChild: mockRunChild(summaryResponses(SAMPLE_ITEMS)) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.items, undefined);
+      assert.equal(result.groups.Backlog.count, 2);
+      assert.equal(result.groups.Backlog.items.length, 2);
+      assert.equal(result.groups.Backlog.items[0].issueNumber, 10);
+      // "Next Up" exists on the board but has no items
+      assert.equal(result.groups["Next Up"].count, 0);
+      assert.deepEqual(result.groups["Next Up"].items, []);
+      assert.equal(result.groups["In Progress"].count, 1);
+      assert.equal(result.groups["In Progress"].items[0].prNumber, 30);
+      assert.equal(result.groups.Done.count, 3);
+      assert.equal(result.groups.Done.items.length, 3);
+    });
+
+    it("null-status items are not placed in any group", async () => {
+      const result = await main(
+        { repo: "mfittko/dev-loops", project: "1", summary: true },
+        { env: {}, runChild: mockRunChild(summaryResponses(SAMPLE_ITEMS)) },
+      );
+      const total = Object.values(result.groups).reduce((s, g) => s + g.count, 0);
+      assert.equal(total, 6); // 7 items minus the 1 null-status item
+    });
+
+    it("groups are keyed in board Status-option order", async () => {
+      const result = await main(
+        { repo: "mfittko/dev-loops", project: "1", summary: true },
+        { env: {}, runChild: mockRunChild(summaryResponses(SAMPLE_ITEMS)) },
+      );
+      assert.deepEqual(
+        Object.keys(result.groups),
+        STATUS_FIELD.options.map((o) => o.name),
+      );
+    });
+
+    it("--done-limit caps Done items but not its count; other columns unaffected", async () => {
+      const result = await main(
+        { repo: "mfittko/dev-loops", project: "1", summary: true, doneLimit: 1 },
+        { env: {}, runChild: mockRunChild(summaryResponses(SAMPLE_ITEMS)) },
+      );
+      assert.equal(result.groups.Done.count, 3);
+      assert.equal(result.groups.Done.items.length, 1);
+      assert.equal(result.groups.Backlog.count, 2);
+      assert.equal(result.groups.Backlog.items.length, 2);
+    });
+
+    it("--done-limit 0 yields Done count>0 with empty items", async () => {
+      const result = await main(
+        { repo: "mfittko/dev-loops", project: "1", summary: true, doneLimit: 0 },
+        { env: {}, runChild: mockRunChild(summaryResponses(SAMPLE_ITEMS)) },
+      );
+      assert.equal(result.groups.Done.count, 3);
+      assert.deepEqual(result.groups.Done.items, []);
+    });
+
+    it("rejects --summary with --column", async () => {
+      await assert.rejects(
+        () => main(
+          { repo: "mfittko/dev-loops", project: "1", summary: true, column: "Backlog" },
+          { env: {}, runChild: mockRunChild(summaryResponses(SAMPLE_ITEMS)) },
+        ),
+        (err) => err.code === "INVALID_ARGS" && /mutually exclusive/.test(err.message),
+      );
+    });
+
+    it("rejects --summary with --limit", async () => {
+      await assert.rejects(
+        () => main(
+          { repo: "mfittko/dev-loops", project: "1", summary: true, limit: 5 },
+          { env: {}, runChild: mockRunChild(summaryResponses(SAMPLE_ITEMS)) },
+        ),
+        (err) => err.code === "INVALID_ARGS" && /mutually exclusive/.test(err.message),
+      );
+    });
+
+    it("rejects --done-limit without --summary", async () => {
+      await assert.rejects(
+        () => main(
+          { repo: "mfittko/dev-loops", project: "1", doneLimit: 5 },
+          { env: {}, runChild: mockRunChild(summaryResponses(SAMPLE_ITEMS)) },
+        ),
+        (err) => err.code === "INVALID_ARGS",
+      );
+    });
+
+    it("--group-by status parses to summary mode", () => {
+      const args = parseCliArgs(["--repo", "o/r", "--project", "1", "--group-by", "status"]);
+      assert.equal(args.summary, true);
+    });
+
+    it("--summary parses as boolean flag", () => {
+      const args = parseCliArgs(["--repo", "o/r", "--project", "1", "--summary"]);
+      assert.equal(args.summary, true);
+    });
+
+    it("--group-by with unsupported value throws usage error", () => {
+      assert.throws(
+        () => parseCliArgs(["--repo", "o/r", "--project", "1", "--group-by", "assignee"]),
+        /only supports "status"/,
+      );
+    });
+
+    it("--done-limit parses non-negative integer including 0", () => {
+      const args = parseCliArgs(["--repo", "o/r", "--project", "1", "--summary", "--done-limit", "0"]);
+      assert.equal(args.doneLimit, 0);
     });
   });
 

--- a/test/projects/list-queue-items.test.mjs
+++ b/test/projects/list-queue-items.test.mjs
@@ -638,6 +638,85 @@ describe("list-queue-items", () => {
       assert.deepEqual(result.groups.Done.items, []);
     });
 
+    it("board option named '__proto__' is an own group with correct count/items", async () => {
+      const protoField = {
+        id: "PVTSSF_status",
+        name: "Status",
+        options: [
+          { id: "opt1", name: "Backlog" },
+          { id: "optp", name: "__proto__" },
+        ],
+      };
+      const items = [
+        makeItem("PVTI_1", "I_1", "Issue", 10, "A", "https://github.com/mfittko/repo/issues/10", "Backlog"),
+        makeItem("PVTI_2", "I_2", "Issue", 20, "B", "https://github.com/mfittko/repo/issues/20", "__proto__"),
+        makeItem("PVTI_3", "I_3", "Issue", 30, "C", "https://github.com/mfittko/repo/issues/30", "__proto__"),
+      ];
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([protoField]) },
+        { payload: getItemsResponse(items) },
+      ];
+      const result = await main(
+        { repo: "mfittko/dev-loops", project: "1", summary: true },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.ok(Object.hasOwn(result.groups, "__proto__"));
+      assert.equal(result.groups["__proto__"].count, 2);
+      assert.equal(result.groups["__proto__"].items.length, 2);
+      assert.equal(result.groups["__proto__"].items[0].issueNumber, 20);
+      assert.equal(result.groups.Backlog.count, 1);
+    });
+
+    it("item with non-null status not among board options is dropped, no rogue key", async () => {
+      const items = [
+        makeItem("PVTI_1", "I_1", "Issue", 10, "A", "https://github.com/mfittko/repo/issues/10", "Backlog"),
+        // "Archived" is not a current board option (renamed/deleted)
+        makeItem("PVTI_2", "I_2", "Issue", 20, "B", "https://github.com/mfittko/repo/issues/20", "Archived"),
+      ];
+      const result = await main(
+        { repo: "mfittko/dev-loops", project: "1", summary: true },
+        { env: {}, runChild: mockRunChild(summaryResponses(items)) },
+      );
+      assert.equal(Object.hasOwn(result.groups, "Archived"), false);
+      assert.deepEqual(Object.keys(result.groups), STATUS_FIELD.options.map((o) => o.name));
+      assert.equal(result.groups.Backlog.count, 1);
+      const total = Object.values(result.groups).reduce((s, g) => s + g.count, 0);
+      assert.equal(total, 1); // Archived item dropped
+    });
+
+    it("--done-limit caps the terminal column when no column is named 'Done'", async () => {
+      const shippedField = {
+        id: "PVTSSF_status",
+        name: "Status",
+        options: [
+          { id: "opt1", name: "Backlog" },
+          { id: "opts", name: "Shipped" },
+        ],
+      };
+      const items = [
+        makeItem("PVTI_1", "I_1", "Issue", 10, "A", "https://github.com/mfittko/repo/issues/10", "Backlog"),
+        makeItem("PVTI_2", "I_2", "Issue", 20, "B", "https://github.com/mfittko/repo/issues/20", "Shipped"),
+        makeItem("PVTI_3", "I_3", "Issue", 30, "C", "https://github.com/mfittko/repo/issues/30", "Shipped"),
+        makeItem("PVTI_4", "I_4", "Issue", 40, "D", "https://github.com/mfittko/repo/issues/40", "Shipped"),
+      ];
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([shippedField]) },
+        { payload: getItemsResponse(items) },
+      ];
+      const result = await main(
+        { repo: "mfittko/dev-loops", project: "1", summary: true, doneLimit: 1 },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.groups.Shipped.count, 3); // true total unchanged
+      assert.equal(result.groups.Shipped.items.length, 1); // capped
+      assert.equal(result.groups.Backlog.count, 1);
+      assert.equal(result.groups.Backlog.items.length, 1);
+    });
+
     it("rejects --summary with --column", async () => {
       await assert.rejects(
         () => main(


### PR DESCRIPTION
## Summary

Adds a grouped board-summary mode to `dev-loops queue list` (`scripts/projects/list-queue-items.mjs`) so a whole-board, grouped-by-status digest is producible in ONE sanctioned call — removing the inline-`python3` temptation that motivated #1061.

`--summary` (alias `--group-by status`) returns an ordered `groups` object keyed by the board's Status-field option names (authoritative "standard column order"), each group carrying a true `count` and its `items` (the same per-item shape the flat mode emits). `--done-limit <n>` caps only the Done group's `items` array while `count` stays the true total (Done tends to be large; `--done-limit 0` yields count-only Done). Null-status items are omitted from groups, matching `--column` behavior.

## What changed

- `scripts/projects/list-queue-items.mjs`
  - `--summary` / `--group-by status` grouped output branch after item collection; reuses existing GraphQL/pagination/owner-resolution unchanged.
  - `--done-limit <n>` to cap Done group items (falls back to the last/terminal board column when no column is literally named "Done").
  - Summary groups are built on a null-prototype object so a board column named `__proto__`/`constructor` is an own group with a real count rather than being silently dropped.
  - Mutual exclusion: `--summary` rejects `--column` and `--limit` (exit 1). `--group-by` accepts only `status`.
  - Result flows through the existing `emitResult` path, so `--jq`/`--silent` compose automatically.
  - USAGE/`--help` documents the new flags and notes grouping/aggregation is done via this mode, not inline parsers / `| python3`.
- `test/projects/list-queue-items.test.mjs`
  - Coverage for grouped shape + counts, zero-count columns, board-order keys, null-status exclusion, `--done-limit N`/`0`, the `__proto__` own-key case, unknown/renamed status drop, terminal-column `--done-limit` fallback, and all mutual-exclusion / `--group-by` parse cases.

## Acceptance criteria

- [x] `queue list --summary` returns per-status groups with counts (and items, with Done cap via `--done-limit`) in ONE call — no client-side grouping.
- [x] Output composes with `--jq` and `--silent`.
- [x] Docs/`--help` updated with the inline-parser note.
- [x] Unit coverage for grouped shape + ordering.

## Definition of Done

- [x] Grouped board-summary mode (`--summary` / `--group-by status`) implemented, keyed in board Status-option order.
- [x] `--done-limit` caps the Done (or terminal) group's items without altering the true count.
- [x] Summary grouping hardened against arbitrary board option names (`__proto__`/`constructor` are own keys).
- [x] Output composes with `--jq` and `--silent` via the shared `emitResult` path.
- [x] `--help`/USAGE and inline-parser note updated to match the new behavior.
- [x] Unit coverage green for grouped shape, ordering, null/unknown-status handling, and `--done-limit` fallback.
- [x] CI green.

## Non-goals

- Extending the `--jq` subset to full jq (`group_by`/`reduce`) — the summary mode is the targeted fix.

## Validation

- `node --test test/projects/list-queue-items.test.mjs` → 43 pass / 0 fail
- `npm run test:scripts` → all green
- `node scripts/projects/list-queue-items.mjs --help` → new flags + inline-parser note shown

Closes #1061
