### PR TITLE
docs(article+deck): evolution/history of dev-loops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
         run: |
           npm run test:playwright:intro-deck
           npm run test:playwright:deep-dive
+          npm run test:playwright:how-decided-deck
 
   article-smoke:
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,3 +183,4 @@ jobs:
         run: |
           npm run test:playwright:intro-article
           npm run test:playwright:deep-dive-article
+          npm run test:playwright:how-decided-article

--- a/docs/articles/how-dev-loops-decided-itself.html
+++ b/docs/articles/how-dev-loops-decided-itself.html
@@ -285,7 +285,7 @@
 
   <h2 id="era-one-the-next-step-is-always-known">Era one: the next step is always known</h2>
 
-  <p>The earliest records fix the idea the whole system rests on. Work flows through a deterministic state graph where the next action for any change is computed from that graph each time (records 0001 and 0002). A single startup resolver reads authoritative state and hands back a bounded task with the exact files to read and the exact stop conditions (record 0011, and the handoff envelope in record 0016). Loss of a temporary artifact degrades fidelity and the run still recovers, because the source of truth is the state graph, which the chat transcript only mirrors.</p>
+  <p>The earliest records fix the idea the whole system rests on. Work flows through a deterministic state graph where the next action for any change is computed from that graph each time (records 0001 and 0002). A single startup resolver reads authoritative state and hands back a bounded task with the exact files to read and the exact stop conditions (record 0011, and the handoff envelope in record 0016). Loss of a temporary artifact degrades fidelity and the run still recovers, because the source of truth is the state graph, and the chat transcript is a disposable reflection of it.</p>
 
   <p>This is what lets an agent pick up work mid-flight without guessing. The state is on the board; whoever is free reads the next card and pulls it.</p>
 
@@ -321,7 +321,7 @@
 
   <h2 id="what-the-log-is-for">What the log is for</h2>
 
-  <p>A decision record takes three paragraphs to write, and skipping it costs weeks later. Skip it, and six weeks on nobody remembers whether the absolute links in the installed docs were a considered choice or an accident, whether the retrospective was meant to block merges, whether one-reviewer-per-angle was a rule or a habit. The log answers all three, with dates and links, because someone wrote three paragraphs at the moment the decision was made.</p>
+  <p>A decision record takes three paragraphs to write and saves weeks of rework later. Skip it, and six weeks on nobody remembers whether the absolute links in the installed docs were a considered choice or an accident, whether the retrospective was meant to block merges, whether one-reviewer-per-angle was a rule or a habit. The log answers all three, with dates and links, because someone wrote three paragraphs at the moment the decision was made.</p>
 
   <p class="closer">That is the whole practice. The next step is always known, the gate never trusts an assumption, and when a decision turns out wrong, the record of it stays — so the correction has something to point back to.</p>
 

--- a/docs/articles/how-dev-loops-decided-itself.html
+++ b/docs/articles/how-dev-loops-decided-itself.html
@@ -265,16 +265,16 @@
 
   <blockquote>New here? Start with <a href="./introducing-dev-loops.html">Introducing dev-loops</a> for the overview and <a href="./dev-loops-deep-dive.html">the deep dive</a> for the mechanics. This article is the history: how the system arrived at its current shape.</blockquote>
 
-  <p>Most projects explain what they are. This one can explain <em>why it is the way it is</em>, because it kept the receipts. Forty architecture decisions live in the repository as dated records under <code>docs/decisions/</code>, each linking the pull request or issue that made it real. Reading them in order is like watching the system argue itself into its current form — and reverse course twice when the argument turned out wrong.</p>
+  <p>This project can explain <em>why it is the way it is</em>, because it kept the receipts. Forty architecture decisions live in the repository as dated records under <code>docs/decisions/</code>, each linking the pull request or issue that made it real. Reading them in order is like watching the system argue itself into its current form, and reverse course twice when the argument turned out wrong.</p>
 
   <p>This article walks that record. Every figure below was re-derived from the repository at the time of writing.</p>
 
   <div class="metrics" role="list">
-    <div class="metric" role="listitem"><div class="num">68</div><div class="lab">days from first commit to the v1.0.0-rc.3 release candidate</div></div>
-    <div class="metric" role="listitem"><div class="num">1,328</div><div class="lab">commits across 687 merged pull requests</div></div>
+    <div class="metric" role="listitem"><div class="num">68</div><div class="lab">days from the first commit to the v1.0.0-rc.3 release candidate</div></div>
+    <div class="metric" role="listitem"><div class="num">1,320</div><div class="lab">commits at rc.3, across 687 merged pull requests</div></div>
     <div class="metric" role="listitem"><div class="num">26</div><div class="lab">tagged releases, with 7 reverts — about 1% of merged PRs, mostly in release mechanics and doc rewrites</div></div>
     <div class="metric" role="listitem"><div class="num">40</div><div class="lab">recorded architecture decisions, 2 of them later superseded</div></div>
-    <div class="metric" role="listitem"><div class="num">2,972</div><div class="lab">automated checks, up from a suite of 146 test files to 190</div></div>
+    <div class="metric" role="listitem"><div class="num">279</div><div class="lab">test files by rc.3, up from 5 at the first commit</div></div>
   </div>
 
   <h2 id="the-method-is-the-point">The method is the point</h2>
@@ -285,13 +285,13 @@
 
   <h2 id="era-one-the-next-step-is-always-known">Era one: the next step is always known</h2>
 
-  <p>The earliest records fix the idea the whole system rests on. Work flows through a deterministic state graph where the next action for any change is computed, not remembered (records 0001 and 0002). A single startup resolver reads authoritative state and hands back a bounded task with the exact files to read and the exact stop conditions (record 0011, and the handoff envelope in record 0016). Loss of a temporary artifact degrades fidelity and the run still recovers, because the graph, not the chat transcript, is the source of truth.</p>
+  <p>The earliest records fix the idea the whole system rests on. Work flows through a deterministic state graph where the next action for any change is computed from that graph each time (records 0001 and 0002). A single startup resolver reads authoritative state and hands back a bounded task with the exact files to read and the exact stop conditions (record 0011, and the handoff envelope in record 0016). Loss of a temporary artifact degrades fidelity and the run still recovers, because the source of truth is the state graph, which the chat transcript only mirrors.</p>
 
   <p>This is what lets an agent pick up work mid-flight without guessing. The state is on the board; whoever is free reads the next card and pulls it.</p>
 
   <h2 id="era-two-the-gate">Era two: the gate</h2>
 
-  <p>Seventeen days in, on 2026-05-29, the review model arrived that still defines the project (record 0006): two gates, a draft gate before review and a pre-approval gate before merge, with merge authority reserved for a human (record 0007). Gate verdicts became durable, fail-closed evidence rather than an agent's say-so — a comment the coordinator refuses to post unless the checks actually succeeded (record 0008).</p>
+  <p>Seventeen days in, on 2026-05-29, the review model arrived that still defines the project (record 0006): two gates, a draft gate before review and a pre-approval gate before merge, with merge authority reserved for a human (record 0007). Gate verdicts became durable, fail-closed evidence backed by the real check result — a comment the coordinator refuses to post unless the checks actually succeeded (record 0008).</p>
 
   <p>The consequence compounds through everything after it. Once a green result has to come from the real check, the agent can no longer assume the build passed. The single most common failure of an autonomous coder — declaring success over an unverified assumption — is closed off at the seam.</p>
 
@@ -313,15 +313,15 @@
 
   <p>The record shows learning at the policy level. The stronger question is whether the code and the delivery got better in measurable terms, and the repository answers it directly.</p>
 
-  <p>The clearest external signal is review pressure. Counting Copilot's review comments per thousand added lines, week over week, the density fell as the internal gates came online and held — roughly halving from the early weeks to the recent ones. The reviewer that sits outside the system found less to say as the system's own checks caught more first.</p>
+  <p>One external signal points the right way. A separate pass over the review history found Copilot's review comments per thousand added lines falling as the internal gates came online and held. The external reviewer found less to say once the system's own checks were catching problems first.</p>
 
-  <p>Escaped defects stayed rare. Across nearly seven hundred merged pull requests, the count of changes that had to be reverted sits at seven, and those cluster in release mechanics and documentation rewrites rather than gated code paths. The test suite grew alongside the surface it guards, from 146 files to 190, and the contract tests — the ones that fail the build when a rule or an output shape drifts — grew fastest, because each hard-won convention got a guard so it could not quietly erode.</p>
+  <p>Escaped defects stayed rare. Across nearly seven hundred merged pull requests, the count of changes that had to be reverted sits at seven, and those cluster in release mechanics and documentation rewrites. The test suite grew alongside the surface it guards, from 5 files at the first commit to 279, and the contract tests — the ones that fail the build when a rule or an output shape drifts — grew fastest, because each hard-won convention got a guard so it could not quietly erode.</p>
 
-  <p>None of this is a claim that the process is finished. Two of forty decisions were wrong enough to reverse, and the reversals are in the log on purpose. The point is narrower and, for an AI-assisted project, unusual: the system changed its own rules deliberately, wrote down why each time, and the numbers moved the right way while it did.</p>
+  <p>The process is still evolving, and the log says so. Two of forty decisions were wrong enough to reverse, and the reversals are in the log on purpose. The point is narrow and, for an AI-assisted project, unusual: the system changed its own rules deliberately, wrote down why each time, and the numbers moved the right way while it did.</p>
 
   <h2 id="what-the-log-is-for">What the log is for</h2>
 
