### PR TITLE
fix(gates): enforce converge-then-gate at pre_approval entry, retire the known gap (#1190)

### DIFF
--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -513,11 +513,39 @@ function applyUnsettledCopilotReviewEntryGuard(input, result) {
   if (copilotReviewRequestStatus !== "requested" && copilotReviewRequestStatus !== "already-requested") {
     return null;
   }
+  // Round-cap exemption (mirrors shouldGuardCopilotReviewRequest, #896/#848):
+  // past the cap a lingering requested/already-requested status is for a review
+  // that can never come (no further round is permitted), so treating it as
+  // "unsettled" here would re-introduce the infinite-wait dead-end the
+  // ROUND_CAP_CLEAN_FALLBACK routing exists to prevent. When the cap is reached
+  // and the head is clean — either sameHeadCleanConverged or the interpreter's
+  // round_cap_clean_fallback state — the pre_approval_gate proceeds unless
+  // significant post-convergence changes require a new review cycle.
+  const roundCapReached = isCopilotRoundCapReached({
+    copilotReviewRoundCount: input.copilotReviewRoundCount,
+    maxCopilotRounds: input.maxCopilotRounds,
+  });
+  const lifecycleState = typeof input.lifecycleState === "string" ? input.lifecycleState.trim().toLowerCase() : "";
+  const roundCapCleanFallback = lifecycleState === STATE.ROUND_CAP_CLEAN_FALLBACK;
+  if (
+    roundCapReached
+    && (input.sameHeadCleanConverged === true || roundCapCleanFallback)
+    && input.postConvergenceSignificantChange !== true
+  ) {
+    return null;
+  }
 
   const allowedNextActions = [];
   const forbiddenActions = [];
   pushUnique(allowedNextActions, [PR_CHECKPOINT_ACTION.WAIT_FOR_COPILOT_REVIEW]);
+  // Full postDraftForbidden set (matching the canonical WAITING_FOR_COPILOT_REVIEW
+  // result this guard synthesizes) plus the final-approval actions the replaced
+  // boundary result also forbade — dropping RUN_DRAFT_GATE/MARK_READY_FOR_REVIEW
+  // here would let a draft_gate verdict post on a non-draft PR slip through where
+  // the replaced result would have refused it.
   pushUnique(forbiddenActions, [
+    PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE,
+    PR_CHECKPOINT_ACTION.MARK_READY_FOR_REVIEW,
     PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE,
     PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL,
     PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY,
@@ -542,6 +570,7 @@ function applyUnsettledCopilotReviewEntryGuard(input, result) {
     mergeStateStatus: result.mergeStateStatus ?? null,
     conflictFiles: result.conflictFiles ?? [],
     refinementArtifact: result.refinementArtifact ?? null,
+    copilotReviewRoundCount: normalizeNonNegativeInteger(input.copilotReviewRoundCount),
   });
 }
 

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -471,6 +471,81 @@ const TITLE_MARKER_GUARDED_BOUNDARIES = Object.freeze([
 ]);
 
 /**
+ * Independent gate-ENTRY re-check (issue #1190): even when the caller's
+ * lifecycleState/sameHeadCleanConverged claims a settled Copilot convergence,
+ * an outstanding (`requested`/`already-requested`) Copilot review request on
+ * the CURRENT head is a second, independent "unsettled" signal — not derived
+ * from sameHeadCleanConverged — that must refuse pre_approval_gate /
+ * final-approval entry outright.
+ *
+ * This mirrors the fail-closed predicate that previously only fired at
+ * *verdict-post* time (upsert-checkpoint-verdict.mjs, which refuses to post a
+ * pre_approval_gate verdict while this same evaluator forbids
+ * RUN_PRE_APPROVAL_GATE): asserting it here, at gate *entry*, refuses the
+ * pre-approval fan-out up front instead of only after reviewer tokens have
+ * already been spent.
+ *
+ * Skipped when Copilot review is not required at all — `reviewMode:
+ * "internal_only"` or `maxCopilotRounds: 0` — preserving the existing #613 /
+ * #1210 exemptions (internal-only and light-dispatched-with-disabled-review
+ * PRs never need a Copilot round in the first place).
+ */
+const PRE_APPROVAL_ENTRY_BOUNDARIES = Object.freeze([
+  PR_CHECKPOINT.PRE_APPROVAL_GATE_NEEDED,
+  PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW,
+  PR_CHECKPOINT.FINAL_APPROVAL_READY,
+]);
+
+function applyUnsettledCopilotReviewEntryGuard(input, result) {
+  if (!result || typeof result !== "object" || !PRE_APPROVAL_ENTRY_BOUNDARIES.includes(result.gateBoundary)) {
+    return null;
+  }
+  if (input.maxCopilotRounds === 0) {
+    return null;
+  }
+  const reviewMode = typeof input.reviewMode === "string" ? input.reviewMode.trim().toLowerCase() : null;
+  if (reviewMode === "internal_only") {
+    return null;
+  }
+  const copilotReviewRequestStatus = typeof input.copilotReviewRequestStatus === "string"
+    ? input.copilotReviewRequestStatus.trim().toLowerCase()
+    : "none";
+  if (copilotReviewRequestStatus !== "requested" && copilotReviewRequestStatus !== "already-requested") {
+    return null;
+  }
+
+  const allowedNextActions = [];
+  const forbiddenActions = [];
+  pushUnique(allowedNextActions, [PR_CHECKPOINT_ACTION.WAIT_FOR_COPILOT_REVIEW]);
+  pushUnique(forbiddenActions, [
+    PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE,
+    PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL,
+    PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY,
+  ]);
+
+  return buildResult({
+    repo: input.repo ?? null,
+    pr: Number.isInteger(input.pr) ? input.pr : null,
+    currentHeadSha: result.currentHeadSha ?? null,
+    lifecycleState: STATE.WAITING_FOR_COPILOT_REVIEW,
+    loopDisposition: DISPOSITION.PENDING,
+    gateBoundary: PR_CHECKPOINT.POST_DRAFT_EXTERNAL_REVIEW,
+    draftGateAlreadySatisfied: result.draftGateAlreadySatisfied === true,
+    draftGate: result.draftGate,
+    preApprovalGate: result.preApprovalGate,
+    allowedNextActions,
+    forbiddenActions,
+    nextAction: PR_CHECKPOINT_ACTION.WAIT_FOR_COPILOT_REVIEW,
+    reason: "A Copilot review request is still outstanding on the current head (independent gate-entry "
+      + "re-check, issue #1190) — pre_approval_gate/final-approval entry is refused until the current-head "
+      + "review settles, even though the caller-reported convergence signal claims otherwise.",
+    mergeStateStatus: result.mergeStateStatus ?? null,
+    conflictFiles: result.conflictFiles ?? [],
+    refinementArtifact: result.refinementArtifact ?? null,
+  });
+}
+
+/**
  * Evaluates PR gate coordination, then re-asserts the merge-blocking title guard
  * (issue #842) at the pre-approval / final-approval boundary for non-draft PRs.
  *
@@ -481,6 +556,11 @@ const TITLE_MARKER_GUARDED_BOUNDARIES = Object.freeze([
  */
 export function evaluatePrGateCoordination(input = {}) {
   const result = evaluatePrGateCoordinationCore(input);
+
+  const unsettledReviewResult = applyUnsettledCopilotReviewEntryGuard(input, result);
+  if (unsettledReviewResult) {
+    return unsettledReviewResult;
+  }
 
   const prDraft = input.prDraft === true;
   const prTitle = typeof input.prTitle === "string" ? input.prTitle : "";

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -241,6 +241,17 @@ test("#1190: outstanding Copilot review request refuses pre_approval_gate entry 
   assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
   assert(!result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
   assert.match(result.reason, /outstanding/i);
+  // Bypass regression: the synthesized wait result must forbid the FULL
+  // postDraftForbidden set — dropping run_draft_gate here would let
+  // upsert-checkpoint-verdict post a draft_gate verdict on a non-draft PR
+  // (gate=draft_gate, no clean draft evidence, outstanding request) where the
+  // replaced boundary result would have refused it.
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE));
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.MARK_READY_FOR_REVIEW));
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL));
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY));
+  // Shape consistency with sibling wait-state results.
+  assert.equal(result.copilotReviewRoundCount, 0);
 });
 
 test("#1190: already-requested Copilot review also refuses pre_approval_gate entry", () => {
@@ -256,6 +267,47 @@ test("#1190: already-requested Copilot review also refuses pre_approval_gate ent
   });
 
   assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.WAIT_FOR_COPILOT_REVIEW);
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+});
+
+test("#1190: round-cap clean fallback with a lingering review request still permits pre_approval_gate "
+  + "entry (no re-introduction of the #896 infinite-wait dead-end)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    lifecycleState: STATE.ROUND_CAP_CLEAN_FALLBACK,
+    ciStatus: "success",
+    copilotReviewRoundCount: 3,
+    maxCopilotRounds: 3,
+    // Past the cap this lingering request is for a round that can never come;
+    // the entry guard must NOT treat it as unsettled (#896/#848 exemption).
+    copilotReviewRequestStatus: "requested",
+    draftGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "fedcba9", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+  });
+
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
+  assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+});
+
+test("#1190: at the cap, significant post-convergence changes re-arm the outstanding-review entry guard "
+  + "(clean-fallback exemption does not apply when a new cycle is required)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    ciStatus: "success",
+    sameHeadCleanConverged: true,
+    copilotReviewRoundCount: 3,
+    maxCopilotRounds: 3,
+    copilotReviewRequestStatus: "requested",
+    postConvergenceSignificantChange: true,
+    preApprovalGate: gate({ visible: false }),
+  });
+
   assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
 });
 

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -213,6 +213,86 @@ test("clean settled current-head review opens the pre-approval gate window", () 
   assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
 });
 
