### PR TITLE
feat(loop): ui_review Stage 2 — computed a11y facts via axe-core (axe.json) (#1298)

### DIFF
--- a/.claude/skills/dev-loop/templates/ui-vision-review.md
+++ b/.claude/skills/dev-loop/templates/ui-vision-review.md
@@ -14,12 +14,13 @@ You are a vision-capable UI reviewer (model: `gpt-5.4`) reviewing deterministic 
   - `screenshotPath` (must point to `screenshot.png`)
   - `statePath` (must point to `state.json`)
   - `snapshotPath` (must point to `snapshot.json`)
+  - `axePath` (must point to `axe.json`)
 
 ## Review policy
 
 1. Fail closed when required inputs are missing, ambiguous, or unreadable.
-2. Ground every finding in one or more `screenshotPath` and `statePath` references.
-3. Evaluate layout, hierarchy, spacing, clipping, overlap, contrast, callouts/highlighting, and state-transition clarity against the acceptance criteria and review brief.
+2. Ground every finding in one or more `screenshotPath` and `statePath` references. Ground accessibility findings in `axePath`.
+3. Evaluate layout, hierarchy, spacing, clipping, overlap, callouts/highlighting, and state-transition clarity against the acceptance criteria and review brief. Do **not** eyeball computable accessibility facts (color contrast, missing accessible names/roles, and similar). Those are asserted from `axe.json` evidence, not judged from pixels: cite the axe rule `id`/`impact` and map its impact to finding severity (`critical`/`serious` → `high`, `moderate` → `medium`, `minor` → `low`; unranked/unknown → `medium`).
 4. Return only deterministic findings; do not invent evidence that is not visible in artifacts.
 
 ## Required output format
@@ -42,7 +43,9 @@ Return strict JSON with this shape (example uses concrete values):
       "stateName": "named state label",
       "evidence": {
         "screenshotPath": "test-results/ui-smoke/<sliceId>/named-states/<state-slug>/screenshot.png",
-        "statePath": "test-results/ui-smoke/<sliceId>/named-states/<state-slug>/state.json"
+        "statePath": "test-results/ui-smoke/<sliceId>/named-states/<state-slug>/state.json",
+        "axePath": "test-results/ui-smoke/<sliceId>/named-states/<state-slug>/axe.json",
+        "axeRuleId": "color-contrast"
       },
       "problem": "what is visually wrong or unclear",
       "suggestedFix": "specific corrective action"

--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -59,7 +59,7 @@ one headless WebKit context, authenticates as the change's target role through a
 project-provided dev-login recipe, dismisses config-declared interstitials once
 per context, then walks the selected flows — rendering each page and exercising
 its declared create/edit/reorder/upload/toggle interactions — capturing a step
-screenshot + sibling `state.json` + `snapshot.json` per step via `captureNamedUiState`. It fails
+screenshot + sibling `state.json` + `snapshot.json` + `axe.json` per step via `captureNamedUiState`. It fails
 closed to a stated stop reason when it cannot authenticate, and drives nothing.
 
 Throughout the walk, `response`, `requestfailed`, and `pageerror` listeners run

--- a/docs/ui-artifact-contract.md
+++ b/docs/ui-artifact-contract.md
@@ -46,11 +46,13 @@ For this level, a state artifact bundle is required:
 - `screenshot.png`
 - `state.json`
 - `snapshot.json`
+- `axe.json`
 
-Why all three are required:
+Why all four are required:
 - the screenshot shows what rendered
 - `state.json` explains which named state it is, which slice produced it, and the minimum metadata needed for review or follow-up automation
 - `snapshot.json` is the semantic accessibility tree captured for the same state — the structured counterpart to the pixels, so a reviewer (or later automation) can reason about roles/names, not just what a screenshot happens to show
+- `axe.json` is the computed accessibility facts (axe-core results) for the same state, so contrast and other computable a11y issues are asserted from a tool, not eyeballed from pixels
 
 ### 3. CI-required artifacts
 
@@ -70,6 +72,7 @@ For a slice id of `<sliceId>` and a state slug of `<state-slug>`, the harness pa
 - screenshot artifact: `test-results/ui-smoke/<sliceId>/named-states/<state-slug>/screenshot.png`
 - structured state artifact: `test-results/ui-smoke/<sliceId>/named-states/<state-slug>/state.json`
 - semantic snapshot artifact: `test-results/ui-smoke/<sliceId>/named-states/<state-slug>/snapshot.json`
+- computed a11y artifact: `test-results/ui-smoke/<sliceId>/named-states/<state-slug>/axe.json`
 - HTML report root: `playwright-report/ui-smoke/<sliceId>/`
 
 The harness currently normalizes:
@@ -96,6 +99,8 @@ The current reusable harness emits `state.json` with this minimum reviewer-facin
 - `artifacts.state.relativePath`
 - `artifacts.snapshot.fileName`
 - `artifacts.snapshot.relativePath`
+- `artifacts.axe.fileName`
+- `artifacts.axe.relativePath`
 - `metadata.fixture`
 - `metadata.route`
 - `metadata.reviewHint`
@@ -112,6 +117,29 @@ is unavailable — still emitted, never skipped). It is
 emitted for every named state at the deterministic path above, and `state.json`
 references it under `artifacts.snapshot`.
 
