### PR TITLE
docs(contract): add follow-up-capture rule to sub-issue-tree-contract (#1101)

### DIFF
--- a/.claude/skills/docs/artifact-authority-contract.md
+++ b/.claude/skills/docs/artifact-authority-contract.md
@@ -25,6 +25,7 @@ Key contract:
 - GitHub issue state is authoritative — not local notes or chat context
 - A linked PR is the single canonical follow-up artifact for the issue
 - When an open linked PR exists, reuse it rather than opening another
+- Follow-ups discovered while working a PR/loop are noted on the originating issue or PR body by default; a standalone issue is filed only when the follow-up is genuinely independent of the PR and outlives it (see [Sub-Issue Tree Contract](../../docs/sub-issue-tree-contract.md))
 - Implementation may proceed through either the GitHub-first routed path or the local implementation strategy (see [Public Dev Loop Contract](public-dev-loop-contract.md) `targetPreference`)
 
 ### Local-planning

--- a/.claude/skills/docs/issue-intake-procedure.md
+++ b/.claude/skills/docs/issue-intake-procedure.md
@@ -111,6 +111,7 @@ Preflight verdicts:
 - do not rely only on PR title/body containing a literal issue number
 - treat an open linked PR as the active implementation for this issue
 - once an open linked PR exists, that PR is the only canonical follow-up artifact for the issue; attach follow-up work to it and do not open another PR unless the prior PR was explicitly superseded and reconciled first
+- **follow-up-capture rule:** when a follow-up is discovered while working a PR/loop, note it on the originating issue (or the PR body); file a standalone issue only if the follow-up is genuinely independent of the PR **and** outlives it (a real separate bug/feature that would be lost as a note on a soon-closed issue). Prefer noting PR-scoped follow-ups on the originating artifact over spinning up standalone tracker items for work that is part of the same effort or will be resolved imminently. See [Sub-Issue Tree Contract](../../docs/sub-issue-tree-contract.md).
 - if a PR already exists, classify bootstrap-wait versus follow-up:
   `node <resolved-skill-scripts>/loop/detect-initial-copilot-pr-state.mjs --repo <resolved-repo> --issue <number>`
 - `waiting_for_initial_copilot_implementation`: keep waiting; in durable-auto mode use:

--- a/docs/sub-issue-tree-contract.md
+++ b/docs/sub-issue-tree-contract.md
@@ -21,10 +21,16 @@ listing, attaching, ordering, and verifying the tree.
 | One issue blocks another but is not a structural child | Plain "blocked by #N" in body |
 | A PR implements an issue | PR body / `Closes #N` syntax (not sub-issue) |
 | Background investigation or spike precedes a slice | Plain related reference; promote to sub-issue if it becomes a required step |
+| A follow-up is discovered while working a PR/loop | Note it on the originating issue (or the PR body); file a standalone issue only if the follow-up is genuinely independent of the PR **and** outlives it (a real separate bug/feature that would be lost as a note on a soon-closed issue) |
 
 **Rule of thumb:** use the sub-issue tree when the parent issue's progress is structurally
 defined by completing its children in some intended order. Use plain references for everything
 else.
+
+**Conservatism clause:** prefer noting PR-scoped follow-ups on the originating artifact
+(issue body or PR body) rather than spinning up standalone tracker items for work that is part
+of the same effort or will be resolved imminently. Cross-cutting contract/policy changes and
+genuinely independent bugs that outlive the PR remain their own issues.
 
 ## Default decomposition flow
 

--- a/skills/docs/artifact-authority-contract.md
+++ b/skills/docs/artifact-authority-contract.md
@@ -25,6 +25,7 @@ Key contract:
 - GitHub issue state is authoritative — not local notes or chat context
 - A linked PR is the single canonical follow-up artifact for the issue
 - When an open linked PR exists, reuse it rather than opening another
+- Follow-ups discovered while working a PR/loop are noted on the originating issue or PR body by default; a standalone issue is filed only when the follow-up is genuinely independent of the PR and outlives it (see [Sub-Issue Tree Contract](../../docs/sub-issue-tree-contract.md))
 - Implementation may proceed through either the GitHub-first routed path or the local implementation strategy (see [Public Dev Loop Contract](public-dev-loop-contract.md) `targetPreference`)
 
 ### Local-planning

--- a/skills/docs/issue-intake-procedure.md
+++ b/skills/docs/issue-intake-procedure.md
@@ -111,6 +111,7 @@ Preflight verdicts:
 - do not rely only on PR title/body containing a literal issue number
 - treat an open linked PR as the active implementation for this issue
 - once an open linked PR exists, that PR is the only canonical follow-up artifact for the issue; attach follow-up work to it and do not open another PR unless the prior PR was explicitly superseded and reconciled first
+- **follow-up-capture rule:** when a follow-up is discovered while working a PR/loop, note it on the originating issue (or the PR body); file a standalone issue only if the follow-up is genuinely independent of the PR **and** outlives it (a real separate bug/feature that would be lost as a note on a soon-closed issue). Prefer noting PR-scoped follow-ups on the originating artifact over spinning up standalone tracker items for work that is part of the same effort or will be resolved imminently. See [Sub-Issue Tree Contract](../../docs/sub-issue-tree-contract.md).
 - if a PR already exists, classify bootstrap-wait versus follow-up:
   `node <resolved-skill-scripts>/loop/detect-initial-copilot-pr-state.mjs --repo <resolved-repo> --issue <number>`
 - `waiting_for_initial_copilot_implementation`: keep waiting; in durable-auto mode use:


### PR DESCRIPTION
## Summary

Closes #1101

Add a follow-up-capture rule to the sub-issue-tree-contract: follow-ups discovered while working a PR/loop should be noted on the originating issue (or PR body); a standalone issue is filed only if the follow-up is genuinely independent of the PR **and** outlives it.

## Scope and context

Docs-only contract change. Adds a new row to the sub-issue-tree-contract decision table for the "follow-up discovered while working a PR/loop" situation that was missing. Extends the Rule of thumb with a conservatism clause. Mirrors the intent in the issue-intake-procedure and cross-references from artifact-authority-contract. Regenerates `.claude` mirrors.

## File-by-file changes

- `docs/sub-issue-tree-contract.md`: new table row for "A follow-up is discovered while working a PR/loop" + conservatism clause in the Rule of thumb
- `skills/docs/issue-intake-procedure.md`: follow-up-capture rule bullet in Phase 2 input normalization
- `skills/docs/artifact-authority-contract.md`: cross-reference bullet in the tracker-first key contract section
- `.claude/skills/docs/issue-intake-procedure.md`: regenerated mirror
- `.claude/skills/docs/artifact-authority-contract.md`: regenerated mirror

## Acceptance criteria

- [x] sub-issue-tree-contract table gains the PR-follow-up row + conservatism clause in the rule of thumb
- [x] issue-intake-procedure + artifact-authority cross-reference the default
- [x] .claude mirrors regenerated
- [x] `npm run verify` — no new failures (2 pre-existing failures on base, unrelated to docs change)

## Definition of done

All acceptance criteria satisfied. No new test failures. `.claude` mirrors match source `skills/docs/` files.

## Non-goals

- No changes to sub-issue tooling (`manage-sub-issues.mjs`)
- No changes to epic decomposition flow
- No tooling enforcement — docs/contract only

## Validation command

```sh
npm run verify
```
