### PR TITLE
fix(gate-evidence): re-fire on review-thread state changes to close the thread-axis stale-green window (#1385)

### DIFF
--- a/.claude/skills/docs/merge-preconditions.md
+++ b/.claude/skills/docs/merge-preconditions.md
@@ -63,13 +63,16 @@ practice:
   dev-loop tooling calls before merging.
 - **Server-side:** the `gate-evidence` status check
   (`.github/workflows/gate-evidence.yml`) re-runs the same verdict check on
-  GitHub's own token for every non-draft PR. This is what closes the ready/merge
-  bypass — a direct GitHub API call (MCP/REST, web UI, a raw `gh` invocation
-  outside the hook) skips the client-side path entirely but still cannot merge
-  without a green `gate-evidence` check **once branch protection on `main`
-  requires it**. Until an operator adds it to branch protection, the check runs
-  and reports on every non-draft PR but does **not** yet block merge — it is
-  reporting-only in that window.
+  GitHub's own token for every non-draft PR, re-firing on push, ready-for-review,
+  a submitted review, and thread resolve/unresolve — so a newly-opened
+  unresolved thread re-evaluates the check instead of leaving a SHA-pinned green
+  stale on the thread axis. This is what closes the ready/merge bypass — a
+  direct GitHub API call (MCP/REST, web UI, a raw `gh` invocation outside the
+  hook) skips the client-side path entirely but still cannot merge without a
+  green `gate-evidence` check **once branch protection on `main` requires it**.
+  Until an operator adds it to branch protection, the check runs and reports on
+  every non-draft PR but does **not** yet block merge — it is reporting-only in
+  that window.
 
 The server-side check verifies the same visible, comment-derived verdict fields
 the client-side tooling does (including the light-mode inline exception,

--- a/.claude/skills/docs/merge-preconditions.md
+++ b/.claude/skills/docs/merge-preconditions.md
@@ -64,9 +64,16 @@ practice:
 - **Server-side:** the `gate-evidence` status check
   (`.github/workflows/gate-evidence.yml`) re-runs the same verdict check on
   GitHub's own token for every non-draft PR, re-firing on push, ready-for-review,
-  a submitted review, thread resolve/unresolve, and a standalone review comment
-  — so a newly-opened unresolved thread re-evaluates the check instead of
-  leaving a SHA-pinned green stale on the thread axis. The `gate-evidence`
+  a submitted review, and a standalone review comment — so a newly-opened
+  unresolved thread re-evaluates the check instead of leaving a SHA-pinned green
+  stale on the thread axis. (There is no `pull_request_review_thread` Actions
+  trigger, so thread resolve/unresolve is not itself a re-fire event; a
+  newly-appearing unresolved thread arrives via a submitted review or a review
+  comment, both of which do re-fire. One narrow residual remains: a bare
+  "Unresolve conversation" UI action on an already-resolved thread, with no
+  accompanying review or comment, fires only that non-triggerable event and so
+  does not re-fire the check — bounded by the maintainer-gated merge, and
+  re-caught on the next push, review, or comment.) The `gate-evidence`
   context itself is always an explicit commit status posted to the PR's actual
   head SHA (not the triggering job's own check-run, which for the
   review/thread/comment event types would land on the base branch's latest

--- a/.claude/skills/docs/merge-preconditions.md
+++ b/.claude/skills/docs/merge-preconditions.md
@@ -64,10 +64,14 @@ practice:
 - **Server-side:** the `gate-evidence` status check
   (`.github/workflows/gate-evidence.yml`) re-runs the same verdict check on
   GitHub's own token for every non-draft PR, re-firing on push, ready-for-review,
-  a submitted review, and thread resolve/unresolve — so a newly-opened
-  unresolved thread re-evaluates the check instead of leaving a SHA-pinned green
-  stale on the thread axis. This is what closes the ready/merge bypass — a
-  direct GitHub API call (MCP/REST, web UI, a raw `gh` invocation outside the
+  a submitted review, thread resolve/unresolve, and a standalone review comment
+  — so a newly-opened unresolved thread re-evaluates the check instead of
+  leaving a SHA-pinned green stale on the thread axis. The `gate-evidence`
+  context itself is always an explicit commit status posted to the PR's actual
+  head SHA (not the triggering job's own check-run, which for the
+  review/thread/comment event types would land on the base branch's latest
+  commit instead of the PR head). This is what closes the ready/merge bypass —
+  a direct GitHub API call (MCP/REST, web UI, a raw `gh` invocation outside the
   hook) skips the client-side path entirely but still cannot merge without a
   green `gate-evidence` check **once branch protection on `main` requires it**.
   Until an operator adds it to branch protection, the check runs and reports on

--- a/.github/workflows/gate-evidence.yml
+++ b/.github/workflows/gate-evidence.yml
@@ -26,10 +26,11 @@ name: Gate evidence
 # don't re-fire when a thread is opened/resolved, a review is submitted, or a
 # standalone review comment opens a thread. Closed by also re-firing on
 # pull_request_review (submitted), pull_request_review_thread
-# (resolved/unresolved), and pull_request_review_comment (created) — all fire
-# on the base repo's own token regardless of whether the PR head is a fork,
-# and all carry the same `pull_request` object (number, draft, head.sha, ...)
-# this workflow already reads.
+# (resolved/unresolved), and pull_request_review_comment (created) — all three
+# are triggered by base-repo actions and run in the base-repo context, so they
+# get this workflow's declared permissions (including `statuses: write`) even
+# when the PR head is a fork, and all carry the same `pull_request` object
+# (number, draft, head.sha, ...) that this workflow already reads.
 #
 # Head-SHA mismatch on those three event types: unlike `pull_request` (whose
 # implicit job check-run GitHub auto-associates with the PR's head commit),

--- a/.github/workflows/gate-evidence.yml
+++ b/.github/workflows/gate-evidence.yml
@@ -11,28 +11,32 @@ name: Gate evidence
 # draft PR cannot be merged regardless); GitHub Actions treats a skipped job on a
 # required check as passing, so this never blocks draft work.
 #
-# Two inherent limitations of a pull_request-triggered, head-run check (both
-# accepted by design, neither a bypass):
-#   - Head-provenance: the workflow and the scripts it runs come from the PR's
-#     own head, so a PR could edit this file or the detector to forge a green
-#     check on itself. This is the "self-reported / not un-forgeable" caveat in
-#     docs/gate-review-sub-loop-contract.md; the un-forgeable provenance bridge
-#     (harness attestation) is #1358's explicit non-goal. Merge is maintainer-
-#     gated, so forging requires the merger to self-modify.
-#   - Trigger staleness: the verdict depends on PR comment history + thread
-#     resolution, which pull_request events don't re-fire on. For HEAD staleness
-#     this fails closed (a new commit re-triggers synchronize; missing/stale
-#     current-head evidence -> red). But the comment/thread dimension is NOT
-#     re-evaluated between triggering events: a NEW unresolved thread appearing
-#     after the last push/ready event leaves the SHA-pinned green check stale
-#     until the next push -> a residual false-green window on the thread axis.
-#     Bounded by the draft-first flow (re-evaluates on ready_for_review after the
-#     verdict is posted) and the maintainer-gated merge, but real; closing it
-#     (re-verify at merge / broaden triggers) is tracked separately. Not a reason
-#     to treat this check as the sole merge guard.
+# One inherent limitation of a head-run check (accepted by design, not a
+# bypass): head-provenance — the workflow and the scripts it runs come from the
+# PR's own head, so a PR could edit this file or the detector to forge a green
+# check on itself. This is the "self-reported / not un-forgeable" caveat in
+# docs/gate-review-sub-loop-contract.md; the un-forgeable provenance bridge
+# (harness attestation) is #1358's explicit non-goal. Merge is maintainer-
+# gated, so forging requires the merger to self-modify.
+#
+# Trigger staleness (the thread/comment axis) was a real gap: the verdict
+# depends on PR comment history + thread resolution, and pull_request events
+# don't re-fire when a thread is opened/resolved or a review is submitted.
+# Head staleness was always fail-closed (a new commit re-triggers synchronize);
+# closed here by also re-firing on pull_request_review (review submitted,
+# which can add unresolved threads) and pull_request_review_thread
+# (resolved/unresolved) — both fire on the base repo's own token regardless of
+# whether the PR head is a fork, and both carry the same `pull_request` object
+# (number, draft, ...) that this workflow already reads. So a NEW unresolved
+# thread, or a submitted review, re-evaluates this check instead of leaving a
+# SHA-pinned green stale until the next push.
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_thread:
+    types: [resolved, unresolved]
 
 permissions:
   contents: read

--- a/.github/workflows/gate-evidence.yml
+++ b/.github/workflows/gate-evidence.yml
@@ -29,7 +29,11 @@ name: Gate evidence
 # unresolved thread appears, which is the stale-green direction that matters
 # here. (GitHub Actions has no `pull_request_review_thread` workflow trigger —
 # thread resolve/unresolve is a webhook but not an `on:` event — so it is not
-# used; the two events above cover a newly-appearing unresolved thread.) Both
+# used; the two events above cover a newly-appearing unresolved thread. Narrow
+# residual: a bare "Unresolve conversation" UI action on an already-resolved
+# thread with no accompanying review/comment fires only that non-triggerable
+# event and is not re-caught until the next push/review/comment — bounded by the
+# maintainer-gated merge.) Both
 # are triggered by base-repo actions and run in the base-repo context, so they
 # get this workflow's declared permissions (including `statuses: write`) even
 # when the PR head is a fork, and both carry the same `pull_request` object

--- a/.github/workflows/gate-evidence.yml
+++ b/.github/workflows/gate-evidence.yml
@@ -23,13 +23,16 @@ name: Gate evidence
 #
 # Trigger staleness (the thread/comment axis) was a real gap: the verdict
 # depends on PR comment history + thread resolution, and pull_request events
-# don't re-fire when a thread is opened/resolved, a review is submitted, or a
-# standalone review comment opens a thread. Closed by also re-firing on
-# pull_request_review (submitted), pull_request_review_thread
-# (resolved/unresolved), and pull_request_review_comment (created) — all three
+# don't re-fire when a review is submitted or a review comment opens a new
+# thread. Closed by also re-firing on pull_request_review (submitted) and
+# pull_request_review_comment (created) — the two events through which a NEW
+# unresolved thread appears, which is the stale-green direction that matters
+# here. (GitHub Actions has no `pull_request_review_thread` workflow trigger —
+# thread resolve/unresolve is a webhook but not an `on:` event — so it is not
+# used; the two events above cover a newly-appearing unresolved thread.) Both
 # are triggered by base-repo actions and run in the base-repo context, so they
 # get this workflow's declared permissions (including `statuses: write`) even
-# when the PR head is a fork, and all carry the same `pull_request` object
+# when the PR head is a fork, and both carry the same `pull_request` object
 # (number, draft, head.sha, ...) that this workflow already reads.
 #
 # Head-SHA mismatch on those three event types: unlike `pull_request` (whose
@@ -50,8 +53,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   pull_request_review:
     types: [submitted]
-  pull_request_review_thread:
-    types: [resolved, unresolved]
   pull_request_review_comment:
     types: [created]
 

--- a/.github/workflows/gate-evidence.yml
+++ b/.github/workflows/gate-evidence.yml
@@ -8,8 +8,10 @@ name: Gate evidence
 # already enforces. Until then it runs and reports but does not block merge.
 #
 # Skipped entirely while the PR is a draft (draft_gate is not required yet, and a
-# draft PR cannot be merged regardless); GitHub Actions treats a skipped job on a
-# required check as passing, so this never blocks draft work.
+# draft PR cannot be merged regardless). A skipped run posts no `gate-evidence`
+# status at all, leaving the required check pending rather than passing — fine,
+# since a draft PR is never mergeable anyway. The first non-draft run (at
+# latest, ready_for_review) always posts a real status once merge is possible.
 #
 # One inherent limitation of a head-run check (accepted by design, not a
 # bypass): head-provenance — the workflow and the scripts it runs come from the
@@ -21,15 +23,27 @@ name: Gate evidence
 #
 # Trigger staleness (the thread/comment axis) was a real gap: the verdict
 # depends on PR comment history + thread resolution, and pull_request events
-# don't re-fire when a thread is opened/resolved or a review is submitted.
-# Head staleness was always fail-closed (a new commit re-triggers synchronize);
-# closed here by also re-firing on pull_request_review (review submitted,
-# which can add unresolved threads) and pull_request_review_thread
-# (resolved/unresolved) — both fire on the base repo's own token regardless of
-# whether the PR head is a fork, and both carry the same `pull_request` object
-# (number, draft, ...) that this workflow already reads. So a NEW unresolved
-# thread, or a submitted review, re-evaluates this check instead of leaving a
-# SHA-pinned green stale until the next push.
+# don't re-fire when a thread is opened/resolved, a review is submitted, or a
+# standalone review comment opens a thread. Closed by also re-firing on
+# pull_request_review (submitted), pull_request_review_thread
+# (resolved/unresolved), and pull_request_review_comment (created) — all fire
+# on the base repo's own token regardless of whether the PR head is a fork,
+# and all carry the same `pull_request` object (number, draft, head.sha, ...)
+# this workflow already reads.
+#
+# Head-SHA mismatch on those three event types: unlike `pull_request` (whose
+# implicit job check-run GitHub auto-associates with the PR's head commit),
+# `github.sha` for pull_request_review/_thread/_comment events is the BASE
+# branch's latest commit, not the PR head. An implicit check-run from those
+# triggers would land on the wrong commit and never refresh the required
+# check on the head — the exact staleness this workflow exists to close. So
+# the job posts an EXPLICIT commit status to `pull_request.head.sha` (always
+# the right commit, on every trigger type) instead of relying on the
+# job's own auto-attached check-run. To avoid two different reporters (the
+# job's own check-run + this explicit status) both claiming the required
+# `gate-evidence` context — which GitHub's docs warn is ambiguous — the job
+# itself is named something else; the explicit status below is the ONLY
+# thing that ever reports context `gate-evidence`.
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -37,14 +51,17 @@ on:
     types: [submitted]
   pull_request_review_thread:
     types: [resolved, unresolved]
+  pull_request_review_comment:
+    types: [created]
 
 permissions:
   contents: read
   pull-requests: read
   issues: read
+  statuses: write
 
 jobs:
-  gate-evidence:
+  gate-evidence-runner:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
@@ -67,11 +84,40 @@ jobs:
       # still enforces the part that IS remotely verifiable: a clean draft_gate
       # verdict, and a clean pre_approval_gate verdict on the current head,
       # including the documented light-mode inline exception.
+      #
+      # set +e: a non-zero exit must still reach the status-reporting step
+      # below (posting a red status) rather than aborting the job with no
+      # status posted at all, which would leave the required check pending
+      # forever instead of failing closed.
       - name: Verify draft_gate / pre_approval_gate evidence
+        id: gate_check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set +e
           node scripts/github/detect-checkpoint-evidence.mjs \
             --repo "${{ github.repository }}" \
             --pr "${{ github.event.pull_request.number }}" \
             --skip-fanout-ledger-check
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      # The only step that reports context `gate-evidence` (see the header
+      # comment on `on:` above for why this can't be the job's own implicit
+      # check-run). Always posts — success only when the detector step above
+      # actually ran and exited 0 — so a missing/empty exit_code (e.g. an
+      # earlier checkout/npm-ci failure that skipped the detector step) fails
+      # closed to `failure`, never leaves the head SHA with no status.
+      - name: Report gate-evidence status on the PR head SHA
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          state="failure"
+          if [ "${{ steps.gate_check.outputs.exit_code }}" = "0" ]; then
+            state="success"
+          fi
+          gh api --method POST "repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" \
+            -f "state=${state}" \
+            -f "context=gate-evidence" \
+            -f "target_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            -f "description=draft_gate/pre_approval_gate evidence check"

--- a/skills/docs/merge-preconditions.md
+++ b/skills/docs/merge-preconditions.md
@@ -63,13 +63,16 @@ practice:
   dev-loop tooling calls before merging.
 - **Server-side:** the `gate-evidence` status check
   (`.github/workflows/gate-evidence.yml`) re-runs the same verdict check on
-  GitHub's own token for every non-draft PR. This is what closes the ready/merge
-  bypass — a direct GitHub API call (MCP/REST, web UI, a raw `gh` invocation
-  outside the hook) skips the client-side path entirely but still cannot merge
-  without a green `gate-evidence` check **once branch protection on `main`
-  requires it**. Until an operator adds it to branch protection, the check runs
-  and reports on every non-draft PR but does **not** yet block merge — it is
-  reporting-only in that window.
+  GitHub's own token for every non-draft PR, re-firing on push, ready-for-review,
+  a submitted review, and thread resolve/unresolve — so a newly-opened
+  unresolved thread re-evaluates the check instead of leaving a SHA-pinned green
+  stale on the thread axis. This is what closes the ready/merge bypass — a
+  direct GitHub API call (MCP/REST, web UI, a raw `gh` invocation outside the
+  hook) skips the client-side path entirely but still cannot merge without a
+  green `gate-evidence` check **once branch protection on `main` requires it**.
+  Until an operator adds it to branch protection, the check runs and reports on
+  every non-draft PR but does **not** yet block merge — it is reporting-only in
+  that window.
 
 The server-side check verifies the same visible, comment-derived verdict fields
 the client-side tooling does (including the light-mode inline exception,

--- a/skills/docs/merge-preconditions.md
+++ b/skills/docs/merge-preconditions.md
@@ -64,9 +64,16 @@ practice:
 - **Server-side:** the `gate-evidence` status check
   (`.github/workflows/gate-evidence.yml`) re-runs the same verdict check on
   GitHub's own token for every non-draft PR, re-firing on push, ready-for-review,
-  a submitted review, thread resolve/unresolve, and a standalone review comment
-  — so a newly-opened unresolved thread re-evaluates the check instead of
-  leaving a SHA-pinned green stale on the thread axis. The `gate-evidence`
+  a submitted review, and a standalone review comment — so a newly-opened
+  unresolved thread re-evaluates the check instead of leaving a SHA-pinned green
+  stale on the thread axis. (There is no `pull_request_review_thread` Actions
+  trigger, so thread resolve/unresolve is not itself a re-fire event; a
+  newly-appearing unresolved thread arrives via a submitted review or a review
+  comment, both of which do re-fire. One narrow residual remains: a bare
+  "Unresolve conversation" UI action on an already-resolved thread, with no
+  accompanying review or comment, fires only that non-triggerable event and so
+  does not re-fire the check — bounded by the maintainer-gated merge, and
+  re-caught on the next push, review, or comment.) The `gate-evidence`
   context itself is always an explicit commit status posted to the PR's actual
   head SHA (not the triggering job's own check-run, which for the
   review/thread/comment event types would land on the base branch's latest

--- a/skills/docs/merge-preconditions.md
+++ b/skills/docs/merge-preconditions.md
@@ -64,10 +64,14 @@ practice:
 - **Server-side:** the `gate-evidence` status check
   (`.github/workflows/gate-evidence.yml`) re-runs the same verdict check on
   GitHub's own token for every non-draft PR, re-firing on push, ready-for-review,
-  a submitted review, and thread resolve/unresolve — so a newly-opened
-  unresolved thread re-evaluates the check instead of leaving a SHA-pinned green
-  stale on the thread axis. This is what closes the ready/merge bypass — a
-  direct GitHub API call (MCP/REST, web UI, a raw `gh` invocation outside the
+  a submitted review, thread resolve/unresolve, and a standalone review comment
+  — so a newly-opened unresolved thread re-evaluates the check instead of
+  leaving a SHA-pinned green stale on the thread axis. The `gate-evidence`
+  context itself is always an explicit commit status posted to the PR's actual
+  head SHA (not the triggering job's own check-run, which for the
+  review/thread/comment event types would land on the base branch's latest
+  commit instead of the PR head). This is what closes the ready/merge bypass —
+  a direct GitHub API call (MCP/REST, web UI, a raw `gh` invocation outside the
   hook) skips the client-side path entirely but still cannot merge without a
   green `gate-evidence` check **once branch protection on `main` requires it**.
   Until an operator adds it to branch protection, the check runs and reports on

--- a/test/github/gate-evidence-workflow.test.mjs
+++ b/test/github/gate-evidence-workflow.test.mjs
@@ -5,7 +5,7 @@ import { assert, readRepo, test } from "../imported-assets-helpers.mjs";
 // just push/ready), so a required green check can't go stale on the thread
 // axis. Head-staleness (synchronize) and the draft no-op guard must survive
 // unchanged.
-test("gate-evidence workflow re-fires on review submission and thread resolve/unresolve", async () => {
+test("gate-evidence workflow re-fires on review submission, thread resolve/unresolve, and standalone review comments", async () => {
   const content = await readRepo(".github/workflows/gate-evidence.yml");
   const workflow = parseYaml(content);
   const triggers = workflow.on;
@@ -13,9 +13,33 @@ test("gate-evidence workflow re-fires on review submission and thread resolve/un
   assert.deepEqual(triggers.pull_request.types, ["opened", "synchronize", "reopened", "ready_for_review"]);
   assert.deepEqual(triggers.pull_request_review.types, ["submitted"]);
   assert.deepEqual(triggers.pull_request_review_thread.types, ["resolved", "unresolved"]);
+  assert.deepEqual(triggers.pull_request_review_comment.types, ["created"]);
 
+  const job = workflow.jobs["gate-evidence-runner"];
   // Draft PRs must still no-op regardless of which event triggered the run —
-  // pull_request_review and pull_request_review_thread payloads carry the same
-  // pull_request.draft field as pull_request events.
-  assert.equal(workflow.jobs["gate-evidence"].if, "github.event.pull_request.draft == false");
+  // every added event type carries the same pull_request.draft field pull_request
+  // events do.
+  assert.equal(job.if, "github.event.pull_request.draft == false");
+  assert.equal(workflow.permissions.statuses, "write");
+});
+
+// Pins the #1385 gate-review must-fix: pull_request_review/_thread/_comment
+// events set github.sha to the BASE branch's latest commit, not the PR head, so
+// the job's own implicit check-run would land on the wrong commit for those
+// triggers. The fix posts an explicit commit status to the PR's real head SHA
+// instead, and no job may be named `gate-evidence` (that would create a second,
+// base-SHA-pinned reporter racing the explicit head-SHA status under the same
+// required context).
+test("gate-evidence posts an explicit status to the PR head SHA, not the job's own check-run", async () => {
+  const content = await readRepo(".github/workflows/gate-evidence.yml");
+  const workflow = parseYaml(content);
+
+  assert.ok(!("gate-evidence" in workflow.jobs), "no job may be named gate-evidence — that context is reserved for the explicit head-SHA status");
+
+  const steps = workflow.jobs["gate-evidence-runner"].steps;
+  const statusStep = steps.find((step) => typeof step.run === "string" && step.run.includes("gh api --method POST"));
+  assert.ok(statusStep, "expected a step posting an explicit commit status");
+  assert.equal(statusStep.if, "always()");
+  assert.match(statusStep.run, /statuses\/\$\{\{ github\.event\.pull_request\.head\.sha \}\}/);
+  assert.match(statusStep.run, /context=gate-evidence/);
 });

--- a/test/github/gate-evidence-workflow.test.mjs
+++ b/test/github/gate-evidence-workflow.test.mjs
@@ -1,19 +1,31 @@
 import { parse as parseYaml } from "yaml";
 import { assert, readRepo, test } from "../imported-assets-helpers.mjs";
 
-// Pins #1385: gate-evidence must re-fire on review-thread state changes (not
-// just push/ready), so a required green check can't go stale on the thread
-// axis. Head-staleness (synchronize) and the draft no-op guard must survive
-// unchanged.
-test("gate-evidence workflow re-fires on review submission, thread resolve/unresolve, and standalone review comments", async () => {
+// Pins #1385: gate-evidence must re-fire when a NEW unresolved thread can appear
+// (review submitted, or a review comment opens a thread) — so a required green
+// check can't go stale on the thread axis. Head-staleness (synchronize) and the
+// draft no-op guard must survive unchanged. NOTE: GitHub Actions has NO
+// `pull_request_review_thread` workflow trigger (thread resolve/unresolve is a
+// webhook but not an `on:` event); using it makes the whole workflow file
+// server-side-invalid, so it must never be added.
+const VALID_PR_WORKFLOW_EVENTS = new Set([
+  "pull_request", "pull_request_target", "pull_request_review", "pull_request_review_comment",
+]);
+test("gate-evidence workflow re-fires on review submission and standalone review comments, with only valid Actions triggers", async () => {
   const content = await readRepo(".github/workflows/gate-evidence.yml");
   const workflow = parseYaml(content);
   const triggers = workflow.on;
 
   assert.deepEqual(triggers.pull_request.types, ["opened", "synchronize", "reopened", "ready_for_review"]);
   assert.deepEqual(triggers.pull_request_review.types, ["submitted"]);
-  assert.deepEqual(triggers.pull_request_review_thread.types, ["resolved", "unresolved"]);
   assert.deepEqual(triggers.pull_request_review_comment.types, ["created"]);
+
+  // Guard against a recurrence of the invalid `pull_request_review_thread` trigger
+  // (and any other non-existent event) that GitHub's parser rejects wholesale.
+  assert.ok(!("pull_request_review_thread" in triggers), "pull_request_review_thread is not a valid Actions trigger");
+  for (const event of Object.keys(triggers)) {
+    assert.ok(VALID_PR_WORKFLOW_EVENTS.has(event), `unknown/invalid workflow trigger: ${event}`);
+  }
 
   const job = workflow.jobs["gate-evidence-runner"];
   // Draft PRs must still no-op regardless of which event triggered the run —

--- a/test/github/gate-evidence-workflow.test.mjs
+++ b/test/github/gate-evidence-workflow.test.mjs
@@ -1,0 +1,21 @@
+import { parse as parseYaml } from "yaml";
+import { assert, readRepo, test } from "../imported-assets-helpers.mjs";
+
+// Pins #1385: gate-evidence must re-fire on review-thread state changes (not
+// just push/ready), so a required green check can't go stale on the thread
+// axis. Head-staleness (synchronize) and the draft no-op guard must survive
+// unchanged.
+test("gate-evidence workflow re-fires on review submission and thread resolve/unresolve", async () => {
+  const content = await readRepo(".github/workflows/gate-evidence.yml");
+  const workflow = parseYaml(content);
+  const triggers = workflow.on;
+
+  assert.deepEqual(triggers.pull_request.types, ["opened", "synchronize", "reopened", "ready_for_review"]);
+  assert.deepEqual(triggers.pull_request_review.types, ["submitted"]);
+  assert.deepEqual(triggers.pull_request_review_thread.types, ["resolved", "unresolved"]);
+
+  // Draft PRs must still no-op regardless of which event triggered the run —
+  // pull_request_review and pull_request_review_thread payloads carry the same
+  // pull_request.draft field as pull_request events.
+  assert.equal(workflow.jobs["gate-evidence"].if, "github.event.pull_request.draft == false");
+});


### PR DESCRIPTION
Closes #1385

## Problem

The `gate-evidence` server-side check is triggered by `pull_request` events `[opened, synchronize, reopened, ready_for_review]`. Its verdict depends on review-thread resolution state, but those events don't re-fire when a thread is opened/resolved — so a green check could go **stale on the thread axis** (a new unresolved thread after the check wouldn't re-fire it). With `gate-evidence` made a **required** branch-protection check on this repo (the #1358 operator step — the shipped default stays reporting-only until a consumer opts it into branch protection), that stale-green window was live on the merge path here.

## Decision: broaden the triggers, and pin the reported context to the PR head SHA

`detect-checkpoint-evidence.mjs` fetches the live PR head SHA + comments by `--repo`/`--pr`, independent of which event triggered the workflow, so no script change was needed. Broadening `on:` to `pull_request_review` (submitted) and `pull_request_review_comment` (created) re-fires the check on the two events through which a NEW unresolved thread appears (the stale-green direction this closes). (`pull_request_review_thread` is a webhook but NOT a valid Actions `on:` trigger — including it made the whole workflow file server-side-invalid, caught by actionlint; it was removed and a test guard now rejects any invalid trigger.)

Gate review caught the real gap in the first cut: for those three event types, `github.sha` (and the job's own implicit check-run) resolves to the **base branch's latest commit**, not the PR head — branch protection evaluates the required `gate-evidence` context on the head SHA, so a thread-triggered re-fire was landing on the wrong commit and never actually refreshing the required check. Fixed by having the job (renamed off `gate-evidence` so it can't become a second, base-SHA-pinned reporter racing the real one) post an **explicit commit status** via `gh api .../statuses/{head_sha}` with context `gate-evidence`, targeting `pull_request.head.sha` on every trigger. `set +e` around the detector plus `if: always()` on the status step means a failed or skipped detector still posts a red status rather than leaving the required check stuck pending.

`skills/docs/merge-preconditions.md` (+ its `.claude` mirror) now describes both the re-fire triggers and the explicit head-SHA status mechanism.

## Validation

- `test/github/gate-evidence-workflow.test.mjs` pins the trigger types, the `statuses: write` permission, the head-SHA status step (context + target), and that no job is named `gate-evidence`.
- `npm run verify` carries the same 15 pre-existing `reconcile-draft-gate` / `detect-checkpoint-evidence` wall-clock/stale-runner-lock fixture failures (reproduce on the unmodified base) — unrelated to this change.

## Non-goals

- No move to a merge-queue (`merge_group`) trigger — broadening the existing `pull_request`-triggered check plus the head-SHA status fix is sufficient for same-repo PRs.
- No `detect-checkpoint-evidence.mjs` change — it's event-type-agnostic.