+## `axe.json` contract
+
+`axe.json` is the computed accessibility facts for the same named state: the raw
+[axe-core](https://github.com/dequelabs/axe-core) results as produced by
+`@axe-core/playwright` running against the live page. Its body is the raw axe
+results JSON (an object with `violations`/`passes`/`incomplete`/`inapplicable`),
+or JSON `null` when axe could not run — the page context is unavailable, or the
+runner is absent in the current browser build. Like `snapshot.json`, it is
+best-effort in content but always emitted for every named state (never skipped)
+at the deterministic path above, and `state.json` references it under
+`artifacts.axe`.
+
+`axe.json` exists so computable accessibility facts (color contrast, missing
+accessible names/roles, and similar) are asserted from a tool rather than judged
+from pixels by a reviewer. A reviewer maps each axe violation's `impact` to a
+finding severity with this fixed mapping:
+
+- `critical` → `high`
+- `serious` → `high`
+- `moderate` → `medium`
+- `minor` → `low`
+- unranked / unknown impact → `medium` (conservative default)
+
 ## When screenshot alone is acceptable
 
 Screenshot alone is acceptable only when the artifact is:
@@ -122,7 +150,7 @@ Screenshot alone is acceptable only when the artifact is:
 
 ## When the state artifact bundle is required
 
-The `screenshot.png` + `state.json` + `snapshot.json` bundle is required when:
+The `screenshot.png` + `state.json` + `snapshot.json` + `axe.json` bundle is required when:
 - the artifact is part of the reusable deterministic smoke harness
 - the slice is handing named UI states to a later reviewer loop
 - the artifact needs to map back to a deterministic local run without guesswork
@@ -145,6 +173,7 @@ When a registered artifact's suite is required:
 - missing or malformed `state.json` is a validation failure
 - missing `screenshot.png` is a validation failure
 - missing or malformed `snapshot.json` is a validation failure
+- missing or malformed `axe.json` is a validation failure
 - mismatched state naming/path conventions are a validation failure
 - the PR should fail closed rather than silently downgrade to screenshot-only review
 

--- a/docs/ui-artifact-contract.md
+++ b/docs/ui-artifact-contract.md
@@ -81,7 +81,7 @@ The harness currently normalizes:
 
 ## Minimum `state.json` contract
 
-The current reusable harness emits `state.json` with this minimum reviewer-facing metadata (current `schemaVersion`: `2`):
+The current reusable harness emits `state.json` with this minimum reviewer-facing metadata (current `schemaVersion`: `3`):
 - `schemaVersion`
 - `artifactType`
 - `validationLevel`

--- a/docs/ui-designer-review-loop.md
+++ b/docs/ui-designer-review-loop.md
@@ -41,8 +41,28 @@ The loop requires all of the following inputs before it may run:
      - `screenshotPath`
      - `statePath`
      - `snapshotPath`
+     - `axePath`
 
 If any required part of this bundle is missing, incomplete, or ambiguous, the loop fails closed instead of guessing.
+
+## Accessibility findings come from axe, not pixels
+
+Computable accessibility facts — color contrast, missing accessible names/roles,
+and similar — are **asserted from `axe.json`**, not judged from the screenshot by
+the reviewer. Each named state carries an `axe.json` (raw `@axe-core/playwright`
+results, or JSON `null` when axe could not run). A reviewer grounds every
+accessibility finding in an axe violation and maps its `impact` to a finding
+severity with a fixed mapping:
+
+- `critical` → `high`
+- `serious` → `high`
+- `moderate` → `medium`
+- `minor` → `low`
+- unranked / unknown impact → `medium`
+
+This mapping is codified and tested in `scripts/loop/ui-designer-review-contract.mjs`
+(`mapAxeImpactToFindingSeverity`); the vision template no longer instructs the
+reviewer to eyeball contrast.
 
 ## Review modes behind `dev-loop`
 
@@ -106,10 +126,11 @@ The loop fails closed when:
 - the review brief is missing or empty
 - the artifact bundle is missing
 - the artifact bundle has no named states
-- a named state lacks `screenshotPath`, `statePath`, or `snapshotPath`
+- a named state lacks `screenshotPath`, `statePath`, `snapshotPath`, or `axePath`
 - vision mode is requested but a named state screenshot path does not end with `screenshot.png`
 - vision mode is requested but a named-state `statePath` does not end with `state.json`
 - vision mode is requested but a named-state `snapshotPath` does not end with `snapshot.json`
+- vision mode is requested but a named-state `axePath` does not end with `axe.json`
 - the work is not actually a UI slice \(the loop returns a skip outcome rather than failing closed\)
 - an unsupported `uiReviewMode` value (anything other than `designer` or `vision`) fails closed with `blocked_unsupported_review_mode`
 

--- a/docs/ui-review-recipe-contract.md
+++ b/docs/ui-review-recipe-contract.md
@@ -38,7 +38,7 @@ drive your app.
    boots the app and polls an HTTP readiness probe.
 2. **Auth + drive** — launches one headless WebKit context, authenticates
    through your dev-login recipe, dismisses declared interstitials once, then
-   walks the changed UI flows, capturing a screenshot + `state.json` + `snapshot.json` per step.
+   walks the changed UI flows, capturing a screenshot + `state.json` + `snapshot.json` + `axe.json` per step.
 3. **Diagnose** — maps each captured failure to a source line and then to a PR
    diff line so a finding can anchor on a real changed line.
 4. **Report** — posts a head-pinned **pending** PR review and produces a

--- a/docs/ui-smoke-harness.md
+++ b/docs/ui-smoke-harness.md
@@ -17,7 +17,7 @@ The harness is intentionally small:
 - Playwright
 - WebKit only
 - fixture-backed scenarios
-- named screenshot/state/snapshot artifact capture
+- named screenshot/state/snapshot/axe artifact capture
 - deterministic local artifact/report locations
 
 It is not a general E2E framework and it does not make browser validation mandatory for non-UI slices.
@@ -72,6 +72,7 @@ Each named-state directory currently contains:
 - `screenshot.png`
 - `state.json`
 - `snapshot.json`
+- `axe.json`
 
 These paths are the local proving ground for the reusable artifact contract in [UI Artifact Contract](./ui-artifact-contract.md) and for later designer-review-loop work.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "dev-loops": "cli/index.mjs"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.10.0",
         "@playwright/test": "^1.60.0",
         "npm-run-all2": "^9.0.2",
         "tsx": "^4.22.0"
@@ -28,6 +29,19 @@
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": "*",
         "@earendil-works/pi-tui": "*"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@dev-loops/core": {
@@ -2468,6 +2482,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@earendil-works/pi-tui": "*"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.10.0",
     "@playwright/test": "^1.60.0",
     "npm-run-all2": "^9.0.2",
     "tsx": "^4.22.0"

--- a/scripts/loop/ui-designer-review-contract.mjs
+++ b/scripts/loop/ui-designer-review-contract.mjs
@@ -1,3 +1,20 @@
+// axe-core impact → review finding severity. Computable a11y facts (contrast,
+// missing names/roles, etc.) come from axe.json evidence, not model judgment;
+// this pins how an axe impact rank becomes a finding severity. A null/unknown
+// impact (e.g. an `incomplete` result axe could not rank) maps to `medium` on
+// purpose — conservative, so an unranked issue is not silently minimized.
+const AXE_IMPACT_TO_FINDING_SEVERITY = {
+  critical: 'high',
+  serious: 'high',
+  moderate: 'medium',
+  minor: 'low',
+};
+
+export function mapAxeImpactToFindingSeverity(impact) {
+  const key = typeof impact === 'string' ? impact.trim().toLowerCase() : '';
+  return AXE_IMPACT_TO_FINDING_SEVERITY[key] ?? 'medium';
+}
+
 export function validateUiDesignerReviewInput(input = {}) {
   if (input.workType !== 'ui' || input.uiReviewRequested !== true) {
     return {
@@ -55,6 +72,9 @@ export function validateUiDesignerReviewInput(input = {}) {
     if (typeof state.snapshotPath !== 'string' || state.snapshotPath.trim().length === 0) {
       incompleteArtifacts.push(`artifactBundle.namedStates[${index}].snapshotPath`);
     }
+    if (typeof state.axePath !== 'string' || state.axePath.trim().length === 0) {
+      incompleteArtifacts.push(`artifactBundle.namedStates[${index}].axePath`);
+    }
     if (reviewMode === 'vision' && typeof state.screenshotPath === 'string' && state.screenshotPath.trim().length > 0 && !state.screenshotPath.trim().endsWith('screenshot.png')) {
       incompleteArtifacts.push(`artifactBundle.namedStates[${index}].screenshotPath`);
     }
@@ -63,6 +83,9 @@ export function validateUiDesignerReviewInput(input = {}) {
     }
     if (reviewMode === 'vision' && typeof state.snapshotPath === 'string' && state.snapshotPath.trim().length > 0 && !state.snapshotPath.trim().endsWith('snapshot.json')) {
       incompleteArtifacts.push(`artifactBundle.namedStates[${index}].snapshotPath`);
+    }
+    if (reviewMode === 'vision' && typeof state.axePath === 'string' && state.axePath.trim().length > 0 && !state.axePath.trim().endsWith('axe.json')) {
+      incompleteArtifacts.push(`artifactBundle.namedStates[${index}].axePath`);
     }
   });
   if (incompleteArtifacts.length > 0) {

--- a/scripts/loop/ui-review-drive.mjs
+++ b/scripts/loop/ui-review-drive.mjs
@@ -5,7 +5,7 @@
  * Launches one headless WebKit context, authenticates as the change's target
  * role via the project's dev-login recipe, dismisses config-declared
  * interstitials once, then walks the changed flows against the arbitrary
- * running-app URL from Stage 1 — capturing a step screenshot + state.json + snapshot.json per
+ * running-app URL from Stage 1 — capturing a step screenshot + state.json + snapshot.json + axe.json per
  * step. Response/requestfailed/pageerror listeners plus a server-log tail run
  * throughout so a swallowed error response is still recorded.
  *
@@ -34,7 +34,7 @@ capturing step screenshots + error-response/pageerror/server-log failures (Stage
 Required:
   --repo-root <p>      Absolute path to the (provisioned) worktree carrying the .devloops recipe.
   --app-url <url>      The running-app URL handed off by Stage 1.
-  --output-dir <p>     Directory for the ordered step screenshots + state.json + snapshot.json artifacts.
+  --output-dir <p>     Directory for the ordered step screenshots + state.json + snapshot.json + axe.json artifacts.
 Optional:
   --changed-path <p>   A changed file path (repeatable); drives the changed-flow selection heuristic.
   -h, --help           Show this help.
@@ -262,7 +262,7 @@ function makeRunStep({ page, outputDir }) {
       outputDir,
       metadata: { fixture: null, route: step.path ?? null, reviewHint: `Drive step "${stateName}" for the "${flow.name}" flow.` },
     });
-    return { ok: true, screenshotPath: paths.screenshotPath, statePath: paths.statePath, snapshotPath: paths.snapshotPath };
+    return { ok: true, screenshotPath: paths.screenshotPath, statePath: paths.statePath, snapshotPath: paths.snapshotPath, axePath: paths.axePath };
   };
 }
 

--- a/skills/dev-loop/templates/ui-vision-review.md
+++ b/skills/dev-loop/templates/ui-vision-review.md
@@ -14,12 +14,13 @@ You are a vision-capable UI reviewer (model: `gpt-5.4`) reviewing deterministic 
   - `screenshotPath` (must point to `screenshot.png`)
   - `statePath` (must point to `state.json`)
   - `snapshotPath` (must point to `snapshot.json`)
+  - `axePath` (must point to `axe.json`)
 
 ## Review policy
 
 1. Fail closed when required inputs are missing, ambiguous, or unreadable.
-2. Ground every finding in one or more `screenshotPath` and `statePath` references.
-3. Evaluate layout, hierarchy, spacing, clipping, overlap, contrast, callouts/highlighting, and state-transition clarity against the acceptance criteria and review brief.
+2. Ground every finding in one or more `screenshotPath` and `statePath` references. Ground accessibility findings in `axePath`.
+3. Evaluate layout, hierarchy, spacing, clipping, overlap, callouts/highlighting, and state-transition clarity against the acceptance criteria and review brief. Do **not** eyeball computable accessibility facts (color contrast, missing accessible names/roles, and similar). Those are asserted from `axe.json` evidence, not judged from pixels: cite the axe rule `id`/`impact` and map its impact to finding severity (`critical`/`serious` → `high`, `moderate` → `medium`, `minor` → `low`; unranked/unknown → `medium`).
 4. Return only deterministic findings; do not invent evidence that is not visible in artifacts.
 
 ## Required output format
@@ -42,7 +43,9 @@ Return strict JSON with this shape (example uses concrete values):
       "stateName": "named state label",
       "evidence": {
         "screenshotPath": "test-results/ui-smoke/<sliceId>/named-states/<state-slug>/screenshot.png",
-        "statePath": "test-results/ui-smoke/<sliceId>/named-states/<state-slug>/state.json"
+        "statePath": "test-results/ui-smoke/<sliceId>/named-states/<state-slug>/state.json",
+        "axePath": "test-results/ui-smoke/<sliceId>/named-states/<state-slug>/axe.json",
+        "axeRuleId": "color-contrast"
       },
       "problem": "what is visually wrong or unclear",
       "suggestedFix": "specific corrective action"

--- a/skills/ui-review/SKILL.md
+++ b/skills/ui-review/SKILL.md
@@ -61,7 +61,7 @@ one headless WebKit context, authenticates as the change's target role through a
 project-provided dev-login recipe, dismisses config-declared interstitials once
 per context, then walks the selected flows — rendering each page and exercising
 its declared create/edit/reorder/upload/toggle interactions — capturing a step
-screenshot + sibling `state.json` + `snapshot.json` per step via `captureNamedUiState`. It fails
+screenshot + sibling `state.json` + `snapshot.json` + `axe.json` per step via `captureNamedUiState`. It fails
 closed to a stated stop reason when it cannot authenticate, and drives nothing.
 
 Throughout the walk, `response`, `requestfailed`, and `pageerror` listeners run

--- a/test/contracts/ui-artifact-contract.test.mjs
+++ b/test/contracts/ui-artifact-contract.test.mjs
@@ -19,6 +19,8 @@ test('ui artifact contract doc defines named-state artifacts and auto-scoped CI 
   assert.match(doc, /screenshot\.png/i);
   assert.match(doc, /state\.json/i);
   assert.match(doc, /snapshot\.json/i);
+  assert.match(doc, /axe\.json/i);
+  assert.match(doc, /axe-core/i);
   assert.match(doc, /test-results\/ui-smoke\/<sliceId>\/named-states\/<state-slug>/i);
   assert.match(doc, /screenshot alone is acceptable/i);
   assert.match(doc, /state artifact bundle is required/i);

--- a/test/contracts/ui-designer-review-loop-contract.test.mjs
+++ b/test/contracts/ui-designer-review-loop-contract.test.mjs
@@ -28,6 +28,9 @@ test('designer review loop doc remains the canonical bounded UI review handoff c
   assert.match(doc, /uiReviewMode: vision/i);
   assert.match(doc, /ready_for_vision_review/i);
   assert.match(doc, /skills\/dev-loop\/templates\/ui-vision-review\.md/i);
+  // Accessibility findings are asserted from axe evidence, not eyeballed.
+  assert.match(doc, /axe\.json/i);
+  assert.match(doc, /mapAxeImpactToFindingSeverity/);
 
   await assert.rejects(
     stat(fromRepoRoot('skills/dev-loop/templates/ui-designer-review.md')),
@@ -40,6 +43,9 @@ test('designer review loop doc remains the canonical bounded UI review handoff c
   assert.match(visionTemplate, /continue_ui_fix_loop/i);
   assert.match(visionTemplate, /ui_review_satisfied/i);
   assert.match(visionTemplate, /blocked_needs_human_decision/i);
+  // Computable a11y facts come from axe.json, not pixel judgment.
+  assert.match(visionTemplate, /axe\.json/i);
+  assert.match(visionTemplate, /Do \*\*not\*\* eyeball computable accessibility facts/i);
   assert.match(indexDoc, /ui-designer-review-loop\.md/i);
   assert.match(localImplementationSkill, /\.\.\/\.\.\/docs\/ui-designer-review-loop\.md/i);
 });

--- a/test/contracts/ui-smoke-harness-contract.test.mjs
+++ b/test/contracts/ui-smoke-harness-contract.test.mjs
@@ -17,7 +17,7 @@ test('ui smoke harness doc defines the bounded reusable local Playwright/WebKit 
   assert.match(doc, /Playwright/i);
   assert.match(doc, /WebKit only/i);
   assert.match(doc, /fixture-backed/i);
-  assert.match(doc, /named screenshot\/state\/snapshot artifact capture/i);
+  assert.match(doc, /named screenshot\/state\/snapshot\/axe artifact capture/i);
   assert.match(doc, /test-results\/ui-smoke\/inspect-run-viewer/i);
   assert.match(doc, /playwright-report\/ui-smoke\/inspect-run-viewer/i);
   assert.match(doc, /ui-artifact-contract\.md/i);

--- a/test/loop/ui-designer-review-contract.test.mjs
+++ b/test/loop/ui-designer-review-contract.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { validateUiDesignerReviewInput } from '../../scripts/loop/ui-designer-review-contract.mjs';
+import { mapAxeImpactToFindingSeverity, validateUiDesignerReviewInput } from '../../scripts/loop/ui-designer-review-contract.mjs';
 
 test('validateUiDesignerReviewInput skips non-UI work instead of triggering the designer loop', () => {
   const result = validateUiDesignerReviewInput({
@@ -51,6 +51,7 @@ test('validateUiDesignerReviewInput rejects incomplete named-state artifacts', (
           stateName: 'Current PR dashboard',
           screenshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/screenshot.png',
           snapshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/snapshot.json',
+          axePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/axe.json',
         },
       ],
     },
@@ -76,6 +77,7 @@ test('validateUiDesignerReviewInput accepts the artifact bundle from the reusabl
           screenshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/screenshot.png',
           statePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/state.json',
           snapshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/snapshot.json',
+          axePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/axe.json',
         },
       ],
     },
@@ -105,6 +107,7 @@ test('validateUiDesignerReviewInput routes opted-in UI slices to vision review',
           screenshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/screenshot.png',
           statePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/state.json',
           snapshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/snapshot.json',
+          axePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/axe.json',
         },
       ],
     },
@@ -133,6 +136,7 @@ test('validateUiDesignerReviewInput fails closed when vision review lacks screen
           screenshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/preview.jpg',
           statePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/state.json',
           snapshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/snapshot.json',
+          axePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/axe.json',
         },
       ],
     },
@@ -173,6 +177,7 @@ test('validateUiDesignerReviewInput fails closed when vision review lacks state.
           screenshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/screenshot.png',
           statePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/meta.txt',
           snapshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/snapshot.json',
+          axePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/axe.json',
         },
       ],
     },
