### PR TITLE
feat(commands): add /loop-enqueue and /loop-queue-status slash commands

### DIFF
--- a/.claude/commands/loop-enqueue.md
+++ b/.claude/commands/loop-enqueue.md
@@ -1,0 +1,22 @@
+---
+description: "Add an issue/PR to the auto queue, or quick-capture a freeform idea as a grilled issue and queue it."
+argument-hint: "<issue-or-pr-number | freeform text>"
+---
+<!-- GENERATED from commands/loop-enqueue.command.md by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate. -->
+
+Add work to the dev-loop queue. Parse `$ARGUMENTS` before acting. The project is auto-resolved from `.devloops` — never pass `--project` and never invent a project number. `<owner/repo>` resolves from the git remote at invocation, same as the other loop commands.
+
+1. **Argument parsing (fail-closed):**
+   - If `$ARGUMENTS` is empty, print `Error: missing argument — provide an issue/PR number or freeform text.` and stop without mutating anything.
+   - If `$ARGUMENTS` is a single integer token, take the **numeric path**. Otherwise take the **freeform path**.
+
+2. **Numeric path (existing issue/PR):**
+   - Run `node scripts/projects/add-queue-item.mjs --repo <owner/repo> --item <n>`.
+   - The script is idempotent and returns `{ ok, item: { status, alreadyPresent } }`. Report the resulting Status column and whether it was already present, e.g. `#<n> is in "Backlog" (already on the board)` or `#<n> added to "Backlog"`.
+   - Exit `3` means the issue/PR was not found (`ITEM_NOT_FOUND` / `CONTENT_NOT_FOUND`): print `Error: issue/PR #<n> not found.` and stop. Do not retry with a guessed project.
+
+3. **Freeform path (quick-capture a new idea):** run these steps in order.
+   1. **Confirm first — no mutation before approval.** Print a one-line preview of the issue to be created (`About to create issue: "<concise title>"`) and STOP for approval. Do not create the issue, grill, or enqueue anything until the human approves.
+   2. **Create the issue.** After approval, create a minimal GitHub issue from the text. The repo has no dedicated create-issue wrapper under `scripts/github/`; the sanctioned create path in this codebase is `gh issue create --repo <owner/repo> --assignee @me --title "<concise title>" --body "<freeform text>"` (the same path used by `skills/docs/issue-intake-procedure.md` and permitted by `skills/docs/main-agent-contract.md`). Title = a concise summary of the text; body = the verbatim freeform text.
+   3. **Grill it.** Run `/loop-grill <n> --auto` (delegates to the `loop-grill` skill). The skill writes a `## Grill findings` section back into the issue body and flags any unresolved items there, so they are visible before pickup. Do not re-implement grilling.
+   4. **Enqueue.** Run `node scripts/projects/add-queue-item.mjs --repo <owner/repo> --item <n>` to add the grill-annotated issue to the board, then report its Status column as in the numeric path. The `strategy: local-first` default is set repo-wide in `.devloops` (`strategy.default: local-first`), so the new issue is already local-first — this repo has no per-issue local-first label or body tag to apply, and you must not invent one.

--- a/.claude/commands/loop-queue-status.md
+++ b/.claude/commands/loop-queue-status.md
@@ -1,0 +1,24 @@
+---
+description: "Show the dev-loop queue board grouped by column."
+argument-hint: ""
+---
+<!-- GENERATED from commands/loop-queue-status.command.md by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate. -->
+
+Show the dev-loop queue board. Takes no arguments; if `$ARGUMENTS` is non-empty, ignore it. `<owner/repo>` resolves from the git remote at invocation, same as the other loop commands, and the project is auto-resolved from `.devloops` — never pass `--project`.
+
+1. Run `node scripts/projects/list-queue-items.mjs --repo <owner/repo> --summary`. This is the sanctioned grouped-by-column path: it emits `{ ok, groups: { "<Status>": { count, items } } }` in board column order. Do not re-implement client-side grouping and do not pipe flat output through inline parsers.
+
+2. Render the result human-readably (not raw JSON). Walk `groups` in the order they are returned (board column order — Backlog, Next Up, In Progress, Done). For each column, print the column name with its count, then one line per item as `#<number> <title>`. Example:
+
+   ```
+   Backlog (2)
+     #1035 Add /loop-enqueue and /loop-queue-status commands
+     #1042 Fix article layout
+   Next Up (0)
+   In Progress (1)
+     #1041 Align nav/wrap/prose widths
+   Done (3)
+     ...
+   ```
+
+3. If every column is empty (all counts `0`), print `Queue is empty.` instead of a list.

--- a/commands/loop-enqueue.command.md
+++ b/commands/loop-enqueue.command.md
@@ -1,0 +1,20 @@
+---
+description: Add an issue/PR to the auto queue, or quick-capture a freeform idea as a grilled issue and queue it.
+argument-hint: "<issue-or-pr-number | freeform text>"
+---
+Add work to the dev-loop queue. Parse `$ARGUMENTS` before acting. The project is auto-resolved from `.devloops` — never pass `--project` and never invent a project number. `<owner/repo>` resolves from the git remote at invocation, same as the other loop commands.
+
+1. **Argument parsing (fail-closed):**
+   - If `$ARGUMENTS` is empty, print `Error: missing argument — provide an issue/PR number or freeform text.` and stop without mutating anything.
+   - If `$ARGUMENTS` is a single integer token, take the **numeric path**. Otherwise take the **freeform path**.
+
+2. **Numeric path (existing issue/PR):**
+   - Run `node scripts/projects/add-queue-item.mjs --repo <owner/repo> --item <n>`.
+   - The script is idempotent and returns `{ ok, item: { status, alreadyPresent } }`. Report the resulting Status column and whether it was already present, e.g. `#<n> is in "Backlog" (already on the board)` or `#<n> added to "Backlog"`.
+   - Exit `3` means the issue/PR was not found (`ITEM_NOT_FOUND` / `CONTENT_NOT_FOUND`): print `Error: issue/PR #<n> not found.` and stop. Do not retry with a guessed project.
+
+3. **Freeform path (quick-capture a new idea):** run these steps in order.
+   1. **Confirm first — no mutation before approval.** Print a one-line preview of the issue to be created (`About to create issue: "<concise title>"`) and STOP for approval. Do not create the issue, grill, or enqueue anything until the human approves.
+   2. **Create the issue.** After approval, create a minimal GitHub issue from the text. The repo has no dedicated create-issue wrapper under `scripts/github/`; the sanctioned create path in this codebase is `gh issue create --repo <owner/repo> --assignee @me --title "<concise title>" --body "<freeform text>"` (the same path used by `skills/docs/issue-intake-procedure.md` and permitted by `skills/docs/main-agent-contract.md`). Title = a concise summary of the text; body = the verbatim freeform text.
+   3. **Grill it.** Run `/loop-grill <n> --auto` (delegates to the `loop-grill` skill). The skill writes a `## Grill findings` section back into the issue body and flags any unresolved items there, so they are visible before pickup. Do not re-implement grilling.
+   4. **Enqueue.** Run `node scripts/projects/add-queue-item.mjs --repo <owner/repo> --item <n>` to add the grill-annotated issue to the board, then report its Status column as in the numeric path. The `strategy: local-first` default is set repo-wide in `.devloops` (`strategy.default: local-first`), so the new issue is already local-first — this repo has no per-issue local-first label or body tag to apply, and you must not invent one.

