### PR TITLE
feat(gates): wire lightMode to auto-bypass full fanout for micro-PRs

### DIFF
--- a/.claude/skills/local-implementation/SKILL.md
+++ b/.claude/skills/local-implementation/SKILL.md
@@ -126,33 +126,33 @@ Follow [Anti-patterns](../docs/anti-patterns.md) for the general tooling-interna
 
 Apply [Structural Quality](../docs/structural-quality.md) from the `deep` review angle.
 
-## Light mode (small changes) — config-only
+## Light mode (small changes)
 
-Light mode is currently **config-only**: the schema, resolver, and scope detector are implemented, but no functional wiring exists yet in the local-implementation flow. When scope is small enough, the intent is to skip fan-out/fan-in and use a single review pass instead. Light mode will still require validation and pre-approval gate once wired.
+Light mode is wired into gate dispatch. A PR that is **under threshold** (≤ `maxLines` lines changed AND ≤ `maxFiles` files, per `.devloops` field `localImplementation.lightMode`; defaults `maxLines: 20`, `maxFiles: 2`) AND carries no `gate:full` label collapses BOTH `draft_gate` and `pre_approval_gate` to a single inline single-agent correctness + no-op check. The Copilot review request and its polling are skipped.
 
-**Eligibility:** ≤3 files AND ≤200 lines changed (configurable via `.devloops` field `localImplementation.lightMode`).
+**Escalation:**
+1. Auto-escalate — if the inline check surfaces any finding whose severity is in the gate's `blockCleanOnFindingSeverities` (i.e. ≥ `worth-fixing-now`), dispatch escalates to full fan-out.
+2. Label override — the `gate:full` label forces full fan-out regardless of PR size.
 
-Use `scripts/loop/detect-change-scope.mjs` to determine eligibility:
+The `draft_gate` boundary (draft → ready) is still recorded because `requireDraftFirst` is honored: light mode only changes HOW the gate runs (inline vs fan-out), not WHETHER the draft boundary exists.
+
+Dispatch is resolved deterministically via `resolveGateDispatchMode(config, gate, { scope, hasFullLabel, inlineFindingSeverities })` from `@dev-loops/core/config`. `scripts/loop/resolve-gate-dispatch.mjs` is the CLI wrapper the orchestrator calls, combining `detect-change-scope.mjs` output with the `gate:full` label fact.
+
+Use `scripts/loop/detect-change-scope.mjs` to determine scope:
 ```sh
 node scripts/loop/detect-change-scope.mjs
 ```
-
-**Planned light mode path (not yet wired):**
-1. Validation (`npm run verify`)
-2. Single review pass (not multi-angle fan-out)
-3. Pre-approval gate
-4. Finalization
 
 **Override threshold:**
 ```yaml
 localImplementation:
   lightMode:
     enabled: true
-    maxFiles: 5
-    maxLines: 300
+    maxFiles: 2
+    maxLines: 20
 ```
 
-Disabled by default (opt-in). Scope above threshold falls back to full fan-out/fan-in path.
+Scope above threshold falls back to the full fan-out/fan-in path.
 
 ## Deterministic logging structure
 

--- a/.claude/skills/local-implementation/SKILL.md
+++ b/.claude/skills/local-implementation/SKILL.md
@@ -128,7 +128,7 @@ Apply [Structural Quality](../docs/structural-quality.md) from the `deep` review
 
 ## Light mode (small changes)
 
-Light mode is wired into gate dispatch. A PR that is **under threshold** (≤ `maxLines` lines changed AND ≤ `maxFiles` files, per `.devloops` field `localImplementation.lightMode` — this repo sets `maxLines: 20`, `maxFiles: 2`; the shipped built-in default is disabled at `maxFiles: 3` / `maxLines: 200`) AND carries no `gate:full` label collapses BOTH `draft_gate` and `pre_approval_gate` to a single inline single-agent correctness + no-op check. The Copilot review request and its polling are skipped.
+Light mode is wired into gate dispatch. A PR that is **under threshold** (≤ `maxLines` lines changed AND ≤ `maxFiles` files, per `.devloops` field `localImplementation.lightMode` — this repo sets `maxLines: 20`, `maxFiles: 2`; the shipped built-in default has light mode disabled (`enabled: false`); if enabled without explicit values it falls back to `maxFiles: 3` / `maxLines: 200`) AND carries no `gate:full` label collapses BOTH `draft_gate` and `pre_approval_gate` to a single inline single-agent correctness + no-op check. The Copilot review request and its polling are skipped.
 
 **Escalation:**
 1. Auto-escalate — if the inline check surfaces any finding whose severity is in the gate's `blockCleanOnFindingSeverities` (i.e. ≥ `worth-fixing-now`), dispatch escalates to full fan-out.

--- a/.claude/skills/local-implementation/SKILL.md
+++ b/.claude/skills/local-implementation/SKILL.md
@@ -128,7 +128,7 @@ Apply [Structural Quality](../docs/structural-quality.md) from the `deep` review
 
 ## Light mode (small changes)
 
