### PR TITLE
feat(loop): diagnose + anchor exceptions to diff lines for ui_review (Stage 3 of #1114)

### DIFF
--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -107,8 +107,10 @@ dropped — one with no source location, a file that is not among the changed
 files, a line that is not on a changed diff line, or a file that maps
 ambiguously to more than one changed file is retained as a finding flagged
 non-anchorable (with a stated reason) so the poster body-attaches it instead of
-inlining. Every finding carries a reproduced-evidence reference to the drive's
-captured screenshot/state artifact.
+inlining. Each finding carries a reference to the drive's final captured
+screenshot/state artifact when one exists (null otherwise) — a single shared
+object across all findings, NOT per-failure attribution — so a Stage-4 consumer
+null-checks it and must not present it as proof of a specific finding.
 
 The findings list is ranked deterministically — severity, then anchorable-first,
 then kind, then source `file:line` — with no wall-clock or input-order

--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -88,9 +88,35 @@ defaulting to a heuristic that a project MUST override when its log format
 differs). The login form is branch-controlled trusted input, same threat
 boundary as the run recipe.
 
+## Diagnose + anchor
+
+Once failures are captured, the route maps each one to a source line and then to
+a PR diff line so the poster can anchor an inline comment on a real changed line,
+via
+`scripts/loop/ui-review-diagnose.mjs --pr <n> --drive-result <p> [--repo <slug>]`
+(pure mapping in `packages/core/src/loop/ui-review-diagnose.mjs`). It reuses PR
+state from `loop info --pr` rather than re-fetching, fetches the PR's unified
+diff, and for each failure parses the exception type/message plus the top in-repo
+stack frame (JS `at` frame, Ruby/Python traceback frame; vendor/framework frames
+in `node_modules`/`gems`/`vendor` are skipped). It then resolves the source
+`file:line` to a diff anchor `{ path, line, side: RIGHT }` on the head.
+
+Only ADDED lines are anchor targets: an inline comment lands on code the PR
+introduced, never on an unchanged context line. A failure is NEVER silently
+dropped — one with no source location, a file that is not among the changed
+files, a line that is not on a changed diff line, or a file that maps
+ambiguously to more than one changed file is retained as a finding flagged
+non-anchorable (with a stated reason) so the poster body-attaches it instead of
+inlining. Every finding carries a reproduced-evidence reference to the drive's
+captured screenshot/state artifact.
+
+The findings list is ranked deterministically — severity, then anchorable-first,
+then kind, then source `file:line` — with no wall-clock or input-order
+dependence, so the same failures always produce the same ordered output.
+
 ## Non-goals
 
-No diagnose/report/teardown logic lives here yet. The drive stage does not map an
-exception to its source line, post the review, pixel-diff for visual regression,
-run a cross-browser matrix, or touch a production DB — those are later stages or
-explicit non-goals.
+No report/teardown logic lives here yet. The stage does not post the review,
+publish artifacts, auto-fix the located defects, pixel-diff for visual
+regression, run a cross-browser matrix, or touch a production DB — those are
+later stages or explicit non-goals.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,6 +59,7 @@
     "./loop/ui-e2e-scoping": "./src/loop/ui-e2e-scoping.mjs",
     "./loop/ui-review-provision": "./src/loop/ui-review-provision.mjs",
     "./loop/ui-review-drive": "./src/loop/ui-review-drive.mjs",
+    "./loop/ui-review-diagnose": "./src/loop/ui-review-diagnose.mjs",
     "./projects/list-queue-items": "./src/projects/list-queue-items.mjs",
     "./projects/move-queue-item": "./src/projects/move-queue-item.mjs",
     "./projects/resolve-project": "./src/projects/resolve-project.mjs",

