### PR TITLE
perf(test): speed up the worst real-git test:scripts files (#1277)

### DIFF
--- a/scripts/loop/_loop-pr-aggregation.mjs
+++ b/scripts/loop/_loop-pr-aggregation.mjs
@@ -1,12 +1,12 @@
 // Shared loop PR-aggregation helpers used by both conductor-monitor.mjs and
 // run-conductor-cycle.mjs. Spawns `gh`, so this lives at the scripts level
 // rather than in @dev-loops/core.
-import { runChild } from "../_cli-primitives.mjs";
+import { runChild as defaultRunChild } from "../_cli-primitives.mjs";
 import { parseJsonText } from "../_core-helpers.mjs";
 
 export const OPEN_PR_LIST_LIMIT = 1000;
 
-export async function listOpenPrs({ repo }, { env, ghCommand }) {
+export async function listOpenPrs({ repo }, { env, ghCommand, runChild = defaultRunChild }) {
   const result = await runChild(
     ghCommand,
     [

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs";
 import { access, open, readFile, readdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { requireTokenValue } from "../_cli-primitives.mjs";
+import { requireTokenValue, runChild as defaultRunChild } from "../_cli-primitives.mjs";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText, readJsonIfExists } from "../_core-helpers.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { autoDetectSnapshot } from "./detect-copilot-loop-state.mjs";
@@ -207,10 +207,10 @@ function buildPrReport(pr, interpretation, interpretationSummary, snapshot) {
     },
   };
 }
-async function buildPrReports(prs, { repo, env, ghCommand }) {
+async function buildPrReports(prs, { repo, env, ghCommand, runChild }) {
   const reports = [];
   for (const pr of prs) {
-    const snapshot = await autoDetectSnapshot({ repo, pr: pr.number }, { env, ghCommand });
+    const snapshot = await autoDetectSnapshot({ repo, pr: pr.number }, { env, ghCommand, runChild });
     const interpretation = interpretLoopState(snapshot);
     const interpretationSummary = summarizeLoopInterpretation(interpretation);
     reports.push(buildPrReport(pr, interpretation, interpretationSummary, snapshot));
@@ -1754,13 +1754,14 @@ export async function runConductorMonitor(
   {
     env = process.env,
     ghCommand = "gh",
+    runChild = defaultRunChild,
     repoRoot = process.cwd(),
     sessionRoots,
     asyncRunRoots,
     asyncResultRoots,
   } = {},
 ) {
-  const prs = await listOpenPrs({ repo }, { env, ghCommand });
+  const prs = await listOpenPrs({ repo }, { env, ghCommand, runChild });
   if (prs.length === 0) {
     const baseResult = buildBaseResult(repo, []);
     if (!autoResume) {
@@ -1785,7 +1786,7 @@ export async function runConductorMonitor(
       localPhaseResumePlans: localPhaseRuns.map((run) => buildLocalPhaseResumePlan(run)),
     });
   }
-  const reports = await buildPrReports(prs, { repo, env, ghCommand });
+  const reports = await buildPrReports(prs, { repo, env, ghCommand, runChild });
   const baseResult = buildBaseResult(repo, reports);
   if (!autoResume) {
     return baseResult;

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { runConductorMonitor, isPrHealthy } from "../../scripts/loop/conductor-monitor.mjs";
-import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
+import { makeGhMock, runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
 
 const scriptPath = path.resolve("scripts/loop/conductor-monitor.mjs");
 const mixedThreadsFixturePath = path.resolve("packages/core/test/fixtures/github/review-threads/mixed-threads.json");
@@ -178,11 +178,11 @@ async function writeAsyncRun({
   return { statusPath, outputPath, eventsPath };
 }
 
-async function runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo, env }) {
+async function runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo, runChild }) {
   return runConductorMonitor(
     { repo, autoResume: true },
     {
-      env,
+      runChild,
       repoRoot,
       sessionRoots: [sessionsRoot],
       asyncRunRoots: [asyncRunsRoot],
@@ -336,11 +336,11 @@ test("conductor-monitor --auto-resume ignores invalid async JSON side artifacts 
     await writeFile(path.join(badAsyncDir, "events.jsonl"), "", "utf8");
     await writeFile(path.join(badAsyncDir, "output-0.log"), "Active PR: owner/repo#40\n", "utf8");
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{ number: 40, requestCopilot: true }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.queueStatus, "monitoring");
     assert.equal(payload.resumePlanCount, 0);
     assert.equal(payload.manualAttentionCount, 0);
@@ -359,11 +359,11 @@ test("conductor-monitor --auto-resume ignores malformed session artifact meta JS
     await writeFile(path.join(badArtifactsDir, "run-bad-meta-99_dev-loop_0_meta.json"), "{not valid json\n", "utf8");
     await writeFile(path.join(badArtifactsDir, "run-bad-meta-99_dev-loop_0_output.md"), "Active PR: owner/repo#99\n", "utf8");
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{ number: 44, requestCopilot: true }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.queueStatus, "monitoring");
     assert.equal(payload.resumePlanCount, 0);
     assert.equal(payload.manualAttentionCount, 0);
@@ -379,11 +379,11 @@ test("conductor-monitor --auto-resume ignores malformed async result JSON instea
     const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
     await writeFile(path.join(asyncResultsRoot, "run-bad-result-45.json"), "{not valid json\n", "utf8");
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{ number: 45, requestCopilot: true }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.queueStatus, "monitoring");
     assert.equal(payload.resumePlanCount, 0);
     assert.equal(payload.manualAttentionCount, 0);
@@ -461,11 +461,11 @@ test("conductor-monitor --auto-resume ignores malformed session headers instead 
     );
     await writeFile(path.join(badArtifactsDir, "run-bad-session-41_dev-loop_0_output.md"), "Active PR: owner/repo#41\n", "utf8");
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{ number: 41, requestCopilot: true }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.queueStatus, "monitoring");
     assert.equal(payload.resumePlanCount, 0);
     assert.equal(payload.manualAttentionCount, 0);
@@ -497,11 +497,11 @@ test("conductor-monitor --auto-resume ignores parse-failed artifacts that do not
       outputText: "Active PR: owner/repo#99\n",
     });
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{ number: 42, requestCopilot: true }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.queueStatus, "monitoring");
     assert.equal(payload.resumePlanCount, 0);
     assert.equal(payload.manualAttentionCount, 0);
@@ -537,11 +537,11 @@ test("conductor-monitor --auto-resume fails closed when an active matching run c
     await writeFile(statusPath, `${JSON.stringify(activeStatus, null, 2)}
 `, "utf8");
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{ number: 43, requestCopilot: true }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.resumePlanCount, 0);
     assert.equal(payload.manualAttentionCount, 1);
     assert.equal(payload.needsManualAttention[0].pr, 43);
@@ -565,7 +565,7 @@ test("conductor-monitor --auto-resume preserves artifact run ids that contain un
       outputText: "Active PR: owner/repo#55\nArtifact state: open\nLoop state: unresolved_feedback_present\n",
     });
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{
         number: 55,
         reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
@@ -574,7 +574,7 @@ test("conductor-monitor --auto-resume preserves artifact run ids that contain un
       }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.resumePlanCount, 1);
     assert.equal(payload.resumePlans[0].runId, "pr_55");
   } finally {
@@ -595,11 +595,11 @@ test("conductor-monitor --auto-resume fails closed when run exit state cannot be
     await writeFile(path.join(artifactsDir, "run-unknown-56_dev-loop_0_output.md"), "Active PR: owner/repo#56\nArtifact state: open\nLoop state: waiting_for_copilot_review\n", "utf8");
     await writeFile(path.join(runDir, "session.jsonl"), `${JSON.stringify({ type: "session", version: 3, id: "run-unknown-56-session", timestamp: "2026-06-03T00:00:00.000Z", cwd: repoRoot })}\n`, "utf8");
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{ number: 56, requestCopilot: true }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.resumePlanCount, 0);
     assert.equal(payload.manualAttentionCount, 1);
     assert.equal(payload.needsManualAttention[0].pr, 56);
@@ -633,7 +633,7 @@ test("conductor-monitor --auto-resume preserves the stronger failed run state wh
       outputText: "Active PR: owner/repo#57\nLoop state: unresolved_feedback_present\n",
     });
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{
         number: 57,
         reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
@@ -642,7 +642,7 @@ test("conductor-monitor --auto-resume preserves the stronger failed run state wh
       }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.resumePlanCount, 1);
     assert.equal(payload.resumePlans[0].runState, "failed");
   } finally {
@@ -683,11 +683,11 @@ test("conductor-monitor --auto-resume uses grouped result summaries as the artif
     }, null, 2)}
 `, "utf8");
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{ number: 58, requestCopilot: true }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.resumePlanCount, 1);
     assert.equal(payload.resumePlans[0].artifactPath, summaryPath);
   } finally {
@@ -742,7 +742,7 @@ test("conductor-monitor --auto-resume reuses grouped result summaries when accep
     }, null, 2)}
 `, "utf8");
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{
         number: 58,
         reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
@@ -750,7 +750,7 @@ test("conductor-monitor --auto-resume reuses grouped result summaries when accep
       }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.resumePlanCount, 1);
     assert.equal(payload.manualAttentionCount, 0);
     assert.equal(payload.resumePlans[0].pr, 58);
@@ -808,7 +808,7 @@ test("conductor-monitor --auto-resume falls back to deterministic output logs wh
     }, null, 2)}
 `, "utf8");
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{
         number: 58,
         reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
@@ -816,7 +816,7 @@ test("conductor-monitor --auto-resume falls back to deterministic output logs wh
       }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.resumePlanCount, 1);
     assert.equal(payload.manualAttentionCount, 0);
     assert.equal(payload.resumePlans[0].pr, 58);
@@ -849,11 +849,11 @@ test("conductor-monitor --auto-resume fails closed when an active matching run h
       outputText: "Active PR: owner/repo#59\nLoop state: waiting_for_copilot_review\n",
     });
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{ number: 59, requestCopilot: true }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.resumePlanCount, 0);
     assert.equal(payload.manualAttentionCount, 1);
     assert.equal(payload.needsManualAttention[0].pr, 59);
@@ -888,11 +888,11 @@ test("conductor-monitor --auto-resume does not invent a failed run state from me
       outputText: "Active PR: owner/repo#60\nLoop state: waiting_for_copilot_review\n",
     });
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{ number: 60, requestCopilot: true }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.resumePlanCount, 1);
     assert.equal(payload.resumePlans[0].runState, "completed");
   } finally {
@@ -934,11 +934,11 @@ test("conductor-monitor --auto-resume keeps stale-worktree runs resumable when J
     }, null, 2)}
 `, "utf8");
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{ number: 61, requestCopilot: true }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.resumePlanCount, 1);
     assert.equal(payload.resumePlans[0].pr, 61);
     assert.equal(payload.resumePlans[0].staleWorktree, true);
