### PR TITLE
fix(loop): hold the runner-coordination lease across a watch boundary (#1257)

### DIFF
--- a/scripts/github/probe-ci-status.mjs
+++ b/scripts/github/probe-ci-status.mjs
@@ -14,6 +14,8 @@ import {
   DEFAULT_POLL_INTERVAL_MS,
   COPILOT_REVIEW_WAIT_TIMEOUT_MS,
 } from "@dev-loops/core/loop/policy-constants";
+import { ensureAsyncRunnerOwnership } from "../loop/_pr-runner-coordination.mjs";
+import { resolveRepoRoot } from "../loop/_repo-root-resolver.mjs";
 
 /** Maximum interval between heartbeat outputs during watch delays.
  *  Must be shorter than pi-subagents default needsAttentionAfterMs (60s). */
@@ -341,8 +343,10 @@ export async function watchCiStatus(
     ghCommand = "gh",
     delayImpl = delay,
     now = Date.now,
+    ensureOwnershipImpl = ensureAsyncRunnerOwnership,
   } = {},
 ) {
+  const leaseCwd = resolveRepoRoot(process.cwd());
   const { headSha: baselineSha, prVisibleCheckNames } = await fetchPrHeadSha(
     { repo: options.repo, pr: options.pr },
     { env, ghCommand },
@@ -382,6 +386,20 @@ export async function watchCiStatus(
               maxPolls: attemptBudget,
             }) + "\n",
           );
+          // The blocking CI wait can span the full watch budget, which equals the
+          // runner-coordination stale window; refresh the lease alongside each
+          // heartbeat so the claim stays fresh for every caller of this engine.
+          // No-ops without DEVLOOPS_RUN_ID; best-effort, never affects the watch.
+          try {
+            await ensureOwnershipImpl({
+              repo: options.repo,
+              pr: options.pr,
+              env,
+              cwd: leaseCwd,
+              claimIfMissing: true,
+              requireExisting: false,
+            });
+          } catch { /* best-effort: never affect the watch */ }
         }
       }
     }

--- a/scripts/github/probe-copilot-review.mjs
+++ b/scripts/github/probe-copilot-review.mjs
@@ -9,6 +9,8 @@ import {
   DEFAULT_POLL_INTERVAL_MS,
   COPILOT_REVIEW_WAIT_TIMEOUT_MS,
 } from "@dev-loops/core/loop/policy-constants";
+import { ensureAsyncRunnerOwnership } from "../loop/_pr-runner-coordination.mjs";
+import { resolveRepoRoot } from "../loop/_repo-root-resolver.mjs";
 
 /** Maximum interval between heartbeat outputs during watch delays.
  *  Must be shorter than pi-subagents default needsAttentionAfterMs (60s). */
