### PR TITLE
perf(ci): parallelize verify suites so wall time ≈ slowest suite, not their sum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,19 @@ jobs:
             echo 'articles=false' >> "$GITHUB_OUTPUT"
           fi
 
-  verify:
+  verify-suite:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - test:assets
+          - test:extension
+          - test:scripts
+          - test:core
+          - test:docs
+          - test:pack
+          - test:dev-loop
 
     steps:
       - name: Check out repository
@@ -87,8 +98,17 @@ jobs:
       - name: Install workspace dependencies
         run: npm ci
 
-      - name: Run canonical verify suite
-        run: npm run verify
+      - name: Run ${{ matrix.suite }}
+        run: npm run ${{ matrix.suite }}
+
+  verify:
+    needs: [verify-suite]
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Require all verify-suite legs to pass
+        run: '[ "${{ needs.verify-suite.result }}" = "success" ] || exit 1'
 
   viewer-smoke:
     needs:

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ docker run -it --rm -e GH_TOKEN="$GH_TOKEN" -v "$HOME/.pi:/home/node/.pi" -v /tm
 npm run verify   # canonical root verification (tests + dev-loop tests)
 ```
 
-CI splits into a small changed-files gate plus parallel `verify` and conditional `viewer-smoke` jobs. `npm ci` + `npm run verify` run on every change; the Playwright/WebKit viewer smoke runs only when the bounded viewer surface or its smoke-path dependencies change.
+CI splits into a small changed-files gate plus a parallel `verify-suite` matrix (one leg per `test:*` suite) gated by a fail-closed `verify` job, and a conditional `viewer-smoke` job. On every change, `npm ci` runs and the verify suites run as parallel matrix legs; the Playwright/WebKit viewer smoke runs only when the bounded viewer surface or its smoke-path dependencies change.
 
 ### Migrating from an earlier release
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -221,7 +221,7 @@ Current Phase 3+ contract:
 - this phase does not require a separate compiled build or `dist/` pipeline
 
 Root verification and test commands are intentionally explicit:
-- `npm run verify` is the canonical root verification path (`npm test` + `npm run test:dev-loop`)
+- `npm run verify` is the canonical root verification path; it runs every suite in parallel via `run-p` as a single aggregated command, and any suite failing fails verify
 - `npm test` runs the current root test suite (`test:assets`, `test:extension`, `test:scripts`, `test:core`, and `test:docs`)
 - `npm run test:extension`
 - `npm run test:extension` currently expands to one `node --import tsx --test ...` invocation in `package.json`; prefer the script entrypoint over copying the file list into downstream docs or runbooks

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
+        "npm-run-all2": "^9.0.2",
         "tsx": "^4.22.0"
       },
       "engines": {
@@ -687,6 +688,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -703,6 +707,9 @@
       "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -721,6 +728,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -738,6 +748,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -754,6 +767,9 @@
       "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2441,6 +2457,57 @@
         "node": ">=18"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
@@ -2511,6 +2578,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-6.0.0.tgz",
+      "integrity": "sha512-2/8adwnK1/+Fdjyts4r6wSpfANWw8zdNhU9U/Llk59c6O+DjSisPWPykwoL8gZmocP9Dy64S7oie2g+Mia123A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
     "node_modules/marked": {
       "version": "15.0.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
@@ -2522,6 +2609,88 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-6.0.0.tgz",
+      "integrity": "sha512-tdt4aFn9QamlhdN3HV2D2ccpBwO5/fyjjbXUxYA6uBjyekMZcZvDq0aSj9t5Jo+tih6AYFnt/cuIRn9013e0Uw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/npm-run-all2": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-all2/-/npm-run-all2-9.0.2.tgz",
+      "integrity": "sha512-+dd4SO2jAlLE06OzmJKzIe6QvvjXezcbmobnh8usR0a8BzQCABTdqTXqVPji0ICOhSQpIIrkGd7IzNl5iDaRSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "cross-spawn": "^7.0.6",
+        "memorystream": "^0.3.1",
+        "picomatch": "^4.0.2",
+        "pidtree": "^1.0.0",
+        "read-package-json-fast": "^6.0.0",
+        "shell-quote": "^1.8.4",
+        "which": "^7.0.0"
+      },
+      "bin": {
+        "npm-run-all": "bin/npm-run-all/index.js",
+        "npm-run-all2": "bin/npm-run-all/index.js",
+        "run-p": "bin/run-p/index.js",
+        "run-s": "bin/run-s/index.js"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
+        "npm": ">= 10"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-1.0.0.tgz",
+      "integrity": "sha512-avfAvjB9Dd0wdj3rjJX//yS+G79OO0KrS5pJHFJENjYGX6N4SMgEDBBI/yFy0lloOYSaC6XQxzpOAMPfSYFV/Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/playwright": {
@@ -2571,6 +2740,56 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/read-package-json-fast": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-6.0.0.tgz",
+      "integrity": "sha512-PNaGjoCnw9DBA2Kl8D+8po957z778q/HOPuY2u3Bkw/JO3eC8MDx7jn/PgMtSgpcBbs+6UOjDbwReGpXmRvs0g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^6.0.0",
+        "npm-normalize-package-bin": "^6.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/tsx": {
       "version": "4.22.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.0.tgz",
@@ -2588,6 +2807,22 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/which": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-7.0.0.tgz",
+      "integrity": "sha512-RancgH2dmbLdHl6LRhEqvklWMgl/Hdnun0Y90KhBOLkMefg8Qa7/Zel8Sm+8HEcP6DEjzsWzpkuBQEZok58isA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "packages/*"
   ],
   "scripts": {
-    "verify": "npm test && npm run test:dev-loop",
-    "test": "npm run test:assets && npm run test:extension && npm run test:scripts && npm run test:core && npm run test:docs && npm run test:pack",
+    "verify": "run-p --aggregate-output --continue-on-error test:assets test:extension test:scripts test:core test:docs test:pack test:dev-loop",
+    "test": "run-p --aggregate-output --continue-on-error test:assets test:extension test:scripts test:core test:docs test:pack",
     "test:assets": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/dev-loop-init-phase-smoke.test.mjs test/contracts/*.test.mjs test/workflow-handoff-contract.test.mjs",
     "test:extension": "node --import tsx --test --test-reporter ./test/failure-summary-reporter.mjs test/extension-checks.test.mjs test/extension-post-merge-update.test.mjs test/extension-command-contract.test.mjs test/extension-package-contract.test.mjs test/extension-pi-adapter.test.mjs test/dev-loops-core.test.mjs test/dev-loops-cli.test.mjs",
     "test:scripts": "GIT_CONFIG_COUNT=2 GIT_CONFIG_KEY_0=core.fsync GIT_CONFIG_VALUE_0=none GIT_CONFIG_KEY_1=core.fsyncObjectFiles GIT_CONFIG_VALUE_1=false node --test --test-reporter ./test/failure-summary-reporter.mjs test/github/*.test.mjs test/loop/*.test.mjs test/docs/*.test.mjs test/projects/*.test.mjs test/pages/*.test.mjs",
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
+    "npm-run-all2": "^9.0.2",
     "tsx": "^4.22.0"
   },
   "pi": {

--- a/test/contracts/review-doc-contracts.test.mjs
+++ b/test/contracts/review-doc-contracts.test.mjs
@@ -197,6 +197,7 @@ test("CI runs verify as a parallel suite matrix gated by a fail-closed aggregati
   // Scope leg-membership to the verify-suite job's matrix list (up to the next
   // job header) so a suite name appearing elsewhere can't satisfy the check.
   const verifySuiteHeaderIndex = ciWorkflow.search(/^\s{2}verify-suite:\s*$/m);
+  assert.ok(verifySuiteHeaderIndex !== -1, "ci.yml must define a verify-suite: job");
   const nextSuiteJobRelative = ciWorkflow
     .slice(verifySuiteHeaderIndex + 1)
     .search(/^\s{2}\S/m);
@@ -228,6 +229,7 @@ test("CI runs verify as a parallel suite matrix gated by a fail-closed aggregati
   // own section (header to the next top-level job header) so a future job added
   // below `verify` carrying either token can't silently satisfy the check.
   const verifyHeaderIndex = ciWorkflow.search(/^\s{2}verify:\s*$/m);
+  assert.ok(verifyHeaderIndex !== -1, "ci.yml must define a verify: aggregation job");
   const nextJobRelative = ciWorkflow
     .slice(verifyHeaderIndex + 1)
     .search(/^\s{2}\S/m);

--- a/test/contracts/review-doc-contracts.test.mjs
+++ b/test/contracts/review-doc-contracts.test.mjs
@@ -196,9 +196,15 @@ test("CI runs verify as a parallel suite matrix gated by a fail-closed aggregati
 
   // Scope leg-membership to the verify-suite job's matrix list (up to the next
   // job header) so a suite name appearing elsewhere can't satisfy the check.
+  const verifySuiteHeaderIndex = ciWorkflow.search(/^\s{2}verify-suite:\s*$/m);
+  const nextSuiteJobRelative = ciWorkflow
+    .slice(verifySuiteHeaderIndex + 1)
+    .search(/^\s{2}\S/m);
   const verifySuiteSection = ciWorkflow.slice(
-    ciWorkflow.search(/^\s{2}verify-suite:\s*$/m),
-    ciWorkflow.search(/^\s{2}verify:\s*$/m),
+    verifySuiteHeaderIndex,
+    nextSuiteJobRelative === -1
+      ? ciWorkflow.length
+      : verifySuiteHeaderIndex + 1 + nextSuiteJobRelative,
   );
   for (const suite of [
     "test:assets",

--- a/test/contracts/review-doc-contracts.test.mjs
+++ b/test/contracts/review-doc-contracts.test.mjs
@@ -157,28 +157,6 @@ test("CI gates the Playwright WebKit smoke behind inspect-run viewer change dete
   assert.match(ciWorkflow, /viewer-smoke:[\s\S]*if:\s*needs\.changes\.outputs\.inspect_run_viewer\s*==\s*'true'/i);
   assert.match(ciWorkflow, /viewer-smoke:[\s\S]*uses:\s*\.\/\.github\/actions\/playwright-webkit/i);
   assert.match(ciWorkflow, /viewer-smoke:[\s\S]*npm run test:playwright:viewer/i);
-  // Verify runs as a parallel matrix (one leg per suite) gated by an
-  // aggregation job named `verify` so the required-status-check name is
-  // preserved. Assert every suite is a matrix leg and the gate fails closed.
-  assert.match(ciWorkflow, /^\s{2}verify-suite:\s*$/m);
-  assert.match(ciWorkflow, /verify-suite:[\s\S]*fail-fast:\s*false/i);
-  assert.match(ciWorkflow, /verify-suite:[\s\S]*npm run \$\{\{\s*matrix\.suite\s*\}\}/i);
-  for (const suite of [
-    "test:assets",
-    "test:extension",
-    "test:scripts",
-    "test:core",
-    "test:docs",
-    "test:pack",
-    "test:dev-loop",
-  ]) {
-    assert.match(
-      ciWorkflow,
-      new RegExp(`-\\s*${suite.replace(":", "\\:")}\\s*$`, "m"),
-      `verify-suite matrix must include ${suite}`,
-    );
-  }
-  assert.match(ciWorkflow, /verify:[\s\S]*needs:\s*\[verify-suite\][\s\S]*needs\.verify-suite\.result[\s\S]*success/i);
 
   // All THREE smoke jobs must route through the shared composite action, so a
   // future edit can't silently reintroduce the duplication in any of them
@@ -204,4 +182,44 @@ test("CI gates the Playwright WebKit smoke behind inspect-run viewer change dete
   assert.match(playwrightWebkitAction, /path:\s*\$\{\{\s*env\.PLAYWRIGHT_BROWSERS_PATH\s*\}\}/i);
   assert.match(playwrightWebkitAction, /PLAYWRIGHT_BROWSERS_PATH=\$\{\{\s*github\.workspace\s*\}\}\/\.cache\/ms-playwright/i);
   assert.match(playwrightWebkitAction, /key:\s*\$\{\{\s*runner\.os\s*\}\}-playwright-webkit-\$\{\{\s*hashFiles\('package-lock\.json'\)\s*\}\}/i);
+});
+
+test("CI runs verify as a parallel suite matrix gated by a fail-closed aggregation job", async () => {
+  const ciWorkflow = await readRepo(".github/workflows/ci.yml");
+
+  // verify runs as a parallel matrix (one leg per suite) gated by an
+  // aggregation job named `verify` so the required-status-check name is
+  // preserved. Assert every suite is a matrix leg and the gate fails closed.
+  assert.match(ciWorkflow, /^\s{2}verify-suite:\s*$/m);
+  assert.match(ciWorkflow, /verify-suite:[\s\S]*fail-fast:\s*false/i);
+  assert.match(ciWorkflow, /verify-suite:[\s\S]*npm run \$\{\{\s*matrix\.suite\s*\}\}/i);
+
+  // Scope leg-membership to the verify-suite job's matrix list (up to the next
+  // job header) so a suite name appearing elsewhere can't satisfy the check.
+  const verifySuiteSection = ciWorkflow.slice(
+    ciWorkflow.search(/^\s{2}verify-suite:\s*$/m),
+    ciWorkflow.search(/^\s{2}verify:\s*$/m),
+  );
+  for (const suite of [
+    "test:assets",
+    "test:extension",
+    "test:scripts",
+    "test:core",
+    "test:docs",
+    "test:pack",
+    "test:dev-loop",
+  ]) {
+    assert.match(
+      verifySuiteSection,
+      new RegExp(`^\\s*-\\s*${suite}\\s*$`, "m"),
+      `verify-suite matrix must include ${suite}`,
+    );
+  }
+
+  // Fail-closed aggregation: the gate must run on `if: always()` (else a failed
+  // leg SKIPS the gate under the default `if: success()`), depend on the whole
+  // matrix, and `exit 1` when any leg is non-success.
+  assert.match(ciWorkflow, /verify:[\s\S]*needs:\s*\[verify-suite\][\s\S]*needs\.verify-suite\.result[\s\S]*success/i);
+  assert.match(ciWorkflow, /verify:[\s\S]*if:\s*always\(\)/i);
+  assert.match(ciWorkflow, /verify:[\s\S]*exit 1/i);
 });

--- a/test/contracts/review-doc-contracts.test.mjs
+++ b/test/contracts/review-doc-contracts.test.mjs
@@ -218,8 +218,18 @@ test("CI runs verify as a parallel suite matrix gated by a fail-closed aggregati
 
   // Fail-closed aggregation: the gate must run on `if: always()` (else a failed
   // leg SKIPS the gate under the default `if: success()`), depend on the whole
-  // matrix, and `exit 1` when any leg is non-success.
-  assert.match(ciWorkflow, /verify:[\s\S]*needs:\s*\[verify-suite\][\s\S]*needs\.verify-suite\.result[\s\S]*success/i);
-  assert.match(ciWorkflow, /verify:[\s\S]*if:\s*always\(\)/i);
-  assert.match(ciWorkflow, /verify:[\s\S]*exit 1/i);
+  // matrix, and `exit 1` when any leg is non-success. Scope to the verify job's
+  // own section (header to the next top-level job header) so a future job added
+  // below `verify` carrying either token can't silently satisfy the check.
+  const verifyHeaderIndex = ciWorkflow.search(/^\s{2}verify:\s*$/m);
+  const nextJobRelative = ciWorkflow
+    .slice(verifyHeaderIndex + 1)
+    .search(/^\s{2}\S/m);
+  const verifySection = ciWorkflow.slice(
+    verifyHeaderIndex,
+    nextJobRelative === -1 ? ciWorkflow.length : verifyHeaderIndex + 1 + nextJobRelative,
+  );
+  assert.match(verifySection, /needs:\s*\[verify-suite\][\s\S]*needs\.verify-suite\.result[\s\S]*success/i);
+  assert.match(verifySection, /if:\s*always\(\)/i);
+  assert.match(verifySection, /exit 1/i);
 });

--- a/test/contracts/review-doc-contracts.test.mjs
+++ b/test/contracts/review-doc-contracts.test.mjs
@@ -157,7 +157,28 @@ test("CI gates the Playwright WebKit smoke behind inspect-run viewer change dete
   assert.match(ciWorkflow, /viewer-smoke:[\s\S]*if:\s*needs\.changes\.outputs\.inspect_run_viewer\s*==\s*'true'/i);
   assert.match(ciWorkflow, /viewer-smoke:[\s\S]*uses:\s*\.\/\.github\/actions\/playwright-webkit/i);
   assert.match(ciWorkflow, /viewer-smoke:[\s\S]*npm run test:playwright:viewer/i);
-  assert.match(ciWorkflow, /verify:[\s\S]*npm run verify/i);
+  // Verify runs as a parallel matrix (one leg per suite) gated by an
+  // aggregation job named `verify` so the required-status-check name is
+  // preserved. Assert every suite is a matrix leg and the gate fails closed.
+  assert.match(ciWorkflow, /^\s{2}verify-suite:\s*$/m);
+  assert.match(ciWorkflow, /verify-suite:[\s\S]*fail-fast:\s*false/i);
+  assert.match(ciWorkflow, /verify-suite:[\s\S]*npm run \$\{\{\s*matrix\.suite\s*\}\}/i);
+  for (const suite of [
+    "test:assets",
+    "test:extension",
+    "test:scripts",
+    "test:core",
+    "test:docs",
+    "test:pack",
+    "test:dev-loop",
+  ]) {
+    assert.match(
+      ciWorkflow,
+      new RegExp(`-\\s*${suite.replace(":", "\\:")}\\s*$`, "m"),
+      `verify-suite matrix must include ${suite}`,
+    );
+  }
+  assert.match(ciWorkflow, /verify:[\s\S]*needs:\s*\[verify-suite\][\s\S]*needs\.verify-suite\.result[\s\S]*success/i);
 
   // All THREE smoke jobs must route through the shared composite action, so a
   // future edit can't silently reintroduce the duplication in any of them


### PR DESCRIPTION
Closes #1270

## Problem
`npm run verify` chained every suite strictly sequentially, so CI wall time was the **sum** of all suites even though they are independent. After #1264, `test:scripts` (~72s) dominated; the other six suites combined were ~10s, yet CI paid for all of them back-to-back.

## Change
Run the independent suites **concurrently** instead of serially, in two places.

**CI (`.github/workflows/ci.yml`)** — the single `verify` job is replaced by:
- `verify-suite`: a matrix job with one leg per suite (`test:assets`, `test:extension`, `test:scripts`, `test:core`, `test:docs`, `test:pack`, `test:dev-loop`), `fail-fast: false` so a failure in one suite never masks or cancels the others. Each leg runs on its own runner, so CI wall time ≈ the slowest single suite (`test:scripts`) instead of the sum.
- `verify`: an aggregation gate job (`needs: [verify-suite]`, `if: always()`) that fails closed unless every matrix leg succeeded (`needs.verify-suite.result == 'success'`). Keeping this job named `verify` **preserves the existing required-status-check name**, so branch protection needs no admin change.

**Local (`package.json`)** — `verify` and `test` now fan the suites across cores via `npm-run-all2`'s `run-p`:
- `verify`: `run-p --aggregate-output --continue-on-error test:assets test:extension test:scripts test:core test:docs test:pack test:dev-loop`
- `test`: same for the six-suite group.
- `--continue-on-error` runs every suite even if one fails (all failures surface, not just the first) and still exits non-zero if any failed; `--aggregate-output` groups each suite's output instead of interleaving it, so a failure stays unambiguously attributable to its suite. Individual `test:*` scripts are unchanged (the matrix invokes them directly, including `test:scripts`' `GIT_CONFIG_*` prefix).

`npm run verify` remains a single local command with a clear aggregated pass/fail (also still used by `npm-publish.yml`).

## File-by-file changes
- **`.github/workflows/ci.yml`** — replaced the single `verify` job with a `verify-suite` matrix (7 legs, `fail-fast: false`) plus a fail-closed `verify` aggregation gate (`needs: [verify-suite]`, `if: always()`, `[ "${{ needs.verify-suite.result }}" = "success" ] || exit 1`). The `changes`/`viewer-smoke`/`deck-smoke`/`article-smoke` jobs are untouched.
- **`package.json`** — `verify` and `test` now use `run-p --aggregate-output --continue-on-error ...`; added `npm-run-all2` to `devDependencies`. All individual `test:*` scripts unchanged.
- **`package-lock.json`** — locks `npm-run-all2` (and its transitive deps) so `npm ci` is reproducible.
- **`test/contracts/review-doc-contracts.test.mjs`** — added a dedicated test, `CI runs verify as a parallel suite matrix gated by a fail-closed aggregation job`, asserting every suite is a matrix leg, `fail-fast: false`, the `verify` gate's `if: always()` and `exit 1` fail-closed branch, and `needs.verify-suite.result == 'success'`. (Extracted out of the WebKit-smoke test so failures attribute correctly.)
- **`extension/README.md`** — corrected the `npm run verify` mechanism description to match the new parallel `run-p` wiring.

## Timing (measured)
CI wall time for the verify path, from the actual workflow runs:

| | Before (sequential single `verify` job, on `main`) | After (parallel `verify-suite` matrix) |
|---|---|---|
| CI verify-path wall | **~124s** (setup + sum of suites) | **~104s** (slowest leg + aggregation gate) |
| Slowest suite leg (`test:scripts`) | — | 99s (own runner: checkout + `npm ci` + suite) |
| Other six legs | ran inside the 124s | 13–24s each, all concurrent |
| `verify` aggregation gate | — | 2s |

Serial sum of the leg runtimes would be ~206s; the parallel matrix bounds wall time at the slowest leg (~104s incl. the aggregation tail). The remaining floor is `test:scripts` itself — addressed by the intrinsic-speedup follow-up (see Non-goals).

Local `npm run verify`: **83.6s → 71.7s** (sequential → `run-p`; a single machine shares cores, so the CI matrix is where the structural win lands).

## Acceptance criteria (from #1270)
- [x] CI `verify` wall time reduced to ≈ the slowest single suite via parallel suite execution, all suites still required, any suite failure still fails CI (fail-closed `verify` aggregation gate over a `fail-fast: false` matrix).
- [x] `npm run verify` still works as a single local command with a clear aggregated pass/fail; a failure in any suite is unambiguously reported (`run-p --aggregate-output --continue-on-error`, non-zero exit on any failure).
- [x] Before/after CI timing recorded in the PR (table above).
- [x] No loss of coverage; no test weakened to hit the target (contract coverage strengthened: the fail-closed gate is now explicitly locked).

## Guarantees
- Every suite is still REQUIRED; any suite failure still fails CI (via the fail-closed `verify` aggregation gate).
- No coverage removed and no assertion weakened to hit the target.
- Contract test asserts the new matrix + aggregation-gate structure, including the `if: always()` + `exit 1` fail-closed branch (stronger, not weaker).

## Non-goals
- Not splitting `test:scripts` itself. Sharding `test:scripts` across additional matrix legs was considered — it would push CI wall below the ~72s floor — but is deliberately **deferred**: the preferred fix is making the slow tests intrinsically fast (no real git ops, sleeps zeroed/configurable), tracked as a separate intrinsic-speedup follow-up. This PR keeps CI wall ≈ the slowest single suite via suite-level parallelization only.
- Not weakening any suite's assertions.
