### PR TITLE
fix(gates): scope briefing-prefix verification by (gate, headSha) [pre-v0.8]

### DIFF
--- a/scripts/github/_gate-names.mjs
+++ b/scripts/github/_gate-names.mjs
@@ -1,0 +1,5 @@
+// Canonical gate vocabulary — the single source of truth for gate names shared
+// across the gate-review tooling. Imported by write-gate-context.mjs (artifact
+// gate validation) and verify-briefing-prefixes.mjs (wrong-gate scope check) so
+// the two can never drift.
+export const GATE_NAMES = ["draft_gate", "pre_approval_gate"];

--- a/scripts/github/verify-briefing-prefixes.mjs
+++ b/scripts/github/verify-briefing-prefixes.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { readdir, readFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import path from "node:path";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { JQ_OUTPUT_USAGE, emitResult } from "../lib/jq-output.mjs";
@@ -17,6 +18,7 @@ Required:
 
 Output (stdout, JSON):
   { "ok": true, "verified": true, "headSha": "...", "reviewerCount": <n>, "prefixHash": "..." }
+  { "ok": true, "verified": true, "headSha": "...", "reviewerCount": <n>, "gates": [{ "gate": "draft_gate", "prefixHash": "...", "reviewerCount": <n> }, ...] }
   { "ok": true, "verified": true, "headSha": "...", "reviewerCount": 0, "reason": "no sentinels found for this round" }
   { "ok": true, "verified": false, "headSha": "...", "reviewerCount": <n>, "reason": "...", "missing": [...], "mismatched": [...] }
   On error (stderr, JSON):
@@ -31,14 +33,15 @@ Exit codes:
      hash is treated as a mismatch, never grandfathered
   2  Usage or internal error, or invalid --jq filter
 
-Gate scoping: sentinels are partitioned by gate (recovered from the reviewer
-scope's <gate>- prefix, e.g. draft-gate-<angle> / pre-approval-gate-<angle>) and
-each gate's reviewers are verified independently. Two gates reviewed at the SAME
-head (e.g. a small change clearing draft_gate and pre_approval_gate without an
-intervening push) therefore each verify against their own prefix record instead
-of colliding into a spurious mismatch. Within one gate the byte-identity check is
-unchanged. Bare-angle scopes with no recognized gate prefix form one "ungated"
-group (legacy behavior). Never manually clear sentinels.`.trim();
+Gate scoping: each reviewer sentinel's recorded prefix hash is verified against
+the on-disk per-gate briefing-prefix records (<gate>-<headSha>.briefing-prefix.txt
+under tmp/gate-context/, written by write-gate-context.mjs). Two gates reviewed
+at the SAME head (e.g. a small change clearing draft_gate and pre_approval_gate
+without an intervening push) each verify against their own record instead of
+colliding into a spurious mismatch, and a hash matching no record fails closed
+regardless of the reviewer's scope string. When no records are present the check
+falls back to the conservative flat rule (all sentinels must share one hash).
+Never manually clear sentinels.`.trim();
 
 // Full 40-char SHA required: sentinel filenames embed the full `git rev-parse
 // HEAD` value, so a short prefix would glob zero sentinels and read as a
@@ -109,101 +112,118 @@ async function readRoundSentinels(tmpRoot, headSha) {
   return results;
 }
 
-// Gate prefixes a reviewer scope may carry (hyphenated form of the gate names,
-// since `--scope` forbids underscores). write-gate-context.mjs renders the
-// reviewer instruction with a `<gate>-<angle>` scope so each reviewer's sentinel
-// self-identifies its gate. Ordered longest-first for unambiguous prefix match.
-const GATE_SCOPE_PREFIXES = ["pre-approval-gate", "draft-gate"];
+const BRIEFING_PREFIX_SUFFIX = ".briefing-prefix.txt";
 
-// Recover the gate a sentinel belongs to from its scope. A scope that carries no
-// recognized gate prefix is "ungated" (legacy bare-angle scope) and all such
-// sentinels share one implicit group — preserving pre-gate-scoping behavior.
-function gateOfScope(scope) {
-  for (const gate of GATE_SCOPE_PREFIXES) {
-    if (scope === gate || scope.startsWith(`${gate}-`)) return gate;
+/**
+ * Read the per-gate invariant-briefing records for this head from
+ * `<tmpRoot>/gate-context/**` (written by write-gate-context.mjs as
+ * `<gate>-<headSha>.briefing-prefix.txt`). Returns a Map from the record's
+ * sha256 (the exact bytes reviewers hash via `--prefix-file`) to its gate name.
+ * These records are the authoritative per-(gate, headSha) proof each reviewer
+ * sentinel is verified against — a sentinel hash that matches no record is a
+ * contaminated/stale briefing. Empty Map when none exist (offline/legacy),
+ * which routes evaluation to the conservative flat fallback.
+ * @param {string} tmpRoot
+ * @param {string} headSha — lowercase hex, already validated
+ * @returns {Promise<Map<string,string>>} sha256 -> gate
+ */
+async function readGateBriefingRecords(tmpRoot, headSha) {
+  const root = path.join(tmpRoot, "gate-context");
+  let entries;
+  try {
+    entries = await readdir(root, { withFileTypes: true, recursive: true });
+  } catch (err) {
+    if (err.code === "ENOENT") return new Map();
+    throw err;
   }
-  return "";
+  const suffix = `-${headSha}${BRIEFING_PREFIX_SUFFIX}`;
+  const records = new Map();
+  for (const e of entries) {
+    if (!e.isFile() || !e.name.endsWith(suffix)) continue;
+    const gate = e.name.slice(0, -suffix.length);
+    if (gate.length === 0) continue;
+    const dir = e.parentPath ?? e.path ?? root;
+    let bytes;
+    try {
+      bytes = await readFile(path.join(dir, e.name));
+    } catch {
+      continue; // unreadable record: skip; a sentinel relying on it fails closed as unknown
+    }
+    const hash = createHash("sha256").update(bytes).digest("hex");
+    if (!records.has(hash)) records.set(hash, gate);
+  }
+  return records;
 }
 
 /**
- * Evaluate a SINGLE gate's (or the ungated legacy) reviewer sentinels for the
- * round: every sentinel must record a hash (no grandfathering) and all recorded
- * hashes must be identical (byte-identical seeded briefings).
+ * Pure comparison: decide verified/reason/missing/mismatched for the round.
+ * Exported for direct unit testing without touching the filesystem.
+ *
+ * When `gateRecords` (sha256 -> gate, from the on-disk `<gate>-<headSha>`
+ * briefing-prefix records) is non-empty, EVERY sentinel's recorded prefix hash
+ * must match one of those authoritative records; a hash matching none is a
+ * contaminated/stale briefing and fails closed. This is what lets two gates
+ * legitimately reviewed at ONE head both pass — each verifies against its own
+ * gate's record — without a spurious cross-gate mismatch, while a genuinely
+ * wrong hash still fails regardless of what scope string the reviewer used
+ * (the fix for the false fail-closed AND the fail-open the scope-prefix
+ * approach would have introduced). When no records exist (offline/legacy) it
+ * falls back to the conservative flat check: all sentinels must share one hash.
+ * A missing/hashless sentinel always fails closed (never grandfathered).
+ *
  * @param {Array<{ scope: string, prefixHash: string|null }>} sentinels
- * @param {string} [gateLabel] — prefixed onto the reason when > 1 gate shares the head
- * @returns {{ verified: boolean, reason?: string, missing?: string[], mismatched?: Array<{scope:string, prefixHash:string}>, prefixHash?: string }}
+ * @param {Map<string,string>|null} [gateRecords] — sha256 -> gate
+ * @returns {{ verified: boolean, reason?: string, missing?: string[], mismatched?: Array<{scope:string, prefixHash:string}>, prefixHash?: string, gates?: Array<{gate:string, prefixHash:string, reviewerCount:number}> }}
  */
-function evaluateGroup(sentinels, gateLabel = "") {
-  const where = gateLabel ? ` (gate "${gateLabel}")` : "";
-  // A hashless sentinel fails closed even when it is the ONLY sentinel (a
-  // one-angle Phase-5 retry round is a real case): "never grandfathered" means
-  // the invariant-prefix proof must exist for every reviewer, not just when a
-  // sibling exists to compare against. A single HASHED sentinel stays verified —
-  // with one recorded hash there is nothing to mismatch.
+export function evaluateBriefingPrefixes(sentinels, gateRecords = null) {
+  if (sentinels.length === 0) {
+    return { verified: true, reason: "no sentinels found for this round" };
+  }
   const missing = sentinels.filter((s) => s.prefixHash === null).map((s) => s.scope);
   if (missing.length > 0) {
     return {
       verified: false,
-      reason: `${missing.length} of ${sentinels.length} reviewer sentinel(s) for this round${where} have no recorded prefix hash — the invariant-briefing-prefix proof (GATE-EXEC-BRIEFING-PREFIX) was never established for them. Missing hashes are treated as a mismatch, not grandfathered in.`,
+      reason: `${missing.length} of ${sentinels.length} reviewer sentinel(s) for this round have no recorded prefix hash — the invariant-briefing-prefix proof (GATE-EXEC-BRIEFING-PREFIX) was never established for them. Missing hashes are treated as a mismatch, not grandfathered in.`,
       missing,
     };
   }
-  const distinct = new Map();
-  for (const { scope, prefixHash } of sentinels) {
-    if (!distinct.has(prefixHash)) distinct.set(prefixHash, []);
-    distinct.get(prefixHash).push(scope);
+  const records = gateRecords instanceof Map ? gateRecords : new Map();
+  if (records.size === 0) {
+    // Flat fallback (pre-record behavior, conservative fail-closed): with no
+    // authoritative records to attribute sentinels to gates, all sentinels must
+    // record ONE identical hash. Two distinct hashes fail closed.
+    const distinct = new Map();
+    for (const { scope, prefixHash } of sentinels) {
+      if (!distinct.has(prefixHash)) distinct.set(prefixHash, []);
+      distinct.get(prefixHash).push(scope);
+    }
+    if (distinct.size > 1) {
+      return {
+        verified: false,
+        reason: `Reviewer sentinels for this round recorded ${distinct.size} DIFFERENT invariant-briefing prefix hashes and no on-disk gate briefing-prefix records were found to attribute them per gate — the seeded briefings were not byte-identical (GATE-EXEC-BRIEFING-PREFIX).`,
+        mismatched: sentinels.map(({ scope, prefixHash }) => ({ scope, prefixHash })),
+      };
+    }
+    return { verified: true, prefixHash: sentinels[0].prefixHash };
   }
-  if (distinct.size > 1) {
-    const mismatched = sentinels.map(({ scope, prefixHash }) => ({ scope, prefixHash }));
+  // Record-matching: every sentinel hash must match a real (gate, headSha) record.
+  const unknown = sentinels.filter((s) => !records.has(s.prefixHash));
+  if (unknown.length > 0) {
     return {
       verified: false,
-      reason: `Reviewer sentinels for this round${where} recorded ${distinct.size} DIFFERENT invariant-briefing prefix hashes — the seeded briefings were not byte-identical (GATE-EXEC-BRIEFING-PREFIX).`,
-      mismatched,
+      reason: `${unknown.length} of ${sentinels.length} reviewer sentinel(s) recorded an invariant-briefing prefix hash that matches no gate briefing-prefix record for this head — a contaminated, stale, or hand-edited briefing (GATE-EXEC-BRIEFING-PREFIX). Never grandfathered.`,
+      mismatched: unknown.map(({ scope, prefixHash }) => ({ scope, prefixHash })),
     };
   }
-  return { verified: true, prefixHash: sentinels[0].prefixHash };
-}
-
-/**
- * Pure comparison: given the round's sentinels, decide verified/reason/missing/mismatched.
- * Exported for direct unit testing without touching the filesystem.
- *
- * Sentinels are first PARTITIONED BY GATE (recovered from the scope's `<gate>-`
- * prefix), then each gate's reviewers are evaluated independently. This is the
- * fix for the false fail-closed when two gates run at one head: a small change
- * that clears draft_gate and pre_approval_gate without an intervening push writes
- * both gates' sentinels under the SAME head SHA, and each gate legitimately has
- * its own (different) invariant-briefing hash. Comparing across gates flagged
- * that as a mismatch; comparing WITHIN each gate does not. The real invariant —
- * reviewers of ONE gate pass must share a byte-identical briefing — is preserved
- * per group. Ungated (legacy bare-angle) scopes form one group with the original
- * behavior.
- *
- * @param {Array<{ scope: string, prefixHash: string|null }>} sentinels
- * @returns {{ verified: boolean, reason?: string, missing?: string[], mismatched?: Array<{scope:string, prefixHash:string}>, prefixHash?: string, gates?: Array<{gate:string, prefixHash:string}> }}
- */
-export function evaluateBriefingPrefixes(sentinels) {
-  if (sentinels.length === 0) {
-    return { verified: true, reason: "no sentinels found for this round" };
+  const byGate = new Map();
+  for (const { prefixHash } of sentinels) {
+    const gate = records.get(prefixHash);
+    if (!byGate.has(gate)) byGate.set(gate, { gate, prefixHash, reviewerCount: 0 });
+    byGate.get(gate).reviewerCount += 1;
   }
-  const groups = new Map();
-  for (const s of sentinels) {
-    const gate = gateOfScope(s.scope);
-    if (!groups.has(gate)) groups.set(gate, []);
-    groups.get(gate).push(s);
-  }
-  // Single group (one gate, or all-ungated legacy) keeps the exact original
-  // shape, including the top-level `prefixHash` on success.
-  if (groups.size === 1) {
-    return evaluateGroup([...groups.values()][0]);
-  }
-  // Multiple gates share this head: verified only when EVERY gate's own
-  // reviewers are internally consistent. Fail closed on the first bad gate.
-  const gates = [];
-  for (const [gate, group] of groups) {
-    const result = evaluateGroup(group, gate || "ungated");
-    if (!result.verified) return { ...result, gate: gate || "ungated" };
-    gates.push({ gate: gate || "ungated", prefixHash: result.prefixHash });
+  const gates = [...byGate.values()].sort((a, b) => a.gate.localeCompare(b.gate));
+  if (gates.length === 1) {
+    return { verified: true, prefixHash: gates[0].prefixHash, gates };
   }
   return { verified: true, gates };
 }
@@ -230,7 +250,8 @@ export async function main(argv = process.argv.slice(2), { tmpRoot = path.join(p
   const silent = argv.includes("--silent") || argv.includes("-s");
 
   const sentinels = await readRoundSentinels(tmpRoot, headSha);
-  const verdict = evaluateBriefingPrefixes(sentinels);
+  const gateRecords = await readGateBriefingRecords(tmpRoot, headSha);
+  const verdict = evaluateBriefingPrefixes(sentinels, gateRecords);
   const payload = {
     ok: true,
     verified: verdict.verified,
@@ -240,6 +261,7 @@ export async function main(argv = process.argv.slice(2), { tmpRoot = path.join(p
     ...(verdict.missing ? { missing: verdict.missing } : {}),
     ...(verdict.mismatched ? { mismatched: verdict.mismatched } : {}),
     ...(verdict.prefixHash ? { prefixHash: verdict.prefixHash } : {}),
+    ...(verdict.gates ? { gates: verdict.gates } : {}),
   };
   return emitResult(payload, { jq, silent, ok: verdict.verified });
 }

--- a/scripts/github/verify-briefing-prefixes.mjs
+++ b/scripts/github/verify-briefing-prefixes.mjs
@@ -155,8 +155,8 @@ async function readGateBriefingRecords(tmpRoot, headSha) {
   const records = new Map();
   const matches = entries
     .filter((e) => e.isFile() && e.name.endsWith(suffix) && e.name.length > suffix.length)
-    // readdir order is filesystem-dependent; sort by name so a same-hash
-    // collision's first-seen-wins Map entry is deterministic across runs.
+    // readdir order is filesystem-dependent; sort by name so the hash->Set<gate>
+    // index is built in a deterministic order across runs.
     .sort((a, b) => a.name.localeCompare(b.name));
   for (const e of matches) {
     const gate = e.name.slice(0, -suffix.length);
@@ -180,20 +180,24 @@ async function readGateBriefingRecords(tmpRoot, headSha) {
 /**
  * Gate a reviewer scope self-declares, matched against the canonical gate
  * vocabulary (hyphenated to the `--scope` form, since scopes forbid
- * underscores). Uses the LONGEST matching prefix so a future gate whose name
- * string-extends another is attributed correctly. Returns null for a bare/legacy
- * scope with no recognized gate prefix — those are matched by hash alone.
+ * underscores). Matching is case-insensitive (`--scope` permits mixed case;
+ * a mis-cased scope must still be attributed to its gate rather than falling
+ * through to the bare-scope path and bypassing the wrong-gate check). Uses
+ * the LONGEST matching prefix so a future gate whose name string-extends
+ * another is attributed correctly. Returns null for a bare/legacy scope with
+ * no recognized gate prefix — those are matched by hash alone.
  * Exported for direct testing.
  * @param {string} scope
  * @param {string[]} [gateNames]
  * @returns {string|null}
  */
 export function declaredGateOf(scope, gateNames = GATE_NAMES) {
+  const s = scope.toLowerCase();
   let best = null;
   let bestLen = -1;
   for (const gate of gateNames) {
     const prefix = gate.replace(/_/g, "-");
-    if ((scope === prefix || scope.startsWith(`${prefix}-`)) && prefix.length > bestLen) {
+    if ((s === prefix || s.startsWith(`${prefix}-`)) && prefix.length > bestLen) {
       best = gate;
       bestLen = prefix.length;
     }

--- a/scripts/github/verify-briefing-prefixes.mjs
+++ b/scripts/github/verify-briefing-prefixes.mjs
@@ -7,10 +7,13 @@ import { JQ_OUTPUT_USAGE, emitResult } from "../lib/jq-output.mjs";
 
 const USAGE = `Usage: verify-briefing-prefixes.mjs --head-sha <sha> [--help]
 Fan-in enforcement for GATE-EXEC-BRIEFING-PREFIX (docs/gate-review-sub-loop-contract.md):
-fails closed when this gate-review round's per-scope reviewer sentinels (written by
-verify-fresh-review-context.mjs --prefix-hash/--prefix-file) do not all record the SAME
-invariant-briefing prefix hash. Deterministic and offline: reads only the sentinel files
-already on disk under tmp/, keyed by the given head SHA.
+fails closed when a reviewer sentinel's (written by verify-fresh-review-context.mjs
+--prefix-hash/--prefix-file) recorded prefix hash matches no on-disk per-gate
+briefing-prefix record for this head, matches a DIFFERENT gate than the sentinel's
+scope declares, or is missing outright. When no per-gate records exist it falls
+back to requiring all of this round's sentinels to share ONE hash. Deterministic
+and offline: reads only the sentinel and record files already on disk under tmp/,
+keyed by the given head SHA.
 
 Required:
   --head-sha <sha>  The FULL 40-char reviewed head SHA (git rev-parse HEAD); sentinels are read from
@@ -18,7 +21,8 @@ Required:
 
 Output (stdout, JSON):
   { "ok": true, "verified": true, "headSha": "...", "reviewerCount": <n>, "prefixHash": "..." }
-  { "ok": true, "verified": true, "headSha": "...", "reviewerCount": <n>, "gates": [{ "gate": "draft_gate", "prefixHash": "...", "reviewerCount": <n> }, ...] }
+  { "ok": true, "verified": true, "headSha": "...", "reviewerCount": <n>, "prefixHash": "...", "gates": [{ "gate": "draft_gate", "prefixHash": "...", "reviewerCount": <n> }] }
+  { "ok": true, "verified": true, "headSha": "...", "reviewerCount": <n>, "gates": [{ "gate": "draft_gate", "prefixHash": "...", "reviewerCount": <n> }, { "gate": "pre_approval_gate", "prefixHash": "...", "reviewerCount": <n> }] }
   { "ok": true, "verified": true, "headSha": "...", "reviewerCount": 0, "reason": "no sentinels found for this round" }
   { "ok": true, "verified": false, "headSha": "...", "reviewerCount": <n>, "reason": "...", "missing": [...], "mismatched": [...] }
   On error (stderr, JSON):
@@ -38,9 +42,12 @@ the on-disk per-gate briefing-prefix records (<gate>-<headSha>.briefing-prefix.t
 under tmp/gate-context/, written by write-gate-context.mjs). Two gates reviewed
 at the SAME head (e.g. a small change clearing draft_gate and pre_approval_gate
 without an intervening push) each verify against their own record instead of
-colliding into a spurious mismatch, and a hash matching no record fails closed
-regardless of the reviewer's scope string. When no records are present the check
-falls back to the conservative flat rule (all sentinels must share one hash).
+colliding into a spurious mismatch, and a hash matching no record fails closed.
+A sentinel whose scope self-declares a gate (e.g. "draft-gate-coverage") must
+also match THAT gate's record — a hash that matches a DIFFERENT gate's record
+is a wrong-gate briefing and fails closed even though the hash itself is known.
+When no records are present the check falls back to the conservative flat rule
+(all sentinels must share one hash).
 Never manually clear sentinels.`.trim();
 
 // Full 40-char SHA required: sentinel filenames embed the full `git rev-parse
@@ -138,11 +145,14 @@ async function readGateBriefingRecords(tmpRoot, headSha) {
   }
   const suffix = `-${headSha}${BRIEFING_PREFIX_SUFFIX}`;
   const records = new Map();
-  for (const e of entries) {
-    if (!e.isFile() || !e.name.endsWith(suffix)) continue;
+  const matches = entries
+    .filter((e) => e.isFile() && e.name.endsWith(suffix) && e.name.length > suffix.length)
+    // readdir order is filesystem-dependent; sort by name so a same-hash
+    // collision's first-seen-wins Map entry is deterministic across runs.
+    .sort((a, b) => a.name.localeCompare(b.name));
+  for (const e of matches) {
     const gate = e.name.slice(0, -suffix.length);
-    if (gate.length === 0) continue;
-    const dir = e.parentPath ?? e.path ?? root;
+    const dir = e.parentPath ?? root;
     let bytes;
     try {
       bytes = await readFile(path.join(dir, e.name));
@@ -153,6 +163,24 @@ async function readGateBriefingRecords(tmpRoot, headSha) {
     if (!records.has(hash)) records.set(hash, gate);
   }
   return records;
+}
+
+/**
+ * Gate a reviewer scope self-declares, using ONLY the gate vocabulary present in
+ * the on-disk records (hyphenated to match the `--scope` form, since scopes
+ * forbid underscores). Returns null for a bare/legacy scope with no recognized
+ * gate prefix — those are matched by hash alone. No hardcoded gate list: the
+ * vocabulary comes from the records themselves.
+ * @param {string} scope
+ * @param {Iterable<string>} knownGates
+ * @returns {string|null}
+ */
+function declaredGateOf(scope, knownGates) {
+  for (const gate of knownGates) {
+    const prefix = gate.replace(/_/g, "-");
+    if (scope === prefix || scope.startsWith(`${prefix}-`)) return gate;
+  }
+  return null;
 }
 
 /**
@@ -213,6 +241,23 @@ export function evaluateBriefingPrefixes(sentinels, gateRecords = null) {
       verified: false,
       reason: `${unknown.length} of ${sentinels.length} reviewer sentinel(s) recorded an invariant-briefing prefix hash that matches no gate briefing-prefix record for this head — a contaminated, stale, or hand-edited briefing (GATE-EXEC-BRIEFING-PREFIX). Never grandfathered.`,
       mismatched: unknown.map(({ scope, prefixHash }) => ({ scope, prefixHash })),
+    };
+  }
+  // Cross-gate check: when a sentinel's scope self-declares a gate, its matched
+  // record must belong to THAT gate. A hash that matches a DIFFERENT gate's
+  // record (a wrong-gate briefing) fails closed even though the hash is known.
+  const knownGates = new Set(records.values());
+  const wrongGate = sentinels
+    .filter((s) => {
+      const declared = declaredGateOf(s.scope, knownGates);
+      return declared !== null && records.get(s.prefixHash) !== declared;
+    })
+    .map(({ scope, prefixHash }) => ({ scope, prefixHash }));
+  if (wrongGate.length > 0) {
+    return {
+      verified: false,
+      reason: `${wrongGate.length} of ${sentinels.length} reviewer sentinel(s) recorded a prefix hash belonging to a DIFFERENT gate than their scope declares — a wrong-gate briefing (GATE-EXEC-BRIEFING-PREFIX).`,
+      mismatched: wrongGate,
     };
   }
   const byGate = new Map();

--- a/scripts/github/verify-briefing-prefixes.mjs
+++ b/scripts/github/verify-briefing-prefixes.mjs
@@ -38,8 +38,10 @@ Exit codes:
      identical hash
   1  Fail closed: a sentinel hash matches no on-disk gate record, or matches a
      DIFFERENT gate than its scope declares (wrong-gate briefing), or any
-     sentinel records no prefix hash — never grandfathered; or, with no
-     records, two or more sentinels record different hashes
+     sentinel records no prefix hash — never grandfathered; or two or more
+     sentinels attributed to the SAME gate recorded DIFFERENT prefix hashes
+     (within-gate briefings were not byte-identical); or, with no records,
+     two or more sentinels record different hashes
   2  Usage or internal error, or invalid --jq filter
 
 Gate scoping: each reviewer sentinel's recorded prefix hash is verified against
@@ -51,8 +53,11 @@ colliding into a spurious mismatch, and a hash matching no record fails closed.
 A sentinel whose scope self-declares a gate (e.g. "draft-gate-coverage") must
 also match THAT gate's record — a hash that matches a DIFFERENT gate's record
 is a wrong-gate briefing and fails closed even though the hash itself is known.
-When no records are present the check falls back to the conservative flat rule
-(all sentinels must share one hash).
+Beyond per-sentinel matching, all reviewers attributed to ONE gate must share
+ONE identical prefix hash — two DIFFERENT hashes for the same gate fails closed
+as a within-gate byte-identity violation, even when each hash individually
+matches a known record. When no records are present the check falls back to
+the conservative flat rule (all sentinels must share one hash).
 Never manually clear sentinels.`.trim();
 
 // Full 40-char SHA required: sentinel filenames embed the full `git rev-parse

--- a/scripts/github/verify-briefing-prefixes.mjs
+++ b/scripts/github/verify-briefing-prefixes.mjs
@@ -130,14 +130,17 @@ const BRIEFING_PREFIX_SUFFIX = ".briefing-prefix.txt";
  * Read the per-gate invariant-briefing records for this head from
  * `<tmpRoot>/gate-context/**` (written by write-gate-context.mjs as
  * `<gate>-<headSha>.briefing-prefix.txt`). Returns a Map from the record's
- * sha256 (the exact bytes reviewers hash via `--prefix-file`) to its gate name.
- * These records are the authoritative per-(gate, headSha) proof each reviewer
- * sentinel is verified against — a sentinel hash that matches no record is a
- * contaminated/stale briefing. Empty Map when none exist (offline/legacy),
- * which routes evaluation to the conservative flat fallback.
+ * sha256 (the exact bytes reviewers hash via `--prefix-file`) to the set of
+ * gate names whose record has that exact hash (normally one gate; a shared
+ * hash across gates is possible in principle and must not false-fail the
+ * wrong-gate check). These records are the authoritative per-(gate, headSha)
+ * proof each reviewer sentinel is verified against — a sentinel hash that
+ * matches no record is a contaminated/stale briefing. Empty Map when none
+ * exist (offline/legacy), which routes evaluation to the conservative flat
+ * fallback.
  * @param {string} tmpRoot
  * @param {string} headSha — lowercase hex, already validated
- * @returns {Promise<Map<string,string>>} sha256 -> gate
+ * @returns {Promise<Map<string, Set<string>>>} sha256 -> set of gates
  */
 async function readGateBriefingRecords(tmpRoot, headSha) {
   const root = path.join(tmpRoot, "gate-context");
@@ -168,7 +171,8 @@ async function readGateBriefingRecords(tmpRoot, headSha) {
       continue; // unreadable record: skip; a sentinel relying on it fails closed as unknown
     }
     const hash = createHash("sha256").update(bytes).digest("hex");
-    if (!records.has(hash)) records.set(hash, gate);
+    if (!records.has(hash)) records.set(hash, new Set());
+    records.get(hash).add(gate);
   }
   return records;
 }
@@ -201,22 +205,26 @@ export function declaredGateOf(scope, gateNames = GATE_NAMES) {
  * Pure comparison: decide verified/reason/missing/mismatched for the round.
  * Exported for direct unit testing without touching the filesystem.
  *
- * When `gateRecords` (sha256 -> gate, from the on-disk `<gate>-<headSha>`
+ * When `gateRecords` (sha256 -> Set<gate>, from the on-disk `<gate>-<headSha>`
  * briefing-prefix records) is non-empty, EVERY sentinel's recorded prefix hash
  * must match one of those authoritative records; a hash matching none is a
  * contaminated/stale briefing and fails closed. This is what lets two gates
  * legitimately reviewed at ONE head both pass — each verifies against its own
  * gate's record — without a spurious cross-gate mismatch. When a sentinel's
  * scope self-declares a gate (against the canonical GATE_NAMES vocabulary),
- * its matched record must belong to that SAME gate: a known hash that instead
- * belongs to a different gate's record fails closed as a wrong-gate briefing
- * (the fix for the false fail-closed AND the fail-open the scope-prefix
- * approach would have introduced). When no records exist (offline/legacy) it
- * falls back to the conservative flat check: all sentinels must share one hash.
+ * its matched record's gate set must contain that SAME gate: a known hash that
+ * instead belongs only to a different gate's record fails closed as a
+ * wrong-gate briefing (the fix for the false fail-closed AND the fail-open the
+ * scope-prefix approach would have introduced). Beyond per-sentinel matching,
+ * every reviewer attributed to the SAME gate must share ONE identical prefix
+ * hash — two distinct hashes for one gate fails closed as a within-gate
+ * byte-identity violation (AC2), even though each hash individually matches a
+ * known record for that gate. When no records exist (offline/legacy) it falls
+ * back to the conservative flat check: all sentinels must share one hash.
  * A missing/hashless sentinel always fails closed (never grandfathered).
  *
  * @param {Array<{ scope: string, prefixHash: string|null }>} sentinels
- * @param {Map<string,string>|null} [gateRecords] — sha256 -> gate
+ * @param {Map<string, Set<string>>|null} [gateRecords] — sha256 -> set of gates
  * @returns {{ verified: boolean, reason?: string, missing?: string[], mismatched?: Array<{scope:string, prefixHash:string}>, prefixHash?: string, gates?: Array<{gate:string, prefixHash:string, reviewerCount:number}> }}
  */
 export function evaluateBriefingPrefixes(sentinels, gateRecords = null) {
@@ -250,7 +258,9 @@ export function evaluateBriefingPrefixes(sentinels, gateRecords = null) {
     }
     return { verified: true, prefixHash: sentinels[0].prefixHash };
   }
-  // Record-matching: every sentinel hash must match a real (gate, headSha) record.
+  // Record-matching: every sentinel hash must match an on-disk record; a scope
+  // that declares a gate must match a record for THAT gate; and all reviewers
+  // attributed to one gate must share ONE hash (within-gate byte-identity, AC2).
   const unknown = sentinels.filter((s) => !records.has(s.prefixHash));
   if (unknown.length > 0) {
     return {
@@ -259,15 +269,27 @@ export function evaluateBriefingPrefixes(sentinels, gateRecords = null) {
       mismatched: unknown.map(({ scope, prefixHash }) => ({ scope, prefixHash })),
     };
   }
-  // Cross-gate check: when a sentinel's scope self-declares a gate, its matched
-  // record must belong to THAT gate. A hash that matches a DIFFERENT gate's
-  // record (a wrong-gate briefing) fails closed even though the hash is known.
-  const wrongGate = sentinels
-    .filter((s) => {
-      const declared = declaredGateOf(s.scope);
-      return declared !== null && records.get(s.prefixHash) !== declared;
-    })
-    .map(({ scope, prefixHash }) => ({ scope, prefixHash }));
+  // Attribute each sentinel to a gate and detect wrong-gate briefings.
+  const wrongGate = [];
+  const attributed = []; // { scope, prefixHash, gate }
+  for (const s of sentinels) {
+    const gatesForHash = records.get(s.prefixHash); // Set<gate>, non-empty
+    const declared = declaredGateOf(s.scope);
+    if (declared !== null) {
+      if (!gatesForHash.has(declared)) {
+        wrongGate.push({ scope: s.scope, prefixHash: s.prefixHash });
+        continue;
+      }
+      attributed.push({ scope: s.scope, prefixHash: s.prefixHash, gate: declared });
+    } else {
+      // Bare/legacy scope: attribute by the record's gate. A hash mapping to
+      // multiple gates (byte-identical briefings across gates — practically
+      // impossible since the gate is embedded in the hashed bytes) is resolved
+      // deterministically to the alphabetically-first gate for a stable summary.
+      const gate = gatesForHash.size === 1 ? [...gatesForHash][0] : [...gatesForHash].sort()[0];
+      attributed.push({ scope: s.scope, prefixHash: s.prefixHash, gate });
+    }
+  }
   if (wrongGate.length > 0) {
     return {
       verified: false,
@@ -275,13 +297,28 @@ export function evaluateBriefingPrefixes(sentinels, gateRecords = null) {
       mismatched: wrongGate,
     };
   }
-  const byGate = new Map();
-  for (const { prefixHash } of sentinels) {
-    const gate = records.get(prefixHash);
-    if (!byGate.has(gate)) byGate.set(gate, { gate, prefixHash, reviewerCount: 0 });
-    byGate.get(gate).reviewerCount += 1;
+  // Within-gate byte-identity: every reviewer attributed to one gate must share
+  // one hash. Two distinct hashes for the same gate (e.g. multiple same-gate
+  // records at this head) fails closed — the byte-identity invariant (AC2).
+  const gateHashes = new Map(); // gate -> Set<hash>
+  const gateCounts = new Map(); // gate -> count
+  for (const a of attributed) {
+    if (!gateHashes.has(a.gate)) gateHashes.set(a.gate, new Set());
+    gateHashes.get(a.gate).add(a.prefixHash);
+    gateCounts.set(a.gate, (gateCounts.get(a.gate) ?? 0) + 1);
   }
-  const gates = [...byGate.values()].sort((a, b) => a.gate.localeCompare(b.gate));
+  const split = [...gateHashes.entries()].find(([, hs]) => hs.size > 1);
+  if (split) {
+    const [g] = split;
+    return {
+      verified: false,
+      reason: `Reviewer sentinels for gate ${g} recorded ${split[1].size} DIFFERENT invariant-briefing prefix hashes — within-gate briefings were not byte-identical (GATE-EXEC-BRIEFING-PREFIX).`,
+      mismatched: attributed.filter((a) => a.gate === g).map(({ scope, prefixHash }) => ({ scope, prefixHash })),
+    };
+  }
+  const gates = [...gateHashes.entries()]
+    .map(([gate, hs]) => ({ gate, prefixHash: [...hs][0], reviewerCount: gateCounts.get(gate) }))
+    .sort((a, b) => a.gate.localeCompare(b.gate));
   if (gates.length === 1) {
     return { verified: true, prefixHash: gates[0].prefixHash, gates };
   }

--- a/scripts/github/verify-briefing-prefixes.mjs
+++ b/scripts/github/verify-briefing-prefixes.mjs
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 import path from "node:path";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { JQ_OUTPUT_USAGE, emitResult } from "../lib/jq-output.mjs";
+import { GATE_NAMES } from "./_gate-names.mjs";
 
 const USAGE = `Usage: verify-briefing-prefixes.mjs --head-sha <sha> [--help]
 Fan-in enforcement for GATE-EXEC-BRIEFING-PREFIX (docs/gate-review-sub-loop-contract.md):
@@ -29,12 +30,16 @@ Output (stdout, JSON):
   { "ok": false, "error": "...", "usage": "..." }
 ${JQ_OUTPUT_USAGE}
 Exit codes:
-  0  Verified: no sentinels found for this round (nothing to check), or every
-     sentinel records a hash and all hashes are identical (a single hashed
-     sentinel verifies — nothing to mismatch)
-  1  Fail closed: two or more sentinels record DIFFERENT prefix hashes, or ANY
-     sentinel for the round (even a lone one) records no prefix hash — a missing
-     hash is treated as a mismatch, never grandfathered
+  0  Verified: no sentinels found for this round (nothing to check); OR, with
+     on-disk per-gate briefing records present, every sentinel's hash matches a
+     record AND matches the gate its scope declares (two gates reviewed at one
+     head each match their own record, so a verified round can involve
+     different per-gate hashes); OR, with no records, all sentinels share one
+     identical hash
+  1  Fail closed: a sentinel hash matches no on-disk gate record, or matches a
+     DIFFERENT gate than its scope declares (wrong-gate briefing), or any
+     sentinel records no prefix hash — never grandfathered; or, with no
+     records, two or more sentinels record different hashes
   2  Usage or internal error, or invalid --jq filter
 
 Gate scoping: each reviewer sentinel's recorded prefix hash is verified against
@@ -166,21 +171,27 @@ async function readGateBriefingRecords(tmpRoot, headSha) {
 }
 
 /**
- * Gate a reviewer scope self-declares, using ONLY the gate vocabulary present in
- * the on-disk records (hyphenated to match the `--scope` form, since scopes
- * forbid underscores). Returns null for a bare/legacy scope with no recognized
- * gate prefix — those are matched by hash alone. No hardcoded gate list: the
- * vocabulary comes from the records themselves.
+ * Gate a reviewer scope self-declares, matched against the canonical gate
+ * vocabulary (hyphenated to the `--scope` form, since scopes forbid
+ * underscores). Uses the LONGEST matching prefix so a future gate whose name
+ * string-extends another is attributed correctly. Returns null for a bare/legacy
+ * scope with no recognized gate prefix — those are matched by hash alone.
+ * Exported for direct testing.
  * @param {string} scope
- * @param {Iterable<string>} knownGates
+ * @param {string[]} [gateNames]
  * @returns {string|null}
  */
-function declaredGateOf(scope, knownGates) {
-  for (const gate of knownGates) {
+export function declaredGateOf(scope, gateNames = GATE_NAMES) {
+  let best = null;
+  let bestLen = -1;
+  for (const gate of gateNames) {
     const prefix = gate.replace(/_/g, "-");
-    if (scope === prefix || scope.startsWith(`${prefix}-`)) return gate;
+    if ((scope === prefix || scope.startsWith(`${prefix}-`)) && prefix.length > bestLen) {
+      best = gate;
+      bestLen = prefix.length;
+    }
   }
-  return null;
+  return best;
 }
 
 /**
@@ -192,8 +203,10 @@ function declaredGateOf(scope, knownGates) {
  * must match one of those authoritative records; a hash matching none is a
  * contaminated/stale briefing and fails closed. This is what lets two gates
  * legitimately reviewed at ONE head both pass — each verifies against its own
- * gate's record — without a spurious cross-gate mismatch, while a genuinely
- * wrong hash still fails regardless of what scope string the reviewer used
+ * gate's record — without a spurious cross-gate mismatch. When a sentinel's
+ * scope self-declares a gate (against the canonical GATE_NAMES vocabulary),
+ * its matched record must belong to that SAME gate: a known hash that instead
+ * belongs to a different gate's record fails closed as a wrong-gate briefing
  * (the fix for the false fail-closed AND the fail-open the scope-prefix
  * approach would have introduced). When no records exist (offline/legacy) it
  * falls back to the conservative flat check: all sentinels must share one hash.
@@ -246,10 +259,9 @@ export function evaluateBriefingPrefixes(sentinels, gateRecords = null) {
   // Cross-gate check: when a sentinel's scope self-declares a gate, its matched
   // record must belong to THAT gate. A hash that matches a DIFFERENT gate's
   // record (a wrong-gate briefing) fails closed even though the hash is known.
-  const knownGates = new Set(records.values());
   const wrongGate = sentinels
     .filter((s) => {
-      const declared = declaredGateOf(s.scope, knownGates);
+      const declared = declaredGateOf(s.scope);
       return declared !== null && records.get(s.prefixHash) !== declared;
     })
     .map(({ scope, prefixHash }) => ({ scope, prefixHash }));

--- a/scripts/github/verify-briefing-prefixes.mjs
+++ b/scripts/github/verify-briefing-prefixes.mjs
@@ -31,11 +31,14 @@ Exit codes:
      hash is treated as a mismatch, never grandfathered
   2  Usage or internal error, or invalid --jq filter
 
-Caveat: rounds are keyed by head SHA only. Two different gates reviewed at the
-SAME head share one sentinel namespace, so run this check per gate pass (the head
-advances between gate passes per GATE-EXEC-REGATE-MANDATORY; never manually clear sentinels); legitimately different per-gate prefixes at an identical
-head would otherwise flag as a mismatch (conservative fail-closed, never
-fail-open).`.trim();
+Gate scoping: sentinels are partitioned by gate (recovered from the reviewer
+scope's <gate>- prefix, e.g. draft-gate-<angle> / pre-approval-gate-<angle>) and
+each gate's reviewers are verified independently. Two gates reviewed at the SAME
+head (e.g. a small change clearing draft_gate and pre_approval_gate without an
+intervening push) therefore each verify against their own prefix record instead
+of colliding into a spurious mismatch. Within one gate the byte-identity check is
+unchanged. Bare-angle scopes with no recognized gate prefix form one "ungated"
+group (legacy behavior). Never manually clear sentinels.`.trim();
 
 // Full 40-char SHA required: sentinel filenames embed the full `git rev-parse
 // HEAD` value, so a short prefix would glob zero sentinels and read as a
@@ -106,16 +109,32 @@ async function readRoundSentinels(tmpRoot, headSha) {
   return results;
 }
 
-/**
- * Pure comparison: given the round's sentinels, decide verified/reason/missing/mismatched.
- * Exported for direct unit testing without touching the filesystem.
- * @param {Array<{ scope: string, prefixHash: string|null }>} sentinels
- * @returns {{ verified: boolean, reason?: string, missing?: string[], mismatched?: Array<{scope:string, prefixHash:string}> }}
- */
-export function evaluateBriefingPrefixes(sentinels) {
-  if (sentinels.length === 0) {
-    return { verified: true, reason: "no sentinels found for this round" };
+// Gate prefixes a reviewer scope may carry (hyphenated form of the gate names,
+// since `--scope` forbids underscores). write-gate-context.mjs renders the
+// reviewer instruction with a `<gate>-<angle>` scope so each reviewer's sentinel
+// self-identifies its gate. Ordered longest-first for unambiguous prefix match.
+const GATE_SCOPE_PREFIXES = ["pre-approval-gate", "draft-gate"];
+
+// Recover the gate a sentinel belongs to from its scope. A scope that carries no
+// recognized gate prefix is "ungated" (legacy bare-angle scope) and all such
+// sentinels share one implicit group — preserving pre-gate-scoping behavior.
+function gateOfScope(scope) {
+  for (const gate of GATE_SCOPE_PREFIXES) {
+    if (scope === gate || scope.startsWith(`${gate}-`)) return gate;
   }
+  return "";
+}
+
+/**
+ * Evaluate a SINGLE gate's (or the ungated legacy) reviewer sentinels for the
+ * round: every sentinel must record a hash (no grandfathering) and all recorded
+ * hashes must be identical (byte-identical seeded briefings).
+ * @param {Array<{ scope: string, prefixHash: string|null }>} sentinels
+ * @param {string} [gateLabel] — prefixed onto the reason when > 1 gate shares the head
+ * @returns {{ verified: boolean, reason?: string, missing?: string[], mismatched?: Array<{scope:string, prefixHash:string}>, prefixHash?: string }}
+ */
+function evaluateGroup(sentinels, gateLabel = "") {
+  const where = gateLabel ? ` (gate "${gateLabel}")` : "";
   // A hashless sentinel fails closed even when it is the ONLY sentinel (a
   // one-angle Phase-5 retry round is a real case): "never grandfathered" means
   // the invariant-prefix proof must exist for every reviewer, not just when a
@@ -125,7 +144,7 @@ export function evaluateBriefingPrefixes(sentinels) {
   if (missing.length > 0) {
     return {
       verified: false,
-      reason: `${missing.length} of ${sentinels.length} reviewer sentinel(s) for this round have no recorded prefix hash — the invariant-briefing-prefix proof (GATE-EXEC-BRIEFING-PREFIX) was never established for them. Missing hashes are treated as a mismatch, not grandfathered in.`,
+      reason: `${missing.length} of ${sentinels.length} reviewer sentinel(s) for this round${where} have no recorded prefix hash — the invariant-briefing-prefix proof (GATE-EXEC-BRIEFING-PREFIX) was never established for them. Missing hashes are treated as a mismatch, not grandfathered in.`,
       missing,
     };
   }
@@ -138,11 +157,55 @@ export function evaluateBriefingPrefixes(sentinels) {
     const mismatched = sentinels.map(({ scope, prefixHash }) => ({ scope, prefixHash }));
     return {
       verified: false,
-      reason: `Reviewer sentinels for this round recorded ${distinct.size} DIFFERENT invariant-briefing prefix hashes — the seeded briefings were not byte-identical (GATE-EXEC-BRIEFING-PREFIX).`,
+      reason: `Reviewer sentinels for this round${where} recorded ${distinct.size} DIFFERENT invariant-briefing prefix hashes — the seeded briefings were not byte-identical (GATE-EXEC-BRIEFING-PREFIX).`,
       mismatched,
     };
   }
   return { verified: true, prefixHash: sentinels[0].prefixHash };
+}
+
+/**
+ * Pure comparison: given the round's sentinels, decide verified/reason/missing/mismatched.
+ * Exported for direct unit testing without touching the filesystem.
+ *
+ * Sentinels are first PARTITIONED BY GATE (recovered from the scope's `<gate>-`
+ * prefix), then each gate's reviewers are evaluated independently. This is the
+ * fix for the false fail-closed when two gates run at one head: a small change
+ * that clears draft_gate and pre_approval_gate without an intervening push writes
+ * both gates' sentinels under the SAME head SHA, and each gate legitimately has
+ * its own (different) invariant-briefing hash. Comparing across gates flagged
+ * that as a mismatch; comparing WITHIN each gate does not. The real invariant —
+ * reviewers of ONE gate pass must share a byte-identical briefing — is preserved
+ * per group. Ungated (legacy bare-angle) scopes form one group with the original
+ * behavior.
+ *
+ * @param {Array<{ scope: string, prefixHash: string|null }>} sentinels
+ * @returns {{ verified: boolean, reason?: string, missing?: string[], mismatched?: Array<{scope:string, prefixHash:string}>, prefixHash?: string, gates?: Array<{gate:string, prefixHash:string}> }}
+ */
+export function evaluateBriefingPrefixes(sentinels) {
+  if (sentinels.length === 0) {
+    return { verified: true, reason: "no sentinels found for this round" };
+  }
+  const groups = new Map();
+  for (const s of sentinels) {
+    const gate = gateOfScope(s.scope);
+    if (!groups.has(gate)) groups.set(gate, []);
+    groups.get(gate).push(s);
+  }
+  // Single group (one gate, or all-ungated legacy) keeps the exact original
+  // shape, including the top-level `prefixHash` on success.
+  if (groups.size === 1) {
+    return evaluateGroup([...groups.values()][0]);
+  }
+  // Multiple gates share this head: verified only when EVERY gate's own
+  // reviewers are internally consistent. Fail closed on the first bad gate.
+  const gates = [];
+  for (const [gate, group] of groups) {
+    const result = evaluateGroup(group, gate || "ungated");
+    if (!result.verified) return { ...result, gate: gate || "ungated" };
+    gates.push({ gate: gate || "ungated", prefixHash: result.prefixHash });
+  }
+  return { verified: true, gates };
 }
 
 export async function main(argv = process.argv.slice(2), { tmpRoot = path.join(process.cwd(), "tmp") } = {}) {

--- a/scripts/github/verify-briefing-prefixes.mjs
+++ b/scripts/github/verify-briefing-prefixes.mjs
@@ -157,6 +157,9 @@ async function readGateBriefingRecords(tmpRoot, headSha) {
     .sort((a, b) => a.name.localeCompare(b.name));
   for (const e of matches) {
     const gate = e.name.slice(0, -suffix.length);
+    // Only canonical gate records are trusted: a stray/leftover file whose
+    // prefix isn't a real gate name must not be able to satisfy record-matching.
+    if (!GATE_NAMES.includes(gate)) continue;
     const dir = e.parentPath ?? root;
     let bytes;
     try {

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -522,7 +522,7 @@ export function renderBriefingPrefix({
   lines.push(`prefixMode: ${prefixMode}`);
   lines.push("");
   lines.push(
-    `Mandatory: before doing any angle-specific work, run \`node scripts/github/verify-fresh-review-context.mjs --scope <your-angle> --context-path ${contextPath} --prefix-file ${briefingPrefixPath}\`. Refuse to proceed on contamination or a missing artifact.`,
+    `Mandatory: before doing any angle-specific work, run \`node scripts/github/verify-fresh-review-context.mjs --scope ${gate.replace(/_/g, "-")}-<your-angle> --context-path ${contextPath} --prefix-file ${briefingPrefixPath}\`. Refuse to proceed on contamination or a missing artifact.`,
   );
   lines.push("");
   lines.push("## PR body");

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -39,6 +39,7 @@ import { resolveGateAnglesDynamic } from "@dev-loops/core/config";
 import { parsePrNumber, requireTokenValue } from "../_cli-primitives.mjs";
 import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { buildAdjacentBundle, DEFAULT_MAX_FILE_BYTES } from "./build-adjacent-bundle.mjs";
+import { GATE_NAMES } from "./_gate-names.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 
 /**
@@ -132,7 +133,7 @@ function parseError(message) {
 }
 
 function normalizeGate(value) {
-  const gates = new Set(["draft_gate", "pre_approval_gate"]);
+  const gates = new Set(GATE_NAMES);
   const normalized = String(value).trim().toLowerCase();
   return gates.has(normalized) ? normalized : null;
 }
@@ -375,7 +376,7 @@ export function buildGateContextPath({ repo, pr, gate, headSha, tmpRoot = "tmp" 
  * @returns {{ pr: number, gate: string, headSha: string }}
  */
 function validatePathSegments({ pr, gate, headSha }) {
-  if (gate !== "draft_gate" && gate !== "pre_approval_gate") {
+  if (!GATE_NAMES.includes(gate)) {
     throw new Error(`--gate segment ${JSON.stringify(gate)} is unsafe (expected draft_gate or pre_approval_gate)`);
   }
   // Require a CANONICAL positive integer: the trimmed string must be all digits

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -377,7 +377,7 @@ export function buildGateContextPath({ repo, pr, gate, headSha, tmpRoot = "tmp" 
  */
 function validatePathSegments({ pr, gate, headSha }) {
   if (!GATE_NAMES.includes(gate)) {
-    throw new Error(`--gate segment ${JSON.stringify(gate)} is unsafe (expected draft_gate or pre_approval_gate)`);
+    throw new Error(`--gate segment ${JSON.stringify(gate)} is unsafe (expected ${GATE_NAMES.join(" or ")})`);
   }
   // Require a CANONICAL positive integer: the trimmed string must be all digits
   // (`/^\d+$/`) and > 0. This mirrors the CLI's parsePrNumber rule so the path

--- a/test/github/verify-briefing-prefixes.test.mjs
+++ b/test/github/verify-briefing-prefixes.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -69,39 +70,56 @@ test("evaluateBriefingPrefixes: different hashes fail closed (negative case)", (
   assert.equal(result.mismatched.length, 2);
 });
 
-test("evaluateBriefingPrefixes: two gates at ONE head each internally consistent both PASS (issue #1246 regression)", () => {
+test("evaluateBriefingPrefixes: two gates at one head, each matching its own record, both PASS (issue #1246 regression)", () => {
+  const records = new Map([["hash-draft", "draft_gate"], ["hash-preapproval", "pre_approval_gate"]]);
   const result = evaluateBriefingPrefixes([
     { scope: "draft-gate-coverage", prefixHash: "hash-draft" },
     { scope: "draft-gate-correctness", prefixHash: "hash-draft" },
     { scope: "pre-approval-gate-yagni", prefixHash: "hash-preapproval" },
     { scope: "pre-approval-gate-kiss", prefixHash: "hash-preapproval" },
-  ]);
+  ], records);
   assert.equal(result.verified, true);
-  // Per-gate breakdown, each with its own recorded hash.
   const byGate = Object.fromEntries(result.gates.map((g) => [g.gate, g.prefixHash]));
-  assert.deepEqual(byGate, { "draft-gate": "hash-draft", "pre-approval-gate": "hash-preapproval" });
+  assert.deepEqual(byGate, { draft_gate: "hash-draft", pre_approval_gate: "hash-preapproval" });
 });
 
-test("evaluateBriefingPrefixes: a mismatch WITHIN one gate still fails closed (invariant preserved)", () => {
+test("evaluateBriefingPrefixes: a sentinel hash matching NO record fails closed (contaminated/stale briefing, not masked)", () => {
+  const records = new Map([["hash-draft", "draft_gate"]]);
   const result = evaluateBriefingPrefixes([
-    { scope: "draft-gate-coverage", prefixHash: "hash-1" },
-    { scope: "draft-gate-correctness", prefixHash: "hash-2" },
-    { scope: "pre-approval-gate-yagni", prefixHash: "hash-preapproval" },
-  ]);
+    { scope: "draft-gate-coverage", prefixHash: "hash-draft" },
+    { scope: "correctness", prefixHash: "hash-bad" }, // bare/stray scope must NOT let it self-verify
+  ], records);
   assert.equal(result.verified, false);
-  assert.equal(result.gate, "draft-gate");
-  assert.ok(result.reason.includes("DIFFERENT"));
+  assert.ok(result.reason.includes("matches no gate briefing-prefix record"));
+  assert.deepEqual(result.mismatched.map((m) => m.prefixHash), ["hash-bad"]);
 });
 
-test("evaluateBriefingPrefixes: a missing hash WITHIN one gate still fails closed (not grandfathered)", () => {
+test("evaluateBriefingPrefixes: a missing hash still fails closed even with records present", () => {
+  const records = new Map([["hash-draft", "draft_gate"]]);
   const result = evaluateBriefingPrefixes([
     { scope: "draft-gate-coverage", prefixHash: "hash-draft" },
     { scope: "draft-gate-correctness", prefixHash: null },
-    { scope: "pre-approval-gate-yagni", prefixHash: "hash-preapproval" },
+  ], records);
+  assert.equal(result.verified, false);
+  assert.deepEqual(result.missing, ["draft-gate-correctness"]);
+});
+
+test("evaluateBriefingPrefixes: no records -> flat fallback, two distinct hashes fail closed", () => {
+  const result = evaluateBriefingPrefixes([
+    { scope: "a", prefixHash: "h1" },
+    { scope: "b", prefixHash: "h2" },
   ]);
   assert.equal(result.verified, false);
-  assert.equal(result.gate, "draft-gate");
-  assert.deepEqual(result.missing, ["draft-gate-correctness"]);
+  assert.ok(result.reason.includes("DIFFERENT"));
+});
+
+test("evaluateBriefingPrefixes: no records -> flat fallback, identical hashes verify", () => {
+  const result = evaluateBriefingPrefixes([
+    { scope: "a", prefixHash: "same" },
+    { scope: "b", prefixHash: "same" },
+  ]);
+  assert.equal(result.verified, true);
+  assert.equal(result.prefixHash, "same");
 });
 
 test("evaluateBriefingPrefixes: a missing hash fails closed even when other hashes agree (fail-closed, not grandfathered)", () => {
@@ -169,12 +187,16 @@ test("verify-briefing-prefixes treats a malformed (non-sha256) recorded hash as 
   }
 });
 
-test("verify-briefing-prefixes: two gates at one head both pass via CLI (issue #1246 regression)", async () => {
+test("verify-briefing-prefixes: two gates at one head both pass via CLI, verified against on-disk records (issue #1246 regression)", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-briefing-prefixes-"));
   try {
     await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
-    const H1 = "a".repeat(64);
-    const H2 = "b".repeat(64);
+    const gateContextDir = path.join(tmpDir, "tmp", "gate-context", "mfittko-dev-loops", "pr-1");
+    await mkdir(gateContextDir, { recursive: true });
+    await writeFile(path.join(gateContextDir, `draft_gate-${FULL_TEST_SHA}.briefing-prefix.txt`), "DRAFT BRIEFING");
+    await writeFile(path.join(gateContextDir, `pre_approval_gate-${FULL_TEST_SHA}.briefing-prefix.txt`), "PREAPPROVAL BRIEFING");
+    const H1 = createHash("sha256").update("DRAFT BRIEFING").digest("hex");
+    const H2 = createHash("sha256").update("PREAPPROVAL BRIEFING").digest("hex");
     const sentinels = [
       ["draft-gate-coverage", H1],
       ["draft-gate-correctness", H1],
@@ -192,6 +214,41 @@ test("verify-briefing-prefixes: two gates at one head both pass via CLI (issue #
     const output = JSON.parse(result.stdout.trim());
     assert.equal(output.verified, true);
     assert.equal(output.reviewerCount, 4);
+    const byGate = Object.fromEntries(output.gates.map((g) => [g.gate, g.prefixHash]));
+    assert.deepEqual(byGate, { draft_gate: H1, pre_approval_gate: H2 });
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test("verify-briefing-prefixes: a sentinel hash matching no on-disk gate record fails closed via CLI", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-briefing-prefixes-"));
+  try {
+    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
+    const gateContextDir = path.join(tmpDir, "tmp", "gate-context", "mfittko-dev-loops", "pr-1");
+    await mkdir(gateContextDir, { recursive: true });
+    await writeFile(path.join(gateContextDir, `draft_gate-${FULL_TEST_SHA}.briefing-prefix.txt`), "DRAFT BRIEFING");
+    await writeFile(path.join(gateContextDir, `pre_approval_gate-${FULL_TEST_SHA}.briefing-prefix.txt`), "PREAPPROVAL BRIEFING");
+    const H1 = createHash("sha256").update("DRAFT BRIEFING").digest("hex");
+    const H2 = createHash("sha256").update("PREAPPROVAL BRIEFING").digest("hex");
+    const BOGUS = "c".repeat(64);
+    const sentinels = [
+      ["draft-gate-coverage", H1],
+      ["draft-gate-correctness", BOGUS],
+      ["pre-approval-gate-yagni", H2],
+      ["pre-approval-gate-kiss", H2],
+    ];
+    for (const [scope, prefixHash] of sentinels) {
+      await writeFile(
+        path.join(tmpDir, "tmp", `checkpoint-context-sentinel-${scope}-${FULL_TEST_SHA}.json`),
+        JSON.stringify({ scope, prefixHash }),
+      );
+    }
+    const result = runChecker(["--head-sha", FULL_TEST_SHA], { cwd: tmpDir });
+    assert.equal(result.status, 1, result.stdout + result.stderr);
+    const output = JSON.parse(result.stdout.trim());
+    assert.equal(output.verified, false);
+    assert.ok(output.reason.includes("matches no gate briefing-prefix record"));
   } finally {
     await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
   }

--- a/test/github/verify-briefing-prefixes.test.mjs
+++ b/test/github/verify-briefing-prefixes.test.mjs
@@ -359,6 +359,29 @@ test("verify-briefing-prefixes: identical-byte records under different gates att
   }
 });
 
+test("verify-briefing-prefixes: a stray non-canonical-gate briefing record is ignored (fails closed)", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-briefing-prefixes-"));
+  try {
+    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
+    const gateContextDir = path.join(tmpDir, "tmp", "gate-context", "mfittko-dev-loops", "pr-1");
+    await mkdir(gateContextDir, { recursive: true });
+    await writeFile(path.join(gateContextDir, `draft_gate-${FULL_TEST_SHA}.briefing-prefix.txt`), "DRAFT");
+    await writeFile(path.join(gateContextDir, `bogus_gate-${FULL_TEST_SHA}.briefing-prefix.txt`), "STRAY");
+    const strayHash = createHash("sha256").update("STRAY").digest("hex");
+    await writeFile(
+      path.join(tmpDir, "tmp", `checkpoint-context-sentinel-coverage-${FULL_TEST_SHA}.json`),
+      JSON.stringify({ scope: "coverage", prefixHash: strayHash }),
+    );
+    const result = runChecker(["--head-sha", FULL_TEST_SHA], { cwd: tmpDir });
+    assert.equal(result.status, 1, result.stdout + result.stderr);
+    const output = JSON.parse(result.stdout.trim());
+    assert.equal(output.verified, false);
+    assert.ok(output.reason.includes("matches no gate briefing-prefix record"));
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Dogfood-style integration (issue #1207 AC3): simulate the exact live flow —
 // write two reviewer sentinels via the REAL verify-fresh-review-context.mjs

--- a/test/github/verify-briefing-prefixes.test.mjs
+++ b/test/github/verify-briefing-prefixes.test.mjs
@@ -71,7 +71,7 @@ test("evaluateBriefingPrefixes: different hashes fail closed (negative case)", (
 });
 
 test("evaluateBriefingPrefixes: two gates at one head, each matching its own record, both PASS (issue #1246 regression)", () => {
-  const records = new Map([["hash-draft", "draft_gate"], ["hash-preapproval", "pre_approval_gate"]]);
+  const records = new Map([["hash-draft", new Set(["draft_gate"])], ["hash-preapproval", new Set(["pre_approval_gate"])]]);
   const result = evaluateBriefingPrefixes([
     { scope: "draft-gate-coverage", prefixHash: "hash-draft" },
     { scope: "draft-gate-correctness", prefixHash: "hash-draft" },
@@ -84,7 +84,7 @@ test("evaluateBriefingPrefixes: two gates at one head, each matching its own rec
 });
 
 test("evaluateBriefingPrefixes: a sentinel hash matching NO record fails closed (contaminated/stale briefing, not masked)", () => {
-  const records = new Map([["hash-draft", "draft_gate"]]);
+  const records = new Map([["hash-draft", new Set(["draft_gate"])]]);
   const result = evaluateBriefingPrefixes([
     { scope: "draft-gate-coverage", prefixHash: "hash-draft" },
     { scope: "correctness", prefixHash: "hash-bad" }, // bare/stray scope must NOT let it self-verify
@@ -95,7 +95,7 @@ test("evaluateBriefingPrefixes: a sentinel hash matching NO record fails closed 
 });
 
 test("evaluateBriefingPrefixes: a missing hash still fails closed even with records present", () => {
-  const records = new Map([["hash-draft", "draft_gate"]]);
+  const records = new Map([["hash-draft", new Set(["draft_gate"])]]);
   const result = evaluateBriefingPrefixes([
     { scope: "draft-gate-coverage", prefixHash: "hash-draft" },
     { scope: "draft-gate-correctness", prefixHash: null },
@@ -105,7 +105,7 @@ test("evaluateBriefingPrefixes: a missing hash still fails closed even with reco
 });
 
 test("evaluateBriefingPrefixes: single gate with a record emits prefixHash and a gates entry with reviewerCount", () => {
-  const records = new Map([["hash-draft", "draft_gate"]]);
+  const records = new Map([["hash-draft", new Set(["draft_gate"])]]);
   const result = evaluateBriefingPrefixes([
     { scope: "draft-gate-coverage", prefixHash: "hash-draft" },
     { scope: "draft-gate-correctness", prefixHash: "hash-draft" },
@@ -116,7 +116,7 @@ test("evaluateBriefingPrefixes: single gate with a record emits prefixHash and a
 });
 
 test("evaluateBriefingPrefixes: a sentinel whose scope declares one gate but whose hash matches a DIFFERENT gate's record fails closed (wrong-gate briefing)", () => {
-  const records = new Map([["hash-draft", "draft_gate"], ["hash-preapproval", "pre_approval_gate"]]);
+  const records = new Map([["hash-draft", new Set(["draft_gate"])], ["hash-preapproval", new Set(["pre_approval_gate"])]]);
   const result = evaluateBriefingPrefixes([
     { scope: "draft-gate-coverage", prefixHash: "hash-draft" },
     { scope: "draft-gate-correctness", prefixHash: "hash-preapproval" }, // wrong-gate: draft scope, pre-approval hash
@@ -127,7 +127,7 @@ test("evaluateBriefingPrefixes: a sentinel whose scope declares one gate but who
 });
 
 test("evaluateBriefingPrefixes: a bare (ungated) scope matches by hash alone and does not trigger the wrong-gate check", () => {
-  const records = new Map([["hash-draft", "draft_gate"]]);
+  const records = new Map([["hash-draft", new Set(["draft_gate"])]]);
   const result = evaluateBriefingPrefixes([
     { scope: "coverage", prefixHash: "hash-draft" },
   ], records);
@@ -135,7 +135,7 @@ test("evaluateBriefingPrefixes: a bare (ungated) scope matches by hash alone and
 });
 
 test("evaluateBriefingPrefixes: wrong-gate briefing fails closed even when the declared gate has no record this round (single-gate round)", () => {
-  const records = new Map([["hash-draft", "draft_gate"]]); // only draft has recorded this round
+  const records = new Map([["hash-draft", new Set(["draft_gate"])]]); // only draft has recorded this round
   const result = evaluateBriefingPrefixes([
     { scope: "draft-gate-coverage", prefixHash: "hash-draft" },
     { scope: "pre-approval-gate-mistaken", prefixHash: "hash-draft" }, // mis-scoped for an absent gate
@@ -143,6 +143,22 @@ test("evaluateBriefingPrefixes: wrong-gate briefing fails closed even when the d
   assert.equal(result.verified, false);
   assert.ok(result.reason.includes("DIFFERENT gate"));
   assert.deepEqual(result.mismatched.map((m) => m.scope), ["pre-approval-gate-mistaken"]);
+});
+
+test("evaluateBriefingPrefixes: within-gate byte-identity fails closed when one gate has two distinct hashes (AC2)", () => {
+  const records = new Map([["h1", new Set(["draft_gate"])], ["h2", new Set(["draft_gate"])]]);
+  const result = evaluateBriefingPrefixes([
+    { scope: "draft-gate-a", prefixHash: "h1" },
+    { scope: "draft-gate-b", prefixHash: "h2" },
+  ], records);
+  assert.equal(result.verified, false);
+  assert.ok(result.reason.includes("within-gate") || result.reason.includes("DIFFERENT"));
+});
+
+test("evaluateBriefingPrefixes: a hash valid for multiple gates passes for a scope declaring one of them", () => {
+  const records = new Map([["hx", new Set(["draft_gate", "pre_approval_gate"])]]);
+  const ok = evaluateBriefingPrefixes([{ scope: "draft-gate-a", prefixHash: "hx" }], records);
+  assert.equal(ok.verified, true);
 });
 
 test("declaredGateOf: matches the canonical gate vocabulary and returns null for bare scopes", () => {

--- a/test/github/verify-briefing-prefixes.test.mjs
+++ b/test/github/verify-briefing-prefixes.test.mjs
@@ -104,6 +104,36 @@ test("evaluateBriefingPrefixes: a missing hash still fails closed even with reco
   assert.deepEqual(result.missing, ["draft-gate-correctness"]);
 });
 
+test("evaluateBriefingPrefixes: single gate with a record emits prefixHash and a gates entry with reviewerCount", () => {
+  const records = new Map([["hash-draft", "draft_gate"]]);
+  const result = evaluateBriefingPrefixes([
+    { scope: "draft-gate-coverage", prefixHash: "hash-draft" },
+    { scope: "draft-gate-correctness", prefixHash: "hash-draft" },
+  ], records);
+  assert.equal(result.verified, true);
+  assert.equal(result.prefixHash, "hash-draft");
+  assert.deepEqual(result.gates, [{ gate: "draft_gate", prefixHash: "hash-draft", reviewerCount: 2 }]);
+});
+
+test("evaluateBriefingPrefixes: a sentinel whose scope declares one gate but whose hash matches a DIFFERENT gate's record fails closed (wrong-gate briefing)", () => {
+  const records = new Map([["hash-draft", "draft_gate"], ["hash-preapproval", "pre_approval_gate"]]);
+  const result = evaluateBriefingPrefixes([
+    { scope: "draft-gate-coverage", prefixHash: "hash-draft" },
+    { scope: "draft-gate-correctness", prefixHash: "hash-preapproval" }, // wrong-gate: draft scope, pre-approval hash
+  ], records);
+  assert.equal(result.verified, false);
+  assert.ok(result.reason.includes("DIFFERENT gate"));
+  assert.deepEqual(result.mismatched.map((m) => m.prefixHash), ["hash-preapproval"]);
+});
+
+test("evaluateBriefingPrefixes: a bare (ungated) scope matches by hash alone and does not trigger the wrong-gate check", () => {
+  const records = new Map([["hash-draft", "draft_gate"]]);
+  const result = evaluateBriefingPrefixes([
+    { scope: "coverage", prefixHash: "hash-draft" },
+  ], records);
+  assert.equal(result.verified, true);
+});
+
 test("evaluateBriefingPrefixes: no records -> flat fallback, two distinct hashes fail closed", () => {
   const result = evaluateBriefingPrefixes([
     { scope: "a", prefixHash: "h1" },

--- a/test/github/verify-briefing-prefixes.test.mjs
+++ b/test/github/verify-briefing-prefixes.test.mjs
@@ -30,6 +30,34 @@ function makeGit(tmpDir) {
   };
 }
 
+// mkdtemp + guaranteed cleanup, for CLI tests that only need a scratch cwd.
+async function withTmpDir(fn) {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-briefing-prefixes-"));
+  try {
+    return await fn(tmpDir);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+// Writes an on-disk per-gate briefing-prefix record (as write-gate-context.mjs
+// would) and returns its sha256 for use as a sentinel's recorded prefixHash.
+async function writeBriefingRecord(tmpDir, gate, sha, bytes) {
+  const gateContextDir = path.join(tmpDir, "tmp", "gate-context", "mfittko-dev-loops", "pr-1");
+  await mkdir(gateContextDir, { recursive: true });
+  await writeFile(path.join(gateContextDir, `${gate}-${sha}.briefing-prefix.txt`), bytes);
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+// Writes a reviewer sentinel (as verify-fresh-review-context.mjs would).
+async function writeSentinel(tmpDir, scope, sha, prefixHash) {
+  await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
+  await writeFile(
+    path.join(tmpDir, "tmp", `checkpoint-context-sentinel-${scope}-${sha}.json`),
+    JSON.stringify({ scope, prefixHash }),
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Pure function unit tests (no filesystem/subprocess).
 // ---------------------------------------------------------------------------
@@ -173,6 +201,20 @@ test("declaredGateOf: uses the LONGEST matching prefix (prefix-extending gate na
   assert.equal(declaredGateOf("draft-gate-coverage", vocab), "draft_gate");
 });
 
+test("declaredGateOf: matches case-insensitively (mixed-case scope still declares its gate)", () => {
+  assert.equal(declaredGateOf("Pre-Approval-Gate-Correctness"), "pre_approval_gate");
+  assert.equal(declaredGateOf("DRAFT-GATE-coverage"), "draft_gate");
+});
+
+test("evaluateBriefingPrefixes: a mixed-case wrong-gate scope still fails closed (case-insensitive)", () => {
+  const records = new Map([["hash-draft", new Set(["draft_gate"])]]);
+  const result = evaluateBriefingPrefixes([
+    { scope: "Pre-Approval-Gate-x", prefixHash: "hash-draft" }, // declares pre_approval but hash is draft's
+  ], records);
+  assert.equal(result.verified, false);
+  assert.ok(result.reason.includes("DIFFERENT gate"));
+});
+
 test("evaluateBriefingPrefixes: no records -> flat fallback, two distinct hashes fail closed", () => {
   const result = evaluateBriefingPrefixes([
     { scope: "a", prefixHash: "h1" },
@@ -226,46 +268,30 @@ test("verify-briefing-prefixes rejects a SHORT head SHA (would glob zero sentine
 const FULL_TEST_SHA = "abc1234abc1234abc1234abc1234abc1234abc12";
 
 test("verify-briefing-prefixes exits 0 with reviewerCount 0 when no sentinels exist for the head SHA", async () => {
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-briefing-prefixes-"));
-  try {
+  await withTmpDir(async (tmpDir) => {
     const result = runChecker(["--head-sha", FULL_TEST_SHA], { cwd: tmpDir });
     assert.equal(result.status, 0, result.stderr);
     const output = JSON.parse(result.stdout.trim());
     assert.equal(output.verified, true);
     assert.equal(output.reviewerCount, 0);
-  } finally {
-    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-  }
+  });
 });
 
 test("verify-briefing-prefixes treats a malformed (non-sha256) recorded hash as missing and fails closed", async () => {
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-briefing-prefixes-"));
-  try {
-    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
-    await writeFile(
-      path.join(tmpDir, "tmp", `checkpoint-context-sentinel-correctness-${FULL_TEST_SHA}.json`),
-      JSON.stringify({ scope: "correctness", prefixHash: "not-a-real-hash" }),
-    );
+  await withTmpDir(async (tmpDir) => {
+    await writeSentinel(tmpDir, "correctness", FULL_TEST_SHA, "not-a-real-hash");
     const result = runChecker(["--head-sha", FULL_TEST_SHA], { cwd: tmpDir });
     assert.equal(result.status, 1, result.stdout + result.stderr);
     const output = JSON.parse(result.stdout.trim());
     assert.equal(output.verified, false);
     assert.deepEqual(output.missing, ["correctness"]);
-  } finally {
-    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-  }
+  });
 });
 
 test("verify-briefing-prefixes: two gates at one head both pass via CLI, verified against on-disk records (issue #1246 regression)", async () => {
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-briefing-prefixes-"));
-  try {
-    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
-    const gateContextDir = path.join(tmpDir, "tmp", "gate-context", "mfittko-dev-loops", "pr-1");
-    await mkdir(gateContextDir, { recursive: true });
-    await writeFile(path.join(gateContextDir, `draft_gate-${FULL_TEST_SHA}.briefing-prefix.txt`), "DRAFT BRIEFING");
-    await writeFile(path.join(gateContextDir, `pre_approval_gate-${FULL_TEST_SHA}.briefing-prefix.txt`), "PREAPPROVAL BRIEFING");
-    const H1 = createHash("sha256").update("DRAFT BRIEFING").digest("hex");
-    const H2 = createHash("sha256").update("PREAPPROVAL BRIEFING").digest("hex");
+  await withTmpDir(async (tmpDir) => {
+    const H1 = await writeBriefingRecord(tmpDir, "draft_gate", FULL_TEST_SHA, "DRAFT BRIEFING");
+    const H2 = await writeBriefingRecord(tmpDir, "pre_approval_gate", FULL_TEST_SHA, "PREAPPROVAL BRIEFING");
     const sentinels = [
       ["draft-gate-coverage", H1],
       ["draft-gate-correctness", H1],
@@ -273,10 +299,7 @@ test("verify-briefing-prefixes: two gates at one head both pass via CLI, verifie
       ["pre-approval-gate-kiss", H2],
     ];
     for (const [scope, prefixHash] of sentinels) {
-      await writeFile(
-        path.join(tmpDir, "tmp", `checkpoint-context-sentinel-${scope}-${FULL_TEST_SHA}.json`),
-        JSON.stringify({ scope, prefixHash }),
-      );
+      await writeSentinel(tmpDir, scope, FULL_TEST_SHA, prefixHash);
     }
     const result = runChecker(["--head-sha", FULL_TEST_SHA], { cwd: tmpDir });
     assert.equal(result.status, 0, result.stdout + result.stderr);
@@ -285,21 +308,13 @@ test("verify-briefing-prefixes: two gates at one head both pass via CLI, verifie
     assert.equal(output.reviewerCount, 4);
     const byGate = Object.fromEntries(output.gates.map((g) => [g.gate, g.prefixHash]));
     assert.deepEqual(byGate, { draft_gate: H1, pre_approval_gate: H2 });
-  } finally {
-    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-  }
+  });
 });
 
 test("verify-briefing-prefixes: a sentinel hash matching no on-disk gate record fails closed via CLI", async () => {
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-briefing-prefixes-"));
-  try {
-    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
-    const gateContextDir = path.join(tmpDir, "tmp", "gate-context", "mfittko-dev-loops", "pr-1");
-    await mkdir(gateContextDir, { recursive: true });
-    await writeFile(path.join(gateContextDir, `draft_gate-${FULL_TEST_SHA}.briefing-prefix.txt`), "DRAFT BRIEFING");
-    await writeFile(path.join(gateContextDir, `pre_approval_gate-${FULL_TEST_SHA}.briefing-prefix.txt`), "PREAPPROVAL BRIEFING");
-    const H1 = createHash("sha256").update("DRAFT BRIEFING").digest("hex");
-    const H2 = createHash("sha256").update("PREAPPROVAL BRIEFING").digest("hex");
+  await withTmpDir(async (tmpDir) => {
+    const H1 = await writeBriefingRecord(tmpDir, "draft_gate", FULL_TEST_SHA, "DRAFT BRIEFING");
+    const H2 = await writeBriefingRecord(tmpDir, "pre_approval_gate", FULL_TEST_SHA, "PREAPPROVAL BRIEFING");
     const BOGUS = "c".repeat(64);
     const sentinels = [
       ["draft-gate-coverage", H1],
@@ -308,94 +323,56 @@ test("verify-briefing-prefixes: a sentinel hash matching no on-disk gate record 
       ["pre-approval-gate-kiss", H2],
     ];
     for (const [scope, prefixHash] of sentinels) {
-      await writeFile(
-        path.join(tmpDir, "tmp", `checkpoint-context-sentinel-${scope}-${FULL_TEST_SHA}.json`),
-        JSON.stringify({ scope, prefixHash }),
-      );
+      await writeSentinel(tmpDir, scope, FULL_TEST_SHA, prefixHash);
     }
     const result = runChecker(["--head-sha", FULL_TEST_SHA], { cwd: tmpDir });
     assert.equal(result.status, 1, result.stdout + result.stderr);
     const output = JSON.parse(result.stdout.trim());
     assert.equal(output.verified, false);
     assert.ok(output.reason.includes("matches no gate briefing-prefix record"));
-  } finally {
-    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-  }
+  });
 });
 
 test("verify-briefing-prefixes: a wrong-gate briefing (scope declares one gate, hash belongs to another) fails closed via CLI", async () => {
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-briefing-prefixes-"));
-  try {
-    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
-    const gateContextDir = path.join(tmpDir, "tmp", "gate-context", "mfittko-dev-loops", "pr-1");
-    await mkdir(gateContextDir, { recursive: true });
-    await writeFile(path.join(gateContextDir, `draft_gate-${FULL_TEST_SHA}.briefing-prefix.txt`), "DRAFT BRIEFING");
-    await writeFile(path.join(gateContextDir, `pre_approval_gate-${FULL_TEST_SHA}.briefing-prefix.txt`), "PREAPPROVAL BRIEFING");
-    const H_DRAFT = createHash("sha256").update("DRAFT BRIEFING").digest("hex");
-    const H_PRE = createHash("sha256").update("PREAPPROVAL BRIEFING").digest("hex");
-    await writeFile(
-      path.join(tmpDir, "tmp", `checkpoint-context-sentinel-draft-gate-coverage-${FULL_TEST_SHA}.json`),
-      JSON.stringify({ scope: "draft-gate-coverage", prefixHash: H_DRAFT }),
-    );
-    await writeFile(
-      path.join(tmpDir, "tmp", `checkpoint-context-sentinel-pre-approval-gate-mistaken-${FULL_TEST_SHA}.json`),
-      JSON.stringify({ scope: "pre-approval-gate-mistaken", prefixHash: H_DRAFT }), // wrong-gate: declares pre-approval, hash is draft's
-    );
+  await withTmpDir(async (tmpDir) => {
+    const H_DRAFT = await writeBriefingRecord(tmpDir, "draft_gate", FULL_TEST_SHA, "DRAFT BRIEFING");
+    await writeBriefingRecord(tmpDir, "pre_approval_gate", FULL_TEST_SHA, "PREAPPROVAL BRIEFING");
+    await writeSentinel(tmpDir, "draft-gate-coverage", FULL_TEST_SHA, H_DRAFT);
+    // wrong-gate: declares pre-approval, hash is draft's
+    await writeSentinel(tmpDir, "pre-approval-gate-mistaken", FULL_TEST_SHA, H_DRAFT);
     const result = runChecker(["--head-sha", FULL_TEST_SHA], { cwd: tmpDir });
     assert.equal(result.status, 1, result.stdout + result.stderr);
     const output = JSON.parse(result.stdout.trim());
     assert.equal(output.verified, false);
     assert.ok(output.reason.includes("DIFFERENT gate"));
     assert.ok(output.mismatched.some((m) => m.scope === "pre-approval-gate-mistaken"));
-  } finally {
-    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-  }
+  });
 });
 
 test("verify-briefing-prefixes: identical-byte records under different gates attribute deterministically to the first gate (CLI)", async () => {
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-briefing-prefixes-"));
-  try {
-    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
-    const gateContextDir = path.join(tmpDir, "tmp", "gate-context", "mfittko-dev-loops", "pr-1");
-    await mkdir(gateContextDir, { recursive: true });
-    await writeFile(path.join(gateContextDir, `draft_gate-${FULL_TEST_SHA}.briefing-prefix.txt`), "IDENTICAL");
-    await writeFile(path.join(gateContextDir, `pre_approval_gate-${FULL_TEST_SHA}.briefing-prefix.txt`), "IDENTICAL");
-    const H = createHash("sha256").update("IDENTICAL").digest("hex");
-    await writeFile(
-      path.join(tmpDir, "tmp", `checkpoint-context-sentinel-coverage-${FULL_TEST_SHA}.json`),
-      JSON.stringify({ scope: "coverage", prefixHash: H }),
-    );
+  await withTmpDir(async (tmpDir) => {
+    await writeBriefingRecord(tmpDir, "draft_gate", FULL_TEST_SHA, "IDENTICAL");
+    const H = await writeBriefingRecord(tmpDir, "pre_approval_gate", FULL_TEST_SHA, "IDENTICAL");
+    await writeSentinel(tmpDir, "coverage", FULL_TEST_SHA, H);
     const result = runChecker(["--head-sha", FULL_TEST_SHA], { cwd: tmpDir });
     assert.equal(result.status, 0, result.stdout + result.stderr);
     const output = JSON.parse(result.stdout.trim());
     assert.equal(output.verified, true);
     assert.equal(output.gates[0].gate, "draft_gate");
-  } finally {
-    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-  }
+  });
 });
 
 test("verify-briefing-prefixes: a stray non-canonical-gate briefing record is ignored (fails closed)", async () => {
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-briefing-prefixes-"));
-  try {
-    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
-    const gateContextDir = path.join(tmpDir, "tmp", "gate-context", "mfittko-dev-loops", "pr-1");
-    await mkdir(gateContextDir, { recursive: true });
-    await writeFile(path.join(gateContextDir, `draft_gate-${FULL_TEST_SHA}.briefing-prefix.txt`), "DRAFT");
-    await writeFile(path.join(gateContextDir, `bogus_gate-${FULL_TEST_SHA}.briefing-prefix.txt`), "STRAY");
-    const strayHash = createHash("sha256").update("STRAY").digest("hex");
-    await writeFile(
-      path.join(tmpDir, "tmp", `checkpoint-context-sentinel-coverage-${FULL_TEST_SHA}.json`),
-      JSON.stringify({ scope: "coverage", prefixHash: strayHash }),
-    );
+  await withTmpDir(async (tmpDir) => {
+    await writeBriefingRecord(tmpDir, "draft_gate", FULL_TEST_SHA, "DRAFT");
+    const strayHash = await writeBriefingRecord(tmpDir, "bogus_gate", FULL_TEST_SHA, "STRAY");
+    await writeSentinel(tmpDir, "coverage", FULL_TEST_SHA, strayHash);
     const result = runChecker(["--head-sha", FULL_TEST_SHA], { cwd: tmpDir });
     assert.equal(result.status, 1, result.stdout + result.stderr);
     const output = JSON.parse(result.stdout.trim());
     assert.equal(output.verified, false);
     assert.ok(output.reason.includes("matches no gate briefing-prefix record"));
-  } finally {
-    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-  }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/github/verify-briefing-prefixes.test.mjs
+++ b/test/github/verify-briefing-prefixes.test.mjs
@@ -69,6 +69,41 @@ test("evaluateBriefingPrefixes: different hashes fail closed (negative case)", (
   assert.equal(result.mismatched.length, 2);
 });
 
+test("evaluateBriefingPrefixes: two gates at ONE head each internally consistent both PASS (issue #1246 regression)", () => {
+  const result = evaluateBriefingPrefixes([
+    { scope: "draft-gate-coverage", prefixHash: "hash-draft" },
+    { scope: "draft-gate-correctness", prefixHash: "hash-draft" },
+    { scope: "pre-approval-gate-yagni", prefixHash: "hash-preapproval" },
+    { scope: "pre-approval-gate-kiss", prefixHash: "hash-preapproval" },
+  ]);
+  assert.equal(result.verified, true);
+  // Per-gate breakdown, each with its own recorded hash.
+  const byGate = Object.fromEntries(result.gates.map((g) => [g.gate, g.prefixHash]));
+  assert.deepEqual(byGate, { "draft-gate": "hash-draft", "pre-approval-gate": "hash-preapproval" });
+});
+
+test("evaluateBriefingPrefixes: a mismatch WITHIN one gate still fails closed (invariant preserved)", () => {
+  const result = evaluateBriefingPrefixes([
+    { scope: "draft-gate-coverage", prefixHash: "hash-1" },
+    { scope: "draft-gate-correctness", prefixHash: "hash-2" },
+    { scope: "pre-approval-gate-yagni", prefixHash: "hash-preapproval" },
+  ]);
+  assert.equal(result.verified, false);
+  assert.equal(result.gate, "draft-gate");
+  assert.ok(result.reason.includes("DIFFERENT"));
+});
+
+test("evaluateBriefingPrefixes: a missing hash WITHIN one gate still fails closed (not grandfathered)", () => {
+  const result = evaluateBriefingPrefixes([
+    { scope: "draft-gate-coverage", prefixHash: "hash-draft" },
+    { scope: "draft-gate-correctness", prefixHash: null },
+    { scope: "pre-approval-gate-yagni", prefixHash: "hash-preapproval" },
+  ]);
+  assert.equal(result.verified, false);
+  assert.equal(result.gate, "draft-gate");
+  assert.deepEqual(result.missing, ["draft-gate-correctness"]);
+});
+
 test("evaluateBriefingPrefixes: a missing hash fails closed even when other hashes agree (fail-closed, not grandfathered)", () => {
   const result = evaluateBriefingPrefixes([
     { scope: "scope-a", prefixHash: "same-hash" },
@@ -129,6 +164,34 @@ test("verify-briefing-prefixes treats a malformed (non-sha256) recorded hash as 
     const output = JSON.parse(result.stdout.trim());
     assert.equal(output.verified, false);
     assert.deepEqual(output.missing, ["correctness"]);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test("verify-briefing-prefixes: two gates at one head both pass via CLI (issue #1246 regression)", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-briefing-prefixes-"));
+  try {
+    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
+    const H1 = "a".repeat(64);
+    const H2 = "b".repeat(64);
+    const sentinels = [
+      ["draft-gate-coverage", H1],
+      ["draft-gate-correctness", H1],
+      ["pre-approval-gate-yagni", H2],
+      ["pre-approval-gate-kiss", H2],
+    ];
+    for (const [scope, prefixHash] of sentinels) {
+      await writeFile(
+        path.join(tmpDir, "tmp", `checkpoint-context-sentinel-${scope}-${FULL_TEST_SHA}.json`),
+        JSON.stringify({ scope, prefixHash }),
+      );
+    }
+    const result = runChecker(["--head-sha", FULL_TEST_SHA], { cwd: tmpDir });
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    const output = JSON.parse(result.stdout.trim());
+    assert.equal(output.verified, true);
+    assert.equal(output.reviewerCount, 4);
   } finally {
     await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
   }

--- a/test/github/verify-briefing-prefixes.test.mjs
+++ b/test/github/verify-briefing-prefixes.test.mjs
@@ -307,6 +307,35 @@ test("verify-briefing-prefixes: a sentinel hash matching no on-disk gate record 
   }
 });
 
+test("verify-briefing-prefixes: a wrong-gate briefing (scope declares one gate, hash belongs to another) fails closed via CLI", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-briefing-prefixes-"));
+  try {
+    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
+    const gateContextDir = path.join(tmpDir, "tmp", "gate-context", "mfittko-dev-loops", "pr-1");
+    await mkdir(gateContextDir, { recursive: true });
+    await writeFile(path.join(gateContextDir, `draft_gate-${FULL_TEST_SHA}.briefing-prefix.txt`), "DRAFT BRIEFING");
+    await writeFile(path.join(gateContextDir, `pre_approval_gate-${FULL_TEST_SHA}.briefing-prefix.txt`), "PREAPPROVAL BRIEFING");
+    const H_DRAFT = createHash("sha256").update("DRAFT BRIEFING").digest("hex");
+    const H_PRE = createHash("sha256").update("PREAPPROVAL BRIEFING").digest("hex");
+    await writeFile(
+      path.join(tmpDir, "tmp", `checkpoint-context-sentinel-draft-gate-coverage-${FULL_TEST_SHA}.json`),
+      JSON.stringify({ scope: "draft-gate-coverage", prefixHash: H_DRAFT }),
+    );
+    await writeFile(
+      path.join(tmpDir, "tmp", `checkpoint-context-sentinel-pre-approval-gate-mistaken-${FULL_TEST_SHA}.json`),
+      JSON.stringify({ scope: "pre-approval-gate-mistaken", prefixHash: H_DRAFT }), // wrong-gate: declares pre-approval, hash is draft's
+    );
+    const result = runChecker(["--head-sha", FULL_TEST_SHA], { cwd: tmpDir });
+    assert.equal(result.status, 1, result.stdout + result.stderr);
+    const output = JSON.parse(result.stdout.trim());
+    assert.equal(output.verified, false);
+    assert.ok(output.reason.includes("DIFFERENT gate"));
+    assert.ok(output.mismatched.some((m) => m.scope === "pre-approval-gate-mistaken"));
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
 test("verify-briefing-prefixes: identical-byte records under different gates attribute deterministically to the first gate (CLI)", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-briefing-prefixes-"));
   try {

--- a/test/github/verify-briefing-prefixes.test.mjs
+++ b/test/github/verify-briefing-prefixes.test.mjs
@@ -6,7 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { evaluateBriefingPrefixes } from "../../scripts/github/verify-briefing-prefixes.mjs";
+import { declaredGateOf, evaluateBriefingPrefixes } from "../../scripts/github/verify-briefing-prefixes.mjs";
 
 const checkerPath = path.resolve("scripts/github/verify-briefing-prefixes.mjs");
 const contextGuardPath = path.resolve("scripts/github/verify-fresh-review-context.mjs");
@@ -132,6 +132,29 @@ test("evaluateBriefingPrefixes: a bare (ungated) scope matches by hash alone and
     { scope: "coverage", prefixHash: "hash-draft" },
   ], records);
   assert.equal(result.verified, true);
+});
+
+test("evaluateBriefingPrefixes: wrong-gate briefing fails closed even when the declared gate has no record this round (single-gate round)", () => {
+  const records = new Map([["hash-draft", "draft_gate"]]); // only draft has recorded this round
+  const result = evaluateBriefingPrefixes([
+    { scope: "draft-gate-coverage", prefixHash: "hash-draft" },
+    { scope: "pre-approval-gate-mistaken", prefixHash: "hash-draft" }, // mis-scoped for an absent gate
+  ], records);
+  assert.equal(result.verified, false);
+  assert.ok(result.reason.includes("DIFFERENT gate"));
+  assert.deepEqual(result.mismatched.map((m) => m.scope), ["pre-approval-gate-mistaken"]);
+});
+
+test("declaredGateOf: matches the canonical gate vocabulary and returns null for bare scopes", () => {
+  assert.equal(declaredGateOf("draft-gate-coverage"), "draft_gate");
+  assert.equal(declaredGateOf("pre-approval-gate-yagni"), "pre_approval_gate");
+  assert.equal(declaredGateOf("coverage"), null);
+});
+
+test("declaredGateOf: uses the LONGEST matching prefix (prefix-extending gate names)", () => {
+  const vocab = ["draft_gate", "draft_gate_v2"];
+  assert.equal(declaredGateOf("draft-gate-v2-correctness", vocab), "draft_gate_v2");
+  assert.equal(declaredGateOf("draft-gate-coverage", vocab), "draft_gate");
 });
 
 test("evaluateBriefingPrefixes: no records -> flat fallback, two distinct hashes fail closed", () => {
@@ -279,6 +302,29 @@ test("verify-briefing-prefixes: a sentinel hash matching no on-disk gate record 
     const output = JSON.parse(result.stdout.trim());
     assert.equal(output.verified, false);
     assert.ok(output.reason.includes("matches no gate briefing-prefix record"));
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test("verify-briefing-prefixes: identical-byte records under different gates attribute deterministically to the first gate (CLI)", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-briefing-prefixes-"));
+  try {
+    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
+    const gateContextDir = path.join(tmpDir, "tmp", "gate-context", "mfittko-dev-loops", "pr-1");
+    await mkdir(gateContextDir, { recursive: true });
+    await writeFile(path.join(gateContextDir, `draft_gate-${FULL_TEST_SHA}.briefing-prefix.txt`), "IDENTICAL");
+    await writeFile(path.join(gateContextDir, `pre_approval_gate-${FULL_TEST_SHA}.briefing-prefix.txt`), "IDENTICAL");
+    const H = createHash("sha256").update("IDENTICAL").digest("hex");
+    await writeFile(
+      path.join(tmpDir, "tmp", `checkpoint-context-sentinel-coverage-${FULL_TEST_SHA}.json`),
+      JSON.stringify({ scope: "coverage", prefixHash: H }),
+    );
+    const result = runChecker(["--head-sha", FULL_TEST_SHA], { cwd: tmpDir });
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    const output = JSON.parse(result.stdout.trim());
+    assert.equal(output.verified, true);
+    assert.equal(output.gates[0].gate, "draft_gate");
   } finally {
     await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
   }

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -1251,6 +1251,9 @@ test("renderBriefingPrefix: under-cap — inline mode, fixed section order, all 
   assert.ok(text.includes("Changed files (1):"));
   assert.ok(text.includes("- x.mjs"));
   assert.ok(text.includes("verify-fresh-review-context.mjs"));
+  // Reviewer scope is gate-prefixed (issue #1246) so each reviewer's sentinel
+  // self-identifies its gate; renderInput() defaults to gate: "draft_gate".
+  assert.ok(text.includes("--scope draft-gate-<your-angle>"));
 });
 
 test("renderBriefingPrefix: deterministic — two renders of identical input produce byte-identical text", () => {

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -1251,9 +1251,14 @@ test("renderBriefingPrefix: under-cap — inline mode, fixed section order, all 
   assert.ok(text.includes("Changed files (1):"));
   assert.ok(text.includes("- x.mjs"));
   assert.ok(text.includes("verify-fresh-review-context.mjs"));
-  // Reviewer scope is gate-prefixed (issue #1246) so each reviewer's sentinel
-  // self-identifies its gate; renderInput() defaults to gate: "draft_gate".
+  // Reviewer scope is gate-prefixed so each reviewer's sentinel self-identifies
+  // its gate; renderInput() defaults to gate: "draft_gate".
   assert.ok(text.includes("--scope draft-gate-<your-angle>"));
+});
+
+test("renderBriefingPrefix: gate scope hyphenation covers ALL underscores, not just the first", () => {
+  const { text } = renderBriefingPrefix(renderInput({ gate: "pre_approval_gate" }));
+  assert.ok(text.includes("--scope pre-approval-gate-<your-angle>"));
 });
 
 test("renderBriefingPrefix: deterministic — two renders of identical input produce byte-identical text", () => {


### PR DESCRIPTION
## Summary

`verify-briefing-prefixes.mjs` globbed every reviewer sentinel at a head SHA and required a single shared briefing-prefix hash across all of them. When `draft_gate` and `pre_approval_gate` run against the **same head** (a small change that clears both gates without an intervening push), each gate legitimately renders its own briefing prefix — the `gate:` line differs — so the two gates' distinct hashes read as a mismatch and the second gate **false fail-closed**, stalling the loop and eroding trust in the fail-closed signal.

This scopes the briefing-prefix verification by `(gate, headSha)` instead of `headSha` alone, so each gate at a shared head verifies against its own prefix record.

## Scope and context

Boundary: the gate-review fan-in briefing-prefix check and the reviewer-scope instruction that feeds it. Pure code + tests. The gate-context briefing-prefix artifacts were already `(gate, headSha)`-keyed; this aligns the reviewer sentinels and the fan-in check with that existing scoping. No contract-doc, `required-rules.json`, `.claude`, or config changes — those are intentionally out of scope (see Non-goals).

## File-by-file changes

- `scripts/github/_gate-names.mjs` (new) — the canonical gate vocabulary (`GATE_NAMES = ["draft_gate", "pre_approval_gate"]`), a single source of truth imported by both `verify-briefing-prefixes.mjs` and `write-gate-context.mjs` so the two never drift.
- `scripts/github/verify-briefing-prefixes.mjs` — verify each reviewer sentinel's recorded prefix hash against the on-disk per-gate briefing-prefix records (`<gate>-<headSha>.briefing-prefix.txt` under `tmp/gate-context/`, read by `readGateBriefingRecords`, sorted for deterministic attribution). `evaluateBriefingPrefixes(sentinels, gateRecords)`: (a) a missing hash fails closed; (b) with records present, a hash matching NO record fails closed; (c) a **wrong-gate briefing** fails closed — when a sentinel's scope self-declares a gate (via `declaredGateOf`, longest-prefix match against the canonical `GATE_NAMES` vocabulary), its matched record must belong to that same gate, so a hash that is valid for a different gate is rejected even in a single-gate round; (d) otherwise verified, with a per-gate `gates` breakdown (single-gate also returns top-level `prefixHash`); (e) when no records exist it falls back to the conservative flat all-one-hash check. `main()` reads the records and emits `gates`; USAGE (intro, Output shapes, Exit codes, caveat) documents the record-matching + wrong-gate semantics.

- `scripts/github/write-gate-context.mjs` — now sources its gate validation from the shared `GATE_NAMES` (`normalizeGate` / `validatePathSegments`). `renderBriefingPrefix` renders the mandatory reviewer instruction with a gate-prefixed scope (`--scope draft-gate-<your-angle>` / `pre-approval-gate-<your-angle>`; underscores→hyphens since `--scope` forbids underscores) so each reviewer's sentinel self-identifies its gate. Also removes a latent cross-gate sentinel filename collision for angle names shared across gates (e.g. `contradiction-lens`).
- `test/github/verify-briefing-prefixes.test.mjs` — record-matching pure-function tests (two gates each matching their own record both pass with a per-gate `gates` breakdown; a hash matching no record fails closed; a missing hash fails closed; single-gate-with-records emits `prefixHash` + `gates` with `reviewerCount`; a wrong-gate briefing fails closed; a bare/ungated scope matches by hash alone; no-records flat fallback pass and fail) plus five CLI regression tests using real on-disk briefing-prefix records (two gates → verified:true with `gates`; a bogus/no-match hash → fail closed; a wrong-gate briefing → fail closed; identical-byte records under different gates → deterministic attribution; a stray non-canonical-gate record → ignored/fail closed).
- `test/github/write-gate-context.test.mjs` — an assertion that the rendered instruction carries the gate-prefixed scope, plus a test that `pre_approval_gate` fully hyphenates to `--scope pre-approval-gate-<your-angle>`.

## Acceptance criteria

- AC1: Two gates' reviewer sentinels at the same head, each internally consistent, → `verified: true` (exit 0). Covered by the pure + CLI regression tests.
- AC2: A prefix-hash mismatch within a single gate still fails closed. Covered.
- AC3: A missing prefix hash within a gate still fails closed (never grandfathered). Covered.
- AC4: Verification scoped by `(gate, headSha)`; reviewer sentinels self-identify their gate. Covered by the write-gate-context gate-prefixed scope change plus `readGateBriefingRecords`/`declaredGateOf` hash-record matching with the wrong-gate cross-check (not scope-based partitioning, which the code's JSDoc rejects as fail-open-risky).
- AC5: Regression test for two gates at one head both passing; pre-fix collision reproduced. Covered (reproduced pre-fix: `verified:false` exit 1).
- AC6: Legacy/no-records rounds keep prior behavior — when no on-disk gate briefing-prefix records exist, verification falls back to the conservative flat check (all sentinels must share one hash; fails closed on divergence). Covered by the flat-fallback pure tests.
- AC7: The full suite (`npm run verify`) is green, not just the focused test files.

## Definition of done

- Pre-fix false fail-closed reproduced and now covered by regression tests.
- `verify-briefing-prefixes` and `write-gate-context` suites green; `verify-fresh-review-context` unaffected. Within-gate byte-identity invariant preserved (not masked).
- Change is code-only.
- Full suite green via `npm run verify` (assets, extension, scripts, core, docs, pack, dev-loop) — the authoritative gate, beyond the focused suites.

## Non-goals

- Updating `docs/gate-review-sub-loop-contract.md` (its "keyed by head SHA only, not by gate" caveat at ~L192-196 and the bare `--scope <angle>` prose at L64/135/214 are now stale) — tracked as a follow-up; kept out of this code-only, file-disjoint PR.
- Changing `verify-fresh-review-context.mjs`, `required-rules.json`, `.claude` assets, or any config.

## Validation

```
npm run verify   # full suite (lint/typecheck/tests) — the authoritative gate
# focused subsets:
node --test test/github/verify-briefing-prefixes.test.mjs
node --test test/github/write-gate-context.test.mjs
node --test test/github/verify-fresh-review-context.test.mjs
```

## Non-substitution / cross-gate invariant note

Within one gate pass the byte-identity requirement (`GATE-EXEC-BRIEFING-PREFIX`) is unchanged: reviewers of the same gate must still record one identical hash, and a missing hash still fails closed. Only the cross-gate comparison at a shared head is removed, because per-gate prefixes legitimately differ.

Closes #1246
