### PR TITLE
feat(loop): auth + Playwright drive harness for ui_review (Stage 2 of #1114)

### DIFF
--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -62,11 +62,13 @@ its declared create/edit/reorder/upload/toggle interactions — capturing a step
 screenshot + sibling `state.json` per step via `captureNamedUiState`. It fails
 closed to a stated stop reason when it cannot authenticate, and drives nothing.
 
-Throughout the walk, `response` (non-2xx), `requestfailed`, and `pageerror`
-listeners run and the project server log is tailed, so a swallowed non-2xx (a 500
-the UI hides behind a success state) is still recorded. The stage emits an
-ordered set of step screenshots plus a structured captured-failures list
-(non-2xx responses, request failures, page errors, server-log exceptions) that
+Throughout the walk, `response`, `requestfailed`, and `pageerror` listeners run
+and the project server log is tailed, so a swallowed error response (a 500 the UI
+hides behind a success state) is still recorded. An error response is a status
+<200 or >=400; 3xx redirects are normal navigation (login/canonical) and are not
+flagged. The stage emits an ordered set of step screenshots plus a structured
+captured-failures list (error responses, request failures, page errors,
+server-log exceptions) that
 feeds the next stage. Every bounded cap — max screenshots, screens skipped, and
 the fixed no-retry policy — is logged explicitly.
 

--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -49,8 +49,46 @@ Threat boundary: the run recipe is branch-controlled, and its `command` is
 executed as a shell command in the worktree. Every later stage inherits this
 assumption — a run recipe is trusted-branch input, not untrusted data.
 
+## Drive
+
+Once the app is booted, the route drives the changed UI flows against the
+handed-off app URL via
+`scripts/loop/ui-review-drive.mjs --repo-root <p> --app-url <url> --output-dir <p> [--changed-path <p> ...]`
+(pure orchestration in `packages/core/src/loop/ui-review-drive.mjs`). It launches
+one headless WebKit context, authenticates as the change's target role through a
+project-provided dev-login recipe, dismisses config-declared interstitials once
+per context, then walks the selected flows — rendering each page and exercising
+its declared create/edit/reorder/upload/toggle interactions — capturing a step
+screenshot + sibling `state.json` per step via `captureNamedUiState`. It fails
+closed to a stated stop reason when it cannot authenticate, and drives nothing.
+
+Throughout the walk, `response` (non-2xx), `requestfailed`, and `pageerror`
+listeners run and the project server log is tailed, so a swallowed non-2xx (a 500
+the UI hides behind a success state) is still recorded. The stage emits an
+ordered set of step screenshots plus a structured captured-failures list
+(non-2xx responses, request failures, page errors, server-log exceptions) that
+feeds the next stage. Every bounded cap — max screenshots, screens skipped, and
+the fixed no-retry policy — is logged explicitly.
+
+Which flows are driven is a bounded heuristic over an explicit allowlist, never
+an unbounded crawl: each `uiReview.flows` entry declares `pathPatterns` matched
+against the PR's changed file paths; an entry with none is always driven, and an
+unknown diff drives every allowlisted flow. The selection is capped and the
+overflow logged.
+
+The drive recipe is per-project and never hard-coded: a project declares
+`uiReview.login` (a `loginUrl`, optional username/password field selectors with
+their dev-only values, a `submitSelector`, and a `successSelector` proving the
+session), optional `interstitials` (dismiss selectors), the `flows` allowlist,
+optional `caps` (clamped to the shipped ceilings — a project may only tighten
+them), and an optional `serverLogPath` (with a `serverLogExceptionPattern`
+defaulting to a heuristic that a project MUST override when its log format
+differs). The login form is branch-controlled trusted input, same threat
+boundary as the run recipe.
+
 ## Non-goals
 
-No drive/diagnose/report/teardown logic lives here yet, and provision+boot does
-not drive the browser, authenticate, capture screenshots, post the review, or
-touch a production DB — those are later stages.
+No diagnose/report/teardown logic lives here yet. The drive stage does not map an
+exception to its source line, post the review, pixel-diff for visual regression,
+run a cross-browser matrix, or touch a production DB — those are later stages or
+explicit non-goals.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:playwright:deep-dive": "PW_UI_SLICE=deep-dive-deck playwright test --project=deep-dive-deck",
     "test:playwright:intro-deck": "PW_UI_SLICE=intro-deck playwright test --project=intro-deck",
     "test:playwright:intro-article": "PW_UI_SLICE=intro-article playwright test --project=intro-article",
+    "test:playwright:ui-review-drive": "PW_UI_SLICE=ui-review-drive playwright test --project=ui-review-drive",
     "test:playwright:deep-dive-article": "PW_UI_SLICE=deep-dive-article playwright test --project=deep-dive-article",
     "smoke:headless": "node scripts/claude/headless-info-smoke.mjs",
     "test:docs": "node scripts/docs/validate-links.mjs && node scripts/docs/validate-rule-ownership.mjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,6 +58,7 @@
     "./loop/tracker-pr-state": "./src/loop/tracker-pr-state.mjs",
     "./loop/ui-e2e-scoping": "./src/loop/ui-e2e-scoping.mjs",
     "./loop/ui-review-provision": "./src/loop/ui-review-provision.mjs",
+    "./loop/ui-review-drive": "./src/loop/ui-review-drive.mjs",
     "./projects/list-queue-items": "./src/projects/list-queue-items.mjs",
     "./projects/move-queue-item": "./src/projects/move-queue-item.mjs",
     "./projects/resolve-project": "./src/projects/resolve-project.mjs",

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -270,11 +270,9 @@ const UiReviewLoginConfig = z.strictObject({
 });
 
 /** A config-declared interstitial (cookie consent etc.) dismissed ONCE per
- * browser context. `optional` (default true): a missing interstitial is not a
- * failure — it simply was not shown this run. */
+ * browser context. */
 const UiReviewInterstitialConfig = z.strictObject({
   selector: z.string().trim().min(1),
-  optional: z.boolean().default(true),
 });
 
 /** One driven step. The action set is deliberately small and maps 1:1 to a
@@ -287,6 +285,12 @@ const UiReviewFlowStepConfig = z.strictObject({
   path: z.string().trim().min(1).optional(),
   value: z.string().optional(),
   event: z.string().trim().min(1).optional(),
+}).superRefine((step, ctx) => {
+  // Every action but `goto` targets an element, so a missing selector is a
+  // config error, not a runtime step-failure. (`goto` uses `path`/url.)
+  if (step.action !== "goto" && (step.selector == null || step.selector.trim().length === 0)) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["selector"], message: `step action "${step.action}" requires a selector` });
+  }
 });
 
 /** An allowlisted changed flow. `pathPatterns` are plain substrings matched
@@ -1636,7 +1640,7 @@ export function resolveUiReviewDriveRecipe(config) {
       successSelector: login.successSelector.trim(),
     },
     interstitials: Array.isArray(ui.interstitials)
-      ? ui.interstitials.map((i) => ({ selector: i.selector, optional: i.optional !== false }))
+      ? ui.interstitials.map((i) => ({ selector: i.selector }))
       : [],
     flows: Array.isArray(ui.flows) ? ui.flows : [],
     caps: ui.caps ?? {},

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -291,6 +291,16 @@ const UiReviewFlowStepConfig = z.strictObject({
   if (step.action !== "goto" && (step.selector == null || step.selector.trim().length === 0)) {
     ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["selector"], message: `step action "${step.action}" requires a selector` });
   }
+  // Action-specific required fields. Rejecting these at parse time turns a silent
+  // wrong drive into a clear config error: a missing `goto.path` would drive "/",
+  // and a missing `upload.value` becomes setInputFiles(sel, "") which throws mid
+  // walk as a step-failure rather than a config problem.
+  if (step.action === "goto" && (step.path == null || step.path.trim().length === 0)) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["path"], message: `step action "goto" requires a path` });
+  }
+  if (step.action === "upload" && (step.value == null || step.value.trim().length === 0)) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["value"], message: `step action "upload" requires a value (the file path to upload)` });
+  }
 });
 
 /** An allowlisted changed flow. `pathPatterns` are plain substrings matched

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -241,12 +241,100 @@ const UiReviewRunConfig = z.strictObject({
 });
 
 /**
- * UI-review route config: the generic, per-project provision+boot recipe. Absent
- * (the default) means no bootable recipe is declared — the provision+boot stage
- * stops with that as a stated reason rather than guessing how to run the app.
+ * Per-project dev-login recipe (Stage 2). The drive stage obtains a session for
+ * the change's target role by driving this login form in the browser. Nothing
+ * is hard-coded here — a project declares its own login URL, field selectors,
+ * and the shared dev credential (never a real user secret; a dev-only password
+ * or role). `successSelector` is what proves the session was established;
+ * without it the drive stage cannot confirm auth and fails closed.
+ */
+const UiReviewLoginConfig = z.strictObject({
+  loginUrl: z
+    .string()
+    .trim()
+    .url()
+    .refine((u) => {
+      try {
+        const p = new URL(u).protocol;
+        return p === "http:" || p === "https:";
+      } catch {
+        return false;
+      }
+    }, "loginUrl must be an http(s) URL"),
+  usernameSelector: z.string().trim().min(1).optional(),
+  usernameValue: z.string().min(1).optional(),
+  passwordSelector: z.string().trim().min(1).optional(),
+  passwordValue: z.string().min(1).optional(),
+  submitSelector: z.string().trim().min(1),
+  successSelector: z.string().trim().min(1),
+});
+
+/** A config-declared interstitial (cookie consent etc.) dismissed ONCE per
+ * browser context. `optional` (default true): a missing interstitial is not a
+ * failure — it simply was not shown this run. */
+const UiReviewInterstitialConfig = z.strictObject({
+  selector: z.string().trim().min(1),
+  optional: z.boolean().default(true),
+});
+
+/** One driven step. The action set is deliberately small and maps 1:1 to a
+ * Playwright page call in the harness — enough to render a page and exercise the
+ * create/edit/reorder/upload/toggle interactions plus dispatch a real event. */
+const UiReviewFlowStepConfig = z.strictObject({
+  name: z.string().trim().min(1).optional(),
+  action: z.enum(["goto", "click", "fill", "select", "upload", "dispatch"]),
+  selector: z.string().trim().min(1).optional(),
+  path: z.string().trim().min(1).optional(),
+  value: z.string().optional(),
+  event: z.string().trim().min(1).optional(),
+});
+
+/** An allowlisted changed flow. `pathPatterns` are plain substrings matched
+ * against the PR's changed file paths to decide whether the flow is in scope
+ * (the bounded changed-flow heuristic); a flow with none is always driven. */
+const UiReviewFlowConfig = z.strictObject({
+  name: z.string().trim().min(1),
+  pathPatterns: z.array(z.string().trim().min(1)).optional(),
+  steps: z.array(UiReviewFlowStepConfig).min(1),
+});
+
+/** Bounded drive caps (Stage 2). Every field is optional and clamped to a
+ * ceiling at resolve time — a project may only tighten a cap, never loosen it. */
+const UiReviewCapsConfig = z.strictObject({
+  maxScreenshots: z.number().int().min(1).optional(),
+  maxFlows: z.number().int().min(1).optional(),
+  maxStepsPerFlow: z.number().int().min(1).optional(),
+});
+
+/**
+ * UI-review route config: the generic, per-project provision+boot recipe (Stage
+ * 1) plus the drive recipe (Stage 2: login, interstitials, changed-flow
+ * allowlist, and an optional server-log path/pattern for tailing). Absent (the
+ * default) means no recipe is declared — the corresponding stage stops with that
+ * as a stated reason rather than guessing how to run or drive the app.
  */
 const UiReviewConfig = z.strictObject({
   run: UiReviewRunConfig.optional(),
+  login: UiReviewLoginConfig.optional(),
+  interstitials: z.array(UiReviewInterstitialConfig).optional(),
+  flows: z.array(UiReviewFlowConfig).optional(),
+  caps: UiReviewCapsConfig.optional(),
+  // Filesystem path (worktree-relative or absolute) to the project's server log.
+  // The drive stage tails it so a swallowed 500 the UI hid is still recorded.
+  serverLogPath: z.string().trim().min(1).optional(),
+  serverLogExceptionPattern: z
+    .string()
+    .trim()
+    .min(1)
+    .refine((p) => {
+      try {
+        new RegExp(p, "iu");
+        return true;
+      } catch {
+        return false;
+      }
+    }, "serverLogExceptionPattern must be a valid regex")
+    .optional(),
 });
 
 /** Internal path whitelist for internal-only PR detection — flat array of regex strings */
@@ -1504,6 +1592,59 @@ export function resolveUiReviewRunRecipe(config) {
     readyIntervalMs: Number.isInteger(run.readyIntervalMs) ? run.readyIntervalMs : 1000,
     cwd: typeof run.cwd === "string" && run.cwd.trim().length > 0 ? run.cwd.trim() : null,
     migrate,
+  };
+}
+
+/**
+ * Default server-log exception signal for the drive stage's log tail. Matched
+ * (case-insensitive, per line) against the tailed server-log text. This is a
+ * HEURISTIC default tuned for common framework logs (a 5xx status, an
+ * uncaught/unhandled marker, an exception/traceback). A project whose log format
+ * these miss MUST override `uiReview.serverLogExceptionPattern` to match its own
+ * server log — the default cannot detect what its log never prints.
+ */
+export const DEFAULT_SERVER_LOG_EXCEPTION_PATTERN =
+  "\\b(5\\d{2}\\b|Internal Server Error|Unhandled|Uncaught|Traceback|Exception|FATAL|\\bERROR\\b)";
+
+/**
+ * Resolve the ui-review drive recipe (Stage 2) from the merged config.
+ *
+ * Returns null when no `uiReview.login` is declared — the drive stage treats
+ * that as a stated stop reason (it cannot authenticate, so it drives nothing).
+ * The server-log exception pattern falls back to the shipped heuristic default
+ * when a `serverLogPath` is set without an explicit pattern.
+ *
+ * @param {DevLoopConfig} config
+ * @returns {null | { login: object, interstitials: object[], flows: object[],
+ *   caps: object, serverLogPath: string|null, serverLogExceptionPattern: string }}
+ */
+export function resolveUiReviewDriveRecipe(config) {
+  const ui = config?.uiReview;
+  const login = ui?.login;
+  if (!login || typeof login.loginUrl !== "string" || login.loginUrl.trim().length === 0) return null;
+  if (typeof login.submitSelector !== "string" || login.submitSelector.trim().length === 0) return null;
+  if (typeof login.successSelector !== "string" || login.successSelector.trim().length === 0) return null;
+  const serverLogPath = typeof ui.serverLogPath === "string" && ui.serverLogPath.trim().length > 0 ? ui.serverLogPath.trim() : null;
+  return {
+    login: {
+      loginUrl: login.loginUrl.trim(),
+      usernameSelector: login.usernameSelector ?? null,
+      usernameValue: login.usernameValue ?? null,
+      passwordSelector: login.passwordSelector ?? null,
+      passwordValue: login.passwordValue ?? null,
+      submitSelector: login.submitSelector.trim(),
+      successSelector: login.successSelector.trim(),
+    },
+    interstitials: Array.isArray(ui.interstitials)
+      ? ui.interstitials.map((i) => ({ selector: i.selector, optional: i.optional !== false }))
+      : [],
+    flows: Array.isArray(ui.flows) ? ui.flows : [],
+    caps: ui.caps ?? {},
+    serverLogPath,
+    serverLogExceptionPattern:
+      typeof ui.serverLogExceptionPattern === "string" && ui.serverLogExceptionPattern.trim().length > 0
+        ? ui.serverLogExceptionPattern.trim()
+        : DEFAULT_SERVER_LOG_EXCEPTION_PATTERN,
   };
 }
 

