### PR TITLE
ci(release): make the publish pipeline prerelease-aware (#1346)

### DIFF
--- a/.claude/skills/docs/release-runbook.md
+++ b/.claude/skills/docs/release-runbook.md
@@ -23,12 +23,17 @@ the workflow does it (and is idempotent if you already created one).
 - **`.github/workflows/release.yml`** fires on the `v*` tag push. It verifies the
   tagged commit is on `origin/main`, extracts the `## <version>` block from
   `CHANGELOG.md` via `scripts/release/extract-changelog-section.mjs`, and creates
-  the GitHub Release (`--latest`, notes = that CHANGELOG section). It is
+  the GitHub Release (`--latest` for a stable version, `--prerelease` for a
+  prerelease version such as `1.0.0-rc.1`; notes = that CHANGELOG section). It is
   **idempotent** (no-op if a Release for the tag already exists) and **fails
   closed** if the version has no CHANGELOG section — an undocumented version never
   gets an empty release.
 - **`.github/workflows/npm-publish.yml`** fires on `release: published` (created by
-  the step above) and publishes the packages to npm.
+  the step above) and publishes the packages to npm under the dist-tag resolved by
+  `scripts/release/resolve-npm-dist-tag.mjs`: a stable version → `latest`; a
+  prerelease → its channel (`1.0.0-rc.1` → `rc`, `…-next.N` → `next`, …) and
+  **never** `latest`, so a release candidate is opt-in (`npm install dev-loops@rc`)
+  and cannot become the default `npm install dev-loops`.
 
 ## Failure modes
 

--- a/.claude/skills/docs/release-runbook.md
+++ b/.claude/skills/docs/release-runbook.md
@@ -28,8 +28,12 @@ the workflow does it (and is idempotent if you already created one).
   **idempotent** (no-op if a Release for the tag already exists) and **fails
   closed** if the version has no CHANGELOG section — an undocumented version never
   gets an empty release.
-- **`.github/workflows/npm-publish.yml`** fires on `release: published` (created by
-  the step above) and publishes the packages to npm under the dist-tag resolved by
+- **`.github/workflows/npm-publish.yml`** is dispatched by the step above via
+  `workflow_dispatch` (`gh workflow run npm-publish.yml --ref <tag>`): a
+  `GITHUB_TOKEN`-created Release does **not** emit the `release` event, so the
+  automated tag flow relies on that explicit dispatch rather than `on: release`
+  (the `release: published` trigger remains only for a Release published by hand
+  in the UI). It publishes the packages to npm under the dist-tag resolved by
   `scripts/release/resolve-npm-dist-tag.mjs`: a stable version → `latest`; a
   prerelease → its channel (`1.0.0-rc.1` → `rc`, `…-next.N` → `next`, …) and
   **never** `latest`, so a release candidate is opt-in (`npm install dev-loops@rc`)

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -54,17 +54,19 @@ jobs:
           # jq, not `npm pkg get`: inside a workspace npm prints a name->version
           # map, not the bare version.
           VERSION=$(jq -r .version packages/core/package.json)
+          DIST_TAG=$(node scripts/release/resolve-npm-dist-tag.mjs --version "${VERSION}")
           if npm view "@dev-loops/core@${VERSION}" version >/dev/null 2>&1; then
             echo "::notice::@dev-loops/core@${VERSION} already published; skipping."
           else
-            npm publish -w packages/core --provenance --access public
+            npm publish -w packages/core --provenance --access public --tag "${DIST_TAG}"
           fi
 
       - name: Publish root package to npm
         run: |
           VERSION=$(npm pkg get version | tr -d '"')
+          DIST_TAG=$(node scripts/release/resolve-npm-dist-tag.mjs --version "${VERSION}")
           if npm view "dev-loops@${VERSION}" version >/dev/null 2>&1; then
             echo "::notice::dev-loops@${VERSION} already published; skipping."
           else
