### PR TITLE
feat(tooling): sanctioned edit-issue.mjs wrapper for the AC-reflection step + allow rule

### DIFF
--- a/.claude/hooks/_bash-command-classify.mjs
+++ b/.claude/hooks/_bash-command-classify.mjs
@@ -235,18 +235,19 @@ function extractRepoFlagsFromGhSubcmdVerbSegments(command, subcmd, verb) {
 
 /**
  * The raw external-write verb forms that must be blocked when originating from a subagent:
- * ad-hoc GitHub issue/PR creation and comments run directly via `gh` (not the sanctioned node
- * wrappers). Each entry is `[subcmd, verb]`.
+ * ad-hoc GitHub issue/PR creation, comments, and edits run directly via `gh` (not the sanctioned
+ * node wrappers). Each entry is `[subcmd, verb]`.
  */
 const EXTERNAL_WRITE_VERB_FORMS = Object.freeze([
   ["issue", "create"],
   ["issue", "comment"],
+  ["issue", "edit"],
   ["pr", "comment"],
 ]);
 
 /**
- * Whether `command` contains a raw `gh issue create`, `gh issue comment`, or `gh pr comment`
- * invocation in ANY shell segment (ignoring --help/-h). PreToolUse gate use only — the gate
+ * Whether `command` contains a raw `gh issue create`, `gh issue comment`, `gh issue edit`, or
+ * `gh pr comment` invocation in ANY shell segment (ignoring --help/-h). PreToolUse gate use only — the gate
  * blocks these when they originate from a subagent context. Node-wrapper commands
  * (`node scripts/github/comment-issue.mjs …`) never match (first token is `node`, not `gh`).
  * @param {string} command @returns {boolean}
@@ -256,8 +257,8 @@ export function commandContainsRawExternalWrite(command) {
 }
 
 /**
- * Return `{ segment, explicitRepo }` for every raw external-write segment across all three verb
- * forms (`gh issue create` / `gh issue comment` / `gh pr comment`). PreToolUse gate use only —
+ * Return `{ segment, explicitRepo }` for every raw external-write segment across all four verb
+ * forms (`gh issue create` / `gh issue comment` / `gh issue edit` / `gh pr comment`). PreToolUse gate use only —
  * lets the gate decide in-scope-ness per segment so a leading out-of-scope write can't shield a
  * later in-scope one. `explicitRepo` is the segment's `--repo`/`-R` value or null.
  * @param {string} command @returns {{ segment: string, explicitRepo: string|null }[]}

--- a/.claude/hooks/_hook-decisions.mjs
+++ b/.claude/hooks/_hook-decisions.mjs
@@ -104,7 +104,8 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
         reason:
           "Ad-hoc GitHub issue/PR creation, comments, and edits from a subagent are blocked. Use the sanctioned " +
           "node wrappers instead — gate-verdict comments via scripts/github/upsert-checkpoint-verdict.mjs, " +
-          "review-thread replies via scripts/github/reply-resolve*.mjs, board sync, or scripts/github/comment-issue.mjs. " +
+          "review-thread replies via scripts/github/reply-resolve*.mjs, board sync, issue comments via " +
+          "scripts/github/comment-issue.mjs, or issue-body edits via scripts/github/edit-issue.mjs. " +
           "Direct `gh issue create` is reserved for the main agent / operator.",
       };
     }

--- a/.claude/hooks/_hook-decisions.mjs
+++ b/.claude/hooks/_hook-decisions.mjs
@@ -62,7 +62,7 @@ export const DEV_LOOP_AGENT_TYPE = "dev-loop";
  *     clean current-head draft_gate + pre_approval_gate). The loop runs this check before merging;
  *     gating it here closes the hole where a hand-run `gh pr merge` skips the pre-approval gate
  *     entirely. Everything else passes through.
- *   - raw `gh issue create` / `gh issue comment` / `gh pr comment` — blocked ONLY when the call
+ *   - raw `gh issue create` / `gh issue comment` / `gh issue edit` / `gh pr comment` — blocked ONLY when the call
  *     originates from a SUBAGENT context (`agentType` is a non-null string) and targets the repo.
  *     Sanctioned external writes flow through node wrappers (gate-verdict comments via
  *     `upsert-checkpoint-verdict.mjs`, review replies via `reply-resolve*.mjs`, board sync,
@@ -86,7 +86,7 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
     return ALLOW;
   }
   // Subagent-scoped external-write guard: block ad-hoc `gh issue create`/`gh issue comment`/
-  // `gh pr comment` on the target repo from a subagent, so external writes flow through the
+  // `gh issue edit`/`gh pr comment` on the target repo from a subagent, so external writes flow through the
   // sanctioned node wrappers. The main-agent/operator path (agentType null) is unaffected (#1051).
   if (typeof agentType === "string" && commandContainsRawExternalWrite(command)) {
     const cwdTargets = (repoSlug ?? "").toLowerCase() === TARGET_REPO_SLUG.toLowerCase();
@@ -102,7 +102,7 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
       return {
         decision: "deny",
         reason:
-          "Ad-hoc GitHub issue/PR creation and comments from a subagent are blocked. Use the sanctioned " +
+          "Ad-hoc GitHub issue/PR creation, comments, and edits from a subagent are blocked. Use the sanctioned " +
           "node wrappers instead — gate-verdict comments via scripts/github/upsert-checkpoint-verdict.mjs, " +
           "review-thread replies via scripts/github/reply-resolve*.mjs, board sync, or scripts/github/comment-issue.mjs. " +
           "Direct `gh issue create` is reserved for the main agent / operator.",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(node scripts/github/edit-issue.mjs:*)"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/.claude/skills/docs/acceptance-criteria-verification.md
+++ b/.claude/skills/docs/acceptance-criteria-verification.md
@@ -25,7 +25,7 @@ Canonical owner for the acceptance-criteria verification procedure run during th
 
 4. **Verify each AC item** against the proposed changes on the current PR head.
 
-5. **Update the issue body once:** compute the fully-updated issue body by replacing each verified item's `- [ ]` with `- [x]`, write it to a temporary file, and perform a single `gh issue edit <issue-number> --body-file <tmp-file> --repo <owner/name>`. Do not issue one edit per item; prefer `--body-file` over inline `--body` to avoid shell quoting/escaping hazards.
+5. **Update the issue body once:** compute the fully-updated issue body by replacing each verified item's `- [ ]` with `- [x]`, write it to a temporary file, and perform a single `node scripts/github/edit-issue.mjs --repo <owner/name> --issue <issue-number> --body-file <tmp-file>`. Do not issue one edit per item; prefer `--body-file` over inline `--body` to avoid shell quoting/escaping hazards.
 
 6. **Tick the PR body once:** after the verification is clean, flip each verified item's `- [ ]` to `- [x]` in the PR body via a single `gh pr edit --body-file` update, so the merged PR shows checked AC/DoD. Run `node scripts/github/tick-verified-checkboxes.mjs --repo <owner/name> --pr <pr-number> --verified <exact label>...` (one edit; exact-label match; only items actually verified are ticked; unverified or deferred items stay `- [ ]`; fail closed). This runs automatically as part of the `pre_approval_gate`, not by memory.
 

--- a/.claude/skills/docs/retrospective-checkpoint-contract.md
+++ b/.claude/skills/docs/retrospective-checkpoint-contract.md
@@ -135,10 +135,13 @@ scripts legitimately call `gh`/GraphQL internally; that is the tooling. The rule
 targets the agent's own top-level shell calls, not a script's internals.
 
 **Write-op allowlist (verifier only):** `gh pr merge`, `gh pr ready`,
-`gh issue create`, `gh issue edit` have no internal wrapper today. The deterministic
-verifier records these as `allowedWriteOps` rather than violations so they are
-surfaced distinctly, not as breaches. Close the gap with a wrapper to remove an
-entry. None of these block anything.
+`gh issue create` have no internal wrapper today. `gh issue edit` now has one
+(`scripts/github/edit-issue.mjs`) and stays as a belt-and-suspenders entry — like
+`gh label create` (`scripts/github/create-label.mjs`) — so a bare invocation
+surfaced from the wrapper's own subprocess is not miscounted as a breach. The
+deterministic verifier records all of these as `allowedWriteOps` rather than
+violations so they are surfaced distinctly, not as breaches. Close the gap with a
+wrapper to remove or reframe a no-wrapper entry. None of these block anything.
 
 **Inline-interpreter check item:** the raw-call scan below mechanically catches
 `node -e`/`python3 -c`/heredoc calls as a `rawCallViolations` entry — the same

--- a/packages/core/src/claude/hook-decisions.mjs
+++ b/packages/core/src/claude/hook-decisions.mjs
@@ -61,7 +61,7 @@ export const DEV_LOOP_AGENT_TYPE = "dev-loop";
  *     clean current-head draft_gate + pre_approval_gate). The loop runs this check before merging;
  *     gating it here closes the hole where a hand-run `gh pr merge` skips the pre-approval gate
  *     entirely. Everything else passes through.
- *   - raw `gh issue create` / `gh issue comment` / `gh pr comment` — blocked ONLY when the call
+ *   - raw `gh issue create` / `gh issue comment` / `gh issue edit` / `gh pr comment` — blocked ONLY when the call
  *     originates from a SUBAGENT context (`agentType` is a non-null string) and targets the repo.
  *     Sanctioned external writes flow through node wrappers (gate-verdict comments via
  *     `upsert-checkpoint-verdict.mjs`, review replies via `reply-resolve*.mjs`, board sync,
@@ -85,7 +85,7 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
     return ALLOW;
   }
   // Subagent-scoped external-write guard: block ad-hoc `gh issue create`/`gh issue comment`/
-  // `gh pr comment` on the target repo from a subagent, so external writes flow through the
+  // `gh issue edit`/`gh pr comment` on the target repo from a subagent, so external writes flow through the
   // sanctioned node wrappers. The main-agent/operator path (agentType null) is unaffected (#1051).
   if (typeof agentType === "string" && commandContainsRawExternalWrite(command)) {
     const cwdTargets = (repoSlug ?? "").toLowerCase() === TARGET_REPO_SLUG.toLowerCase();
@@ -101,7 +101,7 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
       return {
         decision: "deny",
         reason:
-          "Ad-hoc GitHub issue/PR creation and comments from a subagent are blocked. Use the sanctioned " +
+          "Ad-hoc GitHub issue/PR creation, comments, and edits from a subagent are blocked. Use the sanctioned " +
           "node wrappers instead — gate-verdict comments via scripts/github/upsert-checkpoint-verdict.mjs, " +
           "review-thread replies via scripts/github/reply-resolve*.mjs, board sync, or scripts/github/comment-issue.mjs. " +
           "Direct `gh issue create` is reserved for the main agent / operator.",

--- a/packages/core/src/claude/hook-decisions.mjs
+++ b/packages/core/src/claude/hook-decisions.mjs
@@ -103,7 +103,8 @@ export function decideBashGate({ command, repoSlug = null, gatePassed = false, g
         reason:
           "Ad-hoc GitHub issue/PR creation, comments, and edits from a subagent are blocked. Use the sanctioned " +
           "node wrappers instead — gate-verdict comments via scripts/github/upsert-checkpoint-verdict.mjs, " +
-          "review-thread replies via scripts/github/reply-resolve*.mjs, board sync, or scripts/github/comment-issue.mjs. " +
+          "review-thread replies via scripts/github/reply-resolve*.mjs, board sync, issue comments via " +
+          "scripts/github/comment-issue.mjs, or issue-body edits via scripts/github/edit-issue.mjs. " +
           "Direct `gh issue create` is reserved for the main agent / operator.",
       };
     }

--- a/packages/core/src/loop/bash-command-classify.mjs
+++ b/packages/core/src/loop/bash-command-classify.mjs
@@ -234,18 +234,19 @@ function extractRepoFlagsFromGhSubcmdVerbSegments(command, subcmd, verb) {
 
 /**
  * The raw external-write verb forms that must be blocked when originating from a subagent:
- * ad-hoc GitHub issue/PR creation and comments run directly via `gh` (not the sanctioned node
- * wrappers). Each entry is `[subcmd, verb]`.
+ * ad-hoc GitHub issue/PR creation, comments, and edits run directly via `gh` (not the sanctioned
+ * node wrappers). Each entry is `[subcmd, verb]`.
  */
 const EXTERNAL_WRITE_VERB_FORMS = Object.freeze([
   ["issue", "create"],
   ["issue", "comment"],
+  ["issue", "edit"],
   ["pr", "comment"],
 ]);
 
 /**
- * Whether `command` contains a raw `gh issue create`, `gh issue comment`, or `gh pr comment`
- * invocation in ANY shell segment (ignoring --help/-h). PreToolUse gate use only — the gate
+ * Whether `command` contains a raw `gh issue create`, `gh issue comment`, `gh issue edit`, or
+ * `gh pr comment` invocation in ANY shell segment (ignoring --help/-h). PreToolUse gate use only — the gate
  * blocks these when they originate from a subagent context. Node-wrapper commands
  * (`node scripts/github/comment-issue.mjs …`) never match (first token is `node`, not `gh`).
  * @param {string} command @returns {boolean}
@@ -255,8 +256,8 @@ export function commandContainsRawExternalWrite(command) {
 }
 
 /**
- * Return `{ segment, explicitRepo }` for every raw external-write segment across all three verb
- * forms (`gh issue create` / `gh issue comment` / `gh pr comment`). PreToolUse gate use only —
+ * Return `{ segment, explicitRepo }` for every raw external-write segment across all four verb
+ * forms (`gh issue create` / `gh issue comment` / `gh issue edit` / `gh pr comment`). PreToolUse gate use only —
  * lets the gate decide in-scope-ness per segment so a leading out-of-scope write can't shield a
  * later in-scope one. `explicitRepo` is the segment's `--repo`/`-R` value or null.
  * @param {string} command @returns {{ segment: string, explicitRepo: string|null }[]}

--- a/packages/core/test/bash-command-classify.test.mjs
+++ b/packages/core/test/bash-command-classify.test.mjs
@@ -137,13 +137,17 @@ test("extractRepoFlagsFromGhPrCreateSegments returns every create segment's --re
 test("commandContainsRawExternalWrite detects raw issue/pr create+comment in any segment", () => {
   assert.equal(commandContainsRawExternalWrite("gh issue create --title x --body y"), true);
   assert.equal(commandContainsRawExternalWrite("gh issue comment 5 --body hi"), true);
+  assert.equal(commandContainsRawExternalWrite("gh issue edit 5 --body-file x"), true);
   assert.equal(commandContainsRawExternalWrite("gh pr comment 5 --body hi"), true);
   assert.equal(commandContainsRawExternalWrite("git push && gh issue create --title x"), true);
+  assert.equal(commandContainsRawExternalWrite("echo ok && gh issue edit 5 --body-file x"), true);
   // --help is not a write
   assert.equal(commandContainsRawExternalWrite("gh issue create --help"), false);
   assert.equal(commandContainsRawExternalWrite("gh issue comment --help"), false);
+  assert.equal(commandContainsRawExternalWrite("gh issue edit --help"), false);
   // node wrappers never match — first token is `node`, not `gh`
   assert.equal(commandContainsRawExternalWrite("node scripts/github/comment-issue.mjs 5 --body hi"), false);
+  assert.equal(commandContainsRawExternalWrite("node scripts/github/edit-issue.mjs 5 --body-file x"), false);
   assert.equal(commandContainsRawExternalWrite("node scripts/github/upsert-checkpoint-verdict.mjs"), false);
   // pr create / issue view etc. are not external-write forms here
   assert.equal(commandContainsRawExternalWrite("gh pr create --fill"), false);

--- a/packages/core/test/claude-hook-decisions.test.mjs
+++ b/packages/core/test/claude-hook-decisions.test.mjs
@@ -239,6 +239,27 @@ test("decideBashGate denies raw gh issue/pr comment from a subagent on the targe
   );
 });
 
+test("decideBashGate denies raw gh issue edit from a subagent on the target repo", () => {
+  assert.equal(
+    decideBashGate({ command: "gh issue edit 5 --body-file x", repoSlug: TARGET, agentType: SUB }).decision,
+    "deny",
+  );
+});
+
+test("decideBashGate ALLOWS raw gh issue edit from the MAIN agent (agentType null)", () => {
+  assert.equal(
+    decideBashGate({ command: "gh issue edit 5 --body-file x", repoSlug: TARGET, agentType: null }).decision,
+    "allow",
+  );
+});
+
+test("decideBashGate allows subagent gh issue edit with an explicit non-target --repo", () => {
+  assert.equal(
+    decideBashGate({ command: "gh issue edit 5 --repo other/repo --body-file x", repoSlug: TARGET, agentType: SUB }).decision,
+    "allow",
+  );
+});
+
 test("decideBashGate allows subagent gh issue create with an explicit non-target --repo", () => {
   assert.equal(
     decideBashGate({ command: "gh issue create --repo other/repo --title x", repoSlug: TARGET, agentType: SUB }).decision,

--- a/scripts/github/edit-issue.mjs
+++ b/scripts/github/edit-issue.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { parseIssueNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
+import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
+import { parseArgs } from "node:util";
+import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+
+const USAGE = `Usage: edit-issue.mjs --repo <owner/name> --issue <number> [--title <t>] [--body <b> | --body-file <path>] [--add-assignee <u>] [--remove-assignee <u>] [--milestone <m>]
+Edit issue title/body/assignees/milestone. Thin wrapper over \`gh issue edit\` — use this
+instead of an agent-level raw \`gh issue edit\` so the loop's internal-tooling record
+stays clean (siblings: edit-pr.mjs, comment-issue.mjs).
+Required:
+  --repo <owner/name>           Repository slug (e.g. owner/repo)
+  --issue <number>              Issue number
+At least one edit:
+  --title <t>                   New issue title
+  --body <b>                    New issue body as a single argument
+  --body-file <path>            Read the new body from a file (- reads stdin)
+  --add-assignee <u>            Assignee to add (repeatable)
+  --remove-assignee <u>         Assignee to remove (repeatable)
+  --milestone <m>               Milestone to set (empty string clears it)
+                                (--title/--body/--body-file reject empty or
+                                whitespace-only values; use --milestone "" only
+                                to clear the milestone)
+Output (stdout, JSON):
+  { "ok": true, "repo": "owner/repo", "issue": 17, "edited": ["title", "body", ...] }
+Error output (stderr, JSON):
+  { "ok": false, "error": "...", "usage"?: "..." }
+${JQ_OUTPUT_USAGE}
+Exit codes:
+  0  Success
+  1  Argument error or gh failure
+  2  Invalid --jq filter`.trim();
+const parseError = buildParseError(USAGE);
+
+export function parseEditIssueCliArgs(argv) {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      issue: { type: "string" },
+      title: { type: "string" },
+      body: { type: "string" },
+      "body-file": { type: "string" },
+      "add-assignee": { type: "string", multiple: true },
+      "remove-assignee": { type: "string", multiple: true },
+      milestone: { type: "string" },
+      ...JQ_OUTPUT_PARSE_OPTIONS,
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  const options = {
+    help: false,
+    repo: undefined,
+    issue: undefined,
+    title: undefined,
+    body: undefined,
+    bodyFile: undefined,
+    addAssignees: [],
+    removeAssignees: [],
+    milestone: undefined,
+    jq: undefined,
+    silent: false,
+  };
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
+      options.help = true;
+      return options;
+    }
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
+      continue;
+    }
+    if (token.name === "issue") {
+      options.issue = parseIssueNumber(requireTokenValue(token, parseError), parseError);
+      continue;
+    }
+    if (token.name === "title") {
+      const title = requireTokenValue(token, parseError);
+      if (title.trim().length === 0) {
+        throw parseError("--title must not be empty or whitespace-only");
+      }
+      options.title = title;
+      continue;
+    }
+    if (token.name === "body") {
+      const body = requireTokenValue(token, parseError);
+      if (body.trim().length === 0) {
+        throw parseError("--body must not be empty or whitespace-only");
+      }
+      options.body = body;
+      continue;
+    }
+    if (token.name === "body-file") {
+      const rawPath = requireTokenValue(token, parseError).trim();
+      if (rawPath.length === 0) {
+        throw parseError("--body-file must be a non-empty path");
+      }
+      options.bodyFile = rawPath;
+      continue;
+    }
+    if (token.name === "add-assignee") {
+      const u = requireTokenValue(token, parseError).trim();
+      if (u.length === 0) throw parseError("--add-assignee must be a non-empty login");
+      options.addAssignees.push(u);
+      continue;
+    }
+    if (token.name === "remove-assignee") {
+      const u = requireTokenValue(token, parseError).trim();
+      if (u.length === 0) throw parseError("--remove-assignee must be a non-empty login");
+      options.removeAssignees.push(u);
+      continue;
+    }
+    if (token.name === "milestone") {
+      // Read the raw token value: an empty string is a valid milestone value
+      // (`gh issue edit --milestone ""` clears it), so this deliberately does NOT
+      // go through requireTokenValue (which rejects empty). Guard only a truly
+      // missing value (`--milestone` with no following token). A whitespace-only
+      // value is neither a clear nor a real milestone name — fail closed rather
+      // than forwarding it to gh for a less actionable error.
+      if (typeof token.value !== "string") {
+        throw parseError("--milestone requires a value (use an empty string to clear)");
+      }
+      if (token.value.length > 0 && token.value.trim().length === 0) {
+        throw parseError('--milestone must be a milestone name or "" to clear (whitespace-only is not allowed)');
+      }
+      options.milestone = token.value;
+      continue;
+    }
+    if (matchJqOutputToken(token, options, (t) => requireTokenValue(t, parseError))) continue;
+    throw parseError(`Unknown argument: ${token.rawName}`);
+  }
+  if (options.repo === undefined || options.issue === undefined) {
+    throw parseError("Editing an issue requires both --repo <owner/name> and --issue <number>");
+  }
+  if (options.body !== undefined && options.bodyFile !== undefined) {
+    throw parseError("--body and --body-file are mutually exclusive; pass only one");
+  }
+  const hasEdit =
+    options.title !== undefined ||
+    options.body !== undefined ||
+    options.bodyFile !== undefined ||
+    options.addAssignees.length > 0 ||
+    options.removeAssignees.length > 0 ||
+    options.milestone !== undefined;
+  if (!hasEdit) {
+    throw parseError("Editing an issue requires at least one of --title/--body/--body-file/--add-assignee/--remove-assignee/--milestone");
+  }
+  try {
+    parseRepoSlug(options.repo);
+  } catch (error) {
+    throw parseError(error instanceof Error ? error.message : String(error));
+  }
+  return options;
+}
+
+async function resolveBody(options) {
+  if (options.bodyFile === undefined) return options.body;
+  // Stdin (fd 0): the fs/promises readFile does NOT accept an integer fd, so read
+  // it synchronously via the callback-style API (which does). A real path stays on
+  // the async promise read.
+  const body =
+    options.bodyFile === "-" ? readFileSync(0, "utf8") : await readFile(options.bodyFile, "utf8");
+  // Fail closed on an empty / whitespace-only file so a blank --body-file cannot
+  // silently clear the issue body (USAGE promises --body/--title reject empties).
+  if (body.trim().length === 0) {
+    throw new Error(`--body-file ${options.bodyFile} is empty`);
+  }
+  return body;
+}
+
+// Build the `gh issue edit` args and the parallel `edited` list (which fields were
+// touched) so callers get a stable summary without re-reading the issue.
+async function buildEditArgs(options) {
+  const args = ["issue", "edit", String(options.issue), "--repo", options.repo];
+  const edited = [];
+  if (options.title !== undefined) {
+    args.push("--title", options.title);
+    edited.push("title");
+  }
+  // resolveBody still runs for validation (reads the file, throws on empty /
+  // whitespace-only). A REAL --body-file path is handed straight to gh so large
+  // bodies avoid command-length limits. But `--body-file -` (stdin) was already
+  // consumed by resolveBody reading fd 0; re-emitting `--body-file -` makes gh
+  // re-read an exhausted stdin and clear the body, so pass the resolved string
+  // inline via --body instead.
+  const body = await resolveBody(options);
+  if (body !== undefined) {
+    if (options.bodyFile !== undefined && options.bodyFile !== "-") {
+      args.push("--body-file", options.bodyFile);
+    } else {
+      args.push("--body", body);
+    }
+    edited.push("body");
+  }
+  for (const u of options.addAssignees) {
+    args.push("--add-assignee", u);
+  }
+  if (options.addAssignees.length > 0) edited.push("add-assignee");
+  for (const u of options.removeAssignees) {
+    args.push("--remove-assignee", u);
+  }
+  if (options.removeAssignees.length > 0) edited.push("remove-assignee");
+  if (options.milestone !== undefined) {
+    args.push("--milestone", options.milestone);
+    edited.push("milestone");
+  }
+  return { args, edited };
+}
+
+export async function editIssue(options, { env = process.env, ghCommand = "gh", run = runChild } = {}) {
+  const { args, edited } = await buildEditArgs(options);
+  const result = await run(ghCommand, args, env);
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw new Error(`gh issue edit failed: ${detail}`);
+  }
+  return { ok: true, repo: options.repo, issue: options.issue, edited };
+}
+
+export async function runCli(
+  argv = process.argv.slice(2),
+  { stdout = process.stdout, stderr = process.stderr, env = process.env, ghCommand = "gh", run = runChild } = {},
+) {
+  let options;
+  try {
+    options = parseEditIssueCliArgs(argv);
+  } catch (error) {
+    stderr.write(`${formatCliError(error)}\n`);
+    return 1;
+  }
+  if (options.help) {
+    stdout.write(`${USAGE}\n`);
+    return 0;
+  }
+  let result;
+  try {
+    result = await editIssue(options, { env, ghCommand, run });
+  } catch (error) {
+    stderr.write(`${JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) })}\n`);
+    return 1;
+  }
+  return emitResult(result, { jq: options.jq, silent: options.silent, stdout, stderr });
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli().then((code) => { process.exitCode = code; });
+}

--- a/scripts/loop/check-retro-tooling.mjs
+++ b/scripts/loop/check-retro-tooling.mjs
@@ -24,10 +24,13 @@
  *   - dev-loops subcommands and `node scripts/....mjs` invocations. Those scripts
  *     legitimately call gh/GraphQL/etc. internally — that IS the tooling.
  *   - A small explicit allowlist of write-ops that have no internal wrapper today:
- *     `gh pr merge`, `gh pr ready`, `gh issue create`, `gh issue edit`. These are
- *     recorded as `allowedWriteOps` rather than violations so the gate is not
+ *     `gh pr merge`, `gh pr ready`, `gh issue create`. Plus belt-and-suspenders
+ *     entries that DO have wrappers — `gh issue edit` (scripts/github/edit-issue.mjs)
+ *     and `gh label create` (scripts/github/create-label.mjs) — kept so a bare
+ *     invocation surfaced from the wrapper's own subprocess is not a false violation.
+ *     All are recorded as `allowedWriteOps` rather than violations so the gate is not
  *     blocked forever on an unavoidable gap. Document/close the gap with a wrapper
- *     to remove them from the allowlist.
+ *     to remove the no-wrapper entries from the allowlist.
  *
  * VIOLATION (agent-level raw call):
  *   - `gh ...` at the start of a command segment (start of line, or after
@@ -75,19 +78,21 @@ Exit codes:
   2  Argument/runtime error, or invalid --jq filter`;
 
 /**
- * Write-ops that currently have no internal dev-loops wrapper. Recorded
- * distinctly so the gate is not blocked forever on an unavoidable gap.
- * Keep this set SMALL and explicit; remove an entry once a wrapper exists.
+ * Write-ops recorded distinctly (as allowedWriteOps, not violations) so the gate
+ * is not blocked forever on an unavoidable gap. Most have no internal wrapper yet;
+ * a couple DO have wrappers and are kept belt-and-suspenders (see below).
+ * Keep this set SMALL and explicit; remove a no-wrapper entry once a wrapper exists.
  * @type {ReadonlyArray<RegExp>}
  */
 const ALLOWED_WRITE_OPS = Object.freeze([
   /^gh\s+pr\s+merge\b/,
   /^gh\s+pr\s+ready\b/,
   /^gh\s+issue\s+create\b/,
+  // `gh issue edit` (scripts/github/edit-issue.mjs) and `gh label create`
+  // (scripts/github/create-label.mjs) both HAVE wrappers; these entries are
+  // belt-and-suspenders so a bare invocation (e.g. surfaced from the wrapper's
+  // own subprocess) classifies as an allowed write-op, not a violation.
   /^gh\s+issue\s+edit\b/,
-  // `gh label create` HAS a wrapper (scripts/github/create-label.mjs); this
-  // entry is belt-and-suspenders so a bare invocation (e.g. surfaced from the
-  // wrapper's own subprocess) classifies as an allowed write-op, not a violation.
   /^gh\s+label\s+create\b/,
 ]);
 

--- a/scripts/loop/sanctioned-commands.mjs
+++ b/scripts/loop/sanctioned-commands.mjs
@@ -37,6 +37,7 @@ export const SANCTIONED_COMMANDS = Object.freeze({
   // Metadata edits.
   edits: Object.freeze({
     "pr-body-title-assignee-milestone": "scripts/github/edit-pr.mjs",
+    "issue-body-title-assignee-milestone": "scripts/github/edit-issue.mjs",
     "issue-comment": "scripts/github/comment-issue.mjs",
   }),
 

--- a/skills/docs/acceptance-criteria-verification.md
+++ b/skills/docs/acceptance-criteria-verification.md
@@ -25,7 +25,7 @@ Canonical owner for the acceptance-criteria verification procedure run during th
 
 4. **Verify each AC item** against the proposed changes on the current PR head.
 
-5. **Update the issue body once:** compute the fully-updated issue body by replacing each verified item's `- [ ]` with `- [x]`, write it to a temporary file, and perform a single `gh issue edit <issue-number> --body-file <tmp-file> --repo <owner/name>`. Do not issue one edit per item; prefer `--body-file` over inline `--body` to avoid shell quoting/escaping hazards.
+5. **Update the issue body once:** compute the fully-updated issue body by replacing each verified item's `- [ ]` with `- [x]`, write it to a temporary file, and perform a single `node scripts/github/edit-issue.mjs --repo <owner/name> --issue <issue-number> --body-file <tmp-file>`. Do not issue one edit per item; prefer `--body-file` over inline `--body` to avoid shell quoting/escaping hazards.
 
 6. **Tick the PR body once:** after the verification is clean, flip each verified item's `- [ ]` to `- [x]` in the PR body via a single `gh pr edit --body-file` update, so the merged PR shows checked AC/DoD. Run `node scripts/github/tick-verified-checkboxes.mjs --repo <owner/name> --pr <pr-number> --verified <exact label>...` (one edit; exact-label match; only items actually verified are ticked; unverified or deferred items stay `- [ ]`; fail closed). This runs automatically as part of the `pre_approval_gate`, not by memory.
 

--- a/skills/docs/retrospective-checkpoint-contract.md
+++ b/skills/docs/retrospective-checkpoint-contract.md
@@ -135,10 +135,13 @@ scripts legitimately call `gh`/GraphQL internally; that is the tooling. The rule
 targets the agent's own top-level shell calls, not a script's internals.
 
 **Write-op allowlist (verifier only):** `gh pr merge`, `gh pr ready`,
-`gh issue create`, `gh issue edit` have no internal wrapper today. The deterministic
-verifier records these as `allowedWriteOps` rather than violations so they are
-surfaced distinctly, not as breaches. Close the gap with a wrapper to remove an
-entry. None of these block anything.
+`gh issue create` have no internal wrapper today. `gh issue edit` now has one
+(`scripts/github/edit-issue.mjs`) and stays as a belt-and-suspenders entry — like
+`gh label create` (`scripts/github/create-label.mjs`) — so a bare invocation
+surfaced from the wrapper's own subprocess is not miscounted as a breach. The
+deterministic verifier records all of these as `allowedWriteOps` rather than
+violations so they are surfaced distinctly, not as breaches. Close the gap with a
+wrapper to remove or reframe a no-wrapper entry. None of these block anything.
 
 **Inline-interpreter check item:** the raw-call scan below mechanically catches
 `node -e`/`python3 -c`/heredoc calls as a `rawCallViolations` entry — the same

--- a/test/github/edit-issue.test.mjs
+++ b/test/github/edit-issue.test.mjs
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { parseEditIssueCliArgs, editIssue, runCli } from "../../scripts/github/edit-issue.mjs";
+
+function stubGh({ code = 0, stderr = "" } = {}) {
+  const calls = [];
+  const run = async (_cmd, args) => {
+    calls.push(args);
+    return { code, stdout: code === 0 ? "https://github.com/o/n/issues/17\n" : "", stderr };
+  };
+  return { run, calls };
+}
+
+function captureStream() {
+  let data = "";
+  return { write: (s) => { data += s; }, get: () => data };
+}
+
+test("parseEditIssueCliArgs: requires --repo, --issue and at least one edit", () => {
+  assert.throws(() => parseEditIssueCliArgs(["--repo", "o/n"]), /requires both --repo/);
+  assert.throws(() => parseEditIssueCliArgs(["--repo", "o/n", "--issue", "1"]), /at least one of/);
+});
+
+test("parseEditIssueCliArgs: --body and --body-file are mutually exclusive", () => {
+  assert.throws(
+    () => parseEditIssueCliArgs(["--repo", "o/n", "--issue", "1", "--body", "x", "--body-file", "f"]),
+    /mutually exclusive/,
+  );
+});
+
+test("parseEditIssueCliArgs: --milestone '' parses (empty clears; not rejected as missing)", () => {
+  const out = parseEditIssueCliArgs(["--repo", "o/n", "--issue", "1", "--milestone", ""]);
+  assert.equal(out.milestone, "");
+});
+
+test("parseEditIssueCliArgs: --milestone rejects whitespace-only but allows a real name and empty clear", () => {
+  assert.throws(() => parseEditIssueCliArgs(["--repo", "o/n", "--issue", "1", "--milestone", "   "]), /whitespace-only is not allowed/);
+  assert.equal(parseEditIssueCliArgs(["--repo", "o/n", "--issue", "1", "--milestone", "v1.0"]).milestone, "v1.0");
+  assert.equal(parseEditIssueCliArgs(["--repo", "o/n", "--issue", "1", "--milestone", ""]).milestone, "");
+});
+
+test("parseEditIssueCliArgs: --milestone with no value is rejected", () => {
+  // A bare --milestone (no following token) is a real omission, not an empty clear.
+  assert.throws(() => parseEditIssueCliArgs(["--repo", "o/n", "--issue", "1", "--milestone"]), /--milestone requires a value/);
+});
+
+test("parseEditIssueCliArgs: rejects whitespace-only --title / --body", () => {
+  assert.throws(() => parseEditIssueCliArgs(["--repo", "o/n", "--issue", "1", "--title", "   "]), /--title must not be empty or whitespace/);
+  assert.throws(() => parseEditIssueCliArgs(["--repo", "o/n", "--issue", "1", "--body", "\t\n"]), /--body must not be empty or whitespace/);
+});
+
+test("parseEditIssueCliArgs: collects repeated assignees", () => {
+  const out = parseEditIssueCliArgs(["--repo", "o/n", "--issue", "1", "--add-assignee", "a", "--add-assignee", "b"]);
+  assert.deepEqual(out.addAssignees, ["a", "b"]);
+});
+
+test("editIssue: builds gh issue edit args and reports edited fields", async () => {
+  const { run, calls } = stubGh();
+  const result = await editIssue(
+    { repo: "o/n", issue: 17, title: "New", body: "Body", addAssignees: ["me"], removeAssignees: [], milestone: undefined },
+    { run },
+  );
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.edited, ["title", "body", "add-assignee"]);
+  assert.deepEqual(calls[0], [
+    "issue", "edit", "17", "--repo", "o/n", "--title", "New", "--body", "Body", "--add-assignee", "me",
+  ]);
+});
+
+test("editIssue: empty --milestone clears (passes empty string through)", async () => {
+  const { run, calls } = stubGh();
+  await editIssue({ repo: "o/n", issue: 1, addAssignees: [], removeAssignees: [], milestone: "" }, { run });
+  assert.deepEqual(calls[0], ["issue", "edit", "1", "--repo", "o/n", "--milestone", ""]);
+});
+
+test("editIssue: throws when gh fails", async () => {
+  const { run } = stubGh({ code: 1, stderr: "forbidden" });
+  await assert.rejects(
+    () => editIssue({ repo: "o/n", issue: 1, title: "x", addAssignees: [], removeAssignees: [] }, { run }),
+    /gh issue edit failed: forbidden/,
+  );
+});
+
+test("runCli: --jq extracts an edited field; --silent maps to exit code", async () => {
+  const { run } = stubGh();
+  const stdout = captureStream();
+  const code = await runCli(["--repo", "o/n", "--issue", "1", "--title", "T", "--jq", ".edited[0]"], { run, stdout });
+  assert.equal(code, 0);
+  assert.equal(stdout.get().trim(), "title");
+
+  const { run: run2 } = stubGh();
+  const code2 = await runCli(["--repo", "o/n", "--issue", "1", "--title", "T", "--silent"], { run: run2, stdout: captureStream() });
+  assert.equal(code2, 0);
+});
+
+test("editIssue: --body-file fails closed on an empty/whitespace-only file", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "edit-issue-"));
+  const emptyPath = join(dir, "empty.md");
+  writeFileSync(emptyPath, "   \n  ");
+  const { run } = stubGh();
+  await assert.rejects(
+    () => editIssue({ repo: "o/n", issue: 5, bodyFile: emptyPath, addAssignees: [], removeAssignees: [] }, { run }),
+    /is empty/,
+  );
+});
+
+test("editIssue: --body-file reads the body from a real file", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "edit-issue-"));
+  const bodyPath = join(dir, "body.md");
+  writeFileSync(bodyPath, "Body from file\nsecond line");
+  const { run, calls } = stubGh();
+  const result = await editIssue(
+    { repo: "o/n", issue: 5, bodyFile: bodyPath, addAssignees: [], removeAssignees: [] },
+    { run },
+  );
+  assert.deepEqual(result.edited, ["body"]);
+  assert.deepEqual(calls[0], ["issue", "edit", "5", "--repo", "o/n", "--body-file", bodyPath]);
+});
+
+test("editIssue: --body-file - reads stdin and passes it inline as --body (never re-emits exhausted fd 0)", () => {
+  // resolveBody consumes fd 0 to validate the body; re-emitting `--body-file -`
+  // would make gh re-read an already-drained stdin and clear the issue body. So the
+  // resolved stdin content must be passed inline via --body. Exercised in a child
+  // process because resolveBody reads the real fd 0 (stdin).
+  const modUrl = new URL("../../scripts/github/edit-issue.mjs", import.meta.url).href;
+  const dir = mkdtempSync(join(tmpdir(), "edit-issue-stdin-"));
+  const driver = join(dir, "driver.mjs");
+  writeFileSync(
+    driver,
+    `import { editIssue } from ${JSON.stringify(modUrl)};\n` +
+      "const calls = [];\n" +
+      "await editIssue(\n" +
+      "  { repo: \"o/n\", issue: 17, bodyFile: \"-\", addAssignees: [], removeAssignees: [] },\n" +
+      "  { run: async (_cmd, args) => { calls.push(args); return { code: 0, stdout: \"\", stderr: \"\" }; } },\n" +
+      ");\n" +
+      "process.stdout.write(JSON.stringify(calls[0]));\n",
+  );
+  const res = spawnSync(process.execPath, [driver], { input: "Body from stdin\n", encoding: "utf8" });
+  assert.equal(res.status, 0, res.stderr);
+  const args = JSON.parse(res.stdout);
+  assert.deepEqual(args, ["issue", "edit", "17", "--repo", "o/n", "--body", "Body from stdin\n"]);
+  assert.ok(!args.includes("--body-file"), "must not re-emit --body-file - for an exhausted stdin");
+});
+
+test("editIssue: --remove-assignee builds gh args and reports the edited field", async () => {
+  const { run, calls } = stubGh();
+  const result = await editIssue(
+    { repo: "o/n", issue: 5, addAssignees: ["a"], removeAssignees: ["b", "c"] },
+    { run },
+  );
+  assert.deepEqual(result.edited, ["add-assignee", "remove-assignee"]);
+  assert.deepEqual(calls[0], [
+    "issue", "edit", "5", "--repo", "o/n",
+    "--add-assignee", "a", "--remove-assignee", "b", "--remove-assignee", "c",
+  ]);
+});