--- a/commands/loop-queue-status.command.md
+++ b/commands/loop-queue-status.command.md
@@ -1,0 +1,22 @@
+---
+description: Show the dev-loop queue board grouped by column.
+argument-hint: ""
+---
+Show the dev-loop queue board. Takes no arguments; if `$ARGUMENTS` is non-empty, ignore it. `<owner/repo>` resolves from the git remote at invocation, same as the other loop commands, and the project is auto-resolved from `.devloops` — never pass `--project`.
+
+1. Run `node scripts/projects/list-queue-items.mjs --repo <owner/repo> --summary`. This is the sanctioned grouped-by-column path: it emits `{ ok, groups: { "<Status>": { count, items } } }` in board column order. Do not re-implement client-side grouping and do not pipe flat output through inline parsers.
+
+2. Render the result human-readably (not raw JSON). Walk `groups` in the order they are returned (board column order — Backlog, Next Up, In Progress, Done). For each column, print the column name with its count, then one line per item as `#<number> <title>`. Example:
+
+   ```
+   Backlog (2)
+     #1035 Add /loop-enqueue and /loop-queue-status commands
+     #1042 Fix article layout
+   Next Up (0)
+   In Progress (1)
+     #1041 Align nav/wrap/prose widths
+   Done (3)
+     ...
+   ```
+
+3. If every column is empty (all counts `0`), print `Queue is empty.` instead of a list.

--- a/scripts/projects/_resolve-project.mjs
+++ b/scripts/projects/_resolve-project.mjs
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { parse as parseYaml } from "yaml";
+
+// Read .devloops (and extension variants) queue settings, mirroring the
+// resolution used by ensure-queue-board.mjs. Returns { project }, { title },
+// and/or { olderThanDays } when configured; never throws on a missing/bad file.
+function resolveSettings(cwd) {
+  const basePath = path.join(cwd, ".devloops");
+  const extensions = ["", ".yaml", ".yml", ".json"];
+  for (const ext of extensions) {
+    try {
+      const raw = readFileSync(basePath + ext, "utf-8");
+      const settings = ext === ".json" ? JSON.parse(raw) : parseYaml(raw);
+      const queue = settings?.queue;
+      if (!queue) return null;
+      const out = {};
+      if (typeof queue.projectNumber === "number" && Number.isInteger(queue.projectNumber) && queue.projectNumber > 0) {
+        out.project = queue.projectNumber;
+      } else if (typeof queue.boardTitle === "string" && queue.boardTitle.trim().length > 0) {
+        out.title = queue.boardTitle.trim();
+      }
+      if (typeof queue.archiveOlderThanDays === "number" && Number.isInteger(queue.archiveOlderThanDays) && queue.archiveOlderThanDays > 0) {
+        out.olderThanDays = queue.archiveOlderThanDays;
+      }
+      return out;
+    } catch {
+      // extension not present or unparseable — try next
+    }
+  }
+  return null;
+}
+
+export { resolveSettings };

--- a/scripts/projects/_resolve-project.mjs
+++ b/scripts/projects/_resolve-project.mjs
@@ -31,4 +31,80 @@ function resolveSettings(cwd) {
   return null;
 }
 
-export { resolveSettings };
+// Parse a --project value into { kind:"id"|"number", value }. Throws
+// INVALID_PROJECT on empty/malformed input (bare "0" is rejected too).
+const GLOBAL_NODE_ID_RE = /^[A-Za-z0-9_]+$/;
+
+function parseProjectRef(raw) {
+  if (!raw || typeof raw !== "string" || raw.trim().length === 0) {
+    throw Object.assign(new Error("--project is required"), { code: "INVALID_PROJECT" });
+  }
+  const trimmed = raw.trim();
+  const asNum = Number(trimmed);
+  if (Number.isInteger(asNum) && asNum > 0 && String(asNum) === trimmed) {
+    return { kind: "number", value: asNum };
+  }
+  // Reject bare "0" — valid node ID character but not a meaningful project reference
+  if (trimmed === "0") {
+    throw Object.assign(
+      new Error(`--project must be a positive integer or a node ID, got "${raw}"`),
+      { code: "INVALID_PROJECT" },
+    );
+  }
+  if (GLOBAL_NODE_ID_RE.test(trimmed)) {
+    return { kind: "id", value: trimmed };
+  }
+  throw Object.assign(
+    new Error(`--project must be a positive integer or a node ID, got "${raw}"`),
+    { code: "INVALID_PROJECT" },
+  );
+}
+
+// Selector precedence: explicit --project ref wins; else resolve by board title
+// from .devloops (passed as args.projectTitle by runCli). Fail closed if neither.
+function resolveProjectSelector(args) {
+  const hasProjectRef = typeof args.project === "string" && args.project.trim().length > 0;
+  const projectRef = hasProjectRef ? parseProjectRef(args.project) : null;
+  const projectTitle = !hasProjectRef && typeof args.projectTitle === "string" && args.projectTitle.trim().length > 0
+    ? args.projectTitle.trim()
+    : null;
+  if (!projectRef && !projectTitle) {
+    throw Object.assign(
+      new Error("--project is required (or set queue.projectNumber / queue.boardTitle in .devloops)"),
+      { code: "INVALID_PROJECT" },
+    );
+  }
+  return { projectRef, projectTitle };
+}
+
+// Find the project in `projects` matching the resolved selector; throws
+// PROJECT_NOT_FOUND (desc: "<id>" / number N / title "T") under `owner`.
+function findProject(projects, { projectRef, projectTitle }, owner) {
+  const project = projectRef
+    ? (projectRef.kind === "id"
+        ? projects.find((p) => p.id === projectRef.value)
+        : projects.find((p) => p.number === projectRef.value))
+    : projects.find((p) => p.title === projectTitle);
+  if (!project) {
+    const desc = projectRef
+      ? (projectRef.kind === "id" ? `"${projectRef.value}"` : `number ${projectRef.value}`)
+      : `title "${projectTitle}"`;
+    throw Object.assign(
+      new Error(`Project ${desc} not found under owner "${owner}"`),
+      { code: "PROJECT_NOT_FOUND" },
+    );
+  }
+  return project;
+}
+
+// Apply .devloops board settings when --project was not passed. Precedence:
+// explicit --project flag > queue.projectNumber/boardTitle. Mutates args.
+function applyDevloopsBoard(args, cwd) {
+  if (args.project === undefined) {
+    const settings = resolveSettings(cwd);
+    if (settings?.project) args.project = String(settings.project);
+    else if (settings?.title) args.projectTitle = settings.title;
+  }
+}
+
+export { resolveSettings, parseProjectRef, resolveProjectSelector, findProject, applyDevloopsBoard };

--- a/scripts/projects/add-queue-item.mjs
+++ b/scripts/projects/add-queue-item.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
-import { resolveSettings } from "./_resolve-project.mjs";
+import { resolveProjectSelector, findProject, applyDevloopsBoard } from "./_resolve-project.mjs";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult } from "../lib/jq-output.mjs";
 
@@ -117,7 +117,6 @@ function parseCliArgs(argv) {
 
 const OWNER_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
 const REPO_NAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9_.-]*[a-zA-Z0-9])?$/;