@@ -963,7 +963,7 @@ test("conductor-monitor --auto-resume includes a non-zero child index in the res
       outputText: "Active PR: owner/repo#62\nArtifact state: open\nLoop state: unresolved_feedback_present\n",
     });
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{
         number: 62,
         reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
@@ -972,7 +972,7 @@ test("conductor-monitor --auto-resume includes a non-zero child index in the res
       }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.resumePlanCount, 1);
     assert.match(payload.resumePlans[0].resumeCommandPreview, /index: 1/);
   } finally {
@@ -1002,7 +1002,7 @@ test("conductor-monitor --auto-resume emits a feedback-fix resume plan for an or
       ].join("\n"),
     });
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{
         number: 17,
         reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
@@ -1011,7 +1011,7 @@ test("conductor-monitor --auto-resume emits a feedback-fix resume plan for an or
       }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
 
     assert.equal(payload.autoResumeRequested, true);
     assert.equal(payload.resumePlanCount, 1);
@@ -1073,7 +1073,7 @@ test("conductor-monitor --auto-resume fails closed when recorded handoff contrac
       ].join("\n"),
     });
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{
         number: 17,
         reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
@@ -1082,7 +1082,7 @@ test("conductor-monitor --auto-resume fails closed when recorded handoff contrac
       }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
 
     assert.equal(payload.resumePlanCount, 0);
     assert.equal(payload.manualAttentionCount, 1);
@@ -1116,7 +1116,7 @@ test("conductor-monitor --auto-resume emits a final-approval resume plan for an 
       ].join("\n"),
     });
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{
         number: 22,
         reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
@@ -1124,7 +1124,7 @@ test("conductor-monitor --auto-resume emits a final-approval resume plan for an 
       }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.resumePlanCount, 1);
     const plan = payload.resumePlans[0];
     assert.equal(plan.pr, 22);
