### PR TITLE
feat(loop): provision+boot module for ui_review route (Stage 1 of #1114)

### DIFF
--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -28,14 +28,22 @@ reuses the worktree machinery (`ensure-worktree`, `provision-worktree`), refuses
 to operate in the primary checkout, installs only the dependency-lock delta,
 runs pending dev-DB migrations, then boots the app and polls an HTTP readiness
 probe. It fails closed to a stated stop reason on: a primary-checkout target, a
-missing run recipe, a destructive migration lacking `--ack-destructive-migration`,
-or a readiness probe that times out. Every bounded cap is logged.
+missing run recipe, a run-recipe `cwd` that resolves outside the provisioned
+worktree (worktree traversal), a destructive migration lacking
+`--ack-destructive-migration`, or a readiness probe that times out. Every
+bounded cap is logged.
 
 The run recipe is per-project and never hard-coded: a project declares
 `uiReview.run` in `.devloops` — a boot `command`, an HTTP `readyUrl`, probe
 `readyTimeoutMs`/`readyIntervalMs`, an optional worktree-relative `cwd`, and an
 optional `migrate` sub-recipe (`statusCommand`/`applyCommand`, plus a
-`destructivePattern` guard).
+`destructivePattern` guard). The destructive guard matches `destructivePattern`
+against the migration STATUS OUTPUT, not the migration files: the shipped
+default only detects SQL-bearing status output (DROP/TRUNCATE/DELETE FROM). A
+project whose status output lists migration identifiers/filenames instead gets
+no protection from the default and MUST set a `destructivePattern` matching its
+own status format (or emit the destructive SQL/marker from `statusCommand`) —
+otherwise the guard is silently inert.
 
 Threat boundary: the run recipe is branch-controlled, and its `command` is
 executed as a shell command in the worktree. Every later stage inherits this

--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -18,8 +18,26 @@ self-validation (defined in `handoff-envelope.mjs`): no product-code writes,
 worktree-only, outward review stays pending/draft, and destructive migrations
 must be acknowledged before they run.
 
+## Provision + boot
+
+The route's first operational step provisions an isolated worktree for the PR
+head and boots the branch's app to a ready state, via
+`scripts/loop/ui-review-provision.mjs --repo-root <p> --pr <n>`
+(pure orchestration in `packages/core/src/loop/ui-review-provision.mjs`). It
+reuses the worktree machinery (`ensure-worktree`, `provision-worktree`), refuses
+to operate in the primary checkout, installs only the dependency-lock delta,
+runs pending dev-DB migrations, then boots the app and polls an HTTP readiness
+probe. It fails closed to a stated stop reason on: a primary-checkout target, a
+missing run recipe, a destructive migration lacking `--ack-destructive-migration`,
+or a readiness probe that times out. Every bounded cap is logged.
+
+The run recipe is per-project and never hard-coded: a project declares
+`uiReview.run` in `.devloops` — a boot `command`, an HTTP `readyUrl`, probe
+`readyTimeoutMs`/`readyIntervalMs`, and an optional `migrate` sub-recipe
+(`statusCommand`/`applyCommand`, plus a `destructivePattern` guard).
+
 ## Non-goals
 
-No provision/boot/drive/diagnose/report/teardown logic lives in this scaffold
-slice. This file only names the route so the router, startup resolver, and
-handoff envelope have a first-class entrypoint to bind to.
+No drive/diagnose/report/teardown logic lives here yet, and provision+boot does
+not drive the browser, authenticate, capture screenshots, post the review, or
+touch a production DB — those are later stages.

--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -33,8 +33,13 @@ or a readiness probe that times out. Every bounded cap is logged.
 
 The run recipe is per-project and never hard-coded: a project declares
 `uiReview.run` in `.devloops` — a boot `command`, an HTTP `readyUrl`, probe
-`readyTimeoutMs`/`readyIntervalMs`, and an optional `migrate` sub-recipe
-(`statusCommand`/`applyCommand`, plus a `destructivePattern` guard).
+`readyTimeoutMs`/`readyIntervalMs`, an optional worktree-relative `cwd`, and an
+optional `migrate` sub-recipe (`statusCommand`/`applyCommand`, plus a
+`destructivePattern` guard).
+
+Threat boundary: the run recipe is branch-controlled, and its `command` is
+executed as a shell command in the worktree. Every later stage inherits this
+assumption — a run recipe is trusted-branch input, not untrusted data.
 
 ## Non-goals
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,6 +57,7 @@
     "./loop/timeout-policy": "./src/loop/timeout-policy.mjs",
     "./loop/tracker-pr-state": "./src/loop/tracker-pr-state.mjs",
     "./loop/ui-e2e-scoping": "./src/loop/ui-e2e-scoping.mjs",
+    "./loop/ui-review-provision": "./src/loop/ui-review-provision.mjs",
     "./projects/list-queue-items": "./src/projects/list-queue-items.mjs",
     "./projects/move-queue-item": "./src/projects/move-queue-item.mjs",
     "./projects/resolve-project": "./src/projects/resolve-project.mjs",

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -178,6 +178,42 @@ const WorktreeConfig = z.strictObject({
   linkOnInit: z.array(z.string().trim().min(1)).optional(),
 });
 
+/**
+ * Dev-DB migration sub-recipe for the ui-review run recipe. `statusCommand`
+ * lists pending migrations (one per line); `applyCommand` applies them.
+ * `destructivePattern` is an optional regex (default in resolveUiReviewRunRecipe)
+ * matched against the status output to fail closed on destructive migrations.
+ */
+const UiReviewMigrateConfig = z.strictObject({
+  statusCommand: z.string().trim().min(1),
+  applyCommand: z.string().trim().min(1),
+  destructivePattern: z.string().trim().min(1).optional(),
+});
+
+/**
+ * Per-project boot recipe: a shell `command` that starts the branch's app and a
+ * `readyUrl` an HTTP readiness probe polls until the app is up (never a fixed
+ * sleep). No app is hard-coded — a project declares its own recipe. `cwd` is an
+ * optional worktree-relative subdir to run in.
+ */
+const UiReviewRunConfig = z.strictObject({
+  command: z.string().trim().min(1),
+  readyUrl: z.string().trim().min(1),
+  readyTimeoutMs: z.number().int().min(1).max(600000).default(60000),
+  readyIntervalMs: z.number().int().min(1).max(60000).default(1000),
+  cwd: z.string().trim().min(1).optional(),
+  migrate: UiReviewMigrateConfig.optional(),
+});
+
+/**
+ * UI-review route config: the generic, per-project provision+boot recipe. Absent
+ * (the default) means no bootable recipe is declared — the provision+boot stage
+ * stops with that as a stated reason rather than guessing how to run the app.
+ */
+const UiReviewConfig = z.strictObject({
+  run: UiReviewRunConfig.optional(),
+});
+
 /** Internal path whitelist for internal-only PR detection — flat array of regex strings */
 const InternalPatternsConfig = z.array(z.string().trim().min(1)).min(1);
 