-const GLOBAL_NODE_ID_RE = /^[A-Za-z0-9_]+$/;
 
 function validateRepo(repo) {
   if (!repo || typeof repo !== "string") {
@@ -140,30 +139,6 @@ function validateRepo(repo) {
     throw Object.assign(new Error(`--repo must be exactly owner/name, got "${repo}"`), { code: "INVALID_REPO" });
   }
   return repo;
-}
-
-function parseProjectRef(raw) {
-  if (!raw || typeof raw !== "string" || raw.trim().length === 0) {
-    throw Object.assign(new Error("--project is required"), { code: "INVALID_PROJECT" });
-  }
-  const trimmed = raw.trim();
-  const asNum = Number(trimmed);
-  if (Number.isInteger(asNum) && asNum > 0 && String(asNum) === trimmed) {
-    return { kind: "number", value: asNum };
-  }
-  if (trimmed === "0") {
-    throw Object.assign(
-      new Error(`--project must be a positive integer or a node ID, got "${raw}"`),
-      { code: "INVALID_PROJECT" },
-    );
-  }
-  if (GLOBAL_NODE_ID_RE.test(trimmed)) {
-    return { kind: "id", value: trimmed };
-  }
-  throw Object.assign(
-    new Error(`--project must be a positive integer or a node ID, got "${raw}"`),
-    { code: "INVALID_PROJECT" },
-  );
 }
 
 // ── API helpers ──────────────────────────────────────────────────────────
@@ -392,19 +367,7 @@ async function main(args, { env = process.env, runChild } = {}) {
   const child = runChild ?? _runChild;
   const repo = validateRepo(args.repo);
   const [owner, repoName] = repo.split("/");
-  // Board: explicit --project ref wins; otherwise resolve by board title from
-  // .devloops (passed in as args.projectTitle by runCli). Fail closed if neither.
-  const hasProjectRef = typeof args.project === "string" && args.project.trim().length > 0;
-  const projectRef = hasProjectRef ? parseProjectRef(args.project) : null;
-  const projectTitle = !hasProjectRef && typeof args.projectTitle === "string" && args.projectTitle.trim().length > 0
-    ? args.projectTitle.trim()
-    : null;
-  if (!projectRef && !projectTitle) {
-    throw Object.assign(
-      new Error("--project is required (or set queue.projectNumber / queue.boardTitle in .devloops)"),
-      { code: "INVALID_PROJECT" },
-    );
-  }
+  const selector = resolveProjectSelector(args);
   const itemNumber = args.item;
   if (!Number.isInteger(itemNumber) || itemNumber < 1) {
     throw Object.assign(new Error("--item is required and must be a positive integer"), { code: "INVALID_ITEM" });
@@ -425,20 +388,7 @@ async function main(args, { env = process.env, runChild } = {}) {
 
   // 2. Resolve project
   const projects = await listAllProjects(owner, ownerKind, env, child);
-  const project = projectRef
-    ? (projectRef.kind === "id"
-        ? projects.find((p) => p.id === projectRef.value)
-        : projects.find((p) => p.number === projectRef.value))
-    : projects.find((p) => p.title === projectTitle);
-  if (!project) {
-    const desc = projectRef
-      ? (projectRef.kind === "id" ? `"${projectRef.value}"` : `number ${projectRef.value}`)
-      : `title "${projectTitle}"`;
-    throw Object.assign(
-      new Error(`Project ${desc} not found under owner "${owner}"`),
-      { code: "PROJECT_NOT_FOUND" },
-    );
-  }
+  const project = findProject(projects, selector, owner);
 
   // 3. Resolve Status field and target column
   const fieldNodes = await listAllFields(project.id, env, child);
@@ -570,12 +520,7 @@ async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, 
   }
 
   // Resolve the board from .devloops when --project is absent.
-  // Precedence: explicit --project flag > queue.projectNumber/boardTitle.
-  if (args.project === undefined) {
-    const settings = resolveSettings(cwd);
-    if (settings?.project) args.project = String(settings.project);
-    else if (settings?.title) args.projectTitle = settings.title;
-  }
+  applyDevloopsBoard(args, cwd);
 
   try {
     const result = await main(args, { env, runChild });

--- a/scripts/projects/add-queue-item.mjs
+++ b/scripts/projects/add-queue-item.mjs
@@ -1,17 +1,20 @@
 #!/usr/bin/env node
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
+import { resolveSettings } from "./_resolve-project.mjs";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult } from "../lib/jq-output.mjs";
 
-const USAGE = `Usage: dev-loops queue add --repo <owner/name> --project <number|id> --item <number>
+const USAGE = `Usage: dev-loops queue add --repo <owner/name> [--project <number|id>] --item <number>
        dev-loops project add … (back-compat alias for "queue add")
 
 Add an existing issue or PR to a GitHub Projects V2 board.
 
 Options:
   --repo <owner/name>         Required. Repository containing the issue/PR.
-  --project <number|id>       Required. Project number (integer) or node ID.
+  --project <number|id>       Project number (integer) or node ID. When omitted,
+                              resolved from .devloops queue.projectNumber /
+                              queue.boardTitle.
   --item <number>             Required. Issue or PR number to add.
   --column <name>             Initial Status column (default: "Backlog").
   --status <name>             Back-compat alias for --column.
@@ -389,7 +392,19 @@ async function main(args, { env = process.env, runChild } = {}) {
   const child = runChild ?? _runChild;
   const repo = validateRepo(args.repo);
   const [owner, repoName] = repo.split("/");
-  const projectRef = parseProjectRef(args.project);
+  // Board: explicit --project ref wins; otherwise resolve by board title from
+  // .devloops (passed in as args.projectTitle by runCli). Fail closed if neither.
+  const hasProjectRef = typeof args.project === "string" && args.project.trim().length > 0;
+  const projectRef = hasProjectRef ? parseProjectRef(args.project) : null;
+  const projectTitle = !hasProjectRef && typeof args.projectTitle === "string" && args.projectTitle.trim().length > 0
+    ? args.projectTitle.trim()
+    : null;
+  if (!projectRef && !projectTitle) {
+    throw Object.assign(
+      new Error("--project is required (or set queue.projectNumber / queue.boardTitle in .devloops)"),
+      { code: "INVALID_PROJECT" },
+    );
+  }
   const itemNumber = args.item;
   if (!Number.isInteger(itemNumber) || itemNumber < 1) {
     throw Object.assign(new Error("--item is required and must be a positive integer"), { code: "INVALID_ITEM" });
@@ -410,15 +425,17 @@ async function main(args, { env = process.env, runChild } = {}) {
 
   // 2. Resolve project
   const projects = await listAllProjects(owner, ownerKind, env, child);
-  let project;
-  if (projectRef.kind === "id") {
-    project = projects.find((p) => p.id === projectRef.value);
-  } else {
-    project = projects.find((p) => p.number === projectRef.value);
-  }
+  const project = projectRef
+    ? (projectRef.kind === "id"
+        ? projects.find((p) => p.id === projectRef.value)
+        : projects.find((p) => p.number === projectRef.value))
+    : projects.find((p) => p.title === projectTitle);
   if (!project) {
+    const desc = projectRef
+      ? (projectRef.kind === "id" ? `"${projectRef.value}"` : `number ${projectRef.value}`)
+      : `title "${projectTitle}"`;
     throw Object.assign(
-      new Error(`Project ${projectRef.kind === "id" ? `"${projectRef.value}"` : `number ${projectRef.value}`} not found under owner "${owner}"`),
+      new Error(`Project ${desc} not found under owner "${owner}"`),
       { code: "PROJECT_NOT_FOUND" },
     );
   }
@@ -538,7 +555,7 @@ async function main(args, { env = process.env, runChild } = {}) {
 
 // ── CLI entrypoint ──────────────────────────────────────────────────────
 
-async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, env = process.env } = {}) {
+async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, env = process.env, cwd = process.cwd(), runChild } = {}) {
   let args;
   try {
     args = parseCliArgs(argv);
@@ -551,8 +568,17 @@ async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, 
     stdout.write(USAGE);
     return;
   }
+
+  // Resolve the board from .devloops when --project is absent.
+  // Precedence: explicit --project flag > queue.projectNumber/boardTitle.
+  if (args.project === undefined) {
+    const settings = resolveSettings(cwd);
+    if (settings?.project) args.project = String(settings.project);
+    else if (settings?.title) args.projectTitle = settings.title;
+  }
+
   try {
-    const result = await main(args, { env });
+    const result = await main(args, { env, runChild });
     process.exitCode = emitResult(result, { jq: args.jq, silent: args.silent, stdout, stderr });
   } catch (err) {
     stderr.write(JSON.stringify({ ok: false, error: err.message, code: err.code ?? "UNKNOWN" }) + "\n");
@@ -567,4 +593,4 @@ if (isDirectCliRun(import.meta.url)) {
   });
 }
 
-export { main, parseCliArgs };
+export { main, parseCliArgs, runCli };

--- a/scripts/projects/archive-done-items.mjs
+++ b/scripts/projects/archive-done-items.mjs
@@ -1,9 +1,7 @@
 #!/usr/bin/env node
-import { readFileSync } from "node:fs";
-import path from "node:path";
-import { parse as parseYaml } from "yaml";
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
+import { resolveSettings } from "./_resolve-project.mjs";
 import { parseArgs } from "node:util";
 
 const USAGE = `Usage: dev-loops queue archive-done --repo <owner/name> [--project <number|id>] [--older-than <duration>] [--dry-run]
@@ -152,37 +150,6 @@ function parseDuration(raw) {
     throw Object.assign(new Error(`--older-than must be a positive amount, got "${raw}"`), { code: "INVALID_DURATION" });
   }
   return n * UNIT_MS[m[2]];
-}
-
-// ── Settings fallback ──────────────────────────────────────────────────────
-
-// Read .devloops (and extension variants) queue settings, mirroring the
-// resolution used by ensure-queue-board.mjs. Returns { project }, { title },
-// and/or { olderThanDays } when configured; never throws on a missing/bad file.
-function resolveSettings(cwd) {
-  const basePath = path.join(cwd, ".devloops");
-  const extensions = ["", ".yaml", ".yml", ".json"];
-  for (const ext of extensions) {
-    try {
-      const raw = readFileSync(basePath + ext, "utf-8");
-      const settings = ext === ".json" ? JSON.parse(raw) : parseYaml(raw);
-      const queue = settings?.queue;
-      if (!queue) return null;
-      const out = {};
-      if (typeof queue.projectNumber === "number" && Number.isInteger(queue.projectNumber) && queue.projectNumber > 0) {
-        out.project = queue.projectNumber;
-      } else if (typeof queue.boardTitle === "string" && queue.boardTitle.trim().length > 0) {
-        out.title = queue.boardTitle.trim();
-      }
-      if (typeof queue.archiveOlderThanDays === "number" && Number.isInteger(queue.archiveOlderThanDays) && queue.archiveOlderThanDays > 0) {
-        out.olderThanDays = queue.archiveOlderThanDays;
-      }
-      return out;
-    } catch {
-      // extension not present or unparseable — try next
-    }
-  }
-  return null;
 }
 
 // ── API helpers ──────────────────────────────────────────────────────────

--- a/scripts/projects/ensure-queue-board.mjs
+++ b/scripts/projects/ensure-queue-board.mjs
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
-import { readFileSync } from "node:fs";
-import path from "node:path";
 import { parseArgs } from "node:util";
-import { parse as parseYaml } from "yaml";
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
+import { resolveSettings } from "./_resolve-project.mjs";
 
 const USAGE = `Usage: dev-loops queue ensure --repo <owner/name> [--project <number>] [--title <title>] [--link-repo <owner/name>] [--repair-rename]
        (dev-loops project ensure … is a back-compat alias)
@@ -144,36 +142,6 @@ function validateRepo(repo) {
     );
   }
   return repo;
-}
-
-// ── Settings fallback ────────────────────────────────────────────────────
-
-function resolveSettings(cwd) {
-  // Try bare .devloops and extension variants (.yaml, .yml, .json)
-  // to match the config loader's consumer override detection.
-  // .json uses strict JSON.parse; all others use the YAML parser.
-  const basePath = path.join(cwd, ".devloops");
-  const extensions = ["", ".yaml", ".yml", ".json"];
-  for (const ext of extensions) {
-    try {
-      const settingsPath = basePath + ext;
-      const raw = readFileSync(settingsPath, "utf-8");
-      const settings = ext === ".json" ? JSON.parse(raw) : parseYaml(raw);
-      const queue = settings?.queue;
-      if (queue) {
-        if (typeof queue.projectNumber === "number" && Number.isInteger(queue.projectNumber) && queue.projectNumber > 0) {
-          return { project: queue.projectNumber };
-        }
-        if (typeof queue.boardTitle === "string" && queue.boardTitle.trim().length > 0) {
-          return { title: queue.boardTitle.trim() };
-        }
-      }
-      return null;
-    } catch {
-      // extension not present or unparseable — try next
-    }
-  }
-  return null;
 }
 
 // ── API helpers ──────────────────────────────────────────────────────────

--- a/scripts/projects/list-queue-items.mjs
+++ b/scripts/projects/list-queue-items.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
-import { resolveSettings } from "./_resolve-project.mjs";
+import { resolveProjectSelector, findProject, applyDevloopsBoard } from "./_resolve-project.mjs";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult } from "../lib/jq-output.mjs";
 
@@ -147,7 +147,6 @@ function parseCliArgs(argv) {
 
 const OWNER_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
 const REPO_NAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9_.-]*[a-zA-Z0-9])?$/;