@@ -1156,7 +1156,7 @@ test("conductor-monitor --auto-resume emits a merge-authorization resume plan fo
       ].join("\n"),
     });
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{
         number: 24,
         reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
@@ -1164,7 +1164,7 @@ test("conductor-monitor --auto-resume emits a merge-authorization resume plan fo
       }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.resumePlanCount, 1);
     const plan = payload.resumePlans[0];
     assert.equal(plan.pr, 24);
@@ -1205,11 +1205,11 @@ test("conductor-monitor --auto-resume ignores an older completed run when a newe
       outputText: "Active PR: owner/repo#30\nLoop state: waiting_for_copilot_review\n",
     });
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{ number: 30, requestCopilot: true }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.resumePlanCount, 0);
     assert.equal(payload.manualAttentionCount, 0);
     assert.equal(payload.orphanedPrCount, 0);
@@ -1242,7 +1242,7 @@ test("conductor-monitor --auto-resume fails closed when the output artifact is m
       outputText: "Active PR: owner/repo#31\n",
     });
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{
         number: 31,
         reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
@@ -1250,7 +1250,7 @@ test("conductor-monitor --auto-resume fails closed when the output artifact is m
       }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.resumePlanCount, 0);
     assert.equal(payload.manualAttentionCount, 1);
     assert.equal(payload.needsManualAttention[0].pr, 31);
@@ -1277,11 +1277,11 @@ test("conductor-monitor --auto-resume fails closed on ambiguous PR identity insi
       ].join("\n"),
     });
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{ number: 33 }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.resumePlanCount, 0);
     assert.equal(payload.manualAttentionCount, 1);
     assert.equal(payload.needsManualAttention[0].reason, "ambiguous_pr_identity");
@@ -1309,7 +1309,7 @@ test("conductor-monitor --auto-resume keeps a stale-worktree run resumable when 
       ].join("\n"),
     });
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{
         number: 35,
         reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
@@ -1318,7 +1318,7 @@ test("conductor-monitor --auto-resume keeps a stale-worktree run resumable when 
       }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.resumePlanCount, 1);
     assert.equal(payload.resumePlans[0].pr, 35);
     assert.equal(payload.resumePlans[0].staleWorktree, true);
@@ -1349,11 +1349,11 @@ test("conductor-monitor --auto-resume ignores non-dev-loop runs and runs from ot
       outputText: "Active PR: owner/repo#36\n",
     });
 
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{ number: 36, requestCopilot: true }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
     assert.equal(payload.resumePlanCount, 0);
     assert.equal(payload.manualAttentionCount, 0);
     assert.equal(payload.orphanedPrCount, 0);
@@ -1383,7 +1383,7 @@ test("conductor-monitor --auto-resume suppresses orphan alert for healthy PR (no
     });
 
     // Healthy PR: CI green, no unresolved threads
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{
         number: 40,
         reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
@@ -1392,7 +1392,7 @@ test("conductor-monitor --auto-resume suppresses orphan alert for healthy PR (no
       }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
 
     assert.equal(payload.autoResumeRequested, true);
     // Orphan detection suppressed — no resume plan for healthy PR
@@ -1427,7 +1427,7 @@ test("conductor-monitor --auto-resume still flags orphan for unhealthy PR (unres
     });
 
     // Unhealthy PR: CI green but has unresolved threads