-Light mode is wired into gate dispatch. A PR that is **under threshold** (≤ `maxLines` lines changed AND ≤ `maxFiles` files, per `.devloops` field `localImplementation.lightMode`; defaults `maxLines: 20`, `maxFiles: 2`) AND carries no `gate:full` label collapses BOTH `draft_gate` and `pre_approval_gate` to a single inline single-agent correctness + no-op check. The Copilot review request and its polling are skipped.
+Light mode is wired into gate dispatch. A PR that is **under threshold** (≤ `maxLines` lines changed AND ≤ `maxFiles` files, per `.devloops` field `localImplementation.lightMode` — this repo sets `maxLines: 20`, `maxFiles: 2`; the shipped built-in default is disabled at `maxFiles: 3` / `maxLines: 200`) AND carries no `gate:full` label collapses BOTH `draft_gate` and `pre_approval_gate` to a single inline single-agent correctness + no-op check. The Copilot review request and its polling are skipped.
 
 **Escalation:**
 1. Auto-escalate — if the inline check surfaces any finding whose severity is in the gate's `blockCleanOnFindingSeverities` (i.e. ≥ `worth-fixing-now`), dispatch escalates to full fan-out.

--- a/.devloops
+++ b/.devloops
@@ -87,7 +87,7 @@ localImplementation:
   lightMode:
     enabled: true
     maxFiles: 2
-    maxLines: 100
+    maxLines: 20 # micro-PR ceiling (#1043)
 
 queue:
   boardTitle: "dev-loops Queue"

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -1069,10 +1069,13 @@ export const GATE_FULL_LABEL = "gate:full";
  *   - escalation: pass the inline pass's finding severities → auto-escalates when
  *     the inline check surfaced anything worth fixing.
  *
+ * Absent or partial `facts.scope` fails safe to full_fanout (missing
+ * filesChanged/linesChanged are treated as `Infinity` → over threshold).
+ *
  * @param {DevLoopConfig} config
  * @param {"draft"|"preApproval"} gate
  * @param {object} facts
- * @param {{ filesChanged: number, linesChanged: number }} facts.scope
+ * @param {{ filesChanged?: number, linesChanged?: number }} [facts.scope] PR scope; absent/partial fields fail safe to full_fanout
  * @param {boolean} [facts.hasFullLabel]           `gate:full` label present on the PR
  * @param {string[]} [facts.inlineFindingSeverities] severities from the inline pass (escalation phase)
  * @returns {{ mode: "inline"|"full_fanout", reason: string, threshold: {maxFiles:number,maxLines:number}|null }}

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -1048,6 +1048,57 @@ export function resolveLightMode(config) {
   };
 }
 
