### PR TITLE
fix(loop): body-mention cross-references treated as board-ownership links → sibling issues dragged to In Progress

### DIFF
--- a/scripts/github/detect-linked-issue-pr.mjs
+++ b/scripts/github/detect-linked-issue-pr.mjs
@@ -28,6 +28,7 @@ export const LINKED_ISSUE_PR_QUERY = [
   "          }",
   "          ... on CrossReferencedEvent {",
   "            createdAt",
+  "            willCloseTarget",
   "            source {",
   "              __typename",
   "              ... on PullRequest {",
@@ -162,6 +163,13 @@ function normalizeLinkedPrNode(node) {
     };
   }
   if (node.__typename === "CrossReferencedEvent") {
+    // Only a cross-reference that will CLOSE this issue owns its board status.
+    // A bare body-mention (willCloseTarget:false, e.g. "part of #X") must not
+    // create board-ownership linkage — otherwise every sibling a PR mentions
+    // gets dragged to In Progress and the resolver fails closed (#1130).
+    if (node.willCloseTarget !== true) {
+      return null;
+    }
     return {
       eventType: "CROSS_REFERENCED_EVENT",
       eventCreatedAt: node.createdAt,

--- a/test/github/detect-linked-issue-pr.test.mjs
+++ b/test/github/detect-linked-issue-pr.test.mjs
@@ -46,10 +46,11 @@ function connectedNode({ createdAt, number, state = "OPEN", repo = "owner/repo",
   };
 }
 
-function crossNode({ createdAt, number, state = "OPEN", repo = "owner/repo", url }) {
+function crossNode({ createdAt, number, state = "OPEN", repo = "owner/repo", url, willCloseTarget = false }) {
   return {
     __typename: "CrossReferencedEvent",
     createdAt,
+    willCloseTarget,
     source: {
       __typename: "PullRequest",
       number,
@@ -455,4 +456,118 @@ test("runNode rejects deterministically when the child process cannot spawn", as
     runNode(["--help"], { execPath: path.join(os.tmpdir(), "missing-node-binary") }),
     /ENOENT/,
   );
+});
+
+
+// --- #1130: body-mention cross-references are not board-ownership links ---
+// A CrossReferencedEvent fires on ANY body mention of the issue ("part of #X").
+// Only a reference that will CLOSE the issue (willCloseTarget) may own its board
+// status; a bare mention must NOT be reported as a linked open PR. (Subsumes the
+// missing gatherLiveFacts bridge coverage tracked by #1124.)
+
+test("detect-linked-issue-pr: body-mention-only cross-reference (willCloseTarget:false) is not a linked PR", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-linked-pr-mention-only-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "graphql", "-F", "issue=85", "owner=owner", "name=repo"],
+        stdout: graphqlPayload({
+          hasNextPage: false,
+          endCursor: null,
+          nodes: [
+            // Open same-repo PR that merely body-mentions this issue.
+            crossNode({ createdAt: "2026-05-12T10:00:00Z", number: 128, willCloseTarget: false }),
+          ],
+        }),
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--issue", "85"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      repo: "owner/repo",
+      issue: 85,
+      hasOpenLinkedPr: false,
+      prNumber: null,
+      prUrl: null,
+      hasPriorClosedUnmergedPr: false,
+      priorClosedUnmergedPrNumber: null,
+      priorClosedUnmergedPrUrl: null,
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-linked-issue-pr: cross-reference with willCloseTarget:true is a linked PR", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-linked-pr-closing-xref-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "graphql", "-F", "issue=85", "owner=owner", "name=repo"],
+        stdout: graphqlPayload({
+          hasNextPage: false,
+          endCursor: null,
+          nodes: [
+            crossNode({ createdAt: "2026-05-12T10:00:00Z", number: 90, willCloseTarget: true }),
+          ],
+        }),
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--issue", "85"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: true,
+      repo: "owner/repo",
+      issue: 85,
+      hasOpenLinkedPr: true,
+      prNumber: 90,
+      prUrl: "https://github.com/owner/repo/pull/90",
+      selection: {
+        eventType: "CROSS_REFERENCED_EVENT",
+        eventCreatedAt: "2026-05-12T10:00:00Z",
+      },
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("detect-linked-issue-pr: a genuine ConnectedEvent is still a linked PR (semantics unchanged)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-linked-pr-connected-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "graphql", "-F", "issue=85", "owner=owner", "name=repo"],
+        stdout: graphqlPayload({
+          hasNextPage: false,
+          endCursor: null,
+          nodes: [
+            connectedNode({ createdAt: "2026-05-12T10:00:00Z", number: 90 }),
+            // A body-mention xref alongside the ConnectedEvent must not perturb the result.
+            crossNode({ createdAt: "2026-05-13T10:00:00Z", number: 128, willCloseTarget: false }),
+          ],
+        }),
+      },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--issue", "85"], { env });
+
+    assert.equal(result.code, 0);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.hasOpenLinkedPr, true);
+    assert.equal(parsed.prNumber, 90);
+    assert.equal(parsed.selection.eventType, "CONNECTED_EVENT");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
 });

--- a/test/projects/reconcile-queue.test.mjs
+++ b/test/projects/reconcile-queue.test.mjs
@@ -112,6 +112,69 @@ describe("reconcile-queue main (#1069)", () => {
     assert.ok(calls.every((c) => !c.argv.includes("1")));
   });
 
+  it("#1128-shaped: a PR that only body-mentions a sibling issue does NOT link it (no move) [#1130]", async () => {
+    // Live shape of the regression: open PR #1128 closes issue A but merely
+    // body-mentions siblings B/C. gatherLiveFacts must resolve B as having NO
+    // linked open PR, so it derives null and is left untouched — otherwise the
+    // resolver sees multiple in-progress and fails closed.
+    const prViewCalls = [];
+    const runChild = async (cmd, argv) => {
+      if (argv.includes("graphql")) {
+        // detectLinkedIssuePr timeline query: only a bare body-mention xref
+        // (willCloseTarget:false) references this sibling issue.
+        return {
+          code: 0,
+          stdout: JSON.stringify({
+            data: {
+              repository: {
+                issue: {
+                  timelineItems: {
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                    nodes: [
+                      {
+                        __typename: "CrossReferencedEvent",
+                        createdAt: "2026-05-12T10:00:00Z",
+                        willCloseTarget: false,
+                        source: {
+                          __typename: "PullRequest",
+                          number: 1128,
+                          state: "OPEN",
+                          url: "https://github.com/o/r/pull/1128",
+                          repository: { nameWithOwner: "o/r" },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          }),
+          stderr: "",
+        };
+      }
+      if (argv.includes("pr") && argv.includes("view")) {
+        prViewCalls.push(argv);
+        return { code: 0, stdout: JSON.stringify({ state: "OPEN", isDraft: false, mergedAt: null }), stderr: "" };
+      }
+      // issue view --json state
+      return { code: 0, stdout: JSON.stringify({ state: "OPEN" }), stderr: "" };
+    };
+
+    const items = [{ itemId: "I_B", issueNumber: 1084, prNumber: null, status: "Backlog" }];
+    const facts = await gatherLiveFacts(items, "o/r", { env: {}, runChild });
+
+    // Body-mention only → not linked → inert facts → deriveReconcileColumn yields null.
+    assert.deepEqual(facts.get("I_B"), { itemKind: "issue", issueState: "OPEN", prState: null, prIsDraft: null });
+    // The mentioning PR must never be fetched as an owning link.
+    assert.equal(prViewCalls.length, 0);
+
+    // End-to-end through main(): the sibling stays put (zero moves).
+    const moveCalls = [];
+    const result = await run({ items, facts: [...facts], moveCalls });
+    assert.equal(result.moved, 0);
+    assert.equal(moveCalls.length, 0);
+  });
+
   it("gatherLiveFacts WITHOUT doneColumn gathers a Done-status item (explicit-run recovery)", async () => {
     const calls = [];
     const runChild = async (cmd, argv) => {


### PR DESCRIPTION
## Summary

A `CrossReferencedEvent` fires on **any** body mention of an issue (e.g. "part of #X"). `detect-linked-issue-pr` treated a bare mention from an open PR as the issue's linked open PR, so the board sync / `queue reconcile` (`open ready non-draft PR → In Progress`) dragged **every body-mentioned sibling** to In Progress, and `resolve-active-board-item` failed closed on "multiple in-progress".

Root cause: the linkage predicate conflated body-mention with board-ownership. Only a reference that will **close** the issue (or a genuine `ConnectedEvent`) may own its board status.

## Fix

- Select `willCloseTarget` on `CrossReferencedEvent` in the timeline GraphQL query.
- In `normalizeLinkedPrNode` (the single point both the open and prior-closed-unmerged candidate paths flow through), a `CrossReferencedEvent` is an owning link **only when `willCloseTarget: true`**. `ConnectedEvent` unchanged.

## Acceptance criteria

| AC | Status | Evidence |
|----|--------|----------|
| `detectLinkedIssuePr` → `hasOpenLinkedPr: false` for a body-mention-only (willCloseTarget:false) open PR | Met | test: "body-mention-only cross-reference … is not a linked PR" |
| Still returns the linked PR for a genuine `ConnectedEvent` OR `CrossReferencedEvent` with `willCloseTarget: true` | Met | tests: "cross-reference with willCloseTarget:true is a linked PR", "a genuine ConnectedEvent is still a linked PR" |
| Direct unit test for the `detectLinkedIssuePr` / `gatherLiveFacts` bridge (body-mention → not linked; closing → linked) | Met | reconcile-queue test through `gatherLiveFacts` + direct predicate tests |
| Reconcile / board sync no longer move body-mentioned siblings; sub-issue-tree PR keeps resolver single-in-progress | Met | test: "#1128-shaped: a PR that only body-mentions a sibling issue does NOT link it (no move)" |

## Definition of done

- [x] Root-cause predicate fix (not a per-caller patch)
- [x] Direct + regression test coverage
- [x] `npm run verify` green locally

## Non-goals

- No change to `ConnectedEvent` semantics.
- No change to the reconcile column mapping — only the linkage predicate was wrong.

Closes #1130
Closes #1124
