### PR TITLE
refactor: small shrinks — ponytail audit batch 3

### DIFF
--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -17,6 +17,32 @@ import { createPiAdapter } from "@dev-loops/core/harness";
 
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 
+// `project` is an alias for `queue` minus the run driver — derived, not duplicated.
+const QUEUE_ROUTES = {
+  run:            "scripts/loop/run-queue.mjs",
+  list:    "scripts/projects/list-queue-items.mjs",
+  add:     "scripts/projects/add-queue-item.mjs",
+  move:    "scripts/projects/move-queue-item.mjs",
+  reorder: "scripts/projects/reorder-queue-item.mjs",
+  "archive-done": "scripts/projects/archive-done-items.mjs",
+  "sync-status": "scripts/projects/sync-item-status.mjs",
+  ensure:  "scripts/projects/ensure-queue-board.mjs",
+  "resolve-active": "scripts/projects/resolve-active-board-item.mjs",
+};
+const { run: _queueRunRoute, ...PROJECT_ROUTES } = QUEUE_ROUTES;
+
+const QUEUE_DESCRIPTIONS = {
+  run: "Run queue driver",
+  list: "List queue board items",
+  add: "Add issue/PR to queue board",
+  move: "Move queue item between Status columns",
+  reorder: "Reorder items (move-to-top/move-after/order, --dry-run)",
+  "archive-done": "Archive closed Done items older than a duration",
+  "sync-status": "Sync a queued issue/PR's board Status column (best-effort)",
+  ensure: "Create/repair queue board bootstrap surface",
+};
+const { run: _queueRunDescription, ...PROJECT_DESCRIPTIONS } = QUEUE_DESCRIPTIONS;
+
 const SUBCOMMAND_ROUTES = {
   gate: {
     "upsert-verdict":     "scripts/github/upsert-checkpoint-verdict.mjs",
@@ -50,27 +76,8 @@ const SUBCOMMAND_ROUTES = {
     "ready-for-review": "scripts/github/ready-for-review.mjs",
     "reconcile-draft":  "scripts/github/reconcile-draft-gate.mjs",
   },
-  project: {
-    list:    "scripts/projects/list-queue-items.mjs",
-    add:     "scripts/projects/add-queue-item.mjs",
-    move:    "scripts/projects/move-queue-item.mjs",
-    reorder: "scripts/projects/reorder-queue-item.mjs",
-    "archive-done": "scripts/projects/archive-done-items.mjs",
-    "sync-status": "scripts/projects/sync-item-status.mjs",
-    ensure:  "scripts/projects/ensure-queue-board.mjs",
-    "resolve-active": "scripts/projects/resolve-active-board-item.mjs",
-  },
-  queue: {
-    run:            "scripts/loop/run-queue.mjs",
-    list:    "scripts/projects/list-queue-items.mjs",
-    add:     "scripts/projects/add-queue-item.mjs",
-    move:    "scripts/projects/move-queue-item.mjs",
-    reorder: "scripts/projects/reorder-queue-item.mjs",
-    "archive-done": "scripts/projects/archive-done-items.mjs",
-    "sync-status": "scripts/projects/sync-item-status.mjs",
-    ensure:  "scripts/projects/ensure-queue-board.mjs",
-    "resolve-active": "scripts/projects/resolve-active-board-item.mjs",
-  },
+  queue: QUEUE_ROUTES,
+  project: PROJECT_ROUTES,
   inspect: {
     run:    "scripts/loop/inspect-run.mjs",
     viewer: "scripts/loop/inspect-run-viewer.mjs",
@@ -143,25 +150,8 @@ const SUBCOMMAND_DESCRIPTIONS = {
     "ready-for-review": "Mark PR ready for review",
     "reconcile-draft": "Reconcile non-draft PR",
   },
-  project: {
-    list: "List queue board items",
-    add: "Add issue/PR to queue board",
-    move: "Move queue item between Status columns",
-    reorder: "Reorder items (move-to-top/move-after/order, --dry-run)",
-    "archive-done": "Archive closed Done items older than a duration",
-    "sync-status": "Sync a queued issue/PR's board Status column (best-effort)",
-    ensure: "Create/repair queue board bootstrap surface",
-  },
-  queue: {
-    run: "Run queue driver",
-    list: "List queue board items",
-    add: "Add issue/PR to queue board",
-    move: "Move queue item between Status columns",
-    reorder: "Reorder items (move-to-top/move-after/order, --dry-run)",
-    "archive-done": "Archive closed Done items older than a duration",
-    "sync-status": "Sync a queued issue/PR's board Status column (best-effort)",
-    ensure: "Create/repair queue board bootstrap surface",
-  },
+  queue: QUEUE_DESCRIPTIONS,
+  project: PROJECT_DESCRIPTIONS,
   inspect: {
     run: "Inspect run state",
     viewer: "Start inspection viewer",

--- a/extension/checks.ts
+++ b/extension/checks.ts
@@ -1,4 +1,4 @@
-import { collectDevLoopChecks as collectSharedDevLoopChecks, DEV_LOOP_CHECK_IDS } from '../lib/dev-loops-core.mjs';
+import { DEV_LOOP_CHECK_IDS } from '../lib/dev-loops-core.mjs';
 import { createInspectRunViewerLifecycleManager } from '../scripts/loop/inspect-run-viewer/managed-instance.mjs';
 import type { ExtensionHarnessAdapter } from './harness-types.ts';
 
@@ -76,8 +76,4 @@ export function createExtensionCoreRuntime(
       };
     },
   };
-}
-
-export async function collectDevLoopChecks(adapter: ExtensionHarnessAdapter): Promise<DevLoopCheck[]> {
-  return collectSharedDevLoopChecks(createExtensionCoreRuntime(adapter));
 }

--- a/extension/presentation.ts
+++ b/extension/presentation.ts
@@ -19,7 +19,7 @@ function checkMap(checks: DevLoopCheck[]): Map<DevLoopCheckId, DevLoopCheck> {
   return new Map(checks.map((check) => [check.id, check]));
 }
 
-export function orderedSetupSteps(checks: DevLoopCheck[]): string[] {
+function orderedSetupSteps(checks: DevLoopCheck[]): string[] {
   const byId = checkMap(checks);
   const uniqueSteps = [...new Set(DEV_LOOP_CHECK_IDS.filter((id) => byId.get(id)?.ok === false).map((id) => SETUP_GUIDANCE[id]))];
   const steps = uniqueSteps.map((step, index) => `${index + 1}. ${step}`);

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -4,7 +4,7 @@ import { access, open, readFile, readdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { requireTokenValue } from "../_cli-primitives.mjs";
-import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, isDirectCliRun, parseJsonText, readJsonIfExists } from "../_core-helpers.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { autoDetectSnapshot } from "./detect-copilot-loop-state.mjs";
 import {
@@ -306,17 +306,6 @@ async function readFirstLineIfExists(filePath, chunkSize = 4096) {
     await handle?.close().catch(() => {});
   }
 }
-async function readJsonIfExists(filePath) {
-  const text = await readTextIfExists(filePath);
-  if (text === null) {
-    return null;
-  }
-  try {
-    return parseJsonText(text);
-  } catch {
-    return null;
-  }
-}
 function normalizeRunState(value) {
   const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
   switch (normalized) {
@@ -455,7 +444,7 @@ async function scanSessionArtifactRoot(artifactsDir, records) {
     const record = records.get(key) ?? createRunRecord(runId, childIndex);
     const filePath = path.join(artifactsDir, entry.name);
     if (entry.name.endsWith("_meta.json")) {
-      const meta = await readJsonIfExists(filePath);
+      const meta = await readJsonIfExists(filePath).catch(() => null);
       if (meta && typeof meta === "object") {
         records.set(key, mergeRunRecord(record, {
           agent: typeof meta.agent === "string" ? meta.agent : (record.agent ?? agent),
@@ -540,7 +529,7 @@ async function scanAsyncRunRoot(asyncRoot, records) {
     const asyncDir = path.join(asyncRoot, runDirEntry.name);
     const statusPath = path.join(asyncDir, "status.json");
     const eventsPath = path.join(asyncDir, "events.jsonl");
-    const status = await readJsonIfExists(statusPath);
+    const status = await readJsonIfExists(statusPath).catch(() => null);
     if (!status || typeof status !== "object") {
       continue;
     }
@@ -632,7 +621,7 @@ async function scanAsyncResultRoot(resultsRoot, records) {
     }
     const filePath = path.join(resultsRoot, entry.name);
     if (entry.name.endsWith(".json")) {
-      const result = await readJsonIfExists(filePath);
+      const result = await readJsonIfExists(filePath).catch(() => null);
       if (!result || typeof result !== "object") {
         continue;
       }

--- a/test/_helpers.mjs
+++ b/test/_helpers.mjs
@@ -46,7 +46,6 @@ function buildGhStubScript() {
     'const ghLogPath = process.env.GH_LOG_PATH;',
     'const mode = process.env.GH_STUB_MODE || "sequential";',
     'const repeatLast = process.env.GH_REPEAT_LAST_ON_OVERFLOW === "1";',
-    'const overflowMessageMode = process.env.GH_OVERFLOW_MESSAGE_MODE || "numbered";',
     'const defaultStdout = process.env.GH_DEFAULT_STDOUT ?? "{}\\n";',
     'const entries = JSON.parse(readFileSync(sequencePath, "utf8"));',
     'const actual = process.argv.slice(2);',
@@ -71,8 +70,7 @@ function buildGhStubScript() {
     '} else {',
     '  const current = Number(readFileSync(counterPath, "utf8").trim() || "0");',
     '  if (current >= entries.length && !repeatLast) {',
-    '    const message = overflowMessageMode === "generic" ? "unexpected gh call beyond scripted sequence" : `unexpected extra gh call #${current + 1}: ${actual.join(" ")}`;',
-    '    fail(97, message);',
+    '    fail(97, `unexpected extra gh call #${current + 1}: ${actual.join(" ")}`);',
     '  }',
     '  const index = entries.length === 0 ? -1 : Math.min(current, entries.length - 1);',
     '  entry = index >= 0 ? (entries[index] ?? { stdout: defaultStdout }) : { stdout: defaultStdout };',
@@ -96,13 +94,6 @@ function buildGhStubScript() {
     '    for (const expected of entry.assertStdinIncludes) {',
     '      if (!stdin.includes(expected)) {',
     '        fail(96, `missing expected stdin text: ${expected}`);',
-    '      }',
-    '    }',
-    '  }',
-    '  if (entry.assertStdinExcludes) {',
-    '    for (const forbidden of entry.assertStdinExcludes) {',
-    '      if (stdin.includes(forbidden)) {',
-    '        fail(95, `unexpected stdin text: ${forbidden}`);',
     '      }',
     '    }',
     '  }',
@@ -134,7 +125,6 @@ export async function writeGhStub(tempDir, entries = [], {
   repeatLastOnOverflow = false,
   defaultStdout = "{}\n",
   logCalls = false,
-  overflowMessageMode = "numbered",
 } = {}) {
   const sequencePath = path.join(tempDir, `${commandName}-sequence.json`);
   const ghPath = path.join(tempDir, commandName);
@@ -162,7 +152,6 @@ export async function writeGhStub(tempDir, entries = [], {
     GH_STUB_MODE: matchMode,
     GH_REPEAT_LAST_ON_OVERFLOW: repeatLastOnOverflow ? "1" : "0",
     GH_DEFAULT_STDOUT: defaultStdout,
-    GH_OVERFLOW_MESSAGE_MODE: overflowMessageMode,
   };
 
   if (counterPath) {

--- a/test/dev-loops-cli.test.mjs
+++ b/test/dev-loops-cli.test.mjs
@@ -183,6 +183,32 @@ test("queue category help lists run plus management subcommands (issue #912)", a
   assert.equal(stderr.read(), "");
 });
 
+test("project routes are exactly queue routes minus run (issue #1090)", async () => {
+  const readSubcommands = async (category) => {
+    const stdout = createBufferStream();
+    const stderr = createBufferStream();
+    const exitCode = await runCli({
+      argv: [category, "--help"],
+      runtime: createRuntime(),
+      stdout: stdout.stream,
+      stderr: stderr.stream,
+    });
+    assert.equal(exitCode, 0);
+    assert.equal(stderr.read(), "");
+    return stdout.read()
+      .split("\n")
+      .map((line) => line.match(/^ {4}(\S+)/)?.[1])
+      .filter(Boolean);
+  };
+
+  const queueSubs = await readSubcommands("queue");
+  const projectSubs = await readSubcommands("project");
+
+  assert.ok(queueSubs.includes("run"), "queue must expose run");
+  assert.ok(!projectSubs.includes("run"), "project help must omit run");
+  assert.deepEqual(projectSubs, queueSubs.filter((sub) => sub !== "run"));
+});
+
 test("queue add/list route to the same project scripts via --help usage (issue #912)", () => {
   const add = spawnSync("node", ["./cli/index.mjs", "queue", "add", "--help"], {
     cwd: repoRoot,

--- a/test/extension-checks.test.mjs
+++ b/test/extension-checks.test.mjs
@@ -1,9 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { collectDevLoopChecks } from "../extension/checks.ts";
+import { createExtensionCoreRuntime } from "../extension/checks.ts";
 import { createPiExtensionAdapter } from "../extension/pi-extension-adapter.ts";
-import { renderCheckLines, summarizeChecks } from "../lib/dev-loops-core.mjs";
+import { collectDevLoopChecks as collectCoreChecks, renderCheckLines, summarizeChecks } from "../lib/dev-loops-core.mjs";
+
+// Production reaches the shared collector via createExtensionCoreRuntime (executeDevLoopsCommand);
+// exercise the same path here instead of a test-only wrapper.
+const collectDevLoopChecks = (adapter) => collectCoreChecks(createExtensionCoreRuntime(adapter));
 
 function createFakePi({ commandResults = new Map(), tools = [], commands = [] } = {}) {
   return {

--- a/test/github/stage-reviewer-draft.test.mjs
+++ b/test/github/stage-reviewer-draft.test.mjs
@@ -37,15 +37,25 @@ test("stage-reviewer-draft posts a deterministic pending review and writes local
     const gh = await writeGhStub(tempDir, [
       {
         assertArgs: ["api", "-X", "POST", "repos/owner/repo/pulls/17/reviews", "--input", "-"],
+        // Exact full-payload match: subsumes the old field-by-field includes and the
+        // '"event"' exclusion (a pending review must not carry an event field).
         assertStdinIncludes: [
-          '"commit_id":"abc123"',
-          '"path":"src/app.ts"',
-          '"line":10',
-          '"body":"Handle null"',
-          'Reviewer-loop draft verdict: REQUEST_CHANGES',
-          'Summary findings:\\n- [low] Consider the stale draft-review cleanup path',
+          JSON.stringify({
+            commit_id: "abc123",
+            body: [
+              "Reviewer-loop draft verdict: REQUEST_CHANGES",
+              "Total findings: 2",
+              "Review runs merged: 2",
+              "",
+              "Summary findings:",
+              "- [low] Consider the stale draft-review cleanup path",
+              "",
+            ].join("\n"),
+            comments: [
+              { path: "src/app.ts", line: 10, body: "Handle null", side: "RIGHT" },
+            ],
+          }),
         ],
-        assertStdinExcludes: ['"event"'],
         stdout: '{"id":444,"html_url":"https://github.com/owner/repo/pull/17#pullrequestreview-444","state":"PENDING","commit_id":"abc123"}\n',
       },
     ]);

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -349,6 +349,49 @@ test("conductor-monitor --auto-resume ignores invalid async JSON side artifacts 
   }
 });
 
+test("conductor-monitor --auto-resume ignores malformed session artifact meta JSON instead of crashing the scan", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-invalid-meta-json-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const badArtifactsDir = path.join(sessionsRoot, "2026-06-03T00-00-00-000Z_session", "subagent-artifacts");
+    await mkdir(badArtifactsDir, { recursive: true });
+    await writeFile(path.join(badArtifactsDir, "run-bad-meta-99_dev-loop_0_meta.json"), "{not valid json\n", "utf8");
+    await writeFile(path.join(badArtifactsDir, "run-bad-meta-99_dev-loop_0_output.md"), "Active PR: owner/repo#99\n", "utf8");
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{ number: 44, requestCopilot: true }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.queueStatus, "monitoring");
+    assert.equal(payload.resumePlanCount, 0);
+    assert.equal(payload.manualAttentionCount, 0);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume ignores malformed async result JSON instead of crashing the scan", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-invalid-result-json-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    await writeFile(path.join(asyncResultsRoot, "run-bad-result-45.json"), "{not valid json\n", "utf8");
+
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{ number: 45, requestCopilot: true }],
+    }));
+
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    assert.equal(payload.queueStatus, "monitoring");
+    assert.equal(payload.resumePlanCount, 0);
+    assert.equal(payload.manualAttentionCount, 0);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("conductor-monitor flags unresolved-feedback PRs as needing attention while preserving pending waits", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-attention-"));
   const mixedThreadsFixture = await readFile(mixedThreadsFixturePath, "utf8");

--- a/test/loop/detect-reviewer-loop-state.test.mjs
+++ b/test/loop/detect-reviewer-loop-state.test.mjs
@@ -12,7 +12,7 @@ const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, opt
 
 const writeJson = writeJsonHelper;
 
-const writeGhStub = (tempDir, entries) => writeGhStubHelper(tempDir, entries, { overflowMessageMode: "generic" });
+const writeGhStub = (tempDir, entries) => writeGhStubHelper(tempDir, entries);
 
 test("detect-reviewer-loop-state --input returns correct states for planning/running/merge snapshots", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reviewer-state-detect-"));
@@ -378,10 +378,10 @@ test("detect-reviewer-loop-state auto-detect fails when gh stub call budget is e
 
     assert.equal(result.code, 1);
     assert.equal(result.stdout, "");
-    assert.deepEqual(JSON.parse(result.stderr), {
-      ok: false,
-      error: "gh command failed: unexpected gh call beyond scripted sequence",
-    });
+    const parsed = JSON.parse(result.stderr);
+    assert.equal(parsed.ok, false);
+    // The stub reports the overflowing call's index and args; only the budget-exceeded prefix is stable.
+    assert.match(parsed.error, /^gh command failed: unexpected extra gh call #2: /);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #1090

## Summary

Ponytail audit batch 3: five small same-logic-fewer-lines shrinks plus draft-gate remediation tests. 10 files, +134/−87, no behavior change.

## Scope and context

Exactly the five items from #1090. The playwright-config consolidation shipped separately in #1078; parseArgs migration stays in #857.

## File-by-file changes

- `cli/index.mjs` — `PROJECT_ROUTES`/`PROJECT_DESCRIPTIONS` now derived from hoisted `QUEUE_ROUTES`/`QUEUE_DESCRIPTIONS` (rest-destructure out `run`) instead of verbatim duplication
- `scripts/loop/conductor-monitor.mjs` — local `readJsonIfExists` deleted; imports the shared one from `scripts/_core-helpers.mjs` (with `.catch(() => null)` at the three call sites to keep malformed-JSON behavior identical)
- `test/_helpers.mjs` — speculative gh-stub `overflowMessageMode` + `assertStdinExcludes` removed
- `test/loop/detect-reviewer-loop-state.test.mjs`, `test/github/stage-reviewer-draft.test.mjs` — single callers inlined with equal-or-stronger assertions
- `extension/checks.ts` — test-only `collectDevLoopChecks` wrapper deleted
- `test/extension-checks.test.mjs` — repointed at the lib function via `createExtensionCoreRuntime` (production's path); assertions unchanged
- `extension/presentation.ts` — unused `export` dropped from `orderedSetupSteps`
- `test/loop/conductor-monitor.test.mjs` — two malformed-JSON tests covering the remaining `readJsonIfExists` parse-guard call sites (draft-gate finding)
- `test/dev-loops-cli.test.mjs` — contract test pinning project subcommands = queue minus `run` (draft-gate finding)

## Acceptance criteria

- [x] Each of the five shrinks applied exactly as listed in #1090
- [x] No behavior change (existing tests pass unmodified except where a deleted test-only surface forced the inlining)
- [x] `npm run verify` green

## AC / DoD matrix

| Acceptance criterion | Definition of done item(s) | Status | Non-goal boundary |
|---|---|---|---|
| five shrinks applied exactly as listed in #1090 | parse-guard call sites + project=queue−run contract test-covered | ✓ met | playwright configs (#1078), parseArgs (#857) |
| no behavior change (tests pass unmodified except deleted test-only surface) | help output byte-identical; route derivation excludes exactly `run` | ✓ met | broader cli/index.mjs restructuring |
| `npm run verify` green | gates pass with fan-out evidence, merge via queue | verify ✓; gates in progress | batches #1088/#1089 |

## Definition of done

- [x] Draft gate passed with fan-out evidence (clean verdict on 0977df88)

Pre-approval gate and merge via the queue pipeline follow on gate-clean (tracked by the gate comments, not checkboxes).

## Non-goals

Playwright configs (#1078), parseArgs migration (#857), batches #1088/#1089, broader cli/index.mjs restructuring.

## Validation

```
npm run verify   # green: main 2009/2009, core 1817/1817, docs + dev-loop clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019R41gz5zfhq4dwGATzQx4m
