### PR TITLE
fix(gates): self-explaining merge-block for evidence+merge compound commands (#1172)

### DIFF
--- a/.claude/hooks/_hook-decisions.mjs
+++ b/.claude/hooks/_hook-decisions.mjs
@@ -34,6 +34,16 @@ import {
 const ALLOW = Object.freeze({ decision: "allow" });
 
 /**
+ * Whether the command string also invokes an evidence-writing script (findings-log ledger or
+ * checkpoint-verdict upsert). Used only to enrich the merge-block message (#1172) — a compound
+ * command combining an evidence write with `gh pr merge` is blocked pre-execution, so the write
+ * never runs; this substring check has no false-negative cost (worst case: the plain message).
+ */
+function commandContainsEvidenceWrite(command) {
+  return command.includes("write-gate-findings-log") || command.includes("upsert-checkpoint-verdict");
+}
+
+/**
  * The agent type (Claude `agent_type` / the canonical agent name) that owns repo mutations.
  * Only this subagent — not arbitrary subagents (Explore, Plan, generic Task agents) — may
  * bypass the main-agent read-only boundary.
@@ -176,11 +186,25 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
   }
 
   if (!gatePassed) {
+    if (isMerge) {
+      // This hook evaluates PreToolUse — BEFORE the Bash tool call runs. A compound command that
+      // writes gate evidence (findings-log ledger, checkpoint verdict) and merges in the same call
+      // is blocked here with the write never having executed, which looks like the evidence
+      // "vanished" (#1172). Hint the split when the command carries an evidence-writing invocation
+      // alongside the merge, so the failure is self-explaining instead of looking like data loss.
+      const alsoWritesEvidence = commandContainsEvidenceWrite(command);
+      return {
+        decision: "deny",
+        reason:
+          `gh pr merge blocked: missing pre-merge gate evidence for PR #${prNumber} (need clean current-head draft_gate + pre_approval_gate; inline verdicts are not accepted). Run the dev-loop gates instead of merging directly.` +
+          (alsoWritesEvidence
+            ? " This command also writes gate evidence, but hooks evaluate before the command runs — write the evidence in a separate call, then merge alone."
+            : ""),
+      };
+    }
     return {
       decision: "deny",
-      reason: isMerge
-        ? `gh pr merge blocked: missing pre-merge gate evidence for PR #${prNumber} (need clean current-head draft_gate + pre_approval_gate; inline verdicts are not accepted). Run the dev-loop gates instead of merging directly.`
-        : `gh pr ready blocked: no visible clean draft_gate checkpoint verdict comment found for PR #${prNumber}.`,
+      reason: `gh pr ready blocked: no visible clean draft_gate checkpoint verdict comment found for PR #${prNumber}.`,
     };
   }
 

--- a/.claude/skills/docs/merge-preconditions.md
+++ b/.claude/skills/docs/merge-preconditions.md
@@ -49,6 +49,20 @@ doing manually; it is not a general conflict-resolution engine.
 
 > Runner-coordination lock: the pre-merge evidence check fails closed on a stale/foreign runner claim for the PR. A completing run releases its claim best-effort at every terminal stop (including the human approval checkpoint), so a merge re-dispatch normally proceeds. If a lock held by a completed/dead run still blocks the merge, take it over explicitly with `node <resolved-skill-scripts>/loop/pr-runner-coordination.mjs takeover --repo <owner/name> --pr <number>`. Never take over a genuinely active (non-stale) run — that fail-closed block is intentional.
 
+### Evidence writes and `gh pr merge` MUST be separate tool calls (#1172)
+
+The PreToolUse Bash gate evaluates `gh pr merge` **before** the Bash tool call executes. A compound
+command that both writes gate evidence (the findings-log ledger, `upsert-checkpoint-verdict`) and
+merges in the same call is blocked at hook-evaluation time — the write never runs. This can look
+like the ledger "vanished" between writing and merging; it was never written. The block message
+names this when it detects an evidence-writing invocation in the same command string.
+
+Documented pattern — **write, verify, then merge alone**:
+
+1. Write the gate evidence (findings-log ledger / checkpoint verdict) in its own Bash call.
+2. Verify it landed (e.g. `ls tmp/gate-findings/<slug>/pr-<n>/`) in a separate call.
+3. Run `gh pr merge` alone, with no other command chained via `&&`/`;`/newline.
+
 ## Title markers
 
 The PR title is a contract surface, so a merge-blocking marker in the title is enforced

--- a/packages/core/src/claude/hook-decisions.mjs
+++ b/packages/core/src/claude/hook-decisions.mjs
@@ -33,6 +33,16 @@ import {
 const ALLOW = Object.freeze({ decision: "allow" });
 
 /**
+ * Whether the command string also invokes an evidence-writing script (findings-log ledger or
+ * checkpoint-verdict upsert). Used only to enrich the merge-block message (#1172) — a compound
+ * command combining an evidence write with `gh pr merge` is blocked pre-execution, so the write
+ * never runs; this substring check has no false-negative cost (worst case: the plain message).
+ */
+function commandContainsEvidenceWrite(command) {
+  return command.includes("write-gate-findings-log") || command.includes("upsert-checkpoint-verdict");
+}
+
+/**
  * The agent type (Claude `agent_type` / the canonical agent name) that owns repo mutations.
  * Only this subagent — not arbitrary subagents (Explore, Plan, generic Task agents) — may
  * bypass the main-agent read-only boundary.
@@ -175,11 +185,25 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
   }
 
   if (!gatePassed) {
+    if (isMerge) {
+      // This hook evaluates PreToolUse — BEFORE the Bash tool call runs. A compound command that
+      // writes gate evidence (findings-log ledger, checkpoint verdict) and merges in the same call
+      // is blocked here with the write never having executed, which looks like the evidence
+      // "vanished" (#1172). Hint the split when the command carries an evidence-writing invocation
+      // alongside the merge, so the failure is self-explaining instead of looking like data loss.
+      const alsoWritesEvidence = commandContainsEvidenceWrite(command);
+      return {
+        decision: "deny",
+        reason:
+          `gh pr merge blocked: missing pre-merge gate evidence for PR #${prNumber} (need clean current-head draft_gate + pre_approval_gate; inline verdicts are not accepted). Run the dev-loop gates instead of merging directly.` +
+          (alsoWritesEvidence
+            ? " This command also writes gate evidence, but hooks evaluate before the command runs — write the evidence in a separate call, then merge alone."
+            : ""),
+      };
+    }
     return {
       decision: "deny",
-      reason: isMerge
-        ? `gh pr merge blocked: missing pre-merge gate evidence for PR #${prNumber} (need clean current-head draft_gate + pre_approval_gate; inline verdicts are not accepted). Run the dev-loop gates instead of merging directly.`
-        : `gh pr ready blocked: no visible clean draft_gate checkpoint verdict comment found for PR #${prNumber}.`,
+      reason: `gh pr ready blocked: no visible clean draft_gate checkpoint verdict comment found for PR #${prNumber}.`,
     };
   }
 

--- a/packages/core/test/claude-hook-decisions.test.mjs
+++ b/packages/core/test/claude-hook-decisions.test.mjs
@@ -31,6 +31,34 @@ test("decideBashGate denies ungated gh pr merge in the target repo", () => {
   assert.match(d.reason, /#1/);
 });
 
+// #1172: PreToolUse blocks pre-execution, so a compound write+merge command never runs the write —
+// the ledger looks like it "vanished". Hint the split when the command also writes gate evidence.
+test("decideBashGate hints the write/merge split when the compound command also writes gate evidence", () => {
+  const d = decideBashGate({
+    command: "node scripts/loop/write-gate-findings-log.mjs --pr 1 && gh pr merge 1 --squash",
+    repoSlug: TARGET,
+    gatePassed: false,
+  });
+  assert.equal(d.decision, "deny");
+  assert.match(d.reason, /gh pr merge blocked/);
+  assert.match(d.reason, /hooks evaluate before the command runs/);
+
+  const d2 = decideBashGate({
+    command: "node scripts/github/upsert-checkpoint-verdict.mjs --pr 1 && gh pr merge 1",
+    repoSlug: TARGET,
+    gatePassed: false,
+  });
+  assert.equal(d2.decision, "deny");
+  assert.match(d2.reason, /hooks evaluate before the command runs/);
+});
+
+test("decideBashGate keeps the standard message for a bare gh pr merge (no evidence write)", () => {
+  const d = decideBashGate({ command: "gh pr merge 1 --squash", repoSlug: TARGET, gatePassed: false });
+  assert.equal(d.decision, "deny");
+  assert.match(d.reason, /gh pr merge blocked/);
+  assert.doesNotMatch(d.reason, /hooks evaluate before the command runs/);
+});
+
 test("decideBashGate allows gh pr merge when pre-merge evidence passed", () => {
   assert.equal(
     decideBashGate({ command: "gh pr merge 1 --squash", repoSlug: TARGET, gatePassed: true }).decision,

--- a/skills/docs/merge-preconditions.md
+++ b/skills/docs/merge-preconditions.md
@@ -49,6 +49,20 @@ doing manually; it is not a general conflict-resolution engine.
 
 > Runner-coordination lock: the pre-merge evidence check fails closed on a stale/foreign runner claim for the PR. A completing run releases its claim best-effort at every terminal stop (including the human approval checkpoint), so a merge re-dispatch normally proceeds. If a lock held by a completed/dead run still blocks the merge, take it over explicitly with `node <resolved-skill-scripts>/loop/pr-runner-coordination.mjs takeover --repo <owner/name> --pr <number>`. Never take over a genuinely active (non-stale) run — that fail-closed block is intentional.
 
+### Evidence writes and `gh pr merge` MUST be separate tool calls (#1172)
+
+The PreToolUse Bash gate evaluates `gh pr merge` **before** the Bash tool call executes. A compound
+command that both writes gate evidence (the findings-log ledger, `upsert-checkpoint-verdict`) and
+merges in the same call is blocked at hook-evaluation time — the write never runs. This can look
+like the ledger "vanished" between writing and merging; it was never written. The block message
+names this when it detects an evidence-writing invocation in the same command string.
+
+Documented pattern — **write, verify, then merge alone**:
+
+1. Write the gate evidence (findings-log ledger / checkpoint verdict) in its own Bash call.
+2. Verify it landed (e.g. `ls tmp/gate-findings/<slug>/pr-<n>/`) in a separate call.
+3. Run `gh pr merge` alone, with no other command chained via `&&`/`;`/newline.
+
 ## Title markers
 
 The PR title is a contract surface, so a merge-blocking marker in the title is enforced


### PR DESCRIPTION
## Objective / why

The "vanishing" `pre_approval_gate` findings-log ledgers (and `--findings-json` sidecars) reported
on PRs #1167/#1169/#1171 were never deleted by a sweeper. Root cause (confirmed live on PR #1173,
see issue #1172 root-cause comment): the PreToolUse Bash gate evaluates `gh pr merge` **before**
the Bash tool call executes, so a compound command that both writes gate evidence and merges in
the same call is blocked at hook time — the write never runs. The evidence never existed; it
wasn't swept. This PR makes that failure self-explaining instead of looking like data loss.

## In scope

- Extend the `decideBashGate` merge-block message: when the blocked command also invokes an
  evidence-writing script (`write-gate-findings-log` / `upsert-checkpoint-verdict`) alongside
  `gh pr merge`, append a hint that hooks evaluate before the command runs and the write must be
  a separate call.
- Regression test at the hook-decision unit level: a compound write+merge command gets the hinted
  message; a bare `gh pr merge` keeps the standard message.
- Document the contract in `skills/docs/merge-preconditions.md`: gate-evidence writes and
  `gh pr merge` MUST be separate tool calls, with the write → verify (`ls`) → merge-alone sequence
  as the canonical pattern. Mirror regenerated via `scripts/claude/generate-claude-assets.mjs`.

## Explicit non-goals

- Changing the fail-closed pre-merge check itself — it correctly caught the missing evidence
  every time; this PR only improves the diagnostic message and docs.
- Stopping any "sweeper" — root-cause diagnosis (see issue #1172 root-cause comment) shows there is
  no sweeper deleting gate-evidence files; the original "stop sweeping" acceptance criterion is
  resolved by this diagnosis, not by code that stops a sweep.
- The separate, still-open session-scratchpad / sidecar-file purging behavior noted in the
  root-cause comment as unexplained — out of scope for this PR.

## Acceptance criteria

- [ ] `decideBashGate` appends the write/merge-split hint only when the blocked `gh pr merge`
      command also contains `write-gate-findings-log` or `upsert-checkpoint-verdict`.
- [ ] A bare `gh pr merge` (no evidence-write invocation) keeps the original, unhinted message.
- [ ] `packages/core/test/claude-hook-decisions.test.mjs` covers both cases and passes.
- [ ] `skills/docs/merge-preconditions.md` documents the write → verify → merge-alone contract;
      `.claude/skills/docs/merge-preconditions.md` mirror matches (generator run, no manual edits
      to the generated `.claude/` copy).

## Definition of done

- `npm run verify` green.
- Generated `.claude/hooks/_hook-decisions.mjs` and `.claude/skills/docs/merge-preconditions.md`
  regenerated via `scripts/claude/generate-claude-assets.mjs`, not hand-edited.
- PR body validated with `node scripts/loop/validate-pr-body-spec.mjs` (`ok: true`).

## Open questions / risks

- None — this is a message/doc/test-only change; it does not alter any gate decision boundary
  (a command that was allowed/denied before is still allowed/denied identically; only the deny
  `reason` string is enriched in one specific case).

Closes #1172
