### PR TITLE
fix(gates): fail closed on a pending Copilot review at the round cap (#1165)

### DIFF
--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -614,6 +614,63 @@ test("interpretLoopState (handoff baseline) and evaluatePrGateCoordination (dete
   assert(gateResult.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
 });
 
+// Parity (#1165 — in-flight-rerequest race): the SAME snapshot at the cap, clean,
+// but with a Copilot review REQUESTED and pending on the CURRENT head (a
+// --force-rerequest in flight) plus a significant post-convergence change. Both
+// authorities must gate pre_approval_gate until the fresh review lands.
+//
+// Note the interpreter (handoff's base) deliberately routes a pending at-cap
+// request to ROUND_CAP_CLEAN_FALLBACK — it cannot see significance (that needs gh
+// compare I/O). copilot-pr-handoff.mjs therefore flips this to
+// waiting_for_copilot_review when a review is pending on the current head (proven
+// by the "in-flight force-rerequest" integration tests). detect's evaluator, fed
+// the shared significant-change signal, forbids run_pre_approval_gate here. Both
+// gate pre-approval — no divergence.
+test("interpretLoopState (handoff) and evaluatePrGateCoordination (detect) both gate pre_approval with a pending review + significant change at the cap (#1165)", () => {
+  const refinementConfig = { maxCopilotRounds: 2 };
+  const snapshot = {
+    prExists: true,
+    prNumber: 503,
+    // Force-rerequest in flight: Copilot review is requested and pending on the current head.
+    copilotReviewRequestStatus: "requested",
+    copilotReviewPresent: true,
+    copilotReviewOnCurrentHead: false,
+    unresolvedThreadCount: 0,
+    actionableThreadCount: 0,
+    copilotReviewRoundCount: 2, // == cap
+    ciStatus: "success",
+  };
+
+  // handoff's base interpretation: the interpreter ignores the pending at-cap
+  // request and resolves the clean fallback. runHandoff flips this to
+  // waiting_for_copilot_review (integration tests) so it never proceeds.
+  const handoffInterpretation = interpretLoopState(snapshot, refinementConfig);
+  assert.equal(handoffInterpretation.state, STATE.ROUND_CAP_CLEAN_FALLBACK);
+
+  // detect's path with the shared significant-change signal = true.
+  const gateResult = evaluatePrGateCoordination({
+    pr: 503,
+    currentHeadSha: "cafef00dbeef",
+    prDraft: false,
+    lifecycleState: handoffInterpretation.state,
+    loopDisposition: DISPOSITION.CLEAN_CONVERGED,
+    sameHeadCleanConverged: handoffInterpretation.sameHeadCleanConverged,
+    ciStatus: snapshot.ciStatus,
+    copilotReviewRoundCount: snapshot.copilotReviewRoundCount,
+    maxCopilotRounds: refinementConfig.maxCopilotRounds,
+    postConvergenceSignificantChange: true,
+    draftGate: gate({ visible: true, headSha: "cafef00", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "cafef00", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  // Both gate pre-approval: detect forbids run_pre_approval_gate outright; handoff
+  // waits for the pending review (never advancing to pre_approval).
+  assert.equal(gateResult.nextAction, PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW);
+  assert(gateResult.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+});
+
 test("missing ciStatus fails closed to wait_for_ci instead of reopening gate progression", () => {
   const result = evaluatePrGateCoordination({
     pr: 266,

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -462,24 +462,26 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
   // In-flight-rerequest race (#1165): the interpreter routes to
   // ROUND_CAP_CLEAN_FALLBACK even when a Copilot review is REQUESTED and pending
   // on the current head, because at the cap it treats any assignment as a stale
-  // leftover (copilot-loop-state.mjs). But a request pending on THIS head means a
-  // fresh review is genuinely coming (e.g. a force-rerequest for a significant
-  // post-convergence change). Proceeding to pre_approval_gate would skip that
-  // review — the exact gate-integrity gap #1126 closes — and
+  // leftover (copilot-loop-state.mjs). An in-flight request is usually a fresh
+  // review genuinely coming (e.g. a force-rerequest for a significant
+  // post-convergence change) — but it can also be a stale at-cap assignment
+  // mislabeled as requested, as detect-copilot-loop-state.mjs's own fallback
+  // notes. Proceeding to pre_approval_gate on a real in-flight review would skip
+  // it — the exact gate-integrity gap #1126 closes — and
   // detect-pr-gate-coordination-state gates pre-approval here. The reopen escape
   // hatch below can only recover the wait verdict via a SECOND, fail-silent gh
   // fetch (fetchReopenCycleFacts) whose failure/compare-miss silently drops back
   // to "proceed", diverging from detect (which reused already-validated facts).
-  // Fail closed instead: while a review is pending on the current head, wait for
-  // it to land rather than stop. If it never lands, a --watch-status refresh
+  // Fail closed instead: while the in-flight evidence stands, wait for it to
+  // resolve rather than stop. If it never lands, a --watch-status refresh
   // (which skips this branch) re-resolves to the clean fallback, so this never
   // dead-ends the loop.
-  const reviewPendingOnCurrentHead = snapshot.copilotReviewRequestStatus === "requested"
+  const reviewRequestInFlight = snapshot.copilotReviewRequestStatus === "requested"
     || snapshot.copilotReviewRequestStatus === "already-requested";
   if (!internalOnlySkipCopilot
       && options.watchStatus === undefined
       && interpretation.state === STATE.ROUND_CAP_CLEAN_FALLBACK
-      && reviewPendingOnCurrentHead) {
+      && reviewRequestInFlight) {
     interpretation = {
       ...interpretation,
       state: STATE.WAITING_FOR_COPILOT_REVIEW,

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -459,6 +459,36 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh" 
     }
   }
 
+  // In-flight-rerequest race (#1165): the interpreter routes to
+  // ROUND_CAP_CLEAN_FALLBACK even when a Copilot review is REQUESTED and pending
+  // on the current head, because at the cap it treats any assignment as a stale
+  // leftover (copilot-loop-state.mjs). But a request pending on THIS head means a
+  // fresh review is genuinely coming (e.g. a force-rerequest for a significant
+  // post-convergence change). Proceeding to pre_approval_gate would skip that
+  // review — the exact gate-integrity gap #1126 closes — and
+  // detect-pr-gate-coordination-state gates pre-approval here. The reopen escape
+  // hatch below can only recover the wait verdict via a SECOND, fail-silent gh
+  // fetch (fetchReopenCycleFacts) whose failure/compare-miss silently drops back
+  // to "proceed", diverging from detect (which reused already-validated facts).
+  // Fail closed instead: while a review is pending on the current head, wait for
+  // it to land rather than stop. If it never lands, a --watch-status refresh
+  // (which skips this branch) re-resolves to the clean fallback, so this never
+  // dead-ends the loop.
+  const reviewPendingOnCurrentHead = snapshot.copilotReviewRequestStatus === "requested"
+    || snapshot.copilotReviewRequestStatus === "already-requested";
+  if (!internalOnlySkipCopilot
+      && options.watchStatus === undefined
+      && interpretation.state === STATE.ROUND_CAP_CLEAN_FALLBACK
+      && reviewPendingOnCurrentHead) {
+    interpretation = {
+      ...interpretation,
+      state: STATE.WAITING_FOR_COPILOT_REVIEW,
+      nextAction: NEXT_ACTIONS[STATE.WAITING_FOR_COPILOT_REVIEW],
+      allowedTransitions: [...(TRANSITIONS[STATE.WAITING_FOR_COPILOT_REVIEW] || [])],
+      roundCapCleanEligible: false,
+    };
+  }
+
   // Round-cap escape hatch (#1103, #1126): the interpreter resolves
   // ROUND_CAP_CLEAN_FALLBACK (stop, no re-request) at the cap. But when a
   // SIGNIFICANT post-convergence change (new product/test-logic since the last

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -1494,7 +1494,10 @@ test("copilot-pr-handoff waits for the pending Copilot review (in-flight force-r
       { assertArgs: ["api", "graphql"], stdout: EMPTY_THREADS + "\n" },
       { assertArgs: ["api", "repos/owner/repo/commits/newsha/check-runs?per_page=100"], stdout: '{"check_runs":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n' },
       { assertArgs: ["api", "repos/owner/repo/commits/newsha/status?per_page=100"], stdout: '{"statuses":[]}\n' },
-      // The request is newer than any submitted review → pending on the current head.
+      // CAP_REVIEWS are all on older heads (oldsha-N), so there's no submitted Copilot
+      // review on the current head — copilotReviewRequestStatus resolves to "requested"
+      // via the no-submitted-review branch, never reaching the timeline timestamp
+      // comparison. Stub kept (unclaimed) in case that derivation path changes.
       { assertArgs: ["api", "repos/owner/repo/issues/17/timeline"], stdout: JSON.stringify({ login: "Copilot", created_at: "2026-06-03T00:00:00Z" }) + "\n" },
     ], { matchMode: "claims" });
     env.DEVLOOPS_RUN_ID = "";

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -1469,6 +1469,100 @@ test("copilot-pr-handoff stays at round_cap_clean_fallback when the last reviewe
   }
 });
 
+// #1165 (in-flight-rerequest race): at the round cap with all threads clean and
+// a Copilot review REQUESTED and pending on the current head (a --force-rerequest
+// in flight for a significant post-convergence change), handoff must surface
+// waiting_for_copilot_review — NOT round_cap_clean_fallback. Proceeding to
+// pre_approval_gate would skip the pending review; detect-pr-gate-coordination-state
+// gates pre-approval here, so both authorities now gate until the review lands.
+test("copilot-pr-handoff waits for the pending Copilot review (in-flight force-rerequest) instead of the clean fallback (#1165)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-inflight-rerequest-"));
+
+  try {
+    const { env } = await writeGhStubHelper(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: JSON.stringify({
+          isDraft: false, state: "OPEN", number: 17, headRefOid: "newsha",
+          reviews: CAP_REVIEWS,
+          statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+        }) + "\n",
+      },
+      // Copilot IS present in requested_reviewers — a force-rerequest is in flight
+      // and its review has not yet landed on the current head.
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n' },
+      { assertArgs: ["api", "graphql"], stdout: EMPTY_THREADS + "\n" },
+      { assertArgs: ["api", "repos/owner/repo/commits/newsha/check-runs?per_page=100"], stdout: '{"check_runs":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n' },
+      { assertArgs: ["api", "repos/owner/repo/commits/newsha/status?per_page=100"], stdout: '{"statuses":[]}\n' },
+      // The request is newer than any submitted review → pending on the current head.
+      { assertArgs: ["api", "repos/owner/repo/issues/17/timeline"], stdout: JSON.stringify([{ login: "Copilot", created_at: "2026-06-03T00:00:00Z" }]) + "\n" },
+    ], { matchMode: "claims" });
+    env.DEVLOOPS_RUN_ID = "";
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    // Pending review on the current head → wait, never proceed to pre_approval.
+    assert.equal(output.action, "watch");
+    assert.equal(output.state, "waiting_for_copilot_review");
+    assert.equal(output.roundCapCleanEligible, false);
+    assert.equal(output.terminal, false);
+    assert.ok(output.watchArgs, "expected watchArgs while waiting for the pending review");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+// #1165 (fail-closed reconciliation): the SAME in-flight state, but handoff's
+// secondary escape-hatch fetch (fetchReopenCycleFacts / gh compare) fails — the
+// exact production shape where handoff previously dropped to round_cap_clean_fallback
+// (proceed) while detect-pr-gate-coordination-state, reusing its already-validated
+// facts, gated pre-approval. Handoff must still WAIT (fail closed on the pending
+// request), never skip the review.
+test("copilot-pr-handoff waits (fail closed) when a review is pending and the escape-hatch fetch fails (#1165)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-inflight-failclosed-"));
+
+  try {
+    const { env } = await writeGhStubHelper(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: JSON.stringify({
+          isDraft: false, state: "OPEN", number: 17, headRefOid: "newsha",
+          reviews: CAP_REVIEWS,
+          statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+        }) + "\n",
+      },
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n' },
+      { assertArgs: ["api", "graphql"], stdout: EMPTY_THREADS + "\n" },
+      { assertArgs: ["api", "repos/owner/repo/commits/newsha/check-runs?per_page=100"], stdout: '{"check_runs":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n' },
+      { assertArgs: ["api", "repos/owner/repo/commits/newsha/status?per_page=100"], stdout: '{"statuses":[]}\n' },
+      { assertArgs: ["api", "repos/owner/repo/issues/17/timeline"], stdout: JSON.stringify([{ login: "Copilot", created_at: "2026-06-03T00:00:00Z" }]) + "\n" },
+      // Escape-hatch fetch fails — significance cannot be positively determined.
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,reviews,files"], stdout: "", stderr: "boom", exitCode: 1 },
+    ], { matchMode: "claims" });
+    env.DEVLOOPS_RUN_ID = "";
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    // The pending-request guard fires before the fragile escape-hatch fetch, so a
+    // fetch failure can no longer silently downgrade to "proceed".
+    assert.equal(output.action, "watch");
+    assert.equal(output.state, "waiting_for_copilot_review");
+    assert.equal(output.roundCapCleanEligible, false);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Handoff: unresolved feedback → fix
 // ---------------------------------------------------------------------------

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -1495,7 +1495,7 @@ test("copilot-pr-handoff waits for the pending Copilot review (in-flight force-r
       { assertArgs: ["api", "repos/owner/repo/commits/newsha/check-runs?per_page=100"], stdout: '{"check_runs":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n' },
       { assertArgs: ["api", "repos/owner/repo/commits/newsha/status?per_page=100"], stdout: '{"statuses":[]}\n' },
       // The request is newer than any submitted review → pending on the current head.
-      { assertArgs: ["api", "repos/owner/repo/issues/17/timeline"], stdout: JSON.stringify([{ login: "Copilot", created_at: "2026-06-03T00:00:00Z" }]) + "\n" },
+      { assertArgs: ["api", "repos/owner/repo/issues/17/timeline"], stdout: JSON.stringify({ login: "Copilot", created_at: "2026-06-03T00:00:00Z" }) + "\n" },
     ], { matchMode: "claims" });
     env.DEVLOOPS_RUN_ID = "";
 
@@ -1540,7 +1540,7 @@ test("copilot-pr-handoff waits (fail closed) when a review is pending and the es
       { assertArgs: ["api", "graphql"], stdout: EMPTY_THREADS + "\n" },
       { assertArgs: ["api", "repos/owner/repo/commits/newsha/check-runs?per_page=100"], stdout: '{"check_runs":[{"status":"COMPLETED","conclusion":"SUCCESS","name":"ci"}]}\n' },
       { assertArgs: ["api", "repos/owner/repo/commits/newsha/status?per_page=100"], stdout: '{"statuses":[]}\n' },
-      { assertArgs: ["api", "repos/owner/repo/issues/17/timeline"], stdout: JSON.stringify([{ login: "Copilot", created_at: "2026-06-03T00:00:00Z" }]) + "\n" },
+      { assertArgs: ["api", "repos/owner/repo/issues/17/timeline"], stdout: JSON.stringify({ login: "Copilot", created_at: "2026-06-03T00:00:00Z" }) + "\n" },
       // Escape-hatch fetch fails — significance cannot be positively determined.
       { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,reviews,files"], stdout: "", stderr: "boom", exitCode: 1 },
     ], { matchMode: "claims" });


### PR DESCRIPTION
Closes #1165

## Objective

`copilot-pr-handoff` and `detect-pr-gate-coordination-state` returned disagreeing
next-actions for the same PR/head at the round cap (PR #1164, head `52d87052`,
cap = 2): detect gated pre-approval (`post_draft_external_review`,
`rerequest_copilot_review`, forbidding `run_pre_approval_gate`) while handoff
reported `round_cap_clean_fallback` (stop, "continue to pre_approval_gate"). The
loop follows handoff as the pre-flight authority, so acting on it alone would have
skipped Copilot's review of a significant change — the exact gate-integrity gap
#1126 was meant to close. Copilot's review then landed with 2 real findings,
confirming detect was right to gate.

### Root cause (evidence)

The three hypotheses were traced in code and reproduced against a stubbed `gh`:

- Given identical facts, the shared `detectPostConvergenceSignificantChange` returns
  the same verdict at both call sites, so a significant change already reconciles:
  handoff flips `round_cap_clean_fallback` → `waiting_for_copilot_review` via the
  `#1103/#1126` escape hatch. Confirmed by reproduction.
- The divergence is the **in-flight-rerequest race (hypothesis 3), realized through
  hypothesis 2's fail-silent secondary fetch**. When a `--force-rerequest-review` is
  pending on the current head, the interpreter routes to `ROUND_CAP_CLEAN_FALLBACK`
  anyway — it treats any at-cap request as a stale assignment
  (`copilot-loop-state.mjs`) and cannot see significance (that needs `gh compare`
  I/O). Handoff's ONLY recovery is the escape hatch, which depends on a SECOND,
  fail-silent `gh pr view` (`fetchReopenCycleFacts`) plus a `gh compare`. When that
  extra fetch (or the compare) fails, significance silently reads false and handoff
  drops back to "proceed", while `detect-pr-gate-coordination-state` — reusing its
  already-validated `prData` for the same compare — computes significance true and
  gates. Reproduced deterministically: pending request on the current head +
  escape-hatch fetch failure previously yielded `round_cap_clean_fallback`.

### Fix

Handoff now fails closed on a pending review: while a Copilot review is requested
and pending on the current head at the round cap, it surfaces
`waiting_for_copilot_review` (action `watch`) instead of `round_cap_clean_fallback`.
The guard runs before the fragile escape-hatch fetch, so a fetch/compare failure can
no longer silently downgrade to "proceed". A `--watch-status` refresh still skips
this branch, so a request that never resolves re-settles to the clean fallback and
the loop never dead-ends. Both authorities now gate pre-approval until the fresh
review lands.

## In scope

- `scripts/loop/copilot-pr-handoff.mjs`: pending-review-on-current-head guard at the
  round cap.
- Parity/regression tests extending the #1126 coverage with the in-flight /
  review-pending case.

## Explicit non-goals

- No change to the base cap semantics, the #1103 escape hatch, or #1137's
  content-aware significance classifier.
- No change to `detect-pr-gate-coordination-state` or the core evaluator; detect
  already gates on the shared significant-change signal.
- No new distributed coordination between the two separate invocations.

## Acceptance criteria

- [ ] Root cause identified with a reproducing test (in-flight rerequest race via
  the fail-silent secondary fetch).
- [ ] Handoff and detect return reconciled guidance for the same (repo, PR, head) at
  the cap with a pending review + significant change — both gate pre-approval.
- [ ] Handoff surfaces `waiting_for_copilot_review` (not `round_cap_clean_fallback`)
  while a requested review is pending on the current head.
- [ ] Parity tests extend the #1126 coverage with the force-rerequest-in-flight /
  review-pending case driving both paths.

## Definition of done

- [ ] `packages/core/test/pr-gate-coordination.test.mjs` and
  `test/loop/copilot-pr-handoff.test.mjs` cover the reconciliation and pass.
- [ ] Existing #1103 / #1126 / #1137 tests stay green.
- [ ] `npm run verify` is green.

## Open questions / risks

- A genuinely stale at-cap assignment mislabeled "requested" would cause one extra
  wait cycle; the `--watch-status` refresh path re-settles it to the clean fallback,
  so the loop cannot dead-end. Low risk, safe direction (fail closed never skips a
  review).
