### PR TITLE
fix(agents): guard unauthorized external writes (issue/PR/comment creation) from subagents

### DIFF
--- a/.claude/hooks/_bash-command-classify.mjs
+++ b/.claude/hooks/_bash-command-classify.mjs
@@ -40,6 +40,28 @@ function stripSurroundingQuotes(value) {
   return value;
 }
 
+/**
+ * Read an inline `GH_REPO=<value>` env-assignment prefix on a single command segment.
+ * `gh` resolves its target repo from the `GH_REPO` env var, and a segment may set it inline
+ * (`GH_REPO=owner/name gh issue create …`) — same targeting intent as `--repo owner/name`, so the
+ * scope check must treat it the same or an off-cwd redirect evades the guard (#1074). Only the
+ * FIRST leading env assignment matching `GH_REPO=` is read (env assignments precede the executable);
+ * the value is quote-normalized. Ambient `process.env.GH_REPO` is out of scope — this is a static
+ * command-string classifier, so only the inline assignment in the string is considered.
+ * @param {string} segment @returns {string|null}
+ */
+function extractGhRepoEnvAssignment(segment) {
+  if (!segment) return null;
+  for (const token of segment.trim().split(/\s+/)) {
+    const assign = token.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!assign) break; // first non-assignment token ends the env-assignment prefix
+    if (assign[1] === "GH_REPO") {
+      return trimToNull(stripSurroundingQuotes(assign[2]));
+    }
+  }
+  return null;
+}
+
 /** @param {string|null|undefined} value @returns {string|null} */
 export function trimToNull(value) {
   const trimmed = `${value ?? ""}`.trim();
@@ -185,7 +207,9 @@ function extractRepoFlagFromSubcmdSegment(segment, subcmd, verb) {
     const repoEqMatch = token.match(/^(?:--repo|-R)=(.+)$/i);
     if (repoEqMatch) return stripSurroundingQuotes(repoEqMatch[1]);
   }
-  return null;
+  // No explicit --repo/-R flag: fall back to an inline GH_REPO= env assignment (flag wins,
+  // mirroring gh's own precedence). This closes the GH_REPO repo-targeting bypass (#1074).
+  return extractGhRepoEnvAssignment(segment);
 }
 
 /**
@@ -323,7 +347,10 @@ function extractRepoFlagFromSegment(segment, verb) {
       return stripSurroundingQuotes(repoEqMatch[1]);
     }
   }
-  return null;
+  // No explicit --repo/-R flag: fall back to an inline GH_REPO= env assignment (flag wins,
+  // mirroring gh's own precedence). Applied here too so gh pr ready/merge/create scope checks get
+  // consistent GH_REPO handling — the root-cause fix, not just the external-write path (#1074).
+  return extractGhRepoEnvAssignment(segment);
 }
 
 /** First-segment extractor for `gh pr <verb>` PR number — Pi extension public API. */

--- a/.claude/hooks/_bash-command-classify.mjs
+++ b/.claude/hooks/_bash-command-classify.mjs
@@ -24,6 +24,22 @@ export const FLAGS_THAT_TAKE_VALUE = new Set(["-r", "--repo"]);
  */
 const SHELL_SEGMENT_SEPARATOR = /\s*(?:&&|\|\||;|\||\n|\r)\s*/;
 
