### PR TITLE
fix(queue): make board Status transitions deterministic — couple In-Progress to ready-for-review + idempotent `queue reconcile` (#1069)

### DIFF
--- a/.claude/skills/copilot-pr-followup/SKILL.md
+++ b/.claude/skills/copilot-pr-followup/SKILL.md
@@ -310,11 +310,7 @@ The canonical checkpoint verdict comment contract is [Gate Review Comment Contra
 - **CI prerequisite:** resolve the draft gate config first (`resolveGateConfig(config, "draft")`). When `requireCi=true` (default), wait for green current-head CI before entering `draft_gate`. When `requireCi=false`, the draft gate may proceed without green CI. This draft-only override does **not** relax `pre_approval_gate`; final approval and merge readiness still require green current-head CI.
 - **Pass criteria:** all configured draft gate angles pass; all findings at severities in `blockCleanOnFindingSeverities` are addressed; validation passes; no unrelated files are included.
 - **Next step after passing:** mark the PR ready for review.
-- **Board status sync (best-effort, after ready-for-review):** once the PR is created/marked ready for review, sync the linked issue's board item to "In Progress" so the queue board reflects active work without a manual `dev-loops queue sync-status --to-column <col>`:
-  ```sh
-  node <resolved-skill-scripts>/projects/sync-item-status.mjs --repo <owner/name> --item <linked-issue> --to-column "In Progress"
-  ```
-  Best-effort and NON-FATAL: it uses local `gh` auth (no CI/PAT), exits 0 when the board is not configured / the item is not on the board / the API fails, and never blocks marking the PR ready.
+- **Board status sync (built-in, after ready-for-review):** the In-Progress board move is now performed automatically as a deterministic tail of `ready-for-review.mjs` — marking the PR ready couples the board move to the ready transition (#1069), so no separate `sync-item-status` step is needed. It stays best-effort and NON-FATAL: it uses local `gh` auth (no CI/PAT), exits 0 when the board is not configured / the item is not on the board / the API fails, and never blocks marking the PR ready.
 - **Non-substitution rule:** a clean `draft_gate` comment only authorizes the draft → ready-for-review transition for that head SHA. It does **not** satisfy `pre_approval_gate`, final-approval readiness, or merge-ready requirements.
 - **Required PR comment:** post a visible checkpoint verdict comment using the mandatory [Gate comment command](#mandatory-gate-comment-command-contract). Keep validation reporting concise: include command names with pass/fail status. Do **not** paste raw passing test output into the visible gate comment. If you include a failing validation excerpt, keep it focused and truncate it to a deterministic retained-prefix length before posting the comment. See [Gate Review Comment Contract](../../docs/gate-review-comment-contract.md). Do not run `gh pr ready` unless a visible `clean` `draft_gate` checkpoint verdict comment exists for the current head SHA. A checkpoint verdict comment for an older head SHA does not satisfy this requirement for the current head. If findings exist, the PR stays draft and needs fixes before retry. If fixes advance the head SHA while still draft, post a new checkpoint verdict comment for the new head. If the checkpoint verdict comment cannot be posted, fail closed and do not run `gh pr ready`.
 
@@ -398,7 +394,7 @@ node <resolved-skill-scripts>/projects/archive-done-items.mjs --repo <owner/name
 
 Board and threshold resolve from `.devloops` (`queue.projectNumber`/`queue.boardTitle`, `queue.archiveOlderThanDays`, default 7d), using local `gh` auth — no CI, cron, or PAT. This step is best-effort and NON-FATAL: ignore any failure and never let it block the merge or the retrospective.
 
-Alongside the archive step, sync the linked issue's board item to "Done" so the queue board reflects the merge without a manual `dev-loops queue sync-status --to-column <col>`:
+The deterministic mechanism that converges merged→Done is `dev-loops queue reconcile` — idempotent, run best-effort at loop startup — so the merge lands on the "Done" column without a remembered manual step. The manual sync below is now an optional fallback (e.g. to converge immediately without waiting for the next startup reconcile):
 
 ```sh
 node <resolved-skill-scripts>/projects/sync-item-status.mjs --repo <owner/name> --item <linked-issue> --to-column "Done"

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -28,6 +28,7 @@ const QUEUE_ROUTES = {
   "sync-status": "scripts/projects/sync-item-status.mjs",
   ensure:  "scripts/projects/ensure-queue-board.mjs",
   "resolve-active": "scripts/projects/resolve-active-board-item.mjs",
+  reconcile: "scripts/projects/reconcile-queue.mjs",
 };
 const { run: _queueRunRoute, ...PROJECT_ROUTES } = QUEUE_ROUTES;
 
@@ -40,6 +41,7 @@ const QUEUE_DESCRIPTIONS = {
   "archive-done": "Archive closed Done items older than a duration",
   "sync-status": "Sync a queued issue/PR's board Status column (best-effort)",
   ensure: "Create/repair queue board bootstrap surface",
+  reconcile: "Reconcile board Status columns from live GitHub state (idempotent)",
 };
 const { run: _queueRunDescription, ...PROJECT_DESCRIPTIONS } = QUEUE_DESCRIPTIONS;
 

--- a/packages/core/src/loop/queue-board-sync.mjs
+++ b/packages/core/src/loop/queue-board-sync.mjs
@@ -107,6 +107,55 @@ export function boardColumnForLoopState(loopState, mapping = {}) {
   return columnNames[logical] ?? columnNames[DEFAULT_LOGICAL_COLUMN];
 }
 
+/**
+ * Derive the board's target LOGICAL column for a queue item from live GitHub
+ * facts (#1069). Returns LOGICAL_COLUMN.DONE, LOGICAL_COLUMN.IN_PROGRESS, or
+ * null when the item should be left where it is (Backlog/Next Up untouched).
+ *
+ * facts: {
+ *   itemKind: "issue" | "pr",
+ *   issueState: "OPEN" | "CLOSED" | null,   // for issue items
+ *   prState:    "OPEN" | "CLOSED" | "MERGED" | null, // item PR, or the issue's linked PR
+ *   prIsDraft:  boolean | null,
+ * }
+ */
+export function deriveReconcileColumn(facts = {}) {
+  const { itemKind, issueState, prState, prIsDraft } = facts;
+  // Merged PR (item is a PR, or issue's linked PR merged) => Done.
+  if (prState === "MERGED") return LOGICAL_COLUMN.DONE;
+  if (itemKind === "issue" && issueState === "CLOSED") return LOGICAL_COLUMN.DONE;
+  // Open, ready (non-draft) PR => In Progress.
+  if (prState === "OPEN" && prIsDraft === false) return LOGICAL_COLUMN.IN_PROGRESS;
+  // Otherwise leave the item untouched (Backlog / Next Up ordering preserved).
+  return null;
+}
+
+/**
+ * Pure reconcile planner (#1069). Given listed board items, a map of live facts
+ * keyed by the item's issue/PR number, and the resolved column display names,
+ * return the set of moves needed to converge the board and a count of items left
+ * unchanged. Idempotent: when every item already sits in its derived column, the
+ * moves array is empty.
+ *
+ * items: [{ issueNumber, prNumber, status, ... }]  (from list-queue-items)
+ * factsByNumber: Map<number, factsObject>   (facts as consumed by deriveReconcileColumn)
+ * columnNames: { in_progress, done, ... }   (LOGICAL_COLUMN -> display name)
+ */
+export function planReconcile(items = [], factsByNumber = new Map(), columnNames = {}) {
+  const moves = [];
+  let unchanged = 0;
+  for (const item of items) {
+    const number = item.prNumber != null ? item.prNumber : item.issueNumber;
+    const facts = factsByNumber.get(number);
+    const logical = facts ? deriveReconcileColumn(facts) : null;
+    if (logical == null) { unchanged += 1; continue; }
+    const target = columnNames[logical];
+    if (!target || item.status === target) { unchanged += 1; continue; }
+    moves.push({ number, from: item.status ?? null, to: target });
+  }
+  return { moves, unchanged };
+}
+
 // ── Local config loader ─────────────────────────────────────────────────
 
 function readDevloopsSettings(repoRoot) {

--- a/packages/core/src/loop/queue-board-sync.mjs
+++ b/packages/core/src/loop/queue-board-sync.mjs
@@ -132,26 +132,32 @@ export function deriveReconcileColumn(facts = {}) {
 
 /**
  * Pure reconcile planner (#1069). Given listed board items, a map of live facts
- * keyed by the item's issue/PR number, and the resolved column display names,
- * return the set of moves needed to converge the board and a count of items left
- * unchanged. Idempotent: when every item already sits in its derived column, the
- * moves array is empty.
+ * keyed by the item's stable GraphQL node id (`item.itemId`), and the resolved
+ * column display names, return the set of moves needed to converge the board and
+ * a count of items left unchanged. Idempotent: when every item already sits in
+ * its derived column, the moves array is empty.
  *
- * items: [{ issueNumber, prNumber, status, ... }]  (from list-queue-items)
- * factsByNumber: Map<number, factsObject>   (facts as consumed by deriveReconcileColumn)
+ * Keying by the stable `itemId` (not the bare issue/PR number) keeps reconcile
+ * deterministic on a multi-repo GitHub Projects board, where two items can share
+ * a number (repo-A PR #5 vs repo-B issue #5) — number-keying would collide and
+ * make moves order-dependent.
+ *
+ * items: [{ itemId, issueNumber, prNumber, status, ... }]  (from list-queue-items)
+ * factsByItemId: Map<itemId, factsObject>   (facts as consumed by deriveReconcileColumn)
  * columnNames: { in_progress, done, ... }   (LOGICAL_COLUMN -> display name)
  */
-export function planReconcile(items = [], factsByNumber = new Map(), columnNames = {}) {
+export function planReconcile(items = [], factsByItemId = new Map(), columnNames = {}) {
   const moves = [];
   let unchanged = 0;
   for (const item of items) {
-    const number = item.prNumber != null ? item.prNumber : item.issueNumber;
-    const facts = factsByNumber.get(number);
+    const facts = factsByItemId.get(item.itemId);
     const logical = facts ? deriveReconcileColumn(facts) : null;
     if (logical == null) { unchanged += 1; continue; }
     const target = columnNames[logical];
     if (!target || item.status === target) { unchanged += 1; continue; }
-    moves.push({ number, from: item.status ?? null, to: target });
+    // `number` is kept only for reporting; the move is applied by node id.
+    const number = item.prNumber != null ? item.prNumber : item.issueNumber;
+    moves.push({ itemId: item.itemId, number, from: item.status ?? null, to: target });
   }
   return { moves, unchanged };
 }

--- a/packages/core/test/queue-board-sync.test.mjs
+++ b/packages/core/test/queue-board-sync.test.mjs
@@ -555,14 +555,28 @@ test("deriveReconcileColumn: open issue with no linked PR → null (#1057-shape,
   );
 });
 
+test("deriveReconcileColumn: closed-unmerged PR → null (untouched)", () => {
+  assert.equal(
+    deriveReconcileColumn({ itemKind: "pr", issueState: null, prState: "CLOSED", prIsDraft: false }),
+    null,
+  );
+});
+
+test("deriveReconcileColumn: open issue with a MERGED linked PR → Done", () => {
+  assert.equal(
+    deriveReconcileColumn({ itemKind: "issue", issueState: "OPEN", prState: "MERGED", prIsDraft: false }),
+    LOGICAL_COLUMN.DONE,
+  );
+});
+
 test("planReconcile: idempotent — items already in derived column produce no moves", () => {
   const items = [
-    { issueNumber: 1, prNumber: null, status: "In Progress" },
-    { issueNumber: null, prNumber: 2, status: "Done" },
+    { itemId: "I_a", issueNumber: 1, prNumber: null, status: "In Progress" },
+    { itemId: "I_b", issueNumber: null, prNumber: 2, status: "Done" },
   ];
   const facts = new Map([
-    [1, { itemKind: "issue", issueState: "OPEN", prState: "OPEN", prIsDraft: false }],
-    [2, { itemKind: "pr", issueState: null, prState: "MERGED", prIsDraft: false }],
+    ["I_a", { itemKind: "issue", issueState: "OPEN", prState: "OPEN", prIsDraft: false }],
+    ["I_b", { itemKind: "pr", issueState: null, prState: "MERGED", prIsDraft: false }],
   ]);
   const { moves, unchanged } = planReconcile(items, facts, DEFAULT_STATE_COLUMN_NAMES);
   assert.deepEqual(moves, []);
@@ -570,11 +584,30 @@ test("planReconcile: idempotent — items already in derived column produce no m
 });
 
 test("planReconcile: #1057-shaped miss — Backlog issue with a ready linked PR reconciles in one move", () => {
-  const items = [{ issueNumber: 42, prNumber: null, status: "Backlog" }];
+  const items = [{ itemId: "I_42", issueNumber: 42, prNumber: null, status: "Backlog" }];
   const facts = new Map([
-    [42, { itemKind: "issue", issueState: "OPEN", prState: "OPEN", prIsDraft: false }],
+    ["I_42", { itemKind: "issue", issueState: "OPEN", prState: "OPEN", prIsDraft: false }],
   ]);
   const { moves, unchanged } = planReconcile(items, facts, DEFAULT_STATE_COLUMN_NAMES);
   assert.equal(unchanged, 0);
-  assert.deepEqual(moves, [{ number: 42, from: "Backlog", to: "In Progress" }]);
+  assert.deepEqual(moves, [{ itemId: "I_42", number: 42, from: "Backlog", to: "In Progress" }]);
+});
+
+test("planReconcile: multi-repo number collision — two items share a number but keyed by itemId each get their own move (order-independent)", () => {
+  // repo-A PR #5 (merged → Done) and repo-B issue #5 (open, ready linked PR →
+  // In Progress) share the bare number 5. Keying by itemId keeps them distinct.
+  const items = [
+    { itemId: "I_prA", issueNumber: null, prNumber: 5, status: "Backlog" },
+    { itemId: "I_issB", issueNumber: 5, prNumber: null, status: "Backlog" },
+  ];
+  const facts = new Map([
+    ["I_prA", { itemKind: "pr", issueState: null, prState: "MERGED", prIsDraft: false }],
+    ["I_issB", { itemKind: "issue", issueState: "OPEN", prState: "OPEN", prIsDraft: false }],
+  ]);
+  const { moves } = planReconcile(items, facts, DEFAULT_STATE_COLUMN_NAMES);
+  // Each item gets its own correct move regardless of iteration order.
+  const byItemId = new Map(moves.map((m) => [m.itemId, m]));
+  assert.deepEqual(byItemId.get("I_prA"), { itemId: "I_prA", number: 5, from: "Backlog", to: "Done" });
+  assert.deepEqual(byItemId.get("I_issB"), { itemId: "I_issB", number: 5, from: "Backlog", to: "In Progress" });
+  assert.equal(moves.length, 2);
 });

--- a/packages/core/test/queue-board-sync.test.mjs
+++ b/packages/core/test/queue-board-sync.test.mjs
@@ -12,6 +12,8 @@ import {
   loadStateColumnMap,
   LOGICAL_COLUMN,
   DEFAULT_STATE_COLUMN_NAMES,
+  deriveReconcileColumn,
+  planReconcile,
 } from "../src/loop/queue-board-sync.mjs";
 
 async function makeRepo(configYaml) {
@@ -507,4 +509,72 @@ test("syncBoardStatus resolves boardTitle to project number and moves item", asy
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
+});
+
+// ── deriveReconcileColumn / planReconcile (#1069) ─────────────────────────
+
+test("deriveReconcileColumn: ready open non-draft PR → In Progress", () => {
+  assert.equal(
+    deriveReconcileColumn({ itemKind: "pr", issueState: null, prState: "OPEN", prIsDraft: false }),
+    LOGICAL_COLUMN.IN_PROGRESS,
+  );
+});
+
+test("deriveReconcileColumn: merged PR → Done", () => {
+  assert.equal(
+    deriveReconcileColumn({ itemKind: "pr", issueState: null, prState: "MERGED", prIsDraft: false }),
+    LOGICAL_COLUMN.DONE,
+  );
+});
+
+test("deriveReconcileColumn: closed issue → Done", () => {
+  assert.equal(
+    deriveReconcileColumn({ itemKind: "issue", issueState: "CLOSED", prState: null, prIsDraft: null }),
+    LOGICAL_COLUMN.DONE,
+  );
+});
+
+test("deriveReconcileColumn: open issue with open non-draft linked PR → In Progress", () => {
+  assert.equal(
+    deriveReconcileColumn({ itemKind: "issue", issueState: "OPEN", prState: "OPEN", prIsDraft: false }),
+    LOGICAL_COLUMN.IN_PROGRESS,
+  );
+});
+
+test("deriveReconcileColumn: open issue with draft linked PR → null (untouched)", () => {
+  assert.equal(
+    deriveReconcileColumn({ itemKind: "issue", issueState: "OPEN", prState: "OPEN", prIsDraft: true }),
+    null,
+  );
+});
+
+test("deriveReconcileColumn: open issue with no linked PR → null (#1057-shape, untouched)", () => {
+  assert.equal(
+    deriveReconcileColumn({ itemKind: "issue", issueState: "OPEN", prState: null, prIsDraft: null }),
+    null,
+  );
+});
+
+test("planReconcile: idempotent — items already in derived column produce no moves", () => {
+  const items = [
+    { issueNumber: 1, prNumber: null, status: "In Progress" },
+    { issueNumber: null, prNumber: 2, status: "Done" },
+  ];
+  const facts = new Map([
+    [1, { itemKind: "issue", issueState: "OPEN", prState: "OPEN", prIsDraft: false }],
+    [2, { itemKind: "pr", issueState: null, prState: "MERGED", prIsDraft: false }],
+  ]);
+  const { moves, unchanged } = planReconcile(items, facts, DEFAULT_STATE_COLUMN_NAMES);
+  assert.deepEqual(moves, []);
+  assert.equal(unchanged, items.length);
+});
+
+test("planReconcile: #1057-shaped miss — Backlog issue with a ready linked PR reconciles in one move", () => {
+  const items = [{ issueNumber: 42, prNumber: null, status: "Backlog" }];
+  const facts = new Map([
+    [42, { itemKind: "issue", issueState: "OPEN", prState: "OPEN", prIsDraft: false }],
+  ]);
+  const { moves, unchanged } = planReconcile(items, facts, DEFAULT_STATE_COLUMN_NAMES);
+  assert.equal(unchanged, 0);
+  assert.deepEqual(moves, [{ number: 42, from: "Backlog", to: "In Progress" }]);
 });

--- a/scripts/github/detect-linked-issue-pr.mjs
+++ b/scripts/github/detect-linked-issue-pr.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { parseArgs } from "node:util";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
-import { parseIssueNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
+import { parseIssueNumber, requireTokenValue, runChild as defaultRunChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 export const LINKED_ISSUE_PR_QUERY = [
   "query($owner:String!, $name:String!, $issue:Int!, $after:String) {",
@@ -253,7 +253,7 @@ export function selectLinkedIssuePr(candidates) {
   });
   return sorted[0] ?? null;
 }
-export async function detectLinkedIssuePr({ repo, issue }, { env = process.env, ghCommand = "gh" } = {}) {
+export async function detectLinkedIssuePr({ repo, issue }, { env = process.env, ghCommand = "gh", runChild = defaultRunChild } = {}) {
   const { owner, name } = parseRepoSlug(repo);
   const candidates = [];
   const closedUnmergedCandidates = [];

--- a/scripts/github/ready-for-review.mjs
+++ b/scripts/github/ready-for-review.mjs
@@ -5,10 +5,11 @@ import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.m
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { loadDevLoopConfig, resolveGateConfig } from "@dev-loops/core/config";
 import { findBlockingTitleMarkers } from "@dev-loops/core/loop/pr-title-markers";
+import { syncBoardStatus, loadStateColumnMap, LOGICAL_COLUMN } from "@dev-loops/core/loop/queue-board-sync";
 
 const USAGE = `Usage: ready-for-review.mjs --repo <owner/name> --pr <number>\nWrapper around gh pr ready that enforces gate-evidence validation.`;
 const parseError = buildParseError(USAGE);
-const PR_VIEW_QUERY = `query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { pullRequest(number:$number) { id, isDraft, headRefOid, state, mergeStateStatus, title } } }`;
+const PR_VIEW_QUERY = `query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { pullRequest(number:$number) { id, isDraft, headRefOid, state, mergeStateStatus, title, closingIssuesReferences(first:10){ nodes{ number } } } } }`;
 
 export function parseReadyForReviewCliArgs(argv) {
   const { tokens } = parseArgs({
@@ -43,7 +44,10 @@ async function fetchPrState({ repo, pr }, { env, ghCommand }) {
   const r = await runGhJson(["api", "graphql", "-f", `query=${PR_VIEW_QUERY}`, "-f", `owner=${owner}`, "-f", `name=${name}`, "-F", `number=${pr}`], { env, ghCommand });
   const d = r?.data?.repository?.pullRequest;
   if (!d) throw new Error(`Could not fetch PR #${pr}`);
-  return { id: d.id, isDraft: d.isDraft === true, headRefOid: typeof d.headRefOid === "string" ? d.headRefOid.trim() : null, state: typeof d.state === "string" ? d.state.trim() : null, mergeStateStatus: typeof d.mergeStateStatus === "string" ? d.mergeStateStatus.trim() : null, title: typeof d.title === "string" ? d.title : null };
+  const closingIssues = (d.closingIssuesReferences?.nodes ?? [])
+    .map((n) => n?.number)
+    .filter((n) => Number.isInteger(n) && n > 0);
+  return { id: d.id, isDraft: d.isDraft === true, headRefOid: typeof d.headRefOid === "string" ? d.headRefOid.trim() : null, state: typeof d.state === "string" ? d.state.trim() : null, mergeStateStatus: typeof d.mergeStateStatus === "string" ? d.mergeStateStatus.trim() : null, title: typeof d.title === "string" ? d.title : null, closingIssues };
 }
 
 async function fetchCiStatus({ repo, pr }, { env, ghCommand }) {
@@ -89,7 +93,20 @@ export async function readyForReview(options, { env = process.env, ghCommand = "
   if (!gate.effectiveHeadClean) { const mv = gate.draftGateMarker?.visible; const mh = gate.draftGateMarker?.headSha; throw new Error(mv && mh ? `PR #${options.pr} draft_gate marker does not match current head ${headSha.slice(0,7)}. Re-run draft gate.` : `PR #${options.pr} draft_gate marker is missing or incomplete on current head ${headSha.slice(0,7)}. Re-run draft gate.`); }
   const readyResult = await runChild(ghCommand, ["pr", "ready", String(options.pr), "--repo", options.repo], env);
   if (readyResult.code !== 0) throw new Error(`gh pr ready failed`);
-  return { ok: true, action: "marked_ready", repo: options.repo, pr: options.pr, headSha, draftGateSatisfied: gate.effectiveHeadClean };
+  // #1069: couple the In-Progress board move to the ready transition. Best-effort
+  // and NON-FATAL — a board failure must NEVER block or fail marking ready.
+  let boardSync;
+  try {
+    const inProgressColumn = loadStateColumnMap(repoRoot).columnNames[LOGICAL_COLUMN.IN_PROGRESS];
+    const targets = prState.closingIssues.length > 0 ? prState.closingIssues : [options.pr];
+    boardSync = [];
+    for (const target of targets) {
+      boardSync.push(await syncBoardStatus(options.repo, repoRoot, target, inProgressColumn, env, {}));
+    }
+  } catch (err) {
+    boardSync = [{ ok: true, skipped: true, reason: err?.message ?? "board sync failed" }];
+  }
+  return { ok: true, action: "marked_ready", repo: options.repo, pr: options.pr, headSha, draftGateSatisfied: gate.effectiveHeadClean, boardSync };
 }
 
 export async function main(argv = process.argv.slice(2), runtime = {}) {

--- a/scripts/github/ready-for-review.mjs
+++ b/scripts/github/ready-for-review.mjs
@@ -5,7 +5,7 @@ import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.m
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { loadDevLoopConfig, resolveGateConfig } from "@dev-loops/core/config";
 import { findBlockingTitleMarkers } from "@dev-loops/core/loop/pr-title-markers";
-import { syncBoardStatus, loadStateColumnMap, LOGICAL_COLUMN } from "@dev-loops/core/loop/queue-board-sync";
+import { syncBoardStatus as realSyncBoardStatus, loadStateColumnMap, LOGICAL_COLUMN } from "@dev-loops/core/loop/queue-board-sync";
 
 const USAGE = `Usage: ready-for-review.mjs --repo <owner/name> --pr <number>\nWrapper around gh pr ready that enforces gate-evidence validation.`;
 const parseError = buildParseError(USAGE);
@@ -77,7 +77,7 @@ async function fetchGateEvidence({ repo, pr, headSha }, { env, ghCommand }) {
   return { draftGate: dg, draftGateMarker: dm, currentHeadClean: chc, cleanEvidenceExists: cee, effectiveHeadClean: chc || cphm };
 }
 
-export async function readyForReview(options, { env = process.env, ghCommand = "gh", repoRoot = process.cwd() } = {}) {
+export async function readyForReview(options, { env = process.env, ghCommand = "gh", repoRoot = process.cwd(), syncBoardStatus = realSyncBoardStatus } = {}) {
   const { config } = await loadDevLoopConfig({ repoRoot });
   const draftGateConfig = resolveGateConfig(config, "draft");
   const requireCi = draftGateConfig?.requireCi !== false;

--- a/scripts/loop/resolve-dev-loop-startup.mjs
+++ b/scripts/loop/resolve-dev-loop-startup.mjs
@@ -717,6 +717,9 @@ export async function runCli(argv = process.argv.slice(2), { stdout = process.st
     process.exitCode = 1;
     return;
   }
+  // Emit the deterministic bundle FIRST, before the best-effort self-heal below,
+  // so a slow or hung gh reconcile can never delay the startup result.
+  stdout.write(`${JSON.stringify(result)}\n`);
   // #1069: best-effort startup self-heal — converge the board from live GitHub
   // state so merged→Done / ready→In Progress land deterministically. Gated on a
   // configured board so it never shells out to gh in the no-.devloops unit tests;
@@ -735,7 +738,6 @@ export async function runCli(argv = process.argv.slice(2), { stdout = process.st
       } catch { /* best-effort */ }
     }
   }
-  stdout.write(`${JSON.stringify(result)}\n`);
 }
 if (isDirectCliRun(import.meta.url)) {
   runCli().catch((error) => {

--- a/scripts/loop/resolve-dev-loop-startup.mjs
+++ b/scripts/loop/resolve-dev-loop-startup.mjs
@@ -34,6 +34,8 @@ import {
   PLAN_FILE_REFINEMENT_SECTIONS,
 } from "@dev-loops/core/loop/plan-file-intake-contract";
 import { evaluateSpikeIntakeState } from "@dev-loops/core/loop/spike-intake-contract";
+import { loadBoardConfig } from "@dev-loops/core/loop/queue-board-sync";
+import { main as reconcileQueue } from "../projects/reconcile-queue.mjs";
 import { parseArgs } from "node:util";
 const USAGE = `Usage:
   resolve-dev-loop-startup.mjs --issue <number>
@@ -714,6 +716,24 @@ export async function runCli(argv = process.argv.slice(2), { stdout = process.st
     stderr.write(`${JSON.stringify(result)}\n`);
     process.exitCode = 1;
     return;
+  }
+  // #1069: best-effort startup self-heal — converge the board from live GitHub
+  // state so merged→Done / ready→In Progress land deterministically. Gated on a
+  // configured board so it never shells out to gh in the no-.devloops unit tests;
+  // never writes stdout, never changes exit code, never throws. Skips
+  // --input/--plan-file/--spike modes.
+  if (options.issue !== undefined || options.pr !== undefined) {
+    let reconcileRoot = sessionCwd;
+    try {
+      reconcileRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+        cwd: sessionCwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+      }).trim();
+    } catch { /* fall back to sessionCwd */ }
+    if (loadBoardConfig(reconcileRoot).enabled === true) {
+      try {
+        await reconcileQueue({ repo: detectRepoSlug(reconcileRoot) }, { env: adapter.getEnv(), cwd: reconcileRoot });
+      } catch { /* best-effort */ }
+    }
   }
   stdout.write(`${JSON.stringify(result)}\n`);
 }

--- a/scripts/loop/resolve-dev-loop-startup.mjs
+++ b/scripts/loop/resolve-dev-loop-startup.mjs
@@ -59,6 +59,9 @@ Required (exactly one):
 Exit codes:
   0  Success
   1  Argument error, runtime failure, or async-start contract rejection`.trim();
+// Upper bound on the awaited best-effort startup reconcile so a slow or hung gh
+// can never delay startup completion.
+const STARTUP_RECONCILE_BUDGET_MS = 20000;
 const SHARED_PUBLIC_CONTRACT = "skills/docs/public-dev-loop-contract.md";
 const SHARED_RETROSPECTIVE_CONTRACT = "skills/docs/retrospective-checkpoint-contract.md";
 const STRATEGY_REQUIRED_READS = {
@@ -734,7 +737,13 @@ export async function runCli(argv = process.argv.slice(2), { stdout = process.st
     } catch { /* fall back to sessionCwd */ }
     if (loadBoardConfig(reconcileRoot).enabled === true) {
       try {
-        await reconcileQueue({ repo: detectRepoSlug(reconcileRoot) }, { env: adapter.getEnv(), cwd: reconcileRoot });
+        // The budget bounds startup latency; reconcile is best-effort and the
+        // board self-heals on the next entry if it doesn't finish. The timer is
+        // unref'd so it never keeps the event loop alive on its own.
+        await Promise.race([
+          reconcileQueue({ repo: detectRepoSlug(reconcileRoot) }, { env: adapter.getEnv(), cwd: reconcileRoot }),
+          new Promise((resolve) => { const t = setTimeout(resolve, STARTUP_RECONCILE_BUDGET_MS); t.unref?.(); }),
+        ]);
       } catch { /* best-effort */ }
     }
   }

--- a/scripts/loop/resolve-dev-loop-startup.mjs
+++ b/scripts/loop/resolve-dev-loop-startup.mjs
@@ -741,7 +741,7 @@ export async function runCli(argv = process.argv.slice(2), { stdout = process.st
         // board self-heals on the next entry if it doesn't finish. The timer is
         // unref'd so it never keeps the event loop alive on its own.
         await Promise.race([
-          reconcileQueue({ repo: detectRepoSlug(reconcileRoot) }, { env: adapter.getEnv(), cwd: reconcileRoot }),
+          reconcileQueue({ repo: detectRepoSlug(reconcileRoot) }, { env: adapter.getEnv(), cwd: reconcileRoot, skipTerminalColumn: true }),
           new Promise((resolve) => { const t = setTimeout(resolve, STARTUP_RECONCILE_BUDGET_MS); t.unref?.(); }),
         ]);
       } catch { /* best-effort */ }

--- a/scripts/projects/reconcile-queue.mjs
+++ b/scripts/projects/reconcile-queue.mjs
@@ -12,7 +12,7 @@ import { applyDevloopsBoard } from "./_resolve-project.mjs";
 import { main as listQueueItems } from "./list-queue-items.mjs";
 import { main as moveQueueItem } from "./move-queue-item.mjs";
 import { detectLinkedIssuePr } from "../github/detect-linked-issue-pr.mjs";
-import { planReconcile, loadStateColumnMap } from "@dev-loops/core/loop/queue-board-sync";
+import { planReconcile, loadStateColumnMap, LOGICAL_COLUMN } from "@dev-loops/core/loop/queue-board-sync";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
 
 const USAGE = `Usage: dev-loops queue reconcile --repo <owner/name> [--project <number|id|board-uri>]
@@ -118,11 +118,16 @@ async function ghJson(argv, { env, runChild }) {
 // share a number (repo-A PR #5 vs repo-B issue #5) cannot collide. Per-item gh
 // failures are swallowed (best-effort): the item records all-null PR fields →
 // derives null → untouched.
-export async function gatherLiveFacts(items, repo, { env, runChild } = {}) {
+export async function gatherLiveFacts(items, repo, { env, runChild, doneColumn } = {}) {
   const byItemId = new Map();
   for (const item of items) {
     const number = item.prNumber != null ? item.prNumber : item.issueNumber;
     if (number == null || item.itemId == null) continue;
+    // Done is terminal for reconcile; items already in Done are left untouched
+    // (planReconcile treats a missing fact as unchanged). Skip the gh calls
+    // entirely. A rare reopened/re-linked artifact stuck in Done can still be
+    // recovered via an explicit `dev-loops queue reconcile` run.
+    if (doneColumn != null && item.status === doneColumn) continue;
     try {
       if (item.prNumber != null) {
         const pr = await ghJson(["pr", "view", String(item.prNumber), "--repo", repo, "--json", "state,isDraft,mergedAt"], { env, runChild });
@@ -174,13 +179,14 @@ async function main(args, { env = process.env, runChild, cwd = process.cwd(), li
   );
   const items = list.items ?? [];
 
+  const { columnNames } = loadStateColumnMap(cwd);
+
   const factsByItemId = await (gatherFacts ?? ((its, repo, o) => gatherLiveFacts(its, repo, o)))(
     items,
     args.repo,
-    { env, runChild },
+    { env, runChild, doneColumn: columnNames[LOGICAL_COLUMN.DONE] },
   );
 
-  const { columnNames } = loadStateColumnMap(cwd);
   const { moves, unchanged } = planReconcile(items, factsByItemId, columnNames);
 
   const move = moveItem ?? ((a, o) => moveQueueItem(a, o));

--- a/scripts/projects/reconcile-queue.mjs
+++ b/scripts/projects/reconcile-queue.mjs
@@ -123,10 +123,11 @@ export async function gatherLiveFacts(items, repo, { env, runChild, doneColumn }
   for (const item of items) {
     const number = item.prNumber != null ? item.prNumber : item.issueNumber;
     if (number == null || item.itemId == null) continue;
-    // Done is terminal for reconcile; items already in Done are left untouched
-    // (planReconcile treats a missing fact as unchanged). Skip the gh calls
-    // entirely. A rare reopened/re-linked artifact stuck in Done can still be
-    // recovered via an explicit `dev-loops queue reconcile` run.
+    // Done is terminal for reconcile; planReconcile treats a missing fact as
+    // unchanged. At loop startup (doneColumn set) we skip the gh calls for
+    // Done items entirely — terminal + perf. An explicit `dev-loops queue
+    // reconcile` run passes no doneColumn, so Done items ARE gathered and a
+    // reopened/re-linked artifact can be moved back out of Done (recovery).
     if (doneColumn != null && item.status === doneColumn) continue;
     try {
       if (item.prNumber != null) {
@@ -146,7 +147,7 @@ export async function gatherLiveFacts(items, repo, { env, runChild, doneColumn }
         }
         let prState = null;
         let prIsDraft = null;
-        const linkage = await detectLinkedIssuePr({ repo, issue: item.issueNumber }, { env });
+        const linkage = await detectLinkedIssuePr({ repo, issue: item.issueNumber }, { env, runChild });
         if (linkage?.hasOpenLinkedPr) {
           const pr = await ghJson(["pr", "view", String(linkage.prNumber), "--repo", repo, "--json", "state,isDraft,mergedAt"], { env, runChild });
           prState = pr?.mergedAt ? "MERGED" : String(pr?.state ?? "").toUpperCase();
@@ -167,7 +168,7 @@ export async function gatherLiveFacts(items, repo, { env, runChild, doneColumn }
   return byItemId;
 }
 
-async function main(args, { env = process.env, runChild, cwd = process.cwd(), listItems, gatherFacts, moveItem } = {}) {
+async function main(args, { env = process.env, runChild, cwd = process.cwd(), listItems, gatherFacts, moveItem, skipTerminalColumn = false } = {}) {
   // Resolve the board from .devloops when --project is absent. Idempotent (only
   // mutates when args.project === undefined), so callers that reach main()
   // directly (e.g. the loop-startup self-heal) still resolve the board.
@@ -181,10 +182,15 @@ async function main(args, { env = process.env, runChild, cwd = process.cwd(), li
 
   const { columnNames } = loadStateColumnMap(cwd);
 
+  // Loop startup (skipTerminalColumn: true) skips Done items for speed. An
+  // explicit CLI run (default false) leaves doneColumn null so Done items are
+  // gathered and a reopened/re-linked artifact can be recovered out of Done.
+  const doneColumn = skipTerminalColumn ? columnNames[LOGICAL_COLUMN.DONE] : null;
+
   const factsByItemId = await (gatherFacts ?? ((its, repo, o) => gatherLiveFacts(its, repo, o)))(
     items,
     args.repo,
-    { env, runChild, doneColumn: columnNames[LOGICAL_COLUMN.DONE] },
+    { env, runChild, doneColumn },
   );
 
   const { moves, unchanged } = planReconcile(items, factsByItemId, columnNames);

--- a/scripts/projects/reconcile-queue.mjs
+++ b/scripts/projects/reconcile-queue.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+// Reconcile board Status columns from live GitHub state (#1069). For each queue
+// item it derives the target column from live facts (merged PR / closed issue →
+// Done; open ready non-draft PR → In Progress) and moves ONLY the items whose
+// derived column differs from their current Status. Backlog/Next Up ordering is
+// left untouched (items that derive null are skipped). Idempotent: a second run
+// over a converged board performs no moves.
+import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { parseArgs } from "node:util";
+import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult } from "../lib/jq-output.mjs";
+import { applyDevloopsBoard } from "./_resolve-project.mjs";
+import { main as listQueueItems } from "./list-queue-items.mjs";
+import { main as moveQueueItem } from "./move-queue-item.mjs";
+import { detectLinkedIssuePr } from "../github/detect-linked-issue-pr.mjs";
+import { planReconcile, loadStateColumnMap } from "@dev-loops/core/loop/queue-board-sync";
+import { runChild as _runChild } from "../_cli-primitives.mjs";
+
+const USAGE = `Usage: dev-loops queue reconcile --repo <owner/name> [--project <number|id>]
+
+Reconcile board Status columns from live GitHub state. Derives each item's
+target column from live GitHub facts (merged PR or closed issue → Done; an open,
+ready non-draft PR → In Progress) and moves ONLY the items whose derived column
+differs from their current Status. Backlog/Next Up ordering is left untouched.
+Idempotent: a second run over a converged board performs no moves. Best-effort:
+individual per-item failures are recorded but do not fail the run.
+
+Options:
+  --repo <owner/name>     Required. Repository to scope the project search.
+  --project <number|id>   Project number (integer) or node ID. When omitted,
+                          resolved from .devloops queue.projectNumber /
+                          queue.boardTitle.
+  --help, -h              Show this help.
+
+Output (stdout):
+  JSON: { ok: true, moved, unchanged, reconciled: [{ number, from, to, ok }, ...] }
+
+${JQ_OUTPUT_USAGE}
+
+Exit codes:
+  0 — success (reconcile is best-effort; per-item failures do not fail the run)
+  1 — usage or argument error
+  2 — GitHub API error / invalid --jq filter
+  3 — project, field, or column not found
+`.trim();
+
+function parseCliArgs(argv) {
+  const parseError = (message) => Object.assign(new Error(message), { usage: USAGE, code: "INVALID_ARGS" });
+  const requireValue = (token, message) => {
+    const v = token.value;
+    if (typeof v !== "string" || v.length === 0 || v.startsWith("-")) {
+      throw parseError(message);
+    }
+    return v;
+  };
+
+  const args = {};
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      repo: { type: "string" },
+      project: { type: "string" },
+      help: { type: "boolean", short: "h" },
+      ...JQ_OUTPUT_PARSE_OPTIONS,
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unexpected argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    switch (token.name) {
+      case "help":
+        if (token.value !== undefined) {
+          throw parseError(`Unknown flag: ${token.rawName}=${token.value}`);
+        }
+        args.help = true;
+        break;
+      case "repo":
+        args.repo = requireValue(token, "--repo requires a value (owner/name)");
+        break;
+      case "project":
+        args.project = requireValue(token, "--project requires a value (number or node ID)");
+        break;
+      case "jq":
+        args.jq = requireValue(token, "--jq requires a filter");
+        break;
+      case "silent":
+        args.silent = true;
+        break;
+      default:
+        throw parseError(`Unknown flag: ${token.rawName}`);
+    }
+  }
+  return args;
+}
+
+async function ghJson(argv, { env, runChild }) {
+  const child = runChild ?? _runChild;
+  const result = await child("gh", argv, env);
+  if (result.code !== 0) {
+    const detail = result.stderr?.trim() || `exit code ${result.code}`;
+    throw Object.assign(new Error(`gh command failed: ${detail}`), { code: "GH_API_ERROR" });
+  }
+  return parseJsonText(result.stdout);
+}
+
+// Real live-facts gatherer. For each item, resolve GitHub state into the fact
+// shape consumed by deriveReconcileColumn. Per-item gh failures are swallowed
+// (best-effort): the item records all-null PR fields → derives null → untouched.
+export async function gatherLiveFacts(items, repo, { env, runChild } = {}) {
+  const byNumber = new Map();
+  for (const item of items) {
+    const number = item.prNumber != null ? item.prNumber : item.issueNumber;
+    if (number == null) continue;
+    try {
+      if (item.prNumber != null) {
+        const pr = await ghJson(["pr", "view", String(item.prNumber), "--repo", repo, "--json", "state,isDraft,mergedAt"], { env, runChild });
+        byNumber.set(number, {
+          itemKind: "pr",
+          issueState: null,
+          prState: pr?.mergedAt ? "MERGED" : String(pr?.state ?? "").toUpperCase(),
+          prIsDraft: pr?.isDraft === true,
+        });
+      } else {
+        const issue = await ghJson(["issue", "view", String(item.issueNumber), "--repo", repo, "--json", "state"], { env, runChild });
+        const issueState = String(issue?.state ?? "").toUpperCase();
+        if (issueState === "CLOSED") {
+          byNumber.set(number, { itemKind: "issue", issueState: "CLOSED", prState: null, prIsDraft: null });
+          continue;
+        }
+        let prState = null;
+        let prIsDraft = null;
+        const linkage = await detectLinkedIssuePr({ repo, issue: item.issueNumber }, { env });
+        if (linkage?.hasOpenLinkedPr) {
+          const pr = await ghJson(["pr", "view", String(linkage.prNumber), "--repo", repo, "--json", "state,isDraft,mergedAt"], { env, runChild });
+          prState = pr?.mergedAt ? "MERGED" : String(pr?.state ?? "").toUpperCase();
+          prIsDraft = pr?.isDraft === true;
+        }
+        byNumber.set(number, { itemKind: "issue", issueState: "OPEN", prState, prIsDraft });
+      }
+    } catch {
+      // Best-effort: record inert facts so the item derives null (untouched).
+      byNumber.set(number, {
+        itemKind: item.prNumber != null ? "pr" : "issue",
+        issueState: item.prNumber != null ? null : "OPEN",
+        prState: null,
+        prIsDraft: null,
+      });
+    }
+  }
+  return byNumber;
+}
+
+async function main(args, { env = process.env, runChild, cwd = process.cwd(), listItems, gatherFacts, moveItem } = {}) {
+  // Resolve the board from .devloops when --project is absent. Idempotent (only
+  // mutates when args.project === undefined), so callers that reach main()
+  // directly (e.g. the loop-startup self-heal) still resolve the board.
+  applyDevloopsBoard(args, cwd);
+
+  const list = await (listItems ?? ((a, o) => listQueueItems(a, o)))(
+    { repo: args.repo, project: args.project, projectTitle: args.projectTitle },
+    { env, runChild },
+  );
+  const items = list.items ?? [];
+
+  const factsByNumber = await (gatherFacts ?? ((its, repo, o) => gatherLiveFacts(its, repo, o)))(
+    items,
+    args.repo,
+    { env, runChild },
+  );
+
+  const { columnNames } = loadStateColumnMap(cwd);
+  const { moves, unchanged } = planReconcile(items, factsByNumber, columnNames);
+
+  const move = moveItem ?? ((a, o) => moveQueueItem(a, o));
+  const reconciled = [];
+  let moved = 0;
+  for (const m of moves) {
+    try {
+      await move(
+        { repo: args.repo, project: args.project, projectTitle: args.projectTitle, item: String(m.number), toColumn: m.to },
+        { env, runChild },
+      );
+      reconciled.push({ ...m, ok: true });
+      moved += 1;
+    } catch (err) {
+      // Best-effort: a single failed move does not abort the reconcile loop.
+      reconciled.push({ ...m, ok: false, error: err?.message ?? "move failed" });
+    }
+  }
+
+  return { ok: true, moved, unchanged, reconciled };
+}
+
+function classifyExitCode(err) {
+  if (err.code === "INVALID_ARGS" || err.code === "INVALID_REPO" || err.code === "INVALID_PROJECT") return 1;
+  if (err.code === "PROJECT_NOT_FOUND" || err.code === "FIELD_NOT_FOUND" || err.code === "COLUMN_NOT_FOUND") return 3;
+  return 2;
+}
+
+async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, env = process.env, cwd = process.cwd(), runChild } = {}) {
+  let args;
+  try {
+    args = parseCliArgs(argv);
+  } catch (err) {
+    stderr.write(`${formatCliError(err)}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  if (args.help) {
+    stdout.write(USAGE);
+    return;
+  }
+
+  try {
+    const result = await main(args, { env, runChild, cwd });
+    process.exitCode = emitResult(result, { jq: args.jq, silent: args.silent, stdout, stderr });
+  } catch (err) {
+    stderr.write(JSON.stringify({ ok: false, error: err.message, code: err.code ?? "UNKNOWN" }) + "\n");
+    process.exitCode = classifyExitCode(err);
+  }
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(JSON.stringify({ ok: false, error: error.message, code: error.code ?? "UNKNOWN" }) + "\n");
+    process.exitCode = 2;
+  });
+}
+
+export { main, parseCliArgs, runCli };

--- a/scripts/projects/reconcile-queue.mjs
+++ b/scripts/projects/reconcile-queue.mjs
@@ -15,7 +15,8 @@ import { detectLinkedIssuePr } from "../github/detect-linked-issue-pr.mjs";
 import { planReconcile, loadStateColumnMap } from "@dev-loops/core/loop/queue-board-sync";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
 
-const USAGE = `Usage: dev-loops queue reconcile --repo <owner/name> [--project <number|id>]
+const USAGE = `Usage: dev-loops queue reconcile --repo <owner/name> [--project <number|id|board-uri>]
+       (dev-loops project reconcile … is a back-compat alias)
 
 Reconcile board Status columns from live GitHub state. Derives each item's
 target column from live GitHub facts (merged PR or closed issue → Done; an open,
@@ -26,8 +27,9 @@ individual per-item failures are recorded but do not fail the run.
 
 Options:
   --repo <owner/name>     Required. Repository to scope the project search.
-  --project <number|id>   Project number (integer) or node ID. When omitted,
-                          resolved from .devloops queue.projectNumber /
+  --project <number|id|board-uri>
+                          Project number (integer), node ID, or board URI. When
+                          omitted, resolved from .devloops queue.projectNumber /
                           queue.boardTitle.
   --help, -h              Show this help.
 
@@ -111,17 +113,20 @@ async function ghJson(argv, { env, runChild }) {
 }
 
 // Real live-facts gatherer. For each item, resolve GitHub state into the fact
-// shape consumed by deriveReconcileColumn. Per-item gh failures are swallowed
-// (best-effort): the item records all-null PR fields → derives null → untouched.
+// shape consumed by deriveReconcileColumn. Keyed by the stable item node id
+// (item.itemId), not the bare number, so a multi-repo board where two items
+// share a number (repo-A PR #5 vs repo-B issue #5) cannot collide. Per-item gh
+// failures are swallowed (best-effort): the item records all-null PR fields →
+// derives null → untouched.
 export async function gatherLiveFacts(items, repo, { env, runChild } = {}) {
-  const byNumber = new Map();
+  const byItemId = new Map();
   for (const item of items) {
     const number = item.prNumber != null ? item.prNumber : item.issueNumber;
-    if (number == null) continue;
+    if (number == null || item.itemId == null) continue;
     try {
       if (item.prNumber != null) {
         const pr = await ghJson(["pr", "view", String(item.prNumber), "--repo", repo, "--json", "state,isDraft,mergedAt"], { env, runChild });
-        byNumber.set(number, {
+        byItemId.set(item.itemId, {
           itemKind: "pr",
           issueState: null,
           prState: pr?.mergedAt ? "MERGED" : String(pr?.state ?? "").toUpperCase(),
@@ -131,7 +136,7 @@ export async function gatherLiveFacts(items, repo, { env, runChild } = {}) {
         const issue = await ghJson(["issue", "view", String(item.issueNumber), "--repo", repo, "--json", "state"], { env, runChild });
         const issueState = String(issue?.state ?? "").toUpperCase();
         if (issueState === "CLOSED") {
-          byNumber.set(number, { itemKind: "issue", issueState: "CLOSED", prState: null, prIsDraft: null });
+          byItemId.set(item.itemId, { itemKind: "issue", issueState: "CLOSED", prState: null, prIsDraft: null });
           continue;
         }
         let prState = null;
@@ -142,11 +147,11 @@ export async function gatherLiveFacts(items, repo, { env, runChild } = {}) {
           prState = pr?.mergedAt ? "MERGED" : String(pr?.state ?? "").toUpperCase();
           prIsDraft = pr?.isDraft === true;
         }
-        byNumber.set(number, { itemKind: "issue", issueState: "OPEN", prState, prIsDraft });
+        byItemId.set(item.itemId, { itemKind: "issue", issueState: "OPEN", prState, prIsDraft });
       }
     } catch {
       // Best-effort: record inert facts so the item derives null (untouched).
-      byNumber.set(number, {
+      byItemId.set(item.itemId, {
         itemKind: item.prNumber != null ? "pr" : "issue",
         issueState: item.prNumber != null ? null : "OPEN",
         prState: null,
@@ -154,7 +159,7 @@ export async function gatherLiveFacts(items, repo, { env, runChild } = {}) {
       });
     }
   }
-  return byNumber;
+  return byItemId;
 }
 
 async function main(args, { env = process.env, runChild, cwd = process.cwd(), listItems, gatherFacts, moveItem } = {}) {
@@ -169,29 +174,32 @@ async function main(args, { env = process.env, runChild, cwd = process.cwd(), li
   );
   const items = list.items ?? [];
 
-  const factsByNumber = await (gatherFacts ?? ((its, repo, o) => gatherLiveFacts(its, repo, o)))(
+  const factsByItemId = await (gatherFacts ?? ((its, repo, o) => gatherLiveFacts(its, repo, o)))(
     items,
     args.repo,
     { env, runChild },
   );
 
   const { columnNames } = loadStateColumnMap(cwd);
-  const { moves, unchanged } = planReconcile(items, factsByNumber, columnNames);
+  const { moves, unchanged } = planReconcile(items, factsByItemId, columnNames);
 
   const move = moveItem ?? ((a, o) => moveQueueItem(a, o));
   const reconciled = [];
   let moved = 0;
   for (const m of moves) {
     try {
+      // Move by the stable item node id (move-queue-item accepts a node id per
+      // its `--item <number|node-id>` contract) so a multi-repo number collision
+      // can never target the wrong item.
       await move(
-        { repo: args.repo, project: args.project, projectTitle: args.projectTitle, item: String(m.number), toColumn: m.to },
+        { repo: args.repo, project: args.project, projectTitle: args.projectTitle, item: m.itemId, toColumn: m.to },
         { env, runChild },
       );
-      reconciled.push({ ...m, ok: true });
+      reconciled.push({ number: m.number, from: m.from, to: m.to, ok: true });
       moved += 1;
     } catch (err) {
       // Best-effort: a single failed move does not abort the reconcile loop.
-      reconciled.push({ ...m, ok: false, error: err?.message ?? "move failed" });
+      reconciled.push({ number: m.number, from: m.from, to: m.to, ok: false, error: err?.message ?? "move failed" });
     }
   }
 

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -323,11 +323,7 @@ The canonical checkpoint verdict comment contract is [Gate Review Comment Contra
 - **CI prerequisite:** resolve the draft gate config first (`resolveGateConfig(config, "draft")`). When `requireCi=true` (default), wait for green current-head CI before entering `draft_gate`. When `requireCi=false`, the draft gate may proceed without green CI. This draft-only override does **not** relax `pre_approval_gate`; final approval and merge readiness still require green current-head CI.
 - **Pass criteria:** all configured draft gate angles pass; all findings at severities in `blockCleanOnFindingSeverities` are addressed; validation passes; no unrelated files are included.
 - **Next step after passing:** mark the PR ready for review.
-- **Board status sync (best-effort, after ready-for-review):** once the PR is created/marked ready for review, sync the linked issue's board item to "In Progress" so the queue board reflects active work without a manual `dev-loops queue sync-status --to-column <col>`:
-  ```sh
-  node <resolved-skill-scripts>/projects/sync-item-status.mjs --repo <owner/name> --item <linked-issue> --to-column "In Progress"
-  ```
-  Best-effort and NON-FATAL: it uses local `gh` auth (no CI/PAT), exits 0 when the board is not configured / the item is not on the board / the API fails, and never blocks marking the PR ready.
+- **Board status sync (built-in, after ready-for-review):** the In-Progress board move is now performed automatically as a deterministic tail of `ready-for-review.mjs` — marking the PR ready couples the board move to the ready transition (#1069), so no separate `sync-item-status` step is needed. It stays best-effort and NON-FATAL: it uses local `gh` auth (no CI/PAT), exits 0 when the board is not configured / the item is not on the board / the API fails, and never blocks marking the PR ready.
 - **Non-substitution rule:** a clean `draft_gate` comment only authorizes the draft → ready-for-review transition for that head SHA. It does **not** satisfy `pre_approval_gate`, final-approval readiness, or merge-ready requirements.
 - **Required PR comment:** post a visible checkpoint verdict comment using the mandatory [Gate comment command](#mandatory-gate-comment-command-contract). Keep validation reporting concise: include command names with pass/fail status. Do **not** paste raw passing test output into the visible gate comment. If you include a failing validation excerpt, keep it focused and truncate it to a deterministic retained-prefix length before posting the comment. See [Gate Review Comment Contract](../../docs/gate-review-comment-contract.md). Do not run `gh pr ready` unless a visible `clean` `draft_gate` checkpoint verdict comment exists for the current head SHA. A checkpoint verdict comment for an older head SHA does not satisfy this requirement for the current head. If findings exist, the PR stays draft and needs fixes before retry. If fixes advance the head SHA while still draft, post a new checkpoint verdict comment for the new head. If the checkpoint verdict comment cannot be posted, fail closed and do not run `gh pr ready`.
 
@@ -411,7 +407,7 @@ node <resolved-skill-scripts>/projects/archive-done-items.mjs --repo <owner/name
 
 Board and threshold resolve from `.devloops` (`queue.projectNumber`/`queue.boardTitle`, `queue.archiveOlderThanDays`, default 7d), using local `gh` auth — no CI, cron, or PAT. This step is best-effort and NON-FATAL: ignore any failure and never let it block the merge or the retrospective.
 
-Alongside the archive step, sync the linked issue's board item to "Done" so the queue board reflects the merge without a manual `dev-loops queue sync-status --to-column <col>`:
+The deterministic mechanism that converges merged→Done is `dev-loops queue reconcile` — idempotent, run best-effort at loop startup — so the merge lands on the "Done" column without a remembered manual step. The manual sync below is now an optional fallback (e.g. to converge immediately without waiting for the next startup reconcile):
 
 ```sh
 node <resolved-skill-scripts>/projects/sync-item-status.mjs --repo <owner/name> --item <linked-issue> --to-column "Done"

--- a/test/github/detect-linked-issue-pr.test.mjs
+++ b/test/github/detect-linked-issue-pr.test.mjs
@@ -6,7 +6,7 @@ import { spawn } from "node:child_process";
 import test from "node:test";
 import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
-import { selectLinkedIssuePr } from "../../scripts/github/detect-linked-issue-pr.mjs";
+import { detectLinkedIssuePr, selectLinkedIssuePr } from "../../scripts/github/detect-linked-issue-pr.mjs";
 
 const scriptPath = path.resolve("scripts/github/detect-linked-issue-pr.mjs");
 
@@ -406,6 +406,28 @@ test("selectLinkedIssuePr uses locale-independent url fallback ordering", () => 
   ]);
 
   assert.equal(winner?.prUrl, "https://github.com/owner/repo/pull/90?a=1");
+});
+
+test("detectLinkedIssuePr uses the injected runChild (no real gh)", async () => {
+  const calls = [];
+  const runChild = async (cmd, argv) => {
+    calls.push({ cmd, argv });
+    return {
+      code: 0,
+      stdout: graphqlPayload({
+        hasNextPage: false,
+        endCursor: null,
+        nodes: [connectedNode({ createdAt: "2026-05-12T10:00:00Z", number: 90 })],
+      }),
+      stderr: "",
+    };
+  };
+  const result = await detectLinkedIssuePr({ repo: "owner/repo", issue: 85 }, { env: {}, runChild });
+  assert.equal(result.hasOpenLinkedPr, true);
+  assert.equal(result.prNumber, 90);
+  // The injected runner was used; no fallback to the module-level (real gh) runner.
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].cmd, "gh");
 });
 
 test("detect-linked-issue-pr rejects malformed arguments deterministically", async () => {

--- a/test/github/ready-for-review.test.mjs
+++ b/test/github/ready-for-review.test.mjs
@@ -425,6 +425,67 @@ test.skip("--skip-gate-check allows transition without gate evidence", async () 
   }
 });
 
+test("built-in In-Progress board sync runs after gh pr ready and is NON-FATAL (#1069)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-board-sync-"));
+
+  try {
+    // No .devloops in tempDir → board not configured → syncBoardStatus is a
+    // clean fail-open skip. Running with cwd: tempDir keeps the board sync from
+    // shelling out to gh, but proves the tail runs and marking ready still wins.
+    const { env, ghLogPath } = await writeGhStub(tempDir, [
+      {
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                id: "PR_abc123",
+                isDraft: true,
+                headRefOid: "abc123def456",
+                state: "OPEN",
+                mergeStateStatus: "CLEAN",
+                closingIssuesReferences: { nodes: [{ number: 55 }] },
+              },
+            },
+          },
+        }),
+      },
+      { stdout: JSON.stringify([{ name: "test", state: "success", bucket: "pass" }]) },
+      {
+        stdout: JSON.stringify([
+          {
+            body: "Gate review: draft_gate\nReviewed head SHA: abc123def456\nVerdict: clean\nFindings summary: no issues found\nNext action: mark ready for review",
+            id: 101,
+            html_url: "https://github.com/owner/repo/pull/17#issuecomment-101",
+            created_at: "2026-06-05T00:00:00Z",
+            updated_at: "2026-06-05T00:00:00Z",
+          },
+        ]),
+      },
+      { stdout: "" }, // gh pr ready
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
+
+    assert.equal(result.code, 0, `Expected exit 0, got ${result.code}. Stderr: ${result.stderr}`);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.action, "marked_ready");
+    // Board sync tail ran and, with no board configured, reported a skip.
+    assert.ok(Array.isArray(output.boardSync), "boardSync should be present");
+    assert.ok(output.boardSync.length >= 1);
+    assert.ok(output.boardSync.every((r) => r.ok === true && r.skipped === true));
+
+    // The closingIssuesReferences selection is issued as part of the PR view query.
+    const calls = await readGhCalls(ghLogPath);
+    const closingQuery = calls.find(
+      (c) => Array.isArray(c) && c.some((a) => typeof a === "string" && a.includes("closingIssuesReferences")),
+    );
+    assert.ok(closingQuery, `PR view query should request closingIssuesReferences. Calls: ${JSON.stringify(calls)}`);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("fails when draft_gate marker does not match current head SHA", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-mismatch-head-"));
 

--- a/test/github/ready-for-review.test.mjs
+++ b/test/github/ready-for-review.test.mjs
@@ -6,7 +6,7 @@ import path from "node:path";
 import test from "node:test";
 import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
 
-import { parseReadyForReviewCliArgs } from "../../scripts/github/ready-for-review.mjs";
+import { parseReadyForReviewCliArgs, readyForReview } from "../../scripts/github/ready-for-review.mjs";
 
 const scriptPath = path.resolve("scripts/github/ready-for-review.mjs");
 const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
@@ -481,6 +481,110 @@ test("built-in In-Progress board sync runs after gh pr ready and is NON-FATAL (#
       (c) => Array.isArray(c) && c.some((a) => typeof a === "string" && a.includes("closingIssuesReferences")),
     );
     assert.ok(closingQuery, `PR view query should request closingIssuesReferences. Calls: ${JSON.stringify(calls)}`);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+// --- readyForReview board-sync tail: injected syncBoardStatus (#1069) ---
+//
+// Drive readyForReview directly with the gh stub (via injected env/ghCommand)
+// plus an injected fake syncBoardStatus so the board tail is observable: the
+// move target (closing issue vs PR) and the NON-FATAL swallow are verified.
+function preReadyGhStub(tempDir, { closingIssueNodes = [] } = {}) {
+  return writeGhStub(tempDir, [
+    {
+      stdout: JSON.stringify({
+        data: {
+          repository: {
+            pullRequest: {
+              id: "PR_abc123",
+              isDraft: true,
+              headRefOid: "abc123def456",
+              state: "OPEN",
+              mergeStateStatus: "CLEAN",
+              title: "Add feature",
+              closingIssuesReferences: { nodes: closingIssueNodes },
+            },
+          },
+        },
+      }),
+    },
+    { stdout: JSON.stringify([{ name: "test", state: "success", bucket: "pass" }]) },
+    {
+      stdout: JSON.stringify([
+        {
+          body: "Gate review: draft_gate\nReviewed head SHA: abc123def456\nVerdict: clean\nFindings summary: no issues found\nNext action: mark ready for review",
+          id: 101,
+          html_url: "https://github.com/owner/repo/pull/17#issuecomment-101",
+          created_at: "2026-06-05T00:00:00Z",
+          updated_at: "2026-06-05T00:00:00Z",
+        },
+      ]),
+    },
+    { stdout: "" }, // gh pr ready
+  ]);
+}
+
+test("board tail targets the closing issue (not the PR) when closingIssues present (#1069)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-board-target-"));
+  try {
+    const { env } = await preReadyGhStub(tempDir, { closingIssueNodes: [{ number: 55 }] });
+    const syncCalls = [];
+    const fakeSync = async (repo, repoRoot, target, column) => {
+      syncCalls.push({ repo, target, column });
+      return { ok: true, skipped: false };
+    };
+    const result = await readyForReview(
+      { repo: "owner/repo", pr: 17 },
+      { env, repoRoot: tempDir, syncBoardStatus: fakeSync },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.action, "marked_ready");
+    assert.equal(syncCalls.length, 1);
+    assert.equal(syncCalls[0].target, 55, "board move should target the closing issue #55, not the PR");
+    assert.equal(syncCalls[0].column, "In Progress");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("board tail falls back to the PR number when closingIssues is empty (#1069)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-board-fallback-"));
+  try {
+    const { env } = await preReadyGhStub(tempDir, { closingIssueNodes: [] });
+    const syncCalls = [];
+    const fakeSync = async (repo, repoRoot, target, column) => {
+      syncCalls.push({ target, column });
+      return { ok: true, skipped: false };
+    };
+    const result = await readyForReview(
+      { repo: "owner/repo", pr: 17 },
+      { env, repoRoot: tempDir, syncBoardStatus: fakeSync },
+    );
+    assert.equal(result.action, "marked_ready");
+    assert.equal(syncCalls.length, 1);
+    assert.equal(syncCalls[0].target, 17, "with no closing issue the board move targets the PR number");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("board tail is NON-FATAL: a throwing syncBoardStatus never fails marking ready (#1069)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-board-throws-"));
+  try {
+    const { env } = await preReadyGhStub(tempDir, { closingIssueNodes: [{ number: 55 }] });
+    const fakeSync = async () => { throw new Error("board exploded"); };
+    const result = await readyForReview(
+      { repo: "owner/repo", pr: 17 },
+      { env, repoRoot: tempDir, syncBoardStatus: fakeSync },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.action, "marked_ready");
+    // The throw is swallowed and recorded as a skip/failure entry.
+    assert.ok(Array.isArray(result.boardSync));
+    assert.ok(result.boardSync.length >= 1);
+    assert.ok(result.boardSync.some((r) => r.skipped === true && /board exploded/.test(r.reason ?? "")));
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/projects/reconcile-queue.test.mjs
+++ b/test/projects/reconcile-queue.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { main } from "../../scripts/projects/reconcile-queue.mjs";
+import { main, gatherLiveFacts } from "../../scripts/projects/reconcile-queue.mjs";
 
 // Facts consumed by planReconcile via deriveReconcileColumn. A ready open
 // non-draft linked PR on an open issue derives → In Progress.
@@ -88,6 +88,28 @@ describe("reconcile-queue main (#1069)", () => {
     assert.equal(result.moved, 0);
     assert.equal(result.unchanged, 1);
     assert.equal(moveCalls.length, 0);
+  });
+
+  it("gatherLiveFacts skips a Done-status item (zero gh calls) but still gathers a non-Done item", async () => {
+    const calls = [];
+    const runChild = async (cmd, argv) => {
+      calls.push({ cmd, argv });
+      // Minimal shape for `issue view --json state` on the non-Done item.
+      return { code: 0, stdout: JSON.stringify({ state: "CLOSED" }), stderr: "" };
+    };
+    const items = [
+      { itemId: "I_done", issueNumber: 1, prNumber: null, status: "Done" },
+      { itemId: "I_backlog", issueNumber: 2, prNumber: null, status: "Backlog" },
+    ];
+    const facts = await gatherLiveFacts(items, "o/r", { env: {}, runChild, doneColumn: "Done" });
+    // Done item never fetched → absent from the facts Map (planReconcile leaves it in place).
+    assert.equal(facts.has("I_done"), false);
+    // Non-Done item still gathered.
+    assert.equal(facts.has("I_backlog"), true);
+    // Every gh call was for the non-Done issue #2, none for the Done item #1.
+    assert.ok(calls.length > 0);
+    assert.ok(calls.every((c) => c.argv.includes("2")));
+    assert.ok(calls.every((c) => !c.argv.includes("1")));
   });
 
   it("resolves .devloops boardTitle when --project is omitted and forwards projectTitle to list/move", async () => {

--- a/test/projects/reconcile-queue.test.mjs
+++ b/test/projects/reconcile-queue.test.mjs
@@ -27,23 +27,43 @@ function run({ items, facts, moveCalls }) {
 }
 
 describe("reconcile-queue main (#1069)", () => {
-  it("#1057-shaped: Backlog issue with a ready linked PR → one move to In Progress", async () => {
+  it("#1057-shaped: Backlog issue with a ready linked PR → one move to In Progress by item node id", async () => {
     const moveCalls = [];
     const result = await run({
-      items: [{ issueNumber: 42, prNumber: null, status: "Backlog" }],
-      facts: [[42, READY_LINKED_PR]],
+      items: [{ itemId: "I_42", issueNumber: 42, prNumber: null, status: "Backlog" }],
+      facts: [["I_42", READY_LINKED_PR]],
       moveCalls,
     });
     assert.equal(result.ok, true);
     assert.equal(result.moved, 1);
     assert.equal(moveCalls.length, 1);
-    assert.deepEqual(moveCalls[0], { repo: "o/r", project: "7", projectTitle: undefined, item: "42", toColumn: "In Progress" });
+    // Move is applied by the stable node id, not the bare number.
+    assert.deepEqual(moveCalls[0], { repo: "o/r", project: "7", projectTitle: undefined, item: "I_42", toColumn: "In Progress" });
     assert.deepEqual(result.reconciled, [{ number: 42, from: "Backlog", to: "In Progress", ok: true }]);
   });
 
+  it("multi-repo number collision: two items share number 5 but each moves by its own itemId", async () => {
+    const moveCalls = [];
+    const result = await run({
+      items: [
+        { itemId: "I_prA", issueNumber: null, prNumber: 5, status: "Backlog" },
+        { itemId: "I_issB", issueNumber: 5, prNumber: null, status: "Backlog" },
+      ],
+      facts: [
+        ["I_prA", { itemKind: "pr", issueState: null, prState: "MERGED", prIsDraft: false }],
+        ["I_issB", READY_LINKED_PR],
+      ],
+      moveCalls,
+    });
+    assert.equal(result.moved, 2);
+    const byItem = new Map(moveCalls.map((c) => [c.item, c.toColumn]));
+    assert.equal(byItem.get("I_prA"), "Done");
+    assert.equal(byItem.get("I_issB"), "In Progress");
+  });
+
   it("idempotent: item already In Progress → no moves, and a second run also moves nothing", async () => {
-    const items = [{ issueNumber: 42, prNumber: null, status: "In Progress" }];
-    const facts = [[42, READY_LINKED_PR]];
+    const items = [{ itemId: "I_42", issueNumber: 42, prNumber: null, status: "In Progress" }];
+    const facts = [["I_42", READY_LINKED_PR]];
 
     const first = [];
     const r1 = await run({ items, facts, moveCalls: first });
@@ -61,8 +81,8 @@ describe("reconcile-queue main (#1069)", () => {
   it("Backlog/Next Up untouched: a Next Up item deriving null → no move", async () => {
     const moveCalls = [];
     const result = await run({
-      items: [{ issueNumber: 7, prNumber: null, status: "Next Up" }],
-      facts: [[7, UNTOUCHED]],
+      items: [{ itemId: "I_7", issueNumber: 7, prNumber: null, status: "Next Up" }],
+      facts: [["I_7", UNTOUCHED]],
       moveCalls,
     });
     assert.equal(result.moved, 0);
@@ -82,8 +102,8 @@ describe("reconcile-queue main (#1069)", () => {
         {
           env: {},
           cwd: dir,
-          listItems: async (a) => { listArgs.push(a); return { items: [{ issueNumber: 42, prNumber: null, status: "Backlog" }] }; },
-          gatherFacts: async () => new Map([[42, READY_LINKED_PR]]),
+          listItems: async (a) => { listArgs.push(a); return { items: [{ itemId: "I_42", issueNumber: 42, prNumber: null, status: "Backlog" }] }; },
+          gatherFacts: async () => new Map([["I_42", READY_LINKED_PR]]),
           moveItem: async (a) => { moveCalls.push(a); return { ok: true }; },
         },
       );

--- a/test/projects/reconcile-queue.test.mjs
+++ b/test/projects/reconcile-queue.test.mjs
@@ -1,0 +1,102 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { main } from "../../scripts/projects/reconcile-queue.mjs";
+
+// Facts consumed by planReconcile via deriveReconcileColumn. A ready open
+// non-draft linked PR on an open issue derives → In Progress.
+const READY_LINKED_PR = { itemKind: "issue", issueState: "OPEN", prState: "OPEN", prIsDraft: false };
+// Nothing to derive (no linked PR / still draft) → untouched.
+const UNTOUCHED = { itemKind: "issue", issueState: "OPEN", prState: null, prIsDraft: null };
+
+// Run main() with fully injected deps so no network / gh / .devloops is needed.
+// cwd omitted → loadStateColumnMap falls back to the AC1 default column names,
+// so "In Progress"/"Done" resolve deterministically.
+function run({ items, facts, moveCalls }) {
+  return main(
+    { repo: "o/r", project: "7" },
+    {
+      env: {},
+      listItems: async () => ({ items }),
+      gatherFacts: async () => new Map(facts),
+      moveItem: async (args) => { moveCalls.push(args); return { ok: true }; },
+    },
+  );
+}
+
+describe("reconcile-queue main (#1069)", () => {
+  it("#1057-shaped: Backlog issue with a ready linked PR → one move to In Progress", async () => {
+    const moveCalls = [];
+    const result = await run({
+      items: [{ issueNumber: 42, prNumber: null, status: "Backlog" }],
+      facts: [[42, READY_LINKED_PR]],
+      moveCalls,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.moved, 1);
+    assert.equal(moveCalls.length, 1);
+    assert.deepEqual(moveCalls[0], { repo: "o/r", project: "7", projectTitle: undefined, item: "42", toColumn: "In Progress" });
+    assert.deepEqual(result.reconciled, [{ number: 42, from: "Backlog", to: "In Progress", ok: true }]);
+  });
+
+  it("idempotent: item already In Progress → no moves, and a second run also moves nothing", async () => {
+    const items = [{ issueNumber: 42, prNumber: null, status: "In Progress" }];
+    const facts = [[42, READY_LINKED_PR]];
+
+    const first = [];
+    const r1 = await run({ items, facts, moveCalls: first });
+    assert.equal(r1.moved, 0);
+    assert.equal(r1.unchanged, items.length);
+    assert.deepEqual(r1.reconciled, []);
+    assert.equal(first.length, 0);
+
+    const second = [];
+    const r2 = await run({ items, facts, moveCalls: second });
+    assert.equal(r2.moved, 0);
+    assert.equal(second.length, 0);
+  });
+
+  it("Backlog/Next Up untouched: a Next Up item deriving null → no move", async () => {
+    const moveCalls = [];
+    const result = await run({
+      items: [{ issueNumber: 7, prNumber: null, status: "Next Up" }],
+      facts: [[7, UNTOUCHED]],
+      moveCalls,
+    });
+    assert.equal(result.moved, 0);
+    assert.equal(result.unchanged, 1);
+    assert.equal(moveCalls.length, 0);
+  });
+
+  it("resolves .devloops boardTitle when --project is omitted and forwards projectTitle to list/move", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "reconcile-board-"));
+    try {
+      writeFileSync(path.join(dir, ".devloops"), 'queue:\n  boardTitle: "My Board"\n');
+
+      const listArgs = [];
+      const moveCalls = [];
+      const result = await main(
+        { repo: "o/r" }, // no project → must resolve boardTitle from .devloops
+        {
+          env: {},
+          cwd: dir,
+          listItems: async (a) => { listArgs.push(a); return { items: [{ issueNumber: 42, prNumber: null, status: "Backlog" }] }; },
+          gatherFacts: async () => new Map([[42, READY_LINKED_PR]]),
+          moveItem: async (a) => { moveCalls.push(a); return { ok: true }; },
+        },
+      );
+
+      assert.equal(result.ok, true);
+      assert.equal(result.moved, 1);
+      assert.equal(listArgs.length, 1);
+      assert.equal(listArgs[0].projectTitle, "My Board");
+      assert.equal(listArgs[0].project, undefined);
+      assert.equal(moveCalls.length, 1);
+      assert.equal(moveCalls[0].projectTitle, "My Board");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/projects/reconcile-queue.test.mjs
+++ b/test/projects/reconcile-queue.test.mjs
@@ -90,7 +90,7 @@ describe("reconcile-queue main (#1069)", () => {
     assert.equal(moveCalls.length, 0);
   });
 
-  it("gatherLiveFacts skips a Done-status item (zero gh calls) but still gathers a non-Done item", async () => {
+  it("gatherLiveFacts with doneColumn skips a Done-status item (zero gh calls) but still gathers a non-Done item", async () => {
     const calls = [];
     const runChild = async (cmd, argv) => {
       calls.push({ cmd, argv });
@@ -110,6 +110,19 @@ describe("reconcile-queue main (#1069)", () => {
     assert.ok(calls.length > 0);
     assert.ok(calls.every((c) => c.argv.includes("2")));
     assert.ok(calls.every((c) => !c.argv.includes("1")));
+  });
+
+  it("gatherLiveFacts WITHOUT doneColumn gathers a Done-status item (explicit-run recovery)", async () => {
+    const calls = [];
+    const runChild = async (cmd, argv) => {
+      calls.push({ cmd, argv });
+      return { code: 0, stdout: JSON.stringify({ state: "CLOSED" }), stderr: "" };
+    };
+    const items = [{ itemId: "I_done", issueNumber: 1, prNumber: null, status: "Done" }];
+    // No doneColumn (explicit `dev-loops queue reconcile`) → the Done item IS gathered.
+    const facts = await gatherLiveFacts(items, "o/r", { env: {}, runChild });
+    assert.equal(facts.has("I_done"), true);
+    assert.ok(calls.some((c) => c.argv.includes("1")));
   });
 
   it("resolves .devloops boardTitle when --project is omitted and forwards projectTitle to list/move", async () => {


### PR DESCRIPTION
## Summary

Board Status transitions were unreliable on the per-issue dev-loop path: a PR going ready-for-review didn't reliably move its board item to **In Progress** because that move lived in a droppable best-effort prose step (SKILL.md), and it got dropped (observed live: #1057 / PR #1068 stayed in Backlog).

This makes the transitions deterministic in two complementary ways:

1. **Couple In-Progress to the ready transition** — fold a best-effort, NON-FATAL `syncBoardStatus(..., "In Progress")` tail into `scripts/github/ready-for-review.mjs`, so the board move happens exactly at the ready transition instead of via a remembered prose step.
2. **Idempotent `dev-loops queue reconcile`** — derives each item's column from live GitHub state and fixes drift in one call; self-heals *any* missed transition regardless of which path dropped it. Wired into loop startup (best-effort) so the board self-corrects at loop entry.

Closes #1069.

## Design

- Root-cause logic lives in shared core: `deriveReconcileColumn(facts)` (pure state→logical-column mapping) and `planReconcile(items, facts, columnNames)` (pure planner) in `packages/core/src/loop/queue-board-sync.mjs`, reusing the existing `LOGICAL_COLUMN` / column-name config.
- `ready-for-review.mjs` extends its PR view query with `closingIssuesReferences` and syncs the linked issue(s) (falling back to the PR itself), reusing `syncBoardStatus`.
- `queue reconcile` reuses `list-queue-items`, `move-queue-item`, `detect-linked-issue-pr`, and the `.devloops` board resolver; composes with `--jq`/`--silent`.

## Acceptance criteria

- `ready-for-review.mjs` performs a best-effort In-Progress board sync as a built-in tail step; NON-FATAL (board not configured / item not on board / API failure → exit 0, ready still succeeds).
- `dev-loops queue reconcile` derives columns from live state per the mapping and moves only items whose derived column differs; never touches Backlog/Next-Up ordering; composes with `--jq`/`--silent`.
- `queue reconcile` is idempotent: a second run on an already-correct board makes zero writes and reports `unchanged`.
- Loop startup runs `queue reconcile` best-effort (board-gated) so drift self-corrects at loop entry.
- The #1057-shaped miss (ready PR, linked issue still in Backlog) reconciles to In Progress in one call; unit coverage for the derive mapping (ready-PR→In Progress, merged→Done, no-PR→untouched) + idempotence.
- SKILL.md prose (In Progress, Done) references the deterministic mechanism instead of instructing a manual sync.

## Definition of done

- `npm run verify` green (core + scripts + assets + docs + dev-loop).
- New unit tests: `deriveReconcileColumn`/`planReconcile` (core), `reconcile-queue` script (idempotence, #1057-shape, Backlog/Next-Up untouched, `.devloops` boardTitle resolution), ready-for-review NON-FATAL board-sync tail.
- `.claude/` mirror regenerated (byte-reproducible).

## Non-goals

- No `gh pr merge` wrapper for the Done transition (reconcile covers merged→Done idempotently).
- No change to Backlog/Next-Up ordering semantics or the conductor/queue-driver path (already deterministic per #793).
- Board sync stays best-effort everywhere (never fatal).