-  <p>A decision record is cheap to write and expensive to skip. Skip it, and six weeks later nobody remembers whether the absolute links in the installed docs were a considered choice or an accident, whether the retrospective was meant to block merges, whether one-reviewer-per-angle was a rule or a habit. The log answers all three, with dates and links, because someone wrote three paragraphs at the moment the decision was made.</p>
+  <p>A decision record takes three paragraphs to write, and skipping it costs weeks later. Skip it, and six weeks on nobody remembers whether the absolute links in the installed docs were a considered choice or an accident, whether the retrospective was meant to block merges, whether one-reviewer-per-angle was a rule or a habit. The log answers all three, with dates and links, because someone wrote three paragraphs at the moment the decision was made.</p>
 
   <p class="closer">That is the whole practice. The next step is always known, the gate never trusts an assumption, and when a decision turns out wrong, the record of it stays — so the correction has something to point back to.</p>
 

--- a/docs/articles/how-dev-loops-decided-itself.html
+++ b/docs/articles/how-dev-loops-decided-itself.html
@@ -1,0 +1,331 @@
+<!DOCTYPE html>
+<!-- GENERATED from docs/articles/how-dev-loops-decided-itself.md by scripts/pages/render-article.mjs — do not edit; edit the markdown and regenerate. -->
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'" />
+<title>How dev-loops Decided Itself Into Shape</title>
+<style>
+  :root {
+    --ground-1: #08101f;
+    --ground-2: #0b1220;
+    --ground-3: #0f172a;
+    --ink: #e5e7eb;
+    --heading: #f8fafc;
+    --copy: #cbd5e1;
+    --accent: #a78bfa;
+    --accent-soft: #ddd6fe;
+    --kicker: #93c5fd;
+    --card-border: rgba(148, 163, 184, 0.18);
+    --node-border: rgba(129, 140, 248, 0.4);
+    --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Helvetica Neue", sans-serif;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  }
+
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  @media (prefers-reduced-motion: reduce) {
+    html { scroll-behavior: auto; }
+  }
+
+  body {
+    margin: 0;
+    font-family: var(--font);
+    color: var(--ink);
+    overflow-x: hidden;
+    -webkit-text-size-adjust: 100%;
+    background:
+      radial-gradient(circle at 85% 4%, rgba(139, 92, 246, 0.22), transparent 26%),
+      radial-gradient(circle at 12% 2%, rgba(59, 130, 246, 0.16), transparent 22%),
+      linear-gradient(180deg, var(--ground-1) 0%, var(--ground-2) 38%, var(--ground-3) 100%);
+    background-attachment: fixed;
+  }
+
+  .wrap {
+    max-width: 48rem;
+    margin: 0 auto;
+    padding: clamp(2rem, 6vw, 4rem) clamp(1.1rem, 5vw, 2rem) 5rem;
+  }
+
+  /* One column at every width: prose and boxes fill the same wrap, so all
+     left/right edges line up. Desktop widens the column; nothing floats in a
+     narrower centered measure beside a full-width box. */
+  @media (min-width: 900px) {
+    .wrap { max-width: 56rem; }
+  }
+
+  .kicker {
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    font-size: 0.72rem;
+    color: var(--kicker);
+    margin: 0 0 0.6rem;
+    font-weight: 600;
+  }
+
+  h1, h2 { color: var(--heading); letter-spacing: -0.02em; margin-top: 0; }
+  h1 { font-weight: 760; font-size: clamp(1.9rem, 5vw, 2.7rem); line-height: 1.08; margin-bottom: 0.9rem; }
+  h2 { font-weight: 720; font-size: clamp(1.35rem, 3.4vw, 1.85rem); line-height: 1.15; margin: 2.6rem 0 0.9rem; }
+
+  /* part divider: the two big movements of a two-part deep dive */
+  .part {
+    margin: 3.4rem 0 1.4rem;
+    padding-top: 2.2rem;
+    border-top: 1px solid rgba(148, 163, 184, 0.16);
+  }
+  .part .kicker { margin-bottom: 0.4rem; }
+  .part h2 { margin-top: 0; font-size: clamp(1.5rem, 3.8vw, 2.1rem); }
+
+  .lede {
+    color: var(--copy);
+    font-size: clamp(1.08rem, 2.4vw, 1.28rem);
+    line-height: 1.5;
+    margin: 0 0 2rem;
+  }
+
+  p { line-height: 1.72; font-size: 1.05rem; color: var(--ink); margin: 0 0 1.15rem; }
+  strong { color: var(--accent-soft); }
+  em { color: #e2e8f0; font-style: italic; }
+  ul, ol { line-height: 1.7; padding-left: 1.3rem; margin: 0 0 1.15rem; }
+  li + li { margin-top: 0.5rem; }
+  a { color: var(--kicker); text-decoration: none; border-bottom: 1px solid rgba(147, 197, 253, 0.35); }
+  a:hover { border-bottom-color: var(--kicker); }
+
+  /* callout: a left-accent glass panel for asides (e.g. a cross-link nudge) */
+  blockquote {
+    margin: 1.6rem 0;
+    padding: 0.9rem 1.2rem;
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid var(--card-border);
+    border-left: 3px solid var(--accent);
+    border-radius: 0 14px 14px 0;
+    color: var(--copy);
+  }
+  blockquote p { margin: 0; }
+
+  code {
+    font-family: var(--mono);
+    font-size: 0.9em;
+    background: rgba(148, 163, 184, 0.12);
+    border: 1px solid rgba(148, 163, 184, 0.16);
+    border-radius: 6px;
+    padding: 0.05em 0.4em;
+    color: #e2e8f0;
+    overflow-wrap: anywhere;
+  }
+
+  pre {
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0.82), rgba(15, 23, 42, 0.6));
+    border: 1px solid var(--card-border);
+    border-radius: 14px;
+    padding: 1rem 1.15rem;
+    margin: 0 0 1.3rem;
+    overflow-x: auto;
+  }
+  pre code {
+    background: none;
+    border: 0;
+    border-radius: 0;
+    padding: 0;
+    font-size: 0.86rem;
+    line-height: 1.6;
+    color: #e2e8f0;
+    white-space: pre;
+  }
+  pre code .cm { color: #94a3b8; }
+
+  .hero-card {
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0.82), rgba(15, 23, 42, 0.6));
+    border: 1px solid var(--card-border);
+    box-shadow: 0 22px 60px rgba(0, 0, 0, 0.3);
+    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(12px);
+    border-radius: 24px;
+    padding: 1.6rem 1.7rem;
+    margin-bottom: 2.6rem;
+  }
+  .hero-card .lede { margin-bottom: 0; }
+
+  /* diagram figure: glass card + horizontal-scroll safety for wide flows */
+  figure {
+    margin: 1.8rem 0 2rem;
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0.8), rgba(15, 23, 42, 0.62));
+    border: 1px solid var(--card-border);
+    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.26);
+    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(12px);
+    border-radius: 20px;
+    padding: 1.3rem 1.35rem 1.1rem;
+  }
+  .diagram-scroll { overflow-x: auto; padding-bottom: 0.35rem; }
+  figcaption {
+    color: var(--copy);
+    font-size: 0.9rem;
+    line-height: 1.45;
+    margin-top: 1rem;
+    border-top: 1px solid rgba(148, 163, 184, 0.14);
+    padding-top: 0.8rem;
+  }
+  figcaption b { color: var(--accent-soft); font-weight: 650; }
+
+  /* inline flow nodes (ported from the deck's inline-flow technique) */
+  .flow { display: flex; align-items: center; gap: 0; min-width: max-content; }
+  .flow-col { display: flex; flex-direction: column; gap: 0.55rem; justify-content: center; }
+  .node {
+    background: linear-gradient(180deg, rgba(24, 36, 61, 0.92), rgba(17, 24, 39, 0.82));
+    border: 1px solid var(--node-border);
+    border-radius: 14px;
+    padding: 0.55rem 0.85rem;
+    font-family: var(--mono);
+    font-size: 0.8rem;
+    color: #e2e8f0;
+    white-space: nowrap;
+    text-align: center;
+  }
+  .node.accent { border-color: rgba(167, 139, 250, 0.7); color: var(--accent-soft); }
+  .node.start { border-color: rgba(147, 197, 253, 0.6); color: var(--kicker); }
+  .edge {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    color: rgba(148, 163, 184, 0.85);
+    padding: 0 0.6rem;
+    min-width: 3rem;
+  }
+  .edge .arrow { font-size: 1.1rem; line-height: 1; }
+  .edge.dashed .arrow { color: rgba(167, 139, 250, 0.75); }
+  .edge .edge-label {
+    font-size: 0.64rem;
+    color: var(--kicker);
+    text-align: center;
+    margin-top: 0.2rem;
+    max-width: 7.5rem;
+    line-height: 1.2;
+  }
+
+  /* SVG diagrams scale within their scroll container */
+  .diagram-scroll svg { display: block; height: auto; }
+  .diagram-scroll svg text { font-family: var(--mono); fill: #e2e8f0; }
+  .diagram-scroll svg .lab { fill: var(--kicker); font-family: var(--font); }
+
+  /* tree grounding diagram scales down on mobile */
+  .tree-svg { width: 100%; height: auto; display: block; }
+  .tree-svg text { font-family: var(--mono); fill: #e2e8f0; }
+  .tree-svg .lbl { fill: var(--kicker); font-family: var(--font); }
+
+  .closer {
+    color: var(--accent-soft);
+    font-weight: 620;
+    font-size: clamp(1.12rem, 2.6vw, 1.4rem);
+    line-height: 1.4;
+    margin: 1.6rem 0 0;
+  }
+
+  /* metric row for the proof numbers */
+  .metrics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.8rem;
+    margin: 1.8rem 0 2rem;
+  }
+  .metric {
+    flex: 1 1 8rem;
+    min-width: 0;
+    background: linear-gradient(180deg, rgba(24, 36, 61, 0.82), rgba(17, 24, 39, 0.72));
+    border: 1px solid var(--node-border);
+    border-radius: 16px;
+    padding: 1rem 1.1rem;
+  }
+  .metric .num { font-size: 1.5rem; font-weight: 720; color: var(--accent-soft); line-height: 1.05; }
+  .metric .lab { font-size: 0.82rem; color: var(--copy); margin-top: 0.4rem; line-height: 1.35; }
+
+  .rule { border: 0; border-top: 1px solid rgba(148, 163, 184, 0.16); margin: 3rem 0; }
+
+  .deeper {
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    padding: 1.2rem 1.35rem;
+    margin-top: 2rem;
+  }
+  .deeper h2 { margin-top: 0; font-size: 1.2rem; }
+  .deeper p { margin-bottom: 0; font-size: 0.98rem; color: var(--copy); }
+</style>
+</head>
+<body>
+<div class="wrap">
+<article class="article">
+
+  <header class="hero-card">
+    <p class="kicker">dev-loops</p>
+    <h1>How dev-loops Decided Itself Into Shape</h1>
+    <p class="lede">Over 68 days the project made forty architecture-shaping decisions, wrote each one down, and reversed the two that turned out wrong. This is the history read straight from that record.</p>
+  </header>
+
+  <blockquote>New here? Start with <a href="./introducing-dev-loops.html">Introducing dev-loops</a> for the overview and <a href="./dev-loops-deep-dive.html">the deep dive</a> for the mechanics. This article is the history: how the system arrived at its current shape.</blockquote>
+
+  <p>Most projects explain what they are. This one can explain <em>why it is the way it is</em>, because it kept the receipts. Forty architecture decisions live in the repository as dated records under <code>docs/decisions/</code>, each linking the pull request or issue that made it real. Reading them in order is like watching the system argue itself into its current form — and reverse course twice when the argument turned out wrong.</p>
+
+  <p>This article walks that record. Every figure below was re-derived from the repository at the time of writing.</p>
+
+  <div class="metrics" role="list">
+    <div class="metric" role="listitem"><div class="num">68</div><div class="lab">days from first commit to the v1.0.0-rc.3 release candidate</div></div>
+    <div class="metric" role="listitem"><div class="num">1,328</div><div class="lab">commits across 687 merged pull requests</div></div>
+    <div class="metric" role="listitem"><div class="num">26</div><div class="lab">tagged releases, with 7 reverts — about 1% of merged PRs, mostly in release mechanics and doc rewrites</div></div>
+    <div class="metric" role="listitem"><div class="num">40</div><div class="lab">recorded architecture decisions, 2 of them later superseded</div></div>
+    <div class="metric" role="listitem"><div class="num">2,972</div><div class="lab">automated checks, up from a suite of 146 test files to 190</div></div>
+  </div>
+
+  <h2 id="the-method-is-the-point">The method is the point</h2>
+
+  <p>A decision earns a record when it shapes policy or architecture — a review economics choice, a seam other work has to build against, or a reversal of something already established. Routine features and fixes stay out. That bar keeps the log to the load-bearing forty, which is few enough to read in a sitting and honest enough to include the mistakes.</p>
+
+  <p>The record itself is plain: context, decision, consequences, and a dated link to the accepting event. When a later decision overturns an earlier one, the old record stays and its status flips to superseded, with a link forward. Nothing is quietly deleted, so the history stays legible even where it doubled back.</p>
+
+  <h2 id="era-one-the-next-step-is-always-known">Era one: the next step is always known</h2>
+
+  <p>The earliest records fix the idea the whole system rests on. Work flows through a deterministic state graph where the next action for any change is computed, not remembered (records 0001 and 0002). A single startup resolver reads authoritative state and hands back a bounded task with the exact files to read and the exact stop conditions (record 0011, and the handoff envelope in record 0016). Loss of a temporary artifact degrades fidelity and the run still recovers, because the graph, not the chat transcript, is the source of truth.</p>
+
+  <p>This is what lets an agent pick up work mid-flight without guessing. The state is on the board; whoever is free reads the next card and pulls it.</p>
+
+  <h2 id="era-two-the-gate">Era two: the gate</h2>
+
+  <p>Seventeen days in, on 2026-05-29, the review model arrived that still defines the project (record 0006): two gates, a draft gate before review and a pre-approval gate before merge, with merge authority reserved for a human (record 0007). Gate verdicts became durable, fail-closed evidence rather than an agent's say-so — a comment the coordinator refuses to post unless the checks actually succeeded (record 0008).</p>
+
+  <p>The consequence compounds through everything after it. Once a green result has to come from the real check, the agent can no longer assume the build passed. The single most common failure of an autonomous coder — declaring success over an unverified assumption — is closed off at the seam.</p>
+
+  <h2 id="era-three-portability-then-a-reversal">Era three: portability, then a reversal</h2>
+
+  <p>The runtime began coupled to one agent harness. The adapter-seam decision decoupled it (record 0020), routing every harness dependency through frozen, validated boundaries with implementations for each host and a generator that fails the build on drift. The system could now run under more than one harness without a parallel copy of its assets.</p>
+
+  <p>Then the first big reversal. The project had started tracker-first: every change minted a GitHub issue, went through refinement ceremony, and produced a phase document (record 0003, 2026-05-15). Operating experience showed most work is specified and reviewed better locally, before it touches the tracker. So the default flipped to local-first, with a lightweight path that treats a pull request description itself as the spec (record 0018, 2026-06-12, supersedes 0003). The old record stays in the log, marked superseded, because the wrong turn is part of the history worth keeping.</p>
+
+  <h2 id="era-four-the-loop-turns-on-itself">Era four: the loop turns on itself</h2>
+
+  <p>The later records are the system improving its own machinery. Review fans out into independent angles and fans back in (record 0021). A round cap keeps the Copilot review loop from spinning (record 0012). Every operator-facing tool gained a uniform, machine-readable output contract, enforced by a test that fails the build if a new command ships without it (record 0025). Rule identifiers became single-owner and permanent (record 0027).</p>
+
+  <p>The sharpest of these came from a mistake the system caught in itself. Gate reviews had drifted toward grouping several review angles into one agent to save tokens, which quietly recreates a single reviewer approving their own bundle. The fix made one scoped reviewer per fresh angle a machine-enforced requirement at both write and read time (record 0039) — and the new floor then caught its own author miscounting reviewer provenance within hours of shipping.</p>
+
+  <p>The second reversal lives here too. An enforced retrospective gate, meant to make the system reflect before merging, kept deadlocking ordinary product work on self-analysis noise (record 0009). The decision that followed made the retrospective advisory: its findings travel in the handoff envelope and a comment, and never block a merge (record 0024, 2026-07-02, supersedes 0009). A valuable practice had been mounted at the wrong boundary, and the log records both the mounting and the correction.</p>
+
+  <h2 id="did-it-actually-get-better">Did it actually get better?</h2>
+
+  <p>The record shows learning at the policy level. The stronger question is whether the code and the delivery got better in measurable terms, and the repository answers it directly.</p>
+
+  <p>The clearest external signal is review pressure. Counting Copilot's review comments per thousand added lines, week over week, the density fell as the internal gates came online and held — roughly halving from the early weeks to the recent ones. The reviewer that sits outside the system found less to say as the system's own checks caught more first.</p>
+
+  <p>Escaped defects stayed rare. Across nearly seven hundred merged pull requests, the count of changes that had to be reverted sits at seven, and those cluster in release mechanics and documentation rewrites rather than gated code paths. The test suite grew alongside the surface it guards, from 146 files to 190, and the contract tests — the ones that fail the build when a rule or an output shape drifts — grew fastest, because each hard-won convention got a guard so it could not quietly erode.</p>
+
+  <p>None of this is a claim that the process is finished. Two of forty decisions were wrong enough to reverse, and the reversals are in the log on purpose. The point is narrower and, for an AI-assisted project, unusual: the system changed its own rules deliberately, wrote down why each time, and the numbers moved the right way while it did.</p>
+
+  <h2 id="what-the-log-is-for">What the log is for</h2>
+
+  <p>A decision record is cheap to write and expensive to skip. Skip it, and six weeks later nobody remembers whether the absolute links in the installed docs were a considered choice or an accident, whether the retrospective was meant to block merges, whether one-reviewer-per-angle was a rule or a habit. The log answers all three, with dates and links, because someone wrote three paragraphs at the moment the decision was made.</p>
+
+  <p class="closer">That is the whole practice. The next step is always known, the gate never trusts an assumption, and when a decision turns out wrong, the record of it stays — so the correction has something to point back to.</p>
+
+</article>
+</div>
+</body>
+</html>

--- a/docs/articles/how-dev-loops-decided-itself.md
+++ b/docs/articles/how-dev-loops-decided-itself.md
@@ -35,7 +35,7 @@ The record itself is plain: context, decision, consequences, and a dated link to
 
 ## Era one: the next step is always known
 
-The earliest records fix the idea the whole system rests on. Work flows through a deterministic state graph where the next action for any change is computed from that graph each time (records 0001 and 0002). A single startup resolver reads authoritative state and hands back a bounded task with the exact files to read and the exact stop conditions (record 0011, and the handoff envelope in record 0016). Loss of a temporary artifact degrades fidelity and the run still recovers, because the source of truth is the state graph, which the chat transcript only mirrors.
+The earliest records fix the idea the whole system rests on. Work flows through a deterministic state graph where the next action for any change is computed from that graph each time (records 0001 and 0002). A single startup resolver reads authoritative state and hands back a bounded task with the exact files to read and the exact stop conditions (record 0011, and the handoff envelope in record 0016). Loss of a temporary artifact degrades fidelity and the run still recovers, because the source of truth is the state graph, and the chat transcript is a disposable reflection of it.
 
 This is what lets an agent pick up work mid-flight without guessing. The state is on the board; whoever is free reads the next card and pulls it.
 
@@ -71,6 +71,6 @@ The process is still evolving, and the log says so. Two of forty decisions were 
 
 ## What the log is for
 
-A decision record takes three paragraphs to write, and skipping it costs weeks later. Skip it, and six weeks on nobody remembers whether the absolute links in the installed docs were a considered choice or an accident, whether the retrospective was meant to block merges, whether one-reviewer-per-angle was a rule or a habit. The log answers all three, with dates and links, because someone wrote three paragraphs at the moment the decision was made.
+A decision record takes three paragraphs to write and saves weeks of rework later. Skip it, and six weeks on nobody remembers whether the absolute links in the installed docs were a considered choice or an accident, whether the retrospective was meant to block merges, whether one-reviewer-per-angle was a rule or a habit. The log answers all three, with dates and links, because someone wrote three paragraphs at the moment the decision was made.
 
 That is the whole practice. The next step is always known, the gate never trusts an assumption, and when a decision turns out wrong, the record of it stays — so the correction has something to point back to.

--- a/docs/articles/how-dev-loops-decided-itself.md
+++ b/docs/articles/how-dev-loops-decided-itself.md
@@ -15,16 +15,16 @@ outro: closer
 
 > New here? Start with [Introducing dev-loops](./introducing-dev-loops.md) for the overview and [the deep dive](./dev-loops-deep-dive.md) for the mechanics. This article is the history: how the system arrived at its current shape.
 
-Most projects explain what they are. This one can explain *why it is the way it is*, because it kept the receipts. Forty architecture decisions live in the repository as dated records under `docs/decisions/`, each linking the pull request or issue that made it real. Reading them in order is like watching the system argue itself into its current form — and reverse course twice when the argument turned out wrong.
+This project can explain *why it is the way it is*, because it kept the receipts. Forty architecture decisions live in the repository as dated records under `docs/decisions/`, each linking the pull request or issue that made it real. Reading them in order is like watching the system argue itself into its current form, and reverse course twice when the argument turned out wrong.
 
 This article walks that record. Every figure below was re-derived from the repository at the time of writing.
 
 <!-- metrics:start -->
-- **68** days from first commit to the v1.0.0-rc.3 release candidate
-- **1,328** commits across 687 merged pull requests
+- **68** days from the first commit to the v1.0.0-rc.3 release candidate
+- **1,320** commits at rc.3, across 687 merged pull requests
 - **26** tagged releases, with 7 reverts — about 1% of merged PRs, mostly in release mechanics and doc rewrites
 - **40** recorded architecture decisions, 2 of them later superseded
-- **2,972** automated checks, up from a suite of 146 test files to 190
+- **279** test files by rc.3, up from 5 at the first commit
 <!-- metrics:end -->
 
 ## The method is the point
@@ -35,13 +35,13 @@ The record itself is plain: context, decision, consequences, and a dated link to
 
 ## Era one: the next step is always known
 
-The earliest records fix the idea the whole system rests on. Work flows through a deterministic state graph where the next action for any change is computed, not remembered (records 0001 and 0002). A single startup resolver reads authoritative state and hands back a bounded task with the exact files to read and the exact stop conditions (record 0011, and the handoff envelope in record 0016). Loss of a temporary artifact degrades fidelity and the run still recovers, because the graph, not the chat transcript, is the source of truth.
+The earliest records fix the idea the whole system rests on. Work flows through a deterministic state graph where the next action for any change is computed from that graph each time (records 0001 and 0002). A single startup resolver reads authoritative state and hands back a bounded task with the exact files to read and the exact stop conditions (record 0011, and the handoff envelope in record 0016). Loss of a temporary artifact degrades fidelity and the run still recovers, because the source of truth is the state graph, which the chat transcript only mirrors.
 
 This is what lets an agent pick up work mid-flight without guessing. The state is on the board; whoever is free reads the next card and pulls it.
 
 ## Era two: the gate
 
-Seventeen days in, on 2026-05-29, the review model arrived that still defines the project (record 0006): two gates, a draft gate before review and a pre-approval gate before merge, with merge authority reserved for a human (record 0007). Gate verdicts became durable, fail-closed evidence rather than an agent's say-so — a comment the coordinator refuses to post unless the checks actually succeeded (record 0008).
+Seventeen days in, on 2026-05-29, the review model arrived that still defines the project (record 0006): two gates, a draft gate before review and a pre-approval gate before merge, with merge authority reserved for a human (record 0007). Gate verdicts became durable, fail-closed evidence backed by the real check result — a comment the coordinator refuses to post unless the checks actually succeeded (record 0008).
 
 The consequence compounds through everything after it. Once a green result has to come from the real check, the agent can no longer assume the build passed. The single most common failure of an autonomous coder — declaring success over an unverified assumption — is closed off at the seam.
 
@@ -63,14 +63,14 @@ The second reversal lives here too. An enforced retrospective gate, meant to mak
 
 The record shows learning at the policy level. The stronger question is whether the code and the delivery got better in measurable terms, and the repository answers it directly.
 
-The clearest external signal is review pressure. Counting Copilot's review comments per thousand added lines, week over week, the density fell as the internal gates came online and held — roughly halving from the early weeks to the recent ones. The reviewer that sits outside the system found less to say as the system's own checks caught more first.
+One external signal points the right way. A separate pass over the review history found Copilot's review comments per thousand added lines falling as the internal gates came online and held. The external reviewer found less to say once the system's own checks were catching problems first.
 
-Escaped defects stayed rare. Across nearly seven hundred merged pull requests, the count of changes that had to be reverted sits at seven, and those cluster in release mechanics and documentation rewrites rather than gated code paths. The test suite grew alongside the surface it guards, from 146 files to 190, and the contract tests — the ones that fail the build when a rule or an output shape drifts — grew fastest, because each hard-won convention got a guard so it could not quietly erode.
+Escaped defects stayed rare. Across nearly seven hundred merged pull requests, the count of changes that had to be reverted sits at seven, and those cluster in release mechanics and documentation rewrites. The test suite grew alongside the surface it guards, from 5 files at the first commit to 279, and the contract tests — the ones that fail the build when a rule or an output shape drifts — grew fastest, because each hard-won convention got a guard so it could not quietly erode.
 
-None of this is a claim that the process is finished. Two of forty decisions were wrong enough to reverse, and the reversals are in the log on purpose. The point is narrower and, for an AI-assisted project, unusual: the system changed its own rules deliberately, wrote down why each time, and the numbers moved the right way while it did.
+The process is still evolving, and the log says so. Two of forty decisions were wrong enough to reverse, and the reversals are in the log on purpose. The point is narrow and, for an AI-assisted project, unusual: the system changed its own rules deliberately, wrote down why each time, and the numbers moved the right way while it did.
 
 ## What the log is for
 
-A decision record is cheap to write and expensive to skip. Skip it, and six weeks later nobody remembers whether the absolute links in the installed docs were a considered choice or an accident, whether the retrospective was meant to block merges, whether one-reviewer-per-angle was a rule or a habit. The log answers all three, with dates and links, because someone wrote three paragraphs at the moment the decision was made.
+A decision record takes three paragraphs to write, and skipping it costs weeks later. Skip it, and six weeks on nobody remembers whether the absolute links in the installed docs were a considered choice or an accident, whether the retrospective was meant to block merges, whether one-reviewer-per-angle was a rule or a habit. The log answers all three, with dates and links, because someone wrote three paragraphs at the moment the decision was made.
 
 That is the whole practice. The next step is always known, the gate never trusts an assumption, and when a decision turns out wrong, the record of it stays — so the correction has something to point back to.

--- a/docs/articles/how-dev-loops-decided-itself.md
+++ b/docs/articles/how-dev-loops-decided-itself.md
@@ -1,0 +1,76 @@
+---
+title: "How dev-loops Decided Itself Into Shape"
+subtitle: "A working system that kept a record of its own architecture decisions, reversed the ones that were wrong, and got measurably better while doing it."
+heroLede: "Over 68 days the project made forty architecture-shaping decisions, wrote each one down, and reversed the two that turned out wrong. This is the history read straight from that record."
+tags:
+  - AI
+  - Software Engineering
+  - Developer Tools
+  - Process
+  - Architecture Decisions
+outro: closer
+---
+
+# How dev-loops Decided Itself Into Shape
+
+> New here? Start with [Introducing dev-loops](./introducing-dev-loops.md) for the overview and [the deep dive](./dev-loops-deep-dive.md) for the mechanics. This article is the history: how the system arrived at its current shape.
+
+Most projects explain what they are. This one can explain *why it is the way it is*, because it kept the receipts. Forty architecture decisions live in the repository as dated records under `docs/decisions/`, each linking the pull request or issue that made it real. Reading them in order is like watching the system argue itself into its current form — and reverse course twice when the argument turned out wrong.
+
+This article walks that record. Every figure below was re-derived from the repository at the time of writing.
+
+<!-- metrics:start -->
+- 68 days from first commit to the v1.0.0-rc.3 release candidate
+- 1,328 commits across 687 merged pull requests
+- 26 tagged releases, 7 reverts (about 1% of merged PRs), mostly in release mechanics and doc rewrites rather than gated code
+- 40 recorded architecture decisions, 2 of them later superseded
+- The automated test suite grew from 146 test files to 190, and now runs 2,972 checks
+<!-- metrics:end -->
+
+## The method is the point
+
+A decision earns a record when it shapes policy or architecture — a review economics choice, a seam other work has to build against, or a reversal of something already established. Routine features and fixes stay out. That bar keeps the log to the load-bearing forty, which is few enough to read in a sitting and honest enough to include the mistakes.
+
+The record itself is plain: context, decision, consequences, and a dated link to the accepting event. When a later decision overturns an earlier one, the old record stays and its status flips to superseded, with a link forward. Nothing is quietly deleted, so the history stays legible even where it doubled back.
+
+## Era one: the next step is always known
+
+The earliest records fix the idea the whole system rests on. Work flows through a deterministic state graph where the next action for any change is computed, not remembered (records 0001 and 0002). A single startup resolver reads authoritative state and hands back a bounded task with the exact files to read and the exact stop conditions (record 0011, and the handoff envelope in record 0016). Loss of a temporary artifact degrades fidelity and the run still recovers, because the graph, not the chat transcript, is the source of truth.
+
+This is what lets an agent pick up work mid-flight without guessing. The state is on the board; whoever is free reads the next card and pulls it.
+
+## Era two: the gate
+
+Seventeen days in, on 2026-05-29, the review model arrived that still defines the project (record 0006): two gates, a draft gate before review and a pre-approval gate before merge, with merge authority reserved for a human (record 0007). Gate verdicts became durable, fail-closed evidence rather than an agent's say-so — a comment the coordinator refuses to post unless the checks actually succeeded (record 0008).
+
+The consequence compounds through everything after it. Once a green result has to come from the real check, the agent can no longer assume the build passed. The single most common failure of an autonomous coder — declaring success over an unverified assumption — is closed off at the seam.
+
+## Era three: portability, then a reversal
+
+The runtime began coupled to one agent harness. The adapter-seam decision decoupled it (record 0020), routing every harness dependency through frozen, validated boundaries with implementations for each host and a generator that fails the build on drift. The system could now run under more than one harness without a parallel copy of its assets.
+
+Then the first big reversal. The project had started tracker-first: every change minted a GitHub issue, went through refinement ceremony, and produced a phase document (record 0003, 2026-05-15). Operating experience showed most work is specified and reviewed better locally, before it touches the tracker. So the default flipped to local-first, with a lightweight path that treats a pull request description itself as the spec (record 0018, 2026-06-12, supersedes 0003). The old record stays in the log, marked superseded, because the wrong turn is part of the history worth keeping.
+
+## Era four: the loop turns on itself
+
+The later records are the system improving its own machinery. Review fans out into independent angles and fans back in (record 0021). A round cap keeps the Copilot review loop from spinning (record 0012). Every operator-facing tool gained a uniform, machine-readable output contract, enforced by a test that fails the build if a new command ships without it (record 0025). Rule identifiers became single-owner and permanent (record 0027).
+
+The sharpest of these came from a mistake the system caught in itself. Gate reviews had drifted toward grouping several review angles into one agent to save tokens, which quietly recreates a single reviewer approving their own bundle. The fix made one scoped reviewer per fresh angle a machine-enforced requirement at both write and read time (record 0039) — and the new floor then caught its own author miscounting reviewer provenance within hours of shipping.
+
+The second reversal lives here too. An enforced retrospective gate, meant to make the system reflect before merging, kept deadlocking ordinary product work on self-analysis noise (record 0009). The decision that followed made the retrospective advisory: its findings travel in the handoff envelope and a comment, and never block a merge (record 0024, 2026-07-02, supersedes 0009). A valuable practice had been mounted at the wrong boundary, and the log records both the mounting and the correction.
+
+## Did it actually get better?
+
+The record shows learning at the policy level. The stronger question is whether the code and the delivery got better in measurable terms, and the repository answers it directly.
+
+The clearest external signal is review pressure. Counting Copilot's review comments per thousand added lines, week over week, the density fell as the internal gates came online and held — roughly halving from the early weeks to the recent ones. The reviewer that sits outside the system found less to say as the system's own checks caught more first.
+
+Escaped defects stayed rare. Across nearly seven hundred merged pull requests, the count of changes that had to be reverted sits at seven, and those cluster in release mechanics and documentation rewrites rather than gated code paths. The test suite grew alongside the surface it guards, from 146 files to 190, and the contract tests — the ones that fail the build when a rule or an output shape drifts — grew fastest, because each hard-won convention got a guard so it could not quietly erode.
+
+None of this is a claim that the process is finished. Two of forty decisions were wrong enough to reverse, and the reversals are in the log on purpose. The point is narrower and, for an AI-assisted project, unusual: the system changed its own rules deliberately, wrote down why each time, and the numbers moved the right way while it did.
+
+## What the log is for
+
+A decision record is cheap to write and expensive to skip. Skip it, and six weeks later nobody remembers whether the absolute links in the installed docs were a considered choice or an accident, whether the retrospective was meant to block merges, whether one-reviewer-per-angle was a rule or a habit. The log answers all three, with dates and links, because someone wrote three paragraphs at the moment the decision was made.
+
+That is the whole practice. The next step is always known, the gate never trusts an assumption, and when a decision turns out wrong, the record of it stays — so the correction has something to point back to.

--- a/docs/articles/how-dev-loops-decided-itself.md
+++ b/docs/articles/how-dev-loops-decided-itself.md
@@ -20,11 +20,11 @@ Most projects explain what they are. This one can explain *why it is the way it 
 This article walks that record. Every figure below was re-derived from the repository at the time of writing.
 
 <!-- metrics:start -->
-- 68 days from first commit to the v1.0.0-rc.3 release candidate
-- 1,328 commits across 687 merged pull requests
-- 26 tagged releases, 7 reverts (about 1% of merged PRs), mostly in release mechanics and doc rewrites rather than gated code
-- 40 recorded architecture decisions, 2 of them later superseded
-- The automated test suite grew from 146 test files to 190, and now runs 2,972 checks
+- **68** days from first commit to the v1.0.0-rc.3 release candidate
+- **1,328** commits across 687 merged pull requests
+- **26** tagged releases, with 7 reverts — about 1% of merged PRs, mostly in release mechanics and doc rewrites
+- **40** recorded architecture decisions, 2 of them later superseded
+- **2,972** automated checks, up from a suite of 146 test files to 190
 <!-- metrics:end -->
 
 ## The method is the point

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,11 +41,13 @@ Start here for repository documentation.
 
 - [Introducing dev-loops](./articles/introducing-dev-loops.md) — start here: what dev-loops is, the proof from its own history, and how to adopt it
 - [dev-loops: A Deep Dive](./articles/dev-loops-deep-dive.md) — deep dive in two parts: why every handoff is an explicit decision on a state graph, then measuring the waiting between actions
+- [How dev-loops Decided Itself Into Shape](./articles/how-dev-loops-decided-itself.md) — the history: forty dated architecture decisions, the two reversals, and the outcomes, read straight from the decision log
 
 ## Presentations
 
 - [Applied Dev Loops Presentation](./presentations/applied-dev-loops-presentation.md)
 - [Process Observability Presentation](./presentations/process-observability-presentation.md)
+- [How dev-loops Decided Itself Into Shape (deck)](./presentations/how-dev-loops-decided-itself.html) — the evolution/history narrated through the decision log
 - `docs/presentations/style.css`
 
 ## Canonical-owner pointers

--- a/docs/presentations/how-dev-loops-decided-itself.html
+++ b/docs/presentations/how-dev-loops-decided-itself.html
@@ -253,7 +253,7 @@
     <div class="grid grid-2">
       <div class="glass-card">
         <ul class="tight-list">
-          <li>A decision earns a record when it shapes policy or architecture. Routine features and fixes stay out.</li>
+          <li>Records are reserved for decisions that shape policy or architecture; routine features and fixes are not recorded.</li>
           <li>Each record is plain: context, decision, consequences, and a dated link to the accepting pull request or issue.</li>
           <li>When a later decision overturns an earlier one, the old record stays and its status flips to superseded, with a link forward.</li>
           <li>Nothing is quietly deleted, so the history stays legible even where it doubled back.</li>
@@ -276,12 +276,12 @@
         <ul class="tight-list">
           <li>Work flows through a deterministic state graph where the next action for any change is computed from that graph each time (records 0001 and 0002).</li>
           <li>A startup resolver hands back a bounded task with the exact files to read and the exact stop conditions (records 0011 and 0016).</li>
-          <li>Lose a temporary artifact and the run still recovers, because the source of truth is the state graph, which the chat transcript only mirrors.</li>
+          <li>Lose a temporary artifact and the run still recovers, because the source of truth is the state graph, and the chat transcript is a disposable reflection of it.</li>
         </ul>
       </div>
       <div class="glass-card">
         <p class="card-label">Why it matters</p>
-        <p>An agent picks up work mid-flight without guessing. The state is on the board; whoever is free reads the next card and pulls it.</p>
+        <p>An agent picks up work mid-flight and computes the next step from the state graph. The state is on the board; whoever is free reads the next card and pulls it.</p>
       </div>
     </div>
   </div>
@@ -290,7 +290,7 @@
 <section class="slide" id="the-gate">
   <div class="slide-inner">
     <p class="kicker">Era two &middot; day seventeen</p>
-    <h2>The Gate Never Trusts an Assumption</h2>
+    <h2>Every Gate Verdict Comes From a Real Check</h2>
     <div class="grid grid-2">
       <div class="glass-card">
         <ul class="tight-list">
@@ -301,7 +301,7 @@
       </div>
       <div class="metric-card">
         <p class="card-label">The failure it closes</p>
-        <p>Once a green result has to come from the real check, the agent can no longer declare success over an unverified assumption. The most common failure of an autonomous coder is closed off at the seam.</p>
+        <p>Once a green result has to come from the real check, the agent's success claim has to match that result. The most common failure of an autonomous coder is closed off at the seam.</p>
       </div>
     </div>
   </div>
@@ -310,7 +310,7 @@
 <section class="slide" id="reversal-local-first">
   <div class="slide-inner">
     <p class="kicker">Era three &middot; the first reversal</p>
-    <h2>Tracker-First Became Local-First</h2>
+    <h2>The Default Flipped to Local-First</h2>
     <div class="grid grid-2">
       <div class="glass-card">
         <p class="card-label">Superseded &mdash; record 0003 (2026-05-15)</p>
@@ -388,7 +388,7 @@
     <div class="hero-card">
       <p class="kicker">What the log is for</p>
       <h2>The Correction Has Something to Point Back To</h2>
-      <p class="hero-copy">The next step is always known, the gate never trusts an assumption, and when a decision turns out wrong, the record of it stays. A decision record takes three paragraphs to write, and skipping it costs weeks later.</p>
+      <p class="hero-copy">The next step is always computable, every gate verdict comes from a real check, and when a decision turns out wrong its record stays. A decision record takes three paragraphs to write and saves weeks of rework later.</p>
     </div>
   </div>
 </section>

--- a/docs/presentations/how-dev-loops-decided-itself.html
+++ b/docs/presentations/how-dev-loops-decided-itself.html
@@ -1,0 +1,441 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'" />
+<title>dev-loops: How It Decided Itself</title>
+<style>
+  :root {
+    --ground-1: #08101f;
+    --ground-2: #0b1220;
+    --ground-3: #0f172a;
+    --ink: #e5e7eb;
+    --heading: #f8fafc;
+    --copy: #cbd5e1;
+    --accent: #a78bfa;
+    --accent-soft: #ddd6fe;
+    --kicker: #93c5fd;
+    --card-border: rgba(148, 163, 184, 0.18);
+    --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Helvetica Neue", sans-serif;
+  }
+
+  * { box-sizing: border-box; }
+
+  html { scroll-behavior: smooth; }
+  body {
+    margin: 0;
+    font-family: var(--font);
+    color: var(--ink);
+    background: var(--ground-3);
+    overflow-x: hidden;
+    -webkit-text-size-adjust: 100%;
+    scroll-snap-type: y mandatory;
+    height: 100vh;
+    overflow-y: auto;
+  }
+
+  .slide {
+    position: relative;
+    min-height: 100vh;
+    padding: clamp(2rem, 4vh, 4rem) clamp(1.25rem, 4vw, 4rem);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    overflow: visible;
+    scroll-snap-align: start;
+    background:
+      radial-gradient(circle at 85% 12%, rgba(139, 92, 246, 0.24), transparent 24%),
+      radial-gradient(circle at 15% 8%, rgba(59, 130, 246, 0.18), transparent 20%),
+      linear-gradient(180deg, var(--ground-1) 0%, var(--ground-2) 42%, var(--ground-3) 100%);
+    border-top: 1px solid rgba(148, 163, 184, 0.08);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    html { scroll-behavior: auto; }
+    body { scroll-snap-type: none; }
+    .slide { scroll-snap-align: none; }
+  }
+
+  .slide::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image:
+      linear-gradient(rgba(148, 163, 184, 0.045) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(148, 163, 184, 0.045) 1px, transparent 1px);
+    background-size: 42px 42px;
+    -webkit-mask-image: linear-gradient(180deg, rgba(255,255,255,0.28), transparent 72%);
+    mask-image: linear-gradient(180deg, rgba(255,255,255,0.28), transparent 72%);
+  }
+
+  .slide > * { position: relative; z-index: 1; }
+
+  .slide-inner { width: 100%; max-width: 88rem; margin: 0 auto; }
+
+  h1, h2, h3 { color: var(--heading); letter-spacing: -0.02em; line-height: 1.05; margin-top: 0; }
+  h1 { font-weight: 760; margin-bottom: 0.6rem; }
+  h2 { margin-bottom: clamp(0.75rem, 1vw, 1.25rem); font-size: clamp(1.5rem, 3.2vw, 3rem); font-weight: 720; text-wrap: balance; }
+  h3 { margin-bottom: 0.6rem; }
+
+  p, li { font-size: clamp(1rem, 1.1vw, 1.2rem); line-height: 1.55; overflow-wrap: anywhere; }
+  strong { color: var(--accent-soft); }
+  em { color: #e2e8f0; font-style: italic; }
+
+  code {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.92em;
+    background: rgba(148, 163, 184, 0.12);
+    border: 1px solid rgba(148, 163, 184, 0.16);
+    border-radius: 6px;
+    padding: 0.05em 0.4em;
+    color: #e2e8f0;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .kicker {
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    font-size: clamp(0.72rem, 0.85vw, 1.05rem);
+    color: var(--kicker);
+    margin: 0 0 clamp(0.45rem, 0.5vw, 0.7rem);
+    font-weight: 600;
+  }
+
+  .glass-card, .hero-card, .metric-card {
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0.8), rgba(15, 23, 42, 0.62));
+    border: 1px solid var(--card-border);
+    box-shadow: 0 22px 60px rgba(0, 0, 0, 0.28);
+    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(12px);
+    border-radius: 24px;
+    padding: clamp(1.25rem, 1.5vw, 2rem) clamp(1.35rem, 1.8vw, 2.5rem);
+  }
+
+  .metric-card {
+    background: linear-gradient(180deg, rgba(24, 36, 61, 0.92), rgba(17, 24, 39, 0.78));
+    border-color: rgba(129, 140, 248, 0.35);
+    box-shadow: 0 18px 44px rgba(0, 0, 0, 0.24);
+  }
+  .metric-figure { font-size: clamp(2rem, 6vw, 2.8rem); font-weight: 740; color: var(--accent-soft); line-height: 1; margin: 0 0 0.35rem; letter-spacing: -0.02em; }
+  .metric-label { color: var(--copy); font-size: 0.92rem; margin: 0; }
+
+  .hero-card h1 { font-size: clamp(2rem, 5.2vw, 4.5rem); margin-bottom: clamp(1rem, 1.2vw, 1.6rem); }
+  .hero-copy {
+    max-width: 56rem;
+    color: var(--copy);
+    font-size: clamp(1.05rem, 2.4vw, 1.6rem);
+    margin: 0;
+  }
+
+  .grid { display: grid; gap: clamp(1rem, 1.5vw, 2rem); align-items: stretch; }
+  .grid > * { min-width: 0; }
+  .grid > .glass-card, .grid > .metric-card { display: flex; flex-direction: column; min-width: 0; }
+  .grid-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+
+  @media (max-width: 860px) {
+    .grid-2, .grid-3 { grid-template-columns: 1fr; }
+  }
+
+  .tight-list, .mini-list { margin: 0; padding-left: 1.1rem; color: #e2e8f0; }
+  .tight-list li + li { margin-top: clamp(0.4rem, 0.5vw, 0.65rem); }
+  .mini-list li + li { margin-top: clamp(0.45rem, 0.55vw, 0.7rem); }
+
+  .chip-row { display: flex; gap: clamp(0.5rem, 0.65vw, 0.85rem); flex-wrap: wrap; margin-top: clamp(0.85rem, 1vw, 1.3rem); }
+
+  .pill {
+    display: inline-flex;
+    align-items: center;
+    padding: clamp(0.4rem, 0.4vw, 0.55rem) clamp(0.85rem, 0.9vw, 1.15rem);
+    border-radius: 9999px;
+    background: rgba(15, 23, 42, 0.72);
+    border: 1px solid rgba(167, 139, 250, 0.35);
+    color: var(--accent-soft);
+    font-size: clamp(0.86rem, 0.9vw, 1.05rem);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  }
+
+  .card-narrow { max-width: 58rem; }
+
+  .closer { justify-content: center; }
+  .closer .hero-copy {
+    text-align: center;
+    font-weight: 620;
+    font-size: clamp(1.15rem, 2.6vw, 2.2rem);
+    line-height: 1.35;
+    color: var(--accent-soft);
+  }
+
+  .flow-card { justify-content: center; }
+
+  .soft-note { color: var(--copy); margin-top: clamp(0.75rem, 0.9vw, 1.25rem); font-size: clamp(0.95rem, 1vw, 1.15rem); }
+  .note-top-md { margin-top: clamp(0.65rem, 0.8vw, 1rem); }
+  .note-top-sm { margin-top: clamp(0.4rem, 0.5vw, 0.65rem); }
+  .card-label { color: var(--accent-soft); font-weight: 650; margin: 0 0 clamp(0.6rem, 0.7vw, 1rem); font-size: clamp(0.95rem, 1vw, 1.15rem); }
+
+  .flow-scroll {
+    margin-top: clamp(1.2rem, 1.4vw, 1.8rem);
+    padding-bottom: 0.5rem;
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: auto;
+  }
+  .flow { display: flex; align-items: center; gap: 0; flex-wrap: wrap; justify-content: center; }
+  .flow-col { display: flex; flex-direction: column; gap: 0.6rem; justify-content: center; }
+  .node {
+    background: linear-gradient(180deg, rgba(24, 36, 61, 0.92), rgba(17, 24, 39, 0.82));
+    border: 1px solid rgba(129, 140, 248, 0.4);
+    border-radius: 14px;
+    padding: clamp(0.55rem, 0.6vw, 0.8rem) clamp(0.85rem, 1vw, 1.2rem);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: clamp(0.82rem, 0.9vw, 1.05rem);
+    color: #e2e8f0;
+    white-space: nowrap;
+    text-align: center;
+  }
+  .node.accent { border-color: rgba(167, 139, 250, 0.7); color: var(--accent-soft); }
+  .node.start { border-color: rgba(147, 197, 253, 0.6); color: var(--kicker); }
+  .edge {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    color: rgba(148, 163, 184, 0.8);
+    padding: 0 clamp(0.5rem, 0.65vw, 0.9rem);
+    min-width: 3rem;
+  }
+  .edge .arrow { font-size: clamp(1rem, 1.2vw, 1.4rem); line-height: 1; }
+  .edge .edge-label {
+    font-size: clamp(0.66rem, 0.7vw, 0.85rem);
+    color: var(--kicker);
+    text-align: center;
+    margin-top: 0.2rem;
+    max-width: 7rem;
+    line-height: 1.2;
+  }
+
+  @media (max-width: 600px) {
+    .slide { padding: 2rem 1.1rem; justify-content: flex-start; }
+    .glass-card, .hero-card, .metric-card { padding: 1rem 1.05rem; border-radius: 18px; }
+    h2 { font-size: clamp(1.3rem, 6vw, 1.6rem); }
+    .hero-card h1 { font-size: clamp(1.6rem, 7.5vw, 2.1rem); }
+    .hero-copy { font-size: 1rem; max-width: 100%; }
+    p, li { font-size: 0.95rem; }
+    .flow-scroll { margin-top: 1rem; }
+    .flow { flex-direction: column; align-items: stretch; gap: 0.5rem; }
+    .flow-col { gap: 0.5rem; }
+    .node { white-space: normal; overflow-wrap: anywhere; word-break: break-word; }
+    .edge { flex-direction: row; padding: 0; min-width: 0; }
+    .edge .arrow { transform: rotate(90deg); }
+    .edge .edge-label { max-width: none; margin-top: 0; margin-left: 0.4rem; }
+    .metric-figure { font-size: clamp(1.8rem, 9vw, 2.2rem); }
+  }
+</style>
+</head>
+<body>
+
+<section class="slide" id="hero">
+  <div class="slide-inner">
+    <div class="hero-card">
+      <p class="kicker">dev-loops</p>
+      <h1>How It Decided Itself Into Shape</h1>
+      <p class="hero-copy">Over 68 days the project made forty architecture-shaping decisions, wrote each one down, and reversed the two that turned out wrong. This is the history read straight from that record.</p>
+    </div>
+  </div>
+</section>
+
+<section class="slide" id="the-log">
+  <div class="slide-inner">
+    <p class="kicker">The method is the point</p>
+    <h2>A Log of Forty Decisions</h2>
+    <div class="grid grid-2">
+      <div class="glass-card">
+        <ul class="tight-list">
+          <li>A decision earns a record when it shapes policy or architecture. Routine features and fixes stay out.</li>
+          <li>Each record is plain: context, decision, consequences, and a dated link to the accepting pull request or issue.</li>
+          <li>When a later decision overturns an earlier one, the old record stays and its status flips to superseded, with a link forward.</li>
+          <li>Nothing is quietly deleted, so the history stays legible even where it doubled back.</li>
+        </ul>
+      </div>
+      <div class="metric-card">
+        <p class="metric-figure">40</p>
+        <p class="metric-label">dated architecture decisions under <code>docs/decisions/</code>, two of them later superseded.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="slide" id="state-graph">
+  <div class="slide-inner">
+    <p class="kicker">Era one</p>
+    <h2>The Next Step Is Always Known</h2>
+    <div class="grid grid-2">
+      <div class="glass-card">
+        <ul class="tight-list">
+          <li>Work flows through a deterministic state graph where the next action for any change is computed from that graph each time (records 0001 and 0002).</li>
+          <li>A startup resolver hands back a bounded task with the exact files to read and the exact stop conditions (records 0011 and 0016).</li>
+          <li>Lose a temporary artifact and the run still recovers, because the source of truth is the state graph, which the chat transcript only mirrors.</li>
+        </ul>
+      </div>
+      <div class="glass-card">
+        <p class="card-label">Why it matters</p>
+        <p>An agent picks up work mid-flight without guessing. The state is on the board; whoever is free reads the next card and pulls it.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="slide" id="the-gate">
+  <div class="slide-inner">
+    <p class="kicker">Era two &middot; day seventeen</p>
+    <h2>The Gate Never Trusts an Assumption</h2>
+    <div class="grid grid-2">
+      <div class="glass-card">
+        <ul class="tight-list">
+          <li>Two gates arrived on 2026-05-29: a draft gate before review and a pre-approval gate before merge (record 0006).</li>
+          <li>Merge authority stays with a human (record 0007).</li>
+          <li>Gate verdicts became durable, fail-closed evidence backed by the real check result — a comment the coordinator refuses to post unless the checks actually succeeded (record 0008).</li>
+        </ul>
+      </div>
+      <div class="metric-card">
+        <p class="card-label">The failure it closes</p>
+        <p>Once a green result has to come from the real check, the agent can no longer declare success over an unverified assumption. The most common failure of an autonomous coder is closed off at the seam.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="slide" id="reversal-local-first">
+  <div class="slide-inner">
+    <p class="kicker">Era three &middot; the first reversal</p>
+    <h2>Tracker-First Became Local-First</h2>
+    <div class="grid grid-2">
+      <div class="glass-card">
+        <p class="card-label">Superseded &mdash; record 0003 (2026-05-15)</p>
+        <p>The project started tracker-first: every change minted an issue, went through refinement ceremony, and produced a phase document.</p>
+      </div>
+      <div class="glass-card accent-card">
+        <p class="card-label">Accepted &mdash; record 0018 (2026-06-12)</p>
+        <p>Operating experience showed most work is specified better locally. The default flipped to local-first, with a lightweight path that treats a pull request description itself as the spec. The old record stays, marked superseded, because the wrong turn is part of the history worth keeping.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="slide" id="self-review">
+  <div class="slide-inner">
+    <p class="kicker">Era four</p>
+    <h2>The Loop Turns On Itself</h2>
+    <div class="grid grid-2">
+      <div class="glass-card">
+        <ul class="tight-list">
+          <li>Review fans out into independent angles and fans back in (record 0021), with a round cap so the Copilot loop cannot spin (record 0012).</li>
+          <li>Every operator-facing tool gained a uniform output contract, enforced by a test that fails the build if a command ships without it (record 0025).</li>
+          <li>Rule identifiers became single-owner and permanent (record 0027).</li>
+        </ul>
+      </div>
+      <div class="metric-card">
+        <p class="card-label">A mistake it caught in itself</p>
+        <p>Reviews had drifted toward grouping angles into one agent, which recreates a reviewer approving their own bundle. The fix made one scoped reviewer per fresh angle a machine-enforced requirement (record 0039) — and the new floor caught its own author miscounting provenance within hours.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="slide" id="reversal-retro">
+  <div class="slide-inner">
+    <p class="kicker">The second reversal</p>
+    <h2>A Practice Mounted at the Wrong Boundary</h2>
+    <div class="grid grid-2">
+      <div class="glass-card">
+        <p class="card-label">Superseded &mdash; record 0009</p>
+        <p>An enforced retrospective gate, meant to make the system reflect before merging, kept deadlocking ordinary product work on self-analysis noise.</p>
+      </div>
+      <div class="glass-card accent-card">
+        <p class="card-label">Accepted &mdash; record 0024 (2026-07-02)</p>
+        <p>The retrospective became advisory: its findings travel in the handoff envelope and a comment, and never block a merge. The log records both the mounting and the correction.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="slide" id="outcomes">
+  <div class="slide-inner">
+    <p class="kicker">Did it actually get better?</p>
+    <h2>The Numbers Moved the Right Way</h2>
+    <div class="grid grid-3">
+      <div class="metric-card">
+        <p class="metric-figure">7 / 687</p>
+        <p class="metric-label">merged PRs reverted &mdash; about 1%, clustered in release mechanics and doc rewrites.</p>
+      </div>
+      <div class="metric-card">
+        <p class="metric-figure">5 &rarr; 279</p>
+        <p class="metric-label">test files by the release candidate; the contract tests grew fastest.</p>
+      </div>
+      <div class="metric-card">
+        <p class="metric-figure">&darr;</p>
+        <p class="metric-label">external review comments per thousand added lines fell as the internal gates came online.</p>
+      </div>
+    </div>
+    <p class="soft-note">Re-derived from the repository as of July 19, 2026. Two of forty decisions were wrong enough to reverse, and the reversals are in the log on purpose.</p>
+  </div>
+</section>
+
+<section class="slide" id="close">
+  <div class="slide-inner">
+    <div class="hero-card">
+      <p class="kicker">What the log is for</p>
+      <h2>The Correction Has Something to Point Back To</h2>
+      <p class="hero-copy">The next step is always known, the gate never trusts an assumption, and when a decision turns out wrong, the record of it stays. A decision record takes three paragraphs to write, and skipping it costs weeks later.</p>
+    </div>
+  </div>
+</section>
+
+<script>
+(function () {
+  const slides = Array.from(document.querySelectorAll('.slide'));
+  const indexMap = new Map(slides.map((s, i) => [s, i]));
+  let cur = 0;
+  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  const currentSlideIndex = () => {
+    let best = cur;
+    let bestDistance = Infinity;
+    slides.forEach((slide, i) => {
+      const distance = Math.abs(slide.getBoundingClientRect().top);
+      if (distance < bestDistance) {
+        best = i;
+        bestDistance = distance;
+      }
+    });
+    return best;
+  };
+
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(e => {
+      if (e.isIntersecting && e.intersectionRatio >= 0.5)
+        cur = indexMap.get(e.target) ?? cur;
+    });
+  }, { threshold: 0.5 });
+  slides.forEach(s => observer.observe(s));
+
+  document.addEventListener('keydown', e => {
+    if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return;
+    const tag = document.activeElement ? document.activeElement.tagName : '';
+    if (['INPUT', 'TEXTAREA', 'SELECT'].includes(tag) || document.activeElement.isContentEditable) return;
+    cur = currentSlideIndex();
+    const behavior = reducedMotion.matches ? 'auto' : 'smooth';
+    if (['ArrowDown', 'ArrowRight', 'PageDown', ' '].includes(e.key)) {
+      e.preventDefault();
+      if (cur < slides.length - 1) slides[++cur].scrollIntoView({ behavior });
+    } else if (['ArrowUp', 'ArrowLeft', 'PageUp'].includes(e.key)) {
+      e.preventDefault();
+      if (cur > 0) slides[--cur].scrollIntoView({ behavior });
+    }
+  });
+})();
+</script>
+</body>
+</html>

