### PR TITLE
fix(gate-tooling): fail closed on wrong-worktree/degenerate write-gate-context build (#1318)

### DIFF
--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -989,7 +989,8 @@ export async function readGateContext(input, { repoRoot = process.cwd() } = {}) 
  * @param {{ repoRoot: string }} opts
  */
 export function assertWorktreeAtHead(headSha, { repoRoot }) {
-  // Fail-closed self-guard: the bidirectional prefix-match below FALSE-ACCEPTS an
+  // Fail-closed self-guard: the abbreviation prefix-match below (declared must be a
+  // prefix of the full-length HEAD) FALSE-ACCEPTS an
   // empty/too-short `headSha` (an empty string is a prefix of every HEAD). The sole
   // caller (main) pre-validates via normalizeHeadSha, but re-validate here so this
   // exported boundary stays fail-closed for any future importer.

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -981,8 +981,9 @@ export async function readGateContext(input, { repoRoot = process.cwd() } = {}) 
  * is caught at build time (no artifact written) instead.
  *
  * `headSha` may be abbreviated (7-64 hex, per normalizeHeadSha); the worktree
- * HEAD is the full 40-char rev-parse output, so match by prefix in either
- * direction rather than requiring exact equality.
+ * HEAD is the full-length rev-parse output (40 hex for SHA-1, 64 for SHA-256),
+ * so accept `headSha` when it is a prefix of that HEAD rather than requiring
+ * exact equality.
  *
  * @param {string} headSha — the declared --head-sha (already normalized lowercase)
  * @param {{ repoRoot: string }} opts
@@ -1009,9 +1010,11 @@ export function assertWorktreeAtHead(headSha, { repoRoot }) {
       `--base was given but the current working directory (${repoRoot}) is not inside a git worktree (git rev-parse HEAD failed: ${err?.message ?? err}). cd into the PR's worktree — the one checked out at --head-sha ${headSha} — before building its gate context.`,
     );
   }
-  const matches = actualHead === declared
-    || actualHead.startsWith(declared)
-    || declared.startsWith(actualHead);
+  // `git rev-parse HEAD` always returns the full-length SHA, so the only valid
+  // match is `declared` being a prefix of it. Accepting the reverse direction
+  // (declared longer than HEAD) would false-accept a --head-sha whose first
+  // chars merely happen to equal HEAD (e.g. a 64-char value vs a SHA-1 HEAD).
+  const matches = actualHead.startsWith(declared);
   if (!matches) {
     throw new Error(
       `worktree HEAD ${actualHead} does not match --head-sha ${declared}: the current working directory is the WRONG worktree for this PR, so \`git diff <base>...HEAD\` would resolve the WRONG diff. cd into the worktree checked out at ${declared} and re-run.`,

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -988,6 +988,16 @@ export async function readGateContext(input, { repoRoot = process.cwd() } = {}) 
  * @param {{ repoRoot: string }} opts
  */
 export function assertWorktreeAtHead(headSha, { repoRoot }) {
+  // Fail-closed self-guard: the bidirectional prefix-match below FALSE-ACCEPTS an
+  // empty/too-short `headSha` (an empty string is a prefix of every HEAD). The sole
+  // caller (main) pre-validates via normalizeHeadSha, but re-validate here so this
+  // exported boundary stays fail-closed for any future importer.
+  const declared = String(headSha).trim().toLowerCase();
+  if (!/^[0-9a-f]{7,64}$/.test(declared)) {
+    throw new Error(
+      `assertWorktreeAtHead: headSha ${JSON.stringify(headSha)} is not a 7-64 character hex SHA — refusing to prefix-match against the worktree HEAD (an empty/short value would false-accept).`,
+    );
+  }
   let actualHead;
   try {
     actualHead = execFileSync("git", ["rev-parse", "HEAD"], {
@@ -999,7 +1009,6 @@ export function assertWorktreeAtHead(headSha, { repoRoot }) {
       `--base was given but the current working directory (${repoRoot}) is not inside a git worktree (git rev-parse HEAD failed: ${err?.message ?? err}). cd into the PR's worktree — the one checked out at --head-sha ${headSha} — before building its gate context.`,
     );
   }
-  const declared = String(headSha).trim().toLowerCase();
   const matches = actualHead === declared
     || actualHead.startsWith(declared)
     || declared.startsWith(actualHead);

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -970,6 +970,47 @@ export async function readGateContext(input, { repoRoot = process.cwd() } = {}) 
 }
 
 /**
+ * Fail-closed precondition for the CLI `--base` path: verify the CWD git
+ * worktree's HEAD equals the caller-declared `--head-sha` BEFORE we resolve a
+ * diff from that worktree. `--head-sha` is otherwise just metadata; the diff,
+ * changed-file set, and output path all come from whatever worktree the shell
+ * CWD happens to be in. Run from the WRONG worktree (a CWD persisted from a
+ * prior PR's build), `git diff <base>...HEAD` silently resolves the wrong diff
+ * and every fan-out reviewer only fails closed AFTER dispatch on the mislocated
+ * bundle. This turns the head SHA into an enforced precondition so the mistake
+ * is caught at build time (no artifact written) instead.
+ *
+ * `headSha` may be abbreviated (7-64 hex, per normalizeHeadSha); the worktree
+ * HEAD is the full 40-char rev-parse output, so match by prefix in either
+ * direction rather than requiring exact equality.
+ *
+ * @param {string} headSha — the declared --head-sha (already normalized lowercase)
+ * @param {{ repoRoot: string }} opts
+ */
+export function assertWorktreeAtHead(headSha, { repoRoot }) {
+  let actualHead;
+  try {
+    actualHead = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    }).trim().toLowerCase();
+  } catch (err) {
+    throw new Error(
+      `--base was given but the current working directory (${repoRoot}) is not inside a git worktree (git rev-parse HEAD failed: ${err?.message ?? err}). cd into the PR's worktree — the one checked out at --head-sha ${headSha} — before building its gate context.`,
+    );
+  }
+  const declared = String(headSha).trim().toLowerCase();
+  const matches = actualHead === declared
+    || actualHead.startsWith(declared)
+    || declared.startsWith(actualHead);
+  if (!matches) {
+    throw new Error(
+      `worktree HEAD ${actualHead} does not match --head-sha ${declared}: the current working directory is the WRONG worktree for this PR, so \`git diff <base>...HEAD\` would resolve the WRONG diff. cd into the worktree checked out at ${declared} and re-run.`,
+    );
+  }
+}
+
+/**
  * CLI entrypoint. Exported (argv + repoRoot both overridable) so tests can
  * drive the `--base` diff-capture path against a throwaway git repo fixture
  * without spawning a subprocess.
@@ -1001,11 +1042,25 @@ export async function main(argv = process.argv.slice(2), { repoRoot = process.cw
     // git repo, etc.) DOES fail closed: the caller opted into the full bundle,
     // so a silent thin degrade there would be a worse surprise than an error.
     if (options.base) {
+      // Fail-closed precondition: the diff is resolved FROM the CWD worktree, so
+      // enforce that CWD is this PR's worktree at --head-sha before diffing.
+      // Otherwise a stale CWD silently yields the wrong diff (caught only after
+      // fan-out today). Throws → caught below → exit 1, no artifact written.
+      assertWorktreeAtHead(options.headSha, { repoRoot });
       const diff = captureDiffFromBase(options.base, { repoRoot });
       const scope = await resolveDiffScope(
         { diff, repo: options.repo, pr: options.pr, gate: options.gate, headSha: options.headSha, tmpRoot: options.tmpRoot || "tmp" },
         { repoRoot },
       );
+      // A --base build that resolves an EMPTY change set is degenerate: the
+      // caller opted into a full bundle, so a zero-file diff (mis-set base,
+      // wrong worktree that slipped the HEAD guard, etc.) is a fail-closed
+      // error, not a silently-emitted stub with changedFiles:[].
+      if (scope.changedFiles.length === 0) {
+        throw new Error(
+          `--base ${JSON.stringify(options.base)} resolved an EMPTY change set (git diff ${options.base}...HEAD produced no changed files) — refusing to write a degenerate gate-context bundle. Verify --base and that the CWD worktree is checked out at --head-sha ${options.headSha}.`,
+        );
+      }
       options.changedFiles = scope.changedFiles;
       options.diffPath = scope.diffPath;
       options.adjacentCode = scope.adjacentCode;

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -8,6 +8,7 @@ import test from "node:test";
 import { resolveGateAnglesDynamic } from "@dev-loops/core/config";
 
 import {
+  assertWorktreeAtHead,
   BRIEFING_PREFIX_INLINE_DIFF_CAP_BYTES,
   buildGateBriefingPrefixPath,
   buildGateContext,
@@ -956,6 +957,103 @@ test("CLI --base <ref> that fails to resolve fails closed (no artifact written, 
     } finally {
       process.exitCode = priorExitCode;
     }
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI --base fails closed when the CWD worktree HEAD does not match --head-sha (wrong worktree)", async () => {
+  const { repoRoot, baseSha, headSha } = await makeBaseDiffRepo();
+  try {
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      // Declare a --head-sha (baseSha) that is NOT the worktree's HEAD (headSha):
+      // simulates building from a shell CWD left over from another PR's build.
+      await main([
+        "--repo", "owner/repo", "--pr", "46", "--gate", "draft_gate",
+        "--head-sha", baseSha,
+        "--angles", '["scope"]',
+        "--base", "HEAD~1",
+      ], { repoRoot });
+
+      assert.equal(process.exitCode, 1, "fails closed on a HEAD/--head-sha mismatch");
+      const artifact = await readGateContext({
+        repo: "owner/repo", pr: 46, gate: "draft_gate", headSha: baseSha,
+      }, { repoRoot });
+      assert.equal(artifact, null, "no artifact written when CWD is the wrong worktree");
+    } finally {
+      process.exitCode = priorExitCode;
+    }
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI --base fails closed when CWD is not inside a git worktree", async () => {
+  // A bare temp dir with no `git init`: rev-parse HEAD must fail, so the --base
+  // build aborts before touching git diff.
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-nogit-"));
+  try {
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await main([
+        "--repo", "owner/repo", "--pr", "47", "--gate", "draft_gate",
+        "--head-sha", "abcdef1234567890abcdef1234567890abcdef12",
+        "--angles", '["scope"]',
+        "--base", "HEAD~1",
+      ], { repoRoot });
+
+      assert.equal(process.exitCode, 1, "fails closed when CWD is not a git worktree");
+      const artifact = await readGateContext({
+        repo: "owner/repo", pr: 47, gate: "draft_gate",
+        headSha: "abcdef1234567890abcdef1234567890abcdef12",
+      }, { repoRoot });
+      assert.equal(artifact, null, "no artifact written outside a git worktree");
+    } finally {
+      process.exitCode = priorExitCode;
+    }
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI --base fails closed on a degenerate empty change set (no changedFiles)", async () => {
+  const { repoRoot, headSha } = await makeBaseDiffRepo();
+  try {
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      // --base HEAD → range HEAD...HEAD is empty, so changedFiles resolves to [].
+      // HEAD matches --head-sha (guard passes), so this exercises the degenerate
+      // build guard specifically, not the worktree guard.
+      await main([
+        "--repo", "owner/repo", "--pr", "48", "--gate", "draft_gate",
+        "--head-sha", headSha,
+        "--angles", '["scope"]',
+        "--base", "HEAD",
+      ], { repoRoot });
+
+      assert.equal(process.exitCode, 1, "fails closed on an empty --base change set");
+      const artifact = await readGateContext({
+        repo: "owner/repo", pr: 48, gate: "draft_gate", headSha,
+      }, { repoRoot });
+      assert.equal(artifact, null, "no degenerate stub artifact written");
+    } finally {
+      process.exitCode = priorExitCode;
+    }
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("assertWorktreeAtHead accepts an abbreviated --head-sha matching the full worktree HEAD", async () => {
+  const { repoRoot, headSha } = await makeBaseDiffRepo();
+  try {
+    // A 12-char abbreviation of the real HEAD must validate by prefix match.
+    assert.doesNotThrow(() => assertWorktreeAtHead(headSha.slice(0, 12), { repoRoot }));
+    assert.throws(() => assertWorktreeAtHead("0".repeat(40), { repoRoot }), /does not match/);
   } finally {
     await rm(repoRoot, { recursive: true, force: true });
   }

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -1059,6 +1059,32 @@ test("assertWorktreeAtHead accepts an abbreviated --head-sha matching the full w
   }
 });
 
+test("assertWorktreeAtHead throws directly when repoRoot is not a git worktree", async () => {
+  // Direct unit coverage for the non-git catch branch, independent of TMPDIR
+  // happening to sit outside a checkout (which the CLI-level test relies on).
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-nogit-unit-"));
+  try {
+    assert.throws(
+      () => assertWorktreeAtHead("abcdef1234567890abcdef1234567890abcdef12", { repoRoot }),
+      /not inside a git worktree/i,
+    );
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("assertWorktreeAtHead rejects a non-hex/short headSha before touching git", async () => {
+  const { repoRoot } = await makeBaseDiffRepo();
+  try {
+    // Empty and too-short values would prefix-match every HEAD — the format guard
+    // must fail closed regardless of the caller.
+    assert.throws(() => assertWorktreeAtHead("", { repoRoot }), /hex SHA/);
+    assert.throws(() => assertWorktreeAtHead("abc", { repoRoot }), /hex SHA/);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
 test("CLI --base accepts an ancestry ref (HEAD~1) and resolves it end-to-end", async () => {
   const { repoRoot, headSha } = await makeBaseDiffRepo();
   try {

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -1054,6 +1054,10 @@ test("assertWorktreeAtHead accepts an abbreviated --head-sha matching the full w
     // A 12-char abbreviation of the real HEAD must validate by prefix match.
     assert.doesNotThrow(() => assertWorktreeAtHead(headSha.slice(0, 12), { repoRoot }));
     assert.throws(() => assertWorktreeAtHead("0".repeat(40), { repoRoot }), /does not match/);
+    // A --head-sha LONGER than the full HEAD (but sharing it as a prefix) is NOT
+    // a valid abbreviation — rev-parse HEAD is always full-length — and must be
+    // rejected rather than false-accepted by a reverse prefix match.
+    assert.throws(() => assertWorktreeAtHead(`${headSha}0`, { repoRoot }), /does not match/);
   } finally {
     await rm(repoRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Makes `scripts/github/write-gate-context.mjs` **fail closed** when it would build a wrong-worktree / degenerate context bundle, instead of silently emitting a bad artifact that all fan-out reviewers only reject *after* dispatch (the footgun behind a wasted gate round).

## Scope and context

- `scripts/github/write-gate-context.mjs`: new exported `assertWorktreeAtHead(headSha, { repoRoot })` runs `git rev-parse HEAD` in the CWD worktree and throws a clear, sha-naming error if rev-parse fails (CWD isn't a git worktree) or the worktree HEAD doesn't match `--head-sha`. Since `git rev-parse HEAD` always returns the full-length sha, the match is `actualHead.startsWith(declared)` — an abbreviated `--head-sha` (a prefix of the full HEAD) validates, while a `--head-sha` longer than HEAD is correctly rejected; a hex self-guard (`/^[0-9a-f]{7,64}$/`) rejects an empty/short sha before matching. It runs on the `--base` path **before** any diff/artifact work, so a stale CWD aborts before writing anything. Additionally, after diff resolution, a `--base` build whose resolved `changedFiles` is empty fails closed rather than emitting a degenerate `changedFiles: []` stub. The pre-existing name-status fail-closed for an unresolvable base is unchanged. The happy path and the `--jq`/`--silent` contract are untouched.

## Acceptance criteria

Satisfies #1318's ACs (checked off at merge): a `--base` build fails closed (clear error, non-zero exit, no artifact) when CWD HEAD ≠ `--head-sha` or CWD isn't a git worktree; a degenerate/empty resolved diff for a `--base` build is a fail-closed error, not a silent stub; a test covers the head-mismatch/wrong-worktree and degenerate-diff cases; `npm run verify` green.

## Definition of done

`write-gate-context.mjs` cannot silently emit a wrong-worktree/degenerate bundle; the guard fails closed with an actionable message; tests green.

## Non-goals

Changing the briefing-prefix / bundle shape. Changing `verify-fresh-review-context.mjs` (its fail-closed behavior is correct — this catches the mistake at build time). Auto-resolving the worktree path from `--repo`/`--pr` (the HEAD-mismatch guard is the minimal robust fix).

## Validation

- `node --test test/github/write-gate-context.test.mjs` — 75 pass (wrong-worktree → exit 1 no artifact; non-git-dir → exit 1; degenerate empty diff → exit 1; `assertWorktreeAtHead` accepts an abbreviation of HEAD, rejects a non-matching sha, rejects a too-long sha sharing HEAD's prefix, and rejects a non-hex/short sha).
- Full gate uses `npm run verify`.

Closes #1318
