### PR TITLE
fix(loop): bake the sanctioned operation→wrapper command map into the handoff (#1081)

### DIFF
--- a/.claude/agents/dev-loop.md
+++ b/.claude/agents/dev-loop.md
@@ -19,6 +19,7 @@ The envelope is the primary handoff artifact — it is derived from resolver out
 - `nextAction` — the bounded task to execute
 - `stopRules` — stop boundaries that must not be crossed without authorization
 - `acceptance` — self-validation criteria for declaring completion
+- `sanctionedCommands` — the operation → wrapper command map (reads/edits/lifecycle), plus the forbidden and orchestrator-owned lists. Carried by DEFAULT on every build so you never re-derive which wrapper performs a GitHub/loop operation. Do NOT restate the map here — the single source of truth is `scripts/loop/sanctioned-commands.mjs`, surfaced verbatim in the envelope.
 
 **Construction sequence:**
 

--- a/.claude/skills/docs/workflow-handoff-contract.md
+++ b/.claude/skills/docs/workflow-handoff-contract.md
@@ -17,6 +17,35 @@ template.
 | Gate state (detectors) + strategy defaults | `currentGate`, `worktreeRequired` |
 | Settings (`.devloops` at repo root + `defaults.yaml`) | `gateConfig`, `stopRules`, `asyncStartMode`, `requireDraftFirst`, `maxCopilotRounds` |
 | Gate state (detectors) | `currentHeadSha`, `ciStatus`, `unresolvedThreadCount`, `copilotRoundCount` |
+| Canonical sanctioned-command map (`scripts/loop/sanctioned-commands.mjs`) | `sanctionedCommands` |
+
+## Sanctioned commands (MANDATORY DEFAULT — issue #1081)
+
+`sanctionedCommands` is a **mandatory default** element of every handoff
+envelope. It is the operation → wrapper command map (which wrapper performs
+which GitHub/loop operation), plus the forbidden and orchestrator-owned lists.
+The `loop build-envelope` CLI injects it into every emitted envelope, so a
+spawned dev-loop subagent receives it verbatim without the briefer adding it —
+no re-deriving which wrapper does `gh pr ready` etc.
+
+The **single source of truth** is `scripts/loop/sanctioned-commands.mjs` (a
+frozen data module). `@dev-loops/core` stays consumer-agnostic: it defines the
+envelope SHAPE and carries whatever `sanctionedCommands` object the consumer
+supplies; the repo-specific `scripts/...` paths live only in the consumer
+module. Do not duplicate the map into prose — reference the module.
+
+```typescript
+sanctionedCommands?: {
+  reads: Record<string, string>;         // operation → wrapper path (some also accept `loop info`)
+  edits: Record<string, string>;
+  lifecycle: Record<string, string>;
+  forbidden: string[];                   // raw `gh pr view/checks/edit`, `node -e`, `python -c`, transcript tailing, sleep-poll loops
+  orchestratorOwned: string[];           // `gh pr merge`, board status transitions — never done by a subagent
+};
+```
+
+A contract test (`test/contracts/sanctioned-commands-exist.test.mjs`) asserts
+every mapped wrapper exists on disk and fails closed if one is renamed/removed.
 
 ## Acceptance templates
 
@@ -111,6 +140,15 @@ interface HandoffEnvelope {
     scopeConstraint?: string;
     customStopAt?: string;
   };
+
+  // Mandatory default (issue #1081). Source: scripts/loop/sanctioned-commands.mjs
+  sanctionedCommands?: {
+    reads: Record<string, string>;
+    edits: Record<string, string>;
+    lifecycle: Record<string, string>;
+    forbidden: string[];
+    orchestratorOwned: string[];
+  };
 }
 ```
 
@@ -121,6 +159,7 @@ interface HandoffEnvelope {
 3. Execute `nextAction`.
 4. Respect `stopRules` — do not proceed past a gated stop point without authorization.
 5. Use `acceptance` to self-validate before declaring completion.
+6. Use `sanctionedCommands` as the authoritative operation → wrapper map: never call a raw `gh`/`node -e`/`python -c` for an operation the map covers, and never perform an `orchestratorOwned` action.
 
 ## Backward compatibility
 

--- a/agents/dev-loop.agent.md
+++ b/agents/dev-loop.agent.md
@@ -23,6 +23,7 @@ The envelope is the primary handoff artifact — it is derived from resolver out
 - `nextAction` — the bounded task to execute
 - `stopRules` — stop boundaries that must not be crossed without authorization
 - `acceptance` — self-validation criteria for declaring completion
+- `sanctionedCommands` — the operation → wrapper command map (reads/edits/lifecycle), plus the forbidden and orchestrator-owned lists. Carried by DEFAULT on every build so you never re-derive which wrapper performs a GitHub/loop operation. Do NOT restate the map here — the single source of truth is `scripts/loop/sanctioned-commands.mjs`, surfaced verbatim in the envelope.
 
 **Construction sequence:**
 <!-- pi-only -->

--- a/packages/core/src/loop/handoff-envelope.mjs
+++ b/packages/core/src/loop/handoff-envelope.mjs
@@ -509,6 +509,15 @@ export function buildDevLoopHandoffEnvelope(resolverOutput, settings, gateState 
     ? { ...options.overrides }
     : undefined;
 
+  // Sanctioned operation → wrapper command map (issue #1081). Core is
+  // consumer-agnostic: it carries whatever map the consumer supplies (the
+  // `loop build-envelope` CLI injects this repo's scripts/... paths) so every
+  // spawned subagent receives it by DEFAULT. Core defines the SHAPE only —
+  // it never hardcodes repo-specific paths. A non-object is ignored.
+  const sanctionedCommands = options.sanctionedCommands && typeof options.sanctionedCommands === "object" && !Array.isArray(options.sanctionedCommands)
+    ? options.sanctionedCommands
+    : undefined;
+
   // Surface the *effective* async-start posture alongside the *configured* one (#834). The
   // configured `asyncStartMode` is echoed verbatim from settings (back-compat), but the contract
   // is relaxed at validation time under the Claude harness (resolveEffectiveAsyncStartMode →
@@ -562,6 +571,10 @@ export function buildDevLoopHandoffEnvelope(resolverOutput, settings, gateState 
 
   if (overrides) {
     envelope.overrides = overrides;
+  }
+
+  if (sanctionedCommands) {
+    envelope.sanctionedCommands = sanctionedCommands;
   }
 
   // Advisory retrospective findings (issue #1077, Reading B). Optional structured

--- a/scripts/loop/build-handoff-envelope.mjs
+++ b/scripts/loop/build-handoff-envelope.mjs
@@ -24,6 +24,7 @@ import { loadDevLoopConfig } from "@dev-loops/core/config";
 import { createPiAdapter } from "@dev-loops/core/harness";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+import { SANCTIONED_COMMANDS } from "./sanctioned-commands.mjs";
 
 const USAGE = `Usage: build-handoff-envelope.mjs --input <path>
 Build a deterministic handoff envelope from startup resolver output and settings.
