### PR TITLE
test(ci): guard verify-suite matrix against package.json test:* drift (#1273)

### DIFF
--- a/test/contracts/verify-suite-matrix-drift.test.mjs
+++ b/test/contracts/verify-suite-matrix-drift.test.mjs
@@ -1,0 +1,49 @@
+import { assert, readRepo, test } from "../imported-assets-helpers.mjs";
+
+// Guards against the CI verify-suite matrix drifting from the test:* scripts
+// that compose `npm run verify`. Adding a gating suite to package.json without
+// wiring the matrix (or vice-versa) is fail-open: the aggregate verify gate
+// stays green while the new suite never runs. This asserts the two sets match.
+
+const suiteTokens = (text) =>
+  new Set((text.match(/test:[\w:-]+/g) || []));
+
+test("verify-suite matrix suites equal the test:* suites composing npm run verify", async () => {
+  const [pkgRaw, ciWorkflow] = await Promise.all([
+    readRepo("package.json"),
+    readRepo(".github/workflows/ci.yml"),
+  ]);
+
+  // Source of truth: the run-p args of the `verify` script (the aggregate CI
+  // gate). run-p flags never start with `test:`, so token-matching is exact.
+  const verifyScript = JSON.parse(pkgRaw).scripts?.verify;
+  assert.ok(verifyScript, "package.json must define a `verify` script");
+  const verifySuites = suiteTokens(verifyScript);
+
+  // Scope to the verify-suite job's own section (header to the next top-level
+  // job header) so a suite name elsewhere in the workflow can't satisfy this.
+  const headerIndex = ciWorkflow.search(/^\s{2}verify-suite:\s*$/m);
+  assert.ok(headerIndex !== -1, "ci.yml must define a verify-suite: job");
+  const nextJobRelative = ciWorkflow.slice(headerIndex + 1).search(/^\s{2}\S/m);
+  const section = ciWorkflow.slice(
+    headerIndex,
+    nextJobRelative === -1 ? ciWorkflow.length : headerIndex + 1 + nextJobRelative,
+  );
+  const matrixSuites = new Set(
+    [...section.matchAll(/^\s*-\s*(test:[\w:-]+)\s*$/gm)].map((m) => m[1]),
+  );
+
+  const missingFromMatrix = [...verifySuites].filter((s) => !matrixSuites.has(s));
+  const extraInMatrix = [...matrixSuites].filter((s) => !verifySuites.has(s));
+
+  assert.deepEqual(
+    missingFromMatrix,
+    [],
+    `test:* suites in \`npm run verify\` but missing from the ci.yml verify-suite matrix: ${missingFromMatrix.join(", ")}`,
+  );
+  assert.deepEqual(
+    extraInMatrix,
+    [],
+    `suites in the ci.yml verify-suite matrix but not in \`npm run verify\`: ${extraInMatrix.join(", ")}`,
+  );
+});


### PR DESCRIPTION
## Summary

Closes the fail-open gap from #1270: the CI `verify-suite` matrix hand-lists suites, so a new gating `test:*` script added to `package.json` but not the matrix would silently never run in CI while the aggregate `verify` gate stayed green. Adds a contract test asserting set-equality between the two sources — drift in either direction fails the check.

## Scope and context

In scope: one contract test, `test/contracts/verify-suite-matrix-drift.test.mjs`. It derives the gating suite set from the `test:*` tokens composing the `verify` npm script (the aggregate CI gate — keyed off `verify`, not `test`, because the matrix mirrors `verify`, which includes `test:dev-loop`) and the matrix set from the `verify-suite` job section of `.github/workflows/ci.yml`, then asserts both `missingFromMatrix` and `extraInMatrix` are empty. Placed in `test/contracts/` (globbed by `test:assets`) so the guard itself gates — `test/ci/` would not run. No codegen, no new dependency, no workflow change.

## Acceptance criteria

Satisfies issue #1273's acceptance criteria — checked off on the issue at merge. Adding a `test:*` suite to package.json without wiring the ci.yml matrix fails the check (verified both directions).

## Definition of done

A `test:*`/matrix drift in either direction fails CI; no codegen/new build step; verify green.

## Non-goals

No codegen. No new dependency. No change to the existing hard-listed matrix or the `review-doc-contracts` presence test (which this supersedes for drift detection).

## Validation

- Direct: consistent → pass; `test:zzz` added to `verify` but not matrix → FAILS (named); extra matrix leg not in `verify` → FAILS (named); reverted → pass. (Both drift directions proven.)
- `npm run test:assets` (191 pass — picks up the new contract test), `npm run verify` green.
- Full gate uses `npm run verify`.

Closes #1273