+/** Label that forces full fan-out regardless of change size. */
+export const GATE_FULL_LABEL = "gate:full";
+
+/**
+ * Decide whether a gate should run as a single-agent inline check or the full
+ * fan-out, from light-mode config + authoritative PR facts.
+ *
+ * Precedence (first match wins):
+ *   1. `gate:full` label present            → full_fanout (label override)
+ *   2. light mode disabled / no threshold    → full_fanout (light mode off)
+ *   3. scope over threshold (files OR lines) → full_fanout (over threshold)
+ *   4. inline check produced a finding whose severity is in the gate's
+ *      blockCleanOnFindingSeverities set     → full_fanout (escalated)
+ *   5. otherwise                             → inline
+ *
+ * Two call phases share this one function:
+ *   - pre-check: omit `inlineFindingSeverities` (undefined) → decides whether to
+ *     run the inline pass at all.
+ *   - escalation: pass the inline pass's finding severities → auto-escalates when
+ *     the inline check surfaced anything worth fixing.
+ *
+ * @param {DevLoopConfig} config
+ * @param {"draft"|"preApproval"} gate
+ * @param {object} facts
+ * @param {{ filesChanged: number, linesChanged: number }} facts.scope
+ * @param {boolean} [facts.hasFullLabel]           `gate:full` label present on the PR
+ * @param {string[]} [facts.inlineFindingSeverities] severities from the inline pass (escalation phase)
+ * @returns {{ mode: "inline"|"full_fanout", reason: string, threshold: {maxFiles:number,maxLines:number}|null }}
+ */
+export function resolveGateDispatchMode(config, gate, { scope, hasFullLabel = false, inlineFindingSeverities } = {}) {
+  if (hasFullLabel) {
+    return { mode: "full_fanout", reason: "gate_full_label", threshold: null };
+  }
+  const threshold = resolveLightMode(config);
+  if (!threshold) {
+    return { mode: "full_fanout", reason: "light_mode_disabled", threshold: null };
+  }
+  const filesChanged = Number(scope?.filesChanged ?? Infinity);
+  const linesChanged = Number(scope?.linesChanged ?? Infinity);
+  if (filesChanged > threshold.maxFiles || linesChanged > threshold.maxLines) {
+    return { mode: "full_fanout", reason: "over_threshold", threshold };
+  }
+  if (Array.isArray(inlineFindingSeverities) && inlineFindingSeverities.length > 0) {
+    const blocking = new Set(resolveGateConfig(config, gate).blockCleanOnFindingSeverities);
+    if (inlineFindingSeverities.some((s) => blocking.has(s))) {
+      return { mode: "full_fanout", reason: "escalated", threshold };
+    }
+  }
+  return { mode: "inline", reason: "under_threshold", threshold };
+}
+
 /**
  * Resolve review angles for a specific gate from the merged dev-loop config.
  *

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -2508,6 +2508,12 @@ test("resolveGateDispatchMode: over threshold on lines → full fan-out", () => 
   assert.equal(result.reason, "over_threshold");
 });
 
+test("resolveGateDispatchMode: missing/empty scope → over_threshold (Infinity fail-safe)", () => {
+  const result = resolveGateDispatchMode(lightConfig(), "preApproval", { scope: {} });
+  assert.equal(result.mode, "full_fanout");
+  assert.equal(result.reason, "over_threshold");
+});
+
 test("resolveGateDispatchMode: under threshold, no findings → inline", () => {
   const config = lightConfig();
   const result = resolveGateDispatchMode(config, "preApproval", {

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -23,6 +23,8 @@ import {
   resolveGateAnglesDynamic,
   resolveWorkflowConfig,
   resolveLightMode,
+  resolveGateDispatchMode,
+  GATE_FULL_LABEL,
   resolveRequireFanoutEvidence,
   resolveMaxFanoutReviewers,
   resolveGatePostFindingsComments,
@@ -2461,6 +2463,81 @@ test("resolveLightMode uses built-in defaults when enabled with no overrides", (
 test("resolveLightMode with built-in defaults (disabled)", () => {
   const result = resolveLightMode({ version: 1 });
   assert.equal(result, null);
+});
+
+// ── Gate dispatch mode ───────────────────────────────────────────────────
+
+const lightConfig = (over = {}) => ({
+  version: 1,
+  localImplementation: { lightMode: { enabled: true, maxFiles: 2, maxLines: 20, ...over } },
+  gates: {
+    preApproval: { blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"] },
+  },
+});
+
+test("resolveGateDispatchMode: gate:full label forces full fan-out even when tiny", () => {
+  const result = resolveGateDispatchMode(lightConfig(), "preApproval", {
+    scope: { filesChanged: 1, linesChanged: 1 },
+    hasFullLabel: true,
+  });
+  assert.equal(result.mode, "full_fanout");
+  assert.equal(result.reason, "gate_full_label");
+});
+
+test("resolveGateDispatchMode: light mode disabled → full fan-out", () => {
+  const result = resolveGateDispatchMode(lightConfig({ enabled: false }), "preApproval", {
+    scope: { filesChanged: 1, linesChanged: 1 },
+  });
+  assert.equal(result.mode, "full_fanout");
+  assert.equal(result.reason, "light_mode_disabled");
+});
+
+test("resolveGateDispatchMode: over threshold on files → full fan-out", () => {
+  const result = resolveGateDispatchMode(lightConfig(), "preApproval", {
+    scope: { filesChanged: 3, linesChanged: 5 },
+  });
+  assert.equal(result.mode, "full_fanout");
+  assert.equal(result.reason, "over_threshold");
+});
+
+test("resolveGateDispatchMode: over threshold on lines → full fan-out", () => {
+  const result = resolveGateDispatchMode(lightConfig(), "preApproval", {
+    scope: { filesChanged: 1, linesChanged: 21 },
+  });
+  assert.equal(result.mode, "full_fanout");
+  assert.equal(result.reason, "over_threshold");
+});
+
+test("resolveGateDispatchMode: under threshold, no findings → inline", () => {
+  const config = lightConfig();
+  const result = resolveGateDispatchMode(config, "preApproval", {
+    scope: { filesChanged: 2, linesChanged: 20 },
+  });
+  assert.equal(result.mode, "inline");
+  assert.equal(result.reason, "under_threshold");
+  assert.deepStrictEqual(result.threshold, resolveLightMode(config));
+});
+
+test("resolveGateDispatchMode: under threshold + blocking inline finding → escalated", () => {
+  const result = resolveGateDispatchMode(lightConfig(), "preApproval", {
+    scope: { filesChanged: 1, linesChanged: 5 },
+    inlineFindingSeverities: ["worth-fixing-now"],
+  });
+  assert.equal(result.mode, "full_fanout");
+  assert.equal(result.reason, "escalated");
+});
+
+test("resolveGateDispatchMode: under threshold + only non-blocking finding → inline", () => {
+  const result = resolveGateDispatchMode(lightConfig(), "preApproval", {
+    scope: { filesChanged: 1, linesChanged: 5 },
+    inlineFindingSeverities: ["defer"],
+  });
+  assert.equal(result.mode, "inline");
+  assert.equal(result.reason, "under_threshold");
+});
+
+test("GATE_FULL_LABEL is gate:full", () => {
+  assert.equal(GATE_FULL_LABEL, "gate:full");
 });
 
 // ── Light mode eligibility ───────────────────────────────────────────────

--- a/scripts/github/create-label.mjs
+++ b/scripts/github/create-label.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { parseArgs } from "node:util";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
+
+const USAGE = `Usage: create-label.mjs --repo <owner/name> --name <label> [--color <hex>] [--description <text>] [--force]
+Create (or idempotently reuse) a GitHub label. Thin wrapper over \`gh label create\`
+— use this instead of an agent-level raw \`gh label create\` so the loop's
+internal-tooling record stays clean (siblings: comment-issue.mjs, edit-pr.mjs).
+Required:
+  --repo <owner/name>           Repository slug (e.g. owner/repo)
+  --name <label>                Label name to create
+Optional:
+  --color <hex>                 Hex color without '#' (default: d73a4a)
+  --description <text>          Label description
+  --force                       Update the label if it already exists
+Output (stdout, JSON):
+  { "ok": true, "created": true, "name": "gate:full", "color": "d73a4a", "repo": "owner/repo" }
+  { "ok": true, "created": false, "alreadyExists": true, "name": "gate:full" }
+Error output (stderr, JSON):
+  { "ok": false, "error": "...", "usage"?: "..." }
+Exit codes:
+  0  Success (created or already exists)
+  1  Argument error or gh failure`.trim();
+const parseError = buildParseError(USAGE);
+
+export function parseCreateLabelCliArgs(argv) {
+  const { values } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      name: { type: "string" },
+      color: { type: "string" },
+      description: { type: "string" },
+      force: { type: "boolean" },
+    },
+    allowPositionals: false,
+    strict: false,
+  });
+  if (values.help) {
+    return { help: true };
+  }
+  const repo = typeof values.repo === "string" ? values.repo.trim() : undefined;
+  const name = typeof values.name === "string" ? values.name.trim() : undefined;
+  if (!repo || !name) {
+    throw parseError("Creating a label requires both --repo <owner/name> and --name <label>");
+  }
+  try {
+    parseRepoSlug(repo);
+  } catch (error) {
+    throw parseError(error instanceof Error ? error.message : String(error));
+  }
+  const color = typeof values.color === "string" && values.color.trim().length > 0 ? values.color.trim() : "d73a4a";
+  const description =
+    typeof values.description === "string" && values.description.length > 0 ? values.description : undefined;
+  return {
+    help: false,
+    repo,
+    name,
+    color,
+    description,
+    force: values.force === true,
+  };
+}
+
+// Pure: assemble the `gh label create` argv. Exported so the arg shape can be
+// tested without spawning gh.
+export function buildLabelArgs({ repo, name, color, description, force }) {
+  const args = ["label", "create", name, "--repo", repo, "--color", color];
+  if (description !== undefined) {
+    args.push("--description", description);
+  }
+  if (force) {
+    args.push("--force");
+  }
+  return args;
+}
+
+export function createLabel(options, { ghCommand = "gh", exec = execFileSync } = {}) {
+  const args = buildLabelArgs(options);
+  try {
+    exec(ghCommand, args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  } catch (error) {
+    const stderr = typeof error?.stderr === "string" ? error.stderr : String(error?.stderr ?? "");
+    // Without --force, gh errors if the label exists. Treat that as idempotent
+    // success so re-runs are safe; any other failure propagates.
+    if (!options.force && /already exists/i.test(stderr)) {
+      return { ok: true, created: false, alreadyExists: true, name: options.name };
+    }
+    const detail = stderr.trim() || (error instanceof Error ? error.message : String(error));
+    throw new Error(`gh label create failed: ${detail}`);
+  }
+  return { ok: true, created: true, name: options.name, color: options.color, repo: options.repo };
+}
+
+export function run(
+  argv = process.argv.slice(2),
+  { stdout = process.stdout, stderr = process.stderr, ghCommand = "gh", exec = execFileSync } = {},
+) {
+  let options;
+  try {
+    options = parseCreateLabelCliArgs(argv);
+  } catch (error) {
+    stderr.write(`${formatCliError(error)}\n`);
+    return 1;
+  }
+  if (options.help) {
+    stdout.write(`${USAGE}\n`);
+    return 0;
+  }
+  let result;
+  try {
+    result = createLabel(options, { ghCommand, exec });
+  } catch (error) {
+    stderr.write(`${JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) })}\n`);
+    return 1;
+  }
+  stdout.write(`${JSON.stringify(result)}\n`);
+  return 0;
+}
+
+export const main = run;
+
+if (isDirectCliRun(import.meta.url)) {
+  process.exitCode = run();
+}

--- a/scripts/loop/check-retro-tooling.mjs
+++ b/scripts/loop/check-retro-tooling.mjs
@@ -81,6 +81,10 @@ const ALLOWED_WRITE_OPS = Object.freeze([
   /^gh\s+pr\s+ready\b/,
   /^gh\s+issue\s+create\b/,
   /^gh\s+issue\s+edit\b/,
+  // `gh label create` HAS a wrapper (scripts/github/create-label.mjs); this
+  // entry is belt-and-suspenders so a bare invocation (e.g. surfaced from the
+  // wrapper's own subprocess) classifies as an allowed write-op, not a violation.
+  /^gh\s+label\s+create\b/,
 ]);
 
 /** Split a command line into top-level segments on &&, ||, |, ;. */

