### PR TITLE
fix(gates): record fan-out provenance + opt-in enforcement + route-to-conductor (#1110)

### DIFF
--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -321,16 +321,30 @@ findings-log ledger can additionally record **fan-out provenance**:
 ```
 
 Provenance is written via `write-gate-findings-log.mjs --provenance <json>` (validated
-on write; malformed provenance fails the write). It is **optional and additive** — when
-omitted, the ledger is byte-identical to before and no enforcement changes.
+on write; malformed OR self-inconsistent provenance fails the write). It is **optional
+and additive** — when omitted, the ledger is byte-identical to before and no enforcement
+changes. **Internal-consistency rule** (enforced on both the write path and the
+enforcement read path): `perAngle` must be non-empty when `distinctReviewers > 0`, and
+`distinctReviewers` must be `<=` the count of DISTINCT reviewer identities actually
+recorded in `perAngle` (distinct by `reviewer`, else `dispatchId`; a bare `{angle}` is
+not a countable reviewer). You cannot claim more reviewers than you recorded dispatch
+entries for — this closes the `{distinctReviewers: 2, perAngle: []}` loophole.
 
 Enforcement is opt-in via **`gates.requireFanoutProvenance`** (default **false**). When
 enabled, it layers ON TOP of `requireFanoutEvidence` (it only takes effect while fan-out
 evidence enforcement is active): each required `fanout_fanin` gate's ledger must record
-`provenance.distinctReviewers >= 2`. A floor of **2** is the smallest count that proves
-the review was not produced by a single self-producing agent. When the flag is off,
-behavior is byte-identical to today (no new failures) — the Claude-Code path, which
-already honors child fan-out, is a validated no-op.
+internally-consistent provenance with `provenance.distinctReviewers >= 2` (a floor of
+**2** is the smallest count that is not a single agent). When the flag is off, behavior is
+byte-identical to today (no new failures) — the Claude-Code path, which already honors
+child fan-out, is a validated no-op.
+
+**Honest caveat (this is NOT un-forgeable):** recorded provenance is self-reported — it is
+written by the same agent whose independence it claims — so a determined single agent can
+still forge an internally-consistent blob. This enforcement raises the bar (rejects
+malformed/inconsistent provenance and requires distinct recorded dispatch entries) but
+does NOT claim un-forgeable enforcement. Un-forgeable recording (the harness attesting who
+actually ran each per-angle review) is the Pi-harness bridge — the subagent tool honored
+at child depth (see #1084).
 
 ### Fail-closed: fan-out unavailable → route to conductor
 

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -312,7 +312,7 @@ findings-log ledger can additionally record **fan-out provenance**:
 
 ```jsonc
 "provenance": {
-  "distinctReviewers": 3,               // count of distinct reviewer agents dispatched
+  "distinctReviewers": 2,               // count of distinct reviewer agents dispatched (<= distinct identities in perAngle)
   "perAngle": [                          // per-angle dispatch provenance
     { "angle": "scope",   "reviewer": "review-a", "dispatchId": "…", "model": "…" },
     { "angle": "safety",  "reviewer": "review-b" }

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -302,6 +302,53 @@ resolved-in SHA (for findings resolved in a later pass).
 Each gate verdict records an `executionMode` (`fanout_fanin` or `inline_single_agent`,
 default `inline_single_agent`) via the [Gate comment command](../skills/copilot-pr-followup/SKILL.md#mandatory-gate-comment-command-contract); inline runs must declare an `--inline-reason`. A `fanout_fanin` verdict passes the structured per-angle review results via `--findings-json` (the per-angle `{angle, verdict, findings}` artifacts that feed `consolidateFanin`, or the flat `toFindingsLogShape` output grouped by `.angle`) so the comment renders a per-angle breakdown; `--findings-summary` is the inline_single_agent fallback only. Fan-out evidence enforcement is **ON by default** (`gates.requireFanoutEvidence`): a clean gate verdict requires the gate to run via `--execution-mode fanout_fanin` with a findings-log ledger for the head SHA, and the pre-merge evidence check fails closed for a required gate otherwise. Repos can opt out with `gates.requireFanoutEvidence: false`. Live context-builder/fan-out execution (epic #867) is what makes `fanout_fanin` producible — distinct from this contract's own sub-loop phase numbering (preamble / fanout / fanin).
 
+### Fan-out provenance (closing the self-produced-artifact loophole)
+
+`requireFanoutEvidence` is artifact-based: it only proves a `fanout_fanin` verdict
+carries a findings-log ledger. A single agent could self-produce every per-angle
+artifact + the ledger and label the verdict `fanout_fanin`, satisfying the letter
+of the gate while defeating independent parallel review. To close this, the
+findings-log ledger can additionally record **fan-out provenance**:
+
+```jsonc
+"provenance": {
+  "distinctReviewers": 3,               // count of distinct reviewer agents dispatched
+  "perAngle": [                          // per-angle dispatch provenance
+    { "angle": "scope",   "reviewer": "review-a", "dispatchId": "…", "model": "…" },
+    { "angle": "safety",  "reviewer": "review-b" }
+  ]
+}
+```
+
+Provenance is written via `write-gate-findings-log.mjs --provenance <json>` (validated
+on write; malformed provenance fails the write). It is **optional and additive** — when
+omitted, the ledger is byte-identical to before and no enforcement changes.
+
+Enforcement is opt-in via **`gates.requireFanoutProvenance`** (default **false**). When
+enabled, it layers ON TOP of `requireFanoutEvidence` (it only takes effect while fan-out
+evidence enforcement is active): each required `fanout_fanin` gate's ledger must record
+`provenance.distinctReviewers >= 2`. A floor of **2** is the smallest count that proves
+the review was not produced by a single self-producing agent. When the flag is off,
+behavior is byte-identical to today (no new failures) — the Claude-Code path, which
+already honors child fan-out, is a validated no-op.
+
+### Fail-closed: fan-out unavailable → route to conductor
+
+When a child/agent **cannot** perform real parallel fan-out (e.g. a harness that does not
+honor the subagent tool at child depth), the flow MUST fail closed rather than silently
+degrade to a single-agent inline review. The canonical, matchable signal is the exported
+constant `FANOUT_UNAVAILABLE_MESSAGE` (`@dev-loops/core/loop/gate-fanin`):
+
+> **fan-out unavailable — route to conductor**
+
+`fanoutUnavailableError(detail)` builds an `Error` carrying this prefix plus
+`{ routeToConductor: true, code: "FANOUT_UNAVAILABLE" }`. Callers throw it (or check
+`err.routeToConductor === true`) to hand the gate review up to the conductor. The
+`requireFanoutProvenance` pre-merge failure message references this same contract string.
+The full end-to-end driving command that dispatches per-angle review subagents at child
+depth is provided by the Pi-harness child (the bridge); this contract specifies only the
+recording + enforcement + fail-closed signal that land independently.
+
 ## See also
 
 - [Checkpoint Verdict Comment Contract](./gate-review-comment-contract.md) — visible PR comment evidence format

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -72,6 +72,15 @@ const GatesConfig = z.strictObject({
   // true (opt-out): a clean gate verdict requires fan-out/fan-in evidence
   // unless explicitly disabled. See docs/gate-review-sub-loop-contract.md.
   requireFanoutEvidence: z.boolean().default(true),
+  // Fail-closed enforcement that a fanout_fanin gate verdict carries recorded
+  // fan-out *provenance* (distinct reviewer count + per-angle dispatch), proving
+  // the review was produced by independent parallel reviewers rather than a
+  // single agent self-producing every artifact. Layered ON TOP of
+  // requireFanoutEvidence — only takes effect when fan-out evidence enforcement
+  // is active. Default false (opt-in): closing this loophole is additive and
+  // does not change behavior for existing ledgers that carry no provenance. See
+  // docs/gate-review-sub-loop-contract.md.
+  requireFanoutProvenance: z.boolean().default(false),
   // Cap on how many scoped `review` reviewers the gate fan-out spawns in
   // parallel. When the resolved angle set exceeds this cap, the overflow runs
   // in sequential batches and the degradation is recorded in the gate evidence.
@@ -179,6 +188,7 @@ const FileGatesConfig = z.strictObject({
   preApproval: FileGateConfig.optional(),
   spike: FileGateConfig.optional(),
   requireFanoutEvidence: z.boolean().optional(),
+  requireFanoutProvenance: z.boolean().optional(),
   maxFanoutReviewers: z.number().int().min(1).max(64).optional(),
   postFindingsComments: z.boolean().optional(),
   anglePool: z.array(z.string().trim().min(1)).optional(),
@@ -982,6 +992,31 @@ export function resolveGateConfig(config, gate) {
  */
 export function resolveRequireFanoutEvidence(config) {
   return config?.gates?.requireFanoutEvidence !== false;
+}
+
+/**
+ * Minimum distinct reviewer count for a fanout_fanin ledger to satisfy
+ * requireFanoutProvenance. A floor of 2 is the smallest count that proves the
+ * review was not produced by a single self-producing agent. Documented in
+ * docs/gate-review-sub-loop-contract.md.
+ */
+export const FANOUT_PROVENANCE_MIN_REVIEWERS = 2;
+
+/**
+ * Resolve whether fan-out *provenance* is required for a fanout_fanin gate
+ * verdict (distinct reviewer count + per-angle dispatch recorded in the ledger).
+ *
+ * Default-OFF (opt-in): unlike resolveRequireFanoutEvidence, this uses a strict
+ * `=== true` test so behavior is byte-identical to today unless a repo
+ * explicitly opts in via `gates.requireFanoutProvenance: true`. Layered on top
+ * of fan-out evidence enforcement (see buildFanoutEnforcement). See
+ * docs/gate-review-sub-loop-contract.md.
+ *
+ * @param {DevLoopConfig} config
+ * @returns {boolean}
+ */
+export function resolveRequireFanoutProvenance(config) {
+  return config?.gates?.requireFanoutProvenance === true;
 }
 
 /**

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -72,14 +72,15 @@ const GatesConfig = z.strictObject({
   // true (opt-out): a clean gate verdict requires fan-out/fan-in evidence
   // unless explicitly disabled. See docs/gate-review-sub-loop-contract.md.
   requireFanoutEvidence: z.boolean().default(true),
-  // Fail-closed enforcement that a fanout_fanin gate verdict carries recorded
-  // fan-out *provenance* (distinct reviewer count + per-angle dispatch), proving
-  // the review was produced by independent parallel reviewers rather than a
-  // single agent self-producing every artifact. Layered ON TOP of
+  // Fail-closed enforcement that a fanout_fanin gate verdict carries recorded,
+  // internally-consistent fan-out *provenance* (distinct reviewer count +
+  // per-angle dispatch). This RAISES THE BAR against a single agent self-producing
+  // every artifact but does NOT prove independence — provenance is self-reported,
+  // so it remains forgeable; un-forgeable recording is the Pi-harness bridge (see
+  // the honest caveat in docs/gate-review-sub-loop-contract.md). Layered ON TOP of
   // requireFanoutEvidence — only takes effect when fan-out evidence enforcement
   // is active. Default false (opt-in): closing this loophole is additive and
-  // does not change behavior for existing ledgers that carry no provenance. See
-  // docs/gate-review-sub-loop-contract.md.
+  // does not change behavior for existing ledgers that carry no provenance.
   requireFanoutProvenance: z.boolean().default(false),
   // Cap on how many scoped `review` reviewers the gate fan-out spawns in
   // parallel. When the resolved angle set exceeds this cap, the overflow runs
@@ -996,9 +997,10 @@ export function resolveRequireFanoutEvidence(config) {
 
 /**
  * Minimum distinct reviewer count for a fanout_fanin ledger to satisfy
- * requireFanoutProvenance. A floor of 2 is the smallest count that proves the
- * review was not produced by a single self-producing agent. Documented in
- * docs/gate-review-sub-loop-contract.md.
+ * requireFanoutProvenance. A floor of 2 is the smallest count that is not a
+ * single agent; it raises the bar but does not prove independence (provenance
+ * is self-reported — see the honest caveat in
+ * docs/gate-review-sub-loop-contract.md).
  */
 export const FANOUT_PROVENANCE_MIN_REVIEWERS = 2;
 

--- a/packages/core/src/loop/gate-fanin.mjs
+++ b/packages/core/src/loop/gate-fanin.mjs
@@ -50,6 +50,73 @@ export function fanoutUnavailableError(detail) {
 }
 
 /**
+ * Count DISTINCT reviewer identities actually recorded in a `perAngle` array.
+ * An entry contributes an identity via `reviewer` (preferred) or `dispatchId`;
+ * entries carrying neither are not countable reviewers (a bare `{angle}` proves
+ * nothing about who reviewed it). Pure.
+ *
+ * @param {unknown} perAngle
+ * @returns {number}
+ */
+export function countDistinctReviewers(perAngle) {
+  if (!Array.isArray(perAngle)) return 0;
+  const ids = new Set();
+  for (const e of perAngle) {
+    if (!e || typeof e !== "object" || Array.isArray(e)) continue;
+    const id = typeof e.reviewer === "string" && e.reviewer.trim().length > 0
+      ? e.reviewer.trim()
+      : typeof e.dispatchId === "string" && e.dispatchId.trim().length > 0
+        ? e.dispatchId.trim()
+        : null;
+    if (id) ids.add(id);
+  }
+  return ids.size;
+}
+
+/**
+ * Validate INTERNAL CONSISTENCY of a fan-out provenance object. Returns an error
+ * string when the provenance is malformed or self-inconsistent, or null when it
+ * is well-formed and consistent. Shared by the write path (write-gate-findings-log)
+ * and the enforcement read path (buildPreMergeGateCheck) so both agree.
+ *
+ * Consistency rule (documented in docs/gate-review-sub-loop-contract.md):
+ *   - `distinctReviewers` must be a non-negative integer.
+ *   - `perAngle` must be an array, and non-empty when `distinctReviewers > 0`.
+ *   - `distinctReviewers` must be <= the count of DISTINCT reviewer identities
+ *     actually recorded in `perAngle` — you cannot claim more reviewers than you
+ *     recorded dispatch entries for.
+ *
+ * HONEST CAVEAT: this makes recorded provenance internally consistent and raises
+ * the bar, but the provenance is self-reported (written by the same agent whose
+ * independence it claims), so it remains forgeable by a determined single agent.
+ * Un-forgeable recording is the Pi-harness bridge (subagent tool at child depth).
+ *
+ * @param {unknown} prov
+ * @returns {string|null}
+ */
+export function provenanceConsistencyError(prov) {
+  if (!prov || typeof prov !== "object" || Array.isArray(prov)) {
+    return "provenance must be an object";
+  }
+  const p = /** @type {Record<string, unknown>} */ (prov);
+  if (!Number.isInteger(p.distinctReviewers) || /** @type {number} */ (p.distinctReviewers) < 0) {
+    return "provenance.distinctReviewers must be a non-negative integer";
+  }
+  if (!Array.isArray(p.perAngle)) {
+    return "provenance.perAngle must be an array";
+  }
+  const claimed = /** @type {number} */ (p.distinctReviewers);
+  if (claimed > 0 && p.perAngle.length === 0) {
+    return "provenance.perAngle must be non-empty when distinctReviewers > 0";
+  }
+  const recorded = countDistinctReviewers(p.perAngle);
+  if (claimed > recorded) {
+    return `provenance.distinctReviewers (${claimed}) exceeds distinct recorded reviewer identities (${recorded})`;
+  }
+  return null;
+}
+
+/**
  * Default cap on parallel fan-out reviewers when a caller does not supply one.
  * Mirrors the config default (gates.maxFanoutReviewers).
  */

--- a/packages/core/src/loop/gate-fanin.mjs
+++ b/packages/core/src/loop/gate-fanin.mjs
@@ -25,6 +25,31 @@ const VALID_SEVERITIES = new Set(["must-fix", "worth-fixing-now", "defer"]);
 const VALID_VERDICTS = new Set(["clean", "findings_present"]);
 
 /**
+ * Canonical fail-closed signal for when a child/agent cannot perform real
+ * parallel fan-out (e.g. the harness does not honor the subagent tool at child
+ * depth). The flow MUST fail closed with this message and route the gate review
+ * to the conductor rather than silently degrading to a single-agent inline
+ * review (which requireFanoutProvenance is designed to reject). Documented as a
+ * contract in docs/gate-review-sub-loop-contract.md.
+ */
+export const FANOUT_UNAVAILABLE_MESSAGE = "fan-out unavailable — route to conductor";
+
+/**
+ * Build a fail-closed Error carrying the route-to-conductor contract signal.
+ * Callers throw this (or check `.routeToConductor === true`) when real fan-out
+ * cannot be performed. `detail` is appended for diagnostics but the stable,
+ * matchable prefix is always {@link FANOUT_UNAVAILABLE_MESSAGE}.
+ *
+ * @param {string} [detail] — optional diagnostic suffix (e.g. why fan-out failed)
+ * @returns {Error & { routeToConductor: true, code: "FANOUT_UNAVAILABLE" }}
+ */
+export function fanoutUnavailableError(detail) {
+  const suffix = typeof detail === "string" && detail.trim().length > 0 ? ` (${detail.trim()})` : "";
+  const error = new Error(`${FANOUT_UNAVAILABLE_MESSAGE}${suffix}`);
+  return Object.assign(error, { routeToConductor: /** @type {const} */ (true), code: /** @type {const} */ ("FANOUT_UNAVAILABLE") });
+}
+
+/**
  * Default cap on parallel fan-out reviewers when a caller does not supply one.
  * Mirrors the config default (gates.maxFanoutReviewers).
  */

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -27,6 +27,8 @@ import {
   resolveGateDispatchMode,
   GATE_FULL_LABEL,
   resolveRequireFanoutEvidence,
+  resolveRequireFanoutProvenance,
+  FANOUT_PROVENANCE_MIN_REVIEWERS,
   resolveGatePostFindingsComments,
 } from "../src/config/config.mjs";
 // ============================================================================
@@ -3098,6 +3100,39 @@ describe("gates.requireFanoutEvidence", () => {
   test("rejects non-boolean requireFanoutEvidence", () => {
     const bad = DevLoopConfigSchema.safeParse({ version: 1, gates: { requireFanoutEvidence: "yes" } });
     assert.equal(bad.success, false);
+  });
+});
+
+describe("gates.requireFanoutProvenance", () => {
+  test("defaults to false (opt-in) and resolveRequireFanoutProvenance reflects it", () => {
+    // Default-OFF: strict === true resolver, so absent/undefined config is false.
+    assert.equal(resolveRequireFanoutProvenance({}), false);
+    assert.equal(resolveRequireFanoutProvenance({ gates: {} }), false);
+    assert.equal(resolveRequireFanoutProvenance({ gates: { requireFanoutProvenance: false } }), false);
+    const parsed = DevLoopConfigSchema.safeParse({ version: 1, gates: { draft: {} } });
+    assert.equal(parsed.success, true);
+    assert.equal(parsed.data.gates.requireFanoutProvenance, false);
+    assert.equal(resolveRequireFanoutProvenance(parsed.data), false);
+  });
+
+  test("opt-in: explicit requireFanoutProvenance: true enables enforcement", () => {
+    assert.equal(resolveRequireFanoutProvenance({ gates: { requireFanoutProvenance: true } }), true);
+    const full = DevLoopConfigSchema.safeParse({ version: 1, gates: { requireFanoutProvenance: true } });
+    assert.equal(full.success, true);
+    assert.equal(full.data.gates.requireFanoutProvenance, true);
+    assert.equal(resolveRequireFanoutProvenance(full.data), true);
+    const file = FileConfigSchema.safeParse({ version: 1, gates: { requireFanoutProvenance: true } });
+    assert.equal(file.success, true);
+    assert.equal(file.data.gates.requireFanoutProvenance, true);
+  });
+
+  test("rejects non-boolean requireFanoutProvenance", () => {
+    const bad = DevLoopConfigSchema.safeParse({ version: 1, gates: { requireFanoutProvenance: "yes" } });
+    assert.equal(bad.success, false);
+  });
+
+  test("floor constant is 2 (smallest count that is not a single agent)", () => {
+    assert.equal(FANOUT_PROVENANCE_MIN_REVIEWERS, 2);
   });
 });
 

--- a/packages/core/test/gate-fanin.test.mjs
+++ b/packages/core/test/gate-fanin.test.mjs
@@ -6,6 +6,8 @@ import {
   toFindingsLogShape,
   planFanoutBatches,
   DEFAULT_MAX_FANOUT_REVIEWERS,
+  FANOUT_UNAVAILABLE_MESSAGE,
+  fanoutUnavailableError,
 } from "../src/loop/gate-fanin.mjs";
 
 function cleanAngle(angle) {
@@ -186,5 +188,26 @@ describe("planFanoutBatches", () => {
     const angles = Array.from({ length: 9 }, (_, i) => `a${i}`);
     assert.equal(planFanoutBatches(angles, 0).batches.length, 2);
     assert.equal(planFanoutBatches(angles, -1).degraded, true);
+  });
+});
+
+describe("fanoutUnavailableError / route-to-conductor contract (AC4)", () => {
+  test("FANOUT_UNAVAILABLE_MESSAGE is the documented stable signal", () => {
+    assert.equal(FANOUT_UNAVAILABLE_MESSAGE, "fan-out unavailable — route to conductor");
+  });
+
+  test("fanoutUnavailableError carries the route-to-conductor signal", () => {
+    const err = fanoutUnavailableError();
+    assert.ok(err instanceof Error);
+    assert.equal(err.message, FANOUT_UNAVAILABLE_MESSAGE);
+    assert.equal(err.routeToConductor, true);
+    assert.equal(err.code, "FANOUT_UNAVAILABLE");
+  });
+
+  test("fanoutUnavailableError appends a diagnostic detail but keeps the matchable prefix", () => {
+    const err = fanoutUnavailableError("subagent tool not honored at child depth");
+    assert.ok(err.message.startsWith(FANOUT_UNAVAILABLE_MESSAGE));
+    assert.ok(err.message.includes("subagent tool not honored"));
+    assert.equal(err.routeToConductor, true);
   });
 });

--- a/packages/core/test/gate-fanin.test.mjs
+++ b/packages/core/test/gate-fanin.test.mjs
@@ -8,6 +8,8 @@ import {
   DEFAULT_MAX_FANOUT_REVIEWERS,
   FANOUT_UNAVAILABLE_MESSAGE,
   fanoutUnavailableError,
+  countDistinctReviewers,
+  provenanceConsistencyError,
 } from "../src/loop/gate-fanin.mjs";
 
 function cleanAngle(angle) {
@@ -209,5 +211,27 @@ describe("fanoutUnavailableError / route-to-conductor contract (AC4)", () => {
     assert.ok(err.message.startsWith(FANOUT_UNAVAILABLE_MESSAGE));
     assert.ok(err.message.includes("subagent tool not honored"));
     assert.equal(err.routeToConductor, true);
+  });
+});
+
+describe("provenance consistency (closes the self-produced loophole)", () => {
+  test("countDistinctReviewers counts distinct reviewer/dispatchId identities only", () => {
+    assert.equal(countDistinctReviewers([]), 0);
+    assert.equal(countDistinctReviewers([{ angle: "a" }]), 0); // no identity
+    assert.equal(countDistinctReviewers([{ angle: "a", reviewer: "x" }, { angle: "b", reviewer: "x" }]), 1); // dup
+    assert.equal(countDistinctReviewers([{ angle: "a", reviewer: "x" }, { angle: "b", dispatchId: "y" }]), 2);
+    assert.equal(countDistinctReviewers("nope"), 0);
+  });
+
+  test("provenanceConsistencyError accepts consistent provenance", () => {
+    assert.equal(provenanceConsistencyError({ distinctReviewers: 0, perAngle: [] }), null);
+    assert.equal(provenanceConsistencyError({ distinctReviewers: 2, perAngle: [{ angle: "a", reviewer: "x" }, { angle: "b", reviewer: "y" }] }), null);
+  });
+
+  test("provenanceConsistencyError rejects the {n, perAngle:[]} loophole and over-claims", () => {
+    assert.match(provenanceConsistencyError(null), /must be an object/);
+    assert.match(provenanceConsistencyError({ distinctReviewers: 1.5, perAngle: [] }), /non-negative integer/);
+    assert.match(provenanceConsistencyError({ distinctReviewers: 2, perAngle: [] }), /perAngle must be non-empty/);
+    assert.match(provenanceConsistencyError({ distinctReviewers: 2, perAngle: [{ angle: "a", reviewer: "x" }] }), /exceeds distinct recorded reviewer identities/);
   });
 });

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -330,27 +330,32 @@ async function ledgerExistsInAny(checkouts, ledgerPath) {
 }
 /**
  * Read the recorded fan-out `provenance` object from a ledger across the
- * enumerated checkouts. Mirrors ledgerExistsInAny's all-checkout semantics:
- * returns the FIRST NON-NULL provenance found and only null after exhausting
- * every checkout. This prevents a stale/provenance-less ledger for the same head
- * in an earlier-enumerated checkout from SHADOWING a valid provenance-bearing
- * ledger in the PR worktree (which would otherwise falsely fail closed). Only
+ * enumerated checkouts. Mirrors ledgerExistsInAny's "ANY checkout satisfies"
+ * semantics: prefers the FIRST checkout whose ledger provenance actually
+ * SATISFIES enforcement (internally consistent AND distinctReviewers >= floor),
+ * so a below-floor or provenance-less ledger in an earlier-enumerated checkout
+ * cannot SHADOW a valid one in the PR worktree (which would falsely fail closed).
+ * Falls back to the first non-null provenance (for a useful diagnostic message)
+ * only when NO checkout satisfies, and null only when none is present. Only
  * called when requireFanoutProvenance is enabled so the default path pays no I/O.
  */
 async function readLedgerProvenanceInAny(checkouts, ledgerPath) {
+  let firstNonNull = null;
   for (const root of checkouts) {
     const full = path.resolve(root, ledgerPath);
     try {
       const parsed = JSON.parse(await readFile(full, "utf8"));
-      if (parsed && typeof parsed === "object" && parsed.provenance != null) {
-        return parsed.provenance;
+      const prov = parsed && typeof parsed === "object" ? parsed.provenance : null;
+      if (prov == null) continue; // ledger present but no provenance — keep scanning.
+      if (provenanceConsistencyError(prov) === null && prov.distinctReviewers >= FANOUT_PROVENANCE_MIN_REVIEWERS) {
+        return prov; // satisfying ledger — prefer it over any earlier below-floor one.
       }
-      // Ledger present but carries no provenance — keep scanning other checkouts.
+      if (firstNonNull === null) firstNonNull = prov; // remember for diagnostics.
     } catch {
       // Missing/unreadable/malformed ledger in this checkout — try the next.
     }
   }
-  return null;
+  return firstNonNull;
 }
 /**
  * Build the fan-out evidence enforcement descriptor.

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -9,12 +9,13 @@ import {
   summarizeGateReviewCommentMarkers,
   summarizeGateReviewComments,
 } from "../_core-helpers.mjs";
-import { access } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import path from "node:path";
 import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
-import { loadDevLoopConfig, resolveGateConfig, resolveRequireFanoutEvidence } from "@dev-loops/core/config";
+import { FANOUT_PROVENANCE_MIN_REVIEWERS, loadDevLoopConfig, resolveGateConfig, resolveRequireFanoutEvidence, resolveRequireFanoutProvenance } from "@dev-loops/core/config";
+import { FANOUT_UNAVAILABLE_MESSAGE } from "@dev-loops/core/loop/gate-fanin";
 import { buildLogPath } from "./write-gate-findings-log.mjs";
 import { ensureAsyncRunnerOwnership } from "../loop/_pr-runner-coordination.mjs";
 import { detectStaleRunner } from "../loop/_stale-runner-detection.mjs";
@@ -265,6 +266,21 @@ export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null, s
         failures.push(
           `${gate.name}: requireFanoutEvidence is enabled but no findings-log ledger exists for the reviewed head (${gate.ledgerPath})`,
         );
+        continue;
+      }
+      // Opt-in provenance enforcement (gates.requireFanoutProvenance), layered on
+      // top of fan-out evidence. When off (default) requireProvenance is falsy so
+      // NO new failure is added — behavior is byte-identical to today. When on, a
+      // fanout_fanin ledger must record distinctReviewers >= the floor, proving
+      // independent parallel review rather than a single self-producing agent.
+      if (fanoutEnforcement.requireProvenance) {
+        const prov = gate.provenance;
+        const reviewers = prov && typeof prov.distinctReviewers === "number" ? prov.distinctReviewers : null;
+        if (reviewers === null || reviewers < FANOUT_PROVENANCE_MIN_REVIEWERS) {
+          failures.push(
+            `${gate.name}: requireFanoutProvenance is enabled but the findings-log ledger lacks valid fan-out provenance (need provenance.distinctReviewers >= ${FANOUT_PROVENANCE_MIN_REVIEWERS}, got ${reviewers === null ? "none" : reviewers}); ${FANOUT_UNAVAILABLE_MESSAGE}`,
+          );
+        }
       }
     }
   }
@@ -307,6 +323,26 @@ async function ledgerExistsInAny(checkouts, ledgerPath) {
   return false;
 }
 /**
+ * Read the recorded fan-out `provenance` object from the first existing ledger
+ * across the enumerated checkouts. Returns the provenance object, or null when
+ * no ledger is found / it is unreadable / it carries no provenance. Only called
+ * when requireFanoutProvenance is enabled so the default path pays no extra I/O.
+ */
+async function readLedgerProvenanceInAny(checkouts, ledgerPath) {
+  for (const root of checkouts) {
+    const full = path.resolve(root, ledgerPath);
+    try {
+      const parsed = JSON.parse(await readFile(full, "utf8"));
+      if (parsed && typeof parsed === "object") {
+        return parsed.provenance ?? null;
+      }
+    } catch {
+      // Missing/unreadable/malformed ledger in this checkout — try the next.
+    }
+  }
+  return null;
+}
+/**
  * Build the fan-out evidence enforcement descriptor.
  *
  * Enforcement is ON by default (opt-out via gates.requireFanoutEvidence: false).
@@ -322,8 +358,14 @@ export async function buildFanoutEnforcement({ repo, pr, currentHeadSha, draftGa
   // null and undefined; the loader only ever yields null on failure, but the
   // loose check defensively treats an absent config as unavailable.
   if (config == null || !resolveRequireFanoutEvidence(config)) {
+    // Disabled/unavailable return is intentionally byte-identical to before
+    // (no requireProvenance key): buildPreMergeGateCheck only reads it inside
+    // the `required` block, so this preserves the exact existing shape.
     return { required: false, gates: [] };
   }
+  // Provenance enforcement is opt-in and layered ON TOP of fan-out evidence: it
+  // only takes effect while evidence enforcement (above) is active.
+  const requireProvenance = resolveRequireFanoutProvenance(config);
   const draftRequired = resolveGateConfig(config, "draft").required;
   const preApprovalRequired = resolveGateConfig(config, "preApproval").required;
   const gateSpecs = [
@@ -340,9 +382,10 @@ export async function buildFanoutEnforcement({ repo, pr, currentHeadSha, draftGa
       executionMode: spec.marker.executionMode ?? null,
       ledgerPath,
       ledgerExists: await ledgerExistsInAny(checkouts, ledgerPath),
+      provenance: requireProvenance ? await readLedgerProvenanceInAny(checkouts, ledgerPath) : null,
     });
   }
-  return { required: true, gates };
+  return { required: true, requireProvenance, gates };
 }
 export async function detectCheckpointEvidence(options, { env = process.env, ghCommand = "gh", cwd = process.cwd() } = {}) {
   const runnerOwnership = await ensureAsyncRunnerOwnership({

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -15,7 +15,7 @@ import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.m
 import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { FANOUT_PROVENANCE_MIN_REVIEWERS, loadDevLoopConfig, resolveGateConfig, resolveRequireFanoutEvidence, resolveRequireFanoutProvenance } from "@dev-loops/core/config";
-import { FANOUT_UNAVAILABLE_MESSAGE } from "@dev-loops/core/loop/gate-fanin";
+import { FANOUT_UNAVAILABLE_MESSAGE, provenanceConsistencyError } from "@dev-loops/core/loop/gate-fanin";
 import { buildLogPath } from "./write-gate-findings-log.mjs";
 import { ensureAsyncRunnerOwnership } from "../loop/_pr-runner-coordination.mjs";
 import { detectStaleRunner } from "../loop/_stale-runner-detection.mjs";
@@ -271,12 +271,18 @@ export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null, s
       // Opt-in provenance enforcement (gates.requireFanoutProvenance), layered on
       // top of fan-out evidence. When off (default) requireProvenance is falsy so
       // NO new failure is added — behavior is byte-identical to today. When on, a
-      // fanout_fanin ledger must record distinctReviewers >= the floor, proving
-      // independent parallel review rather than a single self-producing agent.
+      // fanout_fanin ledger must record INTERNALLY-CONSISTENT provenance (checked
+      // the same way the write path validates it — a hand-edited or shadow ledger
+      // is re-validated here, not trusted) with distinctReviewers >= the floor.
       if (fanoutEnforcement.requireProvenance) {
         const prov = gate.provenance;
-        const reviewers = prov && typeof prov.distinctReviewers === "number" ? prov.distinctReviewers : null;
-        if (reviewers === null || reviewers < FANOUT_PROVENANCE_MIN_REVIEWERS) {
+        const consistencyErr = provenanceConsistencyError(prov);
+        const reviewers = prov && Number.isInteger(prov.distinctReviewers) ? prov.distinctReviewers : null;
+        if (consistencyErr) {
+          failures.push(
+            `${gate.name}: requireFanoutProvenance is enabled but the findings-log ledger lacks valid fan-out provenance (${consistencyErr}); ${FANOUT_UNAVAILABLE_MESSAGE}`,
+          );
+        } else if (reviewers === null || reviewers < FANOUT_PROVENANCE_MIN_REVIEWERS) {
           failures.push(
             `${gate.name}: requireFanoutProvenance is enabled but the findings-log ledger lacks valid fan-out provenance (need provenance.distinctReviewers >= ${FANOUT_PROVENANCE_MIN_REVIEWERS}, got ${reviewers === null ? "none" : reviewers}); ${FANOUT_UNAVAILABLE_MESSAGE}`,
           );
@@ -323,19 +329,23 @@ async function ledgerExistsInAny(checkouts, ledgerPath) {
   return false;
 }
 /**
- * Read the recorded fan-out `provenance` object from the first existing ledger
- * across the enumerated checkouts. Returns the provenance object, or null when
- * no ledger is found / it is unreadable / it carries no provenance. Only called
- * when requireFanoutProvenance is enabled so the default path pays no extra I/O.
+ * Read the recorded fan-out `provenance` object from a ledger across the
+ * enumerated checkouts. Mirrors ledgerExistsInAny's all-checkout semantics:
+ * returns the FIRST NON-NULL provenance found and only null after exhausting
+ * every checkout. This prevents a stale/provenance-less ledger for the same head
+ * in an earlier-enumerated checkout from SHADOWING a valid provenance-bearing
+ * ledger in the PR worktree (which would otherwise falsely fail closed). Only
+ * called when requireFanoutProvenance is enabled so the default path pays no I/O.
  */
 async function readLedgerProvenanceInAny(checkouts, ledgerPath) {
   for (const root of checkouts) {
     const full = path.resolve(root, ledgerPath);
     try {
       const parsed = JSON.parse(await readFile(full, "utf8"));
-      if (parsed && typeof parsed === "object") {
-        return parsed.provenance ?? null;
+      if (parsed && typeof parsed === "object" && parsed.provenance != null) {
+        return parsed.provenance;
       }
+      // Ledger present but carries no provenance — keep scanning other checkouts.
     } catch {
       // Missing/unreadable/malformed ledger in this checkout — try the next.
     }

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -17,6 +17,7 @@ Required:
   --findings <json>              JSON array of finding objects with severity, disposition, angle, and summary
 Optional:
   --provenance <json>            Fan-out provenance object: { distinctReviewers: <int>, perAngle: [{ angle, reviewer?, dispatchId?, model? }] }
+                                 distinctReviewers must be <= the distinct reviewers recorded in perAngle (perAngle non-empty when distinctReviewers > 0)
   --tmp-root <path>              Root tmp directory (default: tmp/)
 
 ${JQ_OUTPUT_USAGE}

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -5,6 +5,7 @@ import { parseArgs } from "node:util";
 import { parsePrNumber, requireTokenValue } from "../_cli-primitives.mjs";
 import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+import { provenanceConsistencyError } from "@dev-loops/core/loop/gate-fanin";
 const USAGE = `Usage: write-gate-findings-log.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate> --head-sha <sha> --verdict <clean|findings_present|blocked> --findings <json> [--tmp-root <path>]
 Write a durable <gate>-<headSha>.json log under deterministic tmp/ paths.
 Required:
@@ -96,8 +97,12 @@ function parseFindingsJson(raw) {
 /**
  * Validate + normalize the fan-out provenance object. Records how many distinct
  * reviewer agents were dispatched (distinctReviewers) and per-angle dispatch
- * provenance (perAngle). Throws on malformed shape so a caller cannot forge a
- * satisfying-but-empty provenance blob. Returns the normalized object.
+ * provenance (perAngle). Rejects MALFORMED or self-INCONSISTENT provenance (bad
+ * shape, or a distinctReviewers claim not backed by recorded dispatch entries).
+ * This raises the bar; it does NOT make provenance un-forgeable — a determined
+ * single agent can still write an internally-consistent blob. Un-forgeable
+ * recording is the Pi-harness bridge (subagent tool at child depth). Returns the
+ * normalized object.
  */
 export function parseProvenanceJson(raw) {
   let parsed;
@@ -133,7 +138,14 @@ export function parseProvenanceJson(raw) {
     }
     return entry;
   });
-  return { distinctReviewers: parsed.distinctReviewers, perAngle };
+  const normalized = { distinctReviewers: parsed.distinctReviewers, perAngle };
+  // Internal-consistency gate: a distinctReviewers claim must be backed by that
+  // many distinct recorded reviewer identities (closes the {n, perAngle:[]} loophole).
+  const consistencyError = provenanceConsistencyError(normalized);
+  if (consistencyError) {
+    throw parseError(`--${consistencyError}`);
+  }
+  return normalized;
 }
 export function parseWriteGateFindingsLogCliArgs(argv) {
   const { tokens } = parseArgs({

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -15,6 +15,7 @@ Required:
   --verdict <clean|findings_present|blocked>
   --findings <json>              JSON array of finding objects with severity, disposition, angle, and summary
 Optional:
+  --provenance <json>            Fan-out provenance object: { distinctReviewers: <int>, perAngle: [{ angle, reviewer?, dispatchId?, model? }] }
   --tmp-root <path>              Root tmp directory (default: tmp/)
 
 ${JQ_OUTPUT_USAGE}
@@ -92,6 +93,48 @@ function parseFindingsJson(raw) {
     return entry;
   });
 }
+/**
+ * Validate + normalize the fan-out provenance object. Records how many distinct
+ * reviewer agents were dispatched (distinctReviewers) and per-angle dispatch
+ * provenance (perAngle). Throws on malformed shape so a caller cannot forge a
+ * satisfying-but-empty provenance blob. Returns the normalized object.
+ */
+export function parseProvenanceJson(raw) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw parseError("--provenance must be valid JSON");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw parseError("--provenance must be a JSON object");
+  }
+  if (!Number.isInteger(parsed.distinctReviewers) || parsed.distinctReviewers < 0) {
+    throw parseError("--provenance.distinctReviewers must be a non-negative integer");
+  }
+  if (!Array.isArray(parsed.perAngle)) {
+    throw parseError("--provenance.perAngle must be an array");
+  }
+  const perAngle = parsed.perAngle.map((a, i) => {
+    if (!a || typeof a !== "object" || Array.isArray(a)) {
+      throw parseError(`--provenance.perAngle[${i}] must be an object`);
+    }
+    if (typeof a.angle !== "string" || a.angle.trim().length === 0) {
+      throw parseError(`--provenance.perAngle[${i}].angle is required`);
+    }
+    const entry = { angle: a.angle.trim() };
+    for (const key of ["reviewer", "dispatchId", "model"]) {
+      if (key in a) {
+        if (typeof a[key] !== "string" || a[key].trim().length === 0) {
+          throw parseError(`--provenance.perAngle[${i}].${key} must be a non-empty string`);
+        }
+        entry[key] = a[key].trim();
+      }
+    }
+    return entry;
+  });
+  return { distinctReviewers: parsed.distinctReviewers, perAngle };
+}
 export function parseWriteGateFindingsLogCliArgs(argv) {
   const { tokens } = parseArgs({
     args: [...argv],
@@ -103,6 +146,7 @@ export function parseWriteGateFindingsLogCliArgs(argv) {
       "head-sha": { type: "string" },
       verdict: { type: "string" },
       findings: { type: "string" },
+      provenance: { type: "string" },
       "tmp-root": { type: "string" },
       ...JQ_OUTPUT_PARSE_OPTIONS,
     },
@@ -159,6 +203,10 @@ export function parseWriteGateFindingsLogCliArgs(argv) {
       options.findings = requireTokenValue(token, parseError);
       continue;
     }
+    if (token.name === "provenance") {
+      options.provenance = requireTokenValue(token, parseError);
+      continue;
+    }
     if (token.name === "tmp-root") {
       options.tmpRoot = requireTokenValue(token, parseError).trim();
       continue;
@@ -188,6 +236,7 @@ export function buildLogPath({ repo, pr, gate, headSha, tmpRoot }) {
 }
 export async function writeGateFindingsLog(options, { repoRoot = process.cwd() } = {}) {
   const findings = parseFindingsJson(options.findings);
+  const provenance = options.provenance === undefined ? undefined : parseProvenanceJson(options.provenance);
   const logPath = buildLogPath({
     repo: options.repo,
     pr: options.pr,
@@ -205,6 +254,13 @@ export async function writeGateFindingsLog(options, { repoRoot = process.cwd() }
     loggedAt: new Date().toISOString(),
     findings,
   };
+  // Provenance is optional and additive: when absent the ledger writes exactly
+  // as before (no provenance key), preserving byte-identical output for the
+  // default / Claude-Code path. When present it records fan-out provenance for
+  // gates.requireFanoutProvenance enforcement.
+  if (provenance !== undefined) {
+    log.provenance = provenance;
+  }
   await mkdir(path.dirname(fullPath), { recursive: true });
   await writeFile(fullPath, JSON.stringify(log, null, 2) + "\n", "utf8");
   return { ok: true, path: logPath, log };

--- a/test/github/detect-checkpoint-evidence-cross-worktree.test.mjs
+++ b/test/github/detect-checkpoint-evidence-cross-worktree.test.mjs
@@ -189,3 +189,38 @@ test("shadow-bug: a provenance-less ledger in an earlier checkout does NOT shado
     await rm(base, { recursive: true, force: true });
   }
 });
+
+test("residual shadow: a below-floor ledger in cwd checkout does NOT shadow a satisfying one elsewhere", async () => {
+  const { base, repoA, repoB } = await makeRepoWithWorktrees();
+  try {
+    // repoB (== cwd, enumerated FIRST) carries a consistent but BELOW-FLOOR ledger
+    // (distinctReviewers:1 — the write path allows it; it only checks consistency).
+    await writeGateFindingsLog(
+      {
+        repo: "owner/repo", pr: "42", gate: "pre_approval_gate", headSha: HEAD, verdict: "clean", findings: "[]",
+        provenance: JSON.stringify({ distinctReviewers: 1, perAngle: [{ angle: "scope", reviewer: "review-a" }] }),
+      },
+      { repoRoot: repoB },
+    );
+    // repoA (enumerated later) carries the SATISFYING >=2 ledger.
+    await writeGateFindingsLog(
+      {
+        repo: "owner/repo", pr: "42", gate: "pre_approval_gate", headSha: HEAD, verdict: "clean", findings: "[]",
+        provenance: JSON.stringify({ distinctReviewers: 2, perAngle: [{ angle: "scope", reviewer: "review-a" }, { angle: "safety", reviewer: "review-b" }] }),
+      },
+      { repoRoot: repoA },
+    );
+    const enforcement = await buildFanoutEnforcement({
+      repo: "owner/repo", pr: "42", currentHeadSha: HEAD,
+      draftGateMarker: NO_DRAFT_MARKER, preApprovalGateMarker: PA_MARKER,
+      config: PROV_CONFIG, cwd: repoB,
+    });
+    const pa = enforcement.gates.find((g) => g.name === "pre_approval_gate");
+    assert.ok(pa && pa.provenance, "must read the satisfying provenance, not the below-floor shadow");
+    assert.equal(pa.provenance.distinctReviewers, 2, "satisfying ledger preferred over below-floor");
+    const check = buildPreMergeGateCheck(cleanEvidenceFor(HEAD), 0, null, enforcement);
+    assert.equal(check.ok, true, JSON.stringify(check.failures));
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});

--- a/test/github/detect-checkpoint-evidence-cross-worktree.test.mjs
+++ b/test/github/detect-checkpoint-evidence-cross-worktree.test.mjs
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { buildFanoutEnforcement } from "../../scripts/github/detect-checkpoint-evidence.mjs";
+import { buildFanoutEnforcement, buildPreMergeGateCheck } from "../../scripts/github/detect-checkpoint-evidence.mjs";
 import { writeGateFindingsLog } from "../../scripts/github/write-gate-findings-log.mjs";
 
 function git(cwd, args) {
@@ -82,6 +82,109 @@ test("negative: ledger absent in all checkouts reports ledgerExists false", asyn
     for (const gate of result.gates) {
       assert.equal(gate.ledgerExists, false, `${gate.name} ledger must be absent`);
     }
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+// --- Round-trip + shadow-bug coverage (requireFanoutProvenance) ---
+// Config mirroring the enforced posture PLUS opt-in provenance enforcement.
+const PROV_CONFIG = {
+  gates: {
+    requireFanoutEvidence: true,
+    requireFanoutProvenance: true,
+    draft: { required: true },
+    preApproval: { required: true },
+  },
+};
+// Only the pre_approval gate is fanned out here (draft marker not visible) so a
+// single ledger drives the round trip.
+const PA_MARKER = { visible: true, headSha: HEAD, executionMode: "fanout_fanin" };
+const NO_DRAFT_MARKER = { visible: false };
+function cleanEvidenceFor(headSha) {
+  return {
+    currentHeadSha: headSha,
+    draftGate: { visible: true, verdict: "clean" },
+    preApprovalGateMarker: { visible: true, contractComplete: true, verdict: "clean", headSha },
+  };
+}
+
+test("round-trip: write valid provenance -> buildFanoutEnforcement reads it -> pre-merge check PASSES", async () => {
+  const { base, repoA, repoB } = await makeRepoWithWorktrees();
+  try {
+    await writeGateFindingsLog(
+      {
+        repo: "owner/repo", pr: "42", gate: "pre_approval_gate", headSha: HEAD, verdict: "clean", findings: "[]",
+        provenance: JSON.stringify({ distinctReviewers: 2, perAngle: [{ angle: "scope", reviewer: "review-a" }, { angle: "safety", reviewer: "review-b" }] }),
+      },
+      { repoRoot: repoA },
+    );
+    const enforcement = await buildFanoutEnforcement({
+      repo: "owner/repo", pr: "42", currentHeadSha: HEAD,
+      draftGateMarker: NO_DRAFT_MARKER, preApprovalGateMarker: PA_MARKER,
+      config: PROV_CONFIG, cwd: repoB,
+    });
+    assert.equal(enforcement.requireProvenance, true);
+    const pa = enforcement.gates.find((g) => g.name === "pre_approval_gate");
+    assert.ok(pa && pa.provenance, "provenance must be read from the ledger");
+    assert.equal(pa.provenance.distinctReviewers, 2);
+
+    const check = buildPreMergeGateCheck(cleanEvidenceFor(HEAD), 0, null, enforcement);
+    assert.equal(check.ok, true, JSON.stringify(check.failures));
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("round-trip: a below-floor (distinctReviewers:1) ledger FAILS closed", async () => {
+  const { base, repoA, repoB } = await makeRepoWithWorktrees();
+  try {
+    await writeGateFindingsLog(
+      {
+        repo: "owner/repo", pr: "42", gate: "pre_approval_gate", headSha: HEAD, verdict: "clean", findings: "[]",
+        provenance: JSON.stringify({ distinctReviewers: 1, perAngle: [{ angle: "scope", reviewer: "review-a" }] }),
+      },
+      { repoRoot: repoA },
+    );
+    const enforcement = await buildFanoutEnforcement({
+      repo: "owner/repo", pr: "42", currentHeadSha: HEAD,
+      draftGateMarker: NO_DRAFT_MARKER, preApprovalGateMarker: PA_MARKER,
+      config: PROV_CONFIG, cwd: repoB,
+    });
+    const check = buildPreMergeGateCheck(cleanEvidenceFor(HEAD), 0, null, enforcement);
+    assert.equal(check.ok, false);
+    assert.ok(check.failures.some((f) => f.includes("got 1") && f.includes("route to conductor")), JSON.stringify(check.failures));
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("shadow-bug: a provenance-less ledger in an earlier checkout does NOT shadow a valid one in another", async () => {
+  const { base, repoA, repoB } = await makeRepoWithWorktrees();
+  try {
+    // repoB (== cwd, enumerated FIRST) carries a provenance-LESS ledger for the head.
+    await writeGateFindingsLog(
+      { repo: "owner/repo", pr: "42", gate: "pre_approval_gate", headSha: HEAD, verdict: "clean", findings: "[]" },
+      { repoRoot: repoB },
+    );
+    // repoA (enumerated later) carries the valid provenance-bearing ledger.
+    await writeGateFindingsLog(
+      {
+        repo: "owner/repo", pr: "42", gate: "pre_approval_gate", headSha: HEAD, verdict: "clean", findings: "[]",
+        provenance: JSON.stringify({ distinctReviewers: 2, perAngle: [{ angle: "scope", reviewer: "review-a" }, { angle: "safety", reviewer: "review-b" }] }),
+      },
+      { repoRoot: repoA },
+    );
+    const enforcement = await buildFanoutEnforcement({
+      repo: "owner/repo", pr: "42", currentHeadSha: HEAD,
+      draftGateMarker: NO_DRAFT_MARKER, preApprovalGateMarker: PA_MARKER,
+      config: PROV_CONFIG, cwd: repoB,
+    });
+    const pa = enforcement.gates.find((g) => g.name === "pre_approval_gate");
+    assert.ok(pa && pa.provenance, "must read the valid provenance, not the shadowing null");
+    assert.equal(pa.provenance.distinctReviewers, 2);
+    const check = buildPreMergeGateCheck(cleanEvidenceFor(HEAD), 0, null, enforcement);
+    assert.equal(check.ok, true, JSON.stringify(check.failures));
   } finally {
     await rm(base, { recursive: true, force: true });
   }

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -896,6 +896,73 @@ test("buildPreMergeGateCheck passes when requireFanoutEvidence and executionMode
   assert.deepEqual(result.failures, []);
 });
 
+// --- Fan-out provenance enforcement (AC2, gates.requireFanoutProvenance) ---
+
+test("buildPreMergeGateCheck with requireProvenance ON passes when ledger records distinctReviewers >= floor", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    requireProvenance: true,
+    gates: [
+      { name: "pre_approval_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/b.json", ledgerExists: true, provenance: { distinctReviewers: 2, perAngle: [] } },
+    ],
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.failures, []);
+});
+
+test("buildPreMergeGateCheck with requireProvenance ON fails closed when provenance is absent", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    requireProvenance: true,
+    gates: [
+      { name: "pre_approval_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/b.json", ledgerExists: true, provenance: null },
+    ],
+  });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.failures.some((f) => f.includes("requireFanoutProvenance") && f.includes("route to conductor")),
+    JSON.stringify(result.failures),
+  );
+});
+
+test("buildPreMergeGateCheck with requireProvenance ON fails closed when distinctReviewers < floor", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    requireProvenance: true,
+    gates: [
+      { name: "pre_approval_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/b.json", ledgerExists: true, provenance: { distinctReviewers: 1, perAngle: [] } },
+    ],
+  });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.failures.some((f) => f.includes("requireFanoutProvenance") && f.includes("got 1")),
+    JSON.stringify(result.failures),
+  );
+});
+
+test("buildPreMergeGateCheck with requireProvenance OFF (default) adds NO new failure even when provenance is absent (Claude-Code non-regression)", () => {
+  // requireProvenance falsy => today's behavior exactly: fanout_fanin + ledger present passes.
+  const off = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    gates: [
+      { name: "pre_approval_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/b.json", ledgerExists: true, provenance: null },
+    ],
+  });
+  assert.equal(off.ok, true);
+  assert.deepEqual(off.failures, []);
+
+  // Explicit requireProvenance: false is identical.
+  const explicitOff = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    requireProvenance: false,
+    gates: [
+      { name: "pre_approval_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/b.json", ledgerExists: true },
+    ],
+  });
+  assert.equal(explicitOff.ok, true);
+  assert.deepEqual(explicitOff.failures, []);
+});
+
 test("detect-checkpoint-evidence fails pre-merge with unresolved human review threads", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-gate-human-unresolved-"));
 

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -903,7 +903,7 @@ test("buildPreMergeGateCheck with requireProvenance ON passes when ledger record
     required: true,
     requireProvenance: true,
     gates: [
-      { name: "pre_approval_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/b.json", ledgerExists: true, provenance: { distinctReviewers: 2, perAngle: [] } },
+      { name: "pre_approval_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/b.json", ledgerExists: true, provenance: { distinctReviewers: 2, perAngle: [{ angle: "scope", reviewer: "review-a" }, { angle: "safety", reviewer: "review-b" }] } },
     ],
   });
   assert.equal(result.ok, true);
@@ -930,7 +930,7 @@ test("buildPreMergeGateCheck with requireProvenance ON fails closed when distinc
     required: true,
     requireProvenance: true,
     gates: [
-      { name: "pre_approval_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/b.json", ledgerExists: true, provenance: { distinctReviewers: 1, perAngle: [] } },
+      { name: "pre_approval_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/b.json", ledgerExists: true, provenance: { distinctReviewers: 1, perAngle: [{ angle: "scope", reviewer: "review-a" }] } },
     ],
   });
   assert.equal(result.ok, false);
@@ -961,6 +961,51 @@ test("buildPreMergeGateCheck with requireProvenance OFF (default) adds NO new fa
   });
   assert.equal(explicitOff.ok, true);
   assert.deepEqual(explicitOff.failures, []);
+});
+
+test("buildPreMergeGateCheck with requireProvenance ON fails closed on the {n, perAngle:[]} loophole (internal inconsistency)", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    requireProvenance: true,
+    gates: [
+      { name: "pre_approval_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/b.json", ledgerExists: true, provenance: { distinctReviewers: 2, perAngle: [] } },
+    ],
+  });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.failures.some((f) => f.includes("perAngle must be non-empty") && f.includes("route to conductor")),
+    JSON.stringify(result.failures),
+  );
+});
+
+test("buildPreMergeGateCheck with requireProvenance ON fails closed when distinctReviewers exceeds recorded identities", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    requireProvenance: true,
+    gates: [
+      { name: "pre_approval_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/b.json", ledgerExists: true, provenance: { distinctReviewers: 3, perAngle: [{ angle: "scope", reviewer: "review-a" }] } },
+    ],
+  });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.failures.some((f) => f.includes("exceeds distinct recorded reviewer identities")),
+    JSON.stringify(result.failures),
+  );
+});
+
+test("buildPreMergeGateCheck with requireProvenance ON fails closed on a non-integer distinctReviewers (hand-edited ledger)", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    requireProvenance: true,
+    gates: [
+      { name: "pre_approval_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/b.json", ledgerExists: true, provenance: { distinctReviewers: 2.5, perAngle: [{ angle: "scope", reviewer: "review-a" }, { angle: "safety", reviewer: "review-b" }] } },
+    ],
+  });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.failures.some((f) => f.includes("distinctReviewers must be a non-negative integer")),
+    JSON.stringify(result.failures),
+  );
 });
 
 test("detect-checkpoint-evidence fails pre-merge with unresolved human review threads", async () => {

--- a/test/github/write-gate-findings-log.test.mjs
+++ b/test/github/write-gate-findings-log.test.mjs
@@ -389,13 +389,13 @@ test("writeGateFindingsLog rejects empty-string resolvedIn", async () => {
 
 test("parseProvenanceJson accepts a well-formed provenance object", () => {
   const prov = parseProvenanceJson(JSON.stringify({
-    distinctReviewers: 3,
+    distinctReviewers: 2,
     perAngle: [
       { angle: "scope", reviewer: "review-a", dispatchId: "d1", model: "m1" },
       { angle: "safety", reviewer: "review-b" },
     ],
   }));
-  assert.equal(prov.distinctReviewers, 3);
+  assert.equal(prov.distinctReviewers, 2);
   assert.equal(prov.perAngle.length, 2);
   assert.deepEqual(prov.perAngle[0], { angle: "scope", reviewer: "review-a", dispatchId: "d1", model: "m1" });
   assert.deepEqual(prov.perAngle[1], { angle: "safety", reviewer: "review-b" });
@@ -409,6 +409,31 @@ test("parseProvenanceJson rejects malformed provenance (invalid JSON, non-object
   assert.throws(() => parseProvenanceJson(JSON.stringify({ distinctReviewers: 2 })), /perAngle must be an array/);
   assert.throws(() => parseProvenanceJson(JSON.stringify({ distinctReviewers: 2, perAngle: [{}] })), /perAngle\[0\]\.angle is required/);
   assert.throws(() => parseProvenanceJson(JSON.stringify({ distinctReviewers: 2, perAngle: [{ angle: "scope", reviewer: "" }] })), /reviewer must be a non-empty string/);
+  assert.throws(() => parseProvenanceJson(JSON.stringify({ distinctReviewers: 2, perAngle: [null] })), /perAngle\[0\] must be an object/);
+});
+
+test("parseProvenanceJson rejects INTERNALLY-INCONSISTENT provenance (closes the {n, perAngle:[]} loophole)", () => {
+  // The crux loophole: claim N reviewers with zero dispatch records.
+  assert.throws(
+    () => parseProvenanceJson(JSON.stringify({ distinctReviewers: 2, perAngle: [] })),
+    /perAngle must be non-empty when distinctReviewers > 0/,
+  );
+  // Claim more reviewers than distinct recorded identities.
+  assert.throws(
+    () => parseProvenanceJson(JSON.stringify({ distinctReviewers: 2, perAngle: [{ angle: "scope", reviewer: "review-a" }] })),
+    /distinctReviewers \(2\) exceeds distinct recorded reviewer identities \(1\)/,
+  );
+  // A perAngle entry with no reviewer/dispatchId is not a countable reviewer.
+  assert.throws(
+    () => parseProvenanceJson(JSON.stringify({ distinctReviewers: 1, perAngle: [{ angle: "scope" }] })),
+    /distinctReviewers \(1\) exceeds distinct recorded reviewer identities \(0\)/,
+  );
+  // dispatchId also counts as an identity; two distinct dispatchIds satisfy 2.
+  const ok = parseProvenanceJson(JSON.stringify({
+    distinctReviewers: 2,
+    perAngle: [{ angle: "scope", dispatchId: "d1" }, { angle: "safety", dispatchId: "d2" }],
+  }));
+  assert.equal(ok.distinctReviewers, 2);
 });
 
 test("writeGateFindingsLog records provenance in the ledger when passed", async () => {
@@ -421,13 +446,13 @@ test("writeGateFindingsLog records provenance in the ledger when passed", async 
       headSha: "abc1234567890abcdef",
       verdict: "clean",
       findings: "[]",
-      provenance: JSON.stringify({ distinctReviewers: 3, perAngle: [{ angle: "scope", reviewer: "review-a" }] }),
+      provenance: JSON.stringify({ distinctReviewers: 3, perAngle: [{ angle: "scope", reviewer: "review-a" }, { angle: "safety", reviewer: "review-b" }, { angle: "perf", reviewer: "review-c" }] }),
       tmpRoot: tmpDir,
     });
     const fullPath = path.join(tmpDir, "gate-findings", "owner-repo", "pr-7", "pre_approval_gate-abc1234567890abcdef.json");
     const parsed = JSON.parse(await readFile(fullPath, "utf8"));
     assert.equal(parsed.provenance.distinctReviewers, 3);
-    assert.deepEqual(parsed.provenance.perAngle, [{ angle: "scope", reviewer: "review-a" }]);
+    assert.equal(parsed.provenance.perAngle.length, 3);
   } finally {
     await rm(tmpDir, { recursive: true, force: true });
   }

--- a/test/github/write-gate-findings-log.test.mjs
+++ b/test/github/write-gate-findings-log.test.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 
 import {
+  parseProvenanceJson,
   parseWriteGateFindingsLogCliArgs,
   writeGateFindingsLog,
 } from "../../scripts/github/write-gate-findings-log.mjs";
@@ -382,4 +383,86 @@ test("writeGateFindingsLog rejects empty-string resolvedIn", async () => {
       findings: JSON.stringify([{ severity: "must-fix", angle: "scope", summary: "x", resolvedIn: "" }]),
     });
   }, /resolvedIn must be a non-empty string/);
+});
+
+// --- Fan-out provenance (AC1) ---
+
+test("parseProvenanceJson accepts a well-formed provenance object", () => {
+  const prov = parseProvenanceJson(JSON.stringify({
+    distinctReviewers: 3,
+    perAngle: [
+      { angle: "scope", reviewer: "review-a", dispatchId: "d1", model: "m1" },
+      { angle: "safety", reviewer: "review-b" },
+    ],
+  }));
+  assert.equal(prov.distinctReviewers, 3);
+  assert.equal(prov.perAngle.length, 2);
+  assert.deepEqual(prov.perAngle[0], { angle: "scope", reviewer: "review-a", dispatchId: "d1", model: "m1" });
+  assert.deepEqual(prov.perAngle[1], { angle: "safety", reviewer: "review-b" });
+});
+
+test("parseProvenanceJson rejects malformed provenance (invalid JSON, non-object, bad shape)", () => {
+  assert.throws(() => parseProvenanceJson("{not json"), /must be valid JSON/);
+  assert.throws(() => parseProvenanceJson("[]"), /must be a JSON object/);
+  assert.throws(() => parseProvenanceJson(JSON.stringify({ perAngle: [] })), /distinctReviewers must be a non-negative integer/);
+  assert.throws(() => parseProvenanceJson(JSON.stringify({ distinctReviewers: 1.5, perAngle: [] })), /distinctReviewers must be a non-negative integer/);
+  assert.throws(() => parseProvenanceJson(JSON.stringify({ distinctReviewers: 2 })), /perAngle must be an array/);
+  assert.throws(() => parseProvenanceJson(JSON.stringify({ distinctReviewers: 2, perAngle: [{}] })), /perAngle\[0\]\.angle is required/);
+  assert.throws(() => parseProvenanceJson(JSON.stringify({ distinctReviewers: 2, perAngle: [{ angle: "scope", reviewer: "" }] })), /reviewer must be a non-empty string/);
+});
+
+test("writeGateFindingsLog records provenance in the ledger when passed", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-test-"));
+  try {
+    await writeGateFindingsLog({
+      repo: "owner/repo",
+      pr: 7,
+      gate: "pre_approval_gate",
+      headSha: "abc1234567890abcdef",
+      verdict: "clean",
+      findings: "[]",
+      provenance: JSON.stringify({ distinctReviewers: 3, perAngle: [{ angle: "scope", reviewer: "review-a" }] }),
+      tmpRoot: tmpDir,
+    });
+    const fullPath = path.join(tmpDir, "gate-findings", "owner-repo", "pr-7", "pre_approval_gate-abc1234567890abcdef.json");
+    const parsed = JSON.parse(await readFile(fullPath, "utf8"));
+    assert.equal(parsed.provenance.distinctReviewers, 3);
+    assert.deepEqual(parsed.provenance.perAngle, [{ angle: "scope", reviewer: "review-a" }]);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("writeGateFindingsLog omits provenance key entirely when absent (byte-identical to before)", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-test-"));
+  try {
+    await writeGateFindingsLog({
+      repo: "owner/repo",
+      pr: 8,
+      gate: "draft_gate",
+      headSha: "abc1234567890abcdef",
+      verdict: "clean",
+      findings: "[]",
+      tmpRoot: tmpDir,
+    });
+    const fullPath = path.join(tmpDir, "gate-findings", "owner-repo", "pr-8", "draft_gate-abc1234567890abcdef.json");
+    const parsed = JSON.parse(await readFile(fullPath, "utf8"));
+    assert.equal("provenance" in parsed, false);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("writeGateFindingsLog rejects malformed provenance", async () => {
+  await assert.rejects(async () => {
+    await writeGateFindingsLog({
+      repo: "a/b",
+      pr: 1,
+      gate: "draft_gate",
+      headSha: "abc12345",
+      verdict: "clean",
+      findings: "[]",
+      provenance: JSON.stringify({ distinctReviewers: -1, perAngle: [] }),
+    });
+  }, /distinctReviewers must be a non-negative integer/);
 });


### PR DESCRIPTION
Closes #1110. (Seam 2 — dev-loops side of #1084.)

## Summary
`requireFanoutEvidence` is artifact-based and therefore circumventable: a single agent can self-produce all per-angle reviews + a findings-log ledger and label the verdict `fanout_fanin`. **No provenance was recorded anywhere.** This lands the in-repo dev-loops side: fan-out provenance recording, opt-in provenance enforcement, and a fail-closed route-to-conductor contract. The full end-to-end driving command depends on the Pi-harness child (subagent tool at child depth) and is deferred as the bridge.

## Scope and context
Additive + opt-in. **Hard non-regression:** Claude Code already honors real child fan-out (Task at depth), so the enforcement must be a validated no-op there — it's gated behind a new default-off knob, and provenance recording writes nothing when absent.

## File-by-file changes
- `scripts/github/write-gate-findings-log.mjs` — new optional `--provenance <json>` recording `{ distinctReviewers, perAngle:[{angle, reviewer?, dispatchId?, model?}] }`, validated on write and persisted into the ledger. Absent → no `provenance` key (byte-identical to today).
- `packages/core/src/config/config.mjs` — `gates.requireFanoutProvenance` (**default false**, opt-in) + `resolveRequireFanoutProvenance` + `FANOUT_PROVENANCE_MIN_REVIEWERS = 2` (the smallest count proving the review wasn't a single self-producing agent).
- `scripts/github/detect-checkpoint-evidence.mjs` — when `requireFanoutProvenance` is ON, `buildPreMergeGateCheck` also fails closed for any `fanout_fanin` gate whose ledger lacks `provenance.distinctReviewers >= 2` (ledger provenance is only read when the flag is on — default path pays no extra I/O). When OFF (default) behavior is **byte-identical** to today.
- `packages/core/src/loop/gate-fanin.mjs` — `FANOUT_UNAVAILABLE_MESSAGE = "fan-out unavailable — route to conductor"` + `fanoutUnavailableError({routeToConductor, code})`.
- `docs/gate-review-sub-loop-contract.md` — new "Fan-out provenance" + "Fail-closed: fan-out unavailable → route to conductor" sections.
- `packages/core/src/loop/gate-fanin.mjs` — also adds the shared `provenanceConsistencyError` + `countDistinctReviewers` (reused by both write and read paths).
- Tests (config, gate-fanin, write-gate-findings-log, detect-checkpoint-evidence, + a real-git cross-worktree round-trip test): provenance record/validate/absent + consistency; enforcement ON fails-closed-without/inconsistent, passes-with; write→read→enforce round trip + the cross-worktree shadow case; **OFF adds no failure (Claude-Code non-regression)**; config default + resolver; the route-to-conductor helper.

## Acceptance criteria
- [x] AC1: fan-out provenance (distinct reviewer count + per-angle dispatch provenance) recorded in the gate findings-log ledger.
- [x] AC2: `buildPreMergeGateCheck` distinguishes real parallel fan-out from single-agent self-produced artifacts using the recorded provenance (opt-in `requireFanoutProvenance`, floor of 2 distinct reviewers **plus an internal-consistency check** — `perAngle` must record ≥ `distinctReviewers` distinct reviewer/dispatch identities, enforced on both write and read paths, so `{distinctReviewers:2, perAngle:[]}` is rejected). Honest caveat: this raises the bar (internal consistency) but recorded provenance is self-reported and still forgeable — un-forgeable recording is the Pi-harness bridge.
- [ ] AC3 (partial — deferred to the Pi-harness bridge): the fail-closed route-to-conductor signal lands; the FULL end-to-end driving command (dispatch per-angle subagents at child depth) depends on the Pi-harness child and is the bridge — deferred (see Dependency in #1110).
- [x] AC4: a child that cannot fan out fails closed with a documented "fan-out unavailable — route to conductor" message/contract.

## Definition of done
- [x] `npm run verify` green (0 failures).
- [x] Non-regression: enforcement is a no-op when the flag is off (default) — proven by test; not enabled in this repo's `.devloops`.

## Non-goals
- Enabling `requireFanoutProvenance` in this repo now (additive rollout — un-forgeable provenance recording lands with the Pi-harness child).
- The Pi-harness core (subagent tool at child depth) — tracked separately.
- Changing existing `requireFanoutEvidence` behavior.

## Validation command
```
npm run verify
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