@@ -232,6 +268,7 @@ export const DevLoopConfigSchema = z.strictObject({
   personas: PersonasConfig.optional(),
   internalPathPatterns: InternalPatternsConfig.optional(),
   worktree: WorktreeConfig.optional(),
+  uiReview: UiReviewConfig.optional(),
   // Deprecated (removed in #1088): tolerated so consumer .devloops files that
   // still carry a localPlanning block keep parsing. Accepted, never read.
   localPlanning: z.unknown().optional(),
@@ -304,6 +341,7 @@ export const FileConfigSchema = z.strictObject({
   personas: FilePersonasConfig.optional(),
   internalPathPatterns: InternalPatternsConfig.optional(),
   worktree: WorktreeConfig.partial().optional(),
+  uiReview: UiReviewConfig.partial().optional(),
   // Deprecated (removed in #1088): tolerated so consumer .devloops files that
   // still carry a localPlanning block keep parsing. Accepted, never read.
   localPlanning: z.unknown().optional(),
@@ -1383,6 +1421,48 @@ export function resolveWorktreeConfig(config) {
       ? v.map((s) => (typeof s === "string" ? s.trim() : "")).filter((s) => s.length > 0)
       : [];
   return { copyOnInit: list(wt?.copyOnInit), linkOnInit: list(wt?.linkOnInit) };
+}
+
+/**
+ * Default destructive-migration signal: SQL statements that drop or wipe data.
+ * Matched (case-insensitive) against the migration status output. A project may
+ * override via `uiReview.run.migrate.destructivePattern`.
+ */
+export const DEFAULT_DESTRUCTIVE_MIGRATION_PATTERN =
+  "\\b(DROP\\s+(TABLE|COLUMN|DATABASE|SCHEMA)|TRUNCATE|DELETE\\s+FROM|ALTER\\s+TABLE\\s+.*\\bDROP\\b)";
+
+/**
+ * Resolve the ui-review provision+boot run recipe from the merged config.
+ *
+ * Returns null when no `uiReview.run.command` is declared — the provision+boot
+ * stage treats that as a stated stop reason (no app is ever guessed). Numeric
+ * probe bounds fall back to sane defaults so a partial file-level config (whose
+ * schema defaults are dropped by `.partial()`) still resolves fully.
+ *
+ * @param {DevLoopConfig} config
+ * @returns {null | { command: string, readyUrl: string, readyTimeoutMs: number,
+ *   readyIntervalMs: number, cwd: string|null,
+ *   migrate: null | { statusCommand: string, applyCommand: string, destructivePattern: string } }}
+ */
+export function resolveUiReviewRunRecipe(config) {
+  const run = config?.uiReview?.run;
+  if (!run || typeof run.command !== "string" || run.command.trim().length === 0) return null;
+  if (typeof run.readyUrl !== "string" || run.readyUrl.trim().length === 0) return null;
+  const migrate = run.migrate
+    ? {
+        statusCommand: run.migrate.statusCommand,
+        applyCommand: run.migrate.applyCommand,
+        destructivePattern: run.migrate.destructivePattern ?? DEFAULT_DESTRUCTIVE_MIGRATION_PATTERN,
+      }
+    : null;
+  return {
+    command: run.command.trim(),
+    readyUrl: run.readyUrl.trim(),
+    readyTimeoutMs: Number.isInteger(run.readyTimeoutMs) ? run.readyTimeoutMs : 60000,
+    readyIntervalMs: Number.isInteger(run.readyIntervalMs) ? run.readyIntervalMs : 1000,
+    cwd: typeof run.cwd === "string" && run.cwd.trim().length > 0 ? run.cwd.trim() : null,
+    migrate,
+  };
 }
 
 /**

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -187,7 +187,19 @@ const WorktreeConfig = z.strictObject({
 const UiReviewMigrateConfig = z.strictObject({
   statusCommand: z.string().trim().min(1),
   applyCommand: z.string().trim().min(1),
-  destructivePattern: z.string().trim().min(1).optional(),
+  destructivePattern: z
+    .string()
+    .trim()
+    .min(1)
+    .refine((p) => {
+      try {
+        new RegExp(p);
+        return true;
+      } catch {
+        return false;
+      }
+    }, "destructivePattern must be a valid regex")
+    .optional(),
 });
 
 /**
@@ -198,7 +210,7 @@ const UiReviewMigrateConfig = z.strictObject({
  */
 const UiReviewRunConfig = z.strictObject({
   command: z.string().trim().min(1),
-  readyUrl: z.string().trim().min(1),
+  readyUrl: z.string().trim().url(),
   readyTimeoutMs: z.number().int().min(1).max(600000).default(60000),
   readyIntervalMs: z.number().int().min(1).max(60000).default(1000),
   cwd: z.string().trim().min(1).optional(),

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -181,8 +181,17 @@ const WorktreeConfig = z.strictObject({
 /**
  * Dev-DB migration sub-recipe for the ui-review run recipe. `statusCommand`
  * lists pending migrations (one per line); `applyCommand` applies them.
- * `destructivePattern` is an optional regex (default in resolveUiReviewRunRecipe)
- * matched against the status output to fail closed on destructive migrations.
+ *
+ * Destructive detection is EXPLICIT and status-format-dependent: the
+ * `destructivePattern` regex is matched (case-insensitive, per line) against the
+ * STATUS OUTPUT — not against the migration files. The shipped default
+ * (DEFAULT_DESTRUCTIVE_MIGRATION_PATTERN) assumes SQL-bearing status output
+ * (DROP/TRUNCATE/DELETE FROM ...); against a status command that emits migration
+ * identifiers or filenames instead, it matches nothing and the destructive guard
+ * is inert. A project whose status output is NOT SQL therefore MUST set a
+ * `destructivePattern` that matches its own status format (e.g. a `destructive`/
+ * `down` marker), or make `statusCommand` emit the destructive SQL/marker — the
+ * default cannot detect what its status output never prints.
  */
 const UiReviewMigrateConfig = z.strictObject({
   statusCommand: z.string().trim().min(1),
@@ -1451,8 +1460,13 @@ export function resolveWorktreeConfig(config) {
 
 /**
  * Default destructive-migration signal: SQL statements that drop or wipe data.
- * Matched (case-insensitive) against the migration status output. A project may
- * override via `uiReview.run.migrate.destructivePattern`.
+ * Matched (case-insensitive, per line) against the migration STATUS OUTPUT. This
+ * default only detects destructive intent when the status output is itself
+ * SQL-bearing; against status output that lists migration identifiers/filenames
+ * it matches nothing and the guard is inert (no false positives, but also no
+ * protection). Such a project MUST override via
+ * `uiReview.run.migrate.destructivePattern` to match its own status format (or
+ * emit the destructive SQL/marker from `statusCommand`).
  */
 export const DEFAULT_DESTRUCTIVE_MIGRATION_PATTERN =
   "\\b(DROP\\s+(TABLE|COLUMN|DATABASE|SCHEMA)|TRUNCATE|DELETE\\s+FROM|ALTER\\s+TABLE\\s+.*\\bDROP\\b)";
@@ -1462,8 +1476,10 @@ export const DEFAULT_DESTRUCTIVE_MIGRATION_PATTERN =
  *
  * Returns null when no `uiReview.run.command` is declared — the provision+boot
  * stage treats that as a stated stop reason (no app is ever guessed). Numeric
- * probe bounds fall back to sane defaults so a partial file-level config (whose
- * schema defaults are dropped by `.partial()`) still resolves fully.
+ * probe bounds fall back to sane defaults defensively: zod `.partial()` is
+ * shallow (it does not drop nested numeric defaults), so a schema-validated
+ * config already carries them — the fallback covers programmatically-built
+ * config objects that bypass schema defaulting, not the `.partial()` path.
  *
  * @param {DevLoopConfig} config
  * @returns {null | { command: string, readyUrl: string, readyTimeoutMs: number,

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -213,7 +213,18 @@ const UiReviewMigrateConfig = z.strictObject({
  */
 const UiReviewRunConfig = z.strictObject({
   command: z.string().trim().min(1),
-  readyUrl: z.string().trim().url(),
+  readyUrl: z
+    .string()
+    .trim()
+    .url()
+    .refine((u) => {
+      try {
+        const p = new URL(u).protocol;
+        return p === "http:" || p === "https:";
+      } catch {
+        return false;
+      }
+    }, "readyUrl must be an http(s) URL"),
   readyTimeoutMs: z.number().int().min(1).max(600000).default(60000),
   readyIntervalMs: z.number().int().min(1).max(60000).default(1000),
   cwd: z.string().trim().min(1).optional(),

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -193,7 +193,10 @@ const UiReviewMigrateConfig = z.strictObject({
     .min(1)
     .refine((p) => {
       try {
-        new RegExp(p);
+        // Validate under the exact flags the runtime compile uses at the
+        // destructive-migration safety boundary (inspectMigrations), so a
+        // pattern valid bare but invalid under `u` is rejected at load time.
+        new RegExp(p, "iu");
         return true;
       } catch {
         return false;

--- a/packages/core/src/loop/ui-review-provision.mjs
+++ b/packages/core/src/loop/ui-review-provision.mjs
@@ -39,7 +39,7 @@ const MUST_FIX = "must-fix";
  * @param {(a:{worktreePath:string})=>Promise<{ok:boolean,detail:string}>} seams.installDeps
  * @param {(worktreePath:string)=>Promise<object|null>} seams.resolveRunRecipe
  * @param {(a:{worktreePath:string,recipe:object})=>Promise<{pending:string[],destructive:string[],detail:string}>} seams.inspectMigrations
- * @param {(a:{worktreePath:string,recipe:object})=>Promise<{applied:number,detail:string}>} seams.applyMigrations
+ * @param {(a:{worktreePath:string,recipe:object})=>Promise<{ok:boolean,applied:number,detail:string}>} seams.applyMigrations
  * @param {(a:{worktreePath:string,recipe:object})=>Promise<{pid:number|null,detail:string}>} seams.bootApp
  * @param {(url:string)=>Promise<boolean>} seams.probe
  * @param {(ms:number)=>Promise<void>} [seams.delay]
@@ -146,6 +146,13 @@ export async function provisionAndBoot(
         record(`destructive migration(s) acknowledged; applying ${mig.pending.length} pending migration(s)`);
       }
       const applied = await applyMigrations({ worktreePath, recipe });
+      if (!applied.ok) {
+        return stop(
+          "migration apply failed",
+          { kind: "migration-apply", severity: MUST_FIX, message: applied.detail },
+          { worktreePath, depInstall, migrations: { pending: mig.pending.length, applied: 0, destructive: mig.destructive, detail: applied.detail } },
+        );
+      }
       migrations = { pending: mig.pending.length, applied: applied.applied, destructive: mig.destructive, detail: applied.detail };
       record(`migrations applied: ${applied.applied} (${applied.detail})`);
     } else {

--- a/packages/core/src/loop/ui-review-provision.mjs
+++ b/packages/core/src/loop/ui-review-provision.mjs
@@ -40,12 +40,14 @@ const MUST_FIX = "must-fix";
  * @param {(a:{repoRoot:string,worktreePath:string})=>Promise<{changed:boolean,detail:string}>} seams.detectDepDelta
  * @param {(a:{worktreePath:string})=>Promise<{ok:boolean,detail:string}>} seams.installDeps
  * @param {(worktreePath:string)=>Promise<object|null>} seams.resolveRunRecipe
- * @param {(a:{worktreePath:string,recipe:object})=>Promise<{pending:string[],destructive:string[],detail:string}>} seams.inspectMigrations
- * @param {(a:{worktreePath:string,recipe:object})=>Promise<{ok:boolean,applied:number,detail:string}>} seams.applyMigrations
- * @param {(a:{worktreePath:string,recipe:object})=>Promise<{pid:number|null,detail:string}>} seams.bootApp
+ * @param {(a:{worktreePath:string,recipe:object,runCwd:string})=>Promise<{pending:string[],destructive:string[],detail:string}>} seams.inspectMigrations — MUST run in `runCwd` (the guard-validated absolute cwd), never re-derive it
+ * @param {(a:{worktreePath:string,recipe:object,runCwd:string})=>Promise<{ok:boolean,applied:number,detail:string}>} seams.applyMigrations — MUST run in `runCwd`
+ * @param {(a:{worktreePath:string,recipe:object,runCwd:string})=>Promise<{pid:number|null,detail:string}>} seams.bootApp — MUST run in `runCwd`
  * @param {(url:string)=>Promise<boolean>} seams.probe
- * @param {(ms:number)=>Promise<false>} [seams.probeTimeout] - Per-attempt cap:
- *   resolves false once `ms` elapses, so a hung probe can't outlive the budget.
+ * @param {(ms:number)=>Promise<false> & {clear?:()=>void}} [seams.probeTimeout] -
+ *   Per-attempt cap: resolves false once `ms` elapses, so a hung probe can't
+ *   outlive the budget. May expose `clear()`; the poll calls it after each race
+ *   resolves so a pending timer is cancelled rather than left to fire.
  * @param {(ms:number)=>Promise<void>} [seams.delay]
  * @param {()=>number} [seams.now]
  * @param {(msg:string)=>void} [seams.log]
@@ -63,11 +65,19 @@ export async function provisionAndBoot(
     applyMigrations,
     bootApp,
     probe,
-    probeTimeout = (ms) =>
-      new Promise((resolve) => {
-        const t = setTimeout(() => resolve(false), ms);
-        t.unref?.(); // never hold the process open on the success path
-      }),
+    probeTimeout = (ms) => {
+      let t;
+      const p = /** @type {Promise<false> & {clear?:()=>void}} */ (
+        new Promise((resolve) => {
+          t = setTimeout(() => resolve(false), ms);
+        })
+      );
+      // Self-clearing: the poll calls clear() after the race resolves, so a
+      // still-pending timer is cancelled outright (never left to fire, never
+      // holds the process open) — bounding any injected probe seam.
+      p.clear = () => clearTimeout(t);
+      return p;
+    },
     delay = (ms) => new Promise((r) => setTimeout(r, ms)),
     now = () => Date.now(),
     log = () => {},
@@ -131,9 +141,14 @@ export async function provisionAndBoot(
     );
   }
 
-  // 4b. The run recipe's cwd is worktree-relative; a recipe that escapes the
-  //     worktree (e.g. cwd "../..") would run migrate/boot in another checkout.
-  //     Fail closed unless the resolved cwd stays inside the provisioned tree.
+  // 4b. Resolve + validate the run recipe's cwd ONCE, here — the single source
+  //     of cwd truth. The recipe's cwd is worktree-relative; a recipe that
+  //     escapes the worktree (e.g. cwd "../..") would run migrate/boot in
+  //     another checkout, so fail closed unless the resolved cwd stays inside
+  //     the provisioned tree. The validated ABSOLUTE path (`runCwd`) is what the
+  //     migrate/boot seams execute in — they consume it verbatim and never
+  //     re-derive it, so the guarded path and the executed path cannot drift.
+  let runCwd = worktreePath;
   if (recipe.cwd) {
     const resolvedCwd = path.resolve(worktreePath, recipe.cwd);
     const insideWorktree = resolvedCwd === worktreePath || resolvedCwd.startsWith(worktreePath + path.sep);
@@ -144,13 +159,14 @@ export async function provisionAndBoot(
         { worktreePath, depInstall },
       );
     }
+    runCwd = resolvedCwd;
   }
 
   // 5. Dev-DB migrations. A destructive/blocked migration fails closed to a
   //    finding requiring explicit ack; nothing is applied until acknowledged.
   let migrations = { pending: 0, applied: 0, destructive: [], detail: "no migrate recipe" };
   if (recipe.migrate) {
-    const mig = await inspectMigrations({ worktreePath, recipe });
+    const mig = await inspectMigrations({ worktreePath, recipe, runCwd });
     record(`migration status: ${mig.pending.length} pending, ${mig.destructive.length} destructive (${mig.detail})`);
     if (mig.destructive.length > 0 && !ackDestructiveMigration) {
       return stop(
@@ -169,7 +185,7 @@ export async function provisionAndBoot(
       if (mig.destructive.length > 0) {
         record(`destructive migration(s) acknowledged; applying ${mig.pending.length} pending migration(s)`);
       }
-      const applied = await applyMigrations({ worktreePath, recipe });
+      const applied = await applyMigrations({ worktreePath, recipe, runCwd });
       if (!applied.ok) {
         return stop(
           "migration apply failed",
@@ -188,7 +204,7 @@ export async function provisionAndBoot(
   }
 
   // 6. Boot the app, then poll the readiness probe against an explicit deadline.
-  const boot = await bootApp({ worktreePath, recipe });
+  const boot = await bootApp({ worktreePath, recipe, runCwd });
   record(`app booting (pid ${boot.pid ?? "n/a"}): ${boot.detail}`);
 
   const timeoutMs = recipe.readyTimeoutMs;
@@ -206,11 +222,13 @@ export async function provisionAndBoot(
     // a slow/hung probe can't exceed the deadline or block forever — a per-attempt
     // timeout is just "not ready yet", keeping boot-timeout deterministic.
     let probeOk = false;
+    const timeout = probeTimeout(Math.max(0, deadline - now()));
     try {
-      const remaining = Math.max(0, deadline - now());
-      probeOk = await Promise.race([Promise.resolve(probe(recipe.readyUrl)), probeTimeout(remaining)]);
+      probeOk = await Promise.race([Promise.resolve(probe(recipe.readyUrl)), timeout]);
     } catch {
       probeOk = false;
+    } finally {
+      timeout.clear?.(); // cancel the pending per-attempt timer once the race is decided
     }
     if (probeOk) {
       ready = true;

--- a/packages/core/src/loop/ui-review-provision.mjs
+++ b/packages/core/src/loop/ui-review-provision.mjs
@@ -176,7 +176,15 @@ export async function provisionAndBoot(
   // deadline. The injected clock/delay make the timeout deterministic in tests.
   while (now() <= deadline) {
     attempts += 1;
-    if (await probe(recipe.readyUrl)) {
+    // Fail closed: a probe that throws/rejects counts as "not ready yet" so the
+    // deadline path produces the clean boot-timeout stop instead of crashing.
+    let probeOk = false;
+    try {
+      probeOk = await probe(recipe.readyUrl);
+    } catch {
+      probeOk = false;
+    }
+    if (probeOk) {
       ready = true;
       break;
     }

--- a/packages/core/src/loop/ui-review-provision.mjs
+++ b/packages/core/src/loop/ui-review-provision.mjs
@@ -21,6 +21,8 @@
  * posting, production DB.
  */
 
+import path from "node:path";
+
 const MUST_FIX = "must-fix";
 
 /**
@@ -42,6 +44,8 @@ const MUST_FIX = "must-fix";
  * @param {(a:{worktreePath:string,recipe:object})=>Promise<{ok:boolean,applied:number,detail:string}>} seams.applyMigrations
  * @param {(a:{worktreePath:string,recipe:object})=>Promise<{pid:number|null,detail:string}>} seams.bootApp
  * @param {(url:string)=>Promise<boolean>} seams.probe
+ * @param {(ms:number)=>Promise<false>} [seams.probeTimeout] - Per-attempt cap:
+ *   resolves false once `ms` elapses, so a hung probe can't outlive the budget.
  * @param {(ms:number)=>Promise<void>} [seams.delay]
  * @param {()=>number} [seams.now]
  * @param {(msg:string)=>void} [seams.log]
@@ -59,6 +63,11 @@ export async function provisionAndBoot(
     applyMigrations,
     bootApp,
     probe,
+    probeTimeout = (ms) =>
+      new Promise((resolve) => {
+        const t = setTimeout(() => resolve(false), ms);
+        t.unref?.(); // never hold the process open on the success path
+      }),
     delay = (ms) => new Promise((r) => setTimeout(r, ms)),
     now = () => Date.now(),
     log = () => {},
@@ -122,6 +131,21 @@ export async function provisionAndBoot(
     );
   }
 
+  // 4b. The run recipe's cwd is worktree-relative; a recipe that escapes the
+  //     worktree (e.g. cwd "../..") would run migrate/boot in another checkout.
+  //     Fail closed unless the resolved cwd stays inside the provisioned tree.
+  if (recipe.cwd) {
+    const resolvedCwd = path.resolve(worktreePath, recipe.cwd);
+    const insideWorktree = resolvedCwd === worktreePath || resolvedCwd.startsWith(worktreePath + path.sep);
+    if (!insideWorktree) {
+      return stop(
+        "run recipe cwd escapes the provisioned worktree",
+        { kind: "cwd-traversal", severity: MUST_FIX, message: `uiReview.run.cwd (${recipe.cwd}) resolves outside the worktree: ${resolvedCwd}` },
+        { worktreePath, depInstall },
+      );
+    }
+  }
+
   // 5. Dev-DB migrations. A destructive/blocked migration fails closed to a
   //    finding requiring explicit ack; nothing is applied until acknowledged.
   let migrations = { pending: 0, applied: 0, destructive: [], detail: "no migrate recipe" };
@@ -178,9 +202,13 @@ export async function provisionAndBoot(
     attempts += 1;
     // Fail closed: a probe that throws/rejects counts as "not ready yet" so the
     // deadline path produces the clean boot-timeout stop instead of crashing.
+    // Bound each attempt by the remaining budget (raced against probeTimeout) so
+    // a slow/hung probe can't exceed the deadline or block forever — a per-attempt
+    // timeout is just "not ready yet", keeping boot-timeout deterministic.
     let probeOk = false;
     try {
-      probeOk = await probe(recipe.readyUrl);
+      const remaining = Math.max(0, deadline - now());
+      probeOk = await Promise.race([Promise.resolve(probe(recipe.readyUrl)), probeTimeout(remaining)]);
     } catch {
       probeOk = false;
     }

--- a/packages/core/src/loop/ui-review-provision.mjs
+++ b/packages/core/src/loop/ui-review-provision.mjs
@@ -1,0 +1,203 @@
+/**
+ * Provision + boot orchestrator for the ui_review route (Stage 1).
+ *
+ * Provisions an isolated worktree for a PR head and boots the branch's app to a
+ * ready state, then hands off a booted app for the running-app review stages.
+ * The orchestration is a fail-closed sequence:
+ *
+ *   1. create-or-reuse the PR worktree (fetch before) and provision it
+ *   2. refuse to operate in the primary checkout (worktree guard)
+ *   3. install ONLY the dependency-lock delta vs. the primary checkout
+ *   4. run pending dev-DB migrations; a destructive one stops for explicit ack
+ *   5. resolve a per-project run recipe (no app is ever guessed)
+ *   6. boot the app and poll an HTTP readiness probe (never a fixed sleep)
+ *
+ * Every bounded cap (install skipped, migration ack required, boot timeout) is
+ * logged — no silent truncation. This module is pure orchestration: all IO
+ * (git/worktree, config, spawn, HTTP probe, clock) is injected so it is fully
+ * testable against a fixture project. The thin CLI wires the real seams.
+ *
+ * Out of scope (later stages): browser driving, auth, screenshots, review
+ * posting, production DB.
+ */
+
+const MUST_FIX = "must-fix";
+
+/**
+ * Run the provision+boot sequence.
+ *
+ * @param {object} input
+ * @param {string} input.repoRoot - Absolute path to the primary checkout.
+ * @param {number} input.pr - PR number whose head is provisioned.
+ * @param {string} [input.branch] - Branch to check out (default: pr-<n>).
+ * @param {boolean} [input.ackDestructiveMigration] - Explicit ack unblocking a
+ *   destructive/blocked migration. Fail-closed: absent means "not acknowledged".
+ * @param {object} seams - Injected IO (all required except clock/log defaults).
+ * @param {(a:{repoRoot:string,pr:number,branch?:string})=>Promise<{path:string,created:boolean,reused:boolean}>} seams.ensureWorktree
+ * @param {(a:{worktreePath:string,repoRoot:string})=>{ok:boolean,message?:string,mainWorktreePath?:string|null}} seams.assertNotPrimary
+ * @param {(a:{repoRoot:string,worktreePath:string})=>Promise<{changed:boolean,detail:string}>} seams.detectDepDelta
+ * @param {(a:{worktreePath:string})=>Promise<{ok:boolean,detail:string}>} seams.installDeps
+ * @param {(worktreePath:string)=>Promise<object|null>} seams.resolveRunRecipe
+ * @param {(a:{worktreePath:string,recipe:object})=>Promise<{pending:string[],destructive:string[],detail:string}>} seams.inspectMigrations
+ * @param {(a:{worktreePath:string,recipe:object})=>Promise<{applied:number,detail:string}>} seams.applyMigrations
+ * @param {(a:{worktreePath:string,recipe:object})=>Promise<{pid:number|null,detail:string}>} seams.bootApp
+ * @param {(url:string)=>Promise<boolean>} seams.probe
+ * @param {(ms:number)=>Promise<void>} [seams.delay]
+ * @param {()=>number} [seams.now]
+ * @param {(msg:string)=>void} [seams.log]
+ * @returns {Promise<object>} A result envelope (see fields assembled below).
+ */
+export async function provisionAndBoot(
+  { repoRoot, pr, branch, ackDestructiveMigration = false },
+  {
+    ensureWorktree,
+    assertNotPrimary,
+    detectDepDelta,
+    installDeps,
+    resolveRunRecipe,
+    inspectMigrations,
+    applyMigrations,
+    bootApp,
+    probe,
+    delay = (ms) => new Promise((r) => setTimeout(r, ms)),
+    now = () => Date.now(),
+    log = () => {},
+  } = {},
+) {
+  const logs = [];
+  const findings = [];
+  const record = (msg) => {
+    logs.push(msg);
+    log(msg);
+  };
+  const base = () => ({ pr, branch: branch ?? null, findings, logs });
+  const stop = (stopReason, finding, extra = {}) => {
+    if (finding) findings.push(finding);
+    record(`STOP: ${stopReason}`);
+    return { ok: false, stopped: true, stopReason, ...base(), ...extra };
+  };
+
+  // 1. Create-or-reuse the PR worktree (ensureWorktree fetches + provisions).
+  const wt = await ensureWorktree({ repoRoot, pr, branch });
+  const worktreePath = wt.path;
+  record(`worktree ${wt.created ? "created" : "reused"}: ${worktreePath}`);
+
+  // 2. Fail closed if that path is the primary checkout — never operate there.
+  const guard = assertNotPrimary({ worktreePath, repoRoot });
+  if (!guard.ok) {
+    return stop(
+      "worktree guard: refusing to operate in the primary checkout",
+      { kind: "worktree-guard", severity: MUST_FIX, message: guard.message ?? "resolved worktree is the primary checkout" },
+      { worktreePath },
+    );
+  }
+
+  // 3. Install only the dependency-lock delta vs. the primary checkout. No delta
+  //    => deps are shared; installing anything would be a blind re-install.
+  const delta = await detectDepDelta({ repoRoot, worktreePath });
+  let depInstall = { installed: false, detail: delta.detail };
+  if (delta.changed) {
+    record(`dependency-lock delta detected (${delta.detail}); installing branch deps`);
+    const inst = await installDeps({ worktreePath });
+    depInstall = { installed: inst.ok, detail: inst.detail };
+    record(`dependency install ${inst.ok ? "ok" : "FAILED"}: ${inst.detail}`);
+    if (!inst.ok) {
+      return stop(
+        "dependency install failed",
+        { kind: "dep-install", severity: MUST_FIX, message: inst.detail },
+        { worktreePath, depInstall },
+      );
+    }
+  } else {
+    record(`dependency install skipped: no lock delta vs primary checkout (${delta.detail})`);
+  }
+
+  // 4. Resolve the per-project run recipe before migrate/boot (no app guessed).
+  const recipe = await resolveRunRecipe(worktreePath);
+  if (!recipe) {
+    return stop(
+      "no run recipe: the branch declares no uiReview.run recipe (cannot boot the app)",
+      { kind: "run-recipe-missing", severity: MUST_FIX, message: "declare uiReview.run.command + readyUrl in .devloops" },
+      { worktreePath, depInstall },
+    );
+  }
+
+  // 5. Dev-DB migrations. A destructive/blocked migration fails closed to a
+  //    finding requiring explicit ack; nothing is applied until acknowledged.
+  let migrations = { pending: 0, applied: 0, destructive: [], detail: "no migrate recipe" };
+  if (recipe.migrate) {
+    const mig = await inspectMigrations({ worktreePath, recipe });
+    record(`migration status: ${mig.pending.length} pending, ${mig.destructive.length} destructive (${mig.detail})`);
+    if (mig.destructive.length > 0 && !ackDestructiveMigration) {
+      return stop(
+        "destructive migration requires explicit acknowledgement",
+        {
+          kind: "destructive-migration",
+          severity: MUST_FIX,
+          requiresAck: true,
+          message: `${mig.destructive.length} destructive migration(s) blocked pending ack`,
+          destructive: mig.destructive,
+        },
+        { worktreePath, depInstall, migrations: { pending: mig.pending.length, applied: 0, destructive: mig.destructive, detail: mig.detail } },
+      );
+    }
+    if (mig.pending.length > 0) {
+      if (mig.destructive.length > 0) {
+        record(`destructive migration(s) acknowledged; applying ${mig.pending.length} pending migration(s)`);
+      }
+      const applied = await applyMigrations({ worktreePath, recipe });
+      migrations = { pending: mig.pending.length, applied: applied.applied, destructive: mig.destructive, detail: applied.detail };
+      record(`migrations applied: ${applied.applied} (${applied.detail})`);
+    } else {
+      migrations = { pending: 0, applied: 0, destructive: mig.destructive, detail: "no pending migrations" };
+      record("no pending migrations");
+    }
+  } else {
+    record("migrations skipped: branch declares no migrate recipe");
+  }
+
+  // 6. Boot the app, then poll the readiness probe against an explicit deadline.
+  const boot = await bootApp({ worktreePath, recipe });
+  record(`app booting (pid ${boot.pid ?? "n/a"}): ${boot.detail}`);
+
+  const timeoutMs = recipe.readyTimeoutMs;
+  const intervalMs = recipe.readyIntervalMs;
+  const deadline = now() + timeoutMs;
+  let ready = false;
+  let attempts = 0;
+  // Bounded poll (never a fixed sleep): probe, then wait one interval, until the
+  // deadline. The injected clock/delay make the timeout deterministic in tests.
+  while (now() <= deadline) {
+    attempts += 1;
+    if (await probe(recipe.readyUrl)) {
+      ready = true;
+      break;
+    }
+    if (now() + intervalMs > deadline) break; // would overshoot the deadline
+    await delay(intervalMs);
+  }
+
+  const bootResult = { pid: boot.pid ?? null, ready, attempts, readyUrl: recipe.readyUrl, timeoutMs, intervalMs };
+  if (!ready) {
+    record(`boot timeout: not ready after ${timeoutMs}ms (${attempts} probe attempt(s)) at ${recipe.readyUrl}`);
+    return stop(
+      `readiness probe timed out after ${timeoutMs}ms (${attempts} attempt(s) at ${recipe.readyUrl})`,
+      { kind: "boot-timeout", severity: MUST_FIX, message: `app never became ready within ${timeoutMs}ms` },
+      { worktreePath, depInstall, migrations, boot: bootResult },
+    );
+  }
+
+  record(`app ready after ${attempts} probe attempt(s) at ${recipe.readyUrl}`);
+  return {
+    ok: true,
+    stopped: false,
+    stopReason: null,
+    worktreePath,
+    created: wt.created,
+    reused: wt.reused,
+    depInstall,
+    migrations,
+    boot: bootResult,
+    ...base(),
+  };
+}

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -316,6 +316,50 @@ describe("schema validation", () => {
     assert.ok(!result.success);
   });
 
+  test("S27: uiReview.run with a valid readyUrl parses", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      uiReview: { run: { command: "npm start", readyUrl: "http://127.0.0.1:3000/health" } },
+    });
+    assert.ok(result.success);
+  });
+
+  test("S28: uiReview.run.readyUrl rejects a malformed URL", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      uiReview: { run: { command: "npm start", readyUrl: "not-a-url" } },
+    });
+    assert.ok(!result.success);
+  });
+
+  test("S29: uiReview.run.migrate.destructivePattern rejects a malformed regex", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      uiReview: {
+        run: {
+          command: "npm start",
+          readyUrl: "http://127.0.0.1:3000/health",
+          migrate: { statusCommand: "s", applyCommand: "a", destructivePattern: "[" },
+        },
+      },
+    });
+    assert.ok(!result.success);
+  });
+
+  test("S30: uiReview.run.migrate.destructivePattern accepts a valid regex", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      uiReview: {
+        run: {
+          command: "npm start",
+          readyUrl: "http://127.0.0.1:3000/health",
+          migrate: { statusCommand: "s", applyCommand: "a", destructivePattern: "drop|truncate" },
+        },
+      },
+    });
+    assert.ok(result.success);
+  });
+
 });
 
 // ============================================================================

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -360,6 +360,22 @@ describe("schema validation", () => {
     assert.ok(result.success);
   });
 
+  test("S31: destructivePattern valid bare but invalid under `u` flag is rejected at load", () => {
+    // `[a-\d]` compiles as `new RegExp(p)` but throws under `new RegExp(p, "iu")`,
+    // the exact flags inspectMigrations uses at the destructive-migration boundary.
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      uiReview: {
+        run: {
+          command: "npm start",
+          readyUrl: "http://127.0.0.1:3000/health",
+          migrate: { statusCommand: "s", applyCommand: "a", destructivePattern: "[a-\\d]" },
+        },
+      },
+    });
+    assert.ok(!result.success);
+  });
+
 });
 
 // ============================================================================

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -332,6 +332,22 @@ describe("schema validation", () => {
     assert.ok(!result.success);
   });
 
+  test("S28b: uiReview.run.readyUrl rejects a non-http(s) URL", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      uiReview: { run: { command: "npm start", readyUrl: "ftp://example.com/health" } },
+    });
+    assert.ok(!result.success);
+  });
+
+  test("S28c: uiReview.run.readyUrl accepts https", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      uiReview: { run: { command: "npm start", readyUrl: "https://example.com/health" } },
+    });
+    assert.ok(result.success);
+  });
+
   test("S29: uiReview.run.migrate.destructivePattern rejects a malformed regex", () => {
     const result = DevLoopConfigSchema.safeParse({
       version: 1,

--- a/scripts/loop/ui-review-provision.mjs
+++ b/scripts/loop/ui-review-provision.mjs
@@ -175,17 +175,17 @@ function resolveRunRecipe(worktreePath) {
   return loadDevLoopConfig({ repoRoot: worktreePath }).then(({ config }) => resolveUiReviewRunRecipe(config));
 }
 
-function migrateCwd(worktreePath, recipe) {
-  return recipe.cwd ? path.join(worktreePath, recipe.cwd) : worktreePath;
-}
-
 /**
  * List pending migrations from the status command output (one per non-blank
  * line) and flag destructive ones by regex. A status command that itself fails
  * is treated as a migration-safety block (fail closed via a synthetic finding).
+ *
+ * Runs in `runCwd` — the absolute cwd the orchestrator already resolved and
+ * validated against the worktree boundary. This seam never re-derives the cwd,
+ * so the executed path is exactly the guarded one.
  */
-export function inspectMigrations({ worktreePath, recipe }) {
-  const cwd = migrateCwd(worktreePath, recipe);
+export function inspectMigrations({ recipe, runCwd }) {
+  const cwd = runCwd;
   let out;
   try {
     out = runShell(recipe.migrate.statusCommand, cwd);
@@ -200,8 +200,8 @@ export function inspectMigrations({ worktreePath, recipe }) {
   return Promise.resolve({ pending, destructive, detail: `${pending.length} line(s) from status` });
 }
 
-function applyMigrations({ worktreePath, recipe }) {
-  const cwd = migrateCwd(worktreePath, recipe);
+function applyMigrations({ recipe, runCwd }) {
+  const cwd = runCwd;
   try {
     runShell(recipe.migrate.applyCommand, cwd);
     return Promise.resolve({ ok: true, applied: 1, detail: "apply command ran" });
@@ -212,8 +212,8 @@ function applyMigrations({ worktreePath, recipe }) {
 }
 
 /** Spawn the boot command detached so the app stays up after this CLI exits. */
-function bootApp({ worktreePath, recipe }) {
-  const cwd = recipe.cwd ? path.join(worktreePath, recipe.cwd) : worktreePath;
+function bootApp({ recipe, runCwd }) {
+  const cwd = runCwd;
   const child = spawn(recipe.command, { cwd, shell: true, detached: true, stdio: "ignore" });
   child.unref();
   return Promise.resolve({ pid: child.pid ?? null, detail: `spawned: ${recipe.command}` });

--- a/scripts/loop/ui-review-provision.mjs
+++ b/scripts/loop/ui-review-provision.mjs
@@ -87,7 +87,9 @@ export function parseUiReviewProvisionCliArgs(argv) {
       continue;
     }
     if (token.name === "ack-destructive-migration") {
-      options.ackDestructiveMigration = true;
+      // Bare flag or `=true` acks; an explicit `=false`/`=0`/`=no` must NOT ack
+      // (fail closed — a destructive migration stays blocked unless truly asked).
+      options.ackDestructiveMigration = token.value === undefined || !/^(false|0|no)$/iu.test(token.value.trim());
       continue;
     }
     if (matchJqOutputToken(token, options, (t) => requireTokenValue(t, parseError))) continue;
@@ -137,8 +139,8 @@ function detectDepDelta({ repoRoot, worktreePath }) {
  * shared deps. Replace a symlinked node_modules with a real (empty) directory so
  * the install is isolated to the worktree, leaving the primary untouched.
  *
- * ponytail: materializing to an empty dir makes `npm install` reinstall the full
- * tree (not just the lock delta); if that install cost matters, copy the
+ * Note: materializing to an empty dir makes `npm install` reinstall the full
+ * tree (not just the lock delta). If that install cost matters, copy the
  * primary's real node_modules into the worktree first for an incremental
  * reconcile.
  *

--- a/scripts/loop/ui-review-provision.mjs
+++ b/scripts/loop/ui-review-provision.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+/**
+ * CLI wrapper for the ui_review provision+boot orchestrator.
+ *
+ * Provisions an isolated worktree for a PR head (create-or-reuse + provision),
+ * installs only the dependency-lock delta, runs pending dev-DB migrations
+ * (destructive ones fail closed pending ack), boots the branch's app via the
+ * project's declared run recipe, and waits on an HTTP readiness probe.
+ *
+ * This is a thin adapter: it wires real IO seams (git worktree, config, npm
+ * install, shell migration commands, spawn, HTTP probe) into the pure core
+ * orchestrator (packages/core/src/loop/ui-review-provision.mjs).
+ */
+import { execFileSync, spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import http from "node:http";
+import https from "node:https";
+import path from "node:path";
+import { parseArgs } from "node:util";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { requireTokenValue } from "../_cli-primitives.mjs";
+import { loadDevLoopConfig, resolveUiReviewRunRecipe } from "@dev-loops/core/config";
+import { provisionAndBoot } from "@dev-loops/core/loop/ui-review-provision";
+import { isMainCheckout, parseMainWorktreePath } from "@dev-loops/core/loop/worktree-guard";
+import { ensureWorktree } from "./ensure-worktree.mjs";
+import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+
+const USAGE = `Usage:
+  ui-review-provision.mjs --repo-root <p> --pr <n> [--branch <name>] [--ack-destructive-migration]
+Provision an isolated worktree for a PR head and boot the branch's app to a
+ready state (Stage 1 of the ui_review route).
+Required:
+  --repo-root <p>                 Absolute path to the primary checkout.
+  --pr <n>                        PR number whose head is provisioned.
+Optional:
+  --branch <name>                 Branch to check out (default: pr-<n>).
+  --ack-destructive-migration     Acknowledge + unblock a destructive migration.
+  -h, --help                      Show this help.
+Output (stdout, JSON):
+  { "ok": bool, "stopped": bool, "stopReason": string|null,
+    "worktreePath": <p>, "depInstall": {...}, "migrations": {...},
+    "boot": { "ready": bool, "attempts": n, ... }, "findings": [...], "logs": [...] }
+
+${JQ_OUTPUT_USAGE}`.trim();
+
+const parseError = buildParseError(USAGE);
+
+function parsePositiveInt(value, flag) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1) throw parseError(`${flag} must be a positive integer`);
+  return n;
+}
+
+export function parseUiReviewProvisionCliArgs(argv) {
+  const options = { help: false, repoRoot: undefined, pr: undefined, branch: undefined, ackDestructiveMigration: false };
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      "repo-root": { type: "string" },
+      pr: { type: "string" },
+      branch: { type: "string" },
+      "ack-destructive-migration": { type: "boolean" },
+      ...JQ_OUTPUT_PARSE_OPTIONS,
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") throw parseError(`Unknown argument: ${token.value}`);
+    if (token.kind !== "option") continue;
+    if (token.name === "help") {
+      options.help = true;
+      return options;
+    }
+    if (token.name === "repo-root") {
+      options.repoRoot = requireTokenValue(token, parseError, { flagPattern: /^-/u });
+      continue;
+    }
+    if (token.name === "pr") {
+      options.pr = parsePositiveInt(requireTokenValue(token, parseError, { flagPattern: /^-/u }), "--pr");
+      continue;
+    }
+    if (token.name === "branch") {
+      options.branch = requireTokenValue(token, parseError, { flagPattern: /^-/u });
+      continue;
+    }
+    if (token.name === "ack-destructive-migration") {
+      options.ackDestructiveMigration = true;
+      continue;
+    }
+    if (matchJqOutputToken(token, options, (t) => requireTokenValue(t, parseError))) continue;
+    throw parseError(`Unknown argument: ${token.rawName}`);
+  }
+  if (options.help) return options;
+  if (!options.repoRoot) throw parseError("Missing required --repo-root");
+  if (options.pr === undefined) throw parseError("Missing required --pr");
+  return options;
+}
+
+/** Run a shell command in `cwd`, capturing stdout. Throws on non-zero exit. */
+function runShell(command, cwd) {
+  return execFileSync("sh", ["-c", command], { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+/** Read a file's text, or null when absent/unreadable. */
+function readOrNull(file) {
+  try {
+    return readFileSync(file, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * npm-scoped dependency-lock delta: compare the worktree's package-lock.json to
+ * the primary checkout's. Differing (or one-sided) content means the branch
+ * changed dependencies and needs an install; identical means deps are shared.
+ */
+function detectDepDelta({ repoRoot, worktreePath }) {
+  const main = readOrNull(path.join(repoRoot, "package-lock.json"));
+  const branch = readOrNull(path.join(worktreePath, "package-lock.json"));
+  if (main === null && branch === null) {
+    return Promise.resolve({ changed: false, detail: "no package-lock.json in either checkout" });
+  }
+  if (main === branch) {
+    return Promise.resolve({ changed: false, detail: "package-lock.json identical" });
+  }
+  return Promise.resolve({ changed: true, detail: "package-lock.json differs" });
+}
+
+/** npm install in the worktree — incremental, so it reconciles only the delta. */
+function installDeps({ worktreePath }) {
+  try {
+    execFileSync("npm", ["install"], { cwd: worktreePath, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    return Promise.resolve({ ok: true, detail: "npm install" });
+  } catch (err) {
+    return Promise.resolve({ ok: false, detail: (err.stderr ?? err.message ?? "npm install failed").toString().trim() });
+  }
+}
+
+function resolveRunRecipe(worktreePath) {
+  return loadDevLoopConfig({ repoRoot: worktreePath }).then(({ config }) => resolveUiReviewRunRecipe(config));
+}
+
+function migrateCwd(worktreePath, recipe) {
+  return recipe.cwd ? path.join(worktreePath, recipe.cwd) : worktreePath;
+}
+
+/**
+ * List pending migrations from the status command output (one per non-blank
+ * line) and flag destructive ones by regex. A status command that itself fails
+ * is treated as a migration-safety block (fail closed via a synthetic finding).
+ */
+function inspectMigrations({ worktreePath, recipe }) {
+  const cwd = migrateCwd(worktreePath, recipe);
+  let out;
+  try {
+    out = runShell(recipe.migrate.statusCommand, cwd);
+  } catch (err) {
+    const msg = (err.stderr ?? err.message ?? "migration status failed").toString().trim();
+    // Safety block: cannot verify migrations -> treat as a destructive/blocked case.
+    return Promise.resolve({ pending: ["<status-unavailable>"], destructive: [`migration status failed: ${msg}`], detail: "status command failed" });
+  }
+  const pending = out.split("\n").map((l) => l.trim()).filter((l) => l.length > 0);
+  const re = new RegExp(recipe.migrate.destructivePattern, "iu");
+  const destructive = pending.filter((l) => re.test(l));
+  return Promise.resolve({ pending, destructive, detail: `${pending.length} line(s) from status` });
+}
+
+function applyMigrations({ worktreePath, recipe }) {
+  const cwd = migrateCwd(worktreePath, recipe);
+  try {
+    runShell(recipe.migrate.applyCommand, cwd);
+    return Promise.resolve({ applied: 1, detail: "apply command ran" });
+  } catch (err) {
+    const msg = (err.stderr ?? err.message ?? "migration apply failed").toString().trim();
+    return Promise.resolve({ applied: 0, detail: `apply failed: ${msg}` });
+  }
+}
+
+/** Spawn the boot command detached so the app stays up after this CLI exits. */
+function bootApp({ worktreePath, recipe }) {
+  const cwd = recipe.cwd ? path.join(worktreePath, recipe.cwd) : worktreePath;
+  const child = spawn(recipe.command, { cwd, shell: true, detached: true, stdio: "ignore" });
+  child.unref();
+  return Promise.resolve({ pid: child.pid ?? null, detail: `spawned: ${recipe.command}` });
+}
+
+/** HTTP(S) readiness probe: resolve true on a 2xx/3xx response, false otherwise. */
+function probe(url) {
+  return new Promise((resolve) => {
+    let client;
+    try {
+      client = new URL(url).protocol === "https:" ? https : http;
+    } catch {
+      resolve(false);
+      return;
+    }
+    const req = client.get(url, (res) => {
+      const ok = typeof res.statusCode === "number" && res.statusCode >= 200 && res.statusCode < 400;
+      res.resume();
+      resolve(ok);
+    });
+    req.on("error", () => resolve(false));
+    req.setTimeout(5000, () => {
+      req.destroy();
+      resolve(false);
+    });
+  });
+}
+
+/** Assert the resolved worktree is NOT the primary checkout (fail closed). */
+function assertNotPrimary({ worktreePath, repoRoot }) {
+  let listOutput = "";
+  try {
+    listOutput = execFileSync("git", ["worktree", "list"], { cwd: repoRoot, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  } catch (err) {
+    return { ok: false, message: `git worktree list failed: ${(err.stderr ?? err.message ?? "").toString().trim()}` };
+  }
+  const mainWorktreePath = parseMainWorktreePath(listOutput);
+  if (isMainCheckout(worktreePath, mainWorktreePath)) {
+    return { ok: false, message: `${worktreePath} resolves to the primary checkout`, mainWorktreePath };
+  }
+  return { ok: true, mainWorktreePath };
+}
+
+export async function runCli(argv = process.argv.slice(2), { stdout = process.stdout, stderr = process.stderr } = {}) {
+  const options = parseUiReviewProvisionCliArgs(argv);
+  if (options.help) {
+    stdout.write(`${USAGE}\n`);
+    return;
+  }
+  const result = await provisionAndBoot(
+    {
+      repoRoot: options.repoRoot,
+      pr: options.pr,
+      branch: options.branch,
+      ackDestructiveMigration: options.ackDestructiveMigration,
+    },
+    {
+      ensureWorktree: (a) => ensureWorktree(a).then((r) => ({ path: r.path, created: r.created, reused: r.reused })),
+      assertNotPrimary,
+      detectDepDelta,
+      installDeps,
+      resolveRunRecipe,
+      inspectMigrations,
+      applyMigrations,
+      bootApp,
+      probe,
+      log: (msg) => stderr.write(`[ui-review-provision] ${msg}\n`),
+    },
+  );
+  process.exitCode = emitResult(result, { jq: options.jq, silent: options.silent, stdout, stderr });
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli().catch((error) => {
+    process.stderr.write(`${formatCliError(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/loop/ui-review-provision.mjs
+++ b/scripts/loop/ui-review-provision.mjs
@@ -182,7 +182,7 @@ function migrateCwd(worktreePath, recipe) {
  * line) and flag destructive ones by regex. A status command that itself fails
  * is treated as a migration-safety block (fail closed via a synthetic finding).
  */
-function inspectMigrations({ worktreePath, recipe }) {
+export function inspectMigrations({ worktreePath, recipe }) {
   const cwd = migrateCwd(worktreePath, recipe);
   let out;
   try {

--- a/scripts/loop/ui-review-provision.mjs
+++ b/scripts/loop/ui-review-provision.mjs
@@ -12,7 +12,7 @@
  * orchestrator (packages/core/src/loop/ui-review-provision.mjs).
  */
 import { execFileSync, spawn } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { lstatSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import http from "node:http";
 import https from "node:https";
 import path from "node:path";
@@ -130,11 +130,40 @@ function detectDepDelta({ repoRoot, worktreePath }) {
   return Promise.resolve({ changed: true, detail: "package-lock.json differs" });
 }
 
-/** npm install in the worktree — incremental, so it reconciles only the delta. */
+/**
+ * Ensure the worktree owns its node_modules before installing. linkOnInit can
+ * symlink node_modules into the primary checkout; running `npm install` through
+ * that symlink would write into the primary's real node_modules — mutating
+ * shared deps. Replace a symlinked node_modules with a real (empty) directory so
+ * the install is isolated to the worktree, leaving the primary untouched.
+ *
+ * ponytail: materializing to an empty dir makes `npm install` reinstall the full
+ * tree (not just the lock delta); if that install cost matters, copy the
+ * primary's real node_modules into the worktree first for an incremental
+ * reconcile.
+ *
+ * @returns {boolean} true when a symlinked node_modules was materialized.
+ */
+export function ensureOwnNodeModules(worktreePath) {
+  const nm = path.join(worktreePath, "node_modules");
+  let st;
+  try {
+    st = lstatSync(nm);
+  } catch {
+    return false; // absent — npm install creates a real dir
+  }
+  if (!st.isSymbolicLink()) return false;
+  rmSync(nm); // unlinks only the symlink; the primary's real dir is untouched
+  mkdirSync(nm);
+  return true;
+}
+
+/** npm install in the worktree, after ensuring it owns its node_modules. */
 function installDeps({ worktreePath }) {
   try {
+    const materialized = ensureOwnNodeModules(worktreePath);
     execFileSync("npm", ["install"], { cwd: worktreePath, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
-    return Promise.resolve({ ok: true, detail: "npm install" });
+    return Promise.resolve({ ok: true, detail: materialized ? "npm install (materialized own node_modules)" : "npm install" });
   } catch (err) {
     return Promise.resolve({ ok: false, detail: (err.stderr ?? err.message ?? "npm install failed").toString().trim() });
   }
@@ -173,10 +202,10 @@ function applyMigrations({ worktreePath, recipe }) {
   const cwd = migrateCwd(worktreePath, recipe);
   try {
     runShell(recipe.migrate.applyCommand, cwd);
-    return Promise.resolve({ applied: 1, detail: "apply command ran" });
+    return Promise.resolve({ ok: true, applied: 1, detail: "apply command ran" });
   } catch (err) {
     const msg = (err.stderr ?? err.message ?? "migration apply failed").toString().trim();
-    return Promise.resolve({ applied: 0, detail: `apply failed: ${msg}` });
+    return Promise.resolve({ ok: false, applied: 0, detail: `apply failed: ${msg}` });
   }
 }
 

--- a/skills/ui-review/SKILL.md
+++ b/skills/ui-review/SKILL.md
@@ -30,14 +30,22 @@ reuses the worktree machinery (`ensure-worktree`, `provision-worktree`), refuses
 to operate in the primary checkout, installs only the dependency-lock delta,
 runs pending dev-DB migrations, then boots the app and polls an HTTP readiness
 probe. It fails closed to a stated stop reason on: a primary-checkout target, a
-missing run recipe, a destructive migration lacking `--ack-destructive-migration`,
-or a readiness probe that times out. Every bounded cap is logged.
+missing run recipe, a run-recipe `cwd` that resolves outside the provisioned
+worktree (worktree traversal), a destructive migration lacking
+`--ack-destructive-migration`, or a readiness probe that times out. Every
+bounded cap is logged.
 
 The run recipe is per-project and never hard-coded: a project declares
 `uiReview.run` in `.devloops` — a boot `command`, an HTTP `readyUrl`, probe
 `readyTimeoutMs`/`readyIntervalMs`, an optional worktree-relative `cwd`, and an
 optional `migrate` sub-recipe (`statusCommand`/`applyCommand`, plus a
-`destructivePattern` guard).
+`destructivePattern` guard). The destructive guard matches `destructivePattern`
+against the migration STATUS OUTPUT, not the migration files: the shipped
+default only detects SQL-bearing status output (DROP/TRUNCATE/DELETE FROM). A
+project whose status output lists migration identifiers/filenames instead gets
+no protection from the default and MUST set a `destructivePattern` matching its
+own status format (or emit the destructive SQL/marker from `statusCommand`) —
+otherwise the guard is silently inert.
 
 Threat boundary: the run recipe is branch-controlled, and its `command` is
 executed as a shell command in the worktree. Every later stage inherits this

--- a/skills/ui-review/SKILL.md
+++ b/skills/ui-review/SKILL.md
@@ -20,8 +20,26 @@ self-validation (defined in `handoff-envelope.mjs`): no product-code writes,
 worktree-only, outward review stays pending/draft, and destructive migrations
 must be acknowledged before they run.
 
+## Provision + boot
+
+The route's first operational step provisions an isolated worktree for the PR
+head and boots the branch's app to a ready state, via
+`scripts/loop/ui-review-provision.mjs --repo-root <p> --pr <n>`
+(pure orchestration in `packages/core/src/loop/ui-review-provision.mjs`). It
+reuses the worktree machinery (`ensure-worktree`, `provision-worktree`), refuses
+to operate in the primary checkout, installs only the dependency-lock delta,
+runs pending dev-DB migrations, then boots the app and polls an HTTP readiness
+probe. It fails closed to a stated stop reason on: a primary-checkout target, a
+missing run recipe, a destructive migration lacking `--ack-destructive-migration`,
+or a readiness probe that times out. Every bounded cap is logged.
+
+The run recipe is per-project and never hard-coded: a project declares
+`uiReview.run` in `.devloops` — a boot `command`, an HTTP `readyUrl`, probe
+`readyTimeoutMs`/`readyIntervalMs`, and an optional `migrate` sub-recipe
+(`statusCommand`/`applyCommand`, plus a `destructivePattern` guard).
+
 ## Non-goals
 
-No provision/boot/drive/diagnose/report/teardown logic lives in this scaffold
-slice. This file only names the route so the router, startup resolver, and
-handoff envelope have a first-class entrypoint to bind to.
+No drive/diagnose/report/teardown logic lives here yet, and provision+boot does
+not drive the browser, authenticate, capture screenshots, post the review, or
+touch a production DB — those are later stages.

--- a/skills/ui-review/SKILL.md
+++ b/skills/ui-review/SKILL.md
@@ -35,8 +35,13 @@ or a readiness probe that times out. Every bounded cap is logged.
 
 The run recipe is per-project and never hard-coded: a project declares
 `uiReview.run` in `.devloops` — a boot `command`, an HTTP `readyUrl`, probe
-`readyTimeoutMs`/`readyIntervalMs`, and an optional `migrate` sub-recipe
-(`statusCommand`/`applyCommand`, plus a `destructivePattern` guard).
+`readyTimeoutMs`/`readyIntervalMs`, an optional worktree-relative `cwd`, and an
+optional `migrate` sub-recipe (`statusCommand`/`applyCommand`, plus a
+`destructivePattern` guard).
+
+Threat boundary: the run recipe is branch-controlled, and its `command` is
+executed as a shell command in the worktree. Every later stage inherits this
+assumption — a run recipe is trusted-branch input, not untrusted data.
 
 ## Non-goals
 

--- a/test/loop/ui-review-provision.test.mjs
+++ b/test/loop/ui-review-provision.test.mjs
@@ -73,6 +73,9 @@ function baseSeams(root, overrides = {}) {
       applyMigrations: async () => ({ ok: true, applied: 0, detail: "n/a" }),
       bootApp: async () => ({ pid: 4242, detail: "spawned" }),
       probe: async () => false,
+      // Never fires by default so the probe result decides; the fake clock is
+      // driven by the poll interval, not the per-attempt cap.
+      probeTimeout: () => new Promise(() => {}),
       now: clock.now,
       delay: clock.delay,
       log: (m) => logs.push(m),
@@ -98,6 +101,17 @@ test("parseUiReviewProvisionCliArgs: parses pr, branch, ack flag", () => {
   assert.equal(o.pr, 12);
   assert.equal(o.branch, "b");
   assert.equal(o.ackDestructiveMigration, true);
+});
+
+test("parseUiReviewProvisionCliArgs: --ack-destructive-migration=false does NOT ack (fail closed)", () => {
+  const base = ["--repo-root", "/r", "--pr", "12"];
+  // Bare flag and explicit truthy values ack.
+  assert.equal(parseUiReviewProvisionCliArgs([...base, "--ack-destructive-migration"]).ackDestructiveMigration, true);
+  assert.equal(parseUiReviewProvisionCliArgs([...base, "--ack-destructive-migration=true"]).ackDestructiveMigration, true);
+  // Explicit falsy values must NOT ack — otherwise a destructive migration runs.
+  for (const v of ["false", "0", "no"]) {
+    assert.equal(parseUiReviewProvisionCliArgs([...base, `--ack-destructive-migration=${v}`]).ackDestructiveMigration, false, v);
+  }
 });
 
 test("readiness-probe success: app becomes ready within the timeout", async () => {
@@ -152,6 +166,43 @@ test("throwing probe fails closed to boot-timeout (does not propagate)", async (
   assert.equal(result.stopped, true);
   assert.match(result.stopReason, /readiness probe timed out after 5000ms/);
   assert.ok(result.findings.some((f) => f.kind === "boot-timeout"));
+});
+
+test("hung probe (never resolves) still yields a deterministic boot-timeout", async () => {
+  const root = makeFixture(RECIPE_YAML);
+  const { seams } = baseSeams(root, {
+    probe: () => new Promise(() => {}), // never resolves — would hang without the per-attempt cap
+    probeTimeout: () => Promise.resolve(false), // per-attempt budget elapses immediately
+  });
+
+  const result = await provisionAndBoot({ repoRoot: "/main", pr: 8 }, seams);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.stopped, true);
+  assert.match(result.stopReason, /readiness probe timed out after 5000ms/);
+  assert.ok(result.findings.some((f) => f.kind === "boot-timeout"));
+});
+
+test("run recipe cwd escaping the worktree fails closed (no boot)", async () => {
+  const root = makeFixture(`version: 1
+uiReview:
+  run:
+    command: "true"
+    readyUrl: "http://127.0.0.1:65535/health"
+    cwd: "../.."
+`);
+  let booted = false;
+  const { seams } = baseSeams(root, {
+    bootApp: async () => { booted = true; return { pid: 1, detail: "spawned" }; },
+  });
+
+  const result = await provisionAndBoot({ repoRoot: "/main", pr: 8 }, seams);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.stopped, true);
+  assert.match(result.stopReason, /cwd escapes the provisioned worktree/);
+  assert.ok(result.findings.some((f) => f.kind === "cwd-traversal"));
+  assert.equal(booted, false); // never boots outside the worktree
 });
 
 test("no run recipe -> fail-closed stop before boot", async () => {

--- a/test/loop/ui-review-provision.test.mjs
+++ b/test/loop/ui-review-provision.test.mjs
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { provisionAndBoot } from "@dev-loops/core/loop/ui-review-provision";
-import { loadDevLoopConfig, resolveUiReviewRunRecipe } from "@dev-loops/core/config";
+import { loadDevLoopConfig, resolveUiReviewRunRecipe, DEFAULT_DESTRUCTIVE_MIGRATION_PATTERN } from "@dev-loops/core/config";
 import { parseUiReviewProvisionCliArgs, ensureOwnNodeModules, inspectMigrations } from "../../scripts/loop/ui-review-provision.mjs";
 
 // A "fixture project": a temp dir whose .devloops declares a ui-review run
@@ -290,6 +290,34 @@ test("inspectMigrations: a failing statusCommand fails closed with a non-empty d
 
   assert.ok(result.destructive.length > 0);
   assert.match(result.destructive[0], /migration status failed/);
+});
+
+test("inspectMigrations: DEFAULT destructive pattern flags a real DROP TABLE line end-to-end", async () => {
+  // Positive path: exercise the real regex-match against the shipped default
+  // pattern (no destructivePattern override) so a broken default fails the suite
+  // instead of failing open (running a destructive migration without ack).
+  const worktree = mkdtempSync(path.join(tmpdir(), "ui-prov-migrate-pos-"));
+  tempRoots.push(worktree);
+  const recipe = {
+    migrate: {
+      statusCommand: "echo 'DROP TABLE users'",
+      applyCommand: "true",
+      destructivePattern: DEFAULT_DESTRUCTIVE_MIGRATION_PATTERN,
+    },
+  };
+
+  const result = await inspectMigrations({ worktreePath: worktree, recipe });
+
+  assert.deepEqual(result.pending, ["DROP TABLE users"]);
+  assert.deepEqual(result.destructive, ["DROP TABLE users"]);
+});
+
+test("DEFAULT_DESTRUCTIVE_MIGRATION_PATTERN matches known destructive statements", () => {
+  const re = new RegExp(DEFAULT_DESTRUCTIVE_MIGRATION_PATTERN, "iu");
+  for (const line of ["DROP TABLE users", "TRUNCATE users", "DELETE FROM users"]) {
+    assert.ok(re.test(line), `expected default pattern to flag: ${line}`);
+  }
+  assert.equal(re.test("ADD COLUMN email"), false);
 });
 
 test("ensureOwnNodeModules: leaves a real node_modules alone", () => {

--- a/test/loop/ui-review-provision.test.mjs
+++ b/test/loop/ui-review-provision.test.mjs
@@ -205,6 +205,38 @@ uiReview:
   assert.equal(booted, false); // never boots outside the worktree
 });
 
+test("in-worktree cwd: migrate/boot seams receive the guard-validated absolute cwd (no second derivation)", async () => {
+  // A recipe cwd inside the worktree must flow to migrate + boot as the exact
+  // absolute path the orchestrator resolved and validated — the seams must not
+  // re-join it. This ties the guarded path to the executed path.
+  const root = makeFixture(`version: 1
+uiReview:
+  run:
+    command: "true"
+    readyUrl: "http://127.0.0.1:65535/health"
+    cwd: "app/web"
+    migrate:
+      statusCommand: "true"
+      applyCommand: "true"
+`);
+  const expectedCwd = path.resolve(root, "app/web");
+  const seenCwd = {};
+  const { seams } = baseSeams(root, {
+    inspectMigrations: async ({ runCwd }) => { seenCwd.inspect = runCwd; return { pending: ["001"], destructive: [], detail: "1 pending" }; },
+    applyMigrations: async ({ runCwd }) => { seenCwd.apply = runCwd; return { ok: true, applied: 1, detail: "applied" }; },
+    bootApp: async ({ runCwd }) => { seenCwd.boot = runCwd; return { pid: 1, detail: "spawned" }; },
+    probe: async () => true,
+  });
+
+  const result = await provisionAndBoot({ repoRoot: "/main", pr: 30 }, seams);
+
+  assert.equal(result.ok, true);
+  assert.equal(seenCwd.inspect, expectedCwd);
+  assert.equal(seenCwd.apply, expectedCwd);
+  assert.equal(seenCwd.boot, expectedCwd);
+  assert.equal(path.isAbsolute(seenCwd.boot), true);
+});
+
 test("no run recipe -> fail-closed stop before boot", async () => {
   const root = makeFixture("version: 1\n"); // no uiReview.run
   const { seams } = baseSeams(root);
@@ -353,7 +385,7 @@ test("inspectMigrations: a failing statusCommand fails closed with a non-empty d
   tempRoots.push(worktree);
   const recipe = { migrate: { statusCommand: "exit 1", applyCommand: "true", destructivePattern: "drop" } };
 
-  const result = await inspectMigrations({ worktreePath: worktree, recipe });
+  const result = await inspectMigrations({ recipe, runCwd: worktree });
 
   assert.ok(result.destructive.length > 0);
   assert.match(result.destructive[0], /migration status failed/);
@@ -373,7 +405,7 @@ test("inspectMigrations: DEFAULT destructive pattern flags a real DROP TABLE lin
     },
   };
 
-  const result = await inspectMigrations({ worktreePath: worktree, recipe });
+  const result = await inspectMigrations({ recipe, runCwd: worktree });
 
   assert.deepEqual(result.pending, ["DROP TABLE users"]);
   assert.deepEqual(result.destructive, ["DROP TABLE users"]);

--- a/test/loop/ui-review-provision.test.mjs
+++ b/test/loop/ui-review-provision.test.mjs
@@ -1,12 +1,12 @@
 import assert from "node:assert/strict";
 import test, { after } from "node:test";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { lstatSync, mkdirSync, mkdtempSync, readdirSync, symlinkSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { provisionAndBoot } from "@dev-loops/core/loop/ui-review-provision";
 import { loadDevLoopConfig, resolveUiReviewRunRecipe } from "@dev-loops/core/config";
-import { parseUiReviewProvisionCliArgs } from "../../scripts/loop/ui-review-provision.mjs";
+import { parseUiReviewProvisionCliArgs, ensureOwnNodeModules } from "../../scripts/loop/ui-review-provision.mjs";
 
 // A "fixture project": a temp dir whose .devloops declares a ui-review run
 // recipe. The real config resolver reads it; the rest of the IO is injected.
@@ -70,7 +70,7 @@ function baseSeams(root, overrides = {}) {
       installDeps: async () => ({ ok: true, detail: "npm install" }),
       resolveRunRecipe: async (wt) => resolveUiReviewRunRecipe((await loadDevLoopConfig({ repoRoot: wt })).config),
       inspectMigrations: async () => ({ pending: [], destructive: [], detail: "none" }),
-      applyMigrations: async () => ({ applied: 0, detail: "n/a" }),
+      applyMigrations: async () => ({ ok: true, applied: 0, detail: "n/a" }),
       bootApp: async () => ({ pid: 4242, detail: "spawned" }),
       probe: async () => false,
       now: clock.now,
@@ -85,6 +85,11 @@ function baseSeams(root, overrides = {}) {
 test("parseUiReviewProvisionCliArgs: requires --repo-root and --pr", () => {
   assert.throws(() => parseUiReviewProvisionCliArgs(["--pr", "5"]), /repo-root/);
   assert.throws(() => parseUiReviewProvisionCliArgs(["--repo-root", "/r"]), /--pr/);
+});
+
+test("parseUiReviewProvisionCliArgs: rejects a non-integer --pr", () => {
+  assert.throws(() => parseUiReviewProvisionCliArgs(["--repo-root", "/r", "--pr", "abc"]), /positive integer/);
+  assert.throws(() => parseUiReviewProvisionCliArgs(["--repo-root", "/r", "--pr", "0"]), /positive integer/);
 });
 
 test("parseUiReviewProvisionCliArgs: parses pr, branch, ack flag", () => {
@@ -157,7 +162,7 @@ test("destructive migration requires explicit ack (fail closed)", async () => {
   // Without ack: stops, nothing applied.
   const blocked = await provisionAndBoot(
     { repoRoot: "/main", pr: 10 },
-    baseSeams(root, { inspectMigrations, applyMigrations: async () => { applied = true; return { applied: 1, detail: "x" }; } }).seams,
+    baseSeams(root, { inspectMigrations, applyMigrations: async () => { applied = true; return { ok: true, applied: 1, detail: "x" }; } }).seams,
   );
   assert.equal(blocked.ok, false);
   assert.equal(applied, false);
@@ -169,7 +174,7 @@ test("destructive migration requires explicit ack (fail closed)", async () => {
     { repoRoot: "/main", pr: 10, ackDestructiveMigration: true },
     baseSeams(root, {
       inspectMigrations,
-      applyMigrations: async () => ({ applied: 1, detail: "applied" }),
+      applyMigrations: async () => ({ ok: true, applied: 1, detail: "applied" }),
       probe: async () => (++probed >= 1),
     }).seams,
   );
@@ -192,4 +197,93 @@ test("dependency-lock delta triggers a scoped install (logged)", async () => {
   assert.equal(installed, true);
   assert.equal(result.depInstall.installed, true);
   assert.ok(logs.some((l) => /delta detected/.test(l)));
+});
+
+test("dependency install failure -> fail-closed stop before boot", async () => {
+  const root = makeFixture(RECIPE_YAML);
+  let booted = false;
+  const { seams } = baseSeams(root, {
+    detectDepDelta: async () => ({ changed: true, detail: "differs" }),
+    installDeps: async () => ({ ok: false, detail: "npm ERR! boom" }),
+    bootApp: async () => { booted = true; return { pid: 1, detail: "spawned" }; },
+  });
+
+  const result = await provisionAndBoot({ repoRoot: "/main", pr: 20 }, seams);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.stopped, true);
+  assert.match(result.stopReason, /dependency install failed/);
+  assert.ok(result.findings.some((f) => f.kind === "dep-install"));
+  assert.equal(booted, false); // never boots after a failed install
+});
+
+test("migration apply failure -> fail-closed stop before boot", async () => {
+  const root = makeFixture(RECIPE_WITH_MIGRATE_YAML);
+  let booted = false;
+  const { seams } = baseSeams(root, {
+    inspectMigrations: async () => ({ pending: ["001_add_col"], destructive: [], detail: "1 pending" }),
+    applyMigrations: async () => ({ ok: false, applied: 0, detail: "apply failed: exit 1" }),
+    bootApp: async () => { booted = true; return { pid: 1, detail: "spawned" }; },
+  });
+
+  const result = await provisionAndBoot({ repoRoot: "/main", pr: 21 }, seams);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.stopped, true);
+  assert.match(result.stopReason, /migration apply failed/);
+  assert.ok(result.findings.some((f) => f.kind === "migration-apply"));
+  assert.equal(result.migrations.applied, 0);
+  assert.equal(booted, false); // a failed apply never proceeds to boot
+});
+
+test("worktree guard: refuses to operate in the primary checkout", async () => {
+  const root = makeFixture(RECIPE_YAML);
+  let booted = false;
+  const { seams } = baseSeams(root, {
+    assertNotPrimary: () => ({ ok: false, message: "/repo resolves to the primary checkout" }),
+    bootApp: async () => { booted = true; return { pid: 1, detail: "spawned" }; },
+  });
+
+  const result = await provisionAndBoot({ repoRoot: "/main", pr: 22 }, seams);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.stopped, true);
+  assert.match(result.stopReason, /primary checkout/);
+  assert.ok(result.findings.some((f) => f.kind === "worktree-guard"));
+  assert.equal(booted, false);
+});
+
+test("ensureOwnNodeModules: materializes a symlinked node_modules without touching the primary", () => {
+  // Primary checkout with a real node_modules holding one package.
+  const primary = mkdtempSync(path.join(tmpdir(), "ui-prov-primary-"));
+  tempRoots.push(primary);
+  const primaryNm = path.join(primary, "node_modules");
+  mkdirSync(path.join(primaryNm, "left-pad"), { recursive: true });
+  writeFileSync(path.join(primaryNm, "left-pad", "index.js"), "module.exports = 1;\n");
+
+  // Worktree whose node_modules is a symlink into the primary (linkOnInit).
+  const worktree = mkdtempSync(path.join(tmpdir(), "ui-prov-wt-"));
+  tempRoots.push(worktree);
+  symlinkSync(primaryNm, path.join(worktree, "node_modules"));
+
+  const materialized = ensureOwnNodeModules(worktree);
+
+  assert.equal(materialized, true);
+  // Worktree now owns a real (empty) node_modules — not a symlink.
+  const st = lstatSync(path.join(worktree, "node_modules"));
+  assert.equal(st.isSymbolicLink(), false);
+  assert.equal(st.isDirectory(), true);
+  assert.deepEqual(readdirSync(path.join(worktree, "node_modules")), []);
+  // The primary's real node_modules is untouched — an install would go here
+  // if we had written through the symlink.
+  assert.deepEqual(readdirSync(primaryNm), ["left-pad"]);
+});
+
+test("ensureOwnNodeModules: leaves a real node_modules alone", () => {
+  const worktree = mkdtempSync(path.join(tmpdir(), "ui-prov-real-"));
+  tempRoots.push(worktree);
+  mkdirSync(path.join(worktree, "node_modules"));
+
+  assert.equal(ensureOwnNodeModules(worktree), false);
+  assert.equal(lstatSync(path.join(worktree, "node_modules")).isDirectory(), true);
 });

--- a/test/loop/ui-review-provision.test.mjs
+++ b/test/loop/ui-review-provision.test.mjs
@@ -138,6 +138,22 @@ test("boot-timeout stop: probe never succeeds -> stop with a stated reason", asy
   assert.ok(logs.some((l) => /boot timeout/.test(l)));
 });
 
+test("throwing probe fails closed to boot-timeout (does not propagate)", async () => {
+  const root = makeFixture(RECIPE_YAML);
+  const { seams } = baseSeams(root, {
+    probe: async () => {
+      throw new Error("probe blew up");
+    },
+  });
+
+  const result = await provisionAndBoot({ repoRoot: "/main", pr: 8 }, seams);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.stopped, true);
+  assert.match(result.stopReason, /readiness probe timed out after 5000ms/);
+  assert.ok(result.findings.some((f) => f.kind === "boot-timeout"));
+});
+
 test("no run recipe -> fail-closed stop before boot", async () => {
   const root = makeFixture("version: 1\n"); // no uiReview.run
   const { seams } = baseSeams(root);

--- a/test/loop/ui-review-provision.test.mjs
+++ b/test/loop/ui-review-provision.test.mjs
@@ -6,7 +6,7 @@ import path from "node:path";
 
 import { provisionAndBoot } from "@dev-loops/core/loop/ui-review-provision";
 import { loadDevLoopConfig, resolveUiReviewRunRecipe } from "@dev-loops/core/config";
-import { parseUiReviewProvisionCliArgs, ensureOwnNodeModules } from "../../scripts/loop/ui-review-provision.mjs";
+import { parseUiReviewProvisionCliArgs, ensureOwnNodeModules, inspectMigrations } from "../../scripts/loop/ui-review-provision.mjs";
 
 // A "fixture project": a temp dir whose .devloops declares a ui-review run
 // recipe. The real config resolver reads it; the rest of the IO is injected.
@@ -277,6 +277,19 @@ test("ensureOwnNodeModules: materializes a symlinked node_modules without touchi
   // The primary's real node_modules is untouched — an install would go here
   // if we had written through the symlink.
   assert.deepEqual(readdirSync(primaryNm), ["left-pad"]);
+});
+
+test("inspectMigrations: a failing statusCommand fails closed with a non-empty destructive[]", async () => {
+  // The decision seam: if migration state cannot be verified, it must synthesize
+  // a destructive finding so the orchestrator blocks (not return destructive: []).
+  const worktree = mkdtempSync(path.join(tmpdir(), "ui-prov-migrate-"));
+  tempRoots.push(worktree);
+  const recipe = { migrate: { statusCommand: "exit 1", applyCommand: "true", destructivePattern: "drop" } };
+
+  const result = await inspectMigrations({ worktreePath: worktree, recipe });
+
+  assert.ok(result.destructive.length > 0);
+  assert.match(result.destructive[0], /migration status failed/);
 });
 
 test("ensureOwnNodeModules: leaves a real node_modules alone", () => {

--- a/test/loop/ui-review-provision.test.mjs
+++ b/test/loop/ui-review-provision.test.mjs
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import test, { after } from "node:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { provisionAndBoot } from "@dev-loops/core/loop/ui-review-provision";
+import { loadDevLoopConfig, resolveUiReviewRunRecipe } from "@dev-loops/core/config";
+import { parseUiReviewProvisionCliArgs } from "../../scripts/loop/ui-review-provision.mjs";
+
+// A "fixture project": a temp dir whose .devloops declares a ui-review run
+// recipe. The real config resolver reads it; the rest of the IO is injected.
+const tempRoots = [];
+function makeFixture(devloops) {
+  const root = mkdtempSync(path.join(tmpdir(), "ui-prov-"));
+  writeFileSync(path.join(root, ".devloops"), devloops);
+  tempRoots.push(root);
+  return root;
+}
+
+after(() => {
+  for (const root of tempRoots) rmSync(root, { recursive: true, force: true });
+}
+);
+
+// Deterministic clock: delay() advances a mutable counter that now() reads, so
+// the readiness poll's timeout is exercised without any real sleeping.
+function fakeClock() {
+  const state = { t: 0 };
+  return {
+    now: () => state.t,
+    delay: (ms) => {
+      state.t += ms;
+      return Promise.resolve();
+    },
+  };
+}
+
+const RECIPE_YAML = `version: 1
+uiReview:
+  run:
+    command: "true"
+    readyUrl: "http://127.0.0.1:65535/health"
+    readyTimeoutMs: 5000
+    readyIntervalMs: 1000
+`;
+
+const RECIPE_WITH_MIGRATE_YAML = `version: 1
+uiReview:
+  run:
+    command: "true"
+    readyUrl: "http://127.0.0.1:65535/health"
+    readyTimeoutMs: 5000
+    readyIntervalMs: 1000
+    migrate:
+      statusCommand: "true"
+      applyCommand: "true"
+`;
+
+// Base seams: a provisioned worktree, a clean guard, no dep delta, no migrate,
+// a no-op boot. Individual tests override probe/recipe/etc.
+function baseSeams(root, overrides = {}) {
+  const clock = fakeClock();
+  const logs = [];
+  return {
+    seams: {
+      ensureWorktree: async () => ({ path: root, created: true, reused: false }),
+      assertNotPrimary: () => ({ ok: true, mainWorktreePath: "/some/main" }),
+      detectDepDelta: async () => ({ changed: false, detail: "identical" }),
+      installDeps: async () => ({ ok: true, detail: "npm install" }),
+      resolveRunRecipe: async (wt) => resolveUiReviewRunRecipe((await loadDevLoopConfig({ repoRoot: wt })).config),
+      inspectMigrations: async () => ({ pending: [], destructive: [], detail: "none" }),
+      applyMigrations: async () => ({ applied: 0, detail: "n/a" }),
+      bootApp: async () => ({ pid: 4242, detail: "spawned" }),
+      probe: async () => false,
+      now: clock.now,
+      delay: clock.delay,
+      log: (m) => logs.push(m),
+      ...overrides,
+    },
+    logs,
+  };
+}
+
+test("parseUiReviewProvisionCliArgs: requires --repo-root and --pr", () => {
+  assert.throws(() => parseUiReviewProvisionCliArgs(["--pr", "5"]), /repo-root/);
+  assert.throws(() => parseUiReviewProvisionCliArgs(["--repo-root", "/r"]), /--pr/);
+});
+
+test("parseUiReviewProvisionCliArgs: parses pr, branch, ack flag", () => {
+  const o = parseUiReviewProvisionCliArgs(["--repo-root", "/r", "--pr", "12", "--branch", "b", "--ack-destructive-migration"]);
+  assert.equal(o.repoRoot, "/r");
+  assert.equal(o.pr, 12);
+  assert.equal(o.branch, "b");
+  assert.equal(o.ackDestructiveMigration, true);
+});
+
+test("readiness-probe success: app becomes ready within the timeout", async () => {
+  const root = makeFixture(RECIPE_YAML);
+  let calls = 0;
+  const { seams, logs } = baseSeams(root, {
+    probe: async () => {
+      calls += 1;
+      return calls >= 2; // not ready on the first poll, ready on the second
+    },
+  });
+
+  const result = await provisionAndBoot({ repoRoot: "/main", pr: 7 }, seams);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.stopped, false);
+  assert.equal(result.stopReason, null);
+  assert.equal(result.boot.ready, true);
+  assert.equal(result.boot.attempts, 2);
+  assert.equal(result.worktreePath, root);
+  // The install-skipped cap is logged, not silently dropped.
+  assert.ok(logs.some((l) => /install skipped/.test(l)));
+  assert.ok(logs.some((l) => /app ready/.test(l)));
+});
+
+test("boot-timeout stop: probe never succeeds -> stop with a stated reason", async () => {
+  const root = makeFixture(RECIPE_YAML);
+  const { seams, logs } = baseSeams(root, { probe: async () => false });
+
+  const result = await provisionAndBoot({ repoRoot: "/main", pr: 8 }, seams);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.stopped, true);
+  assert.match(result.stopReason, /readiness probe timed out after 5000ms/);
+  assert.equal(result.boot.ready, false);
+  assert.ok(result.findings.some((f) => f.kind === "boot-timeout"));
+  // The boot-timeout cap is logged (no silent truncation).
+  assert.ok(logs.some((l) => /boot timeout/.test(l)));
+});
+
+test("no run recipe -> fail-closed stop before boot", async () => {
+  const root = makeFixture("version: 1\n"); // no uiReview.run
+  const { seams } = baseSeams(root);
+
+  const result = await provisionAndBoot({ repoRoot: "/main", pr: 9 }, seams);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.stopped, true);
+  assert.match(result.stopReason, /no run recipe/);
+  assert.ok(result.findings.some((f) => f.kind === "run-recipe-missing"));
+});
+
+test("destructive migration requires explicit ack (fail closed)", async () => {
+  const root = makeFixture(RECIPE_WITH_MIGRATE_YAML);
+  const inspectMigrations = async () => ({
+    pending: ["DROP TABLE users"],
+    destructive: ["DROP TABLE users"],
+    detail: "1 destructive",
+  });
+  let applied = false;
+
+  // Without ack: stops, nothing applied.
+  const blocked = await provisionAndBoot(
+    { repoRoot: "/main", pr: 10 },
+    baseSeams(root, { inspectMigrations, applyMigrations: async () => { applied = true; return { applied: 1, detail: "x" }; } }).seams,
+  );
+  assert.equal(blocked.ok, false);
+  assert.equal(applied, false);
+  assert.ok(blocked.findings.some((f) => f.kind === "destructive-migration" && f.requiresAck === true));
+
+  // With ack: proceeds past migrations (then boots + is probed).
+  let probed = 0;
+  const acked = await provisionAndBoot(
+    { repoRoot: "/main", pr: 10, ackDestructiveMigration: true },
+    baseSeams(root, {
+      inspectMigrations,
+      applyMigrations: async () => ({ applied: 1, detail: "applied" }),
+      probe: async () => (++probed >= 1),
+    }).seams,
+  );
+  assert.equal(acked.ok, true);
+  assert.equal(acked.migrations.applied, 1);
+});
+
+test("dependency-lock delta triggers a scoped install (logged)", async () => {
+  const root = makeFixture(RECIPE_YAML);
+  let installed = false;
+  const { seams, logs } = baseSeams(root, {
+    detectDepDelta: async () => ({ changed: true, detail: "package-lock.json differs" }),
+    installDeps: async () => { installed = true; return { ok: true, detail: "npm install" }; },
+    probe: async () => true,
+  });
+
+  const result = await provisionAndBoot({ repoRoot: "/main", pr: 11 }, seams);
+
+  assert.equal(result.ok, true);
+  assert.equal(installed, true);
+  assert.equal(result.depInstall.installed, true);
+  assert.ok(logs.some((l) => /delta detected/.test(l)));
+});


### PR DESCRIPTION
## Summary

Stage 1 of epic #1114 (`/loop-review-ui`). A fail-closed **provision + boot** orchestrator for the `ui_review` route: provisions an isolated worktree for a PR head and boots the branch's app to a ready state, reusing the existing worktree machinery and never touching the primary checkout.

## Scope and context

In scope: the provision+boot module + thin CLI, a `uiReview` config surface (run-recipe hook + migration commands), a dep-lock-delta-gated install (a full `npm install`, triggered only on a lockfile delta), dev-DB migration safety with destructive-ack, an HTTP readiness probe with explicit timeout, and a fixture test covering success + timeout-stop paths. Out of scope (Stage 2+ / Non-goals): browser driving, auth, screenshots, review posting, production DB, hard-coded per-project recipes, boot-process teardown (Stage 5).

## File-by-file changes

- `packages/core/src/loop/ui-review-provision.mjs` (new) — pure `provisionAndBoot` orchestrator (injectable fs/spawn/clock/probe for testability).
- `scripts/loop/ui-review-provision.mjs` (new) — thin CLI (`--repo-root --pr [--branch] [--ack-destructive-migration]`) on the shared jq-output emit path (`--jq`/`--silent`).
- `packages/core/src/config/config.mjs` — `uiReview` zod schema (`run` + `migrate`), `resolveUiReviewRunRecipe`, `DEFAULT_DESTRUCTIVE_MIGRATION_PATTERN`.
- `packages/core/package.json` — `./loop/ui-review-provision` export.
- `test/loop/ui-review-provision.test.mjs` (new) — fixture-project test.
- `packages/core/test/config.test.mjs` — config-schema tests for `uiReview` run/migrate validation (readyUrl URL check, destructivePattern regex refine).
- `skills/ui-review/SKILL.md` + regenerated `.claude/skills/ui-review/SKILL.md` — document provision+boot as the route's first operational step.

## Acceptance criteria

Mirrors the 8 AC items in #1117: worktree create-or-reuse via `ensure-worktree.mjs` (never primary checkout, guarded); symlink deps/config via `provision-worktree.mjs`; a dep-lock-delta-gated install (a full `npm install`, run only when the lockfile differs from the primary checkout); dev-DB migrations with destructive-ack fail-closed stop; per-project run-recipe hook (generic, no hard-coded recipes); readiness probe (no fixed sleep); every bounded cap logged; fixture test covering readiness-success + boot-timeout-stop.

## Definition of done

Given a UI PR, the stage produces a booted, ready app in an isolated worktree with deps/config linked and dev-DB migrations applied (or a clean stop with a stated reason), leaving the primary checkout untouched. Side effects (migrations run) are enumerated for Stage 5. Verified by the fixture test (both paths) and full `test:loop` green.

## Non-goals

No browser driving, auth, screenshots, or review posting. No production DB. No hard-coded per-project run/login recipes. No boot-process lifecycle/teardown (Stage 5).

## Validation

- `node --test test/loop/ui-review-provision.test.mjs` (21 pass).
- `npm run test:core` (config schema), `npm run test:docs`, `npm run test:assets`.
- jq-output + cli-invocation contract tests (base-CLI guarantee for the new CLI).
- Full gate uses `npm run verify`.

Closes #1117
