### PR TITLE
chore(cleanup): single-source the SETUP_GUIDANCE map + mark queue-mode SPEC implemented (#1421)

### DIFF
--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -11,6 +11,7 @@ import {
   renderCheckLines,
   summarizeChecks,
   DEV_LOOP_CHECK_IDS,
+  SETUP_GUIDANCE,
 } from "../lib/dev-loops-core.mjs";
 
 // Zero-dep preflight: a Claude Code plugin marketplace checkout ships
@@ -212,13 +213,6 @@ const SUBCOMMAND_DESCRIPTIONS = {
   },
 };
 
-const CLI_SETUP_GUIDANCE = {
-  "gh-installed": "Install GitHub CLI to enable remote GitHub/Copilot workflows.",
-  "gh-auth": "Run `gh auth login` so remote GitHub/Copilot workflows can use your GitHub session.",
-  "subagent-command": "Install or enable subagent support so the `subagent` command is available.",
-  "git-repo": "Run the command from a git repository checkout before using repo-scoped workflows.",
-};
-
 function spawnResult(command, args, options = {}) {
   try {
     const result = spawnSync(command, args, { encoding: "utf8", ...options });
@@ -312,7 +306,7 @@ function buildCliUsageLines(action) {
 
 function orderedCliSetupSteps(checks) {
   const byId = new Map(checks.map((c) => [c.id, c]));
-  const steps = [...new Set(DEV_LOOP_CHECK_IDS.filter((id) => byId.get(id)?.ok === false).map((id) => CLI_SETUP_GUIDANCE[id]))];
+  const steps = [...new Set(DEV_LOOP_CHECK_IDS.filter((id) => byId.get(id)?.ok === false).map((id) => SETUP_GUIDANCE[id]))];
   if (steps.length > 0) return steps.map((step, i) => `${i + 1}. ${step}`);
   return [
     "1. Use `/dev-loop` (Claude Code) or `/skill:dev-loop` (Pi) to start or continue a dev loop — the single public entry.",

--- a/docs/specs/queue-mode/SPEC.md
+++ b/docs/specs/queue-mode/SPEC.md
@@ -1,7 +1,7 @@
 # SPEC: Outer dev-loop queue mode
 
 **Issue:** [#556](https://github.com/mfittko/dev-loops/issues/556)
-**Status:** Draft — intake refinement
+**Status:** Implemented — queue-mode is the live shipped pickup path
 **Branch:** `issue/556-queue-mode`
 
 ## 1. Overview

--- a/docs/specs/queue-mode/SPEC.md
+++ b/docs/specs/queue-mode/SPEC.md
@@ -1,7 +1,7 @@
 # SPEC: Outer dev-loop queue mode
 
 **Issue:** [#556](https://github.com/mfittko/dev-loops/issues/556)
-**Status:** Implemented — queue-mode is the live shipped pickup path
+**Status:** Partially implemented — the board pickup source (Next Up) is the live shipped path; the autonomous queue driver described below remains deliberately unwired (no-op adapter)
 **Branch:** `issue/556-queue-mode`
 
 ## 1. Overview

--- a/extension/presentation.ts
+++ b/extension/presentation.ts
@@ -1,13 +1,13 @@
 import type { DevLoopCheck, DevLoopCheckId } from './checks.ts';
-import { describeReadiness, DEV_LOOP_CHECK_IDS, summarizeChecks, renderCheckLines } from '../lib/dev-loops-core.mjs';
+import { describeReadiness, DEV_LOOP_CHECK_IDS, SETUP_GUIDANCE as BASE_SETUP_GUIDANCE, summarizeChecks, renderCheckLines } from '../lib/dev-loops-core.mjs';
 
 export type DevLoopsAction = 'doctor' | 'help' | 'status' | 'hide';
 export type InspectAction = 'open' | 'resume' | 'status' | 'stop' | 'restart';
 
+// Shared 3-of-4 checks are byte-identical to the CLI's wording; only `git-repo` diverges
+// because Pi's workflow is "open Pi inside a repo", not "run a command inside a repo".
 const SETUP_GUIDANCE: Record<(typeof DEV_LOOP_CHECK_IDS)[number], string> = {
-  'gh-installed': 'Install GitHub CLI to enable remote GitHub/Copilot workflows.',
-  'gh-auth': 'Run `gh auth login` so remote GitHub/Copilot workflows can use your GitHub session.',
-  'subagent-command': 'Install or enable subagent support so the `subagent` command is available.',
+  ...BASE_SETUP_GUIDANCE,
   'git-repo': 'Open Pi inside a git repository checkout before using the shared loops.',
 };
 

--- a/lib/dev-loops-core.mjs
+++ b/lib/dev-loops-core.mjs
@@ -5,6 +5,15 @@ export const DEV_LOOP_CHECK_IDS = [
   'git-repo',
 ];
 
+// Shared check-id -> setup-step guidance. Base wording is the CLI's (the CLI is the
+// standalone/default surface); the extension overrides `git-repo` with Pi-specific wording.
+export const SETUP_GUIDANCE = {
+  'gh-installed': 'Install GitHub CLI to enable remote GitHub/Copilot workflows.',
+  'gh-auth': 'Run `gh auth login` so remote GitHub/Copilot workflows can use your GitHub session.',
+  'subagent-command': 'Install or enable subagent support so the `subagent` command is available.',
+  'git-repo': 'Run the command from a git repository checkout before using repo-scoped workflows.',
+};
+
 const LOCAL_READINESS_IDS = ['subagent-command', 'git-repo'];
 const REMOTE_READINESS_IDS = ['gh-installed', 'gh-auth', 'subagent-command', 'git-repo'];
 const INSPECT_ACTIONS = new Set(['open', 'resume', 'status', 'stop', 'restart']);

--- a/test/dev-loops-cli.test.mjs
+++ b/test/dev-loops-cli.test.mjs
@@ -8,6 +8,7 @@ import { Writable } from "node:stream";
 import { fileURLToPath } from "node:url";
 
 import { createCliRuntime, runCli } from "../cli/index.mjs";
+import { SETUP_GUIDANCE } from "../lib/dev-loops-core.mjs";
 
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 
@@ -110,6 +111,38 @@ test("CLI renderer keeps shared status behavior and shell-friendly argument erro
   assert.equal(malformedStdout.read(), "");
   assert.match(malformedStderr.read(), /`status` does not accept additional arguments\./);
   assert.match(malformedStderr.read(), /Usage:\n- dev-loops status/);
+});
+
+test("CLI setup guidance for failing checks is the shared core map (#1421)", async () => {
+  const failingRuntime = createRuntime({
+    async commandExists() {
+      return false;
+    },
+    async ghAuthOk() {
+      return false;
+    },
+    async insideGitRepo() {
+      return false;
+    },
+    async getSubagentAvailability() {
+      return { ok: false, availableDetail: "n/a", unavailableDetail: "missing subagent" };
+    },
+  });
+
+  const statusStdout = createBufferStream();
+  const statusExitCode = await runCli({
+    argv: ["status"],
+    runtime: failingRuntime,
+    stdout: statusStdout.stream,
+    stderr: createBufferStream().stream,
+  });
+
+  assert.equal(statusExitCode, 0);
+  const output = statusStdout.read();
+  assert(output.includes(`1. ${SETUP_GUIDANCE["gh-installed"]}`));
+  assert(output.includes(`2. ${SETUP_GUIDANCE["gh-auth"]}`));
+  assert(output.includes(`3. ${SETUP_GUIDANCE["subagent-command"]}`));
+  assert(output.includes(`4. ${SETUP_GUIDANCE["git-repo"]}`));
 });
 
 test("CLI help leads with dev-loop as the primary workflow entry", async () => {

--- a/test/extension-command-contract.test.mjs
+++ b/test/extension-command-contract.test.mjs
@@ -5,6 +5,8 @@ import path from "node:path";
 import { access, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 
 import registerExtension, { syncPackagedAgents } from "../extension/index.ts";
+import { buildWidgetLines } from "../extension/presentation.ts";
+import { SETUP_GUIDANCE } from "../lib/dev-loops-core.mjs";
 
 function createPiDouble({ commandResults = new Map(), tools = [], commands = [] } = {}) {
   const events = new Map();
@@ -250,6 +252,26 @@ test("status and doctor use the reduced readiness surface", async () => {
   assert(statusLines.some((line) => /Local loop readiness: needs setup/i.test(line)));
   assert(statusLines.some((line) => /Remote GitHub\/Copilot readiness: needs setup/i.test(line)));
   assert.equal(statusLines.some((line) => /local-dev-loop-skill/i.test(line)), false);
+});
+
+test("extension setup guidance is the shared core map, overriding only git-repo (#1421)", () => {
+  const failingChecks = ["gh-installed", "gh-auth", "subagent-command", "git-repo"].map((id) => ({
+    id,
+    label: id,
+    ok: false,
+    detail: "unused",
+  }));
+
+  const widgetLines = buildWidgetLines("status", failingChecks);
+
+  // The 3 shared checks render byte-identical to the core/CLI guidance map.
+  assert(widgetLines.includes(`1. ${SETUP_GUIDANCE["gh-installed"]}`));
+  assert(widgetLines.includes(`2. ${SETUP_GUIDANCE["gh-auth"]}`));
+  assert(widgetLines.includes(`3. ${SETUP_GUIDANCE["subagent-command"]}`));
+
+  // git-repo is the deliberate per-surface override — Pi-specific wording, not the base CLI wording.
+  assert.equal(widgetLines.includes(`4. ${SETUP_GUIDANCE["git-repo"]}`), false);
+  assert(widgetLines.includes("4. Open Pi inside a git repository checkout before using the shared loops."));
 });
 
 test("hide still clears the widget and unknown commands fall back to help", async () => {


### PR DESCRIPTION
## Summary

Single-sources the check-id → setup-step guidance map that was duplicated verbatim between the CLI and the VS Code extension, and updates the queue-mode SPEC status line to reflect the shipped state. Residuals kept from the #1373 triage of the old #609 cleanup waves.

## Changes

- **`lib/dev-loops-core.mjs`** exports `SETUP_GUIDANCE` next to `DEV_LOOP_CHECK_IDS` (same shared-home mechanism both surfaces already use for the ids), carrying the 3 byte-identical strings plus the CLI's `git-repo` wording as base.
- **`cli/index.mjs`** drops its local `CLI_SETUP_GUIDANCE` copy and consumes the shared map directly.
- **`extension/presentation.ts`** drops its local copy and spreads the base with its one **deliberate per-surface override** — the `git-repo` phrasing ("Open Pi inside a git repository checkout…") differs from the CLI's on purpose (the extension always runs inside Pi; the CLI is standalone). A comment records the intentional divergence. Import mirrors the existing `DEV_LOOP_CHECK_IDS` `.mjs`-import mechanism.
- **`docs/specs/queue-mode/SPEC.md`** status line: stale "Draft" → accurate "Partially implemented" — the board pickup source (Next Up) is the live shipped path, while the SPEC's autonomous queue driver remains deliberately unwired (no-op adapter); a blanket "Implemented" would overclaim (verified against queue-driver.mjs during the pre-approval gate).

## Behavior

Byte-identical on both surfaces, pinned structurally: new tests render all four failing-check guidance lines and compare them against the shared export's values (CLI: all 4 equal the base; extension: 3 shared ids equal the base, only `git-repo` uses the Pi-specific string).

## Testing

- New `test/dev-loops-cli.test.mjs` + `test/extension-command-contract.test.mjs` assertions as above; `grep CLI_SETUP_GUIDANCE` → zero hits.

## Non-goals

- Collapsing the deliberate `git-repo` wording divergence into one string (a real per-surface behavior difference, preserved).
- The old wave-5 `packages/core/src/hooks/` extraction (closed as YAGNI in the #1373 triage).

Closes #1421
