### PR TITLE
fix(pages): bump deploy-pages to v5 (#1211)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -59,4 +59,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

- Bumps the Pages deploy step to `actions/deploy-pages@v5`. v4 deployments fail instantly ("Deployment failed, try again later") across a rerun, a fresh-artifact dispatch, and a Pages-config re-assert; v4's action manifest also still declares the deprecated node20 runtime.

Closes #1211

## Spec (lightweight, PR-body-as-spec)

- Objective: working Pages deploys on main (unblocks serving the LR gate-hub atlas from #1209).
- In scope: the one `uses:` line. Non-goals: upload-pages-artifact/configure-pages versions (current majors), workflow structure.
- Acceptance criteria: pages.yml lints (actionlint green); next main deploy succeeds.
- DoD: merged with light-mode gate evidence; post-merge pages run observed green.
- Risks: v5 requires actions/configure-pages@v5+ (already at v5) — none identified.
