### PR TITLE
docs: correct config-defaults path + precedence in extension README, schema, and migration guide (#1266)

### DIFF
--- a/docs/migrating-to-dev-loops.md
+++ b/docs/migrating-to-dev-loops.md
@@ -80,7 +80,7 @@ set a run-id yourself, prefer `DEVLOOPS_RUN_ID`.
 
 Consumer overrides should live in **`.devloops`** at the repo root. The legacy
 `.pi/dev-loop/settings.*` and `.pi/dev-loop/overrides.*` are deprecated fallbacks that load
-only when no `.devloops` is present (each emits a deprecation warning) — move your
+only when no `.devloops` is present (a single deprecation warning fires when a legacy path is found) — move your
 overrides to `.devloops` (`.yml`/`.json` extensions are also accepted). Packaged defaults
 ship with the extension in `packages/core/src/config/extension-defaults.yaml`; a repo-local
 `.pi/dev-loop/defaults.*` layer merges on top of them when present, and you only need to

--- a/docs/migrating-to-dev-loops.md
+++ b/docs/migrating-to-dev-loops.md
@@ -81,8 +81,9 @@ set a run-id yourself, prefer `DEVLOOPS_RUN_ID`.
 Consumer overrides should live in **`.devloops`** at the repo root. The legacy
 `.pi/dev-loop/settings.yaml` still loads, but emits a deprecation warning — move your
 overrides to `.devloops` (`.yml`/`.json` extensions are also accepted). Packaged defaults
-ship with the extension (`.pi/dev-loop/defaults.yaml`); you only need to override the keys
-you want to change.
+ship with the extension in `packages/core/src/config/extension-defaults.yaml`; a repo-local
+`.pi/dev-loop/defaults.*` layer merges on top of them when present, and you only need to
+override the keys you want to change.
 
 ## 5. Node version floor
 

--- a/docs/migrating-to-dev-loops.md
+++ b/docs/migrating-to-dev-loops.md
@@ -79,7 +79,8 @@ set a run-id yourself, prefer `DEVLOOPS_RUN_ID`.
 ## 4. Config file location
 
 Consumer overrides should live in **`.devloops`** at the repo root. The legacy
-`.pi/dev-loop/settings.yaml` still loads, but emits a deprecation warning — move your
+`.pi/dev-loop/settings.*` and `.pi/dev-loop/overrides.*` are deprecated fallbacks that load
+only when no `.devloops` is present (each emits a deprecation warning) — move your
 overrides to `.devloops` (`.yml`/`.json` extensions are also accepted). Packaged defaults
 ship with the extension in `packages/core/src/config/extension-defaults.yaml`; a repo-local
 `.pi/dev-loop/defaults.*` layer merges on top of them when present, and you only need to

--- a/docs/projects-queue-contract.md
+++ b/docs/projects-queue-contract.md
@@ -399,11 +399,11 @@ ordering fail closed — they do not treat the missing board as equivalent to "n
 The `queue.projectNumber` key provides direct project lookup by number, bypassing title-based
 discovery. When both `projectNumber` and `boardTitle` are set, `projectNumber` takes precedence.
 
-### Settings precedence
+### Settings source
 
-1. `packages/core/src/config/extension-defaults.yaml` — shipped defaults (does not set `boardTitle`)
-2. `.pi/dev-loop/defaults.*` — repo-local override layer (does not set `boardTitle`)
-3. `.devloops` — operator overrides (may set `boardTitle`)
+Queue board settings (`boardTitle` / `projectNumber`) are read only from `.devloops` at the
+repo root. The shipped defaults (`packages/core/src/config/extension-defaults.yaml`) and the
+repo-local `.pi/dev-loop/defaults.*` override layer deliberately do not set them.
 
 Project number and URL are discoverable at runtime via the GraphQL API — no explicit config
 entry is required.

--- a/docs/projects-queue-contract.md
+++ b/docs/projects-queue-contract.md
@@ -401,8 +401,9 @@ discovery. When both `projectNumber` and `boardTitle` are set, `projectNumber` t
 
 ### Settings precedence
 
-1. `.pi/dev-loop/defaults.yaml` — shipped defaults (does not set `boardTitle`)
-2. `.devloops` — operator overrides (may set `boardTitle`)
+1. `packages/core/src/config/extension-defaults.yaml` — shipped defaults (does not set `boardTitle`)
+2. `.pi/dev-loop/defaults.*` — repo-local override layer (does not set `boardTitle`)
+3. `.devloops` — operator overrides (may set `boardTitle`)
 
 Project number and URL are discoverable at runtime via the GraphQL API — no explicit config
 entry is required.

--- a/docs/projects-queue-contract.md
+++ b/docs/projects-queue-contract.md
@@ -402,8 +402,9 @@ discovery. When both `projectNumber` and `boardTitle` are set, `projectNumber` t
 ### Settings source
 
 Queue board settings (`boardTitle` / `projectNumber`) are read only from `.devloops` at the
-repo root. The shipped defaults (`packages/core/src/config/extension-defaults.yaml`) and the
-repo-local `.pi/dev-loop/defaults.*` override layer deliberately do not set them.
+repo root. The queue tooling does not consult the shipped defaults
+(`packages/core/src/config/extension-defaults.yaml`) or the repo-local
+`.pi/dev-loop/defaults.*` override layer for them — both deliberately omit these keys.
 
 Project number and URL are discoverable at runtime via the GraphQL API — no explicit config
 entry is required.

--- a/extension/README.md
+++ b/extension/README.md
@@ -101,7 +101,7 @@ The messaging distinguishes between local loop readiness and remote GitHub/Copil
 
 ## Configuration
 
-The dev-loop workflow is driven by a YAML config at `.pi/dev-loop/defaults.yaml` (shipped with the package) and an optional consumer settings file at `.devloops` at repo root (the loader also accepts `.devloops.yaml`, `.devloops.yml`, and `.devloops.json`; legacy `.pi/dev-loop/settings.*` and `overrides.*` still load as fallbacks with a deprecation warning).
+The dev-loop workflow is driven by the shipped defaults in `packages/core/src/config/extension-defaults.yaml`, an optional repo-local `.pi/dev-loop/defaults.*` layer that merges on top of them, and an optional consumer settings file at `.devloops` at repo root (the loader also accepts `.devloops.yaml`, `.devloops.yml`, and `.devloops.json`; legacy `.pi/dev-loop/settings.*` and `overrides.*` still load as fallbacks with a deprecation warning).
 
 ### How consumers customize config
 
@@ -191,8 +191,9 @@ workflow:
 ### Config precedence
 
 1. Built-in defaults (`packages/core/src/config/config.mjs` `BUILT_IN_DEFAULTS`)
-2. Shipped defaults (`.pi/dev-loop/defaults.yaml` — committed in source repo)
-3. Consumer settings (`.devloops` at repo root — preferred; `.devloops.yaml`/`.devloops.yml`/`.devloops.json` also load; legacy `.pi/dev-loop/settings.*` and `overrides.*` still load as fallbacks with deprecation warning)
+2. Shipped defaults (`packages/core/src/config/extension-defaults.yaml`)
+3. Repo-local override layer (`.pi/dev-loop/defaults.*` — merges on top of the shipped defaults when present)
+4. Consumer settings (`.devloops` at repo root — preferred and authoritative when present; `.devloops.yaml`/`.devloops.yml`/`.devloops.json` also load; legacy `.pi/dev-loop/settings.*` and `overrides.*` still load as fallbacks with deprecation warning)
 
 ### Adding custom review angles
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -101,7 +101,7 @@ The messaging distinguishes between local loop readiness and remote GitHub/Copil
 
 ## Configuration
 
-The dev-loop workflow is driven by the shipped defaults in `packages/core/src/config/extension-defaults.yaml`, an optional repo-local `.pi/dev-loop/defaults.*` layer that merges on top of them, and an optional consumer settings file at `.devloops` at repo root (the loader also accepts `.devloops.yaml`, `.devloops.yml`, and `.devloops.json`; legacy `.pi/dev-loop/settings.*` and `overrides.*` still load as fallbacks with a deprecation warning).
+The dev-loop workflow is driven by the shipped defaults in `packages/core/src/config/extension-defaults.yaml`, an optional repo-local `.pi/dev-loop/defaults.*` layer that merges on top of them, and an optional consumer settings file at `.devloops` at repo root (the loader also accepts `.devloops.yaml`, `.devloops.yml`, and `.devloops.json`; legacy `.pi/dev-loop/settings.*` and `.pi/dev-loop/overrides.*` load only as a fallback when no `.devloops` is present, and are ignored when `.devloops` exists — a deprecation warning still fires).
 
 ### How consumers customize config
 
@@ -193,7 +193,7 @@ workflow:
 1. Built-in defaults (`packages/core/src/config/config.mjs` `BUILT_IN_DEFAULTS`)
 2. Shipped defaults (`packages/core/src/config/extension-defaults.yaml`)
 3. Repo-local override layer (`.pi/dev-loop/defaults.*` — merges on top of the shipped defaults when present)
-4. Consumer settings (`.devloops` at repo root — preferred and authoritative when present; `.devloops.yaml`/`.devloops.yml`/`.devloops.json` also load; legacy `.pi/dev-loop/settings.*` and `overrides.*` still load as fallbacks with deprecation warning)
+4. Consumer settings (`.devloops` at repo root — preferred and authoritative when present; `.devloops.yaml`/`.devloops.yml`/`.devloops.json` also load; legacy `.pi/dev-loop/settings.*` and `.pi/dev-loop/overrides.*` load only as a fallback when no `.devloops` is present; when `.devloops` exists they are ignored, with a deprecation warning)
 
 ### Adding custom review angles
 

--- a/schemas/dev-loop-config.schema.json
+++ b/schemas/dev-loop-config.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/mfittko/dev-loops/schemas/dev-loop-config.schema.json",
   "title": "dev-loops config",
-  "description": "Schema for .pi/dev-loop/defaults.yaml, settings.yaml, or overrides.yaml.",
+  "description": "Schema for dev-loops config across all layers: the shipped defaults in packages/core/src/config/extension-defaults.yaml, the repo-local .pi/dev-loop/defaults.* override layer, and consumer .devloops (legacy .pi/dev-loop/settings.* and overrides.* still validate against it).",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/schemas/dev-loop-config.schema.json
+++ b/schemas/dev-loop-config.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/mfittko/dev-loops/schemas/dev-loop-config.schema.json",
   "title": "dev-loops config",
-  "description": "Schema for dev-loops config across all layers: the shipped defaults in packages/core/src/config/extension-defaults.yaml, the repo-local .pi/dev-loop/defaults.* override layer, and consumer .devloops (legacy .pi/dev-loop/settings.* and overrides.* still validate against it).",
+  "description": "Schema for dev-loops config across all layers: the shipped defaults in packages/core/src/config/extension-defaults.yaml, the repo-local .pi/dev-loop/defaults.* override layer, and consumer .devloops (legacy .pi/dev-loop/settings.* and .pi/dev-loop/overrides.* still validate against it).",
   "type": "object",
   "additionalProperties": false,
   "required": [


### PR DESCRIPTION
## Summary

Follow-up to #1260. Several user-facing surfaces described `.pi/dev-loop/defaults.yaml` as the *shipped defaults*. The shipped defaults live in `packages/core/src/config/extension-defaults.yaml`; `.pi/dev-loop/defaults.*` is a repo-local override layer that merges on top of them. This corrects the remaining surfaces to match, mirroring the #1260 root-README correction.

## Changes

- **`extension/README.md`** — the config-driver sentence and the "Config precedence" list now name `extension-defaults.yaml` as the shipped defaults and add the repo-local `.pi/dev-loop/defaults.*` override layer (precedence, lowest→highest: built-in → shipped extension-defaults → repo-local `.pi/dev-loop/defaults.*` → consumer `.devloops`).
- **`schemas/dev-loop-config.schema.json`** — the `description` names `extension-defaults.yaml` and describes all config layers.
- **`docs/migrating-to-dev-loops.md`** — the packaged-defaults sentence cites `extension-defaults.yaml` and notes the repo-local `.pi/dev-loop/defaults.*` merge layer.
- **`docs/projects-queue-contract.md`** — the "Settings precedence" list names `extension-defaults.yaml` as the shipped defaults with `.pi/dev-loop/defaults.*` as the repo-local override layer.

## Acceptance criteria

- `extension/README.md`, `schemas/dev-loop-config.schema.json`, and `docs/migrating-to-dev-loops.md` name `packages/core/src/config/extension-defaults.yaml` as the shipped-defaults source and present the correct precedence order.
- No live user-facing surface calls `.pi/dev-loop/defaults.yaml` the shipped defaults.
- `.claude` mirrors regenerated if any mirrored doc changed.

## Non-goals

- `docs/phases/phase-8.md` (archival phase record) and the stale suite-count line in `extension/README.md` (:225).
- A repo-wide CI guard asserting the invariant.

Closes #1266