+/**
+ * Strip a single balanced surrounding quote pair (`'…'` or `"…"`) from a shell arg value.
+ * A repo flag value may reach us quoted (`--repo 'owner/name'`); the scope check compares against
+ * the bare slug, so quotes must be normalized or a quoted on-target repo evades the guard (#1074).
+ * ponytail: single balanced pair only — no full shell tokenization (mismatched/partial quotes stay).
+ * @param {string|null} value @returns {string|null}
+ */
+function stripSurroundingQuotes(value) {
+  if (value == null || value.length < 2) return value;
+  const first = value[0];
+  if ((first === "'" || first === '"') && value[value.length - 1] === first) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
 /** @param {string|null|undefined} value @returns {string|null} */
 export function trimToNull(value) {
   const trimmed = `${value ?? ""}`.trim();
@@ -164,10 +180,10 @@ function extractRepoFlagFromSubcmdSegment(segment, subcmd, verb) {
     const token = tokens[i];
     const lower = token.toLowerCase();
     if (lower === "-r" || lower === "--repo") {
-      if (i + 1 < tokens.length && !tokens[i + 1].startsWith("-")) return tokens[i + 1];
+      if (i + 1 < tokens.length && !tokens[i + 1].startsWith("-")) return stripSurroundingQuotes(tokens[i + 1]);
     }
     const repoEqMatch = token.match(/^(?:--repo|-R)=(.+)$/i);
-    if (repoEqMatch) return repoEqMatch[1];
+    if (repoEqMatch) return stripSurroundingQuotes(repoEqMatch[1]);
   }
   return null;
 }
@@ -299,12 +315,12 @@ function extractRepoFlagFromSegment(segment, verb) {
     const lower = token.toLowerCase();
     if (lower === "-r" || lower === "--repo") {
       if (i + 1 < tokens.length && !tokens[i + 1].startsWith("-")) {
-        return tokens[i + 1];
+        return stripSurroundingQuotes(tokens[i + 1]);
       }
     }
     const repoEqMatch = token.match(/^(?:--repo|-R)=(.+)$/i);
     if (repoEqMatch) {
-      return repoEqMatch[1];
+      return stripSurroundingQuotes(repoEqMatch[1]);
     }
   }
   return null;

--- a/.claude/hooks/_bash-command-classify.mjs
+++ b/.claude/hooks/_bash-command-classify.mjs
@@ -117,22 +117,29 @@ function shellSegments(command) {
 const GH_PR_VERB_PREFIX = "(?:[A-Za-z_][A-Za-z0-9_]*=\\S*\\s+)*(?:(?:command|env|exec)\\s+)*(?:\\S*/)?";
 
 /**
- * Build the `gh pr <verb>` prefix matcher for a `gh pr <verb>` subcommand.
+ * Build the `gh <subcmd> <verb>` prefix matcher (subcmd = "pr" | "issue").
  * Tolerates a leading env-assignment/wrapper/path prefix so `GH_TOKEN=x gh pr create`,
- * `command gh pr create`, and `/usr/bin/gh pr create` are all matched. The same regex
+ * `command gh issue create`, and `/usr/bin/gh pr create` are all matched. The same regex
  * is reused to strip the matched prefix (`segment.replace(re, "")`), so remainder
- * extraction stays consistent across all matcher/extractor call sites.
+ * extraction stays consistent across all matcher/extractor call sites. The `gh` prefix
+ * requirement means node-wrapper commands (`node scripts/github/comment-issue.mjs …`) never
+ * match — their first token is `node`, not `gh`.
  */
+function ghSubcmdVerbRegex(subcmd, verb) {
+  return new RegExp(`^${GH_PR_VERB_PREFIX}gh\\s+${subcmd}\\s+${verb}(?:\\s|$)`, "i");
+}
+
+/** Build the `gh pr <verb>` prefix matcher — delegates to the generic subcmd matcher (DRY). */
 function ghPrVerbRegex(verb) {
-  return new RegExp(`^${GH_PR_VERB_PREFIX}gh\\s+pr\\s+${verb}(?:\\s|$)`, "i");
+  return ghSubcmdVerbRegex("pr", verb);
 }
 
 /**
- * Return the first segment in the command that is a `gh pr <verb>` call (ignoring --help/-h),
- * or null. Scans ALL segments so compound commands (`echo ok && gh pr merge 1`) are caught.
+ * Return the first segment in the command that is a `gh <subcmd> <verb>` call (ignoring
+ * --help/-h), or null. Scans ALL segments so compound commands are caught.
  */
-function findGhPrVerbSegment(command, verb) {
-  const re = ghPrVerbRegex(verb);
+function findGhSubcmdVerbSegment(command, subcmd, verb) {
+  const re = ghSubcmdVerbRegex(subcmd, verb);
   for (const segment of shellSegments(command)) {
     if (!re.test(segment)) continue;
     const remainder = segment.replace(re, "").trim();
@@ -141,6 +148,92 @@ function findGhPrVerbSegment(command, verb) {
     if (!args.includes("--help") && !args.includes("-h")) return segment;
   }
   return null;
+}
+
+/**
+ * Extract the `--repo`/`-R` flag value from an already-isolated `gh <subcmd> <verb>` segment.
+ * @param {string} segment @param {string} subcmd @param {string} verb @returns {string|null}
+ */
+function extractRepoFlagFromSubcmdSegment(segment, subcmd, verb) {
+  const re = ghSubcmdVerbRegex(subcmd, verb);
+  if (!segment || !re.test(segment)) return null;
+  const remainder = segment.replace(re, "").trim();
+  if (!remainder) return null;
+  const tokens = remainder.split(/\s+/);
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    const lower = token.toLowerCase();
+    if (lower === "-r" || lower === "--repo") {
+      if (i + 1 < tokens.length && !tokens[i + 1].startsWith("-")) return tokens[i + 1];
+    }
+    const repoEqMatch = token.match(/^(?:--repo|-R)=(.+)$/i);
+    if (repoEqMatch) return repoEqMatch[1];
+  }
+  return null;
+}
+
+/**
+ * Return one `{ segment, explicitRepo }` entry for EVERY `gh <subcmd> <verb>` segment (ignoring
+ * --help/-h). Mirrors `extractRepoFlagsFromGhPrCreateSegments`.
+ * @param {string} command @param {string} subcmd @param {string} verb
+ * @returns {{ segment: string, explicitRepo: string|null }[]}
+ */
+function extractRepoFlagsFromGhSubcmdVerbSegments(command, subcmd, verb) {
+  const re = ghSubcmdVerbRegex(subcmd, verb);
+  const out = [];
+  for (const segment of shellSegments(command)) {
+    if (!re.test(segment)) continue;
+    const remainder = segment.replace(re, "").trim();
+    if (remainder) {
+      const args = remainder.split(/\s+/).map((a) => a.toLowerCase());
+      if (args.includes("--help") || args.includes("-h")) continue;
+    }
+    out.push({ segment, explicitRepo: extractRepoFlagFromSubcmdSegment(segment, subcmd, verb) });
+  }
+  return out;
+}
+
+/**
+ * The raw external-write verb forms that must be blocked when originating from a subagent:
+ * ad-hoc GitHub issue/PR creation and comments run directly via `gh` (not the sanctioned node
+ * wrappers). Each entry is `[subcmd, verb]`.
+ */
+const EXTERNAL_WRITE_VERB_FORMS = Object.freeze([
+  ["issue", "create"],
+  ["issue", "comment"],
+  ["pr", "comment"],
+]);
+
+/**
+ * Whether `command` contains a raw `gh issue create`, `gh issue comment`, or `gh pr comment`
+ * invocation in ANY shell segment (ignoring --help/-h). PreToolUse gate use only — the gate
+ * blocks these when they originate from a subagent context. Node-wrapper commands
+ * (`node scripts/github/comment-issue.mjs …`) never match (first token is `node`, not `gh`).
+ * @param {string} command @returns {boolean}
+ */
+export function commandContainsRawExternalWrite(command) {
+  return EXTERNAL_WRITE_VERB_FORMS.some(([subcmd, verb]) => findGhSubcmdVerbSegment(command, subcmd, verb) !== null);
+}
+
+/**
+ * Return `{ segment, explicitRepo }` for every raw external-write segment across all three verb
+ * forms (`gh issue create` / `gh issue comment` / `gh pr comment`). PreToolUse gate use only —
+ * lets the gate decide in-scope-ness per segment so a leading out-of-scope write can't shield a
+ * later in-scope one. `explicitRepo` is the segment's `--repo`/`-R` value or null.
+ * @param {string} command @returns {{ segment: string, explicitRepo: string|null }[]}
+ */
+export function extractRepoFlagsFromExternalWriteSegments(command) {
+  return EXTERNAL_WRITE_VERB_FORMS.flatMap(([subcmd, verb]) =>
+    extractRepoFlagsFromGhSubcmdVerbSegments(command, subcmd, verb),
+  );
+}
+
+/**
+ * Return the first segment in the command that is a `gh pr <verb>` call (ignoring --help/-h),
+ * or null. Scans ALL segments so compound commands (`echo ok && gh pr merge 1`) are caught.
+ */
+function findGhPrVerbSegment(command, verb) {
+  return findGhSubcmdVerbSegment(command, "pr", verb);
 }
 
 /**
@@ -318,18 +411,7 @@ export function extractRepoFlagFromGhPrCreateAnywhere(command) {
  * @param {string} command @returns {{ segment: string, explicitRepo: string|null }[]}
  */
 export function extractRepoFlagsFromGhPrCreateSegments(command) {
-  const re = ghPrVerbRegex("create");
-  const out = [];
-  for (const segment of shellSegments(command)) {
-    if (!re.test(segment)) continue;
-    const remainder = segment.replace(re, "").trim();
-    if (remainder) {
-      const args = remainder.split(/\s+/).map((a) => a.toLowerCase());
-      if (args.includes("--help") || args.includes("-h")) continue;
-    }
-    out.push({ segment, explicitRepo: extractRepoFlagFromSegment(segment, "create") });
-  }
-  return out;
+  return extractRepoFlagsFromGhSubcmdVerbSegments(command, "pr", "create");
 }
 
 /** @param {string} command @returns {number|null} */

--- a/.claude/hooks/_hook-decisions.mjs
+++ b/.claude/hooks/_hook-decisions.mjs
@@ -78,7 +78,7 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
   // Subagent-scoped external-write guard: block ad-hoc `gh issue create`/`gh issue comment`/
   // `gh pr comment` on the target repo from a subagent, so external writes flow through the
   // sanctioned node wrappers. The main-agent/operator path (agentType null) is unaffected (#1051).
-  if (typeof agentType === "string" && agentType && commandContainsRawExternalWrite(command)) {
+  if (typeof agentType === "string" && commandContainsRawExternalWrite(command)) {
     const cwdTargets = (repoSlug ?? "").toLowerCase() === TARGET_REPO_SLUG.toLowerCase();
     // Scope PER segment, mirroring the `gh pr create` block: in scope when no explicit --repo and
     // cwd is the target, or an explicit --repo/-R equals the target. An explicit non-target --repo

--- a/.claude/hooks/_hook-decisions.mjs
+++ b/.claude/hooks/_hook-decisions.mjs
@@ -20,6 +20,8 @@ import {
   extractPrNumberFromGhPrMergeAnywhere,
   extractRepoFlagFromGhPrMergeAnywhere,
   extractRepoFlagsFromGhPrCreateSegments,
+  commandContainsRawExternalWrite,
+  extractRepoFlagsFromExternalWriteSegments,
   TARGET_REPO_SLUG,
 } from "./_bash-command-classify.mjs";
 
@@ -50,6 +52,13 @@ export const DEV_LOOP_AGENT_TYPE = "dev-loop";
  *     clean current-head draft_gate + pre_approval_gate). The loop runs this check before merging;
  *     gating it here closes the hole where a hand-run `gh pr merge` skips the pre-approval gate
  *     entirely. Everything else passes through.
+ *   - raw `gh issue create` / `gh issue comment` / `gh pr comment` — blocked ONLY when the call
+ *     originates from a SUBAGENT context (`agentType` is a non-null string) and targets the repo.
+ *     Sanctioned external writes flow through node wrappers (gate-verdict comments via
+ *     `upsert-checkpoint-verdict.mjs`, review replies via `reply-resolve*.mjs`, board sync,
+ *     `comment-issue.mjs`), whose Bash command string is `node scripts/…` and never matches these
+ *     raw-`gh` matchers. The MAIN AGENT / operator (agentType null) retains direct `gh issue
+ *     create` — that path is authorized (#1051).
  *
  * The hook computes `gatePassed`/`gateError` from the gate script appropriate to the command kind.
  *
@@ -58,11 +67,37 @@ export const DEV_LOOP_AGENT_TYPE = "dev-loop";
  * @param {string|null} [params.repoSlug] - Resolved owner/name of the cwd repo (null if unknown).
  * @param {boolean} [params.gatePassed] - Whether the relevant gate evidence exists for the PR.
  * @param {string|null} [params.gateError] - Error detail when the gate guard could not run.
+ * @param {string|null} [params.agentType] - Claude `agent_type` from the hook payload; non-null
+ *   string inside a subagent, null in the main agent. Scopes the external-write guard.
  * @returns {HookDecision}
  */
-export function decideBashGate({ command, repoSlug = null, gatePassed = false, gateError = null }) {
+export function decideBashGate({ command, repoSlug = null, gatePassed = false, gateError = null, agentType = null }) {
   if (typeof command !== "string") {
     return ALLOW;
+  }
+  // Subagent-scoped external-write guard: block ad-hoc `gh issue create`/`gh issue comment`/
+  // `gh pr comment` on the target repo from a subagent, so external writes flow through the
+  // sanctioned node wrappers. The main-agent/operator path (agentType null) is unaffected (#1051).
+  if (typeof agentType === "string" && agentType && commandContainsRawExternalWrite(command)) {
+    const cwdTargets = (repoSlug ?? "").toLowerCase() === TARGET_REPO_SLUG.toLowerCase();
+    // Scope PER segment, mirroring the `gh pr create` block: in scope when no explicit --repo and
+    // cwd is the target, or an explicit --repo/-R equals the target. An explicit non-target --repo
+    // passes through. DENY if ANY external-write segment is in scope.
+    const anyWriteInScope = extractRepoFlagsFromExternalWriteSegments(command).some((seg) =>
+      seg.explicitRepo == null
+        ? cwdTargets
+        : seg.explicitRepo.toLowerCase() === TARGET_REPO_SLUG.toLowerCase(),
+    );
+    if (anyWriteInScope) {
+      return {
+        decision: "deny",
+        reason:
+          "Ad-hoc GitHub issue/PR creation and comments from a subagent are blocked. Use the sanctioned " +
+          "node wrappers instead — gate-verdict comments via scripts/github/upsert-checkpoint-verdict.mjs, " +
+          "review-thread replies via scripts/github/reply-resolve*.mjs, board sync, or scripts/github/comment-issue.mjs. " +
+          "Direct `gh issue create` is reserved for the main agent / operator.",
+      };
+    }
   }
   // Scan ALL shell segments — the PreToolUse gate blocks pre-emptively, so a gated verb in any
   // segment (even after `&&` or `;`) must be caught. This differs from the Pi extension's

--- a/.claude/hooks/pre-tool-use-bash-gate.mjs
+++ b/.claude/hooks/pre-tool-use-bash-gate.mjs
@@ -10,6 +10,8 @@
  *   - `gh pr merge` — needs full pre-merge evidence (clean current-head draft_gate +
  *     pre_approval_gate, via scripts/github/detect-checkpoint-evidence.mjs). This closes the hole
  *     where a hand-run merge skips the loop's pre-merge gate check (and thus the pre-approval gate).
+ *   - raw `gh issue create` / `gh issue comment` / `gh pr comment` — blocked only from a SUBAGENT
+ *     context (agent_type present); the main agent/operator retains direct issue creation (#1051).
  */
 import { execFileSync } from "node:child_process";
 import path from "node:path";
@@ -19,6 +21,7 @@ import {
   commandContainsGhPrReady,
   commandContainsGhPrMerge,
   commandContainsGhPrCreate,
+  commandContainsRawExternalWrite,
   extractPrNumberFromGhPrReadyAnywhere,
   extractPrNumberFromGhPrMergeAnywhere,
   normalizeGitHubRepoSlug,
@@ -29,10 +32,14 @@ import { readHookInput, emitDeny, emitAllow } from "./_hook-io.mjs";
 
 const input = readHookInput();
 const command = input?.tool_input?.command;
+// Claude exposes `agent_type` only inside a subagent; null in the main agent. Scopes the
+// external-write guard (raw `gh issue create` etc. is blocked only from a subagent).
+const agentType = typeof input?.agent_type === "string" ? input.agent_type : null;
 const isReady = typeof command === "string" && commandContainsGhPrReady(command);
 const isMerge = typeof command === "string" && commandContainsGhPrMerge(command);
 const isCreate = typeof command === "string" && commandContainsGhPrCreate(command);
-if (!isReady && !isMerge && !isCreate) {
+const isExternalWrite = typeof command === "string" && commandContainsRawExternalWrite(command);
+if (!isReady && !isMerge && !isCreate && !isExternalWrite) {
   emitAllow();
 }
 
@@ -80,7 +87,7 @@ if (repoSlug === TARGET_REPO_SLUG) {
   }
 }
 
-const decision = decideBashGate({ command, repoSlug, gatePassed, gateError });
+const decision = decideBashGate({ command, repoSlug, gatePassed, gateError, agentType });
 if (decision.decision === "deny") {
   emitDeny(decision.reason);
 }

--- a/packages/core/src/claude/hook-decisions.mjs
+++ b/packages/core/src/claude/hook-decisions.mjs
@@ -77,7 +77,7 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
   // Subagent-scoped external-write guard: block ad-hoc `gh issue create`/`gh issue comment`/
   // `gh pr comment` on the target repo from a subagent, so external writes flow through the
   // sanctioned node wrappers. The main-agent/operator path (agentType null) is unaffected (#1051).
-  if (typeof agentType === "string" && agentType && commandContainsRawExternalWrite(command)) {
+  if (typeof agentType === "string" && commandContainsRawExternalWrite(command)) {
     const cwdTargets = (repoSlug ?? "").toLowerCase() === TARGET_REPO_SLUG.toLowerCase();
     // Scope PER segment, mirroring the `gh pr create` block: in scope when no explicit --repo and
     // cwd is the target, or an explicit --repo/-R equals the target. An explicit non-target --repo

--- a/packages/core/src/claude/hook-decisions.mjs
+++ b/packages/core/src/claude/hook-decisions.mjs
@@ -19,6 +19,8 @@ import {
   extractPrNumberFromGhPrMergeAnywhere,
   extractRepoFlagFromGhPrMergeAnywhere,
   extractRepoFlagsFromGhPrCreateSegments,
+  commandContainsRawExternalWrite,
+  extractRepoFlagsFromExternalWriteSegments,
   TARGET_REPO_SLUG,
 } from "../loop/bash-command-classify.mjs";
 
@@ -49,6 +51,13 @@ export const DEV_LOOP_AGENT_TYPE = "dev-loop";
  *     clean current-head draft_gate + pre_approval_gate). The loop runs this check before merging;
  *     gating it here closes the hole where a hand-run `gh pr merge` skips the pre-approval gate
  *     entirely. Everything else passes through.
+ *   - raw `gh issue create` / `gh issue comment` / `gh pr comment` — blocked ONLY when the call
+ *     originates from a SUBAGENT context (`agentType` is a non-null string) and targets the repo.
+ *     Sanctioned external writes flow through node wrappers (gate-verdict comments via
+ *     `upsert-checkpoint-verdict.mjs`, review replies via `reply-resolve*.mjs`, board sync,
+ *     `comment-issue.mjs`), whose Bash command string is `node scripts/…` and never matches these
+ *     raw-`gh` matchers. The MAIN AGENT / operator (agentType null) retains direct `gh issue
+ *     create` — that path is authorized (#1051).
  *
  * The hook computes `gatePassed`/`gateError` from the gate script appropriate to the command kind.
  *
@@ -57,11 +66,37 @@ export const DEV_LOOP_AGENT_TYPE = "dev-loop";
  * @param {string|null} [params.repoSlug] - Resolved owner/name of the cwd repo (null if unknown).
  * @param {boolean} [params.gatePassed] - Whether the relevant gate evidence exists for the PR.
  * @param {string|null} [params.gateError] - Error detail when the gate guard could not run.
+ * @param {string|null} [params.agentType] - Claude `agent_type` from the hook payload; non-null
+ *   string inside a subagent, null in the main agent. Scopes the external-write guard.
  * @returns {HookDecision}
  */
-export function decideBashGate({ command, repoSlug = null, gatePassed = false, gateError = null }) {
+export function decideBashGate({ command, repoSlug = null, gatePassed = false, gateError = null, agentType = null }) {
   if (typeof command !== "string") {
     return ALLOW;
+  }
+  // Subagent-scoped external-write guard: block ad-hoc `gh issue create`/`gh issue comment`/
+  // `gh pr comment` on the target repo from a subagent, so external writes flow through the
+  // sanctioned node wrappers. The main-agent/operator path (agentType null) is unaffected (#1051).
+  if (typeof agentType === "string" && agentType && commandContainsRawExternalWrite(command)) {
+    const cwdTargets = (repoSlug ?? "").toLowerCase() === TARGET_REPO_SLUG.toLowerCase();
+    // Scope PER segment, mirroring the `gh pr create` block: in scope when no explicit --repo and
+    // cwd is the target, or an explicit --repo/-R equals the target. An explicit non-target --repo
+    // passes through. DENY if ANY external-write segment is in scope.
+    const anyWriteInScope = extractRepoFlagsFromExternalWriteSegments(command).some((seg) =>
+      seg.explicitRepo == null
+        ? cwdTargets
+        : seg.explicitRepo.toLowerCase() === TARGET_REPO_SLUG.toLowerCase(),
+    );
+    if (anyWriteInScope) {
+      return {
+        decision: "deny",
+        reason:
+          "Ad-hoc GitHub issue/PR creation and comments from a subagent are blocked. Use the sanctioned " +
+          "node wrappers instead — gate-verdict comments via scripts/github/upsert-checkpoint-verdict.mjs, " +
+          "review-thread replies via scripts/github/reply-resolve*.mjs, board sync, or scripts/github/comment-issue.mjs. " +
+          "Direct `gh issue create` is reserved for the main agent / operator.",
+      };
+    }
   }
   // Scan ALL shell segments — the PreToolUse gate blocks pre-emptively, so a gated verb in any
   // segment (even after `&&` or `;`) must be caught. This differs from the Pi extension's

--- a/packages/core/src/loop/bash-command-classify.mjs
+++ b/packages/core/src/loop/bash-command-classify.mjs
@@ -116,22 +116,29 @@ function shellSegments(command) {
 const GH_PR_VERB_PREFIX = "(?:[A-Za-z_][A-Za-z0-9_]*=\\S*\\s+)*(?:(?:command|env|exec)\\s+)*(?:\\S*/)?";
 
 /**
- * Build the `gh pr <verb>` prefix matcher for a `gh pr <verb>` subcommand.
+ * Build the `gh <subcmd> <verb>` prefix matcher (subcmd = "pr" | "issue").
  * Tolerates a leading env-assignment/wrapper/path prefix so `GH_TOKEN=x gh pr create`,
- * `command gh pr create`, and `/usr/bin/gh pr create` are all matched. The same regex
+ * `command gh issue create`, and `/usr/bin/gh pr create` are all matched. The same regex
  * is reused to strip the matched prefix (`segment.replace(re, "")`), so remainder
- * extraction stays consistent across all matcher/extractor call sites.
+ * extraction stays consistent across all matcher/extractor call sites. The `gh` prefix
+ * requirement means node-wrapper commands (`node scripts/github/comment-issue.mjs …`) never
+ * match — their first token is `node`, not `gh`.
  */
+function ghSubcmdVerbRegex(subcmd, verb) {
+  return new RegExp(`^${GH_PR_VERB_PREFIX}gh\\s+${subcmd}\\s+${verb}(?:\\s|$)`, "i");
+}
+
+/** Build the `gh pr <verb>` prefix matcher — delegates to the generic subcmd matcher (DRY). */
 function ghPrVerbRegex(verb) {
-  return new RegExp(`^${GH_PR_VERB_PREFIX}gh\\s+pr\\s+${verb}(?:\\s|$)`, "i");
+  return ghSubcmdVerbRegex("pr", verb);
 }
 
 /**
- * Return the first segment in the command that is a `gh pr <verb>` call (ignoring --help/-h),
- * or null. Scans ALL segments so compound commands (`echo ok && gh pr merge 1`) are caught.
+ * Return the first segment in the command that is a `gh <subcmd> <verb>` call (ignoring
+ * --help/-h), or null. Scans ALL segments so compound commands are caught.
  */
-function findGhPrVerbSegment(command, verb) {
-  const re = ghPrVerbRegex(verb);
+function findGhSubcmdVerbSegment(command, subcmd, verb) {
+  const re = ghSubcmdVerbRegex(subcmd, verb);
   for (const segment of shellSegments(command)) {
     if (!re.test(segment)) continue;
     const remainder = segment.replace(re, "").trim();
@@ -140,6 +147,92 @@ function findGhPrVerbSegment(command, verb) {
     if (!args.includes("--help") && !args.includes("-h")) return segment;
   }
   return null;
+}
+
+/**
+ * Extract the `--repo`/`-R` flag value from an already-isolated `gh <subcmd> <verb>` segment.
+ * @param {string} segment @param {string} subcmd @param {string} verb @returns {string|null}
+ */
+function extractRepoFlagFromSubcmdSegment(segment, subcmd, verb) {
+  const re = ghSubcmdVerbRegex(subcmd, verb);
+  if (!segment || !re.test(segment)) return null;
+  const remainder = segment.replace(re, "").trim();
+  if (!remainder) return null;
+  const tokens = remainder.split(/\s+/);
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    const lower = token.toLowerCase();
+    if (lower === "-r" || lower === "--repo") {
+      if (i + 1 < tokens.length && !tokens[i + 1].startsWith("-")) return tokens[i + 1];
+    }
+    const repoEqMatch = token.match(/^(?:--repo|-R)=(.+)$/i);
+    if (repoEqMatch) return repoEqMatch[1];
+  }
+  return null;
+}
+
+/**
+ * Return one `{ segment, explicitRepo }` entry for EVERY `gh <subcmd> <verb>` segment (ignoring
+ * --help/-h). Mirrors `extractRepoFlagsFromGhPrCreateSegments`.
+ * @param {string} command @param {string} subcmd @param {string} verb
+ * @returns {{ segment: string, explicitRepo: string|null }[]}
+ */
+function extractRepoFlagsFromGhSubcmdVerbSegments(command, subcmd, verb) {
+  const re = ghSubcmdVerbRegex(subcmd, verb);
+  const out = [];
+  for (const segment of shellSegments(command)) {
+    if (!re.test(segment)) continue;
+    const remainder = segment.replace(re, "").trim();
+    if (remainder) {
+      const args = remainder.split(/\s+/).map((a) => a.toLowerCase());
+      if (args.includes("--help") || args.includes("-h")) continue;
+    }
+    out.push({ segment, explicitRepo: extractRepoFlagFromSubcmdSegment(segment, subcmd, verb) });
+  }
+  return out;
+}
+
+/**
+ * The raw external-write verb forms that must be blocked when originating from a subagent:
+ * ad-hoc GitHub issue/PR creation and comments run directly via `gh` (not the sanctioned node
+ * wrappers). Each entry is `[subcmd, verb]`.
+ */
+const EXTERNAL_WRITE_VERB_FORMS = Object.freeze([
+  ["issue", "create"],
+  ["issue", "comment"],
+  ["pr", "comment"],
+]);
+
+/**
+ * Whether `command` contains a raw `gh issue create`, `gh issue comment`, or `gh pr comment`
+ * invocation in ANY shell segment (ignoring --help/-h). PreToolUse gate use only — the gate
+ * blocks these when they originate from a subagent context. Node-wrapper commands
+ * (`node scripts/github/comment-issue.mjs …`) never match (first token is `node`, not `gh`).
+ * @param {string} command @returns {boolean}
+ */
+export function commandContainsRawExternalWrite(command) {
+  return EXTERNAL_WRITE_VERB_FORMS.some(([subcmd, verb]) => findGhSubcmdVerbSegment(command, subcmd, verb) !== null);
+}
+
+/**
+ * Return `{ segment, explicitRepo }` for every raw external-write segment across all three verb
+ * forms (`gh issue create` / `gh issue comment` / `gh pr comment`). PreToolUse gate use only —
+ * lets the gate decide in-scope-ness per segment so a leading out-of-scope write can't shield a
+ * later in-scope one. `explicitRepo` is the segment's `--repo`/`-R` value or null.
+ * @param {string} command @returns {{ segment: string, explicitRepo: string|null }[]}
+ */
+export function extractRepoFlagsFromExternalWriteSegments(command) {
+  return EXTERNAL_WRITE_VERB_FORMS.flatMap(([subcmd, verb]) =>
+    extractRepoFlagsFromGhSubcmdVerbSegments(command, subcmd, verb),
+  );
+}
+
+/**
+ * Return the first segment in the command that is a `gh pr <verb>` call (ignoring --help/-h),
+ * or null. Scans ALL segments so compound commands (`echo ok && gh pr merge 1`) are caught.
+ */
+function findGhPrVerbSegment(command, verb) {
+  return findGhSubcmdVerbSegment(command, "pr", verb);
 }
 
 /**
@@ -317,18 +410,7 @@ export function extractRepoFlagFromGhPrCreateAnywhere(command) {
  * @param {string} command @returns {{ segment: string, explicitRepo: string|null }[]}
  */
 export function extractRepoFlagsFromGhPrCreateSegments(command) {
-  const re = ghPrVerbRegex("create");
-  const out = [];
-  for (const segment of shellSegments(command)) {
-    if (!re.test(segment)) continue;
-    const remainder = segment.replace(re, "").trim();
-    if (remainder) {
-      const args = remainder.split(/\s+/).map((a) => a.toLowerCase());
-      if (args.includes("--help") || args.includes("-h")) continue;
-    }
-    out.push({ segment, explicitRepo: extractRepoFlagFromSegment(segment, "create") });
-  }
-  return out;
+  return extractRepoFlagsFromGhSubcmdVerbSegments(command, "pr", "create");
 }
 
 /** @param {string} command @returns {number|null} */

--- a/packages/core/src/loop/bash-command-classify.mjs
+++ b/packages/core/src/loop/bash-command-classify.mjs
@@ -39,6 +39,28 @@ function stripSurroundingQuotes(value) {
   return value;
 }
 
+/**
+ * Read an inline `GH_REPO=<value>` env-assignment prefix on a single command segment.
+ * `gh` resolves its target repo from the `GH_REPO` env var, and a segment may set it inline
+ * (`GH_REPO=owner/name gh issue create …`) — same targeting intent as `--repo owner/name`, so the
+ * scope check must treat it the same or an off-cwd redirect evades the guard (#1074). Only the
+ * FIRST leading env assignment matching `GH_REPO=` is read (env assignments precede the executable);
+ * the value is quote-normalized. Ambient `process.env.GH_REPO` is out of scope — this is a static
+ * command-string classifier, so only the inline assignment in the string is considered.
+ * @param {string} segment @returns {string|null}
+ */
+function extractGhRepoEnvAssignment(segment) {
+  if (!segment) return null;
+  for (const token of segment.trim().split(/\s+/)) {
+    const assign = token.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!assign) break; // first non-assignment token ends the env-assignment prefix
+    if (assign[1] === "GH_REPO") {
+      return trimToNull(stripSurroundingQuotes(assign[2]));
+    }
+  }
+  return null;
+}
+
 /** @param {string|null|undefined} value @returns {string|null} */
 export function trimToNull(value) {
   const trimmed = `${value ?? ""}`.trim();
@@ -184,7 +206,9 @@ function extractRepoFlagFromSubcmdSegment(segment, subcmd, verb) {
     const repoEqMatch = token.match(/^(?:--repo|-R)=(.+)$/i);
     if (repoEqMatch) return stripSurroundingQuotes(repoEqMatch[1]);
   }
-  return null;
+  // No explicit --repo/-R flag: fall back to an inline GH_REPO= env assignment (flag wins,
+  // mirroring gh's own precedence). This closes the GH_REPO repo-targeting bypass (#1074).
+  return extractGhRepoEnvAssignment(segment);
 }
 
 /**
@@ -322,7 +346,10 @@ function extractRepoFlagFromSegment(segment, verb) {
       return stripSurroundingQuotes(repoEqMatch[1]);
     }
   }
-  return null;
+  // No explicit --repo/-R flag: fall back to an inline GH_REPO= env assignment (flag wins,
+  // mirroring gh's own precedence). Applied here too so gh pr ready/merge/create scope checks get
+  // consistent GH_REPO handling — the root-cause fix, not just the external-write path (#1074).
+  return extractGhRepoEnvAssignment(segment);
 }
 
 /** First-segment extractor for `gh pr <verb>` PR number — Pi extension public API. */

--- a/packages/core/src/loop/bash-command-classify.mjs
+++ b/packages/core/src/loop/bash-command-classify.mjs
@@ -23,6 +23,22 @@ export const FLAGS_THAT_TAKE_VALUE = new Set(["-r", "--repo"]);
  */
 const SHELL_SEGMENT_SEPARATOR = /\s*(?:&&|\|\||;|\||\n|\r)\s*/;
 
+/**
+ * Strip a single balanced surrounding quote pair (`'…'` or `"…"`) from a shell arg value.
+ * A repo flag value may reach us quoted (`--repo 'owner/name'`); the scope check compares against
+ * the bare slug, so quotes must be normalized or a quoted on-target repo evades the guard (#1074).
+ * ponytail: single balanced pair only — no full shell tokenization (mismatched/partial quotes stay).
+ * @param {string|null} value @returns {string|null}
+ */
+function stripSurroundingQuotes(value) {
+  if (value == null || value.length < 2) return value;
+  const first = value[0];
+  if ((first === "'" || first === '"') && value[value.length - 1] === first) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
 /** @param {string|null|undefined} value @returns {string|null} */
 export function trimToNull(value) {
   const trimmed = `${value ?? ""}`.trim();
@@ -163,10 +179,10 @@ function extractRepoFlagFromSubcmdSegment(segment, subcmd, verb) {
     const token = tokens[i];
     const lower = token.toLowerCase();
     if (lower === "-r" || lower === "--repo") {
-      if (i + 1 < tokens.length && !tokens[i + 1].startsWith("-")) return tokens[i + 1];
+      if (i + 1 < tokens.length && !tokens[i + 1].startsWith("-")) return stripSurroundingQuotes(tokens[i + 1]);
     }
     const repoEqMatch = token.match(/^(?:--repo|-R)=(.+)$/i);
-    if (repoEqMatch) return repoEqMatch[1];
+    if (repoEqMatch) return stripSurroundingQuotes(repoEqMatch[1]);
   }
   return null;
 }
@@ -298,12 +314,12 @@ function extractRepoFlagFromSegment(segment, verb) {
     const lower = token.toLowerCase();
     if (lower === "-r" || lower === "--repo") {
       if (i + 1 < tokens.length && !tokens[i + 1].startsWith("-")) {
-        return tokens[i + 1];
+        return stripSurroundingQuotes(tokens[i + 1]);
       }
     }
     const repoEqMatch = token.match(/^(?:--repo|-R)=(.+)$/i);
     if (repoEqMatch) {
-      return repoEqMatch[1];
+      return stripSurroundingQuotes(repoEqMatch[1]);
     }
   }
   return null;

--- a/packages/core/test/bash-command-classify.test.mjs
+++ b/packages/core/test/bash-command-classify.test.mjs
@@ -169,6 +169,15 @@ test("extractRepoFlagsFromExternalWriteSegments returns per-segment --repo acros
     extractRepoFlagsFromExternalWriteSegments("gh pr comment 5 --repo=a/b --body hi"),
     [{ segment: "gh pr comment 5 --repo=a/b --body hi", explicitRepo: "a/b" }],
   );
+  // short `-R` form (bare + `=`) is honored just like `--repo`
+  assert.deepEqual(
+    extractRepoFlagsFromExternalWriteSegments("gh issue create -R other/repo --title x"),
+    [{ segment: "gh issue create -R other/repo --title x", explicitRepo: "other/repo" }],
+  );
+  assert.deepEqual(
+    extractRepoFlagsFromExternalWriteSegments("gh pr comment 5 -R=other/repo --body hi"),
+    [{ segment: "gh pr comment 5 -R=other/repo --body hi", explicitRepo: "other/repo" }],
+  );
   // --help excluded; wrapper ignored
   assert.deepEqual(
     extractRepoFlagsFromExternalWriteSegments("gh issue create --help && node scripts/github/comment-issue.mjs 5"),

--- a/packages/core/test/bash-command-classify.test.mjs
+++ b/packages/core/test/bash-command-classify.test.mjs
@@ -186,6 +186,32 @@ test("extractRepoFlagsFromExternalWriteSegments returns per-segment --repo acros
   assert.deepEqual(extractRepoFlagsFromExternalWriteSegments("echo hi"), []);
 });
 
+test("repo extractors strip a single surrounding quote pair from the --repo value (#1074)", () => {
+  // external-write extractor (shared subcmd path)
+  assert.deepEqual(
+    extractRepoFlagsFromExternalWriteSegments("gh issue create --repo 'other/repo' --title x"),
+    [{ segment: "gh issue create --repo 'other/repo' --title x", explicitRepo: "other/repo" }],
+  );
+  assert.deepEqual(
+    extractRepoFlagsFromExternalWriteSegments(`gh issue create --repo "other/repo" --title x`),
+    [{ segment: `gh issue create --repo "other/repo" --title x`, explicitRepo: "other/repo" }],
+  );
+  assert.deepEqual(
+    extractRepoFlagsFromExternalWriteSegments("gh pr comment 5 -R='other/repo' --body hi"),
+    [{ segment: "gh pr comment 5 -R='other/repo' --body hi", explicitRepo: "other/repo" }],
+  );
+  // pr create/ready/merge extractor (the other tokenizer)
+  assert.equal(extractRepoFlagFromGhPrReady("gh pr ready --repo 'other/repo' 1"), "other/repo");
+  assert.equal(extractRepoFlagFromGhPrReady(`gh pr ready --repo="other/repo" 1`), "other/repo");
+  assert.equal(extractRepoFlagFromGhPrCreateAnywhere("gh pr create --repo 'other/repo' --fill"), "other/repo");
+  // mismatched / partial quotes are NOT stripped (single balanced pair only)
+  assert.deepEqual(
+    extractRepoFlagsFromExternalWriteSegments(`gh issue create --repo 'other/repo" --title x`),
+    [{ segment: `gh issue create --repo 'other/repo" --title x`, explicitRepo: `'other/repo"` }],
+  );
+  assert.equal(extractRepoFlagFromGhPrReady("gh pr ready --repo 'other/repo 1"), "'other/repo");
+});
+
 test("gate detects gh pr create behind a newline separator", () => {
   assert.equal(commandContainsGhPrCreate("echo hi\ngh pr create --fill"), true);
   assert.equal(commandContainsGhPrCreate("echo hi\r\ngh pr create --fill"), true);

--- a/packages/core/test/bash-command-classify.test.mjs
+++ b/packages/core/test/bash-command-classify.test.mjs
@@ -212,6 +212,29 @@ test("repo extractors strip a single surrounding quote pair from the --repo valu
   assert.equal(extractRepoFlagFromGhPrReady("gh pr ready --repo 'other/repo 1"), "'other/repo");
 });
 
+test("repo extractors honor an inline GH_REPO= env assignment as the effective repo (#1074)", () => {
+  // external-write path: GH_REPO= (no --repo flag) is the segment's effective repo.
+  assert.deepEqual(
+    extractRepoFlagsFromExternalWriteSegments("GH_REPO=mfittko/dev-loops gh issue create --title x"),
+    [{ segment: "GH_REPO=mfittko/dev-loops gh issue create --title x", explicitRepo: "mfittko/dev-loops" }],
+  );
+  // quoted GH_REPO value is normalized.
+  assert.deepEqual(
+    extractRepoFlagsFromExternalWriteSegments("GH_REPO='mfittko/dev-loops' gh issue create --title x"),
+    [{ segment: "GH_REPO='mfittko/dev-loops' gh issue create --title x", explicitRepo: "mfittko/dev-loops" }],
+  );
+  // explicit --repo/-R wins over GH_REPO (gh's own precedence — the flag overrides the env).
+  assert.deepEqual(
+    extractRepoFlagsFromExternalWriteSegments("GH_REPO=mfittko/dev-loops gh issue create --repo other/repo --title x"),
+    [{ segment: "GH_REPO=mfittko/dev-loops gh issue create --repo other/repo --title x", explicitRepo: "other/repo" }],
+  );
+  // pr create/ready/merge tokenizer gets GH_REPO too (shared root-cause fix).
+  assert.equal(extractRepoFlagFromGhPrCreateAnywhere("GH_REPO=mfittko/dev-loops gh pr create --fill"), "mfittko/dev-loops");
+  assert.equal(extractRepoFlagFromGhPrReady("GH_REPO=other/repo gh pr ready 1"), "other/repo");
+  // flag wins here as well.
+  assert.equal(extractRepoFlagFromGhPrCreateAnywhere("GH_REPO=mfittko/dev-loops gh pr create --repo other/repo"), "other/repo");
+});
+
 test("gate detects gh pr create behind a newline separator", () => {
   assert.equal(commandContainsGhPrCreate("echo hi\ngh pr create --fill"), true);
   assert.equal(commandContainsGhPrCreate("echo hi\r\ngh pr create --fill"), true);

--- a/packages/core/test/bash-command-classify.test.mjs
+++ b/packages/core/test/bash-command-classify.test.mjs
@@ -18,6 +18,8 @@ import {
   extractRepoFlagFromGhPrMergeAnywhere,
   extractRepoFlagFromGhPrCreateAnywhere,
   extractRepoFlagsFromGhPrCreateSegments,
+  commandContainsRawExternalWrite,
+  extractRepoFlagsFromExternalWriteSegments,
 } from "../src/loop/bash-command-classify.mjs";
 
 test("TARGET_REPO_SLUG is the dev-loops repo", () => {
@@ -130,6 +132,49 @@ test("extractRepoFlagsFromGhPrCreateSegments returns every create segment's --re
     [{ segment: "gh pr create --repo=a/b", explicitRepo: "a/b" }],
   );
   assert.deepEqual(extractRepoFlagsFromGhPrCreateSegments("echo hi"), []);
+});
+
+test("commandContainsRawExternalWrite detects raw issue/pr create+comment in any segment", () => {
+  assert.equal(commandContainsRawExternalWrite("gh issue create --title x --body y"), true);
+  assert.equal(commandContainsRawExternalWrite("gh issue comment 5 --body hi"), true);
+  assert.equal(commandContainsRawExternalWrite("gh pr comment 5 --body hi"), true);
+  assert.equal(commandContainsRawExternalWrite("git push && gh issue create --title x"), true);
+  // --help is not a write
+  assert.equal(commandContainsRawExternalWrite("gh issue create --help"), false);
+  assert.equal(commandContainsRawExternalWrite("gh issue comment --help"), false);
+  // node wrappers never match — first token is `node`, not `gh`
+  assert.equal(commandContainsRawExternalWrite("node scripts/github/comment-issue.mjs 5 --body hi"), false);
+  assert.equal(commandContainsRawExternalWrite("node scripts/github/upsert-checkpoint-verdict.mjs"), false);
+  // pr create / issue view etc. are not external-write forms here
+  assert.equal(commandContainsRawExternalWrite("gh pr create --fill"), false);
+  assert.equal(commandContainsRawExternalWrite("gh issue view 5"), false);
+});
+
+test("commandContainsRawExternalWrite catches newline/env/wrapper/path prefixes", () => {
+  assert.equal(commandContainsRawExternalWrite("echo hi\ngh issue create --title x"), true);
+  assert.equal(commandContainsRawExternalWrite("GH_TOKEN=x gh issue create --title x"), true);
+  assert.equal(commandContainsRawExternalWrite("command gh pr comment 5 --body hi"), true);
+  assert.equal(commandContainsRawExternalWrite("/usr/bin/gh issue comment 5 --body hi"), true);
+});
+
+test("extractRepoFlagsFromExternalWriteSegments returns per-segment --repo across all verb forms", () => {
+  assert.deepEqual(
+    extractRepoFlagsFromExternalWriteSegments("gh issue create --repo other/repo && gh issue comment 5 --body hi"),
+    [
+      { segment: "gh issue create --repo other/repo", explicitRepo: "other/repo" },
+      { segment: "gh issue comment 5 --body hi", explicitRepo: null },
+    ],
+  );
+  assert.deepEqual(
+    extractRepoFlagsFromExternalWriteSegments("gh pr comment 5 --repo=a/b --body hi"),
+    [{ segment: "gh pr comment 5 --repo=a/b --body hi", explicitRepo: "a/b" }],
+  );
+  // --help excluded; wrapper ignored
+  assert.deepEqual(
+    extractRepoFlagsFromExternalWriteSegments("gh issue create --help && node scripts/github/comment-issue.mjs 5"),
+    [],
+  );
+  assert.deepEqual(extractRepoFlagsFromExternalWriteSegments("echo hi"), []);
 });
 
 test("gate detects gh pr create behind a newline separator", () => {

--- a/packages/core/test/claude-hook-decisions.test.mjs
+++ b/packages/core/test/claude-hook-decisions.test.mjs
@@ -229,6 +229,36 @@ test("decideBashGate denies subagent gh issue create --repo targeting the repo r
   );
 });
 
+test("decideBashGate denies subagent gh issue create redirected via inline GH_REPO= to the target (#1074)", () => {
+  // GH_REPO= (no --repo flag) targets the repo → the off-cwd redirect hole is closed.
+  assert.equal(
+    decideBashGate({ command: `GH_REPO=${TARGET} gh issue create --title x`, repoSlug: "someone/else", agentType: SUB }).decision,
+    "deny",
+  );
+  assert.equal(
+    decideBashGate({ command: `GH_REPO=${TARGET} gh issue create --title x`, repoSlug: null, agentType: SUB }).decision,
+    "deny",
+  );
+  // quoted GH_REPO value is normalized before the scope compare.
+  assert.equal(
+    decideBashGate({ command: `GH_REPO='${TARGET}' gh issue create --title x`, repoSlug: "someone/else", agentType: SUB }).decision,
+    "deny",
+  );
+});
+
+test("decideBashGate: explicit --repo wins over GH_REPO; non-target GH_REPO passes through (#1074)", () => {
+  // flag precedence: --repo other/repo overrides GH_REPO=target → off-target → allow.
+  assert.equal(
+    decideBashGate({ command: `GH_REPO=${TARGET} gh issue create --repo other/repo --title x`, repoSlug: "someone/else", agentType: SUB }).decision,
+    "allow",
+  );
+  // GH_REPO=non-target from a non-target cwd → off-target → allow.
+  assert.equal(
+    decideBashGate({ command: "GH_REPO=other/repo gh issue create --title x", repoSlug: "someone/else", agentType: SUB }).decision,
+    "allow",
+  );
+});
+
 test("decideBashGate allows the comment-issue.mjs wrapper even from a subagent", () => {
   assert.equal(
     decideBashGate({ command: "node scripts/github/comment-issue.mjs 5 --body hi", repoSlug: TARGET, agentType: SUB }).decision,

--- a/packages/core/test/claude-hook-decisions.test.mjs
+++ b/packages/core/test/claude-hook-decisions.test.mjs
@@ -273,6 +273,31 @@ test("decideBashGate does not let a leading out-of-scope external write shield a
   );
 });
 
+test("decideBashGate treats an EMPTY-STRING agent_type as subagent context (non-null) — denies on target (#1074)", () => {
+  assert.equal(
+    decideBashGate({ command: "gh issue create --title x --body y", repoSlug: TARGET, agentType: "" }).decision,
+    "deny",
+  );
+});
+
+test("decideBashGate denies subagent gh issue create with a QUOTED target --repo (#1074)", () => {
+  assert.equal(
+    decideBashGate({ command: `gh issue create --repo '${TARGET}' --title x`, repoSlug: null, agentType: SUB }).decision,
+    "deny",
+  );
+  assert.equal(
+    decideBashGate({ command: `gh issue create --repo "${TARGET}" --title x`, repoSlug: null, agentType: SUB }).decision,
+    "deny",
+  );
+});
+
+test("decideBashGate denies gh pr create with a QUOTED target --repo (#1074)", () => {
+  assert.equal(
+    decideBashGate({ command: `gh pr create --repo '${TARGET}' --fill`, repoSlug: null }).decision,
+    "deny",
+  );
+});
+
 test("decideBashGate does not let an out-of-scope gh pr create short-circuit ready/merge gating", () => {
   // An out-of-scope `--repo other/repo` create must not own the decision when a gated
   // ready/merge segment rides along in the same compound command — the merge/ready segment

--- a/packages/core/test/claude-hook-decisions.test.mjs
+++ b/packages/core/test/claude-hook-decisions.test.mjs
@@ -182,6 +182,97 @@ test("decideBashGate evaluates each gh pr create segment's scope (multi-create b
   );
 });
 
+// --- subagent-scoped external-write guard (#1051) ---
+
+const SUB = "dev-loop"; // any non-null agent_type = subagent context
+
+test("decideBashGate denies raw gh issue create from a subagent on the target repo", () => {
+  const d = decideBashGate({ command: "gh issue create --title x --body y", repoSlug: TARGET, agentType: SUB });
+  assert.equal(d.decision, "deny");
+  assert.match(d.reason, /Ad-hoc GitHub issue\/PR creation/);
+});
+
+test("decideBashGate ALLOWS raw gh issue create from the MAIN agent (agentType null) — AC3", () => {
+  assert.equal(decideBashGate({ command: "gh issue create --title x --body y", repoSlug: TARGET }).decision, "allow");
+  assert.equal(
+    decideBashGate({ command: "gh issue create --title x", repoSlug: TARGET, agentType: null }).decision,
+    "allow",
+  );
+});
+
+test("decideBashGate denies raw gh issue/pr comment from a subagent on the target repo", () => {
+  assert.equal(
+    decideBashGate({ command: "gh issue comment 5 --body hi", repoSlug: TARGET, agentType: SUB }).decision,
+    "deny",
+  );
+  assert.equal(
+    decideBashGate({ command: "gh pr comment 5 --body hi", repoSlug: TARGET, agentType: SUB }).decision,
+    "deny",
+  );
+});
+
+test("decideBashGate allows subagent gh issue create with an explicit non-target --repo", () => {
+  assert.equal(
+    decideBashGate({ command: "gh issue create --repo other/repo --title x", repoSlug: TARGET, agentType: SUB }).decision,
+    "allow",
+  );
+});
+
+test("decideBashGate denies subagent gh issue create --repo targeting the repo regardless of cwd", () => {
+  assert.equal(
+    decideBashGate({ command: `gh issue create --repo ${TARGET} --title x`, repoSlug: null, agentType: SUB }).decision,
+    "deny",
+  );
+  assert.equal(
+    decideBashGate({ command: `gh issue create --repo ${TARGET} --title x`, repoSlug: "someone/else", agentType: SUB }).decision,
+    "deny",
+  );
+});
+
+test("decideBashGate allows the comment-issue.mjs wrapper even from a subagent", () => {
+  assert.equal(
+    decideBashGate({ command: "node scripts/github/comment-issue.mjs 5 --body hi", repoSlug: TARGET, agentType: SUB }).decision,
+    "allow",
+  );
+  assert.equal(
+    decideBashGate({ command: "node scripts/github/upsert-checkpoint-verdict.mjs --pr 5", repoSlug: TARGET, agentType: SUB }).decision,
+    "allow",
+  );
+});
+
+test("decideBashGate denies subagent external write hidden behind compound/newline/env bypasses", () => {
+  assert.equal(
+    decideBashGate({ command: "git push && gh issue create --title x", repoSlug: TARGET, agentType: SUB }).decision,
+    "deny",
+  );
+  assert.equal(
+    decideBashGate({ command: "echo hi\ngh issue create --title x", repoSlug: TARGET, agentType: SUB }).decision,
+    "deny",
+  );
+  assert.equal(
+    decideBashGate({ command: "GH_TOKEN=x gh issue comment 5 --body hi", repoSlug: TARGET, agentType: SUB }).decision,
+    "deny",
+  );
+});
+
+test("decideBashGate passes through subagent external write off-target / no target --repo", () => {
+  assert.equal(
+    decideBashGate({ command: "gh issue create --title x", repoSlug: "someone/else", agentType: SUB }).decision,
+    "allow",
+  );
+  assert.equal(
+    decideBashGate({ command: "gh issue create --title x", repoSlug: null, agentType: SUB }).decision,
+    "allow",
+  );
+});
+
+test("decideBashGate does not let a leading out-of-scope external write shield a later in-scope one", () => {
+  assert.equal(
+    decideBashGate({ command: "gh issue create --repo other/repo && gh issue comment 5 --body hi", repoSlug: TARGET, agentType: SUB }).decision,
+    "deny",
+  );
+});
+
 test("decideBashGate does not let an out-of-scope gh pr create short-circuit ready/merge gating", () => {
   // An out-of-scope `--repo other/repo` create must not own the decision when a gated
   // ready/merge segment rides along in the same compound command — the merge/ready segment


### PR DESCRIPTION
## Summary

Guards subagent-initiated unauthorized external GitHub writes via the bash gate (`decideBashGate`).

Previously, gate/dev-loop subagents twice minted external, user-attributed GitHub artifacts on their own initiative (#1043 during a "stop that loop" turn; #1050 before the operator answered a "want me to file this?" question). This extends the existing `gh pr create`/`ready`/`merge` guard model to external-write side effects.

## Scope and context

Boundary of the change: the PreToolUse bash-gate decision path only. Blocks **raw** `gh issue create`, `gh issue comment`, and `gh pr comment` on the target repo (`mfittko/dev-loops`) **when the call originates from a subagent context** (Claude `agent_type` is a non-null string), mirroring the per-segment target-repo scope semantics of the existing `gh pr create` guard.

Explicitly out of scope: blocking reads, blocking the sanctioned gate-verdict / reply-resolve / board-sync writes, and any change to the existing `gh pr create`/`ready`/`merge` gating behavior (kept byte-identical).

## What changed

- `decideBashGate` now blocks raw subagent external writes (issue/PR creation + comments) on the target repo, subagent-scoped so the **main agent / operator path** (`agent_type` null) can still create issues and comment directly.
- **Contract-driven writes are unaffected by construction**: gate-verdict comments (`upsert-checkpoint-verdict.mjs`), review-thread replies (`reply-resolve*.mjs`), board sync, and `comment-issue.mjs` all invoke `gh` inside a node child process, so the bash command string is `node scripts/...` and never matches the raw-`gh` matchers.
- Repo-scope resolution hardened against two evasion vectors: quoted `--repo` values (`--repo 'mfittko/dev-loops'`) are now quote-normalized before the scope compare, and an inline `GH_REPO=<slug>` env-assignment on the same segment is honored as the effective target repo (gh resolves its target from `GH_REPO`), with an explicit `--repo`/`-R` flag winning over `GH_REPO` per gh's own precedence.
- Vendored `.claude/hooks/` bundle regenerated from `packages/core/src` via `generate-claude-assets.mjs`.

## File-by-file changes

- `packages/core/src/loop/bash-command-classify.mjs` — added generic `gh <subcmd> <verb>` matching machinery; new exports `commandContainsRawExternalWrite` and `extractRepoFlagsFromExternalWriteSegments`; refactored existing `gh pr create`/`ready`/`merge` helpers to delegate to the generic helpers (DRY; existing exports and behavior unchanged). Added `stripSurroundingQuotes` quote-normalization applied to every extracted `--repo`/`-R` value (closes the quoted-`--repo` scope evasion where `--repo 'mfittko/dev-loops'` slipped past the bare-slug compare). Added `extractGhRepoEnvAssignment` reading an inline `GH_REPO=<value>` env-assignment prefix (quote-normalized); wired as a fallback in both segment-level repo extractors so `GH_REPO=owner/name gh <verb>` is treated the same as `--repo owner/name` for scope purposes, with the `--repo`/`-R` flag taking precedence over `GH_REPO`. Applied at the shared extractors so ALL gated verbs (external-write, `gh pr create`/`ready`/`merge`) get consistent `GH_REPO` handling — the root-cause fix, not just the external-write path. Ambient `process.env.GH_REPO` is deliberately out of scope (static command-string classifier).
- `packages/core/src/claude/hook-decisions.mjs` — added `agentType` param (default `null`) to `decideBashGate`; added the subagent-scoped external-write deny branch; updated docstring.
- `.claude/hooks/pre-tool-use-bash-gate.mjs` — reads `agent_type` from the hook payload, extends the top-level short-circuit with the external-write detector so a bare external write reaches `decideBashGate`, and passes `agentType` through.
- `.claude/hooks/_bash-command-classify.mjs` — regenerated vendored copy (via `generate-claude-assets.mjs`; not hand-edited).
- `.claude/hooks/_hook-decisions.mjs` — regenerated vendored copy (via `generate-claude-assets.mjs`; not hand-edited).
- `packages/core/test/bash-command-classify.test.mjs` — added tests for the new detector/scope helpers mirroring the `gh pr create` tests, including `-R` short-form coverage (bare + `=`), quote-stripping tests (single balanced pair only; mismatched/partial quotes preserved), and the new inline-`GH_REPO=` tests (bare + quoted value; `--repo`/`-R` flag wins over `GH_REPO`; applied to both the external-write and `gh pr create`/`ready` extractor paths).
- `packages/core/test/claude-hook-decisions.test.mjs` — added `decideBashGate` tests: subagent deny, main-agent allow (AC3), non-target `--repo` allow, explicit-target `--repo` deny, empty-string `agent_type` treated as subagent (deny on target), quoted-target `--repo` deny (both external-write and `gh pr create` paths), comment forms, wrapper allow, bypass attempts, and the new `GH_REPO=` cases (deny when `GH_REPO` redirects to the target from a non-target/`null` cwd incl. quoted value; explicit `--repo` wins over `GH_REPO`; non-target `GH_REPO` passes through).

## Acceptance criteria

- [x] A subagent invoking raw `gh issue create` on the target repo without authorization is blocked with a clear reason.
- [x] Contract-driven writes (gate verdicts, review-thread replies, board sync) are unaffected.
- [x] The main agent / operator-authorized path can still create issues.
- [x] Unit coverage mirroring the `gh pr create` guard tests.

## Definition of done

- [x] `decideBashGate` blocks raw subagent external writes on the target repo and allows the main-agent path.
- [x] Sanctioned node-wrapper writes and existing `gh pr create`/`ready`/`merge` gating verified unchanged.
- [x] Vendored `.claude/hooks/` bundle regenerated and in sync with `packages/core/src`.
- [x] Unit + classifier tests added and passing; full `npm run verify` green.

## Validation

```sh
# Full gate
npm run verify
# Focused unit suites for the changed surface
node --test packages/core/test/bash-command-classify.test.mjs
node --test packages/core/test/claude-hook-decisions.test.mjs
# Confirm the vendored hook bundle is in sync with packages/core/src
node scripts/claude/generate-claude-assets.mjs --check
```

## Non-goals

- Blocking reads.
- Blocking the sanctioned gate-verdict / reply-resolve / board-sync writes.

Closes #1051

🤖 Generated with [Claude Code](https://claude.com/claude-code)