-const GLOBAL_NODE_ID_RE = /^[A-Za-z0-9_]+$/;
 
 function validateRepo(repo) {
   if (!repo || typeof repo !== "string") {
@@ -170,31 +169,6 @@ function validateRepo(repo) {
     throw Object.assign(new Error(`--repo must be exactly owner/name, got "${repo}"`), { code: "INVALID_REPO" });
   }
   return repo;
-}
-
-function parseProjectRef(raw) {
-  if (!raw || typeof raw !== "string" || raw.trim().length === 0) {
-    throw Object.assign(new Error("--project is required"), { code: "INVALID_PROJECT" });
-  }
-  const trimmed = raw.trim();
-  const asNum = Number(trimmed);
-  if (Number.isInteger(asNum) && asNum > 0 && String(asNum) === trimmed) {
-    return { kind: "number", value: asNum };
-  }
-  // Reject bare "0" — valid node ID character but not a meaningful project reference
-  if (trimmed === "0") {
-    throw Object.assign(
-      new Error(`--project must be a positive integer or a node ID, got "${raw}"`),
-      { code: "INVALID_PROJECT" },
-    );
-  }
-  if (GLOBAL_NODE_ID_RE.test(trimmed)) {
-    return { kind: "id", value: trimmed };
-  }
-  throw Object.assign(
-    new Error(`--project must be a positive integer or a node ID, got "${raw}"`),
-    { code: "INVALID_PROJECT" },
-  );
 }
 
 // ── API helpers ──────────────────────────────────────────────────────────
@@ -413,19 +387,7 @@ async function main(args, { env = process.env, runChild } = {}) {
   const child = runChild ?? _runChild;
   const repo = validateRepo(args.repo);
   const [owner] = repo.split("/");
-  // Board: explicit --project ref wins; otherwise resolve by board title from
-  // .devloops (passed in as args.projectTitle by runCli). Fail closed if neither.
-  const hasProjectRef = typeof args.project === "string" && args.project.trim().length > 0;
-  const projectRef = hasProjectRef ? parseProjectRef(args.project) : null;
-  const projectTitle = !hasProjectRef && typeof args.projectTitle === "string" && args.projectTitle.trim().length > 0
-    ? args.projectTitle.trim()
-    : null;
-  if (!projectRef && !projectTitle) {
-    throw Object.assign(
-      new Error("--project is required (or set queue.projectNumber / queue.boardTitle in .devloops)"),
-      { code: "INVALID_PROJECT" },
-    );
-  }
+  const selector = resolveProjectSelector(args);
 
   // Mutual exclusion: --summary is the whole-board grouped view; --column/--limit
   // are flat-mode knobs. Combining them is ambiguous.
@@ -453,20 +415,7 @@ async function main(args, { env = process.env, runChild } = {}) {
 
   // 2. Resolve project
   const projects = await listAllProjects(owner, ownerKind, env, child);
-  const project = projectRef
-    ? (projectRef.kind === "id"
-        ? projects.find((p) => p.id === projectRef.value)
-        : projects.find((p) => p.number === projectRef.value))
-    : projects.find((p) => p.title === projectTitle);
-  if (!project) {
-    const desc = projectRef
-      ? (projectRef.kind === "id" ? `with ID "${projectRef.value}"` : `number ${projectRef.value}`)
-      : `title "${projectTitle}"`;
-    throw Object.assign(
-      new Error(`Project ${desc} not found under owner "${owner}"`),
-      { code: "PROJECT_NOT_FOUND" },
-    );
-  }
+  const project = findProject(projects, selector, owner);
 
   // 3. Resolve Status field and target column
   const fieldNodes = await listAllFields(project.id, env, child);
@@ -582,12 +531,7 @@ async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, 
   }
 
   // Resolve the board from .devloops when --project is absent.
-  // Precedence: explicit --project flag > queue.projectNumber/boardTitle.
-  if (args.project === undefined) {
-    const settings = resolveSettings(cwd);
-    if (settings?.project) args.project = String(settings.project);
-    else if (settings?.title) args.projectTitle = settings.title;
-  }
+  applyDevloopsBoard(args, cwd);
 
   try {
     const result = await main(args, { env, runChild });

--- a/scripts/projects/list-queue-items.mjs
+++ b/scripts/projects/list-queue-items.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
+import { resolveSettings } from "./_resolve-project.mjs";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult } from "../lib/jq-output.mjs";
 
-const USAGE = `Usage: dev-loops queue list --repo <owner/name> --project <number|id> [--column <name>] [--limit <n>]
-       dev-loops queue list --repo <owner/name> --project <number|id> --summary [--done-limit <n>]
+const USAGE = `Usage: dev-loops queue list --repo <owner/name> [--project <number|id>] [--column <name>] [--limit <n>]
+       dev-loops queue list --repo <owner/name> [--project <number|id>] --summary [--done-limit <n>]
        (dev-loops project list … is a back-compat alias)
 
 List GitHub Projects V2 items filtered by Status column, ordered by position
@@ -13,7 +14,9 @@ ascending. Returns machine-readable JSON.
 
 Options:
   --repo <owner/name>     Required. Repository to scope the project search.
-  --project <number|id>   Required. Project number (integer) or node ID.
+  --project <number|id>   Project number (integer) or node ID. When omitted,
+                          resolved from .devloops queue.projectNumber /
+                          queue.boardTitle.
   --column <name>         Filter items by Status column value (e.g. "Next Up").
   --limit <n>             Return at most <n> items (flat mode only).
   --summary               Whole-board digest grouped by Status column, in board
@@ -410,7 +413,19 @@ async function main(args, { env = process.env, runChild } = {}) {
   const child = runChild ?? _runChild;
   const repo = validateRepo(args.repo);
   const [owner] = repo.split("/");
-  const projectRef = parseProjectRef(args.project);
+  // Board: explicit --project ref wins; otherwise resolve by board title from
+  // .devloops (passed in as args.projectTitle by runCli). Fail closed if neither.
+  const hasProjectRef = typeof args.project === "string" && args.project.trim().length > 0;
+  const projectRef = hasProjectRef ? parseProjectRef(args.project) : null;
+  const projectTitle = !hasProjectRef && typeof args.projectTitle === "string" && args.projectTitle.trim().length > 0
+    ? args.projectTitle.trim()
+    : null;
+  if (!projectRef && !projectTitle) {
+    throw Object.assign(
+      new Error("--project is required (or set queue.projectNumber / queue.boardTitle in .devloops)"),
+      { code: "INVALID_PROJECT" },
+    );
+  }
 
   // Mutual exclusion: --summary is the whole-board grouped view; --column/--limit
   // are flat-mode knobs. Combining them is ambiguous.
@@ -437,27 +452,20 @@ async function main(args, { env = process.env, runChild } = {}) {
   const { id: ownerId, kind: ownerKind } = await resolveOwner(owner, env, child);
 
   // 2. Resolve project
-  let project;
-  if (projectRef.kind === "id") {
-    // Direct ID: use it directly (verify it belongs to owner via projects list)
-    const projects = await listAllProjects(owner, ownerKind, env, child);
-    project = projects.find((p) => p.id === projectRef.value);
-    if (!project) {
-      throw Object.assign(
-        new Error(`Project with ID "${projectRef.value}" not found under owner "${owner}"`),
-        { code: "PROJECT_NOT_FOUND" },
-      );
-    }
-  } else {
-    // By number
-    const projects = await listAllProjects(owner, ownerKind, env, child);
-    project = projects.find((p) => p.number === projectRef.value);
-    if (!project) {
-      throw Object.assign(
-        new Error(`Project number ${projectRef.value} not found under owner "${owner}"`),
-        { code: "PROJECT_NOT_FOUND" },
-      );
-    }
+  const projects = await listAllProjects(owner, ownerKind, env, child);
+  const project = projectRef
+    ? (projectRef.kind === "id"
+        ? projects.find((p) => p.id === projectRef.value)
+        : projects.find((p) => p.number === projectRef.value))
+    : projects.find((p) => p.title === projectTitle);
+  if (!project) {
+    const desc = projectRef
+      ? (projectRef.kind === "id" ? `with ID "${projectRef.value}"` : `number ${projectRef.value}`)
+      : `title "${projectTitle}"`;
+    throw Object.assign(
+      new Error(`Project ${desc} not found under owner "${owner}"`),
+      { code: "PROJECT_NOT_FOUND" },
+    );
   }
 
   // 3. Resolve Status field and target column
@@ -559,7 +567,7 @@ async function main(args, { env = process.env, runChild } = {}) {
 
 // ── CLI entrypoint ──────────────────────────────────────────────────────
 
-async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, env = process.env } = {}) {
+async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, env = process.env, cwd = process.cwd(), runChild } = {}) {
   let args;
   try {
     args = parseCliArgs(argv);
@@ -572,8 +580,17 @@ async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, 
     stdout.write(USAGE);
     return;
   }
+
+  // Resolve the board from .devloops when --project is absent.
+  // Precedence: explicit --project flag > queue.projectNumber/boardTitle.
+  if (args.project === undefined) {
+    const settings = resolveSettings(cwd);
+    if (settings?.project) args.project = String(settings.project);
+    else if (settings?.title) args.projectTitle = settings.title;
+  }
+
   try {
-    const result = await main(args, { env });
+    const result = await main(args, { env, runChild });
     process.exitCode = emitResult(result, { jq: args.jq, silent: args.silent, stdout, stderr });
   } catch (err) {
     stderr.write(JSON.stringify({ ok: false, error: err.message, code: err.code ?? "UNKNOWN" }) + "\n");
@@ -588,4 +605,4 @@ if (isDirectCliRun(import.meta.url)) {
   });
 }
 
-export { main, parseCliArgs };
+export { main, parseCliArgs, runCli };

--- a/test/projects/_resolve-project.test.mjs
+++ b/test/projects/_resolve-project.test.mjs
@@ -67,4 +67,26 @@ describe("_resolve-project — resolveSettings", () => {
       assert.strictEqual(s.project, 7);
     });
   });
+
+  it("returns null (does not throw) on a syntactically broken .devloops", () => {
+    withTempDevloops("queue:\n  projectNumber: : : bad\n", "", (dir) => {
+      assert.strictEqual(resolveSettings(dir), null);
+    });
+  });
+
+  it("ignores a float projectNumber (fail-closed) with no boardTitle", () => {
+    withTempDevloops("queue:\n  projectNumber: 5.5\n", "", (dir) => {
+      const s = resolveSettings(dir);
+      assert.strictEqual(s.project, undefined);
+      assert.strictEqual(s.title, undefined);
+    });
+  });
+
+  it("ignores a quoted-string projectNumber (fail-closed) with no boardTitle", () => {
+    withTempDevloops("queue:\n  projectNumber: \"5\"\n", "", (dir) => {
+      const s = resolveSettings(dir);
+      assert.strictEqual(s.project, undefined);
+      assert.strictEqual(s.title, undefined);
+    });
+  });
 });

