### PR TITLE
fix(tooling): manage-sub-issues reorder — use before_id for first item, never after_id=0 (#1160)

### DIFF
--- a/scripts/github/manage-sub-issues.mjs
+++ b/scripts/github/manage-sub-issues.mjs
@@ -228,15 +228,30 @@ function normalizeSubIssue(raw) {
   return { id, number, title, state };
 }
 
+function extractEndpoint(args) {
+  return args.find((a) => typeof a === "string" && a.startsWith("repos/")) ?? "unknown endpoint";
+}
+function extractHttpStatus(output) {
+  const match = /^HTTP\/\S+\s+(\d{3})/m.exec(output ?? "");
+  return match ? match[1] : null;
+}
 /**
  * Call gh api with optional JSON parsing.
  * @param {boolean} [expectJson=true] - When false, skip JSON parsing (for empty-body responses like PATCH reorder).
  */
 async function ghApi(ghCommand, args, env, expectJson = true) {
-  const result = await runChild(ghCommand, ["api", ...args], env);
+  // Non-JSON calls (POST/PATCH with empty bodies) pass -i so a non-2xx response
+  // still surfaces its HTTP status even when the body is empty. JSON calls are
+  // left untouched since -i would break body parsing.
+  const captureStatus = !expectJson;
+  const apiArgs = captureStatus ? ["-i", ...args] : args;
+  const result = await runChild(ghCommand, ["api", ...apiArgs], env);
   if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw new Error(`gh api command failed: ${detail}`);
+    const endpoint = extractEndpoint(args);
+    const status = captureStatus ? extractHttpStatus(result.stdout) : null;
+    const detail = result.stderr.trim() || "empty response body";
+    const statusPart = status ? ` (HTTP ${status})` : "";
+    throw new Error(`gh api command failed${statusPart} for ${endpoint}: ${detail}`);
   }
   if (!expectJson) {
     return null;
@@ -301,12 +316,26 @@ export async function runReorder({ repo, issue, order }, { env = process.env, gh
     }
   }
   const reorderPath = buildSubIssueReorderPath(owner, name, issue);
-  let afterId = 0;
-  for (const n of order) {
-    const subIssueId = idByNumber.get(n);
+  // GitHub's priority endpoint rejects after_id=0 (the "no predecessor" cursor)
+  // with an HTTP 500. To place the first requested item at the head, move it
+  // before the current head instead — or skip the call entirely if it's
+  // already there.
+  const currentHeadId = subIssues[0]?.id;
+  let afterId;
+  for (let index = 0; index < order.length; index += 1) {
+    const subIssueId = idByNumber.get(order[index]);
+    if (index === 0) {
+      afterId = subIssueId;
+      if (subIssueId === currentHeadId) {
+        continue; // already at the head; no call needed
+      }
+      const fieldArgs = ["-F", `sub_issue_id=${subIssueId}`, "-F", `before_id=${currentHeadId}`];
+      await ghApi(ghCommand, ["-X", "PATCH", reorderPath, ...fieldArgs], env, false);
+      continue;
+    }
     const fieldArgs = ["-F", `sub_issue_id=${subIssueId}`, "-F", `after_id=${afterId}`];
-    await ghApi(ghCommand, ["-X", "PATCH", reorderPath, ...fieldArgs], env, false);
     afterId = subIssueId;
+    await ghApi(ghCommand, ["-X", "PATCH", reorderPath, ...fieldArgs], env, false);
   }
   return {
     ok: true,

--- a/scripts/github/manage-sub-issues.mjs
+++ b/scripts/github/manage-sub-issues.mjs
@@ -249,7 +249,10 @@ async function ghApi(ghCommand, args, env, expectJson = true) {
   if (result.code !== 0) {
     const endpoint = extractEndpoint(args);
     const status = captureStatus ? extractHttpStatus(result.stdout) : null;
-    const detail = result.stderr.trim() || "empty response body";
+    // "empty response body" only makes sense for the -i (captureStatus) path;
+    // for JSON/GET calls an empty stderr means fall back to the exit code.
+    const detail = result.stderr.trim()
+      || (captureStatus ? "empty response body" : `exit code ${result.code}`);
     const statusPart = status ? ` (HTTP ${status})` : "";
     throw new Error(`gh api command failed${statusPart} for ${endpoint}: ${detail}`);
   }

--- a/test/github/manage-sub-issues.test.mjs
+++ b/test/github/manage-sub-issues.test.mjs
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
+import { readFile } from "node:fs/promises";
 import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import {
@@ -22,6 +23,23 @@ async function writeGhStub(tempDir, entries) {
 
 function subIssuePayload(subIssues) {
   return `${JSON.stringify(subIssues)}\n`;
+}
+
+async function readGhLog(ghLogPath) {
+  const raw = await readFile(ghLogPath, "utf8");
+  return raw
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line));
+}
+
+function assertNoAfterIdZero(calls) {
+  for (const call of calls) {
+    assert.ok(
+      !call.some((arg) => arg === "after_id=0"),
+      `PATCH call must never send after_id=0, got: ${JSON.stringify(call)}`,
+    );
+  }
 }
 
 function issuePayload({ id, number, title = "Test issue", state = "open" }) {
@@ -437,13 +455,14 @@ test("manage-sub-issues reorder sets execution order via sequential PATCH calls"
       {
         assertArgs: [
           "api",
+          "-i",
           "-X",
           "PATCH",
           "repos/owner/repo/issues/42/sub_issues/priority",
           "-F",
           "sub_issue_id=1002",
           "-F",
-          "after_id=0",
+          "before_id=1001",
         ],
         stdout: "",
       },
@@ -486,6 +505,325 @@ test("manage-sub-issues reorder sets execution order via sequential PATCH calls"
     assert.equal(parsed.ok, true);
     assert.equal(parsed.command, "reorder");
     assert.deepEqual(parsed.order, [11, 12, 10]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("manage-sub-issues reorder moves a non-head first item using before_id, never after_id=0 (full permutation)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-manage-sub-issues-reorder-perm-"));
+
+  try {
+    const { env, ghLogPath } = await writeGhStubHelper(
+      tempDir,
+      [
+        {
+          assertArgs: ["api", "repos/owner/repo/issues/42/sub_issues"],
+          stdout: subIssuePayload([
+            { id: 1001, number: 10, title: "A", state: "open" },
+            { id: 1002, number: 11, title: "B", state: "open" },
+            { id: 1003, number: 12, title: "C", state: "open" },
+          ]),
+        },
+        {
+          assertArgs: [
+            "api",
+            "-i",
+            "-X",
+            "PATCH",
+            "repos/owner/repo/issues/42/sub_issues/priority",
+            "-F",
+            "sub_issue_id=1003",
+            "-F",
+            "before_id=1001",
+          ],
+          stdout: "",
+        },
+        {
+          assertArgs: [
+            "api",
+            "-i",
+            "-X",
+            "PATCH",
+            "repos/owner/repo/issues/42/sub_issues/priority",
+            "-F",
+            "sub_issue_id=1001",
+            "-F",
+            "after_id=1003",
+          ],
+          stdout: "",
+        },
+        {
+          assertArgs: [
+            "api",
+            "-i",
+            "-X",
+            "PATCH",
+            "repos/owner/repo/issues/42/sub_issues/priority",
+            "-F",
+            "sub_issue_id=1002",
+            "-F",
+            "after_id=1001",
+          ],
+          stdout: "",
+        },
+      ],
+      { logCalls: true },
+    );
+
+    const result = await runNode(
+      ["reorder", "--repo", "owner/repo", "--issue", "42", "--order", "12,10,11"],
+      { env },
+    );
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.ok, true);
+    assert.deepEqual(parsed.order, [12, 10, 11]);
+
+    // AC2: no PATCH call ever sends after_id=0.
+    const calls = await readGhLog(ghLogPath);
+    assertNoAfterIdZero(calls);
+    assert.equal(calls.length, 4); // 1 list + 3 PATCH
+
+    // AC3: verify confirms the resulting order matches the requested order.
+    const verifyEnv = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/42/sub_issues"],
+        stdout: subIssuePayload([
+          { id: 1003, number: 12, title: "C", state: "open" },
+          { id: 1001, number: 10, title: "A", state: "open" },
+          { id: 1002, number: 11, title: "B", state: "open" },
+        ]),
+      },
+    ]);
+    const verifyResult = await runNode(
+      ["verify", "--repo", "owner/repo", "--issue", "42", "--expected", "12,10,11", "--ordered"],
+      { env: verifyEnv },
+    );
+    const verifyParsed = JSON.parse(verifyResult.stdout);
+    assert.equal(verifyParsed.verified, true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("manage-sub-issues reorder skips the head call when the first requested item is already current head", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-manage-sub-issues-reorder-same-"));
+
+  try {
+    const { env, ghLogPath } = await writeGhStubHelper(
+      tempDir,
+      [
+        {
+          assertArgs: ["api", "repos/owner/repo/issues/42/sub_issues"],
+          stdout: subIssuePayload([
+            { id: 1001, number: 10, title: "A", state: "open" },
+            { id: 1002, number: 11, title: "B", state: "open" },
+            { id: 1003, number: 12, title: "C", state: "open" },
+          ]),
+        },
+        {
+          assertArgs: [
+            "api",
+            "-i",
+            "-X",
+            "PATCH",
+            "repos/owner/repo/issues/42/sub_issues/priority",
+            "-F",
+            "sub_issue_id=1002",
+            "-F",
+            "after_id=1001",
+          ],
+          stdout: "",
+        },
+        {
+          assertArgs: [
+            "api",
+            "-i",
+            "-X",
+            "PATCH",
+            "repos/owner/repo/issues/42/sub_issues/priority",
+            "-F",
+            "sub_issue_id=1003",
+            "-F",
+            "after_id=1002",
+          ],
+          stdout: "",
+        },
+      ],
+      { logCalls: true },
+    );
+
+    const result = await runNode(
+      ["reorder", "--repo", "owner/repo", "--issue", "42", "--order", "10,11,12"],
+      { env },
+    );
+
+    assert.equal(result.code, 0);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.ok, true);
+    assert.deepEqual(parsed.order, [10, 11, 12]);
+
+    // AC2: no PATCH call ever sends after_id=0, and the head call was skipped entirely.
+    const calls = await readGhLog(ghLogPath);
+    assertNoAfterIdZero(calls);
+    assert.equal(calls.length, 3); // 1 list + 2 PATCH (head call skipped)
+
+    // AC3: verify confirms order is unchanged and matches the requested order.
+    const verifyEnv = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/42/sub_issues"],
+        stdout: subIssuePayload([
+          { id: 1001, number: 10, title: "A", state: "open" },
+          { id: 1002, number: 11, title: "B", state: "open" },
+          { id: 1003, number: 12, title: "C", state: "open" },
+        ]),
+      },
+    ]);
+    const verifyResult = await runNode(
+      ["verify", "--repo", "owner/repo", "--issue", "42", "--expected", "10,11,12", "--ordered"],
+      { env: verifyEnv },
+    );
+    const verifyParsed = JSON.parse(verifyResult.stdout);
+    assert.equal(verifyParsed.verified, true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("manage-sub-issues reorder moves a middle item to head via before_id", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-manage-sub-issues-reorder-mid-"));
+
+  try {
+    const { env, ghLogPath } = await writeGhStubHelper(
+      tempDir,
+      [
+        {
+          assertArgs: ["api", "repos/owner/repo/issues/42/sub_issues"],
+          stdout: subIssuePayload([
+            { id: 1001, number: 10, title: "A", state: "open" },
+            { id: 1002, number: 11, title: "B", state: "open" },
+            { id: 1003, number: 12, title: "C", state: "open" },
+          ]),
+        },
+        {
+          assertArgs: [
+            "api",
+            "-i",
+            "-X",
+            "PATCH",
+            "repos/owner/repo/issues/42/sub_issues/priority",
+            "-F",
+            "sub_issue_id=1002",
+            "-F",
+            "before_id=1001",
+          ],
+          stdout: "",
+        },
+        {
+          assertArgs: [
+            "api",
+            "-i",
+            "-X",
+            "PATCH",
+            "repos/owner/repo/issues/42/sub_issues/priority",
+            "-F",
+            "sub_issue_id=1001",
+            "-F",
+            "after_id=1002",
+          ],
+          stdout: "",
+        },
+        {
+          assertArgs: [
+            "api",
+            "-i",
+            "-X",
+            "PATCH",
+            "repos/owner/repo/issues/42/sub_issues/priority",
+            "-F",
+            "sub_issue_id=1003",
+            "-F",
+            "after_id=1001",
+          ],
+          stdout: "",
+        },
+      ],
+      { logCalls: true },
+    );
+
+    const result = await runNode(
+      ["reorder", "--repo", "owner/repo", "--issue", "42", "--order", "11,10,12"],
+      { env },
+    );
+
+    assert.equal(result.code, 0);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.ok, true);
+    assert.deepEqual(parsed.order, [11, 10, 12]);
+
+    // AC2: no PATCH call ever sends after_id=0.
+    const calls = await readGhLog(ghLogPath);
+    assertNoAfterIdZero(calls);
+    assert.equal(calls.length, 4); // 1 list + 3 PATCH
+
+    // AC3: verify confirms the resulting order matches the requested order.
+    const verifyEnv = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/42/sub_issues"],
+        stdout: subIssuePayload([
+          { id: 1002, number: 11, title: "B", state: "open" },
+          { id: 1001, number: 10, title: "A", state: "open" },
+          { id: 1003, number: 12, title: "C", state: "open" },
+        ]),
+      },
+    ]);
+    const verifyResult = await runNode(
+      ["verify", "--repo", "owner/repo", "--issue", "42", "--expected", "11,10,12", "--ordered"],
+      { env: verifyEnv },
+    );
+    const verifyParsed = JSON.parse(verifyResult.stdout);
+    assert.equal(verifyParsed.verified, true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("manage-sub-issues reorder surfaces HTTP status and endpoint when PATCH returns an empty error body", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-manage-sub-issues-reorder-500-"));
+
+  try {
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/42/sub_issues"],
+        stdout: subIssuePayload([
+          { id: 1001, number: 10, title: "A", state: "open" },
+          { id: 1002, number: 11, title: "B", state: "open" },
+        ]),
+      },
+      {
+        assertArgs: ["api", "-i", "-X", "PATCH", "repos/owner/repo/issues/42/sub_issues/priority"],
+        // Simulates GitHub's real empty-body 500 for an invalid priority request:
+        // gh still writes the response status line (via -i) to stdout, but the
+        // (empty) body decode failure is all it can put on stderr.
+        stdout: "HTTP/2.0 500 Internal Server Error\ncontent-type: application/json; charset=utf-8\n\n",
+        stderr: "unexpected end of JSON input\n",
+        exitCode: 1,
+      },
+    ]);
+
+    const result = await runNode(
+      ["reorder", "--repo", "owner/repo", "--issue", "42", "--order", "11,10"],
+      { env },
+    );
+
+    assert.equal(result.code, 1);
+    const parsed = JSON.parse(result.stderr);
+    assert.equal(parsed.ok, false);
+    assert.match(parsed.error, /HTTP 500/);
+    assert.match(parsed.error, /repos\/owner\/repo\/issues\/42\/sub_issues\/priority/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/github/manage-sub-issues.test.mjs
+++ b/test/github/manage-sub-issues.test.mjs
@@ -1,10 +1,9 @@
 import assert from "node:assert/strict";
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
-import { readFile } from "node:fs/promises";
 import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import {


### PR DESCRIPTION
Closes #1160.

## Summary
`manage-sub-issues.mjs reorder` always failed with `unexpected end of JSON input`. Root cause: `runReorder` seeded the cursor with `afterId = 0`, so the first PATCH sent `{"after_id": 0, …}`. `after_id: 0` is invalid → GitHub returns **HTTP 500 with an empty body** → `gh` reports a JSON-parse error and the loop aborts on call 1, so no reorder ever succeeded.

## Scope and context
Two focused changes to `scripts/github/manage-sub-issues.mjs`: (1) first-position placement without `after_id=0`, (2) richer error surfacing for empty-body non-2xx responses. No change to list/add/verify behavior or sub-issue tree semantics.

## File-by-file changes
- `scripts/github/manage-sub-issues.mjs` —
  - `runReorder`: track the current head (`subIssues[0].id`, from the list already fetched for validation). For the first `--order` item: **skip** the PATCH if it's already the head, else move it with `{ sub_issue_id, before_id: <current head id> }`. `afterId` is only ever seeded from a real sub-issue id, so **no request carries `after_id=0`**. Subsequent items keep today's `after_id` chaining.
  - `ghApi`: for non-JSON (POST/PATCH) calls, pass `gh -i` so the HTTP status line is captured on empty-body errors; the thrown error now reads `gh api command failed (HTTP <status>) for <endpoint>: <detail|empty response body>`. GET/JSON calls are untouched (no `-i`) so `list`/`verify` parsing is unchanged.
- `test/github/manage-sub-issues.test.mjs` — mocked-gh (no network) tests: full permutation, same-as-current (head skip), middle-to-head — each asserts no `after_id=0` (AC2) and `verify --ordered` afterward (AC3); plus an empty-body 500 asserting the status+endpoint error (AC4).

## Acceptance criteria
- [x] AC1: `reorder` succeeds for full permutation, same-as-current, and middle-to-head (unit-tested).
- [x] AC2: First-position uses `before_id` (or a skip) — no request carries `after_id=0` (asserted in each test).
- [x] AC3: `verify --ordered` confirms the order after each AC1 case (mocked).
- [x] AC4: Failed API calls report HTTP status + endpoint.

## Definition of done
- [x] DoD1: Fix + unit tests; `npm run verify` green (manage-sub-issues suite 39/39).
- [ ] DoD2: Live reorder of epic #1104's tree (`1147,1148,1149,1150,1151,1155,1152,1159`) with the fixed helper + `--ordered` verify — a real GitHub mutation, executed by the orchestrator post-merge (documented in the merge/retro trail).

## Non-goals
- Changing list/add/verify behavior, sub-issue tree semantics, or epic #1104 refinement content.

## Validation command
```
npm run verify
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
