### PR TITLE
feat(gates): briefing prefix carries the reviewed content inline — size-capped, hash-enforced (#1220)

### DIFF
--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -162,10 +162,15 @@ construction and the shared-prefix prompt-cache opportunity is destroyed byte on
 `<gate>-<headSha>.briefing-prefix.txt` file sibling to the JSON context artifact, in a
 fixed section order: header (repo/PR/head/gate/worktree + the verify-fresh instruction),
 PR body, linked-issue body (when present), the full diff at the reviewed head, and a
-changed-files/adjacent-code summary. The diff SHOULD be inlined verbatim up to a size cap
-(`BRIEFING_PREFIX_INLINE_DIFF_CAP_BYTES`, a fixed constant); over the cap the prefix falls
-back to the `scope.diffPath` pointer form and discloses this in both the artifact
-(`prefixMode: "inline"|"pointer"`) and the prefix text itself. This is purely a
+changed-files/adjacent-code summary. The diff SHOULD be inlined up to a size cap
+(`BRIEFING_PREFIX_INLINE_DIFF_CAP_BYTES`, a fixed constant), carried inside a fenced
+markdown block — the fence and surrounding framing are part of the rendered prefix bytes,
+so "inline" means the diff content travels in the prefix, not that its raw bytes appear
+unframed. Over the cap the prefix falls back to pointer mode: it references
+`scope.diffPath` when the persisted `.diff` is present, and otherwise discloses that the
+diff pointer is unavailable (reviewers re-derive via `git diff`). Either way the mode is
+disclosed in both the artifact (`prefixMode: "inline"|"pointer"`) and the prefix text
+itself. This is purely a
 size/performance choice — reviewers spend many turns re-reading the same seeded content,
 so inlining it lets the FIRST turn's prompt-cache write serve every later turn cheaply —
 and is a zero-semantic change to the byte-identity requirement above: whichever mode ran,

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -151,14 +151,29 @@ Fan out one fresh-context reviewer per gate-specific review angle. The reviewer 
 **invariant block** followed by an **angle-specific prompt**, in that order — never
 angle-first. The invariant block MUST be byte-identical across every reviewer of the same
 gate pass and MUST carry, at minimum: the repo, PR number, head SHA, and worktree path; the
-`write-gate-context.mjs` gate-context artifact path (`GATE-EXEC-BUILD-ONCE-SEED`), with the
-heavy content — the full diff and PR description — inlined verbatim when shared-prefix
-prompt-cache reuse across the fan-out is desired; and the mandatory
-`verify-fresh-review-context.mjs` instruction above. Angle identity MUST appear ONLY in the
-suffix (the angle-specific prompt, e.g. `COPILOT-FOLLOWUP-ADVERSARIAL-BRIEFING`'s persona
-prompt) and the reviewer's `--scope` flag — never inside the invariant block, or the
-byte-identity requirement is violated by construction and the shared-prefix prompt-cache
-opportunity is destroyed byte one.
+`write-gate-context.mjs` gate-context artifact path (`GATE-EXEC-BUILD-ONCE-SEED`); and the
+mandatory `verify-fresh-review-context.mjs` instruction above. Angle identity MUST appear
+ONLY in the suffix (the angle-specific prompt, e.g.
+`COPILOT-FOLLOWUP-ADVERSARIAL-BRIEFING`'s persona prompt) and the reviewer's `--scope` flag
+— never inside the invariant block, or the byte-identity requirement is violated by
+construction and the shared-prefix prompt-cache opportunity is destroyed byte one.
+
+**Content inlining.** `write-gate-context.mjs` renders this invariant block as a
+`<gate>-<headSha>.briefing-prefix.txt` file sibling to the JSON context artifact, in a
+fixed section order: header (repo/PR/head/gate/worktree + the verify-fresh instruction),
+PR body, linked-issue body (when present), the full diff at the reviewed head, and a
+changed-files/adjacent-code summary. The diff SHOULD be inlined verbatim up to a size cap
+(`BRIEFING_PREFIX_INLINE_DIFF_CAP_BYTES`, a fixed constant); over the cap the prefix falls
+back to the `scope.diffPath` pointer form and discloses this in both the artifact
+(`prefixMode: "inline"|"pointer"`) and the prefix text itself. This is purely a
+size/performance choice — reviewers spend many turns re-reading the same seeded content,
+so inlining it lets the FIRST turn's prompt-cache write serve every later turn cheaply —
+and is a zero-semantic change to the byte-identity requirement above: whichever mode ran,
+every reviewer of the same round still receives byte-identical prefix bytes, and
+`verify-fresh-review-context.mjs --prefix-file`/`verify-briefing-prefixes.mjs` hash and
+compare those bytes exactly as before, oblivious to which mode produced them. Sharing one
+warmed cache entry ACROSS the fan-out's parallel reviewers (rather than each reviewer's own
+multi-turn reuse) is a separate, harness-dependent optimization not covered by this rule.
 
 **Enforcement.** Each reviewer passes `--prefix-hash <sha256>` (or `--prefix-file <path>`,
 hashed by the tool) to `verify-fresh-review-context.mjs`, which persists the hash on the

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -849,13 +849,18 @@ export async function writeGateContext(options, { repoRoot = process.cwd() } = {
     ...buildGateContextArtifact({ ...options, prefixMode: rendered.prefixMode }),
     loggedAt: new Date().toISOString(),
   };
-  await mkdir(path.dirname(fullPath), { recursive: true });
-  await writeFile(fullPath, JSON.stringify(artifact, null, 2) + "\n", "utf8");
-
+  // Write ORDER matters: the sibling briefing prefix goes first and the JSON
+  // artifact last, so the artifact's existence is the completion marker for
+  // the whole set. Downstream consumers (readGateContext, the reviewers'
+  // --context-path guard) key on the JSON — a prefix-write failure must not
+  // leave a complete-looking artifact pointing at a missing prefix file.
   const fullPrefixPath = path.resolve(repoRoot, briefingPrefixPath);
   await mkdir(path.dirname(fullPrefixPath), { recursive: true });
   await writeFile(fullPrefixPath, rendered.text, "utf8");
   const prefixHash = createHash("sha256").update(rendered.text, "utf8").digest("hex");
+
+  await mkdir(path.dirname(fullPath), { recursive: true });
+  await writeFile(fullPath, JSON.stringify(artifact, null, 2) + "\n", "utf8");
 
   return { ok: true, path: contextPath, artifact, prefixPath: briefingPrefixPath, prefixHash, prefixMode: rendered.prefixMode };
 }

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -465,8 +465,9 @@ export function buildGateBriefingPrefixPath({ repo, pr, gate, headSha, tmpRoot =
 
 /**
  * Size cap (bytes) above which the rendered briefing prefix falls back to
- * pointer mode for the diff section (scope.diffPath reference) instead of
- * inlining the diff text verbatim. No `gates.*` config knob exists for this
+ * pointer mode for the diff section (a scope.diffPath reference when present,
+ * else an explicit unavailable-pointer disclosure) instead of inlining the
+ * diff text in a fenced block. No `gates.*` config knob exists for this
  * yet — a named constant is the right size for a single fixed threshold;
  * promote to config only if a real need for tuning it emerges.
  */
@@ -645,9 +646,9 @@ export function buildGateContextArtifact(options) {
   if (options.adjacentCode && typeof options.adjacentCode === "object") {
     artifact.adjacentCode = options.adjacentCode;
   }
-  // Whether the rendered briefing prefix inlined the reviewed-head diff verbatim
-  // or fell back to the diffPath pointer (size cap). Only set when a caller
-  // actually rendered a prefix (writeGateContext does, always).
+  // Whether the rendered briefing prefix inlined the reviewed-head diff (in a
+  // fenced block) or fell back to the diffPath pointer (size cap). Only set
+  // when a caller actually rendered a prefix (writeGateContext does, always).
   if (typeof options.prefixMode === "string" && options.prefixMode.length > 0) {
     artifact.prefixMode = options.prefixMode;
   }

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -29,6 +29,7 @@
  *   <tmpRoot>/gate-context/<repo-slug>/pr-<N>/<gate>-<headSha>.json
  */
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { parseArgs } from "node:util";
@@ -117,8 +118,10 @@ Optional:
   --branch <name>                Source branch name
   --touched-files <json>         JSON array of changed file path strings (separate from the diff-derived scope.changedFiles)
   --base <ref>                   Git ref to diff against (git diff <ref>...HEAD); populates scope.diffPath, scope.changedFiles, and adjacentCode (the full build-once bundle). Without it, the CLI emits an explicit thin briefing (scope.diffSource="none") — see docs/gate-review-sub-loop-contract.md.
-  --acceptance-criteria <ptr>    Pointer to acceptance criteria (issue ref, doc path, URL)
+  --acceptance-criteria <ptr>    Pointer to acceptance criteria (issue ref, doc path, URL); also used as the linked-issue label in the rendered briefing prefix
   --validation-posture <text>    Short description of the validation posture
+  --pr-body <text>               PR description text, inlined into the rendered briefing prefix
+  --issue-body <text>            Linked-issue body text, inlined into the briefing prefix under --acceptance-criteria's label; omitted entirely when absent
   --tmp-root <path>              Root tmp directory (default: tmp/)
 
 ${JQ_OUTPUT_USAGE}
@@ -231,6 +234,8 @@ export function parseWriteGateContextCliArgs(argv) {
       base: { type: "string" },
       "acceptance-criteria": { type: "string" },
       "validation-posture": { type: "string" },
+      "pr-body": { type: "string" },
+      "issue-body": { type: "string" },
       "tmp-root": { type: "string" },
       ...JQ_OUTPUT_PARSE_OPTIONS,
     },
@@ -250,6 +255,8 @@ export function parseWriteGateContextCliArgs(argv) {
     base: null,
     acceptanceCriteria: null,
     validationPosture: null,
+    prBody: null,
+    issueBody: null,
     tmpRoot: "tmp",
   };
   for (const token of tokens) {
@@ -310,6 +317,14 @@ export function parseWriteGateContextCliArgs(argv) {
     }
     if (token.name === "validation-posture") {
       options.validationPosture = requireTokenValue(token, parseError).trim();
+      continue;
+    }
+    if (token.name === "pr-body") {
+      options.prBody = requireTokenValue(token, parseError);
+      continue;
+    }
+    if (token.name === "issue-body") {
+      options.issueBody = requireTokenValue(token, parseError);
       continue;
     }
     if (token.name === "tmp-root") {
@@ -427,6 +442,136 @@ export function buildGateDiffPath({ repo, pr, gate, headSha, tmpRoot = "tmp" }) 
 }
 
 /**
+ * Build the deterministic path for the rendered invariant briefing prefix
+ * (GATE-EXEC-BRIEFING-PREFIX): the byte-identical block every per-angle
+ * reviewer of this gate pass is seeded with, before their angle-specific
+ * suffix. Mirrors buildGateContextPath/buildGateDiffPath. Exported so the
+ * fan-out reviewers and `verify-fresh-review-context.mjs --prefix-file` agree
+ * on the path with the context-builder.
+ *
+ * @param {object} input
+ * @param {string} input.repo — owner/name
+ * @param {number|string} input.pr
+ * @param {string} input.gate — draft_gate | pre_approval_gate
+ * @param {string} input.headSha
+ * @param {string} [input.tmpRoot] — default "tmp"
+ * @returns {string} relative briefing-prefix path
+ */
+export function buildGateBriefingPrefixPath({ repo, pr, gate, headSha, tmpRoot = "tmp" }) {
+  const repoSlug = repoSlugFor(repo);
+  const { pr: safePr, gate: safeGate, headSha: safeSha } = validatePathSegments({ pr, gate, headSha });
+  return path.join(tmpRoot, "gate-context", repoSlug, `pr-${safePr}`, `${safeGate}-${safeSha}.briefing-prefix.txt`);
+}
+
+/**
+ * Size cap (bytes) above which the rendered briefing prefix falls back to
+ * pointer mode for the diff section (scope.diffPath reference) instead of
+ * inlining the diff text verbatim. No `gates.*` config knob exists for this
+ * yet — a named constant is the right size for a single fixed threshold;
+ * promote to config only if a real need for tuning it emerges.
+ */
+export const BRIEFING_PREFIX_INLINE_DIFF_CAP_BYTES = 200 * 1024;
+
+/**
+ * Render the invariant briefing-prefix text (GATE-EXEC-BRIEFING-PREFIX):
+ * header (repo/PR/head/gate/worktree + the mandatory verify-fresh-review-context.mjs
+ * instruction), PR body, linked-issue body (when present), the full diff at the
+ * reviewed head (inlined up to `capBytes`, else a pointer to `diffPath`), and a
+ * changed-files/adjacent-code summary — in that fixed order. Pure and
+ * deterministic: identical input always renders identical bytes, so two builds
+ * at the same head produce a byte-identical prefix (the fan-out's shared-prefix
+ * requirement).
+ *
+ * @param {object} input
+ * @param {string} input.repo
+ * @param {number|string} input.pr
+ * @param {string} input.gate
+ * @param {string} input.headSha
+ * @param {string} input.worktreeRoot — absolute path reviewers run in
+ * @param {string} input.contextPath — the sibling JSON artifact path
+ * @param {string} input.briefingPrefixPath — this rendered file's own path
+ * @param {string|null} [input.prBody]
+ * @param {string|null} [input.issueRef] — label for the linked-issue section (e.g. "#877")
+ * @param {string|null} [input.issueBody] — omit the whole section when null/empty
+ * @param {string|null} [input.diffOutput] — full diff text, when captured
+ * @param {string|null} [input.diffPath] — persisted `.diff` pointer (pointer-mode fallback)
+ * @param {string[]} [input.changedFiles]
+ * @param {object|null} [input.adjacentCode] — buildAdjacentBundle output
+ * @param {number} [input.capBytes] — default BRIEFING_PREFIX_INLINE_DIFF_CAP_BYTES
+ * @returns {{ text: string, prefixMode: "inline"|"pointer", diffBytes: number }}
+ */
+export function renderBriefingPrefix({
+  repo, pr, gate, headSha, worktreeRoot, contextPath, briefingPrefixPath,
+  prBody = null, issueRef = null, issueBody = null,
+  diffOutput = null, diffPath = null, changedFiles = [], adjacentCode = null,
+  capBytes = BRIEFING_PREFIX_INLINE_DIFF_CAP_BYTES,
+}) {
+  const hasDiffText = typeof diffOutput === "string" && diffOutput.length > 0;
+  const diffBytes = hasDiffText ? Buffer.byteLength(diffOutput, "utf8") : 0;
+  const prefixMode = hasDiffText && diffBytes > capBytes ? "pointer" : "inline";
+
+  const lines = [];
+  lines.push("# Gate Review Briefing — invariant prefix (GATE-EXEC-BRIEFING-PREFIX)");
+  lines.push("");
+  lines.push(`repo: ${repo}`);
+  lines.push(`pr: #${pr}`);
+  lines.push(`gate: ${gate}`);
+  lines.push(`head: ${headSha}`);
+  lines.push(`worktree: ${worktreeRoot}`);
+  lines.push(`prefixMode: ${prefixMode}`);
+  lines.push("");
+  lines.push(
+    `Mandatory: before doing any angle-specific work, run \`node scripts/github/verify-fresh-review-context.mjs --scope <your-angle> --context-path ${contextPath} --prefix-file ${briefingPrefixPath}\`. Refuse to proceed on contamination or a missing artifact.`,
+  );
+  lines.push("");
+  lines.push("## PR body");
+  lines.push("");
+  lines.push(typeof prBody === "string" && prBody.trim().length > 0 ? prBody.trim() : "(no PR body provided)");
+  lines.push("");
+  const hasIssueBody = typeof issueBody === "string" && issueBody.trim().length > 0;
+  if (hasIssueBody) {
+    lines.push(`## Linked issue${issueRef ? ` ${issueRef}` : ""}`);
+    lines.push("");
+    lines.push(issueBody.trim());
+    lines.push("");
+  }
+  lines.push(`## Diff at reviewed head (${headSha})`);
+  lines.push("");
+  if (!hasDiffText) {
+    lines.push("(no diff text captured for this bundle)");
+  } else if (prefixMode === "inline") {
+    lines.push("```diff");
+    lines.push(diffOutput.endsWith("\n") ? diffOutput.slice(0, -1) : diffOutput);
+    lines.push("```");
+  } else {
+    lines.push(
+      `Diff exceeds the ${capBytes}-byte inline cap (${diffBytes} bytes) — pointer mode. Read the full diff from:`,
+    );
+    lines.push(`  ${diffPath ?? "(diff pointer unavailable — re-derive with git diff)"}`);
+  }
+  lines.push("");
+  lines.push("## Changed files + adjacent-code summary");
+  lines.push("");
+  const files = Array.isArray(changedFiles) ? changedFiles : [];
+  lines.push(`Changed files (${files.length}):`);
+  for (const f of files) lines.push(`- ${f}`);
+  const adjacentFiles = adjacentCode && Array.isArray(adjacentCode.files)
+    ? adjacentCode.files.filter((f) => f.role !== "changed")
+    : [];
+  if (adjacentCode) {
+    lines.push(`Adjacent files (${adjacentFiles.length}):`);
+    for (const f of adjacentFiles) lines.push(`- ${f.path} (${f.role})`);
+    lines.push(
+      `Stripped: ${adjacentCode.stripped?.length ?? 0}, Truncated: ${adjacentCode.truncated?.length ?? 0}, Missing: ${adjacentCode.missing?.length ?? 0}`,
+    );
+  } else {
+    lines.push("Adjacent files (0): (no adjacent-code bundle for this briefing)");
+  }
+
+  return { text: lines.join("\n") + "\n", prefixMode, diffBytes };
+}
+
+/**
  * Parse `git diff --name-status` output into full repo-relative changed file
  * paths. Handles rename/copy entries (R100 old new, C75 old new) by recording
  * the destination path. Tolerates blank lines and malformed rows.
@@ -500,6 +645,12 @@ export function buildGateContextArtifact(options) {
   if (options.adjacentCode && typeof options.adjacentCode === "object") {
     artifact.adjacentCode = options.adjacentCode;
   }
+  // Whether the rendered briefing prefix inlined the reviewed-head diff verbatim
+  // or fell back to the diffPath pointer (size cap). Only set when a caller
+  // actually rendered a prefix (writeGateContext does, always).
+  if (typeof options.prefixMode === "string" && options.prefixMode.length > 0) {
+    artifact.prefixMode = options.prefixMode;
+  }
   return artifact;
 }
 
@@ -520,7 +671,7 @@ export function buildGateContextArtifact(options) {
  * @param {string} input.tmpRoot
  * @param {number} [input.maxFileBytes]
  * @param {{ repoRoot: string }} opts
- * @returns {Promise<{ diffPath: string|null, changedFiles: string[], adjacentCode: object|null }>}
+ * @returns {Promise<{ diffPath: string|null, changedFiles: string[], adjacentCode: object|null, diffOutput: string|null }>}
  */
 async function resolveDiffScope({ diff, repo, pr, gate, headSha, tmpRoot, maxFileBytes }, { repoRoot }) {
   const diffOutput = diff?.diffOutput;
@@ -562,7 +713,7 @@ async function resolveDiffScope({ diff, repo, pr, gate, headSha, tmpRoot, maxFil
     }
   }
 
-  return { diffPath, changedFiles, adjacentCode };
+  return { diffPath, changedFiles, adjacentCode, diffOutput: typeof diffOutput === "string" ? diffOutput : null };
 }
 
 /**
@@ -647,6 +798,19 @@ export function captureDiffFromBase(base, { repoRoot, maxBuffer = 64 * 1024 * 10
   return { nameStatusOutput, diffOutput };
 }
 
+/**
+ * Write both the JSON context artifact AND its sibling rendered briefing
+ * prefix (GATE-EXEC-BRIEFING-PREFIX): the byte-identical invariant block every
+ * per-angle reviewer of this gate pass is seeded with. The prefix's
+ * `prefixMode` (inline|pointer, from the diff-size cap) is recorded on the
+ * JSON artifact so both files stay in sync.
+ *
+ * @param {object} options — parsed CLI options shape, optionally carrying
+ *   `diffOutput`, `prBody`, `issueBody` (all null-safe; a caller with none of
+ *   these still gets a valid — if thin — prefix).
+ * @param {{ repoRoot?: string }} [runtime]
+ * @returns {Promise<{ ok: boolean, path: string, artifact: object, prefixPath: string, prefixHash: string, prefixMode: "inline"|"pointer" }>}
+ */
 export async function writeGateContext(options, { repoRoot = process.cwd() } = {}) {
   const contextPath = buildGateContextPath({
     repo: options.repo,
@@ -655,14 +819,44 @@ export async function writeGateContext(options, { repoRoot = process.cwd() } = {
     headSha: options.headSha,
     tmpRoot: options.tmpRoot || "tmp",
   });
+  const briefingPrefixPath = buildGateBriefingPrefixPath({
+    repo: options.repo,
+    pr: options.pr,
+    gate: options.gate,
+    headSha: options.headSha,
+    tmpRoot: options.tmpRoot || "tmp",
+  });
+  const rendered = renderBriefingPrefix({
+    repo: options.repo,
+    pr: options.pr,
+    gate: options.gate,
+    headSha: options.headSha,
+    worktreeRoot: path.resolve(repoRoot),
+    contextPath,
+    briefingPrefixPath,
+    prBody: options.prBody ?? null,
+    issueRef: options.acceptanceCriteria ?? null,
+    issueBody: options.issueBody ?? null,
+    diffOutput: options.diffOutput ?? null,
+    diffPath: options.diffPath ?? null,
+    changedFiles: options.changedFiles ?? [],
+    adjacentCode: options.adjacentCode ?? null,
+  });
+
   const fullPath = path.resolve(repoRoot, contextPath);
   const artifact = {
-    ...buildGateContextArtifact(options),
+    ...buildGateContextArtifact({ ...options, prefixMode: rendered.prefixMode }),
     loggedAt: new Date().toISOString(),
   };
   await mkdir(path.dirname(fullPath), { recursive: true });
   await writeFile(fullPath, JSON.stringify(artifact, null, 2) + "\n", "utf8");
-  return { ok: true, path: contextPath, artifact };
+
+  const fullPrefixPath = path.resolve(repoRoot, briefingPrefixPath);
+  await mkdir(path.dirname(fullPrefixPath), { recursive: true });
+  await writeFile(fullPrefixPath, rendered.text, "utf8");
+  const prefixHash = createHash("sha256").update(rendered.text, "utf8").digest("hex");
+
+  return { ok: true, path: contextPath, artifact, prefixPath: briefingPrefixPath, prefixHash, prefixMode: rendered.prefixMode };
 }
 
 /**
@@ -685,10 +879,12 @@ export async function writeGateContext(options, { repoRoot = process.cwd() } = {
  * @param {string[]} [input.touchedFiles]
  * @param {string|null} [input.acceptanceCriteria]
  * @param {string|null} [input.validationPosture]
+ * @param {string|null} [input.prBody] — PR description text, inlined into the rendered briefing prefix
+ * @param {string|null} [input.issueBody] — linked-issue body text, inlined under `acceptanceCriteria`'s label; omitted when absent
  * @param {number} [input.maxFileBytes] — per-file cap for the adjacent-code bundle (default DEFAULT_MAX_FILE_BYTES)
  * @param {string} [input.tmpRoot]
  * @param {{ repoRoot?: string }} [opts]
- * @returns {Promise<{ ok: boolean, path: string, artifact: object, resolver: object }>}
+ * @returns {Promise<{ ok: boolean, path: string, artifact: object, prefixPath: string, prefixHash: string, prefixMode: "inline"|"pointer", resolver: object }>}
  *
  * The artifact additionally carries a deterministic, neutral `adjacentCode`
  * bundle (#895) when changed files are present: 1-hop import in/out-edges of the
@@ -707,7 +903,7 @@ export async function buildGateContext(input, { repoRoot = process.cwd() } = {})
   // Diff-derived scope: persisted FULL diff (scope.diffPath), parsed
   // scope.changedFiles, and the neutral adjacentCode bundle, all built ONCE by
   // the shared resolveDiffScope helper (also used by the CLI --base path, #1140).
-  const { diffPath, changedFiles, adjacentCode } = await resolveDiffScope(
+  const { diffPath, changedFiles, adjacentCode, diffOutput } = await resolveDiffScope(
     { diff: input.diff, repo: input.repo, pr: input.pr, gate: input.gate, headSha: input.headSha, tmpRoot, maxFileBytes: input.maxFileBytes },
     { repoRoot },
   );
@@ -724,9 +920,12 @@ export async function buildGateContext(input, { repoRoot = process.cwd() } = {})
       touchedFiles: input.touchedFiles ?? [],
       changedFiles,
       diffPath,
+      diffOutput,
       adjacentCode,
       acceptanceCriteria: input.acceptanceCriteria ?? null,
       validationPosture: input.validationPosture ?? null,
+      prBody: input.prBody ?? null,
+      issueBody: input.issueBody ?? null,
       tmpRoot,
     },
     { repoRoot },
@@ -800,6 +999,7 @@ export async function main(argv = process.argv.slice(2), { repoRoot = process.cw
       options.changedFiles = scope.changedFiles;
       options.diffPath = scope.diffPath;
       options.adjacentCode = scope.adjacentCode;
+      options.diffOutput = scope.diffOutput;
       options.diffSource = "base";
     } else {
       process.stderr.write("[write-gate-context] warning: no --base given; emitting a THIN briefing (scope.diffPath=null, scope.changedFiles=[], no adjacentCode). Pass --base <ref> for the full build-once bundle.\n");

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -1431,3 +1431,27 @@ test("dogfood round-trip: CLI-built briefing prefix verifies clean across two re
     await rm(repoRoot, { recursive: true, force: true });
   }
 });
+
+test("writeGateContext failure-ordering: a prefix-write failure leaves NO JSON artifact behind (artifact is the completion marker)", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-order-"));
+  try {
+    // Occupy the deterministic briefing-prefix path with a DIRECTORY so its
+    // writeFile throws EISDIR before the JSON artifact write is attempted.
+    const prefixRel = buildGateBriefingPrefixPath({ repo: "owner/repo", pr: 70, gate: "draft_gate", headSha: "abc1234567890" });
+    await mkdir(path.resolve(repoRoot, prefixRel), { recursive: true });
+
+    const options = parseWriteGateContextCliArgs([
+      "--repo", "owner/repo", "--pr", "70", "--gate", "draft_gate",
+      "--head-sha", "abc1234567890",
+      "--angles", '["scope"]',
+    ]);
+    await assert.rejects(() => writeGateContext(options, { repoRoot }), /EISDIR/);
+
+    const artifact = await readGateContext({
+      repo: "owner/repo", pr: 70, gate: "draft_gate", headSha: "abc1234567890",
+    }, { repoRoot });
+    assert.equal(artifact, null, "no partial gate-context JSON may exist when the prefix write failed");
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -8,6 +8,8 @@ import test from "node:test";
 import { resolveGateAnglesDynamic } from "@dev-loops/core/config";
 
 import {
+  BRIEFING_PREFIX_INLINE_DIFF_CAP_BYTES,
+  buildGateBriefingPrefixPath,
   buildGateContext,
   buildGateContextArtifact,
   buildGateContextPath,
@@ -19,8 +21,12 @@ import {
   parseWriteGateContextCliArgs,
   rationaleFromResolver,
   readGateContext,
+  renderBriefingPrefix,
   writeGateContext,
 } from "../../scripts/github/write-gate-context.mjs";
+
+const contextGuardPath = path.resolve("scripts/github/verify-fresh-review-context.mjs");
+const briefingCheckerPath = path.resolve("scripts/github/verify-briefing-prefixes.mjs");
 
 function git(cwd, args) {
   return execFileSync("git", args, { cwd, encoding: "utf8" });
@@ -1194,6 +1200,233 @@ test("buildGateContext with an empty diffOutput leaves diffPath null but still b
     const byPath = Object.fromEntries(result.artifact.adjacentCode.files.map((f) => [f.path, f]));
     assert.equal(byPath["src/dep.mjs"].role, "imports");
     assert.equal(byPath["src/caller.mjs"].role, "importedBy");
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+// ---------------------------------------------------------------------------
+// renderBriefingPrefix (Phase 1, #1220) — invariant briefing prefix content
+// ---------------------------------------------------------------------------
+
+function renderInput(overrides = {}) {
+  return {
+    repo: "owner/repo",
+    pr: 9,
+    gate: "draft_gate",
+    headSha: "abc1234567890",
+    worktreeRoot: "/repo/worktree",
+    contextPath: "tmp/gate-context/owner-repo/pr-9/draft_gate-abc1234567890.json",
+    briefingPrefixPath: "tmp/gate-context/owner-repo/pr-9/draft_gate-abc1234567890.briefing-prefix.txt",
+    prBody: "Implement the thing.",
+    issueRef: "#42",
+    issueBody: "Acceptance criteria: the thing works.",
+    diffOutput: "diff --git a/x.mjs b/x.mjs\n+added line\n",
+    diffPath: "tmp/gate-context/owner-repo/pr-9/draft_gate-abc1234567890.diff",
+    changedFiles: ["x.mjs"],
+    adjacentCode: { files: [{ path: "x.mjs", role: "changed" }, { path: "y.mjs", role: "imports" }], stripped: [], truncated: [], missing: [] },
+    ...overrides,
+  };
+}
+
+test("renderBriefingPrefix: under-cap — inline mode, fixed section order, all sections present", () => {
+  const { text, prefixMode, diffBytes } = renderBriefingPrefix(renderInput());
+  assert.equal(prefixMode, "inline");
+  assert.equal(diffBytes, Buffer.byteLength(renderInput().diffOutput, "utf8"));
+
+  const headerIdx = text.indexOf("repo: owner/repo");
+  const prBodyIdx = text.indexOf("## PR body");
+  const issueIdx = text.indexOf("## Linked issue #42");
+  const diffIdx = text.indexOf("## Diff at reviewed head");
+  const summaryIdx = text.indexOf("## Changed files + adjacent-code summary");
+
+  // Fixed order: header, PR body, linked issue, diff, changed-files summary.
+  assert.ok(headerIdx >= 0 && headerIdx < prBodyIdx);
+  assert.ok(prBodyIdx < issueIdx);
+  assert.ok(issueIdx < diffIdx);
+  assert.ok(diffIdx < summaryIdx);
+
+  assert.ok(text.includes("Implement the thing."));
+  assert.ok(text.includes("Acceptance criteria: the thing works."));
+  assert.ok(text.includes("+added line"));
+  assert.ok(text.includes("Changed files (1):"));
+  assert.ok(text.includes("- x.mjs"));
+  assert.ok(text.includes("verify-fresh-review-context.mjs"));
+});
+
+test("renderBriefingPrefix: deterministic — two renders of identical input produce byte-identical text", () => {
+  const a = renderBriefingPrefix(renderInput());
+  const b = renderBriefingPrefix(renderInput());
+  assert.equal(a.text, b.text);
+});
+
+test("renderBriefingPrefix: over-cap diff falls back to pointer mode, discloses the pointer, and does NOT inline the diff body", () => {
+  const bigDiff = "+" + "x".repeat(100);
+  const { text, prefixMode, diffBytes } = renderBriefingPrefix(renderInput({ diffOutput: bigDiff, capBytes: 10 }));
+  assert.equal(prefixMode, "pointer");
+  assert.equal(diffBytes, Buffer.byteLength(bigDiff, "utf8"));
+  assert.ok(text.includes("pointer"));
+  assert.ok(text.includes("tmp/gate-context/owner-repo/pr-9/draft_gate-abc1234567890.diff"));
+  assert.ok(!text.includes(bigDiff), "the raw diff body must not be inlined in pointer mode");
+  assert.ok(text.includes(`${diffBytes} bytes`));
+});
+
+test("renderBriefingPrefix: over-cap diff with no persisted diffPath discloses an explicit unavailable-pointer note (no crash)", () => {
+  const bigDiff = "+" + "x".repeat(100);
+  const { text, prefixMode } = renderBriefingPrefix(renderInput({ diffOutput: bigDiff, diffPath: null, capBytes: 10 }));
+  assert.equal(prefixMode, "pointer");
+  assert.ok(text.includes("diff pointer unavailable"));
+});
+
+test("renderBriefingPrefix: issue-less PR omits the Linked issue section entirely (no crash)", () => {
+  const { text } = renderBriefingPrefix(renderInput({ issueBody: null, issueRef: null }));
+  assert.ok(!text.includes("## Linked issue"));
+  assert.ok(text.includes("## PR body"));
+  assert.ok(text.includes("## Diff at reviewed head"));
+});
+
+test("renderBriefingPrefix: fully empty optional input (no PR/issue/diff/changed-files/adjacentCode) renders without crashing", () => {
+  const { text, prefixMode } = renderBriefingPrefix({
+    repo: "owner/repo", pr: 1, gate: "draft_gate", headSha: "abc1234",
+    worktreeRoot: "/repo", contextPath: "tmp/x.json", briefingPrefixPath: "tmp/x.briefing-prefix.txt",
+  });
+  assert.equal(prefixMode, "inline");
+  assert.ok(text.includes("(no PR body provided)"));
+  assert.ok(text.includes("(no diff text captured for this bundle)"));
+  assert.ok(text.includes("Changed files (0):"));
+  assert.ok(!text.includes("## Linked issue"));
+});
+
+test("buildGateBriefingPrefixPath sits beside the context artifact + diff (same dir, same basename stem)", () => {
+  const prefixPath = buildGateBriefingPrefixPath({ repo: "owner/repo", pr: 9, gate: "draft_gate", headSha: "abc1234567890" });
+  const jsonPath = buildGateContextPath({ repo: "owner/repo", pr: 9, gate: "draft_gate", headSha: "abc1234567890" });
+  assert.equal(path.dirname(prefixPath), path.dirname(jsonPath));
+  assert.equal(prefixPath, path.join("tmp", "gate-context", "owner-repo", "pr-9", "draft_gate-abc1234567890.briefing-prefix.txt"));
+});
+
+// ---------------------------------------------------------------------------
+// buildGateContext / writeGateContext — briefing prefix end-to-end (#1220)
+// ---------------------------------------------------------------------------
+
+test("buildGateContext writes an inline-mode briefing prefix under the cap; scope.prefixMode + result.prefixHash/prefixPath agree; deterministic across two builds", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-prefix-"));
+  try {
+    const config = draftConfig({ dynamicAngles: false });
+    const diff = {
+      nameStatusOutput: "M\tsrc/a.mjs\n",
+      diffOutput: "diff --git a/src/a.mjs b/src/a.mjs\n+line\n",
+    };
+    const buildOnce = async () => buildGateContext(
+      {
+        config, gate: "draft_gate", diff, repo: "owner/repo", pr: 50, headSha: "abc1234567890",
+        prBody: "PR description", acceptanceCriteria: "#42", issueBody: "Issue description",
+      },
+      { repoRoot },
+    );
+
+    const result = await buildOnce();
+    assert.equal(result.artifact.prefixMode, "inline");
+    assert.equal(result.prefixMode, "inline");
+    assert.match(result.prefixHash, /^[0-9a-f]{64}$/);
+    assert.equal(result.prefixPath, buildGateBriefingPrefixPath({ repo: "owner/repo", pr: 50, gate: "draft_gate", headSha: "abc1234567890" }));
+
+    const onDisk = await readFile(path.resolve(repoRoot, result.prefixPath), "utf8");
+    assert.ok(onDisk.includes("PR description"));
+    assert.ok(onDisk.includes("Issue description"));
+    assert.ok(onDisk.includes("+line"));
+    const { createHash } = await import("node:crypto");
+    assert.equal(createHash("sha256").update(onDisk, "utf8").digest("hex"), result.prefixHash);
+
+    // A second build at the SAME head produces a byte-identical prefix.
+    const result2 = await buildOnce();
+    const onDisk2 = await readFile(path.resolve(repoRoot, result2.prefixPath), "utf8");
+    assert.equal(onDisk2, onDisk);
+    assert.equal(result2.prefixHash, result.prefixHash);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("buildGateContext falls back to pointer mode when the diff exceeds the inline cap, and discloses it", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-prefix-cap-"));
+  try {
+    const config = draftConfig({ dynamicAngles: false });
+    const bigDiffBody = "+" + "x".repeat(BRIEFING_PREFIX_INLINE_DIFF_CAP_BYTES + 1024);
+    const diff = {
+      nameStatusOutput: "M\tsrc/big.mjs\n",
+      diffOutput: `diff --git a/src/big.mjs b/src/big.mjs\n${bigDiffBody}\n`,
+    };
+    const result = await buildGateContext(
+      { config, gate: "draft_gate", diff, repo: "owner/repo", pr: 51, headSha: "deadbeef123456" },
+      { repoRoot },
+    );
+    assert.equal(result.artifact.prefixMode, "pointer");
+    assert.equal(result.prefixMode, "pointer");
+    assert.ok(result.artifact.scope.diffPath, "diffPath persisted for pointer-mode fallback");
+
+    const onDisk = await readFile(path.resolve(repoRoot, result.prefixPath), "utf8");
+    assert.ok(!onDisk.includes(bigDiffBody), "over-cap diff body must not be inlined");
+    assert.ok(onDisk.includes(result.artifact.scope.diffPath), "prefix discloses the diffPath pointer");
+    assert.ok(onDisk.includes("prefixMode: pointer"));
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("buildGateContext omits the Linked issue section for an issue-less PR (no crash, no issue label)", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-prefix-noissue-"));
+  try {
+    const config = draftConfig({ dynamicAngles: false });
+    const diff = { nameStatusOutput: "M\tsrc/a.mjs\n", diffOutput: "diff --git a/src/a.mjs b/src/a.mjs\n+line\n" };
+    const result = await buildGateContext(
+      { config, gate: "draft_gate", diff, repo: "owner/repo", pr: 52, headSha: "cafef00d123456", prBody: "Just a PR body" },
+      { repoRoot },
+    );
+    assert.equal(result.artifact.prefixMode, "inline");
+    const onDisk = await readFile(path.resolve(repoRoot, result.prefixPath), "utf8");
+    assert.ok(!onDisk.includes("## Linked issue"));
+    assert.ok(onDisk.includes("Just a PR body"));
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Dogfood round-trip (#1220 AC4): real gate-pass shape — build via the CLI,
+// two reviewer sentinels via --prefix-file, fan-in verify — verified:true.
+// Reuses verify-fresh-review-context.mjs / verify-briefing-prefixes.mjs UNCHANGED.
+// ---------------------------------------------------------------------------
+
+test("dogfood round-trip: CLI-built briefing prefix verifies clean across two reviewer sentinels via the real verify tools", async () => {
+  const { repoRoot, baseSha, headSha } = await makeBaseDiffRepo();
+  try {
+    await mkdir(path.join(repoRoot, "tmp"), { recursive: true });
+    await main([
+      "--repo", "owner/repo", "--pr", "60", "--gate", "draft_gate",
+      "--head-sha", headSha,
+      "--angles", '["scope"]',
+      "--base", baseSha,
+      "--pr-body", "Fixes the helper.",
+      "--acceptance-criteria", "#900",
+      "--issue-body", "The helper must return the right value.",
+    ], { repoRoot });
+
+    const artifact = await readGateContext({ repo: "owner/repo", pr: 60, gate: "draft_gate", headSha }, { repoRoot });
+    assert.ok(artifact, "artifact written");
+    assert.equal(artifact.prefixMode, "inline");
+
+    const prefixPath = buildGateBriefingPrefixPath({ repo: "owner/repo", pr: 60, gate: "draft_gate", headSha });
+    const contextPath = buildGateContextPath({ repo: "owner/repo", pr: 60, gate: "draft_gate", headSha });
+
+    const r1 = spawnSync("node", [contextGuardPath, "--scope", "scope-a", "--context-path", contextPath, "--prefix-file", prefixPath], { cwd: repoRoot, encoding: "utf8" });
+    assert.equal(r1.status, 0, r1.stderr);
+    const r2 = spawnSync("node", [contextGuardPath, "--scope", "scope-b", "--context-path", contextPath, "--prefix-file", prefixPath], { cwd: repoRoot, encoding: "utf8" });
+    assert.equal(r2.status, 0, r2.stderr);
+
+    const fanin = spawnSync("node", [briefingCheckerPath, "--head-sha", headSha], { cwd: repoRoot, encoding: "utf8" });
+    assert.equal(fanin.status, 0, fanin.stderr);
+    const finalResult = JSON.parse(fanin.stdout.trim());
+    assert.equal(finalResult.verified, true);
+    assert.equal(finalResult.reviewerCount, 2);
   } finally {
     await rm(repoRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- `write-gate-context.mjs` now renders the invariant reviewer briefing as an actual file (`<gate>-<headSha>.briefing-prefix.txt`, sibling to the JSON context artifact) instead of the prefix living only as prose instructions elsewhere: a fixed section order (header with the mandatory verify-fresh instruction, PR body, linked-issue body when present, the full reviewed-head diff, changed-files/adjacent-code summary), rebuilt fresh at the current head every gate pass.
- The diff inlines inside a fenced block up to a fixed 200KB cap (`BRIEFING_PREFIX_INLINE_DIFF_CAP_BYTES`); over the cap it falls back to the existing `diffPath` pointer form (or discloses the diff as unavailable when no diffPath exists). Either way the mode is recorded as `prefixMode: "inline"|"pointer"` on the JSON artifact and disclosed in the prefix text itself.
- The tool's result JSON now also carries `prefixPath` + `prefixHash` (sha256) alongside `prefixMode` so a coordinator can quote the hash without a second pass.
- `verify-fresh-review-context.mjs` and `verify-briefing-prefixes.mjs` are untouched by design — they already hash/compare whatever bytes `--prefix-file` points at — and a new test builds a real gate context via the CLI, feeds the rendered prefix through both tools with two reviewer scopes, and asserts `verified:true`.
- Contract text (`GATE-EXEC-BRIEFING-PREFIX` in `docs/gate-review-sub-loop-contract.md`) extended to describe the rendered file, the fixed section order, and the cap/fallback — explicitly a zero-semantic change to the byte-identity requirement.

This is **Phase 1 only** of the linked issue's two-phase plan. Phase 2 (a priming pass to share one warmed prompt-cache entry across the fan-out's parallel reviewers) is measurement-gated on confirming cross-subagent cache collisions actually happen in this harness, and stays out of scope here — that phase remains open.

Part of #1220 (Phase 2 stays open).

## Evidence

```
$ npm run verify
...
test:assets   → 189 pass / 0 fail
test:extension→  81 pass / 0 fail
test:scripts  → 2383 tests, 2347 pass / 0 fail (36 skipped)
test:core     → 1896 pass / 0 fail
test:docs     → links + rule-ownership validation passed
test:dev-loop →  32 pass / 0 fail
```

Dogfood round-trip (new test, `test/github/write-gate-context.test.mjs`): builds a gate context via the real CLI (`--base`), writes two reviewer sentinels against the rendered prefix via the real `verify-fresh-review-context.mjs --prefix-file`, then runs the real `verify-briefing-prefixes.mjs --head-sha` — `verified:true`, `reviewerCount:2`.

Head SHA: `6a9f3c750bfb78f9b94bea8c27523ec6dc8f0814`

## Notes

- Size cap is a named constant, not a new `gates.*` config knob — no existing schema slot fit it naturally, and a single fixed threshold doesn't yet need to be tunable.
- `prefixMode` is scoped to the diff section only (per the issue's suggested design); PR/issue body sections have no size cap in this phase.


### Post-draft rounds

1. Contract-text alignment: "inline" documented as diff-inside-a-fenced-block (framing is part of the rendered prefix bytes); pointer mode documented as referencing `scope.diffPath` when present, else disclosing the diff as unavailable — text-only, rendering bytes unchanged.
2. Write ordering: the briefing prefix writes first and the JSON artifact last, making the artifact the completion marker; failure-ordering test added (prefix write throws → no artifact left behind).
