### PR TITLE
feat(queue): auto-enqueue issue-less lightweight PRs as board items (#1218)

### DIFF
--- a/docs/projects-queue-usage.md
+++ b/docs/projects-queue-usage.md
@@ -163,6 +163,8 @@ An issue-less lightweight PR (`resolve-dev-loop-startup.mjs --lightweight` alone
 [ARTIFACT-LIGHTWEIGHT-PLAN-FILE-EXCLUSIVE](../skills/docs/artifact-authority-contract.md#lightweight-pr-body-as-spec))
 has no tracker issue, so it appears on the board as a **PR item only** — there is no
 issue-backed board entry to reconcile or close for it.
+`scripts/github/create-pr.mjs --lightweight` owns enqueuing that PR item on creation
+(In Progress, on a board-configured repo); a tracker-backed PR never triggers this call.
 
 ### Live pickup path (`/loop-continue`)
 

--- a/scripts/github/create-pr.mjs
+++ b/scripts/github/create-pr.mjs
@@ -15,7 +15,8 @@ Behavior:
   - honors an explicit \`--assignee <login>\` / \`-a <login>\` when supplied (no default injected)
   - rejects \`--ready\` before invoking \`gh\`
   - detects missing \`Closes #N\` / \`Fixes #N\` in \`--body\` or \`--body-file\` content (non-fatal stderr warning)
-  - \`--lightweight\` (consumed here, never forwarded to \`gh\`): when an explicit \`--body\`/
+  - \`--lightweight\` (consumed here in every form — bare or \`=true/1/false/0\`, last
+    occurrence wins — never forwarded to \`gh\`): when an explicit \`--body\`/
     \`--body-file\` also carries no \`Closes #N\`/\`Fixes #N\`, the new PR is issue-less
     lightweight and is auto-enqueued as a board PR item in the configured In Progress column
     (reuses \`queue.projectNumber\` / \`queue.boardTitle\` from \`.devloops\`, same as the queue
@@ -39,12 +40,17 @@ Exit codes:
   N  same non-zero exit code returned by \`gh pr create\``.trim();
 const parseError = buildParseError(USAGE);
 const READY_FLAG_PATTERN = /^--ready(?:$|=)/u;
-const LIGHTWEIGHT_FLAG_PATTERN = /^--lightweight$/u;
+// Bare and inline-boolean forms, mirroring DRAFT_FLAG_PATTERN below: every
+// matching token is consumed (never forwarded to gh, which rejects unknown
+// flags), and the LAST occurrence decides — bare or =true/=1 enables,
+// anything else (=false, =0, ...) disables.
+const LIGHTWEIGHT_FLAG_PATTERN = /^--lightweight(?:=(.*))?$/iu;
 // Both `--repo owner/name` and `--repo=owner/name` — gh accepts either form.
 const REPO_FLAG_PATTERN = /^--repo(?:$|=)/u;
 const PR_URL_NUMBER_PATTERN = /\/pull\/(\d+)(?:\D|$)/u;
 const DRAFT_FLAG_PATTERN = /^--draft(?:=(.*))?$/iu;
-const DRAFT_TRUE_VALUE_PATTERN = /^(?:true|1)$/iu;
+// Shared inline-boolean truthiness for --draft= and --lightweight= values.
+const TRUE_FLAG_VALUE_PATTERN = /^(?:true|1)$/iu;
 // Detect both the long `--assignee`/`--assignee=<login>` forms and the `-a`
 // short flag that `gh pr create` documents, so an explicit assignee in either
 // form suppresses the `--assignee @me` default (otherwise a caller passing
@@ -137,7 +143,7 @@ export function buildCreatePrArgs(argv) {
   }
   const draftTokens = args.filter((token) => DRAFT_FLAG_PATTERN.test(token));
   const lastDraftToken = draftTokens.length > 0 ? draftTokens.at(-1) : null;
-  const lastDraftSuppliesDraft = lastDraftToken === "--draft" || (typeof lastDraftToken === "string" && DRAFT_TRUE_VALUE_PATTERN.test(lastDraftToken.slice("--draft=".length)));
+  const lastDraftSuppliesDraft = lastDraftToken === "--draft" || (typeof lastDraftToken === "string" && TRUE_FLAG_VALUE_PATTERN.test(lastDraftToken.slice("--draft=".length)));
   const hasAssignee = args.some((token) => ASSIGNEE_FLAG_PATTERN.test(token));
   return {
     help: false,
@@ -178,7 +184,10 @@ export function spawnCreatePr(ghArgs, { ghCommand = "gh", env = process.env } = 
   });
 }
 export async function main(argv = process.argv.slice(2), runtime = {}) {
-  const lightweight = argv.some((token) => LIGHTWEIGHT_FLAG_PATTERN.test(token));
+  // Last occurrence wins, same as the --draft handling in buildCreatePrArgs.
+  const lastLightweightToken = argv.filter((token) => LIGHTWEIGHT_FLAG_PATTERN.test(token)).at(-1) ?? null;
+  const lightweight = lastLightweightToken === "--lightweight" ||
+    (typeof lastLightweightToken === "string" && TRUE_FLAG_VALUE_PATTERN.test(lastLightweightToken.slice("--lightweight=".length)));
   const forwardedArgv = argv.filter((token) => !LIGHTWEIGHT_FLAG_PATTERN.test(token));
   const { help, ghArgs } = buildCreatePrArgs(forwardedArgv);
   if (help) {

--- a/scripts/github/create-pr.mjs
+++ b/scripts/github/create-pr.mjs
@@ -15,14 +15,15 @@ Behavior:
   - honors an explicit \`--assignee <login>\` / \`-a <login>\` when supplied (no default injected)
   - rejects \`--ready\` before invoking \`gh\`
   - detects missing \`Closes #N\` / \`Fixes #N\` in \`--body\` or \`--body-file\` content (non-fatal stderr warning)
-  - \`--lightweight\` (consumed here, never forwarded to \`gh\`): when the body also carries no
-    \`Closes #N\`/\`Fixes #N\`, the new PR is issue-less lightweight and is auto-enqueued as a
-    board PR item in the configured In Progress column (reuses \`queue.projectNumber\` /
-    \`queue.boardTitle\` from \`.devloops\`, same as the queue scripts). Requires an explicit
-    \`--repo owner/name\`. A trailing stdout line reports the outcome:
-    \`{"board":{"enqueued":bool,...}}\`. No board configured, no \`--repo\`, or an enqueue error
-    is a non-fatal no-op (noted in that line; exit code unaffected). Omitting \`--lightweight\`,
-    or a body that already carries a closing keyword (tracker-backed), never calls the board.
+  - \`--lightweight\` (consumed here, never forwarded to \`gh\`): when an explicit \`--body\`/
+    \`--body-file\` also carries no \`Closes #N\`/\`Fixes #N\`, the new PR is issue-less
+    lightweight and is auto-enqueued as a board PR item in the configured In Progress column
+    (reuses \`queue.projectNumber\` / \`queue.boardTitle\` from \`.devloops\`, same as the queue
+    scripts). Requires an explicit \`--repo owner/name\` (space or = form). A trailing stdout
+    line reports the outcome: \`{"board":{"enqueued":bool,...}}\`. No board configured, no
+    \`--repo\`, no explicit body source, or an enqueue error is a non-fatal no-op (noted in
+    that line; exit code unaffected). Omitting \`--lightweight\`, or a body that already
+    carries a closing keyword (tracker-backed), never calls the board.
   - forwards every other argument to \`gh pr create\` unchanged
   - preserves the underlying \`gh pr create\` stdout, stderr, and exit code
 Examples:
@@ -39,7 +40,8 @@ Exit codes:
 const parseError = buildParseError(USAGE);
 const READY_FLAG_PATTERN = /^--ready(?:$|=)/u;
 const LIGHTWEIGHT_FLAG_PATTERN = /^--lightweight$/u;
-const REPO_FLAG_PATTERN = /^--repo$/u;
+// Both `--repo owner/name` and `--repo=owner/name` — gh accepts either form.
+const REPO_FLAG_PATTERN = /^--repo(?:$|=)/u;
 const PR_URL_NUMBER_PATTERN = /\/pull\/(\d+)(?:\D|$)/u;
 const DRAFT_FLAG_PATTERN = /^--draft(?:=(.*))?$/iu;
 const DRAFT_TRUE_VALUE_PATTERN = /^(?:true|1)$/iu;
@@ -80,12 +82,15 @@ function warnMissingClosingKeyword(body) {
     );
   }
 }
-// A plain string value for a single-value flag (e.g. `--repo owner/name`); unlike
+// A plain string value for a single-value flag, in both the space form
+// (`--repo owner/name`) and the inline form (`--repo=owner/name`); unlike
 // resolveBody, never reads a file. Returns null when the flag is absent.
 function getFlagValue(args, flagPattern) {
   const idx = args.findIndex((token) => flagPattern.test(token));
-  if (idx === -1 || idx + 1 >= args.length) return null;
-  return args[idx + 1];
+  if (idx === -1) return null;
+  const eq = args[idx].indexOf("=");
+  if (eq !== -1) return args[idx].slice(eq + 1);
+  return idx + 1 < args.length ? args[idx + 1] : null;
 }
 function parsePrNumberFromOutput(stdout) {
   const match = PR_URL_NUMBER_PATTERN.exec(stdout ?? "");
@@ -182,21 +187,25 @@ export async function main(argv = process.argv.slice(2), runtime = {}) {
   }
   const body = await resolveBody(forwardedArgv);
   warnMissingClosingKeyword(body);
-  // Issue-less lightweight: caller signals lightweight AND the body carries no
-  // closing keyword. A tracker-backed lightweight PR (closing keyword present)
-  // never reaches the board — its issue already owns the board entry.
-  const issueLess = lightweight && !detectClosingKeyword(body ?? "");
+  // Issue-less lightweight: caller signals lightweight AND an explicit body
+  // source (--body/--body-file) carries no closing keyword. A tracker-backed
+  // lightweight PR (closing keyword present) never reaches the board — its
+  // issue already owns the board entry. A null body (no explicit source) is
+  // NOT classified issue-less: the body may come from elsewhere (editor,
+  // template) and could carry a closing keyword this wrapper never saw, so it
+  // fails toward not enqueuing and reports body-not-provided instead.
+  const issueLess = lightweight && body !== null && !detectClosingKeyword(body);
   const { code, stdout } = await spawnCreatePr(ghArgs, runtime, { captureStdout: issueLess });
-  if (issueLess && code === 0) {
-    const repo = getFlagValue(forwardedArgv, REPO_FLAG_PATTERN);
-    const prNumber = parsePrNumberFromOutput(stdout);
-    const board = await enqueueIssuelessLightweightPr({
-      repo,
-      prNumber,
-      cwd: runtime.cwd ?? process.cwd(),
-      env: runtime.env ?? process.env,
-      runChild: runtime.runChild ?? _runChild,
-    });
+  if (lightweight && code === 0 && (issueLess || body === null)) {
+    const board = issueLess
+      ? await enqueueIssuelessLightweightPr({
+          repo: getFlagValue(forwardedArgv, REPO_FLAG_PATTERN),
+          prNumber: parsePrNumberFromOutput(stdout),
+          cwd: runtime.cwd ?? process.cwd(),
+          env: runtime.env ?? process.env,
+          runChild: runtime.runChild ?? _runChild,
+        })
+      : { enqueued: false, reason: "body-not-provided" };
     if (!board.enqueued) {
       process.stderr.write(`[create-pr] Board note: PR not enqueued (${board.reason}).\n`);
     }

--- a/scripts/github/create-pr.mjs
+++ b/scripts/github/create-pr.mjs
@@ -2,6 +2,10 @@
 import { readFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { runChild as _runChild } from "../_cli-primitives.mjs";
+import { resolveSettings, applyDevloopsBoard } from "../projects/_resolve-project.mjs";
+import { main as addQueueItemMain } from "../projects/add-queue-item.mjs";
+import { loadStateColumnMap, LOGICAL_COLUMN } from "@dev-loops/core/loop/queue-board-sync";
 const USAGE = `Usage: create-pr.mjs [gh pr create args...]
 Canonical PR-creation wrapper around \`gh pr create\`. Every PR opened through this
 tool is ALWAYS a draft and is self-assigned by default. Never call raw \`gh pr create\`.
@@ -11,6 +15,14 @@ Behavior:
   - honors an explicit \`--assignee <login>\` / \`-a <login>\` when supplied (no default injected)
   - rejects \`--ready\` before invoking \`gh\`
   - detects missing \`Closes #N\` / \`Fixes #N\` in \`--body\` or \`--body-file\` content (non-fatal stderr warning)
+  - \`--lightweight\` (consumed here, never forwarded to \`gh\`): when the body also carries no
+    \`Closes #N\`/\`Fixes #N\`, the new PR is issue-less lightweight and is auto-enqueued as a
+    board PR item in the configured In Progress column (reuses \`queue.projectNumber\` /
+    \`queue.boardTitle\` from \`.devloops\`, same as the queue scripts). Requires an explicit
+    \`--repo owner/name\`. A trailing stdout line reports the outcome:
+    \`{"board":{"enqueued":bool,...}}\`. No board configured, no \`--repo\`, or an enqueue error
+    is a non-fatal no-op (noted in that line; exit code unaffected). Omitting \`--lightweight\`,
+    or a body that already carries a closing keyword (tracker-backed), never calls the board.
   - forwards every other argument to \`gh pr create\` unchanged
   - preserves the underlying \`gh pr create\` stdout, stderr, and exit code
 Examples:
@@ -26,6 +38,9 @@ Exit codes:
   N  same non-zero exit code returned by \`gh pr create\``.trim();
 const parseError = buildParseError(USAGE);
 const READY_FLAG_PATTERN = /^--ready(?:$|=)/u;
+const LIGHTWEIGHT_FLAG_PATTERN = /^--lightweight$/u;
+const REPO_FLAG_PATTERN = /^--repo$/u;
+const PR_URL_NUMBER_PATTERN = /\/pull\/(\d+)(?:\D|$)/u;
 const DRAFT_FLAG_PATTERN = /^--draft(?:=(.*))?$/iu;
 const DRAFT_TRUE_VALUE_PATTERN = /^(?:true|1)$/iu;
 // Detect both the long `--assignee`/`--assignee=<login>` forms and the `-a`
@@ -56,14 +71,52 @@ async function resolveBody(args) {
   }
   return null; // unreadable → warn
 }
-async function warnMissingClosingKeyword(args) {
-  const body = await resolveBody(args);
+function warnMissingClosingKeyword(body) {
   if (body === null) return; // no --body or --body-file, skip
   if (!detectClosingKeyword(body)) {
     process.stderr.write(
       "[create-pr] Warning: PR body missing `Closes #N` or `Fixes #N`. " +
         "GitHub will not auto-close the linked issue on merge.\n",
     );
+  }
+}
+// A plain string value for a single-value flag (e.g. `--repo owner/name`); unlike
+// resolveBody, never reads a file. Returns null when the flag is absent.
+function getFlagValue(args, flagPattern) {
+  const idx = args.findIndex((token) => flagPattern.test(token));
+  if (idx === -1 || idx + 1 >= args.length) return null;
+  return args[idx + 1];
+}
+function parsePrNumberFromOutput(stdout) {
+  const match = PR_URL_NUMBER_PATTERN.exec(stdout ?? "");
+  return match ? Number(match[1]) : null;
+}
+// Auto-enqueue an issue-less lightweight PR as a board PR item in the configured
+// In Progress column. Reuses the same .devloops queue.projectNumber /
+// queue.boardTitle resolution and add-queue-item's idempotent add — never
+// reimplements the board API calls. Never throws: an unconfigured board, a
+// missing --repo, an unparsed PR number, or an enqueue failure are all
+// non-fatal no-ops reported in the returned shape.
+export async function enqueueIssuelessLightweightPr({ repo, prNumber, cwd, env, runChild }) {
+  if (!repo) return { enqueued: false, reason: "repo-not-specified" };
+  if (!Number.isInteger(prNumber) || prNumber < 1) return { enqueued: false, reason: "pr-number-not-parsed" };
+  const settings = resolveSettings(cwd);
+  if (!settings?.project && !settings?.title) {
+    return { enqueued: false, reason: "no-board-configured" };
+  }
+  const { columnNames, error: columnError } = loadStateColumnMap(cwd);
+  if (columnError) {
+    return { enqueued: false, reason: `config-error: ${columnError}` };
+  }
+  const args = { repo, item: prNumber };
+  applyDevloopsBoard(args, cwd);
+  args.column = columnNames[LOGICAL_COLUMN.IN_PROGRESS];
+  try {
+    const result = await addQueueItemMain(args, { env, runChild, cwd });
+    const { itemId, prNumber: itemPrNumber, status, alreadyPresent } = result.item;
+    return { enqueued: true, itemId, prNumber: itemPrNumber, status, alreadyPresent };
+  } catch (err) {
+    return { enqueued: false, reason: `enqueue-error: ${err instanceof Error ? err.message : String(err)}` };
   }
 }
 export function buildCreatePrArgs(argv) {
@@ -92,26 +145,64 @@ export function buildCreatePrArgs(argv) {
     ],
   };
 }
-export function spawnCreatePr(ghArgs, { ghCommand = "gh", env = process.env } = {}) {
+// captureStdout tees gh's stdout to a buffer (still writing it straight through to
+// process.stdout, unbuffered) so the PR URL can be parsed once gh exits, without
+// changing what a caller/terminal sees. Only enabled for the issue-less lightweight
+// path; every other caller keeps the plain "inherit" byte-identical behavior.
+export function spawnCreatePr(ghArgs, { ghCommand = "gh", env = process.env } = {}, { captureStdout = false } = {}) {
   return new Promise((resolve, reject) => {
+    // `gh pr create` never reads stdin (body comes from --body/--body-file), so
+    // the captured path ignores it rather than inheriting: inheriting a
+    // never-closing stdin (e.g. an in-process test runner) would hang any child
+    // that waits for stdin to end.
     const child = spawn(ghCommand, ghArgs, {
       env,
-      stdio: "inherit",
+      stdio: captureStdout ? ["ignore", "pipe", "inherit"] : "inherit",
     });
+    let stdout = "";
+    if (captureStdout) {
+      child.stdout.on("data", (chunk) => {
+        stdout += chunk;
+        process.stdout.write(chunk);
+      });
+    }
     child.on("error", reject);
     child.on("close", (code) => {
-      resolve(typeof code === "number" ? code : 1);
+      resolve({ code: typeof code === "number" ? code : 1, stdout });
     });
   });
 }
 export async function main(argv = process.argv.slice(2), runtime = {}) {
-  const { help, ghArgs } = buildCreatePrArgs(argv);
+  const lightweight = argv.some((token) => LIGHTWEIGHT_FLAG_PATTERN.test(token));
+  const forwardedArgv = argv.filter((token) => !LIGHTWEIGHT_FLAG_PATTERN.test(token));
+  const { help, ghArgs } = buildCreatePrArgs(forwardedArgv);
   if (help) {
     process.stdout.write(`${USAGE}\n`);
     return 0;
   }
-  await warnMissingClosingKeyword(argv);
-  return spawnCreatePr(ghArgs, runtime);
+  const body = await resolveBody(forwardedArgv);
+  warnMissingClosingKeyword(body);
+  // Issue-less lightweight: caller signals lightweight AND the body carries no
+  // closing keyword. A tracker-backed lightweight PR (closing keyword present)
+  // never reaches the board — its issue already owns the board entry.
+  const issueLess = lightweight && !detectClosingKeyword(body ?? "");
+  const { code, stdout } = await spawnCreatePr(ghArgs, runtime, { captureStdout: issueLess });
+  if (issueLess && code === 0) {
+    const repo = getFlagValue(forwardedArgv, REPO_FLAG_PATTERN);
+    const prNumber = parsePrNumberFromOutput(stdout);
+    const board = await enqueueIssuelessLightweightPr({
+      repo,
+      prNumber,
+      cwd: runtime.cwd ?? process.cwd(),
+      env: runtime.env ?? process.env,
+      runChild: runtime.runChild ?? _runChild,
+    });
+    if (!board.enqueued) {
+      process.stderr.write(`[create-pr] Board note: PR not enqueued (${board.reason}).\n`);
+    }
+    process.stdout.write(`${JSON.stringify({ board })}\n`);
+  }
+  return code;
 }
 if (isDirectCliRun(import.meta.url)) {
   try {

--- a/test/contracts/jq-output-base-guarantee-contract.test.mjs
+++ b/test/contracts/jq-output-base-guarantee-contract.test.mjs
@@ -91,6 +91,10 @@ const EXCLUDED = new Map([
     "loop/run-queue.mjs",
     "Dormant no-op queue adapter: its runQueue() driver is not on any live pickup path (the active path is `scripts/projects/resolve-active-board-item.mjs`, wired into `loop-continue`), and its pretty-printed JSON is a human-readable dump, not a --jq-consumed tool result. Wire to emitResult if it is ever reactivated.",
   ],
+  [
+    "github/create-pr.mjs",
+    "Thin passthrough wrapper around `gh pr create`; its stdout IS gh's own PR URL, never a JSON tool-result to filter with --jq. The optional trailing board-enqueue line is an advisory side note appended for the issue-less lightweight path, not the command's queryable output.",
+  ],
 ]);
 
 async function walk(dir) {

--- a/test/github/create-pr-board.test.mjs
+++ b/test/github/create-pr-board.test.mjs
@@ -334,3 +334,50 @@ test("create-pr without --lightweight never calls the board and never prints a b
     assert.equal(ghCalls.length, 1); // gh pr create only — no board calls
   });
 });
+
+// --- --lightweight boolean forms: every token consumed, last occurrence wins ---
+// No .devloops board in the temp cwd, so an ENABLED run reports the
+// no-board-configured JSON line (proof the flag was consumed and honored)
+// while a DISABLED run prints the plain PR URL only. Either way the gh log
+// must never contain a --lightweight token.
+
+async function runLightweightForms(tempDir, lightweightTokens) {
+  const { env, ghLogPath } = await writeGhStub(tempDir, [{ stdout: "https://github.com/owner/repo/pull/42\n" }], { logCalls: true });
+  const result = await runNode(
+    ["--repo", "owner/repo", "--base", "main", "--head", "feature", "--title", "t", "--body", "no closing keyword", ...lightweightTokens],
+    { env, cwd: tempDir },
+  );
+  assert.equal(result.code, 0);
+  const ghCalls = (await readFile(ghLogPath, "utf8")).trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
+  assert.equal(ghCalls.length, 1); // gh pr create only — no board calls (no board configured)
+  assert.equal(ghCalls[0].some((arg) => arg.startsWith("--lightweight")), false); // consumed, never forwarded
+  return result.stdout;
+}
+
+test("create-pr --lightweight=true enables the lightweight path (inline boolean form)", async () => {
+  await withTempDir(async (tempDir) => {
+    const stdout = await runLightweightForms(tempDir, ["--lightweight=true"]);
+    assert.deepEqual(JSON.parse(stdout.trim().split("\n").at(-1)), { board: { enqueued: false, reason: "no-board-configured" } });
+  });
+});
+
+test("create-pr --lightweight=false disables the lightweight path and is NOT forwarded to gh", async () => {
+  await withTempDir(async (tempDir) => {
+    const stdout = await runLightweightForms(tempDir, ["--lightweight=false"]);
+    assert.equal(stdout, "https://github.com/owner/repo/pull/42\n");
+  });
+});
+
+test("create-pr --lightweight=false then bare --lightweight: last occurrence wins (enabled)", async () => {
+  await withTempDir(async (tempDir) => {
+    const stdout = await runLightweightForms(tempDir, ["--lightweight=false", "--lightweight"]);
+    assert.deepEqual(JSON.parse(stdout.trim().split("\n").at(-1)), { board: { enqueued: false, reason: "no-board-configured" } });
+  });
+});
+
+test("create-pr bare --lightweight then --lightweight=false: last occurrence wins (disabled)", async () => {
+  await withTempDir(async (tempDir) => {
+    const stdout = await runLightweightForms(tempDir, ["--lightweight", "--lightweight=false"]);
+    assert.equal(stdout, "https://github.com/owner/repo/pull/42\n");
+  });
+});

--- a/test/github/create-pr-board.test.mjs
+++ b/test/github/create-pr-board.test.mjs
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { main, enqueueIssuelessLightweightPr } from "../../scripts/github/create-pr.mjs";
+import { runNode as runNodeHelper, writeGhStub } from "../_helpers.mjs";
+
+const scriptPath = path.resolve("scripts/github/create-pr.mjs");
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
+
+// mockRunChild mirrors test/projects/add-queue-item.test.mjs's fixture style: a
+// sequential list of canned gh-graphql responses, bypassing any real subprocess.
+function mockRunChild(responses) {
+  let callIndex = 0;
+  return async () => {
+    if (callIndex >= responses.length) {
+      throw new Error(`Unexpected gh call #${callIndex + 1} (only ${responses.length} mocked)`);
+    }
+    const resp = responses[callIndex++];
+    return { code: 0, stdout: JSON.stringify(resp), stderr: "" };
+  };
+}
+
+const STATUS_FIELD = {
+  id: "PVTSSF_status",
+  name: "Status",
+  options: [
+    { id: "opt1", name: "Backlog" },
+    { id: "opt2", name: "Next Up" },
+    { id: "opt3", name: "In Progress" },
+    { id: "opt4", name: "Done" },
+  ],
+};
+
+const PROJECT = { id: "PVT_proj1", number: 7, title: "Dev Loop Queue", url: "https://github.com/users/owner/projects/7" };
+
+function userPayload() {
+  return { data: { user: { id: "U_kgDOABC123" } } };
+}
+function listUserProjectsResponse(projects) {
+  return { data: { user: { projectsV2: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: projects } } } };
+}
+function getFieldsResponse(fields) {
+  return { data: { node: { fields: { nodes: fields, pageInfo: { hasNextPage: false } } } } };
+}
+function itemsByContentResponse(items) {
+  return { data: { node: { items: { nodes: items, pageInfo: { hasNextPage: false, endCursor: null } } } } };
+}
+function resolvePrResponse(id) {
+  return { data: { repository: { issueOrPullRequest: { id, __typename: "PullRequest" } } } };
+}
+function addItemResponse(itemId) {
+  return { data: { addProjectV2ItemById: { item: { id: itemId } } } };
+}
+function updateFieldResponse() {
+  return { data: { updateProjectV2ItemFieldValue: { projectV2Item: { id: "PVTI_new" } } } };
+}
+
+async function withTempDir(fn) {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-create-pr-board-"));
+  try {
+    await fn(tempDir);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function writeDevloopsProjectNumber(tempDir, projectNumber) {
+  await writeFile(path.join(tempDir, ".devloops"), `queue:\n  projectNumber: ${projectNumber}\n`, "utf8");
+}
+
+// --- enqueueIssuelessLightweightPr unit tests (AC1, AC3, AC4) ---
+
+test("enqueueIssuelessLightweightPr: no .devloops board configured is a silent no-op", async () => {
+  await withTempDir(async (tempDir) => {
+    const board = await enqueueIssuelessLightweightPr({
+      repo: "owner/repo",
+      prNumber: 42,
+      cwd: tempDir,
+      env: {},
+      runChild: mockRunChild([]),
+    });
+    assert.deepEqual(board, { enqueued: false, reason: "no-board-configured" });
+  });
+});
+
+test("enqueueIssuelessLightweightPr: adds a new PR item in In Progress", async () => {
+  await withTempDir(async (tempDir) => {
+    await writeDevloopsProjectNumber(tempDir, 7);
+    const responses = [
+      userPayload(),
+      listUserProjectsResponse([PROJECT]),
+      getFieldsResponse([STATUS_FIELD]),
+      itemsByContentResponse([]),
+      resolvePrResponse("PR_kwDO_42"),
+      addItemResponse("PVTI_new"),
+      updateFieldResponse(),
+    ];
+    const board = await enqueueIssuelessLightweightPr({
+      repo: "owner/repo",
+      prNumber: 42,
+      cwd: tempDir,
+      env: {},
+      runChild: mockRunChild(responses),
+    });
+    assert.deepEqual(board, {
+      enqueued: true,
+      itemId: "PVTI_new",
+      prNumber: 42,
+      status: "In Progress",
+      alreadyPresent: false,
+    });
+  });
+});
+
+test("enqueueIssuelessLightweightPr: idempotent — an already-present item is not duplicated", async () => {
+  await withTempDir(async (tempDir) => {
+    await writeDevloopsProjectNumber(tempDir, 7);
+    const existing = {
+      id: "PVTI_existing",
+      fieldValues: { nodes: [{ field: { id: "PVTSSF_status", name: "Status" }, name: "In Progress" }] },
+      content: { __typename: "PullRequest", number: 42, repository: { nameWithOwner: "owner/repo" } },
+    };
+    const responses = [
+      userPayload(),
+      listUserProjectsResponse([PROJECT]),
+      getFieldsResponse([STATUS_FIELD]),
+      itemsByContentResponse([existing]),
+    ];
+    const board = await enqueueIssuelessLightweightPr({
+      repo: "owner/repo",
+      prNumber: 42,
+      cwd: tempDir,
+      env: {},
+      runChild: mockRunChild(responses),
+    });
+    assert.deepEqual(board, {
+      enqueued: true,
+      itemId: "PVTI_existing",
+      prNumber: 42,
+      status: "In Progress",
+      alreadyPresent: true,
+    });
+  });
+});
+
+test("enqueueIssuelessLightweightPr: missing --repo is a no-op, never calls gh", async () => {
+  await withTempDir(async (tempDir) => {
+    await writeDevloopsProjectNumber(tempDir, 7);
+    const board = await enqueueIssuelessLightweightPr({
+      repo: null,
+      prNumber: 42,
+      cwd: tempDir,
+      env: {},
+      runChild: mockRunChild([]),
+    });
+    assert.deepEqual(board, { enqueued: false, reason: "repo-not-specified" });
+  });
+});
+
+test("enqueueIssuelessLightweightPr: unparsed PR number is a no-op, never calls gh", async () => {
+  await withTempDir(async (tempDir) => {
+    await writeDevloopsProjectNumber(tempDir, 7);
+    const board = await enqueueIssuelessLightweightPr({
+      repo: "owner/repo",
+      prNumber: null,
+      cwd: tempDir,
+      env: {},
+      runChild: mockRunChild([]),
+    });
+    assert.deepEqual(board, { enqueued: false, reason: "pr-number-not-parsed" });
+  });
+});
+
+// --- main() end-to-end: gh pr create over a stubbed gh, board calls mocked in-process ---
+
+test("create-pr --lightweight on an issue-less body enqueues the new PR board item (AC1)", async () => {
+  await withTempDir(async (tempDir) => {
+    await writeDevloopsProjectNumber(tempDir, 7);
+    const { env } = await writeGhStub(tempDir, [{ stdout: "https://github.com/owner/repo/pull/42\n" }]);
+
+    const responses = [
+      userPayload(),
+      listUserProjectsResponse([PROJECT]),
+      getFieldsResponse([STATUS_FIELD]),
+      itemsByContentResponse([]),
+      resolvePrResponse("PR_kwDO_42"),
+      addItemResponse("PVTI_new"),
+      updateFieldResponse(),
+    ];
+
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    let captured = "";
+    process.stdout.write = (chunk) => {
+      captured += chunk;
+      return true;
+    };
+    let code;
+    try {
+      code = await main(
+        ["--repo", "owner/repo", "--base", "main", "--head", "feature", "--title", "t", "--body", "no closing keyword here", "--lightweight"],
+        { env, cwd: tempDir, runChild: mockRunChild(responses) },
+      );
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+
+    assert.equal(code, 0);
+    assert.match(captured, /https:\/\/github\.com\/owner\/repo\/pull\/42/);
+    const boardLine = captured.trim().split("\n").at(-1);
+    assert.deepEqual(JSON.parse(boardLine), {
+      board: { enqueued: true, itemId: "PVTI_new", prNumber: 42, status: "In Progress", alreadyPresent: false },
+    });
+  });
+});
+
+test("create-pr --lightweight with a Closes #N body is tracker-backed and byte-identical: no board call (AC2)", async () => {
+  await withTempDir(async (tempDir) => {
+    await writeDevloopsProjectNumber(tempDir, 7);
+    const { env, ghLogPath } = await writeGhStub(tempDir, [{ stdout: "https://github.com/owner/repo/pull/42\n" }], { logCalls: true });
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--base", "main", "--head", "feature", "--title", "t", "--body", "Closes #9", "--lightweight"],
+      { env, cwd: tempDir },
+    );
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+    assert.equal(result.stdout, "https://github.com/owner/repo/pull/42\n");
+    const ghCalls = (await readFile(ghLogPath, "utf8")).trim().split("\n").filter(Boolean);
+    assert.equal(ghCalls.length, 1); // gh pr create only — no board calls
+  });
+});
+
+test("create-pr --lightweight on a no-board repo is a silent no-op noted in the JSON line (AC3)", async () => {
+  await withTempDir(async (tempDir) => {
+    const { env } = await writeGhStub(tempDir, [{ stdout: "https://github.com/owner/repo/pull/42\n" }]);
+
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    let captured = "";
+    process.stdout.write = (chunk) => {
+      captured += chunk;
+      return true;
+    };
+    let code;
+    try {
+      code = await main(
+        ["--repo", "owner/repo", "--base", "main", "--head", "feature", "--title", "t", "--body", "no closing keyword", "--lightweight"],
+        { env, cwd: tempDir, runChild: mockRunChild([]) },
+      );
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+
+    assert.equal(code, 0);
+    const boardLine = captured.trim().split("\n").at(-1);
+    assert.deepEqual(JSON.parse(boardLine), { board: { enqueued: false, reason: "no-board-configured" } });
+  });
+});
+
+test("create-pr without --lightweight never calls the board and never prints a board JSON line", async () => {
+  await withTempDir(async (tempDir) => {
+    await writeDevloopsProjectNumber(tempDir, 7);
+    const { env, ghLogPath } = await writeGhStub(tempDir, [{ stdout: "https://github.com/owner/repo/pull/42\n" }], { logCalls: true });
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--base", "main", "--head", "feature", "--title", "t", "--body", "no closing keyword"],
+      { env, cwd: tempDir },
+    );
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stdout, "https://github.com/owner/repo/pull/42\n");
+    const ghCalls = (await readFile(ghLogPath, "utf8")).trim().split("\n").filter(Boolean);
+    assert.equal(ghCalls.length, 1); // gh pr create only — no board calls
+  });
+});

--- a/test/github/create-pr-board.test.mjs
+++ b/test/github/create-pr-board.test.mjs
@@ -259,6 +259,65 @@ test("create-pr --lightweight on a no-board repo is a silent no-op noted in the 
   });
 });
 
