### PR TITLE
chore(release): #1104 closeout corrections + v0.8 changelog/version prep [pre-v0.8]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 <!-- Release date is set at tag time; see the release runbook. This section is prepared ahead of the v0.8.0 tag. -->
 
-The v0.7.x contract-audit epic (#1104) plus follow-on release-gate fixes. Everything below landed since v0.7.1; the v0.7.2 tag was a scoped packaging hotfix (see its section) cut from within this window, so the substantive epic and post-epic work is collected here.
+Everything merged since v0.7.1 — the v0.7.x contract-audit epic (#1104) plus follow-on release-gate fixes. **Versioning note:** most of these commits are ancestors of the `v0.7.2` tag and therefore already ship in the published `0.7.2` npm artifact, but `v0.7.2`'s release notes documented only the #1241 packaging hotfix (see the 0.7.2 section below). This section backfills that omitted changelog and adds the nine changes that genuinely postdate the `v0.7.2` tag (#1240, #1242, #1244, #1249, #1250, #1253, #1254, #1256, and #1236/#1252); it becomes the notes for the eventual `v0.8.0` tag.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## 0.8.0
+
+<!-- Release date is set at tag time; see the release runbook. This section is prepared ahead of the v0.8.0 tag. -->
+
+The v0.7.x contract-audit epic (#1104) plus follow-on release-gate fixes. Everything below landed since v0.7.1; the v0.7.2 tag was a scoped packaging hotfix (see its section) cut from within this window, so the substantive epic and post-epic work is collected here.
+
+### Added
+
+- **Issue-less lightweight PR-first flow (#1210/#1215).** A PR with no backing issue can drive the lightweight path with a configurable composed Copilot round cap; such PRs auto-enqueue as board items so they are still tracked (#1218/#1226).
+- **State-machine conformance + invariant harness (#1148/#1189)** on a rule-ownership foundation (#1183). The PR lifecycle state machine is exported from `@dev-loops/core` as the single source for docs, the state atlas, and the conformance harness (#1193/#1216), and `public-dev-loop-routing` is wired into the L2/L3 conformance harness so all five machines are covered (#1233/#1239).
+- **Inline reviewer briefing prefix (#1220/#1229)** — the reviewed content is carried inline, size-capped and hash-enforced, on top of invariant-prefix-first reviewer briefings with prefix-hash enforcement (#1207/#1214).
+- **First-class loop primitives** `list-review-threads` and `wait-pr-checks` (#1198/#1223), a sanctioned `edit-issue.mjs` wrapper for AC-reflection body edits (#1253), and a refinement-artifact-at-enqueue requirement so no un-refined item enters Next Up (#1251/#1254).
+- **State-atlas fullscreen lightbox for diagrams (#1217).**
+
+### Fixed
+
+- **Package-escaping `@dev-loops/core` imports broke consumer installs (#1241)** — shipped as the v0.7.2 hotfix; full detail is in the 0.7.2 section below.
+- **Converge-then-gate enforced at `pre_approval` entry (#1190/#1219)**, retiring the known gap where a gate could run before Copilot convergence.
+- **Fanout provenance fails closed on missing mandatory or foreign angles (#1196/#1225)**; briefing-prefix verification scoped by (gate, headSha) (#1249).
+- **Reviewer-loop submission-failure edges join the transition table (#1200/#1221)**; Copilot summon literals sanitized on write with a code-span-aware guard and an honest blocked status (#1213/#1222).
+- **Issue-less lightweight PR-first three-origin contracts reconciled** with a gate-coordination `specSource` branch (#1242); contradiction sweep across gate-skip scoping, coverage-modality ownership, and advisory wording (#1244).
+- **run-claim coordination file anchored at the git common dir, not CWD (#1250).**
+- **release.yml dispatches npm-publish.yml explicitly after creating the release (#1187/#1188)**; Pages deploy bumped to deploy-pages v5 (#1211/#1212) and the gate-hub flowchart renders left-to-right (#1208/#1209).
+- **docs-validator manifest gap + corpus→manifest completeness (#1238)**; epic AC1/AC2 zero-states restored — canonical-owner openers plus remaining phrase pins (#1240).
+
+### Changed
+
+- **Contract corpus condensation + single-owner rule IDs.** Rule ownership migrated to single-owner IDs across the gate, queue, loop, worktree, intake, and public-loop clusters, with residual normative phrase-pins retired to a zero-pin end state (#1149–#1159, #1191–#1206). Inline interpreters were banned from coordinator flows in favor of sanctioned paths by reference (#1224/#1228), a final corpus condensation sweep rewired rule IDs with zero semantic change (#1236/#1252), and RFC-2119 modality was harmonized on newly-tagged merge/confirmation clauses (#1256).
+
 ## 0.7.2 - 2026-07-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Everything merged since v0.7.1 — the v0.7.x contract-audit epic (#1104) plus f
 - **Reviewer-loop submission-failure edges join the transition table (#1200/#1221)**; Copilot summon literals sanitized on write with a code-span-aware guard and an honest blocked status (#1213/#1222).
 - **Issue-less lightweight PR-first three-origin contracts reconciled** with a gate-coordination `specSource` branch (#1242); contradiction sweep across gate-skip scoping, coverage-modality ownership, and advisory wording (#1244).
 - **run-claim coordination file anchored at the git common dir, not CWD (#1250).**
+- **`queue --item` accepts the full node-ID alphabet across the projects scripts (#1227/#1230).**
 - **release.yml dispatches npm-publish.yml explicitly after creating the release (#1187/#1188)**; Pages deploy bumped to deploy-pages v5 (#1211/#1212) and the gate-hub flowchart renders left-to-right (#1208/#1209).
 - **docs-validator manifest gap + corpus→manifest completeness (#1238)**; epic AC1/AC2 zero-states restored — canonical-owner openers plus remaining phrase pins (#1240).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ Everything merged since v0.7.1 — the v0.7.x contract-audit epic (#1104) plus f
 - **Fanout provenance fails closed on missing mandatory or foreign angles (#1196/#1225).** Briefing-prefix verification is also scoped by (gate, headSha) (#1249).
 - **Reviewer-loop submission-failure edges join the transition table (#1200/#1221).** Copilot summon literals are sanitized on write with a code-span-aware guard and an honest blocked status (#1213/#1222).
 - **Issue-less lightweight PR-first three-origin contracts reconciled (#1242).** Adds a gate-coordination `specSource` branch; a contradiction sweep covers gate-skip scoping, coverage-modality ownership, and advisory wording (#1244).
-- **run-claim coordination file anchored at the git common dir, not CWD (#1250).**
-- **`queue --item` accepts the full node-ID alphabet across the projects scripts (#1227/#1230).**
+- **run-claim coordination file anchored at the git common dir, not CWD (#1250).** The per-PR runner lease now resolves its coordination file from the shared git common dir, so a runner started from a different worktree/CWD attaches to the same lease instead of forking a second one.
+- **`queue --item` accepts the full node-ID alphabet across the projects scripts (#1227/#1230).** The `--item` node-ID parser now accepts the complete GitHub node-ID character set, so board items whose IDs use previously-rejected characters resolve consistently across the projects scripts.
 - **release.yml dispatches npm-publish.yml explicitly after creating the release (#1187/#1188).** Pages deploy is bumped to deploy-pages v5 (#1211/#1212) and the gate-hub flowchart renders left-to-right (#1208/#1209).
 - **docs-validator manifest gap and corpus→manifest completeness (#1238).** Epic AC1/AC2 zero-states restored — canonical-owner openers plus remaining phrase pins (#1240).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,22 +13,22 @@ Everything merged since v0.7.1 — the v0.7.x contract-audit epic (#1104) plus f
 ### Added
 
 - **Issue-less lightweight PR-first flow (#1210/#1215).** A PR with no backing issue can drive the lightweight path with a configurable composed Copilot round cap; such PRs auto-enqueue as board items so they are still tracked (#1218/#1226).
-- **State-machine conformance + invariant harness (#1148/#1189)** on a rule-ownership foundation (#1183). The PR lifecycle state machine is exported from `@dev-loops/core` as the single source for docs, the state atlas, and the conformance harness (#1193/#1216), and `public-dev-loop-routing` is wired into the L2/L3 conformance harness so all five machines are covered (#1233/#1239).
-- **Inline reviewer briefing prefix (#1220/#1229)** — the reviewed content is carried inline, size-capped and hash-enforced, on top of invariant-prefix-first reviewer briefings with prefix-hash enforcement (#1207/#1214).
-- **First-class loop primitives** `list-review-threads` and `wait-pr-checks` (#1198/#1223), a sanctioned `edit-issue.mjs` wrapper for AC-reflection body edits (#1253), and a refinement-artifact-at-enqueue requirement so no un-refined item enters Next Up (#1251/#1254).
-- **State-atlas fullscreen lightbox for diagrams (#1217).**
+- **State-machine conformance and invariant harness (#1148/#1189).** Built on a rule-ownership foundation (#1183). The PR lifecycle state machine is exported from `@dev-loops/core` as the single source for docs, the state atlas, and the conformance harness (#1193/#1216), and `public-dev-loop-routing` is wired into the L2/L3 conformance harness so all five machines are covered (#1233/#1239).
+- **Inline reviewer briefing prefix (#1220/#1229).** The reviewed content is carried inline, size-capped and hash-enforced, on top of invariant-prefix-first reviewer briefings with prefix-hash enforcement (#1207/#1214).
+- **First-class loop primitives (#1198/#1223).** `list-review-threads` and `wait-pr-checks`, plus a sanctioned `edit-issue.mjs` wrapper for AC-reflection body edits (#1253) and a refinement-artifact-at-enqueue requirement so no un-refined item enters Next Up (#1251/#1254).
+- **State-atlas fullscreen lightbox for diagrams (#1217).** Diagrams open in a fullscreen lightbox for readable inspection.
 
 ### Fixed
 
-- **Package-escaping `@dev-loops/core` imports broke consumer installs (#1241)** — shipped as the v0.7.2 hotfix; full detail is in the 0.7.2 section below.
-- **Converge-then-gate enforced at `pre_approval` entry (#1190/#1219)**, retiring the known gap where a gate could run before Copilot convergence.
-- **Fanout provenance fails closed on missing mandatory or foreign angles (#1196/#1225)**; briefing-prefix verification scoped by (gate, headSha) (#1249).
-- **Reviewer-loop submission-failure edges join the transition table (#1200/#1221)**; Copilot summon literals sanitized on write with a code-span-aware guard and an honest blocked status (#1213/#1222).
-- **Issue-less lightweight PR-first three-origin contracts reconciled** with a gate-coordination `specSource` branch (#1242); contradiction sweep across gate-skip scoping, coverage-modality ownership, and advisory wording (#1244).
+- **Package-escaping `@dev-loops/core` imports broke consumer installs (#1241).** Shipped as the v0.7.2 hotfix; full detail is in the 0.7.2 section below.
+- **Converge-then-gate enforced at `pre_approval` entry (#1190/#1219).** Retires the known gap where a gate could run before Copilot convergence.
+- **Fanout provenance fails closed on missing mandatory or foreign angles (#1196/#1225).** Briefing-prefix verification is also scoped by (gate, headSha) (#1249).
+- **Reviewer-loop submission-failure edges join the transition table (#1200/#1221).** Copilot summon literals are sanitized on write with a code-span-aware guard and an honest blocked status (#1213/#1222).
+- **Issue-less lightweight PR-first three-origin contracts reconciled (#1242).** Adds a gate-coordination `specSource` branch; a contradiction sweep covers gate-skip scoping, coverage-modality ownership, and advisory wording (#1244).
 - **run-claim coordination file anchored at the git common dir, not CWD (#1250).**
 - **`queue --item` accepts the full node-ID alphabet across the projects scripts (#1227/#1230).**
-- **release.yml dispatches npm-publish.yml explicitly after creating the release (#1187/#1188)**; Pages deploy bumped to deploy-pages v5 (#1211/#1212) and the gate-hub flowchart renders left-to-right (#1208/#1209).
-- **docs-validator manifest gap + corpus→manifest completeness (#1238)**; epic AC1/AC2 zero-states restored — canonical-owner openers plus remaining phrase pins (#1240).
+- **release.yml dispatches npm-publish.yml explicitly after creating the release (#1187/#1188).** Pages deploy is bumped to deploy-pages v5 (#1211/#1212) and the gate-hub flowchart renders left-to-right (#1208/#1209).
+- **docs-validator manifest gap and corpus→manifest completeness (#1238).** Epic AC1/AC2 zero-states restored — canonical-owner openers plus remaining phrase pins (#1240).
 
 ### Changed
 


### PR DESCRIPTION
## Objective

Release bookkeeping for the v0.8 tag (the last open child of the #1192 release-gate audit, #1104 closeout). Prep only — **not** a code change, **no** version bump, **no** tag. The actual v0.8.0 tag happens later after an independent re-audit + human approval.

Closes #1237

## What changed (in this diff)

- **CHANGELOG.md — new `## 0.8.0` section** summarizing everything since v0.7.1: the #1104 contract-audit epic (issue-less flow reconciliation, conformance wiring, contradiction fixes, phrase-pin/opener zero-states, condensation, validator hardening) plus the v0.7.2 packaging hotfix. `## Unreleased` stays empty above it as the rolling header; the release date is added at tag time.

## Done outside this diff (release bookkeeping)

- **#1104 closeout corrections** (comments on the closed epic): a word-count roll-up correction (reconciled **50,756 words / 6,530 lines** at `f32eae47`, vs the closeout's 53,015 / 6,865 — claimed growth was overstated ~78%), and the AC5 revised disposition (recoverable-verbosity condensation done via #1236; absolute pre-epic floor dropped as unsatisfiable given legitimate new contract surface). AC3 (5/5 machines via #1233/#1239) was already recorded on #1104, so it is referenced, not duplicated.

## In scope

- CHANGELOG `## 0.8.0` section (Part B).
- Making `extract-changelog-section.mjs --version 0.8.0` pass (Part C).
- #1104 correction + disposition comments (Part A).

## Non-goals

- **No version bump.** `package.json` / `packages/core/package.json` stay at `0.7.2` and the root `@dev-loops/core` range stays `^0.7.2`. Bumping to `0.8.0` is the prohibited "bump-to-release" step and is the only way `assert-core-dependency-version.mjs --release-version 0.8.0` could pass (the lockstep test pins the real manifest version to its own core range).
- **No git tag, no merge.** Stops at the human-approval checkpoint.

## Remaining for tag time

One atomic change makes `assert-core-dependency-version.mjs --release-version 0.8.0` pass and keeps the lockstep test green:

1. `package.json` `version` → `0.8.0`
2. `packages/core/package.json` `version` → `0.8.0`
3. `package.json` `dependencies["@dev-loops/core"]` → `^0.8.0`
4. Add the release date to the `## 0.8.0` heading.
5. Tag `v0.8.0` (triggers release.yml → npm-publish).

## Acceptance criteria

- [x] `extract-changelog-section.mjs --version 0.8.0` exits 0 with a non-empty section.
- [x] `assert-core-dependency-version.mjs` (default manifest) exits 0 — lockstep intact, `npm run verify` green.
- [x] Correction + AC5 disposition comments posted on #1104; AC3 referenced.
- [x] No version bump, no tag, no merge (prep-only).

## Validation

Run from the worktree (`tmp/worktrees/dev-loops/issue-1237`):

```
node scripts/release/extract-changelog-section.mjs --version 0.8.0   # exit 0, prints the 0.8.0 section
node scripts/release/assert-core-dependency-version.mjs             # exit 0, lockstep intact at 0.7.2
npm run verify                                                      # green
```

Observed: `extract` exits 0 with the non-empty 0.8.0 section; `assert` (default manifest) exits 0 (`@dev-loops/core ^0.7.2` in lockstep with 0.7.2); `npm run verify` completed exit 0. `assert --release-version 0.8.0` intentionally still exits 1 — that needs the tag-time version-bump chain (see "Remaining for tag time").

## Definition of done

- CHANGELOG `## 0.8.0` section present and accurate against merged PRs since v0.7.1.
- `npm run verify` passes.
- #1104 bookkeeping comments posted.
- Draft PR through draft_gate + pre_approval_gate (fanout_fanin), stopped at human approval.

## Risks

- Low. Docs/bookkeeping only; no runtime or packaging behavior changes. The `assert --release-version 0.8.0` deferral is intentional and documented above.
