### PR TITLE
feat(cli): route pre-flight-gate / ensure-worktree / issue edit+create as dev-loops subcommands

### DIFF
--- a/.claude/skills/docs/epic-tree-refinement-procedure.md
+++ b/.claude/skills/docs/epic-tree-refinement-procedure.md
@@ -46,6 +46,9 @@ and tree integrity in one deterministic pass.
 
 If the sub-issue tree does not yet exist, use [Issue Intake Procedure](./issue-intake-procedure.md) Phase 3b to decompose and attach it first.
 
+Every "Apply" step below writes back via `dev-loops issue edit` (the routed CLI subcommand); the
+raw `node scripts/github/edit-issue.mjs` wrapper remains only as a source-repo fallback.
+
 ---
 
 ## Phases
@@ -65,7 +68,7 @@ For the root issue:
 7. Confirm **non-goals** section — prevents scope creep into adjacent areas
 8. Write the updated body to a tmp file: `tmp/issues/<root>/refinement/root-body.md`
 9. Show the diff and obtain confirmation before mutating GitHub
-10. Apply: `node scripts/github/edit-issue.mjs --repo <repo> --issue <root> --body-file tmp/issues/<root>/refinement/root-body.md`
+10. Apply: `dev-loops issue edit --repo <repo> --issue <root> --body-file tmp/issues/<root>/refinement/root-body.md`
 
 <!-- rule: EPIC-REFINEMENT-SERIAL-PHASE-GATE -->
 **Gate:** Phase B MUST NOT start until Phase A is complete and the root body is updated on GitHub. The same serial-gate discipline applies at every phase boundary below: a level/phase MUST fully complete (siblings may run in parallel within it) before the next one starts.
@@ -92,7 +95,7 @@ parent's updated body, not each other's output.
    - **Non-goals** — what this child intentionally excludes
 6. Write refined body to `tmp/issues/<child>/refinement/child-body.md`
 7. Show the diff and obtain confirmation before mutating (unless running unattended with explicit authorization)
-8. Apply: `node scripts/github/edit-issue.mjs --repo <repo> --issue <child> --body-file tmp/issues/<child>/refinement/child-body.md`
+8. Apply: `dev-loops issue edit --repo <repo> --issue <child> --body-file tmp/issues/<child>/refinement/child-body.md`
 
 **Parallelism rule:** All siblings at the same level can be refined concurrently. No child needs
 another child's output; each child only reads the parent's contract and its own current body.
@@ -121,7 +124,7 @@ updated bodies, not sibling parents).
 4. Update the parent's phase scope table and AC/DoD as needed to reflect what children now explicitly own
 5. Write refined body to `tmp/issues/<parent>/refinement/parent-reconciled-body.md`
 6. Show the diff and obtain confirmation before mutating
