### PR TITLE
feat(loop): ui_review Stage 4 — encode viewport + interaction-state in the state slug (#1300)

### DIFF
--- a/docs/ui-artifact-contract.md
+++ b/docs/ui-artifact-contract.md
@@ -80,17 +80,38 @@ For a slice id of `<sliceId>` and a state slug of `<state-slug>`, the harness pa
 
 The harness currently normalizes:
 - `sliceId` into a stable path segment
-- the human-readable state name into `<state-slug>`
+- the human-readable state name, a **viewport descriptor**, and an
+  **interaction-state** into `<state-slug>`
+
+`<state-slug>` is `<state-name>-<viewport>-<interaction>`, each part normalized
+independently and joined with `-`:
+- `<viewport>` is `w<width>h<height>` for a `{ width, height }` viewport (for
+  example `w1280h800`), a normalized named breakpoint string, or `default` when no
+  viewport is given.
+- `<interaction>` is one of `focus`, `hover`, `error`, or `none` (the default
+  render state when no interaction is given).
+
+So `Current PR dashboard` at the default viewport with no interaction is
+`current-pr-dashboard-default-none`, while the same state at a mobile viewport in
+its error render is `current-pr-dashboard-w375h667-error`. Baking viewport +
+interaction into the slug means two states differing **only** by viewport (a
+mobile vs desktop render) or **only** by interaction-state (a default vs error
+render) get **distinct** directories and never collide/overwrite. A malformed
+viewport (non-positive/non-integer dimensions) or an unknown interaction-state is
+rejected fail-closed, and two named states that collide to the same slug are
+rejected rather than silently overwriting each other.
 
 ## Minimum `state.json` contract
 
-The current reusable harness emits `state.json` with this minimum reviewer-facing metadata (current `schemaVersion`: `4`):
+The current reusable harness emits `state.json` with this minimum reviewer-facing metadata (current `schemaVersion`: `5`):
 - `schemaVersion`
 - `artifactType`
 - `validationLevel`
 - `sliceId`
 - `stateName`
 - `stateSlug`
+- `viewport`
+- `interactionState`
 - `runId`
 - `capturedAt`
 - `projectName`

--- a/docs/ui-artifact-contract.md
+++ b/docs/ui-artifact-contract.md
@@ -98,8 +98,21 @@ interaction into the slug means two states differing **only** by viewport (a
 mobile vs desktop render) or **only** by interaction-state (a default vs error
 render) get **distinct** directories and never collide/overwrite. A malformed
 viewport (non-positive/non-integer dimensions) or an unknown interaction-state is
-rejected fail-closed, and two named states that collide to the same slug are
-rejected rather than silently overwriting each other.
+rejected fail-closed.
+
+Two logically distinct named states that still collide to the **same** slug are
+kept from overwriting each other by two layers:
+- **Capture-time prevention (primary).** `captureNamedUiState` records the
+  artifact paths it has claimed in the current run and throws on a colliding slug
+  **before it writes any artifacts**, so the second state fails closed instead of
+  clobbering the first state's on-disk artifacts. The registry is per-run (scoped
+  to the process, not the on-disk path, which is slice-scoped rather than
+  run-unique), so a legitimate re-run does not false-positive on its own prior
+  output.
+- **Bundle-validation seam (defense-in-depth).** `validateUiDesignerReviewInput`
+  additionally rejects any reviewed bundle that still contains two named states
+  sharing one `statePath` (`blocked_duplicate_state_slug`), catching a collision
+  assembled outside the capture path.
 
 ## Minimum `state.json` contract
 

--- a/docs/ui-smoke-harness.md
+++ b/docs/ui-smoke-harness.md
@@ -67,6 +67,8 @@ Given a `sliceId` of `inspect-run-viewer`, the baseline paths are:
 - Playwright output directory: `test-results/ui-smoke/inspect-run-viewer`
 - HTML report directory: `playwright-report/ui-smoke/inspect-run-viewer`
 - named-state artifacts: `test-results/ui-smoke/inspect-run-viewer/named-states/<state-slug>/`
