### PR TITLE
test: isolate runner-coordination path in reconcile/checkpoint suites (deterministic verify) (#1405)

### DIFF
--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -1,3 +1,13 @@
+// Determinism convention (issue #1405): fixtures in this file use fixed,
+// self-consistent timestamps (comment `updated_at`, gate-marker dates,
+// etc.). Never compare a fixture against the real wall clock — that means
+// no bare, argument-less Date constructor call and no reading the current
+// epoch millis off the Date global directly. Production seams that need
+// "now" (`detectStaleRunner` in scripts/loop/_stale-runner-detection.mjs;
+// `claimRunnerOwnership` / `assertRunnerOwnership` in
+// scripts/loop/_pr-runner-coordination.mjs) already accept an injected
+// `now`; pass a fixed value through it instead. Enforced mechanically by
+// test/github/deterministic-fixture-time.test.mjs.
 import assert from "node:assert/strict";
 import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -613,7 +613,7 @@ test("detect-checkpoint-evidence fails pre-merge check when only partial draft g
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 1);
     const payload = JSON.parse(result.stderr);
@@ -654,7 +654,7 @@ test("detect-checkpoint-evidence always fails before merge when gate comments ar
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 1);
     assert.equal(result.stdout, "");
@@ -825,7 +825,7 @@ test("detect-checkpoint-evidence reports gh failures deterministically", async (
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 1);
     assert.equal(result.stdout, "");
@@ -885,7 +885,7 @@ test("detect-checkpoint-evidence fails pre-merge with unresolved review threads 
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 1);
     assert.equal(result.stdout, "");
@@ -946,7 +946,7 @@ test("detect-checkpoint-evidence fails pre-merge when graphql review-thread fetc
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 1);
     assert.equal(result.stdout, "");
@@ -1693,7 +1693,7 @@ test("detect-checkpoint-evidence fails pre-merge with unresolved human review th
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 1);
     assert.equal(result.stdout, "");

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -1,12 +1,21 @@
-// Determinism convention (issue #1405): fixtures in this file use fixed,
-// self-consistent timestamps (comment `updated_at`, gate-marker dates,
-// etc.). Never compare a fixture against the real wall clock — that means
-// no bare, argument-less Date constructor call and no reading the current
-// epoch millis off the Date global directly. Production seams that need
-// "now" (`detectStaleRunner` in scripts/loop/_stale-runner-detection.mjs;
-// `claimRunnerOwnership` / `assertRunnerOwnership` in
+// Determinism (issue #1405). The root cause of the intermittent failures
+// here was shared on-disk state, not a fixture-vs-clock comparison: some
+// `runNode` calls omitted `cwd`, so the spawned CLI inherited the real
+// process cwd and resolved its runner-coordination file via
+// `git rev-parse --git-common-dir` — a path SHARED across every worktree
+// over this one `.git`. A stale leftover coordination file from another
+// run/worktree then flipped stale-runner age assertions. The fix: every
+// `runNode` that can reach coordination passes `cwd: tempDir` (a per-test
+// mkdtemp dir where `--git-common-dir` fails, so the coordination root
+// anchors to the isolated temp dir). Any new spawn that touches
+// coordination MUST set `cwd: tempDir`.
+//
+// Related convention: never read the real wall clock here either — no bare,
+// argument-less Date constructor call and no `Date.now()`. Production seams
+// that need "now" (`detectStaleRunner` in scripts/loop/_stale-runner-detection.mjs;
+// `claimRunnerOwnership`/`assertRunnerOwnership` in
 // scripts/loop/_pr-runner-coordination.mjs) already accept an injected
-// `now`; pass a fixed value through it instead. Enforced mechanically by
+// `now`; pass a fixed value through it. Enforced mechanically by
 // test/github/deterministic-fixture-time.test.mjs.
 import assert from "node:assert/strict";
 import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -11,7 +11,7 @@
 // coordination MUST set `cwd: tempDir`.
 //
 // Related convention: never read the real wall clock here either — no bare,
-// argument-less Date constructor call and no `Date.now()`. Production seams
+// argument-less Date constructor, and no read of the current epoch millis off the Date global. Production seams
 // that need "now" (`detectStaleRunner` in scripts/loop/_stale-runner-detection.mjs;
 // `claimRunnerOwnership`/`assertRunnerOwnership` in
 // scripts/loop/_pr-runner-coordination.mjs) already accept an injected

--- a/test/github/deterministic-fixture-time.test.mjs
+++ b/test/github/deterministic-fixture-time.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+// Regression guard for issue #1405: reconcile-draft-gate.test.mjs and
+// detect-checkpoint-evidence.test.mjs carried fixtures that encoded fixed
+// past timestamps but got their "now" from the real wall clock, so
+// assertions about age/staleness silently flipped as real time advanced.
+// Both files use fixed, self-consistent fixture timestamps and must never
+// call the real clock directly — a literal `Date.now()` or bare
+// `new Date()` (no args) is exactly how that flake reappears. Production
+// seams that need "now" already accept an injected value (see each guarded
+// file's header comment); tests should pass a fixed `now` through those
+// instead of reaching for the real clock.
+const GUARDED_FILES = [
+  "reconcile-draft-gate.test.mjs",
+  "detect-checkpoint-evidence.test.mjs",
+];
+
+const REAL_CLOCK_PATTERN = /Date\.now\(\)|new Date\(\s*\)/;
+
+for (const file of GUARDED_FILES) {
+  test(`${file} never compares fixtures against the real wall clock`, () => {
+    const source = readFileSync(path.resolve("test/github", file), "utf8");
+    assert.doesNotMatch(
+      source,
+      REAL_CLOCK_PATTERN,
+      `${file} must not call Date.now()/new Date() (real time) directly; ` +
+        "inject a fixed `now` through the production seam instead (see the file's header comment).",
+    );
+  });
+}

--- a/test/github/deterministic-fixture-time.test.mjs
+++ b/test/github/deterministic-fixture-time.test.mjs
@@ -3,22 +3,22 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-// Regression guard for issue #1405: reconcile-draft-gate.test.mjs and
-// detect-checkpoint-evidence.test.mjs carried fixtures that encoded fixed
-// past timestamps but got their "now" from the real wall clock, so
-// assertions about age/staleness silently flipped as real time advanced.
-// Both files use fixed, self-consistent fixture timestamps and must never
-// call the real clock directly — a literal `Date.now()` or bare
-// `new Date()` (no args) is exactly how that flake reappears. Production
-// seams that need "now" already accept an injected value (see each guarded
-// file's header comment); tests should pass a fixed `now` through those
-// instead of reaching for the real clock.
+// Regression guard for issue #1405. The intermittent failures actually
+// observed in reconcile-draft-gate.test.mjs / detect-checkpoint-evidence.test.mjs
+// were shared-coordination-path contamination (a spawned CLI inheriting the
+// real cwd and reading the git-common-dir-shared `.pi/runner-coordination`
+// state) — fixed in those files by threading `cwd: tempDir`. THIS guard is a
+// complementary, forward-looking determinism check for a DIFFERENT hazard:
+// reintroducing a real wall-clock read (`Date.now()` / bare `new Date()`)
+// into either suite, which would make age/staleness assertions time-dependent
+// again by a fresh route. Production seams that need "now" already accept an
+// injected value (see each guarded file's header); tests should pass a fixed
+// `now` through those instead of reaching for the real clock.
 //
 // This is a deliberately simple textual heuristic, not a full parser: it
 // catches the common real-clock forms (with tolerance for internal
-// whitespace and an empty block comment), which is how the flake would
-// realistically reappear. It does not attempt to defeat adversarial
-// obfuscation.
+// whitespace and an empty block comment). It does not attempt to defeat
+// adversarial obfuscation.
 const GUARDED_FILES = [
   "reconcile-draft-gate.test.mjs",
   "detect-checkpoint-evidence.test.mjs",

--- a/test/github/deterministic-fixture-time.test.mjs
+++ b/test/github/deterministic-fixture-time.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import path from "node:path";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 
 // Regression guard for issue #1405: reconcile-draft-gate.test.mjs and
@@ -13,16 +13,24 @@ import test from "node:test";
 // seams that need "now" already accept an injected value (see each guarded
 // file's header comment); tests should pass a fixed `now` through those
 // instead of reaching for the real clock.
+//
+// This is a deliberately simple textual heuristic, not a full parser: it
+// catches the common real-clock forms (with tolerance for internal
+// whitespace and an empty block comment), which is how the flake would
+// realistically reappear. It does not attempt to defeat adversarial
+// obfuscation.
 const GUARDED_FILES = [
   "reconcile-draft-gate.test.mjs",
   "detect-checkpoint-evidence.test.mjs",
 ];
 
-const REAL_CLOCK_PATTERN = /Date\.now\(\)|new Date\(\s*\)/;
+const REAL_CLOCK_PATTERN = /\bDate\s*\.\s*now\s*\(\s*\)|\bnew\s+Date\s*\(\s*(?:\/\*[\s\S]*?\*\/\s*)?\)/;
 
 for (const file of GUARDED_FILES) {
   test(`${file} never compares fixtures against the real wall clock`, () => {
-    const source = readFileSync(path.resolve("test/github", file), "utf8");
+    // Resolve relative to THIS guard file (cwd-independent — the guarded
+    // files are siblings), so the guard works regardless of the process cwd.
+    const source = readFileSync(fileURLToPath(new URL(file, import.meta.url)), "utf8");
     assert.doesNotMatch(
       source,
       REAL_CLOCK_PATTERN,

--- a/test/github/reconcile-draft-gate.test.mjs
+++ b/test/github/reconcile-draft-gate.test.mjs
@@ -121,7 +121,7 @@ test("reconcile-draft-gate fails closed when visible draft_gate evidence already
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 1);
     assert.equal(result.stdout, "");
@@ -156,7 +156,7 @@ test("reconcile-draft-gate blocks while CI is still pending", async () => {
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 1);
     assert.equal(result.stdout, "");
@@ -193,7 +193,7 @@ test("reconcile-draft-gate treats failing gh pr checks JSON output as blocked ev
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 1);
     assert.equal(result.stdout, "");
@@ -230,7 +230,7 @@ test("reconcile-draft-gate surfaces gh pr checks stderr when exit code 1 has no 
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 1);
     assert.equal(result.stdout, "");
@@ -264,7 +264,7 @@ test("reconcile-draft-gate blocks when no CI checks are reported", async () => {
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 1);
     assert.equal(result.stdout, "");
@@ -439,7 +439,7 @@ test("reconcile-draft-gate skips the draft conversion mutation when the PR is al
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 0);
     assert.equal(result.stderr, "");
@@ -521,7 +521,7 @@ test("reconcile-draft-gate does not mark ready when upsert throws and the PR was
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 1);
     assert.equal(result.stdout, "");
@@ -603,7 +603,7 @@ test("reconcile-draft-gate marks the PR ready again if gate-comment upsert throw
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 1);
     assert.equal(result.stdout, "");
@@ -690,7 +690,7 @@ test("reconcile-draft-gate converts to draft, posts clean evidence, and marks re
       },
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 0);
     assert.equal(result.stderr, "");

--- a/test/github/reconcile-draft-gate.test.mjs
+++ b/test/github/reconcile-draft-gate.test.mjs
@@ -11,7 +11,7 @@
 // that touches coordination MUST set `cwd: tempDir`.
 //
 // Related convention: never read the real wall clock here either — no bare,
-// argument-less Date constructor call and no `Date.now()`. A production seam
+// argument-less Date constructor, and no read of the current epoch millis off the Date global. A production seam
 // that needs "now" (e.g. `claimRunnerOwnership`/`assertRunnerOwnership` in
 // scripts/loop/_pr-runner-coordination.mjs) already accepts an injected
 // `now`; pass a fixed value through it. Enforced mechanically by

--- a/test/github/reconcile-draft-gate.test.mjs
+++ b/test/github/reconcile-draft-gate.test.mjs
@@ -1,11 +1,20 @@
-// Determinism convention (issue #1405): fixtures in this file use fixed,
-// self-consistent timestamps. Never compare a fixture against the real
-// wall clock — that means no bare, argument-less Date constructor call and
-// no reading the current epoch millis off the Date global directly. A
-// production seam that needs "now" (e.g. `claimRunnerOwnership`,
-// `assertRunnerOwnership` in scripts/loop/_pr-runner-coordination.mjs)
-// already accepts an injected `now`; pass a fixed value through it
-// instead. Enforced mechanically by
+// Determinism (issue #1405). The root cause of the intermittent failures
+// here was NOT a fixture-vs-clock comparison but shared on-disk state: some
+// `runNode` calls omitted `cwd`, so the spawned CLI inherited the real
+// process cwd and resolved its runner-coordination file via
+// `git rev-parse --git-common-dir` — a path SHARED across every worktree
+// over this one `.git`. A stale leftover coordination file from another
+// run/worktree then flipped stale-runner age assertions. The fix: every
+// `runNode` that can reach coordination passes `cwd: tempDir` (a per-test
+// mkdtemp dir where `--git-common-dir` fails, so the coordination root
+// anchors to the isolated temp dir). Keep that invariant: any new spawn
+// that touches coordination MUST set `cwd: tempDir`.
+//
+// Related convention: never read the real wall clock here either — no bare,
+// argument-less Date constructor call and no `Date.now()`. A production seam
+// that needs "now" (e.g. `claimRunnerOwnership`/`assertRunnerOwnership` in
+// scripts/loop/_pr-runner-coordination.mjs) already accepts an injected
+// `now`; pass a fixed value through it. Enforced mechanically by
 // test/github/deterministic-fixture-time.test.mjs.
 import assert from "node:assert/strict";
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";

--- a/test/github/reconcile-draft-gate.test.mjs
+++ b/test/github/reconcile-draft-gate.test.mjs
@@ -1,3 +1,12 @@
+// Determinism convention (issue #1405): fixtures in this file use fixed,
+// self-consistent timestamps. Never compare a fixture against the real
+// wall clock — that means no bare, argument-less Date constructor call and
+// no reading the current epoch millis off the Date global directly. A
+// production seam that needs "now" (e.g. `claimRunnerOwnership`,
+// `assertRunnerOwnership` in scripts/loop/_pr-runner-coordination.mjs)
+// already accepts an injected `now`; pass a fixed value through it
+// instead. Enforced mechanically by
+// test/github/deterministic-fixture-time.test.mjs.
 import assert from "node:assert/strict";
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";


### PR DESCRIPTION
## Summary

Makes `reconcile-draft-gate.test.mjs` + `detect-checkpoint-evidence.test.mjs` deterministic. The intermittent "verify not fully green" failures were **not** a wall-clock comparison in the fixtures — they were **shared-state contamination**: several `runNode()` calls omitted `cwd`, so the spawned CLI child inherited the real process cwd. `detectStaleRunner` / the runner-coordination helpers resolve their coordination file via `git rev-parse --git-common-dir`, which is **shared across every worktree over this one `.git`** — so a leftover `.pi/runner-coordination/<owner>/<repo>/pr-*.json` from another run/worktree, with an old timestamp, made the stale-runner age comparison flip.

Reproduced directly: planting a 2020-timestamped `pr-17.json` at the shared path made the pre-fix suite fail with the exact `"…is stale (claimed …ms ago…)"` assertions the issue described; the fixed suite passes unaffected against the same planted file.

## Changes

- Thread `cwd: tempDir` through the 15 remaining `runNode()` calls across the two suites, so each test's coordination-path resolution anchors to its own `mkdtemp` dir (`git rev-parse --git-common-dir` fails there → `resolveRepoCoordinationRoot` falls back to the isolated temp dir). Structurally unable to see another worktree's/run's leftover state. **No production code changed** — `cwd` was already a supported parameter with an unchanged default.
- New `test/github/deterministic-fixture-time.test.mjs` — regression guard that fails if either suite reaches for a bare `Date.now()` / arg-less `new Date()` instead of the existing injected `now` seams (permits fixed-instant `new Date("2026-…")`). Plus header-comment conventions on both files pointing at the `now`-injection seams.

## Testing

- Both target suites + the guard run deterministically (3× each, 0 fail); full `npm run verify` 0 fail across all suites.
- Root cause proven by planting/removing a stale shared-path fixture (pre-fix fails, post-fix passes).

Closes #1405
