### PR TITLE
fix(gates): key fresh-context review sentinels per head SHA (round) so retries aren't blocked

### DIFF
--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -128,11 +128,13 @@ the head SHA. This makes the lifecycle mechanical rather than a manual chore:
 
 - The round key defaults to the current HEAD; reviewers keep invoking the guard as
   `--scope <angle>` and get head-keyed isolation for free. Pass `--round <headSha>` to pin
-  the round explicitly (e.g. the gate-context head SHA). Any git rev (the auto default or a
-  short/full SHA) is canonicalized to its full commit SHA, so auto and pinned invocations for
-  the same head resolve to one key — the same-head fail-closed guard cannot be defeated by
-  spelling the head differently. When git is unavailable the key falls back to scope-only
-  (legacy behavior).
+  the round explicitly (e.g. the gate-context head SHA). A commit SHA (the auto default or a
+  short/full SHA passed via `--round`) is canonicalized to its full commit SHA, so auto and
+  pinned invocations for the same head resolve to one key — the same-head fail-closed guard
+  cannot be defeated by spelling the head differently. The `--round` token is validated with
+  the same alphanumeric+hyphen rule as `--scope` (keeping the sentinel filename path-safe), so
+  rev syntaxes like `HEAD~1`, `v1.0.0`, or `refs/tags/...` are rejected rather than accepted.
+  When git is unavailable the key falls back to scope-only (legacy behavior).
 - **A retry at a new head is never blocked by a prior round's sentinel** — a new head SHA
   produces a new key, so a re-fan-out after a fix commit passes `fresh: true` with **no
   manual clear step**.

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -104,7 +104,7 @@ on an isolated checkout:
 
 Fan out one fresh-context reviewer per gate-specific review angle. The reviewer is the scoped `review` agent ([review agent scoped angle-review mode](../agents/review.agent.md)), spawned once per resolved angle via the plain Agent tool. Reviewers are **independent and seeded with the identical neutral context bundle verbatim** (Phase 1's diff + `adjacentCode`); they do NOT fork from, or inherit the loaded context of, the main agent or a sibling reviewer. Parallelism is capped at `gates.maxFanoutReviewers` (default 8); when the resolved angle set exceeds the cap, the overflow runs in sequential batches (planned by `planFanoutBatches` from `@dev-loops/core/loop/gate-fanin`) and the degradation is recorded in the gate evidence. Each reviewer:
 
-- starts in fresh context. **Mandatory:** run `scripts/github/verify-fresh-review-context.mjs --scope <angle>` at startup; refuse to proceed on contamination. Use `--scope` so parallel reviewers in the same working directory do not trigger false contamination from each other's sentinels. The sentinel is keyed per review ROUND by the head SHA (auto-resolved from `git rev-parse --short HEAD`; pin explicitly with `--round <headSha>`), so a retry at a new head naturally gets a fresh sentinel — see [Sentinel lifecycle](#sentinel-lifecycle). Here "fresh" means the reviewer's context is the neutral builder artifact + its angle, and explicitly NOT the main agent's conversation/state or a prior reviewer session's state: the injected neutral bundle is the intended seed (allowed), while main-agent / cross-session state bleed fails closed.
+- starts in fresh context. **Mandatory:** run `scripts/github/verify-fresh-review-context.mjs --scope <angle>` at startup; refuse to proceed on contamination. Use `--scope` so parallel reviewers in the same working directory do not trigger false contamination from each other's sentinels. The sentinel is keyed per review ROUND by the head SHA (auto-resolved from the current HEAD; pin explicitly with `--round <headSha>`), so a retry at a new head naturally gets a fresh sentinel — see [Sentinel lifecycle](#sentinel-lifecycle). Here "fresh" means the reviewer's context is the neutral builder artifact + its angle, and explicitly NOT the main agent's conversation/state or a prior reviewer session's state: the injected neutral bundle is the intended seed (allowed), while main-agent / cross-session state bleed fails closed.
 - is seeded with the neutral context bundle verbatim (diff + `adjacentCode`) as its base, and widens (loads more files) only when its single angle genuinely needs more — it does not re-derive the whole diff/adjacent-code graph
 - is scoped to exactly one review angle
 - is **read-only**: inspects the diff and returns findings via output artifacts only; never edits files
@@ -126,10 +126,13 @@ The fresh-context sentinel (`tmp/checkpoint-context-sentinel-<scope>-<headSha>.j
 written by `verify-fresh-review-context.mjs`) is scoped **per review round**, keyed by
 the head SHA. This makes the lifecycle mechanical rather than a manual chore:
 
-- The round key defaults to `git rev-parse --short HEAD`; reviewers keep invoking the
-  guard as `--scope <angle>` and get head-keyed isolation for free. Pass `--round <headSha>`
-  to pin the round explicitly (e.g. the gate-context head SHA). When git is unavailable the
-  key falls back to scope-only (legacy behavior).
+- The round key defaults to the current HEAD; reviewers keep invoking the guard as
+  `--scope <angle>` and get head-keyed isolation for free. Pass `--round <headSha>` to pin
+  the round explicitly (e.g. the gate-context head SHA). Any git rev (the auto default or a
+  short/full SHA) is canonicalized to its full commit SHA, so auto and pinned invocations for
+  the same head resolve to one key — the same-head fail-closed guard cannot be defeated by
+  spelling the head differently. When git is unavailable the key falls back to scope-only
+  (legacy behavior).
 - **A retry at a new head is never blocked by a prior round's sentinel** — a new head SHA
   produces a new key, so a re-fan-out after a fix commit passes `fresh: true` with **no
   manual clear step**.

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -104,7 +104,7 @@ on an isolated checkout:
 
 Fan out one fresh-context reviewer per gate-specific review angle. The reviewer is the scoped `review` agent ([review agent scoped angle-review mode](../agents/review.agent.md)), spawned once per resolved angle via the plain Agent tool. Reviewers are **independent and seeded with the identical neutral context bundle verbatim** (Phase 1's diff + `adjacentCode`); they do NOT fork from, or inherit the loaded context of, the main agent or a sibling reviewer. Parallelism is capped at `gates.maxFanoutReviewers` (default 8); when the resolved angle set exceeds the cap, the overflow runs in sequential batches (planned by `planFanoutBatches` from `@dev-loops/core/loop/gate-fanin`) and the degradation is recorded in the gate evidence. Each reviewer:
 
-- starts in fresh context. **Mandatory:** run `scripts/github/verify-fresh-review-context.mjs --scope <angle>` at startup; refuse to proceed on contamination. Use `--scope` so parallel reviewers in the same working directory do not trigger false contamination from each other's sentinels. The sentinel is keyed per review ROUND by the head SHA (auto-resolved from the current HEAD; pin explicitly with `--round <headSha>`), so a retry at a new head naturally gets a fresh sentinel — see [Sentinel lifecycle](#sentinel-lifecycle). Here "fresh" means the reviewer's context is the neutral builder artifact + its angle, and explicitly NOT the main agent's conversation/state or a prior reviewer session's state: the injected neutral bundle is the intended seed (allowed), while main-agent / cross-session state bleed fails closed.
+- starts in fresh context. **Mandatory:** run `scripts/github/verify-fresh-review-context.mjs --scope <angle>` at startup; refuse to proceed on contamination. Use `--scope` so parallel reviewers in the same working directory do not trigger false contamination from each other's sentinels. The sentinel is keyed per review ROUND by the current head SHA (`git rev-parse HEAD`), so a retry at a new head naturally gets a fresh sentinel — see [Sentinel lifecycle](#sentinel-lifecycle). Here "fresh" means the reviewer's context is the neutral builder artifact + its angle, and explicitly NOT the main agent's conversation/state or a prior reviewer session's state: the injected neutral bundle is the intended seed (allowed), while main-agent / cross-session state bleed fails closed.
 - is seeded with the neutral context bundle verbatim (diff + `adjacentCode`) as its base, and widens (loads more files) only when its single angle genuinely needs more — it does not re-derive the whole diff/adjacent-code graph
 - is scoped to exactly one review angle
 - is **read-only**: inspects the diff and returns findings via output artifacts only; never edits files
@@ -126,15 +126,11 @@ The fresh-context sentinel (`tmp/checkpoint-context-sentinel-<scope>-<headSha>.j
 written by `verify-fresh-review-context.mjs`) is scoped **per review round**, keyed by
 the head SHA. This makes the lifecycle mechanical rather than a manual chore:
 
-- The round key defaults to the current HEAD; reviewers keep invoking the guard as
-  `--scope <angle>` and get head-keyed isolation for free. Pass `--round <headSha>` to pin
-  the round explicitly (e.g. the gate-context head SHA). A commit SHA (the auto default or a
-  short/full SHA passed via `--round`) is canonicalized to its full commit SHA, so auto and
-  pinned invocations for the same head resolve to one key — the same-head fail-closed guard
-  cannot be defeated by spelling the head differently. The `--round` token is validated with
-  the same alphanumeric+hyphen rule as `--scope` (keeping the sentinel filename path-safe), so
-  rev syntaxes like `HEAD~1`, `v1.0.0`, or `refs/tags/...` are rejected rather than accepted.
-  When git is unavailable the key falls back to scope-only (legacy behavior).
+- The round key is the current head SHA (`git rev-parse HEAD`); reviewers keep invoking the
+  guard as `--scope <angle>` and get head-keyed isolation for free — no flag to pass. `git
+  rev-parse HEAD` yields the same full SHA on every invocation for a given head, so the key is
+  deterministic and the same-head guard cannot be defeated by an inconsistent spelling. When
+  git is unavailable the key falls back to scope-only (legacy behavior).
 - **A retry at a new head is never blocked by a prior round's sentinel** — a new head SHA
   produces a new key, so a re-fan-out after a fix commit passes `fresh: true` with **no
   manual clear step**.

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -122,15 +122,19 @@ don't need re-review unless their angle's scope overlaps with the fix changes.
 
 #### Sentinel lifecycle
 
-The fresh-context sentinel (`tmp/checkpoint-context-sentinel-<scope>-<headSha>.json`,
-written by `verify-fresh-review-context.mjs`) is scoped **per review round**, keyed by
-the head SHA. This makes the lifecycle mechanical rather than a manual chore:
+The fresh-context sentinel, written by `verify-fresh-review-context.mjs`, is scoped **per
+review round**, keyed by the head SHA. This makes the lifecycle mechanical rather than a
+manual chore:
 
 - The round key is the current head SHA (`git rev-parse HEAD`); reviewers keep invoking the
   guard as `--scope <angle>` and get head-keyed isolation for free — no flag to pass. `git
   rev-parse HEAD` yields the same full SHA on every invocation for a given head, so the key is
-  deterministic and the same-head guard cannot be defeated by an inconsistent spelling. When
-  git is unavailable the key falls back to scope-only (legacy behavior).
+  deterministic and the same-head guard cannot be defeated by an inconsistent spelling. The
+  sentinel filename is therefore `tmp/checkpoint-context-sentinel-<scope>-<headSha>.json` in a
+  git worktree. When git is unavailable (non-git worktree, no commits), the head component is
+  omitted and the key falls back to the scope-only filename
+  `tmp/checkpoint-context-sentinel-<scope>.json` (legacy behavior) — there is no `-<headSha>`
+  file in that case.
 - **A retry at a new head is never blocked by a prior round's sentinel** — a new head SHA
   produces a new key, so a re-fan-out after a fix commit passes `fresh: true` with **no
   manual clear step**.

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -104,7 +104,7 @@ on an isolated checkout:
 
 Fan out one fresh-context reviewer per gate-specific review angle. The reviewer is the scoped `review` agent ([review agent scoped angle-review mode](../agents/review.agent.md)), spawned once per resolved angle via the plain Agent tool. Reviewers are **independent and seeded with the identical neutral context bundle verbatim** (Phase 1's diff + `adjacentCode`); they do NOT fork from, or inherit the loaded context of, the main agent or a sibling reviewer. Parallelism is capped at `gates.maxFanoutReviewers` (default 8); when the resolved angle set exceeds the cap, the overflow runs in sequential batches (planned by `planFanoutBatches` from `@dev-loops/core/loop/gate-fanin`) and the degradation is recorded in the gate evidence. Each reviewer:
 
-- starts in fresh context. **Mandatory:** run `scripts/github/verify-fresh-review-context.mjs --scope <angle>` at startup; refuse to proceed on contamination. Use `--scope` so parallel reviewers in the same working directory do not trigger false contamination from each other's sentinels. Here "fresh" means the reviewer's context is the neutral builder artifact + its angle, and explicitly NOT the main agent's conversation/state or a prior reviewer session's state: the injected neutral bundle is the intended seed (allowed), while main-agent / cross-session state bleed fails closed.
+- starts in fresh context. **Mandatory:** run `scripts/github/verify-fresh-review-context.mjs --scope <angle>` at startup; refuse to proceed on contamination. Use `--scope` so parallel reviewers in the same working directory do not trigger false contamination from each other's sentinels. The sentinel is keyed per review ROUND by the head SHA (auto-resolved from `git rev-parse --short HEAD`; pin explicitly with `--round <headSha>`), so a retry at a new head naturally gets a fresh sentinel — see [Sentinel lifecycle](#sentinel-lifecycle). Here "fresh" means the reviewer's context is the neutral builder artifact + its angle, and explicitly NOT the main agent's conversation/state or a prior reviewer session's state: the injected neutral bundle is the intended seed (allowed), while main-agent / cross-session state bleed fails closed.
 - is seeded with the neutral context bundle verbatim (diff + `adjacentCode`) as its base, and widens (loads more files) only when its single angle genuinely needs more — it does not re-derive the whole diff/adjacent-code graph
 - is scoped to exactly one review angle
 - is **read-only**: inspects the diff and returns findings via output artifacts only; never edits files
@@ -119,6 +119,29 @@ and explicitly record why parallel execution was impractical.
 **Re-run rule:** In subsequent retry cycles (Phase 5), only re-run reviewers that
 produced `findings_present` in the previous pass. Reviewers that returned `clean`
 don't need re-review unless their angle's scope overlaps with the fix changes.
+
+#### Sentinel lifecycle
+
+The fresh-context sentinel (`tmp/checkpoint-context-sentinel-<scope>-<headSha>.json`,
+written by `verify-fresh-review-context.mjs`) is scoped **per review round**, keyed by
+the head SHA. This makes the lifecycle mechanical rather than a manual chore:
+
+- The round key defaults to `git rev-parse --short HEAD`; reviewers keep invoking the
+  guard as `--scope <angle>` and get head-keyed isolation for free. Pass `--round <headSha>`
+  to pin the round explicitly (e.g. the gate-context head SHA). When git is unavailable the
+  key falls back to scope-only (legacy behavior).
+- **A retry at a new head is never blocked by a prior round's sentinel** — a new head SHA
+  produces a new key, so a re-fan-out after a fix commit passes `fresh: true` with **no
+  manual clear step**.
+- **Within one round the contamination guard is preserved:** a same-scope + same-head
+  re-entry still fails closed (`fresh: false`, exit 1) — that is genuine main-agent /
+  cross-session state bleed.
+- The orchestrator **MUST NOT** need to manually clear sentinels between rounds, and
+  **MUST NOT** clear the sentinels of carried-forward clean angles (Phase 5's re-run rule
+  only re-invokes angles that produced `findings_present`; their new-head keys are distinct,
+  so no cleanup is required).
+- Stale pre-round sentinels (the old scope-only name) never collide with a head-keyed round
+  and are simply ignored.
 
 ### Phase 3 — Consolidation: fan-in synthesis and disposition ledger
 

--- a/scripts/github/verify-fresh-review-context.mjs
+++ b/scripts/github/verify-fresh-review-context.mjs
@@ -18,11 +18,13 @@ neutral bundle (a path/prompt, not a sentinel) never creates a sentinel, so it
 never false-positives as contaminated.
 
 Sentinels are per review ROUND, keyed by the head SHA. The round defaults to
-the current \`git rev-parse --short HEAD\`, so a retry at a new head naturally
-gets a fresh sentinel (no manual clear step) while a same-scope + same-head
-re-entry still fails closed. Pass \`--round\` to pin the round explicitly (e.g.
-the gate-context head SHA); when git is unavailable the sentinel is keyed by
-scope only (legacy behavior).
+the current HEAD; any git rev (the auto default, or a short/full SHA passed via
+\`--round\`) is canonicalized to its full 40-char commit SHA, so every spelling
+of the same head maps to ONE key — a same-scope + same-head re-entry still fails
+closed regardless of how the head is spelled. A retry at a new head naturally
+gets a fresh sentinel (no manual clear step). A non-rev \`--round\` token is used
+verbatim; when git is unavailable the sentinel is keyed by scope only (legacy
+behavior).
 Options:
   --scope <name>  Unique reviewer scope (e.g. "draft-gate-coverage").
                   Must be non-empty, containing only alphanumeric
@@ -30,8 +32,11 @@ Options:
                   is scoped so parallel reviewers in the same working
                   directory do not trigger false contamination.
   --round <token> Review-round key (e.g. the head SHA). Alphanumeric and
-                  hyphens only. Defaults to \`git rev-parse --short HEAD\`;
-                  omitted from the key when unset and git is unavailable.
+                  hyphens only. Defaults to the current HEAD. A value that
+                  resolves as a git rev is canonicalized to its full commit SHA
+                  (length-stable across short/full/HEAD spellings); a non-rev
+                  token is used verbatim. Omitted from the key when unset and
+                  git is unavailable.
 Output (stdout, JSON):
   { "ok": true, "fresh": true, "sentinelCreated": true, "round": "<token|null>" }
   { "ok": true, "fresh": false, "sentinelCreated": false, "round": "...", "reason": "..." }
@@ -75,17 +80,26 @@ function resolveValidatedRound(argv) {
   }
   return raw;
 }
-function resolveHeadRound(cwd = process.cwd()) {
+// Canonicalize the round token to a length-stable key: resolve any git rev
+// (the auto default HEAD, or an explicit short/full SHA) to its full 40-char
+// commit SHA so every spelling of the same head maps to ONE sentinel key.
+// Otherwise a same-head re-entry spelled differently (auto vs a pinned --round
+// of another length) would get a distinct key and the contamination guard would
+// fail OPEN. A non-rev explicit token is used verbatim; auto without git => null
+// (legacy scope-only key).
+function resolveRoundKey(roundArg, cwd = process.cwd()) {
+  const rev = roundArg ?? "HEAD"; // null => auto-resolve the current head
   try {
-    const sha = execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+    const sha = execFileSync("git", ["rev-parse", "--verify", "--quiet", `${rev}^{commit}`], {
       cwd,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     }).trim();
-    return VALID_SCOPE_RE.test(sha) ? sha : null;
+    if (VALID_SCOPE_RE.test(sha)) return sha;
   } catch {
-    return null; // not a git repo / git unavailable: legacy scope-only key
+    // not a git rev / git unavailable
   }
+  return roundArg;
 }
 function sentinelRelative(scope, round) {
   const scopeSuffix = scope ? `-${scope}` : "";
@@ -120,7 +134,7 @@ async function main(argv = process.argv.slice(2)) {
   if (scope === undefined) return 2;
   const roundArg = resolveValidatedRound(argv);
   if (roundArg === undefined) return 2;
-  const round = roundArg === null ? resolveHeadRound() : roundArg;
+  const round = resolveRoundKey(roundArg);
   const sentinelPath = path.resolve(process.cwd(), sentinelRelative(scope, round));
   try {
     await mkdir(path.dirname(sentinelPath), { recursive: true });

--- a/scripts/github/verify-fresh-review-context.mjs
+++ b/scripts/github/verify-fresh-review-context.mjs
@@ -3,7 +3,7 @@ import { mkdir, stat, writeFile } from "node:fs/promises";
 import { execFileSync } from "node:child_process";
 import path from "node:path";
 import { buildParseError, isDirectCliRun, formatCliError } from "../_core-helpers.mjs";
-const USAGE = `Usage: verify-fresh-review-context.mjs [--help] [--scope <name>] [--round <token>]
+const USAGE = `Usage: verify-fresh-review-context.mjs [--help] [--scope <name>]
 Verify that the current scoped-reviewer session has fresh context.
 
 "Fresh" means the reviewer's context is the neutral gate-context builder
@@ -17,31 +17,18 @@ existing sentinel for the same round fails closed. Seeding a reviewer with the
 neutral bundle (a path/prompt, not a sentinel) never creates a sentinel, so it
 never false-positives as contaminated.
 
-Sentinels are per review ROUND, keyed by the head SHA. The round defaults to
-the current HEAD; a commit SHA (the auto default, or a short/full SHA passed via
-\`--round\`) is canonicalized to its full 40-char commit SHA, so every spelling
-of the same head maps to ONE key — a same-scope + same-head re-entry still fails
-closed regardless of how the head is spelled. A retry at a new head naturally
-gets a fresh sentinel (no manual clear step). An explicit \`--round\` token that
-does not resolve to a commit is used verbatim; when git is unavailable the
-sentinel is keyed by scope only (legacy behavior).
+Sentinels are per review ROUND, keyed by the current head SHA (\`git rev-parse
+HEAD\`). A retry at a new head naturally gets a fresh sentinel (no manual clear
+step), while a same-scope + same-head re-entry still fails closed. When git is
+unavailable the sentinel is keyed by scope only (legacy behavior).
 Options:
   --scope <name>  Unique reviewer scope (e.g. "draft-gate-coverage").
                   Must be non-empty, containing only alphanumeric
                   characters and hyphens. When provided, the sentinel
                   is scoped so parallel reviewers in the same working
                   directory do not trigger false contamination.
-  --round <token> Review-round key (e.g. the head SHA). Alphanumeric and
-                  hyphens only (same validator as --scope), so the token is
-                  path-safe; rev syntaxes with other characters (\`HEAD~1\`,
-                  \`v1.0.0\`, \`refs/tags/...\`) are rejected. Defaults to the
-                  current HEAD. A token that resolves to a commit (e.g. a short
-                  or full SHA) is canonicalized to its full commit SHA
-                  (length-stable across short/full spellings); a token that does
-                  not resolve is used verbatim. Omitted from the key when unset
-                  and git is unavailable.
 Output (stdout, JSON):
-  { "ok": true, "fresh": true, "sentinelCreated": true, "round": "<token|null>" }
+  { "ok": true, "fresh": true, "sentinelCreated": true, "round": "<headSha|null>" }
   { "ok": true, "fresh": false, "sentinelCreated": false, "round": "...", "reason": "..." }
   On error (stderr, JSON):
   { "ok": false, "error": "...", "usage": "..." }
@@ -51,8 +38,8 @@ Exit codes:
   2  Usage or internal error`.trim();
 const VALID_SCOPE_RE = /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
 const parseError = buildParseError(USAGE);
-function resolveFlag(argv, flag) {
-  const idx = argv.indexOf(flag);
+function resolveScope(argv) {
+  const idx = argv.indexOf("--scope");
   if (idx === -1) return null;
   const val = argv[idx + 1];
   if (val === undefined || val === "" || (val.length > 0 && val[0] === "-")) {
@@ -61,7 +48,7 @@ function resolveFlag(argv, flag) {
   return val;
 }
 function resolveValidatedScope(argv) {
-  const raw = resolveFlag(argv, "--scope");
+  const raw = resolveScope(argv);
   if (raw === null) return null;
   if (raw === "" || !VALID_SCOPE_RE.test(raw)) {
     process.stderr.write(`${formatCliError(
@@ -71,38 +58,22 @@ function resolveValidatedScope(argv) {
   }
   return raw;
 }
-// null => auto-resolve from git HEAD; undefined => invalid; string => explicit round
-function resolveValidatedRound(argv) {
-  const raw = resolveFlag(argv, "--round");
-  if (raw === null) return null;
-  if (raw === "" || !VALID_SCOPE_RE.test(raw)) {
-    process.stderr.write(`${formatCliError(
-      parseError(`Invalid --round value "${raw}": must be non-empty and contain only alphanumeric characters and hyphens.`)
-    )}\n`);
-    return undefined; // signals invalid
-  }
-  return raw;
-}
-// Canonicalize the round token to a length-stable key: resolve any git rev
-// (the auto default HEAD, or an explicit short/full SHA) to its full 40-char
-// commit SHA so every spelling of the same head maps to ONE sentinel key.
-// Otherwise a same-head re-entry spelled differently (auto vs a pinned --round
-// of another length) would get a distinct key and the contamination guard would
-// fail OPEN. A non-rev explicit token is used verbatim; auto without git => null
-// (legacy scope-only key).
-function resolveRoundKey(roundArg, cwd = process.cwd()) {
-  const rev = roundArg ?? "HEAD"; // null => auto-resolve the current head
+// Round = the current head SHA, so a retry on a new head gets a fresh key while
+// a same-head re-entry collides and fails closed. `git rev-parse HEAD` yields the
+// same full SHA on every invocation for a given head, so the key is deterministic
+// with no user input to spell it inconsistently. Returns null when git is
+// unavailable (falls back to the legacy scope-only key).
+function resolveHeadRound(cwd = process.cwd()) {
   try {
-    const sha = execFileSync("git", ["rev-parse", "--verify", "--quiet", `${rev}^{commit}`], {
+    const sha = execFileSync("git", ["rev-parse", "HEAD"], {
       cwd,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     }).trim();
-    if (VALID_SCOPE_RE.test(sha)) return sha;
+    return VALID_SCOPE_RE.test(sha) ? sha : null;
   } catch {
-    // not a git rev / git unavailable
+    return null; // not a git repo / git unavailable
   }
-  return roundArg;
 }
 function sentinelRelative(scope, round) {
   const scopeSuffix = scope ? `-${scope}` : "";
@@ -135,9 +106,7 @@ async function main(argv = process.argv.slice(2)) {
   }
   const scope = resolveValidatedScope(argv);
   if (scope === undefined) return 2;
-  const roundArg = resolveValidatedRound(argv);
-  if (roundArg === undefined) return 2;
-  const round = resolveRoundKey(roundArg);
+  const round = resolveHeadRound();
   const sentinelPath = path.resolve(process.cwd(), sentinelRelative(scope, round));
   try {
     await mkdir(path.dirname(sentinelPath), { recursive: true });

--- a/scripts/github/verify-fresh-review-context.mjs
+++ b/scripts/github/verify-fresh-review-context.mjs
@@ -18,13 +18,13 @@ neutral bundle (a path/prompt, not a sentinel) never creates a sentinel, so it
 never false-positives as contaminated.
 
 Sentinels are per review ROUND, keyed by the head SHA. The round defaults to
-the current HEAD; any git rev (the auto default, or a short/full SHA passed via
+the current HEAD; a commit SHA (the auto default, or a short/full SHA passed via
 \`--round\`) is canonicalized to its full 40-char commit SHA, so every spelling
 of the same head maps to ONE key — a same-scope + same-head re-entry still fails
 closed regardless of how the head is spelled. A retry at a new head naturally
-gets a fresh sentinel (no manual clear step). A non-rev \`--round\` token is used
-verbatim; when git is unavailable the sentinel is keyed by scope only (legacy
-behavior).
+gets a fresh sentinel (no manual clear step). An explicit \`--round\` token that
+does not resolve to a commit is used verbatim; when git is unavailable the
+sentinel is keyed by scope only (legacy behavior).
 Options:
   --scope <name>  Unique reviewer scope (e.g. "draft-gate-coverage").
                   Must be non-empty, containing only alphanumeric
@@ -32,11 +32,14 @@ Options:
                   is scoped so parallel reviewers in the same working
                   directory do not trigger false contamination.
   --round <token> Review-round key (e.g. the head SHA). Alphanumeric and
-                  hyphens only. Defaults to the current HEAD. A value that
-                  resolves as a git rev is canonicalized to its full commit SHA
-                  (length-stable across short/full/HEAD spellings); a non-rev
-                  token is used verbatim. Omitted from the key when unset and
-                  git is unavailable.
+                  hyphens only (same validator as --scope), so the token is
+                  path-safe; rev syntaxes with other characters (\`HEAD~1\`,
+                  \`v1.0.0\`, \`refs/tags/...\`) are rejected. Defaults to the
+                  current HEAD. A token that resolves to a commit (e.g. a short
+                  or full SHA) is canonicalized to its full commit SHA
+                  (length-stable across short/full spellings); a token that does
+                  not resolve is used verbatim. Omitted from the key when unset
+                  and git is unavailable.
 Output (stdout, JSON):
   { "ok": true, "fresh": true, "sentinelCreated": true, "round": "<token|null>" }
   { "ok": true, "fresh": false, "sentinelCreated": false, "round": "...", "reason": "..." }

--- a/scripts/github/verify-fresh-review-context.mjs
+++ b/scripts/github/verify-fresh-review-context.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import { mkdir, stat, writeFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
 import path from "node:path";
 import { buildParseError, isDirectCliRun, formatCliError } from "../_core-helpers.mjs";
-const USAGE = `Usage: verify-fresh-review-context.mjs [--help] [--scope <name>]
+const USAGE = `Usage: verify-fresh-review-context.mjs [--help] [--scope <name>] [--round <token>]
 Verify that the current scoped-reviewer session has fresh context.
 
 "Fresh" means the reviewer's context is the neutral gate-context builder
@@ -10,20 +11,30 @@ artifact (the build-once diff + adjacent-code bundle) plus its single review
 angle, and explicitly NOT the main (orchestrating) agent's conversation/state
 or a prior reviewer session's state. The injected neutral bundle is the
 INTENDED seed and is NOT contamination; this guard detects main-agent /
-cross-session state bleed by way of a per-(cwd, scope) sentinel: a first run in
-a fresh session creates the sentinel and passes, a re-entry that finds an
-existing sentinel fails closed. Seeding a reviewer with the neutral bundle (a
-path/prompt, not a sentinel) never creates a sentinel, so it never
-false-positives as contaminated.
+cross-session state bleed by way of a per-(cwd, scope, round) sentinel: a first
+run in a fresh session creates the sentinel and passes, a re-entry that finds an
+existing sentinel for the same round fails closed. Seeding a reviewer with the
+neutral bundle (a path/prompt, not a sentinel) never creates a sentinel, so it
+never false-positives as contaminated.
+
+Sentinels are per review ROUND, keyed by the head SHA. The round defaults to
+the current \`git rev-parse --short HEAD\`, so a retry at a new head naturally
+gets a fresh sentinel (no manual clear step) while a same-scope + same-head
+re-entry still fails closed. Pass \`--round\` to pin the round explicitly (e.g.
+the gate-context head SHA); when git is unavailable the sentinel is keyed by
+scope only (legacy behavior).
 Options:
   --scope <name>  Unique reviewer scope (e.g. "draft-gate-coverage").
                   Must be non-empty, containing only alphanumeric
                   characters and hyphens. When provided, the sentinel
                   is scoped so parallel reviewers in the same working
                   directory do not trigger false contamination.
+  --round <token> Review-round key (e.g. the head SHA). Alphanumeric and
+                  hyphens only. Defaults to \`git rev-parse --short HEAD\`;
+                  omitted from the key when unset and git is unavailable.
 Output (stdout, JSON):
-  { "ok": true, "fresh": true, "sentinelCreated": true }
-  { "ok": true, "fresh": false, "sentinelCreated": false, "reason": "..." }
+  { "ok": true, "fresh": true, "sentinelCreated": true, "round": "<token|null>" }
+  { "ok": true, "fresh": false, "sentinelCreated": false, "round": "...", "reason": "..." }
   On error (stderr, JSON):
   { "ok": false, "error": "...", "usage": "..." }
 Exit codes:
@@ -32,8 +43,8 @@ Exit codes:
   2  Usage or internal error`.trim();
 const VALID_SCOPE_RE = /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
 const parseError = buildParseError(USAGE);
-function resolveScope(argv) {
-  const idx = argv.indexOf("--scope");
+function resolveFlag(argv, flag) {
+  const idx = argv.indexOf(flag);
   if (idx === -1) return null;
   const val = argv[idx + 1];
   if (val === undefined || val === "" || (val.length > 0 && val[0] === "-")) {
@@ -42,7 +53,7 @@ function resolveScope(argv) {
   return val;
 }
 function resolveValidatedScope(argv) {
-  const raw = resolveScope(argv);
+  const raw = resolveFlag(argv, "--scope");
   if (raw === null) return null;
   if (raw === "" || !VALID_SCOPE_RE.test(raw)) {
     process.stderr.write(`${formatCliError(
@@ -52,22 +63,51 @@ function resolveValidatedScope(argv) {
   }
   return raw;
 }
-function sentinelRelative(scope) {
-  const suffix = scope ? `-${scope}` : "";
-  return path.join("tmp", `checkpoint-context-sentinel${suffix}.json`);
+// null => auto-resolve from git HEAD; undefined => invalid; string => explicit round
+function resolveValidatedRound(argv) {
+  const raw = resolveFlag(argv, "--round");
+  if (raw === null) return null;
+  if (raw === "" || !VALID_SCOPE_RE.test(raw)) {
+    process.stderr.write(`${formatCliError(
+      parseError(`Invalid --round value "${raw}": must be non-empty and contain only alphanumeric characters and hyphens.`)
+    )}\n`);
+    return undefined; // signals invalid
+  }
+  return raw;
+}
+function resolveHeadRound(cwd = process.cwd()) {
+  try {
+    const sha = execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return VALID_SCOPE_RE.test(sha) ? sha : null;
+  } catch {
+    return null; // not a git repo / git unavailable: legacy scope-only key
+  }
+}
+function sentinelRelative(scope, round) {
+  const scopeSuffix = scope ? `-${scope}` : "";
+  const roundSuffix = round ? `-${round}` : "";
+  return path.join("tmp", `checkpoint-context-sentinel${scopeSuffix}${roundSuffix}.json`);
 }
 function legacySentinelRelative(scope) {
   const suffix = scope ? `-${scope}` : "";
   return path.join("tmp", `gate-review-context-sentinel${suffix}.json`);
 }
-async function checkSentinelExists(scope, cwd = process.cwd()) {
-  const sentinelPath = path.resolve(cwd, sentinelRelative(scope));
+async function checkSentinelExists(scope, round, cwd = process.cwd()) {
+  const sentinelPath = path.resolve(cwd, sentinelRelative(scope, round));
   try { await stat(sentinelPath); return { exists: true, path: sentinelPath, legacy: false }; } catch (err) {
     if (err.code !== "ENOENT") throw err;
   }
-  const legacyPath = path.resolve(cwd, legacySentinelRelative(scope));
-  try { await stat(legacyPath); return { exists: true, path: legacyPath, legacy: true }; } catch (err) {
-    if (err.code !== "ENOENT") throw err;
+  // Legacy names predate head-keyed rounds; only consult them for the
+  // scope-only key so a stale pre-round sentinel never blocks a new round.
+  if (!round) {
+    const legacyPath = path.resolve(cwd, legacySentinelRelative(scope));
+    try { await stat(legacyPath); return { exists: true, path: legacyPath, legacy: true }; } catch (err) {
+      if (err.code !== "ENOENT") throw err;
+    }
   }
   return { exists: false, path: sentinelPath, legacy: false };
 }
@@ -78,19 +118,23 @@ async function main(argv = process.argv.slice(2)) {
   }
   const scope = resolveValidatedScope(argv);
   if (scope === undefined) return 2;
-  const sentinelPath = path.resolve(process.cwd(), sentinelRelative(scope));
+  const roundArg = resolveValidatedRound(argv);
+  if (roundArg === undefined) return 2;
+  const round = roundArg === null ? resolveHeadRound() : roundArg;
+  const sentinelPath = path.resolve(process.cwd(), sentinelRelative(scope, round));
   try {
     await mkdir(path.dirname(sentinelPath), { recursive: true });
   } catch (err) {
     process.stderr.write(`${formatCliError(err)}\n`);
     return 2;
   }
-  const existing = await checkSentinelExists(scope);
+  const existing = await checkSentinelExists(scope, round);
   if (existing.exists) {
     process.stdout.write(JSON.stringify({
       ok: true,
       fresh: false,
       sentinelCreated: false,
+      round: round ?? null,
       reason: `Checkpoint context sentinel already exists${existing.legacy ? " (legacy name)" : ""} — inherited session context detected. Restart the subagent with fresh context (subagent({context:\"fresh\"})).`,
     }) + "\n");
     return 1;
@@ -99,6 +143,7 @@ async function main(argv = process.argv.slice(2)) {
     createdAt: new Date().toISOString(),
     pid: process.pid,
     ...(scope ? { scope } : {}),
+    ...(round ? { round } : {}),
   };
   try {
     await writeFile(sentinelPath, JSON.stringify(sentinel, null, 2) + "\n", {
@@ -111,6 +156,7 @@ async function main(argv = process.argv.slice(2)) {
         ok: true,
         fresh: false,
         sentinelCreated: false,
+        round: round ?? null,
         reason: "Checkpoint context sentinel already exists (detected on atomic create) — inherited session context detected. Restart the subagent with fresh context (subagent({context:\"fresh\"})).",
       }) + "\n");
       return 1;
@@ -122,6 +168,7 @@ async function main(argv = process.argv.slice(2)) {
     ok: true,
     fresh: true,
     sentinelCreated: true,
+    round: round ?? null,
   }) + "\n");
   return 0;
 }

--- a/test/github/verify-fresh-review-context.test.mjs
+++ b/test/github/verify-fresh-review-context.test.mjs
@@ -204,3 +204,104 @@ test("verify-fresh-review-context --scope with missing value fails closed", asyn
     await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
   }
 });
+
+// ---------------------------------------------------------------------------
+// Head-keyed review rounds (#1095, closes #1108): sentinels are per review
+// ROUND (keyed by head SHA). A retry at a NEW head/round gets a fresh sentinel
+// with no manual clear step; same scope + same round still fails closed.
+// ---------------------------------------------------------------------------
+
+test("--round: same scope on a DIFFERENT round passes fresh (retry not blocked)", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
+  try {
+    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
+
+    const r1 = runScript(["--scope", "correctness", "--round", "abc1234"], { cwd: tmpDir });
+    assert.equal(r1.status, 0, r1.stderr);
+    assert.equal(JSON.parse(r1.stdout.trim()).fresh, true);
+
+    // A new head/round for the same scope must NOT collide with round 1.
+    const r2 = runScript(["--scope", "correctness", "--round", "def5678"], { cwd: tmpDir });
+    assert.equal(r2.status, 0, r2.stderr);
+    const out2 = JSON.parse(r2.stdout.trim());
+    assert.equal(out2.fresh, true);
+    assert.equal(out2.round, "def5678");
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test("--round: same scope + same round still fails closed (contamination guard intact)", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
+  try {
+    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
+
+    const r1 = runScript(["--scope", "correctness", "--round", "abc1234"], { cwd: tmpDir });
+    assert.equal(r1.status, 0, r1.stderr);
+    assert.equal(JSON.parse(r1.stdout.trim()).fresh, true);
+
+    const r2 = runScript(["--scope", "correctness", "--round", "abc1234"], { cwd: tmpDir });
+    assert.equal(r2.status, 1, r2.stderr);
+    assert.equal(JSON.parse(r2.stdout.trim()).fresh, false);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test("--round: a stale pre-round (scope-only) sentinel does NOT block a new round", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
+  try {
+    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
+    // Old-format sentinel from before head-keying — must not collide with a round.
+    await writeFile(
+      path.join(tmpDir, "tmp", "checkpoint-context-sentinel-correctness.json"),
+      JSON.stringify({ createdAt: "2026-01-01T00:00:00.000Z", pid: 1, scope: "correctness" }) + "\n",
+      "utf8"
+    );
+    const result = runScript(["--scope", "correctness", "--round", "abc1234"], { cwd: tmpDir });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout.trim()).fresh, true);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test("--round rejects values with slashes (path-traversal guard)", async () => {
+  const result = runScript(["--scope", "correctness", "--round", "../../etc"]);
+  assert.equal(result.status, 2, result.stderr);
+});
+
+test("auto round: same scope across commits passes on each new head, fails closed on same head", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
+  const git = (args) => {
+    const r = spawnSync("git", args, { cwd: tmpDir, encoding: "utf8" });
+    assert.equal(r.status, 0, r.stderr);
+  };
+  try {
+    git(["init", "-q"]);
+    git(["config", "user.email", "t@t.dev"]);
+    git(["config", "user.name", "t"]);
+    await writeFile(path.join(tmpDir, "a.txt"), "1", "utf8");
+    git(["add", "-A"]);
+    git(["commit", "-qm", "c1"]);
+    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
+
+    // Round auto-resolves to HEAD; first run fresh.
+    const r1 = runScript(["--scope", "correctness"], { cwd: tmpDir });
+    assert.equal(r1.status, 0, r1.stderr);
+    assert.equal(JSON.parse(r1.stdout.trim()).fresh, true);
+
+    // Same head, same scope → contamination fail-closed.
+    const r1b = runScript(["--scope", "correctness"], { cwd: tmpDir });
+    assert.equal(r1b.status, 1, r1b.stderr);
+
+    // New commit → new head → fresh again, no manual clear.
+    await writeFile(path.join(tmpDir, "a.txt"), "2", "utf8");
+    git(["commit", "-qam", "c2"]);
+    const r2 = runScript(["--scope", "correctness"], { cwd: tmpDir });
+    assert.equal(r2.status, 0, r2.stderr);
+    assert.equal(JSON.parse(r2.stdout.trim()).fresh, true);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+});

--- a/test/github/verify-fresh-review-context.test.mjs
+++ b/test/github/verify-fresh-review-context.test.mjs
@@ -273,8 +273,11 @@ test("--round rejects values with slashes (path-traversal guard)", async () => {
 
 test("auto round: same scope across commits passes on each new head, fails closed on same head", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
+  // Scrub inherited global/system git config so commit signing, hooks, or
+  // templates on the host cannot make this test flaky (determinism review).
+  const gitEnv = { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null" };
   const git = (args) => {
-    const r = spawnSync("git", args, { cwd: tmpDir, encoding: "utf8" });
+    const r = spawnSync("git", args, { cwd: tmpDir, encoding: "utf8", env: gitEnv });
     assert.equal(r.status, 0, r.stderr);
   };
   try {
@@ -301,6 +304,38 @@ test("auto round: same scope across commits passes on each new head, fails close
     const r2 = runScript(["--scope", "correctness"], { cwd: tmpDir });
     assert.equal(r2.status, 0, r2.stderr);
     assert.equal(JSON.parse(r2.stdout.trim()).fresh, true);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test("round canonicalization: auto and an explicit short-SHA --round for the SAME head share one key (no fail-open)", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
+  const gitEnv = { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null" };
+  const git = (args) => {
+    const r = spawnSync("git", args, { cwd: tmpDir, encoding: "utf8", env: gitEnv });
+    assert.equal(r.status, 0, r.stderr);
+    return r;
+  };
+  try {
+    git(["init", "-q"]);
+    git(["config", "user.email", "t@t.dev"]);
+    git(["config", "user.name", "t"]);
+    await writeFile(path.join(tmpDir, "a.txt"), "1", "utf8");
+    git(["add", "-A"]);
+    git(["commit", "-qm", "c1"]);
+    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
+    const shortSha = git(["rev-parse", "--short", "HEAD"]).stdout.trim();
+
+    // First reviewer pins the round with an abbreviated SHA...
+    const r1 = runScript(["--scope", "correctness", "--round", shortSha], { cwd: tmpDir });
+    assert.equal(r1.status, 0, r1.stderr);
+
+    // ...a same-head re-entry that auto-resolves (different spelling) must STILL
+    // fail closed — both canonicalize to the full commit SHA (one key).
+    const r2 = runScript(["--scope", "correctness"], { cwd: tmpDir });
+    assert.equal(r2.status, 1, r2.stderr);
+    assert.equal(JSON.parse(r2.stdout.trim()).fresh, false);
   } finally {
     await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
   }

--- a/test/github/verify-fresh-review-context.test.mjs
+++ b/test/github/verify-fresh-review-context.test.mjs
@@ -207,79 +207,25 @@ test("verify-fresh-review-context --scope with missing value fails closed", asyn
 
 // ---------------------------------------------------------------------------
 // Head-keyed review rounds (#1095, closes #1108): sentinels are per review
-// ROUND (keyed by head SHA). A retry at a NEW head/round gets a fresh sentinel
-// with no manual clear step; same scope + same round still fails closed.
+// ROUND, keyed by the current head SHA (git rev-parse HEAD). A retry at a new
+// head gets a fresh sentinel with no manual clear; a same-head re-entry still
+// fails closed. When git is unavailable the key falls back to scope-only.
 // ---------------------------------------------------------------------------
 
-test("--round: same scope on a DIFFERENT round passes fresh (retry not blocked)", async () => {
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
-  try {
-    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
-
-    const r1 = runScript(["--scope", "correctness", "--round", "abc1234"], { cwd: tmpDir });
-    assert.equal(r1.status, 0, r1.stderr);
-    assert.equal(JSON.parse(r1.stdout.trim()).fresh, true);
-
-    // A new head/round for the same scope must NOT collide with round 1.
-    const r2 = runScript(["--scope", "correctness", "--round", "def5678"], { cwd: tmpDir });
-    assert.equal(r2.status, 0, r2.stderr);
-    const out2 = JSON.parse(r2.stdout.trim());
-    assert.equal(out2.fresh, true);
-    assert.equal(out2.round, "def5678");
-  } finally {
-    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-  }
-});
-
-test("--round: same scope + same round still fails closed (contamination guard intact)", async () => {
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
-  try {
-    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
-
-    const r1 = runScript(["--scope", "correctness", "--round", "abc1234"], { cwd: tmpDir });
-    assert.equal(r1.status, 0, r1.stderr);
-    assert.equal(JSON.parse(r1.stdout.trim()).fresh, true);
-
-    const r2 = runScript(["--scope", "correctness", "--round", "abc1234"], { cwd: tmpDir });
-    assert.equal(r2.status, 1, r2.stderr);
-    assert.equal(JSON.parse(r2.stdout.trim()).fresh, false);
-  } finally {
-    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-  }
-});
-
-test("--round: a stale pre-round (scope-only) sentinel does NOT block a new round", async () => {
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
-  try {
-    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
-    // Old-format sentinel from before head-keying — must not collide with a round.
-    await writeFile(
-      path.join(tmpDir, "tmp", "checkpoint-context-sentinel-correctness.json"),
-      JSON.stringify({ createdAt: "2026-01-01T00:00:00.000Z", pid: 1, scope: "correctness" }) + "\n",
-      "utf8"
-    );
-    const result = runScript(["--scope", "correctness", "--round", "abc1234"], { cwd: tmpDir });
-    assert.equal(result.status, 0, result.stderr);
-    assert.equal(JSON.parse(result.stdout.trim()).fresh, true);
-  } finally {
-    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-  }
-});
-
-test("--round rejects values with slashes (path-traversal guard)", async () => {
-  const result = runScript(["--scope", "correctness", "--round", "../../etc"]);
-  assert.equal(result.status, 2, result.stderr);
-});
-
-test("auto round: same scope across commits passes on each new head, fails closed on same head", async () => {
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
+function makeGit(tmpDir) {
   // Scrub inherited global/system git config so commit signing, hooks, or
-  // templates on the host cannot make this test flaky (determinism review).
+  // templates on the host cannot make these tests flaky (determinism review).
   const gitEnv = { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null" };
-  const git = (args) => {
+  return (args) => {
     const r = spawnSync("git", args, { cwd: tmpDir, encoding: "utf8", env: gitEnv });
     assert.equal(r.status, 0, r.stderr);
+    return r;
   };
+}
+
+test("head round: same scope across commits passes on each new head, fails closed on same head", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
+  const git = makeGit(tmpDir);
   try {
     git(["init", "-q"]);
     git(["config", "user.email", "t@t.dev"]);
@@ -289,16 +235,19 @@ test("auto round: same scope across commits passes on each new head, fails close
     git(["commit", "-qm", "c1"]);
     await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
 
-    // Round auto-resolves to HEAD; first run fresh.
+    // Round auto-resolves to HEAD; first run fresh, keyed by the full head SHA.
     const r1 = runScript(["--scope", "correctness"], { cwd: tmpDir });
     assert.equal(r1.status, 0, r1.stderr);
-    assert.equal(JSON.parse(r1.stdout.trim()).fresh, true);
+    const out1 = JSON.parse(r1.stdout.trim());
+    assert.equal(out1.fresh, true);
+    assert.equal(out1.round, git(["rev-parse", "HEAD"]).stdout.trim());
 
-    // Same head, same scope → contamination fail-closed.
+    // Same head, same scope -> contamination fail-closed.
     const r1b = runScript(["--scope", "correctness"], { cwd: tmpDir });
     assert.equal(r1b.status, 1, r1b.stderr);
+    assert.equal(JSON.parse(r1b.stdout.trim()).fresh, false);
 
-    // New commit → new head → fresh again, no manual clear.
+    // New commit -> new head -> fresh again, no manual clear step.
     await writeFile(path.join(tmpDir, "a.txt"), "2", "utf8");
     git(["commit", "-qam", "c2"]);
     const r2 = runScript(["--scope", "correctness"], { cwd: tmpDir });
@@ -309,14 +258,9 @@ test("auto round: same scope across commits passes on each new head, fails close
   }
 });
 
-test("round canonicalization: auto and an explicit short-SHA --round for the SAME head share one key (no fail-open)", async () => {
+test("head round: a stale pre-round (scope-only) sentinel does NOT block a new head (#1108)", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
-  const gitEnv = { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null" };
-  const git = (args) => {
-    const r = spawnSync("git", args, { cwd: tmpDir, encoding: "utf8", env: gitEnv });
-    assert.equal(r.status, 0, r.stderr);
-    return r;
-  };
+  const git = makeGit(tmpDir);
   try {
     git(["init", "-q"]);
     git(["config", "user.email", "t@t.dev"]);
@@ -325,17 +269,16 @@ test("round canonicalization: auto and an explicit short-SHA --round for the SAM
     git(["add", "-A"]);
     git(["commit", "-qm", "c1"]);
     await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
-    const shortSha = git(["rev-parse", "--short", "HEAD"]).stdout.trim();
-
-    // First reviewer pins the round with an abbreviated SHA...
-    const r1 = runScript(["--scope", "correctness", "--round", shortSha], { cwd: tmpDir });
-    assert.equal(r1.status, 0, r1.stderr);
-
-    // ...a same-head re-entry that auto-resolves (different spelling) must STILL
-    // fail closed — both canonicalize to the full commit SHA (one key).
-    const r2 = runScript(["--scope", "correctness"], { cwd: tmpDir });
-    assert.equal(r2.status, 1, r2.stderr);
-    assert.equal(JSON.parse(r2.stdout.trim()).fresh, false);
+    // Old-format sentinel from before head-keying — must not collide with the
+    // head-keyed round (the #1108 stale-sentinel false positive).
+    await writeFile(
+      path.join(tmpDir, "tmp", "checkpoint-context-sentinel-correctness.json"),
+      JSON.stringify({ createdAt: "2026-01-01T00:00:00.000Z", pid: 1, scope: "correctness" }) + "\n",
+      "utf8"
+    );
+    const result = runScript(["--scope", "correctness"], { cwd: tmpDir });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout.trim()).fresh, true);
   } finally {
     await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
   }


### PR DESCRIPTION
## What & why

Retry-gate reviewers fail closed on stale per-(cwd, scope) fresh-context sentinels (`tmp/checkpoint-context-sentinel-<scope>.json`, written by `scripts/github/verify-fresh-review-context.mjs`). After a fix commit the retry rule re-invokes reviewers, but the round-1 sentinel is still present, so every retry reviewer refuses — and no contract said who clears them or when. Recurring, confirmed friction that has blocked re-fan-outs on every gate.

Fix (issue #1095 chosen approach, option a — mechanical): the sentinel is now keyed **per review ROUND by the current head SHA** — `tmp/checkpoint-context-sentinel-<scope>-<headSha>.json`, resolved from `git rev-parse HEAD`. Reviewers keep invoking the guard exactly as `--scope <angle>` (contract unchanged) and gain head-keyed isolation for free — no new flag. `git rev-parse HEAD` returns the same full SHA on every invocation for a given head, so the key is deterministic and the same-head guard cannot be defeated by an inconsistent spelling. A new head never collides with a prior round's sentinel, removing the manual clear step entirely — while a same-scope + same-head re-entry still fails closed (the real main-agent / cross-session contamination guard is preserved). When git is unavailable it falls back to the legacy scope-only key.

Scope note: an explicit `--round <headSha>` override was prototyped and then dropped during the gate (YAGNI — no committed caller, and it was the only thing that introduced a same-head fail-open needing extra canonicalization). Auto-HEAD keying alone delivers the issue's outcome; a pinning flag can be added later if a real caller needs it.

Closes #1095
Closes #1108 — #1108 reports the same root cause (sentinels never cleaned up → false-positive contamination blocks re-runs). The head-keyed sentinel means stale sentinels never collide with a new round, so the cleanup concern is fully covered: old-format scope-only sentinels are ignored, and each new head gets a distinct key.

## Acceptance criteria

| AC | Where | Status |
|---|---|---|
| Retry reviewer at a new head is not blocked by the prior round's sentinel (no manual clear) | `verify-fresh-review-context.mjs` head-SHA round keying (`resolveHeadRound`) | done |
| Same scope + same head still fails closed (contamination guard intact) | same-head re-entry returns `fresh:false` exit 1 | done |
| Sentinel lifecycle documented | `docs/gate-review-sub-loop-contract.md` -> "Sentinel lifecycle" | done |
| Unit coverage for both branches (new head passes; same head fails closed) | `test/github/verify-fresh-review-context.test.mjs` (+2 head-round tests: real-git new-head/same-head e2e, and stale pre-round sentinel non-collision for #1108) | done |

## Definition of done

- `npm run verify` green locally.
- Additive/no-op across harnesses (Pi + Claude Code): reviewer invocation `--scope <angle>` is unchanged; only the sentinel filename gains a `-<headSha>` component.
- One-commit revertable (local `tmp/` state only).

## Non-goals

| Out of scope | Why |
|---|---|
| Contamination-detection semantics within one round | Per-scope fail-closed within a round stays exactly as-is |
| Reviewer prompts / gate dispatch logic | Unchanged |
| Explicit `--round` pin flag | No committed caller; auto-HEAD keying meets the requirement (dropped during review per YAGNI) |
| Cleanup hook / TTL staleness (#1108 options 2/3) | Head-keying (option 1) fully resolves the collision deterministically; belt-and-suspenders not needed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019R41gz5zfhq4dwGATzQx4m
