### PR TITLE
feat(ci): actionlint semantic validation for workflow files in verify (#1409)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,14 +99,25 @@ jobs:
       - name: Install workspace dependencies
         run: npm ci
 
-      # Pinned to match scripts/github/lint-workflows.mjs's ACTIONLINT_VERSION —
-      # keep both in sync. Only this matrix leg needs the binary; putting it on
-      # PATH via GITHUB_PATH lets test:workflows find the plain `actionlint`
-      # command exactly like a local install would.
+      # Pinned version + sha256 must match scripts/github/lint-workflows.mjs's
+      # ACTIONLINT_VERSION / ACTIONLINT_LINUX_AMD64_SHA256 (a test asserts it).
+      # Downloads the release archive directly and verifies its checksum before
+      # extracting — a supply-chain trust boundary, not just a version pin.
+      # Only this matrix leg needs the binary; putting it on PATH via
+      # GITHUB_PATH lets test:workflows find the plain `actionlint` command
+      # exactly like a local install would.
       - name: Install actionlint
         if: matrix.suite == 'test:workflows'
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+          ACTIONLINT_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
         run: |
-          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12 "$RUNNER_TEMP"
+          set -euo pipefail
+          archive="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -fsSL -o "$RUNNER_TEMP/$archive" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${archive}"
+          echo "${ACTIONLINT_SHA256}  $RUNNER_TEMP/$archive" | sha256sum -c -
+          tar xzf "$RUNNER_TEMP/$archive" -C "$RUNNER_TEMP" actionlint
           echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
 
       - name: Run ${{ matrix.suite }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
           - test:docs
           - test:pack
           - test:dev-loop
+          - test:workflows
 
     steps:
       - name: Check out repository
@@ -97,6 +98,16 @@ jobs:
 
       - name: Install workspace dependencies
         run: npm ci
+
+      # Pinned to match scripts/github/lint-workflows.mjs's ACTIONLINT_VERSION —
+      # keep both in sync. Only this matrix leg needs the binary; putting it on
+      # PATH via GITHUB_PATH lets test:workflows find the plain `actionlint`
+      # command exactly like a local install would.
+      - name: Install actionlint
+        if: matrix.suite == 'test:workflows'
+        run: |
+          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12 "$RUNNER_TEMP"
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
 
       - name: Run ${{ matrix.suite }}
         run: npm run ${{ matrix.suite }}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "packages/*"
   ],
   "scripts": {
-    "verify": "run-p --aggregate-output --continue-on-error test:assets test:extension test:scripts test:core test:docs test:pack test:dev-loop",
+    "verify": "run-p --aggregate-output --continue-on-error test:assets test:extension test:scripts test:core test:docs test:pack test:dev-loop test:workflows",
     "test": "run-p --aggregate-output --continue-on-error test:assets test:extension test:scripts test:core test:docs test:pack",
     "test:assets": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/dev-loop-init-phase-smoke.test.mjs test/contracts/*.test.mjs test/workflow-handoff-contract.test.mjs",
     "test:doc-guard": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/contracts/*.test.mjs test/workflow-handoff-contract.test.mjs",
@@ -37,6 +37,7 @@
     "test:playwright:deep-dive-article": "PW_UI_SLICE=deep-dive-article playwright test --project=deep-dive-article",
     "smoke:headless": "node scripts/claude/headless-info-smoke.mjs",
     "test:docs": "node scripts/docs/validate-links.mjs && node scripts/docs/validate-rule-ownership.mjs",
+    "test:workflows": "node scripts/github/lint-workflows.mjs",
     "test:pack": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/packaged-install-smoke.test.mjs",
     "schema:generate": "node scripts/generate-config-schema.mjs",
     "schema:check": "node scripts/generate-config-schema.mjs --check",

--- a/scripts/github/lint-workflows.mjs
+++ b/scripts/github/lint-workflows.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// GitHub-Actions-semantic validation for .github/workflows/*.yml (issue #1409,
+// root cause #1385): gate-evidence-workflow.test.mjs only YAML-parses the
+// workflow file, so an invalid Actions construct (e.g. the
+// `pull_request_review_thread` non-event that #1385 shipped) is syntactically
+// valid YAML and slips straight through review. actionlint understands Actions
+// semantics (valid `on:` events, expression syntax, permissions, shellcheck of
+// `run:` steps) and GitHub rejects the whole workflow server-side on the same
+// class of error, so this is the real backstop.
+//
+// actionlint is a Go binary, not an npm dependency, so it is not guaranteed to
+// be on a contributor's PATH. Missing binary -> warn and exit 0 (never blocks
+// local `npm run verify` on a tooling-availability gap). A real lint FINDING
+// with the binary present -> exit non-zero, same as any other failing verify
+// leg. CI always installs the pinned version below, so the enforcement itself
+// never has a way to no-op.
+import { spawnSync } from "node:child_process";
+import { isDirectCliRun } from "../_core-helpers.mjs";
+import { resolveRepoRoot } from "../loop/_repo-root-resolver.mjs";
+
+// Keep in sync with the `Install actionlint` step in .github/workflows/ci.yml.
+export const ACTIONLINT_VERSION = "1.7.12";
+
+export function runActionlint(args, { cwd = process.cwd(), actionlintBin = "actionlint" } = {}) {
+  return spawnSync(actionlintBin, args, { cwd, encoding: "utf8" });
+}
+
+function main() {
+  const repoRoot = resolveRepoRoot(process.cwd());
+  const result = runActionlint([], { cwd: repoRoot });
+
+  if (result.error) {
+    if (result.error.code === "ENOENT") {
+      console.warn(
+        `actionlint not installed — install to lint workflows locally (pinned v${ACTIONLINT_VERSION}: `
+        + "https://github.com/rhysd/actionlint/releases); enforced in CI.",
+      );
+      process.exit(0);
+    }
+    console.error(`actionlint failed to run: ${result.error.message}`);
+    process.exit(1);
+  }
+
+  process.stdout.write(result.stdout ?? "");
+  process.stderr.write(result.stderr ?? "");
+  process.exit(result.status ?? 1);
+}
+
+if (isDirectCliRun(import.meta.url)) main();

--- a/scripts/github/lint-workflows.mjs
+++ b/scripts/github/lint-workflows.mjs
@@ -12,14 +12,20 @@
 // be on a contributor's PATH. Missing binary -> warn and exit 0 (never blocks
 // local `npm run verify` on a tooling-availability gap). A real lint FINDING
 // with the binary present -> exit non-zero, same as any other failing verify
-// leg. CI always installs the pinned version below, so the enforcement itself
-// never has a way to no-op.
+// leg. The CI PR matrix's `test:workflows` leg always installs the pinned
+// version below first, so THAT leg's enforcement is real. Other `npm run
+// verify` callers that don't install actionlint (e.g. npm-publish.yml) still
+// hit the same ENOENT -> warn-and-skip path; they rely on the PR matrix leg
+// having already enforced this before merge.
 import { spawnSync } from "node:child_process";
 import { isDirectCliRun } from "../_core-helpers.mjs";
 import { resolveRepoRoot } from "../loop/_repo-root-resolver.mjs";
 
-// Keep in sync with the `Install actionlint` step in .github/workflows/ci.yml.
+// Single source of truth for the pinned version + archive checksum; a test
+// asserts .github/workflows/ci.yml's "Install actionlint" step matches both,
+// so a version bump can't silently desync the two.
 export const ACTIONLINT_VERSION = "1.7.12";
+export const ACTIONLINT_LINUX_AMD64_SHA256 = "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8";
 
 export function runActionlint(args, { cwd = process.cwd(), actionlintBin = "actionlint" } = {}) {
   return spawnSync(actionlintBin, args, { cwd, encoding: "utf8" });

--- a/test/fixtures/workflows/invalid-on-trigger.yml
+++ b/test/fixtures/workflows/invalid-on-trigger.yml
@@ -1,0 +1,17 @@
+# Deliberately-broken workflow fixture for the lint-workflows.mjs negative test
+# (issue #1409, root cause #1385): `pull_request_review_thread` is a webhook
+# event, not a valid GitHub Actions `on:` trigger, so this whole file is
+# server-side-invalid — exactly the failure mode actionlint must catch before
+# review. Lives OUTSIDE .github/workflows/ on purpose: GitHub Actions would try
+# (and fail) to run it if it were a real workflow file in that directory.
+name: Deliberately invalid fixture — do not move into .github/workflows
+
+on:
+  pull_request_review_thread:
+    types: [resolved]
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "should never run"

--- a/test/github/lint-workflows.test.mjs
+++ b/test/github/lint-workflows.test.mjs
@@ -1,8 +1,16 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, copyFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
-import { runActionlint } from "../../scripts/github/lint-workflows.mjs";
+import { fileURLToPath } from "node:url";
+import { ACTIONLINT_LINUX_AMD64_SHA256, ACTIONLINT_VERSION, runActionlint } from "../../scripts/github/lint-workflows.mjs";
 
 const FIXTURE_PATH = "test/fixtures/workflows/invalid-on-trigger.yml";
+const FIXTURE_ABS_PATH = fileURLToPath(new URL(`../../${FIXTURE_PATH}`, import.meta.url));
+const SCRIPT_PATH = fileURLToPath(new URL("../../scripts/github/lint-workflows.mjs", import.meta.url));
+const CI_YML_PATH = fileURLToPath(new URL("../../.github/workflows/ci.yml", import.meta.url));
 
 // Negative test for #1409 (root cause #1385): proves the actionlint wiring
 // actually catches a server-side-invalid workflow (unknown `on:` event), the
@@ -21,4 +29,55 @@ test("actionlint flags the deliberately-invalid on: trigger fixture", (t) => {
 
   assert.notEqual(result.status, 0, "actionlint should fail on the invalid on: trigger fixture");
   assert.match(result.stdout, /pull_request_review_thread/);
+});
+
+// Covers the actual enforcement seam: main()'s skip-vs-fail exit codes. Runs
+// the script as a real child process (main() calls process.exit(), so it
+// can't be asserted in-process) with a controlled PATH so the binary-absent
+// branch is exercised deterministically regardless of what's installed on the
+// machine running this test.
+test("main() exits 0 with an install-hint warning when actionlint is absent from PATH", () => {
+  const result = spawnSync(process.execPath, [SCRIPT_PATH], {
+    encoding: "utf8",
+    // No actionlint on this PATH — only node itself, so `git` also 404s
+    // (resolveRepoRoot falls back to cwd, which is fine either way).
+    env: { PATH: path.dirname(process.execPath) },
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout + result.stderr, /actionlint not installed/);
+});
+
+test("main() exits non-zero when actionlint runs against the invalid-on-trigger fixture", (t) => {
+  const probe = runActionlint(["-version"]);
+  if (probe.error?.code === "ENOENT") {
+    t.skip("actionlint not installed locally — enforced in CI");
+    return;
+  }
+
+  // main() lints whatever .github/workflows/ actionlint auto-detects from cwd
+  // (no file args), so give it a throwaway repo root whose only workflow is
+  // the deliberately-broken fixture.
+  const tmpRoot = mkdtempSync(path.join(tmpdir(), "lint-workflows-main-"));
+  try {
+    const workflowsDir = path.join(tmpRoot, ".github", "workflows");
+    mkdirSync(workflowsDir, { recursive: true });
+    copyFileSync(FIXTURE_ABS_PATH, path.join(workflowsDir, "invalid.yml"));
+
+    const result = spawnSync(process.execPath, [SCRIPT_PATH], { cwd: tmpRoot, encoding: "utf8" });
+
+    assert.notEqual(result.status, 0);
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+// Cheap defer: keeps ci.yml's "Install actionlint" step from silently
+// desyncing from the version/checksum this script warns about and the
+// negative test above proves works.
+test("ci.yml's pinned actionlint version + checksum match lint-workflows.mjs", () => {
+  const ciYml = readFileSync(CI_YML_PATH, "utf8");
+
+  assert.match(ciYml, new RegExp(`ACTIONLINT_VERSION: "${ACTIONLINT_VERSION}"`));
+  assert.match(ciYml, new RegExp(`ACTIONLINT_SHA256: "${ACTIONLINT_LINUX_AMD64_SHA256}"`));
 });

--- a/test/github/lint-workflows.test.mjs
+++ b/test/github/lint-workflows.test.mjs
@@ -37,15 +37,23 @@ test("actionlint flags the deliberately-invalid on: trigger fixture", (t) => {
 // branch is exercised deterministically regardless of what's installed on the
 // machine running this test.
 test("main() exits 0 with an install-hint warning when actionlint is absent from PATH", () => {
-  const result = spawnSync(process.execPath, [SCRIPT_PATH], {
-    encoding: "utf8",
-    // No actionlint on this PATH — only node itself, so `git` also 404s
-    // (resolveRepoRoot falls back to cwd, which is fine either way).
-    env: { PATH: path.dirname(process.execPath) },
-  });
+  // Point PATH at a guaranteed-empty dir (not node's own bindir, which on some
+  // installs — Homebrew, /usr/bin — also holds actionlint) so the binary-absent
+  // branch is exercised deterministically regardless of the host. The child is
+  // spawned via the absolute node path, so node needs no PATH; actionlint and
+  // git both ENOENT (resolveRepoRoot falls back to cwd, which is fine).
+  const emptyDir = mkdtempSync(path.join(tmpdir(), "lint-workflows-nopath-"));
+  try {
+    const result = spawnSync(process.execPath, [SCRIPT_PATH], {
+      encoding: "utf8",
+      env: { PATH: emptyDir },
+    });
 
-  assert.equal(result.status, 0);
-  assert.match(result.stdout + result.stderr, /actionlint not installed/);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout + result.stderr, /actionlint not installed/);
+  } finally {
+    rmSync(emptyDir, { recursive: true, force: true });
+  }
 });
 
 test("main() exits non-zero when actionlint runs against the invalid-on-trigger fixture", (t) => {

--- a/test/github/lint-workflows.test.mjs
+++ b/test/github/lint-workflows.test.mjs
@@ -78,6 +78,8 @@ test("main() exits non-zero when actionlint runs against the invalid-on-trigger 
 test("ci.yml's pinned actionlint version + checksum match lint-workflows.mjs", () => {
   const ciYml = readFileSync(CI_YML_PATH, "utf8");
 
-  assert.match(ciYml, new RegExp(`ACTIONLINT_VERSION: "${ACTIONLINT_VERSION}"`));
-  assert.match(ciYml, new RegExp(`ACTIONLINT_SHA256: "${ACTIONLINT_LINUX_AMD64_SHA256}"`));
+  // Literal substring checks, not RegExp: the version string contains `.`
+  // metacharacters, so a RegExp would match unintended values (e.g. "1X7X12").
+  assert.ok(ciYml.includes(`ACTIONLINT_VERSION: "${ACTIONLINT_VERSION}"`), "ci.yml ACTIONLINT_VERSION must match the lint-workflows.mjs export");
+  assert.ok(ciYml.includes(`ACTIONLINT_SHA256: "${ACTIONLINT_LINUX_AMD64_SHA256}"`), "ci.yml ACTIONLINT_SHA256 must match the lint-workflows.mjs export");
 });

--- a/test/github/lint-workflows.test.mjs
+++ b/test/github/lint-workflows.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { runActionlint } from "../../scripts/github/lint-workflows.mjs";
+
+const FIXTURE_PATH = "test/fixtures/workflows/invalid-on-trigger.yml";
+
+// Negative test for #1409 (root cause #1385): proves the actionlint wiring
+// actually catches a server-side-invalid workflow (unknown `on:` event), the
+// exact defect class that `gate-evidence-workflow.test.mjs`'s YAML-only parse
+// can't see. Skips cleanly when actionlint isn't installed — the missing-
+// binary path is a local-tooling gap, never a stand-in for a real lint pass;
+// CI always has the pinned binary, so the enforcement itself never no-ops.
+test("actionlint flags the deliberately-invalid on: trigger fixture", (t) => {
+  const probe = runActionlint(["-version"]);
+  if (probe.error?.code === "ENOENT") {
+    t.skip("actionlint not installed locally — enforced in CI");
+    return;
+  }
+
+  const result = runActionlint([FIXTURE_PATH]);
+
+  assert.notEqual(result.status, 0, "actionlint should fail on the invalid on: trigger fixture");
+  assert.match(result.stdout, /pull_request_review_thread/);
+});


### PR DESCRIPTION
## Summary

Adds GitHub-Actions-**semantic** validation (actionlint) to the pipeline so an invalid workflow file can't pass review again. This closes the #1385 gap where `pull_request_review_thread` — a webhook event but not a valid Actions `on:` trigger — passed the draft gate, two Copilot rounds, and the full pre-approval fan-out, because the only workflow test YAML-parses the file and never validates Actions semantics.

## Changes

- **`scripts/github/lint-workflows.mjs`** (new) — runs `actionlint` over `.github/workflows/`; exports `runActionlint()` and the pinned `ACTIONLINT_VERSION = "1.7.12"`. Missing-binary path prints an install hint and exits 0 (local convenience); a real lint finding forwards actionlint's non-zero exit and fails closed.
- **`package.json`** — new `test:workflows` script, added to the `verify` `run-p` list so a broken workflow fails locally and in CI.
- **`.github/workflows/ci.yml`** — `test:workflows` added to the `verify-suite` matrix, with a conditional step that curls the pinned actionlint v1.7.12 linux-amd64 release archive, verifies its SHA256 against a hardcoded known-good checksum (`sha256sum -c`) before extracting, and puts the binary on PATH — so CI always has a verified binary present and enforcement is real. `lint-workflows.mjs` exports `ACTIONLINT_VERSION`/`ACTIONLINT_LINUX_AMD64_SHA256` as the source of truth; ci.yml carries its own env copies (YAML can't import the JS constant) that a test asserts match those exports, so a future bump to one without the other fails the suite instead of silently desyncing.
- **`test/fixtures/workflows/invalid-on-trigger.yml`** (new) — deliberately-broken fixture using `pull_request_review_thread`, kept outside `.github/workflows/` so GitHub never runs it.
- **`test/github/lint-workflows.test.mjs`** (new) — negative test asserting actionlint returns non-zero and names the bad event; skips cleanly if the binary is absent. Plus two child-process tests pinning `main()`'s enforcement seam directly: binary-absent (PATH shadowed) → exit 0 + install-hint warning; binary-present + the bad fixture → non-zero exit. And a test asserting ci.yml's pinned version/checksum match the `lint-workflows.mjs` exports.

The existing #1385 fast-check unit guard (`gate-evidence-workflow.test.mjs`) is untouched — actionlint backs it, does not replace it. The change-classifier `ci-guard` wiring the issue floated is already in place (`CATEGORY_ANGLE_MAP[CI_ONLY]` includes `ci-guard`; `.github/workflows/**` already classifies as `ci`), so no new wiring was added.

## Testing

- `npm run verify` green with `test:workflows` wired in (actionlint v1.7.12 present locally via Homebrew, matching the CI pin).
- Missing-binary skip vs lint-error fail verified both ways: PATH-shadowed run → warn + exit 0; direct run against the bad fixture → exit 1.

Closes #1409
