### PR TITLE
feat(gate): seam-triggered adversarial threat-model review angle (#1336)

### DIFF
--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -90,7 +90,8 @@ gitignored, worktree-local `tmp/gate-context` bundle it writes is present for th
   always-include addition. This additive path is off by default, so existing configured angle pools
   are unaffected unless a gate explicitly opts in.
 - **Security-sensitive-seam trigger (`threat-model`).** When the change categories include
-  `SECURITY_SENSITIVE_SEAM` — the diff touches browser automation, `child_process`/shell
+  `SECURITY_SENSITIVE_SEAM` — a **code** file's diff (config/doc/markdown lines that merely
+  name a primitive are file-gated out) touches browser automation, `child_process`/shell
   execution, untrusted network fetch, or destructive filesystem / local-file-upload ops — the
   resolver selects the `threat-model` angle (recommended when configured; added from the pool in
   additive mode). It is never dropped for such a diff, regardless of change size. `threat-model` is

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -89,6 +89,17 @@ gitignored, worktree-local `tmp/gate-context` bundle it writes is present for th
   triggering change category or, for always-include lenses, that it is an
   always-include addition. This additive path is off by default, so existing configured angle pools
   are unaffected unless a gate explicitly opts in.
+- **Security-sensitive-seam trigger (`threat-model`).** When the change categories include
+  `SECURITY_SENSITIVE_SEAM` — the diff touches browser automation, `child_process`/shell
+  execution, untrusted network fetch, or destructive filesystem / local-file-upload ops — the
+  resolver selects the `threat-model` angle (recommended when configured; added from the pool in
+  additive mode). It is never dropped for such a diff, regardless of change size. `threat-model` is
+  an adversarial-security lens that returns an exhaustive trust-boundary checklist (input allowlists,
+  navigation/origin confinement pre-launch **and** at runtime, resource/loop bounds, data-at-rest +
+  cleanup on every fail-closed path, exported/entry-point self-validation, error/teardown safety,
+  path-traversal/deserialization, shell-injection) rather than a spot-check — so a batched up-front
+  pass surfaces the trust-boundary holes that would otherwise be drip-fed serially through Copilot
+  rounds. `input-validation` is likewise part of the core `LOGIC_CHANGE` subset, not pool-only.
 - the preamble produces one or more review handoff artifacts (branch, head SHA, PR/issue
   scope, acceptance criteria, touched files, validation posture). The resolved angle set
   and its rationale are written as a deterministic handoff artifact under

--- a/packages/core/src/analysis/change-classifier.mjs
+++ b/packages/core/src/analysis/change-classifier.mjs
@@ -18,6 +18,10 @@ export const ChangeCategory = Object.freeze({
   CI_ONLY: "CI_ONLY",
   COMMENT_ONLY: "COMMENT_ONLY",
   LOGIC_CHANGE: "LOGIC_CHANGE",
+  // #1336: the diff touches a security-sensitive seam (browser automation,
+  // child_process/shell exec, untrusted network fetch, destructive filesystem
+  // ops / local-file upload). Triggers an up-front adversarial threat-model angle.
+  SECURITY_SENSITIVE_SEAM: "SECURITY_SENSITIVE_SEAM",
 });
 
 // ---------------------------------------------------------------------------
