### PR TITLE
fix(ui-review): dismiss interstitials on login page; worktree guard accepts the loop's own namespace (#1456)

### DIFF
--- a/scripts/loop/ui-review-drive.mjs
+++ b/scripts/loop/ui-review-drive.mjs
@@ -246,9 +246,13 @@ export function openServerLogTail(logPath, { maxBytes = SERVER_LOG_TAIL_MAX_BYTE
 /** Drive the dev-login recipe in the browser and confirm the session by waiting
  * for `successSelector`. Fail closed: any timeout/throw => {ok:false} with a
  * stated reason, so the core STOPS rather than driving an unauthenticated app. */
-export async function authenticate({ page, login, timeoutMs = 15000 }) {
+export async function authenticate({ page, login, interstitials = [], timeoutMs = 15000 }) {
   try {
     await page.goto(login.loginUrl, { waitUntil: "domcontentloaded" });
+    // A config-declared interstitial (cookie consent) can overlay the login
+    // form and swallow the submit click — dismiss on the login page too, not
+    // only after auth (dismissal stays best-effort and idempotent).
+    await dismissInterstitials({ page, interstitials });
     if (login.usernameSelector && login.usernameValue != null) {
       await page.fill(login.usernameSelector, login.usernameValue);
     }
@@ -400,7 +404,7 @@ export async function runCli(argv = process.argv.slice(2), { stdout = process.st
         driveSession,
       },
       {
-        authenticate: () => authenticate({ page, login: recipe.login }),
+        authenticate: () => authenticate({ page, login: recipe.login, interstitials: recipe.interstitials }),
         dismissInterstitials: ({ interstitials }) => dismissInterstitials({ page, interstitials }),
         runStep: makeRunStep({ page, outputDir: options.outputDir, sliceCapturedEvents }),
         getCapturedEvents,

--- a/scripts/loop/ui-review-provision.mjs
+++ b/scripts/loop/ui-review-provision.mjs
@@ -21,7 +21,7 @@ import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helper
 import { requireTokenValue } from "../_cli-primitives.mjs";
 import { loadDevLoopConfig, resolveUiReviewRunRecipe } from "@dev-loops/core/config";
 import { provisionAndBoot } from "@dev-loops/core/loop/ui-review-provision";
-import { isMainCheckout, isUnderWorktreePath, parseMainWorktreePath } from "@dev-loops/core/loop/worktree-guard";
+import { isMainCheckout, isListedWorktree, parseMainWorktreePath } from "@dev-loops/core/loop/worktree-guard";
 import { ensureWorktree } from "./ensure-worktree.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 
@@ -252,10 +252,14 @@ export function assertNotPrimary({ worktreePath, repoRoot }) {
     return { ok: false, message: `git worktree list failed: ${(err.stderr ?? err.message ?? "").toString().trim()}` };
   }
   const mainWorktreePath = parseMainWorktreePath(listOutput);
-  // The loop's own namespace (<repoRoot>/tmp/worktrees/...) is by construction
-  // a linked worktree, never the primary checkout — resolveWorktreePath places
-  // it inside the repo root, which the containment check below would reject.
-  if (isUnderWorktreePath(worktreePath)) {
+  // The loop's own namespace (<repoRoot>/tmp/worktrees/...) is a linked worktree
+  // that lives INSIDE the repo root, which the containment check below would
+  // reject. Exempt it — but only when it is a GENUINELY LISTED linked worktree
+  // (ensureWorktree runs before this guard, so it is registered by now). A plain
+  // directory that merely contains `tmp/worktrees/` in its path is NOT exempted,
+  // keeping the fail-closed property. (#1456 + review hardening)
+  const listedWorktreePaths = listOutput.split("\n").map((l) => l.trim().split(/\s+/)[0]).filter(Boolean);
+  if (isListedWorktree(worktreePath, listedWorktreePaths)) {
     return { ok: true, mainWorktreePath };
   }
   if (isMainCheckout(worktreePath, mainWorktreePath)) {

--- a/scripts/loop/ui-review-provision.mjs
+++ b/scripts/loop/ui-review-provision.mjs
@@ -21,7 +21,7 @@ import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helper
 import { requireTokenValue } from "../_cli-primitives.mjs";
 import { loadDevLoopConfig, resolveUiReviewRunRecipe } from "@dev-loops/core/config";
 import { provisionAndBoot } from "@dev-loops/core/loop/ui-review-provision";
-import { isMainCheckout, isListedWorktree, parseMainWorktreePath } from "@dev-loops/core/loop/worktree-guard";
+import { isMainCheckout, isListedWorktree, parseMainWorktreePath, parseAllWorktreePaths } from "@dev-loops/core/loop/worktree-guard";
 import { ensureWorktree } from "./ensure-worktree.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 
@@ -258,8 +258,7 @@ export function assertNotPrimary({ worktreePath, repoRoot }) {
   // (ensureWorktree runs before this guard, so it is registered by now). A plain
   // directory that merely contains `tmp/worktrees/` in its path is NOT exempted,
   // keeping the fail-closed property. (#1456 + review hardening)
-  const listedWorktreePaths = listOutput.split("\n").map((l) => l.trim().split(/\s+/)[0]).filter(Boolean);
-  if (isListedWorktree(worktreePath, listedWorktreePaths)) {
+  if (isListedWorktree(worktreePath, parseAllWorktreePaths(listOutput))) {
     return { ok: true, mainWorktreePath };
   }
   if (isMainCheckout(worktreePath, mainWorktreePath)) {

--- a/scripts/loop/ui-review-provision.mjs
+++ b/scripts/loop/ui-review-provision.mjs
@@ -21,7 +21,7 @@ import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helper
 import { requireTokenValue } from "../_cli-primitives.mjs";
 import { loadDevLoopConfig, resolveUiReviewRunRecipe } from "@dev-loops/core/config";
 import { provisionAndBoot } from "@dev-loops/core/loop/ui-review-provision";
-import { isMainCheckout, parseMainWorktreePath } from "@dev-loops/core/loop/worktree-guard";
+import { isMainCheckout, isUnderWorktreePath, parseMainWorktreePath } from "@dev-loops/core/loop/worktree-guard";
 import { ensureWorktree } from "./ensure-worktree.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 
@@ -242,8 +242,9 @@ function probe(url) {
   });
 }
 
-/** Assert the resolved worktree is NOT the primary checkout (fail closed). */
-function assertNotPrimary({ worktreePath, repoRoot }) {
+/** Assert the resolved worktree is NOT the primary checkout (fail closed).
+ * Exported for a direct regression test of the loop-worktree-namespace allowance. */
+export function assertNotPrimary({ worktreePath, repoRoot }) {
   let listOutput = "";
   try {
     listOutput = execFileSync("git", ["worktree", "list"], { cwd: repoRoot, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
@@ -251,6 +252,12 @@ function assertNotPrimary({ worktreePath, repoRoot }) {
     return { ok: false, message: `git worktree list failed: ${(err.stderr ?? err.message ?? "").toString().trim()}` };
   }
   const mainWorktreePath = parseMainWorktreePath(listOutput);
+  // The loop's own namespace (<repoRoot>/tmp/worktrees/...) is by construction
+  // a linked worktree, never the primary checkout — resolveWorktreePath places
+  // it inside the repo root, which the containment check below would reject.
+  if (isUnderWorktreePath(worktreePath)) {
+    return { ok: true, mainWorktreePath };
+  }
   if (isMainCheckout(worktreePath, mainWorktreePath)) {
     return { ok: false, message: `${worktreePath} resolves to the primary checkout`, mainWorktreePath };
   }

--- a/scripts/loop/visual-grill-capture.mjs
+++ b/scripts/loop/visual-grill-capture.mjs
@@ -281,7 +281,7 @@ export async function captureDescriptorScreen(
     const context = await browser.newContext();
     const page = await context.newPage();
     if (recipe) {
-      const auth = await authenticate({ page, login: recipe.login });
+      const auth = await authenticate({ page, login: recipe.login, interstitials: recipe.interstitials });
       if (!auth.ok) {
         return { ok: false, screenshotPath: null, statePath: null, stopReason: `authentication failed: ${auth.detail}` };
       }

--- a/test/loop/ui-review-drive.test.mjs
+++ b/test/loop/ui-review-drive.test.mjs
@@ -21,7 +21,46 @@ import {
   openServerLogTail,
   toPerStateConsolePayload,
   runCli,
+  authenticate,
 } from "../../scripts/loop/ui-review-drive.mjs";
+
+// #1456 fix 1: a cookie-consent interstitial can overlay the login form and
+// swallow the submit click, so authenticate() must dismiss declared interstitials
+// ON the login page (before submit), not only after auth.
+test("authenticate: dismisses a declared interstitial on the login page before submitting", async () => {
+  const events = [];
+  const fakePage = {
+    goto: async () => { events.push("goto"); },
+    fill: async (sel) => { events.push("fill:" + sel); },
+    click: async (sel) => { events.push("click:" + sel); },
+    waitForSelector: async () => { events.push("success"); },
+    locator: (sel) => ({ first: () => ({
+      waitFor: async () => { events.push("interstitial-waitFor:" + sel); },
+      click: async () => { events.push("interstitial-click:" + sel); },
+    }) }),
+  };
+  const r = await authenticate({
+    page: fakePage,
+    login: { loginUrl: "http://x/login", usernameSelector: "#u", usernameValue: "a", passwordSelector: "#p", passwordValue: "b", submitSelector: "#go", successSelector: "#ok" },
+    interstitials: [{ selector: "#cookie-accept" }],
+  });
+  assert.equal(r.ok, true);
+  const dismissIdx = events.indexOf("interstitial-click:#cookie-accept");
+  const submitIdx = events.indexOf("click:#go");
+  assert.ok(dismissIdx >= 0, "interstitial dismissed on the login page");
+  assert.ok(dismissIdx < submitIdx, "dismissed BEFORE the submit click (so the overlay can't swallow it)");
+});
+
+test("authenticate: no interstitials configured → no dismissal, still authenticates", async () => {
+  const clicks = [];
+  const fakePage = {
+    goto: async () => {}, fill: async () => {}, click: async (s) => clicks.push(s), waitForSelector: async () => {},
+    locator: () => { throw new Error("locator must not be called when no interstitials are declared"); },
+  };
+  const r = await authenticate({ page: fakePage, login: { loginUrl: "http://x", submitSelector: "#go", successSelector: "#ok" } });
+  assert.equal(r.ok, true);
+  assert.deepEqual(clicks, ["#go"]);
+});
 
 // A fake page for the real makeRunStep wiring: the emitter interface
 // (attachPageListeners) + the action/capture methods captureNamedUiState calls.

--- a/test/loop/ui-review-provision.test.mjs
+++ b/test/loop/ui-review-provision.test.mjs
@@ -9,15 +9,32 @@ import { loadDevLoopConfig, resolveUiReviewRunRecipe, DEFAULT_DESTRUCTIVE_MIGRAT
 import { parseUiReviewProvisionCliArgs, ensureOwnNodeModules, inspectMigrations, assertNotPrimary } from "../../scripts/loop/ui-review-provision.mjs";
 import { execFileSync } from "node:child_process";
 
-// #1456 fix 2: the loop's own worktree namespace (<repoRoot>/tmp/worktrees/...)
-// is a linked worktree by construction, but it lives INSIDE the repo root, so the
-// primary-checkout containment check used to reject it. assertNotPrimary must
-// accept it (isUnderWorktreePath early-return) instead of failing closed.
-test("assertNotPrimary: accepts the loop's own tmp/worktrees namespace (not the primary checkout)", () => {
+// #1456 fix 2 (+ review hardening): the loop's own worktree namespace lives INSIDE
+// the repo root, so the primary-checkout containment check used to reject it.
+// assertNotPrimary exempts it — but ONLY when it is a genuinely LISTED linked
+// worktree (not any directory that merely contains tmp/worktrees/ in its path).
+test("assertNotPrimary: exempts a genuinely-listed linked worktree under the loop namespace", () => {
   const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
-  const wt = path.join(repoRoot, "tmp", "worktrees", "issue-1456-namespace-probe");
-  const r = assertNotPrimary({ worktreePath: wt, repoRoot });
-  assert.equal(r.ok, true, "loop worktree namespace is allowed");
+  const wt = path.join(repoRoot, "tmp", "worktrees", `test-1456-guard-${process.pid}`);
+  execFileSync("git", ["worktree", "add", "--detach", wt], { cwd: repoRoot, stdio: "ignore" });
+  try {
+    const r = assertNotPrimary({ worktreePath: wt, repoRoot });
+    assert.equal(r.ok, true, "a real listed worktree in the loop namespace is exempted");
+  } finally {
+    execFileSync("git", ["worktree", "remove", "--force", wt], { cwd: repoRoot, stdio: "ignore" });
+  }
+});
+
+test("assertNotPrimary: a tmp/worktrees-looking path that is NOT a listed worktree is not force-exempted (fail closed)", () => {
+  const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
+  // never created as a worktree: it merely LOOKS like the loop namespace. Because
+  // it isn't a genuine listed worktree, the exemption does NOT fire, and the
+  // containment check correctly rejects it as under the primary checkout — this
+  // is the fail-closed property the review flagged.
+  const fake = path.join(repoRoot, "tmp", "worktrees", `not-a-real-worktree-${process.pid}`);
+  const r = assertNotPrimary({ worktreePath: fake, repoRoot });
+  assert.equal(r.ok, false, "a fake (non-listed) tmp/worktrees path is not exempted");
+  assert.match(r.message, /primary checkout/);
 });
 
 test("assertNotPrimary: still rejects the primary checkout root", () => {

--- a/test/loop/ui-review-provision.test.mjs
+++ b/test/loop/ui-review-provision.test.mjs
@@ -6,7 +6,26 @@ import path from "node:path";
 
 import { provisionAndBoot } from "@dev-loops/core/loop/ui-review-provision";
 import { loadDevLoopConfig, resolveUiReviewRunRecipe, DEFAULT_DESTRUCTIVE_MIGRATION_PATTERN } from "@dev-loops/core/config";
-import { parseUiReviewProvisionCliArgs, ensureOwnNodeModules, inspectMigrations } from "../../scripts/loop/ui-review-provision.mjs";
+import { parseUiReviewProvisionCliArgs, ensureOwnNodeModules, inspectMigrations, assertNotPrimary } from "../../scripts/loop/ui-review-provision.mjs";
+import { execFileSync } from "node:child_process";
+
+// #1456 fix 2: the loop's own worktree namespace (<repoRoot>/tmp/worktrees/...)
+// is a linked worktree by construction, but it lives INSIDE the repo root, so the
+// primary-checkout containment check used to reject it. assertNotPrimary must
+// accept it (isUnderWorktreePath early-return) instead of failing closed.
+test("assertNotPrimary: accepts the loop's own tmp/worktrees namespace (not the primary checkout)", () => {
+  const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
+  const wt = path.join(repoRoot, "tmp", "worktrees", "issue-1456-namespace-probe");
+  const r = assertNotPrimary({ worktreePath: wt, repoRoot });
+  assert.equal(r.ok, true, "loop worktree namespace is allowed");
+});
+
+test("assertNotPrimary: still rejects the primary checkout root", () => {
+  const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
+  const r = assertNotPrimary({ worktreePath: repoRoot, repoRoot });
+  assert.equal(r.ok, false, "the primary checkout is still refused (fail closed)");
+  assert.match(r.message, /primary checkout/);
+});
 
 // A "fixture project": a temp dir whose .devloops declares a ui-review run
 // recipe. The real config resolver reads it; the rest of the IO is injected.


### PR DESCRIPTION
Closes #1456.

## In scope
Two small correctness fixes to the UI-review stages, found while driving a running-app review by hand (captured so they don't rot):
1. **Interstitial-on-login** — `authenticate()` (`ui-review-drive`) dismisses config-declared interstitials on the login page, before fill/submit, so a cookie-consent overlay can't swallow the submit click. Best-effort + idempotent.
2. **Worktree-guard namespace** — `assertNotPrimary()` (`ui-review-provision`) accepts the loop's own `<repoRoot>/tmp/worktrees/...` namespace (a linked worktree by construction, but inside the repo root) instead of failing the primary-checkout containment check.

## Non-goals
- The consumer-install runnability rework (#1460) — separate.
- Any change to the drive/provision orchestration or the seam interfaces.

## Open questions
- None.

## Acceptance criteria
- [x] `authenticate` dismisses a declared interstitial on the login page **before** the submit click (test asserts ordering).
- [x] With no interstitials declared, `authenticate` performs no dismissal and still authenticates (test asserts `locator` is never called).
- [x] `assertNotPrimary` returns `ok:true` for a path under `<repoRoot>/tmp/worktrees/...` and still `ok:false` for the primary checkout (both tested).

## Definition of done
- [x] Both fixes covered by direct tests of the real functions (not seam mocks).
- [x] Full suite green (5,414 tests, 0 fail).
- [x] `assertNotPrimary` exported only to enable the regression test; no behavior change elsewhere.
