### PR TITLE
docs: underline self-healing + self-improving across articles + decks (#1398)

### DIFF
--- a/docs/articles/dev-loops-deep-dive.html
+++ b/docs/articles/dev-loops-deep-dive.html
@@ -425,6 +425,56 @@
 
   <p>A state graph guarantees the behavior a prompt can only request. When the next step has to be knowable at any moment, the coordination layer itself should rest on something checkable.</p>
 
+  <h2 id="the-loop-heals-itself">The loop heals itself</h2>
+
+  <p>dev-loops treats a failure as a state to recover from. A failed CI check or a fail-closed tool response — a gate or wrapper that stops and surfaces the error — is detected and recorded on the pull request. The loop re-derives the next action from authoritative state and takes exactly one of three recovery moves: retry the check, run the review-fix-re-review loop until the change converges (bounded by a round cap, <code>refinement.maxCopilotRounds</code>), or stop and ask a human. Run progress is preserved as the recovery point, so the work resumes where it left off. Failing closed keeps the failure visible and red, so the loop recovers from the true state.</p>
+
+  <figure>
+    <div class="diagram-scroll">
+      <div class="flow" role="img" aria-label="Self-healing recovery: a run in progress hits a failed check or fail-closed stop, which is detected and recorded, then the loop re-derives the next action and takes one of three recovery moves — retry the check, review-fix-re-review until it converges, or stop and ask a human — before resuming at the preserved progress and returning to the run.">
+        <div class="node start">Run&nbsp;in&nbsp;progress</div>
+        <div class="edge"><span class="arrow">&rarr;</span><span class="edge-label">check fails / fails closed</span></div>
+        <div class="node">Detected&nbsp;&amp;&nbsp;recorded</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node accent">Re-derive&nbsp;the&nbsp;next&nbsp;action</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="flow-col">
+          <div class="node">Retry&nbsp;the&nbsp;check</div>
+          <div class="node">Review&nbsp;&rarr;&nbsp;fix&nbsp;&rarr;&nbsp;re-review&nbsp;(round-capped)</div>
+          <div class="node">Stop&nbsp;&amp;&nbsp;ask&nbsp;a&nbsp;human</div>
+        </div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node accent">Resume&nbsp;at&nbsp;preserved&nbsp;progress</div>
+      </div>
+    </div>
+    <figcaption><b>Diagram 5 — Self-healing recovery.</b> A failed check or fail-closed stop is detected and recorded, then the loop re-derives the next action and takes one of three recovery moves before resuming at the preserved progress.</figcaption>
+  </figure>
+
+  <h2 id="the-loop-improves-itself">The loop improves itself</h2>
+
+  <p>The same machinery that ships a change also sharpens the next one. Grilling refines a raw issue into a locked spec before any code is written. The fan-out review angles (Diagram 3), extendable per repository, and the review-fix rounds tighten the change while it is in flight. After merge, a retrospective records advisory findings on the change; where they warrant it, the conductor opens follow-ups as new tracked issues, carrying improvement from one change into the next.</p>
+
+  <figure>
+    <div class="diagram-scroll">
+      <div class="flow" role="img" aria-label="Self-improving loop: grilling refines an issue into a locked spec, which is implemented, reviewed by fan-out angles, converged through review-fix rounds, and merged; a post-merge retrospective records advisory findings that the conductor can open as follow-up issues, feeding back into grilling the next issue.">
+        <div class="node start">Grill&nbsp;&amp;&nbsp;refine&nbsp;into&nbsp;a&nbsp;locked&nbsp;spec</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node">Implement</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node">Fan-out&nbsp;review&nbsp;angles</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node">Review/fix&nbsp;rounds&nbsp;converge</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node">Merge</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node accent">Retrospective&nbsp;(advisory)</div>
+        <div class="edge"><span class="arrow">&rarr;</span><span class="edge-label">conductor opens, then back to grilling</span></div>
+        <div class="node">Follow-ups&nbsp;(new&nbsp;tracked&nbsp;issues)</div>
+      </div>
+    </div>
+    <figcaption><b>Diagram 6 — Self-improving feedback loop.</b> Grilling locks a spec before code, the fan-out and review-fix rounds tighten the change in flight, and a post-merge retrospective records advisory findings the conductor can open as follow-ups that feed the next cycle.</figcaption>
+  </figure>
+
   <div class="part">
     <p class="kicker">Part 2</p>
     <h2>Make the waiting visible</h2>
@@ -456,7 +506,7 @@
         <div class="node">Recover</div>
       </div>
     </div>
-    <figcaption><b>Diagram 5 — The interrupt-cost chain.</b> A five-minute question triggers five transitions, and the answer itself is only one of them.</figcaption>
+    <figcaption><b>Diagram 7 — The interrupt-cost chain.</b> A five-minute question triggers five transitions, and the answer itself is only one of them.</figcaption>
   </figure>
 
   <p>The five minutes of answering is the small box in the middle. The notice, switch, rebuild, and recover are the tax, and both sides of the exchange pay it. Across a queue of work, these costs multiply. Each handoff is an interrupt for whoever receives it, so a backlog of pending handoffs is a backlog of context switches waiting to happen.</p>
@@ -481,7 +531,7 @@
         <div class="node start">Receiver&nbsp;asks</div>
       </div>
     </div>
-    <figcaption><b>Diagram 6 — One handoff round trip.</b> Every question the state can't answer becomes an ask → answer → confirm cycle, and the work waits until it closes — then the next ambiguity restarts it.</figcaption>
+    <figcaption><b>Diagram 8 — One handoff round trip.</b> Every question the state can't answer becomes an ask → answer → confirm cycle, and the work waits until it closes — then the next ambiguity restarts it.</figcaption>
   </figure>
 
   <p>A mix of humans and AI agents makes it worse. Ambiguous ownership pauses a human until they ask. Missing context halts an agent, which either guesses and leaves you the cleanup or stops cold. Every human-to-agent and agent-to-human swap is one more place the state can drop on the floor. &quot;More hands make it faster&quot; holds only when the state survives each handoff intact, and any boundary it can fall through quietly cancels the gain you were counting on.</p>
@@ -529,7 +579,7 @@
         <div class="node start">Capture&nbsp;state</div>
       </div>
     </div>
-    <figcaption><b>Diagram 7 — The measurement loop.</b> Capture, measure, change, verify — then back to capture. It repeats as a cycle, because the slowest transition moves as you fix things.</figcaption>
+    <figcaption><b>Diagram 9 — The measurement loop.</b> Capture, measure, change, verify — then back to capture. It repeats as a cycle, because the slowest transition moves as you fix things.</figcaption>
   </figure>
 
   <p>This is ordinary improvement discipline, applied to the part of delivery that has stayed invisible. Shortening a wait depends on measuring it, and measuring it depends on capturing its state.</p>
@@ -578,7 +628,7 @@
         <path d="M320,282 L320,314" stroke="rgba(167,139,250,0.7)" fill="none" marker-end="url(#ah2)"/>
       </svg>
     </div>
-    <figcaption><b>Diagram 8 — Grounding &quot;observable state&quot; in real mechanisms.</b> The board carries owner and next step, the gate trail carries the latest decision, the resolver answers whose move it is, and safe automation runs on that confirmed state.</figcaption>
+    <figcaption><b>Diagram 10 — Grounding &quot;observable state&quot; in real mechanisms.</b> The board carries owner and next step, the gate trail carries the latest decision, the resolver answers whose move it is, and safe automation runs on that confirmed state.</figcaption>
   </figure>
 
   <p>These are the same mechanisms from Part 1, read from the other side. The board, the gates, and the resolver carry the four fields latent in the work, ready to surface. Making them explicit stops them from leaking.</p>

--- a/docs/articles/dev-loops-deep-dive.html
+++ b/docs/articles/dev-loops-deep-dive.html
@@ -452,7 +452,7 @@
 
   <h2 id="the-loop-improves-itself">The loop improves itself</h2>
 
-  <p>The same machinery that ships a change also sharpens the next one. Grilling refines a raw issue into a locked spec before any code is written. The fan-out review angles (Diagram 3), extendable per repository, and the review-fix rounds tighten the change while it is in flight. After merge, a retrospective records advisory findings on the change; where they warrant it, the conductor opens follow-ups as new tracked issues, carrying improvement from one change into the next.</p>
+  <p>The same machinery that ships a change also sharpens the next one. Grilling refines a raw issue into a locked spec before any code is written. The fan-out review angles (Diagram 3), extendable per repository, and the review-fix rounds tighten the change while it is in flight. After merge, a retrospective records advisory findings on the change; where they warrant it, the conductor can open follow-ups as new tracked issues, carrying improvement from one change into the next.</p>
 
   <figure>
     <div class="diagram-scroll">
@@ -468,7 +468,7 @@
         <div class="node">Merge</div>
         <div class="edge"><span class="arrow">&rarr;</span></div>
         <div class="node accent">Retrospective&nbsp;(advisory)</div>
-        <div class="edge"><span class="arrow">&rarr;</span><span class="edge-label">conductor opens, then back to grilling</span></div>
+        <div class="edge"><span class="arrow">&rarr;</span><span class="edge-label">conductor can open, then back to grilling</span></div>
         <div class="node">Follow-ups&nbsp;(new&nbsp;tracked&nbsp;issues)</div>
       </div>
     </div>

--- a/docs/articles/dev-loops-deep-dive.md
+++ b/docs/articles/dev-loops-deep-dive.md
@@ -258,7 +258,7 @@ stateDiagram-v2
 
 ## The loop improves itself
 
-The same machinery that ships a change also sharpens the next one. Grilling refines a raw issue into a locked spec before any code is written. The fan-out review angles (Diagram 3), extendable per repository, and the review-fix rounds tighten the change while it is in flight. After merge, a retrospective records advisory findings on the change; where they warrant it, the conductor opens follow-ups as new tracked issues, carrying improvement from one change into the next.
+The same machinery that ships a change also sharpens the next one. Grilling refines a raw issue into a locked spec before any code is written. The fan-out review angles (Diagram 3), extendable per repository, and the review-fix rounds tighten the change while it is in flight. After merge, a retrospective records advisory findings on the change; where they warrant it, the conductor can open follow-ups as new tracked issues, carrying improvement from one change into the next.
 
 ```mermaid
 stateDiagram-v2
@@ -269,7 +269,7 @@ stateDiagram-v2
   FanOutReview --> ReviewFixConverge
   ReviewFixConverge --> Merge
   Merge --> Retrospective
-  Retrospective --> FollowUps: conductor opens, as warranted
+  Retrospective --> FollowUps: conductor can open, as warranted
   FollowUps --> GrillRefine
 ```
 
@@ -288,7 +288,7 @@ stateDiagram-v2
         <div class="node">Merge</div>
         <div class="edge"><span class="arrow">&rarr;</span></div>
         <div class="node accent">Retrospective&nbsp;(advisory)</div>
-        <div class="edge"><span class="arrow">&rarr;</span><span class="edge-label">conductor opens, then back to grilling</span></div>
+        <div class="edge"><span class="arrow">&rarr;</span><span class="edge-label">conductor can open, then back to grilling</span></div>
         <div class="node">Follow-ups&nbsp;(new&nbsp;tracked&nbsp;issues)</div>
       </div>
 -->

--- a/docs/articles/dev-loops-deep-dive.md
+++ b/docs/articles/dev-loops-deep-dive.md
@@ -232,7 +232,7 @@ stateDiagram-v2
   RederiveNextAction --> StopAskHuman
   RetryCheck --> ResumeAtProgress
   ReviewFixReReview --> ResumeAtProgress
-  StopAskHuman --> [*]
+  StopAskHuman --> ResumeAtProgress
   ResumeAtProgress --> RunInProgress
 ```
 

--- a/docs/articles/dev-loops-deep-dive.md
+++ b/docs/articles/dev-loops-deep-dive.md
@@ -217,6 +217,82 @@ Run the workflow on a state graph. The set of possible moves is closed and lista
 
 A state graph guarantees the behavior a prompt can only request. When the next step has to be knowable at any moment, the coordination layer itself should rest on something checkable.
 
+## The loop heals itself
+
+dev-loops treats a failure as a state to recover from. A failed CI check or a fail-closed tool response — a gate or wrapper that stops and surfaces the error — is detected and recorded on the pull request. The loop re-derives the next action from authoritative state and takes exactly one of three recovery moves: retry the check, run the review-fix-re-review loop until the change converges (bounded by a round cap, `refinement.maxCopilotRounds`), or stop and ask a human. Run progress is preserved as the recovery point, so the work resumes where it left off. Failing closed keeps the failure visible and red, so the loop recovers from the true state.
+
+```mermaid
+stateDiagram-v2
+  direction LR
+  [*] --> RunInProgress
+  RunInProgress --> DetectedRecorded: check fails / fails closed
+  DetectedRecorded --> RederiveNextAction
+  RederiveNextAction --> RetryCheck
+  RederiveNextAction --> ReviewFixReReview
+  RederiveNextAction --> StopAskHuman
+  RetryCheck --> ResumeAtProgress
+  ReviewFixReReview --> ResumeAtProgress
+  StopAskHuman --> [*]
+  ResumeAtProgress --> RunInProgress
+```
+
+*Diagram 5 — Self-healing recovery. A failed check or fail-closed stop is detected and recorded, then the loop re-derives the next action and takes one of three recovery moves before resuming at the preserved progress.*
+
+<!-- figure
+      <div class="flow" role="img" aria-label="Self-healing recovery: a run in progress hits a failed check or fail-closed stop, which is detected and recorded, then the loop re-derives the next action and takes one of three recovery moves — retry the check, review-fix-re-review until it converges, or stop and ask a human — before resuming at the preserved progress and returning to the run.">
+        <div class="node start">Run&nbsp;in&nbsp;progress</div>
+        <div class="edge"><span class="arrow">&rarr;</span><span class="edge-label">check fails / fails closed</span></div>
+        <div class="node">Detected&nbsp;&amp;&nbsp;recorded</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node accent">Re-derive&nbsp;the&nbsp;next&nbsp;action</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="flow-col">
+          <div class="node">Retry&nbsp;the&nbsp;check</div>
+          <div class="node">Review&nbsp;&rarr;&nbsp;fix&nbsp;&rarr;&nbsp;re-review&nbsp;(round-capped)</div>
+          <div class="node">Stop&nbsp;&amp;&nbsp;ask&nbsp;a&nbsp;human</div>
+        </div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node accent">Resume&nbsp;at&nbsp;preserved&nbsp;progress</div>
+      </div>
+-->
+
+## The loop improves itself
+
+The same machinery that ships a change also sharpens the next one. Grilling refines a raw issue into a locked spec before any code is written. The fan-out review angles (Diagram 3), extendable per repository, and the review-fix rounds tighten the change while it is in flight. After merge, a retrospective records advisory findings on the change; where they warrant it, the conductor opens follow-ups as new tracked issues, carrying improvement from one change into the next.
+
+```mermaid
+stateDiagram-v2
+  direction LR
+  [*] --> GrillRefine
+  GrillRefine --> Implement
+  Implement --> FanOutReview
+  FanOutReview --> ReviewFixConverge
+  ReviewFixConverge --> Merge
+  Merge --> Retrospective
+  Retrospective --> FollowUps: conductor opens, as warranted
+  FollowUps --> GrillRefine
+```
+
+*Diagram 6 — Self-improving feedback loop. Grilling locks a spec before code, the fan-out and review-fix rounds tighten the change in flight, and a post-merge retrospective records advisory findings the conductor can open as follow-ups that feed the next cycle.*
+
+<!-- figure
+      <div class="flow" role="img" aria-label="Self-improving loop: grilling refines an issue into a locked spec, which is implemented, reviewed by fan-out angles, converged through review-fix rounds, and merged; a post-merge retrospective records advisory findings that the conductor can open as follow-up issues, feeding back into grilling the next issue.">
+        <div class="node start">Grill&nbsp;&amp;&nbsp;refine&nbsp;into&nbsp;a&nbsp;locked&nbsp;spec</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node">Implement</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node">Fan-out&nbsp;review&nbsp;angles</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node">Review/fix&nbsp;rounds&nbsp;converge</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node">Merge</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node accent">Retrospective&nbsp;(advisory)</div>
+        <div class="edge"><span class="arrow">&rarr;</span><span class="edge-label">conductor opens, then back to grilling</span></div>
+        <div class="node">Follow-ups&nbsp;(new&nbsp;tracked&nbsp;issues)</div>
+      </div>
+-->
+
 # Part 2 — Make the waiting visible
 
 Closing the handoffs is half the work. The other half is the gap itself. A change that used to take an afternoon now lands in seconds. The diff shows up before you've finished reading the request. Generation, the part we spent decades trying to speed up, is now fast enough to be routine.
@@ -237,7 +313,7 @@ flowchart LR
   D --> E[Act]
   E --> F[Recover]
 ```
-*Diagram 5 — The interrupt-cost chain. A five-minute question triggers five transitions, and the answer itself is only one of them.*
+*Diagram 7 — The interrupt-cost chain. A five-minute question triggers five transitions, and the answer itself is only one of them.*
 
 <!-- figure
       <div class="flow" role="img" aria-label="Interrupt cost: one interruption forces five transitions — Notice, Switch, Rebuild state, Act, then Recover — before the original work resumes.">
@@ -270,7 +346,7 @@ flowchart LR
   C --> W[Work resumes]
   W -. next ambiguity .-> Q
 ```
-*Diagram 6 — One handoff round trip. Every question the state can't answer becomes an ask → answer → confirm cycle, and the work waits until it closes — then the next ambiguity restarts it.*
+*Diagram 8 — One handoff round trip. Every question the state can't answer becomes an ask → answer → confirm cycle, and the work waits until it closes — then the next ambiguity restarts it.*
 
 <!-- figure
       <div class="flow" role="img" aria-label="Handoff round trip: Receiver asks, Sender answers, Receiver confirms, work resumes — then the cycle repeats on the next ambiguity.">
@@ -322,7 +398,7 @@ flowchart LR
   C --> D[Verify outcomes]
   D --> A
 ```
-*Diagram 7 — The measurement loop. Capture, measure, change, verify — then back to capture. It repeats as a cycle, because the slowest transition moves as you fix things.*
+*Diagram 9 — The measurement loop. Capture, measure, change, verify — then back to capture. It repeats as a cycle, because the slowest transition moves as you fix things.*
 
 <!-- figure
       <div class="flow" role="img" aria-label="Measurement loop: Capture state, Measure waits, Change the process, Verify outcomes — then loop back to capture.">
@@ -361,7 +437,7 @@ flowchart TD
   O --> C[CI wait + post-merge reclaim run only where state says safe]
 ```
 
-*Diagram 8 — Grounding "observable state" in real mechanisms. The board carries owner and next step, the gate trail carries the latest decision, the resolver answers whose move it is, and safe automation runs on that confirmed state.*
+*Diagram 10 — Grounding "observable state" in real mechanisms. The board carries owner and next step, the gate trail carries the latest decision, the resolver answers whose move it is, and safe automation runs on that confirmed state.*
 
 <!-- figure
       <svg class="tree-svg" viewBox="0 0 640 360" role="img" aria-label="Observable state feeds the board, gate trail, and resolver, which let the next actor start and let safe automation run.">

--- a/docs/articles/introducing-dev-loops.html
+++ b/docs/articles/introducing-dev-loops.html
@@ -306,6 +306,48 @@
 
   <p>That split is the practical argument for model flexibility. The structure constrains how far any single step can stray: each step is bounded, each gate fails closed, and the review fan-out checks the work regardless of which model produced it. So the quality bar sits where the gates put it, and a cheaper or self-hosted model can carry the routine steps while the strongest model you have is reserved for the judgment-heavy ones.</p>
 
+  <h2 id="it-heals-and-improves-itself">It heals and improves itself</h2>
+
+  <p>The loop already fails closed when a decision is ambiguous; the same posture covers failure. When a CI check fails or a tool response fails closed, the loop re-derives the next action from the state it already has, then retries the step, runs the review-fix rounds until the change converges, or stops and asks a human. The work resumes from the progress it already had.</p>
+
+  <figure>
+    <div class="diagram-scroll">
+      <div class="flow" role="img" aria-label="Self-healing: a failed check or fail-closed tool triggers re-deriving the next action, which retries, runs review-fix-re-review, or asks a human, then resumes at preserved progress.">
+        <div class="node start">Check&nbsp;or&nbsp;tool&nbsp;fails&nbsp;closed</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node accent">Re-derive&nbsp;next&nbsp;action</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="flow-col">
+          <div class="node">Retry</div>
+          <div class="node">Review&nbsp;&rarr;&nbsp;fix&nbsp;&rarr;&nbsp;re-review</div>
+          <div class="node">Ask&nbsp;a&nbsp;human</div>
+        </div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node">Resume&nbsp;at&nbsp;preserved&nbsp;progress</div>
+      </div>
+    </div>
+    <figcaption><b>Diagram 1 — Self-healing.</b> A failed check or a fail-closed tool response re-derives the next action, then retries, resolves through review, or asks a human — and resumes at the progress already made.</figcaption>
+  </figure>
+
+  <p>The loop also sharpens its own inputs over time. Grilling turns a raw issue into a locked spec before any work starts, the review angles and the review/fix rounds tighten the change while it's in flight, and after merge a retrospective records advisory findings the conductor opens as new tracked issues that feed the next grill.</p>
+
+  <figure>
+    <div class="diagram-scroll">
+      <div class="flow" role="img" aria-label="Self-improving: grilling the issue leads to review and fix rounds, then merge, then a post-merge retrospective whose advisory findings the conductor opens as follow-up issues feeding back into grilling.">
+        <div class="node start">Grill&nbsp;the&nbsp;issue</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node">Review&nbsp;/&nbsp;fix&nbsp;rounds</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node">Merge</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node accent">Retrospective&nbsp;(advisory)</div>
+        <div class="edge"><span class="arrow">&rarr;</span><span class="edge-label">conductor&nbsp;opens&nbsp;follow-ups</span></div>
+        <div class="node">Back&nbsp;to&nbsp;grilling</div>
+      </div>
+    </div>
+    <figcaption><b>Diagram 2 — Self-improving.</b> Grilling locks the spec, review and fix rounds tighten the change, and a post-merge retrospective records advisory findings the conductor opens as new follow-up issues.</figcaption>
+  </figure>
+
   <h2 id="set-it-up">Set it up</h2>
 
   <p>dev-loops drives an ordinary GitHub pull-request workflow from inside Claude Code or Pi. You need Node 24 or newer and the GitHub CLI (<code>gh</code>) authenticated for your repository.</p>

--- a/docs/articles/introducing-dev-loops.html
+++ b/docs/articles/introducing-dev-loops.html
@@ -329,11 +329,11 @@
     <figcaption><b>Diagram 1 — Self-healing.</b> A failed check or a fail-closed tool response re-derives the next action, then retries, resolves through review, or asks a human — and resumes at the progress already made.</figcaption>
   </figure>
 
-  <p>The loop also sharpens its own inputs over time. Grilling turns a raw issue into a locked spec before any work starts, the review angles and the review/fix rounds tighten the change while it's in flight, and after merge a retrospective records advisory findings the conductor opens as new tracked issues that feed the next grill.</p>
+  <p>The loop also sharpens its own inputs over time. Grilling turns a raw issue into a locked spec before any work starts, the review angles and the review/fix rounds tighten the change while it's in flight, and after merge a retrospective records advisory findings the conductor can open as new tracked issues that feed the next grill.</p>
 
   <figure>
     <div class="diagram-scroll">
-      <div class="flow" role="img" aria-label="Self-improving: grilling the issue leads to review and fix rounds, then merge, then a post-merge retrospective whose advisory findings the conductor opens as follow-up issues feeding back into grilling.">
+      <div class="flow" role="img" aria-label="Self-improving: grilling the issue leads to review and fix rounds, then merge, then a post-merge retrospective whose advisory findings the conductor can open as follow-up issues feeding back into grilling.">
         <div class="node start">Grill&nbsp;the&nbsp;issue</div>
         <div class="edge"><span class="arrow">&rarr;</span></div>
         <div class="node">Review&nbsp;/&nbsp;fix&nbsp;rounds</div>
@@ -341,11 +341,11 @@
         <div class="node">Merge</div>
         <div class="edge"><span class="arrow">&rarr;</span></div>
         <div class="node accent">Retrospective&nbsp;(advisory)</div>
-        <div class="edge"><span class="arrow">&rarr;</span><span class="edge-label">conductor&nbsp;opens&nbsp;follow-ups</span></div>
+        <div class="edge"><span class="arrow">&rarr;</span><span class="edge-label">conductor&nbsp;can&nbsp;open&nbsp;follow-ups</span></div>
         <div class="node">Back&nbsp;to&nbsp;grilling</div>
       </div>
     </div>
-    <figcaption><b>Diagram 2 — Self-improving.</b> Grilling locks the spec, review and fix rounds tighten the change, and a post-merge retrospective records advisory findings the conductor opens as new follow-up issues.</figcaption>
+    <figcaption><b>Diagram 2 — Self-improving.</b> Grilling locks the spec, review and fix rounds tighten the change, and a post-merge retrospective records advisory findings the conductor can open as new follow-up issues.</figcaption>
   </figure>
 
   <h2 id="set-it-up">Set it up</h2>

--- a/docs/articles/introducing-dev-loops.md
+++ b/docs/articles/introducing-dev-loops.md
@@ -90,21 +90,21 @@ stateDiagram-v2
       </div>
 -->
 
-The loop also sharpens its own inputs over time. Grilling turns a raw issue into a locked spec before any work starts, the review angles and the review/fix rounds tighten the change while it's in flight, and after merge a retrospective records advisory findings the conductor opens as new tracked issues that feed the next grill.
+The loop also sharpens its own inputs over time. Grilling turns a raw issue into a locked spec before any work starts, the review angles and the review/fix rounds tighten the change while it's in flight, and after merge a retrospective records advisory findings the conductor can open as new tracked issues that feed the next grill.
 
 ```mermaid
 flowchart LR
   A[Grill the issue] --> B[Review / fix rounds]
   B --> C[Merge]
   C --> D[Retrospective]
-  D -->|conductor opens| E[Follow-up issues]
+  D -->|conductor can open| E[Follow-up issues]
   E --> A
 ```
 
-*Diagram 2 — Self-improving. Grilling locks the spec, review and fix rounds tighten the change, and a post-merge retrospective records advisory findings the conductor opens as new follow-up issues.*
+*Diagram 2 — Self-improving. Grilling locks the spec, review and fix rounds tighten the change, and a post-merge retrospective records advisory findings the conductor can open as new follow-up issues.*
 
 <!-- figure
-      <div class="flow" role="img" aria-label="Self-improving: grilling the issue leads to review and fix rounds, then merge, then a post-merge retrospective whose advisory findings the conductor opens as follow-up issues feeding back into grilling.">
+      <div class="flow" role="img" aria-label="Self-improving: grilling the issue leads to review and fix rounds, then merge, then a post-merge retrospective whose advisory findings the conductor can open as follow-up issues feeding back into grilling.">
         <div class="node start">Grill&nbsp;the&nbsp;issue</div>
         <div class="edge"><span class="arrow">&rarr;</span></div>
         <div class="node">Review&nbsp;/&nbsp;fix&nbsp;rounds</div>
@@ -112,7 +112,7 @@ flowchart LR
         <div class="node">Merge</div>
         <div class="edge"><span class="arrow">&rarr;</span></div>
         <div class="node accent">Retrospective&nbsp;(advisory)</div>
-        <div class="edge"><span class="arrow">&rarr;</span><span class="edge-label">conductor&nbsp;opens&nbsp;follow-ups</span></div>
+        <div class="edge"><span class="arrow">&rarr;</span><span class="edge-label">conductor&nbsp;can&nbsp;open&nbsp;follow-ups</span></div>
         <div class="node">Back&nbsp;to&nbsp;grilling</div>
       </div>
 -->

--- a/docs/articles/introducing-dev-loops.md
+++ b/docs/articles/introducing-dev-loops.md
@@ -53,6 +53,70 @@ Model choice is configuration in the same spirit. Roles map to model tiers, and 
 
 That split is the practical argument for model flexibility. The structure constrains how far any single step can stray: each step is bounded, each gate fails closed, and the review fan-out checks the work regardless of which model produced it. So the quality bar sits where the gates put it, and a cheaper or self-hosted model can carry the routine steps while the strongest model you have is reserved for the judgment-heavy ones.
 
+## It heals and improves itself
+
+The loop already fails closed when a decision is ambiguous; the same posture covers failure. When a CI check fails or a tool response fails closed, the loop re-derives the next action from the state it already has, then retries the step, runs the review-fix rounds until the change converges, or stops and asks a human. The work resumes from the progress it already had.
+
+```mermaid
+stateDiagram-v2
+  direction LR
+  [*] --> Run
+  Run --> Fails: check or tool fails closed
+  Fails --> Rederive: re-derive next action
+  Rederive --> Retry
+  Rederive --> ReviewFix: review, fix, re-review
+  Rederive --> AskHuman: ask a human
+  Retry --> Resume
+  ReviewFix --> Resume
+  AskHuman --> Resume
+  Resume --> [*]
+```
+
+*Diagram 1 — Self-healing. A failed check or a fail-closed tool response re-derives the next action, then retries, resolves through review, or asks a human — and resumes at the progress already made.*
+
+<!-- figure
+      <div class="flow" role="img" aria-label="Self-healing: a failed check or fail-closed tool triggers re-deriving the next action, which retries, runs review-fix-re-review, or asks a human, then resumes at preserved progress.">
+        <div class="node start">Check&nbsp;or&nbsp;tool&nbsp;fails&nbsp;closed</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node accent">Re-derive&nbsp;next&nbsp;action</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="flow-col">
+          <div class="node">Retry</div>
+          <div class="node">Review&nbsp;&rarr;&nbsp;fix&nbsp;&rarr;&nbsp;re-review</div>
+          <div class="node">Ask&nbsp;a&nbsp;human</div>
+        </div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node">Resume&nbsp;at&nbsp;preserved&nbsp;progress</div>
+      </div>
+-->
+
+The loop also sharpens its own inputs over time. Grilling turns a raw issue into a locked spec before any work starts, the review angles and the review/fix rounds tighten the change while it's in flight, and after merge a retrospective records advisory findings the conductor opens as new tracked issues that feed the next grill.
+
+```mermaid
+flowchart LR
+  A[Grill the issue] --> B[Review / fix rounds]
+  B --> C[Merge]
+  C --> D[Retrospective]
+  D -->|conductor opens| E[Follow-up issues]
+  E --> A
+```
+
+*Diagram 2 — Self-improving. Grilling locks the spec, review and fix rounds tighten the change, and a post-merge retrospective records advisory findings the conductor opens as new follow-up issues.*
+
+<!-- figure
+      <div class="flow" role="img" aria-label="Self-improving: grilling the issue leads to review and fix rounds, then merge, then a post-merge retrospective whose advisory findings the conductor opens as follow-up issues feeding back into grilling.">
+        <div class="node start">Grill&nbsp;the&nbsp;issue</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node">Review&nbsp;/&nbsp;fix&nbsp;rounds</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node">Merge</div>
+        <div class="edge"><span class="arrow">&rarr;</span></div>
+        <div class="node accent">Retrospective&nbsp;(advisory)</div>
+        <div class="edge"><span class="arrow">&rarr;</span><span class="edge-label">conductor&nbsp;opens&nbsp;follow-ups</span></div>
+        <div class="node">Back&nbsp;to&nbsp;grilling</div>
+      </div>
+-->
+
 ## Set it up
 
 dev-loops drives an ordinary GitHub pull-request workflow from inside Claude Code or Pi. You need Node 24 or newer and the GitHub CLI (`gh`) authenticated for your repository.

--- a/docs/presentations/dev-loops-deep-dive.html
+++ b/docs/presentations/dev-loops-deep-dive.html
@@ -374,6 +374,80 @@
   </div>
 </section>
 
+<section class="slide" id="self-healing">
+  <div class="slide-inner">
+    <p class="kicker">Self-healing</p>
+    <h2>The Loop Recovers and Resumes</h2>
+    <div class="grid grid-2">
+      <div class="glass-card">
+        <ul class="tight-list">
+          <li>A failed CI check or a <strong>fail-closed</strong> tool response is <strong>detected and recorded</strong> on the pull request.</li>
+          <li>The resolver <strong>re-derives the next action</strong> from authoritative state, and the run resumes from there.</li>
+          <li>Recovery is one of three moves: retry the check, run review&rarr;fix&rarr;re-review until it converges (round-capped by <code>refinement.maxCopilotRounds</code>), or stop and ask a human.</li>
+          <li>Run progress is <strong>preserved</strong> through the recovery, so nothing already done gets redone.</li>
+        </ul>
+      </div>
+      <div class="glass-card flow-card">
+        <p class="card-label">Failure detected, one recovery move, resume</p>
+        <div class="flow-scroll">
+          <div class="flow">
+            <div class="node start">Run</div>
+            <div class="edge"><span class="arrow">&rarr;</span></div>
+            <div class="node accent">Fails&nbsp;/&nbsp;fails-closed</div>
+            <div class="edge"><span class="arrow">&rarr;</span></div>
+            <div class="node accent">Re-derive&nbsp;next&nbsp;action</div>
+            <div class="edge"><span class="arrow">&rarr;</span></div>
+            <div class="flow-col">
+              <div class="node">Retry&nbsp;the&nbsp;check</div>
+              <div class="node">Review&nbsp;&rarr;&nbsp;fix&nbsp;&rarr;&nbsp;re-review</div>
+              <div class="node">Ask&nbsp;a&nbsp;human</div>
+            </div>
+            <div class="edge"><span class="arrow">&#8635;</span><span class="edge-label">resume: progress preserved</span></div>
+            <div class="node start">Run</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="slide" id="self-improving">
+  <div class="slide-inner">
+    <p class="kicker">Self-improving</p>
+    <h2>Each Change Sharpens the Next</h2>
+    <div class="grid grid-2">
+      <div class="glass-card">
+        <ul class="tight-list">
+          <li><strong>Grilling</strong> locks a spec before any code moves, so implementation starts from a settled shape.</li>
+          <li>Review runs as <strong>fan-out angles</strong> &mdash; extendable per repo &mdash; each reading the same evidence from a different lens.</li>
+          <li><strong>Review&rarr;fix rounds</strong> tighten the change in flight until it converges.</li>
+          <li>After merge, a <strong>retrospective</strong> records advisory findings on the change that the conductor opens as new tracked issues, feeding the next grill.</li>
+        </ul>
+      </div>
+      <div class="glass-card flow-card">
+        <p class="card-label">Each merge feeds the next issue</p>
+        <div class="flow-scroll">
+          <div class="flow">
+            <div class="node start">Grill&nbsp;/&nbsp;refine</div>
+            <div class="edge"><span class="arrow">&rarr;</span></div>
+            <div class="node">Implement</div>
+            <div class="edge"><span class="arrow">&rarr;</span></div>
+            <div class="node accent">Fan-out&nbsp;angles</div>
+            <div class="edge"><span class="arrow">&rarr;</span></div>
+            <div class="node accent">Review&nbsp;/&nbsp;fix&nbsp;converge</div>
+            <div class="edge"><span class="arrow">&rarr;</span></div>
+            <div class="node">Merge</div>
+            <div class="edge"><span class="arrow">&rarr;</span></div>
+            <div class="node">Retrospective&nbsp;&rarr;&nbsp;follow-ups</div>
+            <div class="edge"><span class="arrow">&#8635;</span><span class="edge-label">loop back to: grill / refine</span></div>
+            <div class="node start">Grill&nbsp;/&nbsp;refine</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
 <section class="slide" id="trust">
   <div class="slide-inner">
     <p class="kicker">Verified done</p>

--- a/docs/presentations/dev-loops-deep-dive.html
+++ b/docs/presentations/dev-loops-deep-dive.html
@@ -421,7 +421,7 @@
           <li><strong>Grilling</strong> locks a spec before any code moves, so implementation starts from a settled shape.</li>
           <li>Review runs as <strong>fan-out angles</strong> &mdash; extendable per repo &mdash; each reading the same evidence from a different lens.</li>
           <li><strong>Review&rarr;fix rounds</strong> tighten the change in flight until it converges.</li>
-          <li>After merge, a <strong>retrospective</strong> records advisory findings on the change that the conductor opens as new tracked issues, feeding the next grill.</li>
+          <li>After merge, a <strong>retrospective</strong> records advisory findings on the change that the conductor can open as new tracked issues, feeding the next grill.</li>
         </ul>
       </div>
       <div class="glass-card flow-card">

--- a/docs/presentations/introducing-dev-loops.html
+++ b/docs/presentations/introducing-dev-loops.html
@@ -442,7 +442,7 @@
         <ul class="mini-list">
           <li>Grilling locks the spec before work starts.</li>
           <li>Review angles and review-fix rounds tighten the change itself.</li>
-          <li>A retrospective records advisory findings the conductor opens as new tracked issues.</li>
+          <li>A retrospective records advisory findings the conductor can open as new tracked issues.</li>
         </ul>
         <div class="flow-scroll">
           <div class="flow">

--- a/docs/presentations/introducing-dev-loops.html
+++ b/docs/presentations/introducing-dev-loops.html
@@ -415,6 +415,49 @@
   </div>
 </section>
 
+<section class="slide" id="self-healing">
+  <div class="slide-inner">
+    <p class="kicker">Recover, then sharpen</p>
+    <h2>Self-Healing, Self-Improving</h2>
+    <div class="grid grid-2">
+      <div class="glass-card flow-card">
+        <p class="card-label">Failure routes to a recovery move</p>
+        <ul class="mini-list">
+          <li>A failed check or a fail-closed tool response is recorded and routed.</li>
+          <li>The loop re-derives the next action and retries, until it converges or stops and asks a person.</li>
+          <li>The run resumes from the progress it already had.</li>
+        </ul>
+        <div class="flow-scroll">
+          <div class="flow">
+            <div class="node start">Check&nbsp;fails</div>
+            <div class="edge"><span class="arrow">&rarr;</span></div>
+            <div class="node">Re-derive&nbsp;&amp;&nbsp;retry</div>
+            <div class="edge"><span class="arrow">&rarr;</span></div>
+            <div class="node accent">Converge&nbsp;or&nbsp;ask</div>
+          </div>
+        </div>
+      </div>
+      <div class="glass-card flow-card">
+        <p class="card-label">Every change tightens the next one</p>
+        <ul class="mini-list">
+          <li>Grilling locks the spec before work starts.</li>
+          <li>Review angles and review-fix rounds tighten the change itself.</li>
+          <li>A retrospective records advisory findings the conductor opens as new tracked issues.</li>
+        </ul>
+        <div class="flow-scroll">
+          <div class="flow">
+            <div class="node start">Grill&nbsp;locks&nbsp;spec</div>
+            <div class="edge"><span class="arrow">&rarr;</span></div>
+            <div class="node">Review&nbsp;&amp;&nbsp;fix</div>
+            <div class="edge"><span class="arrow">&rarr;</span></div>
+            <div class="node accent">Retro&nbsp;&rarr;&nbsp;follow-ups</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
 <section class="slide" id="setup">
   <div class="slide-inner">
     <p class="kicker">Set it up</p>

--- a/test/playwright/harness/deck-fit-harness.mjs
+++ b/test/playwright/harness/deck-fit-harness.mjs
@@ -256,6 +256,7 @@ export const DECK_REGISTRY = {
       { id: "the-work", stateName: "The work" },
       { id: "model-agnostic", stateName: "Model agnostic" },
       { id: "proof", stateName: "Proof (data)" },
+      { id: "self-healing", stateName: "Self-healing / self-improving" },
       { id: "setup", stateName: "Setup" },
     ],
   },
@@ -270,6 +271,8 @@ export const DECK_REGISTRY = {
       { id: "safe-pauses", stateName: "Safe pauses", capture: false },
       { id: "steering", stateName: "Steering", capture: false },
       { id: "parallel-review", stateName: "Parallel review", capture: true },
+      { id: "self-healing", stateName: "Self-healing recovery", capture: true },
+      { id: "self-improving", stateName: "Self-improving loop", capture: true },
       { id: "trust", stateName: "Trust / never-lie", capture: false },
       { id: "why-graphs", stateName: "Why graphs", capture: true },
       // Part 2 — make the waiting visible


### PR DESCRIPTION
Closes #1398

## Objective

Underline dev-loops' self-healing and self-improving nature across all four public surfaces — it was under-told in every one. Each theme gets its own diagrammed unit at a depth matched to the surface.

## What changed

- **Intro article** (`docs/articles/introducing-dev-loops.md`) — new shallow section "It heals and improves itself" with two compact mermaid-fed figures (self-healing recovery; self-improving loop).
- **Deep-dive article** (`docs/articles/dev-loops-deep-dive.md`) — two new deep sections "The loop heals itself" (Diagram 5) and "The loop improves itself" (Diagram 6), naming the mechanisms; Part 2's diagrams renumbered 7–10 to stay sequential.
- **Intro deck** (`docs/presentations/introducing-dev-loops.html`) — new slide `#self-healing` covering both themes with fit-to-mobile `.flow` diagrams.
- **Deep-dive deck** (`docs/presentations/dev-loops-deep-dive.html`) — new slides `#self-healing` and `#self-improving`.
- **`test/playwright/harness/deck-fit-harness.mjs`** — registered the three new slide ids in `DECK_REGISTRY`.
- Rendered `.html` twins for both articles regenerated (`articles:render`).

## Accuracy (deslop pass)

Every claim maps to a real mechanism, verified against the codebase. Two corrections applied during review:
- The **retrospective is advisory**, not an auto-emitting gate (`RETRO-ADVISORY-NEVER-GATE`, #1077): copy states it *records advisory findings the conductor opens as follow-up issues*, discretionary — no automatic issue emission.
- Removed AI-writing tells the first draft carried — the "X, not Y" / "instead of" / "rather than" contrast constructions and two aphoristic "X becomes its Y" closers — rewritten as direct statements.

## Validation

- `npm run articles:check` green (committed twins match the `.md`).
- Playwright: 13/13 across both articles + both decks — locked CSP (`default-src 'none'`), mobile-fit (no horizontal scroll, no vertical clip), all slide ids present once, keyboard nav intact.
- Multi-viewport UI review (360 / 390 / 414 / 768 / 1024 / 1440) of every new figure: 0 overflow/clip findings; decks stack their flows to vertical cards on mobile, articles use the existing `.diagram-scroll` horizontal pattern.
- `npm run test:docs` green (551 links, 165 rules).

## Non-goals

- No live mermaid runtime (CSP `default-src 'none'`; the hand-authored `.flow` figure is what renders, the mermaid fence is the machine-readable spec beside it).
- No restructuring of existing sections/slides beyond the new units; existing slide ids unchanged.
- No new build tooling.
