### PR TITLE
feat(gates): give the context-builder additive angle authority

### DIFF
--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -81,7 +81,16 @@ on an isolated checkout:
   recorded as rationale. Angles in `gates.<gate>.mandatoryAngles` form a floor and are
   always included after dynamic selection (filtered only by `excludeAngles`); they are
   never dropped. When `dynamicAngles` is off (or no diff is available), the configured
-  static pool is used unchanged.
+  static pool is used unchanged. Symmetrically, when `gates.<gate>.additiveAngles` is
+  enabled (default **off**), the resolver may also ADD catalog angles that
+  change-category heuristics recommend but that are not already in the gate's
+  configured pool, drawn from the global lens catalog (the explicit `gates.anglePool`
+  override, or the built-in persona registry's angle union when `anglePool` is not
+  set). `excludeAngles` remains a hard ceiling on additions — an excluded angle is
+  never added, even if the change categories would otherwise recommend it. Additions
+  are recorded in the rationale with action `"added"` naming the triggering change
+  category. This additive path is off by default, so existing configured angle pools
+  are unaffected unless a gate explicitly opts in.
 - the preamble produces one or more review handoff artifacts (branch, head SHA, PR/issue
   scope, acceptance criteria, touched files, validation posture). The resolved angle set
   and its rationale are written as a deterministic handoff artifact under

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -85,8 +85,10 @@ on an isolated checkout:
   enabled (default **off**), the resolver may also ADD catalog angles that
   change-category heuristics recommend but that are not already in the gate's
   configured pool, drawn from the global lens catalog (the explicit `gates.anglePool`
-  override, or the built-in persona registry's angle union when `anglePool` is not
-  set). `excludeAngles` remains a hard ceiling on additions — an excluded angle is
+  override, or — when `anglePool` is not set — the union of the built-in persona
+  registry's angle names and every angle actually configured across this config's
+  own `gates.draft`/`gates.preApproval`/`gates.spike` `angles`/`mandatoryAngles`).
+  `excludeAngles` remains a hard ceiling on additions — an excluded angle is
   never added, even if the change categories would otherwise recommend it. Additions
   are recorded in the rationale with action `"added"` naming the triggering change
   category. This additive path is off by default, so existing configured angle pools

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -85,13 +85,14 @@ on an isolated checkout:
   enabled (default **off**), the resolver may also ADD catalog angles that
   change-category heuristics recommend but that are not already in the gate's
   configured pool, drawn from the global lens catalog (the explicit `gates.anglePool`
-  override, or — when `anglePool` is not set — the union of the built-in persona
+  override, or — when `anglePool` is not set or is empty — the union of the built-in persona
   registry's angle names and every angle actually configured across this config's
   own `gates.draft`/`gates.preApproval`/`gates.spike` `angles`/`mandatoryAngles`).
   `excludeAngles` remains a hard ceiling on additions — an excluded angle is
   never added, even if the change categories would otherwise recommend it. Additions
-  are recorded in the rationale with action `"added"` naming the triggering change
-  category. This additive path is off by default, so existing configured angle pools
+  are recorded in the rationale with action `"added"`, with a reason naming either the
+  triggering change category or, for always-include lenses, that it is an
+  always-include addition. This additive path is off by default, so existing configured angle pools
   are unaffected unless a gate explicitly opts in.
 - the preamble produces one or more review handoff artifacts (branch, head SHA, PR/issue
   scope, acceptance criteria, touched files, validation posture). The resolved angle set

