### PR TITLE
docs(ponytail): add revisit triggers to three no-trigger debt markers

### DIFF
--- a/packages/core/src/loop/issue-refinement-artifact.mjs
+++ b/packages/core/src/loop/issue-refinement-artifact.mjs
@@ -378,6 +378,8 @@ function extractClosingIssueNumbers(body) {
   // backtick-run-delimited span (equal-length runs pair, so ``a `b` c`` works).
   // ponytail: not full CommonMark span matching; an unbalanced stray backtick
   // over-strips toward fail-closed, which is the safe direction for this gate.
+  // Revisit with a real CommonMark span parser only if valid closing refs in
+  // backtick-heavy bodies start being over-stripped into false negatives.
   const text = unfenced.join("\n").replace(/(`+)[\s\S]*?\1/gu, " ");
   const seen = new Set();
   const numbers = [];

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -153,6 +153,9 @@ function normalizeHeadSha(value) {
 // with our own "<base>...HEAD" triple-dot construction). Everything else —
 // including HEAD@{upstream}, main@{1}, tag-peel v1.0.0^{commit}, HEAD~3 — is
 // accepted.
+// Revisit toward an explicit allowlist if `base` ever reaches a shell (or any
+// call without execFileSync's no-shell argv guarantee), or if a malformed ref
+// shape is found slipping past these checks into `git diff`.
 function normalizeBaseRef(value) {
   const trimmed = String(value).trim();
   if (trimmed.length === 0 || trimmed.startsWith("-") || trimmed.includes("..")) return null;

--- a/test/contracts/_rule-helpers.mjs
+++ b/test/contracts/_rule-helpers.mjs
@@ -12,6 +12,8 @@ function readRepo(relativePath) {
 
 // ponytail: process-lifetime memo — test process is short-lived and the repo
 // tree doesn't change mid-run, so a single walk is safe to reuse everywhere.
+// Add cache invalidation if a caller mutates the scanned tree mid-run or reuses
+// this across a long-lived/watch process instead of a one-shot test run.
 let ruleDefinitionsCache = null;
 
 function collectRuleDefinitions() {


### PR DESCRIPTION
## Summary

Three `ponytail:` debt markers named a deliberate shortcut and its ceiling but gave no signal for when to revisit — so they could silently rot. Each now carries a concrete revisit trigger / upgrade path inside the marker comment itself.

Comment-only change; no behavior change.

## Scope and context

Adds a revisit-trigger sentence to the three no-trigger `ponytail:` markers identified by `/skill:ponytail-debt`. No code logic, tests, or tooling change.

## File-by-file changes

- `packages/core/src/loop/issue-refinement-artifact.mjs` — closing-ref inline-span stripping: revisit with a real CommonMark span parser only if valid closing refs in backtick-heavy bodies get over-stripped into false negatives.
- `scripts/github/write-gate-context.mjs` — base-ref denylist: revisit toward an explicit allowlist if `base` ever reaches a shell (no-shell argv guarantee lost) or a malformed shape slips into `git diff`.
- `test/contracts/_rule-helpers.mjs` — rule-definition process-lifetime memo: add cache invalidation if a caller mutates the scanned tree mid-run or reuses it beyond a one-shot test process.

## Acceptance criteria

- Each of the three no-trigger markers names an explicit revisit trigger / upgrade path.
- Unrelated `ponytail:` markers and debt-scanner behavior are unchanged.
- Existing behavior stays unchanged (comment-only).
- `npm run verify` passes.

## Definition of done

- All three no-trigger markers carry a concrete revisit trigger, verified against the code they document.
- No behavior change: diff is comment-only.
- Added comments describe behavior/triggers and cite no PR/issue numbers.
- `npm run verify` passes; gates clean.

## Non-goals

- New ponytail-debt tooling, debt ledgers, or scanner changes.
- The two `ponytail:` markers that already carry triggers.
- Behavior changes to parser / git-ref validation / cache logic.

## Validation

- `npm run verify` passes.

Closes #1261
