### PR TITLE
feat(tooling): add scripts/github/create-issue.mjs sanctioned wrapper (#1309)

### DIFF
--- a/.claude/skills/docs/retrospective-checkpoint-contract.md
+++ b/.claude/skills/docs/retrospective-checkpoint-contract.md
@@ -134,14 +134,16 @@ violations):** dev-loops subcommands and `node scripts/*.mjs` invocations — th
 scripts legitimately call `gh`/GraphQL internally; that is the tooling. The rule
 targets the agent's own top-level shell calls, not a script's internals.
 
-**Write-op allowlist (verifier only):** `gh pr merge`, `gh pr ready`,
-`gh issue create` have no internal wrapper today. `gh issue edit` now has one
-(`scripts/github/edit-issue.mjs`) and stays as a belt-and-suspenders entry — like
-`gh label create` (`scripts/github/create-label.mjs`) — so a bare invocation
-surfaced from the wrapper's own subprocess is not miscounted as a breach. The
-deterministic verifier records all of these as `allowedWriteOps` rather than
-violations so they are surfaced distinctly, not as breaches. Close the gap with a
-wrapper to remove or reframe a no-wrapper entry. None of these block anything.
+**Write-op allowlist (verifier only):** only `gh pr merge` and `gh pr ready` have
+no internal wrapper today; the verifier records those as `allowedWriteOps` rather
+than violations so the gap is surfaced distinctly, not as a breach. Ops that DO
+have a sanctioned wrapper — `gh issue create` (`scripts/github/create-issue.mjs`),
+`gh issue edit` (`scripts/github/edit-issue.mjs`), `gh label create`
+(`scripts/github/create-label.mjs`) — are NOT allowlisted, so a raw agent-level
+call is flagged as a violation. The verifier only ever classifies the agent's own
+top-level shell commands, never a wrapper's internal subprocess, so removing a
+wrapped op from the allowlist produces no false positives. Close a remaining gap
+with a wrapper to remove its allowlist entry. None of these block anything.
 
 **Inline-interpreter check item:** the raw-call scan below mechanically catches
 `node -e`/`python3 -c`/heredoc calls as a `rawCallViolations` entry — the same