--- a/packages/core/src/loop/ui-review-diagnose.mjs
+++ b/packages/core/src/loop/ui-review-diagnose.mjs
@@ -86,16 +86,23 @@ export function topInRepoFrame(frames, inRepo = isInRepoFrame) {
 
 /**
  * Parse a unified diff into a map of changed file -> set of ADDED head line
- * numbers (the RIGHT side). Only added (`+`) lines are anchor targets: an inline
- * comment on an added line points at code the PR introduced. Unchanged context
- * lines advance the head counter but are not anchor targets — a defect on an
- * unchanged line is body-attached, not falsely pinned to "changed" code.
+ * numbers (the RIGHT side). EVERY changed file is a key (registered from its
+ * `diff --git`/`+++ ` header) so a file that is changed but adds no anchorable
+ * line (deletion-only, binary, or mode-only) still reports as changed with an
+ * empty set — distinct from a file the PR never touched. Only added (`+`) lines
+ * are anchor targets: an inline comment on an added line points at code the PR
+ * introduced. Unchanged context lines advance the head counter but are not
+ * anchor targets — a defect on an unchanged line is body-attached, not falsely
+ * pinned to "changed" code.
  *
  * @param {string} diffOutput - raw `gh pr diff` / `git diff` unified output.
  * @returns {Map<string, Set<number>>}
  */
 export function parseDiffAnchors(diffOutput = "") {
   const map = new Map();
+  const register = (p) => {
+    if (p !== null && !map.has(p)) map.set(p, new Set());
+  };
   let currentPath = null;
   let newLine = 0;
   let inHunk = false;
@@ -105,6 +112,10 @@ export function parseDiffAnchors(diffOutput = "") {
       // (content lines always carry a `+`/`-`/space prefix), so it always resets.
       currentPath = null;
       inHunk = false;
+      // Register the RIGHT-side path so binary/mode-only changes (which carry no
+      // `+++ ` header) still count as changed files.
+      const m = line.match(/^diff --git a\/.+ b\/(.+)$/u);
+      if (m) register(m[1]);
       continue;
     }
     // File headers appear only before the first hunk. Inside a hunk a line
@@ -114,6 +125,9 @@ export function parseDiffAnchors(diffOutput = "") {
     if (!inHunk && line.startsWith("+++ ")) {
       const p = line.slice(4).trim();
       currentPath = p === "/dev/null" ? null : p.replace(/^b\//u, "");
+      // Register even deletion-only files (they keep a `+++ b/path` header but
+      // add no line) so they report as changed rather than not-among-changed.
+      register(currentPath);
       continue;
     }
     if (!inHunk && line.startsWith("--- ")) {
@@ -144,12 +158,13 @@ export function parseDiffAnchors(diffOutput = "") {
 
 /** Normalize a stack-frame file to a repo-relative-comparable form: strip a URL
  * scheme+authority (`http://host/assets/x.js` -> `/assets/x.js`) and any
- * query/hash, so an absolute or served path can be suffix-matched to a diff path. */
+ * query/hash, then fold Windows `\` separators to `/`, so an absolute, served,
+ * or Windows-style path can be suffix-matched to a (forward-slash) diff path. */
 function normalizeFrameFile(file) {
   let s = String(file);
   const scheme = s.match(/^[a-z][a-z0-9+.\-]*:\/\/[^/]*(\/.*)$/iu);
   if (scheme) s = scheme[1];
-  return s.split(/[?#]/u)[0];
+  return s.split(/[?#]/u)[0].replace(/\\/gu, "/");
 }
 
 /** The source-file -> changed-file mapping is the fragile axis (bundlers, moved
@@ -208,7 +223,7 @@ function diagnoseOne(failure, anchorsByPath, inRepo, evidence) {
   }
   const path = matches[0];
   if (!anchorsByPath.get(path).has(frame.line)) {
-    finding.nonAnchorableReason = "source line is not on a changed diff line";
+    finding.nonAnchorableReason = "source line is not on an added diff line";
     return finding;
   }
   finding.anchor = { path, line: frame.line, side: RIGHT };

--- a/packages/core/src/loop/ui-review-diagnose.mjs
+++ b/packages/core/src/loop/ui-review-diagnose.mjs
@@ -1,0 +1,271 @@
+/**
+ * Diagnose + anchor for the ui_review route (Stage 3).
+ *
+ * Consumes the structured captured-failures feed from the drive stage and maps
+ * each failure — exception + JS stack or server-log traceback context — to a
+ * source location (the top in-repo stack frame), then to a diff line on the PR
+ * head so the poster stage can anchor an inline comment on a real changed line.
+ *
+ * This module is PURE: the diff text and the drive result are inputs, the
+ * in-repo-frame predicate is an injectable seam. The thin CLI wires the real IO
+ * (loop info for PR state + the PR diff fetch).
+ *
+ * Contract: a failure is NEVER silently dropped. One that has no source
+ * location, whose file is not in the diff, whose line is not on a changed diff
+ * line, or whose file maps ambiguously to more than one changed file, is
+ * RETAINED as a finding flagged non-anchorable (with a stated reason) so the
+ * poster body-attaches it instead of inlining.
+ *
+ * Out of scope (later stages): review posting, artifact publishing, auto-fixing.
+ */
+
+const RIGHT = "RIGHT";
+
+/** Severity ordering for the ranked findings list. Unknown severities sort last
+ * but before nothing — a finding is never dropped for an unrecognized severity. */
+const SEVERITY_RANK = Object.freeze({ "must-fix": 0, note: 1 });
+const severityRank = (s) => (s in SEVERITY_RANK ? SEVERITY_RANK[s] : 2);
+
+/** Frames whose file matches a vendor/framework/runtime marker are NOT in-repo:
+ * the diagnosis anchors the change's own code, not a dependency's internals. The
+ * default is deliberately conservative — a project with an unusual layout injects
+ * its own predicate rather than loosening this shared default. */
+const VENDOR_FRAME = /node_modules|[/\\]gems[/\\]|[/\\]vendor[/\\]|\bwebpack:\/\/|^node:|[/\\]ruby[/\\]|[/\\]dist-packages[/\\]/u;
+
+/** Default in-repo predicate: a non-empty file path that is not a vendor frame. */
+export function isInRepoFrame(file) {
+  return typeof file === "string" && file.length > 0 && !VENDOR_FRAME.test(file);
+}
+
+/** Extract the exception type + message from stack/traceback text. Matches the
+ * first `SomethingError`/`SomethingException` token and the text that follows it
+ * (JS `TypeError: msg`, Ruby `NoMethodError (msg)`, Python `ValueError: msg`).
+ * Returns nulls when no recognizable exception name is present. */
+export function parseException(text = "") {
+  const m = String(text).match(/([A-Za-z_][\w.]*(?:Error|Exception))\b[:\s(]*([^\n)]*)/u);
+  if (!m) return { type: null, message: null };
+  const message = m[2].trim();
+  return { type: m[1], message: message.length > 0 ? message : null };
+}
+
+/** Parse a single stack/traceback line into `{file, line}` or null. Tries the
+ * three shapes the drive feed can carry: Python `File "path", line N`, JS
+ * `at ... (file:line:col)`, then a generic `path.ext:line` (Ruby, and JS frames
+ * without an `at` prefix). */
+function extractFrameFromLine(line) {
+  let m = line.match(/File "([^"]+)", line (\d+)/u);
+  if (m) return { file: m[1], line: Number(m[2]) };
+  m = line.match(/\bat\s+(?:.*\()?([^\s():]+):(\d+)(?::\d+)?\)?\s*$/u);
+  if (m) return { file: m[1], line: Number(m[2]) };
+  m = line.match(/([^\s():]+\.[A-Za-z0-9_]+):(\d+)\b/u);
+  if (m) return { file: m[1], line: Number(m[2]) };
+  return null;
+}
+
+/** Extract all frames from multi-line stack/traceback text, preserving order. */
+export function extractFrames(text = "") {
+  const frames = [];
+  for (const line of String(text).split("\n")) {
+    const frame = extractFrameFromLine(line);
+    if (frame) frames.push(frame);
+  }
+  return frames;
+}
+
+/** The top in-repo frame drives the anchor: the first frame (topmost, closest to
+ * the throw) whose file passes the in-repo predicate. We do NOT search deeper for
+ * a frame that happens to be in the diff — anchoring a lower frame would point at
+ * a caller, not the failing line. A deeper frame that is in-repo but not in the
+ * diff is handled downstream as non-anchorable, never by guessing past the top. */
+export function topInRepoFrame(frames, inRepo = isInRepoFrame) {
+  return frames.find((f) => inRepo(f.file)) ?? null;
+}
+
+/**
+ * Parse a unified diff into a map of changed file -> set of ADDED head line
+ * numbers (the RIGHT side). Only added (`+`) lines are anchor targets: an inline
+ * comment on an added line points at code the PR introduced. Unchanged context
+ * lines advance the head counter but are not anchor targets — a defect on an
+ * unchanged line is body-attached, not falsely pinned to "changed" code.
+ *
+ * @param {string} diffOutput - raw `gh pr diff` / `git diff` unified output.
+ * @returns {Map<string, Set<number>>}
+ */
+export function parseDiffAnchors(diffOutput = "") {
+  const map = new Map();
+  let currentPath = null;
+  let newLine = 0;
+  let inHunk = false;
+  for (const line of String(diffOutput).split("\n")) {
+    if (line.startsWith("diff --git")) {
+      currentPath = null;
+      inHunk = false;
+      continue;
+    }
+    if (line.startsWith("+++ ")) {
+      const p = line.slice(4).trim();
+      currentPath = p === "/dev/null" ? null : p.replace(/^b\//u, "");
+      inHunk = false;
+      continue;
+    }
+    if (line.startsWith("--- ")) {
+      inHunk = false;
+      continue;
+    }
+    if (line.startsWith("@@")) {
+      const m = line.match(/@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/u);
+      newLine = m ? Number(m[1]) : 0;
+      inHunk = Boolean(m);
+      continue;
+    }
+    if (!inHunk || currentPath === null) continue;
+    if (line.startsWith("+")) {
+      if (!map.has(currentPath)) map.set(currentPath, new Set());
+      map.get(currentPath).add(newLine);
+      newLine += 1;
+    } else if (line.startsWith("-")) {
+      // Deleted line: present only on the old side, so it does not advance the head counter.
+    } else if (line.startsWith("\\")) {
+      // "\ No newline at end of file": a marker, not a content line.
+    } else {
+      // Context line: on both sides, so it advances the head counter but is not an anchor target.
+      newLine += 1;
+    }
+  }
+  return map;
+}
+
+/** Normalize a stack-frame file to a repo-relative-comparable form: strip a URL
+ * scheme+authority (`http://host/assets/x.js` -> `/assets/x.js`) and any
+ * query/hash, so an absolute or served path can be suffix-matched to a diff path. */
+function normalizeFrameFile(file) {
+  let s = String(file);
+  const scheme = s.match(/^[a-z][a-z0-9+.\-]*:\/\/[^/]*(\/.*)$/iu);
+  if (scheme) s = scheme[1];
+  return s.split(/[?#]/u)[0];
+}
+
+/** The source-file -> changed-file mapping is the fragile axis (bundlers, moved
+ * code, served paths). Match a frame file to a diff path by exact match or path
+ * suffix. Return every match so an ambiguous mapping (more than one changed file
+ * is a suffix of the frame path) is flagged rather than guessed. */
+function matchDiffPaths(frameFile, anchorPaths) {
+  const nf = normalizeFrameFile(frameFile);
+  return anchorPaths.filter((p) => nf === p || nf.endsWith(`/${p}`));
+}
+
+/**
+ * Map one Stage-2 failure to a finding: parse its exception + source location,
+ * resolve an anchor on the diff, or retain it flagged non-anchorable.
+ *
+ * @param {object} failure - a `classifyFailures` entry `{kind, severity, message, ...}`.
+ * @param {Map<string,Set<number>>} anchorsByPath
+ * @param {(file:string)=>boolean} inRepo
+ * @param {object|null} evidence - the reproduced-evidence reference to attach.
+ */
+function diagnoseOne(failure, anchorsByPath, inRepo, evidence) {
+  // page-error carries `stack`; server-log-exception carries `context`; the
+  // wire-level failures (error/request) carry neither -> no source location.
+  const sourceText =
+    failure.kind === "page-error" ? failure.stack :
+    failure.kind === "server-log-exception" ? failure.context :
+    "";
+  const exception = parseException(sourceText || failure.message || "");
+  const finding = {
+    severity: failure.severity ?? null,
+    kind: failure.kind,
+    message: failure.message ?? null,
+    exception,
+    source: null,
+    anchor: null,
+    anchorable: false,
+    nonAnchorableReason: null,
+    evidence,
+  };
+
+  const frame = topInRepoFrame(extractFrames(sourceText || ""), inRepo);
+  if (!frame) {
+    finding.nonAnchorableReason = "no source location (no in-repo stack frame in the captured failure)";
+    return finding;
+  }
+  finding.source = frame;
+
+  const matches = matchDiffPaths(frame.file, [...anchorsByPath.keys()]);
+  if (matches.length === 0) {
+    finding.nonAnchorableReason = "source file is not among the PR's changed files";
+    return finding;
+  }
+  if (matches.length > 1) {
+    finding.nonAnchorableReason = `ambiguous: source file maps to more than one changed file (${matches.join(", ")})`;
+    return finding;
+  }
+  const path = matches[0];
+  if (!anchorsByPath.get(path).has(frame.line)) {
+    finding.nonAnchorableReason = "source line is not on a changed diff line";
+    return finding;
+  }
+  finding.anchor = { path, line: frame.line, side: RIGHT };
+  finding.anchorable = true;
+  return finding;
+}
+
+/**
+ * Rank findings deterministically — no wall-clock, no input-order dependence.
+ * Order: severity (must-fix first), then anchorable-first (the poster can inline
+ * these), then kind, then source file, then source line. Every key is a total
+ * order over the data so the result is stable for a given input set.
+ */
+export function rankFindings(findings) {
+  const key = (f) => [
+    severityRank(f.severity),
+    f.anchorable ? 0 : 1,
+    f.kind ?? "",
+    f.source?.file ?? "",
+    f.source?.line ?? 0,
+  ];
+  return [...findings].sort((a, b) => {
+    const ka = key(a);
+    const kb = key(b);
+    for (let i = 0; i < ka.length; i += 1) {
+      if (ka[i] < kb[i]) return -1;
+      if (ka[i] > kb[i]) return 1;
+    }
+    return 0;
+  });
+}
+
+/**
+ * Diagnose the drive stage's captured failures into a ranked findings list with
+ * diff-line anchors or explicit non-anchorable flags plus reproduced-evidence
+ * references. Pure; inject `isInRepoFrame` to override the in-repo heuristic.
+ *
+ * @param {object} input
+ * @param {object[]} [input.failures] - the drive stage's `failures`.
+ * @param {object[]} [input.captures] - the drive stage's `captures` (evidence).
+ * @param {string} [input.diffOutput] - the PR's unified diff.
+ * @param {object} [seams]
+ * @param {(file:string)=>boolean} [seams.isInRepoFrame]
+ * @returns {{ok:boolean, findings:object[], counts:{total:number,anchorable:number,nonAnchorable:number}}}
+ */
+export function diagnoseFailures(
+  { failures = [], captures = [], diffOutput = "" } = {},
+  { isInRepoFrame: inRepo = isInRepoFrame } = {},
+) {
+  const anchorsByPath = parseDiffAnchors(diffOutput);
+  // ponytail: one reproduced-evidence reference per finding — the drive's final
+  // captured state (the last screenshot/state pair). Per-step attribution would
+  // need brittle parsing of the step-failure message; wire flow/step through the
+  // drive feed first if a stage needs frame-accurate evidence.
+  const last = captures.length > 0 ? captures[captures.length - 1] : null;
+  const evidence = last
+    ? { flow: last.flow ?? null, step: last.step ?? null, screenshotPath: last.screenshotPath ?? null, statePath: last.statePath ?? null }
+    : null;
+
+  const findings = rankFindings(failures.map((f) => diagnoseOne(f, anchorsByPath, inRepo, evidence)));
+  const anchorable = findings.filter((f) => f.anchorable).length;
+  return {
+    ok: findings.length === 0,
+    findings,
+    counts: { total: findings.length, anchorable, nonAnchorable: findings.length - anchorable },
+  };
+}

--- a/packages/core/src/loop/ui-review-diagnose.mjs
+++ b/packages/core/src/loop/ui-review-diagnose.mjs
@@ -55,7 +55,10 @@ export function parseException(text = "") {
 function extractFrameFromLine(line) {
   let m = line.match(/File "([^"]+)", line (\d+)/u);
   if (m) return { file: m[1], line: Number(m[2]) };
-  m = line.match(/\bat\s+(?:.*\()?([^\s():]+):(\d+)(?::\d+)?\)?\s*$/u);
+  // The file capture excludes only whitespace/parens (not `:`) and is lazy, so a
+  // served URL (`http://host:3000/assets/x.js`) is captured whole up to the
+  // trailing `:line:col` — normalizeFrameFile then strips the scheme/authority.
+  m = line.match(/\bat\s+(?:.*\()?([^\s()]+?):(\d+)(?::\d+)?\)?\s*$/u);
   if (m) return { file: m[1], line: Number(m[2]) };
   m = line.match(/([^\s():]+\.[A-Za-z0-9_]+):(\d+)\b/u);
   if (m) return { file: m[1], line: Number(m[2]) };
@@ -98,18 +101,22 @@ export function parseDiffAnchors(diffOutput = "") {
   let inHunk = false;
   for (const line of String(diffOutput).split("\n")) {
     if (line.startsWith("diff --git")) {
+      // The only hunk terminator: a bare `diff --git` can never be hunk content
+      // (content lines always carry a `+`/`-`/space prefix), so it always resets.
       currentPath = null;
       inHunk = false;
       continue;
     }
-    if (line.startsWith("+++ ")) {
+    // File headers appear only before the first hunk. Inside a hunk a line
+    // beginning `+++ `/`--- ` is content (an added `++ x` / a deleted `-- x`),
+    // so it must fall through to the `+`/`-` content handling below, not be
+    // misread as a header that rebinds the path or drops the rest of the hunk.
+    if (!inHunk && line.startsWith("+++ ")) {
       const p = line.slice(4).trim();
       currentPath = p === "/dev/null" ? null : p.replace(/^b\//u, "");
-      inHunk = false;
       continue;
     }
-    if (line.startsWith("--- ")) {
-      inHunk = false;
+    if (!inHunk && line.startsWith("--- ")) {
       continue;
     }
     if (line.startsWith("@@")) {

--- a/packages/core/src/loop/ui-review-diagnose.mjs
+++ b/packages/core/src/loop/ui-review-diagnose.mjs
@@ -38,11 +38,16 @@ export function isInRepoFrame(file) {
 }
 
 /** Extract the exception type + message from stack/traceback text. Matches the
- * first `SomethingError`/`SomethingException` token and the text that follows it
- * (JS `TypeError: msg`, Ruby `NoMethodError (msg)`, Python `ValueError: msg`).
- * Returns nulls when no recognizable exception name is present. */
+ * first exception token and the text that follows it: a `SomethingError`/
+ * `SomethingException`-suffixed name (JS `TypeError: msg`, Ruby `NoMethodError
+ * (msg)`, Python/dotted `django.core.exceptions.ValidationError: msg`) OR a Ruby
+ * `::`-namespaced constant like `ActiveRecord::RecordNotFound` /
+ * `Mongoid::Errors::DocumentNotFound`, captured whole. The `::` alternative
+ * requires at least one namespace segment so it signals a class, not an
+ * arbitrary identifier. Returns nulls when no recognizable exception name is
+ * present. */
 export function parseException(text = "") {
-  const m = String(text).match(/([A-Za-z_][\w.]*(?:Error|Exception))\b[:\s(]*([^\n)]*)/u);
+  const m = String(text).match(/([A-Z]\w*(?:::[A-Z]\w*)+|[A-Za-z_][\w.]*(?:Error|Exception))\b[:\s(]*([^\n)]*)/u);
   if (!m) return { type: null, message: null };
   const message = m[2].trim();
   return { type: m[1], message: message.length > 0 ? message : null };

--- a/packages/core/src/loop/ui-review-diagnose.mjs
+++ b/packages/core/src/loop/ui-review-diagnose.mjs
@@ -6,9 +6,8 @@
  * source location (the top in-repo stack frame), then to a diff line on the PR
  * head so the poster stage can anchor an inline comment on a real changed line.
  *
- * This module is PURE: the diff text and the drive result are inputs, the
- * in-repo-frame predicate is an injectable seam. The thin CLI wires the real IO
- * (loop info for PR state + the PR diff fetch).
+ * This module is PURE: the diff text and the drive result are inputs. The thin
+ * CLI wires the real IO (loop info for PR state + the PR diff fetch).
  *
  * Contract: a failure is NEVER silently dropped. One that has no source
  * location, whose file is not in the diff, whose line is not on a changed diff
@@ -85,8 +84,8 @@ export function extractFrames(text = "") {
  * a frame that happens to be in the diff — anchoring a lower frame would point at
  * a caller, not the failing line. A deeper frame that is in-repo but not in the
  * diff is handled downstream as non-anchorable, never by guessing past the top. */
-export function topInRepoFrame(frames, inRepo = isInRepoFrame) {
-  return frames.find((f) => inRepo(f.file)) ?? null;
+export function topInRepoFrame(frames) {
+  return frames.find((f) => isInRepoFrame(f.file)) ?? null;
 }
 
 /**
@@ -187,10 +186,9 @@ function matchDiffPaths(frameFile, anchorPaths) {
  *
  * @param {object} failure - a `classifyFailures` entry `{kind, severity, message, ...}`.
  * @param {Map<string,Set<number>>} anchorsByPath
- * @param {(file:string)=>boolean} inRepo
  * @param {object|null} evidence - the reproduced-evidence reference to attach.
  */
-function diagnoseOne(failure, anchorsByPath, inRepo, evidence) {
+function diagnoseOne(failure, anchorsByPath, evidence) {
   // page-error carries `stack`; server-log-exception carries `context`; the
   // wire-level failures (error/request) carry neither -> no source location.
   const sourceText =
@@ -210,7 +208,7 @@ function diagnoseOne(failure, anchorsByPath, inRepo, evidence) {
     evidence,
   };
 
-  const frame = topInRepoFrame(extractFrames(sourceText || ""), inRepo);
+  const frame = topInRepoFrame(extractFrames(sourceText || ""));
   if (!frame) {
     finding.nonAnchorableReason = "no source location (no in-repo stack frame in the captured failure)";
     return finding;
@@ -264,20 +262,15 @@ export function rankFindings(findings) {
 /**
  * Diagnose the drive stage's captured failures into a ranked findings list with
  * diff-line anchors or explicit non-anchorable flags plus reproduced-evidence
- * references. Pure; inject `isInRepoFrame` to override the in-repo heuristic.
+ * references. Pure.
  *
  * @param {object} input
  * @param {object[]} [input.failures] - the drive stage's `failures`.
  * @param {object[]} [input.captures] - the drive stage's `captures` (evidence).
  * @param {string} [input.diffOutput] - the PR's unified diff.
- * @param {object} [seams]
- * @param {(file:string)=>boolean} [seams.isInRepoFrame]
  * @returns {{ok:boolean, findings:object[], counts:{total:number,anchorable:number,nonAnchorable:number}}}
  */
-export function diagnoseFailures(
-  { failures = [], captures = [], diffOutput = "" } = {},
-  { isInRepoFrame: inRepo = isInRepoFrame } = {},
-) {
+export function diagnoseFailures({ failures = [], captures = [], diffOutput = "" } = {}) {
   const anchorsByPath = parseDiffAnchors(diffOutput);
   // ponytail: one reproduced-evidence reference per finding — the drive's final
   // captured state (the last screenshot/state pair). Per-step attribution would
@@ -288,7 +281,7 @@ export function diagnoseFailures(
     ? { flow: last.flow ?? null, step: last.step ?? null, screenshotPath: last.screenshotPath ?? null, statePath: last.statePath ?? null }
     : null;
 
-  const findings = rankFindings(failures.map((f) => diagnoseOne(f, anchorsByPath, inRepo, evidence)));
+  const findings = rankFindings(failures.map((f) => diagnoseOne(f, anchorsByPath, evidence)));
   const anchorable = findings.filter((f) => f.anchorable).length;
   return {
     ok: findings.length === 0,

--- a/scripts/loop/info.mjs
+++ b/scripts/loop/info.mjs
@@ -216,7 +216,7 @@ function formatIssueSummary(issueData, startupBundle, linkedPrData) {
 }
 
 function buildPrInfo(prNumber, repo, cwd) {
-  const prData = ghJson(["pr", "view", String(prNumber), "--repo", repo, "--json", "number,title,body,state,isDraft,headRefName,baseRefName,author,mergedAt,mergeable,mergeStateStatus,url,reviewRequests"], cwd);
+  const prData = ghJson(["pr", "view", String(prNumber), "--repo", repo, "--json", "number,title,body,state,isDraft,headRefName,headRefOid,baseRefName,author,mergedAt,mergeable,mergeStateStatus,url,reviewRequests"], cwd);
   
   let handoffResult = null;
   try {

--- a/scripts/loop/ui-review-diagnose.mjs
+++ b/scripts/loop/ui-review-diagnose.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * CLI wrapper for the ui_review diagnose + anchor stage (Stage 3).
+ *
+ * Reads the drive stage's captured-failures result, reuses PR state from
+ * `loop info --pr` (never a re-fetch), fetches the PR's unified diff, and maps
+ * each failure to a diff-line anchor or an explicit non-anchorable flag via the
+ * pure core (packages/core/src/loop/ui-review-diagnose.mjs). Emits a ranked
+ * findings list for the poster stage on the shared --jq/--silent emit path.
+ *
+ * Thin adapter: the diff fetch and the loop-info read are the only IO. All
+ * parsing/mapping/ranking decisions live in core.
+ */
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { requireTokenValue, parsePositiveInteger } from "../_cli-primitives.mjs";
+import { detectRepoSlug, normalizeRepoSlug } from "@dev-loops/core/github/repo-slug";
+import { diagnoseFailures } from "@dev-loops/core/loop/ui-review-diagnose";
+import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+
+const REPO_ROOT = path.resolve(fileURLToPath(new URL("..", import.meta.url)), "..");
+
+const USAGE = `Usage:
+  ui-review-diagnose.mjs --pr <number> --drive-result <path> [--repo <slug>]
+Map each Stage-2 captured failure (exception + stack/server-log context) to a source
+line, then to a PR diff line, producing the {path,line,side:RIGHT} anchors the poster
+stage needs (Stage 3 of the ui_review route).
+Required:
+  --pr <n>            PR number (reused via loop info; scopes the diff fetch).
+  --drive-result <p>  Path to the drive stage's JSON result (its failures + captures).
+Optional:
+  --repo <slug>       Repository slug (auto-detected from the git remote when omitted).
+  -h, --help          Show this help.
+Output (stdout, JSON):
+  { "ok": bool, "pr": {number,headRefName,baseRefName,state},
+    "findings": [ { severity, kind, exception:{type,message}, source:{file,line}|null,
+                    anchor:{path,line,side}|null, anchorable, nonAnchorableReason, evidence } ],
+    "counts": { total, anchorable, nonAnchorable } }
+
+${JQ_OUTPUT_USAGE}`.trim();
+
+const parseError = buildParseError(USAGE);
+
+export function parseUiReviewDiagnoseCliArgs(argv) {
+  const options = { help: false, pr: undefined, driveResult: undefined, repo: undefined };
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      pr: { type: "string" },
+      "drive-result": { type: "string" },
+      repo: { type: "string" },
+      ...JQ_OUTPUT_PARSE_OPTIONS,
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") throw parseError(`Unknown argument: ${token.value}`);
+    if (token.kind !== "option") continue;
+    if (token.name === "help") {
+      options.help = true;
+      return options;
+    }
+    if (token.name === "pr") {
+      options.pr = parsePositiveInteger(requireTokenValue(token, parseError), "--pr", parseError);
+      continue;
+    }
+    if (token.name === "drive-result") {
+      options.driveResult = requireTokenValue(token, parseError, { flagPattern: /^-/u });
+      continue;
+    }
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError);
+      continue;
+    }
+    if (matchJqOutputToken(token, options, (t) => requireTokenValue(t, parseError))) continue;
+    throw parseError(`Unknown argument: ${token.rawName}`);
+  }
+  if (options.help) return options;
+  if (options.pr === undefined) throw parseError("Missing required --pr");
+  if (!options.driveResult) throw parseError("Missing required --drive-result");
+  return options;
+}
+
+/** Reuse PR state from `loop info --pr --json` rather than re-fetching ad hoc. */
+function loadPrInfo(pr, repo, cwd) {
+  const script = path.join(REPO_ROOT, "loop/info.mjs");
+  const raw = execFileSync(process.execPath, [script, "--pr", String(pr), "--repo", repo, "--json"], {
+    cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+  });
+  const info = JSON.parse(raw);
+  const p = info.pr ?? {};
+  return { number: p.number ?? pr, headRefName: p.headRefName ?? null, baseRefName: p.baseRefName ?? null, state: p.state ?? null };
+}
+
+/** Fetch the PR's unified diff. A bounded read: the diff is the head-vs-base
+ * patch the anchor mapping needs; no ad-hoc file/hunk API stitching. */
+function loadPrDiff(pr, repo, cwd) {
+  return execFileSync("gh", ["pr", "diff", String(pr), "--repo", repo], {
+    cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], maxBuffer: 16 * 1024 * 1024,
+  });
+}
+
+export async function runCli(argv = process.argv.slice(2), { stdout = process.stdout, stderr = process.stderr } = {}) {
+  const options = parseUiReviewDiagnoseCliArgs(argv);
+  if (options.help) {
+    stdout.write(`${USAGE}\n`);
+    return;
+  }
+
+  const cwd = process.cwd();
+  const rawRepo = options.repo || detectRepoSlug(cwd);
+  if (!rawRepo) throw parseError("Repo auto-detection failed. Set origin remote or use --repo.");
+  const repo = normalizeRepoSlug(rawRepo, { errorMessage: "--repo must match <owner/name>" });
+
+  const drive = JSON.parse(readFileSync(options.driveResult, "utf8"));
+  const pr = loadPrInfo(options.pr, repo, cwd);
+  const diffOutput = loadPrDiff(options.pr, repo, cwd);
+
+  const { findings, counts } = diagnoseFailures({
+    failures: Array.isArray(drive.failures) ? drive.failures : [],
+    captures: Array.isArray(drive.captures) ? drive.captures : [],
+    diffOutput,
+  });
+
+  // ok reflects a clean review (no findings), consistent with the drive stage.
+  const result = { ok: counts.total === 0, pr, findings, counts };
+  process.exitCode = emitResult(result, { jq: options.jq, silent: options.silent, stdout, stderr, ok: result.ok });
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli().catch((error) => {
+    process.stderr.write(`${formatCliError(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/loop/ui-review-diagnose.mjs
+++ b/scripts/loop/ui-review-diagnose.mjs
@@ -40,7 +40,7 @@ Optional:
   --repo <slug>       Repository slug (auto-detected from the git remote when omitted).
   -h, --help          Show this help.
 Output (stdout, JSON):
-  { "ok": bool, "pr": {number,headRefName,baseRefName,state},
+  { "ok": bool, "pr": {number,headRefName,headSha,baseRefName,state},
     "findings": [ { severity, kind, message, exception:{type,message}, source:{file,line}|null,
                     anchor:{path,line,side}|null, anchorable, nonAnchorableReason, evidence } ],
     "counts": { total, anchorable, nonAnchorable } }
@@ -92,14 +92,26 @@ export function parseUiReviewDiagnoseCliArgs(argv) {
   return options;
 }
 
+/** Shape the loop-info JSON into the emitted `pr` envelope. Surfaces the reviewed
+ * head SHA (`headRefOid` -> `headSha`): Stage 4's inline poster needs a commit_id
+ * and must detect the head advancing between diagnose and post. */
+export function normalizePrInfo(info, pr) {
+  const p = info?.pr ?? {};
+  return {
+    number: p.number ?? pr,
+    headRefName: p.headRefName ?? null,
+    headSha: p.headRefOid ?? null,
+    baseRefName: p.baseRefName ?? null,
+    state: p.state ?? null,
+  };
+}
+
 /** Reuse PR state from `loop info --pr --json` rather than re-fetching ad hoc. */
 function loadPrInfo(pr, repo, cwd) {
   const raw = execFileSync(process.execPath, [LOOP_INFO_SCRIPT, "--pr", String(pr), "--repo", repo, "--json"], {
     cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
   });
-  const info = JSON.parse(raw);
-  const p = info.pr ?? {};
-  return { number: p.number ?? pr, headRefName: p.headRefName ?? null, baseRefName: p.baseRefName ?? null, state: p.state ?? null };
+  return normalizePrInfo(JSON.parse(raw), pr);
 }
 
 /** Fetch the PR's unified diff. A bounded read: the diff is the head-vs-base

--- a/scripts/loop/ui-review-diagnose.mjs
+++ b/scripts/loop/ui-review-diagnose.mjs
@@ -12,7 +12,7 @@
  * parsing/mapping/ranking decisions live in core.
  */
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
@@ -22,7 +22,11 @@ import { detectRepoSlug, normalizeRepoSlug } from "@dev-loops/core/github/repo-s
 import { diagnoseFailures } from "@dev-loops/core/loop/ui-review-diagnose";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 
-const REPO_ROOT = path.resolve(fileURLToPath(new URL("..", import.meta.url)), "..");
+/** The `loop info` script is a same-dir sibling (both live in scripts/loop/). */
+export const LOOP_INFO_SCRIPT = path.join(path.dirname(fileURLToPath(import.meta.url)), "info.mjs");
+
+/** Bound the drive-result read, matching the PR diff fetch's maxBuffer. */
+const MAX_DRIVE_RESULT_BYTES = 16 * 1024 * 1024;
 
 const USAGE = `Usage:
   ui-review-diagnose.mjs --pr <number> --drive-result <path> [--repo <slug>]
@@ -37,7 +41,7 @@ Optional:
   -h, --help          Show this help.
 Output (stdout, JSON):
   { "ok": bool, "pr": {number,headRefName,baseRefName,state},
-    "findings": [ { severity, kind, exception:{type,message}, source:{file,line}|null,
+    "findings": [ { severity, kind, message, exception:{type,message}, source:{file,line}|null,
                     anchor:{path,line,side}|null, anchorable, nonAnchorableReason, evidence } ],
     "counts": { total, anchorable, nonAnchorable } }
 
@@ -90,8 +94,7 @@ export function parseUiReviewDiagnoseCliArgs(argv) {
 
 /** Reuse PR state from `loop info --pr --json` rather than re-fetching ad hoc. */
 function loadPrInfo(pr, repo, cwd) {
-  const script = path.join(REPO_ROOT, "loop/info.mjs");
-  const raw = execFileSync(process.execPath, [script, "--pr", String(pr), "--repo", repo, "--json"], {
+  const raw = execFileSync(process.execPath, [LOOP_INFO_SCRIPT, "--pr", String(pr), "--repo", repo, "--json"], {
     cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
   });
   const info = JSON.parse(raw);
@@ -119,6 +122,10 @@ export async function runCli(argv = process.argv.slice(2), { stdout = process.st
   if (!rawRepo) throw parseError("Repo auto-detection failed. Set origin remote or use --repo.");
   const repo = normalizeRepoSlug(rawRepo, { errorMessage: "--repo must match <owner/name>" });
 
+  const driveSize = statSync(options.driveResult).size;
+  if (driveSize > MAX_DRIVE_RESULT_BYTES) {
+    throw parseError(`--drive-result is too large (${driveSize} bytes > ${MAX_DRIVE_RESULT_BYTES} cap)`);
+  }
   const drive = JSON.parse(readFileSync(options.driveResult, "utf8"));
   const pr = loadPrInfo(options.pr, repo, cwd);
   const diffOutput = loadPrDiff(options.pr, repo, cwd);

--- a/skills/ui-review/SKILL.md
+++ b/skills/ui-review/SKILL.md
@@ -109,8 +109,10 @@ dropped — one with no source location, a file that is not among the changed
 files, a line that is not on a changed diff line, or a file that maps
 ambiguously to more than one changed file is retained as a finding flagged
 non-anchorable (with a stated reason) so the poster body-attaches it instead of
-inlining. Every finding carries a reproduced-evidence reference to the drive's
-captured screenshot/state artifact.
+inlining. Each finding carries a reference to the drive's final captured
+screenshot/state artifact when one exists (null otherwise) — a single shared
+object across all findings, NOT per-failure attribution — so a Stage-4 consumer
+null-checks it and must not present it as proof of a specific finding.
 
 The findings list is ranked deterministically — severity, then anchorable-first,
 then kind, then source `file:line` — with no wall-clock or input-order

--- a/skills/ui-review/SKILL.md
+++ b/skills/ui-review/SKILL.md
@@ -90,9 +90,35 @@ defaulting to a heuristic that a project MUST override when its log format
 differs). The login form is branch-controlled trusted input, same threat
 boundary as the run recipe.
 
+## Diagnose + anchor
+
+Once failures are captured, the route maps each one to a source line and then to
+a PR diff line so the poster can anchor an inline comment on a real changed line,
+via
+`scripts/loop/ui-review-diagnose.mjs --pr <n> --drive-result <p> [--repo <slug>]`
+(pure mapping in `packages/core/src/loop/ui-review-diagnose.mjs`). It reuses PR
+state from `loop info --pr` rather than re-fetching, fetches the PR's unified
+diff, and for each failure parses the exception type/message plus the top in-repo
+stack frame (JS `at` frame, Ruby/Python traceback frame; vendor/framework frames
+in `node_modules`/`gems`/`vendor` are skipped). It then resolves the source
+`file:line` to a diff anchor `{ path, line, side: RIGHT }` on the head.
+
+Only ADDED lines are anchor targets: an inline comment lands on code the PR
+introduced, never on an unchanged context line. A failure is NEVER silently
+dropped — one with no source location, a file that is not among the changed
+files, a line that is not on a changed diff line, or a file that maps
+ambiguously to more than one changed file is retained as a finding flagged
+non-anchorable (with a stated reason) so the poster body-attaches it instead of
+inlining. Every finding carries a reproduced-evidence reference to the drive's
+captured screenshot/state artifact.
+
+The findings list is ranked deterministically — severity, then anchorable-first,
+then kind, then source `file:line` — with no wall-clock or input-order
+dependence, so the same failures always produce the same ordered output.
+
 ## Non-goals
 
-No diagnose/report/teardown logic lives here yet. The drive stage does not map an
-exception to its source line, post the review, pixel-diff for visual regression,
-run a cross-browser matrix, or touch a production DB — those are later stages or
-explicit non-goals.
+No report/teardown logic lives here yet. The stage does not post the review,
+publish artifacts, auto-fix the located defects, pixel-diff for visual
+regression, run a cross-browser matrix, or touch a production DB — those are
+later stages or explicit non-goals.

--- a/test/loop/ui-review-diagnose.test.mjs
+++ b/test/loop/ui-review-diagnose.test.mjs
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseDiffAnchors,
+  parseException,
+  extractFrames,
+  diagnoseFailures,
+  rankFindings,
+} from "@dev-loops/core/loop/ui-review-diagnose";
+import { parseUiReviewDiagnoseCliArgs } from "../../scripts/loop/ui-review-diagnose.mjs";
+
+// A synthetic PR diff over two changed files. Added (RIGHT-side) head lines:
+//   app/models/user.rb  -> {11, 12, 14}   (line 13 is an unchanged context line)
+//   app/assets/widget.js -> {2, 3, 5}     (lines 1, 4 are context)
+const DIFF = `diff --git a/app/models/user.rb b/app/models/user.rb
+index 1111111..2222222 100644
+--- a/app/models/user.rb
++++ b/app/models/user.rb
+@@ -10,3 +10,5 @@ class User
+   def name
++    raise NoMethodError
++    do_thing
+   end
++  attr_reader :x
+diff --git a/app/assets/widget.js b/app/assets/widget.js
+index 3333333..4444444 100644
+--- a/app/assets/widget.js
++++ b/app/assets/widget.js
+@@ -1,2 +1,4 @@
+ const x = 1;
++function boom() {
++  throw new TypeError("bad");
+ }
++export default boom;
+`;
+
+// ── unified-diff hunk parsing (added lines only, RIGHT side) ────────────────
+
+test("parseDiffAnchors: maps each changed file to its added head lines (RIGHT side)", () => {
+  const anchors = parseDiffAnchors(DIFF);
+  assert.deepEqual([...anchors.get("app/models/user.rb")].sort((a, b) => a - b), [11, 12, 14]);
+  assert.deepEqual([...anchors.get("app/assets/widget.js")].sort((a, b) => a - b), [2, 3, 5]);
+  // The unchanged context lines are NOT anchor targets.
+  assert.ok(!anchors.get("app/models/user.rb").has(13));
+  assert.ok(!anchors.get("app/assets/widget.js").has(1));
+});
+
+// ── exception + frame parsing ───────────────────────────────────────────────
+
+test("parseException: extracts the type and message from a JS stack and a Ruby traceback", () => {
+  assert.deepEqual(parseException("TypeError: cannot read x\n    at boom (a.js:1:1)"), {
+    type: "TypeError",
+    message: "cannot read x",
+  });
+  assert.deepEqual(parseException("NoMethodError (undefined method `foo' for nil):").type, "NoMethodError");
+  assert.deepEqual(parseException("nothing here"), { type: null, message: null });
+});
+
+test("extractFrames: parses JS, Ruby, and Python frames in order", () => {
+  const frames = extractFrames(
+    `    at boom (/repo/app/assets/widget.js:3:9)\napp/models/user.rb:11:in 'save'\n  File "svc/job.py", line 7, in run`,
+  );
+  assert.deepEqual(frames, [
+    { file: "/repo/app/assets/widget.js", line: 3 },
+    { file: "app/models/user.rb", line: 11 },
+    { file: "svc/job.py", line: 7 },
+  ]);
+});
+
+// ── the AC test: source -> diff-line anchoring, incl. the non-anchorable path ─
+
+test("diagnoseFailures: anchors in-repo frames to changed diff lines and retains non-anchorable failures", () => {
+  const captures = [
+    { flow: "account", step: "save", screenshotPath: "/out/account-save.png", statePath: "/out/account-save.json" },
+  ];
+  const failures = [
+    // (1) page-error: the top frame is in node_modules (skipped); the next
+    //     in-repo frame lands on an added line -> anchorable.
+    {
+      kind: "page-error",
+      severity: "must-fix",
+      message: "uncaught page error: cannot read properties of undefined",
+      stack:
+        "TypeError: cannot read properties of undefined\n    at dep (/repo/node_modules/lib/index.js:5:1)\n    at boom (/repo/app/assets/widget.js:3:9)",
+    },
+    // (2) server-log exception: a Ruby traceback whose top in-repo frame is on
+    //     an added line -> anchorable, with the exception type parsed.
+    {
+      kind: "server-log-exception",
+      severity: "must-fix",
+      message: "server log exception: NoMethodError (undefined method `foo')",
+      context:
+        "Started POST \"/users\"\nNoMethodError (undefined method `foo' for nil):\napp/models/user.rb:11:in `save'\napp/controllers/users_controller.rb:5:in `create'",
+    },
+    // (3) server-log exception on an UNCHANGED context line (13) of a changed
+    //     file -> retained, non-anchorable (line not on a changed diff line).
+    {
+      kind: "server-log-exception",
+      severity: "must-fix",
+      message: "server log exception: RuntimeError",
+      context: "RuntimeError (boom):\napp/models/user.rb:13:in `name'",
+    },
+    // (4) page-error whose source file is NOT among the changed files ->
+    //     retained, non-anchorable (file not changed).
+    {
+      kind: "page-error",
+      severity: "must-fix",
+      message: "uncaught page error: oops",
+      stack: "Error: oops\n    at x (/repo/app/other.js:1:1)",
+    },
+    // (5) error-response: no source location at all -> retained, non-anchorable.
+    { kind: "error-response", severity: "must-fix", status: 500, url: "http://app/save", message: "error response 500 at http://app/save" },
+  ];
+
+  const { ok, findings, counts } = diagnoseFailures({ failures, captures, diffOutput: DIFF });
+
+  assert.equal(ok, false, "failures present => not clean");
+  assert.equal(counts.total, 5);
+  assert.equal(counts.anchorable, 2);
+  assert.equal(counts.nonAnchorable, 3);
+
+  // Deterministic ranking: must-fix, then anchorable-first, then kind, then file:line.
+  assert.deepEqual(findings.map((f) => f.anchorable), [true, true, false, false, false]);
+
+  // (1) anchorable page-error -> widget.js:3 on the RIGHT side.
+  assert.equal(findings[0].kind, "page-error");
+  assert.equal(findings[0].exception.type, "TypeError");
+  assert.deepEqual(findings[0].source, { file: "/repo/app/assets/widget.js", line: 3 });
+  assert.deepEqual(findings[0].anchor, { path: "app/assets/widget.js", line: 3, side: "RIGHT" });
+  assert.equal(findings[0].nonAnchorableReason, null);
+  // Reproduced-evidence reference points at a Stage 2 artifact.
+  assert.equal(findings[0].evidence.screenshotPath, "/out/account-save.png");
+
+  // (2) anchorable server-log -> user.rb:11, NoMethodError.
+  assert.equal(findings[1].kind, "server-log-exception");
+  assert.equal(findings[1].exception.type, "NoMethodError");
+  assert.deepEqual(findings[1].anchor, { path: "app/models/user.rb", line: 11, side: "RIGHT" });
+
+  // (5) no-source failure sorts first among non-anchorable (kind order), reason stated.
+  assert.equal(findings[2].kind, "error-response");
+  assert.equal(findings[2].anchorable, false);
+  assert.equal(findings[2].anchor, null);
+  assert.match(findings[2].nonAnchorableReason, /no source location/i);
+
+  // (4) file-not-changed reason.
+  assert.equal(findings[3].kind, "page-error");
+  assert.match(findings[3].nonAnchorableReason, /not among the PR's changed files/i);
+
+  // (3) line-not-changed reason (unchanged context line of a changed file).
+  assert.equal(findings[4].kind, "server-log-exception");
+  assert.match(findings[4].nonAnchorableReason, /not on a changed diff line/i);
+});
+
+test("diagnoseFailures: an ambiguous suffix match is flagged non-anchorable, never guessed", () => {
+  // Two changed files whose paths are both suffixes of the frame path.
+  const diff = `diff --git a/lib/util.rb b/lib/util.rb
+--- a/lib/util.rb
++++ b/lib/util.rb
+@@ -1,1 +1,2 @@
+ x = 1
++y = 2
+diff --git a/util.rb b/util.rb
+--- a/util.rb
++++ b/util.rb
+@@ -1,1 +1,2 @@
+ a = 1
++b = 2
+`;
+  const failures = [
+    { kind: "page-error", severity: "must-fix", message: "x", stack: "Error: x\n    at f (/srv/lib/util.rb:2:1)" },
+  ];
+  const { findings } = diagnoseFailures({ failures, diffOutput: diff });
+  assert.equal(findings[0].anchorable, false);
+  assert.match(findings[0].nonAnchorableReason, /ambiguous/i);
+});
+
+test("rankFindings: is stable and deterministic across input order", () => {
+  const a = { severity: "note", anchorable: false, kind: "z", source: { file: "b", line: 2 } };
+  const b = { severity: "must-fix", anchorable: false, kind: "a", source: { file: "a", line: 1 } };
+  const c = { severity: "must-fix", anchorable: true, kind: "a", source: { file: "a", line: 1 } };
+  assert.deepEqual(rankFindings([a, b, c]), rankFindings([c, a, b]));
+  // must-fix + anchorable ranks first, note ranks last.
+  assert.equal(rankFindings([a, b, c])[0], c);
+  assert.equal(rankFindings([a, b, c])[2], a);
+});
+
+// ── CLI parsing ─────────────────────────────────────────────────────────────
+
+test("parseUiReviewDiagnoseCliArgs: requires --pr and --drive-result", () => {
+  assert.throws(() => parseUiReviewDiagnoseCliArgs(["--drive-result", "/r.json"]), /pr/);
+  assert.throws(() => parseUiReviewDiagnoseCliArgs(["--pr", "7"]), /drive-result/);
+  const o = parseUiReviewDiagnoseCliArgs(["--pr", "7", "--drive-result", "/r.json", "--repo", "o/n"]);
+  assert.equal(o.pr, 7);
+  assert.equal(o.driveResult, "/r.json");
+  assert.equal(o.repo, "o/n");
+});

--- a/test/loop/ui-review-diagnose.test.mjs
+++ b/test/loop/ui-review-diagnose.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
 import test from "node:test";
 
 import {
@@ -7,8 +8,10 @@ import {
   extractFrames,
   diagnoseFailures,
   rankFindings,
+  isInRepoFrame,
+  topInRepoFrame,
 } from "@dev-loops/core/loop/ui-review-diagnose";
-import { parseUiReviewDiagnoseCliArgs } from "../../scripts/loop/ui-review-diagnose.mjs";
+import { parseUiReviewDiagnoseCliArgs, LOOP_INFO_SCRIPT } from "../../scripts/loop/ui-review-diagnose.mjs";
 
 // A synthetic PR diff over two changed files. Added (RIGHT-side) head lines:
 //   app/models/user.rb  -> {11, 12, 14}   (line 13 is an unchanged context line)
@@ -46,6 +49,27 @@ test("parseDiffAnchors: maps each changed file to its added head lines (RIGHT si
   assert.ok(!anchors.get("app/assets/widget.js").has(1));
 });
 
+test("parseDiffAnchors: hunk content that renders as +++/--- is not misread as a file header", () => {
+  // A deleted line whose content is `-- x` renders `--- x`; an added line whose
+  // content is `++ x` renders `+++ x`. Both must be treated as hunk content, so
+  // the deletion does not drop the rest of the hunk and the added `++`/later
+  // added lines still anchor to the correct path and head line numbers.
+  const diff = `diff --git a/app/x.rb b/app/x.rb
+--- a/app/x.rb
++++ b/app/x.rb
+@@ -1,4 +1,5 @@
+ line1
+--- deleted comment
++++ added marker
+ line3
++real_added
+`;
+  const anchors = parseDiffAnchors(diff);
+  // Added head lines: `++ added marker` at 2, `real_added` at 4. The deletion
+  // (present only on the old side) does not advance the head counter.
+  assert.deepEqual([...anchors.get("app/x.rb")].sort((a, b) => a - b), [2, 4]);
+});
+
 // ── exception + frame parsing ───────────────────────────────────────────────
 
 test("parseException: extracts the type and message from a JS stack and a Ruby traceback", () => {
@@ -66,6 +90,24 @@ test("extractFrames: parses JS, Ruby, and Python frames in order", () => {
     { file: "app/models/user.rb", line: 11 },
     { file: "svc/job.py", line: 7 },
   ]);
+});
+
+test("extractFrames: a served-URL frame is captured whole (scheme+host:port), not port-glued garbage", () => {
+  // A browser page-error stack frame is a served URL. The host:port must not
+  // break the file capture — the whole URL is captured so normalizeFrameFile
+  // can strip the scheme/authority and suffix-match the repo-relative diff path.
+  assert.deepEqual(extractFrames("    at boom (http://localhost:3000/app/assets/widget.js:3:9)"), [
+    { file: "http://localhost:3000/app/assets/widget.js", line: 3 },
+  ]);
+});
+
+test("isInRepoFrame/topInRepoFrame: a non-node_modules vendor top frame (gems) is skipped", () => {
+  assert.equal(isInRepoFrame("/usr/local/gems/rails/lib/foo.rb"), false);
+  const frames = [
+    { file: "/usr/local/gems/rails/lib/foo.rb", line: 9 },
+    { file: "app/models/user.rb", line: 11 },
+  ];
+  assert.deepEqual(topInRepoFrame(frames), { file: "app/models/user.rb", line: 11 });
 });
 
 // ── the AC test: source -> diff-line anchoring, incl. the non-anchorable path ─
@@ -175,6 +217,33 @@ diff --git a/util.rb b/util.rb
   assert.match(findings[0].nonAnchorableReason, /ambiguous/i);
 });
 
+test("diagnoseFailures: a page-error whose frame is a served URL anchors to the repo-relative diff path", () => {
+  const diff = `diff --git a/app/assets/widget.js b/app/assets/widget.js
+--- a/app/assets/widget.js
++++ b/app/assets/widget.js
+@@ -1,2 +1,4 @@
+ const x = 1;
++function boom() {
++  throw new TypeError("bad");
+ }
+`;
+  const failures = [
+    {
+      kind: "page-error",
+      severity: "must-fix",
+      message: "uncaught page error",
+      // Browser page-error stack frame served over http with a host:port.
+      stack: "TypeError: bad\n    at boom (http://localhost:3000/app/assets/widget.js:3:9)",
+    },
+  ];
+  const { findings } = diagnoseFailures({ failures, diffOutput: diff });
+  // The whole served URL is retained as the source; the scheme/authority is
+  // stripped only for matching, so the anchor lands on the repo-relative path.
+  assert.equal(findings[0].source.file, "http://localhost:3000/app/assets/widget.js");
+  assert.deepEqual(findings[0].anchor, { path: "app/assets/widget.js", line: 3, side: "RIGHT" });
+  assert.equal(findings[0].anchorable, true);
+});
+
 test("rankFindings: is stable and deterministic across input order", () => {
   const a = { severity: "note", anchorable: false, kind: "z", source: { file: "b", line: 2 } };
   const b = { severity: "must-fix", anchorable: false, kind: "a", source: { file: "a", line: 1 } };
@@ -194,4 +263,11 @@ test("parseUiReviewDiagnoseCliArgs: requires --pr and --drive-result", () => {
   assert.equal(o.pr, 7);
   assert.equal(o.driveResult, "/r.json");
   assert.equal(o.repo, "o/n");
+});
+
+test("LOOP_INFO_SCRIPT resolves to the real sibling loop-info script (the CLI non-help path)", () => {
+  // The CLI's non-help path shells out to this script via execFileSync; a wrong
+  // path throws ENOENT the moment `loop info` is reused. Assert it exists.
+  assert.ok(LOOP_INFO_SCRIPT.endsWith("scripts/loop/info.mjs"), LOOP_INFO_SCRIPT);
+  assert.ok(existsSync(LOOP_INFO_SCRIPT), `loop-info script must exist at ${LOOP_INFO_SCRIPT}`);
 });

--- a/test/loop/ui-review-diagnose.test.mjs
+++ b/test/loop/ui-review-diagnose.test.mjs
@@ -11,7 +11,7 @@ import {
   isInRepoFrame,
   topInRepoFrame,
 } from "@dev-loops/core/loop/ui-review-diagnose";
-import { parseUiReviewDiagnoseCliArgs, LOOP_INFO_SCRIPT } from "../../scripts/loop/ui-review-diagnose.mjs";
+import { parseUiReviewDiagnoseCliArgs, normalizePrInfo, LOOP_INFO_SCRIPT } from "../../scripts/loop/ui-review-diagnose.mjs";
 
 // A synthetic PR diff over two changed files. Added (RIGHT-side) head lines:
 //   app/models/user.rb  -> {11, 12, 14}   (line 13 is an unchanged context line)
@@ -316,6 +316,23 @@ test("parseUiReviewDiagnoseCliArgs: requires --pr and --drive-result", () => {
   assert.equal(o.pr, 7);
   assert.equal(o.driveResult, "/r.json");
   assert.equal(o.repo, "o/n");
+});
+
+test("normalizePrInfo: surfaces the reviewed head SHA (headRefOid -> headSha) into the emitted pr envelope", () => {
+  const pr = normalizePrInfo(
+    { pr: { number: 7, headRefName: "issue-1119", headRefOid: "abc123def", baseRefName: "main", state: "OPEN" } },
+    7,
+  );
+  assert.deepEqual(pr, {
+    number: 7,
+    headRefName: "issue-1119",
+    headSha: "abc123def",
+    baseRefName: "main",
+    state: "OPEN",
+  });
+  // Missing head oid is surfaced as null (never undefined) so Stage 4 null-checks it.
+  assert.equal(normalizePrInfo({ pr: { number: 7 } }, 7).headSha, null);
+  assert.equal(normalizePrInfo({}, 7).headSha, null);
 });
 
 test("LOOP_INFO_SCRIPT resolves to the real sibling loop-info script (the CLI non-help path)", () => {

--- a/test/loop/ui-review-diagnose.test.mjs
+++ b/test/loop/ui-review-diagnose.test.mjs
@@ -189,9 +189,50 @@ test("diagnoseFailures: anchors in-repo frames to changed diff lines and retains
   assert.equal(findings[3].kind, "page-error");
   assert.match(findings[3].nonAnchorableReason, /not among the PR's changed files/i);
 
-  // (3) line-not-changed reason (unchanged context line of a changed file).
+  // (3) line-not-added reason (unchanged context line of a changed file).
   assert.equal(findings[4].kind, "server-log-exception");
-  assert.match(findings[4].nonAnchorableReason, /not on a changed diff line/i);
+  assert.match(findings[4].nonAnchorableReason, /not on an added diff line/i);
+});
+
+test("diagnoseFailures: a changed file with no added lines (deletion-only) reports the changed-file reason, not not-changed", () => {
+  // A deletion-only hunk: the file IS changed (keeps its `+++ b/path` header)
+  // but adds no anchorable line. A frame landing on it must report the
+  // added-line reason, NOT "not among the PR's changed files".
+  const diff = `diff --git a/app/models/user.rb b/app/models/user.rb
+--- a/app/models/user.rb
++++ b/app/models/user.rb
+@@ -10,3 +10,2 @@ class User
+   def name
+-    stale_call
+   end
+`;
+  const failures = [
+    { kind: "page-error", severity: "must-fix", message: "x", stack: "Error: x\n    at f (app/models/user.rb:11:1)" },
+  ];
+  const { findings } = diagnoseFailures({ failures, diffOutput: diff });
+  assert.equal(findings[0].anchorable, false);
+  assert.match(findings[0].nonAnchorableReason, /not on an added diff line/i);
+  assert.doesNotMatch(findings[0].nonAnchorableReason, /not among the PR's changed files/i);
+});
+
+test("diagnoseFailures: a Windows backslash frame path anchors to the forward-slash diff path", () => {
+  const diff = `diff --git a/app/assets/widget.js b/app/assets/widget.js
+--- a/app/assets/widget.js
++++ b/app/assets/widget.js
+@@ -1,2 +1,4 @@
+ const x = 1;
++function boom() {
++  throw new TypeError("bad");
+ }
+`;
+  const failures = [
+    // A Windows-style frame path (backslash separators) must fold to `/` so it
+    // suffix-matches the repo-relative diff path.
+    { kind: "page-error", severity: "must-fix", message: "x", stack: "TypeError: bad\n    at boom (C:\\repo\\app\\assets\\widget.js:3:9)" },
+  ];
+  const { findings } = diagnoseFailures({ failures, diffOutput: diff });
+  assert.deepEqual(findings[0].anchor, { path: "app/assets/widget.js", line: 3, side: "RIGHT" });
+  assert.equal(findings[0].anchorable, true);
 });
 
 test("diagnoseFailures: an ambiguous suffix match is flagged non-anchorable, never guessed", () => {

--- a/test/loop/ui-review-diagnose.test.mjs
+++ b/test/loop/ui-review-diagnose.test.mjs
@@ -81,6 +81,18 @@ test("parseException: extracts the type and message from a JS stack and a Ruby t
   assert.deepEqual(parseException("nothing here"), { type: null, message: null });
 });
 
+test("parseException: captures Ruby `::`-namespaced exception types whole", () => {
+  assert.deepEqual(parseException("ActiveRecord::RecordNotFound: Couldn't find User with 'id'=1"), {
+    type: "ActiveRecord::RecordNotFound",
+    message: "Couldn't find User with 'id'=1",
+  });
+  // Multi-segment namespace (and a name not suffixed with Error/Exception).
+  assert.deepEqual(parseException("Mongoid::Errors::DocumentNotFound: no document"), {
+    type: "Mongoid::Errors::DocumentNotFound",
+    message: "no document",
+  });
+});
+
 test("extractFrames: parses JS, Ruby, and Python frames in order", () => {
   const frames = extractFrames(
     `    at boom (/repo/app/assets/widget.js:3:9)\napp/models/user.rb:11:in 'save'\n  File "svc/job.py", line 7, in run`,


### PR DESCRIPTION
## Summary

Stage 3 of epic #1114 (`/loop-review-ui`). **Diagnose + anchor**: for each Stage-2 captured failure (exception + stack + server-log context), extract the exception + top in-repo stack frame, map the source location to a PR diff line (`{path, line, side: RIGHT}`), and emit a deterministic ranked findings list ready for the Stage-4 inline poster. Failures whose source line isn't on a diff line are retained and flagged non-anchorable (Stage 4 body-attaches them) — never silently dropped.

## Scope and context

In scope: a pure core diagnose module (exception/frame parsing, unified-diff hunk → anchorable-position parsing, source→diff-line mapping, deterministic ranking), a thin CLI reusing `loop info --pr` + the PR diff, and tests covering anchorable + non-anchorable paths. The emitted `pr` envelope also surfaces the reviewed head SHA (`headSha`) so the Stage-4 poster has a `commit_id` and can detect the head advancing between diagnose and post. Out of scope (Stage 4 / Non-goals): review posting, artifact publishing, auto-fixing located defects.

## Acceptance criteria

This change satisfies issue #1119's acceptance criteria; they will be checked off on the issue at merge.

## Definition of done

Given Stage 2 failures, the stage outputs a deterministic ranked findings list with diff-line anchors (or explicit non-anchorable flags) and reproduced-evidence references, ready for the Stage 4 poster. Verified by the test suite (anchorable + non-anchorable + server-log-context + no-source-line, plus served-URL frames and content lines that render as diff headers) and full `test:scripts` green.

## Non-goals

No review posting or artifact publishing (Stage 4). No auto-fixing of located defects.

## Validation

- `node --test test/loop/ui-review-diagnose.test.mjs` (16 pass — hunk parsing incl. `+++`/`---` content lines, exception/frame parsing incl. served-URL frames, vendor-frame skipping, the AC anchoring test incl. non-anchorable cases, ambiguous-match, deterministic ranking, head-SHA envelope mapping, CLI arg validation + sibling loop-info resolution).
- `npm run test:scripts` (full leg, 2522 pass), `npm run test:core`, `npm run test:docs`, `npm run test:assets`.
- Full gate uses `npm run verify`.

Closes #1119