--- a/test/projects/_resolve-project.test.mjs
+++ b/test/projects/_resolve-project.test.mjs
@@ -1,0 +1,70 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { resolveSettings } from "../../scripts/projects/_resolve-project.mjs";
+
+function withTempDevloops(contents, ext, fn) {
+  const dir = mkdtempSync(path.join(tmpdir(), "resolve-project-"));
+  try {
+    if (contents !== null) writeFileSync(path.join(dir, `.devloops${ext}`), contents, "utf-8");
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("_resolve-project — resolveSettings", () => {
+  it("returns null when no .devloops file is present", () => {
+    withTempDevloops(null, "", (dir) => {
+      assert.strictEqual(resolveSettings(dir), null);
+    });
+  });
+
+  it("prefers projectNumber over boardTitle", () => {
+    withTempDevloops("queue:\n  projectNumber: 5\n  boardTitle: \"ignored\"\n", "", (dir) => {
+      const s = resolveSettings(dir);
+      assert.strictEqual(s.project, 5);
+      assert.strictEqual(s.title, undefined);
+    });
+  });
+
+  it("returns { title } when only boardTitle is set", () => {
+    withTempDevloops("queue:\n  boardTitle: \"  Dev Loop Queue  \"\n", "", (dir) => {
+      const s = resolveSettings(dir);
+      assert.strictEqual(s.title, "Dev Loop Queue");
+      assert.strictEqual(s.project, undefined);
+    });
+  });
+
+  it("returns {} (no project/title) when queue present but neither field set", () => {
+    withTempDevloops("queue:\n  archiveOlderThanDays: 3\n", "", (dir) => {
+      const s = resolveSettings(dir);
+      assert.strictEqual(s.project, undefined);
+      assert.strictEqual(s.title, undefined);
+      assert.strictEqual(s.olderThanDays, 3);
+    });
+  });
+
+  it("returns null when queue key is absent entirely", () => {
+    withTempDevloops("other: 1\n", "", (dir) => {
+      assert.strictEqual(resolveSettings(dir), null);
+    });
+  });
+
+  it("ignores a non-positive projectNumber and falls through to boardTitle", () => {
+    withTempDevloops("queue:\n  projectNumber: 0\n  boardTitle: \"B\"\n", "", (dir) => {
+      const s = resolveSettings(dir);
+      assert.strictEqual(s.project, undefined);
+      assert.strictEqual(s.title, "B");
+    });
+  });
+
+  it("reads a .json variant", () => {
+    withTempDevloops(JSON.stringify({ queue: { projectNumber: 7 } }), ".json", (dir) => {
+      const s = resolveSettings(dir);
+      assert.strictEqual(s.project, 7);
+    });
+  });
+});

--- a/test/projects/_resolve-project.test.mjs
+++ b/test/projects/_resolve-project.test.mjs
@@ -3,7 +3,12 @@ import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { resolveSettings } from "../../scripts/projects/_resolve-project.mjs";
+import {
+  resolveSettings,
+  parseProjectRef,
+  resolveProjectSelector,
+  findProject,
+} from "../../scripts/projects/_resolve-project.mjs";
 
 function withTempDevloops(contents, ext, fn) {
   const dir = mkdtempSync(path.join(tmpdir(), "resolve-project-"));
@@ -88,5 +93,82 @@ describe("_resolve-project — resolveSettings", () => {
       assert.strictEqual(s.project, undefined);
       assert.strictEqual(s.title, undefined);
     });
+  });
+});
+
+describe("_resolve-project — parseProjectRef", () => {
+  it("parses a positive integer as a number ref", () => {
+    assert.deepStrictEqual(parseProjectRef("42"), { kind: "number", value: 42 });
+  });
+
+  it("parses a node ID as an id ref", () => {
+    assert.deepStrictEqual(parseProjectRef("PVT_abc123"), { kind: "id", value: "PVT_abc123" });
+  });
+
+  it("throws INVALID_PROJECT for empty/malformed input", () => {
+    for (const bad of ["", "   ", "0", "not/a/ref"]) {
+      assert.throws(() => parseProjectRef(bad), (err) => err.code === "INVALID_PROJECT");
+    }
+  });
+});
+
+describe("_resolve-project — resolveProjectSelector", () => {
+  it("explicit --project ref wins over projectTitle", () => {
+    const sel = resolveProjectSelector({ project: "42", projectTitle: "ignored" });
+    assert.deepStrictEqual(sel.projectRef, { kind: "number", value: 42 });
+    assert.strictEqual(sel.projectTitle, null);
+  });
+
+  it("resolves by title when only projectTitle is set", () => {
+    const sel = resolveProjectSelector({ projectTitle: "  My Board  " });
+    assert.strictEqual(sel.projectRef, null);
+    assert.strictEqual(sel.projectTitle, "My Board");
+  });
+
+  it("throws INVALID_PROJECT when neither is present", () => {
+    assert.throws(() => resolveProjectSelector({}), (err) => err.code === "INVALID_PROJECT");
+  });
+});
+
+describe("_resolve-project — findProject", () => {
+  const projects = [
+    { id: "PVT_x", number: 1, title: "Alpha" },
+    { id: "PVT_y", number: 2, title: "Beta" },
+  ];
+
+  it("finds by node id", () => {
+    const p = findProject(projects, { projectRef: { kind: "id", value: "PVT_y" }, projectTitle: null }, "owner");
+    assert.strictEqual(p.number, 2);
+  });
+
+  it("finds by number", () => {
+    const p = findProject(projects, { projectRef: { kind: "number", value: 1 }, projectTitle: null }, "owner");
+    assert.strictEqual(p.id, "PVT_x");
+  });
+
+  it("finds by title", () => {
+    const p = findProject(projects, { projectRef: null, projectTitle: "Beta" }, "owner");
+    assert.strictEqual(p.number, 2);
+  });
+
+  it("throws PROJECT_NOT_FOUND with an id desc", () => {
+    assert.throws(
+      () => findProject(projects, { projectRef: { kind: "id", value: "PVT_missing" }, projectTitle: null }, "owner"),
+      (err) => err.code === "PROJECT_NOT_FOUND" && /"PVT_missing" not found under owner "owner"/.test(err.message),
+    );
+  });
+
+  it("throws PROJECT_NOT_FOUND with a number desc", () => {
+    assert.throws(
+      () => findProject(projects, { projectRef: { kind: "number", value: 99 }, projectTitle: null }, "owner"),
+      (err) => err.code === "PROJECT_NOT_FOUND" && /number 99 not found under owner "owner"/.test(err.message),
+    );
+  });
+
+  it("throws PROJECT_NOT_FOUND with a title desc", () => {
+    assert.throws(
+      () => findProject(projects, { projectRef: null, projectTitle: "Gamma" }, "owner"),
+      (err) => err.code === "PROJECT_NOT_FOUND" && /title "Gamma" not found under owner "owner"/.test(err.message),
+    );
   });
 });