--- a/scripts/loop/resolve-gate-dispatch.mjs
+++ b/scripts/loop/resolve-gate-dispatch.mjs
@@ -30,7 +30,7 @@ Exit codes:
 
 const VALID_GATES = new Set(["draft", "preApproval"]);
 
-/** Parse a comma-separated severity list into a trimmed, non-empty array (or undefined). */
+/** Parse a comma-separated severity list. Returns `undefined` when the flag is absent, otherwise a trimmed array (which may be empty `[]` for empty/whitespace-only input). */
 export function parseSeverities(csv) {
   if (csv == null) return undefined;
   const list = String(csv)

--- a/scripts/loop/resolve-gate-dispatch.mjs
+++ b/scripts/loop/resolve-gate-dispatch.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+import process from "node:process";
+import { parseArgs } from "node:util";
+import {
+  loadDevLoopConfig,
+  resolveGateDispatchMode,
+  GATE_FULL_LABEL,
+} from "@dev-loops/core/config";
+import { detectScope } from "./detect-change-scope.mjs";
+
+const USAGE = `Usage: resolve-gate-dispatch.mjs --gate <draft|preApproval> [--base <ref>] [--head <ref>] [--full-label] [--inline-severities <csv>]
+Decide inline vs full fan-out for a gate from lightMode config + PR facts.
+Options:
+  --gate <draft|preApproval>   Gate to resolve dispatch for (required)
+  --base <ref>                 Base ref for scope detection (default: HEAD~1)
+  --head <ref>                 Head ref; ignored unless --base is also set
+  --full-label                 PR has the ${GATE_FULL_LABEL} label (forces full fan-out)
+  --inline-severities <csv>    Comma-separated severities from the inline pass (escalation phase)
+  --help, -h                   Show this help
+Exit codes:
+  0   Success
+  1   Error
+`;
+
+const VALID_GATES = new Set(["draft", "preApproval"]);
+
+/** Parse a comma-separated severity list into a trimmed, non-empty array (or undefined). */
+export function parseSeverities(csv) {
+  if (csv == null) return undefined;
+  const list = String(csv)
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return list.length > 0 ? list : [];
+}
+
+function parseCliArgs(argv) {
+  const { values } = parseArgs({
+    args: [...argv],
+    options: {
+      gate: { type: "string" },
+      base: { type: "string" },
+      head: { type: "string" },
+      "full-label": { type: "boolean", default: false },
+      "inline-severities": { type: "string" },
+      help: { type: "boolean", short: "h" },
+    },
+    allowPositionals: true,
+    strict: true,
+  });
+  if (values.help) {
+    process.stdout.write(USAGE);
+    process.exit(0);
+  }
+  if (!values.gate || !VALID_GATES.has(values.gate)) {
+    throw new Error("--gate must be one of: draft, preApproval");
+  }
+  return {
+    gate: values.gate,
+    base: values.base ?? null,
+    head: values.head ?? null,
+    hasFullLabel: Boolean(values["full-label"]),
+    inlineFindingSeverities: parseSeverities(values["inline-severities"]),
+  };
+}
+
+export async function run(argv) {
+  let opts;
+  try {
+    opts = parseCliArgs(argv);
+  } catch (err) {
+    process.stderr.write(
+      JSON.stringify({ ok: false, error: err.message, usage: USAGE.trim() }) + "\n"
+    );
+    process.exitCode = 1;
+    return;
+  }
+  try {
+    const { config } = await loadDevLoopConfig({ repoRoot: process.cwd() });
+    const scope = detectScope({ base: opts.base, head: opts.head });
+    const decision = resolveGateDispatchMode(config, opts.gate, {
+      scope,
+      hasFullLabel: opts.hasFullLabel,
+      inlineFindingSeverities: opts.inlineFindingSeverities,
+    });
+    process.stdout.write(
+      JSON.stringify({ ok: true, gate: opts.gate, scope, ...decision }) + "\n"
+    );
+  } catch (err) {
+    process.stderr.write(
+      JSON.stringify({ ok: false, error: err instanceof Error ? err.message : String(err) }) + "\n"
+    );
+    process.exitCode = 1;
+  }
+}
+
+const isDirectRun =
+  process.argv[1] && process.argv[1].includes("resolve-gate-dispatch.mjs");
+if (isDirectRun) {
+  run(process.argv.slice(2)).catch((err) => {
+    process.stderr.write(
+      JSON.stringify({ ok: false, error: err instanceof Error ? err.message : String(err) }) + "\n"
+    );
+    process.exitCode = 1;
+  });
+}

--- a/scripts/loop/resolve-gate-dispatch.mjs
+++ b/scripts/loop/resolve-gate-dispatch.mjs
@@ -17,6 +17,12 @@ Options:
   --full-label                 PR has the ${GATE_FULL_LABEL} label (forces full fan-out)
   --inline-severities <csv>    Comma-separated severities from the inline pass (escalation phase)
   --help, -h                   Show this help
+Output (stdout, JSON):
+  { "ok": true, "gate": "draft", "scope": { "ok": true, "filesChanged": 1, "linesChanged": 5 }, "mode": "inline", "reason": "under_threshold", "threshold": { "maxFiles": 2, "maxLines": 20 } }
+  { "ok": true, "gate": "draft", "scope": { "ok": true, "filesChanged": 9, "linesChanged": 300 }, "mode": "full_fanout", "reason": "over_threshold", "threshold": { "maxFiles": 2, "maxLines": 20 } }
+  { "ok": true, "gate": "draft", "scope": { "ok": false, ... }, "mode": "full_fanout", "reason": "scope_detection_failed", "threshold": null }
+Error output (stderr, JSON):
+  { "ok": false, "error": "...", "usage"?: "..." }
 Exit codes:
   0   Success
   1   Error
@@ -78,6 +84,21 @@ export async function run(argv) {
   try {
     const { config } = await loadDevLoopConfig({ repoRoot: process.cwd() });
     const scope = detectScope({ base: opts.base, head: opts.head });
+    // Fail CLOSED on unmeasurable scope: a broken/failed diff must route to the
+    // full gate, never silently collapse to inline (which would bypass review).
+    if (scope.ok === false) {
+      process.stdout.write(
+        JSON.stringify({
+          ok: true,
+          gate: opts.gate,
+          scope,
+          mode: "full_fanout",
+          reason: "scope_detection_failed",
+          threshold: null,
+        }) + "\n"
+      );
+      return;
+    }
     const decision = resolveGateDispatchMode(config, opts.gate, {
       scope,
       hasFullLabel: opts.hasFullLabel,

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -132,7 +132,7 @@ Apply [Structural Quality](../docs/structural-quality.md) from the `deep` review
 
 ## Light mode (small changes)
 
-Light mode is wired into gate dispatch. A PR that is **under threshold** (≤ `maxLines` lines changed AND ≤ `maxFiles` files, per `.devloops` field `localImplementation.lightMode`; defaults `maxLines: 20`, `maxFiles: 2`) AND carries no `gate:full` label collapses BOTH `draft_gate` and `pre_approval_gate` to a single inline single-agent correctness + no-op check. The Copilot review request and its polling are skipped.
+Light mode is wired into gate dispatch. A PR that is **under threshold** (≤ `maxLines` lines changed AND ≤ `maxFiles` files, per `.devloops` field `localImplementation.lightMode` — this repo sets `maxLines: 20`, `maxFiles: 2`; the shipped built-in default is disabled at `maxFiles: 3` / `maxLines: 200`) AND carries no `gate:full` label collapses BOTH `draft_gate` and `pre_approval_gate` to a single inline single-agent correctness + no-op check. The Copilot review request and its polling are skipped.
 
 **Escalation:**
 1. Auto-escalate — if the inline check surfaces any finding whose severity is in the gate's `blockCleanOnFindingSeverities` (i.e. ≥ `worth-fixing-now`), dispatch escalates to full fan-out.

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -132,7 +132,7 @@ Apply [Structural Quality](../docs/structural-quality.md) from the `deep` review
 
 ## Light mode (small changes)
 
-Light mode is wired into gate dispatch. A PR that is **under threshold** (≤ `maxLines` lines changed AND ≤ `maxFiles` files, per `.devloops` field `localImplementation.lightMode` — this repo sets `maxLines: 20`, `maxFiles: 2`; the shipped built-in default is disabled at `maxFiles: 3` / `maxLines: 200`) AND carries no `gate:full` label collapses BOTH `draft_gate` and `pre_approval_gate` to a single inline single-agent correctness + no-op check. The Copilot review request and its polling are skipped.
+Light mode is wired into gate dispatch. A PR that is **under threshold** (≤ `maxLines` lines changed AND ≤ `maxFiles` files, per `.devloops` field `localImplementation.lightMode` — this repo sets `maxLines: 20`, `maxFiles: 2`; the shipped built-in default has light mode disabled (`enabled: false`); if enabled without explicit values it falls back to `maxFiles: 3` / `maxLines: 200`) AND carries no `gate:full` label collapses BOTH `draft_gate` and `pre_approval_gate` to a single inline single-agent correctness + no-op check. The Copilot review request and its polling are skipped.
 
 **Escalation:**
 1. Auto-escalate — if the inline check surfaces any finding whose severity is in the gate's `blockCleanOnFindingSeverities` (i.e. ≥ `worth-fixing-now`), dispatch escalates to full fan-out.

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -130,33 +130,33 @@ Follow [Anti-patterns](../docs/anti-patterns.md) for the general tooling-interna
 
 Apply [Structural Quality](../docs/structural-quality.md) from the `deep` review angle.
 
-## Light mode (small changes) — config-only
+## Light mode (small changes)
 
-Light mode is currently **config-only**: the schema, resolver, and scope detector are implemented, but no functional wiring exists yet in the local-implementation flow. When scope is small enough, the intent is to skip fan-out/fan-in and use a single review pass instead. Light mode will still require validation and pre-approval gate once wired.
+Light mode is wired into gate dispatch. A PR that is **under threshold** (≤ `maxLines` lines changed AND ≤ `maxFiles` files, per `.devloops` field `localImplementation.lightMode`; defaults `maxLines: 20`, `maxFiles: 2`) AND carries no `gate:full` label collapses BOTH `draft_gate` and `pre_approval_gate` to a single inline single-agent correctness + no-op check. The Copilot review request and its polling are skipped.
 
-**Eligibility:** ≤3 files AND ≤200 lines changed (configurable via `.devloops` field `localImplementation.lightMode`).
+**Escalation:**
+1. Auto-escalate — if the inline check surfaces any finding whose severity is in the gate's `blockCleanOnFindingSeverities` (i.e. ≥ `worth-fixing-now`), dispatch escalates to full fan-out.
+2. Label override — the `gate:full` label forces full fan-out regardless of PR size.
 
-Use `scripts/loop/detect-change-scope.mjs` to determine eligibility:
+The `draft_gate` boundary (draft → ready) is still recorded because `requireDraftFirst` is honored: light mode only changes HOW the gate runs (inline vs fan-out), not WHETHER the draft boundary exists.
+
+Dispatch is resolved deterministically via `resolveGateDispatchMode(config, gate, { scope, hasFullLabel, inlineFindingSeverities })` from `@dev-loops/core/config`. `scripts/loop/resolve-gate-dispatch.mjs` is the CLI wrapper the orchestrator calls, combining `detect-change-scope.mjs` output with the `gate:full` label fact.
+
+Use `scripts/loop/detect-change-scope.mjs` to determine scope:
 ```sh
 node scripts/loop/detect-change-scope.mjs
 ```
-
-**Planned light mode path (not yet wired):**
-1. Validation (`npm run verify`)
-2. Single review pass (not multi-angle fan-out)
-3. Pre-approval gate
-4. Finalization
 
 **Override threshold:**
 ```yaml
 localImplementation:
   lightMode:
     enabled: true
-    maxFiles: 5
-    maxLines: 300
+    maxFiles: 2
+    maxLines: 20
 ```
 
-Disabled by default (opt-in). Scope above threshold falls back to full fan-out/fan-in path.
+Scope above threshold falls back to the full fan-out/fan-in path.
 
 ## Deterministic logging structure
 

--- a/test/github/create-label.test.mjs
+++ b/test/github/create-label.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildLabelArgs } from "../../scripts/github/create-label.mjs";
+import { buildLabelArgs, createLabel } from "../../scripts/github/create-label.mjs";
 
 test("buildLabelArgs includes name, repo and default color", () => {
   const args = buildLabelArgs({ repo: "o/n", name: "gate:full", color: "d73a4a" });
@@ -28,4 +28,29 @@ test("buildLabelArgs appends --force only when force is true", () => {
 
   const unforced = buildLabelArgs({ repo: "o/n", name: "x", color: "d73a4a", force: false });
   assert.equal(unforced.includes("--force"), false);
+});
+
+test("createLabel treats an existing label as idempotent success without --force", () => {
+  const exec = () => {
+    const err = new Error("gh failed");
+    err.stderr = "HTTP 422: Validation Failed (label already exists)";
+    throw err;
+  };
+  const result = createLabel(
+    { repo: "o/n", name: "gate:full", color: "d73a4a", force: false },
+    { exec },
+  );
+  assert.deepEqual(result, { ok: true, created: false, alreadyExists: true, name: "gate:full" });
+});
+
+test("createLabel rethrows a generic gh failure", () => {
+  const exec = () => {
+    const err = new Error("boom");
+    err.stderr = "HTTP 500: something else broke";
+    throw err;
+  };
+  assert.throws(
+    () => createLabel({ repo: "o/n", name: "gate:full", color: "d73a4a", force: false }, { exec }),
+    /gh label create failed: HTTP 500: something else broke/,
+  );
 });

--- a/test/github/create-label.test.mjs
+++ b/test/github/create-label.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildLabelArgs } from "../../scripts/github/create-label.mjs";
+
+test("buildLabelArgs includes name, repo and default color", () => {
+  const args = buildLabelArgs({ repo: "o/n", name: "gate:full", color: "d73a4a" });
+  assert.deepEqual(args, ["label", "create", "gate:full", "--repo", "o/n", "--color", "d73a4a"]);
+});
+
+test("buildLabelArgs respects a color override", () => {
+  const args = buildLabelArgs({ repo: "o/n", name: "x", color: "00ff00" });
+  assert.equal(args[args.indexOf("--color") + 1], "00ff00");
+});
+
+test("buildLabelArgs appends --description when provided, omits when not", () => {
+  const withDesc = buildLabelArgs({ repo: "o/n", name: "x", color: "d73a4a", description: "hi" });
+  assert.equal(withDesc.includes("--description"), true);
+  assert.equal(withDesc[withDesc.indexOf("--description") + 1], "hi");
+
+  const withoutDesc = buildLabelArgs({ repo: "o/n", name: "x", color: "d73a4a" });
+  assert.equal(withoutDesc.includes("--description"), false);
+});
+
+test("buildLabelArgs appends --force only when force is true", () => {
+  const forced = buildLabelArgs({ repo: "o/n", name: "x", color: "d73a4a", force: true });
+  assert.equal(forced.includes("--force"), true);
+
+  const unforced = buildLabelArgs({ repo: "o/n", name: "x", color: "d73a4a", force: false });
+  assert.equal(unforced.includes("--force"), false);
+});

--- a/test/loop/resolve-gate-dispatch.test.mjs
+++ b/test/loop/resolve-gate-dispatch.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseSeverities } from "../../scripts/loop/resolve-gate-dispatch.mjs";
+
+test("parseSeverities trims and drops empty entries", () => {
+  assert.deepEqual(parseSeverities("a, ,b"), ["a", "b"]);
+});
+
+test("parseSeverities returns [] for an empty string", () => {
+  assert.deepEqual(parseSeverities(""), []);
+});
+
+test("parseSeverities returns undefined for null/undefined", () => {
+  assert.equal(parseSeverities(undefined), undefined);
+  assert.equal(parseSeverities(null), undefined);
+});

--- a/test/loop/resolve-gate-dispatch.test.mjs
+++ b/test/loop/resolve-gate-dispatch.test.mjs
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 
 import { parseSeverities } from "../../scripts/loop/resolve-gate-dispatch.mjs";
+
+const SCRIPT = fileURLToPath(
+  new URL("../../scripts/loop/resolve-gate-dispatch.mjs", import.meta.url)
+);
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
 
 test("parseSeverities trims and drops empty entries", () => {
   assert.deepEqual(parseSeverities("a, ,b"), ["a", "b"]);
@@ -14,4 +21,21 @@ test("parseSeverities returns [] for an empty string", () => {
 test("parseSeverities returns undefined for null/undefined", () => {
   assert.equal(parseSeverities(undefined), undefined);
   assert.equal(parseSeverities(null), undefined);
+});
+
+// Regression: fail-CLOSED. When scope detection fails (scope.ok===false), the
+// gate must route to full_fanout/scope_detection_failed, never collapse to
+// inline. A bad --base ref makes the git diff inside detectScope fail offline.
+test("scope.ok===false routes to full_fanout, never inline", () => {
+  const out = execFileSync(
+    process.execPath,
+    [SCRIPT, "--gate", "draft", "--base", "nonexistent-ref-xyz-please"],
+    { cwd: REPO_ROOT, encoding: "utf8" }
+  );
+  const result = JSON.parse(out.trim());
+  assert.equal(result.ok, true);
+  assert.equal(result.mode, "full_fanout");
+  assert.equal(result.reason, "scope_detection_failed");
+  assert.equal(result.threshold, null);
+  assert.equal(result.scope.ok, false);
 });


### PR DESCRIPTION
## Summary

Wires the `.devloops` `lightMode` config (`enabled` / `maxLines` / `maxFiles`) into gate dispatch so micro-PRs skip the heavyweight fan-out review, while keeping the draft→ready boundary and all real findings intact.

A new pure decision function `resolveGateDispatchMode(config, gate, { scope, hasFullLabel, inlineFindingSeverities })` in `@dev-loops/core/config` returns `{ mode: "inline" | "full_fanout", reason, threshold }`. Precedence (first match wins):

1. `gate:full` label present → `full_fanout` (label override)
2. light mode disabled / no threshold → `full_fanout`
3. scope over threshold (files OR lines) → `full_fanout`
4. inline check produced a finding in the gate's `blockCleanOnFindingSeverities` (≥ `worth-fixing-now`) → `full_fanout` (auto-escalate)
5. otherwise → `inline`

A PR under threshold (≤ `maxLines` lines AND ≤ `maxFiles` files) with no `gate:full` label collapses **both** `draft_gate` and `pre_approval_gate` to a single inline single-agent correctness + no-op check, and Copilot review request + polling are skipped. The `draft_gate` boundary is still recorded because `requireDraftFirst` is honored — light mode only changes *how* the gate runs, not *whether* the draft boundary exists.

## Scope and context

Boundary: the change wires the *already-present* `lightMode` config keys into gate-dispatch decision-making and adds the `gate:full` escape hatch. It reuses the existing `resolveLightMode` / `resolveGateConfig` / `blockCleanOnFindingSeverities` machinery rather than introducing new config surface.

## File-by-file changes

- `packages/core/src/config/config.mjs` — new `resolveGateDispatchMode` + `GATE_FULL_LABEL` export (reuses existing `resolveLightMode` / `resolveGateConfig`).
- `scripts/loop/resolve-gate-dispatch.mjs` — CLI wrapper combining `detect-change-scope.mjs` output + the `gate:full` label fact; fails closed to `full_fanout` when scope detection fails.
- `scripts/github/create-label.mjs` — idempotent label-create wrapper (no wrapper existed); used to create the `gate:full` label (color `d73a4a`).
- `scripts/loop/check-retro-tooling.mjs` — allow `gh label create` as a sanctioned write-op.
- `.devloops` — `maxLines` `100` → `20` (`maxFiles` stays `2`).
- `skills/local-implementation/SKILL.md` (+ regenerated `.claude` copy) — light mode documented as wired; clarifies 20/2 is this repo's override, not the shipped default.
- `packages/core/test/config.test.mjs` — tests for `resolveGateDispatchMode` + `GATE_FULL_LABEL`; `test/github/create-label.test.mjs` — label wrapper tests.

## Acceptance criteria

- [x] Gate dispatch reads `lightMode.enabled` / `maxLines` / `maxFiles`
- [x] PR under threshold (no `gate:full`) → inline check; full fanout skipped
- [x] Inline finding ≥ `worth-fixing-now` → escalates to full fanout
- [x] `gate:full` label → always full fanout regardless of size
- [x] Copilot review request + polling skipped for light-mode PRs (dispatch returns `inline`)
- [x] `draft_gate` boundary still recorded (`requireDraftFirst` honored)
- [x] `.devloops` `maxLines` → 20, `maxFiles` stays 2
- [x] Existing full-fanout path unchanged for PRs over threshold
- [x] `gate:full` label created (color: red `d73a4a`)

## Definition of done

`npm run verify` green; the decision function is unit-tested across all five branches; the `gate:full` label exists in the repo; docs reflect the wired behavior.

## Non-goals

- No `.devloops` schema change — reuses the existing `localImplementation.lightMode` keys.
- No changes to gate angle sets, dynamic-angle resolution, or fan-in consolidation.
- No change to the draft→ready boundary itself (`requireDraftFirst` still enforced) — only *how* the gate runs (inline vs fan-out).
- No change to the shipped consumer defaults in `extension-defaults.yaml` or `BUILT_IN_DEFAULTS`; the 20/2 threshold is this repo's opt-in.
- No change to `pre_approval_gate` angle configuration beyond the inline-vs-fanout dispatch decision.

## Validation

`npm run verify` (all sub-suites green). Dogfooded: `node scripts/loop/resolve-gate-dispatch.mjs --gate draft --base main --head issue-1043` correctly reports this over-threshold PR as `full_fanout`.

Closes #1043
