### PR TITLE
fix(core): classify a docs/-hosted code/config/test file by extension before the docs/ prefix

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,7 @@
   },
   "description": "Shared deterministic support package for dev-loop skills, repo-local scripts, and GitHub automation.",
   "exports": {
+    "./analysis/diff-analyzer": "./src/analysis/diff-analyzer.mjs",
     "./bash-exit-one": "./src/bash-exit-one.mjs",
     "./cli/helpers": "./src/cli/helpers.mjs",
     "./cli/primitives": "./src/cli/primitives.mjs",

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -68,9 +68,10 @@ export function analyzeT0(nameStatusOutput) {
   }
 
   const renameOnly = lines.length > 0 && renameCount === lines.length;
-  const allDocs = lines.length > 0 && files.every(
-    (f) => normalizeSep(f).startsWith("docs/") || f.endsWith(".md") || f === "README.md",
-  );
+  // Derive from the shared classifier so this predicate can't drift from it: a
+  // code/config/test file hosted under docs/ is not prose, so a mixed diff that
+  // includes one is not docs-only (it still gets the code-review surface).
+  const allDocs = lines.length > 0 && files.every((f) => classifyFile(f) === "docs");
 
   return {
     files,

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -96,9 +96,9 @@ export function classifyFile(filePath) {
   if (fp.startsWith(".github/")) {
     return "ci";
   }
-  if (fp.startsWith("docs/") || fp.endsWith(".md") || fp === "README.md") {
-    return "docs";
-  }
+  // A known code/config/test extension wins over the docs/ directory-prefix
+  // fallback: a code/config/test file hosted under docs/ is still that surface,
+  // not prose. Extension checks run before the prefix fallbacks below.
   if (
     fp.endsWith(".yml") || fp.endsWith(".yaml") ||
     fp.endsWith(".json") || fp === "package.json"
@@ -113,6 +113,9 @@ export function classifyFile(filePath) {
     fp.endsWith(".ts") || fp.endsWith(".mts")
   ) {
     return "code";
+  }
+  if (fp.startsWith("docs/") || fp.endsWith(".md") || fp === "README.md") {
+    return "docs";
   }
   return "unknown";
 }

--- a/packages/core/test/diff-analyzer.test.mjs
+++ b/packages/core/test/diff-analyzer.test.mjs
@@ -43,6 +43,18 @@ test("classifyFile: ci for .github/ paths", () => {
   assert.equal(classifyFile(".github/workflows/verify.yml"), "ci");
 });
 
+test("classifyFile: code/config/test extension under docs/ wins over docs prefix", () => {
+  assert.equal(classifyFile("docs/example.mjs"), "code");
+  assert.equal(classifyFile("docs/fixture.json"), "config");
+  assert.equal(classifyFile("docs/x.test.mjs"), "test");
+});
+
+test("classifyFile: prose extensions under docs/ stay docs", () => {
+  assert.equal(classifyFile("docs/foo.md"), "docs");
+  assert.equal(classifyFile("docs/foo.html"), "docs");
+  assert.equal(classifyFile("docs/foo.css"), "docs");
+});
+
 test("classifyFile: unknown for unrecognized", () => {
   assert.equal(classifyFile("assets/logo.png"), "unknown");
 });

--- a/packages/core/test/diff-analyzer.test.mjs
+++ b/packages/core/test/diff-analyzer.test.mjs
@@ -166,6 +166,17 @@ test("analyzeDiff: T0 unambiguous → no T1, not ambiguous", () => {
   assert.equal(result.ambiguous, false);
 });
 
+test("analyzeDiff: a docs/-hosted code file in a mixed diff is NOT docs-only", () => {
+  // allDocs must track classifyFile: a code file under docs/ keeps the code
+  // review surface even alongside a real prose doc — not suppressed as DOCS_ONLY.
+  const result = analyzeDiff({
+    nameStatusOutput: "M\tdocs/example.mjs\nM\tdocs/guide.md",
+    diffOutput: "@@ -1,1 +1,1 @@\n+const x = 1;\n",
+  });
+  assert.equal(result.t0.allDocs, false);
+  assert.ok(!(result.t1.changeCategories.length === 1 && result.t1.changeCategories[0] === "DOCS_ONLY"));
+});
+
 test("analyzeDiff: T0 ambiguous with diff + logic change → classified, not ambiguous", () => {
   const result = analyzeDiff({
     nameStatusOutput: "M\tsrc/foo.mjs\nM\tdocs/bar.md",

--- a/packages/core/test/gate-carry-forward.test.mjs
+++ b/packages/core/test/gate-carry-forward.test.mjs
@@ -79,6 +79,16 @@ describe("resolveAngleCarryForward — fail-closed decision", () => {
     assert.equal(decision.carryForward, false);
   });
 
+  test("docs/-hosted .mjs delta + code angle -> false (code re-runs, not carried)", () => {
+    const decision = resolveAngleCarryForward({
+      angle: "correctness",
+      changedFiles: ["docs/example.mjs"],
+      prevVerdict: "clean",
+    });
+    assert.equal(decision.carryForward, false);
+    assert.match(decision.reason, /review surface \(code\)/);
+  });
+
   test("mandatory / always-include angle -> always re-run (never carried)", () => {
     const decision = resolveAngleCarryForward({
       angle: "pr-description",
@@ -167,6 +177,11 @@ describe("resolveConvergenceCarryForward — AC2 fail-closed Copilot convergence
     assert.equal(resolveConvergenceCarryForward({ changedFiles: ["foo.test.mjs"] }).carryForward, false);
     assert.equal(resolveConvergenceCarryForward({ changedFiles: ["config.json"] }).carryForward, false);
     assert.equal(resolveConvergenceCarryForward({ changedFiles: [".github/workflows/ci.yml"] }).carryForward, false);
+  });
+
+  test("docs/-hosted code/config delta -> fresh blocking round (re-open, not carried)", () => {
+    assert.equal(resolveConvergenceCarryForward({ changedFiles: ["docs/example.mjs"] }).carryForward, false);
+    assert.equal(resolveConvergenceCarryForward({ changedFiles: ["docs/fixture.json"] }).carryForward, false);
   });
 
   test("empty delta / unclassifiable file -> false (fail-closed)", () => {

--- a/scripts/loop/_post-convergence-change.mjs
+++ b/scripts/loop/_post-convergence-change.mjs
@@ -46,7 +46,9 @@ export function isTrivialDocumentationOnlyPath(filePath) {
   // Route the docs/ judgment through the shared classifier so a code/config/test
   // file hosted under docs/ is NOT treated as trivial documentation — such a
   // change must re-open a post-convergence Copilot round, not be suppressed.
-  if (normalized.startsWith("docs/")) return classifyFile(filePath) === "docs";
+  // Pass the SAME trim+lowercased value the prefix check used: classifyFile is
+  // case/whitespace-sensitive, so classifying the raw input could disagree.
+  if (normalized.startsWith("docs/")) return classifyFile(normalized) === "docs";
   return normalized.endsWith(".md")
     || normalized.endsWith(".mdx")
     || normalized.endsWith(".txt")

--- a/scripts/loop/_post-convergence-change.mjs
+++ b/scripts/loop/_post-convergence-change.mjs
@@ -7,6 +7,7 @@
 //
 // It lives in scripts/loop/ (not packages/core) because significance is derived
 // from a `gh api .../compare` diff — gh I/O that does not belong in core.
+import { classifyFile } from "@dev-loops/core/analysis/diff-analyzer";
 import { extractReviewCommitSha, isCopilotLogin, parseJsonText } from "../_core-helpers.mjs";
 import { runChild as defaultRunChild } from "../_cli-primitives.mjs";
 
@@ -42,7 +43,10 @@ export function isTrivialDocumentationOnlyPath(filePath) {
   if (typeof filePath !== "string") return true;
   const normalized = filePath.trim().toLowerCase();
   if (normalized.length === 0) return true;
-  if (normalized.startsWith("docs/")) return true;
+  // Route the docs/ judgment through the shared classifier so a code/config/test
+  // file hosted under docs/ is NOT treated as trivial documentation — such a
+  // change must re-open a post-convergence Copilot round, not be suppressed.
+  if (normalized.startsWith("docs/")) return classifyFile(filePath) === "docs";
   return normalized.endsWith(".md")
     || normalized.endsWith(".mdx")
     || normalized.endsWith(".txt")

--- a/test/loop/_post-convergence-change.test.mjs
+++ b/test/loop/_post-convergence-change.test.mjs
@@ -277,12 +277,15 @@ test("getLatestSubmittedCopilotReviewHeadSha tie-break: a valid timestamp beats 
 });
 
 test("isTrivialDocumentationOnlyPath classifies prose docs as trivial but a docs/-hosted code/config/test file as non-trivial", () => {
-  for (const p of ["docs/guide.md", "docs/notes.rst", "README.md", "a.mdx", "notes.txt", "x.rst", "y.adoc", "", null, undefined]) {
+  // Prose under docs/ (any case / surrounding whitespace) stays trivial.
+  for (const p of ["docs/guide.md", "docs/notes.rst", "DOCS/Guide.md", " docs/guide.md ", "README.md", "a.mdx", "notes.txt", "x.rst", "y.adoc", "", null, undefined]) {
     assert.equal(isTrivialDocumentationOnlyPath(p), true, `${p} should be trivial`);
   }
   // A code/config/test file hosted under docs/ is NOT trivial — it routes through
   // classifyFile, so a post-convergence change there re-opens a Copilot round.
-  for (const p of ["docs/x.mjs", "docs/fixture.json", "docs/x.test.mjs", "packages/core/src/a.mjs", "scripts/loop/x.mjs", "test/a.test.mjs"]) {
+  // The classifier is fed the same normalized value, so case/whitespace variants
+  // (docs/x.MJS, " docs/x.mjs") are handled consistently.
+  for (const p of ["docs/x.mjs", "docs/fixture.json", "docs/x.test.mjs", "docs/x.MJS", " docs/x.mjs", "packages/core/src/a.mjs", "scripts/loop/x.mjs", "test/a.test.mjs"]) {
     assert.equal(isTrivialDocumentationOnlyPath(p), false, `${p} should be non-trivial`);
   }
 });

--- a/test/loop/_post-convergence-change.test.mjs
+++ b/test/loop/_post-convergence-change.test.mjs
@@ -276,11 +276,13 @@ test("getLatestSubmittedCopilotReviewHeadSha tie-break: a valid timestamp beats 
   assert.equal(sha, "dated");
 });
 
-test("isTrivialDocumentationOnlyPath classifies docs and text extensions as trivial", () => {
-  for (const p of ["docs/x.mjs", "README.md", "a.mdx", "notes.txt", "x.rst", "y.adoc", "", null, undefined]) {
+test("isTrivialDocumentationOnlyPath classifies prose docs as trivial but a docs/-hosted code/config/test file as non-trivial", () => {
+  for (const p of ["docs/guide.md", "docs/notes.rst", "README.md", "a.mdx", "notes.txt", "x.rst", "y.adoc", "", null, undefined]) {
     assert.equal(isTrivialDocumentationOnlyPath(p), true, `${p} should be trivial`);
   }
-  for (const p of ["packages/core/src/a.mjs", "scripts/loop/x.mjs", "test/a.test.mjs"]) {
+  // A code/config/test file hosted under docs/ is NOT trivial — it routes through
+  // classifyFile, so a post-convergence change there re-opens a Copilot round.
+  for (const p of ["docs/x.mjs", "docs/fixture.json", "docs/x.test.mjs", "packages/core/src/a.mjs", "scripts/loop/x.mjs", "test/a.test.mjs"]) {
     assert.equal(isTrivialDocumentationOnlyPath(p), false, `${p} should be non-trivial`);
   }
 });


### PR DESCRIPTION
## Summary

Hardens the fail-closed carry-forward soundness that both #1308 (angle carry-forward) and #1326 (Copilot convergence carry-forward) depend on. `classifyFile()` returned `docs` for **any** path under `docs/` because the `docs/` directory-prefix check ran before the code/config/test extension checks — so a code/config/test file hosted under `docs/` misclassified as prose, and a carry-forward consumer would then carry an angle forward / suppress a Copilot round over a real code change. Latent today (docs/ holds only `.md`/`.html`/`.css`), fixed at the source.

## Scope and context

- `packages/core/src/analysis/diff-analyzer.mjs`: `classifyFile()` now runs the known code/config/test extension checks **before** the `docs/` directory-prefix fallback. `docs/example.mjs` → `code`, `docs/fixture.json` → `config`, `docs/x.test.mjs` → `test`; `docs/foo.md`/`.html`/`.css` still → `docs`. The kind set and the `unknown` fallback are unchanged.
- Both carry-forward consumers (`resolveAngleCarryForward`, `resolveConvergenceCarryForward`) inherit the corrected classification unchanged — a `docs/`-hosted code/config delta now **re-runs the angle / re-opens the round** instead of being carried forward.
- `analyzeDiff`'s inline `allDocs` predicate was a byte-copy of the old docs-first logic; it now derives from `classifyFile(f) === "docs"` so the two can't drift. This closes the same misclassification class in the T0/T1 angle-selection consumer: a mixed diff containing a `docs/`-hosted code file is no longer treated as `DOCS_ONLY` (it keeps the code-review surface).
- `scripts/loop/_post-convergence-change.mjs`: `isTrivialDocumentationOnlyPath` (the post-convergence Copilot round-cap significance detector, consumed by `copilot-pr-handoff` + the gate-coordination state) was a third divergent docs-first predicate — a `docs/`-hosted code change classified as trivial-doc and suppressed a Copilot re-open. Its `docs/` judgment now routes through `classifyFile` (exposed via a new `@dev-loops/core/analysis/diff-analyzer` package export), so a `docs/`-hosted code/config/test change re-opens a post-convergence round. `classifyFile` is now the sole authority for the **`docs/` directory-prefix** judgment across the carry-forward, angle-selection, and convergence-significance consumers (the post-convergence detector keeps its own prose-extension list — `.mdx`/`.txt`/`.rst`/`.adoc` — that `classifyFile` intentionally does not cover).

## Acceptance criteria

Satisfies #1330's ACs (checked off at merge): `classifyFile()` classifies by known code/config/test extension before the `docs/` (and other directory-prefix) fallback, while `.md`/`.html`/`.css` under `docs/` stay `docs`; unit tests cover a code/config/test-extension file under `docs/` and the `.md`/`.html`/`.css`-stays-docs cases; both carry-forward consumers inherit the corrected classification (a `docs/`-hosted code delta re-runs/re-opens); `npm run verify` green.

## Non-goals

Changing the `docs/`-hosted prose (`.md`/`SKILL.md`/contract docs) → `docs` behavior. Reworking the surface map or the carry-forward decision logic (only the file-kind classifier's ordering). The `.github/` → `ci` prefix stays prefix-first by design — all of `.github/` is CI surface and `ci` is already a re-run kind, so reordering it would change no carry-forward outcome.

## Validation

- `node --test packages/core/test/diff-analyzer.test.mjs packages/core/test/gate-carry-forward.test.mjs test/loop/_post-convergence-change.test.mjs` — classifier extension-before-prefix cases; the `analyzeDiff` mixed `docs/`-hosted-code diff is not `DOCS_ONLY`; carry-forward now treats a `docs/`-hosted `.mjs` as code → re-run; `isTrivialDocumentationOnlyPath` now treats a `docs/`-hosted code/config/test file as non-trivial (re-open). `npm run verify` — green (all suites); `generate-claude-assets --check` clean.
- `npm run verify` — green (all suites); `generate-claude-assets --check` clean.

Closes #1330
