### PR TITLE
feat(loop): ui_review Stage 3 — per-state console + network capture (console.json) (#1299)

### DIFF
--- a/.claude/skills/dev-loop/templates/ui-vision-review.md
+++ b/.claude/skills/dev-loop/templates/ui-vision-review.md
@@ -15,13 +15,15 @@ You are a vision-capable UI reviewer (model: `gpt-5.4`) reviewing deterministic 
   - `statePath` (must point to `state.json`)
   - `snapshotPath` (must point to `snapshot.json`)
   - `axePath` (must point to `axe.json`)
+  - `consolePath` (must point to `console.json`)
 
 ## Review policy
 
 1. Fail closed when required inputs are missing, ambiguous, or unreadable.
 2. Ground every finding in one or more `screenshotPath` and `statePath` references. Ground accessibility findings in `axePath`.
 3. Evaluate layout, hierarchy, spacing, clipping, overlap, callouts/highlighting, and state-transition clarity against the acceptance criteria and review brief. Do **not** eyeball computable accessibility facts (color contrast, missing accessible names/roles, and similar). Those are asserted from `axe.json` evidence, not judged from pixels: cite the axe rule `id`/`impact` and map its impact to finding severity (`critical`/`serious` → `high`, `moderate` → `medium`, `minor` → `low`; unranked/unknown → `medium`).
-4. Return only deterministic findings; do not invent evidence that is not visible in artifacts.
+4. Treat any console error or failed network request in `console.json` as a must-fix finding grounded in `consolePath` (a swallowed 500, an uncaught page error). Never silently drop a captured error; a state whose `console.json` is JSON `null` captured none.
+5. Return only deterministic findings; do not invent evidence that is not visible in artifacts.
 
 ## Required output format
 

--- a/.claude/skills/dev-loop/templates/ui-vision-review.md
+++ b/.claude/skills/dev-loop/templates/ui-vision-review.md
@@ -22,7 +22,7 @@ You are a vision-capable UI reviewer (model: `gpt-5.4`) reviewing deterministic 
 1. Fail closed when required inputs are missing, ambiguous, or unreadable.
 2. Ground every finding in one or more `screenshotPath` and `statePath` references. Ground accessibility findings in `axePath`.
 3. Evaluate layout, hierarchy, spacing, clipping, overlap, callouts/highlighting, and state-transition clarity against the acceptance criteria and review brief. Do **not** eyeball computable accessibility facts (color contrast, missing accessible names/roles, and similar). Those are asserted from `axe.json` evidence, not judged from pixels: cite the axe rule `id`/`impact` and map its impact to finding severity (`critical`/`serious` → `high`, `moderate` → `medium`, `minor` → `low`; unranked/unknown → `medium`).
-4. Treat any console error or failed network request in `console.json` as a must-fix finding grounded in `consolePath` (a swallowed 500, an uncaught page error). Never silently drop a captured error; a state whose `console.json` is JSON `null` captured none.
+4. Read `console.json` as evidence for that state (its captured console errors and failed network requests: a swallowed 500, an uncaught page error). These captured errors are ALREADY surfaced as fail-closed, source-anchored must-fix findings by the drive's mechanical failure gate — do **not** re-file them as separate findings (the report dedups against the mechanical set). Use `console.json` to corroborate or explain a visual finding, never to independently pass a state; a state whose `console.json` is JSON `null` captured none.
 5. Return only deterministic findings; do not invent evidence that is not visible in artifacts.
 
 ## Required output format

--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -66,13 +66,15 @@ Throughout the walk, `response`, `requestfailed`, and `pageerror` listeners run
 and the project server log is tailed, so a swallowed error response (a 500 the UI
 hides behind a success state) is still recorded. An error response is a status
 <200 or >=400; 3xx redirects are normal navigation (login/canonical) and are not
-flagged. Each per-step capture DRAINS that listener buffer into the step's
-`console.json` (per-state attribution of console errors + failed requests), so an
-error attributed to a named state is not ALSO re-reported by the walk-level
-classifier — the same error is captured once and counted once. The stage emits an
-ordered set of step screenshots plus a structured captured-failures list (the
-walk-level remainder: server-log exceptions, step failures, and any events
-outside a captured state) that feeds the next stage. Every bounded cap — max
+flagged. Each per-step capture SLICES that listener buffer into the step's
+`console.json` (per-state attribution of console errors + failed requests)
+WITHOUT clearing it, so the same classified events still reach the walk-level
+failure gate — a captured step-scoped error deterministically fails the drive
+closed and keeps its source-line anchoring. The stage emits an ordered set of
+step screenshots plus a structured captured-failures list (error responses,
+request failures, page errors, server-log exceptions, and step failures) that
+feeds the next stage; the final report dedups per-state attribution against that
+list so the same error is not posted twice. Every bounded cap — max
 screenshots, screens skipped, and the fixed no-retry policy — is logged
 explicitly.
 

--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -59,18 +59,22 @@ one headless WebKit context, authenticates as the change's target role through a
 project-provided dev-login recipe, dismisses config-declared interstitials once
 per context, then walks the selected flows — rendering each page and exercising
 its declared create/edit/reorder/upload/toggle interactions — capturing a step
-screenshot + sibling `state.json` + `snapshot.json` + `axe.json` per step via `captureNamedUiState`. It fails
+screenshot + sibling `state.json` + `snapshot.json` + `axe.json` + `console.json` per step via `captureNamedUiState`. It fails
 closed to a stated stop reason when it cannot authenticate, and drives nothing.
 
 Throughout the walk, `response`, `requestfailed`, and `pageerror` listeners run
 and the project server log is tailed, so a swallowed error response (a 500 the UI
 hides behind a success state) is still recorded. An error response is a status
 <200 or >=400; 3xx redirects are normal navigation (login/canonical) and are not
-flagged. The stage emits an ordered set of step screenshots plus a structured
-captured-failures list (error responses, request failures, page errors,
-server-log exceptions) that
-feeds the next stage. Every bounded cap — max screenshots, screens skipped, and
-the fixed no-retry policy — is logged explicitly.
+flagged. Each per-step capture DRAINS that listener buffer into the step's
+`console.json` (per-state attribution of console errors + failed requests), so an
+error attributed to a named state is not ALSO re-reported by the walk-level
+classifier — the same error is captured once and counted once. The stage emits an
+ordered set of step screenshots plus a structured captured-failures list (the
+walk-level remainder: server-log exceptions, step failures, and any events
+outside a captured state) that feeds the next stage. Every bounded cap — max
+screenshots, screens skipped, and the fixed no-retry policy — is logged
+explicitly.
 
 Which flows are driven is a bounded heuristic over an explicit allowlist, never
 an unbounded crawl: each `uiReview.flows` entry declares `pathPatterns` matched

--- a/docs/ui-artifact-contract.md
+++ b/docs/ui-artifact-contract.md
@@ -47,12 +47,14 @@ For this level, a state artifact bundle is required:
 - `state.json`
 - `snapshot.json`
 - `axe.json`
+- `console.json`
 
-Why all four are required:
+Why all five are required:
 - the screenshot shows what rendered
 - `state.json` explains which named state it is, which slice produced it, and the minimum metadata needed for review or follow-up automation
 - `snapshot.json` is the semantic accessibility tree captured for the same state — the structured counterpart to the pixels, so a reviewer (or later automation) can reason about roles/names, not just what a screenshot happens to show
 - `axe.json` is the computed accessibility facts (axe-core results) for the same state, so contrast and other computable a11y issues are asserted from a tool, not eyeballed from pixels
+- `console.json` is the console errors and failed network requests attributed to the same state, so a swallowed error (a 500 hidden behind a success toast, an uncaught page error) is a review input rather than something only a live re-run would surface
 
 ### 3. CI-required artifacts
 
@@ -73,6 +75,7 @@ For a slice id of `<sliceId>` and a state slug of `<state-slug>`, the harness pa
 - structured state artifact: `test-results/ui-smoke/<sliceId>/named-states/<state-slug>/state.json`
 - semantic snapshot artifact: `test-results/ui-smoke/<sliceId>/named-states/<state-slug>/snapshot.json`
 - computed a11y artifact: `test-results/ui-smoke/<sliceId>/named-states/<state-slug>/axe.json`
+- console/network artifact: `test-results/ui-smoke/<sliceId>/named-states/<state-slug>/console.json`
 - HTML report root: `playwright-report/ui-smoke/<sliceId>/`
 
 The harness currently normalizes:
@@ -81,7 +84,7 @@ The harness currently normalizes:
 
 ## Minimum `state.json` contract
 
-The current reusable harness emits `state.json` with this minimum reviewer-facing metadata (current `schemaVersion`: `3`):
+The current reusable harness emits `state.json` with this minimum reviewer-facing metadata (current `schemaVersion`: `4`):
 - `schemaVersion`
 - `artifactType`
 - `validationLevel`
@@ -101,6 +104,8 @@ The current reusable harness emits `state.json` with this minimum reviewer-facin
 - `artifacts.snapshot.relativePath`
 - `artifacts.axe.fileName`
 - `artifacts.axe.relativePath`
+- `artifacts.console.fileName`
+- `artifacts.console.relativePath`
 - `metadata.fixture`
 - `metadata.route`
 - `metadata.reviewHint`
@@ -140,6 +145,25 @@ finding severity with this fixed mapping:
 - `minor` → `low`
 - unranked / unknown impact → `medium` (conservative default)
 
+## `console.json` contract
+
+`console.json` is the console errors and failed network requests attributed to
+the same named state. Its body is a `{ consoleErrors, failedRequests }` report —
+`consoleErrors` are uncaught page errors (each with `message` and a bounded
+`stack`), `failedRequests` are error responses (status `<200`/`>=400`) and failed
+requests — or JSON `null` when nothing was captured for the state. Like
+`snapshot.json` and `axe.json`, it is best-effort in content but always emitted
+for every named state (never skipped) at the deterministic path above, and
+`state.json` references it under `artifacts.console`.
+
+`console.json` is populated by **draining the live drive's single walk-level
+listener buffer** into the state active when the events fired — it is per-state
+attribution of the console/network errors the drive already captures, not a new
+capture mechanism. Because the per-state capture drains that slice, an error
+attributed to a state is not ALSO re-reported by the drive's walk-level failure
+classifier: the same error is captured once and counted once. A captured
+console/network error is a fail-closed review input, never silently dropped.
+
 ## When screenshot alone is acceptable
 
 Screenshot alone is acceptable only when the artifact is:
@@ -150,7 +174,7 @@ Screenshot alone is acceptable only when the artifact is:
 
 ## When the state artifact bundle is required
 
-The `screenshot.png` + `state.json` + `snapshot.json` + `axe.json` bundle is required when:
+The `screenshot.png` + `state.json` + `snapshot.json` + `axe.json` + `console.json` bundle is required when:
 - the artifact is part of the reusable deterministic smoke harness
 - the slice is handing named UI states to a later reviewer loop
 - the artifact needs to map back to a deterministic local run without guesswork
@@ -174,6 +198,7 @@ When a registered artifact's suite is required:
 - missing `screenshot.png` is a validation failure
 - missing or malformed `snapshot.json` is a validation failure
 - missing or malformed `axe.json` is a validation failure
+- missing or malformed `console.json` is a validation failure
 - mismatched state naming/path conventions are a validation failure
 - the PR should fail closed rather than silently downgrade to screenshot-only review
 

--- a/docs/ui-artifact-contract.md
+++ b/docs/ui-artifact-contract.md
@@ -156,13 +156,17 @@ requests — or JSON `null` when nothing was captured for the state. Like
 for every named state (never skipped) at the deterministic path above, and
 `state.json` references it under `artifacts.console`.
 
-`console.json` is populated by **draining the live drive's single walk-level
+`console.json` is populated by **slicing the live drive's single walk-level
 listener buffer** into the state active when the events fired — it is per-state
 attribution of the console/network errors the drive already captures, not a new
-capture mechanism. Because the per-state capture drains that slice, an error
-attributed to a state is not ALSO re-reported by the drive's walk-level failure
-classifier: the same error is captured once and counted once. A captured
-console/network error is a fail-closed review input, never silently dropped.
+capture mechanism. The slice does **not** clear the buffer: the same classified
+events still reach the drive's walk-level failure gate, so a captured
+console/network error is a **mechanical, mode-independent fail-closed signal**
+(it flips the drive's `ok` to false and keeps its source-line anchoring), not
+merely a review hint. Attribution (`console.json`) and the mechanical failure gate
+are two views of the same classified events; the final report dedups so the same
+error is not posted twice. A captured console/network error is never silently
+dropped.
 
 ## When screenshot alone is acceptable
 

--- a/docs/ui-designer-review-loop.md
+++ b/docs/ui-designer-review-loop.md
@@ -42,6 +42,7 @@ The loop requires all of the following inputs before it may run:
      - `statePath`
      - `snapshotPath`
      - `axePath`
+     - `consolePath`
 
 If any required part of this bundle is missing, incomplete, or ambiguous, the loop fails closed instead of guessing.
 
@@ -63,6 +64,16 @@ severity with a fixed mapping:
 This mapping is codified and tested in `scripts/loop/ui-designer-review-contract.mjs`
 (`mapAxeImpactToFindingSeverity`); the vision template no longer instructs the
 reviewer to eyeball contrast.
+
+## Console and network errors are review findings
+
+Each named state also carries a `console.json` (raw console errors and failed
+network requests attributed to that state, or JSON `null` when none were
+captured). A captured console error or failed network request — a swallowed 500,
+an uncaught page error — is a **must-fix finding**, never silently dropped: the
+reviewer grounds the finding in `consolePath` and hands it back for a fix. These
+errors are drained from the live drive's walk-level capture per state, so the
+same error is attributed to exactly one place and never double-reported.
 
 ## Review modes behind `dev-loop`
 
@@ -126,11 +137,12 @@ The loop fails closed when:
 - the review brief is missing or empty
 - the artifact bundle is missing
 - the artifact bundle has no named states
-- a named state lacks `screenshotPath`, `statePath`, `snapshotPath`, or `axePath`
+- a named state lacks `screenshotPath`, `statePath`, `snapshotPath`, `axePath`, or `consolePath`
 - vision mode is requested but a named state screenshot path does not end with `screenshot.png`
 - vision mode is requested but a named-state `statePath` does not end with `state.json`
 - vision mode is requested but a named-state `snapshotPath` does not end with `snapshot.json`
 - vision mode is requested but a named-state `axePath` does not end with `axe.json`
+- vision mode is requested but a named-state `consolePath` does not end with `console.json`
 - the work is not actually a UI slice \(the loop returns a skip outcome rather than failing closed\)
 - an unsupported `uiReviewMode` value (anything other than `designer` or `vision`) fails closed with `blocked_unsupported_review_mode`
 

--- a/docs/ui-designer-review-loop.md
+++ b/docs/ui-designer-review-loop.md
@@ -70,10 +70,13 @@ reviewer to eyeball contrast.
 Each named state also carries a `console.json` (raw console errors and failed
 network requests attributed to that state, or JSON `null` when none were
 captured). A captured console error or failed network request — a swallowed 500,
-an uncaught page error — is a **must-fix finding**, never silently dropped: the
-reviewer grounds the finding in `consolePath` and hands it back for a fix. These
-errors are drained from the live drive's walk-level capture per state, so the
-same error is attributed to exactly one place and never double-reported.
+an uncaught page error — is a **mechanical fail-closed signal**, never silently
+dropped: it flips the drive's `ok` to false and is anchored to its source line by
+the diagnose stage, independent of the review mode or the LLM. These errors are
+sliced from the live drive's walk-level capture per state for attribution WITHOUT
+being removed from that walk-level gate, so `console.json` and the mechanical
+failure set are two views of the same error; the final report dedups so it is
+never posted twice.
 
 ## Review modes behind `dev-loop`
 

--- a/docs/ui-review-recipe-contract.md
+++ b/docs/ui-review-recipe-contract.md
@@ -38,7 +38,7 @@ drive your app.
    boots the app and polls an HTTP readiness probe.
 2. **Auth + drive** — launches one headless WebKit context, authenticates
    through your dev-login recipe, dismisses declared interstitials once, then
-   walks the changed UI flows, capturing a screenshot + `state.json` + `snapshot.json` + `axe.json` per step.
+   walks the changed UI flows, capturing a screenshot + `state.json` + `snapshot.json` + `axe.json` + `console.json` per step.
 3. **Diagnose** — maps each captured failure to a source line and then to a PR
    diff line so a finding can anchor on a real changed line.
 4. **Report** — posts a head-pinned **pending** PR review and produces a

--- a/docs/ui-smoke-harness.md
+++ b/docs/ui-smoke-harness.md
@@ -17,7 +17,7 @@ The harness is intentionally small:
 - Playwright
 - WebKit only
 - fixture-backed scenarios
-- named screenshot/state/snapshot/axe artifact capture
+- named screenshot/state/snapshot/axe/console artifact capture
 - deterministic local artifact/report locations
 
 It is not a general E2E framework and it does not make browser validation mandatory for non-UI slices.
@@ -73,6 +73,7 @@ Each named-state directory currently contains:
 - `state.json`
 - `snapshot.json`
 - `axe.json`
+- `console.json`
 
 These paths are the local proving ground for the reusable artifact contract in [UI Artifact Contract](./ui-artifact-contract.md) and for later designer-review-loop work.
 

--- a/packages/core/src/loop/ui-review-drive.mjs
+++ b/packages/core/src/loop/ui-review-drive.mjs
@@ -36,8 +36,9 @@ export function isErrorResponseStatus(status) {
 
 /** Bound the stack text carried onto a page-error failure so a runaway stack
  * (or a synthetic error with a huge stack) can't bloat the feed envelope. Keeps
- * the head — the top frames, where the throwing file:line sits. */
-const PAGE_ERROR_STACK_MAX_CHARS = 4000;
+ * the head — the top frames, where the throwing file:line sits. Exported so the
+ * per-state console.json shaping clamps to the SAME bound as the mechanical feed. */
+export const PAGE_ERROR_STACK_MAX_CHARS = 4000;
 
 /** Lines of context to preserve on each side of a matching server-log line, so
  * the traceback frames that carry file:line (often on adjacent, non-matching

--- a/scripts/loop/ui-designer-review-contract.mjs
+++ b/scripts/loop/ui-designer-review-contract.mjs
@@ -75,6 +75,9 @@ export function validateUiDesignerReviewInput(input = {}) {
     if (typeof state.axePath !== 'string' || state.axePath.trim().length === 0) {
       incompleteArtifacts.push(`artifactBundle.namedStates[${index}].axePath`);
     }
+    if (typeof state.consolePath !== 'string' || state.consolePath.trim().length === 0) {
+      incompleteArtifacts.push(`artifactBundle.namedStates[${index}].consolePath`);
+    }
     if (reviewMode === 'vision' && typeof state.screenshotPath === 'string' && state.screenshotPath.trim().length > 0 && !state.screenshotPath.trim().endsWith('screenshot.png')) {
       incompleteArtifacts.push(`artifactBundle.namedStates[${index}].screenshotPath`);
     }
@@ -86,6 +89,9 @@ export function validateUiDesignerReviewInput(input = {}) {
     }
     if (reviewMode === 'vision' && typeof state.axePath === 'string' && state.axePath.trim().length > 0 && !state.axePath.trim().endsWith('axe.json')) {
       incompleteArtifacts.push(`artifactBundle.namedStates[${index}].axePath`);
+    }
+    if (reviewMode === 'vision' && typeof state.consolePath === 'string' && state.consolePath.trim().length > 0 && !state.consolePath.trim().endsWith('console.json')) {
+      incompleteArtifacts.push(`artifactBundle.namedStates[${index}].consolePath`);
     }
   });
   if (incompleteArtifacts.length > 0) {

--- a/scripts/loop/ui-review-drive.mjs
+++ b/scripts/loop/ui-review-drive.mjs
@@ -8,9 +8,12 @@
  * running-app URL from Stage 1 — capturing a step screenshot + state.json + snapshot.json + axe.json + console.json per
  * step. Response/requestfailed/pageerror listeners plus a server-log tail run
  * throughout so a swallowed error response is still recorded. The per-step
- * capture DRAINS the listener buffer into that step's console.json (per-state
- * attribution), so an event attributed to a state is not ALSO re-reported by the
- * walk-level classifier — the same error is never counted twice.
+ * capture SLICES the listener buffer (the events since the previous step) into
+ * that step's console.json for per-state attribution, WITHOUT clearing the
+ * buffer — so the same classified events still reach the drive's walk-level
+ * failure gate. The mechanical `ok`/`failures` gate stays authoritative: a
+ * captured step-scoped error deterministically fails the drive closed, and keeps
+ * its source-line anchoring, independent of the review mode or the LLM.
  *
  * This is a thin adapter: it wires the real IO seams (WebKit browser/page, the
  * page-event listeners, captureNamedUiState, the login form driving, the
@@ -108,14 +111,17 @@ export function parseUiReviewDriveCliArgs(argv) {
  * the shared threshold owner) are retained so the buffer stays bounded; the pure
  * classifier decides severity from the collected set.
  *
- * `drainCapturedEvents()` returns a snapshot of the events collected since the
- * last drain and CLEARS the buffer. The per-step capture drains its slice into
- * that state's console.json (per-state attribution); whatever is left when the
- * walk ends is what `getCapturedEvents()` hands the walk-level classifier — so an
- * event attributed to a named state is never ALSO classified at walk level (no
- * double-report between the per-state capture and the walk-level classifier).
+ * `sliceCapturedEvents()` returns the events appended since the previous slice
+ * and advances an internal cursor — it does NOT clear the buffer. The per-step
+ * capture slices its window into that state's console.json (per-state
+ * attribution), while `getCapturedEvents()` still hands the walk-level classifier
+ * the WHOLE buffer at walk end. So attribution and the mechanical fail-closed
+ * gate are two views of the same classified events, not a hand-off: a
+ * step-scoped error lands in its state's console.json AND still drives the drive's
+ * `ok`/`failures` gate (keeping its source-line anchoring). The final human-facing
+ * report dedups so the same error is not posted twice.
  *
- * @returns {{ getCapturedEvents: () => {responses:object[],requestFailures:object[],pageErrors:object[]}, drainCapturedEvents: () => {responses:object[],requestFailures:object[],pageErrors:object[]} }}
+ * @returns {{ getCapturedEvents: () => {responses:object[],requestFailures:object[],pageErrors:object[]}, sliceCapturedEvents: () => {responses:object[],requestFailures:object[],pageErrors:object[]} }}
  */
 export function attachPageListeners(page) {
   const responses = [];
@@ -138,17 +144,25 @@ export function attachPageListeners(page) {
     // mapping needs); the classifier bounds it before it lands on the feed.
     pageErrors.push({ message: err?.message ?? String(err), stack: err?.stack ?? null });
   });
-  const drainCapturedEvents = () => {
-    const drained = { responses: [...responses], requestFailures: [...requestFailures], pageErrors: [...pageErrors] };
-    responses.length = 0;
-    requestFailures.length = 0;
-    pageErrors.length = 0;
-    return drained;
+  // Per-state attribution cursor: return the window appended since the previous
+  // slice and advance, WITHOUT clearing — so the walk-level classifier still sees
+  // every event and the mechanical fail-closed gate stays authoritative.
+  const cursor = { responses: 0, requestFailures: 0, pageErrors: 0 };
+  const sliceCapturedEvents = () => {
+    const slice = {
+      responses: responses.slice(cursor.responses),
+      requestFailures: requestFailures.slice(cursor.requestFailures),
+      pageErrors: pageErrors.slice(cursor.pageErrors),
+    };
+    cursor.responses = responses.length;
+    cursor.requestFailures = requestFailures.length;
+    cursor.pageErrors = pageErrors.length;
+    return slice;
   };
-  return { getCapturedEvents: () => ({ responses, requestFailures, pageErrors }), drainCapturedEvents };
+  return { getCapturedEvents: () => ({ responses, requestFailures, pageErrors }), sliceCapturedEvents };
 }
 
-/** Shape a drained per-state slice of listener events into the console.json
+/** Shape a per-state slice of listener events into the console.json
  * review-input payload: JS `pageerror`s become `consoleErrors`, error responses
  * and failed requests become `failedRequests`. Returns null when the slice is
  * empty, so an errorless state emits a deterministic JSON null (mirroring the
@@ -259,8 +273,10 @@ async function dismissInterstitials({ page, interstitials, timeoutMs = 2000 }) {
   return { dismissed };
 }
 
-/** Map one declared step to its Playwright page call, then capture the state. */
-function makeRunStep({ page, outputDir, drainCapturedEvents }) {
+/** Map one declared step to its Playwright page call, then capture the state.
+ * Exported so the per-state attribution + consolePath threading has a regression
+ * test against the REAL production wiring (not a substitute fake runStep). */
+export function makeRunStep({ page, outputDir, sliceCapturedEvents }) {
   return async ({ appUrl, flow, step, index }) => {
     const sel = step.selector;
     switch (step.action) {
@@ -292,10 +308,10 @@ function makeRunStep({ page, outputDir, drainCapturedEvents }) {
       stateName,
       fullPage: false,
       outputDir,
-      // Drain the walk-level listener buffer into THIS state's console.json, so
-      // its console/network errors are attributed here and not re-reported by the
-      // walk-level classifier (single capture source, counted once).
-      captureConsole: drainCapturedEvents ? () => toPerStateConsolePayload(drainCapturedEvents()) : undefined,
+      // Slice the walk-level listener buffer into THIS state's console.json so its
+      // console/network errors are attributed here — WITHOUT clearing the buffer,
+      // so the same classified events still drive the walk-level fail-closed gate.
+      captureConsole: sliceCapturedEvents ? () => toPerStateConsolePayload(sliceCapturedEvents()) : undefined,
       metadata: { fixture: null, route: step.path ?? null, reviewHint: `Drive step "${stateName}" for the "${flow.name}" flow.` },
     });
     return { ok: true, screenshotPath: paths.screenshotPath, statePath: paths.statePath, snapshotPath: paths.snapshotPath, axePath: paths.axePath, consolePath: paths.consolePath };
@@ -335,7 +351,7 @@ export async function runCli(argv = process.argv.slice(2), { stdout = process.st
   try {
     const context = await browser.newContext();
     const page = await context.newPage();
-    const { getCapturedEvents, drainCapturedEvents } = attachPageListeners(page);
+    const { getCapturedEvents, sliceCapturedEvents } = attachPageListeners(page);
     const result = await driveUiReview(
       {
         appUrl: options.appUrl,
@@ -349,7 +365,7 @@ export async function runCli(argv = process.argv.slice(2), { stdout = process.st
       {
         authenticate: () => authenticate({ page, login: recipe.login }),
         dismissInterstitials: ({ interstitials }) => dismissInterstitials({ page, interstitials }),
-        runStep: makeRunStep({ page, outputDir: options.outputDir, drainCapturedEvents }),
+        runStep: makeRunStep({ page, outputDir: options.outputDir, sliceCapturedEvents }),
         getCapturedEvents,
         readServerLogTail: () => logTail.read(),
         log: (msg) => stderr.write(`[ui-review-drive] ${msg}\n`),

--- a/scripts/loop/ui-review-drive.mjs
+++ b/scripts/loop/ui-review-drive.mjs
@@ -29,7 +29,7 @@ import { webkit } from "@playwright/test";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { requireTokenValue } from "../_cli-primitives.mjs";
 import { loadDevLoopConfig, resolveUiReviewDriveRecipe } from "@dev-loops/core/config";
-import { driveUiReview, isErrorResponseStatus } from "@dev-loops/core/loop/ui-review-drive";
+import { driveUiReview, isErrorResponseStatus, PAGE_ERROR_STACK_MAX_CHARS } from "@dev-loops/core/loop/ui-review-drive";
 import { captureNamedUiState } from "../../test/playwright/harness/webkit-smoke-harness.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 
@@ -168,7 +168,12 @@ export function attachPageListeners(page) {
  * empty, so an errorless state emits a deterministic JSON null (mirroring the
  * snapshot/axe best-effort policy) rather than an empty envelope. */
 export function toPerStateConsolePayload(events = {}) {
-  const consoleErrors = (events.pageErrors ?? []).map((e) => ({ message: e.message ?? null, stack: e.stack ?? null }));
+  const consoleErrors = (events.pageErrors ?? []).map((e) => ({
+    message: e.message ?? null,
+    // Clamp to the SAME bound the mechanical feed uses (classifyFailures) so a
+    // runaway stack can't bloat console.json and the two views stay consistent.
+    stack: typeof e.stack === "string" && e.stack.length > 0 ? e.stack.slice(0, PAGE_ERROR_STACK_MAX_CHARS) : null,
+  }));
   const failedRequests = [
     ...(events.responses ?? []).map((r) => ({ kind: "error-response", url: r.url ?? null, status: r.status })),
     ...(events.requestFailures ?? []).map((f) => ({ kind: "request-failed", url: f.url ?? null, failure: f.failure ?? null })),
@@ -302,16 +307,22 @@ export function makeRunStep({ page, outputDir, sliceCapturedEvents }) {
         throw new Error(`unknown step action: ${step.action}`);
     }
     const stateName = step.name ?? `${flow.name} ${step.action} ${index + 1}`;
+    // Slice the walk-level listener window for THIS state IMMEDIATELY after the step
+    // action — BEFORE capturing artifacts — so the attribution cursor advances even if
+    // captureNamedUiState later throws (screenshot/file-write failure). Otherwise the
+    // next step's console.json would misattribute this step's events. Slicing never
+    // clears the buffer, so getCapturedEvents still feeds the whole set to the
+    // mechanical fail-closed gate.
+    const consolePayload = sliceCapturedEvents ? toPerStateConsolePayload(sliceCapturedEvents()) : undefined;
     const paths = await captureNamedUiState({
       page,
       sliceId: flow.name,
       stateName,
       fullPage: false,
       outputDir,
-      // Slice the walk-level listener buffer into THIS state's console.json so its
-      // console/network errors are attributed here — WITHOUT clearing the buffer,
-      // so the same classified events still drive the walk-level fail-closed gate.
-      captureConsole: sliceCapturedEvents ? () => toPerStateConsolePayload(sliceCapturedEvents()) : undefined,
+      // Hand the already-sliced window to this state's console.json (same attribution
+      // as before when capture succeeds); the cursor already advanced above.
+      captureConsole: sliceCapturedEvents ? () => consolePayload : undefined,
       metadata: { fixture: null, route: step.path ?? null, reviewHint: `Drive step "${stateName}" for the "${flow.name}" flow.` },
     });
     return { ok: true, screenshotPath: paths.screenshotPath, statePath: paths.statePath, snapshotPath: paths.snapshotPath, axePath: paths.axePath, consolePath: paths.consolePath };

--- a/scripts/loop/ui-review-drive.mjs
+++ b/scripts/loop/ui-review-drive.mjs
@@ -5,9 +5,12 @@
  * Launches one headless WebKit context, authenticates as the change's target
  * role via the project's dev-login recipe, dismisses config-declared
  * interstitials once, then walks the changed flows against the arbitrary
- * running-app URL from Stage 1 — capturing a step screenshot + state.json + snapshot.json + axe.json per
+ * running-app URL from Stage 1 — capturing a step screenshot + state.json + snapshot.json + axe.json + console.json per
  * step. Response/requestfailed/pageerror listeners plus a server-log tail run
- * throughout so a swallowed error response is still recorded.
+ * throughout so a swallowed error response is still recorded. The per-step
+ * capture DRAINS the listener buffer into that step's console.json (per-state
+ * attribution), so an event attributed to a state is not ALSO re-reported by the
+ * walk-level classifier — the same error is never counted twice.
  *
  * This is a thin adapter: it wires the real IO seams (WebKit browser/page, the
  * page-event listeners, captureNamedUiState, the login form driving, the
@@ -34,7 +37,7 @@ capturing step screenshots + error-response/pageerror/server-log failures (Stage
 Required:
   --repo-root <p>      Absolute path to the (provisioned) worktree carrying the .devloops recipe.
   --app-url <url>      The running-app URL handed off by Stage 1.
-  --output-dir <p>     Directory for the ordered step screenshots + state.json + snapshot.json + axe.json artifacts.
+  --output-dir <p>     Directory for the ordered step screenshots + state.json + snapshot.json + axe.json + console.json artifacts.
 Optional:
   --changed-path <p>   A changed file path (repeatable); drives the changed-flow selection heuristic.
   -h, --help           Show this help.
@@ -105,7 +108,14 @@ export function parseUiReviewDriveCliArgs(argv) {
  * the shared threshold owner) are retained so the buffer stays bounded; the pure
  * classifier decides severity from the collected set.
  *
- * @returns {{ getCapturedEvents: () => {responses:object[],requestFailures:object[],pageErrors:object[]} }}
+ * `drainCapturedEvents()` returns a snapshot of the events collected since the
+ * last drain and CLEARS the buffer. The per-step capture drains its slice into
+ * that state's console.json (per-state attribution); whatever is left when the
+ * walk ends is what `getCapturedEvents()` hands the walk-level classifier — so an
+ * event attributed to a named state is never ALSO classified at walk level (no
+ * double-report between the per-state capture and the walk-level classifier).
+ *
+ * @returns {{ getCapturedEvents: () => {responses:object[],requestFailures:object[],pageErrors:object[]}, drainCapturedEvents: () => {responses:object[],requestFailures:object[],pageErrors:object[]} }}
  */
 export function attachPageListeners(page) {
   const responses = [];
@@ -128,7 +138,29 @@ export function attachPageListeners(page) {
     // mapping needs); the classifier bounds it before it lands on the feed.
     pageErrors.push({ message: err?.message ?? String(err), stack: err?.stack ?? null });
   });
-  return { getCapturedEvents: () => ({ responses, requestFailures, pageErrors }) };
+  const drainCapturedEvents = () => {
+    const drained = { responses: [...responses], requestFailures: [...requestFailures], pageErrors: [...pageErrors] };
+    responses.length = 0;
+    requestFailures.length = 0;
+    pageErrors.length = 0;
+    return drained;
+  };
+  return { getCapturedEvents: () => ({ responses, requestFailures, pageErrors }), drainCapturedEvents };
+}
+
+/** Shape a drained per-state slice of listener events into the console.json
+ * review-input payload: JS `pageerror`s become `consoleErrors`, error responses
+ * and failed requests become `failedRequests`. Returns null when the slice is
+ * empty, so an errorless state emits a deterministic JSON null (mirroring the
+ * snapshot/axe best-effort policy) rather than an empty envelope. */
+export function toPerStateConsolePayload(events = {}) {
+  const consoleErrors = (events.pageErrors ?? []).map((e) => ({ message: e.message ?? null, stack: e.stack ?? null }));
+  const failedRequests = [
+    ...(events.responses ?? []).map((r) => ({ kind: "error-response", url: r.url ?? null, status: r.status })),
+    ...(events.requestFailures ?? []).map((f) => ({ kind: "request-failed", url: f.url ?? null, failure: f.failure ?? null })),
+  ];
+  if (consoleErrors.length === 0 && failedRequests.length === 0) return null;
+  return { consoleErrors, failedRequests };
 }
 
 /** Cap the bytes a single tail read pulls into memory, so a huge log growth
@@ -228,7 +260,7 @@ async function dismissInterstitials({ page, interstitials, timeoutMs = 2000 }) {
 }
 
 /** Map one declared step to its Playwright page call, then capture the state. */
-function makeRunStep({ page, outputDir }) {
+function makeRunStep({ page, outputDir, drainCapturedEvents }) {
   return async ({ appUrl, flow, step, index }) => {
     const sel = step.selector;
     switch (step.action) {
@@ -260,9 +292,13 @@ function makeRunStep({ page, outputDir }) {
       stateName,
       fullPage: false,
       outputDir,
+      // Drain the walk-level listener buffer into THIS state's console.json, so
+      // its console/network errors are attributed here and not re-reported by the
+      // walk-level classifier (single capture source, counted once).
+      captureConsole: drainCapturedEvents ? () => toPerStateConsolePayload(drainCapturedEvents()) : undefined,
       metadata: { fixture: null, route: step.path ?? null, reviewHint: `Drive step "${stateName}" for the "${flow.name}" flow.` },
     });
-    return { ok: true, screenshotPath: paths.screenshotPath, statePath: paths.statePath, snapshotPath: paths.snapshotPath, axePath: paths.axePath };
+    return { ok: true, screenshotPath: paths.screenshotPath, statePath: paths.statePath, snapshotPath: paths.snapshotPath, axePath: paths.axePath, consolePath: paths.consolePath };
   };
 }
 
@@ -299,7 +335,7 @@ export async function runCli(argv = process.argv.slice(2), { stdout = process.st
   try {
     const context = await browser.newContext();
     const page = await context.newPage();
-    const { getCapturedEvents } = attachPageListeners(page);
+    const { getCapturedEvents, drainCapturedEvents } = attachPageListeners(page);
     const result = await driveUiReview(
       {
         appUrl: options.appUrl,
@@ -313,7 +349,7 @@ export async function runCli(argv = process.argv.slice(2), { stdout = process.st
       {
         authenticate: () => authenticate({ page, login: recipe.login }),
         dismissInterstitials: ({ interstitials }) => dismissInterstitials({ page, interstitials }),
-        runStep: makeRunStep({ page, outputDir: options.outputDir }),
+        runStep: makeRunStep({ page, outputDir: options.outputDir, drainCapturedEvents }),
         getCapturedEvents,
         readServerLogTail: () => logTail.read(),
         log: (msg) => stderr.write(`[ui-review-drive] ${msg}\n`),

--- a/skills/dev-loop/templates/ui-vision-review.md
+++ b/skills/dev-loop/templates/ui-vision-review.md
@@ -15,13 +15,15 @@ You are a vision-capable UI reviewer (model: `gpt-5.4`) reviewing deterministic 
   - `statePath` (must point to `state.json`)
   - `snapshotPath` (must point to `snapshot.json`)
   - `axePath` (must point to `axe.json`)
+  - `consolePath` (must point to `console.json`)
 
 ## Review policy
 
 1. Fail closed when required inputs are missing, ambiguous, or unreadable.
 2. Ground every finding in one or more `screenshotPath` and `statePath` references. Ground accessibility findings in `axePath`.
 3. Evaluate layout, hierarchy, spacing, clipping, overlap, callouts/highlighting, and state-transition clarity against the acceptance criteria and review brief. Do **not** eyeball computable accessibility facts (color contrast, missing accessible names/roles, and similar). Those are asserted from `axe.json` evidence, not judged from pixels: cite the axe rule `id`/`impact` and map its impact to finding severity (`critical`/`serious` → `high`, `moderate` → `medium`, `minor` → `low`; unranked/unknown → `medium`).
-4. Return only deterministic findings; do not invent evidence that is not visible in artifacts.
+4. Treat any console error or failed network request in `console.json` as a must-fix finding grounded in `consolePath` (a swallowed 500, an uncaught page error). Never silently drop a captured error; a state whose `console.json` is JSON `null` captured none.
+5. Return only deterministic findings; do not invent evidence that is not visible in artifacts.
 
 ## Required output format
 

--- a/skills/dev-loop/templates/ui-vision-review.md
+++ b/skills/dev-loop/templates/ui-vision-review.md
@@ -22,7 +22,7 @@ You are a vision-capable UI reviewer (model: `gpt-5.4`) reviewing deterministic 
 1. Fail closed when required inputs are missing, ambiguous, or unreadable.
 2. Ground every finding in one or more `screenshotPath` and `statePath` references. Ground accessibility findings in `axePath`.
 3. Evaluate layout, hierarchy, spacing, clipping, overlap, callouts/highlighting, and state-transition clarity against the acceptance criteria and review brief. Do **not** eyeball computable accessibility facts (color contrast, missing accessible names/roles, and similar). Those are asserted from `axe.json` evidence, not judged from pixels: cite the axe rule `id`/`impact` and map its impact to finding severity (`critical`/`serious` → `high`, `moderate` → `medium`, `minor` → `low`; unranked/unknown → `medium`).
-4. Treat any console error or failed network request in `console.json` as a must-fix finding grounded in `consolePath` (a swallowed 500, an uncaught page error). Never silently drop a captured error; a state whose `console.json` is JSON `null` captured none.
+4. Read `console.json` as evidence for that state (its captured console errors and failed network requests: a swallowed 500, an uncaught page error). These captured errors are ALREADY surfaced as fail-closed, source-anchored must-fix findings by the drive's mechanical failure gate — do **not** re-file them as separate findings (the report dedups against the mechanical set). Use `console.json` to corroborate or explain a visual finding, never to independently pass a state; a state whose `console.json` is JSON `null` captured none.
 5. Return only deterministic findings; do not invent evidence that is not visible in artifacts.
 
 ## Required output format

--- a/skills/ui-review/SKILL.md
+++ b/skills/ui-review/SKILL.md
@@ -61,18 +61,22 @@ one headless WebKit context, authenticates as the change's target role through a
 project-provided dev-login recipe, dismisses config-declared interstitials once
 per context, then walks the selected flows — rendering each page and exercising
 its declared create/edit/reorder/upload/toggle interactions — capturing a step
-screenshot + sibling `state.json` + `snapshot.json` + `axe.json` per step via `captureNamedUiState`. It fails
+screenshot + sibling `state.json` + `snapshot.json` + `axe.json` + `console.json` per step via `captureNamedUiState`. It fails
 closed to a stated stop reason when it cannot authenticate, and drives nothing.
 
 Throughout the walk, `response`, `requestfailed`, and `pageerror` listeners run
 and the project server log is tailed, so a swallowed error response (a 500 the UI
 hides behind a success state) is still recorded. An error response is a status
 <200 or >=400; 3xx redirects are normal navigation (login/canonical) and are not
-flagged. The stage emits an ordered set of step screenshots plus a structured
-captured-failures list (error responses, request failures, page errors,
-server-log exceptions) that
-feeds the next stage. Every bounded cap — max screenshots, screens skipped, and
-the fixed no-retry policy — is logged explicitly.
+flagged. Each per-step capture DRAINS that listener buffer into the step's
+`console.json` (per-state attribution of console errors + failed requests), so an
+error attributed to a named state is not ALSO re-reported by the walk-level
+classifier — the same error is captured once and counted once. The stage emits an
+ordered set of step screenshots plus a structured captured-failures list (the
+walk-level remainder: server-log exceptions, step failures, and any events
+outside a captured state) that feeds the next stage. Every bounded cap — max
+screenshots, screens skipped, and the fixed no-retry policy — is logged
+explicitly.
 
 Which flows are driven is a bounded heuristic over an explicit allowlist, never
 an unbounded crawl: each `uiReview.flows` entry declares `pathPatterns` matched

--- a/skills/ui-review/SKILL.md
+++ b/skills/ui-review/SKILL.md
@@ -68,13 +68,15 @@ Throughout the walk, `response`, `requestfailed`, and `pageerror` listeners run
 and the project server log is tailed, so a swallowed error response (a 500 the UI
 hides behind a success state) is still recorded. An error response is a status
 <200 or >=400; 3xx redirects are normal navigation (login/canonical) and are not
-flagged. Each per-step capture DRAINS that listener buffer into the step's
-`console.json` (per-state attribution of console errors + failed requests), so an
-error attributed to a named state is not ALSO re-reported by the walk-level
-classifier — the same error is captured once and counted once. The stage emits an
-ordered set of step screenshots plus a structured captured-failures list (the
-walk-level remainder: server-log exceptions, step failures, and any events
-outside a captured state) that feeds the next stage. Every bounded cap — max
+flagged. Each per-step capture SLICES that listener buffer into the step's
+`console.json` (per-state attribution of console errors + failed requests)
+WITHOUT clearing it, so the same classified events still reach the walk-level
+failure gate — a captured step-scoped error deterministically fails the drive
+closed and keeps its source-line anchoring. The stage emits an ordered set of
+step screenshots plus a structured captured-failures list (error responses,
+request failures, page errors, server-log exceptions, and step failures) that
+feeds the next stage; the final report dedups per-state attribution against that
+list so the same error is not posted twice. Every bounded cap — max
 screenshots, screens skipped, and the fixed no-retry policy — is logged
 explicitly.
 

--- a/test/contracts/ui-artifact-contract.test.mjs
+++ b/test/contracts/ui-artifact-contract.test.mjs
@@ -21,6 +21,7 @@ test('ui artifact contract doc defines named-state artifacts and auto-scoped CI 
   assert.match(doc, /snapshot\.json/i);
   assert.match(doc, /axe\.json/i);
   assert.match(doc, /axe-core/i);
+  assert.match(doc, /console\.json/i);
   assert.match(doc, /test-results\/ui-smoke\/<sliceId>\/named-states\/<state-slug>/i);
   assert.match(doc, /screenshot alone is acceptable/i);
   assert.match(doc, /state artifact bundle is required/i);

--- a/test/contracts/ui-designer-review-loop-contract.test.mjs
+++ b/test/contracts/ui-designer-review-loop-contract.test.mjs
@@ -31,6 +31,9 @@ test('designer review loop doc remains the canonical bounded UI review handoff c
   // Accessibility findings are asserted from axe evidence, not eyeballed.
   assert.match(doc, /axe\.json/i);
   assert.match(doc, /mapAxeImpactToFindingSeverity/);
+  // Console/network errors are per-state review findings, never dropped.
+  assert.match(doc, /console\.json/i);
+  assert.match(doc, /consolePath/);
 
   await assert.rejects(
     stat(fromRepoRoot('skills/dev-loop/templates/ui-designer-review.md')),
@@ -46,6 +49,9 @@ test('designer review loop doc remains the canonical bounded UI review handoff c
   // Computable a11y facts come from axe.json, not pixel judgment.
   assert.match(visionTemplate, /axe\.json/i);
   assert.match(visionTemplate, /Do \*\*not\*\* eyeball computable accessibility facts/i);
+  // Console/network errors in console.json are must-fix findings, never dropped.
+  assert.match(visionTemplate, /console\.json/i);
+  assert.match(visionTemplate, /must-fix finding/i);
   assert.match(indexDoc, /ui-designer-review-loop\.md/i);
   assert.match(localImplementationSkill, /\.\.\/\.\.\/docs\/ui-designer-review-loop\.md/i);
 });

--- a/test/contracts/ui-designer-review-loop-contract.test.mjs
+++ b/test/contracts/ui-designer-review-loop-contract.test.mjs
@@ -49,7 +49,8 @@ test('designer review loop doc remains the canonical bounded UI review handoff c
   // Computable a11y facts come from axe.json, not pixel judgment.
   assert.match(visionTemplate, /axe\.json/i);
   assert.match(visionTemplate, /Do \*\*not\*\* eyeball computable accessibility facts/i);
-  // Console/network errors in console.json are must-fix findings, never dropped.
+  // console.json errors are already mechanically-owned must-fix findings the
+  // reviewer reads as evidence (not re-filed): the template names that ownership.
   assert.match(visionTemplate, /console\.json/i);
   assert.match(visionTemplate, /must-fix finding/i);
   assert.match(indexDoc, /ui-designer-review-loop\.md/i);

--- a/test/contracts/ui-smoke-harness-contract.test.mjs
+++ b/test/contracts/ui-smoke-harness-contract.test.mjs
@@ -17,7 +17,7 @@ test('ui smoke harness doc defines the bounded reusable local Playwright/WebKit 
   assert.match(doc, /Playwright/i);
   assert.match(doc, /WebKit only/i);
   assert.match(doc, /fixture-backed/i);
-  assert.match(doc, /named screenshot\/state\/snapshot\/axe artifact capture/i);
+  assert.match(doc, /named screenshot\/state\/snapshot\/axe\/console artifact capture/i);
   assert.match(doc, /test-results\/ui-smoke\/inspect-run-viewer/i);
   assert.match(doc, /playwright-report\/ui-smoke\/inspect-run-viewer/i);
   assert.match(doc, /ui-artifact-contract\.md/i);

--- a/test/loop/ui-designer-review-contract.test.mjs
+++ b/test/loop/ui-designer-review-contract.test.mjs
@@ -52,6 +52,7 @@ test('validateUiDesignerReviewInput rejects incomplete named-state artifacts', (
           screenshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/screenshot.png',
           snapshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/snapshot.json',
           axePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/axe.json',
+          consolePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/console.json',
         },
       ],
     },
@@ -78,6 +79,7 @@ test('validateUiDesignerReviewInput accepts the artifact bundle from the reusabl
           statePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/state.json',
           snapshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/snapshot.json',
           axePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/axe.json',
+          consolePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/console.json',
         },
       ],
     },
@@ -108,6 +110,7 @@ test('validateUiDesignerReviewInput routes opted-in UI slices to vision review',
           statePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/state.json',
           snapshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/snapshot.json',
           axePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/axe.json',
+          consolePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/console.json',
         },
       ],
     },
@@ -137,6 +140,7 @@ test('validateUiDesignerReviewInput fails closed when vision review lacks screen
           statePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/state.json',
           snapshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/snapshot.json',
           axePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/axe.json',
+          consolePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/console.json',
         },
       ],
     },
@@ -178,6 +182,7 @@ test('validateUiDesignerReviewInput fails closed when vision review lacks state.
           statePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/meta.txt',
           snapshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/snapshot.json',
           axePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/axe.json',
+          consolePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/console.json',
         },
       ],
     },
@@ -202,6 +207,7 @@ test('validateUiDesignerReviewInput fails closed when a named state is missing s
           screenshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/screenshot.png',
           statePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/state.json',
           axePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/axe.json',
+          consolePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/console.json',
         },
       ],
     },
@@ -228,6 +234,7 @@ test('validateUiDesignerReviewInput fails closed when vision review has a malfor
           statePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/state.json',
           snapshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/a11y.txt',
           axePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/axe.json',
+          consolePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/console.json',
         },
       ],
     },
@@ -252,6 +259,7 @@ test('validateUiDesignerReviewInput fails closed when a named state is missing a
           screenshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/screenshot.png',
           statePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/state.json',
           snapshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/snapshot.json',
+          consolePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/console.json',
         },
       ],
     },
@@ -278,6 +286,7 @@ test('validateUiDesignerReviewInput fails closed when vision review has a malfor
           statePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/state.json',
           snapshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/snapshot.json',
           axePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/axe.txt',
+          consolePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/console.json',
         },
       ],
     },
@@ -286,6 +295,58 @@ test('validateUiDesignerReviewInput fails closed when vision review has a malfor
   assert.equal(result.ok, false);
   assert.equal(result.status, 'blocked_incomplete_artifact_bundle');
   assert.deepEqual(result.missing, ['artifactBundle.namedStates[0].axePath']);
+});
+
+test('validateUiDesignerReviewInput fails closed when a named state is missing console.json', () => {
+  const result = validateUiDesignerReviewInput({
+    workType: 'ui',
+    uiReviewRequested: true,
+    acceptanceCriteria: ['named dashboard state renders'],
+    reviewBrief: 'Check layout and visual hierarchy.',
+    artifactBundle: {
+      sliceId: 'inspect-run-viewer',
+      namedStates: [
+        {
+          stateName: 'Current PR dashboard',
+          screenshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/screenshot.png',
+          statePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/state.json',
+          snapshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/snapshot.json',
+          axePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/axe.json',
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 'blocked_incomplete_artifact_bundle');
+  assert.deepEqual(result.missing, ['artifactBundle.namedStates[0].consolePath']);
+});
+
+test('validateUiDesignerReviewInput fails closed when vision review has a malformed console path', () => {
+  const result = validateUiDesignerReviewInput({
+    workType: 'ui',
+    uiReviewRequested: true,
+    uiReviewMode: 'vision',
+    acceptanceCriteria: ['named dashboard state renders'],
+    reviewBrief: 'Check layout and visual hierarchy.',
+    artifactBundle: {
+      sliceId: 'inspect-run-viewer',
+      namedStates: [
+        {
+          stateName: 'Current PR dashboard',
+          screenshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/screenshot.png',
+          statePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/state.json',
+          snapshotPath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/snapshot.json',
+          axePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/axe.json',
+          consolePath: 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard/console.txt',
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 'blocked_incomplete_artifact_bundle');
+  assert.deepEqual(result.missing, ['artifactBundle.namedStates[0].consolePath']);
 });
 
 test('mapAxeImpactToFindingSeverity maps axe impact ranks to finding severities', () => {

--- a/test/loop/ui-review-drive.test.mjs
+++ b/test/loop/ui-review-drive.test.mjs
@@ -11,6 +11,7 @@ import {
   classifyFailures,
   driveUiReview,
   isErrorResponseStatus,
+  PAGE_ERROR_STACK_MAX_CHARS,
 } from "@dev-loops/core/loop/ui-review-drive";
 import { resolveUiReviewDriveRecipe, DEFAULT_SERVER_LOG_EXCEPTION_PATTERN } from "@dev-loops/core/config";
 import {
@@ -236,6 +237,13 @@ test("toPerStateConsolePayload: shapes a per-state slice into console/network fi
   ]);
 });
 
+test("toPerStateConsolePayload: clamps a runaway pageerror stack to the SAME bound as the mechanical feed (bounded console.json)", () => {
+  const huge = "x".repeat(PAGE_ERROR_STACK_MAX_CHARS + 5000);
+  const payload = toPerStateConsolePayload({ pageErrors: [{ message: "boom", stack: huge }] });
+  assert.equal(payload.consoleErrors[0].stack.length, PAGE_ERROR_STACK_MAX_CHARS, "stack clamped to the shared classifyFailures bound");
+  assert.equal(payload.consoleErrors[0].stack, huge.slice(0, PAGE_ERROR_STACK_MAX_CHARS), "keeps the head — the throwing file:line");
+});
+
 test("openServerLogTail: absent path is a no-op; missing file reads once created", async () => {
   assert.equal(await openServerLogTail(null).read(), "");
   const p = path.join(tempDir(), "late.log");
@@ -424,6 +432,39 @@ test("makeRunStep: threads consolePath into the runStep result and points state.
   assert.ok(typeof outcome.consolePath === "string" && outcome.consolePath.endsWith("console.json"), "consolePath is threaded into the runStep result");
   const state = JSON.parse(readFileSync(outcome.statePath, "utf8"));
   assert.equal(state.artifacts.console.path, outcome.consolePath, "state.json back-references the same console.json");
+});
+
+test("makeRunStep: a capture failure still advances the attribution cursor — the next step's console.json does not inherit the prior step's events (no misattribution)", async () => {
+  const outputDir = tempDir();
+  const handlers = {};
+  let failScreenshot = false;
+  const page = {
+    on: (ev, cb) => ((handlers[ev] ??= []).push(cb), undefined),
+    emit: (ev, arg) => (handlers[ev] ?? []).forEach((cb) => cb(arg)),
+    goto: async () => {},
+    click: async () => page.emit("pageerror", { message: "boom", stack: "boom\n    at app.js:1" }),
+    screenshot: async () => { if (failScreenshot) throw new Error("screenshot failed"); },
+  };
+  const { getCapturedEvents, sliceCapturedEvents } = attachPageListeners(page);
+  const runStep = makeRunStep({ page, outputDir, sliceCapturedEvents });
+
+  // Step 1: fires a pageerror DURING the action, then its artifact capture throws.
+  failScreenshot = true;
+  await assert.rejects(
+    runStep({ appUrl: "http://app", flow: { name: "checkout" }, step: { name: "s1", action: "click" }, index: 0 }),
+    /screenshot failed/,
+  );
+
+  // Step 2: a clean action (no events); its console.json MUST be null. If the
+  // cursor had not advanced past step 1 (capture threw), step 1's pageerror would
+  // misattribute forward into step 2 — this asserts it does not.
+  failScreenshot = false;
+  const out2 = await runStep({ appUrl: "http://app", flow: { name: "checkout" }, step: { name: "s2", action: "goto", path: "/next" }, index: 1 });
+  const console2 = JSON.parse(readFileSync(out2.consolePath, "utf8"));
+  assert.equal(console2, null, "step 2 console.json is null — step 1's error was not misattributed forward");
+
+  // Slicing never clears: the walk-level mechanical fail-closed gate still sees step 1's error.
+  assert.equal(getCapturedEvents().pageErrors.length, 1, "the buffer retains step 1's error for the mechanical gate");
 });
 
 // ── Config resolver ──────────────────────────────────────────────────────────

--- a/test/loop/ui-review-drive.test.mjs
+++ b/test/loop/ui-review-drive.test.mjs
@@ -17,6 +17,7 @@ import {
   parseUiReviewDriveCliArgs,
   attachPageListeners,
   openServerLogTail,
+  toPerStateConsolePayload,
 } from "../../scripts/loop/ui-review-drive.mjs";
 
 const tempFiles = [];
@@ -170,6 +171,45 @@ test("attachPageListeners: captures requestfailed and pageerror (with err.stack 
   assert.deepEqual(e.requestFailures, [{ url: "http://x/img", failure: "net::ERR" }]);
   // The file:line signal Stage 3 needs is captured off err.stack, not discarded.
   assert.deepEqual(e.pageErrors, [{ message: "TypeError: boom", stack: "TypeError: boom\n    at app.js:42:9" }]);
+});
+
+test("drainCapturedEvents: attributes a per-state slice and clears it so the walk-level classifier can't double-report the same event", () => {
+  const page = fakePage();
+  const { getCapturedEvents, drainCapturedEvents } = attachPageListeners(page);
+  page.emit("response", { status: () => 500, url: () => "http://app/save" });
+  page.emit("pageerror", { message: "TypeError: boom", stack: "TypeError: boom\n    at app.js:1" });
+
+  // The per-state capture drains its slice (this becomes the state's console.json).
+  const drained = drainCapturedEvents();
+  assert.deepEqual(drained.responses, [{ url: "http://app/save", status: 500 }]);
+  assert.equal(drained.pageErrors.length, 1);
+
+  // Draining clears the buffer, so the walk-level classifier sees nothing to
+  // re-report — the same error is counted once, never twice.
+  const leftover = getCapturedEvents();
+  assert.deepEqual(leftover.responses, []);
+  assert.deepEqual(leftover.requestFailures, []);
+  assert.deepEqual(leftover.pageErrors, []);
+  assert.equal(classifyFailures(leftover).length, 0);
+
+  // A later event lands only in the next drain, never retroactively in the first.
+  page.emit("requestfailed", { url: () => "http://app/img", failure: () => ({ errorText: "net::ERR" }) });
+  assert.deepEqual(drainCapturedEvents().requestFailures, [{ url: "http://app/img", failure: "net::ERR" }]);
+});
+
+test("toPerStateConsolePayload: shapes a drained slice into console/network findings; null when empty", () => {
+  assert.equal(toPerStateConsolePayload({ responses: [], requestFailures: [], pageErrors: [] }), null);
+  assert.equal(toPerStateConsolePayload({}), null);
+  const payload = toPerStateConsolePayload({
+    responses: [{ url: "http://app/save", status: 500 }],
+    requestFailures: [{ url: "http://app/img", failure: "net::ERR" }],
+    pageErrors: [{ message: "boom", stack: "boom\n    at app.js:1" }],
+  });
+  assert.deepEqual(payload.consoleErrors, [{ message: "boom", stack: "boom\n    at app.js:1" }]);
+  assert.deepEqual(payload.failedRequests, [
+    { kind: "error-response", url: "http://app/save", status: 500 },
+    { kind: "request-failed", url: "http://app/img", failure: "net::ERR" },
+  ]);
 });
 
 test("openServerLogTail: absent path is a no-op; missing file reads once created", async () => {

--- a/test/loop/ui-review-drive.test.mjs
+++ b/test/loop/ui-review-drive.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test, { after } from "node:test";
-import { mkdtempSync, rmSync, writeFileSync, appendFileSync, chmodSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, appendFileSync, chmodSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -16,9 +16,26 @@ import { resolveUiReviewDriveRecipe, DEFAULT_SERVER_LOG_EXCEPTION_PATTERN } from
 import {
   parseUiReviewDriveCliArgs,
   attachPageListeners,
+  makeRunStep,
   openServerLogTail,
   toPerStateConsolePayload,
 } from "../../scripts/loop/ui-review-drive.mjs";
+
+// A fake page for the real makeRunStep wiring: the emitter interface
+// (attachPageListeners) + the action/capture methods captureNamedUiState calls.
+// `click` fires a swallowed 500 DURING the step, so it lands in the slice
+// attributed to that state — exercising the production drain/attribute path.
+function fakeDrivePage() {
+  const handlers = {};
+  const page = {
+    on: (ev, cb) => ((handlers[ev] ??= []).push(cb), undefined),
+    emit: (ev, arg) => (handlers[ev] ?? []).forEach((cb) => cb(arg)),
+    goto: async () => {},
+    click: async () => page.emit("response", { status: () => 500, url: () => "http://app/save" }),
+    screenshot: async () => {},
+  };
+  return page;
+}
 
 const tempFiles = [];
 after(() => {
@@ -173,31 +190,38 @@ test("attachPageListeners: captures requestfailed and pageerror (with err.stack 
   assert.deepEqual(e.pageErrors, [{ message: "TypeError: boom", stack: "TypeError: boom\n    at app.js:42:9" }]);
 });
 
-test("drainCapturedEvents: attributes a per-state slice and clears it so the walk-level classifier can't double-report the same event", () => {
+test("sliceCapturedEvents: attributes a per-state window WITHOUT clearing, so the walk-level gate still sees the same classified error (AC2)", () => {
   const page = fakePage();
-  const { getCapturedEvents, drainCapturedEvents } = attachPageListeners(page);
+  const { getCapturedEvents, sliceCapturedEvents } = attachPageListeners(page);
   page.emit("response", { status: () => 500, url: () => "http://app/save" });
   page.emit("pageerror", { message: "TypeError: boom", stack: "TypeError: boom\n    at app.js:1" });
 
-  // The per-state capture drains its slice (this becomes the state's console.json).
-  const drained = drainCapturedEvents();
-  assert.deepEqual(drained.responses, [{ url: "http://app/save", status: 500 }]);
-  assert.equal(drained.pageErrors.length, 1);
+  // The per-state capture slices its window (this becomes the state's console.json).
+  const slice = sliceCapturedEvents();
+  assert.deepEqual(slice.responses, [{ url: "http://app/save", status: 500 }]);
+  assert.equal(slice.pageErrors.length, 1);
 
-  // Draining clears the buffer, so the walk-level classifier sees nothing to
-  // re-report — the same error is counted once, never twice.
-  const leftover = getCapturedEvents();
-  assert.deepEqual(leftover.responses, []);
-  assert.deepEqual(leftover.requestFailures, []);
-  assert.deepEqual(leftover.pageErrors, []);
-  assert.equal(classifyFailures(leftover).length, 0);
+  // Slicing does NOT clear the buffer: the walk-level classifier still sees the
+  // SAME events, so a captured step-scoped error deterministically fails the drive
+  // closed (mechanical gate authoritative), keeping its source-line anchoring.
+  const whole = getCapturedEvents();
+  assert.deepEqual(whole.responses, [{ url: "http://app/save", status: 500 }]);
+  assert.equal(whole.pageErrors.length, 1);
+  const failures = classifyFailures(whole);
+  assert.ok(failures.some((f) => f.kind === "error-response"), "the sliced 500 still reaches the walk-level gate");
+  assert.ok(failures.some((f) => f.kind === "page-error" && /at app\.js:1/.test(f.stack)), "the sliced page error keeps its stack for anchoring");
 
-  // A later event lands only in the next drain, never retroactively in the first.
+  // The cursor advances: a later event lands only in the NEXT slice, and the
+  // window is exactly the delta since the previous slice (no re-attribution).
+  assert.deepEqual(sliceCapturedEvents(), { responses: [], requestFailures: [], pageErrors: [] });
   page.emit("requestfailed", { url: () => "http://app/img", failure: () => ({ errorText: "net::ERR" }) });
-  assert.deepEqual(drainCapturedEvents().requestFailures, [{ url: "http://app/img", failure: "net::ERR" }]);
+  assert.deepEqual(sliceCapturedEvents().requestFailures, [{ url: "http://app/img", failure: "net::ERR" }]);
+  // ...and the whole buffer still carries everything for the mechanical gate.
+  assert.equal(getCapturedEvents().responses.length, 1);
+  assert.equal(getCapturedEvents().requestFailures.length, 1);
 });
 
-test("toPerStateConsolePayload: shapes a drained slice into console/network findings; null when empty", () => {
+test("toPerStateConsolePayload: shapes a per-state slice into console/network findings; null when empty", () => {
   assert.equal(toPerStateConsolePayload({ responses: [], requestFailures: [], pageErrors: [] }), null);
   assert.equal(toPerStateConsolePayload({}), null);
   const payload = toPerStateConsolePayload({
@@ -358,6 +382,48 @@ test("driveUiReview: collates a swallowed error response from the injected liste
   assert.equal(r.ok, false);
   const kinds = r.failures.map((f) => f.kind).sort();
   assert.deepEqual(kinds, ["error-response", "server-log-exception"]);
+});
+
+// ── Production wiring: the REAL makeRunStep (drain/attribute + consolePath) ───
+// These substitute nothing for makeRunStep, so they fail if the wiring that
+// slices per state + threads consolePath is removed.
+
+test("driveUiReview + real makeRunStep: a step-scoped 500 is attributed to that state's console.json AND still fails the mechanical ok gate closed (AC1 + AC2)", async () => {
+  const outputDir = tempDir();
+  const page = fakeDrivePage();
+  const { getCapturedEvents, sliceCapturedEvents } = attachPageListeners(page);
+  const runStep = makeRunStep({ page, outputDir, sliceCapturedEvents });
+
+  const r = await driveUiReview(
+    { appUrl: "http://app", login: {}, flows: [{ name: "checkout", steps: [{ name: "save", action: "click" }] }] },
+    { authenticate: async () => ({ ok: true, detail: "ok" }), runStep, getCapturedEvents },
+  );
+
+  // AC2: the captured step-scoped 500 deterministically fails the drive closed
+  // through the mechanical gate — independent of any review mode or LLM.
+  assert.equal(r.ok, false, "a captured step-scoped 500 must fail the drive closed via the mechanical gate");
+  assert.ok(r.failures.some((f) => f.kind === "error-response"), "the classified error reaches drive.failures");
+
+  // AC1: the same 500 is ALSO attributed into THAT state's console.json (the slice
+  // did not remove it from the walk-level gate — two views of one classified error).
+  const state = JSON.parse(readFileSync(r.steps[0].statePath, "utf8"));
+  const consoleJson = JSON.parse(readFileSync(state.artifacts.console.path, "utf8"));
+  assert.deepEqual(consoleJson.failedRequests, [{ kind: "error-response", url: "http://app/save", status: 500 }]);
+});
+
+test("makeRunStep: threads consolePath into the runStep result and points state.json at it", async () => {
+  const outputDir = tempDir();
+  const page = fakeDrivePage();
+  const { sliceCapturedEvents } = attachPageListeners(page);
+  const runStep = makeRunStep({ page, outputDir, sliceCapturedEvents });
+
+  const outcome = await runStep({ appUrl: "http://app", flow: { name: "checkout" }, step: { name: "save", action: "click" }, index: 0 });
+
+  // The runStep result carries consolePath (the field a bundle assembler threads
+  // into the review contract's namedStates) — deleting it fails here.
+  assert.ok(typeof outcome.consolePath === "string" && outcome.consolePath.endsWith("console.json"), "consolePath is threaded into the runStep result");
+  const state = JSON.parse(readFileSync(outcome.statePath, "utf8"));
+  assert.equal(state.artifacts.console.path, outcome.consolePath, "state.json back-references the same console.json");
 });
 
 // ── Config resolver ──────────────────────────────────────────────────────────

--- a/test/loop/ui-smoke-harness.test.mjs
+++ b/test/loop/ui-smoke-harness.test.mjs
@@ -284,7 +284,7 @@ test('captureNamedUiState emits console.json as JSON null when the injected capt
       outputDir: tempDir,
       sliceId: 'inspect-run-viewer',
       stateName: 'Throwing console capture',
-      captureConsole: async () => { throw new Error('drain failed'); },
+      captureConsole: async () => { throw new Error('slice failed'); },
     });
     assert.equal(await readFile(artifact.consolePath, 'utf8'), 'null\n');
   } finally {

--- a/test/loop/ui-smoke-harness.test.mjs
+++ b/test/loop/ui-smoke-harness.test.mjs
@@ -30,6 +30,7 @@ test('buildNamedUiStateArtifactPaths derives deterministic screenshot and state 
   assert.equal(paths.statePath, path.join(paths.artifactDir, 'state.json'));
   assert.equal(paths.snapshotPath, path.join(paths.artifactDir, 'snapshot.json'));
   assert.equal(paths.axePath, path.join(paths.artifactDir, 'axe.json'));
+  assert.equal(paths.consolePath, path.join(paths.artifactDir, 'console.json'));
 });
 
 test('captureNamedUiState writes the deterministic screenshot and state artifact bundle', async () => {
@@ -37,6 +38,7 @@ test('captureNamedUiState writes the deterministic screenshot and state artifact
   const screenshots = [];
   const accessibilityTree = { role: 'WebArea', name: 'Current PR dashboard', children: [{ role: 'heading', name: 'Runs' }] };
   const axeResults = { violations: [{ id: 'color-contrast', impact: 'serious' }], passes: [], incomplete: [], inapplicable: [] };
+  const consoleReport = { consoleErrors: [{ message: 'TypeError: boom', stack: 'TypeError: boom\n    at app.js:1' }], failedRequests: [{ kind: 'error-response', url: 'http://app/save', status: 500 }] };
 
   try {
     const artifact = await captureNamedUiState({
@@ -51,6 +53,7 @@ test('captureNamedUiState writes the deterministic screenshot and state artifact
         },
       },
       runAxe: async () => axeResults,
+      captureConsole: async () => consoleReport,
       testInfo: {
         config: { outputDir: tempDir },
         project: { name: 'webkit', outputDir: tempDir },
@@ -72,7 +75,7 @@ test('captureNamedUiState writes the deterministic screenshot and state artifact
     await stat(artifact.artifactDir);
 
     const stateJson = JSON.parse(await readFile(artifact.statePath, 'utf8'));
-    assert.equal(stateJson.schemaVersion, 3);
+    assert.equal(stateJson.schemaVersion, 4);
     assert.equal(stateJson.artifactType, 'named-ui-state');
     assert.equal(stateJson.validationLevel, 'deterministic-smoke');
     assert.equal(stateJson.sliceId, 'inspect-run-viewer');
@@ -88,6 +91,8 @@ test('captureNamedUiState writes the deterministic screenshot and state artifact
     assert.equal(stateJson.artifacts.snapshot.relativePath, 'snapshot.json');
     assert.equal(stateJson.artifacts.axe.fileName, 'axe.json');
     assert.equal(stateJson.artifacts.axe.relativePath, 'axe.json');
+    assert.equal(stateJson.artifacts.console.fileName, 'console.json');
+    assert.equal(stateJson.artifacts.console.relativePath, 'console.json');
     assert.equal(stateJson.metadata.fixture, 'makeInspectionSnapshot');
     assert.equal(stateJson.metadata.route, '/');
     assert.match(stateJson.capturedAt, /^\d{4}-\d{2}-\d{2}T/);
@@ -99,6 +104,10 @@ test('captureNamedUiState writes the deterministic screenshot and state artifact
     assert.equal(artifact.axePath, path.join(artifact.artifactDir, 'axe.json'));
     const axeJson = JSON.parse(await readFile(artifact.axePath, 'utf8'));
     assert.deepEqual(axeJson, axeResults);
+
+    assert.equal(artifact.consolePath, path.join(artifact.artifactDir, 'console.json'));
+    const consoleJson = JSON.parse(await readFile(artifact.consolePath, 'utf8'));
+    assert.deepEqual(consoleJson, consoleReport);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -242,6 +251,42 @@ test('captureNamedUiState emits axe.json as JSON null when the injected runner t
       runAxe: async () => { throw new Error('axe unsupported'); },
     });
     assert.equal(await readFile(artifact.axePath, 'utf8'), 'null\n');
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('captureNamedUiState emits console.json as JSON null when no capture seam is provided', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ui-smoke-harness-console-null-'));
+
+  try {
+    // A plain smoke installs no console capture: this harness never listens on
+    // its own (the drive owns the single walk-level buffer), so console.json is a
+    // deterministic JSON null rather than skipped.
+    const artifact = await captureNamedUiState({
+      page: { async screenshot() {} },
+      outputDir: tempDir,
+      sliceId: 'inspect-run-viewer',
+      stateName: 'No console capture',
+    });
+    assert.equal(await readFile(artifact.consolePath, 'utf8'), 'null\n');
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('captureNamedUiState emits console.json as JSON null when the injected capture seam throws', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ui-smoke-harness-console-throw-'));
+
+  try {
+    const artifact = await captureNamedUiState({
+      page: { async screenshot() {} },
+      outputDir: tempDir,
+      sliceId: 'inspect-run-viewer',
+      stateName: 'Throwing console capture',
+      captureConsole: async () => { throw new Error('drain failed'); },
+    });
+    assert.equal(await readFile(artifact.consolePath, 'utf8'), 'null\n');
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/playwright/harness/webkit-smoke-harness.mjs
+++ b/test/playwright/harness/webkit-smoke-harness.mjs
@@ -41,6 +41,7 @@ export function buildNamedUiStateArtifactPaths({ outputDir, sliceId, stateName }
     statePath: path.join(artifactDir, 'state.json'),
     snapshotPath: path.join(artifactDir, 'snapshot.json'),
     axePath: path.join(artifactDir, 'axe.json'),
+    consolePath: path.join(artifactDir, 'console.json'),
   };
 }
 
@@ -59,7 +60,17 @@ async function defaultRunAxe(page) {
   }
 }
 
-export async function captureNamedUiState({ page, testInfo, sliceId, stateName, metadata = {}, fullPage = true, outputDir, runAxe = defaultRunAxe } = {}) {
+// Per-state console errors + failed network requests. Best-effort, and by
+// default a no-op that degrades to JSON null: this harness captures NO events on
+// its own — the drive owns the single walk-level listener buffer and injects a
+// `captureConsole` seam that DRAINS its per-state slice (so nothing is captured
+// twice). A plain smoke or a mock-page test with no seam emits a deterministic
+// JSON null, mirroring the snapshot/axe best-effort policy.
+function defaultCaptureConsole() {
+  return null;
+}
+
+export async function captureNamedUiState({ page, testInfo, sliceId, stateName, metadata = {}, fullPage = true, outputDir, runAxe = defaultRunAxe, captureConsole = defaultCaptureConsole } = {}) {
   const resolvedOutputDir = outputDir ?? testInfo?.project?.outputDir ?? testInfo?.config?.outputDir ?? testInfo?.outputDir;
   const paths = buildNamedUiStateArtifactPaths({
     outputDir: resolvedOutputDir,
@@ -97,6 +108,20 @@ export async function captureNamedUiState({ page, testInfo, sliceId, stateName, 
   }
   await writeFile(paths.axePath, `${JSON.stringify(axeResults, null, 2)}\n`, 'utf8');
 
+  // Per-state console/network errors: the drive's `captureConsole` seam drains
+  // the slice of walk-level events attributed to this state. Best-effort for the
+  // same reason as snapshot/axe (see defaultCaptureConsole); either way a
+  // deterministic JSON payload (a {consoleErrors,failedRequests} report, or null
+  // when nothing was captured) is emitted last — after the pixels/tree/axe — so
+  // draining events can never pollute the earlier artifacts.
+  let consoleReport = null;
+  try {
+    consoleReport = (await captureConsole(page)) ?? null;
+  } catch {
+    consoleReport = null;
+  }
+  await writeFile(paths.consolePath, `${JSON.stringify(consoleReport, null, 2)}\n`, 'utf8');
+
   const normalizedMetadata = {
     ...metadata,
     fixture: metadata.fixture ?? null,
@@ -105,7 +130,7 @@ export async function captureNamedUiState({ page, testInfo, sliceId, stateName, 
   };
 
   const stateArtifact = {
-    schemaVersion: 3,
+    schemaVersion: 4,
     artifactType: 'named-ui-state',
     validationLevel: 'deterministic-smoke',
     sliceId: paths.sliceId,
@@ -136,6 +161,11 @@ export async function captureNamedUiState({ page, testInfo, sliceId, stateName, 
         fileName: path.basename(paths.axePath),
         relativePath: path.basename(paths.axePath),
         path: paths.axePath,
+      },
+      console: {
+        fileName: path.basename(paths.consolePath),
+        relativePath: path.basename(paths.consolePath),
+        path: paths.consolePath,
       },
     },
     metadata: normalizedMetadata,

--- a/test/playwright/harness/webkit-smoke-harness.mjs
+++ b/test/playwright/harness/webkit-smoke-harness.mjs
@@ -63,8 +63,9 @@ async function defaultRunAxe(page) {
 // Per-state console errors + failed network requests. Best-effort, and by
 // default a no-op that degrades to JSON null: this harness captures NO events on
 // its own — the drive owns the single walk-level listener buffer and injects a
-// `captureConsole` seam that DRAINS its per-state slice (so nothing is captured
-// twice). A plain smoke or a mock-page test with no seam emits a deterministic
+// `captureConsole` seam that SLICES its per-state window (without clearing the
+// buffer, so the same events still drive the drive's walk-level fail-closed
+// gate). A plain smoke or a mock-page test with no seam emits a deterministic
 // JSON null, mirroring the snapshot/axe best-effort policy.
 function defaultCaptureConsole() {
   return null;
@@ -108,12 +109,12 @@ export async function captureNamedUiState({ page, testInfo, sliceId, stateName, 
   }
   await writeFile(paths.axePath, `${JSON.stringify(axeResults, null, 2)}\n`, 'utf8');
 
-  // Per-state console/network errors: the drive's `captureConsole` seam drains
-  // the slice of walk-level events attributed to this state. Best-effort for the
+  // Per-state console/network errors: the drive's `captureConsole` seam slices
+  // the window of walk-level events attributed to this state. Best-effort for the
   // same reason as snapshot/axe (see defaultCaptureConsole); either way a
   // deterministic JSON payload (a {consoleErrors,failedRequests} report, or null
   // when nothing was captured) is emitted last — after the pixels/tree/axe — so
-  // draining events can never pollute the earlier artifacts.
+  // slicing events can never pollute the earlier artifacts.
   let consoleReport = null;
   try {
     consoleReport = (await captureConsole(page)) ?? null;


### PR DESCRIPTION
## Summary

Stage 3 of epic #1067. Records per-named-state console errors and failed network requests into the artifact bundle as a review input and a fail-closed signal, reconciled with the live drive's existing walk-level capture so nothing is double-reported.

## Scope and context

- `test/playwright/harness/webkit-smoke-harness.mjs`: `buildNamedUiStateArtifactPaths` derives `consolePath` (`<artifactDir>/console.json`); `captureNamedUiState` gains a best-effort `captureConsole` seam (default returns `null`), emits `console.json` **last** (after screenshot/snapshot/axe, try/catch → JSON `null` on failure — same degrade policy as snapshot/axe, never crashes a real smoke), adds the `artifacts.console` back-reference, and bumps `schemaVersion` 3→4.
- `scripts/loop/ui-designer-review-contract.mjs`: `validateUiDesignerReviewInput` now requires `consolePath` (presence both modes + `console.json` suffix check in vision mode), mirroring `axePath`.
- `scripts/loop/ui-review-drive.mjs`: `attachPageListeners` gains `sliceCapturedEvents()` (cursor-based — returns the window of events since the previous step boundary WITHOUT clearing the buffer); new `toPerStateConsolePayload()` shapes a slice into `{ consoleErrors, failedRequests }` (`null` when empty); the exported `makeRunStep` wires `captureConsole` to slice-per-state and returns `consolePath`. `getCapturedEvents()` still returns the full buffer, so the drive's mechanical failure gate sees every event.
- Docs threaded through every required-bundle enumeration (`docs/ui-artifact-contract.md` incl. schemaVersion 3→4 + a `console.json` contract section, `docs/ui-designer-review-loop.md`, `docs/ui-review-recipe-contract.md`, `docs/ui-smoke-harness.md`, `skills/ui-review/SKILL.md`, `skills/dev-loop/templates/ui-vision-review.md`); `.claude` regenerated (`--check` clean).

## Reconciliation — mechanical fail-closed + per-state attribution (AC2 + AC3)

There is **one** capture mechanism — the drive's existing walk-level listener buffer (`response`/`requestfailed`/`pageerror`); no second listener is added (respecting the non-goal). Per-step `captureNamedUiState` **slices** the buffer's window since the previous step boundary into the active state's `console.json` for per-state attribution (AC1) — via a cursor, **without clearing** the buffer. So the same classified events remain two views of one source: `console.json` (per-state review evidence) and the drive's authoritative mechanical gate.

Fail-closed is **mechanical and mode/LLM-independent** (AC2): `driveUiReview` still calls `getCapturedEvents()` over the full buffer at walk end, so `classifyFailures` sees every step-scoped error and `ok: failures.length === 0` deterministically flips to false on a captured 500 / failed request / page error — regardless of review mode or whether the LLM honors a prompt. Because the page-error stack survives into `classifyFailures`, source-line anchoring (#1119) is **preserved**.

No double-reporting (AC3): the mechanical pipeline (`failures` → diagnose → report) is the single reporting channel — one buffer, one `classifyFailures` pass, each error classified once — so the posted report never double-counts. `console.json` is a per-state *view* of those same classified events (diagnose/report never read it), and the vision template treats a `console.json` error as already-anchored evidence rather than re-filing it.

## Acceptance criteria

Satisfies #1299's ACs (checked off at merge): each named state carries its captured console/network errors (`console.json`); a captured error is a **mechanical** fail-closed signal — the drive's `ok/failures` gate flips false deterministically, independent of review mode/LLM — never silently dropped; no double-reporting (single classify/report channel; `console.json` is a per-state view); `npm run verify` green.

## Non-goals

New capture mechanisms beyond the drive's existing console/network capture (this is per-state attribution, not a new listener).

## Validation

- `node --test test/loop/ui-smoke-harness.test.mjs test/loop/ui-designer-review-contract.test.mjs test/loop/ui-review-drive.test.mjs` — 57 pass (consolePath, schemaVersion 4, `artifacts.console`, console.json content, best-effort-null cases, seam missing/malformed-vision cases, slice cursor + no-double-report, exported `makeRunStep` wiring regression: attribution + mechanical ok=false + consolePath threading).
- `npm run test:assets` — 191 pass; the three doc-guard contract tests updated to the new prose; `node scripts/claude/generate-claude-assets.mjs --check` — clean.
- Full gate uses `npm run verify`.

Closes #1299
