### PR TITLE
fix(queue): accept full node-ID alphabet in --item across projects scripts (#1227)

### DIFF
--- a/scripts/projects/_resolve-project.mjs
+++ b/scripts/projects/_resolve-project.mjs
@@ -31,16 +31,21 @@ function resolveSettings(cwd) {
   return null;
 }
 
+// Shape of a GitHub GraphQL global node ID: a type prefix (e.g. "PVT",
+// "PVTI", "I", "PR") followed by "_" and a base64url-ish payload. The payload
+// alphabet includes "-" and "_" (base64url), which a plain [A-Za-z0-9_] class
+// rejects — the exact shape that broke real PVTI_ ids containing a hyphen.
+const NODE_ID_RE = /^[A-Za-z]+_[A-Za-z0-9_-]+$/;
+
 // Parse a --project value into { kind:"id"|"number"|"uri", ... }. Throws
 // INVALID_PROJECT on empty/malformed input (bare "0" is rejected too).
 //
 // Supported forms:
 //   <n>           positive integer  → { kind:"number", value:<n> }
-//   <NODE_ID>     alphanumeric/_ ID → { kind:"id", value:<NODE_ID> }
+//   <NODE_ID>     GraphQL node ID    → { kind:"id", value:<NODE_ID> }
 //   https://github.com/users/<login>/projects/<n>
 //   https://github.com/orgs/<login>/projects/<n>
 //                 board URI        → { kind:"uri", number:<n>, owner:<login>, ownerKind:"user"|"org" }
-const GLOBAL_NODE_ID_RE = /^[A-Za-z0-9_]+$/;
 
 // GitHub Projects V2 board URI pattern (user- or org-scoped boards).
 const BOARD_URI_RE = /^https:\/\/github\.com\/(users|orgs)\/([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)\/projects\/(\d+)$/;
@@ -78,13 +83,39 @@ function parseProjectRef(raw) {
       { code: "INVALID_PROJECT" },
     );
   }
-  if (GLOBAL_NODE_ID_RE.test(trimmed)) {
+  if (NODE_ID_RE.test(trimmed)) {
     return { kind: "id", value: trimmed };
   }
   throw Object.assign(
     new Error(`--project must be a positive integer, a node ID, or a board URI, got "${raw}"`),
     { code: "INVALID_PROJECT" },
   );
+}
+
+// Parse a --item value into { kind:"id"|"number" }. Throws INVALID_ITEM on
+// empty/malformed input (bare "0" is rejected too). Shared by every --item
+// consumer (move-queue-item, reorder-queue-item) so the accepted node-ID
+// alphabet is defined once.
+//
+// Supported forms:
+//   <n>           positive integer → { kind:"number", value:<n> }
+//   <NODE_ID>     GraphQL node ID   → { kind:"id", value:<NODE_ID> }
+function parseItemRef(raw) {
+  if (!raw || typeof raw !== "string" || raw.trim().length === 0) {
+    throw Object.assign(new Error("--item is required"), { code: "INVALID_ITEM" });
+  }
+  const trimmed = raw.trim();
+  const asNum = Number(trimmed);
+  if (Number.isInteger(asNum) && asNum > 0 && String(asNum) === trimmed) {
+    return { kind: "number", value: asNum };
+  }
+  if (trimmed === "0") {
+    throw Object.assign(new Error(`--item must be a positive integer or an item node ID, got "${raw}"`), { code: "INVALID_ITEM" });
+  }
+  if (NODE_ID_RE.test(trimmed)) {
+    return { kind: "id", value: trimmed };
+  }
+  throw Object.assign(new Error(`--item must be a positive integer or an item node ID, got "${raw}"`), { code: "INVALID_ITEM" });
 }
 
 // Selector precedence: explicit --project ref wins; else resolve by board title
@@ -145,4 +176,4 @@ function applyDevloopsBoard(args, cwd) {
   }
 }
 
-export { resolveSettings, parseProjectRef, resolveProjectSelector, findProject, applyDevloopsBoard };
+export { resolveSettings, parseProjectRef, parseItemRef, resolveProjectSelector, findProject, applyDevloopsBoard };

