### PR TITLE
fix(gates): fail closed on missing mandatory angles + foreign angles in fanout provenance (#1196)

### DIFF
--- a/.devloops
+++ b/.devloops
@@ -33,6 +33,9 @@ gates:
       - gate-evidence
       - pr-description
       - pr-comments
+      - contradiction-lens
+      - code-conformance
+      - semantic-drift
     requireCi: true
     mandatoryAngles:
       - pr-description
@@ -56,12 +59,16 @@ gates:
       - renderer-security
       - pr-checklist-matrix
       - acceptance-criteria
+      - contradiction-lens
+      - correctness-final
+      - ui-validation
     # Mandatory angles always run in the fan-out (never dropped by dynamic
     # resolution); fully configurable — add/remove any angle from the pool.
     mandatoryAngles:
       - pr-checklist-matrix
       - acceptance-criteria
       - yagni
+      - contradiction-lens
 
     blockCleanOnFindingSeverities:
       - must-fix

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -429,6 +429,27 @@ does NOT claim un-forgeable enforcement. Un-forgeable recording (the harness att
 actually ran each per-angle review) is the Pi-harness bridge — the subagent tool honored
 at child depth (see #1084).
 
+### Angle-coverage enforcement (mandatory angles + pool membership)
+
+<!-- rule: GATE-EXEC-ANGLE-COVERAGE -->
+`GATE-EXEC-ANGLE-COVERAGE`: A `fanout_fanin` verdict's recorded per-angle results
+(`provenance.perAngle` on the write path / merge-evidence read path, and the
+`--findings-json` structured per-angle results on the verdict-comment path) MUST
+cover every angle in the gate's configured `mandatoryAngles`, and MUST NOT name an
+angle outside the gate's configured pool (`resolveGateAngles`: configured `angles`
+∪ `mandatoryAngles`) unless `gates.rejectForeignAngles` is explicitly set to
+`false`, in which case a foreign angle downgrades to a warning. A delta-suffixed
+angle (`<angle>-delta-at-...`, e.g. a re-review scoped to only the current head's
+delta) counts toward its base angle for both checks. This is independent of
+`requireFanoutProvenance`: it fires whenever a `fanout_fanin` verdict actually
+records per-angle results, regardless of that opt-in flag, and is exempt for
+`inline_single_agent` verdicts (light-mode inline runs carry no per-angle fan-out
+data to validate). Enforced identically by `write-gate-findings-log.mjs` and
+`upsert-checkpoint-verdict.mjs` (write time) and `detect-checkpoint-evidence.mjs`
+(merge-evidence time, re-validating the ledger so a hand-edited or shadow ledger
+cannot bypass it), sharing the same pure coverage check
+(`checkFanoutAngleCoverage` in `@dev-loops/core/loop/gate-fanin`).
+
 ### Fail-closed: fan-out unavailable → route to conductor
 
 When a child/agent **cannot** perform real parallel fan-out (e.g. a harness that does not

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -435,20 +435,30 @@ at child depth (see #1084).
 `GATE-EXEC-ANGLE-COVERAGE`: A `fanout_fanin` verdict's recorded per-angle results
 (`provenance.perAngle` on the write path / merge-evidence read path, and the
 `--findings-json` structured per-angle results on the verdict-comment path) MUST
-cover every angle in the gate's configured `mandatoryAngles`, and MUST NOT name an
-angle outside the gate's configured pool (`resolveGateAngles`: configured `angles`
-∪ `mandatoryAngles`) unless `gates.rejectForeignAngles` is explicitly set to
-`false`, in which case a foreign angle downgrades to a warning. A delta-suffixed
-angle (`<angle>-delta-at-...`, e.g. a re-review scoped to only the current head's
-delta) counts toward its base angle for both checks. This is independent of
-`requireFanoutProvenance`: it fires whenever a `fanout_fanin` verdict actually
-records per-angle results, regardless of that opt-in flag, and is exempt for
+cover every angle in the gate's effective `mandatoryAngles`, and MUST NOT name an
+angle outside the gate's effective pool unless `gates.rejectForeignAngles` is
+explicitly set to `false`, in which case a foreign angle downgrades to a warning.
+The effective contract is `resolveGateAngleContract` (`@dev-loops/core/config`),
+the single resolver every consumer uses: `mandatoryAngles` is filtered through
+`excludeAngles` (an excluded mandatory angle must not deadlock every fanout
+write), and the pool is `resolveGateAngles` (configured `angles` ∪
+`mandatoryAngles`, minus `excludeAngles`), widened to the global lens catalog
+(`resolveAnglePool`) when the gate enables `additiveAngles` — dynamic resolution
+may legitimately dispatch catalog angles then, with `excludeAngles` still a hard
+ceiling. A delta-suffixed angle (`<angle>-delta-at-...`, e.g. a re-review scoped
+to only the current head's delta) counts toward its base angle for both checks.
+This is independent of `requireFanoutProvenance`, and is exempt for
 `inline_single_agent` verdicts (light-mode inline runs carry no per-angle fan-out
-data to validate). Enforced identically by `write-gate-findings-log.mjs` and
-`upsert-checkpoint-verdict.mjs` (write time) and `detect-checkpoint-evidence.mjs`
-(merge-evidence time, re-validating the ledger so a hand-edited or shadow ledger
-cannot bypass it), sharing the same pure coverage check
-(`checkFanoutAngleCoverage` in `@dev-loops/core/loop/gate-fanin`).
+data to validate). At merge-evidence time, when a gate configures any mandatory
+angle, a `fanout_fanin` ledger MUST record internally-consistent provenance —
+absent or invalid provenance fails closed, so a hand-edited or shadow ledger
+cannot bypass mandatory-angle coverage by simply omitting provenance; gates with
+no mandatory angles keep the previous behavior (absent provenance adds no
+failure unless `requireFanoutProvenance` is on). Enforced identically by
+`write-gate-findings-log.mjs` and `upsert-checkpoint-verdict.mjs` (write time)
+and `detect-checkpoint-evidence.mjs` (merge-evidence time), sharing the same
+pure coverage check (`checkFanoutAngleCoverage` in
+`@dev-loops/core/loop/gate-fanin`).
 
 ### Fail-closed: fan-out unavailable → route to conductor
 

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -1211,6 +1211,36 @@ export function resolveAnglePool(config) {
 }
 
 /**
+ * Resolve a gate's ANGLE ENFORCEMENT CONTRACT: the mandatory angles a
+ * fanout_fanin verdict must cover and the pool its recorded angles must stay
+ * within. Single source of truth for all angle-coverage enforcement consumers
+ * (ledger write, verdict-comment write, merge-evidence read) so they agree.
+ *
+ * - `mandatoryAngles` is filtered through `excludeAngles`: a config that
+ *   excludes a mandatory angle must not deadlock every fanout write (the
+ *   angle would be missing-mandatory if omitted yet foreign if recorded).
+ * - `pool` is `resolveGateAngles` (configured angles ∪ mandatoryAngles, minus
+ *   excludeAngles); when `additiveAngles` is enabled it widens to the global
+ *   lens catalog (`resolveAnglePool`) too — dynamic resolution may
+ *   legitimately dispatch catalog angles then — with `excludeAngles` still a
+ *   hard ceiling. A null pool skips the foreign-angle check entirely.
+ *
+ * @param {DevLoopConfig} config
+ * @param {"draft"|"preApproval"|"spike"} gate
+ * @returns {{ mandatoryAngles: string[], pool: string[]|null }}
+ */
+export function resolveGateAngleContract(config, gate) {
+  const gateConfig = resolveGateConfig(config, gate);
+  const excluded = new Set(gateConfig.excludeAngles);
+  const mandatoryAngles = gateConfig.mandatoryAngles.filter((a) => !excluded.has(a));
+  let pool = resolveGateAngles(config, gate);
+  if (gateConfig.additiveAngles && pool !== null) {
+    pool = [...new Set([...pool, ...resolveAnglePool(config)])].filter((a) => !excluded.has(a));
+  }
+  return { mandatoryAngles, pool };
+}
+
+/**
  * Resolve gate angles dynamically when `dynamicAngles` is enabled in config.
  *
  * Uses diff analysis helpers (from ../analysis/*) to filter the

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -98,6 +98,12 @@ const GatesConfig = z.strictObject({
   // and every angle configured across this config's own draft/preApproval/
   // spike gates (angles + mandatoryAngles).
   anglePool: z.array(z.string().trim().min(1)).optional(),
+  // Fail-closed enforcement that a fanout_fanin gate's recorded per-angle
+  // provenance names only angles in the gate's configured pool (angles +
+  // mandatoryAngles) — ad-hoc/foreign angle labels are rejected rather than
+  // silently accepted. Default true (reject); set false to warn instead of
+  // fail. See resolveRejectForeignAngles / docs/gate-review-sub-loop-contract.md.
+  rejectForeignAngles: z.boolean().default(true),
 });
 
 const AutonomyConfig = z.strictObject({
@@ -197,6 +203,7 @@ const FileGatesConfig = z.strictObject({
   maxFanoutReviewers: z.number().int().min(1).max(64).optional(),
   postFindingsComments: z.boolean().optional(),
   anglePool: z.array(z.string().trim().min(1)).optional(),
+  rejectForeignAngles: z.boolean().optional(),
 });
 
 // Partial persona entries for file-level config (allows omitting fields)
@@ -1023,6 +1030,17 @@ export const FANOUT_PROVENANCE_MIN_REVIEWERS = 2;
  */
 export function resolveRequireFanoutProvenance(config) {
   return config?.gates?.requireFanoutProvenance === true;
+}
+
+/**
+ * Resolve whether a fan-out provenance entry naming an angle outside the
+ * gate's configured pool should FAIL (default) or only WARN.
+ *
+ * @param {DevLoopConfig} config
+ * @returns {boolean}
+ */
+export function resolveRejectForeignAngles(config) {
+  return config?.gates?.rejectForeignAngles !== false;
 }
 
 /**

--- a/packages/core/src/config/extension-defaults.yaml
+++ b/packages/core/src/config/extension-defaults.yaml
@@ -44,6 +44,9 @@ gates:
       - renderer-security
       - determinism
       - pr-comments
+      - contradiction-lens
+      - code-conformance
+      - semantic-drift
     excludeAngles: []
     required: true
     requireCi: true
@@ -66,6 +69,9 @@ gates:
       - dip
       - docs
       - pr-checklist-matrix
+      - contradiction-lens
+      - correctness-final
+      - ui-validation
     excludeAngles: []
     required: true
     mandatoryAngles:

--- a/packages/core/src/loop/gate-fanin.mjs
+++ b/packages/core/src/loop/gate-fanin.mjs
@@ -117,6 +117,51 @@ export function provenanceConsistencyError(prov) {
 }
 
 /**
+ * Base angle name for a delta-suffixed re-review entry (`<angle>-delta-at-...`,
+ * e.g. `pr-checklist-matrix-delta-at-current-head`): a re-review scoped to only
+ * the current head's delta still counts toward its base angle for both
+ * mandatory-angle coverage and pool-membership checks.
+ *
+ * @param {string} angle
+ * @returns {string}
+ */
+function baseAngleName(angle) {
+  return angle.replace(/-delta-at-.+$/, "");
+}
+
+/**
+ * Validate a recorded fan-out angle list against a gate's configured angle
+ * contract: every mandatory angle must be represented, and — when a pool is
+ * supplied — every recorded angle must be a member of it (delta-suffixed
+ * angles count toward their {@link baseAngleName}). Pure; shared by the write
+ * path (write-gate-findings-log's `provenance.perAngle`, upsert-checkpoint-verdict's
+ * `--findings-json` per-angle results) and the merge-evidence read path
+ * (detect-checkpoint-evidence re-validating the ledger's `provenance.perAngle`)
+ * so all three enforce identically.
+ *
+ * @param {unknown} recordedAngles — array of `{ angle: string, ... }` entries (provenance.perAngle or normalized per-angle findings)
+ * @param {object} [gateAngleContract]
+ * @param {string[]} [gateAngleContract.mandatoryAngles] — angles that must always be represented
+ * @param {string[]|null} [gateAngleContract.pool] — configured angle pool; null/omitted skips the foreign-angle check
+ * @returns {{ missingMandatory: string[], foreignAngles: string[] }}
+ */
+export function checkFanoutAngleCoverage(recordedAngles, { mandatoryAngles = [], pool = null } = {}) {
+  const recorded = Array.isArray(recordedAngles)
+    ? recordedAngles
+      .map((e) => (e && typeof e === "object" && typeof e.angle === "string" ? e.angle.trim() : ""))
+      .filter((a) => a.length > 0)
+    : [];
+  const recordedBases = new Set(recorded.map(baseAngleName));
+  const missingMandatory = mandatoryAngles.filter((a) => !recordedBases.has(a));
+  let foreignAngles = [];
+  if (Array.isArray(pool) && pool.length > 0) {
+    const poolSet = new Set(pool);
+    foreignAngles = [...new Set(recorded.filter((a) => !poolSet.has(baseAngleName(a))))];
+  }
+  return { missingMandatory, foreignAngles };
+}
+
+/**
  * Default cap on parallel fan-out reviewers when a caller does not supply one.
  * Mirrors the config default (gates.maxFanoutReviewers).
  */

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -20,6 +20,7 @@ import {
   resolveRefinement,
   resolveGateConfig,
   resolveGateAngles,
+  resolveRejectForeignAngles,
   resolveGateAnglesDynamic,
   resolveAnglePool,
   resolveWorkflowConfig,
@@ -3193,6 +3194,29 @@ describe("gates.requireFanoutProvenance", () => {
 
   test("floor constant is 2 (smallest count that is not a single agent)", () => {
     assert.equal(FANOUT_PROVENANCE_MIN_REVIEWERS, 2);
+  });
+});
+
+describe("gates.rejectForeignAngles (#1196)", () => {
+  test("defaults to true (fail-closed) when absent", () => {
+    assert.equal(resolveRejectForeignAngles({}), true);
+    assert.equal(resolveRejectForeignAngles({ gates: {} }), true);
+    const parsed = DevLoopConfigSchema.safeParse({ version: 1, gates: { draft: {} } });
+    assert.equal(parsed.success, true);
+    assert.equal(parsed.data.gates.rejectForeignAngles, true);
+    assert.equal(resolveRejectForeignAngles(parsed.data), true);
+  });
+
+  test("opt-out: explicit rejectForeignAngles: false switches to warn-only", () => {
+    assert.equal(resolveRejectForeignAngles({ gates: { rejectForeignAngles: false } }), false);
+    const full = DevLoopConfigSchema.safeParse({ version: 1, gates: { rejectForeignAngles: false } });
+    assert.equal(full.success, true);
+    assert.equal(resolveRejectForeignAngles(full.data), false);
+  });
+
+  test("rejects non-boolean rejectForeignAngles", () => {
+    const bad = DevLoopConfigSchema.safeParse({ version: 1, gates: { rejectForeignAngles: "yes" } });
+    assert.equal(bad.success, false);
   });
 });
 

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -20,6 +20,7 @@ import {
   resolveRefinement,
   resolveGateConfig,
   resolveGateAngles,
+  resolveGateAngleContract,
   resolveRejectForeignAngles,
   resolveGateAnglesDynamic,
   resolveAnglePool,
@@ -3217,6 +3218,62 @@ describe("gates.rejectForeignAngles (#1196)", () => {
   test("rejects non-boolean rejectForeignAngles", () => {
     const bad = DevLoopConfigSchema.safeParse({ version: 1, gates: { rejectForeignAngles: "yes" } });
     assert.equal(bad.success, false);
+  });
+});
+
+describe("resolveGateAngleContract (#1196 — shared angle enforcement contract)", () => {
+  test("returns exclude-filtered mandatory angles + the resolveGateAngles pool by default", () => {
+    const config = {
+      gates: { preApproval: { angles: ["dry", "kiss"], mandatoryAngles: ["pr-checklist-matrix"] } },
+    };
+    const { mandatoryAngles, pool } = resolveGateAngleContract(config, "preApproval");
+    assert.deepEqual(mandatoryAngles, ["pr-checklist-matrix"]);
+    assert.deepEqual(pool, ["pr-checklist-matrix", "dry", "kiss"]);
+  });
+
+  test("an excluded mandatory angle is dropped from BOTH sides (no missing-mandatory/foreign deadlock)", () => {
+    const config = {
+      gates: {
+        preApproval: {
+          angles: ["dry", "kiss"],
+          mandatoryAngles: ["pr-checklist-matrix", "yagni"],
+          excludeAngles: ["yagni"],
+        },
+      },
+    };
+    const { mandatoryAngles, pool } = resolveGateAngleContract(config, "preApproval");
+    // yagni is neither required (missing-mandatory) nor allowed (foreign):
+    // it simply leaves the contract, so a fanout write omitting it passes.
+    assert.deepEqual(mandatoryAngles, ["pr-checklist-matrix"]);
+    assert.ok(!pool.includes("yagni"));
+  });
+
+  test("additiveAngles widens the pool to the global lens catalog, excludeAngles still a hard ceiling", () => {
+    const config = {
+      gates: {
+        anglePool: ["dry", "kiss", "catalog-extra", "catalog-blocked"],
+        preApproval: {
+          angles: ["dry"],
+          mandatoryAngles: [],
+          additiveAngles: true,
+          excludeAngles: ["catalog-blocked"],
+        },
+      },
+    };
+    const { pool } = resolveGateAngleContract(config, "preApproval");
+    assert.ok(pool.includes("catalog-extra"), "additively-selectable catalog angle must be in the enforcement pool");
+    assert.ok(!pool.includes("catalog-blocked"), "excludeAngles caps additive widening");
+    // Without additiveAngles the catalog angle stays foreign.
+    const strict = resolveGateAngleContract({
+      gates: { anglePool: ["dry", "catalog-extra"], preApproval: { angles: ["dry"], mandatoryAngles: [] } },
+    }, "preApproval");
+    assert.ok(!strict.pool.includes("catalog-extra"));
+  });
+
+  test("null pool passes through when the gate configures no angles at all", () => {
+    const { mandatoryAngles, pool } = resolveGateAngleContract({ version: 1 }, "draft");
+    assert.deepEqual(mandatoryAngles, []);
+    assert.equal(pool, null);
   });
 });
 

--- a/packages/core/test/gate-fanin.test.mjs
+++ b/packages/core/test/gate-fanin.test.mjs
@@ -10,6 +10,7 @@ import {
   fanoutUnavailableError,
   countDistinctReviewers,
   provenanceConsistencyError,
+  checkFanoutAngleCoverage,
 } from "../src/loop/gate-fanin.mjs";
 
 function cleanAngle(angle) {
@@ -233,5 +234,51 @@ describe("provenance consistency (closes the self-produced loophole)", () => {
     assert.match(provenanceConsistencyError({ distinctReviewers: 1.5, perAngle: [] }), /non-negative integer/);
     assert.match(provenanceConsistencyError({ distinctReviewers: 2, perAngle: [] }), /perAngle must be non-empty/);
     assert.match(provenanceConsistencyError({ distinctReviewers: 2, perAngle: [{ angle: "a", reviewer: "x" }] }), /exceeds distinct recorded reviewer identities/);
+  });
+});
+
+describe("checkFanoutAngleCoverage (#1196 — mandatory angles + angle-pool membership)", () => {
+  test("passes when every mandatory angle is recorded and every angle is in the pool", () => {
+    const result = checkFanoutAngleCoverage(
+      [{ angle: "pr-checklist-matrix" }, { angle: "yagni" }],
+      { mandatoryAngles: ["pr-checklist-matrix"], pool: ["yagni", "pr-checklist-matrix", "dry"] },
+    );
+    assert.deepEqual(result, { missingMandatory: [], foreignAngles: [] });
+  });
+
+  test("reports every mandatory angle absent from the recorded angles", () => {
+    const result = checkFanoutAngleCoverage(
+      [{ angle: "yagni" }],
+      { mandatoryAngles: ["pr-checklist-matrix", "acceptance-criteria", "yagni"] },
+    );
+    assert.deepEqual(result.missingMandatory, ["pr-checklist-matrix", "acceptance-criteria"]);
+  });
+
+  test("reports recorded angles that are outside the configured pool (ad-hoc labels)", () => {
+    const result = checkFanoutAngleCoverage(
+      [{ angle: "dry" }, { angle: "made-up-angle" }],
+      { mandatoryAngles: [], pool: ["dry", "kiss"] },
+    );
+    assert.deepEqual(result.foreignAngles, ["made-up-angle"]);
+  });
+
+  test("skips the foreign-angle check when no pool is supplied (null/absent)", () => {
+    assert.deepEqual(
+      checkFanoutAngleCoverage([{ angle: "anything" }], { mandatoryAngles: [] }),
+      { missingMandatory: [], foreignAngles: [] },
+    );
+  });
+
+  test("delta-suffixed angles (<angle>-delta-at-...) count toward their base angle for BOTH checks", () => {
+    const result = checkFanoutAngleCoverage(
+      [{ angle: "pr-checklist-matrix-delta-at-current-head" }],
+      { mandatoryAngles: ["pr-checklist-matrix"], pool: ["pr-checklist-matrix"] },
+    );
+    assert.deepEqual(result, { missingMandatory: [], foreignAngles: [] });
+  });
+
+  test("tolerates malformed/missing input (non-array, entries without a usable .angle)", () => {
+    assert.deepEqual(checkFanoutAngleCoverage(undefined, { mandatoryAngles: ["a"] }).missingMandatory, ["a"]);
+    assert.deepEqual(checkFanoutAngleCoverage([null, { angle: "" }, "nope"], { mandatoryAngles: [] }).foreignAngles, []);
   });
 });

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -393,17 +393,27 @@ async function ledgerExistsInAny(checkouts, ledgerPath) {
  * Read the recorded fan-out `provenance` object from a ledger across the
  * enumerated checkouts. Mirrors ledgerExistsInAny's "ANY checkout satisfies"
  * semantics: prefers the FIRST checkout whose ledger provenance actually
- * SATISFIES enforcement (internally consistent AND distinctReviewers >= floor),
- * so a below-floor or provenance-less ledger in an earlier-enumerated checkout
- * cannot SHADOW a valid one in the PR worktree (which would falsely fail closed).
- * Falls back to the first non-null provenance (for a useful diagnostic message)
- * only when NO checkout satisfies, and null only when none is present. Called
- * whenever requireFanoutProvenance is enabled OR the gate's verdict is
- * fanout_fanin (angle-coverage enforcement re-validates recorded provenance
- * independently of the requireFanoutProvenance opt-in) — inline verdicts never
- * trigger this read.
+ * SATISFIES the FULL active enforcement — internally consistent, meeting the
+ * distinctReviewers floor when requireFanoutProvenance is on, AND passing the
+ * gate's angle contract (mandatory-angle coverage; pool membership when
+ * foreign angles are rejected) — so a stale checkout's below-floor,
+ * provenance-less, or angle-contract-failing ledger cannot SHADOW a valid one
+ * in the PR worktree (which would falsely fail closed). Falls back to the
+ * first non-null provenance (for a useful diagnostic message) only when NO
+ * checkout satisfies, and null only when none is present. Called whenever
+ * requireFanoutProvenance is enabled OR the gate's verdict is fanout_fanin —
+ * inline verdicts never trigger this read.
  */
-async function readLedgerProvenanceInAny(checkouts, ledgerPath) {
+async function readLedgerProvenanceInAny(checkouts, ledgerPath, criteria = {}) {
+  const { requireProvenance = false, mandatoryAngles = [], anglePool = null, rejectForeignAngles = true } = criteria;
+  const satisfies = (prov) => {
+    if (provenanceConsistencyError(prov) !== null) return false;
+    if (requireProvenance && prov.distinctReviewers < FANOUT_PROVENANCE_MIN_REVIEWERS) return false;
+    const { missingMandatory, foreignAngles } = checkFanoutAngleCoverage(prov.perAngle, { mandatoryAngles, pool: anglePool });
+    if (missingMandatory.length > 0) return false;
+    if (foreignAngles.length > 0 && rejectForeignAngles) return false;
+    return true;
+  };
   let firstNonNull = null;
   for (const root of checkouts) {
     const full = path.resolve(root, ledgerPath);
@@ -411,8 +421,8 @@ async function readLedgerProvenanceInAny(checkouts, ledgerPath) {
       const parsed = JSON.parse(await readFile(full, "utf8"));
       const prov = parsed && typeof parsed === "object" ? parsed.provenance : null;
       if (prov == null) continue; // ledger present but no provenance — keep scanning.
-      if (provenanceConsistencyError(prov) === null && prov.distinctReviewers >= FANOUT_PROVENANCE_MIN_REVIEWERS) {
-        return prov; // satisfying ledger — prefer it over any earlier below-floor one.
+      if (satisfies(prov)) {
+        return prov; // satisfying ledger — prefer it over any earlier failing one.
       }
       if (firstNonNull === null) firstNonNull = prov; // remember for diagnostics.
     } catch {
@@ -505,7 +515,10 @@ export async function buildFanoutEnforcement({ repo, pr, currentHeadSha, draftGa
     // Read ledger provenance for ANY fanout_fanin gate (not just when
     // requireProvenance is on): angle-coverage enforcement re-validates
     // whatever provenance is recorded independently of that opt-in flag.
+    // The selection criteria mirror the full active enforcement so a stale
+    // checkout's contract-failing ledger cannot shadow a passing one.
     const readProvenance = requireProvenance || spec.marker.executionMode === "fanout_fanin";
+    const angleFields = GATE_ANGLE_CONFIG[spec.name];
     gates.push({
       name: spec.name,
       executionMode: spec.marker.executionMode ?? null,
@@ -513,8 +526,10 @@ export async function buildFanoutEnforcement({ repo, pr, currentHeadSha, draftGa
       scopeUnderThreshold,
       ledgerPath,
       ledgerExists: await ledgerExistsInAny(checkouts, ledgerPath),
-      provenance: readProvenance ? await readLedgerProvenanceInAny(checkouts, ledgerPath) : null,
-      ...GATE_ANGLE_CONFIG[spec.name],
+      provenance: readProvenance
+        ? await readLedgerProvenanceInAny(checkouts, ledgerPath, { requireProvenance, rejectForeignAngles, ...angleFields })
+        : null,
+      ...angleFields,
     });
   }
   return { required: true, requireProvenance, rejectForeignAngles, lightMode, hasFullLabel, gates };

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -14,8 +14,8 @@ import path from "node:path";
 import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
-import { FANOUT_PROVENANCE_MIN_REVIEWERS, GATE_FULL_LABEL, loadDevLoopConfig, resolveGateConfig, resolveLightMode, resolveRequireFanoutEvidence, resolveRequireFanoutProvenance } from "@dev-loops/core/config";
-import { FANOUT_UNAVAILABLE_MESSAGE, provenanceConsistencyError } from "@dev-loops/core/loop/gate-fanin";
+import { FANOUT_PROVENANCE_MIN_REVIEWERS, GATE_FULL_LABEL, loadDevLoopConfig, resolveGateAngles, resolveGateConfig, resolveLightMode, resolveRejectForeignAngles, resolveRequireFanoutEvidence, resolveRequireFanoutProvenance } from "@dev-loops/core/config";
+import { FANOUT_UNAVAILABLE_MESSAGE, checkFanoutAngleCoverage, provenanceConsistencyError } from "@dev-loops/core/loop/gate-fanin";
 import { detectMergeBaseScope, isEligibleForLightMode } from "../loop/detect-change-scope.mjs";
 import { buildLogPath } from "./write-gate-findings-log.mjs";
 import { ensureAsyncRunnerOwnership } from "../loop/_pr-runner-coordination.mjs";
@@ -310,6 +310,28 @@ export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null, s
           );
         }
       }
+      // Angle-coverage enforcement: independent of requireFanoutProvenance —
+      // whenever a fanout_fanin ledger recorded ANY internally-consistent
+      // provenance, its perAngle must cover every configured mandatory angle
+      // and (default) stay within the gate's configured pool. An absent or
+      // malformed provenance is not a NEW failure here (that gap is
+      // requireFanoutProvenance's separate, opt-in concern).
+      if (gate.executionMode === "fanout_fanin" && gate.provenance && provenanceConsistencyError(gate.provenance) === null) {
+        const { missingMandatory, foreignAngles } = checkFanoutAngleCoverage(gate.provenance.perAngle, {
+          mandatoryAngles: gate.mandatoryAngles ?? [],
+          pool: gate.anglePool ?? null,
+        });
+        if (missingMandatory.length > 0) {
+          failures.push(
+            `${gate.name}: fan-out provenance is missing mandatory angle(s): ${missingMandatory.join(", ")}; ${FANOUT_UNAVAILABLE_MESSAGE}`,
+          );
+        }
+        if (foreignAngles.length > 0 && (fanoutEnforcement.rejectForeignAngles ?? true)) {
+          failures.push(
+            `${gate.name}: fan-out provenance names angle(s) outside the configured pool: ${foreignAngles.join(", ")}; ${FANOUT_UNAVAILABLE_MESSAGE}`,
+          );
+        }
+      }
     }
   }
   if (typeof unresolvedThreadCount === "number" && unresolvedThreadCount !== 0) {
@@ -358,8 +380,11 @@ async function ledgerExistsInAny(checkouts, ledgerPath) {
  * so a below-floor or provenance-less ledger in an earlier-enumerated checkout
  * cannot SHADOW a valid one in the PR worktree (which would falsely fail closed).
  * Falls back to the first non-null provenance (for a useful diagnostic message)
- * only when NO checkout satisfies, and null only when none is present. Only
- * called when requireFanoutProvenance is enabled so the default path pays no I/O.
+ * only when NO checkout satisfies, and null only when none is present. Called
+ * whenever requireFanoutProvenance is enabled OR the gate's verdict is
+ * fanout_fanin (angle-coverage enforcement re-validates recorded provenance
+ * independently of the requireFanoutProvenance opt-in) — inline verdicts never
+ * trigger this read.
  */
 async function readLedgerProvenanceInAny(checkouts, ledgerPath) {
   let firstNonNull = null;
@@ -413,17 +438,25 @@ export async function buildFanoutEnforcement({ repo, pr, currentHeadSha, draftGa
   // Provenance enforcement is opt-in and layered ON TOP of fan-out evidence: it
   // only takes effect while evidence enforcement (above) is active.
   const requireProvenance = resolveRequireFanoutProvenance(config);
+  // Angle-coverage enforcement (mandatory angles + pool membership) is layered
+  // independently of requireProvenance: it re-validates whatever provenance a
+  // fanout_fanin ledger actually recorded, regardless of that opt-in flag.
+  const rejectForeignAngles = resolveRejectForeignAngles(config);
   // Light-mode facts (#1174): the threshold that a re-derived merge-base scope
   // must fall under for an inline verdict to be accepted. null when lightMode is
   // disabled → no inline verdict can ever be accepted (scopeUnderThreshold stays
   // false), preserving today's rejection.
   const lightThreshold = resolveLightMode(config);
   const lightMode = lightThreshold != null;
-  const draftRequired = resolveGateConfig(config, "draft").required;
-  const preApprovalRequired = resolveGateConfig(config, "preApproval").required;
+  const draftGateConfig = resolveGateConfig(config, "draft");
+  const preApprovalGateConfig = resolveGateConfig(config, "preApproval");
+  const GATE_ANGLE_CONFIG = {
+    draft_gate: { mandatoryAngles: draftGateConfig.mandatoryAngles, pool: resolveGateAngles(config, "draft") },
+    pre_approval_gate: { mandatoryAngles: preApprovalGateConfig.mandatoryAngles, pool: resolveGateAngles(config, "preApproval") },
+  };
   const gateSpecs = [
-    { name: "draft_gate", marker: draftGateMarker, required: draftRequired },
-    { name: "pre_approval_gate", marker: preApprovalGateMarker, required: preApprovalRequired },
+    { name: "draft_gate", marker: draftGateMarker, required: draftGateConfig.required },
+    { name: "pre_approval_gate", marker: preApprovalGateMarker, required: preApprovalGateConfig.required },
   ].filter((spec) => spec.required && spec.marker.visible);
   const gates = [];
   const checkouts = resolveLedgerCheckouts(cwd);
@@ -444,6 +477,10 @@ export async function buildFanoutEnforcement({ repo, pr, currentHeadSha, draftGa
       const scope = detectMergeBaseScope({ base: baseRef, head: headSha, cwd: repoRoot });
       scopeUnderThreshold = scope.ok === true && isEligibleForLightMode(scope, lightThreshold);
     }
+    // Read ledger provenance for ANY fanout_fanin gate (not just when
+    // requireProvenance is on): angle-coverage enforcement re-validates
+    // whatever provenance is recorded independently of that opt-in flag.
+    const readProvenance = requireProvenance || spec.marker.executionMode === "fanout_fanin";
     gates.push({
       name: spec.name,
       executionMode: spec.marker.executionMode ?? null,
@@ -451,10 +488,11 @@ export async function buildFanoutEnforcement({ repo, pr, currentHeadSha, draftGa
       scopeUnderThreshold,
       ledgerPath,
       ledgerExists: await ledgerExistsInAny(checkouts, ledgerPath),
-      provenance: requireProvenance ? await readLedgerProvenanceInAny(checkouts, ledgerPath) : null,
+      provenance: readProvenance ? await readLedgerProvenanceInAny(checkouts, ledgerPath) : null,
+      ...GATE_ANGLE_CONFIG[spec.name],
     });
   }
-  return { required: true, requireProvenance, lightMode, hasFullLabel, gates };
+  return { required: true, requireProvenance, rejectForeignAngles, lightMode, hasFullLabel, gates };
 }
 export async function detectCheckpointEvidence(options, { env = process.env, ghCommand = "gh", cwd = process.cwd() } = {}) {
   const runnerOwnership = await ensureAsyncRunnerOwnership({

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -14,7 +14,7 @@ import path from "node:path";
 import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
-import { FANOUT_PROVENANCE_MIN_REVIEWERS, GATE_FULL_LABEL, loadDevLoopConfig, resolveGateAngles, resolveGateConfig, resolveLightMode, resolveRejectForeignAngles, resolveRequireFanoutEvidence, resolveRequireFanoutProvenance } from "@dev-loops/core/config";
+import { FANOUT_PROVENANCE_MIN_REVIEWERS, GATE_FULL_LABEL, loadDevLoopConfig, resolveGateAngleContract, resolveGateConfig, resolveLightMode, resolveRejectForeignAngles, resolveRequireFanoutEvidence, resolveRequireFanoutProvenance } from "@dev-loops/core/config";
 import { FANOUT_UNAVAILABLE_MESSAGE, checkFanoutAngleCoverage, provenanceConsistencyError } from "@dev-loops/core/loop/gate-fanin";
 import { detectMergeBaseScope, isEligibleForLightMode } from "../loop/detect-change-scope.mjs";
 import { buildLogPath } from "./write-gate-findings-log.mjs";
@@ -310,26 +310,36 @@ export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null, s
           );
         }
       }
-      // Angle-coverage enforcement: independent of requireFanoutProvenance —
-      // whenever a fanout_fanin ledger recorded ANY internally-consistent
-      // provenance, its perAngle must cover every configured mandatory angle
-      // and (default) stay within the gate's configured pool. An absent or
-      // malformed provenance is not a NEW failure here (that gap is
-      // requireFanoutProvenance's separate, opt-in concern).
-      if (gate.executionMode === "fanout_fanin" && gate.provenance && provenanceConsistencyError(gate.provenance) === null) {
-        const { missingMandatory, foreignAngles } = checkFanoutAngleCoverage(gate.provenance.perAngle, {
-          mandatoryAngles: gate.mandatoryAngles ?? [],
-          pool: gate.anglePool ?? null,
-        });
-        if (missingMandatory.length > 0) {
+      // Angle-coverage enforcement: independent of requireFanoutProvenance.
+      // When the gate configures mandatory angles, a fanout_fanin ledger MUST
+      // record internally-consistent provenance — otherwise a shadow ledger
+      // that simply omits provenance would bypass mandatory-angle coverage.
+      // Recorded provenance is then re-validated: perAngle must cover every
+      // mandatory angle and (default) stay within the configured pool. Gates
+      // without mandatory angles keep today's behavior (absent provenance adds
+      // no failure; that stricter gap is requireFanoutProvenance's opt-in).
+      if (gate.executionMode === "fanout_fanin") {
+        const mandatoryAngles = gate.mandatoryAngles ?? [];
+        const provValid = gate.provenance != null && provenanceConsistencyError(gate.provenance) === null;
+        if (mandatoryAngles.length > 0 && !provValid) {
           failures.push(
-            `${gate.name}: fan-out provenance is missing mandatory angle(s): ${missingMandatory.join(", ")}; ${FANOUT_UNAVAILABLE_MESSAGE}`,
+            `${gate.name}: mandatory angle coverage is configured (${mandatoryAngles.join(", ")}) but the findings-log ledger records no valid fan-out provenance to verify it against; write the ledger with --provenance covering the mandatory angles; ${FANOUT_UNAVAILABLE_MESSAGE}`,
           );
-        }
-        if (foreignAngles.length > 0 && (fanoutEnforcement.rejectForeignAngles ?? true)) {
-          failures.push(
-            `${gate.name}: fan-out provenance names angle(s) outside the configured pool: ${foreignAngles.join(", ")}; ${FANOUT_UNAVAILABLE_MESSAGE}`,
-          );
+        } else if (provValid) {
+          const { missingMandatory, foreignAngles } = checkFanoutAngleCoverage(gate.provenance.perAngle, {
+            mandatoryAngles,
+            pool: gate.anglePool ?? null,
+          });
+          if (missingMandatory.length > 0) {
+            failures.push(
+              `${gate.name}: fan-out provenance is missing mandatory angle(s): ${missingMandatory.join(", ")}; ${FANOUT_UNAVAILABLE_MESSAGE}`,
+            );
+          }
+          if (foreignAngles.length > 0 && (fanoutEnforcement.rejectForeignAngles ?? true)) {
+            failures.push(
+              `${gate.name}: fan-out provenance names angle(s) outside the configured pool: ${foreignAngles.join(", ")}; ${FANOUT_UNAVAILABLE_MESSAGE}`,
+            );
+          }
         }
       }
     }
@@ -450,9 +460,17 @@ export async function buildFanoutEnforcement({ repo, pr, currentHeadSha, draftGa
   const lightMode = lightThreshold != null;
   const draftGateConfig = resolveGateConfig(config, "draft");
   const preApprovalGateConfig = resolveGateConfig(config, "preApproval");
+  // Shared angle-contract resolver (exclude-filtered mandatory angles +
+  // additive-aware pool) — the same contract the write paths enforce. The
+  // field names here (`mandatoryAngles`/`anglePool`) are exactly what
+  // buildPreMergeGateCheck reads off each gate entry.
+  const buildAngleFields = (gateKey) => {
+    const { mandatoryAngles, pool } = resolveGateAngleContract(config, gateKey);
+    return { mandatoryAngles, anglePool: pool };
+  };
   const GATE_ANGLE_CONFIG = {
-    draft_gate: { mandatoryAngles: draftGateConfig.mandatoryAngles, pool: resolveGateAngles(config, "draft") },
-    pre_approval_gate: { mandatoryAngles: preApprovalGateConfig.mandatoryAngles, pool: resolveGateAngles(config, "preApproval") },
+    draft_gate: buildAngleFields("draft"),
+    pre_approval_gate: buildAngleFields("preApproval"),
   };
   const gateSpecs = [
     { name: "draft_gate", marker: draftGateMarker, required: draftGateConfig.required },

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -240,6 +240,7 @@ function normalizeGateMarkerSummary(summary) {
 }
 export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null, staleRunnerCheck = null, fanoutEnforcement = null) {
   const failures = [];
+  const warnings = [];
   if (!(evidence.draftGate.visible && evidence.draftGate.verdict === "clean")) {
     failures.push("missing visible clean draft_gate comment");
   }
@@ -335,10 +336,14 @@ export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null, s
               `${gate.name}: fan-out provenance is missing mandatory angle(s): ${missingMandatory.join(", ")}; ${FANOUT_UNAVAILABLE_MESSAGE}`,
             );
           }
-          if (foreignAngles.length > 0 && (fanoutEnforcement.rejectForeignAngles ?? true)) {
-            failures.push(
-              `${gate.name}: fan-out provenance names angle(s) outside the configured pool: ${foreignAngles.join(", ")}; ${FANOUT_UNAVAILABLE_MESSAGE}`,
-            );
+          if (foreignAngles.length > 0) {
+            const message = `${gate.name}: fan-out provenance names angle(s) outside the configured pool: ${foreignAngles.join(", ")}`;
+            if (fanoutEnforcement.rejectForeignAngles ?? true) {
+              failures.push(`${message}; ${FANOUT_UNAVAILABLE_MESSAGE}`);
+            } else {
+              // rejectForeignAngles: false is WARNING mode, not silence.
+              warnings.push(`${message} (gates.rejectForeignAngles is false; recorded as a warning)`);
+            }
           }
         }
       }
@@ -359,6 +364,8 @@ export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null, s
   return {
     ok: failures.length === 0,
     failures,
+    // Additive: only present when non-empty, preserving the existing {ok, failures} shape.
+    ...(warnings.length > 0 ? { warnings } : {}),
   };
 }
 async function ledgerExists(fullPath) {
@@ -669,6 +676,13 @@ async function main() {
       })}\n`);
       process.exitCode = 1;
       return;
+    }
+    // Warnings (e.g. foreign angles under gates.rejectForeignAngles: false) do
+    // not fail the check but must not pass silently. Suppressed under --silent.
+    if (Array.isArray(preMergeGateCheck.warnings) && !options.silent) {
+      for (const warning of preMergeGateCheck.warnings) {
+        process.stderr.write(`WARNING: ${warning}\n`);
+      }
     }
     process.exitCode = emitResult(output, { jq: options.jq, silent: options.silent });
   } catch (error) {

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -1147,6 +1147,7 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
   // multi-line per-angle breakdown and the `**Findings summary:**` line carries a
   // single-line digest (so the marker/parse contract still round-trips).
   let structuredFindings = null;
+  let rawFindingsInput = null;
   if (options.findingsJson) {
     let raw;
     try {
@@ -1165,6 +1166,7 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
     const candidate = Array.isArray(parsed)
       ? parsed
       : (Array.isArray(parsed?.angles) ? parsed.angles : (Array.isArray(parsed?.findings) ? parsed.findings : null));
+    rawFindingsInput = candidate;
     try {
       structuredFindings = normalizeStructuredFindings(candidate);
     } catch (err) {
@@ -1181,6 +1183,17 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
   // a free-text --findings-summary fanout_fanin verdict carries no per-angle
   // data to validate.
   if (structuredFindings && (options.executionMode ?? DEFAULT_EXECUTION_MODE) === "fanout_fanin") {
+    // Angle-less entries would be bucketed under the synthetic `general` label
+    // by normalization and then surface as a CONFUSING foreign-angle error.
+    // Fail first with a dedicated message naming the real problem instead.
+    const angleless = (rawFindingsInput ?? []).filter(
+      (e) => !e || typeof e !== "object" || typeof e.angle !== "string" || e.angle.trim().length === 0,
+    ).length;
+    if (angleless > 0) {
+      throw new Error(
+        `--findings-json for ${options.gate}: ${angleless} entr${angleless === 1 ? "y" : "ies"} lack a non-empty .angle — a fanout_fanin verdict must attribute every per-angle entry/finding to its review angle (use the nested [{ angle, verdict, findings }] shape, or add .angle to each flat finding)`,
+      );
+    }
     const gateKey = options.gate === "draft_gate" ? "draft" : "preApproval";
     const { mandatoryAngles, pool } = resolveGateAngleContract(config, gateKey);
     const { missingMandatory, foreignAngles } = checkFanoutAngleCoverage(structuredFindings, {

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import { readFile } from "node:fs/promises";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText, sanitizeCopilotSummonTokens } from "../_core-helpers.mjs";
-import { loadDevLoopConfig, resolveEffectiveCopilotRoundCap, resolveGateConfig, resolveRefinementConfig } from "@dev-loops/core/config";
+import { loadDevLoopConfig, resolveEffectiveCopilotRoundCap, resolveGateAngles, resolveGateConfig, resolveRefinementConfig, resolveRejectForeignAngles } from "@dev-loops/core/config";
+import { checkFanoutAngleCoverage } from "@dev-loops/core/loop/gate-fanin";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
@@ -1171,6 +1172,30 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
     }
     if (!structuredFindings) {
       throw new Error(`--findings-json "${options.findingsJson}" did not contain any renderable findings (expected a non-empty per-angle array of { angle, findings } entries, or a flat per-finding array of { severity, summary, angle? } entries)`);
+    }
+  }
+  // Fan-out angle-coverage enforcement (fail closed): a fanout_fanin verdict's
+  // structured per-angle results must cover every configured mandatory angle,
+  // and (default) must not name an angle outside the gate's configured pool.
+  // Only applies when structured per-angle results were actually supplied —
+  // a free-text --findings-summary fanout_fanin verdict carries no per-angle
+  // data to validate.
+  if (structuredFindings && (options.executionMode ?? DEFAULT_EXECUTION_MODE) === "fanout_fanin") {
+    const gateKey = options.gate === "draft_gate" ? "draft" : "preApproval";
+    const pool = resolveGateAngles(config, gateKey);
+    const { missingMandatory, foreignAngles } = checkFanoutAngleCoverage(structuredFindings, {
+      mandatoryAngles: activeGateConfig.mandatoryAngles,
+      pool,
+    });
+    if (missingMandatory.length > 0) {
+      throw new Error(
+        `--findings-json for ${options.gate} is missing mandatory angle(s): ${missingMandatory.join(", ")} (configured in gates.${gateKey}.mandatoryAngles; add a per-angle entry for each before posting a fanout_fanin verdict)`,
+      );
+    }
+    if (foreignAngles.length > 0 && resolveRejectForeignAngles(config)) {
+      throw new Error(
+        `--findings-json for ${options.gate} names angle(s) outside the configured pool: ${foreignAngles.join(", ")} (add them to gates.${gateKey}.angles, or set gates.rejectForeignAngles: false to warn instead of fail)`,
+      );
     }
   }
   // --findings-json takes precedence; when structured findings are present, do not

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -1192,10 +1192,17 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
         `--findings-json for ${options.gate} is missing mandatory angle(s): ${missingMandatory.join(", ")} (configured in gates.${gateKey}.mandatoryAngles; add a per-angle entry for each before posting a fanout_fanin verdict)`,
       );
     }
-    if (foreignAngles.length > 0 && resolveRejectForeignAngles(config)) {
-      throw new Error(
-        `--findings-json for ${options.gate} names angle(s) outside the configured pool: ${foreignAngles.join(", ")} (add them to gates.${gateKey}.angles, or set gates.rejectForeignAngles: false to warn instead of fail)`,
-      );
+    if (foreignAngles.length > 0) {
+      const message = `--findings-json for ${options.gate} names angle(s) outside the configured pool: ${foreignAngles.join(", ")}`;
+      if (resolveRejectForeignAngles(config)) {
+        throw new Error(
+          `${message} (add them to gates.${gateKey}.angles, or set gates.rejectForeignAngles: false to warn instead of fail)`,
+        );
+      }
+      // rejectForeignAngles: false is WARNING mode, not silence — one line per call.
+      if (!options.silent) {
+        process.stderr.write(`WARNING: ${message} (gates.rejectForeignAngles is false; recorded as a warning)\n`);
+      }
     }
   }
   // --findings-json takes precedence; when structured findings are present, do not

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { readFile } from "node:fs/promises";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText, sanitizeCopilotSummonTokens } from "../_core-helpers.mjs";
-import { loadDevLoopConfig, resolveEffectiveCopilotRoundCap, resolveGateAngles, resolveGateConfig, resolveRefinementConfig, resolveRejectForeignAngles } from "@dev-loops/core/config";
+import { loadDevLoopConfig, resolveEffectiveCopilotRoundCap, resolveGateAngleContract, resolveGateConfig, resolveRefinementConfig, resolveRejectForeignAngles } from "@dev-loops/core/config";
 import { checkFanoutAngleCoverage } from "@dev-loops/core/loop/gate-fanin";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
@@ -1182,9 +1182,9 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
   // data to validate.
   if (structuredFindings && (options.executionMode ?? DEFAULT_EXECUTION_MODE) === "fanout_fanin") {
     const gateKey = options.gate === "draft_gate" ? "draft" : "preApproval";
-    const pool = resolveGateAngles(config, gateKey);
+    const { mandatoryAngles, pool } = resolveGateAngleContract(config, gateKey);
     const { missingMandatory, foreignAngles } = checkFanoutAngleCoverage(structuredFindings, {
-      mandatoryAngles: activeGateConfig.mandatoryAngles,
+      mandatoryAngles,
       pool,
     });
     if (missingMandatory.length > 0) {

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -6,7 +6,7 @@ import { parsePrNumber, requireTokenValue } from "../_cli-primitives.mjs";
 import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 import { checkFanoutAngleCoverage, provenanceConsistencyError } from "@dev-loops/core/loop/gate-fanin";
-import { loadDevLoopConfig, resolveGateAngles, resolveGateConfig, resolveRejectForeignAngles } from "@dev-loops/core/config";
+import { loadDevLoopConfig, resolveGateAngleContract, resolveRejectForeignAngles } from "@dev-loops/core/config";
 const USAGE = `Usage: write-gate-findings-log.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate> --head-sha <sha> --verdict <clean|findings_present|blocked> --findings <json> [--tmp-root <path>]
 Write a durable <gate>-<headSha>.json log under deterministic tmp/ paths.
 Required:
@@ -167,10 +167,9 @@ export function parseProvenanceJson(raw) {
 export async function checkProvenanceAngleCoverage(provenance, gate, { repoRoot = process.cwd() } = {}) {
   const { config } = await loadDevLoopConfig({ repoRoot });
   const gateKey = GATE_CONFIG_KEY[gate];
-  const gateConfig = resolveGateConfig(config, gateKey);
-  const pool = resolveGateAngles(config, gateKey);
+  const { mandatoryAngles, pool } = resolveGateAngleContract(config, gateKey);
   const { missingMandatory, foreignAngles } = checkFanoutAngleCoverage(provenance.perAngle, {
-    mandatoryAngles: gateConfig.mandatoryAngles,
+    mandatoryAngles,
     pool,
   });
   if (missingMandatory.length > 0) {

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -178,11 +178,11 @@ export async function checkProvenanceAngleCoverage(provenance, gate, { repoRoot 
     );
   }
   if (foreignAngles.length > 0) {
-    const message = `--provenance.perAngle names angle(s) outside the configured pool for ${gate}: ${foreignAngles.join(", ")} (add them to gates.${gateKey}.angles, or set gates.rejectForeignAngles: false to warn instead of fail)`;
+    const message = `--provenance.perAngle names angle(s) outside the configured pool for ${gate}: ${foreignAngles.join(", ")}`;
     if (resolveRejectForeignAngles(config)) {
-      throw parseError(message);
+      throw parseError(`${message} (add them to gates.${gateKey}.angles, or set gates.rejectForeignAngles: false to warn instead of fail)`);
     }
-    return { warning: message };
+    return { warning: `${message} (gates.rejectForeignAngles is false; recorded as a warning)` };
   }
   return { warning: null };
 }
@@ -339,6 +339,12 @@ async function main() {
   }
   try {
     const result = await writeGateFindingsLog(options);
+    // rejectForeignAngles: false is WARNING mode, not silence — surface the
+    // angle-coverage warning on stderr too (the JSON result carries it as
+    // `warning`). Suppressed under --silent.
+    if (result.warning && !options.silent) {
+      process.stderr.write(`WARNING: ${result.warning}\n`);
+    }
     process.exitCode = emitResult(result, { jq: options.jq, silent: options.silent });
   } catch (error) {
     process.stderr.write(JSON.stringify({

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -5,7 +5,8 @@ import { parseArgs } from "node:util";
 import { parsePrNumber, requireTokenValue } from "../_cli-primitives.mjs";
 import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
-import { provenanceConsistencyError } from "@dev-loops/core/loop/gate-fanin";
+import { checkFanoutAngleCoverage, provenanceConsistencyError } from "@dev-loops/core/loop/gate-fanin";
+import { loadDevLoopConfig, resolveGateAngles, resolveGateConfig, resolveRejectForeignAngles } from "@dev-loops/core/config";
 const USAGE = `Usage: write-gate-findings-log.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate> --head-sha <sha> --verdict <clean|findings_present|blocked> --findings <json> [--tmp-root <path>]
 Write a durable <gate>-<headSha>.json log under deterministic tmp/ paths.
 Required:
@@ -30,6 +31,7 @@ function normalizeGate(value) {
   const normalized = String(value).trim().toLowerCase();
   return gates.has(normalized) ? normalized : null;
 }
+const GATE_CONFIG_KEY = { draft_gate: "draft", pre_approval_gate: "preApproval" };
 function normalizeVerdict(value) {
   const verdicts = new Set(["clean", "findings_present", "blocked"]);
   const normalized = String(value).trim().toLowerCase();
@@ -148,6 +150,43 @@ export function parseProvenanceJson(raw) {
   }
   return normalized;
 }
+/**
+ * Validate recorded provenance.perAngle against the gate's configured angle
+ * contract (mandatoryAngles + pool, resolved from .devloops/defaults). A
+ * missing mandatory angle always fails the write. A foreign (out-of-pool)
+ * angle fails the write unless `gates.rejectForeignAngles: false`, in which
+ * case it is returned as a warning instead. Throws a `parseError`-shaped Error
+ * (matching this module's other validation failures) on a fail-closed
+ * rejection.
+ *
+ * @param {{ perAngle: Array<{ angle: string }> }} provenance
+ * @param {"draft_gate"|"pre_approval_gate"} gate
+ * @param {{ repoRoot?: string }} [options]
+ * @returns {Promise<{ warning: string|null }>}
+ */
+export async function checkProvenanceAngleCoverage(provenance, gate, { repoRoot = process.cwd() } = {}) {
+  const { config } = await loadDevLoopConfig({ repoRoot });
+  const gateKey = GATE_CONFIG_KEY[gate];
+  const gateConfig = resolveGateConfig(config, gateKey);
+  const pool = resolveGateAngles(config, gateKey);
+  const { missingMandatory, foreignAngles } = checkFanoutAngleCoverage(provenance.perAngle, {
+    mandatoryAngles: gateConfig.mandatoryAngles,
+    pool,
+  });
+  if (missingMandatory.length > 0) {
+    throw parseError(
+      `--provenance.perAngle is missing mandatory angle(s) for ${gate}: ${missingMandatory.join(", ")} (configured in gates.${gateKey}.mandatoryAngles)`,
+    );
+  }
+  if (foreignAngles.length > 0) {
+    const message = `--provenance.perAngle names angle(s) outside the configured pool for ${gate}: ${foreignAngles.join(", ")} (add them to gates.${gateKey}.angles, or set gates.rejectForeignAngles: false to warn instead of fail)`;
+    if (resolveRejectForeignAngles(config)) {
+      throw parseError(message);
+    }
+    return { warning: message };
+  }
+  return { warning: null };
+}
 export function parseWriteGateFindingsLogCliArgs(argv) {
   const { tokens } = parseArgs({
     args: [...argv],
@@ -250,6 +289,12 @@ export function buildLogPath({ repo, pr, gate, headSha, tmpRoot }) {
 export async function writeGateFindingsLog(options, { repoRoot = process.cwd() } = {}) {
   const findings = parseFindingsJson(options.findings);
   const provenance = options.provenance === undefined ? undefined : parseProvenanceJson(options.provenance);
+  // Angle-coverage enforcement (fail-closed on missing mandatory angles / foreign
+  // angles) only applies when provenance is actually recorded — provenance
+  // remains optional and additive (inline_single_agent writes never carry it).
+  const angleCoverage = provenance !== undefined
+    ? await checkProvenanceAngleCoverage(provenance, options.gate, { repoRoot })
+    : { warning: null };
   const logPath = buildLogPath({
     repo: options.repo,
     pr: options.pr,
@@ -276,7 +321,9 @@ export async function writeGateFindingsLog(options, { repoRoot = process.cwd() }
   }
   await mkdir(path.dirname(fullPath), { recursive: true });
   await writeFile(fullPath, JSON.stringify(log, null, 2) + "\n", "utf8");
-  return { ok: true, path: logPath, log };
+  return angleCoverage.warning
+    ? { ok: true, path: logPath, log, warning: angleCoverage.warning }
+    : { ok: true, path: logPath, log };
 }
 async function main() {
   let options;

--- a/test/github/detect-checkpoint-evidence-cross-worktree.test.mjs
+++ b/test/github/detect-checkpoint-evidence-cross-worktree.test.mjs
@@ -329,3 +329,40 @@ test("detect-checkpoint-evidence: a fanout_fanin ledger that simply OMITS proven
     await rm(base, { recursive: true, force: true });
   }
 });
+
+test("angle-contract shadow: a stale checkout's provenance FAILING the angle contract does NOT shadow a passing one elsewhere", async () => {
+  const { base, repoA, repoB } = await makeRepoWithWorktrees();
+  try {
+    const ledgerPath = buildLogPath({ repo: "owner/repo", pr: "42", gate: "pre_approval_gate", headSha: HEAD, tmpRoot: "tmp" });
+    // repoB (== cwd, enumerated FIRST) carries a stale ledger whose provenance
+    // is internally consistent but MISSES the mandatory angle.
+    const stalePath = path.join(repoB, ledgerPath);
+    await mkdir(path.dirname(stalePath), { recursive: true });
+    await writeFile(stalePath, JSON.stringify({
+      repo: "owner/repo", pr: 42, gate: "pre_approval_gate", headSha: HEAD, verdict: "clean", findings: [],
+      provenance: { distinctReviewers: 2, perAngle: [{ angle: "dry", reviewer: "review-a" }, { angle: "dry", reviewer: "review-b" }] },
+    }) + "\n", "utf8");
+    // repoA (enumerated later) carries the ledger whose provenance PASSES.
+    const goodPath = path.join(repoA, ledgerPath);
+    await mkdir(path.dirname(goodPath), { recursive: true });
+    await writeFile(goodPath, JSON.stringify({
+      repo: "owner/repo", pr: 42, gate: "pre_approval_gate", headSha: HEAD, verdict: "clean", findings: [],
+      provenance: { distinctReviewers: 2, perAngle: [{ angle: "dry", reviewer: "review-a" }, { angle: "pr-checklist-matrix", reviewer: "review-b" }] },
+    }) + "\n", "utf8");
+
+    const enforcement = await buildFanoutEnforcement({
+      repo: "owner/repo", pr: "42", currentHeadSha: HEAD,
+      draftGateMarker: NO_DRAFT_MARKER, preApprovalGateMarker: PA_MARKER,
+      config: ANGLE_CONFIG, cwd: repoB,
+    });
+    const pa = enforcement.gates.find((g) => g.name === "pre_approval_gate");
+    assert.ok(
+      pa.provenance.perAngle.some((e) => e.angle === "pr-checklist-matrix"),
+      "must select the angle-contract-passing provenance, not the stale shadow",
+    );
+    const check = buildPreMergeGateCheck(cleanEvidenceFor(HEAD), 0, null, enforcement);
+    assert.equal(check.ok, true, JSON.stringify(check.failures));
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});

--- a/test/github/detect-checkpoint-evidence-cross-worktree.test.mjs
+++ b/test/github/detect-checkpoint-evidence-cross-worktree.test.mjs
@@ -1,12 +1,12 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtemp, rm, realpath } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, realpath, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
 import { buildFanoutEnforcement, buildPreMergeGateCheck } from "../../scripts/github/detect-checkpoint-evidence.mjs";
-import { writeGateFindingsLog } from "../../scripts/github/write-gate-findings-log.mjs";
+import { buildLogPath, writeGateFindingsLog } from "../../scripts/github/write-gate-findings-log.mjs";
 
 function git(cwd, args) {
   execFileSync("git", args, { cwd, stdio: ["ignore", "pipe", "ignore"] });
@@ -115,7 +115,10 @@ test("round-trip: write valid provenance -> buildFanoutEnforcement reads it -> p
     await writeGateFindingsLog(
       {
         repo: "owner/repo", pr: "42", gate: "pre_approval_gate", headSha: HEAD, verdict: "clean", findings: "[]",
-        provenance: JSON.stringify({ distinctReviewers: 2, perAngle: [{ angle: "scope", reviewer: "review-a" }, { angle: "safety", reviewer: "review-b" }] }),
+        // dry/kiss/pr-checklist-matrix are real preApproval pool angles (shipped
+        // extension defaults); pr-checklist-matrix is also the gate's mandatory
+        // angle, so angle-coverage enforcement passes at write time.
+        provenance: JSON.stringify({ distinctReviewers: 2, perAngle: [{ angle: "dry", reviewer: "review-a" }, { angle: "kiss", reviewer: "review-b" }, { angle: "pr-checklist-matrix" }] }),
       },
       { repoRoot: repoA },
     );
@@ -142,7 +145,10 @@ test("round-trip: a below-floor (distinctReviewers:1) ledger FAILS closed", asyn
     await writeGateFindingsLog(
       {
         repo: "owner/repo", pr: "42", gate: "pre_approval_gate", headSha: HEAD, verdict: "clean", findings: "[]",
-        provenance: JSON.stringify({ distinctReviewers: 1, perAngle: [{ angle: "scope", reviewer: "review-a" }] }),
+        // Bare pr-checklist-matrix entry (no reviewer) satisfies mandatory-angle
+        // coverage without adding a countable reviewer identity — distinctReviewers
+        // stays 1 (below the >=2 floor this test exercises).
+        provenance: JSON.stringify({ distinctReviewers: 1, perAngle: [{ angle: "dry", reviewer: "review-a" }, { angle: "pr-checklist-matrix" }] }),
       },
       { repoRoot: repoA },
     );
@@ -171,7 +177,7 @@ test("shadow-bug: a provenance-less ledger in an earlier checkout does NOT shado
     await writeGateFindingsLog(
       {
         repo: "owner/repo", pr: "42", gate: "pre_approval_gate", headSha: HEAD, verdict: "clean", findings: "[]",
-        provenance: JSON.stringify({ distinctReviewers: 2, perAngle: [{ angle: "scope", reviewer: "review-a" }, { angle: "safety", reviewer: "review-b" }] }),
+        provenance: JSON.stringify({ distinctReviewers: 2, perAngle: [{ angle: "dry", reviewer: "review-a" }, { angle: "kiss", reviewer: "review-b" }, { angle: "pr-checklist-matrix" }] }),
       },
       { repoRoot: repoA },
     );
@@ -198,7 +204,7 @@ test("residual shadow: a below-floor ledger in cwd checkout does NOT shadow a sa
     await writeGateFindingsLog(
       {
         repo: "owner/repo", pr: "42", gate: "pre_approval_gate", headSha: HEAD, verdict: "clean", findings: "[]",
-        provenance: JSON.stringify({ distinctReviewers: 1, perAngle: [{ angle: "scope", reviewer: "review-a" }] }),
+        provenance: JSON.stringify({ distinctReviewers: 1, perAngle: [{ angle: "dry", reviewer: "review-a" }, { angle: "pr-checklist-matrix" }] }),
       },
       { repoRoot: repoB },
     );
@@ -206,7 +212,7 @@ test("residual shadow: a below-floor ledger in cwd checkout does NOT shadow a sa
     await writeGateFindingsLog(
       {
         repo: "owner/repo", pr: "42", gate: "pre_approval_gate", headSha: HEAD, verdict: "clean", findings: "[]",
-        provenance: JSON.stringify({ distinctReviewers: 2, perAngle: [{ angle: "scope", reviewer: "review-a" }, { angle: "safety", reviewer: "review-b" }] }),
+        provenance: JSON.stringify({ distinctReviewers: 2, perAngle: [{ angle: "dry", reviewer: "review-a" }, { angle: "kiss", reviewer: "review-b" }, { angle: "pr-checklist-matrix" }] }),
       },
       { repoRoot: repoA },
     );
@@ -220,6 +226,46 @@ test("residual shadow: a below-floor ledger in cwd checkout does NOT shadow a sa
     assert.equal(pa.provenance.distinctReviewers, 2, "satisfying ledger preferred over below-floor");
     const check = buildPreMergeGateCheck(cleanEvidenceFor(HEAD), 0, null, enforcement);
     assert.equal(check.ok, true, JSON.stringify(check.failures));
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+// --- Angle-coverage enforcement blocks merge on bad provenance (#1196) ---
+// Config declaring a mandatory preApproval angle, independent of requireFanoutProvenance.
+const ANGLE_CONFIG = {
+  gates: {
+    requireFanoutEvidence: true,
+    draft: { required: true },
+    preApproval: { required: true, mandatoryAngles: ["pr-checklist-matrix"], angles: ["dry", "pr-checklist-matrix"] },
+  },
+};
+
+test("detect-checkpoint-evidence: a fanout_fanin ledger missing a mandatory angle blocks merge at evidence time (AC1)", async () => {
+  const { base, repoA, repoB } = await makeRepoWithWorktrees();
+  try {
+    // A hand-edited/shadow ledger (bypassing write-gate-findings-log's own
+    // write-time enforcement) records fan-out provenance that never dispatched
+    // the gate's mandatory angle.
+    const ledgerPath = buildLogPath({ repo: "owner/repo", pr: "42", gate: "pre_approval_gate", headSha: HEAD, tmpRoot: "tmp" });
+    const fullLedgerPath = path.join(repoA, ledgerPath);
+    await mkdir(path.dirname(fullLedgerPath), { recursive: true });
+    await writeFile(fullLedgerPath, JSON.stringify({
+      repo: "owner/repo", pr: 42, gate: "pre_approval_gate", headSha: HEAD, verdict: "clean", findings: [],
+      provenance: { distinctReviewers: 2, perAngle: [{ angle: "dry", reviewer: "review-a" }, { angle: "dry", reviewer: "review-b" }] },
+    }) + "\n", "utf8");
+
+    const enforcement = await buildFanoutEnforcement({
+      repo: "owner/repo", pr: "42", currentHeadSha: HEAD,
+      draftGateMarker: NO_DRAFT_MARKER, preApprovalGateMarker: PA_MARKER,
+      config: ANGLE_CONFIG, cwd: repoB,
+    });
+    const check = buildPreMergeGateCheck(cleanEvidenceFor(HEAD), 0, null, enforcement);
+    assert.equal(check.ok, false);
+    assert.ok(
+      check.failures.some((f) => f.includes("missing mandatory angle(s): pr-checklist-matrix") && f.includes("route to conductor")),
+      JSON.stringify(check.failures),
+    );
   } finally {
     await rm(base, { recursive: true, force: true });
   }

--- a/test/github/detect-checkpoint-evidence-cross-worktree.test.mjs
+++ b/test/github/detect-checkpoint-evidence-cross-worktree.test.mjs
@@ -270,3 +270,62 @@ test("detect-checkpoint-evidence: a fanout_fanin ledger missing a mandatory angl
     await rm(base, { recursive: true, force: true });
   }
 });
+
+test("detect-checkpoint-evidence: a fanout_fanin ledger naming a FOREIGN angle blocks merge at evidence time (AC2, through buildFanoutEnforcement)", async () => {
+  // Full read-path integration: the pool resolved by buildFanoutEnforcement must
+  // actually reach buildPreMergeGateCheck's foreign-angle check (guards against
+  // a field-name mismatch making the merge-time pool check dead code).
+  const { base, repoA, repoB } = await makeRepoWithWorktrees();
+  try {
+    const ledgerPath = buildLogPath({ repo: "owner/repo", pr: "42", gate: "pre_approval_gate", headSha: HEAD, tmpRoot: "tmp" });
+    const fullLedgerPath = path.join(repoA, ledgerPath);
+    await mkdir(path.dirname(fullLedgerPath), { recursive: true });
+    await writeFile(fullLedgerPath, JSON.stringify({
+      repo: "owner/repo", pr: 42, gate: "pre_approval_gate", headSha: HEAD, verdict: "clean", findings: [],
+      // Mandatory angle covered, but one recorded angle is outside the pool.
+      provenance: { distinctReviewers: 2, perAngle: [{ angle: "pr-checklist-matrix", reviewer: "review-a" }, { angle: "made-up-angle", reviewer: "review-b" }] },
+    }) + "\n", "utf8");
+
+    const enforcement = await buildFanoutEnforcement({
+      repo: "owner/repo", pr: "42", currentHeadSha: HEAD,
+      draftGateMarker: NO_DRAFT_MARKER, preApprovalGateMarker: PA_MARKER,
+      config: ANGLE_CONFIG, cwd: repoB,
+    });
+    const pa = enforcement.gates.find((g) => g.name === "pre_approval_gate");
+    assert.deepEqual(pa.anglePool, ["pr-checklist-matrix", "dry"], "enforcement must carry the resolved pool as anglePool");
+    const check = buildPreMergeGateCheck(cleanEvidenceFor(HEAD), 0, null, enforcement);
+    assert.equal(check.ok, false);
+    assert.ok(
+      check.failures.some((f) => f.includes("outside the configured pool: made-up-angle")),
+      JSON.stringify(check.failures),
+    );
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("detect-checkpoint-evidence: a fanout_fanin ledger that simply OMITS provenance blocks merge when mandatory angles are configured", async () => {
+  const { base, repoA, repoB } = await makeRepoWithWorktrees();
+  try {
+    const ledgerPath = buildLogPath({ repo: "owner/repo", pr: "42", gate: "pre_approval_gate", headSha: HEAD, tmpRoot: "tmp" });
+    const fullLedgerPath = path.join(repoA, ledgerPath);
+    await mkdir(path.dirname(fullLedgerPath), { recursive: true });
+    await writeFile(fullLedgerPath, JSON.stringify({
+      repo: "owner/repo", pr: 42, gate: "pre_approval_gate", headSha: HEAD, verdict: "clean", findings: [],
+    }) + "\n", "utf8");
+
+    const enforcement = await buildFanoutEnforcement({
+      repo: "owner/repo", pr: "42", currentHeadSha: HEAD,
+      draftGateMarker: NO_DRAFT_MARKER, preApprovalGateMarker: PA_MARKER,
+      config: ANGLE_CONFIG, cwd: repoB,
+    });
+    const check = buildPreMergeGateCheck(cleanEvidenceFor(HEAD), 0, null, enforcement);
+    assert.equal(check.ok, false);
+    assert.ok(
+      check.failures.some((f) => f.includes("no valid fan-out provenance") && f.includes("route to conductor")),
+      JSON.stringify(check.failures),
+    );
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -1097,7 +1097,7 @@ test("buildPreMergeGateCheck accepts a delta-suffixed angle as covering its base
   assert.equal(result.ok, true, JSON.stringify(result.failures));
 });
 
-test("buildPreMergeGateCheck angle-coverage enforcement adds NO failure when provenance is absent (separate from requireFanoutProvenance)", () => {
+test("buildPreMergeGateCheck FAILS closed when mandatory angles are configured but the ledger records no provenance (shadow-ledger bypass)", () => {
   const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
     required: true,
     gates: [
@@ -1109,6 +1109,28 @@ test("buildPreMergeGateCheck angle-coverage enforcement adds NO failure when pro
         provenance: null,
         mandatoryAngles: ["pr-checklist-matrix"],
         anglePool: ["dry", "pr-checklist-matrix"],
+      },
+    ],
+  });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.failures.some((f) => f.includes("no valid fan-out provenance") && f.includes("route to conductor")),
+    JSON.stringify(result.failures),
+  );
+});
+
+test("buildPreMergeGateCheck adds NO failure for absent provenance when the gate configures no mandatory angles", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    gates: [
+      {
+        name: "pre_approval_gate",
+        executionMode: "fanout_fanin",
+        ledgerPath: "tmp/b.json",
+        ledgerExists: true,
+        provenance: null,
+        mandatoryAngles: [],
+        anglePool: ["dry", "kiss"],
       },
     ],
   });
@@ -1670,7 +1692,17 @@ function fanoutEvidenceGhEntries(executionMode, inlineReason = null) {
 async function writeLedger(tempDir, gate) {
   const dir = path.join(tempDir, "tmp", "gate-findings", "owner-repo", "pr-17");
   await import("node:fs/promises").then((fs) => fs.mkdir(dir, { recursive: true }));
-  await writeFile(path.join(dir, `${gate}-abc1234.json`), JSON.stringify({ gate, headSha: "abc1234", findings: [] }) + "\n", "utf8");
+  // Provenance covering the shipped extension-defaults mandatory angle for each
+  // gate: fanout_fanin ledgers must record it for merge-evidence angle coverage.
+  const mandatory = gate === "draft_gate" ? "pr-description" : "pr-checklist-matrix";
+  const provenance = {
+    distinctReviewers: 2,
+    perAngle: [
+      { angle: mandatory, reviewer: "review-a" },
+      { angle: gate === "draft_gate" ? "scope" : "dry", reviewer: "review-b" },
+    ],
+  };
+  await writeFile(path.join(dir, `${gate}-abc1234.json`), JSON.stringify({ gate, headSha: "abc1234", findings: [], provenance }) + "\n", "utf8");
 }
 
 test("detect-checkpoint-evidence surfaces executionMode in gate markers", async () => {

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -1012,6 +1012,131 @@ test("buildPreMergeGateCheck with requireProvenance ON fails closed on a non-int
   );
 });
 
+// --- Angle-coverage enforcement (#1196: mandatory angles + pool membership) ---
+// Independent of requireFanoutProvenance: fires whenever a fanout_fanin gate
+// recorded ANY internally-consistent provenance.
+
+test("buildPreMergeGateCheck FAILS closed when fan-out provenance is missing a mandatory angle (AC1, merge-evidence time)", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    gates: [
+      {
+        name: "pre_approval_gate",
+        executionMode: "fanout_fanin",
+        ledgerPath: "tmp/b.json",
+        ledgerExists: true,
+        provenance: { distinctReviewers: 2, perAngle: [{ angle: "dry", reviewer: "review-a" }, { angle: "kiss", reviewer: "review-b" }] },
+        mandatoryAngles: ["pr-checklist-matrix", "yagni"],
+        anglePool: ["dry", "kiss", "pr-checklist-matrix", "yagni"],
+      },
+    ],
+  });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.failures.some((f) => f.includes("missing mandatory angle(s): pr-checklist-matrix, yagni") && f.includes("route to conductor")),
+    JSON.stringify(result.failures),
+  );
+});
+
+test("buildPreMergeGateCheck FAILS closed by default when fan-out provenance names an angle outside the configured pool (AC2)", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    gates: [
+      {
+        name: "pre_approval_gate",
+        executionMode: "fanout_fanin",
+        ledgerPath: "tmp/b.json",
+        ledgerExists: true,
+        provenance: { distinctReviewers: 2, perAngle: [{ angle: "dry", reviewer: "review-a" }, { angle: "made-up-angle", reviewer: "review-b" }] },
+        mandatoryAngles: [],
+        anglePool: ["dry", "kiss"],
+      },
+    ],
+  });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.failures.some((f) => f.includes("outside the configured pool: made-up-angle")),
+    JSON.stringify(result.failures),
+  );
+});
+
+test("buildPreMergeGateCheck WARNS (does not fail) on a foreign angle when rejectForeignAngles is false", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    rejectForeignAngles: false,
+    gates: [
+      {
+        name: "pre_approval_gate",
+        executionMode: "fanout_fanin",
+        ledgerPath: "tmp/b.json",
+        ledgerExists: true,
+        provenance: { distinctReviewers: 2, perAngle: [{ angle: "dry", reviewer: "review-a" }, { angle: "made-up-angle", reviewer: "review-b" }] },
+        mandatoryAngles: [],
+        anglePool: ["dry", "kiss"],
+      },
+    ],
+  });
+  assert.equal(result.ok, true, JSON.stringify(result.failures));
+});
+
+test("buildPreMergeGateCheck accepts a delta-suffixed angle as covering its base mandatory angle", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    gates: [
+      {
+        name: "pre_approval_gate",
+        executionMode: "fanout_fanin",
+        ledgerPath: "tmp/b.json",
+        ledgerExists: true,
+        provenance: { distinctReviewers: 2, perAngle: [{ angle: "dry", reviewer: "review-a" }, { angle: "pr-checklist-matrix-delta-at-current-head", reviewer: "review-b" }] },
+        mandatoryAngles: ["pr-checklist-matrix"],
+        anglePool: ["dry", "kiss", "pr-checklist-matrix"],
+      },
+    ],
+  });
+  assert.equal(result.ok, true, JSON.stringify(result.failures));
+});
+
+test("buildPreMergeGateCheck angle-coverage enforcement adds NO failure when provenance is absent (separate from requireFanoutProvenance)", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    gates: [
+      {
+        name: "pre_approval_gate",
+        executionMode: "fanout_fanin",
+        ledgerPath: "tmp/b.json",
+        ledgerExists: true,
+        provenance: null,
+        mandatoryAngles: ["pr-checklist-matrix"],
+        anglePool: ["dry", "pr-checklist-matrix"],
+      },
+    ],
+  });
+  assert.equal(result.ok, true, JSON.stringify(result.failures));
+});
+
+test("buildPreMergeGateCheck angle-coverage enforcement is skipped for an inline_single_agent verdict (AC3)", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    lightMode: true,
+    hasFullLabel: false,
+    gates: [
+      {
+        name: "pre_approval_gate",
+        executionMode: "inline_single_agent",
+        inlineReason: "under_threshold",
+        scopeUnderThreshold: true,
+        ledgerPath: "tmp/b.json",
+        ledgerExists: true,
+        provenance: null,
+        mandatoryAngles: ["pr-checklist-matrix"],
+        anglePool: ["pr-checklist-matrix"],
+      },
+    ],
+  });
+  assert.equal(result.ok, true, JSON.stringify(result.failures));
+});
+
 // --- #1174: light-mode-aware pre-merge acceptance of inline verdicts ---------
 // A genuinely under-threshold micro-PR collapses the gate fan-out to a single
 // inline check (#1043). buildPreMergeGateCheck accepts that inline verdict ONLY

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -1077,6 +1077,10 @@ test("buildPreMergeGateCheck WARNS (does not fail) on a foreign angle when rejec
     ],
   });
   assert.equal(result.ok, true, JSON.stringify(result.failures));
+  // Warning mode is not silence: the foreign angle surfaces on the result.
+  assert.equal(result.warnings.length, 1);
+  assert.match(result.warnings[0], /outside the configured pool: made-up-angle/);
+  assert.match(result.warnings[0], /rejectForeignAngles is false/);
 });
 
 test("buildPreMergeGateCheck accepts a delta-suffixed angle as covering its base mandatory angle", () => {

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -2870,6 +2870,36 @@ test("upsert-checkpoint-verdict rejects a fanout_fanin verdict whose --findings-
   }
 });
 
+test("upsert-checkpoint-verdict rejects an angle-less flat finding in fanout mode with a dedicated error (not a confusing `general` pool error)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-angleless-"));
+  try {
+    const findingsPath = path.join(tempDir, "findings.json");
+    // Flat finding without .angle: normalization would bucket it under the
+    // synthetic `general` label, which would surface as a foreign-angle error.
+    await writeFile(
+      findingsPath,
+      JSON.stringify([
+        { severity: "must-fix", summary: "finding with angle" , angle: "pr-description" },
+        { severity: "must-fix", summary: "finding with no angle attribution" },
+      ]),
+      "utf8",
+    );
+    const env = await writeGhStub(tempDir, [
+      ...buildGateCoordinationEntries({ isDraft: true, statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }] }),
+    ]);
+    const result = await runNode([
+      "--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234",
+      "--verdict", "findings_present", "--findings-json", findingsPath,
+      "--next-action", "fix then re-gate", "--execution-mode", "fanout_fanin",
+    ], { env });
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /lack a non-empty \.angle/);
+    assert.doesNotMatch(result.stderr, /outside the configured pool/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("upsert-checkpoint-verdict WARNS on stderr (not silence) for a foreign angle when gates.rejectForeignAngles is false", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-angle-warn-"));
   try {

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -2870,6 +2870,42 @@ test("upsert-checkpoint-verdict rejects a fanout_fanin verdict whose --findings-
   }
 });
 
+test("upsert-checkpoint-verdict WARNS on stderr (not silence) for a foreign angle when gates.rejectForeignAngles is false", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-angle-warn-"));
+  try {
+    // Repo config opting into warn mode; extension defaults still supply the
+    // draft pool + mandatory pr-description.
+    await writeFile(path.join(tempDir, ".devloops"), "version: 1\ngates:\n  rejectForeignAngles: false\n", "utf8");
+    const findingsPath = path.join(tempDir, "findings.json");
+    await writeFile(
+      findingsPath,
+      JSON.stringify([
+        { angle: "pr-description", verdict: "clean", findings: [] },
+        { angle: "totally-made-up", verdict: "clean", findings: [] },
+      ]),
+      "utf8",
+    );
+    const env = await writeGhStub(tempDir, [
+      ...buildGateCoordinationEntries({ isDraft: true, statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }] }),
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f"],
+        stdout: '{"id":101,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-101"}\n',
+      },
+    ]);
+    const result = await runNode([
+      "--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234",
+      "--verdict", "clean", "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
+      "--findings-json", findingsPath,
+      "--next-action", "mark ready for review", "--execution-mode", "fanout_fanin",
+    ], { env, cwd: tempDir });
+    assert.equal(result.code, 0, result.stderr);
+    assert.match(result.stderr, /WARNING: .*outside the configured pool: totally-made-up/);
+    assert.match(result.stderr, /rejectForeignAngles is false/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("upsert-checkpoint-verdict does NOT enforce angle coverage for an inline_single_agent verdict (AC3 exemption)", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-angle-coverage-inline-"));
   try {

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -2846,6 +2846,7 @@ test("upsert-checkpoint-verdict rejects a fanout_fanin verdict whose --findings-
         { angle: "pr-checklist-matrix", verdict: "clean", findings: [] },
         { angle: "acceptance-criteria", verdict: "clean", findings: [] },
         { angle: "yagni", verdict: "clean", findings: [] },
+        { angle: "contradiction-lens", verdict: "clean", findings: [] },
         { angle: "made-up-angle", verdict: "clean", findings: [] },
       ]),
       "utf8",
@@ -2964,6 +2965,7 @@ test("upsert-checkpoint-verdict --findings-json structured verdict carries the g
         { angle: "pr-checklist-matrix", verdict: "clean", findings: [] },
         { angle: "acceptance-criteria", verdict: "clean", findings: [] },
         { angle: "yagni", verdict: "clean", findings: [] },
+        { angle: "contradiction-lens", verdict: "clean", findings: [] },
       ]),
       "utf8",
     );
@@ -3022,7 +3024,7 @@ test("upsert-checkpoint-verdict --findings-json structured verdict carries the g
           "**Execution mode:** fanout_fanin",
           "- `dry` → findings_present",
           // The structured single-line digest carries the gateEvidenceNote.
-          `**Findings summary:** 4 angles reviewed; 1 finding (see per-angle breakdown below).; ${roundExhaustionNote}`,
+          `**Findings summary:** 5 angles reviewed; 1 finding (see per-angle breakdown below).; ${roundExhaustionNote}`,
         ],
         stdout: '{"id":101,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-101"}\n',
       },

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -2813,6 +2813,87 @@ test("upsert-checkpoint-verdict --findings-json rejects an unrecognizable non-em
   }
 });
 
+// --- Angle-coverage enforcement (#1196: mandatory angles + pool membership) ---
+
+test("upsert-checkpoint-verdict rejects a fanout_fanin verdict whose --findings-json is missing the gate's mandatory angle (AC1)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-angle-coverage-missing-"));
+  try {
+    const findingsPath = path.join(tempDir, "findings.json");
+    // draft_gate's configured mandatory angle (pr-description) is absent.
+    await writeFile(findingsPath, JSON.stringify([{ angle: "scope", verdict: "clean", findings: [] }]), "utf8");
+    const env = await writeGhStub(tempDir, [
+      ...buildGateCoordinationEntries({ isDraft: true, statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }] }),
+    ]);
+    const result = await runNode([
+      "--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234",
+      "--verdict", "findings_present", "--findings-json", findingsPath,
+      "--next-action", "fix then re-gate", "--execution-mode", "fanout_fanin",
+    ], { env });
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /missing mandatory angle\(s\): pr-description/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("upsert-checkpoint-verdict rejects a fanout_fanin verdict whose --findings-json names an angle outside the configured pool (AC2)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-angle-coverage-foreign-"));
+  try {
+    const findingsPath = path.join(tempDir, "findings.json");
+    await writeFile(
+      findingsPath,
+      JSON.stringify([
+        { angle: "pr-checklist-matrix", verdict: "clean", findings: [] },
+        { angle: "acceptance-criteria", verdict: "clean", findings: [] },
+        { angle: "yagni", verdict: "clean", findings: [] },
+        { angle: "made-up-angle", verdict: "clean", findings: [] },
+      ]),
+      "utf8",
+    );
+    const env = await writeGhStub(tempDir, [
+      ...buildGateCoordinationEntries({
+        isDraft: false,
+        statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+        reviews: [{ author: { login: "copilot-pull-request-reviewer" }, state: "COMMENTED", submittedAt: "2026-05-31T20:00:00Z", commit: { oid: "abc1234" } }],
+      }),
+    ]);
+    const result = await runNode([
+      "--repo", "owner/repo", "--pr", "17", "--gate", "pre_approval_gate", "--head-sha", "abc1234",
+      "--verdict", "findings_present", "--findings-json", findingsPath,
+      "--next-action", "fix then re-gate", "--execution-mode", "fanout_fanin",
+    ], { env });
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /outside the configured pool: made-up-angle/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("upsert-checkpoint-verdict does NOT enforce angle coverage for an inline_single_agent verdict (AC3 exemption)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-angle-coverage-inline-"));
+  try {
+    const findingsPath = path.join(tempDir, "findings.json");
+    // No mandatory angle present at all — must still pass because executionMode
+    // is inline_single_agent (angle coverage is a fanout_fanin-only concern).
+    await writeFile(findingsPath, JSON.stringify([{ angle: "scope", verdict: "clean", findings: [] }]), "utf8");
+    const env = await writeGhStub(tempDir, [
+      ...buildGateCoordinationEntries({ isDraft: true, statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }] }),
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f"],
+        stdout: '{"id":101,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-101"}\n',
+      },
+    ]);
+    const result = await runNode([
+      "--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234",
+      "--verdict", "findings_present", "--findings-json", findingsPath,
+      "--next-action", "fix then re-gate", "--inline-reason", "small change",
+    ], { env });
+    assert.equal(result.code, 0, result.stderr);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("upsert-checkpoint-verdict --findings-json renders structured per-angle findings end-to-end (#898)", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-findings-json-"));
   try {
@@ -2825,7 +2906,10 @@ test("upsert-checkpoint-verdict --findings-json renders structured per-angle fin
           verdict: "findings_present",
           findings: [{ severity: "must-fix", summary: "broken edge case", file: "a.mjs", line: 7 }],
         },
-        { angle: "tests", verdict: "clean", findings: [] },
+        { angle: "coverage", verdict: "clean", findings: [] },
+        // draft_gate's configured mandatory angle (gates.draft.mandatoryAngles):
+        // a fanout_fanin verdict's structured per-angle results must cover it.
+        { angle: "pr-description", verdict: "clean", findings: [] },
       ]),
       "utf8",
     );
@@ -2837,8 +2921,8 @@ test("upsert-checkpoint-verdict --findings-json renders structured per-angle fin
           "**Execution mode:** fanout_fanin",
           "- `correctness` → findings_present",
           "  - [must-fix] broken edge case (`a.mjs:7`)",
-          "- `tests` → clean",
-          "**Findings summary:** 2 angles reviewed; 1 finding (see per-angle breakdown below).",
+          "- `coverage` → clean",
+          "**Findings summary:** 3 angles reviewed; 1 finding (see per-angle breakdown below).",
         ],
         stdout: '{"id":101,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-101"}\n',
       },
@@ -2871,10 +2955,15 @@ test("upsert-checkpoint-verdict --findings-json structured verdict carries the g
       findingsPath,
       JSON.stringify([
         {
-          angle: "correctness",
+          angle: "dry",
           verdict: "findings_present",
           findings: [{ severity: "worth-fixing-now", summary: "minor nit worth noting" }],
         },
+        // pre_approval_gate's configured mandatory angles (gates.preApproval.mandatoryAngles):
+        // a fanout_fanin verdict's structured per-angle results must cover them.
+        { angle: "pr-checklist-matrix", verdict: "clean", findings: [] },
+        { angle: "acceptance-criteria", verdict: "clean", findings: [] },
+        { angle: "yagni", verdict: "clean", findings: [] },
       ]),
       "utf8",
     );
@@ -2931,9 +3020,9 @@ test("upsert-checkpoint-verdict --findings-json structured verdict carries the g
         assertArgContains: [
           "body=### Gate review: `pre_approval_gate`",
           "**Execution mode:** fanout_fanin",
-          "- `correctness` → findings_present",
+          "- `dry` → findings_present",
           // The structured single-line digest carries the gateEvidenceNote.
-          `**Findings summary:** 1 angle reviewed; 1 finding (see per-angle breakdown below).; ${roundExhaustionNote}`,
+          `**Findings summary:** 4 angles reviewed; 1 finding (see per-angle breakdown below).; ${roundExhaustionNote}`,
         ],
         stdout: '{"id":101,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-101"}\n',
       },

--- a/test/github/write-gate-findings-log.test.mjs
+++ b/test/github/write-gate-findings-log.test.mjs
@@ -616,3 +616,52 @@ test("checkProvenanceAngleCoverage passes for a fully-covered draft_gate and pre
     assert.equal(preApproval.warning, null);
   });
 });
+
+test("checkProvenanceAngleCoverage: excluding a mandatory angle does not deadlock the write (excludeAngles filters mandatoryAngles)", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-findings-exclude-deadlock-"));
+  try {
+    // The deadlock config: yagni is mandatory AND excluded. Without filtering,
+    // every write would fail — missing-mandatory if omitted, foreign if recorded.
+    await writeFile(path.join(repoRoot, ".devloops"), [
+      "version: 1",
+      "gates:",
+      "  preApproval:",
+      "    angles: [dry, kiss]",
+      "    mandatoryAngles: [pr-checklist-matrix, yagni]",
+      "    excludeAngles: [yagni]",
+      "",
+    ].join("\n"), "utf8");
+    const result = await checkProvenanceAngleCoverage(
+      { perAngle: [{ angle: "dry" }, { angle: "pr-checklist-matrix" }] },
+      "pre_approval_gate",
+      { repoRoot },
+    );
+    assert.equal(result.warning, null);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("checkProvenanceAngleCoverage: additiveAngles widens the enforcement pool to the catalog (catalog angle is not foreign)", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-findings-additive-"));
+  try {
+    await writeFile(path.join(repoRoot, ".devloops"), [
+      "version: 1",
+      "gates:",
+      "  anglePool: [dry, catalog-extra]",
+      "  preApproval:",
+      "    angles: [dry]",
+      "    mandatoryAngles: []",
+      "    additiveAngles: true",
+      "",
+    ].join("\n"), "utf8");
+    const result = await checkProvenanceAngleCoverage(
+      { perAngle: [{ angle: "dry" }, { angle: "catalog-extra" }] },
+      "pre_approval_gate",
+      { repoRoot },
+    );
+    assert.equal(result.warning, null);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});

--- a/test/github/write-gate-findings-log.test.mjs
+++ b/test/github/write-gate-findings-log.test.mjs
@@ -1,14 +1,43 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
 import {
+  checkProvenanceAngleCoverage,
   parseProvenanceJson,
   parseWriteGateFindingsLogCliArgs,
   writeGateFindingsLog,
 } from "../../scripts/github/write-gate-findings-log.mjs";
+
+// A repo config with a fully controlled, minimal angle contract (independent
+// of the shipped extension defaults) so mandatory-angle / pool assertions
+// below are exact.
+const ANGLE_CONTRACT_DEVLOOPS = [
+  "version: 1",
+  "gates:",
+  "  draft:",
+  "    angles: [scope, coverage]",
+  "    mandatoryAngles: [pr-description]",
+  "  preApproval:",
+  "    angles: [dry, kiss]",
+  "    mandatoryAngles: [pr-checklist-matrix]",
+  "",
+].join("\n");
+
+async function withAngleContractRepo(fn, { rejectForeignAngles } = {}) {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-findings-angle-contract-"));
+  try {
+    const devloops = rejectForeignAngles === false
+      ? `${ANGLE_CONTRACT_DEVLOOPS}  rejectForeignAngles: false\n`
+      : ANGLE_CONTRACT_DEVLOOPS;
+    await writeFile(path.join(repoRoot, ".devloops"), devloops, "utf8");
+    return await fn(repoRoot);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+}
 
 test("parseWriteGateFindingsLogCliArgs parses all required args", () => {
   const result = parseWriteGateFindingsLogCliArgs([
@@ -446,9 +475,13 @@ test("writeGateFindingsLog records provenance in the ledger when passed", async 
       headSha: "abc1234567890abcdef",
       verdict: "clean",
       findings: "[]",
-      provenance: JSON.stringify({ distinctReviewers: 3, perAngle: [{ angle: "scope", reviewer: "review-a" }, { angle: "safety", reviewer: "review-b" }, { angle: "perf", reviewer: "review-c" }] }),
+      // Angles must cover the shipped extension-defaults preApproval mandatory
+      // angle (pr-checklist-matrix) and stay within its configured pool — this
+      // test isolates repoRoot from any repo-local .devloops via tmpDir, but
+      // the packaged extension defaults still apply regardless of repoRoot.
+      provenance: JSON.stringify({ distinctReviewers: 3, perAngle: [{ angle: "dry", reviewer: "review-a" }, { angle: "kiss", reviewer: "review-b" }, { angle: "pr-checklist-matrix", reviewer: "review-c" }] }),
       tmpRoot: tmpDir,
-    });
+    }, { repoRoot: tmpDir });
     const fullPath = path.join(tmpDir, "gate-findings", "owner-repo", "pr-7", "pre_approval_gate-abc1234567890abcdef.json");
     const parsed = JSON.parse(await readFile(fullPath, "utf8"));
     assert.equal(parsed.provenance.distinctReviewers, 3);
@@ -490,4 +523,96 @@ test("writeGateFindingsLog rejects malformed provenance", async () => {
       provenance: JSON.stringify({ distinctReviewers: -1, perAngle: [] }),
     });
   }, /distinctReviewers must be a non-negative integer/);
+});
+
+// --- Angle-coverage enforcement (#1196: mandatory angles + pool membership) ---
+
+test("checkProvenanceAngleCoverage rejects a missing mandatory angle (fail-closed, AC1)", async () => {
+  await withAngleContractRepo(async (repoRoot) => {
+    await assert.rejects(
+      () => checkProvenanceAngleCoverage({ perAngle: [{ angle: "dry" }] }, "pre_approval_gate", { repoRoot }),
+      /missing mandatory angle\(s\) for pre_approval_gate: pr-checklist-matrix/,
+    );
+  });
+});
+
+test("writeGateFindingsLog rejects a fanout_fanin ledger missing a mandatory angle (AC1, write time)", async () => {
+  await withAngleContractRepo(async (repoRoot) => {
+    await assert.rejects(
+      () => writeGateFindingsLog({
+        repo: "a/b", pr: 1, gate: "draft_gate", headSha: "abc12345", verdict: "clean", findings: "[]",
+        provenance: JSON.stringify({ distinctReviewers: 1, perAngle: [{ angle: "scope", reviewer: "r1" }] }),
+      }, { repoRoot }),
+      /missing mandatory angle\(s\) for draft_gate: pr-description/,
+    );
+  });
+});
+
+test("checkProvenanceAngleCoverage rejects an angle outside the configured pool by default (AC2)", async () => {
+  await withAngleContractRepo(async (repoRoot) => {
+    await assert.rejects(
+      () => checkProvenanceAngleCoverage(
+        { perAngle: [{ angle: "dry" }, { angle: "pr-checklist-matrix" }, { angle: "made-up-angle" }] },
+        "pre_approval_gate",
+        { repoRoot },
+      ),
+      /names angle\(s\) outside the configured pool for pre_approval_gate: made-up-angle/,
+    );
+  });
+});
+
+test("checkProvenanceAngleCoverage warns (does not fail) on a foreign angle when gates.rejectForeignAngles is false", async () => {
+  await withAngleContractRepo(async (repoRoot) => {
+    const result = await checkProvenanceAngleCoverage(
+      { perAngle: [{ angle: "dry" }, { angle: "pr-checklist-matrix" }, { angle: "made-up-angle" }] },
+      "pre_approval_gate",
+      { repoRoot },
+    );
+    assert.match(result.warning, /made-up-angle/);
+  }, { rejectForeignAngles: false });
+});
+
+test("writeGateFindingsLog surfaces the foreign-angle warning on the result when rejectForeignAngles is false", async () => {
+  await withAngleContractRepo(async (repoRoot) => {
+    const tmpRoot = await mkdtemp(path.join(os.tmpdir(), "gate-findings-warn-"));
+    try {
+      const result = await writeGateFindingsLog({
+        repo: "a/b", pr: 1, gate: "pre_approval_gate", headSha: "abc12345", verdict: "clean", findings: "[]",
+        provenance: JSON.stringify({ distinctReviewers: 1, perAngle: [{ angle: "dry", reviewer: "r1" }, { angle: "pr-checklist-matrix" }, { angle: "made-up-angle" }] }),
+        tmpRoot,
+      }, { repoRoot });
+      assert.equal(result.ok, true);
+      assert.match(result.warning, /made-up-angle/);
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true });
+    }
+  }, { rejectForeignAngles: false });
+});
+
+test("checkProvenanceAngleCoverage: a delta-suffixed angle (<angle>-delta-at-current-head) satisfies its base mandatory angle", async () => {
+  await withAngleContractRepo(async (repoRoot) => {
+    const result = await checkProvenanceAngleCoverage(
+      { perAngle: [{ angle: "dry" }, { angle: "pr-checklist-matrix-delta-at-current-head" }] },
+      "pre_approval_gate",
+      { repoRoot },
+    );
+    assert.equal(result.warning, null);
+  });
+});
+
+test("checkProvenanceAngleCoverage passes for a fully-covered draft_gate and pre_approval_gate shape", async () => {
+  await withAngleContractRepo(async (repoRoot) => {
+    const draft = await checkProvenanceAngleCoverage(
+      { perAngle: [{ angle: "scope" }, { angle: "pr-description" }] },
+      "draft_gate",
+      { repoRoot },
+    );
+    assert.equal(draft.warning, null);
+    const preApproval = await checkProvenanceAngleCoverage(
+      { perAngle: [{ angle: "dry" }, { angle: "kiss" }, { angle: "pr-checklist-matrix" }] },
+      "pre_approval_gate",
+      { repoRoot },
+    );
+    assert.equal(preApproval.warning, null);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `checkFanoutAngleCoverage` to the shared `@dev-loops/core/loop/gate-fanin` layer: validates a `fanout_fanin` verdict's recorded per-angle results against the gate's configured mandatory angles and angle pool, so a missing mandatory angle or an ad-hoc/foreign angle label no longer passes silently.
- All three consumers resolve the contract through one shared resolver, `resolveGateAngleContract` (`@dev-loops/core/config`): `mandatoryAngles` filtered through `excludeAngles` (an excluded mandatory angle cannot deadlock every fanout write), and the pool widens to the global lens catalog (`resolveAnglePool`) when the gate enables `additiveAngles` — so dynamically-added catalog angles are never falsely foreign.
- `write-gate-findings-log.mjs` and `upsert-checkpoint-verdict.mjs` enforce fail-closed at write time (ledger `provenance.perAngle` and `--findings-json` structured results respectively); `detect-checkpoint-evidence.mjs` re-validates at merge-evidence time through `buildFanoutEnforcement` → `buildPreMergeGateCheck` (integration-tested end to end so the merge-time pool check cannot silently go dead).
- Shadow-ledger closure: at merge-evidence time, when a gate configures any mandatory angle, a `fanout_fanin` ledger MUST record internally-consistent provenance — absent/invalid provenance fails closed, so omitting provenance no longer bypasses mandatory-angle coverage. Gates with no mandatory angles keep prior behavior (provenance still opt-in via `requireFanoutProvenance`).
- Delta-suffixed angles (`<angle>-delta-at-...`) count toward their base angle. Foreign-angle rejection is configurable via the new `gates.rejectForeignAngles` (default `true`/fail; `false` downgrades to a warning). `inline_single_agent` verdicts remain exempt (no fan-out per-angle data to validate).

## Config change (deliberate, please review)
**`.devloops` gate pools were extended** so live-practice angles are in-contract rather than foreign:
- `gates.draft.angles` += `contradiction-lens`, `code-conformance`, `semantic-drift`
- `gates.preApproval.angles` += `contradiction-lens`, `correctness-final`, `ui-validation`
- `gates.preApproval.mandatoryAngles` += `contradiction-lens` (this repo's opt-in: every pre-approval pass must run yagni + contradiction-lens)

The shipped `extension-defaults.yaml` pools mirror the pool additions for both gates, but NOT the mandatory addition — mandatory `contradiction-lens` is this repo's own `.devloops` opt-in only.

Closes #1196

## Evidence block
```
verify: env -u PI_SUBAGENT_RUN_ID -u DEVLOOPS_RUN_ID npm run verify
  test:assets    189 pass / 0 fail
  test:extension  81 pass / 0 fail
  test:scripts  2333 tests, 2297 pass / 0 fail (36 skipped, pre-existing)
  test:core     1877 pass / 0 fail
  test:docs      links + rule-ownership OK (142 rules)
  test:dev-loop   32 pass / 0 fail
config: loadDevLoopConfig on this repo → errors: [] ; resolveGateAngleContract
  resolves the extended pools + mandatory contradiction-lens for preApproval
```

## Notes
- `additiveAngles` interaction (disclosed): when a gate enables `gates.<gate>.additiveAngles`, the enforcement pool is the additive-aware catalog (`resolveAnglePool`, `excludeAngles` still a hard ceiling), not just `resolveGateAngles` — otherwise legitimately-added dynamic angles would be rejected as foreign. Covered by resolver unit tests and a write-path test.
- Issue optional item 4 (minimum `distinctReviewers` for `full_fanout` dispatch mode): not implemented as a separate knob — the existing `FANOUT_PROVENANCE_MIN_REVIEWERS` (= 2) floor already applies under the `requireFanoutProvenance` opt-in, and the new mandatory-angle rule additionally forces provenance recording at merge time whenever mandatory angles are configured. A dedicated dispatch-mode floor can layer on later if the opt-in proves insufficient.
- Fixed pre-existing test fixtures whose placeholder angle names didn't match the gates' real configured pools/mandatory angles; fixtures now use real angle names (including the new `contradiction-lens` mandatory entry for pre-approval fixtures).
- Kept `upsert-checkpoint-verdict` changes confined to the provenance/angle-coverage validation call path (before body rendering), per the sibling-PR conflict-avoidance note on that file's comment-body rendering.


### Third post-draft round (also shipped)

1. **Dedicated missing-`.angle` error** in fanout mode: angle-less findings now fail with an error naming the fix (add `.angle` or use the nested per-angle shape), replacing the confusing synthetic-`general` foreign-angle rejection.
2. **Predicate-based cross-checkout provenance selection**: `readLedgerProvenanceInAny` applies the full enforcement predicate (consistency + floor when required + angle contract), so a stale contract-failing checkout's ledger can no longer shadow a passing worktree's — covered by a multi-worktree stale-shadow test.