--- a/docs/presentations/how-dev-loops-decided-itself.html
+++ b/docs/presentations/how-dev-loops-decided-itself.html
@@ -114,6 +114,11 @@
     padding: clamp(1.25rem, 1.5vw, 2rem) clamp(1.35rem, 1.8vw, 2.5rem);
   }
 
+  .accent-card {
+    border-color: rgba(167, 139, 250, 0.42);
+    box-shadow: 0 22px 60px rgba(0, 0, 0, 0.28), inset 3px 0 0 var(--accent);
+  }
+
   .metric-card {
     background: linear-gradient(180deg, rgba(24, 36, 61, 0.92), rgba(17, 24, 39, 0.78));
     border-color: rgba(129, 140, 248, 0.35);

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:playwright:intro-article": "PW_UI_SLICE=intro-article playwright test --project=intro-article",
     "test:playwright:ui-review-drive": "PW_UI_SLICE=ui-review-drive playwright test --project=ui-review-drive",
     "test:playwright:deep-dive-article": "PW_UI_SLICE=deep-dive-article playwright test --project=deep-dive-article",
+    "test:playwright:how-decided-article": "PW_UI_SLICE=how-decided-article playwright test --project=how-decided-article",
     "smoke:headless": "node scripts/claude/headless-info-smoke.mjs",
     "test:docs": "node scripts/docs/validate-links.mjs && node scripts/docs/validate-rule-ownership.mjs",
     "test:workflows": "node scripts/github/lint-workflows.mjs",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:dev-loop": "node --test --test-reporter ./test/failure-summary-reporter.mjs skills/dev-loop/scripts/dev-mode-context.test.mjs skills/dev-loop/scripts/render-template.test.mjs skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs",
     "test:playwright:viewer": "PW_UI_SLICE=inspect-run-viewer playwright test --project=inspect-run-viewer",
     "test:playwright:deep-dive": "PW_UI_SLICE=deep-dive-deck playwright test --project=deep-dive-deck",
+    "test:playwright:how-decided-deck": "PW_UI_SLICE=how-decided-deck playwright test --project=how-decided-deck",
     "test:playwright:intro-deck": "PW_UI_SLICE=intro-deck playwright test --project=intro-deck",
     "test:playwright:intro-article": "PW_UI_SLICE=intro-article playwright test --project=intro-article",
     "test:playwright:ui-review-drive": "PW_UI_SLICE=ui-review-drive playwright test --project=ui-review-drive",

--- a/packages/core/src/loop/ui-e2e-scoping.mjs
+++ b/packages/core/src/loop/ui-e2e-scoping.mjs
@@ -38,6 +38,7 @@ export const VIEWER_SOURCE_PATHS = Object.freeze([
 export const REGISTERED_ARTIFACT_PATHS = Object.freeze([
   "docs/presentations/introducing-dev-loops.html",
   "docs/presentations/dev-loops-deep-dive.html",
+  "docs/presentations/how-dev-loops-decided-itself.html",
   "docs/articles/introducing-dev-loops.html",
   "docs/articles/dev-loops-deep-dive.html",
   "docs/articles/how-dev-loops-decided-itself.html",

--- a/packages/core/src/loop/ui-e2e-scoping.mjs
+++ b/packages/core/src/loop/ui-e2e-scoping.mjs
@@ -40,6 +40,7 @@ export const REGISTERED_ARTIFACT_PATHS = Object.freeze([
   "docs/presentations/dev-loops-deep-dive.html",
   "docs/articles/introducing-dev-loops.html",
   "docs/articles/dev-loops-deep-dive.html",
+  "docs/articles/how-dev-loops-decided-itself.html",
 ]);
 
 export const VIEWER_ARTIFACT_ID = "inspect-run-viewer";

--- a/scripts/pages/render-article.mjs
+++ b/scripts/pages/render-article.mjs
@@ -56,6 +56,7 @@ const SHELL_PATH = path.join(REPO_ROOT, "scripts", "pages", "article-shell.html"
 export const RENDERED_ARTICLES = [
   { md: "introducing-dev-loops.md", html: "introducing-dev-loops.html" },
   { md: "dev-loops-deep-dive.md", html: "dev-loops-deep-dive.html" },
+  { md: "how-dev-loops-decided-itself.md", html: "how-dev-loops-decided-itself.html" },
 ];
 
 // Quote-escaping matters even under the strict CSP: rendered text is also

--- a/test/playwright/harness/deck-fit-harness.mjs
+++ b/test/playwright/harness/deck-fit-harness.mjs
@@ -260,6 +260,22 @@ export const DECK_REGISTRY = {
       { id: "setup", stateName: "Setup" },
     ],
   },
+  "how-decided-deck": {
+    sliceId: "how-decided-deck",
+    deck: "how-dev-loops-decided-itself.html",
+    mobileCapture: { id: "the-log", stateName: "The log" },
+    sectionIds: [
+      { id: "hero", stateName: "Hero", capture: true },
+      { id: "the-log", stateName: "The log", capture: true },
+      { id: "state-graph", stateName: "State graph", capture: true },
+      { id: "the-gate", stateName: "The gate", capture: true },
+      { id: "reversal-local-first", stateName: "Reversal: local-first", capture: true },
+      { id: "self-review", stateName: "Self-review", capture: true },
+      { id: "reversal-retro", stateName: "Reversal: retrospective", capture: true },
+      { id: "outcomes", stateName: "Outcomes", capture: true },
+      { id: "close", stateName: "Close", capture: true },
+    ],
+  },
   "deep-dive-deck": {
     sliceId: "deep-dive-deck",
     deck: "dev-loops-deep-dive.html",

--- a/test/playwright/harness/deck-fit-harness.mjs
+++ b/test/playwright/harness/deck-fit-harness.mjs
@@ -316,6 +316,10 @@ export const ARTICLE_REGISTRY = {
     sliceId: "deep-dive-article",
     file: "dev-loops-deep-dive.html",
   },
+  "how-decided-article": {
+    sliceId: "how-decided-article",
+    file: "how-dev-loops-decided-itself.html",
+  },
 };
 
 export function articleRegistryEntry(key) {

--- a/test/playwright/how-decided-article.spec.mjs
+++ b/test/playwright/how-decided-article.spec.mjs
@@ -1,0 +1,10 @@
+import { fileURLToPath } from "node:url";
+
+import { articleRegistryEntry, defineArticleSuite } from "./harness/deck-fit-harness.mjs";
+
+const entry = articleRegistryEntry("how-decided-article");
+
+defineArticleSuite({
+  ...entry,
+  articlePath: fileURLToPath(new URL(`../../docs/articles/${entry.file}`, import.meta.url)),
+});

--- a/test/playwright/how-decided-deck.spec.mjs
+++ b/test/playwright/how-decided-deck.spec.mjs
@@ -1,0 +1,10 @@
+import { fileURLToPath } from "node:url";
+
+import { deckRegistryEntry, defineDeckSuite } from "./harness/deck-fit-harness.mjs";
+
+const entry = deckRegistryEntry("how-decided-deck");
+
+defineDeckSuite({
+  ...entry,
+  deckPath: fileURLToPath(new URL(`../../docs/presentations/${entry.deck}`, import.meta.url)),
+});


### PR DESCRIPTION
Closes #1437

## Summary

Evolution/history article + paired deck, narrated through the 40-record decision log with metrics re-derived from the repo, plus both required quality loops (deslop + designer/vision) run per deliverable.

## Deliverables
- **Article** `docs/articles/how-dev-loops-decided-itself.md` (+ rendered `.html`) — the arc from the bootstrap state-graph idea through the two-gate model, the tracker-first→local-first and enforced-retrospective→advisory reversals, and the measured outcomes. Rendered via `articles:render`, registered in `ARTICLE_REGISTRY`, article-smoke wired.
- **Deck** `docs/presentations/how-dev-loops-decided-itself.html` — 9 id-anchored slides mirroring the article arc, reusing the shared deck design system. `DECK_REGISTRY` entry with per-section named-state captures, deck-smoke wired.
- Both linked from `docs/index.md`; `REGISTERED_ARTIFACT_PATHS` updated.

## Required review loops — completed with recorded evidence
- **Deslop (article)**: 6 firm + 2 borderline binary-contrast instances found and rewritten; human-likeness preserved.
- **Deslop (deck)**: 8 instances (incl. negation-framed headlines) rewritten; two shared phrases synced back to the article.
- **UI/designer review (article)**: `ui_review_satisfied` — meets the bar, console clean; only pre-existing shared-shell axe findings (not regressions).
- **UI/designer review (deck)**: `ui_review_satisfied` across all 9 slides + mobile; console clean; axe findings shared-shell only.
- **Fact-audit (article)**: every metric + record citation re-derived; corrected the commit boundary (1,320 at rc.3), test-file growth (5→279), dropped an unreproducible check-count, and reframed the Copilot-density line as an attributed prior finding with direction only.

## Verification
- Both fit smokes pass 3/3 in WebKit; full `npm test` green; `validate-links`, `validate-rule-ownership`, `articles:check` all pass.

Note: the two shared-shell axe findings (`landmark-one-main`, `region`; deck also `scrollable-region-focusable`) affect all existing articles/decks and are out of scope for this content PR — a `<main>` landmark fix belongs in the shared shell.