--- a/scripts/projects/_resolve-project.mjs
+++ b/scripts/projects/_resolve-project.mjs
@@ -31,10 +31,13 @@ function resolveSettings(cwd) {
   return null;
 }
 
-// Shape of a GitHub GraphQL global node ID: a type prefix (e.g. "PVT",
-// "PVTI", "I", "PR") followed by "_" and a base64url-ish payload. The payload
-// alphabet includes "-" and "_" (base64url), which a plain [A-Za-z0-9_] class
-// rejects — the exact shape that broke real PVTI_ ids containing a hyphen.
+// Shape of the node IDs this tooling actually receives from the Projects V2
+// API (e.g. "PVT_…", "PVTI_…", "I_…", "PR_…"): a type prefix, "_", then a
+// base64url-ish payload. Intentionally narrower than an arbitrary GraphQL
+// global node ID (which is opaque and carries no guaranteed prefix_payload
+// shape). The payload alphabet includes "-" and "_" (base64url), which a
+// plain [A-Za-z0-9_] class rejects — the exact shape that broke real PVTI_
+// ids containing a hyphen.
 const NODE_ID_RE = /^[A-Za-z]+_[A-Za-z0-9_-]+$/;
 
 // Parse a --project value into { kind:"id"|"number"|"uri", ... }. Throws
@@ -92,17 +95,18 @@ function parseProjectRef(raw) {
   );
 }
 
-// Parse a --item value into { kind:"id"|"number" }. Throws INVALID_ITEM on
-// empty/malformed input (bare "0" is rejected too). Shared by every --item
-// consumer (move-queue-item, reorder-queue-item) so the accepted node-ID
-// alphabet is defined once.
+// Parse an item ref into { kind:"id"|"number" }. Throws INVALID_ITEM on
+// empty/malformed input (bare "0" is rejected too). Shared by every item-ref
+// consumer (move-queue-item --item; reorder-queue-item --item/--after/
+// positionals) so the accepted node-ID alphabet is defined once. `label`
+// names the flag/argument in error messages.
 //
 // Supported forms:
 //   <n>           positive integer → { kind:"number", value:<n> }
-//   <NODE_ID>     GraphQL node ID   → { kind:"id", value:<NODE_ID> }
-function parseItemRef(raw) {
+//   <NODE_ID>     item node ID      → { kind:"id", value:<NODE_ID> }
+function parseItemRef(raw, label = "--item") {
   if (!raw || typeof raw !== "string" || raw.trim().length === 0) {
-    throw Object.assign(new Error("--item is required"), { code: "INVALID_ITEM" });
+    throw Object.assign(new Error(`${label} is required`), { code: "INVALID_ITEM" });
   }
   const trimmed = raw.trim();
   const asNum = Number(trimmed);
@@ -110,12 +114,12 @@ function parseItemRef(raw) {
     return { kind: "number", value: asNum };
   }
   if (trimmed === "0") {
-    throw Object.assign(new Error(`--item must be a positive integer or an item node ID, got "${raw}"`), { code: "INVALID_ITEM" });
+    throw Object.assign(new Error(`${label} must be a positive integer or an item node ID, got "${raw}"`), { code: "INVALID_ITEM" });
   }
   if (NODE_ID_RE.test(trimmed)) {
     return { kind: "id", value: trimmed };
   }
-  throw Object.assign(new Error(`--item must be a positive integer or an item node ID, got "${raw}"`), { code: "INVALID_ITEM" });
+  throw Object.assign(new Error(`${label} must be a positive integer or an item node ID, got "${raw}"`), { code: "INVALID_ITEM" });
 }
 
 // Selector precedence: explicit --project ref wins; else resolve by board title

--- a/scripts/projects/_resolve-project.mjs
+++ b/scripts/projects/_resolve-project.mjs
@@ -45,7 +45,7 @@ const NODE_ID_RE = /^[A-Za-z]+_[A-Za-z0-9_-]+$/;
 //
 // Supported forms:
 //   <n>           positive integer  → { kind:"number", value:<n> }
-//   <NODE_ID>     GraphQL node ID    → { kind:"id", value:<NODE_ID> }
+//   <NODE_ID>     project node ID (prefix_payload shape) → { kind:"id", value:<NODE_ID> }
 //   https://github.com/users/<login>/projects/<n>
 //   https://github.com/orgs/<login>/projects/<n>
 //                 board URI        → { kind:"uri", number:<n>, owner:<login>, ownerKind:"user"|"org" }

--- a/scripts/projects/move-queue-item.mjs
+++ b/scripts/projects/move-queue-item.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
-import { resolveProjectSelector, findProject, applyDevloopsBoard } from "./_resolve-project.mjs";
+import { resolveProjectSelector, findProject, applyDevloopsBoard, parseItemRef } from "./_resolve-project.mjs";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 
@@ -96,7 +96,6 @@ function parseCliArgs(argv) {
 
 const OWNER_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
 const REPO_NAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9_.-]*[a-zA-Z0-9])?$/;
