### PR TITLE
feat(schema,pages): extract config JSON schema from the zod validator and render the intro article from markdown, with drift tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Full details: the shipped defaults in `packages/core/src/config/extension-defaul
 
 From **1.0**, `dev-loops` follows [semantic versioning](https://semver.org/) for its public surface — breaking changes to it bump the major version:
 
-- **The `.devloops` configuration surface** — gate angles, personas, `gates.*` (including each gate's `requireCi` toggle and `gates.preApproval.requireCi`), `refinement.*`, `uiReview.*`, `autonomy.*`, and `workflow.*`. The authoritative validator is the config loader in `packages/core/src/config/config.mjs`; `schemas/dev-loop-config.schema.json` documents the common keys (it is a partial reference, not the full surface).
+- **The `.devloops` configuration surface** — gate angles, personas, `gates.*` (including each gate's `requireCi` toggle and `gates.preApproval.requireCi`), `refinement.*`, `uiReview.*`, `autonomy.*`, and `workflow.*`. The authoritative validator is the config loader in `packages/core/src/config/config.mjs`; `schemas/dev-loop-config.schema.json` is generated from it (`node scripts/generate-config-schema.mjs`) and covers the full file-level surface — only cross-field refinements stay zod-only.
 - **The public `dev-loop` command and skill surface** — the natural-language `dev-loop` router and the named `/loop-*` entrypoints.
 - **The routing contract** — the [Public Dev Loop Contract](./skills/docs/public-dev-loop-contract.md).
 

--- a/docs/articles/introducing-dev-loops.html
+++ b/docs/articles/introducing-dev-loops.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- GENERATED from docs/articles/introducing-dev-loops.md by scripts/pages/render-article.mjs — do not edit; edit the markdown and regenerate. -->
 <html lang="en">
 <head>
 <meta charset="utf-8" />
@@ -164,64 +165,67 @@
   <header class="hero-card">
     <p class="kicker">dev-loops</p>
     <h1>Introducing dev-loops</h1>
-    <p class="lede">The slow part of AI-assisted development is no longer writing code &mdash; it is the coordination around it. dev-loops runs those in-between steps as recorded decisions, with a person at the merge by default.</p>
+    <p class="lede">The slow part of AI-assisted development is no longer writing code — it is the coordination around it. dev-loops runs those in-between steps as recorded decisions, with a person at the merge by default.</p>
   </header>
 
   <p>The slow part of AI-assisted development is no longer writing code. It is everything that has to happen around the code: someone notices a change is ready, rebuilds enough context to review it, checks that the tests ran, decides the next step is safe. Each of those is a small wait, and once the typing is fast, the waits are where the lead time lives.</p>
 
-  <p>dev-loops is a runtime for those in-between steps. It keeps the state of every change explicit, computes the next action from that state, and runs the routine transitions itself &mdash; drafting, reviewing, gating on green CI &mdash; while recording each decision where you can read it. A person stays at the merge by default. This article explains the idea, shows what it does on a real repository, and walks through running it on your own project. A deeper piece is linked at the end.</p>
+  <p>dev-loops is a runtime for those in-between steps. It keeps the state of every change explicit, computes the next action from that state, and runs the routine transitions itself — drafting, reviewing, gating on green CI — while recording each decision where you can read it. A person stays at the merge by default. This article explains the idea, shows what it does on a real repository, and walks through running it on your own project. A deeper piece is linked at the end.</p>
 
-  <h2>The idea</h2>
+  <h2 id="the-idea">The idea</h2>
 
-  <p>An agent left to its own devices tends to assume its way past the hard moments: it declares the review done, the tests good enough, the work finished, and nobody checks the declaration until something breaks. dev-loops replaces each of those assumptions with a decision the system takes deliberately. Is this change ready for review? Did the review actually run, with evidence? Is CI green on the current head? Every transition is computed, applied, and recorded &mdash; and when the answer is ambiguous, the loop fails closed and waits for a person rather than guessing.</p>
+  <p>An agent left to its own devices tends to assume its way past the hard moments: it declares the review done, the tests good enough, the work finished, and nobody checks the declaration until something breaks. dev-loops replaces each of those assumptions with a decision the system takes deliberately. Is this change ready for review? Did the review actually run, with evidence? Is CI green on the current head? Every transition is computed, applied, and recorded — and when the answer is ambiguous, the loop fails closed and waits for a person rather than guessing.</p>
 
   <p>Three ideas carry most of the value:</p>
 
   <ul>
-    <li><strong>Every change walks the same path.</strong> A draft gate checks the basics, automated review rounds look for real problems, and a pre-approval gate re-checks the final state &mdash; with green CI required at both gates unless a repository explicitly opts out. Nothing skips the path, including every change that built dev-loops itself.</li>
-    <li><strong>A person merges by default.</strong> Out of the box the loop stops at the merge and hands over; it merges on its own only when a repository grants that explicitly. There is also a stricter setting that makes the merge human-only no matter what any single run claims &mdash; it cannot be overridden from inside the loop.</li>
+    <li><strong>Every change walks the same path.</strong> A draft gate checks the basics, automated review rounds look for real problems, and a pre-approval gate re-checks the final state — with green CI required at both gates unless a repository explicitly opts out. Nothing skips the path, including every change that built dev-loops itself.</li>
+    <li><strong>A person merges by default.</strong> Out of the box the loop stops at the merge and hands over; it merges on its own only when a repository grants that explicitly. There is also a stricter setting that makes the merge human-only no matter what any single run claims — it cannot be overridden from inside the loop.</li>
     <li><strong>Work starts from a durable spec.</strong> A change begins as a short plan file in the repository or as a tracked issue, and the pull request carries that spec through review to merge. There is always a written artifact to check the result against.</li>
   </ul>
 
   <p>None of this is tied to one model or one editor, and the section <a href="#model-agnostic-by-construction">Model-agnostic by construction</a> explains why that follows from the design. dev-loops is a runtime for the decisions around a change, and it runs inside the AI coding tools teams already use.</p>
 
-  <h2>What it does to the work</h2>
+  <h2 id="what-it-does-to-the-work">What it does to the work</h2>
 
-  <p>Coordination is the cost that compounds. Every change carries a handful of transitions &mdash; is it ready, who reviews it, did the review pass, is CI green, can it merge &mdash; and every transition a person runs by hand is an interrupt with a context-switch attached. Multiply transitions per change by the number of changes and the hand-run coordination grows much faster than the throughput it supports. That compounding, not the code, is what caps how much an AI-assisted team ships.</p>
+  <p>Coordination is the cost that compounds. Every change carries a handful of transitions — is it ready, who reviews it, did the review pass, is CI green, can it merge — and every transition a person runs by hand is an interrupt with a context-switch attached. Multiply transitions per change by the number of changes and the hand-run coordination grows much faster than the throughput it supports. That compounding, not the code, is what caps how much an AI-assisted team ships.</p>
 
   <p>The loop breaks the compounding by turning each transition into a machine decision with a log. What remains for the human is roughly one bounded decision per change: the merge, plus anything the loop flags as unclear.</p>
 
-  <p>dev-loops is developed with dev-loops, so the honest evidence is its own history. The numbers below come straight from the repository&rsquo;s git log, not from a benchmark:</p>
+  <p>dev-loops is developed with dev-loops, so the honest evidence is its own history. The numbers below come straight from the repository's git log, not from a benchmark:</p>
 
   <div class="metrics" role="list">
-    <div class="metric" role="listitem"><div class="num">534</div><div class="lab">pull requests merged in the project&rsquo;s first nine weeks</div></div>
+    <div class="metric" role="listitem"><div class="num">534</div><div class="lab">pull requests merged in the project's first nine weeks</div></div>
     <div class="metric" role="listitem"><div class="num">~10/day</div><div class="lab">over the most recent two weeks (138 in fourteen days)</div></div>
     <div class="metric" role="listitem"><div class="num">24</div><div class="lab">tagged releases in the same stretch, up to a 1.0 release candidate</div></div>
-    <div class="metric" role="listitem"><div class="num">1</div><div class="lab">human decision per change &mdash; the default posture stops at the merge</div></div>
+    <div class="metric" role="listitem"><div class="num">1</div><div class="lab">human decision per change — the default posture stops at the merge</div></div>
   </div>
 
-  <p>The review load behind that pace is real work, and it is where the loop earns its keep. At the draft gate, review fans out to focused reviewers that each read the change through a single lens &mdash; scope, coverage, correctness, and input validation among them. Before approval, a second fan-out applies design and simplicity lenses (DRY, KISS, YAGNI, single-responsibility) plus a check of the change against its own written acceptance criteria. Findings land as comments on the pull request, and a finding rated must-fix blocks a clean verdict until it is addressed. The gate sits exactly where unattended automation is usually weakest &mdash; the moment a change is about to land &mdash; so the cadence stays fast while the merges stay ones a person can stand behind.</p>
+  <p>The review load behind that pace is real work, and it is where the loop earns its keep. At the draft gate, review fans out to focused reviewers that each read the change through a single lens — scope, coverage, correctness, and input validation among them. Before approval, a second fan-out applies design and simplicity lenses (DRY, KISS, YAGNI, single-responsibility) plus a check of the change against its own written acceptance criteria. Findings land as comments on the pull request, and a finding rated must-fix blocks a clean verdict until it is addressed. The gate sits exactly where unattended automation is usually weakest — the moment a change is about to land — so the cadence stays fast while the merges stay ones a person can stand behind.</p>
 
   <h2 id="model-agnostic-by-construction">Model-agnostic by construction</h2>
 
   <p>The same loop runs three ways over one shared core: as a Claude Code plugin, as a Pi extension, and as a standalone CLI. Routing, gates, and phases are defined once; the harnesses are thin integrations over that shared workflow.</p>
 
-  <p>Model choice is configuration in the same spirit. Roles map to model tiers, and tiers map per harness to concrete models: routine subagents (implementation, docs, small fixes, build chores) default to the low tier, while planning and review &mdash; the steps that guard quality &mdash; run on the high tier, and the conductor inherits whatever the session runs. Swapping the model behind any role is a config edit, not a code change.</p>
+  <p>Model choice is configuration in the same spirit. Roles map to model tiers, and tiers map per harness to concrete models: routine subagents (implementation, docs, small fixes, build chores) default to the low tier, while planning and review — the steps that guard quality — run on the high tier, and the conductor inherits whatever the session runs. Swapping the model behind any role is a config edit, not a code change.</p>
 
   <p>That split is the practical argument for model flexibility. The structure constrains how far any single step can stray: each step is bounded, each gate fails closed, and the review fan-out checks the work regardless of which model produced it. So the quality bar sits where the gates put it, and a cheaper or self-hosted model can carry the routine steps while the strongest model you have is reserved for the judgment-heavy ones.</p>
 
-  <h2>Set it up</h2>
+  <h2 id="set-it-up">Set it up</h2>
 
   <p>dev-loops drives an ordinary GitHub pull-request workflow from inside Claude Code or Pi. You need Node 24 or newer and the GitHub CLI (<code>gh</code>) authenticated for your repository.</p>
 
   <p><strong>Claude Code.</strong> Install the plugin from the bundled marketplace catalog:</p>
+
   <pre><code>/plugin marketplace add mfittko/dev-loops
 /plugin install dev-loops@dev-loops</code></pre>
 
   <p><strong>Pi.</strong> Install the extension from npm, pinned to a version so the surfaces cannot drift:</p>
+
   <pre><code>pi install npm:dev-loops@&lt;version&gt;</code></pre>
 
   <p><strong>Run a loop.</strong> The named commands are direct entrypoints; you never pick internal modes. On Claude Code:</p>
+
   <pre><code>/loop-start 112          <span class="cm"># start a dev loop on a tracked issue</span>
 /loop-auto 112           <span class="cm"># run autonomously to the human-approval checkpoint</span>
 /loop-continue 112       <span class="cm"># continue work on an issue or PR</span>
@@ -230,9 +234,10 @@
 /loop-info 112           <span class="cm"># read-only state summary for an issue or PR</span>
 /loop-status             <span class="cm"># readiness check: gh auth, git repo, subagents</span></code></pre>
 
-  <p>On Pi the same set is reachable as subcommands of one command: <code>/dev-loops start 112</code>, <code>/dev-loops auto 112</code>, <code>/dev-loops continue</code>, and so on. Plain language works too &mdash; <code>start dev loop on issue 112</code> or <code>continue dev loop on PR 88</code> routes through the same deterministic contract, so the named commands are thin shortcuts, not a separate mechanism.</p>
+  <p>On Pi the same set is reachable as subcommands of one command: <code>/dev-loops start 112</code>, <code>/dev-loops auto 112</code>, <code>/dev-loops continue</code>, and so on. Plain language works too — <code>start dev loop on issue 112</code> or <code>continue dev loop on PR 88</code> routes through the same deterministic contract, so the named commands are thin shortcuts, not a separate mechanism.</p>
 
   <p><strong>Tune the posture (optional).</strong> A <code>.devloops</code> file at the repository root controls how work arrives and how strict the loop is:</p>
+
   <pre><code><span class="cm"># .devloops</span>
 version: 1
 strategy:
@@ -244,13 +249,18 @@ refinement:
 autonomy:
   humanMergeOnly: true    <span class="cm"># merge stays a human-only action, regardless of any per-run flag</span></code></pre>
 
-  <p>Three choices shape the experience. Work can start <strong>local-first</strong> &mdash; you write a short plan in the repository and the loop opens a pull request straight from it &mdash; or <strong>github-first</strong>, where a tracked issue is the starting point. The automated review rounds can lean on Copilot or run without it. And the loop merges on its own only if you explicitly allow it; by default it stops and hands the merge to you. Start with the shipped defaults and dial each setting toward the autonomy your team is comfortable with. As of 1.0 this configuration surface follows semantic versioning, so a <code>.devloops</code> file you write today keeps working across minor upgrades.</p>
+  <p>Three choices shape the experience. Work can start <strong>local-first</strong> — you write a short plan in the repository and the loop opens a pull request straight from it — or <strong>github-first</strong>, where a tracked issue is the starting point. The automated review rounds can lean on Copilot or run without it. And the loop merges on its own only if you explicitly allow it; by default it stops and hands the merge to you. Start with the shipped defaults and dial each setting toward the autonomy your team is comfortable with. As of 1.0 this configuration surface follows semantic versioning, so a <code>.devloops</code> file you write today keeps working across minor upgrades.</p>
 
   <hr class="rule" />
 
+
+
   <section class="deeper">
-    <h2>Where to go deeper</h2>
-    <p>The <a href="./dev-loops-deep-dive.html">dev-loops deep dive</a> takes these ideas apart in detail, in two parts: why the next step is always computable from visible state, so the next actor pulls work instead of waiting for a handoff &mdash; and how to measure the waiting between actions, which is where the lead time goes once the code itself is fast to write.</p>
+
+    <h2 id="where-to-go-deeper">Where to go deeper</h2>
+
+    <p>The <a href="./dev-loops-deep-dive.html">dev-loops deep dive</a> takes these ideas apart in detail, in two parts: why the next step is always computable from visible state, so the next actor pulls work instead of waiting for a handoff — and how to measure the waiting between actions, which is where the lead time goes once the code itself is fast to write.</p>
+
   </section>
 
 </article>

--- a/docs/articles/introducing-dev-loops.html
+++ b/docs/articles/introducing-dev-loops.html
@@ -164,93 +164,93 @@
   <header class="hero-card">
     <p class="kicker">dev-loops</p>
     <h1>Introducing dev-loops</h1>
-    <p class="lede">AI writes the code in seconds. The expensive part moved to the coordination around it &mdash; and that is the part dev-loops takes over, one explicit decision at a time, with a person merging by default.</p>
+    <p class="lede">The slow part of AI-assisted development is no longer writing code &mdash; it is the coordination around it. dev-loops runs those in-between steps as recorded decisions, with a person at the merge by default.</p>
   </header>
 
-  <p>AI writes the code in seconds. The expensive part is now the coordination around it: the wait for someone to notice a change is ready, to rebuild enough context to review it, to decide the next step is safe. That waiting between actions is where the lead time of an AI-assisted workflow goes once the typing is fast.</p>
+  <p>The slow part of AI-assisted development is no longer writing code. It is everything that has to happen around the code: someone notices a change is ready, rebuilds enough context to review it, checks that the tests ran, decides the next step is safe. Each of those is a small wait, and once the typing is fast, the waits are where the lead time lives.</p>
 
-  <p>dev-loops is a coordination runtime for that problem. Like a Kanban board, the next step is always known: the system computes the next action for any change at any time, and whoever is free &mdash; agent or human &mdash; pulls that step from the visible state. So nobody waits for the previous actor to package up context and hand it over. The handoff becomes optional; when it happens it adds a note, and it stays a recorded decision, with a person merging by default. This article introduces the idea and shows how to run it on your own project. A deeper piece is linked at the end.</p>
+  <p>dev-loops is a runtime for those in-between steps. It keeps the state of every change explicit, computes the next action from that state, and runs the routine transitions itself &mdash; drafting, reviewing, gating on green CI &mdash; while recording each decision where you can read it. A person stays at the merge by default. This article explains the idea, shows what it does on a real repository, and walks through running it on your own project. A deeper piece is linked at the end.</p>
 
   <h2>The idea</h2>
 
-  <p>Left alone, an agent tends to assume its way past the hard moments. It marks the build passed, calls the review done, decides the work is finished &mdash; and those assumptions go unchecked until something breaks downstream. dev-loops takes the assumption out. Every transition &mdash; is this ready, who acts next, is it safe to merge &mdash; becomes a decision the system makes deliberately and records where you can read it. When the answer is unclear, the loop stops and a person decides before the work moves on.</p>
+  <p>An agent left to its own devices tends to assume its way past the hard moments: it declares the review done, the tests good enough, the work finished, and nobody checks the declaration until something breaks. dev-loops replaces each of those assumptions with a decision the system takes deliberately. Is this change ready for review? Did the review actually run, with evidence? Is CI green on the current head? Every transition is computed, applied, and recorded &mdash; and when the answer is ambiguous, the loop fails closed and waits for a person rather than guessing.</p>
 
   <p>Three ideas carry most of the value:</p>
 
   <ul>
-    <li><strong>Every change runs the same path.</strong> A draft check confirms the basics are in place, a review round looks for real problems, and a final gate confirms the tests are green. Nothing skips the path, including the changes that built dev-loops itself.</li>
-    <li><strong>A person merges by default.</strong> The loop does the preparation and reports that a change is ready; a human makes the final call. The autonomy is bounded on purpose, and you choose how much of it to grant.</li>
-    <li><strong>Work starts from a durable artifact.</strong> A change begins from a short plan you write locally or from a tracked issue. That artifact is the spec, and the pull request carries it through review to merge, so there is always something to check the result against.</li>
+    <li><strong>Every change walks the same path.</strong> A draft gate checks the basics, automated review rounds look for real problems, and a pre-approval gate re-checks the final state &mdash; with green CI required at both gates unless a repository explicitly opts out. Nothing skips the path, including every change that built dev-loops itself.</li>
+    <li><strong>A person merges by default.</strong> Out of the box the loop stops at the merge and hands over; it merges on its own only when a repository grants that explicitly. There is also a stricter setting that makes the merge human-only no matter what any single run claims &mdash; it cannot be overridden from inside the loop.</li>
+    <li><strong>Work starts from a durable spec.</strong> A change begins as a short plan file in the repository or as a tracked issue, and the pull request carries that spec through review to merge. There is always a written artifact to check the result against.</li>
   </ul>
 
-  <p>None of this depends on a particular model or a particular editor, and the section <a href="#model-agnostic-by-construction">Model-agnostic by construction</a> is where that claim earns its weight. It is a runtime for the decisions around a change, and it runs inside the AI coding tools teams already use.</p>
+  <p>None of this is tied to one model or one editor, and the section <a href="#model-agnostic-by-construction">Model-agnostic by construction</a> explains why that follows from the design. dev-loops is a runtime for the decisions around a change, and it runs inside the AI coding tools teams already use.</p>
 
   <h2>What it does to the work</h2>
 
-  <p>The point of the loop is what it does to the day-to-day of shipping. The clearest evidence is the project itself: dev-loops is built with dev-loops, so its own history shows the process it produces.</p>
+  <p>Coordination is the cost that compounds. Every change carries a handful of transitions &mdash; is it ready, who reviews it, did the review pass, is CI green, can it merge &mdash; and every transition a person runs by hand is an interrupt with a context-switch attached. Multiply transitions per change by the number of changes and the hand-run coordination grows much faster than the throughput it supports. That compounding, not the code, is what caps how much an AI-assisted team ships.</p>
 
-  <p>Coordination is the cost that grows. Every change carries a handful of transitions &mdash; is it ready, who reviews it, did review pass, is CI green, is it safe to merge &mdash; and each one a person handles by hand is an interrupt with its own switching cost. As the change count climbs, those manual transitions multiply against it: their number is the transitions per change times the volume, so hand-run coordination acts like a power over the throughput, and a person's effective load grows far faster than the number of changes. That compounding is what caps how much an AI-assisted team can actually ship, even once the code itself is cheap to produce.</p>
+  <p>The loop breaks the compounding by turning each transition into a machine decision with a log. What remains for the human is roughly one bounded decision per change: the merge, plus anything the loop flags as unclear.</p>
 
-  <p>dev-loops breaks the compounding by making each transition a decision the system takes and records. Every change follows the same path &mdash; draft, review, green-CI gate, human merge &mdash; so there is no bespoke ceremony to design and no question about what happens next. A person is pulled in only where one is genuinely needed: the merge, and anything the loop flags as ambiguous. What is left for the human is roughly one bounded decision per change; the transitions in between are the loop's to run and to log.</p>
+  <p>dev-loops is developed with dev-loops, so the honest evidence is its own history. The numbers below come straight from the repository&rsquo;s git log, not from a benchmark:</p>
 
   <div class="metrics" role="list">
-    <div class="metric" role="listitem"><div class="num">~100</div><div class="lab">pull requests merged in two weeks</div></div>
-    <div class="metric" role="listitem"><div class="num">~7/day</div><div class="lab">each drafted, reviewed, and gated</div></div>
-    <div class="metric" role="listitem"><div class="num">~7 in 8</div><div class="lab">tied to a tracked item</div></div>
-    <div class="metric" role="listitem"><div class="num">every one</div><div class="lab">merged by a person</div></div>
+    <div class="metric" role="listitem"><div class="num">534</div><div class="lab">pull requests merged in the project&rsquo;s first nine weeks</div></div>
+    <div class="metric" role="listitem"><div class="num">~10/day</div><div class="lab">over the most recent two weeks (138 in fourteen days)</div></div>
+    <div class="metric" role="listitem"><div class="num">24</div><div class="lab">tagged releases in the same stretch, up to a 1.0 release candidate</div></div>
+    <div class="metric" role="listitem"><div class="num">1</div><div class="lab">human decision per change &mdash; the default posture stops at the merge</div></div>
   </div>
 
-  <p>That is what the project's own history shows. In a recent four-day stretch the repository merged 87 pull requests &mdash; roughly 22 a day &mdash; closing 36 tracked issues and shipping two full releases (v0.4.0 and v0.5.0 to npm), each one drafted, reviewed, gated on green tests, and merged by a person. Every PR ran the full gate: a fan-out draft review, at least one Copilot round, a pre-approval gate on the current head, then a squash-merge. The cadence held because the extra work landed as machine transitions, with the human's part staying that one bounded decision at the merge.</p>
-
-  <p>Quality holds at that cadence. The review step keeps catching what slips past a tired reviewer in a hurry: a layout that broke on small screens, documentation that had drifted from the code, a review cycle that had quietly deadlocked. The loop earns its keep at the moment a change is about to land, which is where unattended automation is usually weakest &mdash; so the cadence is fast and the merges are still ones a person stands behind.</p>
+  <p>The review load behind that pace is real work, and it is where the loop earns its keep. At the draft gate, review fans out to focused reviewers that each read the change through a single lens &mdash; scope, coverage, correctness, and input validation among them. Before approval, a second fan-out applies design and simplicity lenses (DRY, KISS, YAGNI, single-responsibility) plus a check of the change against its own written acceptance criteria. Findings land as comments on the pull request, and a finding rated must-fix blocks a clean verdict until it is addressed. The gate sits exactly where unattended automation is usually weakest &mdash; the moment a change is about to land &mdash; so the cadence stays fast while the merges stay ones a person can stand behind.</p>
 
   <h2 id="model-agnostic-by-construction">Model-agnostic by construction</h2>
 
-  <p>The guardrails are what make the model choice cheap. The next action for any change is always computed and visible, so each step runs the same gate: a draft check, a review round, a green-CI confirmation, and a person at the merge. When a step is ambiguous, the loop fails closed and waits for a human. All that structure constrains how far any single step can stray, which means a strong open-source model can drive most or all of the work. Top-tier open-source models are enough here because the process does the constraining, so you can reserve a frontier model for the moments that genuinely call for one.</p>
+  <p>The same loop runs three ways over one shared core: as a Claude Code plugin, as a Pi extension, and as a standalone CLI. Routing, gates, and phases are defined once; the harnesses are thin integrations over that shared workflow.</p>
 
-  <p>That has practical consequences. A model you can self-host is cheaper to run and keeps the work clear of any one vendor's roadmap. The gate is what holds the quality bar: it catches the kind of slip a smaller model would let through, so the bar sits where the gate sets it and the model's job is to propose work the gate then checks.</p>
+  <p>Model choice is configuration in the same spirit. Roles map to model tiers, and tiers map per harness to concrete models: routine subagents (implementation, docs, small fixes, build chores) default to the low tier, while planning and review &mdash; the steps that guard quality &mdash; run on the high tier, and the conductor inherits whatever the session runs. Swapping the model behind any role is a config edit, not a code change.</p>
 
-  <p>This is not hypothetical. The loop has driven real work end to end on top-tier open-source models &mdash; DeepSeek V4, Kimi K2.6, MiniMax M3, Qwen 3.6, and GLM 5.2 &mdash; with the same gate holding the bar throughout.</p>
+  <p>That split is the practical argument for model flexibility. The structure constrains how far any single step can stray: each step is bounded, each gate fails closed, and the review fan-out checks the work regardless of which model produced it. So the quality bar sits where the gates put it, and a cheaper or self-hosted model can carry the routine steps while the strongest model you have is reserved for the judgment-heavy ones.</p>
 
   <h2>Set it up</h2>
 
-  <p>dev-loops runs inside Claude Code or Pi and drives an ordinary GitHub pull-request workflow. You need Node 24 or newer and the GitHub CLI (<code>gh</code>) authenticated for your repository.</p>
+  <p>dev-loops drives an ordinary GitHub pull-request workflow from inside Claude Code or Pi. You need Node 24 or newer and the GitHub CLI (<code>gh</code>) authenticated for your repository.</p>
 
-  <p><strong>Claude Code.</strong> Install the plugin from inside Claude Code:</p>
+  <p><strong>Claude Code.</strong> Install the plugin from the bundled marketplace catalog:</p>
   <pre><code>/plugin marketplace add mfittko/dev-loops
 /plugin install dev-loops@dev-loops</code></pre>
 
-  <p><strong>Pi.</strong> Install the extension:</p>
-  <pre><code>pi install npm:dev-loops</code></pre>
+  <p><strong>Pi.</strong> Install the extension from npm, pinned to a version so the surfaces cannot drift:</p>
+  <pre><code>pi install npm:dev-loops@&lt;version&gt;</code></pre>
 
-  <p><strong>Run a loop.</strong> Reach the same entrypoints through direct named commands; you never pick internal modes:</p>
-  <pre><code>/dev-loops:start 112      <span class="cm"># begin work from a tracked issue</span>
-/dev-loops:auto 112       <span class="cm"># run autonomously up to the human-merge checkpoint</span>
-/dev-loops:continue 112   <span class="cm"># issue or PR — continue work on that artifact</span>
-/dev-loops:continue       <span class="cm"># bare: resumes the single in-progress board item (fail-closed on 0 or multiple)</span>
-/dev-loops:start-spike "why does checkout stall?"  <span class="cm"># time-boxed exploration</span>
-/dev-loops:info 112       <span class="cm"># read-only state summary for an issue or PR</span>
-/dev-loops:status         <span class="cm"># check readiness: gh auth, git repo, subagent</span></code></pre>
-  <p><code>/dev-loops:dev-loop</code> stays the catch-all router for plain-language intent (<code>start dev loop on issue 112</code>, <code>continue dev loop on PR 88</code>). It resolves authoritative state and routes deterministically, so the named commands above are thin shortcuts over the same contract. Inside Pi the set is reachable as <code>/dev-loops start|auto|continue|start-spike|info|status …</code>.</p>
+  <p><strong>Run a loop.</strong> The named commands are direct entrypoints; you never pick internal modes. On Claude Code:</p>
+  <pre><code>/loop-start 112          <span class="cm"># start a dev loop on a tracked issue</span>
+/loop-auto 112           <span class="cm"># run autonomously to the human-approval checkpoint</span>
+/loop-continue 112       <span class="cm"># continue work on an issue or PR</span>
+/loop-continue           <span class="cm"># bare: resume the single in-progress item (fails closed on 0 or several)</span>
+/loop-start-spike "why does checkout stall?"   <span class="cm"># time-boxed exploration</span>
+/loop-info 112           <span class="cm"># read-only state summary for an issue or PR</span>
+/loop-status             <span class="cm"># readiness check: gh auth, git repo, subagents</span></code></pre>
 
-  <p><strong>Tune the posture (optional).</strong> A <code>.devloops</code> file at the repo root controls how work arrives and how strict the loop is. The shipped defaults are a low-noise starting point; loosen from there.</p>
-  <pre><code># .devloops
+  <p>On Pi the same set is reachable as subcommands of one command: <code>/dev-loops start 112</code>, <code>/dev-loops auto 112</code>, <code>/dev-loops continue</code>, and so on. Plain language works too &mdash; <code>start dev loop on issue 112</code> or <code>continue dev loop on PR 88</code> routes through the same deterministic contract, so the named commands are thin shortcuts, not a separate mechanism.</p>
+
+  <p><strong>Tune the posture (optional).</strong> A <code>.devloops</code> file at the repository root controls how work arrives and how strict the loop is:</p>
+  <pre><code><span class="cm"># .devloops</span>
+version: 1
 strategy:
-  default: local-first    <span class="cm"># start from a local plan file; use github-first to start from issues</span>
+  default: local-first    <span class="cm"># start from a local plan file; github-first starts from issues</span>
 inputSource:
-  default: tracker        <span class="cm"># for local-first: read the spec from the issue body, or phase-docs</span>
+  default: tracker        <span class="cm"># read the spec from the issue body, or phase-docs</span>
 refinement:
-  maxCopilotRounds: 5     <span class="cm"># automated review rounds before converging; set 0 to turn Copilot off</span>
+  maxCopilotRounds: 5     <span class="cm"># automated review rounds before converging; 0 turns Copilot off</span>
 autonomy:
-  humanMergeOnly: true    <span class="cm"># the loop prepares and reports ready; a person merges</span></code></pre>
+  humanMergeOnly: true    <span class="cm"># merge stays a human-only action, regardless of any per-run flag</span></code></pre>
 
-  <p>Three choices shape the experience. Work can start <strong>local-first</strong> &mdash; you write a short plan in the repository and the loop opens a pull request straight from it, with no issue to file &mdash; or <strong>github-first</strong>, where a tracked issue is the starting point. The review round can lean on Copilot or run without it. And the loop merges on its own only if you explicitly allow it; out of the box, it stops and hands the merge to you. Begin with the defaults and dial each setting toward the autonomy your team is comfortable with. As of 1.0 this configuration surface is stable &mdash; it follows semantic versioning, so a <code>.devloops</code> file you write today keeps working across minor upgrades.</p>
+  <p>Three choices shape the experience. Work can start <strong>local-first</strong> &mdash; you write a short plan in the repository and the loop opens a pull request straight from it &mdash; or <strong>github-first</strong>, where a tracked issue is the starting point. The automated review rounds can lean on Copilot or run without it. And the loop merges on its own only if you explicitly allow it; by default it stops and hands the merge to you. Start with the shipped defaults and dial each setting toward the autonomy your team is comfortable with. As of 1.0 this configuration surface follows semantic versioning, so a <code>.devloops</code> file you write today keeps working across minor upgrades.</p>
 
   <hr class="rule" />
 
   <section class="deeper">
     <h2>Where to go deeper</h2>
-    <p>The <a href="./dev-loops-deep-dive.html">dev-loops deep dive</a> takes these ideas apart in detail, in two parts: why the next step is always known so the next actor pulls it from the state graph and the handoff turns optional, then how to measure the waiting between actions, which is where the lead time goes once the code itself is fast to write.</p>
+    <p>The <a href="./dev-loops-deep-dive.html">dev-loops deep dive</a> takes these ideas apart in detail, in two parts: why the next step is always computable from visible state, so the next actor pulls work instead of waiting for a handoff &mdash; and how to measure the waiting between actions, which is where the lead time goes once the code itself is fast to write.</p>
   </section>
 
 </article>

--- a/docs/articles/introducing-dev-loops.html
+++ b/docs/articles/introducing-dev-loops.html
@@ -165,16 +165,16 @@
   <header class="hero-card">
     <p class="kicker">dev-loops</p>
     <h1>Introducing dev-loops</h1>
-    <p class="lede">The slow part of AI-assisted development is no longer writing code — it is the coordination around it. dev-loops runs those in-between steps as recorded decisions, with a person at the merge by default.</p>
+    <p class="lede">The coordination around the code is now the slow part of AI-assisted development. dev-loops runs those in-between steps as recorded decisions, with a person at the merge by default.</p>
   </header>
 
-  <p>The slow part of AI-assisted development is no longer writing code. It is everything that has to happen around the code: someone notices a change is ready, rebuilds enough context to review it, checks that the tests ran, decides the next step is safe. Each of those is a small wait, and once the typing is fast, the waits are where the lead time lives.</p>
+  <p>In AI-assisted development, the slow part is now everything that has to happen around the code: someone notices a change is ready, rebuilds enough context to review it, checks that the tests ran, decides the next step is safe. Each of those is a small wait, and together those waits make up most of the lead time.</p>
 
   <p>dev-loops is a runtime for those in-between steps. It keeps the state of every change explicit, computes the next action from that state, and runs the routine transitions itself — drafting, reviewing, gating on green CI — while recording each decision where you can read it. A person stays at the merge by default. This article explains the idea, shows what it does on a real repository, and walks through running it on your own project. A deeper piece is linked at the end.</p>
 
   <h2 id="the-idea">The idea</h2>
 
-  <p>An agent left to its own devices tends to assume its way past the hard moments: it declares the review done, the tests good enough, the work finished, and nobody checks the declaration until something breaks. dev-loops replaces each of those assumptions with a decision the system takes deliberately. Is this change ready for review? Did the review actually run, with evidence? Is CI green on the current head? Every transition is computed, applied, and recorded — and when the answer is ambiguous, the loop fails closed and waits for a person rather than guessing.</p>
+  <p>An agent left to its own devices tends to assume its way past the hard moments: it declares the review done, the tests good enough, the work finished, and nobody checks the declaration until something breaks. dev-loops replaces each of those assumptions with a decision the system takes deliberately. Is this change ready for review? Did the review actually run, with evidence? Is CI green on the current head? Every transition is computed, applied, and recorded — and when the answer is ambiguous, the loop fails closed and waits for a person.</p>
 
   <p>Three ideas carry most of the value:</p>
 
@@ -188,11 +188,11 @@
 
   <h2 id="what-it-does-to-the-work">What it does to the work</h2>
 
-  <p>Coordination is the cost that compounds. Every change carries a handful of transitions — is it ready, who reviews it, did the review pass, is CI green, can it merge — and every transition a person runs by hand is an interrupt with a context-switch attached. Multiply transitions per change by the number of changes and the hand-run coordination grows much faster than the throughput it supports. That compounding, not the code, is what caps how much an AI-assisted team ships.</p>
+  <p>Coordination is the cost that compounds. Every change carries a handful of transitions — is it ready, who reviews it, did the review pass, is CI green, can it merge — and every transition a person runs by hand is an interrupt with a context-switch attached. Multiply transitions per change by the number of changes and the hand-run coordination grows much faster than the throughput it supports. That compounding is what caps how much an AI-assisted team ships.</p>
 
   <p>The loop breaks the compounding by turning each transition into a machine decision with a log. What remains for the human is roughly one bounded decision per change: the merge, plus anything the loop flags as unclear.</p>
 
-  <p>dev-loops is developed with dev-loops, so the honest evidence is its own history. The numbers below come straight from the repository's git log, not from a benchmark:</p>
+  <p>dev-loops is developed with dev-loops, so the honest evidence is its own history. The numbers below come straight from the repository's git log:</p>
 
   <div class="metrics" role="list">
     <div class="metric" role="listitem"><div class="num">534</div><div class="lab">pull requests merged in the project's first nine weeks</div></div>
@@ -207,7 +207,7 @@
 
   <p>The same loop runs three ways over one shared core: as a Claude Code plugin, as a Pi extension, and as a standalone CLI. Routing, gates, and phases are defined once; the harnesses are thin integrations over that shared workflow.</p>
 
-  <p>Model choice is configuration in the same spirit. Roles map to model tiers, and tiers map per harness to concrete models: routine subagents (implementation, docs, small fixes, build chores) default to the low tier, while planning and review — the steps that guard quality — run on the high tier, and the conductor inherits whatever the session runs. Swapping the model behind any role is a config edit, not a code change.</p>
+  <p>Model choice is configuration in the same spirit. Roles map to model tiers, and tiers map per harness to concrete models: routine subagents (implementation, docs, small fixes, build chores) default to the low tier, while planning and review — the steps that guard quality — run on the high tier, and the conductor inherits whatever the session runs. Swapping the model behind any role is a config edit.</p>
 
   <p>That split is the practical argument for model flexibility. The structure constrains how far any single step can stray: each step is bounded, each gate fails closed, and the review fan-out checks the work regardless of which model produced it. So the quality bar sits where the gates put it, and a cheaper or self-hosted model can carry the routine steps while the strongest model you have is reserved for the judgment-heavy ones.</p>
 
@@ -224,7 +224,7 @@
 
   <pre><code>pi install npm:dev-loops@&lt;version&gt;</code></pre>
 
-  <p><strong>Run a loop.</strong> The named commands are direct entrypoints; you never pick internal modes. On Claude Code:</p>
+  <p><strong>Run a loop.</strong> The named commands are direct entrypoints; the loop selects its internal strategy itself. On Claude Code:</p>
 
   <pre><code>/loop-start 112          <span class="cm"># start a dev loop on a tracked issue</span>
 /loop-auto 112           <span class="cm"># run autonomously to the human-approval checkpoint</span>
@@ -234,7 +234,7 @@
 /loop-info 112           <span class="cm"># read-only state summary for an issue or PR</span>
 /loop-status             <span class="cm"># readiness check: gh auth, git repo, subagents</span></code></pre>
 
-  <p>On Pi the same set is reachable as subcommands of one command: <code>/dev-loops start 112</code>, <code>/dev-loops auto 112</code>, <code>/dev-loops continue</code>, and so on. Plain language works too — <code>start dev loop on issue 112</code> or <code>continue dev loop on PR 88</code> routes through the same deterministic contract, so the named commands are thin shortcuts, not a separate mechanism.</p>
+  <p>On Pi the same set is reachable as subcommands of one command: <code>/dev-loops start 112</code>, <code>/dev-loops auto 112</code>, <code>/dev-loops continue</code>, and so on. Plain language works too — <code>start dev loop on issue 112</code> or <code>continue dev loop on PR 88</code> routes through the same deterministic contract, so the named commands are thin shortcuts over that routing.</p>
 
   <p><strong>Tune the posture (optional).</strong> A <code>.devloops</code> file at the repository root controls how work arrives and how strict the loop is:</p>
 
@@ -259,7 +259,7 @@ autonomy:
 
     <h2 id="where-to-go-deeper">Where to go deeper</h2>
 
-    <p>The <a href="./dev-loops-deep-dive.html">dev-loops deep dive</a> takes these ideas apart in detail, in two parts: why the next step is always computable from visible state, so the next actor pulls work instead of waiting for a handoff — and how to measure the waiting between actions, which is where the lead time goes once the code itself is fast to write.</p>
+    <p>The <a href="./dev-loops-deep-dive.html">dev-loops deep dive</a> takes these ideas apart in detail, in two parts: why the next step is always computable from visible state, so the next actor can pull work the moment it is ready — and how to measure the waiting between actions, which accounts for most of the lead time.</p>
 
   </section>
 

--- a/docs/articles/introducing-dev-loops.html
+++ b/docs/articles/introducing-dev-loops.html
@@ -230,7 +230,7 @@
 /loop-auto 112           <span class="cm"># run autonomously to the human-approval checkpoint</span>
 /loop-continue 112       <span class="cm"># continue work on an issue or PR</span>
 /loop-continue           <span class="cm"># bare: resume the single in-progress item (fails closed on 0 or several)</span>
-/loop-start-spike "why does checkout stall?"   <span class="cm"># time-boxed exploration</span>
+/loop-start-spike &quot;why does checkout stall?&quot;   <span class="cm"># time-boxed exploration</span>
 /loop-info 112           <span class="cm"># read-only state summary for an issue or PR</span>
 /loop-status             <span class="cm"># readiness check: gh auth, git repo, subagents</span></code></pre>
 

--- a/docs/articles/introducing-dev-loops.html
+++ b/docs/articles/introducing-dev-loops.html
@@ -179,7 +179,7 @@
   <p>Three ideas carry most of the value:</p>
 
   <ul>
-    <li><strong>Every change walks the same path.</strong> A draft gate checks the basics, automated review rounds look for real problems, and a pre-approval gate re-checks the final state — with green CI required at both gates unless a repository explicitly opts out. Nothing skips the path, including every change that built dev-loops itself.</li>
+    <li><strong>Every change walks the same path.</strong> A draft gate checks the basics, automated review rounds look for real problems, and a pre-approval gate re-checks the final state — with green CI required at both gates unless a repository explicitly opts out. The changes that build dev-loops itself run this same path.</li>
     <li><strong>A person merges by default.</strong> Out of the box the loop stops at the merge and hands over; it merges on its own only when a repository grants that explicitly. There is also a stricter setting that makes the merge human-only no matter what any single run claims — it cannot be overridden from inside the loop.</li>
     <li><strong>Work starts from a durable spec.</strong> A change begins as a short plan file in the repository or as a tracked issue, and the pull request carries that spec through review to merge. There is always a written artifact to check the result against.</li>
   </ul>
@@ -192,16 +192,16 @@
 
   <p>The loop breaks the compounding by turning each transition into a machine decision with a log. What remains for the human is roughly one bounded decision per change: the merge, plus anything the loop flags as unclear.</p>
 
-  <p>dev-loops is developed with dev-loops, so the honest evidence is its own history. The numbers below come straight from the repository's git log:</p>
+  <p>dev-loops is developed with dev-loops, so the honest evidence is its own history. The numbers below come straight from the repository's git log, as of mid-July 2026:</p>
 
   <div class="metrics" role="list">
-    <div class="metric" role="listitem"><div class="num">534</div><div class="lab">pull requests merged in the project's first nine weeks</div></div>
-    <div class="metric" role="listitem"><div class="num">~10/day</div><div class="lab">over the most recent two weeks (138 in fourteen days)</div></div>
+    <div class="metric" role="listitem"><div class="num">530+</div><div class="lab">pull requests merged in the project's first nine weeks</div></div>
+    <div class="metric" role="listitem"><div class="num">~10/day</div><div class="lab">across the most recent two weeks</div></div>
     <div class="metric" role="listitem"><div class="num">24</div><div class="lab">tagged releases in the same stretch, up to a 1.0 release candidate</div></div>
     <div class="metric" role="listitem"><div class="num">1</div><div class="lab">human decision per change — the default posture stops at the merge</div></div>
   </div>
 
-  <p>The review load behind that pace is real work, and it is where the loop earns its keep. At the draft gate, review fans out to focused reviewers that each read the change through a single lens — scope, coverage, correctness, and input validation among them. Before approval, a second fan-out applies design and simplicity lenses (DRY, KISS, YAGNI, single-responsibility) plus a check of the change against its own written acceptance criteria. Findings land as comments on the pull request, and a finding rated must-fix blocks a clean verdict until it is addressed. The gate sits exactly where unattended automation is usually weakest — the moment a change is about to land — so the cadence stays fast while the merges stay ones a person can stand behind.</p>
+  <p>The review load behind that pace is real work, and it is where the loop earns its keep. At the draft gate, review fans out to focused reviewers that each read the change through a single lens — scope, coverage, correctness, and input validation among them. Before approval, a second fan-out applies design and simplicity lenses (DRY, KISS, YAGNI, single-responsibility) plus a check of the change against its own written acceptance criteria. Findings land as comments on the pull request, and a finding rated must-fix blocks a clean verdict until it is addressed. The gate sits exactly where unattended automation is usually weakest — the moment a change is about to land — so the cadence stays fast and every merge is one a person can stand behind.</p>
 
   <h2 id="model-agnostic-by-construction">Model-agnostic by construction</h2>
 
@@ -234,7 +234,7 @@
 /loop-info 112           <span class="cm"># read-only state summary for an issue or PR</span>
 /loop-status             <span class="cm"># readiness check: gh auth, git repo, subagents</span></code></pre>
 
-  <p>On Pi the same set is reachable as subcommands of one command: <code>/dev-loops start 112</code>, <code>/dev-loops auto 112</code>, <code>/dev-loops continue</code>, and so on. Plain language works too — <code>start dev loop on issue 112</code> or <code>continue dev loop on PR 88</code> routes through the same deterministic contract, so the named commands are thin shortcuts over that routing.</p>
+  <p>On Pi the same set is reachable as subcommands of one command: <code>/dev-loops start 112</code>, <code>/dev-loops auto 112</code>, <code>/dev-loops continue</code>, and so on. Plain language works too — <code>start dev loop on issue 112</code> or <code>continue dev loop on PR 88</code> routes through the same deterministic router, so the named commands are thin shortcuts over it.</p>
 
   <p><strong>Tune the posture (optional).</strong> A <code>.devloops</code> file at the repository root controls how work arrives and how strict the loop is:</p>
 
@@ -249,7 +249,7 @@ refinement:
 autonomy:
   humanMergeOnly: true    <span class="cm"># merge stays a human-only action, regardless of any per-run flag</span></code></pre>
 
-  <p>Three choices shape the experience. Work can start <strong>local-first</strong> — you write a short plan in the repository and the loop opens a pull request straight from it — or <strong>github-first</strong>, where a tracked issue is the starting point. The automated review rounds can lean on Copilot or run without it. And the loop merges on its own only if you explicitly allow it; by default it stops and hands the merge to you. Start with the shipped defaults and dial each setting toward the autonomy your team is comfortable with. As of 1.0 this configuration surface follows semantic versioning, so a <code>.devloops</code> file you write today keeps working across minor upgrades.</p>
+  <p>Three choices shape the experience. Work can start <strong>local-first</strong> — you write a short plan in the repository and the loop opens a pull request straight from it — or <strong>github-first</strong>, where a tracked issue is the starting point. The automated review rounds can lean on Copilot or run without it. And the loop merges on its own only if you explicitly allow it; by default it stops and hands the merge to you. Start with the shipped defaults and dial each setting toward the autonomy your team is comfortable with. From 1.0 onward this configuration surface follows semantic versioning, so a <code>.devloops</code> file you write today keeps working across minor upgrades.</p>
 
   <hr class="rule" />
 

--- a/docs/articles/introducing-dev-loops.md
+++ b/docs/articles/introducing-dev-loops.md
@@ -22,7 +22,7 @@ An agent left to its own devices tends to assume its way past the hard moments: 
 
 Three ideas carry most of the value:
 
-- **Every change walks the same path.** A draft gate checks the basics, automated review rounds look for real problems, and a pre-approval gate re-checks the final state — with green CI required at both gates unless a repository explicitly opts out. Nothing skips the path, including every change that built dev-loops itself.
+- **Every change walks the same path.** A draft gate checks the basics, automated review rounds look for real problems, and a pre-approval gate re-checks the final state — with green CI required at both gates unless a repository explicitly opts out. The changes that build dev-loops itself run this same path.
 - **A person merges by default.** Out of the box the loop stops at the merge and hands over; it merges on its own only when a repository grants that explicitly. There is also a stricter setting that makes the merge human-only no matter what any single run claims — it cannot be overridden from inside the loop.
 - **Work starts from a durable spec.** A change begins as a short plan file in the repository or as a tracked issue, and the pull request carries that spec through review to merge. There is always a written artifact to check the result against.
 
@@ -34,16 +34,16 @@ Coordination is the cost that compounds. Every change carries a handful of trans
 
 The loop breaks the compounding by turning each transition into a machine decision with a log. What remains for the human is roughly one bounded decision per change: the merge, plus anything the loop flags as unclear.
 
-dev-loops is developed with dev-loops, so the honest evidence is its own history. The numbers below come straight from the repository's git log:
+dev-loops is developed with dev-loops, so the honest evidence is its own history. The numbers below come straight from the repository's git log, as of mid-July 2026:
 
 <!-- metrics:start -->
-- **534** pull requests merged in the project's first nine weeks
-- **~10/day** over the most recent two weeks (138 in fourteen days)
+- **530+** pull requests merged in the project's first nine weeks
+- **~10/day** across the most recent two weeks
 - **24** tagged releases in the same stretch, up to a 1.0 release candidate
 - **1** human decision per change — the default posture stops at the merge
 <!-- metrics:end -->
 
-The review load behind that pace is real work, and it is where the loop earns its keep. At the draft gate, review fans out to focused reviewers that each read the change through a single lens — scope, coverage, correctness, and input validation among them. Before approval, a second fan-out applies design and simplicity lenses (DRY, KISS, YAGNI, single-responsibility) plus a check of the change against its own written acceptance criteria. Findings land as comments on the pull request, and a finding rated must-fix blocks a clean verdict until it is addressed. The gate sits exactly where unattended automation is usually weakest — the moment a change is about to land — so the cadence stays fast while the merges stay ones a person can stand behind.
+The review load behind that pace is real work, and it is where the loop earns its keep. At the draft gate, review fans out to focused reviewers that each read the change through a single lens — scope, coverage, correctness, and input validation among them. Before approval, a second fan-out applies design and simplicity lenses (DRY, KISS, YAGNI, single-responsibility) plus a check of the change against its own written acceptance criteria. Findings land as comments on the pull request, and a finding rated must-fix blocks a clean verdict until it is addressed. The gate sits exactly where unattended automation is usually weakest — the moment a change is about to land — so the cadence stays fast and every merge is one a person can stand behind.
 
 ## Model-agnostic by construction
 
@@ -82,7 +82,7 @@ pi install npm:dev-loops@<version>
 /loop-status             # readiness check: gh auth, git repo, subagents
 ```
 
