### PR TITLE
docs: close out deferred tracker-first routing as won't-do; align entrypoint-strategies (#1372)

### DIFF
--- a/.claude/skills/docs/entrypoint-strategies.md
+++ b/.claude/skills/docs/entrypoint-strategies.md
@@ -81,23 +81,9 @@ Required reading:
 
 ## Tracker-first
 
-**Strategy:** `tracker_first` (reserved for future `dev-loop` routing when tracker context detected)
+**Decision: won't-do.** There is no `tracker_first` route in `resolve-dev-loop-startup.mjs`, and none is planned. Tracker-backed work is shipped as an **input-source** addition to the existing `local_implementation` strategy (see [Tracker-backed local implementation input-source contract](public-dev-loop-contract.md#tracker-backed-local-implementation-input-source-contract) and the [Local Implementation SKILL](../local-implementation/SKILL.md#tracker-backed-local-implementation)) — not a separate routing family or public workflow entrypoint. That framing is coherent and shipped; a peer `tracker_first` strategy is not needed on top of it.
 
-**Purpose:** Tracker-first workflow for story/epic tracker items that follow a PR-based GitHub execution path.
-
-**Routing status:** Routing integration in `resolve-dev-loop-startup.mjs` is deferred (no `tracker_first` route exists yet). This briefing documents the intended contract surface; the state machine and detector are implemented and tested.
-
-**Key artifacts:**
-- Tracker issue (canonical spec)
-- [Tracker-First Loop State](tracker-first-loop-state.md) — state machine doc
-- `detect-tracker-first-loop-state.mjs` — loop state detector
-- `detect-tracker-pr-state.mjs` — PR-level state detector
-
-**Routing:** `dev-loop` will resolve to tracker-first when a tracker context is detected (issue has tracker labels, is a tracker-backed issue). Fail-closed: unknown tracker state → `needs_triage`.
-
-**State vocabulary:** `drafting`, `needs_triage`, `in_progress`, `in_review`, `merge_ready`, `blocked`, `completed`, `unknown`
-
-**Interface contract:** Same as Copilot loop: `{ ok, state, snapshot, allowedTransitions, nextAction }`
+**Standalone tooling (not routed by `dev-loop`):** [Tracker-First Loop State](tracker-first-loop-state.md) documents a PR-level and loop-level state machine with its own detectors (`detect-tracker-first-loop-state.mjs`, `detect-tracker-pr-state.mjs`). These are implemented and tested, but `resolve-dev-loop-startup.mjs` never dispatches to them and the `dev-loops` CLI wrapper does not expose them under `loop loop-state` (that command maps to the Copilot loop detector instead). Treat them as standalone, directly-invoked tools, not as part of the routed strategy list above.
 
 ## Wait / watch
 

--- a/skills/docs/entrypoint-strategies.md
+++ b/skills/docs/entrypoint-strategies.md
@@ -81,23 +81,9 @@ Required reading:
 
 ## Tracker-first
 
-**Strategy:** `tracker_first` (reserved for future `dev-loop` routing when tracker context detected)
+**Decision: won't-do.** There is no `tracker_first` route in `resolve-dev-loop-startup.mjs`, and none is planned. Tracker-backed work is shipped as an **input-source** addition to the existing `local_implementation` strategy (see [Tracker-backed local implementation input-source contract](public-dev-loop-contract.md#tracker-backed-local-implementation-input-source-contract) and the [Local Implementation SKILL](../local-implementation/SKILL.md#tracker-backed-local-implementation)) — not a separate routing family or public workflow entrypoint. That framing is coherent and shipped; a peer `tracker_first` strategy is not needed on top of it.
 
-**Purpose:** Tracker-first workflow for story/epic tracker items that follow a PR-based GitHub execution path.
-
-**Routing status:** Routing integration in `resolve-dev-loop-startup.mjs` is deferred (no `tracker_first` route exists yet). This briefing documents the intended contract surface; the state machine and detector are implemented and tested.
-
-**Key artifacts:**
-- Tracker issue (canonical spec)
-- [Tracker-First Loop State](tracker-first-loop-state.md) — state machine doc
-- `detect-tracker-first-loop-state.mjs` — loop state detector
-- `detect-tracker-pr-state.mjs` — PR-level state detector
-
-**Routing:** `dev-loop` will resolve to tracker-first when a tracker context is detected (issue has tracker labels, is a tracker-backed issue). Fail-closed: unknown tracker state → `needs_triage`.
-
-**State vocabulary:** `drafting`, `needs_triage`, `in_progress`, `in_review`, `merge_ready`, `blocked`, `completed`, `unknown`
-
-**Interface contract:** Same as Copilot loop: `{ ok, state, snapshot, allowedTransitions, nextAction }`
+**Standalone tooling (not routed by `dev-loop`):** [Tracker-First Loop State](tracker-first-loop-state.md) documents a PR-level and loop-level state machine with its own detectors (`detect-tracker-first-loop-state.mjs`, `detect-tracker-pr-state.mjs`). These are implemented and tested, but `resolve-dev-loop-startup.mjs` never dispatches to them and the `dev-loops` CLI wrapper does not expose them under `loop loop-state` (that command maps to the Copilot loop detector instead). Treat them as standalone, directly-invoked tools, not as part of the routed strategy list above.
 
 ## Wait / watch
 


### PR DESCRIPTION
Closes #1372

## Decision: won't-do the tracker-first routing integration; align the one misaligned doc

#1372 asked to either complete the deferred tracker-first routing integration (#449) or formally close it out and align the docs. Re-verifying shows the shipped design is already coherent and the docs are **almost** all correct — only one doc described a routing family that doesn't exist.

### Re-verify findings

- `scripts/loop/resolve-dev-loop-startup.mjs`: 0 matches for `tracker_first`/`tracker-first` as a routing family — tracker-backed work is an `inputSource` value (`tracker` vs `phase-docs`) feeding the existing `local_implementation` strategy.
- `skills/docs/public-dev-loop-contract.md`, `skills/local-implementation/SKILL.md`, `skills/docs/artifact-authority-contract.md`: **already** frame tracker-backed as an input-source addition ("does not create a new routing mode, strategy family, or public workflow entrypoint") — no change needed.
- The one real gap: `skills/docs/entrypoint-strategies.md`'s "Tracker-first" section listed `tracker_first` as a peer strategy with a "Routing: `dev-loop` will resolve to tracker-first…" line — describing behavior that doesn't exist and isn't planned.
- The tracker-first state-machine detectors (`detect-tracker-first-loop-state.mjs` etc.) are real, tested standalone tools, but genuinely orphaned from routing/CLI dispatch (`dev-loops loop loop-state` maps to `detect-copilot-loop-state.mjs`).

## What changed

- **`skills/docs/entrypoint-strategies.md`** (+ regenerated `.claude` mirror) — the "Tracker-first" section now records the won't-do decision: no route exists or is planned; tracker-backed work stays an input-source addition to `local_implementation`; the loop-state detectors are standalone tooling, not a routed strategy.

## Validation

- `test:docs` + `test:assets` green (incl. `public-facade-doc-contracts.test.mjs`, which pins the input-source framing); `generate-claude-assets --check` → `{"ok":true,"checked":70}`.
- Repo-wide sweep confirms no residual unshipped-routing references remain.
- The same 15 pre-existing `reconcile-draft-gate` / `detect-checkpoint-evidence` wall-clock fixture failures reproduce on the unmodified base — unrelated to this docs-only change.

## Non-goals

- No new `tracker_first` routing family built (the input-source design is coherent and shipped); no change to the standalone tracker-first detectors.
