### PR TITLE
docs: refresh public intro article + deck after the pre-1.0 config changes (#1429)

### DIFF
--- a/docs/articles/introducing-dev-loops.html
+++ b/docs/articles/introducing-dev-loops.html
@@ -287,12 +287,12 @@
 
   <p>The loop breaks the compounding by turning each transition into a machine decision with a log. What remains for the human is roughly one bounded decision per change: the merge, plus anything the loop flags as unclear.</p>
 
-  <p>dev-loops is developed with dev-loops, so the honest evidence is its own history. The numbers below come straight from the repository's git log, as of mid-July 2026:</p>
+  <p>dev-loops is developed with dev-loops, so the honest evidence is its own history. The numbers below come straight from the repository's git log, as of July 19, 2026:</p>
 
   <div class="metrics" role="list">
-    <div class="metric" role="listitem"><div class="num">530+</div><div class="lab">pull requests merged in the project's first nine weeks</div></div>
+    <div class="metric" role="listitem"><div class="num">570+</div><div class="lab">pull requests merged in the project's first ten weeks</div></div>
     <div class="metric" role="listitem"><div class="num">~10/day</div><div class="lab">across the most recent two weeks</div></div>
-    <div class="metric" role="listitem"><div class="num">24</div><div class="lab">tagged releases in the same stretch, up to a 1.0 release candidate</div></div>
+    <div class="metric" role="listitem"><div class="num">26</div><div class="lab">tagged releases in the same stretch, up to a 1.0 release candidate</div></div>
     <div class="metric" role="listitem"><div class="num">1</div><div class="lab">human decision per change — the default posture stops at the merge</div></div>
   </div>
 
@@ -377,14 +377,14 @@
 
   <pre><code><span class="cm"># .devloops</span>
 version: 1
-strategy: local-first    <span class="cm"># start from a local plan file; github-first starts from issues</span>
+strategy: local-first    <span class="cm"># start from a local plan file; tracker-first starts from a tracked issue</span>
 inputSource: tracker     <span class="cm"># read the spec from the issue body, or phase-docs</span>
 refinement:
   maxCopilotRounds: 5     <span class="cm"># automated review rounds before converging; 0 turns Copilot off</span>
 autonomy:
   humanMergeOnly: true    <span class="cm"># merge stays a human-only action, regardless of any per-run flag</span></code></pre>
 
-  <p>Three choices shape the experience. Work can start <strong>local-first</strong> — you write a short plan in the repository and the loop opens a pull request straight from it — or <strong>github-first</strong>, where a tracked issue is the starting point. The automated review rounds can lean on Copilot or run without it. And the loop merges on its own only if you explicitly allow it; by default it stops and hands the merge to you. Start with the shipped defaults and dial each setting toward the autonomy your team is comfortable with. From 1.0 onward this configuration surface follows semantic versioning, so a <code>.devloops</code> file you write today keeps working across minor upgrades.</p>
+  <p>Three choices shape the experience. Work can start <strong>local-first</strong> — you write a short plan in the repository and the loop opens a pull request straight from it — or <strong>tracker-first</strong>, where a tracked issue is the starting point (<code>github-first</code> is a deprecated but still-accepted alias for the same setting). The automated review rounds can lean on Copilot or run without it. And the loop merges on its own only if you explicitly allow it; by default it stops and hands the merge to you. Start with the shipped defaults and dial each setting toward the autonomy your team is comfortable with. From 1.0 onward this configuration surface follows semantic versioning, so a <code>.devloops</code> file you write today keeps working across minor upgrades.</p>
 
   <hr class="rule" />
 

--- a/docs/articles/introducing-dev-loops.md
+++ b/docs/articles/introducing-dev-loops.md
@@ -34,12 +34,12 @@ Coordination is the cost that compounds. Every change carries a handful of trans
 
 The loop breaks the compounding by turning each transition into a machine decision with a log. What remains for the human is roughly one bounded decision per change: the merge, plus anything the loop flags as unclear.
 
-dev-loops is developed with dev-loops, so the honest evidence is its own history. The numbers below come straight from the repository's git log, as of mid-July 2026:
+dev-loops is developed with dev-loops, so the honest evidence is its own history. The numbers below come straight from the repository's git log, as of July 19, 2026:
 
 <!-- metrics:start -->
-- **530+** pull requests merged in the project's first nine weeks
+- **570+** pull requests merged in the project's first ten weeks
 - **~10/day** across the most recent two weeks
-- **24** tagged releases in the same stretch, up to a 1.0 release candidate
+- **26** tagged releases in the same stretch, up to a 1.0 release candidate
 - **1** human decision per change — the default posture stops at the merge
 <!-- metrics:end -->
 
@@ -153,7 +153,7 @@ On Pi the same set is reachable as subcommands of one command: `/dev-loops start
 ```yaml
 # .devloops
 version: 1
-strategy: local-first    # start from a local plan file; github-first starts from issues
+strategy: local-first    # start from a local plan file; tracker-first starts from a tracked issue
 inputSource: tracker     # read the spec from the issue body, or phase-docs
 refinement:
   maxCopilotRounds: 5     # automated review rounds before converging; 0 turns Copilot off
@@ -161,7 +161,7 @@ autonomy:
   humanMergeOnly: true    # merge stays a human-only action, regardless of any per-run flag
 ```
 
-Three choices shape the experience. Work can start **local-first** — you write a short plan in the repository and the loop opens a pull request straight from it — or **github-first**, where a tracked issue is the starting point. The automated review rounds can lean on Copilot or run without it. And the loop merges on its own only if you explicitly allow it; by default it stops and hands the merge to you. Start with the shipped defaults and dial each setting toward the autonomy your team is comfortable with. From 1.0 onward this configuration surface follows semantic versioning, so a `.devloops` file you write today keeps working across minor upgrades.
+Three choices shape the experience. Work can start **local-first** — you write a short plan in the repository and the loop opens a pull request straight from it — or **tracker-first**, where a tracked issue is the starting point (`github-first` is a deprecated but still-accepted alias for the same setting). The automated review rounds can lean on Copilot or run without it. And the loop merges on its own only if you explicitly allow it; by default it stops and hands the merge to you. Start with the shipped defaults and dial each setting toward the autonomy your team is comfortable with. From 1.0 onward this configuration surface follows semantic versioning, so a `.devloops` file you write today keeps working across minor upgrades.
 
 ## Where to go deeper
 

--- a/docs/presentations/introducing-dev-loops.html
+++ b/docs/presentations/introducing-dev-loops.html
@@ -399,19 +399,19 @@
     <h2>A Cadence That Holds</h2>
     <div class="grid grid-3">
       <div class="metric-card">
-        <p class="metric-figure">530+</p>
-        <p class="metric-label">pull requests merged in the project's first nine weeks.</p>
+        <p class="metric-figure">570+</p>
+        <p class="metric-label">pull requests merged in the project's first ten weeks.</p>
       </div>
       <div class="metric-card">
         <p class="metric-figure">~10/day</p>
         <p class="metric-label">across the most recent two weeks.</p>
       </div>
       <div class="metric-card">
-        <p class="metric-figure">24</p>
+        <p class="metric-figure">26</p>
         <p class="metric-label">releases tagged in the same stretch, through a 1.0 release candidate.</p>
       </div>
     </div>
-    <p class="soft-note">Straight from the repository's git log, as of mid-July 2026. The cadence holds because the transitions land as machine decisions, with the human's part staying that one bounded call at the merge.</p>
+    <p class="soft-note">Straight from the repository's git log, as of July 19, 2026. The cadence holds because the transitions land as machine decisions, with the human's part staying that one bounded call at the merge.</p>
   </div>
 </section>
 
@@ -492,7 +492,7 @@
       <div class="glass-card">
         <p class="card-label">Three choices shape the posture</p>
         <ul class="mini-list">
-          <li><strong>Where work starts.</strong> <code>strategy</code> reads <code>local-first</code> for a plan in the repo, or <code>github-first</code> for a tracked issue.</li>
+          <li><strong>Where work starts.</strong> <code>strategy</code> reads <code>local-first</code> for a plan in the repo, or <code>tracker-first</code> for a tracked issue (<code>github-first</code> is a deprecated accepted alias).</li>
           <li><strong>Automated review.</strong> <code>refinement.maxCopilotRounds</code> sets the review rounds; set <code>0</code> to turn Copilot off.</li>
           <li><strong>Autonomy.</strong> <code>autonomy.humanMergeOnly</code> keeps the merge a human's call. Begin with the defaults and dial each setting toward what your team is comfortable with.</li>
         </ul>


### PR DESCRIPTION
## Summary

Fact-refresh of the published intro article + intro deck after the pre-1.0 config changes. The deep-dive article/deck were audited in the same pass and found current (no in-scope defects; left untouched).

## Changes

- **`tracker-first` naming**: the article's config example (`strategy` comment) and prose presented `github-first` as current; both now say `tracker-first`, with the deprecated `github-first` alias called out explicitly in one clause. Same fix in the intro deck (hand-maintained per its README; edited directly). Verified against the shipped schema (`StrategyConfig` enum + the deprecated-alias normalization).
- **Dated figures re-verified + re-anchored to July 19, 2026** (each traces to a git command): merged-PR count 530+/nine weeks → **570+ over ten weeks** (576 squash-merge-titled commits since 2026-05-12); tagged releases 24 → **26** (`git tag | wc -l`, v0.1.0 → v1.0.0-rc.3); the ~10/day recent-cadence claim re-confirmed (134 merges in the last 14 days ≈ 9.6/day).
- **Config examples re-checked** against the shipped schema: `strategy`, `inputSource`, `refinement.maxCopilotRounds`, `autonomy.humanMergeOnly` all current; no other config keys appear in these docs.
- **Article HTML twin regenerated** via `npm run articles:render` (never hand-patched); `articles:check` confirms in-sync.

## Testing

Renderer drift (`articles:check` + 32/32 pages tests), deck/article fit-harness slices (intro-deck, intro-article, deep-dive, deep-dive-article — webkit render, mobile fit, negative wide-element check, keyboard nav), `validate-links` (119 files, 563 links), full `npm run verify` — all green.

## Non-goals

- New narrative content or restructuring (fact-refresh only).
- The internal `.md` presentation sources not published via build-site.

Closes #1429
