### PR TITLE
chore(gates): pin diff configs for cross-env reproducibility of the --base seed (#1168)

### DIFF
--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -600,12 +600,28 @@ export function captureDiffFromBase(base, { repoRoot, maxBuffer = 64 * 1024 * 10
   // a/ b/ prefixes; the --no-ext-diff flag (below) disables any external diff
   // driver (NOT `-c diff.external=`, which makes git try to exec the empty
   // string and die).
+  // CROSS-environment reproducibility (#1168): the overrides above only pin
+  // bytes WITHIN a single run/machine — an operator/CI box with a contrary
+  // local diff.renames/diff.algorithm/diff.context/core.abbrev/core.autocrlf
+  // would still produce different bytes than another box on the SAME base and
+  // HEAD. diff.algorithm=myers + diff.context=3 + core.abbrev=12 +
+  // core.autocrlf=false pin the diff body/hunk headers/blob-id length/line
+  // endings. diff.renames=true additionally pins rename DETECTION itself: with
+  // it off, a moved-and-edited file shows as a straight D+A pair in
+  // `--name-status` instead of an R### pair, which changes the SET of names in
+  // scope.changedFiles (and therefore adjacentCode's membership) across
+  // environments, not just the diff body's bytes.
   const isolation = [
     "-c", "color.ui=false",
     "-c", "color.diff=false",
     "-c", "core.pager=cat",
     "-c", "diff.noprefix=false",
     "-c", "diff.mnemonicPrefix=false",
+    "-c", "diff.renames=true",
+    "-c", "diff.algorithm=myers",
+    "-c", "diff.context=3",
+    "-c", "core.abbrev=12",
+    "-c", "core.autocrlf=false",
   ];
   const runGit = (args) => execFileSync("git", [...isolation, ...args], {
     cwd: repoRoot,

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -1078,6 +1078,83 @@ test("captureDiffFromBase: --name-status failure fails closed (throws)", async (
   }
 });
 
+// A base commit + a HEAD commit that renames src/original.mjs -> src/renamed.mjs
+// with two small edits ("CHANGE_A"/"CHANGE_B") separated by a 4-line unchanged
+// gap. The gap size (4) sits between the merge thresholds of context=1
+// (2*1=2, stays 2 separate hunks) and context=3 (2*3=6, merges into 1 hunk),
+// so an unpinned diff.context would change the hunk COUNT/shape, not just
+// cosmetics. The rename (75% line similarity, above git's default 50%
+// threshold) additionally exercises diff.renames: off, it shows as a D+A pair
+// instead of an R pair, changing --name-status output shape.
+async function makeRenameRepo({ contraryConfig }) {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-cross-env-"));
+  git(repoRoot, ["init", "-q"]);
+  git(repoRoot, ["config", "user.email", "test@example.com"]);
+  git(repoRoot, ["config", "user.name", "Test"]);
+  if (contraryConfig) {
+    git(repoRoot, ["config", "diff.renames", "false"]);
+    git(repoRoot, ["config", "diff.algorithm", "histogram"]);
+    git(repoRoot, ["config", "diff.context", "1"]);
+  }
+  const base = [
+    'export const header = true;',
+    'const a = "CHANGE_A_OLD";',
+    "const gap1 = 1;",
+    "const gap2 = 2;",
+    "const gap3 = 3;",
+    "const gap4 = 4;",
+    'const b = "CHANGE_B_OLD";',
+    "export const footer = true;",
+    "",
+  ].join("\n");
+  await mkdir(path.join(repoRoot, "src"), { recursive: true });
+  await writeFile(path.join(repoRoot, "src/original.mjs"), base, "utf8");
+  git(repoRoot, ["add", "-A"]);
+  git(repoRoot, ["commit", "-q", "-m", "base"]);
+
+  const renamed = [
+    'export const header = true;',
+    'const a = "CHANGE_A_NEW";',
+    "const gap1 = 1;",
+    "const gap2 = 2;",
+    "const gap3 = 3;",
+    "const gap4 = 4;",
+    'const b = "CHANGE_B_NEW";',
+    "export const footer = true;",
+    "",
+  ].join("\n");
+  await rm(path.join(repoRoot, "src/original.mjs"));
+  await writeFile(path.join(repoRoot, "src/renamed.mjs"), renamed, "utf8");
+  git(repoRoot, ["add", "-A"]);
+  git(repoRoot, ["commit", "-q", "-m", "rename+edit"]);
+  return repoRoot;
+}
+
+test("captureDiffFromBase: cross-environment byte-reproducibility — a CONTRARY local config (diff.renames=false, diff.algorithm=histogram, diff.context=1) still yields identical persisted diff bytes + changedFiles as the default case", async () => {
+  const defaultRepo = await makeRenameRepo({ contraryConfig: false });
+  const contraryRepo = await makeRenameRepo({ contraryConfig: true });
+  try {
+    const defaultCapture = captureDiffFromBase("HEAD~1", { repoRoot: defaultRepo });
+    const contraryCapture = captureDiffFromBase("HEAD~1", { repoRoot: contraryRepo });
+
+    assert.equal(
+      contraryCapture.diffOutput,
+      defaultCapture.diffOutput,
+      "persisted diff bytes must be identical regardless of ambient repo diff config",
+    );
+    assert.deepEqual(
+      parseChangedFiles(contraryCapture.nameStatusOutput),
+      parseChangedFiles(defaultCapture.nameStatusOutput),
+      "changedFiles/adjacentCode membership must be identical regardless of ambient diff.renames",
+    );
+    // Locks in that the rename WAS detected (not a D+A pair) in both cases.
+    assert.deepEqual(parseChangedFiles(defaultCapture.nameStatusOutput), ["src/renamed.mjs"]);
+  } finally {
+    await rm(defaultRepo, { recursive: true, force: true });
+    await rm(contraryRepo, { recursive: true, force: true });
+  }
+});
+
 test("buildGateContext with an empty diffOutput leaves diffPath null but still builds changedFiles + adjacentCode, and (programmatic) omits diffSource", async () => {
   // Downstream proof of the best-effort split at the LIBRARY layer: an empty
   // diffOutput (what a failed full-diff capture returns) leaves diffPath null


### PR DESCRIPTION
## Objective

`captureDiffFromBase` in `scripts/github/write-gate-context.mjs` already pins `-c` overrides (color/pager/prefix/ext-diff) so the persisted `--base` neutral diff seed is byte-identical *within a single run*. That guarantee does not extend across machines/environments: an operator or CI box with a contrary `diff.renames`/`diff.algorithm`/`diff.context`/`core.abbrev`/`core.autocrlf` gitconfig can still produce different persisted diff bytes (and, via `diff.renames`, a different `scope.changedFiles`/`adjacentCode` membership) for the identical base/HEAD pair. This closes that gap by extending the isolation argv to pin those settings too.

## In scope

- Extend the isolation `-c` overrides in `captureDiffFromBase` with `diff.renames=true`, `diff.algorithm=myers`, `diff.context=3`, `core.abbrev=12`, `core.autocrlf=false`, keeping the existing overrides and `--no-ext-diff`.
- Document (in the existing comment) that `diff.renames` also affects `scope.changedFiles`/`adjacentCode` membership (rename `R` pair vs delete+add `D`+`A` pair in `--name-status`), not just diff-body bytes.
- Add a regression test asserting that a fixture repo with a CONTRARY local config (`diff.renames=false`, `diff.algorithm=histogram`, `diff.context=1`) still produces byte-identical persisted diff output and `changedFiles` compared to the default-config case for the same change.

## Explicit non-goals

- No change to the fail-closed/best-effort split posture of `captureDiffFromBase` (name-status stays fail-closed, full diff stays best-effort).
- No change to the CLI argument surface, artifact schema, or any other gate-context behavior.
- No attempt to pin every conceivable git diff-affecting config (e.g. `core.whitespace`, `diff.wsErrorHighlight`) — only the five settings named in scope.

## Acceptance criteria

- `captureDiffFromBase`'s isolation argv includes `-c diff.renames=true -c diff.algorithm=myers -c diff.context=3 -c core.abbrev=12 -c core.autocrlf=false` in addition to the existing overrides.
- The inline comment explains that `diff.renames` additionally affects `scope.changedFiles`/`adjacentCode` membership, not only diff-body bytes.
- A new test builds the same repo change twice — once with default config, once with a repo-local CONTRARY config (`diff.renames=false`, `diff.algorithm=histogram`, `diff.context=1`) — and asserts the persisted diff bytes and parsed `changedFiles` are identical between the two runs.
- All existing tests in `test/github/write-gate-context.test.mjs` remain green.

## Definition of done

- Code change implemented and reviewed.
- New contrary-config regression test added and passing alongside the full existing suite.
- `npm run verify` passes.
- No behavior change to any other CLI flag, artifact field, or the fail-closed/best-effort split.

## Open questions / risks

- Pinning `core.abbrev=12` fixes the persisted abbreviated blob-id length; if a future consumer parses `index <sha>..<sha>` lines from the diff for anything beyond display, this value should stay in sync with any such parser (none currently exists).
- `diff.algorithm=myers` is git's long-standing default; pinning it explicitly protects against a future git default change (e.g. to `histogram`) silently altering hunk-splitting across environments.
