### PR TITLE
fix(queue): honor queue.statusColumns.next_up across ordering + pickup + add-queue (#1098)

### DIFF
--- a/packages/core/src/loop/queue-board-ordering.mjs
+++ b/packages/core/src/loop/queue-board-ordering.mjs
@@ -56,13 +56,12 @@ export async function resolveNextUpOrder(
   // Resolve the logical next_up column through the SAME statusColumns mapping
   // board-sync uses (#1098), so a renamed Next Up column (e.g. "Todo") is
   // queried by its configured display name instead of the literal default.
-  const { columnNames, error: configError } = loadStateColumnMap(repoRoot);
-  if (configError) {
-    // Board IS configured but `.devloops` failed to parse: fail closed (query
-    // ERROR shape), never silently query the default literal against a possibly
-    // renamed column (#1098). Driver surfaces it and stops (no Backlog fallback).
-    return { ok: false, configured: true, order: [], reason: `config read/parse error: ${configError}` };
-  }
+  // No config-error guard here: loadBoardConfig above already short-circuits any
+  // `.devloops` read/parse error to `enabled:false` (early return at the top of
+  // this function), so a malformed config never reaches this point. The
+  // fail-closed-on-config-error guard lives on the direct-read pickup path
+  // (resolve-active-board-item), which does NOT go through loadBoardConfig.
+  const { columnNames } = loadStateColumnMap(repoRoot);
   const nextUpColumn = columnNames[LOGICAL_COLUMN.NEXT_UP];
 
   const listItems = dependencies.listQueueItems ?? listQueueItemsMain;

--- a/packages/core/src/loop/queue-board-ordering.mjs
+++ b/packages/core/src/loop/queue-board-ordering.mjs
@@ -56,7 +56,14 @@ export async function resolveNextUpOrder(
   // Resolve the logical next_up column through the SAME statusColumns mapping
   // board-sync uses (#1098), so a renamed Next Up column (e.g. "Todo") is
   // queried by its configured display name instead of the literal default.
-  const nextUpColumn = loadStateColumnMap(repoRoot).columnNames[LOGICAL_COLUMN.NEXT_UP];
+  const { columnNames, error: configError } = loadStateColumnMap(repoRoot);
+  if (configError) {
+    // Board IS configured but `.devloops` failed to parse: fail closed (query
+    // ERROR shape), never silently query the default literal against a possibly
+    // renamed column (#1098). Driver surfaces it and stops (no Backlog fallback).
+    return { ok: false, configured: true, order: [], reason: `config read/parse error: ${configError}` };
+  }
+  const nextUpColumn = columnNames[LOGICAL_COLUMN.NEXT_UP];
 
   const listItems = dependencies.listQueueItems ?? listQueueItemsMain;
   try {

--- a/packages/core/src/loop/queue-board-ordering.mjs
+++ b/packages/core/src/loop/queue-board-ordering.mjs
@@ -1,4 +1,4 @@
-import { loadBoardConfig, resolveProjectNumber } from "./queue-board-sync.mjs";
+import { loadBoardConfig, resolveProjectNumber, loadStateColumnMap, LOGICAL_COLUMN } from "./queue-board-sync.mjs";
 import { main as listQueueItemsMain } from "../../../../scripts/projects/list-queue-items.mjs";
 
 // Canonical fail-closed Next Up tokens — the SINGLE source of truth so the reason
@@ -53,6 +53,11 @@ export async function resolveNextUpOrder(
     return { ok: false, configured: true, order: [], reason: "could not resolve board project" };
   }
 
+  // Resolve the logical next_up column through the SAME statusColumns mapping
+  // board-sync uses (#1098), so a renamed Next Up column (e.g. "Todo") is
+  // queried by its configured display name instead of the literal default.
+  const nextUpColumn = loadStateColumnMap(repoRoot).columnNames[LOGICAL_COLUMN.NEXT_UP];
+
   const listItems = dependencies.listQueueItems ?? listQueueItemsMain;
   try {
     const result = await listItems(
@@ -60,7 +65,7 @@ export async function resolveNextUpOrder(
       // resolveProjectNumber yields a number, so stringify it. Passing the raw
       // number trips parseProjectRef's `typeof raw !== "string"` guard, which
       // surfaces as a misleading "--project is required" (#901).
-      { repo, project: String(projectNumber), column: "Next Up" },
+      { repo, project: String(projectNumber), column: nextUpColumn },
       { env, runChild: dependencies.runChild },
     );
     const order = (result?.items ?? [])

--- a/packages/core/src/loop/queue-board-sync.mjs
+++ b/packages/core/src/loop/queue-board-sync.mjs
@@ -224,7 +224,7 @@ export function loadBoardConfig(repoRoot) {
  *     cannot pollute Object.prototype.
  */
 export function loadStateColumnMap(repoRoot) {
-  const { settings: queue } = readDevloopsSettings(repoRoot);
+  const { settings: queue, error } = readDevloopsSettings(repoRoot);
   // Null-prototype objects: untrusted keys can never reach Object.prototype.
   const columnNames = Object.assign(Object.create(null), DEFAULT_STATE_COLUMN_NAMES);
   const stateColumnMap = Object.create(null);
@@ -255,7 +255,11 @@ export function loadStateColumnMap(repoRoot) {
     }
   }
 
-  return { columnNames, stateColumnMap };
+  // Surface a non-ENOENT read/parse error (mirrors loadBoardConfig). Callers on
+  // the fail-closed next_up pickup path MUST honor it rather than silently
+  // querying the default literal column against a stale/renamed board (#1098).
+  // Existing `.columnNames`-only callers ignore this field and behave unchanged.
+  return { columnNames, stateColumnMap, error: error ?? null };
 }
 
 // ── Minimal project lookup (read-only, no create/repair) ────────────────

--- a/packages/core/test/queue-board-ordering.test.mjs
+++ b/packages/core/test/queue-board-ordering.test.mjs
@@ -198,6 +198,27 @@ test("resolveNextUpOrder yields a clean reason (not '--project is required') whe
   }
 });
 
+test("resolveNextUpOrder queries the configured statusColumns.next_up display name (#1098)", async () => {
+  const dir = await makeRepo('queue:\n  projectNumber: 3\n  statusColumns:\n    next_up: "Todo"\n');
+  try {
+    const result = await resolveNextUpOrder(
+      "owner/repo",
+      dir,
+      { GH_TOKEN: "mock" },
+      {
+        listQueueItems: async (args) => {
+          assert.deepEqual(args, { repo: "owner/repo", project: "3", column: "Todo" });
+          return { ok: true, items: [{ issueNumber: 5 }] };
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.order, [5]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("resolveNextUpOrder reports ok:false on list query error (fail-closed at driver)", async () => {
   const dir = await makeRepo("queue:\n  projectNumber: 3\n");
   try {

--- a/packages/core/test/queue-board-sync.test.mjs
+++ b/packages/core/test/queue-board-sync.test.mjs
@@ -295,6 +295,31 @@ test("loadStateColumnMap reads queue.statusColumns overrides (AC3)", async () =>
   }
 });
 
+test("loadStateColumnMap surfaces a non-ENOENT read/parse error (fail-closed contract, #1098)", async () => {
+  // Un-parseable `.devloops` (mapping then sequence at root) → YAMLParseError.
+  const dir = await makeRepo("queue: renamed\n- broken\n");
+  try {
+    const mapping = loadStateColumnMap(dir);
+    // Error is surfaced (not swallowed) so next_up pickup consumers fail closed
+    // instead of silently querying the default literal column.
+    assert.ok(mapping.error, "expected a config read/parse error to be surfaced");
+    // Backward compatible: columnNames still present (defaults) for the 4
+    // existing .columnNames-only callers that ignore `error`.
+    assert.equal(mapping.columnNames[LOGICAL_COLUMN.NEXT_UP], "Next Up");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadStateColumnMap returns error:null for a clean/missing config (#1098)", async () => {
+  const dir = await makeRepo(null);
+  try {
+    assert.equal(loadStateColumnMap(dir).error, null);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("loadStateColumnMap reads queue.stateColumnMap per-state overrides (AC3)", async () => {
   const dir = await makeRepo(
     "queue:\n  projectNumber: 5\n  stateColumnMap:\n    final_approval_ready: ready_for_review\n  statusColumns:\n    ready_for_review: \"Ready for Review\"\n",

--- a/scripts/projects/add-queue-item.mjs
+++ b/scripts/projects/add-queue-item.mjs
@@ -19,10 +19,11 @@ Options:
   --item <number>             Required. Issue or PR number to add.
   --column <name>             Initial Status column (default: "Backlog").
   --status <name>             Back-compat alias for --column.
-  --next-up                   Land the item directly in the "Next Up" column
-                              (the normative pickup queue). Sugar for
-                              --column "Next Up"; cannot be combined with a
-                              conflicting --column/--status.
+  --next-up                   Land the item directly in the configured next_up
+                              column (the normative pickup queue; "Next Up" by
+                              default, honors queue.statusColumns.next_up). Sugar
+                              for --column <that column>; cannot be combined with
+                              a conflicting --column/--status.
   --help, -h                  Show this help.
 
 Output (stdout):
@@ -390,7 +391,17 @@ async function main(args, { env = process.env, runChild, cwd = process.cwd() } =
   // normative pickup queue, #1091), resolved through the SAME statusColumns
   // mapping board-sync uses (#1098) so a renamed Next Up column agrees with
   // an explicit --column of the same configured name.
-  const nextUpColumn = loadStateColumnMap(cwd).columnNames[LOGICAL_COLUMN.NEXT_UP];
+  const { columnNames, error: configError } = loadStateColumnMap(cwd);
+  // Fail CLOSED on a malformed `.devloops` when --next-up drives the target:
+  // silently using the literal "Next Up" could land in the wrong column (#1098).
+  // A plain `--column X` add never consults statusColumns, so it is unaffected.
+  if (args.nextUp && configError) {
+    throw Object.assign(
+      new Error(`could not resolve next_up column (config read/parse error: ${configError})`),
+      { code: "CONFIG_ERROR" },
+    );
+  }
+  const nextUpColumn = columnNames[LOGICAL_COLUMN.NEXT_UP];
   const explicitColumn = args.column ?? args.status ?? null;
   if (args.nextUp && explicitColumn != null && explicitColumn.trim() !== nextUpColumn) {
     throw Object.assign(

--- a/scripts/projects/add-queue-item.mjs
+++ b/scripts/projects/add-queue-item.mjs
@@ -4,6 +4,7 @@ import { runChild as _runChild } from "../_cli-primitives.mjs";
 import { resolveProjectSelector, findProject, applyDevloopsBoard } from "./_resolve-project.mjs";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+import { loadStateColumnMap, LOGICAL_COLUMN } from "@dev-loops/core/loop/queue-board-sync";
 
 const USAGE = `Usage: dev-loops queue add --repo <owner/name> [--project <number|id>] --item <number>
        dev-loops project add … (back-compat alias for "queue add")
@@ -370,7 +371,7 @@ function classifyExitCode(err) {
 
 // ── Main logic ──────────────────────────────────────────────────────────
 
-async function main(args, { env = process.env, runChild } = {}) {
+async function main(args, { env = process.env, runChild, cwd = process.cwd() } = {}) {
   const child = runChild ?? _runChild;
   const repo = validateRepo(args.repo);
   const [owner, repoName] = repo.split("/");
@@ -385,16 +386,19 @@ async function main(args, { env = process.env, runChild } = {}) {
       { code: "INVALID_ARGS", usage: USAGE },
     );
   }
-  // --next-up is sugar for --column "Next Up" (the normative pickup queue, #1091).
-  // Reject combining it with a conflicting explicit column/status.
+  // --next-up is sugar for --column <resolved next_up display name> (the
+  // normative pickup queue, #1091), resolved through the SAME statusColumns
+  // mapping board-sync uses (#1098) so a renamed Next Up column agrees with
+  // an explicit --column of the same configured name.
+  const nextUpColumn = loadStateColumnMap(cwd).columnNames[LOGICAL_COLUMN.NEXT_UP];
   const explicitColumn = args.column ?? args.status ?? null;
-  if (args.nextUp && explicitColumn != null && explicitColumn.trim() !== "Next Up") {
+  if (args.nextUp && explicitColumn != null && explicitColumn.trim() !== nextUpColumn) {
     throw Object.assign(
       new Error(`Conflicting --next-up and --column/--status ("${explicitColumn}") — pass only one.`),
       { code: "INVALID_ARGS", usage: USAGE },
     );
   }
-  const targetStatus = (args.nextUp ? "Next Up" : (explicitColumn ?? "Backlog")).trim();
+  const targetStatus = (args.nextUp ? nextUpColumn : (explicitColumn ?? "Backlog")).trim();
   if (!targetStatus) {
     throw Object.assign(new Error("--column must not be empty"), { code: "INVALID_STATUS" });
   }
@@ -543,7 +547,7 @@ async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, 
   applyDevloopsBoard(args, cwd);
 
   try {
-    const result = await main(args, { env, runChild });
+    const result = await main(args, { env, runChild, cwd });
     process.exitCode = emitResult(result, { jq: args.jq, silent: args.silent, stdout, stderr });
   } catch (err) {
     stderr.write(JSON.stringify({ ok: false, error: err.message, code: err.code ?? "UNKNOWN" }) + "\n");

--- a/scripts/projects/resolve-active-board-item.mjs
+++ b/scripts/projects/resolve-active-board-item.mjs
@@ -19,8 +19,11 @@ import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 import { main as listQueueItems } from "./list-queue-items.mjs";
 import { EMPTY_NEXT_UP_MESSAGE } from "@dev-loops/core/loop/queue-board-ordering";
+import { loadStateColumnMap, LOGICAL_COLUMN } from "@dev-loops/core/loop/queue-board-sync";
 
 const IN_PROGRESS_COLUMN = "In Progress";
+// Illustrative default label for USAGE/help + comments only; the actual query
+// column resolves through queue.statusColumns.next_up at runtime (#1098).
 const NEXT_UP_COLUMN = "Next Up";
 // Canonical fail-closed empty-queue message — matches queue-driver.mjs so
 // operators see one string regardless of which layer detects it (#1091).
@@ -147,9 +150,14 @@ function collapseToTarget(items) {
 // column, HEAD by POSITION ascending (list-queue-items returns position order).
 // NEVER pulls from Backlog; empty Next Up fails closed with the canonical
 // message, and a query error propagates (fail closed — surface it, no fallback).
-async function resolveNextUpHead(args, { env, runChild } = {}) {
+async function resolveNextUpHead(args, { env, runChild, cwd = process.cwd() } = {}) {
+  // Resolve the next_up column name through the SAME statusColumns mapping
+  // board-sync uses (#1098): a repo that renamed Next Up (e.g. to "Todo") gets
+  // its configured column queried, not the literal default. Pickup SEMANTICS
+  // (position-ascending HEAD, fail-closed on empty, never Backlog) are unchanged.
+  const nextUpColumn = loadStateColumnMap(cwd).columnNames[LOGICAL_COLUMN.NEXT_UP];
   const listed = await listQueueItems(
-    { repo: args.repo, project: args.project, column: NEXT_UP_COLUMN },
+    { repo: args.repo, project: args.project, column: nextUpColumn },
     { env, runChild },
   );
   const items = listed.items ?? [];
@@ -159,7 +167,7 @@ async function resolveNextUpHead(args, { env, runChild } = {}) {
   return { ok: true, target: itemToTarget(items[0]), source: "next-up" };
 }
 
-async function main(args, { env = process.env, runChild } = {}) {
+async function main(args, { env = process.env, runChild, cwd = process.cwd() } = {}) {
   const listed = await listQueueItems(
     { repo: args.repo, project: args.project, column: IN_PROGRESS_COLUMN },
     { env, runChild },
@@ -168,7 +176,7 @@ async function main(args, { env = process.env, runChild } = {}) {
   // Exactly one → continue it. Multiple → fail closed (never guess). Zero →
   // fall through to the Next Up head (the live pickup path, #1091).
   if (items.length === 0) {
-    return resolveNextUpHead(args, { env, runChild });
+    return resolveNextUpHead(args, { env, runChild, cwd });
   }
   return collapseToTarget(items);
 }
@@ -179,7 +187,7 @@ function classifyExitCode(err) {
   return 2;
 }
 
-async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, env = process.env, runChild } = {}) {
+async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, env = process.env, runChild, cwd = process.cwd() } = {}) {
   let args;
   try {
     args = parseCliArgs(argv);
@@ -193,7 +201,7 @@ async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, 
     return;
   }
   try {
-    const result = await main(args, { env, runChild });
+    const result = await main(args, { env, runChild, cwd });
     // Fail closed (zero/multiple) is a clean, expected outcome — distinct exit code 3,
     // not a crash; --jq/--silent still apply so callers can probe `.ok`.
     process.exitCode = emitResult(result, {

--- a/scripts/projects/resolve-active-board-item.mjs
+++ b/scripts/projects/resolve-active-board-item.mjs
@@ -155,7 +155,18 @@ async function resolveNextUpHead(args, { env, runChild, cwd = process.cwd() } = 
   // board-sync uses (#1098): a repo that renamed Next Up (e.g. to "Todo") gets
   // its configured column queried, not the literal default. Pickup SEMANTICS
   // (position-ascending HEAD, fail-closed on empty, never Backlog) are unchanged.
-  const nextUpColumn = loadStateColumnMap(cwd).columnNames[LOGICAL_COLUMN.NEXT_UP];
+  const { columnNames, error: configError } = loadStateColumnMap(cwd);
+  if (configError) {
+    // A malformed `.devloops` must fail CLOSED — never silently fall back to the
+    // literal "Next Up" and risk selecting the wrong item from a stale/renamed
+    // column (#1098). Throw so the CLI surfaces it (exit 2), mirroring a Next Up
+    // query error's "propagate, no fallback" contract.
+    throw Object.assign(
+      new Error(`could not resolve next_up column (config read/parse error: ${configError})`),
+      { code: "CONFIG_ERROR" },
+    );
+  }
+  const nextUpColumn = columnNames[LOGICAL_COLUMN.NEXT_UP];
   const listed = await listQueueItems(
     { repo: args.repo, project: args.project, column: nextUpColumn },
     { env, runChild },

--- a/test/projects/add-queue-item.test.mjs
+++ b/test/projects/add-queue-item.test.mjs
@@ -692,22 +692,54 @@ describe("add-queue-item", () => {
       });
     });
 
-    it("main() without a cwd override still resolves --next-up to the default \"Next Up\"", async () => {
-      const responses = [
-        { payload: userPayload() },
-        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
-        { payload: getFieldsResponse([STATUS_FIELD]) },
-        { payload: emptyItemsResponse() },
-        { payload: resolveIssueResponse("I_kwDO_10") },
-        { payload: addItemResponse("PVTI_new") },
-        { payload: updateFieldResponse() },
-      ];
-      const result = await main(
-        { repo: "mfittko/dev-loops", project: "1", item: 10, nextUp: true },
-        { env: {}, runChild: mockRunChild(responses) },
-      );
-      assert.equal(result.ok, true);
-      assert.equal(result.item.status, "Next Up");
+    it("main() rejects --next-up + the OLD literal --column \"Next Up\" once next_up is renamed to \"Todo\"", async () => {
+      await withTempCwd('queue:\n  projectNumber: 1\n  statusColumns:\n    next_up: "Todo"\n', async (cwd) => {
+        await assert.rejects(
+          () =>
+            main(
+              { repo: "mfittko/dev-loops", project: "1", item: 10, nextUp: true, column: "Next Up" },
+              { env: {}, runChild: mockRunChild([]), cwd },
+            ),
+          /Conflicting --next-up and --column\/--status/,
+        );
+      });
+    });
+
+    it("main() fails CLOSED on a malformed .devloops when --next-up drives the target (no literal fallback)", async () => {
+      // Genuinely un-parseable YAML → loadStateColumnMap surfaces an error;
+      // --next-up must throw rather than silently querying the literal "Next Up".
+      await withTempCwd("queue: renamed\n- broken\n", async (cwd) => {
+        await assert.rejects(
+          () =>
+            main(
+              { repo: "mfittko/dev-loops", project: "1", item: 10, nextUp: true },
+              { env: {}, runChild: mockRunChild([]), cwd },
+            ),
+          /config read\/parse error/,
+        );
+      });
+    });
+
+    it("main() with an override-free .devloops still resolves --next-up to the default \"Next Up\" (hermetic cwd)", async () => {
+      // Hermetic: explicit empty-config temp cwd so this can't break if the real
+      // repo's .devloops ever gains a next_up override.
+      await withTempCwd("queue:\n  projectNumber: 1\n", async (cwd) => {
+        const responses = [
+          { payload: userPayload() },
+          { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+          { payload: getFieldsResponse([STATUS_FIELD]) },
+          { payload: emptyItemsResponse() },
+          { payload: resolveIssueResponse("I_kwDO_10") },
+          { payload: addItemResponse("PVTI_new") },
+          { payload: updateFieldResponse() },
+        ];
+        const result = await main(
+          { repo: "mfittko/dev-loops", project: "1", item: 10, nextUp: true },
+          { env: {}, runChild: mockRunChild(responses), cwd },
+        );
+        assert.equal(result.ok, true);
+        assert.equal(result.item.status, "Next Up");
+      });
     });
   });
 

--- a/test/projects/add-queue-item.test.mjs
+++ b/test/projects/add-queue-item.test.mjs
@@ -630,6 +630,87 @@ describe("add-queue-item", () => {
     });
   });
 
+  describe("--next-up resolves the configured next_up column (#1098)", () => {
+    const TODO_STATUS_FIELD = {
+      id: "PVTSSF_status",
+      name: "Status",
+      options: [
+        { id: "opt1", name: "Backlog" },
+        { id: "opt2", name: "Todo" },
+        { id: "opt3", name: "In Progress" },
+        { id: "opt4", name: "Done" },
+      ],
+    };
+
+    async function withTempCwd(contents, fn) {
+      const dir = mkdtempSync(nodePath.join(tmpdir(), "add-queue-statuscol-"));
+      try {
+        if (contents !== null) writeFileSync(nodePath.join(dir, ".devloops"), contents, "utf-8");
+        return await fn(dir);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+
+    it("main() lands --next-up in the overridden statusColumns.next_up column (\"Todo\")", async () => {
+      await withTempCwd('queue:\n  projectNumber: 1\n  statusColumns:\n    next_up: "Todo"\n', async (cwd) => {
+        const responses = [
+          { payload: userPayload() },
+          { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+          { payload: getFieldsResponse([TODO_STATUS_FIELD]) },
+          { payload: emptyItemsResponse() },
+          { payload: resolveIssueResponse("I_kwDO_10") },
+          { payload: addItemResponse("PVTI_new") },
+          { payload: updateFieldResponse() },
+        ];
+        const result = await main(
+          { repo: "mfittko/dev-loops", project: "1", item: 10, nextUp: true },
+          { env: {}, runChild: mockRunChild(responses), cwd },
+        );
+        assert.equal(result.ok, true);
+        assert.equal(result.item.status, "Todo");
+      });
+    });
+
+    it("main() accepts --next-up together with an agreeing --column \"Todo\" under the same override", async () => {
+      await withTempCwd('queue:\n  projectNumber: 1\n  statusColumns:\n    next_up: "Todo"\n', async (cwd) => {
+        const responses = [
+          { payload: userPayload() },
+          { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+          { payload: getFieldsResponse([TODO_STATUS_FIELD]) },
+          { payload: emptyItemsResponse() },
+          { payload: resolveIssueResponse("I_kwDO_10") },
+          { payload: addItemResponse("PVTI_new") },
+          { payload: updateFieldResponse() },
+        ];
+        const result = await main(
+          { repo: "mfittko/dev-loops", project: "1", item: 10, nextUp: true, column: "Todo" },
+          { env: {}, runChild: mockRunChild(responses), cwd },
+        );
+        assert.equal(result.ok, true);
+        assert.equal(result.item.status, "Todo");
+      });
+    });
+
+    it("main() without a cwd override still resolves --next-up to the default \"Next Up\"", async () => {
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([STATUS_FIELD]) },
+        { payload: emptyItemsResponse() },
+        { payload: resolveIssueResponse("I_kwDO_10") },
+        { payload: addItemResponse("PVTI_new") },
+        { payload: updateFieldResponse() },
+      ];
+      const result = await main(
+        { repo: "mfittko/dev-loops", project: "1", item: 10, nextUp: true },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.item.status, "Next Up");
+    });
+  });
+
   describe("optional --project resolved from .devloops (#1035)", () => {
     function addResponses(project) {
       return [

--- a/test/projects/resolve-active-board-item.test.mjs
+++ b/test/projects/resolve-active-board-item.test.mjs
@@ -219,4 +219,18 @@ describe("resolve-active-board-item resolves the configured next_up column (#109
       assert.deepEqual(r, { ok: true, target: { kind: "issue", number: 7 }, source: "next-up" });
     });
   });
+
+  it("malformed .devloops → pickup fails CLOSED (surfaces config error), never queries the literal \"Next Up\"", async () => {
+    // Zero In Progress → falls through to resolveNextUpHead, which must throw on
+    // an un-parseable config rather than silently querying the default column.
+    await withTempCwd("queue: renamed\n- broken\n", async (cwd) => {
+      const child = boardRunChild({
+        columns: { "In Progress": [], "Next Up": [{ issueNumber: 7, title: "Head" }] },
+      });
+      await assert.rejects(
+        () => main({ repo: "o/r", project: "7" }, { runChild: child, cwd }),
+        /config read\/parse error/,
+      );
+    });
+  });
 });

--- a/test/projects/resolve-active-board-item.test.mjs
+++ b/test/projects/resolve-active-board-item.test.mjs
@@ -1,5 +1,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import nodePath from "node:path";
 import { collapseToTarget, main, runCli } from "../../scripts/projects/resolve-active-board-item.mjs";
 
 // A runChild stub that drives list-queue-items end to end. `columns` maps a
@@ -9,9 +12,9 @@ import { collapseToTarget, main, runCli } from "../../scripts/projects/resolve-a
 // the resolver's --column filter pick. `itemsError` forces only the SECOND items
 // query to fail (the resolver queries In Progress first, then Next Up), so the
 // In Progress query succeeds and only the Next Up query errors / hits an outage.
-function boardRunChild({ columns = {}, itemsError = false } = {}) {
+function boardRunChild({ columns = {}, itemsError = false, optionNames = ["Backlog", "Next Up", "In Progress", "Done"] } = {}) {
   let itemsQueryCount = 0;
-  const options = ["Backlog", "Next Up", "In Progress", "Done"].map((name, i) => ({ id: `O_${i}`, name }));
+  const options = optionNames.map((name, i) => ({ id: `O_${i}`, name }));
   const nodes = [];
   for (const [status, items] of Object.entries(columns)) {
     for (const it of items) {
@@ -179,5 +182,41 @@ describe("resolve-active-board-item CLI exit codes", () => {
     assert.equal(code, 2);
     const parsed = JSON.parse(err);
     assert.equal(parsed.ok, false);
+  });
+});
+
+describe("resolve-active-board-item resolves the configured next_up column (#1098)", () => {
+  async function withTempCwd(contents, fn) {
+    const dir = mkdtempSync(nodePath.join(tmpdir(), "resolve-active-statuscol-"));
+    try {
+      if (contents !== null) writeFileSync(nodePath.join(dir, ".devloops"), contents, "utf-8");
+      return await fn(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("pickup queries the overridden statusColumns.next_up column (\"Todo\"), not the literal", async () => {
+    await withTempCwd('queue:\n  projectNumber: 7\n  statusColumns:\n    next_up: "Todo"\n', async (cwd) => {
+      // Head item lives ONLY in the renamed "Todo" column. If the resolver still
+      // queried the literal "Next Up", it would see an empty column and fail
+      // closed — so a resolved target proves it queried the configured name.
+      const child = boardRunChild({
+        optionNames: ["Backlog", "Todo", "In Progress", "Done"],
+        columns: { "In Progress": [], "Todo": [{ issueNumber: 42, title: "Head" }] },
+      });
+      const r = await main({ repo: "o/r", project: "7" }, { runChild: child, cwd });
+      assert.deepEqual(r, { ok: true, target: { kind: "issue", number: 42 }, source: "next-up" });
+    });
+  });
+
+  it("default config (no override) still resolves the literal \"Next Up\"", async () => {
+    await withTempCwd(null, async (cwd) => {
+      const child = boardRunChild({
+        columns: { "In Progress": [], "Next Up": [{ issueNumber: 7, title: "Head" }] },
+      });
+      const r = await main({ repo: "o/r", project: "7" }, { runChild: child, cwd });
+      assert.deepEqual(r, { ok: true, target: { kind: "issue", number: 7 }, source: "next-up" });
+    });
   });
 });


### PR DESCRIPTION
Closes #1098.

## Summary
Make the Next Up column name configurable **end-to-end**: the ordering, live-pickup, and add-queue layers now resolve the logical `next_up` column to its display name via the same single-source resolver board-sync uses, instead of hardcoding the literal `"Next Up"`.

## Problem
`queue-board-sync.mjs` resolves logical columns (next_up/in_progress/ready_for_review/done) through `queue.statusColumns` overrides (per `docs/queue-board-setup.md`). But the ordering + projects-script layers hardcoded `"Next Up"` and never consulted that mapping. A repo that renamed its next_up column via `.devloops` `queue.statusColumns.next_up` (e.g. to `Todo`) got a driver that queried a non-existent `"Next Up"` column — a fail-closed board-query error or an empty pickup.

## Scope and context
Resolve logical→display via the SAME mechanism board-sync uses (`loadStateColumnMap` + `LOGICAL_COLUMN`, exported from `queue-board-sync.mjs`) — board-sync stays the single source of the mapping, no duplication. The #1091 fail-closed pickup **semantics** are out of scope and unchanged; this only makes the column **name** configurable.

## File-by-file changes
- `packages/core/src/loop/queue-board-sync.mjs` — `loadStateColumnMap` now surfaces the `.devloops` read/parse `error` (returns `{ columnNames, stateColumnMap, error }`, mirroring `loadBoardConfig`); existing `.columnNames`-only callers are unaffected. This lets the next_up consumers **fail closed** on a malformed config instead of silently querying the literal default.
- `packages/core/src/loop/queue-board-ordering.mjs` — `resolveNextUpOrder` queries the resolved next_up display name (`loadStateColumnMap(repoRoot).columnNames[LOGICAL_COLUMN.NEXT_UP]`), not the literal.
- `scripts/projects/resolve-active-board-item.mjs` — the **live pickup driver** resolves the next_up column at query time (threads a `cwd` option through `runCli → main → resolveNextUpHead`). All #1091 pickup semantics byte-identical. On a config read/parse error it throws `CONFIG_ERROR` (fail closed — honoring the documented "query errors → propagate, no fallback"), never falling back to the literal. The `NEXT_UP_COLUMN` constant is retained solely for illustrative USAGE/help text.
- `scripts/projects/add-queue-item.mjs` — `--next-up` lands in the resolved next_up column, and the `--column` conflict guard compares against the resolved name (so `--next-up` + `--column Todo` agree under a Todo override).
- `packages/core/test/queue-board-ordering.test.mjs`, `packages/core/test/queue-board-sync.test.mjs`, `test/projects/add-queue-item.test.mjs`, `test/projects/resolve-active-board-item.test.mjs` — tests with a non-default `queue.statusColumns.next_up: "Todo"` override, default-config regressions, and the fail-closed config-error paths (loadStateColumnMap error-surfacing; malformed `.devloops` → pickup/add fail closed; conflict-under-override).

## Acceptance criteria
- [x] `resolveNextUpOrder` queries the configured next_up display name under a non-default override.
- [x] The live pickup path (`resolve-active-board-item`) queries the overridden column, not the literal — its #1091 semantics unchanged.
- [x] `add-queue-item --next-up` targets the resolved column; `--column <configured-name>` agrees with the conflict guard.
- [x] The logical→display mapping stays single-source (board-sync's `loadStateColumnMap`), not duplicated.
- [x] Default config (no override) resolves `"Next Up"` everywhere (regression-guarded).

## Definition of done
- [x] Tests added with a non-default override + default regressions.
- [x] `npm run verify` green (0 failures).

## Non-goals
- Resolving the sibling logical columns (`in_progress`, …) still hardcoded in the pickup path — filed as follow-up #1143 (post-0.7).
- The #1091 fail-closed pickup semantics themselves (already landed) — only the column name is made configurable.
- `list/move-queue-item` (they only accept an explicit user-supplied `--column`, no hardcoded logical default to resolve).
- `run-queue.mjs` (dormant no-op adapter, not the live path).
- Board provisioning (`ensure-queue-board` creating the default-named column) — separate concern, not part of the pickup/ordering path.

## Validation command
```
npm run verify
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
