### PR TITLE
feat(handoff): byte-stable envelope prefix — isolate volatile gate-state into a trailing block (#1462 precondition)

### DIFF
--- a/.claude/skills/dev-loop/SKILL.md
+++ b/.claude/skills/dev-loop/SKILL.md
@@ -127,7 +127,7 @@ When you need a fact from a dev-loops JSON-emitting script, climb this ladder an
 
 ## Guard rules
 
-**Handoff envelope precedence:** The dev-loop builds the envelope immediately after authoritative-state resolution and treats it as the first handoff artifact. Read it first, load only `requiredReads`, execute `nextAction`. See [Resolve authoritative state](#resolve-authoritative-state). Derivation contract: [Workflow Handoff Contract](../docs/workflow-handoff-contract.md).
+**Handoff envelope precedence:** The dev-loop builds the envelope immediately after authoritative-state resolution and treats it as the first handoff artifact. Read it first, load only `requiredReads`, execute `nextAction`. The envelope's stable body + `requiredReads` are byte-identical across rounds for the same target+gate — the only per-round-varying values live in the trailing `gateState` block, which is **volatile: read it last, or re-derive it fresh via detectors right before acting** (this keeps the stable prefix cache-warm across fresh reviewer spawns — #1462). See [Resolve authoritative state](#resolve-authoritative-state). Derivation contract: [Workflow Handoff Contract](../docs/workflow-handoff-contract.md).
 
 **Handoff contract rule:** When no envelope is present, use the `workflow-handoff-contract.md` contract. Never delegate with abbreviated task summaries. Include deterministic routing inputs, explicit `cwd`, bounded task scope, exit conditions.
 

--- a/.claude/skills/docs/workflow-handoff-contract.md
+++ b/.claude/skills/docs/workflow-handoff-contract.md
@@ -16,7 +16,8 @@ template.
 | Caller options (`repoRoot`, `worktreeCwd`) | `cwd` |
 | Gate state (detectors) + strategy defaults | `currentGate`, `worktreeRequired` |
 | Settings (`.devloops` at repo root + `defaults.yaml`) | `gateConfig`, `stopRules`, `asyncStartMode`, `requireDraftFirst`, `maxCopilotRounds` |
-| Gate state (detectors) | `gateState.{derivedAt, currentHeadSha, ciStatus, unresolvedThreadCount, copilotRoundCount}` (the volatile tail — see below) |
+| Gate state (detectors) | `gateState.{currentHeadSha, ciStatus, unresolvedThreadCount, copilotRoundCount}` (the volatile tail — see below) |
+| Envelope builder (timestamp) | `gateState.derivedAt` (build time, not detector-derived) |
 | Canonical sanctioned-command map (`scripts/loop/sanctioned-commands.mjs`) | `sanctionedCommands` |
 
 ## Sanctioned commands (MANDATORY DEFAULT — issue #1081)

--- a/.claude/skills/docs/workflow-handoff-contract.md
+++ b/.claude/skills/docs/workflow-handoff-contract.md
@@ -16,7 +16,7 @@ template.
 | Caller options (`repoRoot`, `worktreeCwd`) | `cwd` |
 | Gate state (detectors) + strategy defaults | `currentGate`, `worktreeRequired` |
 | Settings (`.devloops` at repo root + `defaults.yaml`) | `gateConfig`, `stopRules`, `asyncStartMode`, `requireDraftFirst`, `maxCopilotRounds` |
-| Gate state (detectors) | `currentHeadSha`, `ciStatus`, `unresolvedThreadCount`, `copilotRoundCount` |
+| Gate state (detectors) | `gateState.{derivedAt, currentHeadSha, ciStatus, unresolvedThreadCount, copilotRoundCount}` (the volatile tail — see below) |
 | Canonical sanctioned-command map (`scripts/loop/sanctioned-commands.mjs`) | `sanctionedCommands` |
 
 ## Sanctioned commands (MANDATORY DEFAULT — issue #1081)
@@ -86,7 +86,6 @@ When absent, strategy defaults apply:
 ```typescript
 interface HandoffEnvelope {
   handoffVersion: 1;
-  derivedAt: string; // ISO timestamp
 
   target: {
     kind: "issue" | "pr" | "local_branch" | "local_phase";
@@ -99,10 +98,6 @@ interface HandoffEnvelope {
   };
 
   currentGate: string;
-  currentHeadSha: string | null;
-  ciStatus: string | null;
-  unresolvedThreadCount: number;
-  copilotRoundCount: number;
   maxCopilotRounds: number;
   executionMode: "bounded_handoff" | "durable_auto";
 
@@ -149,6 +144,20 @@ interface HandoffEnvelope {
     forbidden: string[];
     orchestratorOwned: string[];
   };
+
+  // #1462: the ONLY per-round-varying block, ALWAYS LAST. Every field here changes
+  // between builds/rounds, so isolating it as the envelope tail keeps everything
+  // above it byte-stable — a fresh reviewer spawn cache-READS that stable prefix
+  // instead of re-billing the full contract scaffolding each round. Treat gateState
+  // as volatile: read it last, or re-derive it fresh via detectors. Never add a
+  // per-round-varying field above this block.
+  gateState: {
+    derivedAt: string;         // ISO timestamp
+    currentHeadSha: string | null;
+    ciStatus: string | null;
+    unresolvedThreadCount: number;
+    copilotRoundCount: number;
+  };
 }
 ```
 
@@ -160,6 +169,23 @@ interface HandoffEnvelope {
 4. Respect `stopRules` — do not proceed past a gated stop point without authorization.
 5. Use `acceptance` to self-validate before declaring completion.
 6. Use `sanctionedCommands` as the authoritative operation → wrapper map: never call a raw `gh`/`node -e`/`python -c` for an operation the map covers, and never perform an `orchestratorOwned` action.
+7. Treat `gateState` as **volatile and last**: read it after the stable body + `requiredReads`, or re-derive it fresh via detectors right before acting. Never rely on it being cached.
+
+## Byte-stable prefix (issue #1462)
+
+Everything in the envelope **above `gateState`** is derived only from the target,
+strategy, gate, and settings — it is **byte-identical across builds/rounds for the
+same target+gate**. All per-round-varying values (`derivedAt`, the head SHA, CI
+status, thread/round counts) live in the trailing `gateState` block, and nothing
+else may.
+
+This is deliberate: we spawn **fresh** review subagents each round (independent,
+bias-free reads). Because the stable body + `requiredReads` are byte-identical,
+each fresh spawn **cache-reads** the whole contract scaffolding instead of
+re-billing it, and only the tiny `gateState` tail is a cache write. **Contract
+rule:** never add a field that varies per round anywhere except inside `gateState`
+— doing so re-poisons the cacheable prefix. A test
+(`#1462: the envelope minus gateState is byte-stable ...`) enforces this.
 
 ## Backward compatibility
 

--- a/packages/core/src/loop/handoff-envelope.mjs
+++ b/packages/core/src/loop/handoff-envelope.mjs
@@ -613,14 +613,9 @@ export function buildDevLoopHandoffEnvelope(resolverOutput, settings, gateState 
 
   const envelope = {
     handoffVersion: ENVELOPE_HANDOFF_VERSION,
-    derivedAt: (now ?? new Date()).toISOString(),
 
     target,
     currentGate: subGate,
-    currentHeadSha: gs.currentHeadSha,
-    ciStatus: gs.ciStatus,
-    unresolvedThreadCount: gs.unresolvedThreadCount,
-    copilotRoundCount: gs.copilotRoundCount,
     maxCopilotRounds: settings?.refinement?.maxCopilotRounds ?? 5,
     executionMode,
 
@@ -673,6 +668,20 @@ export function buildDevLoopHandoffEnvelope(resolverOutput, settings, gateState 
   if (specSource) {
     envelope.specSource = specSource;
   }
+
+  // #1462: the ONLY per-round-varying block, kept LAST. Every field here changes
+  // between builds/rounds (the timestamp, the head SHA, CI status, thread/round
+  // counts); isolating them as the envelope's tail keeps everything above a
+  // byte-stable prefix that a fresh reviewer spawn can cache-READ instead of
+  // re-billing the full contract scaffolding each round. Consumers must treat
+  // gateState as volatile — read it last, or re-derive it fresh via detectors.
+  envelope.gateState = {
+    derivedAt: (now ?? new Date()).toISOString(),
+    currentHeadSha: gs.currentHeadSha,
+    ciStatus: gs.ciStatus,
+    unresolvedThreadCount: gs.unresolvedThreadCount,
+    copilotRoundCount: gs.copilotRoundCount,
+  };
 
   return deepFreeze(envelope);
 }
@@ -940,9 +949,10 @@ export function validateHandoffEnvelope(envelope) {
     }
   }
 
-  // ----- derivedAt (informational, warn on missing) -----
-  if (typeof envelope.derivedAt !== "string" || !envelope.derivedAt.trim()) {
-    warnings.push({ field: "derivedAt", reason: "should be an ISO 8601 timestamp" });
+  // ----- gateState.derivedAt (informational, warn on missing) — #1462 moved the
+  // volatile timestamp into the gateState tail so the rest stays byte-stable -----
+  if (typeof envelope.gateState?.derivedAt !== "string" || !envelope.gateState.derivedAt.trim()) {
+    warnings.push({ field: "gateState.derivedAt", reason: "should be an ISO 8601 timestamp" });
   }
 
   return {

--- a/packages/core/test/handoff-envelope.test.mjs
+++ b/packages/core/test/handoff-envelope.test.mjs
@@ -818,6 +818,10 @@ test("#1462: the envelope minus gateState is byte-stable across differing gate-s
   const stable = (env) => { const { gateState, ...rest } = env; return JSON.stringify(rest); };
   assert.strictEqual(stable(a), stable(b), "stable prefix must be byte-identical when only gateState/timestamp changes");
   assert.notStrictEqual(JSON.stringify(a.gateState), JSON.stringify(b.gateState), "gateState is the only part that varies");
+  // gateState MUST be the last key — appending any field after it would move
+  // volatile-adjacent content out of the tail and re-poison the cacheable prefix
+  const keys = Object.keys(a);
+  assert.strictEqual(keys[keys.length - 1], "gateState", "gateState must be positioned last in the envelope");
 });
 
 test("backward-compat: envelope is frozen (top-level)", () => {

--- a/packages/core/test/handoff-envelope.test.mjs
+++ b/packages/core/test/handoff-envelope.test.mjs
@@ -186,8 +186,8 @@ test("shape: envelope has correct top-level keys", () => {
   );
 
   assert.equal(env.handoffVersion, ENVELOPE_HANDOFF_VERSION);
-  assert.equal(typeof env.derivedAt, "string");
-  assert.ok(env.derivedAt.endsWith("Z") || env.derivedAt.includes("T"));
+  assert.equal(typeof env.gateState.derivedAt, "string");
+  assert.ok(env.gateState.derivedAt.endsWith("Z") || env.gateState.derivedAt.includes("T"));
   assert.equal(typeof env.target, "object");
   assert.equal(typeof env.currentGate, "string");
   assert.equal(typeof env.executionMode, "string");
@@ -460,10 +460,10 @@ test("gate-state: head SHA, CI status, thread count, round count populate", () =
     defaultOptions
   );
 
-  assert.equal(env.currentHeadSha, "abc123def456");
-  assert.equal(env.ciStatus, "success");
-  assert.equal(env.unresolvedThreadCount, 3);
-  assert.equal(env.copilotRoundCount, 2);
+  assert.equal(env.gateState.currentHeadSha, "abc123def456");
+  assert.equal(env.gateState.ciStatus, "success");
+  assert.equal(env.gateState.unresolvedThreadCount, 3);
+  assert.equal(env.gateState.copilotRoundCount, 2);
 });
 
 test("gate-state: null/undefined values default to null or 0", () => {
@@ -474,10 +474,10 @@ test("gate-state: null/undefined values default to null or 0", () => {
     defaultOptions
   );
 
-  assert.equal(env.currentHeadSha, null);
-  assert.equal(env.ciStatus, null);
-  assert.equal(env.unresolvedThreadCount, 0);
-  assert.equal(env.copilotRoundCount, 0);
+  assert.equal(env.gateState.currentHeadSha, null);
+  assert.equal(env.gateState.ciStatus, null);
+  assert.equal(env.gateState.unresolvedThreadCount, 0);
+  assert.equal(env.gateState.copilotRoundCount, 0);
 });
 
 test("gate-state: empty gate state is safe", () => {
@@ -488,10 +488,10 @@ test("gate-state: empty gate state is safe", () => {
     defaultOptions
   );
 
-  assert.equal(env.currentHeadSha, null);
-  assert.equal(env.ciStatus, null);
-  assert.equal(env.unresolvedThreadCount, 0);
-  assert.equal(env.copilotRoundCount, 0);
+  assert.equal(env.gateState.currentHeadSha, null);
+  assert.equal(env.gateState.ciStatus, null);
+  assert.equal(env.gateState.unresolvedThreadCount, 0);
+  assert.equal(env.gateState.copilotRoundCount, 0);
 });
 
 // ===========================================================================
@@ -796,15 +796,28 @@ test("determinism: injectable now makes derivedAt stable", () => {
   const frozen = "2026-01-01T00:00:00.000Z";
   const e1 = buildDevLoopHandoffEnvelope(issueBundle(99), defaultSettings, {}, defaultOptions, new Date(frozen));
   const e2 = buildDevLoopHandoffEnvelope(issueBundle(99), defaultSettings, {}, defaultOptions, new Date(frozen));
-  assert.strictEqual(e1.derivedAt, frozen);
-  assert.strictEqual(e2.derivedAt, frozen);
-  assert.strictEqual(e1.derivedAt, e2.derivedAt);
+  assert.strictEqual(e1.gateState.derivedAt, frozen);
+  assert.strictEqual(e2.gateState.derivedAt, frozen);
+  assert.strictEqual(e1.gateState.derivedAt, e2.gateState.derivedAt);
 });
 
 test("determinism: derivedAt defaults to current time when now not provided", () => {
   const before = new Date().toISOString();
   const e = buildDevLoopHandoffEnvelope(issueBundle(99), defaultSettings, {}, defaultOptions);
-  assert.ok(e.derivedAt >= before);
+  assert.ok(e.gateState.derivedAt >= before);
+});
+
+// #1462: the whole point — everything ABOVE gateState must be byte-identical
+// across builds where only the volatile gate-state (or the timestamp) differs, so
+// a fresh reviewer spawn cache-READS the stable prefix instead of re-billing it.
+test("#1462: the envelope minus gateState is byte-stable across differing gate-state / timestamps", () => {
+  const frozen1 = "2026-01-01T00:00:00.000Z";
+  const frozen2 = "2026-02-02T00:00:00.000Z";
+  const a = buildDevLoopHandoffEnvelope(issueBundle(7), defaultSettings, { currentHeadSha: "aaa", ciStatus: "success", unresolvedThreadCount: 0, copilotRoundCount: 1 }, defaultOptions, new Date(frozen1));
+  const b = buildDevLoopHandoffEnvelope(issueBundle(7), defaultSettings, { currentHeadSha: "bbb", ciStatus: "pending", unresolvedThreadCount: 4, copilotRoundCount: 3 }, defaultOptions, new Date(frozen2));
+  const stable = (env) => { const { gateState, ...rest } = env; return JSON.stringify(rest); };
+  assert.strictEqual(stable(a), stable(b), "stable prefix must be byte-identical when only gateState/timestamp changes");
+  assert.notStrictEqual(JSON.stringify(a.gateState), JSON.stringify(b.gateState), "gateState is the only part that varies");
 });
 
 test("backward-compat: envelope is frozen (top-level)", () => {
@@ -857,7 +870,7 @@ test("edge: neg copilotRoundCount clamps to 0", () => {
     defaultOptions
   );
 
-  assert.equal(env.copilotRoundCount, 0);
+  assert.equal(env.gateState.copilotRoundCount, 0);
 });
 
 // ===========================================================================
@@ -1204,10 +1217,11 @@ test("validate: invalid executionMode returns error", () => {
 });
 
 test("validate: missing derivedAt returns warning", () => {
-  const env = { ...validEnvelope() }; delete env.derivedAt;
+  const base = validEnvelope();
+  const env = { ...base, gateState: { ...base.gateState } }; delete env.gateState.derivedAt;
   const result = validateHandoffEnvelope(env);
   assert.equal(result.ok, true);
-  assert.ok(result.warnings.some(w => w.field === "derivedAt"));
+  assert.ok(result.warnings.some(w => w.field === "gateState.derivedAt"));
 });
 
 test("validate: multiple errors reported together", () => {

--- a/scripts/loop/inspect-run-viewer/handoff-envelope-renderer.mjs
+++ b/scripts/loop/inspect-run-viewer/handoff-envelope-renderer.mjs
@@ -282,10 +282,10 @@ export function renderHandoffEnvelopeSection(envelope) {
       <div class="handoff-hero-copy">
         <p class="handoff-card-kicker">Agent handoff</p>
         <h2>${escapeHtml(identity)}</h2>
-        <p class="handoff-hero-meta">Derived${envelope.derivedAt ? ` at ${escapeHtml(envelope.derivedAt)}` : ""} · Version ${escapeHtml(String(envelope.handoffVersion ?? "unknown"))}</p>
+        <p class="handoff-hero-meta">Derived${envelope.gateState?.derivedAt ? ` at ${escapeHtml(envelope.gateState?.derivedAt)}` : ""} · Version ${escapeHtml(String(envelope.handoffVersion ?? "unknown"))}</p>
         <div class="handoff-hero-badges">
           ${renderBadge(`gate: ${envelope.currentGate ?? "not set"}`, toneForGate(envelope.currentGate))}
-          ${renderBadge(`ci: ${envelope.ciStatus ?? "not set"}`, toneForCi(envelope.ciStatus))}
+          ${renderBadge(`ci: ${envelope.gateState?.ciStatus ?? "not set"}`, toneForCi(envelope.gateState?.ciStatus))}
           ${renderBadge(`mode: ${envelope.executionMode ?? "not set"}`, "info")}
         </div>
       </div>
@@ -297,9 +297,9 @@ export function renderHandoffEnvelopeSection(envelope) {
           content: renderStatGrid([
             { label: "Artifact", valueHtml: renderInlineValue(envelope.target?.kind, "kind") },
             { label: "Target", valueHtml: renderInlineValue(envelope.target?.pr ?? envelope.target?.issue ?? envelope.target?.branch ?? envelope.target?.phase, "target") },
-            { label: "Rounds", valueHtml: `<strong>${renderPlainValue(envelope.copilotRoundCount)}</strong> / ${renderPlainValue(envelope.maxCopilotRounds)}` },
+            { label: "Rounds", valueHtml: `<strong>${renderPlainValue(envelope.gateState?.copilotRoundCount)}</strong> / ${renderPlainValue(envelope.maxCopilotRounds)}` },
             { label: "Isolation", valueHtml: renderInlineValue(envelope.worktreeRequired, "worktreeRequired") },
-            { label: "Threads", valueHtml: renderPlainValue(envelope.unresolvedThreadCount) },
+            { label: "Threads", valueHtml: renderPlainValue(envelope.gateState?.unresolvedThreadCount) },
             { label: "Stop rules", valueHtml: renderPlainValue(Array.isArray(envelope.stopRules) ? envelope.stopRules.length : 0) },
           ]),
         })}

--- a/scripts/loop/inspect-run-viewer/handoff-envelope-renderer.mjs
+++ b/scripts/loop/inspect-run-viewer/handoff-envelope-renderer.mjs
@@ -257,10 +257,10 @@ export function renderHandoffEnvelopeSection(envelope) {
     : [{ key: "target", label: "Target", valueHtml: `<span class="handoff-empty-value">missing</span>` }];
   const currentStateEntries = [
     { key: "currentGate", label: humanizeKey("currentGate"), valueHtml: renderInlineValue(envelope.currentGate, "currentGate") },
-    { key: "currentHeadSha", label: humanizeKey("currentHeadSha"), valueHtml: renderInlineValue(envelope.currentHeadSha, "currentHeadSha") },
-    { key: "ciStatus", label: humanizeKey("ciStatus"), valueHtml: renderInlineValue(envelope.ciStatus, "ciStatus") },
-    { key: "unresolvedThreadCount", label: humanizeKey("unresolvedThreadCount"), valueHtml: renderInlineValue(envelope.unresolvedThreadCount, "unresolvedThreadCount") },
-    { key: "copilotRoundCount", label: humanizeKey("copilotRoundCount"), valueHtml: renderInlineValue(envelope.copilotRoundCount, "copilotRoundCount") },
+    { key: "currentHeadSha", label: humanizeKey("currentHeadSha"), valueHtml: renderInlineValue(envelope.gateState?.currentHeadSha, "currentHeadSha") },
+    { key: "ciStatus", label: humanizeKey("ciStatus"), valueHtml: renderInlineValue(envelope.gateState?.ciStatus, "ciStatus") },
+    { key: "unresolvedThreadCount", label: humanizeKey("unresolvedThreadCount"), valueHtml: renderInlineValue(envelope.gateState?.unresolvedThreadCount, "unresolvedThreadCount") },
+    { key: "copilotRoundCount", label: humanizeKey("copilotRoundCount"), valueHtml: renderInlineValue(envelope.gateState?.copilotRoundCount, "copilotRoundCount") },
     { key: "maxCopilotRounds", label: humanizeKey("maxCopilotRounds"), valueHtml: renderInlineValue(envelope.maxCopilotRounds, "maxCopilotRounds") },
     { key: "executionMode", label: humanizeKey("executionMode"), valueHtml: renderInlineValue(envelope.executionMode, "executionMode") },
   ];

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -148,7 +148,7 @@ When you need a fact from a dev-loops JSON-emitting script, climb this ladder an
 
 ## Guard rules
 
-**Handoff envelope precedence:** The dev-loop builds the envelope immediately after authoritative-state resolution and treats it as the first handoff artifact. Read it first, load only `requiredReads`, execute `nextAction`. See [Resolve authoritative state](#resolve-authoritative-state). Derivation contract: [Workflow Handoff Contract](../docs/workflow-handoff-contract.md).
+**Handoff envelope precedence:** The dev-loop builds the envelope immediately after authoritative-state resolution and treats it as the first handoff artifact. Read it first, load only `requiredReads`, execute `nextAction`. The envelope's stable body + `requiredReads` are byte-identical across rounds for the same target+gate — the only per-round-varying values live in the trailing `gateState` block, which is **volatile: read it last, or re-derive it fresh via detectors right before acting** (this keeps the stable prefix cache-warm across fresh reviewer spawns — #1462). See [Resolve authoritative state](#resolve-authoritative-state). Derivation contract: [Workflow Handoff Contract](../docs/workflow-handoff-contract.md).
 
 **Handoff contract rule:** When no envelope is present, use the `workflow-handoff-contract.md` contract. Never delegate with abbreviated task summaries. Include deterministic routing inputs, explicit `cwd`, bounded task scope, exit conditions.
 

--- a/skills/docs/workflow-handoff-contract.md
+++ b/skills/docs/workflow-handoff-contract.md
@@ -16,7 +16,8 @@ template.
 | Caller options (`repoRoot`, `worktreeCwd`) | `cwd` |
 | Gate state (detectors) + strategy defaults | `currentGate`, `worktreeRequired` |
 | Settings (`.devloops` at repo root + `defaults.yaml`) | `gateConfig`, `stopRules`, `asyncStartMode`, `requireDraftFirst`, `maxCopilotRounds` |
-| Gate state (detectors) | `gateState.{derivedAt, currentHeadSha, ciStatus, unresolvedThreadCount, copilotRoundCount}` (the volatile tail — see below) |
+| Gate state (detectors) | `gateState.{currentHeadSha, ciStatus, unresolvedThreadCount, copilotRoundCount}` (the volatile tail — see below) |
+| Envelope builder (timestamp) | `gateState.derivedAt` (build time, not detector-derived) |
 | Canonical sanctioned-command map (`scripts/loop/sanctioned-commands.mjs`) | `sanctionedCommands` |
 
 ## Sanctioned commands (MANDATORY DEFAULT — issue #1081)

--- a/skills/docs/workflow-handoff-contract.md
+++ b/skills/docs/workflow-handoff-contract.md
@@ -16,7 +16,7 @@ template.
 | Caller options (`repoRoot`, `worktreeCwd`) | `cwd` |
 | Gate state (detectors) + strategy defaults | `currentGate`, `worktreeRequired` |
 | Settings (`.devloops` at repo root + `defaults.yaml`) | `gateConfig`, `stopRules`, `asyncStartMode`, `requireDraftFirst`, `maxCopilotRounds` |
-| Gate state (detectors) | `currentHeadSha`, `ciStatus`, `unresolvedThreadCount`, `copilotRoundCount` |
+| Gate state (detectors) | `gateState.{derivedAt, currentHeadSha, ciStatus, unresolvedThreadCount, copilotRoundCount}` (the volatile tail — see below) |
 | Canonical sanctioned-command map (`scripts/loop/sanctioned-commands.mjs`) | `sanctionedCommands` |
 
 ## Sanctioned commands (MANDATORY DEFAULT — issue #1081)
@@ -86,7 +86,6 @@ When absent, strategy defaults apply:
 ```typescript
 interface HandoffEnvelope {
   handoffVersion: 1;
-  derivedAt: string; // ISO timestamp
 
   target: {
     kind: "issue" | "pr" | "local_branch" | "local_phase";
@@ -99,10 +98,6 @@ interface HandoffEnvelope {
   };
 
   currentGate: string;
-  currentHeadSha: string | null;
-  ciStatus: string | null;
-  unresolvedThreadCount: number;
-  copilotRoundCount: number;
   maxCopilotRounds: number;
   executionMode: "bounded_handoff" | "durable_auto";
 
@@ -149,6 +144,20 @@ interface HandoffEnvelope {
     forbidden: string[];
     orchestratorOwned: string[];
   };
+
+  // #1462: the ONLY per-round-varying block, ALWAYS LAST. Every field here changes
+  // between builds/rounds, so isolating it as the envelope tail keeps everything
+  // above it byte-stable — a fresh reviewer spawn cache-READS that stable prefix
+  // instead of re-billing the full contract scaffolding each round. Treat gateState
+  // as volatile: read it last, or re-derive it fresh via detectors. Never add a
+  // per-round-varying field above this block.
+  gateState: {
+    derivedAt: string;         // ISO timestamp
+    currentHeadSha: string | null;
+    ciStatus: string | null;
+    unresolvedThreadCount: number;
+    copilotRoundCount: number;
+  };
 }
 ```
 
@@ -160,6 +169,23 @@ interface HandoffEnvelope {
 4. Respect `stopRules` — do not proceed past a gated stop point without authorization.
 5. Use `acceptance` to self-validate before declaring completion.
 6. Use `sanctionedCommands` as the authoritative operation → wrapper map: never call a raw `gh`/`node -e`/`python -c` for an operation the map covers, and never perform an `orchestratorOwned` action.
+7. Treat `gateState` as **volatile and last**: read it after the stable body + `requiredReads`, or re-derive it fresh via detectors right before acting. Never rely on it being cached.
+
+## Byte-stable prefix (issue #1462)
+
+Everything in the envelope **above `gateState`** is derived only from the target,
+strategy, gate, and settings — it is **byte-identical across builds/rounds for the
+same target+gate**. All per-round-varying values (`derivedAt`, the head SHA, CI
+status, thread/round counts) live in the trailing `gateState` block, and nothing
+else may.
+
+This is deliberate: we spawn **fresh** review subagents each round (independent,
+bias-free reads). Because the stable body + `requiredReads` are byte-identical,
+each fresh spawn **cache-reads** the whole contract scaffolding instead of
+re-billing it, and only the tiny `gateState` tail is a cache write. **Contract
+rule:** never add a field that varies per round anywhere except inside `gateState`
+— doing so re-poisons the cacheable prefix. A test
+(`#1462: the envelope minus gateState is byte-stable ...`) enforces this.
 
 ## Backward compatibility
 

--- a/test/loop/build-handoff-envelope.test.mjs
+++ b/test/loop/build-handoff-envelope.test.mjs
@@ -165,7 +165,7 @@ test("build-handoff-envelope builds envelope from resolver output", async () => 
 
     const envelope = JSON.parse(result.stdout.trim());
     assert.equal(envelope.handoffVersion, 1);
-    assert.ok(typeof envelope.derivedAt === "string", "should have derivedAt");
+    assert.ok(typeof envelope.gateState.derivedAt === "string", "should have derivedAt");
     assert.equal(envelope.target.kind, "issue");
     assert.equal(envelope.target.issue, 42);
     assert.equal(envelope.target.repo, "owner/test-repo");
@@ -196,10 +196,10 @@ test("build-handoff-envelope accepts gate state via --gate-state", async () => {
     assert.equal(result.code, 0, `expected exit 0, got stderr: ${result.stderr}`);
 
     const envelope = JSON.parse(result.stdout.trim());
-    assert.equal(envelope.currentHeadSha, "deadbeef");
-    assert.equal(envelope.ciStatus, "success");
-    assert.equal(envelope.unresolvedThreadCount, 3);
-    assert.equal(envelope.copilotRoundCount, 2);
+    assert.equal(envelope.gateState.currentHeadSha, "deadbeef");
+    assert.equal(envelope.gateState.ciStatus, "success");
+    assert.equal(envelope.gateState.unresolvedThreadCount, 3);
+    assert.equal(envelope.gateState.copilotRoundCount, 2);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/inspect-run-viewer-handoff-envelope-renderer.test.mjs
+++ b/test/loop/inspect-run-viewer-handoff-envelope-renderer.test.mjs
@@ -19,7 +19,7 @@ describe("renderHandoffEnvelopeSection", () => {
     const envelope = {
       target: { kind: "pr", repo: "owner/name", pr: 42 },
       handoffVersion: 1,
-      derivedAt: "2026-01-01T00:00:00.000Z",
+      gateState: { derivedAt: "2026-01-01T00:00:00.000Z" },
     };
     const html = renderHandoffEnvelopeSection(envelope);
     assert.ok(html.includes("owner/name#42"), "should show repo#pr identity");
@@ -54,7 +54,7 @@ describe("renderHandoffEnvelopeSection", () => {
     const envelope = {
       target: { kind: "pr", repo: "a/b", pr: 1 },
       handoffVersion: 1,
-      derivedAt: "2026-01-01T00:00:00.000Z",
+      gateState: { derivedAt: "2026-01-01T00:00:00.000Z" },
       nextAction: "run_draft_gate",
       requiredReads: ["docs/a.md", "docs/b.md"],
     };
@@ -68,7 +68,7 @@ describe("renderHandoffEnvelopeSection", () => {
     const envelope = {
       target: { kind: "pr", repo: "a/b", pr: 1 },
       handoffVersion: 1,
-      derivedAt: "2026-01-01T00:00:00.000Z",
+      gateState: { derivedAt: "2026-01-01T00:00:00.000Z" },
       gateConfig: {
         angles: ["scope", "coverage", "correctness"],
         excludeAngles: [],
@@ -86,7 +86,7 @@ describe("renderHandoffEnvelopeSection", () => {
     const envelope = {
       target: { kind: "pr", repo: "a/b", pr: 1 },
       handoffVersion: 1,
-      derivedAt: "2026-01-01T00:00:00.000Z",
+      gateState: { derivedAt: "2026-01-01T00:00:00.000Z" },
     };
     const html = renderHandoffEnvelopeSection(envelope);
     assert.ok(!html.includes("Gate configuration"), "should not show gate config when absent");
@@ -96,7 +96,7 @@ describe("renderHandoffEnvelopeSection", () => {
     const envelope = {
       target: { kind: "pr", repo: "a/b", pr: 1 },
       handoffVersion: 1,
-      derivedAt: "2026-01-01T00:00:00.000Z",
+      gateState: { derivedAt: "2026-01-01T00:00:00.000Z" },
       asyncStartMode: "required",
       requireDraftFirst: false,
       stopRules: ["draft-pr", "merge"],
@@ -111,7 +111,7 @@ describe("renderHandoffEnvelopeSection", () => {
     const envelope = {
       target: { kind: "pr", repo: "a/b", pr: 1 },
       handoffVersion: 1,
-      derivedAt: "2026-01-01T00:00:00.000Z",
+      gateState: { derivedAt: "2026-01-01T00:00:00.000Z" },
       cwd: "/tmp/worktrees/pr-42",
       worktreeRequired: true,
     };
@@ -124,7 +124,7 @@ describe("renderHandoffEnvelopeSection", () => {
     const envelope = {
       target: { kind: "pr", repo: "a/b", pr: 1 },
       handoffVersion: 1,
-      derivedAt: "2026-01-01T00:00:00.000Z",
+      gateState: { derivedAt: "2026-01-01T00:00:00.000Z" },
       acceptance: {
         criteria: [
           { severity: "required", id: "ci-green", must: "CI must pass" },
@@ -145,7 +145,7 @@ describe("renderHandoffEnvelopeSection", () => {
     const envelope = {
       target: { kind: "pr", repo: "a/b", pr: 1 },
       handoffVersion: 1,
-      derivedAt: "2026-01-01T00:00:00.000Z",
+      gateState: { derivedAt: "2026-01-01T00:00:00.000Z" },
       control: {
         needsAttentionAfterMs: 300000,
         activeNoticeAfterMs: 300000,
@@ -159,7 +159,7 @@ describe("renderHandoffEnvelopeSection", () => {
     const envelope = {
       target: { kind: "pr", repo: "a/b", pr: 1 },
       handoffVersion: 1,
-      derivedAt: "2026-01-01T00:00:00.000Z",
+      gateState: { derivedAt: "2026-01-01T00:00:00.000Z" },
       overrides: { copilotRound: 2 },
     };
     const html = renderHandoffEnvelopeSection(envelope);
@@ -170,10 +170,8 @@ describe("renderHandoffEnvelopeSection", () => {
     const envelope = {
       target: { kind: "pr", repo: "a/b", pr: 1 },
       handoffVersion: 1,
-      derivedAt: null,
+      gateState: { derivedAt: null, currentHeadSha: null, ciStatus: null },
       currentGate: null,
-      currentHeadSha: null,
-      ciStatus: null,
       executionMode: null,
       asyncStartMode: null,
       requireDraftFirst: null,
@@ -187,7 +185,7 @@ describe("renderHandoffEnvelopeSection", () => {
     const envelope = {
       target: { kind: "pr", repo: "a/b", pr: 1, branch: "<script>alert(1)</script>" },
       handoffVersion: 1,
-      derivedAt: "2026-01-01T00:00:00.000Z",
+      gateState: { derivedAt: "2026-01-01T00:00:00.000Z" },
       currentGate: "<img src=x onerror=alert(1)>",
     };
     const html = renderHandoffEnvelopeSection(envelope);
@@ -199,7 +197,7 @@ describe("renderHandoffEnvelopeSection", () => {
   it("renders envelope with missing target gracefully", () => {
     const envelope = {
       handoffVersion: 1,
-      derivedAt: "2026-01-01T00:00:00.000Z",
+      gateState: { derivedAt: "2026-01-01T00:00:00.000Z" },
     };
     const html = renderHandoffEnvelopeSection(envelope);
     assert.ok(html.includes("unknown"), "should show unknown identity");

--- a/test/loop/inspect-run-viewer-handoff-envelope-renderer.test.mjs
+++ b/test/loop/inspect-run-viewer-handoff-envelope-renderer.test.mjs
@@ -32,14 +32,16 @@ describe("renderHandoffEnvelopeSection", () => {
     const envelope = {
       target: { kind: "pr", repo: "a/b", pr: 1 },
       handoffVersion: 1,
-      derivedAt: "2026-01-01T00:00:00.000Z",
       currentGate: "draft",
-      currentHeadSha: "abc123def",
-      ciStatus: "success",
-      unresolvedThreadCount: 0,
-      copilotRoundCount: 2,
       maxCopilotRounds: 5,
       executionMode: "bounded_handoff",
+      gateState: {
+        derivedAt: "2026-01-01T00:00:00.000Z",
+        currentHeadSha: "abc123def",
+        ciStatus: "success",
+        unresolvedThreadCount: 0,
+        copilotRoundCount: 2,
+      },
     };
     const html = renderHandoffEnvelopeSection(envelope);
     assert.ok(html.includes("draft"), "should show current gate");


### PR DESCRIPTION
Part of #1462 — **PR-1: the enabling precondition** (the byte-stable prefix). Does not `Closes` #1462; the primer → fan-out orchestration and additive-round cache chain are follow-up phases on the same issue.

## In scope
- Isolate all per-round-varying handoff-envelope fields (`derivedAt`, `currentHeadSha`, `ciStatus`, `unresolvedThreadCount`, `copilotRoundCount`) into a single trailing `envelope.gateState` block, so everything above it is byte-identical across builds for the same target+gate.
- Update every consumer of the moved fields (validator, renderer, `build-envelope` CLI) and the handoff contract doc + `dev-loop` SKILL; regenerate `.claude` assets.
- Add a test enforcing the byte-stable-prefix property.

## Non-goals
- The cache **primer** step, the reviewer **fan-out**, and the **additive-round** cache chain (all specified in #1462 as follow-up phases; each needs this byte-stable prefix to exist first).
- Any change to reviewer independence / fresh-context spawning (deliberately preserved).
- Any change to gate semantics, verdicts, or dispatch mechanics.

## Open questions
- None blocking this PR. (Follow-up: the primer must load the byte-identical materialized static-context artifact verbatim — tracked in #1462, not here.)

## Problem
`buildDevLoopHandoffEnvelope()` placed `derivedAt` (a fresh timestamp!) + the gate-state fields at the **top level**, so no two envelopes were byte-identical — poisoning the cache prefix for the byte-identical `requiredReads` a fresh reviewer reads next, forcing a full re-bill every round.

## Change
All per-round-varying fields now live in a trailing `envelope.gateState` block; the stable body + `requiredReads` are byte-identical across fresh reviewer spawns → cache-READ, not re-billed. Fresh reviewer context is untouched.

## Acceptance criteria
- [x] `derivedAt` + `currentHeadSha`/`ciStatus`/`unresolvedThreadCount`/`copilotRoundCount` are no longer top-level envelope fields; they live under `envelope.gateState`, positioned last.
- [x] Envelope-minus-`gateState` is byte-identical when only gate-state/timestamp differs (enforcing test added).
- [x] Validator, renderer, and `build-envelope` CLI updated to the nested shape; `.claude` assets regenerated (reproducibility contract test green).
- [x] Handoff contract doc + `dev-loop` SKILL document the byte-stable-prefix rule (never add a per-round-varying field outside `gateState`; read `gateState` last).

## Definition of done
- [x] Full test suite green: `2135 + 206 + 87 + 1 + 2974` (core / scripts / docs / assets), including the `.claude`-reproducibility contract test.
- [x] No new per-round-varying field introduced outside `gateState`.
- [x] Contract + SKILL + `.claude` assets in sync (no drift).
