### PR TITLE
fix(gate): restore probe-copilot-review --timeout-ms 0 single-check mode (#1087)

### DIFF
--- a/.claude/skills/docs/copilot-loop-operations.md
+++ b/.claude/skills/docs/copilot-loop-operations.md
@@ -188,7 +188,7 @@ Preferred defaults for this repo:
 - parent/subagent no-activity threshold for watcher-style runs: at least **15 minutes**
 - active-long-running notice threshold for watcher-style runs: about **30 minutes**
 
-These are the defaults built into `probe-copilot-review.mjs`, `run-watch-cycle.mjs`, and the `watchArgs` emitted by `copilot-pr-handoff.mjs`. Do not pass removed CLI policy flags (`--poll-interval-ms`, `--timeout-ms`, `--probe-only`) — helpers hard-error when they are provided. Timeouts and intervals are derived from `packages/core/src/loop/policy-constants.mjs`.
+These are the defaults built into `probe-copilot-review.mjs`, `run-watch-cycle.mjs`, and the `watchArgs` emitted by `copilot-pr-handoff.mjs`. Do not pass removed CLI policy flags (`--poll-interval-ms`, `--probe-only`) — helpers hard-error when they are provided. `probe-copilot-review.mjs` does accept `--timeout-ms` (watch budget in ms; `0` = single immediate idle check, no watch); timeouts and intervals are otherwise derived from `packages/core/src/loop/policy-constants.mjs`.
 
 ### Outer-loop checkpoint: canonical re-attachment artifact
 

--- a/.claude/skills/docs/copilot-loop-operations.md
+++ b/.claude/skills/docs/copilot-loop-operations.md
@@ -188,7 +188,7 @@ Preferred defaults for this repo:
 - parent/subagent no-activity threshold for watcher-style runs: at least **15 minutes**
 - active-long-running notice threshold for watcher-style runs: about **30 minutes**
 
-These are the defaults built into `probe-copilot-review.mjs`, `run-watch-cycle.mjs`, and the `watchArgs` emitted by `copilot-pr-handoff.mjs`. Do not pass removed CLI policy flags (`--poll-interval-ms`, `--probe-only`) — helpers hard-error when they are provided. `probe-copilot-review.mjs` does accept `--timeout-ms` (watch budget in ms; `0` = single immediate idle check, no watch); timeouts and intervals are otherwise derived from `packages/core/src/loop/policy-constants.mjs`.
+These are the defaults built into `probe-copilot-review.mjs`, `run-watch-cycle.mjs`, and the `watchArgs` emitted by `copilot-pr-handoff.mjs`. Do not pass removed CLI policy flags (`--poll-interval-ms`, `--probe-only`): the scripts reject them as usage errors, but do not rely on that as a guaranteed hard stop in the `dev-loops gate …` path — the CLI retry-wrapper (`buildCorrectedArgs`) may strip an unrecognized/removed flag and silently retry with defaults, so passing one can quietly fall back to default behavior rather than failing. `probe-copilot-review.mjs` does accept `--timeout-ms` (watch budget in ms; `0` = single immediate idle check, no watch); timeouts and intervals are otherwise derived from `packages/core/src/loop/policy-constants.mjs`.
 
 ### Outer-loop checkpoint: canonical re-attachment artifact
 

--- a/scripts/github/probe-copilot-review.mjs
+++ b/scripts/github/probe-copilot-review.mjs
@@ -22,7 +22,7 @@ Required:
   --repo <owner/name>           Repository slug (e.g. owner/repo)
   --pr <number>                 Pull request number
 Options:
-  --timeout-ms <n>              Total watch budget in ms (default 1800000, i.e. 30 min;
+  --timeout-ms <n>              Total watch budget in ms (default ${COPILOT_REVIEW_WAIT_TIMEOUT_MS}, i.e. ${COPILOT_REVIEW_WAIT_TIMEOUT_MS / 60_000} min;
                                 0 = single immediate check, no wait — returns "idle" if
                                 no fresh activity). For a quick non-watch thread/state
                                 read without entering the watch loop, pass 0 here or use

--- a/scripts/github/probe-copilot-review.mjs
+++ b/scripts/github/probe-copilot-review.mjs
@@ -2,7 +2,7 @@
 import { setTimeout as delay } from "node:timers/promises";
 import { buildParseError, formatCliError, isCopilotLogin, isDirectCliRun, parseJsonText, parseReviewThreads } from "../_core-helpers.mjs";
 import { parseArgs } from "node:util";
-import { parsePositiveInteger, requireTokenValue, runChild } from "../_cli-primitives.mjs";
+import { parsePositiveInteger, parseNonNegativeInteger, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult } from "../lib/jq-output.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import {
@@ -15,13 +15,18 @@ import {
 const WATCH_HEARTBEAT_MS = 45_000; // 45 seconds
 const REMOVED_FLAGS = new Set([
   "--poll-interval-ms",
-  "--timeout-ms",
 ]);
-const USAGE = `Usage: probe-copilot-review.mjs --repo <owner/name> --pr <number>
+const USAGE = `Usage: probe-copilot-review.mjs --repo <owner/name> --pr <number> [--timeout-ms <n>]
 Poll for fresh Copilot review activity on a GitHub pull request.
 Required:
   --repo <owner/name>           Repository slug (e.g. owner/repo)
   --pr <number>                 Pull request number
+Options:
+  --timeout-ms <n>              Total watch budget in ms (default 1800000, i.e. 30 min;
+                                0 = single immediate check, no wait — returns "idle" if
+                                no fresh activity). For a quick non-watch thread/state
+                                read without entering the watch loop, pass 0 here or use
+                                'dev-loops gate capture-threads'.
 Output (stdout, JSON):
   { "ok": true, "status": "changed"|"timeout"|"idle", "repo": "...", "pr": N, "attempts": N,
     "newComments": [...], "newReviews": [...], "newIssueComments": [...] }
@@ -32,10 +37,14 @@ ${JQ_OUTPUT_USAGE}
 Activity statuses:
   changed    Fresh Copilot review activity found (check newComments/newReviews/newIssueComments)
   timeout    Watch period elapsed with no fresh Copilot activity
-  idle       Zero-timeout single check found no change
+  idle       Zero-timeout (--timeout-ms 0) single check found no change
 Diagnostic output (stderr):
-  Progress/heartbeat (during watch):
+  Progress/heartbeat (during watch, --timeout-ms > 0):
     { "ok": true, "type": "watch_heartbeat", "elapsedMs": N, "totalBudgetMs": N, "poll": N, "maxPolls": N }
+  Heartbeat contract: watch-shaped runs (--timeout-ms > 0) emit watch_heartbeat lines to
+    stderr roughly every 45s as a liveness signal. Agents MUST NOT suppress stderr
+    (e.g. 2>/dev/null) on watch-shaped invocations — suppressing heartbeats makes a
+    legitimate watch look like a stall. Use --timeout-ms 0 for a non-watch single check.
   Argument/usage errors:
     { "ok": false, "error": "...", "usage": "..." }
   gh/runtime failures:
@@ -100,6 +109,7 @@ export function parseWatchCliArgs(argv) {
       help: { type: "boolean", short: "h" },
       repo: { type: "string" },
       pr: { type: "string" },
+      "timeout-ms": { type: "string" },
       concise: { type: "boolean" },
       summary: { type: "boolean" },
       ...JQ_OUTPUT_PARSE_OPTIONS,
@@ -138,6 +148,10 @@ export function parseWatchCliArgs(argv) {
     }
     if (token.name === "pr") {
       options.pr = parsePositiveInteger(requireTokenValue(token, parseError), "--pr", parseError);
+      continue;
+    }
+    if (token.name === "timeout-ms") {
+      options.timeoutMs = parseNonNegativeInteger(requireTokenValue(token, parseError), "--timeout-ms", parseError);
       continue;
     }
     if (token.name === "concise" || token.name === "summary") {

--- a/skills/docs/copilot-loop-operations.md
+++ b/skills/docs/copilot-loop-operations.md
@@ -188,7 +188,7 @@ Preferred defaults for this repo:
 - parent/subagent no-activity threshold for watcher-style runs: at least **15 minutes**
 - active-long-running notice threshold for watcher-style runs: about **30 minutes**
 
-These are the defaults built into `probe-copilot-review.mjs`, `run-watch-cycle.mjs`, and the `watchArgs` emitted by `copilot-pr-handoff.mjs`. Do not pass removed CLI policy flags (`--poll-interval-ms`, `--timeout-ms`, `--probe-only`) — helpers hard-error when they are provided. Timeouts and intervals are derived from `packages/core/src/loop/policy-constants.mjs`.
+These are the defaults built into `probe-copilot-review.mjs`, `run-watch-cycle.mjs`, and the `watchArgs` emitted by `copilot-pr-handoff.mjs`. Do not pass removed CLI policy flags (`--poll-interval-ms`, `--probe-only`) — helpers hard-error when they are provided. `probe-copilot-review.mjs` does accept `--timeout-ms` (watch budget in ms; `0` = single immediate idle check, no watch); timeouts and intervals are otherwise derived from `packages/core/src/loop/policy-constants.mjs`.
 
 ### Outer-loop checkpoint: canonical re-attachment artifact
 

--- a/skills/docs/copilot-loop-operations.md
+++ b/skills/docs/copilot-loop-operations.md
@@ -188,7 +188,7 @@ Preferred defaults for this repo:
 - parent/subagent no-activity threshold for watcher-style runs: at least **15 minutes**
 - active-long-running notice threshold for watcher-style runs: about **30 minutes**
 
-These are the defaults built into `probe-copilot-review.mjs`, `run-watch-cycle.mjs`, and the `watchArgs` emitted by `copilot-pr-handoff.mjs`. Do not pass removed CLI policy flags (`--poll-interval-ms`, `--probe-only`) — helpers hard-error when they are provided. `probe-copilot-review.mjs` does accept `--timeout-ms` (watch budget in ms; `0` = single immediate idle check, no watch); timeouts and intervals are otherwise derived from `packages/core/src/loop/policy-constants.mjs`.
+These are the defaults built into `probe-copilot-review.mjs`, `run-watch-cycle.mjs`, and the `watchArgs` emitted by `copilot-pr-handoff.mjs`. Do not pass removed CLI policy flags (`--poll-interval-ms`, `--probe-only`): the scripts reject them as usage errors, but do not rely on that as a guaranteed hard stop in the `dev-loops gate …` path — the CLI retry-wrapper (`buildCorrectedArgs`) may strip an unrecognized/removed flag and silently retry with defaults, so passing one can quietly fall back to default behavior rather than failing. `probe-copilot-review.mjs` does accept `--timeout-ms` (watch budget in ms; `0` = single immediate idle check, no watch); timeouts and intervals are otherwise derived from `packages/core/src/loop/policy-constants.mjs`.
 
 ### Outer-loop checkpoint: canonical re-attachment artifact
 

--- a/test/github/probe-copilot-review.test.mjs
+++ b/test/github/probe-copilot-review.test.mjs
@@ -113,6 +113,19 @@ test("probe-copilot-review returns idle for a zero-timeout no-change check", asy
   }
 });
 
+test("probe-copilot-review --timeout-ms 0 returns idle via the CLI (restored #1087)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-watch-copilot-cli-idle-"));
+  const baseline = createActivityPayload();
+  try {
+    const env = await writeGhStub(tempDir, [{ stdout: JSON.stringify(baseline) + "\n" }]);
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17", "--timeout-ms", "0"], { env });
+    assert.equal(result.code, 0);
+    assert.equal(JSON.parse(result.stdout).status, "idle");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("probe-copilot-review returns timeout after bounded polling with no fresh Copilot activity", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-watch-copilot-timeout-"));
   try {
@@ -256,7 +269,7 @@ test("probe-copilot-review rejects malformed arguments deterministically", async
   assert.match(JSON.parse(missingPr.stderr).error, /requires both --repo/i);
   const invalidTimeout = await runNode(["--repo", "owner/repo", "--pr", "17", "--timeout-ms", "-1"]);
   assert.equal(invalidTimeout.code, 1);
-  assert.match(JSON.parse(invalidTimeout.stderr).error, /--timeout-ms has been removed/);
+  assert.match(JSON.parse(invalidTimeout.stderr).error, /--timeout-ms must be a non-negative integer/);
   const invalidInterval = await runNode(["--repo", "owner/repo", "--pr", "17", "--poll-interval-ms", "0"]);
   assert.equal(invalidInterval.code, 1);
   assert.match(JSON.parse(invalidInterval.stderr).error, /--poll-interval-ms has been removed/);
@@ -270,7 +283,7 @@ test("probe-copilot-review --help prints usage and exits 0", async () => {
   assert(helpLong.stdout.includes("--repo"), `expected --repo in help`);
   assert(helpLong.stdout.includes("--pr"), `expected --pr in help`);
   assert(!helpLong.stdout.includes("--poll-interval-ms"), `expected --poll-interval-ms in help`);
-  assert(!helpLong.stdout.includes("--timeout-ms"), `expected --timeout-ms in help`);
+  assert(helpLong.stdout.includes("--timeout-ms"), `expected --timeout-ms in help`);
 
   const helpShort = await runNode(["-h"]);
   assert.equal(helpShort.code, 0);
@@ -287,6 +300,12 @@ test("probe-copilot-review uses production-safe defaults (1-minute poll, 30-minu
 test("probe-copilot-review trims surrounding whitespace from --repo", () => {
   const options = parseWatchCliArgs(["--repo", " owner/repo ", "--pr", "17"]);
   assert.equal(options.repo, "owner/repo");
+});
+
+test("probe-copilot-review parses --timeout-ms (0 = single check, restored #1087)", () => {
+  assert.equal(parseWatchCliArgs(["--repo", "o/r", "--pr", "1", "--timeout-ms", "0"]).timeoutMs, 0);
+  assert.equal(parseWatchCliArgs(["--repo", "o/r", "--pr", "1", "--timeout-ms", "60000"]).timeoutMs, 60_000);
+  assert.equal(parseWatchCliArgs(["--repo", "o/r", "--pr", "1"]).timeoutMs, 1_800_000);
 });
 
 test("probe-copilot-review parses --concise/--summary, --jq, --silent flags", () => {


### PR DESCRIPTION
## Summary

Fixes #1087.

`probe-copilot-review.mjs` advertised a zero-timeout single-check `idle` mode in its USAGE and `scripts/README.md`, but `--timeout-ms` sat in `REMOVED_FLAGS`, so the mode was unreachable via the CLI. Worse, the `cli/index.mjs` retry-wrapper (`buildCorrectedArgs`) stripped the rejected flag on the usage error and retried with the default 30-min watch — silently entering a long watch that, with stderr suppressed (`2>/dev/null`), hid the heartbeats and looked like a ~25-min stall (run 9f2424b9 on PR #1085).

## Changes

- **Restore `--timeout-ms` as a recognized flag** in `probe-copilot-review.mjs`, mirroring the working sibling `probe-ci-status.mjs`. `--timeout-ms 0` performs a single immediate check returning `idle`; the underlying `watchCopilotReview` already implemented `timeoutMs === 0` (`buildAttemptBudget`, the first-attempt skip, and `status = timeoutMs === 0 ? "idle" : "timeout"`).
- This also fixes the silent strip-to-watch: because `--timeout-ms` is no longer a usage error, `buildCorrectedArgs` no longer strips-and-retries into the 30-min watch.
- **Document the heartbeat/stderr liveness contract** in USAGE: watch-shaped runs (`--timeout-ms > 0`) emit `watch_heartbeat` lines to stderr every ~45s; agents MUST NOT suppress stderr on watch-shaped invocations. Point agents to `--timeout-ms 0` or `dev-loops gate capture-threads` for a quick non-watch read.
- `--poll-interval-ms` stays removed (centralized policy constant) — out of scope for this issue.
- **Doc consistency (draft-gate follow-up):** reword `skills/docs/copilot-loop-operations.md` (and its generated `.claude/` mirror) so `--timeout-ms` is no longer listed among removed flags that hard-error, matching the restored USAGE (`--poll-interval-ms` / `--probe-only` stay listed as removed).

## Acceptance criteria (#1087)

- [x] USAGE no longer advertises a broken `--timeout-ms`; a working single-check mode is restored (`--timeout-ms 0` → `idle`).
- [x] Quick non-watch read documented: `--timeout-ms 0` and `dev-loops gate capture-threads` pointed to in USAGE.
- [x] `gate probe-copilot` CLI path forwards the now-recognized `--timeout-ms` (no silent 30-min watch via strip-retry).
- [x] Heartbeat/stderr contract documented in USAGE (MUST NOT `2>/dev/null` on watch-shaped tools).
- [x] `python3`/`node -e` JSON-parse anti-pattern already reasserted in the dev-loop skill ("Reading tool output" §5); a CI/lint check is noted as a follow-up, not in scope here.

## AC / DoD / non-goals matrix

| Acceptance criterion (#1087) | Definition-of-done evidence | Status |
|---|---|---|
| AC1 — USAGE no longer advertises a broken `--timeout-ms`; a working single-check mode is restored | `--timeout-ms` removed from `REMOVED_FLAGS`; parsed via `parseNonNegativeInteger`; `--timeout-ms 0` runs one immediate check → `idle`. Tests: CLI-idle + parse (0/60000/default) in `probe-copilot-review.test.mjs` (19/19). | Done |
| AC2 — quick non-watch read documented | USAGE + `copilot-loop-operations.md` point agents to `--timeout-ms 0` and `dev-loops gate capture-threads` for a fast non-watch read. | Done |
| AC3 — `gate probe-copilot` forwards recognized flags / clear error for removed | `--timeout-ms` now recognized → no silent strip-and-retry; `--poll-interval-ms`/`--probe-only` stay rejected; negative timeout → `--timeout-ms must be a non-negative integer` (test asserts new message). | Done |
| AC4 — heartbeat/stderr liveness contract documented | USAGE documents watch-shaped runs (`--timeout-ms > 0`) emit `watch_heartbeat` to stderr ~45s; agents MUST NOT `2>/dev/null` watch tools; `copilot-loop-operations.md` reworded to not overstate a hard stop in the CLI path. | Done |
| AC5 (discipline) — `python3`/`node -e` JSON-parse anti-pattern reasserted | Already reasserted in the dev-loop skill "Reading tool output" section; a CI/lint check is an explicit non-goal (tracked as follow-up). | Done (skill); lint = non-goal |

**Non-goals:**
- Removing the pre-existing stale `--poll-interval-ms` line from `scripts/README.md` (genuinely-removed flag, separate doc cleanup — tracked as follow-up).
- Adding a CI/lint check that flags `| python3` / `| node -e` in agent commands (follow-up, not required by #1087).
- Any behavior change to the watch/poll loop itself beyond making `--timeout-ms` reachable.

## Validation

- `node --test test/github/probe-copilot-review.test.mjs` — 19/19 pass (incl. new `--timeout-ms 0` parse + CLI idle tests).
- The two `test/contracts/claude-hooks-settings.test.mjs` failures are pre-existing and environmental (they fail identically on clean `origin/main` 6d073174 with a real `node_modules`; main's CI is green). This PR does not touch hooks/run-id code.

## Relationship

- Discovered during the #1077 / PR #1085 gate drive (0.7 line).
- Related to #1084 Seam 2 (child-agent tooling gaps) — distinct tooling-contract bug.
- Harness-agnostic fix (Pi and Claude Code).


