### PR TITLE
feat(docs): state-machine conformance + invariant harness (#1148)

### DIFF
--- a/.claude/skills/docs/contract-style-guide.md
+++ b/.claude/skills/docs/contract-style-guide.md
@@ -34,3 +34,4 @@ Use `&lt;!-- rule-ref: RULE-ID --&gt;` next to a cross-reference when a machine-
 ## Cross-references
 
 - [Stop conditions](stop-conditions.md)
+- [State-machine conformance + invariant harness](../../scripts/docs/validate-state-machine-conformance.mjs) — L2 (doc ↔ code) conformance and L3 (completeness/safety/liveness) graph invariants; its header comment documents the registration path for adding a machine

--- a/.claude/skills/docs/contract-style-guide.md
+++ b/.claude/skills/docs/contract-style-guide.md
@@ -34,4 +34,4 @@ Use `&lt;!-- rule-ref: RULE-ID --&gt;` next to a cross-reference when a machine-
 ## Cross-references
 
 - [Stop conditions](stop-conditions.md)
-- [State-machine conformance + invariant harness](../../scripts/docs/validate-state-machine-conformance.mjs) — L2 (doc ↔ code) conformance and L3 (completeness/safety/liveness) graph invariants; its header comment documents the registration path for adding a machine
+- State-machine conformance + invariant harness (`scripts/docs/validate-state-machine-conformance.mjs`) — L2 (doc ↔ code) conformance and L3 (completeness/safety/liveness) graph invariants; its header comment documents the registration path for adding a machine

--- a/scripts/docs/_pr-lifecycle-tables.mjs
+++ b/scripts/docs/_pr-lifecycle-tables.mjs
@@ -1,0 +1,46 @@
+// PR lifecycle: the 13-state vocabulary + required transitions from
+// skills/docs/pr-lifecycle-contract.md.
+//
+// Pure data, no imports, no side effects: both scripts/pages/build-state-atlas.mjs
+// (site diagram generator) and scripts/docs/validate-state-machine-conformance.mjs
+// (the L2/L3 conformance harness) import this same table as their single source
+// of truth, instead of one importing the other's module (which would pull the
+// whole page generator — eager mermaid diagram rendering, duplicate core module
+// instances via relative imports — into the harness's process at load time).
+export const PR_LIFECYCLE_STATES = [
+  'draft_local_review_gate',
+  'draft_local_remediation',
+  'ready_state_needs_copilot_request',
+  'waiting_for_copilot_review',
+  'copilot_feedback_remediation',
+  'copilot_reply_resolve_pending',
+  'merge_conflict_resolution',
+  'final_local_preapproval_gate',
+  'final_gate_remediation',
+  'waiting_for_human_pr_approval',
+  'waiting_for_merge',
+  'terminal_slice_complete',
+  'stopped_needs_user_decision',
+];
+export const PR_LIFECYCLE_TRANSITIONS = [
+  ['draft_local_review_gate', 'draft_local_remediation'],
+  ['draft_local_review_gate', 'ready_state_needs_copilot_request'],
+  ['draft_local_review_gate', 'stopped_needs_user_decision'],
+  ['draft_local_remediation', 'draft_local_review_gate'],
+  ['ready_state_needs_copilot_request', 'waiting_for_copilot_review'],
+  ['ready_state_needs_copilot_request', 'stopped_needs_user_decision'],
+  ['waiting_for_copilot_review', 'copilot_feedback_remediation'],
+  ['copilot_feedback_remediation', 'copilot_reply_resolve_pending'],
+  ['copilot_reply_resolve_pending', 'ready_state_needs_copilot_request'],
+  ['waiting_for_copilot_review', 'merge_conflict_resolution'],
+  ['merge_conflict_resolution', 'waiting_for_copilot_review'],
+  ['waiting_for_copilot_review', 'final_local_preapproval_gate'],
+  ['final_local_preapproval_gate', 'final_gate_remediation'],
+  ['final_local_preapproval_gate', 'waiting_for_human_pr_approval'],
+  ['final_gate_remediation', 'final_local_preapproval_gate'],
+  ['waiting_for_human_pr_approval', 'waiting_for_merge'],
+  ['waiting_for_human_pr_approval', 'draft_local_review_gate'],
+  ['waiting_for_merge', 'terminal_slice_complete'],
+  ['terminal_slice_complete', '[*]'],
+  ['stopped_needs_user_decision', '[*]'],
+];

--- a/scripts/docs/validate-state-machine-conformance.mjs
+++ b/scripts/docs/validate-state-machine-conformance.mjs
@@ -34,15 +34,15 @@
  *     transitions,           // [from, to][] — the FULL graph, for L3 (may
  *                            //   include a synthetic '[*]' terminal marker
  *                            //   target; it is ignored by both L2 and L3)
- *     docTransitions,        // [from, to][] — the subset of `transitions`
- *                            //   the OWNER DOC declares (usually === transitions
- *                            //   minus the '[*]' marker rows); this is the L2
- *                            //   "doc table" and should be sourced from an
- *                            //   already-reviewed doc-derived table (reuse one
- *                            //   if it exists — see the pr-gate-coordination
- *                            //   registration below for the pattern) rather
- *                            //   than hand-copied prose, so it cannot silently
- *                            //   drift from the doc it represents;
+ *     docTransitions,        // [from, to][] — the transitions the OWNER DOC
+ *                            //   declares (usually === transitions minus the
+ *                            //   '[*]' marker rows); this is the L2 "doc
+ *                            //   table" and MUST be parsed from the owner
+ *                            //   doc's own structured transition section via
+ *                            //   `parseRequiredTransitions` (see the
+ *                            //   pr-gate-coordination registration below for
+ *                            //   the pattern), so editing the doc is visible
+ *                            //   to the harness — never a hand-copied array;
  *     transitionChecks,      // Map<"from->to", Check> — the L2 "code table":
  *                            //   { status: "verified", verify: () => { ok, detail, result } }
  *                            //   { status: "known_gap", issue, note }
@@ -53,6 +53,10 @@
  * "adding a second machine" extensibility test in
  * test/docs/validate-state-machine-conformance.test.mjs.
  */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { isDirectCliRun } from "../_core-helpers.mjs";
 import { evaluatePrGateCoordination, PR_CHECKPOINT, PR_CHECKPOINT_ACTION } from "@dev-loops/core/loop/pr-gate-coordination";
@@ -78,6 +82,40 @@ const TERMINAL_MARKER = "[*]";
 
 function realEdges(transitions) {
   return transitions.filter(([, to]) => to !== TERMINAL_MARKER);
+}
+
+/**
+ * L2 doc-side parser: read a contract doc's structured transition section
+ * (top-level bullets of the shape "- `from` -> `to`" under `sectionHeading`)
+ * into a [from, to][] table. Rows whose from/to is prose rather than a
+ * backtick token (abstract rows like "any open non-terminal lifecycle slice")
+ * MUST be resolved via an explicit `abstractRows` mapping
+ * (Map<"from->to raw text", [from, to][]>) — an unmapped abstract row throws,
+ * never silently drops, so a new abstract bullet in the doc is loud.
+ */
+export function parseRequiredTransitions(markdown, { sectionHeading = "## Required transitions", abstractRows = new Map() } = {}) {
+  const sectionStart = markdown.indexOf(`\n${sectionHeading}\n`);
+  if (sectionStart === -1) throw new Error(`doc has no "${sectionHeading}" section`);
+  const afterHeading = markdown.slice(sectionStart + sectionHeading.length + 2);
+  const body = afterHeading.split(/\n#{1,6} /)[0];
+
+  const transitions = [];
+  for (const line of body.split(/\r?\n/)) {
+    const bullet = line.match(/^- (.+?) -> (.+)$/);
+    if (!bullet) continue; // sub-bullets (guards) are indented and skipped
+    const parts = [bullet[1].trim(), bullet[2].trim()];
+    const tokens = parts.map((p) => p.match(/^`([A-Za-z0-9_]+)`$/)?.[1] ?? null);
+    if (tokens[0] !== null && tokens[1] !== null) {
+      transitions.push([tokens[0], tokens[1]]);
+      continue;
+    }
+    const rawKey = `${parts[0]}->${parts[1]}`;
+    const mapped = abstractRows.get(rawKey);
+    if (!mapped) throw new Error(`unmapped abstract transition row in doc: "${rawKey}" — add it to abstractRows`);
+    transitions.push(...mapped);
+  }
+  if (transitions.length === 0) throw new Error(`"${sectionHeading}" section contains no transition bullets`);
+  return transitions;
 }
 
 /** L3 completeness: every non-terminal state has >=1 outgoing transition. */
@@ -135,13 +173,18 @@ export function checkSafetyRules(observations, safetyRules) {
 
 /**
  * L2: compare a doc-declared transition table against the registered code
- * checks. `transitionChecks` is a Map keyed by `"from->to"`.
+ * checks. `transitionChecks` is a Map keyed by `"from->to"`. Bidirectional:
+ * a doc transition with no check is "missing"; a check key no doc transition
+ * references is "unreferenced" (a stale check, or a code-side transition the
+ * doc dropped) — both fail.
  */
 export function compareDocCodeTransitions(docTransitions, transitionChecks) {
   const results = [];
   const observations = [];
+  const referencedKeys = new Set();
   for (const [from, to] of realEdges(docTransitions)) {
     const key = `${from}->${to}`;
+    referencedKeys.add(key);
     const check = transitionChecks.get(key);
     if (!check) {
       results.push({ from, to, status: "missing" });
@@ -155,7 +198,13 @@ export function compareDocCodeTransitions(docTransitions, transitionChecks) {
       results.push({ from, to, status: check.status, issue: check.issue ?? null, note: check.note ?? null });
     }
   }
-  const ok = results.every((r) => r.status !== "missing" && r.status !== "divergent");
+  for (const key of transitionChecks.keys()) {
+    if (!referencedKeys.has(key)) {
+      const [from, to] = key.split("->");
+      results.push({ from, to, status: "unreferenced" });
+    }
+  }
+  const ok = results.every((r) => r.status !== "missing" && r.status !== "divergent" && r.status !== "unreferenced");
   return { ok, results, observations };
 }
 
@@ -165,6 +214,11 @@ const REGISTRY = new Map();
 export function registerMachine(machine) {
   if (!machine || typeof machine.name !== "string" || machine.name.trim().length === 0) {
     throw new Error("registerMachine requires a non-empty `name`");
+  }
+  // Fail-closed shape check: L2 needs BOTH tables; exactly one present is a
+  // half-registered machine that would otherwise skip L2 silently as ok:true.
+  if (Boolean(machine.docTransitions) !== Boolean(machine.transitionChecks)) {
+    throw new Error(`machine "${machine.name}" must provide docTransitions and transitionChecks together (or neither)`);
   }
   REGISTRY.set(machine.name, machine);
   return machine;
@@ -198,12 +252,13 @@ export function runMachineConformance(machine) {
 // ---------------------------------------------------------------------------
 // Reference machine (issue #1148): pr-gate-coordination.
 //
-// Doc side: skills/docs/pr-lifecycle-contract.md's "Required transitions" /
-// lifecycle-state vocabulary — reused verbatim from
-// scripts/pages/build-state-atlas.mjs's PR_LIFECYCLE_STATES/TRANSITIONS
-// (already a reviewed, hand-derived structured table for that doc; see that
-// file's own header for why no single code table exists for this doc's
-// vocabulary today).
+// Doc side: skills/docs/pr-lifecycle-contract.md's "## Required transitions"
+// bullets, parsed at load time via parseRequiredTransitions so a doc edit is
+// immediately visible to the harness. The two abstract (non-backtick) rows are
+// mapped explicitly to their concrete representatives below. The parsed table
+// is additionally asserted to bind 1:1 to build-state-atlas.mjs's
+// PR_LIFECYCLE_TRANSITIONS (the state-atlas diagram source), so that constant
+// cannot drift from the doc either.
 //
 // Code side: packages/core/src/loop/pr-gate-coordination.mjs exports
 // PR_CHECKPOINT / PR_CHECKPOINT_ACTION but no state-to-state table in the
@@ -215,6 +270,49 @@ export function runMachineConformance(machine) {
 // is consistent with the "to" state — a real characterization of the code,
 // not a hand-copied assumption.
 // ---------------------------------------------------------------------------
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+// Abstract doc rows -> concrete graph edges. "any open non-terminal lifecycle
+// slice" is represented by waiting_for_copilot_review (the guard fires ahead of
+// every lifecycle-state branch in the code, so one representative suffices);
+// "normal lifecycle re-entry state" re-enters the same representative slice.
+const PR_LIFECYCLE_ABSTRACT_ROWS = new Map([
+  ["any open non-terminal lifecycle slice->`merge_conflict_resolution`", [["waiting_for_copilot_review", "merge_conflict_resolution"]]],
+  ["`merge_conflict_resolution`->normal lifecycle re-entry state", [["merge_conflict_resolution", "waiting_for_copilot_review"]]],
+]);
+
+// Edges the doc implies but does not bullet under "Required transitions".
+// pr-lifecycle-contract.md sends pre-approval findings to final_gate_remediation
+// and its "Remediation ownership boundary" section routes that remediation back
+// to the gate, but no explicit re-entry bullet exists (unlike the draft pair's
+// draft_local_remediation -> draft_local_review_gate). Without this edge the
+// state is a non-terminal dead-end, so the atlas diagram carries it; it is
+// allowlisted here explicitly instead of silently — remove this entry if the
+// doc ever gains the bullet.
+const PR_LIFECYCLE_IMPLIED_EDGES = [["final_gate_remediation", "final_local_preapproval_gate"]];
+
+const PR_LIFECYCLE_DOC_TRANSITIONS = [
+  ...parseRequiredTransitions(
+    readFileSync(path.join(REPO_ROOT, "skills", "docs", "pr-lifecycle-contract.md"), "utf8"),
+    { abstractRows: PR_LIFECYCLE_ABSTRACT_ROWS },
+  ),
+  ...PR_LIFECYCLE_IMPLIED_EDGES,
+];
+
+// Bind the parsed doc table 1:1 to the atlas constant (order-insensitive).
+{
+  const docSet = new Set(PR_LIFECYCLE_DOC_TRANSITIONS.map(([a, b]) => `${a}->${b}`));
+  const atlasSet = new Set(realEdges(PR_LIFECYCLE_TRANSITIONS).map(([a, b]) => `${a}->${b}`));
+  const onlyDoc = [...docSet].filter((k) => !atlasSet.has(k));
+  const onlyAtlas = [...atlasSet].filter((k) => !docSet.has(k));
+  if (onlyDoc.length > 0 || onlyAtlas.length > 0) {
+    throw new Error(
+      "pr-lifecycle-contract.md Required transitions and build-state-atlas.mjs PR_LIFECYCLE_TRANSITIONS have drifted apart. "
+      + `Only in doc: [${onlyDoc.join(", ")}]. Only in atlas: [${onlyAtlas.join(", ")}].`,
+    );
+  }
+}
 
 function gate({ visible = false, headSha = null, verdict = null, contractComplete = false } = {}) {
   return { visible, headSha, verdict, contractComplete };
@@ -315,7 +413,10 @@ PR_GATE_TRANSITION_CHECKS.set("waiting_for_copilot_review->final_local_preapprov
   note: "Gate entry into pre_approval_gate trusts caller-supplied sameHeadCleanConverged with no "
     + "independent reviewed-head-SHA check; the fail-closed guard is at verdict-post "
     + "(upsert-checkpoint-verdict.mjs), not at gate entry (pr-gate-coordination.mjs). See epic #1104 "
-    + "comment thread; tracked in #1190.",
+    + "comment thread; tracked in #1190. NOTE: this allowlist entry never fails the CLI — if #1190 "
+    + "lands a backward-compatible gate-entry guard, this run keeps passing silently; the loud guard "
+    + "is the known-gap regression test in test/docs/validate-state-machine-conformance.test.mjs, "
+    + "which starts failing the moment the gap closes and tells you to retire this entry.",
 });
 
 // final_local_preapproval_gate -> final_gate_remediation: pre-approval gate findings require changes.
@@ -414,15 +515,15 @@ const PR_GATE_COORDINATION_MACHINE = {
   states: PR_LIFECYCLE_STATES,
   terminalStates: ["terminal_slice_complete", "stopped_needs_user_decision"],
   transitions: PR_LIFECYCLE_TRANSITIONS,
-  docTransitions: PR_LIFECYCLE_TRANSITIONS,
+  docTransitions: PR_LIFECYCLE_DOC_TRANSITIONS,
   transitionChecks: PR_GATE_TRANSITION_CHECKS,
   safetyRules: [
     {
       // Analog of "no ->merged without both gates clean at head": final-approval readiness
       // (this machine's closest reachable state to "ready to merge") requires both draft_gate and
-      // pre_approval_gate to be clean-at-head; PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY itself is
-      // never returned as an allowed action by this function at all (merge is external/human-only),
-      // so that half of the analog holds trivially and is asserted directly in the unit test.
+      // pre_approval_gate to be clean-at-head. The other half of the analog — DECLARE_MERGE_READY
+      // never appearing in any allowedNextActions (merge is external/human-only) — is asserted over
+      // the gathered observations in test/docs/validate-state-machine-conformance.test.mjs.
       name: "no-final-approval-without-both-gates-clean",
       check: (result) => result.nextAction !== PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL
         || (result.draftGate.cleanEvidenceExists && result.preApprovalGate.currentHeadClean),
@@ -460,7 +561,7 @@ async function main(argv = process.argv.slice(2)) {
     if (!report.liveness.ok) process.stdout.write(`  liveness: state(s) stuck without a terminal path: ${report.liveness.stuck.join(", ")}\n`);
     if (!report.conformance.ok) {
       for (const r of report.conformance.results) {
-        if (r.status === "missing" || r.status === "divergent") {
+        if (r.status === "missing" || r.status === "divergent" || r.status === "unreferenced") {
           process.stdout.write(`  conformance ${r.status}: ${r.from} -> ${r.to}\n`);
         }
       }

--- a/scripts/docs/validate-state-machine-conformance.mjs
+++ b/scripts/docs/validate-state-machine-conformance.mjs
@@ -92,6 +92,13 @@ function realEdges(transitions) {
  * MUST be resolved via an explicit `abstractRows` mapping
  * (Map<"from->to raw text", [from, to][]>) — an unmapped abstract row throws,
  * never silently drops, so a new abstract bullet in the doc is loud.
+ *
+ * Caveat: a top-level line that does not match "- X -> Y" is treated as prose
+ * and skipped, so a malformed-but-intended bullet (unicode arrow, trailing
+ * annotation) drops out silently. For pr-gate-coordination the load-time 1:1
+ * doc<->atlas binding below catches every such drop; a second machine MUST
+ * pair this parser with an equivalent independent binding (or extend the
+ * parser with a "looks like a transition bullet but did not parse" check).
  */
 export function parseRequiredTransitions(markdown, { sectionHeading = "## Required transitions", abstractRows = new Map() } = {}) {
   const sectionStart = markdown.indexOf(`\n${sectionHeading}\n`);
@@ -292,11 +299,20 @@ const PR_LIFECYCLE_ABSTRACT_ROWS = new Map([
 // doc ever gains the bullet.
 const PR_LIFECYCLE_IMPLIED_EDGES = [["final_gate_remediation", "final_local_preapproval_gate"]];
 
+const PR_LIFECYCLE_PARSED_DOC_TRANSITIONS = parseRequiredTransitions(
+  readFileSync(path.join(REPO_ROOT, "skills", "docs", "pr-lifecycle-contract.md"), "utf8"),
+  { abstractRows: PR_LIFECYCLE_ABSTRACT_ROWS },
+);
+
+// Self-retiring seam: once the doc bullets an implied edge, this entry is stale.
+for (const [from, to] of PR_LIFECYCLE_IMPLIED_EDGES) {
+  if (PR_LIFECYCLE_PARSED_DOC_TRANSITIONS.some(([a, b]) => a === from && b === to)) {
+    throw new Error(`implied edge ${from}->${to} now appears in the doc — remove it from PR_LIFECYCLE_IMPLIED_EDGES`);
+  }
+}
+
 const PR_LIFECYCLE_DOC_TRANSITIONS = [
-  ...parseRequiredTransitions(
-    readFileSync(path.join(REPO_ROOT, "skills", "docs", "pr-lifecycle-contract.md"), "utf8"),
-    { abstractRows: PR_LIFECYCLE_ABSTRACT_ROWS },
-  ),
+  ...PR_LIFECYCLE_PARSED_DOC_TRANSITIONS,
   ...PR_LIFECYCLE_IMPLIED_EDGES,
 ];
 

--- a/scripts/docs/validate-state-machine-conformance.mjs
+++ b/scripts/docs/validate-state-machine-conformance.mjs
@@ -308,18 +308,14 @@ verified("waiting_for_copilot_review->merge_conflict_resolution", () => {
 // time (`upsert-checkpoint-verdict.mjs`'s unsettled-review refusal), not at *gate entry* here. This
 // is intentionally NOT fixed by #1148 (own issue, tracked below) — encoded as an expected-fail so a
 // future accidental "fix" (or regression) is visible instead of silently passing either way.
-// ponytail: KNOWN_GAP_TRACKING_ISSUE is a placeholder — subagent execution is hook-blocked from
-// `gh issue create` (reserved for the main agent/operator). Replace with the real issue number
-// once created (see this PR's description for the exact `gh issue create` command to run), then
-// update the `issue` value below to `https://github.com/mfittko/dev-loops/issues/<n>`.
-const KNOWN_GAP_TRACKING_ISSUE = null;
+const KNOWN_GAP_TRACKING_ISSUE = "https://github.com/mfittko/dev-loops/issues/1190";
 PR_GATE_TRANSITION_CHECKS.set("waiting_for_copilot_review->final_local_preapproval_gate", {
   status: "known_gap",
   issue: KNOWN_GAP_TRACKING_ISSUE,
   note: "Gate entry into pre_approval_gate trusts caller-supplied sameHeadCleanConverged with no "
     + "independent reviewed-head-SHA check; the fail-closed guard is at verdict-post "
     + "(upsert-checkpoint-verdict.mjs), not at gate entry (pr-gate-coordination.mjs). See epic #1104 "
-    + "comment thread; tracking issue pending creation (see harness header note).",
+    + "comment thread; tracked in #1190.",
 });
 
 // final_local_preapproval_gate -> final_gate_remediation: pre-approval gate findings require changes.

--- a/scripts/docs/validate-state-machine-conformance.mjs
+++ b/scripts/docs/validate-state-machine-conformance.mjs
@@ -93,17 +93,25 @@ function realEdges(transitions) {
  * (Map<"from->to raw text", [from, to][]>) — an unmapped abstract row throws,
  * never silently drops, so a new abstract bullet in the doc is loud.
  *
- * Caveat: a top-level line that does not match "- X -> Y" is treated as prose
- * and skipped, so a malformed-but-intended bullet (unicode arrow, trailing
- * annotation) drops out silently. For pr-gate-coordination the load-time 1:1
- * doc<->atlas binding below catches every such drop; a second machine MUST
- * pair this parser with an equivalent independent binding (or extend the
- * parser with a "looks like a transition bullet but did not parse" check).
+ * Caveat: a top-level line that does not match "- X -> Y" at all (a unicode
+ * arrow, or missing the "- " bullet prefix) is treated as prose and skipped —
+ * that drop is silent. A line that DOES match "- X -> Y" but whose from/to is
+ * neither a `backtick token` nor a mapped abstractRows entry (e.g. a bullet
+ * with a trailing annotation after the arrow) is NOT silent: it fails the
+ * backtick-token match and throws via the unmapped-abstract-row path above.
+ * For pr-gate-coordination the load-time 1:1 doc<->atlas binding below
+ * additionally catches every silent-drop case; a second machine MUST pair
+ * this parser with an equivalent independent binding (or extend the parser
+ * with a "looks like a transition bullet but did not parse" check).
  */
 export function parseRequiredTransitions(markdown, { sectionHeading = "## Required transitions", abstractRows = new Map() } = {}) {
-  const sectionStart = markdown.indexOf(`\n${sectionHeading}\n`);
+  // The heading may open the file (index 0, no leading "\n") or appear further down (leading
+  // "\n"); check both so a doc that starts with this section is not falsely reported as missing.
+  const atStart = markdown.startsWith(`${sectionHeading}\n`);
+  const sectionStart = atStart ? 0 : markdown.indexOf(`\n${sectionHeading}\n`);
   if (sectionStart === -1) throw new Error(`doc has no "${sectionHeading}" section`);
-  const afterHeading = markdown.slice(sectionStart + sectionHeading.length + 2);
+  const headingEnd = sectionStart + (atStart ? 0 : 1) + sectionHeading.length + 1;
+  const afterHeading = markdown.slice(headingEnd);
   const body = afterHeading.split(/\n#{1,6} /)[0];
 
   const transitions = [];
@@ -208,7 +216,8 @@ export function compareDocCodeTransitions(docTransitions, transitionChecks) {
         if (outcome && outcome.result !== undefined) observations.push(outcome.result);
         results.push({ from, to, status: outcome.ok ? "verified" : "divergent", detail: outcome.detail });
       } catch (err) {
-        results.push({ from, to, status: "divergent", detail: `verify() threw: ${err.message}` });
+        const message = err instanceof Error ? err.message : String(err);
+        results.push({ from, to, status: "divergent", detail: `verify() threw: ${message}` });
       }
     } else {
       results.push({ from, to, status: check.status, issue: check.issue ?? null, note: check.note ?? null });
@@ -235,6 +244,9 @@ export function registerMachine(machine) {
   // half-registered machine that would otherwise skip L2 silently as ok:true.
   if (Boolean(machine.docTransitions) !== Boolean(machine.transitionChecks)) {
     throw new Error(`machine "${machine.name}" must provide docTransitions and transitionChecks together (or neither)`);
+  }
+  if (REGISTRY.has(machine.name)) {
+    throw new Error(`machine "${machine.name}" is already registered — duplicate registration would silently overwrite it`);
   }
   REGISTRY.set(machine.name, machine);
   return machine;

--- a/scripts/docs/validate-state-machine-conformance.mjs
+++ b/scripts/docs/validate-state-machine-conformance.mjs
@@ -61,7 +61,7 @@ import { fileURLToPath } from "node:url";
 import { isDirectCliRun } from "../_core-helpers.mjs";
 import { evaluatePrGateCoordination, PR_CHECKPOINT, PR_CHECKPOINT_ACTION } from "@dev-loops/core/loop/pr-gate-coordination";
 import { DISPOSITION, STATE } from "@dev-loops/core/loop/copilot-loop-state";
-import { PR_LIFECYCLE_STATES, PR_LIFECYCLE_TRANSITIONS } from "../pages/build-state-atlas.mjs";
+import { PR_LIFECYCLE_STATES, PR_LIFECYCLE_TRANSITIONS } from "./_pr-lifecycle-tables.mjs";
 
 const USAGE = `Usage: validate-state-machine-conformance.mjs [--help]
 
@@ -183,7 +183,9 @@ export function checkSafetyRules(observations, safetyRules) {
  * checks. `transitionChecks` is a Map keyed by `"from->to"`. Bidirectional:
  * a doc transition with no check is "missing"; a check key no doc transition
  * references is "unreferenced" (a stale check, or a code-side transition the
- * doc dropped) — both fail.
+ * doc dropped) — both fail. A `verify()` that throws is caught per-transition
+ * and reported as "divergent" (fail-closed) rather than aborting the run, so
+ * every other transition still gets checked and surfaces in the same report.
  */
 export function compareDocCodeTransitions(docTransitions, transitionChecks) {
   const results = [];
@@ -198,9 +200,16 @@ export function compareDocCodeTransitions(docTransitions, transitionChecks) {
       continue;
     }
     if (check.status === "verified") {
-      const outcome = check.verify();
-      if (outcome && outcome.result !== undefined) observations.push(outcome.result);
-      results.push({ from, to, status: outcome.ok ? "verified" : "divergent", detail: outcome.detail });
+      // A throwing verify() is itself a divergence (fail-closed), not a reason to abort the
+      // whole run: report this transition as divergent with the error and keep checking the
+      // rest so other missing/unreferenced edges still surface in the same report.
+      try {
+        const outcome = check.verify();
+        if (outcome && outcome.result !== undefined) observations.push(outcome.result);
+        results.push({ from, to, status: outcome.ok ? "verified" : "divergent", detail: outcome.detail });
+      } catch (err) {
+        results.push({ from, to, status: "divergent", detail: `verify() threw: ${err.message}` });
+      }
     } else {
       results.push({ from, to, status: check.status, issue: check.issue ?? null, note: check.note ?? null });
     }
@@ -263,9 +272,10 @@ export function runMachineConformance(machine) {
 // bullets, parsed at load time via parseRequiredTransitions so a doc edit is
 // immediately visible to the harness. The two abstract (non-backtick) rows are
 // mapped explicitly to their concrete representatives below. The parsed table
-// is additionally asserted to bind 1:1 to build-state-atlas.mjs's
-// PR_LIFECYCLE_TRANSITIONS (the state-atlas diagram source), so that constant
-// cannot drift from the doc either.
+// is additionally asserted to bind 1:1 to _pr-lifecycle-tables.mjs's
+// PR_LIFECYCLE_TRANSITIONS (the shared pure-data table also consumed by
+// build-state-atlas.mjs's diagram), so that constant cannot drift from the doc
+// either.
 //
 // Code side: packages/core/src/loop/pr-gate-coordination.mjs exports
 // PR_CHECKPOINT / PR_CHECKPOINT_ACTION but no state-to-state table in the

--- a/scripts/docs/validate-state-machine-conformance.mjs
+++ b/scripts/docs/validate-state-machine-conformance.mjs
@@ -1,0 +1,484 @@
+#!/usr/bin/env node
+/**
+ * validate-state-machine-conformance.mjs — L2/L3 state-machine conformance +
+ * invariant harness (issue #1148).
+ *
+ * L2 (doc <-> code conformance): for a registered machine, every transition the
+ * doc's structured transition table declares must have a matching, executable
+ * check against the code (`status: "verified"`) or be explicitly accounted for
+ * as `"known_gap"` (tracked divergence, own issue) or `"external"` /
+ * `"owned_elsewhere"` (the transition is real, but decided by another module —
+ * never a silent pass). A doc transition with no registered check at all is
+ * `"missing"` and fails the run: this is how doc drift (a renamed/added/removed
+ * transition nobody updated the registration for) gets caught.
+ *
+ * L3 (graph invariants): a small reachability walk over a machine's declared
+ * `{states, transitions, terminalStates}` checks:
+ *   - completeness: every non-terminal state has >=1 outgoing transition;
+ *   - liveness: every state can reach some terminal state;
+ * plus a per-machine `safetyRules` list of predicates run over the real
+ * observations (the executed code results) gathered while checking L2, e.g.
+ * "no final-approval-readiness observation without both gates clean" or
+ * "no fail-closed (blocked) observation that still permits a gate-progressing
+ * action" — the concrete analogs, for this machine, of the generic "no ->merged
+ * without both gates clean" / "fail-closed states never dispatch a Backlog
+ * pull" invariants named in issue #1148.
+ *
+ * ---------------------------------------------------------------------------
+ * Registration path (DoD3): adding a second machine requires ONLY calling
+ * `registerMachine(machine)` with:
+ *   {
+ *     name,                 // stable machine id, e.g. "pr-gate-coordination"
+ *     states,                // string[] — every state name in the graph
+ *     terminalStates,        // string[] — absorbing states (subset of states)
+ *     transitions,           // [from, to][] — the FULL graph, for L3 (may
+ *                            //   include a synthetic '[*]' terminal marker
+ *                            //   target; it is ignored by both L2 and L3)
+ *     docTransitions,        // [from, to][] — the subset of `transitions`
+ *                            //   the OWNER DOC declares (usually === transitions
+ *                            //   minus the '[*]' marker rows); this is the L2
+ *                            //   "doc table" and should be sourced from an
+ *                            //   already-reviewed doc-derived table (reuse one
+ *                            //   if it exists — see the pr-gate-coordination
+ *                            //   registration below for the pattern) rather
+ *                            //   than hand-copied prose, so it cannot silently
+ *                            //   drift from the doc it represents;
+ *     transitionChecks,      // Map<"from->to", Check> — the L2 "code table":
+ *                            //   { status: "verified", verify: () => { ok, detail, result } }
+ *                            //   { status: "known_gap", issue, note }
+ *                            //   { status: "external"|"owned_elsewhere", note }
+ *     safetyRules,           // [{ name, check: (observation) => boolean }]
+ *   }
+ * No engine function below needs to change for a new machine — see the
+ * "adding a second machine" extensibility test in
+ * test/docs/validate-state-machine-conformance.test.mjs.
+ */
+
+import { isDirectCliRun } from "../_core-helpers.mjs";
+import { evaluatePrGateCoordination, PR_CHECKPOINT, PR_CHECKPOINT_ACTION } from "@dev-loops/core/loop/pr-gate-coordination";
+import { DISPOSITION, STATE } from "@dev-loops/core/loop/copilot-loop-state";
+import { PR_LIFECYCLE_STATES, PR_LIFECYCLE_TRANSITIONS } from "../pages/build-state-atlas.mjs";
+
+const USAGE = `Usage: validate-state-machine-conformance.mjs [--help]
+
+Run the L2 (doc <-> code) conformance check and L3 (completeness/safety/liveness)
+graph invariants for every registered state machine.
+Exit 0 when every registered machine's checks pass or are explicitly accounted
+for (known_gap/external/owned_elsewhere). Exit 1 on any missing coverage,
+divergence, or invariant failure.
+
+Options:
+  --help, -h   Show this help`.trim();
+
+const TERMINAL_MARKER = "[*]";
+
+// ---------------------------------------------------------------------------
+// Generic engine (no machine-specific knowledge below this line).
+// ---------------------------------------------------------------------------
+
+function realEdges(transitions) {
+  return transitions.filter(([, to]) => to !== TERMINAL_MARKER);
+}
+
+/** L3 completeness: every non-terminal state has >=1 outgoing transition. */
+export function checkCompleteness({ states, transitions, terminalStates }) {
+  const outgoing = new Set(realEdges(transitions).map(([from]) => from));
+  const deadEnds = states.filter((s) => !terminalStates.includes(s) && !outgoing.has(s));
+  return { ok: deadEnds.length === 0, deadEnds };
+}
+
+/** L3 liveness: every state can reach some terminal state (reachability walk). */
+export function checkLiveness({ states, transitions, terminalStates }) {
+  const adjacency = new Map(states.map((s) => [s, []]));
+  for (const [from, to] of realEdges(transitions)) {
+    if (!adjacency.has(from)) adjacency.set(from, []);
+    adjacency.get(from).push(to);
+  }
+
+  const resolved = new Map();
+  function canReachTerminal(state, path) {
+    if (resolved.has(state)) return resolved.get(state);
+    if (terminalStates.includes(state)) {
+      resolved.set(state, true);
+      return true;
+    }
+    if (path.has(state)) return false; // cycle without a resolved terminal (yet)
+    path.add(state);
+    let ok = false;
+    for (const next of adjacency.get(state) ?? []) {
+      if (canReachTerminal(next, path)) {
+        ok = true;
+        break;
+      }
+    }
+    path.delete(state);
+    if (ok) resolved.set(state, true);
+    return ok;
+  }
+
+  const stuck = states.filter((s) => !canReachTerminal(s, new Set()));
+  return { ok: stuck.length === 0, stuck };
+}
+
+/** L3 safety: run each named predicate over every gathered observation. */
+export function checkSafetyRules(observations, safetyRules) {
+  const violations = [];
+  for (const rule of safetyRules) {
+    for (const observation of observations) {
+      if (!rule.check(observation)) {
+        violations.push({ rule: rule.name, observation });
+      }
+    }
+  }
+  return { ok: violations.length === 0, violations };
+}
+
+/**
+ * L2: compare a doc-declared transition table against the registered code
+ * checks. `transitionChecks` is a Map keyed by `"from->to"`.
+ */
+export function compareDocCodeTransitions(docTransitions, transitionChecks) {
+  const results = [];
+  const observations = [];
+  for (const [from, to] of realEdges(docTransitions)) {
+    const key = `${from}->${to}`;
+    const check = transitionChecks.get(key);
+    if (!check) {
+      results.push({ from, to, status: "missing" });
+      continue;
+    }
+    if (check.status === "verified") {
+      const outcome = check.verify();
+      if (outcome && outcome.result !== undefined) observations.push(outcome.result);
+      results.push({ from, to, status: outcome.ok ? "verified" : "divergent", detail: outcome.detail });
+    } else {
+      results.push({ from, to, status: check.status, issue: check.issue ?? null, note: check.note ?? null });
+    }
+  }
+  const ok = results.every((r) => r.status !== "missing" && r.status !== "divergent");
+  return { ok, results, observations };
+}
+
+const REGISTRY = new Map();
+
+/** Register a machine for conformance + invariant checking (see header). */
+export function registerMachine(machine) {
+  if (!machine || typeof machine.name !== "string" || machine.name.trim().length === 0) {
+    throw new Error("registerMachine requires a non-empty `name`");
+  }
+  REGISTRY.set(machine.name, machine);
+  return machine;
+}
+
+export function getRegisteredMachines() {
+  return [...REGISTRY.values()];
+}
+
+/** Run every applicable check for one registered machine and return a report. */
+export function runMachineConformance(machine) {
+  const completeness = checkCompleteness(machine);
+  const liveness = checkLiveness(machine);
+  const conformance = machine.docTransitions && machine.transitionChecks
+    ? compareDocCodeTransitions(machine.docTransitions, machine.transitionChecks)
+    : { ok: true, results: [], observations: [] };
+  const safety = machine.safetyRules && machine.safetyRules.length > 0
+    ? checkSafetyRules(conformance.observations, machine.safetyRules)
+    : { ok: true, violations: [] };
+
+  return {
+    name: machine.name,
+    ok: completeness.ok && liveness.ok && conformance.ok && safety.ok,
+    completeness,
+    liveness,
+    conformance,
+    safety,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Reference machine (issue #1148): pr-gate-coordination.
+//
+// Doc side: skills/docs/pr-lifecycle-contract.md's "Required transitions" /
+// lifecycle-state vocabulary — reused verbatim from
+// scripts/pages/build-state-atlas.mjs's PR_LIFECYCLE_STATES/TRANSITIONS
+// (already a reviewed, hand-derived structured table for that doc; see that
+// file's own header for why no single code table exists for this doc's
+// vocabulary today).
+//
+// Code side: packages/core/src/loop/pr-gate-coordination.mjs exports
+// PR_CHECKPOINT / PR_CHECKPOINT_ACTION but no state-to-state table in the
+// doc's vocabulary (a gate boundary is coarser than a lifecycle state, and
+// several lifecycle transitions belong to the copilot inner-loop state graph,
+// out of scope per #1148/#1156/#1157). Each doc transition below is checked by
+// actually calling the exported `evaluatePrGateCoordination` with a fixture
+// standing in for the "from" state and asserting the returned action/boundary
+// is consistent with the "to" state — a real characterization of the code,
+// not a hand-copied assumption.
+// ---------------------------------------------------------------------------
+
+function gate({ visible = false, headSha = null, verdict = null, contractComplete = false } = {}) {
+  return { visible, headSha, verdict, contractComplete };
+}
+
+const HEAD = "abc1234567890";
+const CLEAN_GATE = gate({ visible: true, headSha: "abc1234", verdict: "clean" });
+const CLEAN_MARKER = gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true });
+const FINDINGS_GATE = gate({ visible: true, headSha: "abc1234", verdict: "findings_present" });
+
+function run(input) {
+  return evaluatePrGateCoordination({ currentHeadSha: HEAD, ...input });
+}
+
+const PR_GATE_TRANSITION_CHECKS = new Map();
+
+function verified(key, verify) {
+  PR_GATE_TRANSITION_CHECKS.set(key, { status: "verified", verify });
+}
+
+// draft_local_review_gate -> draft_local_remediation: blocking draft_gate findings.
+verified("draft_local_review_gate->draft_local_remediation", () => {
+  const result = run({ prDraft: true, lifecycleState: STATE.PR_DRAFT, ciStatus: "success", draftGate: FINDINGS_GATE });
+  const ok = result.gateBoundary === PR_CHECKPOINT.DRAFT_REVIEW
+    && result.nextAction === PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE
+    && result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.MARK_READY_FOR_REVIEW);
+  return { ok, detail: result, result };
+});
+
+// draft_local_review_gate -> ready_state_needs_copilot_request: clean current-head draft_gate evidence.
+verified("draft_local_review_gate->ready_state_needs_copilot_request", () => {
+  const result = run({
+    prDraft: true,
+    lifecycleState: STATE.PR_DRAFT,
+    ciStatus: "success",
+    draftGate: CLEAN_GATE,
+    draftGateMarker: CLEAN_MARKER,
+  });
+  const ok = result.gateBoundary === PR_CHECKPOINT.DRAFT_REVIEW
+    && result.nextAction === PR_CHECKPOINT_ACTION.MARK_READY_FOR_REVIEW;
+  return { ok, detail: result, result };
+});
+
+// draft_local_review_gate -> stopped_needs_user_decision: human decision required (failing CI while draft).
+verified("draft_local_review_gate->stopped_needs_user_decision", () => {
+  const result = run({ prDraft: true, lifecycleState: STATE.PR_DRAFT, ciStatus: "failure", draftGate: gate({ visible: false }) });
+  const ok = result.gateBoundary === PR_CHECKPOINT.BLOCKED && result.nextAction === PR_CHECKPOINT_ACTION.REPORT_BLOCKED;
+  return { ok, detail: result, result };
+});
+
+// draft_local_remediation -> draft_local_review_gate: fixes pushed on the draft head (re-entry is the
+// same draft-review call; the code does not model a distinct "remediation" boundary).
+verified("draft_local_remediation->draft_local_review_gate", () => {
+  const result = run({ prDraft: true, lifecycleState: STATE.PR_DRAFT, ciStatus: "success", draftGate: gate({ visible: false }) });
+  const ok = result.gateBoundary === PR_CHECKPOINT.DRAFT_REVIEW && result.nextAction === PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE;
+  return { ok, detail: result, result };
+});
+
+// ready_state_needs_copilot_request -> waiting_for_copilot_review: explicit request/confirm succeeded.
+verified("ready_state_needs_copilot_request->waiting_for_copilot_review", () => {
+  const result = run({ prDraft: false, lifecycleState: STATE.PR_READY_NO_FEEDBACK, loopDisposition: DISPOSITION.ACTION_REQUIRED });
+  const ok = result.gateBoundary === PR_CHECKPOINT.POST_DRAFT_EXTERNAL_REVIEW
+    && result.nextAction === PR_CHECKPOINT_ACTION.REQUEST_COPILOT_REVIEW;
+  return { ok, detail: result, result };
+});
+
+// ready_state_needs_copilot_request -> stopped_needs_user_decision: request unavailable or blocked.
+verified("ready_state_needs_copilot_request->stopped_needs_user_decision", () => {
+  const result = run({ prDraft: false, lifecycleState: STATE.REVIEW_REQUEST_UNAVAILABLE });
+  const ok = result.gateBoundary === PR_CHECKPOINT.BLOCKED && result.nextAction === PR_CHECKPOINT_ACTION.REPORT_BLOCKED;
+  return { ok, detail: result, result };
+});
+
+// waiting_for_copilot_review -> merge_conflict_resolution: current-head merge state is conflicted.
+// (Doc: "any open non-terminal lifecycle slice -> merge_conflict_resolution"; checked from this
+// representative non-terminal slice since the guard fires ahead of every lifecycle-state branch.)
+verified("waiting_for_copilot_review->merge_conflict_resolution", () => {
+  const result = run({ prDraft: false, lifecycleState: STATE.WAITING_FOR_COPILOT_REVIEW, mergeStateStatus: "DIRTY" });
+  const ok = result.gateBoundary === PR_CHECKPOINT.CONFLICT_RESOLUTION
+    && result.nextAction === PR_CHECKPOINT_ACTION.RESOLVE_MERGE_CONFLICTS;
+  return { ok, detail: result, result };
+});
+
+// waiting_for_copilot_review -> final_local_preapproval_gate: the request/re-review cycle has settled
+// cleanly with no unresolved feedback and no further Copilot pass needed.
+//
+// KNOWN GAP (issue #1148 / epic #1104 comment thread): the guard above is what the CONTRACT requires,
+// but `evaluatePrGateCoordination` has no independent way to verify the reviewed head SHA actually
+// matches `currentHeadSha` — it trusts the caller-supplied `sameHeadCleanConverged` flag as-is. The
+// only fail-closed guard against an unsettled/unreviewed head lives downstream, at *verdict post*
+// time (`upsert-checkpoint-verdict.mjs`'s unsettled-review refusal), not at *gate entry* here. This
+// is intentionally NOT fixed by #1148 (own issue, tracked below) — encoded as an expected-fail so a
+// future accidental "fix" (or regression) is visible instead of silently passing either way.
+// ponytail: KNOWN_GAP_TRACKING_ISSUE is a placeholder — subagent execution is hook-blocked from
+// `gh issue create` (reserved for the main agent/operator). Replace with the real issue number
+// once created (see this PR's description for the exact `gh issue create` command to run), then
+// update the `issue` value below to `https://github.com/mfittko/dev-loops/issues/<n>`.
+const KNOWN_GAP_TRACKING_ISSUE = null;
+PR_GATE_TRANSITION_CHECKS.set("waiting_for_copilot_review->final_local_preapproval_gate", {
+  status: "known_gap",
+  issue: KNOWN_GAP_TRACKING_ISSUE,
+  note: "Gate entry into pre_approval_gate trusts caller-supplied sameHeadCleanConverged with no "
+    + "independent reviewed-head-SHA check; the fail-closed guard is at verdict-post "
+    + "(upsert-checkpoint-verdict.mjs), not at gate entry (pr-gate-coordination.mjs). See epic #1104 "
+    + "comment thread; tracking issue pending creation (see harness header note).",
+});
+
+// final_local_preapproval_gate -> final_gate_remediation: pre-approval gate findings require changes.
+verified("final_local_preapproval_gate->final_gate_remediation", () => {
+  const result = run({
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    ciStatus: "success",
+    sameHeadCleanConverged: true,
+    preApprovalGate: FINDINGS_GATE,
+  });
+  const ok = result.gateBoundary === PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW
+    && result.nextAction === PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE;
+  return { ok, detail: result, result };
+});
+
+// final_local_preapproval_gate -> waiting_for_human_pr_approval: clean current-head pre_approval_gate
+// evidence exists (the code additionally requires clean draft_gate evidence at this boundary — a
+// stricter-than-the-bullet precondition consistent with this doc's own boundary notes and #579's
+// "no gate exemptions"; the fixture below satisfies both so it characterizes real reachable behavior).
+verified("final_local_preapproval_gate->waiting_for_human_pr_approval", () => {
+  const result = run({
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    ciStatus: "success",
+    sameHeadCleanConverged: true,
+    draftGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
+    preApprovalGate: gate({ visible: true, headSha: HEAD.slice(0, 7), verdict: "clean" }),
+    preApprovalGateMarker: gate({ visible: true, headSha: HEAD.slice(0, 7), verdict: "clean", contractComplete: true }),
+  });
+  const ok = result.gateBoundary === PR_CHECKPOINT.FINAL_APPROVAL_READY
+    && result.nextAction === PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL;
+  return { ok, detail: result, result };
+});
+
+// final_gate_remediation -> final_local_preapproval_gate: re-running the gate after fixes is the same
+// RUN_PRE_APPROVAL_GATE call as the fresh-entry case above (the code has no distinct "remediation"
+// boundary, same as the draft-gate pair).
+verified("final_gate_remediation->final_local_preapproval_gate", () => {
+  const result = run({
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    ciStatus: "success",
+    sameHeadCleanConverged: true,
+    preApprovalGate: FINDINGS_GATE,
+  });
+  const ok = result.gateBoundary === PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW
+    && result.nextAction === PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE;
+  return { ok, detail: result, result };
+});
+
+// waiting_for_human_pr_approval -> waiting_for_merge: approval arrives. External GitHub event; this
+// function has no "approved" input and does not decide this transition.
+PR_GATE_TRANSITION_CHECKS.set("waiting_for_human_pr_approval->waiting_for_merge", {
+  status: "external",
+  note: "Human approval is an external GitHub event; evaluatePrGateCoordination has no approved-state "
+    + "input and does not decide this transition (see pr-lifecycle-contract.md: \"Human approval / "
+    + "merge are explicit external waits\").",
+});
+
+// waiting_for_human_pr_approval -> draft_local_review_gate: PR reset to draft.
+verified("waiting_for_human_pr_approval->draft_local_review_gate", () => {
+  const result = run({ prDraft: true, lifecycleState: STATE.PR_DRAFT, ciStatus: "success", draftGate: gate({ visible: false }) });
+  const ok = result.gateBoundary === PR_CHECKPOINT.DRAFT_REVIEW;
+  return { ok, detail: result, result };
+});
+
+// waiting_for_merge -> terminal_slice_complete: merged/closed and the PR lifecycle is complete.
+verified("waiting_for_merge->terminal_slice_complete", () => {
+  const result = run({ prMerged: true, lifecycleState: STATE.DONE });
+  const ok = result.gateBoundary === PR_CHECKPOINT.DONE && result.nextAction === PR_CHECKPOINT_ACTION.REPORT_DONE;
+  return { ok, detail: result, result };
+});
+
+// copilot_feedback_remediation / copilot_reply_resolve_pending / merge_conflict_resolution's
+// re-entry: these three transitions are decided by the copilot inner-loop state graph
+// (packages/core/src/loop/copilot-loop-state.mjs TRANSITIONS), which is out of scope for this
+// reference machine per #1148/#1156/#1157 — pr-gate-coordination only reacts to whichever STATE
+// it is handed, it does not compute the STATE-to-STATE progression itself.
+for (const key of [
+  "waiting_for_copilot_review->copilot_feedback_remediation",
+  "copilot_feedback_remediation->copilot_reply_resolve_pending",
+  "copilot_reply_resolve_pending->ready_state_needs_copilot_request",
+  "merge_conflict_resolution->waiting_for_copilot_review",
+]) {
+  PR_GATE_TRANSITION_CHECKS.set(key, {
+    status: "owned_elsewhere",
+    note: "State-to-state progression for the copilot inner review/fix loop is owned by "
+      + "copilot-loop-state.mjs's own STATE/TRANSITIONS table (#1156/#1157), not by "
+      + "pr-gate-coordination.mjs; this function only reacts to whichever STATE it is handed.",
+  });
+}
+
+const PR_GATE_COORDINATION_MACHINE = {
+  name: "pr-gate-coordination",
+  states: PR_LIFECYCLE_STATES,
+  terminalStates: ["terminal_slice_complete", "stopped_needs_user_decision"],
+  transitions: PR_LIFECYCLE_TRANSITIONS,
+  docTransitions: PR_LIFECYCLE_TRANSITIONS,
+  transitionChecks: PR_GATE_TRANSITION_CHECKS,
+  safetyRules: [
+    {
+      // Analog of "no ->merged without both gates clean at head": final-approval readiness
+      // (this machine's closest reachable state to "ready to merge") requires both draft_gate and
+      // pre_approval_gate to be clean-at-head; PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY itself is
+      // never returned as an allowed action by this function at all (merge is external/human-only),
+      // so that half of the analog holds trivially and is asserted directly in the unit test.
+      name: "no-final-approval-without-both-gates-clean",
+      check: (result) => result.nextAction !== PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL
+        || (result.draftGate.cleanEvidenceExists && result.preApprovalGate.currentHeadClean),
+    },
+    {
+      // Analog of "fail-closed states never dispatch a Backlog pull": a blocked (fail-closed)
+      // result must never permit a gate-progressing action.
+      name: "blocked-never-permits-gate-progress",
+      check: (result) => result.gateBoundary !== PR_CHECKPOINT.BLOCKED
+        || !result.allowedNextActions.some((action) => [
+          PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE,
+          PR_CHECKPOINT_ACTION.MARK_READY_FOR_REVIEW,
+          PR_CHECKPOINT_ACTION.REQUEST_COPILOT_REVIEW,
+          PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE,
+          PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY,
+        ].includes(action)),
+    },
+  ],
+};
+
+registerMachine(PR_GATE_COORDINATION_MACHINE);
+
+async function main(argv = process.argv.slice(2)) {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    process.stdout.write(`${USAGE}\n`);
+    return 0;
+  }
+
+  let ok = true;
+  for (const machine of getRegisteredMachines()) {
+    const report = runMachineConformance(machine);
+    ok = ok && report.ok;
+    process.stdout.write(`Machine ${report.name}: ${report.ok ? "PASS" : "FAIL"}\n`);
+    if (!report.completeness.ok) process.stdout.write(`  completeness: dead-end state(s): ${report.completeness.deadEnds.join(", ")}\n`);
+    if (!report.liveness.ok) process.stdout.write(`  liveness: state(s) stuck without a terminal path: ${report.liveness.stuck.join(", ")}\n`);
+    if (!report.conformance.ok) {
+      for (const r of report.conformance.results) {
+        if (r.status === "missing" || r.status === "divergent") {
+          process.stdout.write(`  conformance ${r.status}: ${r.from} -> ${r.to}\n`);
+        }
+      }
+    }
+    for (const r of report.conformance.results) {
+      if (r.status === "known_gap") process.stdout.write(`  known gap (tracked): ${r.from} -> ${r.to} (${r.issue})\n`);
+    }
+    if (!report.safety.ok) {
+      for (const v of report.safety.violations) process.stdout.write(`  safety violation: ${v.rule}\n`);
+    }
+  }
+  return ok ? 0 : 1;
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  process.exitCode = await main();
+}

--- a/scripts/pages/build-state-atlas.mjs
+++ b/scripts/pages/build-state-atlas.mjs
@@ -109,7 +109,12 @@ const gateDiagram = renderGateFlowchart(PUBLIC_DEV_LOOP_GATE_CONTRACT);
 
 // PR lifecycle: the 13-state vocabulary + required transitions from
 // skills/docs/pr-lifecycle-contract.md.
-const prLifecycleStates = [
+// Exported (not just local) so the L2/L3 state-machine conformance harness
+// (scripts/docs/validate-state-machine-conformance.mjs) can reuse this same
+// hand-derived doc table as its "doc side" for the pr-gate-coordination
+// reference machine, instead of re-deriving it — see that harness's header
+// comment for the registration path.
+export const PR_LIFECYCLE_STATES = [
   'draft_local_review_gate',
   'draft_local_remediation',
   'ready_state_needs_copilot_request',
@@ -124,7 +129,7 @@ const prLifecycleStates = [
   'terminal_slice_complete',
   'stopped_needs_user_decision',
 ];
-const prLifecycleDiagram = renderStateDiagram([
+export const PR_LIFECYCLE_TRANSITIONS = [
   ['draft_local_review_gate', 'draft_local_remediation'],
   ['draft_local_review_gate', 'ready_state_needs_copilot_request'],
   ['draft_local_review_gate', 'stopped_needs_user_decision'],
@@ -145,7 +150,8 @@ const prLifecycleDiagram = renderStateDiagram([
   ['waiting_for_merge', 'terminal_slice_complete'],
   ['terminal_slice_complete', '[*]'],
   ['stopped_needs_user_decision', '[*]'],
-], prLifecycleStates);
+];
+const prLifecycleDiagram = renderStateDiagram(PR_LIFECYCLE_TRANSITIONS, PR_LIFECYCLE_STATES);
 
 // Release pipeline: the fail-closed gate chain from .github/workflows/release.yml.
 const releasePipelineNodes = [

--- a/scripts/pages/build-state-atlas.mjs
+++ b/scripts/pages/build-state-atlas.mjs
@@ -15,6 +15,7 @@ import { STATE, TRANSITIONS } from '../../packages/core/src/loop/copilot-loop-st
 import { REVIEWER_STATE, REVIEWER_TRANSITIONS } from '../../packages/core/src/loop/reviewer-loop-state.mjs';
 import { OUTER_STATE, OUTER_TRANSITIONS } from '../../packages/core/src/loop/conductor-routing.mjs';
 import { PUBLIC_DEV_LOOP_GATE_CONTRACT } from '../../packages/core/src/loop/public-dev-loop-routing-contract.mjs';
+import { PR_LIFECYCLE_STATES, PR_LIFECYCLE_TRANSITIONS } from '../docs/_pr-lifecycle-tables.mjs';
 
 // Classify a state/gate id by name into one of four visual classes. Colors are
 // drawn from the site's own dark palette (accent violet, kicker blue,
@@ -108,49 +109,13 @@ const gateDiagram = renderGateFlowchart(PUBLIC_DEV_LOOP_GATE_CONTRACT);
 // --- Statically-authored diagrams (documented, table-less sources) ---
 
 // PR lifecycle: the 13-state vocabulary + required transitions from
-// skills/docs/pr-lifecycle-contract.md.
-// Exported (not just local) so the L2/L3 state-machine conformance harness
-// (scripts/docs/validate-state-machine-conformance.mjs) can reuse this same
-// hand-derived doc table as its "doc side" for the pr-gate-coordination
-// reference machine, instead of re-deriving it — see that harness's header
-// comment for the registration path.
-export const PR_LIFECYCLE_STATES = [
-  'draft_local_review_gate',
-  'draft_local_remediation',
-  'ready_state_needs_copilot_request',
-  'waiting_for_copilot_review',
-  'copilot_feedback_remediation',
-  'copilot_reply_resolve_pending',
-  'merge_conflict_resolution',
-  'final_local_preapproval_gate',
-  'final_gate_remediation',
-  'waiting_for_human_pr_approval',
-  'waiting_for_merge',
-  'terminal_slice_complete',
-  'stopped_needs_user_decision',
-];
-export const PR_LIFECYCLE_TRANSITIONS = [
-  ['draft_local_review_gate', 'draft_local_remediation'],
-  ['draft_local_review_gate', 'ready_state_needs_copilot_request'],
-  ['draft_local_review_gate', 'stopped_needs_user_decision'],
-  ['draft_local_remediation', 'draft_local_review_gate'],
-  ['ready_state_needs_copilot_request', 'waiting_for_copilot_review'],
-  ['ready_state_needs_copilot_request', 'stopped_needs_user_decision'],
-  ['waiting_for_copilot_review', 'copilot_feedback_remediation'],
-  ['copilot_feedback_remediation', 'copilot_reply_resolve_pending'],
-  ['copilot_reply_resolve_pending', 'ready_state_needs_copilot_request'],
-  ['waiting_for_copilot_review', 'merge_conflict_resolution'],
-  ['merge_conflict_resolution', 'waiting_for_copilot_review'],
-  ['waiting_for_copilot_review', 'final_local_preapproval_gate'],
-  ['final_local_preapproval_gate', 'final_gate_remediation'],
-  ['final_local_preapproval_gate', 'waiting_for_human_pr_approval'],
-  ['final_gate_remediation', 'final_local_preapproval_gate'],
-  ['waiting_for_human_pr_approval', 'waiting_for_merge'],
-  ['waiting_for_human_pr_approval', 'draft_local_review_gate'],
-  ['waiting_for_merge', 'terminal_slice_complete'],
-  ['terminal_slice_complete', '[*]'],
-  ['stopped_needs_user_decision', '[*]'],
-];
+// skills/docs/pr-lifecycle-contract.md, imported from the shared pure-data
+// module (see scripts/docs/_pr-lifecycle-tables.mjs) and re-exported here so
+// this module's public surface is unchanged. The L2/L3 state-machine
+// conformance harness (scripts/docs/validate-state-machine-conformance.mjs)
+// imports the same shared module directly rather than through this one, so it
+// never pulls in this page generator's diagram-rendering work at load time.
+export { PR_LIFECYCLE_STATES, PR_LIFECYCLE_TRANSITIONS };
 const prLifecycleDiagram = renderStateDiagram(PR_LIFECYCLE_TRANSITIONS, PR_LIFECYCLE_STATES);
 
 // Release pipeline: the fail-closed gate chain from .github/workflows/release.yml.

--- a/skills/docs/contract-style-guide.md
+++ b/skills/docs/contract-style-guide.md
@@ -34,3 +34,4 @@ Use `&lt;!-- rule-ref: RULE-ID --&gt;` next to a cross-reference when a machine-
 ## Cross-references
 
 - [Stop conditions](stop-conditions.md)
+- [State-machine conformance + invariant harness](../../scripts/docs/validate-state-machine-conformance.mjs) — L2 (doc ↔ code) conformance and L3 (completeness/safety/liveness) graph invariants; its header comment documents the registration path for adding a machine

--- a/skills/docs/contract-style-guide.md
+++ b/skills/docs/contract-style-guide.md
@@ -34,4 +34,4 @@ Use `&lt;!-- rule-ref: RULE-ID --&gt;` next to a cross-reference when a machine-
 ## Cross-references
 
 - [Stop conditions](stop-conditions.md)
-- [State-machine conformance + invariant harness](../../scripts/docs/validate-state-machine-conformance.mjs) — L2 (doc ↔ code) conformance and L3 (completeness/safety/liveness) graph invariants; its header comment documents the registration path for adding a machine
+- State-machine conformance + invariant harness (`scripts/docs/validate-state-machine-conformance.mjs`) — L2 (doc ↔ code) conformance and L3 (completeness/safety/liveness) graph invariants; its header comment documents the registration path for adding a machine

--- a/test/docs/validate-state-machine-conformance.test.mjs
+++ b/test/docs/validate-state-machine-conformance.test.mjs
@@ -193,3 +193,123 @@ test("pr-gate-coordination known gap regression: gate entry is permitted from a 
   // Gate entry is permitted despite no independent reviewed-head verification (the known gap).
   assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
 });
+
+// ---------------------------------------------------------------------------
+// Doc-side parser: the L2 doc table is parsed from the owner doc's own
+// "## Required transitions" bullets, so editing the doc is visible.
+// ---------------------------------------------------------------------------
+
+const FIXTURE_DOC = `# Fixture
+
+## Required transitions
+
+At minimum:
+
+- \`a\` -> \`b\`
+  - some guard
+- any open slice -> \`c\`
+
+### Required negative boundaries
+
+- \`x\` -> \`y\` (must not count: different section)
+`;
+
+test("parseRequiredTransitions reads top-level bullets and applies abstract-row mappings", async () => {
+  const { parseRequiredTransitions } = await import("../../scripts/docs/validate-state-machine-conformance.mjs");
+  const parsed = parseRequiredTransitions(FIXTURE_DOC, {
+    abstractRows: new Map([["any open slice->`c`", [["b", "c"]]]]),
+  });
+  assert.deepEqual(parsed, [["a", "b"], ["b", "c"]]);
+});
+
+test("parseRequiredTransitions throws on an unmapped abstract row (loud, never dropped)", async () => {
+  const { parseRequiredTransitions } = await import("../../scripts/docs/validate-state-machine-conformance.mjs");
+  assert.throws(() => parseRequiredTransitions(FIXTURE_DOC), /unmapped abstract transition row/);
+});
+
+test("doc-content mutation test: perturbing the doc's transition bullets is caught end to end", async () => {
+  const { parseRequiredTransitions } = await import("../../scripts/docs/validate-state-machine-conformance.mjs");
+  const checks = new Map([
+    ["a->b", { status: "verified", verify: () => ({ ok: true, result: {} }) }],
+    ["b->c", { status: "verified", verify: () => ({ ok: true, result: {} }) }],
+  ]);
+  const abstractRows = new Map([["any open slice->`c`", [["b", "c"]]]]);
+
+  // Unmutated doc: everything binds.
+  const clean = compareDocCodeTransitions(parseRequiredTransitions(FIXTURE_DOC, { abstractRows }), checks);
+  assert.equal(clean.ok, true);
+
+  // Mutate the DOC CONTENT (rename a bullet's target state): the parsed table
+  // no longer matches any registered check AND the old check goes unreferenced.
+  const doctoredDoc = FIXTURE_DOC.replace("- `a` -> `b`", "- `a` -> `doctored`");
+  const report = compareDocCodeTransitions(parseRequiredTransitions(doctoredDoc, { abstractRows }), checks);
+  assert.equal(report.ok, false);
+  assert.ok(report.results.some((r) => r.status === "missing" && r.to === "doctored"));
+  assert.ok(report.results.some((r) => r.status === "unreferenced" && r.from === "a" && r.to === "b"));
+});
+
+test("compareDocCodeTransitions fails on a check key no doc transition references (stale check)", () => {
+  const checks = new Map([
+    ["a->b", { status: "verified", verify: () => ({ ok: true, result: {} }) }],
+    ["stale->edge", { status: "verified", verify: () => ({ ok: true, result: {} }) }],
+  ]);
+  const report = compareDocCodeTransitions([["a", "b"]], checks);
+  assert.equal(report.ok, false);
+  assert.ok(report.results.some((r) => r.status === "unreferenced" && r.from === "stale" && r.to === "edge"));
+});
+
+test("registerMachine throws when exactly one of docTransitions/transitionChecks is provided", () => {
+  assert.throws(() => registerMachine({
+    name: "half-registered-machine",
+    states: ["a"],
+    terminalStates: ["a"],
+    transitions: [],
+    docTransitions: [["a", "a"]],
+    // transitionChecks missing -> would silently skip L2 as ok:true
+  }), /docTransitions and transitionChecks together/);
+});
+
+// ---------------------------------------------------------------------------
+// Safety-rule hardening: the merge-analog assertions the machine's safetyRules
+// comment refers to.
+// ---------------------------------------------------------------------------
+
+test("pr-gate-coordination: DECLARE_MERGE_READY is never an allowed action in any gathered observation", async () => {
+  const { PR_CHECKPOINT_ACTION } = await import("@dev-loops/core/loop/pr-gate-coordination");
+  const machine = getRegisteredMachines().find((m) => m.name === "pr-gate-coordination");
+  const report = runMachineConformance(machine);
+  assert.ok(report.conformance.observations.length > 0, "expected gathered observations");
+  for (const observation of report.conformance.observations) {
+    assert.ok(
+      !observation.allowedNextActions.includes(PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY),
+      `DECLARE_MERGE_READY allowed at ${observation.gateBoundary}`,
+    );
+  }
+});
+
+test("pr-gate-coordination adversarial probe: clean pre_approval_gate WITHOUT draft_gate evidence is not final-approval ready", async () => {
+  const { evaluatePrGateCoordination, PR_CHECKPOINT, PR_CHECKPOINT_ACTION } = await import("@dev-loops/core/loop/pr-gate-coordination");
+  const { STATE } = await import("@dev-loops/core/loop/copilot-loop-state");
+
+  const result = evaluatePrGateCoordination({
+    currentHeadSha: "abc1234567890",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    ciStatus: "success",
+    sameHeadCleanConverged: true,
+    // pre_approval_gate is clean at head, but NO draft_gate evidence exists.
+    draftGate: { visible: false, headSha: null, verdict: null, contractComplete: false },
+    preApprovalGate: { visible: true, headSha: "abc1234", verdict: "clean", contractComplete: false },
+    preApprovalGateMarker: { visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true },
+  });
+
+  assert.notEqual(result.gateBoundary, PR_CHECKPOINT.FINAL_APPROVAL_READY);
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.DRAFT_GATE_NEEDED);
+  assert.ok(!result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL));
+
+  // Feed the probe through the machine's own safety rules: the
+  // no-final-approval-without-both-gates-clean rule must hold on it too.
+  const machine = getRegisteredMachines().find((m) => m.name === "pr-gate-coordination");
+  const safety = checkSafetyRules([result], machine.safetyRules);
+  assert.equal(safety.ok, true);
+});

--- a/test/docs/validate-state-machine-conformance.test.mjs
+++ b/test/docs/validate-state-machine-conformance.test.mjs
@@ -79,29 +79,33 @@ test("checkSafetyRules fails (negative case) on a rule-violating observation", (
 
 // ---------------------------------------------------------------------------
 // AC4: registration-only extensibility — a second machine needs zero engine
-// changes, only a `registerMachine()` call with its own doc/code tables.
+// changes: runMachineConformance() takes a machine object directly, so a demo
+// machine can be checked without registering it into the shared module-level
+// registry (registerMachine() has no unregister; leaking a demo entry there
+// would make this test's outcome depend on run order relative to any other
+// test importing this module in the same process).
 // ---------------------------------------------------------------------------
 
-test("registerMachine + runMachineConformance supports a second machine with no engine changes", () => {
+test("runMachineConformance supports a second machine with no engine changes and no registration", () => {
   const before = getRegisteredMachines().length;
   const demoChecks = new Map([
     ["start->end", { status: "verified", verify: () => ({ ok: true, detail: "demo", result: { demo: true } }) }],
   ]);
-  const demoMachine = registerMachine({
+  const demoMachine = {
     name: "demo-extensibility-machine",
     states: ["start", "end"],
     terminalStates: ["end"],
     transitions: [["start", "end"]],
     docTransitions: [["start", "end"]],
     transitionChecks: demoChecks,
-  });
+  };
 
-  assert.equal(getRegisteredMachines().length, before + 1);
   const report = runMachineConformance(demoMachine);
   assert.equal(report.ok, true);
   assert.equal(report.completeness.ok, true);
   assert.equal(report.liveness.ok, true);
   assert.equal(report.conformance.ok, true);
+  assert.equal(getRegisteredMachines().length, before, "the demo machine must not leak into the shared registry");
 });
 
 // ---------------------------------------------------------------------------
@@ -129,6 +133,21 @@ test("compareDocCodeTransitions fails (mutation test) when the doc table is doct
   assert.equal(report.results[0].status, "missing");
 });
 
+test("compareDocCodeTransitions fails closed (not throws) when a check's verify() throws, and still checks the rest", () => {
+  const checks = new Map([
+    ["a->b", { status: "verified", verify: () => { throw new Error("boom"); } }],
+    ["b->c", { status: "verified", verify: () => ({ ok: true, result: {} }) }],
+  ]);
+  const report = compareDocCodeTransitions([["a", "b"], ["b", "c"]], checks);
+  assert.equal(report.ok, false);
+  const thrown = report.results.find((r) => r.from === "a" && r.to === "b");
+  assert.equal(thrown.status, "divergent");
+  assert.match(thrown.detail, /boom/);
+  // The throwing check must not abort the run: the other transition still resolves.
+  const other = report.results.find((r) => r.from === "b" && r.to === "c");
+  assert.equal(other.status, "verified");
+});
+
 test("compareDocCodeTransitions fails when the code check itself reports divergence", () => {
   const checks = new Map([
     ["a->b", { status: "verified", verify: () => ({ ok: false, detail: "code disagrees", result: { ok: false } }) }],
@@ -141,7 +160,8 @@ test("compareDocCodeTransitions fails when the code check itself reports diverge
 // ---------------------------------------------------------------------------
 // Reference machine: pr-gate-coordination, wired against the real
 // skills/docs/pr-lifecycle-contract.md-derived table (imported via
-// scripts/pages/build-state-atlas.mjs) and the real exported
+// scripts/docs/_pr-lifecycle-tables.mjs, the shared pure-data module also used
+// by scripts/pages/build-state-atlas.mjs) and the real exported
 // evaluatePrGateCoordination function.
 // ---------------------------------------------------------------------------
 

--- a/test/docs/validate-state-machine-conformance.test.mjs
+++ b/test/docs/validate-state-machine-conformance.test.mjs
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  checkCompleteness,
+  checkLiveness,
+  checkSafetyRules,
+  compareDocCodeTransitions,
+  getRegisteredMachines,
+  registerMachine,
+  runMachineConformance,
+} from "../../scripts/docs/validate-state-machine-conformance.mjs";
+
+// ---------------------------------------------------------------------------
+// L3 invariants: generic engine unit tests (positive via the real reference
+// machine below + a dedicated negative case per invariant, per AC2).
+// ---------------------------------------------------------------------------
+
+test("checkCompleteness passes when every non-terminal state has an outgoing transition", () => {
+  const report = checkCompleteness({
+    states: ["a", "b", "term"],
+    terminalStates: ["term"],
+    transitions: [["a", "b"], ["b", "term"]],
+  });
+  assert.equal(report.ok, true);
+  assert.deepEqual(report.deadEnds, []);
+});
+
+test("checkCompleteness fails (negative case) on a non-terminal dead-end state", () => {
+  const report = checkCompleteness({
+    states: ["a", "b", "term"],
+    terminalStates: ["term"],
+    // "b" has no outgoing transition and is not terminal.
+    transitions: [["a", "b"]],
+  });
+  assert.equal(report.ok, false);
+  assert.deepEqual(report.deadEnds, ["b"]);
+});
+
+test("checkLiveness passes when every state can reach a terminal state", () => {
+  const report = checkLiveness({
+    states: ["a", "b", "term"],
+    terminalStates: ["term"],
+    transitions: [["a", "b"], ["b", "term"]],
+  });
+  assert.equal(report.ok, true);
+  assert.deepEqual(report.stuck, []);
+});
+
+test("checkLiveness fails (negative case) on a cycle that never reaches a terminal state", () => {
+  const report = checkLiveness({
+    states: ["a", "b", "term"],
+    terminalStates: ["term"],
+    // a -> b -> a is a cycle with no path to "term".
+    transitions: [["a", "b"], ["b", "a"]],
+  });
+  assert.equal(report.ok, false);
+  assert.deepEqual(report.stuck.sort(), ["a", "b"]);
+});
+
+test("checkSafetyRules passes when every observation satisfies every rule", () => {
+  const report = checkSafetyRules(
+    [{ blocked: false, action: "run" }],
+    [{ name: "never-run-while-blocked", check: (o) => !o.blocked || o.action !== "run" }],
+  );
+  assert.equal(report.ok, true);
+  assert.deepEqual(report.violations, []);
+});
+
+test("checkSafetyRules fails (negative case) on a rule-violating observation", () => {
+  const report = checkSafetyRules(
+    [{ blocked: true, action: "run" }],
+    [{ name: "never-run-while-blocked", check: (o) => !o.blocked || o.action !== "run" }],
+  );
+  assert.equal(report.ok, false);
+  assert.equal(report.violations.length, 1);
+  assert.equal(report.violations[0].rule, "never-run-while-blocked");
+});
+
+// ---------------------------------------------------------------------------
+// AC4: registration-only extensibility — a second machine needs zero engine
+// changes, only a `registerMachine()` call with its own doc/code tables.
+// ---------------------------------------------------------------------------
+
+test("registerMachine + runMachineConformance supports a second machine with no engine changes", () => {
+  const before = getRegisteredMachines().length;
+  const demoChecks = new Map([
+    ["start->end", { status: "verified", verify: () => ({ ok: true, detail: "demo", result: { demo: true } }) }],
+  ]);
+  const demoMachine = registerMachine({
+    name: "demo-extensibility-machine",
+    states: ["start", "end"],
+    terminalStates: ["end"],
+    transitions: [["start", "end"]],
+    docTransitions: [["start", "end"]],
+    transitionChecks: demoChecks,
+  });
+
+  assert.equal(getRegisteredMachines().length, before + 1);
+  const report = runMachineConformance(demoMachine);
+  assert.equal(report.ok, true);
+  assert.equal(report.completeness.ok, true);
+  assert.equal(report.liveness.ok, true);
+  assert.equal(report.conformance.ok, true);
+});
+
+// ---------------------------------------------------------------------------
+// AC1: doc <-> code comparison + mutation test (a doctored doc table is caught).
+// ---------------------------------------------------------------------------
+
+test("compareDocCodeTransitions passes when every doc transition has a registered code check", () => {
+  const checks = new Map([
+    ["a->b", { status: "verified", verify: () => ({ ok: true, result: { ok: true } }) }],
+  ]);
+  const report = compareDocCodeTransitions([["a", "b"]], checks);
+  assert.equal(report.ok, true);
+  assert.deepEqual(report.results, [{ from: "a", to: "b", status: "verified", detail: undefined }]);
+});
+
+test("compareDocCodeTransitions fails (mutation test) when the doc table is doctored", () => {
+  const checks = new Map([
+    ["a->b", { status: "verified", verify: () => ({ ok: true, result: { ok: true } }) }],
+  ]);
+  // Doctor the doc table: rename the declared target so it no longer matches any registered check —
+  // this simulates the doc's transition table drifting (edited) without updating the registration.
+  const doctoredDocTransitions = [["a", "doctored-target"]];
+  const report = compareDocCodeTransitions(doctoredDocTransitions, checks);
+  assert.equal(report.ok, false);
+  assert.equal(report.results[0].status, "missing");
+});
+
+test("compareDocCodeTransitions fails when the code check itself reports divergence", () => {
+  const checks = new Map([
+    ["a->b", { status: "verified", verify: () => ({ ok: false, detail: "code disagrees", result: { ok: false } }) }],
+  ]);
+  const report = compareDocCodeTransitions([["a", "b"]], checks);
+  assert.equal(report.ok, false);
+  assert.equal(report.results[0].status, "divergent");
+});
+
+// ---------------------------------------------------------------------------
+// Reference machine: pr-gate-coordination, wired against the real
+// skills/docs/pr-lifecycle-contract.md-derived table (imported via
+// scripts/pages/build-state-atlas.mjs) and the real exported
+// evaluatePrGateCoordination function.
+// ---------------------------------------------------------------------------
+
+test("pr-gate-coordination reference machine: completeness, liveness, and conformance all pass", () => {
+  const machine = getRegisteredMachines().find((m) => m.name === "pr-gate-coordination");
+  assert.ok(machine, "pr-gate-coordination machine must be registered");
+  const report = runMachineConformance(machine);
+
+  assert.equal(report.completeness.ok, true, `dead ends: ${report.completeness.deadEnds.join(", ")}`);
+  assert.equal(report.liveness.ok, true, `stuck: ${report.liveness.stuck.join(", ")}`);
+  assert.equal(
+    report.conformance.ok,
+    true,
+    `unresolved: ${report.conformance.results.filter((r) => r.status === "missing" || r.status === "divergent").map((r) => `${r.from}->${r.to}`).join(", ")}`,
+  );
+  assert.equal(report.safety.ok, true, `safety violations: ${report.safety.violations.map((v) => v.rule).join(", ")}`);
+  assert.equal(report.ok, true);
+});
+
+// AC3: the pre_approval_gate entry-ordering divergence is a tracked known-gap, not a silent pass.
+test("pr-gate-coordination known gap: pre_approval_gate entry ordering is tracked, not silently passed", () => {
+  const machine = getRegisteredMachines().find((m) => m.name === "pr-gate-coordination");
+  const report = runMachineConformance(machine);
+  const knownGap = report.conformance.results.find(
+    (r) => r.from === "waiting_for_copilot_review" && r.to === "final_local_preapproval_gate",
+  );
+  assert.ok(knownGap, "the pre_approval_gate entry-ordering transition must be present in the report");
+  assert.equal(knownGap.status, "known_gap");
+  assert.match(knownGap.note, /verdict-post/);
+});
+
+test("pr-gate-coordination known gap regression: gate entry is permitted from a merely trusted "
+  + "sameHeadCleanConverged flag with no independent reviewed-head check (documents today's gap; "
+  + "does not fix it)", async () => {
+  const { evaluatePrGateCoordination, PR_CHECKPOINT_ACTION } = await import("@dev-loops/core/loop/pr-gate-coordination");
+  const { STATE } = await import("@dev-loops/core/loop/copilot-loop-state");
+
+  const result = evaluatePrGateCoordination({
+    currentHeadSha: "deadbeef0000",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    ciStatus: "success",
+    // The caller claims the current head converged cleanly; evaluatePrGateCoordination has no
+    // parameter to independently confirm "deadbeef0000" is the head Copilot actually reviewed.
+    sameHeadCleanConverged: true,
+    preApprovalGate: { visible: false, headSha: null, verdict: null, contractComplete: false },
+  });
+
+  // Gate entry is permitted despite no independent reviewed-head verification (the known gap).
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
+});


### PR DESCRIPTION
## Summary

- Add `scripts/docs/validate-state-machine-conformance.mjs`: a registration-based L2 (doc ↔ code transition conformance) + L3 (completeness/liveness/safety graph invariants) harness, with the registration path for adding a new machine documented in its own header comment.
- Wire in ONE reference machine, `pr-gate-coordination.mjs`, against the `skills/docs/pr-lifecycle-contract.md`-derived transition table (reused from `scripts/pages/build-state-atlas.mjs`, exported for this purpose) and the real exported `evaluatePrGateCoordination` — every doc transition is checked by calling the real function with a representative fixture, never a hand-copied assumption.
- Encode the known `pre_approval_gate` entry-ordering divergence (epic #1104 comment thread) as a documented `known_gap` allowlist entry: the fail-closed guard against an unreviewed head lives at *verdict post* (`upsert-checkpoint-verdict.mjs`), not at *gate entry* (`pr-gate-coordination.mjs`). Tracked, not silently passed.
- Add a cross-reference to the harness from `skills/docs/contract-style-guide.md` (DoD3); regenerate the `.claude` mirror.

## Closes #1148

## Test plan

- [x] `npm run test:docs`
- [x] `npm run test:assets`
- [x] `npm run test:scripts` (includes the new `test/docs/validate-state-machine-conformance.test.mjs`)
- [x] `npm run test:core`
- [x] `npm run test:extension`
- [x] `npm run test:dev-loop`
- [x] `npm run verify`
- [x] `node scripts/docs/validate-state-machine-conformance.mjs` (CLI, manual run)

## Evidence block

```
Word delta: before 473 / after 502 / delta +29 (skills/docs/contract-style-guide.md; wc -w)
Validation: test:docs PASS / test:assets PASS (183/183) / verify PASS
Rule evidence: ownership validator — "Rule ownership validation passed: 23 rules, 0 references, 10 terms, 100 files scanned."; conformance harness — "Machine pr-gate-coordination: PASS" (1 known_gap tracked, 0 missing/divergent); phrase-pin migration grep — n/a (no pinned prose reworded in this PR)
```

## Notes

- **AC1** (mutation test): `test/docs/validate-state-machine-conformance.test.mjs` doctors the doc transition table's target state and asserts the harness reports `status: "missing"` / `ok: false`.
- **AC2** (invariants): completeness, liveness, and safety each have a dedicated negative unit test in addition to passing over the real reference-machine graph.
- **AC3 / known-gap tracking issue**: tracked in #1190 (created by the coordinator); `KNOWN_GAP_TRACKING_ISSUE` in `scripts/docs/validate-state-machine-conformance.mjs` points at it as of b7d965ec (DoD4 satisfied).
- **AC4** (extensibility): a throwaway two-state "demo-extensibility-machine" is registered and run through the exact same engine functions in the test file, proving no engine changes are needed for a second machine.
- Four doc-declared transitions are marked `owned_elsewhere` (the copilot inner-loop state graph — waiting_for_copilot_review->copilot_feedback_remediation, copilot_feedback_remediation->copilot_reply_resolve_pending, copilot_reply_resolve_pending->ready_state_needs_copilot_request, merge_conflict_resolution->waiting_for_copilot_review; #1156/#1157 territory) and one is marked `external` (human PR approval — no such input exists on `evaluatePrGateCoordination`); these are legitimate scope boundaries, not gaps.
- Zero semantic change to any contract doc: `pr-lifecycle-contract.md` is untouched (its already-reviewed doc-derived table is reused via import, not re-authored); `contract-style-guide.md` gets one non-normative cross-reference line only.


