### PR TITLE
feat(pages): migrate the deep-dive article to the markdown renderer, fact-grounded and desloped

### DIFF
--- a/docs/articles/dev-loops-deep-dive.html
+++ b/docs/articles/dev-loops-deep-dive.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- GENERATED from docs/articles/dev-loops-deep-dive.md by scripts/pages/render-article.mjs — do not edit; edit the markdown and regenerate. -->
 <html lang="en">
 <head>
 <meta charset="utf-8" />
@@ -47,9 +48,9 @@
     padding: clamp(2rem, 6vw, 4rem) clamp(1.1rem, 5vw, 2rem) 5rem;
   }
 
-  /* One column at every width: prose and figures fill the same wrap, so all
+  /* One column at every width: prose and boxes fill the same wrap, so all
      left/right edges line up. Desktop widens the column; nothing floats in a
-     narrower centered measure beside a full-width diagram. */
+     narrower centered measure beside a full-width box. */
   @media (min-width: 900px) {
     .wrap { max-width: 56rem; }
   }
@@ -66,8 +67,9 @@
   h1, h2, h3 { color: var(--heading); letter-spacing: -0.02em; margin-top: 0; }
   h1 { font-weight: 760; font-size: clamp(1.9rem, 5vw, 2.7rem); line-height: 1.08; margin-bottom: 0.9rem; }
   h2 { font-weight: 720; font-size: clamp(1.35rem, 3.4vw, 1.85rem); line-height: 1.15; margin: 2.6rem 0 0.9rem; }
+  h3 { font-weight: 680; font-size: clamp(1.08rem, 2.4vw, 1.28rem); line-height: 1.25; margin: 1.8rem 0 0.6rem; color: var(--accent-soft); }
 