+  where `<state-slug>` bakes the state name, viewport, and interaction-state into
+  one deterministic segment (see [UI Artifact Contract](./ui-artifact-contract.md))
 
 Each named-state directory currently contains:
 - `screenshot.png`

--- a/scripts/loop/ui-designer-review-contract.mjs
+++ b/scripts/loop/ui-designer-review-contract.mjs
@@ -102,6 +102,28 @@ export function validateUiDesignerReviewInput(input = {}) {
       missing: incompleteArtifacts,
     };
   }
+  // The slug bakes viewport + interaction into the per-state directory, so two
+  // logically distinct states that collide to the same slug share one statePath and
+  // would silently overwrite each other. Reject the collision fail-closed rather than
+  // review a bundle where one state's artifacts have clobbered another's.
+  const seenStatePaths = new Set();
+  const collidingStates = [];
+  namedStates.forEach((state, index) => {
+    const key = state.statePath.trim();
+    if (seenStatePaths.has(key)) {
+      collidingStates.push(`artifactBundle.namedStates[${index}].statePath`);
+      return;
+    }
+    seenStatePaths.add(key);
+  });
+  if (collidingStates.length > 0) {
+    return {
+      ok: false,
+      status: 'blocked_duplicate_state_slug',
+      reason: 'duplicate_state_slug',
+      missing: collidingStates,
+    };
+  }
   return {
     ok: true,
     status: reviewMode === 'vision' ? 'ready_for_vision_review' : 'ready_for_designer_review',

--- a/test/loop/ui-designer-review-contract.test.mjs
+++ b/test/loop/ui-designer-review-contract.test.mjs
@@ -349,6 +349,33 @@ test('validateUiDesignerReviewInput fails closed when vision review has a malfor
   assert.deepEqual(result.missing, ['artifactBundle.namedStates[0].consolePath']);
 });
 