--- a/test/projects/add-queue-item.test.mjs
+++ b/test/projects/add-queue-item.test.mjs
@@ -588,11 +588,11 @@ describe("add-queue-item", () => {
       ];
     }
 
-    function withTempCwd(contents, fn) {
+    async function withTempCwd(contents, fn) {
       const dir = mkdtempSync(nodePath.join(tmpdir(), "add-queue-cfg-"));
       try {
         if (contents !== null) writeFileSync(nodePath.join(dir, ".devloops"), contents, "utf-8");
-        return fn(dir);
+        return await fn(dir);
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }

--- a/test/projects/add-queue-item.test.mjs
+++ b/test/projects/add-queue-item.test.mjs
@@ -1,6 +1,9 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { main, parseCliArgs } from "../../scripts/projects/add-queue-item.mjs";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import nodePath from "node:path";
+import { main, parseCliArgs, runCli } from "../../scripts/projects/add-queue-item.mjs";
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
@@ -569,6 +572,95 @@ describe("add-queue-item", () => {
         { env: {}, runChild: mockRunChild(responses) },
       );
       assert.equal(result.item.status, "Next Up");
+    });
+  });
+
+  describe("optional --project resolved from .devloops (#1035)", () => {
+    function addResponses(project) {
+      return [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([project]) },
+        { payload: getFieldsResponse([STATUS_FIELD]) },
+        { payload: emptyItemsResponse() },
+        { payload: resolveIssueResponse("I_kwDO_10") },
+        { payload: addItemResponse("PVTI_new") },
+        { payload: updateFieldResponse() },
+      ];
+    }
+
+    function withTempCwd(contents, fn) {
+      const dir = mkdtempSync(nodePath.join(tmpdir(), "add-queue-cfg-"));
+      try {
+        if (contents !== null) writeFileSync(nodePath.join(dir, ".devloops"), contents, "utf-8");
+        return fn(dir);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+
+    function noopStream() {
+      return { write() {} };
+    }
+
+    it("main() resolves the board by title when --project is omitted (projectTitle)", async () => {
+      const result = await main(
+        { repo: "mfittko/dev-loops", projectTitle: "Dev Loop Queue", item: 10 },
+        { env: {}, runChild: mockRunChild(addResponses(EXISTING_PROJECT)) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.item.itemId, "PVTI_new");
+    });
+
+    it("main() fails closed with INVALID_PROJECT when neither --project nor projectTitle given", async () => {
+      await assert.rejects(
+        () => main({ repo: "mfittko/dev-loops", item: 10 }, { env: {}, runChild: mockRunChild([]) }),
+        (e) => e.code === "INVALID_PROJECT" && /queue\.projectNumber/.test(e.message),
+      );
+    });
+
+    it("runCli resolves projectNumber from .devloops when --project omitted", async () => {
+      await withTempCwd("queue:\n  projectNumber: 1\n", async (cwd) => {
+        await runCli(["--repo", "mfittko/dev-loops", "--item", "10"], {
+          env: {}, cwd, runChild: mockRunChild(addResponses(EXISTING_PROJECT)),
+          stdout: noopStream(), stderr: noopStream(),
+        });
+        assert.equal(process.exitCode, 0);
+      });
+    });
+
+    it("runCli resolves boardTitle from .devloops when --project omitted", async () => {
+      await withTempCwd("queue:\n  boardTitle: \"Dev Loop Queue\"\n", async (cwd) => {
+        await runCli(["--repo", "mfittko/dev-loops", "--item", "10"], {
+          env: {}, cwd, runChild: mockRunChild(addResponses(EXISTING_PROJECT)),
+          stdout: noopStream(), stderr: noopStream(),
+        });
+        assert.equal(process.exitCode, 0);
+      });
+    });
+
+    it("runCli: explicit --project wins over .devloops", async () => {
+      const other = { id: "PVT_flag", number: 9, title: "Flag Project", url: "u" };
+      await withTempCwd("queue:\n  projectNumber: 1\n", async (cwd) => {
+        // Only project #9 is returned; if .devloops (#1) had won, resolution would 404.
+        await runCli(["--repo", "mfittko/dev-loops", "--project", "9", "--item", "10"], {
+          env: {}, cwd, runChild: mockRunChild(addResponses(other)),
+          stdout: noopStream(), stderr: noopStream(),
+        });
+        assert.equal(process.exitCode, 0);
+      });
+    });
+
+    it("runCli fails closed (exit 1) when neither --project nor .devloops resolves", async () => {
+      await withTempCwd(null, async (cwd) => {
+        let err = "";
+        await runCli(["--repo", "mfittko/dev-loops", "--item", "10"], {
+          env: {}, cwd, runChild: mockRunChild([]),
+          stdout: noopStream(), stderr: { write(s) { err += s; } },
+        });
+        assert.equal(process.exitCode, 1);
+        assert.match(err, /INVALID_PROJECT/);
+        process.exitCode = 0; // avoid leaking a failure code into the test runner
+      });
     });
   });
 });

