### PR TITLE
chore(config): trim .devloops to per-layer angle deltas (#1415)

### DIFF
--- a/.devloops
+++ b/.devloops
@@ -16,26 +16,12 @@ gates:
   draft:
     dynamic:
       subtractive: true
+    # Only per-layer DELTAS live here — angles that merely restate an
+    # extension-defaults.yaml draft-pool entry byte-for-byte are a no-op under
+    # merge-by-name (D3) and have been trimmed. This repo's draft gate keeps
+    # the full shipped draft pool at its shipped persona/prompt/order except
+    # for the two explicit drops below.
     angles:
-      - scope
-      - coverage
-      - correctness
-      - ci-guard
-      - contract-surface
-      - input-validation
-      - determinism
-      - no-op
-      - link-check
-      - packaging-runtime
-      - state-concurrency
-      - config-drift
-      - gate-evidence
-      - name: pr-description
-        mandatory: true
-      - pr-comments
-      - contradiction-lens
-      - code-conformance
-      - semantic-drift
       # Shipped in extension-defaults.yaml's draft pool but intentionally not
       # run by this repo's own draft gate (pre-1.0 config-schema redesign,
       # #1404: gates.<gate>.angles now merges BY NAME across config layers —
@@ -52,11 +38,14 @@ gates:
   preApproval:
     dynamic:
       subtractive: true
+    # Only per-layer DELTAS live here (see the draft-gate comment above for
+    # why byte-identical restatements were trimmed). This repo's preApproval
+    # gate keeps the full shipped preApproval pool at its shipped
+    # persona/prompt/order except for the deltas below: two angles promoted
+    # to mandatory, and two additions not in the shipped preApproval pool.
     # Mandatory angles always run in the fan-out (never dropped by dynamic
     # resolution); fully configurable — set `mandatory: true` on any angle.
     angles:
-      - name: pr-checklist-matrix
-        mandatory: true
       - name: acceptance-criteria
         mandatory: true
         persona: review
@@ -65,21 +54,9 @@ gates:
         mandatory: true
       - name: contradiction-lens
         mandatory: true
-      - dry
-      - kiss
-      - srp
-      - soc
-      - deep
-      - docs
-      - ocp
-      - lsp
-      - isp
-      - dip
       - name: renderer-security
         persona: review
         prompt: Review this change for renderer security. Check HTML text escaping, URL encoding, attribute encoding, JSON/script embedding, and rendering of user-controlled content. Treat titles, names, URLs, statuses, errors, and external payload fields as untrusted. Flag raw interpolation into HTML or attributes and tests that expect unsafe output.
-      - correctness-final
-      - ui-validation
     blockCleanOnFindingSeverities:
       - must-fix
       - worth-fixing-now

--- a/packages/core/test/devloops-mandatory-ac-dod.test.mjs
+++ b/packages/core/test/devloops-mandatory-ac-dod.test.mjs
@@ -83,3 +83,27 @@ describe(".devloops mandatory AC/DoD angle (pre_approval_gate)", () => {
     }
   });
 });
+
+// Repo-root .devloops keeps only per-layer DELTAS on top of
+// extension-defaults.yaml's shipped angle pools (#1415): byte-identical
+// restatements were trimmed, leaving only the enabled:false drops and the
+// mandatory/addition overrides above. This pins the draft-gate drops so a
+// future edit can't silently let threat-model/renderer-security merge back in.
+describe(".devloops draft-gate angle drops (draft gate)", () => {
+  test("draft excludes threat-model and renderer-security but keeps the rest of the shipped draft pool", async () => {
+    const { config, errors } = await loadDevLoopConfig({ repoRoot: REPO_ROOT });
+    assert.deepEqual(errors, [], `config load errors: ${JSON.stringify(errors)}`);
+
+    const gate = resolveGateConfig(config, "draft");
+    assert.deepEqual(gate.excludeAngles.sort(), ["renderer-security", "threat-model"]);
+
+    const draftAngles = resolveGateAngles(config, "draft");
+    assert.ok(!draftAngles.includes("threat-model"));
+    assert.ok(!draftAngles.includes("renderer-security"));
+    // A handful of the shipped draft-pool angles this repo's .devloops no
+    // longer restates must still resolve (inherited from extension-defaults).
+    for (const angle of ["scope", "coverage", "ci-guard", "pr-description"]) {
+      assert.ok(draftAngles.includes(angle), `draft angles must still include shipped angle "${angle}"`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Trims the repo-root `.devloops` to per-layer **deltas only**. Under the config redesign's merge-by-name (additive) layering, the repo config still restated 31 gate-review angle entries that `extension-defaults.yaml` already provides identically — redundant no-ops that defeat the point of additive layering and silently drift if the base changes. Deferred from the config redesign because the trim had to be provably behavior-preserving.

## What remains in `.devloops` (the genuine deltas)

- **draft**: `threat-model` + `renderer-security` as `enabled: false` — real drops (the base ships both enabled; merge-by-name needs an explicit disable entry).
- **preApproval**: `acceptance-criteria` (full definition, `mandatory: true`) and `renderer-security` (full definition) — genuine additions absent from the base pool; `yagni` + `contradiction-lens` as `{name, mandatory: true}` deltas — real promotions (base ships them non-mandatory; shallow merge keeps the base persona/prompt untouched).

Removed: 18 draft + 13 preApproval byte-identical restatements (including two that only restated a `mandatory: true` the base already sets).

## Proof of behavior preservation

A throwaway script dumped the fully-resolved config before and after the trim — per gate: `resolveGateAngles`, mandatory/exclude sets, `required`/`requireCi`, `blockCleanOnFindingSeverities`, dynamic/additive angles, `resolveAnglePool`, and per-angle `resolveReviewerRole` (persona/prompt/model/fallback). **`diff` exit 0 — byte-identical.** Merge mechanics verified in `config.mjs` (`mergeAngleArrays` shallow-merges by name and the base array position drives resolved order, so trimming cannot reorder).

## Testing

- `packages/core/test/devloops-mandatory-ac-dod.test.mjs` (the established home for pinning the repo's own resolved `.devloops` values) gains a describe block asserting the draft gate's two drops survive against the real repo config and that a sample of the no-longer-restated shipped draft angles still resolve — guarding this trim's core claim without duplicating the existing AC/DoD pinning.
- Existing parity test (preApproval acceptance-criteria/yagni mandatory pins) stays green.

## Non-goals

- Any change to `extension-defaults.yaml`'s angle set or to resolution semantics — purely removing redundant restatement from the consumer `.devloops`.

Closes #1415