-On Pi the same set is reachable as subcommands of one command: `/dev-loops start 112`, `/dev-loops auto 112`, `/dev-loops continue`, and so on. Plain language works too — `start dev loop on issue 112` or `continue dev loop on PR 88` routes through the same deterministic contract, so the named commands are thin shortcuts over that routing.
+On Pi the same set is reachable as subcommands of one command: `/dev-loops start 112`, `/dev-loops auto 112`, `/dev-loops continue`, and so on. Plain language works too — `start dev loop on issue 112` or `continue dev loop on PR 88` routes through the same deterministic router, so the named commands are thin shortcuts over it.
 
 **Tune the posture (optional).** A `.devloops` file at the repository root controls how work arrives and how strict the loop is:
 
@@ -99,7 +99,7 @@ autonomy:
   humanMergeOnly: true    # merge stays a human-only action, regardless of any per-run flag
 ```
 
-Three choices shape the experience. Work can start **local-first** — you write a short plan in the repository and the loop opens a pull request straight from it — or **github-first**, where a tracked issue is the starting point. The automated review rounds can lean on Copilot or run without it. And the loop merges on its own only if you explicitly allow it; by default it stops and hands the merge to you. Start with the shipped defaults and dial each setting toward the autonomy your team is comfortable with. As of 1.0 this configuration surface follows semantic versioning, so a `.devloops` file you write today keeps working across minor upgrades.
+Three choices shape the experience. Work can start **local-first** — you write a short plan in the repository and the loop opens a pull request straight from it — or **github-first**, where a tracked issue is the starting point. The automated review rounds can lean on Copilot or run without it. And the loop merges on its own only if you explicitly allow it; by default it stops and hands the merge to you. Start with the shipped defaults and dial each setting toward the autonomy your team is comfortable with. From 1.0 onward this configuration surface follows semantic versioning, so a `.devloops` file you write today keeps working across minor upgrades.
 
 ## Where to go deeper
 

--- a/docs/articles/introducing-dev-loops.md
+++ b/docs/articles/introducing-dev-loops.md
@@ -1,7 +1,7 @@
 ---
 title: "Introducing dev-loops"
 subtitle: "A coordination runtime for AI-assisted development — and a guide to running it yourself."
-heroLede: "The slow part of AI-assisted development is no longer writing code — it is the coordination around it. dev-loops runs those in-between steps as recorded decisions, with a person at the merge by default."
+heroLede: "The coordination around the code is now the slow part of AI-assisted development. dev-loops runs those in-between steps as recorded decisions, with a person at the merge by default."
 tags:
   - AI
   - Software Engineering
@@ -12,13 +12,13 @@ tags:
 
 # Introducing dev-loops
 
-The slow part of AI-assisted development is no longer writing code. It is everything that has to happen around the code: someone notices a change is ready, rebuilds enough context to review it, checks that the tests ran, decides the next step is safe. Each of those is a small wait, and once the typing is fast, the waits are where the lead time lives.
+In AI-assisted development, the slow part is now everything that has to happen around the code: someone notices a change is ready, rebuilds enough context to review it, checks that the tests ran, decides the next step is safe. Each of those is a small wait, and together those waits make up most of the lead time.
 
 dev-loops is a runtime for those in-between steps. It keeps the state of every change explicit, computes the next action from that state, and runs the routine transitions itself — drafting, reviewing, gating on green CI — while recording each decision where you can read it. A person stays at the merge by default. This article explains the idea, shows what it does on a real repository, and walks through running it on your own project. A deeper piece is linked at the end.
 
 ## The idea
 
-An agent left to its own devices tends to assume its way past the hard moments: it declares the review done, the tests good enough, the work finished, and nobody checks the declaration until something breaks. dev-loops replaces each of those assumptions with a decision the system takes deliberately. Is this change ready for review? Did the review actually run, with evidence? Is CI green on the current head? Every transition is computed, applied, and recorded — and when the answer is ambiguous, the loop fails closed and waits for a person rather than guessing.
+An agent left to its own devices tends to assume its way past the hard moments: it declares the review done, the tests good enough, the work finished, and nobody checks the declaration until something breaks. dev-loops replaces each of those assumptions with a decision the system takes deliberately. Is this change ready for review? Did the review actually run, with evidence? Is CI green on the current head? Every transition is computed, applied, and recorded — and when the answer is ambiguous, the loop fails closed and waits for a person.
 
 Three ideas carry most of the value:
 
@@ -30,11 +30,11 @@ None of this is tied to one model or one editor, and the section [Model-agnostic
 
 ## What it does to the work
 
-Coordination is the cost that compounds. Every change carries a handful of transitions — is it ready, who reviews it, did the review pass, is CI green, can it merge — and every transition a person runs by hand is an interrupt with a context-switch attached. Multiply transitions per change by the number of changes and the hand-run coordination grows much faster than the throughput it supports. That compounding, not the code, is what caps how much an AI-assisted team ships.
+Coordination is the cost that compounds. Every change carries a handful of transitions — is it ready, who reviews it, did the review pass, is CI green, can it merge — and every transition a person runs by hand is an interrupt with a context-switch attached. Multiply transitions per change by the number of changes and the hand-run coordination grows much faster than the throughput it supports. That compounding is what caps how much an AI-assisted team ships.
 
 The loop breaks the compounding by turning each transition into a machine decision with a log. What remains for the human is roughly one bounded decision per change: the merge, plus anything the loop flags as unclear.
 
-dev-loops is developed with dev-loops, so the honest evidence is its own history. The numbers below come straight from the repository's git log, not from a benchmark:
+dev-loops is developed with dev-loops, so the honest evidence is its own history. The numbers below come straight from the repository's git log:
 
 <!-- metrics:start -->
 - **534** pull requests merged in the project's first nine weeks
@@ -49,7 +49,7 @@ The review load behind that pace is real work, and it is where the loop earns it
 
 The same loop runs three ways over one shared core: as a Claude Code plugin, as a Pi extension, and as a standalone CLI. Routing, gates, and phases are defined once; the harnesses are thin integrations over that shared workflow.
 
-Model choice is configuration in the same spirit. Roles map to model tiers, and tiers map per harness to concrete models: routine subagents (implementation, docs, small fixes, build chores) default to the low tier, while planning and review — the steps that guard quality — run on the high tier, and the conductor inherits whatever the session runs. Swapping the model behind any role is a config edit, not a code change.
+Model choice is configuration in the same spirit. Roles map to model tiers, and tiers map per harness to concrete models: routine subagents (implementation, docs, small fixes, build chores) default to the low tier, while planning and review — the steps that guard quality — run on the high tier, and the conductor inherits whatever the session runs. Swapping the model behind any role is a config edit.
 
 That split is the practical argument for model flexibility. The structure constrains how far any single step can stray: each step is bounded, each gate fails closed, and the review fan-out checks the work regardless of which model produced it. So the quality bar sits where the gates put it, and a cheaper or self-hosted model can carry the routine steps while the strongest model you have is reserved for the judgment-heavy ones.
 
@@ -70,7 +70,7 @@ dev-loops drives an ordinary GitHub pull-request workflow from inside Claude Cod
 pi install npm:dev-loops@<version>
 ```
 
