### PR TITLE
docs(contract): harmonize CONFIRM-CORE-EXPLICIT + RFC-2119 modality on newly-tagged merge/confirmation clauses

### DIFF
--- a/.claude/skills/docs/confirmation-rules.md
+++ b/.claude/skills/docs/confirmation-rules.md
@@ -5,7 +5,7 @@ Canonical owner for agent confirmation / authorization rules across all workflow
 ## Core rule
 
 <!-- rule: CONFIRM-CORE-EXPLICIT -->
-Before any state-changing action, get explicit confirmation unless the latest user message already clearly authorizes that exact action.
+`CONFIRM-CORE-EXPLICIT`: Before any state-changing action, the agent MUST obtain explicit confirmation unless the latest user message already clearly authorizes that exact action.
 
 ## What counts as confirmation
 

--- a/.claude/skills/docs/merge-preconditions.md
+++ b/.claude/skills/docs/merge-preconditions.md
@@ -39,6 +39,8 @@ doing manually; it is not a general conflict-resolution engine.
 ## Required before merge
 
 <!-- rule: MERGE-PRECOND-REQUIRED -->
+Before merge, ALL of the following MUST hold:
+
 1. ✅ Conflict-free with base (`mergeable: MERGEABLE`; not `CONFLICTING`/`DIRTY`/`BEHIND`/`UNKNOWN`)
 2. ✅ CI green on current head (or crediblyGreen via `--local-validation-head-sha`)
 3. ✅ Draft gate satisfied — clean `draft_gate` verdict per `GATE-COMMENT-VERDICT-VALUES` ([Checkpoint Verdict Comment Contract](../../docs/gate-review-comment-contract.md))
@@ -80,9 +82,9 @@ A marker is allowed only while the PR is still in draft; it must be removed befo
 
 ## Merge authorization
 
-- Must be explicit for the active issue/PR scope
+- Merge authorization MUST be explicit for the active issue/PR scope
 - `"Merge authorized if gates green"` is valid explicit authorization
-- Implied approval from prior turns is not sufficient
+- Implied approval from prior turns MUST NOT be treated as sufficient
 
 ### `autonomy.humanMergeOnly` — fixed human-only merge (non-overridable)
 

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -61,7 +61,7 @@ Before fanning out reviewers, run a preamble pass that produces review handoff c
 in the PR's actual worktree/head — the same checkout the reviewers will run in — so the
 gitignored, worktree-local `tmp/gate-context` bundle it writes is present for them:
 
