### PR TITLE
fix(worktree): provision the @dev-loops/core workspace link (#1144)

### DIFF
--- a/scripts/loop/provision-worktree.mjs
+++ b/scripts/loop/provision-worktree.mjs
@@ -12,6 +12,15 @@
  * - Idempotent: skips a dest that is already correct.
  * - Does NOT run npm install (deps belong to `npm ci`-in-worktree).
  *
+ * Also (unconditionally, independent of .devloops): links the workspace
+ * package node_modules/@dev-loops/core -> ../../packages/core (relative,
+ * pointing at the WORKTREE's own packages/core). Without npm install/ci in a
+ * fresh worktree there is no node_modules at all, so scripts/**'s
+ * `@dev-loops/core` imports resolve UP-TREE to the nearest ancestor
+ * node_modules (the main checkout's) — silently testing main's core instead
+ * of the branch's (#1144). Stale/broken links are replaced; a real file/dir
+ * already occupying the slot is left alone (dest-conflict, never clobbered).
+ *
  * Prints a JSON summary of actions to stdout. Never throws on a per-entry
  * problem; exits 0 unless its own arguments are invalid.
  */
@@ -161,6 +170,40 @@ async function provisionLink(src, dest, logWarn) {
   return { mode: "link", src, dest };
 }
 
+/**
+ * Ensure node_modules/@dev-loops/core -> ../../packages/core (relative) in the
+ * worktree, pointing at the worktree's OWN packages/core — never the main
+ * checkout's (#1144). Idempotent: a correct link is a no-op; a stale/broken
+ * link is replaced; a real file/dir at the dest is a dest-conflict skip
+ * (never clobbered). node_modules is gitignored repo-wide, so this link is
+ * always untracked.
+ */
+async function ensureCoreWorkspaceLink(worktreePath, logWarn) {
+  const corePkgDir = path.join(worktreePath, "packages", "core");
+  const scopeDir = path.join(worktreePath, "node_modules", "@dev-loops");
+  const linkPath = path.join(scopeDir, "core");
+
+  if (!(await pathExists(corePkgDir))) {
+    logWarn(`workspace self-link source missing, skipping: ${corePkgDir}`);
+    return { mode: "skip", reason: "source-missing", src: corePkgDir, dest: linkPath };
+  }
+
+  const existing = await fsp.readlink(linkPath).catch(() => null);
+  if (existing !== null) {
+    if (path.resolve(path.dirname(linkPath), existing) === corePkgDir) {
+      return { mode: "skip", reason: "exists", src: corePkgDir, dest: linkPath };
+    }
+    await fsp.rm(linkPath, { force: true }); // stale/broken target — replace below
+  } else if (await pathExists(linkPath)) {
+    logWarn(`workspace self-link dest conflict (not a symlink), skipping: ${linkPath}`);
+    return { mode: "skip", reason: "dest-conflict", src: corePkgDir, dest: linkPath };
+  }
+
+  await fsp.mkdir(scopeDir, { recursive: true });
+  await fsp.symlink(path.relative(scopeDir, corePkgDir), linkPath);
+  return { mode: "link", src: corePkgDir, dest: linkPath };
+}
+
 export async function provisionWorktree({ worktreePath, repoRoot }, { loadConfig = loadDevLoopConfig } = {}) {
   const root = path.resolve(repoRoot);
   const dst = path.resolve(worktreePath);
@@ -218,6 +261,23 @@ export async function provisionWorktree({ worktreePath, repoRoot }, { loadConfig
         }
       }
     }
+  }
+
+  // Unconditional (not driven by .devloops, still applies under a fail-closed
+  // empty config) — the worktree's own package resolution is a structural
+  // need, not an opt-in copy/link entry.
+  try {
+    const selfLink = await ensureCoreWorkspaceLink(dst, logWarn);
+    actions.push({ entry: "node_modules/@dev-loops/core", ...selfLink });
+  } catch (err) {
+    const msg = (err && err.message) ? err.message : String(err);
+    logWarn(`workspace self-link failed, skipping: ${msg}`);
+    actions.push({
+      entry: "node_modules/@dev-loops/core",
+      mode: "skip",
+      reason: `link-failed: ${msg}`,
+      dest: path.join(dst, "node_modules", "@dev-loops", "core"),
+    });
   }
 
   const summary = { copied: 0, linked: 0, skipped: 0, rejected: 0, warnings: warnings.length };

--- a/scripts/loop/provision-worktree.mjs
+++ b/scripts/loop/provision-worktree.mjs
@@ -188,19 +188,24 @@ async function ensureCoreWorkspaceLink(worktreePath, logWarn) {
     return { mode: "skip", reason: "source-missing", src: corePkgDir, dest: linkPath };
   }
 
+  const relTarget = path.relative(scopeDir, corePkgDir);
   const existing = await fsp.readlink(linkPath).catch(() => null);
   if (existing !== null) {
-    if (path.resolve(path.dirname(linkPath), existing) === corePkgDir) {
+    // Only the exact RELATIVE target is idempotent. An absolute (or otherwise
+    // differently-spelled) link that happens to resolve correctly is
+    // normalized to the relative form — absolute links break when the
+    // worktree moves under tmp/.
+    if (existing === relTarget) {
       return { mode: "skip", reason: "exists", src: corePkgDir, dest: linkPath };
     }
-    await fsp.rm(linkPath, { force: true }); // stale/broken target — replace below
+    await fsp.rm(linkPath, { force: true }); // stale/absolute/broken — replace below
   } else if (await pathExists(linkPath)) {
     logWarn(`workspace self-link dest conflict (not a symlink), skipping: ${linkPath}`);
     return { mode: "skip", reason: "dest-conflict", src: corePkgDir, dest: linkPath };
   }
 
   await fsp.mkdir(scopeDir, { recursive: true });
-  await fsp.symlink(path.relative(scopeDir, corePkgDir), linkPath);
+  await fsp.symlink(relTarget, linkPath);
   return { mode: "link", src: corePkgDir, dest: linkPath };
 }
 
@@ -276,6 +281,7 @@ export async function provisionWorktree({ worktreePath, repoRoot }, { loadConfig
       entry: "node_modules/@dev-loops/core",
       mode: "skip",
       reason: `link-failed: ${msg}`,
+      src: path.join(dst, "packages", "core"),
       dest: path.join(dst, "node_modules", "@dev-loops", "core"),
     });
   }