--- a/test/projects/list-queue-items.test.mjs
+++ b/test/projects/list-queue-items.test.mjs
@@ -1,6 +1,9 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { main, parseCliArgs } from "../../scripts/projects/list-queue-items.mjs";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import nodePath from "node:path";
+import { main, parseCliArgs, runCli } from "../../scripts/projects/list-queue-items.mjs";
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
@@ -792,6 +795,91 @@ describe("list-queue-items", () => {
         assert.ok(json.error.includes("not found"));
         assert.equal(json.code, "PROJECT_NOT_FOUND");
       }
+    });
+  });
+
+  describe("optional --project resolved from .devloops (#1035)", () => {
+    function listResponses(project) {
+      return [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([project]) },
+        { payload: getFieldsResponse([STATUS_FIELD]) },
+        { payload: getItemsResponse([]) },
+      ];
+    }
+
+    function withTempCwd(contents, fn) {
+      const dir = mkdtempSync(nodePath.join(tmpdir(), "list-queue-cfg-"));
+      try {
+        if (contents !== null) writeFileSync(nodePath.join(dir, ".devloops"), contents, "utf-8");
+        return fn(dir);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+
+    function noopStream() {
+      return { write() {} };
+    }
+
+    it("main() resolves the board by title when --project is omitted (projectTitle)", async () => {
+      const result = await main(
+        { repo: "mfittko/dev-loops", projectTitle: "Dev Loop Queue" },
+        { env: {}, runChild: mockRunChild(listResponses(EXISTING_PROJECT)) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.items.length, 0);
+    });
+
+    it("main() fails closed with INVALID_PROJECT when neither --project nor projectTitle given", async () => {
+      await assert.rejects(
+        () => main({ repo: "mfittko/dev-loops" }, { env: {}, runChild: mockRunChild([]) }),
+        (e) => e.code === "INVALID_PROJECT" && /queue\.projectNumber/.test(e.message),
+      );
+    });
+
+    it("runCli resolves projectNumber from .devloops when --project omitted", async () => {
+      await withTempCwd("queue:\n  projectNumber: 1\n", async (cwd) => {
+        await runCli(["--repo", "mfittko/dev-loops"], {
+          env: {}, cwd, runChild: mockRunChild(listResponses(EXISTING_PROJECT)),
+          stdout: noopStream(), stderr: noopStream(),
+        });
+        assert.equal(process.exitCode, 0);
+      });
+    });
+
+    it("runCli resolves boardTitle from .devloops when --project omitted", async () => {
+      await withTempCwd("queue:\n  boardTitle: \"Dev Loop Queue\"\n", async (cwd) => {
+        await runCli(["--repo", "mfittko/dev-loops"], {
+          env: {}, cwd, runChild: mockRunChild(listResponses(EXISTING_PROJECT)),
+          stdout: noopStream(), stderr: noopStream(),
+        });
+        assert.equal(process.exitCode, 0);
+      });
+    });
+
+    it("runCli: explicit --project wins over .devloops", async () => {
+      const other = { id: "PVT_flag", number: 9, title: "Flag Project", url: "u" };
+      await withTempCwd("queue:\n  projectNumber: 1\n", async (cwd) => {
+        await runCli(["--repo", "mfittko/dev-loops", "--project", "9"], {
+          env: {}, cwd, runChild: mockRunChild(listResponses(other)),
+          stdout: noopStream(), stderr: noopStream(),
+        });
+        assert.equal(process.exitCode, 0);
+      });
+    });
+
+    it("runCli fails closed (exit 1) when neither --project nor .devloops resolves", async () => {
+      await withTempCwd(null, async (cwd) => {
+        let err = "";
+        await runCli(["--repo", "mfittko/dev-loops"], {
+          env: {}, cwd, runChild: mockRunChild([]),
+          stdout: noopStream(), stderr: { write(s) { err += s; } },
+        });
+        assert.equal(process.exitCode, 1);
+        assert.match(err, /INVALID_PROJECT/);
+        process.exitCode = 0; // avoid leaking a failure code into the test runner
+      });
     });
   });
 });