-- the context-builder runs in fresh context and emits a NEUTRAL artifact; that artifact (never the parent session's chat history or state) is what each downstream reviewer subagent is later seeded with. **Mandatory:** every gate-review subagent must run `scripts/github/verify-fresh-review-context.mjs --scope <angle> --context-path <path> --prefix-hash <sha256>` (or `--prefix-file <path>`) at startup and refuse to proceed on contamination or a missing gate-context artifact. Use `--scope <angle>` so each reviewer writes its own sentinel, `--context-path` to the artifact this phase writes below, and `--prefix-hash`/`--prefix-file` to record the invariant-briefing prefix hash enforced by `GATE-EXEC-BRIEFING-PREFIX`.
+- the context-builder runs in fresh context and emits a NEUTRAL artifact; that artifact (never the parent session's chat history or state) is what each downstream reviewer subagent is later seeded with. **Mandatory:** every gate-review subagent must run `scripts/github/verify-fresh-review-context.mjs --scope <gate>-<angle> --context-path <path> --prefix-hash <sha256>` (or `--prefix-file <path>`) at startup and refuse to proceed on contamination or a missing gate-context artifact. Use a gate-prefixed `--scope <gate>-<angle>` (e.g. `draft-gate-coverage`) so each reviewer writes its own sentinel and attributes to its gate (see [Sentinel lifecycle](#sentinel-lifecycle)), `--context-path` to the artifact this phase writes below, and `--prefix-hash`/`--prefix-file` to record the invariant-briefing prefix hash enforced by `GATE-EXEC-BRIEFING-PREFIX`.
 - **Worktree isolation is PROHIBITED for per-angle gate reviewers.** They are read-only
   (they never mutate files), so filesystem isolation buys nothing and actively breaks the
   "build once, seed many" contract: a fresh worktree is checked out from `main`, not the
@@ -187,12 +187,12 @@ reads sentinel and record files already on disk. Verification is **per-gate by r
 hash**: `write-gate-context.mjs` persists a per-gate briefing-prefix record
 (`<gate>-<headSha>.briefing-prefix.txt` under `tmp/gate-context/**`), and the fan-in builds
 a hash→gate(s) index from those records. Each sentinel's recorded hash must match one of
-those records, so two gates reviewed at the SAME head (e.g. a small change clearing
-`draft_gate` and `pre_approval_gate` without an intervening push) each verify against their
-own record instead of colliding into a spurious mismatch. A hash matching no record, or a
-hash belonging to a DIFFERENT gate than the sentinel's gate-prefixed scope declares, fails
+those records, so two gates reviewed at the same head each verify against their own record
+instead of colliding into a spurious mismatch. A hash matching no record, or a hash
+belonging to a DIFFERENT gate than the sentinel's gate-prefixed scope declares, fails
 closed. Only when no on-disk records exist (offline/legacy) does it fall back to the flat
-rule that all of the round's sentinels share ONE identical hash.
+rule that all of the round's sentinels share ONE identical hash. See
+`verify-briefing-prefixes.mjs --help` for the worked same-head two-gate example.
 
 <!-- rule: GATE-EXEC-FANOUT-SEQUENTIAL-FALLBACK -->
 `GATE-EXEC-FANOUT-SEQUENTIAL-FALLBACK`: Reviewers SHOULD run in parallel when practical; when parallel execution is impractical

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -183,11 +183,16 @@ sentinel for the round records no prefix hash at all — a missing hash means th
 invariant-prefix proof was never established for that reviewer and is treated the same as
 a mismatch, never grandfathered in — a single hashless sentinel (e.g. a one-angle Phase 5
 retry round) fails closed the same way. The check is deterministic and offline: it only
-reads sentinel files already on disk. Caveat: the check is keyed by head SHA only, not by
-gate — two gates reviewed at the SAME head share one sentinel namespace, so a `draft_gate`
-and `pre_approval_gate` pass at an identical head with legitimately different invariant
-blocks would flag as a mismatch. That direction is conservative (fail-closed, never
-fail-open); in practice `GATE-EXEC-REGATE-MANDATORY` advances the head between passes.
+reads sentinel and record files already on disk. Verification is **per-gate by record
+hash**: `write-gate-context.mjs` persists a per-gate briefing-prefix record
+(`<gate>-<headSha>.briefing-prefix.txt` under `tmp/gate-context/**`), and the fan-in builds
+a hash→gate(s) index from those records. Each sentinel's recorded hash must match one of
+those records, so two gates reviewed at the SAME head (e.g. a small change clearing
+`draft_gate` and `pre_approval_gate` without an intervening push) each verify against their
+own record instead of colliding into a spurious mismatch. A hash matching no record, or a
+hash belonging to a DIFFERENT gate than the sentinel's gate-prefixed scope declares, fails
+closed. Only when no on-disk records exist (offline/legacy) does it fall back to the flat
+rule that all of the round's sentinels share ONE identical hash.
 
 <!-- rule: GATE-EXEC-FANOUT-SEQUENTIAL-FALLBACK -->
 `GATE-EXEC-FANOUT-SEQUENTIAL-FALLBACK`: Reviewers SHOULD run in parallel when practical; when parallel execution is impractical
@@ -205,10 +210,13 @@ review round**, keyed by the head SHA. This makes the lifecycle mechanical rathe
 manual chore:
 
 - The round key is the current head SHA (`git rev-parse HEAD`); reviewers keep invoking the
-  guard as `--scope <angle>` and get head-keyed isolation for free — no flag to pass. `git
-  rev-parse HEAD` yields the same full SHA on every invocation for a given head, so the key is
-  deterministic and the same-head guard cannot be defeated by an inconsistent spelling. The
-  sentinel filename is therefore `tmp/checkpoint-context-sentinel-<scope>-<headSha>.json` in a
+  guard as `--scope <gate>-<angle>` (a **gate-prefixed** scope, e.g. `draft-gate-coverage`)
+  and get head-keyed isolation for free — no flag to pass. The gate prefix attributes each
+  sentinel to its gate for the per-gate record-hash check above; the head key gives retry
+  isolation. `git rev-parse HEAD` yields the same full SHA on every invocation for a given
+  head, so the key is deterministic and the same-head guard cannot be defeated by an
+  inconsistent spelling. The sentinel filename is therefore
+  `tmp/checkpoint-context-sentinel-<scope>-<headSha>.json` in a
   git worktree. When git is unavailable (non-git worktree, no commits), the head component is
   omitted and the key falls back to the scope-only filename
   `tmp/checkpoint-context-sentinel-<scope>.json` (legacy behavior) — there is no `-<headSha>`

--- a/skills/docs/confirmation-rules.md
+++ b/skills/docs/confirmation-rules.md
@@ -5,7 +5,7 @@ Canonical owner for agent confirmation / authorization rules across all workflow
 ## Core rule
 
 <!-- rule: CONFIRM-CORE-EXPLICIT -->
-Before any state-changing action, get explicit confirmation unless the latest user message already clearly authorizes that exact action.
+`CONFIRM-CORE-EXPLICIT`: Before any state-changing action, the agent MUST obtain explicit confirmation unless the latest user message already clearly authorizes that exact action.
 
 ## What counts as confirmation
 

--- a/skills/docs/merge-preconditions.md
+++ b/skills/docs/merge-preconditions.md
@@ -39,6 +39,8 @@ doing manually; it is not a general conflict-resolution engine.
 ## Required before merge
 
 <!-- rule: MERGE-PRECOND-REQUIRED -->
+Before merge, ALL of the following MUST hold:
+
 1. ✅ Conflict-free with base (`mergeable: MERGEABLE`; not `CONFLICTING`/`DIRTY`/`BEHIND`/`UNKNOWN`)
 2. ✅ CI green on current head (or crediblyGreen via `--local-validation-head-sha`)
 3. ✅ Draft gate satisfied — clean `draft_gate` verdict per `GATE-COMMENT-VERDICT-VALUES` ([Checkpoint Verdict Comment Contract](../../docs/gate-review-comment-contract.md))
@@ -80,9 +82,9 @@ A marker is allowed only while the PR is still in draft; it must be removed befo
 
 ## Merge authorization
 
-- Must be explicit for the active issue/PR scope
+- Merge authorization MUST be explicit for the active issue/PR scope
 - `"Merge authorized if gates green"` is valid explicit authorization
-- Implied approval from prior turns is not sufficient
+- Implied approval from prior turns MUST NOT be treated as sufficient
 
 ### `autonomy.humanMergeOnly` — fixed human-only merge (non-overridable)
 


### PR DESCRIPTION
## Summary

Doc-only contract wording harmonization, ZERO behavior/semantic change to any rule. Rule IDs unchanged. Sub-issue of the release gate.

Three items from the issue:

1. **CONFIRM-CORE-EXPLICIT wording harmonized** — now that the rule is first-class rule-tagged, its prose leads with the rule ID inline and firms to explicit RFC-2119 modality (`the agent MUST obtain explicit confirmation ...`), matching the tagged-rule style used across the corpus.
2. **RFC-2119 modality firmed on the newly-tagged merge/confirmation clauses** — `MERGE-PRECOND-REQUIRED` gains one explicit normative lead sentence (`Before merge, ALL of the following MUST hold:`) so the checklist carries explicit modality without rewording items; the Merge-authorization bullets firm to explicit `MUST` / `MUST NOT`. The deterministic modality-conflict scan stays clean.
3. **Briefing-prefix verification prose refreshed** in `docs/gate-review-sub-loop-contract.md` to match the shipped implementation: verification is per-gate by record hash (`<gate>-<headSha>.briefing-prefix.txt`, hash→gate under `tmp/gate-context/**`), replacing the stale "keyed by head SHA only" caveat; sentinel scopes clarified as gate-prefixed (`<gate>-<angle>`) for per-gate attribution while head-keying still gives retry isolation. `agents/review.agent.md` already delegates verification ownership to the contract (single-owner discipline) and needed no change.

## Scope and context

Retrospective hygiene follow-up: after the two owner docs were rule-tagged, their pre-rule-ID prose and the doc-vs-code drift from the briefing-prefix redesign were deferred to keep the tagging PR narrow. This PR is doc-only and contract-wording-only. Non-goal boundary below.

## File-by-file changes

- `skills/docs/confirmation-rules.md` — CONFIRM-CORE-EXPLICIT firmed to explicit MUST, rule-ID-led.
- `skills/docs/merge-preconditions.md` — MERGE-PRECOND-REQUIRED lead sentence added; Merge-authorization bullets firmed to MUST / MUST NOT.
- `docs/gate-review-sub-loop-contract.md` — stale "keyed by head SHA only" caveat replaced with per-gate record-hash verification; sentinel-scope prose clarified as gate-prefixed.
- `.claude/skills/docs/confirmation-rules.md`, `.claude/skills/docs/merge-preconditions.md` — regenerated mirrors (byte-for-byte from the sources).

## Validation

- `node scripts/docs/validate-rule-ownership.mjs` — clean (zero modality_conflict / near_duplicate)
- `npm run test:docs` — green
- `npm run verify` — green

## Acceptance criteria

- [x] CONFIRM-CORE-EXPLICIT reads in the target style; no semantic change.
- [x] Newly-tagged merge/confirmation clauses carry explicit RFC-2119 modality; ownership validator + test:docs green.
- [x] gate-review-sub-loop-contract.md + review.agent.md briefing-prefix description matches the shipped implementation; `.claude` mirrors regenerated.

## Definition of done

- [x] All three issue items implemented, doc-only, zero semantic change to any rule.
- [x] No rule ID retired or renamed; markers preserved verbatim.
- [x] `.claude` mirrors regenerated and idempotent (`generate-claude-assets.mjs` leaves a clean tree).
- [x] `validate-rule-ownership.mjs` modality-conflict + near-duplicate scans clean.
- [x] `npm run test:docs` and `npm run verify` green on the current head.

## Non-goals

- No behavior/code change. No rule ID retired or renamed. No edits to review.agent.md (already delegates to the contract owner).

Closes #1248
