### PR TITLE
fix(queue): resolve sibling logical columns via loadStateColumnMap in pickup + archive (#1143)

### DIFF
--- a/scripts/projects/archive-done-items.mjs
+++ b/scripts/projects/archive-done-items.mjs
@@ -4,6 +4,7 @@ import { runChild as _runChild } from "../_cli-primitives.mjs";
 import { resolveSettings, parseProjectRef, findProject } from "./_resolve-project.mjs";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+import { loadStateColumnMap, LOGICAL_COLUMN } from "@dev-loops/core/loop/queue-board-sync";
 
 const USAGE = `Usage: dev-loops queue archive-done --repo <owner/name> [--project <number|id|board-uri>] [--older-than <duration>] [--dry-run]
        (dev-loops project archive-done … is a back-compat alias)
@@ -308,12 +309,14 @@ function normalizeItem(node) {
 // ── Selection logic (pure) ────────────────────────────────────────────────
 
 // Select items whose issue/PR is closed and has been closed for >= olderThanMs.
-function selectArchivable(items, { now, olderThanMs }) {
+// `doneColumn` defaults to the literal "Done" for direct/pure-unit callers;
+// main() always passes the configured column name (#1098, #1143).
+function selectArchivable(items, { now, olderThanMs, doneColumn = "Done" }) {
   return items.filter((it) => {
     if (it.isArchived) return false;
     // Only archive items in the Done column — a closed issue/PR parked in
     // another column (Backlog/Next Up/In Progress) must be left untouched.
-    if (it.status !== "Done") return false;
+    if (it.status !== doneColumn) return false;
     const c = it.content;
     if (!c || !c.closed || !c.closedAt) return false;
     const closedAtMs = Date.parse(c.closedAt);
@@ -333,9 +336,22 @@ function classifyExitCode(err) {
 
 // ── Main logic ──────────────────────────────────────────────────────────
 
-async function main(args, { env = process.env, runChild } = {}) {
+async function main(args, { env = process.env, runChild, cwd = process.cwd() } = {}) {
   const child = runChild ?? _runChild;
   const repo = validateRepo(args.repo);
+  // Resolve the done column name through the SAME statusColumns mapping
+  // board-sync uses (#1098, #1143): a repo that renamed Done gets its
+  // configured column matched here, not the literal default. Fail CLOSED on a
+  // malformed `.devloops` — never silently archive against the literal "Done"
+  // and risk archiving nothing on a renamed/stale column.
+  const { columnNames, error: configError } = loadStateColumnMap(cwd);
+  if (configError) {
+    throw Object.assign(
+      new Error(`could not resolve done column (config read/parse error: ${configError})`),
+      { code: "CONFIG_ERROR" },
+    );
+  }
+  const doneColumn = columnNames[LOGICAL_COLUMN.DONE];
   const [owner] = repo.split("/");
   // Board: explicit --project ref wins; otherwise resolve by board title from
   // .devloops (passed in as args.projectTitle by runCli). Fail closed if neither.
@@ -368,7 +384,7 @@ async function main(args, { env = process.env, runChild } = {}) {
     .filter((n) => n.content && n.content.repository?.nameWithOwner === repo)
     .map(normalizeItem);
 
-  const archivable = selectArchivable(repoItems, { now, olderThanMs });
+  const archivable = selectArchivable(repoItems, { now, olderThanMs, doneColumn });
 
   const mutations = archivable.map((it) => ({
     query: ARCHIVE_ITEM,
@@ -438,7 +454,7 @@ async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, 
   }
 
   try {
-    const result = await main(args, { env });
+    const result = await main(args, { env, cwd });
     process.exitCode = emitResult(result, { jq: args.jq, silent: args.silent, stdout, stderr });
   } catch (err) {
     stderr.write(JSON.stringify({ ok: false, error: err.message, code: err.code ?? "UNKNOWN" }) + "\n");

--- a/scripts/projects/resolve-active-board-item.mjs
+++ b/scripts/projects/resolve-active-board-item.mjs
@@ -21,9 +21,10 @@ import { main as listQueueItems } from "./list-queue-items.mjs";
 import { EMPTY_NEXT_UP_MESSAGE } from "@dev-loops/core/loop/queue-board-ordering";
 import { loadStateColumnMap, LOGICAL_COLUMN } from "@dev-loops/core/loop/queue-board-sync";
 
+// Illustrative default labels for USAGE/help + comments only; the actual query
+// columns resolve through queue.statusColumns.in_progress / .next_up at
+// runtime (#1098, #1143).
 const IN_PROGRESS_COLUMN = "In Progress";
-// Illustrative default label for USAGE/help + comments only; the actual query
-// column resolves through queue.statusColumns.next_up at runtime (#1098).
 const NEXT_UP_COLUMN = "Next Up";
 // Canonical fail-closed empty-queue message — matches queue-driver.mjs so
 // operators see one string regardless of which layer detects it (#1091).
@@ -179,8 +180,21 @@ async function resolveNextUpHead(args, { env, runChild, cwd = process.cwd() } = 
 }
 
 async function main(args, { env = process.env, runChild, cwd = process.cwd() } = {}) {
+  // Resolve the in_progress column name through the SAME statusColumns mapping
+  // board-sync uses (#1098, #1143): a repo that renamed In Progress gets its
+  // configured column queried, not the literal default. Fail CLOSED on a
+  // malformed `.devloops` — never silently query the literal "In Progress"
+  // and risk missing the active item on a renamed/stale column.
+  const { columnNames, error: configError } = loadStateColumnMap(cwd);
+  if (configError) {
+    throw Object.assign(
+      new Error(`could not resolve in_progress column (config read/parse error: ${configError})`),
+      { code: "CONFIG_ERROR" },
+    );
+  }
+  const inProgressColumn = columnNames[LOGICAL_COLUMN.IN_PROGRESS];
   const listed = await listQueueItems(
-    { repo: args.repo, project: args.project, column: IN_PROGRESS_COLUMN },
+    { repo: args.repo, project: args.project, column: inProgressColumn },
     { env, runChild },
   );
   const items = listed.items ?? [];

--- a/test/projects/archive-done-items.test.mjs
+++ b/test/projects/archive-done-items.test.mjs
@@ -1,5 +1,8 @@
-import { describe, it } from "node:test";
+import { after, describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import nodePath from "node:path";
 import {
   main,
   parseCliArgs,
@@ -7,6 +10,12 @@ import {
   selectArchivable,
   resolveSettings,
 } from "../../scripts/projects/archive-done-items.mjs";
+
+// Isolated default cwd (no .devloops): main() resolves statusColumns from cwd,
+// so tests must never read THIS repo's real config as a hidden dependency —
+// a future repo-level statusColumns override would silently break them.
+const ISOLATED_CWD = mkdtempSync(nodePath.join(tmpdir(), "archive-done-isolated-"));
+after(() => rmSync(ISOLATED_CWD, { recursive: true, force: true }));
 
 // ── Pure unit: parseCliArgs ───────────────────────────────────────────────
 
@@ -177,7 +186,7 @@ describe("archive-done — integration", () => {
 
     const result = await main(
       { repo: "mfittko/dev-loops", project: "1", olderThan: "30d", now: Date.parse("2026-06-24T00:00:00Z") },
-      { runChild },
+      { runChild, cwd: ISOLATED_CWD },
     );
 
     assert.ok(result.ok);
@@ -202,7 +211,7 @@ describe("archive-done — integration", () => {
 
     const result = await main(
       { repo: "mfittko/dev-loops", project: "1", olderThan: "30d", dryRun: true, now: Date.parse("2026-06-24T00:00:00Z") },
-      { runChild },
+      { runChild, cwd: ISOLATED_CWD },
     );
 
     assert.strictEqual(result.dryRun, true);
@@ -225,7 +234,7 @@ describe("archive-done — integration", () => {
 
     const result = await main(
       { repo: "mfittko/dev-loops", project: "1", now: Date.parse("2026-06-24T00:00:00Z") },
-      { runChild },
+      { runChild, cwd: ISOLATED_CWD },
     );
 
     assert.ok(result.ok);
@@ -246,7 +255,7 @@ describe("archive-done — integration", () => {
 
     const result = await main(
       { repo: "mfittko/dev-loops", project: "1", olderThanDefault: "3d", now: Date.parse("2026-06-24T00:00:00Z") },
-      { runChild },
+      { runChild, cwd: ISOLATED_CWD },
     );
 
     assert.ok(result.ok);
@@ -266,7 +275,7 @@ describe("archive-done — integration", () => {
     const result = await main(
       // explicit 7d wins over config default 3d → 5d-old item is kept
       { repo: "mfittko/dev-loops", project: "1", olderThan: "7d", olderThanDefault: "3d", now: Date.parse("2026-06-24T00:00:00Z") },
-      { runChild },
+      { runChild, cwd: ISOLATED_CWD },
     );
 
     assert.ok(result.ok);
@@ -286,7 +295,7 @@ describe("archive-done — integration", () => {
 
     const result = await main(
       { repo: "mfittko/dev-loops", projectTitle: "Dev Loop Queue", olderThan: "30d", now: Date.parse("2026-06-24T00:00:00Z") },
-      { runChild },
+      { runChild, cwd: ISOLATED_CWD },
     );
 
     assert.ok(result.ok);
@@ -297,17 +306,13 @@ describe("archive-done — integration", () => {
   it("fails closed when neither --project nor a configured board resolves", async () => {
     const runChild = mockRunChild([]);
     await assert.rejects(
-      () => main({ repo: "mfittko/dev-loops", now: Date.parse("2026-06-24T00:00:00Z") }, { runChild }),
+      () => main({ repo: "mfittko/dev-loops", now: Date.parse("2026-06-24T00:00:00Z") }, { runChild, cwd: ISOLATED_CWD }),
       (e) => e.code === "INVALID_PROJECT",
     );
   });
 });
 
 // ── resolveSettings (config-driven defaults) ──────────────────────────────
-
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import nodePath from "node:path";
 
 function withTempDevloops(contents, fn) {
   const dir = mkdtempSync(nodePath.join(tmpdir(), "archive-done-cfg-"));

--- a/test/projects/archive-done-items.test.mjs
+++ b/test/projects/archive-done-items.test.mjs
@@ -319,6 +319,83 @@ function withTempDevloops(contents, fn) {
   }
 }
 
+describe("archive-done resolves the configured done column (#1143)", () => {
+  it("archives items in the overridden statusColumns.done column (\"Complete\"), not the literal \"Done\"", async () => {
+    await withTempDevloops('queue:\n  projectNumber: 1\n  statusColumns:\n    done: "Complete"\n', async (cwd) => {
+      const nodes = [rawItemNode("A", 1, { closed: true, closedAt: "2026-01-01T00:00:00Z", status: "Complete" })];
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([PROJECT]) },
+        { payload: itemsResponse(nodes) },
+        { payload: archiveResponse("A") },
+      ];
+      const runChild = mockRunChild(responses);
+
+      const result = await main(
+        { repo: "mfittko/dev-loops", project: "1", olderThan: "30d", now: Date.parse("2026-06-24T00:00:00Z") },
+        { runChild, cwd },
+      );
+
+      assert.ok(result.ok);
+      assert.strictEqual(result.archived.length, 1);
+      assert.strictEqual(result.archived[0].itemId, "A");
+    });
+  });
+
+  it("does NOT archive an item still literally in \"Done\" when statusColumns.done is renamed", async () => {
+    await withTempDevloops('queue:\n  projectNumber: 1\n  statusColumns:\n    done: "Complete"\n', async (cwd) => {
+      // Stale item sitting in the old literal "Done" column must be left alone —
+      // the configured column ("Complete") is the only one archive-done matches.
+      const nodes = [rawItemNode("A", 1, { closed: true, closedAt: "2026-01-01T00:00:00Z", status: "Done" })];
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([PROJECT]) },
+        { payload: itemsResponse(nodes) },
+      ];
+      const runChild = mockRunChild(responses);
+
+      const result = await main(
+        { repo: "mfittko/dev-loops", project: "1", olderThan: "30d", now: Date.parse("2026-06-24T00:00:00Z") },
+        { runChild, cwd },
+      );
+
+      assert.ok(result.ok);
+      assert.strictEqual(result.archived.length, 0);
+    });
+  });
+
+  it("default config (no override) still archives against the literal \"Done\"", async () => {
+    await withTempDevloops(null, async (cwd) => {
+      const nodes = [rawItemNode("A", 1, { closed: true, closedAt: "2026-01-01T00:00:00Z" })];
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([PROJECT]) },
+        { payload: itemsResponse(nodes) },
+        { payload: archiveResponse("A") },
+      ];
+      const runChild = mockRunChild(responses);
+
+      const result = await main(
+        { repo: "mfittko/dev-loops", project: "1", olderThan: "30d", now: Date.parse("2026-06-24T00:00:00Z") },
+        { runChild, cwd },
+      );
+
+      assert.ok(result.ok);
+      assert.strictEqual(result.archived.length, 1);
+    });
+  });
+
+  it("malformed .devloops → archive-done fails CLOSED (surfaces config error), never archives against the literal \"Done\"", async () => {
+    await withTempDevloops("queue: renamed\n- broken\n", async (cwd) => {
+      const runChild = mockRunChild([]);
+      await assert.rejects(
+        () => main({ repo: "mfittko/dev-loops", project: "1", now: Date.parse("2026-06-24T00:00:00Z") }, { runChild, cwd }),
+        /config read\/parse error/,
+      );
+    });
+  });
+});
+
 describe("archive-done — resolveSettings", () => {
   it("returns null when no .devloops is present (default threshold/board apply)", () => {
     withTempDevloops(null, (dir) => {

--- a/test/projects/resolve-active-board-item.test.mjs
+++ b/test/projects/resolve-active-board-item.test.mjs
@@ -1,9 +1,15 @@
-import { describe, it } from "node:test";
+import { after, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import nodePath from "node:path";
 import { collapseToTarget, main, runCli } from "../../scripts/projects/resolve-active-board-item.mjs";
+
+// Isolated default cwd (no .devloops): main() resolves statusColumns from cwd,
+// so tests must never read THIS repo's real config as a hidden dependency —
+// a future repo-level statusColumns override would silently break them.
+const ISOLATED_CWD = mkdtempSync(nodePath.join(tmpdir(), "resolve-active-isolated-"));
+after(() => rmSync(ISOLATED_CWD, { recursive: true, force: true }));
 
 // A runChild stub that drives list-queue-items end to end. `columns` maps a
 // Status column name to the items GraphQL returns for it; list-queue-items
@@ -49,7 +55,7 @@ function boardRunChild({ columns = {}, itemsError = false, optionNames = ["Backl
   };
 }
 
-const runArgs = (child) => main({ repo: "o/r", project: "7" }, { runChild: child });
+const runArgs = (child) => main({ repo: "o/r", project: "7" }, { runChild: child, cwd: ISOLATED_CWD });
 
 function captureCli(child, extraArgs = []) {
   let out = "";
@@ -60,6 +66,7 @@ function captureCli(child, extraArgs = []) {
     stdout: { write: (s) => { out += s; } },
     stderr: { write: (s) => { err += s; } },
     runChild: child,
+    cwd: ISOLATED_CWD,
   }).then(() => {
     const code = process.exitCode;
     process.exitCode = prev;

--- a/test/projects/resolve-active-board-item.test.mjs
+++ b/test/projects/resolve-active-board-item.test.mjs
@@ -234,3 +234,51 @@ describe("resolve-active-board-item resolves the configured next_up column (#109
     });
   });
 });
+
+describe("resolve-active-board-item resolves the configured in_progress column (#1143)", () => {
+  async function withTempCwd(contents, fn) {
+    const dir = mkdtempSync(nodePath.join(tmpdir(), "resolve-active-statuscol-inprogress-"));
+    try {
+      if (contents !== null) writeFileSync(nodePath.join(dir, ".devloops"), contents, "utf-8");
+      return await fn(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("pickup queries the overridden statusColumns.in_progress column (\"Doing\"), not the literal", async () => {
+    await withTempCwd('queue:\n  projectNumber: 7\n  statusColumns:\n    in_progress: "Doing"\n', async (cwd) => {
+      // The single active item lives ONLY in the renamed "Doing" column. If the
+      // resolver still queried the literal "In Progress", it would see an empty
+      // column and fall through to Next Up instead — proving misdetection.
+      const child = boardRunChild({
+        optionNames: ["Backlog", "Next Up", "Doing", "Done"],
+        columns: { "Doing": [{ issueNumber: 42, title: "Active" }], "Next Up": [{ issueNumber: 7, title: "Later" }] },
+      });
+      const r = await main({ repo: "o/r", project: "7" }, { runChild: child, cwd });
+      assert.deepEqual(r, { ok: true, target: { kind: "issue", number: 42 }, source: "in-progress" });
+    });
+  });
+
+  it("default config (no override) still resolves the literal \"In Progress\"", async () => {
+    await withTempCwd(null, async (cwd) => {
+      const child = boardRunChild({
+        columns: { "In Progress": [{ issueNumber: 42, title: "Active" }], "Next Up": [] },
+      });
+      const r = await main({ repo: "o/r", project: "7" }, { runChild: child, cwd });
+      assert.deepEqual(r, { ok: true, target: { kind: "issue", number: 42 }, source: "in-progress" });
+    });
+  });
+
+  it("malformed .devloops → pickup fails CLOSED (surfaces config error), never queries the literal \"In Progress\"", async () => {
+    await withTempCwd("queue: renamed\n- broken\n", async (cwd) => {
+      const child = boardRunChild({
+        columns: { "In Progress": [{ issueNumber: 42, title: "Active" }], "Next Up": [] },
+      });
+      await assert.rejects(
+        () => main({ repo: "o/r", project: "7" }, { runChild: child, cwd }),
+        /config read\/parse error/,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Objective

`scripts/projects/resolve-active-board-item.mjs` hardcoded `IN_PROGRESS_COLUMN = "In Progress"` for the live `/loop-continue` pickup query, instead of resolving the column display name through `loadStateColumnMap(cwd).columnNames[LOGICAL_COLUMN.IN_PROGRESS]` the way #1142 already did for `next_up`. A repo that configures `queue.statusColumns.in_progress` to something other than `"In Progress"` would have pickup's in-progress detection silently miss the active item and fall through to Next Up instead — the same class of bug #1098/#1142 fixed for the Next Up head. This closes the sibling gap and audits the rest of the ordering/pickup/projects-script layer for the same pattern.

## In scope

- `scripts/projects/resolve-active-board-item.mjs`: resolve the in_progress column name via `loadStateColumnMap(cwd)` in `main()`, using the identical fail-closed pattern `resolveNextUpHead` already uses for `next_up` (malformed `.devloops` throws `CONFIG_ERROR`, never silently falls back to the literal `"In Progress"`).
- Audit of `scripts/projects/*.mjs` (and the pickup path) for other hardcoded sibling display-name literals that determine LOGIC (item selection / mutation targeting), not just default provisioning or help-text examples.
- `scripts/projects/archive-done-items.mjs`: found and fixed a second real instance — `selectArchivable()` hardcoded `it.status !== "Done"` to decide which items are archivable. A renamed `queue.statusColumns.done` would make `archive-done` silently archive nothing. Routed through the same `loadStateColumnMap(cwd)` / `LOGICAL_COLUMN.DONE` resolution, same fail-closed contract.
- Tests for both fixes: non-default column override honored, default-config regression, and config-parse-error fails closed.

## Explicit non-goals

- `scripts/projects/ensure-queue-board.mjs` provisioning defaults (out of scope per issue).
- `scripts/run-queue.mjs` (dormant no-op adapter — out of scope per issue).
- `scripts/projects/list-queue-items.mjs` `--done-limit` grouping: this caps a *display/summary* list length, already has a documented, intentional fallback (last board option) when no column is literally named `"Done"`, and does not decide which items get archived/worked — a display concern, not pickup logic, so left as-is.
- `scripts/projects/move-queue-item.mjs` / `scripts/projects/sync-item-status.mjs`: their `"In Progress"`/`"Done"` mentions are only illustrative `--to-column` examples in `--help` text; the actual target column is always an explicit CLI argument supplied by the caller, so there is no hardcoded logic to route.
- No new config surface — reuses the existing `queue.statusColumns` mapping and `loadStateColumnMap`/`LOGICAL_COLUMN` exports from `@dev-loops/core`.

## Acceptance criteria

- With `queue.statusColumns.in_progress` set to a non-default name, `/loop-continue` pickup queries that configured column (not the literal `"In Progress"`) and correctly returns the single active item as the continue target.
- With no override, pickup continues to resolve the literal `"In Progress"` column (regression-free).
- A malformed/unparseable `.devloops` causes `resolve-active-board-item` to fail closed with a `config read/parse error` message, never silently querying the literal column.
- With `queue.statusColumns.done` set to a non-default name, `archive-done-items` archives items in that configured column and does NOT archive stale items still sitting in the literal `"Done"` column.
- With no override, `archive-done-items` continues to archive against the literal `"Done"` column (regression-free).
- A malformed/unparseable `.devloops` causes `archive-done-items` to fail closed the same way.
- `npm run verify` passes.

## Definition of done

- Code changes in `scripts/projects/resolve-active-board-item.mjs` and `scripts/projects/archive-done-items.mjs` land, each resolving their respective logical column through `loadStateColumnMap`/`LOGICAL_COLUMN` — single source of truth, no duplicated mapping.
- New tests added to `test/projects/resolve-active-board-item.test.mjs` and `test/projects/archive-done-items.test.mjs` covering override honored / default regression / config-parse-error fail-closed, matching the #1142 test style.
- `npm run verify` green.

## Open questions / risks

- Ambient-cwd coupling: `main()` in both scripts now unconditionally reads `.devloops` from `cwd` (default `process.cwd()`), so any test calling `main()` without an explicit `cwd` would silently depend on the host repo's real config. Addressed in this PR: all pre-existing `main()`/`runCli()` test call sites in both test files now pass an isolated tmp-dir `cwd` (no `.devloops`), so a future repo-level `queue.statusColumns` override cannot break them.
- Otherwise none identified: the change is purely additive fail-closed resolution using an already-existing, already-tested config-mapping utility (`loadStateColumnMap`), matching an established pattern (#1098/#1142) in the same files.
