### PR TITLE
feat(gate): sanctioned same-head PR-body-fix retry path for gate reviewers

### DIFF
--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -242,7 +242,9 @@ manual chore:
   manual clear step**.
 - **Within one round the contamination guard is preserved:** a same-scope + same-head
   re-entry still fails closed (`fresh: false`, exit 1) — that is genuine main-agent /
-  cross-session state bleed.
+  cross-session state bleed. (The one sanctioned same-head exception is the opt-in
+  `--pr-body-fix-retry` overwrite documented below, gated on a matching prefix hash; it is
+  not state bleed.)
 - The orchestrator **MUST NOT** need to manually clear sentinels between rounds, and
   **MUST NOT** clear the sentinels of carried-forward clean angles (Phase 5's re-fan
   re-invokes the surface-touched angles, every angle that produced `findings_present`, and

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -251,6 +251,27 @@ manual chore:
 - Stale pre-round sentinels (the old scope-only name) never collide with a head-keyed round
   and are simply ignored.
 
+**Sanctioned same-head PR-body-fix retry.** A PR-body/description-only fix (e.g. adding a
+missing acceptance-criteria matrix to satisfy `pr-checklist-matrix`) does not change the head
+SHA, so it earns no new round key on its own — a plain re-invocation of the fixed angle
+collides with its own pass-1 sentinel and fails closed exactly like genuine contamination
+would. `verify-fresh-review-context.mjs --pr-body-fix-retry` is the sanctioned escape hatch
+for exactly this case: it overwrites the existing sentinel for that scope+round, but **only**
+when the given `--prefix-hash`/`--prefix-file` matches the existing sentinel's recorded prefix
+hash **exactly**. An identical hash proves the seeded briefing bytes were NOT rebuilt, so the
+byte-identity invariant (`GATE-EXEC-BRIEFING-PREFIX`) stays fully intact for every other
+sentinel of the same round — the previously-clean angles' sentinels are left untouched and
+still verify against the same on-disk record, so `verify-briefing-prefixes.mjs` needs no full
+re-fan of clean angles and no manual sentinel deletion. A hash mismatch (the context-builder
+genuinely rebuilt the briefing) or an existing sentinel recording no prefix hash still fails
+closed — this flag is a narrow, auditable exception for one documented scenario, never a
+general bypass of the contamination guard. Practically: re-brief the retried reviewer with the
+UNCHANGED, byte-identical invariant prefix (do not re-run `write-gate-context.mjs`) plus an
+angle-specific instruction to fetch the CURRENT PR body/description live (e.g. `gh pr view`)
+rather than trust the prefix's now-stale inlined copy, since the point of the retry is to
+re-check the just-edited description. See `verify-fresh-review-context.mjs --help` for the
+flag's exact semantics and exit codes.
+
 ### Phase 3 — Consolidation: fan-in synthesis and disposition ledger
 
 Before consolidating, run `scripts/github/verify-briefing-prefixes.mjs --head-sha <sha>`

--- a/scripts/github/verify-fresh-review-context.mjs
+++ b/scripts/github/verify-fresh-review-context.mjs
@@ -6,7 +6,7 @@ import path from "node:path";
 import { buildParseError, isDirectCliRun, formatCliError } from "../_core-helpers.mjs";
 import { JQ_OUTPUT_USAGE, emitResult } from "../lib/jq-output.mjs";
 const USAGE = `Usage: verify-fresh-review-context.mjs [--help] [--scope <name>] [--context-path <path>]
-       [--prefix-hash <sha256>|--prefix-file <path>]
+       [--prefix-hash <sha256>|--prefix-file <path>] [--pr-body-fix-retry]
 Verify that the current scoped-reviewer session has fresh context.
 
 "Fresh" means the reviewer's context is the neutral gate-context builder
@@ -60,21 +60,43 @@ Options:
                   hashes its raw bytes (sha256) and records the digest same
                   as --prefix-hash. Fails closed (exit 1) if the file is
                   missing. Mutually exclusive with --prefix-hash.
+  --pr-body-fix-retry  Sanctioned same-head retry for a PR-body/description-only
+                  fix (e.g. satisfying pr-checklist-matrix) that does NOT
+                  change the head SHA and therefore does not earn a fresh
+                  round key on its own. Requires --prefix-hash/--prefix-file.
+                  When a sentinel already exists for this exact scope+round
+                  (the normal contamination trip), this flag permits
+                  overwriting it ONLY when the given prefix hash matches the
+                  existing sentinel's recorded prefix hash exactly — proof
+                  the seeded briefing bytes (GATE-EXEC-BRIEFING-PREFIX) were
+                  NOT rebuilt, so the round's byte-identity invariant is
+                  fully preserved and other clean angles' sentinels from the
+                  same round stay valid (no full re-fan required). A hash
+                  MISMATCH (the context-builder WAS re-run) or an existing
+                  sentinel with no recorded prefix hash still fails closed —
+                  this is a narrow escape hatch for one documented scenario,
+                  never a general bypass of the contamination guard. See
+                  "Sentinel lifecycle" in docs/gate-review-sub-loop-contract.md.
 Output (stdout, JSON):
   { "ok": true, "fresh": true, "sentinelCreated": true, "round": "<headSha|null>" }
   { "ok": true, "fresh": true, "sentinelCreated": true, "round": "...", "gateContextPath": "...", "gateContextPresent": true }
+  { "ok": true, "fresh": true, "sentinelCreated": true, "round": "...", "prBodyFixRetry": true, "prefixHash": "..." }
   { "ok": true, "fresh": false, "sentinelCreated": false, "round": "...", "reason": "..." }
   { "ok": true, "fresh": false, "sentinelCreated": false, "round": "...", "gateContextPath": "...", "gateContextPresent": false, "reason": "..." }
   On error (stderr, JSON):
   { "ok": false, "error": "...", "usage": "..." }
 ${JQ_OUTPUT_USAGE}
 Exit codes:
-  0  Clean (first run)
+  0  Clean (first run), OR a sanctioned --pr-body-fix-retry whose prefix hash
+     matches the existing sentinel's recorded hash
   1  Refuse to review: contaminated (prior session detected), OR (with
      --context-path) the seeded gate-context artifact is missing or resolves
      outside the reviewer's working directory, OR (with --prefix-file) the
-     prefix file is missing
-  2  Usage or internal error, invalid --jq filter, or invalid/conflicting
+     prefix file is missing, OR (with --pr-body-fix-retry) the existing
+     sentinel's recorded prefix hash does not match the given one (or records
+     none at all)
+  2  Usage or internal error, invalid --jq filter, invalid/conflicting
+     --prefix-hash/--prefix-file, or --pr-body-fix-retry given without
      --prefix-hash/--prefix-file`.trim();
 const VALID_SCOPE_RE = /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
 const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
@@ -155,6 +177,22 @@ async function checkSentinelExists(scope, round, cwd = process.cwd()) {
   }
   return { exists: false, path: sentinelPath, legacy: false };
 }