+test("create-pr --lightweight without --body/--body-file never enqueues: reason body-not-provided (no explicit body source)", async () => {
+  await withTempDir(async (tempDir) => {
+    await writeDevloopsProjectNumber(tempDir, 7);
+    const { env, ghLogPath } = await writeGhStub(tempDir, [{ stdout: "https://github.com/owner/repo/pull/42\n" }], { logCalls: true });
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--base", "main", "--head", "feature", "--title", "t", "--fill", "--lightweight"],
+      { env, cwd: tempDir },
+    );
+
+    assert.equal(result.code, 0);
+    const boardLine = result.stdout.trim().split("\n").at(-1);
+    assert.deepEqual(JSON.parse(boardLine), { board: { enqueued: false, reason: "body-not-provided" } });
+    const ghCalls = (await readFile(ghLogPath, "utf8")).trim().split("\n").filter(Boolean);
+    assert.equal(ghCalls.length, 1); // gh pr create only — no board calls
+  });
+});
+
+test("create-pr --lightweight with --repo=owner/repo (equals form) enqueues the PR board item", async () => {
+  await withTempDir(async (tempDir) => {
+    await writeDevloopsProjectNumber(tempDir, 7);
+    const { env } = await writeGhStub(tempDir, [{ stdout: "https://github.com/owner/repo/pull/42\n" }]);
+
+    const responses = [
+      userPayload(),
+      listUserProjectsResponse([PROJECT]),
+      getFieldsResponse([STATUS_FIELD]),
+      itemsByContentResponse([]),
+      resolvePrResponse("PR_kwDO_42"),
+      addItemResponse("PVTI_new"),
+      updateFieldResponse(),
+    ];
+
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    let captured = "";
+    process.stdout.write = (chunk) => {
+      captured += chunk;
+      return true;
+    };
+    let code;
+    try {
+      code = await main(
+        // --base directly after --repo= proves the value comes from the inline
+        // token, not the next argv element.
+        ["--repo=owner/repo", "--base", "main", "--head", "feature", "--title", "t", "--body", "no closing keyword here", "--lightweight"],
+        { env, cwd: tempDir, runChild: mockRunChild(responses) },
+      );
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+
+    assert.equal(code, 0);
+    const boardLine = captured.trim().split("\n").at(-1);
+    assert.deepEqual(JSON.parse(boardLine), {
+      board: { enqueued: true, itemId: "PVTI_new", prNumber: 42, status: "In Progress", alreadyPresent: false },
+    });
+  });
+});
+
 test("create-pr without --lightweight never calls the board and never prints a board JSON line", async () => {
   await withTempDir(async (tempDir) => {
     await writeDevloopsProjectNumber(tempDir, 7);


### PR DESCRIPTION
## Summary

An issue-less lightweight PR has no tracker issue, so its only board
representation is a PR item — and until now nothing added that item
automatically; #1217 required a manual `add-queue-item` call after creation.
`scripts/github/create-pr.mjs` now owns that enqueue: a new `--lightweight`
flag, combined with a body that carries no `Closes #N`/`Fixes #N`, marks the
PR as issue-less lightweight, and the wrapper auto-enqueues it as a board PR
item in the configured In Progress column right after `gh pr create` succeeds.

Closes #1218

## Mechanics

- `--lightweight` is consumed by the wrapper and never forwarded to `gh pr
  create`.
- Board resolution reuses `queue.projectNumber`/`queue.boardTitle` from
  `.devloops` (the same resolution `add-queue-item.mjs` and friends already
  use) and the same `In Progress` logical-column mapping
  (`queue.statusColumns.in_progress`) `resolve-active-board-item.mjs` uses.
  The actual add call goes straight through `add-queue-item.mjs`'s exported
  `main()` — no board API calls are reimplemented.
- A tracker-backed PR (closing keyword present) never reaches the board,
  regardless of `--lightweight` — its issue already owns the board entry, and
  its stdout/stderr/exit code stay byte-identical to today.
- A no-board repo, a missing `--repo`, an unparsed PR number, or an enqueue
  error are all non-fatal no-ops; the exit code is unaffected.
- The outcome is reported as one trailing stdout JSON line —
  `{"board":{"enqueued":bool,...}}` — only for the issue-less lightweight
  path; every other caller's stdout is unchanged.
- Idempotent: re-running honors `add-queue-item`'s `alreadyPresent` and never
  duplicates the item.

## Evidence

```
$ node --test test/github/create-pr.test.mjs test/github/create-pr-board.test.mjs test/projects/add-queue-item.test.mjs
ℹ tests 81
ℹ pass 81
ℹ fail 0

$ npm run verify
...
ℹ tests 2341   (test:scripts)   ℹ pass 2305   ℹ fail 0   ℹ skipped 36
ℹ tests 1865   (test:core)      ℹ pass 1865   ℹ fail 0
ℹ tests 189    (test:assets)    ℹ pass 189    ℹ fail 0
ℹ tests 81     (test:extension) ℹ pass 81     ℹ fail 0
ℹ tests 32     (test:dev-loop)  ℹ pass 32     ℹ fail 0
Markdown links OK (97 files, 512 links checked).
Rule ownership validation passed: 141 rules, 13 references, 30 terms, 100 files scanned.
```

## Notes

Signal choice: an explicit `--lightweight` flag (mirroring the existing
`--lightweight` convention already used by `request-copilot-review.mjs`,
`upsert-checkpoint-verdict.mjs`, and `copilot-pr-handoff.mjs`) combined with
the wrapper's existing closing-keyword detection, rather than inferring
lightweight-ness from diff size or any other heuristic at create time — the
caller states its intent explicitly and deterministically, and the wrapper
reuses its own existing `detectClosingKeyword` check rather than adding a
second body-parsing path.

`test/github/create-pr.test.mjs` (30 pre-existing tests) is unchanged and
still green — this is a behind-a-flag addition with no change to any
existing call site's stdout/stderr/exit code.


**Also touched:** `test/contracts/jq-output-base-guarantee-contract.test.mjs` gains an EXCLUDED entry for `create-pr.mjs` — its canonical stdout has always been gh's non-JSON PR URL, and the new advisory board line doesn't change that contract; the entry documents the reasoning.


### Post-draft fix rounds

1. `--repo=owner/name` equals-form recognized (inline `=` handling in `getFlagValue`).
2. Issue-less classification requires an explicit `--body`/`--body-file` (null body → `body-not-provided`, no enqueue).
3. `--lightweight` boolean forms: every bare/inline token consumed (never forwarded to gh), last occurrence wins (mirrors the `--draft` house pattern). Six tests added across the rounds (81 → 87).
