### PR TITLE
feat(release): generate the plugin manifest version so a release can't silently desync it

### DIFF
--- a/.claude/skills/docs/release-runbook.md
+++ b/.claude/skills/docs/release-runbook.md
@@ -5,7 +5,10 @@ manual step.** Everything after the tag is hands-off.
 
 ## Procedure
 
-1. On `main` (merged, green), bump the version and add the matching
+1. On `main` (merged, green), bump the version, run
+   `node scripts/claude/generate-claude-assets.mjs` (stamps the bumped version
+   into the generated `npx dev-loops@<version>` pins and the plugin manifest;
+   a stale manifest fails `verify` at publish), and add the matching
    `## <version> - <date>` section to `CHANGELOG.md` (the empty `## Unreleased`
    heading stays above the latest version).
 2. Tag the release commit and push the tag:

--- a/scripts/claude/generate-claude-assets.mjs
+++ b/scripts/claude/generate-claude-assets.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 /**
- * Generate the Claude Code asset tree (.claude/agents, .claude/skills) from the canonical
- * Pi sources (agents/*.agent.md, skills/<name>/SKILL.md). The sources remain the single
- * source of truth; the generated tree is committed and kept in sync by `--check` (CI/test).
+ * Generate the Claude Code asset tree (.claude/agents, .claude/skills, and the plugin
+ * manifest version in .claude/.claude-plugin/plugin.json) from the canonical Pi sources
+ * (agents/*.agent.md, skills/<name>/SKILL.md) and the root package.json version. The sources
+ * remain the single source of truth; the generated tree is committed and kept in sync by
+ * `--check` (CI/test).
  *
  * Usage:
  *   node scripts/claude/generate-claude-assets.mjs            Write the .claude tree.

--- a/scripts/claude/generate-claude-assets.mjs
+++ b/scripts/claude/generate-claude-assets.mjs
@@ -34,6 +34,19 @@ export function collectGeneratedAssets({ repoRoot = process.cwd() } = {}) {
     version = JSON.parse(fs.readFileSync(pkgPath, "utf8")).version ?? "latest";
   }
 
+  // The plugin manifest's version must equal the package version (locked by the
+  // claude-plugin-manifest contract test). Emitting the manifest as a generated asset makes a
+  // release bump self-syncing and lets --check catch a stale manifest at asset-check time.
+  // Non-version fields stay hand-authored: the committed manifest is the source, only the
+  // version field is stamped.
+  const manifestRel = ".claude/.claude-plugin/plugin.json";
+  const manifestAbs = path.join(repoRoot, manifestRel);
+  if (fs.existsSync(manifestAbs) && version !== "latest") {
+    const manifest = JSON.parse(fs.readFileSync(manifestAbs, "utf8"));
+    manifest.version = version;
+    assets.push({ target: manifestRel, content: JSON.stringify(manifest, null, 2) + "\n" });
+  }
+
   const agentsDir = path.join(repoRoot, "agents");
   if (fs.existsSync(agentsDir)) {
     for (const entry of fs.readdirSync(agentsDir).sort()) {

--- a/skills/docs/release-runbook.md
+++ b/skills/docs/release-runbook.md
@@ -5,7 +5,10 @@ manual step.** Everything after the tag is hands-off.
 
 ## Procedure
 
-1. On `main` (merged, green), bump the version and add the matching
+1. On `main` (merged, green), bump the version, run
+   `node scripts/claude/generate-claude-assets.mjs` (stamps the bumped version
+   into the generated `npx dev-loops@<version>` pins and the plugin manifest;
+   a stale manifest fails `verify` at publish), and add the matching
    `## <version> - <date>` section to `CHANGELOG.md` (the empty `## Unreleased`
    heading stays above the latest version).
 2. Tag the release commit and push the tag:

--- a/test/contracts/claude-assets-reproducible.test.mjs
+++ b/test/contracts/claude-assets-reproducible.test.mjs
@@ -189,6 +189,18 @@ test("every canonical agent and non-doc skill has a generated counterpart", () =
   }
 });
 
+test("a malformed plugin manifest fails asset generation loudly instead of writing garbage", () => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "claude-assets-plugin-bad-"));
+  try {
+    fs.writeFileSync(path.join(tmpRoot, "package.json"), JSON.stringify({ name: "x", version: "9.9.9" }) + "\n", "utf8");
+    fs.mkdirSync(path.join(tmpRoot, ".claude", ".claude-plugin"), { recursive: true });
+    fs.writeFileSync(path.join(tmpRoot, ".claude", ".claude-plugin", "plugin.json"), "{not json", "utf8");
+    assert.throws(() => collectGeneratedAssets({ repoRoot: tmpRoot }), SyntaxError);
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
 test("plugin manifest version is a generated asset stamped from package.json (#1348)", () => {
   // Real repo: the manifest must be emitted with the package version.
   const assets = collectGeneratedAssets({ repoRoot });

--- a/test/contracts/claude-assets-reproducible.test.mjs
+++ b/test/contracts/claude-assets-reproducible.test.mjs
@@ -188,3 +188,41 @@ test("every canonical agent and non-doc skill has a generated counterpart", () =
     assert.ok(targets.includes(expected), `expected generated asset ${expected}`);
   }
 });
+
+test("plugin manifest version is a generated asset stamped from package.json (#1348)", () => {
+  // Real repo: the manifest must be emitted with the package version.
+  const assets = collectGeneratedAssets({ repoRoot });
+  const manifest = assets.find((a) => a.target === ".claude/.claude-plugin/plugin.json");
+  assert.ok(manifest, "plugin manifest must be a generated asset");
+  const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+  assert.equal(JSON.parse(manifest.content).version, pkg.version);
+
+  // Consumer-shaped tree with a STALE committed manifest: checkAssets must flag it
+  // out-of-date, and a plain generate must bring it in sync with zero manual edits.
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "claude-assets-plugin-"));
+  try {
+    fs.writeFileSync(path.join(tmpRoot, "package.json"), JSON.stringify({ name: "x", version: "9.9.9" }) + "\n", "utf8");
+    fs.mkdirSync(path.join(tmpRoot, ".claude", ".claude-plugin"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpRoot, ".claude", ".claude-plugin", "plugin.json"),
+      JSON.stringify({ name: "dev-loops", version: "0.0.1", description: "d" }, null, 2) + "\n",
+      "utf8",
+    );
+    const tmpAssets = collectGeneratedAssets({ repoRoot: tmpRoot });
+    const drifted = checkAssets(tmpAssets, { repoRoot: tmpRoot });
+    assert.ok(
+      drifted.some((d) => d.target === ".claude/.claude-plugin/plugin.json" && d.reason === "out-of-date"),
+      `stale manifest version must be flagged, got ${JSON.stringify(drifted)}`,
+    );
+    writeAssets(tmpAssets, { repoRoot: tmpRoot });
+    const onDisk = JSON.parse(fs.readFileSync(path.join(tmpRoot, ".claude", ".claude-plugin", "plugin.json"), "utf8"));
+    assert.equal(onDisk.version, "9.9.9");
+    assert.equal(onDisk.name, "dev-loops", "non-version manifest fields stay hand-authored");
+    assert.ok(
+      !checkAssets(tmpAssets, { repoRoot: tmpRoot }).some((d) => d.target === ".claude/.claude-plugin/plugin.json"),
+      "freshly generated manifest must be clean",
+    );
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});

--- a/test/contracts/claude-plugin-manifest.test.mjs
+++ b/test/contracts/claude-plugin-manifest.test.mjs
@@ -25,7 +25,7 @@ test("plugin manifest version is kept in sync with the root package.json version
   assert.equal(
     manifest.version,
     pkg.version,
-    "plugin.json version must match package.json version — bump both together",
+    "plugin.json version must match package.json version — run `node scripts/claude/generate-claude-assets.mjs` and commit the regenerated manifest",
   );
 });
 


### PR DESCRIPTION
Closes #1348

## Objective

Remove the release footgun where `.claude/.claude-plugin/plugin.json`'s `version` must be bumped by hand alongside `package.json` — forgetting it aborted the `v1.0.0-rc.1` publish at the pipeline's `verify` step.

## What changed

- `collectGeneratedAssets` emits the plugin manifest as a generated asset: the committed manifest is read as the source (name/description and any other fields stay hand-authored) and only `version` is stamped from the root `package.json`. Skipped when no manifest exists or no package version resolves (consumer/fixture trees).
- No new check wiring needed: the existing committed-tree no-drift contract test (`claude-assets-reproducible`, part of `test:assets` → `verify`) and `generate-claude-assets --check` now flag a stale manifest as `out-of-date` automatically.
- New contract test pins: the manifest asset carries the package version (real repo), a stale consumer-tree manifest is flagged `out-of-date`, a plain generate resyncs it with zero manual edits, non-version fields survive, and a malformed manifest fails generation loudly.
- The manifest-sync contract test's failure message now directs releasers to regenerate assets instead of the manual bump it used to instruct.

## Validation

- `npm run verify` green in the worktree (all legs, including the new test; scripts suite 2790 pass / 0 fail).
- `node scripts/claude/generate-claude-assets.mjs --check` → `{"ok":true,"checked":69}` (manifest now among the checked assets).

## Non-goals

- No change to what the manifest contains beyond `version`; no schema for it.
- No change to the publish pipeline itself (already prerelease-aware).
