### PR TITLE
docs(deck): fact-ground and deslop the intro deck

### DIFF
--- a/docs/presentations/introducing-dev-loops.html
+++ b/docs/presentations/introducing-dev-loops.html
@@ -254,7 +254,7 @@
       <div class="glass-card">
         <ul class="tight-list">
           <li>Code generation is fast now, so most of an AI-assisted workflow's time sits in the coordination around the code.</li>
-          <li>Someone notices a change is ready, rebuilds context to review it, checks the tests ran, decides the next step is safe.</li>
+          <li>Someone notices a change is ready, rebuilds context to review it, checks that the tests ran, decides the next step is safe.</li>
           <li>Each of those is a small wait, and together the waits make up most of the lead time.</li>
         </ul>
       </div>

--- a/docs/presentations/introducing-dev-loops.html
+++ b/docs/presentations/introducing-dev-loops.html
@@ -253,9 +253,9 @@
     <div class="grid grid-2">
       <div class="glass-card">
         <ul class="tight-list">
-          <li>AI writes the code in seconds, so the expensive part of the work moved.</li>
-          <li>It now sits in the coordination around the code: the wait for someone to notice a change is ready, to rebuild context to review it, to decide the next step is safe.</li>
-          <li>That waiting between actions is where the lead time of an AI-assisted workflow goes once the typing is fast.</li>
+          <li>Code generation is fast now, so most of an AI-assisted workflow's time sits in the coordination around the code.</li>
+          <li>Someone notices a change is ready, rebuilds context to review it, checks the tests ran, decides the next step is safe.</li>
+          <li>Each of those is a small wait, and together the waits make up most of the lead time.</li>
         </ul>
       </div>
       <div class="glass-card flow-card">
@@ -316,7 +316,7 @@
         <p class="card-label">Pull, like a Kanban board</p>
         <ul class="mini-list">
           <li>The system computes the next action; whoever is free pulls it from the visible state.</li>
-          <li>Every change still runs the same draft, review, and green-CI path, including the changes that built dev-loops itself.</li>
+          <li>Every change runs the same draft, review, and green-CI path — the changes that build dev-loops itself run it too.</li>
         </ul>
       </div>
       <div class="glass-card">
@@ -389,7 +389,7 @@
         </ul>
       </div>
     </div>
-    <p class="card-label">Run end to end on top-tier open-source models: DeepSeek V4, Kimi K2.6, MiniMax M3, Qwen 3.6, GLM 5.2.</p>
+    <p class="card-label">Model routing is configuration: roles map to tiers, tiers map per harness to concrete models — routine work on the cheap tier, planning and review on the strong one, swappable with a config edit.</p>
   </div>
 </section>
 
@@ -399,19 +399,19 @@
     <h2>A Cadence That Holds</h2>
     <div class="grid grid-3">
       <div class="metric-card">
-        <p class="metric-figure">87</p>
-        <p class="metric-label">pull requests merged in four days — roughly 22 a day.</p>
+        <p class="metric-figure">530+</p>
+        <p class="metric-label">pull requests merged in the project's first nine weeks.</p>
       </div>
       <div class="metric-card">
-        <p class="metric-figure">36</p>
-        <p class="metric-label">tracked issues closed and shipped in that same window.</p>
+        <p class="metric-figure">~10/day</p>
+        <p class="metric-label">across the most recent two weeks.</p>
       </div>
       <div class="metric-card">
-        <p class="metric-figure">2</p>
-        <p class="metric-label">full releases (v0.4.0 + v0.5.0) cut to npm. Every PR: full gate.</p>
+        <p class="metric-figure">24</p>
+        <p class="metric-label">releases tagged in the same stretch, through a 1.0 release candidate.</p>
       </div>
     </div>
-    <p class="soft-note">The cadence held because the extra work landed as machine transitions, with the human's part staying that one bounded decision at the merge.</p>
+    <p class="soft-note">Straight from the repository's git log, as of mid-July 2026. The cadence holds because the transitions land as machine decisions, with the human's part staying that one bounded call at the merge.</p>
   </div>
 </section>
 
@@ -427,24 +427,24 @@
           <span class="pill">/plugin marketplace add mfittko/dev-loops</span>
           <span class="pill">/plugin install dev-loops@dev-loops</span>
         </div>
-        <p class="soft-note note-top-md">Pi:</p>
+        <p class="soft-note note-top-md">Pi, pinned to a version:</p>
         <div class="chip-row note-top-sm">
-          <span class="pill">pi install npm:dev-loops</span>
+          <span class="pill">pi install npm:dev-loops@&lt;version&gt;</span>
         </div>
