### PR TITLE
chore(ponytail): pre-1.0 cleanup — remove verified dead code + inline a pass-through alias (#1344)

### DIFF
--- a/packages/core/src/claude/asset-generation.mjs
+++ b/packages/core/src/claude/asset-generation.mjs
@@ -114,11 +114,6 @@ export function rewriteGeneratedRepoDocLinks(body) {
   return String(body).replace(/(\]\(<?)(\.\.\/docs\/)/g, "$1../$2");
 }
 
-// Back-compat alias for the pre-generalization name. This module is a public
-// `@dev-loops/core/claude/asset-generation` export, so the old export name keeps
-// forwarding to avoid breaking any downstream importer.
-export const rewriteCommandRepoLinks = rewriteGeneratedRepoDocLinks;
-
 /**
  * Map a single Pi tool name to its Claude tool name(s).
  * @param {string} name

--- a/packages/core/src/debt/shape.mjs
+++ b/packages/core/src/debt/shape.mjs
@@ -200,15 +200,3 @@ export function shapeFindings(findings) {
     return { outcome, artifact, findingId: f.id };
   });
 }
-
-/**
- * Run the full pipeline: cluster → score → shape, return shaped artifacts.
- *
- * @param {Array<object>} signals — debt_signal-compatible array
- * @returns {Array<{ outcome: ShapeOutcome, artifact: object|null, findingId: string }>}
- */
-export async function runPipeline(signals) {
-  const { clusterSignalsEnriched } = await import("./cluster.mjs");
-  const findings = clusterSignalsEnriched(signals);
-  return shapeFindings(findings);
-}

--- a/packages/core/src/loop/policy-constants.mjs
+++ b/packages/core/src/loop/policy-constants.mjs
@@ -12,6 +12,3 @@ export const COPILOT_FIRST_DURABLE_WAIT_TIMEOUT_MS = 3_600_000;
 
 /** Copilot review wait: external healthy-wait budget */
 export const COPILOT_REVIEW_WAIT_TIMEOUT_MS = 1_800_000;
-
-/** Explicit single-check timeout value (used only for status probes) */
-export const PROBE_ONLY_TIMEOUT_MS = 0;

--- a/packages/core/src/loop/queue-state.mjs
+++ b/packages/core/src/loop/queue-state.mjs
@@ -285,4 +285,3 @@ export function appendBugIssue(queue, issueNumber, dependsOn = null) {
   queue.entries.push(entry);
   return entry;
 }
-

--- a/packages/core/src/loop/queue-state.mjs
+++ b/packages/core/src/loop/queue-state.mjs
@@ -286,11 +286,3 @@ export function appendBugIssue(queue, issueNumber, dependsOn = null) {
   return entry;
 }
 
-// ── Serialization helpers ────────────────────────────────────────────
-
-export function serializeQueue(queue) {
-  return {
-    version: queue.version,
-    entries: queue.entries.map((e) => ({ ...e })),
-  };
-}

--- a/scripts/loop/_checkpoint-paths.mjs
+++ b/scripts/loop/_checkpoint-paths.mjs
@@ -20,9 +20,3 @@ export function buildLegacyDefaultCheckpointDir(pr) {
 export function buildCheckpointFilePath(checkpointDir) {
   return path.join(checkpointDir, "outer-loop-state.json");
 }
-export function buildDefaultCheckpointFilePath(repo, pr) {
-  return buildCheckpointFilePath(buildDefaultCheckpointDir(repo, pr));
-}
-export function buildLegacyDefaultCheckpointFilePath(pr) {
-  return buildCheckpointFilePath(buildLegacyDefaultCheckpointDir(pr));
-}

--- a/scripts/loop/detect-copilot-loop-state.mjs
+++ b/scripts/loop/detect-copilot-loop-state.mjs
@@ -64,7 +64,6 @@ Exit codes:
   0  Success
   1  Argument error, gh failure, or indeterminate state
   2  Invalid --jq filter`.trim();
-const VALID_OVERRIDE_STATUSES = new Set(["requested", "already-requested", "unavailable", "none", "failed"]);
 const parseError = buildParseError(USAGE);
 export function parseDetectCliArgs(argv) {
   const options = {

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -11,7 +11,7 @@ import {
   summarizeCopilotReviews,
 } from "../_core-helpers.mjs";
 import { parsePrNumber, requireTokenValue, runChild as defaultRunChild } from "../_cli-primitives.mjs";
-import { loadDevLoopConfig, resolveEffectiveCopilotRoundCap, resolveGateConfig, resolveRefinement, resolveRefinementConfig, resolveWorkflowConfig } from "@dev-loops/core/config";
+import { loadDevLoopConfig, resolveEffectiveCopilotRoundCap, resolveGateConfig, resolveRefinement, resolveRefinementConfig } from "@dev-loops/core/config";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { buildSnapshotFromPrFacts, interpretLoopState, isCopilotRoundCapReached, summarizeLoopInterpretation } from "@dev-loops/core/loop/copilot-loop-state";
 import { evaluatePrGateCoordination, PR_CHECKPOINT, PR_CHECKPOINT_ACTION, REFINEMENT_ARTIFACT_SPEC_SOURCE } from "@dev-loops/core/loop/pr-gate-coordination";

--- a/scripts/refine/_refine-helpers.mjs
+++ b/scripts/refine/_refine-helpers.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { readFile } from "node:fs/promises";
 
-import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { buildParseError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { parseArgs } from "node:util";
 import { parsePositiveInteger, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { detectRepoSlug, parseRepoSlug } from "@dev-loops/core/github/repo-slug";
@@ -23,10 +23,6 @@ ${JQ_OUTPUT_USAGE}
 (--jq/--silent only apply together with --json; the verdict is always in the
 payload, never the exit code — a parsed --json run always exits 0 unless
 --jq/--silent explicitly turns the verdict into the exit code.)`.trim();
-
-export function normalizeIssueNumber(value, label, parseError) {
-  return parsePositiveInteger(value, label, parseError);
-}
 
 export function parseCheckerCliArgs(argv, usage, checkerName) {
   const parseError = buildParseError(usage);
@@ -75,7 +71,7 @@ export function normalizeTreePayload(payload) {
   if (!payload || typeof payload !== "object") {
     throw new Error("Refinement tree input must be a JSON object");
   }
-  const rootIssueNumber = normalizeIssueNumber(
+  const rootIssueNumber = parsePositiveInteger(
     payload.rootIssueNumber ?? payload.root,
     "root issue number",
     (message) => new Error(message),
@@ -90,18 +86,18 @@ export function normalizeTreePayload(payload) {
     if (!rawIssue || typeof rawIssue !== "object") {
       throw new Error("Each issue entry must be an object");
     }
-    const number = normalizeIssueNumber(rawIssue.number, "issue number", (message) => new Error(message));
+    const number = parsePositiveInteger(rawIssue.number, "issue number", (message) => new Error(message));
     const title = typeof rawIssue.title === "string" ? rawIssue.title : "";
     const body = typeof rawIssue.body === "string" ? rawIssue.body : "";
     const state = typeof rawIssue.state === "string" ? rawIssue.state : "open";
 
     let parentNumber = null;
     if (rawIssue.parentNumber !== undefined && rawIssue.parentNumber !== null) {
-      parentNumber = normalizeIssueNumber(rawIssue.parentNumber, "parent issue number", (message) => new Error(message));
+      parentNumber = parsePositiveInteger(rawIssue.parentNumber, "parent issue number", (message) => new Error(message));
     }
 
     const children = Array.isArray(rawIssue.children)
-      ? rawIssue.children.map((child) => normalizeIssueNumber(child, "child issue number", (message) => new Error(message)))
+      ? rawIssue.children.map((child) => parsePositiveInteger(child, "child issue number", (message) => new Error(message)))
       : [];
 
     if (byNumber.has(number)) {
@@ -298,9 +294,5 @@ export function writeCheckerOutput(result, { stdout = process.stdout, stderr = p
 }
 
 
-export function handleCliError(error) {
-  process.stderr.write(`${formatCliError(error)}\n`);
-  process.exitCode = 1;
-}
 // Re-exported for checker scripts
 export { isDirectCliRun };

--- a/scripts/refine/_refine-helpers.mjs
+++ b/scripts/refine/_refine-helpers.mjs
@@ -293,6 +293,5 @@ export function writeCheckerOutput(result, { stdout = process.stdout, stderr = p
   return 0;
 }
 
-
 // Re-exported for checker scripts
 export { isDirectCliRun };


### PR DESCRIPTION
## Summary

Pre-1.0 ponytail cleanup sweep — **purely subtractive** (deletion over addition). A 5-way parallel read-only audit over `scripts/` + `packages/core/src/` confirmed the codebase is lean and surfaced a small set of verified, behavior-preserving removals. Each removed symbol was confirmed unreferenced repo-wide (excluding its own definition, tests, and the untracked `ombase/` backup mirror).

## Scope and context

**Dead code (pure deletion):**
- `scripts/loop/_checkpoint-paths.mjs` — `buildDefaultCheckpointFilePath` + `buildLegacyDefaultCheckpointFilePath` (the dir-builders + `buildCheckpointFilePath` they composed stay — those are used).
- `scripts/loop/detect-copilot-loop-state.mjs` — const `VALID_OVERRIDE_STATUSES`.
- `scripts/loop/detect-pr-gate-coordination-state.mjs` — unused import `resolveWorkflowConfig`.
- `scripts/refine/_refine-helpers.mjs` — export `handleCliError` (+ its now-unused `formatCliError` import).
- `packages/core/src/loop/queue-state.mjs` — export `serializeQueue` (`writeQueue` does its own stringify).
- `packages/core/src/loop/policy-constants.mjs` — const `PROBE_ONLY_TIMEOUT_MS` (orphaned with the removed `--probe-only` flag).
- `packages/core/src/debt/shape.mjs` — export `runPipeline` (the live caller `debt-remediate.mjs` chains `clusterSignalsEnriched`→`shapeFindings` itself).
- `packages/core/src/claude/asset-generation.mjs` — back-compat alias `rewriteCommandRepoLinks` (no downstream importer; `rewriteGeneratedRepoDocLinks` stays).

**Speculative indirection:**
- `scripts/refine/_refine-helpers.mjs` — inlined the pure pass-through `normalizeIssueNumber(v,label,err)` → `parsePositiveInteger(v,label,err)` at its 4 callers; deleted the alias.

Net: **-43 lines**, no new abstractions, no behavior change.

## Non-goals / deferred

Two verified byte-identical duplications are **deferred** — consolidating them trades duplication for a new shared abstraction / a new `@dev-loops/core` primitive-surface export, not clearly net-positive for a deletion sweep: the fail-soft config-load block in `_loop-evidence.mjs`/`inspect-run.mjs`, and the 30-line stdin-piping spawn helper in `_review-thread-mutations.mjs`/`stage-reviewer-draft.mjs`. Also not touched: `export`-keyword-only test seams (0 LOC), the trivial `normalizeSha` one-liner, and the public config surface (committed to 1.0 semver stability).

## Acceptance criteria

Satisfies #1344's ACs (checked at merge): every listed dead symbol / unused import removed and `normalizeIssueNumber` inlined; **no behavior change**, and no change to the **committed 1.0 stable surface** (the `.devloops` config surface, the `dev-loop` command/skill surface, and the routing contract — see the README Stability section from #1341). The four removed `@dev-loops/core` named exports (`serializeQueue`, `PROBE_ONLY_TIMEOUT_MS`, `runPipeline`, `rewriteCommandRepoLinks`) are **undocumented internal helpers with zero consumers** — the Stability section explicitly places "internal strategy names, script internals, and undocumented helpers" outside the stability promise. Trimming them from the surface **now, pre-1.0 (0.x), before the semver freeze** is the deliberate intent of this sweep; `npm run verify` green; `generate-claude-assets --check` clean.

## Validation

- `npm run verify` — green (2746 script + core suites, 0 failures); `generate-claude-assets --check` clean (`{"ok":true,"checked":68}`); core `package-surface` + `queue-state` tests pass.

Closes #1344