--- a/packages/core/src/analysis/change-classifier.mjs
+++ b/packages/core/src/analysis/change-classifier.mjs
@@ -76,6 +76,8 @@ const ALWAYS_INCLUDE = new Set(["gate-evidence", "renderer-security", "pr-descri
  * @property {string[]} skippedAngles — angles skipped with reasons
  * @property {Record<string, string>} reasons — why each angle was skipped
  * @property {boolean} fallbackToAll — true when ambiguous → all angles recommended
+ * @property {string[]} addedAngles — catalog angles added (additive mode only, see #1048)
+ * @property {Record<string, string>} addedReasons — why each added angle was added
  */
 
 /**
@@ -85,16 +87,26 @@ const ALWAYS_INCLUDE = new Set(["gate-evidence", "renderer-security", "pr-descri
  * all configured angles are recommended (fallback-to-all). A LOGIC_CHANGE
  * diff resolves to its core review subset, not fallback-to-all.
  *
+ * When `anglePool` is provided (additive mode, see #1048), catalog angles in
+ * the pool that the change categories recommend but that are not already in
+ * `configuredAngles` are additively selected and reported as `addedAngles`.
+ * When `anglePool` is omitted, additive mode is off and `addedAngles` is
+ * always empty.
+ *
  * @param {object} options
  * @param {string[]} options.configuredAngles — all angles configured for this gate
  * @param {string[]} options.changeCategories — from diff analysis
  * @param {boolean} [options.ambiguous] — from diff analysis
+ * @param {string[]} [options.anglePool] — catalog of angles eligible for additive
+ *   selection (caller pre-filters this against excludeAngles); when undefined,
+ *   additive selection is disabled
  * @returns {DynamicAngleResult}
  */
 export function resolveDynamicAngles({
   configuredAngles,
   changeCategories,
   ambiguous = false,
+  anglePool,
 }) {
   // Fallback: ambiguous diff → all angles
   if (ambiguous) {
@@ -103,6 +115,8 @@ export function resolveDynamicAngles({
       skippedAngles: [],
       reasons: {},
       fallbackToAll: true,
+      addedAngles: [],
+      addedReasons: {},
     };
   }
 
@@ -113,21 +127,30 @@ export function resolveDynamicAngles({
       skippedAngles: [],
       reasons: {},
       fallbackToAll: true,
+      addedAngles: [],
+      addedReasons: {},
     };
   }
 
-  // Build recommended set from category union
+  // Build recommended set from category union, tracking the first trigger per angle
   const recommended = new Set();
+  const triggers = new Map();
   for (const cat of changeCategories) {
     const angles = CATEGORY_ANGLE_MAP[cat] ?? [];
     for (const angle of angles) {
       recommended.add(angle);
+      if (!triggers.has(angle)) {
+        triggers.set(angle, cat);
+      }
     }
   }
 
   // Always-include angles
   for (const angle of ALWAYS_INCLUDE) {
     recommended.add(angle);
+    if (!triggers.has(angle)) {
+      triggers.set(angle, "always-include");
+    }
   }
 
   // Filter to only angles that are configured
@@ -140,10 +163,25 @@ export function resolveDynamicAngles({
     reasons[angle] = `Skipped: detected categories (${changeCategories.join(", ") || "none"}) do not trigger this angle`;
   }
 
+  // Additive: pull in recommended catalog angles not already configured (#1048)
+  const configuredSet = new Set(configuredAngles);
+  const addedAngles = Array.isArray(anglePool)
+    ? [...recommended].filter((a) => anglePool.includes(a) && !configuredSet.has(a))
+    : [];
+  const addedReasons = {};
+  for (const angle of addedAngles) {
+    const trigger = triggers.get(angle);
+    addedReasons[angle] = trigger === "always-include"
+      ? "Added: always-include lens not in the configured pool"
+      : `Added: triggered by change category ${trigger}`;
+  }
+
   return {
     recommendedAngles,
     skippedAngles,
     reasons,
     fallbackToAll: false,
+    addedAngles,
+    addedReasons,
   };
 }

--- a/packages/core/src/analysis/change-classifier.mjs
+++ b/packages/core/src/analysis/change-classifier.mjs
@@ -72,7 +72,9 @@ const ALWAYS_INCLUDE = new Set(["gate-evidence", "renderer-security", "pr-descri
 
 /**
  * @typedef {object} DynamicAngleResult
- * @property {string[]} recommendedAngles — angles to run
+ * @property {string[]} recommendedAngles — angles to run, limited to the
+ *   configured pool (subtractive result); in additive mode the caller
+ *   merges addedAngles on top to form the full effective run set
  * @property {string[]} skippedAngles — angles skipped with reasons
  * @property {Record<string, string>} reasons — why each angle was skipped
  * @property {boolean} fallbackToAll — true when ambiguous → all angles recommended

--- a/packages/core/src/analysis/change-classifier.mjs
+++ b/packages/core/src/analysis/change-classifier.mjs
@@ -165,8 +165,9 @@ export function resolveDynamicAngles({
 
   // Additive: pull in recommended catalog angles not already configured (#1048)
   const configuredSet = new Set(configuredAngles);
-  const addedAngles = Array.isArray(anglePool)
-    ? [...recommended].filter((a) => anglePool.includes(a) && !configuredSet.has(a))
+  const anglePoolSet = Array.isArray(anglePool) ? new Set(anglePool) : null;
+  const addedAngles = anglePoolSet
+    ? [...recommended].filter((a) => anglePoolSet.has(a) && !configuredSet.has(a))
     : [];
   const addedReasons = {};
   for (const angle of addedAngles) {

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -1100,8 +1100,12 @@ export function resolveGateAngles(config, gate) {
  * Resolve the global lens catalog available for additive angle selection.
  *
  * Returns the explicit `gates.anglePool` override when configured (non-empty
- * array of trimmed strings), otherwise falls back to the union of all known
- * review angles (the built-in persona registry's angle names) — see #1048.
+ * array of trimmed strings). Otherwise falls back to the union of all known
+ * review angles: the built-in persona registry's angle names, plus every
+ * angle actually configured across this config's own draft/preApproval/spike
+ * gates (angles + mandatoryAngles). The persona registry alone omits angles
+ * that ship in extension-defaults.yaml gate pools but have no dedicated
+ * persona (e.g. ci-guard, link-check) — see #1048.
  *
  * @param {DevLoopConfig} config
  * @returns {string[]}
@@ -1111,7 +1115,11 @@ export function resolveAnglePool(config) {
   if (Array.isArray(explicit) && explicit.length > 0) {
     return [...new Set(explicit.map(a => (typeof a === "string" ? a.trim() : "")).filter(a => a.length > 0))];
   }
-  return Object.keys(BUILTIN_PERSONAS);
+  const configured = ["draft", "preApproval", "spike"].flatMap((gate) => {
+    const gateConfig = resolveGateConfig(config, gate);
+    return [...(gateConfig.angles ?? []), ...gateConfig.mandatoryAngles];
+  });
+  return [...new Set([...Object.keys(BUILTIN_PERSONAS), ...configured])];
 }
 
 /**

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -1185,7 +1185,17 @@ export async function resolveGateAnglesDynamic(config, gate, { diff } = {}) {
   // Merge: mandatory always included (filtered by excludeAngles) + dynamically-selected
   // candidates + additively-selected catalog angles (#1048)
   const filteredMandatory = gateConfig.mandatoryAngles.filter(a => !excluded.has(a));
-  const recommendedAngles = [...new Set([...filteredMandatory, ...dynamicResult.recommendedAngles, ...(dynamicResult.addedAngles ?? [])])];
+
+  // An angle that is both mandatory AND additively recommended must stay
+  // attributed to the mandatory floor, not be reported as "added" — the
+  // resolver has no concept of "mandatory", so the caller (this function,
+  // which already owns the mandatory Set) filters its output.
+  const addedAngles = (dynamicResult.addedAngles ?? []).filter(a => !mandatory.has(a));
+  const addedReasons = Object.fromEntries(
+    Object.entries(dynamicResult.addedReasons ?? {}).filter(([a]) => !mandatory.has(a))
+  );
+
+  const recommendedAngles = [...new Set([...filteredMandatory, ...dynamicResult.recommendedAngles, ...addedAngles])];
 
   return {
     recommendedAngles,
@@ -1193,8 +1203,8 @@ export async function resolveGateAnglesDynamic(config, gate, { diff } = {}) {
     reasons: dynamicResult.reasons,
     fallbackToAll: dynamicResult.fallbackToAll,
     dynamicAnglesActive: true,
-    addedAngles: dynamicResult.addedAngles ?? [],
-    addedReasons: dynamicResult.addedReasons ?? {},
+    addedAngles,
+    addedReasons,
   };
 }
 

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -47,10 +47,11 @@ const GateConfig = z.strictObject({
     .default(["must-fix"]),
   dynamicAngles: z.boolean().default(false),
   // Additive counterpart to the subtractive dynamicAngles path (#1048): when
-  // true, the context-builder may also ADD catalog angles (gates.anglePool or
-  // the built-in persona registry) that change-category heuristics recommend
-  // but that are not already in this gate's configured pool. Default false
-  // preserves today's subtractive-only behavior exactly.
+  // true, the context-builder may also ADD catalog angles — from
+  // resolveAnglePool() (gates.anglePool, or else the union of the persona
+  // registry and this config's own configured angles) — that change-category
+  // heuristics recommend but that are not already in this gate's configured
+  // pool. Default false preserves today's subtractive-only behavior exactly.
   additiveAngles: z.boolean().default(false),
 });
 
@@ -1133,9 +1134,10 @@ export function resolveAnglePool(config) {
  * angle list (same as `resolveGateAngles`).
  *
  * When `additiveAngles` is also enabled (default off, see #1048), catalog
- * angles (`gates.anglePool` or the built-in persona registry) recommended by
- * change-category heuristics but absent from the gate's configured pool may
- * also be added; `excludeAngles` remains a hard ceiling on additions.
+ * angles from `resolveAnglePool()` (`gates.anglePool`, or else the union of
+ * the persona registry and this config's own configured angles) recommended
+ * by change-category heuristics but absent from the gate's configured pool
+ * may also be added; `excludeAngles` remains a hard ceiling on additions.
  *
  * @param {import("./types.js").DevLoopConfig} config
  * @param {"draft"|"preApproval"} gate

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -46,6 +46,12 @@ const GateConfig = z.strictObject({
     .min(1)
     .default(["must-fix"]),
   dynamicAngles: z.boolean().default(false),
+  // Additive counterpart to the subtractive dynamicAngles path (#1048): when
+  // true, the context-builder may also ADD catalog angles (gates.anglePool or
+  // the built-in persona registry) that change-category heuristics recommend
+  // but that are not already in this gate's configured pool. Default false
+  // preserves today's subtractive-only behavior exactly.
+  additiveAngles: z.boolean().default(false),
 });
 
 const GatesConfig = z.strictObject({
@@ -75,6 +81,11 @@ const GatesConfig = z.strictObject({
   // suppresses the PR comment when explicitly false. See
   // docs/gate-review-sub-loop-contract.md.
   postFindingsComments: z.boolean().default(true),
+  // Explicit global lens catalog override for additive angle selection
+  // (gates.<gate>.additiveAngles, #1048). When absent, the resolver falls
+  // back to the union of all known angles (the built-in persona registry's
+  // angle names).
+  anglePool: z.array(z.string().trim().min(1)).optional(),
 });
 
 const AutonomyConfig = z.strictObject({
@@ -168,6 +179,7 @@ const FileGatesConfig = z.strictObject({
   requireFanoutEvidence: z.boolean().optional(),
   maxFanoutReviewers: z.number().int().min(1).max(64).optional(),
   postFindingsComments: z.boolean().optional(),
+  anglePool: z.array(z.string().trim().min(1)).optional(),
 });
 
 // Partial persona entries for file-level config (allows omitting fields)
@@ -928,7 +940,7 @@ export function resolveRefinement(config) {
  *
  * @param {DevLoopConfig} config
  * @param {"draft"|"preApproval"|"spike"} gate
- * @returns {{ angles: string[]|null, excludeAngles: string[], mandatoryAngles: string[], required: boolean, requireCi: boolean, blockCleanOnFindingSeverities: string[], dynamicAngles: boolean }}
+ * @returns {{ angles: string[]|null, excludeAngles: string[], mandatoryAngles: string[], required: boolean, requireCi: boolean, blockCleanOnFindingSeverities: string[], dynamicAngles: boolean, additiveAngles: boolean }}
  */
 export function resolveGateConfig(config, gate) {
   const gateConfig = config?.gates?.[gate];
@@ -945,6 +957,7 @@ export function resolveGateConfig(config, gate) {
     required: gateConfig?.required ?? true,
     requireCi: gateConfig?.requireCi ?? true,
     dynamicAngles: gateConfig?.dynamicAngles ?? false,
+    additiveAngles: gateConfig?.additiveAngles ?? false,
     blockCleanOnFindingSeverities: gateConfig?.blockCleanOnFindingSeverities && Array.isArray(gateConfig.blockCleanOnFindingSeverities)
       ? [...gateConfig.blockCleanOnFindingSeverities]
       : ["must-fix"],
@@ -1084,6 +1097,24 @@ export function resolveGateAngles(config, gate) {
 }
 
 /**
+ * Resolve the global lens catalog available for additive angle selection.
+ *
+ * Returns the explicit `gates.anglePool` override when configured (non-empty
+ * array of trimmed strings), otherwise falls back to the union of all known
+ * review angles (the built-in persona registry's angle names) — see #1048.
+ *
+ * @param {DevLoopConfig} config
+ * @returns {string[]}
+ */
+export function resolveAnglePool(config) {
+  const explicit = config?.gates?.anglePool;
+  if (Array.isArray(explicit) && explicit.length > 0) {
+    return [...new Set(explicit.map(a => (typeof a === "string" ? a.trim() : "")).filter(a => a.length > 0))];
+  }
+  return Object.keys(BUILTIN_PERSONAS);
+}
+
+/**
  * Resolve gate angles dynamically when `dynamicAngles` is enabled in config.
  *
  * Uses diff analysis helpers (from ../analysis/*) to filter the
@@ -1092,17 +1123,22 @@ export function resolveGateAngles(config, gate) {
  * When `dynamicAngles` is disabled (default), returns the full configured
  * angle list (same as `resolveGateAngles`).
  *
+ * When `additiveAngles` is also enabled (default off, see #1048), catalog
+ * angles (`gates.anglePool` or the built-in persona registry) recommended by
+ * change-category heuristics but absent from the gate's configured pool may
+ * also be added; `excludeAngles` remains a hard ceiling on additions.
+ *
  * @param {import("./types.js").DevLoopConfig} config
  * @param {"draft"|"preApproval"} gate
  * @param {object} [options]
  * @param {{ nameStatusOutput: string, diffOutput?: string }} [options.diff]
- * @returns {{ recommendedAngles: string[] | null, skippedAngles: string[], reasons: Record<string,string>, fallbackToAll: boolean, dynamicAnglesActive: boolean }}
+ * @returns {{ recommendedAngles: string[] | null, skippedAngles: string[], reasons: Record<string,string>, fallbackToAll: boolean, dynamicAnglesActive: boolean, addedAngles: string[], addedReasons: Record<string,string> }}
  */
 export async function resolveGateAnglesDynamic(config, gate, { diff } = {}) {
   const gateConfig = resolveGateConfig(config, gate);
   const staticAngles = resolveGateAngles(config, gate);
   if (staticAngles === null) {
-    return { recommendedAngles: null, skippedAngles: [], reasons: {}, fallbackToAll: false, dynamicAnglesActive: false };
+    return { recommendedAngles: null, skippedAngles: [], reasons: {}, fallbackToAll: false, dynamicAnglesActive: false, addedAngles: [], addedReasons: {} };
   }
 
   if (!gateConfig.dynamicAngles || !diff) {
@@ -1112,6 +1148,8 @@ export async function resolveGateAnglesDynamic(config, gate, { diff } = {}) {
       reasons: {},
       fallbackToAll: false,
       dynamicAnglesActive: false,
+      addedAngles: [],
+      addedReasons: {},
     };
   }
 
@@ -1129,17 +1167,25 @@ export async function resolveGateAnglesDynamic(config, gate, { diff } = {}) {
 
   const categories = [...new Set(analysis.t1?.changeCategories ?? [])];
 
+  // excludeAngles is a hard ceiling: computed once and reused both to cap the
+  // additive anglePool and to filter mandatoryAngles below.
+  const excluded = new Set(gateConfig.excludeAngles);
+  const anglePool = gateConfig.additiveAngles
+    ? resolveAnglePool(config).filter(a => !excluded.has(a))
+    : undefined;
+
   const { resolveDynamicAngles: resolve } = await import("../analysis/change-classifier.mjs");
   const dynamicResult = resolve({
     configuredAngles: candidatePool,
     changeCategories: categories,
     ambiguous: analysis.ambiguous,
+    anglePool,
   });
 
-  // Merge: mandatory always included (filtered by excludeAngles) + dynamically-selected candidates
-  const excluded = new Set(gateConfig.excludeAngles);
+  // Merge: mandatory always included (filtered by excludeAngles) + dynamically-selected
+  // candidates + additively-selected catalog angles (#1048)
   const filteredMandatory = gateConfig.mandatoryAngles.filter(a => !excluded.has(a));
-  const recommendedAngles = [...new Set([...filteredMandatory, ...dynamicResult.recommendedAngles])];
+  const recommendedAngles = [...new Set([...filteredMandatory, ...dynamicResult.recommendedAngles, ...(dynamicResult.addedAngles ?? [])])];
 
   return {
     recommendedAngles,
@@ -1147,6 +1193,8 @@ export async function resolveGateAnglesDynamic(config, gate, { diff } = {}) {
     reasons: dynamicResult.reasons,
     fallbackToAll: dynamicResult.fallbackToAll,
     dynamicAnglesActive: true,
+    addedAngles: dynamicResult.addedAngles ?? [],
+    addedReasons: dynamicResult.addedReasons ?? {},
   };
 }
 

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -82,9 +82,10 @@ const GatesConfig = z.strictObject({
   // docs/gate-review-sub-loop-contract.md.
   postFindingsComments: z.boolean().default(true),
   // Explicit global lens catalog override for additive angle selection
-  // (gates.<gate>.additiveAngles, #1048). When absent, the resolver falls
-  // back to the union of all known angles (the built-in persona registry's
-  // angle names).
+  // (gates.<gate>.additiveAngles, #1048). When absent, resolveAnglePool()
+  // falls back to the union of the built-in persona registry's angle names
+  // and every angle configured across this config's own draft/preApproval/
+  // spike gates (angles + mandatoryAngles).
   anglePool: z.array(z.string().trim().min(1)).optional(),
 });
 

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -2956,6 +2956,31 @@ describe("resolveGateAnglesDynamic", () => {
     assert.ok(result.recommendedAngles.includes("gate-evidence"));
   });
 
+  test("additiveAngles: true excludes a mandatory angle from addedAngles/addedReasons even when it also appears in anglePool", async () => {
+    // Regression (#1136 gate-review): renderer-security is both mandatory AND
+    // in the always-include catalog set, so the additive resolver would
+    // otherwise recommend it as "added" — corrupting the audit rationale for
+    // an angle that actually runs unconditionally as the mandatory floor.
+    const config = {
+      version: 1,
+      gates: {
+        anglePool: ["scope", "correctness", "contract-surface", "docs", "renderer-security"],
+        preApproval: {
+          angles: ["scope"],
+          mandatoryAngles: ["renderer-security"],
+          dynamicAngles: true,
+          additiveAngles: true,
+        },
+      },
+    };
+    const result = await resolveGateAnglesDynamic(config, "preApproval", {
+      diff: { nameStatusOutput: "M\tsrc/main.mjs" },
+    });
+    assert.ok(result.recommendedAngles.includes("renderer-security")); // mandatory floor still works
+    assert.ok(!result.addedAngles.includes("renderer-security")); // not misattributed as "added"
+    assert.equal(result.addedReasons["renderer-security"], undefined); // no fabricated rationale
+  });
+
   test("additiveAngles: true with no gates.anglePool falls back to the built-in persona registry catalog", async () => {
     // contract-surface is a LOGIC_CHANGE core-subset angle AND a built-in persona
     // (see BUILTIN_PERSONAS), so it's a valid fallback-catalog addition target.

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1736,6 +1736,7 @@ describe("role resolution", () => {
         required: true,
         requireCi: true,
         dynamicAngles: false,
+        additiveAngles: false,
         blockCleanOnFindingSeverities: ["must-fix"],
       });
     });
@@ -1754,6 +1755,7 @@ describe("role resolution", () => {
         required: false,
         requireCi: false,
         dynamicAngles: false,
+        additiveAngles: false,
         blockCleanOnFindingSeverities: ["must-fix"],
       });
       assert.deepEqual(config.gates.draft.angles, ["scope", "coverage"]);
@@ -2861,6 +2863,122 @@ describe("resolveGateAnglesDynamic", () => {
     });
     assert.ok(!result.recommendedAngles.includes("correctness"));
     assert.ok(result.recommendedAngles.includes("pr-description"));
+  });
+
+  // --------------------------------------------------------------------
+  // Additive angle selection (#1048) — off by default
+  // --------------------------------------------------------------------
+
+  test("additiveAngles: false (default) is a byte-identical no-op vs. today's subtractive-only path", async () => {
+    const baseGates = {
+      draft: {
+        angles: ["scope", "coverage", "docs"],
+        dynamicAngles: true,
+      },
+    };
+    const diff = { diff: { nameStatusOutput: "A\t.github/workflows/ci.yml" } };
+
+    const withoutAdditive = await resolveGateAnglesDynamic({ version: 1, gates: baseGates }, "draft", diff);
+    const withAdditiveUnset = await resolveGateAnglesDynamic(
+      { version: 1, gates: { draft: { ...baseGates.draft, additiveAngles: false } } },
+      "draft",
+      diff,
+    );
+    assert.deepEqual(withAdditiveUnset.recommendedAngles, withoutAdditive.recommendedAngles);
+    assert.deepEqual(withoutAdditive.addedAngles, []);
+    assert.deepEqual(withoutAdditive.addedReasons, {});
+    // recommendedAngles stays a subset of mandatoryAngles ∪ configured angles
+    const allowed = new Set(["scope", "coverage", "docs"]);
+    for (const a of withoutAdditive.recommendedAngles) {
+      assert.ok(allowed.has(a), `${a} should be a subset of configured angles when additive is off`);
+    }
+  });
+
+  test("additiveAngles: true adds a catalog angle recommended by change category but not in the configured pool", async () => {
+    const config = {
+      version: 1,
+      gates: {
+        draft: {
+          angles: ["scope", "coverage", "docs"], // ci-guard deliberately omitted
+          dynamicAngles: true,
+          additiveAngles: true,
+        },
+        anglePool: ["scope", "coverage", "docs", "ci-guard", "config-drift"],
+      },
+    };
+    const result = await resolveGateAnglesDynamic(config, "draft", {
+      diff: { nameStatusOutput: "A\t.github/workflows/ci.yml" },
+    });
+    assert.ok(result.addedAngles.includes("ci-guard"));
+    assert.ok(result.recommendedAngles.includes("ci-guard"));
+    assert.ok(!["scope", "coverage", "docs"].includes("ci-guard")); // sanity: not in original pool
+    assert.equal(result.addedReasons["ci-guard"], "Added: triggered by change category CI_ONLY");
+  });
+
+  test("additiveAngles: true, but excludeAngles ceiling still wins over addition", async () => {
+    const config = {
+      version: 1,
+      gates: {
+        draft: {
+          angles: ["scope", "coverage", "docs"],
+          excludeAngles: ["ci-guard"],
+          dynamicAngles: true,
+          additiveAngles: true,
+        },
+        anglePool: ["scope", "coverage", "docs", "ci-guard", "config-drift"],
+      },
+    };
+    const result = await resolveGateAnglesDynamic(config, "draft", {
+      diff: { nameStatusOutput: "A\t.github/workflows/ci.yml" },
+    });
+    assert.ok(!result.addedAngles.includes("ci-guard"));
+    assert.ok(!result.recommendedAngles.includes("ci-guard"));
+  });
+
+  test("additiveAngles: true still keeps mandatoryAngles floor intact", async () => {
+    const config = {
+      version: 1,
+      gates: {
+        draft: {
+          angles: ["scope", "coverage"],
+          mandatoryAngles: ["pr-description", "correctness", "gate-evidence"],
+          dynamicAngles: true,
+          additiveAngles: true,
+        },
+        anglePool: ["scope", "coverage", "ci-guard"],
+      },
+    };
+    const result = await resolveGateAnglesDynamic(config, "draft", {
+      diff: { nameStatusOutput: "A\t.github/workflows/ci.yml" },
+    });
+    assert.ok(result.recommendedAngles.includes("pr-description"));
+    assert.ok(result.recommendedAngles.includes("correctness"));
+    assert.ok(result.recommendedAngles.includes("gate-evidence"));
+  });
+
+  test("additiveAngles: true with no gates.anglePool falls back to the built-in persona registry catalog", async () => {
+    // contract-surface is a LOGIC_CHANGE core-subset angle AND a built-in persona
+    // (see BUILTIN_PERSONAS), so it's a valid fallback-catalog addition target.
+    const config = {
+      version: 1,
+      gates: {
+        draft: {
+          angles: ["scope", "coverage"], // contract-surface omitted; no explicit anglePool
+          dynamicAngles: true,
+          additiveAngles: true,
+        },
+      },
+    };
+    const result = await resolveGateAnglesDynamic(config, "draft", {
+      diff: { nameStatusOutput: "M\tsrc/main.mjs" },
+    });
+    assert.ok(result.addedAngles.includes("contract-surface"));
+    assert.ok(result.recommendedAngles.includes("contract-surface"));
+  });
+
+  test("resolveGateConfig: additiveAngles defaults to false when unset (this repo's own gates are unaffected)", () => {
+    const config = { version: 1, gates: { draft: { angles: ["scope"], dynamicAngles: true } } };
+    assert.equal(resolveGateConfig(config, "draft").additiveAngles, false);
   });
 
 });

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -2912,7 +2912,7 @@ describe("resolveGateAnglesDynamic", () => {
     });
     assert.ok(result.addedAngles.includes("ci-guard"));
     assert.ok(result.recommendedAngles.includes("ci-guard"));
-    assert.ok(!["scope", "coverage", "docs"].includes("ci-guard")); // sanity: not in original pool
+    assert.ok(!config.gates.draft.angles.includes("ci-guard")); // sanity: not in original pool
     assert.equal(result.addedReasons["ci-guard"], "Added: triggered by change category CI_ONLY");
   });
 

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -21,6 +21,7 @@ import {
   resolveGateConfig,
   resolveGateAngles,
   resolveGateAnglesDynamic,
+  resolveAnglePool,
   resolveWorkflowConfig,
   resolveLightMode,
   resolveGateDispatchMode,
@@ -2999,6 +3000,60 @@ describe("resolveGateAnglesDynamic", () => {
     });
     assert.ok(result.addedAngles.includes("contract-surface"));
     assert.ok(result.recommendedAngles.includes("contract-surface"));
+  });
+
+  test("resolveAnglePool: with no explicit gates.anglePool, includes angles configured on gates.draft that are absent from BUILTIN_PERSONAS", () => {
+    // ci-guard has no entry in BUILTIN_PERSONAS (it resolves via the
+    // default-reviewer persona fallback at dispatch time), but it is a real,
+    // configured angle in this repo's own extension-defaults.yaml draft gate —
+    // the fallback catalog must include it, not just the persona registry.
+    const config = { version: 1, gates: { draft: { angles: ["scope", "ci-guard"] } } };
+    assert.ok(resolveAnglePool(config).includes("ci-guard"));
+  });
+
+  test("resolveAnglePool: with no explicit gates.anglePool, still includes BUILTIN_PERSONAS-only angles not configured on any gate", () => {
+    // renderer-security is in BUILTIN_PERSONAS but not referenced by any gate
+    // in this config — the persona-registry half of the union must still hold.
+    const config = { version: 1, gates: { draft: { angles: ["scope"] } } };
+    assert.ok(resolveAnglePool(config).includes("renderer-security"));
+  });
+
+  test("resolveAnglePool: explicit gates.anglePool override is unaffected by the broadened fallback", () => {
+    const config = {
+      version: 1,
+      gates: {
+        anglePool: [" scope ", "coverage", "scope"],
+        draft: { angles: ["ci-guard"] },
+      },
+    };
+    // Deduped/trimmed explicit list only — no ci-guard leaking in from draft.angles.
+    assert.deepEqual(resolveAnglePool(config), ["scope", "coverage"]);
+  });
+
+  test("additiveAngles: true with no gates.anglePool can additively select an angle configured elsewhere in this config's gates but absent from BUILTIN_PERSONAS", async () => {
+    // ci-guard is a real draft-gate angle in this repo's extension-defaults.yaml
+    // but has no BUILTIN_PERSONAS entry, so the old BUILTIN_PERSONAS-only
+    // fallback could never additively select it. Here the gate under test
+    // (draft) has a hypothetical narrower angle list that omits ci-guard, but
+    // ci-guard is configured on another gate (preApproval) in the same config —
+    // the broadened fallback catalog unions across all of this config's own
+    // gates, so it should still be additively reachable for draft.
+    const config = {
+      version: 1,
+      gates: {
+        draft: {
+          angles: ["scope", "coverage", "docs"], // ci-guard deliberately omitted here
+          dynamicAngles: true,
+          additiveAngles: true,
+        },
+        preApproval: { angles: ["ci-guard", "link-check"] },
+      },
+    };
+    const result = await resolveGateAnglesDynamic(config, "draft", {
+      diff: { nameStatusOutput: "A\t.github/workflows/ci.yml" },
+    });
+    assert.ok(result.addedAngles.includes("ci-guard"));
+    assert.ok(result.recommendedAngles.includes("ci-guard"));
   });
 
   test("resolveGateConfig: additiveAngles defaults to false when unset (this repo's own gates are unaffected)", () => {

--- a/packages/core/test/dynamic-angles.test.mjs
+++ b/packages/core/test/dynamic-angles.test.mjs
@@ -164,3 +164,81 @@ test("resolveDynamicAngles: provides reasons for skipped angles", () => {
   assert.ok(Object.keys(result.reasons).length > 0);
   assert.equal(typeof result.reasons[result.skippedAngles[0]], "string");
 });
+
+// ---------------------------------------------------------------------------
+// Additive angle selection (#1048) — off by default, on when anglePool passed
+// ---------------------------------------------------------------------------
+
+const NARROW_ANGLES = DRAFT_ANGLES.filter((a) => a !== "ci-guard");
+
+test("resolveDynamicAngles: default (no anglePool) never adds angles", () => {
+  const result = resolveDynamicAngles({
+    configuredAngles: NARROW_ANGLES,
+    changeCategories: [ChangeCategory.CI_ONLY],
+  });
+  assert.deepEqual(result.addedAngles, []);
+  assert.deepEqual(result.addedReasons, {});
+  assert.ok(!result.recommendedAngles.includes("ci-guard"));
+});
+
+test("resolveDynamicAngles: additive mode adds a catalog angle triggered by change category", () => {
+  const result = resolveDynamicAngles({
+    configuredAngles: NARROW_ANGLES,
+    changeCategories: [ChangeCategory.CI_ONLY],
+    anglePool: [...NARROW_ANGLES, "ci-guard"],
+  });
+  // addedAngles reports the catalog addition; recommendedAngles itself is
+  // still scoped to configuredAngles — merging addedAngles in is the
+  // caller's (resolveGateAnglesDynamic) responsibility, not this function's.
+  assert.ok(result.addedAngles.includes("ci-guard"));
+  assert.ok(!result.recommendedAngles.includes("ci-guard"));
+  assert.equal(result.addedReasons["ci-guard"], "Added: triggered by change category CI_ONLY");
+});
+
+test("resolveDynamicAngles: additive mode does not re-add already-configured angles", () => {
+  const result = resolveDynamicAngles({
+    configuredAngles: DRAFT_ANGLES,
+    changeCategories: [ChangeCategory.CI_ONLY],
+    anglePool: DRAFT_ANGLES,
+  });
+  assert.deepEqual(result.addedAngles, []);
+});
+
+test("resolveDynamicAngles: additive mode does not add angles outside anglePool", () => {
+  const result = resolveDynamicAngles({
+    configuredAngles: NARROW_ANGLES,
+    changeCategories: [ChangeCategory.CI_ONLY],
+    anglePool: NARROW_ANGLES, // ci-guard not in the catalog
+  });
+  assert.deepEqual(result.addedAngles, []);
+});
+
+test("resolveDynamicAngles: additive mode reports always-include trigger reason", () => {
+  const narrowPreapproval = PREAPPROVAL_ANGLES.filter((a) => a !== "renderer-security");
+  const result = resolveDynamicAngles({
+    configuredAngles: narrowPreapproval,
+    changeCategories: [ChangeCategory.RENAME_ONLY],
+    anglePool: PREAPPROVAL_ANGLES,
+  });
+  assert.ok(result.addedAngles.includes("renderer-security"));
+  assert.equal(result.addedReasons["renderer-security"], "Added: always-include lens not in the configured pool");
+});
+
+test("resolveDynamicAngles: additive is a no-op in ambiguous/no-category fallback branches", () => {
+  const ambiguousResult = resolveDynamicAngles({
+    configuredAngles: NARROW_ANGLES,
+    changeCategories: [ChangeCategory.CI_ONLY],
+    ambiguous: true,
+    anglePool: [...NARROW_ANGLES, "ci-guard"],
+  });
+  assert.deepEqual(ambiguousResult.addedAngles, []);
+  assert.deepEqual(ambiguousResult.addedReasons, {});
+
+  const noCategoriesResult = resolveDynamicAngles({
+    configuredAngles: NARROW_ANGLES,
+    changeCategories: [],
+    anglePool: [...NARROW_ANGLES, "ci-guard"],
+  });
+  assert.deepEqual(noCategoriesResult.addedAngles, []);
+  assert.deepEqual(noCategoriesResult.addedReasons, {});
+});

--- a/packages/core/test/dynamic-angles.test.mjs
+++ b/packages/core/test/dynamic-angles.test.mjs
@@ -195,6 +195,19 @@ test("resolveDynamicAngles: additive mode adds a catalog angle triggered by chan
   assert.equal(result.addedReasons["ci-guard"], "Added: triggered by change category CI_ONLY");
 });
 
+test("resolveDynamicAngles: additive mode addedAngles/addedReasons content and order unchanged with Set-based anglePool lookup", () => {
+  // Regression check for the anglePool.includes -> Set.has refactor: same
+  // scenario as the "adds a catalog angle" test above, asserted with exact
+  // deepEqual (not just .includes) to prove no content/order regression.
+  const result = resolveDynamicAngles({
+    configuredAngles: NARROW_ANGLES,
+    changeCategories: [ChangeCategory.CI_ONLY],
+    anglePool: [...NARROW_ANGLES, "ci-guard"],
+  });
+  assert.deepEqual(result.addedAngles, ["ci-guard"]);
+  assert.deepEqual(result.addedReasons, { "ci-guard": "Added: triggered by change category CI_ONLY" });
+});
+
 test("resolveDynamicAngles: additive mode does not re-add already-configured angles", () => {
   const result = resolveDynamicAngles({
     configuredAngles: DRAFT_ANGLES,

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -17,7 +17,9 @@
  * This module maps that resolver's output into the persisted artifact:
  *   resolvedAngles  = resolver.recommendedAngles
  *   rationale       = resolver.skippedAngles (action 'dropped', reason from
- *                     resolver.reasons) + the rest as action 'kept'
+ *                     resolver.reasons) + the rest as action 'kept', except
+ *                     entries present in resolver.addedAngles are recorded as
+ *                     action 'added' (reason from resolver.addedReasons) — see #1048
  *
  * The artifact records the resolved angle set + rationale + change scope
  * (branch, head SHA, touched files, acceptance-criteria pointer, validation
@@ -52,8 +54,12 @@ export function mapGateToConfigKey(gate) {
  * Map a resolveGateAnglesDynamic result into the persisted artifact fields.
  * Does NOT re-derive angles — it only reshapes the resolver's output.
  *
- * @param {{ recommendedAngles: string[]|null, skippedAngles?: string[], reasons?: Record<string,string> }} resolverResult
- * @returns {{ resolvedAngles: string[], rationale: Array<{angle: string, action: "kept"|"dropped", reason: string}> }}
+ * Angles present in `resolverResult.addedAngles` (additive selection, #1048)
+ * are recorded with action 'added' (reason from `resolverResult.addedReasons`)
+ * instead of 'kept'.
+ *
+ * @param {{ recommendedAngles: string[]|null, skippedAngles?: string[], reasons?: Record<string,string>, addedAngles?: string[], addedReasons?: Record<string,string> }} resolverResult
+ * @returns {{ resolvedAngles: string[], rationale: Array<{angle: string, action: "kept"|"added"|"dropped", reason: string}> }}
  */
 export function rationaleFromResolver(resolverResult) {
   const recommended = Array.isArray(resolverResult?.recommendedAngles)
@@ -63,6 +69,8 @@ export function rationaleFromResolver(resolverResult) {
     ? resolverResult.skippedAngles
     : [];
   const reasons = resolverResult?.reasons ?? {};
+  const added = new Set(Array.isArray(resolverResult?.addedAngles) ? resolverResult.addedAngles : []);
+  const addedReasons = resolverResult?.addedReasons ?? {};
   const dynamicActive = resolverResult?.dynamicAnglesActive === true;
   const keptReason = dynamicActive
     ? "selected by dynamic angle resolver"
@@ -70,6 +78,16 @@ export function rationaleFromResolver(resolverResult) {
 
   const rationale = [];
   for (const angle of recommended) {
+    if (added.has(angle)) {
+      rationale.push({
+        angle,
+        action: "added",
+        reason: typeof addedReasons[angle] === "string" && addedReasons[angle].length > 0
+          ? addedReasons[angle]
+          : "added by dynamic angle resolver (catalog addition)",
+      });
+      continue;
+    }
     rationale.push({ angle, action: "kept", reason: keptReason });
   }
   for (const angle of skipped) {

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -58,7 +58,7 @@ export function mapGateToConfigKey(gate) {
  * are recorded with action 'added' (reason from `resolverResult.addedReasons`)
  * instead of 'kept'.
  *
- * @param {{ recommendedAngles: string[]|null, skippedAngles?: string[], reasons?: Record<string,string>, addedAngles?: string[], addedReasons?: Record<string,string> }} resolverResult
+ * @param {{ recommendedAngles: string[]|null, skippedAngles?: string[], reasons?: Record<string,string>, addedAngles?: string[], addedReasons?: Record<string,string>, dynamicAnglesActive?: boolean }} resolverResult
  * @returns {{ resolvedAngles: string[], rationale: Array<{angle: string, action: "kept"|"added"|"dropped", reason: string}> }}
  */
 export function rationaleFromResolver(resolverResult) {

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -78,7 +78,7 @@ export function rationaleFromResolver(resolverResult) {
 
   const rationale = [];
   for (const angle of recommended) {
-    if (added.has(angle)) {
+    if (added.has(angle) && dynamicActive) {
       rationale.push({
         angle,
         action: "added",

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -399,6 +399,24 @@ test("rationaleFromResolver marks addedAngles entries as 'added' with their adde
   });
 });
 
+test("rationaleFromResolver treats addedAngles entries as 'kept' when dynamicAnglesActive is not true (defensive guard)", () => {
+  // resolveGateAnglesDynamic never produces a non-empty addedAngles with
+  // dynamicAnglesActive false, but a hand-constructed/malformed resolverResult
+  // could. The "added" classification must stay gated on dynamicActive so
+  // rationale semantics remain internally consistent.
+  const { rationale } = rationaleFromResolver({
+    recommendedAngles: ["some-angle"],
+    skippedAngles: [],
+    reasons: {},
+    addedAngles: ["some-angle"],
+    addedReasons: { "some-angle": "Added: triggered by change category CI_ONLY" },
+    dynamicAnglesActive: false,
+  });
+  assert.deepEqual(rationale, [
+    { angle: "some-angle", action: "kept", reason: "static pool (dynamic angle resolution inactive)" },
+  ]);
+});
+
 test("rationaleFromResolver marks a mandatory angle absent from addedAngles as 'kept', not 'added' (#1136 regression)", () => {
   // Mirrors resolveGateAnglesDynamic's fixed output shape: renderer-security is
   // in recommendedAngles (mandatory floor) but excluded from addedAngles because

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -379,6 +379,40 @@ test("rationaleFromResolver tolerates null/empty resolver output", () => {
   assert.deepEqual(rationale, []);
 });
 
+test("rationaleFromResolver marks addedAngles entries as 'added' with their addedReasons, not 'kept' (#1048)", () => {
+  const { resolvedAngles, rationale } = rationaleFromResolver({
+    recommendedAngles: ["gate-evidence", "docs", "ci-guard"],
+    skippedAngles: ["coverage"],
+    reasons: { coverage: "DOCS_ONLY" },
+    addedAngles: ["ci-guard"],
+    addedReasons: { "ci-guard": "Added: triggered by change category CI_ONLY" },
+    dynamicAnglesActive: true,
+  });
+  assert.deepEqual(resolvedAngles, ["gate-evidence", "docs", "ci-guard"]);
+  assert.deepEqual(rationale.find((r) => r.angle === "ci-guard"), {
+    angle: "ci-guard", action: "added", reason: "Added: triggered by change category CI_ONLY",
+  });
+  // Not also recorded as kept
+  assert.equal(rationale.filter((r) => r.angle === "ci-guard").length, 1);
+  assert.deepEqual(rationale.find((r) => r.angle === "gate-evidence"), {
+    angle: "gate-evidence", action: "kept", reason: "selected by dynamic angle resolver",
+  });
+});
+
+test("rationaleFromResolver falls back to a sane default reason for an added angle with no addedReasons entry", () => {
+  const { rationale } = rationaleFromResolver({
+    recommendedAngles: ["ci-guard"],
+    skippedAngles: [],
+    reasons: {},
+    addedAngles: ["ci-guard"],
+    addedReasons: {},
+    dynamicAnglesActive: true,
+  });
+  assert.deepEqual(rationale, [
+    { angle: "ci-guard", action: "added", reason: "added by dynamic angle resolver (catalog addition)" },
+  ]);
+});
+
 // ---------------------------------------------------------------------------
 // buildGateContext — integration with the canonical resolver
 // ---------------------------------------------------------------------------

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -399,6 +399,27 @@ test("rationaleFromResolver marks addedAngles entries as 'added' with their adde
   });
 });
 
+test("rationaleFromResolver marks a mandatory angle absent from addedAngles as 'kept', not 'added' (#1136 regression)", () => {
+  // Mirrors resolveGateAnglesDynamic's fixed output shape: renderer-security is
+  // in recommendedAngles (mandatory floor) but excluded from addedAngles because
+  // it's mandatory, even though it also appears in the anglePool catalog.
+  const { resolvedAngles, rationale } = rationaleFromResolver({
+    recommendedAngles: ["renderer-security", "scope", "contract-surface"],
+    skippedAngles: [],
+    reasons: {},
+    addedAngles: ["contract-surface"],
+    addedReasons: { "contract-surface": "Added: triggered by change category LOGIC_CHANGE" },
+    dynamicAnglesActive: true,
+  });
+  assert.deepEqual(resolvedAngles, ["renderer-security", "scope", "contract-surface"]);
+  assert.deepEqual(rationale.find((r) => r.angle === "renderer-security"), {
+    angle: "renderer-security", action: "kept", reason: "selected by dynamic angle resolver",
+  });
+  assert.deepEqual(rationale.find((r) => r.angle === "contract-surface"), {
+    angle: "contract-surface", action: "added", reason: "Added: triggered by change category LOGIC_CHANGE",
+  });
+});
+
 test("rationaleFromResolver falls back to a sane default reason for an added angle with no addedReasons entry", () => {
   const { rationale } = rationaleFromResolver({
     recommendedAngles: ["ci-guard"],


### PR DESCRIPTION
## Summary

Makes the gate context-builder's dynamic angle resolution symmetric — additive as well as subtractive — bounded and auditable, **off by default**.

Closes #1048

## What changed

- `packages/core/src/analysis/change-classifier.mjs`: `resolveDynamicAngles` gains an optional `anglePool` param. When provided, catalog angles recommended by the same change-category heuristics (`CATEGORY_ANGLE_MAP` + `ALWAYS_INCLUDE`) that are **not already in the gate's configured pool** are additively selected and returned as `addedAngles`/`addedReasons` (reason names the triggering category, or `always-include`). Existing subtractive logic (`recommendedAngles`/`skippedAngles`/`reasons`/`fallbackToAll`) is unchanged byte-for-byte; additive is a hard no-op when `anglePool` is omitted or in the ambiguous/no-category fallback branches.
- `packages/core/src/config/config.mjs`:
  - `GateConfig.additiveAngles` (default `false`) — per-gate opt-in flag.
  - `GatesConfig.anglePool` / `FileGatesConfig.anglePool` (optional string array) — explicit global lens catalog override.
  - `resolveAnglePool(config)` — returns `gates.anglePool` when set and non-empty, else the union of the built-in persona registry's angle names (`Object.keys(BUILTIN_PERSONAS)`) and every angle actually configured across this config's own `gates.draft`/`gates.preApproval`/`gates.spike` (`angles` + `mandatoryAngles`).
  - `resolveGateAnglesDynamic` threads a pre-filtered (`excludeAngles`-ceilinged) `anglePool` into the resolver only when `additiveAngles` is on, and merges `addedAngles` into the final `recommendedAngles` — but first filters `addedAngles`/`addedReasons` to exclude any angle already in `mandatoryAngles`, so a mandatory angle that also appears in the catalog is reported as `"kept"` (mandatory floor) and never mislabeled `"added"`.
- `scripts/github/write-gate-context.mjs`: `rationaleFromResolver` extends the `action` enum to `"added"` for angles present in `addedAngles`, recording the trigger reason, but only when `dynamicAnglesActive` is `true`; otherwise it falls back to the existing `"kept"`/static reason. `"kept"`/`"dropped"` behavior for all other angles is unchanged.
- `docs/gate-review-sub-loop-contract.md`: documents the additive path symmetrically to the existing subtractive/drop language, including the off-by-default posture and the `excludeAngles` ceiling.

## Acceptance criteria

- [x] With `additiveAngles` ON, a change whose categories imply a lens not in the gate's pool ADDS that lens to `recommendedAngles`, recorded with an `"added"` rationale naming the trigger.
- [x] `excludeAngles` still suppresses an otherwise-added angle (ceiling wins).
- [x] `mandatoryAngles` floor unchanged.
- [x] **Off by default**: with the flag off, `recommendedAngles ⊆ mandatoryAngles ∪ gates.<gate>.angles` exactly as today (proven via a byte-identical no-op test).
- [x] Contract doc documents the additive path symmetrically.
- [x] Unit coverage: additive selection, exclude-beats-add, default-off no-op, rationale `"added"` recording.

## Definition of done

- [x] Test-first coverage added in `packages/core/test/dynamic-angles.test.mjs`, `packages/core/test/config.test.mjs`, `test/github/write-gate-context.test.mjs`.
- [x] `npm run verify` green locally (all suites, no regressions).
- [x] This repo's own `.devloops` is untouched — it does not set `additiveAngles`, so this PR's own gates behave exactly as before this change.

## Non-goals (unchanged from issue)

- Reviewers inventing angles at fan-out time — selection stays in the deterministic context-builder.
- Changing the per-reviewer file-context widening mechanism.

