### PR TITLE
feat(loop): register ui_review route + command scaffold (Stage 0 of #1114)

### DIFF
--- a/.claude/commands/loop-review-ui.md
+++ b/.claude/commands/loop-review-ui.md
@@ -1,0 +1,7 @@
+---
+description: "Review a PR in a UI (running-app) dev loop."
+argument-hint: "<pr>"
+---
+<!-- GENERATED from commands/loop-review-ui.command.md by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate. -->
+
+Run the `dev-loop` skill with the public intent `review PR $ARGUMENTS in a UI loop`. Resolve authoritative state first, then route through the deterministic internal strategy. Do not pick an internal strategy name yourself.

--- a/.claude/skills/docs/public-dev-loop-contract.md
+++ b/.claude/skills/docs/public-dev-loop-contract.md
@@ -26,6 +26,7 @@ Day-one user-intent forms:
 - continue the current dev loop
 - auto dev loop (durable auto ownership over the detected routed loop)
 - auto dev loop on issue `<n>`
+- review PR `<n>` in a UI loop
 - what state is the dev loop in?
 
 ## Issue-based shorthand auto trigger contract
@@ -251,7 +252,7 @@ The public router currently maps to these deterministic internal strategies:
 | `reviewer_fixer` | reviewer/fixer passes on the current PR | none |
 | `wait_watch` | waiting/watch states | `dev-loop` |
 | `final_approval` | approval-ready gate, or merge-ready with explicit merge authorization | none (canonical procedure lives in [Copilot PR Follow-up](../copilot-pr-followup/SKILL.md) + [Copilot Loop Operations](./copilot-loop-operations.md) Human approval checkpoint; [Final Approval](../final-approval/SKILL.md) is a thin redirect) |
-| `ui_review` | explicit UI-review "prove it in the running app" pass on the current PR | `dev-loop` (sole entrypoint is the dedicated `loop-review-ui` command; see [UI Review](../ui-review/SKILL.md)) |
+| `ui_review` | explicit UI-review "prove it in the running app" pass on the current PR | `dev-loop` (surfaced entrypoint is the dedicated `loop-review-ui` command; the parameterized `--intent review_pr_ui` form also routes here; see [UI Review](../ui-review/SKILL.md)) |
 
 `waiting_for_merge_authorization` is part of the gate contract below as a stop gate rather than an internal strategy.
 
@@ -495,6 +496,7 @@ The following parameter/state combinations fail closed to `needs_reconcile` inst
 | "run dev loop on PR 88 and stay on it" | `dev-loop --intent continue_on_pr --target pr:88 --watch` |
 | "prefer the local path for issue 42" | `dev-loop --intent start_on_issue --target issue:42 --target-preference prefer_local` |
 | "just inspect current state" | `dev-loop --intent inspect_state` |
+| "review PR 88 in a UI loop" | `dev-loop --intent review_pr_ui --target pr:88` |
 
 These are parameterized uses of `dev-loop`, not new workflow-facing entrypoints.
 
@@ -516,3 +518,4 @@ These are parameterized uses of `dev-loop`, not new workflow-facing entrypoints.
 | start issue `86` locally, then continue the loop | local phase slice for issue `86` -> `local_implementation`, then resume via public `dev-loop` against the updated state |
 | continue the current dev loop while waiting | same target + `status=waiting` -> `wait_watch` |
 | what state is the dev loop in? | inspect the canonical state and report the routed internal strategy without switching public entrypoints |
+| review PR `88` in a UI loop | PR target + explicit UI-review request (`review_pr_ui` intent) -> `ui_review` internal strategy (routed behind `dev-loop`) |

--- a/.claude/skills/docs/public-dev-loop-contract.md
+++ b/.claude/skills/docs/public-dev-loop-contract.md
@@ -251,6 +251,7 @@ The public router currently maps to these deterministic internal strategies:
 | `reviewer_fixer` | reviewer/fixer passes on the current PR | none |
 | `wait_watch` | waiting/watch states | `dev-loop` |
 | `final_approval` | approval-ready gate, or merge-ready with explicit merge authorization | none (canonical procedure lives in [Copilot PR Follow-up](../copilot-pr-followup/SKILL.md) + [Copilot Loop Operations](./copilot-loop-operations.md) Human approval checkpoint; [Final Approval](../final-approval/SKILL.md) is a thin redirect) |
+| `ui_review` | explicit UI-review "prove it in the running app" pass on the current PR | none (internal-only via `dev-loop` routing; see [UI Review](../ui-review/SKILL.md)) |
 
 `waiting_for_merge_authorization` is part of the gate contract below as a stop gate rather than an internal strategy.
 
@@ -313,6 +314,7 @@ The shared machine-checkable gate contract is exported from `packages/core/src/l
 | `external_pr_followup` | `route` | `external_pr_followup` | external-human PR ownership routes to external PR follow-up |
 | `reviewer_fixer` | `route` | `reviewer_fixer` | reviewer-owned or reviewer-next PR state routes to reviewer/fixer |
 | `copilot_pr_followup` | `route` | `copilot_pr_followup` | Copilot-owned PR state routes to Copilot PR follow-up |
+| `ui_review` | `route` | `ui_review` | an explicit UI-review request on a PR target routes to the ui_review running-app review strategy |
 | `fail_closed_reconcile` | `needs_reconcile` | none | ambiguous, conflicting, or unsupported canonical state fails closed to reconcile |
 
 For issue targets, authoritative issue↔PR linkage resolution remains part of state resolution before claiming there is no open linked PR:
@@ -352,6 +354,7 @@ gate can be followed, on the next cycle, by any of the gates.
 - `external_pr_followup` -> any dev-loop gate
 - `reviewer_fixer` -> any dev-loop gate
 - `copilot_pr_followup` -> any dev-loop gate
+- `ui_review` -> any dev-loop gate
 
 Terminal gates (`stop_blocked_or_not_authorized`, `stop_done_terminal`,
 `waiting_for_merge_authorization`, `fail_closed_reconcile`) have no outgoing transitions —

--- a/.claude/skills/docs/public-dev-loop-contract.md
+++ b/.claude/skills/docs/public-dev-loop-contract.md
@@ -251,7 +251,7 @@ The public router currently maps to these deterministic internal strategies:
 | `reviewer_fixer` | reviewer/fixer passes on the current PR | none |
 | `wait_watch` | waiting/watch states | `dev-loop` |
 | `final_approval` | approval-ready gate, or merge-ready with explicit merge authorization | none (canonical procedure lives in [Copilot PR Follow-up](../copilot-pr-followup/SKILL.md) + [Copilot Loop Operations](./copilot-loop-operations.md) Human approval checkpoint; [Final Approval](../final-approval/SKILL.md) is a thin redirect) |
-| `ui_review` | explicit UI-review "prove it in the running app" pass on the current PR | none (internal-only via `dev-loop` routing; see [UI Review](../ui-review/SKILL.md)) |
+| `ui_review` | explicit UI-review "prove it in the running app" pass on the current PR | `dev-loop` (sole entrypoint is the dedicated `loop-review-ui` command; see [UI Review](../ui-review/SKILL.md)) |
 
 `waiting_for_merge_authorization` is part of the gate contract below as a stop gate rather than an internal strategy.
 
@@ -335,10 +335,11 @@ First-match-wins routing posture:
 6. local branch / local phase -> `local_implementation`
 7. issue target with `linkedPr` -> route as the linked PR with the same ownership/actor state
 8. issue target without `linkedPr` -> `issue_intake`
-9. PR owned by external human -> `external_pr_followup`
-10. PR owned by reviewer or next actor reviewer -> `reviewer_fixer`
-11. PR owned by Copilot -> `copilot_pr_followup`
-12. anything else -> fail closed to `needs_reconcile`
+9. explicit UI-review request (`review_pr_ui` intent) on a PR target -> `ui_review`
+10. PR owned by external human -> `external_pr_followup`
+11. PR owned by reviewer or next actor reviewer -> `reviewer_fixer`
+12. PR owned by Copilot -> `copilot_pr_followup`
+13. anything else -> fail closed to `needs_reconcile`
 
 ## Required transitions
 

--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: "ui-review"
+description: "Internal routed strategy behind `dev-loop` for the UI-review route — the \"prove it in the running app\" review sibling of reviewer/fixer. Scaffold slice only: registers the route, its stop rules, and its acceptance self-validation."
+allowed-tools: Read Bash
+user-invocable: false
+---
+<!-- GENERATED from skills/ui-review/SKILL.md by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate. -->
+
+
+# UI Review (scaffold)
+
+When the public router selects `ui_review`, this route reviews a PR by proving
+the change in the running app from an isolated worktree, rather than reading the
+diff alone. It is the running-app review sibling of the `reviewer_fixer` route.
+
+The route's handoff envelope carries its stop rules and acceptance
+self-validation (defined in `handoff-envelope.mjs`): no product-code writes,
+worktree-only, outward review stays pending/draft, and destructive migrations
+must be acknowledged before they run.
+
+## Non-goals
+
+No provision/boot/drive/diagnose/report/teardown logic lives in this scaffold
+slice. This file only names the route so the router, startup resolver, and
+handoff envelope have a first-class entrypoint to bind to.

--- a/commands/loop-review-ui.command.md
+++ b/commands/loop-review-ui.command.md
@@ -1,0 +1,5 @@
+---
+description: Review a PR in a UI (running-app) dev loop.
+argument-hint: <pr>
+---
+Run the `dev-loop` skill with the public intent `review PR $ARGUMENTS in a UI loop`. Resolve authoritative state first, then route through the deterministic internal strategy. Do not pick an internal strategy name yourself.

--- a/packages/core/src/loop/handoff-envelope.mjs
+++ b/packages/core/src/loop/handoff-envelope.mjs
@@ -143,9 +143,11 @@ register(INTERNAL_DEV_LOOP_STRATEGY.WAIT_WATCH, "default", {
 
 // ui_review — running-app review sibling of reviewer/fixer. Scaffold slice:
 // self-validation only, no drive/report/provision/boot logic. The criteria
-// mirror the stop rules so the dispatched agent self-checks the review
-// boundaries (no product-code writes, worktree isolation, outward review stays
-// pending/draft, destructive migrations acknowledged before running).
+// capture the route-specific review boundaries (no product-code writes,
+// worktree isolation, outward review stays pending/draft, destructive
+// migrations acknowledged before running) so the dispatched agent self-checks
+// them; the generic finalization stop rules (e.g. merge) are layered on
+// separately and are not restated here.
 register(INTERNAL_DEV_LOOP_STRATEGY.UI_REVIEW, "default", {
   criteria: [
     { id: "no-product-code-writes", must: "No product code is written; the UI-review route only observes and reports on the running app.", severity: "required" },

--- a/packages/core/src/loop/handoff-envelope.mjs
+++ b/packages/core/src/loop/handoff-envelope.mjs
@@ -44,6 +44,13 @@ const STRATEGY_DEFAULT_STOP_RULES = Object.freeze({
   [INTERNAL_DEV_LOOP_STRATEGY.WAIT_WATCH]: ["merge"],
   [INTERNAL_DEV_LOOP_STRATEGY.FINAL_APPROVAL]: ["merge"],
   [INTERNAL_DEV_LOOP_STRATEGY.LOCAL_IMPLEMENTATION]: [],
+  [INTERNAL_DEV_LOOP_STRATEGY.UI_REVIEW]: [
+    "no-product-code-writes",
+    "worktree-only",
+    "outward-review-pending",
+    "ack-destructive-migrations",
+    "merge",
+  ],
 });
 
 // ---------------------------------------------------------------------------
@@ -132,6 +139,24 @@ register(INTERNAL_DEV_LOOP_STRATEGY.WAIT_WATCH, "default", {
   maxFinalizationTurns: 4,
   needsAttentionAfterMs: WATCH_NEEDS_ATTENTION_MS,
   activeNoticeAfterMs: WATCH_ACTIVE_NOTICE_MS,
+});
+
+// ui_review — running-app review sibling of reviewer/fixer. Scaffold slice:
+// self-validation only, no drive/report/provision/boot logic. The criteria
+// mirror the stop rules so the dispatched agent self-checks the review
+// boundaries (no product-code writes, worktree isolation, outward review stays
+// pending/draft, destructive migrations acknowledged before running).
+register(INTERNAL_DEV_LOOP_STRATEGY.UI_REVIEW, "default", {
+  criteria: [
+    { id: "no-product-code-writes", must: "No product code is written; the UI-review route only observes and reports on the running app.", severity: "required" },
+    { id: "worktree-only", must: "All work stays inside the isolated worktree; nothing is written outside it.", severity: "required" },
+    { id: "outward-review-pending", must: "Any outward review stays pending/draft; no approval or merge is emitted from the UI-review route.", severity: "required" },
+    { id: "ack-destructive-migrations", must: "Destructive migrations are explicitly acknowledged before they are run.", severity: "required" },
+  ],
+  evidence: ["commands-run", "validation-output"],
+  maxFinalizationTurns: 4,
+  needsAttentionAfterMs: DEFAULT_NEEDS_ATTENTION_MS,
+  activeNoticeAfterMs: DEFAULT_ACTIVE_NOTICE_MS,
 });
 
 // Remaining strategies get a generic acceptance template

--- a/packages/core/src/loop/public-dev-loop-routing-contract.mjs
+++ b/packages/core/src/loop/public-dev-loop-routing-contract.mjs
@@ -23,6 +23,7 @@ export const DEV_LOOP_PUBLIC_INTENT = Object.freeze({
   CONTINUE_CURRENT: "continue_current",
   AUTO_CONTINUE_CURRENT: "auto_continue_current",
   INSPECT_STATE: "inspect_state",
+  REVIEW_PR_UI: "review_pr_ui",
 });
 
 export const DEV_LOOP_TARGET_KIND = Object.freeze({
@@ -76,6 +77,7 @@ export const DEV_LOOP_GATE = Object.freeze({
   EXTERNAL_PR_FOLLOWUP: "external_pr_followup",
   REVIEWER_FIXER: "reviewer_fixer",
   COPILOT_PR_FOLLOWUP: "copilot_pr_followup",
+  UI_REVIEW: "ui_review",
   FAIL_CLOSED_RECONCILE: "fail_closed_reconcile",
 });
 
@@ -87,6 +89,7 @@ export const INTERNAL_DEV_LOOP_STRATEGY = Object.freeze({
   REVIEWER_FIXER: "reviewer_fixer",
   WAIT_WATCH: "wait_watch",
   FINAL_APPROVAL: "final_approval",
+  UI_REVIEW: "ui_review",
   NONE: null,
 });
 
@@ -266,6 +269,12 @@ export const PUBLIC_DEV_LOOP_GATE_CONTRACT = Object.freeze([
     routeKind: DEV_LOOP_ROUTE_KIND.ROUTE,
     selectedStrategy: INTERNAL_DEV_LOOP_STRATEGY.COPILOT_PR_FOLLOWUP,
     summary: "Copilot-owned PR state routes to Copilot PR follow-up; an already-linked open PR stays the canonical artifact for that issue until reconciled",
+  }),
+  Object.freeze({
+    gate: DEV_LOOP_GATE.UI_REVIEW,
+    routeKind: DEV_LOOP_ROUTE_KIND.ROUTE,
+    selectedStrategy: INTERNAL_DEV_LOOP_STRATEGY.UI_REVIEW,
+    summary: "an explicit UI-review request on a PR target routes to the ui_review running-app review strategy",
   }),
   Object.freeze({
     gate: DEV_LOOP_GATE.FAIL_CLOSED_RECONCILE,

--- a/packages/core/src/loop/public-dev-loop-routing.mjs
+++ b/packages/core/src/loop/public-dev-loop-routing.mjs
@@ -461,7 +461,7 @@ function toRoutableCanonicalState(canonicalState) {
   };
 }
 
-function selectGateForState(canonicalState) {
+function selectGateForState(canonicalState, { uiReviewRequested = false } = {}) {
   if (canonicalState.status === DEV_LOOP_STATUS.BLOCKED || canonicalState.authorization === DEV_LOOP_AUTHORIZATION.NOT_AUTHORIZED) {
     return DEV_LOOP_GATE.STOP_BLOCKED_OR_NOT_AUTHORIZED;
   }
@@ -497,6 +497,15 @@ function selectGateForState(canonicalState) {
 
   if (canonicalState.target.kind === DEV_LOOP_TARGET_KIND.ISSUE) {
     return DEV_LOOP_GATE.ISSUE_INTAKE;
+  }
+
+  // An explicit UI-review request intercepts a PR target ahead of the
+  // ownership-derived PR gates: the running-app review is requested regardless
+  // of who owns the PR. It stays after the authoritative lifecycle stop/terminal/
+  // approval/waiting gates so it can never bypass them. Absent the signal this
+  // branch is inert, so existing routes stay byte-identical.
+  if (uiReviewRequested && canonicalState.target.kind === DEV_LOOP_TARGET_KIND.PR) {
+    return DEV_LOOP_GATE.UI_REVIEW;
   }
 
   if (canonicalState.target.kind === DEV_LOOP_TARGET_KIND.PR && canonicalState.ownership === DEV_LOOP_ACTOR.EXTERNAL_HUMAN) {
@@ -581,10 +590,11 @@ function routeForState(
     issueAssignmentState = null,
     gateReviewEvidence = null,
     targetPreference = null,
+    uiReviewRequested = false,
   } = {},
 ) {
   const routableCanonicalState = toRoutableCanonicalState(canonicalState);
-  const selectedGate = selectGateForState(routableCanonicalState);
+  const selectedGate = selectGateForState(routableCanonicalState, { uiReviewRequested });
   if (
     selectedGate === DEV_LOOP_GATE.FINAL_APPROVAL
     && routableCanonicalState.target.kind === DEV_LOOP_TARGET_KIND.PR
@@ -760,6 +770,18 @@ function routeForState(
       canonicalState: routableCanonicalState,
       nextAction: "Run the Copilot PR follow-up strategy for the current PR; treat it as the canonical artifact for the issue and do not open a second PR.",
       reason: "Copilot-owned PR states route to the Copilot PR follow-up strategy; an already-open linked PR must stay canonical until reconciled.",
+    });
+  }
+
+  if (selectedGate === DEV_LOOP_GATE.UI_REVIEW) {
+    return buildResult({
+      selectedGate,
+      routeKind: DEV_LOOP_ROUTE_KIND.ROUTE,
+      selectedStrategy: INTERNAL_DEV_LOOP_STRATEGY.UI_REVIEW,
+      executionMode,
+      canonicalState: routableCanonicalState,
+      nextAction: "Run the UI-review route for the current PR: prove the change in the running app from an isolated worktree. Do not write product code; keep any outward review pending/draft; acknowledge destructive migrations before running them.",
+      reason: "An explicit UI-review request on a PR target routes to the ui_review strategy — the running-app review sibling of the reviewer/fixer route.",
     });
   }
 
@@ -1171,6 +1193,7 @@ export function resolveAuthoritativeStartupResumeBundle(input = {}) {
     issueAssignmentState,
     gateReviewEvidence,
     targetPreference,
+    uiReviewRequested: intent === DEV_LOOP_PUBLIC_INTENT.REVIEW_PR_UI,
   });
   if (routed.routeKind === DEV_LOOP_ROUTE_KIND.NEEDS_RECONCILE) {
     return buildStartupResumeBundleReconcile({
@@ -1699,6 +1722,23 @@ export function evaluatePublicDevLoopRouting(input = {}) {
 
     return finalizeRoutingResult(applyWatchValidation(
       routeForState(explicitState, { ...routingOptions, executionMode: effectiveMode }),
+      watchRequested,
+    ));
+  }
+
+  if (intent === DEV_LOOP_PUBLIC_INTENT.REVIEW_PR_UI) {
+    if (!explicitTarget || explicitTarget.kind !== DEV_LOOP_TARGET_KIND.PR) {
+      return buildInputReconcile("`review_pr_ui` requires a PR target.", null, effectiveMode);
+    }
+    if (!explicitState || explicitState.target.kind !== DEV_LOOP_TARGET_KIND.PR) {
+      return buildInputReconcile("`review_pr_ui` requires a valid canonical PR state.", explicitState, effectiveMode);
+    }
+    if (explicitState.target.pr !== explicitTarget.pr) {
+      return buildInputReconcile("`review_pr_ui` target conflicts with the canonical current PR state.", explicitState, effectiveMode);
+    }
+
+    return finalizeRoutingResult(applyWatchValidation(
+      routeForState(explicitState, { ...routingOptions, executionMode: effectiveMode, uiReviewRequested: true }),
       watchRequested,
     ));
   }

--- a/packages/core/test/handoff-envelope.test.mjs
+++ b/packages/core/test/handoff-envelope.test.mjs
@@ -1358,6 +1358,26 @@ test("invariant: every strategy with default stop rules has an acceptance templa
   }
 });
 
+test("invariant: ui_review locks its review-boundary stopRules and acceptance criteria ids", () => {
+  const stopRules = STRATEGY_DEFAULT_STOP_RULES[INTERNAL_DEV_LOOP_STRATEGY.UI_REVIEW];
+  for (const boundary of [
+    "no-product-code-writes",
+    "worktree-only",
+    "outward-review-pending",
+    "ack-destructive-migrations",
+  ]) {
+    assert.ok(stopRules.includes(boundary), `ui_review stopRules must contain "${boundary}"`);
+  }
+
+  const template = ACCEPTANCE_TEMPLATES.get(
+    acceptanceKey(INTERNAL_DEV_LOOP_STRATEGY.UI_REVIEW, "default"),
+  );
+  assert.deepEqual(
+    template.criteria.map((c) => c.id),
+    ["no-product-code-writes", "worktree-only", "outward-review-pending", "ack-destructive-migrations"],
+  );
+});
+
 
 // ===========================================================================
 // Advisory retrospective findings (issue #1077, Reading B)

--- a/packages/core/test/public-dev-loop-routing-contract.test.mjs
+++ b/packages/core/test/public-dev-loop-routing-contract.test.mjs
@@ -94,6 +94,11 @@ test("public dev-loop routing exposes an explicit gate contract for the current 
         selectedStrategy: INTERNAL_DEV_LOOP_STRATEGY.COPILOT_PR_FOLLOWUP,
       },
       {
+        gate: DEV_LOOP_GATE.UI_REVIEW,
+        routeKind: DEV_LOOP_ROUTE_KIND.ROUTE,
+        selectedStrategy: INTERNAL_DEV_LOOP_STRATEGY.UI_REVIEW,
+      },
+      {
         gate: DEV_LOOP_GATE.FAIL_CLOSED_RECONCILE,
         routeKind: DEV_LOOP_ROUTE_KIND.NEEDS_RECONCILE,
         selectedStrategy: INTERNAL_DEV_LOOP_STRATEGY.NONE,

--- a/packages/core/test/public-dev-loop-routing-startup.test.mjs
+++ b/packages/core/test/public-dev-loop-routing-startup.test.mjs
@@ -113,6 +113,60 @@ test("the ui-review intent routes a PR target to the ui_review strategy", () => 
   assert.equal(bundle.activeArtifact.pr, 1234);
 });
 
+test("review_pr_ui without a PR target fails closed", () => {
+  const result = evaluatePublicDevLoopRouting({
+    intent: DEV_LOOP_PUBLIC_INTENT.REVIEW_PR_UI,
+    target: { kind: DEV_LOOP_TARGET_KIND.ISSUE, issue: 86 },
+    currentState: {
+      target: { kind: DEV_LOOP_TARGET_KIND.PR, pr: 88 },
+      ownership: DEV_LOOP_ACTOR.COPILOT,
+      nextActor: DEV_LOOP_ACTOR.USER,
+      status: DEV_LOOP_STATUS.ACTIVE,
+      authorization: DEV_LOOP_AUTHORIZATION.AUTHORIZED,
+    },
+  });
+
+  assert.equal(result.routeKind, DEV_LOOP_ROUTE_KIND.NEEDS_RECONCILE);
+  assert.equal(result.selectedStrategy, INTERNAL_DEV_LOOP_STRATEGY.NONE);
+  assert.match(result.reason, /requires a PR target/);
+});
+
+test("review_pr_ui with a non-PR canonical state fails closed", () => {
+  const result = evaluatePublicDevLoopRouting({
+    intent: DEV_LOOP_PUBLIC_INTENT.REVIEW_PR_UI,
+    target: { kind: DEV_LOOP_TARGET_KIND.PR, pr: 88 },
+    currentState: {
+      target: { kind: DEV_LOOP_TARGET_KIND.ISSUE, issue: 86 },
+      ownership: DEV_LOOP_ACTOR.COPILOT,
+      nextActor: DEV_LOOP_ACTOR.USER,
+      status: DEV_LOOP_STATUS.ACTIVE,
+      authorization: DEV_LOOP_AUTHORIZATION.AUTHORIZED,
+    },
+  });
+
+  assert.equal(result.routeKind, DEV_LOOP_ROUTE_KIND.NEEDS_RECONCILE);
+  assert.equal(result.selectedStrategy, INTERNAL_DEV_LOOP_STRATEGY.NONE);
+  assert.match(result.reason, /requires a valid canonical PR state/);
+});
+
+test("review_pr_ui with a conflicting canonical PR state fails closed", () => {
+  const result = evaluatePublicDevLoopRouting({
+    intent: DEV_LOOP_PUBLIC_INTENT.REVIEW_PR_UI,
+    target: { kind: DEV_LOOP_TARGET_KIND.PR, pr: 88 },
+    currentState: {
+      target: { kind: DEV_LOOP_TARGET_KIND.PR, pr: 99 },
+      ownership: DEV_LOOP_ACTOR.COPILOT,
+      nextActor: DEV_LOOP_ACTOR.USER,
+      status: DEV_LOOP_STATUS.ACTIVE,
+      authorization: DEV_LOOP_AUTHORIZATION.AUTHORIZED,
+    },
+  });
+
+  assert.equal(result.routeKind, DEV_LOOP_ROUTE_KIND.NEEDS_RECONCILE);
+  assert.equal(result.selectedStrategy, INTERNAL_DEV_LOOP_STRATEGY.NONE);
+  assert.match(result.reason, /target conflicts/);
+});
+
 test("absent the ui-review intent, a copilot PR target still routes to copilot follow-up", () => {
   const prState = {
     target: { kind: DEV_LOOP_TARGET_KIND.PR, pr: 1234 },

--- a/packages/core/test/public-dev-loop-routing-startup.test.mjs
+++ b/packages/core/test/public-dev-loop-routing-startup.test.mjs
@@ -82,6 +82,53 @@ test("authoritative startup/resume bundle resolves routed state with authoritati
   );
 });
 
+test("the ui-review intent routes a PR target to the ui_review strategy", () => {
+  const prState = {
+    target: { kind: DEV_LOOP_TARGET_KIND.PR, pr: 1234 },
+    ownership: DEV_LOOP_ACTOR.COPILOT,
+    nextActor: DEV_LOOP_ACTOR.USER,
+    status: DEV_LOOP_STATUS.ACTIVE,
+    authorization: DEV_LOOP_AUTHORIZATION.AUTHORIZED,
+  };
+
+  const routed = evaluatePublicDevLoopRouting({
+    intent: DEV_LOOP_PUBLIC_INTENT.REVIEW_PR_UI,
+    target: { kind: DEV_LOOP_TARGET_KIND.PR, pr: 1234 },
+    currentState: prState,
+  });
+  assert.equal(routed.selectedGate, DEV_LOOP_GATE.UI_REVIEW);
+  assert.equal(routed.routeKind, DEV_LOOP_ROUTE_KIND.ROUTE);
+  assert.equal(routed.selectedStrategy, INTERNAL_DEV_LOOP_STRATEGY.UI_REVIEW);
+
+  const bundle = resolveAuthoritativeStartupResumeBundle({
+    intent: DEV_LOOP_PUBLIC_INTENT.REVIEW_PR_UI,
+    currentState: prState,
+    artifactState: DEV_LOOP_ARTIFACT_STATE.OPEN,
+    loopState: "pr_ui_review_start",
+  });
+  assert.equal(bundle.bundleKind, DEV_LOOP_STARTUP_RESUME_BUNDLE_KIND.RESOLVED);
+  assert.equal(bundle.selectedGate, DEV_LOOP_GATE.UI_REVIEW);
+  assert.equal(bundle.selectedStrategy, INTERNAL_DEV_LOOP_STRATEGY.UI_REVIEW);
+  assert.equal(bundle.activeArtifact.kind, DEV_LOOP_TARGET_KIND.PR);
+  assert.equal(bundle.activeArtifact.pr, 1234);
+});
+
+test("absent the ui-review intent, a copilot PR target still routes to copilot follow-up", () => {
+  const prState = {
+    target: { kind: DEV_LOOP_TARGET_KIND.PR, pr: 1234 },
+    ownership: DEV_LOOP_ACTOR.COPILOT,
+    nextActor: DEV_LOOP_ACTOR.USER,
+    status: DEV_LOOP_STATUS.ACTIVE,
+    authorization: DEV_LOOP_AUTHORIZATION.AUTHORIZED,
+  };
+  const routed = evaluatePublicDevLoopRouting({
+    intent: DEV_LOOP_PUBLIC_INTENT.CONTINUE_CURRENT,
+    currentState: prState,
+    targetPreference: DEV_LOOP_TARGET_PREFERENCE.PREFER_GITHUB_FIRST,
+  });
+  assert.equal(routed.selectedStrategy, INTERNAL_DEV_LOOP_STRATEGY.COPILOT_PR_FOLLOWUP);
+});
+
 test("authoritative startup/resume bundle fails closed when issue linkage is missing", () => {
   const bundle = resolveAuthoritativeStartupResumeBundle({
     currentState: {

--- a/scripts/docs/validate-state-machine-conformance.mjs
+++ b/scripts/docs/validate-state-machine-conformance.mjs
@@ -1087,6 +1087,7 @@ const PUBLIC_DEV_LOOP_GATE_TO_FIXTURE = new Map([
   [DEV_LOOP_GATE.EXTERNAL_PR_FOLLOWUP, () => evaluatePublicDevLoopRouting({ intent: DEV_LOOP_PUBLIC_INTENT.CONTINUE_CURRENT, currentState: publicDevLoopPrState({ target: { kind: DEV_LOOP_TARGET_KIND.PR, pr: 91 }, ownership: DEV_LOOP_ACTOR.EXTERNAL_HUMAN, nextActor: DEV_LOOP_ACTOR.REVIEWER }), targetPreference: PUBLIC_DEV_LOOP_GITHUB_FIRST })],
   [DEV_LOOP_GATE.REVIEWER_FIXER, () => evaluatePublicDevLoopRouting({ intent: DEV_LOOP_PUBLIC_INTENT.CONTINUE_CURRENT, currentState: publicDevLoopPrState({ ownership: DEV_LOOP_ACTOR.REVIEWER, nextActor: DEV_LOOP_ACTOR.REVIEWER }), targetPreference: PUBLIC_DEV_LOOP_GITHUB_FIRST })],
   [DEV_LOOP_GATE.COPILOT_PR_FOLLOWUP, () => evaluatePublicDevLoopRouting({ intent: DEV_LOOP_PUBLIC_INTENT.CONTINUE_CURRENT, currentState: publicDevLoopPrState({}), targetPreference: PUBLIC_DEV_LOOP_GITHUB_FIRST })],
+  [DEV_LOOP_GATE.UI_REVIEW, () => evaluatePublicDevLoopRouting({ intent: DEV_LOOP_PUBLIC_INTENT.REVIEW_PR_UI, target: { kind: DEV_LOOP_TARGET_KIND.PR, pr: 88 }, currentState: publicDevLoopPrState({}), targetPreference: PUBLIC_DEV_LOOP_GITHUB_FIRST })],
   [DEV_LOOP_GATE.FAIL_CLOSED_RECONCILE, () => evaluatePublicDevLoopRouting({ intent: DEV_LOOP_PUBLIC_INTENT.CONTINUE_ON_PR, target: { kind: DEV_LOOP_TARGET_KIND.PR, pr: 88 } })],
 ]);
 

--- a/scripts/loop/resolve-dev-loop-startup.mjs
+++ b/scripts/loop/resolve-dev-loop-startup.mjs
@@ -128,6 +128,10 @@ const STRATEGY_REQUIRED_READS = {
     "skills/docs/copilot-loop-operations.md",
     "skills/final-approval/SKILL.md",
   ],
+  ui_review: [
+    SHARED_PUBLIC_CONTRACT,
+    "skills/ui-review/SKILL.md",
+  ],
   none: [SHARED_PUBLIC_CONTRACT],
 };
 const STRATEGY_ASYNC_DISPATCH = {
@@ -138,6 +142,7 @@ const STRATEGY_ASYNC_DISPATCH = {
   reviewer_fixer: true,
   wait_watch: true,
   final_approval: false,
+  ui_review: false,
   none: false,
 };
 const parseError = buildParseError(USAGE);

--- a/skills/docs/public-dev-loop-contract.md
+++ b/skills/docs/public-dev-loop-contract.md
@@ -26,6 +26,7 @@ Day-one user-intent forms:
 - continue the current dev loop
 - auto dev loop (durable auto ownership over the detected routed loop)
 - auto dev loop on issue `<n>`
+- review PR `<n>` in a UI loop
 - what state is the dev loop in?
 
 ## Issue-based shorthand auto trigger contract
@@ -251,7 +252,7 @@ The public router currently maps to these deterministic internal strategies:
 | `reviewer_fixer` | reviewer/fixer passes on the current PR | none |
 | `wait_watch` | waiting/watch states | `dev-loop` |
 | `final_approval` | approval-ready gate, or merge-ready with explicit merge authorization | none (canonical procedure lives in [Copilot PR Follow-up](../copilot-pr-followup/SKILL.md) + [Copilot Loop Operations](./copilot-loop-operations.md) Human approval checkpoint; [Final Approval](../final-approval/SKILL.md) is a thin redirect) |
-| `ui_review` | explicit UI-review "prove it in the running app" pass on the current PR | `dev-loop` (sole entrypoint is the dedicated `loop-review-ui` command; see [UI Review](../ui-review/SKILL.md)) |
+| `ui_review` | explicit UI-review "prove it in the running app" pass on the current PR | `dev-loop` (surfaced entrypoint is the dedicated `loop-review-ui` command; the parameterized `--intent review_pr_ui` form also routes here; see [UI Review](../ui-review/SKILL.md)) |
 
 `waiting_for_merge_authorization` is part of the gate contract below as a stop gate rather than an internal strategy.
 
@@ -495,6 +496,7 @@ The following parameter/state combinations fail closed to `needs_reconcile` inst
 | "run dev loop on PR 88 and stay on it" | `dev-loop --intent continue_on_pr --target pr:88 --watch` |
 | "prefer the local path for issue 42" | `dev-loop --intent start_on_issue --target issue:42 --target-preference prefer_local` |
 | "just inspect current state" | `dev-loop --intent inspect_state` |
+| "review PR 88 in a UI loop" | `dev-loop --intent review_pr_ui --target pr:88` |
 
 These are parameterized uses of `dev-loop`, not new workflow-facing entrypoints.
 
@@ -516,3 +518,4 @@ These are parameterized uses of `dev-loop`, not new workflow-facing entrypoints.
 | start issue `86` locally, then continue the loop | local phase slice for issue `86` -> `local_implementation`, then resume via public `dev-loop` against the updated state |
 | continue the current dev loop while waiting | same target + `status=waiting` -> `wait_watch` |
 | what state is the dev loop in? | inspect the canonical state and report the routed internal strategy without switching public entrypoints |
+| review PR `88` in a UI loop | PR target + explicit UI-review request (`review_pr_ui` intent) -> `ui_review` internal strategy (routed behind `dev-loop`) |

--- a/skills/docs/public-dev-loop-contract.md
+++ b/skills/docs/public-dev-loop-contract.md
@@ -251,6 +251,7 @@ The public router currently maps to these deterministic internal strategies:
 | `reviewer_fixer` | reviewer/fixer passes on the current PR | none |
 | `wait_watch` | waiting/watch states | `dev-loop` |
 | `final_approval` | approval-ready gate, or merge-ready with explicit merge authorization | none (canonical procedure lives in [Copilot PR Follow-up](../copilot-pr-followup/SKILL.md) + [Copilot Loop Operations](./copilot-loop-operations.md) Human approval checkpoint; [Final Approval](../final-approval/SKILL.md) is a thin redirect) |
+| `ui_review` | explicit UI-review "prove it in the running app" pass on the current PR | none (internal-only via `dev-loop` routing; see [UI Review](../ui-review/SKILL.md)) |
 
 `waiting_for_merge_authorization` is part of the gate contract below as a stop gate rather than an internal strategy.
 
@@ -313,6 +314,7 @@ The shared machine-checkable gate contract is exported from `packages/core/src/l
 | `external_pr_followup` | `route` | `external_pr_followup` | external-human PR ownership routes to external PR follow-up |
 | `reviewer_fixer` | `route` | `reviewer_fixer` | reviewer-owned or reviewer-next PR state routes to reviewer/fixer |
 | `copilot_pr_followup` | `route` | `copilot_pr_followup` | Copilot-owned PR state routes to Copilot PR follow-up |
+| `ui_review` | `route` | `ui_review` | an explicit UI-review request on a PR target routes to the ui_review running-app review strategy |
 | `fail_closed_reconcile` | `needs_reconcile` | none | ambiguous, conflicting, or unsupported canonical state fails closed to reconcile |
 
 For issue targets, authoritative issue↔PR linkage resolution remains part of state resolution before claiming there is no open linked PR:
@@ -352,6 +354,7 @@ gate can be followed, on the next cycle, by any of the gates.
 - `external_pr_followup` -> any dev-loop gate
 - `reviewer_fixer` -> any dev-loop gate
 - `copilot_pr_followup` -> any dev-loop gate
+- `ui_review` -> any dev-loop gate
 
 Terminal gates (`stop_blocked_or_not_authorized`, `stop_done_terminal`,
 `waiting_for_merge_authorization`, `fail_closed_reconcile`) have no outgoing transitions —

--- a/skills/docs/public-dev-loop-contract.md
+++ b/skills/docs/public-dev-loop-contract.md
@@ -251,7 +251,7 @@ The public router currently maps to these deterministic internal strategies:
 | `reviewer_fixer` | reviewer/fixer passes on the current PR | none |
 | `wait_watch` | waiting/watch states | `dev-loop` |
 | `final_approval` | approval-ready gate, or merge-ready with explicit merge authorization | none (canonical procedure lives in [Copilot PR Follow-up](../copilot-pr-followup/SKILL.md) + [Copilot Loop Operations](./copilot-loop-operations.md) Human approval checkpoint; [Final Approval](../final-approval/SKILL.md) is a thin redirect) |
-| `ui_review` | explicit UI-review "prove it in the running app" pass on the current PR | none (internal-only via `dev-loop` routing; see [UI Review](../ui-review/SKILL.md)) |
+| `ui_review` | explicit UI-review "prove it in the running app" pass on the current PR | `dev-loop` (sole entrypoint is the dedicated `loop-review-ui` command; see [UI Review](../ui-review/SKILL.md)) |
 
 `waiting_for_merge_authorization` is part of the gate contract below as a stop gate rather than an internal strategy.
 
@@ -335,10 +335,11 @@ First-match-wins routing posture:
 6. local branch / local phase -> `local_implementation`
 7. issue target with `linkedPr` -> route as the linked PR with the same ownership/actor state
 8. issue target without `linkedPr` -> `issue_intake`
-9. PR owned by external human -> `external_pr_followup`
-10. PR owned by reviewer or next actor reviewer -> `reviewer_fixer`
-11. PR owned by Copilot -> `copilot_pr_followup`
-12. anything else -> fail closed to `needs_reconcile`
+9. explicit UI-review request (`review_pr_ui` intent) on a PR target -> `ui_review`
+10. PR owned by external human -> `external_pr_followup`
+11. PR owned by reviewer or next actor reviewer -> `reviewer_fixer`
+12. PR owned by Copilot -> `copilot_pr_followup`
+13. anything else -> fail closed to `needs_reconcile`
 
 ## Required transitions
 

--- a/skills/ui-review/SKILL.md
+++ b/skills/ui-review/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: ui-review
+description: >-
+  Internal routed strategy behind `dev-loop` for the UI-review route — the
+  "prove it in the running app" review sibling of reviewer/fixer. Scaffold slice
+  only: registers the route, its stop rules, and its acceptance self-validation.
+compatibility: Pi skill for git+GitHub repositories. Requires gh auth.
+allowed-tools: read bash
+user-invocable: false
+---
+
+# UI Review (scaffold)
+
+When the public router selects `ui_review`, this route reviews a PR by proving
+the change in the running app from an isolated worktree, rather than reading the
+diff alone. It is the running-app review sibling of the `reviewer_fixer` route.
+
+The route's handoff envelope carries its stop rules and acceptance
+self-validation (defined in `handoff-envelope.mjs`): no product-code writes,
+worktree-only, outward review stays pending/draft, and destructive migrations
+must be acknowledged before they run.
+
+## Non-goals
+
+No provision/boot/drive/diagnose/report/teardown logic lives in this scaffold
+slice. This file only names the route so the router, startup resolver, and
+handoff envelope have a first-class entrypoint to bind to.

--- a/test/contracts/claude-plugin-manifest.test.mjs
+++ b/test/contracts/claude-plugin-manifest.test.mjs
@@ -47,7 +47,7 @@ test("the plugin exposes exactly the expected agents + skills (locks the surface
     if (existsSync(path.join(repoRoot, ".claude", "skills", d.name, "SKILL.md"))) skills.push(d.name);
   }
   skills.sort();
-  assert.deepEqual(skills, ["copilot-pr-followup", "dev-loop", "final-approval", "local-implementation", "loop-grill"]);
+  assert.deepEqual(skills, ["copilot-pr-followup", "dev-loop", "final-approval", "local-implementation", "loop-grill", "ui-review"]);
 });
 
 test("the publish files allowlist ships the plugin (not the project settings.json) and preserves Pi packaging", async () => {

--- a/test/loop/resolve-dev-loop-startup.test.mjs
+++ b/test/loop/resolve-dev-loop-startup.test.mjs
@@ -184,6 +184,30 @@ test("buildResolveDevLoopStartupResult maps local implementation to the local ro
   assert.equal(result.canonicalStateSummary.routeKind, "route");
 });
 
+test("buildResolveDevLoopStartupResult maps the ui-review intent to the ui-review route pack without throwing on the new key", () => {
+  const result = buildResolveDevLoopStartupResult({
+    intent: "review_pr_ui",
+    currentState: {
+      target: { kind: "pr", pr: 1234 },
+      ownership: "copilot",
+      nextActor: "user",
+      status: "active",
+      authorization: "authorized",
+    },
+    artifactState: "open",
+    loopState: "pr_ui_review_start",
+  }, { env: { DEVLOOPS_WORKTREE_BYPASS: "1" }, cwd: os.tmpdir() });
+
+  assert.equal(result.bundleKind, "resolved");
+  assert.equal(result.selectedStrategy, "ui_review");
+  assert.deepEqual(result.requiredReads, [
+    "skills/docs/public-dev-loop-contract.md",
+    "skills/ui-review/SKILL.md",
+  ]);
+  assert.equal(result.canonicalStateSummary.target.kind, "pr");
+  assert.equal(result.canonicalStateSummary.requiresAsyncDispatch, false);
+});
+
 test("buildResolveDevLoopStartupResult maps linked Copilot follow-up to the PR follow-up route pack", () => {
   const result = buildResolveDevLoopStartupResult({
     currentState: {


### PR DESCRIPTION
## Summary

Stage 0 of epic #1114 (`/loop-review-ui`). Registers `ui_review` as a first-class internal dev-loop route — gate + strategy + public intent — and adds the public command scaffold, so later stages have a real entrypoint, envelope, stop-rules, and gate discipline to plug into. **Scaffold only: no drive/report/provision/boot/diagnose/teardown behavior.**

## Scope and context

Foundation slice for the epic. In scope: enum/gate/strategy registration, minimal router threading of a UI-review intent signal, startup-resolver map mirroring, the handoff envelope's ui_review stop-rules/acceptance, the public command wrapper, the route-pack scaffold, generated-asset regeneration, and route-selection tests. Out of scope: everything the stage stages (1–6) own — provisioning, boot, auth/Playwright drive, diagnose/anchor, report/inline-review, teardown. The router change is non-perturbing: existing routes are byte-identical when the UI-review signal is absent.

## File-by-file changes

- `packages/core/src/loop/public-dev-loop-routing-contract.mjs` — `DEV_LOOP_PUBLIC_INTENT.REVIEW_PR_UI`, `DEV_LOOP_GATE.UI_REVIEW`, `INTERNAL_DEV_LOOP_STRATEGY.UI_REVIEW`, and the `UI_REVIEW` entry in `PUBLIC_DEV_LOOP_GATE_CONTRACT`.
- `packages/core/src/loop/public-dev-loop-routing.mjs` — dedicated `uiReviewRequested` signal threaded through `selectGateForState`/`routeForState`; gate-selection condition (ahead of ownership-derived PR gates, after lifecycle stop/terminal/approval/waiting gates); gate→strategy block emitting `selectedStrategy: ui_review`; `REVIEW_PR_UI` intent branch.
- `packages/core/src/loop/handoff-envelope.mjs` — `ui_review` stop rules + `ui_review::default` acceptance template (no product writes, worktree-only, outward review pending/draft, ack destructive migrations).
- `scripts/loop/resolve-dev-loop-startup.mjs` — `ui_review` key in `STRATEGY_REQUIRED_READS` and `STRATEGY_ASYNC_DISPATCH` (async `false`).
- `scripts/docs/validate-state-machine-conformance.mjs` — `UI_REVIEW` gate conformance fixture.
- `skills/docs/public-dev-loop-contract.md` — gate-table row, required-transition bullet, strategy-families row.
- `commands/loop-review-ui.command.md` (new) — thin public command wrapper (same shape as `loop-start`), declares intent `review PR <n> in a UI loop`.
- `skills/ui-review/SKILL.md` (new) — thin route pack, `user-invocable: false`, explicit scaffold Non-goals.
- `.claude/commands/loop-review-ui.md`, `.claude/skills/ui-review/SKILL.md`, `.claude/skills/docs/public-dev-loop-contract.md` — regenerated generated assets (never hand-edited).
- `packages/core/test/public-dev-loop-routing-startup.test.mjs`, `packages/core/test/public-dev-loop-routing-contract.test.mjs`, `test/loop/resolve-dev-loop-startup.test.mjs`, `test/contracts/claude-plugin-manifest.test.mjs` — route-selection + non-perturbation + startup + manifest tests.
- `packages/core/test/handoff-envelope.test.mjs` — adds the ui_review envelope-contract invariant test.

## Acceptance criteria

Mirrors the 8 AC items in #1116:
- `UI_REVIEW` in the gate enum + `INTERNAL_DEV_LOOP_STRATEGY`.
- Router gate-selection condition + gate→strategy block emit `selectedStrategy: ui_review`.
- Startup resolver mirrors `ui_review` in both maps; no unknown-key throw.
- `commands/loop-review-ui.command.md` wrapper declares the public intent.
- `skills/ui-review/SKILL.md` route pack referenced by the strategy's required-reads.
- Handoff envelope defines `stopRules` + `acceptance` for the route.
- `.claude/**` regenerated and committed.
- Route-selection test asserts the UI-review intent resolves to `ui_review` and startup does not throw on the new key.

## Definition of done

Running the startup resolver for the UI-review intent returns `selectedStrategy: ui_review` with a valid envelope (requiredReads, nextAction, stopRules, acceptance); the command wrapper exists; generated assets are in sync; the new route test passes; no product/drive logic added. Verified end-to-end: `resolve-dev-loop-startup --input` (ui_review) → `build-handoff-envelope` emits a valid ui_review envelope.

## Non-goals

No provisioning, boot, drive, diagnose, report, or teardown logic. No `.claude/**` hand-edits. No downstream/private-repo identifiers. No change to existing route behavior when the UI-review signal is absent.

## Validation

- `node --test` core routing contract/startup/handoff-envelope suites (162 pass) + startup-resolver/CLI-contract suites.
- `node scripts/docs/validate-state-machine-conformance.mjs` (6 machines pass) + conformance test.
- `npm run test:docs` (links + rule-ownership), `npm run test:assets` (generated-assets-in-sync + manifest + contracts, 190 pass).
- Full gate uses `npm run verify`.

Closes #1116

