### PR TITLE
fix(gates): light-mode-aware pre-merge gate accepts scoped inline verdicts (#1174)

### DIFF
--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -323,6 +323,33 @@ resolved-in SHA (for findings resolved in a later pass).
 Each gate verdict records an `executionMode` (`fanout_fanin` or `inline_single_agent`,
 default `inline_single_agent`) via the [Gate comment command](../skills/copilot-pr-followup/SKILL.md#mandatory-gate-comment-command-contract); inline runs must declare an `--inline-reason`. A `fanout_fanin` verdict passes the structured per-angle review results via `--findings-json` (the per-angle `{angle, verdict, findings}` artifacts that feed `consolidateFanin`, or the flat `toFindingsLogShape` output grouped by `.angle`) so the comment renders a per-angle breakdown; `--findings-summary` is the inline_single_agent fallback only. Fan-out evidence enforcement is **ON by default** (`gates.requireFanoutEvidence`): a clean gate verdict requires the gate to run via `--execution-mode fanout_fanin` with a findings-log ledger for the head SHA, and the pre-merge evidence check fails closed for a required gate otherwise. Repos can opt out with `gates.requireFanoutEvidence: false`. Live context-builder/fan-out execution (epic #867) is what makes `fanout_fanin` producible — distinct from this contract's own sub-loop phase numbering (preamble / fanout / fanin).
 
+### Light-mode inline acceptance (under-threshold micro-PRs)
+
+`lightMode` (`localImplementation.lightMode`, #1043) collapses the gate fan-out to a
+single `inline_single_agent` check for genuinely small changes. Because
+`requireFanoutEvidence` otherwise rejects any non-`fanout_fanin` verdict, the pre-merge
+evidence check (`buildPreMergeGateCheck` in `detect-checkpoint-evidence.mjs`) is
+**light-mode-aware** (#1174): it accepts a required gate's `inline_single_agent` verdict
+**only** when **all** of the following hold, and **fails closed** on any one that does
+not — leaving today's rejection byte-identical:
+
+- `localImplementation.lightMode.enabled` is `true` in config;
+- the reviewed head's scope is **re-derived fail-closed** at merge time — the merge-base
+  diff (`git diff <base>...<head>`, the same scope resolution `resolve-gate-dispatch`
+  uses) is genuinely under the configured `maxFiles`/`maxLines`. If scope cannot be
+  derived (missing base ref, git failure), the inline verdict is rejected;
+- the PR carries **no `gate:full` label** (the label always forces the full fan-out —
+  scope is not even measured);
+- the verdict records a non-empty `--inline-reason`.
+
+Evidence retention stays uniform: a light-accepted inline verdict **still requires a
+findings-log ledger** for the reviewed head (the single-agent path's
+`write-gate-findings-log.mjs` writes it). `requireFanoutProvenance`, when enabled, is
+enforced **only for `fanout_fanin` verdicts** — a light inline verdict is already
+scope-bounded and carries no multi-reviewer provenance, so it is exempt. Any inline
+verdict that is over threshold, labelled `gate:full`, produced while `lightMode` is
+disabled, or whose scope is underivable remains rejected exactly as before.
+
 ### Fan-out provenance (closing the self-produced-artifact loophole)
 
 `requireFanoutEvidence` is artifact-based: it only proves a `fanout_fanin` verdict

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -14,8 +14,9 @@ import path from "node:path";
 import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
-import { FANOUT_PROVENANCE_MIN_REVIEWERS, loadDevLoopConfig, resolveGateConfig, resolveRequireFanoutEvidence, resolveRequireFanoutProvenance } from "@dev-loops/core/config";
+import { FANOUT_PROVENANCE_MIN_REVIEWERS, GATE_FULL_LABEL, loadDevLoopConfig, resolveGateConfig, resolveLightMode, resolveRequireFanoutEvidence, resolveRequireFanoutProvenance } from "@dev-loops/core/config";
 import { FANOUT_UNAVAILABLE_MESSAGE, provenanceConsistencyError } from "@dev-loops/core/loop/gate-fanin";
+import { detectMergeBaseScope, isEligibleForLightMode } from "../loop/detect-change-scope.mjs";
 import { buildLogPath } from "./write-gate-findings-log.mjs";
 import { ensureAsyncRunnerOwnership } from "../loop/_pr-runner-coordination.mjs";
 import { detectStaleRunner } from "../loop/_stale-runner-detection.mjs";
@@ -256,7 +257,24 @@ export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null, s
   // { required: false, gates: [] } so the `.required` guard skips this block.
   if (fanoutEnforcement && fanoutEnforcement.required) {
     for (const gate of fanoutEnforcement.gates) {
-      if (gate.executionMode !== "fanout_fanin") {
+      // Light-mode acceptance (#1174): a genuinely under-threshold micro-PR
+      // collapses the gate fan-out to a single inline check (#1043). Accept that
+      // inline verdict ONLY when ALL hold, fail CLOSED otherwise:
+      //   - lightMode is enabled in config, AND
+      //   - the reviewed head's merge-base scope was RE-DERIVED under threshold
+      //     (scopeUnderThreshold; false whenever scope could not be derived), AND
+      //   - the PR carries no gate:full label (which always forces fan-out), AND
+      //   - the verdict records a non-empty inline reason.
+      // Any non-light inline verdict (over threshold / label / lightMode off /
+      // scope underivable) falls through to the byte-identical rejection below.
+      const lightAccepted =
+        gate.executionMode === "inline_single_agent"
+        && fanoutEnforcement.lightMode === true
+        && fanoutEnforcement.hasFullLabel !== true
+        && gate.scopeUnderThreshold === true
+        && typeof gate.inlineReason === "string"
+        && gate.inlineReason.trim().length > 0;
+      if (gate.executionMode !== "fanout_fanin" && !lightAccepted) {
         failures.push(
           `${gate.name}: requireFanoutEvidence is enabled but executionMode is "${gate.executionMode ?? "unset"}" (expected "fanout_fanin"); inline gate verdicts are not accepted`,
         );
@@ -274,7 +292,11 @@ export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null, s
       // fanout_fanin ledger must record INTERNALLY-CONSISTENT provenance (checked
       // the same way the write path validates it — a hand-edited or shadow ledger
       // is re-validated here, not trusted) with distinctReviewers >= the floor.
-      if (fanoutEnforcement.requireProvenance) {
+      // Provenance is enforced ONLY for fanout_fanin verdicts (#1174): a
+      // light-accepted inline verdict is already scope-bounded and has no
+      // multi-reviewer provenance to record, so requiring it would make the
+      // light path unmergeable — the inverse of this issue's fix.
+      if (fanoutEnforcement.requireProvenance && gate.executionMode === "fanout_fanin") {
         const prov = gate.provenance;
         const consistencyErr = provenanceConsistencyError(prov);
         const reviewers = prov && Number.isInteger(prov.distinctReviewers) ? prov.distinctReviewers : null;
@@ -368,7 +390,7 @@ async function readLedgerProvenanceInAny(checkouts, ledgerPath) {
  * reviewed head SHA so the pre-merge check can fail closed on inline verdicts or
  * missing ledgers.
  */
-export async function buildFanoutEnforcement({ repo, pr, currentHeadSha, draftGateMarker, preApprovalGateMarker, config, cwd }) {
+export async function buildFanoutEnforcement({ repo, pr, currentHeadSha, draftGateMarker, preApprovalGateMarker, config, cwd, hasFullLabel = false, baseRef = null }) {
   // Fail open when config could not be loaded/validated. `== null` covers both
   // null and undefined; the loader only ever yields null on failure, but the
   // loose check defensively treats an absent config as unavailable.
@@ -381,6 +403,12 @@ export async function buildFanoutEnforcement({ repo, pr, currentHeadSha, draftGa
   // Provenance enforcement is opt-in and layered ON TOP of fan-out evidence: it
   // only takes effect while evidence enforcement (above) is active.
   const requireProvenance = resolveRequireFanoutProvenance(config);
+  // Light-mode facts (#1174): the threshold that a re-derived merge-base scope
+  // must fall under for an inline verdict to be accepted. null when lightMode is
+  // disabled → no inline verdict can ever be accepted (scopeUnderThreshold stays
+  // false), preserving today's rejection.
+  const lightThreshold = resolveLightMode(config);
+  const lightMode = lightThreshold != null;
   const draftRequired = resolveGateConfig(config, "draft").required;
   const preApprovalRequired = resolveGateConfig(config, "preApproval").required;
   const gateSpecs = [
@@ -389,18 +417,31 @@ export async function buildFanoutEnforcement({ repo, pr, currentHeadSha, draftGa
   ].filter((spec) => spec.required && spec.marker.visible);
   const gates = [];
   const checkouts = resolveLedgerCheckouts(cwd);
+  const repoRoot = resolveRepoRoot(cwd);
   for (const spec of gateSpecs) {
     const headSha = spec.marker.headSha ?? currentHeadSha;
     const ledgerPath = buildLogPath({ repo, pr, gate: spec.name, headSha, tmpRoot: "tmp" });
+    // Re-derive scope FAIL-CLOSED for inline verdicts only (the fan-out default
+    // path pays no git I/O). scopeUnderThreshold is true ONLY when lightMode is
+    // on, the PR has no gate:full label, a base ref is known, and the merge-base
+    // diff for the reviewed head is genuinely under threshold. Any git/scope
+    // failure leaves it false, so the inline verdict is rejected exactly as today.
+    let scopeUnderThreshold = false;
+    if (lightMode && !hasFullLabel && baseRef && spec.marker.executionMode === "inline_single_agent") {
+      const scope = detectMergeBaseScope({ base: baseRef, head: headSha, cwd: repoRoot });
+      scopeUnderThreshold = scope.ok === true && isEligibleForLightMode(scope, lightThreshold);
+    }
     gates.push({
       name: spec.name,
       executionMode: spec.marker.executionMode ?? null,
+      inlineReason: spec.marker.inlineReason ?? null,
+      scopeUnderThreshold,
       ledgerPath,
       ledgerExists: await ledgerExistsInAny(checkouts, ledgerPath),
       provenance: requireProvenance ? await readLedgerProvenanceInAny(checkouts, ledgerPath) : null,
     });
   }
-  return { required: true, requireProvenance, gates };
+  return { required: true, requireProvenance, lightMode, hasFullLabel, gates };
 }
 export async function detectCheckpointEvidence(options, { env = process.env, ghCommand = "gh", cwd = process.cwd() } = {}) {
   const runnerOwnership = await ensureAsyncRunnerOwnership({
@@ -457,6 +498,29 @@ export async function detectCheckpointEvidence(options, { env = process.env, ghC
   let config = null;
   const { config: loadedConfig, errors: configErrors } = await loadDevLoopConfig({ repoRoot: resolveRepoRoot(cwd) });
   config = Array.isArray(configErrors) && configErrors.length > 0 ? null : loadedConfig;
+  // Light-mode pre-merge facts (#1174): the base commit for the merge-base scope
+  // re-derivation and whether the PR forces full fan-out via the gate:full label.
+  // Fetched LAZILY — only when fan-out enforcement is active AND lightMode is on
+  // AND a gate actually recorded an inline verdict — so the common fan-out path
+  // (and every existing caller/test) makes NO extra gh call and stays unchanged.
+  let baseRef = null;
+  let hasFullLabel = false;
+  const anyInlineVerdict = [draftGateMarker, preApprovalGateMarker].some(
+    (marker) => marker.visible && marker.executionMode === "inline_single_agent",
+  );
+  if (config != null && resolveRequireFanoutEvidence(config) && resolveLightMode(config) != null && anyInlineVerdict) {
+    try {
+      const lightFacts = await runGhJson(["pr", "view", String(options.pr), "--repo", options.repo, "--json", "baseRefOid,labels"], { env, ghCommand });
+      baseRef = typeof lightFacts?.baseRefOid === "string" && lightFacts.baseRefOid.trim().length > 0
+        ? lightFacts.baseRefOid.trim()
+        : null;
+      hasFullLabel = Array.isArray(lightFacts?.labels)
+        && lightFacts.labels.some((label) => (typeof label === "string" ? label : label?.name) === GATE_FULL_LABEL);
+    } catch {
+      // Fail CLOSED: without the label/base facts we cannot safely accept an
+      // inline verdict, so leave baseRef null (scope underivable → rejected).
+    }
+  }
   const fanoutEnforcement = await buildFanoutEnforcement({
     repo: options.repo,
     pr: options.pr,
@@ -465,6 +529,8 @@ export async function detectCheckpointEvidence(options, { env = process.env, ghC
     preApprovalGateMarker,
     config,
     cwd,
+    hasFullLabel,
+    baseRef,
   });
   return {
     ok: true,

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -385,10 +385,20 @@ async function readLedgerProvenanceInAny(checkouts, ledgerPath) {
  * Enforcement is ON by default (opt-out via gates.requireFanoutEvidence: false).
  * Returns { required: false } when enforcement is disabled OR when config is
  * unavailable (config == null — null or undefined — after a failed load) — config-unavailable must
- * fail open and never enable enforcement. When enabled, records per-required-gate
- * executionMode and whether the deterministic findings-log ledger exists for the
- * reviewed head SHA so the pre-merge check can fail closed on inline verdicts or
- * missing ledgers.
+ * fail open and never enable enforcement. When enabled, returns
+ * { required: true, requireProvenance, lightMode, hasFullLabel, gates } where
+ * each per-required-gate entry records executionMode, inlineReason,
+ * scopeUnderThreshold, and whether the deterministic findings-log ledger exists
+ * for the reviewed head SHA, so the pre-merge check can fail closed on inline
+ * verdicts or missing ledgers.
+ *
+ * Light mode (#1174): when gates.lightMode is configured, `hasFullLabel`
+ * (gate:full PR label) and `baseRef` feed a fail-closed merge-base scope
+ * re-derivation for inline verdicts. A gate's scopeUnderThreshold is true only
+ * when light mode is on, the PR has no gate:full label, a base ref is known,
+ * and the reviewed head's merge-base diff is genuinely under threshold — which
+ * lets the pre-merge check accept an inline single-agent verdict for a
+ * small-scope PR instead of always rejecting inline evidence.
  */
 export async function buildFanoutEnforcement({ repo, pr, currentHeadSha, draftGateMarker, preApprovalGateMarker, config, cwd, hasFullLabel = false, baseRef = null }) {
   // Fail open when config could not be loaded/validated. `== null` covers both

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -417,7 +417,10 @@ export async function buildFanoutEnforcement({ repo, pr, currentHeadSha, draftGa
   ].filter((spec) => spec.required && spec.marker.visible);
   const gates = [];
   const checkouts = resolveLedgerCheckouts(cwd);
-  const repoRoot = resolveRepoRoot(cwd);
+  // checkouts[0] is always resolveRepoRoot(cwd) (resolveLedgerCheckouts adds it
+  // first, unconditionally, and never throws — it falls back to cwd on git
+  // failure) — reuse it instead of a second `git rev-parse --show-toplevel`.
+  const repoRoot = checkouts[0];
   for (const spec of gateSpecs) {
     const headSha = spec.marker.headSha ?? currentHeadSha;
     const ledgerPath = buildLogPath({ repo, pr, gate: spec.name, headSha, tmpRoot: "tmp" });

--- a/scripts/loop/detect-change-scope.mjs
+++ b/scripts/loop/detect-change-scope.mjs
@@ -96,6 +96,27 @@ function detectScope({ base, head } = {}) {
 function isEligibleForLightMode(scope, threshold) {
   return scope.filesChanged <= threshold.maxFiles && scope.linesChanged <= threshold.maxLines;
 }
+/**
+ * Detect change scope for the merge-base diff between `base` and `head` (the
+ * three-dot `base...head` diff git resolves against merge-base(base, head)).
+ *
+ * Fails CLOSED: a missing base/head, or any git failure, returns `{ ok: false }`
+ * so callers that gate on scope (e.g. the light-mode pre-merge acceptance) reject
+ * rather than silently treating an unmeasurable diff as under threshold. Reuses
+ * the same `parseGitDiffStat` scope resolution as `detectScope`.
+ */
+function detectMergeBaseScope({ base, head, cwd } = {}) {
+  if (!base || !head) {
+    return { ok: false, filesChanged: 0, linesChanged: 0, error: "base and head are required for merge-base scope detection" };
+  }
+  let output;
+  try {
+    output = execFileSync("git", ["diff", "--stat", `${base}...${head}`], { encoding: "utf8", maxBuffer: 1_000_000, cwd: cwd || undefined });
+  } catch (err) {
+    return { ok: false, filesChanged: 0, linesChanged: 0, error: err instanceof Error ? err.message : String(err) };
+  }
+  return { ok: true, ...parseGitDiffStat(output) };
+}
 async function main() {
   const opts = parseCliArgs(process.argv.slice(2));
   const scope = detectScope(opts);
@@ -132,4 +153,4 @@ if (isDirectRun) {
     process.exitCode = 1;
   });
 }
-export { detectScope, isEligibleForLightMode };
+export { detectScope, detectMergeBaseScope, isEligibleForLightMode };

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -15,8 +15,12 @@ import {
 import {
   parseDetectCheckpointEvidenceCliArgs,
   buildPreMergeGateCheck,
+  buildFanoutEnforcement,
 } from "../../scripts/github/detect-checkpoint-evidence.mjs";
 import { claimRunnerOwnership } from "../../scripts/loop/_pr-runner-coordination.mjs";
+import { execFileSync } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import { loadDevLoopConfig } from "@dev-loops/core/config";
 
 const scriptPath = path.resolve("scripts/github/detect-checkpoint-evidence.mjs");
 
@@ -1006,6 +1010,209 @@ test("buildPreMergeGateCheck with requireProvenance ON fails closed on a non-int
     result.failures.some((f) => f.includes("distinctReviewers must be a non-negative integer")),
     JSON.stringify(result.failures),
   );
+});
+
+// --- #1174: light-mode-aware pre-merge acceptance of inline verdicts ---------
+// A genuinely under-threshold micro-PR collapses the gate fan-out to a single
+// inline check (#1043). buildPreMergeGateCheck accepts that inline verdict ONLY
+// when lightMode is on, scope was re-derived under threshold, no gate:full label,
+// a ledger exists, and a non-empty inline reason was recorded. Fail closed on any
+// missing precondition — non-light inline verdicts stay byte-identically rejected.
+function lightGate(overrides = {}) {
+  return {
+    name: "pre_approval_gate",
+    executionMode: "inline_single_agent",
+    inlineReason: "under_threshold",
+    scopeUnderThreshold: true,
+    ledgerPath: "tmp/b.json",
+    ledgerExists: true,
+    provenance: null,
+    ...overrides,
+  };
+}
+
+test("buildPreMergeGateCheck (#1174) ACCEPTS a light inline verdict under threshold with reason + ledger", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    lightMode: true,
+    hasFullLabel: false,
+    gates: [lightGate()],
+  });
+  assert.equal(result.ok, true, JSON.stringify(result.failures));
+  assert.deepEqual(result.failures, []);
+});
+
+test("buildPreMergeGateCheck (#1174) REJECTS a light inline verdict when the ledger is missing (evidence retention still uniform)", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    lightMode: true,
+    hasFullLabel: false,
+    gates: [lightGate({ ledgerExists: false, ledgerPath: "tmp/gate-findings/o-r/pr-17/pre_approval_gate-abc1234.json" })],
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.failures.some((f) => f.includes("no findings-log ledger")), JSON.stringify(result.failures));
+});
+
+test("buildPreMergeGateCheck (#1174) REJECTS an over-threshold inline verdict (scope not under threshold)", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    lightMode: true,
+    hasFullLabel: false,
+    gates: [lightGate({ scopeUnderThreshold: false })],
+  });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.failures.some((f) => f.includes("inline_single_agent") && f.includes("requireFanoutEvidence")),
+    JSON.stringify(result.failures),
+  );
+});
+
+test("buildPreMergeGateCheck (#1174) REJECTS an inline verdict when the gate:full label is present", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    lightMode: true,
+    hasFullLabel: true,
+    gates: [lightGate()],
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.failures.some((f) => f.includes("inline_single_agent")), JSON.stringify(result.failures));
+});
+
+test("buildPreMergeGateCheck (#1174) REJECTS an inline verdict when lightMode is disabled", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    lightMode: false,
+    hasFullLabel: false,
+    gates: [lightGate()],
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.failures.some((f) => f.includes("inline_single_agent")), JSON.stringify(result.failures));
+});
+
+test("buildPreMergeGateCheck (#1174) REJECTS an inline verdict with no recorded inline reason", () => {
+  for (const inlineReason of [null, "", "   "]) {
+    const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+      required: true,
+      lightMode: true,
+      hasFullLabel: false,
+      gates: [lightGate({ inlineReason })],
+    });
+    assert.equal(result.ok, false, `inlineReason=${JSON.stringify(inlineReason)}`);
+    assert.ok(result.failures.some((f) => f.includes("inline_single_agent")), JSON.stringify(result.failures));
+  }
+});
+
+test("buildPreMergeGateCheck (#1174) exempts a light inline verdict from requireFanoutProvenance (provenance only enforced for fanout_fanin)", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    requireProvenance: true,
+    lightMode: true,
+    hasFullLabel: false,
+    gates: [lightGate({ provenance: null })],
+  });
+  assert.equal(result.ok, true, JSON.stringify(result.failures));
+  assert.deepEqual(result.failures, []);
+});
+
+test("buildPreMergeGateCheck (#1174) non-regression: fanout gates unaffected by the light keys", () => {
+  // A fanout_fanin gate with lightMode on/off and hasFullLabel present must
+  // behave exactly as before: ledger present => pass, provenance still enforced.
+  const pass = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    lightMode: true,
+    hasFullLabel: true,
+    gates: [
+      { name: "draft_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/a.json", ledgerExists: true },
+      { name: "pre_approval_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/b.json", ledgerExists: true },
+    ],
+  });
+  assert.equal(pass.ok, true, JSON.stringify(pass.failures));
+  const provFail = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    requireProvenance: true,
+    lightMode: true,
+    hasFullLabel: false,
+    gates: [
+      { name: "draft_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/a.json", ledgerExists: true, provenance: { distinctReviewers: 2, perAngle: [{ angle: "scope", reviewer: "review-a" }, { angle: "safety", reviewer: "review-b" }] } },
+      { name: "pre_approval_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/b.json", ledgerExists: true, provenance: null },
+    ],
+  });
+  assert.equal(provFail.ok, false);
+  assert.ok(provFail.failures.some((f) => f.includes("requireFanoutProvenance")), JSON.stringify(provFail.failures));
+});
+
+test("buildFanoutEnforcement (#1174) re-derives scope fail-closed and sets scopeUnderThreshold for light inline verdicts", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-fanout-light-"));
+  try {
+    const g = (...args) => execFileSync("git", args, { cwd: dir, encoding: "utf8" });
+    g("init", "-q");
+    g("config", "user.email", "t@t.t");
+    g("config", "user.name", "t");
+    g("config", "commit.gpgsign", "false");
+    await writeFile(path.join(dir, ".devloops"), "version: 1\ngates:\n  requireFanoutEvidence: true\nlocalImplementation:\n  lightMode:\n    enabled: true\n    maxFiles: 3\n    maxLines: 200\n", "utf8");
+    await writeFile(path.join(dir, "a.txt"), "one\n", "utf8");
+    g("add", "-A");
+    g("commit", "-qm", "base");
+    const baseRef = g("rev-parse", "HEAD").trim();
+    await writeFile(path.join(dir, "a.txt"), "one\ntwo\n", "utf8");
+    g("add", "-A");
+    g("commit", "-qm", "head");
+    const headSha = g("rev-parse", "HEAD").trim();
+
+    // Ledger for the reviewed head so the light path retains evidence uniformly.
+    const ledgerDir = path.join(dir, "tmp", "gate-findings", "owner-repo", "pr-17");
+    await mkdir(ledgerDir, { recursive: true });
+    for (const gate of ["draft_gate", "pre_approval_gate"]) {
+      await writeFile(path.join(ledgerDir, `${gate}-${headSha}.json`), JSON.stringify({ gate, headSha, findings: [] }) + "\n", "utf8");
+    }
+
+    const { config } = await loadDevLoopConfig({ repoRoot: dir });
+    const marker = (headOverride) => ({ visible: true, headSha: headOverride, executionMode: "inline_single_agent", inlineReason: "under_threshold" });
+
+    const enforcement = await buildFanoutEnforcement({
+      repo: "owner/repo",
+      pr: 17,
+      currentHeadSha: headSha,
+      draftGateMarker: marker(headSha),
+      preApprovalGateMarker: marker(headSha),
+      config,
+      cwd: dir,
+      hasFullLabel: false,
+      baseRef,
+    });
+    assert.equal(enforcement.required, true);
+    assert.equal(enforcement.lightMode, true);
+    assert.equal(enforcement.hasFullLabel, false);
+    for (const gate of enforcement.gates) {
+      assert.equal(gate.scopeUnderThreshold, true, gate.name);
+      assert.equal(gate.inlineReason, "under_threshold");
+      assert.equal(gate.ledgerExists, true, gate.name);
+    }
+    const accepted = buildPreMergeGateCheck({
+      currentHeadSha: headSha,
+      draftGate: { visible: true, verdict: "clean" },
+      preApprovalGateMarker: { visible: true, contractComplete: true, verdict: "clean", headSha },
+    }, 0, null, enforcement);
+    assert.equal(accepted.ok, true, JSON.stringify(accepted.failures));
+
+    // gate:full label forces fan-out: scope is never even measured -> rejected.
+    const labelled = await buildFanoutEnforcement({
+      repo: "owner/repo",
+      pr: 17,
+      currentHeadSha: headSha,
+      draftGateMarker: marker(headSha),
+      preApprovalGateMarker: marker(headSha),
+      config,
+      cwd: dir,
+      hasFullLabel: true,
+      baseRef,
+    });
+    for (const gate of labelled.gates) {
+      assert.equal(gate.scopeUnderThreshold, false, gate.name);
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
 test("detect-checkpoint-evidence fails pre-merge with unresolved human review threads", async () => {

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -1042,8 +1042,8 @@ test("upsert-checkpoint-verdict suppresses duplicate repost when the current sam
       inlineReason: "single-agent inline review (test)",
       blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
     });
-    // 7 gh calls: pr facts + requested_reviewers + review threads + headRefOid + issue comments + PR reviews + internal-only file check
-    assert.equal(Number((await readFile(env.GH_COUNTER_PATH, "utf8")).trim()), 7);
+    // 8 gh calls: pr facts + requested_reviewers + review threads + headRefOid + issue comments + PR reviews + internal-only file check + light-mode facts (baseRefOid,labels) — the repo config enables lightMode, so an inline verdict triggers the #1174 light-fact fetch.
+    assert.equal(Number((await readFile(env.GH_COUNTER_PATH, "utf8")).trim()), 8);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -1553,8 +1553,8 @@ test("upsert-checkpoint-verdict expands an abbreviated current-head SHA before m
       inlineReason: "single-agent inline review (test)",
       blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
     });
-    // 7 gh calls: pr facts + requested_reviewers + review threads + headRefOid + issue comments + PR reviews + internal-only file check
-    assert.equal(Number((await readFile(env.GH_COUNTER_PATH, "utf8")).trim()), 7);
+    // 8 gh calls: pr facts + requested_reviewers + review threads + headRefOid + issue comments + PR reviews + internal-only file check + light-mode facts (baseRefOid,labels) — the repo config enables lightMode, so an inline verdict triggers the #1174 light-fact fetch.
+    assert.equal(Number((await readFile(env.GH_COUNTER_PATH, "utf8")).trim()), 8);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/detect-merge-base-scope.test.mjs
+++ b/test/loop/detect-merge-base-scope.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { detectMergeBaseScope } from "../../scripts/loop/detect-change-scope.mjs";
+
+// #1174: the merge-base scope re-derivation used to accept a light inline verdict
+// at merge time. It MUST fail CLOSED — any missing input or git failure yields
+// { ok: false } so the caller rejects rather than treating it as under-threshold.
+
+function git(cwd, ...args) {
+  execFileSync("git", args, { cwd, encoding: "utf8" });
+}
+
+async function makeRepo() {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-mbscope-"));
+  git(dir, "init", "-q");
+  git(dir, "config", "user.email", "t@t.t");
+  git(dir, "config", "user.name", "t");
+  git(dir, "config", "commit.gpgsign", "false");
+  return dir;
+}
+
+test("detectMergeBaseScope fails closed without base or head", () => {
+  assert.equal(detectMergeBaseScope({ base: null, head: "HEAD" }).ok, false);
+  assert.equal(detectMergeBaseScope({ base: "HEAD", head: null }).ok, false);
+  assert.equal(detectMergeBaseScope({}).ok, false);
+});
+
+test("detectMergeBaseScope fails closed on an unresolvable ref (git error)", async () => {
+  const dir = await makeRepo();
+  try {
+    await writeFile(path.join(dir, "a.txt"), "one\n", "utf8");
+    git(dir, "add", "-A");
+    git(dir, "commit", "-qm", "base");
+    const result = detectMergeBaseScope({ base: "HEAD", head: "does-not-exist", cwd: dir });
+    assert.equal(result.ok, false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("detectMergeBaseScope reports the merge-base diff scope for the head", async () => {
+  const dir = await makeRepo();
+  try {
+    await writeFile(path.join(dir, "a.txt"), "one\n", "utf8");
+    git(dir, "add", "-A");
+    git(dir, "commit", "-qm", "base");
+    const base = execFileSync("git", ["rev-parse", "HEAD"], { cwd: dir, encoding: "utf8" }).trim();
+    await writeFile(path.join(dir, "a.txt"), "one\ntwo\n", "utf8");
+    git(dir, "add", "-A");
+    git(dir, "commit", "-qm", "head");
+    const head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: dir, encoding: "utf8" }).trim();
+    const result = detectMergeBaseScope({ base, head, cwd: dir });
+    assert.equal(result.ok, true);
+    assert.equal(result.filesChanged, 1);
+    assert.equal(result.linesChanged, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Objective

Make the pre-merge gate evidence check light-mode-aware so a genuinely
under-threshold micro-PR can merge through the #1043 light path. Today
`buildPreMergeGateCheck` rejects any `inline_single_agent` verdict whenever
`gates.requireFanoutEvidence` is on (the repo default), so the light path's
inline verdict is unmergeable without falling back to a full fan-out (observed
live on PR #1173, 1 file / 11 lines). This closes that gap while keeping
fail-closed discipline everywhere else.

## In scope

- `scripts/github/detect-checkpoint-evidence.mjs`: `buildPreMergeGateCheck`
  accepts an `inline_single_agent` verdict only when lightMode is enabled, the
  re-derived merge-base scope is under threshold, no `gate:full` label is
  present, and a non-empty inline reason is recorded — rejecting exactly as
  today otherwise. Provenance stays enforced for `fanout_fanin` only.
- `buildFanoutEnforcement` re-derives the reviewed head's scope fail-closed and
  fetches the base ref + labels lazily (only for inline verdicts under an
  enabled lightMode, so the common fan-out path makes no extra `gh` call).
- `scripts/loop/detect-change-scope.mjs`: shared `detectMergeBaseScope` helper
  reusing the same scope resolution as `resolve-gate-dispatch`.
- Docs: light-mode inline acceptance section in
  `docs/gate-review-sub-loop-contract.md`.

## Explicit non-goals

- No change to `resolve-gate-dispatch`'s dispatch decision or to how inline
  verdicts are produced/posted.
- No change to the #1043 CHANGELOG entry (history is immutable).
- No relaxation of the fan-out path: `fanout_fanin` verdicts, ledger, and
  provenance enforcement are byte-identical to today.
- No new merge path for over-threshold, labelled, or lightMode-disabled PRs.

## Acceptance criteria

- [x] A genuinely under-threshold PR with a recorded inline reason and a
  findings-log ledger merges through the light path without a full fan-out.
- [x] The `gate:full` label still forces the full fan-out; scope stays
  fail-closed (underivable scope → rejected).
- [x] Non-light inline verdicts (over threshold / label / lightMode disabled /
  scope underivable) remain rejected byte-identically.
- [x] `requireFanoutProvenance` is enforced only for `fanout_fanin` verdicts;
  light inline verdicts are exempt.
- [x] Regression tests at the `buildPreMergeGateCheck` level for the
  light-accepted case and each still-rejected case.

## Definition of done

- [x] `buildPreMergeGateCheck` + `buildFanoutEnforcement` implement the
  acceptance conditions above.
- [x] Ledger still required for light inline verdicts (uniform evidence
  retention).
- [x] Unit tests (buildPreMergeGateCheck acceptance/rejections,
  `detectMergeBaseScope` fail-closed, `buildFanoutEnforcement` wiring) pass.
- [x] Existing detect-checkpoint-evidence suite stays green (non-regression).
- [x] `npm run verify` green.

## Open questions / risks

- Base ref resolution relies on the local checkout having the base commit
  fetched; if `git diff <base>...<head>` cannot run, scope is treated as
  underivable and the inline verdict is rejected (fail-closed), never silently
  accepted.

Closes #1174