--- a/scripts/github/create-issue.mjs
+++ b/scripts/github/create-issue.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { requireTokenValue, runChild } from "../_cli-primitives.mjs";
+import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
+import { parseArgs } from "node:util";
+import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+
+const USAGE = `Usage: create-issue.mjs --repo <owner/name> --title <t> (--body <b> | --body-file <path>) [--milestone <m>] [--label <l>...] [--assignee <u>...]
+Create an issue. Thin wrapper over \`gh issue create\` — use this instead of an
+agent-level raw \`gh issue create\` so the loop's internal-tooling record stays
+clean (siblings: edit-issue.mjs, comment-issue.mjs).
+Required:
+  --repo <owner/name>           Repository slug (e.g. owner/repo)
+  --title <t>                   Issue title
+Body (exactly one):
+  --body <b>                    Issue body as a single argument
+  --body-file <path>            Read the body from a file (- reads stdin, handled by gh)
+Optional:
+  --milestone <m>               Milestone to set
+  --label <l>                   Label to add (repeatable)
+  --assignee <u>                Assignee login to add (repeatable)
+Output (stdout, JSON):
+  { "ok": true, "issueNumber": 42, "url": "https://github.com/owner/repo/issues/42" }
+Error output (stderr, JSON):
+  { "ok": false, "error": "...", "usage"?: "..." }
+${JQ_OUTPUT_USAGE}
+Exit codes:
+  0  Success
+  1  Argument error or gh failure
+  2  Invalid --jq filter`.trim();
+const parseError = buildParseError(USAGE);
+
+const ISSUE_URL_NUMBER_PATTERN = /\/issues\/(\d+)(?:\D|$)/u;
+
+export function parseCreateIssueCliArgs(argv) {
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      title: { type: "string" },
+      body: { type: "string" },
+      "body-file": { type: "string" },
+      milestone: { type: "string" },
+      label: { type: "string", multiple: true },
+      assignee: { type: "string", multiple: true },
+      ...JQ_OUTPUT_PARSE_OPTIONS,
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  const options = {
+    help: false,
+    repo: undefined,
+    title: undefined,
+    body: undefined,
+    bodyFile: undefined,
+    milestone: undefined,
+    labels: [],
+    assignees: [],
+    jq: undefined,
+    silent: false,
+  };
+  for (const token of tokens) {
+    if (token.kind === "positional") {
+      throw parseError(`Unknown argument: ${token.value}`);
+    }
+    if (token.kind !== "option") {
+      continue;
+    }
+    if (token.name === "help") {
+      options.help = true;
+      return options;
+    }
+    if (token.name === "repo") {
+      options.repo = requireTokenValue(token, parseError).trim();
+      continue;
+    }
+    if (token.name === "title") {
+      const title = requireTokenValue(token, parseError);
+      if (title.trim().length === 0) {
+        throw parseError("--title must not be empty or whitespace-only");
+      }
+      options.title = title;
+      continue;
+    }
+    if (token.name === "body") {
+      const body = requireTokenValue(token, parseError);
+      if (body.trim().length === 0) {
+        throw parseError("--body must not be empty or whitespace-only");
+      }
+      options.body = body;
+      continue;
+    }
+    if (token.name === "body-file") {
+      const rawPath = requireTokenValue(token, parseError).trim();
+      if (rawPath.length === 0) {
+        throw parseError("--body-file must be a non-empty path");
+      }
+      options.bodyFile = rawPath;
+      continue;
+    }
+    if (token.name === "milestone") {
+      const m = requireTokenValue(token, parseError).trim();
+      if (m.length === 0) throw parseError("--milestone must be a non-empty milestone name");
+      options.milestone = m;
+      continue;
+    }
+    if (token.name === "label") {
+      const l = requireTokenValue(token, parseError).trim();
+      if (l.length === 0) throw parseError("--label must be a non-empty label");
+      options.labels.push(l);
+      continue;
+    }
+    if (token.name === "assignee") {
+      const u = requireTokenValue(token, parseError).trim();
+      if (u.length === 0) throw parseError("--assignee must be a non-empty login");
+      options.assignees.push(u);
+      continue;
+    }
+    if (matchJqOutputToken(token, options, (t) => requireTokenValue(t, parseError))) continue;
+    throw parseError(`Unknown argument: ${token.rawName}`);
+  }
+  if (options.repo === undefined || options.title === undefined) {
+    throw parseError("Creating an issue requires both --repo <owner/name> and --title <t>");
+  }
+  if (options.body !== undefined && options.bodyFile !== undefined) {
+    throw parseError("--body and --body-file are mutually exclusive; pass exactly one");
+  }
+  if (options.body === undefined && options.bodyFile === undefined) {
+    throw parseError("Creating an issue requires exactly one of --body <b> or --body-file <path>");
+  }
+  try {
+    parseRepoSlug(options.repo);
+  } catch (error) {
+    throw parseError(error instanceof Error ? error.message : String(error));
+  }
+  return options;
+}
+
+// Build the `gh issue create` args. A --body-file path is forwarded straight to
+// gh (so large bodies avoid command-length limits and `-` reads stdin natively).
+export function buildCreateArgs(options) {
+  const args = ["issue", "create", "--repo", options.repo, "--title", options.title];
+  if (options.body !== undefined) {
+    args.push("--body", options.body);
+  } else {
+    args.push("--body-file", options.bodyFile);
+  }
+  if (options.milestone !== undefined) {
+    args.push("--milestone", options.milestone);
+  }
+  for (const l of options.labels) {
+    args.push("--label", l);
+  }
+  for (const u of options.assignees) {
+    args.push("--assignee", u);
+  }
+  return args;
+}
+
+export async function createIssue(options, { env = process.env, ghCommand = "gh", run = runChild } = {}) {
+  const args = buildCreateArgs(options);
+  const result = await run(ghCommand, args, env);
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw new Error(`gh issue create failed: ${detail}`);
+  }
+  // gh prints the created issue URL to stdout.
+  const url = (result.stdout ?? "").trim();
+  const match = ISSUE_URL_NUMBER_PATTERN.exec(url);
+  if (!match) {
+    throw new Error(`gh issue create returned no parseable issue URL: ${url || "<empty>"}`);
+  }
+  return { ok: true, issueNumber: Number(match[1]), url };
+}
+
+export async function runCli(
+  argv = process.argv.slice(2),
+  { stdout = process.stdout, stderr = process.stderr, env = process.env, ghCommand = "gh", run = runChild } = {},
+) {
+  let options;
+  try {
+    options = parseCreateIssueCliArgs(argv);
+  } catch (error) {
+    stderr.write(`${formatCliError(error)}\n`);
+    return 1;
+  }
+  if (options.help) {
+    stdout.write(`${USAGE}\n`);
+    return 0;
+  }
+  let result;
+  try {
+    result = await createIssue(options, { env, ghCommand, run });
+  } catch (error) {
+    stderr.write(`${JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) })}\n`);
+    return 1;
+  }
+  return emitResult(result, { jq: options.jq, silent: options.silent, stdout, stderr });
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli().then((code) => { process.exitCode = code; });
+}

