### PR TITLE
test(worktree): resolver-level regression for the worktree-local @dev-loops/core link (#1432)

### DIFF
--- a/test/loop/ensure-worktree.test.mjs
+++ b/test/loop/ensure-worktree.test.mjs
@@ -276,9 +276,10 @@ test("ensure: workspace self-link survives re-provisioning an existing worktree 
 test("ensure: a real node process resolves @dev-loops/core to the worktree's OWN packages/core (#1432)", async () => {
   const repo = makeRepo();
   try {
-    // "main" (not "exports") so a bare `import.meta.resolve("@dev-loops/core")`
-    // resolves via Node's legacy fallback — matches how a workspace package
-    // with no top-level "." export still resolves the package root.
+    // "main" with the `exports` field omitted entirely, so a bare
+    // `import.meta.resolve("@dev-loops/core")` resolves via Node's legacy
+    // main fallback. (The real @dev-loops/core ships an `exports` map; this
+    // fixture only needs SOME resolvable entry to prove which copy wins.)
     mkdirSync(path.join(repo.root, "packages/core"), { recursive: true });
     writeFileSync(
       path.join(repo.root, "packages/core/package.json"),

--- a/test/loop/ensure-worktree.test.mjs
+++ b/test/loop/ensure-worktree.test.mjs
@@ -308,9 +308,10 @@ test("ensure: a real node process resolves @dev-loops/core to the worktree's OWN
       encoding: "utf8",
     });
     const { resolved, marker } = JSON.parse(out);
-    const resolvedPath = new URL(resolved).pathname;
+    const { fileURLToPath } = await import("node:url");
+    const resolvedPath = fileURLToPath(resolved);
     const { realpathSync } = await import("node:fs");
-    assert.equal(path.dirname(resolvedPath), realpathSync(path.join(res.path, "packages/core")));
+    assert.equal(realpathSync(path.dirname(resolvedPath)), realpathSync(path.join(res.path, "packages/core")));
     assert.equal(marker, "worktree", "resolved module content is the worktree's OWN edit, not the checkout's");
   } finally {
     repo.cleanup();

--- a/test/loop/ensure-worktree.test.mjs
+++ b/test/loop/ensure-worktree.test.mjs
@@ -273,6 +273,50 @@ test("ensure: workspace self-link survives re-provisioning an existing worktree 
   }
 });
 
+test("ensure: a real node process resolves @dev-loops/core to the worktree's OWN packages/core (#1432)", async () => {
+  const repo = makeRepo();
+  try {
+    // "main" (not "exports") so a bare `import.meta.resolve("@dev-loops/core")`
+    // resolves via Node's legacy fallback — matches how a workspace package
+    // with no top-level "." export still resolves the package root.
+    mkdirSync(path.join(repo.root, "packages/core"), { recursive: true });
+    writeFileSync(
+      path.join(repo.root, "packages/core/package.json"),
+      '{"name":"@dev-loops/core","type":"module","main":"./index.mjs"}\n',
+    );
+    writeFileSync(path.join(repo.root, "packages/core/index.mjs"), "export const marker = \"root\";\n");
+    writeFileSync(path.join(repo.root, ".gitignore"), "node_modules/\n");
+    repo.git("add", "-A");
+    repo.git("commit", "-q", "-m", "add resolvable packages/core");
+    repo.git("fetch", "-q", "origin");
+
+    const res = await ensureWorktree({ repoRoot: repo.root, issue: 1432, base: "origin/main" });
+    assert.equal(res.ok, true);
+
+    // Diverge the worktree's OWN copy from the checkout's, simulating an
+    // in-progress edit — proves resolution follows the worktree, not a copy
+    // that merely happens to start out identical.
+    writeFileSync(path.join(res.path, "packages/core/index.mjs"), "export const marker = \"worktree\";\n");
+
+    const script = [
+      "const resolved = import.meta.resolve('@dev-loops/core');",
+      "const mod = await import(resolved);",
+      "console.log(JSON.stringify({ resolved, marker: mod.marker }));",
+    ].join("\n");
+    const out = execFileSync(process.execPath, ["--input-type=module", "-e", script], {
+      cwd: res.path,
+      encoding: "utf8",
+    });
+    const { resolved, marker } = JSON.parse(out);
+    const resolvedPath = new URL(resolved).pathname;
+    const { realpathSync } = await import("node:fs");
+    assert.equal(path.dirname(resolvedPath), realpathSync(path.join(res.path, "packages/core")));
+    assert.equal(marker, "worktree", "resolved module content is the worktree's OWN edit, not the checkout's");
+  } finally {
+    repo.cleanup();
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Provisioning is invoked (injected core) and fails soft
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the worktree core-resolution gotcha at its actual root. Investigation found the provisioning itself already exists — `provision-worktree.mjs`'s `ensureCoreWorkspaceLink` creates a relative `node_modules/@dev-loops/core` → `packages/core` symlink, idempotently, with stale-link repair and dest-conflict/fail-soft handling — but it only runs through the sanctioned `ensure-worktree` lifecycle entrypoint. The two incidents that motivated this issue came from worktrees created with raw `git worktree add`, which skips provisioning entirely.

## What this PR adds

The genuinely missing piece: **no test verified Node's actual module resolution** — existing tests asserted the symlink via `readlink`/`realpath` only, so a link that exists but doesn't resolve (or resolves to the wrong copy) would still pass. New regression test in `test/loop/ensure-worktree.test.mjs`:

- Provisions a temp worktree with a resolvable `packages/core`, **deliberately diverges** the worktree's copy from the checkout's after provisioning, then spawns a real `node --input-type=module` process (cwd inside the worktree) that `import.meta.resolve`s and imports `@dev-loops/core` — asserting both the resolved path and the imported value belong to the worktree's own `packages/core`, not the checkout's.

No production-code change: the provisioning implementation (hardcoded single-workspace mapping with an explanatory comment) was reviewed against a workspace-derived alternative and kept — simpler and correct for this repo's one-workspace layout.

## Testing

`ensure-worktree` suite 14/14, `provision-worktree` suite 18/18, full `npm run verify` green.

## Non-goals

- A full per-worktree `npm install` (heavy; the targeted symlink covers core resolution).
- Workspace-config-derived link generation (single workspace today; revisit if `packages/*` grows).

Closes #1432