+// Read the recorded `prefixHash` off an existing sentinel file, for the
+// --pr-body-fix-retry comparison. Returns null on any read/parse failure or
+// when the sentinel recorded no (or a malformed) hash — the caller treats
+// null as "never grandfathered in", same posture as verify-briefing-prefixes.mjs.
+async function readSentinelPrefixHash(sentinelPath) {
+  try {
+    const raw = await readFile(sentinelPath, "utf8");
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed.prefixHash === "string" && SHA256_HEX_RE.test(parsed.prefixHash.toLowerCase().trim())) {
+      return parsed.prefixHash.toLowerCase().trim();
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
 async function main(argv = process.argv.slice(2)) {
   if (argv.includes("--help") || argv.includes("-h")) {
     process.stdout.write(`${USAGE}\n`);
@@ -192,6 +230,13 @@ async function main(argv = process.argv.slice(2)) {
   if (prefixHashArg !== null && !SHA256_HEX_RE.test(prefixHashArg.trim().toLowerCase())) {
     process.stderr.write(`${formatCliError(
       parseError(`Invalid --prefix-hash value "${prefixHashArg}": must be a 64-character hex SHA-256 digest (case-insensitive).`)
+    )}\n`);
+    return 2;
+  }
+  const prBodyFixRetry = argv.includes("--pr-body-fix-retry");
+  if (prBodyFixRetry && prefixHashArg === null && prefixFileArg === null) {
+    process.stderr.write(`${formatCliError(
+      parseError("--pr-body-fix-retry requires --prefix-hash or --prefix-file (the sanctioned retry proves byte-identity by comparing prefix hashes, so a hash to compare is mandatory).")
     )}\n`);
     return 2;
   }
@@ -277,6 +322,51 @@ async function main(argv = process.argv.slice(2)) {
   }
   const existing = await checkSentinelExists(scope, round);
   if (existing.exists) {
+    // Sanctioned same-head PR-body-fix retry (docs/gate-review-sub-loop-contract.md,
+    // "Sentinel lifecycle"): a PR-body/description-only fix does not earn a new
+    // round key (the round is keyed by head SHA, which a body edit never changes),
+    // so a same-scope + same-head re-entry would otherwise always trip the
+    // contamination guard. Permit ONE narrow exception: overwrite the existing
+    // sentinel ONLY when the given prefix hash matches its recorded one exactly —
+    // proof the seeded briefing (GATE-EXEC-BRIEFING-PREFIX) was NOT rebuilt, so
+    // the round's byte-identity invariant stays fully intact for every other
+    // sentinel of this round (no full re-fan needed). A mismatch (or an existing
+    // sentinel recording no prefix hash) still fails closed — never grandfathered.
+    if (prBodyFixRetry) {
+      const existingPrefixHash = await readSentinelPrefixHash(existing.path);
+      if (existingPrefixHash !== null && existingPrefixHash === prefixHash) {
+        const sentinel = {
+          createdAt: new Date().toISOString(),
+          pid: process.pid,
+          ...(scope ? { scope } : {}),
+          ...(round ? { round } : {}),
+          prefixHash,
+          prBodyFixRetry: true,
+        };
+        try {
+          await writeFile(existing.path, JSON.stringify(sentinel, null, 2) + "\n", "utf8");
+        } catch (err) {
+          process.stderr.write(`${formatCliError(err)}\n`);
+          return 2;
+        }
+        return finish({
+          ok: true,
+          fresh: true,
+          sentinelCreated: true,
+          prBodyFixRetry: true,
+          round: round ?? null,
+          ...(contextPathArg !== null ? { gateContextPath: contextPathArg, gateContextPresent: true } : {}),
+          prefixHash,
+        }, true);
+      }
+      return finish({
+        ok: true,
+        fresh: false,
+        sentinelCreated: false,
+        round: round ?? null,
+        reason: `--pr-body-fix-retry refused: the existing sentinel${existingPrefixHash === null ? " recorded no prefix hash" : " recorded a DIFFERENT prefix hash"} — this sanctioned path only covers a same-head retry where the seeded briefing bytes are UNCHANGED (proven by an identical prefix hash). ${existingPrefixHash === null ? "A hashless sentinel is never grandfathered in." : "A changed hash means the context-builder WAS re-run; use the standard head-bump retry instead."}`,
+      }, false);
+    }
     return finish({
       ok: true,
       fresh: false,

--- a/test/github/verify-fresh-review-context.test.mjs
+++ b/test/github/verify-fresh-review-context.test.mjs
@@ -500,3 +500,112 @@ test("head round: a stale pre-round (scope-only) sentinel does NOT block a new h
     await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
   }
 });
+
+// ---------------------------------------------------------------------------
+// Sanctioned same-head PR-body-fix retry: a PR-body/description-only fix does
+// not change the head SHA (the round key), so a same-scope + same-head
+// re-entry would otherwise always trip the contamination guard. --pr-body-fix-retry
+// permits ONE narrow exception, gated on the given prefix hash matching the
+// existing sentinel's recorded one exactly (proof the seeded briefing bytes
+// were NOT rebuilt, preserving the round's byte-identity invariant).
+// ---------------------------------------------------------------------------
+
+test("--pr-body-fix-retry overwrites an existing sentinel when the prefix hash matches", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
+  try {
+    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
+    const hash = "a".repeat(64);
+
+    const first = runScript(["--scope", "findings-present", "--prefix-hash", hash], { cwd: tmpDir });
+    assert.equal(first.status, 0, first.stderr);
+    assert.equal(JSON.parse(first.stdout.trim()).fresh, true);
+
+    // Plain re-entry (no flag) still fails closed — the escape hatch is opt-in only.
+    const collision = runScript(["--scope", "findings-present", "--prefix-hash", hash], { cwd: tmpDir });
+    assert.equal(collision.status, 1, collision.stderr);
+    assert.equal(JSON.parse(collision.stdout.trim()).fresh, false);
+
+    const retry = runScript(
+      ["--scope", "findings-present", "--prefix-hash", hash, "--pr-body-fix-retry"],
+      { cwd: tmpDir },
+    );
+    assert.equal(retry.status, 0, retry.stderr);
+    const retryOutput = JSON.parse(retry.stdout.trim());
+    assert.equal(retryOutput.fresh, true);
+    assert.equal(retryOutput.sentinelCreated, true);
+    assert.equal(retryOutput.prBodyFixRetry, true);
+    assert.equal(retryOutput.prefixHash, hash);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test("--pr-body-fix-retry fails closed when the prefix hash does not match the existing sentinel's recorded hash", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
+  try {
+    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
+    const first = runScript(["--scope", "findings-present", "--prefix-hash", "a".repeat(64)], { cwd: tmpDir });
+    assert.equal(first.status, 0, first.stderr);
+
+    // A DIFFERENT hash means the context-builder actually rebuilt the briefing —
+    // outside this narrow escape hatch's scope; still fail closed.
+    const retry = runScript(
+      ["--scope", "findings-present", "--prefix-hash", "b".repeat(64), "--pr-body-fix-retry"],
+      { cwd: tmpDir },
+    );
+    assert.equal(retry.status, 1, retry.stderr);
+    const output = JSON.parse(retry.stdout.trim());
+    assert.equal(output.fresh, false);
+    assert.ok(output.reason.includes("DIFFERENT prefix hash"), output.reason);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test("--pr-body-fix-retry fails closed when the existing sentinel recorded no prefix hash", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
+  try {
+    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
+    // Existing sentinel with no prefixHash at all (predates GATE-EXEC-BRIEFING-PREFIX
+    // enforcement, or a caller that never passed --prefix-hash/--prefix-file).
+    const first = runScript(["--scope", "findings-present"], { cwd: tmpDir });
+    assert.equal(first.status, 0, first.stderr);
+
+    const retry = runScript(
+      ["--scope", "findings-present", "--prefix-hash", "a".repeat(64), "--pr-body-fix-retry"],
+      { cwd: tmpDir },
+    );
+    assert.equal(retry.status, 1, retry.stderr);
+    const output = JSON.parse(retry.stdout.trim());
+    assert.equal(output.fresh, false);
+    assert.ok(output.reason.includes("no prefix hash"), output.reason);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test("--pr-body-fix-retry requires --prefix-hash or --prefix-file", async () => {
+  const result = runScript(["--scope", "findings-present", "--pr-body-fix-retry"]);
+  assert.equal(result.status, 2, result.stderr);
+  assert.ok(result.stderr.includes("pr-body-fix-retry"), result.stderr);
+});
+
+test("--pr-body-fix-retry on a first run (no existing sentinel) behaves like a normal fresh run", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
+  try {
+    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
+    const result = runScript(
+      ["--scope", "findings-present", "--prefix-hash", "a".repeat(64), "--pr-body-fix-retry"],
+      { cwd: tmpDir },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const output = JSON.parse(result.stdout.trim());
+    assert.equal(output.fresh, true);
+    assert.equal(output.sentinelCreated, true);
+    // The flag only changes behavior when a collision actually occurs; a plain
+    // first run is unaffected and does not report prBodyFixRetry.
+    assert.equal("prBodyFixRetry" in output, false);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+});


### PR DESCRIPTION
Closes #1364

## Objective

Give gate reviewers a sanctioned same-head retry path for a PR-body/description-only fix — one that doesn't change the head SHA — without a manual sentinel deletion or a full re-fan of already-clean angles (which would desync the byte-identical briefing-prefix record).

## What changed

- **New `--pr-body-fix-retry` flag on `verify-fresh-review-context.mjs`.** When a fresh-context sentinel already exists for the exact `(scope, round)`, the flag permits overwriting it **only** when the caller's `--prefix-hash`/`--prefix-file` matches the existing sentinel's recorded hash exactly — proof the seeded briefing bytes were not rebuilt. A hash mismatch, a hashless existing sentinel, or a missing prefix arg still fails closed. This is a narrow, explicit escape hatch, not a general bypass.
- **`GATE-EXEC-BRIEFING-PREFIX` byte-identity is preserved, not relaxed.** Because the prefix hash is unchanged, every other clean angle's sentinel from the same round still matches the same on-disk record — `verify-briefing-prefixes.mjs` needs zero changes (leaving it untouched is itself part of the invariant-preservation proof).
- **Docs** (`docs/gate-review-sub-loop-contract.md`, Sentinel lifecycle): the retried reviewer is re-briefed with the unchanged prefix plus an angle-specific instruction to fetch the current PR body live, since the point of the retry is the just-edited description.

## Implementation decision

Chosen the smallest-blast-radius mechanism that matches the existing ad-hoc workaround: a hash-gated same-head sentinel overwrite. Rejected relaxing the prefix byte-identity invariant (would weaken the fan-out provenance guarantee) and a full re-fan (re-reviews clean angles and rebuilds the prefix). The retry is only usable when the briefing bytes are provably unchanged.

## Validation

- New tests in `test/github/verify-fresh-review-context.test.mjs`: overwrite succeeds on matching hash; fails closed on mismatch / hashless sentinel / missing prefix arg; first-run behaves like a normal fresh run; plain re-entry (no flag) still fails closed.
- `verify-briefing-prefixes.test.mjs` / `write-gate-context.test.mjs` unchanged and green (the invariant the mechanism relies on).
- `npm run verify` green (all legs, 0 failures); `test:doc-guard` 200 pass.

## Non-goals

- No change to head-advancing retries (Phase-5 re-fan on a new head is unchanged).
- No relaxation of the briefing-prefix byte-identity or fan-out provenance contracts.
