### PR TITLE
docs(tooling): route gh issue edit call-sites through edit-issue.mjs wrapper (#1255)

### DIFF
--- a/.claude/commands/loop-review-ui.md
+++ b/.claude/commands/loop-review-ui.md
@@ -11,7 +11,7 @@ Run the `dev-loop` skill with the public intent `review PR $ARGUMENTS in a UI lo
 **Arguments:**
 - `<pr>` — the pull request to review, as a number or URL. Required; with no argument the loop cannot resolve a target and stops.
 
-**What it does:** reviews the PR by proving the change in the running app from an isolated worktree, not by reading the diff alone. It resolves state, provisions a worktree for the PR head and boots the app, authenticates and drives the changed UI flows, diagnoses captured failures against the diff, reports, then tears down — the running-app sibling of the standard `review` angle. It needs a per-project run/auth recipe in `.devloops`; see the [UI-Review Run/Auth Recipe Contract](../docs/ui-review-recipe-contract.md).
+**What it does:** reviews the PR by proving the change in the running app from an isolated worktree, not by reading the diff alone. It resolves state, provisions a worktree for the PR head and boots the app, authenticates and drives the changed UI flows, diagnoses captured failures against the diff, reports, then tears down — the running-app sibling of the standard `review` angle. It needs a per-project run/auth recipe in `.devloops`; see the [UI-Review Run/Auth Recipe Contract](../../docs/ui-review-recipe-contract.md).
 
 **Stop conditions (fails closed with a stated reason):** the target is the primary checkout; no run recipe is declared; a run-recipe `cwd` resolves outside the worktree; a destructive dev-DB migration is not acknowledged; the readiness probe times out; the dev-login recipe cannot authenticate; or the live head has advanced since diagnose.
 

--- a/.claude/commands/loop-review-ui.md
+++ b/.claude/commands/loop-review-ui.md
@@ -11,7 +11,7 @@ Run the `dev-loop` skill with the public intent `review PR $ARGUMENTS in a UI lo
 **Arguments:**
 - `<pr>` — the pull request to review, as a number or URL. Required; with no argument the loop cannot resolve a target and stops.
 
-**What it does:** reviews the PR by proving the change in the running app from an isolated worktree, not by reading the diff alone. It resolves state, provisions a worktree for the PR head and boots the app, authenticates and drives the changed UI flows, diagnoses captured failures against the diff, reports, then tears down — the running-app sibling of the standard `review` angle. It needs a per-project run/auth recipe in `.devloops`; see the [UI-Review Run/Auth Recipe Contract](../../docs/ui-review-recipe-contract.md).
+**What it does:** reviews the PR by proving the change in the running app from an isolated worktree, not by reading the diff alone. It resolves state, provisions a worktree for the PR head and boots the app, authenticates and drives the changed UI flows, diagnoses captured failures against the diff, reports, then tears down — the running-app sibling of the standard `review` angle. It needs a per-project run/auth recipe in `.devloops`; see the [UI-Review Run/Auth Recipe Contract](../docs/ui-review-recipe-contract.md).
 
 **Stop conditions (fails closed with a stated reason):** the target is the primary checkout; no run recipe is declared; a run-recipe `cwd` resolves outside the worktree; a destructive dev-DB migration is not acknowledged; the readiness probe times out; the dev-login recipe cannot authenticate; or the live head has advanced since diagnose.
 

--- a/.claude/skills/docs/epic-tree-refinement-procedure.md
+++ b/.claude/skills/docs/epic-tree-refinement-procedure.md
@@ -65,7 +65,7 @@ For the root issue:
 7. Confirm **non-goals** section — prevents scope creep into adjacent areas
 8. Write the updated body to a tmp file: `tmp/issues/<root>/refinement/root-body.md`
 9. Show the diff and obtain confirmation before mutating GitHub
-10. Apply: `gh issue edit <root> --repo <repo> --body-file tmp/issues/<root>/refinement/root-body.md`
+10. Apply: `node scripts/github/edit-issue.mjs --repo <repo> --issue <root> --body-file tmp/issues/<root>/refinement/root-body.md`
 
 <!-- rule: EPIC-REFINEMENT-SERIAL-PHASE-GATE -->
 **Gate:** Phase B MUST NOT start until Phase A is complete and the root body is updated on GitHub. The same serial-gate discipline applies at every phase boundary below: a level/phase MUST fully complete (siblings may run in parallel within it) before the next one starts.
@@ -92,7 +92,7 @@ parent's updated body, not each other's output.
    - **Non-goals** — what this child intentionally excludes
 6. Write refined body to `tmp/issues/<child>/refinement/child-body.md`
 7. Show the diff and obtain confirmation before mutating (unless running unattended with explicit authorization)
-8. Apply: `gh issue edit <child> --repo <repo> --body-file tmp/issues/<child>/refinement/child-body.md`
+8. Apply: `node scripts/github/edit-issue.mjs --repo <repo> --issue <child> --body-file tmp/issues/<child>/refinement/child-body.md`
 
 **Parallelism rule:** All siblings at the same level can be refined concurrently. No child needs
 another child's output; each child only reads the parent's contract and its own current body.
@@ -121,7 +121,7 @@ updated bodies, not sibling parents).
 4. Update the parent's phase scope table and AC/DoD as needed to reflect what children now explicitly own
 5. Write refined body to `tmp/issues/<parent>/refinement/parent-reconciled-body.md`
 6. Show the diff and obtain confirmation before mutating