--- a/test/loop/ensure-worktree.test.mjs
+++ b/test/loop/ensure-worktree.test.mjs
@@ -146,6 +146,83 @@ test("ensure: reuses an existing branch when no worktree occupies it", async () 
 });
 
 // ---------------------------------------------------------------------------
+// Workspace self-link (#1144): node_modules/@dev-loops/core resolves to the
+// fresh worktree's OWN packages/core, not the main checkout's — and the link
+// stays untracked (git-ignored).
+// ---------------------------------------------------------------------------
+
+test("ensure: node_modules/@dev-loops/core resolves to the worktree's OWN packages/core, untracked", async () => {
+  const repo = makeRepo();
+  try {
+    // A tracked packages/core in main — git worktree add checks out its own
+    // on-disk copy, so main's and the worktree's copies are distinct
+    // directories even though both are tracked at the same path.
+    mkdirSync(path.join(repo.root, "packages/core/src"), { recursive: true });
+    writeFileSync(path.join(repo.root, "packages/core/package.json"), '{"name":"@dev-loops/core"}\n');
+    writeFileSync(path.join(repo.root, ".gitignore"), "node_modules/\n");
+    repo.git("add", "-A");
+    repo.git("commit", "-q", "-m", "add packages/core");
+    repo.git("fetch", "-q", "origin");
+
+    const res = await ensureWorktree({ repoRoot: repo.root, issue: 1144, base: "origin/main" });
+    assert.equal(res.ok, true);
+
+    const linkPath = path.join(res.path, "node_modules/@dev-loops/core");
+    assert.ok(existsSync(linkPath), "self-link exists");
+    const { realpathSync, lstatSync } = await import("node:fs");
+    assert.ok(lstatSync(linkPath).isSymbolicLink());
+    assert.equal(
+      realpathSync(linkPath),
+      realpathSync(path.join(res.path, "packages/core")),
+      "resolves to the worktree's OWN packages/core",
+    );
+    assert.notEqual(
+      realpathSync(linkPath),
+      realpathSync(path.join(repo.root, "packages/core")),
+      "must NOT resolve to the main checkout's packages/core",
+    );
+
+    // Untracked: node_modules is gitignored repo-wide (asserted, not changed).
+    const ignored = repo.git("-C", res.path, "check-ignore", "-q", "node_modules/@dev-loops/core");
+    // execFileSync throws on non-zero exit; reaching here means exit 0 (ignored).
+    assert.equal(ignored, "");
+    const statusInWorktree = execFileSync("git", ["status", "--porcelain"], {
+      cwd: res.path,
+      encoding: "utf8",
+    });
+    assert.ok(
+      !statusInWorktree.includes("node_modules"),
+      `node_modules must not show up in git status, got: ${statusInWorktree}`,
+    );
+  } finally {
+    repo.cleanup();
+  }
+});
+
+test("ensure: workspace self-link survives re-provisioning an existing worktree (idempotent)", async () => {
+  const repo = makeRepo();
+  try {
+    mkdirSync(path.join(repo.root, "packages/core"), { recursive: true });
+    writeFileSync(path.join(repo.root, "packages/core/package.json"), '{"name":"@dev-loops/core"}\n');
+    repo.git("add", "-A");
+    repo.git("commit", "-q", "-m", "add packages/core");
+    repo.git("fetch", "-q", "origin");
+
+    const first = await ensureWorktree({ repoRoot: repo.root, issue: 42, base: "origin/main" });
+    const linkPath = path.join(first.path, "node_modules/@dev-loops/core");
+    assert.ok(existsSync(linkPath));
+
+    // Re-provision (reuse path) must not fail and must keep the link valid.
+    const second = await ensureWorktree({ repoRoot: repo.root, issue: 42, base: "origin/main" });
+    assert.equal(second.reused, true);
+    const { realpathSync } = await import("node:fs");
+    assert.equal(realpathSync(linkPath), realpathSync(path.join(second.path, "packages/core")));
+  } finally {
+    repo.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
 // Provisioning is invoked (injected core) and fails soft
 // ---------------------------------------------------------------------------
 

--- a/test/loop/provision-worktree.test.mjs
+++ b/test/loop/provision-worktree.test.mjs
@@ -294,6 +294,33 @@ test("provision: workspace self-link is idempotent on re-provision", async () =>
     const secondAction = second.actions.find((a) => a.entry === "node_modules/@dev-loops/core");
     assert.equal(secondAction.mode, "skip");
     assert.equal(secondAction.reason, "exists");
+    // skip/exists is only granted for the exact relative target form.
+    assert.equal(
+      readlinkSync(path.join(fx.worktreePath, "node_modules/@dev-loops/core")),
+      path.join("..", "..", "packages", "core"),
+    );
+  } finally {
+    fx.cleanup();
+  }
+});
+
+test("provision: normalizes an absolute-but-correct pre-existing link to relative", async () => {
+  const fx = makeFixture("version: 1\n");
+  try {
+    mkdirSync(path.join(fx.worktreePath, "packages/core"), { recursive: true });
+    // Absolute link that resolves to the CORRECT dir — still not the required
+    // relative form, so it must be replaced (reported as link, not skip/exists).
+    const scopeDir = path.join(fx.worktreePath, "node_modules/@dev-loops");
+    mkdirSync(scopeDir, { recursive: true });
+    symlinkSync(path.join(fx.worktreePath, "packages/core"), path.join(scopeDir, "core"));
+
+    const res = await provisionWorktree({ worktreePath: fx.worktreePath, repoRoot: fx.repoRoot });
+    const action = res.actions.find((a) => a.entry === "node_modules/@dev-loops/core");
+    assert.equal(action.mode, "link");
+
+    const dest = path.join(fx.worktreePath, "node_modules/@dev-loops/core");
+    assert.equal(readlinkSync(dest), path.join("..", "..", "packages", "core"));
+    assert.equal(realpathSync(dest), realpathSync(path.join(fx.worktreePath, "packages/core")));
   } finally {
     fx.cleanup();
   }

--- a/test/loop/provision-worktree.test.mjs
+++ b/test/loop/provision-worktree.test.mjs
@@ -1,6 +1,17 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, lstatSync, readlinkSync, existsSync, symlinkSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  lstatSync,
+  readlinkSync,
+  existsSync,
+  symlinkSync,
+  realpathSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -175,10 +186,12 @@ test("provision: rejects a source that is a symlink escaping the main checkout",
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// Fail-closed: a config with load/validation errors yields zero actions
+// Fail-closed: a config with load/validation errors yields zero CONFIG-DRIVEN
+// actions. The workspace self-link (#1144) is unconditional — a structural
+// need, not a config-driven copy/link entry — so it still runs.
 // ---------------------------------------------------------------------------
 
-test("provision: config with errors yields zero provisioning actions (fail-closed)", async () => {
+test("provision: config with errors yields zero config-driven actions (fail-closed)", async () => {
   const fx = makeFixture("version: 1\nworktree:\n  copyOnInit:\n    - config/app.yml\n");
   try {
     // A real, present source — proves the EMPTY treatment is driven by the
@@ -196,7 +209,10 @@ test("provision: config with errors yields zero provisioning actions (fail-close
       { loadConfig },
     );
     assert.equal(res.ok, true);
-    assert.equal(res.actions.length, 0);
+    // Only the unconditional self-link action remains (this fixture has no
+    // packages/core in the worktree, so it's a source-missing skip).
+    assert.equal(res.actions.length, 1);
+    assert.equal(res.actions[0].entry, "node_modules/@dev-loops/core");
     assert.equal(res.summary.copied, 0);
     assert.equal(res.summary.linked, 0);
     assert.ok(res.summary.warnings >= 1, "one WARN about the invalid config");
@@ -239,6 +255,104 @@ test("provision: a per-entry copy failure is recorded as skip and does not throw
   }
 });
 
+// ---------------------------------------------------------------------------
+// Workspace self-link: node_modules/@dev-loops/core -> worktree's OWN
+// packages/core (#1144) — unconditional, independent of .devloops entries.
+// ---------------------------------------------------------------------------
+
+test("provision: links node_modules/@dev-loops/core to the worktree's OWN packages/core", async () => {
+  const fx = makeFixture("version: 1\n");
+  try {
+    mkdirSync(path.join(fx.worktreePath, "packages/core"), { recursive: true });
+    writeFileSync(path.join(fx.worktreePath, "packages/core/index.mjs"), "export const x = 1;\n");
+
+    const res = await provisionWorktree({ worktreePath: fx.worktreePath, repoRoot: fx.repoRoot });
+    const action = res.actions.find((a) => a.entry === "node_modules/@dev-loops/core");
+    assert.ok(action, `expected a self-link action, got ${JSON.stringify(res.actions)}`);
+    assert.equal(action.mode, "link");
+
+    const dest = path.join(fx.worktreePath, "node_modules/@dev-loops/core");
+    assert.ok(lstatSync(dest).isSymbolicLink());
+    assert.ok(!path.isAbsolute(readlinkSync(dest)), "expected a relative symlink target");
+    // Resolves to the worktree's OWN packages/core, not the main checkout's.
+    assert.equal(realpathSync(dest), realpathSync(path.join(fx.worktreePath, "packages/core")));
+  } finally {
+    fx.cleanup();
+  }
+});
+
+test("provision: workspace self-link is idempotent on re-provision", async () => {
+  const fx = makeFixture("version: 1\n");
+  try {
+    mkdirSync(path.join(fx.worktreePath, "packages/core"), { recursive: true });
+
+    const first = await provisionWorktree({ worktreePath: fx.worktreePath, repoRoot: fx.repoRoot });
+    const firstAction = first.actions.find((a) => a.entry === "node_modules/@dev-loops/core");
+    assert.equal(firstAction.mode, "link");
+
+    const second = await provisionWorktree({ worktreePath: fx.worktreePath, repoRoot: fx.repoRoot });
+    const secondAction = second.actions.find((a) => a.entry === "node_modules/@dev-loops/core");
+    assert.equal(secondAction.mode, "skip");
+    assert.equal(secondAction.reason, "exists");
+  } finally {
+    fx.cleanup();
+  }
+});
+
+test("provision: workspace self-link replaces a stale/broken symlink", async () => {
+  const fx = makeFixture("version: 1\n");
+  try {
+    mkdirSync(path.join(fx.worktreePath, "packages/core"), { recursive: true });
+    // Simulate the up-tree bug: an existing link pointing at some OTHER core
+    // (e.g. the main checkout's), which must be replaced, not left in place.
+    const scopeDir = path.join(fx.worktreePath, "node_modules/@dev-loops");
+    mkdirSync(scopeDir, { recursive: true });
+    const staleTarget = path.join(fx.repoRoot, "packages/core"); // does not even exist — broken too
+    symlinkSync(staleTarget, path.join(scopeDir, "core"));
+
+    const res = await provisionWorktree({ worktreePath: fx.worktreePath, repoRoot: fx.repoRoot });
+    const action = res.actions.find((a) => a.entry === "node_modules/@dev-loops/core");
+    assert.equal(action.mode, "link");
+
+    const dest = path.join(fx.worktreePath, "node_modules/@dev-loops/core");
+    assert.equal(realpathSync(dest), realpathSync(path.join(fx.worktreePath, "packages/core")));
+  } finally {
+    fx.cleanup();
+  }
+});
+
+test("provision: workspace self-link never clobbers a real dir/file at the dest", async () => {
+  const fx = makeFixture("version: 1\n");
+  try {
+    mkdirSync(path.join(fx.worktreePath, "packages/core"), { recursive: true });
+    const scopeDir = path.join(fx.worktreePath, "node_modules/@dev-loops");
+    mkdirSync(path.join(scopeDir, "core"), { recursive: true });
+    writeFileSync(path.join(scopeDir, "core/marker.txt"), "not a symlink");
+
+    const res = await provisionWorktree({ worktreePath: fx.worktreePath, repoRoot: fx.repoRoot });
+    const action = res.actions.find((a) => a.entry === "node_modules/@dev-loops/core");
+    assert.equal(action.mode, "skip");
+    assert.equal(action.reason, "dest-conflict");
+    assert.ok(existsSync(path.join(scopeDir, "core/marker.txt")), "real dest left untouched");
+  } finally {
+    fx.cleanup();
+  }
+});
+
+test("provision: workspace self-link fails soft when the worktree has no packages/core", async () => {
+  const fx = makeFixture("version: 1\n");
+  try {
+    // No packages/core created in the worktree at all.
+    const res = await provisionWorktree({ worktreePath: fx.worktreePath, repoRoot: fx.repoRoot });
+    const action = res.actions.find((a) => a.entry === "node_modules/@dev-loops/core");
+    assert.equal(action.mode, "skip");
+    assert.equal(action.reason, "source-missing");
+    assert.ok(!existsSync(path.join(fx.worktreePath, "node_modules")));
+  } finally {
+    fx.cleanup();
+  }
+});
+
 test("provision: idempotent on reuse (second run skips)", async () => {
   const fx = makeFixture("version: 1\nworktree:\n  copyOnInit:\n    - config/app.yml\n  linkOnInit:\n    - data/big\n");
   try {
@@ -253,7 +367,9 @@ test("provision: idempotent on reuse (second run skips)", async () => {
     const second = await provisionWorktree({ worktreePath: fx.worktreePath, repoRoot: fx.repoRoot });
     assert.equal(second.summary.copied, 0);
     assert.equal(second.summary.linked, 0);
-    assert.equal(second.summary.skipped, 2);
+    // 2 config-driven entries (exists) + the workspace self-link (this fixture
+    // has no packages/core, so it's a source-missing skip on both runs).
+    assert.equal(second.summary.skipped, 3);
   } finally {
     fx.cleanup();
   }


### PR DESCRIPTION
## Objective

Worktrees provisioned by `ensure-worktree.mjs` / `provision-worktree.mjs` have no
`node_modules` (no `npm ci` runs during provisioning). Any `scripts/**` CLI that
imports `@dev-loops/core` resolves the bare specifier by walking UP the directory
tree, so it silently finds the MAIN checkout's `node_modules/@dev-loops/core`
instead of the worktree's own `packages/core`. Local `npm run verify` in a
worktree therefore tests main's core, not the branch's — this masked a real
regression on PR #1142, and the operator manually created the symlink by hand
roughly 15 times this session. This change makes provisioning create that link
automatically so every fresh (and reused) worktree resolves `@dev-loops/core` to
its own `packages/core`.

## In scope

- `provisionWorktree()` (`scripts/loop/provision-worktree.mjs`) gains an
  unconditional step (independent of `.devloops` `copyOnInit`/`linkOnInit`
  config) that ensures `node_modules/@dev-loops/core` is a relative symlink to
  `../../packages/core` inside the worktree being provisioned — the worktree's
  OWN `packages/core`, never the main checkout's.
- The step is idempotent: a correct existing link is a no-op; a stale or
  broken link is replaced; a real file/dir already at the destination is left
  untouched (`dest-conflict`, never clobbered); a worktree with no
  `packages/core` yet is a fail-soft `source-missing` skip.
- The action is reported in the existing provisioning `actions`/`summary`
  shape (`copied`/`linked`/`skipped`/`rejected`/`warnings` counts), tagged with
  `entry: "node_modules/@dev-loops/core"`.
- Tests in `test/loop/provision-worktree.test.mjs` (unit) and
  `test/loop/ensure-worktree.test.mjs` (integration, real git worktrees)
  covering: fresh link creation + realpath resolves to the worktree's own
  `packages/core` (not main's), idempotent re-provision, stale-link
  replacement, dest-conflict non-clobber, missing-source fail-soft, and that
  the link stays untracked (`git check-ignore`, `git status --porcelain`).

## Explicit non-goals

- Does not run `npm install`/`npm ci` in the worktree — deps still belong to
  that separate step, unchanged from the existing header contract.
- Does not change `.gitignore` — `node_modules/` is already gitignored
  repo-wide; this is asserted in tests, not modified.
- Does not generalize to other workspace packages — only `@dev-loops/core` is
  linked, since it's the only workspace package `scripts/**` imports today.
  Extending to future workspace packages is a separate change if/when needed.
- Does not touch `cleanup-worktree.mjs` or the `.devloops`
  `copyOnInit`/`linkOnInit` config-driven mechanism itself.

## Acceptance criteria

- A freshly provisioned worktree has `node_modules/@dev-loops/core` as a
  symlink whose realpath equals the worktree's own `packages/core` (not the
  main checkout's), verified via `fs.realpathSync`.
- Re-provisioning an existing worktree (the `reused: true` path in
  `ensureWorktree`) does not throw and leaves the link correctly resolved.
- A stale/broken pre-existing link at that path is replaced, not left in
  place.
- A real file/directory already occupying `node_modules/@dev-loops/core` is
  never deleted or overwritten (`dest-conflict` skip).
- The link is reported in `provision.summary` using the existing
  `copied`/`linked`/`skipped`/`rejected`/`warnings` shape.
- `git check-ignore` / `git status --porcelain` confirm the link is untracked.

## Definition of done

- `provision-worktree.mjs` implements the self-link step described above.
- `test/loop/provision-worktree.test.mjs` and `test/loop/ensure-worktree.test.mjs`
  cover creation, idempotency, stale-link replacement, dest-conflict, and
  missing-source fail-soft, plus the untracked/gitignored assertion.
- `npm run verify` is green in this worktree (validated with the same
  self-link manually applied here, since this worktree predates the fix).
- No unrequested changes to `.gitignore`, `cleanup-worktree.mjs`, or the
  config-driven `copyOnInit`/`linkOnInit` mechanism.

## Open questions / risks

- This worktree (`issue-1144`) itself was provisioned before this fix
  existed, so it has no `node_modules` of its own; the same symlink was
  created here by hand to validate `npm run verify` — once this change lands,
  new worktrees no longer need that manual step.
- If a future workspace package beyond `@dev-loops/core` needs the same
  treatment, this single-package special case should be revisited (e.g.
  driven by `package.json` `workspaces` enumeration) rather than growing a
  second hardcoded entry — out of scope here per YAGNI.
