### PR TITLE
fix(queue): signal moved:false when add-queue-item leaves an already-present item in a different column (#1306)

### DIFF
--- a/scripts/projects/add-queue-item.mjs
+++ b/scripts/projects/add-queue-item.mjs
@@ -36,6 +36,9 @@ Options:
 Output (stdout):
   JSON: { ok: true, item: { itemId, issueNumber, prNumber, status, alreadyPresent },
           refinement? }
+  When already present in a DIFFERENT column than requested, item also carries
+  { moved: false, currentColumn, requestedColumn } — the add stays an idempotent
+  no-op (use "queue move" to relocate), but signals the ignored column request.
   refinement (present only when the pickup-column gate ran): either
     { refined: true } or, on a headless --auto divert,
     { refined: false, diverted: true, requestedColumn, parkedColumn, reason, missing }.
@@ -492,6 +495,11 @@ async function main(args, { env = process.env, runChild, cwd = process.cwd() } =
       if (existing.content.__typename === "Issue") issueNumber = existing.content.number;
       else prNumber = existing.content.number;
     }
+    // Stay an idempotent no-op (never move an already-present item — that is
+    // `queue move`'s job), but when the requested column differs from where the
+    // item actually sits, surface an explicit moved:false signal so callers
+    // detect the ignored request instead of silently assuming placement (#1306).
+    const differentColumn = existingStatus !== null && existingStatus !== targetStatus;
     return {
       ok: true,
       item: {
@@ -500,6 +508,9 @@ async function main(args, { env = process.env, runChild, cwd = process.cwd() } =
         prNumber,
         status: existingStatus,
         alreadyPresent: true,
+        ...(differentColumn
+          ? { moved: false, currentColumn: existingStatus, requestedColumn: targetStatus }
+          : {}),
       },
     };
   }

--- a/test/projects/add-queue-item.test.mjs
+++ b/test/projects/add-queue-item.test.mjs
@@ -336,6 +336,48 @@ describe("add-queue-item", () => {
       assert.equal(result.item.alreadyPresent, true);
     });
 
+    it("signals moved:false when already present in a DIFFERENT column (#1306)", async () => {
+      // Item sits in "Backlog" but the caller requests "Next Up" — stay a no-op
+      // (no resolve/add/update calls) yet surface the ignored column request.
+      const existingItem = makeItemNode("PVTI_existing", makeContent("Issue", 10), "Backlog");
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([STATUS_FIELD]) },
+        { payload: getItemsByContentResponse([existingItem]) },
+        // No resolve, add, or update calls expected — still an idempotent no-op.
+      ];
+      const result = await main(
+        { repo: "mfittko/dev-loops", project: "1", item: 10, column: "Next Up" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.item.alreadyPresent, true);
+      assert.equal(result.item.status, "Backlog");
+      assert.equal(result.item.moved, false);
+      assert.equal(result.item.currentColumn, "Backlog");
+      assert.equal(result.item.requestedColumn, "Next Up");
+    });
+
+    it("omits the moved signal when already present in the SAME column", async () => {
+      const existingItem = makeItemNode("PVTI_existing", makeContent("Issue", 10), "Backlog");
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([STATUS_FIELD]) },
+        { payload: getItemsByContentResponse([existingItem]) },
+      ];
+      const result = await main(
+        { repo: "mfittko/dev-loops", project: "1", item: 10, column: "Backlog" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.item.alreadyPresent, true);
+      assert.equal(result.item.status, "Backlog");
+      assert.equal("moved" in result.item, false);
+      assert.equal("currentColumn" in result.item, false);
+      assert.equal("requestedColumn" in result.item, false);
+    });
+
     it("filters already-present check by repo", async () => {
       // Item from different repo should not match
       const otherRepoContent = { __typename: "Issue", number: 10, repository: { nameWithOwner: "other/repo" } };

--- a/test/projects/add-queue-item.test.mjs
+++ b/test/projects/add-queue-item.test.mjs
@@ -378,6 +378,26 @@ describe("add-queue-item", () => {
       assert.equal("requestedColumn" in result.item, false);
     });
 
+    it("omits the moved signal when the already-present item has no known Status", async () => {
+      // Unknown/absent Status must not emit a misleading moved:false + currentColumn:null.
+      const existingItem = makeItemNode("PVTI_existing", makeContent("Issue", 10), null);
+      const responses = [
+        { payload: userPayload() },
+        { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+        { payload: getFieldsResponse([STATUS_FIELD]) },
+        { payload: getItemsByContentResponse([existingItem]) },
+      ];
+      const result = await main(
+        { repo: "mfittko/dev-loops", project: "1", item: 10, column: "Next Up" },
+        { env: {}, runChild: mockRunChild(responses) },
+      );
+      assert.equal(result.item.alreadyPresent, true);
+      assert.equal(result.item.status, null);
+      assert.equal("moved" in result.item, false);
+      assert.equal("currentColumn" in result.item, false);
+      assert.equal("requestedColumn" in result.item, false);
+    });
+
     it("filters already-present check by repo", async () => {
       // Item from different repo should not match
       const otherRepoContent = { __typename: "Issue", number: 10, repository: { nameWithOwner: "other/repo" } };


### PR DESCRIPTION
## Summary

Fixes the silent no-op in `add-queue-item.mjs`: `--item <n> --next-up` on an item already on the board in a DIFFERENT column returned `alreadyPresent:true` without moving it and with no signal the requested column was ignored — the footgun behind #1258's re-enqueue step.

## Scope and context

`scripts/projects/add-queue-item.mjs`: in the `alreadyPresent` branch, when the existing column differs from the requested column, the returned `item` now carries `moved:false, currentColumn:<existing>, requestedColumn:<requested>`. Same-column (and unknown-status) stays an unchanged idempotent no-op (the three keys are omitted). Chosen over gate-and-move to preserve the long-standing "`queue add` is idempotent; `queue move` moves" contract (the existing no-op tests pin it). The signal lets a caller detect the ignored placement and fall back to `queue move`; the dev-loop SKILL's parked-item promotion already uses `queue move` directly (from #1258), so it doesn't hit the no-op — this closes the silent-no-op footgun for every other caller that assumes `--next-up` places the item.

## Acceptance criteria

Satisfies issue #1306's ACs (checked off at merge):
- `add-queue-item --<column>` on an already-present item in a different column no longer silently ignores the requested column — it returns the explicit `moved:false, currentColumn, requestedColumn` signal (option b).
- Same-column already-present stays an idempotent no-op.
- A test covers the already-present-different-column case.

## Definition of done

The no-move is detectable via an explicit signal; same-column no-op unchanged; USAGE doc updated; tests green.

## Non-goals

Changing the idempotent same-column no-op. Making `queue add` guarantee pickup placement for already-present items (that's the larger option-a change to the enqueue contract — its own decision). Replacing `queue move`.

## Validation

- `npm run test:scripts` (add-queue-item + create-pr-board tests; 2588 pass) — adds "signals moved:false when already present in a DIFFERENT column" + "omits the moved signal when already present in the SAME column".
- Full gate uses `npm run verify`.

Closes #1306
