### PR TITLE
fix(gate-context): make --angles optional; CLI resolves angles dynamically

### DIFF
--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -1132,6 +1132,11 @@ export async function main(argv = process.argv.slice(2), { repoRoot = process.cw
       const configKey = mapGateToConfigKey(options.gate);
       const resolverResult = await resolveGateAnglesDynamic(config, configKey, { diff });
       const { resolvedAngles, rationale } = rationaleFromResolver(resolverResult);
+      if (resolvedAngles.length === 0) {
+        process.stderr.write(
+          `[write-gate-context] warning: dynamic angle resolution produced zero angles for gate ${options.gate}; the gate-context bundle carries no review angles. Check the gate's configured angles/mandatoryAngles.\n`,
+        );
+      }
       options.angles = resolvedAngles;
       if (options.rationale.length === 0) options.rationale = rationale;
     }

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -1113,7 +1113,22 @@ export async function main(argv = process.argv.slice(2), { repoRoot = process.cw
     // falls back to the static configured pool otherwise. When --angles IS
     // supplied, it is a verbatim override (dynamic resolution bypassed).
     if (!Array.isArray(options.angles)) {
-      const { config } = await loadDevLoopConfig({ repoRoot });
+      // loadDevLoopConfig never throws: it returns { config, warnings, errors }, and
+      // on a validation error it still returns `config` with every layer merged (its
+      // own documented fallback). buildGateContext — the programmatic API this CLI
+      // mirrors — never calls loadDevLoopConfig itself (callers hand it a config), so
+      // there is no separate fail-closed/null-out behavior to match there; the gap is
+      // purely a missing signal. Mirror post-gate-findings.mjs's stderr warning so a
+      // malformed .devloops is never silently swallowed, then proceed with that same
+      // merged fallback config — nulling it out here (unlike post-gate-findings.mjs's
+      // boolean-flag default) would replace a partially-valid configured angle set
+      // with an EMPTY one, a worse regression than the signal gap this fixes.
+      const { config, errors: configErrors } = await loadDevLoopConfig({ repoRoot });
+      if (Array.isArray(configErrors) && configErrors.length > 0) {
+        process.stderr.write(
+          `[write-gate-context] warning: dev-loop config could not be fully loaded/validated; resolving angles from the merged fallback config. errors=${JSON.stringify(configErrors)}\n`,
+        );
+      }
       const configKey = mapGateToConfigKey(options.gate);
       const resolverResult = await resolveGateAnglesDynamic(config, configKey, { diff });
       const { resolvedAngles, rationale } = rationaleFromResolver(resolverResult);

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -1138,7 +1138,16 @@ export async function main(argv = process.argv.slice(2), { repoRoot = process.cw
         );
       }
       options.angles = resolvedAngles;
-      if (options.rationale.length === 0) options.rationale = rationale;
+      // Resolver-derived rationale is authoritative here: a caller cannot supply
+      // meaningful rationale for angles it did not name (angles were just
+      // resolved dynamically above), so any --rationale the caller passed is
+      // ignored rather than persisted as a stale mismatch.
+      if (options.rationale.length > 0) {
+        process.stderr.write(
+          "[write-gate-context] warning: --rationale was supplied without --angles; ignoring it in favor of the dynamically-resolved rationale.\n",
+        );
+      }
+      options.rationale = rationale;
     }
     const result = await writeGateContext(options, { repoRoot });
     process.exitCode = emitResult(result, { jq: options.jq, silent: options.silent });

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -34,7 +34,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { parseArgs } from "node:util";
 
-import { resolveGateAnglesDynamic } from "@dev-loops/core/config";
+import { loadDevLoopConfig, resolveGateAnglesDynamic } from "@dev-loops/core/config";
 
 import { parsePrNumber, requireTokenValue } from "../_cli-primitives.mjs";
 import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
@@ -106,15 +106,15 @@ export function rationaleFromResolver(resolverResult) {
   return { resolvedAngles: [...recommended], rationale };
 }
 
-const USAGE = `Usage: write-gate-context.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate> --head-sha <sha> --angles <json> [--rationale <json>] [--branch <name>] [--touched-files <json>] [--base <ref>] [--acceptance-criteria <pointer>] [--validation-posture <text>] [--tmp-root <path>]
+const USAGE = `Usage: write-gate-context.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate> --head-sha <sha> [--angles <json>] [--rationale <json>] [--branch <name>] [--touched-files <json>] [--base <ref>] [--acceptance-criteria <pointer>] [--validation-posture <text>] [--tmp-root <path>]
 Write a deterministic gate-review context-builder handoff artifact under tmp/ paths.
 Required:
   --repo <owner/name>
   --pr <number>
   --gate <draft_gate|pre_approval_gate>
   --head-sha <sha>
-  --angles <json>                JSON array of resolved review-angle name strings
 Optional:
+  --angles <json>               JSON array of review-angle name strings. OPTIONAL: when omitted, angles resolve dynamically from the loaded config (.devloops) + the --base diff via resolveGateAnglesDynamic (the same path buildGateContext uses). When supplied, the list is used VERBATIM as an explicit override (dynamic resolution is bypassed) — an escape hatch for forcing a specific angle set.
   --rationale <json>             JSON array of {angle, action, reason} entries
   --branch <name>                Source branch name
   --touched-files <json>         JSON array of changed file path strings (separate from the diff-derived scope.changedFiles)
@@ -338,7 +338,7 @@ export function parseWriteGateContextCliArgs(argv) {
     if (matchJqOutputToken(token, options, (t) => requireTokenValue(t, parseError))) continue;
     throw parseError(`Unknown argument: ${token.rawName}`);
   }
-  const missing = ["repo", "pr", "gate", "headSha", "angles"]
+  const missing = ["repo", "pr", "gate", "headSha"]
     .filter((k) => options[k] === undefined);
   if (missing.length > 0) {
     throw parseError(`Missing required arguments: ${missing.join(", ")}`);
@@ -1075,13 +1075,14 @@ export async function main(argv = process.argv.slice(2), { repoRoot = process.cw
     // full bundle. A run WITH --base that then fails to resolve (bad ref, not a
     // git repo, etc.) DOES fail closed: the caller opted into the full bundle,
     // so a silent thin degrade there would be a worse surprise than an error.
+    let diff = null;
     if (options.base) {
       // Fail-closed precondition: the diff is resolved FROM the CWD worktree, so
       // enforce that CWD is this PR's worktree at --head-sha before diffing.
       // Otherwise a stale CWD silently yields the wrong diff (caught only after
       // fan-out today). Throws → caught below → exit 1, no artifact written.
       assertWorktreeAtHead(options.headSha, { repoRoot });
-      const diff = captureDiffFromBase(options.base, { repoRoot });
+      diff = captureDiffFromBase(options.base, { repoRoot });
       const scope = await resolveDiffScope(
         { diff, repo: options.repo, pr: options.pr, gate: options.gate, headSha: options.headSha, tmpRoot: options.tmpRoot || "tmp" },
         { repoRoot },
@@ -1103,6 +1104,21 @@ export async function main(argv = process.argv.slice(2), { repoRoot = process.cw
     } else {
       process.stderr.write("[write-gate-context] warning: no --base given; emitting a THIN briefing (scope.diffPath=null, scope.changedFiles=[], no adjacentCode). Pass --base <ref> for the full build-once bundle.\n");
       options.diffSource = "none";
+    }
+    // Angle resolution: when --angles is omitted, resolve dynamically from the
+    // loaded config (.devloops) + the captured --base diff — the SAME path the
+    // programmatic buildGateContext API uses (resolveGateAnglesDynamic). This
+    // keeps the CLI consistent with the API: dynamicAngles trims to the
+    // mandatory floor + diff-selected candidates when a diff is present, and
+    // falls back to the static configured pool otherwise. When --angles IS
+    // supplied, it is a verbatim override (dynamic resolution bypassed).
+    if (!Array.isArray(options.angles)) {
+      const { config } = await loadDevLoopConfig({ repoRoot });
+      const configKey = mapGateToConfigKey(options.gate);
+      const resolverResult = await resolveGateAnglesDynamic(config, configKey, { diff });
+      const { resolvedAngles, rationale } = rationaleFromResolver(resolverResult);
+      options.angles = resolvedAngles;
+      if (options.rationale.length === 0) options.rationale = rationale;
     }
     const result = await writeGateContext(options, { repoRoot });
     process.exitCode = emitResult(result, { jq: options.jq, silent: options.silent });

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -1134,7 +1134,7 @@ export async function main(argv = process.argv.slice(2), { repoRoot = process.cw
       const { resolvedAngles, rationale } = rationaleFromResolver(resolverResult);
       if (resolvedAngles.length === 0) {
         process.stderr.write(
-          `[write-gate-context] warning: dynamic angle resolution produced zero angles for gate ${options.gate}; the gate-context bundle carries no review angles. Check the gate's configured angles/mandatoryAngles.\n`,
+          `[write-gate-context] warning: angle resolution produced zero angles for gate ${options.gate}; the gate-context bundle carries no review angles. Check the gate's configured angles/mandatoryAngles.\n`,
         );
       }
       options.angles = resolvedAngles;
@@ -1144,7 +1144,7 @@ export async function main(argv = process.argv.slice(2), { repoRoot = process.cw
       // ignored rather than persisted as a stale mismatch.
       if (options.rationale.length > 0) {
         process.stderr.write(
-          "[write-gate-context] warning: --rationale was supplied without --angles; ignoring it in favor of the dynamically-resolved rationale.\n",
+          "[write-gate-context] warning: --rationale was supplied without --angles; ignoring it in favor of the resolver-derived rationale (angles were resolved from config rather than supplied via --angles).\n",
         );
       }
       options.rationale = rationale;

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -1196,6 +1196,51 @@ test("CLI without --angles + malformed .devloops: warns to stderr and proceeds w
   }
 });
 
+test("CLI without --angles + a gate with no configured angles/mandatoryAngles: warns of zero resolved angles and still writes the artifact (warn-and-proceed, not fail-closed)", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-emptyresolved-"));
+  try {
+    // draft gate explicitly configured with EMPTY angles + mandatoryAngles
+    // (overriding the extension-defaults angle pool): resolveGateAnglesDynamic
+    // resolves an empty recommendedAngles — the hollow gate-evidence path this
+    // warning exists to flag.
+    await writeFile(
+      path.join(repoRoot, ".devloops"),
+      [
+        "version: 1", "gates:", "  draft:",
+        "    angles: []", "    mandatoryAngles: []", "    excludeAngles: []", "    dynamicAngles: false",
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const origErr = process.stderr.write;
+    const stderrChunks = [];
+    process.stderr.write = (chunk) => { stderrChunks.push(String(chunk)); return true; };
+    try {
+      await main([
+        "--repo", "owner/repo", "--pr", "64", "--gate", "draft_gate",
+        "--head-sha", "abc1234567890",
+      ], { repoRoot });
+    } finally {
+      process.stderr.write = origErr;
+    }
+
+    const stderrText = stderrChunks.join("");
+    assert.match(
+      stderrText,
+      /dynamic angle resolution produced zero angles for gate draft_gate/,
+      "warns to stderr when dynamic resolution yields zero angles",
+    );
+
+    const artifact = await readGateContext({
+      repo: "owner/repo", pr: 64, gate: "draft_gate", headSha: "abc1234567890",
+    }, { repoRoot });
+    assert.ok(artifact, "artifact still written despite zero resolved angles (warn-and-proceed)");
+    assert.deepEqual(artifact.resolvedAngles, [], "resolvedAngles is empty, matching the resolver's null->[] mapping");
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
 test("CLI --base <ref> that fails to resolve fails closed (no artifact written, non-zero exit)", async () => {
   const { repoRoot, headSha } = await makeBaseDiffRepo();
   try {

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -126,7 +126,7 @@ async function writeDraftDevLoops(repoRoot, overrides = {}) {
   };
   const lines = ["version: 1", "gates:", "  draft:"];
   lines.push(`    dynamicAngles: ${draft.dynamicAngles}`);
-  lines.push(`    excludeAngles: []`);
+  lines.push(`    excludeAngles: ${JSON.stringify(draft.excludeAngles)}`);
   lines.push("    angles:");
   for (const a of draft.angles) lines.push(`      - ${a}`);
   lines.push("    mandatoryAngles:");
@@ -1151,6 +1151,30 @@ test("CLI without --base and without --angles: static fallback pool + CLI/API pa
       { repoRoot },
     );
     assert.deepEqual(cliArtifact.resolvedAngles, apiResult.artifact.resolvedAngles);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("writeDraftDevLoops honors an excludeAngles override (emitted excludeAngles matches draft, not hard-coded [])", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-exclude-angles-"));
+  try {
+    await writeDraftDevLoops(repoRoot, { excludeAngles: ["coverage"] });
+    await main([
+      "--repo", "owner/repo", "--pr", "63", "--gate", "draft_gate",
+      "--head-sha", "abc1234567890",
+    ], { repoRoot });
+
+    const cliArtifact = await readGateContext({
+      repo: "owner/repo", pr: 63, gate: "draft_gate", headSha: "abc1234567890",
+    }, { repoRoot });
+
+    // diff=null -> static fallback pool. If excludeAngles were still ignored in
+    // the emitted .devloops YAML, "coverage" would leak into resolvedAngles.
+    assert.ok(!cliArtifact.resolvedAngles.includes("coverage"), "excludeAngles override must be honored by the loaded config");
+    assert.deepEqual(cliArtifact.resolvedAngles, [
+      "gate-evidence", "scope", "correctness", "docs", "link-check", "config-drift",
+    ]);
   } finally {
     await rm(repoRoot, { recursive: true, force: true });
   }

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { resolveGateAnglesDynamic } from "@dev-loops/core/config";
+import { loadDevLoopConfig, resolveGateAnglesDynamic } from "@dev-loops/core/config";
 
 import {
   assertWorktreeAtHead,
@@ -90,6 +90,49 @@ const DOCS_ONLY_DIFF = {
   nameStatusOutput: "M\tdocs/foo.md\nM\tREADME.md\n",
   diffOutput: "",
 };
+
+// A git repo fixture whose HEAD diff is DOCS-ONLY (only docs/foo.md changes),
+// so the dynamic classifier drops non-docs candidate angles (e.g. "coverage"),
+// mirroring the synthetic DOCS_ONLY_DIFF above but exercisable through the CLI
+// --base path (which captures the diff from a real `git diff`).
+async function makeDocsOnlyDiffRepo() {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-docs-"));
+  git(repoRoot, ["init", "-q"]);
+  git(repoRoot, ["config", "user.email", "test@example.com"]);
+  git(repoRoot, ["config", "user.name", "Test"]);
+  await mkdir(path.join(repoRoot, "docs"), { recursive: true });
+  await writeFile(path.join(repoRoot, "docs", "foo.md"), "# Old heading\n", "utf8");
+  git(repoRoot, ["add", "-A"]);
+  git(repoRoot, ["commit", "-q", "-m", "base"]);
+  const baseSha = git(repoRoot, ["rev-parse", "HEAD"]).trim();
+  await writeFile(path.join(repoRoot, "docs", "foo.md"), "# New heading\nMore detail.\n", "utf8");
+  git(repoRoot, ["add", "-A"]);
+  git(repoRoot, ["commit", "-q", "-m", "docs only"]);
+  const headSha = git(repoRoot, ["rev-parse", "HEAD"]).trim();
+  return { repoRoot, baseSha, headSha };
+}
+
+// Write a .devloops gate config the CLI's loadDevLoopConfig will pick up. Mirrors
+// draftConfig() but as the on-disk YAML the loader reads, so the CLI path and the
+// programmatic buildGateContext path (which receives the same loaded config) see
+// identical config and must resolve identical angle sets.
+async function writeDraftDevLoops(repoRoot, overrides = {}) {
+  const draft = {
+    angles: ["scope", "coverage", "correctness", "docs", "link-check", "config-drift"],
+    mandatoryAngles: ["gate-evidence"],
+    excludeAngles: [],
+    dynamicAngles: true,
+    ...overrides,
+  };
+  const lines = ["version: 1", "gates:", "  draft:"];
+  lines.push(`    dynamicAngles: ${draft.dynamicAngles}`);
+  lines.push(`    excludeAngles: []`);
+  lines.push("    angles:");
+  for (const a of draft.angles) lines.push(`      - ${a}`);
+  lines.push("    mandatoryAngles:");
+  for (const m of draft.mandatoryAngles) lines.push(`      - ${m}`);
+  await writeFile(path.join(repoRoot, ".devloops"), `${lines.join("\n")}\n`, "utf8");
+}
 
 // ---------------------------------------------------------------------------
 // Path builder
@@ -927,6 +970,122 @@ test("CLI without --base emits an explicit thin-briefing posture, not a silent f
     assert.equal(artifact.scope.diffPath, null);
     assert.deepEqual(artifact.scope.changedFiles, []);
     assert.equal(Object.prototype.hasOwnProperty.call(artifact, "adjacentCode"), false);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("parseWriteGateContextCliArgs: --angles is optional (omitted → undefined, no missing-arg error)", () => {
+  const result = parseWriteGateContextCliArgs([
+    "--repo", "a/b", "--pr", "1", "--gate", "draft_gate", "--head-sha", "abc1234",
+  ]);
+  assert.equal(result.repo, "a/b");
+  assert.equal(result.angles, undefined, "--angles omitted → undefined (resolved dynamically by main)");
+});
+
+test("CLI without --angles resolves angles dynamically (trims for a docs-only diff; keeps the mandatory floor)", async () => {
+  const { repoRoot, baseSha, headSha } = await makeDocsOnlyDiffRepo();
+  try {
+    await writeDraftDevLoops(repoRoot); // dynamicAngles: true
+    await main([
+      "--repo", "owner/repo", "--pr", "50", "--gate", "draft_gate",
+      "--head-sha", headSha, "--base", baseSha,
+    ], { repoRoot });
+
+    const artifact = await readGateContext({
+      repo: "owner/repo", pr: 50, gate: "draft_gate", headSha,
+    }, { repoRoot });
+
+    assert.ok(artifact, "artifact written without --angles");
+    // Mandatory floor survives dynamic selection.
+    assert.ok(artifact.resolvedAngles.includes("gate-evidence"), "mandatory floor kept");
+    // "coverage" is dropped for a docs-only diff (matches the buildGateContext
+    // DOCS_ONLY_DIFF behavior) — proves the dynamic resolver RAN on the CLI path,
+    // not just returned the static pool verbatim.
+    assert.ok(!artifact.resolvedAngles.includes("coverage"), "non-docs candidate trimmed");
+    // Resolved set is a subset of the configured pool + mandatory.
+    for (const a of artifact.resolvedAngles) {
+      assert.ok(
+        ["scope", "coverage", "correctness", "docs", "link-check", "config-drift", "gate-evidence"].includes(a),
+        `resolved angle ${a} is from the pool/mandatory`,
+      );
+    }
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI without --angles matches buildGateContext resolvedAngles (CLI/API parity, dynamicAngles:true)", async () => {
+  const { repoRoot, baseSha, headSha } = await makeBaseDiffRepo();
+  try {
+    await writeDraftDevLoops(repoRoot); // dynamicAngles: true
+    await main([
+      "--repo", "owner/repo", "--pr", "51", "--gate", "draft_gate",
+      "--head-sha", headSha, "--base", baseSha,
+    ], { repoRoot });
+
+    const cliArtifact = await readGateContext({
+      repo: "owner/repo", pr: 51, gate: "draft_gate", headSha,
+    }, { repoRoot });
+
+    // API path: same loaded config + the same captured diff the CLI used.
+    const { config } = await loadDevLoopConfig({ repoRoot });
+    const diff = captureDiffFromBase(baseSha, { repoRoot });
+    const apiResult = await buildGateContext(
+      { config, repo: "owner/repo", pr: "51", gate: "draft_gate", headSha, branch: null, diff, tmpRoot: "tmp" },
+      { repoRoot },
+    );
+
+    assert.deepEqual(cliArtifact.resolvedAngles, apiResult.artifact.resolvedAngles);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI without --angles + dynamicAngles:false falls back to the full static pool (matches API)", async () => {
+  const { repoRoot, baseSha, headSha } = await makeBaseDiffRepo();
+  try {
+    await writeDraftDevLoops(repoRoot, { dynamicAngles: false });
+    await main([
+      "--repo", "owner/repo", "--pr", "52", "--gate", "draft_gate",
+      "--head-sha", headSha, "--base", baseSha,
+    ], { repoRoot });
+
+    const cliArtifact = await readGateContext({
+      repo: "owner/repo", pr: 52, gate: "draft_gate", headSha,
+    }, { repoRoot });
+
+    const { config } = await loadDevLoopConfig({ repoRoot });
+    const diff = captureDiffFromBase(baseSha, { repoRoot });
+    const apiResult = await buildGateContext(
+      { config, repo: "owner/repo", pr: "52", gate: "draft_gate", headSha, branch: null, diff, tmpRoot: "tmp" },
+      { repoRoot },
+    );
+
+    assert.deepEqual(cliArtifact.resolvedAngles, apiResult.artifact.resolvedAngles);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI with --angles uses the list VERBATIM (override bypasses dynamic resolution)", async () => {
+  const { repoRoot, baseSha, headSha } = await makeDocsOnlyDiffRepo();
+  try {
+    await writeDraftDevLoops(repoRoot); // dynamicAngles: true — would normally drop "coverage"
+    await main([
+      "--repo", "owner/repo", "--pr", "53", "--gate", "draft_gate",
+      "--head-sha", headSha, "--base", baseSha,
+      "--angles", '["coverage","custom-angle"]',
+    ], { repoRoot });
+
+    const artifact = await readGateContext({
+      repo: "owner/repo", pr: 53, gate: "draft_gate", headSha,
+    }, { repoRoot });
+
+    // Verbatim override: the passed list is used as-is, including an angle that
+    // dynamic resolution would have dropped ("coverage") and one outside the
+    // configured pool ("custom-angle"). No trimming, no mandatory-floor merge.
+    assert.deepEqual(artifact.resolvedAngles, ["coverage", "custom-angle"]);
   } finally {
     await rm(repoRoot, { recursive: true, force: true });
   }

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -1091,6 +1091,111 @@ test("CLI with --angles uses the list VERBATIM (override bypasses dynamic resolu
   }
 });
 
+test("CLI without --base and without --angles: static fallback pool + CLI/API parity (diffSource=none)", async () => {
+  // Realistic operator/CI invocation: neither --base nor --angles supplied.
+  // dynamicAngles:true in config, but with no diff available the resolver
+  // falls back to the full static configured pool (mandatory floor + angles).
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-nobase-noangles-"));
+  try {
+    await writeDraftDevLoops(repoRoot); // dynamicAngles: true
+    await main([
+      "--repo", "owner/repo", "--pr", "60", "--gate", "draft_gate",
+      "--head-sha", "abc1234567890",
+    ], { repoRoot });
+
+    const cliArtifact = await readGateContext({
+      repo: "owner/repo", pr: 60, gate: "draft_gate", headSha: "abc1234567890",
+    }, { repoRoot });
+
+    assert.ok(cliArtifact, "artifact written for the no-base/no-angles invocation");
+    assert.equal(cliArtifact.scope.diffSource, "none");
+    assert.deepEqual(cliArtifact.resolvedAngles, [
+      "gate-evidence", "scope", "coverage", "correctness", "docs", "link-check", "config-drift",
+    ], "diff=null -> static fallback pool (mandatory floor + configured angles), despite dynamicAngles:true");
+
+    // CLI/API parity: buildGateContext with the same loaded config and diff:null
+    // must resolve the identical angle set as the CLI path.
+    const { config } = await loadDevLoopConfig({ repoRoot });
+    const apiResult = await buildGateContext(
+      { config, repo: "owner/repo", pr: "61", gate: "draft_gate", headSha: "abc1234567890", branch: null, diff: null, tmpRoot: "tmp" },
+      { repoRoot },
+    );
+    assert.deepEqual(cliArtifact.resolvedAngles, apiResult.artifact.resolvedAngles);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI --angles '[]' is used VERBATIM (empty escape hatch bypasses dynamic resolution)", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-empty-angles-"));
+  try {
+    await writeDraftDevLoops(repoRoot); // dynamicAngles: true; static pool is non-empty
+    await main([
+      "--repo", "owner/repo", "--pr", "62", "--gate", "draft_gate",
+      "--head-sha", "abc1234567890",
+      "--angles", "[]",
+    ], { repoRoot });
+
+    const artifact = await readGateContext({
+      repo: "owner/repo", pr: 62, gate: "draft_gate", headSha: "abc1234567890",
+    }, { repoRoot });
+
+    assert.ok(artifact, "artifact written for an explicit empty override");
+    assert.deepEqual(artifact.resolvedAngles, [], "empty array override used verbatim, not the configured pool");
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("CLI without --angles + malformed .devloops: warns to stderr and proceeds with the documented fallback (not fail-closed)", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-badconfig-"));
+  try {
+    // dynamicAngles must be a boolean; a string value fails schema validation
+    // (mirrors the postFindingsComments:"yes" fixture in post-gate-findings.test.mjs).
+    await writeFile(
+      path.join(repoRoot, ".devloops"),
+      [
+        "version: 1",
+        "gates:",
+        "  draft:",
+        "    dynamicAngles: \"yes\"",
+        "    angles:",
+        "      - scope",
+        "      - coverage",
+        "    mandatoryAngles:",
+        "      - gate-evidence",
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const origErr = process.stderr.write;
+    const stderrChunks = [];
+    process.stderr.write = (chunk) => { stderrChunks.push(String(chunk)); return true; };
+    try {
+      await main([
+        "--repo", "owner/repo", "--pr", "63", "--gate", "draft_gate",
+        "--head-sha", "abc1234567890",
+      ], { repoRoot });
+    } finally {
+      process.stderr.write = origErr;
+    }
+
+    const stderrText = stderrChunks.join("");
+    assert.match(stderrText, /could not be fully loaded\/validated/, "warns to stderr on a malformed .devloops");
+    assert.match(stderrText, /dynamicAngles/, "warning surfaces the actual validation error");
+
+    const artifact = await readGateContext({
+      repo: "owner/repo", pr: 63, gate: "draft_gate", headSha: "abc1234567890",
+    }, { repoRoot });
+    assert.ok(artifact, "artifact still written despite the config error (documented fallback, not a fail-closed exit)");
+    // Fallback proceeds with the merged config rather than nulling it out into
+    // an empty angle set: a non-empty resolved pool comes back either way.
+    assert.ok(Array.isArray(artifact.resolvedAngles) && artifact.resolvedAngles.length > 0);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
 test("CLI --base <ref> that fails to resolve fails closed (no artifact written, non-zero exit)", async () => {
   const { repoRoot, headSha } = await makeBaseDiffRepo();
   try {

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -1281,8 +1281,8 @@ test("CLI without --angles + a gate with no configured angles/mandatoryAngles: w
     const stderrText = stderrChunks.join("");
     assert.match(
       stderrText,
-      /dynamic angle resolution produced zero angles for gate draft_gate/,
-      "warns to stderr when dynamic resolution yields zero angles",
+      /angle resolution produced zero angles for gate draft_gate/,
+      "warns to stderr when angle resolution yields zero angles",
     );
 
     const artifact = await readGateContext({

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -1042,6 +1042,36 @@ test("CLI without --angles matches buildGateContext resolvedAngles (CLI/API pari
   }
 });
 
+test("CLI --rationale supplied WITHOUT --angles is ignored; resolver-derived rationale is persisted", async () => {
+  const { repoRoot, baseSha, headSha } = await makeDocsOnlyDiffRepo();
+  try {
+    await writeDraftDevLoops(repoRoot); // dynamicAngles: true
+    const staleRationale = [{ angle: "coverage", action: "kept", reason: "caller-supplied, cannot apply to dynamically-resolved angles" }];
+    await main([
+      "--repo", "owner/repo", "--pr", "55", "--gate", "draft_gate",
+      "--head-sha", headSha, "--base", baseSha,
+      "--rationale", JSON.stringify(staleRationale),
+    ], { repoRoot });
+
+    const artifact = await readGateContext({
+      repo: "owner/repo", pr: 55, gate: "draft_gate", headSha,
+    }, { repoRoot });
+
+    // The resolver-derived rationale (from the SAME resolution the API path
+    // uses) is what's persisted, not the caller's stale --rationale.
+    const { config } = await loadDevLoopConfig({ repoRoot });
+    const diff = captureDiffFromBase(baseSha, { repoRoot });
+    const apiResult = await buildGateContext(
+      { config, repo: "owner/repo", pr: "55", gate: "draft_gate", headSha, branch: null, diff, tmpRoot: "tmp" },
+      { repoRoot },
+    );
+    assert.deepEqual(artifact.rationale, apiResult.artifact.rationale);
+    assert.notDeepEqual(artifact.rationale, staleRationale, "caller's stale --rationale must not be persisted");
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
 test("CLI without --angles + dynamicAngles:false falls back to the full static pool (matches API)", async () => {
   const { repoRoot, baseSha, headSha } = await makeBaseDiffRepo();
   try {


### PR DESCRIPTION
## Summary

The `write-gate-context.mjs` CLI required `--angles` and used the passed list verbatim, bypassing `resolveGateAnglesDynamic` entirely — while the sibling programmatic `buildGateContext` API resolves dynamically from config + diff. So a caller running the CLI got no dynamic trimming even with `dynamicAngles: true` and a `--base` diff (all configured angles were kept). This makes `--angles` optional and routes the CLI through the same dynamic resolver the API uses.

## Scope and context

- `scripts/github/write-gate-context.mjs` `main()`: when `--angles` is omitted, load config via `loadDevLoopConfig` and resolve angles through `resolveGateAnglesDynamic(config, configKey, { diff })` — the same call `buildGateContext` makes. The `--base` diff is captured before resolution so the resolver can trim. When `--angles` IS supplied, it stays a verbatim override (documented escape hatch; dynamic resolution bypassed).
- Removed `angles` from the required-arg missing-check; updated USAGE text.
- Added stderr warnings on the no-`--angles` path (warn-and-proceed, non-fatal): unvalidatable `.devloops` config (proceeds on the merged fallback config), zero angles resolved for the gate (so a hollow context bundle is never written silently), and a caller-supplied `--rationale` discarded because angles were resolved dynamically.
- Tests added for the new dynamic-resolution behaviors and their edge cases (optionality, docs-only trimming, CLI/API parity, the verbatim override, the static-pool fallback, the warn-and-proceed paths, and resolver-derived rationale) — see `test/github/write-gate-context.test.mjs`.

Filed as investigation #1366 — discovered during the #1365 `pre_approval_gate` run, where passing all 17 `preApproval` angles kept all 17 (none trimmed).

## Acceptance criteria

- [x] `write-gate-context.mjs` runs successfully without `--angles`, resolving dynamically from config + the `--base` diff.
- [x] `--angles`, when supplied, has documented semantics (verbatim override) and behaves accordingly.
- [x] The CLI path and the `buildGateContext` API produce the same `resolvedAngles` for the same config + diff.
- [x] A contract/unit test pins the CLI dynamic-resolution behavior (trims when `dynamicAngles: true` + diff; falls back to the static pool otherwise).
- [x] The `pre_approval_gate` context build for a small PR no longer fans out all configured angles when dynamic resolution would trim them.

## Definition of done

- [x] Source fixed (CLI resolves dynamically by default; `--angles` optional).
- [x] Tests added/updated and green; `npm run verify` passes.
- [ ] Merged through the full loop (draft_gate → pre_approval_gate → Copilot → green CI).

## Non-goals

- Changing which angles are mandatory or the configured `preApproval` pool itself.
- Rewriting the diff analyzer / change classifier — only wiring the existing resolver into the CLI path.
- Re-evaluating the fan-out parallelism cap.

## Validation

- `node scripts/github/write-gate-context.mjs --repo mfittko/dev-loops --pr 1366 --gate pre_approval_gate --head-sha <sha> --base origin/main` (no `--angles`) resolves a trimmed set: **17 → 5 angles** (`pr-checklist-matrix`, `acceptance-criteria`, `yagni`, `contradiction-lens`, `renderer-security`).
- `npm run verify` green; `test/github/write-gate-context.test.mjs` passing.

Closes #1366