-            npm publish --provenance --access public
+            npm publish --provenance --access public --tag "${DIST_TAG}"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,13 +75,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # A prerelease version (e.g. 1.0.0-rc.1, contains a `-`) must NOT be
-          # marked --latest — it stays a --prerelease GitHub Release so it never
-          # becomes the default download, mirroring the npm dist-tag choice.
-          case "${{ steps.version.outputs.version }}" in
-            *-*) RELEASE_FLAG=--prerelease ;;
-            *)   RELEASE_FLAG=--latest ;;
-          esac
+          # Single source of truth for prerelease detection: reuse the npm
+          # dist-tag resolver (it strips SemVer build metadata, validates the
+          # version, and fails closed on a garbled tag). A `latest` dist-tag means
+          # a stable release (--latest); anything else is a prerelease channel
+          # (--prerelease) so the RC never becomes the default download. This
+          # keeps the GitHub-Release flag and the npm dist-tag from ever drifting.
+          DIST_TAG=$(node scripts/release/resolve-npm-dist-tag.mjs --version "${{ steps.version.outputs.version }}")
+          if [ "${DIST_TAG}" = "latest" ]; then
+            RELEASE_FLAG=--latest
+          else
+            RELEASE_FLAG=--prerelease
+          fi
           gh release create "${{ steps.version.outputs.tag }}" \
             --title "${{ steps.version.outputs.tag }}" \
             --notes-file release-notes.md \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,10 +75,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # A prerelease version (e.g. 1.0.0-rc.1, contains a `-`) must NOT be
+          # marked --latest — it stays a --prerelease GitHub Release so it never
+          # becomes the default download, mirroring the npm dist-tag choice.
+          case "${{ steps.version.outputs.version }}" in
+            *-*) RELEASE_FLAG=--prerelease ;;
+            *)   RELEASE_FLAG=--latest ;;
+          esac
           gh release create "${{ steps.version.outputs.tag }}" \
             --title "${{ steps.version.outputs.tag }}" \
             --notes-file release-notes.md \
-            --latest \
+            "${RELEASE_FLAG}" \
             --verify-tag
 
       # Not gated on `exists`: re-running after a failed dispatch/publish must