-**Run a loop.** The named commands are direct entrypoints; you never pick internal modes. On Claude Code:
+**Run a loop.** The named commands are direct entrypoints; the loop selects its internal strategy itself. On Claude Code:
 
 ```text
 /loop-start 112          # start a dev loop on a tracked issue
@@ -82,7 +82,7 @@ pi install npm:dev-loops@<version>
 /loop-status             # readiness check: gh auth, git repo, subagents
 ```
 
-On Pi the same set is reachable as subcommands of one command: `/dev-loops start 112`, `/dev-loops auto 112`, `/dev-loops continue`, and so on. Plain language works too — `start dev loop on issue 112` or `continue dev loop on PR 88` routes through the same deterministic contract, so the named commands are thin shortcuts, not a separate mechanism.
+On Pi the same set is reachable as subcommands of one command: `/dev-loops start 112`, `/dev-loops auto 112`, `/dev-loops continue`, and so on. Plain language works too — `start dev loop on issue 112` or `continue dev loop on PR 88` routes through the same deterministic contract, so the named commands are thin shortcuts over that routing.
 
 **Tune the posture (optional).** A `.devloops` file at the repository root controls how work arrives and how strict the loop is:
 
@@ -103,4 +103,4 @@ Three choices shape the experience. Work can start **local-first** — you write
 
 ## Where to go deeper
 
