### PR TITLE
feat(gate-evidence): close the API-driven ready/merge gate bypass

### DIFF
--- a/.claude/skills/docs/copilot-ci-status-contract.md
+++ b/.claude/skills/docs/copilot-ci-status-contract.md
@@ -12,13 +12,15 @@ Implementation surface:
 
 - `normalizeStatusCheckRollupContract(statusCheckRollup)` — normalizes the PR `statusCheckRollup` snapshot from `gh pr view`
 - `normalizeHeadScopedCiContract({ checkRunsStatus, commitStatus })` — normalizes current-head refresh inputs after explicit `check-runs` / commit-status probes
-- `deriveLoopCiStatusFromRollup(statusCheckRollup)` — same rollup input as above, but excludes the loop's own `LOOP_DERIVED_CI_CHECK_NAME` (`gate-evidence`) check before computing the status, returning `{ status, excludedFailureDetails }`. `status` is `"crediblyGreen"` (never masked as a plain `"success"`) when every OTHER check is green and `gate-evidence` was the only excluded failure; a genuinely failing check right beside it still yields `"failure"`.
+- `deriveLoopCiStatusFromRollup(statusCheckRollup)` — same rollup input as above, but excludes the loop's own `LOOP_DERIVED_CI_CHECK_NAME` (`gate-evidence`) check before computing the status, returning `{ status, excludedFailureDetails }`. `status` is a plain `"success"` (not an "unconfirmed" `crediblyGreen`) when every OTHER check is green and `gate-evidence` was the only excluded failure — every reason gate-evidence can be red is independently tracked elsewhere in the loop snapshot, so excluding it loses no signal; `excludedFailureDetails` still lists it for transparency. A genuinely failing check right beside it still yields `"failure"` (never masked).
 
 Both `normalizeStatusCheckRollupContract` and `normalizeHeadScopedCiContract` return the same machine-readable contract shape.
 
 ## Loop-derived check exclusion
 
