### PR TITLE
docs(1.0): semver-stability statement across README/Pages/CHANGELOG + fix stale shared requireCi schema $def

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Stability
 
-- **The `.devloops` configuration surface is now a semver-stable public API**, as defined by `schemas/dev-loop-config.schema.json`: gate angles, personas, `gates.*` (including each gate's `requireCi` toggle and `gates.preApproval.requireCi`), `refinement.*`, the `uiReview.*` route config, `autonomy.*`, and `workflow.*`. New keys and gate angles are additive (minor); removing or repurposing an existing one is breaking (major).
+- **The `.devloops` configuration surface is now a semver-stable public API** (validated by the config loader in `packages/core/src/config/config.mjs`; `schemas/dev-loop-config.schema.json` documents the common keys): gate angles, personas, `gates.*` (including each gate's `requireCi` toggle and `gates.preApproval.requireCi`), `refinement.*`, the `uiReview.*` route config, `autonomy.*`, and `workflow.*`. New keys and gate angles are additive (minor); removing or repurposing an existing one is breaking (major).
 - **The public `dev-loop` command/skill surface and the [Public Dev Loop Contract](./skills/docs/public-dev-loop-contract.md) routing contract** are likewise stable. Internal strategy names, script internals, and undocumented helpers are not part of the stable surface.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## 1.0.0 - 2026-07-11
+
+**1.0 marks the public surface as stable.** From this release, `dev-loops` follows [semantic versioning](https://semver.org/) for its public API — breaking changes to it bump the major version. See the [Stability section in the README](./README.md#stability) for the full statement.
+
+### Stability
+
+- **The `.devloops` configuration surface is now a semver-stable public API**, as defined by `schemas/dev-loop-config.schema.json`: gate angles, personas, `gates.*` (including each gate's `requireCi` toggle and `gates.preApproval.requireCi`), `refinement.*`, the `uiReview.*` route config, `autonomy.*`, and `workflow.*`. New keys and gate angles are additive (minor); removing or repurposing an existing one is breaking (major).
+- **The public `dev-loop` command/skill surface and the [Public Dev Loop Contract](./skills/docs/public-dev-loop-contract.md) routing contract** are likewise stable. Internal strategy names, script internals, and undocumented helpers are not part of the stable surface.
+
+### Added
+
+- **`/loop-review-ui` matured to a full running-app review route (ui_review Stages 1–6).** Per-state semantic snapshot (`snapshot.json`, #1297), computed a11y facts via axe-core (`axe.json`, #1298), per-state console + network capture (`console.json`, #1299), viewport + interaction-state encoded in the state slug (#1300, #1331), a lens fan-out with a pure converge/dedupe seam (#1322), and acceptance-criterion traceability with a coverage gate (#1323). Drive-session row tagging so teardown drops exactly the drive-created rows (#1333), plus a GitHub-native gist fallback for artifact hosting (#1332).
+- **CI opt-out at the pre-approval gate (#1337).** `gates.preApproval.requireCi: false` is now honored (default stays `true`), so a repo with no CI can run the loop end-to-end instead of blocking forever at the pre-approval gate — mirroring the draft gate's `requireCi` knob. When false, the CI verdict is ignored entirely at that boundary (including a real failure).
+- **Visual grilling in the loop-grill external-resources step (#1034).** A design gap can reference a screenshot (path or URL) or a Playwright navigation descriptor, captured via a bounded wrapper over the existing ui_review harness — surfaced before the Q&A, fail-closed to `unresolved` on an inaccessible resource.
+- **Harness-aware model-tier policy on the existing models config (#1134)** and a sanctioned `create-issue.mjs` wrapper (#1309).
+
+### Changed
+
+- **Convergence carry-forward (#1326).** A doc/comment-only post-convergence head bump no longer forces a fresh Copilot round; a fail-closed angle carry-forward also skips gate re-review when a head delta doesn't touch the reviewed surface (#1308).
+- **Change-classifier soundness (#1330).** A `docs/`-hosted code/config/test file is now classified by its extension before the `docs/` prefix fallback, so it is never mis-treated as documentation-only.
+
+### Fixed
+
+- **Model-tier role-name collision (#1314)** — gate review angles resolve at the high tier despite a routine-role name collision.
+- **Gate-context build fails closed on a wrong-worktree/degenerate build (#1318);** queue `add` signals `moved: false` when it leaves an already-present item in a different column (#1306); generated `../docs` links shift correctly for `.claude/agents` and `validate-links` scans `.claude/**` (#1290).
+
 ## 0.9.0 - 2026-07-09
 
 The v0.9 headline is the **`/loop-review-ui` epic (#1114)** — a UI-review dev-loop route that proves a change in the running app — plus a batch of loop-hardening and dev-loop self-convention fixes.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Full details: the shipped defaults in `packages/core/src/config/extension-defaul
 
 From **1.0**, `dev-loops` follows [semantic versioning](https://semver.org/) for its public surface — breaking changes to it bump the major version:
 
-- **The `.devloops` configuration surface** — gate angles, personas, `gates.*` (including each gate's `requireCi` toggle and `gates.preApproval.requireCi`), `refinement.*`, `uiReview.*`, `autonomy.*`, and `workflow.*`, as defined by `schemas/dev-loop-config.schema.json`.
+- **The `.devloops` configuration surface** — gate angles, personas, `gates.*` (including each gate's `requireCi` toggle and `gates.preApproval.requireCi`), `refinement.*`, `uiReview.*`, `autonomy.*`, and `workflow.*`. The authoritative validator is the config loader in `packages/core/src/config/config.mjs`; `schemas/dev-loop-config.schema.json` documents the common keys (it is a partial reference, not the full surface).
 - **The public `dev-loop` command and skill surface** — the natural-language `dev-loop` router and the named `/loop-*` entrypoints.
 - **The routing contract** — the [Public Dev Loop Contract](./skills/docs/public-dev-loop-contract.md).
 

--- a/README.md
+++ b/README.md
@@ -133,11 +133,23 @@ Key surfaces:
 
 - **Gate angles** — which review lenses run at the draft and pre-approval gates
 - **Personas** — focused per-angle prompts (DRY, KISS, YAGNI, SRP, SoC, and more)
+- **Gates** — per-gate `requireCi` CI-precondition toggle (`gates.draft.requireCi`, `gates.preApproval.requireCi`; default `true`). Set a gate's `requireCi: false` to opt that gate out of the CI precondition — e.g. a repo with no CI can run the loop end-to-end instead of blocking at the gate.
 - **Refinement** — fan-out count and mode for parallel review variants; `refinement.maxCopilotRounds` caps Copilot re-review rounds (default `5`). Set `maxCopilotRounds: 0` to disable the Copilot gate entirely — local-harness-only review (`draft_gate → pre_approval_gate`), useful when the repo has no Copilot reviewer configured.
+- **UI review** — the `uiReview` surface configures the `/loop-review-ui` route (per-project run/boot command, login recipe, log/exception patterns)
 - **Autonomy** — which gates require operator confirmation
 - **Workflow defaults** — retrospective enforcement, draft-first posture, dev-mode policy
 
 Full details: the shipped defaults in `packages/core/src/config/extension-defaults.yaml` and the loader in `packages/core/src/config/config.mjs`.
+
+## Stability
+
+From **1.0**, `dev-loops` follows [semantic versioning](https://semver.org/) for its public surface — breaking changes to it bump the major version:
+
+- **The `.devloops` configuration surface** — gate angles, personas, `gates.*` (including each gate's `requireCi` toggle and `gates.preApproval.requireCi`), `refinement.*`, `uiReview.*`, `autonomy.*`, and `workflow.*`, as defined by `schemas/dev-loop-config.schema.json`.
+- **The public `dev-loop` command and skill surface** — the natural-language `dev-loop` router and the named `/loop-*` entrypoints.
+- **The routing contract** — the [Public Dev Loop Contract](./skills/docs/public-dev-loop-contract.md).
+
+Internal strategy names, script internals, and undocumented helpers are not part of the stable surface and may change in a minor release. New config keys and gate angles are additive (minor); removing or repurposing an existing one is a breaking change (major).
 
 ## Docker
 

--- a/docs/articles/introducing-dev-loops.html
+++ b/docs/articles/introducing-dev-loops.html
@@ -244,7 +244,7 @@ refinement:
 autonomy:
   humanMergeOnly: true    <span class="cm"># the loop prepares and reports ready; a person merges</span></code></pre>
 
-  <p>Three choices shape the experience. Work can start <strong>local-first</strong> &mdash; you write a short plan in the repository and the loop opens a pull request straight from it, with no issue to file &mdash; or <strong>github-first</strong>, where a tracked issue is the starting point. The review round can lean on Copilot or run without it. And the loop merges on its own only if you explicitly allow it; out of the box, it stops and hands the merge to you. Begin with the defaults and dial each setting toward the autonomy your team is comfortable with.</p>
+  <p>Three choices shape the experience. Work can start <strong>local-first</strong> &mdash; you write a short plan in the repository and the loop opens a pull request straight from it, with no issue to file &mdash; or <strong>github-first</strong>, where a tracked issue is the starting point. The review round can lean on Copilot or run without it. And the loop merges on its own only if you explicitly allow it; out of the box, it stops and hands the merge to you. Begin with the defaults and dial each setting toward the autonomy your team is comfortable with. As of 1.0 this configuration surface is stable &mdash; it follows semantic versioning, so a <code>.devloops</code> file you write today keeps working across minor upgrades.</p>
 
   <hr class="rule" />
 

--- a/docs/articles/introducing-dev-loops.md
+++ b/docs/articles/introducing-dev-loops.md
@@ -92,7 +92,7 @@ autonomy:
   humanMergeOnly: true    # the loop prepares and reports ready; a person merges
 ```
 
-Three choices shape the experience. Work can start **local-first** — you write a short plan in the repository and the loop opens a pull request straight from it, with no issue to file — or **github-first**, where a tracked issue is the starting point. The review round can lean on Copilot or run without it. And the loop merges on its own only if you explicitly allow it; out of the box, it stops and hands the merge to you. Begin with the defaults and dial each setting toward the autonomy your team is comfortable with.
+Three choices shape the experience. Work can start **local-first** — you write a short plan in the repository and the loop opens a pull request straight from it, with no issue to file — or **github-first**, where a tracked issue is the starting point. The review round can lean on Copilot or run without it. And the loop merges on its own only if you explicitly allow it; out of the box, it stops and hands the merge to you. Begin with the defaults and dial each setting toward the autonomy your team is comfortable with. As of 1.0 this configuration surface is stable — it follows semantic versioning, so a `.devloops` file you write today keeps working across minor upgrades.
 
 ## Where to go deeper
 

--- a/schemas/dev-loop-config.schema.json
+++ b/schemas/dev-loop-config.schema.json
@@ -240,7 +240,7 @@
         "requireCi": {
           "type": "boolean",
           "default": true,
-          "description": "Draft gate CI prerequisite toggle. preApproval remains CI-gated regardless of this flag."
+          "description": "Per-gate CI prerequisite toggle (default true). When true the gate requires green current-head CI; set false to opt that gate out of the CI precondition. Honored on both the draft and pre-approval gates — on the pre-approval gate a false value ignores the CI verdict entirely (including a real failure)."
         },
         "blockCleanOnFindingSeverities": {
           "type": "array",


### PR DESCRIPTION
## Summary

v1.0 public-docs pass across the three public surfaces (README, the GitHub Pages landing article, CHANGELOG), plus a residual schema-description fix — the last step before the release cut. Commits the public API to semantic versioning from 1.0.

## Scope and context

- `README.md` — new **Stability** section: from 1.0 the public surface follows semver (the `.devloops` config surface including `gates.*`/`requireCi`/`gates.preApproval.requireCi` and `uiReview.*`, the public `dev-loop` command/skill surface, and the routing contract); additive keys/angles are minor, removals/repurposing are major. The Configuration "Key surfaces" list now surfaces the per-gate `requireCi` toggle and the `uiReview` route config.
- `docs/articles/introducing-dev-loops.md` **and** `docs/articles/introducing-dev-loops.html` — the Pages landing (published as `index.html`) gets one in-voice sentence noting the config surface is stable as of 1.0. Both the `.md` and the hand-maintained `.html` (the actually-published file) are updated in lockstep.
- `CHANGELOG.md` — a `## 1.0.0` section: the 1.0 headline, an explicit **Stability** subsection naming the committed surfaces (the `uiReview` config surface and `gates.preApproval.requireCi` in particular), and Added/Changed/Fixed for the notable work since 0.9.0.
- `schemas/dev-loop-config.schema.json` — fixes a residual that #1337's scoped diffs hid: the shared `gateConfig.requireCi` `$def` description still claimed *"preApproval remains CI-gated regardless of this flag"* (now false). Reworded gate-neutrally — `requireCi` is honored on both the draft and pre-approval gates.

## Acceptance criteria

Satisfies #1341's ACs (checked off at merge): the shared `requireCi` `$def` no longer claims pre-approval always requires CI and no doc anywhere still does; README has the semver-Stability section and surfaces `uiReview`/`requireCi`; the Pages landing has the light 1.0 note; CHANGELOG has the `## 1.0.0` section with the stability statement; `npm run verify` green, `generate-claude-assets --check` clean, `test:docs` green.

## Non-goals

The `package.json` version bump, the `chore(release)` commit, tag push, and npm publish — those are the separate release-cut step performed after this docs pass.

## Validation

- `npm run verify` — green (2746 script + core suites); `generate-claude-assets --check` clean (`{"ok":true,"checked":68}`); `test:docs` links (547) + rule-ownership green; `test/pages/build-site.test.mjs` green (article/site build).

Closes #1341
