### PR TITLE
fix(loop): count plain-bullet AC under recognized heading as refinement artifact

### DIFF
--- a/packages/core/src/loop/issue-refinement-artifact.mjs
+++ b/packages/core/src/loop/issue-refinement-artifact.mjs
@@ -11,7 +11,7 @@
  *
  * This module owns:
  * - canonical section-name matching for AC / DoD blocks
- * - bullet-item extraction (both `- [ ]` and `- [x]`)
+ * - bullet-item extraction (checklist `- [ ]`/`- [x]` and top-level `- ` bullets)
  * - linked-refinement-doc detection from issue body
  *
  * It deliberately does NOT:
@@ -97,10 +97,16 @@ function findSectionByPatterns(sections, patterns) {
 }
 
 /**
- * Extract checklist bullet items (`- [ ]` and `- [x]`) from a section body.
- * Returns the trimmed item text for each matching line. The checkbox state
- * (checked vs unchecked) is intentionally not preserved: callers only need
- * the item text to satisfy the refinement-artifact contract.
+ * Extract bullet items from a section body. Counts both `- [ ]`/`- [x]`
+ * checklist items and top-level plain `- ` bullets (dash at column 0, so
+ * nested/indented sub-bullets are not counted). Returns the trimmed item
+ * text for each matching line. The checkbox state (checked vs unchecked) is
+ * intentionally not preserved: callers only need the item text to satisfy
+ * the refinement-artifact contract.
+ *
+ * This is only ever called on the body of an already-recognized AC/DoD
+ * section (see `detectIssueRefinementArtifact`), so counting plain bullets
+ * is scoped to those sections and never affects prose sections.
  */
 export function extractChecklistItems(sectionBody) {
   if (typeof sectionBody !== "string" || sectionBody.length === 0) {
@@ -111,9 +117,19 @@ export function extractChecklistItems(sectionBody) {
   const lines = sectionBody.split(/\r?\n/u);
 
   for (const line of lines) {
-    const match = /^\s*-\s+\[(?:[ xX])\]\s+(.+?)\s*$/u.exec(line);
-    if (match) {
-      const text = match[1].trim();
+    const checkboxMatch = /^\s*-\s+\[(?:[ xX])\]\s+(.+?)\s*$/u.exec(line);
+    if (checkboxMatch) {
+      const text = checkboxMatch[1].trim();
+      if (text.length > 0) {
+        items.push(text);
+      }
+      continue;
+    }
+    // Top-level plain bullet: dash at column 0, space required (so `---`
+    // horizontal rules and `-x` do not match; indented sub-bullets do not).
+    const bulletMatch = /^-\s+(.+?)\s*$/u.exec(line);
+    if (bulletMatch) {
+      const text = bulletMatch[1].trim();
       if (text.length > 0) {
         items.push(text);
       }

--- a/packages/core/src/loop/issue-refinement-artifact.mjs
+++ b/packages/core/src/loop/issue-refinement-artifact.mjs
@@ -103,9 +103,8 @@ function findSectionByPatterns(sections, patterns) {
  * (`- [ ]` / `- [x]` with no trailing text) are skipped, not counted, so a
  * section of only unfilled placeholders reports as unrefined. Returns the
  * trimmed item text for each matching line. The checkbox state (checked vs
- * unchecked) is
- * intentionally not preserved: callers only need the item text to satisfy
- * the refinement-artifact contract.
+ * unchecked) is intentionally not preserved: callers only need the item
+ * text to satisfy the refinement-artifact contract.
  *
  * This is only ever called on the body of an already-recognized AC/DoD
  * section (see `detectIssueRefinementArtifact`), so counting plain bullets

--- a/packages/core/src/loop/issue-refinement-artifact.mjs
+++ b/packages/core/src/loop/issue-refinement-artifact.mjs
@@ -99,8 +99,11 @@ function findSectionByPatterns(sections, patterns) {
 /**
  * Extract bullet items from a section body. Counts both `- [ ]`/`- [x]`
  * checklist items and top-level plain `- ` bullets (dash at column 0, so
- * nested/indented sub-bullets are not counted). Returns the trimmed item
- * text for each matching line. The checkbox state (checked vs unchecked) is
+ * nested/indented sub-bullets are not counted). Empty checkbox placeholders
+ * (`- [ ]` / `- [x]` with no trailing text) are skipped, not counted, so a
+ * section of only unfilled placeholders reports as unrefined. Returns the
+ * trimmed item text for each matching line. The checkbox state (checked vs
+ * unchecked) is
  * intentionally not preserved: callers only need the item text to satisfy
  * the refinement-artifact contract.
  *
@@ -117,9 +120,12 @@ export function extractChecklistItems(sectionBody) {
   const lines = sectionBody.split(/\r?\n/u);
 
   for (const line of lines) {
-    const checkboxMatch = /^\s*-\s+\[(?:[ xX])\]\s+(.+?)\s*$/u.exec(line);
+    // Checklist item: `- [ ]` / `- [x]` (leading indentation tolerated).
+    // Consume ANY checkbox-marker line here; push only when it carries text,
+    // so empty placeholders (`- [ ]`) are skipped rather than counted.
+    const checkboxMatch = /^\s*-\s+\[(?:[ xX])\](?:\s+(.+?))?\s*$/u.exec(line);
     if (checkboxMatch) {
-      const text = checkboxMatch[1].trim();
+      const text = (checkboxMatch[1] ?? "").trim();
       if (text.length > 0) {
         items.push(text);
       }

--- a/packages/core/test/issue-refinement-artifact.test.mjs
+++ b/packages/core/test/issue-refinement-artifact.test.mjs
@@ -118,7 +118,7 @@ test("detectIssueRefinementArtifact rejects a Refinement section without explici
   assert.equal(result.finding, "missing_refinement_artifact");
 });
 
-test("detectIssueRefinementArtifact rejects AC section without checkboxes", () => {
+test("detectIssueRefinementArtifact rejects a prose-only AC section (no bullets or checkboxes)", () => {
   // Per #532 review feedback: prose-only AC/DoD sections must not satisfy
   // the refinement artifact; the section must contain at least one checklist
   // item OR a top-level plain `- ` bullet. Plain prose lines (no `- `) still

--- a/packages/core/test/issue-refinement-artifact.test.mjs
+++ b/packages/core/test/issue-refinement-artifact.test.mjs
@@ -131,6 +131,35 @@ test("detectIssueRefinementArtifact rejects AC section without checkboxes", () =
   assert.equal(result.finding, "missing_refinement_artifact");
 });
 
+test("detectIssueRefinementArtifact rejects an AC section of only empty checkbox placeholders", () => {
+  // The canonical not-yet-refined template: `- [ ]` placeholders with no
+  // text must NOT satisfy the gate (#1075 regression guard).
+  const unchecked = detectIssueRefinementArtifact({ body: "## Acceptance criteria\n\n- [ ]\n- [ ]\n" });
+  assert.equal(unchecked.hasACs, false);
+  assert.equal(unchecked.source, REFINEMENT_SOURCE.MISSING);
+  assert.equal(unchecked.finding, "missing_refinement_artifact");
+
+  const checked = detectIssueRefinementArtifact({ body: "## Acceptance criteria\n\n- [x]\n- [x]\n" });
+  assert.equal(checked.hasACs, false);
+  assert.equal(checked.source, REFINEMENT_SOURCE.MISSING);
+  assert.equal(checked.finding, "missing_refinement_artifact");
+});
+
+test("detectIssueRefinementArtifact drops empty checkbox placeholders but keeps filled ones", () => {
+  const result = detectIssueRefinementArtifact({
+    body: "## Acceptance criteria\n\n- [ ] real ac\n- [ ]\n",
+  });
+  assert.equal(result.hasACs, true);
+  assert.equal(result.source, REFINEMENT_SOURCE.ISSUE_BODY_AC);
+  assert.deepEqual(result.acItems, ["real ac"]);
+});
+
+test("detectIssueRefinementArtifact rejects an AC section of only a horizontal rule", () => {
+  const result = detectIssueRefinementArtifact({ body: "## Acceptance criteria\n\n---\n" });
+  assert.equal(result.hasACs, false);
+  assert.equal(result.finding, "missing_refinement_artifact");
+});
+
 test("detectIssueRefinementArtifact returns finding for empty body", () => {
   const result = detectIssueRefinementArtifact({ body: "" });
   assert.equal(result.hasACs, false);

--- a/packages/core/test/issue-refinement-artifact.test.mjs
+++ b/packages/core/test/issue-refinement-artifact.test.mjs
@@ -40,6 +40,50 @@ test("detectIssueRefinementArtifact detects Acceptance criteria with checkboxes"
   assert.deepEqual(result.acItems, ["First AC", "Second AC"]);
 });
 
+test("detectIssueRefinementArtifact detects Acceptance criteria with plain bullets", () => {
+  const result = detectIssueRefinementArtifact({
+    body: "## Problem\n\nX\n\n## Acceptance criteria\n\n- First AC\n- Second AC\n",
+  });
+  assert.equal(result.hasACs, true);
+  assert.equal(result.source, REFINEMENT_SOURCE.ISSUE_BODY_AC);
+  assert.equal(result.finding, null);
+  assert.deepEqual(result.acItems, ["First AC", "Second AC"]);
+});
+
+test("detectIssueRefinementArtifact detects DoD section with plain bullets when AC is absent", () => {
+  const result = detectIssueRefinementArtifact({
+    body: "## Problem\n\nX\n\n## Definition of Done\n\n- Ship it\n- Docs updated\n",
+  });
+  assert.equal(result.hasACs, true);
+  assert.equal(result.source, REFINEMENT_SOURCE.ISSUE_BODY_DOD);
+  assert.deepEqual(result.dodItems, ["Ship it", "Docs updated"]);
+});
+
+test("detectIssueRefinementArtifact rejects an empty recognized AC section", () => {
+  const result = detectIssueRefinementArtifact({ body: "## Acceptance criteria\n\n" });
+  assert.equal(result.hasACs, false);
+  assert.equal(result.source, REFINEMENT_SOURCE.MISSING);
+  assert.equal(result.finding, "missing_refinement_artifact");
+});
+
+test("detectIssueRefinementArtifact ignores plain bullets under an unrecognized heading", () => {
+  const result = detectIssueRefinementArtifact({
+    body: "## Problem\n\n- some bullet\n- another bullet\n",
+  });
+  assert.equal(result.hasACs, false);
+  assert.equal(result.source, REFINEMENT_SOURCE.MISSING);
+  assert.equal(result.finding, "missing_refinement_artifact");
+});
+
+test("detectIssueRefinementArtifact counts only top-level bullets, not indented sub-bullets", () => {
+  const result = detectIssueRefinementArtifact({
+    body: "## Acceptance criteria\n\n- foo\n  - detail of foo\n- bar\n",
+  });
+  assert.equal(result.hasACs, true);
+  assert.equal(result.source, REFINEMENT_SOURCE.ISSUE_BODY_AC);
+  assert.deepEqual(result.acItems, ["foo", "bar"]);
+});
+
 test("detectIssueRefinementArtifact detects DoD section when AC is absent", () => {
   const result = detectIssueRefinementArtifact({
     body: "## Problem\n\nX\n\n## Definition of Done\n\n- [ ] DoD1\n- [x] DoD2\n",
@@ -76,8 +120,9 @@ test("detectIssueRefinementArtifact rejects a Refinement section without explici
 
 test("detectIssueRefinementArtifact rejects AC section without checkboxes", () => {
   // Per #532 review feedback: prose-only AC/DoD sections must not satisfy
-  // the refinement artifact; the section must contain at least one
-  // `- [ ]` / `- [x]` checklist item.
+  // the refinement artifact; the section must contain at least one checklist
+  // item OR a top-level plain `- ` bullet. Plain prose lines (no `- `) still
+  // do not count.
   const result = detectIssueRefinementArtifact({
     body: "## Acceptance criteria\n\nFirst AC without checkbox\nSecond AC also without checkbox\n",
   });


### PR DESCRIPTION
## Summary

Fixes the refinement gate rejecting spec-complete issues whose acceptance criteria are authored as plain markdown bullets (`- foo`) instead of checklist items (`- [ ] foo`).

Root cause: `packages/core/src/loop/issue-refinement-artifact.mjs` → `extractChecklistItems()` only matched `- [ ]`/`- [x]`. A `## Acceptance criteria` section written with plain `-` bullets yielded `acItems: []` → `missing_refinement_artifact` → the coordination detector failed closed with `blocked_needs_user_decision`, forbidding `run_draft_gate` and everything downstream.

This is the issue's **preferred** option: within a recognized AC/DoD section, count top-level plain `- ` bullets as acceptance items while keeping `- [ ]`/`- [x]` fully working. The fix is root-caused in the shared extractor (the only caller passes already-recognized AC/DoD section bodies), so all callers benefit with no per-caller patching.

Closes #1075

## Change

- `extractChecklistItems`: after the existing checklist regex, also match a **top-level** plain bullet (`^-\s+(.+?)\s*$` — dash at column 0, space required). Nested/indented sub-bullets, `---` horizontal rules, and `-x` do not match. Checklist handling is unchanged.
- Because the extractor only runs on recognized AC/DoD section bodies, plain bullets under unrecognized headings (Problem, Non-goals, References) are never counted.

## Acceptance criteria (from #1075)

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Plain-bullet AC under a recognized heading → `acItems` non-empty, passes refinement check, no manual normalization | Done | test: "detects Acceptance criteria with plain bullets" |
| 2 | `- [ ]`/`- [x]` checklist AC continue to work unchanged | Done | pre-existing "with checkboxes" + "DoD section" tests still green |
| 3 | `missing_refinement_artifact` still fires for genuinely empty/absent AC (empty section or no recognized heading) | Done | tests: "rejects an empty recognized AC section", "ignores plain bullets under an unrecognized heading", pre-existing prose-only test |
| 4 | Unit coverage: bullet-AC counted, checklist-AC counted, empty/absent AC still missing, DoD-section parity | Done | 5 new tests incl. DoD plain-bullet parity + top-level-only guard |

## Definition of done

- [ ] `npm run test:core` green (1748/1748)
- [ ] Downstream refinement/gate tests green (`detect-issue-refinement-artifact`, `detect-pr-gate-coordination-umbrella`)
- [ ] Production diff scoped to the shared extractor; no heading-pattern changes

## Non-goals

- Loosening what counts as a *recognized* AC/DoD heading (heading patterns untouched).
- Removing the linked-refinement-doc path (remains valid).
- The auto-normalize alternative (not chosen; no extra `edit-issue` writes).
