### PR TITLE
fix(release): dispatch npm-publish.yml explicitly after creating the release (#1187)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -47,8 +47,22 @@ jobs:
       - name: Dry-run pack root package
         run: npm pack --dry-run
 
+      # Per-package idempotency: a re-run after a partial failure must not
+      # fail on the package that already made it to the registry.
       - name: Publish core package to npm
-        run: npm publish -w packages/core --provenance --access public
+        run: |
+          VERSION=$(npm pkg get version | tr -d '"')
+          if npm view "@dev-loops/core@${VERSION}" version >/dev/null 2>&1; then
+            echo "::notice::@dev-loops/core@${VERSION} already published; skipping."
+          else
+            npm publish -w packages/core --provenance --access public
+          fi
 
       - name: Publish root package to npm
-        run: npm publish --provenance --access public
+        run: |
+          VERSION=$(npm pkg get version | tr -d '"')
+          if npm view "dev-loops@${VERSION}" version >/dev/null 2>&1; then
+            echo "::notice::dev-loops@${VERSION} already published; skipping."
+          else
+            npm publish --provenance --access public
+          fi

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -51,7 +51,7 @@ jobs:
       # fail on the package that already made it to the registry.
       - name: Publish core package to npm
         run: |
-          VERSION=$(npm pkg get version | tr -d '"')
+          VERSION=$(cd packages/core && npm pkg get version | tr -d '"')
           if npm view "@dev-loops/core@${VERSION}" version >/dev/null 2>&1; then
             echo "::notice::@dev-loops/core@${VERSION} already published; skipping."
           else

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,6 +1,10 @@
 name: Publish to npm
 
+# release.yml dispatches this with --ref <tag> (GITHUB_TOKEN-created releases
+# never fire `on: release`, see #1187); the release trigger remains for
+# releases published manually in the UI.
 on:
+  workflow_dispatch:
   release:
     types:
       - published

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -51,7 +51,9 @@ jobs:
       # fail on the package that already made it to the registry.
       - name: Publish core package to npm
         run: |
-          VERSION=$(cd packages/core && npm pkg get version | tr -d '"')
+          # jq, not `npm pkg get`: inside a workspace npm prints a name->version
+          # map, not the bare version.
+          VERSION=$(jq -r .version packages/core/package.json)
           if npm view "@dev-loops/core@${VERSION}" version >/dev/null 2>&1; then
             echo "::notice::@dev-loops/core@${VERSION} already published; skipping."
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,8 +81,9 @@ jobs:
             --latest \
             --verify-tag
 
+      # Not gated on `exists`: re-running after a failed dispatch/publish must
+      # retry. npm-publish.yml itself skips versions already on the registry.
       - name: Dispatch npm publish for the release tag
-        if: steps.exists.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 name: Create GitHub Release
 
 # Tagging is the only manual release step. Pushing a "v*" tag creates the
-# GitHub Release (notes = the matching CHANGELOG.md section), which in turn
-# fires npm-publish.yml (on: release: published).
+# GitHub Release, then dispatches npm-publish.yml explicitly: releases
+# created with GITHUB_TOKEN never fire `on: release`, so event chaining
+# alone silently skips npm publishing (#1187). workflow_dispatch is the
+# documented GITHUB_TOKEN exception.
 on:
   push:
     tags:
@@ -13,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
@@ -77,3 +80,10 @@ jobs:
             --notes-file release-notes.md \
             --latest \
             --verify-tag
+
+      - name: Dispatch npm publish for the release tag
+        if: steps.exists.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run npm-publish.yml --ref "${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
## Summary

- `release.yml`: after creating the GitHub release, explicitly dispatch `npm-publish.yml` with `--ref <tag>` (grants `actions: write`). Releases created with `GITHUB_TOKEN` never fire `on: release`, so npm publishing has been silently skipped since v0.6.0.
- `npm-publish.yml`: add `workflow_dispatch:` trigger; the existing `release: published` trigger remains for releases published manually in the UI.
- Idempotent re-runs: the dispatch step is not gated on the release already existing (a re-run after a failed dispatch/publish retries), and each npm publish step skips when that package@version is already on the registry.

Closes #1187

## Evidence

Validation: actionlint passed on both workflow files
Backfill: v0.7.1 was published by draft-toggling the release with a user token (`dev-loops@0.7.1` and `@dev-loops/core@0.7.1` now resolve; dist-tag latest = 0.7.1)

## Notes

- 0.6.2 and 0.7.0 remain unpublished on npm deliberately — latest is what installers resolve; backfilling superseded versions adds no value.
- No repo tests pin workflow triggers, so no test changes.