@@ -196,6 +201,7 @@ test('validateUiDesignerReviewInput fails closed when a named state is missing s
           stateName: 'Current PR dashboard',
           screenshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/screenshot.png',
           statePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/state.json',
+          axePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/axe.json',
         },
       ],
     },
@@ -221,6 +227,7 @@ test('validateUiDesignerReviewInput fails closed when vision review has a malfor
           screenshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/screenshot.png',
           statePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/state.json',
           snapshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/a11y.txt',
+          axePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/axe.json',
         },
       ],
     },
@@ -229,4 +236,70 @@ test('validateUiDesignerReviewInput fails closed when vision review has a malfor
   assert.equal(result.ok, false);
   assert.equal(result.status, 'blocked_incomplete_artifact_bundle');
   assert.deepEqual(result.missing, ['artifactBundle.namedStates[0].snapshotPath']);
+});
+
+test('validateUiDesignerReviewInput fails closed when a named state is missing axe.json', () => {
+  const result = validateUiDesignerReviewInput({
+    workType: 'ui',
+    uiReviewRequested: true,
+    acceptanceCriteria: ['named dashboard state renders'],
+    reviewBrief: 'Check layout and visual hierarchy.',
+    artifactBundle: {
+      sliceId: 'inspect-run-viewer',
+      namedStates: [
+        {
+          stateName: 'Current PR dashboard',
+          screenshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/screenshot.png',
+          statePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/state.json',
+          snapshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/snapshot.json',
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 'blocked_incomplete_artifact_bundle');
+  assert.deepEqual(result.missing, ['artifactBundle.namedStates[0].axePath']);
+});
+
+test('validateUiDesignerReviewInput fails closed when vision review has a malformed axe path', () => {
+  const result = validateUiDesignerReviewInput({
+    workType: 'ui',
+    uiReviewRequested: true,
+    uiReviewMode: 'vision',
+    acceptanceCriteria: ['named dashboard state renders'],
+    reviewBrief: 'Check layout and visual hierarchy.',
+    artifactBundle: {
+      sliceId: 'inspect-run-viewer',
+      namedStates: [
+        {
+          stateName: 'Current PR dashboard',
+          screenshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/screenshot.png',
+          statePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/state.json',
+          snapshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/snapshot.json',
+          axePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/axe.txt',
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 'blocked_incomplete_artifact_bundle');
+  assert.deepEqual(result.missing, ['artifactBundle.namedStates[0].axePath']);
+});
+
+test('mapAxeImpactToFindingSeverity maps axe impact ranks to finding severities', () => {
+  assert.equal(mapAxeImpactToFindingSeverity('critical'), 'high');
+  assert.equal(mapAxeImpactToFindingSeverity('serious'), 'high');
+  assert.equal(mapAxeImpactToFindingSeverity('moderate'), 'medium');
+  assert.equal(mapAxeImpactToFindingSeverity('minor'), 'low');
+  assert.equal(mapAxeImpactToFindingSeverity('SERIOUS'), 'high');
+  assert.equal(mapAxeImpactToFindingSeverity('  moderate  '), 'medium');
+});
+
+test('mapAxeImpactToFindingSeverity defaults unranked/unknown impact to medium', () => {
+  assert.equal(mapAxeImpactToFindingSeverity(null), 'medium');
+  assert.equal(mapAxeImpactToFindingSeverity(undefined), 'medium');
+  assert.equal(mapAxeImpactToFindingSeverity(''), 'medium');
+  assert.equal(mapAxeImpactToFindingSeverity('bogus'), 'medium');
 });

--- a/test/loop/ui-smoke-harness.test.mjs
+++ b/test/loop/ui-smoke-harness.test.mjs
@@ -29,12 +29,14 @@ test('buildNamedUiStateArtifactPaths derives deterministic screenshot and state 
   assert.equal(paths.screenshotPath, path.join(paths.artifactDir, 'screenshot.png'));
   assert.equal(paths.statePath, path.join(paths.artifactDir, 'state.json'));
   assert.equal(paths.snapshotPath, path.join(paths.artifactDir, 'snapshot.json'));
+  assert.equal(paths.axePath, path.join(paths.artifactDir, 'axe.json'));
 });
 
 test('captureNamedUiState writes the deterministic screenshot and state artifact bundle', async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ui-smoke-harness-'));
   const screenshots = [];
   const accessibilityTree = { role: 'WebArea', name: 'Current PR dashboard', children: [{ role: 'heading', name: 'Runs' }] };
+  const axeResults = { violations: [{ id: 'color-contrast', impact: 'serious' }], passes: [], incomplete: [], inapplicable: [] };
 
   try {
     const artifact = await captureNamedUiState({
@@ -48,6 +50,7 @@ test('captureNamedUiState writes the deterministic screenshot and state artifact
           },
         },
       },
+      runAxe: async () => axeResults,
       testInfo: {
         config: { outputDir: tempDir },
         project: { name: 'webkit', outputDir: tempDir },
@@ -83,6 +86,8 @@ test('captureNamedUiState writes the deterministic screenshot and state artifact
     assert.equal(stateJson.artifacts.state.relativePath, 'state.json');
     assert.equal(stateJson.artifacts.snapshot.fileName, 'snapshot.json');
     assert.equal(stateJson.artifacts.snapshot.relativePath, 'snapshot.json');
+    assert.equal(stateJson.artifacts.axe.fileName, 'axe.json');
+    assert.equal(stateJson.artifacts.axe.relativePath, 'axe.json');
     assert.equal(stateJson.metadata.fixture, 'makeInspectionSnapshot');
     assert.equal(stateJson.metadata.route, '/');
     assert.match(stateJson.capturedAt, /^\d{4}-\d{2}-\d{2}T/);
@@ -90,6 +95,10 @@ test('captureNamedUiState writes the deterministic screenshot and state artifact
     assert.equal(artifact.snapshotPath, path.join(artifact.artifactDir, 'snapshot.json'));
     const snapshotJson = JSON.parse(await readFile(artifact.snapshotPath, 'utf8'));
     assert.deepEqual(snapshotJson, accessibilityTree);
+
+    assert.equal(artifact.axePath, path.join(artifact.artifactDir, 'axe.json'));
+    const axeJson = JSON.parse(await readFile(artifact.axePath, 'utf8'));
+    assert.deepEqual(axeJson, axeResults);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -195,6 +204,44 @@ test('captureNamedUiState emits snapshot.json as JSON null when the accessibilit
       stateName: 'No accessibility API',
     });
     assert.equal(await readFile(artifact.snapshotPath, 'utf8'), 'null\n');
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('captureNamedUiState emits axe.json as JSON null when axe cannot run', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ui-smoke-harness-axe-null-'));
+
+  try {
+    // axe is best-effort: a mock page (or a browser build without the runner)
+    // throws inside the axe runner; capture falls back to a deterministic JSON
+    // null rather than crashing the whole capture. The default runner is used
+    // here (no injection), which dynamic-imports @axe-core/playwright and then
+    // fails against the mock page.
+    const artifact = await captureNamedUiState({
+      page: { async screenshot() {} },
+      outputDir: tempDir,
+      sliceId: 'inspect-run-viewer',
+      stateName: 'No axe run',
+    });
+    assert.equal(await readFile(artifact.axePath, 'utf8'), 'null\n');
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('captureNamedUiState emits axe.json as JSON null when the injected runner throws', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ui-smoke-harness-axe-throw-'));
+
+  try {
+    const artifact = await captureNamedUiState({
+      page: { async screenshot() {} },
+      outputDir: tempDir,
+      sliceId: 'inspect-run-viewer',
+      stateName: 'Throwing axe runner',
+      runAxe: async () => { throw new Error('axe unsupported'); },
+    });
+    assert.equal(await readFile(artifact.axePath, 'utf8'), 'null\n');
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/ui-smoke-harness.test.mjs
+++ b/test/loop/ui-smoke-harness.test.mjs
@@ -72,7 +72,7 @@ test('captureNamedUiState writes the deterministic screenshot and state artifact
     await stat(artifact.artifactDir);
 
     const stateJson = JSON.parse(await readFile(artifact.statePath, 'utf8'));
-    assert.equal(stateJson.schemaVersion, 2);
+    assert.equal(stateJson.schemaVersion, 3);
     assert.equal(stateJson.artifactType, 'named-ui-state');
     assert.equal(stateJson.validationLevel, 'deterministic-smoke');
     assert.equal(stateJson.sliceId, 'inspect-run-viewer');

--- a/test/playwright/harness/webkit-smoke-harness.mjs
+++ b/test/playwright/harness/webkit-smoke-harness.mjs
@@ -40,10 +40,26 @@ export function buildNamedUiStateArtifactPaths({ outputDir, sliceId, stateName }
     screenshotPath: path.join(artifactDir, 'screenshot.png'),
     statePath: path.join(artifactDir, 'state.json'),
     snapshotPath: path.join(artifactDir, 'snapshot.json'),
+    axePath: path.join(artifactDir, 'axe.json'),
   };
 }
 
-export async function captureNamedUiState({ page, testInfo, sliceId, stateName, metadata = {}, fullPage = true, outputDir } = {}) {
+// Run axe-core against the live page via @axe-core/playwright, best-effort.
+// The import is dynamic (and try/catch-wrapped) on purpose: axe only runs
+// against a real Playwright page, so mock-page smokes/tests and browser builds
+// where axe can't load degrade to a deterministic JSON null rather than throwing
+// — mirroring the snapshot.json best-effort policy. Real UI smokes install
+// @axe-core/playwright and get populated results.
+async function defaultRunAxe(page) {
+  try {
+    const { default: AxeBuilder } = await import('@axe-core/playwright');
+    return (await new AxeBuilder({ page }).analyze()) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function captureNamedUiState({ page, testInfo, sliceId, stateName, metadata = {}, fullPage = true, outputDir, runAxe = defaultRunAxe } = {}) {
   const resolvedOutputDir = outputDir ?? testInfo?.project?.outputDir ?? testInfo?.config?.outputDir ?? testInfo?.outputDir;
   const paths = buildNamedUiStateArtifactPaths({
     outputDir: resolvedOutputDir,
@@ -69,6 +85,17 @@ export async function captureNamedUiState({ page, testInfo, sliceId, stateName, 
     accessibilityTree = null;
   }
   await writeFile(paths.snapshotPath, `${JSON.stringify(accessibilityTree, null, 2)}\n`, 'utf8');
+
+  // Computed a11y facts: axe-core results next to the pixels/tree. Best-effort
+  // for the same reason as the snapshot (see defaultRunAxe); either way a
+  // deterministic JSON payload (raw axe results, or null) is emitted, never skipped.
+  let axeResults = null;
+  try {
+    axeResults = (await runAxe(page)) ?? null;
+  } catch {
+    axeResults = null;
+  }
+  await writeFile(paths.axePath, `${JSON.stringify(axeResults, null, 2)}\n`, 'utf8');
 
   const normalizedMetadata = {
     ...metadata,
@@ -104,6 +131,11 @@ export async function captureNamedUiState({ page, testInfo, sliceId, stateName, 
         fileName: path.basename(paths.snapshotPath),
         relativePath: path.basename(paths.snapshotPath),
         path: paths.snapshotPath,
+      },
+      axe: {
+        fileName: path.basename(paths.axePath),
+        relativePath: path.basename(paths.axePath),
+        path: paths.axePath,
       },
     },
     metadata: normalizedMetadata,

--- a/test/playwright/harness/webkit-smoke-harness.mjs
+++ b/test/playwright/harness/webkit-smoke-harness.mjs
@@ -105,7 +105,7 @@ export async function captureNamedUiState({ page, testInfo, sliceId, stateName, 
   };
 
   const stateArtifact = {
-    schemaVersion: 2,
+    schemaVersion: 3,
     artifactType: 'named-ui-state',
     validationLevel: 'deterministic-smoke',
     sliceId: paths.sliceId,


### PR DESCRIPTION
## Summary

Stage 2 of epic #1067. Emits `axe.json` (computed accessibility facts from `@axe-core/playwright`) per named state, and moves computable a11y judgment — contrast etc. — off the vision reviewer's eyeballs onto axe evidence. Builds directly on Stage 1's (#1297) snapshot.json + artifact-contract + fail-closed-seam infrastructure.

## Scope and context

- `test/playwright/harness/webkit-smoke-harness.mjs`: `captureNamedUiState()` emits `axe.json` alongside screenshot/state/snapshot at the same deterministic path (`.../named-states/<state-slug>/axe.json`), referenced from `state.json` under `artifacts.axe`. axe runs via a **dynamic** `import('@axe-core/playwright')` in try/catch; content is the raw axe results object, or JSON `null` when axe can't run (best-effort content, same policy as snapshot.json so mock-page/no-runner cases degrade rather than crash real smokes).
- `scripts/loop/ui-designer-review-contract.mjs`: the fail-closed seam now requires `axePath` (presence + `axe.json` suffix in vision), mirroring snapshotPath; adds `mapAxeImpactToFindingSeverity()` (critical/serious→high, moderate→medium, minor→low, unknown→medium).
- `skills/dev-loop/templates/ui-vision-review.md`: **removed contrast (and other axe-computable facts) from the visual-judgment list**; a11y findings now cite `axePath` + the axe rule id instead of eyeballing pixels.
- Docs threaded (artifact-contract, smoke-harness, designer-review-loop, recipe-contract, ui-review SKILL) + `.claude` mirror regenerated. `@axe-core/playwright ^4.10.0` added to devDependencies (lock 4.12.1).

## Acceptance criteria

Satisfies issue #1298's ACs (checked off at merge):
- `axe.json` emitted per named state + validated fail-closed.
- `ui-vision-review.md` no longer instructs contrast judgment; the designer-review-loop doc reflects the axe-evidence rule.
- axe severity → finding-severity mapping documented + tested.
- `@axe-core/playwright` added as a dev dependency; verify green.

## Definition of done

axe runs per named state and emits `axe.json`; computable a11y facts asserted from axe, not model judgment; mapping documented + tested; docs + .claude consistent.

## Non-goals

Parallel lens fan-out (Stage 5). Non-a11y visual review.

## Validation

- `npm run test:assets` (191), `npm run test:core` (1958), `node --test test/loop/*.test.mjs`, `generate-claude-assets --check` (ok). The populated-`axe.json` path runs in the article/deck/viewer Playwright smokes on CI (devDeps installed there); the harness unit test exercises it browser-free via an injected `runAxe`, and the degraded (`null`) path via the default dynamic-import runner.
- Full gate uses `npm run verify`.

## For review

- **Decision to confirm:** `axe.json` is **required** (presence + path), like snapshot.json, rather than "only required where a11y review runs." The seam is one validator block if a narrower scope is preferred.

Closes #1298