-        <p class="soft-note note-top-md">Run a loop with a direct command (Claude Code; in Pi drop the colon: <code>/dev-loops start …</code>):</p>
+        <p class="soft-note note-top-md">Run a loop with a direct command (Claude Code; on Pi the same set hangs off one command: <code>/dev-loops start …</code>):</p>
         <div class="chip-row note-top-sm">
-          <span class="pill">/dev-loops:start 112</span>
-          <span class="pill">/dev-loops:auto 112</span>
-          <span class="pill">/dev-loops:continue 112</span>
-          <span class="pill">/dev-loops:continue</span>
-          <span class="pill">/dev-loops:start-spike "…"</span>
+          <span class="pill">/loop-start 112</span>
+          <span class="pill">/loop-auto 112</span>
+          <span class="pill">/loop-continue 112</span>
+          <span class="pill">/loop-continue</span>
+          <span class="pill">/loop-start-spike "…"</span>
         </div>
-        <p class="soft-note note-top-sm">Read state, never start work:</p>
+        <p class="soft-note note-top-sm">Read-only state commands:</p>
         <div class="chip-row note-top-sm">
-          <span class="pill">/dev-loops:info 112</span>
-          <span class="pill">/dev-loops:status</span>
+          <span class="pill">/loop-info 112</span>
+          <span class="pill">/loop-status</span>
         </div>
-        <p class="soft-note note-top-sm"><code>/dev-loops:dev-loop</code> is the catch-all router for plain-language intent. You never pick internal modes.</p>
+        <p class="soft-note note-top-sm">Plain language works too — <code>start dev loop on issue 112</code> routes through the same deterministic router; the loop selects its internal strategy itself.</p>
       </div>
       <div class="glass-card">
         <p class="card-label">Three choices shape the posture</p>


### PR DESCRIPTION
Closes #1354. Part of the fact-grounded rebuild sweep (#1352).

## Summary

Grounding pass over `docs/presentations/introducing-dev-loops.html`: every command, config key, and evidence figure re-verified against the shipped surface and git history, plus the A/B-contrast deslop step with an independent verification pass.

## Scope and context

One file: `docs/presentations/introducing-dev-loops.html`. Prose and command-pill text only — no visual-system, slide-structure, CSP-meta, or section-id changes.

- **Evidence slide re-derived from git history, date-anchored** ("as of mid-July 2026"): 530+ PRs merged in the project's first nine weeks (543 in the log today; repo starts 2026-05-12), ~10/day across the most recent two weeks (141 in 14 days), 24 tagged releases through v1.0.0-rc.1. Replaces the stale 87-PRs/four-days, 36-issues, v0.4.0+v0.5.0 figures.
- **Command pills match the shipped surface**: `/loop-start`, `/loop-auto`, `/loop-continue`, `/loop-start-spike`, `/loop-info`, `/loop-status` (all exist under `.claude/commands/`), with the Pi form `/dev-loops start …` matching the README command table. Removes the nonexistent `/dev-loops:*` syntax. Pi install pinned to a version.
- **Config-verifiable claims only**: the unverifiable open-source-model name-drop is replaced with the tier-routing claim, which verifies against `models.roleTiers`/`models.tiers` in `packages/core/src/config/config.mjs`. The "Three choices" keys (`strategy.default`, `refinement.maxCopilotRounds` with "0 disables", `autonomy.humanMergeOnly`) all verify against `FileConfigSchema`. The deck contains no `.devloops` snippet.
- **A/B-contrast deslop applied** per `docs/ab-contrast-deslop-step.md`, with an independent verification pass over the full deck text (headlines included) confirming no remaining instances.

## Acceptance criteria, definition of done & non-goals

From #1354, each criterion independently verified at head. The definition of done applies to all criteria: merged through the full loop (gates, Copilot, green CI) with `deck-smoke`/fit slices green — merge is the pending human decision at this head.

| Acceptance criterion | Definition of done | Non-goal |
| --- | --- | --- |
| Every command shown matches the shipped surface (`/loop-start` etc. on Claude Code; `/dev-loops start` etc. on Pi) | Merged through the full loop (gates, Copilot, green CI); `deck-smoke`/fit slices green | Redesigning the deck's visual system or slide structure |
| Every config key/default claim verifies against `packages/core/src/config/config.mjs`; no `.devloops` snippet | ″ | Converting the deck to a generated artifact |
| Evidence figures re-derived from git history, date-anchored ("as of mid-July 2026"; "530+", "~10/day") | ″ | |
| A/B-contrast deslop applied with an independent verification pass; slide headlines included | ″ | |
| Deck-fit harness slice (`test:playwright:intro-deck`) green in CI; CSP meta + named section states unchanged | ″ | |

## Validation

- `npm run verify` — green (2806 tests, 0 fail)
- `npm run test:playwright:intro-deck` — 4/4 passed (WebKit render + named states, mobile fit, deliberately-wide negative case, keyboard navigation)
- PR CI green at head e669c446


