### PR TITLE
ci: deduplicate the three Playwright smoke jobs via a composite action (#1058)

### DIFF
--- a/.github/actions/playwright-webkit/action.yml
+++ b/.github/actions/playwright-webkit/action.yml
@@ -1,0 +1,31 @@
+name: Set up Playwright WebKit
+description: >-
+  Installs Node + workspace dependencies and installs (with cache) the
+  Playwright WebKit runtime shared by the WebKit smoke jobs. The calling job
+  must check out the repository before this action, since a local action
+  (`uses: ./...`) can only be resolved once the repo is on disk.
+runs:
+  using: composite
+  steps:
+    - name: Export Playwright browsers path
+      shell: bash
+      run: echo "PLAYWRIGHT_BROWSERS_PATH=${{ github.workspace }}/.cache/ms-playwright" >> "$GITHUB_ENV"
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v5
+      with:
+        node-version: 24
+
+    - name: Install workspace dependencies
+      shell: bash
+      run: npm ci
+
+    - name: Restore Playwright WebKit runtime cache
+      uses: actions/cache@v5
+      with:
+        path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+        key: ${{ runner.os }}-playwright-webkit-${{ hashFiles('package-lock.json') }}
+
+    - name: Install Playwright WebKit runtime
+      shell: bash
+      run: npx playwright install --with-deps webkit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,29 +95,13 @@ jobs:
       - changes
     if: needs.changes.outputs.inspect_run_viewer == 'true'
     runs-on: ubuntu-latest
-    env:
-      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 24
-
-      - name: Install workspace dependencies
-        run: npm ci
-
-      - name: Restore Playwright WebKit runtime cache
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
-          key: ${{ runner.os }}-playwright-webkit-${{ hashFiles('package-lock.json') }}
-
-      - name: Install Playwright WebKit runtime
-        run: npx playwright install --with-deps webkit
+      - name: Set up Playwright WebKit
+        uses: ./.github/actions/playwright-webkit
 
       - name: Run inspect-run viewer WebKit smoke
         run: npm run test:playwright:viewer
@@ -127,29 +111,13 @@ jobs:
       - changes
     if: needs.changes.outputs.presentations == 'true'
     runs-on: ubuntu-latest
-    env:
-      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 24
-
-      - name: Install workspace dependencies
-        run: npm ci
-
-      - name: Restore Playwright WebKit runtime cache
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
-          key: ${{ runner.os }}-playwright-webkit-${{ hashFiles('package-lock.json') }}
-
-      - name: Install Playwright WebKit runtime
-        run: npx playwright install --with-deps webkit
+      - name: Set up Playwright WebKit
+        uses: ./.github/actions/playwright-webkit
 
       - name: Run presentation deck fit smoke (WebKit)
         run: |
@@ -161,29 +129,13 @@ jobs:
       - changes
     if: needs.changes.outputs.articles == 'true'
     runs-on: ubuntu-latest
-    env:
-      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 24
-
-      - name: Install workspace dependencies
-        run: npm ci
-
-      - name: Restore Playwright WebKit runtime cache
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
-          key: ${{ runner.os }}-playwright-webkit-${{ hashFiles('package-lock.json') }}
-
-      - name: Install Playwright WebKit runtime
-        run: npx playwright install --with-deps webkit
+      - name: Set up Playwright WebKit
+        uses: ./.github/actions/playwright-webkit
 
       - name: Run article fit smoke (WebKit)
         run: |

--- a/test/contracts/review-doc-contracts.test.mjs
+++ b/test/contracts/review-doc-contracts.test.mjs
@@ -134,8 +134,9 @@ test("local-implementation skill documents the auto-scoped rendered-artifact UI 
 
 
 test("CI gates the Playwright WebKit smoke behind inspect-run viewer change detection and uses Node24-ready first-party actions", async () => {
-  const [ciWorkflow, readme] = await Promise.all([
+  const [ciWorkflow, playwrightWebkitAction, readme] = await Promise.all([
     readRepo(".github/workflows/ci.yml"),
+    readRepo(".github/actions/playwright-webkit/action.yml"),
     readRepo("README.md"),
   ]);
 
@@ -145,17 +146,21 @@ test("CI gates the Playwright WebKit smoke behind inspect-run viewer change dete
   assert.match(ciWorkflow, /fetch-depth:\s*0/i);
   assert.match(ciWorkflow, /actions\/checkout@v5/i);
   assert.match(ciWorkflow, /actions\/setup-node@v5/i);
-  assert.match(ciWorkflow, /actions\/cache@v5/i);
   assert.match(ciWorkflow, /changes:[\s\S]*Set up Node\.js[\s\S]*node-version:\s*24/i);
   assert.match(ciWorkflow, /GITHUB_OUTPUT="\$GITHUB_OUTPUT" node scripts\/loop\/inspect-run-viewer-ci-changes\.mjs \.inspect-run-viewer-changed-files\.txt/i);
   assert.doesNotMatch(ciWorkflow, /inspect_run_viewer_relevant_paths_json/i);
   assert.match(ciWorkflow, /viewer-smoke:[\s\S]*needs:[\s\S]*- changes/i);
   assert.match(ciWorkflow, /viewer-smoke:[\s\S]*if:\s*needs\.changes\.outputs\.inspect_run_viewer\s*==\s*'true'/i);
-  assert.match(ciWorkflow, /viewer-smoke:[\s\S]*path:\s*\$\{\{\s*env\.PLAYWRIGHT_BROWSERS_PATH\s*\}\}/i);
-  assert.match(ciWorkflow, /PLAYWRIGHT_BROWSERS_PATH:\s*\$\{\{\s*github\.workspace\s*\}\}\/\.cache\/ms-playwright/i);
-  assert.match(ciWorkflow, /key:\s*\$\{\{\s*runner\.os\s*\}\}-playwright-webkit-\$\{\{\s*hashFiles\('package-lock\.json'\)\s*\}\}/i);
+  assert.match(ciWorkflow, /viewer-smoke:[\s\S]*uses:\s*\.\/\.github\/actions\/playwright-webkit/i);
   assert.match(ciWorkflow, /viewer-smoke:[\s\S]*npm run test:playwright:viewer/i);
   assert.match(ciWorkflow, /verify:[\s\S]*npm run verify/i);
+
+  // Shared Playwright WebKit setup lives in the composite action; assert its
+  // cache/env wiring stayed intact after the dedup (issue #1058).
+  assert.match(playwrightWebkitAction, /actions\/cache@v5/i);
+  assert.match(playwrightWebkitAction, /path:\s*\$\{\{\s*env\.PLAYWRIGHT_BROWSERS_PATH\s*\}\}/i);
+  assert.match(playwrightWebkitAction, /PLAYWRIGHT_BROWSERS_PATH=\$\{\{\s*github\.workspace\s*\}\}\/\.cache\/ms-playwright/i);
+  assert.match(playwrightWebkitAction, /key:\s*\$\{\{\s*runner\.os\s*\}\}-playwright-webkit-\$\{\{\s*hashFiles\('package-lock\.json'\)\s*\}\}/i);
 
   assert.match(readme, /workspace-local Playwright WebKit/i);
   assert.match(readme, /small changed-files gate plus parallel `verify` and conditional `viewer-smoke` jobs/i);

--- a/test/contracts/review-doc-contracts.test.mjs
+++ b/test/contracts/review-doc-contracts.test.mjs
@@ -156,10 +156,17 @@ test("CI gates the Playwright WebKit smoke behind inspect-run viewer change dete
   assert.match(ciWorkflow, /verify:[\s\S]*npm run verify/i);
 
   // All THREE smoke jobs must route through the shared composite action, so a
-  // future edit can't silently reintroduce the duplication in deck/article
+  // future edit can't silently reintroduce the duplication in any of them
   // (#1058 dedup guard — the whole point is all three share one setup).
-  assert.match(ciWorkflow, /deck-smoke:[\s\S]*uses:\s*\.\/\.github\/actions\/playwright-webkit/i);
-  assert.match(ciWorkflow, /article-smoke:[\s\S]*uses:\s*\.\/\.github\/actions\/playwright-webkit/i);
+  // Count-based, not per-job `job:[\s\S]*uses:` regexes: those are greedy and
+  // match across job boundaries (a `deck-smoke:` header is "satisfied" by
+  // article-smoke's later `uses:` line), so they'd pass even if deck lost its
+  // reference. Asserting exactly 3 occurrences catches any job dropping it.
+  assert.equal(
+    (ciWorkflow.match(/uses:\s*\.\/\.github\/actions\/playwright-webkit/gi) || []).length,
+    3,
+    "all three smoke jobs (viewer/deck/article) must reference the composite action exactly once",
+  );
 
   // Shared Playwright WebKit setup lives in the composite action; assert its
   // cache/env wiring AND its Node setup stayed intact after the dedup (#1058).

--- a/test/contracts/review-doc-contracts.test.mjs
+++ b/test/contracts/review-doc-contracts.test.mjs
@@ -155,8 +155,19 @@ test("CI gates the Playwright WebKit smoke behind inspect-run viewer change dete
   assert.match(ciWorkflow, /viewer-smoke:[\s\S]*npm run test:playwright:viewer/i);
   assert.match(ciWorkflow, /verify:[\s\S]*npm run verify/i);
 
+  // All THREE smoke jobs must route through the shared composite action, so a
+  // future edit can't silently reintroduce the duplication in deck/article
+  // (#1058 dedup guard — the whole point is all three share one setup).
+  assert.match(ciWorkflow, /deck-smoke:[\s\S]*uses:\s*\.\/\.github\/actions\/playwright-webkit/i);
+  assert.match(ciWorkflow, /article-smoke:[\s\S]*uses:\s*\.\/\.github\/actions\/playwright-webkit/i);
+
   // Shared Playwright WebKit setup lives in the composite action; assert its
-  // cache/env wiring stayed intact after the dedup (issue #1058).
+  // cache/env wiring AND its Node setup stayed intact after the dedup (#1058).
+  // (The ciWorkflow node-version:24 assertion above is satisfied by the
+  // changes/verify jobs, so assert the ACTION's own Node setup here or a
+  // regression in the shared action's Node would go uncaught.)
+  assert.match(playwrightWebkitAction, /actions\/setup-node@v5/i);
+  assert.match(playwrightWebkitAction, /node-version:\s*24/i);
   assert.match(playwrightWebkitAction, /actions\/cache@v5/i);
   assert.match(playwrightWebkitAction, /path:\s*\$\{\{\s*env\.PLAYWRIGHT_BROWSERS_PATH\s*\}\}/i);
   assert.match(playwrightWebkitAction, /PLAYWRIGHT_BROWSERS_PATH=\$\{\{\s*github\.workspace\s*\}\}\/\.cache\/ms-playwright/i);


### PR DESCRIPTION
Closes #1058.

## Summary
Deduplicate the three near-identical Playwright WebKit smoke jobs (`viewer-smoke` / `deck-smoke` / `article-smoke`) by extracting their shared setup into a local composite action, keeping the three jobs so the current **zero-cost skip** semantics are preserved.

## Scope and context
Composite-action extraction (the issue's recommended approach over a matrix). A matrix leg can't gate its own spawn, so skipped legs would still pay checkout + `npm ci` + Playwright install — a regression the issue explicitly rules out. The composite action removes the duplication while each job keeps its job-level `if:` trigger (zero-cost skip).

## File-by-file changes
- `.github/actions/playwright-webkit/action.yml` (**new**) — `runs: using: composite`, no inputs (constants match today): exports `PLAYWRIGHT_BROWSERS_PATH` to `$GITHUB_ENV` (composite actions have no top-level `env:`), `actions/setup-node@v5` (node 24), `npm ci`, `actions/cache@v5` with the **same** path/key (cache still hits), and `npx playwright install --with-deps webkit`.
- `.github/workflows/ci.yml` — each smoke job now runs: `actions/checkout@v5` (must stay per-job — a local `uses: ./...` action can't be resolved before the repo is checked out), then `uses: ./.github/actions/playwright-webkit`, then its **unchanged** `test:playwright:*` command. Triggers, commands, browser, and cache behavior are identical to today; −60 duplicated lines.
- `test/contracts/review-doc-contracts.test.mjs` — the cache/env assertions moved with the content: they now assert against the composite action file, plus each `ci.yml` job references the action. Same facts, new file layout (root-cause update, not a workaround).

## Acceptance criteria
- [x] Shared smoke setup defined once (the composite action), not copy-pasted across the three jobs.
- [x] A non-triggered smoke category still incurs no wasted CI cost — each job keeps its job-level `if:` gate (zero-cost skip preserved; no step-level gating, no matrix).
- [x] The three smoke commands and their `changes`-output triggers behave identically to today (verbatim preserved).
- [x] `ci.yml` + the action are valid (`actionlint` clean, which lints the referenced local action too).

## Definition of done
- [x] `ci.yml` deduplicated via the composite action.
- [x] `npm run verify` green (0 failures); `actionlint` clean. CI on this PR is the live validator for the workflow itself (each smoke category runs when its trigger fires, skips zero-cost otherwise).

## Non-goals
- Changing what the smoke tests assert or which browsers they run.
- Touching the `verify` or `changes` jobs beyond what the dedup requires.

## Validation command
```
npm run verify
# and: actionlint .github/workflows/ci.yml
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