-`gate-evidence` (`.github/workflows/gate-evidence.yml`) is a server-side check whose conclusion is DERIVED from the loop's own progress (a clean current-head `pre_approval_gate` verdict) — not an independent build/test signal. The dev-loop must never let it block the very step (posting `pre_approval_gate`) that would turn it green. `LOOP_DERIVED_CI_CHECK_NAME` is the single exported constant naming this check; `partitionEntriesByCheckName` and `promoteExcludedCleanCiStatus` are the shared primitives `deriveLoopCiStatusFromRollup` composes from, and the check-runs-shaped equivalent in `scripts/loop/detect-copilot-loop-state.mjs` reuses the same constant and promotion rule so the fallback (rollup) and refresh (check-runs) derivation paths never disagree.
+`gate-evidence` (`.github/workflows/gate-evidence.yml`) is a server-side check whose conclusion is DERIVED from the loop's own progress (a clean current-head `pre_approval_gate` verdict) — not an independent build/test signal. The dev-loop must never let it block the very step (posting `pre_approval_gate`) that would turn it green, and must not treat it as "unconfirmed" CI either: every reason it can be red (missing draft_gate/pre_approval evidence, unresolved threads, a stale runner) is independently tracked elsewhere in the loop snapshot. `LOOP_DERIVED_CI_CHECK_NAME` is the single exported constant naming this check; `partitionEntriesByCheckName` is the shared primitive `deriveLoopCiStatusFromRollup` composes from, and the check-runs-shaped equivalent in `scripts/loop/detect-copilot-loop-state.mjs` reuses the same constant and exclusion rule so the fallback (rollup) and refresh (check-runs) derivation paths never disagree.
+
+Note: `"crediblyGreen"` is a distinct, unrelated CI status reserved for the bounded zero-suite local-validation exception (`--local-validation-head-sha`, #740/#1338) — it is never produced by the gate-evidence exclusion above.
 
 ## Inputs
 

--- a/.claude/skills/docs/copilot-ci-status-contract.md
+++ b/.claude/skills/docs/copilot-ci-status-contract.md
@@ -12,8 +12,13 @@ Implementation surface:
 
 - `normalizeStatusCheckRollupContract(statusCheckRollup)` — normalizes the PR `statusCheckRollup` snapshot from `gh pr view`
 - `normalizeHeadScopedCiContract({ checkRunsStatus, commitStatus })` — normalizes current-head refresh inputs after explicit `check-runs` / commit-status probes
+- `deriveLoopCiStatusFromRollup(statusCheckRollup)` — same rollup input as above, but excludes the loop's own `LOOP_DERIVED_CI_CHECK_NAME` (`gate-evidence`) check before computing the status, returning `{ status, excludedFailureDetails }`. `status` is `"crediblyGreen"` (never masked as a plain `"success"`) when every OTHER check is green and `gate-evidence` was the only excluded failure; a genuinely failing check right beside it still yields `"failure"`.
 
-Both entry points return the same machine-readable contract shape.
+Both `normalizeStatusCheckRollupContract` and `normalizeHeadScopedCiContract` return the same machine-readable contract shape.
+
+## Loop-derived check exclusion
+
+`gate-evidence` (`.github/workflows/gate-evidence.yml`) is a server-side check whose conclusion is DERIVED from the loop's own progress (a clean current-head `pre_approval_gate` verdict) — not an independent build/test signal. The dev-loop must never let it block the very step (posting `pre_approval_gate`) that would turn it green. `LOOP_DERIVED_CI_CHECK_NAME` is the single exported constant naming this check; `partitionEntriesByCheckName` and `promoteExcludedCleanCiStatus` are the shared primitives `deriveLoopCiStatusFromRollup` composes from, and the check-runs-shaped equivalent in `scripts/loop/detect-copilot-loop-state.mjs` reuses the same constant and promotion rule so the fallback (rollup) and refresh (check-runs) derivation paths never disagree.
 
 ## Inputs
 

--- a/.claude/skills/docs/merge-preconditions.md
+++ b/.claude/skills/docs/merge-preconditions.md
@@ -52,6 +52,33 @@ Before merge, ALL of the following MUST hold:
 
 > Runner-coordination lock: the pre-merge evidence check fails closed on a stale/foreign runner claim for the PR. A completing run releases its claim best-effort at every terminal stop (including the human approval checkpoint), so a merge re-dispatch normally proceeds. If a lock held by a completed/dead run still blocks the merge, take it over explicitly with `node <resolved-skill-scripts>/loop/pr-runner-coordination.mjs takeover --repo <owner/name> --pr <number>`. Never take over a genuinely active (non-stale) run — that fail-closed block is intentional.
 
+### Items 3 and 4 apply to every path, not just the dev-loop tooling
+
+Items 3 and 4 (clean `draft_gate` / current-head `pre_approval_gate` verdicts) are
+enforced two ways, and both must be closed for the precondition to hold in
+practice:
+
+- **Client-side:** the PreToolUse Bash hook blocks an ungated `gh pr ready` /
+  `gh pr merge` invocation, and `detect-checkpoint-evidence.mjs` is what the
+  dev-loop tooling calls before merging.
+- **Server-side:** the `gate-evidence` required status check
+  (`.github/workflows/gate-evidence.yml`) re-runs the same verdict check on
+  GitHub's own token for every non-draft PR. This is what actually closes the
+  ready/merge bypass — a direct GitHub API call (MCP/REST, web UI, a raw `gh`
+  invocation outside the hook) skips the client-side path entirely but still
+  cannot merge without a green `gate-evidence` check once branch protection on
+  `main` requires it.
+
+The server-side check verifies the same visible, comment-derived verdict fields
+the client-side tooling does (including the light-mode inline exception,
+[Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md#light-mode-inline-acceptance-under-threshold-micro-prs)),
+via `--skip-fanout-ledger-check`. It does **not** re-verify the deeper fan-out
+findings-log ledger/provenance layer (`gates.requireFanoutEvidence` /
+`requireFanoutProvenance`): that evidence lives in a gitignored, worktree-local
+`tmp/` file only the machine that ran the review has on disk, so a stateless CI
+runner can never see it. That layer remains client-side/self-reported-only — the
+same "not un-forgeable" caveat the sub-loop contract already documents.
+
 ### Evidence writes and `gh pr merge` MUST be separate tool calls (#1172)
 
 The PreToolUse Bash gate evaluates `gh pr merge` **before** the Bash tool call executes. A compound

--- a/.claude/skills/docs/merge-preconditions.md
+++ b/.claude/skills/docs/merge-preconditions.md
@@ -61,13 +61,15 @@ practice:
 - **Client-side:** the PreToolUse Bash hook blocks an ungated `gh pr ready` /
   `gh pr merge` invocation, and `detect-checkpoint-evidence.mjs` is what the
   dev-loop tooling calls before merging.
-- **Server-side:** the `gate-evidence` required status check
+- **Server-side:** the `gate-evidence` status check
   (`.github/workflows/gate-evidence.yml`) re-runs the same verdict check on
-  GitHub's own token for every non-draft PR. This is what actually closes the
-  ready/merge bypass — a direct GitHub API call (MCP/REST, web UI, a raw `gh`
-  invocation outside the hook) skips the client-side path entirely but still
-  cannot merge without a green `gate-evidence` check once branch protection on
-  `main` requires it.
+  GitHub's own token for every non-draft PR. This is what closes the ready/merge
+  bypass — a direct GitHub API call (MCP/REST, web UI, a raw `gh` invocation
+  outside the hook) skips the client-side path entirely but still cannot merge
+  without a green `gate-evidence` check **once branch protection on `main`
+  requires it**. Until an operator adds it to branch protection, the check runs
+  and reports on every non-draft PR but does **not** yet block merge — it is
+  reporting-only in that window.
 
 The server-side check verifies the same visible, comment-derived verdict fields
 the client-side tooling does (including the light-mode inline exception,

--- a/.github/workflows/gate-evidence.yml
+++ b/.github/workflows/gate-evidence.yml
@@ -1,0 +1,51 @@
+name: Gate evidence
+
+# Server-side enforcement of the draft_gate / pre_approval_gate contract
+# (skills/docs/merge-preconditions.md, MERGE-PRECOND-REQUIRED items 3-4). Runs on
+# GitHub's own token, so an API-driven ready/merge transition (gh CLI, MCP/REST,
+# web UI) cannot bypass the gates the client-side tooling already enforces.
+#
+# Skipped entirely while the PR is a draft (draft_gate is not required yet, and a
+# draft PR cannot be merged regardless); GitHub Actions treats a skipped job on a
+# required check as passing, so this never blocks draft work.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  gate-evidence:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Install workspace dependencies
+        run: npm ci
+
+      # --skip-fanout-ledger-check: the fan-out findings-log ledger is a
+      # gitignored, worktree-local tmp/ file that only the machine that ran the
+      # review has on disk, so this stateless runner can never see it. This check
+      # still enforces the part that IS remotely verifiable: a clean draft_gate
+      # verdict, and a clean pre_approval_gate verdict on the current head,
+      # including the documented light-mode inline exception.
+      - name: Verify draft_gate / pre_approval_gate evidence
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/github/detect-checkpoint-evidence.mjs \
+            --repo "${{ github.repository }}" \
+            --pr "${{ github.event.pull_request.number }}" \
+            --skip-fanout-ledger-check

--- a/.github/workflows/gate-evidence.yml
+++ b/.github/workflows/gate-evidence.yml
@@ -18,10 +18,16 @@ name: Gate evidence
 #     (harness attestation) is #1358's explicit non-goal. Merge is maintainer-
 #     gated, so forging requires the merger to self-modify.
 #   - Trigger staleness: the verdict depends on PR comment history + thread
-#     resolution, which pull_request events don't re-fire on. This fails CLOSED
-#     (stale/missing evidence -> red, never a false green); the draft-first flow
-#     re-evaluates on ready_for_review after the verdict is posted while still
-#     draft, and any push re-triggers. Broadening triggers is out of scope here.
+#     resolution, which pull_request events don't re-fire on. For HEAD staleness
+#     this fails closed (a new commit re-triggers synchronize; missing/stale
+#     current-head evidence -> red). But the comment/thread dimension is NOT
+#     re-evaluated between triggering events: a NEW unresolved thread appearing
+#     after the last push/ready event leaves the SHA-pinned green check stale
+#     until the next push -> a residual false-green window on the thread axis.
+#     Bounded by the draft-first flow (re-evaluates on ready_for_review after the
+#     verdict is posted) and the maintainer-gated merge, but real; closing it
+#     (re-verify at merge / broaden triggers) is tracked separately. Not a reason
+#     to treat this check as the sole merge guard.
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]

--- a/.github/workflows/gate-evidence.yml
+++ b/.github/workflows/gate-evidence.yml
@@ -2,8 +2,10 @@ name: Gate evidence
 
 # Server-side enforcement of the draft_gate / pre_approval_gate contract
 # (skills/docs/merge-preconditions.md, MERGE-PRECOND-REQUIRED items 3-4). Runs on
-# GitHub's own token, so an API-driven ready/merge transition (gh CLI, MCP/REST,
-# web UI) cannot bypass the gates the client-side tooling already enforces.
+# GitHub's own token so that — once an operator makes this a required check in
+# branch protection on the default branch — an API-driven ready/merge transition
+# (gh CLI, MCP/REST, web UI) cannot bypass the gates the client-side tooling
+# already enforces. Until then it runs and reports but does not block merge.
 #
 # Skipped entirely while the PR is a draft (draft_gate is not required yet, and a
 # draft PR cannot be merged regardless); GitHub Actions treats a skipped job on a

--- a/.github/workflows/gate-evidence.yml
+++ b/.github/workflows/gate-evidence.yml
@@ -8,6 +8,20 @@ name: Gate evidence
 # Skipped entirely while the PR is a draft (draft_gate is not required yet, and a
 # draft PR cannot be merged regardless); GitHub Actions treats a skipped job on a
 # required check as passing, so this never blocks draft work.
+#
+# Two inherent limitations of a pull_request-triggered, head-run check (both
+# accepted by design, neither a bypass):
+#   - Head-provenance: the workflow and the scripts it runs come from the PR's
+#     own head, so a PR could edit this file or the detector to forge a green
+#     check on itself. This is the "self-reported / not un-forgeable" caveat in
+#     docs/gate-review-sub-loop-contract.md; the un-forgeable provenance bridge
+#     (harness attestation) is #1358's explicit non-goal. Merge is maintainer-
+#     gated, so forging requires the merger to self-modify.
+#   - Trigger staleness: the verdict depends on PR comment history + thread
+#     resolution, which pull_request events don't re-fire on. This fails CLOSED
+#     (stale/missing evidence -> red, never a false green); the draft-first flow
+#     re-evaluates on ready_for_review after the verdict is posted while still
+#     draft, and any push re-triggers. Broadening triggers is out of scope here.
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -502,6 +502,17 @@ does NOT claim un-forgeable enforcement. Un-forgeable recording (the harness att
 actually ran each per-angle review) is the Pi-harness bridge — the subagent tool honored
 at child depth (see #1084).
 
+This provenance layer is distinct from the underlying gate verdict itself. The verdict
+comment's clean `draft_gate`/`pre_approval_gate` presence on the current head IS enforced
+server-side — the `gate-evidence` required status check
+(`.github/workflows/gate-evidence.yml`, [Merge preconditions](../skills/docs/merge-preconditions.md#items-3-and-4-apply-to-every-path-not-just-the-dev-loop-tooling))
+re-runs `detect-checkpoint-evidence.mjs --skip-fanout-ledger-check` on GitHub's own
+token so an API-driven ready/merge transition cannot skip it. That flag deliberately
+does NOT re-verify the findings-log ledger/provenance/angle-coverage layer described
+above: the ledger is a gitignored, worktree-local `tmp/` file that only the machine
+that ran the review has on disk, so a stateless CI runner can never see it. That
+narrower gap is exactly what this caveat and the Pi-harness bridge remain scoped to.
+
 ### Angle-coverage enforcement (mandatory angles + pool membership)
 
 <!-- rule: GATE-EXEC-ANGLE-COVERAGE -->

--- a/docs/gate-review-sub-loop-contract.md
+++ b/docs/gate-review-sub-loop-contract.md
@@ -503,11 +503,13 @@ actually ran each per-angle review) is the Pi-harness bridge — the subagent to
 at child depth (see #1084).
 
 This provenance layer is distinct from the underlying gate verdict itself. The verdict
-comment's clean `draft_gate`/`pre_approval_gate` presence on the current head IS enforced
-server-side — the `gate-evidence` required status check
-(`.github/workflows/gate-evidence.yml`, [Merge preconditions](../skills/docs/merge-preconditions.md#items-3-and-4-apply-to-every-path-not-just-the-dev-loop-tooling))
-re-runs `detect-checkpoint-evidence.mjs --skip-fanout-ledger-check` on GitHub's own
-token so an API-driven ready/merge transition cannot skip it. That flag deliberately
+comment's clean `draft_gate`/`pre_approval_gate` presence on the current head is enforced
+server-side by the `gate-evidence` check
+(`.github/workflows/gate-evidence.yml`, [Merge preconditions](../skills/docs/merge-preconditions.md#items-3-and-4-apply-to-every-path-not-just-the-dev-loop-tooling)),
+which re-runs `detect-checkpoint-evidence.mjs --skip-fanout-ledger-check` on GitHub's own
+token so that — once branch protection on `main` requires it — an API-driven ready/merge
+transition cannot skip it. (Until that operator step lands the check runs and reports but
+does not yet block merge.) That flag deliberately
 does NOT re-verify the findings-log ledger/provenance/angle-coverage layer described
 above: the ledger is a gitignored, worktree-local `tmp/` file that only the machine
 that ran the review has on disk, so a stateless CI runner can never see it. That

--- a/packages/core/src/loop/copilot-ci-status.mjs
+++ b/packages/core/src/loop/copilot-ci-status.mjs
@@ -5,6 +5,62 @@ const STATUS_CONTEXT_FAILURE_STATES = new Set(["FAILURE", "ERROR"]);
 const STATUS_CONTEXT_PENDING_STATES = new Set(["PENDING", "EXPECTED"]);
 const STATUS_CONTEXT_SUCCESS_STATES = new Set(["SUCCESS"]);
 
+/**
+ * Name of the server-side "Gate evidence" check dev-loops posts on its own
+ * pull requests (`.github/workflows/gate-evidence.yml`). Its conclusion is
+ * DERIVED from the loop's own progress (a clean current-head
+ * pre_approval_gate verdict), not an independent build/test signal — so the
+ * loop must exclude it, by this exact name only, when deriving the CI status
+ * that gates its own pre_approval step. Otherwise the loop could never post
+ * the very verdict that would turn this check green (#1358).
+ */
+export const LOOP_DERIVED_CI_CHECK_NAME = "gate-evidence";
+
+function checkEntryName(entry) {
+  if (typeof entry?.name === "string" && entry.name.length > 0) return entry.name;
+  if (typeof entry?.context === "string" && entry.context.length > 0) return entry.context;
+  return "";
+}
+
+/**
+ * Split rollup/check-run entries into those matching `targetName` and the rest.
+ * Shared by both statusCheckRollup-shaped and check-runs-shaped payloads —
+ * both use `.name` (check-runs also use `.context` for legacy StatusContext).
+ *
+ * @param {Array<object>} entries
+ * @param {string} targetName
+ * @returns {{ matched: Array<object>, rest: Array<object> }}
+ */
+export function partitionEntriesByCheckName(entries, targetName) {
+  const list = Array.isArray(entries) ? entries : [];
+  const matched = [];
+  const rest = [];
+  for (const entry of list) {
+    (checkEntryName(entry) === targetName ? matched : rest).push(entry);
+  }
+  return { matched, rest };
+}
+
+/**
+ * Promote an ordinary "success" CI status to "crediblyGreen" when the only
+ * reason it isn't literally all-green is a known loop-derived check (e.g.
+ * `gate-evidence`) that was excluded before computing it. A genuine
+ * failure/pending/none is never promoted — this only relabels an
+ * already-"success" verdict so callers can tell "all green" apart from
+ * "green except our own excluded, self-referential check" while still
+ * treating both as non-blocking.
+ *
+ * @param {"success"|"failure"|"pending"|"none"} status
+ * @param {Array<string>} excludedFailureDetails
+ * @returns {"success"|"failure"|"pending"|"none"|"crediblyGreen"}
+ */
+export function promoteExcludedCleanCiStatus(status, excludedFailureDetails) {
+  if (status === "success" && Array.isArray(excludedFailureDetails) && excludedFailureDetails.length > 0) {
+    return "crediblyGreen";
+  }
+  return status;
+}
+
 function normalizeHeadScopedCiStatus(status) {
   return VALID_HEAD_SCOPED_CI_STATUSES.has(status) ? status : "none";
 }
@@ -252,4 +308,22 @@ export function normalizeHeadScopedCiContract({
   }
 
   return buildCiContract(overallStatus);
+}
+
+/**
+ * Derive a loop-safe CI status from a PR `statusCheckRollup` snapshot: the
+ * `LOOP_DERIVED_CI_CHECK_NAME` entry (`gate-evidence`) is excluded from the
+ * status computation before it can block, and surfaced separately so a
+ * genuinely failing check right beside it can never be masked.
+ *
+ * @param {Array<object>} rollup
+ * @returns {{ status: "success"|"failure"|"pending"|"none"|"crediblyGreen", excludedFailureDetails: Array<string> }}
+ */
+export function deriveLoopCiStatusFromRollup(rollup) {
+  const { matched, rest } = partitionEntriesByCheckName(rollup, LOOP_DERIVED_CI_CHECK_NAME);
+  const status = normalizeStatusCheckRollupStatus(rest);
+  const excludedFailureDetails = matched.length > 0 && normalizeStatusCheckRollupStatus(matched) === "failure"
+    ? [LOOP_DERIVED_CI_CHECK_NAME]
+    : [];
+  return { status: promoteExcludedCleanCiStatus(status, excludedFailureDetails), excludedFailureDetails };
 }

--- a/packages/core/src/loop/copilot-ci-status.mjs
+++ b/packages/core/src/loop/copilot-ci-status.mjs
@@ -41,26 +41,6 @@ export function partitionEntriesByCheckName(entries, targetName) {
   return { matched, rest };
 }
 
-/**
- * Promote an ordinary "success" CI status to "crediblyGreen" when the only
- * reason it isn't literally all-green is a known loop-derived check (e.g.
- * `gate-evidence`) that was excluded before computing it. A genuine
- * failure/pending/none is never promoted — this only relabels an
- * already-"success" verdict so callers can tell "all green" apart from
- * "green except our own excluded, self-referential check" while still
- * treating both as non-blocking.
- *
- * @param {"success"|"failure"|"pending"|"none"} status
- * @param {Array<string>} excludedFailureDetails
- * @returns {"success"|"failure"|"pending"|"none"|"crediblyGreen"}
- */
-export function promoteExcludedCleanCiStatus(status, excludedFailureDetails) {
-  if (status === "success" && Array.isArray(excludedFailureDetails) && excludedFailureDetails.length > 0) {
-    return "crediblyGreen";
-  }
-  return status;
-}
-
 function normalizeHeadScopedCiStatus(status) {
   return VALID_HEAD_SCOPED_CI_STATUSES.has(status) ? status : "none";
 }
@@ -314,10 +294,15 @@ export function normalizeHeadScopedCiContract({
  * Derive a loop-safe CI status from a PR `statusCheckRollup` snapshot: the
  * `LOOP_DERIVED_CI_CHECK_NAME` entry (`gate-evidence`) is excluded from the
  * status computation before it can block, and surfaced separately so a
- * genuinely failing check right beside it can never be masked.
+ * genuinely failing check right beside it can never be masked. Every reason
+ * gate-evidence can be red (missing draft_gate/pre_approval evidence,
+ * unresolved threads, a stale runner) is independently tracked elsewhere in
+ * the loop snapshot, so excluding it here loses no real signal: `status`
+ * stays a plain "success" (not an "unconfirmed" crediblyGreen) when it is the
+ * only excluded failure and everything else is green.
  *
  * @param {Array<object>} rollup
- * @returns {{ status: "success"|"failure"|"pending"|"none"|"crediblyGreen", excludedFailureDetails: Array<string> }}
+ * @returns {{ status: "success"|"failure"|"pending"|"none", excludedFailureDetails: Array<string> }}
  */
 export function deriveLoopCiStatusFromRollup(rollup) {
   const { matched, rest } = partitionEntriesByCheckName(rollup, LOOP_DERIVED_CI_CHECK_NAME);
@@ -325,5 +310,5 @@ export function deriveLoopCiStatusFromRollup(rollup) {
   const excludedFailureDetails = matched.length > 0 && normalizeStatusCheckRollupStatus(matched) === "failure"
     ? [LOOP_DERIVED_CI_CHECK_NAME]
     : [];
-  return { status: promoteExcludedCleanCiStatus(status, excludedFailureDetails), excludedFailureDetails };
+  return { status, excludedFailureDetails };
 }

--- a/packages/core/src/loop/copilot-loop-state.mjs
+++ b/packages/core/src/loop/copilot-loop-state.mjs
@@ -12,7 +12,7 @@
  * becomes an explicit bounded input (agentFixStatus) rather than hidden orchestration behavior.
  */
 
-import { normalizeStatusCheckRollupContract } from "./copilot-ci-status.mjs";
+import { deriveLoopCiStatusFromRollup } from "./copilot-ci-status.mjs";
 
 /** Stable state name constants for the async Copilot review/fix loop. */
 export const STATE = Object.freeze({
@@ -191,7 +191,7 @@ export function isCopilotRoundCapReached({ copilotReviewRoundCount, maxCopilotRo
 }
 
 export function normalizeCiStatus(rollup) {
-  return normalizeStatusCheckRollupContract(rollup).overallStatus;
+  return deriveLoopCiStatusFromRollup(rollup).status;
 }
 
 export function buildSnapshotFromPrFacts({
@@ -206,11 +206,15 @@ export function buildSnapshotFromPrFacts({
   ciStatus,
   lastCopilotRoundMaxSignal = null,
   failureDetails = [],
-  excludedFailureDetails = [],
+  excludedFailureDetails,
 }) {
   const prState = typeof prData?.state === "string" ? prData.state.toUpperCase() : "OPEN";
   const prMerged = prState === "MERGED";
   const prClosed = prState === "CLOSED";
+  // Default derivation excludes the loop's own gate-evidence check (#1358) so a
+  // caller that never threads an explicit ciStatus (e.g. gate-coordination
+  // detection) still never treats it as a blocking CI failure.
+  const rollupDerivation = deriveLoopCiStatusFromRollup(prData?.statusCheckRollup);
 
   return normalizeSnapshot({
     prExists: true,
@@ -225,9 +229,9 @@ export function buildSnapshotFromPrFacts({
     actionableThreadCount,
     copilotReviewRoundCount,
     lastCopilotRoundMaxSignal,
-    ciStatus: ciStatus ?? normalizeCiStatus(prData?.statusCheckRollup),
+    ciStatus: ciStatus ?? rollupDerivation.status,
     failureDetails,
-    excludedFailureDetails,
+    excludedFailureDetails: excludedFailureDetails ?? rollupDerivation.excludedFailureDetails,
   });
 }
 

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -1380,41 +1380,17 @@ function evaluatePrGateCoordinationCore(input = {}) {
   // exhausted and the current head is clean (zero unresolved threads + green CI)
   // — including a POST-CAP head Copilot has not (and will not) re-review, since
   // no further Copilot round is permitted. Re-requesting review is illegal here,
-  // so this MUST NOT dead-end at READY_TO_REREQUEST_REVIEW. It routes to the
-  // pre_approval_gate, which reviews the post-cap head itself (per #848). The CI
-  // guards below still hold (failing / credibly-green CI blocks), and conflicts /
-  // blocked states are handled earlier, so genuinely-blocked states still forbid
-  // pre_approval. Mirrors LOW_SIGNAL_CONVERGED routing with round-cap reasoning.
+  // so this MUST NOT dead-end at READY_TO_REREQUEST_REVIEW — nor at a forced
+  // rerequest for a post-convergence significant change (#1387): the cap makes
+  // that rerequest impossible (request-copilot-review suppresses it), so a
+  // significant change discovered here is reviewed by the pre_approval_gate
+  // fan-out itself, on the post-cap head, same as any other clean fallback. It
+  // routes to the pre_approval_gate, which reviews the post-cap head itself
+  // (per #848). The CI guards below still hold (failing / credibly-green CI
+  // blocks), and conflicts / blocked states are handled earlier, so
+  // genuinely-blocked states still forbid pre_approval. Mirrors
+  // LOW_SIGNAL_CONVERGED routing with round-cap reasoning.
   if (effectiveLifecycleState === STATE.ROUND_CAP_CLEAN_FALLBACK) {
-    if (roundCapNewCycleRequired) {
-      pushUnique(allowedNextActions, [PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW]);
-      pushUnique(forbiddenActions, [
-        PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE,
-        PR_CHECKPOINT_ACTION.MARK_READY_FOR_REVIEW,
-        PR_CHECKPOINT_ACTION.REQUEST_COPILOT_REVIEW,
-        PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE,
-        PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY,
-      ]);
-      return buildResult({
-        repo: input.repo ?? null,
-        pr: Number.isInteger(input.pr) ? input.pr : null,
-        currentHeadSha,
-        lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
-        loopDisposition: DISPOSITION.ACTION_REQUIRED,
-        gateBoundary: PR_CHECKPOINT.POST_DRAFT_EXTERNAL_REVIEW,
-        draftGateAlreadySatisfied: roundCapReached ? true : draftGateAlreadySatisfied,
-        draftGate,
-        preApprovalGate,
-        allowedNextActions,
-        forbiddenActions,
-        nextAction: PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW,
-        reason: `The previous Copilot cycle converged at the round cap (${copilotReviewRoundCount}/${maxCopilotRounds}), but significant post-convergence changes landed on the current head. Open a new cycle and re-request Copilot review before entering \`pre_approval_gate\`.`,
-        mergeStateStatus,
-        conflictFiles,
-        refinementArtifact,
-        copilotReviewRoundCount,
-      });
-    }
     if (preApprovalRequireCi && (ciStatus === "failure" || ciStatus === "crediblyGreen")) {
       pushUnique(allowedNextActions, [PR_CHECKPOINT_ACTION.REPORT_BLOCKED]);
       pushUnique(forbiddenActions, postDraftForbidden);

--- a/packages/core/test/copilot-ci-status.test.mjs
+++ b/packages/core/test/copilot-ci-status.test.mjs
@@ -11,7 +11,6 @@ import {
   normalizeHeadScopedCiContract,
   deriveLoopCiStatusFromRollup,
   partitionEntriesByCheckName,
-  promoteExcludedCleanCiStatus,
   LOOP_DERIVED_CI_CHECK_NAME,
 } from "../src/loop/copilot-ci-status.mjs";
 
@@ -227,22 +226,17 @@ test("partitionEntriesByCheckName splits rollup entries by name/context", () => 
   assert.equal(rest[0].name, "test-scripts");
 });
 
-test("promoteExcludedCleanCiStatus promotes success to crediblyGreen only when excluded failures exist", () => {
-  assert.equal(promoteExcludedCleanCiStatus("success", ["gate-evidence"]), "crediblyGreen");
-  assert.equal(promoteExcludedCleanCiStatus("success", []), "success");
-  assert.equal(promoteExcludedCleanCiStatus("failure", ["gate-evidence"]), "failure");
-  assert.equal(promoteExcludedCleanCiStatus("pending", ["gate-evidence"]), "pending");
-  assert.equal(promoteExcludedCleanCiStatus("none", ["gate-evidence"]), "none");
-});
-
-test("deriveLoopCiStatusFromRollup: gate-evidence as the ONLY failing check yields crediblyGreen and excludes it", () => {
+// #1387: gate-evidence red-alone must derive plain "success", not an
+// "unconfirmed" crediblyGreen — every reason it can be red is independently
+// tracked elsewhere in the loop snapshot, so excluding it loses no signal.
+test("deriveLoopCiStatusFromRollup: gate-evidence as the ONLY failing check yields success and excludes it", () => {
   const result = deriveLoopCiStatusFromRollup([
     { name: "gate-evidence", status: "COMPLETED", conclusion: "FAILURE" },
     { name: "test-scripts", status: "COMPLETED", conclusion: "SUCCESS" },
     { name: "test-core", status: "COMPLETED", conclusion: "SUCCESS" },
   ]);
 
-  assert.equal(result.status, "crediblyGreen");
+  assert.equal(result.status, "success");
   assert.deepEqual(result.excludedFailureDetails, ["gate-evidence"]);
 });
 

--- a/packages/core/test/copilot-ci-status.test.mjs
+++ b/packages/core/test/copilot-ci-status.test.mjs
@@ -9,6 +9,10 @@ import {
   normalizeHeadScopedCheckRunsStatus,
   normalizeHeadScopedCommitStatus,
   normalizeHeadScopedCiContract,
+  deriveLoopCiStatusFromRollup,
+  partitionEntriesByCheckName,
+  promoteExcludedCleanCiStatus,
+  LOOP_DERIVED_CI_CHECK_NAME,
 } from "../src/loop/copilot-ci-status.mjs";
 
 test("normalizeStatusCheckRollupStatus returns failure over pending for mixed rollup entries", () => {
@@ -198,4 +202,75 @@ test("summarizeHeadScopedCheckRunsSignal returns failureDetails undefined when n
 
   assert.equal(summary.status, "success");
   assert.equal(summary.failureDetails, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// deriveLoopCiStatusFromRollup / gate-evidence exclusion (#1358)
+// ---------------------------------------------------------------------------
+
+test("LOOP_DERIVED_CI_CHECK_NAME is the gate-evidence check", () => {
+  assert.equal(LOOP_DERIVED_CI_CHECK_NAME, "gate-evidence");
+});
+
+test("partitionEntriesByCheckName splits rollup entries by name/context", () => {
+  const { matched, rest } = partitionEntriesByCheckName(
+    [
+      { name: "gate-evidence", status: "COMPLETED", conclusion: "FAILURE" },
+      { name: "test-scripts", status: "COMPLETED", conclusion: "SUCCESS" },
+      { context: "gate-evidence" },
+    ],
+    "gate-evidence",
+  );
+
+  assert.equal(matched.length, 2);
+  assert.equal(rest.length, 1);
+  assert.equal(rest[0].name, "test-scripts");
+});
+
+test("promoteExcludedCleanCiStatus promotes success to crediblyGreen only when excluded failures exist", () => {
+  assert.equal(promoteExcludedCleanCiStatus("success", ["gate-evidence"]), "crediblyGreen");
+  assert.equal(promoteExcludedCleanCiStatus("success", []), "success");
+  assert.equal(promoteExcludedCleanCiStatus("failure", ["gate-evidence"]), "failure");
+  assert.equal(promoteExcludedCleanCiStatus("pending", ["gate-evidence"]), "pending");
+  assert.equal(promoteExcludedCleanCiStatus("none", ["gate-evidence"]), "none");
+});
+
+test("deriveLoopCiStatusFromRollup: gate-evidence as the ONLY failing check yields crediblyGreen and excludes it", () => {
+  const result = deriveLoopCiStatusFromRollup([
+    { name: "gate-evidence", status: "COMPLETED", conclusion: "FAILURE" },
+    { name: "test-scripts", status: "COMPLETED", conclusion: "SUCCESS" },
+    { name: "test-core", status: "COMPLETED", conclusion: "SUCCESS" },
+  ]);
+
+  assert.equal(result.status, "crediblyGreen");
+  assert.deepEqual(result.excludedFailureDetails, ["gate-evidence"]);
+});
+
+test("deriveLoopCiStatusFromRollup: a real failing check alongside gate-evidence still fails (not masked)", () => {
+  const result = deriveLoopCiStatusFromRollup([
+    { name: "gate-evidence", status: "COMPLETED", conclusion: "FAILURE" },
+    { name: "test-scripts", status: "COMPLETED", conclusion: "FAILURE" },
+  ]);
+
+  assert.equal(result.status, "failure");
+  assert.deepEqual(result.excludedFailureDetails, ["gate-evidence"]);
+});
+
+test("deriveLoopCiStatusFromRollup: all-green rollup with no gate-evidence entry is unchanged", () => {
+  const result = deriveLoopCiStatusFromRollup([
+    { name: "test-scripts", status: "COMPLETED", conclusion: "SUCCESS" },
+  ]);
+
+  assert.equal(result.status, "success");
+  assert.deepEqual(result.excludedFailureDetails, []);
+});
+
+test("deriveLoopCiStatusFromRollup: a passing gate-evidence entry does not get reported as excluded", () => {
+  const result = deriveLoopCiStatusFromRollup([
+    { name: "gate-evidence", status: "COMPLETED", conclusion: "SUCCESS" },
+    { name: "test-scripts", status: "COMPLETED", conclusion: "SUCCESS" },
+  ]);
+
+  assert.equal(result.status, "success");
+  assert.deepEqual(result.excludedFailureDetails, []);
 });

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -428,7 +428,13 @@ test("round-cap exhaustion opens the pre-approval gate window even without a cur
   assert.match(result.reason, /pre_approval_gate/i);
 });
 
-test("significant post-convergence changes at the round cap reopen a new Copilot cycle", () => {
+// #1387: at ROUND_CAP_CLEAN_FALLBACK, a post-convergence significant change must
+// NOT force rerequest_copilot_review — the round cap makes that rerequest
+// impossible (request-copilot-review.mjs suppresses it), so the only allowed
+// action would be a dead end. The pre_approval_gate fan-out reviews the
+// current post-cap head, which IS the review of the significant change —
+// matching detect-copilot-loop-state's own ROUND_CAP_CLEAN_FALLBACK nextAction.
+test("post-convergence significant change at the round cap allows pre_approval_gate instead of an impossible rerequest (#1387)", () => {
   const result = evaluatePrGateCoordination({
     pr: 266,
     currentHeadSha: "fedcba987654",
@@ -446,11 +452,41 @@ test("significant post-convergence changes at the round cap reopen a new Copilot
     preApprovalGateMarker: gate({ visible: false }),
   });
 
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
+  assert(result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  // The impossible rerequest must never be offered — the round cap forbids it.
+  assert(!result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW));
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW));
+});
+
+// #1387: below the cap, a not-yet-settled review cycle (e.g. a significant
+// post-convergence change landed on a newer head) still reopens a new Copilot
+// cycle (no regression) — a rerequest is always POSSIBLE below the cap, so
+// only AT the cap (where it is impossible) does the routing change.
+test("post-convergence significant change below the round cap still reopens a new Copilot cycle (#1387 no regression)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    loopDisposition: DISPOSITION.ACTION_REQUIRED,
+    sameHeadCleanConverged: false,
+    ciStatus: "success",
+    copilotReviewRoundCount: 3,
+    maxCopilotRounds: 5,
+    postConvergenceSignificantChange: true,
+    draftGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "fedcba9", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
   assert.equal(result.gateBoundary, PR_CHECKPOINT.POST_DRAFT_EXTERNAL_REVIEW);
   assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW);
   assert(result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW));
   assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
-  assert.match(result.reason, /significant post-convergence changes/i);
 });
 
 // #896: a post-cap commit leaves the head unreviewed by Copilot. The interpreter
@@ -696,16 +732,14 @@ test("interpretLoopState (handoff) and evaluatePrGateCoordination (coordination-
   assert(!gateResult.forbiddenActions.includes(PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW));
 });
 
-// Full parity (#1103, #1126): at the cap WITH a significant post-convergence
-// change, both detectors reopen the Copilot cycle. The significance boolean is
-// computed by the SHARED detectPostConvergenceSignificantChange (scripts/loop/
-// _post-convergence-change.mjs). This test covers the DETECT side (core level)
-// and the handoff BASELINE it flips from. The handoff FLIP itself (clean-fallback
-// → re-request/watch on a significant change, and staying stopped on a doc-only
-// change) is covered by the copilot-pr-handoff integration tests
-// "re-requests Copilot review at the cap when a significant post-convergence
-// change lands" / "stays at round_cap_clean_fallback ... doc-only".
-test("interpretLoopState (handoff baseline) and evaluatePrGateCoordination (detect) reopen the cycle at the cap WITH a significant post-convergence change (#1103, #1126)", () => {
+// #1387 (supersedes the prior #1103/#1126 expectation): at the cap WITH a
+// significant post-convergence change, the round cap makes a fresh Copilot
+// cycle impossible (request-copilot-review.mjs suppresses the re-request), so
+// detect-copilot-loop-state's own ROUND_CAP_CLEAN_FALLBACK nextAction says
+// "continue to pre_approval_gate instead of re-requesting Copilot review" —
+// evaluatePrGateCoordination must agree, not offer the one impossible action
+// while forbidding the one loop-state says to take.
+test("interpretLoopState (handoff baseline) and evaluatePrGateCoordination (detect) agree at the cap WITH a significant post-convergence change — pre_approval_gate, not an impossible rerequest (#1387)", () => {
   const refinementConfig = { maxCopilotRounds: 2 };
   const snapshot = {
     prExists: true,
@@ -722,6 +756,7 @@ test("interpretLoopState (handoff baseline) and evaluatePrGateCoordination (dete
   // Same clean-fallback baseline both scripts derive from the snapshot.
   const handoffInterpretation = interpretLoopState(snapshot, refinementConfig);
   assert.equal(handoffInterpretation.state, STATE.ROUND_CAP_CLEAN_FALLBACK);
+  assert.match(handoffInterpretation.nextAction, /continue to pre_approval_gate instead of re-requesting/i);
 
   // detect's path with the shared significant-change signal = true.
   const gateResult = evaluatePrGateCoordination({
@@ -741,23 +776,29 @@ test("interpretLoopState (handoff baseline) and evaluatePrGateCoordination (dete
     preApprovalGateMarker: gate({ visible: false }),
   });
 
-  assert.equal(gateResult.nextAction, PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW);
-  assert(gateResult.allowedNextActions.includes(PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW));
-  assert(gateResult.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  // The two detectors must agree: neither dead-ends on the impossible rerequest.
+  assert.equal(gateResult.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
+  assert(gateResult.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert(!gateResult.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert(!gateResult.allowedNextActions.includes(PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW));
 });
 
 // Parity (#1165 — in-flight-rerequest race): the SAME snapshot at the cap, clean,
 // but with a Copilot review REQUESTED and pending on the CURRENT head (a
 // --force-rerequest in flight) plus a significant post-convergence change. Both
-// authorities must gate pre_approval_gate until the fresh review lands.
+// authorities must gate pre_approval_gate until the fresh review lands. This is
+// the independent unsettled-review-entry guard (#1190) — orthogonal to #1387's
+// round-cap routing fix: an outstanding request on the CURRENT head still
+// refuses pre_approval_gate even though the round-cap-clean-fallback branch
+// itself now allows it for a significant change with no outstanding request.
 //
 // Note the interpreter (handoff's base) deliberately routes a pending at-cap
 // request to ROUND_CAP_CLEAN_FALLBACK — it cannot see significance (that needs gh
 // compare I/O). copilot-pr-handoff.mjs therefore flips this to
 // waiting_for_copilot_review when a review is pending on the current head (proven
 // by the "in-flight force-rerequest" integration tests). detect's evaluator, fed
-// the shared significant-change signal, forbids run_pre_approval_gate here. Both
-// gate pre-approval — no divergence.
+// the outstanding copilotReviewRequestStatus, waits for the pending review here.
+// Both gate pre-approval — no divergence.
 test("interpretLoopState (handoff) and evaluatePrGateCoordination (detect) both gate pre_approval with a pending review + significant change at the cap (#1165)", () => {
   const refinementConfig = { maxCopilotRounds: 2 };
   const snapshot = {
@@ -779,7 +820,9 @@ test("interpretLoopState (handoff) and evaluatePrGateCoordination (detect) both 
   const handoffInterpretation = interpretLoopState(snapshot, refinementConfig);
   assert.equal(handoffInterpretation.state, STATE.ROUND_CAP_CLEAN_FALLBACK);
 
-  // detect's path with the shared significant-change signal = true.
+  // detect's path with the shared significant-change signal = true AND the
+  // outstanding review-request status wired through (the independent #1190
+  // gate-entry re-check reads this directly, not derived from lifecycleState).
   const gateResult = evaluatePrGateCoordination({
     pr: 503,
     currentHeadSha: "cafef00dbeef",
@@ -790,6 +833,7 @@ test("interpretLoopState (handoff) and evaluatePrGateCoordination (detect) both 
     ciStatus: snapshot.ciStatus,
     copilotReviewRoundCount: snapshot.copilotReviewRoundCount,
     maxCopilotRounds: refinementConfig.maxCopilotRounds,
+    copilotReviewRequestStatus: snapshot.copilotReviewRequestStatus,
     postConvergenceSignificantChange: true,
     draftGate: gate({ visible: true, headSha: "cafef00", verdict: "clean" }),
     draftGateMarker: gate({ visible: true, headSha: "cafef00", verdict: "clean", contractComplete: true }),
@@ -797,9 +841,9 @@ test("interpretLoopState (handoff) and evaluatePrGateCoordination (detect) both 
     preApprovalGateMarker: gate({ visible: false }),
   });
 
-  // Both gate pre-approval: detect forbids run_pre_approval_gate outright; handoff
-  // waits for the pending review (never advancing to pre_approval).
-  assert.equal(gateResult.nextAction, PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW);
+  // Both gate pre-approval: detect waits for the outstanding review instead of
+  // entering pre_approval_gate; handoff waits for the same pending review.
+  assert.equal(gateResult.nextAction, PR_CHECKPOINT_ACTION.WAIT_FOR_COPILOT_REVIEW);
   assert(gateResult.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
 });
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -729,6 +729,20 @@ Required:
 - `--repo <owner/name>`
 - `--pr <number>`
 
+Optional:
+- `--skip-fanout-ledger-check` — skips only the fan-out findings-log
+  ledger/provenance/angle-coverage layer of `gates.requireFanoutEvidence`
+  enforcement (that ledger is a gitignored, worktree-local `tmp/` file, invisible
+  to a stateless remote verifier); the comment-derived executionMode/inlineReason
+  check (including the light-mode inline exception) still applies. Used by the
+  `gate-evidence` CI check (`.github/workflows/gate-evidence.yml`); client-side
+  callers should omit it.
+
+When the `gh` binary is not on PATH, gh calls fall back to GitHub's REST/GraphQL
+API directly, given a `GH_TOKEN`/`GITHUB_TOKEN` in the environment — so a gh-less
+session can still read gate evidence instead of having no option but to bypass
+the check.
+
 Success output shape:
 - `{ "ok": true, "repo": "owner/repo", "pr": 17, "currentHeadSha": "abc1234", "draftGate": { ... }, "preApprovalGate": { ... }, "draftGateMarker": { ... }, "preApprovalGateMarker": { ... } }`
 - each gate summary includes `visible`, `headSha`, `verdict`, `findingsSummary`, `nextAction`, `commentId`, `commentUrl`, and `updatedAt`

--- a/scripts/github/_gh-rest-fallback.mjs
+++ b/scripts/github/_gh-rest-fallback.mjs
@@ -70,7 +70,20 @@ export async function restGraphqlJson(query, variables, env, { fetchImpl = fetch
   if (!res.ok) {
     throw new Error(`GitHub GraphQL fallback failed: ${res.status} ${res.statusText}`);
   }
-  return res.json();
+  const body = await res.json();
+  // GraphQL returns HTTP 200 even for query-level failures (`{errors:[...], data:null}`).
+  // Fail CLOSED on that, matching the gh path (`gh api graphql` exits non-zero): a
+  // 200-with-errors or a missing `data` must NOT be handed back as an empty/clean
+  // result, or a gh-less verifier would read "0 unresolved threads" (false green) on
+  // exactly the API-merge path this check guards.
+  if (Array.isArray(body?.errors) && body.errors.length > 0) {
+    const first = body.errors[0]?.message ?? "unknown GraphQL error";
+    throw new Error(`GitHub GraphQL fallback returned errors: ${first}`);
+  }
+  if (body?.data == null) {
+    throw new Error("GitHub GraphQL fallback returned no data");
+  }
+  return body;
 }
 
 // Fetches the fields gate-evidence reads off `gh pr view --json headRefOid` /

--- a/scripts/github/_gh-rest-fallback.mjs
+++ b/scripts/github/_gh-rest-fallback.mjs
@@ -1,0 +1,89 @@
+// Minimal REST/GraphQL fallback transport for gh-less sessions (issue #1358):
+// gate-evidence reads normally shell out to the `gh` binary. When that binary is
+// not on PATH (spawn ENOENT — never an auth/rate-limit/network failure, which must
+// still surface as a real error), the read-only evidence detector falls back to
+// calling GitHub's REST/GraphQL API directly over a bearer token from GH_TOKEN or
+// GITHUB_TOKEN. This lets a remote/MCP session with no gh CLI installed still
+// verify gate evidence instead of having no option but to bypass the check.
+const GITHUB_API_BASE = "https://api.github.com";
+
+export function isGhBinaryMissing(error) {
+  return Boolean(error) && typeof error === "object" && error.code === "ENOENT";
+}
+
+function resolveToken(env) {
+  const token = env?.GH_TOKEN || env?.GITHUB_TOKEN;
+  return typeof token === "string" && token.trim().length > 0 ? token.trim() : null;
+}
+
+function authHeaders(env) {
+  const token = resolveToken(env);
+  if (!token) {
+    throw new Error("gh binary not found and no GH_TOKEN/GITHUB_TOKEN set for the REST/GraphQL fallback");
+  }
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+function parseNextLink(linkHeader) {
+  if (typeof linkHeader !== "string" || linkHeader.length === 0) return null;
+  const match = /<([^>]+)>;\s*rel="next"/.exec(linkHeader);
+  return match ? match[1] : null;
+}
+
+export async function restGetJson(path, env, { fetchImpl = fetch } = {}) {
+  const res = await fetchImpl(`${GITHUB_API_BASE}/${path}`, { headers: authHeaders(env) });
+  if (!res.ok) {
+    throw new Error(`GitHub REST fallback GET ${path} failed: ${res.status} ${res.statusText}`);
+  }
+  return res.json();
+}
+
+// Mirrors `gh api --paginate --slurp`: follows RFC 5988 `Link: rel="next"` and
+// flattens every page's array into one list.
+export async function restGetPaginatedJson(path, env, { fetchImpl = fetch } = {}) {
+  const all = [];
+  let url = `${GITHUB_API_BASE}/${path}`;
+  while (url) {
+    const res = await fetchImpl(url, { headers: authHeaders(env) });
+    if (!res.ok) {
+      throw new Error(`GitHub REST fallback GET ${url} failed: ${res.status} ${res.statusText}`);
+    }
+    const page = await res.json();
+    if (Array.isArray(page)) {
+      all.push(...page);
+    }
+    url = parseNextLink(res.headers.get("link"));
+  }
+  return all;
+}
+
+export async function restGraphqlJson(query, variables, env, { fetchImpl = fetch } = {}) {
+  const res = await fetchImpl(`${GITHUB_API_BASE}/graphql`, {
+    method: "POST",
+    headers: { ...authHeaders(env), "Content-Type": "application/json" },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!res.ok) {
+    throw new Error(`GitHub GraphQL fallback failed: ${res.status} ${res.statusText}`);
+  }
+  return res.json();
+}
+
+// Fetches the fields gate-evidence reads off `gh pr view --json headRefOid` /
+// `--json baseRefOid,labels` in one call (`gh pr view` itself always fetches the
+// full PR object; requesting a subset is a gh-side projection, not a smaller API
+// call), so one REST GET covers both call sites.
+export async function restFetchPrView(repo, pr, env, { fetchImpl = fetch } = {}) {
+  const data = await restGetJson(`repos/${repo}/pulls/${pr}`, env, { fetchImpl });
+  return {
+    headRefOid: typeof data?.head?.sha === "string" ? data.head.sha : null,
+    baseRefOid: typeof data?.base?.sha === "string" ? data.base.sha : null,
+    labels: Array.isArray(data?.labels)
+      ? data.labels.map((label) => (typeof label?.name === "string" ? label.name : label))
+      : [],
+  };
+}

--- a/scripts/github/capture-review-threads.mjs
+++ b/scripts/github/capture-review-threads.mjs
@@ -11,6 +11,7 @@ import {
 import { parseArgs } from "node:util";
 import { parsePrNumber, requireTokenValue, runChild as defaultRunChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
+import { isGhBinaryMissing, restGraphqlJson } from "./_gh-rest-fallback.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 export const REVIEW_THREADS_QUERY = [
   "query($owner: String!, $name: String!, $pr: Int!) {",
@@ -116,27 +117,39 @@ export function parseCaptureCliArgs(argv) {
   }
   return options;
 }
+// Falls back to a direct GraphQL POST (GH_TOKEN/GITHUB_TOKEN) ONLY when spawning
+// the `gh` binary itself fails (ENOENT — not on PATH), so a gh-less session can
+// still verify review-thread resolution state (#1358). Any other `gh` failure
+// (auth, rate limit) surfaces as a real error, unchanged.
 export async function fetchGithubReviewThreadsPayload(
   { repo, pr },
   { env = process.env, ghCommand = "gh", runChild = defaultRunChild } = {},
 ) {
   const { owner, name } = parseRepoSlug(repo);
-  const result = await runChild(
-    ghCommand,
-    [
-      "api",
-      "graphql",
-      "--field",
-      `owner=${owner}`,
-      "--field",
-      `name=${name}`,
-      "--field",
-      `pr=${pr}`,
-      "--field",
-      `query=${REVIEW_THREADS_QUERY}`,
-    ],
-    env,
-  );
+  let result;
+  try {
+    result = await runChild(
+      ghCommand,
+      [
+        "api",
+        "graphql",
+        "--field",
+        `owner=${owner}`,
+        "--field",
+        `name=${name}`,
+        "--field",
+        `pr=${pr}`,
+        "--field",
+        `query=${REVIEW_THREADS_QUERY}`,
+      ],
+      env,
+    );
+  } catch (error) {
+    if (isGhBinaryMissing(error)) {
+      return await restGraphqlJson(REVIEW_THREADS_QUERY, { owner, name, pr }, env);
+    }
+    throw error;
+  }
   if (result.code !== 0) {
     const detail = result.stderr.trim() || `exit code ${result.code}`;
     throw new Error(`gh command failed: ${detail}`);

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -148,6 +148,10 @@ export function parseDetectCheckpointEvidenceCliArgs(argv) {
       continue;
     }
     if (token.name === "skip-fanout-ledger-check") {
+      // node:util parseArgs has no `--no-` boolean negation (unlike commander/
+      // yargs): `--no-skip-fanout-ledger-check` is rejected as an unknown token
+      // below, never silently enabling the skip. So presence => enable, and the
+      // only way to keep full enforcement is to omit the flag (the default).
       options.skipFanoutLedgerCheck = true;
       continue;
     }

--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -13,6 +13,7 @@ import { access, readFile } from "node:fs/promises";
 import path from "node:path";
 import { parsePrNumber, requireTokenValue, runChild as defaultRunChild } from "../_cli-primitives.mjs";
 import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
+import { isGhBinaryMissing, restFetchPrView, restGetPaginatedJson } from "./_gh-rest-fallback.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { FANOUT_PROVENANCE_MIN_REVIEWERS, GATE_FULL_LABEL, loadDevLoopConfig, resolveGateAngleContract, resolveGateConfig, resolveLightMode, resolveRejectForeignAngles, resolveRequireFanoutEvidence, resolveRequireFanoutProvenance } from "@dev-loops/core/config";
 import { FANOUT_UNAVAILABLE_MESSAGE, checkFanoutAngleCoverage, provenanceConsistencyError } from "@dev-loops/core/loop/gate-fanin";
@@ -31,6 +32,18 @@ pre_approval_gate comment.
 Required:
   --repo <owner/name>   Repository slug (e.g. owner/repo)
   --pr <number>         Pull request number
+Optional:
+  --skip-fanout-ledger-check  Skip the fan-out findings-log ledger/provenance/
+                              angle-coverage layer of requireFanoutEvidence
+                              enforcement. That evidence lives in a gitignored,
+                              worktree-local tmp/ file only the machine that ran
+                              the review has on disk, so a stateless remote
+                              verifier (the gate-evidence CI check; a gh-less API
+                              session) can never see it. The comment-derived
+                              executionMode/inlineReason check (including the
+                              light-mode inline exception) still applies. Intended
+                              for server-side/CI callers only; client-side callers
+                              should omit this flag to keep full enforcement.
 Output (stdout, JSON; always includes preMergeGateCheck):
   {
     "ok": true,
@@ -102,6 +115,7 @@ export function parseDetectCheckpointEvidenceCliArgs(argv) {
       repo: { type: "string" },
       pr: { type: "string" },
       "require-before-merge": { type: "boolean" },
+      "skip-fanout-ledger-check": { type: "boolean" },
       ...JQ_OUTPUT_PARSE_OPTIONS,
     },
     allowPositionals: true,
@@ -112,6 +126,7 @@ export function parseDetectCheckpointEvidenceCliArgs(argv) {
     help: false,
     repo: undefined,
     pr: undefined,
+    skipFanoutLedgerCheck: false,
   };
   for (const token of tokens) {
     if (token.kind === "positional") {
@@ -132,6 +147,10 @@ export function parseDetectCheckpointEvidenceCliArgs(argv) {
       options.pr = parsePrNumber(requireTokenValue(token, parseError), parseError);
       continue;
     }
+    if (token.name === "skip-fanout-ledger-check") {
+      options.skipFanoutLedgerCheck = true;
+      continue;
+    }
     if (matchJqOutputToken(token, options, (t) => requireTokenValue(t, parseError))) continue;
     if (token.name === "require-before-merge") {
       throw parseError(`--require-before-merge has been removed: gate evidence enforcement is now always-on by default. Omit the flag.`);
@@ -148,8 +167,20 @@ export function parseDetectCheckpointEvidenceCliArgs(argv) {
   }
   return options;
 }
-async function runGhJson(args, { env, ghCommand, runChild = defaultRunChild }) {
-  const result = await runChild(ghCommand, args, env);
+// restFallback, when provided, is invoked ONLY when spawning the `gh` binary
+// itself fails (ENOENT — the binary is not on PATH); a `gh` invocation that runs
+// and fails for any other reason (auth, rate limit, a real 404) is a genuine
+// error and is never silently retried through the REST fallback (#1358).
+async function runGhJson(args, { env, ghCommand, runChild = defaultRunChild, restFallback = null }) {
+  let result;
+  try {
+    result = await runChild(ghCommand, args, env);
+  } catch (error) {
+    if (restFallback && isGhBinaryMissing(error)) {
+      return await restFallback();
+    }
+    throw error;
+  }
   if (result.code !== 0) {
     const detail = result.stderr.trim() || `exit code ${result.code}`;
     throw new Error(`gh command failed: ${detail}`);
@@ -238,7 +269,7 @@ function normalizeGateMarkerSummary(summary) {
     updatedAt: summary.updatedAt,
   };
 }
-export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null, staleRunnerCheck = null, fanoutEnforcement = null) {
+export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null, staleRunnerCheck = null, fanoutEnforcement = null, { skipFanoutLedgerCheck = false } = {}) {
   const failures = [];
   const warnings = [];
   if (!(evidence.draftGate.visible && evidence.draftGate.verdict === "clean")) {
@@ -279,6 +310,17 @@ export function buildPreMergeGateCheck(evidence, unresolvedThreadCount = null, s
         failures.push(
           `${gate.name}: requireFanoutEvidence is enabled but executionMode is "${gate.executionMode ?? "unset"}" (expected "fanout_fanin"); inline gate verdicts are not accepted`,
         );
+        continue;
+      }
+      // A stateless remote verifier (the gate-evidence CI check, or a gh-less API
+      // session) never has the gitignored, worktree-local tmp/gate-findings ledger
+      // on disk — only the machine that ran the review does. skipFanoutLedgerCheck
+      // scopes enforcement down to what IS remotely verifiable from the PR's public
+      // comment history: the comment-derived executionMode/inlineReason check above
+      // (including the light-mode inline exception). The deeper ledger/provenance/
+      // angle-coverage layer stays client-side-only (docs/gate-review-sub-loop-contract.md's
+      // existing "not un-forgeable" caveat covers that gap).
+      if (skipFanoutLedgerCheck) {
         continue;
       }
       if (!gate.ledgerExists) {
@@ -558,8 +600,14 @@ export async function detectCheckpointEvidence(options, { env = process.env, ghC
     error.staleRunner = staleRunnerDetection;
     throw error;
   }
-  const prPayload = await runGhJson(["pr", "view", String(options.pr), "--repo", options.repo, "--json", "headRefOid"], { env, ghCommand, runChild });
-  const commentsPayload = normalizeIssueCommentsPayload(await runGhJson(["api", "--paginate", "--slurp", `repos/${options.repo}/issues/${options.pr}/comments?per_page=100`], { env, ghCommand, runChild }));
+  const prPayload = await runGhJson(
+    ["pr", "view", String(options.pr), "--repo", options.repo, "--json", "headRefOid"],
+    { env, ghCommand, runChild, restFallback: () => restFetchPrView(options.repo, options.pr, env) },
+  );
+  const commentsPayload = normalizeIssueCommentsPayload(await runGhJson(
+    ["api", "--paginate", "--slurp", `repos/${options.repo}/issues/${options.pr}/comments?per_page=100`],
+    { env, ghCommand, runChild, restFallback: () => restGetPaginatedJson(`repos/${options.repo}/issues/${options.pr}/comments?per_page=100`, env) },
+  ));
   const currentHeadSha = typeof prPayload?.headRefOid === "string" && prPayload.headRefOid.trim().length > 0
     ? prPayload.headRefOid.trim()
     : null;
@@ -571,7 +619,10 @@ export async function detectCheckpointEvidence(options, { env = process.env, ghC
   // as a PR review rather than an issue comment (root cause 3 from issue #692).
   let prReviews = [];
   try {
-    const reviewsRaw = await runGhJson(["api", "--paginate", "--slurp", `repos/${options.repo}/pulls/${options.pr}/reviews?per_page=100`], { env, ghCommand, runChild });
+    const reviewsRaw = await runGhJson(
+      ["api", "--paginate", "--slurp", `repos/${options.repo}/pulls/${options.pr}/reviews?per_page=100`],
+      { env, ghCommand, runChild, restFallback: () => restGetPaginatedJson(`repos/${options.repo}/pulls/${options.pr}/reviews?per_page=100`, env) },
+    );
     prReviews = normalizePrReviewsPayload(reviewsRaw);
   } catch {
     // Graceful fallback: PR reviews fetch failure is non-fatal.
@@ -601,7 +652,10 @@ export async function detectCheckpointEvidence(options, { env = process.env, ghC
   );
   if (config != null && resolveRequireFanoutEvidence(config) && resolveLightMode(config) != null && anyInlineVerdict) {
     try {
-      const lightFacts = await runGhJson(["pr", "view", String(options.pr), "--repo", options.repo, "--json", "baseRefOid,labels"], { env, ghCommand, runChild });
+      const lightFacts = await runGhJson(
+        ["pr", "view", String(options.pr), "--repo", options.repo, "--json", "baseRefOid,labels"],
+        { env, ghCommand, runChild, restFallback: () => restFetchPrView(options.repo, options.pr, env) },
+      );
       baseRef = typeof lightFacts?.baseRefOid === "string" && lightFacts.baseRefOid.trim().length > 0
         ? lightFacts.baseRefOid.trim()
         : null;
@@ -676,7 +730,7 @@ async function main() {
         ? [`exit signal recorded for run ${result.staleRunner.activeRun?.runId}: refuse to merge`]
         : [],
     };
-    const preMergeGateCheck = buildPreMergeGateCheck(result, unresolvedThreadCount, staleRunnerCheck, result.fanoutEnforcement);
+    const preMergeGateCheck = buildPreMergeGateCheck(result, unresolvedThreadCount, staleRunnerCheck, result.fanoutEnforcement, { skipFanoutLedgerCheck: options.skipFanoutLedgerCheck === true });
     const output = { ...result, preMergeGateCheck, staleRunnerCheck };
     if (!preMergeGateCheck.ok) {
       process.stderr.write(`${JSON.stringify({

--- a/scripts/loop/detect-copilot-loop-state.mjs
+++ b/scripts/loop/detect-copilot-loop-state.mjs
@@ -22,10 +22,13 @@ import {
   summarizeLoopInterpretation,
 } from "@dev-loops/core/loop/copilot-loop-state";
 import {
-  normalizeStatusCheckRollupContract,
   summarizeHeadScopedCheckRunsSignal,
   normalizeHeadScopedCommitStatus,
   normalizeHeadScopedCiContract,
+  deriveLoopCiStatusFromRollup,
+  partitionEntriesByCheckName,
+  promoteExcludedCleanCiStatus,
+  LOOP_DERIVED_CI_CHECK_NAME,
 } from "@dev-loops/core/loop/copilot-ci-status";
 import { resolveRepoRoot } from "./_repo-root-resolver.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
@@ -226,24 +229,37 @@ async function fetchCurrentHeadCiEvidence({ repo, headSha, prVisibleCheckNames }
   ]);
   let checkRunsSignal = null;
   let checkRunsCount = null;
+  // Failing-ness of the excluded gate-evidence run (#1358), tracked separately
+  // from the pre-existing PR-visibility exclusion (#740) so only OUR
+  // exclusion can promote the merged status to crediblyGreen below.
+  let loopDerivedFailureDetails = [];
   if (checkRunsResult.code === 0) {
     try {
       const payload = JSON.parse(checkRunsResult.stdout);
       if (Array.isArray(payload?.check_runs)) {
+        const { matched: loopDerivedRuns, rest: nonLoopDerivedRuns } =
+          partitionEntriesByCheckName(payload.check_runs, LOOP_DERIVED_CI_CHECK_NAME);
+        loopDerivedFailureDetails = summarizeHeadScopedCheckRunsSignal({ check_runs: loopDerivedRuns }).status === "failure"
+          ? [LOOP_DERIVED_CI_CHECK_NAME]
+          : [];
         const visibleSet = prVisibleCheckNames?.length > 0 ? new Set(prVisibleCheckNames) : null;
         const visibleRuns = visibleSet
-          ? payload.check_runs.filter((run) => !run.name || visibleSet.has(run.name))
-          : payload.check_runs;
+          ? nonLoopDerivedRuns.filter((run) => !run.name || visibleSet.has(run.name))
+          : nonLoopDerivedRuns;
         // Use visible runs for the status signal, but preserve the full-set
         // unsupportedCompleted flag so hidden check-runs still contribute to
         // the cautious none override (#740).
         const visibleSignal = summarizeHeadScopedCheckRunsSignal({ check_runs: visibleRuns });
-        const fullSignal = summarizeHeadScopedCheckRunsSignal(payload);
+        const fullSignal = summarizeHeadScopedCheckRunsSignal({ check_runs: nonLoopDerivedRuns });
         const excludedRuns = visibleSet
-          ? payload.check_runs.filter((run) => run.name && !visibleSet.has(run.name))
+          ? nonLoopDerivedRuns.filter((run) => run.name && !visibleSet.has(run.name))
           : [];
         const excludedSignal = summarizeHeadScopedCheckRunsSignal({ check_runs: excludedRuns });
-        checkRunsSignal = { ...visibleSignal, unsupportedCompleted: fullSignal.unsupportedCompleted, excludedFailureDetails: excludedSignal.failureDetails ?? [] };
+        checkRunsSignal = {
+          ...visibleSignal,
+          unsupportedCompleted: fullSignal.unsupportedCompleted,
+          excludedFailureDetails: [...(excludedSignal.failureDetails ?? []), ...loopDerivedFailureDetails],
+        };
         checkRunsCount = payload.check_runs.length;
       }
     } catch {
@@ -268,12 +284,13 @@ async function fetchCurrentHeadCiEvidence({ repo, headSha, prVisibleCheckNames }
   if (checkRunsSignal === null && commitStatus === null) {
     return null;
   }
+  const mergedStatus = normalizeHeadScopedCiContract({
+    checkRunsStatus: checkRunsSignal?.status ?? "none",
+    commitStatus: commitStatus ?? "none",
+    checkRunsUnsupportedCompleted: checkRunsSignal?.unsupportedCompleted ?? false,
+  }).overallStatus;
   return {
-    status: normalizeHeadScopedCiContract({
-      checkRunsStatus: checkRunsSignal?.status ?? "none",
-      commitStatus: commitStatus ?? "none",
-      checkRunsUnsupportedCompleted: checkRunsSignal?.unsupportedCompleted ?? false,
-    }).overallStatus,
+    status: promoteExcludedCleanCiStatus(mergedStatus, loopDerivedFailureDetails),
     observedZeroSuitesAndStatuses: checkRunsCount === 0 && statusesCount === 0,
     failureDetails: checkRunsSignal?.failureDetails ?? [],
     excludedFailureDetails: checkRunsSignal?.excludedFailureDetails ?? [],
@@ -347,7 +364,11 @@ export async function autoDetectSnapshot({ repo, pr, reviewRequestStatusOverride
     ? prData.headRefOid.trim()
     : null;
   const reviewSummary = summarizeCopilotReviews(prData.reviews, { headSha: prHeadSha, draftGateResetAtMs });
-  const fallbackCiStatus = normalizeStatusCheckRollupContract(prData.statusCheckRollup).overallStatus;
+  // Exclude the loop's own gate-evidence check (#1358): its conclusion is derived
+  // from the loop's own progress, so it must never block the pre_approval step
+  // that would turn it green.
+  const fallbackDerivation = deriveLoopCiStatusFromRollup(prData.statusCheckRollup);
+  const fallbackCiStatus = fallbackDerivation.status;
   let copilotReviewRequestStatus;
   if (reviewRequestStatusOverride !== undefined) {
     copilotReviewRequestStatus = reviewRequestStatusOverride;
@@ -397,7 +418,7 @@ export async function autoDetectSnapshot({ repo, pr, reviewRequestStatusOverride
   const prVisibleCheckNames = extractPrVisibleCheckNames(prData.statusCheckRollup);
   let currentHeadCiStatus = fallbackCiStatus;
   let failureDetails = [];
-  let excludedFailureDetails = [];
+  let excludedFailureDetails = fallbackDerivation.excludedFailureDetails;
   if (shouldRefreshCurrentHeadCi) {
     const refreshed = await fetchCurrentHeadCiEvidence({ repo, headSha: prHeadSha, prVisibleCheckNames }, { env, ghCommand, runChild });
     currentHeadCiStatus = refreshed?.status ?? "none";

--- a/scripts/loop/detect-copilot-loop-state.mjs
+++ b/scripts/loop/detect-copilot-loop-state.mjs
@@ -27,7 +27,6 @@ import {
   normalizeHeadScopedCiContract,
   deriveLoopCiStatusFromRollup,
   partitionEntriesByCheckName,
-  promoteExcludedCleanCiStatus,
   LOOP_DERIVED_CI_CHECK_NAME,
 } from "@dev-loops/core/loop/copilot-ci-status";
 import { resolveRepoRoot } from "./_repo-root-resolver.mjs";
@@ -230,8 +229,10 @@ async function fetchCurrentHeadCiEvidence({ repo, headSha, prVisibleCheckNames }
   let checkRunsSignal = null;
   let checkRunsCount = null;
   // Failing-ness of the excluded gate-evidence run (#1358), tracked separately
-  // from the pre-existing PR-visibility exclusion (#740) so only OUR
-  // exclusion can promote the merged status to crediblyGreen below.
+  // from the pre-existing PR-visibility exclusion (#740) — excluding it never
+  // masks a real failure and (unlike #740) never needs a crediblyGreen relabel
+  // either, since every reason it can be red is independently tracked
+  // elsewhere in the loop snapshot (#1387).
   let loopDerivedFailureDetails = [];
   if (checkRunsResult.code === 0) {
     try {
@@ -290,7 +291,7 @@ async function fetchCurrentHeadCiEvidence({ repo, headSha, prVisibleCheckNames }
     checkRunsUnsupportedCompleted: checkRunsSignal?.unsupportedCompleted ?? false,
   }).overallStatus;
   return {
-    status: promoteExcludedCleanCiStatus(mergedStatus, loopDerivedFailureDetails),
+    status: mergedStatus,
     observedZeroSuitesAndStatuses: checkRunsCount === 0 && statusesCount === 0,
     failureDetails: checkRunsSignal?.failureDetails ?? [],
     excludedFailureDetails: checkRunsSignal?.excludedFailureDetails ?? [],

--- a/skills/docs/copilot-ci-status-contract.md
+++ b/skills/docs/copilot-ci-status-contract.md
@@ -12,13 +12,15 @@ Implementation surface:
 
 - `normalizeStatusCheckRollupContract(statusCheckRollup)` — normalizes the PR `statusCheckRollup` snapshot from `gh pr view`
 - `normalizeHeadScopedCiContract({ checkRunsStatus, commitStatus })` — normalizes current-head refresh inputs after explicit `check-runs` / commit-status probes
-- `deriveLoopCiStatusFromRollup(statusCheckRollup)` — same rollup input as above, but excludes the loop's own `LOOP_DERIVED_CI_CHECK_NAME` (`gate-evidence`) check before computing the status, returning `{ status, excludedFailureDetails }`. `status` is `"crediblyGreen"` (never masked as a plain `"success"`) when every OTHER check is green and `gate-evidence` was the only excluded failure; a genuinely failing check right beside it still yields `"failure"`.
+- `deriveLoopCiStatusFromRollup(statusCheckRollup)` — same rollup input as above, but excludes the loop's own `LOOP_DERIVED_CI_CHECK_NAME` (`gate-evidence`) check before computing the status, returning `{ status, excludedFailureDetails }`. `status` is a plain `"success"` (not an "unconfirmed" `crediblyGreen`) when every OTHER check is green and `gate-evidence` was the only excluded failure — every reason gate-evidence can be red is independently tracked elsewhere in the loop snapshot, so excluding it loses no signal; `excludedFailureDetails` still lists it for transparency. A genuinely failing check right beside it still yields `"failure"` (never masked).
 
 Both `normalizeStatusCheckRollupContract` and `normalizeHeadScopedCiContract` return the same machine-readable contract shape.
 
 ## Loop-derived check exclusion
 
-`gate-evidence` (`.github/workflows/gate-evidence.yml`) is a server-side check whose conclusion is DERIVED from the loop's own progress (a clean current-head `pre_approval_gate` verdict) — not an independent build/test signal. The dev-loop must never let it block the very step (posting `pre_approval_gate`) that would turn it green. `LOOP_DERIVED_CI_CHECK_NAME` is the single exported constant naming this check; `partitionEntriesByCheckName` and `promoteExcludedCleanCiStatus` are the shared primitives `deriveLoopCiStatusFromRollup` composes from, and the check-runs-shaped equivalent in `scripts/loop/detect-copilot-loop-state.mjs` reuses the same constant and promotion rule so the fallback (rollup) and refresh (check-runs) derivation paths never disagree.
+`gate-evidence` (`.github/workflows/gate-evidence.yml`) is a server-side check whose conclusion is DERIVED from the loop's own progress (a clean current-head `pre_approval_gate` verdict) — not an independent build/test signal. The dev-loop must never let it block the very step (posting `pre_approval_gate`) that would turn it green, and must not treat it as "unconfirmed" CI either: every reason it can be red (missing draft_gate/pre_approval evidence, unresolved threads, a stale runner) is independently tracked elsewhere in the loop snapshot. `LOOP_DERIVED_CI_CHECK_NAME` is the single exported constant naming this check; `partitionEntriesByCheckName` is the shared primitive `deriveLoopCiStatusFromRollup` composes from, and the check-runs-shaped equivalent in `scripts/loop/detect-copilot-loop-state.mjs` reuses the same constant and exclusion rule so the fallback (rollup) and refresh (check-runs) derivation paths never disagree.
+
+Note: `"crediblyGreen"` is a distinct, unrelated CI status reserved for the bounded zero-suite local-validation exception (`--local-validation-head-sha`, #740/#1338) — it is never produced by the gate-evidence exclusion above.
 
 ## Inputs
 

--- a/skills/docs/copilot-ci-status-contract.md
+++ b/skills/docs/copilot-ci-status-contract.md
@@ -12,8 +12,13 @@ Implementation surface:
 
 - `normalizeStatusCheckRollupContract(statusCheckRollup)` — normalizes the PR `statusCheckRollup` snapshot from `gh pr view`
 - `normalizeHeadScopedCiContract({ checkRunsStatus, commitStatus })` — normalizes current-head refresh inputs after explicit `check-runs` / commit-status probes
+- `deriveLoopCiStatusFromRollup(statusCheckRollup)` — same rollup input as above, but excludes the loop's own `LOOP_DERIVED_CI_CHECK_NAME` (`gate-evidence`) check before computing the status, returning `{ status, excludedFailureDetails }`. `status` is `"crediblyGreen"` (never masked as a plain `"success"`) when every OTHER check is green and `gate-evidence` was the only excluded failure; a genuinely failing check right beside it still yields `"failure"`.
 
-Both entry points return the same machine-readable contract shape.
+Both `normalizeStatusCheckRollupContract` and `normalizeHeadScopedCiContract` return the same machine-readable contract shape.
+
+## Loop-derived check exclusion
+
+`gate-evidence` (`.github/workflows/gate-evidence.yml`) is a server-side check whose conclusion is DERIVED from the loop's own progress (a clean current-head `pre_approval_gate` verdict) — not an independent build/test signal. The dev-loop must never let it block the very step (posting `pre_approval_gate`) that would turn it green. `LOOP_DERIVED_CI_CHECK_NAME` is the single exported constant naming this check; `partitionEntriesByCheckName` and `promoteExcludedCleanCiStatus` are the shared primitives `deriveLoopCiStatusFromRollup` composes from, and the check-runs-shaped equivalent in `scripts/loop/detect-copilot-loop-state.mjs` reuses the same constant and promotion rule so the fallback (rollup) and refresh (check-runs) derivation paths never disagree.
 
 ## Inputs
 

--- a/skills/docs/merge-preconditions.md
+++ b/skills/docs/merge-preconditions.md
@@ -52,6 +52,33 @@ Before merge, ALL of the following MUST hold:
 
 > Runner-coordination lock: the pre-merge evidence check fails closed on a stale/foreign runner claim for the PR. A completing run releases its claim best-effort at every terminal stop (including the human approval checkpoint), so a merge re-dispatch normally proceeds. If a lock held by a completed/dead run still blocks the merge, take it over explicitly with `node <resolved-skill-scripts>/loop/pr-runner-coordination.mjs takeover --repo <owner/name> --pr <number>`. Never take over a genuinely active (non-stale) run — that fail-closed block is intentional.
 
+### Items 3 and 4 apply to every path, not just the dev-loop tooling
+
+Items 3 and 4 (clean `draft_gate` / current-head `pre_approval_gate` verdicts) are
+enforced two ways, and both must be closed for the precondition to hold in
+practice:
+
+- **Client-side:** the PreToolUse Bash hook blocks an ungated `gh pr ready` /
+  `gh pr merge` invocation, and `detect-checkpoint-evidence.mjs` is what the
+  dev-loop tooling calls before merging.
+- **Server-side:** the `gate-evidence` required status check
+  (`.github/workflows/gate-evidence.yml`) re-runs the same verdict check on
+  GitHub's own token for every non-draft PR. This is what actually closes the
+  ready/merge bypass — a direct GitHub API call (MCP/REST, web UI, a raw `gh`
+  invocation outside the hook) skips the client-side path entirely but still
+  cannot merge without a green `gate-evidence` check once branch protection on
+  `main` requires it.
+
+The server-side check verifies the same visible, comment-derived verdict fields
+the client-side tooling does (including the light-mode inline exception,
+[Gate Review Sub-Loop Contract](../../docs/gate-review-sub-loop-contract.md#light-mode-inline-acceptance-under-threshold-micro-prs)),
+via `--skip-fanout-ledger-check`. It does **not** re-verify the deeper fan-out
+findings-log ledger/provenance layer (`gates.requireFanoutEvidence` /
+`requireFanoutProvenance`): that evidence lives in a gitignored, worktree-local
+`tmp/` file only the machine that ran the review has on disk, so a stateless CI
+runner can never see it. That layer remains client-side/self-reported-only — the
+same "not un-forgeable" caveat the sub-loop contract already documents.
+
 ### Evidence writes and `gh pr merge` MUST be separate tool calls (#1172)
 
 The PreToolUse Bash gate evaluates `gh pr merge` **before** the Bash tool call executes. A compound

--- a/skills/docs/merge-preconditions.md
+++ b/skills/docs/merge-preconditions.md
@@ -61,13 +61,15 @@ practice:
 - **Client-side:** the PreToolUse Bash hook blocks an ungated `gh pr ready` /
   `gh pr merge` invocation, and `detect-checkpoint-evidence.mjs` is what the
   dev-loop tooling calls before merging.
-- **Server-side:** the `gate-evidence` required status check
+- **Server-side:** the `gate-evidence` status check
   (`.github/workflows/gate-evidence.yml`) re-runs the same verdict check on
-  GitHub's own token for every non-draft PR. This is what actually closes the
-  ready/merge bypass — a direct GitHub API call (MCP/REST, web UI, a raw `gh`
-  invocation outside the hook) skips the client-side path entirely but still
-  cannot merge without a green `gate-evidence` check once branch protection on
-  `main` requires it.
+  GitHub's own token for every non-draft PR. This is what closes the ready/merge
+  bypass — a direct GitHub API call (MCP/REST, web UI, a raw `gh` invocation
+  outside the hook) skips the client-side path entirely but still cannot merge
+  without a green `gate-evidence` check **once branch protection on `main`
+  requires it**. Until an operator adds it to branch protection, the check runs
+  and reports on every non-draft PR but does **not** yet block merge — it is
+  reporting-only in that window.
 
 The server-side check verifies the same visible, comment-derived verdict fields
 the client-side tooling does (including the light-mode inline exception,

--- a/test/github/_gh-rest-fallback.test.mjs
+++ b/test/github/_gh-rest-fallback.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  isGhBinaryMissing,
+  restFetchPrView,
+  restGetJson,
+  restGetPaginatedJson,
+  restGraphqlJson,
+} from "../../scripts/github/_gh-rest-fallback.mjs";
+
+function jsonResponse(body, { ok = true, status = 200, headers = {} } = {}) {
+  return {
+    ok,
+    status,
+    statusText: ok ? "OK" : "Error",
+    headers: { get: (name) => headers[name.toLowerCase()] ?? null },
+    json: async () => body,
+  };
+}
+
+test("isGhBinaryMissing is true only for an ENOENT-coded error", () => {
+  assert.equal(isGhBinaryMissing(Object.assign(new Error("spawn gh ENOENT"), { code: "ENOENT" })), true);
+  assert.equal(isGhBinaryMissing(new Error("gh command failed: exit code 1")), false);
+  assert.equal(isGhBinaryMissing(null), false);
+  assert.equal(isGhBinaryMissing(undefined), false);
+});
+
+test("restGetJson requires a GH_TOKEN/GITHUB_TOKEN and calls the expected URL", async () => {
+  await assert.rejects(
+    () => restGetJson("repos/o/r/pulls/1", {}),
+    /gh binary not found and no GH_TOKEN\/GITHUB_TOKEN set/,
+  );
+
+  const calls = [];
+  const fetchImpl = async (url, options) => {
+    calls.push({ url, options });
+    return jsonResponse({ id: 1 });
+  };
+  const result = await restGetJson("repos/o/r/pulls/1", { GH_TOKEN: "tok" }, { fetchImpl });
+  assert.deepEqual(result, { id: 1 });
+  assert.equal(calls[0].url, "https://api.github.com/repos/o/r/pulls/1");
+  assert.equal(calls[0].options.headers.Authorization, "Bearer tok");
+});
+
+test("restGetJson throws on a non-ok response", async () => {
+  const fetchImpl = async () => jsonResponse({}, { ok: false, status: 404 });
+  await assert.rejects(
+    () => restGetJson("repos/o/r/pulls/1", { GITHUB_TOKEN: "tok" }, { fetchImpl }),
+    /failed: 404/,
+  );
+});
+
+test("restGetPaginatedJson follows Link: rel=\"next\" and flattens every page", async () => {
+  let call = 0;
+  const fetchImpl = async (url) => {
+    call += 1;
+    if (call === 1) {
+      assert.equal(url, "https://api.github.com/repos/o/r/issues/1/comments?per_page=100");
+      return jsonResponse([{ id: 1 }, { id: 2 }], { headers: { link: '<https://api.github.com/repos/o/r/issues/1/comments?page=2>; rel="next"' } });
+    }
+    assert.equal(url, "https://api.github.com/repos/o/r/issues/1/comments?page=2");
+    return jsonResponse([{ id: 3 }]);
+  };
+  const result = await restGetPaginatedJson("repos/o/r/issues/1/comments?per_page=100", { GH_TOKEN: "tok" }, { fetchImpl });
+  assert.deepEqual(result, [{ id: 1 }, { id: 2 }, { id: 3 }]);
+  assert.equal(call, 2);
+});
+
+test("restGraphqlJson posts the query/variables and returns the raw GraphQL response", async () => {
+  const calls = [];
+  const fetchImpl = async (url, options) => {
+    calls.push({ url, options });
+    return jsonResponse({ data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } });
+  };
+  const result = await restGraphqlJson("query { x }", { owner: "o", name: "r", pr: 1 }, { GH_TOKEN: "tok" }, { fetchImpl });
+  assert.equal(calls[0].url, "https://api.github.com/graphql");
+  assert.equal(calls[0].options.method, "POST");
+  assert.deepEqual(JSON.parse(calls[0].options.body), { query: "query { x }", variables: { owner: "o", name: "r", pr: 1 } });
+  assert.deepEqual(result.data.repository.pullRequest.reviewThreads.nodes, []);
+});
+
+test("restFetchPrView maps head/base sha and labels (string or object shape)", async () => {
+  const fetchImpl = async () => jsonResponse({
+    head: { sha: "abc1234" },
+    base: { sha: "def5678" },
+    labels: [{ name: "gate:full" }],
+  });
+  const result = await restFetchPrView("o/r", 17, { GH_TOKEN: "tok" }, { fetchImpl });
+  assert.deepEqual(result, { headRefOid: "abc1234", baseRefOid: "def5678", labels: ["gate:full"] });
+});
+
+test("restFetchPrView tolerates a missing head/base/labels shape", async () => {
+  const fetchImpl = async () => jsonResponse({});
+  const result = await restFetchPrView("o/r", 17, { GH_TOKEN: "tok" }, { fetchImpl });
+  assert.deepEqual(result, { headRefOid: null, baseRefOid: null, labels: [] });
+});

--- a/test/github/_gh-rest-fallback.test.mjs
+++ b/test/github/_gh-rest-fallback.test.mjs
@@ -79,6 +79,24 @@ test("restGraphqlJson posts the query/variables and returns the raw GraphQL resp
   assert.deepEqual(result.data.repository.pullRequest.reviewThreads.nodes, []);
 });
 
+test("restGraphqlJson fails closed on a 200 response carrying GraphQL errors (no false green)", async () => {
+  // GraphQL returns HTTP 200 even for query-level failures; returning it as-is would
+  // let a gh-less verifier read "0 unresolved threads" where the gh path fails closed.
+  const fetchImpl = async () => jsonResponse({ data: null, errors: [{ message: "Bad credentials" }] });
+  await assert.rejects(
+    () => restGraphqlJson("query { x }", {}, { GH_TOKEN: "tok" }, { fetchImpl }),
+    /returned errors: Bad credentials/,
+  );
+});
+
+test("restGraphqlJson fails closed on a 200 response with no data", async () => {
+  const fetchImpl = async () => jsonResponse({ data: null });
+  await assert.rejects(
+    () => restGraphqlJson("query { x }", {}, { GH_TOKEN: "tok" }, { fetchImpl }),
+    /returned no data/,
+  );
+});
+
 test("restFetchPrView maps head/base sha and labels (string or object shape)", async () => {
   const fetchImpl = async () => jsonResponse({
     head: { sha: "abc1234" },

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -16,7 +16,9 @@ import {
   parseDetectCheckpointEvidenceCliArgs,
   buildPreMergeGateCheck,
   buildFanoutEnforcement,
+  detectCheckpointEvidence,
 } from "../../scripts/github/detect-checkpoint-evidence.mjs";
+import { fetchGithubReviewThreadsPayload } from "../../scripts/github/capture-review-threads.mjs";
 import { claimRunnerOwnership } from "../../scripts/loop/_pr-runner-coordination.mjs";
 import { execFileSync } from "node:child_process";
 import { mkdir } from "node:fs/promises";
@@ -203,6 +205,138 @@ test("parseDetectCheckpointEvidenceCliArgs rejects malformed arguments determini
     () => parseDetectCheckpointEvidenceCliArgs(["--repo", "owner/repo", "--pr", "17", "--require-before-merge"]),
     /--require-before-merge has been removed/i,
   );
+});
+
+test("parseDetectCheckpointEvidenceCliArgs defaults skipFanoutLedgerCheck to false and honors --skip-fanout-ledger-check", () => {
+  const defaultOpts = parseDetectCheckpointEvidenceCliArgs(["--repo", "owner/repo", "--pr", "17"]);
+  assert.equal(defaultOpts.skipFanoutLedgerCheck, false);
+
+  const opts = parseDetectCheckpointEvidenceCliArgs(["--repo", "owner/repo", "--pr", "17", "--skip-fanout-ledger-check"]);
+  assert.equal(opts.skipFanoutLedgerCheck, true);
+});
+
+// --- gh-less REST/GraphQL fallback (issue #1358, AC4) ---
+// A session with no `gh` binary on PATH (spawn ENOENT) must still be able to read
+// gate evidence given a GH_TOKEN/GITHUB_TOKEN, via the REST/GraphQL fallback.
+
+function enoentRunChild(command) {
+  return async (cmd) => {
+    if (cmd === command) {
+      throw Object.assign(new Error(`spawn ${command} ENOENT`), { code: "ENOENT" });
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  };
+}
+
+test("detectCheckpointEvidence falls back to the REST API when the gh binary is missing (ENOENT) given a token", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-gh-less-"));
+  const originalFetch = globalThis.fetch;
+  try {
+    await writeFile(path.join(tempDir, ".devloops"), "version: 1\ngates:\n  requireFanoutEvidence: false\n", "utf8");
+    const fetchCalls = [];
+    globalThis.fetch = async (url) => {
+      fetchCalls.push(String(url));
+      if (String(url).includes("/pulls/17") && !String(url).includes("/reviews")) {
+        return { ok: true, status: 200, statusText: "OK", headers: { get: () => null }, json: async () => ({ head: { sha: "abc1234" } }) };
+      }
+      if (String(url).includes("/issues/17/comments")) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          headers: { get: () => null },
+          json: async () => ([
+            {
+              id: 42,
+              body: [
+                "Gate review: draft_gate",
+                "Reviewed head SHA: abc1234",
+                "Verdict: clean",
+                "Findings summary: no issues found",
+                "Next action: mark ready for review",
+              ].join("\n"),
+              updated_at: "2026-05-29T21:00:00Z",
+              html_url: "https://github.com/owner/repo/pull/17#issuecomment-42",
+            },
+            {
+              id: 43,
+              body: [
+                "Gate review: pre_approval_gate",
+                "Reviewed head SHA: abc1234",
+                "Verdict: clean",
+                "Findings summary: no issues found",
+                "Next action: await final human approval",
+              ].join("\n"),
+              updated_at: "2026-05-29T22:00:00Z",
+              html_url: "https://github.com/owner/repo/pull/17#issuecomment-43",
+            },
+          ]),
+        };
+      }
+      if (String(url).includes("/pulls/17/reviews")) {
+        return { ok: true, status: 200, statusText: "OK", headers: { get: () => null }, json: async () => [] };
+      }
+      throw new Error(`unexpected fetch call in test: ${url}`);
+    };
+
+    const result = await detectCheckpointEvidence(
+      { repo: "owner/repo", pr: 17 },
+      { env: { GH_TOKEN: "test-token" }, ghCommand: "gh", runChild: enoentRunChild("gh"), cwd: tempDir },
+    );
+
+    assert.equal(result.currentHeadSha, "abc1234");
+    assert.equal(result.draftGate.verdict, "clean");
+    assert.equal(result.preApprovalGate.verdict, "clean");
+    assert.ok(fetchCalls.some((u) => u.includes("/pulls/17")), JSON.stringify(fetchCalls));
+    assert.ok(fetchCalls.some((u) => u.includes("/issues/17/comments")), JSON.stringify(fetchCalls));
+  } finally {
+    globalThis.fetch = originalFetch;
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("fetchGithubReviewThreadsPayload falls back to the GraphQL REST endpoint when the gh binary is missing (ENOENT)", async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    const fetchCalls = [];
+    globalThis.fetch = async (url, options) => {
+      fetchCalls.push({ url, options });
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: { get: () => null },
+        json: async () => ({ data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } }),
+      };
+    };
+
+    const payload = await fetchGithubReviewThreadsPayload(
+      { repo: "owner/repo", pr: 17 },
+      { env: { GITHUB_TOKEN: "test-token" }, ghCommand: "gh", runChild: enoentRunChild("gh") },
+    );
+
+    assert.deepEqual(payload.data.repository.pullRequest.reviewThreads.nodes, []);
+    assert.equal(fetchCalls[0].url, "https://api.github.com/graphql");
+    assert.equal(JSON.parse(fetchCalls[0].options.body).variables.pr, 17);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("detectCheckpointEvidence surfaces a real gh error (not ENOENT) instead of silently falling back to REST", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-gh-real-error-"));
+  try {
+    const runChild = async () => ({ code: 1, stdout: "", stderr: "gh: authentication required" });
+    await assert.rejects(
+      () => detectCheckpointEvidence(
+        { repo: "owner/repo", pr: 17 },
+        { env: {}, ghCommand: "gh", runChild, cwd: tempDir },
+      ),
+      /gh command failed/,
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
 });
 
 test("detect-checkpoint-evidence summarizes the newest valid live gate comments and passes pre-merge check", async () => {
@@ -896,6 +1030,70 @@ test("buildPreMergeGateCheck passes when requireFanoutEvidence and executionMode
       { name: "pre_approval_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/b.json", ledgerExists: true },
     ],
   });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.failures, []);
+});
+
+// --- skipFanoutLedgerCheck: remote-verifier mode (issue #1358) ---
+// A stateless remote verifier (the gate-evidence CI check; a gh-less API session)
+// never has the gitignored, worktree-local tmp/gate-findings ledger on disk. This
+// mode skips ONLY the ledger/provenance/angle-coverage layer, keeping the
+// comment-derived executionMode/inlineReason check (and the light-mode inline
+// exception) enforced exactly as before.
+
+test("buildPreMergeGateCheck skipFanoutLedgerCheck: PASSES a fanout_fanin verdict with a missing ledger (ledger not remotely verifiable)", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    gates: [
+      { name: "pre_approval_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/gate-findings/o-r/pr-17/pre_approval_gate-abc1234.json", ledgerExists: false },
+    ],
+  }, { skipFanoutLedgerCheck: true });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.failures, []);
+});
+
+test("buildPreMergeGateCheck skipFanoutLedgerCheck: still FAILS an inline_single_agent verdict that is not light-accepted", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    gates: [
+      { name: "pre_approval_gate", executionMode: "inline_single_agent", ledgerPath: "tmp/x.json", ledgerExists: false },
+    ],
+  }, { skipFanoutLedgerCheck: true });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.failures.some((f) => f.includes("pre_approval_gate") && f.includes("inline_single_agent")),
+    JSON.stringify(result.failures),
+  );
+});
+
+test("buildPreMergeGateCheck skipFanoutLedgerCheck: still respects the light-mode inline exception without requiring a ledger", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    lightMode: true,
+    hasFullLabel: false,
+    gates: [
+      {
+        name: "pre_approval_gate",
+        executionMode: "inline_single_agent",
+        inlineReason: "docs-only micro change",
+        scopeUnderThreshold: true,
+        ledgerPath: "tmp/x.json",
+        ledgerExists: false,
+      },
+    ],
+  }, { skipFanoutLedgerCheck: true });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.failures, []);
+});
+
+test("buildPreMergeGateCheck skipFanoutLedgerCheck: also skips requireFanoutProvenance/angle-coverage failures", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    requireProvenance: true,
+    gates: [
+      { name: "pre_approval_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/b.json", ledgerExists: false, provenance: null, mandatoryAngles: ["scope"], anglePool: ["scope", "safety"] },
+    ],
+  }, { skipFanoutLedgerCheck: true });
   assert.equal(result.ok, true);
   assert.deepEqual(result.failures, []);
 });

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -215,6 +215,17 @@ test("parseDetectCheckpointEvidenceCliArgs defaults skipFanoutLedgerCheck to fal
   assert.equal(opts.skipFanoutLedgerCheck, true);
 });
 
+test("parseDetectCheckpointEvidenceCliArgs REJECTS --no-skip-fanout-ledger-check (no parseArgs negation; fail closed)", () => {
+  // node:util parseArgs does NOT implement `--no-<boolean>` negation (that is a
+  // commander/yargs feature). So the negation form must be rejected outright, not
+  // silently treated as enabling the skip — the only way to keep full enforcement
+  // is to omit the flag. This pins the fail-closed behavior on a security-gate flag.
+  assert.throws(
+    () => parseDetectCheckpointEvidenceCliArgs(["--repo", "owner/repo", "--pr", "17", "--no-skip-fanout-ledger-check"]),
+    /Unknown argument/,
+  );
+});
+
 // --- gh-less REST/GraphQL fallback (issue #1358, AC4) ---
 // A session with no `gh` binary on PATH (spawn ENOENT) must still be able to read
 // gate evidence given a GH_TOKEN/GITHUB_TOKEN, via the REST/GraphQL fallback.

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -1098,6 +1098,50 @@ test("buildPreMergeGateCheck skipFanoutLedgerCheck: also skips requireFanoutProv
   assert.deepEqual(result.failures, []);
 });
 
+// AC1/AC2 "unaffected by the skip flag": --skip-fanout-ledger-check drops ONLY the
+// ledger/provenance/angle-coverage layer. The remotely-verifiable preconditions —
+// a clean draft_gate and a clean CURRENT-head pre_approval_gate — must still fail
+// closed under the flag, so a future refactor that hoisted the skip short-circuit
+// above those checks (silently reopening the exact API-driven bypass #1358 closes)
+// would flip these assertions instead of leaving every skip test green on clean input.
+test("buildPreMergeGateCheck skipFanoutLedgerCheck: still FAILS when the draft_gate verdict is missing", () => {
+  const evidence = {
+    currentHeadSha: "abc1234",
+    draftGate: { visible: false },
+    preApprovalGateMarker: { visible: true, contractComplete: true, verdict: "clean", headSha: "abc1234" },
+  };
+  const result = buildPreMergeGateCheck(evidence, 0, null, {
+    required: true,
+    gates: [
+      { name: "pre_approval_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/b.json", ledgerExists: false },
+    ],
+  }, { skipFanoutLedgerCheck: true });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.failures.some((f) => f.includes("draft_gate")),
+    JSON.stringify(result.failures),
+  );
+});
+
+test("buildPreMergeGateCheck skipFanoutLedgerCheck: still FAILS when the pre_approval_gate is for a stale head", () => {
+  const evidence = {
+    currentHeadSha: "abc1234",
+    draftGate: { visible: true, verdict: "clean" },
+    preApprovalGateMarker: { visible: true, contractComplete: true, verdict: "clean", headSha: "stale999" },
+  };
+  const result = buildPreMergeGateCheck(evidence, 0, null, {
+    required: true,
+    gates: [
+      { name: "pre_approval_gate", executionMode: "fanout_fanin", ledgerPath: "tmp/b.json", ledgerExists: false },
+    ],
+  }, { skipFanoutLedgerCheck: true });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.failures.some((f) => f.includes("current-head pre_approval_gate")),
+    JSON.stringify(result.failures),
+  );
+});
+
 // --- Fan-out provenance enforcement (AC2, gates.requireFanoutProvenance) ---
 
 test("buildPreMergeGateCheck with requireProvenance ON passes when ledger records distinctReviewers >= floor", () => {

--- a/test/loop/detect-copilot-loop-state-auto-detect.test.mjs
+++ b/test/loop/detect-copilot-loop-state-auto-detect.test.mjs
@@ -603,9 +603,24 @@ test("detect-copilot-loop-state routes round-cap clean PRs to round_cap_clean_fa
         assertArgs: ["api", "graphql"],
         stdout: emptyThreads + "\n",
       },
-      // No check-runs/status refresh calls: fallbackCiStatus is "crediblyGreen"
-      // (not the literal "success" the refresh guard requires), so the current-head
-      // refresh never fires — gate-evidence alone must not trigger it either.
+      // fallbackCiStatus is now the literal "success" (#1387: gate-evidence-only
+      // red no longer promotes to crediblyGreen), so the current-head refresh
+      // DOES fire here (all reviews are off the current head) — mirror the same
+      // gate-evidence-red/rest-green shape at the check-runs layer.
+      {
+        assertArgs: ["api", "repos/owner/repo/commits/newsha/check-runs?per_page=100"],
+        stdout: JSON.stringify({
+          check_runs: [
+            { status: "COMPLETED", conclusion: "FAILURE", name: "gate-evidence" },
+            { status: "COMPLETED", conclusion: "SUCCESS", name: "test-scripts" },
+            { status: "COMPLETED", conclusion: "SUCCESS", name: "test-core" },
+          ],
+        }) + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/commits/newsha/status?per_page=100"],
+        stdout: '{"statuses":[]}\n',
+      },
     ]);
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
@@ -613,11 +628,13 @@ test("detect-copilot-loop-state routes round-cap clean PRs to round_cap_clean_fa
     assert.equal(result.code, 0, `stderr: ${result.stderr}`);
 
     const output = JSON.parse(result.stdout);
-    assert.equal(output.snapshot.ciStatus, "crediblyGreen");
+    assert.equal(output.snapshot.ciStatus, "success");
     assert.deepEqual(output.snapshot.excludedFailureDetails, ["gate-evidence"]);
     // This is the exact #1383 deadlock: at the round cap with clean threads, a
     // red gate-evidence check must fall through to the clean fallback (which can
-    // post pre_approval_gate) instead of hard-stopping at ROUND_CAP_REACHED.
+    // post pre_approval_gate) instead of hard-stopping at ROUND_CAP_REACHED. Its
+    // ciStatus is plain "success" (#1387), not an "unconfirmed" crediblyGreen,
+    // so it also clears the round-cap-clean-fallback CI-confirmation gate.
     assert.equal(output.state, "round_cap_clean_fallback");
     assert.equal(output.terminal, true);
   } finally {

--- a/test/loop/detect-copilot-loop-state-auto-detect.test.mjs
+++ b/test/loop/detect-copilot-loop-state-auto-detect.test.mjs
@@ -533,6 +533,98 @@ test("detect-copilot-loop-state keeps zero-suite current-head CI at none under r
 });
 
 
+test("detect-copilot-loop-state routes round-cap clean PRs to round_cap_clean_fallback when only the loop's own gate-evidence check is red (#1358 regression: the exact #1383 deadlock)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-round-cap-gate-evidence-"));
+
+  try {
+    const emptyThreads = JSON.stringify({
+      data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } },
+    });
+
+    const { env } = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: JSON.stringify({
+          isDraft: false,
+          state: "OPEN",
+          number: 17,
+          headRefOid: "newsha",
+          reviews: [
+            {
+              id: "r-1",
+              author: { login: "copilot-pull-request-reviewer[bot]" },
+              state: "COMMENTED",
+              submittedAt: "2026-06-02T08:00:00Z",
+              commit: { oid: "oldsha-1" },
+            },
+            {
+              id: "r-2",
+              author: { login: "copilot-pull-request-reviewer[bot]" },
+              state: "COMMENTED",
+              submittedAt: "2026-06-02T09:00:00Z",
+              commit: { oid: "oldsha-2" },
+            },
+            {
+              id: "r-3",
+              author: { login: "copilot-pull-request-reviewer[bot]" },
+              state: "COMMENTED",
+              submittedAt: "2026-06-02T10:00:00Z",
+              commit: { oid: "oldsha-3" },
+            },
+            {
+              id: "r-4",
+              author: { login: "copilot-pull-request-reviewer[bot]" },
+              state: "COMMENTED",
+              submittedAt: "2026-06-02T11:00:00Z",
+              commit: { oid: "oldsha-4" },
+            },
+            {
+              id: "r-5",
+              author: { login: "copilot-pull-request-reviewer[bot]" },
+              state: "COMMENTED",
+              submittedAt: "2026-06-02T12:00:00Z",
+              commit: { oid: "oldsha-5" },
+            },
+          ],
+          // Mirrors the live #1383 rollup exactly: gate-evidence is the only red
+          // check, every other check (including CI test suites) is green.
+          statusCheckRollup: [
+            { status: "COMPLETED", conclusion: "FAILURE", name: "gate-evidence" },
+            { status: "COMPLETED", conclusion: "SUCCESS", name: "test-scripts" },
+            { status: "COMPLETED", conclusion: "SUCCESS", name: "test-core" },
+          ],
+        }) + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql"],
+        stdout: emptyThreads + "\n",
+      },
+      // No check-runs/status refresh calls: fallbackCiStatus is "crediblyGreen"
+      // (not the literal "success" the refresh guard requires), so the current-head
+      // refresh never fires — gate-evidence alone must not trigger it either.
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 0, `stderr: ${result.stderr}`);
+
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.snapshot.ciStatus, "crediblyGreen");
+    assert.deepEqual(output.snapshot.excludedFailureDetails, ["gate-evidence"]);
+    // This is the exact #1383 deadlock: at the round cap with clean threads, a
+    // red gate-evidence check must fall through to the clean fallback (which can
+    // post pre_approval_gate) instead of hard-stopping at ROUND_CAP_REACHED.
+    assert.equal(output.state, "round_cap_clean_fallback");
+    assert.equal(output.terminal, true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("detect-copilot-loop-state routes round-cap clean PRs to round_cap_clean_fallback when new commits land after resolved comments", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-round-cap-rerequest-"));
 

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -585,7 +585,15 @@ test("detect-pr-gate-coordination-state routes a post-cap clean head to pre_appr
   }
 });
 
-test("detect-pr-gate-coordination-state re-requests Copilot when significant post-convergence changes land after cap convergence", async () => {
+// #1387: at the round cap, a significant post-convergence change must NOT
+// force an impossible rerequest_copilot_review (the round cap makes a fresh
+// Copilot cycle impossible — request-copilot-review.mjs suppresses it). It
+// must instead allow run_pre_approval_gate, which reviews the post-cap head
+// itself, matching detect-copilot-loop-state's own round_cap_clean_fallback
+// guidance. Copilot WAS formally requested in this fixture's timeline (a
+// prior round actually ran) so the separate #613 formal-request guard does
+// not also fire, isolating the #1387 routing behavior under test.
+test("detect-pr-gate-coordination-state allows pre_approval_gate (not an impossible rerequest) when significant post-convergence changes land after cap convergence (#1387)", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pr-gate-round-cap-significant-"));
 
   try {
@@ -625,8 +633,10 @@ test("detect-pr-gate-coordination-state re-requests Copilot when significant pos
       { assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/pulls/266/reviews?per_page=100"], stdout: '[]\n' },
       { assertArgs: ["api", "repos/owner/repo/compare/5555555555555555555555555555555555555555...def56789abcdef"], stdout: jsonLine({ files: [{ filename: "scripts/loop/resolve-active-board-item.mjs", changes: 670 }] }) },
       {
+        // Copilot WAS formally requested (a prior round actually ran) — the
+        // durable #613 signal must not also gate this scenario.
         assertArgContains: ["api", "--paginate", "--jq", 'event == "review_requested"'],
-        stdout: "\n",
+        stdout: "copilot-pull-request-reviewer[bot]\n",
       },
     ]);
 
@@ -635,11 +645,16 @@ test("detect-pr-gate-coordination-state re-requests Copilot when significant pos
     assert.equal(result.code, 0);
     assert.equal(result.stderr, "");
     const parsed = JSON.parse(result.stdout);
-    assert.equal(parsed.gateBoundary, "post_draft_external_review");
-    assert.equal(parsed.nextAction, "rerequest_copilot_review");
-    assert.ok(parsed.allowedNextActions.includes("rerequest_copilot_review"));
-    assert.ok(parsed.forbiddenActions.includes("run_pre_approval_gate"));
-    assert.match(parsed.reason, /significant post-convergence changes/i);
+    // No contract-complete pre_approval marker exists for the post-cap head yet,
+    // so the boundary normalizes to pre_approval_gate_needed (mirrors the #896
+    // sibling test above) — the key point is run_pre_approval_gate is permitted.
+    assert.equal(parsed.gateBoundary, "pre_approval_gate_needed");
+    assert.equal(parsed.nextAction, "run_pre_approval_gate");
+    assert.ok(parsed.allowedNextActions.includes("run_pre_approval_gate"));
+    assert.ok(!parsed.forbiddenActions.includes("run_pre_approval_gate"));
+    // The round cap forbids any further Copilot (re-)request — no dead-end.
+    assert.ok(!parsed.allowedNextActions.includes("rerequest_copilot_review"));
+    assert.ok(!parsed.allowedNextActions.includes("request_copilot_review"));
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #1358
Closes #1387

## Objective

Close the API-driven ready/merge gate bypass: every gate-evidence enforcement point lived on the client / `gh`-CLI path only, so a direct GitHub API call (MCP/REST, web UI, an un-hooked `gh`) reached ready-for-review or merge without ever touching draft-gate / pre-approval-gate verification.

## What changed

- **Server-side check** — new `.github/workflows/gate-evidence.yml` runs on every non-draft PR and re-verifies the remotely-verifiable merge preconditions from the PR's public GitHub state: a clean `draft_gate`, a clean current-head `pre_approval_gate`, the `executionMode` / light-mode-inline exception, and unresolved-thread state (GraphQL). This is the enforcement that cannot be skipped by choosing a different client. (Worktree-local state — the fan-out findings-log ledger **and** the runner-coordination/stale-runner file — is not present on a stateless CI checkout, so it is deliberately outside what the server check re-verifies; see `--skip-fanout-ledger-check` below.) The check is **reporting-only until an operator adds it to branch protection** on `main` (the post-merge step below).
- **`--skip-fanout-ledger-check` on `detect-checkpoint-evidence.mjs`** — the fan-out findings-log **ledger** (`tmp/gate-findings/…`) is gitignored and worktree-local; it never exists on a fresh stateless Actions checkout, so re-verifying it server-side is architecturally impossible without a new artifact-publishing mechanism (the "un-forgeable provenance bridge" the issue marks as a non-goal). The new CI check skips **only** that ledger/provenance/angle-coverage layer while enforcing everything remotely verifiable. Default (client-side) callers omit the flag and keep today's full enforcement unchanged.
- **Harness-agnostic evidence reads** — `detect-checkpoint-evidence.mjs` and `capture-review-threads.mjs` fall back to GitHub's REST/GraphQL API over `GH_TOKEN`/`GITHUB_TOKEN` **only** when spawning the `gh` binary fails with `ENOENT` (a real `gh` error is never masked). Scoped to the read/verify path the CI check and a gh-less session need; the comment-posting path (`upsert-checkpoint-verdict.mjs`) is unchanged.

## Implementation decision

Chosen the issue's own proposed fix (server-side required check + harness-agnostic reads) with one scope narrowing forced by architecture: the worktree-local ledger cannot be re-verified on a stateless runner, so the server check enforces the remotely-verifiable preconditions and explicitly does **not** re-check the ledger. Rejected inventing a provenance-publishing bridge (explicit non-goal, much larger blast radius).

## Validation

- New tests:
  - `test/github/_gh-rest-fallback.test.mjs` (9, incl. the GraphQL fail-closed guards + ENOENT-only / real-error-not-masked non-regression).
  - `detect-checkpoint-evidence.test.mjs` `skipFanoutLedgerCheck` cases (clean draft-gate required; stale pre-approval fails; fanout verdict passes with missing ledger; light-mode inline exception without ledger) + the `--no-skip-fanout-ledger-check` rejection pin.
  - `packages/core/test/copilot-ci-status.test.mjs` (6 — gate-evidence CI-exclusion, exact-name scope, and real-failure-not-masked).
  - `packages/core/test/pr-gate-coordination.test.mjs` + `test/loop/detect-pr-gate-coordination-state.test.mjs` (the #1387 at-cap routing fix + the two-detector agreement).
  - `test/loop/detect-copilot-loop-state-auto-detect.test.mjs` (the exact #1383 round-cap gate-evidence deadlock regression, now asserting `ciStatus: success`).
- `npm run verify` green (all 7 suites); `actionlint` clean on the new workflow.

## Loop self-deadlock fix (required for this feature to ship)

Adding a server-side `gate-evidence` check that is red until `pre_approval_gate` is posted created a self-referential deadlock in the dev-loop's own CI-status derivation: the loop reads its PR's rollup, sees the red `gate-evidence`, derives `ciStatus: "failure"`, and — with `preApproval.requireCi: true` — refuses to enter the pre_approval boundary. But entering pre_approval is exactly what turns `gate-evidence` green. Left unfixed this would deadlock **every** future PR.

Resolving this fully took three layers, all in this PR (all loop-CLIENT-side; the server-side `detect-checkpoint-evidence` merge check is unchanged and still fails closed on missing evidence):

1. **CI-status exclusion** (`packages/core/src/loop/copilot-ci-status.mjs`, a single shared seam wired into `copilot-loop-state.mjs` + `detect-copilot-loop-state.mjs`): the loop excludes **only** its own `gate-evidence` check (one named constant, exact-name match) from CI-status derivation. When `gate-evidence` is the *sole* red check the derived status is **`success`** (the checks the loop actually gates on are confirmed green); if *any* real check is also failing the status stays `failure` and the real check is surfaced in `failureDetails` — the exclusion never masks a real failure. The excluded check is recorded in `excludedFailureDetails` for transparency. (Every reason gate-evidence can be red — missing draft_gate, missing/stale pre_approval, unresolved threads, stale runner — is independently tracked in the loop snapshot, so excluding it from `ciStatus` loses no signal.)
2. **Coordination routing** (`packages/core/src/loop/pr-gate-coordination.mjs`, **Closes #1387**): at `ROUND_CAP_CLEAN_FALLBACK` with a post-convergence significant change, the coordination evaluator no longer forces an impossible `rerequest_copilot_review` (the round cap forbids it) — it allows `run_pre_approval_gate`, agreeing with `detect-copilot-loop-state`'s own `nextAction`. Below the cap, a significant change still reopens a Copilot cycle (unchanged). (One safe knock-on: at the cap with a review still in-flight on the current head, the state now resolves to `WAIT_FOR_COPILOT_REVIEW` rather than a forced re-request — waiting, never deadlocking; test-covered.)
3. **`success`, not `crediblyGreen`**: an earlier iteration promoted the excluded-clean case to `crediblyGreen`, but that label means "unconfirmed CI" downstream and blocks *first* pre_approval entry — re-deadlocking. `gate-evidence` is expected-red-by-design, not unconfirmed, so `success` is the honest and correct label.

Covered by unit tests (`copilot-ci-status.test.mjs`, `pr-gate-coordination.test.mjs`) + end-to-end tests pinning the exact #1383 round-cap scenario and the two-detector agreement (`detect-copilot-loop-state-auto-detect.test.mjs`, `detect-pr-gate-coordination-state.test.mjs`).

## Operator follow-up required (not satisfiable by this PR)

Requiring the `gate-evidence` check in branch protection needs repo-admin write access and must be applied to `main` **after** merge:

```
gh api repos/mfittko/dev-loops/branches/main/protection/required_status_checks \
  --method PATCH -f 'contexts[]=gate-evidence'
```

Until that lands, the check **runs and reports but does not yet block merge**. The DoD item "branch protection live on `main`" is therefore **not** ticked by this PR alone — it is completed by the operator step above.

## Non-goals

- An un-forgeable provenance bridge that would let a stateless runner re-verify the worktree-local fan-out ledger.
- Changing the comment-posting path or the client-side hook enforcement (both unchanged).