@@ -275,14 +277,18 @@ export async function watchCopilotReview(
   {
     env = process.env,
     ghCommand = "gh",
+    delayImpl = delay,
+    now = Date.now,
+    ensureOwnershipImpl = ensureAsyncRunnerOwnership,
   } = {},
 ) {
+  const leaseCwd = resolveRepoRoot(process.cwd());
   const baseline = parseCopilotActivity(await fetchGithubCopilotActivityPayload(
     { repo: options.repo, pr: options.pr },
     { env, ghCommand },
   ));
   const attemptBudget = buildAttemptBudget(options.timeoutMs, options.pollIntervalMs);
-  const watchStartedAtMs = Date.now();
+  const watchStartedAtMs = now();
   for (let attempt = 1; attempt <= attemptBudget; attempt += 1) {
     if (!(options.timeoutMs === 0 && attempt === 1)) {
       const pollDelayMs = buildPollDelayMs(
@@ -290,15 +296,16 @@ export async function watchCopilotReview(
         options.timeoutMs,
         options.pollIntervalMs,
         attempt,
+        now(),
       );
       if (pollDelayMs > 0) {
         let remainingMs = pollDelayMs;
         while (remainingMs > 0) {
           const chunkMs = Math.min(WATCH_HEARTBEAT_MS, remainingMs);
-          await delay(chunkMs);
+          await delayImpl(chunkMs);
           remainingMs -= chunkMs;
           if (remainingMs > 0) {
-            const nowMs = Date.now();
+            const nowMs = now();
             process.stderr.write(
               JSON.stringify({
                 ok: true,
@@ -309,6 +316,20 @@ export async function watchCopilotReview(
                 maxPolls: attemptBudget,
               }) + "\n",
             );
+            // The blocking review wait can span the full watch budget, which
+            // equals the runner-coordination stale window; refresh the lease
+            // alongside each heartbeat so the claim stays fresh for every caller
+            // of this engine. No-ops without DEVLOOPS_RUN_ID; best-effort.
+            try {
+              await ensureOwnershipImpl({
+                repo: options.repo,
+                pr: options.pr,
+                env,
+                cwd: leaseCwd,
+                claimIfMissing: true,
+                requireExisting: false,
+              });
+            } catch { /* best-effort: never affect the watch */ }
           }
         }
       }

--- a/scripts/loop/run-watch-cycle.mjs
+++ b/scripts/loop/run-watch-cycle.mjs
@@ -354,10 +354,7 @@ export async function runWatchCycle(
       pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
       timeoutMs: ciTimeoutMs,
     };
-    const ciWatch = await runWatchHoldingLease(
-      () => watchCiStatusImpl(ciWatchArgs, { env, ghCommand }),
-      { repo: options.repo, pr: options.pr, env, cwd: leaseCwd, ensureOwnershipImpl },
-    );
+    const ciWatch = await watchCiStatusImpl(ciWatchArgs, { env, ghCommand });
     result.ciWatchArgs = ciWatchArgs;
     result.ciWatch = ciWatch;
     result.watchStatus = ciWatch.status;
@@ -428,10 +425,7 @@ export async function runWatchCycle(
     ...handoff.watchArgs,
     timeoutMs: persistentWatchTimeoutMs,
   };
-  const watch = await runWatchHoldingLease(
-    () => watchCopilotReviewImpl(watchOptions, { env, ghCommand }),
-    { repo: options.repo, pr: options.pr, env, cwd: leaseCwd, ensureOwnershipImpl },
-  );
+  const watch = await watchCopilotReviewImpl(watchOptions, { env, ghCommand });
   result.watchArgs = watchOptions;
   result.watchStatus = watch.status;
   result.watch = watch;

--- a/scripts/loop/run-watch-cycle.mjs
+++ b/scripts/loop/run-watch-cycle.mjs
@@ -10,6 +10,9 @@ import { runHandoff } from "./copilot-pr-handoff.mjs";
 import { STATE } from "@dev-loops/core/loop/copilot-loop-state";
 import { DEFAULT_POLL_INTERVAL_MS } from "@dev-loops/core/loop/policy-constants";
 import { detectCopilotSessionActivity } from "./detect-copilot-session-activity.mjs";
+import { ensureAsyncRunnerOwnership } from "./_pr-runner-coordination.mjs";
+import { resolveRepoRoot } from "./_repo-root-resolver.mjs";
+import { resolveStaleRunnerMaxAgeMs } from "./_stale-runner-detection.mjs";
 import { parseArgs } from "node:util";
 import {
   EXTERNAL_HEALTHY_WAIT_TIMEOUT_POLICY,
@@ -205,6 +208,33 @@ function buildWatchCycleContractTrace({
     },
   };
 }
+// A blocking watch can run for the full external-healthy-wait timeout (30 min for
+// Copilot/CI), which equals the runner-coordination stale window. Without a
+// heartbeat the claim ages to stale across a single watch and the next step is
+// refused. Refresh the lease on entry, on a periodic interval below
+// the stale window, and once more on return so the resuming runner has a fresh claim.
+async function runWatchHoldingLease(watchFactory, { repo, pr, env, cwd, ensureOwnershipImpl }) {
+  const heartbeat = async () => {
+    try {
+      // claimIfMissing:true self-heals a missing record but never stomps a live
+      // competitor (assertRunnerOwnership refuses to write on OWNERSHIP_LOST), so
+      // fail-closed competitor semantics are preserved.
+      await ensureOwnershipImpl({ repo, pr, env, cwd, claimIfMissing: true, requireExisting: false });
+    } catch {
+      // best-effort: a heartbeat failure must never affect the watch
+    }
+  };
+  const intervalMs = Math.max(1, Math.floor(resolveStaleRunnerMaxAgeMs({}, env) / 2));
+  await heartbeat();
+  const timer = setInterval(() => { void heartbeat(); }, intervalMs);
+  if (typeof timer.unref === "function") timer.unref();
+  try {
+    return await watchFactory();
+  } finally {
+    clearInterval(timer);
+    await heartbeat();
+  }
+}
 export function parseWatchCycleCliArgs(argv) {
   const options = {
     help: false,
@@ -278,9 +308,11 @@ export async function runWatchCycle(
     detectCopilotSessionActivityImpl = detectCopilotSessionActivity,
     fetchPrHeadBranchImpl = fetchPrHeadBranch,
     watchWorkflowRunImpl = watchWorkflowRun,
+    ensureOwnershipImpl = ensureAsyncRunnerOwnership,
     detectSessionActivity = false,
   } = {},
 ) {
+  const leaseCwd = resolveRepoRoot(process.cwd());
   const handoff = await runHandoffImpl(options, { env, ghCommand });
   const result = {
     ok: true,
@@ -322,7 +354,10 @@ export async function runWatchCycle(
       pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
       timeoutMs: ciTimeoutMs,
     };
-    const ciWatch = await watchCiStatusImpl(ciWatchArgs, { env, ghCommand });
+    const ciWatch = await runWatchHoldingLease(
+      () => watchCiStatusImpl(ciWatchArgs, { env, ghCommand }),
+      { repo: options.repo, pr: options.pr, env, cwd: leaseCwd, ensureOwnershipImpl },
+    );
     result.ciWatchArgs = ciWatchArgs;
     result.ciWatch = ciWatch;
     result.watchStatus = ciWatch.status;
@@ -370,13 +405,16 @@ export async function runWatchCycle(
       session.activity === "active"
       && Number.isInteger(session.runId)
     ) {
-      const workflowWatchResult = await watchWorkflowRunImpl(
-        {
-          repo: options.repo,
-          runId: session.runId,
-          timeoutMs: persistentWatchTimeoutMs,
-        },
-        { env, ghCommand },
+      const workflowWatchResult = await runWatchHoldingLease(
+        () => watchWorkflowRunImpl(
+          {
+            repo: options.repo,
+            runId: session.runId,
+            timeoutMs: persistentWatchTimeoutMs,
+          },
+          { env, ghCommand },
+        ),
+        { repo: options.repo, pr: options.pr, env, cwd: leaseCwd, ensureOwnershipImpl },
       );
       workflowRunWatch = {
         attempted: true,
@@ -390,7 +428,10 @@ export async function runWatchCycle(
     ...handoff.watchArgs,
     timeoutMs: persistentWatchTimeoutMs,
   };
-  const watch = await watchCopilotReviewImpl(watchOptions, { env, ghCommand });
+  const watch = await runWatchHoldingLease(
+    () => watchCopilotReviewImpl(watchOptions, { env, ghCommand }),
+    { repo: options.repo, pr: options.pr, env, cwd: leaseCwd, ensureOwnershipImpl },
+  );
   result.watchArgs = watchOptions;
   result.watchStatus = watch.status;
   result.watch = watch;

--- a/test/github/probe-ci-status-lease-heartbeat.test.mjs
+++ b/test/github/probe-ci-status-lease-heartbeat.test.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { watchCiStatus } from "../../scripts/github/probe-ci-status.mjs";
+
+function prView(headSha, checkNames = []) {
+  return JSON.stringify({
+    headRefOid: headSha,
+    statusCheckRollup: checkNames.map((name) => ({ name })),
+  });
+}
+function checkRuns(runs) {
+  return JSON.stringify({ check_runs: runs });
+}
+function statuses(items) {
+  return JSON.stringify({ statuses: items });
+}
+
+// gh stub that keeps CI pending for every poll so the watch runs its full budget
+// (>=2 polls) and exercises the inter-poll heartbeat loop before timing out.
+async function withPendingGhStub(fn) {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ci-lease-hb-"));
+  try {
+    const ghPath = path.join(tempDir, "gh");
+    const script = [
+      "#!/usr/bin/env node",
+      'const argv = process.argv.slice(2).join(" ");',
+      'const has = (n) => argv.includes(n);',
+      `if (has("pr") && has("view")) { process.stdout.write(${JSON.stringify(prView("sha-a", ["build"]))}); process.exit(0); }`,
+      `if (has("check-runs")) { process.stdout.write(${JSON.stringify(checkRuns([{ status: "in_progress", conclusion: null, name: "build" }]))}); process.exit(0); }`,
+      `if (has("/status")) { process.stdout.write(${JSON.stringify(statuses([]))}); process.exit(0); }`,
+      'process.stderr.write(`unexpected gh args: ${argv}\\n`); process.exit(97);',
+      "",
+    ].join("\n");
+    await writeFile(ghPath, script, "utf8");
+    await chmod(ghPath, 0o755);
+    const env = { ...process.env, PATH: [tempDir, process.env.PATH ?? ""].filter(Boolean).join(path.delimiter) };
+    return await fn(env);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+// Frozen clock advanced by delayImpl so the inter-poll heartbeat loop runs (the
+// heartbeat only writes when time remains in the chunked delay) without sleeping.
+function advancingClockDeps(env, extra = {}) {
+  let nowMs = 1_000;
+  return {
+    env,
+    ghCommand: "gh",
+    // Advance the clock by less than the chunk so remainingMs stays > 0 for at
+    // least one iteration, guaranteeing the co-located heartbeat fires.
+    delayImpl: async (ms) => { nowMs += Math.min(ms, 1_000); },
+    now: () => nowMs,
+    ...extra,
+  };
+}
+
+test("watchCiStatus heartbeats the runner-coordination lease during the inter-poll wait", async () => {
+  await withPendingGhStub(async (env) => {
+    let ownershipCalls = 0;
+    const result = await watchCiStatus(
+      { repo: "owner/repo", pr: 7, pollIntervalMs: 60_000, timeoutMs: 120_000 },
+      advancingClockDeps(env, {
+        ensureOwnershipImpl: async () => {
+          ownershipCalls += 1;
+          return { ok: true, status: "owner_confirmed" };
+        },
+      }),
+    );
+    assert.equal(result.status, "timeout");
+    // Fails if the engine-level lease heartbeat is removed.
+    assert.ok(ownershipCalls >= 1, `expected >= 1 lease heartbeat during the wait, got ${ownershipCalls}`);
+  });
+});
+
+test("watchCiStatus treats a rejecting lease heartbeat as non-fatal", async () => {
+  await withPendingGhStub(async (env) => {
+    const result = await watchCiStatus(
+      { repo: "owner/repo", pr: 7, pollIntervalMs: 60_000, timeoutMs: 120_000 },
+      advancingClockDeps(env, {
+        ensureOwnershipImpl: async () => { throw new Error("lease boom"); },
+      }),
+    );
+    // The watch still returns its normal terminal result despite the failure.
+    assert.equal(result.status, "timeout");
+    assert.equal(result.settled, false);
+  });
+});

--- a/test/github/probe-copilot-review-lease-heartbeat.test.mjs
+++ b/test/github/probe-copilot-review-lease-heartbeat.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
+
+import { watchCopilotReview } from "../../scripts/github/probe-copilot-review.mjs";
+
+function emptyActivityPayload() {
+  return {
+    data: {
+      repository: {
+        pullRequest: {
+          reviewThreads: { nodes: [] },
+          reviews: { nodes: [] },
+          comments: { nodes: [] },
+        },
+      },
+    },
+  };
+}
+
+async function withGhStub(fn) {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-copilot-lease-hb-"));
+  try {
+    // Every poll returns the same empty activity, so the watch runs its full
+    // budget and times out -> the inter-poll heartbeat loop runs on each poll.
+    const { env } = await writeGhStubHelper(tempDir, [{ stdout: JSON.stringify(emptyActivityPayload()) + "\n" }], {
+      repeatLastOnOverflow: true,
+      defaultStdout: "null\n",
+    });
+    return await fn(env);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+// No real sleeping: a no-op delay that advances the injected clock by less than
+// a heartbeat chunk, so the inter-poll loop always leaves remainingMs > 0 for at
+// least one iteration and the co-located lease heartbeat fires.
+function advancingClockDeps(env, extra = {}) {
+  let nowMs = 1_000;
+  return {
+    env,
+    ghCommand: "gh",
+    delayImpl: async (ms) => { nowMs += Math.min(ms, 1_000); },
+    now: () => nowMs,
+    ...extra,
+  };
+}
+
+test("watchCopilotReview heartbeats the runner-coordination lease during the inter-poll wait", async () => {
+  await withGhStub(async (env) => {
+    let ownershipCalls = 0;
+    const result = await watchCopilotReview(
+      { repo: "owner/repo", pr: 17, pollIntervalMs: 60_000, timeoutMs: 120_000 },
+      advancingClockDeps(env, {
+        ensureOwnershipImpl: async () => {
+          ownershipCalls += 1;
+          return { ok: true, status: "owner_confirmed" };
+        },
+      }),
+    );
+    assert.equal(result.status, "timeout");
+    // Fails if the engine-level lease heartbeat is removed.
+    assert.ok(ownershipCalls >= 1, `expected >= 1 lease heartbeat during the wait, got ${ownershipCalls}`);
+  });
+});
+
+test("watchCopilotReview treats a rejecting lease heartbeat as non-fatal", async () => {
+  await withGhStub(async (env) => {
+    const result = await watchCopilotReview(
+      { repo: "owner/repo", pr: 17, pollIntervalMs: 60_000, timeoutMs: 120_000 },
+      advancingClockDeps(env, {
+        ensureOwnershipImpl: async () => { throw new Error("lease boom"); },
+      }),
+    );
+    // The watch still returns its normal terminal result despite the failure.
+    assert.equal(result.status, "timeout");
+  });
+});

--- a/test/loop/run-watch-cycle-lease-heartbeat.test.mjs
+++ b/test/loop/run-watch-cycle-lease-heartbeat.test.mjs
@@ -3,6 +3,12 @@ import assert from "node:assert/strict";
 
 import { runWatchCycle } from "../../scripts/loop/run-watch-cycle.mjs";
 
+// The CI and Copilot waits are heartbeated inside their shared engines
+// (probe-ci-status / probe-copilot-review), so run-watch-cycle no longer wraps
+// them. The `gh run watch` workflow-run watch blocks as a single child with no
+// poll loop / no shared engine, so it is still wrapped here with the
+// interval-heartbeat lease holder. These cases guard that remaining wrap.
+
 function copilotWatchHandoff() {
   return {
     ok: true,
@@ -22,43 +28,55 @@ function copilotWatchHandoff() {
   };
 }
 
-test("runWatchCycle heartbeats the runner-coordination lease around a Copilot watch", async () => {
+const idleCopilotWatch = (options) => ({
+  ok: true,
+  status: "idle",
+  repo: options.repo,
+  pr: options.pr,
+  attempts: 1,
+  newComments: [],
+  newReviews: [],
+  newIssueComments: [],
+});
+
+// Deps that drive session-activity detection to an active run so the
+// workflow-run watch (the wrapped call) is exercised.
+function sessionActiveDeps(overrides = {}) {
+  return {
+    detectSessionActivity: true,
+    runHandoffImpl: async () => copilotWatchHandoff(),
+    fetchPrHeadBranchImpl: async () => "feature-branch",
+    detectCopilotSessionActivityImpl: async () => ({ activity: "active", runId: 4242 }),
+    watchCopilotReviewImpl: async (options) => idleCopilotWatch(options),
+    ...overrides,
+  };
+}
+
+test("runWatchCycle heartbeats the runner-coordination lease around the workflow-run watch", async () => {
   let ownershipCalls = 0;
 
   const result = await runWatchCycle(
     { repo: "owner/repo", pr: 17 },
-    {
-      runHandoffImpl: async () => copilotWatchHandoff(),
-      watchCopilotReviewImpl: async (options) =>
+    sessionActiveDeps({
+      watchWorkflowRunImpl: async () =>
         new Promise((resolve) => {
-          setTimeout(() => {
-            resolve({
-              ok: true,
-              status: "idle",
-              repo: options.repo,
-              pr: options.pr,
-              attempts: 1,
-              newComments: [],
-              newReviews: [],
-              newIssueComments: [],
-            });
-          }, 0);
+          setTimeout(() => resolve({ status: "completed" }), 0);
         }),
       ensureOwnershipImpl: async () => {
         ownershipCalls += 1;
         return { ok: true, status: "owner_confirmed" };
       },
-    },
+    }),
   );
 
-  // On-entry and on-return heartbeats both fired around the blocking watch.
+  // On-entry and on-return heartbeats both fired around the blocking workflow watch.
   assert.ok(ownershipCalls >= 2, `expected >= 2 heartbeats, got ${ownershipCalls}`);
   assert.equal(result.ok, true);
   assert.equal(result.watchStatus, "idle");
 });
 
 test(
-  "runWatchCycle fires the periodic mid-watch heartbeat while the Copilot watch is in-flight",
+  "runWatchCycle fires the periodic mid-watch heartbeat while the workflow-run watch is in-flight",
   { timeout: 5000 },
   async (t) => {
     // Deterministic clock: the mid-watch interval is the load-bearing mechanism
@@ -76,32 +94,33 @@ test(
     });
 
     // setImmediate is NOT mocked, so this yields a real macrotask boundary that
-    // drains all pending microtasks (handoff + heartbeat awaits) between ticks.
+    // drains all pending microtasks between ticks.
     const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
 
-    // Kick off the cycle WITHOUT awaiting: the watch stays in-flight so we can
-    // advance the clock while runWatchHoldingLease is blocked on watchFactory().
+    // Kick off the cycle WITHOUT awaiting: the workflow watch stays in-flight so
+    // we can advance the clock while runWatchHoldingLease is blocked on it.
     const cyclePromise = runWatchCycle(
       { repo: "owner/repo", pr: 17 },
-      {
+      sessionActiveDeps({
         env,
-        runHandoffImpl: async () => copilotWatchHandoff(),
-        watchCopilotReviewImpl: async () => watchPending,
+        watchWorkflowRunImpl: async () => watchPending,
         ensureOwnershipImpl: async () => {
           ownershipCalls += 1;
           return { ok: true, status: "owner_confirmed" };
         },
-      },
+      }),
     );
 
-    // Let the async chain register setInterval and run the on-entry heartbeat.
+    // Let the async chain (handoff + head branch + session detection) run and
+    // register setInterval + the on-entry heartbeat.
+    await flushMicrotasks();
     await flushMicrotasks();
     const afterEntry = ownershipCalls;
     assert.equal(afterEntry, 1, `expected exactly the on-entry heartbeat, got ${afterEntry}`);
 
-    // Advance well past several 10ms intervals. The watch is still pending, so
-    // the on-return heartbeat has NOT fired yet: every call beyond the on-entry
-    // one is interval-driven.
+    // Advance well past several 10ms intervals. The workflow watch is still
+    // pending, so the on-return heartbeat has NOT fired yet: every call beyond
+    // the on-entry one is interval-driven.
     t.mock.timers.tick(50);
     await flushMicrotasks();
     t.mock.timers.tick(50);
@@ -109,8 +128,7 @@ test(
 
     const duringWatch = ownershipCalls;
     const periodicCalls = duringWatch - afterEntry;
-    // Fails if the setInterval heartbeat is removed (entry+return heartbeats
-    // alone leave duringWatch === 1 while the watch is still pending).
+    // Fails if the setInterval heartbeat is removed.
     assert.ok(
       periodicCalls >= 1,
       `expected >= 1 periodic interval heartbeat, got ${periodicCalls}`,
@@ -120,17 +138,8 @@ test(
       `expected >= 3 heartbeats during the in-flight watch, got ${duringWatch}`,
     );
 
-    // Now let the watch complete and the cycle finish cleanly.
-    resolveWatch({
-      ok: true,
-      status: "idle",
-      repo: "owner/repo",
-      pr: 17,
-      attempts: 1,
-      newComments: [],
-      newReviews: [],
-      newIssueComments: [],
-    });
+    // Now let the workflow watch complete and the cycle finish cleanly.
+    resolveWatch({ status: "completed" });
     const result = await cyclePromise;
 
     assert.equal(result.ok, true);
@@ -138,30 +147,18 @@ test(
   },
 );
 
-test("runWatchCycle treats a heartbeat failure as non-fatal", async () => {
+test("runWatchCycle treats a workflow-watch heartbeat failure as non-fatal", async () => {
   const result = await runWatchCycle(
     { repo: "owner/repo", pr: 17 },
-    {
-      runHandoffImpl: async () => copilotWatchHandoff(),
-      watchCopilotReviewImpl: async (options) =>
+    sessionActiveDeps({
+      watchWorkflowRunImpl: async () =>
         new Promise((resolve) => {
-          setTimeout(() => {
-            resolve({
-              ok: true,
-              status: "idle",
-              repo: options.repo,
-              pr: options.pr,
-              attempts: 1,
-              newComments: [],
-              newReviews: [],
-              newIssueComments: [],
-            });
-          }, 0);
+          setTimeout(() => resolve({ status: "completed" }), 0);
         }),
       ensureOwnershipImpl: async () => {
         throw new Error("heartbeat boom");
       },
-    },
+    }),
   );
 
   assert.equal(result.ok, true);

--- a/test/loop/run-watch-cycle-lease-heartbeat.test.mjs
+++ b/test/loop/run-watch-cycle-lease-heartbeat.test.mjs
@@ -57,6 +57,87 @@ test("runWatchCycle heartbeats the runner-coordination lease around a Copilot wa
   assert.equal(result.watchStatus, "idle");
 });
 
+test(
+  "runWatchCycle fires the periodic mid-watch heartbeat while the Copilot watch is in-flight",
+  { timeout: 5000 },
+  async (t) => {
+    // Deterministic clock: the mid-watch interval is the load-bearing mechanism
+    // that keeps the claim fresh during a full-length (~30 min) watch. Mock
+    // timers let us advance past the interval without any real waiting.
+    t.mock.timers.enable({ apis: ["setInterval", "setTimeout"] });
+
+    // Shrink the stale window so the interval is floor(20/2) = 10ms.
+    const env = { ...process.env, DEVLOOPS_STALE_RUNNER_MAX_AGE_MS: "20" };
+
+    let ownershipCalls = 0;
+    let resolveWatch;
+    const watchPending = new Promise((resolve) => {
+      resolveWatch = resolve;
+    });
+
+    // setImmediate is NOT mocked, so this yields a real macrotask boundary that
+    // drains all pending microtasks (handoff + heartbeat awaits) between ticks.
+    const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
+
+    // Kick off the cycle WITHOUT awaiting: the watch stays in-flight so we can
+    // advance the clock while runWatchHoldingLease is blocked on watchFactory().
+    const cyclePromise = runWatchCycle(
+      { repo: "owner/repo", pr: 17 },
+      {
+        env,
+        runHandoffImpl: async () => copilotWatchHandoff(),
+        watchCopilotReviewImpl: async () => watchPending,
+        ensureOwnershipImpl: async () => {
+          ownershipCalls += 1;
+          return { ok: true, status: "owner_confirmed" };
+        },
+      },
+    );
+
+    // Let the async chain register setInterval and run the on-entry heartbeat.
+    await flushMicrotasks();
+    const afterEntry = ownershipCalls;
+    assert.equal(afterEntry, 1, `expected exactly the on-entry heartbeat, got ${afterEntry}`);
+
+    // Advance well past several 10ms intervals. The watch is still pending, so
+    // the on-return heartbeat has NOT fired yet: every call beyond the on-entry
+    // one is interval-driven.
+    t.mock.timers.tick(50);
+    await flushMicrotasks();
+    t.mock.timers.tick(50);
+    await flushMicrotasks();
+
+    const duringWatch = ownershipCalls;
+    const periodicCalls = duringWatch - afterEntry;
+    // Fails if the setInterval heartbeat is removed (entry+return heartbeats
+    // alone leave duringWatch === 1 while the watch is still pending).
+    assert.ok(
+      periodicCalls >= 1,
+      `expected >= 1 periodic interval heartbeat, got ${periodicCalls}`,
+    );
+    assert.ok(
+      duringWatch >= 3,
+      `expected >= 3 heartbeats during the in-flight watch, got ${duringWatch}`,
+    );
+
+    // Now let the watch complete and the cycle finish cleanly.
+    resolveWatch({
+      ok: true,
+      status: "idle",
+      repo: "owner/repo",
+      pr: 17,
+      attempts: 1,
+      newComments: [],
+      newReviews: [],
+      newIssueComments: [],
+    });
+    const result = await cyclePromise;
+
+    assert.equal(result.ok, true);
+    assert.equal(result.watchStatus, "idle");
+  },
+);
+
 test("runWatchCycle treats a heartbeat failure as non-fatal", async () => {
   const result = await runWatchCycle(
     { repo: "owner/repo", pr: 17 },

--- a/test/loop/run-watch-cycle-lease-heartbeat.test.mjs
+++ b/test/loop/run-watch-cycle-lease-heartbeat.test.mjs
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runWatchCycle } from "../../scripts/loop/run-watch-cycle.mjs";
+
+function copilotWatchHandoff() {
+  return {
+    ok: true,
+    action: "watch",
+    state: "waiting_for_copilot_review",
+    allowedTransitions: [],
+    nextAction: "Wait for Copilot review via scripts/github/probe-copilot-review.mjs",
+    snapshot: { repo: "owner/repo", pr: 17 },
+    loopDisposition: "pending",
+    terminal: false,
+    watchArgs: {
+      repo: "owner/repo",
+      pr: 17,
+      pollIntervalMs: 60_000,
+      timeoutMs: 1_800_000,
+    },
+  };
+}
+
+test("runWatchCycle heartbeats the runner-coordination lease around a Copilot watch", async () => {
+  let ownershipCalls = 0;
+
+  const result = await runWatchCycle(
+    { repo: "owner/repo", pr: 17 },
+    {
+      runHandoffImpl: async () => copilotWatchHandoff(),
+      watchCopilotReviewImpl: async (options) =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({
+              ok: true,
+              status: "idle",
+              repo: options.repo,
+              pr: options.pr,
+              attempts: 1,
+              newComments: [],
+              newReviews: [],
+              newIssueComments: [],
+            });
+          }, 0);
+        }),
+      ensureOwnershipImpl: async () => {
+        ownershipCalls += 1;
+        return { ok: true, status: "owner_confirmed" };
+      },
+    },
+  );
+
+  // On-entry and on-return heartbeats both fired around the blocking watch.
+  assert.ok(ownershipCalls >= 2, `expected >= 2 heartbeats, got ${ownershipCalls}`);
+  assert.equal(result.ok, true);
+  assert.equal(result.watchStatus, "idle");
+});
+
+test("runWatchCycle treats a heartbeat failure as non-fatal", async () => {
+  const result = await runWatchCycle(
+    { repo: "owner/repo", pr: 17 },
+    {
+      runHandoffImpl: async () => copilotWatchHandoff(),
+      watchCopilotReviewImpl: async (options) =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({
+              ok: true,
+              status: "idle",
+              repo: options.repo,
+              pr: options.pr,
+              attempts: 1,
+              newComments: [],
+              newReviews: [],
+              newIssueComments: [],
+            });
+          }, 0);
+        }),
+      ensureOwnershipImpl: async () => {
+        throw new Error("heartbeat boom");
+      },
+    },
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.watchStatus, "idle");
+});


### PR DESCRIPTION
## What

Runners stalled idle after a watch boundary (CI wait, Copilot-review wait, verify/session watch) and never resumed without an external nudge, because their runner-coordination claim went stale *across a single watch*.

## Root cause

The blocking wait engines never refreshed the runner-coordination lease (`activeRun.updatedAt`). The Copilot-review and CI watch budgets are `EXTERNAL_HEALTHY_WAIT_TIMEOUT_POLICY.defaultTimeoutMs` = **30 min**, which is exactly `STALE_RUNNER_DEFAULT_MAX_AGE_MS` = **30 min**. So one full-length watch ages the claim to the stale boundary; when the watch returns, the fail-closed evidence check sees `stale_runner` / `no_owner_record` and refuses the next step, leaving the runner idle.

`#1245` fixed `assert` refreshing the lease during *active* operations, but the idle-watch case emits no heartbeat — this is the missing watch→resume edge.

## Fix

Hold the lease at the true shared seam: the two blocking wait engines. `watchCiStatus` (scripts/github/probe-ci-status.mjs) and `watchCopilotReview` (scripts/github/probe-copilot-review.mjs) each now fire a best-effort runner-coordination heartbeat co-located with the `watch_heartbeat` they already emit inside the inter-poll delay loop. Because those engines are the single path every CI/Copilot wait routes through — `run-watch-cycle`, `wait-pr-checks`, and the `dev-loops loop watch-ci` CLI — every wait entry point now holds the lease, not just one caller.

`run-watch-cycle.mjs` keeps a small lease-holding wrapper (`runWatchHoldingLease`) for ONLY the `gh run watch` session-activity watch, which blocks as a single child with no poll engine of its own.

- Harness-agnostic: `ensureAsyncRunnerOwnership` no-ops when `DEVLOOPS_RUN_ID` is unset.
- Best-effort / non-fatal: a heartbeat failure never changes watch behavior.
- Fail-closed preserved: `claimIfMissing` self-heals only a *missing* record; `assertRunnerOwnership` refuses to write on `OWNERSHIP_LOST`, so a live competitor's claim is never stomped. Heartbeat writes serialize on the coordination file lock and are idempotent (same-runId `updatedAt` refresh), so overlapping heartbeats cannot corrupt the record. No watch timeout, disposition, contract-trace, or gate logic changed.

## File-by-file changes

- `scripts/github/probe-ci-status.mjs` — `watchCiStatus` refreshes the lease alongside each inter-poll `watch_heartbeat`; adds an injectable `ensureOwnershipImpl` seam.
- `scripts/github/probe-copilot-review.mjs` — same for `watchCopilotReview`; `delayImpl`/`now` made injectable for deterministic engine tests.
- `scripts/loop/run-watch-cycle.mjs` — CI/Copilot watches now rely on the engine heartbeat (wrappers removed); `runWatchHoldingLease` retained for the engineless `gh run watch` session watch only.
- `test/github/probe-ci-status-lease-heartbeat.test.mjs`, `test/github/probe-copilot-review-lease-heartbeat.test.mjs` — engine-level heartbeat regression coverage (fires during the inter-poll wait; non-fatal on failure).
- `test/loop/run-watch-cycle-lease-heartbeat.test.mjs` — covers the remaining workflow-watch wrapper (entry/interval/return + non-fatal).

## Non-goals

No change to watch timeouts, cycle disposition, contract-trace, or any fail-closed gate/merge-evidence check.

## Validation

```
node --test test/github/probe-ci-status-lease-heartbeat.test.mjs test/github/probe-copilot-review-lease-heartbeat.test.mjs test/loop/run-watch-cycle-lease-heartbeat.test.mjs test/loop/run-watch-cycle.test.mjs test/github/probe-ci-status.test.mjs test/github/probe-copilot-review.test.mjs test/github/wait-pr-checks.test.mjs
```

## Definition of done

- Lease is refreshed during every CI/Copilot wait at the shared engine seam, plus the session `gh run watch`, so all wait entry points hold the claim.
- Engine-level regression tests fail if the heartbeat is removed.
- Existing probe / run-watch-cycle / wait-pr-checks tests still pass; no gate-contract or fail-closed check weakened.

## Acceptance criteria

- [x] Root cause identified and documented (harness/loop-code: the shared CI/Copilot wait engines dropped the lease; stale window == watch budget).
- [x] Regression coverage for the watch→resume lease edge at the engine seam (CI + Copilot) and the session watch.
- [ ] Full headless zero-nudge run to human-approval — validated by the coordinator driving this PR's gates.

Closes #1257