-    const env = await writeGhStub(tempDir, buildGhEntries({
+    const { runChild } = makeGhMock(buildGhEntries({
       prs: [{
         number: 41,
         reviews: [{ id: "r-1", author: { login: "copilot-pull-request-reviewer[bot]" } }],
@@ -1436,7 +1436,7 @@ test("conductor-monitor --auto-resume still flags orphan for unhealthy PR (unres
       }],
     }));
 
-    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", env });
+    const payload = await runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo: "owner/repo", runChild });
 
     // Should still flag as orphan — PR has unresolved threads
     assert.equal(payload.orphanedPrCount, 1);

--- a/test/loop/pre-commit-branch-guard.test.mjs
+++ b/test/loop/pre-commit-branch-guard.test.mjs
@@ -14,22 +14,21 @@ const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, opt
 
 async function writeGitStub(tempDir, { branch = "copilot/feature-branch", logFile } = {}) {
   const gitPath = path.join(tempDir, "git");
+  // Shell stub (cheap spawn) standing in for the real git binary: it still runs
+  // as a subprocess resolved via PATH, so the git-command boundary stays under
+  // test, but without paying node startup on every git invocation.
   await writeFile(
     gitPath,
     [
-      "#!/usr/bin/env node",
-      "import { appendFileSync } from 'node:fs';",
-      "const args = process.argv.slice(2);",
-      "const joined = args.join(' ');",
-      "if (process.env.BRANCH_GUARD_LOG_FILE) {",
-      "  appendFileSync(process.env.BRANCH_GUARD_LOG_FILE, `${joined}\\n`);",
-      "}",
-      "if (joined === 'branch --show-current') {",
-      `  process.stdout.write(${JSON.stringify(`${branch}\n`)});`,
-      "  process.exit(0);",
-      "}",
-      "process.stderr.write(`unexpected git args: ${joined}\\n`);",
-      "process.exit(1);",
+      "#!/usr/bin/env sh",
+      'joined="$*"',
+      'if [ -n "$BRANCH_GUARD_LOG_FILE" ]; then printf \'%s\\n\' "$joined" >> "$BRANCH_GUARD_LOG_FILE"; fi',
+      'if [ "$joined" = "branch --show-current" ]; then',
+      `  printf '%s\\n' ${JSON.stringify(branch)}`,
+      "  exit 0",
+      "fi",
+      'printf \'unexpected git args: %s\\n\' "$joined" >&2',
+      "exit 1",
       "",
     ].join("\n"),
     "utf8",
@@ -217,27 +216,27 @@ async function writeWorktreeGitStub(tempDir, {
   logFile,
 } = {}) {
   const gitPath = path.join(tempDir, "git");
-  const escapedWorktreeList = JSON.stringify(worktreeListOut);
+  // Shell stub (cheap spawn) standing in for the real git binary — still spawned
+  // as a subprocess resolved via PATH, preserving the git-command boundary, but
+  // without node startup per git invocation.
   await writeFile(
     gitPath,
     [
-      "#!/usr/bin/env node",
-      "import { appendFileSync } from 'node:fs';",
-      "const args = process.argv.slice(2);",
-      "const joined = args.join(' ');",
-      "if (process.env.BRANCH_GUARD_LOG_FILE) {",
-      "  appendFileSync(process.env.BRANCH_GUARD_LOG_FILE, `${joined}\\n`);",
-      "}",
-      "if (joined === 'branch --show-current') {",
-      `  process.stdout.write(${JSON.stringify(`${branch}\n`)});`,
-      "  process.exit(0);",
-      "}",
-      "if (joined === 'worktree list') {",
-      `  process.stdout.write(${escapedWorktreeList});`,
-      "  process.exit(0);",
-      "}",
-      "process.stderr.write(`unexpected git args: ${joined}\\n`);",
-      "process.exit(1);",
+      "#!/usr/bin/env sh",
+      'joined="$*"',
+      'if [ -n "$BRANCH_GUARD_LOG_FILE" ]; then printf \'%s\\n\' "$joined" >> "$BRANCH_GUARD_LOG_FILE"; fi',
+      'if [ "$joined" = "branch --show-current" ]; then',
+      `  printf '%s\\n' ${JSON.stringify(branch)}`,
+      "  exit 0",
+      "fi",
+      'if [ "$joined" = "worktree list" ]; then',
+      "  cat <<'WTEOF'",
+      ...worktreeListOut.split("\n"),
+      "WTEOF",
+      "  exit 0",
+      "fi",
+      'printf \'unexpected git args: %s\\n\' "$joined" >&2',
+      "exit 1",
       "",
     ].join("\n"),
     "utf8",

--- a/test/loop/pre-flight-gate.test.mjs
+++ b/test/loop/pre-flight-gate.test.mjs
@@ -2,10 +2,9 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import { mkdtempSync, mkdirSync, realpathSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { execFileSync } from "node:child_process";
 import test from "node:test";
 
-import { parsePreFlightGateCliArgs } from "../../scripts/loop/pre-flight-gate.mjs";
+import { parsePreFlightGateCliArgs, runCli } from "../../scripts/loop/pre-flight-gate.mjs";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -41,29 +40,34 @@ function writeGitStub(tempDir, {
   return gitPath;
 }
 
-const PREFLIGHT_SCRIPT = path.resolve("scripts/loop/pre-flight-gate.mjs");
-
-function runGate(args = [], { cwd, env = {}, gitDir, logFile } = {}) {
+async function runGate(args = [], { cwd, env = {}, gitDir } = {}) {
+  // Run the CLI in-process (no node subprocess per test) while keeping the real
+  // git boundary: the shell git stub at `<gitDir|cwd>/git` is still spawned via
+  // execFileSync inside the gate, so the git-command contract stays under test.
+  const gitCommand = path.join(gitDir ?? cwd, "git");
   const fullEnv = { ...process.env, ...env };
-  // Ensure PATH includes cwd and gitDir so the git stub is found
-  const paths = [];
-  if (cwd) paths.push(cwd);
-  if (gitDir && gitDir !== cwd) paths.push(gitDir);
-  if (paths.length > 0) {
-    fullEnv.PATH = `${paths.join(path.delimiter)}${path.delimiter}${fullEnv.PATH || ""}`;
-  }
+  let outBuf = "";
+  let errBuf = "";
+  const collect = (bucket) => ({
+    write: (chunk) => {
+      if (bucket === "out") outBuf += String(chunk);
+      else errBuf += String(chunk);
+      return true;
+    },
+  });
+  const previousExitCode = process.exitCode;
+  process.exitCode = 0;
   try {
-    const stdout = execFileSync(
-      process.execPath,
-      [PREFLIGHT_SCRIPT, ...args],
-      { cwd, env: fullEnv, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
-    );
-    return { exitCode: 0, stdout: stdout.trim(), stderr: "" };
-  } catch (err) {
-    const code = err.status ?? 1;
-    const stdout = (err.stdout ?? "").trim();
-    const stderr = (err.stderr ?? err.message ?? "").trim();
-    return { exitCode: code, stdout, stderr };
+    await runCli(args, {
+      cwd,
+      env: fullEnv,
+      gitCommand,
+      stdout: collect("out"),
+      stderr: collect("err"),
+    });
+    return { exitCode: process.exitCode ?? 0, stdout: outBuf.trim(), stderr: errBuf.trim() };
+  } finally {
+    process.exitCode = previousExitCode;
   }
 }
 
@@ -122,10 +126,10 @@ test("parsePreFlightGateCliArgs: rejects --expected-branch with missing value", 
 // Bypass
 // ---------------------------------------------------------------------------
 
-test("gate passes with DEVLOOPS_PREFLIGHT_BYPASS=1 from main checkout", () => {
+test("gate passes with DEVLOOPS_PREFLIGHT_BYPASS=1 from main checkout", async () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-bypass-"));
   try {
-    const result = runGate([], {
+    const result = await runGate([], {
       cwd: tempDir,
       env: { DEVLOOPS_PREFLIGHT_BYPASS: "1" },
     });
@@ -143,7 +147,7 @@ test("gate passes with DEVLOOPS_PREFLIGHT_BYPASS=1 from main checkout", () => {
 // Worktree isolation: pass
 // ---------------------------------------------------------------------------
 
-test("gate passes when cwd is under tmp/worktrees/", () => {
+test("gate passes when cwd is under tmp/worktrees/", async () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-worktree-ok-"));
   try {
     const worktreeDir = path.join(tempDir, "tmp", "worktrees", "issue-497");
@@ -157,7 +161,7 @@ test("gate passes when cwd is under tmp/worktrees/", () => {
 
     writeGitStub(tempDir, { worktreeListOut, logFile });
 
-    const result = runGate([], { cwd: worktreeDir, gitDir: tempDir });
+    const result = await runGate([], { cwd: worktreeDir, gitDir: tempDir });
 
     assert.equal(result.exitCode, 0);
     const payload = JSON.parse(result.stdout);
@@ -172,7 +176,7 @@ test("gate passes when cwd is under tmp/worktrees/", () => {
 // Worktree isolation: fail
 // ---------------------------------------------------------------------------
 
-test("gate fails when cwd is main checkout (detects main_checkout_detected)", () => {
+test("gate fails when cwd is main checkout (detects main_checkout_detected)", async () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-main-fail-"));
   try {
     const logFile = path.join(tempDir, "git.log");
@@ -180,7 +184,7 @@ test("gate fails when cwd is main checkout (detects main_checkout_detected)", ()
 
     writeGitStub(tempDir, { worktreeListOut, logFile });
 
-    const result = runGate([], { cwd: tempDir });
+    const result = await runGate([], { cwd: tempDir });
 
     assert.equal(result.exitCode, 1);
     assert.ok(result.stderr.length > 0, "stderr should have content");
@@ -193,7 +197,7 @@ test("gate fails when cwd is main checkout (detects main_checkout_detected)", ()
   }
 });
 
-test("gate fails when cwd is main checkout with main-checkout-detected error (under main)", () => {
+test("gate fails when cwd is main checkout with main-checkout-detected error (under main)", async () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-main-subdir-"));
   try {
     const subDir = path.join(tempDir, "src");
@@ -204,7 +208,7 @@ test("gate fails when cwd is main checkout with main-checkout-detected error (un
 
     writeGitStub(tempDir, { worktreeListOut, logFile });
 
-    const result = runGate([], { cwd: subDir, gitDir: tempDir });
+    const result = await runGate([], { cwd: subDir, gitDir: tempDir });
 
     assert.equal(result.exitCode, 1);
     const payload = JSON.parse(result.stderr);
@@ -218,13 +222,13 @@ test("gate fails when cwd is main checkout with main-checkout-detected error (un
   }
 });
 
-test("gate fails when git worktree list fails", () => {
+test("gate fails when git worktree list fails", async () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-git-fail-"));
   try {
     const gitPath = path.join(tempDir, "git");
     writeFileSync(gitPath, "#!/usr/bin/env sh\nexit 1\n", { mode: 0o755 });
 
-    const result = runGate([], { cwd: tempDir });
+    const result = await runGate([], { cwd: tempDir });
 
     assert.equal(result.exitCode, 1);
     const payload = JSON.parse(result.stderr);
@@ -235,7 +239,7 @@ test("gate fails when git worktree list fails", () => {
   }
 });
 
-test("gate fails when cwd is under tmp/worktrees/ but not a real git worktree", () => {
+test("gate fails when cwd is under tmp/worktrees/ but not a real git worktree", async () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-fake-worktree-"));
   try {
     const fakeWorktreeDir = path.join(tempDir, "tmp", "worktrees", "fake-issue");
@@ -246,7 +250,7 @@ test("gate fails when cwd is under tmp/worktrees/ but not a real git worktree", 
 
     writeGitStub(tempDir, { worktreeListOut, logFile });
 
-    const result = runGate([], { cwd: fakeWorktreeDir, gitDir: tempDir });
+    const result = await runGate([], { cwd: fakeWorktreeDir, gitDir: tempDir });
 
     assert.equal(result.exitCode, 1);
     const payload = JSON.parse(result.stderr);
@@ -265,7 +269,7 @@ test("gate fails when cwd is under tmp/worktrees/ but not a real git worktree", 
 // Branch identity
 // ---------------------------------------------------------------------------
 
-test("gate passes when --expected-branch matches current branch", () => {
+test("gate passes when --expected-branch matches current branch", async () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-branch-ok-"));
   try {
     const worktreeDir = path.join(tempDir, "tmp", "worktrees", "issue-497");
@@ -294,7 +298,7 @@ test("gate passes when --expected-branch matches current branch", () => {
     ];
     writeFileSync(gitPath, lines.join("\n"), { mode: 0o755 });
 
-    const result = runGate(["--expected-branch", "issue-497"], { cwd: worktreeDir, gitDir: tempDir });
+    const result = await runGate(["--expected-branch", "issue-497"], { cwd: worktreeDir, gitDir: tempDir });
 
     assert.equal(result.exitCode, 0);
     const payload = JSON.parse(result.stdout);
@@ -305,7 +309,7 @@ test("gate passes when --expected-branch matches current branch", () => {
   }
 });
 
-test("gate fails when --expected-branch does not match current branch", () => {
+test("gate fails when --expected-branch does not match current branch", async () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-branch-mismatch-"));
   try {
     const worktreeDir = path.join(tempDir, "tmp", "worktrees", "issue-497");
@@ -332,7 +336,7 @@ test("gate fails when --expected-branch does not match current branch", () => {
     ];
     writeFileSync(gitPath, lines.join("\n"), { mode: 0o755 });
 
-    const result = runGate(["--expected-branch", "issue-497"], { cwd: worktreeDir, gitDir: tempDir });
+    const result = await runGate(["--expected-branch", "issue-497"], { cwd: worktreeDir, gitDir: tempDir });
 
     assert.equal(result.exitCode, 1);
     const payload = JSON.parse(result.stderr);
@@ -343,7 +347,7 @@ test("gate fails when --expected-branch does not match current branch", () => {
   }
 });
 
-test("gate skips branch check when --expected-branch not provided", () => {
+test("gate skips branch check when --expected-branch not provided", async () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-no-branch-"));
   try {
     const worktreeDir = path.join(tempDir, "tmp", "worktrees", "issue-497");
@@ -357,7 +361,7 @@ test("gate skips branch check when --expected-branch not provided", () => {
 
     writeGitStub(tempDir, { worktreeListOut, logFile });
 
-    const result = runGate([], { cwd: worktreeDir, gitDir: tempDir });
+    const result = await runGate([], { cwd: worktreeDir, gitDir: tempDir });
 
     assert.equal(result.exitCode, 0);
     const payload = JSON.parse(result.stdout);
@@ -371,7 +375,7 @@ test("gate skips branch check when --expected-branch not provided", () => {
 // Subagent availability
 // ---------------------------------------------------------------------------
 
-test("gate reports subagent status skipped when --check-subagents not set", () => {
+test("gate reports subagent status skipped when --check-subagents not set", async () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-subagent-skip-"));
   try {
     const worktreeDir = path.join(tempDir, "tmp", "worktrees", "issue-497");
@@ -385,7 +389,7 @@ test("gate reports subagent status skipped when --check-subagents not set", () =
 
     writeGitStub(tempDir, { worktreeListOut, logFile });
 
-    const result = runGate([], {
+    const result = await runGate([], {
       cwd: worktreeDir,
       gitDir: tempDir,
       env: { DEVLOOPS_SUBAGENT_AVAILABLE: "1" },
@@ -399,7 +403,7 @@ test("gate reports subagent status skipped when --check-subagents not set", () =
   }
 });
 
-test("gate reports subagent available when DEVLOOPS_SUBAGENT_AVAILABLE=1 and --check-subagents", () => {
+test("gate reports subagent available when DEVLOOPS_SUBAGENT_AVAILABLE=1 and --check-subagents", async () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-subagent-ok-"));
   try {
     const worktreeDir = path.join(tempDir, "tmp", "worktrees", "issue-497");
@@ -413,7 +417,7 @@ test("gate reports subagent available when DEVLOOPS_SUBAGENT_AVAILABLE=1 and --c
 
     writeGitStub(tempDir, { worktreeListOut, logFile });
 
-    const result = runGate(["--check-subagents"], {
+    const result = await runGate(["--check-subagents"], {
       cwd: worktreeDir,
       gitDir: tempDir,
       env: { DEVLOOPS_SUBAGENT_AVAILABLE: "1" },
@@ -427,7 +431,7 @@ test("gate reports subagent available when DEVLOOPS_SUBAGENT_AVAILABLE=1 and --c
   }
 });
 
-test("gate reports subagent unavailable when --check-subagents and env var not set", () => {
+test("gate reports subagent unavailable when --check-subagents and env var not set", async () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-subagent-unavail-"));
   try {
     const worktreeDir = path.join(tempDir, "tmp", "worktrees", "issue-497");
@@ -441,7 +445,7 @@ test("gate reports subagent unavailable when --check-subagents and env var not s
 
     writeGitStub(tempDir, { worktreeListOut, logFile });
 
-    const result = runGate(["--check-subagents"], { cwd: worktreeDir, gitDir: tempDir });
+    const result = await runGate(["--check-subagents"], { cwd: worktreeDir, gitDir: tempDir });
 
     assert.equal(result.exitCode, 0);
     const payload = JSON.parse(result.stdout);
@@ -455,7 +459,7 @@ test("gate reports subagent unavailable when --check-subagents and env var not s
 // Output contract
 // ---------------------------------------------------------------------------
 
-test("success output is valid JSON on stdout", () => {
+test("success output is valid JSON on stdout", async () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-output-ok-"));
   try {
     const worktreeDir = path.join(tempDir, "tmp", "worktrees", "issue-497");
@@ -482,7 +486,7 @@ test("success output is valid JSON on stdout", () => {
     ];
     writeFileSync(gitPath, branchAwareLines.join("\n"), { mode: 0o755 });
 
-    const result = runGate(["--expected-branch", "issue-497"], {
+    const result = await runGate(["--expected-branch", "issue-497"], {
       cwd: worktreeDir,
       gitDir: tempDir,
       env: { DEVLOOPS_SUBAGENT_AVAILABLE: "1" },
@@ -499,7 +503,7 @@ test("success output is valid JSON on stdout", () => {
   }
 });
 
-test("failure output is valid JSON on stderr with error + guidance + checks", () => {
+test("failure output is valid JSON on stderr with error + guidance + checks", async () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-output-fail-"));
   try {
     const logFile = path.join(tempDir, "git.log");
@@ -507,7 +511,7 @@ test("failure output is valid JSON on stderr with error + guidance + checks", ()
 
     writeGitStub(tempDir, { worktreeListOut, logFile });
 
-    const result = runGate([], { cwd: tempDir });
+    const result = await runGate([], { cwd: tempDir });
 
     assert.equal(result.exitCode, 1);
     assert.ok(result.stderr.length > 0, "stderr should have content");
@@ -527,10 +531,10 @@ test("failure output is valid JSON on stderr with error + guidance + checks", ()
 // --help
 // ---------------------------------------------------------------------------
 
-test("gate prints usage with --help", () => {
+test("gate prints usage with --help", async () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-help-"));
   try {
-    const result = runGate(["--help"], { cwd: tempDir });
+    const result = await runGate(["--help"], { cwd: tempDir });
     assert.equal(result.exitCode, 0);
     assert.ok(result.stdout.includes("Usage"), "stdout should contain usage text");
   } finally {
@@ -538,10 +542,10 @@ test("gate prints usage with --help", () => {
   }
 });
 
-test("gate prints usage with -h", () => {
+test("gate prints usage with -h", async () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "preflight-h-"));
   try {
-    const result = runGate(["-h"], { cwd: tempDir });
+    const result = await runGate(["-h"], { cwd: tempDir });
     assert.equal(result.exitCode, 0);
     assert.ok(result.stdout.includes("Usage"), "stdout should contain usage text");
   } finally {

--- a/test/loop/resolve-dev-loop-startup.test.mjs
+++ b/test/loop/resolve-dev-loop-startup.test.mjs
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { mkdtempSync, mkdirSync, realpathSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, realpathSync, writeFileSync, rmSync, cpSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
-import test from "node:test";
+import test, { after } from "node:test";
 import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import {
@@ -19,6 +19,27 @@ import {
 const scriptPath = path.resolve("scripts/loop/resolve-dev-loop-startup.mjs");
 
 const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
+
+// Build a throwaway git repo carrying the standard origin remote ONCE, then
+// stamp per-test copies by cloning the .git dir on disk (no git subprocess per
+// test). buildAutoResolvedInput still shells out to git to read the remote, so
+// the git-remote-detection boundary stays exercised — only the identical repo
+// setup is amortized.
+let originRepoTemplate = null;
+function stampRepoWithOrigin() {
+  if (originRepoTemplate === null) {
+    const template = mkdtempSync(path.join(os.tmpdir(), "dev-loop-origin-template-"));
+    execFileSync("git", ["init"], { cwd: template, stdio: "ignore" });
+    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/dev-loops.git"], { cwd: template, stdio: "ignore" });
+    originRepoTemplate = template;
+  }
+  const tmp = mkdtempSync(path.join(os.tmpdir(), "dev-loop-511-"));
+  cpSync(path.join(originRepoTemplate, ".git"), path.join(tmp, ".git"), { recursive: true });
+  return tmp;
+}
+after(() => {
+  if (originRepoTemplate) rmSync(originRepoTemplate, { recursive: true, force: true });
+});
 
 async function writeTempJson(tempDir, name, value) {
   const filePath = path.join(tempDir, name);
@@ -805,10 +826,8 @@ test("resolver does not block non-local_implementation strategies from main chec
 });
 
 test("buildAutoResolvedInput returns warnings array for failed detection", () => {
-  const tmp = mkdtempSync(path.join(os.tmpdir(), "dev-loop-511-"));
+  const tmp = stampRepoWithOrigin();
   try {
-    execFileSync("git", ["init"], { cwd: tmp, stdio: "ignore" });
-    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/dev-loops.git"], { cwd: tmp, stdio: "ignore" });
     const result = buildAutoResolvedInput({ issue: 999999, cwd: tmp });
     assert.equal(result.intent, "start_issue_locally");
     assert.equal(result.artifactState, "not_applicable");
@@ -824,10 +843,8 @@ test("buildAutoResolvedInput returns warnings array for failed detection", () =>
 });
 
 test("buildAutoResolvedInput sets linkedPr null when detection fails", () => {
-  const tmp = mkdtempSync(path.join(os.tmpdir(), "dev-loop-511-"));
+  const tmp = stampRepoWithOrigin();
   try {
-    execFileSync("git", ["init"], { cwd: tmp, stdio: "ignore" });
-    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/dev-loops.git"], { cwd: tmp, stdio: "ignore" });
     const result = buildAutoResolvedInput({ issue: 999999, cwd: tmp });
     assert.equal(result.currentState.target.linkedPr, null);
     assert.equal(result.issueLinkageResolution, "resolved_no_open_pr");
@@ -837,10 +854,8 @@ test("buildAutoResolvedInput sets linkedPr null when detection fails", () => {
 });
 
 test("buildAutoResolvedInput for PR returns pr_followup_start", () => {
-  const tmp = mkdtempSync(path.join(os.tmpdir(), "dev-loop-511-"));
+  const tmp = stampRepoWithOrigin();
   try {
-    execFileSync("git", ["init"], { cwd: tmp, stdio: "ignore" });
-    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/dev-loops.git"], { cwd: tmp, stdio: "ignore" });
     const result = buildAutoResolvedInput({ pr: 999999, cwd: tmp });
     assert.equal(result.intent, "continue_on_pr");
     assert.equal(result.loopState, "pr_followup_start");
@@ -852,10 +867,8 @@ test("buildAutoResolvedInput for PR returns pr_followup_start", () => {
 });
 
 test("buildAutoResolvedInput returns valid targetPreference", () => {
-  const tmp = mkdtempSync(path.join(os.tmpdir(), "dev-loop-511-"));
+  const tmp = stampRepoWithOrigin();
   try {
-    execFileSync("git", ["init"], { cwd: tmp, stdio: "ignore" });
-    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/dev-loops.git"], { cwd: tmp, stdio: "ignore" });
     const result = buildAutoResolvedInput({ issue: 999999, cwd: tmp });
     assert.ok(
       result.targetPreference === "prefer_local" || result.targetPreference === "prefer_github_first",
@@ -866,10 +879,8 @@ test("buildAutoResolvedInput returns valid targetPreference", () => {
 });
 
 test("buildAutoResolvedInput with local-first tracker source keeps issue-backed startup state", () => {
-  const tmp = mkdtempSync(path.join(os.tmpdir(), "dev-loop-511-"));
+  const tmp = stampRepoWithOrigin();
   try {
-    execFileSync("git", ["init"], { cwd: tmp, stdio: "ignore" });
-    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/dev-loops.git"], { cwd: tmp, stdio: "ignore" });
     const result = buildAutoResolvedInput({
       issue: 999999,
       cwd: tmp,
@@ -885,10 +896,8 @@ test("buildAutoResolvedInput with local-first tracker source keeps issue-backed 
 });
 
 test("buildAutoResolvedInput with local-first phase-doc source uses local_phase startup state", () => {
-  const tmp = mkdtempSync(path.join(os.tmpdir(), "dev-loop-511-"));
+  const tmp = stampRepoWithOrigin();
   try {
-    execFileSync("git", ["init"], { cwd: tmp, stdio: "ignore" });
-    execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/dev-loops.git"], { cwd: tmp, stdio: "ignore" });
     const result = buildAutoResolvedInput({
       issue: 999999,
       cwd: tmp,


### PR DESCRIPTION
## Summary

Speeds up the worst real-git-repo `test:scripts` files (the "new floor" after #1272) by converting them to the faster technique that fits each — module-seam (`makeGhMock`), in-process CLI, cheap shell stubs, and a copy-once git fixture. Semantics preserved: every test still asserts the same behavior, and genuine git-boundary/CLI-error smokes keep their real spawns.

## Scope and context

In scope: perf conversion of 4 profiled offenders + the injectable `runChild` seam threaded through `conductor-monitor`/`_loop-pr-aggregation` to enable in-process gh mocking. Per-file results (best-of-3, `node --test <file>`): conductor-monitor 11476ms→2512ms (module-seam — the largest file, the named pole), pre-flight-gate 4484→3465 (in-process `runCli`), pre-commit-branch-guard 4273→3202 (shell git-stub). The clean, defensible wall wins are these three. resolve-dev-loop-startup 8279→8181 is **noise-level on wall time** (~1.2%, same run-to-run band that makes AC3 NOT MET); its real change is structural — collapsing 6 identical `git init` setups to one stamped-once fixture (fewer real git spawns), not a wall win. Out of scope: files already optimized by #1272 (copilot-pr-handoff/request-copilot-review/upsert-checkpoint-verdict), and genuine git-boundary/CLI-error smokes (deliberately kept real).

## Honest result (headline caveat)

The issue's premise was a serial real-git wall floor. In practice `node --test` runs the 136 `test:scripts` files **in parallel** — the suite is throughput-bound, so per-file CPU savings translate sub-linearly to wall time. Measured suite wall: ~66s → ~63s (edge of run-to-run noise). The large, clean, defensible win is **per-file** (conductor 11.5s→2.5s). Moving the suite wall materially further would need a broad CPU-reduction campaign across many files, not just the git ones — noted for a potential follow-up rather than overclaimed here.

## Acceptance criteria

Honest per-criterion status of issue #1277's ACs (only met ones checked off on the issue at merge):
- **AC1 — heaviest real-git files addressed, per-file before/after recorded: MET** — the wall-bound heavy files are genuinely faster (conductor 11476→2512ms, pre-flight 4484→3465, pre-commit 4273→3202); resolve-dev-loop-startup (also among the heaviest) was addressed structurally (6 identical git-init setups → one stamped-once fixture, fewer real git spawns) with wall time noise-level. All per-file numbers recorded above.
- **AC2 — minimal real-git-boundary smokes retained, no coverage lost: MET** (git-boundary + CLI-error smokes deliberately kept real).
- **AC3 — `test:scripts` wall meaningfully reduced below ~63s: NOT MET** — the issue's serial-floor premise was incorrect; `node --test` runs the 136 files in parallel (throughput-bound), so per-file CPU savings move the wall only ~66s→~63s (noise-level). A throughput-aware suite-wall reduction is tracked as a separate follow-up. AC3's checkbox stays UNCHECKED at merge.

## Definition of done

The worst real-git test:scripts files are faster where wall time was the bottleneck (per-file, quantified; three clear wins, one structural/noise-level), no test is weakened or turned into a no-op, `test:scripts` green.

## Non-goals

No coverage/assertion changes. No mocking-away of the git-boundary behavior a git-boundary test exists to verify. No new dependency.

## Validation

- `npm run test:scripts` (2568 pass, 0 fail); touched files + dependents (run-conductor-cycle, conductor-routing) 223 pass.
- Per-file before/after timings above (best-of-3 warm).
- Full gate uses `npm run verify`.

Closes #1277


