### PR TITLE
test(ui-review): resolve primary checkout via parseMainWorktreePath in assertNotPrimary tests

### DIFF
--- a/test/loop/ui-review-provision.test.mjs
+++ b/test/loop/ui-review-provision.test.mjs
@@ -16,7 +16,9 @@ import { execFileSync } from "node:child_process";
 // test does, so test and implementation agree by construction.
 function primaryCheckoutRoot() {
   const listOutput = execFileSync("git", ["worktree", "list"], { encoding: "utf8" });
-  return parseMainWorktreePath(listOutput);
+  const root = parseMainWorktreePath(listOutput);
+  assert.ok(root, "could not parse the primary checkout from `git worktree list` output");
+  return root;
 }
 
 // #1456 fix 2 (+ review hardening): the loop's own worktree namespace lives INSIDE

--- a/test/loop/ui-review-provision.test.mjs
+++ b/test/loop/ui-review-provision.test.mjs
@@ -7,14 +7,24 @@ import path from "node:path";
 import { provisionAndBoot } from "@dev-loops/core/loop/ui-review-provision";
 import { loadDevLoopConfig, resolveUiReviewRunRecipe, DEFAULT_DESTRUCTIVE_MIGRATION_PATTERN } from "@dev-loops/core/config";
 import { parseUiReviewProvisionCliArgs, ensureOwnNodeModules, inspectMigrations, assertNotPrimary } from "../../scripts/loop/ui-review-provision.mjs";
+import { parseMainWorktreePath } from "@dev-loops/core/loop/worktree-guard";
 import { execFileSync } from "node:child_process";
+
+// The primary checkout, NOT the current worktree: `--show-toplevel` returns the
+// linked worktree's root when the suite runs from one (the mandated validation
+// flow), which broke these assertions. Resolve it the same way the code under
+// test does, so test and implementation agree by construction.
+function primaryCheckoutRoot() {
+  const listOutput = execFileSync("git", ["worktree", "list"], { encoding: "utf8" });
+  return parseMainWorktreePath(listOutput);
+}
 
 // #1456 fix 2 (+ review hardening): the loop's own worktree namespace lives INSIDE
 // the repo root, so the primary-checkout containment check used to reject it.
 // assertNotPrimary exempts it — but ONLY when it is a genuinely LISTED linked
 // worktree (not any directory that merely contains tmp/worktrees/ in its path).
 test("assertNotPrimary: exempts a genuinely-listed linked worktree under the loop namespace", () => {
-  const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
+  const repoRoot = primaryCheckoutRoot();
   const wt = path.join(repoRoot, "tmp", "worktrees", `test-1456-guard-${process.pid}`);
   execFileSync("git", ["worktree", "add", "--detach", wt], { cwd: repoRoot, stdio: "ignore" });
   try {
@@ -26,7 +36,7 @@ test("assertNotPrimary: exempts a genuinely-listed linked worktree under the loo
 });
 
 test("assertNotPrimary: a tmp/worktrees-looking path that is NOT a listed worktree is not force-exempted (fail closed)", () => {
-  const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
+  const repoRoot = primaryCheckoutRoot();
   // never created as a worktree: it merely LOOKS like the loop namespace. Because
   // it isn't a genuine listed worktree, the exemption does NOT fire, and the
   // containment check correctly rejects it as under the primary checkout — this
@@ -38,7 +48,7 @@ test("assertNotPrimary: a tmp/worktrees-looking path that is NOT a listed worktr
 });
 
 test("assertNotPrimary: still rejects the primary checkout root", () => {
-  const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
+  const repoRoot = primaryCheckoutRoot();
   const r = assertNotPrimary({ worktreePath: repoRoot, repoRoot });
   assert.equal(r.ok, false, "the primary checkout is still refused (fail closed)");
   assert.match(r.message, /primary checkout/);


### PR DESCRIPTION
Fixes the two `assertNotPrimary` tests (and a third sharing the same resolution) in `test/loop/ui-review-provision.test.mjs` that failed when the suite runs from a linked worktree — the dev-loop's mandated validation flow.

The tests resolved `repoRoot` with `git rev-parse --show-toplevel`, which names the **current worktree's** root, not the primary checkout. From a linked worktree, the fake `tmp/worktrees/...` paths and the containment assertions were built against the wrong root, so the guard's correct behavior read as failures. The fix resolves the primary checkout with the same `git worktree list` + `parseMainWorktreePath` parse the guard under test uses, keeping test and implementation in agreement by construction. Production code is untouched.

Sweep result: the only other `--show-toplevel` in `test/**` is a mocked `runChild` stub in `test/loop/promote-plan.test.mjs` (no cwd assumption), so no further sites need the treatment.

## Validation

- `node --test test/loop/ui-review-provision.test.mjs` from a linked worktree: 24/24 (was 22 pass / 2 fail).
- Full verify from a linked worktree: 0 failures (previously 2) — the mandated flow now reports green.

Closes #1469