-  /* part divider: the two big movements of the deep dive */
+  /* part divider: the two big movements of a two-part deep dive */
   .part {
     margin: 3.4rem 0 1.4rem;
     padding-top: 2.2rem;
@@ -86,8 +88,22 @@
   p { line-height: 1.72; font-size: 1.05rem; color: var(--ink); margin: 0 0 1.15rem; }
   strong { color: var(--accent-soft); }
   em { color: #e2e8f0; font-style: italic; }
-  ul { line-height: 1.7; padding-left: 1.2rem; margin: 0 0 1.15rem; }
-  li + li { margin-top: 0.4rem; }
+  ul, ol { line-height: 1.7; padding-left: 1.3rem; margin: 0 0 1.15rem; }
+  li + li { margin-top: 0.5rem; }
+  a { color: var(--kicker); text-decoration: none; border-bottom: 1px solid rgba(147, 197, 253, 0.35); }
+  a:hover { border-bottom-color: var(--kicker); }
+
+  /* callout: a left-accent glass panel for asides (e.g. a cross-link nudge) */
+  blockquote {
+    margin: 1.6rem 0;
+    padding: 0.9rem 1.2rem;
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid var(--card-border);
+    border-left: 3px solid var(--accent);
+    border-radius: 0 14px 14px 0;
+    color: var(--copy);
+  }
+  blockquote p { margin: 0; }
 
   code {
     font-family: var(--mono);
@@ -97,7 +113,28 @@
     border-radius: 6px;
     padding: 0.05em 0.4em;
     color: #e2e8f0;
+    overflow-wrap: anywhere;
   }
+
+  pre {
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0.82), rgba(15, 23, 42, 0.6));
+    border: 1px solid var(--card-border);
+    border-radius: 14px;
+    padding: 1rem 1.15rem;
+    margin: 0 0 1.3rem;
+    overflow-x: auto;
+  }
+  pre code {
+    background: none;
+    border: 0;
+    border-radius: 0;
+    padding: 0;
+    font-size: 0.86rem;
+    line-height: 1.6;
+    color: #e2e8f0;
+    white-space: pre;
+  }
+  pre code .cm { color: #94a3b8; }
 
   .hero-card {
     background: linear-gradient(180deg, rgba(15, 23, 42, 0.82), rgba(15, 23, 42, 0.6));
@@ -174,22 +211,10 @@
   .diagram-scroll svg text { font-family: var(--mono); fill: #e2e8f0; }
   .diagram-scroll svg .lab { fill: var(--kicker); font-family: var(--font); }
 
-  /* tree grounding diagram (figure 8) scales down on mobile */
+  /* tree grounding diagram scales down on mobile */
   .tree-svg { width: 100%; height: auto; display: block; }
   .tree-svg text { font-family: var(--mono); fill: #e2e8f0; }
   .tree-svg .lbl { fill: var(--kicker); font-family: var(--font); }
-
-  .rule { border: 0; border-top: 1px solid rgba(148, 163, 184, 0.16); margin: 3rem 0; }
-
-  .render-note {
-    background: rgba(15, 23, 42, 0.55);
-    border: 1px solid var(--card-border);
-    border-radius: 16px;
-    padding: 1.2rem 1.35rem;
-    margin-top: 2rem;
-  }
-  .render-note h2 { margin-top: 0; font-size: 1.2rem; }
-  .render-note p { margin-bottom: 0; font-size: 0.98rem; color: var(--copy); }
 
   .closer {
     color: var(--accent-soft);
@@ -198,6 +223,36 @@
     line-height: 1.4;
     margin: 1.6rem 0 0;
   }
+
+  /* metric row for the proof numbers */
+  .metrics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.8rem;
+    margin: 1.8rem 0 2rem;
+  }
+  .metric {
+    flex: 1 1 8rem;
+    min-width: 0;
+    background: linear-gradient(180deg, rgba(24, 36, 61, 0.82), rgba(17, 24, 39, 0.72));
+    border: 1px solid var(--node-border);
+    border-radius: 16px;
+    padding: 1rem 1.1rem;
+  }
+  .metric .num { font-size: 1.5rem; font-weight: 720; color: var(--accent-soft); line-height: 1.05; }
+  .metric .lab { font-size: 0.82rem; color: var(--copy); margin-top: 0.4rem; line-height: 1.35; }
+
+  .rule { border: 0; border-top: 1px solid rgba(148, 163, 184, 0.16); margin: 3rem 0; }
+
+  .deeper {
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    padding: 1.2rem 1.35rem;
+    margin-top: 2rem;
+  }
+  .deeper h2 { margin-top: 0; font-size: 1.2rem; }
+  .deeper p { margin-bottom: 0; font-size: 0.98rem; color: var(--copy); }
 </style>
 </head>
 <body>
@@ -210,6 +265,8 @@
     <p class="lede">AI made writing code cheap. The hours now go into the handoffs around the code, author to reviewer, reviewer to CI, CI back to a human, and into the waiting between actions.</p>
   </header>
 
+  <blockquote>New here? Start with <a href="./introducing-dev-loops.html">Introducing dev-loops</a> for the overview; this article is the deep dive beneath it.</blockquote>
+
   <p>An AI agent can write a working function in seconds. That part is solved. The hard part is everything that happens <em>around</em> the function: handing it to a reviewer, getting feedback back to the author, waiting for the build, deciding whether it is safe to merge. Each of those handoffs takes hours in real life, even when the diagram makes it look instant. An agent left to manage them on its own will guess at them. It assumes the build passed, assumes the review is done, and marks the work finished while those assumptions go unchecked.</p>
 
   <p>That gap has a name: coordination delay. It is the time work spends waiting between people and steps, plus the rework caused when someone, or something, guesses wrong about where the work actually is. Code is cheap to write now, and the cost has moved into getting it through the pipeline.</p>
@@ -221,7 +278,7 @@
     <h2>Eliminating coordination delay</h2>
   </div>
 
-  <h2>The one idea: the next step is always known</h2>
+  <h2 id="the-one-idea-the-next-step-is-always-known">The one idea: the next step is always known</h2>
 
   <p>Here is the whole thing in a sentence: the next step is always known, like the next card on a Kanban board. The system computes the next action for any change at any time, and whoever is free pulls it from the visible state.</p>
 
@@ -247,20 +304,20 @@
         <div class="node accent">What&nbsp;is&nbsp;the&nbsp;next&nbsp;action?</div>
       </div>
     </div>
-    <figcaption><b>Diagram 1 &mdash; The nested loops.</b> An outer "what is the next action here?" decision routes each cycle to exactly one move, then returns to ask again. When the next step is ambiguous, the loop hands control to a human.</figcaption>
+    <figcaption><b>Diagram 1 — The nested loops.</b> An outer &quot;what is the next action here?&quot; decision routes each cycle to exactly one move, then returns to ask again. When the next step is ambiguous, the loop hands control to a human.</figcaption>
   </figure>
 
-  <h2>What a known next step buys you</h2>
+  <h2 id="what-a-known-next-step-buys-you">What a known next step buys you</h2>
 
   <p>Computing the next action for any change makes four behaviors possible that a guess-based workflow cannot offer.</p>
 
-  <p>The first is safe pauses. Because the system always knows where it is, it can stop without making a mess. Ask it to stop mid-edit and it finishes the current step, lands it clean, and hands you a stopping point with the file intact. There are only a few honest answers to "can I stop now?": <em>stop this instant</em>, <em>stop at the next clean boundary</em>, or <em>not yet, because a required check is missing</em>. The system gives you whichever one holds.</p>
+  <p>The first is safe pauses. Because the system always knows where it is, it can stop without making a mess. Ask it to stop mid-edit and it finishes the current step, lands it clean, and hands you a stopping point with the file intact. There are only two honest answers to &quot;can I stop now?&quot;: stop at the next clean boundary, or not yet because a required check is missing. The system gives you whichever one holds.</p>
 
-  <p>The second is mid-flight steering. You can change the rules while the machine keeps running. Halfway through a run you can say "don't touch the auth module," and that lands as a hard constraint the remaining steps must honor; the run keeps its progress and applies the rule from the next move on. A softer nudge becomes a preference the system honors when it can, and a "stop when safe" request winds the work down at the next clean boundary.</p>
+  <p>The second is mid-flight steering. You can change the rules while the machine keeps running. Halfway through a run you can say &quot;don't touch the auth module,&quot; and that lands as a hard constraint the remaining steps must honor; the run keeps its progress and applies the rule from the next move on. A softer nudge becomes a preference the system honors when it can, and a &quot;stop when safe&quot; request winds the work down at the next clean boundary.</p>
 
-  <p>The third is parallel review that consolidates into a single verdict. Several reviewers examine a pull request at once, each on a different angle (scope, test coverage, security), and all of them read the <em>same evidence bundle</em>: the same diff, the same context. Because the inputs are identical, the verdicts are directly comparable, and they merge into a single answer. One serious finding blocks the merge.</p>
+  <p>The third is parallel review that consolidates into a single verdict. Several reviewers examine a pull request at once, each on a different angle (scope, coverage, input validation, among others), and all of them read the <em>same evidence bundle</em>: the same diff, the same context. Because the inputs are identical, the verdicts are directly comparable, and they merge into a single answer. One serious finding blocks the merge.</p>
 
-  <p>The fourth is the most important: "done" means merged. The board shows done only when a pull request has actually merged, read from the platform's own merge signal the agent cannot fabricate. CI-green comes from the real check result, so the system waits for it before proceeding. And the merge itself always belongs to a contributor.</p>
+  <p>The fourth is the most important: &quot;done&quot; means merged. The board shows done only when a pull request has actually merged, read from the platform's own merge signal that the agent cannot fabricate. CI-green comes from the real check result, so the system waits for it before proceeding. And the merge itself is a human's call by default.</p>
 
   <figure>
     <div class="diagram-scroll">
@@ -270,7 +327,6 @@
             <path d="M0,0 L8,4 L0,8 z" fill="#94a3b8" />
           </marker>
         </defs>
-        <!-- nodes -->
         <g font-size="12">
           <rect x="20" y="20" width="150" height="40" rx="12" fill="#0f172a" stroke="#93c5fd" />
           <text x="95" y="44" text-anchor="middle">Draft opened</text>
@@ -296,7 +352,6 @@
           <rect x="245" y="200" width="150" height="40" rx="12" fill="#0f172a" stroke="#6ee7b7" />
           <text x="320" y="224" text-anchor="middle" style="fill:#6ee7b7">Done = merged</text>
         </g>
-        <!-- edges -->
         <g stroke="#94a3b8" fill="none" stroke-width="1.4" marker-end="url(#ah)">
           <path d="M95,60 L95,100" />
           <path d="M170,124 L245,122" />
@@ -312,33 +367,33 @@
         </g>
       </svg>
     </div>
-    <figcaption><b>Diagram 2 &mdash; A pull request's lifecycle through the gates.</b> Every gate must run before the next step: a draft with missing checks loops back, an unresolved finding returns to the author, and a human performs the merge.</figcaption>
+    <figcaption><b>Diagram 2 — A pull request's lifecycle through the gates.</b> Every gate must run before the next step: a draft with missing checks loops back, an unresolved finding returns to the author, and a human performs the merge.</figcaption>
   </figure>
 
-  <h2>Fan out wide, fan in to one answer</h2>
+  <h2 id="fan-out-wide-fan-in-to-one-answer">Fan out wide, fan in to one answer</h2>
 
   <p>The parallel review deserves a closer look, because it is a small pattern with a large payoff. Build the evidence once and neutrally (the diff plus just enough surrounding context) and hand that identical bundle to every reviewer. Every reviewer works from the same view, so their findings sit on the same footing. Then consolidate the separate verdicts into one, with the strictest finding winning.</p>
 
   <figure>
     <div class="diagram-scroll">
-      <div class="flow" role="img" aria-label="Fan-out then fan-in: one neutral evidence bundle goes as the same diff to independent scope, coverage, and security reviewers; the strictest verdict wins.">
+      <div class="flow" role="img" aria-label="Fan-out then fan-in: one neutral evidence bundle goes as the same diff to independent scope, coverage, and input-validation reviewers; the strictest verdict wins.">
         <div class="node start">One&nbsp;neutral<br/>evidence&nbsp;bundle</div>
         <div class="edge"><span class="arrow">&rarr;</span><span class="edge-label">same diff to each</span></div>
         <div class="flow-col">
           <div class="node">Scope&nbsp;review</div>
           <div class="node">Coverage&nbsp;review</div>
-          <div class="node">Security&nbsp;review</div>
+          <div class="node">Input&nbsp;validation&nbsp;review</div>
         </div>
         <div class="edge"><span class="arrow">&rarr;</span><span class="edge-label">consolidate</span></div>
         <div class="node accent">One&nbsp;verdict<br/>strictest&nbsp;wins</div>
       </div>
     </div>
-    <figcaption><b>Diagram 3 &mdash; Fan-out / fan-in.</b> One evidence bundle fans out to independent reviewers working different angles in parallel, then their findings fan back in to a single consolidated verdict.</figcaption>
+    <figcaption><b>Diagram 3 — Fan-out / fan-in.</b> One evidence bundle fans out to independent reviewers working different angles in parallel, then their findings fan back in to a single consolidated verdict.</figcaption>
   </figure>
 
   <p>A shared bundle keeps the angles aligned, because when each reviewer scrapes its own context they end up arguing about different versions of reality. With one input feeding every angle in parallel, the verdicts stay comparable and merge into a single answer you can trust.</p>
 
-  <h2>Steering without stopping</h2>
+  <h2 id="steering-without-stopping">Steering without stopping</h2>
 
   <p>Mid-flight steering is worth one more diagram, because it shows the discipline in action. When you inject an instruction, the system classifies it and decides <em>when</em> it can be honored safely.</p>
 
@@ -361,14 +416,14 @@
         <div class="node accent">Run&nbsp;continues,<br/>steered</div>
       </div>
     </div>
-    <figcaption><b>Diagram 4 &mdash; Steering flow.</b> A hard constraint is applied immediately when it is safe, or queued until the next safe point. The run keeps its progress either way and applies the change only at a clean boundary.</figcaption>
+    <figcaption><b>Diagram 4 — Steering flow.</b> A hard constraint is applied immediately when it is safe, or queued until the next safe point. The run keeps its progress either way and applies the change only at a clean boundary.</figcaption>
   </figure>
 
-  <h2>Why a state graph beats a prompt</h2>
+  <h2 id="why-a-state-graph-beats-a-prompt">Why a state graph beats a prompt</h2>
 
   <p>You could try to get all of this from prompting alone: write a long, careful instruction and trust the model to follow it. It will follow it most of the time, then drift without warning. Steer a workflow with prose and its behavior shifts with every model update, every longer context window, every change in sampling. That drift surfaces in production.</p>
 
-  <p>Run the workflow on a state graph. The set of possible moves is closed and listable, so the resolver can compute the one next action for any change and surface it. This is what makes the next step always known and pullable: the next actor reads the current state and takes the move waiting there, with no handoff to wait for. It buys two things prose alone cannot. A known set of moves is a <em>testable</em> set, so a wrong transition shows up in a test run before it reaches production. And the system can always say exactly where it is and what it is allowed to do next, which is what makes safe pauses, steering, and an honest "done" possible at all.</p>
+  <p>Run the workflow on a state graph. The set of possible moves is closed and listable, so the resolver can compute the one next action for any change and surface it. This is what makes the next step always known and pullable: the next actor reads the current state and takes the move waiting there, with no handoff to wait for. It buys two things prose alone cannot. A known set of moves is a testable set, so a wrong transition shows up in a test run before it reaches production. And the system can always say exactly where it is and what it is allowed to do next, which is what makes safe pauses, steering, and an honest &quot;done&quot; possible at all.</p>
 
   <p>A state graph guarantees the behavior a prompt can only request. When the next step has to be knowable at any moment, the coordination layer itself should rest on something checkable.</p>
 
@@ -377,15 +432,15 @@
     <h2>Make the waiting visible</h2>
   </div>
 
-  <p>Closing the handoffs is half the work. The other half is the gap itself. A change that used to take an afternoon now lands in seconds. The diff shows up before you&rsquo;ve finished reading the request. Generation, the part we spent decades trying to speed up, is now fast enough to be routine.</p>
+  <p>Closing the handoffs is half the work. The other half is the gap itself. A change that used to take an afternoon now lands in seconds. The diff shows up before you've finished reading the request. Generation, the part we spent decades trying to speed up, is now fast enough to be routine.</p>
 
-  <p>Then the work sits. It sits while someone notices it&rsquo;s ready. It sits while a reviewer rebuilds enough context to have an opinion. It sits in a queue, waiting for the one person who knows whether the next step is safe. The code is written in seconds, and the change ships hours later. Almost none of that gap shows up anywhere you&rsquo;d think to look.</p>
+  <p>Then the work sits. It sits while someone notices it's ready. It sits while a reviewer rebuilds enough context to have an opinion. It sits in a queue, waiting for the one person who knows whether the next step is safe. The code is written in seconds, and the change ships hours later. Almost none of that gap shows up anywhere you'd think to look.</p>
 
-  <p>The waiting between actions is where your lead time goes now, and it&rsquo;s the most expensive part of delivery precisely because nothing measures it. The fix starts with measurement, and there&rsquo;s a cheap, concrete way to begin.</p>
+  <p>The waiting between actions is where your lead time goes now, and it's the most expensive part of delivery precisely because nothing measures it. The fix starts with measurement, and there's a cheap, concrete way to begin.</p>
 
-  <h2>One interrupt costs five transitions</h2>
+  <h2 id="one-interrupt-costs-five-transitions">One interrupt costs five transitions</h2>
 
-  <p>A &ldquo;quick question&rdquo; costs far more than the minute it takes to answer. The real cost is the chain it sets off: you notice the request, switch away from what you were doing, rebuild the mental state for the new thing, act on it, and then recover by climbing back into the work you abandoned and reconstructing where you were. Each link in that chain has its own latency, and most of that latency is pure overhead.</p>
+  <p>A &quot;quick question&quot; costs far more than the minute it takes to answer. The real cost is the chain it sets off: you notice the request, switch away from what you were doing, rebuild the mental state for the new thing, act on it, and then recover by climbing back into the work you abandoned and reconstructing where you were. Each link in that chain has its own latency, and most of that latency is pure overhead.</p>
 
   <figure>
     <div class="diagram-scroll">
@@ -403,16 +458,16 @@
         <div class="node">Recover</div>
       </div>
     </div>
-    <figcaption><b>Diagram 5 &mdash; The interrupt-cost chain.</b> A five-minute question triggers five transitions, and the answer itself (Act) is only one of them.</figcaption>
+    <figcaption><b>Diagram 5 — The interrupt-cost chain.</b> A five-minute question triggers five transitions, and the answer itself is only one of them.</figcaption>
   </figure>
 
   <p>The five minutes of answering is the small box in the middle. The notice, switch, rebuild, and recover are the tax, and both sides of the exchange pay it. Across a queue of work, these costs multiply. Each handoff is an interrupt for whoever receives it, so a backlog of pending handoffs is a backlog of context switches waiting to happen.</p>
 
-  <h2>Every handoff restarts the same discovery from scratch</h2>
+  <h2 id="every-handoff-restarts-the-same-discovery-from-scratch">Every handoff restarts the same discovery from scratch</h2>
 
   <p>The same pattern repeats one level up, at the handoff.</p>
 
-  <p>When work crosses from one actor to another, the receiver starts an investigation: what changed since they last looked, whether they have enough context to act with confidence, who owns this now, and what&rsquo;s blocking it. When any of that is unclear, they ask, and you&rsquo;ve paid for a round trip before any real work happens.</p>
+  <p>When work crosses from one actor to another, the receiver starts an investigation: what changed since they last looked, whether they have enough context to act with confidence, who owns this now, and what's blocking it. When any of that is unclear, they ask, and you've paid for a round trip before any real work happens.</p>
 
   <figure>
     <div class="diagram-scroll">
@@ -428,20 +483,20 @@
         <div class="node start">Receiver&nbsp;asks</div>
       </div>
     </div>
-    <figcaption><b>Diagram 6 &mdash; One handoff round trip.</b> Every question the state can&rsquo;t answer becomes an ask &rarr; answer &rarr; confirm cycle, and the work waits until it closes &mdash; then the next ambiguity restarts it.</figcaption>
+    <figcaption><b>Diagram 6 — One handoff round trip.</b> Every question the state can't answer becomes an ask → answer → confirm cycle, and the work waits until it closes — then the next ambiguity restarts it.</figcaption>
   </figure>
 
-  <p>A mix of humans and AI agents makes it worse. Ambiguous ownership pauses a human until they ask. Missing context halts an agent, which either guesses and leaves you the cleanup or stops cold. Every human-to-agent and agent-to-human swap is one more place the state can drop on the floor. &ldquo;More hands make it faster&rdquo; holds only when the state survives each handoff intact, and any boundary it can fall through quietly cancels the gain you were counting on.</p>
+  <p>A mix of humans and AI agents makes it worse. Ambiguous ownership pauses a human until they ask. Missing context halts an agent, which either guesses and leaves you the cleanup or stops cold. Every human-to-agent and agent-to-human swap is one more place the state can drop on the floor. &quot;More hands make it faster&quot; holds only when the state survives each handoff intact, and any boundary it can fall through quietly cancels the gain you were counting on.</p>
 
-  <h2>The bottleneck is where human attention goes</h2>
+  <h2 id="the-bottleneck-is-where-human-attention-goes">The bottleneck is where human attention goes</h2>
 
-  <p>The tools can show the wait. GitHub timestamps every transition; a pull request&rsquo;s timeline reveals exactly how long it sat between &ldquo;CI passed&rdquo; and &ldquo;someone acted.&rdquo; The waiting is visible, when you choose to look.</p>
+  <p>The tools can show the wait. GitHub timestamps every transition; a pull request's timeline reveals exactly how long it sat between &quot;CI passed&quot; and &quot;someone acted.&quot; The waiting is visible, when you choose to look.</p>
 
-  <p>The cost is not concealment &mdash; it is the routing. Getting work from &ldquo;ready&rdquo; to &ldquo;shipped&rdquo; runs through human attention, and attention has two failure modes. It is often not immediately available: the person who can act is in a meeting, context-switched onto something else, or on the other side of a timezone. That unavailability is where the stall lives. And when attention is available, spending it on mechanical coordination &mdash; noticing a status update, confirming a CI result, deciding a branch is safe to merge &mdash; crowds out the work only a person can do: shaping the product, setting the right review bar, staying accountable for what ships.</p>
+  <p>The cost is not concealment — it is the routing. Getting work from &quot;ready&quot; to &quot;shipped&quot; runs through human attention, and attention has two failure modes. It is often not immediately available: the person who can act is in a meeting, context-switched onto something else, or on the other side of a timezone. That unavailability is where the stall lives. And when attention is available, spending it on mechanical coordination — noticing a status update, confirming a CI result, deciding a branch is safe to merge — crowds out the work only a person can do: shaping the product, setting the right review bar, staying accountable for what ships.</p>
 
-  <p>The drag on lead time is not that the tooling cannot see the wait. It is that routing routine transitions through human attention makes those transitions dependent on attention&rsquo;s availability &mdash; and pulls that attention away from the judgment-heavy decisions where it is irreplaceable.</p>
+  <p>The drag on lead time is not that the tooling cannot see the wait. It is that routing routine transitions through human attention makes those transitions dependent on attention's availability — and pulls that attention away from the judgment-heavy decisions where it is irreplaceable.</p>
 
-  <h2>Four fields get the next actor moving</h2>
+  <h2 id="four-fields-get-the-next-actor-moving">Four fields get the next actor moving</h2>
 
   <p>More meetings and status pings are themselves interrupts. The fix is making the state of the work explicit, so picking it up becomes a continuation of work already in motion.</p>
 
@@ -449,18 +504,18 @@
 
   <ul>
     <li><strong>Who owns it now</strong>, so nobody guesses whose move it is.</li>
-    <li><strong>What&rsquo;s blocking it</strong>, and what would unblock it.</li>
+    <li><strong>What's blocking it</strong>, and what would unblock it.</li>
     <li><strong>The latest decision</strong>, so nobody re-litigates settled ground.</li>
     <li><strong>The safe next step</strong>, the one move known to be safe to take.</li>
   </ul>
 
   <p>Keep these four current and the next actor, human or agent, starts right away. The reconstruction is already written down, ready to read. The investigation that every handoff used to trigger collapses into a glance.</p>
 
-  <h2>Measure the wait first</h2>
+  <h2 id="measure-the-wait-first">Measure the wait first</h2>
 
   <p>Explicit state does more than speed up the next pickup. It turns the waiting into something you can measure, and measurement is what lets you shorten it.</p>
 
-  <p>Once you capture state at each transition, the waits between actors turn into numbers you can point at, in place of anecdotes like &ldquo;review felt slow this sprint.&rdquo; From there you can run a real loop: find the transition that stalls the most, change the process at exactly that point, and check whether the wait dropped. Then confirm the change held quality steady, which is the step people skip once a wait finally drops.</p>
+  <p>Once you capture state at each transition, the waits between actors turn into numbers you can point at, in place of anecdotes like &quot;review felt slow this sprint.&quot; From there you can run a real loop: find the transition that stalls the most, change the process at exactly that point, and check whether the wait dropped. Then confirm the change held quality steady, which is the step people skip once a wait finally drops.</p>
 
   <figure>
     <div class="diagram-scroll">
@@ -476,20 +531,20 @@
         <div class="node start">Capture&nbsp;state</div>
       </div>
     </div>
-    <figcaption><b>Diagram 7 &mdash; The measurement loop.</b> Capture, measure, change, verify &mdash; then back to capture. It repeats as a cycle, because the slowest transition moves as you fix things.</figcaption>
+    <figcaption><b>Diagram 7 — The measurement loop.</b> Capture, measure, change, verify — then back to capture. It repeats as a cycle, because the slowest transition moves as you fix things.</figcaption>
   </figure>
 
   <p>This is ordinary improvement discipline, applied to the part of delivery that has stayed invisible. Shortening a wait depends on measuring it, and measuring it depends on capturing its state.</p>
 
-  <h2>Those four fields already live in the work</h2>
+  <h2 id="those-four-fields-already-live-in-the-work">Those four fields already live in the work</h2>
 
-  <p>&ldquo;Make the state explicit&rdquo; is more concrete than &ldquo;write better tickets&rdquo;: each of the four fields maps onto a mechanism that already does the work when you let it.</p>
+  <p>&quot;Make the state explicit&quot; is more concrete than &quot;write better tickets&quot;: each of the four fields maps onto a mechanism that already does the work when you let it.</p>
 
-  <p><strong>Owner and safe next step are a board.</strong> Work moves through visible columns: waiting, in progress, done. The column carries the current owner and the safe next step, so a glance at it tells you both. A deterministic resolver picks the next action from the board&rsquo;s state, so &ldquo;whose move is it?&rdquo; has one settled answer.</p>
+  <p><strong>Owner and safe next step are a board.</strong> Work moves through visible columns: waiting, in progress, done. The column carries the current owner and the safe next step, so a glance at it tells you both. A deterministic resolver picks the next action from the board's state, so &quot;whose move is it?&quot; has one settled answer.</p>
 
   <p><strong>The latest decision leaves a trail.</strong> Each review gate records its verdict in the open, with the findings that justified it attached. The decision lives written down, where it survives past the moment someone logs off. Pick the work up tomorrow and the reasoning is still there, right where the verdict was.</p>
 
-  <p><strong>Automation runs only where the state proves it&rsquo;s safe.</strong> Handle the wait at CI by waiting on the real result, the actual check status from whatever provider runs it. After a merge, finished workspaces get reclaimed and long-done items get archived. Each of those automations is gated on state that says continuing is safe. The judgment stays human while the waiting in between gets handled automatically.</p>
+  <p><strong>Automation runs only where the state proves it's safe.</strong> Handle the wait at CI by waiting on the real result, the actual check status from whatever provider runs it. After a merge, finished workspaces get reclaimed and long-done items get archived. Each of those automations is gated on state that says continuing is safe. The judgment stays human while the waiting in between gets handled automatically.</p>
 
   <figure>
     <div class="diagram-scroll">
@@ -499,10 +554,8 @@
             <path d="M0,0 L7,3 L0,6 Z" fill="rgba(148,163,184,0.85)" />
           </marker>
         </defs>
-        <!-- root -->
         <rect x="230" y="14" width="180" height="46" rx="13" fill="rgba(24,36,61,0.92)" stroke="rgba(167,139,250,0.7)"/>
         <text x="320" y="42" text-anchor="middle" font-size="15" style="fill:#ddd6fe">Observable state</text>
-        <!-- three mechanisms -->
         <rect x="22" y="118" width="180" height="58" rx="13" fill="rgba(24,36,61,0.92)" stroke="rgba(129,140,248,0.4)"/>
         <text x="112" y="143" text-anchor="middle" font-size="13">Board lifecycle</text>
         <text x="112" y="162" text-anchor="middle" font-size="11" class="lbl">owner + safe next step</text>
@@ -514,45 +567,31 @@
         <rect x="438" y="118" width="180" height="58" rx="13" fill="rgba(24,36,61,0.92)" stroke="rgba(129,140,248,0.4)"/>
         <text x="528" y="143" text-anchor="middle" font-size="13">Next-action resolver</text>
         <text x="528" y="162" text-anchor="middle" font-size="11" class="lbl">whose move it is</text>
-        <!-- outcome -->
         <rect x="150" y="232" width="340" height="50" rx="13" fill="rgba(24,36,61,0.92)" stroke="rgba(147,197,253,0.6)"/>
         <text x="320" y="262" text-anchor="middle" font-size="14" style="fill:#93c5fd">Next actor starts immediately</text>
-        <!-- automation -->
         <rect x="120" y="316" width="400" height="40" rx="13" fill="rgba(17,24,39,0.82)" stroke="rgba(167,139,250,0.55)"/>
         <text x="320" y="341" text-anchor="middle" font-size="12.5" style="fill:#ddd6fe">CI wait + post-merge reclaim run only where state says safe</text>
-        <!-- edges root -> mechanisms -->
         <path d="M285,60 L130,116" stroke="rgba(148,163,184,0.85)" fill="none" marker-end="url(#ah2)"/>
         <path d="M320,60 L320,116" stroke="rgba(148,163,184,0.85)" fill="none" marker-end="url(#ah2)"/>
         <path d="M355,60 L510,116" stroke="rgba(148,163,184,0.85)" fill="none" marker-end="url(#ah2)"/>
-        <!-- edges mechanisms -> outcome -->
         <path d="M120,176 L240,230" stroke="rgba(148,163,184,0.85)" fill="none" marker-end="url(#ah2)"/>
         <path d="M320,176 L320,230" stroke="rgba(148,163,184,0.85)" fill="none" marker-end="url(#ah2)"/>
         <path d="M520,176 L400,230" stroke="rgba(148,163,184,0.85)" fill="none" marker-end="url(#ah2)"/>
-        <!-- outcome -> automation -->
         <path d="M320,282 L320,314" stroke="rgba(167,139,250,0.7)" fill="none" marker-end="url(#ah2)"/>
       </svg>
     </div>
-    <figcaption><b>Diagram 8 &mdash; Grounding &ldquo;observable state&rdquo; in real mechanisms.</b> The board carries owner and next step, the gate trail carries the latest decision, the resolver answers whose move it is, and safe automation runs on that confirmed state.</figcaption>
+    <figcaption><b>Diagram 8 — Grounding &quot;observable state&quot; in real mechanisms.</b> The board carries owner and next step, the gate trail carries the latest decision, the resolver answers whose move it is, and safe automation runs on that confirmed state.</figcaption>
   </figure>
 
   <p>These are the same mechanisms from Part 1, read from the other side. The board, the gates, and the resolver carry the four fields latent in the work, ready to surface. Making them explicit stops them from leaking.</p>
 
-  <h2>The close</h2>
+  <h2 id="the-close">The close</h2>
 
-  <p>AI made the code cheap, and the coordination around it is now the expensive part. Most of that cost is paid in bad handoffs: wrong routing, stalls nobody noticed, and a "done" that was only assumed. The rest is paid in the waiting between actions, which stays expensive because nothing measures it.</p>
+  <p>AI made the code cheap, and the coordination around it is now the expensive part. Most of that cost is paid in bad handoffs: wrong routing, stalls nobody noticed, and a &quot;done&quot; that was only assumed. The rest is paid in the waiting between actions, which stays expensive because nothing measures it.</p>
 
-  <p>So make the next step always known, and measure the waits. Compute the next action for any change and put it on the board, so whoever is free pulls it. Once the next action is visible, the rest follows from it: who acts next, whether it is safe to pause, what a mid-flight instruction means, and above all whether the work has actually merged. A handoff still happens when someone adds a note, and it stays a decision you can see. Build that on a state graph so the guarantee holds even when the model underneath you changes. Then capture state at each transition so the biggest stall shows up in plain numbers, and automate only where the state proves it&rsquo;s safe.</p>
+  <p>So make the next step always known, and measure the waits. Compute the next action for any change and put it on the board, so whoever is free pulls it. Once the next action is visible, the rest follows from it: who acts next, whether it is safe to pause, what a mid-flight instruction means, and above all whether the work has actually merged. A handoff still happens when someone adds a note, and it stays a decision you can see. Build that on a state graph so the guarantee holds even when the model underneath you changes. Then capture state at each transition so the biggest stall shows up in plain numbers, and automate only where the state proves it's safe.</p>
 
   <p class="closer">The next agent will write your code in seconds. The lever you control is the coordination around it: keep the next step known so the next actor pulls it, and measure how long the work waits.</p>
-
-<!--
-  <hr class="rule" />
-
-  <div class="render-note">
-    <h2>Rendering the diagrams on Medium</h2>
-    <p>Medium does not natively render Mermaid. In the Markdown version of this article each diagram is a fenced <code>mermaid</code> block so it stays editable, and each carries a caption so the article reads cleanly with each diagram shown as a static image. To publish on Medium, either paste each block into a Mermaid-enabled editor and embed the rendered image, or export each diagram as SVG/PNG and drop it in where the block sits. Because every diagram is captioned, the prose carries the argument on its own.</p>
-  </div>
--->
 
 </article>
 </div>

--- a/docs/articles/dev-loops-deep-dive.html
+++ b/docs/articles/dev-loops-deep-dive.html
@@ -64,10 +64,9 @@
     font-weight: 600;
   }
 
-  h1, h2, h3 { color: var(--heading); letter-spacing: -0.02em; margin-top: 0; }
+  h1, h2 { color: var(--heading); letter-spacing: -0.02em; margin-top: 0; }
   h1 { font-weight: 760; font-size: clamp(1.9rem, 5vw, 2.7rem); line-height: 1.08; margin-bottom: 0.9rem; }
   h2 { font-weight: 720; font-size: clamp(1.35rem, 3.4vw, 1.85rem); line-height: 1.15; margin: 2.6rem 0 0.9rem; }
-  h3 { font-weight: 680; font-size: clamp(1.08rem, 2.4vw, 1.28rem); line-height: 1.25; margin: 1.8rem 0 0.6rem; color: var(--accent-soft); }
 
   /* part divider: the two big movements of a two-part deep dive */
   .part {
@@ -186,7 +185,6 @@
   }
   .node.accent { border-color: rgba(167, 139, 250, 0.7); color: var(--accent-soft); }
   .node.start { border-color: rgba(147, 197, 253, 0.6); color: var(--kicker); }
-  .node.done { border-color: rgba(110, 231, 183, 0.6); color: #6ee7b7; }
   .edge {
     display: flex;
     flex-direction: column;

--- a/docs/articles/dev-loops-deep-dive.md
+++ b/docs/articles/dev-loops-deep-dive.md
@@ -1,12 +1,14 @@
 ---
 title: "dev-loops: A Deep Dive"
 subtitle: "AI made writing code cheap. The hours now go into the handoffs around the code, and into the waiting between actions."
+heroLede: "AI made writing code cheap. The hours now go into the handoffs around the code, author to reviewer, reviewer to CI, CI back to a human, and into the waiting between actions."
 tags:
   - AI
   - Software Engineering
   - Developer Tools
   - Automation
   - Productivity
+outro: closer
 ---
 
 # dev-loops: A Deep Dive
@@ -45,17 +47,33 @@ stateDiagram-v2
 
 *Diagram 1 — The nested loops. An outer "what is the next action here?" decision routes each cycle to exactly one move, then returns to ask again. When the next step is ambiguous, the loop hands control to a human.*
 
+<!-- figure
+      <div class="flow" role="img" aria-label="Nested loops: from Start the system repeatedly computes what the next action is — write the code, resolve feedback, or ask a human when ambiguous — then returns to that decision.">
+        <div class="node start">Start</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node accent">What&nbsp;is&nbsp;the&nbsp;next&nbsp;action?</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="flow-col">
+          <div class="node">Write&nbsp;the&nbsp;code</div>
+          <div class="node">Resolve&nbsp;feedback</div>
+          <div class="node">Ask&nbsp;a&nbsp;human&nbsp;(ambiguous)</div>
+        </div>
+        <div class="edge"><span class="arrow">&rarr;</span><span class="edge-label">one move, then ask again</span></div>
+        <div class="node accent">What&nbsp;is&nbsp;the&nbsp;next&nbsp;action?</div>
+      </div>
+-->
+
 ## What a known next step buys you
 
 Computing the next action for any change makes four behaviors possible that a guess-based workflow cannot offer.
 
-The first is safe pauses. Because the system always knows where it is, it can stop without making a mess. Ask it to stop mid-edit and it finishes the current step, lands it clean, and hands you a stopping point with the file intact. There are only a few honest answers to "can I stop now?": stop this instant, stop at the next clean boundary, or not yet because a required check is missing. The system gives you whichever one holds.
+The first is safe pauses. Because the system always knows where it is, it can stop without making a mess. Ask it to stop mid-edit and it finishes the current step, lands it clean, and hands you a stopping point with the file intact. There are only two honest answers to "can I stop now?": stop at the next clean boundary, or not yet because a required check is missing. The system gives you whichever one holds.
 
 The second is mid-flight steering. You can change the rules while the machine keeps running. Halfway through a run you can say "don't touch the auth module," and that lands as a hard constraint the remaining steps must honor; the run keeps its progress and applies the rule from the next move on. A softer nudge becomes a preference the system honors when it can, and a "stop when safe" request winds the work down at the next clean boundary.
 
-The third is parallel review that consolidates into a single verdict. Several reviewers examine a pull request at once, each on a different angle (scope, test coverage, security), and all of them read the *same evidence bundle*: the same diff, the same context. Because the inputs are identical, the verdicts are directly comparable, and they merge into a single answer. One serious finding blocks the merge.
+The third is parallel review that consolidates into a single verdict. Several reviewers examine a pull request at once, each on a different angle (scope, coverage, input validation, among others), and all of them read the *same evidence bundle*: the same diff, the same context. Because the inputs are identical, the verdicts are directly comparable, and they merge into a single answer. One serious finding blocks the merge.
 
-The fourth is the most important: "done" means merged. The board shows done only when a pull request has actually merged, read from the platform's own merge signal that the agent cannot fabricate. CI-green comes from the real check result, so the system waits for it before proceeding. And the merge itself always belongs to a contributor.
+The fourth is the most important: "done" means merged. The board shows done only when a pull request has actually merged, read from the platform's own merge signal that the agent cannot fabricate. CI-green comes from the real check result, so the system waits for it before proceeding. And the merge itself is a human's call by default.
 
 ```mermaid
 flowchart TD
@@ -66,12 +84,59 @@ flowchart TD
   D -- yes --> E[Author resolves] --> C
   D -- no --> F{Pre-approval gate:<br/>CI verified green?}
   F -- not yet --> C
-  F -- yes --> G[Hand to a contributor]
-  G --> H[Human merges]
-  H --> I([Done = merged])
+  F -- yes --> G[Human merges]
+  G --> H([Done = merged])
 ```
 
 *Diagram 2 — A pull request's lifecycle through the gates. Every gate must run before the next step: a draft with missing checks loops back, an unresolved finding returns to the author, and a human performs the merge.*
+
+<!-- figure
+      <svg viewBox="0 0 640 300" width="640" role="img" aria-label="A pull request's lifecycle through the gates">
+        <defs>
+          <marker id="ah" markerWidth="9" markerHeight="9" refX="7" refY="4" orient="auto">
+            <path d="M0,0 L8,4 L0,8 z" fill="#94a3b8" />
+          </marker>
+        </defs>
+        <g font-size="12">
+          <rect x="20" y="20" width="150" height="40" rx="12" fill="#0f172a" stroke="#93c5fd" />
+          <text x="95" y="44" text-anchor="middle">Draft opened</text>
+
+          <rect x="20" y="100" width="150" height="48" rx="12" fill="#111827" stroke="#818cf8" />
+          <text x="95" y="120" text-anchor="middle">Draft gate:</text>
+          <text x="95" y="136" text-anchor="middle">checks present?</text>
+
+          <rect x="245" y="100" width="150" height="40" rx="12" fill="#0f172a" stroke="#818cf8" />
+          <text x="320" y="124" text-anchor="middle">Review rounds</text>
+
+          <rect x="245" y="20" width="150" height="48" rx="12" fill="#111827" stroke="#a78bfa" />
+          <text x="320" y="40" text-anchor="middle" class="lab">findings? author</text>
+          <text x="320" y="56" text-anchor="middle" class="lab">resolves &amp; loops</text>
+
+          <rect x="470" y="100" width="150" height="48" rx="12" fill="#111827" stroke="#818cf8" />
+          <text x="545" y="120" text-anchor="middle">Pre-approval gate:</text>
+          <text x="545" y="136" text-anchor="middle">CI green?</text>
+
+          <rect x="470" y="200" width="150" height="40" rx="12" fill="#0f172a" stroke="#818cf8" />
+          <text x="545" y="224" text-anchor="middle">Hand to a human</text>
+
+          <rect x="245" y="200" width="150" height="40" rx="12" fill="#0f172a" stroke="#6ee7b7" />
+          <text x="320" y="224" text-anchor="middle" style="fill:#6ee7b7">Done = merged</text>
+        </g>
+        <g stroke="#94a3b8" fill="none" stroke-width="1.4" marker-end="url(#ah)">
+          <path d="M95,60 L95,100" />
+          <path d="M170,124 L245,122" />
+          <path d="M320,100 L320,68" />
+          <path d="M395,120 L470,122" />
+          <path d="M545,148 L545,200" />
+          <path d="M470,220 L395,220" />
+        </g>
+        <g font-size="10" font-family="-apple-system, sans-serif">
+          <text x="60" y="84" style="fill:#93c5fd">yes</text>
+          <text x="408" y="114" style="fill:#93c5fd">verified</text>
+          <text x="500" y="180" style="fill:#93c5fd">human merges</text>
+        </g>
+      </svg>
+-->
 
 ## Fan out wide, fan in to one answer
 
@@ -81,7 +146,7 @@ The parallel review deserves a closer look, because it is a small pattern with a
 flowchart LR
   E[One neutral<br/>evidence bundle] --> S[Scope review]
   E --> C[Coverage review]
-  E --> Z[Security review]
+  E --> Z[Input validation review]
   S --> V{Consolidate}
   C --> V
   Z --> V
@@ -89,6 +154,20 @@ flowchart LR
 ```
 
 *Diagram 3 — Fan-out / fan-in. One evidence bundle fans out to independent reviewers working different angles in parallel, then their findings fan back in to a single consolidated verdict.*
+
+<!-- figure
+      <div class="flow" role="img" aria-label="Fan-out then fan-in: one neutral evidence bundle goes as the same diff to independent scope, coverage, and input-validation reviewers; the strictest verdict wins.">
+        <div class="node start">One&nbsp;neutral<br/>evidence&nbsp;bundle</div>
+        <div class="edge"><span class="arrow">&rarr;</span><span class="edge-label">same diff to each</span></div>
+        <div class="flow-col">
+          <div class="node">Scope&nbsp;review</div>
+          <div class="node">Coverage&nbsp;review</div>
+          <div class="node">Input&nbsp;validation&nbsp;review</div>
+        </div>
+        <div class="edge"><span class="arrow">&rarr;</span><span class="edge-label">consolidate</span></div>
+        <div class="node accent">One&nbsp;verdict<br/>strictest&nbsp;wins</div>
+      </div>
+-->
 
 A shared bundle keeps the angles aligned, because when each reviewer scrapes its own context they end up arguing about different versions of reality. With one input feeding every angle in parallel, the verdicts stay comparable and merge into a single answer you can trust.
 
@@ -110,6 +189,25 @@ flowchart TD
 ```
 
 *Diagram 4 — Steering flow. A hard constraint is applied immediately when it is safe, or queued until the next safe point. The run keeps its progress either way and applies the change only at a clean boundary.*
+
+<!-- figure
+      <div class="flow" role="img" aria-label="Mid-flight steering: an operator instruction is classified as a hard constraint or a preference; a hard constraint applies from the next move or queues until safe, a preference is honored when safe.">
+        <div class="node start">Operator&nbsp;injects<br/>an&nbsp;instruction</div>
+        <div class="edge"><span class="arrow">&rarr;</span><span class="edge-label">classify</span></div>
+        <div class="flow-col">
+          <div class="node accent">Hard&nbsp;constraint</div>
+          <div class="node">Preference</div>
+          <div class="node">Stop&nbsp;when&nbsp;safe</div>
+        </div>
+        <div class="edge"><span class="arrow">&rarr;</span><span class="edge-label">safe now?</span></div>
+        <div class="flow-col">
+          <div class="node">Apply&nbsp;from&nbsp;next&nbsp;move</div>
+          <div class="node">Queue&nbsp;until&nbsp;safe</div>
+        </div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node accent">Run&nbsp;continues,<br/>steered</div>
+      </div>
+-->
 
 ## Why a state graph beats a prompt
 
@@ -141,6 +239,22 @@ flowchart LR
 ```
 *Diagram 5 — The interrupt-cost chain. A five-minute question triggers five transitions, and the answer itself is only one of them.*
 
+<!-- figure
+      <div class="flow" role="img" aria-label="Interrupt cost: one interruption forces five transitions — Notice, Switch, Rebuild state, Act, then Recover — before the original work resumes.">
+        <div class="node start">Need&nbsp;response</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node">Notice</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node">Switch</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node accent">Rebuild&nbsp;state</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node accent">Act</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node">Recover</div>
+      </div>
+-->
+
 The five minutes of answering is the small box in the middle. The notice, switch, rebuild, and recover are the tax, and both sides of the exchange pay it. Across a queue of work, these costs multiply. Each handoff is an interrupt for whoever receives it, so a backlog of pending handoffs is a backlog of context switches waiting to happen.
 
 ## Every handoff restarts the same discovery from scratch
@@ -158,6 +272,20 @@ flowchart LR
 ```
 *Diagram 6 — One handoff round trip. Every question the state can't answer becomes an ask → answer → confirm cycle, and the work waits until it closes — then the next ambiguity restarts it.*
 
+<!-- figure
+      <div class="flow" role="img" aria-label="Handoff round trip: Receiver asks, Sender answers, Receiver confirms, work resumes — then the cycle repeats on the next ambiguity.">
+        <div class="node start">Receiver&nbsp;asks</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node">Sender&nbsp;answers</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node">Receiver&nbsp;confirms</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node accent">Work&nbsp;resumes</div>
+        <div class="edge dashed"><span class="arrow">&#8630;</span><span class="edge-label">next ambiguity</span></div>
+        <div class="node start">Receiver&nbsp;asks</div>
+      </div>
+-->
+
 A mix of humans and AI agents makes it worse. Ambiguous ownership pauses a human until they ask. Missing context halts an agent, which either guesses and leaves you the cleanup or stops cold. Every human-to-agent and agent-to-human swap is one more place the state can drop on the floor. "More hands make it faster" holds only when the state survives each handoff intact, and any boundary it can fall through quietly cancels the gain you were counting on.
 
 ## The bottleneck is where human attention goes
@@ -166,7 +294,7 @@ The tools can show the wait. GitHub timestamps every transition; a pull request'
 
 The cost is not concealment — it is the routing. Getting work from "ready" to "shipped" runs through human attention, and attention has two failure modes. It is often not immediately available: the person who can act is in a meeting, context-switched onto something else, or on the other side of a timezone. That unavailability is where the stall lives. And when attention is available, spending it on mechanical coordination — noticing a status update, confirming a CI result, deciding a branch is safe to merge — crowds out the work only a person can do: shaping the product, setting the right review bar, staying accountable for what ships.
 
-The drag on lead time is not that the tooling cannot see the wait. It is that routing routine transitions through human attention makes those transitions dependent on attention's availability — and pulls that attention away from the judgment-heavy decisions where it is genuinely irreplaceable.
+The drag on lead time is not that the tooling cannot see the wait. It is that routing routine transitions through human attention makes those transitions dependent on attention's availability — and pulls that attention away from the judgment-heavy decisions where it is irreplaceable.
 
 ## Four fields get the next actor moving
 
@@ -196,6 +324,20 @@ flowchart LR
 ```
 *Diagram 7 — The measurement loop. Capture, measure, change, verify — then back to capture. It repeats as a cycle, because the slowest transition moves as you fix things.*
 
+<!-- figure
+      <div class="flow" role="img" aria-label="Measurement loop: Capture state, Measure waits, Change the process, Verify outcomes — then loop back to capture.">
+        <div class="node start">Capture&nbsp;state</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node">Measure&nbsp;waits</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node accent">Change&nbsp;the&nbsp;process</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node">Verify&nbsp;outcomes</div>
+        <div class="edge"><span class="arrow">&#8635;</span><span class="edge-label">back to capture</span></div>
+        <div class="node start">Capture&nbsp;state</div>
+      </div>
+-->
+
 This is ordinary improvement discipline, applied to the part of delivery that has stayed invisible. Shortening a wait depends on measuring it, and measuring it depends on capturing its state.
 
 ## Those four fields already live in the work
@@ -221,6 +363,40 @@ flowchart TD
 
 *Diagram 8 — Grounding "observable state" in real mechanisms. The board carries owner and next step, the gate trail carries the latest decision, the resolver answers whose move it is, and safe automation runs on that confirmed state.*
 
+<!-- figure
+      <svg class="tree-svg" viewBox="0 0 640 360" role="img" aria-label="Observable state feeds the board, gate trail, and resolver, which let the next actor start and let safe automation run.">
+        <defs>
+          <marker id="ah2" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto">
+            <path d="M0,0 L7,3 L0,6 Z" fill="rgba(148,163,184,0.85)" />
+          </marker>
+        </defs>
+        <rect x="230" y="14" width="180" height="46" rx="13" fill="rgba(24,36,61,0.92)" stroke="rgba(167,139,250,0.7)"/>
+        <text x="320" y="42" text-anchor="middle" font-size="15" style="fill:#ddd6fe">Observable state</text>
+        <rect x="22" y="118" width="180" height="58" rx="13" fill="rgba(24,36,61,0.92)" stroke="rgba(129,140,248,0.4)"/>
+        <text x="112" y="143" text-anchor="middle" font-size="13">Board lifecycle</text>
+        <text x="112" y="162" text-anchor="middle" font-size="11" class="lbl">owner + safe next step</text>
+
+        <rect x="230" y="118" width="180" height="58" rx="13" fill="rgba(24,36,61,0.92)" stroke="rgba(129,140,248,0.4)"/>
+        <text x="320" y="143" text-anchor="middle" font-size="13">Gate evidence trail</text>
+        <text x="320" y="162" text-anchor="middle" font-size="11" class="lbl">latest decision + findings</text>
+
+        <rect x="438" y="118" width="180" height="58" rx="13" fill="rgba(24,36,61,0.92)" stroke="rgba(129,140,248,0.4)"/>
+        <text x="528" y="143" text-anchor="middle" font-size="13">Next-action resolver</text>
+        <text x="528" y="162" text-anchor="middle" font-size="11" class="lbl">whose move it is</text>
+        <rect x="150" y="232" width="340" height="50" rx="13" fill="rgba(24,36,61,0.92)" stroke="rgba(147,197,253,0.6)"/>
+        <text x="320" y="262" text-anchor="middle" font-size="14" style="fill:#93c5fd">Next actor starts immediately</text>
+        <rect x="120" y="316" width="400" height="40" rx="13" fill="rgba(17,24,39,0.82)" stroke="rgba(167,139,250,0.55)"/>
+        <text x="320" y="341" text-anchor="middle" font-size="12.5" style="fill:#ddd6fe">CI wait + post-merge reclaim run only where state says safe</text>
+        <path d="M285,60 L130,116" stroke="rgba(148,163,184,0.85)" fill="none" marker-end="url(#ah2)"/>
+        <path d="M320,60 L320,116" stroke="rgba(148,163,184,0.85)" fill="none" marker-end="url(#ah2)"/>
+        <path d="M355,60 L510,116" stroke="rgba(148,163,184,0.85)" fill="none" marker-end="url(#ah2)"/>
+        <path d="M120,176 L240,230" stroke="rgba(148,163,184,0.85)" fill="none" marker-end="url(#ah2)"/>
+        <path d="M320,176 L320,230" stroke="rgba(148,163,184,0.85)" fill="none" marker-end="url(#ah2)"/>
+        <path d="M520,176 L400,230" stroke="rgba(148,163,184,0.85)" fill="none" marker-end="url(#ah2)"/>
+        <path d="M320,282 L320,314" stroke="rgba(167,139,250,0.7)" fill="none" marker-end="url(#ah2)"/>
+      </svg>
+-->
+
 These are the same mechanisms from Part 1, read from the other side. The board, the gates, and the resolver carry the four fields latent in the work, ready to surface. Making them explicit stops them from leaking.
 
 ## The close
@@ -230,13 +406,3 @@ AI made the code cheap, and the coordination around it is now the expensive part
 So make the next step always known, and measure the waits. Compute the next action for any change and put it on the board, so whoever is free pulls it. Once the next action is visible, the rest follows from it: who acts next, whether it is safe to pause, what a mid-flight instruction means, and above all whether the work has actually merged. A handoff still happens when someone adds a note, and it stays a decision you can see. Build that on a state graph so the guarantee holds even when the model underneath you changes. Then capture state at each transition so the biggest stall shows up in plain numbers, and automate only where the state proves it's safe.
 
 The next agent will write your code in seconds. The lever you control is the coordination around it: keep the next step known so the next actor pulls it, and measure how long the work waits.
-
-<!--
----
-
-## Rendering the diagrams on Medium
-
-Before pasting into Medium, remove the YAML front-matter block (the `---` fenced `title` / `subtitle` / `tags` at the top) — Medium shows it as literal text; use the title and subtitle as the Medium headline and subtitle, and the tags as Medium tags.
-
-Medium does not natively render Mermaid. Each diagram above is written as a fenced `mermaid` block so it stays editable, and each carries a caption so the article reads cleanly with each diagram shown as a static image. To publish on Medium, either paste each block into a Mermaid-enabled editor (for example, the Mermaid Live Editor or any Markdown tool with Mermaid support) and embed the rendered image, or export each diagram as SVG/PNG and drop it in where the block sits. Because every diagram is captioned, the prose carries the argument on its own and the diagrams support it.
--->

--- a/docs/articles/introducing-dev-loops.html
+++ b/docs/articles/introducing-dev-loops.html
@@ -69,6 +69,15 @@
   h2 { font-weight: 720; font-size: clamp(1.35rem, 3.4vw, 1.85rem); line-height: 1.15; margin: 2.6rem 0 0.9rem; }
   h3 { font-weight: 680; font-size: clamp(1.08rem, 2.4vw, 1.28rem); line-height: 1.25; margin: 1.8rem 0 0.6rem; color: var(--accent-soft); }
 
+  /* part divider: the two big movements of a two-part deep dive */
+  .part {
+    margin: 3.4rem 0 1.4rem;
+    padding-top: 2.2rem;
+    border-top: 1px solid rgba(148, 163, 184, 0.16);
+  }
+  .part .kicker { margin-bottom: 0.4rem; }
+  .part h2 { margin-top: 0; font-size: clamp(1.5rem, 3.8vw, 2.1rem); }
+
   .lede {
     color: var(--copy);
     font-size: clamp(1.08rem, 2.4vw, 1.28rem);
@@ -83,6 +92,18 @@
   li + li { margin-top: 0.5rem; }
   a { color: var(--kicker); text-decoration: none; border-bottom: 1px solid rgba(147, 197, 253, 0.35); }
   a:hover { border-bottom-color: var(--kicker); }
+
+  /* callout: a left-accent glass panel for asides (e.g. a cross-link nudge) */
+  blockquote {
+    margin: 1.6rem 0;
+    padding: 0.9rem 1.2rem;
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid var(--card-border);
+    border-left: 3px solid var(--accent);
+    border-radius: 0 14px 14px 0;
+    color: var(--copy);
+  }
+  blockquote p { margin: 0; }
 
   code {
     font-family: var(--mono);
@@ -126,6 +147,82 @@
     margin-bottom: 2.6rem;
   }
   .hero-card .lede { margin-bottom: 0; }
+
+  /* diagram figure: glass card + horizontal-scroll safety for wide flows */
+  figure {
+    margin: 1.8rem 0 2rem;
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0.8), rgba(15, 23, 42, 0.62));
+    border: 1px solid var(--card-border);
+    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.26);
+    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(12px);
+    border-radius: 20px;
+    padding: 1.3rem 1.35rem 1.1rem;
+  }
+  .diagram-scroll { overflow-x: auto; padding-bottom: 0.35rem; }
+  figcaption {
+    color: var(--copy);
+    font-size: 0.9rem;
+    line-height: 1.45;
+    margin-top: 1rem;
+    border-top: 1px solid rgba(148, 163, 184, 0.14);
+    padding-top: 0.8rem;
+  }
+  figcaption b { color: var(--accent-soft); font-weight: 650; }
+
+  /* inline flow nodes (ported from the deck's inline-flow technique) */
+  .flow { display: flex; align-items: center; gap: 0; min-width: max-content; }
+  .flow-col { display: flex; flex-direction: column; gap: 0.55rem; justify-content: center; }
+  .node {
+    background: linear-gradient(180deg, rgba(24, 36, 61, 0.92), rgba(17, 24, 39, 0.82));
+    border: 1px solid var(--node-border);
+    border-radius: 14px;
+    padding: 0.55rem 0.85rem;
+    font-family: var(--mono);
+    font-size: 0.8rem;
+    color: #e2e8f0;
+    white-space: nowrap;
+    text-align: center;
+  }
+  .node.accent { border-color: rgba(167, 139, 250, 0.7); color: var(--accent-soft); }
+  .node.start { border-color: rgba(147, 197, 253, 0.6); color: var(--kicker); }
+  .node.done { border-color: rgba(110, 231, 183, 0.6); color: #6ee7b7; }
+  .edge {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    color: rgba(148, 163, 184, 0.85);
+    padding: 0 0.6rem;
+    min-width: 3rem;
+  }
+  .edge .arrow { font-size: 1.1rem; line-height: 1; }
+  .edge.dashed .arrow { color: rgba(167, 139, 250, 0.75); }
+  .edge .edge-label {
+    font-size: 0.64rem;
+    color: var(--kicker);
+    text-align: center;
+    margin-top: 0.2rem;
+    max-width: 7.5rem;
+    line-height: 1.2;
+  }
+
+  /* SVG diagrams scale within their scroll container */
+  .diagram-scroll svg { display: block; height: auto; }
+  .diagram-scroll svg text { font-family: var(--mono); fill: #e2e8f0; }
+  .diagram-scroll svg .lab { fill: var(--kicker); font-family: var(--font); }
+
+  /* tree grounding diagram scales down on mobile */
+  .tree-svg { width: 100%; height: auto; display: block; }
+  .tree-svg text { font-family: var(--mono); fill: #e2e8f0; }
+  .tree-svg .lbl { fill: var(--kicker); font-family: var(--font); }
+
+  .closer {
+    color: var(--accent-soft);
+    font-weight: 620;
+    font-size: clamp(1.12rem, 2.6vw, 1.4rem);
+    line-height: 1.4;
+    margin: 1.6rem 0 0;
+  }
 
   /* metric row for the proof numbers */
   .metrics {

--- a/docs/articles/introducing-dev-loops.html
+++ b/docs/articles/introducing-dev-loops.html
@@ -64,10 +64,9 @@
     font-weight: 600;
   }
 
-  h1, h2, h3 { color: var(--heading); letter-spacing: -0.02em; margin-top: 0; }
+  h1, h2 { color: var(--heading); letter-spacing: -0.02em; margin-top: 0; }
   h1 { font-weight: 760; font-size: clamp(1.9rem, 5vw, 2.7rem); line-height: 1.08; margin-bottom: 0.9rem; }
   h2 { font-weight: 720; font-size: clamp(1.35rem, 3.4vw, 1.85rem); line-height: 1.15; margin: 2.6rem 0 0.9rem; }
-  h3 { font-weight: 680; font-size: clamp(1.08rem, 2.4vw, 1.28rem); line-height: 1.25; margin: 1.8rem 0 0.6rem; color: var(--accent-soft); }
 
   /* part divider: the two big movements of a two-part deep dive */
   .part {
@@ -186,7 +185,6 @@
   }
   .node.accent { border-color: rgba(167, 139, 250, 0.7); color: var(--accent-soft); }
   .node.start { border-color: rgba(147, 197, 253, 0.6); color: var(--kicker); }
-  .node.done { border-color: rgba(110, 231, 183, 0.6); color: #6ee7b7; }
   .edge {
     display: flex;
     flex-direction: column;

--- a/scripts/pages/article-shell.html
+++ b/scripts/pages/article-shell.html
@@ -69,6 +69,15 @@
   h2 { font-weight: 720; font-size: clamp(1.35rem, 3.4vw, 1.85rem); line-height: 1.15; margin: 2.6rem 0 0.9rem; }
   h3 { font-weight: 680; font-size: clamp(1.08rem, 2.4vw, 1.28rem); line-height: 1.25; margin: 1.8rem 0 0.6rem; color: var(--accent-soft); }
 
+  /* part divider: the two big movements of a two-part deep dive */
+  .part {
+    margin: 3.4rem 0 1.4rem;
+    padding-top: 2.2rem;
+    border-top: 1px solid rgba(148, 163, 184, 0.16);
+  }
+  .part .kicker { margin-bottom: 0.4rem; }
+  .part h2 { margin-top: 0; font-size: clamp(1.5rem, 3.8vw, 2.1rem); }
+
   .lede {
     color: var(--copy);
     font-size: clamp(1.08rem, 2.4vw, 1.28rem);
@@ -83,6 +92,18 @@
   li + li { margin-top: 0.5rem; }
   a { color: var(--kicker); text-decoration: none; border-bottom: 1px solid rgba(147, 197, 253, 0.35); }
   a:hover { border-bottom-color: var(--kicker); }
+
+  /* callout: a left-accent glass panel for asides (e.g. a cross-link nudge) */
+  blockquote {
+    margin: 1.6rem 0;
+    padding: 0.9rem 1.2rem;
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid var(--card-border);
+    border-left: 3px solid var(--accent);
+    border-radius: 0 14px 14px 0;
+    color: var(--copy);
+  }
+  blockquote p { margin: 0; }
 
   code {
     font-family: var(--mono);
@@ -126,6 +147,82 @@
     margin-bottom: 2.6rem;
   }
   .hero-card .lede { margin-bottom: 0; }
+
+  /* diagram figure: glass card + horizontal-scroll safety for wide flows */
+  figure {
+    margin: 1.8rem 0 2rem;
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0.8), rgba(15, 23, 42, 0.62));
+    border: 1px solid var(--card-border);
+    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.26);
+    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(12px);
+    border-radius: 20px;
+    padding: 1.3rem 1.35rem 1.1rem;
+  }
+  .diagram-scroll { overflow-x: auto; padding-bottom: 0.35rem; }
+  figcaption {
+    color: var(--copy);
+    font-size: 0.9rem;
+    line-height: 1.45;
+    margin-top: 1rem;
+    border-top: 1px solid rgba(148, 163, 184, 0.14);
+    padding-top: 0.8rem;
+  }
+  figcaption b { color: var(--accent-soft); font-weight: 650; }
+
+  /* inline flow nodes (ported from the deck's inline-flow technique) */
+  .flow { display: flex; align-items: center; gap: 0; min-width: max-content; }
+  .flow-col { display: flex; flex-direction: column; gap: 0.55rem; justify-content: center; }
+  .node {
+    background: linear-gradient(180deg, rgba(24, 36, 61, 0.92), rgba(17, 24, 39, 0.82));
+    border: 1px solid var(--node-border);
+    border-radius: 14px;
+    padding: 0.55rem 0.85rem;
+    font-family: var(--mono);
+    font-size: 0.8rem;
+    color: #e2e8f0;
+    white-space: nowrap;
+    text-align: center;
+  }
+  .node.accent { border-color: rgba(167, 139, 250, 0.7); color: var(--accent-soft); }
+  .node.start { border-color: rgba(147, 197, 253, 0.6); color: var(--kicker); }
+  .node.done { border-color: rgba(110, 231, 183, 0.6); color: #6ee7b7; }
+  .edge {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    color: rgba(148, 163, 184, 0.85);
+    padding: 0 0.6rem;
+    min-width: 3rem;
+  }
+  .edge .arrow { font-size: 1.1rem; line-height: 1; }
+  .edge.dashed .arrow { color: rgba(167, 139, 250, 0.75); }
+  .edge .edge-label {
+    font-size: 0.64rem;
+    color: var(--kicker);
+    text-align: center;
+    margin-top: 0.2rem;
+    max-width: 7.5rem;
+    line-height: 1.2;
+  }
+
+  /* SVG diagrams scale within their scroll container */
+  .diagram-scroll svg { display: block; height: auto; }
+  .diagram-scroll svg text { font-family: var(--mono); fill: #e2e8f0; }
+  .diagram-scroll svg .lab { fill: var(--kicker); font-family: var(--font); }
+
+  /* tree grounding diagram scales down on mobile */
+  .tree-svg { width: 100%; height: auto; display: block; }
+  .tree-svg text { font-family: var(--mono); fill: #e2e8f0; }
+  .tree-svg .lbl { fill: var(--kicker); font-family: var(--font); }
+
+  .closer {
+    color: var(--accent-soft);
+    font-weight: 620;
+    font-size: clamp(1.12rem, 2.6vw, 1.4rem);
+    line-height: 1.4;
+    margin: 1.6rem 0 0;
+  }
 
   /* metric row for the proof numbers */
   .metrics {

--- a/scripts/pages/article-shell.html
+++ b/scripts/pages/article-shell.html
@@ -64,10 +64,9 @@
     font-weight: 600;
   }
 
-  h1, h2, h3 { color: var(--heading); letter-spacing: -0.02em; margin-top: 0; }
+  h1, h2 { color: var(--heading); letter-spacing: -0.02em; margin-top: 0; }
   h1 { font-weight: 760; font-size: clamp(1.9rem, 5vw, 2.7rem); line-height: 1.08; margin-bottom: 0.9rem; }
   h2 { font-weight: 720; font-size: clamp(1.35rem, 3.4vw, 1.85rem); line-height: 1.15; margin: 2.6rem 0 0.9rem; }
-  h3 { font-weight: 680; font-size: clamp(1.08rem, 2.4vw, 1.28rem); line-height: 1.25; margin: 1.8rem 0 0.6rem; color: var(--accent-soft); }
 
   /* part divider: the two big movements of a two-part deep dive */
   .part {
@@ -186,7 +185,6 @@
   }
   .node.accent { border-color: rgba(167, 139, 250, 0.7); color: var(--accent-soft); }
   .node.start { border-color: rgba(147, 197, 253, 0.6); color: var(--kicker); }
-  .node.done { border-color: rgba(110, 231, 183, 0.6); color: #6ee7b7; }
   .edge {
     display: flex;
     flex-direction: column;

--- a/scripts/pages/render-article.mjs
+++ b/scripts/pages/render-article.mjs
@@ -6,7 +6,7 @@
 // on) plus a deterministic transform of the markdown body.
 //
 // The transform is deliberately a fail-closed subset, not a general markdown
-// engine: headings (h1-h3), paragraphs, bullet lists, blockquotes, fenced code
+// engine: headings (h1-h2), paragraphs, bullet lists, blockquotes, fenced code
 // blocks, mermaid diagram figures, and the inline set (**bold**, *em*, `code`,
 // [links]) used by the articles. Anything it does not recognize throws, so an
 // unsupported construct becomes a build error instead of silently mangled

--- a/scripts/pages/render-article.mjs
+++ b/scripts/pages/render-article.mjs
@@ -16,8 +16,9 @@
 //     `heroLede` fills the hero card's lede line.
 //   - A bullet list between `<!-- metrics:start -->` and `<!-- metrics:end -->`
 //     renders as the .metrics card row; each item must be `**<num>** <label>`.
-//   - Every h2 gets a GitHub-style slug id, so in-page `#anchors` written in
-//     the markdown resolve in both renderings. Duplicate h2 slugs throw.
+//   - Every `##` section heading gets a GitHub-style slug id, so in-page
+//     `#anchors` written in the markdown resolve in both renderings.
+//     Duplicate slugs throw. (Part-divider h2s are visual only — no id.)
 //   - The final h2 section renders as the boxed .deeper outro behind an
 //     <hr class="rule" />, unless frontmatter sets `outro: closer` — then the
 //     last h2 renders as a plain section and the article's final paragraph
@@ -143,7 +144,7 @@ function parseBlocks(body) {
     // regions are only ever consumed from inside the mermaid-fence branch
     // below, so a stray one here still hits this throw.
     if (line.trimStart().startsWith("<!--")) {
-      throw new Error(`unsupported HTML comment at line ${i + 1}: ${JSON.stringify(line.trim())} — only the metrics markers and diagram figure regions are recognized`);
+      throw new Error(`unsupported HTML comment at line ${i + 1}: ${JSON.stringify(line.trim())} — only the metrics markers are recognized here; a figure region is valid only immediately after a mermaid fence`);
     }
     if (line.startsWith("```")) {
       const info = line.slice(3).trim();

--- a/scripts/pages/render-article.mjs
+++ b/scripts/pages/render-article.mjs
@@ -54,6 +54,7 @@ const SHELL_PATH = path.join(REPO_ROOT, "scripts", "pages", "article-shell.html"
 // Rendered articles: markdown source → derived HTML twin.
 export const RENDERED_ARTICLES = [
   { md: "introducing-dev-loops.md", html: "introducing-dev-loops.html" },
+  { md: "dev-loops-deep-dive.md", html: "dev-loops-deep-dive.html" },
 ];
 
 // Quote-escaping matters even under the strict CSP: rendered text is also

--- a/scripts/pages/render-article.mjs
+++ b/scripts/pages/render-article.mjs
@@ -158,8 +158,6 @@ function parseBlocks(body) {
       } else {
         blocks.push({ type: "code", text: fence.join("\n") });
       }
-    } else if (line.startsWith("### ")) {
-      blocks.push({ type: "h3", text: line.slice(4).trim() });
     } else if (line.startsWith("## ")) {
       blocks.push({ type: "h2", text: line.slice(3).trim() });
     } else if (line.startsWith("# ")) {
@@ -272,8 +270,6 @@ export function renderArticleHtml(mdSource, shell, sourceBasename) {
       }
     } else if (block.type === "part") {
       out.push(`  <div class="part">\n    <p class="kicker">Part ${block.num}</p>\n    <h2>${renderInline(block.title)}</h2>\n  </div>`);
-    } else if (block.type === "h3") {
-      out.push(inDeeper ? `    <h3>${renderInline(block.text)}</h3>` : `  <h3>${renderInline(block.text)}</h3>`);
     } else if (block.type === "blockquote") {
       out.push(inDeeper ? `    <blockquote>${renderInline(block.text)}</blockquote>` : `  <blockquote>${renderInline(block.text)}</blockquote>`);
     } else if (block.type === "diagram") {

--- a/scripts/pages/render-article.mjs
+++ b/scripts/pages/render-article.mjs
@@ -6,10 +6,11 @@
 // on) plus a deterministic transform of the markdown body.
 //
 // The transform is deliberately a fail-closed subset, not a general markdown
-// engine: headings, paragraphs, bullet lists, fenced code blocks, and the
-// inline set (**bold**, *em*, `code`, [links]) used by the articles. Anything
-// it does not recognize throws, so an unsupported construct becomes a build
-// error instead of silently mangled prose. Article-specific conventions:
+// engine: headings (h1-h3), paragraphs, bullet lists, blockquotes, fenced code
+// blocks, mermaid diagram figures, and the inline set (**bold**, *em*, `code`,
+// [links]) used by the articles. Anything it does not recognize throws, so an
+// unsupported construct becomes a build error instead of silently mangled
+// prose. Article-specific conventions:
 //
 //   - Frontmatter `title` fills the shell <title> and hero <h1>; frontmatter
 //     `heroLede` fills the hero card's lede line.
@@ -18,7 +19,19 @@
 //   - Every h2 gets a GitHub-style slug id, so in-page `#anchors` written in
 //     the markdown resolve in both renderings. Duplicate h2 slugs throw.
 //   - The final h2 section renders as the boxed .deeper outro behind an
-//     <hr class="rule" />.
+//     <hr class="rule" />, unless frontmatter sets `outro: closer` — then the
+//     last h2 renders as a plain section and the article's final paragraph
+//     gets a `.closer` class instead.
+//   - A non-first h1 must be a `Part N — Title` divider, rendered as a
+//     `.part` group above the following h2s.
+//   - A ```mermaid fence must be followed by a single-line italic
+//     `*Diagram N — Title. …*` caption and then a `<!-- figure … -->` region;
+//     the mermaid source is dropped and the region's inner HTML is emitted
+//     verbatim inside a `<figure>` (the design-system markup a mermaid
+//     renderer can't reproduce). The region must not contain nested HTML
+//     comments or a `<script` element (case-insensitive).
+//   - A run of `> `-prefixed lines renders as one <blockquote> with inline
+//     rendering (including link rewrites) applied.
 //   - Relative `./`- or `../`-prefixed links to `.md` files are rewritten to
 //     their `.html` twins.
 //   - `#`-to-end-of-line comments inside fenced code render in .cm spans.
@@ -38,8 +51,7 @@ const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..
 const ARTICLES_DIR = path.join(REPO_ROOT, "docs", "articles");
 const SHELL_PATH = path.join(REPO_ROOT, "scripts", "pages", "article-shell.html");
 
-// Rendered articles: markdown source → derived HTML twin. The deep-dive
-// article predates this renderer and stays hand-maintained until migrated.
+// Rendered articles: markdown source → derived HTML twin.
 export const RENDERED_ARTICLES = [
   { md: "introducing-dev-loops.md", html: "introducing-dev-loops.html" },
 ];
@@ -72,11 +84,53 @@ const markCodeComments = (escaped) =>
     .map((line) => line.replace(/(^|\s)(#.*)$/, '$1<span class="cm">$2</span>'))
     .join("\n");
 
+const DIAGRAM_CAPTION_RE = /^\*Diagram \d+ [—-] .+\*$/;
+const PART_HEADING_RE = /^Part (\d+) [—-] (.+)$/;
+
+/**
+ * Parse the diagram caption + `<!-- figure … -->` region that must follow a
+ * ```mermaid fence. `startIndex` is the line right after the closing fence.
+ * Blank lines are tolerated (zero or more) both before the caption and before
+ * the figure opener. The region's terminator is an exact-line `-->`: any
+ * other line inside the region carrying `<!--` or `-->` throws, so a nested
+ * HTML comment fails the build instead of silently truncating the region.
+ */
+function parseDiagramRegion(lines, startIndex) {
+  let j = startIndex;
+  while (j < lines.length && lines[j].trim() === "") j++;
+  if (j >= lines.length || !DIAGRAM_CAPTION_RE.test(lines[j].trim())) {
+    throw new Error(`mermaid fence must be followed by a "*Diagram N — Title. …*" caption at line ${j + 1}`);
+  }
+  const caption = lines[j].trim().slice(1, -1);
+  j++;
+  while (j < lines.length && lines[j].trim() === "") j++;
+  if (j >= lines.length || lines[j].trim() !== "<!-- figure") {
+    throw new Error(`diagram caption must be followed by a "<!-- figure" region at line ${j + 1}`);
+  }
+  j++;
+  const inner = [];
+  let closed = false;
+  for (; j < lines.length; j++) {
+    if (lines[j].trim() === "-->") { closed = true; j++; break; }
+    if (lines[j].includes("<!--") || lines[j].includes("-->")) {
+      throw new Error(`figure region must not contain nested HTML comments at line ${j + 1}: ${JSON.stringify(lines[j].trim())}`);
+    }
+    inner.push(lines[j]);
+  }
+  if (!closed) throw new Error("unterminated figure region: <!-- figure has no matching -->");
+  const innerHtml = inner.join("\n");
+  if (/<script/i.test(innerHtml)) {
+    throw new Error("figure region must not contain a <script> element");
+  }
+  return { caption, inner: innerHtml, nextIndex: j };
+}
+
 /** Parse the markdown body into a flat block list. Throws on unknown syntax. */
 function parseBlocks(body) {
   const lines = body.split("\n");
   const blocks = [];
   let metricsPending = false;
+  let seenH1 = false;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     if (line.trim() === "") continue;
@@ -84,19 +138,45 @@ function parseBlocks(body) {
     if (line.trim() === "<!-- metrics:end -->") { metricsPending = false; continue; }
     // Any other HTML comment must fail closed: the paragraph collector treats
     // `<!--` as a block boundary, so an unrecognized comment line would
-    // otherwise re-enter the loop at the same index forever.
+    // otherwise re-enter the loop at the same index forever. `<!-- figure`
+    // regions are only ever consumed from inside the mermaid-fence branch
+    // below, so a stray one here still hits this throw.
     if (line.trimStart().startsWith("<!--")) {
-      throw new Error(`unsupported HTML comment at line ${i + 1}: ${JSON.stringify(line.trim())} — only the metrics markers are recognized`);
+      throw new Error(`unsupported HTML comment at line ${i + 1}: ${JSON.stringify(line.trim())} — only the metrics markers and diagram figure regions are recognized`);
     }
     if (line.startsWith("```")) {
+      const info = line.slice(3).trim();
       const fence = [];
       for (i++; i < lines.length && !lines[i].startsWith("```"); i++) fence.push(lines[i]);
       if (i >= lines.length) throw new Error("unterminated code fence");
-      blocks.push({ type: "code", text: fence.join("\n") });
+      if (info === "mermaid") {
+        const { caption, inner, nextIndex } = parseDiagramRegion(lines, i + 1);
+        blocks.push({ type: "diagram", caption, inner });
+        i = nextIndex - 1;
+      } else {
+        blocks.push({ type: "code", text: fence.join("\n") });
+      }
+    } else if (line.startsWith("### ")) {
+      blocks.push({ type: "h3", text: line.slice(4).trim() });
     } else if (line.startsWith("## ")) {
       blocks.push({ type: "h2", text: line.slice(3).trim() });
     } else if (line.startsWith("# ")) {
-      blocks.push({ type: "h1", text: line.slice(2).trim() });
+      const text = line.slice(2).trim();
+      if (!seenH1) {
+        seenH1 = true;
+        blocks.push({ type: "h1", text });
+      } else {
+        const part = text.match(PART_HEADING_RE);
+        if (!part) {
+          throw new Error(`non-first h1 must be a "Part N — Title" divider at line ${i + 1}: ${JSON.stringify(text)}`);
+        }
+        blocks.push({ type: "part", num: part[1], title: part[2] });
+      }
+    } else if (line.startsWith("> ")) {
+      const quote = [];
+      for (; i < lines.length && lines[i].startsWith("> "); i++) quote.push(lines[i].slice(2));
+      i--;
+      blocks.push({ type: "blockquote", text: quote.join(" ") });
     } else if (line.startsWith("- ")) {
       const items = [];
       for (; i < lines.length && lines[i].startsWith("- "); i++) items.push(lines[i].slice(2).trim());
@@ -106,7 +186,7 @@ function parseBlocks(body) {
       throw new Error(`unsupported markdown construct at line ${i + 1}: ${JSON.stringify(line)}`);
     } else {
       const para = [];
-      for (; i < lines.length && lines[i].trim() !== "" && !/^(#|-|```|<!--)/.test(lines[i]); i++) para.push(lines[i]);
+      for (; i < lines.length && lines[i].trim() !== "" && !/^(#|-|>|```|<!--)/.test(lines[i]); i++) para.push(lines[i]);
       i--;
       blocks.push({ type: "p", text: para.join(" ") });
     }
@@ -115,6 +195,14 @@ function parseBlocks(body) {
     throw new Error("unterminated metrics block: <!-- metrics:start --> has no matching <!-- metrics:end -->");
   }
   return blocks;
+}
+
+/** Diagram figcaption: bold-split the caption's first sentence from the rest. */
+function renderDiagramCaption(caption) {
+  const dot = caption.indexOf(". ");
+  const head = dot === -1 ? caption : caption.slice(0, dot + 1);
+  const rest = dot === -1 ? "" : caption.slice(dot + 2);
+  return rest ? `<b>${renderInline(head)}</b> ${renderInline(rest)}` : `<b>${renderInline(head)}</b>`;
 }
 
 function renderMetrics(items) {
@@ -141,6 +229,10 @@ export function renderArticleHtml(mdSource, shell, sourceBasename) {
   if (!meta?.title || !meta?.heroLede) {
     throw new Error("article frontmatter must set title and heroLede");
   }
+  const outro = meta.outro ?? "deeper";
+  if (outro !== "deeper" && outro !== "closer") {
+    throw new Error(`unknown frontmatter outro value ${JSON.stringify(meta.outro)} — expected "deeper" or "closer"`);
+  }
 
   const blocks = parseBlocks(mdSource.slice(fm[0].length));
   if (blocks[0]?.type !== "h1" || blocks[0].text !== meta.title) {
@@ -148,6 +240,7 @@ export function renderArticleHtml(mdSource, shell, sourceBasename) {
   }
 
   const lastH2 = blocks.reduce((last, b, i) => (b.type === "h2" ? i : last), -1);
+  const lastP = blocks.reduce((last, b, i) => (b.type === "p" ? i : last), -1);
   const out = [];
   out.push(`  <header class="hero-card">
     <p class="kicker">dev-loops</p>
@@ -168,15 +261,27 @@ export function renderArticleHtml(mdSource, shell, sourceBasename) {
         throw new Error(`duplicate h2 slug "${slug}" — two sections would share one anchor id`);
       }
       seenSlugs.add(slug);
-      if (i === lastH2) {
+      if (i === lastH2 && outro === "deeper") {
         out.push(`  <hr class="rule" />`, ``, `  <section class="deeper">`);
         out.push(`    <h2 id="${slug}">${renderInline(block.text)}</h2>`);
         inDeeper = true;
       } else {
         out.push(`  <h2 id="${slug}">${renderInline(block.text)}</h2>`);
       }
+    } else if (block.type === "part") {
+      out.push(`  <div class="part">\n    <p class="kicker">Part ${block.num}</p>\n    <h2>${renderInline(block.title)}</h2>\n  </div>`);
+    } else if (block.type === "h3") {
+      out.push(inDeeper ? `    <h3>${renderInline(block.text)}</h3>` : `  <h3>${renderInline(block.text)}</h3>`);
+    } else if (block.type === "blockquote") {
+      out.push(inDeeper ? `    <blockquote>${renderInline(block.text)}</blockquote>` : `  <blockquote>${renderInline(block.text)}</blockquote>`);
+    } else if (block.type === "diagram") {
+      out.push(`  <figure>\n    <div class="diagram-scroll">\n${block.inner}\n    </div>\n    <figcaption>${renderDiagramCaption(block.caption)}</figcaption>\n  </figure>`);
     } else if (block.type === "p") {
-      out.push(inDeeper ? `    <p>${renderInline(block.text)}</p>` : `  <p>${renderInline(block.text)}</p>`);
+      if (outro === "closer" && i === lastP) {
+        out.push(`  <p class="closer">${renderInline(block.text)}</p>`);
+      } else {
+        out.push(inDeeper ? `    <p>${renderInline(block.text)}</p>` : `  <p>${renderInline(block.text)}</p>`);
+      }
     } else if (block.type === "list") {
       out.push(`  <ul>\n${block.items.map((it) => `    <li>${renderInline(it)}</li>`).join("\n")}\n  </ul>`);
     } else if (block.type === "metrics") {

--- a/test/pages/article-render.test.mjs
+++ b/test/pages/article-render.test.mjs
@@ -69,15 +69,15 @@ test("in-page anchors written in the markdown resolve in the rendered HTML", asy
 
 const MIN_SHELL = "<title>{{TITLE}}</title>\n{{GENERATED}}\n<style></style>\n";
 
-function doc(body, { title = "T", heroLede = "L" } = {}) {
-  return `---\ntitle: "${title}"\nheroLede: "${heroLede}"\n---\n\n# ${title}\n\n${body}\n`;
+function doc(body, { title = "T", heroLede = "L", outro } = {}) {
+  const outroLine = outro ? `\noutro: ${outro}` : "";
+  return `---\ntitle: "${title}"\nheroLede: "${heroLede}"${outroLine}\n---\n\n# ${title}\n\n${body}\n`;
 }
 
 const render = (body, fm) => renderArticleHtml(doc(body, fm), MIN_SHELL, "t.md");
 
 test("renderer fails closed on unsupported markdown constructs", () => {
   for (const body of [
-    "> a blockquote",
     "| a | b |",
     "  indented block start",
     "```text\nunterminated fence",
@@ -135,4 +135,136 @@ test("generated page carries slug ids, hero fields, and the provenance marker", 
   assert.ok(html.includes('<h2 id="first-section">'));
   assert.ok(html.includes('<section class="deeper">'), "last h2 section becomes the deeper outro");
   assert.ok(html.includes("GENERATED from docs/articles/t.md"));
+});
+
+// ---------------------------------------------------------------------------
+// Diagram figure unit: ```mermaid fence + *Diagram N — Title. …* caption +
+// <!-- figure … --> region. Mermaid source is dropped; the region's inner
+// HTML is emitted verbatim inside the figure.
+// ---------------------------------------------------------------------------
+
+test("diagram figure unit renders a figure with the region's inner HTML emitted verbatim", () => {
+  const html = render([
+    "```mermaid",
+    "flowchart LR",
+    "  A --> B",
+    "```",
+    "",
+    "*Diagram 1 — Title. Rest of the caption.*",
+    "",
+    "<!-- figure",
+    '      <svg viewBox="0 0 10 10"><text>A &rarr; B</text></svg>',
+    "-->",
+  ].join("\n"));
+  assert.ok(!html.includes("flowchart LR"), "mermaid source must be dropped from the HTML output");
+  assert.ok(html.includes('<div class="diagram-scroll">'));
+  assert.ok(html.includes('<svg viewBox="0 0 10 10"><text>A &rarr; B</text></svg>'), "figure region inner HTML must survive verbatim, including entities and <svg");
+  assert.ok(html.includes("<figcaption><b>Diagram 1 — Title.</b> Rest of the caption.</figcaption>"), "figcaption bold-splits on the first '. '");
+});
+
+test("diagram figure unit tolerates zero blank lines between fence, caption, and figure region (D5/D6/D7 shape)", () => {
+  const html = render([
+    "```mermaid",
+    "flowchart LR",
+    "  A --> B",
+    "```",
+    "*Diagram 2 — Title. Rest.*",
+    "<!-- figure",
+    '      <div class="flow">X</div>',
+    "-->",
+  ].join("\n"));
+  assert.ok(html.includes('<div class="flow">X</div>'));
+});
+
+test("diagram figure unit fails closed on a malformed coupled triple", () => {
+  const fence = ["```mermaid", "flowchart LR", "  A --> B", "```"].join("\n");
+  const goodCaption = "*Diagram 1 — Title. Rest.*";
+  for (const body of [
+    `${fence}\n\nno caption here\n`,
+    `${fence}\n\n${goodCaption}\n\nno figure region\n`,
+    `${fence}\n\n${goodCaption}\n\n<!-- figure\n  <div>x</div>\n`,
+    `${fence}\n\nDiagram 1 without asterisks or em dash\n\n<!-- figure\n  <div>x</div>\n-->\n`,
+    `${fence}\n\n${goodCaption}\n\n<!-- figure\n  <ScRiPt>alert(1)</ScRiPt>\n-->\n`,
+  ]) {
+    assert.throws(() => render(body), `should throw for: ${JSON.stringify(body)}`);
+  }
+});
+
+test("figure region rejects nested HTML comments (M1) and requires an exact-line '-->' terminator (M2)", () => {
+  const fence = ["```mermaid", "flowchart LR", "  A --> B", "```"].join("\n");
+  const caption = "*Diagram 1 — Title. Rest.*";
+  assert.throws(
+    () => render(`${fence}\n\n${caption}\n\n<!-- figure\n  <!-- nested -->\n  <div>after</div>\n-->\n`),
+    /nested/i,
+  );
+  assert.throws(
+    () => render(`${fence}\n\n${caption}\n\n<!-- figure\n  <div>text with --> inline</div>\n-->\n`),
+    /nested/i,
+  );
+});
+
+test("stray <!-- figure without a preceding mermaid fence still hits the unsupported-comment throw", () => {
+  assert.throws(() => render("<!-- figure\n  <div>x</div>\n-->\n"), /unsupported HTML comment/);
+});
+
+// ---------------------------------------------------------------------------
+// Part divider: a non-first h1 must be a "Part N — Title" line.
+// ---------------------------------------------------------------------------
+
+test("a non-first h1 shaped \"Part N — Title\" renders as a part divider", () => {
+  const html = render("intro\n\n# Part 1 — Eliminating coordination delay\n\n## Section\n\nbody");
+  assert.ok(html.includes('<div class="part">'));
+  assert.ok(html.includes('<p class="kicker">Part 1</p>'));
+  assert.ok(html.includes("<h2>Eliminating coordination delay</h2>"));
+});
+
+test("a non-first h1 not shaped like a part divider throws", () => {
+  assert.throws(() => render("intro\n\n# Just Another Heading\n\nbody"), /Part N/);
+});
+
+// ---------------------------------------------------------------------------
+// Blockquote: a run of "> "-prefixed lines renders as one <blockquote>.
+// ---------------------------------------------------------------------------
+
+test("a run of \"> \" lines renders as one blockquote with inline rendering applied", () => {
+  const html = render("> See [more](./x.md) here.\n> Second line.");
+  assert.ok(html.includes("<blockquote>See <a href=\"./x.html\">more</a> here. Second line.</blockquote>"));
+});
+
+test("a bare \">\" or nested \">>\" blockquote line throws", () => {
+  assert.throws(() => render(">no space"));
+  assert.throws(() => render("> ok\n>>nested"));
+});
+
+// ---------------------------------------------------------------------------
+// h3: a trivial construct, listed in the AC.
+// ---------------------------------------------------------------------------
+
+test("### renders as an h3 with no slug id", () => {
+  const html = render("### A subheading\n\nbody");
+  assert.ok(html.includes("<h3>A subheading</h3>"));
+});
+
+// ---------------------------------------------------------------------------
+// outro frontmatter: default "deeper" keeps today's boxed-outro behavior;
+// "closer" unboxes the last h2 and marks the final paragraph .closer.
+// ---------------------------------------------------------------------------
+
+test('frontmatter outro: "closer" renders the last h2 unboxed and the final paragraph as <p class="closer">', () => {
+  const html = render("intro\n\n## First\n\na\n\n## Last\n\nb\n\nfinal para", { outro: "closer" });
+  assert.ok(!html.includes('<section class="deeper">'), "closer outro must not box the last h2");
+  assert.ok(!html.includes('<hr class="rule" />'), "closer outro must not add the deeper rule");
+  assert.ok(html.includes('<h2 id="last">Last</h2>'), "last h2 still renders, just unboxed");
+  assert.ok(html.includes('<p class="closer">final para</p>'));
+});
+
+test("default outro (deeper) still boxes the last h2 behind the rule", () => {
+  const html = render("intro\n\n## First\n\na\n\n## Last\n\nb\n\nfinal para");
+  assert.ok(html.includes('<hr class="rule" />'));
+  assert.ok(html.includes('<section class="deeper">'));
+  assert.ok(!html.includes('class="closer"'));
+});
+
+test("unknown outro frontmatter value throws", () => {
+  assert.throws(() => render("intro\n\n## Last\n\nb", { outro: "bogus" }), /outro/);
 });

--- a/test/pages/article-render.test.mjs
+++ b/test/pages/article-render.test.mjs
@@ -237,12 +237,12 @@ test("a bare \">\" or nested \">>\" blockquote line throws", () => {
 });
 
 // ---------------------------------------------------------------------------
-// h3: a trivial construct, listed in the AC.
+// h3: no rendered article uses ###; the parser fails closed on it, so support
+// can land with the first real use.
 // ---------------------------------------------------------------------------
 
-test("### renders as an h3 with no slug id", () => {
-  const html = render("### A subheading\n\nbody");
-  assert.ok(html.includes("<h3>A subheading</h3>"));
+test("### fails closed as an unsupported construct", () => {
+  assert.throws(() => render("### A subheading\n\nbody"));
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1356

## Objective

Migrate the deep-dive article — the last hand-synced md/html twin — to the markdown renderer (`scripts/pages/render-article.mjs`), fact-grounded and desloped, so both articles are rendered from one source with drift protection.

## What changed

- Renderer extended fail-closed for the deep-dive's constructs, each behavior-tested before implementation: blockquote callouts, `# Part N` section breaks (tightened from silent-drop to fail-closed), mermaid diagram figures (fence kept as portable source with a verbatim figure-region seam), and a new `outro: closer` frontmatter opt-out of the boxed outro. Shell CSS extended to match the existing twin's design system. h3 support was initially added but removed in review as unused — no rendered article uses `###`, the parser fails closed on it (test-pinned), so support lands with the first real use.
- `dev-loops-deep-dive` registered in `RENDERED_ARTICLES`; the existing drift/anchor/nav/CSP contract tests now cover it automatically.
- Fact-grounding pass: 4 substantive corrections (dropped an ungrounded claim, corrected the contributor-attribution posture to the shipped default-opt-out behavior and collapsed a duplicate diagram node, renamed the prose/diagram "security" angle to the shipped `input-validation` naming, dropped an overstating adverb). Full claim→evidence→action log in the loop's tmp artifacts.
- Deslop pass over the content including the subtitle, with an independent re-read verification pass.
- 7 md/html divergences resolved explicitly (documented in the loop's tmp artifacts); both HTML twins regenerated (the intro article's HTML changed only via the shared shell CSS).

## Validation

- `npm run articles:check` clean (both twins up to date).
- `test/pages/article-render.test.mjs` 24/24; `npm run test:docs` green (118 files / 547 links); `npm run test:playwright:deep-dive-article` 3/3.
- `npm run verify` fully green (scripts suite 2785 pass / 36 pre-existing skips / 0 fail).

## Non-goals

- Rewriting the article's two-part structure or core argument.
- The decks (separate issues, #1354 shipped / #1355 in flight).