-7. Apply: `gh issue edit <parent> --repo <repo> --body-file tmp/issues/<parent>/refinement/parent-reconciled-body.md`
+7. Apply: `node scripts/github/edit-issue.mjs --repo <repo> --issue <parent> --body-file tmp/issues/<parent>/refinement/parent-reconciled-body.md`
 
 **Serial gate between levels** ([EPIC-REFINEMENT-SERIAL-PHASE-GATE](#phase-a--root-refinement-serial)): all parents at depth N must complete reconciliation before ascending to depth N-1.
 
@@ -140,7 +140,7 @@ After all immediate children of the root have been reconciled:
 4. Update the root body with the final reconciled phase scope table and AC/DoD
 5. Write to `tmp/issues/<root>/refinement/root-final-body.md`
 6. Show the diff and obtain confirmation before mutating
-7. Apply: `gh issue edit <root> --repo <repo> --body-file tmp/issues/<root>/refinement/root-final-body.md`
+7. Apply: `node scripts/github/edit-issue.mjs --repo <repo> --issue <root> --body-file tmp/issues/<root>/refinement/root-final-body.md`
 8. Verify the sub-issue tree still reflects the correct execution order:
    ```sh
    node <resolved-skill-scripts>/github/manage-sub-issues.mjs verify \
@@ -156,7 +156,7 @@ After all immediate children of the root have been reconciled:
 
 <!-- rule: EPIC-REFINEMENT-SCOPE-BOUNDARY -->
 This procedure MUST stay refinement-only: no implementation, no PRs, no Copilot assignment.
-Apply changes directly with `gh issue edit` — never create new issues or PRs. Hierarchy MUST
+Apply changes directly with `scripts/github/edit-issue.mjs` — never create new issues or PRs. Hierarchy MUST
 stay in the GitHub sub-issues API, not prose parent/child links or a duplicated child-list
 checklist in parent bodies.
 
@@ -168,7 +168,7 @@ AC/DoD matrix, and an explicit scope boundary in the format
 <!-- rule: EPIC-REFINEMENT-CONFIRM-BEFORE-MUTATE -->
 `EPIC-REFINEMENT-CONFIRM-BEFORE-MUTATE`: The procedure MUST write the refined body to
 `tmp/issues/<number>/refinement/` first and MUST show the diff and get confirmation before
-each `gh issue edit` mutation, unless running unattended with explicit authorization.
+each `edit-issue.mjs` mutation, unless running unattended with explicit authorization.
 
 ---
 

--- a/.claude/skills/docs/epic-tree-refinement-procedure.md
+++ b/.claude/skills/docs/epic-tree-refinement-procedure.md
@@ -168,7 +168,7 @@ AC/DoD matrix, and an explicit scope boundary in the format
 <!-- rule: EPIC-REFINEMENT-CONFIRM-BEFORE-MUTATE -->
 `EPIC-REFINEMENT-CONFIRM-BEFORE-MUTATE`: The procedure MUST write the refined body to
 `tmp/issues/<number>/refinement/` first and MUST show the diff and get confirmation before
-each `edit-issue.mjs` mutation, unless running unattended with explicit authorization.
+each `node scripts/github/edit-issue.mjs` mutation, unless running unattended with explicit authorization.
 
 ---
 

--- a/.claude/skills/docs/epic-tree-refinement-procedure.md
+++ b/.claude/skills/docs/epic-tree-refinement-procedure.md
@@ -156,7 +156,7 @@ After all immediate children of the root have been reconciled:
 
 <!-- rule: EPIC-REFINEMENT-SCOPE-BOUNDARY -->
 This procedure MUST stay refinement-only: no implementation, no PRs, no Copilot assignment.
-Apply changes directly with `scripts/github/edit-issue.mjs` — never create new issues or PRs. Hierarchy MUST
+Apply changes directly with `node scripts/github/edit-issue.mjs` — never create new issues or PRs. Hierarchy MUST
 stay in the GitHub sub-issues API, not prose parent/child links or a duplicated child-list
 checklist in parent bodies.
 

--- a/.claude/skills/docs/issue-intake-procedure.md
+++ b/.claude/skills/docs/issue-intake-procedure.md
@@ -225,8 +225,8 @@ When an existing sub-issue tree needs **scope alignment, AC/DoD contracts, and d
 
 Before updating the GitHub issue body, show the diff and get explicit confirmation. Then use:
 ```sh
-gh issue edit <number> --repo <resolved-repo> --body-file <updated-body-file>
-gh issue edit <number> --repo <resolved-repo> --add-assignee copilot-swe-agent
+node scripts/github/edit-issue.mjs --repo <resolved-repo> --issue <number> --body-file <updated-body-file>
+node scripts/github/edit-issue.mjs --repo <resolved-repo> --issue <number> --add-assignee copilot-swe-agent
 ```
 Verify assignment with:
 ```sh

--- a/.claude/skills/loop-grill/SKILL.md
+++ b/.claude/skills/loop-grill/SKILL.md
@@ -118,7 +118,7 @@ Write the raw Q&A transcript ONLY to the gitignored, ephemeral, session-scoped a
 **Tracker-first write-back:** update the GitHub issue body using:
 
 ```
-gh issue edit <n> --repo <owner/repo> --body-file <tmp-path>
+node scripts/github/edit-issue.mjs --repo <owner/repo> --issue <n> --body-file <tmp-path>
 ```
 
 The synthesized sections live in the issue body, not as a comment. Do not use `comment-issue.mjs` here — that creates a comment, not a body update.

--- a/skills/docs/epic-tree-refinement-procedure.md
+++ b/skills/docs/epic-tree-refinement-procedure.md
@@ -65,7 +65,7 @@ For the root issue:
 7. Confirm **non-goals** section — prevents scope creep into adjacent areas
 8. Write the updated body to a tmp file: `tmp/issues/<root>/refinement/root-body.md`
 9. Show the diff and obtain confirmation before mutating GitHub
-10. Apply: `gh issue edit <root> --repo <repo> --body-file tmp/issues/<root>/refinement/root-body.md`
+10. Apply: `node scripts/github/edit-issue.mjs --repo <repo> --issue <root> --body-file tmp/issues/<root>/refinement/root-body.md`
 
 <!-- rule: EPIC-REFINEMENT-SERIAL-PHASE-GATE -->
 **Gate:** Phase B MUST NOT start until Phase A is complete and the root body is updated on GitHub. The same serial-gate discipline applies at every phase boundary below: a level/phase MUST fully complete (siblings may run in parallel within it) before the next one starts.
@@ -92,7 +92,7 @@ parent's updated body, not each other's output.
    - **Non-goals** — what this child intentionally excludes
 6. Write refined body to `tmp/issues/<child>/refinement/child-body.md`
 7. Show the diff and obtain confirmation before mutating (unless running unattended with explicit authorization)
-8. Apply: `gh issue edit <child> --repo <repo> --body-file tmp/issues/<child>/refinement/child-body.md`
+8. Apply: `node scripts/github/edit-issue.mjs --repo <repo> --issue <child> --body-file tmp/issues/<child>/refinement/child-body.md`
 
 **Parallelism rule:** All siblings at the same level can be refined concurrently. No child needs
 another child's output; each child only reads the parent's contract and its own current body.
@@ -121,7 +121,7 @@ updated bodies, not sibling parents).
 4. Update the parent's phase scope table and AC/DoD as needed to reflect what children now explicitly own
 5. Write refined body to `tmp/issues/<parent>/refinement/parent-reconciled-body.md`
 6. Show the diff and obtain confirmation before mutating
-7. Apply: `gh issue edit <parent> --repo <repo> --body-file tmp/issues/<parent>/refinement/parent-reconciled-body.md`
+7. Apply: `node scripts/github/edit-issue.mjs --repo <repo> --issue <parent> --body-file tmp/issues/<parent>/refinement/parent-reconciled-body.md`
 
 **Serial gate between levels** ([EPIC-REFINEMENT-SERIAL-PHASE-GATE](#phase-a--root-refinement-serial)): all parents at depth N must complete reconciliation before ascending to depth N-1.
 
@@ -140,7 +140,7 @@ After all immediate children of the root have been reconciled:
 4. Update the root body with the final reconciled phase scope table and AC/DoD
 5. Write to `tmp/issues/<root>/refinement/root-final-body.md`
 6. Show the diff and obtain confirmation before mutating
-7. Apply: `gh issue edit <root> --repo <repo> --body-file tmp/issues/<root>/refinement/root-final-body.md`
+7. Apply: `node scripts/github/edit-issue.mjs --repo <repo> --issue <root> --body-file tmp/issues/<root>/refinement/root-final-body.md`
 8. Verify the sub-issue tree still reflects the correct execution order:
    ```sh
    node <resolved-skill-scripts>/github/manage-sub-issues.mjs verify \
@@ -156,7 +156,7 @@ After all immediate children of the root have been reconciled:
 
 <!-- rule: EPIC-REFINEMENT-SCOPE-BOUNDARY -->
 This procedure MUST stay refinement-only: no implementation, no PRs, no Copilot assignment.
-Apply changes directly with `gh issue edit` — never create new issues or PRs. Hierarchy MUST
+Apply changes directly with `scripts/github/edit-issue.mjs` — never create new issues or PRs. Hierarchy MUST
 stay in the GitHub sub-issues API, not prose parent/child links or a duplicated child-list
 checklist in parent bodies.
 
@@ -168,7 +168,7 @@ AC/DoD matrix, and an explicit scope boundary in the format
 <!-- rule: EPIC-REFINEMENT-CONFIRM-BEFORE-MUTATE -->
 `EPIC-REFINEMENT-CONFIRM-BEFORE-MUTATE`: The procedure MUST write the refined body to
 `tmp/issues/<number>/refinement/` first and MUST show the diff and get confirmation before
-each `gh issue edit` mutation, unless running unattended with explicit authorization.
+each `edit-issue.mjs` mutation, unless running unattended with explicit authorization.
 
 ---
 

--- a/skills/docs/epic-tree-refinement-procedure.md
+++ b/skills/docs/epic-tree-refinement-procedure.md
@@ -168,7 +168,7 @@ AC/DoD matrix, and an explicit scope boundary in the format
 <!-- rule: EPIC-REFINEMENT-CONFIRM-BEFORE-MUTATE -->
 `EPIC-REFINEMENT-CONFIRM-BEFORE-MUTATE`: The procedure MUST write the refined body to
 `tmp/issues/<number>/refinement/` first and MUST show the diff and get confirmation before
-each `edit-issue.mjs` mutation, unless running unattended with explicit authorization.
+each `node scripts/github/edit-issue.mjs` mutation, unless running unattended with explicit authorization.
 
 ---
 

--- a/skills/docs/epic-tree-refinement-procedure.md
+++ b/skills/docs/epic-tree-refinement-procedure.md
@@ -156,7 +156,7 @@ After all immediate children of the root have been reconciled:
 
 <!-- rule: EPIC-REFINEMENT-SCOPE-BOUNDARY -->
 This procedure MUST stay refinement-only: no implementation, no PRs, no Copilot assignment.
-Apply changes directly with `scripts/github/edit-issue.mjs` — never create new issues or PRs. Hierarchy MUST
+Apply changes directly with `node scripts/github/edit-issue.mjs` — never create new issues or PRs. Hierarchy MUST
 stay in the GitHub sub-issues API, not prose parent/child links or a duplicated child-list
 checklist in parent bodies.
 

--- a/skills/docs/issue-intake-procedure.md
+++ b/skills/docs/issue-intake-procedure.md
@@ -225,8 +225,8 @@ When an existing sub-issue tree needs **scope alignment, AC/DoD contracts, and d
 
 Before updating the GitHub issue body, show the diff and get explicit confirmation. Then use:
 ```sh
-gh issue edit <number> --repo <resolved-repo> --body-file <updated-body-file>
-gh issue edit <number> --repo <resolved-repo> --add-assignee copilot-swe-agent
+node scripts/github/edit-issue.mjs --repo <resolved-repo> --issue <number> --body-file <updated-body-file>
+node scripts/github/edit-issue.mjs --repo <resolved-repo> --issue <number> --add-assignee copilot-swe-agent
 ```
 Verify assignment with:
 ```sh

--- a/skills/loop-grill/SKILL.md
+++ b/skills/loop-grill/SKILL.md
@@ -121,7 +121,7 @@ Write the raw Q&A transcript ONLY to the gitignored, ephemeral, session-scoped a
 **Tracker-first write-back:** update the GitHub issue body using:
 
 ```
-gh issue edit <n> --repo <owner/repo> --body-file <tmp-path>
+node scripts/github/edit-issue.mjs --repo <owner/repo> --issue <n> --body-file <tmp-path>
 ```
 
 The synthesized sections live in the issue body, not as a comment. Do not use `comment-issue.mjs` here — that creates a comment, not a body update.

--- a/test/contracts/issue-intake-doc-contracts.test.mjs
+++ b/test/contracts/issue-intake-doc-contracts.test.mjs
@@ -234,8 +234,8 @@ test("issue-intake flow carries the resolved repo slug through later GitHub issu
 
   assert.match(skillContent, /Carry that resolved repo slug through every later GitHub issue\/PR command/i);
   assert.match(skillContent, /gh issue create --repo <resolved-repo> --assignee @me/);
-  assert.match(skillContent, /gh issue edit <number> --repo <resolved-repo> --body-file <updated-body-file>/);
-  assert.match(skillContent, /gh issue edit <number> --repo <resolved-repo> --add-assignee copilot-swe-agent/);
+  assert.match(skillContent, /node scripts\/github\/edit-issue\.mjs --repo <resolved-repo> --issue <number> --body-file <updated-body-file>/);
+  assert.match(skillContent, /node scripts\/github\/edit-issue\.mjs --repo <resolved-repo> --issue <number> --add-assignee copilot-swe-agent/);
   assert.match(skillContent, /gh pr edit <pr-number> --repo <resolved-repo> --title/);
   assert.match(skillContent, /gh pr ready <pr-number> --repo <resolved-repo>/);
   assert.match(skillContent, /gh pr review <pr-number> --repo <resolved-repo> --approve/);


### PR DESCRIPTION
## Summary

Routes the remaining raw `gh issue edit` call-sites in three skill docs through the sanctioned `scripts/github/edit-issue.mjs` wrapper (follow-up to #1247), so subagent paths get the allow-listed command instead of a gated raw call. Call-site consistency only — no behavior change.

## Scope and context

In scope: `skills/docs/issue-intake-procedure.md`, `skills/docs/epic-tree-refinement-procedure.md`, `skills/loop-grill/SKILL.md` (raw `gh issue edit` → `node scripts/github/edit-issue.mjs --repo <r> --issue <n> ...`), their regenerated `.claude` mirrors, and an update to `test/contracts/issue-intake-doc-contracts.test.mjs` whose assertions pinned the old raw strings (repo slug still carried via `--repo`). Out of scope: any other doc; the wrapper's own unit tests (which legitimately reference the internal `gh issue edit` args).

## Acceptance criteria

Satisfies issue #1255's acceptance criteria — checked off on the issue at merge. No raw `gh issue edit` remains in the three docs; `.claude` mirrors regenerated; verify green.

## Definition of done

The three docs reference `scripts/github/edit-issue.mjs` (matching the real wrapper interface) instead of raw `gh issue edit`; generated `.claude` mirrors in sync; test:docs + test:assets green.

## Non-goals

No behavior change; no global rewrite beyond the three named docs; the wrapper's own unit tests unchanged.

## Validation

- `npm run test:docs` (links 101 files/532 + rule-ownership), `npm run test:assets` (190 pass, incl. generated-assets-in-sync + the updated contract test).
- Full gate uses `npm run verify`.

Closes #1255