--- a/scripts/github/create-issue.mjs
+++ b/scripts/github/create-issue.mjs
@@ -14,7 +14,7 @@ Required:
   --title <t>                   Issue title
 Body (exactly one):
   --body <b>                    Issue body as a single argument
-  --body-file <path>            Read the body from a file (- reads stdin, handled by gh)
+  --body-file <path>            Read the body from a file (- is rejected; stdin is not supported)
 Optional:
   --milestone <m>               Milestone to set
   --label <l>                   Label to add (repeatable)
@@ -98,6 +98,11 @@ export function parseCreateIssueCliArgs(argv) {
       if (rawPath.length === 0) {
         throw parseError("--body-file must be a non-empty path");
       }
+      // gh is spawned with stdin ignored, so `--body-file -` would read /dev/null
+      // and silently create an empty-body issue; reject it fail-closed instead.
+      if (rawPath === "-") {
+        throw parseError("--body-file '-' (stdin) is not supported");
+      }
       options.bodyFile = rawPath;
       continue;
     }
@@ -140,7 +145,7 @@ export function parseCreateIssueCliArgs(argv) {
 }
 
 // Build the `gh issue create` args. A --body-file path is forwarded straight to
-// gh (so large bodies avoid command-length limits and `-` reads stdin natively).
+// gh so large bodies avoid command-length limits.
 export function buildCreateArgs(options) {
   const args = ["issue", "create", "--repo", options.repo, "--title", options.title];
   if (options.body !== undefined) {

--- a/scripts/loop/check-retro-tooling.mjs
+++ b/scripts/loop/check-retro-tooling.mjs
@@ -24,13 +24,11 @@
  *   - dev-loops subcommands and `node scripts/....mjs` invocations. Those scripts
  *     legitimately call gh/GraphQL/etc. internally — that IS the tooling.
  *   - A small explicit allowlist of write-ops that have no internal wrapper today:
- *     `gh pr merge`, `gh pr ready`. Plus belt-and-suspenders
- *     entries that DO have wrappers — `gh issue edit` (scripts/github/edit-issue.mjs)
- *     and `gh label create` (scripts/github/create-label.mjs) — kept so a bare
- *     invocation surfaced from the wrapper's own subprocess is not a false violation.
- *     All are recorded as `allowedWriteOps` rather than violations so the gate is not
- *     blocked forever on an unavoidable gap. Document/close the gap with a wrapper
- *     to remove the no-wrapper entries from the allowlist.
+ *     `gh pr merge`, `gh pr ready`. These are recorded as `allowedWriteOps` rather
+ *     than violations so the gate is not blocked forever on an unavoidable gap.
+ *     Once an op gains a sanctioned wrapper it is removed from this allowlist so a
+ *     raw agent-level call is flagged (the analyzer only ever sees agent Bash-tool
+ *     commands, never a wrapper's internal subprocess, so no false positive results).
  *
  * VIOLATION (agent-level raw call):
  *   - `gh ...` at the start of a command segment (start of line, or after
@@ -79,20 +77,15 @@ Exit codes:
 
 /**
  * Write-ops recorded distinctly (as allowedWriteOps, not violations) so the gate
- * is not blocked forever on an unavoidable gap. Most have no internal wrapper yet;
- * a couple DO have wrappers and are kept belt-and-suspenders (see below).
- * Keep this set SMALL and explicit; remove a no-wrapper entry once a wrapper exists.
+ * is not blocked forever on an unavoidable gap. These have no internal wrapper yet.
+ * Keep this set SMALL and explicit; remove an entry once a wrapper exists so a raw
+ * agent-level call is flagged (as `gh issue create`/`edit`, `gh label create` now
+ * are — their wrappers live under scripts/github/).
  * @type {ReadonlyArray<RegExp>}
  */
 const ALLOWED_WRITE_OPS = Object.freeze([
   /^gh\s+pr\s+merge\b/,
   /^gh\s+pr\s+ready\b/,
-  // `gh issue edit` (scripts/github/edit-issue.mjs) and `gh label create`
-  // (scripts/github/create-label.mjs) both HAVE wrappers; these entries are
-  // belt-and-suspenders so a bare invocation (e.g. surfaced from the wrapper's
-  // own subprocess) classifies as an allowed write-op, not a violation.
-  /^gh\s+issue\s+edit\b/,
-  /^gh\s+label\s+create\b/,
 ]);
 
 /** Split a command line into top-level segments on &&, ||, |, ;. */

--- a/scripts/loop/check-retro-tooling.mjs
+++ b/scripts/loop/check-retro-tooling.mjs
@@ -24,7 +24,7 @@
  *   - dev-loops subcommands and `node scripts/....mjs` invocations. Those scripts
  *     legitimately call gh/GraphQL/etc. internally — that IS the tooling.
  *   - A small explicit allowlist of write-ops that have no internal wrapper today:
- *     `gh pr merge`, `gh pr ready`, `gh issue create`. Plus belt-and-suspenders
+ *     `gh pr merge`, `gh pr ready`. Plus belt-and-suspenders
  *     entries that DO have wrappers — `gh issue edit` (scripts/github/edit-issue.mjs)
  *     and `gh label create` (scripts/github/create-label.mjs) — kept so a bare
  *     invocation surfaced from the wrapper's own subprocess is not a false violation.
@@ -87,7 +87,6 @@ Exit codes:
 const ALLOWED_WRITE_OPS = Object.freeze([
   /^gh\s+pr\s+merge\b/,
   /^gh\s+pr\s+ready\b/,
-  /^gh\s+issue\s+create\b/,
   // `gh issue edit` (scripts/github/edit-issue.mjs) and `gh label create`
   // (scripts/github/create-label.mjs) both HAVE wrappers; these entries are
   // belt-and-suspenders so a bare invocation (e.g. surfaced from the wrapper's

--- a/scripts/loop/sanctioned-commands.mjs
+++ b/scripts/loop/sanctioned-commands.mjs
@@ -39,6 +39,7 @@ export const SANCTIONED_COMMANDS = Object.freeze({
     "pr-body-title-assignee-milestone": "scripts/github/edit-pr.mjs",
     "issue-body-title-assignee-milestone": "scripts/github/edit-issue.mjs",
     "issue-comment": "scripts/github/comment-issue.mjs",
+    "issue-create": "scripts/github/create-issue.mjs",
   }),
 
   // Lifecycle mutations a subagent MAY perform (state transitions on the PR /

--- a/skills/docs/retrospective-checkpoint-contract.md
+++ b/skills/docs/retrospective-checkpoint-contract.md
@@ -134,14 +134,16 @@ violations):** dev-loops subcommands and `node scripts/*.mjs` invocations — th
 scripts legitimately call `gh`/GraphQL internally; that is the tooling. The rule
 targets the agent's own top-level shell calls, not a script's internals.
 
-**Write-op allowlist (verifier only):** `gh pr merge`, `gh pr ready`,
-`gh issue create` have no internal wrapper today. `gh issue edit` now has one
-(`scripts/github/edit-issue.mjs`) and stays as a belt-and-suspenders entry — like
-`gh label create` (`scripts/github/create-label.mjs`) — so a bare invocation
-surfaced from the wrapper's own subprocess is not miscounted as a breach. The
-deterministic verifier records all of these as `allowedWriteOps` rather than
-violations so they are surfaced distinctly, not as breaches. Close the gap with a
-wrapper to remove or reframe a no-wrapper entry. None of these block anything.
+**Write-op allowlist (verifier only):** only `gh pr merge` and `gh pr ready` have
+no internal wrapper today; the verifier records those as `allowedWriteOps` rather
+than violations so the gap is surfaced distinctly, not as a breach. Ops that DO
+have a sanctioned wrapper — `gh issue create` (`scripts/github/create-issue.mjs`),
+`gh issue edit` (`scripts/github/edit-issue.mjs`), `gh label create`
+(`scripts/github/create-label.mjs`) — are NOT allowlisted, so a raw agent-level
+call is flagged as a violation. The verifier only ever classifies the agent's own
+top-level shell commands, never a wrapper's internal subprocess, so removing a
+wrapped op from the allowlist produces no false positives. Close a remaining gap
+with a wrapper to remove its allowlist entry. None of these block anything.
 
 **Inline-interpreter check item:** the raw-call scan below mechanically catches
 `node -e`/`python3 -c`/heredoc calls as a `rawCallViolations` entry — the same

--- a/test/github/create-issue.test.mjs
+++ b/test/github/create-issue.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseCreateIssueCliArgs, createIssue, runCli } from "../../scripts/github/create-issue.mjs";
+
+function stubGh({ code = 0, stdout, stderr = "" } = {}) {
+  const calls = [];
+  const run = async (_cmd, args) => {
+    calls.push(args);
+    return {
+      code,
+      stdout: code === 0 ? (stdout ?? "https://github.com/o/n/issues/42\n") : "",
+      stderr,
+    };
+  };
+  return { run, calls };
+}
+
+function captureStream() {
+  let data = "";
+  return { write: (s) => { data += s; }, get: () => data };
+}
+
+test("parseCreateIssueCliArgs: requires --repo and --title", () => {
+  assert.throws(() => parseCreateIssueCliArgs(["--repo", "o/n", "--body", "b"]), /requires both --repo/);
+  assert.throws(() => parseCreateIssueCliArgs(["--title", "t", "--body", "b"]), /requires both --repo/);
+});
+
+test("parseCreateIssueCliArgs: --body XOR --body-file (both / neither fail)", () => {
+  assert.throws(
+    () => parseCreateIssueCliArgs(["--repo", "o/n", "--title", "t", "--body", "b", "--body-file", "f"]),
+    /mutually exclusive/,
+  );
+  assert.throws(
+    () => parseCreateIssueCliArgs(["--repo", "o/n", "--title", "t"]),
+    /exactly one of --body/,
+  );
+});
+
+test("parseCreateIssueCliArgs: rejects whitespace-only --title / --body", () => {
+  assert.throws(() => parseCreateIssueCliArgs(["--repo", "o/n", "--title", "  ", "--body", "b"]), /--title must not be empty/);
+  assert.throws(() => parseCreateIssueCliArgs(["--repo", "o/n", "--title", "t", "--body", "\t\n"]), /--body must not be empty/);
+});
+
+test("parseCreateIssueCliArgs: collects repeated --label / --assignee", () => {
+  const out = parseCreateIssueCliArgs([
+    "--repo", "o/n", "--title", "t", "--body", "b",
+    "--label", "bug", "--label", "p1", "--assignee", "a", "--assignee", "b",
+  ]);
+  assert.deepEqual(out.labels, ["bug", "p1"]);
+  assert.deepEqual(out.assignees, ["a", "b"]);
+});
+
+test("createIssue: builds gh issue create args and parses issueNumber + url", async () => {
+  const { run, calls } = stubGh();
+  const result = await createIssue(
+    { repo: "o/n", title: "New", body: "Body", milestone: "v1", labels: ["bug"], assignees: ["me"] },
+    { run },
+  );
+  assert.deepEqual(result, { ok: true, issueNumber: 42, url: "https://github.com/o/n/issues/42" });
+  assert.deepEqual(calls[0], [
+    "issue", "create", "--repo", "o/n", "--title", "New", "--body", "Body",
+    "--milestone", "v1", "--label", "bug", "--assignee", "me",
+  ]);
+});
+
+test("createIssue: --body-file forwards the path to gh", async () => {
+  const { run, calls } = stubGh();
+  await createIssue({ repo: "o/n", title: "T", bodyFile: "body.md", labels: [], assignees: [] }, { run });
+  assert.deepEqual(calls[0], ["issue", "create", "--repo", "o/n", "--title", "T", "--body-file", "body.md"]);
+});
+
+test("createIssue: throws when gh fails", async () => {
+  const { run } = stubGh({ code: 1, stderr: "forbidden" });
+  await assert.rejects(
+    () => createIssue({ repo: "o/n", title: "T", body: "b", labels: [], assignees: [] }, { run }),
+    /gh issue create failed: forbidden/,
+  );
+});
+
+test("createIssue: throws on unparseable URL output", async () => {
+  const { run } = stubGh({ stdout: "not-a-url\n" });
+  await assert.rejects(
+    () => createIssue({ repo: "o/n", title: "T", body: "b", labels: [], assignees: [] }, { run }),
+    /no parseable issue URL/,
+  );
+});
+
+test("runCli: --jq extracts issueNumber; --silent maps to exit code", async () => {
+  const { run } = stubGh();
+  const stdout = captureStream();
+  const code = await runCli(["--repo", "o/n", "--title", "T", "--body", "b", "--jq", ".issueNumber"], { run, stdout });
+  assert.equal(code, 0);
+  assert.equal(stdout.get().trim(), "42");
+
+  const { run: run2 } = stubGh();
+  const code2 = await runCli(["--repo", "o/n", "--title", "T", "--body", "b", "--silent"], { run: run2, stdout: captureStream() });
+  assert.equal(code2, 0);
+});
+
+test("runCli: fails closed (exit 1) on missing required args", async () => {
+  const stderr = captureStream();
+  const code = await runCli(["--repo", "o/n"], { run: stubGh().run, stdout: captureStream(), stderr });
+  assert.equal(code, 1);
+});

--- a/test/github/create-issue.test.mjs
+++ b/test/github/create-issue.test.mjs
@@ -42,6 +42,13 @@ test("parseCreateIssueCliArgs: rejects whitespace-only --title / --body", () => 
   assert.throws(() => parseCreateIssueCliArgs(["--repo", "o/n", "--title", "t", "--body", "\t\n"]), /--body must not be empty/);
 });
 
+test("parseCreateIssueCliArgs: rejects --body-file - (stdin) fail-closed", () => {
+  assert.throws(
+    () => parseCreateIssueCliArgs(["--repo", "o/n", "--title", "t", "--body-file", "-"]),
+    /--body-file '-' \(stdin\) is not supported/,
+  );
+});
+
 test("parseCreateIssueCliArgs: collects repeated --label / --assignee", () => {
   const out = parseCreateIssueCliArgs([
     "--repo", "o/n", "--title", "t", "--body", "b",
@@ -96,6 +103,19 @@ test("runCli: --jq extracts issueNumber; --silent maps to exit code", async () =
   const { run: run2 } = stubGh();
   const code2 = await runCli(["--repo", "o/n", "--title", "T", "--body", "b", "--silent"], { run: run2, stdout: captureStream() });
   assert.equal(code2, 0);
+});
+
+test("runCli: fails closed (exit 1) with {ok:false,error} JSON on gh failure", async () => {
+  const { run } = stubGh({ code: 1, stderr: "forbidden" });
+  const stderr = captureStream();
+  const code = await runCli(
+    ["--repo", "o/n", "--title", "T", "--body", "b"],
+    { run, stdout: captureStream(), stderr },
+  );
+  assert.equal(code, 1);
+  const parsed = JSON.parse(stderr.get().trim());
+  assert.equal(parsed.ok, false);
+  assert.match(parsed.error, /gh issue create failed: forbidden/);
 });
 
 test("runCli: fails closed (exit 1) on missing required args", async () => {

--- a/test/loop/check-retro-tooling.test.mjs
+++ b/test/loop/check-retro-tooling.test.mjs
@@ -64,16 +64,23 @@ test("gh after && / | / ; separator is caught", () => {
   assert.match(violations[0], /gh pr view/);
 });
 
-test("allowed write-ops (gh pr merge / issue create) are recorded, not violations", () => {
+test("allowed write-ops (gh pr merge / pr ready) are recorded, not violations", () => {
   const transcript = [
     "gh pr merge 982 --squash",
-    "gh issue create --title x",
     "gh pr ready 982",
   ].join("\n");
   const { violations, allowedWriteOps, internalToolingOnly } = analyzeTranscript(transcript);
   assert.deepEqual(violations, []);
-  assert.equal(allowedWriteOps.length, 3);
+  assert.equal(allowedWriteOps.length, 2);
   assert.equal(internalToolingOnly, true);
+});
+
+test("raw `gh issue create` is a violation now that create-issue.mjs wraps it", () => {
+  const { violations, allowedWriteOps, internalToolingOnly } = analyzeTranscript("gh issue create --title x");
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /gh issue create/);
+  assert.deepEqual(allowedWriteOps, []);
+  assert.equal(internalToolingOnly, false);
 });
 
 test("representative mixed transcript classifies correctly", () => {


### PR DESCRIPTION
## Summary

Adds a sanctioned `scripts/github/create-issue.mjs` wrapper. Until now only comment/edit/list issue wrappers existed, so creating issues (epic sub-issues, filing bugs) required raw `gh issue create` — a recorded advisory retro violation (#1077) that bypasses the loop's internal-tooling record.

## Scope and context

- `scripts/github/create-issue.mjs`: thin fail-closed wrapper over `gh issue create`, mirroring the `edit-issue.mjs` idiom (same `parseArgs` loop, `buildParseError`/`formatCliError` shape, and `matchJqOutputToken`/`emitResult` wiring — so it inherits the base-CLI `--jq`/`--silent` guarantee). Requires `--repo` + `--title`; enforces `--body` XOR `--body-file` (both-or-neither fails closed); rejects `--body-file -` (stdin unsupported — `runChild` ignores stdin, so it would silently create an empty body); repeatable `--label`/`--assignee` collect into arrays; optional `--milestone`. Returns `{ ok, issueNumber, url }` (issue number parsed from gh's stdout URL).
- `scripts/loop/check-retro-tooling.mjs`: the retro analyzer classifies only the agent's own Bash lines (never a wrapper's internal subprocess spawn), so the belt-and-suspenders `ALLOWED_WRITE_OPS` entries for wrapped ops were dead code with a false rationale. Removed `gh issue create`, `gh issue edit`, and `gh label create` consistently — raw agent-level use of any wrapped op is now a flagged retro-tooling violation (closing the record-bypass this wrapper was created to fix). `skills/docs/retrospective-checkpoint-contract.md` (+ its regenerated `.claude` mirror) updated to match.
- `scripts/loop/sanctioned-commands.mjs`: registered `issue-create → scripts/github/create-issue.mjs` in the SSOT operation→wrapper map so dev-loop subagents/envelopes discover and prefer the wrapper.

## Acceptance criteria

Satisfies issue #1309's ACs (checked off at merge):
- The wrapper exists with the specified flags, on the shared `scripts/lib/jq-output.mjs` emit path, returning `{ ok, issueNumber, url }`.
- Follows the `edit-issue.mjs` idiom (thin, fail-closed).
- A test covers arg parsing + the create path with mocked gh.

## Definition of done

Sanctioned issue-creation path exists so the loop no longer needs raw `gh issue create`; tests green.

## Non-goals

Issue templates. Project-board auto-add (`add-queue-item` handles enqueue). `--body-file` is forwarded straight to gh (no read/validate), matching `create-pr.mjs`.

## Validation

- `node --test test/github/create-issue.test.mjs` — 12 pass (required-args, XOR, reject `--body-file -`, whitespace rejection, repeatable flags, create-path arg assembly + issueNumber/url parse, gh-failure + unparseable-URL fail-closed, `runCli` exit-1 on gh failure, `--jq`/`--silent`).
- `node --test test/loop/check-retro-tooling.test.mjs` — 14 pass (incl. raw `gh issue create` now flagged); `node --test test/contracts/sanctioned-commands-exist.test.mjs` — green.
- `node scripts/claude/generate-claude-assets.mjs --check` — clean (68 checked, no drift).
- Full gate uses `npm run verify`.

Closes #1309