@@ -54,8 +58,16 @@ export const CATEGORY_ANGLE_MAP = {
   // Core review subset for any non-trivial code change. Peripheral lenses
   // (ci-guard, link-check, packaging-runtime, config-drift, etc.) are pulled in
   // only when the diff's other categories implicate them, not by logic alone.
+  // input-validation is included (#1336): it was pool-only and never auto-
+  // recommended, so entrypoint/input drift went unreviewed unless hand-picked.
   [ChangeCategory.LOGIC_CHANGE]: [
-    "scope", "correctness", "coverage", "determinism", "contract-surface",
+    "scope", "correctness", "coverage", "determinism", "contract-surface", "input-validation",
+  ],
+  // #1336: security-sensitive seam → up-front adversarial threat-model, plus
+  // input-validation and the core correctness/scope lenses. threat-model is
+  // never dropped for such a diff (a seam is dangerous regardless of size).
+  [ChangeCategory.SECURITY_SENSITIVE_SEAM]: [
+    "threat-model", "input-validation", "scope", "correctness",
   ],
 };
 

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -200,9 +200,30 @@ function isSecuritySensitiveSeamLine(content) {
 export function diffHasSecuritySeam(diffOutput) {
   if (!diffOutput) return false;
   let inHunk = false;
+  // Only CODE files can carry an executable seam — a YAML/markdown/JSON line that
+  // merely names a primitive (e.g. `shell: true` in a persona prompt) is not a
+  // seam. Track the current file from the unified-diff `--- a/`/`+++ b/` headers
+  // and gate the scan on `classifyFile(...) === "code"`. Bare-hunk input (no file
+  // header — used in tests / direct hunk analysis) defaults to code so it still
+  // scans; a real `git diff` always carries headers, so it is gated per file.
+  let currentFileIsCode = true;
+  let fromPath = null;
   for (const line of diffOutput.split("\n")) {
+    if (line.startsWith("--- ")) {
+      const p = line.slice(4).trim().replace(/^a\//, "");
+      fromPath = p === "/dev/null" ? null : p;
+      inHunk = false;
+      continue;
+    }
+    if (line.startsWith("+++ ")) {
+      const p = line.slice(4).trim().replace(/^b\//, "");
+      const effective = p === "/dev/null" ? fromPath : p;
+      currentFileIsCode = effective != null && classifyFile(effective) === "code";
+      inHunk = false;
+      continue;
+    }
     if (line.startsWith("@@")) { inHunk = true; continue; }
-    if (!inHunk) continue;
+    if (!inHunk || !currentFileIsCode) continue;
     const isAdd = line.startsWith("+") && !line.startsWith("+++");
     const isDel = line.startsWith("-") && !line.startsWith("---");
     if (!isAdd && !isDel) continue;

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -427,7 +427,7 @@ export function analyzeDiff({ nameStatusOutput, diffOutput }) {
   // pure-code diff (single `code` category, T1 skipped) editing a browser/exec/
   // fetch/fs-mutation driver still triggers the up-front threat-model angle — the
   // most concentrated seam case, and the one this feature targets.
-  if (diffHasSecuritySeam(diffOutput) && !t1.changeCategories.includes("SECURITY_SENSITIVE_SEAM")) {
+  if (!t1.changeCategories.includes("SECURITY_SENSITIVE_SEAM") && diffHasSecuritySeam(diffOutput)) {
     t1.changeCategories.push("SECURITY_SENSITIVE_SEAM");
   }
 

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -146,6 +146,45 @@ function isNonLogicLine(content) {
   return false;
 }
 
+// Security-sensitive seams (#1336): touching these primitives on caller-/plan-
+// influenced input is where trust-boundary bugs concentrate (drove #1335's 8
+// serial Copilot rounds). A changed line matching any of these triggers the
+// SECURITY_SENSITIVE_SEAM category so an up-front adversarial threat-model angle
+// is selected. Fail-safe by design — over-selection just adds one review lens.
+// Plain readFile/writeFile are deliberately excluded (ubiquitous JSON I/O would
+// flag nearly every script diff); the browser/process/network/destructive-fs/
+// upload seams below cover the genuinely dangerous surface, including #1335's
+// Playwright driver.
+const SECURITY_SEAM_PATTERNS = [
+  // Browser automation (driving a real browser over semi-trusted navigation)
+  /\b(playwright|webkit|chromium|puppeteer)\b/i,
+  /\bpage\.(goto|click|fill|evaluate|type|press|selectOption|setInputFiles|route|addInitScript)\b/,
+  /\.newPage\s*\(/,
+  /\bbrowser\.newContext\b/,
+  // Child-process / shell execution
+  /\bchild_process\b/,
+  /\b(exec|execSync|execFile|execFileSync|spawn|spawnSync)\s*\(/,
+  /\bshell\s*:\s*true\b/,
+  // Untrusted network fetch
+  /\bfetch\s*\(/,
+  /\bhttps?\.(get|request)\s*\(/,
+  /\b(axios|node-fetch|undici)\b/,
+  // Destructive filesystem ops + local-file upload (caller-path removal/read)
+  /\b(rm|rmSync|unlink|unlinkSync|rmdir|rmdirSync)\s*\(/,
+  /\bsetInputFiles\s*\(/,
+];
+
+/**
+ * Whether a changed diff line (content, prefix stripped) touches a
+ * security-sensitive seam (#1336).
+ *
+ * @param {string} content — trimmed line content (without + / - prefix)
+ * @returns {boolean}
+ */
+function isSecuritySensitiveSeamLine(content) {
+  return SECURITY_SEAM_PATTERNS.some((re) => re.test(content));
+}
+
 /**
  * Analyze unified diff hunks to classify change types.
  *
@@ -172,6 +211,7 @@ export function analyzeT1(diffOutput, t0) {
   let hasLogicChange = false;
   let hasAnyChangedLine = false;
   let allChangedLinesAreNonLogic = true;
+  let hasSecuritySeam = false;
 
   for (const line of lines) {
     // Track hunk headers
@@ -192,6 +232,7 @@ export function analyzeT1(diffOutput, t0) {
         hasLogicChange = true;
         allChangedLinesAreNonLogic = false;
       }
+      if (isSecuritySensitiveSeamLine(content)) hasSecuritySeam = true;
     } else if (line.startsWith("-") && !line.startsWith("---")) {
       deleted++;
       hasAnyChangedLine = true;
@@ -200,12 +241,16 @@ export function analyzeT1(diffOutput, t0) {
         hasLogicChange = true;
         allChangedLinesAreNonLogic = false;
       }
+      if (isSecuritySensitiveSeamLine(content)) hasSecuritySeam = true;
     }
   }
 
   // Build categories from T0 (shared with inferCategoriesFromT0) + hunk analysis.
   for (const c of t0FileCategories(t0)) categories.add(c);
   if (hasLogicChange) categories.add("LOGIC_CHANGE");
+  // #1336: a diff touching a security-sensitive seam gets an up-front adversarial
+  // threat-model angle, batched at draft time instead of drip-fed via Copilot.
+  if (hasSecuritySeam) categories.add("SECURITY_SENSITIVE_SEAM");
   // Mixed diffs never satisfy the exclusive `_ONLY` checks above (some files are
   // code), so their peripheral surfaces would be dropped. In this hunk-level path
   // (only reached for genuinely mixed diffs), also union each surface by PRESENCE

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -187,12 +187,15 @@ function isSecuritySensitiveSeamLine(content) {
 
 /**
  * Scan a unified diff for a security-sensitive seam (#1336) on any added/removed
- * LOGIC line. Gated on `!isNonLogicLine` so a comment/docstring/prose line that
- * merely names a primitive (e.g. `child_process` in a doc, `shell: true` in a
- * yaml prompt) does not falsely trigger — a real seam is always executable code.
- * Runs independently of the T0/T1 category path so it also covers a pure-code
- * diff (all files classify as `code`), which is the MOST concentrated seam case
- * (e.g. editing a Playwright/child_process driver) and the one #1336 targets.
+ * LOGIC line of a CODE file. Two gates keep it precise: (1) file-gate — only a
+ * file that `classifyFile()` calls `code` is scanned, so a yaml/markdown/json
+ * line that merely names a primitive (e.g. `shell: true` in a persona prompt, or
+ * `child_process` in a doc) never triggers; (2) `!isNonLogicLine` — within a code
+ * file, a comment/blank line that names a primitive (e.g. `// spawn( a child`)
+ * does not trigger either. Runs independently of the T0/T1 category path so it
+ * also covers a pure-code diff (all files classify as `code`), which is the MOST
+ * concentrated seam case (e.g. editing a Playwright/child_process driver) and the
+ * one #1336 targets.
  *
  * @param {string} diffOutput — raw unified diff output
  * @returns {boolean}

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -186,6 +186,34 @@ function isSecuritySensitiveSeamLine(content) {
 }
 
 /**
+ * Scan a unified diff for a security-sensitive seam (#1336) on any added/removed
+ * LOGIC line. Gated on `!isNonLogicLine` so a comment/docstring/prose line that
+ * merely names a primitive (e.g. `child_process` in a doc, `shell: true` in a
+ * yaml prompt) does not falsely trigger — a real seam is always executable code.
+ * Runs independently of the T0/T1 category path so it also covers a pure-code
+ * diff (all files classify as `code`), which is the MOST concentrated seam case
+ * (e.g. editing a Playwright/child_process driver) and the one #1336 targets.
+ *
+ * @param {string} diffOutput — raw unified diff output
+ * @returns {boolean}
+ */
+export function diffHasSecuritySeam(diffOutput) {
+  if (!diffOutput) return false;
+  let inHunk = false;
+  for (const line of diffOutput.split("\n")) {
+    if (line.startsWith("@@")) { inHunk = true; continue; }
+    if (!inHunk) continue;
+    const isAdd = line.startsWith("+") && !line.startsWith("+++");
+    const isDel = line.startsWith("-") && !line.startsWith("---");
+    if (!isAdd && !isDel) continue;
+    const content = line.slice(1).trim();
+    if (isNonLogicLine(content)) continue;
+    if (isSecuritySensitiveSeamLine(content)) return true;
+  }
+  return false;
+}
+
+/**
  * Analyze unified diff hunks to classify change types.
  *
  * Detects:
@@ -211,7 +239,6 @@ export function analyzeT1(diffOutput, t0) {
   let hasLogicChange = false;
   let hasAnyChangedLine = false;
   let allChangedLinesAreNonLogic = true;
-  let hasSecuritySeam = false;
 
   for (const line of lines) {
     // Track hunk headers
@@ -232,7 +259,6 @@ export function analyzeT1(diffOutput, t0) {
         hasLogicChange = true;
         allChangedLinesAreNonLogic = false;
       }
-      if (isSecuritySensitiveSeamLine(content)) hasSecuritySeam = true;
     } else if (line.startsWith("-") && !line.startsWith("---")) {
       deleted++;
       hasAnyChangedLine = true;
@@ -241,7 +267,6 @@ export function analyzeT1(diffOutput, t0) {
         hasLogicChange = true;
         allChangedLinesAreNonLogic = false;
       }
-      if (isSecuritySensitiveSeamLine(content)) hasSecuritySeam = true;
     }
   }
 
@@ -250,7 +275,7 @@ export function analyzeT1(diffOutput, t0) {
   if (hasLogicChange) categories.add("LOGIC_CHANGE");
   // #1336: a diff touching a security-sensitive seam gets an up-front adversarial
   // threat-model angle, batched at draft time instead of drip-fed via Copilot.
-  if (hasSecuritySeam) categories.add("SECURITY_SENSITIVE_SEAM");
+  if (diffHasSecuritySeam(diffOutput)) categories.add("SECURITY_SENSITIVE_SEAM");
   // Mixed diffs never satisfy the exclusive `_ONLY` checks above (some files are
   // code), so their peripheral surfaces would be dropped. In this hunk-level path
   // (only reached for genuinely mixed diffs), also union each surface by PRESENCE
@@ -375,6 +400,14 @@ export function analyzeDiff({ nameStatusOutput, diffOutput }) {
       hunkCount: 0,
       lineStats: { added: 0, deleted: 0 },
     };
+  }
+
+  // #1336: seam detection runs on the raw diff regardless of the T0/T1 path, so a
+  // pure-code diff (single `code` category, T1 skipped) editing a browser/exec/
+  // fetch/fs-mutation driver still triggers the up-front threat-model angle — the
+  // most concentrated seam case, and the one this feature targets.
+  if (diffHasSecuritySeam(diffOutput) && !t1.changeCategories.includes("SECURITY_SENSITIVE_SEAM")) {
+    t1.changeCategories.push("SECURITY_SENSITIVE_SEAM");
   }
 
   // `ambiguous` flags one specific case: a diff T0 could not classify (mixed file

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -605,6 +605,7 @@ const BUILTIN_PERSONAS = Object.freeze({
   yagni:       { persona: "review", defaultModel: null },
   "contract-surface":  { persona: "review", defaultModel: null },
   "input-validation":  { persona: "review", defaultModel: null },
+  "threat-model":      { persona: "review", defaultModel: null },
   "packaging-runtime": { persona: "review", defaultModel: null },
   "state-concurrency": { persona: "review", defaultModel: null },
   "renderer-security": { persona: "review", defaultModel: null },

--- a/packages/core/src/config/extension-defaults.yaml
+++ b/packages/core/src/config/extension-defaults.yaml
@@ -39,6 +39,7 @@ gates:
       - gate-evidence
       - no-op
       - input-validation
+      - threat-model
       - packaging-runtime
       - state-concurrency
       - renderer-security
@@ -350,6 +351,12 @@ personas:
     persona: review
     prompt: >-
       Review this change for renderer security. Check HTML text escaping, URL encoding, attribute encoding, JSON/script embedding, and rendering of user-controlled content. Treat titles, names, URLs, statuses, errors, and external payload fields as untrusted. Flag raw interpolation into HTML or attributes and tests that expect unsafe output.
+    defaultModel: null
+
+  threat-model:
+    persona: review
+    prompt: >-
+      Adversarially threat-model this change end to end — you are an attacker with control over every caller-/plan-influenced input (descriptors, paths, URLs, flags, env, fixture data). Do NOT spot-check; return a trust-boundary CHECKLIST and a verdict per item. Enumerate exhaustively for every seam the diff touches: (1) INPUT ALLOWLISTS — are actions/commands/schemes/hosts allowlisted (not denylisted), and enforced BEFORE any dangerous use (browser launch, exec, read)? (2) NAVIGATION/ORIGIN CONFINEMENT — same-origin/scheme enforced both pre-launch AND at runtime after every redirect / click / server-response (a pre-check the runtime can defeat is a hole). (3) RESOURCE/LOOP BOUNDS — step/size/time/recursion caps on attacker-influenced counts. (4) DATA-AT-REST + CLEANUP — sensitive intermediate artifacts minimized and removed on EVERY fail-closed path (not just the happy path); no off-origin/partial artifact left on disk on error. (5) EXPORTED/ENTRY-POINT TRUST — does every exported function / alternate entry self-validate, or can it bypass the parse-time validation the CLI does? (6) ERROR/TEARDOWN SAFETY — a throw in rm/close/teardown must not break the fail-closed envelope or leak state. (7) PATH TRAVERSAL / DESERIALIZATION — reject absolute/`..`/escape-base paths before read; no unsafe deserialization of untrusted data. (8) SHELL/PROCESS — no unescaped interpolation into a shell; prefer argv arrays; no `shell:true` with caller input. For each category that applies, state whether the change is safe and cite the guarding code (file:line) or flag the specific abuse and a failing-input example. If a category does not apply to the touched seam, say so explicitly rather than skipping it.
     defaultModel: null
 
   determinism:

--- a/packages/core/test/diff-analyzer.test.mjs
+++ b/packages/core/test/diff-analyzer.test.mjs
@@ -6,6 +6,7 @@ import {
   classifyFile,
   analyzeT1,
   analyzeDiff,
+  diffHasSecuritySeam,
 } from "../src/analysis/diff-analyzer.mjs";
 import { resolveDynamicAngles } from "../src/analysis/change-classifier.mjs";
 
@@ -166,6 +167,24 @@ test("analyzeDiff: pure-code NON-seam diff does not get SECURITY_SENSITIVE_SEAM"
     diffOutput: "@@ -1,2 +1,3 @@\n const y = 1;\n+  const total = a + b;\n",
   });
   assert.ok(!result.t1.changeCategories.includes("SECURITY_SENSITIVE_SEAM"));
+});
+
+test("seam: a config/docs FILE hunk naming a primitive is NOT a seam; a code file IS (file-gated via diff headers)", () => {
+  // #1336: a real git diff carries `+++ b/<path>` headers; only code files can
+  // carry an executable seam. A yaml persona line with `shell: true` must not flag.
+  const yamlSeamMention =
+    "diff --git a/packages/core/src/config/extension-defaults.yaml b/packages/core/src/config/extension-defaults.yaml\n" +
+    "--- a/packages/core/src/config/extension-defaults.yaml\n" +
+    "+++ b/packages/core/src/config/extension-defaults.yaml\n" +
+    "@@ -1,1 +1,2 @@\n prompt: review\n+      prompt: no shell: true and no child_process here\n";
+  assert.equal(diffHasSecuritySeam(yamlSeamMention), false, "config/docs mention must not flag a seam");
+
+  const codeSeam =
+    "diff --git a/scripts/loop/driver.mjs b/scripts/loop/driver.mjs\n" +
+    "--- a/scripts/loop/driver.mjs\n" +
+    "+++ b/scripts/loop/driver.mjs\n" +
+    "@@ -1,1 +1,2 @@\n const y = 1;\n+  await page.goto(appUrl);\n";
+  assert.equal(diffHasSecuritySeam(codeSeam), true, "code-file seam must flag");
 });
 
 test("analyzeT1: logic change from import-only diff (imports ARE logic)", () => {

--- a/packages/core/test/diff-analyzer.test.mjs
+++ b/packages/core/test/diff-analyzer.test.mjs
@@ -143,6 +143,31 @@ test("analyzeT1: ordinary logic change (no dangerous primitive) is NOT a seam", 
   assert.ok(!result.changeCategories.includes("SECURITY_SENSITIVE_SEAM"));
 });
 
+test("seam: a comment/doc line that merely names a primitive is NOT a seam (gated on !isNonLogicLine)", () => {
+  // #1336 fix: no over-triggering on prose/comment mentions of a primitive.
+  assert.ok(!analyzeT1("@@ -1,1 +1,2 @@\n const y = 1;\n+// spawn( a child_process here\n", codeT0).changeCategories.includes("SECURITY_SENSITIVE_SEAM"));
+  assert.ok(!analyzeT1("@@ -1,1 +1,2 @@\n const y = 1;\n+ * documents fetch( behavior\n", codeT0).changeCategories.includes("SECURITY_SENSITIVE_SEAM"));
+});
+
+test("analyzeDiff: PURE-CODE seam diff (no test/doc/config file) still triggers SECURITY_SENSITIVE_SEAM", () => {
+  // #1336 fix: the most concentrated case (editing a browser/exec driver with no
+  // mixed surface) previously skipped analyzeT1 entirely and missed the seam.
+  const result = analyzeDiff({
+    nameStatusOutput: "M\tscripts/loop/driver.mjs",
+    diffOutput: "@@ -1,2 +1,3 @@\n const y = 1;\n+  await page.goto(appUrl);\n",
+  });
+  assert.equal(result.t0.files.length, 1);
+  assert.ok(result.t1.changeCategories.includes("SECURITY_SENSITIVE_SEAM"), "pure-code seam must be detected");
+});
+
+test("analyzeDiff: pure-code NON-seam diff does not get SECURITY_SENSITIVE_SEAM", () => {
+  const result = analyzeDiff({
+    nameStatusOutput: "M\tscripts/loop/driver.mjs",
+    diffOutput: "@@ -1,2 +1,3 @@\n const y = 1;\n+  const total = a + b;\n",
+  });
+  assert.ok(!result.t1.changeCategories.includes("SECURITY_SENSITIVE_SEAM"));
+});
+
 test("analyzeT1: logic change from import-only diff (imports ARE logic)", () => {
   const t0 = { files: ["src/foo.mjs"], extensions: [".mjs"], directories: ["src"], renameOnly: false, allDocs: false };
   const diff = "@@ -1,1 +1,1 @@\n-import x from 'y';\n+import z from 'y';\n";

--- a/packages/core/test/diff-analyzer.test.mjs
+++ b/packages/core/test/diff-analyzer.test.mjs
@@ -114,6 +114,35 @@ test("analyzeT1: detects logic change from code additions", () => {
   assert.equal(result.hunkCount, 1);
 });
 
+// #1336: security-sensitive seam detection.
+const codeT0 = { files: ["scripts/loop/x.mjs"], extensions: [".mjs"], directories: ["scripts/loop"], renameOnly: false, allDocs: false };
+
+test("analyzeT1: browser-automation seam yields SECURITY_SENSITIVE_SEAM", () => {
+  const diff = "@@ -1,2 +1,3 @@\n const y = 1;\n+  await page.goto(appUrl);\n";
+  const result = analyzeT1(diff, codeT0);
+  assert.ok(result.changeCategories.includes("SECURITY_SENSITIVE_SEAM"));
+});
+
+test("analyzeT1: child_process/exec seam yields SECURITY_SENSITIVE_SEAM", () => {
+  const diff = "@@ -1,2 +1,3 @@\n const y = 1;\n+  const out = execSync(`git log ${ref}`);\n";
+  const result = analyzeT1(diff, codeT0);
+  assert.ok(result.changeCategories.includes("SECURITY_SENSITIVE_SEAM"));
+});
+
+test("analyzeT1: untrusted fetch + destructive rm seams yield SECURITY_SENSITIVE_SEAM", () => {
+  for (const line of ["+  const r = await fetch(url);", "+  await rm(dir, { recursive: true });", "+  await page.setInputFiles(sel, localPath);"]) {
+    const diff = `@@ -1,2 +1,3 @@\n const y = 1;\n${line}\n`;
+    assert.ok(analyzeT1(diff, codeT0).changeCategories.includes("SECURITY_SENSITIVE_SEAM"), `expected seam for: ${line}`);
+  }
+});
+
+test("analyzeT1: ordinary logic change (no dangerous primitive) is NOT a seam", () => {
+  const diff = "@@ -1,3 +1,5 @@\n import x from 'y';\n+const total = a + b;\n+export { total };\n";
+  const result = analyzeT1(diff, codeT0);
+  assert.ok(result.changeCategories.includes("LOGIC_CHANGE"));
+  assert.ok(!result.changeCategories.includes("SECURITY_SENSITIVE_SEAM"));
+});
+
 test("analyzeT1: logic change from import-only diff (imports ARE logic)", () => {
   const t0 = { files: ["src/foo.mjs"], extensions: [".mjs"], directories: ["src"], renameOnly: false, allDocs: false };
   const diff = "@@ -1,1 +1,1 @@\n-import x from 'y';\n+import z from 'y';\n";

--- a/packages/core/test/dynamic-angles.test.mjs
+++ b/packages/core/test/dynamic-angles.test.mjs
@@ -89,16 +89,51 @@ test("resolveDynamicAngles: LOGIC_CHANGE resolves to core subset, not all angles
   });
   assert.equal(result.fallbackToAll, false);
   // Core review subset (∩ DRAFT_ANGLES) + always-include gate-evidence.
-  for (const a of ["scope", "correctness", "coverage", "determinism", "contract-surface", "gate-evidence"]) {
+  // input-validation is part of the core subset (#1336): entrypoint/input drift
+  // is reviewed for every logic change, not only when hand-picked.
+  for (const a of ["scope", "correctness", "coverage", "determinism", "contract-surface", "gate-evidence", "input-validation"]) {
     assert.ok(result.recommendedAngles.includes(a), `expected ${a} in core subset`);
   }
   // Peripheral lenses are dropped, not run for logic alone.
-  for (const a of ["link-check", "packaging-runtime", "config-drift", "ci-guard", "input-validation", "state-concurrency", "no-op"]) {
+  for (const a of ["link-check", "packaging-runtime", "config-drift", "ci-guard", "state-concurrency", "no-op"]) {
     assert.ok(result.skippedAngles.includes(a), `expected ${a} skipped`);
     assert.ok(typeof result.reasons[a] === "string");
   }
   // Meaningfully narrower than the full configured pool (not a fallback-to-all).
   assert.ok(result.recommendedAngles.length < DRAFT_ANGLES.length);
+});
+
+// #1336: security-sensitive seam → up-front threat-model angle.
+const SEAM_DRAFT_ANGLES = [...DRAFT_ANGLES, "threat-model"];
+
+test("resolveDynamicAngles: SECURITY_SENSITIVE_SEAM selects threat-model (configured)", () => {
+  const result = resolveDynamicAngles({
+    configuredAngles: SEAM_DRAFT_ANGLES,
+    changeCategories: [ChangeCategory.LOGIC_CHANGE, ChangeCategory.SECURITY_SENSITIVE_SEAM],
+  });
+  assert.equal(result.fallbackToAll, false);
+  assert.ok(result.recommendedAngles.includes("threat-model"), "seam diff must select threat-model");
+  assert.ok(!result.skippedAngles.includes("threat-model"), "threat-model must never be skipped for a seam diff");
+  assert.ok(result.recommendedAngles.includes("input-validation"));
+});
+
+test("resolveDynamicAngles: SECURITY_SENSITIVE_SEAM adds threat-model from the pool (additive mode)", () => {
+  const result = resolveDynamicAngles({
+    configuredAngles: DRAFT_ANGLES, // threat-model NOT configured
+    changeCategories: [ChangeCategory.SECURITY_SENSITIVE_SEAM],
+    anglePool: ["threat-model"],
+  });
+  assert.ok(result.addedAngles.includes("threat-model"), "threat-model pulled from the pool for a seam diff");
+  assert.match(result.addedReasons["threat-model"], /SECURITY_SENSITIVE_SEAM/);
+});
+
+test("resolveDynamicAngles: a non-seam logic change does NOT select threat-model", () => {
+  const result = resolveDynamicAngles({
+    configuredAngles: SEAM_DRAFT_ANGLES,
+    changeCategories: [ChangeCategory.LOGIC_CHANGE],
+  });
+  assert.ok(!result.recommendedAngles.includes("threat-model"), "non-seam change must not run threat-model");
+  assert.ok(result.skippedAngles.includes("threat-model"));
 });
 
 test("resolveDynamicAngles: mixed logic + CI unions ci-guard into the core subset", () => {

--- a/packages/core/test/dynamic-angles.test.mjs
+++ b/packages/core/test/dynamic-angles.test.mjs
@@ -104,7 +104,8 @@ test("resolveDynamicAngles: LOGIC_CHANGE resolves to core subset, not all angles
 });
 
 // #1336: security-sensitive seam → up-front threat-model angle.
-const SEAM_DRAFT_ANGLES = [...DRAFT_ANGLES, "threat-model"];
+// De-duped so it stays correct if DRAFT_ANGLES is later updated to include threat-model.
+const SEAM_DRAFT_ANGLES = [...new Set([...DRAFT_ANGLES, "threat-model"])];
 
 test("resolveDynamicAngles: SECURITY_SENSITIVE_SEAM selects threat-model (configured)", () => {
   const result = resolveDynamicAngles({
@@ -119,7 +120,9 @@ test("resolveDynamicAngles: SECURITY_SENSITIVE_SEAM selects threat-model (config
 
 test("resolveDynamicAngles: SECURITY_SENSITIVE_SEAM adds threat-model from the pool (additive mode)", () => {
   const result = resolveDynamicAngles({
-    configuredAngles: DRAFT_ANGLES, // threat-model NOT configured
+    // Explicitly exclude threat-model so the additive path is exercised even if
+    // DRAFT_ANGLES is later updated to include it.
+    configuredAngles: DRAFT_ANGLES.filter((a) => a !== "threat-model"),
     changeCategories: [ChangeCategory.SECURITY_SENSITIVE_SEAM],
     anglePool: ["threat-model"],
   });


### PR DESCRIPTION
## Summary

Adds a **seam-triggered adversarial `threat-model` draft-gate angle** so trust-boundary review is batched **up front** at the draft gate instead of drip-fed serially through Copilot rounds. #1335 (the `--auto` visual-grill browser navigation) needed **8 Copilot rounds**, each surfacing one distinct real security/robustness hole in a headless browser driven by semi-trusted plan-authored input — because nothing triggered a deep security angle when the diff touched high-risk seams.

## Scope and context

- `packages/core/src/analysis/diff-analyzer.mjs` — a `SECURITY_SENSITIVE_SEAM` change category is flagged when a changed **logic** line touches a dangerous primitive: browser automation (`playwright`/`webkit`/`page.goto`/`setInputFiles`/…), `child_process`/shell exec (`exec`/`spawn`/`shell:true`), untrusted network fetch (`fetch(`/`http.get`/…), or destructive filesystem / local-file-upload ops (`rm`/`unlink`/`setInputFiles`). Detection is a standalone `diffHasSecuritySeam(diffOutput)` pass that runs **regardless of the T0/T1 category path**, so a pure-code diff (all files classify as `code` — e.g. editing a Playwright/`child_process` driver, the most concentrated seam case) is covered, not just mixed-surface diffs. Two gates keep it precise: a **file-gate** (`classifyFile === "code"`, tracked from the diff's `---`/`+++` headers) so a yaml/markdown/json line that merely *names* a primitive (e.g. `shell: true` in a persona prompt) does not trigger; and `!isNonLogicLine` so a comment/blank line *within a code file* does not trigger either. Plain `readFile`/`writeFile` are deliberately excluded (ubiquitous JSON I/O would flag nearly every script diff); the seam set covers the genuinely dangerous surface, including #1335's Playwright driver. Fail-safe: over-selection just adds one review lens.
- `packages/core/src/analysis/change-classifier.mjs` — `CATEGORY_ANGLE_MAP[SECURITY_SENSITIVE_SEAM] = [threat-model, input-validation, scope, correctness]`; `threat-model` is never dropped for a seam diff (a seam is dangerous regardless of size). Also fixes the narrower drift: `input-validation` joins the core `LOGIC_CHANGE` subset (it was pool-only and never auto-recommended).
- `packages/core/src/config/extension-defaults.yaml` — `threat-model` added to the draft angle pool with an adversarial-security persona that returns an **exhaustive trust-boundary checklist**, not a spot-check.
- `packages/core/src/config/config.mjs` — `threat-model` added to the `BUILTIN_PERSONAS` code fallback (parity with every other review angle), so persona resolution succeeds even when a consumer config omits the yaml persona.
- `docs/gate-review-sub-loop-contract.md` — documents the seam trigger and the `threat-model` lens.

## Regression note — the 8 #1335 findings mapped to the `threat-model` checklist

Evidence the angle would have surfaced all eight together, at draft time:

| #1335 finding | `threat-model` checklist category |
|---|---|
| 1. `file://`/`data:` goto → local-file screenshot | Input allowlists — scheme allowlist enforced before launch |
| 2. runtime origin escape (server redirect / click-to-external) | Navigation/origin confinement **at runtime**, not just pre-launch |
| 3. `upload`/`setInputFiles` → local-file exfiltration | Input allowlists — action/command allowlist |
| 4. sensitive intermediate captures retained | Data-at-rest minimization |
| 5. off-origin/partial artifact left on disk on failure | Cleanup on **every** fail-closed path |
| 6. exported `captureDescriptorScreen` bypasses parse validation | Exported/entry-point self-validation |
| 7. teardown error (`rm`/`close` throw) breaks the fail-closed envelope | Error/teardown safety |
| 8. walk can start off-origin (auth redirect / non-goto first step) | Initial-state confinement |

The diff's own driver file (`visual-grill-capture.mjs`, which drives Playwright) trips the browser-automation seam, so it would receive `threat-model` automatically.

## Acceptance criteria

Satisfies #1336's ACs (checked off at merge): a `threat-model` draft-gate angle exists in the pool with an exhaustive adversarial-security prompt, documented in the gate-review contract; the change-classifier detects a security-sensitive seam and selects `threat-model` (never dropped for such diffs), verified by tests that a seam diff yields it and a non-seam diff does not; `input-validation` is auto-recommended for logic changes, with a test; this regression note maps the 8 #1335 findings to the checklist; `npm run verify` green.

## Non-goals

Replacing Copilot review (it remains the external cross-check). Retroactively re-reviewing merged PRs. A full SAST tool — this is a prompted adversarial-review angle, not static analysis.

## Validation

- `node --test packages/core/test/dynamic-angles.test.mjs packages/core/test/diff-analyzer.test.mjs` — seam→threat-model (configured + additive), non-seam→no threat-model, input-validation in the LOGIC_CHANGE core subset, seam detection across browser/exec/fetch/rm/upload lines.
- `npm run verify` — green (2746 script + core suites); `generate-claude-assets --check` clean; `test:docs` green.

Closes #1336