### PR DESCRIPTION
## Summary

Adds `scripts/github/edit-issue.mjs` — a thin sanctioned wrapper over `gh issue edit`, mirroring the `edit-pr.mjs` / `comment-issue.mjs` siblings (same output / `--jq` / `--silent` conventions). Routes the `ACCEPT-CRITERIA-VERIFY-AND-REFLECT` procedure's issue-body update through the wrapper and default-permits the wrapper while keeping raw `gh issue edit` gated.

This removes a recurring hard stall: the AC-reflection step (step 5) mandates reflecting verified acceptance criteria back into the linked issue body on every `pre_approval_gate`, but the sanctioned-edit surface had no issue-body editor, so the flow fell back to raw `gh issue edit` and stalled on a permission prompt.

## Changes

- `scripts/github/edit-issue.mjs` (new) — sanctioned wrapper over `gh issue edit` (title/body/body-file/assignees/milestone), mirroring `edit-pr.mjs`.
- `test/github/edit-issue.test.mjs` (new) — coverage mirror of `edit-pr.test.mjs`.
- `scripts/loop/sanctioned-commands.mjs` — registers the wrapper in the `edits` map.
- `packages/core/src/loop/bash-command-classify.mjs` — adds `gh issue edit` to the subagent external-write verb forms so raw `gh issue edit` from a subagent is gated like `gh issue comment`.
- `packages/core/src/claude/hook-decisions.mjs` — deny reason wording covers edits.
- `skills/docs/acceptance-criteria-verification.md` — step 5 routes through the wrapper.
- `.claude/settings.json` — `permissions.allow` default-permits `Bash(node scripts/github/edit-issue.mjs:*)`; raw `gh issue edit` stays gated.
- Regenerated `.claude` mirrors + classifier/decisions tests.

## Acceptance criteria

- [ ] `scripts/github/edit-issue.mjs` exists as a thin sanctioned wrapper over `gh issue edit`, mirroring `edit-pr.mjs`/`comment-issue.mjs` (same output/`--jq`/`--silent` conventions).
- [ ] The `ACCEPT-CRITERIA-VERIFY-AND-REFLECT` procedure routes the issue-body update through the wrapper.
- [ ] The wrapper's invocation is added to the repo `.claude/settings.json` allow list; raw `gh issue edit` stays gated.
- [ ] `npm run verify` green; `.claude` mirrors regenerated.

## Definition of done

- [ ] Wrapper + routing + allow rule merged via a gated PR; the AC-reflection step no longer requires a manual permission approval.

Closes #1247

## Non-goals

- Routing the other skill docs that still reference raw `gh issue edit` (`issue-intake-procedure.md`, `epic-tree-refinement-procedure.md`, `loop-grill/SKILL.md`) through the new wrapper — tracked as a follow-up; this PR scopes to the AC-reflection step per issue #1247.
- Broadening `edit-issue.mjs` beyond the `edit-pr.mjs` surface (labels, state, etc.).
- Changing raw `gh issue edit` behavior for the main agent / operator (it stays permitted; only subagent raw use is gated).
