### PR TITLE
feat(loop): report — inline pending-review poster + severity policy + self-contained artifact for ui_review (Stage 4 of #1114)

### DIFF
--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -116,9 +116,46 @@ The findings list is ranked deterministically — severity, then anchorable-firs
 then kind, then source `file:line` — with no wall-clock or input-order
 dependence, so the same failures always produce the same ordered output.
 
+## Report
+
+The terminal reporting stage turns the ranked findings into a head-pinned
+PENDING PR review plus a self-contained screenshot artifact, via
+`scripts/loop/ui-review-report.mjs --pr <n> --diagnose-result <p> --html-output <p> [--repo <slug>]`
+(pure decisions in `packages/core/src/loop/ui-review-report.mjs`). It reuses the
+shared pending-review poster (`scripts/github/stage-reviewer-draft.mjs` +
+`buildDraftReviewPayload`) — a caller/adapter, not a new poster. Each anchorable
+finding becomes an inline comment on its exact `{path,line,side:RIGHT}` anchor
+carrying the reproduced exception + a fix direction; non-anchorable findings are
+retained in the review body (never dropped). It reuses the live head SHA from
+`loop info` and fails closed when the diagnosed head is missing or the live head
+has advanced since diagnose, so the inline anchors always bind to the exact
+reviewed commit.
+
+The review defaults to **pending/draft** (no `event`) — this stage never
+auto-submits. A confirmed user-facing server error (a must-fix error-response /
+server-log-exception) maps to `REQUEST_CHANGES` **only when submit is
+authorized**; otherwise the review stays pending with the severity recorded. The
+severity->event decision is emitted as guidance; submitting via the events
+endpoint is a separate authorized action outside this stage.
+
+The self-contained artifact is always produced: a CSP-safe, fully inlined HTML
+(ranked findings + the reproduced-evidence screenshot as a data URI, no external
+resources). Hosting is harness-aware: on the **Claude Code** harness the stage
+emits a publishable directive (`{ hosting: "claude-artifact", htmlPath,
+publishable: true }`) for the orchestrating agent to publish via Claude
+Artifacts — the module never calls an Artifacts tool itself. On any other
+harness it **fails closed with a stated reason** (`{ hosting: "unavailable",
+reason, followup }`); the GitHub-native fallback publisher is deferred. The
+review body links a hosted artifact when one exists and otherwise states the
+artifact is unhosted (with the reason), so the review never blocks on hosting.
+Every bounded cap — findings truncated past the artifact cap, an oversized or
+unreadable evidence screenshot omitted — is logged, never silent.
+
 ## Non-goals
 
-No report/teardown logic lives here yet. The stage does not post the review,
-publish artifacts, auto-fix the located defects, pixel-diff for visual
-regression, run a cross-browser matrix, or touch a production DB — those are
-later stages or explicit non-goals.
+No teardown logic lives here yet. The stage does not auto-submit a review
+without explicit authorization, publish to a production/non-dev posting target,
+ship the GitHub-native hosted-artifact fallback, auto-fix the located defects,
+pixel-diff for visual regression, run a cross-browser matrix, or touch a
+production DB — those are later stages or explicit non-goals. It does not
+replace the product/eng `review` angle or the Copilot gate.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,6 +60,7 @@
     "./loop/ui-review-provision": "./src/loop/ui-review-provision.mjs",
     "./loop/ui-review-drive": "./src/loop/ui-review-drive.mjs",
     "./loop/ui-review-diagnose": "./src/loop/ui-review-diagnose.mjs",
+    "./loop/ui-review-report": "./src/loop/ui-review-report.mjs",
     "./projects/list-queue-items": "./src/projects/list-queue-items.mjs",
     "./projects/move-queue-item": "./src/projects/move-queue-item.mjs",
     "./projects/resolve-project": "./src/projects/resolve-project.mjs",

--- a/packages/core/src/loop/ui-review-report.mjs
+++ b/packages/core/src/loop/ui-review-report.mjs
@@ -139,6 +139,21 @@ function artifactBodyLine({ hosting, hostedUrl }) {
   return `Screenshot artifact is unhosted this stage${reason}${followup}. Findings are included below.`;
 }
 
+/** A finding is inlineable ONLY with a complete anchor buildDraftReviewPayload
+ * will keep: non-empty path, finite line, side RIGHT. A finding flagged
+ * anchorable but carrying a malformed/incomplete anchor falls back to the body
+ * (summaryFindings) instead of being dropped by the payload's null-anchor filter. */
+function hasValidAnchor(finding) {
+  const a = finding?.anchor;
+  return Boolean(
+    finding?.anchorable &&
+    a &&
+    typeof a.path === "string" && a.path.length > 0 &&
+    typeof a.line === "number" && Number.isFinite(a.line) &&
+    a.side === "RIGHT"
+  );
+}
+
 /** Body line for a non-anchorable finding: it is kept, never dropped. */
 function nonAnchorableBodyMessage(finding) {
   const reason = finding?.nonAnchorableReason ? ` — not inlined: ${finding.nonAnchorableReason}` : "";
@@ -155,8 +170,8 @@ function nonAnchorableBodyMessage(finding) {
  */
 export function buildReviewInput({ findings = [], headSha = null, hosting = null, hostedUrl = null } = {}) {
   const list = Array.isArray(findings) ? findings : [];
-  const anchorable = list.filter((f) => f?.anchorable && f?.anchor);
-  const nonAnchorable = list.filter((f) => !(f?.anchorable && f?.anchor));
+  const anchorable = list.filter(hasValidAnchor);
+  const nonAnchorable = list.filter((f) => !hasValidAnchor(f));
 
   // Untrusted target-app text (exception type/message, log lines, nonAnchorableReason)
   // flows into these bodies. Sanitize copilot-summon tokens before they enter the
@@ -169,7 +184,7 @@ export function buildReviewInput({ findings = [], headSha = null, hosting = null
   }));
 
   const summaryFindings = [
-    { message: artifactBodyLine({ hosting, hostedUrl }), severity: "note" },
+    { message: sanitizeCopilotSummonTokens(artifactBodyLine({ hosting, hostedUrl })), severity: "note" },
     ...nonAnchorable.map((f) => ({ message: sanitizeCopilotSummonTokens(nonAnchorableBodyMessage(f)), severity: f.severity ?? "note" })),
   ];
 

--- a/packages/core/src/loop/ui-review-report.mjs
+++ b/packages/core/src/loop/ui-review-report.mjs
@@ -1,0 +1,267 @@
+/**
+ * Report for the ui_review route (Stage 4, terminal reporting stage).
+ *
+ * Pure decision layer. Maps the Stage-3 ranked findings into:
+ *   - a pending draft-review input (consumed by buildDraftReviewPayload — the
+ *     shared poster's contract: {path,line,body,side:RIGHT} inline comments, no
+ *     `event`), with anchorable findings inlined on their exact diff anchors and
+ *     non-anchorable findings retained in the review body,
+ *   - a severity->event policy (a confirmed user-facing server error maps to
+ *     REQUEST_CHANGES ONLY when the caller authorizes submit; otherwise the
+ *     review stays pending with the severity recorded — never auto-submit),
+ *   - a self-contained, CSP-safe HTML artifact string (ranked findings + inline
+ *     screenshot evidence), and
+ *   - a harness-aware hosting directive (Claude Code -> a publishable Artifacts
+ *     directive for the orchestrator; any other harness -> fail closed with a
+ *     stated reason and a follow-up marker — no hosted link this stage).
+ *
+ * All IO (reading the diagnose output + the screenshot bytes, writing the HTML,
+ * invoking the poster) lives in the thin CLI. This module reads only its inputs.
+ */
+
+import { isClaudeHarness } from "./run-context.mjs";
+
+/** Follow-up marker for the descoped GitHub-native hosting fallback. */
+export const HOSTING_FOLLOWUP = "#1285";
+
+/** Findings past this cap are dropped from the artifact and the drop is logged. */
+export const ARTIFACT_MAX_FINDINGS = 100;
+
+/** A screenshot whose data URI exceeds this is omitted from the artifact (logged). */
+export const ARTIFACT_MAX_SCREENSHOT_BYTES = 4 * 1024 * 1024;
+
+/** The drive kinds that count as a confirmed user-facing server error. Both are
+ * must-fix in the drive's classification: an error response the app returned and
+ * a server-log exception the request raised. */
+const SERVER_ERROR_KINDS = new Set(["error-response", "server-log-exception"]);
+
+function normalizeSha(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+/** A confirmed user-facing server error: a must-fix error-response / server-log
+ * exception. This is the single-source predicate the severity policy keys off. */
+function isBlockingFinding(finding) {
+  return finding?.severity === "must-fix" && SERVER_ERROR_KINDS.has(finding?.kind);
+}
+
+/** Render a finding's reproduced exception as one line, falling back to its
+ * message when the drive captured no parseable exception. */
+function reproducedLine(finding) {
+  const type = finding?.exception?.type;
+  const message = finding?.exception?.message;
+  if (typeof type === "string" && type.length > 0) {
+    return message ? `${type}: ${message}` : type;
+  }
+  return typeof finding?.message === "string" && finding.message.length > 0
+    ? finding.message
+    : "Captured failure (no exception detail)";
+}
+
+/** A short, kind-specific fix direction. Deliberately generic — the goal is to
+ * point the author at the changed line, not to prescribe the patch. */
+function fixDirection(kind) {
+  switch (kind) {
+    case "error-response":
+      return "Fix the request path so it no longer returns an error response.";
+    case "server-log-exception":
+    case "page-error":
+      return "Guard the throwing code path; the exception above was raised here.";
+    case "request-failed":
+      return "The request from this change failed at the wire; verify the endpoint/URL.";
+    default:
+      return "Address the reproduced failure on this changed line.";
+  }
+}
+
+/** Inline-comment body for an anchorable finding: reproduced exception + fix direction. */
+export function formatInlineBody(finding) {
+  return `Reproduced in the running app: ${reproducedLine(finding)}\nFix direction: ${fixDirection(finding?.kind)}`;
+}
+
+/**
+ * Severity->event policy (pure). A confirmed user-facing server error maps to
+ * REQUEST_CHANGES ONLY when submit is authorized; otherwise the review stays
+ * pending (event null) with the severity recorded. Never auto-submits.
+ *
+ * @param {{findings?: object[], submitAuthorized?: boolean}} [input]
+ * @returns {{event: "REQUEST_CHANGES"|null, blocking: boolean, submitAuthorized: boolean, severity: string}}
+ */
+export function severityToEvent({ findings = [], submitAuthorized = false } = {}) {
+  const list = Array.isArray(findings) ? findings : [];
+  const blocking = list.some(isBlockingFinding);
+  const severity = blocking
+    ? "must-fix"
+    : (list.some((f) => f?.severity === "must-fix") ? "must-fix" : (list.length > 0 ? "note" : "none"));
+  return {
+    event: submitAuthorized && blocking ? "REQUEST_CHANGES" : null,
+    blocking,
+    submitAuthorized: Boolean(submitAuthorized),
+    severity,
+  };
+}
+
+/**
+ * Harness-aware hosting directive (pure). Claude Code -> a publishable Artifacts
+ * directive for the orchestrator to host (this module never calls an agent tool
+ * itself). Any other harness / Artifacts unavailable -> fail closed with a
+ * stated reason and the follow-up marker. The self-contained HTML is produced
+ * regardless; only this link step is harness-aware.
+ *
+ * @param {{htmlPath: string, env?: Record<string,string|undefined>}} input
+ */
+export function decideHosting({ htmlPath, env = process.env } = {}) {
+  if (isClaudeHarness(env)) {
+    return { hosting: "claude-artifact", publishable: true, htmlPath: htmlPath ?? null };
+  }
+  return {
+    hosting: "unavailable",
+    publishable: false,
+    htmlPath: htmlPath ?? null,
+    reason: "no hosted-artifact publisher on this harness; GitHub-native fallback is deferred",
+    followup: HOSTING_FOLLOWUP,
+  };
+}
+
+/** One review-body line describing where the screenshot artifact lives. Links a
+ * real hosted URL when one exists; otherwise states the harness-aware status so
+ * the review never blocks on hosting. */
+function artifactBodyLine({ hosting, hostedUrl }) {
+  if (typeof hostedUrl === "string" && hostedUrl.length > 0) {
+    return `Screenshot artifact: ${hostedUrl}`;
+  }
+  if (hosting?.hosting === "claude-artifact") {
+    return "Screenshot artifact prepared for Claude Artifacts hosting (published by the harness; see run output).";
+  }
+  const reason = hosting?.reason ? ` (${hosting.reason})` : "";
+  const followup = hosting?.followup ? ` [follow-up ${hosting.followup}]` : "";
+  return `Screenshot artifact is unhosted this stage${reason}${followup}. Findings are included below.`;
+}
+
+/** Body line for a non-anchorable finding: it is kept, never dropped. */
+function nonAnchorableBodyMessage(finding) {
+  const reason = finding?.nonAnchorableReason ? ` — not inlined: ${finding.nonAnchorableReason}` : "";
+  return `${reproducedLine(finding)}${reason}`;
+}
+
+/**
+ * Map Stage-3 findings + hosting status into the merged-result input that the
+ * shared buildDraftReviewPayload consumes. Anchorable findings become inline
+ * comments on their exact {path,line,side:RIGHT} anchors; the artifact line and
+ * every non-anchorable finding are retained as summary (body) findings.
+ *
+ * @param {{findings?: object[], headSha?: string|null, hosting?: object, hostedUrl?: string}} input
+ */
+export function buildReviewInput({ findings = [], headSha = null, hosting = null, hostedUrl = null } = {}) {
+  const list = Array.isArray(findings) ? findings : [];
+  const anchorable = list.filter((f) => f?.anchorable && f?.anchor);
+  const nonAnchorable = list.filter((f) => !(f?.anchorable && f?.anchor));
+
+  const inlineComments = anchorable.map((f) => ({
+    path: f.anchor.path,
+    line: f.anchor.line,
+    message: formatInlineBody(f),
+    severity: f.severity ?? "note",
+  }));
+
+  const summaryFindings = [
+    { message: artifactBodyLine({ hosting, hostedUrl }), severity: "note" },
+    ...nonAnchorable.map((f) => ({ message: nonAnchorableBodyMessage(f), severity: f.severity ?? "note" })),
+  ];
+
+  const blocking = list.some(isBlockingFinding);
+  const verdict = list.length === 0 ? "APPROVE" : (blocking ? "REQUEST_CHANGES" : "COMMENT");
+
+  return {
+    headSha: normalizeSha(headSha),
+    verdict,
+    inlineComments,
+    summaryFindings,
+    totalFindings: list.length,
+    runsMerged: 0,
+  };
+}
+
+function escapeHtml(value) {
+  return String(value).replace(/[&<>"']/gu, (c) => (
+    { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]
+  ));
+}
+
+const ARTIFACT_STYLE = [
+  "body{font:14px/1.5 system-ui,sans-serif;margin:0;padding:24px;color:#1a1a1a;background:#fafafa}",
+  "h1{font-size:20px;margin:0 0 4px}",
+  ".meta{color:#666;margin-bottom:20px}",
+  ".finding{border:1px solid #ddd;border-radius:6px;padding:12px 16px;margin:0 0 12px;background:#fff}",
+  ".finding.blocking{border-left:4px solid #c0392b}",
+  ".finding.note{border-left:4px solid #999}",
+  ".sev{font-weight:600;text-transform:uppercase;font-size:11px;letter-spacing:.05em}",
+  ".anchor{color:#2c3e50;font-family:ui-monospace,monospace;font-size:12px}",
+  ".exc{font-family:ui-monospace,monospace;white-space:pre-wrap;margin:6px 0}",
+  ".reason{color:#c0392b;font-size:12px}",
+  "img{max-width:100%;border:1px solid #ddd;border-radius:4px;margin-top:12px}",
+].join("");
+
+const ARTIFACT_CSP = "default-src 'none'; style-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'";
+
+/**
+ * Build the self-contained, CSP-safe HTML artifact (ranked findings + inline
+ * screenshot evidence). Fully inlined: no external scripts/styles/fonts/images.
+ * Bounded caps (findings past ARTIFACT_MAX_FINDINGS, an oversized screenshot)
+ * are applied here and returned in `caps` so the CLI can log them — never a
+ * silent truncation.
+ *
+ * @param {{findings?: object[], counts?: object, pr?: object, screenshot?: {path:string,dataUri:string}|null, generatedAt?: string}} input
+ * @returns {{html: string, caps: string[]}}
+ */
+export function buildArtifactHtml({ findings = [], counts = {}, pr = {}, screenshot = null, generatedAt } = {}) {
+  const caps = [];
+  const list = Array.isArray(findings) ? findings : [];
+
+  let shown = list;
+  if (list.length > ARTIFACT_MAX_FINDINGS) {
+    shown = list.slice(0, ARTIFACT_MAX_FINDINGS);
+    caps.push(`artifact: findings truncated to ${ARTIFACT_MAX_FINDINGS} of ${list.length} (${list.length - ARTIFACT_MAX_FINDINGS} not rendered)`);
+  }
+
+  let screenshotHtml = "";
+  if (screenshot && typeof screenshot.dataUri === "string") {
+    if (screenshot.dataUri.length > ARTIFACT_MAX_SCREENSHOT_BYTES) {
+      caps.push(`artifact: screenshot omitted (${screenshot.dataUri.length} bytes > ${ARTIFACT_MAX_SCREENSHOT_BYTES} cap): ${screenshot.path ?? "unknown"}`);
+    } else {
+      screenshotHtml = `<h2>Reproduced evidence</h2><img alt="reproduced state" src="${escapeHtml(screenshot.dataUri)}" />`;
+    }
+  }
+
+  const findingsHtml = shown.map((f) => {
+    const blocking = isBlockingFinding(f);
+    const cls = blocking ? "blocking" : "note";
+    const anchor = f?.anchor
+      ? `<div class="anchor">${escapeHtml(f.anchor.path)}:${escapeHtml(f.anchor.line)} (${escapeHtml(f.anchor.side)})</div>`
+      : `<div class="reason">not inlined: ${escapeHtml(f?.nonAnchorableReason ?? "no anchor")}</div>`;
+    return [
+      `<div class="finding ${cls}">`,
+      `<div class="sev">${escapeHtml(f?.severity ?? "note")} · ${escapeHtml(f?.kind ?? "finding")}</div>`,
+      `<div class="exc">${escapeHtml(reproducedLine(f))}</div>`,
+      anchor,
+      "</div>",
+    ].join("");
+  }).join("");
+
+  const total = Number.isFinite(counts?.total) ? counts.total : list.length;
+  const html = [
+    "<!doctype html>",
+    '<html lang="en"><head><meta charset="utf-8" />',
+    `<meta http-equiv="Content-Security-Policy" content="${ARTIFACT_CSP}" />`,
+    "<title>UI review findings</title>",
+    `<style>${ARTIFACT_STYLE}</style>`,
+    "</head><body>",
+    `<h1>UI review findings — PR #${escapeHtml(pr?.number ?? "?")}</h1>`,
+    `<div class="meta">head ${escapeHtml(pr?.headSha ?? "?")} · ${escapeHtml(total)} finding(s) · ${escapeHtml(counts?.anchorable ?? 0)} anchorable · generated ${escapeHtml(generatedAt ?? "")}</div>`,
+    findingsHtml,
+    screenshotHtml,
+    "</body></html>",
+  ].join("");
+
+  return { html, caps };
+}

--- a/packages/core/src/loop/ui-review-report.mjs
+++ b/packages/core/src/loop/ui-review-report.mjs
@@ -20,6 +20,7 @@
  */
 
 import { isClaudeHarness } from "./run-context.mjs";
+import { sanitizeCopilotSummonTokens } from "../github/copilot-helpers.mjs";
 
 /** Follow-up marker for the descoped GitHub-native hosting fallback. */
 export const HOSTING_FOLLOWUP = "#1285";
@@ -157,16 +158,19 @@ export function buildReviewInput({ findings = [], headSha = null, hosting = null
   const anchorable = list.filter((f) => f?.anchorable && f?.anchor);
   const nonAnchorable = list.filter((f) => !(f?.anchorable && f?.anchor));
 
+  // Untrusted target-app text (exception type/message, log lines, nonAnchorableReason)
+  // flows into these bodies. Sanitize copilot-summon tokens before they enter the
+  // payload buildDraftReviewPayload posts verbatim — every sibling posting path does.
   const inlineComments = anchorable.map((f) => ({
     path: f.anchor.path,
     line: f.anchor.line,
-    message: formatInlineBody(f),
+    message: sanitizeCopilotSummonTokens(formatInlineBody(f)),
     severity: f.severity ?? "note",
   }));
 
   const summaryFindings = [
     { message: artifactBodyLine({ hosting, hostedUrl }), severity: "note" },
-    ...nonAnchorable.map((f) => ({ message: nonAnchorableBodyMessage(f), severity: f.severity ?? "note" })),
+    ...nonAnchorable.map((f) => ({ message: sanitizeCopilotSummonTokens(nonAnchorableBodyMessage(f)), severity: f.severity ?? "note" })),
   ];
 
   const blocking = list.some(isBlockingFinding);

--- a/packages/core/src/loop/ui-review-report.mjs
+++ b/packages/core/src/loop/ui-review-report.mjs
@@ -140,16 +140,17 @@ function artifactBodyLine({ hosting, hostedUrl }) {
 }
 
 /** A finding is inlineable ONLY with a complete anchor buildDraftReviewPayload
- * will keep: non-empty path, finite line, side RIGHT. A finding flagged
- * anchorable but carrying a malformed/incomplete anchor falls back to the body
- * (summaryFindings) instead of being dropped by the payload's null-anchor filter. */
+ * will keep: a non-blank path and a line > 0 (exactly the payload's inline
+ * filter), side RIGHT. A finding flagged anchorable but carrying a
+ * malformed/incomplete anchor (blank path, line <= 0) falls back to the body
+ * (summaryFindings) instead of being dropped by the payload's inline filter. */
 function hasValidAnchor(finding) {
   const a = finding?.anchor;
   return Boolean(
     finding?.anchorable &&
     a &&
-    typeof a.path === "string" && a.path.length > 0 &&
-    typeof a.line === "number" && Number.isFinite(a.line) &&
+    typeof a.path === "string" && a.path.trim().length > 0 &&
+    typeof a.line === "number" && a.line > 0 &&
     a.side === "RIGHT"
   );
 }

--- a/scripts/loop/ui-review-report.mjs
+++ b/scripts/loop/ui-review-report.mjs
@@ -120,8 +120,14 @@ function loadLiveHeadSha(pr, repo, cwd) {
 
 /** Read the shared reproduced-evidence screenshot (Stage 3 surfaces one shared
  * ref across findings) and inline it as a data URI. Bounded: an oversized or
- * unreadable screenshot is skipped with a logged cap, never fatal. */
-function loadScreenshot(findings, caps) {
+ * unreadable screenshot is skipped with a logged cap, never fatal.
+ *
+ * The artifact cap (ARTIFACT_MAX_SCREENSHOT_BYTES) bounds the INLINED data-URI
+ * length, not the raw file. Base64 expands ~4/3 plus the `data:<mime>;base64,`
+ * prefix, so we derive the largest raw file size whose data URI still fits that
+ * budget and omit oversize files here — before the wasted read+encode that
+ * buildArtifactHtml would only drop again. Both layers then apply one limit. */
+export function loadScreenshot(findings, caps) {
   const withEvidence = findings.find((f) => f?.evidence?.screenshotPath);
   const p = withEvidence?.evidence?.screenshotPath;
   if (!p) return null;
@@ -132,11 +138,15 @@ function loadScreenshot(findings, caps) {
     caps.push(`artifact: evidence screenshot not readable, omitted: ${p}`);
     return null;
   }
-  if (size > ARTIFACT_MAX_SCREENSHOT_BYTES) {
-    caps.push(`artifact: screenshot omitted (${size} bytes > ${ARTIFACT_MAX_SCREENSHOT_BYTES} cap): ${p}`);
+  const mime = MIME_BY_EXT[path.extname(p).toLowerCase()] ?? "image/png";
+  const prefixLen = `data:${mime};base64,`.length;
+  // Largest raw byte count whose base64 data URI stays within the budget:
+  // dataUri.length = prefixLen + 4*ceil(size/3) <= ARTIFACT_MAX_SCREENSHOT_BYTES.
+  const maxRawBytes = 3 * Math.floor((ARTIFACT_MAX_SCREENSHOT_BYTES - prefixLen) / 4);
+  if (size > maxRawBytes) {
+    caps.push(`artifact: screenshot omitted (${size} raw bytes exceed the ${ARTIFACT_MAX_SCREENSHOT_BYTES}-byte data-URI cap): ${p}`);
     return null;
   }
-  const mime = MIME_BY_EXT[path.extname(p).toLowerCase()] ?? "image/png";
   const dataUri = `data:${mime};base64,${readFileSync(p).toString("base64")}`;
   return { path: p, dataUri };
 }

--- a/scripts/loop/ui-review-report.mjs
+++ b/scripts/loop/ui-review-report.mjs
@@ -55,7 +55,7 @@ Optional:
   --dry-run             Build + write the artifact and emit the directive, but do NOT post.
   -h, --help            Show this help.
 Output (stdout, JSON):
-  { ok, pr, htmlPath, hosting:{hosting,publishable,...}, policy:{event,blocking,severity},
+  { ok, pr, htmlPath, reviewFile, hosting:{hosting,publishable,...}, policy:{event,blocking,severity},
     review:{reviewId,reviewUrl,commitSha}|null, caps:[...] }
 
 ${JQ_OUTPUT_USAGE}`.trim();

--- a/scripts/loop/ui-review-report.mjs
+++ b/scripts/loop/ui-review-report.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+/**
+ * CLI wrapper for the ui_review report stage (Stage 4, terminal reporting).
+ *
+ * Reads the Stage-3 diagnose output, builds the self-contained CSP-safe HTML
+ * artifact + the pending draft-review input + the harness-aware hosting
+ * directive via the pure core (packages/core/src/loop/ui-review-report.mjs),
+ * then posts the head-pinned PENDING review by invoking the shared poster
+ * (scripts/github/stage-reviewer-draft.mjs). The review always stays pending;
+ * the severity->event decision is emitted as guidance — submitting is a separate
+ * authorized action this stage never performs.
+ *
+ * Thin adapter: the diagnose read, the live-head reuse (loop info), the
+ * screenshot read + base64 inline, the HTML write, and the poster spawn are the
+ * only IO. Every mapping/policy/cap decision lives in core.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { requireTokenValue, parsePositiveInteger } from "../_cli-primitives.mjs";
+import { detectRepoSlug, normalizeRepoSlug } from "@dev-loops/core/github/repo-slug";
+import {
+  buildArtifactHtml,
+  buildReviewInput,
+  decideHosting,
+  severityToEvent,
+  ARTIFACT_MAX_SCREENSHOT_BYTES,
+} from "@dev-loops/core/loop/ui-review-report";
+import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+export const LOOP_INFO_SCRIPT = path.join(HERE, "info.mjs");
+export const STAGE_REVIEWER_DRAFT_SCRIPT = path.join(HERE, "..", "github", "stage-reviewer-draft.mjs");
+
+const MAX_DIAGNOSE_RESULT_BYTES = 16 * 1024 * 1024;
+
+const MIME_BY_EXT = { ".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".webp": "image/webp", ".gif": "image/gif" };
+
+const USAGE = `Usage:
+  ui-review-report.mjs --pr <n> --diagnose-result <p> --html-output <p> [--repo <slug>] [options]
+Publish a self-contained screenshot/findings artifact and post a head-pinned PENDING
+PR review with inline comments on the exact Stage-3 diff anchors (Stage 4 of ui_review).
+Required:
+  --pr <n>              PR number (also used to reuse live head via loop info).
+  --diagnose-result <p> Path to the Stage-3 diagnose JSON (its findings + pr.headSha).
+  --html-output <p>     Path to write the self-contained HTML artifact.
+Optional:
+  --repo <slug>         Repository slug (auto-detected from the git remote when omitted).
+  --review-file <p>     Path to write the poster's review-file input (default: alongside --html-output).
+  --submit-authorized   Record the severity->event decision as authorized (never auto-submits).
+  --hosted-url <url>    A real hosted artifact URL to link in the review body (when known).
+  --dry-run             Build + write the artifact and emit the directive, but do NOT post.
+  -h, --help            Show this help.
+Output (stdout, JSON):
+  { ok, pr, htmlPath, hosting:{hosting,publishable,...}, policy:{event,blocking,severity},
+    review:{reviewId,reviewUrl,commitSha}|null, caps:[...] }
+
+${JQ_OUTPUT_USAGE}`.trim();
+
+const parseError = buildParseError(USAGE);
+
+export function parseUiReviewReportCliArgs(argv) {
+  const options = {
+    help: false, pr: undefined, diagnoseResult: undefined, htmlOutput: undefined,
+    repo: undefined, reviewFile: undefined, submitAuthorized: false, hostedUrl: undefined, dryRun: false,
+  };
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      pr: { type: "string" },
+      "diagnose-result": { type: "string" },
+      "html-output": { type: "string" },
+      repo: { type: "string" },
+      "review-file": { type: "string" },
+      "submit-authorized": { type: "boolean" },
+      "hosted-url": { type: "string" },
+      "dry-run": { type: "boolean" },
+      ...JQ_OUTPUT_PARSE_OPTIONS,
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") throw parseError(`Unknown argument: ${token.value}`);
+    if (token.kind !== "option") continue;
+    if (token.name === "help") { options.help = true; return options; }
+    if (token.name === "pr") { options.pr = parsePositiveInteger(requireTokenValue(token, parseError), "--pr", parseError); continue; }
+    if (token.name === "diagnose-result") { options.diagnoseResult = requireTokenValue(token, parseError, { flagPattern: /^-/u }); continue; }
+    if (token.name === "html-output") { options.htmlOutput = requireTokenValue(token, parseError, { flagPattern: /^-/u }); continue; }
+    if (token.name === "repo") { options.repo = requireTokenValue(token, parseError); continue; }
+    if (token.name === "review-file") { options.reviewFile = requireTokenValue(token, parseError, { flagPattern: /^-/u }); continue; }
+    if (token.name === "submit-authorized") { options.submitAuthorized = true; continue; }
+    if (token.name === "hosted-url") { options.hostedUrl = requireTokenValue(token, parseError); continue; }
+    if (token.name === "dry-run") { options.dryRun = true; continue; }
+    if (matchJqOutputToken(token, options, (t) => requireTokenValue(t, parseError))) continue;
+    throw parseError(`Unknown argument: ${token.rawName}`);
+  }
+  if (options.help) return options;
+  if (options.pr === undefined) throw parseError("Missing required --pr");
+  if (!options.diagnoseResult) throw parseError("Missing required --diagnose-result");
+  if (!options.htmlOutput) throw parseError("Missing required --html-output");
+  return options;
+}
+
+/** Reuse the live head SHA from `loop info --pr` (never an ad-hoc re-fetch), so
+ * the report can detect the head advancing since diagnose and fail closed. */
+function loadLiveHeadSha(pr, repo, cwd) {
+  const raw = execFileSync(process.execPath, [LOOP_INFO_SCRIPT, "--pr", String(pr), "--repo", repo, "--json"], {
+    cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+  });
+  const info = JSON.parse(raw);
+  const sha = info?.pr?.headRefOid;
+  return typeof sha === "string" && sha.trim().length > 0 ? sha.trim() : null;
+}
+
+/** Read the shared reproduced-evidence screenshot (Stage 3 surfaces one shared
+ * ref across findings) and inline it as a data URI. Bounded: an oversized or
+ * unreadable screenshot is skipped with a logged cap, never fatal. */
+function loadScreenshot(findings, caps) {
+  const withEvidence = findings.find((f) => f?.evidence?.screenshotPath);
+  const p = withEvidence?.evidence?.screenshotPath;
+  if (!p) return null;
+  let size;
+  try {
+    size = statSync(p).size;
+  } catch {
+    caps.push(`artifact: evidence screenshot not readable, omitted: ${p}`);
+    return null;
+  }
+  if (size > ARTIFACT_MAX_SCREENSHOT_BYTES) {
+    caps.push(`artifact: screenshot omitted (${size} bytes > ${ARTIFACT_MAX_SCREENSHOT_BYTES} cap): ${p}`);
+    return null;
+  }
+  const mime = MIME_BY_EXT[path.extname(p).toLowerCase()] ?? "image/png";
+  const dataUri = `data:${mime};base64,${readFileSync(p).toString("base64")}`;
+  return { path: p, dataUri };
+}
+
+/** Post the head-pinned PENDING review via the shared poster and return its
+ * parsed result. The poster asserts state === PENDING and pins to commit_id. */
+function postPendingReview({ repo, pr, reviewFile, cwd }) {
+  const raw = execFileSync(process.execPath, [STAGE_REVIEWER_DRAFT_SCRIPT, "--repo", repo, "--pr", String(pr), "--review-file", reviewFile], {
+    cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+  });
+  const parsed = JSON.parse(raw);
+  return { reviewId: parsed.reviewId ?? null, reviewUrl: parsed.reviewUrl ?? null, commitSha: parsed.commitSha ?? null };
+}
+
+export async function runCli(argv = process.argv.slice(2), { stdout = process.stdout, stderr = process.stderr, env = process.env } = {}) {
+  const options = parseUiReviewReportCliArgs(argv);
+  if (options.help) { stdout.write(`${USAGE}\n`); return; }
+
+  const cwd = process.cwd();
+  const rawRepo = options.repo || detectRepoSlug(cwd);
+  if (!rawRepo) throw parseError("Repo auto-detection failed. Set origin remote or use --repo.");
+  const repo = normalizeRepoSlug(rawRepo, { errorMessage: "--repo must match <owner/name>" });
+
+  const diagSize = statSync(options.diagnoseResult).size;
+  if (diagSize > MAX_DIAGNOSE_RESULT_BYTES) {
+    throw parseError(`--diagnose-result is too large (${diagSize} bytes > ${MAX_DIAGNOSE_RESULT_BYTES} cap)`);
+  }
+  const diagnose = JSON.parse(readFileSync(options.diagnoseResult, "utf8"));
+  const findings = Array.isArray(diagnose.findings) ? diagnose.findings : [];
+  const counts = diagnose.counts ?? { total: findings.length, anchorable: 0, nonAnchorable: 0 };
+  const diagnosedHeadSha = diagnose?.pr?.headSha ?? null;
+
+  // Head pinning: the inline anchors bind to the reviewed commit. Fail closed
+  // when the diagnose head is missing or the live head has advanced since.
+  const liveHeadSha = loadLiveHeadSha(options.pr, repo, cwd);
+  if (!diagnosedHeadSha) {
+    throw parseError("Stage-3 diagnose output has no pr.headSha; cannot head-pin the review. Failing closed.");
+  }
+  if (liveHeadSha && liveHeadSha !== diagnosedHeadSha) {
+    throw parseError(`Live PR head (${liveHeadSha}) advanced past the diagnosed head (${diagnosedHeadSha}); re-run diagnose. Failing closed.`);
+  }
+
+  const caps = [];
+  const screenshot = loadScreenshot(findings, caps);
+  const { html, caps: artifactCaps } = buildArtifactHtml({
+    findings,
+    counts,
+    pr: { number: options.pr, headSha: diagnosedHeadSha },
+    screenshot,
+    generatedAt: new Date().toISOString(),
+  });
+  caps.push(...artifactCaps);
+
+  mkdirSync(path.dirname(path.resolve(options.htmlOutput)), { recursive: true });
+  writeFileSync(options.htmlOutput, html, "utf8");
+
+  const hosting = decideHosting({ htmlPath: path.resolve(options.htmlOutput), env });
+  const policy = severityToEvent({ findings, submitAuthorized: options.submitAuthorized });
+
+  const reviewInput = buildReviewInput({
+    findings,
+    headSha: diagnosedHeadSha,
+    hosting,
+    hostedUrl: options.hostedUrl ?? null,
+  });
+  const reviewFile = options.reviewFile
+    ? path.resolve(options.reviewFile)
+    : `${path.resolve(options.htmlOutput)}.review.json`;
+  mkdirSync(path.dirname(reviewFile), { recursive: true });
+  writeFileSync(reviewFile, `${JSON.stringify(reviewInput, null, 2)}\n`, "utf8");
+
+  for (const cap of caps) stderr.write(`[ui-review-report] cap: ${cap}\n`);
+
+  const review = options.dryRun ? null : postPendingReview({ repo, pr: options.pr, reviewFile, cwd });
+
+  const result = {
+    ok: true,
+    pr: { number: options.pr, headSha: diagnosedHeadSha },
+    htmlPath: path.resolve(options.htmlOutput),
+    reviewFile,
+    hosting,
+    policy,
+    review,
+    caps,
+  };
+  process.exitCode = emitResult(result, { jq: options.jq, silent: options.silent, stdout, stderr, ok: result.ok });
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli().catch((error) => {
+    process.stderr.write(`${formatCliError(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/skills/ui-review/SKILL.md
+++ b/skills/ui-review/SKILL.md
@@ -118,9 +118,46 @@ The findings list is ranked deterministically — severity, then anchorable-firs
 then kind, then source `file:line` — with no wall-clock or input-order
 dependence, so the same failures always produce the same ordered output.
 
+## Report
+
+The terminal reporting stage turns the ranked findings into a head-pinned
+PENDING PR review plus a self-contained screenshot artifact, via
+`scripts/loop/ui-review-report.mjs --pr <n> --diagnose-result <p> --html-output <p> [--repo <slug>]`
+(pure decisions in `packages/core/src/loop/ui-review-report.mjs`). It reuses the
+shared pending-review poster (`scripts/github/stage-reviewer-draft.mjs` +
+`buildDraftReviewPayload`) — a caller/adapter, not a new poster. Each anchorable
+finding becomes an inline comment on its exact `{path,line,side:RIGHT}` anchor
+carrying the reproduced exception + a fix direction; non-anchorable findings are
+retained in the review body (never dropped). It reuses the live head SHA from
+`loop info` and fails closed when the diagnosed head is missing or the live head
+has advanced since diagnose, so the inline anchors always bind to the exact
+reviewed commit.
+
+The review defaults to **pending/draft** (no `event`) — this stage never
+auto-submits. A confirmed user-facing server error (a must-fix error-response /
+server-log-exception) maps to `REQUEST_CHANGES` **only when submit is
+authorized**; otherwise the review stays pending with the severity recorded. The
+severity->event decision is emitted as guidance; submitting via the events
+endpoint is a separate authorized action outside this stage.
+
+The self-contained artifact is always produced: a CSP-safe, fully inlined HTML
+(ranked findings + the reproduced-evidence screenshot as a data URI, no external
+resources). Hosting is harness-aware: on the **Claude Code** harness the stage
+emits a publishable directive (`{ hosting: "claude-artifact", htmlPath,
+publishable: true }`) for the orchestrating agent to publish via Claude
+Artifacts — the module never calls an Artifacts tool itself. On any other
+harness it **fails closed with a stated reason** (`{ hosting: "unavailable",
+reason, followup }`); the GitHub-native fallback publisher is deferred. The
+review body links a hosted artifact when one exists and otherwise states the
+artifact is unhosted (with the reason), so the review never blocks on hosting.
+Every bounded cap — findings truncated past the artifact cap, an oversized or
+unreadable evidence screenshot omitted — is logged, never silent.
+
 ## Non-goals
 
-No report/teardown logic lives here yet. The stage does not post the review,
-publish artifacts, auto-fix the located defects, pixel-diff for visual
-regression, run a cross-browser matrix, or touch a production DB — those are
-later stages or explicit non-goals.
+No teardown logic lives here yet. The stage does not auto-submit a review
+without explicit authorization, publish to a production/non-dev posting target,
+ship the GitHub-native hosted-artifact fallback, auto-fix the located defects,
+pixel-diff for visual regression, run a cross-browser matrix, or touch a
+production DB — those are later stages or explicit non-goals. It does not
+replace the product/eng `review` angle or the Copilot gate.

--- a/test/loop/ui-review-report.test.mjs
+++ b/test/loop/ui-review-report.test.mjs
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildReviewInput,
+  severityToEvent,
+  decideHosting,
+  buildArtifactHtml,
+  ARTIFACT_MAX_FINDINGS,
+} from "@dev-loops/core/loop/ui-review-report";
+import { buildDraftReviewPayload } from "@dev-loops/core/loop/reviewer-loop-state";
+import { parseUiReviewReportCliArgs } from "../../scripts/loop/ui-review-report.mjs";
+
+const HEAD_SHA = "a".repeat(40);
+
+// A ranked findings list shaped exactly like Stage 3 (ui-review-diagnose) emits:
+// two anchorable (a server-log exception + a 500 error response) and one
+// non-anchorable (source file not in the diff) that must land in the body.
+const FINDINGS = [
+  {
+    severity: "must-fix",
+    kind: "server-log-exception",
+    message: "NoMethodError in UsersController#show",
+    exception: { type: "NoMethodError", message: "undefined method `name' for nil" },
+    source: { file: "app/models/user.rb", line: 11 },
+    anchor: { path: "app/models/user.rb", line: 11, side: "RIGHT" },
+    anchorable: true,
+    nonAnchorableReason: null,
+    evidence: { flow: "users", step: "show", screenshotPath: "/out/users-show.png", statePath: "/out/users-show.json" },
+  },
+  {
+    severity: "must-fix",
+    kind: "error-response",
+    message: "error response 500 at /users/1",
+    exception: { type: null, message: null },
+    source: { file: "app/assets/widget.js", line: 3 },
+    anchor: { path: "app/assets/widget.js", line: 3, side: "RIGHT" },
+    anchorable: true,
+    nonAnchorableReason: null,
+    evidence: { flow: "users", step: "show", screenshotPath: "/out/users-show.png", statePath: "/out/users-show.json" },
+  },
+  {
+    severity: "must-fix",
+    kind: "error-response",
+    message: "error response 500 at /api/orphan",
+    exception: { type: null, message: null },
+    source: null,
+    anchor: null,
+    anchorable: false,
+    nonAnchorableReason: "source file is not among the PR's changed files",
+    evidence: null,
+  },
+];
+
+test("buildReviewInput -> buildDraftReviewPayload: pending, head-pinned, anchored inline comments, non-anchorable in body", () => {
+  const reviewInput = buildReviewInput({
+    findings: FINDINGS,
+    headSha: HEAD_SHA,
+    hosting: { hosting: "claude-artifact", publishable: true, htmlPath: "/out/report.html" },
+  });
+  const payload = buildDraftReviewPayload(reviewInput);
+
+  // Head-pinned to the exact reviewed commit.
+  assert.equal(payload.commit_id, HEAD_SHA);
+  // Pending/draft: never carries an event.
+  assert.equal(Object.prototype.hasOwnProperty.call(payload, "event"), false);
+
+  // Exactly the two anchorable findings become inline comments on their anchors.
+  assert.equal(payload.comments.length, 2);
+  for (const c of payload.comments) {
+    assert.equal(c.side, "RIGHT");
+    assert.ok(c.path && c.line && c.body.length > 0);
+  }
+  const byPath = Object.fromEntries(payload.comments.map((c) => [c.path, c]));
+  assert.equal(byPath["app/models/user.rb"].line, 11);
+  assert.equal(byPath["app/assets/widget.js"].line, 3);
+  // Inline comment carries the reproduced exception + a fix direction.
+  assert.match(byPath["app/models/user.rb"].body, /NoMethodError/);
+  assert.match(byPath["app/models/user.rb"].body, /Fix direction/i);
+
+  // The non-anchorable finding is retained in the body (never dropped).
+  assert.match(payload.body, /source file is not among the PR's changed files/);
+  assert.match(payload.body, /orphan/);
+});
+
+test("severityToEvent: confirmed 500 stays PENDING unless submit is authorized", () => {
+  const unauthorized = severityToEvent({ findings: FINDINGS, submitAuthorized: false });
+  assert.equal(unauthorized.event, null);
+  assert.equal(unauthorized.blocking, true);
+  assert.equal(unauthorized.severity, "must-fix");
+
+  const authorized = severityToEvent({ findings: FINDINGS, submitAuthorized: true });
+  assert.equal(authorized.event, "REQUEST_CHANGES");
+  assert.equal(authorized.blocking, true);
+
+  // No blocking server error -> no REQUEST_CHANGES even when authorized.
+  const noteOnly = severityToEvent({
+    findings: [{ severity: "note", kind: "server-log-pattern-invalid", anchorable: false }],
+    submitAuthorized: true,
+  });
+  assert.equal(noteOnly.event, null);
+  assert.equal(noteOnly.blocking, false);
+});
+
+test("decideHosting: Claude harness -> publishable directive; off-Claude -> fail closed with reason + follow-up", () => {
+  const onClaude = decideHosting({ htmlPath: "/out/report.html", env: { CLAUDECODE: "1" } });
+  assert.equal(onClaude.hosting, "claude-artifact");
+  assert.equal(onClaude.publishable, true);
+  assert.equal(onClaude.htmlPath, "/out/report.html");
+
+  const offClaude = decideHosting({ htmlPath: "/out/report.html", env: {} });
+  assert.equal(offClaude.hosting, "unavailable");
+  assert.equal(offClaude.publishable, false);
+  assert.ok(typeof offClaude.reason === "string" && offClaude.reason.length > 0);
+  assert.equal(offClaude.followup, "#1285");
+});
+
+test("buildArtifactHtml: self-contained + CSP-safe, inlines screenshot, logs caps", () => {
+  const screenshot = { path: "/out/users-show.png", dataUri: "data:image/png;base64,AAAA" };
+  const { html, caps } = buildArtifactHtml({
+    findings: FINDINGS,
+    counts: { total: 3, anchorable: 2, nonAnchorable: 1 },
+    pr: { number: 42, headSha: HEAD_SHA },
+    screenshot,
+    generatedAt: "2026-07-09T00:00:00.000Z",
+  });
+
+  assert.match(html, /Content-Security-Policy/);
+  // Fully inlined: no remote resources.
+  assert.doesNotMatch(html, /https?:\/\//);
+  assert.match(html, /data:image\/png;base64,AAAA/);
+  assert.match(html, /NoMethodError/);
+  assert.match(html, /source file is not among the PR/);
+  assert.equal(caps.length, 0);
+
+  // Findings past the cap are truncated and the truncation is logged.
+  const many = Array.from({ length: ARTIFACT_MAX_FINDINGS + 5 }, (_unused, i) => ({
+    severity: "note",
+    kind: "page-error",
+    message: `finding ${i}`,
+    exception: { type: null, message: null },
+    source: null,
+    anchor: null,
+    anchorable: false,
+    nonAnchorableReason: "note",
+    evidence: null,
+  }));
+  const capped = buildArtifactHtml({
+    findings: many,
+    counts: { total: many.length, anchorable: 0, nonAnchorable: many.length },
+    pr: { number: 42, headSha: HEAD_SHA },
+    screenshot: null,
+    generatedAt: "2026-07-09T00:00:00.000Z",
+  });
+  assert.ok(capped.caps.some((c) => /truncated/i.test(c)));
+});
+
+test("CLI: parses required args, submit-authorized and dry-run default off", () => {
+  const opts = parseUiReviewReportCliArgs(["--pr", "42", "--diagnose-result", "d.json", "--html-output", "o.html"]);
+  assert.equal(opts.pr, 42);
+  assert.equal(opts.diagnoseResult, "d.json");
+  assert.equal(opts.htmlOutput, "o.html");
+  assert.equal(opts.submitAuthorized, false);
+  assert.equal(opts.dryRun, false);
+  assert.throws(() => parseUiReviewReportCliArgs(["--diagnose-result", "d.json", "--html-output", "o.html"]), /Missing required --pr/);
+});
+
+test("buildArtifactHtml: oversized screenshot is omitted and logged, never silently dropped", () => {
+  const big = "data:image/png;base64," + "A".repeat(10 * 1024 * 1024);
+  const { html, caps } = buildArtifactHtml({
+    findings: FINDINGS,
+    counts: { total: 3, anchorable: 2, nonAnchorable: 1 },
+    pr: { number: 42, headSha: HEAD_SHA },
+    screenshot: { path: "/out/big.png", dataUri: big },
+    generatedAt: "2026-07-09T00:00:00.000Z",
+  });
+  assert.doesNotMatch(html, /AAAA/);
+  assert.ok(caps.some((c) => /screenshot/i.test(c) && /omitted/i.test(c)));
+});

--- a/test/loop/ui-review-report.test.mjs
+++ b/test/loop/ui-review-report.test.mjs
@@ -126,6 +126,42 @@ test("buildReviewInput: untrusted app text is copilot-summon-sanitized in both i
   assert.equal(containsBareCopilotSummon(payload.body), false);
 });
 
+test("buildReviewInput: anchorable finding with a malformed anchor falls back to the body, never dropped", () => {
+  // Flagged anchorable but the anchor is incomplete (empty path / null line):
+  // buildDraftReviewPayload would filter the inline comment, so it MUST route to
+  // the review body instead of being lost.
+  const findings = [{
+    severity: "must-fix",
+    kind: "server-log-exception",
+    message: "boom",
+    exception: { type: "NoMethodError", message: "undefined method `x'" },
+    anchor: { path: "", line: null, side: "RIGHT" },
+    anchorable: true,
+    nonAnchorableReason: "anchor incomplete",
+  }];
+  const reviewInput = buildReviewInput({ findings, headSha: HEAD_SHA });
+  const payload = buildDraftReviewPayload(reviewInput);
+
+  // Not inlined (no valid anchor) ...
+  assert.equal(payload.comments.length, 0);
+  // ... but kept in the review body, so the finding is never dropped.
+  assert.match(payload.body, /NoMethodError/);
+});
+
+test("buildReviewInput: artifactBodyLine hostedUrl is copilot-summon-sanitized in the body", () => {
+  const summonUrl = "https://example.test/@copilot/report.html";
+  assert.equal(containsBareCopilotSummon(summonUrl), true);
+
+  const reviewInput = buildReviewInput({
+    findings: [],
+    headSha: HEAD_SHA,
+    hosting: { hosting: "claude-artifact" },
+    hostedUrl: summonUrl,
+  });
+  // The artifact summary line is sanitized: no bare summon reaches the body.
+  assert.equal(containsBareCopilotSummon(reviewInput.summaryFindings[0].message), false);
+});
+
 test("severityToEvent: confirmed 500 stays PENDING unless submit is authorized", () => {
   const unauthorized = severityToEvent({ findings: FINDINGS, submitAuthorized: false });
   assert.equal(unauthorized.event, null);

--- a/test/loop/ui-review-report.test.mjs
+++ b/test/loop/ui-review-report.test.mjs
@@ -148,6 +148,36 @@ test("buildReviewInput: anchorable finding with a malformed anchor falls back to
   assert.match(payload.body, /NoMethodError/);
 });
 
+test("buildReviewInput: anchorable finding with line<=0 or a whitespace-only path falls to the body, never dropped", () => {
+  // Both anchors pass Number.isFinite/non-empty-string but buildDraftReviewPayload
+  // filters them (it keeps only line>0 and a non-blank trimmed path). hasValidAnchor
+  // must mirror that filter so neither finding is lost between the two layers.
+  const findings = [
+    {
+      severity: "must-fix",
+      kind: "server-log-exception",
+      exception: { type: "ZeroLineError", message: "line is 0" },
+      anchor: { path: "app/models/user.rb", line: 0, side: "RIGHT" },
+      anchorable: true,
+    },
+    {
+      severity: "must-fix",
+      kind: "error-response",
+      exception: { type: "BlankPathError", message: "path is blank" },
+      anchor: { path: "   ", line: 12, side: "RIGHT" },
+      anchorable: true,
+    },
+  ];
+  const reviewInput = buildReviewInput({ findings, headSha: HEAD_SHA });
+  const payload = buildDraftReviewPayload(reviewInput);
+
+  // Neither is inlined (both anchors are what the payload would drop) ...
+  assert.equal(payload.comments.length, 0);
+  // ... and both land in the review body, so neither finding is lost.
+  assert.match(payload.body, /ZeroLineError/);
+  assert.match(payload.body, /BlankPathError/);
+});
+
 test("buildReviewInput: artifactBodyLine hostedUrl is copilot-summon-sanitized in the body", () => {
   const summonUrl = "https://example.test/@copilot/report.html";
   assert.equal(containsBareCopilotSummon(summonUrl), true);

--- a/test/loop/ui-review-report.test.mjs
+++ b/test/loop/ui-review-report.test.mjs
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 import {
   buildReviewInput,
@@ -7,10 +10,11 @@ import {
   decideHosting,
   buildArtifactHtml,
   ARTIFACT_MAX_FINDINGS,
+  ARTIFACT_MAX_SCREENSHOT_BYTES,
 } from "@dev-loops/core/loop/ui-review-report";
 import { buildDraftReviewPayload } from "@dev-loops/core/loop/reviewer-loop-state";
 import { containsBareCopilotSummon } from "@dev-loops/core/github/copilot-helpers";
-import { parseUiReviewReportCliArgs } from "../../scripts/loop/ui-review-report.mjs";
+import { parseUiReviewReportCliArgs, loadScreenshot } from "../../scripts/loop/ui-review-report.mjs";
 
 const HEAD_SHA = "a".repeat(40);
 
@@ -260,6 +264,48 @@ test("CLI: parses required args, submit-authorized and dry-run default off", () 
   assert.equal(opts.submitAuthorized, false);
   assert.equal(opts.dryRun, false);
   assert.throws(() => parseUiReviewReportCliArgs(["--diagnose-result", "d.json", "--html-output", "o.html"]), /Missing required --pr/);
+});
+
+test("loadScreenshot: raw-file cap agrees with the data-URI budget (no read-then-drop)", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "ui-review-shot-"));
+  const prefixLen = "data:image/png;base64,".length;
+  // Largest raw size whose base64 data URI still fits the budget (mirrors the
+  // omission boundary buildArtifactHtml applies to the inlined data-URI length).
+  const maxRawBytes = 3 * Math.floor((ARTIFACT_MAX_SCREENSHOT_BYTES - prefixLen) / 4);
+
+  const shot = (name, bytes) => {
+    const p = path.join(dir, name);
+    writeFileSync(p, Buffer.alloc(bytes));
+    return [{ evidence: { screenshotPath: p } }];
+  };
+  const dataUriLen = (bytes) => prefixLen + 4 * Math.ceil(bytes / 3);
+
+  // One byte over the raw threshold: its data URI would exceed the budget, so it
+  // is omitted+logged HERE — never read + base64-encoded only to be dropped by
+  // buildArtifactHtml (which is where the old raw-vs-data-URI mismatch wasted IO).
+  const overSize = maxRawBytes + 1;
+  assert.ok(overSize < ARTIFACT_MAX_SCREENSHOT_BYTES, "over case is still under the old raw cap");
+  assert.ok(dataUriLen(overSize) > ARTIFACT_MAX_SCREENSHOT_BYTES, "over case data URI exceeds budget");
+  const overCaps = [];
+  assert.equal(loadScreenshot(shot("over.png", overSize), overCaps), null);
+  assert.ok(overCaps.some((c) => /screenshot/i.test(c) && /omitted/i.test(c)));
+
+  // Exactly at the threshold: data URI fits the budget, so it is read + inlined
+  // and buildArtifactHtml keeps it (the two checks agree).
+  assert.ok(dataUriLen(maxRawBytes) <= ARTIFACT_MAX_SCREENSHOT_BYTES, "under case data URI fits budget");
+  const underCaps = [];
+  const loaded = loadScreenshot(shot("under.png", maxRawBytes), underCaps);
+  assert.ok(loaded && loaded.dataUri.length <= ARTIFACT_MAX_SCREENSHOT_BYTES);
+  assert.equal(underCaps.length, 0);
+  const { html, caps } = buildArtifactHtml({
+    findings: FINDINGS,
+    counts: { total: 3, anchorable: 2, nonAnchorable: 1 },
+    pr: { number: 42, headSha: HEAD_SHA },
+    screenshot: loaded,
+    generatedAt: "2026-07-09T00:00:00.000Z",
+  });
+  assert.match(html, /data:image\/png;base64,/);
+  assert.equal(caps.length, 0);
 });
 
 test("buildArtifactHtml: oversized screenshot is omitted and logged, never silently dropped", () => {

--- a/test/loop/ui-review-report.test.mjs
+++ b/test/loop/ui-review-report.test.mjs
@@ -9,6 +9,7 @@ import {
   ARTIFACT_MAX_FINDINGS,
 } from "@dev-loops/core/loop/ui-review-report";
 import { buildDraftReviewPayload } from "@dev-loops/core/loop/reviewer-loop-state";
+import { containsBareCopilotSummon } from "@dev-loops/core/github/copilot-helpers";
 import { parseUiReviewReportCliArgs } from "../../scripts/loop/ui-review-report.mjs";
 
 const HEAD_SHA = "a".repeat(40);
@@ -83,6 +84,44 @@ test("buildReviewInput -> buildDraftReviewPayload: pending, head-pinned, anchore
   assert.match(payload.body, /orphan/);
 });
 
+test("buildReviewInput: untrusted app text is copilot-summon-sanitized in both inline and summary bodies", () => {
+  const summonFindings = [
+    {
+      severity: "must-fix",
+      kind: "server-log-exception",
+      message: "boom",
+      // Untrusted target-app exception text carrying summon literals.
+      exception: { type: "RuntimeError", message: "hey @copilot please /copilot fix this" },
+      anchor: { path: "app/models/user.rb", line: 11, side: "RIGHT" },
+      anchorable: true,
+      nonAnchorableReason: null,
+    },
+    {
+      severity: "must-fix",
+      kind: "error-response",
+      message: "unhandled",
+      exception: { type: "Error", message: "log said @copilot review /copilot now" },
+      anchor: null,
+      anchorable: false,
+      nonAnchorableReason: "source file is not among the PR's changed files",
+    },
+  ];
+  const reviewInput = buildReviewInput({ findings: summonFindings, headSha: HEAD_SHA });
+  const payload = buildDraftReviewPayload(reviewInput);
+
+  // Sanity: the raw untrusted text WOULD arm the guard.
+  assert.equal(containsBareCopilotSummon("hey @copilot please /copilot fix this"), true);
+
+  // Inline comment body is sanitized (guard-inert) and no longer a bare summon.
+  const inline = payload.comments[0].body;
+  assert.match(inline, /RuntimeError/);
+  assert.equal(containsBareCopilotSummon(inline), false);
+
+  // Summary/review body (carries the non-anchorable finding) is sanitized too.
+  assert.match(payload.body, /source file is not among the PR's changed files/);
+  assert.equal(containsBareCopilotSummon(payload.body), false);
+});
+
 test("severityToEvent: confirmed 500 stays PENDING unless submit is authorized", () => {
   const unauthorized = severityToEvent({ findings: FINDINGS, submitAuthorized: false });
   assert.equal(unauthorized.event, null);
@@ -153,6 +192,64 @@ test("buildArtifactHtml: self-contained + CSP-safe, inlines screenshot, logs cap
     generatedAt: "2026-07-09T00:00:00.000Z",
   });
   assert.ok(capped.caps.some((c) => /truncated/i.test(c)));
+});
+
+test("buildArtifactHtml: attacker-influenceable finding text is HTML-escaped, never raw", () => {
+  const xss = [{
+    severity: "note",
+    kind: "page-error",
+    message: `<script>alert("x&y's")</script>`,
+    exception: { type: `<script>`, message: `alert("x&y's")` },
+    anchor: null,
+    anchorable: false,
+    nonAnchorableReason: `<script>&"'`,
+  }];
+  const { html } = buildArtifactHtml({
+    findings: xss,
+    counts: { total: 1, anchorable: 0, nonAnchorable: 1 },
+    pr: { number: 42, headSha: HEAD_SHA },
+    screenshot: null,
+    generatedAt: "2026-07-09T00:00:00.000Z",
+  });
+
+  // The raw markup never reaches the artifact.
+  assert.doesNotMatch(html, /<script>/);
+  // Each metacharacter is emitted as its escapeHtml entity.
+  assert.match(html, /&lt;script&gt;/);
+  assert.match(html, /&amp;/);
+  assert.match(html, /&quot;/);
+  assert.match(html, /&#39;/);
+});
+
+test("artifactBodyLine/verdict: hosted URL vs off-Claude follow-up, and empty/non-blocking verdicts", () => {
+  // A real hosted URL is linked verbatim in the summary body.
+  const hosted = buildReviewInput({
+    findings: [],
+    headSha: HEAD_SHA,
+    hosting: { hosting: "claude-artifact" },
+    hostedUrl: "https://example.test/report.html",
+  });
+  assert.match(hosted.summaryFindings[0].message, /https:\/\/example\.test\/report\.html/);
+
+  // Off-Claude with no hosted URL states the fail-closed reason + follow-up marker.
+  const offClaude = buildReviewInput({
+    findings: [],
+    headSha: HEAD_SHA,
+    hosting: decideHosting({ htmlPath: "/out/report.html", env: {} }),
+  });
+  assert.match(offClaude.summaryFindings[0].message, /unhosted/i);
+  assert.match(offClaude.summaryFindings[0].message, /#1285/);
+
+  // Zero findings -> APPROVE, severity none.
+  assert.equal(hosted.verdict, "APPROVE");
+  assert.equal(severityToEvent({ findings: [] }).severity, "none");
+
+  // Non-blocking (note-only) findings -> COMMENT, never REQUEST_CHANGES.
+  const noteOnly = buildReviewInput({
+    findings: [{ severity: "note", kind: "page-error", anchorable: false, anchor: null, message: "minor" }],
+    headSha: HEAD_SHA,
+  });
+  assert.equal(noteOnly.verdict, "COMMENT");
 });
 
 test("CLI: parses required args, submit-authorized and dry-run default off", () => {


### PR DESCRIPTION
## Summary

Stage 4 of epic #1114 (`/loop-review-ui`). **Report**: builds a CSP-safe self-contained screenshot/findings artifact and posts a **head-pinned PENDING** PR review with inline comments on the exact Stage-3 diff-line anchors (each carrying the reproduced exception + a fix direction); non-anchorable findings go in the review body. Review event is chosen by severity but never auto-submitted. Reuses the existing pending-review poster (`stage-reviewer-draft.mjs` + `buildDraftReviewPayload`) as an adapter, not a new poster.

## Scope and context

In scope: a pure core report module (findings→review-payload adapter, severity→event policy, self-contained HTML builder, harness-aware hosting directive), a thin CLI that reuses the pending-review poster + `loop info --pr` head pinning, and offline tests. **Harness-aware hosting is descoped this stage** (operator decision): on Claude Code the module returns a `claude-artifact` publish directive for the orchestrator; off-Claude it fails closed with a stated reason — the full GitHub-native fallback is follow-up #1285. Out of scope (Non-goals): auto-submit without authorization, production/non-dev posting targets, visual-regression; does not replace the product/eng review angle or the Copilot gate.

## Acceptance criteria

Satisfies issue #1120's acceptance criteria (as descoped 2026-07-09: GitHub-native fallback deferred to #1285, off-Claude hosting fails closed with a stated reason) — checked off on the issue at merge.

## Definition of done

For a UI PR with Stage 3 findings, the stage posts a head-pinned PENDING review with inline comments on real diff lines + a body-linked (or fail-closed-noted) self-contained artifact, defaulting to pending unless submit is authorized; severity policy applied; caps logged.

## Non-goals

No auto-submit without authorization. No production/non-dev posting target. No visual-regression. No GitHub-native fallback publisher (follow-up #1285). Does not replace the product/eng review angle or the Copilot gate.

## Validation

- `node --test test/loop/ui-review-report.test.mjs` (13 pass — payload shape/PENDING/head-pinned/anchors, `hasValidAnchor` mirrors the payload's inline filter so malformed anchors (blank path / line<=0) fall to the body and are never dropped, copilot-summon sanitization, severity→event policy authorized-vs-not, harness-aware hosting directive, self-contained artifact + caps, screenshot read/data-URI cap agreement).
- `npm run test:scripts` (full leg, 2535 pass), `npm run test:core`, `npm run test:assets`.
- Full gate uses `npm run verify`.

Closes #1120