-The [dev-loops deep dive](./dev-loops-deep-dive.md) takes these ideas apart in detail, in two parts: why the next step is always computable from visible state, so the next actor pulls work instead of waiting for a handoff — and how to measure the waiting between actions, which is where the lead time goes once the code itself is fast to write.
+The [dev-loops deep dive](./dev-loops-deep-dive.md) takes these ideas apart in detail, in two parts: why the next step is always computable from visible state, so the next actor can pull work the moment it is ready — and how to measure the waiting between actions, which accounts for most of the lead time.

--- a/docs/articles/introducing-dev-loops.md
+++ b/docs/articles/introducing-dev-loops.md
@@ -11,89 +11,93 @@ tags:
 
 # Introducing dev-loops
 
-AI writes the code in seconds. The expensive part moved. It now sits in the coordination around the code: the wait for someone to notice a change is ready, to rebuild enough context to review it, to decide the next step is safe. That waiting between actions is where the lead time of an AI-assisted workflow goes once the typing is fast.
+The slow part of AI-assisted development is no longer writing code. It is everything that has to happen around the code: someone notices a change is ready, rebuilds enough context to review it, checks that the tests ran, decides the next step is safe. Each of those is a small wait, and once the typing is fast, the waits are where the lead time lives.
 
-dev-loops is a coordination runtime for that problem. Like a Kanban board, the next step is always known: the system computes the next action for any change at any time, and whoever is free — agent or human — pulls that step from the visible state. So nobody waits for the previous actor to package up context and hand it over. The handoff becomes optional; when it happens it adds a note, and it stays a recorded decision, with a person merging by default. This article introduces the idea and shows how to run it on your own project. A deeper piece is linked at the end.
+dev-loops is a runtime for those in-between steps. It keeps the state of every change explicit, computes the next action from that state, and runs the routine transitions itself — drafting, reviewing, gating on green CI — while recording each decision where you can read it. A person stays at the merge by default. This article explains the idea, shows what it does on a real repository, and walks through running it on your own project. A deeper piece is linked at the end.
 
 ## The idea
 
-Left alone, an agent tends to assume its way past the hard moments. It marks the build passed, calls the review done, decides the work is finished — and those assumptions go unchecked until something breaks downstream. dev-loops takes the assumption out. Every transition — is this ready, who acts next, is it safe to merge — becomes a decision the system makes deliberately and records where you can read it. When the answer is unclear, the loop stops and a person decides before the work moves on.
+An agent left to its own devices tends to assume its way past the hard moments: it declares the review done, the tests good enough, the work finished, and nobody checks the declaration until something breaks. dev-loops replaces each of those assumptions with a decision the system takes deliberately. Is this change ready for review? Did the review actually run, with evidence? Is CI green on the current head? Every transition is computed, applied, and recorded — and when the answer is ambiguous, the loop fails closed and waits for a person rather than guessing.
 
 Three ideas carry most of the value:
 
-- **Every change runs the same path.** A draft check confirms the basics are in place, a review round looks for real problems, and a final gate confirms the tests are green. Nothing skips the path, including the changes that built dev-loops itself.
-- **A person merges by default.** The loop does the preparation and reports that a change is ready; a human makes the final call. The autonomy is bounded on purpose, and you choose how much of it to grant.
-- **Work starts from a durable artifact.** A change begins from a short plan you write locally or from a tracked issue. That artifact is the spec, and the pull request carries it through review to merge, so there is always something to check the result against.
+- **Every change walks the same path.** A draft gate checks the basics, automated review rounds look for real problems, and a pre-approval gate re-checks the final state — with green CI required at both gates unless a repository explicitly opts out. Nothing skips the path, including every change that built dev-loops itself.
+- **A person merges by default.** Out of the box the loop stops at the merge and hands over; it merges on its own only when a repository grants that explicitly. There is also a stricter setting that makes the merge human-only no matter what any single run claims — it cannot be overridden from inside the loop.
+- **Work starts from a durable spec.** A change begins as a short plan file in the repository or as a tracked issue, and the pull request carries that spec through review to merge. There is always a written artifact to check the result against.
 