+// Issue #1190: gate-ENTRY re-check. Even when the caller asserts convergence
+// (sameHeadCleanConverged: true, the same fixture as the test above), an
+// independent, outstanding Copilot review request on the current head must
+// refuse pre_approval_gate entry outright — the same predicate that
+// previously only fired at verdict-post time (upsert-checkpoint-verdict.mjs)
+// now also fires here, before any reviewer fan-out spends tokens.
+test("#1190: outstanding Copilot review request refuses pre_approval_gate entry even when the caller "
+  + "claims sameHeadCleanConverged", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    loopDisposition: DISPOSITION.CLEAN_CONVERGED,
+    sameHeadCleanConverged: true,
+    copilotReviewRequestStatus: "requested",
+    ciStatus: "success",
+    draftGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "fedcba9", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.POST_DRAFT_EXTERNAL_REVIEW);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.WAIT_FOR_COPILOT_REVIEW);
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert(!result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert.match(result.reason, /outstanding/i);
+});
+
+test("#1190: already-requested Copilot review also refuses pre_approval_gate entry", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    sameHeadCleanConverged: true,
+    copilotReviewRequestStatus: "already-requested",
+    ciStatus: "success",
+    preApprovalGate: gate({ visible: false }),
+  });
+
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.WAIT_FOR_COPILOT_REVIEW);
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+});
+
+test("#1190: internal_only reviewMode is exempt from the outstanding-review entry guard (#1210 lightweight cap)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    sameHeadCleanConverged: true,
+    copilotReviewRequestStatus: "requested",
+    reviewMode: "internal_only",
+    ciStatus: "success",
+    preApprovalGate: gate({ visible: false }),
+  });
+
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
+  assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+});
+
+test("#1190: maxCopilotRounds: 0 (Copilot review disabled) is exempt from the outstanding-review entry guard", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    sameHeadCleanConverged: true,
+    copilotReviewRequestStatus: "requested",
+    maxCopilotRounds: 0,
+    ciStatus: "success",
+    preApprovalGate: gate({ visible: false }),
+  });
+
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
+  assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+});
+
 test("draft gate with crediblyGreen CI routes to WAIT_FOR_CI — unconfirmed CI is not a hard block", () => {
   const result = evaluatePrGateCoordination({
     pr: 266,

--- a/scripts/docs/validate-state-machine-conformance.mjs
+++ b/scripts/docs/validate-state-machine-conformance.mjs
@@ -421,24 +421,46 @@ verified("waiting_for_copilot_review->merge_conflict_resolution", () => {
 // waiting_for_copilot_review -> final_local_preapproval_gate: the request/re-review cycle has settled
 // cleanly with no unresolved feedback and no further Copilot pass needed.
 //
-// KNOWN GAP (issue #1148 / epic #1104 comment thread): the guard above is what the CONTRACT requires,
-// but `evaluatePrGateCoordination` has no independent way to verify the reviewed head SHA actually
-// matches `currentHeadSha` — it trusts the caller-supplied `sameHeadCleanConverged` flag as-is. The
-// only fail-closed guard against an unsettled/unreviewed head lives downstream, at *verdict post*
-// time (`upsert-checkpoint-verdict.mjs`'s unsettled-review refusal), not at *gate entry* here. This
-// is intentionally NOT fixed by #1148 (own issue, tracked below) — encoded as an expected-fail so a
-// future accidental "fix" (or regression) is visible instead of silently passing either way.
-const KNOWN_GAP_TRACKING_ISSUE = "https://github.com/mfittko/dev-loops/issues/1190";
-PR_GATE_TRANSITION_CHECKS.set("waiting_for_copilot_review->final_local_preapproval_gate", {
-  status: "known_gap",
-  issue: KNOWN_GAP_TRACKING_ISSUE,
-  note: "Gate entry into pre_approval_gate trusts caller-supplied sameHeadCleanConverged with no "
-    + "independent reviewed-head-SHA check; the fail-closed guard is at verdict-post "
-    + "(upsert-checkpoint-verdict.mjs), not at gate entry (pr-gate-coordination.mjs). See epic #1104 "
-    + "comment thread; tracked in #1190. NOTE: this allowlist entry never fails the CLI — if #1190 "
-    + "lands a backward-compatible gate-entry guard, this run keeps passing silently; the loud guard "
-    + "is the known-gap regression test in test/docs/validate-state-machine-conformance.test.mjs, "
-    + "which starts failing the moment the gap closes and tells you to retire this entry.",
+// Fixed by #1190 (previously a tracked known_gap; issue #1148 / epic #1104 comment thread): gate
+// ENTRY used to trust the caller-supplied `sameHeadCleanConverged` flag as-is, with no independent
+// signal to catch an unsettled/unreviewed current head — the only fail-closed guard against that
+// lived downstream, at *verdict-post* time (`upsert-checkpoint-verdict.mjs`'s unsettled-review
+// refusal). `evaluatePrGateCoordination` now takes an independent `copilotReviewRequestStatus`
+// signal (not derived from `sameHeadCleanConverged`) and refuses `RUN_PRE_APPROVAL_GATE` outright
+// whenever a Copilot review request is still outstanding on the current head — asserted at gate
+// *entry*, mirroring the verdict-post predicate instead of only duplicating it after the fact.
+verified("waiting_for_copilot_review->final_local_preapproval_gate", () => {
+  // Even a caller that reports sameHeadCleanConverged: true (e.g. a stale/racy
+  // interpretation) must still be refused while a Copilot review request is
+  // outstanding on the current head — the entry guard is independent of that flag.
+  const unsettled = run({
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    ciStatus: "success",
+    sameHeadCleanConverged: true,
+    copilotReviewRequestStatus: "requested",
+    preApprovalGate: gate({ visible: false }),
+  });
+  const unsettledOk = unsettled.gateBoundary === PR_CHECKPOINT.POST_DRAFT_EXTERNAL_REVIEW
+    && unsettled.nextAction === PR_CHECKPOINT_ACTION.WAIT_FOR_COPILOT_REVIEW
+    && unsettled.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
+
+  // Once the review request has genuinely settled (no outstanding request) and the
+  // current head converged cleanly, pre_approval_gate entry is legal — the fix does
+  // not regress the real transition the doc requires.
+  const settled = run({
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    ciStatus: "success",
+    sameHeadCleanConverged: true,
+    copilotReviewRequestStatus: "none",
+    preApprovalGate: gate({ visible: false }),
+  });
+  const settledOk = settled.gateBoundary === PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW
+    && settled.nextAction === PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE;
+
+  const ok = unsettledOk && settledOk;
+  return { ok, detail: { unsettled, settled }, result: settled };
 });
 
 // final_local_preapproval_gate -> final_gate_remediation: pre-approval gate findings require changes.

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -998,6 +998,10 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
     copilotReviewRoundCount: coordinationContext.snapshot?.copilotReviewRoundCount ?? 0,
     maxCopilotRounds,
     sameHeadCleanConverged: coordinationContext.interpretation.sameHeadCleanConverged,
+    // Independent gate-ENTRY re-check (#1190): fed alongside (not derived from)
+    // sameHeadCleanConverged, so an outstanding request on the current head refuses
+    // RUN_PRE_APPROVAL_GATE even if sameHeadCleanConverged were somehow stale/wrong.
+    copilotReviewRequestStatus: coordinationContext.snapshot?.copilotReviewRequestStatus ?? "none",
     draftGateRequireCi: draftGateConfig.requireCi,
     draftGate: coordinationContext.gateEvidence.draftGate,
     draftGateMarker: coordinationContext.gateEvidence.draftGateMarker,

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -584,6 +584,10 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
     copilotReviewRoundCount: context.snapshot?.copilotReviewRoundCount ?? 0,
     maxCopilotRounds,
     sameHeadCleanConverged: context.interpretation.sameHeadCleanConverged,
+    // Independent gate-ENTRY re-check (#1190): fed alongside (not derived from)
+    // sameHeadCleanConverged, so an outstanding request on the current head refuses
+    // RUN_PRE_APPROVAL_GATE even if sameHeadCleanConverged were somehow stale/wrong.
+    copilotReviewRequestStatus: context.snapshot?.copilotReviewRequestStatus ?? "none",
     draftGateRequireCi: draftGateConfig.requireCi,
     draftGate: context.gateEvidence.draftGate,
     draftGateMarker: context.gateEvidence.draftGateMarker,

--- a/test/docs/validate-state-machine-conformance.test.mjs
+++ b/test/docs/validate-state-machine-conformance.test.mjs
@@ -201,22 +201,21 @@ test("every registered machine passes its full conformance report", () => {
   }
 });
 
-// AC3: the pre_approval_gate entry-ordering divergence is a tracked known-gap, not a silent pass.
-test("pr-gate-coordination known gap: pre_approval_gate entry ordering is tracked, not silently passed", () => {
+// Issue #1190: the pre_approval_gate entry-ordering transition is now a verified (conforming)
+// transition, not a tracked known-gap.
+test("pr-gate-coordination #1190: pre_approval_gate entry ordering is a verified conforming transition", () => {
   const machine = getRegisteredMachines().find((m) => m.name === "pr-gate-coordination");
   const report = runMachineConformance(machine);
-  const knownGap = report.conformance.results.find(
+  const transition = report.conformance.results.find(
     (r) => r.from === "waiting_for_copilot_review" && r.to === "final_local_preapproval_gate",
   );
-  assert.ok(knownGap, "the pre_approval_gate entry-ordering transition must be present in the report");
-  assert.equal(knownGap.status, "known_gap");
-  assert.match(knownGap.note, /verdict-post/);
+  assert.ok(transition, "the pre_approval_gate entry-ordering transition must be present in the report");
+  assert.equal(transition.status, "verified");
 });
 
-test("pr-gate-coordination known gap regression: gate entry is permitted from a merely trusted "
-  + "sameHeadCleanConverged flag with no independent reviewed-head check (documents today's gap; "
-  + "does not fix it)", async () => {
-  const { evaluatePrGateCoordination, PR_CHECKPOINT_ACTION } = await import("@dev-loops/core/loop/pr-gate-coordination");
+test("pr-gate-coordination #1190 fix: gate entry is refused when a Copilot review request is "
+  + "outstanding on the current head, even though the caller reports sameHeadCleanConverged", async () => {
+  const { evaluatePrGateCoordination, PR_CHECKPOINT, PR_CHECKPOINT_ACTION } = await import("@dev-loops/core/loop/pr-gate-coordination");
   const { STATE } = await import("@dev-loops/core/loop/copilot-loop-state");
 
   const result = evaluatePrGateCoordination({
@@ -224,14 +223,18 @@ test("pr-gate-coordination known gap regression: gate entry is permitted from a 
     prDraft: false,
     lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
     ciStatus: "success",
-    // The caller claims the current head converged cleanly; evaluatePrGateCoordination has no
-    // parameter to independently confirm "deadbeef0000" is the head Copilot actually reviewed.
+    // The caller claims the current head converged cleanly, but an independent signal — an
+    // outstanding Copilot review request on the current head — says otherwise. #1190 added this
+    // independent cross-check so the caller-supplied flag alone can no longer open the gate.
     sameHeadCleanConverged: true,
+    copilotReviewRequestStatus: "requested",
     preApprovalGate: { visible: false, headSha: null, verdict: null, contractComplete: false },
   });
 
-  // Gate entry is permitted despite no independent reviewed-head verification (the known gap).
-  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
+  // Gate entry is refused: the fix closes the gap the flag alone could not catch.
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.WAIT_FOR_COPILOT_REVIEW);
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.POST_DRAFT_EXTERNAL_REVIEW);
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `pre_approval_gate`/final-approval entry now independently refuses to proceed while a Copilot review request is still outstanding on the current head, instead of only catching the divergence downstream at verdict-post time (`upsert-checkpoint-verdict.mjs`).
- `evaluatePrGateCoordination` gains a `copilotReviewRequestStatus` input, independent of the caller-supplied `sameHeadCleanConverged` flag, and refuses gate entry outright (full `postDraftForbidden` set + `AWAIT_FINAL_HUMAN_APPROVAL`/`DECLARE_MERGE_READY`) whenever a request is `requested`/`already-requested` on the current head.
- Exemptions preserved: `reviewMode: "internal_only"` and `maxCopilotRounds: 0` (#613/#1210), and the round-cap clean case (#896/#848) — past the cap a lingering request is for a review that can never come, so `ROUND_CAP_CLEAN_FALLBACK` / same-head clean convergence at the cap still proceeds to `pre_approval_gate` (no re-introduction of the #896 infinite-wait dead-end); significant post-convergence changes re-arm the guard.
- Threaded the new field from the same real callers that already compute it (`detect-pr-gate-coordination-state.mjs`, `upsert-checkpoint-verdict.mjs`), so the pre-approval fan-out authorization path and the verdict-post refusal now share one predicate.
- Flipped the L2 conformance harness's tracked `known_gap` for `waiting_for_copilot_review -> final_local_preapproval_gate` (issue #1148 / epic #1104) to a `verified` conforming transition; removed `KNOWN_GAP_TRACKING_ISSUE`; flipped the regression test that documented the gap to assert the fix.

Closes #1190

## Evidence

```
node scripts/docs/validate-state-machine-conformance.mjs
Machine pr-gate-coordination: PASS
Machine conductor-routing: PASS
Machine copilot-loop-state: PASS
Machine reviewer-loop-state: PASS

env -u PI_SUBAGENT_RUN_ID -u DEVLOOPS_RUN_ID npm run verify   (head f0200243)
... test:assets 189/189, test:extension 81/81, test:scripts 2274/2274 (36 skipped),
    test:core 1864/1864, test:docs (links + rule ownership) OK, test:dev-loop 32/32
```

## Notes (seam choice rationale)

The fan-out is authorized wherever `evaluatePrGateCoordination`'s `RUN_PRE_APPROVAL_GATE` next-action is consulted (`detect-pr-gate-coordination-state.mjs`) — `write-gate-context.mjs` is a downstream artifact writer that trusts whatever gate/head-sha its caller supplies and does not itself decide legality. Rather than add a second, duplicate live-`gh`-fetching guard inside `write-gate-context.mjs` (or the harness's pure-function `run()` fixture, which cannot make network calls), the fix lives in the single shared evaluator (`pr-gate-coordination.mjs::evaluatePrGateCoordination`) that both the entry-authorization caller and the verdict-post caller already route through — one root-cause fix, verifiable at the unit level without a live PR, and honest for both callers by construction (each just needed one additional field threaded from data they already compute).