@@ -147,6 +148,10 @@ export async function buildHandoffEnvelopeCli(
 
   // Build options for envelope builder
   const envelopeOptions = {};
+
+  // Carry the canonical sanctioned operation → wrapper command map (issue #1081)
+  // into every emitted envelope by DEFAULT so spawned subagents never re-derive it.
+  envelopeOptions.sanctionedCommands = SANCTIONED_COMMANDS;
 
   // Repo slug: explicit --repo, then resolver output bundle, then git remote
   const bundleSlug = resolverOutput?.bundle?.repoSlug ?? resolverOutput?.bundle?.repo ?? null;

--- a/scripts/loop/sanctioned-commands.mjs
+++ b/scripts/loop/sanctioned-commands.mjs
@@ -38,7 +38,11 @@ export const SANCTIONED_COMMANDS = Object.freeze({
     "issue-comment": "scripts/github/comment-issue.mjs",
   }),
 
-  // Lifecycle mutations (state transitions on the PR / review / board).
+  // Lifecycle mutations a subagent MAY perform (state transitions on the PR /
+  // review). Board status transitions are deliberately NOT here — they are
+  // orchestratorOwned (see below): in the current batch model the orchestrator
+  // owns board moves, and a subagent's In-Progress move rides ready-for-review.mjs
+  // (#1069), so there is no standalone subagent-sanctioned board-sync op.
   lifecycle: Object.freeze({
     "ready-for-review": "scripts/github/ready-for-review.mjs",
     "pr-create": "scripts/github/create-pr.mjs",
@@ -46,7 +50,6 @@ export const SANCTIONED_COMMANDS = Object.freeze({
     "reply-resolve-thread": "scripts/github/reply-resolve-review-thread.mjs",
     "reply-resolve-threads": "scripts/github/reply-resolve-review-threads.mjs",
     "gate-verdict-comment": "scripts/github/upsert-checkpoint-verdict.mjs",
-    "board-status-sync": "scripts/projects/sync-item-status.mjs",
   }),
 
   // Never allowed for any operation above — the sanctioned wrapper is mandatory.
@@ -63,23 +66,36 @@ export const SANCTIONED_COMMANDS = Object.freeze({
     "sleep-poll loops",
   ]),
 
-  // Orchestrator-owned: a spawned dev-loop subagent must NEVER do these.
+  // Orchestrator-owned: a spawned dev-loop subagent must NEVER do these. Board
+  // status transitions live here (not in `lifecycle`) — the orchestrator owns
+  // move-queue-item/sync-item-status in the current batch model.
   orchestratorOwned: Object.freeze([
     "gh pr merge",
-    "board status transitions (current batch model)",
+    "board status transitions (move-queue-item / sync-item-status.mjs; current batch model)",
   ]),
 });
 
+// The wrapper-path-bearing groups are the object-valued groups (reads/edits/
+// lifecycle); `forbidden`/`orchestratorOwned` are string arrays, not path maps.
+const PATH_GROUP_KEYS = Object.freeze(
+  Object.keys(SANCTIONED_COMMANDS).filter(
+    (k) => !Array.isArray(SANCTIONED_COMMANDS[k]),
+  ),
+);
+
 /**
- * Flat list of every repo-root-relative wrapper path named in the map.
- * Shared by the existence contract test so the map cannot drift from disk.
+ * EVERY repo-root-relative value named across the path-bearing groups — with NO
+ * shape filtering, so a malformed/typo'd entry is RETURNED (and then fails the
+ * contract test's shape+existence assertions) rather than being silently
+ * skipped. Auto-includes any future path-bearing group. This is what keeps the
+ * map from drifting off disk (#1081).
  * @returns {string[]}
  */
 export function listSanctionedWrapperPaths() {
   const out = [];
-  for (const group of [SANCTIONED_COMMANDS.reads, SANCTIONED_COMMANDS.edits, SANCTIONED_COMMANDS.lifecycle]) {
-    for (const value of Object.values(group)) {
-      if (typeof value === "string" && /^scripts\/.+\.mjs$/.test(value)) out.push(value);
+  for (const key of PATH_GROUP_KEYS) {
+    for (const value of Object.values(SANCTIONED_COMMANDS[key])) {
+      out.push(value);
     }
   }
   return out;

--- a/scripts/loop/sanctioned-commands.mjs
+++ b/scripts/loop/sanctioned-commands.mjs
@@ -84,12 +84,14 @@ const PATH_GROUP_KEYS = Object.freeze(
 );
 
 /**
- * EVERY repo-root-relative value named across the path-bearing groups — with NO
- * shape filtering, so a malformed/typo'd entry is RETURNED (and then fails the
- * contract test's shape+existence assertions) rather than being silently
- * skipped. Auto-includes any future path-bearing group. This is what keeps the
- * map from drifting off disk (#1081).
- * @returns {string[]}
+ * EVERY value named across the path-bearing groups — with NO shape filtering,
+ * so a malformed/typo'd entry is RETURNED (and then fails the contract test's
+ * shape+existence assertions) rather than being silently skipped. Auto-includes
+ * any future path-bearing group. This is what keeps the map from drifting off
+ * disk (#1081). For a well-formed map every element is a repo-root-relative
+ * `scripts/*.mjs` string; the no-filtering contract means a malformed map can
+ * yield a non-string here, which the contract test is designed to catch.
+ * @returns {unknown[]} wrapper-path values (strings for a well-formed map)
  */
 export function listSanctionedWrapperPaths() {
   const out = [];

--- a/scripts/loop/sanctioned-commands.mjs
+++ b/scripts/loop/sanctioned-commands.mjs
@@ -1,0 +1,86 @@
+/**
+ * Canonical sanctioned operation → wrapper command map (issue #1081).
+ *
+ * SINGLE SOURCE OF TRUTH for "which wrapper does a dev-loop subagent use for
+ * which GitHub/loop operation". Previously this knowledge was re-derived per
+ * handoff and scattered across SKILL.md / copilot-loop-operations.md /
+ * pr-lifecycle-contract.md, so subagents burned cycles rediscovering e.g.
+ * `gh pr ready` → scripts/github/ready-for-review.mjs.
+ *
+ * This lives in the CONSUMER layer (scripts/), NOT in @dev-loops/core, because
+ * the values are THIS repo's `scripts/...` wrapper paths. Core stays
+ * consumer-agnostic: it defines the envelope SHAPE and carries whatever
+ * `sanctionedCommands` object the consumer supplies. The
+ * `loop build-envelope` CLI injects this map into every emitted envelope so a
+ * spawned subagent receives it verbatim by DEFAULT, regardless of who wrote
+ * the handoff.
+ *
+ * Wrapper paths are repo-root-relative. A contract test
+ * (test/contracts/sanctioned-commands-exist.test.mjs) asserts every mapped
+ * wrapper exists on disk and fails closed if one is renamed/removed.
+ */
+
+export const SANCTIONED_COMMANDS = Object.freeze({
+  // Read-only lookups. Each value is the sanctioned wrapper; several also
+  // accept `loop info` as an equivalent aggregate read (noted in the doc).
+  reads: Object.freeze({
+    "pr-facts": "scripts/github/view-pr.mjs",
+    "ci-status": "scripts/github/probe-ci-status.mjs",
+    "ci-logs": "scripts/github/fetch-ci-logs.mjs",
+    "issue-list": "scripts/github/list-issues.mjs",
+    "copilot-review-state": "scripts/github/probe-copilot-review.mjs",
+    "gate-coordination": "scripts/loop/detect-pr-gate-coordination-state.mjs",
+  }),
+
+  // Metadata edits.
+  edits: Object.freeze({
+    "pr-body-title-assignee-milestone": "scripts/github/edit-pr.mjs",
+    "issue-comment": "scripts/github/comment-issue.mjs",
+  }),
+
+  // Lifecycle mutations (state transitions on the PR / review / board).
+  lifecycle: Object.freeze({
+    "ready-for-review": "scripts/github/ready-for-review.mjs",
+    "pr-create": "scripts/github/create-pr.mjs",
+    "copilot-request": "scripts/github/request-copilot-review.mjs",
+    "reply-resolve-thread": "scripts/github/reply-resolve-review-thread.mjs",
+    "reply-resolve-threads": "scripts/github/reply-resolve-review-threads.mjs",
+    "gate-verdict-comment": "scripts/github/upsert-checkpoint-verdict.mjs",
+    "board-status-sync": "scripts/projects/sync-item-status.mjs",
+  }),
+
+  // Never allowed for any operation above — the sanctioned wrapper is mandatory.
+  forbidden: Object.freeze([
+    "gh pr view",
+    "gh pr checks",
+    "gh pr edit",
+    "node -e",
+    "node --input-type=module -e",
+    "node -p",
+    "python -c",
+    "python3 -c",
+    "tailing subagent transcripts",
+    "sleep-poll loops",
+  ]),
+
+  // Orchestrator-owned: a spawned dev-loop subagent must NEVER do these.
+  orchestratorOwned: Object.freeze([
+    "gh pr merge",
+    "board status transitions (current batch model)",
+  ]),
+});
+
+/**
+ * Flat list of every repo-root-relative wrapper path named in the map.
+ * Shared by the existence contract test so the map cannot drift from disk.
+ * @returns {string[]}
+ */
+export function listSanctionedWrapperPaths() {
+  const out = [];
+  for (const group of [SANCTIONED_COMMANDS.reads, SANCTIONED_COMMANDS.edits, SANCTIONED_COMMANDS.lifecycle]) {
+    for (const value of Object.values(group)) {
+      if (typeof value === "string" && /^scripts\/.+\.mjs$/.test(value)) out.push(value);
+    }
+  }
+  return out;
+}

--- a/skills/docs/workflow-handoff-contract.md
+++ b/skills/docs/workflow-handoff-contract.md
@@ -17,6 +17,35 @@ template.
 | Gate state (detectors) + strategy defaults | `currentGate`, `worktreeRequired` |
 | Settings (`.devloops` at repo root + `defaults.yaml`) | `gateConfig`, `stopRules`, `asyncStartMode`, `requireDraftFirst`, `maxCopilotRounds` |
 | Gate state (detectors) | `currentHeadSha`, `ciStatus`, `unresolvedThreadCount`, `copilotRoundCount` |
+| Canonical sanctioned-command map (`scripts/loop/sanctioned-commands.mjs`) | `sanctionedCommands` |
+
+## Sanctioned commands (MANDATORY DEFAULT — issue #1081)
+
+`sanctionedCommands` is a **mandatory default** element of every handoff
+envelope. It is the operation → wrapper command map (which wrapper performs
+which GitHub/loop operation), plus the forbidden and orchestrator-owned lists.
+The `loop build-envelope` CLI injects it into every emitted envelope, so a
+spawned dev-loop subagent receives it verbatim without the briefer adding it —
+no re-deriving which wrapper does `gh pr ready` etc.
+
+The **single source of truth** is `scripts/loop/sanctioned-commands.mjs` (a
+frozen data module). `@dev-loops/core` stays consumer-agnostic: it defines the
+envelope SHAPE and carries whatever `sanctionedCommands` object the consumer
+supplies; the repo-specific `scripts/...` paths live only in the consumer
+module. Do not duplicate the map into prose — reference the module.
+
+```typescript
+sanctionedCommands?: {
+  reads: Record<string, string>;         // operation → wrapper path (some also accept `loop info`)
+  edits: Record<string, string>;
+  lifecycle: Record<string, string>;
+  forbidden: string[];                   // raw `gh pr view/checks/edit`, `node -e`, `python -c`, transcript tailing, sleep-poll loops
+  orchestratorOwned: string[];           // `gh pr merge`, board status transitions — never done by a subagent
+};
+```
+
+A contract test (`test/contracts/sanctioned-commands-exist.test.mjs`) asserts
+every mapped wrapper exists on disk and fails closed if one is renamed/removed.
 
 ## Acceptance templates
 
@@ -111,6 +140,15 @@ interface HandoffEnvelope {
     scopeConstraint?: string;
     customStopAt?: string;
   };
+
+  // Mandatory default (issue #1081). Source: scripts/loop/sanctioned-commands.mjs
+  sanctionedCommands?: {
+    reads: Record<string, string>;
+    edits: Record<string, string>;
+    lifecycle: Record<string, string>;
+    forbidden: string[];
+    orchestratorOwned: string[];
+  };
 }
 ```
 
@@ -121,6 +159,7 @@ interface HandoffEnvelope {
 3. Execute `nextAction`.
 4. Respect `stopRules` — do not proceed past a gated stop point without authorization.
 5. Use `acceptance` to self-validate before declaring completion.
+6. Use `sanctionedCommands` as the authoritative operation → wrapper map: never call a raw `gh`/`node -e`/`python -c` for an operation the map covers, and never perform an `orchestratorOwned` action.
 
 ## Backward compatibility
 

--- a/test/contracts/sanctioned-commands-exist.test.mjs
+++ b/test/contracts/sanctioned-commands-exist.test.mjs
@@ -16,11 +16,21 @@ import {
 
 const repoRootUrl = new URL("../../", import.meta.url);
 
-test("sanctioned-commands: every mapped wrapper exists on disk (fails closed)", async () => {
+test("sanctioned-commands: every mapped wrapper is well-shaped AND exists on disk (fails closed)", async () => {
   const paths = listSanctionedWrapperPaths();
   assert.ok(paths.length > 0, "map must name at least one wrapper path");
 
+  // listSanctionedWrapperPaths returns EVERY value across the path-bearing
+  // groups with no shape filtering, so a malformed/typo'd entry (wrong
+  // extension, non-scripts path, or a non-string) is caught here rather than
+  // silently skipped — the fail-OPEN hole this test must not have.
   for (const relPath of paths) {
+    assert.equal(typeof relPath, "string", `mapped wrapper value is not a string: ${JSON.stringify(relPath)}`);
+    assert.match(
+      relPath,
+      /^scripts\/.+\.mjs$/,
+      `mapped wrapper path is malformed (must be a repo-root-relative scripts/*.mjs path): ${relPath}`,
+    );
     const fileUrl = new URL(relPath, repoRootUrl);
     await assert.doesNotReject(
       access(fileUrl),
@@ -64,9 +74,11 @@ test("sanctioned-commands: the map is carried into the built handoff envelope", 
   const envelope = await buildHandoffEnvelopeCli({ inputPath }, { adapter });
 
   assert.ok(envelope.sanctionedCommands, "envelope must carry sanctionedCommands by default");
-  assert.equal(
-    envelope.sanctionedCommands.lifecycle["ready-for-review"],
-    "scripts/github/ready-for-review.mjs",
-    "envelope must carry the canonical map verbatim",
+  // Assert the WHOLE map is carried verbatim, not just one key — so a partial
+  // or mutated injection (e.g. a dropped group) fails the test.
+  assert.deepEqual(
+    envelope.sanctionedCommands,
+    SANCTIONED_COMMANDS,
+    "envelope must carry the canonical map verbatim (whole map, all groups)",
   );
 });

--- a/test/contracts/sanctioned-commands-exist.test.mjs
+++ b/test/contracts/sanctioned-commands-exist.test.mjs
@@ -1,0 +1,72 @@
+// Contract guard for issue #1081: the canonical sanctioned operation → wrapper
+// command map (scripts/loop/sanctioned-commands.mjs) is the SINGLE SOURCE OF
+// TRUTH carried into every handoff envelope. This test asserts every wrapper
+// path named in the map actually exists on disk, so the map cannot silently
+// drift when a wrapper is renamed or removed. It fails CLOSED: a missing
+// wrapper (or an empty map) is a hard failure.
+
+import assert from "node:assert/strict";
+import { access } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  SANCTIONED_COMMANDS,
+  listSanctionedWrapperPaths,
+} from "../../scripts/loop/sanctioned-commands.mjs";
+
+const repoRootUrl = new URL("../../", import.meta.url);
+
+test("sanctioned-commands: every mapped wrapper exists on disk (fails closed)", async () => {
+  const paths = listSanctionedWrapperPaths();
+  assert.ok(paths.length > 0, "map must name at least one wrapper path");
+
+  for (const relPath of paths) {
+    const fileUrl = new URL(relPath, repoRootUrl);
+    await assert.doesNotReject(
+      access(fileUrl),
+      `mapped wrapper missing on disk: ${relPath} — update scripts/loop/sanctioned-commands.mjs or restore the wrapper`,
+    );
+  }
+});
+
+test("sanctioned-commands: forbidden + orchestrator-owned lists are non-empty", () => {
+  assert.ok(SANCTIONED_COMMANDS.forbidden.length > 0, "forbidden list must not be empty");
+  assert.ok(SANCTIONED_COMMANDS.orchestratorOwned.length > 0, "orchestrator-owned list must not be empty");
+});
+
+test("sanctioned-commands: the map is carried into the built handoff envelope", async () => {
+  const { buildHandoffEnvelopeCli } = await import("../../scripts/loop/build-handoff-envelope.mjs");
+
+  // Minimal in-memory resolver output + stub adapter — no git/network.
+  const resolverOutput = {
+    bundle: {
+      selectedStrategy: "copilot_pr_followup",
+      executionMode: "bounded_handoff",
+      nextAction: "Draft PR implementation.",
+      requiredReads: ["skills/docs/public-dev-loop-contract.md"],
+      repoSlug: "owner/name",
+      activeArtifact: { kind: "issue", issue: 1 },
+    },
+  };
+
+  const { writeFile, mkdtemp } = await import("node:fs/promises");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const dir = await mkdtemp(path.join(os.tmpdir(), "sanctioned-cmd-"));
+  const inputPath = path.join(dir, "resolver.json");
+  await writeFile(inputPath, JSON.stringify(resolverOutput), "utf8");
+
+  const adapter = {
+    getCwd: () => dir,
+    getRepoRoot: () => dir,
+  };
+
+  const envelope = await buildHandoffEnvelopeCli({ inputPath }, { adapter });
+
+  assert.ok(envelope.sanctionedCommands, "envelope must carry sanctionedCommands by default");
+  assert.equal(
+    envelope.sanctionedCommands.lifecycle["ready-for-review"],
+    "scripts/github/ready-for-review.mjs",
+    "envelope must carry the canonical map verbatim",
+  );
+});


### PR DESCRIPTION
Closes #1081.

## Summary
Make the sanctioned **operation → wrapper command map** (+ forbidden list + orchestrator-owned list) a single-source, default, structural part of every dev-loop handoff, so a spawned subagent receives it verbatim instead of re-deriving "which wrapper for which operation" per handoff.

## Problem
That knowledge was scattered across `SKILL.md` / `copilot-loop-operations.md` / `pr-lifecycle-contract.md` and spelled out (or not) per handoff by whoever wrote it. Observed live in the 0.7 drive: a subagent burned reasoning cycles rediscovering the ready-for-review transition wrapper because the briefing had listed the read/edit wrappers but omitted the lifecycle ones.

## Scope and context
Single-source data module in the consumer layer; a path-free hook in core; unconditional injection at the envelope-building CLI; a reference (not a copy) in the dev-loop agent doc; an existence test; a contract-doc update. No wrapper behavior changes, no new wrappers.

## File-by-file changes
- `scripts/loop/sanctioned-commands.mjs` — **NEW** canonical data module: `SANCTIONED_COMMANDS` (`reads`/`edits`/`lifecycle` operation→wrapper maps + `forbidden` + `orchestratorOwned` lists) and `listSanctionedWrapperPaths()`. Lives in the consumer layer because its values are this repo's `scripts/...` paths.
- `packages/core/src/loop/handoff-envelope.mjs` — generic, **path-free** hook: `buildDevLoopHandoffEnvelope` accepts `options.sanctionedCommands` and carries it onto the envelope (deep-frozen). Core stays consumer-agnostic — it defines the shape; the consumer supplies the paths.
- `scripts/loop/build-handoff-envelope.mjs` — the `build-envelope` CLI injects `SANCTIONED_COMMANDS` **unconditionally**, so every emitted envelope carries the map by default.
- `agents/dev-loop.agent.md` — one bullet referencing the single source (no copy); regenerated `.claude/agents/dev-loop.md`.
- `test/contracts/sanctioned-commands-exist.test.mjs` — fails closed if any mapped wrapper is renamed/removed; also asserts the envelope output carries the map.
- `skills/docs/workflow-handoff-contract.md` (+ generated `.claude` copy) — documents the map as a mandatory default handoff element sourced from the one canonical location.

## Acceptance criteria
- [x] The handoff (envelope + `agents/dev-loop.agent.md`) includes the map + forbidden + orchestrator-owned lists by default; a spawned subagent has it without the briefer adding it.
- [x] The map is defined in ONE canonical location and referenced by the handoff — not copy-pasted per handoff/doc.
- [x] A dev-loop run performs the ready-for-review / reply-resolve / Copilot-request transitions via the mapped wrappers with no re-derivation — satisfied structurally: the map is carried in every emitted envelope by default (verified by the envelope-carry test), so a spawned subagent always has the sanctioned mechanism without re-deriving it. (Full runtime absence-of-churn is observable only across live loops, not unit-assertable.)
- [x] A test asserts every mapped wrapper exists (map stays in sync with the scripts), failing closed on drift — including malformed/typo'd entries and the whole-map envelope carry.
- [x] `workflow-handoff-contract.md` documents the map as a mandatory default handoff element.

## Definition of done
- [x] `npm run verify` green (0 failures).
- [x] `build-envelope` demonstrably emits `.sanctionedCommands`.

## Non-goals
- No dependency on repo-wiki/`.llmwiki` (deferred).
- No changes to what wrappers do; no new wrappers (that's #1057/#1071 territory).
- Did not rewrite the scattered prose mentions in SKILL.md/copilot-loop-operations.md/pr-lifecycle-contract.md into pointers (optional per the issue; kept the diff focused and avoided churning the duplicate-rules validator).

## Validation command
```
npm run verify
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