-None of this depends on a particular model or a particular editor, and the section [Model-agnostic by construction](#model-agnostic-by-construction) is where that claim earns its weight. It is a runtime for the decisions around a change, and it runs inside the AI coding tools teams already use.
+None of this is tied to one model or one editor; the section on model-agnosticism below explains why that follows from the design. dev-loops is a runtime for the decisions around a change, and it runs inside the AI coding tools teams already use.
 
 ## What it does to the work
 
-The point of the loop is what it does to the day-to-day of shipping. The clearest evidence is the project itself: dev-loops is built with dev-loops, so its own history shows the process it produces.
+Coordination is the cost that compounds. Every change carries a handful of transitions — is it ready, who reviews it, did the review pass, is CI green, can it merge — and every transition a person runs by hand is an interrupt with a context-switch attached. Multiply transitions per change by the number of changes and the hand-run coordination grows much faster than the throughput it supports. That compounding, not the code, is what caps how much an AI-assisted team ships.
 
-Coordination is the cost that grows. Every change carries a handful of transitions — is it ready, who reviews it, did review pass, is CI green, is it safe to merge — and each one a person handles by hand is an interrupt with its own switching cost. As the change count climbs, those manual transitions multiply against it: their number is the transitions per change times the volume, so hand-run coordination acts like a power over the throughput, and a person's effective load grows far faster than the number of changes. That compounding is what caps how much an AI-assisted team can actually ship, even once the code itself is cheap to produce.
+The loop breaks the compounding by turning each transition into a machine decision with a log. What remains for the human is roughly one bounded decision per change: the merge, plus anything the loop flags as unclear.
 
-dev-loops breaks the compounding by making each transition a decision the system takes and records. Every change follows the same path — draft, review, green-CI gate, human merge — so there is no bespoke ceremony to design and no question about what happens next. A person is pulled in only where one is genuinely needed: the merge, and anything the loop flags as ambiguous. What is left for the human is roughly one bounded decision per change; the transitions in between are the loop's to run and to log.
+dev-loops is developed with dev-loops, so the honest evidence is its own history. The numbers below come straight from the repository's git log, not from a benchmark:
 
-That is what the project's own history shows. In a recent four-day stretch the repository merged 87 pull requests — roughly 22 a day — closing 36 tracked issues and shipping two full releases (v0.4.0 and v0.5.0 to npm), each one drafted, reviewed, gated on green tests, and merged by a person. Every PR ran the full gate: a fan-out draft review, at least one Copilot round, a pre-approval gate on the current head, then a squash-merge. The cadence held because the extra work landed as machine transitions, with the human's part staying that one bounded decision at the merge.
+- **534 pull requests** merged in the project's first nine weeks.
+- **About ten a day** over the most recent two weeks (138 in fourteen days).
+- **24 tagged releases** in the same stretch, up to a 1.0 release candidate.
+- **One human decision per change** — the loop's default posture stops every change at the merge.
 
-And it stays honest at that speed. The review step keeps catching what slips past a tired reviewer in a hurry: a layout that broke on small screens, documentation that had drifted from the code, a review cycle that had quietly deadlocked. The loop earns its keep at the moment a change is about to land, which is where unattended automation is usually weakest — so the cadence is fast and the merges are still ones a person stands behind.
+The review load behind that pace is real work, and it is where the loop earns its keep. At the draft gate, review fans out to focused reviewers that each read the change through a single lens — scope, coverage, correctness, and input validation among them. Before approval, a second fan-out applies design and simplicity lenses (DRY, KISS, YAGNI, single-responsibility) plus a check of the change against its own written acceptance criteria. Findings land as comments on the pull request, and a finding rated must-fix blocks a clean verdict until it is addressed. The gate sits exactly where unattended automation is usually weakest — the moment a change is about to land — so the cadence stays fast while the merges stay ones a person can stand behind.
 
 ## Model-agnostic by construction
 
-The guardrails are what make the model choice cheap. The next action for any change is always computed and visible, so each step runs the same gate: a draft check, a review round, a green-CI confirmation, and a person at the merge. When a step is ambiguous, the loop fails closed and waits for a human. All that structure constrains how far any single step can stray, which means a strong open-source model can drive most or all of the work. Top-tier open-source models are enough here because the process does the constraining, so you can reserve a frontier model for the moments that genuinely call for one.
+The same loop runs three ways over one shared core: as a Claude Code plugin, as a Pi extension, and as a standalone CLI. Routing, gates, and phases are defined once; the harnesses are thin integrations over that shared workflow.
 
-That has practical consequences. A model you can self-host is cheaper to run and keeps the work clear of any one vendor's roadmap. The gate is what holds the quality bar: it catches the kind of slip a smaller model would let through, so the bar sits where the gate sets it and the model's job is to propose work the gate then checks.
+Model choice is configuration in the same spirit. Roles map to model tiers, and tiers map per harness to concrete models: routine subagents (implementation, docs, small fixes, build chores) default to the low tier, while planning and review — the steps that guard quality — run on the high tier, and the conductor inherits whatever the session runs. Swapping the model behind any role is a config edit, not a code change.
 
-This is not hypothetical. The loop has driven real work end to end on top-tier open-source models — DeepSeek V4, Kimi K2.6, MiniMax M3, Qwen 3.6, and GLM 5.2 — with the same gate holding the bar throughout.
+That split is the practical argument for model flexibility. The structure constrains how far any single step can stray: each step is bounded, each gate fails closed, and the review fan-out checks the work regardless of which model produced it. So the quality bar sits where the gates put it, and a cheaper or self-hosted model can carry the routine steps while the strongest model you have is reserved for the judgment-heavy ones.
 
 ## Set it up
 
-dev-loops runs inside Claude Code or Pi and drives an ordinary GitHub pull-request workflow. You need Node 24 or newer and the GitHub CLI (`gh`) authenticated for your repository.
+dev-loops drives an ordinary GitHub pull-request workflow from inside Claude Code or Pi. You need Node 24 or newer and the GitHub CLI (`gh`) authenticated for your repository.
 
-**Claude Code.** Install the plugin from inside Claude Code:
+**Claude Code.** Install the plugin from the bundled marketplace catalog:
 
 ```text
 /plugin marketplace add mfittko/dev-loops
 /plugin install dev-loops@dev-loops
 ```
 
-**Pi.** Install the extension:
+**Pi.** Install the extension from npm, pinned to a version so the surfaces cannot drift:
 
 ```bash
-pi install npm:dev-loops
+pi install npm:dev-loops@<version>
 ```
 
-**Run a loop.** Reach the same entrypoints through direct named commands; you never pick internal modes:
+**Run a loop.** The named commands are direct entrypoints; you never pick internal modes. On Claude Code:
 
 ```text
-/dev-loops:start 112      # begin work from a tracked issue
-/dev-loops:auto 112       # run autonomously up to the human-merge checkpoint
-/dev-loops:continue 112   # issue or PR — continue work on that artifact
-/dev-loops:continue       # bare: resumes the single in-progress board item (fail-closed on 0 or multiple)
-/dev-loops:start-spike "why does checkout stall?"  # time-boxed exploration
-/dev-loops:info 112       # read-only state summary for an issue or PR
-/dev-loops:status         # check readiness: gh auth, git repo, subagent
+/loop-start 112          # start a dev loop on a tracked issue
+/loop-auto 112           # run autonomously to the human-approval checkpoint
+/loop-continue 112       # continue work on an issue or PR
+/loop-continue           # bare: resume the single in-progress item (fails closed on 0 or several)
+/loop-start-spike "why does checkout stall?"   # time-boxed exploration
+/loop-info 112           # read-only state summary for an issue or PR
+/loop-status             # readiness check: gh auth, git repo, subagents
 ```
 
-`/dev-loops:dev-loop` stays the catch-all router for plain-language intent (`start dev loop on issue 112`, `continue dev loop on PR 88`). It resolves authoritative state and routes deterministically, so the named commands above are thin shortcuts over the same contract. Inside Pi the set is reachable as `/dev-loops start|auto|continue|start-spike|info|status …`.
+On Pi the same set is reachable as subcommands of one command: `/dev-loops start 112`, `/dev-loops auto 112`, `/dev-loops continue`, and so on. Plain language works too — `start dev loop on issue 112` or `continue dev loop on PR 88` routes through the same deterministic contract, so the named commands are thin shortcuts, not a separate mechanism.
 
-**Tune the posture (optional).** A `.devloops` file at the repo root controls how work arrives and how strict the loop is. The shipped defaults are a low-noise starting point; loosen from there.
+**Tune the posture (optional).** A `.devloops` file at the repository root controls how work arrives and how strict the loop is:
 
 ```yaml
 # .devloops
+version: 1
 strategy:
-  default: local-first    # start from a local plan file; use github-first to start from issues
+  default: local-first    # start from a local plan file; github-first starts from issues
 inputSource:
-  default: tracker        # for local-first: read the spec from the issue body, or phase-docs
+  default: tracker        # read the spec from the issue body, or phase-docs
 refinement:
-  maxCopilotRounds: 5     # automated review rounds before converging; set 0 to turn Copilot off
+  maxCopilotRounds: 5     # automated review rounds before converging; 0 turns Copilot off
 autonomy:
-  humanMergeOnly: true    # the loop prepares and reports ready; a person merges
+  humanMergeOnly: true    # merge stays a human-only action, regardless of any per-run flag
 ```
 
-Three choices shape the experience. Work can start **local-first** — you write a short plan in the repository and the loop opens a pull request straight from it, with no issue to file — or **github-first**, where a tracked issue is the starting point. The review round can lean on Copilot or run without it. And the loop merges on its own only if you explicitly allow it; out of the box, it stops and hands the merge to you. Begin with the defaults and dial each setting toward the autonomy your team is comfortable with. As of 1.0 this configuration surface is stable — it follows semantic versioning, so a `.devloops` file you write today keeps working across minor upgrades.
+Three choices shape the experience. Work can start **local-first** — you write a short plan in the repository and the loop opens a pull request straight from it — or **github-first**, where a tracked issue is the starting point. The automated review rounds can lean on Copilot or run without it. And the loop merges on its own only if you explicitly allow it; by default it stops and hands the merge to you. Start with the shipped defaults and dial each setting toward the autonomy your team is comfortable with. As of 1.0 this configuration surface follows semantic versioning, so a `.devloops` file you write today keeps working across minor upgrades.
 
 ## Where to go deeper
 
-The [dev-loops deep dive](./dev-loops-deep-dive.md) takes these ideas apart in detail, in two parts: why the next step is always known so the next actor pulls it from the state graph and the handoff turns optional, then how to measure the waiting between actions, which is where the lead time goes once the code itself is fast to write.
+The [dev-loops deep dive](./dev-loops-deep-dive.md) takes these ideas apart in detail, in two parts: why the next step is always computable from visible state, so the next actor pulls work instead of waiting for a handoff — and how to measure the waiting between actions, which is where the lead time goes once the code itself is fast to write.

--- a/docs/articles/introducing-dev-loops.md
+++ b/docs/articles/introducing-dev-loops.md
@@ -1,6 +1,7 @@
 ---
 title: "Introducing dev-loops"
 subtitle: "A coordination runtime for AI-assisted development — and a guide to running it yourself."
+heroLede: "The slow part of AI-assisted development is no longer writing code — it is the coordination around it. dev-loops runs those in-between steps as recorded decisions, with a person at the merge by default."
 tags:
   - AI
   - Software Engineering
@@ -25,7 +26,7 @@ Three ideas carry most of the value:
 - **A person merges by default.** Out of the box the loop stops at the merge and hands over; it merges on its own only when a repository grants that explicitly. There is also a stricter setting that makes the merge human-only no matter what any single run claims — it cannot be overridden from inside the loop.
 - **Work starts from a durable spec.** A change begins as a short plan file in the repository or as a tracked issue, and the pull request carries that spec through review to merge. There is always a written artifact to check the result against.
 
-None of this is tied to one model or one editor; the section on model-agnosticism below explains why that follows from the design. dev-loops is a runtime for the decisions around a change, and it runs inside the AI coding tools teams already use.
+None of this is tied to one model or one editor, and the section [Model-agnostic by construction](#model-agnostic-by-construction) explains why that follows from the design. dev-loops is a runtime for the decisions around a change, and it runs inside the AI coding tools teams already use.
 
 ## What it does to the work
 
@@ -35,10 +36,12 @@ The loop breaks the compounding by turning each transition into a machine decisi
 
 dev-loops is developed with dev-loops, so the honest evidence is its own history. The numbers below come straight from the repository's git log, not from a benchmark:
 
-- **534 pull requests** merged in the project's first nine weeks.
-- **About ten a day** over the most recent two weeks (138 in fourteen days).
-- **24 tagged releases** in the same stretch, up to a 1.0 release candidate.
-- **One human decision per change** — the loop's default posture stops every change at the merge.
+<!-- metrics:start -->
+- **534** pull requests merged in the project's first nine weeks
+- **~10/day** over the most recent two weeks (138 in fourteen days)
+- **24** tagged releases in the same stretch, up to a 1.0 release candidate
+- **1** human decision per change — the default posture stops at the merge
+<!-- metrics:end -->
 
 The review load behind that pace is real work, and it is where the loop earns its keep. At the draft gate, review fans out to focused reviewers that each read the change through a single lens — scope, coverage, correctness, and input validation among them. Before approval, a second fan-out applies design and simplicity lenses (DRY, KISS, YAGNI, single-responsibility) plus a check of the change against its own written acceptance criteria. Findings land as comments on the pull request, and a finding rated must-fix blocks a clean verdict until it is addressed. The gate sits exactly where unattended automation is usually weakest — the moment a change is about to land — so the cadence stays fast while the merges stay ones a person can stand behind.
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "test:pack": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/packaged-install-smoke.test.mjs",
     "schema:generate": "node scripts/generate-config-schema.mjs",
     "schema:check": "node scripts/generate-config-schema.mjs --check",
+    "articles:render": "node scripts/pages/render-article.mjs",
+    "articles:check": "node scripts/pages/render-article.mjs --check",
     "repo-wiki": "node scripts/repo-wiki.mjs",
     "repo-wiki:bootstrap": "node scripts/repo-wiki.mjs scan --repo . && node scripts/repo-wiki.mjs plan --repo . && node scripts/repo-wiki.mjs compile --repo .",
     "repo-wiki:scan": "node scripts/repo-wiki.mjs scan --repo .",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "smoke:headless": "node scripts/claude/headless-info-smoke.mjs",
     "test:docs": "node scripts/docs/validate-links.mjs && node scripts/docs/validate-rule-ownership.mjs",
     "test:pack": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/packaged-install-smoke.test.mjs",
+    "schema:generate": "node scripts/generate-config-schema.mjs",
+    "schema:check": "node scripts/generate-config-schema.mjs --check",
     "repo-wiki": "node scripts/repo-wiki.mjs",
     "repo-wiki:bootstrap": "node scripts/repo-wiki.mjs scan --repo . && node scripts/repo-wiki.mjs plan --repo . && node scripts/repo-wiki.mjs compile --repo .",
     "repo-wiki:scan": "node scripts/repo-wiki.mjs scan --repo .",

--- a/schemas/dev-loop-config.schema.json
+++ b/schemas/dev-loop-config.schema.json
@@ -2,31 +2,41 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/mfittko/dev-loops/schemas/dev-loop-config.schema.json",
   "title": "dev-loops config",
-  "description": "Schema for dev-loops config across all layers: the shipped defaults in packages/core/src/config/extension-defaults.yaml, the repo-local .pi/dev-loop/defaults.* override layer, and consumer .devloops (legacy .pi/dev-loop/settings.* and .pi/dev-loop/overrides.* still validate against it).",
+  "description": "GENERATED FILE — do not edit by hand; regenerate with `node scripts/generate-config-schema.mjs`. Extracted from FileConfigSchema in packages/core/src/config/config.mjs, the validator the loader applies to every config file layer: the shipped defaults in packages/core/src/config/extension-defaults.yaml, the repo-local .pi/dev-loop/defaults.* layer, consumer .devloops (.yaml/.yml/.json), and the legacy .pi/dev-loop/settings.*/overrides.* fallbacks. The zod loader remains authoritative: cross-field refinements (models.roleTiers alias resolution, uiReview step per-action requirements, regex validity) are enforced there and cannot be expressed in JSON Schema.",
   "type": "object",
-  "additionalProperties": false,
-  "required": [
-    "version"
-  ],
   "properties": {
     "version": {
+      "type": "number",
       "const": 1
     },
     "strategy": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "default": {
+          "type": "string",
           "enum": [
             "local-first",
             "github-first"
           ]
         }
-      }
+      },
+      "additionalProperties": false
+    },
+    "inputSource": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": "string",
+          "enum": [
+            "tracker",
+            "phase-docs"
+          ]
+        }
+      },
+      "additionalProperties": false
     },
     "models": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "conductor": {
           "type": "string",
@@ -34,16 +44,65 @@
         },
         "roles": {
           "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "tiers": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string",
+            "minLength": 1
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "claude": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "pi": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "roleTiers": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string",
+            "minLength": 1
+          },
           "additionalProperties": {
             "type": "string",
             "minLength": 1
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "refinement": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "fanOut": {
           "type": "integer",
@@ -51,14 +110,30 @@
           "maximum": 10
         },
         "mode": {
+          "type": "string",
           "enum": [
             "parallel",
             "sequential"
           ]
         },
         "maxCopilotRounds": {
+          "default": 5,
           "type": "integer",
-          "minimum": 1
+          "minimum": 0
+        },
+        "stopOnLowSignal": {
+          "default": false,
+          "type": "boolean"
+        },
+        "lowSignalRoundThreshold": {
+          "default": 3,
+          "type": "integer",
+          "minimum": 0
+        },
+        "lowSignalMaxComments": {
+          "default": 2,
+          "type": "integer",
+          "minimum": 0
         },
         "roles": {
           "type": "array",
@@ -67,47 +142,226 @@
             "minLength": 1
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "gates": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "draft": {
-          "$ref": "#/$defs/gateConfig",
-          "description": "Draft gate config. `requireCi` controls whether draft gate waits for green CI."
+          "type": "object",
+          "properties": {
+            "angles": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "excludeAngles": {
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "mandatoryAngles": {
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": {
+              "default": true,
+              "type": "boolean"
+            },
+            "requireCi": {
+              "default": true,
+              "type": "boolean"
+            },
+            "blockCleanOnFindingSeverities": {
+              "default": [
+                "must-fix"
+              ],
+              "minItems": 1,
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "must-fix",
+                  "worth-fixing-now",
+                  "defer"
+                ]
+              }
+            },
+            "dynamicAngles": {
+              "default": false,
+              "type": "boolean"
+            },
+            "additiveAngles": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
         },
         "preApproval": {
-          "$ref": "#/$defs/gateConfig",
-          "description": "Pre-approval gate config. `requireCi` is honored (default true): set it to false to opt out of the CI precondition so a repo with no CI is not held at the pre-approval gate. When false the CI verdict is ignored entirely at this boundary — including a real CI failure, which no longer blocks (not merely 'green optional')."
+          "type": "object",
+          "properties": {
+            "angles": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "excludeAngles": {
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "mandatoryAngles": {
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": {
+              "default": true,
+              "type": "boolean"
+            },
+            "requireCi": {
+              "default": true,
+              "type": "boolean"
+            },
+            "blockCleanOnFindingSeverities": {
+              "default": [
+                "must-fix"
+              ],
+              "minItems": 1,
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "must-fix",
+                  "worth-fixing-now",
+                  "defer"
+                ]
+              }
+            },
+            "dynamicAngles": {
+              "default": false,
+              "type": "boolean"
+            },
+            "additiveAngles": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
         },
         "spike": {
-          "$ref": "#/$defs/gateConfig",
-          "description": "Relaxed spike gate profile (#965). Lighter than the production draft -> pre-approval set: a spike's deliverable is a findings doc, so this is a small docs-first angle set, not a required gate, and CI is not a prerequisite. Applies only to spike-mode work."
+          "type": "object",
+          "properties": {
+            "angles": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "excludeAngles": {
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "mandatoryAngles": {
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": {
+              "default": true,
+              "type": "boolean"
+            },
+            "requireCi": {
+              "default": true,
+              "type": "boolean"
+            },
+            "blockCleanOnFindingSeverities": {
+              "default": [
+                "must-fix"
+              ],
+              "minItems": 1,
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "must-fix",
+                  "worth-fixing-now",
+                  "defer"
+                ]
+              }
+            },
+            "dynamicAngles": {
+              "default": false,
+              "type": "boolean"
+            },
+            "additiveAngles": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
         },
         "requireFanoutEvidence": {
-          "type": "boolean",
-          "description": "Require fan-out/fan-in review evidence on gate verdicts (rejects inline_single_agent)."
+          "type": "boolean"
+        },
+        "requireFanoutProvenance": {
+          "type": "boolean"
         },
         "maxFanoutReviewers": {
           "type": "integer",
           "minimum": 1,
-          "maximum": 64,
-          "description": "Maximum number of fan-out reviewers per gate."
+          "maximum": 64
         },
         "postFindingsComments": {
-          "type": "boolean",
-          "description": "Whether to post gate findings comments (default true). Local-first keeps them on: findings live on the PR as review evidence."
+          "type": "boolean"
+        },
+        "anglePool": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "rejectForeignAngles": {
+          "type": "boolean"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "autonomy": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "stopAt": {
           "type": "array",
           "items": {
+            "type": "string",
             "enum": [
               "refinement",
               "draft-pr",
@@ -117,53 +371,55 @@
           }
         },
         "humanMergeOnly": {
-          "type": "boolean",
-          "description": "When true, merge is a fixed human-only action: the agent never runs `gh pr merge`, `resolveAutonomyStopAt` always includes \"merge\", and any per-run merge authorization is ignored (fails closed).",
-          "default": false
+          "type": "boolean"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "approval": {
       "type": "object",
-      "additionalProperties": false,
-      "description": "Approval / merge-handoff behavior. `humanHandoff` (opt-in) offers to assign the PR to a contributor at the pre-approval gate. Pairs with autonomy.humanMergeOnly.",
       "properties": {
         "humanHandoff": {
           "type": "object",
-          "additionalProperties": false,
-          "description": "Offer to assign the PR to a human reviewer/assignee at the pre-approval / merge-handoff boundary. Opt-in; disabled by default. OFFER-only \u2014 the operator confirms the assignee.",
           "properties": {
             "enabled": {
-              "type": "boolean",
               "default": false,
-              "description": "Enable the human-handoff offer at the pre-approval gate."
+              "type": "boolean"
             },
             "candidatesFrom": {
               "type": "array",
               "items": {
+                "type": "string",
                 "enum": [
                   "codeowners",
                   "recent-committers"
                 ]
-              },
-              "description": "Candidate sources the resolver queries: CODEOWNERS for touched paths and/or recent committers to those paths."
+              }
             },
             "assignees": {
               "type": "array",
               "items": {
                 "type": "string",
                 "minLength": 1
-              },
-              "description": "Static, highest-priority candidate logins to offer (e.g. [alice, bob])."
+              }
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "workflow": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
+        "asyncStartMode": {
+          "default": "required",
+          "type": "string",
+          "enum": [
+            "required",
+            "allowed"
+          ]
+        },
         "requireRetrospective": {
           "type": "boolean"
         },
@@ -173,128 +429,394 @@
         "devModeDefault": {
           "type": "boolean"
         }
-      }
+      },
+      "additionalProperties": false
+    },
+    "localImplementation": {
+      "type": "object",
+      "properties": {
+        "lightMode": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "maxFiles": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "maxLines": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "maxCopilotRounds": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "required": [
+            "enabled",
+            "maxFiles",
+            "maxLines"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "queue": {
+      "type": "object",
+      "properties": {
+        "maxParallel": {
+          "default": 3,
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10
+        },
+        "maxAutoFiledIssues": {
+          "default": 10,
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "reDispatchMaxRetries": {
+          "default": 1,
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10
+        },
+        "projectNumber": {
+          "type": "integer",
+          "exclusiveMinimum": 0
+        },
+        "boardTitle": {
+          "type": "string",
+          "minLength": 1
+        },
+        "archiveOlderThanDays": {
+          "type": "integer",
+          "exclusiveMinimum": 0
+        }
+      },
+      "additionalProperties": false
     },
     "personas": {
       "type": "object",
       "propertyNames": {
+        "type": "string",
         "minLength": 1
       },
       "additionalProperties": {
-        "$ref": "#/$defs/personaEntry"
+        "type": "object",
+        "properties": {
+          "persona": {
+            "type": "string",
+            "minLength": 1
+          },
+          "prompt": {
+            "description": "Short focused instruction for the reviewer agent — what to look for and how to judge this angle",
+            "type": "string",
+            "minLength": 1
+          },
+          "defaultModel": {
+            "default": null,
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "internalPathPatterns": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
       }
     },
     "worktree": {
       "type": "object",
-      "additionalProperties": false,
-      "description": "Worktree lifecycle automation. Provision gitignored files/dirs into a fresh worktree from the main checkout. Entries are repo-relative literal paths or glob patterns; directories recurse. Empty/absent is a no-op.",
       "properties": {
         "copyOnInit": {
           "type": "array",
           "items": {
             "type": "string",
             "minLength": 1
-          },
-          "description": "Paths/globs copied into the worktree (isolated per worktree \u2014 use for mutable files). Do not target node_modules."
+          }
         },
         "linkOnInit": {
           "type": "array",
           "items": {
             "type": "string",
             "minLength": 1
-          },
-          "description": "Paths/globs symlinked (absolute) into the main checkout (shared \u2014 use only for read-only data). Do not target node_modules."
+          }
         }
-      }
+      },
+      "additionalProperties": false
     },
-    "localPlanning": {
-      "deprecated": true,
-      "description": "Deprecated (removed in #1088). Accepted for backward compatibility but ignored \u2014 nothing reads it."
-    }
-  },
-  "$defs": {
-    "gateConfig": {
+    "uiReview": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
-        "angles": {
+        "run": {
+          "type": "object",
+          "properties": {
+            "command": {
+              "type": "string",
+              "minLength": 1
+            },
+            "readyUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "readyTimeoutMs": {
+              "default": 60000,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 600000
+            },
+            "readyIntervalMs": {
+              "default": 1000,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 60000
+            },
+            "cwd": {
+              "type": "string",
+              "minLength": 1
+            },
+            "migrate": {
+              "type": "object",
+              "properties": {
+                "statusCommand": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "applyCommand": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "destructivePattern": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": [
+                "statusCommand",
+                "applyCommand"
+              ],
+              "additionalProperties": false
+            },
+            "rowTeardown": {
+              "type": "object",
+              "properties": {
+                "deleteCommand": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": [
+                "deleteCommand"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "command",
+            "readyUrl"
+          ],
+          "additionalProperties": false
+        },
+        "login": {
+          "type": "object",
+          "properties": {
+            "loginUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "usernameSelector": {
+              "type": "string",
+              "minLength": 1
+            },
+            "usernameValue": {
+              "type": "string",
+              "minLength": 1
+            },
+            "passwordSelector": {
+              "type": "string",
+              "minLength": 1
+            },
+            "passwordValue": {
+              "type": "string",
+              "minLength": 1
+            },
+            "submitSelector": {
+              "type": "string",
+              "minLength": 1
+            },
+            "successSelector": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "loginUrl",
+            "submitSelector",
+            "successSelector"
+          ],
+          "additionalProperties": false
+        },
+        "interstitials": {
           "type": "array",
           "items": {
-            "type": "string",
-            "minLength": 1
+            "type": "object",
+            "properties": {
+              "selector": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "selector"
+            ],
+            "additionalProperties": false
           }
         },
-        "excludeAngles": {
+        "flows": {
           "type": "array",
           "items": {
-            "type": "string",
-            "minLength": 1
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "pathPatterns": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "steps": {
+                "minItems": 1,
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "action": {
+                      "type": "string",
+                      "enum": [
+                        "goto",
+                        "click",
+                        "fill",
+                        "select",
+                        "upload",
+                        "dispatch"
+                      ]
+                    },
+                    "selector": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "path": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "value": {
+                      "type": "string"
+                    },
+                    "event": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "viewport": {
+                      "type": "object",
+                      "properties": {
+                        "width": {
+                          "type": "integer",
+                          "exclusiveMinimum": 0
+                        },
+                        "height": {
+                          "type": "integer",
+                          "exclusiveMinimum": 0
+                        }
+                      },
+                      "required": [
+                        "width",
+                        "height"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "interactionState": {
+                      "type": "string",
+                      "enum": [
+                        "none",
+                        "focus",
+                        "hover",
+                        "error"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "action"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "name",
+              "steps"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "caps": {
+          "type": "object",
+          "properties": {
+            "maxScreenshots": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "maxFlows": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "maxStepsPerFlow": {
+              "type": "integer",
+              "minimum": 1
+            }
           },
-          "default": [],
-          "description": "Angles to remove from the resolved angle list."
+          "additionalProperties": false
         },
-        "required": {
-          "type": "boolean",
-          "default": true
+        "serverLogPath": {
+          "type": "string",
+          "minLength": 1
         },
-        "requireCi": {
-          "type": "boolean",
-          "default": true,
-          "description": "Per-gate CI prerequisite toggle (default true). When true the gate requires green current-head CI; set false to opt that gate out of the CI precondition. Honored on both the draft and pre-approval gates — on the pre-approval gate a false value ignores the CI verdict entirely (including a real failure)."
-        },
-        "blockCleanOnFindingSeverities": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "must-fix",
-              "worth-fixing-now",
-              "defer"
-            ]
-          },
-          "minItems": 1,
-          "default": [
-            "must-fix"
-          ],
-          "description": "Finding severities that block a clean gate verdict."
-        },
-        "dynamicAngles": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enable dynamic gate angle resolution based on PR diff analysis."
-        },
-        "mandatoryAngles": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "minLength": 1
-          },
-          "default": [],
-          "description": "Angles that always run regardless of diff-based dynamic selection."
+        "serverLogExceptionPattern": {
+          "type": "string",
+          "minLength": 1
         }
-      }
+      },
+      "additionalProperties": false
     },
-    "personaEntry": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "persona": {
-          "type": "string",
-          "minLength": 1
-        },
-        "prompt": {
-          "type": "string",
-          "minLength": 1
-        },
-        "defaultModel": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "minLength": 1,
-          "default": null
-        }
-      }
-    }
-  }
+    "localPlanning": {}
+  },
+  "required": [
+    "version"
+  ],
+  "additionalProperties": false
 }

--- a/scripts/generate-config-schema.mjs
+++ b/scripts/generate-config-schema.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// Generate schemas/dev-loop-config.schema.json from the authoritative zod
+// validator (FileConfigSchema in @dev-loops/core/config).
+//
+// The JSON schema file is a derived artifact: every config layer the loader
+// reads (shipped extension-defaults, repo .pi/dev-loop/defaults.*, consumer
+// .devloops, legacy .pi/dev-loop/settings.*/overrides.*) is validated with
+// FileConfigSchema (see applyLayer in packages/core/src/config/config.mjs),
+// so the JSON schema is extracted from that schema rather than maintained by
+// hand. Cross-field refinements (roleTiers alias checks, per-action step
+// requirements, regex validity) are not representable in JSON Schema and are
+// enforced only by the zod loader.
+//
+// Usage:
+//   node scripts/generate-config-schema.mjs           # rewrite the schema file
+//   node scripts/generate-config-schema.mjs --check   # exit 1 if the file is stale
+
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { z } from "zod";
+import { FileConfigSchema } from "@dev-loops/core/config";
+
+const SCHEMA_PATH = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "schemas",
+  "dev-loop-config.schema.json"
+);
+
+/**
+ * zod emits the JS safe-integer range as explicit numeric bounds on every
+ * `.int()` field. Those bounds are a JS runtime artifact, not a config
+ * constraint an author needs to see — drop exactly them and nothing else.
+ * @param {unknown} node
+ */
+function stripSafeIntegerBounds(node) {
+  if (Array.isArray(node)) {
+    for (const item of node) stripSafeIntegerBounds(item);
+    return;
+  }
+  if (node === null || typeof node !== "object") return;
+  const obj = /** @type {Record<string, unknown>} */ (node);
+  if (obj.maximum === Number.MAX_SAFE_INTEGER) delete obj.maximum;
+  if (obj.minimum === -Number.MAX_SAFE_INTEGER) delete obj.minimum;
+  for (const value of Object.values(obj)) stripSafeIntegerBounds(value);
+}
+
+/**
+ * Build the JSON schema document from the zod file-level validator.
+ * @returns {Record<string, unknown>}
+ */
+export function generateConfigJsonSchema() {
+  const generated = z.toJSONSchema(FileConfigSchema, {
+    target: "draft-2020-12",
+    io: "input",
+    reused: "defs",
+  });
+  stripSafeIntegerBounds(generated);
+
+  const { $schema, ...body } = generated;
+  return {
+    $schema,
+    $id: "https://github.com/mfittko/dev-loops/schemas/dev-loop-config.schema.json",
+    title: "dev-loops config",
+    description:
+      "GENERATED FILE — do not edit by hand; regenerate with `node scripts/generate-config-schema.mjs`. " +
+      "Extracted from FileConfigSchema in packages/core/src/config/config.mjs, the validator the loader " +
+      "applies to every config file layer: the shipped defaults in packages/core/src/config/extension-defaults.yaml, " +
+      "the repo-local .pi/dev-loop/defaults.* layer, consumer .devloops (.yaml/.yml/.json), and the legacy " +
+      ".pi/dev-loop/settings.*/overrides.* fallbacks. The zod loader remains authoritative: cross-field " +
+      "refinements (models.roleTiers alias resolution, uiReview step per-action requirements, regex validity) " +
+      "are enforced there and cannot be expressed in JSON Schema.",
+    ...body,
+  };
+}
+
+/** @returns {string} */
+export function renderConfigJsonSchema() {
+  return `${JSON.stringify(generateConfigJsonSchema(), null, 2)}\n`;
+}
+
+async function main() {
+  const rendered = renderConfigJsonSchema();
+  const relative = path.relative(process.cwd(), SCHEMA_PATH);
+
+  if (process.argv.includes("--check")) {
+    let existing = null;
+    try {
+      existing = await readFile(SCHEMA_PATH, "utf8");
+    } catch (err) {
+      if (err?.code !== "ENOENT") throw err;
+    }
+    if (existing !== rendered) {
+      console.error(
+        `${relative} is stale — regenerate with \`node scripts/generate-config-schema.mjs\``
+      );
+      process.exit(1);
+    }
+    console.log(`${relative} is up to date`);
+    return;
+  }
+
+  await writeFile(SCHEMA_PATH, rendered, "utf8");
+  console.log(`wrote ${relative}`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  await main();
+}

--- a/scripts/generate-config-schema.mjs
+++ b/scripts/generate-config-schema.mjs
@@ -18,9 +18,10 @@
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { z } from "zod";
 import { FileConfigSchema } from "@dev-loops/core/config";
+import { isDirectCliRun } from "./_core-helpers.mjs";
 
 const SCHEMA_PATH = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -106,6 +107,6 @@ async function main() {
   console.log(`wrote ${relative}`);
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+if (isDirectCliRun(import.meta.url)) {
   await main();
 }

--- a/scripts/pages/article-shell.html
+++ b/scripts/pages/article-shell.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+{{GENERATED}}
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'" />
+<title>{{TITLE}}</title>
+<style>
+  :root {
+    --ground-1: #08101f;
+    --ground-2: #0b1220;
+    --ground-3: #0f172a;
+    --ink: #e5e7eb;
+    --heading: #f8fafc;
+    --copy: #cbd5e1;
+    --accent: #a78bfa;
+    --accent-soft: #ddd6fe;
+    --kicker: #93c5fd;
+    --card-border: rgba(148, 163, 184, 0.18);
+    --node-border: rgba(129, 140, 248, 0.4);
+    --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Helvetica Neue", sans-serif;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  }
+
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  @media (prefers-reduced-motion: reduce) {
+    html { scroll-behavior: auto; }
+  }
+
+  body {
+    margin: 0;
+    font-family: var(--font);
+    color: var(--ink);
+    overflow-x: hidden;
+    -webkit-text-size-adjust: 100%;
+    background:
+      radial-gradient(circle at 85% 4%, rgba(139, 92, 246, 0.22), transparent 26%),
+      radial-gradient(circle at 12% 2%, rgba(59, 130, 246, 0.16), transparent 22%),
+      linear-gradient(180deg, var(--ground-1) 0%, var(--ground-2) 38%, var(--ground-3) 100%);
+    background-attachment: fixed;
+  }
+
+  .wrap {
+    max-width: 48rem;
+    margin: 0 auto;
+    padding: clamp(2rem, 6vw, 4rem) clamp(1.1rem, 5vw, 2rem) 5rem;
+  }
+
+  /* One column at every width: prose and boxes fill the same wrap, so all
+     left/right edges line up. Desktop widens the column; nothing floats in a
+     narrower centered measure beside a full-width box. */
+  @media (min-width: 900px) {
+    .wrap { max-width: 56rem; }
+  }
+
+  .kicker {
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    font-size: 0.72rem;
+    color: var(--kicker);
+    margin: 0 0 0.6rem;
+    font-weight: 600;
+  }
+
+  h1, h2, h3 { color: var(--heading); letter-spacing: -0.02em; margin-top: 0; }
+  h1 { font-weight: 760; font-size: clamp(1.9rem, 5vw, 2.7rem); line-height: 1.08; margin-bottom: 0.9rem; }
+  h2 { font-weight: 720; font-size: clamp(1.35rem, 3.4vw, 1.85rem); line-height: 1.15; margin: 2.6rem 0 0.9rem; }
+  h3 { font-weight: 680; font-size: clamp(1.08rem, 2.4vw, 1.28rem); line-height: 1.25; margin: 1.8rem 0 0.6rem; color: var(--accent-soft); }
+
+  .lede {
+    color: var(--copy);
+    font-size: clamp(1.08rem, 2.4vw, 1.28rem);
+    line-height: 1.5;
+    margin: 0 0 2rem;
+  }
+
+  p { line-height: 1.72; font-size: 1.05rem; color: var(--ink); margin: 0 0 1.15rem; }
+  strong { color: var(--accent-soft); }
+  em { color: #e2e8f0; font-style: italic; }
+  ul, ol { line-height: 1.7; padding-left: 1.3rem; margin: 0 0 1.15rem; }
+  li + li { margin-top: 0.5rem; }
+  a { color: var(--kicker); text-decoration: none; border-bottom: 1px solid rgba(147, 197, 253, 0.35); }
+  a:hover { border-bottom-color: var(--kicker); }
+
+  code {
+    font-family: var(--mono);
+    font-size: 0.9em;
+    background: rgba(148, 163, 184, 0.12);
+    border: 1px solid rgba(148, 163, 184, 0.16);
+    border-radius: 6px;
+    padding: 0.05em 0.4em;
+    color: #e2e8f0;
+    overflow-wrap: anywhere;
+  }
+
+  pre {
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0.82), rgba(15, 23, 42, 0.6));
+    border: 1px solid var(--card-border);
+    border-radius: 14px;
+    padding: 1rem 1.15rem;
+    margin: 0 0 1.3rem;
+    overflow-x: auto;
+  }
+  pre code {
+    background: none;
+    border: 0;
+    border-radius: 0;
+    padding: 0;
+    font-size: 0.86rem;
+    line-height: 1.6;
+    color: #e2e8f0;
+    white-space: pre;
+  }
+  pre code .cm { color: #94a3b8; }
+
+  .hero-card {
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0.82), rgba(15, 23, 42, 0.6));
+    border: 1px solid var(--card-border);
+    box-shadow: 0 22px 60px rgba(0, 0, 0, 0.3);
+    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(12px);
+    border-radius: 24px;
+    padding: 1.6rem 1.7rem;
+    margin-bottom: 2.6rem;
+  }
+  .hero-card .lede { margin-bottom: 0; }
+
+  /* metric row for the proof numbers */
+  .metrics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.8rem;
+    margin: 1.8rem 0 2rem;
+  }
+  .metric {
+    flex: 1 1 8rem;
+    min-width: 0;
+    background: linear-gradient(180deg, rgba(24, 36, 61, 0.82), rgba(17, 24, 39, 0.72));
+    border: 1px solid var(--node-border);
+    border-radius: 16px;
+    padding: 1rem 1.1rem;
+  }
+  .metric .num { font-size: 1.5rem; font-weight: 720; color: var(--accent-soft); line-height: 1.05; }
+  .metric .lab { font-size: 0.82rem; color: var(--copy); margin-top: 0.4rem; line-height: 1.35; }
+
+  .rule { border: 0; border-top: 1px solid rgba(148, 163, 184, 0.16); margin: 3rem 0; }
+
+  .deeper {
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    padding: 1.2rem 1.35rem;
+    margin-top: 2rem;
+  }
+  .deeper h2 { margin-top: 0; font-size: 1.2rem; }
+  .deeper p { margin-bottom: 0; font-size: 0.98rem; color: var(--copy); }
+</style>
+</head>

--- a/scripts/pages/build-site.mjs
+++ b/scripts/pages/build-site.mjs
@@ -2,8 +2,11 @@
 // Assembles the GitHub Pages publishable dir deterministically. The landing
 // page (index.html) is the "Introducing dev-loops" article; the deep-dive
 // article and the deep-dive deck are published alongside it and reached through
-// a shared navigation bar injected into the article pages. The source HTML files
-// under docs/ are the source of truth; site/ is assembled, never hand-maintained.
+// a shared navigation bar injected into the article pages. The HTML files under
+// docs/ are the inputs here; site/ is assembled, never hand-maintained. Articles
+// listed in render-article.mjs's RENDERED_ARTICLES are themselves derived from
+// their markdown twin (edit the .md, then `npm run articles:render`); the rest
+// are hand-maintained sources.
 // Usage: node scripts/pages/build-site.mjs [--out <dir>] [--repo-root <dir>]
 import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve, parse as parsePath } from 'node:path';

--- a/scripts/pages/render-article.mjs
+++ b/scripts/pages/render-article.mjs
@@ -43,8 +43,10 @@ export const RENDERED_ARTICLES = [
   { md: "introducing-dev-loops.md", html: "introducing-dev-loops.html" },
 ];
 
+// Quote-escaping matters even under the strict CSP: rendered text is also
+// interpolated into href="" attributes, where a bare quote breaks out.
 const escapeHtml = (s) =>
-  s.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+  s.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;");
 
 const slugify = (s) =>
   s.toLowerCase().replace(/[^a-z0-9\s-]/g, "").trim().replace(/\s+/g, "-");
@@ -79,6 +81,12 @@ function parseBlocks(body) {
     if (line.trim() === "") continue;
     if (line.trim() === "<!-- metrics:start -->") { metricsPending = true; continue; }
     if (line.trim() === "<!-- metrics:end -->") { metricsPending = false; continue; }
+    // Any other HTML comment must fail closed: the paragraph collector treats
+    // `<!--` as a block boundary, so an unrecognized comment line would
+    // otherwise re-enter the loop at the same index forever.
+    if (line.trimStart().startsWith("<!--")) {
+      throw new Error(`unsupported HTML comment at line ${i + 1}: ${JSON.stringify(line.trim())} — only the metrics markers are recognized`);
+    }
     if (line.startsWith("```")) {
       const fence = [];
       for (i++; i < lines.length && !lines[i].startsWith("```"); i++) fence.push(lines[i]);

--- a/scripts/pages/render-article.mjs
+++ b/scripts/pages/render-article.mjs
@@ -30,8 +30,9 @@
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
+import { isDirectCliRun } from "../_core-helpers.mjs";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 const ARTICLES_DIR = path.join(REPO_ROOT, "docs", "articles");
@@ -110,6 +111,9 @@ function parseBlocks(body) {
       blocks.push({ type: "p", text: para.join(" ") });
     }
   }
+  if (metricsPending) {
+    throw new Error("unterminated metrics block: <!-- metrics:start --> has no matching <!-- metrics:end -->");
+  }
   return blocks;
 }
 
@@ -157,6 +161,9 @@ export function renderArticleHtml(mdSource, shell, sourceBasename) {
     if (block.type === "h1") continue;
     if (block.type === "h2") {
       const slug = slugify(block.text);
+      if (slug === "") {
+        throw new Error(`h2 heading ${JSON.stringify(block.text)} produces an empty slug id`);
+      }
       if (seenSlugs.has(slug)) {
         throw new Error(`duplicate h2 slug "${slug}" — two sections would share one anchor id`);
       }
@@ -222,6 +229,6 @@ async function main() {
   }
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+if (isDirectCliRun(import.meta.url)) {
   await main();
 }

--- a/scripts/pages/render-article.mjs
+++ b/scripts/pages/render-article.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+// Render docs/articles/*.html from their markdown twin. The markdown is the
+// single source of truth for article CONTENT; the HTML twin is a derived
+// artifact assembled from scripts/pages/article-shell.html (the design system:
+// head, CSP meta, and the style tokens build-site.mjs's nav injection depends
+// on) plus a deterministic transform of the markdown body.
+//
+// The transform is deliberately a fail-closed subset, not a general markdown
+// engine: headings, paragraphs, bullet lists, fenced code blocks, and the
+// inline set (**bold**, *em*, `code`, [links]) used by the articles. Anything
+// it does not recognize throws, so an unsupported construct becomes a build
+// error instead of silently mangled prose. Article-specific conventions:
+//
+//   - Frontmatter `title` fills the shell <title> and hero <h1>; frontmatter
+//     `heroLede` fills the hero card's lede line.
+//   - A bullet list between `<!-- metrics:start -->` and `<!-- metrics:end -->`
+//     renders as the .metrics card row; each item must be `**<num>** <label>`.
+//   - Every h2 gets a GitHub-style slug id, so in-page `#anchors` written in
+//     the markdown resolve in both renderings.
+//   - The final h2 section renders as the boxed .deeper outro behind an
+//     <hr class="rule" />.
+//   - Relative links to `.md` files are rewritten to their `.html` twins.
+//   - `#`-to-end-of-line comments inside fenced code render in .cm spans.
+//
+// Usage:
+//   node scripts/pages/render-article.mjs           # rewrite the HTML twin(s)
+//   node scripts/pages/render-article.mjs --check   # exit 1 if any twin is stale
+
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { parse as parseYaml } from "yaml";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const ARTICLES_DIR = path.join(REPO_ROOT, "docs", "articles");
+const SHELL_PATH = path.join(REPO_ROOT, "scripts", "pages", "article-shell.html");
+
+// Rendered articles: markdown source → derived HTML twin. The deep-dive
+// article predates this renderer and stays hand-maintained until migrated.
+export const RENDERED_ARTICLES = [
+  { md: "introducing-dev-loops.md", html: "introducing-dev-loops.html" },
+];
+
+const escapeHtml = (s) =>
+  s.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+
+const slugify = (s) =>
+  s.toLowerCase().replace(/[^a-z0-9\s-]/g, "").trim().replace(/\s+/g, "-");
+
+/** Inline markdown → HTML: escape first, then `code`, **bold**, *em*, [links]. */
+function renderInline(text) {
+  let out = escapeHtml(text);
+  out = out.replace(/`([^`]+)`/g, (_, code) => `<code>${code}</code>`);
+  out = out.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+  out = out.replace(/(^|[^*])\*([^*\s][^*]*)\*/g, "$1<em>$2</em>");
+  out = out.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, (_, label, href) => {
+    const target = href.replace(/^(\.{1,2}\/[^)#]*)\.md(#[^)]*)?$/, "$1.html$2");
+    return `<a href="${target}">${label}</a>`;
+  });
+  return out;
+}
+
+/** Wrap `#`-to-end-of-line comments of an escaped code block in .cm spans. */
+const markCodeComments = (escaped) =>
+  escaped
+    .split("\n")
+    .map((line) => line.replace(/(^|\s)(#.*)$/, '$1<span class="cm">$2</span>'))
+    .join("\n");
+
+/** Parse the markdown body into a flat block list. Throws on unknown syntax. */
+function parseBlocks(body) {
+  const lines = body.split("\n");
+  const blocks = [];
+  let metricsPending = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === "") continue;
+    if (line.trim() === "<!-- metrics:start -->") { metricsPending = true; continue; }
+    if (line.trim() === "<!-- metrics:end -->") { metricsPending = false; continue; }
+    if (line.startsWith("```")) {
+      const fence = [];
+      for (i++; i < lines.length && !lines[i].startsWith("```"); i++) fence.push(lines[i]);
+      if (i >= lines.length) throw new Error("unterminated code fence");
+      blocks.push({ type: "code", text: fence.join("\n") });
+    } else if (line.startsWith("## ")) {
+      blocks.push({ type: "h2", text: line.slice(3).trim() });
+    } else if (line.startsWith("# ")) {
+      blocks.push({ type: "h1", text: line.slice(2).trim() });
+    } else if (line.startsWith("- ")) {
+      const items = [];
+      for (; i < lines.length && lines[i].startsWith("- "); i++) items.push(lines[i].slice(2).trim());
+      i--;
+      blocks.push({ type: metricsPending ? "metrics" : "list", items });
+    } else if (/^[#>|]/.test(line) || line.startsWith("  ")) {
+      throw new Error(`unsupported markdown construct at line ${i + 1}: ${JSON.stringify(line)}`);
+    } else {
+      const para = [];
+      for (; i < lines.length && lines[i].trim() !== "" && !/^(#|-|```|<!--)/.test(lines[i]); i++) para.push(lines[i]);
+      i--;
+      blocks.push({ type: "p", text: para.join(" ") });
+    }
+  }
+  return blocks;
+}
+
+function renderMetrics(items) {
+  const cards = items.map((item) => {
+    const m = item.match(/^\*\*([^*]+)\*\*\s+(.*)$/);
+    if (!m) throw new Error(`metrics item must be "**<num>** <label>": ${JSON.stringify(item)}`);
+    return `    <div class="metric" role="listitem"><div class="num">${renderInline(m[1])}</div><div class="lab">${renderInline(m[2])}</div></div>`;
+  });
+  return `  <div class="metrics" role="list">\n${cards.join("\n")}\n  </div>`;
+}
+
+/**
+ * Render one article's markdown source into the full HTML page.
+ * @param {string} mdSource - full markdown file contents including frontmatter
+ * @param {string} shell - article-shell.html template contents
+ * @returns {string}
+ */
+export function renderArticleHtml(mdSource, shell) {
+  const fm = mdSource.match(/^---\n([\s\S]*?)\n---\n/);
+  if (!fm) throw new Error("article markdown must start with YAML frontmatter");
+  const meta = parseYaml(fm[1]);
+  if (!meta?.title || !meta?.heroLede) {
+    throw new Error("article frontmatter must set title and heroLede");
+  }
+
+  const blocks = parseBlocks(mdSource.slice(fm[0].length));
+  if (blocks[0]?.type !== "h1" || blocks[0].text !== meta.title) {
+    throw new Error("article body must open with an h1 matching the frontmatter title");
+  }
+
+  const lastH2 = blocks.reduce((last, b, i) => (b.type === "h2" ? i : last), -1);
+  const out = [];
+  out.push(`  <header class="hero-card">
+    <p class="kicker">dev-loops</p>
+    <h1>${renderInline(meta.title)}</h1>
+    <p class="lede">${renderInline(meta.heroLede)}</p>
+  </header>`);
+
+  let inDeeper = false;
+  for (const [i, block] of blocks.entries()) {
+    if (block.type === "h1") continue;
+    if (block.type === "h2") {
+      if (i === lastH2) {
+        out.push(`  <hr class="rule" />`, ``, `  <section class="deeper">`);
+        out.push(`    <h2 id="${slugify(block.text)}">${renderInline(block.text)}</h2>`);
+        inDeeper = true;
+      } else {
+        out.push(`  <h2 id="${slugify(block.text)}">${renderInline(block.text)}</h2>`);
+      }
+    } else if (block.type === "p") {
+      out.push(inDeeper ? `    <p>${renderInline(block.text)}</p>` : `  <p>${renderInline(block.text)}</p>`);
+    } else if (block.type === "list") {
+      out.push(`  <ul>\n${block.items.map((it) => `    <li>${renderInline(it)}</li>`).join("\n")}\n  </ul>`);
+    } else if (block.type === "metrics") {
+      out.push(renderMetrics(block.items));
+    } else if (block.type === "code") {
+      out.push(`  <pre><code>${markCodeComments(escapeHtml(block.text))}</code></pre>`);
+    }
+  }
+  if (inDeeper) out.push(`  </section>`);
+
+  const generated = `<!-- GENERATED from docs/articles/${meta.sourceBasename} by scripts/pages/render-article.mjs — do not edit; edit the markdown and regenerate. -->`;
+  return (
+    shell.replace("{{TITLE}}", escapeHtml(meta.title)).replace("{{GENERATED}}", generated) +
+    `<body>\n<div class="wrap">\n<article class="article">\n\n${out.join("\n\n")}\n\n</article>\n</div>\n</body>\n</html>\n`
+  );
+}
+
+async function renderAll() {
+  const shell = await readFile(SHELL_PATH, "utf8");
+  const results = [];
+  for (const { md, html } of RENDERED_ARTICLES) {
+    const mdSource = await readFile(path.join(ARTICLES_DIR, md), "utf8");
+    // Thread the source basename through frontmatter meta for the marker line.
+    const rendered = renderArticleHtml(
+      mdSource.replace(/^---\n/, `---\nsourceBasename: ${md}\n`),
+      shell
+    );
+    results.push({ md, html, rendered });
+  }
+  return results;
+}
+
+async function main() {
+  const check = process.argv.includes("--check");
+  for (const { md, html, rendered } of await renderAll()) {
+    const htmlPath = path.join(ARTICLES_DIR, html);
+    if (check) {
+      let existing = null;
+      try {
+        existing = await readFile(htmlPath, "utf8");
+      } catch (err) {
+        if (err?.code !== "ENOENT") throw err;
+      }
+      if (existing !== rendered) {
+        console.error(
+          `docs/articles/${html} is stale relative to ${md} — regenerate with \`node scripts/pages/render-article.mjs\``
+        );
+        process.exit(1);
+      }
+      console.log(`docs/articles/${html} is up to date`);
+    } else {
+      await writeFile(htmlPath, rendered, "utf8");
+      console.log(`rendered docs/articles/${html} from ${md}`);
+    }
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  await main();
+}

--- a/scripts/pages/render-article.mjs
+++ b/scripts/pages/render-article.mjs
@@ -16,10 +16,11 @@
 //   - A bullet list between `<!-- metrics:start -->` and `<!-- metrics:end -->`
 //     renders as the .metrics card row; each item must be `**<num>** <label>`.
 //   - Every h2 gets a GitHub-style slug id, so in-page `#anchors` written in
-//     the markdown resolve in both renderings.
+//     the markdown resolve in both renderings. Duplicate h2 slugs throw.
 //   - The final h2 section renders as the boxed .deeper outro behind an
 //     <hr class="rule" />.
-//   - Relative links to `.md` files are rewritten to their `.html` twins.
+//   - Relative `./`- or `../`-prefixed links to `.md` files are rewritten to
+//     their `.html` twins.
 //   - `#`-to-end-of-line comments inside fenced code render in .cm spans.
 //
 // Usage:
@@ -117,9 +118,11 @@ function renderMetrics(items) {
  * Render one article's markdown source into the full HTML page.
  * @param {string} mdSource - full markdown file contents including frontmatter
  * @param {string} shell - article-shell.html template contents
+ * @param {string} sourceBasename - the markdown file's basename, for the GENERATED marker
  * @returns {string}
  */
-export function renderArticleHtml(mdSource, shell) {
+export function renderArticleHtml(mdSource, shell, sourceBasename) {
+  if (!sourceBasename) throw new Error("renderArticleHtml requires the markdown sourceBasename");
   const fm = mdSource.match(/^---\n([\s\S]*?)\n---\n/);
   if (!fm) throw new Error("article markdown must start with YAML frontmatter");
   const meta = parseYaml(fm[1]);
@@ -141,15 +144,21 @@ export function renderArticleHtml(mdSource, shell) {
   </header>`);
 
   let inDeeper = false;
+  const seenSlugs = new Set();
   for (const [i, block] of blocks.entries()) {
     if (block.type === "h1") continue;
     if (block.type === "h2") {
+      const slug = slugify(block.text);
+      if (seenSlugs.has(slug)) {
+        throw new Error(`duplicate h2 slug "${slug}" — two sections would share one anchor id`);
+      }
+      seenSlugs.add(slug);
       if (i === lastH2) {
         out.push(`  <hr class="rule" />`, ``, `  <section class="deeper">`);
-        out.push(`    <h2 id="${slugify(block.text)}">${renderInline(block.text)}</h2>`);
+        out.push(`    <h2 id="${slug}">${renderInline(block.text)}</h2>`);
         inDeeper = true;
       } else {
-        out.push(`  <h2 id="${slugify(block.text)}">${renderInline(block.text)}</h2>`);
+        out.push(`  <h2 id="${slug}">${renderInline(block.text)}</h2>`);
       }
     } else if (block.type === "p") {
       out.push(inDeeper ? `    <p>${renderInline(block.text)}</p>` : `  <p>${renderInline(block.text)}</p>`);
@@ -163,7 +172,7 @@ export function renderArticleHtml(mdSource, shell) {
   }
   if (inDeeper) out.push(`  </section>`);
 
-  const generated = `<!-- GENERATED from docs/articles/${meta.sourceBasename} by scripts/pages/render-article.mjs — do not edit; edit the markdown and regenerate. -->`;
+  const generated = `<!-- GENERATED from docs/articles/${sourceBasename} by scripts/pages/render-article.mjs — do not edit; edit the markdown and regenerate. -->`;
   return (
     shell.replace("{{TITLE}}", escapeHtml(meta.title)).replace("{{GENERATED}}", generated) +
     `<body>\n<div class="wrap">\n<article class="article">\n\n${out.join("\n\n")}\n\n</article>\n</div>\n</body>\n</html>\n`
@@ -175,12 +184,7 @@ async function renderAll() {
   const results = [];
   for (const { md, html } of RENDERED_ARTICLES) {
     const mdSource = await readFile(path.join(ARTICLES_DIR, md), "utf8");
-    // Thread the source basename through frontmatter meta for the marker line.
-    const rendered = renderArticleHtml(
-      mdSource.replace(/^---\n/, `---\nsourceBasename: ${md}\n`),
-      shell
-    );
-    results.push({ md, html, rendered });
+    results.push({ md, html, rendered: renderArticleHtml(mdSource, shell, md) });
   }
   return results;
 }

--- a/test/contracts/config-schema-generated.test.mjs
+++ b/test/contracts/config-schema-generated.test.mjs
@@ -9,7 +9,7 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { parse as parseYaml } from "yaml";
 import { FileConfigSchema } from "@dev-loops/core/config";
-import { renderConfigJsonSchema } from "../../scripts/generate-config-schema.mjs";
+import { generateConfigJsonSchema, renderConfigJsonSchema } from "../../scripts/generate-config-schema.mjs";
 
 const schemaFileUrl = new URL("../../schemas/dev-loop-config.schema.json", import.meta.url);
 
@@ -31,6 +31,20 @@ test("JSON schema top-level surface mirrors FileConfigSchema exactly", async () 
   assert.equal(jsonSchema.additionalProperties, false);
   assert.deepEqual(jsonSchema.required, ["version"]);
   assert.deepEqual(jsonSchema.properties.version, { type: "number", const: 1 });
+});
+
+test("JS safe-integer sentinels are stripped from the generated schema", () => {
+  // zod stamps ±MAX_SAFE_INTEGER bounds on every .int() field; the generator
+  // strips exactly those. The drift test can't catch this regressing (both
+  // sides come from the same code), so pin it against the generator directly.
+  const rendered = JSON.stringify(generateConfigJsonSchema());
+  assert.ok(
+    !rendered.includes(String(Number.MAX_SAFE_INTEGER)),
+    "generated schema leaks MAX_SAFE_INTEGER bounds"
+  );
+  // Real hand-authored bounds must survive the strip (refinement.fanOut max 10).
+  const schema = generateConfigJsonSchema();
+  assert.equal(schema.properties.refinement.properties.fanOut.maximum, 10);
 });
 
 test("shipped config layers parse under the validator the schema is extracted from", async () => {

--- a/test/contracts/config-schema-generated.test.mjs
+++ b/test/contracts/config-schema-generated.test.mjs
@@ -1,0 +1,51 @@
+// schemas/dev-loop-config.schema.json is a derived artifact extracted from the
+// authoritative zod validator (FileConfigSchema in @dev-loops/core/config) by
+// scripts/generate-config-schema.mjs. These contracts keep it from drifting:
+// the checked-in file must match a fresh extraction, its top-level surface must
+// mirror the zod schema's shape exactly, and the config layers shipped in this
+// repo must actually parse under the validator the schema was extracted from.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { parse as parseYaml } from "yaml";
+import { FileConfigSchema } from "@dev-loops/core/config";
+import { renderConfigJsonSchema } from "../../scripts/generate-config-schema.mjs";
+
+const schemaFileUrl = new URL("../../schemas/dev-loop-config.schema.json", import.meta.url);
+
+test("checked-in JSON schema matches a fresh extraction from the zod validator", async () => {
+  const checkedIn = await readFile(schemaFileUrl, "utf8");
+  assert.equal(
+    checkedIn,
+    renderConfigJsonSchema(),
+    "schemas/dev-loop-config.schema.json is stale — regenerate with `node scripts/generate-config-schema.mjs`"
+  );
+});
+
+test("JSON schema top-level surface mirrors FileConfigSchema exactly", async () => {
+  const jsonSchema = JSON.parse(await readFile(schemaFileUrl, "utf8"));
+  assert.deepEqual(
+    Object.keys(jsonSchema.properties).sort(),
+    Object.keys(FileConfigSchema.shape).sort()
+  );
+  assert.equal(jsonSchema.additionalProperties, false);
+  assert.deepEqual(jsonSchema.required, ["version"]);
+  assert.deepEqual(jsonSchema.properties.version, { type: "number", const: 1 });
+});
+
+test("shipped config layers parse under the validator the schema is extracted from", async () => {
+  const layers = [
+    new URL("../../packages/core/src/config/extension-defaults.yaml", import.meta.url),
+    new URL("../../.devloops", import.meta.url),
+  ];
+  for (const url of layers) {
+    const parsed = parseYaml(await readFile(url, "utf8"));
+    const result = FileConfigSchema.safeParse(parsed);
+    assert.ok(
+      result.success,
+      `${url.pathname} failed FileConfigSchema: ${result.error?.issues
+        .map((i) => `${i.path.join(".")}: ${i.message}`)
+        .join("; ")}`
+    );
+  }
+});

--- a/test/contracts/jq-output-base-guarantee-contract.test.mjs
+++ b/test/contracts/jq-output-base-guarantee-contract.test.mjs
@@ -95,6 +95,14 @@ const EXCLUDED = new Map([
     "github/create-pr.mjs",
     "Thin passthrough wrapper around `gh pr create`; its stdout IS gh's own PR URL, never a JSON tool-result to filter with --jq. The optional trailing board-enqueue line is an advisory side note appended for the issue-less lightweight path, not the command's queryable output.",
   ],
+  [
+    "generate-config-schema.mjs",
+    "Derived-artifact generator (npm run schema:generate/schema:check): JSON.stringify writes schemas/dev-loop-config.schema.json to disk; stdout is a one-line human status, never a JSON tool-result to filter with --jq — same class as claude/generate-claude-assets.mjs.",
+  ],
+  [
+    "pages/render-article.mjs",
+    "Derived-artifact generator (npm run articles:render/articles:check): emits HTML files; JSON.stringify appears only inside thrown error messages, and stdout is a one-line human status — nothing for a caller to filter with --jq.",
+  ],
 ]);
 
 async function walk(dir) {

--- a/test/pages/article-render.test.mjs
+++ b/test/pages/article-render.test.mjs
@@ -1,0 +1,62 @@
+// docs/articles HTML twins listed in RENDERED_ARTICLES are derived artifacts:
+// scripts/pages/render-article.mjs renders them from their markdown source.
+// These contracts keep the pair from drifting the way the hand-synced twins
+// did (stale command syntax, an invalid config example nobody re-checked):
+// the checked-in HTML must match a fresh render, and the rendered page must
+// keep the structural anchors build-site.mjs's nav injection and the
+// Playwright fit harness rely on.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { RENDERED_ARTICLES, renderArticleHtml } from "../../scripts/pages/render-article.mjs";
+
+const articlesUrl = new URL("../../docs/articles/", import.meta.url);
+const shellUrl = new URL("../../scripts/pages/article-shell.html", import.meta.url);
+
+async function freshRender({ md }) {
+  const shell = await readFile(shellUrl, "utf8");
+  const mdSource = await readFile(new URL(md, articlesUrl), "utf8");
+  return renderArticleHtml(mdSource.replace(/^---\n/, `---\nsourceBasename: ${md}\n`), shell);
+}
+
+for (const article of RENDERED_ARTICLES) {
+  test(`docs/articles/${article.html} matches a fresh render of ${article.md}`, async () => {
+    const checkedIn = await readFile(new URL(article.html, articlesUrl), "utf8");
+    assert.equal(
+      checkedIn,
+      await freshRender(article),
+      `docs/articles/${article.html} is stale — regenerate with \`node scripts/pages/render-article.mjs\``
+    );
+  });
+
+  test(`rendered ${article.html} keeps the anchors nav injection and CSP depend on`, async () => {
+    const html = await freshRender(article);
+    // injectNav (build-site.mjs) throws without these two anchors.
+    assert.ok(html.includes("</style>"), "missing </style> anchor for nav CSS injection");
+    assert.match(html, /<body[^>]*>/, "missing <body> anchor for nav markup injection");
+    // The injected nav CSS styles itself with these article design tokens.
+    for (const token of ["--heading", "--kicker", "--accent-soft"]) {
+      assert.ok(html.includes(token), `missing design token ${token} the nav CSS uses`);
+    }
+    // The fit harness asserts a locked CSP <meta> on every article page.
+    assert.ok(
+      html.includes('http-equiv="Content-Security-Policy"'),
+      "missing Content-Security-Policy meta"
+    );
+    // Derived artifacts carry the do-not-edit provenance marker.
+    assert.ok(html.includes("GENERATED from docs/articles/"), "missing GENERATED marker");
+  });
+}
+
+test("in-page anchors written in the markdown resolve in the rendered HTML", async () => {
+  for (const article of RENDERED_ARTICLES) {
+    const mdSource = await readFile(new URL(article.md, articlesUrl), "utf8");
+    const html = await freshRender(article);
+    for (const [, anchor] of mdSource.matchAll(/\]\(#([^)]+)\)/g)) {
+      assert.ok(
+        html.includes(`id="${anchor}"`),
+        `markdown links to #${anchor} but the rendered HTML has no such id`
+      );
+    }
+  }
+});

--- a/test/pages/article-render.test.mjs
+++ b/test/pages/article-render.test.mjs
@@ -83,6 +83,8 @@ test("renderer fails closed on unsupported markdown constructs", () => {
     "```text\nunterminated fence",
     "<!-- not-a-metrics-marker -->",
     "<!-- metrics -->\n- **1** item",
+    "<!-- metrics:start -->\n- **1** unterminated block",
+    "## ¿¿¿\n\nempty slug heading",
   ]) {
     assert.throws(() => render(body), `should throw for: ${JSON.stringify(body)}`);
   }

--- a/test/pages/article-render.test.mjs
+++ b/test/pages/article-render.test.mjs
@@ -16,7 +16,7 @@ const shellUrl = new URL("../../scripts/pages/article-shell.html", import.meta.u
 async function freshRender({ md }) {
   const shell = await readFile(shellUrl, "utf8");
   const mdSource = await readFile(new URL(md, articlesUrl), "utf8");
-  return renderArticleHtml(mdSource.replace(/^---\n/, `---\nsourceBasename: ${md}\n`), shell);
+  return renderArticleHtml(mdSource, shell, md);
 }
 
 for (const article of RENDERED_ARTICLES) {
@@ -59,4 +59,69 @@ test("in-page anchors written in the markdown resolve in the rendered HTML", asy
       );
     }
   }
+});
+
+// ---------------------------------------------------------------------------
+// Behavior units. The drift test above compares two outputs of the same code,
+// so it cannot catch the renderer itself regressing; these pin the promised
+// behaviors directly against synthetic inputs.
+// ---------------------------------------------------------------------------
+
+const MIN_SHELL = "<title>{{TITLE}}</title>\n{{GENERATED}}\n<style></style>\n";
+
+function doc(body, { title = "T", heroLede = "L" } = {}) {
+  return `---\ntitle: "${title}"\nheroLede: "${heroLede}"\n---\n\n# ${title}\n\n${body}\n`;
+}
+
+const render = (body, fm) => renderArticleHtml(doc(body, fm), MIN_SHELL, "t.md");
+
+test("renderer fails closed on unsupported markdown constructs", () => {
+  for (const body of [
+    "> a blockquote",
+    "| a | b |",
+    "  indented block start",
+    "```text\nunterminated fence",
+  ]) {
+    assert.throws(() => render(body), `should throw for: ${JSON.stringify(body)}`);
+  }
+  assert.throws(() => renderArticleHtml("# no frontmatter\n\ntext\n", MIN_SHELL, "t.md"));
+  assert.throws(() => renderArticleHtml('---\ntitle: "T"\n---\n\n# T\n\ntext\n', MIN_SHELL, "t.md"), /heroLede/);
+  assert.throws(() => renderArticleHtml(doc("text"), MIN_SHELL, ""), /sourceBasename/);
+  assert.throws(() => renderArticleHtml('---\ntitle: "T"\nheroLede: "L"\n---\n\n# Other\n\ntext\n', MIN_SHELL, "t.md"), /h1 matching/);
+  assert.throws(() => render("## Same\n\na\n\n## Same\n\nb"), /duplicate h2 slug/);
+});
+
+test("relative .md links rewrite to .html; absolute and anchor links pass through", () => {
+  const html = render(
+    "See [a](./x.md), [b](../y.md#frag), [c](https://example.com/z.md), and [d](#the-end).\n\n## The end\n\nfin"
+  );
+  assert.ok(html.includes('href="./x.html"'), "./x.md should rewrite");
+  assert.ok(html.includes('href="../y.html#frag"'), "../y.md#frag should rewrite keeping the fragment");
+  assert.ok(html.includes('href="https://example.com/z.md"'), "absolute URLs must not rewrite");
+  assert.ok(html.includes('href="#the-end"'), "in-page anchors must pass through");
+});
+
+test("metrics-marked lists render as .metric cards and reject malformed items", () => {
+  const html = render("<!-- metrics:start -->\n- **42** things counted\n- **~7/day** of pace\n<!-- metrics:end -->");
+  assert.ok(html.includes('<div class="num">42</div>'));
+  assert.ok(html.includes('<div class="lab">things counted</div>'));
+  assert.ok(html.includes('<div class="num">~7/day</div>'));
+  assert.throws(() => render("<!-- metrics:start -->\n- no bold prefix\n<!-- metrics:end -->"), /metrics item/);
+});
+
+test("code-fence # comments get .cm spans; non-comment # stays plain", () => {
+  const html = render("```text\nrun me   # trailing note\n# full-line note\nvalue a#b stays\n```");
+  assert.ok(html.includes('<span class="cm"># trailing note</span>'));
+  assert.ok(html.includes('<span class="cm"># full-line note</span>'));
+  assert.ok(html.includes("value a#b stays"), "a#b must not be treated as a comment");
+  assert.equal(html.match(/class="cm"/g).length, 2);
+});
+
+test("generated page carries slug ids, hero fields, and the provenance marker", () => {
+  const html = render("intro para\n\n## First Section\n\nbody\n\n## Keep going\n\nout", { title: "My Page", heroLede: "The lede." });
+  assert.ok(html.includes("<title>My Page</title>"));
+  assert.ok(html.includes('<p class="lede">The lede.</p>'));
+  assert.ok(html.includes('<h2 id="first-section">'));
+  assert.ok(html.includes('<section class="deeper">'), "last h2 section becomes the deeper outro");
+  assert.ok(html.includes("GENERATED from docs/articles/t.md"));
 });

--- a/test/pages/article-render.test.mjs
+++ b/test/pages/article-render.test.mjs
@@ -81,6 +81,8 @@ test("renderer fails closed on unsupported markdown constructs", () => {
     "| a | b |",
     "  indented block start",
     "```text\nunterminated fence",
+    "<!-- not-a-metrics-marker -->",
+    "<!-- metrics -->\n- **1** item",
   ]) {
     assert.throws(() => render(body), `should throw for: ${JSON.stringify(body)}`);
   }
@@ -99,6 +101,13 @@ test("relative .md links rewrite to .html; absolute and anchor links pass throug
   assert.ok(html.includes('href="../y.html#frag"'), "../y.md#frag should rewrite keeping the fragment");
   assert.ok(html.includes('href="https://example.com/z.md"'), "absolute URLs must not rewrite");
   assert.ok(html.includes('href="#the-end"'), "in-page anchors must pass through");
+});
+
+test("quotes in link targets and text are attribute-safe", () => {
+  const html = render('A [q](./a"b.md) link and a "quoted" word.');
+  assert.ok(html.includes('href="./a&quot;b.html"'), "quote in href must be escaped");
+  assert.ok(!html.includes('href="./a"b'), "raw quote must not break out of the attribute");
+  assert.ok(html.includes("&quot;quoted&quot;"));
 });
 
 test("metrics-marked lists render as .metric cards and reject malformed items", () => {


### PR DESCRIPTION
## Summary

Two hand-maintained artifacts had drifted from their sources of truth, and this PR turns both into derived artifacts with generators and drift tests:

1. **Config JSON schema**: `schemas/dev-loop-config.schema.json` was a partial, unreferenced hand-written document (missing `inputSource`, `models.tiers`/`roleTiers`, `queue`, `uiReview`, `localImplementation`, `internalPathPatterns`, and several `gates.*`/`refinement.*`/`workflow.*` knobs). It is now mechanically extracted from `FileConfigSchema` — the zod validator `applyLayer` runs on every config layer — via `z.toJSONSchema()`, covering the full file-level surface.
2. **Intro article**: `docs/articles/introducing-dev-loops.md` carried a dead command syntax (`/dev-loops:start` — the shipped surface is `/loop-start` / `/dev-loops start`), a `.devloops` example that failed schema validation (missing `version: 1`), and stale/unverifiable evidence claims. The article is rebuilt with every claim verified against shipped code and git history, the A/B-contrast deslop step applied, and its HTML twin is now rendered from the markdown by a fail-closed generator instead of being hand-synced.

A local five-angle gate-style review (correctness, coverage, simplicity, docs/config drift, acceptance + fact grounding) ran over the full diff; all must-fix and worth-fixing-now findings are applied in the final commit.

## Scope / context

In scope: the schema generator + regenerated schema + contract tests; the article renderer + shell + regenerated article twins + contract/behavior tests; README stability-section correction; npm script wiring; build-site comment correction.

Out of scope: runtime/config behavior (no change to the loader or defaults), the deep-dive article (stays hand-maintained until migrated to the renderer).

## Linked issue

None — local-first change; this PR body is the spec of record.

## Changes

| File | Change |
|------|--------|
| `scripts/generate-config-schema.mjs` | New: extracts the JSON schema from `FileConfigSchema` via `z.toJSONSchema()`; strips JS safe-integer sentinels; `--check` staleness mode. |
| `schemas/dev-loop-config.schema.json` | Regenerated: full file-level surface, self-describing as a generated artifact. |
| `test/contracts/config-schema-generated.test.mjs` | New: drift guard (file == fresh extraction), top-level surface mirror vs `FileConfigSchema.shape`, shipped-layer parse check, sentinel-strip unit. |
| `scripts/pages/render-article.mjs` | New: fail-closed markdown→HTML article renderer (throws on unsupported constructs, duplicate h2 slugs, malformed metrics); `--check` mode. |
| `scripts/pages/article-shell.html` | New: shared head/design-system template (CSP meta + tokens the nav injection uses). |
| `docs/articles/introducing-dev-loops.md` | Rebuilt fact-grounded content; deslop pass; renderer frontmatter (`heroLede`) and metrics markers. |
| `docs/articles/introducing-dev-loops.html` | Now GENERATED from the markdown (marker in file). |
| `test/pages/article-render.test.mjs` | New: drift guard, nav/CSP anchor contract, in-page anchor resolution, plus behavior units (fail-closed throws, link rewrite, metrics cards, `.cm` spans, slugs/provenance). |
| `scripts/pages/build-site.mjs` | Comment updated: rendered articles are derived from markdown; the rest stay hand-maintained. |
| `README.md` | Stability section: schema is generated and full-surface (was "a partial reference"). |
| `package.json` | New scripts: `schema:generate`, `schema:check`, `articles:render`, `articles:check`. |

## Acceptance criteria

- [x] The JSON schema is generated from the authoritative zod validator and its top-level surface mirrors `FileConfigSchema` exactly (contract-tested).
- [x] Every config file layer the loader validates still parses (`extension-defaults.yaml`, repo `.devloops` — contract-tested).
- [x] The article HTML twin is byte-identical to a fresh render of the markdown (contract-tested), keeps the CSP meta and nav-injection anchors, and carries a GENERATED marker.
- [x] Every command, config key, and number in the article verifies against shipped code / git history; the `.devloops` example parses under `FileConfigSchema`.
- [x] The renderer fails closed on unsupported markdown (behavior-tested).
- [x] A/B-contrast deslop step applied to the article (two independent scans + rhythm pass).

## Definition of done

- [x] `test:docs`, `test/pages` (11), `test/contracts/config-schema-generated` (4), `test:extension`, `test:pack` green locally.
- [x] Mobile fit (390×844, no horizontal scroll) verified in Chromium; WebKit Playwright slice needs CI (no WebKit in the dev container).
- [x] Both `--check` scripts exit clean on the checked-in artifacts.

## Non-goals

- Migrating `dev-loops-deep-dive.md`/`.html` to the renderer (registry holds one entry; follow-up).
- Testing the `--check` CLI exit codes via child process (in-process drift tests cover the semantics).
- Adding `.describe()` prose to the zod validator so field descriptions flow into the generated schema (follow-up).

## AC/DoD/Non-goals matrix

| Item | Type (AC/DoD/Non-goal) | Status (Met/Partial/Unmet/Unverified) | Evidence | Notes |
|---|---|---|---|---|
| Schema generated from zod validator, full surface mirror | AC | Met | `test/contracts/config-schema-generated.test.mjs` | |
| Shipped config layers parse | AC | Met | same test file | |
| Article HTML == fresh render + CSP/nav anchors + marker | AC | Met | `test/pages/article-render.test.mjs` | |
| Article facts verified against code/history | AC | Met | commands vs README/`commands/*.command.md`; keys vs `config.mjs`; numbers vs `git log` (anchored "as of mid-July 2026") | |
| Renderer fails closed | AC | Met | behavior units in `article-render.test.mjs` | |
| Deslop step applied | AC | Met | 11 rewrites; residual scan clean | |
| Local test suites green | DoD | Met | see Validation | pre-existing bash-gate e2e failures reproduce on base |
| Mobile fit | DoD | Partial | Chromium verified; WebKit needs CI | |
| Deep-dive migration | Non-goal | — | | tracked follow-up |

## Validation

```
npm run schema:check && npm run articles:check
node --test test/pages/*.test.mjs test/contracts/config-schema-generated.test.mjs
npm run -s test:docs
npm run test:playwright:intro-article   # CI / machine with WebKit
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2dERwcTUAeiTUPNgsXC4n

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2dERwcTUAeiTUPNgsXC4n)_