-7. Apply: `node scripts/github/edit-issue.mjs --repo <repo> --issue <parent> --body-file tmp/issues/<parent>/refinement/parent-reconciled-body.md`
+7. Apply: `dev-loops issue edit --repo <repo> --issue <parent> --body-file tmp/issues/<parent>/refinement/parent-reconciled-body.md`
 
 **Serial gate between levels** ([EPIC-REFINEMENT-SERIAL-PHASE-GATE](#phase-a--root-refinement-serial)): all parents at depth N must complete reconciliation before ascending to depth N-1.
 
@@ -140,7 +143,7 @@ After all immediate children of the root have been reconciled:
 4. Update the root body with the final reconciled phase scope table and AC/DoD
 5. Write to `tmp/issues/<root>/refinement/root-final-body.md`
 6. Show the diff and obtain confirmation before mutating
-7. Apply: `node scripts/github/edit-issue.mjs --repo <repo> --issue <root> --body-file tmp/issues/<root>/refinement/root-final-body.md`
+7. Apply: `dev-loops issue edit --repo <repo> --issue <root> --body-file tmp/issues/<root>/refinement/root-final-body.md`
 8. Verify the sub-issue tree still reflects the correct execution order:
    ```sh
    node <resolved-skill-scripts>/github/manage-sub-issues.mjs verify \
@@ -156,7 +159,7 @@ After all immediate children of the root have been reconciled:
 
 <!-- rule: EPIC-REFINEMENT-SCOPE-BOUNDARY -->
 This procedure MUST stay refinement-only: no implementation, no PRs, no Copilot assignment.
-Apply changes directly with `node scripts/github/edit-issue.mjs` — never create new issues or PRs. Hierarchy MUST
+Apply changes directly with `dev-loops issue edit` (raw `node scripts/github/edit-issue.mjs` remains a source-repo fallback) — never create new issues or PRs. Hierarchy MUST
 stay in the GitHub sub-issues API, not prose parent/child links or a duplicated child-list
 checklist in parent bodies.
 
@@ -168,7 +171,7 @@ AC/DoD matrix, and an explicit scope boundary in the format
 <!-- rule: EPIC-REFINEMENT-CONFIRM-BEFORE-MUTATE -->
 `EPIC-REFINEMENT-CONFIRM-BEFORE-MUTATE`: The procedure MUST write the refined body to
 `tmp/issues/<number>/refinement/` first and MUST show the diff and get confirmation before
-each `node scripts/github/edit-issue.mjs` mutation, unless running unattended with explicit authorization.
+each `dev-loops issue edit` mutation, unless running unattended with explicit authorization.
 
 ---
 

--- a/.claude/skills/docs/issue-intake-procedure.md
+++ b/.claude/skills/docs/issue-intake-procedure.md
@@ -141,7 +141,7 @@ Preflight verdicts:
   - <!-- rule: INTAKE-TIMEOUT-SURFACE-BUDGET-EXHAUSTED --> `INTAKE-TIMEOUT-SURFACE-BUDGET-EXHAUSTED`: only surface timeout attention when the seam's durable watch budget is actually exhausted
   - for explicit inspect/status requests, report the still-waiting state and exit normally
 - carry that resolved repo slug through every later GitHub issue/PR command
-- before invoking `resolve-dev-loop-startup.mjs --issue <number>` for local implementation on this directly-targeted issue, claim ownership: `node scripts/github/edit-issue.mjs --repo <resolved-repo> --issue <number> --add-assignee @me` (skip if already assigned to the viewer). The resolver's single-contributor ownership gate fails closed on a foreign or unclaimed assignee — see [Public Dev Loop Contract](public-dev-loop-contract.md#single-contributor-ownership-gate-resolve-dev-loop-startup)
+- before invoking `resolve-dev-loop-startup.mjs --issue <number>` for local implementation on this directly-targeted issue, claim ownership: `dev-loops issue edit --repo <resolved-repo> --issue <number> --add-assignee @me` (skip if already assigned to the viewer; source-repo fallback: `node scripts/github/edit-issue.mjs ...`). The resolver's single-contributor ownership gate fails closed on a foreign or unclaimed assignee — see [Public Dev Loop Contract](public-dev-loop-contract.md#single-contributor-ownership-gate-resolve-dev-loop-startup)
 
 ### From a plan-doc path
 
@@ -226,9 +226,10 @@ When an existing sub-issue tree needs **scope alignment, AC/DoD contracts, and d
 
 Before updating the GitHub issue body, show the diff and get explicit confirmation. Then use:
 ```sh
-node scripts/github/edit-issue.mjs --repo <resolved-repo> --issue <number> --body-file <updated-body-file>
-node scripts/github/edit-issue.mjs --repo <resolved-repo> --issue <number> --add-assignee copilot-swe-agent
+dev-loops issue edit --repo <resolved-repo> --issue <number> --body-file <updated-body-file>
+dev-loops issue edit --repo <resolved-repo> --issue <number> --add-assignee copilot-swe-agent
 ```
+(source-repo fallback: `node scripts/github/edit-issue.mjs ...`)
 Verify assignment with:
 ```sh
 node scripts/github/view-issue.mjs --repo <resolved-repo> --issue <number> --json assignees

--- a/.claude/skills/local-implementation/SKILL.md
+++ b/.claude/skills/local-implementation/SKILL.md
@@ -72,14 +72,18 @@ When the local spec already lives in a tracker issue:
 For the `local_implementation` strategy, before any planning or implementation mutation, you MUST run the pre-flight gate:
 
 ```sh
-node scripts/loop/pre-flight-gate.mjs --expected-branch <working-branch> --check-subagents
+dev-loops loop pre-flight-gate --expected-branch <working-branch> --check-subagents
 ```
+
+(source-repo fallback: `node scripts/loop/pre-flight-gate.mjs --expected-branch <working-branch> --check-subagents`)
 
 Before creating or reusing a worktree for local implementation, use the canonical lifecycle entrypoint (`WORKTREE-CREATE-PROVISION`, see [Worktree usage guidance](../../docs/worktree-guidance.md#create-or-reuse--provision-ensure-worktreemjs)):
 
 ```sh
-node scripts/loop/ensure-worktree.mjs --repo-root <main> --issue <n>
+dev-loops loop ensure-worktree --repo-root <main> --issue <n>
 ```
+
+(source-repo fallback: `node scripts/loop/ensure-worktree.mjs --repo-root <main> --issue <n>`)
 
 This validates worktree isolation (current directory under `tmp/worktrees/`) and branch identity (current branch matches the working branch); `--check-subagents` only reports subagent availability and is advisory (fails-open, does not block the gate). If the gate fails, **stop and fix the violation** before proceeding — do not bypass it in normal workflow execution.
 

--- a/.claude/skills/loop-grill/SKILL.md
+++ b/.claude/skills/loop-grill/SKILL.md
@@ -128,8 +128,10 @@ Write the raw Q&A transcript ONLY to the gitignored, ephemeral, session-scoped a
 **Tracker-first write-back:** update the GitHub issue body using:
 
 ```
-node scripts/github/edit-issue.mjs --repo <owner/repo> --issue <n> --body-file <tmp-path>
+dev-loops issue edit --repo <owner/repo> --issue <n> --body-file <tmp-path>
 ```
+
+(source-repo fallback: `node scripts/github/edit-issue.mjs --repo <owner/repo> --issue <n> --body-file <tmp-path>`)
 
 The synthesized sections live in the issue body, not as a comment. Do not use `comment-issue.mjs` here — that creates a comment, not a body update.
 

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -98,11 +98,17 @@ const SUBCOMMAND_ROUTES = {
     "info":                  "scripts/loop/info.mjs",
     "issue-refinement":     "scripts/loop/detect-issue-refinement-artifact.mjs",
     "debt-remediate":       "scripts/loop/debt-remediate.mjs",
+    "pre-flight-gate":      "scripts/loop/pre-flight-gate.mjs",
+    "ensure-worktree":      "scripts/loop/ensure-worktree.mjs",
   },
   pr: {
     create:             "scripts/github/create-pr.mjs",
     "ready-for-review": "scripts/github/ready-for-review.mjs",
     "reconcile-draft":  "scripts/github/reconcile-draft-gate.mjs",
+  },
+  issue: {
+    edit:   "scripts/github/edit-issue.mjs",
+    create: "scripts/github/create-issue.mjs",
   },
   queue: QUEUE_ROUTES,
   project: PROJECT_ROUTES,
@@ -137,13 +143,14 @@ const HELP_CATEGORY_LABELS = {
   gate: "Gate verdicts, evidence, and review operations",
   loop: "Loop lifecycle",
   pr: "PR helpers",
+  issue: "Issue helpers",
   queue: "Queue board: run + management (add/list/reorder/move/sync-status/archive)",
   project: "Alias for queue (GitHub Projects queue helpers)",
   inspect: "Inspection (Pi extension only)",
   refine: "Epic tree refinement verification",
 };
 
-const TOP_LEVEL_HELP_CATEGORY_ORDER = ["gate", "loop", "pr", "queue", "project", "inspect", "refine"];
+const TOP_LEVEL_HELP_CATEGORY_ORDER = ["gate", "loop", "pr", "issue", "queue", "project", "inspect", "refine"];
 
 const SUBCOMMAND_DESCRIPTIONS = {
   gate: {
@@ -172,11 +179,17 @@ const SUBCOMMAND_DESCRIPTIONS = {
     "issue-refinement": "Detect issue refinement artifact",
     info: "Show read-only issue/PR state summary",
     "debt-remediate": "File debt remediation issues",
+    "pre-flight-gate": "Gate local implementation mutations before planning or editing",
+    "ensure-worktree": "Create/reuse and provision a loop-owned worktree",
   },
   pr: {
     create: "Create PR (always draft, self-assigned by default)",
     "ready-for-review": "Mark PR ready for review",
     "reconcile-draft": "Reconcile non-draft PR",
+  },
+  issue: {
+    edit: "Edit issue title/body/assignees/milestone",
+    create: "Create an issue",
   },
   queue: QUEUE_DESCRIPTIONS,
   project: PROJECT_DESCRIPTIONS,

--- a/skills/docs/epic-tree-refinement-procedure.md
+++ b/skills/docs/epic-tree-refinement-procedure.md
@@ -46,6 +46,9 @@ and tree integrity in one deterministic pass.
 
 If the sub-issue tree does not yet exist, use [Issue Intake Procedure](./issue-intake-procedure.md) Phase 3b to decompose and attach it first.
 
+Every "Apply" step below writes back via `dev-loops issue edit` (the routed CLI subcommand); the
+raw `node scripts/github/edit-issue.mjs` wrapper remains only as a source-repo fallback.
+
 ---
 
 ## Phases
@@ -65,7 +68,7 @@ For the root issue:
 7. Confirm **non-goals** section — prevents scope creep into adjacent areas
 8. Write the updated body to a tmp file: `tmp/issues/<root>/refinement/root-body.md`
 9. Show the diff and obtain confirmation before mutating GitHub
-10. Apply: `node scripts/github/edit-issue.mjs --repo <repo> --issue <root> --body-file tmp/issues/<root>/refinement/root-body.md`
+10. Apply: `dev-loops issue edit --repo <repo> --issue <root> --body-file tmp/issues/<root>/refinement/root-body.md`
 
 <!-- rule: EPIC-REFINEMENT-SERIAL-PHASE-GATE -->
 **Gate:** Phase B MUST NOT start until Phase A is complete and the root body is updated on GitHub. The same serial-gate discipline applies at every phase boundary below: a level/phase MUST fully complete (siblings may run in parallel within it) before the next one starts.
@@ -92,7 +95,7 @@ parent's updated body, not each other's output.
    - **Non-goals** — what this child intentionally excludes
 6. Write refined body to `tmp/issues/<child>/refinement/child-body.md`
 7. Show the diff and obtain confirmation before mutating (unless running unattended with explicit authorization)
-8. Apply: `node scripts/github/edit-issue.mjs --repo <repo> --issue <child> --body-file tmp/issues/<child>/refinement/child-body.md`
+8. Apply: `dev-loops issue edit --repo <repo> --issue <child> --body-file tmp/issues/<child>/refinement/child-body.md`
 
 **Parallelism rule:** All siblings at the same level can be refined concurrently. No child needs
 another child's output; each child only reads the parent's contract and its own current body.
@@ -121,7 +124,7 @@ updated bodies, not sibling parents).
 4. Update the parent's phase scope table and AC/DoD as needed to reflect what children now explicitly own
 5. Write refined body to `tmp/issues/<parent>/refinement/parent-reconciled-body.md`
 6. Show the diff and obtain confirmation before mutating
-7. Apply: `node scripts/github/edit-issue.mjs --repo <repo> --issue <parent> --body-file tmp/issues/<parent>/refinement/parent-reconciled-body.md`
+7. Apply: `dev-loops issue edit --repo <repo> --issue <parent> --body-file tmp/issues/<parent>/refinement/parent-reconciled-body.md`
 
 **Serial gate between levels** ([EPIC-REFINEMENT-SERIAL-PHASE-GATE](#phase-a--root-refinement-serial)): all parents at depth N must complete reconciliation before ascending to depth N-1.
 
@@ -140,7 +143,7 @@ After all immediate children of the root have been reconciled:
 4. Update the root body with the final reconciled phase scope table and AC/DoD
 5. Write to `tmp/issues/<root>/refinement/root-final-body.md`
 6. Show the diff and obtain confirmation before mutating
-7. Apply: `node scripts/github/edit-issue.mjs --repo <repo> --issue <root> --body-file tmp/issues/<root>/refinement/root-final-body.md`
+7. Apply: `dev-loops issue edit --repo <repo> --issue <root> --body-file tmp/issues/<root>/refinement/root-final-body.md`
 8. Verify the sub-issue tree still reflects the correct execution order:
    ```sh
    node <resolved-skill-scripts>/github/manage-sub-issues.mjs verify \
@@ -156,7 +159,7 @@ After all immediate children of the root have been reconciled:
 
 <!-- rule: EPIC-REFINEMENT-SCOPE-BOUNDARY -->
 This procedure MUST stay refinement-only: no implementation, no PRs, no Copilot assignment.
-Apply changes directly with `node scripts/github/edit-issue.mjs` — never create new issues or PRs. Hierarchy MUST
+Apply changes directly with `dev-loops issue edit` (raw `node scripts/github/edit-issue.mjs` remains a source-repo fallback) — never create new issues or PRs. Hierarchy MUST
 stay in the GitHub sub-issues API, not prose parent/child links or a duplicated child-list
 checklist in parent bodies.
 
@@ -168,7 +171,7 @@ AC/DoD matrix, and an explicit scope boundary in the format
 <!-- rule: EPIC-REFINEMENT-CONFIRM-BEFORE-MUTATE -->
 `EPIC-REFINEMENT-CONFIRM-BEFORE-MUTATE`: The procedure MUST write the refined body to
 `tmp/issues/<number>/refinement/` first and MUST show the diff and get confirmation before
-each `node scripts/github/edit-issue.mjs` mutation, unless running unattended with explicit authorization.
+each `dev-loops issue edit` mutation, unless running unattended with explicit authorization.
 
 ---
 

--- a/skills/docs/issue-intake-procedure.md
+++ b/skills/docs/issue-intake-procedure.md
@@ -141,7 +141,7 @@ Preflight verdicts:
   - <!-- rule: INTAKE-TIMEOUT-SURFACE-BUDGET-EXHAUSTED --> `INTAKE-TIMEOUT-SURFACE-BUDGET-EXHAUSTED`: only surface timeout attention when the seam's durable watch budget is actually exhausted
   - for explicit inspect/status requests, report the still-waiting state and exit normally
 - carry that resolved repo slug through every later GitHub issue/PR command
-- before invoking `resolve-dev-loop-startup.mjs --issue <number>` for local implementation on this directly-targeted issue, claim ownership: `node scripts/github/edit-issue.mjs --repo <resolved-repo> --issue <number> --add-assignee @me` (skip if already assigned to the viewer). The resolver's single-contributor ownership gate fails closed on a foreign or unclaimed assignee — see [Public Dev Loop Contract](public-dev-loop-contract.md#single-contributor-ownership-gate-resolve-dev-loop-startup)
+- before invoking `resolve-dev-loop-startup.mjs --issue <number>` for local implementation on this directly-targeted issue, claim ownership: `dev-loops issue edit --repo <resolved-repo> --issue <number> --add-assignee @me` (skip if already assigned to the viewer; source-repo fallback: `node scripts/github/edit-issue.mjs ...`). The resolver's single-contributor ownership gate fails closed on a foreign or unclaimed assignee — see [Public Dev Loop Contract](public-dev-loop-contract.md#single-contributor-ownership-gate-resolve-dev-loop-startup)
 
 ### From a plan-doc path
 
@@ -226,9 +226,10 @@ When an existing sub-issue tree needs **scope alignment, AC/DoD contracts, and d
 
 Before updating the GitHub issue body, show the diff and get explicit confirmation. Then use:
 ```sh
-node scripts/github/edit-issue.mjs --repo <resolved-repo> --issue <number> --body-file <updated-body-file>
-node scripts/github/edit-issue.mjs --repo <resolved-repo> --issue <number> --add-assignee copilot-swe-agent
+dev-loops issue edit --repo <resolved-repo> --issue <number> --body-file <updated-body-file>
+dev-loops issue edit --repo <resolved-repo> --issue <number> --add-assignee copilot-swe-agent
 ```
+(source-repo fallback: `node scripts/github/edit-issue.mjs ...`)
 Verify assignment with:
 ```sh
 node scripts/github/view-issue.mjs --repo <resolved-repo> --issue <number> --json assignees

--- a/skills/local-implementation/SKILL.md
+++ b/skills/local-implementation/SKILL.md
@@ -76,14 +76,18 @@ When the local spec already lives in a tracker issue:
 For the `local_implementation` strategy, before any planning or implementation mutation, you MUST run the pre-flight gate:
 
 ```sh
-node scripts/loop/pre-flight-gate.mjs --expected-branch <working-branch> --check-subagents
+dev-loops loop pre-flight-gate --expected-branch <working-branch> --check-subagents
 ```
+
+(source-repo fallback: `node scripts/loop/pre-flight-gate.mjs --expected-branch <working-branch> --check-subagents`)
 
 Before creating or reusing a worktree for local implementation, use the canonical lifecycle entrypoint (`WORKTREE-CREATE-PROVISION`, see [Worktree usage guidance](../../docs/worktree-guidance.md#create-or-reuse--provision-ensure-worktreemjs)):
 
 ```sh
-node scripts/loop/ensure-worktree.mjs --repo-root <main> --issue <n>
+dev-loops loop ensure-worktree --repo-root <main> --issue <n>
 ```
+
+(source-repo fallback: `node scripts/loop/ensure-worktree.mjs --repo-root <main> --issue <n>`)
 
 This validates worktree isolation (current directory under `tmp/worktrees/`) and branch identity (current branch matches the working branch); `--check-subagents` only reports subagent availability and is advisory (fails-open, does not block the gate). If the gate fails, **stop and fix the violation** before proceeding — do not bypass it in normal workflow execution.
 

--- a/skills/loop-grill/SKILL.md
+++ b/skills/loop-grill/SKILL.md
@@ -131,8 +131,10 @@ Write the raw Q&A transcript ONLY to the gitignored, ephemeral, session-scoped a
 **Tracker-first write-back:** update the GitHub issue body using:
 
 ```
-node scripts/github/edit-issue.mjs --repo <owner/repo> --issue <n> --body-file <tmp-path>
+dev-loops issue edit --repo <owner/repo> --issue <n> --body-file <tmp-path>
 ```
+
+(source-repo fallback: `node scripts/github/edit-issue.mjs --repo <owner/repo> --issue <n> --body-file <tmp-path>`)
 
 The synthesized sections live in the issue body, not as a comment. Do not use `comment-issue.mjs` here — that creates a comment, not a body update.
 

--- a/test/contracts/issue-intake-doc-contracts.test.mjs
+++ b/test/contracts/issue-intake-doc-contracts.test.mjs
@@ -234,8 +234,8 @@ test("issue-intake flow carries the resolved repo slug through later GitHub issu
 
   assert.match(skillContent, /Carry that resolved repo slug through every later GitHub issue\/PR command/i);
   assert.match(skillContent, /gh issue create --repo <resolved-repo> --assignee @me/);
-  assert.match(skillContent, /node scripts\/github\/edit-issue\.mjs --repo <resolved-repo> --issue <number> --body-file <updated-body-file>/);
-  assert.match(skillContent, /node scripts\/github\/edit-issue\.mjs --repo <resolved-repo> --issue <number> --add-assignee copilot-swe-agent/);
+  assert.match(skillContent, /dev-loops issue edit --repo <resolved-repo> --issue <number> --body-file <updated-body-file>/);
+  assert.match(skillContent, /dev-loops issue edit --repo <resolved-repo> --issue <number> --add-assignee copilot-swe-agent/);
   assert.match(skillContent, /gh pr edit <pr-number> --repo <resolved-repo> --title/);
   assert.match(skillContent, /gh pr ready <pr-number> --repo <resolved-repo>/);
   assert.match(skillContent, /gh pr review <pr-number> --repo <resolved-repo> --approve/);

--- a/test/contracts/issue-intake-doc-contracts.test.mjs
+++ b/test/contracts/issue-intake-doc-contracts.test.mjs
@@ -235,6 +235,7 @@ test("issue-intake flow carries the resolved repo slug through later GitHub issu
   assert.match(skillContent, /Carry that resolved repo slug through every later GitHub issue\/PR command/i);
   assert.match(skillContent, /gh issue create --repo <resolved-repo> --assignee @me/);
   assert.match(skillContent, /dev-loops issue edit --repo <resolved-repo> --issue <number> --body-file <updated-body-file>/);
+  assert.match(skillContent, /dev-loops issue edit --repo <resolved-repo> --issue <number> --add-assignee @me/);
   assert.match(skillContent, /dev-loops issue edit --repo <resolved-repo> --issue <number> --add-assignee copilot-swe-agent/);
   assert.match(skillContent, /gh pr edit <pr-number> --repo <resolved-repo> --title/);
   assert.match(skillContent, /gh pr ready <pr-number> --repo <resolved-repo>/);

--- a/test/contracts/issue-intake-doc-contracts.test.mjs
+++ b/test/contracts/issue-intake-doc-contracts.test.mjs
@@ -244,6 +244,24 @@ test("issue-intake flow carries the resolved repo slug through later GitHub issu
   assert.match(skillContent, /gh pr merge <pr-number> --repo <resolved-repo> --squash --delete-branch/);
 });
 
+test("residual raw-script refs are migrated to dev-loops subcommands (subcommand named first, raw kept only as fallback)", async () => {
+  // Every consumer-facing doc that used to instruct a raw `node scripts/*.mjs`
+  // call as the ONLY path must now name the routed `dev-loops <sub>` first. This
+  // pins the migration so a future revert to raw-only ships red (the generator
+  // --check only guarantees .claude mirror parity, not the source wording).
+  const [localImpl, grill, epic] = await Promise.all([
+    readRepo("skills/local-implementation/SKILL.md"),
+    readRepo("skills/loop-grill/SKILL.md"),
+    readRepo("skills/docs/epic-tree-refinement-procedure.md"),
+  ]);
+  // pre-flight-gate + ensure-worktree routed under the `loop` category.
+  assert.match(localImpl, /dev-loops loop pre-flight-gate /);
+  assert.match(localImpl, /dev-loops loop ensure-worktree /);
+  // edit-issue routed under the new `issue` category.
+  assert.match(grill, /dev-loops issue edit /);
+  assert.match(epic, /dev-loops issue edit /);
+});
+
 test("issue-intake docs define closed-match handling and keep the handoff helper on the resolved repo", async () => {
   const skillContent = await readIssueIntakeSurface();
 

--- a/test/packaged-install-smoke.test.mjs
+++ b/test/packaged-install-smoke.test.mjs
@@ -105,8 +105,13 @@ test("packaged install: every @dev-loops/core export resolves and the queue CLIs
       ["issue", "edit", "--help"],
       ["issue", "create", "--help"],
     ]) {
+      // execFileSync throws on a non-zero exit, so reaching here already means
+      // the command succeeded; additionally assert it printed real help (a
+      // command exiting 0 with empty/wrong output would otherwise slip past the
+      // ERR_MODULE_NOT_FOUND-only check).
       const output = execFileSync("node", [devLoopsBin, ...args], { cwd: installDir }).toString();
       assert.doesNotMatch(output, /ERR_MODULE_NOT_FOUND/, `dev-loops ${args.join(" ")} failed to resolve @dev-loops/core`);
+      assert.match(output, /Usage/i, `dev-loops ${args.join(" ")} printed no Usage/help output`);
     }
   } finally {
     rmSync(tmpRoot, { recursive: true, force: true });

--- a/test/packaged-install-smoke.test.mjs
+++ b/test/packaged-install-smoke.test.mjs
@@ -103,6 +103,7 @@ test("packaged install: every @dev-loops/core export resolves and the queue CLIs
       ["loop", "pre-flight-gate", "--help"],
       ["loop", "ensure-worktree", "--help"],
       ["issue", "edit", "--help"],
+      ["issue", "create", "--help"],
     ]) {
       const output = execFileSync("node", [devLoopsBin, ...args], { cwd: installDir }).toString();
       assert.doesNotMatch(output, /ERR_MODULE_NOT_FOUND/, `dev-loops ${args.join(" ")} failed to resolve @dev-loops/core`);

--- a/test/packaged-install-smoke.test.mjs
+++ b/test/packaged-install-smoke.test.mjs
@@ -93,6 +93,20 @@ test("packaged install: every @dev-loops/core export resolves and the queue CLIs
       const helpOutput = execFileSync("node", [cliPath, "--help"], { cwd: installDir }).toString();
       assert.match(helpOutput, /^Usage: dev-loops/);
     }
+
+    // 5. Run the newly-routed `dev-loops` CLI subcommands (issue #1369) from
+    // the installed tree — the same deps-less consumer context that broke
+    // on raw `node scripts/*.mjs` — and assert exit 0 + `@dev-loops/core`
+    // resolves (no ERR_MODULE_NOT_FOUND).
+    const devLoopsBin = path.join(installDir, "node_modules/dev-loops/cli/index.mjs");
+    for (const args of [
+      ["loop", "pre-flight-gate", "--help"],
+      ["loop", "ensure-worktree", "--help"],
+      ["issue", "edit", "--help"],
+    ]) {
+      const output = execFileSync("node", [devLoopsBin, ...args], { cwd: installDir }).toString();
+      assert.doesNotMatch(output, /ERR_MODULE_NOT_FOUND/, `dev-loops ${args.join(" ")} failed to resolve @dev-loops/core`);
+    }
   } finally {
     rmSync(tmpRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #1369

## Objective

Close the consumer-facing raw-`node scripts/*.mjs` gaps: route the operations that had no `dev-loops` CLI subcommand (so consumers hit `@dev-loops/core` unresolved errors), and migrate the residual raw-only skill/doc references to the routed subcommands.

## What changed

- **`cli/index.mjs` routing (no behavior change to the underlying scripts):**
  - `loop pre-flight-gate` → `scripts/loop/pre-flight-gate.mjs`, `loop ensure-worktree` → `scripts/loop/ensure-worktree.mjs` (added to the existing `loop` category — they're loop-lifecycle operations).
  - New top-level `issue` category: `issue edit` → `scripts/github/edit-issue.mjs`, `issue create` → `scripts/github/create-issue.mjs`.
  - Help ordering: `issue` placed right after `pr` (both GitHub-object helpers), ahead of the queue/board group.
- **Skill/doc migration:** the residual raw-only references now name the `dev-loops <subcommand>` first, keeping the raw `node scripts/*.mjs` line only as an explicit source-repo fallback — in `skills/local-implementation/SKILL.md` (pre-flight-gate, ensure-worktree), `skills/loop-grill/SKILL.md` + `skills/docs/{epic-tree-refinement-procedure,issue-intake-procedure}.md` (edit-issue), and their regenerated `.claude/skills/**` mirrors (via the generator, not hand-edited).
- **Consumer entry contract:** documented once already — #1379's `README.md` paragraph links the #1376 cli-contract tracking issue; verified it doesn't conflict and left it untouched (per the non-goal).

## Validation

- `npm run verify` green (all legs): `test:core` 2070, `test:assets` 203, `test:extension` 84, `test:dev-loop` 32, `test:pack` 1, `test:scripts` 2864 (36 network-skipped). `generate-claude-assets --check` green (70).
- `test/packaged-install-smoke.test.mjs` (consumer-shaped, no workspace symlink) extended to run all four new subcommands — `loop pre-flight-gate --help`, `loop ensure-worktree --help`, `issue edit --help`, `issue create --help` — from the installed tree and assert exit 0 + a `/Usage/` help match + no `ERR_MODULE_NOT_FOUND` (`@dev-loops/core` resolves).
- `test/contracts/issue-intake-doc-contracts.test.mjs` updated to reflect the migrated refs.

## Operational note (not fixed here)

A `test/github/reconcile-draft-gate.test.mjs` flake was traced to a stale gitignored cross-worktree fixture: worktrees share one `.git` common dir, so `git rev-parse --git-common-dir` resolves runner-coordination state to the main checkout, and a concurrent test run in another worktree can leave a stale `test-run-123` claim there. Pre-existing (fails identically on unmodified HEAD); the stale scratch file was removed to unblock. Worth a separate test-isolation follow-up.

## Non-goals

- Re-migrating refs already covered by #1340/#1374 (only the residuals with no existing subcommand).
- Authoring/owning the single-source cli-contract doc (#1376).
- Making the marketplace *checkout* run raw `node scripts/*.mjs` (no post-install / vendored node_modules) — the runtime is the npm CLI.
- Re-publishing `@dev-loops/core`.
