### PR TITLE
fix(loop): anchor run-claim coordination file at git-common-dir, not CWD

### DIFF
--- a/scripts/loop/_pr-runner-coordination.mjs
+++ b/scripts/loop/_pr-runner-coordination.mjs
@@ -11,6 +11,7 @@ import {
 } from "./_steering-state-file.mjs";
 export const RUNNER_COORDINATION_SCHEMA_VERSION = 2;
 export const RUNNER_COORDINATION_SUPPORTED_SCHEMA_VERSIONS = Object.freeze([1, 2]);
+export const RUNNER_COORDINATION_HISTORY_LIMIT = 50; // ponytail: cap audit trail; heartbeats append per-round, keep the most recent 50 events
 export const RUNNER_OWNERSHIP_ERROR = Object.freeze({
   ACTIVE_RUN_EXISTS: "active_run_exists",
   OWNERSHIP_LOST: "ownership_lost",
@@ -52,7 +53,10 @@ async function loadRunnerStateFile(filePath) {
 }
 async function saveRunnerStateFile(filePath, state) {
   try {
-    return await saveSharedStateFile(filePath, state);
+    const capped = Array.isArray(state.history) && state.history.length > RUNNER_COORDINATION_HISTORY_LIMIT
+      ? { ...state, history: state.history.slice(-RUNNER_COORDINATION_HISTORY_LIMIT) }
+      : state;
+    return await saveSharedStateFile(filePath, capped);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to write runner coordination state file '${filePath}': ${message}`);
@@ -109,7 +113,7 @@ function resolveRepoCoordinationRoot(cwd) {
       root = path.dirname(path.resolve(canonicalCwd, commonDir));
     }
   } catch {
-    // not a git checkout / git unavailable — anchor at canonicalCwd (legacy behavior)
+    // not a git checkout / git unavailable — anchor at the canonical (realpath'd) cwd
   }
   coordinationRootCache.set(canonicalCwd, root);
   return root;

--- a/scripts/loop/_pr-runner-coordination.mjs
+++ b/scripts/loop/_pr-runner-coordination.mjs
@@ -11,7 +11,7 @@ import {
 } from "./_steering-state-file.mjs";
 export const RUNNER_COORDINATION_SCHEMA_VERSION = 2;
 export const RUNNER_COORDINATION_SUPPORTED_SCHEMA_VERSIONS = Object.freeze([1, 2]);
-export const RUNNER_COORDINATION_HISTORY_LIMIT = 50; // ponytail: cap audit trail; heartbeats append per-round, keep the most recent 50 events
+export const RUNNER_COORDINATION_HISTORY_LIMIT = 50; // cap audit trail; heartbeats append per-round, keep the most recent 50 events
 export const RUNNER_OWNERSHIP_ERROR = Object.freeze({
   ACTIVE_RUN_EXISTS: "active_run_exists",
   OWNERSHIP_LOST: "ownership_lost",

--- a/scripts/loop/_pr-runner-coordination.mjs
+++ b/scripts/loop/_pr-runner-coordination.mjs
@@ -89,7 +89,7 @@ function resolveRepoCoordinationRoot(cwd) {
   try {
     canonicalCwd = fs.realpathSync(cwd);
   } catch (err) {
-    // ponytail: realpathSync on an existing checkout dir virtually never fails;
+    // realpathSync on an existing checkout dir virtually never fails;
     // warn (don't throw) so the rare transient failure — which can desync the
     // coordination path across worktrees — is diagnosable instead of silent.
     console.warn(

--- a/scripts/loop/_pr-runner-coordination.mjs
+++ b/scripts/loop/_pr-runner-coordination.mjs
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import path from "node:path";
 import process from "node:process";
 import { parseRepoSlugParts } from "@dev-loops/core/github/repo-slug";
@@ -64,13 +65,43 @@ async function withRunnerStateFileLock(filePath, callback) {
     throw new Error(`Failed to acquire runner coordination state lock for '${filePath}': ${message}`);
   }
 }
+const coordinationRootCache = new Map();
+/**
+ * Resolve the single stable coordination root for a checkout, independent of CWD.
+ *
+ * `git rev-parse --git-common-dir` yields the shared git dir that is identical for
+ * a repo and all its linked worktrees, so its parent is the one main-checkout root
+ * that a worktree runner and a repo-root detector both anchor to — eliminating the
+ * split-copy false-stale stall where each read a different `.pi/runner-coordination`
+ * file. Falls back to `cwd` when git is unavailable or the dir is not a checkout
+ * (preserves legacy behavior for non-git temp dirs). Cached per cwd for the process.
+ */
+function resolveRepoCoordinationRoot(cwd) {
+  if (coordinationRootCache.has(cwd)) return coordinationRootCache.get(cwd);
+  let root = cwd;
+  try {
+    const commonDir = execFileSync("git", ["rev-parse", "--git-common-dir"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (commonDir) {
+      root = path.dirname(path.resolve(cwd, commonDir));
+    }
+  } catch {
+    // not a git checkout / git unavailable — anchor at cwd (legacy behavior)
+  }
+  coordinationRootCache.set(cwd, root);
+  return root;
+}
 export function defaultRunnerCoordinationFilePathForTarget({ repo, pr }, cwd = process.cwd()) {
   const { owner, name } = parseRepoSlugParts(repo, {
     errorMessage: `Invalid repo slug for coordination target path: ${JSON.stringify(repo)}`,
     lowercase: true,
   });
   const normalizedPr = normalizePr(pr);
-  return path.join(cwd, ".pi", "runner-coordination", owner, name, `pr-${normalizedPr}.json`);
+  const root = resolveRepoCoordinationRoot(cwd);
+  return path.join(root, ".pi", "runner-coordination", owner, name, `pr-${normalizedPr}.json`);
 }
 export function createRunnerCoordinationState({ repo, pr, runId = null, now = new Date().toISOString() }) {
   const normalizedRepo = normalizeRepoSlug(repo);

--- a/scripts/loop/_pr-runner-coordination.mjs
+++ b/scripts/loop/_pr-runner-coordination.mjs
@@ -74,8 +74,9 @@ const coordinationRootCache = new Map();
  * a repo and all its linked worktrees, so its parent is the one main-checkout root
  * that a worktree runner and a repo-root detector both anchor to — eliminating the
  * split-copy false-stale stall where each read a different `.pi/runner-coordination`
- * file. Falls back to `cwd` when git is unavailable or the dir is not a checkout
- * (preserves legacy behavior for non-git temp dirs).
+ * file. Falls back to the canonicalized (realpath'd) `cwd` when git is
+ * unavailable or the dir is not a checkout, so symlinked and realpath'd
+ * spellings of the same non-git dir still converge on one coordination path.
  *
  * `cwd` is realpath'd once at entry: git returns a relative `--git-common-dir` from
  * a main checkout but an already-realpath'd absolute one from a linked worktree, so
@@ -374,6 +375,18 @@ export async function claimRunnerOwnership({
     };
   });
 }
+/**
+ * Verify the caller still owns the PR's runner claim.
+ *
+ * A successful owner-confirmed assert (the active owner's runId matches the
+ * caller's) refreshes `activeRun.updatedAt` — it acts as a heartbeat. Every
+ * other outcome (no record, no active run, ownership lost, missing run id)
+ * is a pure lock-free read with no write. Long-running loops must assert (or
+ * claim) at least once within the stale-max-age window
+ * (`STALE_RUNNER_DEFAULT_MAX_AGE_MS`, 30 minutes by default, overridable via
+ * `DEVLOOPS_STALE_RUNNER_MAX_AGE_MS`; see `_stale-runner-detection.mjs`) to
+ * avoid being seen as stale during a long multi-round gate cycle.
+ */
 export async function assertRunnerOwnership({
   repo,
   pr,
@@ -381,6 +394,7 @@ export async function assertRunnerOwnership({
   cwd = process.cwd(),
   filePath = null,
   requireExisting = false,
+  now = new Date().toISOString(),
 } = {}) {
   const normalizedRepo = normalizeRepoSlug(repo);
   const normalizedPr = normalizePr(pr);
@@ -447,17 +461,48 @@ export async function assertRunnerOwnership({
     });
   }
   if (state.activeRun.runId === normalizedRunId) {
-    return {
-      ok: true,
-      status: "owner_confirmed",
-      repo: normalizedRepo,
-      pr: normalizedPr,
-      runId: normalizedRunId,
-      activeRun: state.activeRun,
-      previousRun: state.previousRun,
-      exitSignals: state.exitSignals,
-      filePath: resolvedPath,
-    };
+    return withRunnerStateFileLock(resolvedPath, async () => {
+      const lockedRaw = await loadRunnerStateFile(resolvedPath);
+      const lockedState = lockedRaw === null
+        ? null
+        : normalizeRunnerCoordinationState(lockedRaw, { repo: normalizedRepo, pr: normalizedPr });
+      if (lockedState?.activeRun?.runId !== normalizedRunId) {
+        // Ownership changed hands between the lockless read above and acquiring
+        // the lock (a concurrent takeover) — don't write; report the new owner.
+        return buildConflict({
+          error: RUNNER_OWNERSHIP_ERROR.OWNERSHIP_LOST,
+          repo: normalizedRepo,
+          pr: normalizedPr,
+          runId: normalizedRunId,
+          activeRun: lockedState?.activeRun ?? null,
+          filePath: resolvedPath,
+          exitSignals: lockedState?.exitSignals ?? [],
+          message: lockedState?.activeRun?.runId
+            ? `PR ${normalizedRepo}#${normalizedPr} is now owned by run ${lockedState.activeRun.runId}; run ${normalizedRunId} must stop.`
+            : `PR ${normalizedRepo}#${normalizedPr} no longer has an active runner ownership record; run ${normalizedRunId} must stop.`,
+        });
+      }
+      const nextState = {
+        ...lockedState,
+        activeRun: {
+          ...lockedState.activeRun,
+          updatedAt: now,
+        },
+        history: [...lockedState.history, { type: "heartbeat", runId: normalizedRunId, at: now }],
+      };
+      await saveRunnerStateFile(resolvedPath, nextState);
+      return {
+        ok: true,
+        status: "owner_confirmed",
+        repo: normalizedRepo,
+        pr: normalizedPr,
+        runId: normalizedRunId,
+        activeRun: nextState.activeRun,
+        previousRun: nextState.previousRun,
+        exitSignals: nextState.exitSignals,
+        filePath: resolvedPath,
+      };
+    });
   }
   return buildConflict({
     error: RUNNER_OWNERSHIP_ERROR.OWNERSHIP_LOST,

--- a/scripts/loop/_pr-runner-coordination.mjs
+++ b/scripts/loop/_pr-runner-coordination.mjs
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { parseRepoSlugParts } from "@dev-loops/core/github/repo-slug";
@@ -74,24 +75,37 @@ const coordinationRootCache = new Map();
  * that a worktree runner and a repo-root detector both anchor to — eliminating the
  * split-copy false-stale stall where each read a different `.pi/runner-coordination`
  * file. Falls back to `cwd` when git is unavailable or the dir is not a checkout
- * (preserves legacy behavior for non-git temp dirs). Cached per cwd for the process.
+ * (preserves legacy behavior for non-git temp dirs).
+ *
+ * `cwd` is realpath'd once at entry: git returns a relative `--git-common-dir` from
+ * a main checkout but an already-realpath'd absolute one from a linked worktree, so
+ * resolving against a symlinked cwd (e.g. macOS /tmp -> /private/tmp) would make the
+ * two sides compute different roots for the same physical repo. Canonicalizing first
+ * makes both sides converge, and doubles as the cache key so symlink-variant cwd
+ * spellings share one cache entry. Cached per canonical cwd for the process.
  */
 function resolveRepoCoordinationRoot(cwd) {
-  if (coordinationRootCache.has(cwd)) return coordinationRootCache.get(cwd);
-  let root = cwd;
+  let canonicalCwd = cwd;
+  try {
+    canonicalCwd = fs.realpathSync(cwd);
+  } catch {
+    // cwd may not exist yet (or realpath unavailable) — resolve against the raw path
+  }
+  if (coordinationRootCache.has(canonicalCwd)) return coordinationRootCache.get(canonicalCwd);
+  let root = canonicalCwd;
   try {
     const commonDir = execFileSync("git", ["rev-parse", "--git-common-dir"], {
-      cwd,
+      cwd: canonicalCwd,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     }).trim();
     if (commonDir) {
-      root = path.dirname(path.resolve(cwd, commonDir));
+      root = path.dirname(path.resolve(canonicalCwd, commonDir));
     }
   } catch {
-    // not a git checkout / git unavailable — anchor at cwd (legacy behavior)
+    // not a git checkout / git unavailable — anchor at canonicalCwd (legacy behavior)
   }
-  coordinationRootCache.set(cwd, root);
+  coordinationRootCache.set(canonicalCwd, root);
   return root;
 }
 export function defaultRunnerCoordinationFilePathForTarget({ repo, pr }, cwd = process.cwd()) {

--- a/scripts/loop/_pr-runner-coordination.mjs
+++ b/scripts/loop/_pr-runner-coordination.mjs
@@ -88,8 +88,13 @@ function resolveRepoCoordinationRoot(cwd) {
   let canonicalCwd = cwd;
   try {
     canonicalCwd = fs.realpathSync(cwd);
-  } catch {
-    // cwd may not exist yet (or realpath unavailable) — resolve against the raw path
+  } catch (err) {
+    // ponytail: realpathSync on an existing checkout dir virtually never fails;
+    // warn (don't throw) so the rare transient failure — which can desync the
+    // coordination path across worktrees — is diagnosable instead of silent.
+    console.warn(
+      `[runner-coordination] realpathSync(${cwd}) failed; using raw cwd, coordination path may diverge across worktrees: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
   if (coordinationRootCache.has(canonicalCwd)) return coordinationRootCache.get(canonicalCwd);
   let root = canonicalCwd;

--- a/test/loop/pr-runner-coordination.test.mjs
+++ b/test/loop/pr-runner-coordination.test.mjs
@@ -456,6 +456,13 @@ test("detector from repo root sees a worktree runner's refresh (no false-stale)"
   const { repoRoot, wtPath } = await makeRepoWithWorktree();
 
   try {
+    // Resolved coordination path must converge as a STRING across cwds (proves
+    // fs.realpathSync canonicalization, not just I/O round-trip transparency).
+    const fromWt = defaultRunnerCoordinationFilePathForTarget({ repo: "owner/repo", pr: 17 }, wtPath);
+    const fromRoot = defaultRunnerCoordinationFilePathForTarget({ repo: "owner/repo", pr: 17 }, repoRoot);
+    assert.equal(fromWt, fromRoot);
+    assert.ok(fromWt.startsWith(realpathSync(repoRoot)));
+
     await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-wt", cwd: wtPath, now: "2026-06-05T08:00:00.000Z" });
     const refreshed = await claimRunnerOwnership({
       repo: "owner/repo",
@@ -486,6 +493,13 @@ test("no false-stale split: worktree and repo root converge on one coordination 
   const { repoRoot, wtPath } = await makeRepoWithWorktree();
 
   try {
+    // Resolved coordination path must converge as a STRING across cwds (proves
+    // fs.realpathSync canonicalization, not just I/O round-trip transparency).
+    const pathFromWt = defaultRunnerCoordinationFilePathForTarget({ repo: "owner/repo", pr: 17 }, wtPath);
+    const pathFromRoot = defaultRunnerCoordinationFilePathForTarget({ repo: "owner/repo", pr: 17 }, repoRoot);
+    assert.equal(pathFromWt, pathFromRoot);
+    assert.ok(pathFromWt.startsWith(realpathSync(repoRoot)));
+
     await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-wt", cwd: wtPath, now: "2026-06-05T08:00:00.000Z" });
     await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-wt", cwd: wtPath, now: "2026-06-05T08:15:00.000Z" });
 

--- a/test/loop/pr-runner-coordination.test.mjs
+++ b/test/loop/pr-runner-coordination.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { realpathSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -20,12 +21,15 @@ import { runPrRunnerCoordination } from "../../scripts/loop/pr-runner-coordinati
 
 // Builds a throwaway git repo with a linked worktree so cross-CWD coordination
 // path resolution (git-common-dir anchoring) can be exercised for real.
+//
+// repoRoot/wtPath are deliberately left un-realpath'd (raw mkdtemp() output,
+// e.g. macOS's symlinked /var/... rather than /private/var/...): git returns a
+// relative --git-common-dir from a main checkout but an already-realpath'd
+// absolute one from a linked worktree, so the un-normalized paths are what
+// exercise resolveRepoCoordinationRoot's own canonicalization instead of
+// masking a divergence the test helper resolved away.
 async function makeRepoWithWorktree() {
-  // realpath both dirs: macOS mkdtemp() returns /var/... which is a symlink to
-  // /private/var/...; git resolves symlinks internally, so leaving these
-  // unresolved makes the worktree and repo-root paths diverge for reasons
-  // unrelated to the coordination-root fix under test.
-  const repoRoot = await realpath(await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-git-")));
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-git-"));
   const git = (args) => execFileSync("git", args, { cwd: repoRoot, encoding: "utf8" });
   git(["init", "-q"]);
   git(["config", "user.email", "test@example.com"]);
@@ -33,7 +37,7 @@ async function makeRepoWithWorktree() {
   await writeFile(path.join(repoRoot, "README.md"), "init\n", "utf8");
   git(["add", "README.md"]);
   git(["commit", "-q", "-m", "init"]);
-  const wtPath = await realpath(await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-wt-")));
+  const wtPath = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-wt-"));
   git(["worktree", "add", "-q", wtPath, "-b", "issue-1245-wt"]);
   return { repoRoot, wtPath };
 }
@@ -422,10 +426,14 @@ test("cross-CWD claim visibility: worktree and repo root resolve the same coordi
   const { repoRoot, wtPath } = await makeRepoWithWorktree();
 
   try {
-    assert.equal(
-      defaultRunnerCoordinationFilePathForTarget({ repo: "owner/repo", pr: 17 }, wtPath),
-      defaultRunnerCoordinationFilePathForTarget({ repo: "owner/repo", pr: 17 }, repoRoot),
-    );
+    const pathFromWorktree = defaultRunnerCoordinationFilePathForTarget({ repo: "owner/repo", pr: 17 }, wtPath);
+    const pathFromRoot = defaultRunnerCoordinationFilePathForTarget({ repo: "owner/repo", pr: 17 }, repoRoot);
+    assert.equal(pathFromWorktree, pathFromRoot);
+    // repoRoot/wtPath are raw (potentially symlinked) mkdtemp paths; both resolved
+    // coordination paths must land under the *realpath'd* repo root, proving
+    // resolveRepoCoordinationRoot canonicalizes cwd instead of relying on the
+    // caller (or the test helper) to have already done so.
+    assert.ok(pathFromRoot.startsWith(realpathSync(repoRoot)));
 
     const claimedFromWorktree = await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-wt", cwd: wtPath });
     assert.equal(claimedFromWorktree.ok, true);

--- a/test/loop/pr-runner-coordination.test.mjs
+++ b/test/loop/pr-runner-coordination.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -14,7 +15,28 @@ import {
   releaseAsyncRunnerOwnership,
   releaseRunnerOwnership,
 } from "../../scripts/loop/_pr-runner-coordination.mjs";
+import { detectStaleRunner } from "../../scripts/loop/_stale-runner-detection.mjs";
 import { runPrRunnerCoordination } from "../../scripts/loop/pr-runner-coordination.mjs";
+
+// Builds a throwaway git repo with a linked worktree so cross-CWD coordination
+// path resolution (git-common-dir anchoring) can be exercised for real.
+async function makeRepoWithWorktree() {
+  // realpath both dirs: macOS mkdtemp() returns /var/... which is a symlink to
+  // /private/var/...; git resolves symlinks internally, so leaving these
+  // unresolved makes the worktree and repo-root paths diverge for reasons
+  // unrelated to the coordination-root fix under test.
+  const repoRoot = await realpath(await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-git-")));
+  const git = (args) => execFileSync("git", args, { cwd: repoRoot, encoding: "utf8" });
+  git(["init", "-q"]);
+  git(["config", "user.email", "test@example.com"]);
+  git(["config", "user.name", "Test User"]);
+  await writeFile(path.join(repoRoot, "README.md"), "init\n", "utf8");
+  git(["add", "README.md"]);
+  git(["commit", "-q", "-m", "init"]);
+  const wtPath = await realpath(await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-wt-")));
+  git(["worktree", "add", "-q", wtPath, "-b", "issue-1245-wt"]);
+  return { repoRoot, wtPath };
+}
 
 test("runner coordination claims empty PR ownership and refreshes same run", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-"));
@@ -393,5 +415,78 @@ test("releaseAsyncRunnerOwnership is non-fatal (release_error) when the coordina
     assert.ok(typeof result.message === "string" && result.message.length > 0);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("cross-CWD claim visibility: worktree and repo root resolve the same coordination file", async () => {
+  const { repoRoot, wtPath } = await makeRepoWithWorktree();
+
+  try {
+    assert.equal(
+      defaultRunnerCoordinationFilePathForTarget({ repo: "owner/repo", pr: 17 }, wtPath),
+      defaultRunnerCoordinationFilePathForTarget({ repo: "owner/repo", pr: 17 }, repoRoot),
+    );
+
+    const claimedFromWorktree = await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-wt", cwd: wtPath });
+    assert.equal(claimedFromWorktree.ok, true);
+    const confirmedFromRoot = await assertRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-wt", cwd: repoRoot });
+    assert.equal(confirmedFromRoot.ok, true);
+    assert.equal(confirmedFromRoot.status, "owner_confirmed");
+
+    const claimedFromRoot = await claimRunnerOwnership({ repo: "owner/repo", pr: 18, runId: "run-root", cwd: repoRoot });
+    assert.equal(claimedFromRoot.ok, true);
+    const confirmedFromWorktree = await assertRunnerOwnership({ repo: "owner/repo", pr: 18, runId: "run-root", cwd: wtPath });
+    assert.equal(confirmedFromWorktree.ok, true);
+    assert.equal(confirmedFromWorktree.status, "owner_confirmed");
+  } finally {
+    await rm(wtPath, { recursive: true, force: true });
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("detector from repo root sees a worktree runner's refresh (no false-stale)", async () => {
+  const { repoRoot, wtPath } = await makeRepoWithWorktree();
+
+  try {
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-wt", cwd: wtPath, now: "2026-06-05T08:00:00.000Z" });
+    const refreshed = await claimRunnerOwnership({
+      repo: "owner/repo",
+      pr: 17,
+      runId: "run-wt",
+      cwd: wtPath,
+      now: "2026-06-05T08:29:00.000Z",
+    });
+    assert.equal(refreshed.status, "refreshed");
+
+    const detected = await detectStaleRunner({
+      repo: "owner/repo",
+      pr: 17,
+      cwd: repoRoot,
+      now: Date.parse("2026-06-05T08:29:30.000Z"),
+      maxAgeMs: 5 * 60 * 1000,
+    });
+    assert.equal(detected.ok, true);
+    assert.equal(detected.status, "fresh_runner");
+    assert.equal(detected.staleRunner, null);
+  } finally {
+    await rm(wtPath, { recursive: true, force: true });
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("no false-stale split: worktree and repo root converge on one coordination state", async () => {
+  const { repoRoot, wtPath } = await makeRepoWithWorktree();
+
+  try {
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-wt", cwd: wtPath, now: "2026-06-05T08:00:00.000Z" });
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-wt", cwd: wtPath, now: "2026-06-05T08:15:00.000Z" });
+
+    const fromRoot = await loadRunnerCoordinationState({ repo: "owner/repo", pr: 17, cwd: repoRoot });
+    const fromWorktree = await loadRunnerCoordinationState({ repo: "owner/repo", pr: 17, cwd: wtPath });
+    assert.equal(fromRoot.state.activeRun.updatedAt, "2026-06-05T08:15:00.000Z");
+    assert.equal(fromRoot.state.activeRun.updatedAt, fromWorktree.state.activeRun.updatedAt);
+  } finally {
+    await rm(wtPath, { recursive: true, force: true });
+    await rm(repoRoot, { recursive: true, force: true });
   }
 });

--- a/test/loop/pr-runner-coordination.test.mjs
+++ b/test/loop/pr-runner-coordination.test.mjs
@@ -15,6 +15,7 @@ import {
   loadRunnerCoordinationState,
   releaseAsyncRunnerOwnership,
   releaseRunnerOwnership,
+  RUNNER_COORDINATION_HISTORY_LIMIT,
 } from "../../scripts/loop/_pr-runner-coordination.mjs";
 import { detectStaleRunner, STALE_RUNNER_DEFAULT_MAX_AGE_MS } from "../../scripts/loop/_stale-runner-detection.mjs";
 import { runPrRunnerCoordination } from "../../scripts/loop/pr-runner-coordination.mjs";
@@ -556,5 +557,40 @@ test("no false-stale split: worktree and repo root converge on one coordination 
   } finally {
     await rm(wtPath, { recursive: true, force: true });
     await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("history stays bounded across many heartbeats and keeps the newest entries", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-"));
+
+  try {
+    await claimRunnerOwnership({
+      repo: "owner/repo",
+      pr: 17,
+      runId: "run-1",
+      cwd: tempDir,
+      now: "2026-06-05T08:00:00.000Z",
+    });
+
+    const heartbeatCount = 120;
+    for (let i = 0; i < heartbeatCount; i += 1) {
+      const now = new Date(Date.parse("2026-06-05T08:00:01.000Z") + i * 1000).toISOString();
+      const asserted = await assertRunnerOwnership({
+        repo: "owner/repo",
+        pr: 17,
+        runId: "run-1",
+        cwd: tempDir,
+        now,
+      });
+      assert.equal(asserted.ok, true);
+      assert.equal(asserted.status, "owner_confirmed");
+    }
+
+    const loaded = await loadRunnerCoordinationState({ repo: "owner/repo", pr: 17, cwd: tempDir });
+    assert.ok(loaded.state.history.length <= RUNNER_COORDINATION_HISTORY_LIMIT);
+    const newest = loaded.state.history.at(-1);
+    assert.equal(newest.type, "heartbeat");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
   }
 });

--- a/test/loop/pr-runner-coordination.test.mjs
+++ b/test/loop/pr-runner-coordination.test.mjs
@@ -16,7 +16,7 @@ import {
   releaseAsyncRunnerOwnership,
   releaseRunnerOwnership,
 } from "../../scripts/loop/_pr-runner-coordination.mjs";
-import { detectStaleRunner } from "../../scripts/loop/_stale-runner-detection.mjs";
+import { detectStaleRunner, STALE_RUNNER_DEFAULT_MAX_AGE_MS } from "../../scripts/loop/_stale-runner-detection.mjs";
 import { runPrRunnerCoordination } from "../../scripts/loop/pr-runner-coordination.mjs";
 
 // Builds a throwaway git repo with a linked worktree so cross-CWD coordination
@@ -104,6 +104,52 @@ test("runner coordination fails closed for second claim and allows explicit take
     assert.equal(staleAssert.ok, false);
     assert.equal(staleAssert.error, "ownership_lost");
     assert.equal(staleAssert.activeRun.runId, "run-2");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("owner-confirmed assert refreshes updatedAt so a long gate cycle stays non-stale", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-"));
+  const t0 = Date.parse("2026-01-01T00:00:00.000Z");
+  const isoAt = (offsetMs) => new Date(t0 + offsetMs).toISOString();
+
+  try {
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-1", cwd: tempDir, now: isoAt(0) });
+
+    let lastAssertedAt = isoAt(0);
+    for (const offsetMinutes of [20, 40, 60]) {
+      const at = isoAt(offsetMinutes * 60 * 1000);
+      const asserted = await assertRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-1", cwd: tempDir, now: at });
+      assert.equal(asserted.ok, true);
+      assert.equal(asserted.status, "owner_confirmed");
+      assert.equal(asserted.activeRun.updatedAt, at);
+      lastAssertedAt = at;
+    }
+
+    // 65 min after claim / 5 min after last assert: claimedAt is stale-old but
+    // the refreshed updatedAt keeps the runner fresh.
+    const freshCheck = await detectStaleRunner({
+      repo: "owner/repo",
+      pr: 17,
+      cwd: tempDir,
+      now: Date.parse(lastAssertedAt) + 5 * 60 * 1000,
+      maxAgeMs: STALE_RUNNER_DEFAULT_MAX_AGE_MS,
+    });
+    assert.equal(freshCheck.staleRunner, null);
+    assert.equal(freshCheck.status, "fresh_runner");
+
+    // Discrimination: with no further assert, 40 min after the last assert
+    // both claimedAt and updatedAt exceed maxAge, so it IS stale — proving
+    // the refresh (not some other mechanism) was what kept it alive above.
+    const staleCheck = await detectStaleRunner({
+      repo: "owner/repo",
+      pr: 17,
+      cwd: tempDir,
+      now: Date.parse(lastAssertedAt) + 40 * 60 * 1000,
+      maxAgeMs: STALE_RUNNER_DEFAULT_MAX_AGE_MS,
+    });
+    assert.notEqual(staleCheck.staleRunner, null);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Fixes a CWD-relative coordination bug: `defaultRunnerCoordinationFilePathForTarget` in `scripts/loop/_pr-runner-coordination.mjs` keyed the per-PR run-claim file off `process.cwd()`, so a worktree runner (cwd = `tmp/worktrees/…/issue-<n>`) and a repo-root detector read/wrote **different** `.pi/runner-coordination/<owner>/<name>/pr-<n>.json` copies. A live, refreshing claim looked perpetually **stale** to any reader outside the runner's CWD — this stalled PR #1242 until the claim was manually released.

## Fix

Anchor the claim store at a single stable location per checkout, independent of CWD, via `git rev-parse --git-common-dir` (identical for a repo and all its linked worktrees; its parent is the shared main-checkout root). All worktrees and the repo root now read/write one file. Falls back to `cwd` when git is unavailable or the dir is not a checkout (preserves legacy behavior for non-git temp dirs). Resolution is cached per cwd.

`_stale-runner-detection.mjs` inherits the fix automatically (it threads `cwd` through `loadRunnerCoordinationState`); no change needed there or in the `detect-checkpoint-evidence.mjs` multi-checkout fallback (left as harmless belt-and-suspenders).

## Tests

Three regression tests added against a **real** throwaway git repo + linked worktree:
- cross-CWD claim visibility (claim from worktree confirmed as owner from repo root, and vice-versa; identical resolved path)
- detector from repo root sees a worktree runner's refresh — no false-stale (`detectStaleRunner` returns `staleRunner: null` / `status: "fresh_runner"`)
- single-file convergence (same `activeRun.updatedAt` from both CWDs)

Full `npm run verify` green; downstream importers (`copilot-pr-handoff`, `detect-checkpoint-evidence`, `upsert-checkpoint-verdict`) unaffected.

## Lease heartbeat (issue #1245 "Also fix")

`assertRunnerOwnership` previously verified ownership without refreshing `updatedAt`, so during a long multi-round gate cycle the lease could be seen as stale even though the owning runner was alive and asserting (it had to re-`claim` to refresh). Now an **owner-confirmed** assert bumps `updatedAt` under the coordination-file lock (a heartbeat) and appends a `heartbeat` history entry; non-owner asserts remain pure reads (a dead owner's lease is never kept alive by another run). Long-running loops stay non-stale as long as they assert or claim at least once within the stale-max-age window (`STALE_RUNNER_DEFAULT_MAX_AGE_MS`, 30 min; overridable via `DEVLOOPS_STALE_RUNNER_MAX_AGE_MS`). Regression test asserts repeatedly past the stale window and confirms the claim stays non-stale (with a discrimination check that it goes stale without the refresh).

## Migration note

Existing split `.pi/runner-coordination/` copies previously written under a worktree's own CWD become dead/orphaned once the path unifies at the git-common-dir root — state-only stale files, no migration code needed. One narrow, self-healing caveat during the rollout crossover: an *active* claim recorded only at an old cwd-joined path is invisible to a reader already running the new code (it resolves the new git-common-dir path and sees `no_owner_record`) until the owning process's next check re-claims at the new path. The window is narrow and one-shot, not a lasting defect.

Closes #1245
