### PR TITLE
fix(gates): add --base to write-gate-context CLI to build the diff+adjacentCode bundle (#1140)

### DIFF
--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -111,6 +111,18 @@ gitignored, worktree-local `tmp/gate-context` bundle it writes is present for th
   long tail) recorded in a `stripped`/`truncated`/`missing` manifest for observability.
   This is the build-once, work-deduped seed handed verbatim to every reviewer; no
   reviewer re-derives the diff + adjacent code from scratch.
+  - **`scope.diffSource` posture (CLI `--base`).** `write-gate-context.mjs` records this
+    full bundle only when it has a resolvable diff source. Pass `--base <ref>` and the CLI
+    captures the diff itself (`git diff <ref>...HEAD`, run with color/pager/external-diff
+    config isolated so the persisted bytes are environment-independent) and stamps
+    `scope.diffSource: "base"` — the full build-once bundle (`scope.diffPath` +
+    `scope.changedFiles` + `adjacentCode`). Without `--base`, the CLI does NOT silently
+    emit a full-looking bundle: it warns and stamps `scope.diffSource: "none"` — an
+    explicit **thin briefing** (`scope.diffPath: null`, `scope.changedFiles: []`, no
+    `adjacentCode`) that reviewers detect and fall back from (re-derive via `git diff`). A
+    `--base` that fails to resolve fails closed (non-zero exit, no artifact) rather than
+    degrading to a thin briefing. Programmatic `buildGateContext({ diff })` callers are
+    unaffected and omit `scope.diffSource` entirely.
 - reference the pi-subagents `parallel context-build` technique when applicable:
   run parallel `context-builder` agents from fresh context with distinct output paths
   (e.g. `context-build/request-and-scope.md`, `context-build/codebase-and-patterns.md`,

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -120,9 +120,18 @@ gitignored, worktree-local `tmp/gate-context` bundle it writes is present for th
     emit a full-looking bundle: it warns and stamps `scope.diffSource: "none"` — an
     explicit **thin briefing** (`scope.diffPath: null`, `scope.changedFiles: []`, no
     `adjacentCode`) that reviewers detect and fall back from (re-derive via `git diff`). A
-    `--base` that fails to resolve fails closed (non-zero exit, no artifact) rather than
-    degrading to a thin briefing. Programmatic `buildGateContext({ diff })` callers are
-    unaffected and omit `scope.diffSource` entirely.
+    `--base` that fails to resolve (its `git diff --name-status` fails) fails closed
+    (non-zero exit, no artifact) rather than degrading to a thin briefing. Programmatic
+    `buildGateContext({ diff })` callers are unaffected and omit `scope.diffSource` entirely.
+  - **Partial `"base"` (best-effort full-diff).** `scope.diffSource: "base"` can co-occur
+    with `scope.diffPath: null`: the required `git diff --name-status` succeeded (so
+    `scope.changedFiles` + `adjacentCode` are present — it IS a base-derived bundle) but the
+    best-effort FULL-diff capture degraded (e.g. output exceeded the buffer, a render error),
+    so no persisted `.diff` was written. Reviewers MUST therefore key their diff-fallback on
+    `scope.diffPath` (null → re-derive via `git diff`), NOT on `scope.diffSource`:
+    `diffSource` distinguishes a base-derived bundle (`"base"`) from a thin briefing
+    (`"none"`), while `diffPath` independently signals whether the persisted full diff is
+    available.
 - reference the pi-subagents `parallel context-build` technique when applicable:
   run parallel `context-builder` agents from fresh context with distinct output paths
   (e.g. `context-build/request-and-scope.md`, `context-build/codebase-and-patterns.md`,

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -28,6 +28,7 @@
  * Path scheme mirrors write-gate-findings-log.mjs `buildLogPath`:
  *   <tmpRoot>/gate-context/<repo-slug>/pr-<N>/<gate>-<headSha>.json
  */
+import { execFileSync } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { parseArgs } from "node:util";
@@ -103,7 +104,7 @@ export function rationaleFromResolver(resolverResult) {
   return { resolvedAngles: [...recommended], rationale };
 }
 
-const USAGE = `Usage: write-gate-context.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate> --head-sha <sha> --angles <json> [--rationale <json>] [--branch <name>] [--touched-files <json>] [--acceptance-criteria <pointer>] [--validation-posture <text>] [--tmp-root <path>]
+const USAGE = `Usage: write-gate-context.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate> --head-sha <sha> --angles <json> [--rationale <json>] [--branch <name>] [--touched-files <json>] [--base <ref>] [--acceptance-criteria <pointer>] [--validation-posture <text>] [--tmp-root <path>]
 Write a deterministic gate-review context-builder handoff artifact under tmp/ paths.
 Required:
   --repo <owner/name>
@@ -114,7 +115,8 @@ Required:
 Optional:
   --rationale <json>             JSON array of {angle, action, reason} entries
   --branch <name>                Source branch name
-  --touched-files <json>         JSON array of changed file path strings
+  --touched-files <json>         JSON array of changed file path strings (separate from the diff-derived scope.changedFiles)
+  --base <ref>                   Git ref to diff against (git diff <ref>...HEAD); populates scope.diffPath, scope.changedFiles, and adjacentCode (the full build-once bundle). Without it, the CLI emits an explicit thin briefing (scope.diffSource="none") — see docs/gate-review-sub-loop-contract.md.
   --acceptance-criteria <ptr>    Pointer to acceptance criteria (issue ref, doc path, URL)
   --validation-posture <text>    Short description of the validation posture
   --tmp-root <path>              Root tmp directory (default: tmp/)
@@ -135,6 +137,18 @@ function normalizeGate(value) {
 function normalizeHeadSha(value) {
   const normalized = String(value).trim().toLowerCase();
   return /^[0-9a-f]{7,64}$/i.test(normalized) ? normalized : null;
+}
+
+// ponytail: a conservative allowlist for a "plausible" git ref — rejects a
+// leading "-" (flag injection into the argv-array `git diff` call below,
+// which is already immune since execFileSync never invokes a shell, but a
+// leading dash is also just never a valid ref) and ".." (ambiguous with our
+// own "<base>...HEAD" triple-dot construction). Not a full git ref-name
+// validator; upgrade if a legitimately-shaped ref ever gets rejected.
+function normalizeBaseRef(value) {
+  const trimmed = String(value).trim();
+  if (trimmed.length === 0 || trimmed.startsWith("-") || trimmed.includes("..")) return null;
+  return /^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(trimmed) ? trimmed : null;
 }
 
 const VALID_ACTIONS = new Set(["kept", "added", "dropped", "joined"]);
@@ -210,6 +224,7 @@ export function parseWriteGateContextCliArgs(argv) {
       rationale: { type: "string" },
       branch: { type: "string" },
       "touched-files": { type: "string" },
+      base: { type: "string" },
       "acceptance-criteria": { type: "string" },
       "validation-posture": { type: "string" },
       "tmp-root": { type: "string" },
@@ -228,6 +243,7 @@ export function parseWriteGateContextCliArgs(argv) {
     rationale: [],
     branch: null,
     touchedFiles: [],
+    base: null,
     acceptanceCriteria: null,
     validationPosture: null,
     tmpRoot: "tmp",
@@ -276,6 +292,12 @@ export function parseWriteGateContextCliArgs(argv) {
     }
     if (token.name === "touched-files") {
       options.touchedFiles = parseStringArrayJson(requireTokenValue(token, parseError), "--touched-files");
+      continue;
+    }
+    if (token.name === "base") {
+      const base = normalizeBaseRef(requireTokenValue(token, parseError));
+      if (!base) throw parseError("--base must be a plausible git ref (no leading '-', no '..')");
+      options.base = base;
       continue;
     }
     if (token.name === "acceptance-criteria") {
@@ -460,6 +482,14 @@ export function buildGateContextArtifact(options) {
       validationPosture: options.validationPosture ?? null,
     },
   };
+  // ADD (#1140): an explicit posture marker distinguishing a full build-once
+  // bundle from a thin briefing. Only set by the CLI (`--base` present → "base";
+  // absent → "none"); programmatic `buildGateContext`/`writeGateContext` callers
+  // that never pass `diffSource` leave the field out entirely, so this stays
+  // backward compatible with the artifact shape they already assert on.
+  if (typeof options.diffSource === "string" && options.diffSource.length > 0) {
+    artifact.scope.diffSource = options.diffSource;
+  }
   // ADD (#895): the deterministic, neutral adjacent-code bundle. Only present
   // when the context-builder computed it — keeps the artifact shape backward
   // compatible for callers that build the artifact without an adjacency pass.
@@ -467,6 +497,100 @@ export function buildGateContextArtifact(options) {
     artifact.adjacentCode = options.adjacentCode;
   }
   return artifact;
+}
+
+/**
+ * Resolve the diff-derived scope fields shared by `buildGateContext` (the
+ * programmatic `{ diff }` path) and the CLI `--base` path (#1140): the FULL
+ * diff persisted to a deterministic `.diff` file, the parsed `changedFiles`,
+ * and the neutral `adjacentCode` bundle built once from those changed files.
+ * Extracted to a single function so both callers stay in sync — see the
+ * doc comment on {@link buildGateContext} for the field semantics.
+ *
+ * @param {object} input
+ * @param {{ nameStatusOutput: string, diffOutput?: string }} [input.diff]
+ * @param {string} input.repo
+ * @param {number|string} input.pr
+ * @param {string} input.gate
+ * @param {string} input.headSha
+ * @param {string} input.tmpRoot
+ * @param {number} [input.maxFileBytes]
+ * @param {{ repoRoot: string }} opts
+ * @returns {Promise<{ diffPath: string|null, changedFiles: string[], adjacentCode: object|null }>}
+ */
+async function resolveDiffScope({ diff, repo, pr, gate, headSha, tmpRoot, maxFileBytes }, { repoRoot }) {
+  const diffOutput = diff?.diffOutput;
+  let diffPath = null;
+  const changedFiles = parseChangedFiles(diff?.nameStatusOutput);
+  if (typeof diffOutput === "string" && diffOutput.length > 0) {
+    diffPath = buildGateDiffPath({ repo, pr, gate, headSha, tmpRoot });
+    const fullDiffPath = path.resolve(repoRoot, diffPath);
+    try {
+      await mkdir(path.dirname(fullDiffPath), { recursive: true });
+      await writeFile(fullDiffPath, diffOutput.endsWith("\n") ? diffOutput : diffOutput + "\n", "utf8");
+    } catch (err) {
+      // Best-effort: a diff-file write failure (disk, permissions) must not block
+      // the context artifact. Degrade to diffPath=null; reviewers reconstruct the
+      // diff with `git diff`. changedFiles (from nameStatusOutput) is unaffected.
+      process.stderr.write(`[gate-context] full-diff capture failed (continuing without scope.diffPath): ${err?.message ?? err}\n`);
+      diffPath = null;
+    }
+  }
+
+  // Build the deterministic, neutral adjacent-code bundle ONCE (#895): for each
+  // changed source file, include its 1-hop import out-edges (files it imports)
+  // and in-edges (files that import it), with size guards (skip
+  // lockfiles/generated/binary/minified; cap per-file bytes; truncate the long
+  // tail) recorded in a stripped/truncated manifest. Every independent reviewer
+  // is seeded with this identical bundle instead of re-deriving it — work-dedup.
+  // Best-effort: bundle computation must never block the context artifact.
+  let adjacentCode = null;
+  if (changedFiles.length > 0) {
+    try {
+      adjacentCode = await buildAdjacentBundle({
+        changedFiles,
+        repoRoot,
+        maxFileBytes: typeof maxFileBytes === "number" && maxFileBytes > 0 ? maxFileBytes : DEFAULT_MAX_FILE_BYTES,
+      });
+    } catch (err) {
+      process.stderr.write(`[gate-context] adjacent-code bundle failed (continuing without adjacentCode): ${err?.message ?? err}\n`);
+      adjacentCode = null;
+    }
+  }
+
+  return { diffPath, changedFiles, adjacentCode };
+}
+
+/**
+ * Capture a diff against `base` for the CLI `--base <ref>` flag: `git diff
+ * --name-status <base>...HEAD` and `git diff <base>...HEAD`, shaped as the
+ * `{ nameStatusOutput, diffOutput }` input `resolveDiffScope`/`buildGateContext`
+ * expect. Uses execFileSync with an argv array (no shell), so `base` cannot
+ * inject shell syntax; `parseWriteGateContextCliArgs` additionally validates it
+ * looks like a plausible ref before this runs. Throws on failure (unresolvable
+ * base, not a git repo, etc.) — the CLI treats that as fail-closed, not a
+ * silent degrade to a thin briefing.
+ *
+ * @param {string} base
+ * @param {{ repoRoot: string }} opts
+ * @returns {{ nameStatusOutput: string, diffOutput: string }}
+ */
+function captureDiffFromBase(base, { repoRoot }) {
+  const range = `${base}...HEAD`;
+  const runGit = (args) => execFileSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  let nameStatusOutput;
+  let diffOutput;
+  try {
+    nameStatusOutput = runGit(["diff", "--name-status", range]);
+    diffOutput = runGit(["diff", range]);
+  } catch (err) {
+    throw new Error(`git diff against --base ${JSON.stringify(base)} failed: ${err?.message ?? err}`);
+  }
+  return { nameStatusOutput, diffOutput };
 }
 
 export async function writeGateContext(options, { repoRoot = process.cwd() } = {}) {
@@ -526,58 +650,13 @@ export async function buildGateContext(input, { repoRoot = process.cwd() } = {})
 
   const tmpRoot = input.tmpRoot || "tmp";
 
-  // Best-effort full-diff capture: when the resolver was handed a diff with
-  // `diffOutput`, persist the ENTIRE diff to a deterministic `.diff` file next
-  // to the context artifact so scoped reviewers can read the full change set
-  // (not just hunks) and trace adjacent code. Reference it from `scope.diffPath`
-  // (relative) and record full repo-relative `scope.changedFiles` parsed from
-  // the diff's `nameStatusOutput`. We do NOT inline the diff in the JSON.
-  const diffOutput = input.diff?.diffOutput;
-  let diffPath = null;
-  let changedFiles = parseChangedFiles(input.diff?.nameStatusOutput);
-  if (typeof diffOutput === "string" && diffOutput.length > 0) {
-    diffPath = buildGateDiffPath({
-      repo: input.repo,
-      pr: input.pr,
-      gate: input.gate,
-      headSha: input.headSha,
-      tmpRoot,
-    });
-    const fullDiffPath = path.resolve(repoRoot, diffPath);
-    try {
-      await mkdir(path.dirname(fullDiffPath), { recursive: true });
-      await writeFile(fullDiffPath, diffOutput.endsWith("\n") ? diffOutput : diffOutput + "\n", "utf8");
-    } catch (err) {
-      // Best-effort: a diff-file write failure (disk, permissions) must not block
-      // the context artifact. Degrade to diffPath=null; reviewers reconstruct the
-      // diff with `git diff`. changedFiles (from nameStatusOutput) is unaffected.
-      process.stderr.write(`[gate-context] full-diff capture failed (continuing without scope.diffPath): ${err?.message ?? err}\n`);
-      diffPath = null;
-    }
-  }
-
-  // Build the deterministic, neutral adjacent-code bundle ONCE (#895): for each
-  // changed source file, include its 1-hop import out-edges (files it imports)
-  // and in-edges (files that import it), with size guards (skip
-  // lockfiles/generated/binary/minified; cap per-file bytes; truncate the long
-  // tail) recorded in a stripped/truncated manifest. Every independent reviewer
-  // is seeded with this identical bundle instead of re-deriving it — work-dedup.
-  // Best-effort: bundle computation must never block the context artifact.
-  let adjacentCode = null;
-  if (changedFiles.length > 0) {
-    try {
-      adjacentCode = await buildAdjacentBundle({
-        changedFiles,
-        repoRoot,
-        maxFileBytes: typeof input.maxFileBytes === "number" && input.maxFileBytes > 0
-          ? input.maxFileBytes
-          : DEFAULT_MAX_FILE_BYTES,
-      });
-    } catch (err) {
-      process.stderr.write(`[gate-context] adjacent-code bundle failed (continuing without adjacentCode): ${err?.message ?? err}\n`);
-      adjacentCode = null;
-    }
-  }
+  // Diff-derived scope: persisted FULL diff (scope.diffPath), parsed
+  // scope.changedFiles, and the neutral adjacentCode bundle, all built ONCE by
+  // the shared resolveDiffScope helper (also used by the CLI --base path, #1140).
+  const { diffPath, changedFiles, adjacentCode } = await resolveDiffScope(
+    { diff: input.diff, repo: input.repo, pr: input.pr, gate: input.gate, headSha: input.headSha, tmpRoot, maxFileBytes: input.maxFileBytes },
+    { repoRoot },
+  );
 
   const writeResult = await writeGateContext(
     {
@@ -627,10 +706,17 @@ export async function readGateContext(input, { repoRoot = process.cwd() } = {}) 
   }
 }
 
-async function main() {
+/**
+ * CLI entrypoint. Exported (argv + repoRoot both overridable) so tests can
+ * drive the `--base` diff-capture path against a throwaway git repo fixture
+ * without spawning a subprocess.
+ * @param {string[]} [argv]
+ * @param {{ repoRoot?: string }} [runtime]
+ */
+export async function main(argv = process.argv.slice(2), { repoRoot = process.cwd() } = {}) {
   let options;
   try {
-    options = parseWriteGateContextCliArgs(process.argv.slice(2));
+    options = parseWriteGateContextCliArgs(argv);
   } catch (error) {
     process.stderr.write(`${formatCliError(error, { usage: USAGE })}\n`);
     process.exitCode = 1;
@@ -641,7 +727,31 @@ async function main() {
     return;
   }
   try {
-    const result = await writeGateContext(options);
+    // AC3 (#1140): the CLI only produces the full build-once bundle
+    // (scope.diffPath + scope.changedFiles + adjacentCode) when it has a
+    // resolvable diff source. --base is OPTIONAL rather than required — making
+    // it required would break any existing caller that only ever passed
+    // --touched-files (angles + scope already resolved elsewhere) — so a run
+    // without --base does not fail closed; it explicitly WARNS and records the
+    // thin-briefing posture in scope.diffSource so it is never mistaken for a
+    // full bundle. A run WITH --base that then fails to resolve (bad ref, not a
+    // git repo, etc.) DOES fail closed: the caller opted into the full bundle,
+    // so a silent thin degrade there would be a worse surprise than an error.
+    if (options.base) {
+      const diff = captureDiffFromBase(options.base, { repoRoot });
+      const scope = await resolveDiffScope(
+        { diff, repo: options.repo, pr: options.pr, gate: options.gate, headSha: options.headSha, tmpRoot: options.tmpRoot || "tmp" },
+        { repoRoot },
+      );
+      options.changedFiles = scope.changedFiles;
+      options.diffPath = scope.diffPath;
+      options.adjacentCode = scope.adjacentCode;
+      options.diffSource = "base";
+    } else {
+      process.stderr.write("[write-gate-context] warning: no --base given; emitting a THIN briefing (scope.diffPath=null, scope.changedFiles=[], no adjacentCode). Pass --base <ref> for the full build-once bundle.\n");
+      options.diffSource = "none";
+    }
+    const result = await writeGateContext(options, { repoRoot });
     process.exitCode = emitResult(result, { jq: options.jq, silent: options.silent });
   } catch (error) {
     process.stderr.write(JSON.stringify({

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -139,18 +139,20 @@ function normalizeHeadSha(value) {
   return /^[0-9a-f]{7,64}$/i.test(normalized) ? normalized : null;
 }
 
-// ponytail: a conservative allowlist for a "plausible" git ref — rejects a
-// leading "-" (flag injection into the argv-array `git diff` call below,
-// which is already immune since execFileSync never invokes a shell, but a
-// leading dash is also just never a valid ref) and ".." (ambiguous with our
-// own "<base>...HEAD" triple-dot construction). `~` and `^` are allowed so
-// ancestry refs (HEAD~3, main^, HEAD~2^2) resolve — they are injection-safe
-// under execFileSync's argv array. Not a full git ref-name validator; upgrade
-// if a legitimately-shaped ref ever gets rejected.
+// ponytail: a DENYLIST, not an allowlist — the `git diff` call runs via
+// execFileSync's argv array (no shell), so `base` cannot inject shell syntax
+// and we don't need to enumerate every valid git revision grammar. We reject
+// only what is genuinely unsafe or malformed for OUR use, and let `git diff`
+// itself resolve validity (a syntactically-allowed but nonexistent ref fails
+// closed via the unresolvable-base path). Rejected: empty/whitespace-only; a
+// leading "-" (flag-injection shape, never a valid ref); and ".." (ambiguous
+// with our own "<base>...HEAD" triple-dot construction). Everything else —
+// including HEAD@{upstream}, main@{1}, tag-peel v1.0.0^{commit}, HEAD~3 — is
+// accepted.
 function normalizeBaseRef(value) {
   const trimmed = String(value).trim();
   if (trimmed.length === 0 || trimmed.startsWith("-") || trimmed.includes("..")) return null;
-  return /^[A-Za-z0-9][A-Za-z0-9._/~^-]*$/.test(trimmed) ? trimmed : null;
+  return trimmed;
 }
 
 const VALID_ACTIONS = new Set(["kept", "added", "dropped", "joined"]);
@@ -569,15 +571,24 @@ async function resolveDiffScope({ diff, repo, pr, gate, headSha, tmpRoot, maxFil
  * `{ nameStatusOutput, diffOutput }` input `resolveDiffScope`/`buildGateContext`
  * expect. Uses execFileSync with an argv array (no shell), so `base` cannot
  * inject shell syntax; `parseWriteGateContextCliArgs` additionally validates it
- * looks like a plausible ref before this runs. Throws on failure (unresolvable
- * base, not a git repo, etc.) — the CLI treats that as fail-closed, not a
- * silent degrade to a thin briefing.
+ * looks like a plausible ref before this runs.
+ *
+ * Split posture:
+ * - the `--name-status` capture is FAIL-CLOSED: it drives scope.changedFiles +
+ *   the adjacentCode bundle, so an unresolvable base / non-git-repo throws and
+ *   the CLI writes NO artifact (never a silent thin briefing).
+ * - the FULL diff capture is BEST-EFFORT: if it fails (output exceeds maxBuffer,
+ *   a rendering error, etc.) we warn and return an EMPTY diffOutput. downstream
+ *   resolveDiffScope then leaves scope.diffPath null while still populating
+ *   changedFiles + adjacentCode; reviewers fall back to re-deriving the diff
+ *   (the existing safety net). scope.diffSource stays "base" — it IS a
+ *   base-derived bundle, just without the persisted full diff.
  *
  * @param {string} base
- * @param {{ repoRoot: string }} opts
+ * @param {{ repoRoot: string, maxBuffer?: number }} opts — maxBuffer overridable for tests
  * @returns {{ nameStatusOutput: string, diffOutput: string }}
  */
-function captureDiffFromBase(base, { repoRoot }) {
+export function captureDiffFromBase(base, { repoRoot, maxBuffer = 64 * 1024 * 1024 }) {
   const range = `${base}...HEAD`;
   // Isolate the persisted .diff BYTES from ambient global/system gitconfig so
   // every reviewer is seeded with an IDENTICAL neutral bundle (the whole point
@@ -599,15 +610,23 @@ function captureDiffFromBase(base, { repoRoot }) {
   const runGit = (args) => execFileSync("git", [...isolation, ...args], {
     cwd: repoRoot,
     encoding: "utf8",
-    maxBuffer: 64 * 1024 * 1024,
+    maxBuffer,
   });
+  // FAIL-CLOSED: --name-status feeds changedFiles + adjacentCode (the bundle's core).
   let nameStatusOutput;
-  let diffOutput;
   try {
     nameStatusOutput = runGit(["diff", "--no-ext-diff", "--name-status", range]);
-    diffOutput = runGit(["diff", "--no-ext-diff", range]);
   } catch (err) {
     throw new Error(`git diff against --base ${JSON.stringify(base)} failed: ${err?.message ?? err}`);
+  }
+  // BEST-EFFORT: the full diff only feeds the persisted scope.diffPath; on
+  // failure degrade to an empty diffOutput (diffPath becomes null downstream).
+  let diffOutput = "";
+  try {
+    diffOutput = runGit(["diff", "--no-ext-diff", range]);
+  } catch (err) {
+    process.stderr.write(`[gate-context] full-diff capture against --base ${JSON.stringify(base)} failed (continuing without scope.diffPath): ${err?.message ?? err}\n`);
+    diffOutput = "";
   }
   return { nameStatusOutput, diffOutput };
 }

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -143,12 +143,14 @@ function normalizeHeadSha(value) {
 // leading "-" (flag injection into the argv-array `git diff` call below,
 // which is already immune since execFileSync never invokes a shell, but a
 // leading dash is also just never a valid ref) and ".." (ambiguous with our
-// own "<base>...HEAD" triple-dot construction). Not a full git ref-name
-// validator; upgrade if a legitimately-shaped ref ever gets rejected.
+// own "<base>...HEAD" triple-dot construction). `~` and `^` are allowed so
+// ancestry refs (HEAD~3, main^, HEAD~2^2) resolve — they are injection-safe
+// under execFileSync's argv array. Not a full git ref-name validator; upgrade
+// if a legitimately-shaped ref ever gets rejected.
 function normalizeBaseRef(value) {
   const trimmed = String(value).trim();
   if (trimmed.length === 0 || trimmed.startsWith("-") || trimmed.includes("..")) return null;
-  return /^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(trimmed) ? trimmed : null;
+  return /^[A-Za-z0-9][A-Za-z0-9._/~^-]*$/.test(trimmed) ? trimmed : null;
 }
 
 const VALID_ACTIONS = new Set(["kept", "added", "dropped", "joined"]);
@@ -577,7 +579,24 @@ async function resolveDiffScope({ diff, repo, pr, gate, headSha, tmpRoot, maxFil
  */
 function captureDiffFromBase(base, { repoRoot }) {
   const range = `${base}...HEAD`;
-  const runGit = (args) => execFileSync("git", args, {
+  // Isolate the persisted .diff BYTES from ambient global/system gitconfig so
+  // every reviewer is seeded with an IDENTICAL neutral bundle (the whole point
+  // of build-once). Without this isolation, an operator/CI with
+  // color.diff=always, a configured diff.external/difftool, or non-default
+  // prefix settings would make scope.diffPath environment-dependent.
+  // color.ui=false + color.diff=false strip ANSI; core.pager=cat neutralizes a
+  // configured pager; diff.noprefix=false + diff.mnemonicPrefix=false pin the
+  // a/ b/ prefixes; the --no-ext-diff flag (below) disables any external diff
+  // driver (NOT `-c diff.external=`, which makes git try to exec the empty
+  // string and die).
+  const isolation = [
+    "-c", "color.ui=false",
+    "-c", "color.diff=false",
+    "-c", "core.pager=cat",
+    "-c", "diff.noprefix=false",
+    "-c", "diff.mnemonicPrefix=false",
+  ];
+  const runGit = (args) => execFileSync("git", [...isolation, ...args], {
     cwd: repoRoot,
     encoding: "utf8",
     maxBuffer: 64 * 1024 * 1024,
@@ -585,8 +604,8 @@ function captureDiffFromBase(base, { repoRoot }) {
   let nameStatusOutput;
   let diffOutput;
   try {
-    nameStatusOutput = runGit(["diff", "--name-status", range]);
-    diffOutput = runGit(["diff", range]);
+    nameStatusOutput = runGit(["diff", "--no-ext-diff", "--name-status", range]);
+    diffOutput = runGit(["diff", "--no-ext-diff", range]);
   } catch (err) {
     throw new Error(`git diff against --base ${JSON.stringify(base)} failed: ${err?.message ?? err}`);
   }

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -1019,6 +1019,10 @@ test("CLI --base degrades to scope.diffPath=null but STILL writes the artifact w
     }, { repoRoot });
     assert.ok(artifact, "artifact still written despite the .diff write failure");
     assert.equal(artifact.scope.diffPath, null, "diffPath degrades to null on write failure");
+    // Partial "base": the CLI still stamps diffSource="base" (name-status succeeded, so it
+    // IS a base-derived bundle) even though the persisted full diff is absent. Reviewers key
+    // their diff-fallback on diffPath (null), NOT on diffSource. Locked in end-to-end here.
+    assert.equal(artifact.scope.diffSource, "base", "diffSource stays 'base' when only the full-diff persist degrades");
     // changedFiles (from name-status) and adjacentCode are unaffected by the diff-write failure.
     assert.deepEqual(artifact.scope.changedFiles, ["src/changed.mjs"]);
     assert.ok(artifact.adjacentCode, "adjacentCode still built from changedFiles");
@@ -1068,10 +1072,12 @@ test("captureDiffFromBase: --name-status failure fails closed (throws)", async (
   }
 });
 
-test("CLI --base with a failing full diff still writes the artifact (changedFiles + adjacentCode present, diffPath null, diffSource stays 'base')", async () => {
-  // Downstream proof of the best-effort split: an empty diffOutput (what a failed
-  // full-diff capture returns) leaves diffPath null while changedFiles +
-  // adjacentCode are still built, and the posture marker stays "base".
+test("buildGateContext with an empty diffOutput leaves diffPath null but still builds changedFiles + adjacentCode, and (programmatic) omits diffSource", async () => {
+  // Downstream proof of the best-effort split at the LIBRARY layer: an empty
+  // diffOutput (what a failed full-diff capture returns) leaves diffPath null
+  // while changedFiles + adjacentCode are still built. Programmatic callers do
+  // NOT get a diffSource field — that posture marker is CLI-only (backward
+  // compat); the CLI-driven partial-"base" case is asserted separately above.
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-partial-"));
   try {
     const files = {
@@ -1098,6 +1104,8 @@ test("CLI --base with a failing full diff still writes the artifact (changedFile
       { repoRoot },
     );
     assert.equal(result.artifact.scope.diffPath, null);
+    // Programmatic callers omit diffSource entirely (CLI-only marker, backward compat).
+    assert.equal(result.artifact.scope.diffSource, undefined);
     assert.deepEqual(result.artifact.scope.changedFiles, ["src/changed.mjs"]);
     assert.ok(result.artifact.adjacentCode, "adjacentCode still built from changedFiles");
     const byPath = Object.fromEntries(result.artifact.adjacentCode.files.map((f) => [f.path, f]));

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -854,6 +854,17 @@ test("parseWriteGateContextCliArgs rejects an implausible --base ref", () => {
   ]), /--base/);
 });
 
+test("parseWriteGateContextCliArgs accepts ancestry refs (HEAD~3, main^)", () => {
+  for (const ref of ["HEAD~3", "main^", "HEAD~2^2", "release/1.0~1"]) {
+    const result = parseWriteGateContextCliArgs([
+      "--repo", "owner/repo", "--pr", "1", "--gate", "draft_gate",
+      "--head-sha", "abc1234", "--angles", '["scope"]',
+      "--base", ref,
+    ]);
+    assert.equal(result.base, ref, `${ref} should be accepted`);
+  }
+});
+
 test("CLI --base <ref> produces a full build-once bundle: non-null diffPath, populated changedFiles, adjacentCode present", async () => {
   const { repoRoot, baseSha, headSha } = await makeBaseDiffRepo();
   try {
@@ -930,6 +941,84 @@ test("CLI --base <ref> that fails to resolve fails closed (no artifact written, 
       repo: "owner/repo", pr: 42, gate: "draft_gate", headSha,
     }, { repoRoot });
     assert.equal(artifact, null, "no artifact written on a fail-closed --base resolution failure");
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI --base accepts an ancestry ref (HEAD~1) and resolves it end-to-end", async () => {
+  const { repoRoot, headSha } = await makeBaseDiffRepo();
+  try {
+    // HEAD~1 is the base commit; the range HEAD~1...HEAD is the single change.
+    await main([
+      "--repo", "owner/repo", "--pr", "43", "--gate", "draft_gate",
+      "--head-sha", headSha,
+      "--angles", '["scope"]',
+      "--base", "HEAD~1",
+    ], { repoRoot });
+    const artifact = await readGateContext({
+      repo: "owner/repo", pr: 43, gate: "draft_gate", headSha,
+    }, { repoRoot });
+    assert.equal(artifact.scope.diffSource, "base");
+    assert.deepEqual(artifact.scope.changedFiles, ["src/changed.mjs"]);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI --base isolates git config: persisted diff is color-free even with color.diff=always in the repo config (determinism)", async () => {
+  const { repoRoot, headSha } = await makeBaseDiffRepo();
+  try {
+    // Force git to want color regardless of tty; the -c isolation in
+    // captureDiffFromBase must override this so the persisted .diff bytes are
+    // environment-independent (the neutral-bundle determinism guarantee).
+    git(repoRoot, ["config", "color.ui", "always"]);
+    git(repoRoot, ["config", "color.diff", "always"]);
+
+    await main([
+      "--repo", "owner/repo", "--pr", "44", "--gate", "draft_gate",
+      "--head-sha", headSha,
+      "--angles", '["scope"]',
+      "--base", "HEAD~1",
+    ], { repoRoot });
+
+    const artifact = await readGateContext({
+      repo: "owner/repo", pr: 44, gate: "draft_gate", headSha,
+    }, { repoRoot });
+    const diffOnDisk = await readFile(path.resolve(repoRoot, artifact.scope.diffPath), "utf8");
+    // No ANSI escape sequences (ESC, \x1b) leaked into the persisted diff.
+    assert.ok(!diffOnDisk.includes("\x1b"), "persisted diff must contain no ANSI color codes");
+    assert.deepEqual(artifact.scope.changedFiles, ["src/changed.mjs"]);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI --base degrades to scope.diffPath=null but STILL writes the artifact when the .diff write fails (best-effort)", async () => {
+  const { repoRoot, headSha } = await makeBaseDiffRepo();
+  try {
+    // Force the .diff writeFile to fail without touching the .json write: occupy
+    // the deterministic .diff path with a DIRECTORY so writeFile throws EISDIR.
+    // The sibling .json context write (different filename) still succeeds.
+    const diffRel = buildGateDiffPath({ repo: "owner/repo", pr: 45, gate: "draft_gate", headSha });
+    const diffAbs = path.resolve(repoRoot, diffRel);
+    await mkdir(diffAbs, { recursive: true });
+
+    await main([
+      "--repo", "owner/repo", "--pr", "45", "--gate", "draft_gate",
+      "--head-sha", headSha,
+      "--angles", '["scope"]',
+      "--base", "HEAD~1",
+    ], { repoRoot });
+
+    const artifact = await readGateContext({
+      repo: "owner/repo", pr: 45, gate: "draft_gate", headSha,
+    }, { repoRoot });
+    assert.ok(artifact, "artifact still written despite the .diff write failure");
+    assert.equal(artifact.scope.diffPath, null, "diffPath degrades to null on write failure");
+    // changedFiles (from name-status) and adjacentCode are unaffected by the diff-write failure.
+    assert.deepEqual(artifact.scope.changedFiles, ["src/changed.mjs"]);
+    assert.ok(artifact.adjacentCode, "adjacentCode still built from changedFiles");
   } finally {
     await rm(repoRoot, { recursive: true, force: true });
   }

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -928,22 +928,28 @@ test("CLI without --base emits an explicit thin-briefing posture, not a silent f
 test("CLI --base <ref> that fails to resolve fails closed (no artifact written, non-zero exit)", async () => {
   const { repoRoot, headSha } = await makeBaseDiffRepo();
   try {
+    // Nested try/finally: main() sets the GLOBAL process.exitCode on fail-closed,
+    // so restore it even if an assertion below throws — otherwise the mutated
+    // global leaks into subsequent tests and cascades false failures.
     const priorExitCode = process.exitCode;
     process.exitCode = undefined;
-    await main([
-      "--repo", "owner/repo", "--pr", "42", "--gate", "draft_gate",
-      "--head-sha", headSha,
-      "--angles", '["scope"]',
-      "--base", "this-ref-does-not-exist",
-    ], { repoRoot });
+    try {
+      await main([
+        "--repo", "owner/repo", "--pr", "42", "--gate", "draft_gate",
+        "--head-sha", headSha,
+        "--angles", '["scope"]',
+        "--base", "this-ref-does-not-exist",
+      ], { repoRoot });
 
-    assert.equal(process.exitCode, 1, "fails closed with a non-zero exit rather than degrading to a thin bundle");
-    process.exitCode = priorExitCode;
+      assert.equal(process.exitCode, 1, "fails closed with a non-zero exit rather than degrading to a thin bundle");
 
-    const artifact = await readGateContext({
-      repo: "owner/repo", pr: 42, gate: "draft_gate", headSha,
-    }, { repoRoot });
-    assert.equal(artifact, null, "no artifact written on a fail-closed --base resolution failure");
+      const artifact = await readGateContext({
+        repo: "owner/repo", pr: 42, gate: "draft_gate", headSha,
+      }, { repoRoot });
+      assert.equal(artifact, null, "no artifact written on a fail-closed --base resolution failure");
+    } finally {
+      process.exitCode = priorExitCode;
+    }
   } finally {
     await rm(repoRoot, { recursive: true, force: true });
   }

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -12,6 +12,7 @@ import {
   buildGateContextArtifact,
   buildGateContextPath,
   buildGateDiffPath,
+  captureDiffFromBase,
   main,
   mapGateToConfigKey,
   parseChangedFiles,
@@ -841,21 +842,23 @@ test("parseWriteGateContextCliArgs defaults --base to null", () => {
   assert.equal(result.base, null);
 });
 
-test("parseWriteGateContextCliArgs rejects an implausible --base ref", () => {
-  assert.throws(() => parseWriteGateContextCliArgs([
-    "--repo", "owner/repo", "--pr", "1", "--gate", "draft_gate",
-    "--head-sha", "abc1234", "--angles", '["scope"]',
-    "--base", "--evil-flag",
-  ]), /--base/);
-  assert.throws(() => parseWriteGateContextCliArgs([
-    "--repo", "owner/repo", "--pr", "1", "--gate", "draft_gate",
-    "--head-sha", "abc1234", "--angles", '["scope"]',
-    "--base", "a..b",
-  ]), /--base/);
+test("parseWriteGateContextCliArgs rejects only the genuinely-unsafe/malformed --base refs (denylist)", () => {
+  // Leading "-" (flag-injection shape), ".." (ambiguous with <base>...HEAD),
+  // and empty/whitespace-only are the ONLY rejected shapes.
+  for (const bad of ["--evil-flag", "a..b", "   "]) {
+    assert.throws(() => parseWriteGateContextCliArgs([
+      "--repo", "owner/repo", "--pr", "1", "--gate", "draft_gate",
+      "--head-sha", "abc1234", "--angles", '["scope"]',
+      "--base", bad,
+    ]), /--base/, `${JSON.stringify(bad)} should be rejected`);
+  }
 });
 
-test("parseWriteGateContextCliArgs accepts ancestry refs (HEAD~3, main^)", () => {
-  for (const ref of ["HEAD~3", "main^", "HEAD~2^2", "release/1.0~1"]) {
+test("parseWriteGateContextCliArgs accepts valid git revision syntaxes (denylist lets git resolve validity)", () => {
+  // Ancestry, reflog/upstream selectors, and tag-peel — all argv-safe under
+  // execFileSync (no shell), so the parser accepts them and defers resolution
+  // to `git diff` (a nonexistent-but-well-shaped ref fails closed downstream).
+  for (const ref of ["HEAD~3", "main^", "HEAD~2^2", "release/1.0~1", "HEAD@{upstream}", "main@{1}", "v1.0.0^{commit}"]) {
     const result = parseWriteGateContextCliArgs([
       "--repo", "owner/repo", "--pr", "1", "--gate", "draft_gate",
       "--head-sha", "abc1234", "--angles", '["scope"]',
@@ -1019,6 +1022,87 @@ test("CLI --base degrades to scope.diffPath=null but STILL writes the artifact w
     // changedFiles (from name-status) and adjacentCode are unaffected by the diff-write failure.
     assert.deepEqual(artifact.scope.changedFiles, ["src/changed.mjs"]);
     assert.ok(artifact.adjacentCode, "adjacentCode still built from changedFiles");
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// captureDiffFromBase — split posture: --name-status fail-closed, full diff best-effort
+// ---------------------------------------------------------------------------
+
+test("captureDiffFromBase: full-diff overflow (tiny maxBuffer) degrades to empty diffOutput while --name-status still resolves", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-cap-"));
+  try {
+    git(repoRoot, ["init", "-q"]);
+    git(repoRoot, ["config", "user.email", "test@example.com"]);
+    git(repoRoot, ["config", "user.name", "Test"]);
+    await mkdir(path.join(repoRoot, "src"), { recursive: true });
+    await writeFile(path.join(repoRoot, "src/big.mjs"), "export const x = 0;\n", "utf8");
+    git(repoRoot, ["add", "-A"]);
+    git(repoRoot, ["commit", "-q", "-m", "base"]);
+    // A large single-file change: name-status stays one tiny line, the full diff
+    // is many KB — so a small maxBuffer overflows ONLY the full-diff capture.
+    const bigBody = Array.from({ length: 4000 }, (_, i) => `export const v${i} = ${i};`).join("\n") + "\n";
+    await writeFile(path.join(repoRoot, "src/big.mjs"), bigBody, "utf8");
+    git(repoRoot, ["add", "-A"]);
+    git(repoRoot, ["commit", "-q", "-m", "grow"]);
+
+    const { nameStatusOutput, diffOutput } = captureDiffFromBase("HEAD~1", { repoRoot, maxBuffer: 512 });
+    assert.match(nameStatusOutput, /src\/big\.mjs/, "--name-status resolved under the tiny buffer");
+    assert.equal(diffOutput, "", "full diff degraded to empty on overflow (best-effort)");
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("captureDiffFromBase: --name-status failure fails closed (throws)", async () => {
+  const { repoRoot } = await makeBaseDiffRepo();
+  try {
+    assert.throws(
+      () => captureDiffFromBase("this-ref-does-not-exist", { repoRoot }),
+      /git diff against --base .* failed/,
+    );
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI --base with a failing full diff still writes the artifact (changedFiles + adjacentCode present, diffPath null, diffSource stays 'base')", async () => {
+  // Downstream proof of the best-effort split: an empty diffOutput (what a failed
+  // full-diff capture returns) leaves diffPath null while changedFiles +
+  // adjacentCode are still built, and the posture marker stays "base".
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-partial-"));
+  try {
+    const files = {
+      "src/changed.mjs": 'import { helper } from "./dep.mjs";\nexport function changed() { return helper(); }\n',
+      "src/dep.mjs": "export function helper() { return 1; }\n",
+      "src/caller.mjs": 'import { changed } from "./changed.mjs";\nchanged();\n',
+    };
+    for (const [rel, content] of Object.entries(files)) {
+      const abs = path.join(repoRoot, rel);
+      await mkdir(path.dirname(abs), { recursive: true });
+      await writeFile(abs, content, "utf8");
+    }
+    const config = draftConfig({ dynamicAngles: false });
+    const result = await buildGateContext(
+      {
+        config,
+        gate: "draft_gate",
+        // diffOutput:"" == what captureDiffFromBase returns on a best-effort full-diff failure.
+        diff: { nameStatusOutput: "M\tsrc/changed.mjs\n", diffOutput: "" },
+        repo: "owner/repo",
+        pr: 46,
+        headSha: "abc1234567890",
+      },
+      { repoRoot },
+    );
+    assert.equal(result.artifact.scope.diffPath, null);
+    assert.deepEqual(result.artifact.scope.changedFiles, ["src/changed.mjs"]);
+    assert.ok(result.artifact.adjacentCode, "adjacentCode still built from changedFiles");
+    const byPath = Object.fromEntries(result.artifact.adjacentCode.files.map((f) => [f.path, f]));
+    assert.equal(byPath["src/dep.mjs"].role, "imports");
+    assert.equal(byPath["src/caller.mjs"].role, "importedBy");
   } finally {
     await rm(repoRoot, { recursive: true, force: true });
   }

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -11,6 +12,7 @@ import {
   buildGateContextArtifact,
   buildGateContextPath,
   buildGateDiffPath,
+  main,
   mapGateToConfigKey,
   parseChangedFiles,
   parseWriteGateContextCliArgs,
@@ -18,6 +20,48 @@ import {
   readGateContext,
   writeGateContext,
 } from "../../scripts/github/write-gate-context.mjs";
+
+function git(cwd, args) {
+  return execFileSync("git", args, { cwd, encoding: "utf8" });
+}
+
+// A git repo fixture with a `base` commit and a later HEAD commit that adds an
+// import chain (changed.mjs <- caller.mjs, changed.mjs -> dep.mjs), so a
+// `--base <baseSha>` diff exercises the full scope.diffPath + changedFiles +
+// adjacentCode build (mirrors the buildGateContext adjacentCode fixture above).
+async function makeBaseDiffRepo() {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-cli-"));
+  git(repoRoot, ["init", "-q"]);
+  git(repoRoot, ["config", "user.email", "test@example.com"]);
+  git(repoRoot, ["config", "user.name", "Test"]);
+  // Base commit: dep.mjs and caller.mjs already exist (unchanged after this),
+  // so the later diff isolates changed.mjs as the only changed file, leaving
+  // dep.mjs/caller.mjs to be resolved purely via the adjacent-code 1-hop scan.
+  const files = {
+    "src/changed.mjs": 'import { helper } from "./dep.mjs";\nexport function changed() { return helper(); }\n',
+    "src/dep.mjs": "export function helper() { return 1; }\n",
+    "src/caller.mjs": 'import { changed } from "./changed.mjs";\nchanged();\n',
+  };
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = path.join(repoRoot, rel);
+    await mkdir(path.dirname(abs), { recursive: true });
+    await writeFile(abs, content, "utf8");
+  }
+  git(repoRoot, ["add", "-A"]);
+  git(repoRoot, ["commit", "-q", "-m", "base"]);
+  const baseSha = git(repoRoot, ["rev-parse", "HEAD"]).trim();
+
+  await writeFile(
+    path.join(repoRoot, "src/changed.mjs"),
+    'import { helper } from "./dep.mjs";\nexport function changed() { return helper() + 1; }\n',
+    "utf8",
+  );
+  git(repoRoot, ["add", "-A"]);
+  git(repoRoot, ["commit", "-q", "-m", "modify changed.mjs"]);
+  const headSha = git(repoRoot, ["rev-parse", "HEAD"]).trim();
+
+  return { repoRoot, baseSha, headSha };
+}
 
 function draftConfig(overrides = {}) {
   return {
@@ -771,6 +815,121 @@ test("buildGateContext leaves scope.diffPath null and changedFiles empty when no
     );
     assert.equal(result.artifact.scope.diffPath, null);
     assert.deepEqual(result.artifact.scope.changedFiles, []);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// CLI --base flag (#1140) — the CLI-driven "build once, seed many" bundle
+// ---------------------------------------------------------------------------
+
+test("parseWriteGateContextCliArgs parses --base", () => {
+  const result = parseWriteGateContextCliArgs([
+    "--repo", "owner/repo", "--pr", "1", "--gate", "draft_gate",
+    "--head-sha", "abc1234", "--angles", '["scope"]',
+    "--base", "origin/main",
+  ]);
+  assert.equal(result.base, "origin/main");
+});
+
+test("parseWriteGateContextCliArgs defaults --base to null", () => {
+  const result = parseWriteGateContextCliArgs([
+    "--repo", "owner/repo", "--pr", "1", "--gate", "draft_gate",
+    "--head-sha", "abc1234", "--angles", '["scope"]',
+  ]);
+  assert.equal(result.base, null);
+});
+
+test("parseWriteGateContextCliArgs rejects an implausible --base ref", () => {
+  assert.throws(() => parseWriteGateContextCliArgs([
+    "--repo", "owner/repo", "--pr", "1", "--gate", "draft_gate",
+    "--head-sha", "abc1234", "--angles", '["scope"]',
+    "--base", "--evil-flag",
+  ]), /--base/);
+  assert.throws(() => parseWriteGateContextCliArgs([
+    "--repo", "owner/repo", "--pr", "1", "--gate", "draft_gate",
+    "--head-sha", "abc1234", "--angles", '["scope"]',
+    "--base", "a..b",
+  ]), /--base/);
+});
+
+test("CLI --base <ref> produces a full build-once bundle: non-null diffPath, populated changedFiles, adjacentCode present", async () => {
+  const { repoRoot, baseSha, headSha } = await makeBaseDiffRepo();
+  try {
+    await main([
+      "--repo", "owner/repo", "--pr", "40", "--gate", "draft_gate",
+      "--head-sha", headSha,
+      "--angles", '["scope"]',
+      "--base", baseSha,
+    ], { repoRoot });
+
+    const artifact = await readGateContext({
+      repo: "owner/repo", pr: 40, gate: "draft_gate", headSha,
+    }, { repoRoot });
+
+    assert.ok(artifact, "artifact written");
+    assert.equal(artifact.scope.diffSource, "base");
+    assert.ok(artifact.scope.diffPath, "scope.diffPath is non-null");
+    assert.deepEqual(artifact.scope.changedFiles, ["src/changed.mjs"]);
+
+    // The .diff file was actually written and contains the real diff.
+    const diffOnDisk = await readFile(path.resolve(repoRoot, artifact.scope.diffPath), "utf8");
+    assert.ok(diffOnDisk.includes("src/changed.mjs"));
+
+    // adjacentCode bundle present, with the 1-hop import edges resolved.
+    assert.ok(artifact.adjacentCode, "adjacentCode bundle attached");
+    const byPath = Object.fromEntries(artifact.adjacentCode.files.map((f) => [f.path, f]));
+    assert.equal(byPath["src/changed.mjs"].role, "changed");
+    assert.equal(byPath["src/dep.mjs"].role, "imports");
+    assert.equal(byPath["src/caller.mjs"].role, "importedBy");
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI without --base emits an explicit thin-briefing posture, not a silent full-looking bundle", async () => {
+  const { repoRoot, headSha } = await makeBaseDiffRepo();
+  try {
+    await main([
+      "--repo", "owner/repo", "--pr", "41", "--gate", "draft_gate",
+      "--head-sha", headSha,
+      "--angles", '["scope"]',
+    ], { repoRoot });
+
+    const artifact = await readGateContext({
+      repo: "owner/repo", pr: 41, gate: "draft_gate", headSha,
+    }, { repoRoot });
+
+    assert.ok(artifact, "artifact still written (warn, not fail-closed, when --base is simply absent)");
+    assert.equal(artifact.scope.diffSource, "none");
+    assert.equal(artifact.scope.diffPath, null);
+    assert.deepEqual(artifact.scope.changedFiles, []);
+    assert.equal(Object.prototype.hasOwnProperty.call(artifact, "adjacentCode"), false);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI --base <ref> that fails to resolve fails closed (no artifact written, non-zero exit)", async () => {
+  const { repoRoot, headSha } = await makeBaseDiffRepo();
+  try {
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    await main([
+      "--repo", "owner/repo", "--pr", "42", "--gate", "draft_gate",
+      "--head-sha", headSha,
+      "--angles", '["scope"]',
+      "--base", "this-ref-does-not-exist",
+    ], { repoRoot });
+
+    assert.equal(process.exitCode, 1, "fails closed with a non-zero exit rather than degrading to a thin bundle");
+    process.exitCode = priorExitCode;
+
+    const artifact = await readGateContext({
+      repo: "owner/repo", pr: 42, gate: "draft_gate", headSha,
+    }, { repoRoot });
+    assert.equal(artifact, null, "no artifact written on a fail-closed --base resolution failure");
   } finally {
     await rm(repoRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #1140.

## Summary
The gate-review Phase 1 "build once, seed many" bundle (full diff at `scope.diffPath` + an `adjacentCode` bundle + populated `scope.changedFiles`) was only produced when a caller passed `{ diff }` to the library — and that diff-processing actually lived inside `buildGateContext`, **which the CLI never called**. So every CLI-driven gate run emitted a **thin briefing** (`diffPath:null`, `changedFiles:[]`, no `adjacentCode`), and each per-angle reviewer re-ran its own `git diff` — the build-once dedup and shared neutral adjacent-code bundle never happened on the CLI path (observed live in the #1135 draft-gate run, PR #1139).

## Root cause
The CLI called `writeGateContext()` (write an already-resolved artifact) directly, bypassing the diff-processing in `buildGateContext`. Fixed by extracting `resolveDiffScope` (diff-persist + `parseChangedFiles` + `buildAdjacentBundle`) into a shared helper both paths use — they can no longer drift.

## Changes
- `scripts/github/write-gate-context.mjs`:
  - `--base <ref>` flag → captures `git diff --name-status <base>...HEAD` + `git diff <base>...HEAD` (`execFileSync` argv, no shell interpolation) and feeds `resolveDiffScope`, populating `scope.diffPath`, `scope.changedFiles`, `adjacentCode`; stamps `scope.diffSource:"base"`. `normalizeBaseRef` is a denylist (rejects empty/whitespace, leading-`-`, `..`; accepts argv-safe refs incl. `HEAD~3`, `main^`, `HEAD@{upstream}`, `v1.0.0^{commit}` — git resolves validity, unresolvable fails closed).
  - **git-config isolation** (determinism): the diff runs with `-c color.ui=false -c color.diff=false -c core.pager=cat -c diff.noprefix=false -c diff.mnemonicPrefix=false ... --no-ext-diff` so the persisted neutral seed is byte-identical regardless of the operator's ambient gitconfig.
  - **fail-closed / best-effort split**: `git diff --name-status` is fail-closed (required for `changedFiles`+`adjacentCode`); the full `git diff` is best-effort — on failure (e.g. output > `maxBuffer`) it warns + degrades `scope.diffPath` to null while keeping `changedFiles`+`adjacentCode` (`diffSource` stays `"base"`; reviewers re-derive the diff via the safety net).
  - No-diff-source posture: `--base` absent → still succeeds (does not break `--touched-files`-only callers) but warns + stamps `scope.diffSource:"none"`. `--base` present but unresolvable → fail closed (non-zero, no artifact written).
  - `writeGateContext()`'s own contract unchanged; `scope.diffSource` attaches conditionally (programmatic `buildGateContext` callers omit it — existing artifact shape preserved).
- `docs/gate-review-sub-loop-contract.md`: Phase 1 — document `scope.diffSource` (`"base"`/`"none"`), the `--base` build-once path vs the explicit thin briefing, and the **partial `"base"`** case (`diffSource:"base"` can co-occur with `diffPath:null` when the best-effort full-diff degrades; reviewers key their fallback on `diffPath`, not `diffSource`).
- `test/github/write-gate-context.test.mjs`: `--base` denylist accept/reject (ancestry/reflog/tag-peel refs); e2e temp-git-repo full bundle (non-null `diffPath` on disk + `changedFiles` + `adjacentCode` roles + `diffSource:"base"`); git-config isolation (`color.diff=always` → no ANSI in the persisted diff); best-effort degrade (`diffPath:null` + `changedFiles`/`adjacentCode` preserved + `diffSource:"base"`); no-base posture; unresolvable-base fail-closed (no artifact).

## Acceptance criteria
- [x] A CLI invocation with a resolvable `--base` produces populated `scope.changedFiles` + an `adjacentCode` bundle (the fail-closed guarantee) and, on a successful full-diff capture, a non-null `scope.diffPath`. (The full diff is best-effort: if it degrades, `diffPath` is null but `changedFiles`/`adjacentCode` still seed reviewers — `diffSource` stays `"base"`; reviewers key their fallback on `diffPath`.)
- [x] The Phase 1 "build once, seed many" contract holds on the CLI path (reviewers consume the seeded diff/adjacentCode).
- [x] No silent thin briefing masquerading as a full bundle — `scope.diffSource` ("base"/"none") + a stderr warning; unresolvable `--base` fails closed.
- [x] Tests cover the diff-populated CLI path and the no-diff-source path.

## Definition of done
- [x] `npm run verify` green (0 failures).

## Non-goals
- Reviewer fallback when `diffPath` is genuinely null (stays as the safety net).
- `adjacentCode` size-guard heuristics.
- `--diff-file` (the issue's optional alternative — `--base` alone satisfies the ask; a second unused diff-source flag would be speculative).

## Validation command
```
npm run verify
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

