### PR TITLE
chore(loop): drop unused isFenceLine field from stepFence return (#1166)

### DIFF
--- a/packages/core/src/loop/issue-refinement-artifact.mjs
+++ b/packages/core/src/loop/issue-refinement-artifact.mjs
@@ -49,9 +49,8 @@ const DOD_SECTION_PATTERNS = Object.freeze([
 
 /**
  * Fenced-code-span tracker. Given the previous fence state and the current
- * line, returns { fence, isFenceLine, insideFence } where:
+ * line, returns { fence, insideFence } where:
  *   - `fence` is the next state ({ char, len } while open, else null)
- *   - `isFenceLine` is true when the line is itself a fence open/close marker
  *   - `insideFence` is true when the line's CONTENT is inside a code span
  *     (i.e. a fence line, or a line between an open and its close)
  *
@@ -69,14 +68,14 @@ function stepFence(fence, line) {
     // (CommonMark: no mixed markers, no info string).
     const isBareRun = new RegExp(`^\\s*${char}+\\s*$`, "u").test(line);
     if (fence === null) {
-      return { fence: { char, len }, isFenceLine: true, insideFence: true };
+      return { fence: { char, len }, insideFence: true };
     }
     if (fence.char === char && len >= fence.len && isBareRun) {
-      return { fence: null, isFenceLine: true, insideFence: true };
+      return { fence: null, insideFence: true };
     }
-    return { fence, isFenceLine: true, insideFence: true };
+    return { fence, insideFence: true };
   }
-  return { fence, isFenceLine: false, insideFence: fence !== null };
+  return { fence, insideFence: fence !== null };
 }
 
 /**


### PR DESCRIPTION
## Objective

`stepFence` in `packages/core/src/loop/issue-refinement-artifact.mjs` computed and returned an `isFenceLine` field on every branch, but none of its three call sites (`parseMarkdownSections`, `extractChecklistItems`, `sectionHasBody`) ever read it — only `fence` and `insideFence` are consumed. Drop the dead field to keep the helper's contract minimal.

## In scope

- Remove `isFenceLine` from every `return` in `stepFence`.
- Update the `stepFence` JSDoc to drop the `isFenceLine` bullet from the documented return shape.

## Explicit non-goals

- No change to `fence` or `insideFence` behavior.
- No change to any caller (`parseMarkdownSections`, `extractChecklistItems`, `sectionHasBody`).
- No change to the fence-detection regexes or CommonMark closing-fence logic.

## Acceptance criteria

- [x] `stepFence` no longer returns an `isFenceLine` property on any branch.
- [x] The `stepFence` JSDoc no longer documents `isFenceLine`.
- [x] `grep -rn "isFenceLine"` across the repo (excluding `node_modules`) returns no matches.
- [x] `npm run verify` passes with no new failures.

## Definition of done

- [x] Code change is minimal (single function body + its JSDoc).
- [x] No consumer referenced `isFenceLine`, confirmed via repo-wide grep before and after the change.
- [x] `npm run verify` is green.

## Open questions / risks

- None. This is a pure dead-code removal with no behavioral surface area; the fence/insideFence contract that all three callers rely on is unchanged.