+test('validateUiDesignerReviewInput fails closed when two named states collide to the same slug', () => {
+  const dir = 'test-results/ui-smoke/inspect-run-viewer/named-states/current-pr-dashboard-default-none';
+  const collidingState = {
+    stateName: 'Current PR dashboard',
+    screenshotPath: `${dir}/screenshot.png`,
+    statePath: `${dir}/state.json`,
+    snapshotPath: `${dir}/snapshot.json`,
+    axePath: `${dir}/axe.json`,
+    consolePath: `${dir}/console.json`,
+  };
+  const result = validateUiDesignerReviewInput({
+    workType: 'ui',
+    uiReviewRequested: true,
+    acceptanceCriteria: ['named dashboard state renders'],
+    reviewBrief: 'Check layout and visual hierarchy.',
+    artifactBundle: {
+      sliceId: 'inspect-run-viewer',
+      namedStates: [collidingState, { ...collidingState, stateName: 'Current PR dashboard (again)' }],
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 'blocked_duplicate_state_slug');
+  assert.equal(result.reason, 'duplicate_state_slug');
+  assert.deepEqual(result.missing, ['artifactBundle.namedStates[1].statePath']);
+});
+
 test('mapAxeImpactToFindingSeverity maps axe impact ranks to finding severities', () => {
   assert.equal(mapAxeImpactToFindingSeverity('critical'), 'high');
   assert.equal(mapAxeImpactToFindingSeverity('serious'), 'high');

--- a/test/loop/ui-smoke-harness.test.mjs
+++ b/test/loop/ui-smoke-harness.test.mjs
@@ -153,6 +153,38 @@ test('captureNamedUiState writes the deterministic screenshot and state artifact
   }
 });
 
+test('captureNamedUiState fails closed on a within-run duplicate slug instead of overwriting', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ui-smoke-harness-dup-'));
+
+  try {
+    const first = await captureNamedUiState({
+      page: { async screenshot() {} },
+      outputDir: tempDir,
+      sliceId: 'inspect-run-viewer',
+      stateName: 'Current PR dashboard',
+    });
+
+    // A second, logically distinct state that normalizes to the same slug must
+    // fail closed at capture time — before it can overwrite the first on disk.
+    await assert.rejects(
+      captureNamedUiState({
+        page: { async screenshot() {} },
+        outputDir: tempDir,
+        sliceId: 'inspect-run-viewer',
+        stateName: 'Current PR / Dashboard',
+      }),
+      /duplicate named ui state slug/i,
+    );
+
+    // The first state's artifacts are intact (not clobbered by the rejected capture).
+    const stateJson = JSON.parse(await readFile(first.statePath, 'utf8'));
+    assert.equal(stateJson.stateName, 'Current PR dashboard');
+    assert.equal(stateJson.stateSlug, 'current-pr-dashboard-default-none');
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test('captureNamedUiState normalizes undefined metadata contract keys to null', async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ui-smoke-harness-metadata-'));
 

--- a/test/loop/ui-smoke-harness.test.mjs
+++ b/test/loop/ui-smoke-harness.test.mjs
@@ -185,6 +185,37 @@ test('captureNamedUiState fails closed on a within-run duplicate slug instead of
   }
 });
 
+test('captureNamedUiState allows the SAME state name to re-capture the same statePath (Playwright retry)', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ui-smoke-harness-retry-'));
+
+  try {
+    // A Playwright retry re-runs the test in the same reused worker process and,
+    // because resolvedOutputDir prefers the retry-STABLE testInfo.project.outputDir,
+    // re-captures the SAME stateName to the SAME statePath. That is a legitimate
+    // overwrite and must NOT trip the duplicate-slug guard.
+    const first = await captureNamedUiState({
+      page: { async screenshot() {} },
+      outputDir: tempDir,
+      sliceId: 'inspect-run-viewer',
+      stateName: 'Current PR dashboard',
+    });
+
+    const retried = await captureNamedUiState({
+      page: { async screenshot() {} },
+      outputDir: tempDir,
+      sliceId: 'inspect-run-viewer',
+      stateName: 'Current PR dashboard',
+    });
+
+    assert.equal(retried.statePath, first.statePath);
+    const stateJson = JSON.parse(await readFile(retried.statePath, 'utf8'));
+    assert.equal(stateJson.stateName, 'Current PR dashboard');
+    assert.equal(stateJson.stateSlug, 'current-pr-dashboard-default-none');
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test('captureNamedUiState normalizes undefined metadata contract keys to null', async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ui-smoke-harness-metadata-'));
 

--- a/test/loop/ui-smoke-harness.test.mjs
+++ b/test/loop/ui-smoke-harness.test.mjs
@@ -8,6 +8,8 @@ import {
   buildNamedUiStateArtifactPaths,
   captureNamedUiState,
   normalizeUiStateSegment,
+  normalizeViewportSegment,
+  normalizeInteractionSegment,
 } from '../playwright/harness/webkit-smoke-harness.mjs';
 
 test('normalizeUiStateSegment collapses UI state names into stable path segments', () => {
@@ -17,6 +19,24 @@ test('normalizeUiStateSegment collapses UI state names into stable path segments
   assert.throws(() => normalizeUiStateSegment('!!!'), /must contain at least one/i);
 });
 
+test('normalizeViewportSegment encodes dimensions/breakpoints and rejects malformed descriptors', () => {
+  assert.equal(normalizeViewportSegment(undefined), 'default');
+  assert.equal(normalizeViewportSegment(null), 'default');
+  assert.equal(normalizeViewportSegment({ width: 1280, height: 800 }), 'w1280h800');
+  assert.equal(normalizeViewportSegment('Mobile Small'), 'mobile-small');
+  assert.throws(() => normalizeViewportSegment({ width: 0, height: 800 }), /positive integer/i);
+  assert.throws(() => normalizeViewportSegment({ width: 1280.5, height: 800 }), /positive integer/i);
+  assert.throws(() => normalizeViewportSegment(1280), /object or a named breakpoint/i);
+});
+
+test('normalizeInteractionSegment defaults to none and rejects unknown interaction states', () => {
+  assert.equal(normalizeInteractionSegment(undefined), 'none');
+  assert.equal(normalizeInteractionSegment('Focus'), 'focus');
+  assert.equal(normalizeInteractionSegment(' hover '), 'hover');
+  assert.equal(normalizeInteractionSegment('error'), 'error');
+  assert.throws(() => normalizeInteractionSegment('pressed'), /must be one of/i);
+});
+
 test('buildNamedUiStateArtifactPaths derives deterministic screenshot and state paths', () => {
   const paths = buildNamedUiStateArtifactPaths({
     outputDir: 'test-results/ui-smoke/inspect-run-viewer',
@@ -24,13 +44,29 @@ test('buildNamedUiStateArtifactPaths derives deterministic screenshot and state 
     stateName: 'Current PR dashboard',
   });
 
-  assert.equal(paths.stateSlug, 'current-pr-dashboard');
-  assert.equal(paths.artifactDir, path.join('test-results/ui-smoke/inspect-run-viewer', 'named-states', 'current-pr-dashboard'));
+  assert.equal(paths.stateSlug, 'current-pr-dashboard-default-none');
+  assert.equal(paths.viewport, 'default');
+  assert.equal(paths.interactionState, 'none');
+  assert.equal(paths.artifactDir, path.join('test-results/ui-smoke/inspect-run-viewer', 'named-states', 'current-pr-dashboard-default-none'));
   assert.equal(paths.screenshotPath, path.join(paths.artifactDir, 'screenshot.png'));
   assert.equal(paths.statePath, path.join(paths.artifactDir, 'state.json'));
   assert.equal(paths.snapshotPath, path.join(paths.artifactDir, 'snapshot.json'));
   assert.equal(paths.axePath, path.join(paths.artifactDir, 'axe.json'));
   assert.equal(paths.consolePath, path.join(paths.artifactDir, 'console.json'));
+});
+
+test('buildNamedUiStateArtifactPaths gives distinct dirs for viewport- or interaction-only differences', () => {
+  const base = { outputDir: 'out', sliceId: 'inspect-run-viewer', stateName: 'Current PR dashboard' };
+  const desktop = buildNamedUiStateArtifactPaths({ ...base, viewport: { width: 1280, height: 800 } });
+  const mobile = buildNamedUiStateArtifactPaths({ ...base, viewport: { width: 375, height: 667 } });
+  const error = buildNamedUiStateArtifactPaths({ ...base, viewport: { width: 1280, height: 800 }, interactionState: 'error' });
+
+  assert.equal(desktop.stateSlug, 'current-pr-dashboard-w1280h800-none');
+  assert.equal(mobile.stateSlug, 'current-pr-dashboard-w375h667-none');
+  assert.equal(error.stateSlug, 'current-pr-dashboard-w1280h800-error');
+  // Differ only by viewport → distinct dirs. Differ only by interaction → distinct dirs.
+  assert.notEqual(desktop.artifactDir, mobile.artifactDir);
+  assert.notEqual(desktop.artifactDir, error.artifactDir);
 });
 
 test('captureNamedUiState writes the deterministic screenshot and state artifact bundle', async () => {
@@ -62,6 +98,8 @@ test('captureNamedUiState writes the deterministic screenshot and state artifact
       },
       sliceId: 'inspect-run-viewer',
       stateName: 'Current PR dashboard',
+      viewport: { width: 1280, height: 800 },
+      interactionState: 'error',
       metadata: {
         reviewHint: 'Use this state for the initial dashboard pass.',
         fixture: 'makeInspectionSnapshot',
@@ -75,13 +113,15 @@ test('captureNamedUiState writes the deterministic screenshot and state artifact
     await stat(artifact.artifactDir);
 
     const stateJson = JSON.parse(await readFile(artifact.statePath, 'utf8'));
-    assert.equal(stateJson.schemaVersion, 4);
+    assert.equal(stateJson.schemaVersion, 5);
     assert.equal(stateJson.artifactType, 'named-ui-state');
     assert.equal(stateJson.validationLevel, 'deterministic-smoke');
     assert.equal(stateJson.sliceId, 'inspect-run-viewer');
     assert.equal(stateJson.stateName, 'Current PR dashboard');
-    assert.equal(stateJson.stateSlug, 'current-pr-dashboard');
-    assert.equal(stateJson.runId, 'inspect-run-viewer-current-pr-dashboard-webkit');
+    assert.equal(stateJson.stateSlug, 'current-pr-dashboard-w1280h800-error');
+    assert.equal(stateJson.viewport, 'w1280h800');
+    assert.equal(stateJson.interactionState, 'error');
+    assert.equal(stateJson.runId, 'inspect-run-viewer-current-pr-dashboard-w1280h800-error-webkit');
     assert.equal(stateJson.projectName, 'webkit');
     assert.equal(stateJson.artifacts.screenshot.fileName, 'screenshot.png');
     assert.equal(stateJson.artifacts.screenshot.relativePath, 'screenshot.png');

--- a/test/playwright/harness/webkit-smoke-harness.mjs
+++ b/test/playwright/harness/webkit-smoke-harness.mjs
@@ -56,15 +56,19 @@ export function normalizeInteractionSegment(interactionState) {
   return normalized;
 }
 
-// Per-process registry of claimed named-state artifact paths. The artifact path
-// is slice-scoped, not run-unique (the same sliceId re-renders to the same dir,
-// and runId is deterministic), so a raw existsSync would false-positive against a
-// prior run's on-disk leftovers. Scoping the guard to this process instead catches
-// the real hazard — two logically distinct states in the SAME walk normalizing to
-// one slug — and resets naturally on a fresh run.
-// ponytail: per-process Set. A Playwright retry in a reused worker gets a
-// retry-suffixed outputDir, so its statePath differs and does not trip this.
-const claimedStatePaths = new Set();
+// Per-process registry mapping each claimed named-state artifact path to the
+// stateName that claimed it. The artifact path is slice-scoped, not run-unique
+// (the same sliceId re-renders to the same dir, and runId is deterministic), so a
+// raw existsSync would false-positive against a prior run's on-disk leftovers.
+// Scoping the guard to this process instead catches the real hazard — two
+// logically distinct states in the SAME walk normalizing to one slug — and resets
+// naturally on a fresh run.
+// ponytail: keyed on stateName. `resolvedOutputDir` prefers
+// `testInfo.project.outputDir`, which is stable per project (NOT retry-suffixed),
+// so a Playwright retry in a reused worker re-captures the SAME statePath. Keying
+// on the claiming stateName lets a same-state retry re-claim/overwrite, while a
+// DIFFERENT state slug-colliding to that path is still rejected.
+const claimedStatePaths = new Map();
 
 function requireOutputDir(outputDir) {
   if (typeof outputDir !== 'string' || outputDir.trim().length === 0) {
@@ -138,14 +142,17 @@ export async function captureNamedUiState({ page, testInfo, sliceId, stateName, 
   });
   const projectName = testInfo?.project?.name ?? null;
 
-  // Fail-closed capture-time collision guard: if a state already captured in this
-  // run resolves to the same on-disk artifacts, throw before writing anything so
-  // the second colliding slug can never silently overwrite the first. The bundle
-  // validator's blocked_duplicate_state_slug seam is defense-in-depth after this.
-  if (claimedStatePaths.has(paths.statePath)) {
+  // Fail-closed capture-time collision guard: if a DIFFERENT state already claimed
+  // these on-disk artifacts in this run, throw before writing anything so the
+  // second colliding slug can never silently overwrite the first. A re-capture by
+  // the SAME stateName (a Playwright retry hitting the same statePath) is a
+  // legitimate overwrite and is allowed. The bundle validator's
+  // blocked_duplicate_state_slug seam is defense-in-depth after this.
+  const claimedBy = claimedStatePaths.get(paths.statePath);
+  if (claimedBy !== undefined && claimedBy !== stateName) {
     throw new Error(`Duplicate named UI state slug "${paths.stateSlug}" for slice "${paths.sliceId}": a second state resolves to ${paths.statePath} and would overwrite the first. Give it a distinct state name, viewport, or interaction state.`);
   }
-  claimedStatePaths.add(paths.statePath);
+  claimedStatePaths.set(paths.statePath, stateName);
 
   await mkdir(paths.artifactDir, { recursive: true });
   await page.screenshot({ path: paths.screenshotPath, fullPage });

--- a/test/playwright/harness/webkit-smoke-harness.mjs
+++ b/test/playwright/harness/webkit-smoke-harness.mjs
@@ -17,6 +17,45 @@ export function normalizeUiStateSegment(value) {
   return normalized;
 }
 
+// The interaction states the slug can encode. `none` is the default render state;
+// the others are the stateful renders reviewers care about distinguishing.
+const UI_INTERACTION_STATES = new Set(['none', 'focus', 'hover', 'error']);
+
+// Normalize a viewport descriptor into a stable slug segment. A `{ width, height }`
+// object becomes `w<width>h<height>`; a named breakpoint string is normalized like
+// any other segment; an unspecified viewport defaults to `default`. A malformed
+// viewport (non-positive/non-integer dimensions, or a non-object/non-string) is
+// rejected — a bad descriptor must fail closed, never collapse to a silent default.
+export function normalizeViewportSegment(viewport) {
+  if (viewport === undefined || viewport === null) {
+    return 'default';
+  }
+  if (typeof viewport === 'string') {
+    return normalizeUiStateSegment(viewport);
+  }
+  if (typeof viewport === 'object') {
+    const { width, height } = viewport;
+    if (!Number.isInteger(width) || !Number.isInteger(height) || width <= 0 || height <= 0) {
+      throw new Error('UI state viewport must provide positive integer width and height');
+    }
+    return `w${width}h${height}`;
+  }
+  throw new Error('UI state viewport must be a { width, height } object or a named breakpoint string');
+}
+
+// Normalize an interaction state into a stable slug segment. Unspecified defaults to
+// `none`; anything outside the known set is rejected (fail closed, not silently kept).
+export function normalizeInteractionSegment(interactionState) {
+  if (interactionState === undefined || interactionState === null) {
+    return 'none';
+  }
+  const normalized = String(interactionState).trim().toLowerCase();
+  if (!UI_INTERACTION_STATES.has(normalized)) {
+    throw new Error(`UI state interaction must be one of ${[...UI_INTERACTION_STATES].join(', ')}`);
+  }
+  return normalized;
+}
+
 function requireOutputDir(outputDir) {
   if (typeof outputDir !== 'string' || outputDir.trim().length === 0) {
     throw new Error('A deterministic outputDir is required for named UI state artifacts');
@@ -28,14 +67,21 @@ function buildRunId({ sliceId, stateSlug, projectName }) {
   return [sliceId, stateSlug, projectName ?? 'unknown'].map((part) => normalizeUiStateSegment(part)).join('-');
 }
 
-export function buildNamedUiStateArtifactPaths({ outputDir, sliceId, stateName }) {
+export function buildNamedUiStateArtifactPaths({ outputDir, sliceId, stateName, viewport, interactionState }) {
   const normalizedSliceId = normalizeUiStateSegment(sliceId);
-  const stateSlug = normalizeUiStateSegment(stateName);
+  // The slug bakes viewport + interaction into the directory so a mobile vs desktop
+  // render, or a default vs error state, are distinct reviewable dirs that never
+  // collide/overwrite. Each part is normalized independently, then joined with `-`.
+  const viewportSlug = normalizeViewportSegment(viewport);
+  const interactionSlug = normalizeInteractionSegment(interactionState);
+  const stateSlug = `${normalizeUiStateSegment(stateName)}-${viewportSlug}-${interactionSlug}`;
   const artifactDir = path.join(requireOutputDir(outputDir), 'named-states', stateSlug);
 
   return {
     sliceId: normalizedSliceId,
     stateSlug,
+    viewport: viewportSlug,
+    interactionState: interactionSlug,
     artifactDir,
     screenshotPath: path.join(artifactDir, 'screenshot.png'),
     statePath: path.join(artifactDir, 'state.json'),
@@ -71,12 +117,14 @@ function defaultCaptureConsole() {
   return null;
 }
 
-export async function captureNamedUiState({ page, testInfo, sliceId, stateName, metadata = {}, fullPage = true, outputDir, runAxe = defaultRunAxe, captureConsole = defaultCaptureConsole } = {}) {
+export async function captureNamedUiState({ page, testInfo, sliceId, stateName, viewport, interactionState, metadata = {}, fullPage = true, outputDir, runAxe = defaultRunAxe, captureConsole = defaultCaptureConsole } = {}) {
   const resolvedOutputDir = outputDir ?? testInfo?.project?.outputDir ?? testInfo?.config?.outputDir ?? testInfo?.outputDir;
   const paths = buildNamedUiStateArtifactPaths({
     outputDir: resolvedOutputDir,
     sliceId,
     stateName,
+    viewport,
+    interactionState,
   });
   const projectName = testInfo?.project?.name ?? null;
 
@@ -131,12 +179,14 @@ export async function captureNamedUiState({ page, testInfo, sliceId, stateName, 
   };
 
   const stateArtifact = {
-    schemaVersion: 4,
+    schemaVersion: 5,
     artifactType: 'named-ui-state',
     validationLevel: 'deterministic-smoke',
     sliceId: paths.sliceId,
     stateName,
     stateSlug: paths.stateSlug,
+    viewport: paths.viewport,
+    interactionState: paths.interactionState,
     runId: buildRunId({ sliceId: paths.sliceId, stateSlug: paths.stateSlug, projectName }),
     capturedAt: new Date().toISOString(),
     projectName,

--- a/test/playwright/harness/webkit-smoke-harness.mjs
+++ b/test/playwright/harness/webkit-smoke-harness.mjs
@@ -56,6 +56,16 @@ export function normalizeInteractionSegment(interactionState) {
   return normalized;
 }
 
+// Per-process registry of claimed named-state artifact paths. The artifact path
+// is slice-scoped, not run-unique (the same sliceId re-renders to the same dir,
+// and runId is deterministic), so a raw existsSync would false-positive against a
+// prior run's on-disk leftovers. Scoping the guard to this process instead catches
+// the real hazard — two logically distinct states in the SAME walk normalizing to
+// one slug — and resets naturally on a fresh run.
+// ponytail: per-process Set. A Playwright retry in a reused worker gets a
+// retry-suffixed outputDir, so its statePath differs and does not trip this.
+const claimedStatePaths = new Set();
+
 function requireOutputDir(outputDir) {
   if (typeof outputDir !== 'string' || outputDir.trim().length === 0) {
     throw new Error('A deterministic outputDir is required for named UI state artifacts');
@@ -127,6 +137,15 @@ export async function captureNamedUiState({ page, testInfo, sliceId, stateName, 
     interactionState,
   });
   const projectName = testInfo?.project?.name ?? null;
+
+  // Fail-closed capture-time collision guard: if a state already captured in this
+  // run resolves to the same on-disk artifacts, throw before writing anything so
+  // the second colliding slug can never silently overwrite the first. The bundle
+  // validator's blocked_duplicate_state_slug seam is defense-in-depth after this.
+  if (claimedStatePaths.has(paths.statePath)) {
+    throw new Error(`Duplicate named UI state slug "${paths.stateSlug}" for slice "${paths.sliceId}": a second state resolves to ${paths.statePath} and would overwrite the first. Give it a distinct state name, viewport, or interaction state.`);
+  }
+  claimedStatePaths.add(paths.statePath);
 
   await mkdir(paths.artifactDir, { recursive: true });
   await page.screenshot({ path: paths.screenshotPath, fullPage });


### PR DESCRIPTION
## Summary

Stage 4 of epic #1067. The per-named-state directory slug now bakes in **viewport** and **interaction-state**, so responsive (mobile vs desktop) and stateful (default vs focus/hover/error) renders are distinct, non-colliding, independently-reviewable artifact directories.

## Scope and context

- `test/playwright/harness/webkit-smoke-harness.mjs`: `buildNamedUiStateArtifactPaths` now derives the slug as `<state-name>-<viewport>-<interaction>`, each segment normalized independently. New `normalizeViewportSegment` (`w<width>h<height>` for a `{width,height}` object, a normalized named-breakpoint string, or `default` when unspecified) and `normalizeInteractionSegment` (`focus`/`hover`/`error`/`none`, default `none`). `captureNamedUiState` records `viewport`/`interactionState` in `state.json`; `schemaVersion` bumped 4→5.
- `scripts/loop/ui-designer-review-contract.mjs`: `validateUiDesignerReviewInput` gains a duplicate-slug fail-closed seam — two named states colliding to the same slug (shared `statePath`) now return `blocked_duplicate_state_slug` / `duplicate_state_slug` instead of reviewing a bundle where one state clobbered another.
- `docs/ui-artifact-contract.md`: documents the slug shape, the distinctness + fail-closed guarantees, `viewport`/`interactionState` in the minimum `state.json` contract, and bumps the documented `schemaVersion` to 5. `docs/ui-smoke-harness.md` notes the slug composition. `.claude` regenerated (`--check` clean).

## Fail-closed + backward-compat

Duplicate-slug rejection is enforced in **two layers**: (1) capture-time prevention — `captureNamedUiState` throws on a within-run duplicate slug **before** any `mkdir`/`writeFile`, so a colliding second state can never silently overwrite the first on disk (a per-process claimed-slug set, so deterministic re-runs don't false-trip); (2) the bundle-validation seam (`blocked_duplicate_state_slug`) as defense-in-depth for an already-assembled bundle. A malformed viewport (non-positive/non-integer dims, or a non-object/non-string) or an interaction outside the known set **throws** — never silently collapses to a default. Existing callers (drive, deck/article/viewer harnesses) pass no viewport/interaction and keep working deterministically as `default`/`none`; only the slug **format** changed (covered by the schemaVersion bump — additive, no artifact-migration obligation per the Stage-1 path contract). The screenshot/state/snapshot/axe/console bundle is unchanged.

## Acceptance criteria

Satisfies #1300's ACs (checked off at merge): the slug encodes viewport + interaction-state and the path/slug contract doc is updated; two states differing only by viewport or interaction produce distinct artifact directories; a fail-closed seam rejects a malformed slug (normalizer throw) and a duplicate slug (contract seam); `npm run verify` green.

## Non-goals

Auto-enumerating interaction states (the spec/route names them). Lens fan-out (Stage 5). **Caller wiring is deferred:** this stage delivers the slug capability + fail-closed contract; wiring the live drive and the deck-fit harness to actually *pass* viewport/interaction (the deck-fit harness currently encodes the viewport into the state-name string) is a follow-up so the discriminator becomes reachable in production — tracked separately. Until then the discriminator is exercised by the harness/unit contract, and every current caller resolves to `default`/`none`.

## Validation

- `node --test test/loop/ui-smoke-harness.test.mjs test/loop/ui-designer-review-contract.test.mjs` — 34 pass (normalizers, distinct-dir per viewport/interaction, malformed-throw, capture-time duplicate-slug rejection incl. same-state-retry-allowed vs distinct-state-collision-rejected, bundle-validation duplicate seam, schemaVersion 5). `test/loop/ui-review-drive.test.mjs` — 31 pass.
- `npm run test:assets` — 191 pass; `node scripts/claude/generate-claude-assets.mjs --check` — clean.
- Full gate uses `npm run verify`.

Closes #1300
