### PR TITLE
test(scripts): stub real resolver work in inspect-run-viewer tests to speed up verify (#1264)

### DIFF
--- a/test/loop/inspect-run-viewer-server.test.mjs
+++ b/test/loop/inspect-run-viewer-server.test.mjs
@@ -157,7 +157,6 @@ test("createInspectRunViewerServer supports selecting another PR from query para
 test("createInspectRunViewerServer serves the Mermaid browser asset without loading a snapshot", async () => {
   let loadCount = 0;
   const adapter = {
-    loadHandoffEnvelope: async () => null,
     async loadSnapshot() {
       loadCount += 1;
       return makeSnapshot();
@@ -190,7 +189,6 @@ test("createInspectRunViewerServer keeps Mermaid asset failures generic and path
   let loadCount = 0;
   const loggedErrors = [];
   const adapter = {
-    loadHandoffEnvelope: async () => null,
     async loadSnapshot() {
       loadCount += 1;
       return makeSnapshot();
@@ -232,7 +230,6 @@ test("createInspectRunViewerServer serves authoritative snapshot JSON on /snapsh
   let loadCount = 0;
   const snapshot = makeSnapshot({ sourceMode: "partial", trust: "degraded" });
   const adapter = {
-    loadHandoffEnvelope: async () => null,
     async loadSnapshot() {
       loadCount += 1;
       return snapshot;
@@ -401,7 +398,6 @@ test("createInspectRunViewerServer keeps explicit query targets even when they a
 test("createInspectRunViewerServer resolves /snapshot.json target from query params", async () => {
   const seenTargets = [];
   const adapter = {
-    loadHandoffEnvelope: async () => null,
     async loadSnapshot(target) {
       seenTargets.push(target);
       return makeSnapshot({ target, runId: `pr-${target.pr}` });
@@ -432,7 +428,6 @@ test("createInspectRunViewerServer resolves /snapshot.json target from query par
 test("createInspectRunViewerServer treats missing JSON snapshots as machine-readable failures", async () => {
   let loadCount = 0;
   const adapter = {
-    loadHandoffEnvelope: async () => null,
     async loadSnapshot() {
       loadCount += 1;
       return undefined;
@@ -509,7 +504,6 @@ test("createInspectRunViewerServer keeps JSON failures machine-readable and HTML
 test("createInspectRunViewerServer keeps favicon, unsupported paths, and unsupported methods load-free", async () => {
   let loadCount = 0;
   const adapter = {
-    loadHandoffEnvelope: async () => null,
     async loadSnapshot() {
       loadCount += 1;
       return makeSnapshot();
@@ -569,7 +563,6 @@ test("createInspectRunViewerServer keeps favicon, unsupported paths, and unsuppo
 test("createInspectRunViewerServer treats malformed repo slug query params as bad requests", async () => {
   let loadCount = 0;
   const adapter = {
-    loadHandoffEnvelope: async () => null,
     async loadSnapshot() {
       loadCount += 1;
       throw new Error("should not load snapshot for malformed targets");
@@ -729,7 +722,6 @@ test("createInspectRunViewerServer constrains repo-scoped inbox discovery to the
 
 test("createInspectRunViewerServer returns JSON for malformed /snapshot.json repo/pr query params", async () => {
   const adapter = {
-    loadHandoffEnvelope: async () => null,
     async loadSnapshot() {
       throw new Error("should not load snapshot for malformed targets");
     },
@@ -760,7 +752,6 @@ test("createInspectRunViewerServer returns JSON for malformed /snapshot.json rep
 
 test("createInspectRunViewerServer treats malformed repo/pr query params as bad requests", async () => {
   const adapter = {
-    loadHandoffEnvelope: async () => null,
     async loadSnapshot() {
       throw new Error("should not load snapshot for malformed targets");
     },

--- a/test/loop/inspect-run-viewer-server.test.mjs
+++ b/test/loop/inspect-run-viewer-server.test.mjs
@@ -8,6 +8,7 @@ import { makeSnapshot, requestOnce } from "./inspect-run-viewer-test-helpers.mjs
 test("createInspectRunViewerServer serves browser html from adapter snapshot without inline full snapshot dump", async () => {
   let loadCount = 0;
   const adapter = {
+    loadHandoffEnvelope: async () => null,
     async loadSnapshot() {
       loadCount += 1;
       return makeSnapshot({ sourceMode: "partial", trust: "degraded" });
@@ -43,6 +44,7 @@ test("createInspectRunViewerServer serves browser html from adapter snapshot wit
 test("createInspectRunViewerServer does not eager-load non-selected sidebar snapshots", async () => {
   const seenTargets = [];
   const adapter = {
+    loadHandoffEnvelope: async () => null,
     async loadSnapshot(target) {
       seenTargets.push(`${target.repo}#${target.pr}`);
       return makeSnapshot({ target, runId: `pr-${target.pr}` });
@@ -81,6 +83,7 @@ test("createInspectRunViewerServer does not eager-load non-selected sidebar snap
 
 test("createInspectRunViewerServer skips malformed assigned inbox entries instead of blanking the list", async () => {
   const adapter = {
+    loadHandoffEnvelope: async () => null,
     async loadSnapshot(target) {
       return makeSnapshot({ target, runId: `pr-${target.pr}` });
     },
@@ -114,6 +117,7 @@ test("createInspectRunViewerServer skips malformed assigned inbox entries instea
 test("createInspectRunViewerServer supports selecting another PR from query params", async () => {
   const seenTargets = [];
   const adapter = {
+    loadHandoffEnvelope: async () => null,
     async loadSnapshot(target) {
       seenTargets.push(target);
       return makeSnapshot({
@@ -153,6 +157,7 @@ test("createInspectRunViewerServer supports selecting another PR from query para
 test("createInspectRunViewerServer serves the Mermaid browser asset without loading a snapshot", async () => {
   let loadCount = 0;
   const adapter = {
+    loadHandoffEnvelope: async () => null,
     async loadSnapshot() {
       loadCount += 1;
       return makeSnapshot();
@@ -185,6 +190,7 @@ test("createInspectRunViewerServer keeps Mermaid asset failures generic and path
   let loadCount = 0;
   const loggedErrors = [];
   const adapter = {
+    loadHandoffEnvelope: async () => null,
     async loadSnapshot() {
       loadCount += 1;
       return makeSnapshot();
@@ -226,6 +232,7 @@ test("createInspectRunViewerServer serves authoritative snapshot JSON on /snapsh
   let loadCount = 0;
   const snapshot = makeSnapshot({ sourceMode: "partial", trust: "degraded" });
   const adapter = {
+    loadHandoffEnvelope: async () => null,
     async loadSnapshot() {
       loadCount += 1;
       return snapshot;
@@ -255,6 +262,7 @@ test("createInspectRunViewerServer serves authoritative snapshot JSON on /snapsh
 
 test("createInspectRunViewerServer preserves cached authoritative inbox signals after another PR is selected", async () => {
   const adapter = {
+    loadHandoffEnvelope: async () => null,
     async loadSnapshot(target) {
       if (target.pr === 55) {
         return makeSnapshot({
@@ -311,6 +319,7 @@ test("createInspectRunViewerServer preserves cached authoritative inbox signals 
 test("createInspectRunViewerServer honors an explicit inbox page even when a selected PR exists", async () => {
   const seenTargets = [];
   const adapter = {
+    loadHandoffEnvelope: async () => null,
     async loadSnapshot(target) {
       seenTargets.push(target);
       return makeSnapshot({ target, runId: `pr-${target.pr}` });
@@ -349,6 +358,7 @@ test("createInspectRunViewerServer honors an explicit inbox page even when a sel
 test("createInspectRunViewerServer keeps explicit query targets even when they are not in the current inbox page", async () => {
   const seenTargets = [];
   const adapter = {
+    loadHandoffEnvelope: async () => null,
     async loadSnapshot(target) {
       seenTargets.push(target);
       return makeSnapshot({ target, runId: `pr-${target.pr}` });
@@ -391,6 +401,7 @@ test("createInspectRunViewerServer keeps explicit query targets even when they a
 test("createInspectRunViewerServer resolves /snapshot.json target from query params", async () => {
   const seenTargets = [];
   const adapter = {
+    loadHandoffEnvelope: async () => null,
     async loadSnapshot(target) {
       seenTargets.push(target);
       return makeSnapshot({ target, runId: `pr-${target.pr}` });
@@ -421,6 +432,7 @@ test("createInspectRunViewerServer resolves /snapshot.json target from query par
 test("createInspectRunViewerServer treats missing JSON snapshots as machine-readable failures", async () => {
   let loadCount = 0;
   const adapter = {
+    loadHandoffEnvelope: async () => null,
     async loadSnapshot() {
       loadCount += 1;
       return undefined;
@@ -455,6 +467,7 @@ test("createInspectRunViewerServer treats missing JSON snapshots as machine-read
 test("createInspectRunViewerServer keeps JSON failures machine-readable and HTML failures browser-friendly", async () => {
   let loadCount = 0;
   const adapter = {
+    loadHandoffEnvelope: async () => null,
     async loadSnapshot() {
       loadCount += 1;
       throw new Error("inspection snapshot unavailable");
@@ -496,6 +509,7 @@ test("createInspectRunViewerServer keeps JSON failures machine-readable and HTML
 test("createInspectRunViewerServer keeps favicon, unsupported paths, and unsupported methods load-free", async () => {
   let loadCount = 0;
   const adapter = {
+    loadHandoffEnvelope: async () => null,
     async loadSnapshot() {
       loadCount += 1;
       return makeSnapshot();
@@ -555,6 +569,7 @@ test("createInspectRunViewerServer keeps favicon, unsupported paths, and unsuppo
 test("createInspectRunViewerServer treats malformed repo slug query params as bad requests", async () => {
   let loadCount = 0;
   const adapter = {
+    loadHandoffEnvelope: async () => null,
     async loadSnapshot() {
       loadCount += 1;
       throw new Error("should not load snapshot for malformed targets");
@@ -591,6 +606,7 @@ test("createInspectRunViewerServer treats malformed repo slug query params as ba
 test("createInspectRunViewerServer reuses the all-repos inbox query for the default unscoped view", async () => {
   const listCalls = [];
   const adapter = {
+    loadHandoffEnvelope: async () => null,
     async loadSnapshot(target) {
       return makeSnapshot({ target, runId: `pr-${target.pr}` });
     },
@@ -635,6 +651,7 @@ test("createInspectRunViewerServer reuses the all-repos inbox query for the defa
 
 test("createInspectRunViewerServer normalizes unsupported assigned inbox signals before rendering", async () => {
   const adapter = {
+    loadHandoffEnvelope: async () => null,
     async listAssignedPullRequests() {
       return [
         { target: { repo: "owner/repo", pr: 55 }, title: "Primary PR", updatedAt: "2026-05-21T00:00:00Z" },
@@ -667,6 +684,7 @@ test("createInspectRunViewerServer normalizes unsupported assigned inbox signals
 test("createInspectRunViewerServer constrains repo-scoped inbox discovery to the fixed repo", async () => {
   const listCalls = [];
   const adapter = {
+    loadHandoffEnvelope: async () => null,
     async loadSnapshot(target) {
       return makeSnapshot({ target, runId: `pr-${target.pr}` });
     },
@@ -711,6 +729,7 @@ test("createInspectRunViewerServer constrains repo-scoped inbox discovery to the
 
 test("createInspectRunViewerServer returns JSON for malformed /snapshot.json repo/pr query params", async () => {
   const adapter = {
+    loadHandoffEnvelope: async () => null,
     async loadSnapshot() {
       throw new Error("should not load snapshot for malformed targets");
     },
@@ -741,6 +760,7 @@ test("createInspectRunViewerServer returns JSON for malformed /snapshot.json rep
 
 test("createInspectRunViewerServer treats malformed repo/pr query params as bad requests", async () => {
   const adapter = {
+    loadHandoffEnvelope: async () => null,
     async loadSnapshot() {
       throw new Error("should not load snapshot for malformed targets");
     },
@@ -767,6 +787,7 @@ test("createInspectRunViewerServer treats malformed repo/pr query params as bad 
 test("createInspectRunViewerServer guards malformed request URLs and undefined snapshots", async () => {
   let loadCount = 0;
   const adapter = {
+    loadHandoffEnvelope: async () => null,
     async loadSnapshot() {
       loadCount += 1;
       return undefined;


### PR DESCRIPTION
## Summary

Speeds up `npm run verify` by removing the dominant `test:scripts` bottleneck.

`test/loop/inspect-run-viewer-server.test.mjs` supplied test adapters with `loadSnapshot` but no `loadHandoffEnvelope`. On every HTML `/` render with a selected PR, `scripts/loop/inspect-run-viewer/server.mjs` falls through to `runResolverForTarget`, which spawns the real `resolve-dev-loop-startup.mjs` subprocess (~13-20s per case). That made this one file ~180-260s on its own.

Fix: add `loadHandoffEnvelope: async () => null` to the test adapters that actually reach that render path, so the real resolver subprocess is never invoked during ordinary HTML-render unit tests. The stub is applied only to the 12 tests that GET `/` with a selected PR (the ones that would otherwise spawn the resolver); tests on other paths (assets, `/snapshot.json`, favicon/405, malformed-target 400s) never call `loadHandoffEnvelope` and are left unchanged. No production change.

## Results (same machine)

| | Before | After |
|---|---|---|
| `inspect-run-viewer-server.test.mjs` | ~180-260s | ~0.25s |
| `test:scripts` (full) | ~264s | ~72s |
| `npm run verify` | ~274s | ~85s |

New dominant `test:scripts` cost is the legitimate CLI-contract spawn suites (largest: `test/github/upsert-checkpoint-verdict.test.mjs` ~69s), which spawn the real CLI with `gh` stubbed — genuine boundary coverage, no real network/sleep/redundant work — left as-is per the issue's "only as needed to hit the target."

## Coverage

No assertions weakened or removed. None of the modified tests reference handoff or assert handoff-envelope output — they exercised the resolver only as an accidental side effect. The resolver/handoff render path stays covered by `test/loop/build-handoff-envelope.test.mjs` and `test/loop/inspect-run-viewer-handoff-envelope-renderer.test.mjs` (incl. its XSS-escaping assertion).

## Scope

- 1 file changed, +12 lines, test-only.

Closes #1264