--- a/test/projects/list-queue-items.test.mjs
+++ b/test/projects/list-queue-items.test.mjs
@@ -808,11 +808,11 @@ describe("list-queue-items", () => {
       ];
     }
 
-    function withTempCwd(contents, fn) {
+    async function withTempCwd(contents, fn) {
       const dir = mkdtempSync(nodePath.join(tmpdir(), "list-queue-cfg-"));
       try {
         if (contents !== null) writeFileSync(nodePath.join(dir, ".devloops"), contents, "utf-8");
-        return fn(dir);
+        return await fn(dir);
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }


### PR DESCRIPTION
## Summary

Adds two dev-loop queue slash commands and makes the queue scripts auto-resolve the project board from `.devloops`, so operators no longer pass a project number for common queue operations.

Closes #1035

## Scope and context

Boundary: the two new slash commands, the shared `.devloops`→project resolver they rely on, and the minimal script edits to make `--project` optional. The `archive-done-items.mjs` and `ensure-queue-board.mjs` refactors are in-scope because they remove the exact `.devloops`-parser duplication this change consolidates. No routing, gate, or unrelated behavior is touched.

## File-by-file changes

- `commands/loop-enqueue.command.md` (new) — `/loop-enqueue` command: numeric → wraps `add-queue-item.mjs`; freeform → confirm, create issue, `/loop-grill --auto`, enqueue.
- `commands/loop-queue-status.command.md` (new) — `/loop-queue-status` command: wraps `list-queue-items.mjs --summary`, renders per-column.
- `.claude/commands/loop-enqueue.md`, `.claude/commands/loop-queue-status.md` (generated) — regenerated Claude asset wrappers (no drift).
- `scripts/projects/_resolve-project.mjs` (new) — shared `resolveSettings(cwd)`, extracted from the inline copy in `archive-done-items.mjs`.
- `scripts/projects/add-queue-item.mjs`, `scripts/projects/list-queue-items.mjs` — `--project` now optional; resolves from `.devloops` (`queue.projectNumber` / `queue.boardTitle`); explicit `--project` wins; fails closed when neither is available. USAGE updated.
- `scripts/projects/archive-done-items.mjs`, `scripts/projects/ensure-queue-board.mjs` — refactored to import the shared resolver instead of forking their own `.devloops` parser.
- `test/projects/_resolve-project.test.mjs` (new) + additions to `add-queue-item` / `list-queue-items` tests — resolver behavior, `.devloops` fallback, explicit-flag-wins, fail-closed, bad-file, coercion cases.

## Acceptance criteria (issue #1035)

- [x] `/loop-enqueue <n>` adds an issue/PR to the queue; auto-resolves project from `.devloops`
- [x] `/loop-enqueue` on an already-queued item is a no-op with a clear message (`add-queue-item` `alreadyPresent`)
- [x] `/loop-enqueue` with a non-existent number emits a clear error (`add-queue-item` exit 3)
- [x] `/loop-enqueue <freeform text>` confirms before creating, creates a minimal issue, runs `loop-grill --auto`, writes findings back, then queues
- [x] Freeform path tags the new issue for `local-first` (repo-wide `.devloops` `strategy.default: local-first`; no per-issue tag mechanism exists — none invented)
- [x] Unresolved grill items are visible in the issue before pickup (grill writes `## Grill findings`)
- [x] `/loop-queue-status` lists items grouped by column with numbers and titles (`list-queue-items --summary`, #1061 mode)
- [x] `/loop-queue-status` on an empty board shows a clear empty-state message
- [x] Both commands registered in `commands/` and regenerated into `.claude/commands/`

## Definition of done

- [x] Both commands present in `commands/` and regenerated into `.claude/commands/` with no drift (`generate-claude-assets.mjs --check` exit 0)
- [x] `--project` auto-resolution shared across all four project scripts (no forked `.devloops` parser)
- [x] New + existing tests cover resolver, fallback, precedence, fail-closed, bad-file, and coercion paths
- [x] `npm run verify` green
- [x] Draft gate and pre-approval gate pass; CI green

## Non-goals (per issue)

Moving items between columns, archiving done items, full project-board management, multi-round human Q&A on freeform capture.

## Validation command

`npm run verify` (scripts + core + docs + dev-loop suites). Narrower: `node --test test/projects/*.test.mjs`.
