### PR TITLE
fix(pages): gate-hub flowchart renders LR (#1208)

### DIFF
--- a/scripts/pages/build-state-atlas.mjs
+++ b/scripts/pages/build-state-atlas.mjs
@@ -81,7 +81,7 @@ function gateClass(row) {
 }
 
 function renderGateFlowchart(contract) {
-  const lines = ['flowchart TD', '    router(["dev-loop router"])'];
+  const lines = ['flowchart LR', '    router(["dev-loop router"])'];
   for (const row of contract) {
     const strategy = row.selectedStrategy ?? 'none';
     lines.push(`    router -->|${row.routeKind}| ${row.gate}["${row.gate} — ${strategy}"]`);


### PR DESCRIPTION
## Summary

- The "Public dev-loop gate hub" atlas section rendered `flowchart TD` — one hub fanning out to eleven gates horizontally, shrinking nodes to unreadable size. The hub flowchart now renders `flowchart LR` (hub left, gates stacked vertically). Other atlas sections keep their orientation.

Closes #1208

## Spec (lightweight, PR-body-as-spec)

- Objective: readable gate-hub diagram on state-atlas.html.
- In scope: `renderGateFlowchart` orientation only. Non-goals: other diagram sections, mermaid theming, site pipeline.
- Acceptance criteria: gate-hub mermaid source begins `flowchart LR`; other sections unchanged; pages tests green.
- DoD: merged with light-mode gate evidence; site re-renders on next pages deploy.
- Risks: none — presentation-only, deterministic generator output verified locally (`build-state-atlas.mjs` builds clean; test/pages 7/7).