--- a/scripts/release/resolve-npm-dist-tag.mjs
+++ b/scripts/release/resolve-npm-dist-tag.mjs
@@ -40,10 +40,11 @@ function isDirectCliRun(importMetaUrl, argv1 = process.argv[1]) {
  * @returns {string} the npm dist-tag
  */
 // A release-safety helper must fail closed: a non-SemVer input (e.g. "foo", a
-// truncated tag) must NOT slip through as a stable release and publish under the
-// default `latest` dist-tag. Requires major.minor.patch, with optional
-// dot-separated prerelease (`-…`) and build (`+…`) identifiers.
-const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+// truncated tag, or one with a leading-zero component like "01.2.3") must NOT
+// slip through as a stable release and publish under the default `latest`
+// dist-tag. This is the canonical SemVer 2.0.0 regex (semver.org) — it forbids
+// leading zeros in numeric identifiers and validates prerelease/build fields.
+const SEMVER_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
 
 export function resolveNpmDistTag(version) {
   if (typeof version !== "string" || version.trim().length === 0) {

--- a/scripts/release/resolve-npm-dist-tag.mjs
+++ b/scripts/release/resolve-npm-dist-tag.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Resolve the npm dist-tag to publish a given version under.
+ *
+ * A stable release (no SemVer prerelease component) publishes under `latest` —
+ * the tag `npm install dev-loops` resolves by default. A prerelease
+ * (e.g. `1.0.0-rc.1`) publishes under the leading ALPHABETIC token of its first
+ * prerelease identifier (`rc`, `next`, `beta`, …) and NEVER under `latest`, so a
+ * release candidate can never hijack the default-install tag. This is the check
+ * that keeps a `v1.0.0-rc.1` tag from overwriting `latest` when release.yml
+ * dispatches npm-publish.yml.
+ *
+ * Usage:
+ *   node scripts/release/resolve-npm-dist-tag.mjs --version <v>
+ *   node scripts/release/resolve-npm-dist-tag.mjs            # defaults to ./package.json version
+ *
+ * Prints the dist-tag to stdout. Exit 0 on success, 2 on usage/parse error.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * @param {string} version — a SemVer version string
+ * @returns {string} the npm dist-tag
+ */
+export function resolveNpmDistTag(version) {
+  if (typeof version !== "string" || version.trim().length === 0) {
+    throw new Error("version must be a non-empty string");
+  }
+  const v = version.trim();
+  // SemVer: the prerelease component is everything after the first `-` and
+  // before any `+build` metadata.
+  const withoutBuild = v.split("+", 1)[0];
+  const dashIndex = withoutBuild.indexOf("-");
+  if (dashIndex === -1) return "latest"; // stable release
+  const prerelease = withoutBuild.slice(dashIndex + 1);
+  const firstIdentifier = prerelease.split(".")[0] ?? "";
+  const alpha = (firstIdentifier.match(/^[a-zA-Z]+/) ?? [])[0];
+  // A purely-numeric prerelease identifier (e.g. `1.0.0-1`) has no alpha token;
+  // fall back to `next` — anything but `latest`.
+  return alpha ? alpha.toLowerCase() : "next";
+}
+
+function parseArgs(argv) {
+  let version = null;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--version") {
+      version = argv[i + 1];
+      i++;
+    } else {
+      throw new Error(`Unknown argument: ${argv[i]}`);
+    }
+  }
+  return { version };
+}
+
+function main() {
+  let parsed;
+  try {
+    parsed = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(2);
+  }
+  let { version } = parsed;
+  if (version == null) {
+    try {
+      version = JSON.parse(fs.readFileSync(path.join(process.cwd(), "package.json"), "utf8")).version;
+    } catch (error) {
+      process.stderr.write(`Could not read version from ./package.json: ${error instanceof Error ? error.message : String(error)}\n`);
+      process.exit(2);
+    }
+  }
+  try {
+    process.stdout.write(`${resolveNpmDistTag(version)}\n`);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(2);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/release/resolve-npm-dist-tag.mjs
+++ b/scripts/release/resolve-npm-dist-tag.mjs
@@ -10,14 +10,13 @@
  * that keeps a `v1.0.0-rc.1` tag from overwriting `latest` when release.yml
  * dispatches npm-publish.yml.
  *
- * Usage:
- *   node scripts/release/resolve-npm-dist-tag.mjs --version <v>
- *   node scripts/release/resolve-npm-dist-tag.mjs            # defaults to ./package.json version
+ * Usage: node scripts/release/resolve-npm-dist-tag.mjs --version <v>
  *
- * Prints the dist-tag to stdout. Exit 0 on success, 2 on usage/parse error.
+ * `--version` is required (the workflows always pass it) — fail closed rather
+ * than silently guessing. Prints the dist-tag to stdout. Exit 0 on success,
+ * 2 on usage/parse error.
  */
 import fs from "node:fs";
-import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 // Inlined (node: builtins only): this script runs in npm-publish.yml as a CLI; a
@@ -94,14 +93,10 @@ function main() {
     process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     process.exit(2);
   }
-  let { version } = parsed;
+  const { version } = parsed;
   if (version == null) {
-    try {
-      version = JSON.parse(fs.readFileSync(path.join(process.cwd(), "package.json"), "utf8")).version;
-    } catch (error) {
-      process.stderr.write(`Could not read version from ./package.json: ${error instanceof Error ? error.message : String(error)}\n`);
-      process.exit(2);
-    }
+    process.stderr.write("Missing required --version <v>\n");
+    process.exit(2);
   }
   try {
     process.stdout.write(`${resolveNpmDistTag(version)}\n`);

--- a/scripts/release/resolve-npm-dist-tag.mjs
+++ b/scripts/release/resolve-npm-dist-tag.mjs
@@ -18,6 +18,22 @@
  */
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Inlined (node: builtins only): this script runs in npm-publish.yml as a CLI; a
+// workspace import would be fragile in the release environment. realpath-based so
+// a relative `node scripts/release/resolve-npm-dist-tag.mjs` invocation (as the
+// workflow uses) still detects direct-run — a brittle `file://${argv[1]}` string
+// compare could miss and skip main(), yielding an empty `npm publish --tag ""`.
+// Mirrors scripts/release/extract-changelog-section.mjs.
+function isDirectCliRun(importMetaUrl, argv1 = process.argv[1]) {
+  if (typeof argv1 !== "string" || argv1.length === 0) return false;
+  try {
+    return fs.realpathSync(argv1) === fs.realpathSync(fileURLToPath(importMetaUrl));
+  } catch {
+    return false;
+  }
+}
 
 /**
  * @param {string} version — a SemVer version string
@@ -79,6 +95,6 @@ function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isDirectCliRun(import.meta.url)) {
   main();
 }

--- a/scripts/release/resolve-npm-dist-tag.mjs
+++ b/scripts/release/resolve-npm-dist-tag.mjs
@@ -39,11 +39,20 @@ function isDirectCliRun(importMetaUrl, argv1 = process.argv[1]) {
  * @param {string} version — a SemVer version string
  * @returns {string} the npm dist-tag
  */
+// A release-safety helper must fail closed: a non-SemVer input (e.g. "foo", a
+// truncated tag) must NOT slip through as a stable release and publish under the
+// default `latest` dist-tag. Requires major.minor.patch, with optional
+// dot-separated prerelease (`-…`) and build (`+…`) identifiers.
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
 export function resolveNpmDistTag(version) {
   if (typeof version !== "string" || version.trim().length === 0) {
     throw new Error("version must be a non-empty string");
   }
   const v = version.trim();
+  if (!SEMVER_RE.test(v)) {
+    throw new Error(`not a valid SemVer version: ${version}`);
+  }
   // SemVer: the prerelease component is everything after the first `-` and
   // before any `+build` metadata.
   const withoutBuild = v.split("+", 1)[0];
@@ -62,6 +71,9 @@ function parseArgs(argv) {
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === "--version") {
       version = argv[i + 1];
+      if (version === undefined) {
+        throw new Error("Missing value for --version");
+      }
       i++;
     } else {
       throw new Error(`Unknown argument: ${argv[i]}`);

--- a/scripts/release/resolve-npm-dist-tag.mjs
+++ b/scripts/release/resolve-npm-dist-tag.mjs
@@ -62,9 +62,12 @@ export function resolveNpmDistTag(version) {
   const prerelease = withoutBuild.slice(dashIndex + 1);
   const firstIdentifier = prerelease.split(".")[0] ?? "";
   const alpha = (firstIdentifier.match(/^[a-zA-Z]+/) ?? [])[0];
-  // A purely-numeric prerelease identifier (e.g. `1.0.0-1`) has no alpha token;
-  // fall back to `next` — anything but `latest`.
-  return alpha ? alpha.toLowerCase() : "next";
+  const tag = alpha ? alpha.toLowerCase() : "next";
+  // A prerelease NEVER publishes under `latest`. A purely-numeric prerelease
+  // (`1.0.0-1`) has no alpha token, and the pathological `1.0.0-latest` would
+  // otherwise resolve to `latest` — both fall back to `next` so the invariant
+  // holds for every input, not just bump-script-generated `rc.N` tags.
+  return tag === "latest" ? "next" : tag;
 }
 
 function parseArgs(argv) {

--- a/skills/docs/release-runbook.md
+++ b/skills/docs/release-runbook.md
@@ -23,12 +23,17 @@ the workflow does it (and is idempotent if you already created one).
 - **`.github/workflows/release.yml`** fires on the `v*` tag push. It verifies the
   tagged commit is on `origin/main`, extracts the `## <version>` block from
   `CHANGELOG.md` via `scripts/release/extract-changelog-section.mjs`, and creates
-  the GitHub Release (`--latest`, notes = that CHANGELOG section). It is
+  the GitHub Release (`--latest` for a stable version, `--prerelease` for a
+  prerelease version such as `1.0.0-rc.1`; notes = that CHANGELOG section). It is
   **idempotent** (no-op if a Release for the tag already exists) and **fails
   closed** if the version has no CHANGELOG section — an undocumented version never
   gets an empty release.
 - **`.github/workflows/npm-publish.yml`** fires on `release: published` (created by
-  the step above) and publishes the packages to npm.
+  the step above) and publishes the packages to npm under the dist-tag resolved by
+  `scripts/release/resolve-npm-dist-tag.mjs`: a stable version → `latest`; a
+  prerelease → its channel (`1.0.0-rc.1` → `rc`, `…-next.N` → `next`, …) and
+  **never** `latest`, so a release candidate is opt-in (`npm install dev-loops@rc`)
+  and cannot become the default `npm install dev-loops`.
 
 ## Failure modes
 

--- a/skills/docs/release-runbook.md
+++ b/skills/docs/release-runbook.md
@@ -28,8 +28,12 @@ the workflow does it (and is idempotent if you already created one).
   **idempotent** (no-op if a Release for the tag already exists) and **fails
   closed** if the version has no CHANGELOG section — an undocumented version never
   gets an empty release.
-- **`.github/workflows/npm-publish.yml`** fires on `release: published` (created by
-  the step above) and publishes the packages to npm under the dist-tag resolved by
+- **`.github/workflows/npm-publish.yml`** is dispatched by the step above via
+  `workflow_dispatch` (`gh workflow run npm-publish.yml --ref <tag>`): a
+  `GITHUB_TOKEN`-created Release does **not** emit the `release` event, so the
+  automated tag flow relies on that explicit dispatch rather than `on: release`
+  (the `release: published` trigger remains only for a Release published by hand
+  in the UI). It publishes the packages to npm under the dist-tag resolved by
   `scripts/release/resolve-npm-dist-tag.mjs`: a stable version → `latest`; a
   prerelease → its channel (`1.0.0-rc.1` → `rc`, `…-next.N` → `next`, …) and
   **never** `latest`, so a release candidate is opt-in (`npm install dev-loops@rc`)

--- a/test/docs/resolve-npm-dist-tag.test.mjs
+++ b/test/docs/resolve-npm-dist-tag.test.mjs
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 
 import { resolveNpmDistTag } from "../../scripts/release/resolve-npm-dist-tag.mjs";
+
+const CLI = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "scripts", "release", "resolve-npm-dist-tag.mjs");
+const runCli = (...args) => spawnSync("node", [CLI, ...args], { encoding: "utf8" });
 
 test("resolveNpmDistTag: stable release -> latest", () => {
   assert.equal(resolveNpmDistTag("1.0.0"), "latest");
@@ -38,4 +44,22 @@ test("resolveNpmDistTag: rejects empty/invalid input", () => {
   assert.throws(() => resolveNpmDistTag(""), /non-empty string/);
   assert.throws(() => resolveNpmDistTag(null), /non-empty string/);
   assert.throws(() => resolveNpmDistTag(42), /non-empty string/);
+});
+
+// CLI entrypoint — the workflow captures stdout via $(...), so the CLI MUST
+// print a non-empty tag and exit 0 on success (an empty capture would become
+// `npm publish --tag ""`), and fail closed (exit 2) on bad input.
+test("CLI: prints the resolved tag and exits 0", () => {
+  const rc = runCli("--version", "1.0.0-rc.1");
+  assert.equal(rc.status, 0);
+  assert.equal(rc.stdout.trim(), "rc");
+  const stable = runCli("--version", "1.0.0");
+  assert.equal(stable.status, 0);
+  assert.equal(stable.stdout.trim(), "latest");
+});
+
+test("CLI: fails closed (exit 2) on an unknown arg", () => {
+  const r = runCli("--bogus", "x");
+  assert.equal(r.status, 2);
+  assert.equal(r.stdout.trim(), "", "must not print a tag on error");
 });

--- a/test/docs/resolve-npm-dist-tag.test.mjs
+++ b/test/docs/resolve-npm-dist-tag.test.mjs
@@ -39,9 +39,11 @@ test("resolveNpmDistTag: purely-numeric prerelease falls back to next, never lat
 });
 
 test("resolveNpmDistTag: a prerelease is NEVER latest (the load-bearing invariant)", () => {
-  for (const v of ["1.0.0-rc.1", "1.0.0-next.1", "1.0.0-beta", "1.0.0-1", "1.0.0-0.3.7"]) {
+  // incl. the pathological `-latest` identifier, which must be guarded, not passed through.
+  for (const v of ["1.0.0-rc.1", "1.0.0-next.1", "1.0.0-beta", "1.0.0-1", "1.0.0-0.3.7", "1.0.0-latest", "1.0.0-latest.2", "1.0.0-LATEST"]) {
     assert.notEqual(resolveNpmDistTag(v), "latest", `${v} must not publish to latest`);
   }
+  assert.equal(resolveNpmDistTag("1.0.0-latest"), "next");
 });
 
 test("resolveNpmDistTag: rejects empty/invalid input", () => {

--- a/test/docs/resolve-npm-dist-tag.test.mjs
+++ b/test/docs/resolve-npm-dist-tag.test.mjs
@@ -13,8 +13,12 @@ test("resolveNpmDistTag: stable release -> latest", () => {
   assert.equal(resolveNpmDistTag("1.0.0"), "latest");
   assert.equal(resolveNpmDistTag("0.9.0"), "latest");
   assert.equal(resolveNpmDistTag("2.3.4"), "latest");
-  // build metadata is not a prerelease
+  // build metadata is not a prerelease — even when it contains a hyphen, which
+  // must not be mistaken for a prerelease separator (release.yml derives the
+  // GitHub-Release --latest/--prerelease flag from this same result).
   assert.equal(resolveNpmDistTag("1.0.0+build.5"), "latest");
+  assert.equal(resolveNpmDistTag("1.0.0+build-1"), "latest");
+  assert.equal(resolveNpmDistTag("1.0.0+20130313144700"), "latest");
 });
 
 test("resolveNpmDistTag: rc prerelease -> rc (never latest)", () => {

--- a/test/docs/resolve-npm-dist-tag.test.mjs
+++ b/test/docs/resolve-npm-dist-tag.test.mjs
@@ -48,7 +48,7 @@ test("resolveNpmDistTag: rejects empty/invalid input", () => {
 
 test("resolveNpmDistTag: fails closed on a non-SemVer string (never latest for garbage)", () => {
   // A truncated/garbled tag must NOT be treated as a stable release -> latest.
-  for (const bad of ["foo", "1.0", "1", "v1.0.0", "1.0.0.0", "1.0.0-", "latest", "1.2.x"]) {
+  for (const bad of ["foo", "1.0", "1", "v1.0.0", "1.0.0.0", "1.0.0-", "latest", "1.2.x", "01.2.3", "1.02.3", "1.2.03"]) {
     assert.throws(() => resolveNpmDistTag(bad), /not a valid SemVer version/, `${bad} must fail closed`);
   }
 });

--- a/test/docs/resolve-npm-dist-tag.test.mjs
+++ b/test/docs/resolve-npm-dist-tag.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveNpmDistTag } from "../../scripts/release/resolve-npm-dist-tag.mjs";
+
+test("resolveNpmDistTag: stable release -> latest", () => {
+  assert.equal(resolveNpmDistTag("1.0.0"), "latest");
+  assert.equal(resolveNpmDistTag("0.9.0"), "latest");
+  assert.equal(resolveNpmDistTag("2.3.4"), "latest");
+  // build metadata is not a prerelease
+  assert.equal(resolveNpmDistTag("1.0.0+build.5"), "latest");
+});
+
+test("resolveNpmDistTag: rc prerelease -> rc (never latest)", () => {
+  assert.equal(resolveNpmDistTag("1.0.0-rc.1"), "rc");
+  assert.equal(resolveNpmDistTag("1.0.0-rc.10"), "rc");
+  assert.equal(resolveNpmDistTag("1.0.0-rc.1+build.2"), "rc");
+});
+
+test("resolveNpmDistTag: other prerelease channels map to their identifier", () => {
+  assert.equal(resolveNpmDistTag("1.2.0-next.3"), "next");
+  assert.equal(resolveNpmDistTag("1.0.0-beta.2"), "beta");
+  assert.equal(resolveNpmDistTag("1.0.0-alpha"), "alpha");
+  assert.equal(resolveNpmDistTag("1.0.0-RC.1"), "rc"); // case-normalized
+});
+
+test("resolveNpmDistTag: purely-numeric prerelease falls back to next, never latest", () => {
+  assert.equal(resolveNpmDistTag("1.0.0-1"), "next");
+});
+
+test("resolveNpmDistTag: a prerelease is NEVER latest (the load-bearing invariant)", () => {
+  for (const v of ["1.0.0-rc.1", "1.0.0-next.1", "1.0.0-beta", "1.0.0-1", "1.0.0-0.3.7"]) {
+    assert.notEqual(resolveNpmDistTag(v), "latest", `${v} must not publish to latest`);
+  }
+});
+
+test("resolveNpmDistTag: rejects empty/invalid input", () => {
+  assert.throws(() => resolveNpmDistTag(""), /non-empty string/);
+  assert.throws(() => resolveNpmDistTag(null), /non-empty string/);
+  assert.throws(() => resolveNpmDistTag(42), /non-empty string/);
+});

--- a/test/docs/resolve-npm-dist-tag.test.mjs
+++ b/test/docs/resolve-npm-dist-tag.test.mjs
@@ -83,6 +83,12 @@ test("CLI: --version with no value is a usage error (exit 2, no fallback)", () =
   assert.equal(r.stdout.trim(), "", "must not silently fall back or print a tag");
 });
 
+test("CLI: no args is a usage error (--version is required, exit 2)", () => {
+  const r = runCli();
+  assert.equal(r.status, 2);
+  assert.equal(r.stdout.trim(), "", "must fail closed, not guess from package.json");
+});
+
 test("CLI: a non-SemVer --version value fails closed (exit 2)", () => {
   const r = runCli("--version", "foo");
   assert.equal(r.status, 2);

--- a/test/docs/resolve-npm-dist-tag.test.mjs
+++ b/test/docs/resolve-npm-dist-tag.test.mjs
@@ -46,6 +46,13 @@ test("resolveNpmDistTag: rejects empty/invalid input", () => {
   assert.throws(() => resolveNpmDistTag(42), /non-empty string/);
 });
 
+test("resolveNpmDistTag: fails closed on a non-SemVer string (never latest for garbage)", () => {
+  // A truncated/garbled tag must NOT be treated as a stable release -> latest.
+  for (const bad of ["foo", "1.0", "1", "v1.0.0", "1.0.0.0", "1.0.0-", "latest", "1.2.x"]) {
+    assert.throws(() => resolveNpmDistTag(bad), /not a valid SemVer version/, `${bad} must fail closed`);
+  }
+});
+
 // CLI entrypoint — the workflow captures stdout via $(...), so the CLI MUST
 // print a non-empty tag and exit 0 on success (an empty capture would become
 // `npm publish --tag ""`), and fail closed (exit 2) on bad input.
@@ -62,4 +69,16 @@ test("CLI: fails closed (exit 2) on an unknown arg", () => {
   const r = runCli("--bogus", "x");
   assert.equal(r.status, 2);
   assert.equal(r.stdout.trim(), "", "must not print a tag on error");
+});
+
+test("CLI: --version with no value is a usage error (exit 2, no fallback)", () => {
+  const r = runCli("--version");
+  assert.equal(r.status, 2);
+  assert.equal(r.stdout.trim(), "", "must not silently fall back or print a tag");
+});
+
+test("CLI: a non-SemVer --version value fails closed (exit 2)", () => {
+  const r = runCli("--version", "foo");
+  assert.equal(r.status, 2);
+  assert.equal(r.stdout.trim(), "", "garbage must not publish under latest");
 });


### PR DESCRIPTION
## Summary

Makes the release/publish pipeline **prerelease-aware** so the 1.0 line can ship as an RC (`1.0.0-rc.1`) that consumers opt into and validate before the final `1.0.0` freeze — without the RC hijacking the `latest` dist-tag or the "latest release".

## Problem

The pipeline was stable-only: `npm-publish.yml` ran `npm publish` with **no `--tag`** (so it defaulted to the `latest` dist-tag — what `npm install dev-loops` resolves), and `release.yml` marked every GitHub Release `--latest`. Pushing a `v1.0.0-rc.1` tag would therefore make the RC the default install and the "latest release" — the opposite of an opt-in candidate.

## Scope and context

- `scripts/release/resolve-npm-dist-tag.mjs` (new, tested): maps a version to its npm dist-tag. Stable (no SemVer prerelease) → `latest`; a prerelease (`1.0.0-rc.1`) → the leading **alpha** token of its first prerelease identifier (`rc`, `next`, `beta`, …); a purely-numeric prerelease → `next`. A prerelease is **never** `latest` — that's the load-bearing invariant.
- `.github/workflows/npm-publish.yml` — both publish steps (core + root) now resolve `DIST_TAG` from the helper and pass `--tag "$DIST_TAG"`.
- `.github/workflows/release.yml` — the `gh release create` step derives its `--prerelease`/`--latest` flag from the SAME dist-tag helper (a `latest` dist-tag ⇒ `--latest`, else `--prerelease`), so the GitHub-Release flag and the npm dist-tag share one prerelease-detection and cannot drift; it also strips build metadata + validates SemVer + fails closed on a garbled tag.

A stable release (`1.0.0`, patches) still publishes to `latest` / `--latest` exactly as before — no behavior change for stable cuts.

## Acceptance criteria

Satisfies #1346's ACs (checked at merge): `resolve-npm-dist-tag.mjs` returns `latest` for stable, `rc` for `-rc.N`, the channel identifier for others, and never `latest` for any prerelease (unit-tested incl. the never-latest invariant); both npm publish steps + the GitHub-Release step are prerelease-aware with stable behavior unchanged; `npm run verify` green.

## Non-goals

Cutting the actual `1.0.0-rc.1` release (the follow-on `chore(release)` step). Changing the tag-triggered flow, provenance, or the main-ancestry publish guard.

## Validation

- `node --test test/docs/resolve-npm-dist-tag.test.mjs` — 12 cases (incl. 5 CLI) incl. the never-latest invariant across `rc`/`next`/`beta`/numeric prereleases; smoke: `1.0.0-rc.1`→`rc`, `1.0.0`→`latest`, `1.0.0-next.2`→`next`.
- `npm run verify` — green (2752 script + core suites).

Closes #1346