-const GLOBAL_NODE_ID_RE = /^[A-Za-z0-9_]+$/;
 
 function validateRepo(repo) {
   if (!repo || typeof repo !== "string") {
@@ -116,24 +115,6 @@ function validateRepo(repo) {
     throw Object.assign(new Error(`--repo must be exactly owner/name, got "${repo}"`), { code: "INVALID_REPO" });
   }
   return repo;
-}
-
-function parseItemRef(raw) {
-  if (!raw || typeof raw !== "string" || raw.trim().length === 0) {
-    throw Object.assign(new Error("--item is required"), { code: "INVALID_ITEM" });
-  }
-  const trimmed = raw.trim();
-  const asNum = Number(trimmed);
-  if (Number.isInteger(asNum) && asNum > 0 && String(asNum) === trimmed) {
-    return { kind: "number", value: asNum };
-  }
-  if (trimmed === "0") {
-    throw Object.assign(new Error(`--item must be a positive integer or an item node ID, got "${raw}"`), { code: "INVALID_ITEM" });
-  }
-  if (GLOBAL_NODE_ID_RE.test(trimmed)) {
-    return { kind: "id", value: trimmed };
-  }
-  throw Object.assign(new Error(`--item must be a positive integer or an item node ID, got "${raw}"`), { code: "INVALID_ITEM" });
 }
 
 // ── API helpers ──────────────────────────────────────────────────────────

--- a/scripts/projects/reorder-queue-item.mjs
+++ b/scripts/projects/reorder-queue-item.mjs
@@ -522,7 +522,7 @@ function executePosition(projectId, itemId, afterId) {
 async function mainFlagForm(args, { env, child, repo, owner, repoName, project }) {
   const itemRef = parseItemRef(args.item);
   let afterRef = null;
-  if (args.after !== undefined) afterRef = parseItemRef(args.after);
+  if (args.after !== undefined) afterRef = parseItemRef(args.after, "--after");
 
   const item = await resolveProjectItem(project.id, itemRef, owner, repoName, repo, env, child);
 
@@ -596,7 +596,7 @@ async function mainSubcommand(args, { env, child, repo, project }) {
   const items = await fetchAllItems(project.id, env, child);
 
   // Resolve all referenced items up-front (fail closed before any mutation).
-  const refs = positional.map((p) => parseItemRef(p));
+  const refs = positional.map((p) => parseItemRef(p, "<ref>"));
   const resolved = refs.map((ref) => resolveFromItems(items, ref, repo));
 
   // Reordering positions within a single Status column. The before/after snapshot is scoped

--- a/scripts/projects/reorder-queue-item.mjs
+++ b/scripts/projects/reorder-queue-item.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
-import { resolveProjectSelector, findProject, applyDevloopsBoard } from "./_resolve-project.mjs";
+import { resolveProjectSelector, findProject, applyDevloopsBoard, parseItemRef } from "./_resolve-project.mjs";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 
@@ -129,7 +129,6 @@ function parseCliArgs(argv) {
 
 const OWNER_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
 const REPO_NAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9_.-]*[a-zA-Z0-9])?$/;
-const GLOBAL_NODE_ID_RE = /^[A-Za-z0-9_]+$/;
 
 function validateRepo(repo) {
   if (!repo || typeof repo !== "string") {
@@ -152,24 +151,6 @@ function validateRepo(repo) {
     throw Object.assign(new Error(`--repo must be exactly owner/name, got "${repo}"`), { code: "INVALID_REPO" });
   }
   return repo;
-}
-
-function parseItemRef(raw) {
-  if (!raw || typeof raw !== "string" || raw.trim().length === 0) {
-    throw Object.assign(new Error("--item is required"), { code: "INVALID_ITEM" });
-  }
-  const trimmed = raw.trim();
-  const asNum = Number(trimmed);
-  if (Number.isInteger(asNum) && asNum > 0 && String(asNum) === trimmed) {
-    return { kind: "number", value: asNum };
-  }
-  if (trimmed === "0") {
-    throw Object.assign(new Error(`--item must be a positive integer or an item node ID, got "${raw}"`), { code: "INVALID_ITEM" });
-  }
-  if (GLOBAL_NODE_ID_RE.test(trimmed)) {
-    return { kind: "id", value: trimmed };
-  }
-  throw Object.assign(new Error(`--item must be a positive integer or an item node ID, got "${raw}"`), { code: "INVALID_ITEM" });
 }
 
 // ── API helpers ──────────────────────────────────────────────────────────

--- a/test/projects/_resolve-project.test.mjs
+++ b/test/projects/_resolve-project.test.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import {
   resolveSettings,
   parseProjectRef,
+  parseItemRef,
   resolveProjectSelector,
   findProject,
 } from "../../scripts/projects/_resolve-project.mjs";
@@ -144,6 +145,36 @@ describe("_resolve-project — parseProjectRef", () => {
       () => parseProjectRef("https://github.com/users/mfittko/repos/dev-loops"),
       (err) => err.code === "INVALID_PROJECT",
     );
+  });
+
+  it("parses a node ID whose payload contains a hyphen (#1227)", () => {
+    assert.deepStrictEqual(
+      parseProjectRef("PVT_lAHOAAT8js4BaBePzgxz5-I"),
+      { kind: "id", value: "PVT_lAHOAAT8js4BaBePzgxz5-I" },
+    );
+  });
+});
+
+describe("_resolve-project — parseItemRef", () => {
+  it("parses a positive integer as a number ref", () => {
+    assert.deepStrictEqual(parseItemRef("10"), { kind: "number", value: 10 });
+  });
+
+  it("parses a node ID as an id ref", () => {
+    assert.deepStrictEqual(parseItemRef("PVTI_42"), { kind: "id", value: "PVTI_42" });
+  });
+
+  // Regression (#1227): the exact live ID that reconcile-queue passed and
+  // move-queue-item's validator rejected — its base64url payload has a hyphen.
+  it("parses a node ID whose payload contains a hyphen", () => {
+    const hyphenId = "PVTI_lAHOAAT8js4BaBePzgxz5-I";
+    assert.deepStrictEqual(parseItemRef(hyphenId), { kind: "id", value: hyphenId });
+  });
+
+  it("throws INVALID_ITEM for empty/malformed input", () => {
+    for (const bad of ["", "   ", "0", "not-a-number", "not/a/ref"]) {
+      assert.throws(() => parseItemRef(bad), (err) => err.code === "INVALID_ITEM");
+    }
   });
 });
 

--- a/test/projects/move-queue-item.test.mjs
+++ b/test/projects/move-queue-item.test.mjs
@@ -206,6 +206,31 @@ describe("move-queue-item", () => {
       assert.equal(result.item.newColumn, "In Progress");
       assert.equal(result.item.issueNumber, 10);
     });
+
+    // Regression (#1227): a real project item node ID whose base64url payload
+    // contains a hyphen was rejected by an [A-Za-z0-9_] validator that never
+    // accounted for the full node-ID alphabet.
+    it("accepts an item node ID containing a hyphen", async () => {
+      const hyphenId = "PVTI_lAHOAAT8js4BaBePzgxz5-I";
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([STATUS_FIELD]) },
+        {
+          payload: getItemsByContentResponse([
+            makeItemNode(hyphenId, makeContent("Issue", 10), "In Progress"),
+          ]),
+        },
+        { payload: updateItemFieldResponse() },
+      ];
+      const result = await main(
+        { repo: "mfittko/dev-loops", project: "1", item: hyphenId, toColumn: "Done" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.item.itemId, hyphenId);
+      assert.equal(result.item.newColumn, "Done");
+    });
   });
 
   describe("success path — move by number", () => {

--- a/test/projects/reconcile-queue.test.mjs
+++ b/test/projects/reconcile-queue.test.mjs
@@ -217,4 +217,77 @@ describe("reconcile-queue main (#1069)", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // Regression (#1227): reconcile passes the item's stable node id straight
+  // through to the REAL move-queue-item main() (moveItem left undefined here,
+  // unlike the mocked-moveItem tests above), so this exercises the actual
+  // --item validator end to end against a live-shaped node ID with a hyphen
+  // in its base64url payload. Only `gh` (runChild) is mocked, per house seams.
+  it("reconcile end-to-end moves an item whose node ID contains a hyphen (real move-queue-item validator)", async () => {
+    const hyphenId = "PVTI_lAHOAAT8js4BaBePzgxz5-I";
+    const items = [{ itemId: hyphenId, issueNumber: 1196, prNumber: null, status: "Backlog" }];
+
+    const ghResponses = [
+      { data: { user: { id: "U_kgDOABC123" } } },
+      {
+        data: {
+          user: {
+            projectsV2: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [{ id: "PVT_proj1", number: 7, title: "Dev Loop Queue", url: "https://github.com/users/o/projects/7" }],
+            },
+          },
+        },
+      },
+      {
+        data: {
+          node: {
+            fields: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [{
+                id: "PVTSSF_status",
+                name: "Status",
+                options: [{ id: "opt-backlog", name: "Backlog" }, { id: "opt-progress", name: "In Progress" }],
+              }],
+            },
+          },
+        },
+      },
+      {
+        data: {
+          node: {
+            items: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [{
+                id: hyphenId,
+                fieldValues: { nodes: [{ field: { id: "PVTSSF_status", name: "Status" }, name: "Backlog" }] },
+                content: { __typename: "Issue", number: 1196, repository: { nameWithOwner: "o/r" } },
+              }],
+            },
+          },
+        },
+      },
+      { data: { updateProjectV2ItemFieldValue: { projectV2Item: { id: hyphenId } } } },
+    ];
+    let ghCall = 0;
+    const runChild = async (_cmd, _argv, _env) => {
+      const payload = ghResponses[ghCall++];
+      return { code: 0, stdout: JSON.stringify(payload), stderr: "" };
+    };
+
+    const result = await main(
+      { repo: "o/r", project: "7" },
+      {
+        env: {},
+        runChild,
+        listItems: async () => ({ items }),
+        gatherFacts: async () => new Map([[hyphenId, READY_LINKED_PR]]),
+        // moveItem intentionally omitted → real move-queue-item main() runs.
+      },
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.moved, 1);
+    assert.deepEqual(result.reconciled, [{ number: 1196, from: "Backlog", to: "In Progress", ok: true }]);
+  });
 });

