### PR TITLE
feat(pages): fullscreen lightbox for state-atlas diagrams

### DIFF
--- a/scripts/pages/build-state-atlas.mjs
+++ b/scripts/pages/build-state-atlas.mjs
@@ -375,7 +375,7 @@ export function buildStateAtlasHtml() {
   .diagram .mermaid { text-align: center; }
   .diagram .mermaid svg { max-width: 100%; height: auto; }
   .diagram { position: relative; }
-  .diagram .expand { position: absolute; top: 0.6rem; right: 0.6rem; z-index: 2; font: 600 0.72rem var(--font); color: var(--copy); background: rgba(15, 23, 42, 0.85); border: 1px solid var(--card-border); border-radius: 8px; padding: 0.35rem 0.6rem; cursor: pointer; }
+  .diagram .expand { position: sticky; float: right; top: 0.6rem; right: 0.6rem; margin: 0 0 -2rem; z-index: 2; font: 600 0.72rem var(--font); color: var(--copy); background: rgba(15, 23, 42, 0.85); border: 1px solid var(--card-border); border-radius: 8px; padding: 0.35rem 0.6rem; cursor: pointer; }
   .diagram .expand:hover { color: var(--heading); border-color: var(--accent); }
   .diagram .mermaid { cursor: zoom-in; }
   .diagram .mermaid:fullscreen { cursor: zoom-out; background: #0b1220; display: flex; align-items: center; justify-content: center; padding: 2rem; }
@@ -394,10 +394,13 @@ ${sections}
     </main>
     <script src="assets/mermaid.min.js"></script>
     <script>
+      let fsInFlight = false;
       document.addEventListener('click', async (e) => {
+        if (fsInFlight) return;
         const btn = e.target.closest('.diagram .expand');
         const box = btn ? btn.parentElement.querySelector('.mermaid') : e.target.closest('.diagram .mermaid');
         if (!box) return;
+        fsInFlight = true;
         try {
           const fsElement = document.fullscreenElement || document.webkitFullscreenElement;
           if (fsElement === box) {
@@ -409,6 +412,7 @@ ${sections}
           if (request) await request.call(box);
           else box.classList.add('fs-fallback'); // iOS Safari: CSS overlay fallback
         } catch { /* fullscreen denied: fall back to the CSS overlay */ box.classList.add('fs-fallback'); }
+        finally { fsInFlight = false; }
       });
       mermaid.initialize({
         startOnLoad: true,

--- a/scripts/pages/build-state-atlas.mjs
+++ b/scripts/pages/build-state-atlas.mjs
@@ -240,7 +240,7 @@ function sectionMarkup(s) {
         <h2>${s.title}</h2>
         <p class="source">Diagram generated from <code>${s.source}</code></p>
 ${proseParagraphs(s.prose)}
-        <div class="diagram"><div class="mermaid">
+        <div class="diagram"><button class="expand" type="button" aria-label="View diagram fullscreen">⤢ Fullscreen</button><div class="mermaid">
 ${escapeMermaid(s.diagram)}
 </div></div>
       </section>`;
@@ -374,9 +374,14 @@ export function buildStateAtlasHtml() {
   }
   .diagram .mermaid { text-align: center; }
   .diagram .mermaid svg { max-width: 100%; height: auto; }
+  .diagram { position: relative; }
+  .diagram .expand { position: absolute; top: 0.6rem; right: 0.6rem; z-index: 2; font: 600 0.72rem var(--font); color: var(--copy); background: rgba(15, 23, 42, 0.85); border: 1px solid var(--card-border); border-radius: 8px; padding: 0.35rem 0.6rem; cursor: pointer; }
+  .diagram .expand:hover { color: var(--heading); border-color: var(--accent); }
   .diagram .mermaid { cursor: zoom-in; }
   .diagram .mermaid:fullscreen { cursor: zoom-out; background: #0b1220; display: flex; align-items: center; justify-content: center; padding: 2rem; }
   .diagram .mermaid:fullscreen svg { max-width: 96vw; max-height: 92vh; width: auto; height: auto; }
+  .diagram .mermaid.fs-fallback { position: fixed; inset: 0; z-index: 50; background: #0b1220; display: flex; align-items: center; justify-content: center; padding: 1rem; cursor: zoom-out; overflow: auto; }
+  .diagram .mermaid.fs-fallback svg { max-width: 96vw; max-height: 92vh; width: auto; height: auto; }
 </style>
 </head>
 <body>
@@ -389,11 +394,21 @@ ${sections}
     </main>
     <script src="assets/mermaid.min.js"></script>
     <script>
-      document.addEventListener('click', (e) => {
-        const box = e.target.closest('.diagram .mermaid');
+      document.addEventListener('click', async (e) => {
+        const btn = e.target.closest('.diagram .expand');
+        const box = btn ? btn.parentElement.querySelector('.mermaid') : e.target.closest('.diagram .mermaid');
         if (!box) return;
-        if (document.fullscreenElement) document.exitFullscreen();
-        else box.requestFullscreen?.();
+        try {
+          const fsElement = document.fullscreenElement || document.webkitFullscreenElement;
+          if (fsElement === box) {
+            await (document.exitFullscreen || document.webkitExitFullscreen)?.call(document);
+            return;
+          }
+          if (box.classList.contains('fs-fallback')) { box.classList.remove('fs-fallback'); return; }
+          const request = box.requestFullscreen || box.webkitRequestFullscreen;
+          if (request) await request.call(box);
+          else box.classList.add('fs-fallback'); // iOS Safari: CSS overlay fallback
+        } catch { /* fullscreen denied: fall back to the CSS overlay */ box.classList.add('fs-fallback'); }
       });
       mermaid.initialize({
         startOnLoad: true,

--- a/scripts/pages/build-state-atlas.mjs
+++ b/scripts/pages/build-state-atlas.mjs
@@ -379,6 +379,8 @@ export function buildStateAtlasHtml() {
   .diagram .expand:hover { color: var(--heading); border-color: var(--accent); }
   .diagram .mermaid { cursor: zoom-in; }
   .diagram .mermaid:fullscreen { cursor: zoom-out; background: #0b1220; display: flex; align-items: center; justify-content: center; padding: 2rem; }
+  .diagram .mermaid:-webkit-full-screen { cursor: zoom-out; background: #0b1220; display: flex; align-items: center; justify-content: center; padding: 2rem; }
+  .diagram .mermaid:-webkit-full-screen svg { max-width: calc(100vw - 4rem); max-height: calc(100vh - 4rem); width: auto; height: auto; }
   .diagram .mermaid:fullscreen svg { max-width: calc(100vw - 4rem); max-height: calc(100vh - 4rem); width: auto; height: auto; }
   .diagram .mermaid.fs-fallback { position: fixed; inset: 0; z-index: 50; background: #0b1220; display: flex; align-items: center; justify-content: center; padding: 1rem; cursor: zoom-out; overflow: auto; }
   .diagram .mermaid.fs-fallback svg { max-width: calc(100vw - 2rem); max-height: calc(100vh - 2rem); width: auto; height: auto; }
@@ -397,8 +399,10 @@ ${sections}
       let fsInFlight = false;
       document.addEventListener('click', async (e) => {
         if (fsInFlight) return;
-        const btn = e.target.closest('.diagram .expand');
-        const box = btn ? btn.parentElement.querySelector('.mermaid') : e.target.closest('.diagram .mermaid');
+        const target = e.target instanceof Element ? e.target : e.target?.parentElement;
+        if (!target) return;
+        const btn = target.closest('.diagram .expand');
+        const box = btn ? btn.parentElement.querySelector('.mermaid') : target.closest('.diagram .mermaid');
         if (!box) return;
         fsInFlight = true;
         try {

--- a/scripts/pages/build-state-atlas.mjs
+++ b/scripts/pages/build-state-atlas.mjs
@@ -379,9 +379,9 @@ export function buildStateAtlasHtml() {
   .diagram .expand:hover { color: var(--heading); border-color: var(--accent); }
   .diagram .mermaid { cursor: zoom-in; }
   .diagram .mermaid:fullscreen { cursor: zoom-out; background: #0b1220; display: flex; align-items: center; justify-content: center; padding: 2rem; }
-  .diagram .mermaid:fullscreen svg { max-width: 96vw; max-height: 92vh; width: auto; height: auto; }
+  .diagram .mermaid:fullscreen svg { max-width: calc(100vw - 4rem); max-height: calc(100vh - 4rem); width: auto; height: auto; }
   .diagram .mermaid.fs-fallback { position: fixed; inset: 0; z-index: 50; background: #0b1220; display: flex; align-items: center; justify-content: center; padding: 1rem; cursor: zoom-out; overflow: auto; }
-  .diagram .mermaid.fs-fallback svg { max-width: 96vw; max-height: 92vh; width: auto; height: auto; }
+  .diagram .mermaid.fs-fallback svg { max-width: calc(100vw - 2rem); max-height: calc(100vh - 2rem); width: auto; height: auto; }
 </style>
 </head>
 <body>

--- a/scripts/pages/build-state-atlas.mjs
+++ b/scripts/pages/build-state-atlas.mjs
@@ -374,6 +374,9 @@ export function buildStateAtlasHtml() {
   }
   .diagram .mermaid { text-align: center; }
   .diagram .mermaid svg { max-width: 100%; height: auto; }
+  .diagram .mermaid { cursor: zoom-in; }
+  .diagram .mermaid:fullscreen { cursor: zoom-out; background: #0b1220; display: flex; align-items: center; justify-content: center; padding: 2rem; }
+  .diagram .mermaid:fullscreen svg { max-width: 96vw; max-height: 92vh; width: auto; height: auto; }
 </style>
 </head>
 <body>
@@ -386,6 +389,12 @@ ${sections}
     </main>
     <script src="assets/mermaid.min.js"></script>
     <script>
+      document.addEventListener('click', (e) => {
+        const box = e.target.closest('.diagram .mermaid');
+        if (!box) return;
+        if (document.fullscreenElement) document.exitFullscreen();
+        else box.requestFullscreen?.();
+      });
       mermaid.initialize({
         startOnLoad: true,
         securityLevel: 'strict',

--- a/test/pages/build-site.test.mjs
+++ b/test/pages/build-site.test.mjs
@@ -107,6 +107,18 @@ test('build-state-atlas: generator is pure and deterministic (identical bytes ac
   assert.equal(buildStateAtlasHtml(), buildStateAtlasHtml(), 'atlas HTML is byte-identical across calls');
 });
 
+test('build-state-atlas: fullscreen lightbox structure (one expand button per diagram, wired handler + CSS)', async () => {
+  const { buildStateAtlasHtml } = await import('../../scripts/pages/build-state-atlas.mjs');
+  const html = buildStateAtlasHtml();
+  const diagrams = (html.match(/class="diagram"/g) ?? []).length;
+  const buttons = (html.match(/class="expand" type="button" aria-label="View diagram fullscreen"/g) ?? []).length;
+  assert.ok(diagrams > 0, 'atlas renders diagrams');
+  assert.equal(buttons, diagrams, 'exactly one expand button per diagram');
+  for (const token of ['requestFullscreen', 'fs-fallback', ':-webkit-full-screen', '.diagram .expand', 'fsInFlight']) {
+    assert.ok(html.includes(token), `lightbox structure token missing: ${token}`);
+  }
+});
+
 test('injectNav fails closed when a page lacks the expected structure', () => {
   assert.throws(() => injectNav('<html><body>no style block</body></html>', REPO_URL), /missing a <style> block or <body>/);
   assert.throws(() => injectNav('<style>x</style> no body', REPO_URL), /missing a <style> block or <body>/);


### PR DESCRIPTION
## Summary

Click any state-atlas diagram to open it fullscreen (native `requestFullscreen`; click again or Esc exits). Fullscreen letterboxes the SVG to ~96vw/92vh on the page background; zoom cursors signal the affordance.

## Objective

Readable full-screen inspection of the atlas graphs at https://mfittko.github.io/dev-loops/state-atlas.html (operator request, 2026-07-06).

## In scope

- `renderStateAtlas` CSS (8 rules incl. the mobile button + fallback overlay) + one delegated click handler in `scripts/pages/build-state-atlas.mjs` (+45/-1 across 2 files: the builder + a structural pages test — grew past the light-mode threshold after the mobile expand buttons; gates escalated to full fan-out accordingly).

## Explicit non-goals

- Pan/zoom controls, mermaid theming, other site pages, lightbox libraries.

## Acceptance criteria

- [ ] Clicking a `.diagram .mermaid` block enters fullscreen; clicking again exits (Esc also works on the native-fullscreen path; the iOS CSS-fallback overlay exits on tap).
- [ ] Diagram/SVG output unchanged in normal rendering (the expand button + zoom cursor are the intended new chrome); site builds deterministically.
- [ ] Pages tests green (8/8 at head, incl. the new lightbox structure test).

## Definition of done

- Merged with full fan-out gate evidence (escalated from light mode on scope growth); behavior verified on the next pages deploy.

## Open questions/risks

- None. `requestFullscreen` requires a user gesture (satisfied — click handler); optional chaining makes unsupported browsers a no-op.

**Dogfood note (#1210 AC4):** first issue-less lightweight PR — no tracker issue backs it; per `ARTIFACT-LIGHTWEIGHT-BODY-INVARIANTS` (conditional Closes) this body deliberately carries no closing reference.


### Mobile support (round-2 scope addition, operator request)

- Per-diagram "⤢ Fullscreen" buttons (touch-visible affordance) + a fixed-overlay CSS fallback for browsers without element fullscreen (iOS Safari).



### Round-3 hardening (draft-gate correctness findings, 50a020af)

- In-flight guard on the async fullscreen toggle (draft reviewer: rapid double-click during the transition could stack native fullscreen + the fallback overlay).
- Expand button `position: sticky` (draft reviewer: absolute positioning scrolled out of view on horizontally-scrolling diagrams).


### Round-4 (Copilot round 2, 88b69065)

- `:-webkit-full-screen` CSS parity (older Safari got fullscreen without the intended styles).
- Element-safe event delegation (`e.target` can be a Text node; normalized before `closest()`).
- New structural pages test: one expand button per diagram + wired handler/CSS tokens asserted in the emitted HTML (interaction testing deferred to epic #1114's browser harness).