--- a/packages/core/src/loop/ui-review-drive.mjs
+++ b/packages/core/src/loop/ui-review-drive.mjs
@@ -6,7 +6,7 @@
  * handed off by Stage 1 — rendering each page, exercising its declared
  * interactions, and capturing an ordered set of step screenshots. While it
  * drives, response/requestfailed/pageerror listeners and a server-log tail run
- * so a swallowed non-2xx (a 500 the UI hides) is still recorded.
+ * so a swallowed error response (a 500 the UI hides) is still recorded.
  *
  * This module is PURE orchestration: all browser/page IO, the auth recipe, the
  * interstitial dismissal, the per-step capture, the event collection, and the
@@ -14,7 +14,7 @@
  * (WebKit). The decision logic that lives here is: which flows to drive
  * (a bounded changed-flow heuristic over an explicit allowlist), cap
  * enforcement (max screenshots, screens skipped, no-retry) with explicit logs,
- * and failure classification (collating non-2xx responses, request failures,
+ * and failure classification (collating error responses, request failures,
  * page errors, and server-log exceptions into one structured list).
  *
  * Fail closed: a can't-authenticate condition STOPS with a stated reason and
@@ -89,9 +89,9 @@ export function selectFlows({ flows = [], changedPaths = [], caps = DEFAULT_DRIV
 
 /**
  * Classify raw captured events + the server-log tail into one structured failure
- * list. Pure. This is where a swallowed non-2xx surfaces twice — once from the
- * response listener and once from the server-log tail — so a 500 the UI hid is
- * still recorded.
+ * list. Pure. This is where a swallowed error response surfaces twice — once
+ * from the response listener and once from the server-log tail — so a 500 the UI
+ * hid is still recorded.
  *
  * @param {object} input
  * @param {{url?:string,status:number}[]} [input.responses] - from page.on('response')
@@ -111,15 +111,17 @@ export function classifyFailures({
   const failures = [];
 
   for (const r of responses) {
-    // Non-2xx = anything outside 2xx/3xx. A swallowed 500 lands here even when
-    // the page rendered a success state, because the listener sees the wire.
+    // An error response is anything outside 2xx/3xx (status <200 or >=400). 3xx
+    // redirects are normal navigation (login/canonical), not errors, so they are
+    // not flagged. A swallowed 500 lands here even when the page rendered a
+    // success state, because the listener sees the wire.
     if (typeof r.status === "number" && (r.status < 200 || r.status >= 400)) {
       failures.push({
-        kind: "non-2xx-response",
+        kind: "error-response",
         severity: MUST_FIX,
         status: r.status,
         url: r.url ?? null,
-        message: `non-2xx response ${r.status}${r.url ? ` at ${r.url}` : ""}`,
+        message: `error response ${r.status}${r.url ? ` at ${r.url}` : ""}`,
       });
     }
   }
@@ -142,15 +144,29 @@ export function classifyFailures({
   }
 
   if (serverLogTail && serverLogExceptionPattern) {
-    const re = new RegExp(serverLogExceptionPattern, "iu");
-    for (const line of serverLogTail.split("\n")) {
-      const trimmed = line.trim();
-      if (trimmed.length > 0 && re.test(trimmed)) {
-        failures.push({
-          kind: "server-log-exception",
-          severity: MUST_FIX,
-          message: `server log exception: ${trimmed.slice(0, 500)}`,
-        });
+    // Config validates the pattern only on the CLI path; a direct caller can
+    // pass an invalid regex. Guard the compile so a bad pattern degrades to a
+    // surfaced note instead of throwing and breaking the whole drive envelope.
+    let re;
+    try {
+      re = new RegExp(serverLogExceptionPattern, "iu");
+    } catch (err) {
+      failures.push({
+        kind: "server-log-pattern-invalid",
+        severity: "note",
+        message: `server-log exception pattern is not a valid regex; skipped server-log classification: ${err?.message ?? String(err)}`,
+      });
+    }
+    if (re) {
+      for (const line of serverLogTail.split("\n")) {
+        const trimmed = line.trim();
+        if (trimmed.length > 0 && re.test(trimmed)) {
+          failures.push({
+            kind: "server-log-exception",
+            severity: MUST_FIX,
+            message: `server log exception: ${trimmed.slice(0, 500)}`,
+          });
+        }
       }
     }
   }

--- a/packages/core/src/loop/ui-review-drive.mjs
+++ b/packages/core/src/loop/ui-review-drive.mjs
@@ -236,7 +236,11 @@ export async function driveUiReview(
   let screenshots = 0;
   let screensSkipped = 0;
   for (const flow of selected) {
-    const flowSteps = Array.isArray(flow.steps) ? flow.steps.slice(0, resolvedCaps.maxStepsPerFlow) : [];
+    const declaredSteps = Array.isArray(flow.steps) ? flow.steps : [];
+    const flowSteps = declaredSteps.slice(0, resolvedCaps.maxStepsPerFlow);
+    if (declaredSteps.length > flowSteps.length) {
+      record(`steps skipped: ${flow.name} truncated to ${flowSteps.length} step(s) at the maxStepsPerFlow cap (${resolvedCaps.maxStepsPerFlow})`);
+    }
     for (let i = 0; i < flowSteps.length; i += 1) {
       const step = flowSteps[i];
       if (screenshots >= resolvedCaps.maxScreenshots) {

--- a/packages/core/src/loop/ui-review-drive.mjs
+++ b/packages/core/src/loop/ui-review-drive.mjs
@@ -26,6 +26,26 @@
 
 const MUST_FIX = "must-fix";
 
+/** The one owner of the error-response threshold: an error response is anything
+ * outside 2xx/3xx. 3xx redirects are normal navigation (login/canonical), not
+ * errors, so they are not flagged. Shared by the CLI listener's pre-filter (for
+ * buffer bounding) and the classifier, so the policy has a single source. */
+export function isErrorResponseStatus(status) {
+  return typeof status === "number" && (status < 200 || status >= 400);
+}
+
+/** Bound the stack text carried onto a page-error failure so a runaway stack
+ * (or a synthetic error with a huge stack) can't bloat the feed envelope. Keeps
+ * the head — the top frames, where the throwing file:line sits. */
+const PAGE_ERROR_STACK_MAX_CHARS = 4000;
+
+/** Lines of context to preserve on each side of a matching server-log line, so
+ * the traceback frames that carry file:line (often on adjacent, non-matching
+ * lines) survive into the Stage 3 feed. */
+const SERVER_LOG_CONTEXT_LINES = 4;
+/** Char cap on the preserved server-log context window per failure entry. */
+const SERVER_LOG_CONTEXT_MAX_CHARS = 2000;
+
 /** Bounded caps. A project cannot raise these past the ceilings — the walker is
  * a diagnostic pass over the changed flows, never an unbounded crawl. */
 export const DEFAULT_DRIVE_CAPS = Object.freeze({
@@ -96,7 +116,7 @@ export function selectFlows({ flows = [], changedPaths = [], caps = DEFAULT_DRIV
  * @param {object} input
  * @param {{url?:string,status:number}[]} [input.responses] - from page.on('response')
  * @param {{url?:string,failure?:string}[]} [input.requestFailures] - from page.on('requestfailed')
- * @param {{message?:string}[]} [input.pageErrors] - from page.on('pageerror')
+ * @param {{message?:string,stack?:string|null}[]} [input.pageErrors] - from page.on('pageerror'); `stack` (file:line) feeds Stage 3
  * @param {string} [input.serverLogTail] - tail text of the project server log
  * @param {string} [input.serverLogExceptionPattern] - regex (source) flagging a log exception line
  * @returns {{kind:string, severity:string, message:string, [k:string]:unknown}[]}
@@ -111,11 +131,10 @@ export function classifyFailures({
   const failures = [];
 
   for (const r of responses) {
-    // An error response is anything outside 2xx/3xx (status <200 or >=400). 3xx
-    // redirects are normal navigation (login/canonical), not errors, so they are
-    // not flagged. A swallowed 500 lands here even when the page rendered a
-    // success state, because the listener sees the wire.
-    if (typeof r.status === "number" && (r.status < 200 || r.status >= 400)) {
+    // A swallowed 500 lands here even when the page rendered a success state,
+    // because the listener sees the wire. The error-response threshold has one
+    // owner: isErrorResponseStatus.
+    if (isErrorResponseStatus(r.status)) {
       failures.push({
         kind: "error-response",
         severity: MUST_FIX,
@@ -136,10 +155,14 @@ export function classifyFailures({
   }
 
   for (const e of pageErrors) {
+    // Carry the bounded stack so Stage 3's exception -> source-line mapping has
+    // the file:line signal; null when the listener captured no stack.
+    const stack = typeof e.stack === "string" && e.stack.length > 0 ? e.stack.slice(0, PAGE_ERROR_STACK_MAX_CHARS) : null;
     failures.push({
       kind: "page-error",
       severity: MUST_FIX,
       message: `uncaught page error: ${e.message ?? "(no message)"}`,
+      stack,
     });
   }
 
@@ -158,13 +181,21 @@ export function classifyFailures({
       });
     }
     if (re) {
-      for (const line of serverLogTail.split("\n")) {
-        const trimmed = line.trim();
+      const lines = serverLogTail.split("\n");
+      for (let i = 0; i < lines.length; i += 1) {
+        const trimmed = lines[i].trim();
         if (trimmed.length > 0 && re.test(trimmed)) {
+          // Preserve the contiguous frames around the match: the file:line the
+          // traceback carries usually sits on adjacent, non-matching lines that
+          // the per-line match alone would drop. Bounded on both axes.
+          const from = Math.max(0, i - SERVER_LOG_CONTEXT_LINES);
+          const to = Math.min(lines.length, i + SERVER_LOG_CONTEXT_LINES + 1);
+          const context = lines.slice(from, to).join("\n").slice(0, SERVER_LOG_CONTEXT_MAX_CHARS);
           failures.push({
             kind: "server-log-exception",
             severity: MUST_FIX,
             message: `server log exception: ${trimmed.slice(0, 500)}`,
+            context,
           });
         }
       }

--- a/packages/core/src/loop/ui-review-drive.mjs
+++ b/packages/core/src/loop/ui-review-drive.mjs
@@ -1,0 +1,297 @@
+/**
+ * Drive orchestrator for the ui_review route (Stage 2).
+ *
+ * Authenticates as the change's target role via a project-provided dev-login
+ * recipe, then walks the changed UI flows against the arbitrary running-app URL
+ * handed off by Stage 1 — rendering each page, exercising its declared
+ * interactions, and capturing an ordered set of step screenshots. While it
+ * drives, response/requestfailed/pageerror listeners and a server-log tail run
+ * so a swallowed non-2xx (a 500 the UI hides) is still recorded.
+ *
+ * This module is PURE orchestration: all browser/page IO, the auth recipe, the
+ * interstitial dismissal, the per-step capture, the event collection, and the
+ * server-log tail are injected seams. The thin CLI/harness wires real Playwright
+ * (WebKit). The decision logic that lives here is: which flows to drive
+ * (a bounded changed-flow heuristic over an explicit allowlist), cap
+ * enforcement (max screenshots, screens skipped, no-retry) with explicit logs,
+ * and failure classification (collating non-2xx responses, request failures,
+ * page errors, and server-log exceptions into one structured list).
+ *
+ * Fail closed: a can't-authenticate condition STOPS with a stated reason and
+ * drives nothing. The structured captured-failures list feeds the next stage.
+ *
+ * Out of scope (later stages): exception -> source-line mapping, review
+ * posting, visual-regression/pixel-diffing, cross-browser matrix.
+ */
+
+const MUST_FIX = "must-fix";
+
+/** Bounded caps. A project cannot raise these past the ceilings — the walker is
+ * a diagnostic pass over the changed flows, never an unbounded crawl. */
+export const DEFAULT_DRIVE_CAPS = Object.freeze({
+  maxScreenshots: 40,
+  maxFlows: 12,
+  maxStepsPerFlow: 20,
+  // No-retry is a fixed policy, not a tunable: a flaky step is a finding, not
+  // something to paper over by re-running. Logged explicitly on every run.
+  retries: 0,
+});
+
+/** Merge project caps onto the defaults, clamping each to its ceiling so a
+ * recipe can only tighten a cap, never loosen it past the diagnostic budget. */
+export function resolveCaps(caps = {}) {
+  const clamp = (v, ceiling) =>
+    Number.isInteger(v) && v >= 0 ? Math.min(v, ceiling) : ceiling;
+  return {
+    maxScreenshots: clamp(caps.maxScreenshots, DEFAULT_DRIVE_CAPS.maxScreenshots),
+    maxFlows: clamp(caps.maxFlows, DEFAULT_DRIVE_CAPS.maxFlows),
+    maxStepsPerFlow: clamp(caps.maxStepsPerFlow, DEFAULT_DRIVE_CAPS.maxStepsPerFlow),
+    retries: 0,
+  };
+}
+
+/**
+ * Changed-flow discovery: pick which allowlisted flows to drive.
+ *
+ * This is a DOCUMENTED HEURISTIC over an EXPLICIT allowlist, never an unbounded
+ * crawl. Each flow declares `pathPatterns` (plain substrings matched against the
+ * PR's changed file paths). A flow is in scope when any changed path contains
+ * any of its patterns. A flow with no `pathPatterns` is always in scope (the
+ * project opted it into every run). When `changedPaths` is empty/absent the diff
+ * is unknown, so every allowlisted flow is driven — the safe over-approximation.
+ * The selection is then capped at `caps.maxFlows`; the overflow is skipped and
+ * logged, never silently dropped.
+ *
+ * @returns {{ selected: object[], skipped: {name:string, reason:string}[] }}
+ */
+export function selectFlows({ flows = [], changedPaths = [], caps = DEFAULT_DRIVE_CAPS } = {}) {
+  const paths = Array.isArray(changedPaths) ? changedPaths : [];
+  const haveDiff = paths.length > 0;
+  const matched = [];
+  const skipped = [];
+  for (const flow of flows) {
+    const patterns = Array.isArray(flow.pathPatterns) ? flow.pathPatterns : [];
+    let inScope;
+    if (!haveDiff || patterns.length === 0) {
+      inScope = true; // unknown diff, or an always-on flow
+    } else {
+      inScope = patterns.some((p) => paths.some((cp) => cp.includes(p)));
+    }
+    if (inScope) matched.push(flow);
+    else skipped.push({ name: flow.name, reason: "no changed path matched its pathPatterns" });
+  }
+  const selected = matched.slice(0, caps.maxFlows);
+  for (const flow of matched.slice(caps.maxFlows)) {
+    skipped.push({ name: flow.name, reason: `maxFlows cap (${caps.maxFlows}) reached` });
+  }
+  return { selected, skipped };
+}
+
+/**
+ * Classify raw captured events + the server-log tail into one structured failure
+ * list. Pure. This is where a swallowed non-2xx surfaces twice — once from the
+ * response listener and once from the server-log tail — so a 500 the UI hid is
+ * still recorded.
+ *
+ * @param {object} input
+ * @param {{url?:string,status:number}[]} [input.responses] - from page.on('response')
+ * @param {{url?:string,failure?:string}[]} [input.requestFailures] - from page.on('requestfailed')
+ * @param {{message?:string}[]} [input.pageErrors] - from page.on('pageerror')
+ * @param {string} [input.serverLogTail] - tail text of the project server log
+ * @param {string} [input.serverLogExceptionPattern] - regex (source) flagging a log exception line
+ * @returns {{kind:string, severity:string, message:string, [k:string]:unknown}[]}
+ */
+export function classifyFailures({
+  responses = [],
+  requestFailures = [],
+  pageErrors = [],
+  serverLogTail = "",
+  serverLogExceptionPattern,
+} = {}) {
+  const failures = [];
+
+  for (const r of responses) {
+    // Non-2xx = anything outside 2xx/3xx. A swallowed 500 lands here even when
+    // the page rendered a success state, because the listener sees the wire.
+    if (typeof r.status === "number" && (r.status < 200 || r.status >= 400)) {
+      failures.push({
+        kind: "non-2xx-response",
+        severity: MUST_FIX,
+        status: r.status,
+        url: r.url ?? null,
+        message: `non-2xx response ${r.status}${r.url ? ` at ${r.url}` : ""}`,
+      });
+    }
+  }
+
+  for (const f of requestFailures) {
+    failures.push({
+      kind: "request-failed",
+      severity: MUST_FIX,
+      url: f.url ?? null,
+      message: `request failed${f.url ? ` at ${f.url}` : ""}${f.failure ? `: ${f.failure}` : ""}`,
+    });
+  }
+
+  for (const e of pageErrors) {
+    failures.push({
+      kind: "page-error",
+      severity: MUST_FIX,
+      message: `uncaught page error: ${e.message ?? "(no message)"}`,
+    });
+  }
+
+  if (serverLogTail && serverLogExceptionPattern) {
+    const re = new RegExp(serverLogExceptionPattern, "iu");
+    for (const line of serverLogTail.split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed.length > 0 && re.test(trimmed)) {
+        failures.push({
+          kind: "server-log-exception",
+          severity: MUST_FIX,
+          message: `server log exception: ${trimmed.slice(0, 500)}`,
+        });
+      }
+    }
+  }
+
+  return failures;
+}
+
+/**
+ * Run the auth + drive sequence over the changed flows.
+ *
+ * @param {object} input
+ * @param {string} input.appUrl - The arbitrary running-app URL from Stage 1.
+ * @param {object} input.login - Resolved dev-login recipe (loginUrl + selectors).
+ * @param {object[]} [input.flows] - Allowlisted changed-flow definitions.
+ * @param {object[]} [input.interstitials] - Config-declared dismiss selectors.
+ * @param {string[]} [input.changedPaths] - Changed file paths (drives selection).
+ * @param {string} [input.serverLogExceptionPattern] - regex source for log-tail classification.
+ * @param {object} [input.caps] - Project cap overrides (clamped to the ceilings).
+ * @param {object} seams - Injected IO.
+ * @param {(a:{appUrl:string,login:object})=>Promise<{ok:boolean,detail:string}>} seams.authenticate
+ * @param {(a:{interstitials:object[]})=>Promise<{dismissed:string[]}>} [seams.dismissInterstitials]
+ * @param {(a:{appUrl:string,flow:object,step:object,index:number})=>Promise<{screenshotPath?:string,statePath?:string,ok?:boolean,detail?:string}>} seams.runStep
+ * @param {()=>{responses?:object[],requestFailures?:object[],pageErrors?:object[]}} seams.getCapturedEvents
+ * @param {()=>Promise<string>} [seams.readServerLogTail]
+ * @param {(msg:string)=>void} [seams.log]
+ * @returns {Promise<object>} Result envelope (steps, captures, failures, caps, logs).
+ */
+export async function driveUiReview(
+  { appUrl, login, flows = [], interstitials = [], changedPaths = [], serverLogExceptionPattern, caps = {} },
+  {
+    authenticate,
+    dismissInterstitials = async () => ({ dismissed: [] }),
+    runStep,
+    getCapturedEvents,
+    readServerLogTail = async () => "",
+    log = () => {},
+  } = {},
+) {
+  const logs = [];
+  const record = (msg) => {
+    logs.push(msg);
+    log(msg);
+  };
+  const resolvedCaps = resolveCaps(caps);
+  // No-retry is a fixed policy — log it every run so the bound is never implicit.
+  record(`caps: maxScreenshots=${resolvedCaps.maxScreenshots}, maxFlows=${resolvedCaps.maxFlows}, maxStepsPerFlow=${resolvedCaps.maxStepsPerFlow}, retries=${resolvedCaps.retries} (no-retry)`);
+
+  const base = () => ({ appUrl: appUrl ?? null, logs });
+
+  // 1. Authenticate as the target role. Fail closed: no session -> STOP, drive
+  //    nothing (a review that never reached the app is worthless, not empty).
+  const auth = await authenticate({ appUrl, login });
+  if (!auth.ok) {
+    const stopReason = `cannot authenticate: ${auth.detail ?? "dev-login recipe did not yield a session"}`;
+    record(`STOP: ${stopReason}`);
+    return {
+      ok: false,
+      stopped: true,
+      stopReason,
+      steps: [],
+      captures: [],
+      failures: [{ kind: "auth-failed", severity: MUST_FIX, message: stopReason }],
+      caps: resolvedCaps,
+      ...base(),
+    };
+  }
+  record(`authenticated: ${auth.detail ?? "session established"}`);
+
+  // 2. Dismiss known interstitials ONCE per browser context (config-declared).
+  const dismiss = await dismissInterstitials({ interstitials });
+  if (dismiss.dismissed?.length) record(`interstitials dismissed: ${dismiss.dismissed.join(", ")}`);
+
+  // 3. Select the changed flows (bounded heuristic over the explicit allowlist).
+  const { selected, skipped } = selectFlows({ flows, changedPaths, caps: resolvedCaps });
+  for (const s of skipped) record(`flow skipped: ${s.name} (${s.reason})`);
+  record(`driving ${selected.length} flow(s)`);
+
+  // 4. Walk each flow's steps, capturing every step, until the screenshot cap.
+  //    No retry: a step that throws is recorded as a step failure and the walk
+  //    moves on — deterministic, bounded, never re-run.
+  const steps = [];
+  const captures = [];
+  let screenshots = 0;
+  let screensSkipped = 0;
+  for (const flow of selected) {
+    const flowSteps = Array.isArray(flow.steps) ? flow.steps.slice(0, resolvedCaps.maxStepsPerFlow) : [];
+    for (let i = 0; i < flowSteps.length; i += 1) {
+      const step = flowSteps[i];
+      if (screenshots >= resolvedCaps.maxScreenshots) {
+        screensSkipped += 1;
+        continue;
+      }
+      let outcome;
+      try {
+        outcome = await runStep({ appUrl, flow, step, index: screenshots });
+      } catch (err) {
+        outcome = { ok: false, detail: (err?.message ?? String(err)).slice(0, 500) };
+      }
+      const ok = outcome?.ok !== false;
+      screenshots += 1;
+      const entry = {
+        flow: flow.name,
+        step: step.name ?? step.action ?? `step-${i}`,
+        order: screenshots,
+        ok,
+        screenshotPath: outcome?.screenshotPath ?? null,
+        statePath: outcome?.statePath ?? null,
+        detail: outcome?.detail ?? null,
+      };
+      steps.push(entry);
+      if (entry.screenshotPath) captures.push({ flow: flow.name, step: entry.step, screenshotPath: entry.screenshotPath, statePath: entry.statePath });
+      if (!ok) record(`step failed (no retry): ${flow.name} / ${entry.step}: ${entry.detail ?? "unknown"}`);
+    }
+  }
+  if (screensSkipped > 0) record(`screens skipped: ${screensSkipped} step(s) past the maxScreenshots cap (${resolvedCaps.maxScreenshots})`);
+
+  // 5. Collate the out-of-band captures: listener events + the server-log tail.
+  const events = getCapturedEvents() ?? {};
+  const serverLogTail = await readServerLogTail();
+  const failures = classifyFailures({
+    responses: events.responses ?? [],
+    requestFailures: events.requestFailures ?? [],
+    pageErrors: events.pageErrors ?? [],
+    serverLogTail,
+    serverLogExceptionPattern,
+  });
+  // A step that threw is a drive failure too — surface it in the structured list.
+  for (const s of steps) {
+    if (!s.ok) failures.push({ kind: "step-failure", severity: MUST_FIX, message: `step failed: ${s.flow} / ${s.step}${s.detail ? `: ${s.detail}` : ""}` });
+  }
+  record(`captured ${failures.length} failure(s) across ${steps.length} step(s)`);
+
+  return {
+    ok: failures.length === 0,
+    stopped: false,
+    stopReason: null,
+    steps,
+    captures,
+    failures,
+    caps: resolvedCaps,
+    screensSkipped,
+    ...base(),
+  };
+}

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -392,6 +392,51 @@ describe("schema validation", () => {
     assert.ok(!result.success);
   });
 
+  test("S32: uiReview.login with loginUrl + submit/success selectors parses", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      uiReview: { login: { loginUrl: "http://127.0.0.1:3000/login", submitSelector: "button", successSelector: "#home" } },
+    });
+    assert.ok(result.success);
+  });
+
+  test("S33: uiReview.login.loginUrl rejects a non-http(s) URL", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      uiReview: { login: { loginUrl: "ftp://x/login", submitSelector: "b", successSelector: "#h" } },
+    });
+    assert.ok(!result.success);
+  });
+
+  test("S34: uiReview.login requires submitSelector and successSelector", () => {
+    assert.ok(!DevLoopConfigSchema.safeParse({
+      version: 1,
+      uiReview: { login: { loginUrl: "http://x/login", successSelector: "#h" } },
+    }).success);
+    assert.ok(!DevLoopConfigSchema.safeParse({
+      version: 1,
+      uiReview: { login: { loginUrl: "http://x/login", submitSelector: "b" } },
+    }).success);
+  });
+
+  test("S35: uiReview.flows steps require a known action", () => {
+    assert.ok(DevLoopConfigSchema.safeParse({
+      version: 1,
+      uiReview: { flows: [{ name: "decks", steps: [{ action: "goto", path: "/decks" }] }] },
+    }).success);
+    assert.ok(!DevLoopConfigSchema.safeParse({
+      version: 1,
+      uiReview: { flows: [{ name: "decks", steps: [{ action: "teleport" }] }] },
+    }).success);
+  });
+
+  test("S36: uiReview.serverLogExceptionPattern rejects a malformed regex", () => {
+    assert.ok(!DevLoopConfigSchema.safeParse({
+      version: 1,
+      uiReview: { serverLogExceptionPattern: "[" },
+    }).success);
+  });
+
 });
 
 // ============================================================================

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -430,6 +430,17 @@ describe("schema validation", () => {
     }).success);
   });
 
+  test("S35b: a selector-based step action requires a selector; goto does not", () => {
+    assert.ok(DevLoopConfigSchema.safeParse({
+      version: 1,
+      uiReview: { flows: [{ name: "decks", steps: [{ action: "click", selector: "#save" }] }] },
+    }).success);
+    assert.ok(!DevLoopConfigSchema.safeParse({
+      version: 1,
+      uiReview: { flows: [{ name: "decks", steps: [{ action: "click" }] }] },
+    }).success);
+  });
+
   test("S36: uiReview.serverLogExceptionPattern rejects a malformed regex", () => {
     assert.ok(!DevLoopConfigSchema.safeParse({
       version: 1,

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -441,6 +441,27 @@ describe("schema validation", () => {
     }).success);
   });
 
+  test("S35c: goto requires a path and upload requires a value; both rejected at parse time", () => {
+    // goto: accepts with a path, rejects without one (a missing path would drive "/").
+    assert.ok(DevLoopConfigSchema.safeParse({
+      version: 1,
+      uiReview: { flows: [{ name: "decks", steps: [{ action: "goto", path: "/decks" }] }] },
+    }).success);
+    assert.ok(!DevLoopConfigSchema.safeParse({
+      version: 1,
+      uiReview: { flows: [{ name: "decks", steps: [{ action: "goto" }] }] },
+    }).success);
+    // upload: accepts with a value (file path), rejects without one (setInputFiles("") throws).
+    assert.ok(DevLoopConfigSchema.safeParse({
+      version: 1,
+      uiReview: { flows: [{ name: "decks", steps: [{ action: "upload", selector: "#file", value: "fixtures/a.png" }] }] },
+    }).success);
+    assert.ok(!DevLoopConfigSchema.safeParse({
+      version: 1,
+      uiReview: { flows: [{ name: "decks", steps: [{ action: "upload", selector: "#file" }] }] },
+    }).success);
+  });
+
   test("S36: uiReview.serverLogExceptionPattern rejects a malformed regex", () => {
     assert.ok(!DevLoopConfigSchema.safeParse({
       version: 1,

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -49,7 +49,7 @@ export default defineConfig({
       use: { browserName: "webkit" },
     })),
     // ui_review drive harness smoke: a net-new spec (not registry-driven) that
-    // drives a fixture app exhibiting a swallowed non-2xx and asserts the
+    // drives a fixture app exhibiting a swallowed error response and asserts the
     // listener + server-log tail both catch it.
     {
       name: "ui-review-drive",

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -41,10 +41,21 @@ export default defineConfig({
     trace: "retain-on-failure",
     video: "off",
   },
-  projects: sliceIds.map((sliceId) => ({
-    name: sliceId,
-    testMatch: [`${sliceId}.spec.mjs`],
-    outputDir: `test-results/ui-smoke/${sliceId}`,
-    use: { browserName: "webkit" },
-  })),
+  projects: [
+    ...sliceIds.map((sliceId) => ({
+      name: sliceId,
+      testMatch: [`${sliceId}.spec.mjs`],
+      outputDir: `test-results/ui-smoke/${sliceId}`,
+      use: { browserName: "webkit" },
+    })),
+    // ui_review drive harness smoke: a net-new spec (not registry-driven) that
+    // drives a fixture app exhibiting a swallowed non-2xx and asserts the
+    // listener + server-log tail both catch it.
+    {
+      name: "ui-review-drive",
+      testMatch: ["ui-review-drive.spec.mjs"],
+      outputDir: "test-results/ui-smoke/ui-review-drive",
+      use: { browserName: "webkit" },
+    },
+  ],
 });

--- a/scripts/loop/ui-review-drive.mjs
+++ b/scripts/loop/ui-review-drive.mjs
@@ -147,8 +147,10 @@ const SERVER_LOG_TAIL_MAX_BYTES = 1024 * 1024; // 1 MiB
  * @param {string|null} logPath
  * @param {{maxBytes?:number, log?:(msg:string)=>void}} [opts] - `maxBytes` caps a
  *   single read; `log` receives a truncation note when the delta exceeds it.
+ *   Defaults to `console.warn` so a truncation is surfaced by default (honoring
+ *   the "logged, never silent" contract); pass `log: () => {}` to opt into silence.
  */
-export function openServerLogTail(logPath, { maxBytes = SERVER_LOG_TAIL_MAX_BYTES, log = () => {} } = {}) {
+export function openServerLogTail(logPath, { maxBytes = SERVER_LOG_TAIL_MAX_BYTES, log = console.warn } = {}) {
   if (!logPath) return { read: async () => "" };
   let startOffset = 0;
   try {

--- a/scripts/loop/ui-review-drive.mjs
+++ b/scripts/loop/ui-review-drive.mjs
@@ -7,7 +7,7 @@
  * interstitials once, then walks the changed flows against the arbitrary
  * running-app URL from Stage 1 — capturing a step screenshot + state.json per
  * step. Response/requestfailed/pageerror listeners plus a server-log tail run
- * throughout so a swallowed non-2xx is still recorded.
+ * throughout so a swallowed error response is still recorded.
  *
  * This is a thin adapter: it wires the real IO seams (WebKit browser/page, the
  * page-event listeners, captureNamedUiState, the login form driving, the
@@ -30,7 +30,7 @@ import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToke
 const USAGE = `Usage:
   ui-review-drive.mjs --repo-root <p> --app-url <url> --output-dir <p> [--changed-path <p> ...]
 Authenticate as the target role and drive the changed UI flows headless (WebKit),
-capturing step screenshots + non-2xx/pageerror/server-log failures (Stage 2 of the ui_review route).
+capturing step screenshots + error-response/pageerror/server-log failures (Stage 2 of the ui_review route).
 Required:
   --repo-root <p>      Absolute path to the (provisioned) worktree carrying the .devloops recipe.
   --app-url <url>      The running-app URL handed off by Stage 1.
@@ -101,7 +101,8 @@ export function parseUiReviewDriveCliArgs(argv) {
 /**
  * Register the response/requestfailed/pageerror listeners on a page (or any
  * object exposing the same `on(event, cb)` emitter interface, so this is unit
- * testable without a browser). Only non-2xx responses are retained so the buffer
+ * testable without a browser). Only error responses (status <200 or >=400; 3xx
+ * redirects are normal navigation and are not flagged) are retained so the buffer
  * stays bounded; the pure classifier decides severity from the collected set.
  *
  * @returns {{ getCapturedEvents: () => {responses:object[],requestFailures:object[],pageErrors:object[]} }}
@@ -128,6 +129,12 @@ export function attachPageListeners(page) {
   return { getCapturedEvents: () => ({ responses, requestFailures, pageErrors }) };
 }
 
+/** Cap the bytes a single tail read pulls into memory, so a huge log growth
+ * (a runaway error loop dumping megabytes) can't OOM the drive. On overflow we
+ * keep the LAST maxBytes of the delta (the newest lines, where a just-logged 500
+ * lives) and log the truncation — a bounded cap, never a silent one. */
+const SERVER_LOG_TAIL_MAX_BYTES = 1024 * 1024; // 1 MiB
+
 /**
  * Open a server-log tail bound to the log's size at drive start. `read()` returns
  * only the bytes appended since — the tail of one drive run, so a 500 logged
@@ -136,8 +143,12 @@ export function attachPageListeners(page) {
  * ponytail: tracks a byte offset, not the inode. If the project rotates the log
  * mid-run the offset goes stale; upgrade to an inode/rename watch if that
  * matters. Absent log path => a no-op read (empty tail).
+ *
+ * @param {string|null} logPath
+ * @param {{maxBytes?:number, log?:(msg:string)=>void}} [opts] - `maxBytes` caps a
+ *   single read; `log` receives a truncation note when the delta exceeds it.
  */
-export function openServerLogTail(logPath) {
+export function openServerLogTail(logPath, { maxBytes = SERVER_LOG_TAIL_MAX_BYTES, log = () => {} } = {}) {
   if (!logPath) return { read: async () => "" };
   let startOffset = 0;
   try {
@@ -152,9 +163,15 @@ export function openServerLogTail(logPath) {
         handle = await open(logPath, "r");
         const { size } = await handle.stat();
         if (size <= startOffset) return "";
-        const length = size - startOffset;
+        const delta = size - startOffset;
+        // Keep the newest maxBytes of the delta on overflow; read from the tail.
+        const length = Math.min(delta, maxBytes);
+        const readFrom = size - length;
+        if (delta > maxBytes) {
+          log(`server-log tail truncated: kept the last ${length} of ${delta} appended byte(s) at the ${maxBytes}-byte cap`);
+        }
         const buf = Buffer.alloc(length);
-        await handle.read(buf, 0, length, startOffset);
+        await handle.read(buf, 0, length, readFrom);
         return buf.toString("utf8");
       } catch {
         return "";
@@ -269,7 +286,7 @@ export async function runCli(argv = process.argv.slice(2), { stdout = process.st
   }
 
   const serverLogPath = recipe.serverLogPath ? path.resolve(options.repoRoot, recipe.serverLogPath) : null;
-  const logTail = openServerLogTail(serverLogPath);
+  const logTail = openServerLogTail(serverLogPath, { log: (msg) => stderr.write(`[ui-review-drive] ${msg}\n`) });
 
   const browser = await webkit.launch({ headless: true });
   try {

--- a/scripts/loop/ui-review-drive.mjs
+++ b/scripts/loop/ui-review-drive.mjs
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+/**
+ * CLI/harness wrapper for the ui_review drive orchestrator (Stage 2).
+ *
+ * Launches one headless WebKit context, authenticates as the change's target
+ * role via the project's dev-login recipe, dismisses config-declared
+ * interstitials once, then walks the changed flows against the arbitrary
+ * running-app URL from Stage 1 — capturing a step screenshot + state.json per
+ * step. Response/requestfailed/pageerror listeners plus a server-log tail run
+ * throughout so a swallowed non-2xx is still recorded.
+ *
+ * This is a thin adapter: it wires the real IO seams (WebKit browser/page, the
+ * page-event listeners, captureNamedUiState, the login form driving, the
+ * server-log tail) into the pure core orchestrator
+ * (packages/core/src/loop/ui-review-drive.mjs). The decision logic (flow
+ * selection, cap enforcement, failure classification) lives in core.
+ */
+import { statSync } from "node:fs";
+import { open } from "node:fs/promises";
+import path from "node:path";
+import { parseArgs } from "node:util";
+import { webkit } from "@playwright/test";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { requireTokenValue } from "../_cli-primitives.mjs";
+import { loadDevLoopConfig, resolveUiReviewDriveRecipe } from "@dev-loops/core/config";
+import { driveUiReview } from "@dev-loops/core/loop/ui-review-drive";
+import { captureNamedUiState } from "../../test/playwright/harness/webkit-smoke-harness.mjs";
+import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+
+const USAGE = `Usage:
+  ui-review-drive.mjs --repo-root <p> --app-url <url> --output-dir <p> [--changed-path <p> ...]
+Authenticate as the target role and drive the changed UI flows headless (WebKit),
+capturing step screenshots + non-2xx/pageerror/server-log failures (Stage 2 of the ui_review route).
+Required:
+  --repo-root <p>      Absolute path to the (provisioned) worktree carrying the .devloops recipe.
+  --app-url <url>      The running-app URL handed off by Stage 1.
+  --output-dir <p>     Directory for the ordered step screenshots + state.json artifacts.
+Optional:
+  --changed-path <p>   A changed file path (repeatable); drives the changed-flow selection heuristic.
+  -h, --help           Show this help.
+Output (stdout, JSON):
+  { "ok": bool, "stopped": bool, "stopReason": string|null,
+    "steps": [...], "captures": [...], "failures": [...], "caps": {...}, "logs": [...] }
+
+${JQ_OUTPUT_USAGE}`.trim();
+
+const parseError = buildParseError(USAGE);
+
+export function parseUiReviewDriveCliArgs(argv) {
+  const options = { help: false, repoRoot: undefined, appUrl: undefined, outputDir: undefined, changedPaths: [] };
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      "repo-root": { type: "string" },
+      "app-url": { type: "string" },
+      "output-dir": { type: "string" },
+      "changed-path": { type: "string", multiple: true },
+      ...JQ_OUTPUT_PARSE_OPTIONS,
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") throw parseError(`Unknown argument: ${token.value}`);
+    if (token.kind !== "option") continue;
+    if (token.name === "help") {
+      options.help = true;
+      return options;
+    }
+    if (token.name === "repo-root") {
+      options.repoRoot = requireTokenValue(token, parseError, { flagPattern: /^-/u });
+      continue;
+    }
+    if (token.name === "app-url") {
+      options.appUrl = requireTokenValue(token, parseError, { flagPattern: /^-/u });
+      continue;
+    }
+    if (token.name === "output-dir") {
+      options.outputDir = requireTokenValue(token, parseError, { flagPattern: /^-/u });
+      continue;
+    }
+    if (token.name === "changed-path") {
+      options.changedPaths.push(requireTokenValue(token, parseError, { flagPattern: /^-/u }));
+      continue;
+    }
+    if (matchJqOutputToken(token, options, (t) => requireTokenValue(t, parseError))) continue;
+    throw parseError(`Unknown argument: ${token.rawName}`);
+  }
+  if (options.help) return options;
+  if (!options.repoRoot) throw parseError("Missing required --repo-root");
+  if (!options.appUrl) throw parseError("Missing required --app-url");
+  if (!options.outputDir) throw parseError("Missing required --output-dir");
+  return options;
+}
+
+/**
+ * Register the response/requestfailed/pageerror listeners on a page (or any
+ * object exposing the same `on(event, cb)` emitter interface, so this is unit
+ * testable without a browser). Only non-2xx responses are retained so the buffer
+ * stays bounded; the pure classifier decides severity from the collected set.
+ *
+ * @returns {{ getCapturedEvents: () => {responses:object[],requestFailures:object[],pageErrors:object[]} }}
+ */
+export function attachPageListeners(page) {
+  const responses = [];
+  const requestFailures = [];
+  const pageErrors = [];
+  page.on("response", (res) => {
+    const status = typeof res.status === "function" ? res.status() : res.status;
+    if (typeof status === "number" && (status < 200 || status >= 400)) {
+      const url = typeof res.url === "function" ? res.url() : res.url;
+      responses.push({ url, status });
+    }
+  });
+  page.on("requestfailed", (req) => {
+    const url = typeof req.url === "function" ? req.url() : req.url;
+    const failure = typeof req.failure === "function" ? req.failure()?.errorText : req.failure;
+    requestFailures.push({ url, failure: failure ?? null });
+  });
+  page.on("pageerror", (err) => {
+    pageErrors.push({ message: err?.message ?? String(err) });
+  });
+  return { getCapturedEvents: () => ({ responses, requestFailures, pageErrors }) };
+}
+
+/**
+ * Open a server-log tail bound to the log's size at drive start. `read()` returns
+ * only the bytes appended since — the tail of one drive run, so a 500 logged
+ * during the walk is captured without dragging in unrelated history.
+ *
+ * ponytail: tracks a byte offset, not the inode. If the project rotates the log
+ * mid-run the offset goes stale; upgrade to an inode/rename watch if that
+ * matters. Absent log path => a no-op read (empty tail).
+ */
+export function openServerLogTail(logPath) {
+  if (!logPath) return { read: async () => "" };
+  let startOffset = 0;
+  try {
+    startOffset = statSync(logPath).size;
+  } catch {
+    startOffset = 0; // not created yet; read from the beginning once it exists
+  }
+  return {
+    read: async () => {
+      let handle;
+      try {
+        handle = await open(logPath, "r");
+        const { size } = await handle.stat();
+        if (size <= startOffset) return "";
+        const length = size - startOffset;
+        const buf = Buffer.alloc(length);
+        await handle.read(buf, 0, length, startOffset);
+        return buf.toString("utf8");
+      } catch {
+        return "";
+      } finally {
+        await handle?.close();
+      }
+    },
+  };
+}
+
+/** Drive the dev-login recipe in the browser and confirm the session by waiting
+ * for `successSelector`. Fail closed: any timeout/throw => {ok:false} with a
+ * stated reason, so the core STOPS rather than driving an unauthenticated app. */
+async function authenticate({ page, login, timeoutMs = 15000 }) {
+  try {
+    await page.goto(login.loginUrl, { waitUntil: "domcontentloaded" });
+    if (login.usernameSelector && login.usernameValue != null) {
+      await page.fill(login.usernameSelector, login.usernameValue);
+    }
+    if (login.passwordSelector && login.passwordValue != null) {
+      await page.fill(login.passwordSelector, login.passwordValue);
+    }
+    await page.click(login.submitSelector);
+    await page.waitForSelector(login.successSelector, { timeout: timeoutMs, state: "visible" });
+    return { ok: true, detail: `session confirmed via ${login.successSelector}` };
+  } catch (err) {
+    return { ok: false, detail: (err?.message ?? String(err)).split("\n")[0].slice(0, 300) };
+  }
+}
+
+/** Dismiss config-declared interstitials once. A non-optional interstitial that
+ * never appears is not fatal here (the drive stage records it, not this seam);
+ * a click failure is swallowed so one stubborn overlay can't abort the walk. */
+async function dismissInterstitials({ page, interstitials, timeoutMs = 2000 }) {
+  const dismissed = [];
+  for (const it of interstitials ?? []) {
+    try {
+      const el = page.locator(it.selector).first();
+      await el.waitFor({ timeout: timeoutMs, state: "visible" });
+      await el.click();
+      dismissed.push(it.selector);
+    } catch {
+      // Not shown this run (or not clickable) — dismissal is best-effort.
+    }
+  }
+  return { dismissed };
+}
+
+/** Map one declared step to its Playwright page call, then capture the state. */
+function makeRunStep({ page, outputDir }) {
+  return async ({ appUrl, flow, step, index }) => {
+    const sel = step.selector;
+    switch (step.action) {
+      case "goto":
+        await page.goto(new URL(step.path ?? "/", appUrl).toString(), { waitUntil: "domcontentloaded" });
+        break;
+      case "click":
+        await page.click(sel);
+        break;
+      case "fill":
+        await page.fill(sel, step.value ?? "");
+        break;
+      case "select":
+        await page.selectOption(sel, step.value ?? "");
+        break;
+      case "upload":
+        await page.setInputFiles(sel, step.value ?? "");
+        break;
+      case "dispatch":
+        await page.dispatchEvent(sel, step.event ?? "click");
+        break;
+      default:
+        throw new Error(`unknown step action: ${step.action}`);
+    }
+    const stateName = step.name ?? `${flow.name} ${step.action} ${index + 1}`;
+    const paths = await captureNamedUiState({
+      page,
+      sliceId: flow.name,
+      stateName,
+      fullPage: false,
+      outputDir,
+      metadata: { fixture: null, route: step.path ?? null, reviewHint: `Drive step "${stateName}" for the "${flow.name}" flow.` },
+    });
+    return { ok: true, screenshotPath: paths.screenshotPath, statePath: paths.statePath };
+  };
+}
+
+export async function runCli(argv = process.argv.slice(2), { stdout = process.stdout, stderr = process.stderr } = {}) {
+  const options = parseUiReviewDriveCliArgs(argv);
+  if (options.help) {
+    stdout.write(`${USAGE}\n`);
+    return;
+  }
+
+  const { config } = await loadDevLoopConfig({ repoRoot: options.repoRoot });
+  const recipe = resolveUiReviewDriveRecipe(config);
+  if (!recipe) {
+    // Fail closed: no dev-login recipe => cannot authenticate => drive nothing.
+    const result = {
+      ok: false,
+      stopped: true,
+      stopReason: "no drive recipe: the branch declares no uiReview.login recipe (cannot authenticate)",
+      steps: [],
+      captures: [],
+      failures: [{ kind: "drive-recipe-missing", severity: "must-fix", message: "declare uiReview.login (loginUrl + submitSelector + successSelector) in .devloops" }],
+      logs: [],
+    };
+    process.exitCode = emitResult(result, { jq: options.jq, silent: options.silent, stdout, stderr });
+    return;
+  }
+
+  const serverLogPath = recipe.serverLogPath ? path.resolve(options.repoRoot, recipe.serverLogPath) : null;
+  const logTail = openServerLogTail(serverLogPath);
+
+  const browser = await webkit.launch({ headless: true });
+  try {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    const { getCapturedEvents } = attachPageListeners(page);
+    const result = await driveUiReview(
+      {
+        appUrl: options.appUrl,
+        login: recipe.login,
+        flows: recipe.flows,
+        interstitials: recipe.interstitials,
+        changedPaths: options.changedPaths,
+        serverLogExceptionPattern: recipe.serverLogExceptionPattern,
+        caps: recipe.caps,
+      },
+      {
+        authenticate: () => authenticate({ page, login: recipe.login }),
+        dismissInterstitials: ({ interstitials }) => dismissInterstitials({ page, interstitials }),
+        runStep: makeRunStep({ page, outputDir: options.outputDir }),
+        getCapturedEvents,
+        readServerLogTail: () => logTail.read(),
+        log: (msg) => stderr.write(`[ui-review-drive] ${msg}\n`),
+      },
+    );
+    process.exitCode = emitResult(result, { jq: options.jq, silent: options.silent, stdout, stderr });
+  } finally {
+    await browser.close();
+  }
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli().catch((error) => {
+    process.stderr.write(`${formatCliError(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/loop/ui-review-drive.mjs
+++ b/scripts/loop/ui-review-drive.mjs
@@ -185,9 +185,9 @@ async function authenticate({ page, login, timeoutMs = 15000 }) {
   }
 }
 
-/** Dismiss config-declared interstitials once. A non-optional interstitial that
- * never appears is not fatal here (the drive stage records it, not this seam);
- * a click failure is swallowed so one stubborn overlay can't abort the walk. */
+/** Dismiss config-declared interstitials once, best-effort: an interstitial that
+ * never appears or is not clickable is skipped silently so one stubborn overlay
+ * can't abort the walk. */
 async function dismissInterstitials({ page, interstitials, timeoutMs = 2000 }) {
   const dismissed = [];
   for (const it of interstitials ?? []) {

--- a/scripts/loop/ui-review-drive.mjs
+++ b/scripts/loop/ui-review-drive.mjs
@@ -40,7 +40,10 @@ Optional:
   -h, --help           Show this help.
 Output (stdout, JSON):
   { "ok": bool, "stopped": bool, "stopReason": string|null,
-    "steps": [...], "captures": [...], "failures": [...], "caps": {...}, "logs": [...] }
+    "steps": [...], "captures": [...], "failures": [...], "caps": {...},
+    "appUrl": string|null, "logs": [...] }
+  On the walk (non-stopped) path the envelope also carries "screensSkipped": number
+  (steps dropped past the maxScreenshots cap).
 
 ${JQ_OUTPUT_USAGE}`.trim();
 
@@ -257,6 +260,8 @@ export async function runCli(argv = process.argv.slice(2), { stdout = process.st
       steps: [],
       captures: [],
       failures: [{ kind: "drive-recipe-missing", severity: "must-fix", message: "declare uiReview.login (loginUrl + submitSelector + successSelector) in .devloops" }],
+      caps: {},
+      appUrl: options.appUrl ?? null,
       logs: [],
     };
     process.exitCode = emitResult(result, { jq: options.jq, silent: options.silent, stdout, stderr });

--- a/scripts/loop/ui-review-drive.mjs
+++ b/scripts/loop/ui-review-drive.mjs
@@ -23,7 +23,7 @@ import { webkit } from "@playwright/test";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { requireTokenValue } from "../_cli-primitives.mjs";
 import { loadDevLoopConfig, resolveUiReviewDriveRecipe } from "@dev-loops/core/config";
-import { driveUiReview } from "@dev-loops/core/loop/ui-review-drive";
+import { driveUiReview, isErrorResponseStatus } from "@dev-loops/core/loop/ui-review-drive";
 import { captureNamedUiState } from "../../test/playwright/harness/webkit-smoke-harness.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 
@@ -101,9 +101,9 @@ export function parseUiReviewDriveCliArgs(argv) {
 /**
  * Register the response/requestfailed/pageerror listeners on a page (or any
  * object exposing the same `on(event, cb)` emitter interface, so this is unit
- * testable without a browser). Only error responses (status <200 or >=400; 3xx
- * redirects are normal navigation and are not flagged) are retained so the buffer
- * stays bounded; the pure classifier decides severity from the collected set.
+ * testable without a browser). Only error responses (per isErrorResponseStatus,
+ * the shared threshold owner) are retained so the buffer stays bounded; the pure
+ * classifier decides severity from the collected set.
  *
  * @returns {{ getCapturedEvents: () => {responses:object[],requestFailures:object[],pageErrors:object[]} }}
  */
@@ -113,7 +113,7 @@ export function attachPageListeners(page) {
   const pageErrors = [];
   page.on("response", (res) => {
     const status = typeof res.status === "function" ? res.status() : res.status;
-    if (typeof status === "number" && (status < 200 || status >= 400)) {
+    if (isErrorResponseStatus(status)) {
       const url = typeof res.url === "function" ? res.url() : res.url;
       responses.push({ url, status });
     }
@@ -124,7 +124,9 @@ export function attachPageListeners(page) {
     requestFailures.push({ url, failure: failure ?? null });
   });
   page.on("pageerror", (err) => {
-    pageErrors.push({ message: err?.message ?? String(err) });
+    // Carry err.stack (the file:line signal Stage 3's exception -> source-line
+    // mapping needs); the classifier bounds it before it lands on the feed.
+    pageErrors.push({ message: err?.message ?? String(err), stack: err?.stack ?? null });
   });
   return { getCapturedEvents: () => ({ responses, requestFailures, pageErrors }) };
 }
@@ -175,7 +177,10 @@ export function openServerLogTail(logPath, { maxBytes = SERVER_LOG_TAIL_MAX_BYTE
         const buf = Buffer.alloc(length);
         await handle.read(buf, 0, length, readFrom);
         return buf.toString("utf8");
-      } catch {
+      } catch (err) {
+        // Degrade to an empty tail, but never silently: a present-but-unreadable
+        // log (permissions, mid-run rotation) is a real signal, not "no errors".
+        log(`server-log tail unreadable at ${logPath}; treated as empty: ${(err?.message ?? String(err)).split("\n")[0]}`);
         return "";
       } finally {
         await handle?.close();

--- a/skills/ui-review/SKILL.md
+++ b/skills/ui-review/SKILL.md
@@ -51,8 +51,46 @@ Threat boundary: the run recipe is branch-controlled, and its `command` is
 executed as a shell command in the worktree. Every later stage inherits this
 assumption — a run recipe is trusted-branch input, not untrusted data.
 
+## Drive
+
+Once the app is booted, the route drives the changed UI flows against the
+handed-off app URL via
+`scripts/loop/ui-review-drive.mjs --repo-root <p> --app-url <url> --output-dir <p> [--changed-path <p> ...]`
+(pure orchestration in `packages/core/src/loop/ui-review-drive.mjs`). It launches
+one headless WebKit context, authenticates as the change's target role through a
+project-provided dev-login recipe, dismisses config-declared interstitials once
+per context, then walks the selected flows — rendering each page and exercising
+its declared create/edit/reorder/upload/toggle interactions — capturing a step
+screenshot + sibling `state.json` per step via `captureNamedUiState`. It fails
+closed to a stated stop reason when it cannot authenticate, and drives nothing.
+
+Throughout the walk, `response` (non-2xx), `requestfailed`, and `pageerror`
+listeners run and the project server log is tailed, so a swallowed non-2xx (a 500
+the UI hides behind a success state) is still recorded. The stage emits an
+ordered set of step screenshots plus a structured captured-failures list
+(non-2xx responses, request failures, page errors, server-log exceptions) that
+feeds the next stage. Every bounded cap — max screenshots, screens skipped, and
+the fixed no-retry policy — is logged explicitly.
+
+Which flows are driven is a bounded heuristic over an explicit allowlist, never
+an unbounded crawl: each `uiReview.flows` entry declares `pathPatterns` matched
+against the PR's changed file paths; an entry with none is always driven, and an
+unknown diff drives every allowlisted flow. The selection is capped and the
+overflow logged.
+
+The drive recipe is per-project and never hard-coded: a project declares
+`uiReview.login` (a `loginUrl`, optional username/password field selectors with
+their dev-only values, a `submitSelector`, and a `successSelector` proving the
+session), optional `interstitials` (dismiss selectors), the `flows` allowlist,
+optional `caps` (clamped to the shipped ceilings — a project may only tighten
+them), and an optional `serverLogPath` (with a `serverLogExceptionPattern`
+defaulting to a heuristic that a project MUST override when its log format
+differs). The login form is branch-controlled trusted input, same threat
+boundary as the run recipe.
+
 ## Non-goals
 
-No drive/diagnose/report/teardown logic lives here yet, and provision+boot does
-not drive the browser, authenticate, capture screenshots, post the review, or
-touch a production DB — those are later stages.
+No diagnose/report/teardown logic lives here yet. The drive stage does not map an
+exception to its source line, post the review, pixel-diff for visual regression,
+run a cross-browser matrix, or touch a production DB — those are later stages or
+explicit non-goals.

--- a/skills/ui-review/SKILL.md
+++ b/skills/ui-review/SKILL.md
@@ -64,11 +64,13 @@ its declared create/edit/reorder/upload/toggle interactions — capturing a step
 screenshot + sibling `state.json` per step via `captureNamedUiState`. It fails
 closed to a stated stop reason when it cannot authenticate, and drives nothing.
 
-Throughout the walk, `response` (non-2xx), `requestfailed`, and `pageerror`
-listeners run and the project server log is tailed, so a swallowed non-2xx (a 500
-the UI hides behind a success state) is still recorded. The stage emits an
-ordered set of step screenshots plus a structured captured-failures list
-(non-2xx responses, request failures, page errors, server-log exceptions) that
+Throughout the walk, `response`, `requestfailed`, and `pageerror` listeners run
+and the project server log is tailed, so a swallowed error response (a 500 the UI
+hides behind a success state) is still recorded. An error response is a status
+<200 or >=400; 3xx redirects are normal navigation (login/canonical) and are not
+flagged. The stage emits an ordered set of step screenshots plus a structured
+captured-failures list (error responses, request failures, page errors,
+server-log exceptions) that
 feeds the next stage. Every bounded cap — max screenshots, screens skipped, and
 the fixed no-retry policy — is logged explicitly.
 

--- a/test/loop/playwright-config-generation.test.mjs
+++ b/test/loop/playwright-config-generation.test.mjs
@@ -17,6 +17,15 @@ const expectedSliceIds = [
   VIEWER_REGISTRY.sliceId,
 ];
 
+// The config holds two kinds of webkit projects:
+//   1. rendered-artifact slice projects, auto-generated one-per-registry-entry
+//      (DECK/ARTICLE/VIEWER) — the generation invariant below pins these exactly.
+//   2. non-slice harness projects: net-new specs that reuse the webkit engine but
+//      drive an arbitrary running app, so they don't belong to any registry. These
+//      are declared explicitly in the config and are NOT held to the rendered-
+//      artifact sliceId == normalized-segment / test-results/ui-smoke coupling.
+const NON_SLICE_PROJECT_NAMES = new Set(['ui-review-drive']);
+
 test('playwright.config generates one webkit project per registered slice', () => {
   const projects = playwrightConfig.projects;
   assert.ok(Array.isArray(projects), 'config exposes a projects array');
@@ -25,16 +34,21 @@ test('playwright.config generates one webkit project per registered slice', () =
   for (const name of names) {
     assert.ok(typeof name === 'string' && name.length > 0, 'each project.name is a non-empty string');
   }
-  // Playwright requires unique project names; a duplicate sliceId would still
-  // pass a set-based comparison, so assert uniqueness explicitly.
+  // Playwright requires unique project names; a duplicate name would still
+  // pass a set-based comparison, so assert uniqueness explicitly across ALL
+  // projects (slice and non-slice alike).
   assert.equal(new Set(names).size, names.length, 'project names are unique');
 
-  const projectNames = [...names].sort();
-  assert.deepEqual(projectNames, [...expectedSliceIds].sort());
+  const sliceProjects = projects.filter((p) => !NON_SLICE_PROJECT_NAMES.has(p.name));
+  const nonSliceProjects = projects.filter((p) => NON_SLICE_PROJECT_NAMES.has(p.name));
 
-  for (const project of projects) {
+  // (a) The rendered-artifact slice projects match the registries exactly —
+  // adding/removing a slice must be a registry edit, not a config edit.
+  const sliceNames = sliceProjects.map((p) => p.name).sort();
+  assert.deepEqual(sliceNames, [...expectedSliceIds].sort());
+
+  for (const project of sliceProjects) {
     const sliceId = project.name;
-    assert.equal(project.name, sliceId);
     // Config enforces sliceId == normalized form so test-results/ui-smoke/<sliceId>
     // matches the artifact path segment the harness writes.
     assert.equal(project.name, normalizeUiStateSegment(project.name));
@@ -46,6 +60,23 @@ test('playwright.config generates one webkit project per registered slice', () =
     assert.ok(
       existsSync(path.join(repoRoot, 'test', 'playwright', `${sliceId}.spec.mjs`)),
       `spec test/playwright/${sliceId}.spec.mjs must exist on disk`,
+    );
+  }
+
+  // (b) Every declared non-slice harness project must be present and well-formed:
+  // it reuses the webkit engine and pins a real, existing spec — but it is NOT
+  // asserted to be a rendered-artifact slice.
+  const nonSliceNames = new Set(nonSliceProjects.map((p) => p.name));
+  for (const expected of NON_SLICE_PROJECT_NAMES) {
+    assert.ok(nonSliceNames.has(expected), `non-slice harness project "${expected}" must be declared`);
+  }
+  for (const project of nonSliceProjects) {
+    assert.equal(project.use.browserName, 'webkit');
+    assert.ok(Array.isArray(project.testMatch) && project.testMatch.length === 1, 'harness project pins one spec');
+    const specBasename = project.testMatch[0];
+    assert.ok(
+      existsSync(path.join(repoRoot, 'test', 'playwright', specBasename)),
+      `spec test/playwright/${specBasename} must exist on disk`,
     );
   }
 });

--- a/test/loop/ui-review-drive.test.mjs
+++ b/test/loop/ui-review-drive.test.mjs
@@ -92,6 +92,18 @@ test("swallowed non-2xx: the response listener AND the server-log tail both capt
   assert.ok(kinds.includes("server-log-exception"), "server-log tail must record the swallowed 500");
 });
 
+test("classifyFailures: a requestFailure becomes request-failed and a pageError becomes page-error", () => {
+  const failures = classifyFailures({
+    requestFailures: [{ url: "http://x/img", failure: "net::ERR" }],
+    pageErrors: [{ message: "TypeError: boom" }],
+  });
+  const byKind = Object.fromEntries(failures.map((f) => [f.kind, f]));
+  assert.equal(byKind["request-failed"].severity, "must-fix");
+  assert.match(byKind["request-failed"].message, /request failed at http:\/\/x\/img: net::ERR/);
+  assert.equal(byKind["page-error"].severity, "must-fix");
+  assert.match(byKind["page-error"].message, /uncaught page error: TypeError: boom/);
+});
+
 test("attachPageListeners: captures requestfailed and pageerror", () => {
   const page = fakePage();
   const { getCapturedEvents } = attachPageListeners(page);
@@ -144,9 +156,10 @@ test("selectFlows: caps the selection at maxFlows and logs the overflow reason",
 });
 
 test("resolveCaps: clamps to ceilings and pins retries to 0", () => {
-  const caps = resolveCaps({ maxScreenshots: 9999, maxFlows: 1, retries: 5 });
+  const caps = resolveCaps({ maxScreenshots: 9999, maxFlows: 1, maxStepsPerFlow: 9999, retries: 5 });
   assert.equal(caps.maxScreenshots, DEFAULT_DRIVE_CAPS.maxScreenshots); // clamped down
   assert.equal(caps.maxFlows, 1); // project may tighten
+  assert.equal(caps.maxStepsPerFlow, DEFAULT_DRIVE_CAPS.maxStepsPerFlow); // clamped down
   assert.equal(caps.retries, 0); // no-retry is fixed policy
 });
 
@@ -198,6 +211,19 @@ test("driveUiReview: enforces maxScreenshots and logs screens skipped", async ()
   assert.equal(r.steps.length, 2, "only up to the cap are captured");
   assert.equal(r.screensSkipped, 3);
   assert.ok(logs.some((m) => /screens skipped: 3/.test(m)));
+});
+
+test("driveUiReview: caps a flow at maxStepsPerFlow and logs the truncation", async () => {
+  const steps = Array.from({ length: 5 }, (_, i) => ({ name: `s${i}`, action: "goto" }));
+  const logs = [];
+  let calls = 0;
+  const r = await driveUiReview(
+    { appUrl: "http://app", login: {}, flows: [{ name: "f", steps }], caps: { maxStepsPerFlow: 2 } },
+    baseSeams({ runStep: async ({ step }) => (calls += 1, { ok: true, screenshotPath: `/o/${step.name}.png` }), log: (m) => logs.push(m) }),
+  );
+  assert.equal(calls, 2, "only the capped number of steps run");
+  assert.equal(r.steps.length, 2);
+  assert.ok(logs.some((m) => /maxStepsPerFlow cap \(2\)/.test(m)), "the step truncation is logged");
 });
 
 test("driveUiReview: collates a swallowed non-2xx from the injected listener + log tail", async () => {

--- a/test/loop/ui-review-drive.test.mjs
+++ b/test/loop/ui-review-drive.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test, { after } from "node:test";
-import { mkdtempSync, rmSync, writeFileSync, appendFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, appendFileSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -10,6 +10,7 @@ import {
   selectFlows,
   classifyFailures,
   driveUiReview,
+  isErrorResponseStatus,
 } from "@dev-loops/core/loop/ui-review-drive";
 import { resolveUiReviewDriveRecipe, DEFAULT_SERVER_LOG_EXCEPTION_PATTERN } from "@dev-loops/core/config";
 import {
@@ -109,28 +110,66 @@ test("classifyFailures: an invalid serverLogExceptionPattern degrades to a surfa
   assert.ok(!byKind["server-log-exception"], "server-log line classification is skipped");
 });
 
-test("classifyFailures: a requestFailure becomes request-failed and a pageError becomes page-error", () => {
+test("isErrorResponseStatus: one owner flags <200/>=400 and clears 2xx/3xx", () => {
+  assert.equal(isErrorResponseStatus(500), true);
+  assert.equal(isErrorResponseStatus(199), true);
+  assert.equal(isErrorResponseStatus(200), false);
+  assert.equal(isErrorResponseStatus(302), false, "3xx redirects are normal navigation");
+  assert.equal(isErrorResponseStatus(399), false);
+  assert.equal(isErrorResponseStatus(400), true);
+  assert.equal(isErrorResponseStatus("500"), false, "non-number is not an error status");
+});
+
+test("classifyFailures: server-log-exception carries surrounding traceback frames as context", () => {
+  const tail = [
+    "I, [ts] INFO -- : Started POST /save",
+    "app/controllers/save_controller.rb:17:in `create'",
+    "ERROR 500 Internal Server Error: NoMethodError",
+    "app/models/deck.rb:42:in `publish'",
+    "I, [ts] INFO -- : Completed 500",
+  ].join("\n");
+  const failures = classifyFailures({ serverLogTail: tail, serverLogExceptionPattern: "ERROR 500" });
+  const exc = failures.find((f) => f.kind === "server-log-exception");
+  assert.ok(exc, "the matching line is classified");
+  // The file:line frames sit on adjacent, non-matching lines; they survive.
+  assert.match(exc.context, /save_controller\.rb:17/);
+  assert.match(exc.context, /deck\.rb:42/);
+});
+
+test("classifyFailures: a requestFailure becomes request-failed and a pageError becomes page-error carrying err.stack", () => {
   const failures = classifyFailures({
     requestFailures: [{ url: "http://x/img", failure: "net::ERR" }],
-    pageErrors: [{ message: "TypeError: boom" }],
+    pageErrors: [{ message: "TypeError: boom", stack: "TypeError: boom\n    at app.js:42:9" }],
   });
   const byKind = Object.fromEntries(failures.map((f) => [f.kind, f]));
   assert.equal(byKind["request-failed"].severity, "must-fix");
   assert.match(byKind["request-failed"].message, /request failed at http:\/\/x\/img: net::ERR/);
   assert.equal(byKind["page-error"].severity, "must-fix");
   assert.match(byKind["page-error"].message, /uncaught page error: TypeError: boom/);
+  // Stage 3 exception -> source-line mapping needs the stack on the feed entry.
+  assert.match(byKind["page-error"].stack, /at app\.js:42:9/);
 });
 
-test("attachPageListeners: captures requestfailed and pageerror", () => {
+test("classifyFailures: page-error stack is null when absent and bounded when huge", () => {
+  const huge = "x".repeat(10000);
+  const failures = classifyFailures({ pageErrors: [{ message: "no stack" }, { message: "big", stack: huge }] });
+  const entries = failures.filter((f) => f.kind === "page-error");
+  assert.equal(entries[0].stack, null, "no stack -> null, never undefined");
+  assert.ok(entries[1].stack.length < huge.length, "a runaway stack is bounded before it lands on the feed");
+});
+
+test("attachPageListeners: captures requestfailed and pageerror (with err.stack for Stage 3)", () => {
   const page = fakePage();
   const { getCapturedEvents } = attachPageListeners(page);
   page.emit("response", { status: () => 204, url: () => "http://x/ok" }); // 2xx ignored
+  page.emit("response", { status: () => 302, url: () => "http://x/redir" }); // 3xx ignored (shared predicate)
   page.emit("requestfailed", { url: () => "http://x/img", failure: () => ({ errorText: "net::ERR" }) });
-  page.emit("pageerror", { message: "TypeError: boom" });
+  page.emit("pageerror", { message: "TypeError: boom", stack: "TypeError: boom\n    at app.js:42:9" });
   const e = getCapturedEvents();
-  assert.equal(e.responses.length, 0, "2xx responses are not retained");
+  assert.equal(e.responses.length, 0, "2xx/3xx responses are not retained");
   assert.deepEqual(e.requestFailures, [{ url: "http://x/img", failure: "net::ERR" }]);
-  assert.deepEqual(e.pageErrors, [{ message: "TypeError: boom" }]);
+  // The file:line signal Stage 3 needs is captured off err.stack, not discarded.
+  assert.deepEqual(e.pageErrors, [{ message: "TypeError: boom", stack: "TypeError: boom\n    at app.js:42:9" }]);
 });
 
 test("openServerLogTail: absent path is a no-op; missing file reads once created", async () => {
@@ -139,6 +178,18 @@ test("openServerLogTail: absent path is a no-op; missing file reads once created
   const tail = openServerLogTail(p); // file does not exist yet
   writeFileSync(p, "boot line\n");
   assert.match(await tail.read(), /boot line/);
+});
+
+test("openServerLogTail: a present-but-unreadable log is surfaced as a note, not silent empty", async () => {
+  if (typeof process.getuid === "function" && process.getuid() === 0) return; // root bypasses file perms
+  const p = path.join(tempDir(), "locked.log");
+  writeFileSync(p, "ERROR 500 boom\n"); // present, with content a review would want
+  chmodSync(p, 0o000); // now unreadable
+  const notes = [];
+  const out = await openServerLogTail(p, { log: (m) => notes.push(m) }).read();
+  chmodSync(p, 0o600); // restore so temp cleanup can remove it
+  assert.equal(out, "", "degrades to an empty tail (never throws)");
+  assert.ok(notes.some((m) => /unreadable/.test(m)), "a genuinely unreadable log is surfaced, not silently treated as empty");
 });
 
 test("openServerLogTail: caps a huge delta to the last maxBytes and logs the truncation", async () => {

--- a/test/loop/ui-review-drive.test.mjs
+++ b/test/loop/ui-review-drive.test.mjs
@@ -1,0 +1,243 @@
+import assert from "node:assert/strict";
+import test, { after } from "node:test";
+import { mkdtempSync, rmSync, writeFileSync, appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  DEFAULT_DRIVE_CAPS,
+  resolveCaps,
+  selectFlows,
+  classifyFailures,
+  driveUiReview,
+} from "@dev-loops/core/loop/ui-review-drive";
+import { resolveUiReviewDriveRecipe, DEFAULT_SERVER_LOG_EXCEPTION_PATTERN } from "@dev-loops/core/config";
+import {
+  parseUiReviewDriveCliArgs,
+  attachPageListeners,
+  openServerLogTail,
+} from "../../scripts/loop/ui-review-drive.mjs";
+
+const tempFiles = [];
+after(() => {
+  for (const f of tempFiles) rmSync(f, { recursive: true, force: true });
+});
+function tempDir() {
+  const d = mkdtempSync(path.join(tmpdir(), "ui-drive-"));
+  tempFiles.push(d);
+  return d;
+}
+
+// A fake page exposing Playwright's emitter interface, so attachPageListeners is
+// exercised for real without launching a browser.
+function fakePage() {
+  const handlers = {};
+  return {
+    on: (ev, cb) => ((handlers[ev] ??= []).push(cb), undefined),
+    emit: (ev, arg) => (handlers[ev] ?? []).forEach((cb) => cb(arg)),
+  };
+}
+
+// ── CLI parsing ────────────────────────────────────────────────────────────
+
+test("parseUiReviewDriveCliArgs: requires --repo-root, --app-url, --output-dir", () => {
+  assert.throws(() => parseUiReviewDriveCliArgs(["--app-url", "http://x", "--output-dir", "/o"]), /repo-root/);
+  assert.throws(() => parseUiReviewDriveCliArgs(["--repo-root", "/r", "--output-dir", "/o"]), /app-url/);
+  assert.throws(() => parseUiReviewDriveCliArgs(["--repo-root", "/r", "--app-url", "http://x"]), /output-dir/);
+});
+
+test("parseUiReviewDriveCliArgs: collects repeatable --changed-path", () => {
+  const o = parseUiReviewDriveCliArgs([
+    "--repo-root", "/r", "--app-url", "http://x", "--output-dir", "/o",
+    "--changed-path", "app/a.rb", "--changed-path", "app/b.rb",
+  ]);
+  assert.deepEqual(o.changedPaths, ["app/a.rb", "app/b.rb"]);
+});
+
+// ── The AC test: a swallowed non-2xx is captured by the listener AND the log ──
+
+test("swallowed non-2xx: the response listener AND the server-log tail both capture a hidden 500", async () => {
+  // Fixture: a page that fires a 500 response the UI swallows (no visible error),
+  // and a server that logs the 500 during the drive. Uses the real harness
+  // listener + real log tail + real classifier — no browser required.
+  const page = fakePage();
+  const { getCapturedEvents } = attachPageListeners(page);
+
+  const logPath = path.join(tempDir(), "server.log");
+  writeFileSync(logPath, "GET / 200 OK\n"); // pre-existing history the tail must NOT re-report
+  const tail = openServerLogTail(logPath); // pins the offset at drive start
+
+  // ── drive happens: the app 500s on save but renders a success toast ──
+  page.emit("response", { status: () => 500, url: () => "http://app.test/api/save" });
+  appendFileSync(logPath, "ERROR 500 Internal Server Error: NoMethodError in SaveController#create\n");
+
+  const events = getCapturedEvents();
+  const serverLogTail = await tail.read();
+
+  // The listener saw the wire status even though the UI hid it.
+  assert.deepEqual(events.responses, [{ url: "http://app.test/api/save", status: 500 }]);
+  // The tail returned only the delta since drive start (not the 200 history line).
+  assert.match(serverLogTail, /NoMethodError/);
+  assert.doesNotMatch(serverLogTail, /GET \/ 200/);
+
+  const failures = classifyFailures({
+    responses: events.responses,
+    requestFailures: events.requestFailures,
+    pageErrors: events.pageErrors,
+    serverLogTail,
+    serverLogExceptionPattern: DEFAULT_SERVER_LOG_EXCEPTION_PATTERN,
+  });
+  const kinds = failures.map((f) => f.kind);
+  assert.ok(kinds.includes("non-2xx-response"), "response listener must record the swallowed 500");
+  assert.ok(kinds.includes("server-log-exception"), "server-log tail must record the swallowed 500");
+});
+
+test("attachPageListeners: captures requestfailed and pageerror", () => {
+  const page = fakePage();
+  const { getCapturedEvents } = attachPageListeners(page);
+  page.emit("response", { status: () => 204, url: () => "http://x/ok" }); // 2xx ignored
+  page.emit("requestfailed", { url: () => "http://x/img", failure: () => ({ errorText: "net::ERR" }) });
+  page.emit("pageerror", { message: "TypeError: boom" });
+  const e = getCapturedEvents();
+  assert.equal(e.responses.length, 0, "2xx responses are not retained");
+  assert.deepEqual(e.requestFailures, [{ url: "http://x/img", failure: "net::ERR" }]);
+  assert.deepEqual(e.pageErrors, [{ message: "TypeError: boom" }]);
+});
+
+test("openServerLogTail: absent path is a no-op; missing file reads once created", async () => {
+  assert.equal(await openServerLogTail(null).read(), "");
+  const p = path.join(tempDir(), "late.log");
+  const tail = openServerLogTail(p); // file does not exist yet
+  writeFileSync(p, "boot line\n");
+  assert.match(await tail.read(), /boot line/);
+});
+
+// ── Changed-flow discovery heuristic ─────────────────────────────────────────
+
+test("selectFlows: drives only flows whose pathPatterns match a changed path", () => {
+  const flows = [
+    { name: "decks", pathPatterns: ["app/decks"], steps: [] },
+    { name: "users", pathPatterns: ["app/users"], steps: [] },
+  ];
+  const { selected, skipped } = selectFlows({ flows, changedPaths: ["app/decks/edit.rb"] });
+  assert.deepEqual(selected.map((f) => f.name), ["decks"]);
+  assert.equal(skipped[0].name, "users");
+});
+
+test("selectFlows: a flow with no pathPatterns is always in scope", () => {
+  const flows = [{ name: "always", steps: [] }];
+  const { selected } = selectFlows({ flows, changedPaths: ["anything.rb"] });
+  assert.deepEqual(selected.map((f) => f.name), ["always"]);
+});
+
+test("selectFlows: an unknown diff (no changed paths) drives every allowlisted flow", () => {
+  const flows = [{ name: "a", pathPatterns: ["x"], steps: [] }, { name: "b", pathPatterns: ["y"], steps: [] }];
+  const { selected } = selectFlows({ flows, changedPaths: [] });
+  assert.deepEqual(selected.map((f) => f.name), ["a", "b"]);
+});
+
+test("selectFlows: caps the selection at maxFlows and logs the overflow reason", () => {
+  const flows = Array.from({ length: 5 }, (_, i) => ({ name: `f${i}`, steps: [] }));
+  const { selected, skipped } = selectFlows({ flows, changedPaths: [], caps: { ...DEFAULT_DRIVE_CAPS, maxFlows: 2 } });
+  assert.equal(selected.length, 2);
+  assert.ok(skipped.some((s) => /maxFlows cap/.test(s.reason)));
+});
+
+test("resolveCaps: clamps to ceilings and pins retries to 0", () => {
+  const caps = resolveCaps({ maxScreenshots: 9999, maxFlows: 1, retries: 5 });
+  assert.equal(caps.maxScreenshots, DEFAULT_DRIVE_CAPS.maxScreenshots); // clamped down
+  assert.equal(caps.maxFlows, 1); // project may tighten
+  assert.equal(caps.retries, 0); // no-retry is fixed policy
+});
+
+// ── driveUiReview orchestration ──────────────────────────────────────────────
+
+const baseSeams = (over = {}) => ({
+  authenticate: async () => ({ ok: true, detail: "ok" }),
+  dismissInterstitials: async () => ({ dismissed: [] }),
+  runStep: async ({ step }) => ({ ok: true, screenshotPath: `/o/${step.name}.png`, statePath: `/o/${step.name}.json` }),
+  getCapturedEvents: () => ({ responses: [], requestFailures: [], pageErrors: [] }),
+  readServerLogTail: async () => "",
+  ...over,
+});
+
+test("driveUiReview: fails closed with a stated reason when auth fails (drives nothing)", async () => {
+  const logs = [];
+  const r = await driveUiReview(
+    { appUrl: "http://app", login: {}, flows: [{ name: "f", steps: [{ name: "s", action: "goto" }] }] },
+    baseSeams({ authenticate: async () => ({ ok: false, detail: "bad password" }), log: (m) => logs.push(m) }),
+  );
+  assert.equal(r.stopped, true);
+  assert.match(r.stopReason, /cannot authenticate: bad password/);
+  assert.equal(r.steps.length, 0, "nothing is driven without a session");
+  assert.equal(r.failures[0].kind, "auth-failed");
+});
+
+test("driveUiReview: no-retry is logged and a thrown step becomes a step-failure (not re-run)", async () => {
+  const logs = [];
+  let calls = 0;
+  const r = await driveUiReview(
+    { appUrl: "http://app", login: {}, flows: [{ name: "f", steps: [{ name: "boom", action: "click" }] }] },
+    baseSeams({
+      runStep: async () => { calls += 1; throw new Error("selector missing"); },
+      log: (m) => logs.push(m),
+    }),
+  );
+  assert.equal(calls, 1, "the failing step is not retried");
+  assert.ok(logs.some((m) => /no-retry/.test(m)), "the no-retry cap is logged");
+  assert.ok(r.failures.some((f) => f.kind === "step-failure"));
+});
+
+test("driveUiReview: enforces maxScreenshots and logs screens skipped", async () => {
+  const steps = Array.from({ length: 5 }, (_, i) => ({ name: `s${i}`, action: "goto" }));
+  const logs = [];
+  const r = await driveUiReview(
+    { appUrl: "http://app", login: {}, flows: [{ name: "f", steps }], caps: { maxScreenshots: 2 } },
+    baseSeams({ log: (m) => logs.push(m) }),
+  );
+  assert.equal(r.steps.length, 2, "only up to the cap are captured");
+  assert.equal(r.screensSkipped, 3);
+  assert.ok(logs.some((m) => /screens skipped: 3/.test(m)));
+});
+
+test("driveUiReview: collates a swallowed non-2xx from the injected listener + log tail", async () => {
+  const r = await driveUiReview(
+    { appUrl: "http://app", login: {}, flows: [{ name: "f", steps: [{ name: "save", action: "click" }] }], serverLogExceptionPattern: DEFAULT_SERVER_LOG_EXCEPTION_PATTERN },
+    baseSeams({
+      getCapturedEvents: () => ({ responses: [{ url: "http://app/save", status: 500 }], requestFailures: [], pageErrors: [] }),
+      readServerLogTail: async () => "ERROR 500 Internal Server Error\n",
+    }),
+  );
+  assert.equal(r.ok, false);
+  const kinds = r.failures.map((f) => f.kind).sort();
+  assert.deepEqual(kinds, ["non-2xx-response", "server-log-exception"]);
+});
+
+// ── Config resolver ──────────────────────────────────────────────────────────
+
+test("resolveUiReviewDriveRecipe: null when no login recipe is declared", () => {
+  assert.equal(resolveUiReviewDriveRecipe({ uiReview: { run: { command: "x", readyUrl: "http://x" } } }), null);
+  assert.equal(resolveUiReviewDriveRecipe({}), null);
+});
+
+test("resolveUiReviewDriveRecipe: resolves login + defaults the log-exception pattern", () => {
+  const r = resolveUiReviewDriveRecipe({
+    uiReview: {
+      login: { loginUrl: "http://app/login", submitSelector: "button[type=submit]", successSelector: "#dashboard" },
+      serverLogPath: "log/dev.log",
+    },
+  });
+  assert.equal(r.login.loginUrl, "http://app/login");
+  assert.equal(r.serverLogPath, "log/dev.log");
+  assert.equal(r.serverLogExceptionPattern, DEFAULT_SERVER_LOG_EXCEPTION_PATTERN);
+});
+
+test("resolveUiReviewDriveRecipe: honours an explicit log-exception pattern override", () => {
+  const r = resolveUiReviewDriveRecipe({
+    uiReview: {
+      login: { loginUrl: "http://app/login", submitSelector: "b", successSelector: "#ok" },
+      serverLogExceptionPattern: "MY_MARKER",
+    },
+  });
+  assert.equal(r.serverLogExceptionPattern, "MY_MARKER");
+});

--- a/test/loop/ui-review-drive.test.mjs
+++ b/test/loop/ui-review-drive.test.mjs
@@ -54,9 +54,9 @@ test("parseUiReviewDriveCliArgs: collects repeatable --changed-path", () => {
   assert.deepEqual(o.changedPaths, ["app/a.rb", "app/b.rb"]);
 });
 
-// ── The AC test: a swallowed non-2xx is captured by the listener AND the log ──
+// ─ The AC test: a swallowed error response is captured by the listener AND log ─
 
-test("swallowed non-2xx: the response listener AND the server-log tail both capture a hidden 500", async () => {
+test("swallowed error response: the response listener AND the server-log tail both capture a hidden 500", async () => {
   // Fixture: a page that fires a 500 response the UI swallows (no visible error),
   // and a server that logs the 500 during the drive. Uses the real harness
   // listener + real log tail + real classifier — no browser required.
@@ -88,8 +88,25 @@ test("swallowed non-2xx: the response listener AND the server-log tail both capt
     serverLogExceptionPattern: DEFAULT_SERVER_LOG_EXCEPTION_PATTERN,
   });
   const kinds = failures.map((f) => f.kind);
-  assert.ok(kinds.includes("non-2xx-response"), "response listener must record the swallowed 500");
+  assert.ok(kinds.includes("error-response"), "response listener must record the swallowed 500");
   assert.ok(kinds.includes("server-log-exception"), "server-log tail must record the swallowed 500");
+});
+
+test("classifyFailures: an invalid serverLogExceptionPattern degrades to a surfaced note (no throw)", () => {
+  let failures;
+  assert.doesNotThrow(() => {
+    failures = classifyFailures({
+      responses: [{ url: "http://app/save", status: 500 }],
+      serverLogTail: "ERROR 500 Internal Server Error\n",
+      serverLogExceptionPattern: "[", // not a valid regex
+    });
+  });
+  const byKind = Object.fromEntries(failures.map((f) => [f.kind, f]));
+  // The bad pattern is surfaced as a note, server-log classification is skipped,
+  // and the wire-level error response is still recorded.
+  assert.equal(byKind["server-log-pattern-invalid"].severity, "note");
+  assert.ok(byKind["error-response"], "response classification still runs");
+  assert.ok(!byKind["server-log-exception"], "server-log line classification is skipped");
 });
 
 test("classifyFailures: a requestFailure becomes request-failed and a pageError becomes page-error", () => {
@@ -122,6 +139,19 @@ test("openServerLogTail: absent path is a no-op; missing file reads once created
   const tail = openServerLogTail(p); // file does not exist yet
   writeFileSync(p, "boot line\n");
   assert.match(await tail.read(), /boot line/);
+});
+
+test("openServerLogTail: caps a huge delta to the last maxBytes and logs the truncation", async () => {
+  const p = path.join(tempDir(), "big.log");
+  writeFileSync(p, ""); // pins offset at 0
+  const notes = [];
+  const tail = openServerLogTail(p, { maxBytes: 1024, log: (m) => notes.push(m) });
+  // Append far more than the cap; the newest bytes carry the marker to keep.
+  appendFileSync(p, "x".repeat(4096) + "\nTAIL_MARKER\n");
+  const out = await tail.read();
+  assert.ok(Buffer.byteLength(out, "utf8") <= 1024, "read is capped to maxBytes");
+  assert.match(out, /TAIL_MARKER/, "the newest bytes (where a just-logged 500 lives) are kept");
+  assert.ok(notes.some((m) => /truncated/.test(m)), "truncation is logged, not silent");
 });
 
 // ── Changed-flow discovery heuristic ─────────────────────────────────────────
@@ -226,7 +256,7 @@ test("driveUiReview: caps a flow at maxStepsPerFlow and logs the truncation", as
   assert.ok(logs.some((m) => /maxStepsPerFlow cap \(2\)/.test(m)), "the step truncation is logged");
 });
 
-test("driveUiReview: collates a swallowed non-2xx from the injected listener + log tail", async () => {
+test("driveUiReview: collates a swallowed error response from the injected listener + log tail", async () => {
   const r = await driveUiReview(
     { appUrl: "http://app", login: {}, flows: [{ name: "f", steps: [{ name: "save", action: "click" }] }], serverLogExceptionPattern: DEFAULT_SERVER_LOG_EXCEPTION_PATTERN },
     baseSeams({
@@ -236,7 +266,7 @@ test("driveUiReview: collates a swallowed non-2xx from the injected listener + l
   );
   assert.equal(r.ok, false);
   const kinds = r.failures.map((f) => f.kind).sort();
-  assert.deepEqual(kinds, ["non-2xx-response", "server-log-exception"]);
+  assert.deepEqual(kinds, ["error-response", "server-log-exception"]);
 });
 
 // ── Config resolver ──────────────────────────────────────────────────────────

--- a/test/playwright/ui-review-drive.spec.mjs
+++ b/test/playwright/ui-review-drive.spec.mjs
@@ -1,6 +1,5 @@
 import { createServer } from "node:http";
-import { mkdtempSync, existsSync, appendFileSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, appendFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 import { test, expect } from "@playwright/test";
@@ -41,7 +40,7 @@ function makeFixtureApp(logPath) {
       return;
     }
     if (route === "/api/save") {
-      // The swallowed non-2xx: the server errors and logs it, the UI hides it.
+      // The swallowed error response: the server errors and logs it, the UI hides it.
       appendFileSync(logPath, "ERROR 500 Internal Server Error: NoMethodError in DecksController#save\n");
       res.writeHead(500, { "content-type": "text/plain" });
       res.end("boom");
@@ -52,9 +51,12 @@ function makeFixtureApp(logPath) {
   });
 }
 
-test("webkit drive harness captures a swallowed non-2xx via the response listener AND the server-log tail", async ({ page }) => {
-  const outputDir = mkdtempSync(path.join(tmpdir(), "ui-drive-spec-"));
-  const logPath = path.join(outputDir, "server.log");
+test("webkit drive harness captures a swallowed error response via the response listener AND the server-log tail", async ({ page }, testInfo) => {
+  // Write artifacts under Playwright's per-test outputDir so CI artifact
+  // collection/retention captures them and cleanup is handled — not an OS temp
+  // dir that leaks and escapes outputDir retention.
+  const outputDir = testInfo.outputDir;
+  const logPath = testInfo.outputPath("server.log");
   writeFileSync(logPath, "GET /login 200\n"); // history the tail must not re-report
 
   const { server, url } = await startFixtureServer(() => makeFixtureApp(logPath));
@@ -119,7 +121,7 @@ test("webkit drive harness captures a swallowed non-2xx via the response listene
 
     // The UI hid the failure ("Saved!"), yet the drive stage recorded it twice.
     const kinds = result.failures.map((f) => f.kind);
-    expect(kinds, "response listener must record the swallowed 500").toContain("non-2xx-response");
+    expect(kinds, "response listener must record the swallowed 500").toContain("error-response");
     expect(kinds, "server-log tail must record the swallowed 500").toContain("server-log-exception");
     expect(result.captures.length).toBe(2);
     expect(existsSync(result.captures[0].screenshotPath)).toBe(true);

--- a/test/playwright/ui-review-drive.spec.mjs
+++ b/test/playwright/ui-review-drive.spec.mjs
@@ -66,7 +66,7 @@ test("webkit drive harness captures a swallowed non-2xx via the response listene
       {
         appUrl: url,
         login: { loginUrl: `${url}/login`, submitSelector: "#login", successSelector: "#dashboard" },
-        interstitials: [{ selector: "#accept-cookies", optional: true }],
+        interstitials: [{ selector: "#accept-cookies" }],
         flows: [
           {
             name: "decks",

--- a/test/playwright/ui-review-drive.spec.mjs
+++ b/test/playwright/ui-review-drive.spec.mjs
@@ -1,0 +1,129 @@
+import { createServer } from "node:http";
+import { mkdtempSync, existsSync, appendFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { test, expect } from "@playwright/test";
+
+import { driveUiReview } from "@dev-loops/core/loop/ui-review-drive";
+import {
+  attachPageListeners,
+  openServerLogTail,
+} from "../../scripts/loop/ui-review-drive.mjs";
+import { startFixtureServer, stopFixtureServer } from "./harness/webkit-smoke-harness.mjs";
+
+// A tiny fixture app that authenticates via a dev-login button, shows a cookie
+// interstitial, and — the point of the test — swallows a 500: the "Save" button
+// POSTs to /api/save, which 500s and logs the failure server-side, but the page
+// renders "Saved!" regardless, hiding the error from a human reviewer.
+function makeFixtureApp(logPath) {
+  const page = (title, body) =>
+    `<!doctype html><html><head><title>${title}</title></head><body>${body}</body></html>`;
+  return createServer((req, res) => {
+    const route = (req.url ?? "/").split("?")[0];
+    if (route === "/login") {
+      res.writeHead(200, { "content-type": "text/html" });
+      res.end(page("login", `<button id="login" onclick="location.href='/decks'">Sign in (dev)</button>`));
+      return;
+    }
+    if (route === "/decks") {
+      res.writeHead(200, { "content-type": "text/html" });
+      res.end(page("decks", `
+        <div id="dashboard">Decks</div>
+        <div id="cookie-banner"><button id="accept-cookies">Accept</button></div>
+        <button id="save" onclick="
+          fetch('/api/save', { method: 'POST' })
+            .catch(() => {})
+            .finally(() => { document.getElementById('status').textContent = 'Saved!'; });
+        ">Save</button>
+        <div id="status"></div>
+      `));
+      return;
+    }
+    if (route === "/api/save") {
+      // The swallowed non-2xx: the server errors and logs it, the UI hides it.
+      appendFileSync(logPath, "ERROR 500 Internal Server Error: NoMethodError in DecksController#save\n");
+      res.writeHead(500, { "content-type": "text/plain" });
+      res.end("boom");
+      return;
+    }
+    res.writeHead(200, { "content-type": "text/plain" });
+    res.end("ok");
+  });
+}
+
+test("webkit drive harness captures a swallowed non-2xx via the response listener AND the server-log tail", async ({ page }) => {
+  const outputDir = mkdtempSync(path.join(tmpdir(), "ui-drive-spec-"));
+  const logPath = path.join(outputDir, "server.log");
+  writeFileSync(logPath, "GET /login 200\n"); // history the tail must not re-report
+
+  const { server, url } = await startFixtureServer(() => makeFixtureApp(logPath));
+  const { getCapturedEvents } = attachPageListeners(page);
+  const logTail = openServerLogTail(logPath);
+
+  try {
+    const result = await driveUiReview(
+      {
+        appUrl: url,
+        login: { loginUrl: `${url}/login`, submitSelector: "#login", successSelector: "#dashboard" },
+        interstitials: [{ selector: "#accept-cookies", optional: true }],
+        flows: [
+          {
+            name: "decks",
+            steps: [
+              { name: "open decks", action: "goto", path: "/decks" },
+              { name: "save deck", action: "click", selector: "#save" },
+            ],
+          },
+        ],
+        serverLogExceptionPattern: "5\\d{2}|Internal Server Error",
+      },
+      {
+        authenticate: async ({ login }) => {
+          try {
+            await page.goto(login.loginUrl, { waitUntil: "domcontentloaded" });
+            await page.click(login.submitSelector);
+            await page.waitForSelector(login.successSelector, { state: "visible", timeout: 10_000 });
+            return { ok: true, detail: "signed in" };
+          } catch (err) {
+            return { ok: false, detail: String(err) };
+          }
+        },
+        dismissInterstitials: async ({ interstitials }) => {
+          const dismissed = [];
+          for (const it of interstitials) {
+            const el = page.locator(it.selector).first();
+            if (await el.isVisible().catch(() => false)) {
+              await el.click();
+              dismissed.push(it.selector);
+            }
+          }
+          return { dismissed };
+        },
+        runStep: async ({ appUrl, flow, step }) => {
+          if (step.action === "goto") {
+            await page.goto(new URL(step.path, appUrl).toString(), { waitUntil: "domcontentloaded" });
+          } else if (step.action === "click") {
+            await page.click(step.selector);
+            // Wait for the swallowed request to complete so its response is seen.
+            await page.waitForFunction(() => document.getElementById("status")?.textContent === "Saved!");
+          }
+          const shot = path.join(outputDir, `${flow.name}-${step.name.replace(/\W+/g, "-")}.png`);
+          await page.screenshot({ path: shot });
+          return { ok: true, screenshotPath: shot, statePath: null };
+        },
+        getCapturedEvents,
+        readServerLogTail: () => logTail.read(),
+      },
+    );
+
+    // The UI hid the failure ("Saved!"), yet the drive stage recorded it twice.
+    const kinds = result.failures.map((f) => f.kind);
+    expect(kinds, "response listener must record the swallowed 500").toContain("non-2xx-response");
+    expect(kinds, "server-log tail must record the swallowed 500").toContain("server-log-exception");
+    expect(result.captures.length).toBe(2);
+    expect(existsSync(result.captures[0].screenshotPath)).toBe(true);
+  } finally {
+    await stopFixtureServer(server);
+  }
+});


### PR DESCRIPTION
## Summary

Stage 2 of epic #1114 (`/loop-review-ui`). An **auth + Playwright drive harness** for the `ui_review` route: authenticates as the change's target role via a project-provided dev-login recipe, walks the changed flows headless (WebKit), and captures step screenshots plus a structured failure list — with `response`/`requestfailed`/`pageerror` listeners and a server-log tail running throughout so a swallowed 500 (hidden behind a success UI) is still recorded.

## Scope and context

In scope: a net-new core drive orchestrator (flow selection, caps, failure classification — pure, injected seams), a CLI/harness wiring real WebKit + listeners + `captureNamedUiState` + dev-login + server-log tail, the `uiReview.login`/`interstitials`/`flows`/`caps`/`serverLogPath` config surface, and tests (a real-WebKit spec + a browser-free harness-level proof). Out of scope (Stage 3+/Non-goals): exception→source-line mapping, review posting, visual-regression/pixel-diffing, cross-browser matrix.

## File-by-file changes

- `.claude/skills/ui-review/SKILL.md` — generated mirror of the ui-review skill doc.
- `package.json` — adds the drive test script (`@playwright/test` is pre-existing, reused).
- `packages/core/package.json` — exposes the `loop/ui-review-drive` subpath export.
- `packages/core/src/config/config.mjs` — the `uiReview` drive schema + `resolveUiReviewDriveRecipe`; interstitials carry only `selector` (the inert `optional` field dropped), and step actions are validated at parse time — selector-based actions require a `selector`, `goto` requires a `path`, and `upload` requires a `value` (the file to upload).
- `packages/core/src/loop/ui-review-drive.mjs` — the pure drive orchestrator (flow selection, cap enforcement, failure classification); the `maxStepsPerFlow` truncation is now logged like the other caps.
- `packages/core/test/config.test.mjs` — schema tests, incl. the new step-action-requires-selector accept/reject case.
- `playwright.config.mjs` — WebKit-only project config for the drive spec.
- `scripts/loop/ui-review-drive.mjs` — the CLI/harness wiring real IO seams; USAGE `Output` block reconciled with the actual emitted envelope (`caps`/`appUrl` on both paths, `screensSkipped` on the walk path).
- `skills/ui-review/SKILL.md` — source ui-review skill doc.
- `test/loop/playwright-config-generation.test.mjs` — asserts the generated Playwright config partitions the rendered-artifact slice projects from the non-slice `ui-review-drive` harness project (the drive spec runs under its own project, not the artifact-slice matrix).
- `test/loop/ui-review-drive.test.mjs` — harness-level tests, incl. new `request-failed`/`page-error` classification and `maxStepsPerFlow` cap coverage.
- `test/playwright/ui-review-drive.spec.mjs` — real-WebKit fixture-app proof of the swallowed-500 capture.

## Acceptance criteria

Mirrors the 8 AC items in #1118: project-provided dev-login recipe (never hard-coded); once-per-context interstitial dismissal; Playwright walker over changed flows against the arbitrary Stage-1 app URL; `response`(error responses — status <200 or >=400; 3xx redirects are normal navigation and not flagged)/`requestfailed`/`pageerror` listeners + server-log tail; reuse of `captureNamedUiState()` for per-step screenshot + `state.json`; installed `@playwright/test ^1.60.0` WebKit only; bounded caps logged; a fixture-app test asserting a swallowed error response is captured by the listener AND the log tail.

## Definition of done

For a booted UI PR, the stage produces an ordered set of step screenshots + `state.json` artifacts and a structured captured-failures list (error responses, page errors, server-log exceptions) for the changed flows, or stops with a stated reason (can't auth). This feeds Stage 3.

## Non-goals

No exception→source-line mapping (Stage 3). No review posting (Stage 4). No visual-regression/pixel-diffing. No cross-browser matrix.

## Validation

- `node --test test/loop/ui-review-drive.test.mjs` (harness-level: swallowed-500 proof, selection/caps/fail-closed-stop, classification kinds).
- `npm run test:playwright:ui-review-drive` (real WebKit, swallowed-500 caught by listener + log tail).
- `node --test packages/core/test/config.test.mjs`; `npm run test:core`; `npm run test:assets`.
- Full gate uses `npm run verify`.

Closes #1118