--- a/test/projects/reconcile-queue.test.mjs
+++ b/test/projects/reconcile-queue.test.mjs
@@ -270,7 +270,10 @@ describe("reconcile-queue main (#1069)", () => {
       { data: { updateProjectV2ItemFieldValue: { projectV2Item: { id: hyphenId } } } },
     ];
     let ghCall = 0;
-    const runChild = async (_cmd, _argv, _env) => {
+    const runChild = async (cmd, argv, _env) => {
+      if (ghCall >= ghResponses.length) {
+        throw new Error(`Unexpected gh call #${ghCall + 1} (only ${ghResponses.length} mocked): ${cmd} ${argv.join(" ")}`);
+      }
       const payload = ghResponses[ghCall++];
       return { code: 0, stdout: JSON.stringify(payload), stderr: "" };
     };

--- a/test/projects/reorder-queue-item.test.mjs
+++ b/test/projects/reorder-queue-item.test.mjs
@@ -215,6 +215,33 @@ describe("reorder-queue-item — move to top (no --after)", () => {
     assert.ok(capturedInput !== null);
     assert.strictEqual(capturedInput.afterId, undefined);
   });
+
+  // Regression (#1227): a real project item node ID whose base64url payload
+  // contains a hyphen was rejected by an [A-Za-z0-9_] validator.
+  it("moves an item to top by an item node ID containing a hyphen", async () => {
+    const hyphenId = "PVTI_lAHOAAT8js4BaBePzgxz5-I";
+    const responses = [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      {
+        payload: getProjectItemResponse(hyphenId, {
+          __typename: "PullRequest",
+          number: 88,
+          title: "PR",
+          url: "...",
+        }),
+      },
+      { payload: updatePositionResponse() },
+    ];
+
+    const result = await main(
+      { repo: "mfittko/dev-loops", project: "1", item: hyphenId },
+      { runChild: mockRunChild(responses) },
+    );
+
+    assert.ok(result.ok);
+    assert.strictEqual(result.item.itemId, hyphenId);
+  });
 });
 
 describe("reorder-queue-item — move after another item", () => {


### PR DESCRIPTION
## Summary

- `move-queue-item.mjs` and `reorder-queue-item.mjs` each duplicated a `parseItemRef` validator whose node-ID regex was `/^[A-Za-z0-9_]+$/` — missing the hyphen that's part of the base64url alphabet real GraphQL node IDs use for their payload segment. `reconcile-queue.mjs` passes the item's stable node ID straight through to `move-queue-item` by design (multi-repo number collisions must resolve by node id), so any item whose real node ID happened to contain a hyphen (e.g. `PVTI_lAHOAAT8js4BaBePzgxz5-I`) failed to move even though the identical move by issue number succeeded.
- Extracted a single shared `parseItemRef` into `_resolve-project.mjs` (already imported by both `--item` consumers) with an anchored node-ID shape (`[A-Za-z]+_[A-Za-z0-9_-]+`) that accepts the full alphabet while still rejecting non-node-ID garbage like `not-a-number`. `parseProjectRef`'s identical charset bug (same file, same root cause) is fixed too, reusing the same regex.
- Removed both duplicate `parseItemRef` implementations; usage text already described `--item` generically (`<number|node-id>`) with no charset claim, so no wording changes were needed.
- Audited `add-queue-item.mjs`: its `--item` only ever accepted a positive integer (issue/PR number, used to look up content to add) — it never accepted node IDs, so it wasn't affected by this bug.

Closes #1227

## Evidence

```
node --test test/projects/move-queue-item.test.mjs test/projects/reorder-queue-item.test.mjs \
  test/projects/_resolve-project.test.mjs test/projects/reconcile-queue.test.mjs
ℹ tests 89
ℹ pass 89
ℹ fail 0

npm run verify
... test:assets 189/189, test:extension 81/81, test:scripts 2394 (2358 pass, 36 skipped), test:core 1896/1896, test:docs OK, test:dev-loop 32/32
```

New regression coverage (all exercise the exact live-shaped id `PVTI_lAHOAAT8js4BaBePzgxz5-I`):
- `_resolve-project.test.mjs`: `parseItemRef`/`parseProjectRef` unit tests for the hyphenated node-ID shape, plus the still-rejected malformed-input cases (`not-a-number`, `not/a/ref`, `0`, empty).
- `move-queue-item.test.mjs` / `reorder-queue-item.test.mjs`: each accepts the hyphenated id end to end against mocked `gh`.
- `reconcile-queue.test.mjs`: a true integration test that leaves `moveItem` unmocked so the real `move-queue-item` `main()` (and its validator) runs, with only `gh` (`runChild`) mocked — this is the path that broke live.

## Notes

- Single shared validator now backs both `--item` consumers (`sharedValidator: true`); no new dependency, no config surface added.
- Scope stayed to the validator + its direct duplicates; did not touch unrelated `validateRepo` duplication between the two scripts (pre-existing, out of scope for this issue).


### Polish rounds

1. Copilot round 1 (f9526048): NODE_ID_RE comment reworded to the narrower project-item prefix_payload shape; parseItemRef takes a label param so --after/positional call sites report accurate flag names; reconcile test mock throws with the unexpected gh command.
2. Pre-approval contradiction fix (b23f954c): parseProjectRef's supported-forms comment aligned to the same narrowed shape (was still "GraphQL node ID").
