### PR TITLE
fix(gates): make copilot-pr-handoff + gate-coordination agree past the round cap (#1126)

### DIFF
--- a/packages/core/src/loop/copilot-loop-state.mjs
+++ b/packages/core/src/loop/copilot-loop-state.mjs
@@ -148,6 +148,30 @@ function isBlockedCiStatus(status) {
   return status === "failure";
 }
 
+/**
+ * Single source of truth for whether the Copilot review round cap has been
+ * reached (issue #1126). `copilot-pr-handoff.mjs` enforces the cap by calling
+ * `interpretLoopState`, which uses this predicate internally; every other
+ * caller that needs the same "cap reached" boolean (gate coordination,
+ * detect-pr-gate-coordination-state) MUST call this function too rather than
+ * re-deriving `copilotReviewRoundCount >= maxCopilotRounds` locally, so the
+ * two never disagree at the cap boundary.
+ *
+ * `copilotReviewRoundCount` counts COMPLETED rounds, so `>=` means every
+ * permitted round has already happened. `maxCopilotRounds` of `null`/`0`/
+ * non-number means the cap does not apply (unlimited or disabled).
+ *
+ * @param {object} params
+ * @param {number} params.copilotReviewRoundCount
+ * @param {number|null} [params.maxCopilotRounds]
+ * @returns {boolean}
+ */
+export function isCopilotRoundCapReached({ copilotReviewRoundCount, maxCopilotRounds }) {
+  return typeof maxCopilotRounds === "number" && maxCopilotRounds > 0
+    && typeof copilotReviewRoundCount === "number"
+    && copilotReviewRoundCount >= maxCopilotRounds;
+}
+
 export function normalizeCiStatus(rollup) {
   return normalizeStatusCheckRollupContract(rollup).overallStatus;
 }
@@ -375,8 +399,7 @@ export function interpretLoopState(snapshot, refinementConfig) {
   const maxRounds = refinementConfig?.maxCopilotRounds;
   const reviewInFlight = s.copilotReviewRequestStatus === "requested"
     || s.copilotReviewRequestStatus === "already-requested";
-  if (typeof maxRounds === "number" && maxRounds > 0
-      && s.copilotReviewRoundCount >= maxRounds
+  if (isCopilotRoundCapReached({ copilotReviewRoundCount: s.copilotReviewRoundCount, maxCopilotRounds: maxRounds })
       && state !== STATE.NO_PR && state !== STATE.DONE
       && state !== STATE.PR_DRAFT && state !== STATE.REVIEW_REQUEST_UNAVAILABLE
       && state !== STATE.BLOCKED_NEEDS_USER_DECISION) {

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -1,4 +1,4 @@
-import { DISPOSITION, STATE } from "./copilot-loop-state.mjs";
+import { DISPOSITION, isCopilotRoundCapReached, STATE } from "./copilot-loop-state.mjs";
 import { findBlockingTitleMarkers } from "./pr-title-markers.mjs";
 import { evaluateUiE2eScoping } from "./ui-e2e-scoping.mjs";
 
@@ -443,9 +443,7 @@ export function shouldGuardCopilotReviewRequest({
   //    CI) but Copilot has NOT reviewed THIS head (e.g. a post-cap commit). No further
   //    Copilot round is permitted, so forcing a formal request would dead-end the loop;
   //    the pre_approval_gate reviews the post-cap head instead (per #848).
-  const roundCapReached = maxCopilotRounds !== null
-    && typeof copilotReviewRoundCount === "number"
-    && copilotReviewRoundCount >= maxCopilotRounds;
+  const roundCapReached = isCopilotRoundCapReached({ copilotReviewRoundCount, maxCopilotRounds });
   if (
     roundCapReached
     && (sameHeadCleanConverged || roundCapCleanFallback)
@@ -537,7 +535,7 @@ function evaluatePrGateCoordinationCore(input = {}) {
   const draftGateRequireCi = input.draftGateRequireCi !== false;
   const copilotReviewRoundCount = normalizeNonNegativeInteger(input.copilotReviewRoundCount);
   const maxCopilotRounds = normalizePositiveInteger(input.maxCopilotRounds);
-  const roundCapReached = maxCopilotRounds !== null && copilotReviewRoundCount >= maxCopilotRounds;
+  const roundCapReached = isCopilotRoundCapReached({ copilotReviewRoundCount, maxCopilotRounds });
   const postConvergenceSignificantChange = input.postConvergenceSignificantChange === true;
   const roundCapNewCycleRequired = roundCapReached && copilotReviewRoundCount > 0 && postConvergenceSignificantChange;
   const prTitle = typeof input.prTitle === "string" ? input.prTitle : "";

--- a/packages/core/test/copilot-loop-state.test.mjs
+++ b/packages/core/test/copilot-loop-state.test.mjs
@@ -9,6 +9,7 @@ import {
   interpretLoopState,
   applyConfirmedReviewRequest,
   summarizeLoopInterpretation,
+  isCopilotRoundCapReached,
 } from "../src/loop/copilot-loop-state.mjs";
 
 // ---------------------------------------------------------------------------
@@ -1056,6 +1057,28 @@ test("interpretLoopState does not apply round cap when copilotReviewRoundCount i
   assert.equal(result.state, STATE.READY_TO_REREQUEST_REVIEW);
   assert.equal(result.roundCapCleanEligible, false);
   assert.equal(result.autoRerequestEligible, true);
+});
+
+// isCopilotRoundCapReached (#1126): the single shared predicate that both
+// copilot-pr-handoff.mjs (via interpretLoopState) and
+// detect-pr-gate-coordination-state.mjs (via evaluatePrGateCoordination) must
+// consume so they cannot disagree at the cap boundary.
+test("isCopilotRoundCapReached is true when completed rounds equal the cap", () => {
+  assert.equal(isCopilotRoundCapReached({ copilotReviewRoundCount: 2, maxCopilotRounds: 2 }), true);
+});
+
+test("isCopilotRoundCapReached is true when completed rounds exceed the cap", () => {
+  assert.equal(isCopilotRoundCapReached({ copilotReviewRoundCount: 3, maxCopilotRounds: 2 }), true);
+});
+
+test("isCopilotRoundCapReached is false when completed rounds are below the cap", () => {
+  assert.equal(isCopilotRoundCapReached({ copilotReviewRoundCount: 1, maxCopilotRounds: 2 }), false);
+});
+
+test("isCopilotRoundCapReached is false when maxCopilotRounds is null, 0, or absent (cap disabled/unset)", () => {
+  assert.equal(isCopilotRoundCapReached({ copilotReviewRoundCount: 5, maxCopilotRounds: null }), false);
+  assert.equal(isCopilotRoundCapReached({ copilotReviewRoundCount: 5, maxCopilotRounds: 0 }), false);
+  assert.equal(isCopilotRoundCapReached({ copilotReviewRoundCount: 5, maxCopilotRounds: undefined }), false);
 });
 
 test("interpretLoopState does not apply round cap when maxCopilotRounds is not configured", () => {

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -7,7 +7,7 @@ import {
   PR_CHECKPOINT,
   shouldGuardCopilotReviewRequest,
 } from "../src/loop/pr-gate-coordination.mjs";
-import { DISPOSITION, STATE } from "../src/loop/copilot-loop-state.mjs";
+import { DISPOSITION, interpretLoopState, STATE } from "../src/loop/copilot-loop-state.mjs";
 
 function gate({ visible = false, headSha = null, verdict = null, contractComplete = false } = {}) {
   return {
@@ -474,6 +474,145 @@ test("guard still fires at the cap without a clean-fallback signal (#896 backwar
     roundCapCleanFallback: false,
     gateBoundary: PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW,
   }), true);
+});
+
+// Parity (#1126): copilot-pr-handoff.mjs enforces the round cap by calling
+// interpretLoopState; detect-pr-gate-coordination-state.mjs enforces it by
+// calling evaluatePrGateCoordination. Both must reach the shared
+// isCopilotRoundCapReached predicate (via copilot-loop-state.mjs) for the same
+// PR facts and agree on whether a Copilot re-request may be offered — the
+// coordination-state detector must never advertise `rerequest_copilot_review`
+// once the handoff would refuse it.
+test("interpretLoopState (handoff) and evaluatePrGateCoordination (coordination-state) agree at the round-cap boundary — no rerequest offered (#1126)", () => {
+  const refinementConfig = { maxCopilotRounds: 2 };
+  const snapshot = {
+    prExists: true,
+    prNumber: 500,
+    copilotReviewRequestStatus: "none",
+    copilotReviewPresent: true,
+    copilotReviewOnCurrentHead: false,
+    unresolvedThreadCount: 0,
+    actionableThreadCount: 0,
+    copilotReviewRoundCount: 2, // == maxCopilotRounds: exactly at the cap
+    ciStatus: "success",
+  };
+
+  // copilot-pr-handoff.mjs's path.
+  const handoffInterpretation = interpretLoopState(snapshot, refinementConfig);
+  assert.equal(handoffInterpretation.state, STATE.ROUND_CAP_CLEAN_FALLBACK);
+  assert.equal(handoffInterpretation.roundCapCleanEligible, true);
+
+  // detect-pr-gate-coordination-state.mjs's path, fed the same lifecycle state
+  // and round-count/cap inputs it would derive from the same PR facts.
+  const gateResult = evaluatePrGateCoordination({
+    pr: 500,
+    currentHeadSha: "deadbeefcafe",
+    prDraft: false,
+    lifecycleState: handoffInterpretation.state,
+    loopDisposition: DISPOSITION.CLEAN_CONVERGED,
+    sameHeadCleanConverged: handoffInterpretation.sameHeadCleanConverged,
+    ciStatus: snapshot.ciStatus,
+    copilotReviewRoundCount: snapshot.copilotReviewRoundCount,
+    maxCopilotRounds: refinementConfig.maxCopilotRounds,
+    draftGate: gate({ visible: true, headSha: "deadbeef", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "deadbeef", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.notEqual(gateResult.nextAction, PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW);
+  assert(!gateResult.allowedNextActions.includes(PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW));
+  assert(gateResult.forbiddenActions.includes(PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW));
+});
+
+test("interpretLoopState (handoff) and evaluatePrGateCoordination (coordination-state) agree below the round cap — rerequest_copilot_review is still allowed (#1126, no regression)", () => {
+  const refinementConfig = { maxCopilotRounds: 2 };
+  const snapshot = {
+    prExists: true,
+    prNumber: 501,
+    copilotReviewRequestStatus: "none",
+    copilotReviewPresent: true,
+    copilotReviewOnCurrentHead: false,
+    unresolvedThreadCount: 0,
+    actionableThreadCount: 0,
+    copilotReviewRoundCount: 1, // below maxCopilotRounds: cap not reached
+    ciStatus: "success",
+  };
+
+  const handoffInterpretation = interpretLoopState(snapshot, refinementConfig);
+  assert.equal(handoffInterpretation.state, STATE.READY_TO_REREQUEST_REVIEW);
+  assert.equal(handoffInterpretation.autoRerequestEligible, true);
+
+  const gateResult = evaluatePrGateCoordination({
+    pr: 501,
+    currentHeadSha: "cafedeadbeef",
+    prDraft: false,
+    lifecycleState: handoffInterpretation.state,
+    loopDisposition: DISPOSITION.ACTION_REQUIRED,
+    sameHeadCleanConverged: handoffInterpretation.sameHeadCleanConverged,
+    ciStatus: snapshot.ciStatus,
+    copilotReviewRoundCount: snapshot.copilotReviewRoundCount,
+    maxCopilotRounds: refinementConfig.maxCopilotRounds,
+    draftGate: gate({ visible: true, headSha: "cafedead", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "cafedead", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(gateResult.nextAction, PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW);
+  assert(gateResult.allowedNextActions.includes(PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW));
+  assert(!gateResult.forbiddenActions.includes(PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW));
+});
+
+// Full parity (#1103, #1126): at the cap WITH a significant post-convergence
+// change, both detectors reopen the Copilot cycle. The significance boolean is
+// computed by the SHARED detectPostConvergenceSignificantChange (scripts/loop/
+// _post-convergence-change.mjs) — exercised end-to-end from both consumers by
+// the handoff integration tests (doc-only stops / significant re-requests) and
+// detect's #1103 integration test. Here we assert the core decision each path
+// makes once that shared boolean is true: interpretLoopState resolves the
+// clean-fallback baseline that both scripts start from, and
+// evaluatePrGateCoordination (detect's path) offers the re-request; the handoff
+// script flips the same baseline to a re-request via the shared detector.
+test("interpretLoopState (handoff baseline) and evaluatePrGateCoordination (detect) reopen the cycle at the cap WITH a significant post-convergence change (#1103, #1126)", () => {
+  const refinementConfig = { maxCopilotRounds: 2 };
+  const snapshot = {
+    prExists: true,
+    prNumber: 502,
+    copilotReviewRequestStatus: "none",
+    copilotReviewPresent: true,
+    copilotReviewOnCurrentHead: false,
+    unresolvedThreadCount: 0,
+    actionableThreadCount: 0,
+    copilotReviewRoundCount: 2, // == cap
+    ciStatus: "success",
+  };
+
+  // Same clean-fallback baseline both scripts derive from the snapshot.
+  const handoffInterpretation = interpretLoopState(snapshot, refinementConfig);
+  assert.equal(handoffInterpretation.state, STATE.ROUND_CAP_CLEAN_FALLBACK);
+
+  // detect's path with the shared significant-change signal = true.
+  const gateResult = evaluatePrGateCoordination({
+    pr: 502,
+    currentHeadSha: "beefcafedead",
+    prDraft: false,
+    lifecycleState: handoffInterpretation.state,
+    loopDisposition: DISPOSITION.CLEAN_CONVERGED,
+    sameHeadCleanConverged: handoffInterpretation.sameHeadCleanConverged,
+    ciStatus: snapshot.ciStatus,
+    copilotReviewRoundCount: snapshot.copilotReviewRoundCount,
+    maxCopilotRounds: refinementConfig.maxCopilotRounds,
+    postConvergenceSignificantChange: true,
+    draftGate: gate({ visible: true, headSha: "beefcafe", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "beefcafe", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(gateResult.nextAction, PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW);
+  assert(gateResult.allowedNextActions.includes(PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW));
+  assert(gateResult.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
 });
 
 test("missing ciStatus fails closed to wait_for_ci instead of reopening gate progression", () => {

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -567,13 +567,12 @@ test("interpretLoopState (handoff) and evaluatePrGateCoordination (coordination-
 // Full parity (#1103, #1126): at the cap WITH a significant post-convergence
 // change, both detectors reopen the Copilot cycle. The significance boolean is
 // computed by the SHARED detectPostConvergenceSignificantChange (scripts/loop/
-// _post-convergence-change.mjs) — exercised end-to-end from both consumers by
-// the handoff integration tests (doc-only stops / significant re-requests) and
-// detect's #1103 integration test. Here we assert the core decision each path
-// makes once that shared boolean is true: interpretLoopState resolves the
-// clean-fallback baseline that both scripts start from, and
-// evaluatePrGateCoordination (detect's path) offers the re-request; the handoff
-// script flips the same baseline to a re-request via the shared detector.
+// _post-convergence-change.mjs). This test covers the DETECT side (core level)
+// and the handoff BASELINE it flips from. The handoff FLIP itself (clean-fallback
+// → re-request/watch on a significant change, and staying stopped on a doc-only
+// change) is covered by the copilot-pr-handoff integration tests
+// "re-requests Copilot review at the cap when a significant post-convergence
+// change lands" / "stays at round_cap_clean_fallback ... doc-only".
 test("interpretLoopState (handoff baseline) and evaluatePrGateCoordination (detect) reopen the cycle at the cap WITH a significant post-convergence change (#1103, #1126)", () => {
   const refinementConfig = { maxCopilotRounds: 2 };
   const snapshot = {

--- a/scripts/loop/_post-convergence-change.mjs
+++ b/scripts/loop/_post-convergence-change.mjs
@@ -60,6 +60,11 @@ export async function detectPostConvergenceSignificantChange(
   if (!Array.isArray(changedFiles) || changedFiles.length === 0) {
     return false;
   }
+  if (!currentHeadSha) {
+    // No usable current head → the compare call would be doomed; fail closed
+    // without issuing a wasted gh API request.
+    return false;
+  }
   const lastReviewedHeadSha = getLatestSubmittedCopilotReviewHeadSha(reviews);
   if (!lastReviewedHeadSha || lastReviewedHeadSha === currentHeadSha) {
     return false;

--- a/scripts/loop/_post-convergence-change.mjs
+++ b/scripts/loop/_post-convergence-change.mjs
@@ -1,0 +1,100 @@
+// Single source of truth (#1103, #1126) for "did a significant product/test-logic
+// change land since the last Copilot review at the round cap". Both
+// detect-pr-gate-coordination-state.mjs and copilot-pr-handoff.mjs consume this
+// so they agree on the round-cap escape hatch: at the cap, a significant
+// post-convergence change reopens a Copilot cycle (rerequest) instead of the
+// clean fallback; a doc/comment-only change stays at the clean fallback.
+//
+// It lives in scripts/loop/ (not packages/core) because significance is derived
+// from a `gh api .../compare` diff — gh I/O that does not belong in core.
+import { extractReviewCommitSha, isCopilotLogin, parseJsonText } from "../_core-helpers.mjs";
+import { runChild } from "../_cli-primitives.mjs";
+
+export function getLatestSubmittedCopilotReviewHeadSha(reviews) {
+  const copilotSubmitted = (Array.isArray(reviews) ? reviews : [])
+    .filter((review) => {
+      const login = review?.author?.login;
+      const state = String(review?.state ?? "").toUpperCase();
+      return isCopilotLogin(login) && state !== "PENDING";
+    })
+    .map((review, index) => {
+      const submittedAt = review?.submittedAt ?? review?.submitted_at;
+      const submittedAtMs = typeof submittedAt === "string" ? Date.parse(submittedAt) : Number.NaN;
+      return { review, submittedAtMs, index };
+    })
+    .sort((left, right) => {
+      const leftValid = !Number.isNaN(left.submittedAtMs);
+      const rightValid = !Number.isNaN(right.submittedAtMs);
+      if (leftValid && rightValid) {
+        return right.submittedAtMs - left.submittedAtMs;
+      }
+      if (leftValid !== rightValid) {
+        return leftValid ? -1 : 1;
+      }
+      return right.index - left.index;
+    });
+  const latest = copilotSubmitted[0]?.review;
+  const sha = extractReviewCommitSha(latest);
+  return typeof sha === "string" && sha.trim().length > 0 ? sha.trim() : null;
+}
+
+export function isTrivialDocumentationOnlyPath(filePath) {
+  if (typeof filePath !== "string") return true;
+  const normalized = filePath.trim().toLowerCase();
+  if (normalized.length === 0) return true;
+  if (normalized.startsWith("docs/")) return true;
+  return normalized.endsWith(".md")
+    || normalized.endsWith(".mdx")
+    || normalized.endsWith(".txt")
+    || normalized.endsWith(".rst")
+    || normalized.endsWith(".adoc");
+}
+
+export async function detectPostConvergenceSignificantChange(
+  { repo, pr, currentHeadSha, reviews, changedFiles, roundCapReached, regularCopilotRounds },
+  { env = process.env, ghCommand = "gh" } = {},
+) {
+  if (!roundCapReached || !regularCopilotRounds) {
+    return false;
+  }
+  if (!Array.isArray(changedFiles) || changedFiles.length === 0) {
+    return false;
+  }
+  const lastReviewedHeadSha = getLatestSubmittedCopilotReviewHeadSha(reviews);
+  if (!lastReviewedHeadSha || lastReviewedHeadSha === currentHeadSha) {
+    return false;
+  }
+  const compareResult = await runChild(
+    ghCommand,
+    ["api", `repos/${repo}/compare/${lastReviewedHeadSha}...${currentHeadSha}`],
+    env,
+  );
+  if (compareResult.code !== 0) {
+    return false;
+  }
+  let payload;
+  try {
+    payload = parseJsonText(compareResult.stdout, { label: "gh compare" });
+  } catch {
+    return false;
+  }
+  const files = Array.isArray(payload?.files) ? payload.files : [];
+  if (files.length === 0) {
+    return false;
+  }
+  const hasNonDocChanges = files.some((file) => !isTrivialDocumentationOnlyPath(file?.filename));
+  if (!hasNonDocChanges) {
+    return false;
+  }
+  const totalChangedLines = files.reduce((sum, file) => {
+    const changes = Number(file?.changes);
+    if (Number.isFinite(changes) && changes > 0) {
+      return sum + changes;
+    }
+    const additions = Number(file?.additions);
+    const deletions = Number(file?.deletions);
+    const fallback = (Number.isFinite(additions) ? additions : 0) + (Number.isFinite(deletions) ? deletions : 0);
+    return sum + (fallback > 0 ? fallback : 0);
+  }, 0);
+  return totalChangedLines >= 20 || files.length >= 2;
+}

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
-import { buildParseError, formatCliError, isCopilotLogin, isDirectCliRun, normalizeTimestamp } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, isCopilotLogin, isDirectCliRun, normalizeTimestamp, parseJsonText } from "../_core-helpers.mjs";
 import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
+import { detectPostConvergenceSignificantChange } from "./_post-convergence-change.mjs";
 import { detectRepoSlug, parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { resolveRunId } from "@dev-loops/core/loop/run-context";
 import { loadDevLoopConfig, resolveRefinement } from "@dev-loops/core/config";
@@ -293,6 +294,26 @@ export async function detectRecentHumanComments({ repo, pr, claimedAtMs }, { env
   }
 }
 
+// Facts needed by the round-cap escape-hatch significant-change detector
+// (#1103, #1126): the current head, the Copilot reviews (to find the last
+// reviewed head), and the PR's changed files. Fetched only when the interpreter
+// already resolved ROUND_CAP_CLEAN_FALLBACK, so this extra call is off the hot path.
+async function fetchReopenCycleFacts({ repo, pr }, { env = process.env, ghCommand = "gh" } = {}) {
+  const result = await runChild(
+    ghCommand,
+    ["pr", "view", String(pr), "--repo", repo, "--json", "headRefOid,reviews,files"],
+    env,
+  );
+  if (result.code !== 0) {
+    return null;
+  }
+  try {
+    return parseJsonText(result.stdout, { label: "gh pr view reopen-cycle facts" });
+  } catch {
+    return null;
+  }
+}
+
 export async function runHandoff(options, { env = process.env, ghCommand = "gh" } = {}) {
   const runnerOwnership = await ensureAsyncRunnerOwnership({
     repo: options.repo,
@@ -438,6 +459,44 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
     }
   }
 
+  // Round-cap escape hatch (#1103, #1126): the interpreter resolves
+  // ROUND_CAP_CLEAN_FALLBACK (stop, no re-request) at the cap. But when a
+  // SIGNIFICANT post-convergence change (new product/test-logic since the last
+  // Copilot review — not doc/comment-only) has landed, a new Copilot cycle is
+  // owed. Reopen it here via the SAME shared detector detect-pr-gate-coordination-state
+  // uses, so the two agree: both offer a re-request iff (cap reached AND
+  // significant post-convergence change). A doc-only change stays at the clean
+  // fallback (stop), unchanged.
+  let reopenedCapCycle = false;
+  if (!internalOnlySkipCopilot
+      && options.watchStatus === undefined
+      && interpretation.state === STATE.ROUND_CAP_CLEAN_FALLBACK) {
+    const reopenFacts = await fetchReopenCycleFacts(options, { env, ghCommand });
+    const significant = await detectPostConvergenceSignificantChange(
+      {
+        repo: options.repo,
+        pr: options.pr,
+        currentHeadSha: typeof reopenFacts?.headRefOid === "string" ? reopenFacts.headRefOid.trim() : null,
+        reviews: reopenFacts?.reviews,
+        changedFiles: reopenFacts?.files,
+        roundCapReached: true,
+        regularCopilotRounds: (snapshot.copilotReviewRoundCount ?? 0) > 0,
+      },
+      { env, ghCommand },
+    );
+    if (significant) {
+      reopenedCapCycle = true;
+      interpretation = {
+        ...interpretation,
+        state: STATE.READY_TO_REREQUEST_REVIEW,
+        nextAction: NEXT_ACTIONS[STATE.READY_TO_REREQUEST_REVIEW],
+        allowedTransitions: [...(TRANSITIONS[STATE.READY_TO_REREQUEST_REVIEW] || [])],
+        autoRerequestEligible: true,
+        roundCapCleanEligible: false,
+      };
+    }
+  }
+
   let reviewRequestStatus;
   const shouldRequestReview = !internalOnlySkipCopilot && options.watchStatus === undefined
     && (interpretation.state === STATE.PR_READY_NO_FEEDBACK
@@ -449,12 +508,31 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
         repo: options.repo,
         pr: options.pr,
         sameHeadCleanConverged: interpretation.sameHeadCleanConverged,
+        // A reopened cap cycle was decided via the shared significant-change
+        // detector; tell the requester to honor it. performCopilotReviewRequest
+        // still refuses unless the head actually advanced past the last review
+        // (its hasNewCommits guard), so this cannot force an over-cap same-head request.
+        forceRerequestReview: reopenedCapCycle,
       },
       { env, ghCommand },
     );
     reviewRequestStatus = requestResult.status;
     snapshot = applyConfirmedReviewRequest(snapshot, reviewRequestStatus);
     interpretation = interpretLoopState(snapshot, refinementConfig);
+    // The re-interpretation re-hits the round cap (rounds still >= max) and would
+    // flip a reopened cycle back to ROUND_CAP_CLEAN_FALLBACK. A confirmed request
+    // for a significant new change is a genuine new wait cycle, so map it to the
+    // honest WAITING_FOR_COPILOT_REVIEW state (what a below-cap re-request yields).
+    if (reopenedCapCycle
+        && (reviewRequestStatus === "requested" || reviewRequestStatus === "already-requested")) {
+      interpretation = {
+        ...interpretation,
+        state: STATE.WAITING_FOR_COPILOT_REVIEW,
+        nextAction: NEXT_ACTIONS[STATE.WAITING_FOR_COPILOT_REVIEW],
+        allowedTransitions: [...(TRANSITIONS[STATE.WAITING_FOR_COPILOT_REVIEW] || [])],
+        roundCapCleanEligible: false,
+      };
+    }
   }
   const interpretationSummary = summarizeLoopInterpretation(interpretation, refinementConfig);
   const effectiveReviewRequestStatus = reviewRequestStatus

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -581,6 +581,10 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
   const roundCapCleanFallback = context.interpretation?.roundCapCleanEligible ?? false;
   const copilotReviewEverFormallyRequested = copilotReviewRequestStatus === "none"
     && guardBoundaries.has(result.gateBoundary)
+    // cap-0 disables the Copilot gate, so shouldGuardCopilotReviewRequest always
+    // returns false here — skip the timeline fetch it would never need (#1126).
+    // (Restores the suppression the roundCapReached predicate swap dropped.)
+    && maxCopilotRounds !== 0
     && !(roundCapReached
       && (sameHeadCleanConverged || roundCapCleanFallback)
       && !postConvergenceSignificantChange)

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -2,7 +2,6 @@
 import path from "node:path";
 import {
   buildParseError,
-  extractReviewCommitSha,
   formatCliError,
   isCopilotLogin,
   isDirectCliRun,
@@ -14,11 +13,12 @@ import {
 import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { loadDevLoopConfig, resolveGateConfig, resolveRefinement, resolveRefinementConfig, resolveWorkflowConfig } from "@dev-loops/core/config";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
-import { buildSnapshotFromPrFacts, interpretLoopState, summarizeLoopInterpretation } from "@dev-loops/core/loop/copilot-loop-state";
+import { buildSnapshotFromPrFacts, interpretLoopState, isCopilotRoundCapReached, summarizeLoopInterpretation } from "@dev-loops/core/loop/copilot-loop-state";
 import { evaluatePrGateCoordination, PR_CHECKPOINT, PR_CHECKPOINT_ACTION } from "@dev-loops/core/loop/pr-gate-coordination";
 import { shouldGuardCopilotReviewRequest } from "@dev-loops/core/loop/pr-gate-coordination";
 import { UI_E2E_CHECK_NAMES } from "@dev-loops/core/loop/ui-e2e-scoping";
 import { fetchGithubReviewThreadsPayload } from "../github/capture-review-threads.mjs";
+import { detectPostConvergenceSignificantChange } from "./_post-convergence-change.mjs";
 import { detectCheckpointEvidence } from "../github/detect-checkpoint-evidence.mjs";
 import { resolveRepoRoot } from "./_repo-root-resolver.mjs";
 import { parseArgs } from "node:util";
@@ -508,95 +508,6 @@ async function fetchCopilotEverFormallyRequested({ repo, pr }, { env = process.e
   return false;
 }
 
-function getLatestSubmittedCopilotReviewHeadSha(reviews) {
-  const copilotSubmitted = (Array.isArray(reviews) ? reviews : [])
-    .filter((review) => {
-      const login = review?.author?.login;
-      const state = String(review?.state ?? "").toUpperCase();
-      return isCopilotLogin(login) && state !== "PENDING";
-    })
-    .map((review, index) => {
-      const submittedAt = review?.submittedAt ?? review?.submitted_at;
-      const submittedAtMs = typeof submittedAt === "string" ? Date.parse(submittedAt) : Number.NaN;
-      return { review, submittedAtMs, index };
-    })
-    .sort((left, right) => {
-      const leftValid = !Number.isNaN(left.submittedAtMs);
-      const rightValid = !Number.isNaN(right.submittedAtMs);
-      if (leftValid && rightValid) {
-        return right.submittedAtMs - left.submittedAtMs;
-      }
-      if (leftValid !== rightValid) {
-        return leftValid ? -1 : 1;
-      }
-      return right.index - left.index;
-    });
-  const latest = copilotSubmitted[0]?.review;
-  const sha = extractReviewCommitSha(latest);
-  return typeof sha === "string" && sha.trim().length > 0 ? sha.trim() : null;
-}
-
-function isTrivialDocumentationOnlyPath(filePath) {
-  if (typeof filePath !== "string") return true;
-  const normalized = filePath.trim().toLowerCase();
-  if (normalized.length === 0) return true;
-  if (normalized.startsWith("docs/")) return true;
-  return normalized.endsWith(".md")
-    || normalized.endsWith(".mdx")
-    || normalized.endsWith(".txt")
-    || normalized.endsWith(".rst")
-    || normalized.endsWith(".adoc");
-}
-
-async function detectPostConvergenceSignificantChange(
-  { repo, pr, currentHeadSha, reviews, changedFiles, roundCapReached, regularCopilotRounds },
-  { env = process.env, ghCommand = "gh" } = {},
-) {
-  if (!roundCapReached || !regularCopilotRounds) {
-    return false;
-  }
-  if (!Array.isArray(changedFiles) || changedFiles.length === 0) {
-    return false;
-  }
-  const lastReviewedHeadSha = getLatestSubmittedCopilotReviewHeadSha(reviews);
-  if (!lastReviewedHeadSha || lastReviewedHeadSha === currentHeadSha) {
-    return false;
-  }
-  const compareResult = await runChild(
-    ghCommand,
-    ["api", `repos/${repo}/compare/${lastReviewedHeadSha}...${currentHeadSha}`],
-    env,
-  );
-  if (compareResult.code !== 0) {
-    return false;
-  }
-  let payload;
-  try {
-    payload = parseJsonText(compareResult.stdout, { label: "gh compare" });
-  } catch {
-    return false;
-  }
-  const files = Array.isArray(payload?.files) ? payload.files : [];
-  if (files.length === 0) {
-    return false;
-  }
-  const hasNonDocChanges = files.some((file) => !isTrivialDocumentationOnlyPath(file?.filename));
-  if (!hasNonDocChanges) {
-    return false;
-  }
-  const totalChangedLines = files.reduce((sum, file) => {
-    const changes = Number(file?.changes);
-    if (Number.isFinite(changes) && changes > 0) {
-      return sum + changes;
-    }
-    const additions = Number(file?.additions);
-    const deletions = Number(file?.deletions);
-    const fallback = (Number.isFinite(additions) ? additions : 0) + (Number.isFinite(deletions) ? deletions : 0);
-    return sum + (fallback > 0 ? fallback : 0);
-  }, 0);
-  return totalChangedLines >= 20 || files.length >= 2;
-}
-
 export async function detectPrGateCoordinationState(options, runtime = {}) {
   const context = await loadPrGateCoordinationContext(options, runtime);
   const repoRoot = runtime.repoRoot ?? resolveRepoRoot(process.cwd());
@@ -605,9 +516,14 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
   const config = hasConfigErrors ? {} : (configLoadResult.config ?? {});
   const draftGateConfig = resolveGateConfig(config, "draft");
   const maxCopilotRounds = resolveRefinementConfig(config, "maxCopilotRounds");
-  const roundCapReached = maxCopilotRounds !== null
-    && typeof (context.snapshot?.copilotReviewRoundCount) === "number"
-    && context.snapshot?.copilotReviewRoundCount >= maxCopilotRounds;
+  // Shared with interpretLoopState (consumed by copilot-pr-handoff.mjs) and
+  // evaluatePrGateCoordination — the single source of truth for "is the
+  // Copilot round cap reached" so this detector cannot disagree with the
+  // handoff at the cap boundary (#1126).
+  const roundCapReached = isCopilotRoundCapReached({
+    copilotReviewRoundCount: context.snapshot?.copilotReviewRoundCount,
+    maxCopilotRounds,
+  });
   const postConvergenceSignificantChange = await detectPostConvergenceSignificantChange(
     {
       repo: context.repo,

--- a/test/loop/_post-convergence-change.test.mjs
+++ b/test/loop/_post-convergence-change.test.mjs
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { writeGhStub } from "../_helpers.mjs";
+import {
+  detectPostConvergenceSignificantChange,
+  getLatestSubmittedCopilotReviewHeadSha,
+  isTrivialDocumentationOnlyPath,
+} from "../../scripts/loop/_post-convergence-change.mjs";
+
+const COPILOT = "copilot-pull-request-reviewer[bot]";
+
+// One submitted Copilot review on "oldsha"; current head "newsha" → the detector
+// reaches the compare call unless an earlier fail-closed guard trips.
+function baseInput(overrides = {}) {
+  return {
+    repo: "owner/repo",
+    pr: 17,
+    currentHeadSha: "newsha",
+    reviews: [{ author: { login: COPILOT }, state: "COMMENTED", submittedAt: "2026-06-02T10:00:00Z", commit: { oid: "oldsha" } }],
+    changedFiles: [{ path: "packages/core/src/loop/x.mjs" }],
+    roundCapReached: true,
+    regularCopilotRounds: true,
+    ...overrides,
+  };
+}
+
+// Runs the detector with a single mocked `gh` compare response.
+async function runWithCompare(compareEntry, overrides = {}) {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pcc-"));
+  try {
+    const { env } = await writeGhStub(tempDir, [compareEntry]);
+    return await detectPostConvergenceSignificantChange(baseInput(overrides), { env, ghCommand: "gh" });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+// --- fail-closed guards that short-circuit BEFORE any gh call (no stub) ---
+
+test("returns false when roundCapReached is false", async () => {
+  assert.equal(await detectPostConvergenceSignificantChange(baseInput({ roundCapReached: false })), false);
+});
+
+test("returns false when regularCopilotRounds is false", async () => {
+  assert.equal(await detectPostConvergenceSignificantChange(baseInput({ regularCopilotRounds: false })), false);
+});
+
+test("returns false when changedFiles is empty", async () => {
+  assert.equal(await detectPostConvergenceSignificantChange(baseInput({ changedFiles: [] })), false);
+});
+
+test("returns false (fail closed, no gh call) when currentHeadSha is missing", async () => {
+  // No gh stub on PATH: if this reached the compare call it would throw ENOENT,
+  // so a clean `false` proves the guard short-circuits before spawning gh.
+  assert.equal(await detectPostConvergenceSignificantChange(baseInput({ currentHeadSha: null })), false);
+});
+
+test("returns false when the last reviewed head equals the current head (same-head guard, no gh call)", async () => {
+  assert.equal(await detectPostConvergenceSignificantChange(baseInput({
+    reviews: [{ author: { login: COPILOT }, state: "COMMENTED", submittedAt: "2026-06-02T10:00:00Z", commit: { oid: "newsha" } }],
+  })), false);
+});
+
+test("returns false when there is no submitted Copilot review to compare against (no gh call)", async () => {
+  assert.equal(await detectPostConvergenceSignificantChange(baseInput({ reviews: [] })), false);
+});
+
+// --- fail-closed guards around the gh compare call ---
+
+test("returns false when the gh compare command exits non-zero (fail closed)", async () => {
+  // Payload WOULD be significant if parsed — only the exit-code guard keeps it false.
+  assert.equal(await runWithCompare({ exitCode: 1, stdout: JSON.stringify({ files: [{ filename: "a.mjs", changes: 670 }] }) }), false);
+});
+
+test("returns false when the gh compare stdout is unparseable", async () => {
+  assert.equal(await runWithCompare({ stdout: "not json{" }), false);
+});
+
+test("returns false when the compare returns an empty files list", async () => {
+  assert.equal(await runWithCompare({ stdout: JSON.stringify({ files: [] }) }), false);
+});
+
+// --- significance criteria ---
+
+test("returns false for doc-only changes", async () => {
+  assert.equal(await runWithCompare({ stdout: JSON.stringify({ files: [
+    { filename: "docs/guide.md", changes: 500 },
+    { filename: "README.md", changes: 40 },
+  ] }) }), false);
+});
+
+test("threshold: 19 changed lines in a single non-doc file → false", async () => {
+  assert.equal(await runWithCompare({ stdout: JSON.stringify({ files: [{ filename: "a.mjs", changes: 19 }] }) }), false);
+});
+
+test("threshold: 20 changed lines in a single non-doc file → true", async () => {
+  assert.equal(await runWithCompare({ stdout: JSON.stringify({ files: [{ filename: "a.mjs", changes: 20 }] }) }), true);
+});
+
+test("threshold: 2 non-doc files each below 20 lines → true (files>=2 arm)", async () => {
+  assert.equal(await runWithCompare({ stdout: JSON.stringify({ files: [
+    { filename: "a.mjs", changes: 3 },
+    { filename: "b.mjs", changes: 5 },
+  ] }) }), true);
+});
+
+test("threshold: 1 non-doc file below 20 lines → false", async () => {
+  assert.equal(await runWithCompare({ stdout: JSON.stringify({ files: [{ filename: "a.mjs", changes: 5 }] }) }), false);
+});
+
+test("additions/deletions fallback aggregates when file.changes is non-finite", async () => {
+  // changes absent → sum additions+deletions = 25 ≥ 20 → true
+  assert.equal(await runWithCompare({ stdout: JSON.stringify({ files: [{ filename: "a.mjs", additions: 15, deletions: 10 }] }) }), true);
+  // changes present but small; single file, no files>=2 → false
+  assert.equal(await runWithCompare({ stdout: JSON.stringify({ files: [{ filename: "a.mjs", additions: 3, deletions: 1 }] }) }), false);
+});
+
+// --- helper units ---
+
+test("getLatestSubmittedCopilotReviewHeadSha picks the latest submitted head by timestamp", () => {
+  const sha = getLatestSubmittedCopilotReviewHeadSha([
+    { author: { login: COPILOT }, state: "COMMENTED", submittedAt: "2026-06-02T08:00:00Z", commit: { oid: "early" } },
+    { author: { login: COPILOT }, state: "COMMENTED", submittedAt: "2026-06-02T12:00:00Z", commit: { oid: "late" } },
+  ]);
+  assert.equal(sha, "late");
+});
+
+test("getLatestSubmittedCopilotReviewHeadSha tie-break: a valid timestamp beats a missing one; PENDING/non-Copilot ignored", () => {
+  const sha = getLatestSubmittedCopilotReviewHeadSha([
+    { author: { login: COPILOT }, state: "COMMENTED", commit: { oid: "no-timestamp" } },
+    { author: { login: COPILOT }, state: "COMMENTED", submittedAt: "2026-06-02T09:00:00Z", commit: { oid: "dated" } },
+    { author: { login: COPILOT }, state: "PENDING", submittedAt: "2026-06-02T23:00:00Z", commit: { oid: "pending" } },
+    { author: { login: "someone-else" }, state: "COMMENTED", submittedAt: "2026-06-02T23:00:00Z", commit: { oid: "human" } },
+  ]);
+  assert.equal(sha, "dated");
+});
+
+test("isTrivialDocumentationOnlyPath classifies docs and text extensions as trivial", () => {
+  for (const p of ["docs/x.mjs", "README.md", "a.mdx", "notes.txt", "x.rst", "y.adoc", "", null, undefined]) {
+    assert.equal(isTrivialDocumentationOnlyPath(p), true, `${p} should be trivial`);
+  }
+  for (const p of ["packages/core/src/a.mjs", "scripts/loop/x.mjs", "test/a.test.mjs"]) {
+    assert.equal(isTrivialDocumentationOnlyPath(p), false, `${p} should be non-trivial`);
+  }
+});

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -44,6 +44,16 @@ const OPEN_PR = JSON.stringify({
   statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
 });
 
+// Five completed Copilot rounds on older heads (oldsha-1..5), latest reviewed
+// head = oldsha-5. Used by the round-cap escape-hatch tests (#1103/#1126).
+const CAP_REVIEWS = [1, 2, 3, 4, 5].map((n) => ({
+  id: `r-${n}`,
+  author: { login: "copilot-pull-request-reviewer[bot]" },
+  state: "COMMENTED",
+  submittedAt: `2026-06-02T${String(n + 7).padStart(2, "0")}:00:00Z`,
+  commit: { oid: `oldsha-${n}` },
+}));
+
 // ---------------------------------------------------------------------------
 // Help and argument validation
 // ---------------------------------------------------------------------------
@@ -1252,127 +1262,35 @@ test("copilot-pr-handoff keeps same-head suppression (no force flag)", async () 
   }
 });
 
-test("copilot-pr-handoff stops at round_cap_clean_fallback (no re-request) when new commits land after resolved comments", async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-round-cap-rerequest-"));
+// #1103/#1126: at the round cap, handoff must AGREE with
+// detect-pr-gate-coordination-state via the shared significant-change detector.
+// A DOC-ONLY post-convergence change stays at round_cap_clean_fallback (stop, no
+// re-request).
+test("copilot-pr-handoff stays at round_cap_clean_fallback (no re-request) when the post-cap change is doc-only", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-round-cap-doconly-"));
 
   try {
     const { env } = await writeGhStubHelper(tempDir, [
       {
         assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
         stdout: JSON.stringify({
-          isDraft: false,
-          state: "OPEN",
-          number: 17,
-          headRefOid: "newsha",
-          reviews: [
-            {
-              id: "r-1",
-              author: { login: "copilot-pull-request-reviewer[bot]" },
-              state: "COMMENTED",
-              submittedAt: "2026-06-02T08:00:00Z",
-              commit: { oid: "oldsha-1" },
-            },
-            {
-              id: "r-2",
-              author: { login: "copilot-pull-request-reviewer[bot]" },
-              state: "COMMENTED",
-              submittedAt: "2026-06-02T09:00:00Z",
-              commit: { oid: "oldsha-2" },
-            },
-            {
-              id: "r-3",
-              author: { login: "copilot-pull-request-reviewer[bot]" },
-              state: "COMMENTED",
-              submittedAt: "2026-06-02T10:00:00Z",
-              commit: { oid: "oldsha-3" },
-            },
-            {
-              id: "r-4",
-              author: { login: "copilot-pull-request-reviewer[bot]" },
-              state: "COMMENTED",
-              submittedAt: "2026-06-02T11:00:00Z",
-              commit: { oid: "oldsha-4" },
-            },
-            {
-              id: "r-5",
-              author: { login: "copilot-pull-request-reviewer[bot]" },
-              state: "COMMENTED",
-              submittedAt: "2026-06-02T12:00:00Z",
-              commit: { oid: "oldsha-5" },
-            },
-          ],
+          isDraft: false, state: "OPEN", number: 17, headRefOid: "newsha",
+          reviews: CAP_REVIEWS,
           statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
         }) + "\n",
       },
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[],"teams":[]}\n' },
+      { assertArgs: ["api", "graphql"], stdout: EMPTY_THREADS + "\n" },
+      { assertArgs: ["api", "repos/owner/repo/commits/newsha/check-runs?per_page=100"], stdout: '{"check_runs":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n' },
+      { assertArgs: ["api", "repos/owner/repo/commits/newsha/status?per_page=100"], stdout: '{"statuses":[]}\n' },
+      // escape-hatch: shared significant-change detector facts + compare
       {
-        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
-        stdout: '{"users":[],"teams":[]}\n',
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,reviews,files"],
+        stdout: JSON.stringify({ headRefOid: "newsha", reviews: CAP_REVIEWS, files: [{ path: "docs/guide.md" }] }) + "\n",
       },
       {
-        assertArgs: ["api", "graphql"],
-        stdout: EMPTY_THREADS + "\n",
-      },
-      {
-        assertArgs: ["api", "repos/owner/repo/commits/newsha/check-runs?per_page=100"],
-        stdout: '{"check_runs":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n',
-      },
-      {
-        assertArgs: ["api", "repos/owner/repo/commits/newsha/status?per_page=100"],
-        stdout: '{"statuses":[]}\n',
-      },
-      {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files", "--jq", ".files[].path"],
-        stdout: 'packages/core/src/loop/copilot-loop-state.mjs\n',
-      },
-      {
-        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
-        stdout: '{"users":[],"teams":[]}\n',
-      },
-      {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
-        stdout: JSON.stringify({
-          headRefOid: "newsha",
-          isDraft: false,
-          state: "OPEN",
-          number: 17,
-          reviews: [
-            { id: "r-1", state: "COMMENTED", author: { login: "copilot-pull-request-reviewer[bot]" }, commit: { oid: "oldsha-1" } },
-            { id: "r-2", state: "COMMENTED", author: { login: "copilot-pull-request-reviewer[bot]" }, commit: { oid: "oldsha-2" } },
-            { id: "r-3", state: "COMMENTED", author: { login: "copilot-pull-request-reviewer[bot]" }, commit: { oid: "oldsha-3" } },
-            { id: "r-4", state: "COMMENTED", author: { login: "copilot-pull-request-reviewer[bot]" }, commit: { oid: "oldsha-4" } },
-            { id: "r-5", state: "COMMENTED", author: { login: "copilot-pull-request-reviewer[bot]" }, commit: { oid: "oldsha-5" } },
-          ],
-          statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
-        }) + "\n",
-      },
-      {
-        assertArgs: ["api", "graphql"],
-        stdout: EMPTY_THREADS + "\n",
-      },
-      {
-        assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
-        stdout: "https://github.com/owner/repo/pull/17\n",
-      },
-      {
-        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
-        stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n',
-      },
-      {
-        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
-        stdout: JSON.stringify({
-          headRefOid: "newsha",
-          isDraft: false,
-          state: "OPEN",
-          number: 17,
-          reviews: [
-            { id: "r-1", state: "COMMENTED", author: { login: "copilot-pull-request-reviewer[bot]" }, commit: { oid: "oldsha-1" } },
-            { id: "r-2", state: "COMMENTED", author: { login: "copilot-pull-request-reviewer[bot]" }, commit: { oid: "oldsha-2" } },
-            { id: "r-3", state: "COMMENTED", author: { login: "copilot-pull-request-reviewer[bot]" }, commit: { oid: "oldsha-3" } },
-            { id: "r-4", state: "COMMENTED", author: { login: "copilot-pull-request-reviewer[bot]" }, commit: { oid: "oldsha-4" } },
-            { id: "r-5", state: "COMMENTED", author: { login: "copilot-pull-request-reviewer[bot]" }, commit: { oid: "oldsha-5" } },
-          ],
-          statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
-        }) + "\n",
+        assertArgs: ["api", "repos/owner/repo/compare/oldsha-5...newsha"],
+        stdout: JSON.stringify({ files: [{ filename: "docs/guide.md", changes: 500 }] }) + "\n",
       },
     ], { matchMode: "claims" });
     env.DEVLOOPS_RUN_ID = "";
@@ -1384,14 +1302,77 @@ test("copilot-pr-handoff stops at round_cap_clean_fallback (no re-request) when 
 
     const output = JSON.parse(result.stdout);
     assert.equal(output.ok, true);
-    // Head advanced past the last review at the cap: no Copilot re-request is permitted.
-    // The loop proceeds to the pre_approval_gate fallback (terminal/proceeding) rather
-    // than re-requesting and waiting for a review that would be an over-cap round.
+    // Doc-only change → not significant → no re-request; clean fallback holds.
     assert.equal(output.action, "stop");
     assert.equal(output.state, "round_cap_clean_fallback");
     assert.equal(output.roundCapCleanEligible, true);
     assert.equal(output.loopDisposition, "done");
     assert.equal(output.terminal, true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+// #1103/#1126: a SIGNIFICANT (product/test-logic) post-convergence change at the
+// cap reopens a Copilot cycle — handoff now re-requests review (action=watch),
+// matching detect-pr-gate-coordination-state's rerequest_copilot_review.
+test("copilot-pr-handoff re-requests Copilot review at the cap when a significant post-convergence change lands", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-round-cap-significant-"));
+
+  try {
+    const { env } = await writeGhStubHelper(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: JSON.stringify({
+          isDraft: false, state: "OPEN", number: 17, headRefOid: "newsha",
+          reviews: CAP_REVIEWS,
+          statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+        }) + "\n",
+      },
+      // detect requested_reviewers + performRequest pre/post checks (claimed in order)
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[],"teams":[]}\n' },
+      { assertArgs: ["api", "graphql"], stdout: EMPTY_THREADS + "\n" },
+      { assertArgs: ["api", "repos/owner/repo/commits/newsha/check-runs?per_page=100"], stdout: '{"check_runs":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n' },
+      { assertArgs: ["api", "repos/owner/repo/commits/newsha/status?per_page=100"], stdout: '{"statuses":[]}\n' },
+      // escape-hatch: shared significant-change detector facts + compare (significant)
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,reviews,files"],
+        stdout: JSON.stringify({ headRefOid: "newsha", reviews: CAP_REVIEWS, files: [{ path: "packages/core/src/loop/foo.mjs" }] }) + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/compare/oldsha-5...newsha"],
+        stdout: JSON.stringify({ files: [{ filename: "packages/core/src/loop/foo.mjs", changes: 670 }] }) + "\n",
+      },
+      // performCopilotReviewRequest: pre-check reviewers, pre-check reviews, add, verify reviewers, verify reviews
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[],"teams":[]}\n' },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+        stdout: JSON.stringify({ headRefOid: "newsha", isDraft: false, state: "OPEN", number: 17, reviews: CAP_REVIEWS, statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }] }) + "\n",
+      },
+      { assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"], stdout: "https://github.com/owner/repo/pull/17\n" },
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n' },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+        stdout: JSON.stringify({ headRefOid: "newsha", isDraft: false, state: "OPEN", number: 17, reviews: CAP_REVIEWS, statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }] }) + "\n",
+      },
+    ], { matchMode: "claims" });
+    env.DEVLOOPS_RUN_ID = "";
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    // Significant change at the cap → reopen a Copilot cycle: re-request + watch.
+    assert.equal(output.action, "watch");
+    assert.equal(output.state, "waiting_for_copilot_review");
+    assert.equal(output.reviewRequestStatus, "requested");
+    assert.equal(output.roundCapCleanEligible, false);
+    assert.notEqual(output.loopDisposition, "done");
+    assert.equal(output.terminal, false);
+    assert.ok(output.watchArgs, "expected watchArgs for the reopened cycle");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -1378,6 +1378,97 @@ test("copilot-pr-handoff re-requests Copilot review at the cap when a significan
   }
 });
 
+// #1126 fail-closed (integration): if the shared detector's gh compare exits
+// non-zero at the cap, significance is unknown → no re-request; clean fallback holds.
+test("copilot-pr-handoff stays at round_cap_clean_fallback when the compare call fails (fail closed)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-round-cap-compare-fail-"));
+
+  try {
+    const { env } = await writeGhStubHelper(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: JSON.stringify({
+          isDraft: false, state: "OPEN", number: 17, headRefOid: "newsha",
+          reviews: CAP_REVIEWS,
+          statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+        }) + "\n",
+      },
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[],"teams":[]}\n' },
+      { assertArgs: ["api", "graphql"], stdout: EMPTY_THREADS + "\n" },
+      { assertArgs: ["api", "repos/owner/repo/commits/newsha/check-runs?per_page=100"], stdout: '{"check_runs":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n' },
+      { assertArgs: ["api", "repos/owner/repo/commits/newsha/status?per_page=100"], stdout: '{"statuses":[]}\n' },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,reviews,files"],
+        stdout: JSON.stringify({ headRefOid: "newsha", reviews: CAP_REVIEWS, files: [{ path: "packages/core/src/loop/foo.mjs" }] }) + "\n",
+      },
+      // compare fails → detector returns false → no reopen
+      { assertArgs: ["api", "repos/owner/repo/compare/oldsha-5...newsha"], stdout: "", stderr: "boom", exitCode: 1 },
+    ], { matchMode: "claims" });
+    env.DEVLOOPS_RUN_ID = "";
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.action, "stop");
+    assert.equal(output.state, "round_cap_clean_fallback");
+    assert.equal(output.roundCapCleanEligible, true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+// #1126 (integration): when Copilot's latest review is already on the current
+// head (no new commits since), the same-head guard short-circuits before any
+// compare — clean fallback holds, no re-request.
+test("copilot-pr-handoff stays at round_cap_clean_fallback when the last reviewed head equals the current head", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-round-cap-samehead-"));
+
+  // Five completed rounds; the latest submitted review is on the CURRENT head "newsha".
+  const sameHeadReviews = [1, 2, 3, 4].map((n) => ({
+    id: `r-${n}`, author: { login: "copilot-pull-request-reviewer[bot]" }, state: "COMMENTED",
+    submittedAt: `2026-06-02T0${n}:00:00Z`, commit: { oid: `oldsha-${n}` },
+  })).concat([{
+    id: "r-5", author: { login: "copilot-pull-request-reviewer[bot]" }, state: "COMMENTED",
+    submittedAt: "2026-06-02T12:00:00Z", commit: { oid: "newsha" },
+  }]);
+
+  try {
+    const { env } = await writeGhStubHelper(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: JSON.stringify({
+          isDraft: false, state: "OPEN", number: 17, headRefOid: "newsha",
+          reviews: sameHeadReviews,
+          statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+        }) + "\n",
+      },
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[],"teams":[]}\n' },
+      { assertArgs: ["api", "graphql"], stdout: EMPTY_THREADS + "\n" },
+      { assertArgs: ["api", "repos/owner/repo/commits/newsha/check-runs?per_page=100"], stdout: '{"check_runs":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n' },
+      { assertArgs: ["api", "repos/owner/repo/commits/newsha/status?per_page=100"], stdout: '{"statuses":[]}\n' },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,reviews,files"],
+        stdout: JSON.stringify({ headRefOid: "newsha", reviews: sameHeadReviews, files: [{ path: "packages/core/src/loop/foo.mjs" }] }) + "\n",
+      },
+      // NOTE: no compare entry — the same-head guard returns before any compare call.
+    ], { matchMode: "claims" });
+    env.DEVLOOPS_RUN_ID = "";
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.action, "stop");
+    assert.equal(output.state, "round_cap_clean_fallback");
+    assert.equal(output.roundCapCleanEligible, true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Handoff: unresolved feedback → fix
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1126.

## Summary
After the Copilot review round cap, `detect-pr-gate-coordination-state` and `copilot-pr-handoff` could disagree: detect offered `rerequest_copilot_review` for a **significant post-convergence change** (the #1103 escape hatch), while the handoff — with no significant-change detection — refused (observed in #1125). This makes them agree by sharing **one** cap predicate and **one** significant-change detector, and teaching the handoff the same escape-hatch capability.

## Scope and context
Two single-source extractions + a handoff behavior addition. The two coordinator detectors now conclude a re-request **iff (cap reached AND significant post-convergence change)** — identical inputs, identical conclusion.

## File-by-file changes
- `packages/core/src/loop/copilot-loop-state.mjs` — extract `isCopilotRoundCapReached({copilotReviewRoundCount, maxCopilotRounds})`, the single cap predicate. Every prior inline `>= maxCopilotRounds` comparison (interpretLoopState, `pr-gate-coordination` ×2, `detect-pr-gate-coordination-state`) now calls it.
- `scripts/loop/_post-convergence-change.mjs` (**new**) — single implementation of `detectPostConvergenceSignificantChange` (+ `getLatestSubmittedCopilotReviewHeadSha`, `isTrivialDocumentationOnlyPath`). In `scripts/loop/` (not core) because significance is derived from a `gh compare`. Consumed by both detectors.
- `scripts/loop/detect-pr-gate-coordination-state.mjs` — its ~87-line inline copy deleted, replaced by the import (no behavior change; escape-hatch offer unchanged).
- `scripts/loop/copilot-pr-handoff.mjs` — at `round_cap_clean_fallback`, fetch reopen-cycle facts (gated helper, off the hot path) and run the shared detector; on a significant post-convergence change, override to a re-request (`waiting_for_copilot_review`) matching detect. No significant change → unchanged `round_cap_clean_fallback` (stop).
- `packages/core/src/loop/pr-gate-coordination.mjs` — its two inline `>= maxCopilotRounds` comparisons now call the shared `isCopilotRoundCapReached`.
- `packages/core/test/copilot-loop-state.test.mjs` — `isCopilotRoundCapReached` unit tests (at/above/below cap, disabled/null/0).
- `packages/core/test/pr-gate-coordination.test.mjs` — 3 parity tests from the SAME snapshot: at-cap no-change → both forbid re-request; below-cap → both allow; at-cap + significant → both reopen the cycle.
- `test/loop/copilot-pr-handoff.test.mjs` — the existing cap test split into: doc-only post-cap change → stays `round_cap_clean_fallback` (stop); significant change → re-requests + watch. Plus 2 fail-closed integration cases (compare non-zero at cap → stop; same-head → stop).
- `test/loop/_post-convergence-change.test.mjs` (**new**) — 18 direct unit tests for the shared detector: every fail-closed branch (compare failure, unparseable JSON, empty files, missing/same head, no submitted review), the significance thresholds (19/1→false, 20/1→true, 2-files arm, additions/deletions fallback), doc-only exclusion, and the `getLatestSubmittedCopilotReviewHeadSha` ordering/tie-break. Proven real (breaking a guard fails a test).

## Acceptance criteria
- [x] `detect-pr-gate-coordination-state` is cap-aware via the same shared cap check as the handoff (no duplicated `>= maxCopilotRounds`).
- [x] The two detectors agree at the cap boundary — including the #1103 escape-hatch case (both re-request iff cap reached AND significant post-convergence change).
- [x] Significant-change detection is single-source (`_post-convergence-change.mjs`), consumed by both.
- [x] Parity tests assert agreement across the boundary from the same snapshot; the existing handoff test correctly distinguishes doc-only vs significant.

## Definition of done
- [x] `npm run verify` green (0 failures).

## Non-goals
- The `request-copilot-review` **CLI**'s own standalone auto-rerequest still keys off `interpretLoopState` alone, so a direct CLI call at the cap needs `--force-rerequest-review` for a significant change; the handoff passes that bypass internally after the shared-detector decision. Wiring the CLI as a 4th consumer of the shared detector is out of scope — the two named coordinator detectors now fully agree.
- No change to draft/pre-approval/merge gating beyond making the Copilot re-request cap-aware.

## Validation command
```
npm run verify
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
