### PR TITLE
feat(loop): teardown + side-effect ledger for ui_review (Stage 5 of #1114)

### DIFF
--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -151,9 +151,46 @@ artifact is unhosted (with the reason), so the review never blocks on hosting.
 Every bounded cap — findings truncated past the artifact cap, an oversized or
 unreadable evidence screenshot omitted — is logged, never silent.
 
+## Teardown + side-effect ledger
+
+The terminal cleanup stage tears down the loop's transient state — stops the
+app booted in provision, drops the dev-DB rows the drive created, removes the
+provisioned worktree — and ALWAYS emits a side-effect ledger so nothing is
+silently orphaned, via
+`scripts/loop/ui-review-teardown.mjs --repo-root <p> --provision-result <p> [--drive-result <p>] [--row-manifest <p>] [--confirm] [--no-stop-app]`
+(pure decisions in `packages/core/src/loop/ui-review-teardown.mjs`). It reads
+the prior-stage result JSON — the app PID + applied migrations + worktree path
+from provision, and the rows-created signal from the drive.
+
+The destructive steps (dev-DB row drops and worktree removal) run ONLY with an
+explicit `--confirm`. Without it, those steps are skipped and the ledger records
+what remains; stopping the app still runs, because it is a clean shutdown of a
+process the loop itself started, not a mutation of persisted state. The app is
+stopped via the provision boot PID (SIGTERM, then a LOGGED SIGKILL fallback); a
+null PID is never a blind kill — the ledger reports the process may still be
+running. Worktree removal delegates to `scripts/loop/cleanup-worktree.mjs`,
+which refuses any path outside the loop namespace and leaves the primary
+checkout untouched.
+
+The side-effect ledger is emitted in EVERY case (success, skip, partial
+failure) and enumerates: migrations applied (recorded as applied-not-reverted —
+reversing a dev-DB migration is a separate explicit action, never a default),
+rows created/dropped or left behind, the worktree path + whether it was removed,
+and the process status. A failed kill/drop/removal is reported in the ledger and
+the result's `errors` list, never swallowed.
+
+Row dropping is honest about a known limitation: the drive does not tag the
+dev-DB rows it creates with a session id or manifest, so this stage cannot know
+which rows to drop and MUST NOT guess. It drops rows only from an explicit
+manifest handed in; when the drive walked mutating flows without one, the ledger
+reports rows "may remain (untagged)". Making the drop real requires row/session
+tagging upstream in the drive.
+
 ## Non-goals
 
-No teardown logic lives here yet. The stage does not auto-submit a review
+The teardown stage never rolls back the branch's dev-DB migrations by default
+(the ledger records they were applied, not reverted) and never tears down a
+production DB. The stage does not auto-submit a review
 without explicit authorization, publish to a production/non-dev posting target,
 ship the GitHub-native hosted-artifact fallback, auto-fix the located defects,
 pixel-diff for visual regression, run a cross-browser matrix, or touch a

--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -184,7 +184,10 @@ dev-DB rows it creates with a session id or manifest, so this stage cannot know
 which rows to drop and MUST NOT guess. It drops rows only from an explicit
 manifest handed in; when the drive walked mutating flows without one, the ledger
 reports rows "may remain (untagged)". Making the drop real requires row/session
-tagging upstream in the drive.
+tagging upstream in the drive. The CLI's row-drop seam is not yet wired: a
+confirmed manifest fails CLOSED (the ledger records a drop failure, never a drop)
+rather than silently no-op'ing, so a caller can never believe rows were dropped;
+wiring a real drop is a tracked follow-up.
 
 ## Non-goals
 

--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -168,7 +168,9 @@ what remains; stopping the app still runs, because it is a clean shutdown of a
 process the loop itself started, not a mutation of persisted state. The app is
 stopped via the provision boot PID (SIGTERM, then a LOGGED SIGKILL fallback); a
 null PID is never a blind kill — the ledger reports the process may still be
-running. Worktree removal delegates to `scripts/loop/cleanup-worktree.mjs`,
+running. On win32 the app-stop fails closed (process-group kill is unsupported,
+so the kill is not attempted): the ledger reports may-be-running rather than a
+false stopped. Worktree removal delegates to `scripts/loop/cleanup-worktree.mjs`,
 which refuses any path outside the loop namespace and leaves the primary
 checkout untouched.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,6 +61,7 @@
     "./loop/ui-review-drive": "./src/loop/ui-review-drive.mjs",
     "./loop/ui-review-diagnose": "./src/loop/ui-review-diagnose.mjs",
     "./loop/ui-review-report": "./src/loop/ui-review-report.mjs",
+    "./loop/ui-review-teardown": "./src/loop/ui-review-teardown.mjs",
     "./projects/list-queue-items": "./src/projects/list-queue-items.mjs",
     "./projects/move-queue-item": "./src/projects/move-queue-item.mjs",
     "./projects/resolve-project": "./src/projects/resolve-project.mjs",

--- a/packages/core/src/loop/ui-review-teardown.mjs
+++ b/packages/core/src/loop/ui-review-teardown.mjs
@@ -105,28 +105,50 @@ export async function teardown(
   };
 
   const provision = provisionResult ?? {};
-  const worktreePath = provision.worktreePath ?? null;
+  // `worktreePath` is read from disk (trust boundary). A non-string (number,
+  // object, array) must never reach `removeWorktree` — the CLI's cleanup path
+  // calls `path.resolve(worktreePath)`, which throws on a non-string, breaking
+  // the always-emit-ledger invariant. Coerce to a usable string or null here.
+  const rawWorktreePath = provision.worktreePath ?? null;
+  const worktreePath = typeof rawWorktreePath === "string" ? rawWorktreePath : null;
+  const worktreePathMalformed = rawWorktreePath != null && typeof rawWorktreePath !== "string";
   const pid = provision.boot?.pid ?? null;
   const migrations = provision.migrations ?? { applied: 0, pending: 0, destructive: [], detail: "no provision migrations" };
 
   // 1. Stop the app (clean shutdown; NOT confirmation-gated). Uses the Stage-1
-  //    boot PID. A null PID means we never captured one, so we cannot stop it —
-  //    the ledger reports it may still be running rather than guessing.
+  //    boot PID. A missing OR unusable PID means we cannot stop it — the ledger
+  //    reports it may still be running rather than guessing. `boot.pid` is read
+  //    from disk (trust boundary), so anything that is not a positive integer
+  //    (0, negative, NaN, float, string) is rejected here: passing it to the
+  //    kill seam would let the CLI's process-group kill signal `process.kill(0)`
+  //    (this loop's OWN group) or `process.kill(-1)` (every process).
+  const usablePid = Number.isInteger(pid) && pid > 0;
   let processLedger;
   if (!stopApp) {
-    processLedger = { pid, status: PROCESS_STATUS.SKIPPED, forced: false, detail: "app stop skipped by request" };
-    record(`app stop skipped (pid ${pid ?? "n/a"})`);
-  } else if (pid == null) {
-    processLedger = { pid: null, status: PROCESS_STATUS.MAY_BE_RUNNING, forced: false, detail: "no PID captured from Stage 1; process may still be running" };
-    record("app stop: no PID captured from Stage 1; process may still be running");
+    processLedger = { pid: usablePid ? pid : null, status: PROCESS_STATUS.SKIPPED, forced: false, detail: "app stop skipped by request" };
+    record(`app stop skipped (pid ${usablePid ? pid : "n/a"})`);
+  } else if (!usablePid) {
+    const detail = pid == null
+      ? "no PID captured from Stage 1; process may still be running"
+      : "no usable PID from Stage 1 (not a positive integer); process may still be running";
+    processLedger = { pid: null, status: PROCESS_STATUS.MAY_BE_RUNNING, forced: false, detail };
+    record(`app stop: ${detail}`);
   } else {
-    const kill = await killProcess({ pid });
-    if (kill.stopped) {
-      processLedger = { pid, status: PROCESS_STATUS.STOPPED, forced: !!kill.forced, detail: kill.detail };
-      record(`app stopped (pid ${pid})${kill.forced ? " [force-killed: SIGKILL fallback]" : ""}: ${kill.detail}`);
-    } else {
-      processLedger = { pid, status: PROCESS_STATUS.KILL_FAILED, forced: !!kill.forced, detail: kill.detail };
-      fail(`app stop FAILED (pid ${pid}): ${kill.detail}`);
+    // A seam that THROWS must still yield a fully-emitted ledger: catch it,
+    // record KILL_FAILED, and press on. The always-emit invariant holds even
+    // when a real IO seam rejects.
+    try {
+      const kill = await killProcess({ pid });
+      if (kill.stopped) {
+        processLedger = { pid, status: PROCESS_STATUS.STOPPED, forced: !!kill.forced, detail: kill.detail };
+        record(`app stopped (pid ${pid})${kill.forced ? " [force-killed: SIGKILL fallback]" : ""}: ${kill.detail}`);
+      } else {
+        processLedger = { pid, status: PROCESS_STATUS.KILL_FAILED, forced: !!kill.forced, detail: kill.detail };
+        fail(`app stop FAILED (pid ${pid}): ${kill.detail}`);
+      }
+    } catch (err) {
+      processLedger = { pid, status: PROCESS_STATUS.KILL_FAILED, forced: false, detail: `kill seam threw: ${err?.message ?? err}` };
+      fail(`app stop FAILED (pid ${pid}): kill seam threw: ${err?.message ?? err}`);
     }
   }
 
@@ -145,13 +167,18 @@ export async function teardown(
       rowsLedger = { status: ROW_STATUS.NONE, dropped: 0, candidates: 0, detail: "no rows created (drive drove no mutating steps)" };
     }
   } else if (hasManifest) {
-    const drop = await dropRows({ rows: rowManifest });
-    if (drop.ok) {
-      rowsLedger = { status: ROW_STATUS.DROPPED, dropped: drop.dropped ?? rowManifest.length, candidates: rowManifest.length, detail: drop.detail };
-      record(`dev-DB rows dropped: ${drop.dropped ?? rowManifest.length} (${drop.detail})`);
-    } else {
-      rowsLedger = { status: ROW_STATUS.DROP_FAILED, dropped: drop.dropped ?? 0, candidates: rowManifest.length, detail: drop.detail };
-      fail(`dev-DB row drop FAILED: ${drop.detail}`);
+    try {
+      const drop = await dropRows({ rows: rowManifest });
+      if (drop.ok) {
+        rowsLedger = { status: ROW_STATUS.DROPPED, dropped: drop.dropped ?? rowManifest.length, candidates: rowManifest.length, detail: drop.detail };
+        record(`dev-DB rows dropped: ${drop.dropped ?? rowManifest.length} (${drop.detail})`);
+      } else {
+        rowsLedger = { status: ROW_STATUS.DROP_FAILED, dropped: drop.dropped ?? 0, candidates: rowManifest.length, detail: drop.detail };
+        fail(`dev-DB row drop FAILED: ${drop.detail}`);
+      }
+    } catch (err) {
+      rowsLedger = { status: ROW_STATUS.DROP_FAILED, dropped: 0, candidates: rowManifest.length, detail: `drop seam threw: ${err?.message ?? err}` };
+      fail(`dev-DB row drop FAILED: drop seam threw: ${err?.message ?? err}`);
     }
   } else if (driveMayHaveCreatedRows(driveResult)) {
     // Confirmed, but nothing to target: honesty over a guess-drop.
@@ -164,20 +191,28 @@ export async function teardown(
   // 3. Remove the worktree — DESTRUCTIVE, confirmation-gated. Delegated to the
   //    shared cleanup path, which refuses anything outside the loop namespace.
   let worktreeLedger;
-  if (!worktreePath) {
+  if (worktreePathMalformed) {
+    worktreeLedger = { path: null, removed: false, status: WORKTREE_STATUS.REMOVE_FAILED, detail: `malformed worktree path in provision result (not a string): ${typeof rawWorktreePath}` };
+    fail(`worktree removal FAILED: malformed worktree path in provision result (not a string): ${typeof rawWorktreePath}`);
+  } else if (!worktreePath) {
     worktreeLedger = { path: null, removed: false, status: WORKTREE_STATUS.SKIPPED_UNCONFIRMED, detail: "no worktree path in provision result" };
     record("worktree removal skipped: no worktree path in provision result");
   } else if (!confirm) {
     worktreeLedger = { path: worktreePath, removed: false, status: WORKTREE_STATUS.SKIPPED_UNCONFIRMED, detail: "worktree retained: teardown not confirmed" };
     record(`worktree removal skipped (not confirmed): ${worktreePath} retained`);
   } else {
-    const rm = await removeWorktree({ worktreePath });
-    if (rm.removed) {
-      worktreeLedger = { path: worktreePath, removed: true, status: WORKTREE_STATUS.REMOVED, detail: rm.detail };
-      record(`worktree removed: ${worktreePath} (${rm.detail})`);
-    } else {
-      worktreeLedger = { path: worktreePath, removed: false, status: WORKTREE_STATUS.REMOVE_FAILED, detail: rm.detail };
-      fail(`worktree removal FAILED: ${worktreePath} (${rm.detail})`);
+    try {
+      const rm = await removeWorktree({ worktreePath });
+      if (rm.removed) {
+        worktreeLedger = { path: worktreePath, removed: true, status: WORKTREE_STATUS.REMOVED, detail: rm.detail };
+        record(`worktree removed: ${worktreePath} (${rm.detail})`);
+      } else {
+        worktreeLedger = { path: worktreePath, removed: false, status: WORKTREE_STATUS.REMOVE_FAILED, detail: rm.detail };
+        fail(`worktree removal FAILED: ${worktreePath} (${rm.detail})`);
+      }
+    } catch (err) {
+      worktreeLedger = { path: worktreePath, removed: false, status: WORKTREE_STATUS.REMOVE_FAILED, detail: `removeWorktree seam threw: ${err?.message ?? err}` };
+      fail(`worktree removal FAILED: ${worktreePath} (removeWorktree seam threw: ${err?.message ?? err})`);
     }
   }
 

--- a/packages/core/src/loop/ui-review-teardown.mjs
+++ b/packages/core/src/loop/ui-review-teardown.mjs
@@ -1,0 +1,202 @@
+/**
+ * Teardown + side-effect ledger orchestrator for the ui_review route (Stage 5).
+ *
+ * Terminal cleanup for a running-app review: stop the app booted in Stage 1,
+ * drop the dev-DB rows the Stage-2 drive created, and remove the provisioned
+ * worktree. The core safety property of this stage is that a side-effect ledger
+ * is ALWAYS emitted — enumerating every migration applied, row created/dropped,
+ * the worktree path, and any process left running — so nothing the loop touched
+ * is ever silently orphaned, whether teardown succeeds, is skipped, or partially
+ * fails.
+ *
+ * Two safety rails:
+ *   - Destructive steps (row drops, worktree removal) run ONLY on explicit
+ *     confirmation. Without it the destructive steps are skipped and the ledger
+ *     records what remains. Stopping the app is a clean shutdown of a process
+ *     the loop itself started, not a destructive mutation of persisted state, so
+ *     it runs regardless of confirmation.
+ *   - A failed kill/drop/removal is REPORTED in the ledger and the result's
+ *     errors list, never swallowed.
+ *
+ * This module is PURE orchestration: the process kill, the row drop, and the
+ * worktree removal are injected seams so it is fully testable without real side
+ * effects. The thin CLI wires the real ones.
+ *
+ * Non-goals (explicit): NO rollback of the branch's dev-DB migrations by default
+ * (they were applied to a dev DB; reversal is a separate explicit action — the
+ * ledger records they were applied, not reverted). NO production teardown.
+ */
+
+/**
+ * The honest row-drop reality: Stage 2 does NOT tag the dev-DB rows it creates
+ * with a session id or row manifest. So unless an explicit row manifest is
+ * handed in (and confirmed), this stage CANNOT know which rows to drop and MUST
+ * NOT guess. When the drive ran mutating flows without a manifest, the ledger
+ * reports rows "may remain (untagged)" rather than dropping anything.
+ */
+
+const ROW_STATUS = Object.freeze({
+  DROPPED: "dropped",
+  DROP_FAILED: "drop-failed",
+  MAY_REMAIN_UNTAGGED: "may-remain-untagged",
+  SKIPPED_UNCONFIRMED: "skipped-unconfirmed",
+  NONE: "none",
+});
+
+const WORKTREE_STATUS = Object.freeze({
+  REMOVED: "removed",
+  REMOVE_FAILED: "remove-failed",
+  SKIPPED_UNCONFIRMED: "skipped-unconfirmed",
+});
+
+const PROCESS_STATUS = Object.freeze({
+  STOPPED: "stopped",
+  KILL_FAILED: "kill-failed",
+  MAY_BE_RUNNING: "may-be-running",
+  SKIPPED: "skipped",
+});
+
+/**
+ * Did the Stage-2 drive potentially create dev-DB rows? Without row tagging this
+ * is a coarse but honest signal: a drive that actually walked steps exercised
+ * create/edit/upload interactions, so rows may have been created. A drive that
+ * stopped before driving anything (e.g. auth failure) created nothing.
+ */
+function driveMayHaveCreatedRows(driveResult) {
+  if (!driveResult || driveResult.stopped) return false;
+  return Array.isArray(driveResult.steps) && driveResult.steps.length > 0;
+}
+
+/**
+ * Run the teardown sequence and always return a result carrying the side-effect
+ * ledger.
+ *
+ * @param {object} input
+ * @param {object} input.provisionResult - Stage-1 result: `boot.pid` (app PID),
+ *   `migrations` (applied count/detail), and `worktreePath`.
+ * @param {object|null} [input.driveResult] - Stage-2 result: the rows-created
+ *   signal (whether the drive walked mutating steps). Null when no drive ran.
+ * @param {Array<object>|null} [input.rowManifest] - Explicit rows to drop, when
+ *   a session tag/manifest is available. Absent/empty => untagged fallback.
+ * @param {boolean} [input.confirm] - Explicit authorization for the destructive
+ *   steps (row drop, worktree removal). Fail-safe: absent means NOT confirmed.
+ * @param {boolean} [input.stopApp] - Stop the Stage-1 app (default true). This is
+ *   a clean shutdown, NOT gated on confirmation.
+ * @param {object} seams
+ * @param {(a:{pid:number})=>Promise<{stopped:boolean,forced:boolean,detail:string}>} seams.killProcess
+ * @param {(a:{rows:Array<object>})=>Promise<{ok:boolean,dropped:number,detail:string}>} seams.dropRows
+ * @param {(a:{worktreePath:string})=>Promise<{removed:string|null,ok:boolean,detail:string}>} seams.removeWorktree
+ * @param {(msg:string)=>void} [seams.log]
+ * @returns {Promise<{ok:boolean,confirmed:boolean,ledger:object,errors:string[],logs:string[]}>}
+ */
+export async function teardown(
+  { provisionResult, driveResult = null, rowManifest = null, confirm = false, stopApp = true },
+  { killProcess, dropRows, removeWorktree, log = () => {} } = {},
+) {
+  const logs = [];
+  const errors = [];
+  const record = (msg) => {
+    logs.push(msg);
+    log(msg);
+  };
+  const fail = (msg) => {
+    errors.push(msg);
+    record(msg);
+  };
+
+  const provision = provisionResult ?? {};
+  const worktreePath = provision.worktreePath ?? null;
+  const pid = provision.boot?.pid ?? null;
+  const migrations = provision.migrations ?? { applied: 0, pending: 0, destructive: [], detail: "no provision migrations" };
+
+  // 1. Stop the app (clean shutdown; NOT confirmation-gated). Uses the Stage-1
+  //    boot PID. A null PID means we never captured one, so we cannot stop it —
+  //    the ledger reports it may still be running rather than guessing.
+  let processLedger;
+  if (!stopApp) {
+    processLedger = { pid, status: PROCESS_STATUS.SKIPPED, forced: false, detail: "app stop skipped by request" };
+    record(`app stop skipped (pid ${pid ?? "n/a"})`);
+  } else if (pid == null) {
+    processLedger = { pid: null, status: PROCESS_STATUS.MAY_BE_RUNNING, forced: false, detail: "no PID captured from Stage 1; process may still be running" };
+    record("app stop: no PID captured from Stage 1; process may still be running");
+  } else {
+    const kill = await killProcess({ pid });
+    if (kill.stopped) {
+      processLedger = { pid, status: PROCESS_STATUS.STOPPED, forced: !!kill.forced, detail: kill.detail };
+      record(`app stopped (pid ${pid})${kill.forced ? " [force-killed: SIGKILL fallback]" : ""}: ${kill.detail}`);
+    } else {
+      processLedger = { pid, status: PROCESS_STATUS.KILL_FAILED, forced: !!kill.forced, detail: kill.detail };
+      fail(`app stop FAILED (pid ${pid}): ${kill.detail}`);
+    }
+  }
+
+  // 2. Drop dev-DB rows — DESTRUCTIVE, confirmation-gated, dev DB only. Only ever
+  //    drops an explicit manifest; never guesses untagged rows (see file header).
+  const hasManifest = Array.isArray(rowManifest) && rowManifest.length > 0;
+  let rowsLedger;
+  if (!confirm) {
+    if (hasManifest) {
+      rowsLedger = { status: ROW_STATUS.SKIPPED_UNCONFIRMED, dropped: 0, candidates: rowManifest.length, detail: `${rowManifest.length} row(s) NOT dropped: teardown not confirmed` };
+      record(`row drop skipped (not confirmed): ${rowManifest.length} manifest row(s) remain`);
+    } else if (driveMayHaveCreatedRows(driveResult)) {
+      rowsLedger = { status: ROW_STATUS.MAY_REMAIN_UNTAGGED, dropped: 0, candidates: 0, detail: "rows may remain (untagged): drive created rows but no session tag/manifest to target them, and teardown not confirmed" };
+      record("row drop skipped: rows may remain (untagged)");
+    } else {
+      rowsLedger = { status: ROW_STATUS.NONE, dropped: 0, candidates: 0, detail: "no rows created (drive drove no mutating steps)" };
+    }
+  } else if (hasManifest) {
+    const drop = await dropRows({ rows: rowManifest });
+    if (drop.ok) {
+      rowsLedger = { status: ROW_STATUS.DROPPED, dropped: drop.dropped ?? rowManifest.length, candidates: rowManifest.length, detail: drop.detail };
+      record(`dev-DB rows dropped: ${drop.dropped ?? rowManifest.length} (${drop.detail})`);
+    } else {
+      rowsLedger = { status: ROW_STATUS.DROP_FAILED, dropped: drop.dropped ?? 0, candidates: rowManifest.length, detail: drop.detail };
+      fail(`dev-DB row drop FAILED: ${drop.detail}`);
+    }
+  } else if (driveMayHaveCreatedRows(driveResult)) {
+    // Confirmed, but nothing to target: honesty over a guess-drop.
+    rowsLedger = { status: ROW_STATUS.MAY_REMAIN_UNTAGGED, dropped: 0, candidates: 0, detail: "rows may remain (untagged): drive created rows but no session tag/manifest to target them; refusing to guess which rows to drop" };
+    record("row drop: rows may remain (untagged) — no manifest to target, not guessing");
+  } else {
+    rowsLedger = { status: ROW_STATUS.NONE, dropped: 0, candidates: 0, detail: "no rows created (drive drove no mutating steps)" };
+  }
+
+  // 3. Remove the worktree — DESTRUCTIVE, confirmation-gated. Delegated to the
+  //    shared cleanup path, which refuses anything outside the loop namespace.
+  let worktreeLedger;
+  if (!worktreePath) {
+    worktreeLedger = { path: null, removed: false, status: WORKTREE_STATUS.SKIPPED_UNCONFIRMED, detail: "no worktree path in provision result" };
+    record("worktree removal skipped: no worktree path in provision result");
+  } else if (!confirm) {
+    worktreeLedger = { path: worktreePath, removed: false, status: WORKTREE_STATUS.SKIPPED_UNCONFIRMED, detail: "worktree retained: teardown not confirmed" };
+    record(`worktree removal skipped (not confirmed): ${worktreePath} retained`);
+  } else {
+    const rm = await removeWorktree({ worktreePath });
+    if (rm.removed) {
+      worktreeLedger = { path: worktreePath, removed: true, status: WORKTREE_STATUS.REMOVED, detail: rm.detail };
+      record(`worktree removed: ${worktreePath} (${rm.detail})`);
+    } else {
+      worktreeLedger = { path: worktreePath, removed: false, status: WORKTREE_STATUS.REMOVE_FAILED, detail: rm.detail };
+      fail(`worktree removal FAILED: ${worktreePath} (${rm.detail})`);
+    }
+  }
+
+  // The ledger is ALWAYS emitted (every case), enumerating every known side
+  // effect. Migrations are recorded as applied-not-reverted by design.
+  const ledger = {
+    confirmed: confirm,
+    migrations: {
+      applied: migrations.applied ?? 0,
+      reverted: false,
+      detail: migrations.detail ?? null,
+      note: "not reverted (dev DB; migration reversal is a separate explicit action)",
+    },
+    rows: rowsLedger,
+    worktree: worktreeLedger,
+    process: processLedger,
+  };
+
+  return { ok: errors.length === 0, confirmed: confirm, ledger, errors, logs };
+}
+
+export { ROW_STATUS, WORKTREE_STATUS, PROCESS_STATUS };

--- a/packages/core/src/loop/ui-review-teardown.mjs
+++ b/packages/core/src/loop/ui-review-teardown.mjs
@@ -47,6 +47,10 @@ const WORKTREE_STATUS = Object.freeze({
   REMOVED: "removed",
   REMOVE_FAILED: "remove-failed",
   SKIPPED_UNCONFIRMED: "skipped-unconfirmed",
+  // No worktree path in the provision result at all. Distinct from
+  // SKIPPED_UNCONFIRMED (which is the confirmation gate) so the ledger says WHY
+  // removal did not run — a missing path, not a withheld confirmation.
+  MISSING_PATH: "missing-path",
 });
 
 const PROCESS_STATUS = Object.freeze({
@@ -195,7 +199,7 @@ export async function teardown(
     worktreeLedger = { path: null, removed: false, status: WORKTREE_STATUS.REMOVE_FAILED, detail: `malformed worktree path in provision result (not a string): ${typeof rawWorktreePath}` };
     fail(`worktree removal FAILED: malformed worktree path in provision result (not a string): ${typeof rawWorktreePath}`);
   } else if (!worktreePath) {
-    worktreeLedger = { path: null, removed: false, status: WORKTREE_STATUS.SKIPPED_UNCONFIRMED, detail: "no worktree path in provision result" };
+    worktreeLedger = { path: null, removed: false, status: WORKTREE_STATUS.MISSING_PATH, detail: "no worktree path in provision result" };
     record("worktree removal skipped: no worktree path in provision result");
   } else if (!confirm) {
     worktreeLedger = { path: worktreePath, removed: false, status: WORKTREE_STATUS.SKIPPED_UNCONFIRMED, detail: "worktree retained: teardown not confirmed" };

--- a/packages/core/src/loop/ui-review-teardown.mjs
+++ b/packages/core/src/loop/ui-review-teardown.mjs
@@ -87,7 +87,9 @@ function driveMayHaveCreatedRows(driveResult) {
  * @param {boolean} [input.stopApp] - Stop the Stage-1 app (default true). This is
  *   a clean shutdown, NOT gated on confirmation.
  * @param {object} seams
- * @param {(a:{pid:number})=>Promise<{stopped:boolean,forced:boolean,detail:string}>} seams.killProcess
+ * @param {(a:{pid:number})=>Promise<{stopped:boolean,forced:boolean,detail:string,mayBeRunning?:boolean}>} seams.killProcess
+ *   `mayBeRunning:true` marks a NOT-ATTEMPTED outcome (e.g. win32, where process-group
+ *   signalling is unsupported) — mapped to MAY_BE_RUNNING (non-fatal), not KILL_FAILED.
  * @param {(a:{rows:Array<object>})=>Promise<{ok:boolean,dropped:number,detail:string}>} seams.dropRows
  * @param {(a:{worktreePath:string})=>Promise<{removed:string|null,ok:boolean,detail:string}>} seams.removeWorktree
  * @param {(msg:string)=>void} [seams.log]
@@ -146,6 +148,13 @@ export async function teardown(
       if (kill.stopped) {
         processLedger = { pid, status: PROCESS_STATUS.STOPPED, forced: !!kill.forced, detail: kill.detail };
         record(`app stopped (pid ${pid})${kill.forced ? " [force-killed: SIGKILL fallback]" : ""}: ${kill.detail}`);
+      } else if (kill.mayBeRunning) {
+        // The kill was NOT ATTEMPTED (e.g. win32 process-group signalling is
+        // unsupported) — this is a "couldn't stop", not a failed attempt, so it
+        // is non-fatal (matches the null-PID may-be-running treatment): the
+        // ledger reports the app may still be running and `ok` is left intact.
+        processLedger = { pid, status: PROCESS_STATUS.MAY_BE_RUNNING, forced: !!kill.forced, detail: kill.detail };
+        record(`app stop: ${kill.detail}`);
       } else {
         processLedger = { pid, status: PROCESS_STATUS.KILL_FAILED, forced: !!kill.forced, detail: kill.detail };
         fail(`app stop FAILED (pid ${pid}): ${kill.detail}`);

--- a/scripts/loop/ui-review-teardown.mjs
+++ b/scripts/loop/ui-review-teardown.mjs
@@ -163,15 +163,16 @@ function signalProcess(pid, sig) {
  * signal would throw, `signalProcess` would fall back to the bare shell PID, and
  * a bare-pid `isAlive` poll would then report `stopped:true` while the detached
  * server keeps running — a FALSE success the ledger would enshrine. Rather than
- * misreport, we refuse to attempt the kill and report the app as NOT reliably
- * stopped (mapped to a not-stopped ledger status upstream). `platform` is
+ * misreport, we refuse to ATTEMPT the kill and report the app as may-still-be-
+ * running (`mayBeRunning:true` → mapped to a MAY_BE_RUNNING ledger status
+ * upstream, non-fatal: a "couldn't stop", not a failed attempt). `platform` is
  * injectable so the win32 path is testable off a real Windows host.
  * ponytail: fail-closed stated-limitation, not a taskkill /T tree-kill — honest
  * and minimal for this stage; upgrade to a Windows process-tree kill if/when the
  * loop actually needs to run and reliably stop the app on win32. */
 export async function killProcess({ pid, graceMs = 3000, pollMs = 100, platform = process.platform }) {
   if (platform === "win32") {
-    return { stopped: false, forced: false, detail: "win32 process-group kill unsupported; app may still be running (a shell-PID kill would not reach the detached server child)" };
+    return { stopped: false, forced: false, mayBeRunning: true, detail: "win32 process-group kill unsupported; app may still be running (a shell-PID kill would not reach the detached server child)" };
   }
   try {
     signalProcess(pid, "SIGTERM");

--- a/scripts/loop/ui-review-teardown.mjs
+++ b/scripts/loop/ui-review-teardown.mjs
@@ -90,15 +90,17 @@ export function parseUiReviewTeardownCliArgs(argv) {
   return options;
 }
 
-/** Read + parse a prior-stage result JSON, bounded. Returns null for an absent
- * path (an optional input); throws on an oversized/unreadable/invalid file. */
-function readResultJson(file, { optional = false } = {}) {
+/** Read + parse a prior-stage result JSON, bounded. Returns null ONLY for a
+ * genuinely OMITTED path (`file === undefined`); a SUPPLIED path that can't be
+ * stat/read/parsed FAILS CLOSED (throws). A supplied-but-unreadable path silently
+ * nulled would let teardown proceed on an incomplete ledger, misreporting rows as
+ * none/may-remain off missing input even though a path was explicitly provided. */
+function readResultJson(file) {
   if (file === undefined) return null;
   let size;
   try {
     size = statSync(file).size;
   } catch (err) {
-    if (optional) return null;
     throw parseError(`cannot read ${file}: ${(err.message ?? err).toString()}`);
   }
   if (size > MAX_RESULT_BYTES) throw parseError(`${file} is too large (${size} bytes > ${MAX_RESULT_BYTES} cap)`);
@@ -153,8 +155,24 @@ function signalProcess(pid, sig) {
 }
 
 /** Stop a process: SIGTERM, wait a bounded budget for a clean exit, then a
- * LOGGED SIGKILL fallback. A failed kill is reported (never swallowed). */
-export async function killProcess({ pid, graceMs = 3000, pollMs = 100 }) {
+ * LOGGED SIGKILL fallback. A failed kill is reported (never swallowed).
+ *
+ * win32 FAIL-CLOSED: Node cannot signal a process GROUP on Windows (the `-pid`
+ * form is unsupported and throws), and Stage 1 boots the app detached via a
+ * shell — so the real server is a CHILD of the shell PID we hold. The group
+ * signal would throw, `signalProcess` would fall back to the bare shell PID, and
+ * a bare-pid `isAlive` poll would then report `stopped:true` while the detached
+ * server keeps running — a FALSE success the ledger would enshrine. Rather than
+ * misreport, we refuse to attempt the kill and report the app as NOT reliably
+ * stopped (mapped to a not-stopped ledger status upstream). `platform` is
+ * injectable so the win32 path is testable off a real Windows host.
+ * ponytail: fail-closed stated-limitation, not a taskkill /T tree-kill — honest
+ * and minimal for this stage; upgrade to a Windows process-tree kill if/when the
+ * loop actually needs to run and reliably stop the app on win32. */
+export async function killProcess({ pid, graceMs = 3000, pollMs = 100, platform = process.platform }) {
+  if (platform === "win32") {
+    return { stopped: false, forced: false, detail: "win32 process-group kill unsupported; app may still be running (a shell-PID kill would not reach the detached server child)" };
+  }
   try {
     signalProcess(pid, "SIGTERM");
   } catch (err) {
@@ -191,7 +209,7 @@ export async function runCli(argv = process.argv.slice(2), { stdout = process.st
   if (options.help) { stdout.write(`${USAGE}\n`); return; }
 
   const provisionResult = readResultJson(options.provisionResult);
-  const driveResult = readResultJson(options.driveResult, { optional: true });
+  const driveResult = readResultJson(options.driveResult);
   const rowManifest = readRowManifest(options.rowManifest);
 
   const result = await teardown(

--- a/scripts/loop/ui-review-teardown.mjs
+++ b/scripts/loop/ui-review-teardown.mjs
@@ -14,7 +14,6 @@
  * result JSON from disk.
  */
 import { readFileSync, statSync } from "node:fs";
-import path from "node:path";
 import { parseArgs } from "node:util";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { requireTokenValue } from "../_cli-primitives.mjs";
@@ -106,6 +105,20 @@ function readResultJson(file, { optional = false } = {}) {
   return JSON.parse(readFileSync(file, "utf8"));
 }
 
+/** Read + validate an explicit `--row-manifest`. Absent (`undefined`) is the
+ * honest "no manifest" path -> null. When a manifest path IS supplied, it must
+ * parse to a JSON array or `{ rows: [...] }`; any other shape is a user/config
+ * error and FAILS CLOSED (throws), never silently nulled — a silent null would
+ * hide the error behind a misleading "may remain (untagged)" ledger even though
+ * a manifest file was provided. */
+function readRowManifest(file) {
+  if (file === undefined) return null;
+  const manifestJson = readResultJson(file); // present but unreadable/unparseable throws
+  if (Array.isArray(manifestJson)) return manifestJson;
+  if (Array.isArray(manifestJson?.rows)) return manifestJson.rows;
+  throw parseError(`--row-manifest ${file} is malformed: expected a JSON array or { "rows": [...] }`);
+}
+
 const delay = (ms) => new Promise((r) => setTimeout(r, ms));
 
 /** True while `pid` is still alive. `process.kill(pid,0)` throws ESRCH when gone;
@@ -179,8 +192,7 @@ export async function runCli(argv = process.argv.slice(2), { stdout = process.st
 
   const provisionResult = readResultJson(options.provisionResult);
   const driveResult = readResultJson(options.driveResult, { optional: true });
-  const manifestJson = readResultJson(options.rowManifest, { optional: true });
-  const rowManifest = Array.isArray(manifestJson) ? manifestJson : Array.isArray(manifestJson?.rows) ? manifestJson.rows : null;
+  const rowManifest = readRowManifest(options.rowManifest);
 
   const result = await teardown(
     {

--- a/scripts/loop/ui-review-teardown.mjs
+++ b/scripts/loop/ui-review-teardown.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * CLI wrapper for the ui_review teardown stage (Stage 5, terminal cleanup).
+ *
+ * Stops the app booted in Stage 1, drops the dev-DB rows the Stage-2 drive
+ * created (only from an explicit manifest, only on confirmation), and removes
+ * the provisioned worktree via the shared cleanup path. It ALWAYS emits a
+ * side-effect ledger enumerating what was torn down and what remains.
+ *
+ * Thin adapter: it wires the real IO seams — process kill (SIGTERM then a
+ * logged SIGKILL fallback), row drop, and worktree removal (the shared
+ * cleanup-worktree path) — into the pure core orchestrator
+ * (packages/core/src/loop/ui-review-teardown.mjs), reading the prior-stage
+ * result JSON from disk.
+ */
+import { readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { parseArgs } from "node:util";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { requireTokenValue } from "../_cli-primitives.mjs";
+import { teardown } from "@dev-loops/core/loop/ui-review-teardown";
+import { cleanupWorktree } from "./cleanup-worktree.mjs";
+import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+
+const MAX_RESULT_BYTES = 16 * 1024 * 1024;
+
+const USAGE = `Usage:
+  ui-review-teardown.mjs --repo-root <p> --provision-result <p> [--drive-result <p>] [--row-manifest <p>] [--confirm] [--no-stop-app]
+Tear down the ui_review route's transient state and emit a side-effect ledger
+(Stage 5 of the ui_review route). Destructive steps (row drops, worktree
+removal) run ONLY with --confirm; the ledger is emitted in every case.
+Required:
+  --repo-root <p>          Absolute path to the primary checkout (git cwd for worktree removal).
+  --provision-result <p>   Path to the Stage-1 provision JSON (boot.pid, migrations, worktreePath).
+Optional:
+  --drive-result <p>       Path to the Stage-2 drive JSON (the rows-created signal).
+  --row-manifest <p>       Path to a JSON array of rows to drop (only used with --confirm).
+  --confirm                Authorize the destructive steps (row drop + worktree removal).
+  --no-stop-app            Do NOT stop the app process (clean shutdown otherwise runs regardless of --confirm).
+  -h, --help               Show this help.
+Output (stdout, JSON):
+  { "ok": bool, "confirmed": bool, "errors": [...], "logs": [...],
+    "ledger": { "migrations": {...}, "rows": {...}, "worktree": {...}, "process": {...} } }
+
+${JQ_OUTPUT_USAGE}`.trim();
+
+const parseError = buildParseError(USAGE);
+
+export function parseUiReviewTeardownCliArgs(argv) {
+  const options = {
+    help: false, repoRoot: undefined, provisionResult: undefined, driveResult: undefined,
+    rowManifest: undefined, confirm: false, stopApp: true,
+  };
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      "repo-root": { type: "string" },
+      "provision-result": { type: "string" },
+      "drive-result": { type: "string" },
+      "row-manifest": { type: "string" },
+      confirm: { type: "boolean" },
+      "no-stop-app": { type: "boolean" },
+      ...JQ_OUTPUT_PARSE_OPTIONS,
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") throw parseError(`Unknown argument: ${token.value}`);
+    if (token.kind !== "option") continue;
+    if (token.name === "help") { options.help = true; return options; }
+    if (token.name === "repo-root") { options.repoRoot = requireTokenValue(token, parseError, { flagPattern: /^-/u }); continue; }
+    if (token.name === "provision-result") { options.provisionResult = requireTokenValue(token, parseError, { flagPattern: /^-/u }); continue; }
+    if (token.name === "drive-result") { options.driveResult = requireTokenValue(token, parseError, { flagPattern: /^-/u }); continue; }
+    if (token.name === "row-manifest") { options.rowManifest = requireTokenValue(token, parseError, { flagPattern: /^-/u }); continue; }
+    if (token.name === "confirm") {
+      // Bare flag or `=true` confirms; explicit `=false`/`=0`/`=no` must NOT
+      // confirm (fail-safe — destructive steps stay gated unless truly asked).
+      options.confirm = token.value === undefined || !/^(false|0|no)$/iu.test(token.value.trim());
+      continue;
+    }
+    if (token.name === "no-stop-app") { options.stopApp = false; continue; }
+    if (matchJqOutputToken(token, options, (t) => requireTokenValue(t, parseError))) continue;
+    throw parseError(`Unknown argument: ${token.rawName}`);
+  }
+  if (options.help) return options;
+  if (!options.repoRoot) throw parseError("Missing required --repo-root");
+  if (!options.provisionResult) throw parseError("Missing required --provision-result");
+  return options;
+}
+
+/** Read + parse a prior-stage result JSON, bounded. Returns null for an absent
+ * path (an optional input); throws on an oversized/unreadable/invalid file. */
+function readResultJson(file, { optional = false } = {}) {
+  if (file === undefined) return null;
+  let size;
+  try {
+    size = statSync(file).size;
+  } catch (err) {
+    if (optional) return null;
+    throw parseError(`cannot read ${file}: ${(err.message ?? err).toString()}`);
+  }
+  if (size > MAX_RESULT_BYTES) throw parseError(`${file} is too large (${size} bytes > ${MAX_RESULT_BYTES} cap)`);
+  return JSON.parse(readFileSync(file, "utf8"));
+}
+
+const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** True while `pid` is still alive. `process.kill(pid,0)` throws ESRCH when gone;
+ * EPERM means it exists but we can't signal it (still "alive" for our purposes). */
+function isAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err.code === "EPERM";
+  }
+}
+
+/** Signal a detached app: target the process GROUP (-pid) first — Stage 1 boots
+ * the app detached (its own group leader) via a shell, so the real server is a
+ * child in that group; signalling the group reaches it. Fall back to the bare
+ * pid when the group signal is not deliverable. */
+function signalProcess(pid, sig) {
+  try {
+    process.kill(-pid, sig);
+    return;
+  } catch {
+    process.kill(pid, sig);
+  }
+}
+
+/** Stop a process: SIGTERM, wait a bounded budget for a clean exit, then a
+ * LOGGED SIGKILL fallback. A failed kill is reported (never swallowed). */
+async function killProcess({ pid, graceMs = 3000, pollMs = 100 }) {
+  try {
+    signalProcess(pid, "SIGTERM");
+  } catch (err) {
+    if (err.code === "ESRCH") return { stopped: true, forced: false, detail: "process already exited" };
+    return { stopped: false, forced: false, detail: `SIGTERM failed: ${err.message ?? err}` };
+  }
+  const deadline = Date.now() + graceMs;
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) return { stopped: true, forced: false, detail: "stopped via SIGTERM" };
+    await delay(pollMs);
+  }
+  if (!isAlive(pid)) return { stopped: true, forced: false, detail: "stopped via SIGTERM" };
+  // Force-kill fallback (logged upstream via the returned `forced` flag).
+  try {
+    signalProcess(pid, "SIGKILL");
+  } catch (err) {
+    if (err.code === "ESRCH") return { stopped: true, forced: false, detail: "process exited before SIGKILL" };
+    return { stopped: false, forced: true, detail: `SIGKILL failed after SIGTERM timeout: ${err.message ?? err}` };
+  }
+  await delay(pollMs);
+  if (!isAlive(pid)) return { stopped: true, forced: true, detail: `force-killed (SIGKILL) after ${graceMs}ms SIGTERM grace` };
+  return { stopped: false, forced: true, detail: "process still alive after SIGKILL" };
+}
+
+/** Remove the worktree via the shared, namespace-safe cleanup path. Maps its
+ * fail-soft result to the teardown seam contract. */
+function removeWorktree(repoRoot, { worktreePath }) {
+  const res = cleanupWorktree({ repoRoot, path: worktreePath });
+  return Promise.resolve({ removed: res.removed, ok: res.ok, detail: res.reason });
+}
+
+export async function runCli(argv = process.argv.slice(2), { stdout = process.stdout, stderr = process.stderr } = {}) {
+  const options = parseUiReviewTeardownCliArgs(argv);
+  if (options.help) { stdout.write(`${USAGE}\n`); return; }
+
+  const provisionResult = readResultJson(options.provisionResult);
+  const driveResult = readResultJson(options.driveResult, { optional: true });
+  const manifestJson = readResultJson(options.rowManifest, { optional: true });
+  const rowManifest = Array.isArray(manifestJson) ? manifestJson : Array.isArray(manifestJson?.rows) ? manifestJson.rows : null;
+
+  const result = await teardown(
+    {
+      provisionResult,
+      driveResult,
+      rowManifest,
+      confirm: options.confirm,
+      stopApp: options.stopApp,
+    },
+    {
+      killProcess,
+      // No real drop seam yet: Stage 2 does not tag rows, so an actual manifest
+      // never arrives today and the ledger reports "may remain (untagged)". A
+      // manifest handed in is dropped by whatever project mechanism supplies it;
+      // until one exists, a confirmed manifest is a hard fail-closed error rather
+      // than a silent no-op, so a caller can never think rows were dropped.
+      dropRows: () => Promise.resolve({ ok: false, dropped: 0, detail: "no row-drop mechanism wired: dev-DB rows are untagged (Stage 2 does not tag rows); cannot drop a manifest safely" }),
+      removeWorktree: (a) => removeWorktree(options.repoRoot, a),
+      log: (msg) => stderr.write(`[ui-review-teardown] ${msg}\n`),
+    },
+  );
+  process.exitCode = emitResult(result, { jq: options.jq, silent: options.silent, stdout, stderr, ok: result.ok });
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli().catch((error) => {
+    process.stderr.write(`${formatCliError(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/loop/ui-review-teardown.mjs
+++ b/scripts/loop/ui-review-teardown.mjs
@@ -124,6 +124,13 @@ function isAlive(pid) {
  * child in that group; signalling the group reaches it. Fall back to the bare
  * pid when the group signal is not deliverable. */
 function signalProcess(pid, sig) {
+  // Defense-in-depth: never signal unless `pid` is a positive integer. A pid of
+  // 0 (`process.kill(0)` targets our OWN process group) or -1 (`process.kill(-1)`
+  // targets EVERY process) would be catastrophic; the core already rejects these,
+  // this guard makes it impossible for a group-kill to ever fire on a bad pid.
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new Error(`refusing to signal non-positive-integer pid: ${pid}`);
+  }
   try {
     process.kill(-pid, sig);
     return;
@@ -134,7 +141,7 @@ function signalProcess(pid, sig) {
 
 /** Stop a process: SIGTERM, wait a bounded budget for a clean exit, then a
  * LOGGED SIGKILL fallback. A failed kill is reported (never swallowed). */
-async function killProcess({ pid, graceMs = 3000, pollMs = 100 }) {
+export async function killProcess({ pid, graceMs = 3000, pollMs = 100 }) {
   try {
     signalProcess(pid, "SIGTERM");
   } catch (err) {

--- a/skills/ui-review/SKILL.md
+++ b/skills/ui-review/SKILL.md
@@ -170,7 +170,9 @@ what remains; stopping the app still runs, because it is a clean shutdown of a
 process the loop itself started, not a mutation of persisted state. The app is
 stopped via the provision boot PID (SIGTERM, then a LOGGED SIGKILL fallback); a
 null PID is never a blind kill — the ledger reports the process may still be
-running. Worktree removal delegates to `scripts/loop/cleanup-worktree.mjs`,
+running. On win32 the app-stop fails closed (process-group kill is unsupported,
+so the kill is not attempted): the ledger reports may-be-running rather than a
+false stopped. Worktree removal delegates to `scripts/loop/cleanup-worktree.mjs`,
 which refuses any path outside the loop namespace and leaves the primary
 checkout untouched.
 

--- a/skills/ui-review/SKILL.md
+++ b/skills/ui-review/SKILL.md
@@ -153,9 +153,46 @@ artifact is unhosted (with the reason), so the review never blocks on hosting.
 Every bounded cap — findings truncated past the artifact cap, an oversized or
 unreadable evidence screenshot omitted — is logged, never silent.
 
+## Teardown + side-effect ledger
+
+The terminal cleanup stage tears down the loop's transient state — stops the
+app booted in provision, drops the dev-DB rows the drive created, removes the
+provisioned worktree — and ALWAYS emits a side-effect ledger so nothing is
+silently orphaned, via
+`scripts/loop/ui-review-teardown.mjs --repo-root <p> --provision-result <p> [--drive-result <p>] [--row-manifest <p>] [--confirm] [--no-stop-app]`
+(pure decisions in `packages/core/src/loop/ui-review-teardown.mjs`). It reads
+the prior-stage result JSON — the app PID + applied migrations + worktree path
+from provision, and the rows-created signal from the drive.
+
+The destructive steps (dev-DB row drops and worktree removal) run ONLY with an
+explicit `--confirm`. Without it, those steps are skipped and the ledger records
+what remains; stopping the app still runs, because it is a clean shutdown of a
+process the loop itself started, not a mutation of persisted state. The app is
+stopped via the provision boot PID (SIGTERM, then a LOGGED SIGKILL fallback); a
+null PID is never a blind kill — the ledger reports the process may still be
+running. Worktree removal delegates to `scripts/loop/cleanup-worktree.mjs`,
+which refuses any path outside the loop namespace and leaves the primary
+checkout untouched.
+
+The side-effect ledger is emitted in EVERY case (success, skip, partial
+failure) and enumerates: migrations applied (recorded as applied-not-reverted —
+reversing a dev-DB migration is a separate explicit action, never a default),
+rows created/dropped or left behind, the worktree path + whether it was removed,
+and the process status. A failed kill/drop/removal is reported in the ledger and
+the result's `errors` list, never swallowed.
+
+Row dropping is honest about a known limitation: the drive does not tag the
+dev-DB rows it creates with a session id or manifest, so this stage cannot know
+which rows to drop and MUST NOT guess. It drops rows only from an explicit
+manifest handed in; when the drive walked mutating flows without one, the ledger
+reports rows "may remain (untagged)". Making the drop real requires row/session
+tagging upstream in the drive.
+
 ## Non-goals
 
-No teardown logic lives here yet. The stage does not auto-submit a review
+The teardown stage never rolls back the branch's dev-DB migrations by default
+(the ledger records they were applied, not reverted) and never tears down a
+production DB. The stage does not auto-submit a review
 without explicit authorization, publish to a production/non-dev posting target,
 ship the GitHub-native hosted-artifact fallback, auto-fix the located defects,
 pixel-diff for visual regression, run a cross-browser matrix, or touch a

--- a/skills/ui-review/SKILL.md
+++ b/skills/ui-review/SKILL.md
@@ -186,7 +186,10 @@ dev-DB rows it creates with a session id or manifest, so this stage cannot know
 which rows to drop and MUST NOT guess. It drops rows only from an explicit
 manifest handed in; when the drive walked mutating flows without one, the ledger
 reports rows "may remain (untagged)". Making the drop real requires row/session
-tagging upstream in the drive.
+tagging upstream in the drive. The CLI's row-drop seam is not yet wired: a
+confirmed manifest fails CLOSED (the ledger records a drop failure, never a drop)
+rather than silently no-op'ing, so a caller can never believe rows were dropped;
+wiring a real drop is a tracked follow-up.
 
 ## Non-goals
 

--- a/test/loop/ui-review-teardown.test.mjs
+++ b/test/loop/ui-review-teardown.test.mjs
@@ -307,21 +307,24 @@ test("killProcess escalates to SIGKILL (forced:true) for a child that ignores SI
 // Thread 1: win32 has no process-group signalling and Stage 1 boots the app
 // detached via a shell, so a bare shell-PID kill would leave the real server
 // running while a bare-pid poll falsely reports stopped. killProcess must FAIL
-// CLOSED on win32 — report not-stopped, never a false success — and the core
-// must map that to a not-stopped ledger status (never PROCESS_STATUS.STOPPED).
-test("killProcess fails closed on win32 (process-group kill unsupported): stopped:false, not a false success", async () => {
+// CLOSED on win32 — the kill is NOT ATTEMPTED, so it reports may-be-running
+// (never a false STOPPED) via mayBeRunning:true, which the core maps to
+// MAY_BE_RUNNING (non-fatal: a "couldn't stop", not a failed attempt).
+test("killProcess fails closed on win32 (process-group kill unsupported): not attempted, may-be-running", async () => {
   const res = await killProcess({ pid: 4242, platform: "win32" });
   assert.equal(res.stopped, false, "win32 must not claim the app stopped");
   assert.equal(res.forced, false);
+  assert.equal(res.mayBeRunning, true, "win32 kill is not attempted => may-be-running, not a failed attempt");
   assert.match(res.detail, /win32.*(may still be running|unsupported)/i);
 });
 
-test("win32 killProcess flows to a not-stopped ledger (KILL_FAILED, ok:false), never a false STOPPED", async () => {
+test("win32 killProcess flows to a MAY_BE_RUNNING ledger (non-fatal), never a false STOPPED", async () => {
   const { seams } = makeSeams({ killProcess: (a) => killProcess({ ...a, platform: "win32" }) });
   const res = await teardown({ provisionResult: PROVISION, confirm: true }, seams);
   assert.notEqual(res.ledger.process.status, PROCESS_STATUS.STOPPED, "win32 must never report a false STOPPED");
-  assert.equal(res.ledger.process.status, PROCESS_STATUS.KILL_FAILED);
-  assert.equal(res.ok, false);
+  assert.equal(res.ledger.process.status, PROCESS_STATUS.MAY_BE_RUNNING);
+  assert.equal(res.ok, true, "not-attempted (couldn't stop) is non-fatal, matching the null-PID may-be-running treatment");
+  assert.ok(!res.errors.some((e) => /app stop FAILED/.test(e)), "win32 not-attempted must not surface as a kill failure");
   assert.match(res.ledger.process.detail, /win32/i);
 });
 

--- a/test/loop/ui-review-teardown.test.mjs
+++ b/test/loop/ui-review-teardown.test.mjs
@@ -304,7 +304,45 @@ test("killProcess escalates to SIGKILL (forced:true) for a child that ignores SI
   assert.equal(res.forced, true, "SIGTERM-ignoring child forces the SIGKILL escalation");
 });
 
-// Thread 1: a present-but-malformed --row-manifest must FAIL CLOSED (clear parse
+// Thread 1: win32 has no process-group signalling and Stage 1 boots the app
+// detached via a shell, so a bare shell-PID kill would leave the real server
+// running while a bare-pid poll falsely reports stopped. killProcess must FAIL
+// CLOSED on win32 — report not-stopped, never a false success — and the core
+// must map that to a not-stopped ledger status (never PROCESS_STATUS.STOPPED).
+test("killProcess fails closed on win32 (process-group kill unsupported): stopped:false, not a false success", async () => {
+  const res = await killProcess({ pid: 4242, platform: "win32" });
+  assert.equal(res.stopped, false, "win32 must not claim the app stopped");
+  assert.equal(res.forced, false);
+  assert.match(res.detail, /win32.*(may still be running|unsupported)/i);
+});
+
+test("win32 killProcess flows to a not-stopped ledger (KILL_FAILED, ok:false), never a false STOPPED", async () => {
+  const { seams } = makeSeams({ killProcess: (a) => killProcess({ ...a, platform: "win32" }) });
+  const res = await teardown({ provisionResult: PROVISION, confirm: true }, seams);
+  assert.notEqual(res.ledger.process.status, PROCESS_STATUS.STOPPED, "win32 must never report a false STOPPED");
+  assert.equal(res.ledger.process.status, PROCESS_STATUS.KILL_FAILED);
+  assert.equal(res.ok, false);
+  assert.match(res.ledger.process.detail, /win32/i);
+});
+
+// Thread 2: --drive-result is optional only when OMITTED. A SUPPLIED-but-
+// unreadable path must FAIL CLOSED (clear error), never be silently nulled into
+// an incomplete ledger that misreports rows off missing input.
+test("runCli: supplied-but-unreadable --drive-result fails closed (not silent null + incomplete ledger)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "teardown-drive-"));
+  const provisionPath = join(dir, "provision.json");
+  writeFileSync(provisionPath, JSON.stringify(PROVISION));
+  const missingDrivePath = join(dir, "does-not-exist.json"); // supplied, unreadable
+
+  const argv = ["--repo-root", "/r", "--provision-result", provisionPath, "--drive-result", missingDrivePath];
+  const sink = { write: () => true };
+  await assert.rejects(
+    runCli(argv, { stdout: sink, stderr: sink }),
+    /cannot read .*does-not-exist/i,
+  );
+});
+
+// Thread 1 (prior): a present-but-malformed --row-manifest must FAIL CLOSED (clear parse
 // error), never be silently nulled into a misleading "may remain (untagged)"
 // ledger even though a manifest file WAS supplied. Absent --row-manifest is the
 // honest untagged path and stays fine (covered by the core tests above).

--- a/test/loop/ui-review-teardown.test.mjs
+++ b/test/loop/ui-review-teardown.test.mjs
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import test from "node:test";
 
 import { teardown, ROW_STATUS, WORKTREE_STATUS, PROCESS_STATUS } from "@dev-loops/core/loop/ui-review-teardown";
-import { parseUiReviewTeardownCliArgs } from "../../scripts/loop/ui-review-teardown.mjs";
+import { parseUiReviewTeardownCliArgs, killProcess } from "../../scripts/loop/ui-review-teardown.mjs";
 
 // A Stage-1 provision result: a booted app (pid), applied migrations, a worktree.
 const PROVISION = {
@@ -169,6 +170,132 @@ test("--no-stop-app path leaves the process untouched but still enumerates it", 
   assert.equal(calls.kill, 0);
   assert.equal(res.ledger.process.status, PROCESS_STATUS.SKIPPED);
   assert.equal(res.ledger.process.pid, 4242);
+});
+
+// Fix 1: a PID that is not a positive integer must NEVER reach the kill seam.
+// The CLI's group-kill would signal `process.kill(0)` (this loop's OWN group)
+// for pid 0 or `process.kill(-1)` (every process) for pid -1.
+for (const badPid of [0, -1, NaN, 3.5, "4242", {}]) {
+  test(`non-positive/non-integer PID (${String(badPid)}) never reaches the kill seam; ledger reports may-be-running`, async () => {
+    const { seams, calls } = makeSeams();
+    const provisionBadPid = { ...PROVISION, boot: { pid: badPid, ready: true } };
+    const res = await teardown({ provisionResult: provisionBadPid, confirm: true }, seams);
+    assert.equal(calls.kill, 0, "unusable PID => never call kill");
+    assert.equal(res.ledger.process.status, PROCESS_STATUS.MAY_BE_RUNNING);
+    assert.equal(res.ledger.process.pid, null, "unusable PID is nulled in the ledger");
+    assert.match(res.ledger.process.detail, /may still be running/i);
+  });
+}
+
+// Fix 2: the always-emit-ledger invariant must survive a seam that THROWS.
+test("a throwing kill seam still yields a fully-emitted ledger (KILL_FAILED, ok:false)", async () => {
+  const { seams } = makeSeams({
+    killProcess: async () => { throw new Error("kill seam boom"); },
+  });
+  const res = await teardown({ provisionResult: PROVISION, confirm: true }, seams);
+  assert.equal(res.ok, false);
+  assert.equal(res.ledger.process.status, PROCESS_STATUS.KILL_FAILED);
+  // Ledger is STILL emitted in full despite the throw.
+  assert.ok(res.ledger.migrations && res.ledger.rows && res.ledger.worktree && res.ledger.process);
+  assert.ok(res.errors.some((e) => /kill seam threw/.test(e)));
+});
+
+test("a throwing removeWorktree seam still yields a fully-emitted ledger (REMOVE_FAILED, ok:false)", async () => {
+  const { seams } = makeSeams({
+    removeWorktree: async () => { throw new Error("rm seam boom"); },
+  });
+  const res = await teardown({ provisionResult: PROVISION, confirm: true }, seams);
+  assert.equal(res.ok, false);
+  assert.equal(res.ledger.worktree.status, WORKTREE_STATUS.REMOVE_FAILED);
+  assert.ok(res.ledger.migrations && res.ledger.rows && res.ledger.worktree && res.ledger.process);
+  assert.ok(res.errors.some((e) => /removeWorktree seam threw/.test(e)));
+});
+
+test("a throwing dropRows seam still yields a fully-emitted ledger (DROP_FAILED, ok:false)", async () => {
+  const { seams } = makeSeams({
+    dropRows: async () => { throw new Error("drop seam boom"); },
+  });
+  const res = await teardown(
+    { provisionResult: PROVISION, driveResult: DRIVE_WITH_STEPS, rowManifest: [{ id: 1 }], confirm: true },
+    seams,
+  );
+  assert.equal(res.ok, false);
+  assert.equal(res.ledger.rows.status, ROW_STATUS.DROP_FAILED);
+  assert.ok(res.ledger.migrations && res.ledger.rows && res.ledger.worktree && res.ledger.process);
+  assert.ok(res.errors.some((e) => /drop seam threw/.test(e)));
+});
+
+// Fix 2: a non-string worktreePath must not throw (path.resolve would); it is
+// recorded as a malformed-path failure and the removeWorktree seam is not called.
+test("malformed (non-string) worktreePath fails closed, never reaches removeWorktree, ledger still emitted", async () => {
+  const { seams, calls } = makeSeams();
+  const provisionBadPath = { ...PROVISION, worktreePath: { not: "a string" } };
+  const res = await teardown({ provisionResult: provisionBadPath, confirm: true }, seams);
+  assert.equal(calls.removeWorktree, 0, "malformed path must not reach the removal seam");
+  assert.equal(res.ledger.worktree.status, WORKTREE_STATUS.REMOVE_FAILED);
+  assert.match(res.ledger.worktree.detail, /malformed worktree path/i);
+  assert.equal(res.ok, false);
+});
+
+// Fix 3(a): unconfirmed drive-with-steps and no manifest => rows may remain.
+test("confirm:false + drive-with-steps + no manifest => MAY_REMAIN_UNTAGGED, drop seam not called", async () => {
+  const { seams, calls } = makeSeams();
+  const res = await teardown(
+    { provisionResult: PROVISION, driveResult: DRIVE_WITH_STEPS, rowManifest: null, confirm: false },
+    seams,
+  );
+  assert.equal(res.ledger.rows.status, ROW_STATUS.MAY_REMAIN_UNTAGGED);
+  assert.equal(calls.drop, 0);
+  assert.equal(res.ok, true);
+});
+
+// Fix 3(b): unconfirmed stopped-drive (no rows) => NONE.
+test("confirm:false + stopped drive (no rows) => ROW_STATUS.NONE", async () => {
+  const { seams, calls } = makeSeams();
+  const res = await teardown(
+    { provisionResult: PROVISION, driveResult: DRIVE_STOPPED, confirm: false },
+    seams,
+  );
+  assert.equal(res.ledger.rows.status, ROW_STATUS.NONE);
+  assert.equal(calls.drop, 0);
+});
+
+// Fix 3(c): provision without worktreePath => skipped with the distinct detail.
+test("provision without worktreePath => worktree skipped with 'no worktree path' detail, removeWorktree not called", async () => {
+  const { seams, calls } = makeSeams();
+  const provisionNoWorktree = { ...PROVISION, worktreePath: undefined };
+  const res = await teardown({ provisionResult: provisionNoWorktree, confirm: true }, seams);
+  assert.equal(res.ledger.worktree.status, WORKTREE_STATUS.SKIPPED_UNCONFIRMED);
+  assert.match(res.ledger.worktree.detail, /no worktree path/i);
+  assert.equal(res.ledger.worktree.path, null);
+  assert.equal(calls.removeWorktree, 0);
+});
+
+// Folded defer: real killProcess against a spawned child process. Each child
+// prints "ready" AFTER its handlers are installed; the test waits for that line
+// to avoid a startup race where a signal arrives before the child is set up.
+function spawnReadyChild(script) {
+  const child = spawn(process.execPath, ["-e", script], { detached: true });
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.stdout.on("data", (buf) => {
+      if (buf.toString().includes("ready")) resolve(child);
+    });
+  });
+}
+
+test("killProcess stops a real short-lived child (stopped:true via SIGTERM)", async () => {
+  const child = await spawnReadyChild("console.log('ready'); setInterval(() => {}, 60000)");
+  const res = await killProcess({ pid: child.pid, graceMs: 3000, pollMs: 50 });
+  assert.equal(res.stopped, true);
+});
+
+test("killProcess escalates to SIGKILL (forced:true) for a child that ignores SIGTERM", async () => {
+  // Traps SIGTERM (no-op) and keeps running; only the SIGKILL fallback stops it.
+  const child = await spawnReadyChild("process.on('SIGTERM', () => {}); console.log('ready'); setInterval(() => {}, 60000)");
+  const res = await killProcess({ pid: child.pid, graceMs: 500, pollMs: 50 });
+  assert.equal(res.stopped, true);
+  assert.equal(res.forced, true, "SIGTERM-ignoring child forces the SIGKILL escalation");
 });
 
 test("parseUiReviewTeardownCliArgs: requires --repo-root and --provision-result", () => {

--- a/test/loop/ui-review-teardown.test.mjs
+++ b/test/loop/ui-review-teardown.test.mjs
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { teardown, ROW_STATUS, WORKTREE_STATUS, PROCESS_STATUS } from "@dev-loops/core/loop/ui-review-teardown";
+import { parseUiReviewTeardownCliArgs } from "../../scripts/loop/ui-review-teardown.mjs";
+
+// A Stage-1 provision result: a booted app (pid), applied migrations, a worktree.
+const PROVISION = {
+  ok: true,
+  worktreePath: "/repo/tmp/worktrees/dev-loops/pr-7",
+  migrations: { pending: 2, applied: 2, destructive: [], detail: "2 applied" },
+  boot: { pid: 4242, ready: true },
+};
+
+// A Stage-2 drive result that DID drive mutating steps (rows may have been made).
+const DRIVE_WITH_STEPS = { ok: true, stopped: false, steps: [{ flow: "users", step: "create", ok: true }] };
+// A drive that stopped before driving anything (auth failed) — created nothing.
+const DRIVE_STOPPED = { ok: false, stopped: true, steps: [] };
+
+// Recording seams: every destructive seam logs whether it was called, so a test
+// can assert the confirmation gate actually blocked (not merely no-op'd) a step.
+function makeSeams(overrides = {}) {
+  const calls = { kill: 0, drop: 0, removeWorktree: 0 };
+  const seams = {
+    killProcess: async () => {
+      calls.kill += 1;
+      return { stopped: true, forced: false, detail: "stopped via SIGTERM" };
+    },
+    dropRows: async ({ rows }) => {
+      calls.drop += 1;
+      return { ok: true, dropped: rows.length, detail: "dropped" };
+    },
+    removeWorktree: async () => {
+      calls.removeWorktree += 1;
+      return { removed: "/repo/tmp/worktrees/dev-loops/pr-7", ok: true, detail: "removed" };
+    },
+    log: () => {},
+    ...overrides,
+  };
+  return { seams, calls };
+}
+
+test("teardown always emits a ledger enumerating every known side effect (confirmed success)", async () => {
+  const { seams, calls } = makeSeams();
+  const res = await teardown(
+    { provisionResult: PROVISION, driveResult: DRIVE_WITH_STEPS, rowManifest: [{ table: "users", id: 1 }], confirm: true },
+    seams,
+  );
+
+  assert.equal(res.ok, true);
+  assert.equal(res.confirmed, true);
+  // Ledger enumerates ALL four side-effect categories.
+  assert.ok(res.ledger.migrations, "migrations enumerated");
+  assert.ok(res.ledger.rows, "rows enumerated");
+  assert.ok(res.ledger.worktree, "worktree enumerated");
+  assert.ok(res.ledger.process, "process enumerated");
+  // Migrations recorded as applied-not-reverted (non-goal: no rollback).
+  assert.equal(res.ledger.migrations.applied, 2);
+  assert.equal(res.ledger.migrations.reverted, false);
+  // Destructive steps ran (confirmed): app stopped, rows dropped, worktree removed.
+  assert.equal(res.ledger.process.status, PROCESS_STATUS.STOPPED);
+  assert.equal(res.ledger.rows.status, ROW_STATUS.DROPPED);
+  assert.equal(res.ledger.rows.dropped, 1);
+  assert.equal(res.ledger.worktree.status, WORKTREE_STATUS.REMOVED);
+  assert.equal(res.ledger.worktree.path, PROVISION.worktreePath);
+  assert.deepEqual(calls, { kill: 1, drop: 1, removeWorktree: 1 });
+});
+
+test("confirmation gate blocks destructive steps (no --confirm): app stops, row-drop + worktree-removal do NOT run, ledger still emitted", async () => {
+  const { seams, calls } = makeSeams();
+  const res = await teardown(
+    { provisionResult: PROVISION, driveResult: DRIVE_WITH_STEPS, rowManifest: [{ table: "users", id: 1 }], confirm: false },
+    seams,
+  );
+
+  // The ledger is STILL emitted in full.
+  assert.ok(res.ledger.migrations && res.ledger.rows && res.ledger.worktree && res.ledger.process);
+  assert.equal(res.confirmed, false);
+  // App stop is a clean shutdown — NOT gated on confirmation — so it ran.
+  assert.equal(calls.kill, 1);
+  assert.equal(res.ledger.process.status, PROCESS_STATUS.STOPPED);
+  // Destructive steps were BLOCKED — the seams were never called.
+  assert.equal(calls.drop, 0, "row drop must not run without confirmation");
+  assert.equal(calls.removeWorktree, 0, "worktree removal must not run without confirmation");
+  assert.equal(res.ledger.rows.status, ROW_STATUS.SKIPPED_UNCONFIRMED);
+  assert.equal(res.ledger.worktree.status, WORKTREE_STATUS.SKIPPED_UNCONFIRMED);
+  assert.equal(res.ledger.worktree.removed, false);
+  // No confirmation is not a failure.
+  assert.equal(res.ok, true);
+  assert.deepEqual(res.errors, []);
+});
+
+test("untagged rows: confirmed drive with no manifest reports 'rows may remain (untagged)', never guesses", async () => {
+  const { seams, calls } = makeSeams();
+  const res = await teardown(
+    { provisionResult: PROVISION, driveResult: DRIVE_WITH_STEPS, rowManifest: null, confirm: true },
+    seams,
+  );
+  assert.equal(res.ledger.rows.status, ROW_STATUS.MAY_REMAIN_UNTAGGED);
+  assert.match(res.ledger.rows.detail, /may remain \(untagged\)/i);
+  assert.equal(calls.drop, 0, "must not guess-drop untagged rows");
+  // Not a teardown failure — the honest expected state.
+  assert.equal(res.ok, true);
+});
+
+test("no rows created: a drive that stopped before driving reports 'none'", async () => {
+  const { seams } = makeSeams();
+  const res = await teardown(
+    { provisionResult: PROVISION, driveResult: DRIVE_STOPPED, confirm: true },
+    seams,
+  );
+  assert.equal(res.ledger.rows.status, ROW_STATUS.NONE);
+});
+
+test("null PID: ledger reports the process may still be running (no blind kill)", async () => {
+  const { seams, calls } = makeSeams();
+  const provisionNoPid = { ...PROVISION, boot: { pid: null, ready: true } };
+  const res = await teardown({ provisionResult: provisionNoPid, confirm: true }, seams);
+  assert.equal(calls.kill, 0, "no PID => never call kill");
+  assert.equal(res.ledger.process.status, PROCESS_STATUS.MAY_BE_RUNNING);
+  assert.equal(res.ledger.process.pid, null);
+});
+
+test("failed kill is reported, not swallowed", async () => {
+  const { seams } = makeSeams({
+    killProcess: async () => ({ stopped: false, forced: true, detail: "process still alive after SIGKILL" }),
+  });
+  const res = await teardown({ provisionResult: PROVISION, confirm: true }, seams);
+  assert.equal(res.ok, false, "a failed kill fails the teardown result");
+  assert.equal(res.ledger.process.status, PROCESS_STATUS.KILL_FAILED);
+  assert.ok(res.errors.some((e) => /app stop FAILED/.test(e)), "kill failure surfaced in errors");
+});
+
+test("force-kill (SIGKILL fallback) is recorded in the ledger", async () => {
+  const { seams } = makeSeams({
+    killProcess: async () => ({ stopped: true, forced: true, detail: "force-killed after grace" }),
+  });
+  const res = await teardown({ provisionResult: PROVISION, confirm: true }, seams);
+  assert.equal(res.ledger.process.status, PROCESS_STATUS.STOPPED);
+  assert.equal(res.ledger.process.forced, true);
+});
+
+test("failed row drop (confirmed manifest) is reported, not swallowed", async () => {
+  const { seams } = makeSeams({
+    dropRows: async () => ({ ok: false, dropped: 0, detail: "db connection refused" }),
+  });
+  const res = await teardown(
+    { provisionResult: PROVISION, driveResult: DRIVE_WITH_STEPS, rowManifest: [{ id: 1 }], confirm: true },
+    seams,
+  );
+  assert.equal(res.ok, false);
+  assert.equal(res.ledger.rows.status, ROW_STATUS.DROP_FAILED);
+  assert.ok(res.errors.some((e) => /row drop FAILED/.test(e)));
+});
+
+test("failed worktree removal (confirmed) is reported, not swallowed", async () => {
+  const { seams } = makeSeams({
+    removeWorktree: async () => ({ removed: null, ok: false, detail: "refused: not under namespace" }),
+  });
+  const res = await teardown({ provisionResult: PROVISION, confirm: true }, seams);
+  assert.equal(res.ok, false);
+  assert.equal(res.ledger.worktree.status, WORKTREE_STATUS.REMOVE_FAILED);
+  assert.ok(res.errors.some((e) => /worktree removal FAILED/.test(e)));
+});
+
+test("--no-stop-app path leaves the process untouched but still enumerates it", async () => {
+  const { seams, calls } = makeSeams();
+  const res = await teardown({ provisionResult: PROVISION, stopApp: false, confirm: true }, seams);
+  assert.equal(calls.kill, 0);
+  assert.equal(res.ledger.process.status, PROCESS_STATUS.SKIPPED);
+  assert.equal(res.ledger.process.pid, 4242);
+});
+
+test("parseUiReviewTeardownCliArgs: requires --repo-root and --provision-result", () => {
+  assert.throws(() => parseUiReviewTeardownCliArgs(["--provision-result", "/p.json"]), /repo-root/);
+  assert.throws(() => parseUiReviewTeardownCliArgs(["--repo-root", "/r"]), /provision-result/);
+});
+
+test("parseUiReviewTeardownCliArgs: --confirm is fail-safe (bare confirms, =false does not)", () => {
+  const base = ["--repo-root", "/r", "--provision-result", "/p.json"];
+  assert.equal(parseUiReviewTeardownCliArgs(base).confirm, false, "default is unconfirmed");
+  assert.equal(parseUiReviewTeardownCliArgs([...base, "--confirm"]).confirm, true);
+  assert.equal(parseUiReviewTeardownCliArgs([...base, "--confirm=false"]).confirm, false);
+  assert.equal(parseUiReviewTeardownCliArgs([...base, "--no-stop-app"]).stopApp, false);
+});

--- a/test/loop/ui-review-teardown.test.mjs
+++ b/test/loop/ui-review-teardown.test.mjs
@@ -1,9 +1,12 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
 import { teardown, ROW_STATUS, WORKTREE_STATUS, PROCESS_STATUS } from "@dev-loops/core/loop/ui-review-teardown";
-import { parseUiReviewTeardownCliArgs, killProcess } from "../../scripts/loop/ui-review-teardown.mjs";
+import { parseUiReviewTeardownCliArgs, killProcess, runCli } from "../../scripts/loop/ui-review-teardown.mjs";
 
 // A Stage-1 provision result: a booted app (pid), applied migrations, a worktree.
 const PROVISION = {
@@ -260,12 +263,15 @@ test("confirm:false + stopped drive (no rows) => ROW_STATUS.NONE", async () => {
   assert.equal(calls.drop, 0);
 });
 
-// Fix 3(c): provision without worktreePath => skipped with the distinct detail.
-test("provision without worktreePath => worktree skipped with 'no worktree path' detail, removeWorktree not called", async () => {
+// Fix 3(c): provision without worktreePath => distinct MISSING_PATH status (NOT
+// conflated with SKIPPED_UNCONFIRMED — the ledger must say WHY removal did not
+// run: a missing path, not a withheld confirmation). Holds even with confirm:true.
+test("provision without worktreePath => MISSING_PATH (distinct from unconfirmed-skip), removeWorktree not called", async () => {
   const { seams, calls } = makeSeams();
   const provisionNoWorktree = { ...PROVISION, worktreePath: undefined };
   const res = await teardown({ provisionResult: provisionNoWorktree, confirm: true }, seams);
-  assert.equal(res.ledger.worktree.status, WORKTREE_STATUS.SKIPPED_UNCONFIRMED);
+  assert.equal(res.ledger.worktree.status, WORKTREE_STATUS.MISSING_PATH);
+  assert.notEqual(res.ledger.worktree.status, WORKTREE_STATUS.SKIPPED_UNCONFIRMED);
   assert.match(res.ledger.worktree.detail, /no worktree path/i);
   assert.equal(res.ledger.worktree.path, null);
   assert.equal(calls.removeWorktree, 0);
@@ -296,6 +302,25 @@ test("killProcess escalates to SIGKILL (forced:true) for a child that ignores SI
   const res = await killProcess({ pid: child.pid, graceMs: 500, pollMs: 50 });
   assert.equal(res.stopped, true);
   assert.equal(res.forced, true, "SIGTERM-ignoring child forces the SIGKILL escalation");
+});
+
+// Thread 1: a present-but-malformed --row-manifest must FAIL CLOSED (clear parse
+// error), never be silently nulled into a misleading "may remain (untagged)"
+// ledger even though a manifest file WAS supplied. Absent --row-manifest is the
+// honest untagged path and stays fine (covered by the core tests above).
+test("runCli: present-but-malformed --row-manifest fails closed with a clear parse error (not silent null)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "teardown-manifest-"));
+  const provisionPath = join(dir, "provision.json");
+  writeFileSync(provisionPath, JSON.stringify(PROVISION));
+  const manifestPath = join(dir, "manifest.json");
+  writeFileSync(manifestPath, JSON.stringify({ notRows: [{ id: 1 }] })); // wrong shape
+
+  const argv = ["--repo-root", "/r", "--provision-result", provisionPath, "--row-manifest", manifestPath];
+  const sink = { write: () => true };
+  await assert.rejects(
+    runCli(argv, { stdout: sink, stderr: sink }),
+    /--row-manifest .* malformed/i,
+  );
 });
 
 test("parseUiReviewTeardownCliArgs: requires --repo-root and --provision-result", () => {


### PR DESCRIPTION
## Summary

Stage 5 of epic #1114 (`/loop-review-ui`). **Teardown + side-effect ledger**: stops the Stage-1 app (SIGTERM → logged SIGKILL fallback — a clean shutdown of a process the loop started, NOT confirmation-gated); then, on confirmation, removes the provisioned worktree (via `cleanup-worktree.mjs`, primary checkout untouched) and drops drive-created dev-DB rows — and ALWAYS emits a complete side-effect ledger so nothing the loop touched is silently orphaned, in every case (success, skip, partial failure).

## Scope and context

In scope: a pure core teardown module (builds the ledger from prior-stage results, gates destructive steps on confirmation) with injected process-kill / row-drop / worktree-remove seams, and a thin CLI wiring real process-group kill + `cleanup-worktree.mjs`. Per issue #1121's Risk note, dev-DB row-drop is honest-but-inert: Stage 2 doesn't tag the rows it creates, so absent an explicit `--row-manifest` the ledger reports `rows: may-remain-untagged` and never guesses; making the drop real is follow-up #1287 (Stage-2 row tagging). Out of scope (Non-goals): migration rollback (dev DB; the ledger records migrations, doesn't revert), production teardown.

## Acceptance criteria

Satisfies issue #1121's acceptance criteria — checked off on the issue at merge. (Row-drop uses the AC's untagged-rows fallback; the full tagged drop is tracked in #1287.)

## Definition of done

After a run: the app is stopped, drive-created rows + worktree are removed on confirmation (rows only when a manifest is present, else reported as may-remain), and a complete side-effect ledger is emitted in every case.

## Non-goals

No migration rollback by default. No production teardown. No guessed row-drop (untagged → reported, not dropped).

## Validation

- `node --test test/loop/ui-review-teardown.test.mjs` (12 pass — ledger enumerated in every case; confirmation gate blocks destructive steps; failed kill/drop/removal surfaced not swallowed; null PID → may-be-running; untagged rows → may-remain; SIGKILL fallback logged).
- `npm run test:scripts` (full leg, 2547 pass), `npm run test:core`, `npm run test:docs`, `npm run test:assets`.
- Full gate uses `npm run verify`.

Closes #1121

